### PR TITLE
Fix compile problem, when DEFER_STRILE_LOAD is undefined

### DIFF
--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -7556,7 +7556,7 @@ int GTiffDataset::IsBlockAvailable( int nBlockId )
 
 {
 #ifdef INTERNAL_LIBTIFF
-
+#ifdef DEFER_STRILE_LOAD
     /* Optimization to avoid fetching the whole Strip/TileCounts and Strip/TileOffsets arrays */
     if( eAccess == GA_ReadOnly &&
         !(hTIFF->tif_flags & TIFF_SWAB) &&
@@ -7660,6 +7660,7 @@ int GTiffDataset::IsBlockAvailable( int nBlockId )
         }
         return hTIFF->tif_dir.td_stripbytecount[nBlockId] != 0;
     }
+#endif /* DEFER_STRILE_LOAD */
 #endif /* INTERNAL_LIBTIFF */
     toff_t *panByteCounts = NULL;
 


### PR DESCRIPTION
Some TIFF files can be accessed via GDAL only if we deactivate DEFER_STRILE_LOAD flag in tif_config.h. But in this case we have compile error. This patch fix this problem.