### PR TITLE
Fix PIAPRD location

### DIFF
--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -608,7 +608,7 @@
         </loop>
     </tre>
 
-    <tre name="PIAPRD" minlength="201" maxlength="63759" location="image">
+    <tre name="PIAPRD" minlength="201" maxlength="63759" location="file">
         <field name="ACCESSID" length="64" type="string"/>
         <field name="FMCONTROL" length="32" type="string"/>
         <field name="SUBDET" length="1" type="string"/>


### PR DESCRIPTION
Matt Parker (Endoxa US) reported this problem (and provided the fix) on the Codice Imaging variant of this file.

The relevant spec is STDI-0002 Vol 1 Appendix C, which states:

> C.2 Profile for Imagery Access Product Support Extension - Version D
> The data found in the Product Support Extension addresses information regarding the products derived from source imagery. While there is product-related data in the NITF main header and SDEs, many fields contained in the Standards Profile for Imagery Access (SPIA) are absent. This extension aligns the SPIA and NITF for product information, and adds descriptive detail associated with products. This extension shall be present no more than once for each product. When present, this extension shall be contained within the extended header data field of the NITF file header or within an overflow DES if there is insufficient room to place the entire extension within the file’s extended header data field.

I recognise that this value probably isn't important to GDAL, but I'd still like to keep it consistent and correct where possible.