### PR TITLE
Install gnm-headers

### DIFF
--- a/gdal/gnm/GNUmakefile
+++ b/gdal/gnm/GNUmakefile
@@ -25,7 +25,10 @@ obj:	$(OBJ)
 sublibs:
 	(cd gnm_frmts; $(MAKE))
 	
-install:	;
+install:
+	for f in *.h ; \
+	    do $(INSTALL_DATA) $$f $(DESTDIR)$(INST_INCLUDE) ; \
+	done
 
 install-obj:	$(O_OBJ:.o=.$(OBJ_EXT))
 	


### PR DESCRIPTION
Currently, the Geographic Network Model headers are not installed. I'm not sure if this is intentional, but if not this PR would fix that.