### PR TITLE
Remove unused import in osgeo/gdal.py

### DIFF
--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -426,7 +426,7 @@ class Driver(MajorObject):
 Driver_swigregister = _gdal.Driver_swigregister
 Driver_swigregister(Driver)
 
-import ogr
+#import ogr
 import osr
 class ColorEntry(_object):
     """Proxy of C++ GDALColorEntry class"""


### PR DESCRIPTION
Removed import (from . import ogr in osgeo/gdal.py) also breaks
a circular import.