### PR TITLE
Fix WMTS tile width & height limits

### DIFF
--- a/gdal/frmts/wmts/wmtsdataset.cpp
+++ b/gdal/frmts/wmts/wmtsdataset.cpp
@@ -738,8 +738,8 @@ int WMTSDataset::ReadTMS(CPLXMLNode* psContents,
             }
             oTM.nTileWidth = atoi(pszTileWidth);
             oTM.nTileHeight = atoi(pszTileHeight);
-            if( oTM.nTileWidth < 128 || oTM.nTileWidth > 4096 ||
-                oTM.nTileHeight < 128 || oTM.nTileHeight > 4096 )
+            if( oTM.nTileWidth <= 0 || oTM.nTileWidth > 4096 ||
+                oTM.nTileHeight <= 0 || oTM.nTileHeight > 4096 )
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Invalid TileWidth/TileHeight element");


### PR DESCRIPTION
Hi!
[OpenGIS Web Map Tile Service Implementation Standard](http://portal.opengeospatial.org/files/?artifact_id=35326) (p. 27, Table 14) says: tileWidth & tileHeight is "positive integer type", but in GDAL lower bound is 128.
Our customers have a service with a tile size equal to 64.It can't be accessed via GDAL-based applications.