### PR TITLE
Python code: Fix E116: unexpected indentation (comment)

### DIFF
--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -890,7 +890,7 @@ def grib_grib2_write_creation_options():
     ds = None
     gdal.Unlink(tmpfilename)
 
-     # Test with unknown PDS_PDTN with PDS_TEMPLATE_ASSEMBLED_VALUES
+    # Test with unknown PDS_PDTN with PDS_TEMPLATE_ASSEMBLED_VALUES
     with gdaltest.error_handler():
         out_ds = gdal.Translate(tmpfilename, 'data/byte.tif', format = 'GRIB',
                    creationOptions = [

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -697,7 +697,7 @@ def netcdf_17():
         else:
             name = ds.GetDriver().GetDescription()
             ds = None
-                #return fail if opened with the netCDF driver
+            # return fail if opened with the netCDF driver
             if name == 'netCDF':
                 gdaltest.post_reason('netcdf driver opened hdf5 file')
                 return 'fail'

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1000,11 +1000,11 @@ class GDALTest:
         dict = {}
         dict['TEST_KEY'] = 'TestValue'
         new_ds.SetMetadata( dict )
-# FIXME
-        #if new_ds.SetMetadata( dict ) is not gdal.CE_None:
-            #print new_ds.SetMetadata( dict )
-            #post_reason( 'Failed to set metadata item.' )
-            #return 'fail'
+        # FIXME
+        # if new_ds.SetMetadata( dict ) is not gdal.CE_None:
+        #     print new_ds.SetMetadata( dict )
+        #     post_reason( 'Failed to set metadata item.' )
+        #     return 'fail'
 
         src_ds = None
         new_ds = None

--- a/gdal/swig/python/scripts/gdal_retile.py
+++ b/gdal/swig/python/scripts/gdal_retile.py
@@ -203,8 +203,7 @@ class mosaic_info:
 
         self.ogrTileIndexDS.GetLayer().SetSpatialFilter(None)
 
-         # merge tiles
-
+        # merge tiles
 
         resultSizeX =int(math.ceil(((maxx-minx) / self.scaleX )))
         resultSizeY =int(math.ceil(((miny-maxy) / self.scaleY )))


### PR DESCRIPTION
## What does this PR do?

Removes a few `flake8` warnings about E116 (unexpected indentation of comments).