### PR TITLE
change corner order in 'wgs84Extent' polygon to counter-clockwise

### DIFF
--- a/autotest/utilities/test_gdalinfo.py
+++ b/autotest/utilities/test_gdalinfo.py
@@ -783,7 +783,7 @@ def test_gdalinfo_40():
     if 'coordinates' not in ret['wgs84Extent']:
         print(ret)
         return 'fail'
-    if ret['wgs84Extent']['coordinates'] != [ [ -180.0, 90.0 ], [ -180.0, -90.0 ], [ 180.0, -90.0 ], [ 180.0, 90.0 ], [ -180.0, 90.0 ] ]:
+    if ret['wgs84Extent']['coordinates'] != [ [ [ -180.0, 90.0 ], [ -180.0, -90.0 ], [ 180.0, -90.0 ], [ 180.0, 90.0 ], [ -180.0, 90.0 ] ] ]:
         print(ret)
         return 'fail'
 

--- a/autotest/utilities/test_gdalinfo.py
+++ b/autotest/utilities/test_gdalinfo.py
@@ -762,6 +762,33 @@ def test_gdalinfo_39():
 
     return 'success'
 
+###############################################################################
+# Test -json wgs84Extent
+
+def test_gdalinfo_40():
+    if test_cli_utilities.get_gdalinfo_path() is None:
+        return 'skip'
+
+    ret = gdaltest.runexternal(test_cli_utilities.get_gdalinfo_path() + ' -json ../gdrivers/data/small_world.tif')
+    ret = json.loads(ret)
+    if 'wgs84Extent' not in ret:
+        print(ret)
+        return 'fail'
+    if 'type' not in ret['wgs84Extent']:
+        print(ret)
+        return 'fail'
+    if ret['wgs84Extent']['type'] != 'Polygon':
+        print(ret)
+        return 'fail'
+    if 'coordinates' not in ret['wgs84Extent']:
+        print(ret)
+        return 'fail'
+    if ret['wgs84Extent']['coordinates'] != [ [ -180.0, 90.0 ], [ -180.0, -90.0 ], [ 180.0, -90.0 ], [ 180.0, 90.0 ], [ -180.0, 90.0 ] ]:
+        print(ret)
+        return 'fail'
+
+    return 'success'
+
 gdaltest_list = [
     test_gdalinfo_1,
     test_gdalinfo_2,
@@ -802,6 +829,7 @@ gdaltest_list = [
     test_gdalinfo_37,
     test_gdalinfo_38,
     test_gdalinfo_39,
+    test_gdalinfo_40,
     ]
 
 

--- a/gdal/apps/gdalinfo_lib.cpp
+++ b/gdal/apps/gdalinfo_lib.cpp
@@ -628,16 +628,16 @@ char *GDALInfo( GDALDatasetH hDataset, const GDALInfoOptions *psOptions )
                               poCornerCoordinates, poWGS84ExtentCoordinates,
                               osStr );
         GDALInfoReportCorner( psOptions, hDataset, hTransform, hTransformWGS84,
+                              "lowerRight",
+                              GDALGetRasterXSize(hDataset),
+                              GDALGetRasterYSize(hDataset),
+                              bJson, poCornerCoordinates,
+                              poWGS84ExtentCoordinates, osStr );
+        GDALInfoReportCorner( psOptions, hDataset, hTransform, hTransformWGS84,
                               "upperRight",
                               GDALGetRasterXSize(hDataset), 0.0, bJson,
                               poCornerCoordinates, poWGS84ExtentCoordinates,
                               osStr );
-        GDALInfoReportCorner( psOptions, hDataset, hTransform, hTransformWGS84,
-                              "lowerRight",
-                              GDALGetRasterXSize(hDataset)
-                              , GDALGetRasterYSize(hDataset),
-                              bJson, poCornerCoordinates,
-                              poWGS84ExtentCoordinates, osStr );
         GDALInfoReportCorner( psOptions, hDataset, hTransform, hTransformWGS84,
                               "center",
                               GDALGetRasterXSize(hDataset) / 2.0,


### PR DESCRIPTION
When using gdalinfo with the '-json' switch, I noticed that the 'wgx84Extent' element is returned as a polgyon feature in GeoJSON format, however the coordinates of the polygon are reported in the order top-left, bottom-left, top-right, bottom-right, top-left. The correct order for a well-formed polygon should be top-left, bottom-left, bottom-right, top-right, top-left, i.e. the corners in counter-clockwise order (with first corner repeated to close the polygon).

This patch implements that change. I've also added a test case. Hope I did everything right! :)

edit: one small mistake in my test, but it's passing now