### PR TITLE
NAS: also accept XML files that have NAS-Operationen_optional.xsd in header

### DIFF
--- a/gdal/ogr/ogrsf_frmts/nas/ogrnasdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/nas/ogrnasdatasource.cpp
@@ -135,6 +135,7 @@ int OGRNASDataSource::Open( const char * pszNewName, int bTestOpen )
         if( szPtr[0] != '<'
             || strstr(szPtr,"opengis.net/gml") == NULL
             || (strstr(szPtr,"NAS-Operationen.xsd") == NULL &&
+                strstr(szPtr,"NAS-Operationen_optional.xsd") == NULL &&
                 strstr(szPtr,"AAA-Fachschema.xsd") == NULL ) )
         {
             VSIFClose( fp );


### PR DESCRIPTION
Add support for NAS files that only have NAS-Operationen_optional.xsd in their header.
