### PR TITLE
Python code: Fix E227: missing whitespace around bitwise or shift operator

### DIFF
--- a/autotest/gdrivers/arg.py
+++ b/autotest/gdrivers/arg.py
@@ -86,15 +86,15 @@ def arg_init():
 
     # None means "no data"
     gdaltest.argTests = [
-        {'formats': [('int8', '>b', -(1<<7)),
-                     ('int16', '>h', -(1<<15)),
-                     ('int32', '>i', -(1<<31)),
-                     ('int64', '>q', -(1<<63))],
+        {'formats': [('int8', '>b', -(1 << 7)),
+                     ('int16', '>h', -(1 << 15)),
+                     ('int32', '>i', -(1 << 31)),
+                     ('int64', '>q', -(1 << 63))],
          'data': [None, 2, -3, -4]},
-        {'formats': [('uint8', '>B', (1<<8)-1),
-                     ('uint16', '>H', (1<<16)-1),
-                     ('uint32', '>I', (1<<32)-1),
-                     ('uint64', '>Q', (1<<64)-1)],
+        {'formats': [('uint8', '>B', (1 << 8)-1),
+                     ('uint16', '>H', (1 << 16)-1),
+                     ('uint32', '>I', (1 << 32)-1),
+                     ('uint64', '>Q', (1 << 64)-1)],
          'data': [None, 2, 3, 4]},
         {'formats': [('float32', '>f', gdaltest.NaN()),
                      ('float64', '>d', gdaltest.NaN())],

--- a/gdal/swig/python/samples/gdalinfo.py
+++ b/gdal/swig/python/samples/gdalinfo.py
@@ -459,7 +459,7 @@ def main( argv = None ):
             print( "  Overviews: arbitrary" )
 
         nMaskFlags = hBand.GetMaskFlags()
-        if (nMaskFlags & (gdal.GMF_NODATA|gdal.GMF_ALL_VALID)) == 0:
+        if (nMaskFlags & (gdal.GMF_NODATA | gdal.GMF_ALL_VALID)) == 0:
 
             hMaskBand = hBand.GetMaskBand()
 


### PR DESCRIPTION
## What does this PR do?

Silences diagnostic E227 (`missing whitespace around bitwise or shift operator`).