### PR TITLE
Fix leak in ogrgeometrycollection.cpp getLinearGeometry

### DIFF
--- a/gdal/ogr/ogrgeometrycollection.cpp
+++ b/gdal/ogr/ogrgeometrycollection.cpp
@@ -1329,7 +1329,8 @@ OGRGeometry* OGRGeometryCollection::getLinearGeometry(
         OGRGeometry* poSubGeom =
             papoGeoms[iGeom]->getLinearGeometry(dfMaxAngleStepSizeDegrees,
                                                 papszOptions);
-        poGC->addGeometryDirectly( poSubGeom );
+        if( poGC->addGeometryDirectly(poSubGeom) != OGRERR_NONE )
+            delete poSubGeom;
     }
     return poGC;
 }


### PR DESCRIPTION
poSubGeom must be deleted if it fails being added directly.

Found with autofuzz