### PR TITLE
lines 353/354 shift must be changed for correct mbtile-tif registration

### DIFF
--- a/gdal/frmts/mbtiles/mbtilesdataset.cpp
+++ b/gdal/frmts/mbtiles/mbtilesdataset.cpp
@@ -350,8 +350,8 @@ char* MBTilesDataset::FindKey(int iPixel, int iLine)
 
     // Compute shift between GDAL origin and TileMatrixSet origin
     // Caution this is in GeoPackage / WMTS convention ! That is upper-left corner
-    const int nShiftXPixels = (int)floor(0.5 + (m_adfGeoTransform[0] - TMS_ORIGIN_X) /  m_adfGeoTransform[1]);
-    const int nShiftYPixelsFromGPKGOrigin = (int)floor(0.5 + (m_adfGeoTransform[3] - TMS_ORIGIN_Y) /  m_adfGeoTransform[5]);
+    const int nShiftXPixels = (int)floor(1 + (m_adfGeoTransform[0] - TMS_ORIGIN_X) /  m_adfGeoTransform[1]);
+    const int nShiftYPixelsFromGPKGOrigin = (int)floor(1 + (m_adfGeoTransform[3] - TMS_ORIGIN_Y) /  m_adfGeoTransform[5]);
 
     const int iLineFromGPKGOrigin = iLine + nShiftYPixelsFromGPKGOrigin;
     const int iLineFromMBTilesOrigin = m_nTileMatrixHeight * nBlockYSize - 1 - iLineFromGPKGOrigin;


### PR DESCRIPTION
the 0.5 factor results in a shift to the right and south relative to 'truth' (confirmed from google, bing, near map source imagery and WMS layers). Converting to 1 removes this offset and appears to generate correctly placed tifs. 