### PR TITLE
fix return type on fallback version of `CPLHaveRuntimeAVX`

### DIFF
--- a/gdal/port/cpl_cpu_features.cpp
+++ b/gdal/port/cpl_cpu_features.cpp
@@ -202,7 +202,7 @@ bool CPLHaveRuntimeAVX()
 
 #else
 
-int CPLHaveRuntimeAVX()
+bool CPLHaveRuntimeAVX()
 {
     return false;
 }


### PR DESCRIPTION
All the others were changed to bool, looks like this one was missed.