### PR TITLE
Reusable python scripts (now gdal_calc.py)

### DIFF
--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -68,15 +68,20 @@ def test_gdal_calc_py_1():
 
     test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --calc=A --overwrite --outfile tmp/test_gdal_calc_py_1_1.tif')
     test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band=2 --calc=A --overwrite --outfile tmp/test_gdal_calc_py_1_2.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-Z tmp/test_gdal_calc_py.tif --Z_band=2 --calc=Z --overwrite --outfile tmp/test_gdal_calc_py_1_3.tif')
 
     ds1 = gdal.Open('tmp/test_gdal_calc_py_1_1.tif')
     ds2 = gdal.Open('tmp/test_gdal_calc_py_1_2.tif')
+    ds3 = gdal.Open('tmp/test_gdal_calc_py_1_3.tif')
 
     if ds1 is None:
         gdaltest.post_reason('ds1 not found')
         return 'fail'
     if ds2 is None:
         gdaltest.post_reason('ds2 not found')
+        return 'fail'
+    if ds3 is None:
+        gdaltest.post_reason('ds3 not found')
         return 'fail'
 
     if ds1.GetRasterBand(1).Checksum() != 12603:
@@ -85,9 +90,13 @@ def test_gdal_calc_py_1():
     if ds2.GetRasterBand(1).Checksum() != 58561:
         gdaltest.post_reason('ds2 wrong checksum')
         return 'fail'
+    if ds3.GetRasterBand(1).Checksum() != 58561:
+        gdaltest.post_reason('ds3 wrong checksum')
+        return 'fail'
 
     ds1 = None
     ds2 = None
+    ds3 = None
 
     return 'success'
 
@@ -105,15 +114,20 @@ def test_gdal_calc_py_2():
 
     test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band 1 -B tmp/test_gdal_calc_py.tif --B_band 2 --calc=A+B --overwrite --outfile tmp/test_gdal_calc_py_2_1.tif')
     test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band 1 -B tmp/test_gdal_calc_py.tif --B_band 2 --calc=A*B --overwrite --outfile tmp/test_gdal_calc_py_2_2.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band 1 --calc="sqrt(A)" --type=Float32 --overwrite --outfile tmp/test_gdal_calc_py_2_3.tif')
 
     ds1 = gdal.Open('tmp/test_gdal_calc_py_2_1.tif')
     ds2 = gdal.Open('tmp/test_gdal_calc_py_2_2.tif')
+    ds3 = gdal.Open('tmp/test_gdal_calc_py_2_3.tif')
 
     if ds1 is None:
         gdaltest.post_reason('ds1 not found')
         return 'fail'
     if ds2 is None:
         gdaltest.post_reason('ds2 not found')
+        return 'fail'
+    if ds3 is None:
+        gdaltest.post_reason('ds3 not found')
         return 'fail'
 
     if ds1.GetRasterBand(1).Checksum() != 12368:
@@ -122,9 +136,13 @@ def test_gdal_calc_py_2():
     if ds2.GetRasterBand(1).Checksum() != 62785:
         gdaltest.post_reason('ds2 wrong checksum')
         return 'fail'
+    if ds3.GetRasterBand(1).Checksum() != 47132:
+        gdaltest.post_reason('ds3 wrong checksum')
+        return 'fail'
 
     ds1 = None
     ds2 = None
+    ds3 = None
 
     return 'success'
 
@@ -220,18 +238,74 @@ def test_gdal_calc_py_4():
 
     return 'success'
 
+###############################################################################
+# test python interface, basic copy
+
+def test_gdal_calc_py_5():
+
+    if gdalnumeric_not_available:
+        gdaltest.post_reason('gdalnumeric is not available, skipping all tests')
+        return 'skip'
+
+    script_path = test_py_scripts.get_py_script('gdal_calc')
+    if script_path is None:
+        return 'skip'
+
+    sys.path.insert(0, script_path)
+    import gdal_calc
+
+    shutil.copy('../gcore/data/stefan_full_rgba.tif', 'tmp/test_gdal_calc_py.tif')
+
+    gdal_calc.Calc('A', A='tmp/test_gdal_calc_py.tif', overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_1_1.tif')
+    gdal_calc.Calc('A', A='tmp/test_gdal_calc_py.tif', A_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_1_2.tif')
+    gdal_calc.Calc('Z', Z='tmp/test_gdal_calc_py.tif', Z_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_1_3.tif')
+
+    ds1 = gdal.Open('tmp/test_gdal_calc_py_1_1.tif')
+    ds2 = gdal.Open('tmp/test_gdal_calc_py_1_2.tif')
+    ds3 = gdal.Open('tmp/test_gdal_calc_py_1_3.tif')
+
+    if ds1 is None:
+        gdaltest.post_reason('ds1 not found')
+        return 'fail'
+    if ds2 is None:
+        gdaltest.post_reason('ds2 not found')
+        return 'fail'
+    if ds3 is None:
+        gdaltest.post_reason('ds3 not found')
+        return 'fail'
+
+    if ds1.GetRasterBand(1).Checksum() != 12603:
+        gdaltest.post_reason('ds1 wrong checksum')
+        return 'fail'
+    if ds2.GetRasterBand(1).Checksum() != 58561:
+        gdaltest.post_reason('ds2 wrong checksum')
+        return 'fail'
+    if ds3.GetRasterBand(1).Checksum() != 58561:
+        gdaltest.post_reason('ds3 wrong checksum')
+        return 'fail'
+
+    ds1 = None
+    ds2 = None
+    ds3 = None
+
+    return 'success'
 
 def test_gdal_calc_py_cleanup():
 
     lst = [ 'tmp/test_gdal_calc_py.tif',
             'tmp/test_gdal_calc_py_1_1.tif',
             'tmp/test_gdal_calc_py_1_2.tif',
+            'tmp/test_gdal_calc_py_1_3.tif',
             'tmp/test_gdal_calc_py_2_1.tif',
             'tmp/test_gdal_calc_py_2_2.tif',
+            'tmp/test_gdal_calc_py_2_3.tif',
             'tmp/test_gdal_calc_py_3.tif',
             'tmp/test_gdal_calc_py_4_1.tif',
             'tmp/test_gdal_calc_py_4_2.tif',
             'tmp/test_gdal_calc_py_4_3.tif',
+            'tmp/test_gdal_calc_py_5_1.tif',
+            'tmp/test_gdal_calc_py_5_2.tif',
+            'tmp/test_gdal_calc_py_5_3.tif',
             ]
     for filename in lst:
         try:
@@ -246,6 +320,7 @@ gdaltest_list = [
     test_gdal_calc_py_2,
     test_gdal_calc_py_3,
     test_gdal_calc_py_4,
+    test_gdal_calc_py_5,
     test_gdal_calc_py_cleanup
     ]
 

--- a/gdal/swig/python/scripts/gdal_calc.dox
+++ b/gdal/swig/python/scripts/gdal_calc.dox
@@ -6,30 +6,29 @@ Command line raster calculator with numpy syntax
 \section gdal_calc_synopsis SYNOPSIS
 
 \verbatim
-gdal_calc.py [-A <filename>] [--A_band] [-B...-Z filename] [other_options]
+gdal_calc.py --calc=expression --outfile=out_filename [-A filename]
+             [--A_band=n] [-B...-Z filename] [other_options]
 
 Options:
   -h, --help            show this help message and exit
-  --calc=CALC           calculation in gdalnumeric syntax using +-/* or any
-                        numpy array functions (i.e. logical_and())
-  -A A                  input gdal raster file, note you can use any letter
-                        A-Z
-  --A_band=A_BAND       number of raster band for file A (default 1)
-  --outfile=OUTF        output file to generate or fill
-  --NoDataValue=NODATAVALUE
-                        set output nodata value (Defaults to datatype specific
-                        value)
-  --type=TYPE           output datatype, must be one of ['Int32', 'Int16',
+  --calc=expression     calculation in gdalnumeric syntax using +-/* or any
+                        numpy array functions (i.e. log10())
+  -A filename           input gdal raster file, you can use any letter (A-Z)
+  --A_band=n            number of raster band for file A (default 1)
+  --outfile=filename    output file to generate or fill
+  --NoDataValue=value   output nodata value (default datatype specific value)
+  --type=datatype       output datatype, must be one of ['Int32', 'Int16',
                         'Float64', 'UInt16', 'Byte', 'UInt32', 'Float32']
-  --format=FORMAT       GDAL format for output file (default 'GTiff')
-  --creation-option=CREATION_OPTIONS, --co=CREATION_OPTIONS
+  --format=gdal_format  GDAL format for output file (default 'GTiff')
+  --creation-option=option, --co=option
                         Passes a creation option to the output format driver.
                         Multiple options may be listed. See format specific
                         documentation for legal creation options for each
                         format.
-  --allBands=ALLBANDS   process all bands of given raster (A-Z)
+  --allBands=[A-Z]      process all bands of given raster (A-Z)
   --overwrite           overwrite output file if it already exists
   --debug               print debugging information
+  --quiet               suppress progress messages
 \endverbatim
 
 \section gdal_edit_description DESCRIPTION

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -67,6 +67,10 @@ def doit(opts, args):
     if opts.debug:
         print("gdal_calc.py starting calculation %s" %(opts.calc))
 
+    # set up global namespace for eval with all functions of gdalnumeric
+    global_namespace = dict([(key, getattr(gdalnumeric, key))
+        for key in dir(gdalnumeric) if not key.startswith('__')])
+
     ################################################################
     # fetch details of input layers
     ################################################################
@@ -249,6 +253,9 @@ def doit(opts, args):
                 myNDVs=numpy.zeros(myBufSize)
                 myNDVs.shape=(nYValid,nXValid)
 
+                # modules available to calculation
+                local_namespace = {}
+
                 # fetch data for each input layer
                 for i,Alpha in enumerate(myAlphaList):
 
@@ -264,14 +271,14 @@ def doit(opts, args):
                     # fill in nodata values
                     myNDVs=1*numpy.logical_or(myNDVs==1, myval==myNDV[i])
 
-                    # create an array of values for this block
-                    exec("%s=myval" %Alpha)
+                    # add an array of values for this block to the eval namespace
+                    local_namespace[Alpha] = myval
                     myval=None
 
 
                 # try the calculation on the array blocks
                 try:
-                    myResult = eval(opts.calc)
+                    myResult = eval(opts.calc, global_namespace, local_namespace)
                 except:
                     print("evaluation of calculation %s failed" %(opts.calc))
                     raise

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -58,9 +58,7 @@ AlphaList=["A","B","C","D","E","F","G","H","I","J","K","L","M",
            "N","O","P","Q","R","S","T","U","V","W","X","Y","Z"]
 
 # set up some default nodatavalues for each datatype
-DefaultNDVLookup={'Byte':255, 'UInt16':65535, 'Int16':-32767, 'UInt32':4294967293, 'Int32':-2147483647, 'Float32':1.175494351E-38, 'Float64':1.7976931348623158E+308}
-
-#3.402823466E+38
+DefaultNDVLookup={'Byte':255, 'UInt16':65535, 'Int16':-32767, 'UInt32':4294967293, 'Int32':-2147483647, 'Float32':3.402823466E+38, 'Float64':1.7976931348623158E+308}
 
 ################################################################
 def doit(opts, args):

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -42,7 +42,7 @@
 # gdal_calc.py -A input.tif --outfile=result.tif --calc="A*(A>0)" --NoDataValue=0
 ################################################################
 
-from optparse import OptionParser
+from optparse import OptionParser, Values
 import os
 import sys
 
@@ -85,31 +85,34 @@ def doit(opts, args):
     DimensionsCheck=None
 
     # loop through input files - checking dimensions
-    for i,myI in enumerate(AlphaList[0:len(sys.argv)-1]):
-        myF = eval("opts.%s" %(myI))
-        myBand = eval("opts.%s_band" %(myI))
-        if myF:
-            myFiles.append(gdal.Open(myF, gdal.GA_ReadOnly))
+    for myI, myF in opts.input_files.items():
+        if not myI.endswith("_band"):
             # check if we have asked for a specific band...
-            if myBand:
-                myBands.append(myBand)
+            if "%s_band" % myI in opts.input_files:
+                myBand = opts.input_files["%s_band" % myI]
             else:
-                myBands.append(1)
+                myBand = 1
+
+            myFile = gdal.Open(myF, gdal.GA_ReadOnly)
+            if not myFile:
+                raise IOError("No such file or directory: '%s'" % myF)
+
+            myFiles.append(myFile)
+            myBands.append(myBand)
             myAlphaList.append(myI)
-            myDataType.append(gdal.GetDataTypeName(myFiles[i].GetRasterBand(myBands[i]).DataType))
-            myDataTypeNum.append(myFiles[i].GetRasterBand(myBands[i]).DataType)
-            myNDV.append(myFiles[i].GetRasterBand(myBands[i]).GetNoDataValue())
+            myDataType.append(gdal.GetDataTypeName(myFile.GetRasterBand(myBand).DataType))
+            myDataTypeNum.append(myFile.GetRasterBand(myBand).DataType)
+            myNDV.append(myFile.GetRasterBand(myBand).GetNoDataValue())
             # check that the dimensions of each layer are the same
             if DimensionsCheck:
-                if DimensionsCheck!=[myFiles[i].RasterXSize, myFiles[i].RasterYSize]:
-                    print("Error! Dimensions of file %s (%i, %i) are different from other files (%i, %i).  Cannot proceed" % \
-                            (myF,myFiles[i].RasterXSize, myFiles[i].RasterYSize,DimensionsCheck[0],DimensionsCheck[1]))
-                    return
+                if DimensionsCheck != [myFile.RasterXSize, myFile.RasterYSize]:
+                    raise Exception("Error! Dimensions of file %s (%i, %i) are different from other files (%i, %i).  Cannot proceed" % \
+                            (myF, myFile.RasterXSize, myFile.RasterYSize, DimensionsCheck[0], DimensionsCheck[1]))
             else:
-                DimensionsCheck=[myFiles[i].RasterXSize, myFiles[i].RasterYSize]
+                DimensionsCheck = [myFile.RasterXSize, myFile.RasterYSize]
 
             if opts.debug:
-                print("file %s: %s, dimensions: %s, %s, type: %s" %(myI,myF,DimensionsCheck[0],DimensionsCheck[1],myDataType[i]))
+                print("file %s: %s, dimensions: %s, %s, type: %s" %(myI,myF,DimensionsCheck[0],DimensionsCheck[1],myDataType[-1]))
 
     # process allBands option
     allBandsIndex=None
@@ -118,8 +121,7 @@ def doit(opts, args):
         try:
             allBandsIndex=myAlphaList.index(opts.allBands)
         except ValueError:
-            print("Error! allBands option was given but Band %s not found.  Cannot proceed" % (opts.allBands))
-            return
+            raise Exception("Error! allBands option was given but Band %s not found.  Cannot proceed" % (opts.allBands))
         allBandsCount=myFiles[allBandsIndex].RasterCount
         if allBandsCount <= 1:
             allBandsIndex=None
@@ -131,14 +133,12 @@ def doit(opts, args):
     # open output file exists
     if os.path.isfile(opts.outF) and not opts.overwrite:
         if allBandsIndex is not None:
-            print("Error! allBands option was given but Output file exists, must use --overwrite option!")
-            return
+            raise Exception("Error! allBands option was given but Output file exists, must use --overwrite option!")
         if opts.debug:
             print("Output file %s exists - filling in results into file" %(opts.outF))
         myOut=gdal.Open(opts.outF, gdal.GA_Update)
         if [myOut.RasterXSize,myOut.RasterYSize] != DimensionsCheck:
-            print("Error! Output exists, but is the wrong size.  Use the --overwrite option to automatically overwrite the existing file")
-            return
+            raise Exception("Error! Output exists, but is the wrong size.  Use the --overwrite option to automatically overwrite the existing file")
         myOutB=myOut.GetRasterBand(1)
         myOutNDV=myOutB.GetNoDataValue()
         myOutType=gdal.GetDataTypeName(myOutB.DataType)
@@ -233,7 +233,7 @@ def doit(opts, args):
             # loop through Y lines
             for Y in range(0,nYBlocks):
                 ProgressCt+=1
-                if 10*ProgressCt/ProgressEnd%10!=ProgressMk:
+                if 10*ProgressCt/ProgressEnd%10!=ProgressMk and not opts.quiet:
                     ProgressMk=10*ProgressCt/ProgressEnd%10
                     from sys import version_info
                     if version_info >= (3,0,0):
@@ -253,7 +253,7 @@ def doit(opts, args):
                 myNDVs=numpy.zeros(myBufSize)
                 myNDVs.shape=(nYValid,nXValid)
 
-                # modules available to calculation
+                # make local namespace for calculation
                 local_namespace = {}
 
                 # fetch data for each input layer
@@ -291,22 +291,62 @@ def doit(opts, args):
                 myOutB=myOut.GetRasterBand(bandNo)
                 gdalnumeric.BandWriteArray(myOutB, myResult, xoff=myX, yoff=myY)
 
-    print("100 - Done")
+    if not opts.quiet:
+        print("100 - Done")
     #print("Finished - Results written to %s" %opts.outF)
 
     return
 
 ################################################################
+def Calc(calc, outfile, NoDataValue=None, type=None, format='GTiff', creation_options=[], allBands='', overwrite=False, debug=False, quiet=False, **input_files):
+    """ Perform raster calculations with numpy syntax.
+    Use any basic arithmetic supported by numpy arrays such as +-*\ along with logical
+    operators such as >. Note that all files must have the same dimensions, but no projection checking is performed.
+
+    Keyword arguments:
+        [A-Z]: input files
+        [A_band - Z_band]: band to use for respective input file
+
+    Examples:
+    add two files together:
+        Calc("A+B", A="input1.tif", B="input2.tif", outfile="result.tif")
+
+    average of two layers:
+        Calc(calc="(A+B)/2", A="input1.tif", B="input2.tif", outfile="result.tif")
+
+    set values of zero and below to null:
+        Calc(calc="A*(A>0)", A="input.tif", A_Band=2, outfile="result.tif", NoDataValue=0)
+    """
+    opts = Values()
+    opts.input_files = input_files
+    opts.calc = calc
+    opts.outF = outfile
+    opts.NoDataValue = NoDataValue
+    opts.type = type
+    opts.format = format
+    opts.creation_options = creation_options
+    opts.allBands = allBands
+    opts.overwrite = overwrite
+    opts.debug = debug
+    opts.quiet = quiet
+
+    doit(opts, None)
+
+def store_input_file(option, opt_str, value, parser):
+    if not hasattr(parser.values, 'input_files'):
+        parser.values.input_files = {}
+    parser.values.input_files[opt_str.lstrip('-')] = value
+
 def main():
-    usage = "usage: %prog [-A <filename>] [--A_band] [-B...-Z filename] [other_options]"
+    usage = "usage: %prog [-A <filename>] [--A_band=n] [-B...-Z filename] [other_options]"
     parser = OptionParser(usage)
 
     # define options
     parser.add_option("--calc", dest="calc", help="calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. logical_and())")
-    # hack to limit the number of input file options close to required number
-    for myAlpha in AlphaList[0:len(sys.argv)-1]:
-        eval('parser.add_option("-%s", dest="%s", help="input gdal raster file, note you can use any letter A-Z")' %(myAlpha, myAlpha))
-        eval('parser.add_option("--%s_band", dest="%s_band", default=1, type=int, help="number of raster band for file %s (default 1)")' %(myAlpha, myAlpha, myAlpha))
+    # limit the input file options to the ones in the argument list
+    for myAlpha in [a[1] for a in sys.argv if a[1:2] in AlphaList]:
+        parser.add_option("-%s" % myAlpha, action="callback", callback=store_input_file, type=str, help="input gdal raster file, note you can use any letter A-Z")
+        parser.add_option("--%s_band" % myAlpha, action="callback", callback=store_input_file, type=int, help="number of raster band for file %s (default 1)" % myAlpha)
 
     parser.add_option("--outfile", dest="outF", default='gdal_calc.tif', help="output file to generate or fill")
     parser.add_option("--NoDataValue", dest="NoDataValue", type=float, help="set output nodata value (Defaults to datatype specific value)")
@@ -320,8 +360,11 @@ def main():
     parser.add_option("--allBands", dest="allBands", default="", help="process all bands of given raster (A-Z)")
     parser.add_option("--overwrite", dest="overwrite", action="store_true", help="overwrite output file if it already exists")
     parser.add_option("--debug", dest="debug", action="store_true", help="print debugging information")
+    parser.add_option("--quiet", dest="quiet", action="store_true", help="suppress progress messages")
 
     (opts, args) = parser.parse_args()
+    if not hasattr(opts, "input_files"):
+        opts.input_files = {}
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -329,7 +372,12 @@ def main():
         print("No calculation provided.  Nothing to do!")
         parser.print_help()
     else:
-        doit(opts, args)
+        try:
+            doit(opts, args)
+        except IOError as e:
+            print(e)
+            sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The same way as the GDAL utilities are made available as library (https://trac.osgeo.org/gdal/wiki/rfc59.1_utilities_as_a_library) it would be nice have the python utilities also available for calling directly from python. Judging from Stack Exchange there is quite some interest in this possibility.

I now implemented an interface for gdal_calc.py, so it can be used from python for example as
  import gdal_calc
  gdal_calc.Calc("-log10(A)", outfile="output.tif", A="raster.tif", A_band=1)

This could be done for the other python utilities as well. For some (gdal_edit and gdal_pansharpen) there is already a very basic (not documented) interface which just takes the command line arguments, it would be nice to make them more pythonic too.

There are some open questions:
1. Naming, whether to use gdal_calc, calc or Calc. gdal_calc is most recognizable, calc is python default style for functions, Calc would be like the rest of GDAL. So now I chose for the last option.
2. Whether or not include it in osgeo.gdal, so it can be accessed in the same way as the other tools. I'd say it would be a good thing, maybe in a try: clause for the case that they are not installed or not on the path or so. In ubuntu /usr/bin is in the python path by default, I don't know how that is on other systems (windows/geo4w?).

Furthermore I fixed a bug which came in in GDAL 2.0, namely that functions are not directly available for use in expressions anymore, so for example "log10(A)" fails. This is the first commit and should be merged to version 2.0 and 2.1 also.