### PR TITLE
Let PostgreSQL decide the name of primary key constraints

### DIFF
--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -1443,11 +1443,11 @@ OGRPGDataSource::CreateLayer( const char * pszLayerName,
                  "%s ( "
                  "    %s SERIAL, "
                  "   WKB_GEOMETRY %s, "
-                 "   CONSTRAINT \"%s_pk\" PRIMARY KEY (%s) )",
+                 "   PRIMARY KEY (%s) )",
                  osCreateTable.c_str(),
                  pszFIDColumnName,
                  pszGeomType,
-                 pszTableName, pszFIDColumnName);
+                 pszFIDColumnName);
     }
     else if ( eType != wkbNone && EQUAL(pszGeomType, "geography") )
     {
@@ -1458,24 +1458,24 @@ OGRPGDataSource::CreateLayer( const char * pszLayerName,
         
         if (nSRSId)
             osCommand.Printf(
-                     "%s ( %s SERIAL, %s geography(%s%s,%d), CONSTRAINT \"%s_pk\" PRIMARY KEY (%s) )",
+                     "%s ( %s SERIAL, %s geography(%s%s,%d), PRIMARY KEY (%s) )",
                      osCreateTable.c_str(), pszFIDColumnName,
                      OGRPGEscapeColumnName(pszGFldName).c_str(), pszGeometryType,
-                     nDimension == 2 ? "" : "Z", nSRSId, pszTableName,
+                     nDimension == 2 ? "" : "Z", nSRSId, 
                      pszFIDColumnName);
         else
             osCommand.Printf(
-                     "%s ( %s SERIAL, %s geography(%s%s), CONSTRAINT \"%s_pk\" PRIMARY KEY (%s) )",
+                     "%s ( %s SERIAL, %s geography(%s%s), PRIMARY KEY (%s) )",
                      osCreateTable.c_str(), pszFIDColumnName,
                      OGRPGEscapeColumnName(pszGFldName).c_str(), pszGeometryType,
-                     nDimension == 2 ? "" : "Z", pszTableName,
+                     nDimension == 2 ? "" : "Z", 
                      pszFIDColumnName);
     }
     else
     {
         osCommand.Printf(
-                 "%s ( %s SERIAL, CONSTRAINT \"%s_pk\" PRIMARY KEY (%s) )",
-                 osCreateTable.c_str(), pszFIDColumnName, pszTableName, pszFIDColumnName );
+                 "%s ( %s SERIAL, PRIMARY KEY (%s) )",
+                 osCreateTable.c_str(), pszFIDColumnName, pszFIDColumnName );
     }
 
     hResult = OGRPG_PQexec(hPGConn, osCommand.c_str());


### PR DESCRIPTION
Fixes name clash creating tables with names longer than 63 chars
See http://trac.osgeo.org/gdal/ticket/5125
