### PR TITLE
Python code: Fix typo in unified_diff `lineterm' argument

### DIFF
--- a/autotest/ogr/ograpispy.py
+++ b/autotest/ogr/ograpispy.py
@@ -67,7 +67,7 @@ def ograpispy_1():
         print()
         for line in unified_diff(ref_data.splitlines(), got_data.splitlines(),
                                  fromfile='expected', tofile='got',
-                                 linterm=""):
+                                 lineterm=""):
             print(line)
         return 'fail'
 


### PR DESCRIPTION
## What does this PR do?

Fixes a typo that must have slipped through when this code was introduced a week ago.