### PR TITLE
Vagrant: Add lxc provider support

### DIFF
--- a/gdal/Vagrantfile
+++ b/gdal/Vagrantfile
@@ -7,27 +7,34 @@ require 'socket'
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-
+  # specify memory size in MiB
   vm_ram = ENV['VAGRANT_VM_RAM'] || 2048
   vm_cpu = ENV['VAGRANT_VM_CPU'] || 2
-
-  config.vm.box = "precise64"
+  vm_ram_bytes = vm_ram * 1024 * 1024
 
   config.vm.hostname = "gdal-vagrant"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.host_name = "gdal-vagrant"
-
-  config.vm.network :forwarded_port, guest: 80, host: 8080
 
   config.vm.synced_folder "../autotest/", "/home/vagrant/autotest/"
 
-  config.vm.provider :virtualbox do |vb|
+  config.vm.provider :virtualbox do |vb,ovrd|
+     ovrd.vm.network :forwarded_port, guest: 80, host: 8080
+     ovrd.vm.box = "precise64"
+     ovrd.vm.box_url = "http://files.vagrantup.com/precise64.box"
      vb.customize ["modifyvm", :id, "--memory", vm_ram]
      vb.customize ["modifyvm", :id, "--cpus", vm_cpu]
      vb.customize ["modifyvm", :id, "--ioapic", "on"]
      vb.name = "gdal-vagrant"
-   end
+  end
 
+  config.vm.provider :lxc do |lxc,ovrd|
+    ovrd.vm.box = "fgrehm/precise64-lxc"
+    lxc.backingstore = 'dir'
+    lxc.customize 'cgroup.memory.limit_in_bytes', vm_ram_bytes
+    lxc.customize 'aa_allow_incomplete', 1
+    lxc.container_name = "gdal-vagrant"
+  end
+ 
   ppaRepos = [
     "ppa:ubuntugis/ubuntugis-unstable", "ppa:marlam/gta"
   ]
@@ -88,11 +95,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     "mono-mcs"
   ];
 
-  unless File.exists?(".no_apt_cache")
-    cache_dir = "apt-cache/#{config.vm.box}"
-    FileUtils.mkdir_p(cache_dir) unless Dir.exists?(cache_dir)
-    puts "Using local apt cache, #{cache_dir}"
-    config.vm.synced_folder cache_dir, "/var/cache/apt/archives"
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
   end
 
   if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/default/*/id").empty?

--- a/gdal/scripts/vagrant/gdal.sh
+++ b/gdal/scripts/vagrant/gdal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # abort install if any errors occur and enable tracing
 set -o errexit

--- a/gdal/scripts/vagrant/libkml.sh
+++ b/gdal/scripts/vagrant/libkml.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # abort install if any errors occur and enable tracing
 set -o errexit

--- a/gdal/scripts/vagrant/openjpeg.sh
+++ b/gdal/scripts/vagrant/openjpeg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # abort install if any errors occur and enable tracing
 set -o errexit
@@ -12,7 +12,7 @@ fi
 #NUMTHREADS=1 # disable MP
 export NUMTHREADS
 
-wget http://sourceforge.net/projects/openjpeg.mirror/files/openjpeg-2.0.0.tar.gz/download -O openjpeg-2.0.0.tar.gz
+wget --no-check-certificate https://sourceforge.net/projects/openjpeg.mirror/files/openjpeg-2.0.0.tar.gz/download -O openjpeg-2.0.0.tar.gz
 tar xvzf openjpeg-2.0.0.tar.gz
 cd openjpeg-2.0.0
 mkdir build

--- a/gdal/scripts/vagrant/sfcgal.sh
+++ b/gdal/scripts/vagrant/sfcgal.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Build CGAL
 wget https://gforge.inria.fr/frs/download.php/file/34400/CGAL-4.5.1.tar.gz
 tar xf CGAL-4.5.1.tar.gz

--- a/gdal/scripts/vagrant/swig-1.3.40.sh
+++ b/gdal/scripts/vagrant/swig-1.3.40.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # abort install if any errors occur and enable tracing
 set -o errexit
@@ -12,7 +12,7 @@ fi
 #NUMTHREADS=1 # disable MP
 export NUMTHREADS
 
-wget "http://downloads.sourceforge.net/project/swig/swig/swig-1.3.40/swig-1.3.40.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fswig%2Ffiles%2Fswig%2Fswig-1.3.40%2F&ts=1425900154&use_mirror=freefr" -O swig-1.3.40.tar.gz
+wget --no-check-certificate https://sourceforge.net/projects/swig/files/swig/swig-1.3.40/swig-1.3.40.tar.gz/download -O swig-1.3.40.tar.gz
 tar xvzf swig-1.3.40.tar.gz
 cd  swig-1.3.40
 ./configure --prefix=$HOME/install-swig-1.3.40


### PR DESCRIPTION
-Add LXC provider support.
-Package cache control by vagrant-cachier plugin.
-Only bash,ksh or zsh can support double bracket,
 /bin/sh that can be an another shell.
-Fix download link URL for sourceforge.net.

Ubuntu 16.04 LTS includes vagrant-lxc and vagrant-cachier as package.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>