### PR TITLE
Detect when PROJCS cannot be found in RemapGeogCSName

### DIFF
--- a/gdal/ogr/ogr_srs_esri.cpp
+++ b/gdal/ogr/ogr_srs_esri.cpp
@@ -1841,10 +1841,7 @@ OGRErr OGRSpatialReference::morphToESRI()
       }
       if( pszGcsName != nullptr )
       {
-        if( RemapGeogCSName(this, pszGcsName) < 0 )
-        {
-          return OGRERR_CORRUPT_DATA;
-        }
+        RemapGeogCSName(this, pszGcsName);
       }
 
       // Specific processing and remapping

--- a/gdal/ogr/ogr_srs_esri.cpp
+++ b/gdal/ogr/ogr_srs_esri.cpp
@@ -1322,6 +1322,12 @@ int RemapGeogCSName( OGRSpatialReference* pOgr, const char *pszGeogCSName )
     if( ret < 0 )
     {
         const char* pszProjCS = pOgr->GetAttrValue( "PROJCS" );
+        if (pszProjCS == nullptr)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "RemapGeogCSName: PROJCS does not exist.");
+            return ret;
+        }
         ret = RemapNamesBasedOnTwo(
             pOgr, pszProjCS, pszGeogCSName,
             const_cast<char**>(apszGcsNameMappingBasedOnProjCS),
@@ -1835,7 +1841,10 @@ OGRErr OGRSpatialReference::morphToESRI()
       }
       if( pszGcsName != nullptr )
       {
-        RemapGeogCSName(this, pszGcsName);
+        if( RemapGeogCSName(this, pszGcsName) < 0 )
+        {
+          return OGRERR_CORRUPT_DATA;
+        }
       }
 
       // Specific processing and remapping


### PR DESCRIPTION
morphToESRI now checks the return from RemapGeogCSName.
There are similar cases not yet fixed.
Found with autofuzz.