### PR TITLE
Remove imports: os, os.path, subprocess.call.

### DIFF
--- a/gdal/scripts/completionFinder.py
+++ b/gdal/scripts/completionFinder.py
@@ -29,11 +29,9 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
 import sys
-import os.path as op
 
-from subprocess import call, Popen, PIPE, STDOUT
+from subprocess import Popen, PIPE, STDOUT
 
 
 def showHelp():


### PR DESCRIPTION
Fixed warnings about unused imports.