### PR TITLE
Fix potential geotiff condition error

### DIFF
--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -16955,7 +16955,6 @@ GTiffDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
         GTIFF_CopyFromJPEG_WriteAdditionalTags(l_hTIFF,
                                                poSrcDS);
     }
-#endif
 
 #if !defined(BIGTIFF_SUPPORT)
     /* -------------------------------------------------------------------- */
@@ -16986,6 +16985,7 @@ GTiffDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
         }
         l_bDontReloadFirstBlock = true;
     }
+#endif
 #endif
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
ifdef  block and bracket  are not match.
Current configure not produce a situation to break but potential problem.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>