### PR TITLE
Use latestWkid when reading ESRI GeoJSON

### DIFF
--- a/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
@@ -993,7 +993,9 @@ OGRSpatialReference* OGRESRIJSONReadSpatialReference( json_object* poObj )
         OGRGeoJSONFindMemberByName( poObj, "spatialReference" );
     if( NULL != poObjSrs )
     {
-        json_object* poObjWkid = OGRGeoJSONFindMemberByName( poObjSrs, "wkid" );
+        json_object* poObjWkid = OGRGeoJSONFindMemberByName( poObjSrs, "latestWkid" );
+        if( poObjWkid == NULL )
+            poObjWkid =OGRGeoJSONFindMemberByName( poObjSrs, "wkid" );
         if( poObjWkid == NULL )
         {
             json_object* poObjWkt =

--- a/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
@@ -995,7 +995,7 @@ OGRSpatialReference* OGRESRIJSONReadSpatialReference( json_object* poObj )
     {
         json_object* poObjWkid = OGRGeoJSONFindMemberByName( poObjSrs, "latestWkid" );
         if( poObjWkid == NULL )
-            poObjWkid =OGRGeoJSONFindMemberByName( poObjSrs, "wkid" );
+            poObjWkid = OGRGeoJSONFindMemberByName( poObjSrs, "wkid" );
         if( poObjWkid == NULL )
         {
             json_object* poObjWkt =


### PR DESCRIPTION
I have noticed ESRI ArcGIS servers will return the spatial reference as an ESRI well-known ID in preference to the standard EPSG code. For example, a web mercator service returns 102100 instead of 3857:

```
"spatialReference": {
  "wkid": 102100,
  "latestWkid": 3857
}
```

This can still happen if the request includes a specific code via the `outSR` parameter. For example, when features are requested in SA Lambert with `&outSR=3107` as URL parameter, the response uses an ESRI equivalent 102172 code:

```
"spatialReference": {
  "wkid": 102172,
  "latestWkid": 3107
}
```

This situation causes problems because a standard GDAL installation does not know about the ESRI codes, so the spatial reference for the data is lost. However, as can be seen, the standard code is also returned as `latestWkid`. (This apparently occurs for ArcGIS Server 10.1 and newer.)

This small patch addresses this issue by retrieving and using the `latestWkid` member in preference to `wkid`, if it is present in the response.
