### PR TITLE
Python code: Avoid using built-in types as variable names

### DIFF
--- a/autotest/gcore/hfa_rfc40.py
+++ b/autotest/gcore/hfa_rfc40.py
@@ -359,11 +359,11 @@ def CheckLinearBinning(fname):
     band = ds.GetRasterBand(1)
     rat = band.GetDefaultRAT()
 
-    (state, min, size) = rat.GetLinearBinning()
+    (state, mini, size) = rat.GetLinearBinning()
     if not state:
         raise HFATestError("GetLinearBinning failed")
 
-    if min != 0 or size != 1:
+    if mini != 0 or size != 1:
         raise HFATestError("GetLinearBinning values wrong")
 
     if rat.GetRowOfValue(3) != 3:

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -427,9 +427,8 @@ def numpy_rw_12():
 
     drv = gdal.GetDriverByName('MEM')
     ds = drv.Create('', 1, 2, 1, gdal.GDT_Byte)
-    slice = ar[:, 1:]
 
-    ds.GetRasterBand(1).WriteArray(slice)
+    ds.GetRasterBand(1).WriteArray(ar[:, 1:])
 
     ar_read = numpy.zeros_like(ar)
     slice_read = ar_read[:, 1:]

--- a/autotest/gcore/pam.py
+++ b/autotest/gcore/pam.py
@@ -476,10 +476,10 @@ def pam_12():
 </PAMDataset>""")
 
     ds = gdal.Open('tmp/byte.tif')
-    (min, max, _, hist1) = ds.GetRasterBand(1).GetDefaultHistogram()
+    (mini, maxi, _, hist1) = ds.GetRasterBand(1).GetDefaultHistogram()
     hist2 = ds.GetRasterBand(1).GetHistogram(include_out_of_range=1, approx_ok=0)
     ds.SetMetadataItem('FOO', 'BAR')
-    ds.GetRasterBand(1).SetDefaultHistogram(min, max, hist1)
+    ds.GetRasterBand(1).SetDefaultHistogram(mini, maxi, hist1)
     ds = None
     aux_xml = open('tmp/byte.tif.aux.xml', 'rt').read()
     gdal.Unlink('tmp/byte.tif')

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -1602,7 +1602,7 @@ def tiff_ovr_40():
         for i in range(pix_count):
             total += ord(ovimage[i])
 
-    average = sum / pix_count
+    average = total / pix_count
     exp_average = 153.0656
     if abs(average - exp_average) > 0.1:
         print(average)

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -192,19 +192,19 @@ def tiff_ovr_4():
     ovimage = ovband.ReadRaster(0, 0, ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    sum = 0.0
+    total = 0.0
     is_bytes = False
     if (isinstance(ovimage, bytes) and not isinstance(ovimage, str)):
         is_bytes = True
 
     if is_bytes is True:
         for i in range(pix_count):
-            sum = sum + ovimage[i]
+            total += ovimage[i]
     else:
         for i in range(pix_count):
-            sum = sum + ord(ovimage[i])
+            total += ord(ovimage[i])
 
-    average = sum / pix_count
+    average = total / pix_count
     exp_average = 153.0656
     if abs(average - exp_average) > 0.1:
         print(average)
@@ -219,14 +219,14 @@ def tiff_ovr_4():
                                 ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    sum = 0.0
+    total = 0.0
     if is_bytes is True:
         for i in range(pix_count):
-            sum = sum + ovimage[i]
+            total += ovimage[i]
     else:
         for i in range(pix_count):
-            sum = sum + ord(ovimage[i])
-    average = sum / pix_count
+            total += ord(ovimage[i])
+    average = total / pix_count
     exp_average = 0.6096
 
     if abs(average - exp_average) > 0.01:
@@ -1156,9 +1156,7 @@ def tiff_ovr_30():
     ds = None
 
     ds = gdal.Open('tmp/ovr30.tif', gdal.GA_Update)
-    dict = {}
-    dict['TEST_KEY'] = 'TestValue'
-    ds.SetMetadata(dict)
+    ds.SetMetadata({'TEST_KEY': 'TestValue'})
     ds = None
 
     ds = gdaltest.tiff_drv.Create('tmp/ovr30.tif', 20, 20, 1)
@@ -1592,17 +1590,17 @@ def tiff_ovr_40():
     ovimage = ovband.ReadRaster(0, 0, ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    sum = 0.0
+    total = 0.0
     is_bytes = False
     if (isinstance(ovimage, bytes) and not isinstance(ovimage, str)):
         is_bytes = True
 
     if is_bytes is True:
         for i in range(pix_count):
-            sum = sum + ovimage[i]
+            total += ovimage[i]
     else:
         for i in range(pix_count):
-            sum = sum + ord(ovimage[i])
+            total += ord(ovimage[i])
 
     average = sum / pix_count
     exp_average = 153.0656
@@ -1619,14 +1617,14 @@ def tiff_ovr_40():
                                 ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    sum = 0.0
+    total = 0.0
     if is_bytes is True:
         for i in range(pix_count):
-            sum = sum + ovimage[i]
+            total += ovimage[i]
     else:
         for i in range(pix_count):
-            sum = sum + ord(ovimage[i])
-    average = sum / pix_count
+            total += ord(ovimage[i])
+    average = total / pix_count
     exp_average = 0.6096
 
     if abs(average - exp_average) > 0.01:

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -182,9 +182,7 @@ def tiff_write_4():
         gdaltest.post_reason('Wrong geotransform.')
         return 'fail'
 
-    dict = {}
-    dict['TEST_KEY'] = 'TestValue'
-    new_ds.SetMetadata(dict)
+    new_ds.SetMetadata({'TEST_KEY': 'TestValue'})
 
     new_ds = None
 
@@ -2706,9 +2704,7 @@ def tiff_write_72():
 
     shutil.copyfile('data/byte.tif', 'tmp/byte.tif')
     ds = gdal.Open('tmp/byte.tif', gdal.GA_Update)
-    dict = {}
-    dict['TEST_KEY'] = 'TestValue'
-    ds.SetMetadata(dict)
+    ds.SetMetadata({'TEST_KEY': 'TestValue'})
     ds = None
 
     for profile in ('GDALGeotiff', 'GEOTIFF', 'BASELINE'):
@@ -2748,9 +2744,7 @@ def tiff_write_73():
     srs = osr.SpatialReference()
     srs.SetFromUserInput('EPSG:32601')
     out_ds.SetProjection(srs.ExportToWkt())
-    dict = {}
-    dict['TEST_KEY'] = 'TestValue'
-    out_ds.SetMetadata(dict)
+    out_ds.SetMetadata({'TEST_KEY': 'TestValue'})
     out_ds.BuildOverviews('NONE', [2])
     out_ds.GetRasterBand(1).Fill(255)
     out_ds = None

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -911,10 +911,7 @@ def tiff_write_20():
               ('TIFFTAG_MAXSAMPLEVALUE', '2'),
               ]
 
-    dict = {}
-    for item in values:
-        dict[item[0]] = item[1]
-    new_ds.SetMetadata(dict)
+    new_ds.SetMetadata(dict(values))
 
     new_ds = None
 
@@ -3690,9 +3687,9 @@ def tiff_write_88():
     # so that the CreateCopy() aborts quickly
     f = open('tmp/tiff_write_88_src.tif', 'rb')
     f.seek(0, 2)
-    len = f.tell()
+    length = f.tell()
     f.seek(0, 0)
-    data = f.read(len - 1)
+    data = f.read(length - 1)
     f.close()
     f = open('tmp/tiff_write_88_src.tif', 'wb')
     f.write(data)

--- a/autotest/gdrivers/arg.py
+++ b/autotest/gdrivers/arg.py
@@ -105,9 +105,8 @@ def arg_init():
 
     for d in gdaltest.argTests:
         for (name, fmt, nodata) in d['formats']:
-            bytes = encode(fmt, nodata, d['data'])
             arg = open('data/arg-' + name + '.arg', 'wb')
-            arg.write(bytes)
+            arg.write(encode(fmt, nodata, d['data']))
             arg.close()
 
             meta = copy(gdaltest.argDefaults)

--- a/autotest/gdrivers/hfa.py
+++ b/autotest/gdrivers/hfa.py
@@ -244,13 +244,13 @@ def hfa_float_stats_1():
 
     tolerance = 0.0001
 
-    min = float(md['STATISTICS_MINIMUM'])
-    if abs(min - 40.91858291626) > tolerance:
+    mini = float(md['STATISTICS_MINIMUM'])
+    if abs(mini - 40.91858291626) > tolerance:
         gdaltest.post_reason('STATISTICS_MINIMUM is wrong.')
         return 'fail'
 
-    max = float(md['STATISTICS_MAXIMUM'])
-    if abs(max - 41.134323120117) > tolerance:
+    maxi = float(md['STATISTICS_MAXIMUM'])
+    if abs(maxi - 41.134323120117) > tolerance:
         gdaltest.post_reason('STATISTICS_MAXIMUM is wrong.')
         return 'fail'
 

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -1167,9 +1167,9 @@ def get_attribute_val(ar, attr_name):
 
 
 def find_element_with_name(ar, element_name, name):
-    type = ar[XML_TYPE_IDX]
+    typ = ar[XML_TYPE_IDX]
     value = ar[XML_VALUE_IDX]
-    if type == gdal.CXT_Element and value == element_name and get_attribute_val(ar, 'name') == name:
+    if typ == gdal.CXT_Element and value == element_name and get_attribute_val(ar, 'name') == name:
         return ar
     for child_idx in range(XML_FIRST_CHILD_IDX, len(ar)):
         child = ar[child_idx]

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -1347,9 +1347,9 @@ def get_attribute_val(ar, attr_name):
 
 
 def find_element_with_name(ar, element_name, name):
-    type = ar[XML_TYPE_IDX]
+    typ = ar[XML_TYPE_IDX]
     value = ar[XML_VALUE_IDX]
-    if type == gdal.CXT_Element and value == element_name and get_attribute_val(ar, 'name') == name:
+    if typ == gdal.CXT_Element and value == element_name and get_attribute_val(ar, 'name') == name:
         return ar
     for child_idx in range(XML_FIRST_CHILD_IDX, len(ar)):
         child = ar[child_idx]

--- a/autotest/gdrivers/mrsid.py
+++ b/autotest/gdrivers/mrsid.py
@@ -160,15 +160,15 @@ def mrsid_2():
         is_bytes = True
 
     # check that we got roughly the right values by checking mean.
-    sum = 0
+    total = 0
     if is_bytes is True:
         for i in range(len(data)):
-            sum = sum + data[i]
+            total += data[i]
     else:
         for i in range(len(data)):
-            sum = sum + ord(data[i])
+            total += ord(data[i])
 
-    mean = float(sum) / len(data)
+    mean = float(total) / len(data)
 
     if mean < 95 or mean > 105:
         gdaltest.post_reason('image mean out of range.')

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -651,13 +651,13 @@ class CFChecker:
         return
 
         # ---------------------------
-    def uniqueList(self, list):
+    def uniqueList(self, lst):
         # ---------------------------
         """Determine if list has any repeated elements."""
         # Rewrite to allow list to be either a list or a Numeric array
         seen = []
 
-        for x in list:
+        for x in lst:
             if x in seen:
                 return 0
             else:
@@ -1057,30 +1057,30 @@ class CFChecker:
         self.formulas['ocean_double_sigma_coordinate'] = ['z(k,j,i)=sigma(k)*f(j,i)', 'z(k,j,i)=f(j,i)+(sigma(k)-1)*(depth(j,i)-f(j,i))', 'f(j,i)=0.5*(z1+z2)+0.5*(z1-z2)*tanh(2*a/(z1-z2)*(depth(j,i)-href))']
 
         # ----------------------------------------
-    def parseBlankSeparatedList(self, list):
+    def parseBlankSeparatedList(self, lst):
         # ----------------------------------------
         """Parse blank separated list"""
-        if re.match("^[a-zA-Z0-9_ ]*$", list):
+        if re.match("^[a-zA-Z0-9_ ]*$", lst):
             return 1
         else:
             return 0
 
         # -------------------------------------------
-    def extendedBlankSeparatedList(self, list):
+    def extendedBlankSeparatedList(self, lst):
         # -------------------------------------------
         """Check list is a blank separated list of words containing alphanumeric characters
         plus underscore '_', period '.', plus '+', hyphen '-', or "at" sign '@'."""
-        if re.match("^[a-zA-Z0-9_ @\-\+\.]*$", list):
+        if re.match("^[a-zA-Z0-9_ @\-\+\.]*$", lst):
             return 1
         else:
             return 0
 
         # -------------------------------------------
-    def commaOrBlankSeparatedList(self, list):
+    def commaOrBlankSeparatedList(self, lst):
         # -------------------------------------------
         """Check list is a blank or comma separated list of words containing alphanumeric
         characters plus underscore '_', period '.', plus '+', hyphen '-', or "at" sign '@'."""
-        if re.match("^[a-zA-Z0-9_ @\-\+\.,]*$", list):
+        if re.match("^[a-zA-Z0-9_ @\-\+\.,]*$", lst):
             return 1
         else:
             return 0
@@ -1549,7 +1549,7 @@ class CFChecker:
         return rc
 
         # ---------------------------------------------------
-    def isValidCellMethodTypeValue(self, type, value):
+    def isValidCellMethodTypeValue(self, typ, value):
         # ---------------------------------------------------
         """ Is <type1> or <type2> in the cell_methods attribute a valid value"""
         rc = 1
@@ -1557,7 +1557,7 @@ class CFChecker:
         if value in self.auxCoordVars:
             if self.getTypeCode(self.f[value]) != 'c':
                 rc = 0
-            elif type == "type2":
+            elif typ == "type2":
                 # <type2> has the additional requirement that it is not allowed a leading dimension of more than one
                 leadingDim = self.f[value].getAxisIds()[0]
                 # Must not be a value of more than one

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -149,8 +149,7 @@ class ConstructDict(ContentHandler):
     def startElement(self, name, attrs):
         # If it's an entry element, save the id
         if name == 'entry':
-            id = normalize_whitespace(attrs.get('id', ""))
-            self.this_id = id
+            self.this_id = normalize_whitespace(attrs.get('id', ""))
 
         # If it's the start of a canonical_units element
         elif name == 'canonical_units':
@@ -229,8 +228,7 @@ class ConstructList(ContentHandler):
     def startElement(self, name, attrs):
         # If it's an entry element, save the id
         if name == 'entry':
-            id = normalize_whitespace(attrs.get('id', ""))
-            self.list.append(id)
+            self.list.append(normalize_whitespace(attrs.get('id', "")))
 
         elif name == 'version_number':
             self.inVersionNoContent = 1

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -305,11 +305,11 @@ def pds4_9():
 
     filename = '/vsimem/out.xml'
     # Test copy of all specialConstants and overide noData
-    for format in ['RAW', 'GEOTIFF']:
+    for frmt in ['RAW', 'GEOTIFF']:
         with hide_substitution_warnings_error_handler():
             gdal.Translate(filename, 'data/byte_pds4.xml', format='PDS4',
                            noData=75,
-                           creationOptions=['IMAGE_FORMAT=' + format])
+                           creationOptions=['IMAGE_FORMAT=' + frmt])
 
         ret = validate_xml(filename)
         if ret == 'fail':
@@ -338,11 +338,11 @@ def pds4_9():
         ds = None
 
     # Test just setting noData
-    for format in ['RAW', 'GEOTIFF']:
+    for frmt in ['RAW', 'GEOTIFF']:
         with hide_substitution_warnings_error_handler():
             gdal.Translate(filename, 'data/byte_pds4.xml', format='PDS4',
                            creationOptions=['USE_SRC_LABEL=NO',
-                                            'IMAGE_FORMAT=' + format])
+                                            'IMAGE_FORMAT=' + frmt])
 
         ret = validate_xml(filename)
         if ret == 'fail':
@@ -353,7 +353,7 @@ def pds4_9():
         ndv = ds.GetRasterBand(1).GetNoDataValue()
         if ndv != 74:
             gdaltest.post_reason('fail')
-            print(format)
+            print(frmt)
             print(ndv)
             return 'fail'
 
@@ -361,7 +361,7 @@ def pds4_9():
 
         # Test filling with nodata
         ds = gdal.GetDriverByName('PDS4').Create(filename, 1, 1,
-                                                 options=['IMAGE_FORMAT=' + format])
+                                                 options=['IMAGE_FORMAT=' + frmt])
         ds.GetRasterBand(1).SetNoDataValue(1)
         with hide_substitution_warnings_error_handler():
             ds = None
@@ -370,7 +370,7 @@ def pds4_9():
         cs = ds.GetRasterBand(1).Checksum()
         if cs != 1:
             gdaltest.post_reason('fail')
-            print(format)
+            print(frmt)
             print(cs)
             return 'fail'
         ds = None

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -377,7 +377,7 @@ def pds4_9():
 
         # Test setting nodata and then explicit Fill()
         ds = gdal.GetDriverByName('PDS4').Create(filename, 1, 1,
-                                                 options=['IMAGE_FORMAT=' + format])
+                                                 options=['IMAGE_FORMAT=' + frmt])
         ds.GetRasterBand(1).SetNoDataValue(10)
         ds.GetRasterBand(1).Fill(1)
         with hide_substitution_warnings_error_handler():

--- a/autotest/gdrivers/wcs.py
+++ b/autotest/gdrivers/wcs.py
@@ -316,9 +316,9 @@ class WCSHTTPHandler(BaseHTTPRequestHandler):
     def log_request(self, code='-', size='-'):
         return
 
-    def Headers(self, type):
+    def Headers(self, typ):
         self.send_response(200)
-        self.send_header('Content-Type', type)
+        self.send_header('Content-Type', typ)
         self.end_headers()
 
     def Respond(self, request, brand, version, test):

--- a/autotest/gdrivers/xmp.py
+++ b/autotest/gdrivers/xmp.py
@@ -97,31 +97,31 @@ class TestXMPRead:
 
 gdaltest_list = []
 
-list = [["GTiff", "data/byte_with_xmp.tif", True],
-        ["GTiff", "data/byte.tif", False],
-        ["GIF", "data/byte_with_xmp.gif", True],
-        ["BIGGIF", "data/fakebig.gif", False],
-        ["JPEG", "data/byte_with_xmp.jpg", True],
-        ["JPEG", "data/rgbsmall_rgb.jpg", False],
-        ["PNG", "data/byte_with_xmp.png", True],
-        ["PNG", "data/test.png", False],
-        ["JP2ECW", "data/byte_with_xmp.jp2", True],
-        ["JP2ECW", "data/byte.jp2", False],
-        ["JP2MrSID", "data/byte_with_xmp.jp2", True],
-        ["JP2MrSID", "data/byte.jp2", False],
-        ["JPEG2000", "data/byte_with_xmp.jp2", True],
-        ["JPEG2000", "data/byte.jp2", False],
-        ["JP2OpenJPEG", "data/byte_with_xmp.jp2", True],
-        ["JP2OpenJPEG", "data/byte.jp2", False],
-        ["JP2KAK", "data/byte_with_xmp.jp2", True],
-        ["JP2KAK", "data/byte.jp2", False],
-        ["PDF", "data/adobe_style_geospatial_with_xmp.pdf", True],
-        ["PDF", "data/adobe_style_geospatial.pdf", False],
-        ["WEBP", "data/rgbsmall_with_xmp.webp", True],
-        ["WEBP", "data/rgbsmall.webp", False],
-        ]
+lst = [["GTiff", "data/byte_with_xmp.tif", True],
+       ["GTiff", "data/byte.tif", False],
+       ["GIF", "data/byte_with_xmp.gif", True],
+       ["BIGGIF", "data/fakebig.gif", False],
+       ["JPEG", "data/byte_with_xmp.jpg", True],
+       ["JPEG", "data/rgbsmall_rgb.jpg", False],
+       ["PNG", "data/byte_with_xmp.png", True],
+       ["PNG", "data/test.png", False],
+       ["JP2ECW", "data/byte_with_xmp.jp2", True],
+       ["JP2ECW", "data/byte.jp2", False],
+       ["JP2MrSID", "data/byte_with_xmp.jp2", True],
+       ["JP2MrSID", "data/byte.jp2", False],
+       ["JPEG2000", "data/byte_with_xmp.jp2", True],
+       ["JPEG2000", "data/byte.jp2", False],
+       ["JP2OpenJPEG", "data/byte_with_xmp.jp2", True],
+       ["JP2OpenJPEG", "data/byte.jp2", False],
+       ["JP2KAK", "data/byte_with_xmp.jp2", True],
+       ["JP2KAK", "data/byte.jp2", False],
+       ["PDF", "data/adobe_style_geospatial_with_xmp.pdf", True],
+       ["PDF", "data/adobe_style_geospatial.pdf", False],
+       ["WEBP", "data/rgbsmall_with_xmp.webp", True],
+       ["WEBP", "data/rgbsmall.webp", False],
+       ]
 
-for item in list:
+for item in lst:
     drivername = item[0]
     filename = item[1]
     expect_xmp = item[2]

--- a/autotest/gdrivers/xmp.py
+++ b/autotest/gdrivers/xmp.py
@@ -121,11 +121,7 @@ lst = [["GTiff", "data/byte_with_xmp.tif", True],
        ["WEBP", "data/rgbsmall.webp", False],
        ]
 
-for item in lst:
-    drivername = item[0]
-    filename = item[1]
-    expect_xmp = item[2]
-
+for drivername, filename, expect_xmp in lst:
     ut = TestXMPRead(drivername, filename, expect_xmp)
     gdaltest_list.append((ut.test, "xmp_read_%s_%s" % (drivername, "true" if expect_xmp is True else "false")))
 

--- a/autotest/gdrivers/xyz.py
+++ b/autotest/gdrivers/xyz.py
@@ -116,10 +116,7 @@ def xyz_3():
 
 def xyz_4_checkline(ds, i, expected_bytes):
     buf = ds.ReadRaster(0, i, ds.RasterXSize, 1)
-    bytes = struct.unpack('B' * ds.RasterXSize, buf)
-    if bytes != expected_bytes:
-        return False
-    return True
+    return struct.unpack('B' * ds.RasterXSize, buf) == expected_bytes
 
 
 def xyz_4():

--- a/autotest/ogr/ogr_fgdb_stress_test.py
+++ b/autotest/ogr/ogr_fgdb_stress_test.py
@@ -117,14 +117,13 @@ def ogr_fgdb_stress_test_1():
             fid = -1
             if random.randrange(0, 2) == 0:
                 fid = 1 + random.randrange(0, 1000)
-            str = '%d' % random.randrange(0, 1000)
             wkt = 'POINT (%d %d)' % (random.randrange(0, 100), random.randrange(0, 100))
             if verbose:
                 print('Create(%d)' % fid)
             for lyr in [lyr_test, lyr_ref]:
                 f = ogr.Feature(lyr.GetLayerDefn())
                 f.SetFID(fid)
-                f.SetField(0, str)
+                f.SetField(0, '%d' % random.randrange(0, 1000))
                 f.SetGeometry(ogr.CreateGeometryFromWkt(wkt))
                 gdal.PushErrorHandler()
                 ret.append(lyr.CreateFeature(f))
@@ -145,12 +144,11 @@ def ogr_fgdb_stress_test_1():
             fid = 1 + random.randrange(0, 1000)
             if verbose:
                 print('Update(%d)' % fid)
-            str = '%d' % random.randrange(0, 1000)
             wkt = 'POINT (%d %d)' % (random.randrange(0, 100), random.randrange(0, 100))
             for lyr in [lyr_test, lyr_ref]:
                 f = ogr.Feature(lyr.GetLayerDefn())
                 f.SetFID(fid)
-                f.SetField(0, str)
+                f.SetField(0, '%d' % random.randrange(0, 1000))
                 f.SetGeometry(ogr.CreateGeometryFromWkt(wkt))
                 # gdal.PushErrorHandler()
                 ret.append(lyr.SetFeature(f))

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -59,7 +59,7 @@ def validate_layer(lyr, name, features, type, fields, box):
         print('Layer definition is none')
         return False
 
-    if type != lyrDefn.GetGeomType():
+    if typ != lyrDefn.GetGeomType():
         print('Wrong geometry type')
         print(lyrDefn.GetGeomType())
         return False
@@ -1737,8 +1737,8 @@ def ogr_geojson_35():
         gdaltest.post_reason('fail')
         print(data)
         return 'fail'
-    for id in range(2, 8):
-        if data.find('{ "type": "Feature", "id": %d, "properties": { }, "geometry": null }' % id) == -1:
+    for ident in range(2, 8):
+        if data.find('{ "type": "Feature", "id": %d, "properties": { }, "geometry": null }' % ident) == -1:
             gdaltest.post_reason('fail')
             print(data)
             return 'fail'

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -44,7 +44,7 @@ import ogrtest
 # Test utilities
 
 
-def validate_layer(lyr, name, features, type, fields, box):
+def validate_layer(lyr, name, features, typ, fields, box):
 
     if name is not None and name != lyr.GetName():
         print('Wrong layer name')

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -2326,12 +2326,12 @@ def ogr_mitab_45():
     dsExts = ['.mif', '.tab', '', '']
 
     for formatN in range(len(formats)):
-        format = formats[formatN]
+        frmt = formats[formatN]
         lyrCount = lyrNums[formatN]
         ext = dsExts[formatN]
-        dsName = '/vsimem/45/ogr_mitab_45_%s_%s%s' % (format, lyrCount, ext)
+        dsName = '/vsimem/45/ogr_mitab_45_%s_%s%s' % (frmt, lyrCount, ext)
 
-        ds = gdaltest.mapinfo_drv.CreateDataSource(dsName, options=['FORMAT=' + format])
+        ds = gdaltest.mapinfo_drv.CreateDataSource(dsName, options=['FORMAT=' + frmt])
 
         if ds is None:
             gdaltest.post_reason('Can\'t create dataset: ' + dsName)

--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -488,8 +488,8 @@ def ogr_mysql_15():
 
     query = 'eas_id = 169'
 
-    for id in range(1000):
-        query = query + (' or eas_id = %d' % (id + 1000))
+    for i in range(1000):
+        query = query + (' or eas_id = %d' % (i + 1000))
 
     gdaltest.mysql_lyr.SetAttributeFilter(query)
     tr = ogrtest.check_features_against_list(gdaltest.mysql_lyr,
@@ -514,8 +514,8 @@ def ogr_mysql_16():
 
     query = 'eas_id = 169'
 
-    for id in range(1000):
-        query = query + (' or eas_id = %d' % (id + 1000))
+    for ident in range(1000):
+        query = query + (' or eas_id = %d' % (ident + 1000))
 
     statement = 'select eas_id from tpoly where ' + query
 

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -779,8 +779,8 @@ def ogr_pg_15():
 
     query = 'eas_id = 169'
 
-    for id in range(1000):
-        query = query + (' or eas_id = %d' % (id + 1000))
+    for ident in range(1000):
+        query = query + (' or eas_id = %d' % (ident + 1000))
 
     gdaltest.pg_lyr.SetAttributeFilter(query)
     tr = ogrtest.check_features_against_list(gdaltest.pg_lyr,
@@ -805,8 +805,8 @@ def ogr_pg_16():
 
     query = 'eas_id = 169'
 
-    for id in range(1000):
-        query = query + (' or eas_id = %d' % (id + 1000))
+    for ident in range(1000):
+        query = query + (' or eas_id = %d' % (ident + 1000))
 
     statement = 'select eas_id from tpoly where ' + query
 
@@ -1200,8 +1200,8 @@ def ogr_pg_22():
     shp_lyr = shp_ds.GetLayer(0)
 
     # Insert 3 features only
-    for id in range(0, 3):
-        feat = shp_lyr.GetFeature(id)
+    for ident in range(0, 3):
+        feat = shp_lyr.GetFeature(ident)
         dst_feat.SetFrom(feat)
         gdaltest.pg_lyr.CreateFeature(dst_feat)
 

--- a/autotest/ogr/ogr_plscenes.py
+++ b/autotest/ogr/ogr_plscenes.py
@@ -806,9 +806,9 @@ def ogr_plscenes_data_v1_live():
     filter = "acquired='%s'" % f.GetFieldAsString(acquired_field)
     if int_field >= 0:
         name = lyr_defn.GetFieldDefn(int_field).GetName()
-        min = f.GetField(int_field) - 1
-        max = f.GetField(int_field) + 1
-        filter += ' AND %s >= %d AND %s <= %d' % (name, min, name, max)
+        mini = f.GetField(int_field) - 1
+        maxi = f.GetField(int_field) + 1
+        filter += ' AND %s >= %d AND %s <= %d' % (name, mini, name, maxi)
     if float_field >= 0:
         name = lyr_defn.GetFieldDefn(float_field).GetName()
         min = f.GetField(float_field) - 0.01

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -1287,21 +1287,21 @@ def ogr_shape_29():
     ds.ExecuteSQL('REPACK UPPERCASE')
     ds = None
 
-    list = gdal.ReadDir('tmp/UPPERCASE')
+    lst = gdal.ReadDir('tmp/UPPERCASE')
 
-    if len(list) != 6:
-        print(list)
+    if len(lst) != 6:
+        print(lst)
         return 'fail'
 
-    for filename in list:
+    for filename in lst:
         if filename not in ['.', '..', 'UPPERCASE.SHP', 'UPPERCASE.SHX', 'UPPERCASE.DBF', 'UPPERCASE.CPG']:
             gdaltest.post_reason('fail')
-            print(list)
+            print(lst)
             print(filename)
             return 'fail'
         if filename.find('packed') >= 0:
             gdaltest.post_reason('fail')
-            print(list)
+            print(lst)
             print(filename)
             return 'fail'
 
@@ -1324,15 +1324,15 @@ def ogr_shape_30():
     ds.ExecuteSQL('REPACK lowercase')
     ds = None
 
-    list = gdal.ReadDir('tmp/lowercase')
+    lst = gdal.ReadDir('tmp/lowercase')
 
-    if len(list) != 5:
-        print(list)
+    if len(lst) != 5:
+        print(lst)
         return 'fail'
 
-    for filename in list:
+    for filename in lst:
         if filename not in ['.', '..', 'lowercase.shp', 'lowercase.shx', 'lowercase.dbf']:
-            print(list)
+            print(lst)
             return 'fail'
 
     return 'success'

--- a/autotest/ogr/ogr_wfs3.py
+++ b/autotest/ogr/ogr_wfs3.py
@@ -315,14 +315,14 @@ def ogr_wfs3_schema_from_api():
         ("boolean_attr", ogr.OFTInteger, ogr.OFSTBoolean),
         ("string_attr", ogr.OFTString, ogr.OFSTNone),
     ]
-    for (attr_name, type, subtype) in expected_attrs:
+    for (attr_name, typ, subtype) in expected_attrs:
         fld_idx = lyr.GetLayerDefn().GetFieldIndex(attr_name)
         if fld_idx < 0:
             gdaltest.post_reason('fail')
             print(attr_name)
             return 'fail'
         fld_defn = lyr.GetLayerDefn().GetFieldDefn(fld_idx)
-        if fld_defn.GetType() != type and fld_defn.GetSubType() != subtype:
+        if fld_defn.GetType() != typ and fld_defn.GetSubType() != subtype:
             gdaltest.post_reason('fail')
             print(attr_name, fld_defn.GetType(), fld_defn.GetSubType())
             return 'fail'

--- a/autotest/osr/osr_metacrs.py
+++ b/autotest/osr/osr_metacrs.py
@@ -89,8 +89,8 @@ class MetaCRSTest:
 
         return 'success'
 
-    def build_srs(self, type, crstext):
-        if type == 'EPSG':
+    def build_srs(self, typ, crstext):
+        if typ == 'EPSG':
             srs = osr.SpatialReference()
             if srs.ImportFromEPSGA(int(crstext)) == 0:
                 return srs
@@ -98,7 +98,7 @@ class MetaCRSTest:
                 gdaltest.post_reason('failed to translate EPSG:' + crstext)
                 return None
         else:
-            gdaltest.post_reason('unsupported srs type: ' + type)
+            gdaltest.post_reason('unsupported srs type: ' + typ)
             return None
 
     def testMetaCRS(self):

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1007,7 +1007,7 @@ class GDALTest:
             post_reason('Failed to create test file using Create method.')
             return 'fail'
 
-        new_ds.SetMetadata({'TEST_KEY': 'TestValue')
+        new_ds.SetMetadata({'TEST_KEY': 'TestValue'})
         # FIXME
         # if new_ds.SetMetadata( dict ) is not gdal.CE_None:
         #     print new_ds.SetMetadata( dict )

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1007,9 +1007,7 @@ class GDALTest:
             post_reason('Failed to create test file using Create method.')
             return 'fail'
 
-        dict = {}
-        dict['TEST_KEY'] = 'TestValue'
-        new_ds.SetMetadata(dict)
+        new_ds.SetMetadata({'TEST_KEY': 'TestValue')
         # FIXME
         # if new_ds.SetMetadata( dict ) is not gdal.CE_None:
         #     print new_ds.SetMetadata( dict )

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -68,8 +68,8 @@ class RequestResponse:
 
 
 class FileHandler:
-    def __init__(self, dict):
-        self.dict = dict
+    def __init__(self, _dict):
+        self.dict = _dict
 
     def final_check(self):
         pass

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -324,11 +324,10 @@ def test_gdal_calc_py_6():
         gdaltest.post_reason('failure')
         print(cs)
         return 'fail'
-    (min, max) = ds.GetRasterBand(1).ComputeRasterMinMax()
-    if min != 90 or max != 255:
+    result = ds.GetRasterBand(1).ComputeRasterMinMax()
+    if result != (90, 255):
         gdaltest.post_reason('failure')
-        print(min)
-        print(max)
+        print(result)
         return 'fail'
 
     return 'success'

--- a/autotest/test_random_tiff.py
+++ b/autotest/test_random_tiff.py
@@ -123,7 +123,7 @@ for level in range(len(tags)):
     nVals = nVals * len_possible_vals
 itern = 0
 while True:
-    itern = itern + 1
+    itern += 1
     comb_val = random.randrange(0, nVals)
     content = generate_tif(comb_val)
 

--- a/autotest/test_random_tiff.py
+++ b/autotest/test_random_tiff.py
@@ -121,9 +121,9 @@ for level in range(len(tags)):
     len_possible_vals = len(tags[level][2])
     tags[level].append(len_possible_vals)
     nVals = nVals * len_possible_vals
-iter = 0
+itern = 0
 while True:
-    iter = iter + 1
+    itern = itern + 1
     comb_val = random.randrange(0, nVals)
     content = generate_tif(comb_val)
 
@@ -136,7 +136,7 @@ while True:
     # Create in-memory file
     gdal.FileFromMemBuffer('/vsimem/test.tif', content)
 
-    print('iter = %d, comb_val_init = %d' % (iter, comb_val))
+    print('iter = %d, comb_val_init = %d' % (itern, comb_val))
     ds = gdal.Open('/vsimem/test.tif')
     # if ds is not None and ds.RasterCount == 1:
     #    (blockxsize, blockysize) = ds.GetRasterBand(1).GetBlockSize()

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -431,10 +431,10 @@ def test_gdal_translate_lib_101():
 def test_gdal_translate_lib_102():
 
     ds = gdal.Translate('', gdal.Open('../gcore/data/byte.tif'), format='MEM', scaleParams=[[0, 255, 0, 65535]], outputType=gdal.GDT_UInt16)
-    (min, max) = ds.GetRasterBand(1).ComputeRasterMinMax(False)
-    if (min, max) != (19018.0, 65535.0):
+    result = ds.GetRasterBand(1).ComputeRasterMinMax(False)
+    if result != (19018.0, 65535.0):
         gdaltest.post_reason('failure')
-        print(min, max)
+        print(result)
         return 'fail'
 
     (approx_min, approx_max) = ds.GetRasterBand(1).ComputeRasterMinMax(True)

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -542,14 +542,14 @@ def test_gdaldem_lib_aspect_ZevenbergenThorne():
 def test_gdaldem_lib_nodata():
 
     for (value, typ) in [(0, gdal.GDT_Byte),
-                          (1, gdal.GDT_Byte),
-                          (255, gdal.GDT_Byte),
-                          (0, gdal.GDT_UInt16),
-                          (1, gdal.GDT_UInt16),
-                          (65535, gdal.GDT_UInt16),
-                          (0, gdal.GDT_Int16),
-                          (-32678, gdal.GDT_Int16),
-                          (32767, gdal.GDT_Int16)]:
+                         (1, gdal.GDT_Byte),
+                         (255, gdal.GDT_Byte),
+                         (0, gdal.GDT_UInt16),
+                         (1, gdal.GDT_UInt16),
+                         (65535, gdal.GDT_UInt16),
+                         (0, gdal.GDT_Int16),
+                         (-32678, gdal.GDT_Int16),
+                         (32767, gdal.GDT_Int16)]:
         src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1, typ)
         src_ds.GetRasterBand(1).SetNoDataValue(value)
         src_ds.GetRasterBand(1).Fill(value)

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -541,7 +541,7 @@ def test_gdaldem_lib_aspect_ZevenbergenThorne():
 
 def test_gdaldem_lib_nodata():
 
-    for (value, type) in [(0, gdal.GDT_Byte),
+    for (value, typ) in [(0, gdal.GDT_Byte),
                           (1, gdal.GDT_Byte),
                           (255, gdal.GDT_Byte),
                           (0, gdal.GDT_UInt16),
@@ -550,7 +550,7 @@ def test_gdaldem_lib_nodata():
                           (0, gdal.GDT_Int16),
                           (-32678, gdal.GDT_Int16),
                           (32767, gdal.GDT_Int16)]:
-        src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1, type)
+        src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1, typ)
         src_ds.GetRasterBand(1).SetNoDataValue(value)
         src_ds.GetRasterBand(1).Fill(value)
 


### PR DESCRIPTION
## What does this PR do?

Some variables shadow the names of built-in types (as found by `pylint`). This patch either renames the variables or avoids declaring a variable at all.