### PR TITLE
Update gdal2tiles.py

### DIFF
--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -851,7 +851,7 @@ gdal2tiles temp.vrt""" % self.input )
                         os.unlink(tempfilename)
 
                         # set NODATA_VALUE metadata
-                        self.out_ds.SetMetadataItem('NODATA_VALUES','%i %i %i' % (self.in_nodata[0],self.in_nodata[1],self.in_nodata[2]))
+                        self.out_ds.SetMetadataItem('NODATA_VALUES',' '.join([str(i) for i in self.in_nodata]))
 
                         if self.options.verbose:
                             print("Modified warping result saved into 'tiles1.vrt'")


### PR DESCRIPTION
Writing nodata metadata was hard coded for 3 band rasters in gdal2tiles.py
Using gdal2tiles.py on a raster with less than 3 bands resulted in a "IndexError: list index out of range".
Fixed by adding the metadata values based on iterating the source no_data list instead of reading exactly 3 bands.