### PR TITLE
Don't append garbage data to tag names

### DIFF
--- a/gdal/ogr/ogrsf_frmts/osm/ogrosmlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/osm/ogrosmlayer.cpp
@@ -426,7 +426,8 @@ const char* OGROSMLayer::GetLaunderedFieldName(const char* pszName)
     if( poDS->DoesAttributeNameLaundering()  &&
         strchr(pszName, ':') != NULL )
     {
-        for( size_t i = 0;
+        size_t i;
+        for( i = 0;
              i < sizeof(szLaunderedFieldName) - 1 && pszName[i] != '\0';
              i++ )
         {
@@ -435,7 +436,7 @@ const char* OGROSMLayer::GetLaunderedFieldName(const char* pszName)
             else
                 szLaunderedFieldName[i] = pszName[i];
         }
-        szLaunderedFieldName[sizeof(szLaunderedFieldName) - 1] = '\0';
+        szLaunderedFieldName[i] = '\0';
         return szLaunderedFieldName;
     }
 


### PR DESCRIPTION
Bug was introduced in https://github.com/OSGeo/gdal/commit/662729c939ccd896f0853d5e888b6fcb17223f74

The string should *not* be terminated at the end of the entire shared buffer. Rather, it should be terminated at the index after the end of the copied string.

This commit restores the original behaviour before 662729c939ccd896f0853d5e888b6fcb17223f74

Moving the index variable into the for-loop scope is a good practice in general, but it introduced a bug in this particular case.

##### Example of bug:
A key like:
`addr:housenumber`
becomes
`addr_housenumber ¬’/`
or something like that, since the bytes after `'r'` are undefined until byte number 255.