### PR TITLE
Flip y-coords if netcdf is bottom up

### DIFF
--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -3160,6 +3160,17 @@ void netCDFDataset::SetProjectionFromVar( int nVarId, bool bReadSRSOnly )
             }
 
 
+            // If the data is bottom up then flip the y - coords
+            // this is significantly faster than reading row by row
+            if (poDS->bBottomUp)
+            {
+                double temp = yMinMax[0];
+                yMinMax[0] = yMinMax[1];
+                yMinMax[1] = temp;
+                poDS->bBottomUp = false;
+             }
+
+
             // Geostationary satellites can specify units in (micro)radians
             // So we check if they do, and if so convert to linear units (meters)
             const char *pszProjName = oSRS.GetAttrValue( "PROJECTION" );


### PR DESCRIPTION
Significant speedup versus switching nBlockYSize to 1 and reading row by row as was done before.

Test netcdf: https://storage.googleapis.com/gcp-public-data-goes-16/ABI-L2-CMIPF/2017/243/15/OR_ABI-L2-CMIPF-M3C02_G16_s20172431545343_e20172431556110_c20172431556174.nc