### PR TITLE
CSV: `HEADERS` open option

### DIFF
--- a/gdal/ogr/ogrsf_frmts/csv/drv_csv.html
+++ b/gdal/ogr/ogrsf_frmts/csv/drv_csv.html
@@ -63,12 +63,13 @@ Otherwise it will default to comma as separator.</p>
 may be placed in double quotes. Any occurances of double quotes within 
 the quoted string should be doubled up to "escape" them.</p>
 
-<p>The driver attempts to treat the first line of the file as a list of field 
+<p>By default, the driver attempts to treat the first line of the file as a list of field 
 names for all the fields. However, if one or more of the names is all 
 numeric it is assumed that the first line is actually data values and
 dummy field names are generated internally (field_1 through field_n) and
 the first record is treated as a feature. Starting with GDAL 1.9.0 
-numeric values are treated as field names if they are enclosed in double quotes. 
+numeric values are treated as field names if they are enclosed in double quotes.
+Starting with GDAL 2.1, this behaviour can be modified via the HEADERS open option.
 </p>
 
 <p>All CSV files are treated as UTF-8 encoded. Starting with GDAL 1.9.0, a Byte
@@ -225,6 +226,9 @@ WKT, WKB (in hexadecimal form, potentially in PostGIS 2.0 extended WKB) or GeoJS
 using the star character in starting and/or ending position. E.g.: prefix*, *suffix or *middle*</li>
 <li><b>KEEP_GEOM_COLUMNS</b>=YES/NO (default YES) Expose the detected X,Y,Z or geometry columns
 as regular attribute fields.</li>
+<li><b>HEADERS</b>=YES/NO/AUTO (default AUTO) (GDAL &gt;= 2.1) Whether the first line of the file
+contains column names or not. When set to AUTO, GDAL will assume the first line is column names if none
+of the values are strictly numeric.
 </ul>
 
 <h2>Creation Issues</h2>

--- a/gdal/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
@@ -299,6 +299,11 @@ void RegisterOGRCSV()
 "  <Option name='Z_POSSIBLE_NAMES' type='string' description='Comma separated list of possible names for Z/elevation coordinate of a point.'/>"
 "  <Option name='GEOM_POSSIBLE_NAMES' type='string' description='Comma separated list of possible names for geometry columns.' default='WKT'/>"
 "  <Option name='KEEP_GEOM_COLUMNS' type='boolean' description='whether to add original x/y/geometry columns as regular fields.' default='YES'/>"
+"  <Option name='HEADERS' type='string-select' description='Whether the first line of the file contains column names or not' default='AUTO'>"
+"    <Value>YES</Value>"
+"    <Value>NO</Value>"
+"    <Value>AUTO</Value>"
+"  </Option>"
 "</OpenOptionList>");
 
         poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );


### PR DESCRIPTION
Adds `HEADERS=YES/NO/AUTO` open option for the CSV driver, to force OGR to handle numeric column names.

Otherwise any CSV with (for instance) year numbers in the column names will parse badly (e.g. https://gist.github.com/craigds/454b0d04b63d012f991d )

was #62. Changed it to use an open option instead of a config option, and added docs.