### PR TITLE
Add const-correctness to methods in OGRFeatureDefn, OGRFeature and OGR[Geom]FieldDefn

### DIFF
--- a/gdal/MIGRATION_GUIDE.TXT
+++ b/gdal/MIGRATION_GUIDE.TXT
@@ -19,6 +19,39 @@ GDAL now requires a C++11 compatible compiler. External code using GDAL C++ API
 will also need to enable at least C++11 compilation mode, if the compiler
 defaults to C++98/C++03.
 
+3) Stricter const-ness in OGRGeomFieldDefn, OGRFeatureDefn and OGRFeature
+   classes, impacting out-of-tree drivers that subclass them.
+
+   The following methods are now const qualified:
+
+     OGRGeomFieldDefn class:
+        virtual OGRSpatialReference* GetSpatialRef() const
+
+     OGRFeatureDefn class:
+        virtual const char* GetName() const
+        virtual int GetFieldCount() const
+        virtual int GetFieldIndex(const char*) const
+        virtual int GetGeomFieldCount() const
+        virtual int GetGeomFieldIndex(const char*) const
+        virtual OGRwkbGeometryType GetGeomType() const
+        virtual OGRFeatureDefn* Clone() const
+        virtual int IsGeometryIgnored() const
+        virtual int IsSame(const OGRFeatureDefn*) const // argument is const now too
+
+     OGRFeature class:
+        virtual OGRBoolean Equal(const OGRFeature*) const // argument is const now too
+        virtual const char* GetStyleString() const
+        virtual OGRStyleTable* GetStyleTable() const
+
+    The following virtual methods, offering const alternatives to their
+    non-const equivalent methods, should be overloaded if the non-const
+    method is overloaded.
+
+     OGRFeatureDefn class:
+        virtual const OGRFieldDefn* GetFieldDefn(int) const
+        virtual const OGRGeomFieldDefn* GetGeomFieldDefn(int) const
+
+
 MIGRATION GUIDE FROM GDAL 2.1 to GDAL 2.2
 -----------------------------------------
 

--- a/gdal/ogr/ogr_api.h
+++ b/gdal/ogr/ogr_api.h
@@ -463,7 +463,7 @@ GIntBig CPL_DLL OGR_F_GetFID( OGRFeatureH );
 OGRErr CPL_DLL OGR_F_SetFID( OGRFeatureH, GIntBig );
 void   CPL_DLL OGR_F_DumpReadable( OGRFeatureH, FILE * );
 OGRErr CPL_DLL OGR_F_SetFrom( OGRFeatureH, OGRFeatureH, int );
-OGRErr CPL_DLL OGR_F_SetFromWithMap( OGRFeatureH, OGRFeatureH, int , int * );
+OGRErr CPL_DLL OGR_F_SetFromWithMap( OGRFeatureH, OGRFeatureH, int , const int * );
 
 const char CPL_DLL *OGR_F_GetStyleString( OGRFeatureH );
 void   CPL_DLL OGR_F_SetStyleString( OGRFeatureH, const char * );

--- a/gdal/ogr/ogr_feature.h
+++ b/gdal/ogr/ogr_feature.h
@@ -79,11 +79,11 @@ class CPL_DLL OGRFieldDefn
 
   public:
                         OGRFieldDefn( const char *, OGRFieldType );
-               explicit OGRFieldDefn( OGRFieldDefn * );
+               explicit OGRFieldDefn( const OGRFieldDefn * );
                         ~OGRFieldDefn();
 
     void                SetName( const char * );
-    const char         *GetNameRef() { return pszName; }
+    const char         *GetNameRef() const { return pszName; }
 
     OGRFieldType        GetType() const { return eType; }
     void                SetType( OGRFieldType eTypeIn );
@@ -147,10 +147,10 @@ protected:
 //! @cond Doxygen_Suppress
         char                *pszName;
         OGRwkbGeometryType   eGeomType; /* all values possible except wkbNone */
-        OGRSpatialReference* poSRS;
+        mutable OGRSpatialReference* poSRS;
 
         int                 bIgnore;
-        int                 bNullable;
+        mutable int         bNullable;
 
         void                Initialize( const char *, OGRwkbGeometryType );
 //! @endcond
@@ -158,16 +158,16 @@ protected:
 public:
                             OGRGeomFieldDefn( const char *pszNameIn,
                                               OGRwkbGeometryType eGeomTypeIn );
-                  explicit OGRGeomFieldDefn( OGRGeomFieldDefn * );
+                  explicit OGRGeomFieldDefn( const OGRGeomFieldDefn * );
         virtual            ~OGRGeomFieldDefn();
 
         void                SetName( const char * );
-        const char         *GetNameRef() { return pszName; }
+        const char         *GetNameRef() const { return pszName; }
 
         OGRwkbGeometryType  GetType() const { return eGeomType; }
         void                SetType( OGRwkbGeometryType eTypeIn );
 
-        virtual OGRSpatialReference* GetSpatialRef();
+        virtual OGRSpatialReference* GetSpatialRef() const;
         void                 SetSpatialRef( OGRSpatialReference* poSRSIn );
 
         int                 IsIgnored() const { return bIgnore; }
@@ -177,7 +177,7 @@ public:
         void                SetNullable( int bNullableIn )
             { bNullable = bNullableIn; }
 
-        int                 IsSame( OGRGeomFieldDefn * );
+        int                 IsSame( const OGRGeomFieldDefn * ) const;
 
   private:
     CPL_DISALLOW_COPY_ASSIGN(OGRGeomFieldDefn)
@@ -213,11 +213,11 @@ class CPL_DLL OGRFeatureDefn
 //! @cond Doxygen_Suppress
     volatile int nRefCount;
 
-    int         nFieldCount;
-    OGRFieldDefn **papoFieldDefn;
+    mutable int         nFieldCount;
+    mutable OGRFieldDefn **papoFieldDefn;
 
-    int                nGeomFieldCount;
-    OGRGeomFieldDefn **papoGeomFieldDefn;
+    mutable int                nGeomFieldCount;
+    mutable OGRGeomFieldDefn **papoGeomFieldDefn;
 
     char        *pszFeatureClassName;
 
@@ -229,48 +229,50 @@ class CPL_DLL OGRFeatureDefn
     virtual    ~OGRFeatureDefn();
 
     void                 SetName( const char* pszName );
-    virtual const char  *GetName();
+    virtual const char  *GetName() const;
 
-    virtual int         GetFieldCount();
+    virtual int         GetFieldCount() const;
     virtual OGRFieldDefn *GetFieldDefn( int i );
-    virtual int         GetFieldIndex( const char * );
+    virtual const OGRFieldDefn *GetFieldDefn( int i ) const;
+    virtual int         GetFieldIndex( const char * ) const;
 
     virtual void        AddFieldDefn( OGRFieldDefn * );
     virtual OGRErr      DeleteFieldDefn( int iField );
     virtual OGRErr      ReorderFieldDefns( int* panMap );
 
-    virtual int         GetGeomFieldCount();
+    virtual int         GetGeomFieldCount() const;
     virtual OGRGeomFieldDefn *GetGeomFieldDefn( int i );
-    virtual int         GetGeomFieldIndex( const char * );
+    virtual const OGRGeomFieldDefn *GetGeomFieldDefn( int i ) const;
+    virtual int         GetGeomFieldIndex( const char * ) const;
 
     virtual void        AddGeomFieldDefn( OGRGeomFieldDefn *,
                                           int bCopy = TRUE );
     virtual OGRErr      DeleteGeomFieldDefn( int iGeomField );
 
-    virtual OGRwkbGeometryType GetGeomType();
+    virtual OGRwkbGeometryType GetGeomType() const;
     virtual void        SetGeomType( OGRwkbGeometryType );
 
-    virtual OGRFeatureDefn *Clone();
+    virtual OGRFeatureDefn *Clone() const;
 
     int         Reference() { return CPLAtomicInc(&nRefCount); }
     int         Dereference() { return CPLAtomicDec(&nRefCount); }
-    int         GetReferenceCount() { return nRefCount; }
+    int         GetReferenceCount() const { return nRefCount; }
     void        Release();
 
-    virtual int         IsGeometryIgnored();
+    virtual int         IsGeometryIgnored() const;
     virtual void        SetGeometryIgnored( int bIgnore );
     virtual int         IsStyleIgnored() const { return bIgnoreStyle; }
     virtual void        SetStyleIgnored( int bIgnore )
         { bIgnoreStyle = bIgnore; }
 
-    virtual int         IsSame( OGRFeatureDefn * poOtherFeatureDefn );
+    virtual int         IsSame( const OGRFeatureDefn * poOtherFeatureDefn ) const;
 
 //! @cond Doxygen_Suppress
     void ReserveSpaceForFields(int nFieldCountIn);
 //! @endcond
 
-    std::vector<int>    ComputeMapForSetFrom( OGRFeatureDefn* poSrcFDefn,
-                                              bool bForgiving = true );
+    std::vector<int>    ComputeMapForSetFrom( const OGRFeatureDefn* poSrcFDefn,
+                                              bool bForgiving = true ) const;
 
     static OGRFeatureDefn  *CreateFeatureDefn( const char *pszName = nullptr );
     static void         DestroyFeatureDefn( OGRFeatureDefn * );
@@ -302,103 +304,112 @@ class CPL_DLL OGRFeature
 
   protected:
 //! @cond Doxygen_Suppress
-    char                *m_pszStyleString;
-    OGRStyleTable       *m_poStyleTable;
-    char                *m_pszTmpFieldValue;
+    mutable char        *m_pszStyleString;
+    mutable OGRStyleTable *m_poStyleTable;
+    mutable char        *m_pszTmpFieldValue;
 //! @endcond
 
-    bool                CopySelfTo( OGRFeature *poNew );
+    bool                CopySelfTo( OGRFeature *poNew ) const;
 
   public:
     explicit            OGRFeature( OGRFeatureDefn * );
     virtual            ~OGRFeature();
 
     OGRFeatureDefn     *GetDefnRef() { return poDefn; }
+    const OGRFeatureDefn     *GetDefnRef() const { return poDefn; }
 
     OGRErr              SetGeometryDirectly( OGRGeometry * );
     OGRErr              SetGeometry( const OGRGeometry * );
     OGRGeometry        *GetGeometryRef();
+    const OGRGeometry  *GetGeometryRef() const;
     OGRGeometry        *StealGeometry() CPL_WARN_UNUSED_RESULT;
 
     int                 GetGeomFieldCount() const
                                 { return poDefn->GetGeomFieldCount(); }
     OGRGeomFieldDefn   *GetGeomFieldDefnRef( int iField )
                                 { return poDefn->GetGeomFieldDefn(iField); }
-    int                 GetGeomFieldIndex( const char * pszName )
+    const OGRGeomFieldDefn   *GetGeomFieldDefnRef( int iField ) const
+                                { return poDefn->GetGeomFieldDefn(iField); }
+    int                 GetGeomFieldIndex( const char * pszName ) const
                                 { return poDefn->GetGeomFieldIndex(pszName); }
 
     OGRGeometry*        GetGeomFieldRef( int iField );
+    const OGRGeometry*  GetGeomFieldRef( int iField ) const;
     OGRGeometry*        StealGeometry( int iField );
     OGRGeometry*        GetGeomFieldRef( const char* pszFName );
+    const OGRGeometry*  GetGeomFieldRef( const char* pszFName ) const;
     OGRErr              SetGeomFieldDirectly( int iField, OGRGeometry * );
     OGRErr              SetGeomField( int iField, const OGRGeometry * );
 
-    OGRFeature         *Clone() CPL_WARN_UNUSED_RESULT;
-    virtual OGRBoolean  Equal( OGRFeature * poFeature );
+    OGRFeature         *Clone() const CPL_WARN_UNUSED_RESULT;
+    virtual OGRBoolean  Equal( const OGRFeature * poFeature ) const;
 
     int                 GetFieldCount() const
         { return poDefn->GetFieldCount(); }
-    OGRFieldDefn       *GetFieldDefnRef( int iField ) const
+    const OGRFieldDefn *GetFieldDefnRef( int iField ) const
                                       { return poDefn->GetFieldDefn(iField); }
-    int                 GetFieldIndex( const char * pszName )
+    OGRFieldDefn       *GetFieldDefnRef( int iField )
+                                      { return poDefn->GetFieldDefn(iField); }
+    int                 GetFieldIndex( const char * pszName ) const
                                       { return poDefn->GetFieldIndex(pszName); }
 
-    int                 IsFieldSet( int iField );
+    int                 IsFieldSet( int iField ) const;
 
     void                UnsetField( int iField );
 
-    bool                IsFieldNull( int iField );
+    bool                IsFieldNull( int iField ) const;
 
     void                SetFieldNull( int iField );
 
-    bool                IsFieldSetAndNotNull( int iField );
+    bool                IsFieldSetAndNotNull( int iField ) const;
 
     OGRField           *GetRawFieldRef( int i ) { return pauFields + i; }
+    const OGRField     *GetRawFieldRef( int i ) const { return pauFields + i; }
 
-    int                 GetFieldAsInteger( int i );
-    GIntBig             GetFieldAsInteger64( int i );
-    double              GetFieldAsDouble( int i );
-    const char         *GetFieldAsString( int i );
-    const int          *GetFieldAsIntegerList( int i, int *pnCount );
-    const GIntBig      *GetFieldAsInteger64List( int i, int *pnCount );
-    const double       *GetFieldAsDoubleList( int i, int *pnCount );
-    char              **GetFieldAsStringList( int i );
-    GByte              *GetFieldAsBinary( int i, int *pnCount );
+    int                 GetFieldAsInteger( int i ) const;
+    GIntBig             GetFieldAsInteger64( int i ) const;
+    double              GetFieldAsDouble( int i ) const;
+    const char         *GetFieldAsString( int i ) const;
+    const int          *GetFieldAsIntegerList( int i, int *pnCount ) const;
+    const GIntBig      *GetFieldAsInteger64List( int i, int *pnCount ) const;
+    const double       *GetFieldAsDoubleList( int i, int *pnCount ) const;
+    char              **GetFieldAsStringList( int i ) const;
+    GByte              *GetFieldAsBinary( int i, int *pnCount ) const;
     int                 GetFieldAsDateTime( int i,
                                             int *pnYear, int *pnMonth,
                                             int *pnDay,
                                             int *pnHour, int *pnMinute,
                                             int *pnSecond,
-                                            int *pnTZFlag );
+                                            int *pnTZFlag ) const;
     int                 GetFieldAsDateTime( int i,
                                             int *pnYear, int *pnMonth,
                                             int *pnDay,
                                             int *pnHour, int *pnMinute,
                                             float *pfSecond,
-                                            int *pnTZFlag );
-    char               *GetFieldAsSerializedJSon( int i );
+                                            int *pnTZFlag ) const;
+    char               *GetFieldAsSerializedJSon( int i ) const;
 
-    int                 GetFieldAsInteger( const char *pszFName )
+    int                 GetFieldAsInteger( const char *pszFName )  const
                       { return GetFieldAsInteger( GetFieldIndex(pszFName) ); }
-    GIntBig             GetFieldAsInteger64( const char *pszFName )
+    GIntBig             GetFieldAsInteger64( const char *pszFName )  const
                       { return GetFieldAsInteger64( GetFieldIndex(pszFName) ); }
-    double              GetFieldAsDouble( const char *pszFName )
+    double              GetFieldAsDouble( const char *pszFName )  const
                       { return GetFieldAsDouble( GetFieldIndex(pszFName) ); }
-    const char         *GetFieldAsString( const char *pszFName )
+    const char         *GetFieldAsString( const char *pszFName )  const
                       { return GetFieldAsString( GetFieldIndex(pszFName) ); }
     const int          *GetFieldAsIntegerList( const char *pszFName,
-                                               int *pnCount )
+                                               int *pnCount )  const
                       { return GetFieldAsIntegerList( GetFieldIndex(pszFName),
                                                       pnCount ); }
     const GIntBig      *GetFieldAsInteger64List( const char *pszFName,
-                                               int *pnCount )
+                                               int *pnCount )  const
                       { return GetFieldAsInteger64List( GetFieldIndex(pszFName),
                                                       pnCount ); }
     const double       *GetFieldAsDoubleList( const char *pszFName,
-                                              int *pnCount )
+                                              int *pnCount )  const
                       { return GetFieldAsDoubleList( GetFieldIndex(pszFName),
                                                      pnCount ); }
-    char              **GetFieldAsStringList( const char *pszFName )
+    char              **GetFieldAsStringList( const char *pszFName )  const
                       { return GetFieldAsStringList(GetFieldIndex(pszFName)); }
 
     void                SetField( int i, int nValue );
@@ -448,33 +459,33 @@ class CPL_DLL OGRFeature
     GIntBig             GetFID() const { return nFID; }
     virtual OGRErr      SetFID( GIntBig nFIDIn );
 
-    void                DumpReadable( FILE *, char** papszOptions = nullptr );
+    void                DumpReadable( FILE *, char** papszOptions = nullptr ) const;
 
-    OGRErr              SetFrom( OGRFeature *, int = TRUE );
-    OGRErr              SetFrom( OGRFeature *, int *, int = TRUE );
-    OGRErr              SetFieldsFrom( OGRFeature *, int *, int = TRUE );
+    OGRErr              SetFrom( const OGRFeature *, int = TRUE );
+    OGRErr              SetFrom( const OGRFeature *, const int *, int = TRUE );
+    OGRErr              SetFieldsFrom( const OGRFeature *, const int *, int = TRUE );
 
 //! @cond Doxygen_Suppress
     OGRErr              RemapFields( OGRFeatureDefn *poNewDefn,
-                                     int *panRemapSource );
+                                     const int *panRemapSource );
     void                AppendField();
     OGRErr              RemapGeomFields( OGRFeatureDefn *poNewDefn,
-                                     int *panRemapSource );
+                                         const int *panRemapSource );
 //! @endcond
 
     int                 Validate( int nValidateFlags,
-                                  int bEmitError );
+                                  int bEmitError ) const;
     void                FillUnsetWithDefault( int bNotNullableOnly,
                                               char** papszOptions );
 
-    virtual const char *GetStyleString();
+    virtual const char *GetStyleString() const;
     virtual void        SetStyleString( const char * );
     virtual void        SetStyleStringDirectly( char * );
 
     /** Return style table.
      * @return style table.
      */
-    virtual OGRStyleTable *GetStyleTable() { return m_poStyleTable; }
+    virtual OGRStyleTable *GetStyleTable() const { return m_poStyleTable; } /* f.i.x.m.e: add a const qualifier for return type */
     virtual void        SetStyleTable( OGRStyleTable *poStyleTable );
     virtual void        SetStyleTableDirectly( OGRStyleTable *poStyleTable );
 

--- a/gdal/ogr/ogrfeature.cpp
+++ b/gdal/ogr/ogrfeature.cpp
@@ -299,6 +299,17 @@ void OGRFeature::DestroyFeature( OGRFeature *poFeature )
  * @return a reference to the feature definition object.
  */
 
+/**
+ * \fn const OGRFeatureDefn *OGRFeature::GetDefnRef() const;
+ *
+ * \brief Fetch feature definition.
+ *
+ * This method is the same as the C function OGR_F_GetDefnRef().
+ *
+ * @return a reference to the feature definition object.
+ * @since GDAL 2.3
+ */
+
 /************************************************************************/
 /*                          OGR_F_GetDefnRef()                          */
 /************************************************************************/
@@ -578,6 +589,27 @@ OGRGeometry *OGRFeature::GetGeometryRef()
     return nullptr;
 }
 
+/**
+ * \fn const OGRGeometry *OGRFeature::GetGeometryRef() const;
+ *
+ * \brief Fetch pointer to feature geometry.
+ *
+ * This method is essentially the same as the C function OGR_F_GetGeometryRef().
+ * (the only difference is that the C function honours OGRGetNonLinearGeometriesEnabledFlag())
+ *
+ * @return pointer to internal feature geometry.  This object should
+ * not be modified.
+ * @since GDAL 2.3
+ */
+const OGRGeometry *OGRFeature::GetGeometryRef() const
+
+{
+    if( GetGeomFieldCount() > 0 )
+        return GetGeomFieldRef(0);
+
+    return nullptr;
+}
+
 /************************************************************************/
 /*                        OGR_F_GetGeometryRef()                        */
 /************************************************************************/
@@ -640,6 +672,26 @@ OGRGeometry *OGRFeature::GetGeomFieldRef( int iField )
         return papoGeometries[iField];
 }
 
+/**
+ * \brief Fetch pointer to feature geometry.
+ *
+ * This method is the same as the C function OGR_F_GetGeomFieldRef().
+ *
+ * @param iField geometry field to get.
+ *
+ * @return pointer to internal feature geometry.  This object should
+ * not be modified.
+ * @since GDAL 2.3
+ */
+const OGRGeometry *OGRFeature::GetGeomFieldRef( int iField ) const
+
+{
+    if( iField < 0 || iField >= GetGeomFieldCount() )
+        return nullptr;
+    else
+        return papoGeometries[iField];
+}
+
 /************************************************************************/
 /*                           GetGeomFieldRef()                          */
 /************************************************************************/
@@ -655,6 +707,25 @@ OGRGeometry *OGRFeature::GetGeomFieldRef( int iField )
  * @since GDAL 1.11
  */
 OGRGeometry *OGRFeature::GetGeomFieldRef( const char* pszFName )
+
+{
+    const int iField = GetGeomFieldIndex(pszFName);
+    if( iField < 0 )
+        return nullptr;
+
+    return papoGeometries[iField];
+}
+
+/**
+ * \brief Fetch pointer to feature geometry.
+ *
+ * @param pszFName name of geometry field to get.
+ *
+ * @return pointer to internal feature geometry.  This object should
+ * not be modified.
+ * @since GDAL 2.3
+ */
+const OGRGeometry *OGRFeature::GetGeomFieldRef( const char* pszFName ) const
 
 {
     const int iField = GetGeomFieldIndex(pszFName);
@@ -874,7 +945,7 @@ OGRErr OGR_F_SetGeomField( OGRFeatureH hFeat, int iField, OGRGeometryH hGeom )
  * 2.1, NULL in case of out of memory situation.
  */
 
-OGRFeature *OGRFeature::Clone()
+OGRFeature *OGRFeature::Clone() const
 
 {
     OGRFeature *poNew = CreateFeature( poDefn );
@@ -929,7 +1000,7 @@ OGRFeatureH OGR_F_Clone( OGRFeatureH hFeat )
 * @return True if successful, false if the copy failed.
 */
 
-bool OGRFeature::CopySelfTo( OGRFeature* poNew )
+bool OGRFeature::CopySelfTo( OGRFeature* poNew ) const
 {
     for( int i = 0; i < poDefn->GetFieldCount(); i++ )
     {
@@ -1029,7 +1100,7 @@ int OGR_F_GetFieldCount( OGRFeatureH hFeat )
 /************************************************************************/
 
 /**
- * \fn OGRFieldDefn *OGRFeature::GetFieldDefnRef( int iField ) const;
+ * \fn OGRFieldDefn *OGRFeature::GetFieldDefnRef( int iField );
  *
  * \brief Fetch definition for this field.
  *
@@ -1039,6 +1110,20 @@ int OGR_F_GetFieldCount( OGRFeatureH hFeat )
  *
  * @return the field definition (from the OGRFeatureDefn).  This is an
  * internal reference, and should not be deleted or modified.
+ */
+
+/**
+ * \fn const OGRFieldDefn *OGRFeature::GetFieldDefnRef( int iField ) const;
+ *
+ * \brief Fetch definition for this field.
+ *
+ * This method is the same as the C function OGR_F_GetFieldDefnRef().
+ *
+ * @param iField the field to fetch, from 0 to GetFieldCount()-1.
+ *
+ * @return the field definition (from the OGRFeatureDefn).  This is an
+ * internal reference, and should not be deleted or modified.
+ * @since GDAL 2.3
  */
 
 /************************************************************************/
@@ -1078,7 +1163,7 @@ OGRFieldDefnH OGR_F_GetFieldDefnRef( OGRFeatureH hFeat, int i )
 /************************************************************************/
 
 /**
- * \fn int OGRFeature::GetFieldIndex( const char * pszName );
+ * \fn int OGRFeature::GetFieldIndex( const char * pszName ) const;
  *
  * \brief Fetch the field index given field name.
  *
@@ -1178,6 +1263,21 @@ int OGR_F_GetGeomFieldCount( OGRFeatureH hFeat )
  * @since GDAL 1.11
  */
 
+/**
+ * \fn const OGRGeomFieldDefn *OGRFeature::GetGeomFieldDefnRef( int iGeomField ) const;
+ *
+ * \brief Fetch definition for this geometry field.
+ *
+ * This method is the same as the C function OGR_F_GetGeomFieldDefnRef().
+ *
+ * @param iGeomField the field to fetch, from 0 to GetGeomFieldCount()-1.
+ *
+ * @return the field definition (from the OGRFeatureDefn).  This is an
+ * internal reference, and should not be deleted or modified.
+ *
+* @since GDAL 2.3
+ */
+
 /************************************************************************/
 /*                       OGR_F_GetGeomFieldDefnRef()                    */
 /************************************************************************/
@@ -1202,8 +1302,9 @@ OGRGeomFieldDefnH OGR_F_GetGeomFieldDefnRef( OGRFeatureH hFeat, int i )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetGeomFieldDefnRef", nullptr );
 
-    return reinterpret_cast<OGRGeomFieldDefnH>(
-        reinterpret_cast<OGRFeature *>(hFeat)->GetGeomFieldDefnRef(i));
+    return reinterpret_cast<OGRGeomFieldDefnH>(const_cast<OGRGeomFieldDefn*>(
+      const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->GetGeomFieldDefnRef(i)));
 }
 
 /************************************************************************/
@@ -1252,7 +1353,8 @@ int OGR_F_GetGeomFieldIndex( OGRFeatureH hFeat, const char *pszName )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetGeomFieldIndex", 0 );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->GetGeomFieldIndex( pszName );
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->GetGeomFieldIndex( pszName );
 }
 
 /************************************************************************/
@@ -1269,7 +1371,7 @@ int OGR_F_GetGeomFieldIndex( OGRFeatureH hFeat, const char *pszName )
  * @return TRUE if the field has been set, otherwise false.
  */
 
-int OGRFeature::IsFieldSet( int iField )
+int OGRFeature::IsFieldSet( int iField ) const
 
 {
     const int iSpecialField = iField - poDefn->GetFieldCount();
@@ -1325,7 +1427,8 @@ int OGR_F_IsFieldSet( OGRFeatureH hFeat, int iField )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_IsFieldSet", 0 );
 
-    OGRFeature* poFeature = reinterpret_cast<OGRFeature *>(hFeat);
+    const OGRFeature* poFeature =
+        const_cast<const OGRFeature*>(reinterpret_cast<OGRFeature *>(hFeat));
 
     if( iField < 0 || iField >= poFeature->GetFieldCount() )
     {
@@ -1424,7 +1527,7 @@ void OGR_F_UnsetField( OGRFeatureH hFeat, int iField )
  * @since GDAL 2.2
  */
 
-bool OGRFeature::IsFieldNull( int iField )
+bool OGRFeature::IsFieldNull( int iField ) const
 
 {
     const int iSpecialField = iField - poDefn->GetFieldCount();
@@ -1461,7 +1564,8 @@ int OGR_F_IsFieldNull( OGRFeatureH hFeat, int iField )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_IsFieldNull", 0 );
 
-    OGRFeature* poFeature = reinterpret_cast<OGRFeature *>(hFeat);
+    const OGRFeature* poFeature = const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat));
 
     if( iField < 0 || iField >= poFeature->GetFieldCount() )
     {
@@ -1488,7 +1592,7 @@ int OGR_F_IsFieldNull( OGRFeatureH hFeat, int iField )
  * @since GDAL 2.2
  */
 
-bool OGRFeature::IsFieldSetAndNotNull( int iField )
+bool OGRFeature::IsFieldSetAndNotNull( int iField ) const
 
 {
     const int iSpecialField = iField - poDefn->GetFieldCount();
@@ -1628,6 +1732,20 @@ void OGR_F_SetFieldNull( OGRFeatureH hFeat, int iField )
  * not be freed, or modified.
  */
 
+/**
+ * \fn const OGRField *OGRFeature::GetRawFieldRef( int iField ) const;
+ *
+ * \brief Fetch a pointer to the internal field value given the index.
+ *
+ * This method is the same as the C function OGR_F_GetRawFieldRef().
+ *
+ * @param iField the field to fetch, from 0 to GetFieldCount()-1.
+ *
+ * @return the returned pointer is to an internal data structure, and should
+ * not be freed, or modified.
+ * @since GDAL 2.3
+ */
+
 /************************************************************************/
 /*                        OGR_F_GetRawFieldRef()                        */
 /************************************************************************/
@@ -1657,7 +1775,7 @@ OGRField *OGR_F_GetRawFieldRef( OGRFeatureH hFeat, int iField )
 /************************************************************************/
 
 /**
- * \fn OGRFeature::GetFieldAsInteger( const char* pszFName )
+ * \fn OGRFeature::GetFieldAsInteger( const char* pszFName ) const
  * \brief Fetch field value as integer.
  *
  * OFTString features will be translated using atoi().  OFTReal fields
@@ -1685,7 +1803,7 @@ OGRField *OGR_F_GetRawFieldRef( OGRFeatureH hFeat, int iField )
  * @return the field value.
  */
 
-int OGRFeature::GetFieldAsInteger( int iField )
+int OGRFeature::GetFieldAsInteger( int iField ) const
 
 {
     int iSpecialField = iField - poDefn->GetFieldCount();
@@ -1787,7 +1905,8 @@ int OGR_F_GetFieldAsInteger( OGRFeatureH hFeat, int iField )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsInteger", 0 );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->GetFieldAsInteger(iField);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->GetFieldAsInteger(iField);
 }
 
 /************************************************************************/
@@ -1795,7 +1914,7 @@ int OGR_F_GetFieldAsInteger( OGRFeatureH hFeat, int iField )
 /************************************************************************/
 
 /**
- * \fn OGRFeature::GetFieldAsInteger64( const char* pszFName )
+ * \fn OGRFeature::GetFieldAsInteger64( const char* pszFName ) const
  * \brief Fetch field value as integer 64 bit.
  *
  * OFTInteger are promoted to 64 bit.
@@ -1824,7 +1943,7 @@ int OGR_F_GetFieldAsInteger( OGRFeatureH hFeat, int iField )
  * @since GDAL 2.0
  */
 
-GIntBig OGRFeature::GetFieldAsInteger64( int iField )
+GIntBig OGRFeature::GetFieldAsInteger64( int iField ) const
 
 {
     const int iSpecialField = iField - poDefn->GetFieldCount();
@@ -1908,7 +2027,8 @@ GIntBig OGR_F_GetFieldAsInteger64( OGRFeatureH hFeat, int iField )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsInteger64", 0 );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->GetFieldAsInteger64(iField);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->GetFieldAsInteger64(iField);
 }
 
 /************************************************************************/
@@ -1916,7 +2036,7 @@ GIntBig OGR_F_GetFieldAsInteger64( OGRFeatureH hFeat, int iField )
 /************************************************************************/
 
 /**
- * \fn OGRFeature::GetFieldAsDouble( const char* pszFName )
+ * \fn OGRFeature::GetFieldAsDouble( const char* pszFName ) const
  * \brief Fetch field value as a double.
  *
  * OFTString features will be translated using CPLAtof().  OFTInteger and
@@ -1942,7 +2062,7 @@ GIntBig OGR_F_GetFieldAsInteger64( OGRFeatureH hFeat, int iField )
  * @return the field value.
  */
 
-double OGRFeature::GetFieldAsDouble( int iField )
+double OGRFeature::GetFieldAsDouble( int iField ) const
 
 {
     const int iSpecialField = iField - poDefn->GetFieldCount();
@@ -2021,7 +2141,8 @@ double OGR_F_GetFieldAsDouble( OGRFeatureH hFeat, int iField )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsDouble", 0 );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->GetFieldAsDouble(iField);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->GetFieldAsDouble(iField);
 }
 
 /************************************************************************/
@@ -2095,7 +2216,7 @@ static void OGRFeatureFormatDateTimeBuffer( char szTempBuffer[TEMP_BUFFER_SIZE],
 /************************************************************************/
 
 /**
- * \fn OGRFeature::GetFieldAsString( const char* pszFName )
+ * \fn OGRFeature::GetFieldAsString( const char* pszFName ) const
  * \brief Fetch field value as a string.
  *
  * OFTReal and OFTInteger fields will be translated to string using
@@ -2123,7 +2244,7 @@ static void OGRFeatureFormatDateTimeBuffer( char szTempBuffer[TEMP_BUFFER_SIZE],
  * modified, or freed.  Its lifetime may be very brief.
  */
 
-const char *OGRFeature::GetFieldAsString( int iField )
+const char *OGRFeature::GetFieldAsString( int iField ) const
 
 {
     char szTempBuffer[TEMP_BUFFER_SIZE] = {};
@@ -2481,7 +2602,8 @@ const char *OGR_F_GetFieldAsString( OGRFeatureH hFeat, int iField )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsString", nullptr );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->GetFieldAsString(iField);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->GetFieldAsString(iField);
 }
 
 /************************************************************************/
@@ -2489,7 +2611,7 @@ const char *OGR_F_GetFieldAsString( OGRFeatureH hFeat, int iField )
 /************************************************************************/
 
 /**
- * \fn OGRFeature::GetFieldAsIntegerList( const char* pszFName, int *pnCount )
+ * \fn OGRFeature::GetFieldAsIntegerList( const char* pszFName, int *pnCount ) const
  * \brief Fetch field value as a list of integers.
  *
  * Currently this method only works for OFTIntegerList fields.
@@ -2520,7 +2642,7 @@ const char *OGR_F_GetFieldAsString( OGRFeatureH hFeat, int iField )
  * on return the returned pointer may be NULL or non-NULL.
  */
 
-const int *OGRFeature::GetFieldAsIntegerList( int iField, int *pnCount )
+const int *OGRFeature::GetFieldAsIntegerList( int iField, int *pnCount ) const
 
 {
     OGRFieldDefn *poFDefn = poDefn->GetFieldDefn( iField );
@@ -2567,15 +2689,16 @@ const int *OGR_F_GetFieldAsIntegerList( OGRFeatureH hFeat, int iField,
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsIntegerList", nullptr );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->
-        GetFieldAsIntegerList(iField, pnCount);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->
+            GetFieldAsIntegerList(iField, pnCount);
 }
 
 /************************************************************************/
 /*                      GetFieldAsInteger64List()                       */
 /************************************************************************/
 /**
- * \fn OGRFeature::GetFieldAsInteger64List( const char* pszFName, int *pnCount )
+ * \fn OGRFeature::GetFieldAsInteger64List( const char* pszFName, int *pnCount ) const
  * \brief Fetch field value as a list of 64 bit integers.
  *
  * Currently this method only works for OFTInteger64List fields.
@@ -2605,7 +2728,7 @@ const int *OGR_F_GetFieldAsIntegerList( OGRFeatureH hFeat, int iField,
  * @since GDAL 2.0
  */
 
-const GIntBig *OGRFeature::GetFieldAsInteger64List( int iField, int *pnCount )
+const GIntBig *OGRFeature::GetFieldAsInteger64List( int iField, int *pnCount ) const
 
 {
     OGRFieldDefn *poFDefn = poDefn->GetFieldDefn( iField );
@@ -2653,15 +2776,16 @@ const GIntBig *OGR_F_GetFieldAsInteger64List( OGRFeatureH hFeat, int iField,
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsInteger64List", nullptr );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->
-        GetFieldAsInteger64List(iField, pnCount);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->
+            GetFieldAsInteger64List(iField, pnCount);
 }
 
 /************************************************************************/
 /*                        GetFieldAsDoubleList()                        */
 /************************************************************************/
 /**
- * \fn OGRFeature::GetFieldAsDoubleList( const char* pszFName, int *pnCount )
+ * \fn OGRFeature::GetFieldAsDoubleList( const char* pszFName, int *pnCount ) const
  * \brief Fetch field value as a list of doubles.
  *
  * Currently this method only works for OFTRealList fields.
@@ -2689,7 +2813,7 @@ const GIntBig *OGR_F_GetFieldAsInteger64List( OGRFeatureH hFeat, int iField,
  * on return the returned pointer may be NULL or non-NULL.
  */
 
-const double *OGRFeature::GetFieldAsDoubleList( int iField, int *pnCount )
+const double *OGRFeature::GetFieldAsDoubleList( int iField, int *pnCount ) const
 
 {
     OGRFieldDefn *poFDefn = poDefn->GetFieldDefn( iField );
@@ -2736,15 +2860,16 @@ const double *OGR_F_GetFieldAsDoubleList( OGRFeatureH hFeat, int iField,
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsDoubleList", nullptr );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->
-        GetFieldAsDoubleList(iField, pnCount);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->
+            GetFieldAsDoubleList(iField, pnCount);
 }
 
 /************************************************************************/
 /*                        GetFieldAsStringList()                        */
 /************************************************************************/
 /**
- * \fn OGRFeature::GetFieldAsStringList( const char* pszFName )
+ * \fn OGRFeature::GetFieldAsStringList( const char* pszFName ) const
  * \brief Fetch field value as a list of strings.
  *
  * Currently this method only works for OFTStringList fields.
@@ -2774,7 +2899,7 @@ const double *OGR_F_GetFieldAsDoubleList( OGRFeatureH hFeat, int iField,
  * modified, or freed.  Its lifetime may be very brief.
  */
 
-char **OGRFeature::GetFieldAsStringList( int iField )
+char **OGRFeature::GetFieldAsStringList( int iField ) const
 
 {
     OGRFieldDefn *poFDefn = poDefn->GetFieldDefn( iField );
@@ -2820,7 +2945,8 @@ char **OGR_F_GetFieldAsStringList( OGRFeatureH hFeat, int iField )
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsStringList", nullptr );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->GetFieldAsStringList(iField);
+    return const_cast<const OGRFeature*>(
+        reinterpret_cast<OGRFeature *>(hFeat))->GetFieldAsStringList(iField);
 }
 
 /************************************************************************/
@@ -2841,7 +2967,7 @@ char **OGR_F_GetFieldAsStringList( OGRFeatureH hFeat, int iField )
  * modified, or freed.  Its lifetime may be very brief.
  */
 
-GByte *OGRFeature::GetFieldAsBinary( int iField, int *pnBytes )
+GByte *OGRFeature::GetFieldAsBinary( int iField, int *pnBytes ) const
 
 {
     OGRFieldDefn *poFDefn = poDefn->GetFieldDefn( iField );
@@ -2894,8 +3020,9 @@ GByte *OGR_F_GetFieldAsBinary( OGRFeatureH hFeat, int iField, int *pnBytes )
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsBinary", nullptr );
     VALIDATE_POINTER1( pnBytes, "OGR_F_GetFieldAsBinary", nullptr );
 
-    return reinterpret_cast<OGRFeature *>(hFeat)->
-        GetFieldAsBinary(iField, pnBytes);
+    return const_cast<const OGRFeature*>(
+            reinterpret_cast<OGRFeature *>(hFeat))->
+                GetFieldAsBinary(iField, pnBytes);
 }
 
 /************************************************************************/
@@ -2924,7 +3051,7 @@ GByte *OGR_F_GetFieldAsBinary( OGRFeatureH hFeat, int iField, int *pnBytes )
 int OGRFeature::GetFieldAsDateTime( int iField,
                                     int *pnYear, int *pnMonth, int *pnDay,
                                     int *pnHour, int *pnMinute, float *pfSecond,
-                                    int *pnTZFlag )
+                                    int *pnTZFlag ) const
 
 {
     OGRFieldDefn *poFDefn = poDefn->GetFieldDefn( iField );
@@ -2982,7 +3109,7 @@ int OGRFeature::GetFieldAsDateTime( int iField,
 int OGRFeature::GetFieldAsDateTime( int iField,
                                     int *pnYear, int *pnMonth, int *pnDay,
                                     int *pnHour, int *pnMinute, int *pnSecond,
-                                    int *pnTZFlag )
+                                    int *pnTZFlag ) const
 {
     float fSecond = 0.0f;
     const bool bRet = CPL_TO_BOOL(
@@ -3028,7 +3155,8 @@ int OGR_F_GetFieldAsDateTime( OGRFeatureH hFeat, int iField,
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsDateTime", 0 );
 
     float fSecond = 0.0f;
-    const bool bRet = CPL_TO_BOOL(reinterpret_cast<OGRFeature *>(hFeat)->
+    const bool bRet = CPL_TO_BOOL(const_cast<const OGRFeature*>(
+            reinterpret_cast<OGRFeature *>(hFeat))->
         GetFieldAsDateTime( iField,
                             pnYear, pnMonth, pnDay,
                             pnHour, pnMinute, &fSecond,
@@ -3072,7 +3200,7 @@ int OGR_F_GetFieldAsDateTimeEx( OGRFeatureH hFeat, int iField,
     VALIDATE_POINTER1( hFeat, "OGR_F_GetFieldAsDateTimeEx", 0 );
 
     return
-        reinterpret_cast<OGRFeature *>(hFeat)->
+        const_cast<const OGRFeature*>(reinterpret_cast<OGRFeature *>(hFeat))->
             GetFieldAsDateTime(iField,
                                pnYear, pnMonth, pnDay,
                                pnHour, pnMinute, pfSecond,
@@ -3127,7 +3255,7 @@ static int OGRFeatureGetIntegerValue( OGRFieldDefn *poFDefn, int nValue )
  * @return a string that must be de-allocate with CPLFree()
  * @since GDAL 2.2
  */
-char* OGRFeature::GetFieldAsSerializedJSon( int iField )
+char* OGRFeature::GetFieldAsSerializedJSon( int iField ) const
 
 {
     const int iSpecialField = iField - poDefn->GetFieldCount();
@@ -5099,7 +5227,7 @@ void OGR_F_SetFieldRaw( OGRFeatureH hFeat, int iField, OGRField *psValue )
  * @param papszOptions NULL terminated list of options (may be NULL)
  */
 
-void OGRFeature::DumpReadable( FILE * fpOut, char** papszOptions )
+void OGRFeature::DumpReadable( FILE * fpOut, char** papszOptions ) const
 
 {
     if( fpOut == nullptr )
@@ -5311,7 +5439,7 @@ OGRErr OGR_F_SetFID( OGRFeatureH hFeat, GIntBig nFID )
  * @return TRUE if they are equal, otherwise FALSE.
  */
 
-OGRBoolean OGRFeature::Equal( OGRFeature * poFeature )
+OGRBoolean OGRFeature::Equal( const OGRFeature * poFeature ) const
 
 {
     if( poFeature == this )
@@ -5483,8 +5611,8 @@ OGRBoolean OGRFeature::Equal( OGRFeature * poFeature )
     const int nGeomFieldCount = GetGeomFieldCount();
     for( int i = 0; i < nGeomFieldCount; i++ )
     {
-        OGRGeometry* poThisGeom = GetGeomFieldRef(i);
-        OGRGeometry* poOtherGeom = poFeature->GetGeomFieldRef(i);
+        const OGRGeometry* poThisGeom = GetGeomFieldRef(i);
+        const OGRGeometry* poOtherGeom = poFeature->GetGeomFieldRef(i);
 
         if( poThisGeom == nullptr && poOtherGeom != nullptr )
             return FALSE;
@@ -5554,7 +5682,7 @@ int OGR_F_Equal( OGRFeatureH hFeat, OGRFeatureH hOtherFeat )
  * not transferred, otherwise an error code.
  */
 
-OGRErr OGRFeature::SetFrom( OGRFeature * poSrcFeature, int bForgiving )
+OGRErr OGRFeature::SetFrom( const OGRFeature * poSrcFeature, int bForgiving )
 
 {
     const auto& oMap = poDefn->ComputeMapForSetFrom(
@@ -5640,7 +5768,8 @@ OGRErr OGR_F_SetFrom( OGRFeatureH hFeat, OGRFeatureH hOtherFeat,
  * not transferred, otherwise an error code.
  */
 
-OGRErr OGRFeature::SetFrom( OGRFeature * poSrcFeature, int *panMap ,
+OGRErr OGRFeature::SetFrom( const OGRFeature * poSrcFeature,
+                            const int *panMap ,
                             int bForgiving )
 
 {
@@ -5654,7 +5783,7 @@ OGRErr OGRFeature::SetFrom( OGRFeature * poSrcFeature, int *panMap ,
 /* -------------------------------------------------------------------- */
     if( GetGeomFieldCount() == 1 )
     {
-        OGRGeomFieldDefn* poGFieldDefn = GetGeomFieldDefnRef(0);
+        const OGRGeomFieldDefn* poGFieldDefn = GetGeomFieldDefnRef(0);
 
         int iSrc = poSrcFeature->GetGeomFieldIndex(
                                     poGFieldDefn->GetNameRef());
@@ -5669,7 +5798,7 @@ OGRErr OGRFeature::SetFrom( OGRFeature * poSrcFeature, int *panMap ,
     {
         for( int i = 0; i < GetGeomFieldCount(); i++ )
         {
-            OGRGeomFieldDefn* poGFieldDefn = GetGeomFieldDefnRef(i);
+            const OGRGeomFieldDefn* poGFieldDefn = GetGeomFieldDefnRef(i);
 
             const int iSrc =
                 poSrcFeature->GetGeomFieldIndex(poGFieldDefn->GetNameRef());
@@ -5736,7 +5865,7 @@ OGRErr OGRFeature::SetFrom( OGRFeature * poSrcFeature, int *panMap ,
  */
 
 OGRErr OGR_F_SetFromWithMap( OGRFeatureH hFeat, OGRFeatureH hOtherFeat,
-                             int bForgiving, int *panMap )
+                             int bForgiving, const int *panMap )
 
 {
     VALIDATE_POINTER1( hFeat, "OGR_F_SetFrom", OGRERR_FAILURE );
@@ -5779,7 +5908,8 @@ OGRErr OGR_F_SetFromWithMap( OGRFeatureH hFeat, OGRFeatureH hOtherFeat,
  * not transferred, otherwise an error code.
  */
 
-OGRErr OGRFeature::SetFieldsFrom( OGRFeature * poSrcFeature, int *panMap,
+OGRErr OGRFeature::SetFieldsFrom( const OGRFeature * poSrcFeature,
+                                  const int *panMap,
                                   int bForgiving )
 
 {
@@ -5880,7 +6010,8 @@ OGRErr OGRFeature::SetFieldsFrom( OGRFeature * poSrcFeature, int *panMap,
                 eDstFieldType == OFTTime ||
                 eDstFieldType == OFTDateTime )
             {
-                SetField( iDstField, poSrcFeature->GetRawFieldRef( iField ) );
+                SetField( iDstField, const_cast<OGRField*>(
+                    poSrcFeature->GetRawFieldRef( iField )) );
             }
             else if( eDstFieldType == OFTString ||
                      eDstFieldType == OFTStringList )
@@ -5898,7 +6029,8 @@ OGRErr OGRFeature::SetFieldsFrom( OGRFeature * poSrcFeature, int *panMap,
             if( poSrcFeature->GetFieldDefnRef(iField)->GetType()
                 == eDstFieldType )
             {
-                SetField( iDstField, poSrcFeature->GetRawFieldRef(iField) );
+                SetField( iDstField, const_cast<OGRField*>(
+                    poSrcFeature->GetRawFieldRef( iField )) );
             }
             else if( eDstFieldType == OFTString ||
                      eDstFieldType == OFTStringList )
@@ -5931,7 +6063,7 @@ OGRErr OGRFeature::SetFieldsFrom( OGRFeature * poSrcFeature, int *panMap,
  * there isn't one.
  */
 
-const char *OGRFeature::GetStyleString()
+const char *OGRFeature::GetStyleString() const
 {
     if( m_pszStyleString )
         return m_pszStyleString;
@@ -6104,7 +6236,7 @@ void OGRFeature::SetStyleTableDirectly( OGRStyleTable *poStyleTable )
 /************************************************************************/
 
 OGRErr OGRFeature::RemapFields( OGRFeatureDefn *poNewDefn,
-                                int *panRemapSource )
+                                const int *panRemapSource )
 
 {
     if( poNewDefn == nullptr )
@@ -6165,7 +6297,7 @@ void OGRFeature::AppendField()
 /************************************************************************/
 
 OGRErr OGRFeature::RemapGeomFields( OGRFeatureDefn *poNewDefn,
-                                    int *panRemapSource )
+                                    const int *panRemapSource )
 
 {
     if( poNewDefn == nullptr )
@@ -6377,7 +6509,7 @@ void OGR_F_FillUnsetWithDefault( OGRFeatureH hFeat,
  * @since GDAL 2.0
  */
 
-int OGRFeature::Validate( int nValidateFlags, int bEmitError )
+int OGRFeature::Validate( int nValidateFlags, int bEmitError ) const
 
 {
     bool bRet = true;
@@ -6401,7 +6533,7 @@ int OGRFeature::Validate( int nValidateFlags, int bEmitError )
         if( (nValidateFlags & OGR_F_VAL_GEOM_TYPE) &&
             poDefn->GetGeomFieldDefn(i)->GetType() != wkbUnknown )
         {
-            OGRGeometry* poGeom = GetGeomFieldRef(i);
+            const OGRGeometry* poGeom = GetGeomFieldRef(i);
             if( poGeom != nullptr )
             {
                 const OGRwkbGeometryType eType =

--- a/gdal/ogr/ogrfielddefn.cpp
+++ b/gdal/ogr/ogrfielddefn.cpp
@@ -81,7 +81,7 @@ OGRFieldDefn::OGRFieldDefn( const char * pszNameIn, OGRFieldType eTypeIn ) :
  * @param poPrototype the field definition to clone.
  */
 
-OGRFieldDefn::OGRFieldDefn( OGRFieldDefn *poPrototype ) :
+OGRFieldDefn::OGRFieldDefn( const OGRFieldDefn *poPrototype ) :
     pszName(CPLStrdup(poPrototype->GetNameRef())),
     eType(poPrototype->GetType()),
     eJustify(poPrototype->GetJustify()),

--- a/gdal/ogr/ogrgeomfielddefn.cpp
+++ b/gdal/ogr/ogrgeomfielddefn.cpp
@@ -76,7 +76,7 @@ OGRGeomFieldDefn::OGRGeomFieldDefn( const char * pszNameIn,
  * @since GDAL 1.11
  */
 
-OGRGeomFieldDefn::OGRGeomFieldDefn( OGRGeomFieldDefn *poPrototype )
+OGRGeomFieldDefn::OGRGeomFieldDefn( const OGRGeomFieldDefn *poPrototype )
 
 {
     Initialize( poPrototype->GetNameRef(), poPrototype->GetType() );
@@ -432,7 +432,7 @@ void OGR_GFld_SetIgnored( OGRGeomFieldDefnH hDefn, int ignore )
  * @since GDAL 1.11
  */
 
-OGRSpatialReference* OGRGeomFieldDefn::GetSpatialRef()
+OGRSpatialReference* OGRGeomFieldDefn::GetSpatialRef() const
 {
     return poSRS;
 }
@@ -533,7 +533,7 @@ void OGR_GFld_SetSpatialRef( OGRGeomFieldDefnH hDefn,
  * @since GDAL 1.11
  */
 
-int OGRGeomFieldDefn::IsSame( OGRGeomFieldDefn * poOtherFieldDefn )
+int OGRGeomFieldDefn::IsSame( const OGRGeomFieldDefn * poOtherFieldDefn ) const
 {
     if( !(strcmp(GetNameRef(), poOtherFieldDefn->GetNameRef()) == 0 &&
                  GetType() == poOtherFieldDefn->GetType() &&

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab.h
@@ -849,14 +849,15 @@ class ITABFeaturePen
   public:
     ITABFeaturePen();
     ~ITABFeaturePen() {}
-    int         GetPenDefIndex() {return m_nPenDefIndex;}
+    int         GetPenDefIndex() const {return m_nPenDefIndex;}
     TABPenDef  *GetPenDefRef() {return &m_sPenDef;}
+    const TABPenDef  *GetPenDefRef() const {return &m_sPenDef;}
 
-    GByte       GetPenWidthPixel();
-    double      GetPenWidthPoint();
-    int         GetPenWidthMIF();
-    GByte       GetPenPattern() {return m_sPenDef.nLinePattern;}
-    GInt32      GetPenColor()   {return m_sPenDef.rgbColor;}
+    GByte       GetPenWidthPixel() const;
+    double      GetPenWidthPoint() const;
+    int         GetPenWidthMIF() const;
+    GByte       GetPenPattern() const {return m_sPenDef.nLinePattern;}
+    GInt32      GetPenColor() const   {return m_sPenDef.rgbColor;}
 
     void        SetPenWidthPixel(GByte val);
     void        SetPenWidthPoint(double val);
@@ -865,7 +866,7 @@ class ITABFeaturePen
     void        SetPenPattern(GByte val) {m_sPenDef.nLinePattern=val;}
     void        SetPenColor(GInt32 clr)  {m_sPenDef.rgbColor = clr;}
 
-    const char *GetPenStyleString();
+    const char *GetPenStyleString() const;
     void        SetPenFromStyleString(const char *pszStyleString);
 
     void        DumpPenDef(FILE *fpOut = nullptr);
@@ -879,13 +880,14 @@ class ITABFeatureBrush
   public:
     ITABFeatureBrush();
     ~ITABFeatureBrush() {}
-    int         GetBrushDefIndex() {return m_nBrushDefIndex;}
+    int         GetBrushDefIndex() const {return m_nBrushDefIndex;}
     TABBrushDef *GetBrushDefRef() {return &m_sBrushDef;}
+    const TABBrushDef *GetBrushDefRef() const {return &m_sBrushDef;}
 
-    GInt32      GetBrushFGColor()     {return m_sBrushDef.rgbFGColor;}
-    GInt32      GetBrushBGColor()     {return m_sBrushDef.rgbBGColor;}
-    GByte       GetBrushPattern()     {return m_sBrushDef.nFillPattern;}
-    GByte       GetBrushTransparent() {return m_sBrushDef.bTransparentFill;}
+    GInt32      GetBrushFGColor() const     {return m_sBrushDef.rgbFGColor;}
+    GInt32      GetBrushBGColor() const     {return m_sBrushDef.rgbBGColor;}
+    GByte       GetBrushPattern() const     {return m_sBrushDef.nFillPattern;}
+    GByte       GetBrushTransparent() const {return m_sBrushDef.bTransparentFill;}
 
     void        SetBrushFGColor(GInt32 clr)  { m_sBrushDef.rgbFGColor = clr;}
     void        SetBrushBGColor(GInt32 clr)  { m_sBrushDef.rgbBGColor = clr;}
@@ -893,7 +895,7 @@ class ITABFeatureBrush
     void        SetBrushTransparent(GByte val)
                                           {m_sBrushDef.bTransparentFill=val;}
 
-    const char *GetBrushStyleString();
+    const char *GetBrushStyleString() const;
     void        SetBrushFromStyleString(const char *pszStyleString);
 
     void        DumpBrushDef(FILE *fpOut = nullptr);
@@ -907,10 +909,11 @@ class ITABFeatureFont
   public:
     ITABFeatureFont();
     ~ITABFeatureFont() {}
-    int         GetFontDefIndex() {return m_nFontDefIndex;}
+    int         GetFontDefIndex() const {return m_nFontDefIndex;}
     TABFontDef *GetFontDefRef() {return &m_sFontDef;}
+    const TABFontDef *GetFontDefRef() const {return &m_sFontDef;}
 
-    const char *GetFontNameRef() {return m_sFontDef.szFontName;}
+    const char *GetFontNameRef() const {return m_sFontDef.szFontName;}
 
     void        SetFontName(const char *pszName);
 
@@ -925,18 +928,19 @@ class ITABFeatureSymbol
   public:
     ITABFeatureSymbol();
     ~ITABFeatureSymbol() {}
-    int         GetSymbolDefIndex() {return m_nSymbolDefIndex;}
+    int         GetSymbolDefIndex() const {return m_nSymbolDefIndex;}
     TABSymbolDef *GetSymbolDefRef() {return &m_sSymbolDef;}
+    const TABSymbolDef *GetSymbolDefRef() const {return &m_sSymbolDef;}
 
-    GInt16      GetSymbolNo()    {return m_sSymbolDef.nSymbolNo;}
-    GInt16      GetSymbolSize()  {return m_sSymbolDef.nPointSize;}
-    GInt32      GetSymbolColor() {return m_sSymbolDef.rgbColor;}
+    GInt16      GetSymbolNo() const    {return m_sSymbolDef.nSymbolNo;}
+    GInt16      GetSymbolSize() const  {return m_sSymbolDef.nPointSize;}
+    GInt32      GetSymbolColor() const {return m_sSymbolDef.rgbColor;}
 
     void        SetSymbolNo(GInt16 val)     { m_sSymbolDef.nSymbolNo = val;}
     void        SetSymbolSize(GInt16 val)   { m_sSymbolDef.nPointSize = val;}
     void        SetSymbolColor(GInt32 clr)  { m_sSymbolDef.rgbColor = clr;}
 
-    const char *GetSymbolStyleString(double dfAngle = 0.0);
+    const char *GetSymbolStyleString(double dfAngle = 0.0) const;
     void        SetSymbolFromStyleString(const char *pszStyleString);
 
     void        DumpSymbolDef(FILE *fpOut = nullptr);
@@ -1090,7 +1094,7 @@ class TABPoint: public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 };
@@ -1133,7 +1137,7 @@ class TABFontPoint CPL_FINAL : public TABPoint,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     GBool       QueryFontStyle(TABFontStyle eStyleToQuery);
     void        ToggleFontStyle(TABFontStyle eStyleToToggle, GBool bStatus);
@@ -1144,7 +1148,7 @@ class TABFontPoint CPL_FINAL : public TABPoint,
     void        SetFontStyleTABValue(int nStyle){m_nFontStyle=(GInt16)nStyle;}
 
     // GetSymbolAngle(): Return angle in degrees counterclockwise
-    double      GetSymbolAngle()        {return m_dAngle;}
+    double      GetSymbolAngle() const {return m_dAngle;}
     void        SetSymbolAngle(double dAngle);
 };
 
@@ -1189,7 +1193,7 @@ class TABCustomPoint CPL_FINAL : public TABPoint,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     const char *GetSymbolNameRef()      { return GetFontNameRef(); }
     void        SetSymbolName(const char *pszName) {SetFontName(pszName);}
@@ -1250,7 +1254,7 @@ class TABPolyline CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 
@@ -1324,7 +1328,7 @@ class TABRegion CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 
@@ -1374,7 +1378,7 @@ class TABRectangle CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 
@@ -1433,7 +1437,7 @@ class TABEllipse CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 
@@ -1493,7 +1497,7 @@ class TABArc CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 
@@ -1534,7 +1538,7 @@ class TABText CPL_FINAL : public TABFeature,
 
     double      m_dAngle;
     double      m_dHeight;
-    double      m_dWidth;
+    mutable double      m_dWidth;
     double      m_dfLineEndX;
     double      m_dfLineEndY;
     GBool       m_bLineEndSet;
@@ -1548,7 +1552,7 @@ class TABText CPL_FINAL : public TABFeature,
     GInt16      m_nTextAlignment;       // Justification/Vert.Spacing/arrow
     GInt16      m_nFontStyle;           // Bold/italic/underlined/shadow/...
 
-    const char *GetLabelStyleString();
+    const char *GetLabelStyleString() const;
 
     virtual int UpdateMBR(TABMAPFile *poMapFile = nullptr) override;
 
@@ -1571,24 +1575,24 @@ class TABText CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 
-    const char *GetTextString();
-    double      GetTextAngle();
-    double      GetTextBoxHeight();
-    double      GetTextBoxWidth();
-    GInt32      GetFontFGColor();
-    GInt32      GetFontBGColor();
-    GInt32      GetFontOColor();
-    GInt32      GetFontSColor();
+    const char *GetTextString() const;
+    double      GetTextAngle() const;
+    double      GetTextBoxHeight() const;
+    double      GetTextBoxWidth() const;
+    GInt32      GetFontFGColor() const;
+    GInt32      GetFontBGColor() const;
+    GInt32      GetFontOColor() const;
+    GInt32      GetFontSColor() const;
     void        GetTextLineEndPoint(double &dX, double &dY);
 
-    TABTextJust GetTextJustification();
-    TABTextSpacing  GetTextSpacing();
-    TABTextLineType GetTextLineType();
-    GBool       QueryFontStyle(TABFontStyle eStyleToQuery);
+    TABTextJust GetTextJustification() const;
+    TABTextSpacing  GetTextSpacing() const;
+    TABTextLineType GetTextLineType() const;
+    GBool       QueryFontStyle(TABFontStyle eStyleToQuery) const;
 
     void        SetTextString(const char *pszStr);
     void        SetTextAngle(double dAngle);
@@ -1605,15 +1609,15 @@ class TABText CPL_FINAL : public TABFeature,
     void        SetTextLineType(TABTextLineType eLineType);
     void        ToggleFontStyle(TABFontStyle eStyleToToggle, GBool bStatus);
 
-    int         GetFontStyleMIFValue();
+    int         GetFontStyleMIFValue() const;
     void        SetFontStyleMIFValue(int nStyle, GBool bBGColorSet=FALSE);
-    GBool       IsFontBGColorUsed();
-    GBool       IsFontOColorUsed();
-    GBool       IsFontSColorUsed();
-    GBool       IsFontBold();
-    GBool       IsFontItalic();
-    GBool       IsFontUnderline();
-    int         GetFontStyleTABValue()           {return m_nFontStyle;}
+    GBool       IsFontBGColorUsed() const;
+    GBool       IsFontOColorUsed() const;
+    GBool       IsFontSColorUsed() const;
+    GBool       IsFontBold() const;
+    GBool       IsFontItalic() const;
+    GBool       IsFontUnderline() const;
+    int         GetFontStyleTABValue() const {return m_nFontStyle;}
     void        SetFontStyleTABValue(int nStyle){m_nFontStyle=(GInt16)nStyle;}
 };
 
@@ -1665,7 +1669,7 @@ class TABMultiPoint CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 };
@@ -1738,7 +1742,7 @@ class TABCollection CPL_FINAL : public TABFeature,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
-    virtual const char *GetStyleString() override;
+    virtual const char *GetStyleString() const override;
 
     virtual void DumpMIF(FILE *fpOut = nullptr) override;
 

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1136,13 +1136,13 @@ double TABPoint::GetY()
 }
 
 /**********************************************************************
- *                   TABPoint::GetStyleString()
+ *                   TABPoint::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABPoint::GetStyleString()
+const char *TABPoint::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -1500,13 +1500,13 @@ void TABFontPoint::SetSymbolAngle(double dAngle)
 }
 
 /**********************************************************************
- *                   TABFontPoint::GetStyleString()
+ *                   TABFontPoint::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABFontPoint::GetStyleString()
+const char *TABFontPoint::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -1724,13 +1724,13 @@ int TABCustomPoint::WriteGeometryToMAPFile(TABMAPFile *poMapFile,
 }
 
 /**********************************************************************
- *                   TABCustomPoint::GetStyleString()
+ *                   TABCustomPoint::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABCustomPoint::GetStyleString()
+const char *TABCustomPoint::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -2643,13 +2643,13 @@ int TABPolyline::WriteGeometryToMAPFile(TABMAPFile *poMapFile,
 }
 
 /**********************************************************************
- *                   TABPolyline::GetStyleString()
+ *                   TABPolyline::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABPolyline::GetStyleString()
+const char *TABPolyline::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -3653,13 +3653,13 @@ GBool TABRegion::IsInteriorRing(int nRequestedRingIndex)
 }
 
 /**********************************************************************
- *                   TABRegion::GetStyleString()
+ *                   TABRegion::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABRegion::GetStyleString()
+const char *TABRegion::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -4166,13 +4166,13 @@ int TABRectangle::WriteGeometryToMAPFile(TABMAPFile *poMapFile,
 }
 
 /**********************************************************************
- *                   TABRectangle::GetStyleString()
+ *                   TABRectangle::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABRectangle::GetStyleString()
+const char *TABRectangle::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -4578,13 +4578,13 @@ int TABEllipse::WriteGeometryToMAPFile(TABMAPFile *poMapFile,
 }
 
 /**********************************************************************
- *                   TABEllipse::GetStyleString()
+ *                   TABEllipse::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABEllipse::GetStyleString()
+const char *TABEllipse::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -5123,13 +5123,13 @@ void TABArc::SetEndAngle(double dAngle)
 }
 
 /**********************************************************************
- *                   TABArc::GetStyleString()
+ *                   TABArc::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABArc::GetStyleString()
+const char *TABArc::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -5677,7 +5677,7 @@ int TABText::WriteGeometryToMAPFile(TABMAPFile *poMapFile,
  * Returned string is a reference to the internal string buffer and should
  * not be modified or freed by the caller.
  **********************************************************************/
-const char *TABText::GetTextString()
+const char *TABText::GetTextString() const
 {
     if (m_pszString == nullptr)
         return "";
@@ -5705,7 +5705,7 @@ void TABText::SetTextString(const char *pszNewStr)
  *
  * Return text angle in degrees.
  **********************************************************************/
-double TABText::GetTextAngle()
+double TABText::GetTextAngle() const
 {
     return m_dAngle;
 }
@@ -5725,7 +5725,7 @@ void TABText::SetTextAngle(double dAngle)
  *
  * Return text height in Y axis coord. units of the text box before rotation.
  **********************************************************************/
-double TABText::GetTextBoxHeight()
+double TABText::GetTextBoxHeight() const
 {
     return m_dHeight;
 }
@@ -5746,7 +5746,7 @@ void TABText::SetTextBoxHeight(double dHeight)
  * the multiline case.  This should not matter when the user PROPERLY sets
  * the value.
  **********************************************************************/
-double TABText::GetTextBoxWidth()
+double TABText::GetTextBoxWidth() const
 {
     if (m_dWidth == 0.0 && m_pszString)
     {
@@ -5864,7 +5864,7 @@ int TABText::UpdateMBR(TABMAPFile * poMapFile /*=NULL*/)
  *
  * Return background color.
  **********************************************************************/
-GInt32 TABText::GetFontBGColor()
+GInt32 TABText::GetFontBGColor() const
 {
     return m_rgbBackground;
 }
@@ -5879,7 +5879,7 @@ void TABText::SetFontBGColor(GInt32 rgbColor)
  *
  * Return outline color.
  **********************************************************************/
-GInt32 TABText::GetFontOColor()
+GInt32 TABText::GetFontOColor() const
 {
     return m_rgbOutline;
 }
@@ -5894,7 +5894,7 @@ void TABText::SetFontOColor(GInt32 rgbColor)
  *
  * Return shadow color.
  **********************************************************************/
-GInt32 TABText::GetFontSColor()
+GInt32 TABText::GetFontSColor() const
 {
     return m_rgbShadow;
 }
@@ -5909,7 +5909,7 @@ void TABText::SetFontSColor(GInt32 rgbColor)
  *
  * Return foreground color.
  **********************************************************************/
-GInt32 TABText::GetFontFGColor()
+GInt32 TABText::GetFontFGColor() const
 {
     return m_rgbForeground;
 }
@@ -5924,7 +5924,7 @@ void TABText::SetFontFGColor(GInt32 rgbColor)
  *
  * Return text justification.  Default is TABTJLeft
  **********************************************************************/
-TABTextJust TABText::GetTextJustification()
+TABTextJust TABText::GetTextJustification() const
 {
     TABTextJust eJust = TABTJLeft;
 
@@ -5952,7 +5952,7 @@ void TABText::SetTextJustification(TABTextJust eJustification)
  *
  * Return text vertical spacing factor.  Default is TABTSSingle
  **********************************************************************/
-TABTextSpacing TABText::GetTextSpacing()
+TABTextSpacing TABText::GetTextSpacing() const
 {
     TABTextSpacing eSpacing = TABTSSingle;
 
@@ -5980,7 +5980,7 @@ void TABText::SetTextSpacing(TABTextSpacing eSpacing)
  *
  * Return text line (arrow) type.  Default is TABTLNoLine
  **********************************************************************/
-TABTextLineType TABText::GetTextLineType()
+TABTextLineType TABText::GetTextLineType() const
 {
     TABTextLineType eLine = TABTLNoLine;
 
@@ -6010,7 +6010,7 @@ void TABText::SetTextLineType(TABTextLineType eLineType)
  * or FALSE otherwise.  See enum TABFontStyle for the list of styles
  * that can be queried on.
  **********************************************************************/
-GBool TABText::QueryFontStyle(TABFontStyle eStyleToQuery)
+GBool TABText::QueryFontStyle(TABFontStyle eStyleToQuery) const
 {
     return (m_nFontStyle & (int)eStyleToQuery) ? TRUE: FALSE;
 }
@@ -6037,7 +6037,7 @@ void TABText::ToggleFontStyle(TABFontStyle eStyleToToggle, GBool bStyleOn)
  * This also has the effect of shifting all the other style values > 0x100
  * by 1 byte.
  **********************************************************************/
-int TABText::GetFontStyleMIFValue()
+int TABText::GetFontStyleMIFValue() const
 {
     // The conversion is simply to remove bit 0x100 from the value and shift
     // down all values past this bit.
@@ -6052,37 +6052,37 @@ void TABText:: SetFontStyleMIFValue(int nStyle, GBool bBGColorSet)
         ToggleFontStyle(TABFSBox, TRUE);
 }
 
-int TABText::IsFontBGColorUsed()
+int TABText::IsFontBGColorUsed() const
 {
     // Font BG color is used only when BOX is set.
     return QueryFontStyle(TABFSBox);
 }
 
-int TABText::IsFontOColorUsed()
+int TABText::IsFontOColorUsed() const
 {
     // Font outline color is used only when HALO is set.
     return QueryFontStyle(TABFSHalo);
 }
 
-int TABText::IsFontSColorUsed()
+int TABText::IsFontSColorUsed() const
 {
     // Font shadow color is used only when Shadow is set.
     return QueryFontStyle(TABFSShadow);
 }
 
-int TABText::IsFontBold()
+int TABText::IsFontBold() const
 {
     // Font bold is used only when Bold is set.
     return QueryFontStyle(TABFSBold);
 }
 
-int TABText::IsFontItalic()
+int TABText::IsFontItalic() const
 {
     // Font italic is used only when Italic is set.
     return QueryFontStyle(TABFSItalic);
 }
 
-int TABText::IsFontUnderline()
+int TABText::IsFontUnderline() const
 {
     // Font underline is used only when Underline is set.
     return QueryFontStyle(TABFSUnderline);
@@ -6095,7 +6095,7 @@ int TABText::IsFontUnderline()
  * but it's really more easy to put it here.  This fct return a complete
  * string for the representation with the string to display
  **********************************************************************/
-const char *TABText::GetLabelStyleString()
+const char *TABText::GetLabelStyleString() const
 {
     const char *pszStyle = nullptr;
     int nStringLen = static_cast<int>(strlen(GetTextString()));
@@ -6209,13 +6209,13 @@ const char *TABText::GetLabelStyleString()
 }
 
 /**********************************************************************
- *                   TABText::GetStyleString()
+ *                   TABText::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABText::GetStyleString()
+const char *TABText::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -6697,13 +6697,13 @@ int TABMultiPoint::GetNumPoints()
 }
 
 /**********************************************************************
- *                   TABMultiPoint::GetStyleString()
+ *                   TABMultiPoint::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABMultiPoint::GetStyleString()
+const char *TABMultiPoint::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -7882,13 +7882,13 @@ int    TABCollection::SetMultiPointDirectly(TABMultiPoint *poMpoint)
 }
 
 /**********************************************************************
- *                   TABCollection::GetStyleString()
+ *                   TABCollection::GetStyleString() const
  *
  * Return style string for this feature.
  *
  * Style String is built only once during the first call to GetStyleString().
  **********************************************************************/
-const char *TABCollection::GetStyleString()
+const char *TABCollection::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
@@ -8099,7 +8099,7 @@ ITABFeaturePen::ITABFeaturePen() :
  * even when the pen width was actually set in points.
  **********************************************************************/
 
-GByte ITABFeaturePen::GetPenWidthPixel()
+GByte ITABFeaturePen::GetPenWidthPixel() const
 {
     return m_sPenDef.nPixelWidth;
 }
@@ -8113,7 +8113,7 @@ void  ITABFeaturePen::SetPenWidthPixel(GByte val)
     m_sPenDef.nPointWidth = 0;
 }
 
-double ITABFeaturePen::GetPenWidthPoint()
+double ITABFeaturePen::GetPenWidthPoint() const
 {
     // We store point width internally as tenths of points
     return m_sPenDef.nPointWidth/10.0;
@@ -8134,7 +8134,7 @@ void  ITABFeaturePen::SetPenWidthPoint(double val)
  * for a pen width in pixels, or a value from 11 to 2047 for a pen
  * width in points = 10 + (point_width*10)
  **********************************************************************/
-int     ITABFeaturePen::GetPenWidthMIF()
+int     ITABFeaturePen::GetPenWidthMIF() const
 {
     return ( m_sPenDef.nPointWidth > 0?
              (m_sPenDef.nPointWidth+10): m_sPenDef.nPixelWidth );
@@ -8159,7 +8159,7 @@ void ITABFeaturePen::SetPenWidthMIF( int val )
  *
  *  Return a PEN() string. All representations info for the pen are here.
  **********************************************************************/
-const char *ITABFeaturePen::GetPenStyleString()
+const char *ITABFeaturePen::GetPenStyleString() const
 {
     const char *pszStyle = nullptr;
     int    nOGRStyle  = 0;
@@ -8517,7 +8517,7 @@ ITABFeatureBrush::ITABFeatureBrush() :
  *
  *  Return a Brush() string. All representations info for the Brush are here.
  **********************************************************************/
-const char *ITABFeatureBrush::GetBrushStyleString()
+const char *ITABFeatureBrush::GetBrushStyleString() const
 {
     const char *pszStyle = nullptr;
     int    nOGRStyle  = 0;
@@ -8747,7 +8747,7 @@ ITABFeatureSymbol::ITABFeatureSymbol() :
  *
  *  Return a Symbol() string. All representations info for the Symbol are here.
  **********************************************************************/
-const char *ITABFeatureSymbol::GetSymbolStyleString(double dfAngle)
+const char *ITABFeatureSymbol::GetSymbolStyleString(double dfAngle) const
 {
     const char *pszStyle = nullptr;
     int    nOGRStyle  = 1;

--- a/gdal/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/gdal/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -122,13 +122,13 @@ class OGRPGGeomFieldDefn : public OGRGeomFieldDefn
             {
             }
 
-        virtual OGRSpatialReference* GetSpatialRef() override;
+        virtual OGRSpatialReference* GetSpatialRef() const override;
 
         void UnsetLayer() { poLayer = nullptr; }
 
-        int nSRSId;
-        int GeometryTypeFlags;
-        PostgisType   ePostgisType;
+        mutable int nSRSId;
+        mutable int GeometryTypeFlags;
+        mutable PostgisType   ePostgisType;
 };
 
 /************************************************************************/
@@ -238,7 +238,7 @@ class OGRPGLayer : public OGRLayer
 
     OGRPGDataSource    *GetDS() { return poDS; }
 
-    virtual void        ResolveSRID(OGRPGGeomFieldDefn* poGFldDefn) = 0;
+    virtual void        ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn) = 0;
 };
 
 /************************************************************************/
@@ -396,7 +396,7 @@ public:
     void                SetDeferredCreation(int bDeferredCreationIn, CPLString osCreateTable);
     OGRErr              RunDeferredCreationIfNecessary();
 
-    virtual void        ResolveSRID(OGRPGGeomFieldDefn* poGFldDefn) override;
+    virtual void        ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn) override;
 };
 
 /************************************************************************/
@@ -434,7 +434,7 @@ class OGRPGResultLayer : public OGRPGLayer
 
     virtual OGRFeature *GetNextFeature() override;
 
-    virtual void        ResolveSRID(OGRPGGeomFieldDefn* poGFldDefn) override;
+    virtual void        ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn) override;
 };
 
 /************************************************************************/

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -2669,7 +2669,7 @@ class OGRPGNoResetResultLayer : public OGRPGLayer
     virtual OGRFeature *GetNextFeature() override;
 
     virtual CPLString   GetFromClauseForGetExtent() override { CPLAssert(false); return ""; }
-    virtual void        ResolveSRID(OGRPGGeomFieldDefn* poGFldDefn) override { poGFldDefn->nSRSId = -1; }
+    virtual void        ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn) override { poGFldDefn->nSRSId = -1; }
 };
 
 /************************************************************************/

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
@@ -2206,7 +2206,7 @@ int OGRPGLayer::ReadResultDefinition(PGresult *hInitialResultIn)
 /*                          GetSpatialRef()                             */
 /************************************************************************/
 
-OGRSpatialReference* OGRPGGeomFieldDefn::GetSpatialRef()
+OGRSpatialReference* OGRPGGeomFieldDefn::GetSpatialRef() const
 {
     if( poLayer == nullptr )
         return nullptr;

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgresultlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgresultlayer.cpp
@@ -353,7 +353,7 @@ void OGRPGResultLayer::SetSpatialFilter( int iGeomField, OGRGeometry * poGeomIn 
 /*                            ResolveSRID()                             */
 /************************************************************************/
 
-void OGRPGResultLayer::ResolveSRID(OGRPGGeomFieldDefn* poGFldDefn)
+void OGRPGResultLayer::ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn)
 
 {
     /* We have to get the SRID of the geometry column, so to be able */

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -51,7 +51,7 @@ class OGRPGTableFeatureDefn : public OGRPGFeatureDefn
     private:
         OGRPGTableLayer *poLayer;
 
-        void SolveFields();
+        void SolveFields() const;
 
     public:
         OGRPGTableFeatureDefn( OGRPGTableLayer* poLayerIn,
@@ -66,14 +66,16 @@ class OGRPGTableFeatureDefn : public OGRPGFeatureDefn
             OGRPGFeatureDefn::UnsetLayer();
         }
 
-        virtual int         GetFieldCount() override
+        virtual int         GetFieldCount() const override
             { SolveFields(); return OGRPGFeatureDefn::GetFieldCount(); }
         virtual OGRFieldDefn *GetFieldDefn( int i ) override
             { SolveFields(); return OGRPGFeatureDefn::GetFieldDefn(i); }
-        virtual int         GetFieldIndex( const char * pszName ) override
+        virtual const OGRFieldDefn *GetFieldDefn( int i ) const override
+            { SolveFields(); return OGRPGFeatureDefn::GetFieldDefn(i); }
+        virtual int         GetFieldIndex( const char * pszName ) const override
             { SolveFields(); return OGRPGFeatureDefn::GetFieldIndex(pszName); }
 
-        virtual int         GetGeomFieldCount() override
+        virtual int         GetGeomFieldCount() const override
             { if (poLayer != nullptr && !poLayer->HasGeometryInformation())
                   SolveFields();
               return OGRPGFeatureDefn::GetGeomFieldCount(); }
@@ -81,7 +83,11 @@ class OGRPGTableFeatureDefn : public OGRPGFeatureDefn
             { if (poLayer != nullptr && !poLayer->HasGeometryInformation())
                   SolveFields();
               return OGRPGFeatureDefn::GetGeomFieldDefn(i); }
-        virtual int         GetGeomFieldIndex( const char * pszName) override
+        virtual const OGRGeomFieldDefn *GetGeomFieldDefn( int i ) const override
+            { if (poLayer != nullptr && !poLayer->HasGeometryInformation())
+                  SolveFields();
+              return OGRPGFeatureDefn::GetGeomFieldDefn(i); }
+        virtual int         GetGeomFieldIndex( const char * pszName) const override
             { if (poLayer != nullptr && !poLayer->HasGeometryInformation())
                   SolveFields();
               return OGRPGFeatureDefn::GetGeomFieldIndex(pszName); }
@@ -91,7 +97,7 @@ class OGRPGTableFeatureDefn : public OGRPGFeatureDefn
 /*                           SolveFields()                              */
 /************************************************************************/
 
-void OGRPGTableFeatureDefn::SolveFields()
+void OGRPGTableFeatureDefn::SolveFields() const
 {
     if( poLayer == nullptr )
         return;
@@ -2782,7 +2788,7 @@ GIntBig OGRPGTableLayer::GetFeatureCount( int bForce )
 /*                             ResolveSRID()                            */
 /************************************************************************/
 
-void OGRPGTableLayer::ResolveSRID(OGRPGGeomFieldDefn* poGFldDefn)
+void OGRPGTableLayer::ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn)
 
 {
     PGconn      *hPGConn = poDS->GetPGConn();

--- a/gdal/ogr/ogrsf_frmts/plscenes/ogr_plscenes.h
+++ b/gdal/ogr/ogrsf_frmts/plscenes/ogr_plscenes.h
@@ -97,7 +97,7 @@ class OGRPLScenesDataV1FeatureDefn: public OGRFeatureDefn
                             OGRFeatureDefn(pszName), m_poLayer(poLayer) {}
        ~OGRPLScenesDataV1FeatureDefn() {}
 
-       virtual int GetFieldCount() override;
+       virtual int GetFieldCount() const override;
 
        void DropRefToLayer() { m_poLayer = nullptr; }
 };

--- a/gdal/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp
+++ b/gdal/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp
@@ -36,7 +36,7 @@ CPL_CVSID("$Id$")
 /*                           GetFieldCount()                            */
 /************************************************************************/
 
-int OGRPLScenesDataV1FeatureDefn::GetFieldCount()
+int OGRPLScenesDataV1FeatureDefn::GetFieldCount() const
 {
     if( nFieldCount == 0 && m_poLayer != nullptr )
         m_poLayer->EstablishLayerDefn();

--- a/gdal/ogr/ogrsf_frmts/shape/ogrshape.h
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshape.h
@@ -72,8 +72,8 @@ OGRErr SHPWriteOGRFeature( SHPHandle hSHP, DBFHandle hDBF,
 class OGRShapeGeomFieldDefn CPL_FINAL: public OGRGeomFieldDefn
 {
     char* pszFullName;
-    bool  bSRSSet;
-    CPLString osPrjFile;
+    mutable bool  bSRSSet;
+    mutable CPLString osPrjFile;
 
     public:
         OGRShapeGeomFieldDefn( const char* pszFullNameIn,
@@ -88,7 +88,7 @@ class OGRShapeGeomFieldDefn CPL_FINAL: public OGRGeomFieldDefn
 
         virtual ~OGRShapeGeomFieldDefn() { CPLFree(pszFullName); }
 
-        virtual OGRSpatialReference* GetSpatialRef() override;
+        virtual OGRSpatialReference* GetSpatialRef() const override;
 
         const CPLString& GetPrjFilename() const { return osPrjFile; }
 };

--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -2083,7 +2083,7 @@ OGRErr OGRShapeLayer::AlterFieldDefn( int iField, OGRFieldDefn* poNewFieldDefn,
 /*                           GetSpatialRef()                            */
 /************************************************************************/
 
-OGRSpatialReference *OGRShapeGeomFieldDefn::GetSpatialRef()
+OGRSpatialReference *OGRShapeGeomFieldDefn::GetSpatialRef() const
 
 {
     if( bSRSSet )


### PR DESCRIPTION
This can have an impact on out-of-tree drivers. See MIGRATION_GUIDE.TXT
