### PR TITLE
Systematic pixel shift with geoloc arrays

### DIFF
--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -40,7 +40,7 @@ import gdaltest
 
 def geoloc_1():
 
-    tst = gdaltest.GDALTest( 'VRT', 'warpsst.vrt', 1, 62319 )
+    tst = gdaltest.GDALTest( 'VRT', 'warpsst.vrt', 1, 61818 )
     return tst.testOpen( check_filelist = False )
 
 

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -149,8 +149,8 @@ def transformer_4():
     (success,pnt) = tr.TransformPoint( 1, pnt[0], pnt[1], pnt[2] )
 
     if not success \
-       or abs(pnt[0]-19.554539744554866) > 0.001 \
-       or abs(pnt[1]-9.1910760024906537) > 0.001 \
+       or abs(pnt[0]-20.436627518907024) > 0.001 \
+       or abs(pnt[1]-10.484599774610549) > 0.001 \
        or pnt[2] != 0:
         print(success, pnt)
         gdaltest.post_reason( 'got wrong reverse transform result.' )

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -405,7 +405,7 @@ def vrtwarp_9():
     if vrtwarp_ds.GetRasterBand(1).Checksum() != expected_cs_main:
         gdaltest.post_reason('fail')
         return 'fail'
-    if vrtwarp_ds.GetRasterBand(1).GetOverview(0).Checksum() != 63972:
+    if vrtwarp_ds.GetRasterBand(1).GetOverview(0).Checksum() != 63859:
         gdaltest.post_reason('fail')
         print(vrtwarp_ds.GetRasterBand(1).GetOverview(0).XSize)
         print(vrtwarp_ds.GetRasterBand(1).GetOverview(0).YSize)

--- a/gdal/alg/gdalgeoloc.cpp
+++ b/gdal/alg/gdalgeoloc.cpp
@@ -369,7 +369,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                     static_cast<float>( tempwt * (
                         (iY + FSHIFT) * psTransform->dfLINE_STEP +
                         psTransform->dfLINE_OFFSET));
-                wgtsBackMap[iBMX + iBMY * nBMXSize] += tempwt;
+                wgtsBackMap[iBMX + iBMY * nBMXSize] += static_cast<float>(tempwt);
 
                 //For backward compatibility
                 pabyValidFlag[iBMX + iBMY * nBMXSize] = static_cast<GByte>(nMaxIter+1);
@@ -389,7 +389,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                     static_cast<float>( tempwt * (
                         (iY + FSHIFT)* psTransform->dfLINE_STEP +
                         psTransform->dfLINE_OFFSET));
-                wgtsBackMap[iBMX + 1 + iBMY * nBMXSize] +=  tempwt;
+                wgtsBackMap[iBMX + 1 + iBMY * nBMXSize] +=  static_cast<float>(tempwt);
 
                 //For backward compatibility
                 pabyValidFlag[iBMX + 1 + iBMY * nBMXSize] = static_cast<GByte>(nMaxIter+1);
@@ -408,7 +408,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                     static_cast<float>( tempwt * (
                         (iY + FSHIFT) * psTransform->dfLINE_STEP +
                         psTransform->dfLINE_OFFSET));
-                wgtsBackMap[iBMX + 1 + (iBMY+1) * nBMXSize] += tempwt;
+                wgtsBackMap[iBMX + 1 + (iBMY+1) * nBMXSize] += static_cast<float>(tempwt);
 
                 //For backward compatibility
                 pabyValidFlag[iBMX + 1 + (iBMY+1) * nBMXSize] = static_cast<GByte>(nMaxIter+1);
@@ -427,7 +427,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                     static_cast<float>(tempwt * (
                         (iY + FSHIFT) * psTransform->dfLINE_STEP +
                         psTransform->dfLINE_OFFSET));
-                wgtsBackMap[iBMX + (iBMY+1) * nBMXSize] += tempwt;
+                wgtsBackMap[iBMX + (iBMY+1) * nBMXSize] += static_cast<float>(tempwt);
 
                 //For backward compatibility
                 pabyValidFlag[iBMX + (iBMY+1) * nBMXSize] = static_cast<GByte>(nMaxIter+1);

--- a/gdal/alg/gdalgeoloc.cpp
+++ b/gdal/alg/gdalgeoloc.cpp
@@ -334,10 +334,10 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
             const int i = iX + iY * nXSize;
 
             const double dBMX = static_cast<double>(
-                    (psTransform->padfGeoLocX[i] - dfMinX) / dfPixelSize);
+                    (psTransform->padfGeoLocX[i] - dfMinX) / dfPixelSize) - 0.5;
 
             const double dBMY = static_cast<double>(
-                (dfMaxY - psTransform->padfGeoLocY[i]) / dfPixelSize);
+                (dfMaxY - psTransform->padfGeoLocY[i]) / dfPixelSize) - 0.5;
 
 
             //Get top left index by truncation
@@ -386,12 +386,12 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 
                 psTransform->pafBackMapX[iBMX + 1 + iBMY * nBMXSize] +=
                     static_cast<float>( tempwt * (
-                        iX * psTransform->dfPIXEL_STEP +
+                        (iX + 0.5) * psTransform->dfPIXEL_STEP +
                         psTransform->dfPIXEL_OFFSET));
 
                 psTransform->pafBackMapY[iBMX + 1 + iBMY * nBMXSize] +=
                     static_cast<float>( tempwt * (
-                        iY * psTransform->dfLINE_STEP +
+                        (iY + 0.5)* psTransform->dfLINE_STEP +
                         psTransform->dfLINE_OFFSET));
                 wgtsBackMap[iBMX + 1 + iBMY * nBMXSize] +=  tempwt;
 
@@ -405,12 +405,12 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                 const double tempwt = fracBMX * fracBMY;
                 psTransform->pafBackMapX[iBMX + 1 + (iBMY+1) * nBMXSize] +=
                     static_cast<float>( tempwt * (
-                        iX * psTransform->dfPIXEL_STEP +
+                        (iX + 0.5) * psTransform->dfPIXEL_STEP +
                         psTransform->dfPIXEL_OFFSET));
 
                 psTransform->pafBackMapY[iBMX + 1 + (iBMY+1) * nBMXSize] +=
                     static_cast<float>( tempwt * (
-                        iY * psTransform->dfLINE_STEP +
+                        (iY + 0.5) * psTransform->dfLINE_STEP +
                         psTransform->dfLINE_OFFSET));
                 wgtsBackMap[iBMX + 1 + (iBMY+1) * nBMXSize] += tempwt;
 
@@ -424,12 +424,12 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                 const double tempwt = (1.0 - fracBMX) * fracBMY;
                 psTransform->pafBackMapX[iBMX + (iBMY+1) * nBMXSize] +=
                     static_cast<float>( tempwt * (
-                        iX * psTransform->dfPIXEL_STEP +
+                        (iX + 0.5) * psTransform->dfPIXEL_STEP +
                         psTransform->dfPIXEL_OFFSET));
 
                 psTransform->pafBackMapY[iBMX + (iBMY+1) * nBMXSize] +=
                     static_cast<float>(tempwt * (
-                        iY * psTransform->dfLINE_STEP +
+                        (iY + 0.5) * psTransform->dfLINE_STEP +
                         psTransform->dfLINE_OFFSET));
                 wgtsBackMap[iBMX + (iBMY+1) * nBMXSize] += tempwt;
 
@@ -878,10 +878,10 @@ int GDALGeoLocTransform( void *pTransformArg,
             }
 
             const double dfGeoLocPixel =
-                (padfX[i] - psTransform->dfPIXEL_OFFSET)
+                (padfX[i] - 0.5 - psTransform->dfPIXEL_OFFSET)
                 / psTransform->dfPIXEL_STEP;
             const double dfGeoLocLine =
-                (padfY[i] - psTransform->dfLINE_OFFSET)
+                (padfY[i] - 0.5 - psTransform->dfLINE_OFFSET)
                 / psTransform->dfLINE_STEP;
 
             int iX = std::max(0, static_cast<int>(dfGeoLocPixel));
@@ -969,10 +969,10 @@ int GDALGeoLocTransform( void *pTransformArg,
 
             const double dfBMX =
                 ((padfX[i] - psTransform->adfBackMapGeoTransform[0])
-                 / psTransform->adfBackMapGeoTransform[1]);
+                 / psTransform->adfBackMapGeoTransform[1]) - 0.5;
             const double dfBMY =
                 ((padfY[i] - psTransform->adfBackMapGeoTransform[3])
-                 / psTransform->adfBackMapGeoTransform[5]);
+                 / psTransform->adfBackMapGeoTransform[5]) - 0.5;
 
             const int iBMX = static_cast<int>(dfBMX);
             const int iBMY = static_cast<int>(dfBMY);


### PR DESCRIPTION
Hi,
    I'm issuing this pull request as a starting point to discuss some more details. The changes made to gdalgeoloc.cpp fixes systematic 1 pixel shift as reported in [https://trac.osgeo.org/gdal/ticket/6959](https://trac.osgeo.org/gdal/ticket/6959).

The maximum error observed is now less than 1/10th of pixel. However, there still appears to be some discrepancy in the way x and y coordinates are treated by gdalwarp. The error in x coordinate shows a systematic ramp whereas the error in y show much higher rate of change consistent with truncation. 

I'm attaching the output discrepancy plot after making the changes. The errors are consistent across all orientations. I would have expected the errors to be close to zero. 

I run similar tests (see trac ticket for test details) with gdal_translate and gdalwarp. gdalwarp is able to upsample an image without near zero error whereas gdal_translate demonstrates similar features as when using geoloc arrays.

![wens](https://user-images.githubusercontent.com/8147682/31235570-b2676ce0-a9a6-11e7-982e-5f8fb38a89ea.png)


