### PR TITLE
Experimental fix TIFF files reading with one big stripe

### DIFF
--- a/gdal/frmts/gtiff/libtiff/tif_dirread.c
+++ b/gdal/frmts/gtiff/libtiff/tif_dirread.c
@@ -5588,6 +5588,7 @@ int _TIFFFillStriles( TIFF *tif )
         if (!TIFFFetchStripThing(tif,&(td->td_stripbytecount_entry),
                                  td->td_nstrips,&td->td_stripbytecount))
         {
+            if( tif->tif_dir.td_nstrips > 1 )
                 return_value = 0;
         }
 


### PR DESCRIPTION
This is continuation of pull request https://github.com/OSGeo/gdal/pull/90
I'm not 100% feel certain in this changeset, but it fix problem with one stripe TIFF files.
  