### PR TITLE
OCI: check view with unquoted table name

### DIFF
--- a/gdal/ogr/ogrsf_frmts/oci/ogrocitablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/oci/ogrocitablelayer.cpp
@@ -200,8 +200,8 @@ OGRFeatureDefn *OGROCITableLayer::ReadTableDefinition( const char * pszTable )
 
         nStatus =
             OCIDescribeAny(poSession->hSvcCtx, poSession->hError,
-                           (dvoid *) osQuotedTableName.c_str(),
-                           static_cast<ub4>(osQuotedTableName.length()), OCI_OTYPE_NAME,
+                           (dvoid *) osUnquotedTableName.c_str(),
+                           static_cast<ub4>(osUnquotedTableName.length()), OCI_OTYPE_NAME,
                            OCI_DEFAULT, OCI_PTYPE_VIEW, poSession->hDescribe );
 
         if( poSession->Failed( nStatus, "OCIDescribeAny" ) )


### PR DESCRIPTION
This is a fix for trac ticket 5552 (https://trac.osgeo.org/gdal/ticket/5552).