### PR TITLE
Avoid bare exceptions where possible

### DIFF
--- a/gdal/swig/python/samples/classify.py
+++ b/gdal/swig/python/samples/classify.py
@@ -31,7 +31,7 @@ from osgeo import gdal
 import gdalnumeric
 try:
     import numpy
-except:
+except ImportError:
     import Numeric as numpy
 
 

--- a/gdal/swig/python/samples/crs2crs2grid.py
+++ b/gdal/swig/python/samples/crs2crs2grid.py
@@ -360,7 +360,7 @@ if __name__ == '__main__':
     # Run htdp to transform the data.
     try:
       os.unlink( out_grid_fn )
-    except:
+    except OSError:
       pass
 
     rc = os.system( htdp_path + ' < ' + control_fn )

--- a/gdal/swig/python/samples/gdal_lut.py
+++ b/gdal/swig/python/samples/gdal_lut.py
@@ -36,7 +36,7 @@ gdal.TermProgress = gdal.TermProgress_nocb
 
 try:
     import numpy
-except:
+except ImportError:
     import Numeric as numpy
     numpy.arange = numpy.arrayrange
 

--- a/gdal/swig/python/samples/magphase.py
+++ b/gdal/swig/python/samples/magphase.py
@@ -31,7 +31,7 @@ from osgeo import gdal
 import gdalnumeric
 try:
     import numpy
-except:
+except ImportError:
     import Numeric as numpy
 
 

--- a/gdal/swig/python/samples/ogr2ogr.py
+++ b/gdal/swig/python/samples/ogr2ogr.py
@@ -608,12 +608,12 @@ def main(args = None, progress_func = TermProgress, progress_data = None):
 
             try:
                 os.stat(pszDestDataSource)
-            except:
+            except OSError:
                 try:
                     # decimal 493 = octal 0755. Python 3 needs 0o755, but
                     # this syntax is only supported by Python >= 2.6
                     os.mkdir(pszDestDataSource, 493)
-                except:
+                except OSError:
                     print("Failed to create directory %s\n"
                           "for shapefile datastore.\n" % pszDestDataSource )
                     return False

--- a/gdal/swig/python/samples/validate_gpkg.py
+++ b/gdal/swig/python/samples/validate_gpkg.py
@@ -40,7 +40,7 @@ import sys
 try:
     from osgeo import gdal
     has_gdal = True
-except:
+except ImportError:
     has_gdal = False
 
 
@@ -285,7 +285,7 @@ class GPKGChecker:
             try:
                 datetime.datetime.strptime(
                     last_change, '%Y-%m-%dT%H:%M:%S.%fZ')
-            except:
+            except ValueError:
                 self._assert(False, 15,
                              ('last_change = %s for table_name = %s ' +
                               'is invalid datetime') %
@@ -1440,7 +1440,7 @@ class GPKGChecker:
         for (timestamp, ) in rows:
             try:
                 datetime.datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
-            except:
+            except ValueError:
                 self._assert(False, 100,
                              ('timestamp = %s in gpkg_metadata_reference' +
                               'is invalid datetime') % (timestamp))

--- a/gdal/swig/python/samples/validate_jp2.py
+++ b/gdal/swig/python/samples/validate_jp2.py
@@ -419,7 +419,7 @@ def validate(filename, oidoc, inspire_tg, expected_gmljp2, ogc_schemas_location,
                 try:
                     import xmlvalidate
                     xml_validate_found = True
-                except:
+                except ImportError:
                     error_report.EmitWarning('GMLJP2', 'xmlvalidate not found or not runnable')
                     xml_validate_found = False
                 if xml_validate_found:
@@ -1225,11 +1225,11 @@ def main():
     if ogc_schemas_location is not None:
         try:
             os.stat('%s/xml.xsd' % ogc_schemas_location)
-        except:
+        except OSError:
             try:
                 os.stat('%s/SCHEMAS_OPENGIS_NET/xml.xsd' % ogc_schemas_location)
                 ogc_schemas_location = '%s/SCHEMAS_OPENGIS_NET' % ogc_schemas_location
-            except:
+            except OSError:
                 print('Cannot find %s/xml.xsd. -ogc_schemas_location value is probably wrong' % ogc_schemas_location)
                 return 1
 

--- a/gdal/swig/python/scripts/gdalcompare.py
+++ b/gdal/swig/python/scripts/gdalcompare.py
@@ -281,7 +281,7 @@ if __name__ == '__main__':
     if not filecmp.cmp(golden_file,new_file):
       print('Files differ at the binary level.')
       found_diff += 1
-  except:
+  except OSError:
     print('Skipped binary file comparison, golden file not in filesystem.')
 
   # compare as GDAL Datasets.

--- a/gdal/swig/python/scripts/gdalident.py
+++ b/gdal/swig/python/scripts/gdalident.py
@@ -62,7 +62,7 @@ def ProcessTarget( target, recursive, report_failure, filelist = None ):
     if recursive and driver is None:
         try:
             mode = os.stat(target)[stat.ST_MODE]
-        except:
+        except OSError:
             mode = 0
 
         if stat.S_ISDIR(mode):


### PR DESCRIPTION
## What does this PR do?

Bare exceptions (where `except` does not specify an exception type) should be avoided because they undermine the exception system by catching every exception type. Many of the `except` statements in the Python code can be restricted to specific types (eg `OSError`, `ImportError`, etc).