### PR TITLE
Support out-of-source build on test

### DIFF
--- a/autotest/cpp/test_data.h
+++ b/autotest/cpp/test_data.h
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Project:  C++ Test Suite for GDAL/OGR
+// Purpose:  Locate test data for test suite
+// Author:   Hiroshi Miura
+//
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017, Hiroshi Miura
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Library General Public
+// License as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Library General Public License for more details.
+//
+// You should have received a copy of the GNU Library General Public
+// License along with this library; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef GDAL_TEST_DATA_H
+#define GDAL_TEST_DATA_H
+
+// Use GDAL_TEST_ROOT_DIR for the root directory of test project's source
+#ifdef GDAL_TEST_ROOT_DIR
+#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
+#define GDRIVERS_DIR GDAL_TEST_ROOT_DIR "/gdrivers/"
+#else
+#define GCORE_DATA_DIR "../gcore/data/"
+#define GDRIVERS_DIR "../gdrivers/"
+#endif
+
+#endif //GDAL_TEST_DATA_H

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -33,11 +33,7 @@
 #include <limits>
 #include <string>
 
-#ifdef GDAL_TEST_ROOT_DIR
-#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
-#else
-#define GCORE_DATA_DIR "../gcore/data/"
-#endif
+#include "test_data.h"
 
 namespace tut
 {

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -33,6 +33,12 @@
 #include <limits>
 #include <string>
 
+#ifdef GDAL_TEST_ROOT_DIR
+#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
+#else
+#define GCORE_DATA_DIR "../gcore/data/"
+#endif
+
 namespace tut
 {
     // Common fixture with test data
@@ -291,7 +297,7 @@ namespace tut
         GetGDALDriverManager()->RegisterDriver( poDriver );
         const char* args[] = { "-of", "DatasetWithErrorInFlushCache", nullptr };
         GDALTranslateOptions* psOptions = GDALTranslateOptionsNew((char**)args, nullptr);
-        GDALDatasetH hSrcDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+        GDALDatasetH hSrcDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
         CPLErrorReset();
         CPLPushErrorHandler(CPLQuietErrorHandler);
         GDALDatasetH hOutDS = GDALTranslate("", hSrcDS, psOptions, nullptr);
@@ -313,7 +319,7 @@ namespace tut
         GetGDALDriverManager()->RegisterDriver( poDriver );
         const char* args[] = { "-of", "DatasetWithErrorInFlushCache", nullptr };
         GDALWarpAppOptions* psOptions = GDALWarpAppOptionsNew((char**)args, nullptr);
-        GDALDatasetH hSrcDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+        GDALDatasetH hSrcDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
         CPLErrorReset();
         CPLPushErrorHandler(CPLQuietErrorHandler);
         GDALDatasetH hOutDS = GDALWarp("/", nullptr, 1, &hSrcDS, psOptions, nullptr);

--- a/autotest/cpp/testblockcachelimits.cpp
+++ b/autotest/cpp/testblockcachelimits.cpp
@@ -35,11 +35,17 @@
 
 #include <cassert>
 
+#ifdef GDAL_TEST_ROOT_DIR
+#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
+#else
+#define GCORE_DATA_DIR "../gcore/data/"
+#endif
+
 static void thread_func(void* /* unused */)
 {
     printf("begin thread %p\n", (void*)CPLGetPID());
     CPLSetThreadLocalConfigOption("GDAL_RB_INTERNALIZE_SLEEP_AFTER_DROP_LOCK", "0.6");
-    GDALDatasetH hDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+    GDALDatasetH hDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
     char buf[20*20];
     CPL_IGNORE_RET_VAL(GDALRasterIO(GDALGetRasterBand(hDS, 1), GF_Read, 0, 0, 20, 20, buf, 20, 20, GDT_Byte, 0, 0));
     CPLSetThreadLocalConfigOption("GDAL_RB_INTERNALIZE_SLEEP_AFTER_DROP_LOCK", "0");
@@ -89,7 +95,7 @@ int main(int argc, char* argv[])
     CPLSetConfigOption("GDAL_DEBUG_BLOCK_CACHE", "ON");
     GDALAllRegister();
 
-    GDALDatasetH hDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+    GDALDatasetH hDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
 
     char buf[20*20];
     printf("cache fill\n");
@@ -140,7 +146,7 @@ int main(int argc, char* argv[])
     GDALClose(hDS);
     CPLJoinThread(hThread);
 
-    hDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+    hDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
     CPL_IGNORE_RET_VAL(GDALRasterIO(GDALGetRasterBand(hDS, 1), GF_Read, 0, 0, 20, 20, buf, 20, 20, GDT_Byte, 0, 0));
     hThread = CPLCreateJoinableThread(thread_func4, nullptr);
     CPLSleep(0.3);

--- a/autotest/cpp/testblockcachelimits.cpp
+++ b/autotest/cpp/testblockcachelimits.cpp
@@ -35,11 +35,7 @@
 
 #include <cassert>
 
-#ifdef GDAL_TEST_ROOT_DIR
-#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
-#else
-#define GCORE_DATA_DIR "../gcore/data/"
-#endif
+#include "test_data.h"
 
 static void thread_func(void* /* unused */)
 {

--- a/autotest/cpp/testclosedondestroydm.cpp
+++ b/autotest/cpp/testclosedondestroydm.cpp
@@ -35,6 +35,14 @@
 
 #include <cassert>
 
+#ifdef GDAL_TEST_ROOT_DIR
+#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
+#define GDRIVERS_DIR GDAL_TEST_ROOT_DIR "/gdrivers/"
+#else
+#define GCORE_DATA_DIR "../gcore/data/"
+#define GDRIVERS_DIR "../gdrivers/"
+#endif
+
 static void OpenJPEG2000(const char* pszFilename)
 {
     const int N_DRIVERS = 6;
@@ -87,41 +95,41 @@ int main(int /* argc*/ , char* /* argv */[])
 
     GDALAllRegister();
 
-    hDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+    hDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gcore/data/byte.vrt", GA_ReadOnly);
+    hDS = GDALOpen(GCORE_DATA_DIR "byte.vrt", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gdrivers/data/rgb_warp.vrt", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/rgb_warp.vrt", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gdrivers/data/A.TOC", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/A.TOC", GA_ReadOnly);
 
-    hDS = GDALOpen("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:../gdrivers/data/A.TOC", GA_ReadOnly);
+    hDS = GDALOpen("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:" GDRIVERS_DIR "data/A.TOC", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gdrivers/data/testtil.til", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/testtil.til", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gdrivers/data/product.xml", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/product.xml", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gdrivers/data/METADATA.DIM", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/METADATA.DIM", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gdrivers/tmp/cache/file9_j2c.ntf", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "tmp/cache/file9_j2c.ntf", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen("../gdrivers/data/bug407.gif", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/bug407.gif", GA_ReadOnly);
     if (hDS)
     {
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
@@ -130,7 +138,7 @@ int main(int /* argc*/ , char* /* argv */[])
     }
 
     /* Create external overviews */
-    hSrcDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+    hSrcDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
     hDS = GDALCreateCopy(GDALGetDriverByName("GTiff"), "byte.tif", hSrcDS, 0, nullptr, nullptr, nullptr);
     GDALClose(hSrcDS);
     hSrcDS = nullptr;
@@ -144,7 +152,7 @@ int main(int /* argc*/ , char* /* argv */[])
     GDALGetOverviewCount(GDALGetRasterBand(hDS, 1));
 
     /* Create internal overviews */
-    hSrcDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+    hSrcDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
     hDS = GDALCreateCopy(GDALGetDriverByName("GTiff"), "byte2.tif", hSrcDS, 0, nullptr, nullptr, nullptr);
     GDALClose(hSrcDS);
     hSrcDS = nullptr;
@@ -158,7 +166,7 @@ int main(int /* argc*/ , char* /* argv */[])
     GDALGetOverviewCount(GDALGetRasterBand(hDS, 1));
 
     /* Create external mask */
-    hSrcDS = GDALOpen("../gcore/data/byte.tif", GA_ReadOnly);
+    hSrcDS = GDALOpen(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
     hDS = GDALCreateCopy(GDALGetDriverByName("GTiff"), "byte3.tif", hSrcDS, 0, nullptr, nullptr, nullptr);
     GDALClose(hSrcDS);
     hSrcDS = nullptr;
@@ -173,7 +181,7 @@ int main(int /* argc*/ , char* /* argv */[])
     fprintf(f, "%s", "<VRTDataset rasterXSize=\"20\" rasterYSize=\"20\">"
   "<VRTRasterBand dataType=\"Byte\" band=\"1\">"
     "<SimpleSource>"
-      "<SourceFilename relativeToVRT=\"1\">../gcore/data/byte.tif</SourceFilename>"
+      "<SourceFilename relativeToVRT=\"1\">" GCORE_DATA_DIR "byte.tif</SourceFilename>"
       "<SourceBand>1</SourceBand>"
       "<SourceProperties RasterXSize=\"20\" RasterYSize=\"20\" DataType=\"Byte\" BlockXSize=\"20\" BlockYSize=\"20\" />"
       "<SrcRect xOff=\"0\" yOff=\"0\" xSize=\"20\" ySize=\"20\"/>"
@@ -206,17 +214,17 @@ int main(int /* argc*/ , char* /* argv */[])
 "</VRTDataset>", GA_ReadOnly);
     GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpenShared("../gcore/data/byte.tif", GA_ReadOnly);
-    hDS = GDALOpenShared("../gcore/data/byte.tif", GA_ReadOnly);
+    hDS = GDALOpenShared(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
+    hDS = GDALOpenShared(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
 
-    hDS = GDALOpenShared("../gdrivers/data/mercator.sid", GA_ReadOnly);
+    hDS = GDALOpenShared(GDRIVERS_DIR "data/mercator.sid", GA_ReadOnly);
 
-    hDS = GDALOpen("RASTERLITE:../gdrivers/data/rasterlite_pyramids.sqlite,table=test", GA_ReadOnly);
-    hDS = GDALOpen("RASTERLITE:../gdrivers/data/rasterlite_pyramids.sqlite,table=test,level=1", GA_ReadOnly);
+    hDS = GDALOpen("RASTERLITE:" GDRIVERS_DIR "data/rasterlite_pyramids.sqlite,table=test", GA_ReadOnly);
+    hDS = GDALOpen("RASTERLITE:" GDRIVERS_DIR "data/rasterlite_pyramids.sqlite,table=test,level=1", GA_ReadOnly);
 
-    OpenJPEG2000("../gdrivers/data/rgbwcmyk01_YeGeo_kakadu.jp2");
+    OpenJPEG2000(GDRIVERS_DIR "data/rgbwcmyk01_YeGeo_kakadu.jp2");
 
-    hDS = GDALOpen("../gdrivers/tmp/cache/Europe 2001_OZF.map", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "tmp/cache/Europe 2001_OZF.map", GA_ReadOnly);
 
     CPLDebug("TEST","Call GDALDestroyDriverManager()");
     GDALDestroyDriverManager();

--- a/autotest/cpp/testclosedondestroydm.cpp
+++ b/autotest/cpp/testclosedondestroydm.cpp
@@ -35,13 +35,7 @@
 
 #include <cassert>
 
-#ifdef GDAL_TEST_ROOT_DIR
-#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
-#define GDRIVERS_DIR GDAL_TEST_ROOT_DIR "/gdrivers/"
-#else
-#define GCORE_DATA_DIR "../gcore/data/"
-#define GDRIVERS_DIR "../gdrivers/"
-#endif
+#include "test_data.h"
 
 static void OpenJPEG2000(const char* pszFilename)
 {

--- a/autotest/cpp/testvirtualmem.cpp
+++ b/autotest/cpp/testvirtualmem.cpp
@@ -75,6 +75,12 @@ static void test_huge_mapping()
 }
 #endif
 
+#ifdef GDAL_TEST_ROOT_DIR
+#define DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
+#else
+#define DATA_DIR "../gcore/data/"
+#endif
+
 static void test_two_pages_cbk(CPLVirtualMem* /* ctxt */,
                   size_t nOffset,
                   void* pPageToFill,
@@ -235,7 +241,7 @@ int main(int /* argc */, char* /* argv */[])
     if( CPLIsVirtualMemFileMapAvailable() )
     {
         printf("Testing CPLVirtualMemFileMapNew()\n");
-        VSILFILE* fp = VSIFOpenL("../gcore/data/byte.tif", "rb");
+        VSILFILE* fp = VSIFOpenL(DATA_DIR "byte.tif", "rb");
         assert(fp);
         VSIFSeekL(fp, 0, SEEK_END);
         size_t nSize = (size_t)VSIFTellL(fp);

--- a/autotest/cpp/testvirtualmem.cpp
+++ b/autotest/cpp/testvirtualmem.cpp
@@ -75,11 +75,7 @@ static void test_huge_mapping()
 }
 #endif
 
-#ifdef GDAL_TEST_ROOT_DIR
-#define DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
-#else
-#define DATA_DIR "../gcore/data/"
-#endif
+#include "test_data.h"
 
 static void test_two_pages_cbk(CPLVirtualMem* /* ctxt */,
                   size_t nOffset,
@@ -241,7 +237,7 @@ int main(int /* argc */, char* /* argv */[])
     if( CPLIsVirtualMemFileMapAvailable() )
     {
         printf("Testing CPLVirtualMemFileMapNew()\n");
-        VSILFILE* fp = VSIFOpenL(DATA_DIR "byte.tif", "rb");
+        VSILFILE* fp = VSIFOpenL(GCORE_DATA_DIR "byte.tif", "rb");
         assert(fp);
         VSIFSeekL(fp, 0, SEEK_END);
         size_t nSize = (size_t)VSIFTellL(fp);


### PR DESCRIPTION
Here introduce a GDAL_TEST_ROOT_DIR to allow autotest/cpp to run out-of-source.

It allows build system to make test program out-of-source and run it.
Without specifying GDAL_TEST_ROOT_DIR, a behavior is as same as before.

It is preparation for migrating a build system to support out-of-source build.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>