### PR TITLE
Set nodata value on vrtsource allowing for unscale to not change it

### DIFF
--- a/gdal/apps/gdal_translate_lib.cpp
+++ b/gdal/apps/gdal_translate_lib.cpp
@@ -1425,6 +1425,13 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
             poSource->SetColorTableComponent(nComponent);
 
+            int bSuccess;
+            double dfNoData = poSrcBand->GetNoDataValue( &bSuccess );
+            if ( bSuccess )
+            {
+                poSource->SetNoDataValue(dfNoData);
+            } 
+
             poSimpleSource = poSource;
         }
         else


### PR DESCRIPTION
The NoData value is not currently passed through to the VRTComplexSource meaning that unscale operates on nodata pixels as well as those with valid values. This corrects that.

See https://trac.osgeo.org/gdal/ticket/3085 where this was discussed previously but not completely fixed.

Sample grid with nodata values in middle that needs to be unscaled: https://www.dropbox.com/s/edti8l67z6mqd5o/TIRC07_KNES_062357_PAI.nc?dl=0
Sample command: gdal_translate -unscale -ot float32 TIRC07_KNES_062357_PAI.nc test.tif