### PR TITLE
Python code: Call print(), not print for Python 3.

### DIFF
--- a/autotest/ogr/ograpispy.py
+++ b/autotest/ogr/ograpispy.py
@@ -64,7 +64,7 @@ def ograpispy_1():
 
     if ref_data != got_data:
         gdaltest.post_reason('did not get expected script')
-        print
+        print()
         for line in unified_diff(ref_data.splitlines(), got_data.splitlines(),
                                      fromfile='expected', tofile='got',
                                      linterm=""):


### PR DESCRIPTION
I think this was missed in the adjustments made for #418 ?