### PR TITLE
Added /I flag to the INSTALL command in the nmake.opt so that xcopy w…

### DIFF
--- a/gdal/nmake.opt
+++ b/gdal/nmake.opt
@@ -730,7 +730,7 @@ MAKE	=	nmake /nologo
 CC	=	cl
 !ENDIF
 
-INSTALL	=	xcopy /y /r /d /f
+INSTALL	=	xcopy /y /r /d /f /I
 
 CPLLIB	=    $(GDAL_ROOT)/port/cpl.lib
 


### PR DESCRIPTION
…ill be smart enough to create a directory when copying files and avoid prompting for user input.

[Mailing list thread](http://lists.osgeo.org/pipermail/gdal-dev/2016-February/043735.html)