### PR TITLE
Fix syntax errors in autotest/pymod/gdaltest.py

### DIFF
--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -546,8 +546,8 @@ class GDALTest:
                 # because we need to support old and buggy Python 2.3.
                 # Tested on Linux, Mac OS X and Windows, with Python 2.3/2.4/2.5.
                 sv = str(new_stat[i]).lower()
-                if sv.find('n') >= 0 or sv.find('i') >= 0 or sv.find('#') >= 0:
-                    post_reason( 'NaN or Invinite value encountered '%'.' % sv )
+                if 'n' in sv or 'i' in sv or '#' in sv:
+                    post_reason('NaN or infinity value encountered \'%s\'.' % sv)
                     return 'fail'
 
                 if abs(new_stat[i]-check_approx_stat[i]) > stat_epsilon:
@@ -570,8 +570,8 @@ class GDALTest:
             for i in range(4):
 
                 sv = str(new_stat[i]).lower()
-                if sv.find('n') >= 0 or sv.find('i') >= 0 or sv.find('#') >= 0:
-                    post_reason( 'NaN or Infinite value encountered '%'.' % sv )
+                if 'n' in sv or 'i' in sv or '#' in sv:
+                    post_reason('NaN or infinity value encountered \'%s\'.' % sv)
                     return 'fail'
 
                 if abs(new_stat[i]-check_stat[i]) > stat_epsilon:


### PR DESCRIPTION
## What does this PR do?

Fixes issue #404. This change fixes syntax errors in `autotest/pymod/gdaltest.py` (found by Pylint). Also, don't call `find()` on a string when `if <char> in <str>` suffices.
    
