### PR TITLE
GeoJSON Driver: Add support of TopoJSON without 'transform' element.

### DIFF
--- a/autotest/ogr/data/topojson3.topojson
+++ b/autotest/ogr/data/topojson3.topojson
@@ -1,0 +1,11 @@
+{
+"type":"Topology",
+"arcs": [
+[[0.0, 0.0], [10, 0], [0, 10]]
+],
+"objects": {
+"a_layer" : {"type": "GeometryCollection", "geometries" : [ {"type": "LineString", "arcs": [0, -1] } ] },
+"foo" : {"type": "LineString", "arcs": [0, -1], "id" : "1" }
+}
+}
+

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -1183,6 +1183,25 @@ def ogr_geojson_25():
         return 'fail'
     ds = None
 
+    ds = ogr.Open('data/topojson3.topojson')
+    lyr = ds.GetLayer(0)
+    if lyr.GetName() != 'a_layer':
+        gdaltest.post_reason('failure')
+        return 'fail'
+    feat = lyr.GetNextFeature()
+    if ogrtest.check_feature_geometry(feat, 'LINESTRING (0 0,10 0,0 10,10 0,0 0)') != 0:
+        gdaltest.post_reason('failure')
+        return 'fail'
+    lyr = ds.GetLayer(1)
+    if lyr.GetName() != 'TopoJSON':
+        gdaltest.post_reason('failure')
+        return 'fail'
+    feat = lyr.GetNextFeature()
+    if ogrtest.check_feature_geometry(feat, 'LINESTRING (0 0,10 0,0 10,10 0,0 0)') != 0:
+        gdaltest.post_reason('failure')
+        return 'fail'
+    ds = None
+
     return 'success'
 
 ###############################################################################

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrtopojsonreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrtopojsonreader.cpp
@@ -89,6 +89,7 @@ typedef struct
     double dfScale1;
     double dfTranslate0;
     double dfTranslate1;
+    bool bElementExists;
 } ScalingParams;
 
 /************************************************************************/
@@ -138,10 +139,18 @@ static void ParseArc( OGRLineString* poLS, json_object* poArcsDB, int nArcID,
         double dfY = 0.0;
         if( ParsePoint( poPoint, &dfX, &dfY ) )
         {
-            dfAccX += dfX;
-            dfAccY += dfY;
-            dfX = dfAccX * psParams->dfScale0 + psParams->dfTranslate0;
-            dfY = dfAccY * psParams->dfScale1 + psParams->dfTranslate1;
+            if( psParams->bElementExists )
+            {
+                dfAccX += dfX;
+                dfAccY += dfY;
+                dfX = dfAccX * psParams->dfScale0 + psParams->dfTranslate0;
+                dfY = dfAccY * psParams->dfScale1 + psParams->dfTranslate1;
+            }
+            else
+            {
+                dfX = dfX * psParams->dfScale0 + psParams->dfTranslate0;
+                dfY = dfY * psParams->dfScale1 + psParams->dfTranslate1;
+            }
             if( i == 0 )
             {
                 if( !bReverse && poLS->getNumPoints() > 0 )
@@ -566,6 +575,7 @@ void OGRTopoJSONReader::ReadLayers( OGRGeoJSONDataSource* poDS )
     sParams.dfScale1 = 1.0;
     sParams.dfTranslate0 = 0.0;
     sParams.dfTranslate1 = 0.0;
+    sParams.bElementExists = false;
     json_object* poObjTransform =
         OGRGeoJSONFindMemberByName( poGJObject_, "transform" );
     if( NULL != poObjTransform &&
@@ -588,6 +598,7 @@ void OGRTopoJSONReader::ReadLayers( OGRGeoJSONDataSource* poDS )
             {
                 sParams.dfScale0 = json_object_get_double(poScale0);
                 sParams.dfScale1 = json_object_get_double(poScale1);
+                sParams.bElementExists = true;
             }
         }
 
@@ -610,6 +621,7 @@ void OGRTopoJSONReader::ReadLayers( OGRGeoJSONDataSource* poDS )
             {
                 sParams.dfTranslate0 = json_object_get_double(poTranslate0);
                 sParams.dfTranslate1 = json_object_get_double(poTranslate1);
+                sParams.bElementExists = true;
             }
         }
     }


### PR DESCRIPTION
A TopoJSON file without 'transform' element such as ['11-examples' in topojson-specification](https://github.com/topojson/topojson-specification#11-examples) should not be handled as delta-encoded.

I added the logic similar to [topojson-client: transform.js](https://github.com/topojson/topojson-client/blob/master/src/transform.js#L4).