### PR TITLE
Fix load/store datum parameters to HFA files

### DIFF
--- a/gdal/frmts/hfa/hfadataset.cpp
+++ b/gdal/frmts/hfa/hfadataset.cpp
@@ -45,6 +45,9 @@ CPL_CVSID("$Id$");
 #  define D2R	(M_PI/180)
 #endif
 
+#define ARCSEC2RAD (M_PI/648000)
+#define RAD2ARCSEC (648000/M_PI)
+
 int WritePeStringIfNeeded(OGRSpatialReference* poSRS, HFAHandle hHFA);
 void ClearSR(HFAHandle hHFA);
 
@@ -3393,7 +3396,13 @@ CPLErr HFADataset::WriteProjection()
             sDatum.datumname = (char*) "GDA94";
 
         if( poGeogSRS->GetTOWGS84( sDatum.params ) == OGRERR_NONE )
+        {
             sDatum.type = EPRJ_DATUM_PARAMETRIC;
+            sDatum.params[3] *= -ARCSEC2RAD;
+            sDatum.params[4] *= -ARCSEC2RAD;
+            sDatum.params[5] *= -ARCSEC2RAD;
+            sDatum.params[6] *= 1e-6;
+        }
         else if( EQUAL(sDatum.datumname,"NAD27") )
         {
             sDatum.type = EPRJ_DATUM_GRID;
@@ -4921,10 +4930,10 @@ HFAPCSStructToWKT( const Eprj_Datum *psDatum,
             oSRS.SetTOWGS84( psDatum->params[0],
                              psDatum->params[1],
                              psDatum->params[2],
-                             psDatum->params[3],
-                             psDatum->params[4],
-                             psDatum->params[5],
-                             psDatum->params[6] );
+                             -psDatum->params[3]*RAD2ARCSEC,
+                             -psDatum->params[4]*RAD2ARCSEC,
+                             -psDatum->params[5]*RAD2ARCSEC,
+                             psDatum->params[6]*1e+6 );
         }
     }
 


### PR DESCRIPTION
Hello, Friends!

GDAL write toWGS84 parameters differ than Erdas imagine. This commit fix that problem.
Apparently the problem is rarely seen, because Erdas Imagine in most cases use Datum names, instead transform parameters. 
GDAL using rotation parameters in arc-seconds, but Erdas using in radians (see: [Adding New Datums, Spheroids and Projections](https://hexagongeospatial.fluidtopics.net/book#!book;uri=fb4350968f8f8b57984ae66bba04c48d;breadcrumb=98d11f6e256a86a22eaebb041a3f6075-6f6058bbb31db78e0c863aa9e8834d9a-1ec15505fb198ba56209da3e95409b65-93951cdcd610962bdd6e62dc1d77f29f) (section 7) )
Additionally, they are using different rotation direction and scale factor notations (GDAL - parts per million, but Erdas - 1:1 ) 

Datum dump from file, created by Erdas Imagine:

```
Contents of :Band_1:Projection:Datum

struct Eprj_Datum {
    char *datumname[13] = "Pulkovo 1942"
    enum type = EPRJ_DATUM_PARAMETRIC
    double *params[7] = 2.3570000000000000e+001  , -1.4094999999999999e+002 , -7.9799999999999997e+001 , 0.0000000000000000e+000  , -1.6968499999999999e-006 , -3.8300300000000002e-006 , -2.2000000000000001e-007 
    char *gridname[0] = ""
} Eprj_Datum

```

Datum dump from file, created by GDAL:

```
Contents of :Band_1:Projection:Datum

struct Eprj_Datum {
    char *datumname[13] = "Pulkovo 1942"
    enum type = EPRJ_DATUM_PARAMETRIC
    double *params[7] = 2.3899999999999999e+001  , -1.4130000000000001e+002 , -8.0900000000000006e+001 , 0.0000000000000000e+000  , 3.7127665100000001e-001  , 8.4981100200000004e-001  , -1.2000000000000000e-001 
    char *gridname[0] = ""
} Eprj_Datum

```