### PR TITLE
RDA with template support

### DIFF
--- a/autotest/gdrivers/rda.py
+++ b/autotest/gdrivers/rda.py
@@ -32,6 +32,7 @@
 import os
 import struct
 import sys
+import json
 
 sys.path.append( '../pymod' )
 
@@ -198,7 +199,7 @@ def rda_error_metadata():
     handler = webserver.SequentialHandler()
     # caching of access_token not possible since no expires_in
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token"}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 404)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 404)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
@@ -216,7 +217,7 @@ def rda_error_metadata():
     handler = webserver.SequentialHandler()
     # caching of access_token not possible since no expires_in
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token"}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 404, {}, '{"error": "some error"}')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 404, {}, '{"error": "some error"}')
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
@@ -234,7 +235,7 @@ def rda_error_metadata():
     handler = webserver.SequentialHandler()
     # caching possible now
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, 'invalid json')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, 'invalid json')
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
@@ -250,7 +251,7 @@ def rda_error_metadata():
 
     # a lot of missing elements
     handler = webserver.SequentialHandler()
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, '{}')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, '{}')
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
@@ -266,7 +267,7 @@ def rda_error_metadata():
 
     # Bad dataType
     handler = webserver.SequentialHandler()
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, """{
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, """{"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -289,7 +290,7 @@ def rda_error_metadata():
         "maxTileX": 1,
         "maxTileY": 1,
         "colorInterpretation": "FOO"
-    }""")
+    }}""")
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
@@ -305,7 +306,7 @@ def rda_error_metadata():
 
     # Huge numBands
     handler = webserver.SequentialHandler()
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, """{
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, """{"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -328,7 +329,7 @@ def rda_error_metadata():
         "maxTileX": 1,
         "maxTileY": 1,
         "colorInterpretation": "FOO"
-    }""")
+    }}""")
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
@@ -344,7 +345,7 @@ def rda_error_metadata():
 
     # Invalid dataset dimensions
     handler = webserver.SequentialHandler()
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, """{
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, """{"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -367,7 +368,7 @@ def rda_error_metadata():
         "maxTileX": 1,
         "maxTileY": 1,
         "colorInterpretation": "FOO"
-    }""")
+    }}""")
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
@@ -385,7 +386,7 @@ def rda_error_metadata():
 
 ###############################################################################
 
-def rda_nominal():
+def rda_graph_nominal():
 
     if gdaltest.rda_drv is None:
         return 'skip'
@@ -393,7 +394,7 @@ def rda_nominal():
         return 'skip'
 
     handler = webserver.SequentialHandler()
-    image_json = """{
+    metadata_json = {"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -424,9 +425,9 @@ def rda_nominal():
         "sunAzimuth": 2.2,
         "sunElevation": 3.2,
         "satAzimuth": 4.2,
-        "satElevation": 5.2,
-    }"""
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+        "satElevation": 5.2
+    }}
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
 
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
@@ -471,13 +472,10 @@ def rda_nominal():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    handler = webserver.SequentialHandler()
-    handler.add('GET', '/rda_api/metadata/foo/bar/georeferencing.json', 404)
-    with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
-            if ds.GetProjectionRef() != '':
-                gdaltest.post_reason('fail')
-                return 'fail'
+    if ds.GetProjectionRef() != '':
+        gdaltest.post_reason('fail')
+        return 'fail'
+
     ds = None
 
     # Retry without any network setup to test caching
@@ -490,31 +488,28 @@ def rda_nominal():
         gdaltest.post_reason('fail')
         return 'fail'
 
+    gdal.RmdirRecursive('/vsimem/cache_dir')
+
+    metadata_json["imageGeoreferencing"] = {"spatialReferenceSystemCode": "EPSG:32631", "scaleX": 1.0, "scaleY": 2.0,
+                                            "translateX": 123.0, "translateY": 456.0, "shearX": 0.0, "shearY": 0.0 }
+
     handler = webserver.SequentialHandler()
-    handler.add('GET', '/rda_api/metadata/foo/bar/georeferencing.json', 200, {}, """{
-        "spatialReferenceSystemCode": "EPSG:32631",
-        "scaleX": 1.0,
-        "scaleY": 2.0,
-        "translateX": 123.0,
-        "translateY": 456.0,
-        "shearX": 0.0,
-        "shearY": 0.0
-    }""")
+    handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
     with webserver.install_http_handler(handler):
+        with gdaltest.config_options(config_options):
+            ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
+        if ds is None:
+            gdaltest.post_reason('fail')
+            return 'fail'
         if ds.GetProjectionRef().find('32631') < 0:
             gdaltest.post_reason('fail')
             return 'fail'
+
     got_gt = ds.GetGeoTransform()
     if got_gt != (125.0, 1.0, 0.0, 462.0, 0.0, 2.0):
         gdaltest.post_reason('fail')
         print(got_gt)
-        return 'fail'
-
-    # RPC should be ignored since there is a valid geotransform
-    handler = webserver.SequentialHandler()
-    handler.add('GET', '/rda_api/metadata/foo/bar/rpcs.json', 200, {}, """{"spatialReferenceSystem":"EPSG:4326","upperLeftCorner":{"x":2.07724378,"y":48.84065078},"upperRightCorner":{"x":2.31489579,"y":48.84057427},"lowerRightCorner":{"x":2.31360304,"y":48.69084146},"lowerLeftCorner":{"x":2.07783336,"y":48.69170554},"gsd":5.641394178943586E-6,"postScaleFactorX":1.0,"postScaleFactorY":1.0,"lineOffset":13313.0,"sampleOffset":13775.0,"latOffset":48.7657,"lonOffset":2.1959,"heightOffset":151.0,"lineScale":13314.0,"sampleScale":13776.0,"latScale":0.075,"lonScale":0.1203,"heightScale":500.0,"lineNumCoefs":[0.003462388,-0.003319885,-1.004173,-5.694582E-4,0.00138283,1.973615E-6,3.606842E-4,-8.287262E-4,-0.001348337,3.399036E-7,-1.431479E-6,1.058794E-6,2.705906E-5,-9.732266E-8,-2.988015E-5,-1.20553E-4,-2.956054E-5,2.817489E-7,0.0,-1.663039E-8],"lineDenCoefs":[1.0,0.001393466,0.002175939,3.615903E-4,1.188453E-5,-5.55041E-7,-2.20758E-6,1.688344E-5,-6.33621E-5,2.911688E-5,-2.333141E-8,1.367653E-7,1.006995E-6,8.290656E-8,-7.302754E-7,-1.959288E-4,2.555922E-8,2.074273E-8,6.766787E-7,2.106776E-8],"sampleNumCoefs":[-0.003627584,1.015469,-0.001694738,-0.0107359,-0.001958667,5.325142E-4,-4.003552E-4,0.003666871,2.035126E-4,-5.427884E-6,-1.176796E-6,-1.536131E-5,-6.907792E-5,-1.670626E-5,7.908289E-5,-4.442762E-6,1.143467E-7,3.322555E-6,8.624531E-7,1.741671E-7],"sampleDenCoefs":[1.0,-3.707032E-5,0.001978281,-5.804113E-4,-4.497994E-5,-2.659572E-6,9.73096E-7,-1.250655E-5,4.714011E-5,-1.697617E-5,-6.041848E-8,0.0,2.173017E-7,5.608078E-8,-2.660194E-7,-2.020556E-7,-6.347383E-8,1.321956E-8,-8.626535E-8,1.908747E-8]}""")
-    if ds.GetMetadata('RPC') != {}:
-        gdaltest.post_reason('fail')
         return 'fail'
 
     ds = None
@@ -527,6 +522,45 @@ def rda_nominal():
         gdaltest.post_reason('fail')
         print(got_gt)
         return 'fail'
+
+    gdal.RmdirRecursive('/vsimem/cache_dir')
+
+    # RPC should be ignored since there is a valid geotransform
+    metadata_json["rpcSensorModel"] = {"spatialReferenceSystem":"EPSG:4326","upperLeftCorner":{"x":2.07724378,"y":48.84065078},"upperRightCorner":{"x":2.31489579,"y":48.84057427},"lowerRightCorner":{"x":2.31360304,"y":48.69084146},"lowerLeftCorner":{"x":2.07783336,"y":48.69170554},"gsd":5.641394178943586E-6,"postScaleFactorX":1.0,"postScaleFactorY":1.0,"lineOffset":13313.0,"sampleOffset":13775.0,"latOffset":48.7657,"lonOffset":2.1959,"heightOffset":151.0,"lineScale":13314.0,"sampleScale":13776.0,"latScale":0.075,"lonScale":0.1203,"heightScale":500.0,"lineNumCoefs":[0.003462388,-0.003319885,-1.004173,-5.694582E-4,0.00138283,1.973615E-6,3.606842E-4,-8.287262E-4,-0.001348337,3.399036E-7,-1.431479E-6,1.058794E-6,2.705906E-5,-9.732266E-8,-2.988015E-5,-1.20553E-4,-2.956054E-5,2.817489E-7,0.0,-1.663039E-8],"lineDenCoefs":[1.0,0.001393466,0.002175939,3.615903E-4,1.188453E-5,-5.55041E-7,-2.20758E-6,1.688344E-5,-6.33621E-5,2.911688E-5,-2.333141E-8,1.367653E-7,1.006995E-6,8.290656E-8,-7.302754E-7,-1.959288E-4,2.555922E-8,2.074273E-8,6.766787E-7,2.106776E-8],"sampleNumCoefs":[-0.003627584,1.015469,-0.001694738,-0.0107359,-0.001958667,5.325142E-4,-4.003552E-4,0.003666871,2.035126E-4,-5.427884E-6,-1.176796E-6,-1.536131E-5,-6.907792E-5,-1.670626E-5,7.908289E-5,-4.442762E-6,1.143467E-7,3.322555E-6,8.624531E-7,1.741671E-7],"sampleDenCoefs":[1.0,-3.707032E-5,0.001978281,-5.804113E-4,-4.497994E-5,-2.659572E-6,9.73096E-7,-1.250655E-5,4.714011E-5,-1.697617E-5,-6.041848E-8,0.0,2.173017E-7,5.608078E-8,-2.660194E-7,-2.020556E-7,-6.347383E-8,1.321956E-8,-8.626535E-8,1.908747E-8]}
+    handler = webserver.SequentialHandler()
+    handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
+
+    with webserver.install_http_handler(handler):
+        with gdaltest.config_options(config_options):
+            ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
+        if ds is None:
+            gdaltest.post_reason('fail')
+            return 'fail'
+        if ds.GetMetadata('RPC') != {}:
+            gdaltest.post_reason('fail')
+            return 'fail'
+
+    gdal.RmdirRecursive('/vsimem/cache_dir')
+
+    # RPC should be ignored regardless if the profile is georectified_image
+    temp_metadata = json.loads(json.dumps(metadata_json))
+    del temp_metadata["imageGeoreferencing"]
+    temp_metadata["imageMetadata"]["profileName"] = "georectified_image"
+    handler = webserver.SequentialHandler()
+    handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(temp_metadata))
+
+    with webserver.install_http_handler(handler):
+        with gdaltest.config_options(config_options):
+            ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
+        if ds is None:
+            gdaltest.post_reason('fail')
+            return 'fail'
+        if ds.GetMetadata('RPC') != {}:
+            gdaltest.post_reason('fail')
+            return 'fail'
+
 
     tile_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/tile_00.tif', 256, 256, 3)
     tile_ds.GetRasterBand(1).Fill(255)
@@ -621,7 +655,7 @@ def rda_nominal():
     # Test Dataset::AdviseRead
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, tile00_data)
     handler.add('GET', '/rda_api/tile/foo/bar/1/0.tif', 200, {}, tile01_data)
     handler.add('GET', '/rda_api/tile/foo/bar/0/1.tif', 200, {}, tile10_data)
@@ -638,7 +672,7 @@ def rda_nominal():
     # Test RasterBand::AdviseRead
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, tile00_data)
     handler.add('GET', '/rda_api/tile/foo/bar/1/0.tif', 200, {}, tile01_data)
     handler.add('GET', '/rda_api/tile/foo/bar/0/1.tif', 200, {}, tile10_data)
@@ -655,7 +689,7 @@ def rda_nominal():
     # Test ReadBlock directly
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, tile00_data)
     handler.add('GET', '/rda_api/tile/foo/bar/1/0.tif', 200, {}, tile01_data)
     handler.add('GET', '/rda_api/tile/foo/bar/0/1.tif', 200, {}, tile10_data)
@@ -696,7 +730,7 @@ def rda_read_gbdx_config():
 
     gdal.RmdirRecursive('/vsimem/cache_dir')
 
-    image_json = """{
+    metadata_json = """{"imageMetadata":{
         "imageId": "imageId",
         "tileXOffset": 0,
         "tileYOffset": 0,
@@ -717,7 +751,7 @@ def rda_read_gbdx_config():
         "maxTileX": 1,
         "maxTileY": 1,
         "colorInterpretation": "RGB",
-    }"""
+    }}"""
 
     gdal.FileFromMemBuffer('/vsimem/.gbdx-config', """
 [gbdx]
@@ -734,7 +768,7 @@ idaho_api_url = 127.0.0.1:%d/rda_api
     }
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
@@ -756,7 +790,7 @@ def rda_download_queue():
 
     gdal.RmdirRecursive('/vsimem/cache_dir')
 
-    image_json = """{
+    metadata_json = """{"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -779,7 +813,7 @@ def rda_download_queue():
         "maxTileX": 4,
         "maxTileY": 3,
         "colorInterpretation": "PAN",
-    }"""
+    }}"""
 
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
@@ -800,14 +834,14 @@ def rda_download_queue():
 
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     for y in range(5):
         for x in range(4):
             handler.add_unordered('GET', '/rda_api/tile/foo/bar/%d/%d.tif' % (x,y), 200, {}, tile_data)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
-            # We need at least (width=5) <= 2 * MAXCONNECT so that AdviseRead(all_raster) is honoured
-            ds = gdal.OpenEx('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}', open_options = ['MAXCONNECT=4'])
+            # We need at least (width=5) <= MAXCONNECT so that AdviseRead(all_raster) is honoured
+            ds = gdal.OpenEx('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}', open_options = ['MAXCONNECT=8'])
         ds.AdviseRead(0,0,4,5)
         ds.ReadRaster(0,0,4,3)
         ref_data = ds.ReadRaster(0,1,4,2)
@@ -836,30 +870,33 @@ def rda_rpc():
 
     gdal.RmdirRecursive('/vsimem/cache_dir')
 
-    image_json = """{
-        "imageId": "imageId",
-        "profileName": "profileName",
-        "nativeTileFileFormat": "TIF",
-        "tileXOffset": 0,
-        "tileYOffset": 0,
-        "numXTiles": 5,
-        "numYTiles": 4,
-        "tileXSize": 1,
-        "tileYSize": 1,
-        "numBands": 1,
-        "dataType": "BYTE",
-        "imageHeight": 5,
-        "imageWidth": 4,
-        "minX": 0,
-        "minY": 0,
-        "maxX": 4,
-        "maxY": 3,
-        "minTileX": 0,
-        "minTileY": 0,
-        "maxTileX": 4,
-        "maxTileY": 3,
-        "colorInterpretation": "PAN",
-    }"""
+    # No RPC
+    metadata_json = {
+        "imageMetadata": {
+            "imageId": "imageId",
+            "profileName": "profileName",
+            "nativeTileFileFormat": "TIF",
+            "tileXOffset": 0,
+            "tileYOffset": 0,
+            "numXTiles": 5,
+            "numYTiles": 4,
+            "tileXSize": 1,
+            "tileYSize": 1,
+            "numBands": 1,
+            "dataType": "BYTE",
+            "imageHeight": 5,
+            "imageWidth": 4,
+            "minX": 0,
+            "minY": 0,
+            "maxX": 4,
+            "maxY": 3,
+            "minTileX": 0,
+            "minTileY": 0,
+            "maxTileX": 4,
+            "maxTileY": 3,
+            "colorInterpretation": "PAN"
+        }
+    }
 
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
@@ -870,10 +907,10 @@ def rda_rpc():
         'GBDX_PASSWORD': 'password'
     }
 
+
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
-    handler.add('GET', '/rda_api/metadata/foo/bar/rpcs.json', 404, {}, '{ "error": "an error" }')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
@@ -884,10 +921,28 @@ def rda_rpc():
 
     gdal.RmdirRecursive('/vsimem/cache_dir')
 
+    # Invalid RPC
+    metadata_json["rpcSensorModel"] = {"spatialReferenceSystem":"EPSG:4326","upperLeftCorner":{"x":2.07724378,"y":48.84065078},"upperRightCorner":{"x":2.31489579,"y":48.84057427},"lowerRightCorner":{"x":2.31360304,"y":48.69084146},"lowerLeftCorner":{"x":2.07783336,"y":48.69170554},"gsd":5.641394178943586E-6,"postScaleFactorX":2.0,"postScaleFactorY":2.0,"lineOffset":13313.0,"sampleOffset":13775.0,"latOffset":48.7657,"lonOffset":2.1959,"heightOffset":151.0,"lineScale":13314.0,"sampleScale":13776.0,"latScale":0.075,"lonScale":0.1203,"heightScale":500.0,"lineNumCoefs":[],"lineDenCoefs":[],"sampleNumCoefs":[],"sampleDenCoefs":[]}
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
-    handler.add('GET', '/rda_api/metadata/foo/bar/rpcs.json', 200, {}, """{"spatialReferenceSystem":"EPSG:4326","upperLeftCorner":{"x":2.07724378,"y":48.84065078},"upperRightCorner":{"x":2.31489579,"y":48.84057427},"lowerRightCorner":{"x":2.31360304,"y":48.69084146},"lowerLeftCorner":{"x":2.07783336,"y":48.69170554},"gsd":5.641394178943586E-6,"postScaleFactorX":1.0,"postScaleFactorY":1.0,"lineOffset":13313.0,"sampleOffset":13775.0,"latOffset":48.7657,"lonOffset":2.1959,"heightOffset":151.0,"lineScale":13314.0,"sampleScale":13776.0,"latScale":0.075,"lonScale":0.1203,"heightScale":500.0,"lineNumCoefs":[0.003462388,-0.003319885,-1.004173,-5.694582E-4,0.00138283,1.973615E-6,3.606842E-4,-8.287262E-4,-0.001348337,3.399036E-7,-1.431479E-6,1.058794E-6,2.705906E-5,-9.732266E-8,-2.988015E-5,-1.20553E-4,-2.956054E-5,2.817489E-7,0.0,-1.663039E-8],"lineDenCoefs":[1.0,0.001393466,0.002175939,3.615903E-4,1.188453E-5,-5.55041E-7,-2.20758E-6,1.688344E-5,-6.33621E-5,2.911688E-5,-2.333141E-8,1.367653E-7,1.006995E-6,8.290656E-8,-7.302754E-7,-1.959288E-4,2.555922E-8,2.074273E-8,6.766787E-7,2.106776E-8],"sampleNumCoefs":[-0.003627584,1.015469,-0.001694738,-0.0107359,-0.001958667,5.325142E-4,-4.003552E-4,0.003666871,2.035126E-4,-5.427884E-6,-1.176796E-6,-1.536131E-5,-6.907792E-5,-1.670626E-5,7.908289E-5,-4.442762E-6,1.143467E-7,3.322555E-6,8.624531E-7,1.741671E-7],"sampleDenCoefs":[1.0,-3.707032E-5,0.001978281,-5.804113E-4,-4.497994E-5,-2.659572E-6,9.73096E-7,-1.250655E-5,4.714011E-5,-1.697617E-5,-6.041848E-8,0.0,2.173017E-7,5.608078E-8,-2.660194E-7,-2.020556E-7,-6.347383E-8,1.321956E-8,-8.626535E-8,1.908747E-8]}""")
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
+
+    with webserver.install_http_handler(handler):
+        with gdaltest.config_options(config_options):
+            ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
+        with gdaltest.error_handler():
+            md = ds.GetMetadata('RPC')
+    if md != {}:
+        gdaltest.post_reason('fail')
+        return 'fail'
+
+    gdal.RmdirRecursive('/vsimem/cache_dir')
+
+    # Good RPC
+    metadata_json["rpcSensorModel"] = {"spatialReferenceSystem":"EPSG:4326","upperLeftCorner":{"x":2.07724378,"y":48.84065078},"upperRightCorner":{"x":2.31489579,"y":48.84057427},"lowerRightCorner":{"x":2.31360304,"y":48.69084146},"lowerLeftCorner":{"x":2.07783336,"y":48.69170554},"gsd":5.641394178943586E-6,"postScaleFactorX":1.0,"postScaleFactorY":1.0,"lineOffset":13313.0,"sampleOffset":13775.0,"latOffset":48.7657,"lonOffset":2.1959,"heightOffset":151.0,"lineScale":13314.0,"sampleScale":13776.0,"latScale":0.075,"lonScale":0.1203,"heightScale":500.0,"lineNumCoefs":[0.003462388,-0.003319885,-1.004173,-5.694582E-4,0.00138283,1.973615E-6,3.606842E-4,-8.287262E-4,-0.001348337,3.399036E-7,-1.431479E-6,1.058794E-6,2.705906E-5,-9.732266E-8,-2.988015E-5,-1.20553E-4,-2.956054E-5,2.817489E-7,0.0,-1.663039E-8],"lineDenCoefs":[1.0,0.001393466,0.002175939,3.615903E-4,1.188453E-5,-5.55041E-7,-2.20758E-6,1.688344E-5,-6.33621E-5,2.911688E-5,-2.333141E-8,1.367653E-7,1.006995E-6,8.290656E-8,-7.302754E-7,-1.959288E-4,2.555922E-8,2.074273E-8,6.766787E-7,2.106776E-8],"sampleNumCoefs":[-0.003627584,1.015469,-0.001694738,-0.0107359,-0.001958667,5.325142E-4,-4.003552E-4,0.003666871,2.035126E-4,-5.427884E-6,-1.176796E-6,-1.536131E-5,-6.907792E-5,-1.670626E-5,7.908289E-5,-4.442762E-6,1.143467E-7,3.322555E-6,8.624531E-7,1.741671E-7],"sampleDenCoefs":[1.0,-3.707032E-5,0.001978281,-5.804113E-4,-4.497994E-5,-2.659572E-6,9.73096E-7,-1.250655E-5,4.714011E-5,-1.697617E-5,-6.041848E-8,0.0,2.173017E-7,5.608078E-8,-2.660194E-7,-2.020556E-7,-6.347383E-8,1.321956E-8,-8.626535E-8,1.908747E-8]}
+    handler = webserver.SequentialHandler()
+    handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, json.dumps(metadata_json))
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
@@ -908,22 +963,7 @@ def rda_rpc():
                     print(key, md)
                     return 'fail'
     ds = None
-
-    # Invalid RPC
     gdal.RmdirRecursive('/vsimem/cache_dir')
-
-    handler = webserver.SequentialHandler()
-    handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 3600}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
-    handler.add('GET', '/rda_api/metadata/foo/bar/rpcs.json', 200, {}, """{"spatialReferenceSystem":"EPSG:4326","upperLeftCorner":{"x":2.07724378,"y":48.84065078},"upperRightCorner":{"x":2.31489579,"y":48.84057427},"lowerRightCorner":{"x":2.31360304,"y":48.69084146},"lowerLeftCorner":{"x":2.07783336,"y":48.69170554},"gsd":5.641394178943586E-6,"postScaleFactorX":2.0,"postScaleFactorY":2.0,"lineOffset":13313.0,"sampleOffset":13775.0,"latOffset":48.7657,"lonOffset":2.1959,"heightOffset":151.0,"lineScale":13314.0,"sampleScale":13776.0,"latScale":0.075,"lonScale":0.1203,"heightScale":500.0,"lineNumCoefs":[],"lineDenCoefs":[],"sampleNumCoefs":[],"sampleDenCoefs":[]}""")
-    with webserver.install_http_handler(handler):
-        with gdaltest.config_options(config_options):
-            ds = gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
-        with gdaltest.error_handler():
-            md = ds.GetMetadata('RPC')
-    if md != {}:
-        gdaltest.post_reason('fail')
-        return 'fail'
 
     return 'success'
 
@@ -942,7 +982,7 @@ def rda_real_cache_dir():
 
     gdal.RmdirRecursive('/vsimem/cache_dir')
 
-    image_json = """{
+    metadata_json = """{"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -965,7 +1005,7 @@ def rda_real_cache_dir():
         "maxTileX": 4,
         "maxTileY": 3,
         "colorInterpretation": "PAN",
-    }"""
+    }}"""
 
     config_options = {
         'RDA_CACHE_DIR': '',
@@ -977,14 +1017,14 @@ def rda_real_cache_dir():
         'GBDX_PASSWORD': 'password'
     }
 
-    cached_file = os.path.join(home, '.gdal', 'rda_cache', 'foo', 'bar', 'image.json')
+    cached_file = os.path.join(home, '.gdal', 'rda_cache', 'foo', 'bar', 'metadata.json')
     if os.path.exists(cached_file):
         gdal.RmdirRecursive(os.path.join(home, '.gdal', 'rda_cache', 'foo'))
 
     handler = webserver.SequentialHandler()
     if not os.path.exists(os.path.join(home, '.gdal', 'rda_cache', 'authorization.json')):
         handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token" }')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             gdal.Open('{"graph-id":"foo","node-id":"bar","options":{"delete-on-close":false}}')
@@ -996,7 +1036,7 @@ def rda_real_cache_dir():
     handler = webserver.SequentialHandler()
     if not os.path.exists(os.path.join(home, '.gdal', 'rda_cache', 'authorization.json')):
         handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token" }')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             gdal.Open('{"graph-id":"foo","node-id":"bar"}')
@@ -1010,7 +1050,7 @@ def rda_real_cache_dir():
     handler = webserver.SequentialHandler()
     if not os.path.exists(os.path.join(home, '.gdal', 'rda_cache', 'authorization.json')):
         handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token" }')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             gdal.Open('{"graph-id":"foo","node-id":"bar"}')
@@ -1033,7 +1073,7 @@ def rda_real_expired_authentication():
 
     gdal.RmdirRecursive('/vsimem/cache_dir')
 
-    image_json = """{
+    metadata_json = """{"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -1056,7 +1096,7 @@ def rda_real_expired_authentication():
         "maxTileX": 4,
         "maxTileY": 3,
         "colorInterpretation": "PAN",
-    }"""
+    }}"""
 
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
@@ -1070,14 +1110,14 @@ def rda_real_expired_authentication():
     handler = webserver.SequentialHandler()
     # As we have a 60 second security margin, expires_in=1 will already have expired
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token", "expires_in": 1 }')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             gdal.Open('{"graph-id":"foo","node-id":"bar"}')
 
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token" }')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
             gdal.Open('{"graph-id":"foo","node-id":"bar"}')
@@ -1095,7 +1135,7 @@ def rda_bad_tile():
 
     gdal.RmdirRecursive('/vsimem/cache_dir')
 
-    image_json = """{
+    metadata_json = """{"imageMetadata":{
         "imageId": "imageId",
         "profileName": "profileName",
         "nativeTileFileFormat": "TIF",
@@ -1118,7 +1158,7 @@ def rda_bad_tile():
         "maxTileX": 1,
         "maxTileY": 1,
         "colorInterpretation": "PAN",
-    }"""
+    }}"""
 
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
@@ -1139,7 +1179,7 @@ def rda_bad_tile():
 
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token"}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, tile_data)
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, tile_data)
     with webserver.install_http_handler(handler):
@@ -1156,7 +1196,7 @@ def rda_bad_tile():
 
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token"}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, tile_data)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
@@ -1171,7 +1211,7 @@ def rda_bad_tile():
     gdal.RmdirRecursive('/vsimem/cache_dir')
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token"}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, 'foo')
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, 'foo')
     with webserver.install_http_handler(handler):
@@ -1188,7 +1228,7 @@ def rda_bad_tile():
 
     handler = webserver.SequentialHandler()
     handler.add('POST', '/auth_url', 200, {}, '{"access_token": "token"}')
-    handler.add('GET', '/rda_api/metadata/foo/bar/image.json', 200, {}, image_json)
+    handler.add('GET', '/rda_api/metadata/foo/bar/metadata.json', 200, {}, metadata_json)
     handler.add('GET', '/rda_api/tile/foo/bar/0/0.tif', 200, {}, 'foo')
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(config_options):
@@ -1224,7 +1264,7 @@ gdaltest_list = [
     rda_missing_credentials,
     rda_failed_authentication,
     rda_error_metadata,
-    rda_nominal,
+    rda_graph_nominal,
     rda_read_gbdx_config,
     rda_download_queue,
     rda_rpc,

--- a/gdal/frmts/rda/frmt_rda.html
+++ b/gdal/frmts/rda/frmt_rda.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>RDA (DigitalGlobe Raster Data Access)</title>
+    <title>RDA (DigitalGlobe Raster Data Access)</title>
 </head>
 
 <body bgcolor="#ffffff">
@@ -9,72 +9,113 @@
 
 (GDAL/OGR &gt;= 2.3)<p>
 
-This driver can connect to DigitalGlobe RDA REST API.
-GDAL/OGR must be built with Curl support in order for the
-RDA driver to be compiled.<p>
+    This driver can connect to DigitalGlobe RDA REST API.
+    GDAL/OGR must be built with Curl support in order for the
+    RDA driver to be compiled.
+<p>
 
-The driver retrieves metadata on graphs and fetches the raster by tiles.
-Data types byte, uint16, int16, uint32, int32, float32 and float64 are
-supported.<p>
+    The driver retrieves metadata on graphs and fetches the raster by tiles.
+    Data types byte, uint16, int16, uint32, int32, float32 and float64 are
+    supported.
+<p>
 
-Orthorectified (with geotransform) and raw (Level-1B with RPCs) datasets are
-supported.<p>
+    Orthorectified (with geotransform) and raw (Level-1B with RPCs) datasets are
+    supported.
+<p>
 
-There is no support for overviews.<p>
+    There is no support for overviews.
+<p>
 
 <h2>Dataset name syntax</h2>
 
 The minimal syntax to open a datasource is :
-<pre>{"graph-id":"some_value", "node-id": "another_value"}</pre><p>
+<pre>{"graph-id":"some_value", "node-id": "another_value"}</pre>
+OR
+<pre>{"template-id":"some_value", "params": [{ "someparam": "someparamval"}]}</pre>
+<p>
 
-So a JSon serialized document with 2 attributes graph-id and node-id.<p>
+    So a JSon serialized document with 2 attributes graph-id and node-id.
+<p>
 
 <p>Those values can for example be retrieved from graphs built by
-<a href="https://rda.geobigdata.io/">GraphStudio</a>.</p>
+    <a href="https://rda.geobigdata.io/">GraphStudio</a>.</p>
 
-An optional <pre>"options": {"delete-on-close": false}</pre> can be added to
-the JSon document to request that cached tiles and metadata are not destroyed
-at dataset closing.<p>
+<h2>Connection String options (optional)</h2>
+<ul>
+    <li>
+        <pre>"options": {"delete-on-close": false}</pre>
+        can be added to
+        the JSon document to request that cached tiles and metadata are not destroyed
+        at dataset closing. The default, if not specified, is true.
+    </li>
+
+    <li>
+        <pre>"options": {"delete-on-close": false}</pre>
+        can be added to
+        the JSon document to request that cached tiles and metadata are not destroyed
+        at dataset closing. The default, if not specified, is true.
+    </li>
+
+    <li>
+        <pre>"options": {"max-connections": 32}</pre>
+        can be added to
+        the JSon document to request that cached tiles be fetched using a maximum number of
+        concurrent connections. The default, if not specified, is equal to 8 * number of CPUs.
+    </li>
+
+    <li>
+        <pre>"options": {"advise-read": false}</pre>
+        can be added to
+        the JSon document to request advise read not be used when reading the dataset.
+        The default, if not specified, is true.
+    </li>
+</ul>
 
 <h2>Authentication</h2>
 
 <p>Access to the API requires an authentication token. For that, 4 parameters
-(client_id, client_secret, username, password) must be provided to the driver.
-They can be retrieved from the below configuration options, or from the
-~/.gbdx-config file.</p>
+    (client_id, client_secret, username, password) must be provided to the driver.
+    They can be retrieved from the below configuration options, or from the
+    ~/.gbdx-config file.</p>
 
 <p>The access token will be cached in ~/.gdal/rda_cache/authentication.json and
-reused from there until its expiration period is reached.</p>
+    reused from there until its expiration period is reached.</p>
 
 <h2>Configuration options</h2>
 
 The following configuration options are available :
 <ul>
-<li><b>GBDX_AUTH_URL</b>=value: To specify the OAuth authentication endpoint.
-Defaults to https://geobigdata.io/auth/v1/oauth/token/. If not specified, the
-auth_url parameter from ~/.gbdx-config will be used if it exists.</li>
-<li><b>GBDX_RDA_API_URL</b>=value: To specify the RDA API endpoint.
-Defaults to https://rda.geobigdata.io/v1. If not specified, the
-rda_api_url parameter from ~/.gbdx-config will be used if it exists.</li>
-<li><b>GBDX_CLIENT_ID</b>=value: To specify the OAuth client id needed to get
-to an authentication token. If not specified, the
-client_id parameter from ~/.gbdx-config must be set.</li>
-<li><b>GBDX_CLIENT_SECRET</b>=value: To specify the OAuth client secret needed to get
-to an authentication token. If not specified, the
-client_secret parameter from ~/.gbdx-config must be set.</li>
-<li><b>GBDX_USERNAME</b>=value: To specify the OAuth user name needed to get
-to an authentication token. If not specified, the
-user_name parameter from ~/.gbdx-config must be set.</li>
-<li><b>GBDX_PASSWORD</b>=value: To specify the OAuth user name needed to get
-to an authentication token. If not specified, the
-password parameter from ~/.gbdx-config must be set.</li>
+    <li><b>GBDX_AUTH_URL</b>=value: To specify the OAuth authentication endpoint.
+        Defaults to https://geobigdata.io/auth/v1/oauth/token/. If not specified, the
+        auth_url parameter from ~/.gbdx-config will be used if it exists.
+    </li>
+    <li><b>GBDX_RDA_API_URL</b>=value: To specify the RDA API endpoint.
+        Defaults to https://rda.geobigdata.io/v1. If not specified, the
+        rda_api_url parameter from ~/.gbdx-config will be used if it exists.
+    </li>
+    <li><b>GBDX_CLIENT_ID</b>=value: To specify the OAuth client id needed to get
+        to an authentication token. If not specified, the
+        client_id parameter from ~/.gbdx-config must be set.
+    </li>
+    <li><b>GBDX_CLIENT_SECRET</b>=value: To specify the OAuth client secret needed to get
+        to an authentication token. If not specified, the
+        client_secret parameter from ~/.gbdx-config must be set.
+    </li>
+    <li><b>GBDX_USERNAME</b>=value: To specify the OAuth user name needed to get
+        to an authentication token. If not specified, the
+        user_name parameter from ~/.gbdx-config must be set.
+    </li>
+    <li><b>GBDX_PASSWORD</b>=value: To specify the OAuth user name needed to get
+        to an authentication token. If not specified, the
+        password parameter from ~/.gbdx-config must be set.
+    </li>
 </ul>
 
 <h2>~/.gbdx-config file</h2>
 
 <p>This file may be created in the home directory of the user (value of the
-$HOME environment variable on Unix, $USERPROFILE on Windows). It can contain
-values from the above configuration options.</p>
+    $HOME environment variable on Unix, $USERPROFILE on Windows). It can contain
+    values from the above configuration options.</p>
 
 <pre>
 [gbdx]
@@ -89,25 +130,27 @@ user_password = value (required)
 <h2>Caching</h2>
 
 <p>By default, the authentication token is cached in the ~/.gdal/rda_cache
-directory. This directory may be changed with the RDA_CACHE_DIR configuration
-option. By default, dataset metadata and tiles are temporarily cached in
-~/.gdal/rda_cache/{graph-id}/{node-id}, and deleted on dataset closing,
-unless <pre>"options": {"delete-on-close": false}</pre> is found in the
+    directory. This directory may be changed with the RDA_CACHE_DIR configuration
+    option. By default, dataset metadata and tiles are temporarily cached in
+    ~/.gdal/rda_cache/{graph-id}/{node-id}, and deleted on dataset closing,
+    unless
+<pre>"options": {"delete-on-close": false}</pre>
+is found in the
 dataset name.</p>
 
 
 <h2>Open Options</h2>
 
 <p>By default, the number of concurrent downloads will be 8*number of CPUs up to a maximum of 64. The maximum number of
-concurrent connections can be configured by the <em>MAXCONNECT</em> option</p>
+    concurrent connections can be configured by the <em>MAXCONNECT</em> option</p>
 
 <h3>Examples</h3>
 <ul>
-<li> Display metadata, and keep it cached:
+    <li> Display metadata, and keep it cached:
 
-<pre>gdalinfo '{"graph-id":"832050eb7d271d8704c8889369ee0a8a1da82acdee1b20e1700b6d053e94d1fe","node-id":"Orthorectify_hko89y", "options": {"delete-on-close": false}}'</pre>
+        <pre>gdalinfo '{"graph-id":"832050eb7d271d8704c8889369ee0a8a1da82acdee1b20e1700b6d053e94d1fe","node-id":"Orthorectify_hko89y", "options": {"delete-on-close": false}}'</pre>
 
-<pre>
+        <pre>
 Driver: RDA/DigitalGlobe Raster Data Access driver
 Files: none associated
 Size is 9911, 7084
@@ -151,16 +194,20 @@ Band 6 Block=256x256 Type=UInt16, ColorInterp=Undefined
 Band 7 Block=256x256 Type=UInt16, ColorInterp=Undefined
 Band 8 Block=256x256 Type=UInt16, ColorInterp=Undefined
 </pre>
-</li>
+    </li>
 
-<li> Extract a subwindow from a dataset:
+    <li> Extract a subwindow from a dataset:
 
-<pre>gdal_translate -srcwin 1000 2000 500 500 '{"graph-id":"832050eb7d271d8704c8889369ee0a8a1da82acdee1b20e1700b6d053e94d1fe","node-id":"Orthorectify_hko89y"}' out.tif</pre>
-</li>
+        <pre>gdal_translate -srcwin 1000 2000 500 500 '{"graph-id":"832050eb7d271d8704c8889369ee0a8a1da82acdee1b20e1700b6d053e94d1fe","node-id":"Orthorectify_hko89y"}' out.tif</pre>
+    </li>
 
-<li> Materialize a dataset specifying a custom number of concurrent connections:
-<pre>gdal_translate -oo MAXCONNECT=96 '{"graph-id":"832050eb7d271d8704c8889369ee0a8a1da82acdee1b20e1700b6d053e94d1fe","node-id":"Orthorectify_hko89y"}' out.tif</pre>
-</li>
+    <li> Materialize a dataset specifying a custom number of concurrent connections:
+        <pre>gdal_translate -oo MAXCONNECT=96 '{"graph-id":"832050eb7d271d8704c8889369ee0a8a1da82acdee1b20e1700b6d053e94d1fe","node-id":"Orthorectify_hko89y"}' out.tif</pre>
+    </li>
+
+    <li> Materialize a dataset from a template:
+        <pre>gdal_translate '{"template-id": "sample", "params": [{ "imageId": "afa56b05-35ad-47d1-bc7f-3e23d220482d"}]}' out.tif</pre>
+    </li>
 </ul>
 </body>
 </html>

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -75,6 +75,7 @@ static void GDALRDADriverUnload(GDALDriver*)
 /************************************************************************/
 /*                          GDALRDADataset                              */
 /************************************************************************/
+enum class RDADatasetType : std::int8_t { UNDEFINED = -1, GRAPH = 1, TEMPLATE = 2 };
 
 class GDALRDADataset: public GDALDataset
 {
@@ -90,10 +91,14 @@ class GDALRDADataset: public GDALDataset
         CPLString m_osAccessToken;
         int       m_nExpiresIn = 0;
 
+        RDADatasetType m_osType = RDADatasetType::UNDEFINED;
+
         CPLString m_osGraphId;
         CPLString m_osNodeId;
+        CPLString m_osTemplateId;
+        std::vector<std::tuple<CPLString, CPLString>> m_osParams;
         bool      m_bDeleteOnClose = true;
-
+        bool      m_bAdviseRead = true;
         CPLString m_osImageId;
         CPLString m_osProfileName;
         CPLString m_osNativeTileFileFormat;
@@ -133,12 +138,14 @@ class GDALRDADataset: public GDALDataset
         int       m_nYSizeFetched = 0;
 
         int       m_nMaxCurlConnections = 8;
+        bool      m_bIsMaxCurlConnectionsExplicitlySet = false;
 
         bool      ReadConfiguration();
         bool      GetAuthorization();
         bool      ParseAuthorizationResponse(const CPLString& osAuth);
         bool      ParseConnectionString( GDALOpenInfo* poOpenInfo );
-        json_object* ReadJSonFile(const char* pszFilename, bool bErrorOn404);
+        json_object* ReadJSonFile(const char* pszFilename, const char* pszKey, bool bErrorOn404);
+        CPLString ConstructTileFetchURL(CPLString baseUrl, CPLString subPath);
         bool      ReadImageMetadata();
         bool      ReadRPCs();
         bool      ReadGeoreferencing();
@@ -184,6 +191,8 @@ class GDALRDADataset: public GDALDataset
                                         int /*nBands*/, int* /*panBands*/,
                                         char ** /* papszOptions */) override;
         char**          GetMetadata( const char* pszDomain = "" ) override;
+        bool            IsMaxCurlConnectionsSet();
+        void            MaxCurlConnectionsSet(unsigned int nMaxCurlConnections);
 };
 
 
@@ -332,8 +341,16 @@ void GDALRDADataset::CacheFile( const CPLString& osCachedFilename,
 
 int GDALRDADataset::Identify( GDALOpenInfo* poOpenInfo )
 {
-    return strstr(poOpenInfo->pszFilename, "graph-id") != nullptr &&
-           strstr(poOpenInfo->pszFilename, "node-id") != nullptr;
+    // if connection string is JSON
+    if((strstr(poOpenInfo->pszFilename, "graph-id") != nullptr &&
+       strstr(poOpenInfo->pszFilename, "node-id") != nullptr) ||
+    strstr(poOpenInfo->pszFilename, "template-id") != nullptr)
+        return true;
+    else if (CPLString(CPLGetExtension(poOpenInfo->pszFilename)).toupper().compare("RDA") == 0)
+        return true;
+
+    return false;
+
 }
 
 /************************************************************************/
@@ -616,8 +633,18 @@ bool GDALRDADataset::ParseAuthorizationResponse(const CPLString& osAuth)
 
 bool GDALRDADataset::ParseConnectionString( GDALOpenInfo* poOpenInfo )
 {
+    CPLString osConnectionString;
+    if(CPLString(CPLGetExtension(poOpenInfo->pszFilename)).toupper().compare("RDA") == 0)
+    {
+        CSLUniquePtr papszContent(CSLLoad2( poOpenInfo->pszFilename, -1, -1, nullptr));
+        osConnectionString = *(papszContent.get());
+    }
+    else
+    {
+        osConnectionString = poOpenInfo->pszFilename;
+    }
     json_object* poObj = nullptr;
-    if( !OGRJSonParse(poOpenInfo->pszFilename, &poObj, true) )
+    if( !OGRJSonParse(osConnectionString, &poObj, true) )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Invalid JSon document as dataset name");
@@ -626,26 +653,47 @@ bool GDALRDADataset::ParseConnectionString( GDALOpenInfo* poOpenInfo )
     JsonObjectUniquePtr oObj(poObj);
 
     json_object* poGraphId =
-        CPL_json_object_object_get(poObj, "graph-id");
-    if( poGraphId == nullptr ||
-        json_object_get_type(poGraphId) != json_type_string )
+        json_object_object_get(poObj, "graph-id");
+
+    if( poGraphId != nullptr &&
+         json_object_get_type(poGraphId) == json_type_string)
+    {
+        m_osType = RDADatasetType::GRAPH;
+        m_osGraphId = json_object_get_string(poGraphId);
+    }
+
+
+
+    json_object* poTemplateId =
+            json_object_object_get(poObj, "template-id");
+
+    if( poTemplateId != nullptr &&
+        json_object_get_type(poTemplateId) == json_type_string)
+    {
+        m_osType = RDADatasetType::TEMPLATE;
+        m_osTemplateId = json_object_get_string(poTemplateId);
+    }
+
+    if(m_osType == RDADatasetType::UNDEFINED)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "Missing graph-id");
+                 "Missing graph-id or template-id");
         return false;
     }
-    m_osGraphId = json_object_get_string(poGraphId);
+
 
     json_object* poNodeId =
-        CPL_json_object_object_get(poObj, "node-id");
-    if( poNodeId == nullptr ||
-        json_object_get_type(poNodeId) != json_type_string )
+        json_object_object_get(poObj, "node-id");
+    if( (poNodeId == nullptr ||
+        json_object_get_type(poNodeId) != json_type_string) && m_osType == RDADatasetType::GRAPH )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Missing node-id");
         return false;
     }
-    m_osNodeId = json_object_get_string(poNodeId);
+
+    m_osNodeId = (poNodeId != nullptr && json_object_get_type(poNodeId) == json_type_string)
+                 ?  json_object_get_string(poNodeId) :"";
 
     json_object* poDeleteOnClose = json_ex_get_object_by_path(poObj,
                                                 "options.delete-on-close");
@@ -654,6 +702,50 @@ bool GDALRDADataset::ParseConnectionString( GDALOpenInfo* poOpenInfo )
     {
         m_bDeleteOnClose = CPL_TO_BOOL(
             json_object_get_boolean(poDeleteOnClose));
+    }
+
+    json_object* poMaxConnections = json_ex_get_object_by_path(poObj,
+                                                              "options.max-connections");
+    if( poMaxConnections &&
+        json_object_get_type(poMaxConnections) == json_type_int )
+    {
+        MaxCurlConnectionsSet(json_object_get_int(poMaxConnections));
+    }
+
+    json_object* poEnforceAdviseRead = json_ex_get_object_by_path(poObj,
+                                                               "options.advise-read");
+    if( poEnforceAdviseRead &&
+        json_object_get_type(poEnforceAdviseRead) == json_type_boolean )
+    {
+        m_bAdviseRead = CPL_TO_BOOL(
+                json_object_get_boolean(poEnforceAdviseRead));
+    }
+
+    if(m_osType == RDADatasetType::TEMPLATE)
+    {
+        json_object *poParams = json_object_object_get(poObj, "params");
+
+        if(poParams != nullptr) {
+            array_list *res = json_object_get_array(poParams);
+            if(res != nullptr) {
+                for (decltype(res->length) i = 0; i < res->length; i++) {
+                    json_object *ds = (json_object *) array_list_get_idx(res, i);
+                    if (ds != nullptr) {
+                        json_object_iter it;
+                        it.key = nullptr;
+                        it.val = nullptr;
+                        it.entry = nullptr;
+                        json_object_object_foreachC( ds, it )
+                        {
+                            CPLString tkey = it.key;
+                            CPLString tval = json_object_get_string(it.val);
+                            m_osParams.push_back(std::make_tuple(tkey, tval));
+                        }
+                    }
+                }
+            }
+        }
+
     }
 
     return true;
@@ -791,7 +883,7 @@ static double GetJsonDouble(json_object* poObj, const char* pszPath,
 /*                           ReadJSonFile()                             */
 /************************************************************************/
 
-json_object* GDALRDADataset::ReadJSonFile(const char* pszFilename,
+json_object* GDALRDADataset::ReadJSonFile(const char* pszFilename, const char* pszKey,
                                           bool bErrorOn404)
 {
     CPLString osCachedFilename(
@@ -818,14 +910,42 @@ json_object* GDALRDADataset::ReadJSonFile(const char* pszFilename,
     if( pszRes == nullptr )
     {
         CPLString osURL(m_osRDAAPIURL);
-        osURL += "/metadata/" + m_osGraphId + "/" +
-                 m_osNodeId + "/" + pszFilename;
+        if(m_osType == RDADatasetType::GRAPH)
+        {
+            osURL += "/metadata/" + m_osGraphId + "/" +
+                     m_osNodeId + "/" + pszFilename;
+        }
+        else if(m_osType == RDADatasetType::TEMPLATE)
+        {
+            osURL += "/template/" + m_osTemplateId + "/metadata";
+            osURL += m_osParams.size()>0 ? "?": "";
+            if(!m_osNodeId.empty())
+            {
+                osURL += "nodeId="+m_osNodeId+"&";
+            }
+            for (auto tup : m_osParams)
+            {
+                osURL += std::get<0>(tup)+"="+std::get<1>(tup)+"&";
+            }
+            //remove trailing &
+            if(osURL.endsWith("&") ==0 )
+            {
+                osURL.erase((osURL.begin() + osURL.size()-1), osURL.end());
+            }
+        }
+        else
+        {
+            //this shouldn't happen
+            return nullptr;
+        }
+
         pszRes = reinterpret_cast<char*>(Download(osURL, bErrorOn404));
         bToCache = true;
     }
     if( pszRes == nullptr )
         return nullptr;
     json_object* poObj = nullptr;
+    json_object* poRetval = nullptr;
     if( !OGRJSonParse(pszRes, &poObj, true) )
     {
         CPLFree(pszRes);
@@ -837,16 +957,26 @@ json_object* GDALRDADataset::ReadJSonFile(const char* pszFilename,
     {
         json_object_put(poObj);
         poObj = nullptr;
-        // In case we don't get image.json, don't cache anything
-        if( strcmp(pszFilename, "image.json") == 0 )
+        // In case we don't get metadata.json, don't cache anything
+        if( strcmp(pszFilename, "metadata.json") == 0 )
             bToCache = false;
     }
+
+    if(pszKey != nullptr)
+    {
+        poRetval = json_object_object_get(poObj, pszKey);
+    }
+    else
+    {
+        poRetval = poObj;
+    }
+
     if( bToCache )
     {
         CacheFile( osCachedFilename, pszRes, strlen(pszRes) );
     }
     CPLFree(pszRes);
-    return poObj;
+    return poRetval;
 }
 
 /************************************************************************/
@@ -855,7 +985,7 @@ json_object* GDALRDADataset::ReadJSonFile(const char* pszFilename,
 
 bool GDALRDADataset::ReadImageMetadata()
 {
-    json_object* poObj = ReadJSonFile("image.json", true);
+    json_object* poObj = ReadJSonFile("metadata.json", "imageMetadata", true);
     if( poObj == nullptr )
         return false;
 
@@ -1023,7 +1153,7 @@ bool GDALRDADataset::ReadGeoreferencing()
 {
     m_bTriedReadGeoreferencing = true;
 
-    json_object* poObj = ReadJSonFile("georeferencing.json", false);
+    json_object* poObj = ReadJSonFile("metadata.json", "imageGeoreferencing", false);
     if( poObj == nullptr )
         return false;
 
@@ -1109,7 +1239,11 @@ static CPLString Get20Coeffs(json_object* poObj, const char* pszPath,
 
 bool GDALRDADataset::ReadRPCs()
 {
-    json_object* poObj = ReadJSonFile("rpcs.json", false);
+    // No RPCs for a georectified image
+    if(m_osProfileName.tolower().compare("georectified_image") == 0)
+        return false;
+
+    json_object* poObj = ReadJSonFile("metadata.json", "rpcSensorModel", false);
     if( poObj == nullptr )
         return false;
 
@@ -1122,14 +1256,14 @@ bool GDALRDADataset::ReadRPCs()
     if( poScale != nullptr && json_object_get_double(poScale) != 1.0 )
     {
         CPLError(CE_Failure, CPLE_NotSupported,
-                 "postScaleFactorX != 1 in rpcs.json not supported");
+                 "postScaleFactorX != 1 in metadata.json|rpcSensorModel  not supported");
         bError = true;
     }
     poScale = CPL_json_object_object_get(poObj, "postScaleFactorY");
     if( poScale != nullptr && json_object_get_double(poScale) != 1.0 )
     {
         CPLError(CE_Failure, CPLE_NotSupported,
-                 "postScaleFactorY != 1 in rpcs.json not supported");
+                 "postScaleFactorY != 1 in metadata.json|rpcSensorModel not supported");
         bError = true;
     }
 
@@ -1200,6 +1334,23 @@ bool GDALRDADataset::ReadRPCs()
         SetMetadata(papszMD, "RPC");
     CSLDestroy(papszMD);
     return !bError;
+}
+
+/************************************************************************/
+/*              IsMaxCurlConnectionsSet()                       */
+/************************************************************************/
+bool GDALRDADataset::IsMaxCurlConnectionsSet()
+{
+    return m_bIsMaxCurlConnectionsExplicitlySet;
+}
+
+/************************************************************************/
+/*              MaxCurlConnectionsSet()                       */
+/************************************************************************/
+void GDALRDADataset::MaxCurlConnectionsSet(unsigned int nMaxCurlConnections)
+{
+    m_nMaxCurlConnections = std::max(1, std::min(256, static_cast<int>(nMaxCurlConnections)));
+    m_bIsMaxCurlConnectionsExplicitlySet = true;
 }
 
 /************************************************************************/
@@ -1286,18 +1437,21 @@ GDALDataset* GDALRDADataset::OpenStatic( GDALOpenInfo* poOpenInfo )
     if( !poDS->Open(poOpenInfo) )
         return nullptr;
 
-    const char* pszMaxConnect =
-            CSLFetchNameValue(poOpenInfo->papszOpenOptions, "MAXCONNECT");
-
-    if (pszMaxConnect != nullptr) {
-        poDS->m_nMaxCurlConnections =
-            std::max(1, std::min(1024, atoi(pszMaxConnect)));
-    }
-    else
+    if(!poDS->IsMaxCurlConnectionsSet())
     {
-        unsigned int n = std::thread::hardware_concurrency();
-        poDS->m_nMaxCurlConnections = std::max(static_cast<int>(8*n), 64);
+        const char* pszMaxConnect =
+                CSLFetchNameValue(poOpenInfo->papszOpenOptions, "MAXCONNECT");
+
+        if (pszMaxConnect != nullptr) {
+            poDS->MaxCurlConnectionsSet(atoi(pszMaxConnect));
+        }
+        else
+        {
+            unsigned int n = std::thread::hardware_concurrency();
+            poDS->MaxCurlConnectionsSet(std::max(static_cast<int>(8 * n), 64));
+        }
     }
+
 
     return poDS.release();
 }
@@ -1379,7 +1533,46 @@ std::string GDALRDADataset::MakeKeyCache(int64_t nTileX, int64_t nTileY)
                                   this, static_cast<GIntBig>(nTileX),
                                   static_cast<GIntBig>(nTileY)));
 }
-
+/************************************************************************/
+/*                          ConstructTileFetchURL()                                */
+/************************************************************************/
+CPLString GDALRDADataset::ConstructTileFetchURL(CPLString baseUrl, CPLString subPath)
+{
+    CPLString retVal = baseUrl;
+    if(m_osType == RDADatasetType::GRAPH)
+    {
+        retVal += "/tile/" + m_osGraphId + "/" + m_osNodeId + "/";
+        retVal += subPath;
+    }
+    else if(m_osType == RDADatasetType::TEMPLATE)
+    {
+        retVal += "/template/" + m_osTemplateId + "/tile/";
+        CPLString tosDiscardPath= "." + m_osNativeTileFileFormat;
+        CPLString tosSubPath = subPath ;
+        tosSubPath.erase((tosSubPath.begin()+tosSubPath.find(tosDiscardPath)), tosSubPath.end());
+        retVal += tosSubPath;
+        retVal += m_osParams.size()>0 || m_osNodeId ? "?": "";
+        if(!m_osNodeId.empty())
+        {
+            retVal += "nodeId="+m_osNodeId+"&";
+        }
+        for (auto tup : m_osParams)
+        {
+            retVal += std::get<0>(tup)+"="+std::get<1>(tup)+"&";
+        }
+        //remove trailing &
+        if(retVal.endsWith("&"))
+        {
+            retVal.erase((retVal.begin() + retVal.size()-1), retVal.end());
+        }
+    }
+    else
+    {
+        //this shouldn't happen
+        throw new std::runtime_error("Udefined RDADatasetType");
+    }
+    return retVal;
+}
 /************************************************************************/
 /*                          BatchFetch()                                */
 /************************************************************************/
@@ -1404,7 +1597,7 @@ void GDALRDADataset::BatchFetch(int nXOff, int nYOff, int nXSize, int nYSize)
     int nFullXSize = GetRasterBand(1)->GetXSize();
     int nFullYSize = GetRasterBand(1)->GetYSize();
     bool fetchAllAdvised = false;
-    if(m_nXSizeAdvise != 0 && m_nYSizeAdvise != 0)
+    if(m_nXSizeAdvise != 0 && m_nYSizeAdvise != 0 && m_bAdviseRead)
     {
         fetchAllAdvised = true;
         int advisedXBlocks = static_cast<int>(
@@ -1412,10 +1605,10 @@ void GDALRDADataset::BatchFetch(int nXOff, int nYOff, int nXSize, int nYSize)
         int advisedYBlocks = static_cast<int>(
             std::ceil(static_cast<double>(m_nYSizeAdvise)/nBlockYSize));
         if(m_nXSizeAdvise == nFullXSize &&
-            advisedXBlocks>2*m_nMaxCurlConnections)
+            advisedXBlocks > m_nMaxCurlConnections)
             fetchAllAdvised = false;
         else if(m_nYSizeAdvise == nFullYSize &&
-            advisedYBlocks>2*m_nMaxCurlConnections)
+            advisedYBlocks > m_nMaxCurlConnections)
             fetchAllAdvised = false;
     }
 
@@ -1477,9 +1670,7 @@ void GDALRDADataset::BatchFetch(int nXOff, int nYOff, int nXSize, int nYSize)
                 continue;
             }
 
-            CPLString osURL(m_osRDAAPIURL);
-            osURL += "/tile/" + m_osGraphId + "/" + m_osNodeId + "/";
-            osURL += osSubPath;
+            CPLString osURL = ConstructTileFetchURL(m_osRDAAPIURL, osSubPath);
             apszURLLists.push_back(CPLStrdup(osURL));
             aTileIdx.push_back(std::pair<int64_t,int64_t>(nTileX, nTileY));
         }
@@ -1577,9 +1768,7 @@ GDALRDADataset::GetTiles(
             }
         }
 
-        CPLString osURL(m_osRDAAPIURL);
-        osURL += "/tile/" + m_osGraphId + "/" + m_osNodeId + "/";
-        osURL += osSubPath;
+        CPLString osURL = ConstructTileFetchURL(m_osRDAAPIURL, osSubPath);
         apszURLLists.push_back(CPLStrdup(osURL));
         anOutIndex.push_back(i);
         oResult.push_back( nullptr );
@@ -1923,7 +2112,7 @@ void GDALRegister_RDA()
 
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
 "<OpenOptionList>"
-"  <Option name='MAXCONNECT' type='int' min='1' max='1024' "
+"  <Option name='MAXCONNECT' type='int' min='1' max='256' "
                         "description='Maximum number of connections'/>"
 "</OpenOptionList>" );
 

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -2109,13 +2109,14 @@ void GDALRegister_RDA()
                                "DigitalGlobe Raster Data Access driver" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
                                "frmt_rda.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "rda" );
 
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
 "<OpenOptionList>"
 "  <Option name='MAXCONNECT' type='int' min='1' max='256' "
                         "description='Maximum number of connections'/>"
 "</OpenOptionList>" );
-
+    
     poDriver->pfnIdentify = GDALRDADataset::Identify;
     poDriver->pfnOpen = GDALRDADataset::OpenStatic;
     poDriver->pfnUnloadDriver = GDALRDADriverUnload;


### PR DESCRIPTION
RDA api has added support for a graph template with variable substitution. 

I've updated the driver to
-  allow access from a template-id with substitution parameters
-  use consolidated metadata read 
-  make convenience changes to help with use in 3rd-party software (QGIS for example) where controlling open options or passing non filename is not supported.
    -  add connection string options to set the max-connections and whether to ignore advise-read
    -  allow the connection string to be json in a file with .rda extension