### PR TITLE
Fixed segfaults in GDAL_CG_Create and GDALGridContextFree

### DIFF
--- a/gdal/alg/contour.cpp
+++ b/gdal/alg/contour.cpp
@@ -171,6 +171,11 @@ GDAL_CG_Create( int nWidth, int nHeight, int bNoDataSet, double dfNoDataValue,
     GDALContourGenerator *poCG = new GDALContourGenerator( nWidth, nHeight,
                                                            pfnWriter, pCBData );
 
+    if( !poCG->Init() )
+    {
+        delete poCG;
+        return NULL;
+    }
     if( bNoDataSet )
         poCG->SetNoData( dfNoDataValue );
 


### PR DESCRIPTION
GDAL_CG_Create was not initializing GDALContourGenerator properly so the first call to GDAL_CG_FeedLine would crash as the last scanline would be NULL.

Also fixed GDALGridContextFree in the case that GDAL_NUM_THREADS is < 1.