### PR TITLE
#5357-v110: add OGR_G_SetPointCount + OGR_G_SetPoints to API C (v1.10)

### DIFF
--- a/gdal/ogr/ogr_api.cpp
+++ b/gdal/ogr/ogr_api.cpp
@@ -69,6 +69,38 @@ int OGR_G_GetPointCount( OGRGeometryH hGeom )
 }
 
 /************************************************************************/
+/*                        OGR_G_SetPointCount()                         */
+/************************************************************************/
+/**
+ * \brief Set number of points in a geometry.
+ *
+ * This method primary exists to preset the number of points in a linestring
+ * geometry before setPoint() is used to assign them to avoid reallocating
+ * the array larger with each call to addPoint(). 
+ *
+ * @param nNewPointCount the new number of points for geometry.
+ */
+
+void OGR_G_SetPointCount( OGRGeometryH hGeom, int nNewPointCount )
+
+{
+    VALIDATE_POINTER0( hGeom, "OGR_G_SetPointCount" );
+
+    switch( wkbFlatten(((OGRGeometry *) hGeom)->getGeometryType()) )
+    {
+      case wkbLineString:
+      {
+        OGRLineString *poLine = (OGRLineString *) hGeom;
+        poLine->setNumPoints( nNewPointCount );
+        break;
+      }
+      default:
+        CPLError(CE_Failure, CPLE_NotSupported, "Incompatible geometry for operation");
+        break;
+    }
+}
+
+/************************************************************************/
 /*                             OGR_G_GetX()                             */
 /************************************************************************/
 /**
@@ -323,6 +355,73 @@ void OGR_G_GetPoint( OGRGeometryH hGeom, int i,
       }
       break;
 
+      default:
+        CPLError(CE_Failure, CPLE_NotSupported, "Incompatible geometry for operation");
+        break;
+    }
+}
+
+/************************************************************************/
+/*                           OGR_G_SetPoints()                          */
+/************************************************************************/
+/**
+ * \brief Assign all points in a point or a line string geometry.
+ *
+ * This method clear any existing points assigned to this geometry,
+ * and assigns a whole new set.
+ *
+ * @param hGeom handle to the geometry to set the coordinates.
+ * @param nPointsIn number of points being passed in padfX and padfY.
+ * @param padfX list of X coordinates of points being assigned.
+ * @param nXStride the number of bytes between 2 elements of pabyX.
+ * @param padfY list of Y coordinates of points being assigned.
+ * @param nYStride the number of bytes between 2 elements of pabyY.
+ * @param padfZ list of Z coordinates of points being assigned (defaults to NULL for 2D objects).
+ * @param nZStride the number of bytes between 2 elements of pabyZ.
+ */
+
+void CPL_DLL OGR_G_SetPoints( OGRGeometryH hGeom, int nPointsIn,
+                              void* pabyX, int nXStride,
+                              void* pabyY, int nYStride,
+                              void* pabyZ, int nZStride )
+
+{
+    VALIDATE_POINTER0( hGeom, "OGR_G_SetPoints" );
+
+    switch( wkbFlatten(((OGRGeometry *) hGeom)->getGeometryType()) )
+    {
+      case wkbPoint:
+      {
+        ((OGRPoint *) hGeom)->setX( pabyX ? *( (double *)pabyX ) : 0.0 );
+        ((OGRPoint *) hGeom)->setY( pabyY ? *( (double *)pabyY ) : 0.0 );
+        ((OGRPoint *) hGeom)->setZ( pabyZ ? *( (double *)pabyZ ) : 0.0 );
+        break;
+      }
+      case wkbLineString:
+      {
+        OGRLineString* poLine = (OGRLineString *) hGeom;
+
+        if( nXStride == 0 && nYStride == 0 && nZStride == 0 )
+        {
+          poLine->setPoints( nPointsIn, (double *)pabyX, (double *)pabyY, (double *)pabyZ ); 
+        }
+        else
+        {
+          double x, y, z;                  
+          x = y = z = 0;
+          poLine->setNumPoints( nPointsIn );
+
+          for (int i = 0; i < nPointsIn; ++i)
+          {
+            if( pabyX ) x = *(double*)((char*)pabyX + i * nXStride);
+            if( pabyY ) y = *(double*)((char*)pabyY + i * nYStride);
+            if( pabyZ ) z = *(double*)((char*)pabyZ + i * nZStride);
+
+            poLine->setPoint( i, x, y, z );
+          }
+        }
+        break;
+      }
       default:
         CPLError(CE_Failure, CPLE_NotSupported, "Incompatible geometry for operation");
         break;

--- a/gdal/ogr/ogr_api.h
+++ b/gdal/ogr/ogr_api.h
@@ -180,6 +180,7 @@ OGRGeometryH CPL_DLL OGR_G_GetBoundary( OGRGeometryH ) CPL_WARN_DEPRECATED("Non 
 
 /* Methods for getting/setting vertices in points, line strings and rings */
 int    CPL_DLL OGR_G_GetPointCount( OGRGeometryH );
+void   CPL_DLL OGR_G_SetPointCount( OGRGeometryH hGeom, int nNewPointCount );
 int    CPL_DLL OGR_G_GetPoints( OGRGeometryH hGeom,
                                 void* pabyX, int nXStride,
                                 void* pabyY, int nYStride,
@@ -195,6 +196,10 @@ void   CPL_DLL OGR_G_SetPoint_2D( OGRGeometryH, int iPoint,
                                   double, double );
 void   CPL_DLL OGR_G_AddPoint( OGRGeometryH, double, double, double );
 void   CPL_DLL OGR_G_AddPoint_2D( OGRGeometryH, double, double );
+void   CPL_DLL OGR_G_SetPoints( OGRGeometryH hGeom, int nPointsIn,
+                                void* pabyX, int nXStride,
+                                void* pabyY, int nYStride,
+                                void* pabyZ, int nZStride );
 
 /* Methods for getting/setting rings and members collections */
 


### PR DESCRIPTION
New functions:

void CPL_DLL OGR_G_SetPointCount( OGRGeometryH hGeom, int nNewPointCount );
void CPL_DLL OGR_G_SetPoints( OGRGeometryH hGeom, ... );

Now, QGIS simplifies the geometries fetched from provider, but in OGR-provider we can not use a pre-simplification of the OgrGeometry because GDAL API C has not published one of these functions.
