### PR TITLE
configure: don't conflate freebsd1 with freebsd10 and 11

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -13623,7 +13623,7 @@ fi
       hardcode_shlibpath_var=no
       ;;
 
-    freebsd1*)
+    freebsd1.*)
       ld_shlibs=no
       ;;
 
@@ -13639,7 +13639,7 @@ fi
       ;;
 
     # Unfortunately, older versions of FreeBSD 2 do not have this feature.
-    freebsd2*)
+    freebsd2.*)
       archive_cmds='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'
       hardcode_direct=yes
       hardcode_minus_L=yes
@@ -14617,7 +14617,7 @@ dgux*)
   shlibpath_var=LD_LIBRARY_PATH
   ;;
 
-freebsd1*)
+freebsd1.*)
   dynamic_linker=no
   ;;
 
@@ -14628,7 +14628,7 @@ freebsd* | dragonfly*)
     objformat=`/usr/bin/objformat`
   else
     case $host_os in
-    freebsd[123]*) objformat=aout ;;
+    freebsd[123].*) objformat=aout ;;
     *) objformat=elf ;;
     esac
   fi
@@ -14646,7 +14646,7 @@ freebsd* | dragonfly*)
   esac
   shlibpath_var=LD_LIBRARY_PATH
   case $host_os in
-  freebsd2*)
+  freebsd2.*)
     shlibpath_overrides_runpath=yes
     ;;
   freebsd3.[01]* | freebsdelf3.[01]*)
@@ -16586,7 +16586,7 @@ fi
         esac
         ;;
 
-      freebsd[12]*)
+      freebsd[12].*)
         # C++ shared libraries reported to be fairly broken before
 	# switch to ELF
         ld_shlibs_CXX=no
@@ -18450,7 +18450,7 @@ dgux*)
   shlibpath_var=LD_LIBRARY_PATH
   ;;
 
-freebsd1*)
+freebsd1.*)
   dynamic_linker=no
   ;;
 
@@ -18461,7 +18461,7 @@ freebsd* | dragonfly*)
     objformat=`/usr/bin/objformat`
   else
     case $host_os in
-    freebsd[123]*) objformat=aout ;;
+    freebsd[123].*) objformat=aout ;;
     *) objformat=elf ;;
     esac
   fi
@@ -18479,7 +18479,7 @@ freebsd* | dragonfly*)
   esac
   shlibpath_var=LD_LIBRARY_PATH
   case $host_os in
-  freebsd2*)
+  freebsd2.*)
     shlibpath_overrides_runpath=yes
     ;;
   freebsd3.[01]* | freebsdelf3.[01]*)


### PR DESCRIPTION
## What does this PR do?

The checks for freebsd versions in configure are too general.  Checks for version 1 also match versions 10, 11 and upwards.  Those for version 2 will match 20, 21 etc. (an issue for the future).

The end result is that a static build is always generated, and thus all tools such as gdalwarp are >120 MB in size, libgdal.a is ~360 MB and the build tree is another 8-9 GB.  

## What are related issues/pull requests?

See further comments in shawnlaffan/perl-alien-gdal#7 (not all are directly relevant to this PR)

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:  freebsd
* Compiler:  Freebsd clang 4.0.0


