### PR TITLE
[BUG] GML JPGIS FGD: fix test case and logic

### DIFF
--- a/autotest/ogr/ogr_gml_fgd_read.py
+++ b/autotest/ogr/ogr_gml_fgd_read.py
@@ -86,7 +86,7 @@ def ogr_gml_fgd_1():
 
     # check the first feature
     feat = lyr.GetNextFeature()
-    if ogrtest.check_feature_geometry(feat, 'POINT (34.123456789 133.123456789)'):
+    if ogrtest.check_feature_geometry(feat, 'POINT (133.123456789 34.123456789)'):
         gdaltest.post_reason('Wrong geometry')
         return 'fail'
 

--- a/autotest/ogr/ogr_gml_fgd_read.py
+++ b/autotest/ogr/ogr_gml_fgd_read.py
@@ -98,10 +98,49 @@ def ogr_gml_fgd_1():
 
 
 ###############################################################################
+# Test reading Japanese FGD GML (v4) BldA file
+
+def ogr_gml_fgd_2():
+    if not gdaltest.have_gml_fgd_reader:
+        return 'skip'
+
+    ### open FGD GML file
+    ds = ogr.Open(_fgd_dir + 'BldA.xml')
+
+    # check number of layers
+    if ds.GetLayerCount() != 1:
+        gdaltest.post_reason('Wrong layer count')
+        return 'fail'
+
+    lyr = ds.GetLayer(0)
+
+    # check the SRS
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(6668)   # JGD2011
+    if not sr.IsSame(lyr.GetSpatialRef()):
+        gdaltest.post_reason('Wrong SRS')
+        return 'fail'
+
+    wkt = 'POLYGON ((139.718509733734 35.6952171397133,139.718444177734 35.6953121947133,139.718496754142 35.6953498949667,139.718550483734 35.6952359447133,139.718509733734 35.6952171397133))'
+
+    # check the first feature
+    feat = lyr.GetNextFeature()
+    if ogrtest.check_feature_geometry(feat, wkt):
+        gdaltest.post_reason('Wrong geometry')
+        return 'fail'
+
+    if feat.GetField('devDate') != '2017-03-07':
+        gdaltest.post_reason('Wrong attribute value')
+        return 'fail'
+
+    return 'success'
+
+###############################################################################
 # List test cases
 
 gdaltest_list = [
-    ogr_gml_fgd_1
+    ogr_gml_fgd_1,
+    ogr_gml_fgd_2
     ]
 
 

--- a/gdal/ogr/ogrsf_frmts/gml/gmlutils.cpp
+++ b/gdal/ogr/ogrsf_frmts/gml/gmlutils.cpp
@@ -100,6 +100,12 @@ bool GML_IsSRSLatLongOrder(const char *pszSRSName)
         // Shortcut.
         return true;
     }
+    /* fguuid:jgd20??.bl (Japanese FGD GML v4) */
+    else if( EQUALN(pszSRSName, "fguuid:jgd2011.bl", 17) ||
+            EQUALN(pszSRSName, "fguuid:jgd2001.bl", 17) )
+    {
+        return true;
+    }
     else if( !EQUALN(pszSRSName, "EPSG:", 5) )
     {
         OGRSpatialReference oSRS;
@@ -108,13 +114,7 @@ bool GML_IsSRSLatLongOrder(const char *pszSRSName)
             if(oSRS.EPSGTreatsAsLatLong() || oSRS.EPSGTreatsAsNorthingEasting())
                 return true;
         }
-        return false;
     }
-    /* fguuid:jgd20??.bl (Japanese FGD GML v4) */
-    else if (strncmp(pszSRSName, "fguuid:jgd", 10) == 0 && strstr(pszSRSName, ".bl") != NULL) {
-        return true;
-    }
-
     return false;
 }
 


### PR DESCRIPTION
When reading JPGIS FGD v4 data, lon/lat is swapped.

This fixes an expected result of the test case and
add more tests, and fix a detection logic whether data represent lat/lon or x/y.

There is the logic to detect JPGIS FGD v4, but it never run in current implementation.