### PR TITLE
Use panSrcBands when accessing the source data

### DIFF
--- a/gdal/alg/gdalwarpoperation.cpp
+++ b/gdal/alg/gdalwarpoperation.cpp
@@ -1793,7 +1793,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
         if( psOptions->nBandCount == 1 )
         {
             // Particular case to simplify the stack a bit.
-            eErr = poSrcDS->GetRasterBand(psOptions->panDstBands[0])->RasterIO(
+            eErr = poSrcDS->GetRasterBand(psOptions->panSrcBands[0])->RasterIO(
                                   GF_Read,
                                   nSrcXOff, nSrcYOff, nSrcXSize, nSrcYSize,
                                   oWK.papabySrcImage[0], nSrcXSize, nSrcYSize,


### PR DESCRIPTION
Commit 65fd09caf43989799a4834e12e7ea30ccd197f2a introduced an optimisation when there is only a single band being read, but when reading from the source it is using `panDstBands` to find the number of that band which will be wrong if the band number is different in the source and destination file.

This is a simple test case, extracted from one of the `node-gdal` tests, which demonstrates the problem:

```c++
#include <stdlib.h>

#include <gdal_priv.h>
#include <gdalwarper.h>
#include <ogrsf_frmts.h>

int main(int argc, char **argv)
{
  GDALAllRegister();

  GDALDriver *mem = GetGDALDriverManager()->GetDriverByName("MEM");
  GDALDataset *src = (GDALDataset *)GDALOpenEx("./rpm/BUILD/node-gdal-0.9.6-fedora/test/data/sample.tif", GDAL_OF_READONLY, NULL, NULL, NULL);
  GDALDataset *dst = mem->Create("temp", 208, 127, 2, GDT_Int16, nullptr);
  GDALWarpOptions *options = GDALCreateWarpOptions();
  int srcBands[1] = { 1 };
  int dstBands[1] = { 2 };
  double transform[6] = { -110.3765574645805, 0.0005, 0, 44.59676651822825, 0, -0.0005 };

  options->hSrcDS = src;
  options->hDstDS = dst;
  options->nDstAlphaBand = 1;
  options->nBandCount = 1;
  options->panSrcBands = srcBands;
  options->panDstBands = dstBands;

  const char *s_srs_wkt = src->GetProjectionRef();
  char *t_srs_wkt;

  OGRSpatialReference::GetWGS84SRS()->exportToWkt(&t_srs_wkt);

  dst->SetProjection(t_srs_wkt);
  dst->SetGeoTransform(transform);

  GDALReprojectImage(options->hSrcDS, s_srs_wkt,
                     options->hDstDS, t_srs_wkt,
                     options->eResampleAlg, 0.0, 0,
                     nullptr, nullptr, options);

  exit(0);
}
```

without this change that will error as it tries to read band 2 from a source that only has one band:

```
ERROR 5: ./rpm/BUILD/node-gdal-0.9.6-fedora/test/data/sample.tif: GDALDataset::GetRasterBand(2) - Illegal band #
```