### PR TITLE
Python code: Fix E211: whitespace before '('.

### DIFF
--- a/autotest/gdrivers/db2.py
+++ b/autotest/gdrivers/db2.py
@@ -82,7 +82,7 @@ def gpkg_init():
         gdaltest.post_reason('Environment variable DB2_TEST_SERVER not found')
         gdaltest.db2_drv = None
         return 'skip'
-    print ("\ntest server: "  + gdaltest.db2_test_server + "\n")
+    print("\ntest server: "  + gdaltest.db2_test_server + "\n")
 
     return 'success'
 

--- a/autotest/gdrivers/dimap.py
+++ b/autotest/gdrivers/dimap.py
@@ -51,11 +51,11 @@ def dimap_1():
     if ds.RasterCount != 1 \
        or ds.RasterXSize != 6000 \
        or ds.RasterYSize != 6000:
-        gdaltest.post_reason ( 'wrong size or bands' )
+        gdaltest.post_reason( 'wrong size or bands' )
         return 'fail'
 
     if ds.GetRasterBand(1).Checksum(0,0,100,100) != 21586:
-        gdaltest.post_reason ( 'wrong checksum' )
+        gdaltest.post_reason( 'wrong checksum' )
         return 'fail'
 
     md = ds.GetMetadata()
@@ -105,7 +105,7 @@ def dimap_2():
         if ds.RasterCount != 4 \
           or ds.RasterXSize != 20 \
           or ds.RasterYSize != 30:
-            gdaltest.post_reason ( 'wrong size or bands' )
+            gdaltest.post_reason( 'wrong size or bands' )
             return 'fail'
 
         md = ds.GetMetadata()

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -1410,13 +1410,13 @@ def ecw_36():
     dswr = gdaltest.ecw_drv.CreateCopy( 'tmp/jrc312.ecw', vrt_ds, options = ['ECW_FORMAT_VERSION=3','TARGET=75'] )
 
     if dswr.GetRasterBand(1).GetColorInterpretation() != gdal.GCI_BlueBand :
-        print ('Band 1 color interpretation should be Blue  but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(1).GetColorInterpretation()))
+        print('Band 1 color interpretation should be Blue  but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(1).GetColorInterpretation()))
         return 'fail'
     if dswr.GetRasterBand(2).GetColorInterpretation() != gdal.GCI_RedBand:
-        print ('Band 2 color interpretation should be Red but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(2).GetColorInterpretation()))
+        print('Band 2 color interpretation should be Red but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(2).GetColorInterpretation()))
         return 'fail'
     if dswr.GetRasterBand(3).GetColorInterpretation() != gdal.GCI_GreenBand:
-        print ('Band 3 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(3).GetColorInterpretation()))
+        print('Band 3 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(3).GetColorInterpretation()))
         return 'fail'
 
     dswr = None
@@ -1424,13 +1424,13 @@ def ecw_36():
     dsr = gdal.Open( 'tmp/jrc312.ecw' )
 
     if dsr.GetRasterBand(1).GetColorInterpretation() != gdal.GCI_BlueBand :
-        print ('Band 1 color interpretation should be Blue  but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(1).GetColorInterpretation()))
+        print('Band 1 color interpretation should be Blue  but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(1).GetColorInterpretation()))
         return 'fail'
     if dsr.GetRasterBand(2).GetColorInterpretation() != gdal.GCI_RedBand:
-        print ('Band 2 color interpretation should be Red but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(2).GetColorInterpretation()))
+        print('Band 2 color interpretation should be Red but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(2).GetColorInterpretation()))
         return 'fail'
     if dsr.GetRasterBand(3).GetColorInterpretation() != gdal.GCI_GreenBand:
-        print ('Band 3 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(3).GetColorInterpretation()))
+        print('Band 3 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(3).GetColorInterpretation()))
         return 'fail'
 
     dsr = None
@@ -1452,13 +1452,13 @@ def ecw_37():
     dswr = gdaltest.ecw_drv.CreateCopy( 'tmp/jrc123.ecw', ds, options = ['ECW_FORMAT_VERSION=3','TARGET=75'] )
 
     if dswr.GetRasterBand(1).GetColorInterpretation() != gdal.GCI_RedBand :
-        print ('Band 1 color interpretation should be Red but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(1).GetColorInterpretation()))
+        print('Band 1 color interpretation should be Red but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(1).GetColorInterpretation()))
         return 'fail'
     if dswr.GetRasterBand(2).GetColorInterpretation() != gdal.GCI_GreenBand:
-        print ('Band 2 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(2).GetColorInterpretation()))
+        print('Band 2 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(2).GetColorInterpretation()))
         return 'fail'
     if dswr.GetRasterBand(3).GetColorInterpretation() != gdal.GCI_BlueBand:
-        print ('Band 3 color interpretation should be Blue but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(3).GetColorInterpretation()))
+        print('Band 3 color interpretation should be Blue but is : '+ gdal.GetColorInterpretationName(dswr.GetRasterBand(3).GetColorInterpretation()))
         return 'fail'
 
     dswr = None
@@ -1466,13 +1466,13 @@ def ecw_37():
     dsr = gdal.Open( 'tmp/jrc123.ecw' )
 
     if dsr.GetRasterBand(1).GetColorInterpretation() != gdal.GCI_RedBand :
-        print ('Band 1 color interpretation should be Red  but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(1).GetColorInterpretation()))
+        print('Band 1 color interpretation should be Red  but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(1).GetColorInterpretation()))
         return 'fail'
     if dsr.GetRasterBand(2).GetColorInterpretation() != gdal.GCI_GreenBand:
-        print ('Band 2 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(2).GetColorInterpretation()))
+        print('Band 2 color interpretation should be Green but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(2).GetColorInterpretation()))
         return 'fail'
     if dsr.GetRasterBand(3).GetColorInterpretation() != gdal.GCI_BlueBand:
-        print ('Band 3 color interpretation should be Blue but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(3).GetColorInterpretation()))
+        print('Band 3 color interpretation should be Blue but is : '+ gdal.GetColorInterpretationName(dsr.GetRasterBand(3).GetColorInterpretation()))
         return 'fail'
 
     dsr = None

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -246,7 +246,7 @@ def grib_grib2_read_template_4_15():
     if test_cli_utilities.get_gdalinfo_path() is None:
         return 'skip'
 
-    ret, err = gdaltest.runexternal_out_and_err (test_cli_utilities.get_gdalinfo_path() + ' data/grib/template_4_15.grb2 -checksum')
+    ret, err = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' data/grib/template_4_15.grb2 -checksum')
 
     # This is a JPEG2000 compressed file, so just check we can open it or that we get a message saying there's no JPEG2000 driver available
     if ret.find('Checksum=') < 0 and err.find('Is the JPEG2000 driver available?') < 0:

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -2672,6 +2672,6 @@ if __name__ == '__main__':
     inst = CFChecker(uploader=uploader, useFileName=useFileName, badc=badc, coards=coards, cfStandardNamesXML=standardName, cfAreaTypesXML=areaTypes, udunitsDat=udunitsDat, version=version)
     for file in files:
         rc = inst.checker(file)
-        exit (rc)
+        exit(rc)
 
 

--- a/autotest/gdrivers/saga.py
+++ b/autotest/gdrivers/saga.py
@@ -151,13 +151,13 @@ def saga_6():
         import struct
         value = struct.unpack('d' * 1, data)[0]
         if value != expected_nodata[i]:
-            print (value)
+            print(value)
             gdaltest.post_reason('did not get expected pixel value')
             return 'fail'
 
         nodata = ds.GetRasterBand(1).GetNoDataValue()
         if nodata != expected_nodata[i]:
-            print (nodata)
+            print(nodata)
             gdaltest.post_reason('did not get expected nodata value')
             return 'fail'
 

--- a/autotest/gdrivers/usgsdem.py
+++ b/autotest/gdrivers/usgsdem.py
@@ -78,7 +78,7 @@ def usgsdem_4():
 
     tst = gdaltest.GDALTest( 'USGSDEM', '39079G6_truncated.dem', 1, 61424, \
         options = [ 'RESAMPLE=Nearest' ] )
-    return tst.testCreateCopy ( check_gt = 1, check_srs = 1, vsimem = 1 )
+    return tst.testCreateCopy( check_gt = 1, check_srs = 1, vsimem = 1 )
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_geoconcept.py
+++ b/autotest/ogr/ogr_geoconcept.py
@@ -149,7 +149,7 @@ def ogr_gxt_3():
     src_ds = ogr.Open( 'data/points.gxt' )
 
     try:
-        os.remove ('tmp/tmp.gxt')
+        os.remove('tmp/tmp.gxt')
     except:
         pass
 
@@ -309,7 +309,7 @@ def ogr_gxt_cleanup():
 
     gdaltest.gxt_ds = None
     try:
-        os.remove ('tmp/tmp.gxt')
+        os.remove('tmp/tmp.gxt')
     except:
         pass
     return 'success'

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -147,17 +147,17 @@ def ogr_geom_is_empty():
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
 
     if not geom.IsEmpty():
-        gdaltest.post_reason ("IsEmpty returning false for an empty geometry")
+        gdaltest.post_reason("IsEmpty returning false for an empty geometry")
         return 'fail'
 
     geom_wkt = 'POINT( 1 2 )'
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
     if not geom:
-        gdaltest.post_reason ("A geometry could not be created from wkt: %s"%geom_wkt)
+        gdaltest.post_reason("A geometry could not be created from wkt: %s"%geom_wkt)
         return 'fail'
 
     if geom.IsEmpty():
-        gdaltest.post_reason ("IsEmpty returning true for a non-empty geometry")
+        gdaltest.post_reason("IsEmpty returning true for a non-empty geometry")
         return 'fail'
     return 'success'
 
@@ -170,13 +170,13 @@ def ogr_geom_is_empty_triangle():
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
 
     if not geom.IsEmpty():
-        gdaltest.post_reason ("IsEmpty returning false for an empty geometry")
+        gdaltest.post_reason("IsEmpty returning false for an empty geometry")
         return 'fail'
 
     geom = ogr.CreateGeometryFromWkb( geom.ExportToWkb() )
 
     if not geom.IsEmpty():
-        gdaltest.post_reason ("IsEmpty returning false for an empty geometry")
+        gdaltest.post_reason("IsEmpty returning false for an empty geometry")
         return 'fail'
 
 
@@ -184,11 +184,11 @@ def ogr_geom_is_empty_triangle():
 
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
     if not geom:
-        gdaltest.post_reason ("A geometry could not be created from wkt: %s"%geom_wkt)
+        gdaltest.post_reason("A geometry could not be created from wkt: %s"%geom_wkt)
         return 'fail'
 
     if geom.IsEmpty():
-        gdaltest.post_reason ("IsEmpty returning true for a non-empty geometry")
+        gdaltest.post_reason("IsEmpty returning true for a non-empty geometry")
         return 'fail'
     return 'success'
 
@@ -201,7 +201,7 @@ def ogr_geom_pickle():
         g = pickle.loads(p)
 
     if not geom.Equal(g):
-        gdaltest.post_reason ("pickled geometries were not equal")
+        gdaltest.post_reason("pickled geometries were not equal")
         return 'fail'
 
     return 'success'
@@ -223,35 +223,35 @@ def ogr_geom_polyhedral_surface():
     geom = ogr.CreateGeometryFromWkb(wkb_string)
     wkt_string = geom.ExportToWkt()
     if wkt_string != wkt_original:
-        gdaltest.post_reason ("Failure in Wkb methods of PolyhedralSurface")
+        gdaltest.post_reason("Failure in Wkb methods of PolyhedralSurface")
         return 'fail'
 
     wkt_string = geom.Clone().ExportToWkt()
     if wkt_string != wkt_original:
-        gdaltest.post_reason ("Failure in Clone()")
+        gdaltest.post_reason("Failure in Clone()")
         return 'fail'
 
     polygon_wkt = ogr.ForceTo(geom.Clone(), ogr.wkbPolygon).ExportToWkt()
     if polygon_wkt != wkt_original:
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         print(polygon_wkt)
         return 'fail'
 
     polygon_wkt = ogr.ForceTo(geom.Clone(), ogr.wkbMultiPolygon).ExportToWkt()
     if polygon_wkt != 'MULTIPOLYGON (((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 0,1 0 0,1 0 1,0 0 1,0 0 0)),((1 1 0,1 1 1,1 0 1,1 0 0,1 1 0)),((0 1 0,0 1 1,1 1 1,1 1 0,0 1 0)),((0 0 1,1 0 1,1 1 1,0 1 1,0 0 1)))':
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         print(polygon_wkt)
         return 'fail'
 
     if ogrtest.have_sfcgal():
         area = ps.Area()
         if area != 6.0:
-            gdaltest.post_reason ("Wrong area of PolyhedralSurface")
+            gdaltest.post_reason("Wrong area of PolyhedralSurface")
             return 'fail'
 
     size = ps.WkbSize()
     if size != 807:
-        gdaltest.post_reason ("Wrong WkbSize() of PolyhedralSurface")
+        gdaltest.post_reason("Wrong WkbSize() of PolyhedralSurface")
         return 'fail'
 
     #if ogrtest.have_sfcgal():
@@ -266,22 +266,22 @@ def ogr_geom_polyhedral_surface():
     if ogrtest.have_geos() or ogrtest.have_sfcgal():
         geom = ogr.CreateGeometryFromWkb(wkb_string)
         if not ps.Contains(geom):
-            gdaltest.post_reason ("Failure in Contains() of PolyhedralSurface")
+            gdaltest.post_reason("Failure in Contains() of PolyhedralSurface")
             return 'fail'
 
     if ps.IsEmpty():
-        gdaltest.post_reason ("Failure in IsEmpty() of PolyhedralSurface")
+        gdaltest.post_reason("Failure in IsEmpty() of PolyhedralSurface")
         return 'fail'
 
     ps.Empty()
     wkt_string = ps.ExportToWkt()
     if wkt_string != 'POLYHEDRALSURFACE Z EMPTY':
-        gdaltest.post_reason ("Failure in Empty() of PolyhedralSurface")
+        gdaltest.post_reason("Failure in Empty() of PolyhedralSurface")
         return 'fail'
 
     g = ogr.CreateGeometryFromWkt('POLYHEDRALSURFACE (((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)))')
     if g.Equals(g) == 0:
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         return 'fail'
 
     for wkt in [ 'MULTIPOLYGON (((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)))',
@@ -290,18 +290,18 @@ def ogr_geom_polyhedral_surface():
                  'POLYHEDRALSURFACE EMPTY' ]:
         g2 = ogr.CreateGeometryFromWkt(wkt)
         if g.Equals(g2):
-            gdaltest.post_reason ("Unexpected true Equals() return")
+            gdaltest.post_reason("Unexpected true Equals() return")
             print(wkt)
             return 'fail'
 
     # Error
     if g.AddGeometry( ogr.CreateGeometryFromWkt('POINT (0 0)') ) == 0:
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         return 'fail'
 
     # Error
     if g.AddGeometryDirectly( ogr.CreateGeometryFromWkt('POINT (0 0)') ) == 0:
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         return 'fail'
 
     # Test dimension promotion
@@ -310,7 +310,7 @@ def ogr_geom_polyhedral_surface():
     g.AddGeometryDirectly( ogr.CreateGeometryFromWkt('POLYGON ((10 10,10 11,11 11,10 10))') )
     wkt = g.ExportToIsoWkt()
     if wkt != 'POLYHEDRALSURFACE ZM (((0 0 1 2,0 1 1 2,1 1 1 2,0 0 1 2)),((10 10 0 0,10 11 0 0,11 11 0 0,10 10 0 0)))':
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         print(wkt)
         return 'fail'
 
@@ -331,7 +331,7 @@ def ogr_geom_tin():
         geom = tin.GetGeometryRef(i)
         wkt_geom = geom.ExportToWkt()
         if polygon_wkt[i] != wkt_geom:
-            gdaltest.post_reason ("Failure in getting geometries of TIN")
+            gdaltest.post_reason("Failure in getting geometries of TIN")
             return 'fail'
 
     wkt_original = 'TIN Z (((0 0 0,0 0 1,0 1 0,0 0 0)),((0 0 0,0 1 0,1 1 0,0 0 0)))'
@@ -341,23 +341,23 @@ def ogr_geom_tin():
     geom = ogr.CreateGeometryFromWkb(wkb_string)
     wkt_string = geom.ExportToWkt()
     if wkt_string != wkt_original:
-        gdaltest.post_reason ("Failure in Wkb methods of TIN")
+        gdaltest.post_reason("Failure in Wkb methods of TIN")
         return 'fail'
 
     wkt_string = geom.Clone().ExportToWkt()
     if wkt_string != wkt_original:
-        gdaltest.post_reason ("Failure in Clone()")
+        gdaltest.post_reason("Failure in Clone()")
         return 'fail'
 
     if ogrtest.have_sfcgal():
         area = 12.3*tin.Area()
         if area != 12.3:
-            gdaltest.post_reason ("Wrong area of TIN")
+            gdaltest.post_reason("Wrong area of TIN")
             return 'fail'
 
     size = tin.WkbSize()
     if size != 227:
-        gdaltest.post_reason ("Wrong WkbSize() of TIN")
+        gdaltest.post_reason("Wrong WkbSize() of TIN")
         return 'fail'
 
     #geom = tin.DelaunayTriangulation(0.0,True)
@@ -374,13 +374,13 @@ def ogr_geom_tin():
     #    return 'fail'
 
     if tin.IsEmpty():
-        gdaltest.post_reason ("Failure in IsEmpty() of TIN")
+        gdaltest.post_reason("Failure in IsEmpty() of TIN")
         return 'fail'
 
     tin.Empty()
     wkt_string = tin.ExportToWkt()
     if wkt_string != 'TIN Z EMPTY':
-        gdaltest.post_reason ("Failure in Empty() of TIN")
+        gdaltest.post_reason("Failure in Empty() of TIN")
         return 'fail'
 
     wrong_polygon = ogr.CreateGeometryFromWkt('POLYGON ((0 0 0,0 1 0,1 1 0,0 0 1))')
@@ -389,7 +389,7 @@ def ogr_geom_tin():
     x = tin.AddGeometry(wrong_polygon)
     gdal.PopErrorHandler()
     if tin.GetGeometryCount() != geom_count:
-        gdaltest.post_reason ("Added wrong geometry in TIN, error has code " + str(x))
+        gdaltest.post_reason("Added wrong geometry in TIN, error has code " + str(x))
         return 'fail'
 
     if ogrtest.have_geos() or ogrtest.have_sfcgal():
@@ -397,7 +397,7 @@ def ogr_geom_tin():
         point_wkt = point.ExportToWkt()
         point_correct_wkt = 'POINT EMPTY'
         if point_wkt != point_correct_wkt:
-            gdaltest.post_reason ("Wrong Point Obtained for PointOnSurface() in TIN")
+            gdaltest.post_reason("Wrong Point Obtained for PointOnSurface() in TIN")
             print(point_wkt)
             return 'fail'
 
@@ -412,7 +412,7 @@ def ogr_geom_tin():
 
     tin.FlattenTo2D()
     if tin.IsValid():
-        gdaltest.post_reason ("Problem with IsValid() in TIN")
+        gdaltest.post_reason("Problem with IsValid() in TIN")
         return 'fail'
 
     # 4 points
@@ -1390,23 +1390,23 @@ def ogr_geom_triangle():
     geom = ogr.CreateGeometryFromWkb(wkb_string)
     wkt_string = geom.ExportToWkt()
     if wkt_string != wkt_original:
-        gdaltest.post_reason ("Failure in Wkb methods of Triangle")
+        gdaltest.post_reason("Failure in Wkb methods of Triangle")
         return 'fail'
 
     wkt_string = geom.Clone().ExportToWkt()
     if wkt_string != wkt_original:
-        gdaltest.post_reason ("Failure in Clone()")
+        gdaltest.post_reason("Failure in Clone()")
         return 'fail'
 
     polygon_wkt = ogr.ForceTo(geom.Clone(), ogr.wkbPolygon).ExportToWkt()
     if polygon_wkt != 'POLYGON ((0 0,0 1,1 1,0 0))':
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         print(polygon_wkt)
         return 'fail'
 
     polygon_wkt = ogr.ForceTo(geom.Clone(), ogr.wkbMultiPolygon).ExportToWkt()
     if polygon_wkt != 'MULTIPOLYGON (((0 0,0 1,1 1,0 0)))':
-        gdaltest.post_reason ("fail")
+        gdaltest.post_reason("fail")
         print(polygon_wkt)
         return 'fail'
 

--- a/autotest/ogr/ogr_georss.py
+++ b/autotest/ogr/ogr_georss.py
@@ -131,7 +131,7 @@ def ogr_georss_1_atom_ns():
 def ogr_georss_1bis():
 
     try:
-        os.remove ('tmp/test_atom.xml')
+        os.remove('tmp/test_atom.xml')
     except:
         pass
 
@@ -261,7 +261,7 @@ def ogr_georss_3():
 def ogr_georss_create(filename, options):
 
     try:
-        os.remove (filename)
+        os.remove(filename)
     except:
         pass
     ds = ogr.GetDriverByName('GeoRSS').CreateDataSource(filename, options = options )
@@ -402,7 +402,7 @@ def ogr_georss_9():
 
 def ogr_georss_10():
     try:
-        os.remove ('tmp/test32631.rss')
+        os.remove('tmp/test32631.rss')
     except:
         pass
 
@@ -423,7 +423,7 @@ def ogr_georss_10():
     ds = None
 
     try:
-        os.remove ('tmp/test32631.rss')
+        os.remove('tmp/test32631.rss')
     except:
         pass
 
@@ -520,7 +520,7 @@ def ogr_georss_12():
 
 def ogr_georss_13():
     try:
-        os.remove ('tmp/nonstandard.rss')
+        os.remove('tmp/nonstandard.rss')
     except:
         pass
     ds = ogr.GetDriverByName('GeoRSS').CreateDataSource('tmp/nonstandard.rss', options = [ 'USE_EXTENSIONS=YES'] )
@@ -631,7 +631,7 @@ def ogr_georss_cleanup():
     list_files = [ 'tmp/test_rss2.xml', 'tmp/test_atom.xml', 'tmp/test32631.rss', 'tmp/broken.rss', 'tmp/nonstandard.rss' ]
     for filename in list_files:
         try:
-            os.remove (filename)
+            os.remove(filename)
         except:
             pass
 

--- a/autotest/ogr/ogr_gpx.py
+++ b/autotest/ogr/ogr_gpx.py
@@ -356,7 +356,7 @@ def ogr_gpx_7():
     bna_ds = ogr.Open( 'data/bna_for_gpx.bna' )
 
     try:
-        os.remove ('tmp/gpx.gpx')
+        os.remove('tmp/gpx.gpx')
     except:
         pass
 
@@ -427,7 +427,7 @@ def ogr_gpx_8():
     gdaltest.gpx_ds = None
 
     try:
-        os.remove ('tmp/gpx.gpx')
+        os.remove('tmp/gpx.gpx')
     except:
         pass
 
@@ -535,7 +535,7 @@ def ogr_gpx_cleanup():
 
     gdaltest.gpx_ds = None
     try:
-        os.remove ('tmp/gpx.gpx')
+        os.remove('tmp/gpx.gpx')
     except:
         pass
     return 'success'

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -405,11 +405,11 @@ def ogr_libkml_write(filename):
 
     lyr = ds.CreateLayer('test_wgs84')
 
-    fielddefn = ogr.FieldDefn ( 'name', ogr.OFTString)
+    fielddefn = ogr.FieldDefn( 'name', ogr.OFTString)
     lyr.CreateField(fielddefn)
-    fielddefn = ogr.FieldDefn ( 'description', ogr.OFTString)
+    fielddefn = ogr.FieldDefn( 'description', ogr.OFTString)
     lyr.CreateField(fielddefn)
-    fielddefn = ogr.FieldDefn ( 'foo', ogr.OFTString)
+    fielddefn = ogr.FieldDefn( 'foo', ogr.OFTString)
     lyr.CreateField(fielddefn)
 
     dst_feat = ogr.Feature( lyr.GetLayerDefn() )

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -60,7 +60,7 @@ def ogr_mem_2():
         return 'skip'
 
     if gdaltest.mem_ds.TestCapability( ogr.ODsCCreateLayer ) == 0:
-        gdaltest.post_reason ('ODsCCreateLayer TestCapability failed.' )
+        gdaltest.post_reason('ODsCCreateLayer TestCapability failed.' )
         return 'fail'
 
     #######################################################
@@ -94,7 +94,7 @@ def ogr_mem_2():
         dst_feat.SetFrom( feat )
         ret = gdaltest.mem_lyr.CreateFeature( dst_feat )
         if ret != 0:
-            gdaltest.post_reason ('CreateFeature() failed.' )
+            gdaltest.post_reason('CreateFeature() failed.' )
             return 'fail'
 
         feat = shp_lyr.GetNextFeature()
@@ -369,7 +369,7 @@ def ogr_mem_10():
 def ogr_mem_11():
 
     if gdaltest.mem_ds.TestCapability( 'DeleteLayer' ) == 0:
-        gdaltest.post_reason ('Deletelayer TestCapability failed.' )
+        gdaltest.post_reason('Deletelayer TestCapability failed.' )
         return 'fail'
 
     gdaltest.mem_ds.CreateLayer( 'extra' )

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -1132,7 +1132,7 @@ def ogr_pg_21_3d_geometries():
         gdaltest.post_reason( 'No layer received' )
         return 'fail'
 
-    for i in range (0, 3):
+    for i in range(0, 3):
         feat = layer.GetFeature(i)
         geom = feat.GetGeometryRef()
 

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -2860,7 +2860,7 @@ def ogr_shape_59():
     geom = feat.GetGeometryRef()
 
     if geom.GetGeometryName() != 'POINT':
-        print (geom.GetGeometryName())
+        print(geom.GetGeometryName())
         gdaltest.post_reason( 'Geometry of wrong type.' )
         return 'fail'
 
@@ -2878,7 +2878,7 @@ def ogr_shape_59():
     feat = shp_lyr.GetNextFeature()
     geom = feat.GetGeometryRef()
     if geom.ExportToIsoWkt() != 'LINESTRING M (0 0 10,1 1 20)':
-        print (geom.ExportToIsoWkt())
+        print(geom.ExportToIsoWkt())
         gdaltest.post_reason( 'fail' )
         return 'fail'
     feat = shp_lyr.GetNextFeature()
@@ -2894,13 +2894,13 @@ def ogr_shape_59():
     feat = shp_lyr.GetNextFeature()
     geom = feat.GetGeometryRef()
     if geom.ExportToIsoWkt() != 'POLYGON M ((0 0 10,0 1 20,1 1 30,0 0 40))':
-        print (geom.ExportToIsoWkt())
+        print(geom.ExportToIsoWkt())
         gdaltest.post_reason( 'fail' )
         return 'fail'
     feat = shp_lyr.GetNextFeature()
     geom = feat.GetGeometryRef()
     if geom.ExportToIsoWkt() != 'POLYGON M ((0 0 10,0 1 20,1 1 30,0 0 40),(0.25 0.25 50,0.75 0.75 60,0.25 0.75 70,0.25 0.25 80))':
-        print (geom.ExportToIsoWkt())
+        print(geom.ExportToIsoWkt())
         gdaltest.post_reason( 'fail' )
         return 'fail'
     geom = None

--- a/autotest/ogr/ogr_vfk.py
+++ b/autotest/ogr/ogr_vfk.py
@@ -165,7 +165,7 @@ def ogr_vfk_4():
         return 'fail'
 
     feat = gdaltest.vfk_layer_sbp.GetFeature(5)
-    length = int (feat.geometry().Length())
+    length = int(feat.geometry().Length())
 
     if length != 10:
         gdaltest.post_reason('did not get expected length, got %d' % length)

--- a/autotest/ogr/ogr_wktempty.py
+++ b/autotest/ogr/ogr_wktempty.py
@@ -46,7 +46,7 @@ class TestWktEmpty:
 
         if not geom.IsEmpty():
             geom.Destroy()
-            gdaltest.post_reason ("IsEmpty returning false for an empty geometry")
+            gdaltest.post_reason("IsEmpty returning false for an empty geometry")
             return 'fail'
 
         return 'success'

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1084,7 +1084,7 @@ class GDALTest:
         new_ds = None
 
         if delete:
-            new_ds = gdal.Open (new_filename)
+            new_ds = gdal.Open(new_filename)
             if new_ds.GetRasterBand(1).GetNoDataValue() is not None:
                 post_reason( 'Got nodata value whereas none was expected' )
                 return 'fail'

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -304,7 +304,7 @@ class GDAL_Handler(BaseHTTPRequestHandler):
 
 class GDAL_HttpServer(HTTPServer):
 
-    def __init__ (self, server_address, handlerClass):
+    def __init__(self, server_address, handlerClass):
         HTTPServer.__init__(self, server_address, handlerClass)
         self.running = False
         self.stop_requested = False
@@ -332,7 +332,7 @@ class GDAL_HttpServer(HTTPServer):
 
 class GDAL_ThreadedHttpServer(Thread):
 
-    def __init__ (self, handlerClass = None):
+    def __init__(self, handlerClass = None):
         Thread.__init__(self)
         ok = False
         self.server = 0

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1400,7 +1400,7 @@ def CopyDatasetInfo( src, dst, xoff=0, yoff=0 ):
             try:
                 dst.SetGCPs( new_gcps , src.GetGCPProjection() )
             except:
-                print ("Failed to set GCPs")
+                print("Failed to set GCPs")
                 return
 
     return

--- a/gdal/swig/python/osgeo/gdal_array.py
+++ b/gdal/swig/python/osgeo/gdal_array.py
@@ -489,7 +489,7 @@ def CopyDatasetInfo( src, dst, xoff=0, yoff=0 ):
             try:
                 dst.SetGCPs( new_gcps , src.GetGCPProjection() )
             except:
-                print ("Failed to set GCPs")
+                print("Failed to set GCPs")
                 return
 
     return

--- a/gdal/swig/python/samples/gdal_vrtmerge.py
+++ b/gdal/swig/python/samples/gdal_vrtmerge.py
@@ -44,7 +44,7 @@ def names_to_fileinfos( names ):
         if fi.init_from_name(name):
             file_infos.append(fi)
         else:
-            print ('Can not open dataset "%s", skipped' % name)
+            print('Can not open dataset "%s", skipped' % name)
 
     return file_infos
 
@@ -158,9 +158,9 @@ class file_info:
 
 # =============================================================================
 def Usage():
-    print ('Usage: gdal_vrtmerge.py [-o out_filename] [-separate] [-pct]')
-    print ('           [-ul_lr ulx uly lrx lry] [-ot datatype] [-i input_file_list')
-    print ('           | input_files]')
+    print('Usage: gdal_vrtmerge.py [-o out_filename] [-separate] [-pct]')
+    print('           [-ul_lr ulx uly lrx lry] [-ot datatype] [-i input_file_list')
+    print('           | input_files]')
 
 # =============================================================================
 #
@@ -206,7 +206,7 @@ if __name__ == '__main__':
             i = i + 4
 
         elif arg[:1] == '-':
-            print ('Unrecognized command option: ', arg)
+            print('Unrecognized command option: ', arg)
             Usage()
             sys.exit( 1 )
 
@@ -216,14 +216,14 @@ if __name__ == '__main__':
         i = i + 1
 
     if len(names) == 0:
-        print ('No input files selected.')
+        print('No input files selected.')
         Usage()
         sys.exit( 1 )
 
     # Collect information on all the source files.
     file_infos = names_to_fileinfos( names )
     if len(file_infos) == 0:
-        print ('Nothing to process, exiting.')
+        print('Nothing to process, exiting.')
         sys.exit(1)
 
     if ulx is None:
@@ -246,16 +246,16 @@ if __name__ == '__main__':
 
     for fi in file_infos:
         if fi.geotransform[1] != psize_x or fi.geotransform[5] != psize_y:
-            print ("All files must have the same scale; %s does not" \
+            print("All files must have the same scale; %s does not" \
                 % fi.filename)
             sys.exit(1)
 
         if fi.geotransform[2] != 0 or fi.geotransform[4] != 0:
-            print ("No file must be rotated; %s is" % fi.filename)
+            print("No file must be rotated; %s is" % fi.filename)
             sys.exit(1)
 
         if fi.projection != projection:
-            print ("All files must be in the same projection; %s is not" \
+            print("All files must be in the same projection; %s is not" \
                 % fi.filename)
             sys.exit(1)
 
@@ -283,7 +283,7 @@ if __name__ == '__main__':
         for fi in file_infos:
             band_n = band_n + 1
             if len(fi.band_types) != 2:
-                print ( 'File %s has %d bands. Only first band will be taken '
+                print( 'File %s has %d bands. Only first band will be taken '
                         'into account' % (fi.filename, len(fi.band_types)-1))
             dataType = gdal.GetDataTypeName(fi.band_types[1])
 

--- a/gdal/swig/python/samples/ogr2ogr.py
+++ b/gdal/swig/python/samples/ogr2ogr.py
@@ -73,7 +73,7 @@ nLastTick = -1
 def TermProgress( dfComplete, pszMessage, pProgressArg ):
 
     global nLastTick
-    nThisTick = (int) (dfComplete * 40.0)
+    nThisTick = int(dfComplete * 40.0)
 
     if nThisTick < 0:
         nThisTick = 0
@@ -494,7 +494,7 @@ def main(args = None, progress_func = TermProgress, progress_data = None):
         elif pszDataSource is None:
             pszDataSource = args[iArg]
         else:
-            papszLayers.append (args[iArg] )
+            papszLayers.append(args[iArg])
 
         iArg = iArg + 1
 
@@ -1159,7 +1159,7 @@ def wkbFlatten(x):
 #                               SetZ()
 #**********************************************************************
 
-def SetZ (poGeom, dfZ ):
+def SetZ(poGeom, dfZ):
 
     if poGeom is None:
         return

--- a/gdal/swig/python/scripts/gdal_retile.py
+++ b/gdal/swig/python/scripts/gdal_retile.py
@@ -311,7 +311,7 @@ def getTileIndexFromFiles( inputTiles, driverTyp):
 
 
 
-def getTargetDir (level = -1):
+def getTargetDir(level = -1):
     if level==-1:
         return TargetDir
     else:
@@ -893,7 +893,7 @@ def main(args = None):
 
     if Levels > 0:    #prepare Dirs for pyramid
         startIndx=1
-        for levelIndx in range (startIndx,Levels+1):
+        for levelIndx in range(startIndx,Levels+1):
             leveldir=TargetDir+str(levelIndx)+os.sep
             if (os.path.exists(leveldir)):
                 continue

--- a/gdal/swig/python/scripts/mkgraticule.py
+++ b/gdal/swig/python/scripts/mkgraticule.py
@@ -59,8 +59,8 @@ def float_range(*args):
 
 #############################################################################
 def Usage():
-    print ('Usage: mkgraticule [-connected] [-s stepsize] [-substep substepsize]')
-    print ('         [-t_srs srs] [-range xmin ymin xmax ymax] outfile')
+    print('Usage: mkgraticule [-connected] [-s stepsize] [-substep substepsize]')
+    print('         [-t_srs srs] [-range xmin ymin xmax ymax] outfile')
     print('')
     sys.exit(1)
 


### PR DESCRIPTION
## What does this PR do?

Fixes diagnostic E211: `whitespace before '('`. Note that there is one non-whitespace change in the `diff` output:

```
diff --git a/gdal/swig/python/samples/ogr2ogr.py b/gdal/swig/python/samples/ogr2ogr.py
index a1dd054..e554441 100755
--- a/gdal/swig/python/samples/ogr2ogr.py
+++ b/gdal/swig/python/samples/ogr2ogr.py
@@ -73,7 +73,7 @@ nLastTick = -1
 def TermProgress( dfComplete, pszMessage, pProgressArg ):
 
     global nLastTick
-    nThisTick = (int) (dfComplete * 40.0)
+    nThisTick = int(dfComplete * 40.0)
 
     if nThisTick < 0:
         nThisTick = 0
```

This code that mimics C did work, but only because `(int)` as just an over-parenthesised version of `int`.