### PR TITLE
Python code: Use if x/not x rather than == comparison with True/False

### DIFF
--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -1265,7 +1265,7 @@ def tiff_read_huge4GB():
     if md['DMD_CREATIONOPTIONLIST'].find('BigTIFF') == -1:
         return 'skip'
 
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         ds = gdal.Open('data/huge4GB.tif')
         if ds is None:
             return 'fail'

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2594,7 +2594,7 @@ def tiff_write_71():
 
     # Determine if the filesystem supports sparse files (we don't want to create a real 10 GB
     # file !
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         return 'skip'
 
     header = open('data/bigtiff_header_extract.tif', 'rb').read()
@@ -6597,7 +6597,7 @@ def tiff_write_144():
 
     # Determine if the filesystem supports sparse files (we don't want to create a real 10 GB
     # file !
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         return 'skip'
 
     ds = gdal.GetDriverByName('GTiff').Create('tmp/tiff_write_144.tif', 20, 20, 1, options = ['BIGTIFF=YES'])

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -166,7 +166,7 @@ def vsifile_2():
 
 def vsifile_3():
 
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         return 'skip'
 
     filename = 'tmp/vsifile_3'
@@ -299,7 +299,7 @@ def vsifile_5():
 
 def vsifile_6():
 
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         return 'skip'
 
     offset = 4 * 1024 * 1024 * 1024

--- a/autotest/gdrivers/kro.py
+++ b/autotest/gdrivers/kro.py
@@ -79,7 +79,7 @@ def kro_5():
 
     # Determine if the filesystem supports sparse files (we don't want to create a real 10 GB
     # file !
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         return 'skip'
 
     ds = gdal.GetDriverByName('KRO').Create('tmp/kro_5.kro', 100000, 10000, 4)

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -1165,7 +1165,7 @@ def nitf_40():
 
     # Determine if the filesystem supports sparse files (we don't want to create a real 10 GB
     # file !
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         return 'skip'
 
     width = 99000

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -169,13 +169,13 @@ def ogr_geom_is_empty_triangle():
     geom_wkt = 'TRIANGLE EMPTY'
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
 
-    if (geom.IsEmpty() == False):
+    if not geom.IsEmpty():
         gdaltest.post_reason ("IsEmpty returning false for an empty geometry")
         return 'fail'
 
     geom = ogr.CreateGeometryFromWkb( geom.ExportToWkb() )
 
-    if (geom.IsEmpty() == False):
+    if not geom.IsEmpty():
         gdaltest.post_reason ("IsEmpty returning false for an empty geometry")
         return 'fail'
 
@@ -187,7 +187,7 @@ def ogr_geom_is_empty_triangle():
         gdaltest.post_reason ("A geometry could not be created from wkt: %s"%geom_wkt)
         return 'fail'
 
-    if (geom.IsEmpty() == True):
+    if geom.IsEmpty():
         gdaltest.post_reason ("IsEmpty returning true for a non-empty geometry")
         return 'fail'
     return 'success'
@@ -265,11 +265,11 @@ def ogr_geom_polyhedral_surface():
 
     if ogrtest.have_geos() or ogrtest.have_sfcgal():
         geom = ogr.CreateGeometryFromWkb(wkb_string)
-        if ps.Contains(geom) != True:
+        if not ps.Contains(geom):
             gdaltest.post_reason ("Failure in Contains() of PolyhedralSurface")
             return 'fail'
 
-    if ps.IsEmpty() == True:
+    if ps.IsEmpty():
         gdaltest.post_reason ("Failure in IsEmpty() of PolyhedralSurface")
         return 'fail'
 
@@ -373,7 +373,7 @@ def ogr_geom_tin():
     #    gdaltest.post_reason ("Failure in Contains() of TIN")
     #    return 'fail'
 
-    if tin.IsEmpty() == True:
+    if tin.IsEmpty():
         gdaltest.post_reason ("Failure in IsEmpty() of TIN")
         return 'fail'
 
@@ -411,7 +411,7 @@ def ogr_geom_tin():
     #    return 'fail'
 
     tin.FlattenTo2D()
-    if tin.IsValid() == True:
+    if tin.IsValid():
         gdaltest.post_reason ("Problem with IsValid() in TIN")
         return 'fail'
 
@@ -1468,7 +1468,7 @@ def ogr_geom_triangle_sfcgal():
 
     g1 = ogr.CreateGeometryFromWkt( 'TRIANGLE ((0 0,100 0 100,0 100 100,0 0))' )
     g2 = ogr.CreateGeometryFromWkt( 'TRIANGLE ((-1 -1,100 0 100,0 100 100,-1 -1))' )
-    if g2.Intersects(g1) != True:
+    if not g2.Intersects(g1):
         gdaltest.post_reason('fail')
         return 'fail'
 
@@ -1476,7 +1476,7 @@ def ogr_geom_triangle_sfcgal():
     g2 = ogr.CreateGeometryFromWkt( 'TRIANGLE ((0 0,1 0,1 1,0 0))' )
     g3 = g1.Intersection(g2)
     g4 = ogr.CreateGeometryFromWkt('TRIANGLE ((0.5 0.5 0,0 0 0,1 0 0,0.5 0.5 0))')
-    if g4.Equals(g3) == False:
+    if not g4.Equals(g3):
         gdaltest.post_reason('fail')
         return 'fail'
 

--- a/autotest/ogr/ogr_gmlas.py
+++ b/autotest/ogr/ogr_gmlas.py
@@ -3147,7 +3147,7 @@ def ogr_gmlas_swe_dataarray():
        f.GetField('myQuantity') != 2.34 or \
        f.GetField('myCount') != 3 or \
        f.GetField('myText') != 'foo' or \
-       f.GetField('myBoolean') != True:
+       f.GetField('myBoolean') is False:
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'
@@ -3240,7 +3240,7 @@ def ogr_gmlas_swe_datarecord():
        f.GetField('myquantity_value') != 1.23 or \
        f.GetField('mycount_value') != 2 or \
        f.GetField('mytext_value') != 'foo' or \
-       f.GetField('myboolean_value') != True:
+       f.GetField('myboolean_value') is False:
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'

--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -972,7 +972,7 @@ def ogr_mvt_write_one_layer():
        out_f['realfield'] != 1.25 or \
        out_f['datefield'] != '2018-02-01' or \
        out_f['datetimefield'] != '2018-02-01T12:34:56Z' or \
-       out_f['boolfield'] != True or \
+       out_f['boolfield'] is False or \
        ogrtest.check_feature_geometry(out_f, 'POINT (498980.920645632 997961.84129126)') != 0:
         gdaltest.post_reason('fail')
         out_f.DumpReadable()
@@ -985,7 +985,7 @@ def ogr_mvt_write_one_layer():
        out_f['realfield'] != 1.25 or \
        out_f['datefield'] != '2018-02-01' or \
        out_f['datetimefield'] != '2018-02-01T12:34:56Z' or \
-       out_f['boolfield'] != True or \
+       out_f['boolfield'] is False or \
        ogrtest.check_feature_geometry(out_f, 'MULTILINESTRING ((498980.920645632 997961.84129126,508764.860266134 1007745.78091176,518548.799886636 1017529.72053226))') != 0:
         gdaltest.post_reason('fail')
         out_f.DumpReadable()

--- a/autotest/ogr/ogr_ods.py
+++ b/autotest/ogr/ogr_ods.py
@@ -538,11 +538,11 @@ def ogr_ods_boolean():
         gdaltest.post_reason('failure')
         return 'fail'
     f = lyr.GetNextFeature()
-    if f.GetField(0) != True:
+    if not f.GetField(0):
         gdaltest.post_reason('failure')
         return 'fail'
     f = lyr.GetNextFeature()
-    if f.GetField(0) != False:
+    if f.GetField(0):
         gdaltest.post_reason('failure')
         return 'fail'
     ds = None

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -1142,7 +1142,7 @@ def ogr_shape_28():
 
     # Determine if the filesystem supports sparse files (we don't want to create a real 3 GB
     # file !
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if not gdaltest.filesystem_supports_sparse_files('tmp'):
         return 'skip'
 
     for filename in ('tmp/hugedbf.dbf', 'tmp/hugedbf.shp', 'tmp/hugedbf.shx'):
@@ -3486,7 +3486,7 @@ def ogr_shape_72():
 
     # Determine if the filesystem supports sparse files (we don't want to create a real 3 GB
     # file !
-    if (gdaltest.filesystem_supports_sparse_files('tmp') == False):
+    if gdaltest.filesystem_supports_sparse_files('tmp') is False:
         return 'skip'
 
     import struct

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -880,7 +880,7 @@ def ogr_sqlite_17():
     with gdaltest.error_handler():
         ds = ogr.GetDriverByName( 'SQLite' ).CreateDataSource( 'tmp/spatialite_test.db', options = ['SPATIALITE=YES'] )
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         if ds is not None:
             return 'fail'
         return 'success'
@@ -929,7 +929,7 @@ def ogr_sqlite_18():
     if gdaltest.sl_ds is None:
         return 'skip'
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     ds = ogr.Open( 'tmp/spatialite_test.db', update = 1  )
@@ -972,7 +972,7 @@ def ogr_sqlite_19():
     if int(gdal.VersionInfo('VERSION_NUM')) < 1800:
         return 'skip'
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     if gdaltest.spatialite_version != '2.3.1':
@@ -1009,7 +1009,7 @@ def ogr_sqlite_19_bis():
     if gdaltest.sl_ds is None:
         return 'skip'
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     if int(gdaltest.spatialite_version[0:gdaltest.spatialite_version.find('.')]) < 4:
@@ -1504,7 +1504,7 @@ def ogr_spatialite_1():
 
 def ogr_spatialite_2():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     ds = ogr.Open( 'tmp/spatialite_test.db', update = 1 )
@@ -1554,10 +1554,10 @@ def ogr_spatialite_2():
         'POLYGON((2 2,2 8,8 8,8 2,2 2))' )
     lyr.SetSpatialFilter( geom )
 
-    if lyr.TestCapability(ogr.OLCFastFeatureCount) != True:
+    if lyr.TestCapability(ogr.OLCFastFeatureCount) is False:
         gdaltest.post_reason('OLCFastFeatureCount failed')
         return 'fail'
-    if lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
 
@@ -1582,11 +1582,11 @@ def ogr_spatialite_2():
         print(extent)
         return 'fail'
 
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     sql_lyr.SetSpatialFilter( geom )
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     if sql_lyr.GetFeatureCount() != 50:
@@ -1597,11 +1597,11 @@ def ogr_spatialite_2():
 
     # Test spatial filter with a SQL result layer with WHERE clause
     sql_lyr = ds.ExecuteSQL('SELECT * FROM test_spatialfilter WHERE 1=1')
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     sql_lyr.SetSpatialFilter( geom )
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     if sql_lyr.GetFeatureCount() != 50:
@@ -1626,11 +1626,11 @@ def ogr_spatialite_2():
         print(extent)
         return 'fail'
 
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     sql_lyr.SetSpatialFilter( geom )
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     if sql_lyr.GetFeatureCount() != 50:
@@ -1655,11 +1655,11 @@ def ogr_spatialite_2():
         print(extent)
         return 'fail'
 
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     sql_lyr.SetSpatialFilter( geom )
-    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) != True:
+    if sql_lyr.TestCapability(ogr.OLCFastSpatialFilter) is False:
         gdaltest.post_reason('OLCFastSpatialFilter failed')
         return 'fail'
     if sql_lyr.GetFeatureCount() != 50:
@@ -1694,9 +1694,9 @@ def ogr_spatialite_2():
     lyr.SetSpatialFilter( geom )
     geom.Destroy()
 
-    if lyr.TestCapability(ogr.OLCFastFeatureCount) != False:
+    if lyr.TestCapability(ogr.OLCFastFeatureCount) is True:
         return 'fail'
-    if lyr.TestCapability(ogr.OLCFastSpatialFilter) != False:
+    if lyr.TestCapability(ogr.OLCFastSpatialFilter) is True:
         return 'fail'
 
     if lyr.GetFeatureCount() != 50:
@@ -1712,7 +1712,7 @@ def ogr_spatialite_2():
 
 def ogr_spatialite_3():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     ds = ogr.Open( 'tmp/spatialite_test.db', update = 1 )
@@ -1741,7 +1741,7 @@ def ogr_spatialite_3():
 
 def ogr_spatialite_4():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     ds = ogr.Open( 'tmp/spatialite_test.db', update = 1  )
@@ -1798,7 +1798,7 @@ def ogr_spatialite_4():
 
 def ogr_spatialite_5(bUseComprGeom = False):
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     try:
@@ -1936,7 +1936,7 @@ def ogr_spatialite_5(bUseComprGeom = False):
 
 def ogr_spatialite_compressed_geom_5():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     if gdaltest.spatialite_version == '2.3.1':
@@ -1949,7 +1949,7 @@ def ogr_spatialite_compressed_geom_5():
 
 def ogr_spatialite_6():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     if gdaltest.spatialite_version.find('2.3') == 0:
@@ -2095,7 +2095,7 @@ def ogr_spatialite_6():
 
 def ogr_spatialite_7():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     ds = ogr.Open('VirtualShape:data/poly.shp')
@@ -2124,7 +2124,7 @@ def ogr_spatialite_7():
 
 def ogr_spatialite_8():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     if gdaltest.spatialite_version.find('2.3') == 0:
@@ -2477,7 +2477,7 @@ def ogr_sqlite_33():
         if i == 0:
             options = []
         else:
-            if gdaltest.has_spatialite == False:
+            if not gdaltest.has_spatialite:
                 return 'success'
             if gdaltest.spatialite_version.find('2.3') == 0:
                 return 'success'
@@ -2620,7 +2620,7 @@ def ogr_sqlite_35():
     if gdaltest.sl_ds is None:
         return 'skip'
 
-    if gdaltest.has_spatialite == True and gdaltest.spatialite_version.find('2.3') < 0:
+    if gdaltest.has_spatialite and gdaltest.spatialite_version.find('2.3') < 0:
         options = ['SPATIALITE=YES']
     else:
         options = []
@@ -3002,7 +3002,7 @@ def ogr_sqlite_38():
 
 def ogr_spatialite_9():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     ds = ogr.GetDriverByName('SQLite').CreateDataSource('/vsimem/ogr_spatialite_9.sqlite', options = [ 'SPATIALITE=YES'] )
@@ -3025,7 +3025,7 @@ def ogr_spatialite_9():
 
 def ogr_spatialite_10():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
     try:
         os.remove('tmp/ogr_spatialite_10.sqlite')
@@ -3529,7 +3529,7 @@ def ogr_sqlite_45():
 
 def ogr_spatialite_11():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     ds = ogr.GetDriverByName('SQLite').CreateDataSource('/vsimem/ogr_spatialite_11.sqlite', options = ['SPATIALITE=YES'])
@@ -3558,7 +3558,7 @@ def ogr_spatialite_11():
 
 def ogr_spatialite_12():
 
-    if gdaltest.has_spatialite == False:
+    if not gdaltest.has_spatialite:
         return 'skip'
 
     if gdal.GetDriverByName('SQLite').GetMetadataItem("ENABLE_SQL_SQLITE_FORMAT") != 'YES':
@@ -3690,7 +3690,7 @@ def ogr_sqlite_cleanup():
 
 def ogr_sqlite_without_spatialite():
 
-    if gdaltest.has_spatialite == False or not run_without_spatialite:
+    if not gdaltest.has_spatialite or not run_without_spatialite:
         return 'skip'
 
     import test_py_scripts

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -262,7 +262,7 @@ def ogr_wfs_geoserver_json():
     if gdaltest.wfs_drv is None:
         return 'skip'
 
-    if gdaltest.geoserver_wfs != True:
+    if not gdaltest.geoserver_wfs:
         return 'skip'
 
     ds = ogr.Open('WFS:http://demo.opengeo.org/geoserver/wfs?TYPENAME=za:za_points&MAXFEATURES=10&VERSION=1.1.0&OUTPUTFORMAT=json')
@@ -309,7 +309,7 @@ def ogr_wfs_geoserver_shapezip():
     if gdaltest.wfs_drv is None:
         return 'skip'
 
-    if gdaltest.geoserver_wfs != True:
+    if not gdaltest.geoserver_wfs:
         return 'skip'
 
     ds = ogr.Open('WFS:http://demo.opengeo.org/geoserver/wfs?TYPENAME=za:za_points&MAXFEATURES=10&VERSION=1.1.0&OUTPUTFORMAT=SHAPE-ZIP')
@@ -355,7 +355,7 @@ def ogr_wfs_geoserver_paging():
     if gdaltest.wfs_drv is None:
         return 'skip'
 
-    if gdaltest.geoserver_wfs != True:
+    if not gdaltest.geoserver_wfs:
         return 'skip'
 
     ds = ogr.Open('WFS:http://demo.opengeo.org/geoserver/wfs?TYPENAME=og:bugsites&VERSION=1.1.0')
@@ -489,7 +489,7 @@ def ogr_wfs_test_ogrsf():
     if gdaltest.wfs_drv is None:
         return 'skip'
 
-    if gdaltest.deegree_wfs != True:
+    if not gdaltest.deegree_wfs:
         return 'skip'
 
     import test_cli_utilities
@@ -614,7 +614,7 @@ def ogr_wfs_geoserver_wfst():
     if gdaltest.wfs_drv is None:
         return 'skip'
 
-    if gdaltest.geoserver_wfs != True:
+    if not gdaltest.geoserver_wfs:
         return 'skip'
 
     ds = ogr.Open('WFS:http://demo.opengeo.org/geoserver/wfs?VERSION=1.1.0', update = 1)
@@ -794,7 +794,7 @@ def ogr_wfs_ionic_sql():
     if gdaltest.wfs_drv is None:
         return 'skip'
 
-    if gdaltest.ionic_wfs != True:
+    if not gdaltest.ionic_wfs:
         return 'skip'
 
     ds = ogr.Open('WFS:http://webservices.ionicsoft.com/ionicweb/wfs/BOSTON_ORA')
@@ -863,7 +863,7 @@ def ogr_wfs_xmldescriptionfile_to_be_updated():
     if gdaltest.wfs_drv is None:
         return 'skip'
 
-    if gdaltest.geoserver_wfs != True:
+    if not gdaltest.geoserver_wfs:
         return 'skip'
 
     f = open('tmp/ogr_wfs_xmldescriptionfile_to_be_updated.xml', 'wt')

--- a/autotest/ogr/ogr_wktempty.py
+++ b/autotest/ogr/ogr_wktempty.py
@@ -44,7 +44,7 @@ class TestWktEmpty:
         except:
             return 'skip'
 
-        if (geom.IsEmpty() == False):
+        if not geom.IsEmpty():
             geom.Destroy()
             gdaltest.post_reason ("IsEmpty returning false for an empty geometry")
             return 'fail'


### PR DESCRIPTION
## What does this PR do?

Uses `if x` and `if not x` rather than `==` comparison with True and False. In most cases, the code is much easier to read. `if x != False` is very unnatural!