### PR TITLE
Support for Requester Pays S3 buckets

### DIFF
--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -46,7 +46,7 @@ def open_for_read(uri):
 def vsis3_init():
 
     gdaltest.aws_vars = {}
-    for var in ('AWS_SECRET_ACCESS_KEY', 'AWS_ACCESS_KEY_ID', 'AWS_TIMESTAMP', 'AWS_HTTPS', 'AWS_VIRTUAL_HOSTING', 'AWS_S3_ENDPOINT'):
+    for var in ('AWS_SECRET_ACCESS_KEY', 'AWS_ACCESS_KEY_ID', 'AWS_TIMESTAMP', 'AWS_HTTPS', 'AWS_VIRTUAL_HOSTING', 'AWS_S3_ENDPOINT', 'AWS_REQUEST_PAYER'):
         gdaltest.aws_vars[var] = gdal.GetConfigOption(var)
         if gdaltest.aws_vars[var] is not None:
             gdal.SetConfigOption(var, "")
@@ -288,6 +288,16 @@ def vsis3_2():
         gdaltest.post_reason('fail')
         print(gdal.VSIGetLastErrorMsg())
         return 'fail'
+
+    # Test with requester pays
+    gdal.SetConfigOption('AWS_REQUEST_PAYER', 'requester')
+    f = open_for_read('/vsis3/s3_fake_bucket_with_requester_pays/resource')
+    if f is None:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    data = gdal.VSIFReadL(1, 4, f).decode('ascii')
+    gdal.VSIFCloseL(f)
+    gdal.SetConfigOption('AWS_REQUEST_PAYER', None)
 
     return 'success'
 

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -462,6 +462,32 @@ class GDAL_Handler(BaseHTTPRequestHandler):
                 self.wfile.write("""foo""".encode('ascii'))
                 return
 
+            if self.path == '/s3_fake_bucket_with_requester_pays/resource':
+                self.protocol_version = 'HTTP/1.1'
+
+                if 'x-amz-request-payer' not in self.headers:
+                    sys.stderr.write('Bad headers: %s\n' % str(self.headers))
+                    self.send_response(403)
+                    return
+                expected_authorization_8080 = 'AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20150101/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-request-payer,Signature=464a21835038b4f4d292b6463b8a005b9aaa980513aa8c42fc170abb733dce85'
+                expected_authorization_8081 = 'AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20150101/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-request-payer,Signature=b10e91575186342f9f2acfc91c4c2c9938c4a9e8cdcbc043d09d59d9641ad7fb'
+                if self.headers['Authorization'] != expected_authorization_8080 and self.headers['Authorization'] != expected_authorization_8081:
+                    sys.stderr.write("Bad Authorization: '%s'\n" % str(self.headers['Authorization']))
+                    self.send_response(403)
+                    return
+                if self.headers['x-amz-request-payer'] != 'requester':
+                    sys.stderr.write("Bad x-amz-request-payer: '%s'\n" % str(self.headers['x-amz-request-payer']))
+                    self.send_response(403)
+                    return
+
+                self.send_response(200)
+                self.send_header('Content-type', 'text/plain')
+                self.send_header('Content-Length', 3)
+                self.end_headers()
+                self.wfile.write("""foo""".encode('ascii'))
+                return
+
+
             if self.path == '/s3_fake_bucket/resource2.bin':
                 self.protocol_version = 'HTTP/1.1'
                 if 'Range' in self.headers:

--- a/gdal/port/cpl_aws.h
+++ b/gdal/port/cpl_aws.h
@@ -41,6 +41,7 @@ CPLString CPLGetAWS_SIGN4_Authorization(const CPLString& osSecretAccessKey,
                                         const CPLString& osAccessKeyId,
                                         const CPLString& osAccessToken,
                                         const CPLString& osAWSRegion,
+                                        const CPLString& osRequestPayer,
                                         const CPLString& osService,
                                         const CPLString& osVerb,
                                         const CPLString& osHost,
@@ -69,6 +70,7 @@ class VSIS3HandleHelper
         CPLString m_osSessionToken;
         CPLString m_osAWSS3Endpoint;
         CPLString m_osAWSRegion;
+        CPLString m_osRequestPayer;
         CPLString m_osBucket;
         CPLString m_osObjectKey;
         bool m_bUseHTTPS;
@@ -88,6 +90,7 @@ class VSIS3HandleHelper
                     const CPLString& osSessionToken,
                     const CPLString& osAWSS3Endpoint,
                     const CPLString& osAWSRegion,
+                    const CPLString& osRequestPayer,
                     const CPLString& osBucket,
                     const CPLString& osObjectKey,
                     bool bUseHTTPS, bool bUseVirtualHosting);
@@ -113,9 +116,11 @@ class VSIS3HandleHelper
         const CPLString& GetObjectKey() const { return m_osObjectKey; }
         const CPLString& GetAWSS3Endpoint()const  { return m_osAWSS3Endpoint; }
         const CPLString& GetAWSRegion() const { return m_osAWSRegion; }
+        const CPLString& GetRequestPayer() const { return m_osRequestPayer; }
         bool GetVirtualHosting() const { return m_bUseVirtualHosting; }
         void SetAWSS3Endpoint(const CPLString &osStr);
         void SetAWSRegion(const CPLString &osStr);
+        void SetRequestPayer(const CPLString &osStr);
         void SetVirtualHosting(bool b);
         void SetObjectKey(const CPLString &osStr);
 };
@@ -125,13 +130,16 @@ class VSIS3UpdateParams
     public:
         CPLString m_osAWSRegion;
         CPLString m_osAWSS3Endpoint;
+        CPLString m_osRequestPayer;
         bool m_bUseVirtualHosting;
 
         VSIS3UpdateParams(const CPLString& osAWSRegion = "",
                           const CPLString& osAWSS3Endpoint = "",
+                          const CPLString& osRequestPayer = "",
                           bool bUseVirtualHosting = false) :
             m_osAWSRegion(osAWSRegion),
             m_osAWSS3Endpoint(osAWSS3Endpoint),
+            m_osRequestPayer(osRequestPayer),
             m_bUseVirtualHosting(bUseVirtualHosting) {}
 };
 

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -4643,7 +4643,10 @@ void VSIInstallCurlFileHandler( void )
  * set to one of the supported
  * <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">S3
  * regions</a> and defaults to 'us-east-1' The AWS_S3_ENDPOINT configuration
- * option defaults to s3.amazonaws.com.
+ * option defaults to s3.amazonaws.com. The AWS_REQUEST_PAYER configuration
+ * option may be set to "requester" to facilitate use with
+ * <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester
+ * Pays buckets</a>.
  *
  * The GDAL_HTTP_PROXY, GDAL_HTTP_PROXYUSERPWD and GDAL_PROXY_AUTH configuration
  * options can be used to define a proxy server. The syntax to use is the one of

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -4643,8 +4643,9 @@ void VSIInstallCurlFileHandler( void )
  * set to one of the supported
  * <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">S3
  * regions</a> and defaults to 'us-east-1' The AWS_S3_ENDPOINT configuration
- * option defaults to s3.amazonaws.com. The AWS_REQUEST_PAYER configuration
- * option may be set to "requester" to facilitate use with
+ * option defaults to s3.amazonaws.com. Starting with GDAL 2.2, the
+ * AWS_REQUEST_PAYER configuration option may be set to "requester" to
+ * facilitate use with
  * <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester
  * Pays buckets</a>.
  *

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -4418,6 +4418,7 @@ void VSIS3FSHandler::UpdateMapFromHandle( VSIS3HandleHelper * poS3HandleHelper )
     oMapBucketsToS3Params[ poS3HandleHelper->GetBucket() ] =
         VSIS3UpdateParams ( poS3HandleHelper->GetAWSRegion(),
                       poS3HandleHelper->GetAWSS3Endpoint(),
+                      poS3HandleHelper->GetRequestPayer(),
                       poS3HandleHelper->GetVirtualHosting() );
 }
 
@@ -4435,6 +4436,7 @@ void VSIS3FSHandler::UpdateHandleFromMap( VSIS3HandleHelper * poS3HandleHelper )
     {
         poS3HandleHelper->SetAWSRegion(oIter->second.m_osAWSRegion);
         poS3HandleHelper->SetAWSS3Endpoint(oIter->second.m_osAWSS3Endpoint);
+        poS3HandleHelper->SetRequestPayer(oIter->second.m_osRequestPayer);
         poS3HandleHelper->SetVirtualHosting(oIter->second.m_bUseVirtualHosting);
     }
 }

--- a/gdal/port/cpl_vsil_curl_streaming.cpp
+++ b/gdal/port/cpl_vsil_curl_streaming.cpp
@@ -1848,7 +1848,11 @@ void VSIInstallCurlStreamingFileHandler(void)
  * The AWS_REGION configuration option may be set to one of the supported
  * <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">
  * S3 regions</a> and defaults to 'us-east-1'.  The AWS_S3_ENDPOINT
- * configuration option defaults to s3.amazonaws.com.
+ * configuration option defaults to s3.amazonaws.com. Starting with GDAL 2.2,
+ * the AWS_REQUEST_PAYER configuration option may be set to "requester" to
+ * facilitate use with
+ * <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester
+ * Pays buckets</a>.
  *
  * The GDAL_HTTP_PROXY, GDAL_HTTP_PROXYUSERPWD and GDAL_PROXY_AUTH configuration
  * options can be used to define a proxy server. The syntax to use is the one of

--- a/gdal/port/cpl_vsil_curl_streaming.cpp
+++ b/gdal/port/cpl_vsil_curl_streaming.cpp
@@ -1662,6 +1662,7 @@ void VSIS3StreamingFSHandler::UpdateMapFromHandle(
     oMapBucketsToS3Params[ poS3HandleHelper->GetBucket() ] =
         VSIS3UpdateParams ( poS3HandleHelper->GetAWSRegion(),
                       poS3HandleHelper->GetAWSS3Endpoint(),
+                      poS3HandleHelper->GetRequestPayer(),
                       poS3HandleHelper->GetVirtualHosting() );
 }
 
@@ -1680,6 +1681,7 @@ void VSIS3StreamingFSHandler::UpdateHandleFromMap(
     {
         poS3HandleHelper->SetAWSRegion(oIter->second.m_osAWSRegion);
         poS3HandleHelper->SetAWSS3Endpoint(oIter->second.m_osAWSS3Endpoint);
+        poS3HandleHelper->SetRequestPayer(oIter->second.m_osRequestPayer);
         poS3HandleHelper->SetVirtualHosting(oIter->second.m_bUseVirtualHosting);
     }
 }


### PR DESCRIPTION
To enable, set `AWS_REQUEST_PAYER=requester`

http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html