### PR TITLE
Identify nested blocks in the AutoCAD DXF driver

### DIFF
--- a/gdal/ogr/ogrsf_frmts/dxf/ogrdxfblockslayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogrdxfblockslayer.cpp
@@ -45,6 +45,10 @@ OGRDXFBlocksLayer::OGRDXFBlocksLayer( OGRDXFDataSource *poDSIn ) :
     poFeatureDefn->Reference();
 
     poDS->AddStandardFields( poFeatureDefn );
+
+    OGRFieldDefn  oChildBlockNameField( "ChildBlockName", OFTString );
+    poFeatureDefn->AddFieldDefn( &oChildBlockNameField );
+  
 }
 
 /************************************************************************/
@@ -139,6 +143,7 @@ OGRFeature *OGRDXFBlocksLayer::GetNextUnfilteredFeature()
 /* -------------------------------------------------------------------- */
     poFeature->SetFID( iNextFID++ );
 
+    poFeature->SetField( "ChildBlockName", poFeature->GetFieldAsString( "BlockName" ) );
     poFeature->SetField( "BlockName", oIt->first.c_str() );
 
     m_nFeaturesRead++;


### PR DESCRIPTION
When `DXF_INLINE_BLOCKS` is set to `false`, the OGR AutoCAD DXF driver emits a layer called `blocks` that contains all features that are inside blocks accompanied by their respective `BlockName`. However, AutoCAD allows blocks to be nested inside other blocks (by using `INSERT` entities), a hierarchy the driver is unable to correctly represent in its current state because it is impossible to determine the `BlockName` of a nested block.

To fix the above situation, this pull request adds a new column (`ChildBlockName`) to the `blocks` layer. Whenever a nested `INSERT` is encountered, `ChildBlockName` is set to the name of the block referenced by the `INSERT`.
