### PR TITLE
Disable preserveFID when no FID column is available

### DIFF
--- a/gdal/apps/ogr2ogr_lib.cpp
+++ b/gdal/apps/ogr2ogr_lib.cpp
@@ -4243,7 +4243,7 @@ int LayerTranslator::Translate( OGRFeature* poFeatureIn,
     OGRLayer *poDstLayer = psInfo->poDstLayer;
     int* const panMap = psInfo->panMap;
     const int iSrcZField = psInfo->iSrcZField;
-    const bool bPreserveFID = psInfo->bPreserveFID;
+    const bool bPreserveFID = psInfo->bPreserveFID && strcmp(poSrcLayer->GetFIDColumn(), "") != 0;
     const int nSrcGeomFieldCount = poSrcLayer->GetLayerDefn()->GetGeomFieldCount();
     const int nDstGeomFieldCount = poDstLayer->GetLayerDefn()->GetGeomFieldCount();
     const bool bExplodeCollections = m_bExplodeCollections && nDstGeomFieldCount <= 1;


### PR DESCRIPTION
There is no point on preserving FID if none is available in the source dataset.

This was causing problems for FileGDB format (maybe not the only one). When no FID column is available, PG driver starts the counter on 0 (https://github.com/OSGeo/gdal/blob/d7e08bb5078a4483d3fccab137cc9c0050ccae13/gdal/ogr/ogrsf_frmts/pg/ogrpglayer.cpp#L176). However, FileGDB format only supports FID starting in 1.