### PR TITLE
frmt_blx: Fix include blx.h

### DIFF
--- a/gdal/frmts/blx/GNUmakefile
+++ b/gdal/frmts/blx/GNUmakefile
@@ -1,7 +1,7 @@
 
 include ../../GDALmake.opt
 
-XTRA_OPT =	-I. -DGDALDRIVER
+XTRA_OPT =	-DGDALDRIVER
 
 OBJ	=	blxdataset.o blx.o
 

--- a/gdal/frmts/blx/blxdataset.cpp
+++ b/gdal/frmts/blx/blxdataset.cpp
@@ -34,7 +34,7 @@
 #include "gdal_pam.h"
 
 CPL_C_START
-#include <blx.h>
+#include "blx.h"
 CPL_C_END
 
 CPL_CVSID("$Id$")


### PR DESCRIPTION
blx.h is located in same directory and provided by author.
so using double quote style.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>