### PR TITLE
CreateGeomField is not supported on FGdbDatasource

### DIFF
--- a/gdal/ogr/ogrsf_frmts/filegdb/FGdbDatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/filegdb/FGdbDatasource.cpp
@@ -476,8 +476,6 @@ int FGdbDataSource::TestCapability( const char * pszCap )
 
     else if( EQUAL(pszCap,ODsCDeleteLayer) )
         return m_bUpdate;
-    else if( EQUAL(pszCap,ODsCCreateGeomFieldAfterCreateLayer) )
-        return TRUE;
     else if( EQUAL(pszCap,ODsCRandomLayerWrite) )
         return m_bUpdate;
 


### PR DESCRIPTION
CreateGeomField is not overwriten for FGdbLayer, so that Capability should be false on the datasource.

This was preventing the creation of FileGDB layers when the geometry field was required. It was being called here https://github.com/OSGeo/gdal/blob/trunk/gdal/apps/ogr2ogr_lib.cpp#L3683 because of this https://github.com/OSGeo/gdal/blob/trunk/gdal/apps/ogr2ogr_lib.cpp#L3529-L3530