### PR TITLE
remove auth deprecated fields

### DIFF
--- a/autotest/gdrivers/rda.py
+++ b/autotest/gdrivers/rda.py
@@ -117,8 +117,6 @@ def rda_failed_authentication():
     # invalid characters in env variable
     with gdaltest.config_options({'GBDX_AUTH_URL': '\\',
                                   'GBDX_RDA_API_URL': '\\',
-                                  'GBDX_CLIENT_ID': '\\',
-                                  'GBDX_CLIENT_SECRET': '\\',
                                   'GBDX_USERNAME': 'user_name',
                                   'GBDX_PASSWORD': 'password'}):
         with gdaltest.error_handler():
@@ -129,8 +127,6 @@ def rda_failed_authentication():
 
     # invalid URL
     with gdaltest.config_options({'GBDX_AUTH_URL': '/vsimem/auth_url',
-                                  'GBDX_CLIENT_ID': 'client_id',
-                                  'GBDX_CLIENT_SECRET': 'client_secret',
                                   'GBDX_USERNAME': 'user_name',
                                   'GBDX_PASSWORD': 'password'}):
         with gdaltest.error_handler():
@@ -144,8 +140,6 @@ def rda_failed_authentication():
     handler.add('POST', '/auth_url', 404)
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL':  '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -159,8 +153,6 @@ def rda_failed_authentication():
     handler.add('POST', '/auth_url', 200, {}, 'invalid_json')
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL':  '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -174,8 +166,6 @@ def rda_failed_authentication():
     handler.add('POST', '/auth_url', 200, {}, '{}')
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL':  '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -203,8 +193,6 @@ def rda_error_metadata():
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -221,8 +209,6 @@ def rda_error_metadata():
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -239,8 +225,6 @@ def rda_error_metadata():
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -255,8 +239,6 @@ def rda_error_metadata():
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -294,8 +276,6 @@ def rda_error_metadata():
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -333,8 +313,6 @@ def rda_error_metadata():
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -372,8 +350,6 @@ def rda_error_metadata():
     with webserver.install_http_handler(handler):
         with gdaltest.config_options({'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
                                     'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-                                    'GBDX_CLIENT_ID': 'client_id',
-                                    'GBDX_CLIENT_SECRET': 'client_secret',
                                     'GBDX_USERNAME': 'user_name',
                                     'GBDX_PASSWORD': 'password'}):
             with gdaltest.error_handler():
@@ -432,8 +408,6 @@ def rda_graph_nominal():
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
         'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-        'GBDX_CLIENT_ID': 'client_id',
-        'GBDX_CLIENT_SECRET': 'client_secret',
         'GBDX_USERNAME': 'user_name',
         'GBDX_PASSWORD': 'password'
     }
@@ -756,8 +730,6 @@ def rda_read_gbdx_config():
     gdal.FileFromMemBuffer('/vsimem/.gbdx-config', """
 [gbdx]
 auth_url = 127.0.0.1:%d/auth_url
-client_id = client_id
-client_secret = client_secret
 user_name = user_name
 user_password = password
 idaho_api_url = 127.0.0.1:%d/rda_api
@@ -818,8 +790,6 @@ def rda_download_queue():
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
         'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-        'GBDX_CLIENT_ID': 'client_id',
-        'GBDX_CLIENT_SECRET': 'client_secret',
         'GBDX_USERNAME': 'user_name',
         'GBDX_PASSWORD': 'password'
     }
@@ -901,8 +871,6 @@ def rda_rpc():
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
         'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-        'GBDX_CLIENT_ID': 'client_id',
-        'GBDX_CLIENT_SECRET': 'client_secret',
         'GBDX_USERNAME': 'user_name',
         'GBDX_PASSWORD': 'password'
     }
@@ -1011,8 +979,6 @@ def rda_real_cache_dir():
         'RDA_CACHE_DIR': '',
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
         'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-        'GBDX_CLIENT_ID': 'client_id',
-        'GBDX_CLIENT_SECRET': 'client_secret',
         'GBDX_USERNAME': 'user_name',
         'GBDX_PASSWORD': 'password'
     }
@@ -1101,8 +1067,6 @@ def rda_real_expired_authentication():
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
         'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-        'GBDX_CLIENT_ID': 'client_id',
-        'GBDX_CLIENT_SECRET': 'client_secret',
         'GBDX_USERNAME': 'user_name',
         'GBDX_PASSWORD': 'password'
     }
@@ -1163,9 +1127,7 @@ def rda_bad_tile():
     config_options = {
         'GBDX_AUTH_URL': '127.0.0.1:%d/auth_url' % gdaltest.webserver_port,
         'GBDX_RDA_API_URL':  '127.0.0.1:%d/rda_api' % gdaltest.webserver_port,
-        'GBDX_CLIENT_ID': 'client_id',
-        'GBDX_CLIENT_SECRET': 'client_secret',
-        'GBDX_USERNAME': 'user_name',
+         'GBDX_USERNAME': 'user_name',
         'GBDX_PASSWORD': 'password'
     }
 

--- a/gdal/frmts/rda/frmt_rda.html
+++ b/gdal/frmts/rda/frmt_rda.html
@@ -19,8 +19,7 @@
     supported.
 <p>
 
-    Orthorectified (with geotransform) and raw (Level-1B with RPCs) datasets are
-    supported.
+    Any valid graph or template is supported via the DigitalGlobe RDA REST API.
 <p>
 
     There is no support for overviews.
@@ -66,8 +65,8 @@ OR
 
 <h2>Authentication</h2>
 
-<p>Access to the API requires an authentication token. For that, 4 parameters
-    (client_id, client_secret, username, password) must be provided to the driver.
+<p>Access to the API requires an authentication token. For that, 2 parameters
+    (username, password) must be provided to the driver.
     They can be retrieved from the below configuration options, or from the
     ~/.gbdx-config file.</p>
 
@@ -85,14 +84,6 @@ The following configuration options are available :
     <li><b>GBDX_RDA_API_URL</b>=value: To specify the RDA API endpoint.
         Defaults to https://rda.geobigdata.io/v1. If not specified, the
         rda_api_url parameter from ~/.gbdx-config will be used if it exists.
-    </li>
-    <li><b>GBDX_CLIENT_ID</b>=value: To specify the OAuth client id needed to get
-        to an authentication token. If not specified, the
-        client_id parameter from ~/.gbdx-config must be set.
-    </li>
-    <li><b>GBDX_CLIENT_SECRET</b>=value: To specify the OAuth client secret needed to get
-        to an authentication token. If not specified, the
-        client_secret parameter from ~/.gbdx-config must be set.
     </li>
     <li><b>GBDX_USERNAME</b>=value: To specify the OAuth user name needed to get
         to an authentication token. If not specified, the
@@ -114,8 +105,6 @@ The following configuration options are available :
 [gbdx]
 auth_url = https://geobigdata.io/auth/v1/oauth/token/ (optional)
 rda_api_url = https://rda.geobigdata.io/v1 (optional)
-client_id = value (required)
-client_secret = value (required)
 user_name = value (required)
 user_password = value (required)
 </pre>

--- a/gdal/frmts/rda/frmt_rda.html
+++ b/gdal/frmts/rda/frmt_rda.html
@@ -50,13 +50,6 @@ OR
     </li>
 
     <li>
-        <pre>"options": {"delete-on-close": false}</pre>
-        can be added to
-        the JSon document to request that cached tiles and metadata are not destroyed
-        at dataset closing. The default, if not specified, is true.
-    </li>
-
-    <li>
         <pre>"options": {"max-connections": 32}</pre>
         can be added to
         the JSon document to request that cached tiles be fetched using a maximum number of
@@ -135,8 +128,7 @@ user_password = value (required)
     ~/.gdal/rda_cache/{graph-id}/{node-id}, and deleted on dataset closing,
     unless
 <pre>"options": {"delete-on-close": false}</pre>
-is found in the
-dataset name.</p>
+is found in the dataset name.</p>
 
 
 <h2>Open Options</h2>

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -259,7 +259,8 @@ GDALRDADataset::GDALRDADataset() :
     m_osClientId(CPLGetConfigOption("GBDX_CLIENT_ID", "")),
     m_osClientSecret(CPLGetConfigOption("GBDX_CLIENT_SECRET", "")),
     m_osUserName(CPLGetConfigOption("GBDX_USERNAME", "")),
-    m_osUserPassword(CPLGetConfigOption("GBDX_PASSWORD", ""))
+    m_osUserPassword(CPLGetConfigOption("GBDX_PASSWORD", "")),
+    m_osNativeTileFileFormat(CPLGetConfigOption("RDA_NATIVE_FORMAT", "tif"))
 {
 }
 
@@ -1030,11 +1031,7 @@ bool GDALRDADataset::ReadImageMetadata()
     m_osImageId = GetJsonString(poObj, "imageId", true, bError);
     m_osProfileName = GetJsonString(poObj, "profileName", false,
                                     bNonFatalError);
-    m_osNativeTileFileFormat = GetJsonString(poObj, "nativeTileFileFormat",
-                                            false, bNonFatalError);
-    m_osNativeTileFileFormat = m_osNativeTileFileFormat.tolower();
-    if( m_osNativeTileFileFormat.empty() )
-        m_osNativeTileFileFormat = "tif";
+
     m_nTileXOffset = GetJsonInt64(poObj, "tileXOffset", true, bError);
     m_nTileYOffset = GetJsonInt64(poObj, "tileYOffset", true, bError);
     m_nNumXTiles = std::max<GIntBig>(0,

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -101,7 +101,7 @@ class GDALRDADataset: public GDALDataset
         bool      m_bAdviseRead = true;
         CPLString m_osImageId;
         CPLString m_osProfileName;
-        CPLString m_osNativeTileFileFormat;
+        CPLString m_osRequestTileFileFormat;
         int64_t   m_nTileXOffset = 0;
         int64_t   m_nTileYOffset = 0;
         int64_t   m_nNumXTiles = 0;
@@ -260,7 +260,7 @@ GDALRDADataset::GDALRDADataset() :
     m_osClientSecret(CPLGetConfigOption("GBDX_CLIENT_SECRET", "")),
     m_osUserName(CPLGetConfigOption("GBDX_USERNAME", "")),
     m_osUserPassword(CPLGetConfigOption("GBDX_PASSWORD", "")),
-    m_osNativeTileFileFormat(CPLGetConfigOption("RDA_NATIVE_FORMAT", "tif"))
+    m_osRequestTileFileFormat(CPLGetConfigOption("RDA_REQUEST_FORMAT", "tif"))
 {
 }
 
@@ -1584,7 +1584,7 @@ CPLString GDALRDADataset::ConstructTileFetchURL(const CPLString& baseUrl,
     else if(m_osType == RDADatasetType::TEMPLATE)
     {
         retVal += "/template/" + m_osTemplateId + "/tile/";
-        CPLString tosDiscardPath= "." + m_osNativeTileFileFormat;
+        CPLString tosDiscardPath= "." + m_osRequestTileFileFormat;
         CPLString tosSubPath = subPath ;
         tosSubPath.erase((tosSubPath.begin()+tosSubPath.find(tosDiscardPath)),
                          tosSubPath.end());
@@ -1700,7 +1700,7 @@ void GDALRDADataset::BatchFetch(int nXOff, int nYOff, int nXSize, int nYSize)
             osSubPath += "/";
             osSubPath += CPLSPrintf(CPL_FRMT_GIB, static_cast<GIntBig>(nTileY));
             osSubPath += ".";
-            osSubPath += m_osNativeTileFileFormat;
+            osSubPath += m_osRequestTileFileFormat;
             CPLString osCachedFilename(GetDatasetCacheDir() + "/" + osSubPath);
             VSIStatBufL sStat;
             if( VSIStatL(osCachedFilename, &sStat) == 0 )
@@ -1741,7 +1741,7 @@ void GDALRDADataset::BatchFetch(int nXOff, int nYOff, int nXSize, int nYSize)
                 osSubPath += CPLSPrintf(CPL_FRMT_GIB,
                                         static_cast<GIntBig>(nTileY));
                 osSubPath += ".";
-                osSubPath += m_osNativeTileFileFormat;
+                osSubPath += m_osRequestTileFileFormat;
                 CPLString osCachedFilename(
                     GetDatasetCacheDir() + "/" + osSubPath);
                 CacheFile( osCachedFilename,
@@ -1782,7 +1782,7 @@ GDALRDADataset::GetTiles(
         osSubPath += "/";
         osSubPath += CPLSPrintf(CPL_FRMT_GIB, static_cast<GIntBig>(nTileY));
         osSubPath += ".";
-        osSubPath += m_osNativeTileFileFormat;
+        osSubPath += m_osRequestTileFileFormat;
         CPLString osCachedFilename(GetDatasetCacheDir() + "/" + osSubPath);
         VSIStatBufL sStat;
         if( VSIStatL(osCachedFilename, &sStat) == 0 )
@@ -1839,7 +1839,7 @@ GDALRDADataset::GetTiles(
                                                 this,
                                                 static_cast<int>(nTileX),
                                                 static_cast<int>(nTileY)));
-                osTmpMemFile += m_osNativeTileFileFormat;
+                osTmpMemFile += m_osRequestTileFileFormat;
                 GByte* pabyData = pasResults[i]->pabyData;
                 pasResults[i]->pabyData = nullptr;
                 VSIFCloseL(VSIFileFromMemBuffer(osTmpMemFile, pabyData,
@@ -1871,7 +1871,7 @@ GDALRDADataset::GetTiles(
                         osSubPath += CPLSPrintf(CPL_FRMT_GIB,
                                                 static_cast<GIntBig>(nTileY));
                         osSubPath += ".";
-                        osSubPath += m_osNativeTileFileFormat;
+                        osSubPath += m_osRequestTileFileFormat;
                         CPLString osCachedFilename(
                             GetDatasetCacheDir() + "/" + osSubPath);
                         CacheFile( osCachedFilename, pabyData,

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -1067,7 +1067,7 @@ bool GDALRDADataset::ReadImageMetadata()
     m_nMaxTileX = GetJsonInt64(poObj, "maxTileX", true, bError);
     m_nMaxTileY = GetJsonInt64(poObj, "maxTileY", true, bError);
     m_osColorInterpretation = GetJsonString(poObj,
-                                        "colorInterpretation", true, bError);
+                                        "colorInterpretation", false, bNonFatalError);
     int64_t nXStart = m_nMinX - m_nMinTileX * m_nTileXSize;
     if( nXStart < 0 || nXStart >= m_nTileXSize )
     {
@@ -1546,14 +1546,18 @@ GDALColorInterp GDALRDARasterBand::GetColorInterpretation()
 
     if( nBand <= 5 )
     {
-        for( size_t i = 0; i < CPL_ARRAYSIZE(asColorInterpretations); i++ )
+        if (!poGDS->m_osColorInterpretation.empty())
         {
-            if( EQUAL(poGDS->m_osColorInterpretation,
-                      asColorInterpretations[i].pszName) )
+            for( size_t i = 0; i < CPL_ARRAYSIZE(asColorInterpretations); i++ )
             {
-                return asColorInterpretations[i].aeInter[nBand-1];
+                if( EQUAL(poGDS->m_osColorInterpretation,
+                        asColorInterpretations[i].pszName) )
+                {
+                    return asColorInterpretations[i].aeInter[nBand-1];
+                }
             }
         }
+        
     }
 
     return GCI_Undefined;


### PR DESCRIPTION
## What does this PR do?
GBDX Auth was updated and now no longer requires client_id or client_secret creds (GBDX_CLIENT_ID or GBDX_CLIENT_SECRET) when fetching bearer tokens.

https://gbdxdocs.digitalglobe.com/docs/authentication-changes

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
