### PR TITLE
Allow libjvm.so to be dlopen'd with --with-jvm-lib=dlopen

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -1820,7 +1820,7 @@ Optional Packages:
   --with-python=ARG   Enable python bindings (ARG=yes, no, or path to python binary)
   --with-java       Include Java support (ARG=yes, no or JDK home path)  [default=no]
   --with-mdb       Include MDB driver
-  --with-jvm-lib=ARG        ARG points to Java libjvm path
+  --with-jvm-lib=ARG        ARG is dlopen or points to Java libjvm path
   --with-jvm-lib-add-rpath    Add the libjvm path to the RPATH (no by default)
   --with-rasdaman=DIR        Include rasdaman support (DIR is rasdaman's install dir).
   --with-armadillo=ARG       Include Armadillo support for faster TPS transform computation (ARG=yes/no/path to armadillo install root) [default=no]
@@ -32791,7 +32791,14 @@ if test "${with_jvm_lib_add_rpath+set}" = set; then :
 fi
 
 
-    if test "x$with_jvm_lib" != "x"; then
+    if test "x$with_jvm_lib" = "xdlopen"; then
+
+cat >>confdefs.h <<_ACEOF
+#define JVM_LIB_DLOPEN 1
+_ACEOF
+
+        JVM_LIB="-ldl"
+    elif test "x$with_jvm_lib" != "x"; then
         if test -d "$with_jvm_lib"; then
             saved_LDFLAGS="$LDFLAGS"
             LDFLAGS="$LDFLAGS -L$with_jvm_lib"

--- a/gdal/configure.in
+++ b/gdal/configure.in
@@ -4937,11 +4937,14 @@ if test "$with_mdb" = "yes" ; then
         AC_MSG_ERROR("--with-java must be specified.")
     fi
 
-    AC_ARG_WITH(jvm-lib,          [  --with-jvm-lib=[ARG]        ARG points to Java libjvm path],,)
+    AC_ARG_WITH(jvm-lib,          [  --with-jvm-lib=[ARG]        ARG is dlopen or points to Java libjvm path],,)
 
     AC_ARG_WITH(jvm-lib-add-rpath,[  --with-jvm-lib-add-rpath    Add the libjvm path to the RPATH (no by default)],,)
 
-    if test "x$with_jvm_lib" != "x"; then
+    if test "x$with_jvm_lib" = "xdlopen"; then
+        AC_DEFINE_UNQUOTED(JVM_LIB_DLOPEN, 1, [Define to 1 if libjvm.so should be dlopen'd])
+        JVM_LIB="-ldl"
+    elif test "x$with_jvm_lib" != "x"; then
         if test -d "$with_jvm_lib"; then
             saved_LDFLAGS="$LDFLAGS"
             LDFLAGS="$LDFLAGS -L$with_jvm_lib"

--- a/gdal/ogr/ogrsf_frmts/mdb/ogrmdbjackcess.cpp
+++ b/gdal/ogr/ogrsf_frmts/mdb/ogrmdbjackcess.cpp
@@ -28,6 +28,11 @@
 
 #include "ogr_mdb.h"
 
+#if JVM_LIB_DLOPEN
+#include <limits.h>
+#include <stdio.h>
+#endif
+
 CPL_CVSID("$Id$");
 
 static JavaVM *jvm_static = NULL;
@@ -162,9 +167,48 @@ int OGRMDBJavaEnv::Init()
     {
         JavaVM* vmBuf[1];
         jsize nVMs;
+        int ret = 0;
+
+#if JVM_LIB_DLOPEN
+        const char *jvmLibPtr = "libjvm.so";
+        char jvmLib[PATH_MAX];
+
+        /* libjvm.so's location is hard to predict so
+           ${JAVA_HOME}/bin/java -XshowSettings is executed to find
+           its location. If JAVA_HOME is not set then java is executed
+           from the PATH instead. This is POSIX-compliant code. */
+        FILE *javaCmd = popen("\"${JAVA_HOME}${JAVA_HOME:+/bin/}java\" -XshowSettings 2>&1 | sed -n '/\\bsun\\.boot\\.library\\.path =/s:.* = \\(.*\\):\\1/server/libjvm.so:p'", "r");
+
+        if (javaCmd != NULL)
+        {
+            size_t javaCmdRead = fread(jvmLib, 1, PATH_MAX, javaCmd);
+            ret = pclose(javaCmd);
+
+            if (ret == 0 && javaCmdRead >= 2)
+            {
+                /* Chomp the new line */
+                jvmLib[javaCmdRead - 1] = '\0';
+                jvmLibPtr = jvmLib;
+            }
+        }
+
+        CPLDebug("MDB", "Trying %s", jvmLibPtr);
+        jint (*pfnJNI_GetCreatedJavaVMs)(JavaVM **, jsize, jsize *);
+        pfnJNI_GetCreatedJavaVMs = (jint (*)(JavaVM **, jsize, jsize *))
+            CPLGetSymbol(jvmLibPtr, "JNI_GetCreatedJavaVMs");
+
+        if (pfnJNI_GetCreatedJavaVMs == NULL) {
+            CPLDebug("MDB", "Cannot find JNI_GetCreatedJavaVMs function");
+            return FALSE;
+        } else {
+            ret = pfnJNI_GetCreatedJavaVMs(vmBuf, 1, &nVMs);
+        }
+#else
+        ret = JNI_GetCreatedJavaVMs(vmBuf, 1, &nVMs);
+#endif
 
         /* Are we already called from Java ? */
-        if (JNI_GetCreatedJavaVMs(vmBuf, 1, &nVMs) == JNI_OK && nVMs == 1)
+        if (ret == JNI_OK && nVMs == 1)
         {
             jvm = vmBuf[0];
             if (jvm->GetEnv((void **)&env, JNI_VERSION_1_2) == JNI_OK)
@@ -195,11 +239,22 @@ int OGRMDBJavaEnv::Init()
                 args.nOptions = 0;
             args.ignoreUnrecognized = JNI_FALSE;
 
-            int ret = JNI_CreateJavaVM(&jvm, (void **)&env, &args);
+#if JVM_LIB_DLOPEN
+            jint (*pfnJNI_CreateJavaVM)(JavaVM **, void **, void *);
+            pfnJNI_CreateJavaVM = (jint (*)(JavaVM **, void **, void *))
+                CPLGetSymbol(jvmLibPtr, "JNI_CreateJavaVM");
+
+            if (pfnJNI_CreateJavaVM == NULL)
+                return FALSE;
+            else
+                ret = pfnJNI_CreateJavaVM(&jvm, (void **)&env, &args);
+#else
+            ret = JNI_CreateJavaVM(&jvm, (void **)&env, &args);
+#endif
 
             CPLFree(pszClassPathOption);
 
-            if (ret != 0 || jvm == NULL || env == NULL)
+            if (ret != JNI_OK || jvm == NULL || env == NULL)
             {
                 CPLError(CE_Failure, CPLE_AppDefined, "JNI_CreateJavaVM failed (%d)", ret);
                 return FALSE;

--- a/gdal/port/cpl_config.h.in
+++ b/gdal/port/cpl_config.h.in
@@ -177,6 +177,9 @@
 /* For .cpp files, define as const if the declaration of iconv() needs const. */
 #undef ICONV_CPP_CONST
 
+/* Define to 1 if libjvm.so should be dlopen'd */
+#undef JVM_LIB_DLOPEN
+
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
 #undef LT_OBJDIR


### PR DESCRIPTION
Having to set `LD_LIBRARY_PATH` is a pain and relying on the rpath can be problematic when libjvm.so lives in a versioned directory. Some distributions even allow per-user JVM selection so checking the value of `JAVA_HOME` at runtime allows this choice to be respected.

libjvm.so's location is hard to predict (amd64 vs i386, jre or not?) so `${JAVA_HOME}/bin/java -XshowSettings` is executed to find its location. If `JAVA_HOME` is not set then java is executed from the `PATH` instead.