### PR TITLE
Export VSICreateCachedFile

### DIFF
--- a/gdal/port/cpl_vsi_virtual.h
+++ b/gdal/port/cpl_vsi_virtual.h
@@ -202,7 +202,7 @@ VSIVirtualHandle CPL_DLL *VSICreateBufferedReaderHandle(VSIVirtualHandle* poBase
 VSIVirtualHandle* VSICreateBufferedReaderHandle(VSIVirtualHandle* poBaseHandle,
                                                 const GByte* pabyBeginningContent,
                                                 vsi_l_offset nCheatFileSize);
-VSIVirtualHandle* VSICreateCachedFile( VSIVirtualHandle* poBaseHandle, size_t nChunkSize = 32768, size_t nCacheSize = 0 );
+VSIVirtualHandle CPL_DLL *VSICreateCachedFile( VSIVirtualHandle* poBaseHandle, size_t nChunkSize = 32768, size_t nCacheSize = 0 );
 VSIVirtualHandle CPL_DLL *VSICreateGZipWritable( VSIVirtualHandle* poBaseHandle, int bRegularZLibIn, int bAutoCloseBaseHandle );
 
 #endif /* ndef CPL_VSI_VIRTUAL_H_INCLUDED */


### PR DESCRIPTION
jp2kak plugin is meant to be compiled as a .lib in the same compilation directory than gdal.
Therefore it has access to every symbol of gdal.lib.

But, it is convenient to compile it as a .dll. It helps greatly to solve licences issues related with kakadu.

It can be done only if the method `VSIVirtualHandle* VSICreateCachedFile` is exported.

This PR adds the needed export for `VSIVirtualHandle* VSICreateCachedFile`