### PR TITLE
Change default 'BIGTIFF_OVERVIEW' value from 'IF_NEEDED' to 'IF_SAFER'

### DIFF
--- a/gdal/frmts/gtiff/gt_overview.cpp
+++ b/gdal/frmts/gtiff/gt_overview.cpp
@@ -593,7 +593,7 @@ GTIFFBuildOverviews( const char * pszFilename,
         const char *pszBIGTIFF = CPLGetConfigOption( "BIGTIFF_OVERVIEW", NULL );
 
         if( pszBIGTIFF == NULL )
-            pszBIGTIFF = "IF_NEEDED";
+            pszBIGTIFF = "IF_SAFER";
 
         bool bCreateBigTIFF = false;
         if( EQUAL(pszBIGTIFF,"IF_NEEDED") )


### PR DESCRIPTION
Hello!

I'm change default 'BIGTIFF_OVERVIEW' value from 'IF_NEEDED' to 'IF_SAFER'.
This is more convenient for usage. Because for large rasters with compression with the option 'BIGTIFF_OVERVIEW'='IF_NEEDED', an inappropriate format of TIFF (no bigtiff) is selected and GTIFFBuildOverviews produces corrupted file.