### PR TITLE
Fix an #5405

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_middatafile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_middatafile.cpp
@@ -87,8 +87,9 @@
  *
  *====================================================================*/
 
-MIDDATAFile::MIDDATAFile()
+MIDDATAFile::MIDDATAFile( GBool bSkipLeadingSpaces )
 {
+	m_bSkipLeadingSpaces = bSkipLeadingSpaces;
     m_fp = NULL;
     m_szLastRead[0] = '\0';
     m_szSavedLine[0] = '\0';
@@ -213,9 +214,12 @@ const char *MIDDATAFile::GetLine()
         }
         else
         {
-            // skip leading spaces
-            while(pszLine && (*pszLine == ' ' || *pszLine == '\t') )
-                pszLine++;
+			if( m_bSkipLeadingSpaces )
+			{
+				// skip leading spaces
+				while(pszLine && (*pszLine == ' ' || *pszLine == '\t') )
+					pszLine++;
+			}
 
             strncpy(m_szLastRead,pszLine,MIDMAXCHAR);
         }

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_miffile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_miffile.cpp
@@ -396,7 +396,7 @@ int MIFFile::Open(const char *pszFname, TABAccess eAccess,
         TABAdjustFilenameExtension(pszTmpFname);
 #endif
 
-        m_poMIDFile = new MIDDATAFile;
+		m_poMIDFile = new MIDDATAFile( FALSE );
 
         if (m_poMIDFile->Open(pszTmpFname, pszAccess) !=0)
         {

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_priv.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_priv.h
@@ -1892,7 +1892,7 @@ class TABRelation
 class MIDDATAFile
 {
    public:
-      MIDDATAFile();
+	  MIDDATAFile( GBool bSkipLeadingSpaces = TRUE );
      ~MIDDATAFile();
 
      int         Open(const char *pszFname, const char *pszAccess);
@@ -1921,6 +1921,8 @@ class MIDDATAFile
        VSILFILE *m_fp;
        const char *m_pszDelimiter;
 
+	   //We must skip leading spaces only for feature file
+	   GBool       m_bSkipLeadingSpaces;
        // Set limit for the length of a line
 #define MIDMAXCHAR 10000
        char m_szLastRead[MIDMAXCHAR];


### PR DESCRIPTION
Hello!
I'm add small patch to fix problem with reading mid/mif files with empty fields in first several columns.

[See gdal ticket #5405](https://trac.osgeo.org/gdal/ticket/5405)