### PR TITLE
DXF: Fix crash with self-including blocks and memory leak

### DIFF
--- a/autotest/ogr/data/insert-recursive-pair.dxf
+++ b/autotest/ogr/data/insert-recursive-pair.dxf
@@ -1,0 +1,142 @@
+  0
+SECTION
+  2
+TABLES
+  0
+ENDSEC
+  0
+SECTION
+  2
+BLOCKS
+  0
+BLOCK
+  5
+ABC0
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+RecursiveBlock1
+ 70
+0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+RecursiveBlock1
+  1
+
+  0
+INSERT
+  5
+ABC1
+100
+AcDbEntity
+100
+AcDbBlockReference
+  8
+0
+  2
+RecursiveBlock2
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  0
+ENDBLK
+  5
+ABC2
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+BLOCK
+  5
+DEF0
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockBegin
+  2
+RecursiveBlock2
+ 70
+0
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  3
+RecursiveBlock2
+  1
+
+  0
+INSERT
+  5
+DEF1
+100
+AcDbEntity
+100
+AcDbBlockReference
+  8
+0
+  2
+RecursiveBlock1
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  0
+ENDBLK
+  5
+DEF2
+100
+AcDbEntity
+  8
+0
+100
+AcDbBlockEnd
+  0
+ENDSEC
+  0
+SECTION
+  2
+ENTITIES
+  0
+INSERT
+  5
+1234
+100
+AcDbEntity
+100
+AcDbBlockReference
+  8
+0
+  2
+RecursiveBlock1
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+  0
+ENDSEC
+  0
+EOF

--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -2799,6 +2799,19 @@ def ogr_dxf_42():
     return 'success'
 
 ###############################################################################
+# Ensure recursively-included blocks don't fail badly
+
+def ogr_dxf_43():
+
+    # Inlining, merging
+    ds = ogr.Open('data/insert-recursive-pair.dxf')
+    lyr = ds.GetLayer(0)
+    if lyr.GetFeatureCount() != 0:
+        return 'fail'
+
+    return 'success'
+
+###############################################################################
 # cleanup
 
 def ogr_dxf_cleanup():
@@ -2853,6 +2866,7 @@ gdaltest_list = [
     ogr_dxf_40,
     ogr_dxf_41,
     ogr_dxf_42,
+    ogr_dxf_43,
     ogr_dxf_cleanup ]
 
 if __name__ == '__main__':

--- a/gdal/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -259,7 +259,8 @@ class OGRDXFLayer : public OGRLayer
                                            OGRDXFFeature* const poFeature,
                                            std::queue<OGRDXFFeature *>& apoExtraFeatures,
                                            const bool bInlineNestedBlocks,
-                                           const bool bMergeGeometry );
+                                           const bool bMergeGeometry,
+                                           const int iRecursionDepth = 0 );
     OGRDXFFeature *     InsertBlockReference( const CPLString& osBlockName,
                                               const OGRDXFInsertTransformer& oTransformer,
                                               OGRDXFFeature* const poFeature );

--- a/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
@@ -2446,8 +2446,20 @@ OGRDXFFeature *OGRDXFLayer::InsertBlockInline( const CPLString& osBlockName,
     OGRDXFFeature* const poFeature,
     std::queue<OGRDXFFeature *>& apoExtraFeatures,
     const bool bInlineRecursively,
-    const bool bMergeGeometry )
+    const bool bMergeGeometry,
+    const int iRecursionDepth /* = 0 */ )
 {
+    // Make sure we are not recursing too deeply (avoid stack overflows)
+    // 128 is a totally arbitrary limit
+    if( iRecursionDepth > 128 )
+    {
+        CPLDebug( "DXF",
+            "Block recursion limit exceeded. Ignoring further INSERTs" );
+
+        delete poFeature;
+        return NULL;
+    }
+
 /* -------------------------------------------------------------------- */
 /*      Transform the insertion point from OCS into                     */
 /*      world coordinates.                                              */
@@ -2519,7 +2531,7 @@ OGRDXFFeature *OGRDXFLayer::InsertBlockInline( const CPLString& osBlockName,
                 poSubFeature = InsertBlockInline( poSubFeature->osBlockName,
                     oInnerTransformer, poSubFeature->adfBlockOCS,
                     poSubFeature, apoInnerExtraFeatures,
-                    true, bMergeGeometry );
+                    true, bMergeGeometry, iRecursionDepth + 1 );
             }
             catch( const std::invalid_argument& )
             {
@@ -2576,7 +2588,8 @@ OGRDXFFeature *OGRDXFLayer::InsertBlockInline( const CPLString& osBlockName,
                 !poSubFeature->IsBlockReference() &&
                 poSubFeature->GetGeometryRef() )
             {
-                poMergedGeometry->addGeometry( poSubFeature->GetGeometryRef() );
+                poMergedGeometry->addGeometry( poSubFeature->StealGeometry() );
+                delete poSubFeature;
             }
             else
             {


### PR DESCRIPTION
Interestingly the test DXF file crashes AutoCAD upon opening...