### PR TITLE
Fix access to ECW files with names in UTF-8

### DIFF
--- a/gdal/frmts/ecw/ecwcreatecopy.cpp
+++ b/gdal/frmts/ecw/ecwcreatecopy.cpp
@@ -993,7 +993,7 @@ CPLErr GDALECWCompressor::Initialize(
             return CE_Failure;
         }
 
-        m_OStream.Access( fpVSIL, TRUE, (BOOLEAN) bSeekable, pszFilename, 
+		m_OStream.Access( fpVSIL, TRUE, (BOOLEAN) bSeekable, pszFilename,
 			  0, -1 );
     }    
 
@@ -1069,9 +1069,23 @@ CPLErr GDALECWCompressor::Initialize(
     if( oError.GetErrorNumber() == NCS_SUCCESS )
     {
         if( fpVSIL == NULL )
-            oError = Open( (char *) pszFilename, false, true );
+		{
+			if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+			{
+				wchar_t *pwszFilename = CPLRecodeToWChar( pszFilename, CPL_ENC_UTF8, CPL_ENC_UCS2 );
+
+				oError = Open( pwszFilename, false, true );
+				CPLFree( pwszFilename );
+			}
+			else
+			{
+				oError = Open( (char *) pszFilename, false, true );
+			}
+		}
         else
+		{
             oError = CNCSJP2FileView::Open( &(m_OStream) );
+		}
     }
 
     if( oError.GetErrorNumber() == NCS_SUCCESS )

--- a/gdal/frmts/ecw/ecwcreatecopy.cpp
+++ b/gdal/frmts/ecw/ecwcreatecopy.cpp
@@ -993,7 +993,7 @@ CPLErr GDALECWCompressor::Initialize(
             return CE_Failure;
         }
 
-		m_OStream.Access( fpVSIL, TRUE, (BOOLEAN) bSeekable, pszFilename,
+        m_OStream.Access( fpVSIL, TRUE, (BOOLEAN) bSeekable, pszFilename,
 			  0, -1 );
     }    
 
@@ -1070,14 +1070,16 @@ CPLErr GDALECWCompressor::Initialize(
     {
         if( fpVSIL == NULL )
 		{
-			if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
-			{
-				wchar_t *pwszFilename = CPLRecodeToWChar( pszFilename, CPL_ENC_UTF8, CPL_ENC_UCS2 );
+#if ECWSDK_VERSION>=40		
+            if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+            {
+                wchar_t *pwszFilename = CPLRecodeToWChar( pszFilename, CPL_ENC_UTF8, CPL_ENC_UCS2 );
 
-				oError = Open( pwszFilename, false, true );
-				CPLFree( pwszFilename );
-			}
-			else
+                oError = Open( pwszFilename, false, true );
+                CPLFree( pwszFilename );
+            }
+            else
+#endif//ECWSDK_VERSION>=40			
 			{
 				oError = Open( (char *) pszFilename, false, true );
 			}

--- a/gdal/frmts/ecw/ecwdataset.cpp
+++ b/gdal/frmts/ecw/ecwdataset.cpp
@@ -2388,17 +2388,19 @@ CNCSJP2FileView *ECWDataset::OpenFileView( const char *pszDatasetName,
     //we always open in read only mode. This should be improved in the future.
     try
     {
-		if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
-		{
-			wchar_t *pwszDatasetName = CPLRecodeToWChar( pszDatasetName, CPL_ENC_UTF8, CPL_ENC_UCS2 );
+#if ECWSDK_VERSION>=40    
+        if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+        {
+            wchar_t *pwszDatasetName = CPLRecodeToWChar( pszDatasetName, CPL_ENC_UTF8, CPL_ENC_UCS2 );
 
-			oErr = poFileView->Open( pwszDatasetName, bProgressive, false );
-			CPLFree( pwszDatasetName );
-		}
-		else
-		{
-			oErr = poFileView->Open( (char *) pszDatasetName, bProgressive, false );
-		}
+            oErr = poFileView->Open( pwszDatasetName, bProgressive, false );
+            CPLFree( pwszDatasetName );
+        }
+        else
+#endif //#if ECWSDK_VERSION>=40        
+        {
+            oErr = poFileView->Open( (char *) pszDatasetName, bProgressive, false );
+        }
     }
     catch(...)
     {

--- a/gdal/frmts/ecw/ecwdataset.cpp
+++ b/gdal/frmts/ecw/ecwdataset.cpp
@@ -2388,7 +2388,17 @@ CNCSJP2FileView *ECWDataset::OpenFileView( const char *pszDatasetName,
     //we always open in read only mode. This should be improved in the future.
     try
     {
-        oErr = poFileView->Open( (char *) pszDatasetName, bProgressive, false );
+		if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+		{
+			wchar_t *pwszDatasetName = CPLRecodeToWChar( pszDatasetName, CPL_ENC_UTF8, CPL_ENC_UCS2 );
+
+			oErr = poFileView->Open( pwszDatasetName, bProgressive, false );
+			CPLFree( pwszDatasetName );
+		}
+		else
+		{
+			oErr = poFileView->Open( (char *) pszDatasetName, bProgressive, false );
+		}
     }
     catch(...)
     {

--- a/gdal/frmts/ecw/gdal_ecw.h
+++ b/gdal/frmts/ecw/gdal_ecw.h
@@ -266,8 +266,20 @@ class VSIIOStream : public CNCSJPCIOStream
             }
             CPLDebug( "ECW", "Using filename '%s' for temporary directory determination purposes.", osFilenameUsed.c_str() );
         }
-        return(CNCSJPCIOStream::Open((char *)osFilenameUsed.c_str(), 
-                                     (bool) bWrite));
+
+		if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+		{
+			wchar_t		*pwszFilename = CPLRecodeToWChar( pszFilename, CPL_ENC_UTF8, CPL_ENC_UCS2 );
+			CNCSError	oError;
+			oError = CNCSJPCIOStream::Open( pwszFilename, (bool) bWrite );
+			CPLFree( pwszFilename );
+			return oError;
+		}
+		else
+		{
+			return(CNCSJPCIOStream::Open((char *)osFilenameUsed.c_str(),
+										 (bool) bWrite));
+		}
     }
 
     virtual bool NCS_FASTCALL Seek() {

--- a/gdal/frmts/ecw/gdal_ecw.h
+++ b/gdal/frmts/ecw/gdal_ecw.h
@@ -266,20 +266,21 @@ class VSIIOStream : public CNCSJPCIOStream
             }
             CPLDebug( "ECW", "Using filename '%s' for temporary directory determination purposes.", osFilenameUsed.c_str() );
         }
-
-		if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
-		{
-			wchar_t		*pwszFilename = CPLRecodeToWChar( pszFilename, CPL_ENC_UTF8, CPL_ENC_UCS2 );
-			CNCSError	oError;
-			oError = CNCSJPCIOStream::Open( pwszFilename, (bool) bWrite );
-			CPLFree( pwszFilename );
-			return oError;
-		}
-		else
-		{
-			return(CNCSJPCIOStream::Open((char *)osFilenameUsed.c_str(),
-										 (bool) bWrite));
-		}
+#if ECWSDK_VERSION>=40
+        if( CSLTestBoolean( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+        {
+            wchar_t		*pwszFilename = CPLRecodeToWChar( pszFilename, CPL_ENC_UTF8, CPL_ENC_UCS2 );
+            CNCSError	oError;
+            oError = CNCSJPCIOStream::Open( pwszFilename, (bool) bWrite );
+            CPLFree( pwszFilename );
+            return oError;
+        }
+        else
+#endif//ECWSDK_VERSION>=40		
+        {
+            return(CNCSJPCIOStream::Open((char *)osFilenameUsed.c_str(),
+                                         (bool) bWrite));
+        }
     }
 
     virtual bool NCS_FASTCALL Seek() {


### PR DESCRIPTION
Hello!

This update fixes problem with access to ECW files in local encoding when GDAL_FILENAME_IS_UTF8 is set to TRUE.
Bug can be reproduced if we set system encoding different then UTF8 (that is common for Windows)

Im test it with libecw33 & ERDAS_ECW_JPEG2000_SDK_4.3(RW)