### PR TITLE
Catch CompileError only in setup.py

### DIFF
--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -129,7 +129,7 @@ class gdal_config_error(Exception): pass
 
 from distutils.command.build_ext import build_ext
 from distutils.ccompiler import get_default_compiler
-
+from distutils.errors import CompileError
 
 def fetch_config(option, gdal_config='gdal-config'):
 

--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -218,7 +218,7 @@ int main () { return 0; }""")
             try:
                 compiler.compile([f.name], extra_postargs=extra_postargs)
                 ret = True
-            except:
+            except CompileError:
                 pass
     os.unlink('gdal_python_cxx11_test.cpp')
     if os.path.exists('gdal_python_cxx11_test.o'):


### PR DESCRIPTION
## What does this PR do?

It's not very Pythonic to catch all exceptions with a bare `except` statement. The only thing we are trying to detect here is a compilation error, so we should catch `CompileError` only. All other exceptions should propagate back up the call stack for more helpful diagnostics.
