### PR TITLE
AVX: Add necessary include for gcc

### DIFF
--- a/gdal/gcore/gdal_priv_templates.hpp
+++ b/gdal/gcore/gdal_priv_templates.hpp
@@ -439,6 +439,8 @@ inline void GDALCopy4Words(const float* pValueIn, GUInt16* const &pValueOut)
 
 #ifdef __AVX2__
 
+#include <immintrin.h>
+
 inline void GDALCopy8Words(const float* pValueIn, GByte* const &pValueOut)
 {
     __m256 ymm = _mm256_loadu_ps(pValueIn);


### PR DESCRIPTION
GCC and Clang fail to build `gcore/gdalrasterband.cpp` with AVX due to missing intrinsics:
```
In file included from gdalrasterband.cpp:53:0:
gdal_priv_templates.hpp: In function 'void GDALCopy8Words(const float*, GByte* const&)'
gdal_priv_templates.hpp:444:5: error: '__m256' was not declared in this scope
     __m256 ymm = _mm256_loadu_ps(pValueIn);
```