### PR TITLE
Added RawCodeValues field to DXF features

### DIFF
--- a/gdal/ogr/ogrsf_frmts/dxf/ogrdxfdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogrdxfdatasource.cpp
@@ -648,6 +648,9 @@ void OGRDXFDataSource::AddStandardFields( OGRFeatureDefn *poFeatureDefn )
     OGRFieldDefn  oTextField( "Text", OFTString );
     poFeatureDefn->AddFieldDefn( &oTextField );
 
+    OGRFieldDefn  oRawCodeValuesField( "RawCodeValues", OFTString );
+    poFeatureDefn->AddFieldDefn( &oRawCodeValuesField );
+
     if( !bInlineBlocks )
     {
         OGRFieldDefn  oBlockNameField( "BlockName", OFTString );

--- a/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
@@ -34,7 +34,7 @@
 
 #include <cmath>
 
-CPL_CVSID("$Id$")
+CPL_CVSID("$Id$");
 
 /************************************************************************/
 /*                            OGRDXFLayer()                             */
@@ -1055,8 +1055,11 @@ OGRFeature *OGRDXFLayer::TranslateLWPOLYLINE()
     int nNumVertices = 1;   // use 1 based index
     int npolyarcVertexCount = 1;
     double dfBulge = 0.0;
+    double dfConstantWidth = 0.0;
     DXFSmoothPolyline smoothPolyline;
 
+    CPLString osRawCodeValuesBuf;
+    
     smoothPolyline.setCoordinateDimension(2);
 
 /* -------------------------------------------------------------------- */
@@ -1116,6 +1119,10 @@ OGRFeature *OGRDXFLayer::TranslateLWPOLYLINE()
             dfBulge = CPLAtof(szLineBuf);
             break;
 
+          case 43:
+            dfConstantWidth = CPLAtof(szLineBuf);
+            break;
+
           default:
             TranslateGenericProperty( poFeature, nCode, szLineBuf );
             break;
@@ -1152,6 +1159,19 @@ OGRFeature *OGRDXFLayer::TranslateLWPOLYLINE()
 
     PrepareLineStyle( poFeature );
 
+/* -------------------------------------------------------------------- */
+/*      Prepare RawCodeValues property.                                 */
+/* -------------------------------------------------------------------- */
+
+    if( dfConstantWidth > 0.0 )
+    {
+        char szBuffer[64];
+        CPLsnprintf(szBuffer, sizeof(szBuffer), "%.6g", dfConstantWidth);
+        osRawCodeValuesBuf += CPLString().Printf( "43=%s", szBuffer );
+    }
+
+    poFeature->SetField( "RawCodeValues", TextUnescape(osRawCodeValuesBuf) );
+    
     return poFeature;
 }
 


### PR DESCRIPTION
RawCodeValues is a string to store all DXF properties that aren't handled as other standard OGR fields in form of `code=value[,code=value]`.
Added DXF code 43 (Constant width) for LWPOLYLINE objects to RawCodeValues field.