### PR TITLE
Retrieve s57 geometric attributes posacc and quapos

### DIFF
--- a/gdal/ogr/ogrsf_frmts/s57/s57featuredefns.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/s57featuredefns.cpp
@@ -265,6 +265,15 @@ S57GenerateVectorPrimitiveFeatureDefn( int nRCNM,
 
     oField.Set( "RUIN", OFTInteger, 2, 0 );
     poFDefn->AddFieldDefn( &oField );
+	
+/* -------------------------------------------------------------------- */
+/*      Geometric primitive attributes                                  */
+/* -------------------------------------------------------------------- */	
+	oField.Set( "POSACC", OFTReal, 10, 2 );
+	poFDefn->AddFieldDefn( &oField );
+
+	oField.Set( "QUAPOS", OFTInteger, 2, 0 );
+	poFDefn->AddFieldDefn( &oField );
 
 /* -------------------------------------------------------------------- */
 /*      For lines we want to capture the point links for the first      */

--- a/gdal/ogr/ogrsf_frmts/s57/s57featuredefns.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/s57featuredefns.cpp
@@ -269,11 +269,11 @@ S57GenerateVectorPrimitiveFeatureDefn( int nRCNM,
 /* -------------------------------------------------------------------- */
 /*      Geometric primitive attributes                                  */
 /* -------------------------------------------------------------------- */	
-	oField.Set( "POSACC", OFTReal, 10, 2 );
-	poFDefn->AddFieldDefn( &oField );
+    oField.Set( "POSACC", OFTReal, 10, 2 );
+    poFDefn->AddFieldDefn( &oField );
 
-	oField.Set( "QUAPOS", OFTInteger, 2, 0 );
-	poFDefn->AddFieldDefn( &oField );
+    oField.Set( "QUAPOS", OFTInteger, 2, 0 );
+    poFDefn->AddFieldDefn( &oField );
 
 /* -------------------------------------------------------------------- */
 /*      For lines we want to capture the point links for the first      */

--- a/gdal/ogr/ogrsf_frmts/s57/s57reader.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/s57reader.cpp
@@ -1506,7 +1506,30 @@ OGRFeature *S57Reader::ReadVector( int nFeatureId, int nRCNM )
                              poRecord->GetIntSubfield("VRPT",iField,
                              "MASK",iSubField) );
     }
+	
+/* -------------------------------------------------------------------- */
+/*      Geometric attributes                                            */
+/*      Retrieve POSACC and QUAPOS attributes                           */
+/* -------------------------------------------------------------------- */
 
+	const int posaccField = poRegistrar->FindAttrByAcronym("POSACC");
+	const int quaposField = poRegistrar->FindAttrByAcronym("QUAPOS");
+	
+	DDFField * field = poRecord->GetField(i);
+	for( int j = 0; j < field->GetRepeatCount(); j++ ) {
+		// POSACC field
+		if (poRecord->GetIntSubfield("ATTV",0,"ATTL",j) == posaccField) {
+            poFeature->SetField( "POSACC",
+                                poRecord->GetFloatSubfield("ATTV",0,"ATVL",j) );
+		}
+	
+		// QUAPOS field
+		if (poRecord->GetIntSubfield("ATTV",0,"ATTL",j) == quaposField) {
+			poFeature->SetField( "QUAPOS",
+                            poRecord->GetFloatSubfield("ATTV",0,"ATVL",j) );
+		}
+	}
+	
     return poFeature;
 }
 

--- a/gdal/ogr/ogrsf_frmts/s57/s57reader.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/s57reader.cpp
@@ -1506,30 +1506,33 @@ OGRFeature *S57Reader::ReadVector( int nFeatureId, int nRCNM )
                              poRecord->GetIntSubfield("VRPT",iField,
                              "MASK",iSubField) );
     }
-	
+
 /* -------------------------------------------------------------------- */
 /*      Geometric attributes                                            */
 /*      Retrieve POSACC and QUAPOS attributes                           */
 /* -------------------------------------------------------------------- */
 
-	const int posaccField = poRegistrar->FindAttrByAcronym("POSACC");
-	const int quaposField = poRegistrar->FindAttrByAcronym("QUAPOS");
-	
-	DDFField * field = poRecord->GetField(i);
-	for( int j = 0; j < field->GetRepeatCount(); j++ ) {
-		// POSACC field
-		if (poRecord->GetIntSubfield("ATTV",0,"ATTL",j) == posaccField) {
-            poFeature->SetField( "POSACC",
-                                poRecord->GetFloatSubfield("ATTV",0,"ATVL",j) );
-		}
-	
-		// QUAPOS field
-		if (poRecord->GetIntSubfield("ATTV",0,"ATTL",j) == quaposField) {
-			poFeature->SetField( "QUAPOS",
-                            poRecord->GetFloatSubfield("ATTV",0,"ATVL",j) );
-		}
-	}
-	
+    const int posaccField = poRegistrar->FindAttrByAcronym("POSACC");
+    const int quaposField = poRegistrar->FindAttrByAcronym("QUAPOS");
+
+    for( int i = 0; i < poRecord->GetFieldCount(); ++i ) {
+        DDFField * field = poRecord->GetField(i);
+        for( int j = 0; j < field->GetRepeatCount(); j++ ) {
+            const int subField = poRecord->GetIntSubfield("ATTV",0,"ATTL",j);
+            // POSACC field
+            if (subField == posaccField) {
+                poFeature->SetField( "POSACC",
+                                    poRecord->GetFloatSubfield("ATTV",0,"ATVL",j) );
+            }
+
+            // QUAPOS field
+            if (subField == quaposField) {
+                poFeature->SetField( "QUAPOS",
+                                    poRecord->GetIntSubfield("ATTV",0,"ATVL",j) );
+            }
+        }
+    }
+
     return poFeature;
 }
 


### PR DESCRIPTION
Hi

I propose a s57 reader update to retrieve posacc and quapos geometric attributes on primitives Edge, Connected Point and Isolated Point.

POSACC and QUAPOS are defined in `gpapszS57attributes` (`gdal/ogr/ogrsf_frmts/s57/s57tables.h`) : 
```
"401,Positional Accuracy,POSACC,F,S",
"402,Quality of position,QUAPOS,E,S",
```

For example : 
```
ogr2ogr -oo "RETURN_PRIMITIVES=ON" 
	-oo "RETURN_LINKAGES=ON" 
	-oo "LNAM_REFS=ON" 
	-nlt "MULTIPOINT" 
	-skipfailures
	isolatednode-point.shp
	file.000 
	IsolatedNode
```
		
Thanks for your feedbacks on it !		