### PR TITLE
Force Google compute engine detection with CPL_MACHINE_IS_GCE=YES

### DIFF
--- a/gdal/doc/gdal_virtual_file_systems.dox
+++ b/gdal/doc/gdal_virtual_file_systems.dox
@@ -454,7 +454,9 @@ for OAuth2 client authentication.</li>
  <li>(GDAL &gt;= 2.3) Finally if none of the above method succeeds, the code
 will check if the current machine is a Google Compute Engine instance, and
 if so will use the permissions associated to it (using the default service
-account associated with the VM)</li>
+account associated with the VM). To force a machine to be detected as a GCE instance
+(for example for code running in a container with no access to the boot logs), you
+can set CPL_MACHINE_IS_GCE to YES.</li>
 </ol>
 
 @since GDAL 2.2

--- a/gdal/port/cpl_google_cloud.cpp
+++ b/gdal/port/cpl_google_cloud.cpp
@@ -55,6 +55,11 @@ static GOA2Manager oStaticManager;
  */
 bool CPLIsMachineForSureGCEInstance()
 {
+    if( CPLTestBool(CPLGetConfigOption(
+                        "CPL_MACHINE_IS_GCE", "NO")) )
+    {
+        return true;
+    }
 #ifdef __linux
     // If /var/log/kern.log exists, it should contain a string like
     // DMI: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011


### PR DESCRIPTION
The detection code used to obtain default credentials from a GCE instance's metadata server fails if the code is running inside a container with no access to the boot logs. This PR adds a CPL_MACHINE_IS_GCE config option that informs gdal that the instance is in fact a GCE instance and thus has access to the metadata server