### PR TITLE
Add GDALIdentifyDriverEx function.

### DIFF
--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -357,6 +357,12 @@ GDALCreateCopy( GDALDriverH, const char *, GDALDatasetH,
 
 GDALDriverH CPL_DLL CPL_STDCALL GDALIdentifyDriver( const char * pszFilename,
                                             char ** papszFileList );
+
+GDALDriverH CPL_DLL CPL_STDCALL GDALIdentifyDriverEx( const char* pszFilename,
+											unsigned int nIdentifyFlags,
+											const char* const* papszAllowedDrivers,
+											const char* const* papszFileList );
+
 GDALDatasetH CPL_DLL CPL_STDCALL
 GDALOpen( const char *pszFilename, GDALAccess eAccess ) CPL_WARN_UNUSED_RESULT;
 GDALDatasetH CPL_DLL CPL_STDCALL GDALOpenShared( const char *, GDALAccess ) CPL_WARN_UNUSED_RESULT;

--- a/gdal/gcore/gdaldriver.cpp
+++ b/gdal/gcore/gdaldriver.cpp
@@ -1904,7 +1904,7 @@ GDALIdentifyDriverEx( const char* pszFilename,
 {
     GDALDriverManager  *poDM = GetGDALDriverManager();
     CPLAssert( NULL != poDM );
-    GDALOpenInfo oOpenInfo( pszFilename, GA_ReadOnly, papszFileList );
+    GDALOpenInfo oOpenInfo( pszFilename, GA_ReadOnly, (char**)papszFileList );
 
     CPLErrorReset();
 
@@ -1913,7 +1913,7 @@ GDALIdentifyDriverEx( const char* pszFilename,
     // First pass: only use drivers that have a pfnIdentify implementation.
     for( int iDriver = -1; iDriver < nDriverCount; ++iDriver )
     {
-		GDALDriver * const poDriver;
+		GDALDriver* poDriver;
 
 		if( iDriver < 0 )
             poDriver = GDALGetAPIPROXYDriver();
@@ -1951,7 +1951,7 @@ GDALIdentifyDriverEx( const char* pszFilename,
     // Second pass: slow method.
     for( int iDriver = -1; iDriver < nDriverCount; ++iDriver )
     {
-        GDALDriver * const poDriver;
+        GDALDriver* poDriver;
 
 		if( iDriver < 0 )
             poDriver = GDALGetAPIPROXYDriver();

--- a/gdal/gcore/gdaldriver.cpp
+++ b/gdal/gcore/gdaldriver.cpp
@@ -1852,7 +1852,7 @@ GDALIdentifyDriver( const char * pszFilename,
                     char **papszFileList )
 
 {
-	return GDALIdentifyDriverEx( pszFilename, 0, NULL, papszFileList );
+    return GDALIdentifyDriverEx( pszFilename, 0, NULL, papszFileList );
 }
 
 
@@ -1913,9 +1913,9 @@ GDALIdentifyDriverEx( const char* pszFilename,
     // First pass: only use drivers that have a pfnIdentify implementation.
     for( int iDriver = -1; iDriver < nDriverCount; ++iDriver )
     {
-		GDALDriver* poDriver;
+        GDALDriver* poDriver;
 
-		if( iDriver < 0 )
+        if( iDriver < 0 )
             poDriver = GDALGetAPIPROXYDriver();
         else
         {
@@ -1928,24 +1928,24 @@ GDALIdentifyDriverEx( const char* pszFilename,
         VALIDATE_POINTER1( poDriver, "GDALIdentifyDriver", NULL );
 
         if( poDriver->pfnIdentify == NULL )
-		{
-			continue;
-		}
+        {
+            continue;
+        }
 
-		if (papszAllowedDrivers != NULL &&
-			CSLFindString((char**)papszAllowedDrivers, GDALGetDriverShortName(poDriver)) == -1)
-			continue;
-		if( (nIdentifyFlags & GDAL_OF_RASTER) != 0 &&
-			(nIdentifyFlags & GDAL_OF_VECTOR) == 0 &&
-			poDriver->GetMetadataItem(GDAL_DCAP_RASTER) == NULL )
-			continue;
-		if( (nIdentifyFlags & GDAL_OF_VECTOR) != 0 &&
-			(nIdentifyFlags & GDAL_OF_RASTER) == 0 &&
-			poDriver->GetMetadataItem(GDAL_DCAP_VECTOR) == NULL )
-			continue;
+        if (papszAllowedDrivers != NULL &&
+            CSLFindString((char**)papszAllowedDrivers, GDALGetDriverShortName(poDriver)) == -1)
+            continue;
+        if( (nIdentifyFlags & GDAL_OF_RASTER) != 0 &&
+            (nIdentifyFlags & GDAL_OF_VECTOR) == 0 &&
+            poDriver->GetMetadataItem(GDAL_DCAP_RASTER) == NULL )
+            continue;
+        if( (nIdentifyFlags & GDAL_OF_VECTOR) != 0 &&
+            (nIdentifyFlags & GDAL_OF_RASTER) == 0 &&
+            poDriver->GetMetadataItem(GDAL_DCAP_VECTOR) == NULL )
+            continue;
 
-		if( poDriver->pfnIdentify( &oOpenInfo ) > 0 )
-			return poDriver;
+        if( poDriver->pfnIdentify( &oOpenInfo ) > 0 )
+            return poDriver;
     }
 
     // Second pass: slow method.
@@ -1953,7 +1953,7 @@ GDALIdentifyDriverEx( const char* pszFilename,
     {
         GDALDriver* poDriver;
 
-		if( iDriver < 0 )
+        if( iDriver < 0 )
             poDriver = GDALGetAPIPROXYDriver();
         else
         {
@@ -1963,9 +1963,9 @@ GDALIdentifyDriverEx( const char* pszFilename,
                 continue;
         }
 
-		VALIDATE_POINTER1( poDriver, "GDALIdentifyDriver", NULL );
+        VALIDATE_POINTER1( poDriver, "GDALIdentifyDriver", NULL );
 
-		if( (nIdentifyFlags & GDAL_OF_RASTER) != 0 &&
+        if( (nIdentifyFlags & GDAL_OF_RASTER) != 0 &&
             (nIdentifyFlags & GDAL_OF_VECTOR) == 0 &&
             poDriver->GetMetadataItem(GDAL_DCAP_RASTER) == NULL )
             continue;

--- a/gdal/gcore/gdaldriver.cpp
+++ b/gdal/gcore/gdaldriver.cpp
@@ -1852,6 +1852,56 @@ GDALIdentifyDriver( const char * pszFilename,
                     char **papszFileList )
 
 {
+	return GDALIdentifyDriverEx( pszFilename, 0, NULL, papszFileList );
+}
+
+
+/************************************************************************/
+/*                         GDALIdentifyDriverEx()                         */
+/************************************************************************/
+
+/**
+ * \brief Identify the driver that can open a raster file.
+ *
+ * This function will try to identify the driver that can open the passed file
+ * name by invoking the Identify method of each registered GDALDriver in turn.
+ * The first driver that successful identifies the file name will be returned.
+ * If all drivers fail then NULL is returned.
+ *
+ * In order to reduce the need for such searches touch the operating system
+ * file system machinery, it is possible to give an optional list of files.
+ * This is the list of all files at the same level in the file system as the
+ * target file, including the target file. The filenames will not include any
+ * path components, are essentially just the output of VSIReadDir() on the
+ * parent directory. If the target object does not have filesystem semantics
+ * then the file list should be NULL.
+ *
+ * @param pszFilename the name of the file to access.  In the case of
+ * exotic drivers this may not refer to a physical file, but instead contain
+ * information for the driver on how to access a dataset.
+ *
+ * @param nIdentifyFlags a combination of GDAL_OF_RASTER for raster drivers
+ * or GDAL_OF_VECTOR for vector drivers. If none of the value is specified,
+ * both kinds are implied.
+ *
+ * @param papszAllowedDrivers NULL to consider all candidate drivers, or a NULL
+ * terminated list of strings with the driver short names that must be considered.
+ *
+ * @param papszFileList an array of strings, whose last element is the NULL
+ * pointer.  These strings are filenames that are auxiliary to the main
+ * filename. The passed value may be NULL.
+ *
+ * @return A GDALDriverH handle or NULL on failure.  For C++ applications
+ * this handle can be cast to a GDALDriver *.
+ */
+
+
+GDALDriverH CPL_STDCALL
+GDALIdentifyDriverEx( const char* pszFilename,
+                      unsigned int nIdentifyFlags,
+                      const char* const* papszAllowedDrivers,
+                      const char* const* papszFileList )
+{
     GDALDriverManager  *poDM = GetGDALDriverManager();
     CPLAssert( NULL != poDM );
     GDALOpenInfo oOpenInfo( pszFilename, GA_ReadOnly, papszFileList );
@@ -1863,25 +1913,66 @@ GDALIdentifyDriver( const char * pszFilename,
     // First pass: only use drivers that have a pfnIdentify implementation.
     for( int iDriver = -1; iDriver < nDriverCount; ++iDriver )
     {
-        GDALDriver * const poDriver =
-            iDriver < 0 ? GDALGetAPIPROXYDriver() : poDM->GetDriver( iDriver );
+		GDALDriver * const poDriver;
+
+		if( iDriver < 0 )
+            poDriver = GDALGetAPIPROXYDriver();
+        else
+        {
+            poDriver = poDM->GetDriver( iDriver );
+            if (papszAllowedDrivers != NULL &&
+                CSLFindString((char**)papszAllowedDrivers, GDALGetDriverShortName(poDriver)) == -1)
+                continue;
+        }
 
         VALIDATE_POINTER1( poDriver, "GDALIdentifyDriver", NULL );
 
-        if( poDriver->pfnIdentify != NULL )
-        {
-            if( poDriver->pfnIdentify( &oOpenInfo ) > 0 )
-                return poDriver;
-        }
+        if( poDriver->pfnIdentify == NULL )
+		{
+			continue;
+		}
+
+		if (papszAllowedDrivers != NULL &&
+			CSLFindString((char**)papszAllowedDrivers, GDALGetDriverShortName(poDriver)) == -1)
+			continue;
+		if( (nIdentifyFlags & GDAL_OF_RASTER) != 0 &&
+			(nIdentifyFlags & GDAL_OF_VECTOR) == 0 &&
+			poDriver->GetMetadataItem(GDAL_DCAP_RASTER) == NULL )
+			continue;
+		if( (nIdentifyFlags & GDAL_OF_VECTOR) != 0 &&
+			(nIdentifyFlags & GDAL_OF_RASTER) == 0 &&
+			poDriver->GetMetadataItem(GDAL_DCAP_VECTOR) == NULL )
+			continue;
+
+		if( poDriver->pfnIdentify( &oOpenInfo ) > 0 )
+			return poDriver;
     }
 
     // Second pass: slow method.
     for( int iDriver = -1; iDriver < nDriverCount; ++iDriver )
     {
-        GDALDriver * const poDriver =
-            iDriver < 0 ? GDALGetAPIPROXYDriver() : poDM->GetDriver( iDriver );
+        GDALDriver * const poDriver;
 
-        VALIDATE_POINTER1( poDriver, "GDALIdentifyDriver", NULL );
+		if( iDriver < 0 )
+            poDriver = GDALGetAPIPROXYDriver();
+        else
+        {
+            poDriver = poDM->GetDriver( iDriver );
+            if (papszAllowedDrivers != NULL &&
+                CSLFindString((char**)papszAllowedDrivers, GDALGetDriverShortName(poDriver)) == -1)
+                continue;
+        }
+
+		VALIDATE_POINTER1( poDriver, "GDALIdentifyDriver", NULL );
+
+		if( (nIdentifyFlags & GDAL_OF_RASTER) != 0 &&
+            (nIdentifyFlags & GDAL_OF_VECTOR) == 0 &&
+            poDriver->GetMetadataItem(GDAL_DCAP_RASTER) == NULL )
+            continue;
+        if( (nIdentifyFlags & GDAL_OF_VECTOR) != 0 &&
+            (nIdentifyFlags & GDAL_OF_RASTER) == 0 &&
+            poDriver->GetMetadataItem(GDAL_DCAP_VECTOR) == NULL )
+            continue;
 
         if( poDriver->pfnIdentify != NULL )
         {


### PR DESCRIPTION
Since GDAL2 GDALIdentifyDriver returns both raster and vector drivers. It's not easy to use In some cases. Commit contains new function GDALIdentifyDriverEx looks like GDALOpenEx and with similar params to filter drivers.