### PR TITLE
Shape: don't let REPACK silently fail and try to recover

### DIFF
--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
@@ -833,7 +833,14 @@ OGRLayer * OGRShapeDataSource::ExecuteSQL( const char *pszStatement,
             GetLayerByName( pszStatement + 7 );
 
         if( poLayer != NULL )
-            poLayer->Repack();
+        {
+            if( poLayer->Repack() != OGRERR_NONE )
+            {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "REPACK of layer '%s' failed.",
+                          pszStatement + 7 );
+            }
+        }
         else
         {
             CPLError( CE_Failure, CPLE_AppDefined, 

--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -2258,7 +2258,20 @@ OGRErr OGRShapeLayer::Repack()
     DBFClose( hNewDBF );
     hDBF = hNewDBF = NULL;
     
-    VSIUnlink( osDBFName );
+    if( VSIUnlink( osDBFName ) != 0 )
+    {
+        CPLDebug( "Shape", "Failed to delete DBF file: %s", VSIStrerror( errno ) );
+        CPLFree( panRecordsToDelete );
+
+        hDBF = DBFOpen ( osDBFName, bUpdateAccess ? "r+" : "r" );
+
+        VSIUnlink( oTempFile );
+
+        if( osCPGName.size() )
+            VSIUnlink( osCPGName );
+
+        return OGRERR_FAILURE;
+    }
         
     if( VSIRename( oTempFile, osDBFName ) != 0 )
     {


### PR DESCRIPTION
QGIS does a automatic REPACK after deleting features from shapes.  This silently fails if the shape file is opened multiple times and an leaves the layer behind without a DBF.  This pull request add an error if that happens and reopens the DBF, if it cannot be removed and cleans up the _packed.{dbf,cpg}.

See also http://hub.qgis.org/issues/7540
