### PR TITLE
Export overview type from HFA files to GDAL metadata

### DIFF
--- a/gdal/frmts/hfa/frmt_hfa.html
+++ b/gdal/frmts/hfa/frmt_hfa.html
@@ -54,6 +54,12 @@ the original .img) set the global config option HFA_USE_RRD=YES).<p>
 
 Layer names can be set and retrieved with the GDALSetDescription/GDALGetDescription calls on the Raster Band objects. <p>
 
+<p>Some HFA band metadata exported to GDAL metadata:</p>
+<ul>
+<li>LAYER_TYPE - layer type (athematic, ... )</li>
+<li>OVERVIEWS_ALGORITHM - layer overviews algorithm ('IMAGINE 2X2 Resampling', 'IMAGINE 4X4 Resampling', and others)</li>
+</ul>
+
 <h2>Configuration Options</h2>
 Currently two <a href="http://trac.osgeo.org/gdal/wiki/ConfigOptions">runtime configuration options</a> are supported by the HFA driver:
 

--- a/gdal/frmts/hfa/hfaopen.cpp
+++ b/gdal/frmts/hfa/hfaopen.cpp
@@ -62,6 +62,7 @@ static const char * const apszAuxMetadataItems[] = {
  "StatisticsParameters", "lSkipFactorY",          "STATISTICS_SKIPFACTORY", "",
  "StatisticsParameters", "dExcludedValues",       "STATISTICS_EXCLUDEDVALUES","",
  "",                     "elayerType",            "LAYER_TYPE",             "",
+ "RRDInfoList",          "salgorithm.string",     "OVERVIEWS_ALGORITHM",    "Emif_String",
  NULL
 };
 


### PR DESCRIPTION
HFA files may contain overview layers of different types: 2x2, 3x3, 4x4. It's important to know overview type for some algorithms. 