### PR TITLE
Removed hard coded pi constant

### DIFF
--- a/gdal/frmts/gtiff/libgeotiff/geo_normalize.c
+++ b/gdal/frmts/gtiff/libgeotiff/geo_normalize.c
@@ -36,10 +36,6 @@
 #  define KvUserDefined 32767
 #endif
 
-#ifndef M_PI
-#  define M_PI 3.14159265358979323846
-#endif
-
 /* EPSG Codes for projection parameters.  Unfortunately, these bear no
    relationship to the GeoTIFF codes even though the names are so similar. */
 


### PR DESCRIPTION
M_PI is defined in math.h, and most modern environments should be able to use that, so no point in defining M_PI again.