### PR TITLE
Fixed a small typo in CPLReleaseMutex

### DIFF
--- a/gdal/port/cpl_multiproc.cpp
+++ b/gdal/port/cpl_multiproc.cpp
@@ -503,7 +503,7 @@ void CPLReleaseMutex( CPLMutex * /* hMutex */ ) {}
 #else
 void CPLReleaseMutex( CPLMutex *hMutex )
 {
-    unsigned char *pabyMutex = retinterpret_cast<unsigned char *>(hMutex);
+    unsigned char *pabyMutex = reinterpret_cast<unsigned char *>(hMutex);
 
     CPLAssert( pabyMutex[1] == 'r' && pabyMutex[2] == 'e'
                && pabyMutex[3] == 'd' );


### PR DESCRIPTION
Fixed a small typo with `reinterpret_cast` in `CPLReleaseMutex` that was causing a build failure.