### PR TITLE
ENVI Rotation Bug Fix

### DIFF
--- a/gdal/frmts/raw/envidataset.cpp
+++ b/gdal/frmts/raw/envidataset.cpp
@@ -1433,7 +1433,6 @@ bool ENVIDataset::ProcessMapinfo( const char *pszMapinfo )
     char **papszFields = SplitList(pszMapinfo);
     char *units = NULL;
     double rotation = 0.0;
-    const double PI = atan(1.0) * 4;
     const int nCount = CSLCount(papszFields);
 
     if( nCount < 7 )
@@ -1449,7 +1448,7 @@ bool ENVIDataset::ProcessMapinfo( const char *pszMapinfo )
             {
                 units = papszFields[i] + strlen("units=");
             } else if (strncmp(papszFields[i], "rotation=", strlen("rotation=")) == 0) {
-                rotation = CPLAtof(papszFields[i] + strlen("rotation=")) * (PI/180) * -1;
+                rotation = CPLAtof(papszFields[i] + strlen("rotation=")) * (M_PI/180) * -1;
             }
         }
     }


### PR DESCRIPTION
This pull request fixes the file `gdal/frmts/raw/envidataset.cpp` to correctly process rotated ENVI files as described on the [mailing list](https://lists.osgeo.org/pipermail/gdal-dev/2017-February/046127.html).

This change reads the `map info` section of the header to properly set `units` when it is not the last element of the list and to use the `rotation` specified in degrees to calculate the geotransform.

As requested, I have based this change off of `trunk` and used the `M_PI` constant.