### PR TITLE
Python code: Fix warning E714: test for object identity should be 'is not'.

### DIFF
--- a/autotest/gdrivers/arg.py
+++ b/autotest/gdrivers/arg.py
@@ -133,7 +133,7 @@ def arg_unsupported():
             if name == 'int64' or name == 'uint64':
                 with gdaltest.error_handler('CPLQuietErrorHandler'):
                     ds = gdal.Open('data/arg-'+name+'.arg')
-                if not ds is None:
+                if ds is not None:
                     return 'fail'
             else:
                 ds = gdal.Open('data/arg-'+name+'.arg')

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1076,7 +1076,7 @@ def netcdf_test_4dfile( ofile ):
         return 'fail'
     md = ds.GetMetadata( 'SUBDATASETS' )
     subds_count = 0
-    if not md is None:
+    if md is not None:
         subds_count = len(md) / 2
     if ds.RasterCount != 8 or subds_count != 0:
         gdaltest.post_reason( 'copy has %d bands (expected 8) and has %d subdatasets'\


### PR DESCRIPTION
## What does this PR do?

Silences warnings E714: `test for object identity should be 'is not'`.