### PR TITLE
CSV: handle numeric column names

### DIFF
--- a/gdal/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -350,8 +350,8 @@ void OGRCSVLayer::BuildFeatureDefn( const char* pszNfdcGeomField,
 
 /* -------------------------------------------------------------------- */
 /*      Check if the first record seems to be field definitions or      */
-/*      not.  We assume it is field definitions if none of the          */
-/*      values are strictly numeric.                                    */
+/*      not.  We assume it is field definitions if OGR_CSV_HEADERS is   */
+/*      not supplied and none of the values are strictly numeric.       */
 /* -------------------------------------------------------------------- */
     char **papszTokens = NULL;
     int nFieldCount=0, iField;
@@ -380,26 +380,34 @@ void OGRCSVLayer::BuildFeatureDefn( const char* pszNfdcGeomField,
                                                CSLT_ALLOWEMPTYTOKENS |
                                                CSLT_PRESERVEQUOTES) );
             nFieldCount = CSLCount( papszTokens );
+
+            const char* pszCSVHeaders = CPLGetConfigOption("OGR_CSV_HEADERS", "");
             bHasFieldNames = TRUE;
-
-            for( iField = 0; iField < nFieldCount && bHasFieldNames; iField++ )
-            {
-                CPLValueType eType = CPLGetValueType(papszTokens[iField]);
-                if ( (eType == CPL_VALUE_INTEGER ||
-                      eType == CPL_VALUE_REAL) ) {
-                    /* we have a numeric field, therefore do not consider the first line as field names */
-                    bHasFieldNames = FALSE;
-                }
-            }
-
-            CPLString osExt = OGRCSVDataSource::GetRealExtension(pszFilename);
-
-            /* Eurostat .tsv files */
-            if( EQUAL(osExt, "tsv") && nFieldCount > 1 &&
-                strchr(papszTokens[0], ',') != NULL && strchr(papszTokens[0], '\\') != NULL )
-            {
+            if (EQUAL(pszCSVHeaders, "FORCE"))
                 bHasFieldNames = TRUE;
-                bIsEurostatTSV = TRUE;
+            else if (EQUAL(pszCSVHeaders, "DISABLE"))
+                bHasFieldNames = FALSE;
+            else {
+                // not sure - check for the presence of numeric values.
+                for( iField = 0; iField < nFieldCount && bHasFieldNames; iField++ )
+                {
+                    CPLValueType eType = CPLGetValueType(papszTokens[iField]);
+                    if ( (eType == CPL_VALUE_INTEGER ||
+                          eType == CPL_VALUE_REAL) ) {
+                        /* we have a numeric field, therefore do not consider the first line as field names */
+                        bHasFieldNames = FALSE;
+                    }
+                }
+
+                CPLString osExt = OGRCSVDataSource::GetRealExtension(pszFilename);
+
+                /* Eurostat .tsv files */
+                if( EQUAL(osExt, "tsv") && nFieldCount > 1 &&
+                    strchr(papszTokens[0], ',') != NULL && strchr(papszTokens[0], '\\') != NULL )
+                {
+                    bHasFieldNames = TRUE;
+                    bIsEurostatTSV = TRUE;
+                }
             }
 
             /* tokenize without quotes to get the actual values */


### PR DESCRIPTION
Adds `OGR_CSV_HEADERS=FORCE` config option to force OGR to handle numeric column names.

Otherwise any CSV with (for instance) year numbers in the column names will parse badly (e.g. https://gist.github.com/craigds/454b0d04b63d012f991d )

I considered doing this with an 'open option', but the corresponding things in other formats (XLS, XLSX, ODS) are all still config options so I figured I'd make it consistent with those.