### PR TITLE
Fix raster garbage values while reading sparse RMF files

### DIFF
--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -180,6 +180,11 @@ CPLErr RMFRasterBand::IReadBlock( int nBlockXOff, int nBlockYOff,
     vsi_l_offset nTileOffset =
         poGDS->GetFileOffset( poGDS->paiTiles[2 * nTile] );
 
+    if( nTileOffset == 0 )
+    {
+        return CE_None;
+    }
+
     if( VSIFSeekL( poGDS->fp, nTileOffset, SEEK_SET ) < 0 )
     {
         // XXX: We will not report error here, because file just may be


### PR DESCRIPTION
In the RMF file format the missing tiles are marked as having a zero offset, because this is a valid offset, we read the garbage data without any warnings. We must skip such tiles explicitly.