### PR TITLE
Python code: Do not compare types, use isinstance()

### DIFF
--- a/autotest/gcore/pam.py
+++ b/autotest/gcore/pam.py
@@ -62,7 +62,7 @@ def pam_1():
         gdaltest.post_reason( 'xml:test metadata missing' )
         return 'fail'
 
-    if type(xml_md) != type(['abc']):
+    if not isinstance(xml_md, list):
         gdaltest.post_reason( 'xml:test metadata not returned as list.' )
         return 'fail'
 
@@ -120,7 +120,7 @@ def pam_3():
         gdaltest.post_reason( 'xml:test metadata missing' )
         return 'fail'
 
-    if type(xml_md) != type(['abc']):
+    if not isinstance(xml_md, list):
         gdaltest.post_reason( 'xml:test metadata not returned as list.' )
         return 'fail'
 

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -1252,7 +1252,7 @@ def grib_grib2_write_data_encodings():
         nd = out_ds.GetRasterBand(1).GetNoDataValue()
         out_ds = None
         gdal.Unlink(tmpfilename)
-        if not isinstace(expected_cs, tuple):
+        if not isinstance(expected_cs, tuple):
             expected_cs = (expected_cs,)
         if cs not in expected_cs:
             gdaltest.post_reason('did not get expected checksum for %s, %s' % (str(filename), str(options)))
@@ -1260,7 +1260,7 @@ def grib_grib2_write_data_encodings():
             return 'fail'
 
         if section5_template_number in (GS5_CMPLX, GS5_CMPLXSEC):
-            if isinstace(filename, str):
+            if isinstance(filename, str):
                 ref_ds = gdal.Open(filename)
             else:
                 ref_ds = filename

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -1252,7 +1252,7 @@ def grib_grib2_write_data_encodings():
         nd = out_ds.GetRasterBand(1).GetNoDataValue()
         out_ds = None
         gdal.Unlink(tmpfilename)
-        if type(expected_cs) != type((1,)):
+        if not isinstace(expected_cs, tuple):
             expected_cs = (expected_cs,)
         if cs not in expected_cs:
             gdaltest.post_reason('did not get expected checksum for %s, %s' % (str(filename), str(options)))
@@ -1260,7 +1260,7 @@ def grib_grib2_write_data_encodings():
             return 'fail'
 
         if section5_template_number in (GS5_CMPLX, GS5_CMPLXSEC):
-            if type(filename) == type(''):
+            if isinstace(filename, str):
                 ref_ds = gdal.Open(filename)
             else:
                 ref_ds = filename
@@ -1407,7 +1407,7 @@ def grib_grib2_write_data_encodings_warnings_and_errors():
 
         out_ds = None
         gdal.Unlink(tmpfilename)
-        if type(expected_cs) != type((1,)):
+        if not isinstance(expected_cs, tuple):
             expected_cs = (expected_cs,)
         if cs not in expected_cs:
             gdaltest.post_reason('did not get expected checksum for %s, %s' % (str(filename), str(options)))

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -747,7 +747,7 @@ for item in init_list:
     if item[3]:
         options = item[3]
     chksum_param = item[2]
-    if type(chksum_param) == type([]):
+    if isinstance(chksum_param, list):
         chksum = chksum_param[0]
         chksum_after_reopening = chksum_param[1]
     else:

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -1123,7 +1123,7 @@ class CFChecker:
 
     for attribute in ['title','history','institution','source','reference','comment']:
         if self.f.attributes.has_key(attribute):
-            if type(self.f.attributes[attribute]) != types.StringType:
+            if not isinstance(self.f.attributes[attribute], str):
                 print("ERROR (2.6.2): Global attribute",attribute,"must be of type 'String'")
                 self.err = self.err+1
     return rc
@@ -1321,13 +1321,13 @@ class CFChecker:
 
         attrType=type(value)
 
-        if attrType == types.StringType:
+        if isinstance(value, str):
             attrType='S'
-        elif attrType == types.IntType or attrType == types.FloatType:
+        elif isinstance(value, int) or isinstance(value, float):
             attrType='N'
-        elif attrType == type(numpy.array([])):
+        elif isinstance(value, numpy.ndarray):
             attrType='N'
-        elif attrType == types.NoneType:
+        elif isinstance(value, type(None)):
             #attrType=self.AttrList[attribute][0]
             attrType='NoneType'
         else:
@@ -1842,7 +1842,7 @@ class CFChecker:
       if var.attributes.has_key('units') and var.attributes['units'] != '':
           # Type of units is a string
           units = var.attributes['units']
-          if type(units) != types.StringType:
+          if not isinstance(units, str):
               print("ERROR (3.1): units attribute must be of type 'String'")
               self.err = self.err+1
               # units not a string so no point carrying out further tests
@@ -2449,7 +2449,7 @@ class CFChecker:
   #-----------------------
   def getType(self, arg):
   #-----------------------
-      if type(arg) == type(numpy.array([])):
+      if isinstance(arg, numpy.ndarray):
           return "array"
 
       elif type(arg) == str:

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -48,7 +48,7 @@ Options:
 
 '''
 
-import cdms2 as cdms, re, string, types, numpy
+import cdms2 as cdms, re, string, numpy
 import sys
 
 from cdms2.axis import FileAxis

--- a/autotest/gdrivers/rraster.py
+++ b/autotest/gdrivers/rraster.py
@@ -81,7 +81,7 @@ def rraster_1_copy():
 
 ###############################################################################
 def _compare_val(got, expected, key_name, to_print):
-    if type(got) == type([]) and type(expected) == type([]):
+    if isinstance(got, list) and isinstance(expected, list):
         if len(got) != len(expected):
             print('Unexpected number of elements for %s. Got %d, expected %d' % (key_name, len(got), len(expected)))
             pprint.pprint(to_print)
@@ -89,7 +89,7 @@ def _compare_val(got, expected, key_name, to_print):
         for idx in range(len(got)):
             if not _compare_val(got[idx], expected[idx], '%s[%d]' % (key_name, idx), to_print):
                 return False
-    elif type(got) == type({}) and type(expected) == type({}):
+    elif isinstance(got, dict) and isinstance(expected, dict):
         if not _is_dict_included_in_dict(got, expected, key_name, to_print):
             pprint.pprint(to_print)
             return False

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -382,7 +382,7 @@ class GDALTest:
         self.band = band
         self.chksum = chksum
         if chksum_after_reopening is not None:
-            if type(chksum_after_reopening) == type([]):
+            if isinstance(chksum_after_reopening, list):
                 self.chksum_after_reopening = chksum_after_reopening
             else:
                 self.chksum_after_reopening = [ chksum_after_reopening ]


### PR DESCRIPTION
## What does this PR do?

It is more Pythonically correct to use `isinstance()` rather than compare types directly. It leads to more readable code, to boot.