### PR TITLE
Python code: Remove unused variables and imports

### DIFF
--- a/gdal/swig/include/python/docs/doxy2swig.py
+++ b/gdal/swig/include/python/docs/doxy2swig.py
@@ -231,8 +231,6 @@ class Doxy2SWIG:
 
     def do_memberdef(self, node):
         prot = node.attributes['prot'].value
-        id = node.attributes['id'].value
-        kind = node.attributes['kind'].value
         tmp = node.parentNode.parentNode.parentNode
         compdef = tmp.getElementsByTagName('compounddef')[0]
         cdef_kind = compdef.attributes['kind'].value


### PR DESCRIPTION
## What does this PR do?

Silences two warnings from `flake8` about unused variables.