### PR TITLE
GIntBig: use __int64 for MinGW

### DIFF
--- a/gdal/port/cpl_port.h
+++ b/gdal/port/cpl_port.h
@@ -219,7 +219,7 @@ typedef int             GBool;
 /*      64bit support                                                   */
 /* -------------------------------------------------------------------- */
 
-#if defined(WIN32) && defined(_MSC_VER)
+#if defined(WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
 
 #define VSI_LARGE_API_SUPPORTED
 typedef __int64          GIntBig;


### PR DESCRIPTION
attempt to fix issues with GIntBig if GDAL is compiled on WIN32 with MSC and other software using GDAL is compiled with MinGW