### PR TITLE
Unscale coordinates in netcdf if scaled

### DIFF
--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -3257,6 +3257,25 @@ void netCDFDataset::SetProjectionFromVar( int nVarId, bool bReadSRSOnly )
                     yMinMax[1] = dummy[1];
                 }
 
+                double dummyAdd, dummyScale;
+                if ( !nc_get_att_double(cdfid, nVarDimXID,
+                                       CF_ADD_OFFSET, &dummyAdd) &&
+                     !nc_get_att_double(cdfid, nVarDimXID,
+                                       CF_SCALE_FACTOR, &dummyScale) )
+                {
+                   xMinMax[0] = dummyAdd + xMinMax[0] * dummyScale;
+                   xMinMax[1] = dummyAdd + xMinMax[1] * dummyScale;
+                }
+
+                if ( !nc_get_att_double(cdfid, nVarDimYID,
+                                       CF_ADD_OFFSET, &dummyAdd) &&
+                     !nc_get_att_double(cdfid, nVarDimYID,
+                                       CF_SCALE_FACTOR, &dummyScale) )
+                {
+                   yMinMax[0] = dummyAdd + yMinMax[0] * dummyScale;
+                   yMinMax[1] = dummyAdd + yMinMax[1] * dummyScale;
+                }
+
                 adfTempGeoTransform[0] = xMinMax[0];
                 adfTempGeoTransform[2] = 0;
                 adfTempGeoTransform[3] = yMinMax[1];


### PR DESCRIPTION
NOAA recently started serving NetCDF files from the new GOES-16 (GOES-R) satellite. These files have add offset & scale factors on the coordinate information which needs to be accounted for in order to properly geolocate the data. This PR does that.

Sample data: https://www.dropbox.com/s/edti8l67z6mqd5o/TIRC07_KNES_062357_PAI.nc?dl=0
