### PR TITLE
Add GDAL_DCAP_NONSPATIAL capability

### DIFF
--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -368,6 +368,13 @@ typedef GIntBig GSpacing;
  */
 #define GDAL_DCAP_NOTNULL_GEOMFIELDS "DCAP_NOTNULL_GEOMFIELDS"
 
+/** Capability set by a non-spatial driver having no support for geometries. E.g. non-spatial
+ * vector drivers (e.g. spreadsheet format drivers) do not support geometries,
+ * and accordingly will have this capability present.
+ * @since GDAL 2.3
+ */
+#define GDAL_DCAP_NONSPATIAL     "DCAP_NONSPATIAL"
+
 void CPL_DLL CPL_STDCALL GDALAllRegister( void );
 
 GDALDatasetH CPL_DLL CPL_STDCALL GDALCreate( GDALDriverH hDriver,

--- a/gdal/ogr/ogrsf_frmts/ods/ogrodsdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/ods/ogrodsdriver.cpp
@@ -215,6 +215,7 @@ void RegisterOGRODS()
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,
                                "Integer Integer64 Real String Date DateTime "
                                "Time Binary" );
+    poDriver->SetMetadataItem( GDAL_DCAP_NONSPATIAL, "YES" );
 
     poDriver->pfnIdentify = OGRODSDriverIdentify;
     poDriver->pfnOpen = OGRODSDriverOpen;

--- a/gdal/ogr/ogrsf_frmts/xls/ogrxlsdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/xls/ogrxlsdriver.cpp
@@ -100,6 +100,7 @@ void RegisterOGRXLS()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "MS Excel format" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "xls" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drv_xls.html" );
+    poDriver->SetMetadataItem( GDAL_DCAP_NONSPATIAL, "YES" );
 
     OGRSFDriverRegistrar::GetRegistrar()->RegisterDriver( poDriver );
 }

--- a/gdal/ogr/ogrsf_frmts/xlsx/ogrxlsxdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/xlsx/ogrxlsxdriver.cpp
@@ -191,6 +191,7 @@ void RegisterOGRXLSX()
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,
                                "Integer Integer64 Real String Date DateTime "
                                "Time" );
+    poDriver->SetMetadataItem( GDAL_DCAP_NONSPATIAL, "YES" );
 
     poDriver->pfnIdentify = OGRXLSXDriverIdentify;
     poDriver->pfnOpen = OGRXLSXDriverOpen;


### PR DESCRIPTION
This capability set by a non-spatial driver having no support for geometries. E.g. non-spatial vector drivers (e.g. spreadsheet format drivers) do not support geometries, and accordingly will have this capability present.

The intention here is to allow gui based applications to filter out formats with no geometry support from available lists of formats users can use.

I debated whether a capability indicating spatial support (e.g. "GDAL_DCAP_GEOMETRY") was more appropriate, but in the end these drivers are really the exception rather than the norm and it seems more sensible to set the flag for the exceptional drivers only, rather than every other driver. 