### PR TITLE
Update with copy column

### DIFF
--- a/gdal/frmts/formats_list.html
+++ b/gdal/frmts/formats_list.html
@@ -13,10 +13,10 @@
 <tr>
 <th>Long Format Name</th>
 <th>Code</th>
-<th>Creation</th>
-<th>Copy</th>
+<th>Creation<sup><a href="#footnote1">1</th>
+<th>Copy<sup><a href="#footnote2">2</th>
 <th>Georeferencing</th>
-<th>Maximum file size<sup><a href="#footnote1">1</a></sup></th>
+<th>Maximum file size<sup><a href="#footnote3">3</a></sup></th>
 <th>Compiled by<br/>default</th>
 </tr>
 
@@ -193,7 +193,7 @@
 
 <tr><td> <a href="drv_db2_raster.html">DB2</a>
 </td><td> DB2
-</td><td> --
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td> No limits
@@ -409,7 +409,7 @@
 
 <tr><td> <a href="drv_geopackage_raster.html">GeoPackage</a>
 </td><td> GPKG
-</td><td> --
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td> No limits
@@ -583,7 +583,7 @@
 </td><td> Yes
 </td><td> Yes
 </td><td> Yes
-</td><td> No limits<sup><a href="#footnote2">2</a></sup>
+</td><td> No limits<sup><a href="#footnote4">4</a></sup>
 </td><td> Yes
 </td></tr>
 
@@ -1391,14 +1391,22 @@
 </table>
 
 <p>
-<a name="footnote1"><sup>1</sup></a>Maximum file size is not only determined by
+<a name="footnote1"><sup>1</sup></a>Creation of a new dataset from scratch
+</p>
+
+<p>
+<a name="footnote2"><sup>2</sup></a>Copy from an existing source dataset
+</p>
+
+<p>
+<a name="footnote3"><sup>3</sup></a>Maximum file size is not only determined by
 	the file format itself, but operating system/file system capabilities
 	as well. Look <a href="gdal_building.html#gdal_building_lfs">here</a>
 	for details.
 </p>
 
 <p>
-<a name="footnote2"><sup>2</sup></a>ERDAS Imagine has different file format for
+<a name="footnote4"><sup>4</sup></a>ERDAS Imagine has different file format for
 	large files, where 32-bit pointers cannot be used. Look for details
 	<a href="frmt_hfa.html">here</a>.
 </p>

--- a/gdal/frmts/formats_list.html
+++ b/gdal/frmts/formats_list.html
@@ -14,6 +14,7 @@
 <th>Long Format Name</th>
 <th>Code</th>
 <th>Creation</th>
+<th>Copy</th>
 <th>Georeferencing</th>
 <th>Maximum file size<sup><a href="#footnote1">1</a></sup></th>
 <th>Compiled by<br/>default</th>
@@ -21,6 +22,7 @@
 
 <tr><td> <a href="frmt_various.html#AAIGrid">Arc/Info ASCII Grid</a>
 </td><td> AAIGrid
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> 2GB
@@ -29,6 +31,7 @@
 
 <tr><td> <a href="frmt_various.html#ACE2">ACE2</a>
 </td><td> ACE2
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -39,12 +42,14 @@
 </td><td> ADRG
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#AIG">Arc/Info Binary Grid (.adf)</a>
 </td><td> AIG
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -55,12 +60,14 @@
 </td><td> AIRSAR
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#ARG">Azavea Raster Grid</a>
 </td><td> ARG
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -69,6 +76,7 @@
 
 <tr><td> <a href="frmt_blx.html">Magellan BLX Topo (.blx, .xlb)</a>
 </td><td> BLX
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -77,6 +85,7 @@
 
 <tr><td> <a href="frmt_bag.html">Bathymetry Attributed Grid (.bag)</a>
 </td><td> BAG
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> 2GiB
@@ -87,6 +96,7 @@
 </td><td> BMP
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 4GiB
 </td><td> Yes
 </td></tr>
@@ -95,12 +105,14 @@
 </td><td> BPG
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> ---
 </td><td> No, needs libbpg (manual build required for now)
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#BSB">BSB Nautical Chart Format (.kap)</a>
 </td><td> BSB
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -111,12 +123,14 @@
 </td><td> BT
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#CAD">AutoCAD DWG Raster layer</a>
 </td><td> CAD
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -125,6 +139,7 @@
 
 <tr><td> <a href="frmt_cals.html">CALS Type I</a>
 </td><td> CALS
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -135,12 +150,14 @@
 </td><td> CEOS
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> DRDC COASP SAR Processor Raster
 </td><td> COASP
+</td><td> No
 </td><td> No
 </td><td> No
 </td><td> --
@@ -151,12 +168,14 @@
 </td><td> COSAR
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> Convair PolGASP data
 </td><td> CPG
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -166,6 +185,7 @@
 <tr><td> <a href="frmt_various.html#CTG">USGS LULC Composite Theme Grid</a>
 </td><td> CTG
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -173,6 +193,7 @@
 
 <tr><td> <a href="drv_db2_raster.html">DB2</a>
 </td><td> DB2
+</td><td> --
 </td><td> Yes
 </td><td> Yes
 </td><td> No limits
@@ -181,6 +202,7 @@
 
 <tr><td> <a href="frmt_various.html#DDS">DirectDraw Surface</a>
 </td><td> DDS
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td>
@@ -190,6 +212,7 @@
 <tr><td> <a href="frmt_derived.html">Derived</a>
 </td><td> DERIVED
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -197,6 +220,7 @@
 
 <tr><td> <a href="frmt_various.html#DIMAP">Spot DIMAP (metadata.dim)</a>
 </td><td> DIMAP
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -206,6 +230,7 @@
 <tr><td> ELAS DIPEx
 </td><td> DIPEx
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -213,6 +238,7 @@
 
 <tr><td> <a href="frmt_dods.html">DODS / OPeNDAP</a>
 </td><td> DODS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -222,6 +248,7 @@
 <tr><td> <a href="frmt_various.html#DOQ1">First Generation USGS DOQ (.doq)</a>
 </td><td> DOQ1
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -230,6 +257,7 @@
 <tr><td> <a href="frmt_various.html#DOQ2">New Labelled USGS DOQ (.doq)</a>
 </td><td> DOQ2
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -237,6 +265,7 @@
 
 <tr><td> <a href="frmt_dted.html">Military Elevation Data (.dt0, .dt1, .dt2)</a>
 </td><td> DTED
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -246,6 +275,7 @@
 <tr><td> <a href="frmt_various.html#E00GRID">Arc/Info Export E00 GRID</a>
 </td><td> E00GRID
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -253,6 +283,7 @@
 
 <tr><td> <a href="frmt_various.html#ECRGTOC">ECRG Table Of Contents (TOC.xml)</a>
 </td><td> ECRGTOC
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -263,6 +294,7 @@
 </td><td> ECW
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td>&nbsp;
 </td><td> No, needs ECW SDK
 </td></tr>
@@ -271,12 +303,14 @@
 </td><td> EHdr
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> No limits
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#EIR">Erdas Imagine Raw</a>
 </td><td> EIR
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -287,6 +321,7 @@
 </td><td> ELAS
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
@@ -295,12 +330,14 @@
 </td><td> ENVI
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> No limits
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_epsilon.html">Epsilon - Wavelet compressed images</a>
 </td><td> EPSILON
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -311,12 +348,14 @@
 </td><td> ERS
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td>
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#Envisat">Envisat Image Product (.n1)</a>
 </td><td> ESAT
+</td><td> No
 </td><td> No
 </td><td> No
 </td><td> --
@@ -326,6 +365,7 @@
 <tr><td> <a href="frmt_fast.html">EOSAT FAST Format</a>
 </td><td> FAST
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -333,6 +373,7 @@
 
 <tr><td> FIT
 </td><td> FIT
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -341,6 +382,7 @@
 
 <tr><td> <a href="frmt_various.html#FITS">FITS (.fits)</a>
 </td><td> FITS
+</td><td> Yes
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -351,6 +393,7 @@
 </td><td> FujiBAS
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> --
 </td><td> Yes
 </td></tr>
@@ -359,12 +402,14 @@
 </td><td> GENBIN
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="drv_geopackage_raster.html">GeoPackage</a>
 </td><td> GPKG
+</td><td> --
 </td><td> Yes
 </td><td> Yes
 </td><td> No limits
@@ -375,6 +420,7 @@
 </td><td> GEORASTER
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> No limits
 </td><td> No, needs Oracle client libraries
 </td></tr>
@@ -383,12 +429,14 @@
 </td><td>GFF
 </td><td>No
 </td><td>No
+</td><td>No
 </td><td>--
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_gif.html">Graphics Interchange Format (.gif)</a>
 </td><td> GIF
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td> 2GB
@@ -397,6 +445,7 @@
 
 <tr><td> <a href="frmt_grib.html">WMO GRIB1/GRIB2 (.grb)</a>
 </td><td> GRIB
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> 2GB
@@ -407,12 +456,14 @@
 </td><td> GMT
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 2GB
 </td><td> No, needs libnetcdf
 </td></tr>
 
 <tr><td> <a href="frmt_grass.html">GRASS Raster Format</a>
 </td><td> GRASS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -422,6 +473,7 @@
 <tr><td> <a href="frmt_various.html#GRASSASCIIGrid">GRASS ASCII Grid</a>
 </td><td> GRASSASCIIGrid
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -429,6 +481,7 @@
 
 <tr><td> <a href="frmt_various.html#GSAG">Golden Software ASCII Grid</a>
 </td><td> GSAG
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -439,6 +492,7 @@
 </td><td> GSBG
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 4GiB (32767x32767 of 4 bytes each + 56 byte header)
 </td><td> Yes
 </td></tr>
@@ -447,13 +501,15 @@
 </td><td> GS7BG
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 4GiB
 </td><td> Yes
 </td></tr>
 
 <tr><td> GSC Geogrid
 </td><td> GSC
-</td><td> Yes
+</td><td> No
+</td><td> No
 </td><td> No
 </td><td> --
 </td><td> Yes
@@ -461,6 +517,7 @@
 
 <tr><td> <a href="frmt_gta.html">Generic Tagged Arrays (.gta)</a>
 </td><td> GTA
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td>
@@ -471,6 +528,7 @@
 </td><td> GTiff
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 4GiB for classical TIFF / No limits for BigTIFF
 </td><td> Yes (internal libtiff and libgeotiff provided)
 </td></tr>
@@ -479,12 +537,14 @@
 </td><td> GTX
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td>
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#GXF">GXF - Grid eXchange File</a>
 </td><td> GXF
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> 4GiB
@@ -495,12 +555,14 @@
 </td><td> HDF4
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 2GiB
 </td><td> No, needs libdf
 </td></tr>
 
 <tr><td> <a href="frmt_hdf5.html">Hierarchical Data Format Release 5 (HDF5)</a>
 </td><td> HDF5
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> 2GiB
@@ -509,6 +571,7 @@
 
 <tr><td> <a href="frmt_hf2.html">HF2/HFZ heightfield raster</a>
 </td><td> HF2
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> -
@@ -519,12 +582,14 @@
 </td><td> HFA
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> No limits<sup><a href="#footnote2">2</a></sup>
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#IDA">Image Display and Analysis (WinDisp)</a>
 </td><td> IDA
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td> 2GB
@@ -535,12 +600,14 @@
 </td><td> ILWIS
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_intergraphraster.html">Intergraph Raster</a>
 </td><td> INGR
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td> 2GiB
@@ -550,6 +617,7 @@
 <tr><td> <a href="frmt_various.html#IRIS">IRIS</a>
 </td><td> IRIS
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -557,6 +625,7 @@
 
 <tr><td> <a href="frmt_various.html#ISCE">ISCE raster</a>
 </td><td> ISCE
+</td><td> Yes
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -567,12 +636,14 @@
 </td><td> ISIS2
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_isis3.html">USGS Astrogeology ISIS cube (Version 3)</a>
 </td><td> ISIS3
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -583,12 +654,14 @@
 </td><td> JAXAPALSAR
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#JDEM">Japanese DEM (.mem)</a>
 </td><td> JDEM
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -597,6 +670,7 @@
 
 <tr><td> <a href="frmt_jpeg.html">JPEG JFIF (.jpg)</a>
 </td><td> JPEG
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> 4GiB (max dimensions 65500x65500)
@@ -605,6 +679,7 @@
 
 <tr><td> <a href="frmt_jpegls.html">JPEG-LS</a>
 </td><td> JPEGLS
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -613,6 +688,7 @@
 
 <tr><td> <a href="frmt_jpeg2000.html">JPEG2000 (.jp2, .j2k)</a>
 </td><td> JPEG2000
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> 2GiB
@@ -623,12 +699,14 @@
 </td><td> JP2ECW
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 500MB
 </td><td> No, needs ECW SDK
 </td></tr>
 
 <tr><td> <a href="frmt_jp2kak.html">JPEG2000 (.jp2, .j2k)</a>
 </td><td> JP2KAK
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> No limits
@@ -637,6 +715,7 @@
 
 <tr><td> <a href="frmt_jp2lura.html">JPEG2000 (.jp2, .j2k)</a>
 </td><td> JP2Lura
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td>
@@ -645,6 +724,7 @@
 
 <tr><td> <a href="frmt_jp2mrsid.html">JPEG2000 (.jp2, .j2k)</a>
 </td><td> JP2MrSID
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td>
@@ -653,6 +733,7 @@
 
 <tr><td> <a href="frmt_jp2openjpeg.html">JPEG2000 (.jp2, .j2k)</a>
 </td><td> JP2OpenJPEG
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td>
@@ -661,6 +742,7 @@
 
 <tr><td> <a href="frmt_jpipkak.html">JPIP (based on Kakadu)</a>
 </td><td> JPIPKAK
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td>
@@ -671,12 +753,14 @@
 </td><td> KEA
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> No, needs libkea and libhdf5 libraries
 </td></tr>
 
 <tr><td> KMLSUPEROVERLAY
 </td><td> KMLSUPEROVERLAY
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td>
@@ -686,6 +770,7 @@
 <tr><td> <a href="frmt_various.html#KRO">KRO</a>
 </td><td> KRO
 </td><td> Yes
+</td><td> Yes
 </td><td> No
 </td><td> --
 </td><td> Yes
@@ -693,6 +778,7 @@
 
 <tr><td> <a href="frmt_l1b.html">NOAA Polar Orbiter Level 1b Data Set (AVHRR)</a>
 </td><td> L1B
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -702,6 +788,7 @@
 <tr><td> <a href="frmt_various.html#LAN">Erdas 7.x .LAN and .GIS</a>
 </td><td> LAN
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> 2GB
 </td><td> Yes
@@ -709,6 +796,7 @@
 
 <tr><td> <a href="frmt_lcp.html">FARSITE v.4 LCP Format</a>
 </td><td> LCP
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> No limits
@@ -717,7 +805,8 @@
 
 <tr><td> <a href="frmt_leveller.html">Daylon Leveller Heightfield</a>
 </td><td> Leveller
-</td><td> No
+</td><td> Yes
+</td><td> Yes
 </td><td> Yes
 </td><td> 2GB
 </td><td> Yes
@@ -725,6 +814,7 @@
 
 <tr><td> NADCON .los/.las Datum Grid Shift
 </td><td> LOSLAS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td>
@@ -735,12 +825,14 @@
 </td><td> MBTiles
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> No (needs OGR SQLite driver)
 </td></tr>
 
 <tr><td>  <a href="frmt_map.html">OziExplorer .MAP</a>
 </td><td> MAP
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -751,12 +843,14 @@
 </td><td> MEM
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td>
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#MFF">Vexcel MFF</a>
 </td><td> MFF
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td> No limits
@@ -767,12 +861,14 @@
 </td><td> MFF2 (HKV)
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> No limits
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_mrsid_lidar.html">MG4 Encoded Lidar</a>
 </td><td> MG4Lidar
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -783,12 +879,14 @@
 </td><td> MRF
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_mrsid.html">Multi-resolution Seamless Image Database</a>
 </td><td> MrSID
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -798,6 +896,7 @@
 <tr><td> <a href="frmt_msg.html">Meteosat Second Generation</a>
 </td><td> MSG
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td>
 </td><td> No, needs msg library
@@ -805,6 +904,7 @@
 
 <tr><td> <a href="frmt_msgn.html">EUMETSAT Archive native (.nat)</a>
 </td><td> MSGN
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td>
@@ -814,6 +914,7 @@
 <tr><td> <a href="frmt_various.html#NDF">NLAPS Data Format</a>
 </td><td> NDF
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> No limits
 </td><td> Yes
@@ -821,6 +922,7 @@
 
 <tr><td> <a href="frmt_ngsgeoid.html">NOAA NGS Geoid Height Grids</a>
 </td><td> NGSGEOID
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td>
@@ -831,12 +933,14 @@
 </td><td> NITF
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 10GB
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_netcdf.html">NetCDF</a>
 </td><td> netCDF
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td> 2GB
@@ -847,12 +951,14 @@
 </td><td> NTv2
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td>
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_nwtgrd.html">Northwood/VerticalMapper Classified Grid Format .grc/.tab</a>
 </td><td> NWT_GRC
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -862,6 +968,7 @@
 <tr><td> <a href="frmt_nwtgrd.html">Northwood/VerticalMapper Numeric Grid Format .grd/.tab</a>
 </td><td> NWT_GRD
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -869,6 +976,7 @@
 
 <tr><td> <a href="frmt_ogdi.html">OGDI Bridge</a>
 </td><td> OGDI
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -878,6 +986,7 @@
 <tr><td> <a href="frmt_ozi.html">OZI OZF2/OZFX3</a>
 </td><td> OZI
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> No
@@ -885,6 +994,7 @@
 
 <tr><td> <a href="frmt_various.html#PAux">PCI .aux Labelled</a>
 </td><td> PAux
+</td><td> Yes
 </td><td> Yes
 </td><td> No
 </td><td> No limits
@@ -895,12 +1005,14 @@
 </td><td> PCIDSK
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> No limits
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#PCRaster">PCRaster</a>
 </td><td> PCRaster
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td>&nbsp;
@@ -911,12 +1023,14 @@
 </td><td> PDF
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes (but needs libpoppler, libpodofo or PDFium for read support)
 </td></tr>
 
 <tr><td> <a href="frmt_pds.html">NASA Planetary Data System</a>
 </td><td> PDS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -926,6 +1040,7 @@
 <tr><td> <a href="frmt_plmosaic.html">Planet Labs Mosaics API</a>
 </td><td> PLMosaic
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> No, needs libcurl
@@ -933,6 +1048,7 @@
 
 <tr><td> <a href="frmt_various.html#PNG">Portable Network Graphics (.png)</a>
 </td><td> PNG
+</td><td> Yes
 </td><td> Yes
 </td><td> No
 </td><td>&nbsp;
@@ -942,6 +1058,7 @@
 <tr><td>  <a href="http://trac.osgeo.org/gdal/wiki/frmts_wtkraster.html">PostGIS Raster (previously WKTRaster)</a>
 </td><td> PostGISRaster
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> No, needs PostgreSQL library
@@ -949,6 +1066,7 @@
 
 <tr><td> <a href="frmt_various.html#PNM">Netpbm (.ppm,.pgm)</a>
 </td><td> PNM
+</td><td> Yes
 </td><td> Yes
 </td><td> No
 </td><td> No limits
@@ -958,6 +1076,7 @@
 <tr><td> <a href="frmt_prf.html">PHOTOMOD raster file (.prf,.x-dem)</a>
 </td><td> PRF
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> No limits
 </td><td> Yes
@@ -965,6 +1084,7 @@
 
 <tr><td> <a href="frmt_r.html">R Object Data Store</a>
 </td><td> R
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -975,12 +1095,14 @@
 </td><td> RASDAMAN
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> No limits
 </td><td> No (needs raslib)
 </td></tr>
 
 <tr><td> <a href="frmt_rasterlite.html">Rasterlite - Rasters in SQLite DB</a>
 </td><td> Rasterlite
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -990,6 +1112,7 @@
 <tr><td> <a href="frmt_rasterlite2.html">Rasterlite2 - Rasters in SQLite DB</a>
 </td><td> SQLite
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> No (needs libsqlite3, librasterlite2, libspatialite)
@@ -997,6 +1120,7 @@
 
 <tr><td> <a href="frmt_rik.html">Swedish Grid RIK (.rik)</a>
 </td><td> RIK
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> 4GB
@@ -1007,12 +1131,14 @@
 </td><td> RMF
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> 4GB
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#ROI_PAC">ROI_PAC Raster</a>
 </td><td> ROI_PAC
+</td><td> Yes
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -1022,6 +1148,7 @@
 <tr><td> <a href="frmt_various.html#RPFTOC">Raster Product Format/RPF (CADRG, CIB)</a>
 </td><td> RPFTOC
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> Yes
@@ -1030,6 +1157,7 @@
 <tr><td> <a href="frmt_rs2.html">RadarSat2 XML (product.xml)</a>
 </td><td> RS2
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> 4GB
 </td><td> Yes
@@ -1037,6 +1165,7 @@
 
 <tr><td> <a href="frmt_various.html#RRASTER">R Raster (.grd)</a>
 </td><td> RRASTER
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> -
@@ -1047,12 +1176,14 @@
 </td><td> RST
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> No limits
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_safe.html">Sentinel 1 SAR SAFE (manifest.safe)</a>
 </td><td> SAFE
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> No limits
@@ -1061,6 +1192,7 @@
 
 <tr><td> <a href="frmt_sentinel2.html">Sentinel 2</a>
 </td><td> SENTINEL2
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> No limits
@@ -1071,12 +1203,14 @@
 </td><td> SAGA
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#SAR_CEOS">SAR CEOS</a>
 </td><td> SAR_CEOS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -1086,6 +1220,7 @@
 <tr><td> <a href="frmt_sde.html">ArcSDE Raster</a>
 </td><td> SDE
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> No, needs ESRI SDE
@@ -1093,6 +1228,7 @@
 
 <tr><td> <a href="frmt_various.html#SDTS">USGS SDTS DEM (*CATD.DDF)</a>
 </td><td> SDTS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -1103,12 +1239,14 @@
 </td><td> SGI
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_various.html#SNODAS">Snow Data Assimilation System</a>
 </td><td> SNODAS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -1118,6 +1256,7 @@
 <tr><td> <a href="frmt_various.html#SRP">Standard Raster Product (ASRP/USRP)</a>
 </td><td> SRP
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> 2GB
 </td><td> Yes
@@ -1125,6 +1264,7 @@
 
 <tr><td> <a href="frmt_various.html#SRTMHGT">SRTM HGT Format</a>
 </td><td> SRTMHGT
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -1133,6 +1273,7 @@
 
 <tr><td> <a href="frmt_terragen.html">Terragen Heightfield (.ter)</a>
 </td><td> TERRAGEN
+</td><td> Yes
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -1143,13 +1284,15 @@
 </td><td> TIL
 </td><td> No
 </td><td> No
+</td><td> No
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> TerraSAR-X Product
 </td><td> TSX
-</td><td> Yes
+</td><td> No
+</td><td> No
 </td><td> No
 </td><td> --
 </td><td> Yes
@@ -1157,6 +1300,7 @@
 
 <tr><td> <a href="frmt_usgsdem.html">USGS ASCII DEM / CDED (.dem)</a>
 </td><td> USGSDEM
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -1165,6 +1309,7 @@
 
 <tr><td> <a href="http://www-mipl.jpl.nasa.gov/external/vicar.html">VICAR</a>
 </td><td> VICAR
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -1175,12 +1320,14 @@
 </td><td> VRT
 </td><td> Yes
 </td><td> Yes
+</td><td> Yes
 </td><td> --
 </td><td> Yes
 </td></tr>
 
 <tr><td> <a href="frmt_wcs.html">OGC Web Coverage Service</a>
 </td><td> WCS
+</td><td> No
 </td><td> No
 </td><td> Yes
 </td><td> --
@@ -1189,6 +1336,7 @@
 
 <tr><td> <a href="frmt_webp.html">WEBP</a>
 </td><td> WEBP
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td> --
@@ -1198,6 +1346,7 @@
 <tr><td> <a href="frmt_wms.html">OGC Web Map Service, and TMS, WorldWind, On Earth tiled, VirtualEarth, ArcGIS REST, IIP)</a>
 </td><td> WMS
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> No, needs libcurl
@@ -1206,6 +1355,7 @@
 <tr><td> <a href="frmt_wmts.html">OGC Web Map Tile Service</a>
 </td><td> WMTS
 </td><td> No
+</td><td> No
 </td><td> Yes
 </td><td> --
 </td><td> No, needs libcurl
@@ -1213,6 +1363,7 @@
 
 <tr><td> <a href="frmt_various.html#XPM">X11 Pixmap (.xpm)</a>
 </td><td> XPM
+</td><td> No
 </td><td> Yes
 </td><td> No
 </td><td>&nbsp;
@@ -1221,6 +1372,7 @@
 
 <tr><td> <a href="frmt_xyz.html">ASCII Gridded XYZ</a>
 </td><td> XYZ
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td> --
@@ -1229,6 +1381,7 @@
 
 <tr><td> <a href="frmt_various.html#ZMap">ZMap Plus Grid</a>
 </td><td> ZMap
+</td><td> No
 </td><td> Yes
 </td><td> Yes
 </td><td>


### PR DESCRIPTION
There are several drivers for which I couldn't locate the code:
DB2
Geopackage

Leveller claimed not to support creation, but the code says otherwise.
TerraSAR claimed to support creation, but the code says otherwise.
DTED looks as if there is a function to do creation in addition to copy, but it doesn't seem to be registered as a callback.

I'm also wondering about GDAL_DCAP_CREATECOPY and GDAL_DCAP_CREATE, as they only seem to be used in the NITF driver.  Should they be removed or flushed out?