### PR TITLE
Python code: adjust comparisons to None

### DIFF
--- a/autotest/gcore/overviewds.py
+++ b/autotest/gcore/overviewds.py
@@ -118,7 +118,7 @@ def overviewds_2():
     if len(ds.GetMetadata('GEOLOCATION')) != 0:
         gdaltest.post_reason('fail')
         return 'fail'
-    if ds.GetMetadataItem('RPC', 'FOO') != None:
+    if ds.GetMetadataItem('RPC', 'FOO') is not None:
         gdaltest.post_reason('fail')
         return 'fail'
     ds = None

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2109,7 +2109,7 @@ def tiff_write_56():
     ds = gdal.Open( 'tmp/tiff_write_56.tif' )
     ct = ds.GetRasterBand(1).GetRasterColorTable()
 
-    if ct != None:
+    if ct is not None:
         gdaltest.post_reason( 'color table seemingly not cleared.' )
         return 'fail'
 
@@ -3138,7 +3138,7 @@ def tiff_write_80():
 
     # Third part : test storing and retrieving scale & offsets from PAM metadata
     ds = gdaltest.tiff_drv.Create( 'tmp/tiff_write_80_bis.tif', 1, 1)
-    if ds.GetRasterBand(1).GetScale() != None or ds.GetRasterBand(1).GetOffset() != None:
+    if ds.GetRasterBand(1).GetScale() is not None or ds.GetRasterBand(1).GetOffset() is not None:
         gdaltest.post_reason('expected None values')
         return 'fail'
     ds = None
@@ -3477,7 +3477,7 @@ def tiff_write_86():
                'tmp/tiff_write_86.tif.aux.xml.hidden' )
 
     ds = gdal.Open( 'tmp/tiff_write_86.tif' )
-    if ds.GetMetadata( 'xml:ESRI' ) != None:
+    if ds.GetMetadata( 'xml:ESRI' ) is not None:
         print(ds.GetMetadata( 'xml:ESRI' ))
         gdaltest.post_reason( 'unexpectedly got xml:ESRI metadata' )
         return 'fail'
@@ -3516,7 +3516,7 @@ def tiff_write_86():
     os.remove( 'tmp/tiff_write_86_cc.tif.aux.xml' )
 
     ds = gdal.Open( 'tmp/tiff_write_86_cc.tif' )
-    if ds.GetMetadata( 'xml:ESRI' ) != None:
+    if ds.GetMetadata( 'xml:ESRI' ) is not None:
         print(ds.GetMetadata( 'xml:ESRI' ))
         gdaltest.post_reason( 'unexpectedly got xml:ESRI metadata(2)' )
         return 'fail'
@@ -4006,7 +4006,7 @@ def tiff_write_95():
     gdal.SetConfigOption('GTIFF_DONT_WRITE_BLOCKS', 'YES')
     ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_95_dst.tif', src_ds, options = ['COPY_SRC_OVERVIEWS=YES'])
     gdal.SetConfigOption('GTIFF_DONT_WRITE_BLOCKS', None)
-    ok = ds != None
+    ok = ds is not None
     ds = None
     src_ds = None
 

--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -250,7 +250,7 @@ def vsizip_2():
         gdaltest.post_reason('expected error')
         print(gdal.GetLastErrorMsg())
         return 'fail'
-    if content != None:
+    if content is not None:
         gdaltest.post_reason('bad content 2')
         print(content)
         return 'fail'

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -81,7 +81,7 @@ def ecw_1():
     gdaltest.ecw_write = 0
 
     if gdaltest.ecw_drv is not None:
-        if gdaltest.ecw_drv.GetMetadataItem('DMD_CREATIONDATATYPES') != None:
+        if gdaltest.ecw_drv.GetMetadataItem('DMD_CREATIONDATATYPES') is not None:
             gdaltest.ecw_write = 1
 
         longname = gdaltest.ecw_drv.GetMetadataItem('DMD_LONGNAME')

--- a/autotest/gdrivers/ehdr.py
+++ b/autotest/gdrivers/ehdr.py
@@ -255,10 +255,10 @@ def ehdr_13():
     src_ds = None
 
     ds = gdal.Open('/vsimem/byte.bil')
-    if ds.GetRasterBand(1).GetMinimum() != None:
+    if ds.GetRasterBand(1).GetMinimum() is not None:
         gdaltest.post_reason('did not expected minimum')
         return 'fail'
-    if ds.GetRasterBand(1).GetMaximum() != None:
+    if ds.GetRasterBand(1).GetMaximum() is not None:
         gdaltest.post_reason('did not expected maximum')
         return 'fail'
     stats = ds.GetRasterBand(1).GetStatistics(False, True)

--- a/autotest/gdrivers/hfa.py
+++ b/autotest/gdrivers/hfa.py
@@ -953,7 +953,7 @@ def hfa_delete_colortable():
 
     # check color table gone.
     ds = gdal.Open( 'tmp/i8u.img' )
-    if ds.GetRasterBand(1).GetColorTable() != None:
+    if ds.GetRasterBand(1).GetColorTable() is not None:
         gdaltest.post_reason( 'failed to remove color table' )
         return 'fail'
 
@@ -992,7 +992,7 @@ def hfa_delete_colortable2():
 
     # check color table gone.
     ds = gdal.Open( 'tmp/hfa_delete_colortable2.img' )
-    if ds.GetRasterBand(1).GetColorTable() != None:
+    if ds.GetRasterBand(1).GetColorTable() is not None:
         gdaltest.post_reason( 'failed to remove color table' )
         return 'fail'
 

--- a/autotest/gdrivers/lcp.py
+++ b/autotest/gdrivers/lcp.py
@@ -237,7 +237,7 @@ def lcp_2():
 def lcp_3():
 
     ds = gdal.Open('data/test_USGS_LFNM_Alb83.lcp')
-    if ds == None:
+    if ds is None:
         return 'fail'
     wkt = ds.GetProjection()
     if wkt is None:
@@ -251,7 +251,7 @@ def lcp_3():
 def lcp_4():
 
     ds = gdal.Open('data/test_USGS_LFNM_Alb83.lcp')
-    if ds == None:
+    if ds is None:
         return 'fail'
     fl = ds.GetFileList()
     if len(fl) != 1:
@@ -265,7 +265,7 @@ def lcp_4():
 def lcp_5():
 
     ds = gdal.Open('data/test_FARSITE_UTM12.LCP')
-    if ds == None:
+    if ds is None:
         return 'fail'
     wkt = ds.GetProjection()
     if wkt is None or wkt == '':
@@ -280,7 +280,7 @@ def lcp_6():
 
     retval = 'success'
     ds = gdal.Open('data/test_FARSITE_UTM12.LCP')
-    if ds == None:
+    if ds is None:
         return 'fail'
     fl = ds.GetFileList()
     if len(fl) != 2:
@@ -300,20 +300,20 @@ def lcp_6():
 def lcp_7():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     lcp_drv = gdal.GetDriverByName('LCP')
-    if lcp_drv == None:
+    if lcp_drv is None:
         return 'fail'
     # Make sure all available band counts work.
     retval = 'success'
     co = ['LATITUDE=0', 'LINEAR_UNIT=METER']
     for i in [5, 7, 8, 10]:
         src_ds = mem_drv.Create('/vsimem/lcptest', 10, 20, i, gdal.GDT_Int16)
-        if src_ds == None:
+        if src_ds is None:
             return 'fail'
         dst_ds = lcp_drv.CreateCopy('tmp/lcp_7.lcp', src_ds, False, co)
-        if dst_ds == None:
+        if dst_ds is None:
             gdaltest.post_reason('Failed to create lcp with %d bands' % i)
             retval = 'fail'
             break
@@ -335,22 +335,22 @@ def lcp_7():
 def lcp_8():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     lcp_drv = gdal.GetDriverByName('LCP')
-    if lcp_drv == None:
+    if lcp_drv is None:
         return 'fail'
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     retval = 'success'
     co = ['LATITUDE=0', 'LINEAR_UNIT=METER']
     for i in [0,1,2,3,4,6,9,11]:
         src_ds = mem_drv.Create('', 10, 10, i, gdal.GDT_Int16)
-        if src_ds == None:
+        if src_ds is None:
             retval = 'fail'
             break
         dst_ds = lcp_drv.CreateCopy('tmp/lcp_8.lcp', src_ds, False, co)
         src_ds = None
-        if dst_ds != None:
+        if dst_ds is not None:
             gdaltest.post_reason('Created invalid lcp')
             retval = 'fail'
             dst_ds = None
@@ -370,18 +370,18 @@ def lcp_8():
 def lcp_9():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     lcp_drv = gdal.GetDriverByName('LCP')
-    if lcp_drv == None:
+    if lcp_drv is None:
         return 'fail'
     src_ds = mem_drv.Create('', 10, 20, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
     retval = 'success'
     co = ['LATITUDE=0', 'LINEAR_UNIT=METER']
     lcp_ds = lcp_drv.CreateCopy('tmp/lcp_9.lcp', src_ds, False, co)
-    if lcp_ds == None:
+    if lcp_ds is None:
         return 'fail'
     lcp_ds = None
     for ext in ['lcp', 'lcp.aux.xml']:
@@ -397,20 +397,20 @@ def lcp_9():
 def lcp_10():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     for option in ['METERS', 'FEET']:
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'ELEVATION_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_10.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(1).GetMetadataItem("ELEVATION_UNIT_NAME")
@@ -436,20 +436,20 @@ def lcp_10():
 def lcp_11():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     for option in ['DEGREES', 'PERCENT']:
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'SLOPE_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_11.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(2).GetMetadataItem("SLOPE_UNIT_NAME")
@@ -475,20 +475,20 @@ def lcp_11():
 def lcp_12():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     for option in ['GRASS_CATEGORIES', 'AZIMUTH_DEGREES', 'GRASS_DEGREES']:
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'ASPECT_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_12.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(3).GetMetadataItem("ASPECT_UNIT_NAME")
@@ -513,20 +513,20 @@ def lcp_12():
 def lcp_13():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     for option in ['PERCENT', 'CATEGORIES']:
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'CANOPY_COV_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_13.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(5).GetMetadataItem("CANOPY_COV_UNIT_NAME")
@@ -552,20 +552,20 @@ def lcp_13():
 def lcp_14():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     for option in ['METERS', 'FEET', 'METERS_X_10', 'FEET_X_10']:
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'CANOPY_HT_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_14.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(6).GetMetadataItem("CANOPY_HT_UNIT_NAME")
@@ -591,20 +591,20 @@ def lcp_14():
 def lcp_15():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     for option in ['METERS', 'FEET', 'METERS_X_10', 'FEET_X_10']:
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'CBH_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_15.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(7).GetMetadataItem("CBH_UNIT_NAME")
@@ -630,13 +630,13 @@ def lcp_15():
 def lcp_16():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
@@ -647,7 +647,7 @@ def lcp_16():
                                 'POUND_PER_CUBIC_FOOT_X_1000']):
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'CBD_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_16.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(8).GetMetadataItem("CBD_UNIT_NAME")
@@ -675,13 +675,13 @@ def lcp_16():
 def lcp_17():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
@@ -689,7 +689,7 @@ def lcp_17():
     for i, option in enumerate(['MG_PER_HECTARE_X_10', 'TONS_PER_ACRE_X_10']):
         co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'DUFF_UNIT=%s' % option]
         lcp_ds = drv.CreateCopy('tmp/lcp_17.lcp', src_ds, False, co)
-        if lcp_ds == None:
+        if lcp_ds is None:
             retval = 'fail'
             break
         units = lcp_ds.GetRasterBand(9).GetMetadataItem("DUFF_UNIT_NAME")
@@ -715,19 +715,19 @@ def lcp_17():
 def lcp_18():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     co = ['LATITUDE=45', 'LINEAR_UNIT=METER']
     lcp_ds = drv.CreateCopy('tmp/lcp_18.lcp', src_ds, False, co)
-    if lcp_ds == None:
+    if lcp_ds is None:
         retval = 'fail'
     if lcp_ds.GetMetadataItem('LATITUDE') != '45':
         gdaltest.post_reason('Failed to set LATITUDE creation option')
@@ -748,19 +748,19 @@ def lcp_18():
 def lcp_19():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     co = ['LATITUDE=0', 'LINEAR_UNIT=FOOT']
     lcp_ds = drv.CreateCopy('tmp/lcp_19.lcp', src_ds, False, co)
-    if lcp_ds == None:
+    if lcp_ds is None:
         retval = 'fail'
     if lcp_ds.GetMetadataItem('LINEAR_UNIT') != 'Feet':
         gdaltest.post_reason('Failed to set LINEAR_UNIT creation option')
@@ -782,20 +782,20 @@ def lcp_19():
 def lcp_20():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
     desc = 'test description'
     co = ['LATITUDE=0', 'LINEAR_UNIT=METER', 'DESCRIPTION=%s' % desc]
     lcp_ds = drv.CreateCopy('tmp/lcp_20.lcp', src_ds, False, co)
-    if lcp_ds == None:
+    if lcp_ds is None:
         retval = 'fail'
     if lcp_ds.GetMetadataItem('DESCRIPTION') != desc:
         gdaltest.post_reason('Failed to set DESCRIPTION creation option')
@@ -820,13 +820,13 @@ def lcp_21():
     except ImportError:
         return 'skip'
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 3, 3, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     for i in range(10):
@@ -835,7 +835,7 @@ def lcp_21():
 
     co = ['LATITUDE=0', 'LINEAR_UNIT=METER']
     lcp_ds = drv.CreateCopy('tmp/lcp_21.lcp', src_ds, False, co)
-    if lcp_ds == None:
+    if lcp_ds is None:
         retval = 'fail'
     retval = 'success'
     for i in range(10):
@@ -864,13 +864,13 @@ def lcp_22():
     except ImportError:
         return 'skip'
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 3, 3, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     for i in range(10):
@@ -880,7 +880,7 @@ def lcp_22():
     retval = 'success'
     co = ['LATITUDE=0', 'LINEAR_UNIT=METER']
     lcp_ds = drv.CreateCopy('tmp/lcp_22.lcp', src_ds, False, co)
-    if lcp_ds == None:
+    if lcp_ds is None:
         return 'fail'
     retval = 'success'
     for i in range(10):
@@ -906,13 +906,13 @@ def lcp_22():
 def lcp_23():
 
     mem_drv = gdal.GetDriverByName('MEM')
-    if mem_drv == None:
+    if mem_drv is None:
         return 'fail'
     drv = gdal.GetDriverByName('LCP')
-    if drv == None:
+    if drv is None:
         return 'fail'
     src_ds = mem_drv.Create('/vsimem/', 10, 10, 10, gdal.GDT_Int16)
-    if src_ds == None:
+    if src_ds is None:
         return 'fail'
 
     retval = 'success'
@@ -923,7 +923,7 @@ def lcp_23():
                    'CBH_UNIT', 'CBD_UNIT', 'DUFF_UNIT']:
         co = ['%s=%s' % (option, bad),]
         lcp_ds = drv.CreateCopy('tmp/lcp_23.lcp', src_ds, False, co)
-        if lcp_ds != None:
+        if lcp_ds is not None:
             retval = 'fail'
     gdal.PopErrorHandler()
 

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -578,7 +578,7 @@ def netcdf_13():
     scale = ds.GetRasterBand( 1 ).GetScale()
     offset = ds.GetRasterBand( 1 ).GetOffset()
 
-    if scale != None or offset != None:
+    if scale is not None or offset is not None:
         gdaltest.post_reason( 'Incorrect scale or offset' )
         return 'fail'
 
@@ -1090,7 +1090,7 @@ def netcdf_test_4dfile( ofile ):
     except:
         print('NOTICE: ncdump not found')
         return 'success'
-    if err == None or not 'netcdf library version' in err:
+    if err is None or not 'netcdf library version' in err:
         print('NOTICE: ncdump not found')
         return 'success'
     (ret, err) = gdaltest.runexternal_out_and_err( 'ncdump -h '+ ofile )

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -2142,7 +2142,7 @@ class CFChecker:
 #          print "interp:",interp
 #          print "axis:",var.axis
 
-          if interp != None:
+          if interp is not None:
               # It was possible to deduce axis interpretation from units/positive
               if interp != var.axis:
                   print("ERROR (4): axis attribute inconsistent with coordinate type as deduced from units and/or positive")

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -3400,7 +3400,7 @@ def nitf_online_16(driver_to_test):
 
     elif ds.RasterCount == 1 and \
        ds.GetRasterBand(1).Checksum() == 47664 and \
-       ds.GetRasterBand(1).GetRasterColorTable() != None:
+       ds.GetRasterBand(1).GetRasterColorTable() is not None:
         ret = 'success'
     else:
         print(ds.RasterCount)
@@ -3451,7 +3451,7 @@ def nitf_online_17(driver_to_test):
     ds = gdal.Open('tmp/cache/file9_j2c.ntf')
     if ds.RasterCount == 1 and \
        ds.GetRasterBand(1).Checksum() == 47664 and \
-       ds.GetRasterBand(1).GetRasterColorTable() != None:
+       ds.GetRasterBand(1).GetRasterColorTable() is not None:
         ret = 'success'
     else:
         print(ds.RasterCount)

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -808,7 +808,7 @@ def pdf_update_info():
     author = ds.GetMetadataItem('AUTHOR')
     ds = None
 
-    if author != None:
+    if author is not None:
         gdaltest.post_reason('did not get expected metadata')
         print(author)
         return 'fail'
@@ -875,7 +875,7 @@ def pdf_update_xmp():
     xmp = ds.GetMetadata('xml:XMP')
     ds = None
 
-    if xmp != None:
+    if xmp is not None:
         gdaltest.post_reason('did not get expected metadata')
         print(xmp)
         return 'fail'

--- a/autotest/ogr/ogr_couchdb.py
+++ b/autotest/ogr/ogr_couchdb.py
@@ -123,7 +123,7 @@ def ogr_couchdb_2():
         return 'fail'
 
     f = lyr.GetNextFeature()
-    if f['str_field'] != None:
+    if f['str_field'] is not None:
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'

--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -2483,7 +2483,7 @@ def ogr_dxf_33():
     # 3DSOLID, plain
     feat = layer.GetNextFeature()
 
-    if feat.GetGeometryRef() != None:
+    if feat.GetGeometryRef() is not None:
         feat.DumpReadable()
         gdaltest.post_reason( 'geometry on first 3DSOLID was not empty' )
         return 'fail'
@@ -2506,7 +2506,7 @@ def ogr_dxf_33():
     # 3DSOLID inside a block
     feat = layer.GetNextFeature()
 
-    if feat.GetGeometryRef() != None:
+    if feat.GetGeometryRef() is not None:
         feat.DumpReadable()
         gdaltest.post_reason( 'geometry on second 3DSOLID was not empty' )
         return 'fail'

--- a/autotest/ogr/ogr_elasticsearch.py
+++ b/autotest/ogr/ogr_elasticsearch.py
@@ -2314,7 +2314,7 @@ def ogr_elasticsearch_11():
         return 'fail'
 
     f = lyr.GetNextFeature()
-    if f['str_field'] != None:
+    if f['str_field'] is not None:
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -159,7 +159,7 @@ def ogr_fgdb_1():
         # We need at least 5 features so that test_ogrsf can test SetFeature()
         for i in range(5):
             feat = ogr.Feature(lyr.GetLayerDefn())
-            if data[1] != ogr.wkbNone and data[2] != None:
+            if data[1] != ogr.wkbNone and data[2] is not None:
                 feat.SetGeometry(ogr.CreateGeometryFromWkt(data[2]))
             feat.SetField("id", i + 1)
             feat.SetField("str", "foo_\xc3\xa9")

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -4155,7 +4155,7 @@ def ogr_gml_80():
         return 'fail'
 
     f = lyr.GetNextFeature()
-    if f['int_field'] != None:
+    if f['int_field'] is not None:
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'

--- a/autotest/ogr/ogr_gtm.py
+++ b/autotest/ogr/ogr_gtm.py
@@ -140,7 +140,7 @@ def ogr_gtm_read_1():
         gdaltest.post_reason( 'Wrong icon field value' )
         return 'fail'
 
-    if feat.GetField('time') != None:
+    if feat.GetField('time') is not None:
         gdaltest.post_reason( 'Wrong time field value' )
         return 'fail'
 
@@ -181,7 +181,7 @@ def ogr_gtm_read_2():
         gdaltest.post_reason( 'Wrong color field value' )
         return 'fail'
 
-    #if feat.GetField('time') != None:
+    #if feat.GetField('time') is not None:
     #    gdaltest.post_reason( 'Wrong time field value' )
     #    return 'fail'
 
@@ -208,7 +208,7 @@ def ogr_gtm_read_2():
         gdaltest.post_reason( 'Wrong color field value' )
         return 'fail'
 
-    #if feat.GetField('time') != None:
+    #if feat.GetField('time') is not None:
     #    gdaltest.post_reason( 'Wrong time field value' )
     #    return 'fail'
 
@@ -234,7 +234,7 @@ def ogr_gtm_read_2():
         gdaltest.post_reason( 'Wrong color field value' )
         return 'fail'
 
-    #if feat.GetField('time') != None:
+    #if feat.GetField('time') is not None:
     #    gdaltest.post_reason( 'Wrong time field value' )
     #    return 'fail'
 
@@ -367,7 +367,7 @@ def ogr_gtm_check_write_1():
         gdaltest.post_reason( 'Wrong icon field value' )
         return 'fail'
 
-    if feat.GetField('time') != None:
+    if feat.GetField('time') is not None:
         gdaltest.post_reason( 'Wrong time field value' )
         return 'fail'
 

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -159,7 +159,7 @@ def ogr_libkml_attributes_2():
         gdaltest.post_reason( 'Wrong name field value' )
         return 'fail'
 
-    if feat.GetField('description') != None:
+    if feat.GetField('description') is not None:
         gdaltest.post_reason( 'Wrong description field value' )
         print("'%s'" % feat.GetField('description'))
         return 'fail'
@@ -237,7 +237,7 @@ def ogr_libkml_attributes_4():
             print('Got: "%s"' % feat.GetField('name'))
             return 'fail'
 
-        if feat.GetField('description') != None:
+        if feat.GetField('description') is not None:
             gdaltest.post_reason( 'Wrong description field value' )
             return 'fail'
 

--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -291,7 +291,7 @@ def ogr_mysql_6():
         gdaltest.post_reason( 'GetFeatureCount() returned %d instead of 0' % sql_lyr.GetFeatureCount() )
         return 'fail'
 
-    if sql_lyr.GetNextFeature() != None:
+    if sql_lyr.GetNextFeature() is not None:
         gdaltest.post_reason( 'GetNextFeature() did not return None' )
         return 'fail'
 

--- a/autotest/ogr/ogr_ods.py
+++ b/autotest/ogr/ogr_ods.py
@@ -60,7 +60,7 @@ def ogr_ods_check(ds):
         gdaltest.post_reason('bad layer geometry type')
         return 'fail'
 
-    if lyr.GetSpatialRef() != None:
+    if lyr.GetSpatialRef() is not None:
         gdaltest.post_reason('bad spatial ref')
         return 'fail'
 
@@ -177,7 +177,7 @@ def ogr_ods_kspread_1():
         gdaltest.post_reason('bad layer geometry type')
         return 'fail'
 
-    if lyr.GetSpatialRef() != None:
+    if lyr.GetSpatialRef() is not None:
         gdaltest.post_reason('bad spatial ref')
         return 'fail'
 

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -129,7 +129,7 @@ def ogr_openfilegdb_make_test_data():
         # We need at least 5 features so that test_ogrsf can test SetFeature()
         for i in range(5):
             feat = ogr.Feature(lyr.GetLayerDefn())
-            if data[1] != ogr.wkbNone and data[2] != None:
+            if data[1] != ogr.wkbNone and data[2] is not None:
                 feat.SetGeometry(ogr.CreateGeometryFromWkt(data[2]))
             feat.SetField("id", i + 1)
             feat.SetField("str", "foo_\xc3\xa9")

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -378,7 +378,7 @@ def ogr_pg_6():
         gdaltest.post_reason( 'GetFeatureCount() returned %d instead of 0' % sql_lyr.GetFeatureCount() )
         return 'fail'
 
-    if sql_lyr.GetNextFeature() != None:
+    if sql_lyr.GetNextFeature() is not None:
         gdaltest.post_reason( 'GetNextFeature() did not return None' )
         return 'fail'
 
@@ -514,7 +514,7 @@ def ogr_pg_9():
     feat.Destroy()
 
     feat = gdaltest.pg_lyr.GetFeature( fid )
-    if feat.GetGeometryRef() != None:
+    if feat.GetGeometryRef() is not None:
         print(feat.GetGeometryRef())
         gdaltest.post_reason( 'Geometry update failed. null geometry expected' )
         return 'fail'
@@ -2214,7 +2214,7 @@ def ogr_pg_40():
         return 'skip'
 
     layer = gdaltest.pg_ds.GetLayerByName('tpoly')
-    if layer.GetFeature(0) != None:
+    if layer.GetFeature(0) is not None:
         return 'fail'
 
     return 'success'
@@ -3058,19 +3058,19 @@ def ogr_pg_56():
     lyr = ds.GetLayerByName('ogr_pg_56')
 
     feat = lyr.GetNextFeature()
-    if feat.GetField(0) != None or feat.GetField(1) != None:
+    if feat.GetField(0) is not None or feat.GetField(1) is not None:
         gdaltest.post_reason('did not get expected value for feat %d' % feat.GetFID())
         feat.DumpReadable()
         return 'fail'
 
     feat = lyr.GetNextFeature()
-    if feat.GetField(0) != '' or feat.GetField(1) != None:
+    if feat.GetField(0) != '' or feat.GetField(1) is not None:
         gdaltest.post_reason('did not get expected value for feat %d' % feat.GetFID())
         feat.DumpReadable()
         return 'fail'
 
     feat = lyr.GetNextFeature()
-    if feat.GetField(0) != None or feat.GetField(1) != '':
+    if feat.GetField(0) is not None or feat.GetField(1) != '':
         gdaltest.post_reason('did not get expected value for feat %d' % feat.GetFID())
         feat.DumpReadable()
         return 'fail'

--- a/autotest/ogr/ogr_rfc41.py
+++ b/autotest/ogr/ogr_rfc41.py
@@ -52,7 +52,7 @@ def ogr_rfc41_1():
     if gfld_defn.GetType() != ogr.wkbUnknown:
         gdaltest.post_reason('fail')
         return 'fail'
-    if gfld_defn.GetSpatialRef() != None:
+    if gfld_defn.GetSpatialRef() is not None:
         gdaltest.post_reason('fail')
         return 'fail'
     if gfld_defn.IsIgnored() != 0:
@@ -80,7 +80,7 @@ def ogr_rfc41_1():
         return 'fail'
 
     gfld_defn.SetSpatialRef(None)
-    if gfld_defn.GetSpatialRef() != None:
+    if gfld_defn.GetSpatialRef() is not None:
         gdaltest.post_reason('fail')
         return 'fail'
 
@@ -205,7 +205,7 @@ def ogr_rfc41_2():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
         ret = feature_defn.GetGeomFieldDefn(idx)
         gdal.PopErrorHandler()
-        if ret != None:
+        if ret is not None:
             gdaltest.post_reason('fail')
             return 'fail'
 
@@ -336,7 +336,7 @@ def ogr_rfc41_3():
     if feature.SetGeomFieldDirectly(0, None) != 0:
         gdaltest.post_reason('fail')
         return 'fail'
-    if feature.GetGeomFieldRef(0) != None:
+    if feature.GetGeomFieldRef(0) is not None:
         gdaltest.post_reason('fail')
         return 'fail'
     if feature.Equal(feature_clone_with_geom):
@@ -530,17 +530,17 @@ def ogr_rfc41_5():
 
     f = ogr.Feature(feature_defn)
 
-    if f['strfield'] != None:
+    if f['strfield'] is not None:
         gdaltest.post_reason('fail')
         return 'fail'
-    if f.strfield != None:
+    if f.strfield is not None:
         gdaltest.post_reason('fail')
         return 'fail'
 
-    if f['geomfield'] != None:
+    if f['geomfield'] is not None:
         gdaltest.post_reason('fail')
         return 'fail'
-    if f.geomfield != None:
+    if f.geomfield is not None:
         gdaltest.post_reason('fail')
         return 'fail'
 
@@ -1026,7 +1026,7 @@ def ogr_rfc41_7():
        feat.area_int != 215229 or \
        abs(feat.area - 215229.266) > 1e-5 or \
        feat.geom1.GetGeometryType() != ogr.wkbPolygon or \
-       feat.geom2 != None or \
+       feat.geom2 is not None or \
        feat.geom3.GetGeometryType() != ogr.wkbPoint or \
        feat.geom4.GetGeometryType() != ogr.wkbPolygon or \
        feat['_ogr_geometry_'].GetGeometryType() != ogr.wkbPolygon:

--- a/autotest/ogr/ogr_segy.py
+++ b/autotest/ogr/ogr_segy.py
@@ -59,7 +59,7 @@ def ogr_segy_1():
         gdaltest.post_reason('bad layer geometry type')
         return 'fail'
 
-    if lyr.GetSpatialRef() != None:
+    if lyr.GetSpatialRef() is not None:
         gdaltest.post_reason('bad spatial ref')
         return 'fail'
 
@@ -89,7 +89,7 @@ def ogr_segy_1():
         gdaltest.post_reason('bad layer geometry type')
         return 'fail'
 
-    if lyr.GetSpatialRef() != None:
+    if lyr.GetSpatialRef() is not None:
         gdaltest.post_reason('bad spatial ref')
         return 'fail'
 

--- a/autotest/ogr/ogr_selafin.py
+++ b/autotest/ogr/ogr_selafin.py
@@ -69,7 +69,7 @@ def ogr_selafin_create_nodes():
     ref=osr.SpatialReference()
     ref.ImportFromEPSG(4326)
     layer=gdaltest.selafin_ds.CreateLayer('name',ref,geom_type=ogr.wkbPoint)
-    if layer == None:
+    if layer is None:
         gdaltest.post_reason( 'unable to create layer')
         return 'fail'
     layer.CreateField(ogr.FieldDefn('value',ogr.OFTReal))

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -838,7 +838,7 @@ def ogr_shape_23_write_valid_and_invalid(layer_name, wkt, invalid_wkt, wkbType, 
         return 'fail'
     feat_read = read_lyr.GetNextFeature()
 
-    if isEmpty and feat_read.GetGeometryRef() == None:
+    if isEmpty and feat_read.GetGeometryRef() is None:
         return 'success'
 
     if ogrtest.check_feature_geometry(feat_read,ogr.CreateGeometryFromWkt(wkt),
@@ -1912,7 +1912,7 @@ def ogr_shape_45():
 
     feat = shp_layer.GetNextFeature()
 
-    if feat.GetGeometryRef() != None:
+    if feat.GetGeometryRef() is not None:
         gdaltest.post_reason( 'Unexpectedly got a geometry on feature 2.' )
         return 'fail'
 

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -1750,12 +1750,12 @@ def ogr_sql_sqlite_25():
         print(val_ogr)
         return 'fail'
 
-    if val1_sql != None:
+    if val1_sql is not None:
         gdaltest.post_reason('fail')
         print(val1_sql)
         return 'fail'
 
-    if val2_sql != None:
+    if val2_sql is not None:
         gdaltest.post_reason('fail')
         return 'fail'
 

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -1172,7 +1172,7 @@ def ogr_sqlite_23():
 
     feat = shp_layer.GetNextFeature()
 
-    if feat.GetGeometryRef() != None:
+    if feat.GetGeometryRef() is not None:
         gdaltest.post_reason( 'Unexpectedly got a geometry on feature 2.' )
         return 'fail'
 

--- a/autotest/ogr/ogr_tiger.py
+++ b/autotest/ogr/ogr_tiger.py
@@ -85,7 +85,7 @@ def ogr_tiger_1():
     feat = cc_layer.GetNextFeature()
     feat = cc_layer.GetNextFeature()
 
-    if feat.TLID != 2833200 or feat.FRIADDL != None or feat.BLOCKL != 5000:
+    if feat.TLID != 2833200 or feat.FRIADDL is not None or feat.BLOCKL != 5000:
         gdaltest.post_reason( 'wrong attribute on cc feature.' )
         return 'fail'
 
@@ -211,7 +211,7 @@ def ogr_tiger_4():
     feat = cc_layer.GetNextFeature()
     feat = cc_layer.GetNextFeature()
 
-    if feat.TLID != 2833200 or feat.FRIADDL != None or feat.BLOCKL != 5000:
+    if feat.TLID != 2833200 or feat.FRIADDL is not None or feat.BLOCKL != 5000:
         gdaltest.post_reason( 'wrong attribute on cc feature.' )
         return 'fail'
 

--- a/autotest/ogr/ogr_vrt.py
+++ b/autotest/ogr/ogr_vrt.py
@@ -840,7 +840,7 @@ def ogr_vrt_17():
     feat = vrt_lyr.GetNextFeature()
 
     if feat.GetField(0) != 8901 or feat.GetField(1) != "Greenwich" \
-       or feat.GetField(2) != None:
+       or feat.GetField(2) is not None:
         gdaltest.post_reason( 'did not get expected field value(s).' )
         return 'fail'
 

--- a/autotest/ogr/ogr_wasp.py
+++ b/autotest/ogr/ogr_wasp.py
@@ -71,7 +71,7 @@ def ogr_wasp_elevation_from_linestring_z():
                                           ref,
                                           geom_type=ogr.wkbLineString25D )
 
-    if layer == None:
+    if layer is None:
         gdaltest.post_reason( 'unable to create layer')
         return 'fail'
 
@@ -136,7 +136,7 @@ def ogr_wasp_elevation_from_linestring_z_toler():
     if not ogrtest.have_geos() :
         gdal.PopErrorHandler()
 
-    if layer == None:
+    if layer is None:
         gdaltest.post_reason( 'unable to create layer')
         return 'fail'
 
@@ -198,7 +198,7 @@ def ogr_wasp_elevation_from_linestring_field():
                                           options = ['WASP_FIELDS=elevation'],
                                           geom_type=ogr.wkbLineString )
 
-    if layer == None:
+    if layer is None:
         gdaltest.post_reason( 'unable to create layer')
         return 'fail'
 
@@ -252,7 +252,7 @@ def ogr_wasp_roughness_from_linestring_fields():
                                           options = ['WASP_FIELDS=z_left,z_right'],
                                           geom_type=ogr.wkbLineString )
 
-    if layer == None:
+    if layer is None:
         gdaltest.post_reason( 'unable to create layer')
         return 'fail'
 
@@ -317,7 +317,7 @@ def ogr_wasp_roughness_from_polygon_z():
     if not ogrtest.have_geos() :
         gdal.PopErrorHandler()
 
-    if layer == None:
+    if layer is None:
         if ogrtest.have_geos():
             gdaltest.post_reason( 'unable to create layer')
             return 'fail'
@@ -388,7 +388,7 @@ def ogr_wasp_roughness_from_polygon_field():
     if not ogrtest.have_geos() :
         gdal.PopErrorHandler()
 
-    if layer == None:
+    if layer is None:
         if ogrtest.have_geos():
             gdaltest.post_reason( 'unable to create layer')
             return 'fail'
@@ -462,7 +462,7 @@ def ogr_wasp_merge():
     if not ogrtest.have_geos() :
         gdal.PopErrorHandler()
 
-    if layer == None:
+    if layer is None:
         if ogrtest.have_geos():
             gdaltest.post_reason( 'unable to create layer')
             return 'fail'
@@ -528,7 +528,7 @@ def ogr_wasp_reading():
 
     ds = ogr.Open( 'tmp.map' )
 
-    if ds == None or  ds.GetLayerCount() != 1:
+    if ds is None or  ds.GetLayerCount() != 1:
         return 'fail'
 
     layer = ds.GetLayer(0)

--- a/autotest/ogr/ogr_xls.py
+++ b/autotest/ogr/ogr_xls.py
@@ -72,7 +72,7 @@ def ogr_xls_1():
         gdaltest.post_reason('bad layer geometry type')
         return 'fail'
 
-    if lyr.GetSpatialRef() != None:
+    if lyr.GetSpatialRef() is not None:
         gdaltest.post_reason('bad spatial ref')
         return 'fail'
 

--- a/autotest/ogr/ogr_xlsx.py
+++ b/autotest/ogr/ogr_xlsx.py
@@ -60,7 +60,7 @@ def ogr_xlsx_check(ds):
         gdaltest.post_reason('bad layer geometry type')
         return 'fail'
 
-    if lyr.GetSpatialRef() != None:
+    if lyr.GetSpatialRef() is not None:
         gdaltest.post_reason('bad spatial ref')
         return 'fail'
 

--- a/autotest/osr/osr_esri.py
+++ b/autotest/osr/osr_esri.py
@@ -449,7 +449,7 @@ def osr_esri_14():
                           'FIPSZONE 2600',
                           'DATUM NAD83',
                           'PARAMETERS' ] )
-    if srs.GetAuthorityCode( 'PROJCS' ) != None:
+    if srs.GetAuthorityCode( 'PROJCS' ) is not None:
         print(srs.GetAuthorityCode( 'PROJCS' ))
         gdaltest.post_reason( 'Get epsg authority code inappropriately.' )
         return 'fail'

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -562,7 +562,7 @@ def test_gdal_translate_20():
         return 'fail'
 
     nodata = ds.GetRasterBand(1).GetNoDataValue()
-    if nodata != None:
+    if nodata is not None:
         print(nodata)
         return 'fail'
 

--- a/autotest/utilities/test_ogrtindex.py
+++ b/autotest/utilities/test_ogrtindex.py
@@ -96,7 +96,7 @@ def test_ogrtindex_1(srs = None):
         return 'fail'
 
     if srs is not None:
-        if ds.GetLayer(0).GetSpatialRef() == None or not ds.GetLayer(0).GetSpatialRef().IsSame(srs):
+        if ds.GetLayer(0).GetSpatialRef() is None or not ds.GetLayer(0).GetSpatialRef().IsSame(srs):
             gdaltest.post_reason('did not get expected spatial ref')
             return 'fail'
     else:

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1184,7 +1184,7 @@ def DatasetReadAsArray( ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_
                     buf_type = gdalconst.GDT_Float32
 
         typecode = GDALTypeCodeToNumericTypeCode( buf_type )
-        if typecode == None:
+        if typecode is None:
             buf_type = gdalconst.GDT_Float32
             typecode = numpy.float32
         if buf_type == gdalconst.GDT_Byte and ds.GetRasterBand(1).GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
@@ -1238,7 +1238,7 @@ def BandReadAsArray( band, xoff = 0, yoff = 0, win_xsize = None, win_ysize = Non
             buf_type = band.DataType
 
         typecode = GDALTypeCodeToNumericTypeCode( buf_type )
-        if typecode == None:
+        if typecode is None:
             buf_type = gdalconst.GDT_Float32
             typecode = numpy.float32
         else:

--- a/gdal/swig/python/samples/crs2crs2grid.py
+++ b/gdal/swig/python/samples/crs2crs2grid.py
@@ -86,7 +86,7 @@ def read_grid_crs_to_crs(filename,shape):
     points_found = 0
 
     ptuple = next_point(fd)
-    while ptuple != None:
+    while ptuple is not None:
         grid[0,ptuple[1],ptuple[0]] = ptuple[4] - ptuple[2]
         grid[1,ptuple[1],ptuple[0]] = ptuple[5] - ptuple[3]
         points_found = points_found + 1

--- a/gdal/swig/python/samples/fft.py
+++ b/gdal/swig/python/samples/fft.py
@@ -84,7 +84,7 @@ while i < len(sys.argv):
 
     if arg == '-inv':
         transformation = 'inverse'
-        if type == None:
+        if type is None:
             type = gdal.GDT_Float32
 
     elif arg == '-of':
@@ -112,7 +112,7 @@ if infile is None:
 if  outfile is None:
     Usage()
 
-if type == None:
+if type is None:
     type = gdal.GDT_CFloat32
 
 indataset = gdal.Open( infile, gdal.GA_ReadOnly )

--- a/gdal/swig/python/samples/gdal2grd.py
+++ b/gdal/swig/python/samples/gdal2grd.py
@@ -84,12 +84,12 @@ if  outfile is None:
     Usage()
 
 indataset = gdal.Open(infile, gdal.GA_ReadOnly)
-if infile == None:
+if infile is None:
     print('Cannot open', infile)
     sys.exit(2)
 geotransform = indataset.GetGeoTransform()
 band = indataset.GetRasterBand(iBand)
-if band == None:
+if band is None:
     print('Cannot load band', iBand, 'from the', infile)
     sys.exit(2)
 

--- a/gdal/swig/python/samples/gdal_vrtmerge.py
+++ b/gdal/swig/python/samples/gdal_vrtmerge.py
@@ -84,7 +84,7 @@ class file_info:
             band = fh.GetRasterBand(i)
             self.band_types.append(band.DataType)
             self.block_sizes.append(band.GetBlockSize())
-            if band.GetNoDataValue() != None:
+            if band.GetNoDataValue() is not None:
                 self.nodata.append(band.GetNoDataValue())
             self.color_interps.append(band.GetRasterColorInterpretation())
             ct = band.GetRasterColorTable()
@@ -307,7 +307,7 @@ if __name__ == '__main__':
                     file_infos[0].color_interps[band]))
 
             ct = file_infos[0].cts[band]
-            if ct != None:
+            if ct is not None:
                 t_fh.write('\t\t<ColorTable>\n')
                 for i in range(ct.GetCount()):
                     t_fh.write(

--- a/gdal/swig/python/samples/ogrinfo.py
+++ b/gdal/swig/python/samples/ogrinfo.py
@@ -467,7 +467,7 @@ def DumpReadableFeature( poFeature, options = None ):
 
 def DumpReadableGeometry( poGeometry, pszPrefix, options ):
 
-    if pszPrefix == None:
+    if pszPrefix is None:
         pszPrefix = ""
 
     if 'DISPLAY_GEOMETRY' in options and EQUAL(options['DISPLAY_GEOMETRY'], 'SUMMARY'):

--- a/gdal/swig/python/samples/rel.py
+++ b/gdal/swig/python/samples/rel.py
@@ -178,7 +178,7 @@ lz =  math.sin(lsrcel)
 lxyz = math.sqrt(lx**2 + ly**2 + lz**2)
 
 indataset = gdal.Open(infile, gdal.GA_ReadOnly)
-if indataset == None:
+if indataset is None:
     print('Cannot open', infile)
     sys.exit(2)
 
@@ -199,7 +199,7 @@ if ysize is None:
     ysize = abs(geotransform[5])
 
 inband = indataset.GetRasterBand(iBand)
-if inband == None:
+if inband is None:
     print('Cannot load band', iBand, 'from the', infile)
     sys.exit(2)
 

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -221,7 +221,7 @@ def doit(opts, args):
         myOut.SetGeoTransform(myFiles[0].GetGeoTransform())
         myOut.SetProjection(myFiles[0].GetProjection())
 
-        if opts.NoDataValue!=None:
+        if opts.NoDataValue is not None:
             myOutNDV=opts.NoDataValue
         else:
             myOutNDV=DefaultNDVLookup[myOutType]

--- a/gdal/swig/python/scripts/gdalmove.py
+++ b/gdal/swig/python/scripts/gdalmove.py
@@ -242,7 +242,7 @@ def main():
             pixel_threshold = float(argv[i+1])
             i += 1
 
-        elif filename == None:
+        elif filename is None:
             filename = argv[i]
 
         else:


### PR DESCRIPTION
## What does this PR do?

"Comparisons to singletons like `None` should always be done with `is` or `is not`, never the equality operators." -- PEP8