### PR TITLE
Pass driver for temp files via options

### DIFF
--- a/gdal/alg/rasterfill.cpp
+++ b/gdal/alg/rasterfill.cpp
@@ -463,8 +463,10 @@ GDALFillNodata( GDALRasterBandH hTargetBand,
 
     char **papszWorkFileOptions = NULL;
     if (osTmpFileDriver == "GTiff") {
-        CSLSetNameValue(papszWorkFileOptions, "COMPRESS", "LZW");
-        CSLSetNameValue(papszWorkFileOptions, "BIGTIFF", "IF_SAFER");
+        papszWorkFileOptions = CSLSetNameValue(
+                papszWorkFileOptions, "COMPRESS", "LZW");
+        papszWorkFileOptions = CSLSetNameValue(
+                papszWorkFileOptions, "BIGTIFF", "IF_SAFER");
     }
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
This is a copy of the rasterfill.cpp file I'm maintaining in Rasterio. It allows a driver other than GTiff (I'm thinking about MEM in particular), to be used for temp files. Would love to see it in a future version of GDAL.

