### PR TITLE
Simplify gdal/scripts/check_broken_links.py

### DIFF
--- a/gdal/scripts/check_broken_links.py
+++ b/gdal/scripts/check_broken_links.py
@@ -63,17 +63,12 @@ def check(filename):
                 print('ERROR: Broken link %s in %s' % (url, filename))
             print('Checking %s...' % url)
             if url.startswith('http'):
-                ok = False
-                try:
-                    r = requests.get(url, verify=False)
-                    ok = r.status_code == 200
-                except:
-                    pass
-                if not ok:
+                r = requests.get(url, verify=False)
+                if r.status_code == requests.codes.ok:
+                    ok_set[url] = True
+                else:
                     print('ERROR: Broken link %s in %s' % (url, filename))
                     broken_set[url] = True
-                else:
-                    ok_set[url] = True
             else:
                 checked_filename = os.path.join(os.path.dirname(filename), url)
                 # print(checked_filename)


### PR DESCRIPTION
## What does this PR do?

This PR simplifies the `check` function in `check_broken_links.py`. The change now checks the HTTP response against `requests.codes.ok`, not `200`. The `requests.get()` method does not raise exceptions for HTTP errors (just check `r.status_code`), so it is better to not catch any exceptions here. This eliminates a `flake8` warning about a catching a bare exception.