### PR TITLE
Handle Exceptions returned from PIX Destructor

### DIFF
--- a/gdal/frmts/pcidsk/pcidskdataset2.cpp
+++ b/gdal/frmts/pcidsk/pcidskdataset2.cpp
@@ -156,6 +156,13 @@ PCIDSK2Band::~PCIDSK2Band()
 void PCIDSK2Band::SetDescription( const char *pszDescription )
 
 {
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set description on read-only file." );
+        return;
+    }
+
     try
     {
         poChannel->SetDescription( pszDescription );
@@ -398,6 +405,13 @@ CPLErr PCIDSK2Band::SetColorTable( GDALColorTable *poCT )
     if( poFile == NULL )
         return CE_Failure;
 
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set color table on read-only file." );
+        return CE_Failure;
+    }
+
     try
     {
 /* -------------------------------------------------------------------- */
@@ -616,6 +630,13 @@ CPLErr PCIDSK2Band::SetMetadata( char **papszMD,
     CSLDestroy( papszLastMDListValue );
     papszLastMDListValue = NULL;
 
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set metadata on read-only file." );
+        return CE_Failure;
+    }
+
     try
     {
         for( int iItem = 0; papszMD && papszMD[iItem]; iItem++ )
@@ -661,6 +682,13 @@ CPLErr PCIDSK2Band::SetMetadataItem( const char *pszName,
 /* -------------------------------------------------------------------- */
     CSLDestroy( papszLastMDListValue );
     papszLastMDListValue = NULL;
+
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set metadata on read-only file." );
+        return CE_Failure;
+    }
 
     try
     {
@@ -1039,6 +1067,13 @@ CPLErr PCIDSK2Dataset::SetMetadata( char **papszMD,
     CSLDestroy( papszLastMDListValue );
     papszLastMDListValue = NULL;
 
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set metadata on read-only file." );
+        return CE_Failure;
+    }
+
     try
     {
         for( int iItem = 0; papszMD && papszMD[iItem]; iItem++ )
@@ -1083,6 +1118,13 @@ CPLErr PCIDSK2Dataset::SetMetadataItem( const char *pszName,
 /* -------------------------------------------------------------------- */
     CSLDestroy( papszLastMDListValue );
     papszLastMDListValue = NULL;
+
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set metadata on read-only file." );
+        return CE_Failure;
+    }
 
     try
     {
@@ -1210,6 +1252,13 @@ CPLErr PCIDSK2Dataset::SetGeoTransform( double * padfTransform )
     if( poGeoref == NULL )
         return GDALPamDataset::SetGeoTransform( padfTransform );
 
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set GeoTransform on read-only file." );
+        return CE_Failure;
+    }
+
     try
     {
         poGeoref->WriteSimple( poGeoref->GetGeosys(),
@@ -1325,7 +1374,13 @@ CPLErr PCIDSK2Dataset::SetProjection( const char *pszWKT )
         return GDALPamDataset::SetProjection( pszWKT );
     }
 
-    try
+    if( GetAccess() == GA_ReadOnly )
+    {
+        CPLError( CE_Failure, CPLE_NoWriteAccess,
+                  "Unable to set projection on read-only file." );
+        return CE_Failure;
+    }
+    else try
     {
         double adfGT[6];
         poGeoref->GetTransform( adfGT[0], adfGT[1], adfGT[2],

--- a/gdal/frmts/pcidsk/sdk/segment/metadatasegment_p.cpp
+++ b/gdal/frmts/pcidsk/sdk/segment/metadatasegment_p.cpp
@@ -30,6 +30,7 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#include "pcidsk_exception.h"
 #include "pcidsk_file.h"
 #include "segment/metadatasegment.h"
 #include <cassert>
@@ -58,7 +59,19 @@ MetadataSegment::MetadataSegment( PCIDSKFile *fileIn, int segmentIn,
 MetadataSegment::~MetadataSegment()
 
 {
-    Synchronize();
+    try {
+        Synchronize();
+    }
+    catch( const PCIDSKException& ex )
+    {
+        fprintf( stderr, "Exception in MetadataSegment Destructor: %s\n",
+                 ex.what() );
+    }
+    catch( ... )
+    {
+        fprintf( stderr, "PCIDSK SDK Failure in MetadataSegment Destructor(), \
+                 unexpected exception." );
+    }
 }
 
 /************************************************************************/


### PR DESCRIPTION
1. Handle exception inside the destructor.
2. Check Access Rights before writing to dataset.