### PR TITLE
Pass --silent to libtool

### DIFF
--- a/gdal/GDALmake.opt.in
+++ b/gdal/GDALmake.opt.in
@@ -10,12 +10,12 @@ SHELL    =   @SHELL@
 HAVE_LIBTOOL	=	@HAVE_LIBTOOL@
 LIBTOOL	=	@LIBTOOL@
 ifeq ($(HAVE_LIBTOOL),yes)
-LIBTOOL_COMPILE_CC =	$(LIBTOOL) --mode=compile --tag=CC
-LIBTOOL_COMPILE_CXX =	$(LIBTOOL) --mode=compile --tag=CXX
-LIBTOOL_LINK	=	$(LIBTOOL) --mode=link
-LIBTOOL_INSTALL	=	$(LIBTOOL) --mode=install
+LIBTOOL_COMPILE_CC =	$(LIBTOOL) --mode=compile --silent --tag=CC
+LIBTOOL_COMPILE_CXX =	$(LIBTOOL) --mode=compile --silent --tag=CXX
+LIBTOOL_LINK	=	$(LIBTOOL) --mode=link --silent
+LIBTOOL_INSTALL	=	$(LIBTOOL) --mode=install --silent
 LIBTOOL_FINISH	=	$(LIBTOOL) --mode=finish --silent
-LIBTOOL_CLEAN	=	$(LIBTOOL) --mode=clean
+LIBTOOL_CLEAN	=	$(LIBTOOL) --mode=clean --silent
 OBJ_EXT = lo
 else
 LIBTOOL_FINISH	=	@BINTRUE@

--- a/gdal/ci/travis/osx/install.sh
+++ b/gdal/ci/travis/osx/install.sh
@@ -17,7 +17,7 @@ cd ..
 # build GDAL
 cd gdal
 CC="ccache gcc" CXX="ccache g++" ./configure --prefix=$HOME/install-gdal --enable-debug --with-jpeg12 --with-geotiff=internal --with-png=internal --with-static-proj4=$HOME/install-proj --with-sqlite3=/usr/local/opt/sqlite
-make USER_DEFS="-Wextra -Werror" -j3 -s
+make USER_DEFS="-Wextra -Werror" -j3
 cd apps
 make USER_DEFS="-Wextra -Werror" test_ogrsf
 echo "Show which shared libs got used:"


### PR DESCRIPTION
## What does this PR do?

Pass `--silent` to `libtool` in compile (C and C++), link, install and clean modes so that libtool does not show subordinate command lines. This allows `make -s` to operate properly.