### PR TITLE
Make shpopen error message more general

### DIFF
--- a/gdal/NEWS
+++ b/gdal/NEWS
@@ -618,6 +618,7 @@ Shapefile driver:
  * fix regression affecting GDAL 2.1.3 or later, 2.2.0 and 2.2.1, when editing the last shape of a file and growing it, and then appending a new shape, which resulted in corruption of both shapes (#7031)
  * hide shapelib symbols on Unix
  * improvements auto-identification of EPSG codes from input SRS, using OSRFindMatches()
+ * Improve guidance on use of SHAPE_RESTORE_SHX in SHPOpenLL() (#7246)
 
 S57 driver:
 

--- a/gdal/ogr/ogrsf_frmts/shape/shpopen.c
+++ b/gdal/ogr/ogrsf_frmts/shape/shpopen.c
@@ -652,9 +652,9 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
     {
         size_t nMessageLen = strlen(pszBasename)*2+256;
         char *pszMessage = (char *) malloc(nMessageLen);
-        snprintf( pszMessage, nMessageLen, "Unable to open %s.shx or %s.SHX."
-                  "Try --config SHAPE_RESTORE_SHX true to restore or create it",
-                  pszBasename, pszBasename );
+        snprintf( pszMessage, nMessageLen, "Unable to open %s.shx or %s.SHX. "
+                  "Set SHAPE_RESTORE_SHX config option to YES to restore or "
+                  "create it.", pszBasename, pszBasename );
         psHooks->Error( pszMessage );
         free( pszMessage );
 


### PR DESCRIPTION
The error message is trunk is helpful in the context of ogrinfo but not in other contexts. I'm trying to make it more generally useful.

Resolves https://trac.osgeo.org/gdal/ticket/7246#ticket.