### PR TITLE
fix(6794): option for handling of utf8 filenames with python2 executable

### DIFF
--- a/autotest/pyscripts/data/test_latin1_é.vrt
+++ b/autotest/pyscripts/data/test_latin1_é.vrt
@@ -1,0 +1,24 @@
+<VRTDataset rasterXSize="504" rasterYSize="454">
+  <SRS>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</SRS>
+  <GeoTransform>  6.3490506599999999e+05,  4.7627007652033447e-02,  0.0000000000000000e+00,  8.1392822900000000e+06,  0.0000000000000000e+00, -4.7657934423650940e-02</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">Area</MDI>
+    <MDI key="TIFFTAG_SOFTWARE">pix4dmapper</MDI>
+  </Metadata>
+  <VRTRasterBand dataType="Byte" band="1">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Red</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Green</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Blue</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="4">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Alpha</ColorInterp>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/pyscripts/data/test_utf8_漢字.vrt
+++ b/autotest/pyscripts/data/test_utf8_漢字.vrt
@@ -1,0 +1,24 @@
+<VRTDataset rasterXSize="504" rasterYSize="454">
+  <SRS>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</SRS>
+  <GeoTransform>  6.3490506599999999e+05,  4.7627007652033447e-02,  0.0000000000000000e+00,  8.1392822900000000e+06,  0.0000000000000000e+00, -4.7657934423650940e-02</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">Area</MDI>
+    <MDI key="TIFFTAG_SOFTWARE">pix4dmapper</MDI>
+  </Metadata>
+  <VRTRasterBand dataType="Byte" band="1">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Red</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Green</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Blue</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="4">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Alpha</ColorInterp>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/pyscripts/data/漢字/test_bounds_close_to_tile_bounds_x.vrt
+++ b/autotest/pyscripts/data/漢字/test_bounds_close_to_tile_bounds_x.vrt
@@ -1,0 +1,24 @@
+<VRTDataset rasterXSize="504" rasterYSize="454">
+  <SRS>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</SRS>
+  <GeoTransform>  6.3490506599999999e+05,  4.7627007652033447e-02,  0.0000000000000000e+00,  8.1392822900000000e+06,  0.0000000000000000e+00, -4.7657934423650940e-02</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">Area</MDI>
+    <MDI key="TIFFTAG_SOFTWARE">pix4dmapper</MDI>
+  </Metadata>
+  <VRTRasterBand dataType="Byte" band="1">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Red</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Green</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Blue</ColorInterp>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="4">
+    <NoDataValue>-10000</NoDataValue>
+    <ColorInterp>Alpha</ColorInterp>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -177,7 +177,7 @@ def test_no_error_when_bad_lc_ctype_but_bad_content():
     if sys.version_info[0] >= 3:
         return 'skip'
 
-    lc_ctype_current = os.environ['LC_CTYPE']
+    lc_ctype_current = os.environ.get('LC_CTYPE', "")
     os.environ['LC_CTYPE'] = "fr_FR.latin-1"
 
     ret =  _test_utf8(should_raise_unicode=False, content_ok=False)

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -651,8 +651,15 @@ gdal_vrtmerge.py -o merged.vrt %s""" % " ".join(self.args))
         # KML generation
         self.kml = self.options.kml
 
-        # Output the results
+        # LC_CTYPE check
+        if 'UTF-8' not in os.environ.get("LC_CTYPE", ""):
+            if not self.options.quiet:
+                print("\nWARNING: "
+                      "You are running gdal2tiles.py with a LC_CTYPE environment variable that is "
+                      "not UTF-8 compatible. The generated sample googlemaps, openlayers or "
+                      "leaflet files might contain some invalid characters as a result\n")
 
+        # Output the results
         if self.options.verbose:
             print("Options:", self.options)
             print("Input:", self.input)

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -1104,22 +1104,22 @@ gdal2tiles temp.vrt""" % self.input )
             # Generate googlemaps.html
             if self.options.webviewer in ('all','google') and self.options.profile == 'mercator':
                 if not self.options.resume or not os.path.exists(os.path.join(self.output, 'googlemaps.html')):
-                    f = open(os.path.join(self.output, 'googlemaps.html'), 'w')
-                    f.write( self.generate_googlemaps() )
+                    f = open(os.path.join(self.output, 'googlemaps.html'), 'wb')
+                    f.write( self.generate_googlemaps().encode('utf-8') )
                     f.close()
 
             # Generate openlayers.html
             if self.options.webviewer in ('all','openlayers'):
                 if not self.options.resume or not os.path.exists(os.path.join(self.output, 'openlayers.html')):
-                    f = open(os.path.join(self.output, 'openlayers.html'), 'w')
-                    f.write( self.generate_openlayers() )
+                    f = open(os.path.join(self.output, 'openlayers.html'), 'wb')
+                    f.write( self.generate_openlayers().encode('utf-8') )
                     f.close()
 
             # Generate leaflet.html
             if self.options.webviewer in ('all','leaflet'):
                 if not self.options.resume or not os.path.exists(os.path.join(self.output, 'leaflet.html')):
-                    f = open(os.path.join(self.output, 'leaflet.html'), 'w')
-                    f.write( self.generate_leaflet() )
+                    f = open(os.path.join(self.output, 'leaflet.html'), 'wb')
+                    f.write( self.generate_leaflet().encode('utf-8') )
                     f.close()
 
         elif self.options.profile == 'geodetic':
@@ -1133,8 +1133,8 @@ gdal2tiles temp.vrt""" % self.input )
             # Generate openlayers.html
             if self.options.webviewer in ('all','openlayers'):
                 if not self.options.resume or not os.path.exists(os.path.join(self.output, 'openlayers.html')):
-                    f = open(os.path.join(self.output, 'openlayers.html'), 'w')
-                    f.write( self.generate_openlayers() )
+                    f = open(os.path.join(self.output, 'openlayers.html'), 'wb')
+                    f.write( self.generate_openlayers().encode('utf-8') )
                     f.close()
 
         elif self.options.profile == 'raster':
@@ -1147,15 +1147,15 @@ gdal2tiles temp.vrt""" % self.input )
             # Generate openlayers.html
             if self.options.webviewer in ('all','openlayers'):
                 if not self.options.resume or not os.path.exists(os.path.join(self.output, 'openlayers.html')):
-                    f = open(os.path.join(self.output, 'openlayers.html'), 'w')
-                    f.write( self.generate_openlayers() )
+                    f = open(os.path.join(self.output, 'openlayers.html'), 'wb')
+                    f.write(self.generate_openlayers().encode('utf-8'))
                     f.close()
 
 
         # Generate tilemapresource.xml.
         if not self.options.resume or not os.path.exists(os.path.join(self.output, 'tilemapresource.xml')):
-            f = open(os.path.join(self.output, 'tilemapresource.xml'), 'w')
-            f.write( self.generate_tilemapresource())
+            f = open(os.path.join(self.output, 'tilemapresource.xml'), 'wb')
+            f.write( self.generate_tilemapresource().encode('utf-8') )
             f.close()
 
         if self.kml:
@@ -1169,8 +1169,8 @@ gdal2tiles temp.vrt""" % self.input )
             # Generate Root KML
             if self.kml:
                 if not self.options.resume or not os.path.exists(os.path.join(self.output, 'doc.kml')):
-                    f = open(os.path.join(self.output, 'doc.kml'), 'w')
-                    f.write( self.generate_kml( None, None, None, children) )
+                    f = open(os.path.join(self.output, 'doc.kml'), 'wb')
+                    f.write( self.generate_kml( None, None, None, children).encode('utf-8') )
                     f.close()
 
     # -------------------------------------------------------------------------
@@ -1336,8 +1336,8 @@ gdal2tiles temp.vrt""" % self.input )
                 if self.kml:
                     kmlfilename = os.path.join(self.output, str(tz), str(tx), '%d.kml' % ty)
                     if not self.options.resume or not os.path.exists(kmlfilename):
-                        f = open( kmlfilename, 'w')
-                        f.write( self.generate_kml( tx, ty, tz ))
+                        f = open( kmlfilename, 'wb')
+                        f.write(self.generate_kml( tx, ty, tz ).encode('utf-8'))
                         f.close()
 
                 if not self.options.verbose and not self.options.quiet:
@@ -1431,8 +1431,8 @@ gdal2tiles temp.vrt""" % self.input )
 
                     # Create a KML file for this tile.
                     if self.kml:
-                        f = open( os.path.join(self.output, '%d/%d/%d.kml' % (tz, tx, ty)), 'w')
-                        f.write( self.generate_kml( tx, ty, tz, children ) )
+                        f = open( os.path.join(self.output, '%d/%d/%d.kml' % (tz, tx, ty)), 'wb')
+                        f.write( self.generate_kml( tx, ty, tz, children ).encode('utf-8') )
                         f.close()
 
                     if not self.options.verbose and not self.options.quiet:

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -651,12 +651,21 @@ gdal_vrtmerge.py -o merged.vrt %s""" % " ".join(self.args))
         # KML generation
         self.kml = self.options.kml
 
+        # Check if the input filename is full ascii or not
+        try:
+          os.path.basename(self.input).encode('ascii')
+        except UnicodeEncodeError:
+          full_ascii = False
+        else:
+          full_ascii = True
+
         # LC_CTYPE check
-        if 'UTF-8' not in os.environ.get("LC_CTYPE", ""):
+        if not full_ascii and 'UTF-8' not in os.environ.get("LC_CTYPE", ""):
             if not self.options.quiet:
                 print("\nWARNING: "
                       "You are running gdal2tiles.py with a LC_CTYPE environment variable that is "
-                      "not UTF-8 compatible. The generated sample googlemaps, openlayers or "
+                      "not UTF-8 compatible, and your input file contains non-ascii characters. "
+                      "The generated sample googlemaps, openlayers or "
                       "leaflet files might contain some invalid characters as a result\n")
 
         # Output the results


### PR DESCRIPTION
I know there is a lot of spilled ink on the web on whether this construct
```python
reload(sys)
sys.setdefaultencoding('utf8')
```
should be used or not BUT

- in several hours of search, I could not make it work in any other way
- I have made the code optional (with the `--with-utf8` option) so that it's the user choice to activate it or not (--> no regression)
- My production tiling 1000+ images per month has been running without issues with this code for 6 months
- I have checked the consistency with the system `LC_CTYPE` env variable because both the code and the LC_CTYPE need to be set (AFAIK)

The only worry I have is windows. I can confirm it works on mac and linux (at least Ubuntu 14.04) but I don't have access to a windows machine. According to my research, `LC_CTYPE` does exist on Windows too, so we should be fine