### PR TITLE
Python code: Simplify dictionary setup in autotest/gcore/tiff_write.py

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -913,10 +913,7 @@ def tiff_write_20():
               ('TIFFTAG_MAXSAMPLEVALUE', '2'),
               ]
 
-    dict = {}
-    for item in values:
-        dict[item[0]] = item[1]
-    new_ds.SetMetadata(dict)
+    new_ds.SetMetadata(dict(values))
 
     new_ds = None
 


### PR DESCRIPTION
## What does this PR do?

Simplifies the setup of the dictionary in `tiff_write_4`. There is no need to loop over the list of tuples when this works instead:

```
>>> lst = [(1,2), (3,4), (5,6)]
>>> dict(lst)
{1: 2, 3: 4, 5: 6}
```