### PR TITLE
fix(): do not crash on empty tiles generation

### DIFF
--- a/autotest/pymod/test_py_scripts.py
+++ b/autotest/pymod/test_py_scripts.py
@@ -124,13 +124,12 @@ def run_py_script_as_py_module(script_path, script_name, concatenated_argv):
 
     ret = None
 
-    # Redirect stdout to file
-    fout = open('tmp/stdout.txt', 'wt')
-    ori_stdout = sys.stdout
-    sys.stdout = fout
+    try:
+        # Redirect stdout to file
+        fout = open('tmp/stdout.txt', 'wt')
+        ori_stdout = sys.stdout
+        sys.stdout = fout
 
-    #try:
-    if True:
         exec('import ' + script_name)
         has_imported_module = True
 
@@ -140,13 +139,10 @@ def run_py_script_as_py_module(script_path, script_name, concatenated_argv):
         # If so, run it (otherwise the import has already run the script)
         if has_main:
             exec(script_name + '.main()')
-
-    #except:
-    #    pass
-
-    # Restore original stdout
-    fout.close()
-    sys.stdout = ori_stdout
+    finally:
+        # Restore original stdout
+        fout.close()
+        sys.stdout = ori_stdout
 
     fout = open('tmp/stdout.txt', 'rt')
     ret = fout.read()

--- a/autotest/pyscripts/data/test_bounds_close_to_tile_bounds_x.vrt
+++ b/autotest/pyscripts/data/test_bounds_close_to_tile_bounds_x.vrt
@@ -1,0 +1,24 @@
+<VRTDataset rasterXSize="504" rasterYSize="454">
+  <SRS>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</SRS>
+  <GeoTransform>  6.3490506599999999e+05,  4.7627007652033447e-02,  0.0000000000000000e+00,  8.1392822900000000e+06,  0.0000000000000000e+00, -4.7657934423650940e-02</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">Area</MDI>
+    <MDI key="TIFFTAG_SOFTWARE">pix4dmapper</MDI>
+  </Metadata>
+  <VRTRasterBand dataType="Byte" band="1">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Red</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Green</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Blue</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="4">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Alpha</ColorInterp>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/pyscripts/data/test_bounds_close_to_tile_bounds_y.vrt
+++ b/autotest/pyscripts/data/test_bounds_close_to_tile_bounds_y.vrt
@@ -1,0 +1,24 @@
+<VRTDataset rasterXSize="802" rasterYSize="423">
+  <SRS>PROJCS["WGS 84 / UTM zone 31N",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",3],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","32631"]]</SRS>
+  <GeoTransform>  6.5614318824000005e+05,  2.4702942643333180e-02,  0.0000000000000000e+00,  6.5219694422600009e+06,  0.0000000000000000e+00, -2.4686193855448537e-02</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">Area</MDI>
+    <MDI key="TIFFTAG_SOFTWARE">pix4dmapper</MDI>
+  </Metadata>
+  <VRTRasterBand dataType="Byte" band="1">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Red</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Green</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Blue</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="4">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Alpha</ColorInterp>
+  </VRTRasterBand>
+</VRTDataset>


### PR DESCRIPTION
This is NOT a ready PR but I wanted to put it out there to gather some comments since it's my first, and maybe check the logic.
This is about https://trac.osgeo.org/gdal/ticket/6057

My understanding of the issue is
- we determine that the top left coordinates fall in tile X, Y, Z
- when we try to compute the content of this tile, because of raster approximation, we don't find anything. The first pixel of the image would actually be on tile X, Y-1, Z

The way I solved it is different than the one proposed in the ticket. I'm not sure yet what I prefer. I'll try to wrap it up tomorrow.

Let me know if you have any comments


