### PR TITLE
Fix Jasper build error

### DIFF
--- a/gdal/frmts/jpeg2000/jpeg2000_vsil_io.cpp
+++ b/gdal/frmts/jpeg2000/jpeg2000_vsil_io.cpp
@@ -212,7 +212,7 @@ static void JPEG2000_VSIL_jas_stream_initbuf(jas_stream_t *stream, int bufmode, 
             /* The buffer must be large enough to accommodate maximum
                putback. */
             assert(bufsize > JAS_STREAM_MAXPUTBACK);
-            stream->bufbase_ = JAS_CAST(uchar *, buf);
+            stream->bufbase_ = JAS_CAST(unsigned char *, buf);
             stream->bufsize_ = bufsize - JAS_STREAM_MAXPUTBACK;
         }
     } else {


### PR DESCRIPTION
Newer versions of Jasper no longer define `uchar` but instead define it as `jas_uchar`. Since it's just a macro for `unsigned char` anyways, might as well use the built in type.