### PR TITLE
Python code: autotest/ogr/ogr_dxf.py: Fix E1121.

### DIFF
--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -533,7 +533,7 @@ def ogr_dxf_13():
     # that the points lie along (or reasonably close to) said path.
 
     if geom.GetPointCount() != 146:
-        gdaltest.post_reason( 'did not get expected number of points, got %d' % (geom.GetPointCount()) )
+        gdaltest.post_reason( 'did not get expected number of points, got %d' % geom.GetPointCount() )
         return 'fail'
 
     if abs(geom.GetX(0)-251297.8179) > 0.001 \
@@ -588,7 +588,7 @@ def ogr_dxf_14():
         return 'fail'
 
     if geom.GetPointCount() != 146:
-        gdaltest.post_reason( 'did not get expected number of points, got %d' % (geom.GetPointCount()) )
+        gdaltest.post_reason( 'did not get expected number of points, got %d' % geom.GetPointCount() )
         return 'fail'
 
     if abs(geom.GetX(0)-251297.8179) > 0.001 \
@@ -2464,7 +2464,7 @@ def ogr_dxf_33():
 
     faces = geom.GetGeometryCount()
     if faces != 6:
-        gdaltest.post_reason( 'did not get expected number of faces, got %d instead of %d', faces, 6)
+        gdaltest.post_reason( 'did not get expected number of faces, got %d instead of %d' % (faces, 6))
         return 'fail'
 
     # Cylinder (CIRCLE with thickness)


### PR DESCRIPTION
## What does this PR do?

Silences the Pylint error:

```
autotest/ogr/ogr_dxf.py:2467: [E1121(too-many-function-args), ogr_dxf_33] Too many positional arguments for function call
```