### PR TITLE
- Fixed error reporting for MapInfo tab files

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -273,7 +273,7 @@ IMapInfoFile *IMapInfoFile::SmartOpen(const char *pszFname,
         poFile = NULL;
     }
 
-    if (!bTestOpenNoError && poFile == NULL)
+    if (!bTestOpenNoError && poFile == NULL && CPLGetLastErrorNo() == CPLE_None)
     {
         CPLError(CE_Failure, CPLE_FileIO,
                  "%s could not be opened as a MapInfo dataset.", pszFname);

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.cpp
@@ -151,7 +151,7 @@ static GDALDataset *OGRTABDriverOpen( GDALOpenInfo* poOpenInfo )
 #endif
 
     OGRTABDataSource *poDS = new OGRTABDataSource();
-    if( poDS->Open( poOpenInfo, TRUE ) )
+    if( poDS->Open( poOpenInfo, FALSE ) )
         return poDS;
     else
     {

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_tabfile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_tabfile.cpp
@@ -1083,8 +1083,6 @@ int TABFile::WriteTABFile()
  **********************************************************************/
 int TABFile::Close()
 {
-    CPLErrorReset();
-
     // Commit the latest changes to the file...
 
     if (m_poMAPFile)


### PR DESCRIPTION
- In mitab_ogr_driver.cpp, calling "Open" with bTestOpen=TRUE, this prevents errors from being recorded
- In mitab_tabfile.cpp, CPLErrorReset() was being called in the destructor, which clears errors and prevents the caller from getting more precise error information
- In mitab_imapinfofile.cpp, error information was being replaced with a generic error