### PR TITLE
Python code: '<>' is deprecated, use '!='

### DIFF
--- a/gdal/swig/include/python/docs/doxy2swig.py
+++ b/gdal/swig/include/python/docs/doxy2swig.py
@@ -186,7 +186,7 @@ class Doxy2SWIG:
         kind = node.attributes['kind'].value
         if kind in ('class', 'struct'):
             prot = node.attributes['prot'].value
-            if prot <> 'public':
+            if prot != 'public':
                 return
             names = ('compoundname', 'briefdescription',
                      'detaileddescription', 'includes')


### PR DESCRIPTION
## What does this PR do?

Removes the single, deprecated occurrence of `<>` in the Python code.