### PR TITLE
Python code: Use str * N instead of more convoluted ways to compute strings

### DIFF
--- a/autotest/gcore/minixml.py
+++ b/autotest/gcore/minixml.py
@@ -308,8 +308,8 @@ def minixml_7():
 
 def minixml_8():
 
-    xml_str = ''.join('<a>' for i in range(10001))
-    xml_str += ''.join('</a>' for i in range(10001))
+    xml_str = '<a>' * 10001
+    xml_str += '</a>' * 10001
 
     gdal.ErrorReset()
     with gdaltest.error_handler():

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -6077,7 +6077,7 @@ def tiff_write_133():
     # Test reading strips in not increasing order
     ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['BLOCKYSIZE=1'])
     for y in range(1000):
-        ds.WriteRaster(0, 1000 - y - 1, 1024, 1, ''.join('a' for i in range(3 * 1024)))
+        ds.WriteRaster(0, 1000 - y - 1, 1024, 1, 'a' * (3 * 1024))
         ds.FlushCache()
     ds = None
 
@@ -6101,7 +6101,7 @@ def tiff_write_133():
     ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'BLOCKYSIZE=1'])
     gdal.ErrorReset()
     gdal.PushErrorHandler()
-    ret = ds.WriteRaster(0, 999, 1024, 1, ''.join('a' for i in range(3 * 1024)))
+    ret = ds.WriteRaster(0, 999, 1024, 1, 'a' * (3 * 1024))
     ds.FlushCache()
     gdal.PopErrorHandler()
     if gdal.GetLastErrorMsg() == '':
@@ -6113,7 +6113,7 @@ def tiff_write_133():
     ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'TILED=YES'])
     gdal.ErrorReset()
     gdal.PushErrorHandler()
-    ret = ds.WriteRaster(256, 256, 256, 256, ''.join('a' for i in range(3 * 256 * 256)))
+    ret = ds.WriteRaster(256, 256, 256, 256, 'a' * (3 * 256 * 256))
     ds.FlushCache()
     gdal.PopErrorHandler()
     if gdal.GetLastErrorMsg() == '':

--- a/autotest/gcore/vsioss.py
+++ b/autotest/gcore/vsioss.py
@@ -885,7 +885,7 @@ def visoss_6():
         gdaltest.post_reason('fail')
         return 'fail'
     size = 1024 * 1024 + 1
-    big_buffer = ''.join('a' for i in range(size))
+    big_buffer = 'a' * size
 
     handler = webserver.SequentialHandler()
 

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -305,14 +305,14 @@ def vsis3_2():
             request.send_header('Content-Length', 16384)
             request.send_header('Connection', 'close')
             request.end_headers()
-            request.wfile.write(''.join('a' for i in range(16384)).encode('ascii'))
+            request.wfile.write(('a' * 16384).encode('ascii'))
         else:
             request.send_response(200)
             request.send_header('Content-type', 'text/plain')
             request.send_header('Content-Length', 1000000)
             request.send_header('Connection', 'close')
             request.end_headers()
-            request.wfile.write(''.join('a' for i in range(1000000)).encode('ascii'))
+            request.wfile.write(('a' * 1000000).encode('ascii'))
 
     handler.add('GET', '/s3_fake_bucket/resource2.bin', custom_method=method)
 
@@ -1333,7 +1333,7 @@ def vsis3_6():
         gdaltest.post_reason('fail')
         return 'fail'
     size = 1024 * 1024 + 1
-    big_buffer = ''.join('a' for i in range(size))
+    big_buffer = 'a' * size
 
     handler = webserver.SequentialHandler()
 

--- a/autotest/gcore/vsistdin.py
+++ b/autotest/gcore/vsistdin.py
@@ -139,7 +139,7 @@ def vsistdin_4():
       <SourceBand>1</SourceBand>
     </SimpleSource>
   </VRTRasterBand>
-</VRTDataset>""" % ' ' * (2 * 1024 * 1024))
+</VRTDataset>""" % (' ' * (2 * 1024 * 1024)))
     f.close()
 
     # Should work on both Unix and Windows

--- a/autotest/gcore/vsistdin.py
+++ b/autotest/gcore/vsistdin.py
@@ -139,7 +139,7 @@ def vsistdin_4():
       <SourceBand>1</SourceBand>
     </SimpleSource>
   </VRTRasterBand>
-</VRTDataset>""" % (' '.join([' ' for i in range(1024 * 1024)])))
+</VRTDataset>""" % ' ' * (2 * 1024 * 1024))
     f.close()
 
     # Should work on both Unix and Windows

--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -356,9 +356,7 @@ def vsizip_5():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    filename = "a"
-    for i in range(1000):
-        filename = filename + "/a"
+    filename = "a" + "/a" * 1000
     finside = gdal.VSIFOpenL('/vsizip/vsimem/bigdepthzip.zip/' + filename, 'wb')
     if finside is None:
         gdaltest.post_reason('fail')

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -1292,7 +1292,7 @@ def jpeg_28():
 
     # Too much content for EXIF
     src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1)
-    src_ds.SetMetadataItem('EXIF_UserComment', ''.join(['x' for i in range(65535)]))
+    src_ds.SetMetadataItem('EXIF_UserComment', 'x' * 65535)
     with gdaltest.error_handler():
         gdal.GetDriverByName('JPEG').CreateCopy(tmpfilename, src_ds)
     src_ds = None

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -593,7 +593,7 @@ def ogr_fgdb_9():
     srs = osr.SpatialReference()
     srs.SetFromUserInput("WGS84")
 
-    _160char = ''.join(['A123456789' for i in range(16)])
+    _160char = 'A123456789' * 16
 
     in_names = ['FROM',  # reserved keyword
                 '1NUMBER',  # starting with a number

--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -1487,24 +1487,18 @@ def gml_write_gml3_srs():
 
 def gml_nested():
 
-    gml = ''
-    for i in range(31):
-        gml = gml + '<gml:MultiGeometry><gml:geometryMember>'
-    gml = gml + '<gml:MultiPolygon></gml:MultiPolygon>'
-    for i in range(31):
-        gml = gml + '</gml:geometryMember></gml:MultiGeometry>'
+    gml = '<gml:MultiGeometry><gml:geometryMember>' * 31
+    gml += '<gml:MultiPolygon></gml:MultiPolygon>'
+    gml += '</gml:geometryMember></gml:MultiGeometry>' * 31
 
     geom = ogr.CreateGeometryFromGML(gml)
     if geom is None:
         gdaltest.post_reason('expected a geometry')
         return 'fail'
 
-    gml = ''
-    for i in range(32):
-        gml = gml + '<gml:MultiGeometry><gml:geometryMember>'
-    gml = gml + '<gml:MultiPolygon></gml:MultiPolygon>'
-    for i in range(32):
-        gml = gml + '</gml:geometryMember></gml:MultiGeometry>'
+    gml = '<gml:MultiGeometry><gml:geometryMember>' * 32
+    gml += '<gml:MultiPolygon></gml:MultiPolygon>'
+    gml += '</gml:geometryMember></gml:MultiGeometry>' * 32
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     geom = ogr.CreateGeometryFromGML(gml)

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -2821,7 +2821,7 @@ def ogr_shape_57():
         return 'fail'
 
     feat = ogr.Feature(lyr.GetLayerDefn())
-    feat.SetField(0, '0123456789'.join(['' for i in range(27)]))
+    feat.SetField(0, '0123456789' * 27)
 
     gdal.ErrorReset()
     gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -3009,7 +3009,7 @@ def ogr_shape_61():
     lyr.CreateField(field_defn)
 
     feat = ogr.Feature(lyr.GetLayerDefn())
-    feat.SetField(0, ''.join(['0123456789' for i in range(8)]))
+    feat.SetField(0, '0123456789' * 8)
     feat.SetField(1, 2)
     lyr.CreateFeature(feat)
     feat = None
@@ -3021,7 +3021,7 @@ def ogr_shape_61():
         return 'fail'
 
     feat = ogr.Feature(lyr.GetLayerDefn())
-    feat.SetField(0, ''.join(['0123456789' for i in range(9)]))
+    feat.SetField(0, '0123456789' * 9)
     feat.SetField(1, 34)
     lyr.CreateFeature(feat)
     feat = None
@@ -3050,7 +3050,7 @@ def ogr_shape_61():
 
     feat = lyr.GetFeature(1)
     val = feat.GetFieldAsString(0)
-    if val != ''.join(['0123456789' for i in range(9)]):
+    if val != '0123456789' * 9
         gdaltest.post_reason('did not get expected field value')
         print(val)
         return 'fail'

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -3050,7 +3050,7 @@ def ogr_shape_61():
 
     feat = lyr.GetFeature(1)
     val = feat.GetFieldAsString(0)
-    if val != '0123456789' * 9
+    if val != '0123456789' * 9:
         gdaltest.post_reason('did not get expected field value')
         print(val)
         return 'fail'

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -1624,7 +1624,7 @@ def ogr_sql_sqlite_24():
     ds.ReleaseResultSet(sql_lyr)
 
     # Big very compressible string
-    bigstr = ''.join(['a' for i in range(10000)])
+    bigstr = 'a' * 10000
     sql_lyr = ds.ExecuteSQL("SELECT CAST(ogr_inflate(ogr_deflate('%s')) AS VARCHAR)" % bigstr, dialect='SQLite')
     feat = sql_lyr.GetNextFeature()
     if feat.GetField(0) != bigstr:

--- a/autotest/ogr/ogr_wkbwkt_geom.py
+++ b/autotest/ogr/ogr_wkbwkt_geom.py
@@ -565,12 +565,7 @@ def ogr_wkbwkt_test_geometrycollection_wktwkb():
 
 def ogr_wkbwkt_test_geometrycollection_wkt_recursion():
 
-    wkt = ''
-    for i in range(31):
-        wkt = wkt + 'GEOMETRYCOLLECTION ('
-    wkt = wkt + 'GEOMETRYCOLLECTION EMPTY'
-    for i in range(31):
-        wkt = wkt + ')'
+    wkt = 'GEOMETRYCOLLECTION (' * 31 + 'GEOMETRYCOLLECTION EMPTY' + ')' * 31
 
     geom = ogr.CreateGeometryFromWkt(wkt)
     if geom.ExportToWkt() != wkt:
@@ -578,12 +573,7 @@ def ogr_wkbwkt_test_geometrycollection_wkt_recursion():
         print(geom.ExportToWkt())
         return 'fail'
 
-    wkt = ''
-    for i in range(32):
-        wkt = wkt + 'GEOMETRYCOLLECTION ('
-    wkt = wkt + 'GEOMETRYCOLLECTION EMPTY'
-    for i in range(32):
-        wkt = wkt + ')'
+    wkt = 'GEOMETRYCOLLECTION (' * 32 + 'GEOMETRYCOLLECTION EMPTY' + ')' * 32
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     geom = ogr.CreateGeometryFromWkt(wkt)
@@ -604,20 +594,14 @@ def ogr_wkbwkt_test_geometrycollection_wkb_recursion():
     wkb_repeat = struct.pack('B' * 9, 0, 0, 0, 0, 7, 0, 0, 0, 1)
     wkb_end = struct.pack('B' * 9, 0, 0, 0, 0, 7, 0, 0, 0, 0)
 
-    wkb = struct.pack('B' * 0)
-    for i in range(31):
-        wkb = wkb + wkb_repeat
-    wkb = wkb + wkb_end
+    wkb = wkb_repeat * 31 + wkb_end
 
     geom = ogr.CreateGeometryFromWkb(wkb)
     if geom is None:
         gdaltest.post_reason('expected a geometry')
         return 'fail'
 
-    wkb = struct.pack('B' * 0)
-    for i in range(32):
-        wkb = wkb + wkb_repeat
-    wkb = wkb + wkb_end
+    wkb = struct.pack('B' * 0) + wkb_repeat * 32 + wkb_end
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     geom = ogr.CreateGeometryFromWkb(wkb)

--- a/autotest/pymod/xmlvalidate.py
+++ b/autotest/pymod/xmlvalidate.py
@@ -221,8 +221,7 @@ def transform_abs_links_to_ref_links(path, level=0):
                 if pos >= 0:
                     rewrite = True
                     s = ln[0:pos]
-                    for j in range(level):
-                        s = s + "../"
+                    s += "../" * level
                     s = s + ln[pos + len('http://schemas.opengis.net/'):]
                     ln = s
                     lines[i] = ln
@@ -231,8 +230,7 @@ def transform_abs_links_to_ref_links(path, level=0):
                 if pos >= 0:
                     rewrite = True
                     s = ln[0:pos]
-                    for j in range(level):
-                        s = s + "../"
+                    s += "../" * level
                     s = s + ln[pos + len('http://www.w3.org/1999/'):]
                     ln = s
                     lines[i] = ln
@@ -241,9 +239,8 @@ def transform_abs_links_to_ref_links(path, level=0):
                 if pos >= 0:
                     rewrite = True
                     s = ln[0:pos]
-                    for j in range(level):
-                        s = s + "../"
-                    s = s + ln[pos + len('http://www.w3.org/2001/'):]
+                    s += "../" * level
+                    s += ln[pos + len('http://www.w3.org/2001/'):]
                     ln = s
                     lines[i] = ln
 
@@ -277,10 +274,8 @@ def transform_inspire_abs_links_to_ref_links(path, level=0):
                 if pos >= 0:
                     pos += len('schemaLocation="')
                     rewrite = True
-                    s = ln[0:pos]
-                    for j in range(level):
-                        s = s + "../"
-                    s = s + ln[pos + len('http://inspire.ec.europa.eu/schemas/'):]
+                    s = ln[0:pos] + "../" * level
+                    s += ln[pos + len('http://inspire.ec.europa.eu/schemas/'):]
                     ln = s
                     lines[i] = ln
 
@@ -296,9 +291,7 @@ def transform_inspire_abs_links_to_ref_links(path, level=0):
                 if pos >= 0:
                     rewrite = True
                     s = ln[0:pos]
-                    for j in range(level):
-                        s = s + "../"
-                    s = s + "../SCHEMAS_OPENGIS_NET/"
+                    s += "../" * level + "../SCHEMAS_OPENGIS_NET/"
                     s = s + ln[pos + len('http://schemas.opengis.net/'):]
                     ln = s
                     lines[i] = ln


### PR DESCRIPTION
## What does this PR do?

In Python, `'a' * 3 == 'aaa'`. Simplify convoluted `for` loops and `join()` with list comprehensions to construct strings at runtime.