### PR TITLE
Avoid perl binding failures due to isnan clash (GCC 7)

### DIFF
--- a/gdal/port/cpl_port.h
+++ b/gdal/port/cpl_port.h
@@ -634,7 +634,7 @@ static inline char* CPL_afl_friendly_strstr(const char* haystack, const char* ne
 /*      function but no corresponding macro, but I can live with        */
 /*      that since it isn't that important a test.                      */
 /* -------------------------------------------------------------------- */
-#ifdef _MSC_VER
+#if defined(WIN64) || defined(_MSC_VER)
 #  include <float.h>
 #  define CPLIsNan(x) _isnan(x)
 #  define CPLIsInf(x) (!_isnan(x) && !_finite(x))


### PR DESCRIPTION
This commit should avoid failures when building the perl bindings using GCC 7.1 (from the strawberry perl project).  



Example failures look like:

```
C:\berrybrew\5.26.1_64_PDL\perl\lib\CORE/win32.h:361:16: error: '_isnan' is not a member of 'std'
 #define isnan  _isnan /* ...same libraries as MSVC */
                ^
C:/shawn/git/perl-alien-gdal/blib/lib/auto/share/dist/Alien-gdal/include/cpl_port.h:661:51: note: in expansion of macro 'isnan'
 static inline int CPLIsNan(float f) { return std::isnan(f); }
                                                   ^
                ^
```

The patch was adapted from https://rt.cpan.org/Ticket/Display.html?id=121683

I don't know if it is the correct fix, but it works for my use case.  

Shawn.
