### PR TITLE
fix(6795): handle requested tile at too low zoom to get any data

### DIFF
--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -135,10 +135,41 @@ def test_does_not_error_when_source_bounds_close_to_tiles_bound():
     return 'success'
 
 
+def test_does_not_error_when_nothing_to_put_in_the_low_zoom_tile():
+    """
+    Case when the highest zoom level asked is actually too low for any pixel of the raster to be
+    selected
+    """
+    in_file = './data/test_bounds_close_to_tile_bounds_x.vrt'
+    out_folder = 'tmp/out_gdal2tiles_bounds_approx'
+    try:
+        shutil.rmtree(out_folder)
+    except:
+        pass
+
+    script_path = test_py_scripts.get_py_script('gdal2tiles')
+    if script_path is None:
+        return 'skip'
+
+    try:
+        test_py_scripts.run_py_script(
+            script_path,
+            'gdal2tiles',
+            '-q -z 10 %s %s' % (in_file, out_folder))
+    except TypeError:
+        gdaltest.post_reason(
+            'Case of low level tile not getting any data not handled properly '
+            '(tile at a zoom level too low)')
+        return 'fail'
+
+    return 'success'
+
+
 gdaltest_list = [
     test_gdal2tiles_py_1,
     test_gdal2tiles_py_2,
     test_does_not_error_when_source_bounds_close_to_tiles_bound,
+    test_does_not_error_when_nothing_to_put_in_the_low_zoom_tile,
     test_gdal2tiles_py_cleanup,
     ]
 

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -1246,12 +1246,7 @@ gdal2tiles temp.vrt""" % self.input )
                 # to the native resolution (and return smaller query tile) for scaling
 
                 if self.options.profile in ('mercator','geodetic'):
-                    try:
-                        rb, wb = self.geo_query( ds, b[0], b[3], b[2], b[1])
-                    except Gdal2TilesError:
-                        if self.options.verbose:
-                            print("Nothing from the input to put in output ", b)
-                        continue
+                    rb, wb = self.geo_query( ds, b[0], b[3], b[2], b[1])
 
                     nativesize = wb[0]+wb[2] # Pixel size in the raster covering query geo extent
                     if self.options.verbose:
@@ -1302,7 +1297,7 @@ gdal2tiles temp.vrt""" % self.input )
                 data = alpha = None
                 # Read the source raster if anything is going inside the tile as per the computed
                 # geo_query
-                if wxsize != 0 and wysize != 0:
+                if rxsize != 0 and rysize != 0 and wxsize != 0 and wysize != 0:
                     data = ds.ReadRaster(rx, ry, rxsize, rysize, wxsize, wysize, band_list=list(range(1,self.dataBandsCount+1)))
                     alpha = self.alphaband.ReadRaster(rx, ry, rxsize, rysize, wxsize, wysize)
 
@@ -1486,11 +1481,6 @@ gdal2tiles temp.vrt""" % self.input )
         if ry+rysize > ds.RasterYSize:
             wysize = int( wysize * (float(ds.RasterYSize - ry) / rysize) )
             rysize = ds.RasterYSize - ry
-
-        # Following rounding, it is possible that less than 1 pixel (a fraction of a pixel) is
-        # actually meant for the tile requested (can happen on tiles close to a border of the image)
-        if rxsize == 0 or rysize == 0:
-            raise Gdal2TilesError("Nothing in this dataset fits in that query")
 
         return (rx, ry, rxsize, rysize), (wx, wy, wxsize, wysize)
 


### PR DESCRIPTION
So this does fix the issue and the result is one single empty tile as expected 

BUT
- error (warnings?) are still generated by the gdal library (`ERROR 5: Illegal values for buffer size`)
- it looks a lot like the previous issue I fixed with border tiles --> it looks to me like there is a more fundamental issue into how the tile range computed, the `ReadRaster` and the `WriteRaster` are handled. I'm going to continue to investigate that but I did to understand a lot better what those things are doing and how they are currently used.

So in the meantime, a fix, even if not likely not the best one.
