### PR TITLE
Fixed bug where null pointer was accessed in ogrwfslayer.cpp.

### DIFF
--- a/gdal/ogr/ogrsf_frmts/wfs/ogrwfslayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/wfs/ogrwfslayer.cpp
@@ -1183,6 +1183,8 @@ OGRFeature *OGRWFSLayer::GetNextFeature()
             if (poBaseDS)
             {
                 poBaseLayer = poBaseDS->GetLayer(0);
+                if(poBaseLayer == NULL)
+                    return NULL;
                 poBaseLayer->ResetReading();
 
                 /* Check that the layer field definition is consistent with the one */


### PR DESCRIPTION
Accessing null pointer was happening when handling and empty layer and thus causing the program to crash.