### PR TITLE
Python code: Fix E228: missing whitespace around modulo operator

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -781,7 +781,7 @@ def warp_22():
     for j in range(h):
         line = ''
         for i in range(w):
-            line = line + '%c' % int((i*i+h*j/(i+1))%256)
+            line = line + '%c' % int((i*i+h*j/(i+1)) % 256)
         ds.GetRasterBand(1).WriteRaster(0,j,w,1,line)
 
     expected_cs = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -2609,7 +2609,7 @@ def getargs(arglist):
     try:
         (opts,args)=getopt(arglist[1:],'a:bchlnu:s:v:',['area_types=','badc','coards','help','uploader','noname','udunits=','cf_standard_names=','version='])
     except GetoptError:
-        stderr.write('%s\n'%__doc__)
+        stderr.write('%s\n' % __doc__)
         exit(1)
 
     for a, v in opts:
@@ -2653,7 +2653,7 @@ def getargs(arglist):
             continue
 
     if len(args) == 0:
-        stderr.write('ERROR in command line\n\nusage:\n%s\n'%__doc__)
+        stderr.write('ERROR in command line\n\nusage:\n%s\n' % __doc__)
         exit(1)
 
     return (badc,coards,uploader,useFileName,standardname,areatypes,udunits,version,args)

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -153,7 +153,7 @@ def ogr_geom_is_empty():
     geom_wkt = 'POINT( 1 2 )'
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
     if not geom:
-        gdaltest.post_reason ("A geometry could not be created from wkt: %s"%geom_wkt)
+        gdaltest.post_reason ("A geometry could not be created from wkt: %s" % geom_wkt)
         return 'fail'
 
     if geom.IsEmpty():
@@ -184,7 +184,7 @@ def ogr_geom_is_empty_triangle():
 
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
     if not geom:
-        gdaltest.post_reason ("A geometry could not be created from wkt: %s"%geom_wkt)
+        gdaltest.post_reason ("A geometry could not be created from wkt: %s" % geom_wkt)
         return 'fail'
 
     if geom.IsEmpty():

--- a/autotest/ogr/ogr_sde.py
+++ b/autotest/ogr/ogr_sde.py
@@ -332,7 +332,7 @@ def ogr_sde_cleanup():
         return 'skip'
     base = 'SDE:%s,%s,%s,%s,%s' % (sde_server, sde_port, sde_db, sde_user, sde_password)
     ds = ogr.Open(base, update=1)
-    ds.DeleteLayer('%s.%s'%(sde_user.upper(),'TPOLY'))
+    ds.DeleteLayer('%s.%s' % (sde_user.upper(),'TPOLY'))
     ds.Destroy()
 
 

--- a/autotest/ogr/ogr_wasp.py
+++ b/autotest/ogr/ogr_wasp.py
@@ -97,14 +97,14 @@ def ogr_wasp_elevation_from_linestring_z():
     i = 0
     j = 0
     for line in f:
-        if not i%2:
+        if not i % 2:
             [h,n] = line.split()
             if int(n) != 3:
                 gdaltest.post_reason( 'number of points should be 3 and is %s' % n )
                 return 'fail'
 
             if float(h) != j:
-                gdaltest.post_reason( 'altitude should be %d and is %s' %(j,h) )
+                gdaltest.post_reason( 'altitude should be %d and is %s' % (j,h) )
                 return 'fail'
 
             j+=1
@@ -162,7 +162,7 @@ def ogr_wasp_elevation_from_linestring_z_toler():
     i = 0
     j = 0
     for line in f:
-        if not i%2:
+        if not i % 2:
             [h,n] = line.split()
             if int(n) != 2:
                 if ogrtest.have_geos():
@@ -173,7 +173,7 @@ def ogr_wasp_elevation_from_linestring_z_toler():
                     return 'fail'
 
             if float(h) != j:
-                gdaltest.post_reason( 'altitude should be %d and is %s' %(j,h) )
+                gdaltest.post_reason( 'altitude should be %d and is %s' % (j,h) )
                 return 'fail'
 
             j+=1
@@ -225,14 +225,14 @@ def ogr_wasp_elevation_from_linestring_field():
     i = 0
     j = 0
     for line in f:
-        if not i%2:
+        if not i % 2:
             [h,n] = line.split()
             if int(n) != 3:
                 gdaltest.post_reason( 'number of points should be 3 and is %s' % n )
                 return 'fail'
 
             if float(h) != j:
-                gdaltest.post_reason( 'altitude should be %d and is %s' %(j,h) )
+                gdaltest.post_reason( 'altitude should be %d and is %s' % (j,h) )
                 return 'fail'
 
             j+=1
@@ -271,7 +271,7 @@ def ogr_wasp_roughness_from_linestring_fields():
         line.AddPoint( i, 1 )
         feat.SetGeometry( line )
         if layer.CreateFeature( feat ) != 0:
-            gdaltest.post_reason( 'unable to create feature %d'%i)
+            gdaltest.post_reason( 'unable to create feature %d' % i)
             return 'fail'
 
     del gdaltest.wasp_ds
@@ -283,14 +283,14 @@ def ogr_wasp_roughness_from_linestring_fields():
     i = 0
     j = 0
     for line in f:
-        if not i%2:
+        if not i % 2:
             [l,r,n] = line.split()
             if int(n) != 3:
                 gdaltest.post_reason( 'number of points should be 3 and is %s' % n )
                 return 'fail'
 
             if float(r) != j or float(l) != j-1:
-                gdaltest.post_reason( 'roughness should be %d and %d and is %s and %s' %(j-1,j,l,r) )
+                gdaltest.post_reason( 'roughness should be %d and %d and is %s and %s' % (j-1,j,l,r) )
                 return 'fail'
 
             j+=1
@@ -350,7 +350,7 @@ def ogr_wasp_roughness_from_polygon_z():
     j = 0
     res = set()
     for line in f:
-        if not i%2:
+        if not i % 2:
             [l,r,n] = [v for v in line.split()]
             if int(n) != 2:
                 gdaltest.post_reason( 'number of points should be 2 and is %d' % int(n) )
@@ -423,7 +423,7 @@ def ogr_wasp_roughness_from_polygon_field():
     j = 0
     res = set()
     for line in f:
-        if not i%2:
+        if not i % 2:
             [l,r,n] = [v for v in line.split()]
             if int(n) != 2:
                 gdaltest.post_reason( 'number of points should be 2 and is %d' % int(n) )
@@ -474,7 +474,7 @@ def ogr_wasp_merge():
     for i in range(6):
         feat = ogr.Feature( dfn )
         ring = ogr.Geometry( type = ogr.wkbLinearRing )
-        h = i%2
+        h = i % 2
         ring.AddPoint( 0, 0, h )
         ring.AddPoint( round(math.cos(i*math.pi/3),6),  round(math.sin(i*math.pi/3),6), h )
         ring.AddPoint( round(math.cos((i+1)*math.pi/3),6),  round(math.sin((i+1)*math.pi/3),6), h )
@@ -496,7 +496,7 @@ def ogr_wasp_merge():
     j = 0
     res = []
     for line in f:
-        if not i%2:
+        if not i % 2:
             [l,r,n] = [v for v in line.split()]
             if int(n) != 2:
                 gdaltest.post_reason( 'number of points should be 2 and is %d (unwanted merge ?)' % int(n) )

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -547,7 +547,7 @@ class GDALTest:
                 # Tested on Linux, Mac OS X and Windows, with Python 2.3/2.4/2.5.
                 sv = str(new_stat[i]).lower()
                 if sv.find('n') >= 0 or sv.find('i') >= 0 or sv.find('#') >= 0:
-                    post_reason( 'NaN or Invinite value encountered '%'.' % sv )
+                    post_reason( 'NaN or Invinite value encountered ' % '.' % sv )
                     return 'fail'
 
                 if abs(new_stat[i]-check_approx_stat[i]) > stat_epsilon:
@@ -571,7 +571,7 @@ class GDALTest:
 
                 sv = str(new_stat[i]).lower()
                 if sv.find('n') >= 0 or sv.find('i') >= 0 or sv.find('#') >= 0:
-                    post_reason( 'NaN or Infinite value encountered '%'.' % sv )
+                    post_reason( 'NaN or Infinite value encountered ' % '.' % sv )
                     return 'fail'
 
                 if abs(new_stat[i]-check_stat[i]) > stat_epsilon:

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -546,8 +546,8 @@ class GDALTest:
                 # because we need to support old and buggy Python 2.3.
                 # Tested on Linux, Mac OS X and Windows, with Python 2.3/2.4/2.5.
                 sv = str(new_stat[i]).lower()
-                if sv.find('n') >= 0 or sv.find('i') >= 0 or sv.find('#') >= 0:
-                    post_reason( 'NaN or Invinite value encountered ' % '.' % sv )
+                if 'n' in sv or 'i' in sv or '#' in sv:
+                    post_reason('NaN or infinity value encountered \'%s\'.' % sv)
                     return 'fail'
 
                 if abs(new_stat[i]-check_approx_stat[i]) > stat_epsilon:
@@ -570,8 +570,8 @@ class GDALTest:
             for i in range(4):
 
                 sv = str(new_stat[i]).lower()
-                if sv.find('n') >= 0 or sv.find('i') >= 0 or sv.find('#') >= 0:
-                    post_reason( 'NaN or Infinite value encountered ' % '.' % sv )
+                if 'n' in sv or 'i' in sv or '#' in sv:
+                    post_reason('NaN or infinity value encountered \'%s\'.' % sv)
                     return 'fail'
 
                 if abs(new_stat[i]-check_stat[i]) > stat_epsilon:


### PR DESCRIPTION
## What does this PR do?

Silences diagnostic E228 (`missing whitespace around modulo operator').