### PR TITLE
Replace strdup() to CPLStrdup().

### DIFF
--- a/gdal/port/cpl_vsisimple.cpp
+++ b/gdal/port/cpl_vsisimple.cpp
@@ -689,7 +689,7 @@ char *VSIStrdup( const char * pszString )
     memcpy(ptr, pszString, nSize);
     return ptr;
 #else
-    return( strdup( pszString ) );
+    return( CPLStrdup( pszString ) );
 #endif
 }
 


### PR DESCRIPTION
The strdup() API is deprecated under Windows. I ma having memory heap corruption isssue under Windows 8. A while a go, I file a ticket about this. But I missed one strdup() in gdal/port/cpl_vsisimple.cpp. Apparently, it is also problematic. I have replace it with CPLStrdup() and everything works fine afterwords.

I have created a ticket #5931. Just want to check in and see if it passes all the travis test. 

P.S.: Hope you will move your development to Git soon. So that it will be easier for community to contribute back to this great