### PR TITLE
Fix load/store elevation units in MTW files

### DIFF
--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1644,10 +1644,10 @@ do {                                                                    \
                 poDS->pszUnitType = CPLStrdup( RMF_UnitsM );
                 break;
             case 1:
-                poDS->pszUnitType = CPLStrdup( RMF_UnitsCM );
+                poDS->pszUnitType = CPLStrdup( RMF_UnitsDM );
                 break;
             case 2:
-                poDS->pszUnitType = CPLStrdup( RMF_UnitsDM );
+                poDS->pszUnitType = CPLStrdup( RMF_UnitsCM );
                 break;
             case 3:
                 poDS->pszUnitType = CPLStrdup( RMF_UnitsMM );
@@ -1895,9 +1895,9 @@ GDALDataset *RMFDataset::Create( const char * pszFilename,
     // Elevation units
     if( EQUAL(poDS->pszUnitType, RMF_UnitsM) )
         poDS->sHeader.iElevationUnit = 0;
-    else if( EQUAL(poDS->pszUnitType, RMF_UnitsCM) )
+    else if ( EQUAL(poDS->pszUnitType, RMF_UnitsDM) )
         poDS->sHeader.iElevationUnit = 1;
-    else if( EQUAL(poDS->pszUnitType, RMF_UnitsDM) )
+    else if ( EQUAL(poDS->pszUnitType, RMF_UnitsCM) )
         poDS->sHeader.iElevationUnit = 2;
     else if( EQUAL(poDS->pszUnitType, RMF_UnitsMM) )
         poDS->sHeader.iElevationUnit = 3;


### PR DESCRIPTION
See comments to BUILDMTW::Unit
 in GIS 'Panorama' SDK documentation http://gistoolkit.ru/download/doc/mapapi.pdf page 127 [RUS].