### PR TITLE
add Komsat Mission ID to possible value for HDF5 SAR product

### DIFF
--- a/gdal/frmts/hdf5/hdf5imagedataset.cpp
+++ b/gdal/frmts/hdf5/hdf5imagedataset.cpp
@@ -955,7 +955,7 @@ void HDF5ImageDataset::IdentifyProductType()
     if(pszMissionId != NULL && strstr(GetDescription(), "QLK") == NULL)
     {
         //Check if the mission type is CSK
-        if(EQUAL(pszMissionId,"CSK"))
+        if(EQUAL(pszMissionId,"CSK") || EQUAL(pszMissionId,"KMPS"))
         {
             iSubdatasetType = CSK_PRODUCT;
 


### PR DESCRIPTION
Komsat-5 is Korean mission with a SAR intrument [.](https://directory.eoportal.org/web/eoportal/satellite-missions/k/kompsat-5) 
Files are based on the ComSat file format.
this PR update the missionID test to take into account the Komsat-5 mission. 