### PR TITLE
Increase the tolerance used to consider identical source and target units.

### DIFF
--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -32,7 +32,6 @@
 
 #include <cmath>
 #include <cstring>
-#include <cfloat>
 
 #include "cpl_conv.h"
 #include "cpl_error.h"
@@ -891,9 +890,11 @@ int OGRProj4CT::InitializeNoLock( OGRSpatialReference * poSourceIn,
     bIdentityTransform = strcmp(pszSrcProj4Defn, pszDstProj4Defn) == 0;
 
     // Determine if we can skip the transformation completely.
+    // Assume that source and target units are defined with at least
+    // 10 correct significant digits; hence the 1E-9 tolerance used.
     bNoTransform = bIdentityTransform && bSourceLatLong && !bSourceWrap &&
                     bTargetLatLong && !bTargetWrap &&
-                    fabs(dfSourceToRadians * dfTargetFromRadians - 1.0) < DBL_EPSILON;
+                    fabs(dfSourceToRadians * dfTargetFromRadians - 1.0) < 1E-9;
 
     CPLFree( pszSrcProj4Defn );
     CPLFree( pszDstProj4Defn );


### PR DESCRIPTION
To determine if input and output units of longitude/latitude are the same  (so we can avoid any transformation of coordinates) we where checking  the product of `input_units_to_radians * (1/target_units_to_radians)` to be 1 within a tolerance of `DBL_EPSILON` (to account for roundoff).

The value DBL_EPSILON had been chose with the premise that  when the same units were chosen for input and output (degrees) the same conversion to radian would be in use for both source and target.

But even in cases where all SRS originate from the same definition the units definition may have been altered, e.g. when saving the SRS to a `.prj` file: https://github.com/OSGeo/gdal/blob/8dde8c78f51359e9de64850a15cf6c6e0af56713/gdal/ogr/ogr_srs_esri.cpp#L1586

For this reason, to support exact round-trip transformations of datasets through shapefile format, we need to allow for slightly different units definitions in source and target and we must set the comparison tolerance accordingly. (see https://github.com/CartoDB/cartodb/issues/10945#issuecomment-273110711 for more information of this)

We have chosen a tolerance of 1E-9 for consistency with  the variation that can be introduced [here](https://github.com/OSGeo/gdal/blob/8dde8c78f51359e9de64850a15cf6c6e0af56713/gdal/ogr/ogr_srs_esri.cpp#L1586)
, so we are effectively expecting at least 10 correct decimal digits in the units definitions.

