### PR TITLE
Conforming gdal dataset layers iterator to input iterator

### DIFF
--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -674,10 +674,10 @@ private:
                 Iterator(const Iterator& oOther); 
                 Iterator(Iterator&& oOther); 
                 ~Iterator();
-				
+                
                 Iterator& operator=(const Iterator& oOther);
                 Iterator& operator=(Iterator&& oOther);
-				
+                
                 OGRLayer* operator*() const;
                 Iterator& operator++();
                 Iterator operator++(int);

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -65,12 +65,14 @@ class GDALAsyncReader;
 #include "cpl_minixml.h"
 #include "cpl_multiproc.h"
 #include "cpl_atomic_ops.h"
-#include <vector>
-#include <map>
-#include <limits>
+
 #include <cmath>
-#include <memory>
 #include <iterator>
+#include <limits>
+#include <map>
+#include <memory>
+#include <vector>
+
 #include "ogr_core.h"
 #include "ogr_feature.h"
 

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -70,6 +70,7 @@ class GDALAsyncReader;
 #include <limits>
 #include <cmath>
 #include <memory>
+#include <iterator>
 #include "ogr_core.h"
 #include "ogr_feature.h"
 
@@ -645,7 +646,7 @@ private:
     virtual int         GetLayerCount();
     virtual OGRLayer    *GetLayer(int iLayer);
 
-    /** Class returned by GetLayers() that act as a container for vector layers. */
+    /** Class returned by GetLayers() that acts as a range of layers. */
     class CPL_DLL Layers
     {
       private:
@@ -659,20 +660,32 @@ private:
                 struct Private;
                 std::unique_ptr<Private> m_poPrivate;
             public:
+				using value_type = OGRLayer*;
+				using reference = OGRLayer*;
+				using difference_type = void;
+				using pointer = void;
+				using iterator_category = std::input_iterator_tag;
+				
+				
+                Iterator();
                 Iterator(GDALDataset* poDS, bool bStart);
-                Iterator(const Iterator& oOther); // declared but not defined. Needed for gcc 5.4 at least
-                Iterator(Iterator&& oOther); // declared but not defined. Needed for gcc 5.4 at least
+                Iterator(const Iterator& oOther); 
+                Iterator(Iterator&& oOther); 
                 ~Iterator();
-                OGRLayer* operator*();
+				
+				Iterator& operator=(const Iterator& oOther);
+                Iterator& operator=(Iterator&& oOther);
+				
+                OGRLayer* operator*() const;
                 Iterator& operator++();
+				Iterator operator++(int);
                 bool operator!=(const Iterator& it) const;
         };
 
       public:
 
-        const Iterator begin() const;
-
-        const Iterator end() const;
+        Iterator begin() const;
+        Iterator end() const;
 
         size_t size() const;
 

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -660,25 +660,25 @@ private:
                 struct Private;
                 std::unique_ptr<Private> m_poPrivate;
             public:
-				using value_type = OGRLayer*;
-				using reference = OGRLayer*;
-				using difference_type = void;
-				using pointer = void;
-				using iterator_category = std::input_iterator_tag;
-				
-				
+
+                using value_type = OGRLayer*;
+                using reference = OGRLayer*;
+                using difference_type = void;
+                using pointer = void;
+                using iterator_category = std::input_iterator_tag;
+
                 Iterator();
                 Iterator(GDALDataset* poDS, bool bStart);
                 Iterator(const Iterator& oOther); 
                 Iterator(Iterator&& oOther); 
                 ~Iterator();
 				
-				Iterator& operator=(const Iterator& oOther);
+                Iterator& operator=(const Iterator& oOther);
                 Iterator& operator=(Iterator&& oOther);
 				
                 OGRLayer* operator*() const;
                 Iterator& operator++();
-				Iterator operator++(int);
+                Iterator operator++(int);
                 bool operator!=(const Iterator& it) const;
         };
 

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -6945,7 +6945,7 @@ GDALDataset::Features GDALDataset::GetFeatures()
  @since GDAL 2.3
 */
 
-const GDALDataset::Features::Iterator GDALDataset::Features::begin() const
+GDALDataset::Features::Iterator GDALDataset::Features::begin() const
 {
     return {m_poSelf, true};
 }
@@ -6960,7 +6960,7 @@ const GDALDataset::Features::Iterator GDALDataset::Features::begin() const
  @since GDAL 2.3
 */
 
-const GDALDataset::Features::Iterator GDALDataset::Features::end() const
+GDALDataset::Features::Iterator GDALDataset::Features::end() const
 {
     return {m_poSelf, false};
 }

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -7020,7 +7020,7 @@ GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator=(
 {
     *m_poPrivate = *oOther.m_poPrivate;
     return *this;
-)
+}
 
 GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator=(
 	GDALDataset::Layers::Iterator&& oOther)

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -6945,7 +6945,7 @@ GDALDataset::Features GDALDataset::GetFeatures()
  @since GDAL 2.3
 */
 
-GDALDataset::Features::Iterator GDALDataset::Features::begin() const
+const GDALDataset::Features::Iterator GDALDataset::Features::begin() const
 {
     return {m_poSelf, true};
 }
@@ -6960,7 +6960,7 @@ GDALDataset::Features::Iterator GDALDataset::Features::begin() const
  @since GDAL 2.3
 */
 
-GDALDataset::Features::Iterator GDALDataset::Features::end() const
+const GDALDataset::Features::Iterator GDALDataset::Features::end() const
 {
     return {m_poSelf, false};
 }
@@ -7096,7 +7096,7 @@ GDALDataset::Layers GDALDataset::GetLayers()
  @since GDAL 2.3
 */
 
-const GDALDataset::Layers::Iterator GDALDataset::Layers::begin() const
+GDALDataset::Layers::Iterator GDALDataset::Layers::begin() const
 {
     return {m_poSelf, true};
 }
@@ -7111,7 +7111,7 @@ const GDALDataset::Layers::Iterator GDALDataset::Layers::begin() const
  @since GDAL 2.3
 */
 
-const GDALDataset::Layers::Iterator GDALDataset::Layers::end() const
+GDALDataset::Layers::Iterator GDALDataset::Layers::end() const
 {
     return {m_poSelf, false};
 }

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -6977,6 +6977,24 @@ struct GDALDataset::Layers::Iterator::Private
     GDALDataset* m_poDS = nullptr;
 };
 
+GDALDataset::Layers::Iterator::Iterator():
+    m_poPrivate(new GDALDataset::Layers::Iterator::Private())
+{}
+
+GDALDataset::Layers::Iterator::Iterator(
+	const GDALDataset::Layers::Iterator& oOther):
+    m_poPrivate(new GDALDataset::Layers::Iterator::Private())
+{
+	*m_poPrivate = *oOther.m_poPrivate;
+}
+
+GDALDataset::Layers::Iterator::Iterator(
+	GDALDataset::Layers::Iterator&& oOther):
+    m_poPrivate(new GDALDataset::Layers::Iterator::Private())
+{
+	*m_poPrivate = *oOther.m_poPrivate;
+}
+
 GDALDataset::Layers::Iterator::Iterator(GDALDataset* poDS, bool bStart):
     m_poPrivate(new GDALDataset::Layers::Iterator::Private())
 {
@@ -6997,7 +7015,21 @@ GDALDataset::Layers::Iterator::~Iterator()
 {
 }
 
-OGRLayer* GDALDataset::Layers::Iterator::operator*()
+GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator=(
+	const GDALDataset::Layers::Iterator& oOther)
+{
+	*m_poPrivate = *oOther.m_poPrivate;
+	return *this;
+)
+
+GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator=(
+	GDALDataset::Layers::Iterator&& oOther)
+{
+	*m_poPrivate = *oOther.m_poPrivate;
+	return *this;
+}
+
+OGRLayer* GDALDataset::Layers::Iterator::operator*() const
 {
     return m_poPrivate->m_poLayer;
 }
@@ -7015,6 +7047,13 @@ GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator++()
         m_poPrivate->m_poLayer = nullptr;
     }
     return *this;
+}
+
+GDALDataset::Layers::Iterator GDALDataset::Layers::Iterator::operator++(int)
+{
+	GDALDataset::Layers::Iterator temp = *this;
+	++(*this);
+	return temp;
 }
 
 bool GDALDataset::Layers::Iterator::operator!= (const Iterator& it) const

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -6982,17 +6982,17 @@ GDALDataset::Layers::Iterator::Iterator():
 {}
 
 GDALDataset::Layers::Iterator::Iterator(
-	const GDALDataset::Layers::Iterator& oOther):
+    const GDALDataset::Layers::Iterator& oOther):
     m_poPrivate(new GDALDataset::Layers::Iterator::Private())
 {
-	*m_poPrivate = *oOther.m_poPrivate;
+    *m_poPrivate = *oOther.m_poPrivate;
 }
 
 GDALDataset::Layers::Iterator::Iterator(
-	GDALDataset::Layers::Iterator&& oOther):
+    GDALDataset::Layers::Iterator&& oOther):
     m_poPrivate(new GDALDataset::Layers::Iterator::Private())
 {
-	*m_poPrivate = *oOther.m_poPrivate;
+    *m_poPrivate = *oOther.m_poPrivate;
 }
 
 GDALDataset::Layers::Iterator::Iterator(GDALDataset* poDS, bool bStart):
@@ -7018,15 +7018,15 @@ GDALDataset::Layers::Iterator::~Iterator()
 GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator=(
 	const GDALDataset::Layers::Iterator& oOther)
 {
-	*m_poPrivate = *oOther.m_poPrivate;
-	return *this;
+    *m_poPrivate = *oOther.m_poPrivate;
+    return *this;
 )
 
 GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator=(
 	GDALDataset::Layers::Iterator&& oOther)
 {
-	*m_poPrivate = *oOther.m_poPrivate;
-	return *this;
+    *m_poPrivate = *oOther.m_poPrivate;
+    return *this;
 }
 
 OGRLayer* GDALDataset::Layers::Iterator::operator*() const
@@ -7051,9 +7051,9 @@ GDALDataset::Layers::Iterator& GDALDataset::Layers::Iterator::operator++()
 
 GDALDataset::Layers::Iterator GDALDataset::Layers::Iterator::operator++(int)
 {
-	GDALDataset::Layers::Iterator temp = *this;
-	++(*this);
-	return temp;
+    GDALDataset::Layers::Iterator temp = *this;
+    ++(*this);
+    return temp;
 }
 
 bool GDALDataset::Layers::Iterator::operator!= (const Iterator& it) const


### PR DESCRIPTION
## What does this PR do?
Adds boilerplate to gdaldataset::layer::iterator to make it conform to InputIterator concept. As follow up to mailing list comment by Even. Still needs testing because I don't have a proper GDAL development environment.
