### PR TITLE
make GDALCreateGenImgProjTransformer take into account the METHOD met…

### DIFF
--- a/gdal/alg/gdaltransformer.cpp
+++ b/gdal/alg/gdaltransformer.cpp
@@ -980,8 +980,8 @@ GDALCreateGenImgProjTransformer( GDALDatasetH hSrcDS, const char *pszSrcWKT,
 {
     char **papszOptions = NULL;
     void *pRet;
-    const char *pszSrcMethod = GDALGetMetadataItem(hSrcDS, "METHOD", NULL);
-    const char *pszDstMethod = GDALGetMetadataItem(hDstDS, "METHOD", NULL);
+    const char *pszSrcMethod = NULL;
+    const char *pszDstMethod = NULL;
 
     if( pszSrcWKT != NULL )
         papszOptions = CSLSetNameValue( papszOptions, "SRC_SRS", pszSrcWKT );
@@ -993,6 +993,11 @@ GDALCreateGenImgProjTransformer( GDALDatasetH hSrcDS, const char *pszSrcWKT,
         papszOptions = CSLSetNameValue( papszOptions, "MAX_GCP_ORDER",
                                         CPLString().Printf("%d",nOrder) );
 
+
+    if( hSrcDS != NULL )
+      pszSrcMethod = GDALGetMetadataItem(hSrcDS, "METHOD", NULL);
+    if( hDstDS != NULL )
+      pszDstMethod = GDALGetMetadataItem(hDstDS, "METHOD", NULL);
     if( pszSrcMethod != NULL )
         papszOptions = CSLSetNameValue( papszOptions, "SRC_METHOD", pszSrcMethod );
     if( pszDstMethod != NULL )

--- a/gdal/alg/gdaltransformer.cpp
+++ b/gdal/alg/gdaltransformer.cpp
@@ -980,6 +980,8 @@ GDALCreateGenImgProjTransformer( GDALDatasetH hSrcDS, const char *pszSrcWKT,
 {
     char **papszOptions = NULL;
     void *pRet;
+    const char *pszSrcMethod = GDALGetMetadataItem(hSrcDS, "METHOD", NULL);
+    const char *pszDstMethod = GDALGetMetadataItem(hDstDS, "METHOD", NULL);
 
     if( pszSrcWKT != NULL )
         papszOptions = CSLSetNameValue( papszOptions, "SRC_SRS", pszSrcWKT );
@@ -990,6 +992,12 @@ GDALCreateGenImgProjTransformer( GDALDatasetH hSrcDS, const char *pszSrcWKT,
     if( nOrder != 0 )
         papszOptions = CSLSetNameValue( papszOptions, "MAX_GCP_ORDER",
                                         CPLString().Printf("%d",nOrder) );
+
+    if( pszSrcMethod != NULL )
+        papszOptions = CSLSetNameValue( papszOptions, "SRC_METHOD", pszSrcMethod );
+    if( pszDstMethod != NULL )
+        papszOptions = CSLSetNameValue( papszOptions, "DST_METHOD", pszDstMethod );
+
 
     pRet = GDALCreateGenImgProjTransformer2( hSrcDS, hDstDS, papszOptions );
     CSLDestroy( papszOptions );


### PR DESCRIPTION
…adata from source and destination dataset. Useful when using ReprojectImage from Swing Python binding and need of using the GCP_TPS Transformer