### PR TITLE
Python code: Use isinstance()

### DIFF
--- a/gdal/swig/include/python/docs/doxy2swig.py
+++ b/gdal/swig/include/python/docs/doxy2swig.py
@@ -127,7 +127,7 @@ class Doxy2SWIG:
 
     def add_text(self, value):
         """Adds text corresponding to `value` into `self.pieces`."""
-        if type(value) in (types.ListType, types.TupleType):
+        if isinstance(value, list) or isinstance(value, tuple):
             self.pieces.extend(value)
         else:
             self.pieces.append(value)

--- a/gdal/swig/include/python/docs/doxy2swig.py
+++ b/gdal/swig/include/python/docs/doxy2swig.py
@@ -26,7 +26,6 @@ from xml.dom import minidom
 import re
 import textwrap
 import sys
-import types
 import os.path
 
 

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -57,6 +57,7 @@ try:
     import osgeo.gdal_array as gdalarray
 except Exception:
     # 'antialias' resampling is not available
+    numpy = None
     pass
 
 __version__ = "$Id$"
@@ -1260,7 +1261,7 @@ def options_post_processing(options, input_file, output_folder):
 
     elif options.resampling == 'antialias':
         try:
-            if numpy:     # pylint:disable=W0125
+            if numpy is not None:
                 pass
         except Exception:
             exit_with_error("'antialias' resampling algorithm is not available.",


### PR DESCRIPTION
## What does this PR do?

Changes `gdal/swig/include/python/docs/doxy2swig.py` to use `isinstance` instead of `type(x) == types.T`. It is cleaner and improves Python 3 compatibility.