### PR TITLE
Fixed geodetic tile calculation and cleaned up code.

### DIFF
--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -355,13 +355,13 @@ class GlobalGeodetic(object):
     def __init__(self, tmscompatible, tileSize = 256):
         self.tileSize = tileSize
         if tmscompatible is not None:
-            # Defaults the resolution factor to 1.40625 (1 tile @ level 0)
-            # Adheres OpenLayers, MapProxy, etc default resolution for TMS
+            # Defaults the resolution factor to 0.703125 (2 tiles @ level 0)
+            # Adhers to OSGeo TMS spec http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-geodetic
             self.resFact = 180.0 / self.tileSize
 
         else:
-            # Defaults the resolution factor to 0.703125 (2 tiles @ level 0)
-            # Adhers to OSGeo TMS spec http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-geodetic
+            # Defaults the resolution factor to 1.40625 (1 tile @ level 0)
+            # Adheres OpenLayers, MapProxy, etc default resolution for TMS
             self.resFact = 360.0 / self.tileSize
 
     def LatLonToPixels(self, lat, lon, zoom):


### PR DESCRIPTION
The geodetic profile was creating tile caches with a resolution factor of 0.703125, instead of the standard for TMS geodetic tiles which is 1.40625.  This error broke tile numbering for subsequent zoom levels.

Additionally, refactored code within the geodetic object for better maintainability.
