### PR TITLE
Added DXF style attribute of TEXT and MTEXT to OGR style string

### DIFF
--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -207,7 +207,7 @@ def ogr_dxf_6():
         gdaltest.post_reason( 'not keeping 2D text as 2D' )
         return 'fail'
 
-    if feat.GetStyleString() != 'LABEL(f:"Arial",t:"Test",a:30,s:5g,p:7,c:#000000)':
+    if feat.GetStyleString() != 'LABEL(f:"normallatin1",t:"Test",a:30,s:5g,p:7,c:#000000)':
         print(feat.GetStyleString())
         gdaltest.post_reason( 'got wrong style string' )
         return 'fail'
@@ -299,7 +299,7 @@ def ogr_dxf_9():
         gdaltest.post_reason( 'Did not get expected first mtext.' )
         return 'fail'
 
-    expected_style = 'LABEL(f:"Arial",t:"'+gdaltest.sample_style+'",a:45,s:0.5g,p:5,c:#000000)'
+    expected_style = 'LABEL(f:"normallatin1",t:"'+gdaltest.sample_style+'",a:45,s:0.5g,p:5,c:#000000)'
     if feat.GetStyleString() != expected_style:
         gdaltest.post_reason( 'Got unexpected style string:\n%s\ninstead of:\n%s.' % (feat.GetStyleString(),expected_style) )
         return 'fail'
@@ -730,7 +730,7 @@ def ogr_dxf_16():
         gdaltest.post_reason( 'Did not get expected first mtext.' )
         return 'fail'
 
-    expected_style = 'LABEL(f:"Arial",t:"'+gdaltest.sample_style+'",a:45,s:0.5g,p:5,c:#000000)'
+    expected_style = 'LABEL(f:"normallatin1",t:"'+gdaltest.sample_style+'",a:45,s:0.5g,p:5,c:#000000)'
     if feat.GetStyleString() != expected_style:
         gdaltest.post_reason( 'Got unexpected style string:\n%s\ninstead of:\n%s.' % (feat.GetStyleString(),expected_style) )
         return 'fail'

--- a/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
@@ -478,6 +478,7 @@ OGRFeature *OGRDXFLayer::TranslateMTEXT()
     bool bHaveZ = false;
     int nAttachmentPoint = -1;
     CPLString osText;
+    CPLString styleName;
 
     while( (nCode = poDS->ReadValue(szLineBuf,sizeof(szLineBuf))) > 0 )
     {
@@ -522,6 +523,10 @@ OGRFeature *OGRDXFLayer::TranslateMTEXT()
 
           case 50:
             dfAngle = CPLAtof(szLineBuf);
+            break;
+
+          case 7:
+            styleName = TextUnescape(szLineBuf);
             break;
 
           default:
@@ -595,8 +600,13 @@ OGRFeature *OGRDXFLayer::TranslateMTEXT()
 /* -------------------------------------------------------------------- */
     CPLString osStyle;
     char szBuffer[64];
+    
+    if (styleName == "") 
+    {
+        styleName = "Arial";
+    }
 
-    osStyle.Printf("LABEL(f:\"Arial\",t:\"%s\"",osText.c_str());
+    osStyle.Printf("LABEL(f:\"%s\",t:\"%s\"", styleName.c_str(), osText.c_str());
 
     if( dfAngle != 0.0 )
     {
@@ -652,6 +662,7 @@ OGRFeature *OGRDXFLayer::TranslateTEXT()
     double dfAngle = 0.0;
     double dfHeight = 0.0;
     CPLString osText;
+    CPLString styleName;
     bool bHaveZ = false;
     int nAnchorPosition = 1;
     int nHorizontalAlignment = 0;
@@ -695,6 +706,10 @@ OGRFeature *OGRDXFLayer::TranslateTEXT()
             nVerticalAlignment = atoi(szLineBuf);
             break;
 
+          case 7:
+            styleName = TextUnescape(szLineBuf);
+            break;
+          
           default:
             TranslateGenericProperty( poFeature, nCode, szLineBuf );
             break;
@@ -804,8 +819,13 @@ OGRFeature *OGRDXFLayer::TranslateTEXT()
     CPLString osStyle;
     char szBuffer[64];
 
-    osStyle.Printf("LABEL(f:\"Arial\",t:\"%s\"",osText.c_str());
+    if (styleName == "") 
+    {
+        styleName = "Arial";
+    }
 
+    osStyle.Printf("LABEL(f:\"%s\",t:\"%s\"", styleName.c_str(), osText.c_str());
+    
     osStyle += CPLString().Printf(",p:%d", nAnchorPosition);
 
     if( dfAngle != 0.0 )

--- a/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
@@ -478,7 +478,7 @@ OGRFeature *OGRDXFLayer::TranslateMTEXT()
     bool bHaveZ = false;
     int nAttachmentPoint = -1;
     CPLString osText;
-    CPLString styleName;
+    CPLString osStyleName = "Arial";
 
     while( (nCode = poDS->ReadValue(szLineBuf,sizeof(szLineBuf))) > 0 )
     {
@@ -526,7 +526,7 @@ OGRFeature *OGRDXFLayer::TranslateMTEXT()
             break;
 
           case 7:
-            styleName = TextUnescape(szLineBuf);
+            osStyleName = TextUnescape(szLineBuf);
             break;
 
           default:
@@ -601,12 +601,7 @@ OGRFeature *OGRDXFLayer::TranslateMTEXT()
     CPLString osStyle;
     char szBuffer[64];
     
-    if (styleName == "") 
-    {
-        styleName = "Arial";
-    }
-
-    osStyle.Printf("LABEL(f:\"%s\",t:\"%s\"", styleName.c_str(), osText.c_str());
+    osStyle.Printf("LABEL(f:\"%s\",t:\"%s\"", osStyleName.c_str(), osText.c_str());
 
     if( dfAngle != 0.0 )
     {
@@ -662,7 +657,7 @@ OGRFeature *OGRDXFLayer::TranslateTEXT()
     double dfAngle = 0.0;
     double dfHeight = 0.0;
     CPLString osText;
-    CPLString styleName;
+    CPLString osStyleName = "Arial";
     bool bHaveZ = false;
     int nAnchorPosition = 1;
     int nHorizontalAlignment = 0;
@@ -707,7 +702,7 @@ OGRFeature *OGRDXFLayer::TranslateTEXT()
             break;
 
           case 7:
-            styleName = TextUnescape(szLineBuf);
+            osStyleName = TextUnescape(szLineBuf);
             break;
           
           default:
@@ -819,12 +814,7 @@ OGRFeature *OGRDXFLayer::TranslateTEXT()
     CPLString osStyle;
     char szBuffer[64];
 
-    if (styleName == "") 
-    {
-        styleName = "Arial";
-    }
-
-    osStyle.Printf("LABEL(f:\"%s\",t:\"%s\"", styleName.c_str(), osText.c_str());
+    osStyle.Printf("LABEL(f:\"%s\",t:\"%s\"", osStyleName.c_str(), osText.c_str());
     
     osStyle += CPLString().Printf(",p:%d", nAnchorPosition);
 


### PR DESCRIPTION
Added parsing of property 7 from TEXT and MTEXT DXF objects and printing it out to the "font" `f` property of style string.