### PR TITLE
Fixed typo in CPLE_AWSSignatureDoesNotMatch

### DIFF
--- a/gdal/port/cpl_error.h
+++ b/gdal/port/cpl_error.h
@@ -82,7 +82,7 @@ typedef enum
   CPLE_AWSObjectNotFound,
   CPLE_AWSAccessDenied,
   CPLE_AWSInvalidCredentials,
-  CPLE_AWSSignaturDoesNotMatch,
+  CPLE_AWSSignatureDoesNotMatch,
 } CPLErrorNum;
 
 #else
@@ -109,7 +109,7 @@ typedef int CPLErrorNum;
 #define CPLE_AWSObjectNotFound          13
 #define CPLE_AWSAccessDenied            14
 #define CPLE_AWSInvalidCredentials      15
-#define CPLE_AWSSignaturDoesNotMatch    16
+#define CPLE_AWSSignatureDoesNotMatch    16
 
 /* 100 - 299 reserved for GDAL */
 

--- a/gdal/port/cpl_vsi_error.cpp
+++ b/gdal/port/cpl_vsi_error.cpp
@@ -284,7 +284,7 @@ int CPL_DLL CPL_STDCALL VSIToCPLError(CPLErr eErrClass, CPLErrorNum eDefaultErro
             CPLError(eErrClass, CPLE_AWSInvalidCredentials, "%s", VSIGetLastErrorMsg());
             break;
         case VSIE_AWSSignatureDoesNotMatch:
-            CPLError(eErrClass, CPLE_AWSSignaturDoesNotMatch, "%s", VSIGetLastErrorMsg());
+            CPLError(eErrClass, CPLE_AWSSignatureDoesNotMatch, "%s", VSIGetLastErrorMsg());
             break;
         default:
             CPLError(eErrClass, CPLE_HttpResponse, "A filesystem error with code %d occurred", err);


### PR DESCRIPTION
This fixes a type that was discovered in #98's work.
