### PR TITLE
Make UKOOA P1/90 and SEG-P1 Line layer output optional

### DIFF
--- a/gdal/ogr/ogrsf_frmts/segukooa/ogrsegukooadatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/segukooa/ogrsegukooadatasource.cpp
@@ -123,11 +123,15 @@ int OGRSEGUKOOADataSource::Open( const char * pszFilename )
             return FALSE;
         }
 
-        nLayers = 2;
-        papoLayers = (OGRLayer**) CPLMalloc(2 * sizeof(OGRLayer*));
+        nLayers = 1;
+        int bNoLineLayer = CSLTestBoolean(CPLGetConfigOption("UKOOAP190_NO_LINE_LAYER", "NO"));
+        if (!bNoLineLayer)
+            nLayers++;
+        papoLayers = (OGRLayer**) CPLMalloc(nLayers * sizeof(OGRLayer*));
         papoLayers[0] = new OGRUKOOAP190Layer(pszName, fp);
-        papoLayers[1] = new OGRSEGUKOOALineLayer(pszName,
-                                         new OGRUKOOAP190Layer(pszName, fp2));
+        if (!bNoLineLayer)
+            papoLayers[1] = new OGRSEGUKOOALineLayer(pszName,
+                                             new OGRUKOOAP190Layer(pszName, fp2));
 
         return TRUE;
     }
@@ -178,12 +182,16 @@ int OGRSEGUKOOADataSource::Open( const char * pszFilename )
             return FALSE;
         }
 
-        nLayers = 2;
-        papoLayers = (OGRLayer**) CPLMalloc(2 * sizeof(OGRLayer*));
+        nLayers = 1;
+        int bNoLineLayer = CSLTestBoolean(CPLGetConfigOption("SEGP1_NO_LINE_LAYER", "NO"));
+        if (!bNoLineLayer)
+            nLayers++;
+        papoLayers = (OGRLayer**) CPLMalloc(nLayers * sizeof(OGRLayer*));
         papoLayers[0] = new OGRSEGP1Layer(pszName, fp, nLatitudeCol);
-        papoLayers[1] = new OGRSEGUKOOALineLayer(pszName,
-                                         new OGRSEGP1Layer(pszName, fp2,
-                                                           nLatitudeCol));
+        if (!bNoLineLayer)
+            papoLayers[1] = new OGRSEGUKOOALineLayer(pszName,
+                                             new OGRSEGP1Layer(pszName, fp2,
+                                                               nLatitudeCol));
 
         return TRUE;
     }


### PR DESCRIPTION
Introducing options UKOOAP190_NO_LINE_LAYER and SEGP1_NO_LINE_LAYER. Rationale behind this is to reduce processing time and space usage when the line layer is not needed and working with files of several gigabytes