### PR TITLE
Prevent unnecessary coordinate transformations

### DIFF
--- a/autotest/utilities/test_ogr2ogr.py
+++ b/autotest/utilities/test_ogr2ogr.py
@@ -2651,6 +2651,67 @@ def test_ogr2ogr_66():
 
     return 'success'
 
+def check_identity_transformation(x, y, srid):
+    import struct
+
+    if test_cli_utilities.get_ogr2ogr_path() is None:
+        return 'skip'
+
+    if not ogrtest.have_geos():
+        return 'skip'
+
+
+    shape_drv = ogr.GetDriverByName('ESRI Shapefile')
+    try:
+        os.stat('tmp/output_point.shp')
+        shape_drv.DeleteDataSource('tmp/output_point.shp')
+    except:
+        pass
+
+    # Generate CSV file with test point
+    xy_wkb = '0101000000' + ''.join(hex(q)[2:].zfill(16).upper() for q in struct.unpack('>QQ', struct.pack("<dd",x,y)))
+    f = open('tmp/input_point.csv', 'wt')
+    f.write('id,wkb_geom\n')
+    f.write('1,' + xy_wkb + '\n')
+    f.close()
+
+    # To check that the transformed values are identical to the original ones we need
+    # to use a binary format with the same accuracy as the source (WKB).
+    # CSV cannot be used for this purpose because WKB is not supported as a geometry output format.
+
+    gdaltest.runexternal(test_cli_utilities.get_ogr2ogr_path() + " tmp/output_point.shp tmp/input_point.csv -oo GEOM_POSSIBLE_NAMES=wkb_geom -s_srs EPSG:%(srid)d  -t_srs EPSG:%(srid)d"  % locals())
+
+    ds = ogr.Open('tmp/output_point.shp')
+    feat = ds.GetLayer(0).GetNextFeature()
+    ok = feat.GetGeometryRef().GetX() == x and feat.GetGeometryRef().GetY() == y
+
+    feat.Destroy()
+    ds.Destroy()
+
+    shape_drv.DeleteDataSource('tmp/output_point.shp')
+    os.remove('tmp/input_point.csv')
+
+    if ok:
+        return 'success'
+    else:
+        return 'fail'
+
+###############################################################################
+# Test coordinates values are preserved for identity transformations
+
+def test_ogr2ogr_67():
+
+    # Test coordinates
+    # The x value is such that x * k * (1/k) != x with k the common factor used in degrees unit definition
+    # If the coordinates are converted to radians and back to degrees the value of x will be altered
+    x = float.fromhex('0x1.5EB3ED959A307p6')
+    y = 0.0
+
+    # Now we will check the value of x is preserved in a transformation with same target and source SRS,
+    # both as latitutude/longitude in degrees.
+    ret = check_identity_transformation(x, y, 4326)
+    return ret
+
 gdaltest_list = [
     test_ogr2ogr_1,
     test_ogr2ogr_2,
@@ -2718,7 +2779,8 @@ gdaltest_list = [
     test_ogr2ogr_63,
     test_ogr2ogr_64,
     test_ogr2ogr_65,
-    test_ogr2ogr_66
+    test_ogr2ogr_66,
+    test_ogr2ogr_67
     ]
 
 # gdaltest_list = [ test_ogr2ogr_66 ]

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -32,6 +32,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <cfloat>
 
 #include "cpl_conv.h"
 #include "cpl_error.h"
@@ -160,6 +161,8 @@ class OGRProj4CT : public OGRCoordinateTransformation
     double     *padfTargetZ;
 
     bool        m_bEmitErrors;
+
+    bool        bNoTransform;
 
 public:
                 OGRProj4CT();
@@ -515,7 +518,8 @@ OGRProj4CT::OGRProj4CT() :
     padfTargetX(NULL),
     padfTargetY(NULL),
     padfTargetZ(NULL),
-    m_bEmitErrors(true)
+    m_bEmitErrors(true),
+    bNoTransform(false)
 {
     if( pfn_pj_ctx_alloc != NULL )
         pjctx = pfn_pj_ctx_alloc();
@@ -885,6 +889,11 @@ int OGRProj4CT::InitializeNoLock( OGRSpatialReference * poSourceIn,
     // Determine if we really have a transformation to do.
     bIdentityTransform = strcmp(pszSrcProj4Defn, pszDstProj4Defn) == 0;
 
+    // Determine if we can skip the tranformation completely.
+    bNoTransform = bIdentityTransform && bSourceLatLong && !bSourceWrap &&
+                    bTargetLatLong && !bTargetWrap &&
+                    fabs(dfSourceToRadians * dfTargetFromRadians - 1.0) < DBL_EPSILON;
+
     CPLFree( pszSrcProj4Defn );
     CPLFree( pszDstProj4Defn );
 
@@ -979,6 +988,19 @@ int OGRProj4CT::TransformEx( int nCount, double *x, double *y, double *z,
                              int *pabSuccess )
 
 {
+    // Prevent any coordinate modification when possible
+    if ( bNoTransform )
+    {
+        if( pabSuccess )
+        {
+            for( int i = 0; i < nCount; i++ )
+            {
+                 pabSuccess[i] = TRUE;
+            }
+        }
+        return TRUE;
+    }
+
     // Workaround potential bugs in proj.4 such as
     // the one of https://github.com/OSGeo/proj.4/commit/
     //                              bc7453d1a75aab05bdff2c51ed78c908e3efa3cd


### PR DESCRIPTION
In some cases in which ogr2ogr source and target use the same coordinate systems and
the source and target formats allow for the full input target precision to be preserved
in the output, some coordinates may be altered (e.g. by 1-ulp deviations in floating point numbers)

This is inconvenient for cases where a format is intended for transparent round-trip conversions
(e.g. export data from PostGIS into a Geopackage, then back to PostGIS).

The cause is that longitude/latitude coordinates are always converted internally to radians.
The floating point multiplication by a factor and its inverse may introduce 1-ulp differences.

Here we're adding a test to detect such cases and a fix to avoid conversion to radians when possible.