### PR TITLE
Explicitly delete copy constructor

### DIFF
--- a/gdal/port/cpl_conv.h
+++ b/gdal/port/cpl_conv.h
@@ -295,12 +295,12 @@ public:
     CPLLocaleC();
     ~CPLLocaleC();
 
+	/* Make it non-copyable */
+	CPLLocaleC(const CPLLocaleC&) = delete;
+	CPLLocaleC& operator=(const CPLLocaleC&) = delete;
+
 private:
     char *pszOldLocale;
-
-    /* Make it non-copyable */
-    CPLLocaleC(const CPLLocaleC&);
-    CPLLocaleC& operator=(const CPLLocaleC&);
 };
 
 // Does the same as CPLLocaleC except that, when available, it tries to
@@ -314,12 +314,12 @@ public:
     CPLThreadLocaleC();
     ~CPLThreadLocaleC();
 
+	/* Make it non-copyable */
+	CPLThreadLocaleC(const CPLThreadLocaleC&) = delete;
+	CPLThreadLocaleC& operator=(const CPLThreadLocaleC&) = delete;
+
 private:
     CPLThreadLocaleCPrivate* m_private;
-
-    /* Make it non-copyable */
-    CPLThreadLocaleC(const CPLThreadLocaleC&);
-    CPLThreadLocaleC& operator=(const CPLThreadLocaleC&);
 };
 
 #endif /* def __cplusplus */
@@ -341,14 +341,14 @@ public:
                           bool bSetOnlyIfUndefined);
     ~CPLConfigOptionSetter();
 
+	/* Make it non-copyable */
+	CPLConfigOptionSetter(const CPLConfigOptionSetter&) = delete;
+	CPLConfigOptionSetter& operator=(const CPLConfigOptionSetter&) = delete;
+
 private:
     char* m_pszKey;
     char *m_pszOldValue;
     bool m_bRestoreOldValue;
-
-    /* Make it non-copyable */
-    CPLConfigOptionSetter(const CPLConfigOptionSetter&);
-    CPLConfigOptionSetter& operator=(const CPLConfigOptionSetter&);
 };
 
 #endif /* def __cplusplus */

--- a/gdal/port/cpl_conv.h
+++ b/gdal/port/cpl_conv.h
@@ -295,9 +295,9 @@ public:
     CPLLocaleC();
     ~CPLLocaleC();
 
-	/* Make it non-copyable */
-	CPLLocaleC(const CPLLocaleC&) = delete;
-	CPLLocaleC& operator=(const CPLLocaleC&) = delete;
+    /* Make it non-copyable */
+    CPLLocaleC(const CPLLocaleC&) = delete;
+    CPLLocaleC& operator=(const CPLLocaleC&) = delete;
 
 private:
     char *pszOldLocale;
@@ -314,9 +314,9 @@ public:
     CPLThreadLocaleC();
     ~CPLThreadLocaleC();
 
-	/* Make it non-copyable */
-	CPLThreadLocaleC(const CPLThreadLocaleC&) = delete;
-	CPLThreadLocaleC& operator=(const CPLThreadLocaleC&) = delete;
+    /* Make it non-copyable */
+    CPLThreadLocaleC(const CPLThreadLocaleC&) = delete;
+    CPLThreadLocaleC& operator=(const CPLThreadLocaleC&) = delete;
 
 private:
     CPLThreadLocaleCPrivate* m_private;
@@ -341,9 +341,9 @@ public:
                           bool bSetOnlyIfUndefined);
     ~CPLConfigOptionSetter();
 
-	/* Make it non-copyable */
-	CPLConfigOptionSetter(const CPLConfigOptionSetter&) = delete;
-	CPLConfigOptionSetter& operator=(const CPLConfigOptionSetter&) = delete;
+    /* Make it non-copyable */
+    CPLConfigOptionSetter(const CPLConfigOptionSetter&) = delete;
+    CPLConfigOptionSetter& operator=(const CPLConfigOptionSetter&) = delete;
 
 private:
     char* m_pszKey;


### PR DESCRIPTION
This is a small change to use C++11 delete keyword instead of declaring methods private