### PR TITLE
Add DMD_CREATIONFIELDDATASUBTYPES metadata type

### DIFF
--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -310,6 +310,11 @@ typedef GIntBig GSpacing;
  * */
 #define GDAL_DMD_CREATIONFIELDDATATYPES "DMD_CREATIONFIELDDATATYPES"
 
+/** List of (space separated) vector field sub-types support by the CreateField() API.
+ * @since GDAL 2.3
+ * */
+#define GDAL_DMD_CREATIONFIELDDATASUBTYPES "DMD_CREATIONFIELDDATASUBTYPES"
+
 /** Capability set by a driver that exposes Subdatasets. */
 #define GDAL_DMD_SUBDATASETS "DMD_SUBDATASETS"
 

--- a/gdal/gcore/gdal_misc.cpp
+++ b/gdal/gcore/gdal_misc.cpp
@@ -3094,6 +3094,9 @@ GDALGeneralCmdLineProcessor( int nArgc, char ***ppapszArgv, int nOptions )
             if( CSLFetchNameValue( papszMD, GDAL_DMD_CREATIONFIELDDATATYPES ) )
                 printf( "  Creation Field Datatypes: %s\n",/*ok*/
                         CSLFetchNameValue( papszMD, GDAL_DMD_CREATIONFIELDDATATYPES ) );
+            if ( CSLFetchNameValue( papszMD, GDAL_DMD_CREATIONFIELDDATASUBTYPES ) )
+              printf( "  Creation Field Data Sub-types: %s\n",/*ok*/
+                      CSLFetchNameValue( papszMD, GDAL_DMD_CREATIONFIELDDATASUBTYPES ) );
             if( CPLFetchBool( papszMD, GDAL_DCAP_NOTNULL_FIELDS, false ) )
                 printf( "  Supports: Creating fields with NOT NULL constraint.\n" );/*ok*/
             if( CPLFetchBool( papszMD, GDAL_DCAP_DEFAULT_FIELDS, false ) )

--- a/gdal/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
@@ -376,6 +376,7 @@ void RegisterOGRCSV()
                               "Integer Integer64 Real String Date DateTime "
                               "Time IntegerList Integer64List RealList "
                               "StringList");
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean Int16 Float32" );
 
     poDriver->pfnOpen = OGRCSVDriverOpen;
     poDriver->pfnIdentify = OGRCSVDriverIdentify;

--- a/gdal/ogr/ogrsf_frmts/filegdb/FGdbDriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/filegdb/FGdbDriver.cpp
@@ -849,6 +849,7 @@ void RegisterOGRFileGDB()
 
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,
                                "Integer Real String Date DateTime Binary" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Int16 Float32" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_DEFAULT_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_GEOMFIELDS, "YES" );

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
@@ -663,6 +663,7 @@ void RegisterOGRGeoJSON()
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,
                                "Integer Integer64 Real String IntegerList "
                                "Integer64List RealList StringList" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean" );
 
     poDriver->pfnOpen = OGRGeoJSONDriverOpen;
     poDriver->pfnIdentify = OGRGeoJSONDriverIdentify;

--- a/gdal/ogr/ogrsf_frmts/gml/ogrgmldriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/gml/ogrgmldriver.cpp
@@ -222,6 +222,7 @@ void RegisterOGRGML()
 
     poDriver->SetMetadataItem( GDAL_DS_LAYER_CREATIONOPTIONLIST, "<LayerCreationOptionList/>");
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES, "Integer Integer64 Real String Date DateTime IntegerList Integer64List RealList StringList" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean Int16 Float32" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_GEOMFIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -403,6 +403,7 @@ COMPRESSION_OPTIONS
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,
                                "Integer Integer64 Real String Date DateTime "
                                "Binary" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean Int16 Float32" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_DEFAULT_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_GEOMFIELDS, "YES" );

--- a/gdal/ogr/ogrsf_frmts/mongodb/ogrmongodbdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/mongodb/ogrmongodbdriver.cpp
@@ -2844,6 +2844,7 @@ void RegisterOGRMongoDB()
 "</OpenOptionList>");
 
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES, "Integer Integer64 Real String Date DateTime Time IntegerList Integer64List RealList StringList Binary" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean" );
 
     poDriver->pfnOpen = OGRMongoDBDriverOpen;
     poDriver->pfnIdentify = OGRMongoDBDriverIdentify;

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
@@ -160,6 +160,7 @@ void RegisterOGRPG()
                                "Integer Integer64 Real String Date DateTime "
                                "Time IntegerList Integer64List RealList "
                                "StringList Binary" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean Int16 Float32" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_DEFAULT_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_GEOMFIELDS, "YES" );

--- a/gdal/ogr/ogrsf_frmts/pgdump/ogrpgdumpdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgdump/ogrpgdumpdriver.cpp
@@ -125,6 +125,7 @@ void RegisterOGRPGDump()
                                "Integer Integer64 Real String Date DateTime "
                                "Time IntegerList Integer64List RealList "
                                "StringList Binary" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean Int16 Float32" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_DEFAULT_FIELDS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_NOTNULL_GEOMFIELDS, "YES" );

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitedriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitedriver.cpp
@@ -355,6 +355,8 @@ void RegisterOGRSQLite()
                                "Integer Integer64 Real String Date DateTime "
                                "Time Binary IntegerList Integer64List "
                                "RealList StringList" );
+    poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean Int16 Float32" );
+
 #ifdef HAVE_RASTERLITE2
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte UInt16 Int16 UInt32 Int32 Float32 "


### PR DESCRIPTION
For determining vector field sub-types which can be created for a driver.

There's currently the GDAL_DMD_CREATIONFIELDDATATYPES type which returns field types for a driver, but no way of currently determining sub-types which are handled by a driver.