### PR TITLE
Radragor rmf path

### DIFF
--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1258,8 +1258,7 @@ do {                                                                    \
                 abyHeader + 248, sizeof(poDS->sHeader.abyInvisibleColors) );
         RMF_READ_DOUBLE( abyHeader, poDS->sHeader.adfElevMinMax[0], 280 );
         RMF_READ_DOUBLE( abyHeader, poDS->sHeader.adfElevMinMax[1], 288 );
-        RMF_READ_DOUBLE(abyHeader, poDS->sHeader.dfNoData, 296);
-        
+        RMF_READ_DOUBLE(abyHeader, poDS->sHeader.dfNoData, 296);        
 
         RMF_READ_ULONG( abyHeader, poDS->sHeader.iElevationUnit, 304 );
         poDS->sHeader.iElevationType = *(abyHeader + 308);

--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1258,23 +1258,8 @@ do {                                                                    \
                 abyHeader + 248, sizeof(poDS->sHeader.abyInvisibleColors) );
         RMF_READ_DOUBLE( abyHeader, poDS->sHeader.adfElevMinMax[0], 280 );
         RMF_READ_DOUBLE( abyHeader, poDS->sHeader.adfElevMinMax[1], 288 );
-
-        if( poDS->sHeader.nBitDepth == 8 )
-        {
-            poDS->sHeader.dfNoData = *reinterpret_cast<char *>(abyHeader + 296);
-        }
-        else if( poDS->sHeader.nBitDepth == 16 )
-        {
-            RMF_READ_SHORT(abyHeader, poDS->sHeader.dfNoData, 296);
-        }
-        else if( poDS->sHeader.nBitDepth == 32 )
-        {
-            RMF_READ_LONG(abyHeader, poDS->sHeader.dfNoData, 296);
-        }
-        else if( poDS->sHeader.nBitDepth == 64 )
-        {
-            RMF_READ_DOUBLE(abyHeader, poDS->sHeader.dfNoData, 296);
-        }
+        RMF_READ_DOUBLE(abyHeader, poDS->sHeader.dfNoData, 296);
+        
 
         RMF_READ_ULONG( abyHeader, poDS->sHeader.iElevationUnit, 304 );
         poDS->sHeader.iElevationType = *(abyHeader + 308);


### PR DESCRIPTION
GetNoDataValue returns wrong value for 32-bit mtw files after https://github.com/OSGeo/gdal/pull/58, suppose same problem exists for 16 and 8-bit mtw (i have only 32-bit mtw for tests).
I think it's because RMFHeader.dfNoData record in file is interpreted as long type when it's actually double (as you can see in WriteHeader method of RMFDataset), so old code is correct.