### PR TITLE
* gdal/PROVENANCE.TXT: Update to remove directories that no longer exist.

### DIFF
--- a/gdal/PROVENANCE.TXT
+++ b/gdal/PROVENANCE.TXT
@@ -139,55 +139,20 @@ Note: all the following are build options, not required.
                Derived from modules of GRASS 4.1 (public domain), properly noted in the headers.
                See http://trac.osgeo.org/gdal/ticket/2975
 
-=== gdal/debian ===
-
-* copyright somewhat unclear, not actually part of software.
-
 === gdal/doc ===
 
 * no copyright messages in .dox files.
 * ERMapper logo used with permissions.
 * "ru" subdirectory (Russian translations) by Andrey Kiselev.
 
-=== gdal/pymod ===
-
-* gdal_merge.py: copyright held by Atlantis, under LGPL. This is an acceptable license and it is just noted as an exception to the general MIT/X rule for GDAL but no further action required.
-* gdal2xyz.py: copyright me, under LGPL - relicensed MIT/X.
-* gdal_wrap.c: Generated with SWIG under very permissive license (noted in file).
-* Scripts mostly by me, all ok.
-
-=== gdal/pymod/samples ===
-
-* gdal_vrtmerge.py: Under LGPL (derived from gdal_merge.py), several contributors.
-* histrep.py: corrected copyright message (Atlantis to FrankW), change license to MIT/X.
-* various contributors, all under proper and compatible copyright headers.
-
-=== gdal/ogr/ogrsf_rmts/generic ===
-
-* Some files here (and elsewhere in OGR) copyright Softmap Inc (but MIT/X).
-
 === gdal/ogr/ogrsf_frmts/avc ===
 
 * Some copyright Daniel Morissette, MIT/X.
 * Included copy of dbfopen.h from Shapelib.  We really ought to reference the one in ../shape.
 
-=== gdal/ogr/ogrsf_rmts/csv ===
-
-* drv_*.html not copyright.
-
-=== gdal/ogr/ogrsf_rmts/dgn ===
-
-* Copyright Avenza Systems (MIT/X).
-* dgn_pge.cpp, dgn_pge.h, pge_test.cpp, vbe_pge.cpp: copyright Pacific Gas and Electric, all rights reserved!  (this has all been removed from trunk)
-* web/* docs lack any copyright message.  The isff.txt originally came from Intergraph and dgn.html is a reformatted version of that.  Perhaps these ought to move out of GDAL CVS tree - action: this has been removed from svn. (#1813)
-
 === gdal/ogr/ogrsf_frmts/dods ===
 
 * all FrankW, clean.
-
-=== gdal/ogr/ogrsf_frmts/dxfdwg ===
-
-* OdFileBuf.h, OdFileBuf.cpp is derived from DWGdirect source code.  No copyright message! Action: This driver has been removed from subversion (#1816)
 
 === gdal/ogr/ogrsf_frmts/fme ===
 
@@ -293,31 +258,6 @@ Note: all the following are build options, not required.
 * oledbgis.h: No copyright message, mostly OGC spec constants.
 * swq.h, swq.c: Has alternate form of MIT/X license.  On review this license is functionally equivalent to the general GDAL license.
 * Copyright holders include Frank Warmerdam, Daniel Morissette, Softmap Inc., Stephane Villeneuve., Andrey Kiselev, Information Interoperability Institute
-
-
-=== gdal/ogr/wcts ===
-
-* FrankW, clean.
-* No copyrights on xml sample docs (protocol messages), but also all authored under the normal terms.
-* No copyright message for html docs.
-
-=== gdal/ogr/ccclient, gdal/ogr/ccdriver ===
-
-* Removed all contents since they are of no modern use, and may have included outside source.
-
-=== gdal/ogr/sfcom_oledb ===
-
-* sfcom_oledb/ICommandWidthParametersImpl.h: Provided by ESRI without clear copyright/license terms.   (#1817)
-* atl_net/ICRRowsetImpl.h,IFRowsetImpl.h,CCRRowsetImpl.h,SFAccessorImpl.h: Modified form of code from ATLDB.H, properly credited in the header. Copyright claim is dubious.  (#1817)
-* atl_net/IColumnsRowsetImpl.h: Derived from code for article by Len Holgate, JetByte Limited.  It is not clear if the code is properly licensed, though it is attributed.  (#1817)
-* Similar issues to above in atl_vc6 directory.
-* Code Copyright Softmap, FrankW,
-* Some files lack headers (mostly MS Visual Studio generated files).
-* Whole tree moved to /spike/sfcom_oledb to avoid problems by act of the PSC.
-
-=== gdal/ogr/sfcom_serv ===
-
-* Obsolete code, all deleted from CVS.
 
 === gdal/frmts/aaigrid ===
 
@@ -429,12 +369,6 @@ I have added this license to LICENSE.TXT to satisfy the credit requirement.
 
 * FrankW, clean.
 
-=== gdal/frmts/hdf ===
-
-* geoextra.c: Derived by public domain contribution to libgeotiff from PCI but the terms are not clear.  This is a libgeotiff issue.  There is no problem with the license - it just isn't well documented in the code file.
-* Mostly copyright Intergraph Corporation, clean.
-* hfacompress.cpp: Sam Gillingham, clean.
-
 === gdal/frmts/idrisi ===
 
 * Ivan Lucena (Clark University), clean.
@@ -502,10 +436,6 @@ I have added this license to LICENSE.TXT to satisfy the credit requirement.
 * mgrs.h, mgrs.c: Derived from Geotrans (public domain), not current copyright header.
 * The rest is FrankW, clean.
 
-=== gdal/frmts/ogdi ===
-
-* FrankW, clean.
-
 === gdal/frmts/pcidsk ===
 
 * AndreyK/FrankW, clean.
@@ -547,10 +477,6 @@ I have added this license to LICENSE.TXT to satisfy the credit requirement.
  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-=== gdal/frmts/pgchip ===
-
-* Benjamin Simon, clean.
 
 === gdal/frmts/png ===
 

--- a/gdal/PROVENANCE.TXT
+++ b/gdal/PROVENANCE.TXT
@@ -145,10 +145,24 @@ Note: all the following are build options, not required.
 * ERMapper logo used with permissions.
 * "ru" subdirectory (Russian translations) by Andrey Kiselev.
 
+=== gdal/ogr/ogrsf_frmts/generic ===
+
+* Some files here (and elsewhere in OGR) copyright Softmap Inc (but MIT/X).
+
 === gdal/ogr/ogrsf_frmts/avc ===
 
 * Some copyright Daniel Morissette, MIT/X.
 * Included copy of dbfopen.h from Shapelib.  We really ought to reference the one in ../shape.
+
+=== gdal/ogr/ogrsf_frmts/csv ===
+
+* drv_*.html not copyright.
+
+=== gdal/ogr/ogrsf_frmts/dgn ===
+
+* Copyright Avenza Systems (MIT/X).
+* dgn_pge.cpp, dgn_pge.h, pge_test.cpp, vbe_pge.cpp: copyright Pacific Gas and Electric, all rights reserved!  (this has all been removed from trunk)
+* web/* docs lack any copyright message.  The isff.txt originally came from Intergraph and dgn.html is a reformatted version of that.  Perhaps these ought to move out of GDAL CVS tree - action: this has been removed from svn. (#1813)
 
 === gdal/ogr/ogrsf_frmts/dods ===
 
@@ -368,6 +382,11 @@ I have added this license to LICENSE.TXT to satisfy the credit requirement.
 === gdal/frmts/hdf5 ===
 
 * FrankW, clean.
+
+=== gdal/frmts/hfa ===
+
+* Mostly copyright Intergraph Corporation, clean.
+* hfacompress.cpp: Sam Gillingham, clean.
 
 === gdal/frmts/idrisi ===
 


### PR DESCRIPTION
The history, while interesting, can be preserved in version control. I think it's better that the content of the file corresponds to the source tree.