### PR TITLE
Check for null before accessing img nodata values

### DIFF
--- a/gdal/alg/gdalapplyverticalshiftgrid.cpp
+++ b/gdal/alg/gdalapplyverticalshiftgrid.cpp
@@ -479,9 +479,6 @@ GDALDatasetH GDALApplyVerticalShiftGrid( GDALDatasetH hSrcDataset,
         psWO->padfSrcNoDataReal =
                 static_cast<double*>(CPLMalloc(sizeof(double)));
         psWO->padfSrcNoDataReal[0] = dfSrcNoData;
-        psWO->padfSrcNoDataImag =
-                static_cast<double*>(CPLMalloc(sizeof(double)));
-        psWO->padfSrcNoDataImag[0] = 0.0;
     }
 
     psWO->padfDstNoDataReal = static_cast<double*>(CPLMalloc(sizeof(double)));
@@ -490,8 +487,6 @@ GDALDatasetH GDALApplyVerticalShiftGrid( GDALDatasetH hSrcDataset,
                                               false );
     psWO->padfDstNoDataReal[0] = 
         (bErrorOnMissingShift) ? -std::numeric_limits<float>::infinity() : 0.0;
-    psWO->padfDstNoDataImag = static_cast<double*>(CPLMalloc(sizeof(double)));
-    psWO->padfDstNoDataImag[0] = 0.0;
     psWO->papszWarpOptions = CSLSetNameValue(psWO->papszWarpOptions,
                                                  "INIT_DEST",
                                                  "NO_DATA");

--- a/gdal/alg/gdalwarper.cpp
+++ b/gdal/alg/gdalwarper.cpp
@@ -185,13 +185,10 @@ GDALReprojectImage( GDALDatasetH hSrcDS, const char *pszSrcWKT,
             {
                 psWOptions->padfSrcNoDataReal = static_cast<double *>(
                     CPLMalloc(sizeof(double) * psWOptions->nBandCount));
-                psWOptions->padfSrcNoDataImag = static_cast<double *>(
-                    CPLMalloc(sizeof(double) * psWOptions->nBandCount));
 
                 for( int ii = 0; ii < psWOptions->nBandCount; ii++ )
                 {
                     psWOptions->padfSrcNoDataReal[ii] = -1.1e20;
-                    psWOptions->padfSrcNoDataImag[ii] = 0.0;
                 }
             }
 
@@ -212,13 +209,10 @@ GDALReprojectImage( GDALDatasetH hSrcDS, const char *pszSrcWKT,
             {
                 psWOptions->padfDstNoDataReal = static_cast<double *>(
                     CPLMalloc(sizeof(double) * psWOptions->nBandCount));
-                psWOptions->padfDstNoDataImag = static_cast<double *>(
-                    CPLMalloc(sizeof(double) * psWOptions->nBandCount));
 
                 for( int ii = 0; ii < psWOptions->nBandCount; ii++ )
                 {
                     psWOptions->padfDstNoDataReal[ii] = -1.1e20;
-                    psWOptions->padfDstNoDataImag[ii] = 0.0;
                 }
             }
 

--- a/gdal/alg/gdalwarpoperation.cpp
+++ b/gdal/alg/gdalwarpoperation.cpp
@@ -1431,7 +1431,10 @@ CPLErr GDALWarpOperation::WarpRegion( int nDstXOff, int nDstYOff,
                 && psOptions->padfDstNoDataReal != NULL )
             {
                 adfInitRealImag[0] = psOptions->padfDstNoDataReal[iBand];
-                adfInitRealImag[1] = psOptions->padfDstNoDataImag[iBand];
+                if( psOptions->padfDstNoDataImag != NULL )
+                {
+                    adfInitRealImag[1] = psOptions->padfDstNoDataImag[iBand];
+                }
             }
             else
             {
@@ -2045,7 +2048,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
                 double adfNoData[2] =
                 {
                     psOptions->padfDstNoDataReal[iBand],
-                    psOptions->padfDstNoDataImag[iBand]
+                    psOptions->padfDstNoDataImag != NULL ? psOptions->padfDstNoDataImag[iBand] : 0.0
                 };
 
                 int bAllValid = FALSE;

--- a/gdal/alg/gdalwarpoperation.cpp
+++ b/gdal/alg/gdalwarpoperation.cpp
@@ -320,15 +320,6 @@ int GDALWarpOperation::ValidateOptions()
         return FALSE;
     }
 
-    if( psOptions->padfSrcNoDataReal != NULL
-        && psOptions->padfSrcNoDataImag == NULL )
-    {
-        CPLError( CE_Failure, CPLE_IllegalArg,
-                  "GDALWarpOptions.Validate(): "
-                  "padfSrcNoDataReal set, but padfSrcNoDataImag not set." );
-        return FALSE;
-    }
-
     if( psOptions->pfnProgress == NULL )
     {
         CPLError( CE_Failure, CPLE_IllegalArg,
@@ -1919,7 +1910,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
                 double adfNoData[2] =
                 {
                     psOptions->padfSrcNoDataReal[i2],
-                    psOptions->padfSrcNoDataImag[i2]
+                    psOptions->padfSrcNoDataImag != NULL ? psOptions->padfSrcNoDataImag[i2] : 0.0
                 };
 
                 int bAllValid = FALSE;

--- a/gdal/apps/gdalwarp_lib.cpp
+++ b/gdal/apps/gdalwarp_lib.cpp
@@ -1405,8 +1405,6 @@ GDALDatasetH GDALWarp( const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
                 }
                 psWO->padfSrcNoDataReal = (double *)
                     CPLMalloc(psWO->nBandCount*sizeof(double));
-                psWO->padfSrcNoDataImag = (double *)
-                    CPLMalloc(psWO->nBandCount*sizeof(double));
 
                 for( int i = 0; i < psWO->nBandCount; i++ )
                 {
@@ -1417,12 +1415,10 @@ GDALDatasetH GDALWarp( const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
                     if( bHaveNodata )
                     {
                         psWO->padfSrcNoDataReal[i] = dfReal;
-                        psWO->padfSrcNoDataImag[i] = 0.0;
                     }
                     else
                     {
                         psWO->padfSrcNoDataReal[i] = -123456.789;
-                        psWO->padfSrcNoDataImag[i] = 0.0;
                     }
                 }
             }
@@ -1532,8 +1528,6 @@ GDALDatasetH GDALWarp( const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
             {
                 psWO->padfDstNoDataReal = (double *)
                     CPLMalloc(psWO->nBandCount*sizeof(double));
-                psWO->padfDstNoDataImag = (double *)
-                    CPLCalloc(psWO->nBandCount, sizeof(double));
                 for( int i = 0; i < psWO->nBandCount; i++ )
                 {
                     GDALRasterBandH hBand = GDALGetRasterBand( hDstDS, i+1 );
@@ -1550,8 +1544,12 @@ GDALDatasetH GDALWarp( const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
         {
             psWO->padfDstNoDataReal = (double *)
                 CPLMalloc(psWO->nBandCount*sizeof(double));
-            psWO->padfDstNoDataImag = (double *)
-                CPLMalloc(psWO->nBandCount*sizeof(double));
+
+            if( psWO->padfSrcNoDataImag != NULL)
+            {
+                psWO->padfDstNoDataImag = (double *)
+                    CPLMalloc(psWO->nBandCount*sizeof(double));
+            }
 
             if( !psOptions->bQuiet )
                 printf( "Copying nodata values from source %s to destination %s.\n",
@@ -1560,7 +1558,10 @@ GDALDatasetH GDALWarp( const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
             for( int i = 0; i < psWO->nBandCount; i++ )
             {
                 psWO->padfDstNoDataReal[i] = psWO->padfSrcNoDataReal[i];
-                psWO->padfDstNoDataImag[i] = psWO->padfSrcNoDataImag[i];
+                if( psWO->padfSrcNoDataImag != NULL)
+                {
+                    psWO->padfDstNoDataImag[i] = psWO->padfSrcNoDataImag[i];
+                }
                 CPLDebug("WARP", "srcNoData=%f dstNoData=%f",
                             psWO->padfSrcNoDataReal[i], psWO->padfDstNoDataReal[i] );
 

--- a/gdal/frmts/vrt/vrtwarped.cpp
+++ b/gdal/frmts/vrt/vrtwarped.cpp
@@ -1537,7 +1537,10 @@ CPLErr VRTWarpedDataset::ProcessBlock( int iBlockX, int iBlockY )
                 && psWO->padfDstNoDataReal != NULL )
             {
                 adfInitRealImag[0] = psWO->padfDstNoDataReal[iBand];
-                adfInitRealImag[1] = psWO->padfDstNoDataImag[iBand];
+                if( psWO->padfDstNoDataImag != NULL )
+                {
+                    adfInitRealImag[1] = psWO->padfDstNoDataImag[iBand];
+                }
             }
             else
             {

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -4082,14 +4082,10 @@ GDALDataset* GDALGeoPackageDataset::CreateCopy( const char *pszFilename,
         psWO->padfSrcNoDataReal =
             static_cast<double*>(CPLMalloc(sizeof(double)));
         psWO->padfSrcNoDataReal[0] = dfNoDataValue;
-        psWO->padfSrcNoDataImag = static_cast<double*>(
-                CPLCalloc(1, sizeof(double)));
 
         psWO->padfDstNoDataReal =
             static_cast<double*>(CPLMalloc(sizeof(double)));
         psWO->padfDstNoDataReal[0] = dfNoDataValue;
-        psWO->padfDstNoDataImag = static_cast<double*>(
-                CPLCalloc(1, sizeof(double)));
     }
     psWO->eWorkingDataType = eDT;
     psWO->eResampleAlg = eResampleAlg;


### PR DESCRIPTION
Gdal documentation says, "The "nodata" value imaginary component - may be NULL even if real component is provided. "

I found a couple null derefs due to providing a real component with no imaginary.

http://www.gdal.org/structGDALWarpOptions.html#a1848d03a0deb1194a31e75a5b102a662