### PR TITLE
Fix rounding error in scale factor of warp operation

### DIFF
--- a/gdal/alg/gdalwarper.h
+++ b/gdal/alg/gdalwarper.h
@@ -333,9 +333,9 @@ public:
     /** Height of the source image */
     int                 nSrcYSize;
     /** Extra pixels (included in nSrcXSize) reserved for filter window. Should be ignored in scale computation */
-    int                 nSrcXExtraSize;
+    double              dfSrcXExtraSize;
     /** Extra pixels (included in nSrcYSize) reserved for filter window. Should be ignored in scale computation */
-    int                 nSrcYExtraSize;
+    double              dfSrcYExtraSize;
     /** Array of nBands source images of size nSrcXSize * nSrcYSize. Each subarray must have WARP_EXTRA_ELTS at the end */
     GByte               **papabySrcImage;
 
@@ -446,7 +446,7 @@ private:
                                          int nDstXSize, int nDstYSize,
                                          int *pnSrcXOff, int *pnSrcYOff,
                                          int *pnSrcXSize, int *pnSrcYSize,
-                                         int *pnSrcXExtraSize, int *pnSrcYExtraSize,
+                                         double *pdfSrcXExtraSize, double *pdfSrcYExtraSize,
                                          double* pdfSrcFillRatio );
 
     static CPLErr          CreateKernelMask( GDALWarpKernel *, int iBand,
@@ -495,7 +495,7 @@ public:
                                 int nDstXSize, int nDstYSize,
                                 int nSrcXOff, int nSrcYOff,
                                 int nSrcXSize, int nSrcYSize,
-                                int nSrcXExtraSize, int nSrcYExtraSize,
+                                double dfSrcXExtraSize, double dfSrcYExtraSize,
                                 double dfProgressBase, double dfProgressScale);
     CPLErr          WarpRegionToBuffer( int nDstXOff, int nDstYOff,
                                         int nDstXSize, int nDstYSize,
@@ -510,7 +510,7 @@ public:
                                         GDALDataType eBufDataType,
                                         int nSrcXOff, int nSrcYOff,
                                         int nSrcXSize, int nSrcYSize,
-                                        int nSrcXExtraSize, int nSrcYExtraSize,
+                                        double dfSrcXExtraSize, double dfSrcYExtraSize,
                                         double dfProgressBase, double dfProgressScale);
 };
 

--- a/gdal/alg/gdalwarpkernel.cpp
+++ b/gdal/alg/gdalwarpkernel.cpp
@@ -667,7 +667,7 @@ static CPLErr GWKRun( GDALWarpKernel *poWK,
  */
 
 /**
- * \var int GDALWarpKernel::nSrcXExtraSize;
+ * \var double GDALWarpKernel::dfSrcXExtraSize;
  *
  * Number of pixels included in nSrcXSize that are present on the edges of
  * the area of interest to take into account the width of the kernel.
@@ -676,7 +676,7 @@ static CPLErr GWKRun( GDALWarpKernel *poWK,
  */
 
 /**
- * \var int GDALWarpKernel::nSrcYExtraSize;
+ * \var double GDALWarpKernel::dfSrcYExtraSize;
  *
  * Number of pixels included in nSrcYExtraSize that are present on the edges of
  * the area of interest to take into account the height of the kernel.
@@ -981,8 +981,8 @@ GDALWarpKernel::GDALWarpKernel() :
     nBands(0),
     nSrcXSize(0),
     nSrcYSize(0),
-    nSrcXExtraSize(0),
-    nSrcYExtraSize(0),
+    dfSrcXExtraSize(0.0),
+    dfSrcYExtraSize(0.0),
     papabySrcImage(NULL),
     papanBandSrcValid(NULL),
     panUnifiedSrcValid(NULL),
@@ -1056,11 +1056,11 @@ CPLErr GDALWarpKernel::PerformWarp()
 /*      Pre-calculate resampling scales and window sizes for filtering. */
 /* -------------------------------------------------------------------- */
 
-    dfXScale = static_cast<double>(nDstXSize) / (nSrcXSize - nSrcXExtraSize);
-    dfYScale = static_cast<double>(nDstYSize) / (nSrcYSize - nSrcYExtraSize);
-    if( nSrcXSize >= nDstXSize && nSrcXSize <= nDstXSize + nSrcXExtraSize )
+    dfXScale = static_cast<double>(nDstXSize) / (nSrcXSize - dfSrcXExtraSize);
+    dfYScale = static_cast<double>(nDstYSize) / (nSrcYSize - dfSrcYExtraSize);
+    if( nSrcXSize >= nDstXSize && nSrcXSize <= nDstXSize + dfSrcXExtraSize )
         dfXScale = 1.0;
-    if( nSrcYSize >= nDstYSize && nSrcYSize <= nDstYSize + nSrcYExtraSize )
+    if( nSrcYSize >= nDstYSize && nSrcYSize <= nDstYSize + dfSrcYExtraSize )
         dfYScale = 1.0;
     if( dfXScale < 1.0 )
     {

--- a/gdal/alg/gdalwarpoperation.cpp
+++ b/gdal/alg/gdalwarpoperation.cpp
@@ -54,7 +54,7 @@ CPL_CVSID("$Id$")
 struct _GDALWarpChunk {
     int dx, dy, dsx, dsy;
     int sx, sy, ssx, ssy;
-    int sExtraSx, sExtraSy;
+    double sExtraSx, sExtraSy;
 };
 
 /************************************************************************/
@@ -1184,13 +1184,13 @@ CPLErr GDALWarpOperation::CollectChunkListInternal(
     int nSrcYOff = 0;
     int nSrcXSize = 0;
     int nSrcYSize = 0;
-    int nSrcXExtraSize = 0;
-    int nSrcYExtraSize = 0;
+    double dfSrcXExtraSize = 0.0;
+    double dfSrcYExtraSize = 0.0;
     double dfSrcFillRatio = 0.0;
     CPLErr eErr =
         ComputeSourceWindow(nDstXOff, nDstYOff, nDstXSize, nDstYSize,
                             &nSrcXOff, &nSrcYOff, &nSrcXSize, &nSrcYSize,
-                            &nSrcXExtraSize, &nSrcYExtraSize, &dfSrcFillRatio);
+                            &dfSrcXExtraSize, &dfSrcYExtraSize, &dfSrcFillRatio);
 
     if( eErr != CE_None )
     {
@@ -1374,8 +1374,8 @@ CPLErr GDALWarpOperation::CollectChunkListInternal(
     pasChunkList[nChunkListCount].sy = nSrcYOff;
     pasChunkList[nChunkListCount].ssx = nSrcXSize;
     pasChunkList[nChunkListCount].ssy = nSrcYSize;
-    pasChunkList[nChunkListCount].sExtraSx = nSrcXExtraSize;
-    pasChunkList[nChunkListCount].sExtraSy = nSrcYExtraSize;
+    pasChunkList[nChunkListCount].sExtraSx = dfSrcXExtraSize;
+    pasChunkList[nChunkListCount].sExtraSy = dfSrcYExtraSize;
 
     nChunkListCount++;
 
@@ -1452,9 +1452,9 @@ CPLErr GDALWarpOperation::WarpRegion( int nDstXOff, int nDstYOff,
  * @param nSrcYOff source window Y offset (computed if window all zero)
  * @param nSrcXSize source window X size (computed if window all zero)
  * @param nSrcYSize source window Y size (computed if window all zero)
- * @param nSrcXExtraSize Extra pixels (included in nSrcXSize) reserved
+ * @param dfSrcXExtraSize Extra pixels (included in nSrcXSize) reserved
  * for filter window. Should be ignored in scale computation
- * @param nSrcYExtraSize Extra pixels (included in nSrcYSize) reserved
+ * @param dfSrcYExtraSize Extra pixels (included in nSrcYSize) reserved
  * for filter window. Should be ignored in scale computation
  * @param dfProgressBase minimum progress value reported
  * @param dfProgressScale value such as dfProgressBase + dfProgressScale is the
@@ -1467,7 +1467,7 @@ CPLErr GDALWarpOperation::WarpRegion( int nDstXOff, int nDstYOff,
                                       int nDstXSize, int nDstYSize,
                                       int nSrcXOff, int nSrcYOff,
                                       int nSrcXSize, int nSrcYSize,
-                                      int nSrcXExtraSize, int nSrcYExtraSize,
+                                      double dfSrcXExtraSize, double dfSrcYExtraSize,
                                       double dfProgressBase,
                                       double dfProgressScale)
 
@@ -1531,7 +1531,7 @@ CPLErr GDALWarpOperation::WarpRegion( int nDstXOff, int nDstYOff,
         WarpRegionToBuffer(nDstXOff, nDstYOff, nDstXSize, nDstYSize,
                            pDstBuffer, psOptions->eWorkingDataType,
                            nSrcXOff, nSrcYOff, nSrcXSize, nSrcYSize,
-                           nSrcXExtraSize, nSrcYExtraSize,
+                           dfSrcXExtraSize, dfSrcYExtraSize,
                            dfProgressBase, dfProgressScale);
 
 /* -------------------------------------------------------------------- */
@@ -1669,9 +1669,9 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
  * @param nSrcYOff source window Y offset (computed if window all zero)
  * @param nSrcXSize source window X size (computed if window all zero)
  * @param nSrcYSize source window Y size (computed if window all zero)
- * @param nSrcXExtraSize Extra pixels (included in nSrcXSize) reserved
+ * @param dfSrcXExtraSize Extra pixels (included in nSrcXSize) reserved
  * for filter window. Should be ignored in scale computation
- * @param nSrcYExtraSize Extra pixels (included in nSrcYSize) reserved
+ * @param dfSrcYExtraSize Extra pixels (included in nSrcYSize) reserved
  * for filter window. Should be ignored in scale computation
  * @param dfProgressBase minimum progress value reported
  * @param dfProgressScale value such as dfProgressBase + dfProgressScale is the
@@ -1686,7 +1686,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
     // Only in a CPLAssert.
     CPL_UNUSED GDALDataType eBufDataType,
     int nSrcXOff, int nSrcYOff, int nSrcXSize, int nSrcYSize,
-    int nSrcXExtraSize, int nSrcYExtraSize,
+    double dfSrcXExtraSize, double dfSrcYExtraSize,
     double dfProgressBase, double dfProgressScale)
 
 {
@@ -1712,7 +1712,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
             ComputeSourceWindow( nDstXOff, nDstYOff, nDstXSize, nDstYSize,
                                  &nSrcXOff, &nSrcYOff,
                                  &nSrcXSize, &nSrcYSize,
-                                 &nSrcXExtraSize, &nSrcYExtraSize, NULL );
+                                 &dfSrcXExtraSize, &dfSrcYExtraSize, NULL );
         if( hWarpMutex != NULL )
             CPLReleaseMutex( hWarpMutex );
         if( eErr != CE_None )
@@ -1751,8 +1751,8 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
     oWK.nSrcYOff = nSrcYOff;
     oWK.nSrcXSize = nSrcXSize;
     oWK.nSrcYSize = nSrcYSize;
-    oWK.nSrcXExtraSize = nSrcXExtraSize;
-    oWK.nSrcYExtraSize = nSrcYExtraSize;
+    oWK.dfSrcXExtraSize = dfSrcXExtraSize;
+    oWK.dfSrcYExtraSize = dfSrcYExtraSize;
 
     if( nSrcXSize != 0 && nSrcYSize != 0 &&
         (nSrcXSize > INT_MAX / nSrcYSize ||
@@ -2347,7 +2347,7 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
     int nDstXSize, int nDstYSize,
     int *pnSrcXOff, int *pnSrcYOff,
     int *pnSrcXSize, int *pnSrcYSize,
-    int *pnSrcXExtraSize, int *pnSrcYExtraSize,
+    double *pdfSrcXExtraSize, double *pdfSrcYExtraSize,
     double *pdfSrcFillRatio )
 
 {
@@ -2581,10 +2581,10 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
         *pnSrcYOff = 0;
         *pnSrcXSize = 0;
         *pnSrcYSize = 0;
-        if( pnSrcXExtraSize )
-            *pnSrcXExtraSize = 0;
-        if( pnSrcYExtraSize )
-            *pnSrcYExtraSize = 0;
+        if( pdfSrcXExtraSize )
+            *pdfSrcXExtraSize = 0.0;
+        if( pdfSrcYExtraSize )
+            *pdfSrcYExtraSize = 0.0;
         if( pdfSrcFillRatio )
             *pdfSrcFillRatio = 0.0;
         return CE_None;
@@ -2604,9 +2604,9 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
         static_cast<double>(nDstXSize) / (dfMaxXOut - dfMinXOut);
     const double dfYScale =
         static_cast<double>(nDstYSize) / (dfMaxYOut - dfMinYOut);
-    const int nXRadius = dfXScale < 1.0 ?
+    const int nXRadius = dfXScale < 0.95 ?
         static_cast<int>(ceil( nResWinSize / dfXScale )) : nResWinSize;
-    const int nYRadius = dfYScale < 1.0 ?
+    const int nYRadius = dfYScale < 0.95 ?
         static_cast<int>(ceil( nResWinSize / dfYScale )) : nResWinSize;
     nResWinSize = std::max(nXRadius, nYRadius);
 
@@ -2655,12 +2655,14 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
     if( dfCeilMaxYOut > INT_MAX )
         dfCeilMaxYOut = INT_MAX;
 
-    int nSrcXSizeRaw = std::min(nRasterXSize - *pnSrcXOff,
-                                static_cast<int>(dfCeilMaxXOut) - *pnSrcXOff);
-    int nSrcYSizeRaw = std::min(nRasterYSize - *pnSrcYOff,
-                                static_cast<int>(dfCeilMaxYOut) - *pnSrcYOff);
-    nSrcXSizeRaw = std::max(0, nSrcXSizeRaw);
-    nSrcYSizeRaw = std::max(0, nSrcYSizeRaw);
+    double dfSrcXSizeRaw = dfMaxXOut - dfMinXOut;
+    double dfSrcYSizeRaw = dfMaxYOut - dfMinYOut;
+    dfSrcXSizeRaw = std::min(static_cast<double>(nRasterXSize - *pnSrcXOff),
+                             dfSrcXSizeRaw);
+    dfSrcYSizeRaw = std::min(static_cast<double>(nRasterYSize - *pnSrcYOff),
+                             dfSrcYSizeRaw);
+    dfSrcXSizeRaw = std::max(0.0, dfSrcXSizeRaw);
+    dfSrcYSizeRaw = std::max(0.0, dfSrcYSizeRaw);
 
     *pnSrcXOff = std::max(0, nMinXOutClamped - nResWinSize);
     *pnSrcYOff = std::max(0, nMinYOutClamped - nResWinSize);
@@ -2676,10 +2678,10 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
     *pnSrcXSize = std::max(0, *pnSrcXSize);
     *pnSrcYSize = std::max(0, *pnSrcYSize);
 
-    if( pnSrcXExtraSize )
-        *pnSrcXExtraSize = *pnSrcXSize - nSrcXSizeRaw;
-    if( pnSrcYExtraSize )
-        *pnSrcYExtraSize = *pnSrcYSize - nSrcYSizeRaw;
+    if( pdfSrcXExtraSize )
+        *pdfSrcXExtraSize = *pnSrcXSize - dfSrcXSizeRaw;
+    if( pdfSrcYExtraSize )
+        *pdfSrcYExtraSize = *pnSrcYSize - dfSrcYSizeRaw;
 
     // Computed the ratio of the clamped source raster window size over
     // the unclamped source raster window size.


### PR DESCRIPTION
This PR consists of two commits. The first adds only a failing test, which demonstrates a bug. The second fixes it.

The bug is based on a rounding error when calculating the scale factors. In the new test case they should be exactly 1, but were sometimes 0.5 instead. With such a factor, to prevent aliasing effects, a filter is used instead of the actually desired 4-sample bilinear interpolation. This is why the new test fails.

The scale factor depends on the destination size and (raw) source size. However, the source size is rounded to an integer, which is not required. The scale factor should give the exact scaling, which relies on the (integer) destination size and the real source size. Therefore the second commit changes the source extra size variable to double type, such that when subtracted from the integer source (window) size, it gives the real (raw) source size.

Also, the scale factors in GDALWarpOperation::ComputeSourceWindow, which are used to compute the window size, are now compared to 0.95 instead of 1 for consistency with GDALWarpKernel methods. They also gave occasionally the wrong value due to rounding.