### PR TITLE
default driver to fetch from tif RDA endpoint

### DIFF
--- a/gdal/frmts/rda/frmt_rda.html
+++ b/gdal/frmts/rda/frmt_rda.html
@@ -50,13 +50,6 @@ OR
     </li>
 
     <li>
-        <pre>"options": {"delete-on-close": false}</pre>
-        can be added to
-        the JSon document to request that cached tiles and metadata are not destroyed
-        at dataset closing. The default, if not specified, is true.
-    </li>
-
-    <li>
         <pre>"options": {"max-connections": 32}</pre>
         can be added to
         the JSon document to request that cached tiles be fetched using a maximum number of
@@ -135,8 +128,7 @@ user_password = value (required)
     ~/.gdal/rda_cache/{graph-id}/{node-id}, and deleted on dataset closing,
     unless
 <pre>"options": {"delete-on-close": false}</pre>
-is found in the
-dataset name.</p>
+is found in the dataset name.</p>
 
 
 <h2>Open Options</h2>

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -259,7 +259,8 @@ GDALRDADataset::GDALRDADataset() :
     m_osClientId(CPLGetConfigOption("GBDX_CLIENT_ID", "")),
     m_osClientSecret(CPLGetConfigOption("GBDX_CLIENT_SECRET", "")),
     m_osUserName(CPLGetConfigOption("GBDX_USERNAME", "")),
-    m_osUserPassword(CPLGetConfigOption("GBDX_PASSWORD", ""))
+    m_osUserPassword(CPLGetConfigOption("GBDX_PASSWORD", "")),
+    m_osNativeTileFileFormat(CPLGetConfigOption("RDA_NATIVE_FORMAT", "tif"))
 {
 }
 
@@ -1030,11 +1031,7 @@ bool GDALRDADataset::ReadImageMetadata()
     m_osImageId = GetJsonString(poObj, "imageId", true, bError);
     m_osProfileName = GetJsonString(poObj, "profileName", false,
                                     bNonFatalError);
-    m_osNativeTileFileFormat = GetJsonString(poObj, "nativeTileFileFormat",
-                                            false, bNonFatalError);
-    m_osNativeTileFileFormat = m_osNativeTileFileFormat.tolower();
-    if( m_osNativeTileFileFormat.empty() )
-        m_osNativeTileFileFormat = "tif";
+
     m_nTileXOffset = GetJsonInt64(poObj, "tileXOffset", true, bError);
     m_nTileYOffset = GetJsonInt64(poObj, "tileYOffset", true, bError);
     m_nNumXTiles = std::max<GIntBig>(0,

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -101,7 +101,7 @@ class GDALRDADataset: public GDALDataset
         bool      m_bAdviseRead = true;
         CPLString m_osImageId;
         CPLString m_osProfileName;
-        CPLString m_osNativeTileFileFormat;
+        CPLString m_osRequestTileFileFormat;
         int64_t   m_nTileXOffset = 0;
         int64_t   m_nTileYOffset = 0;
         int64_t   m_nNumXTiles = 0;
@@ -260,7 +260,7 @@ GDALRDADataset::GDALRDADataset() :
     m_osClientSecret(CPLGetConfigOption("GBDX_CLIENT_SECRET", "")),
     m_osUserName(CPLGetConfigOption("GBDX_USERNAME", "")),
     m_osUserPassword(CPLGetConfigOption("GBDX_PASSWORD", "")),
-    m_osNativeTileFileFormat(CPLGetConfigOption("RDA_NATIVE_FORMAT", "tif"))
+    m_osRequestTileFileFormat(CPLGetConfigOption("RDA_REQUEST_FORMAT", "tif"))
 {
 }
 
@@ -1584,7 +1584,7 @@ CPLString GDALRDADataset::ConstructTileFetchURL(const CPLString& baseUrl,
     else if(m_osType == RDADatasetType::TEMPLATE)
     {
         retVal += "/template/" + m_osTemplateId + "/tile/";
-        CPLString tosDiscardPath= "." + m_osNativeTileFileFormat;
+        CPLString tosDiscardPath= "." + m_osRequestTileFileFormat;
         CPLString tosSubPath = subPath ;
         tosSubPath.erase((tosSubPath.begin()+tosSubPath.find(tosDiscardPath)),
                          tosSubPath.end());
@@ -1700,7 +1700,7 @@ void GDALRDADataset::BatchFetch(int nXOff, int nYOff, int nXSize, int nYSize)
             osSubPath += "/";
             osSubPath += CPLSPrintf(CPL_FRMT_GIB, static_cast<GIntBig>(nTileY));
             osSubPath += ".";
-            osSubPath += m_osNativeTileFileFormat;
+            osSubPath += m_osRequestTileFileFormat;
             CPLString osCachedFilename(GetDatasetCacheDir() + "/" + osSubPath);
             VSIStatBufL sStat;
             if( VSIStatL(osCachedFilename, &sStat) == 0 )
@@ -1741,7 +1741,7 @@ void GDALRDADataset::BatchFetch(int nXOff, int nYOff, int nXSize, int nYSize)
                 osSubPath += CPLSPrintf(CPL_FRMT_GIB,
                                         static_cast<GIntBig>(nTileY));
                 osSubPath += ".";
-                osSubPath += m_osNativeTileFileFormat;
+                osSubPath += m_osRequestTileFileFormat;
                 CPLString osCachedFilename(
                     GetDatasetCacheDir() + "/" + osSubPath);
                 CacheFile( osCachedFilename,
@@ -1782,7 +1782,7 @@ GDALRDADataset::GetTiles(
         osSubPath += "/";
         osSubPath += CPLSPrintf(CPL_FRMT_GIB, static_cast<GIntBig>(nTileY));
         osSubPath += ".";
-        osSubPath += m_osNativeTileFileFormat;
+        osSubPath += m_osRequestTileFileFormat;
         CPLString osCachedFilename(GetDatasetCacheDir() + "/" + osSubPath);
         VSIStatBufL sStat;
         if( VSIStatL(osCachedFilename, &sStat) == 0 )
@@ -1839,7 +1839,7 @@ GDALRDADataset::GetTiles(
                                                 this,
                                                 static_cast<int>(nTileX),
                                                 static_cast<int>(nTileY)));
-                osTmpMemFile += m_osNativeTileFileFormat;
+                osTmpMemFile += m_osRequestTileFileFormat;
                 GByte* pabyData = pasResults[i]->pabyData;
                 pasResults[i]->pabyData = nullptr;
                 VSIFCloseL(VSIFileFromMemBuffer(osTmpMemFile, pabyData,
@@ -1871,7 +1871,7 @@ GDALRDADataset::GetTiles(
                         osSubPath += CPLSPrintf(CPL_FRMT_GIB,
                                                 static_cast<GIntBig>(nTileY));
                         osSubPath += ".";
-                        osSubPath += m_osNativeTileFileFormat;
+                        osSubPath += m_osRequestTileFileFormat;
                         CPLString osCachedFilename(
                             GetDatasetCacheDir() + "/" + osSubPath);
                         CacheFile( osCachedFilename, pabyData,


### PR DESCRIPTION

## What does this PR do?
Fixes a bug whereby the driver uses the nativeTileFormat from the image metadata instead of defaulting to .tif. The nativeTileFormat field in the image metadata is only valid for the source Idaho data. Using the value may cause tile fetching from an unsupported RDA endpoing, Only TIF endpoint is officially supported at the present time.
Remove duplicate text block from documentation.

## Note:
The RDA_NATIVE_FORMAT config option is meant to NOT BE documented. It is only used internally for testing against the RDA endpoints for future development.

## Tasklist

 - [ x] Add test case(s) - not needed
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

