### PR TITLE
* autotest/cpp/Makefile: Allow 'check' as a synonym for 'test'.

### DIFF
--- a/autotest/cpp/Makefile
+++ b/autotest/cpp/Makefile
@@ -11,7 +11,7 @@ PROGS = gdal_unit_test testperfcopywords testcopywords testclosedondestroydm tes
 
 all: $(PROGS)
 
-test:
+test check:
 	make quick_test
 	./testperfcopywords
 


### PR DESCRIPTION
This patch allows `make test` or `make check` for the benefit of old GNU hippies.