### PR TITLE
Do not test $? after running commands. Just use 'if cmd ; then' instead

### DIFF
--- a/gdal/scripts/detect_printf.sh
+++ b/gdal/scripts/detect_printf.sh
@@ -4,9 +4,7 @@ ret_code=0
 
 echo "Checking for printf() statements..."
 # apps is voluntarily missing in the list of directories, due to lots of legitimate uses of such statements in programs
-grep -r --include="*.c*" " printf" alg gnm port ogr gcore frmts | grep -v "/*ok" | grep -v "printf()" | grep -v "printf-like" | grep -v "printf style" | grep -v "with printf"  | grep -v "/\* printf" |  grep -v "//" | grep -v degrib | grep -v aitest | grep -v dted_test | grep -v giflib | grep -v 8211view | grep -v 8211dump | grep -v timetest | grep -v 8211createfromxml | grep -v hfatest | grep -v zlib | grep -v libtiff | grep -v envisat_dump | grep -v dumpgeo | grep -v nitfdump | grep -v ceostest| grep -v libpng | grep -v generate_encoding | grep -v capi_test | grep -v ntfdump | grep -v test_load_virtual_ogr | grep -v ocitest | grep -v fastload | grep -v s57dump | grep -v dgndump | grep -v test_geo_utils | grep -v testparser | grep -v internal_libqhull
-
-if [[ $? -eq 0 ]] ; then
+if grep -r --include="*.c*" " printf" alg gnm port ogr gcore frmts | grep -v "/*ok" | grep -v "printf()" | grep -v "printf-like" | grep -v "printf style" | grep -v "with printf"  | grep -v "/\\* printf" |  grep -v "//" | grep -v degrib | grep -v aitest | grep -v dted_test | grep -v giflib | grep -v 8211view | grep -v 8211dump | grep -v timetest | grep -v 8211createfromxml | grep -v hfatest | grep -v zlib | grep -v libtiff | grep -v envisat_dump | grep -v dumpgeo | grep -v nitfdump | grep -v ceostest| grep -v libpng | grep -v generate_encoding | grep -v capi_test | grep -v ntfdump | grep -v test_load_virtual_ogr | grep -v ocitest | grep -v fastload | grep -v s57dump | grep -v dgndump | grep -v test_geo_utils | grep -v testparser | grep -v internal_libqhull ; then
     echo "FAIL: suspicious printf found. Remove or tag it with /*ok*/"
     ret_code=1
 else
@@ -16,9 +14,7 @@ fi
 
 echo "Checking for fprintf(stderr,) statements..."
 # apps is voluntarily missing in the list of directories, due to lots of legitimate uses of such statements in programs
-grep fprintf -r  alg gnm port ogr gcore frmts --include="*.cpp" | grep stderr | grep -v -G "/[/|*][ ]*fprintf" | grep -v "/*ok" | grep -v sdts2shp | grep -v degrib  | grep -v 8211view | grep -v 8211createfromxml | grep -v 8211dump | grep -v pcidskexception | grep -v vsipreload | grep -v fprintfstderr | grep -v cpl_multiproc | grep -v "truncation occurred" | grep -v xmlreformat | grep -v cpl_error
-
-if [[ $? -eq 0 ]] ; then
+if grep fprintf -r  alg gnm port ogr gcore frmts --include="*.cpp" | grep stderr | grep -v -G "/[/|*][ ]*fprintf" | grep -v "/*ok" | grep -v sdts2shp | grep -v degrib  | grep -v 8211view | grep -v 8211createfromxml | grep -v 8211dump | grep -v pcidskexception | grep -v vsipreload | grep -v fprintfstderr | grep -v cpl_multiproc | grep -v "truncation occurred" | grep -v xmlreformat | grep -v cpl_error ; then
     echo "FAIL: suspicious fprintf(stder,...) found. Remove or tag it with /*ok*/"
     ret_code=1
 else

--- a/gdal/scripts/detect_self_assignment.sh
+++ b/gdal/scripts/detect_self_assignment.sh
@@ -5,9 +5,7 @@ ret_code=0
 # This catches a bit more than gcc -Winit-self and clang -Wself-assign (https://trac.osgeo.org/gdal/ticket/6196)
 
 echo "Checking for self assignment..."
-find alg port gcore apps ogr frmts gnm \( -name "*.cpp" -o -name "*.c" -o -name "*.h" \) -exec python scripts/detect_self_assignment.py {} \; | grep ''
-
-if [[ $? -eq 0 ]] ; then
+if find alg port gcore apps ogr frmts gnm \( -name "*.cpp" -o -name "*.c" -o -name "*.h" \) -exec python scripts/detect_self_assignment.py {} \; | grep '' ; then
     echo "FAIL: check assignment detected. Please remove them!"
     ret_code=1
 else

--- a/gdal/scripts/detect_suspicious_char_digit_zero.sh
+++ b/gdal/scripts/detect_suspicious_char_digit_zero.sh
@@ -5,22 +5,18 @@ ret_code=0
 echo "Checking for suspicious comparisons to '0'..."
 
 # Detect comparisons where we'd likely want to check against nul terminating byte in the condition of a for/while loop
-grep -r --include="*.c*" "!= '0'" alg gnm port ogr gcore frmts apps
-if [[ $? -eq 0 ]] ; then
+if grep -r --include="*.c*" "!= '0'" alg gnm port ogr gcore frmts apps ; then
     ret_code=1
 fi
-grep -r --include="*.c*" "!='0'" alg gnm port ogr gcore frmts apps | grep -v libjson
-if [[ $? -eq 0 ]] ; then
+if grep -r --include="*.c*" "!='0'" alg gnm port ogr gcore frmts apps | grep -v libjson ; then
     ret_code=1
 fi
 
 # Detect comparisons where we'd likely want to check against nul terminating byte with a if (*pszPtr == '\0'), after interrupting a loop due to a != '\0' check
-grep -r --include="*.c*" "== '0'" alg gnm port ogr gcore frmts apps | grep "*"
-if [[ $? -eq 0 ]] ; then
+if grep -r --include="*.c*" "== '0'" alg gnm port ogr gcore frmts apps | grep "*" ; then
     ret_code=1
 fi
-grep -r --include="*.c*" "=='0'" alg gnm port ogr gcore frmts apps | grep "*"
-if [[ $? -eq 0 ]] ; then
+if grep -r --include="*.c*" "=='0'" alg gnm port ogr gcore frmts apps | grep "*" ; then
     ret_code=1
 fi
 

--- a/gdal/scripts/detect_tabulations.sh
+++ b/gdal/scripts/detect_tabulations.sh
@@ -3,9 +3,7 @@
 ret_code=0
 
 echo "Checking for tabulation characters..."
-find alg gnm port ogr gcore frmts apps \( -name "*.cpp" -o -name "*.h" \) -exec sh -c "grep -P '\t' {} >/dev/null && echo {}" \; | grep -v frmts/msg/PublicDecompWT | grep -v frmts/jpeg/libjpeg | grep -v frmts/gtiff/libtiff | grep -v frmts/gtiff/libgeotiff | grep -v frmts/grib/degrib | grep -v ogr/ogrsf_frmts/geojson/libjson | grep -v frmts/hdf4/hdf-eos | grep -v frmts/gif/giflib | grep -v frmts/pcraster/libcsf | grep -v frmts/png/libpng | grep -v cpl_mem_cache
-
-if [[ $? -eq 0 ]] ; then
+if find alg gnm port ogr gcore frmts apps \( -name "*.cpp" -o -name "*.h" \) -exec sh -c "grep -P '\\t' {} >/dev/null && echo {}" \; | grep -v frmts/msg/PublicDecompWT | grep -v frmts/jpeg/libjpeg | grep -v frmts/gtiff/libtiff | grep -v frmts/gtiff/libgeotiff | grep -v frmts/grib/degrib | grep -v ogr/ogrsf_frmts/geojson/libjson | grep -v frmts/hdf4/hdf-eos | grep -v frmts/gif/giflib | grep -v frmts/pcraster/libcsf | grep -v frmts/png/libpng | grep -v cpl_mem_cache ; then
     echo "FAIL: tabulations detected. Please remove them!"
     ret_code=1
 else


### PR DESCRIPTION
These changes silence a bunch of warnings from Shellcheck.