### PR TITLE
Fix python package installation in custom prefixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ install:
   - make
   - cd ../..
   - sudo rm -f /usr/lib/libgdal.so*
-  - env INSTALL_LAYOUT=deb sudo make install
+  - sudo make INSTALL_LAYOUT=deb install
   - sudo ldconfig
   - cd ../autotest/cpp
   - make -j3

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ install:
   - make
   - cd ../..
   - sudo rm -f /usr/lib/libgdal.so*
-  - sudo make install
+  - env INSTALL_LAYOUT=deb sudo make install
   - sudo ldconfig
   - cd ../autotest/cpp
   - make -j3

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ install:
   - make
   - cd ../..
   - sudo rm -f /usr/lib/libgdal.so*
-  - sudo make INSTALL_LAYOUT=deb install
+  - sudo make install
   - sudo ldconfig
   - cd ../autotest/cpp
   - make -j3

--- a/gdal/swig/python/GNUmakefile
+++ b/gdal/swig/python/GNUmakefile
@@ -69,13 +69,18 @@ build:
 
 egg:
 	$(PYTHON) setup.py bdist_egg 
-
+prefix:=/usr
 site_package_dir=$(shell $(PYTHON) -c "from __future__ import print_function;from distutils.sysconfig import get_python_lib;print(get_python_lib(prefix=\"$(prefix)\"))")
 
 ifeq ($(PY_HAVE_SETUPTOOLS),1)
     setup_opts=--single-version-externally-managed --record=record.txt
-    ifdef INSTALL_LAYOUT
-        setup_opts+=--install-layout=$(INSTALL_LAYOUT)
+endif
+
+ifdef INSTALL_LAYOUT
+    setup_opts+=--install-layout=$(INSTALL_LAYOUT)
+else
+    ifneq ($(shell echo $(site_package_dir) | grep dist-packages),)
+        setup_opts+=--install-layout=deb
     endif
 endif
 

--- a/gdal/swig/python/GNUmakefile
+++ b/gdal/swig/python/GNUmakefile
@@ -65,15 +65,21 @@ build:
 
 egg:
 	$(PYTHON) setup.py bdist_egg 
-	
+
+site_package_dir=$(shell $(PYTHON) -c "from __future__ import print_function;from distutils.sysconfig import get_python_lib;print(get_python_lib(prefix=\"$(DESTDIR)$(prefix)\"))")
+
 install:
-
-ifeq ($(PY_HAVE_SETUPTOOLS),1)
-	$(PYTHON) setup.py install 
-else
-	$(PYTHON) setup.py install --prefix=$(DESTDIR)$(prefix)
-endif
-
+	@if [ ! -d $(site_package_dir) ]; then \
+		mkdir -p $(site_package_dir); \
+		echo "----------------------------------------------------------------------";\
+		echo ""; \
+		echo "The GDAL python package has bee installed in $(site_package_dir)"; \
+		echo "Please ensure to add $(site_package_dir) to your PYTHONPATH"; \
+		echo ""; \
+		echo "----------------------------------------------------------------------";\
+	fi
+	env PYTHONPATH=$(site_package_dir)$${PYTHONPATH:+:$$PYTHONPATH} \
+		$(PYTHON) setup.py install --prefix=$(DESTDIR)$(prefix)
 	for f in $(SCRIPTS) ; do $(INSTALL) ./scripts/$$f $(DESTDIR)$(INST_BIN) ; done
 
 docs:

--- a/gdal/swig/python/GNUmakefile
+++ b/gdal/swig/python/GNUmakefile
@@ -69,7 +69,7 @@ build:
 
 egg:
 	$(PYTHON) setup.py bdist_egg 
-prefix:=/usr
+
 site_package_dir=$(shell $(PYTHON) -c "from __future__ import print_function;from distutils.sysconfig import get_python_lib;print(get_python_lib(prefix=\"$(prefix)\"))")
 
 ifeq ($(PY_HAVE_SETUPTOOLS),1)

--- a/gdal/swig/python/GNUmakefile
+++ b/gdal/swig/python/GNUmakefile
@@ -6,6 +6,14 @@ ifndef PYTHON
         PYTHON=python
 endif
 
+ifndef DESTDIR
+    DESTDIR=/
+endif
+
+ifndef INSTALL_LAYOUT
+    INSTALL_LAYOUT=unix
+endif
+
 all: build
 
 BINDING = python
@@ -66,11 +74,15 @@ build:
 egg:
 	$(PYTHON) setup.py bdist_egg 
 
-site_package_dir=$(shell $(PYTHON) -c "from __future__ import print_function;from distutils.sysconfig import get_python_lib;print(get_python_lib(prefix=\"$(DESTDIR)$(prefix)\"))")
+site_package_dir=$(shell $(PYTHON) -c "from __future__ import print_function;from distutils.sysconfig import get_python_lib;print(get_python_lib(prefix=\"$(prefix)\"))")
+
+ifeq ($(PY_HAVE_SETUPTOOLS),1)
+    setup_opts=--single-version-externally-managed --install-layout=$(INSTALL_LAYOUT) --record=record.txt
+endif
 
 install:
 	@if [ ! -d $(site_package_dir) ]; then \
-		mkdir -p $(site_package_dir); \
+		mkdir -p $(DESTDIR)$(site_package_dir); \
 		echo "----------------------------------------------------------------------";\
 		echo ""; \
 		echo "The GDAL python package has bee installed in $(site_package_dir)"; \
@@ -79,7 +91,7 @@ install:
 		echo "----------------------------------------------------------------------";\
 	fi
 	env PYTHONPATH=$(site_package_dir)$${PYTHONPATH:+:$$PYTHONPATH} \
-		$(PYTHON) setup.py install --prefix=$(DESTDIR)$(prefix)
+		$(PYTHON) setup.py install --root=$(DESTDIR) --prefix=$(prefix) ${setup_opts}
 	for f in $(SCRIPTS) ; do $(INSTALL) ./scripts/$$f $(DESTDIR)$(INST_BIN) ; done
 
 docs:

--- a/gdal/swig/python/GNUmakefile
+++ b/gdal/swig/python/GNUmakefile
@@ -10,10 +10,6 @@ ifndef DESTDIR
     DESTDIR=/
 endif
 
-ifndef INSTALL_LAYOUT
-    INSTALL_LAYOUT=unix
-endif
-
 all: build
 
 BINDING = python
@@ -77,7 +73,10 @@ egg:
 site_package_dir=$(shell $(PYTHON) -c "from __future__ import print_function;from distutils.sysconfig import get_python_lib;print(get_python_lib(prefix=\"$(prefix)\"))")
 
 ifeq ($(PY_HAVE_SETUPTOOLS),1)
-    setup_opts=--single-version-externally-managed --install-layout=$(INSTALL_LAYOUT) --record=record.txt
+    setup_opts=--single-version-externally-managed --record=record.txt
+    ifdef INSTALL_LAYOUT
+        setup_opts+=--install-layout=$(INSTALL_LAYOUT)
+    endif
 endif
 
 install:


### PR DESCRIPTION
This PR should address issue no [4563](https://trac.osgeo.org/gdal/ticket/4563): "Python bindings installation ignores prefix"