### PR TITLE
Python code: Simplify uses of string.split and friends

### DIFF
--- a/autotest/gcore/pamproxydb.py
+++ b/autotest/gcore/pamproxydb.py
@@ -40,7 +40,6 @@ except OSError:
 if len(sys.argv) == 2 and sys.argv[1] == '-test1':
 
     from osgeo import gdal
-    import os
     import shutil
 
     try:

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -4334,7 +4334,6 @@ def tiff_write_101():
         f.close()
     else:
         import random
-        import array
         rand_array = array.array('B')
         for i in range(10 * 1024 * 1024):
             rand_array.append(random.randint(0, 255))

--- a/autotest/gdrivers/georaster.py
+++ b/autotest/gdrivers/georaster.py
@@ -502,7 +502,7 @@ if __name__ == '__main__':
 
     if 'OCI_DSNAME' not in os.environ:
         print('Enter ORACLE connection (e.g. OCI:scott/tiger@orcl): ')
-        oci_dsname = string.strip(sys.stdin.readline())
+        oci_dsname = sys.stdin.readline().strip()
         os.environ['OCI_DSNAME'] = oci_dsname
 
     gdaltest.setup_run('GeoRaster')

--- a/autotest/gdrivers/georaster.py
+++ b/autotest/gdrivers/georaster.py
@@ -29,7 +29,6 @@
 ###############################################################################
 
 import os
-import string
 import sys
 from osgeo import gdal
 from osgeo import ogr

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -50,7 +50,6 @@ Options:
 
 import cdms2 as cdms
 import re
-import string
 import numpy
 import sys
 

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -100,7 +100,7 @@ class CFVersion(object):
             return False
 
     def __str__(self):
-        return "CF-%s" % string.join(map(str, self.tuple), ".")
+        return "CF-%s" % '.'.join(map(str, self.tuple))
 
     def __cmp__(self, other):
         # maybe overkill but allow for different lengths in future e.g. 3.2 and 3.2.1
@@ -322,7 +322,7 @@ class CFChecker:
 
         print("")
         if self.uploader:
-            realfile = string.split(file, ".nc")[0] + ".nc"
+            realfile = nc.split(".nc")[0] + ".nc"
             print("CHECKING NetCDF FILE:", realfile)
         elif self.useFileName == "no":
             print("CHECKING NetCDF FILE")
@@ -680,7 +680,7 @@ class CFChecker:
         attDict = var.attributes
         if attName not in attDict.keys():
             return None
-        bits = string.split(attDict[attName])
+        bits = attDict[attName].split()
         if bits:
             return bits[0]
         else:
@@ -696,7 +696,7 @@ class CFChecker:
         if attName not in attDict.keys():
             return None
 
-        bits = string.split(attDict[attName])
+        bits = attDict[attName].split()
 
         if len(bits) == 1:
             # Only standard_name part present
@@ -798,7 +798,7 @@ class CFChecker:
                     print("ERROR (5): Invalid syntax for 'coordinates' attribute in", var)
                     self.err = self.err + 1
                 else:
-                    coordinates = string.split(self.f[var].attributes['coordinates'])
+                    coordinates = self.f[var].attributes['coordinates'].split()
                     for dataVar in coordinates:
                         if dataVar in variables:
 
@@ -1100,9 +1100,9 @@ class CFChecker:
                 # Split string up into component parts
                 # If a comma is present we assume a comma separated list as names cannot contain commas
                 if re.match("^.*,.*$", conventions):
-                    conventionList = string.split(conventions, ",")
+                    conventionList = conventions.split(",")
                 else:
-                    conventionList = string.split(conventions)
+                    conventionList = conventions.split()
 
                 found = 0
                 for convention in conventionList:
@@ -1152,9 +1152,9 @@ class CFChecker:
             # Split string up into component parts
             # If a comma is present we assume a comma separated list as names cannot contain commas
             if re.match("^.*,.*$", conventions):
-                conventionList = string.split(conventions, ",")
+                conventionList = conventions.split(",")
             else:
-                conventionList = string.split(conventions)
+                conventionList = conventions.split()
 
             found = 0
             coards = 0
@@ -1713,7 +1713,7 @@ class CFChecker:
                 rc = 0
             else:
                 # Need to validate the measure + name
-                split = string.split(cellMeasures)
+                split = cellMeasures.split()
                 splitIter = iter(split)
                 try:
                     while 1:
@@ -1804,7 +1804,7 @@ class CFChecker:
                 rc = 0
             else:
                 # Need to validate the term & var
-                split = string.split(formulaTerms)
+                split = formulaTerms.split()
                 for x in split[:]:
                     if not re.search("^[a-zA-Z0-9_]+:$", x):
                         # Variable - should be declared in netCDF file
@@ -1963,7 +1963,7 @@ class CFChecker:
 
         # units must be recognizable by the BADC units file
         for line in units_lines:
-            if hasattr(var, 'units') and var.attributes['units'] in string.split(line):
+            if hasattr(var, 'units') and var.attributes['units'] in line.split():
                 print("Valid units in BADC list:", var.attributes['units'])
                 rc = 1
                 break
@@ -2229,7 +2229,7 @@ class CFChecker:
 
             # standard_name attribute can comprise a standard_name only or a standard_name
             # followed by a modifier (E.g. atmosphere_cloud_liquid_water_content status_flag)
-            std_name_el = string.split(std_name)
+            std_name_el = std_name.split()
             if not std_name_el:
                 print("ERROR (3.3): Empty string for 'standard_name' attribute")
                 self.err = self.err + 1
@@ -2275,7 +2275,7 @@ class CFChecker:
                 self.err = self.err + 1
                 rc = 0
             else:
-                dimensions = string.split(compress)
+                dimensions = compress.split()
                 dimProduct = 1
                 for x in dimensions:
                     found = 'false'

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -322,7 +322,7 @@ class CFChecker:
 
         print("")
         if self.uploader:
-            realfile = nc.split(".nc")[0] + ".nc"
+            realfile = file.split(".nc")[0] + ".nc"
             print("CHECKING NetCDF FILE:", realfile)
         elif self.useFileName == "no":
             print("CHECKING NetCDF FILE")

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -3136,8 +3136,6 @@ def ogr_shape_62():
 
 def ogr_shape_63():
 
-    import struct
-
     ds = ogr.GetDriverByName('ESRI Shapefile').CreateDataSource('/vsimem/ogr_shape_63.dbf')
     lyr = ds.CreateLayer('ogr_shape_63', geom_type=ogr.wkbNone)
     gdaltest.fieldname = '\xc3\xa9'
@@ -3551,7 +3549,6 @@ def ogr_shape_72():
     if gdaltest.filesystem_supports_sparse_files('tmp') is False:
         return 'skip'
 
-    import struct
     ds = ogr.GetDriverByName('ESRI Shapefile').CreateDataSource('tmp/ogr_shape_72.shp')
     lyr = ds.CreateLayer('2gb', geom_type=ogr.wkbPoint)
     feat = ogr.Feature(lyr.GetLayerDefn())
@@ -4287,8 +4284,6 @@ def ogr_shape_89():
 
 
 def ogr_shape_90():
-
-    import struct
 
     ds = ogr.GetDriverByName('ESRI Shapefile').CreateDataSource('/vsimem/ogr_shape_90.shp')
     lyr = ds.CreateLayer('ogr_shape_90')

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1327,7 +1327,6 @@ def download_file(url, filename=None, download_size=-1, force_download=False, ma
     except OSError:
         if 'GDAL_DOWNLOAD_TEST_DATA' in os.environ or force_download:
             val = None
-            import time
             start_time = time.time()
             try:
                 handle = gdalurlopen(url)

--- a/gdal/frmts/ecw/lookup.py
+++ b/gdal/frmts/ecw/lookup.py
@@ -48,9 +48,9 @@ def load_dict(filename):
     this_dict = {}
     for line in lines:
         if line[:8] != 'proj_name':
-            tokens = string.split(line, ',')
+            tokens = line.split(',')
             for i in range(len(tokens)):
-                tokens[i] = string.strip(tokens[i])
+                tokens[i] = tokens[i].strip()
 
             this_dict[tokens[0]] = tokens
 
@@ -77,12 +77,12 @@ pfile.readline()
 
 for line in pfile.readlines():
     try:
-        tokens = string.split(string.strip(line), ',')
+        tokens = line.strip().split(',')
         if len(tokens) < 3:
             continue
 
         for i in range(len(tokens)):
-            tokens[i] = string.strip(tokens[i])
+            tokens[i] = tokens[i].strip()
 
         id = tokens[0]
         type = tokens[1]
@@ -169,9 +169,9 @@ pfile = open(dir + 'datum.dat')
 pfile.readline()
 
 for line in pfile.readlines():
-    tokens = string.split(string.strip(line), ',')
+    tokens = line.strip().split(',')
     for i in range(len(tokens)):
-        tokens[i] = string.strip(tokens[i])
+        tokens[i] = tokens[i].strip()
 
     id = tokens[0]
 

--- a/gdal/ogr/ogrsf_frmts/s57/s57tables.py
+++ b/gdal/ogr/ogrsf_frmts/s57/s57tables.py
@@ -66,7 +66,7 @@ print('char *gpapszS57Classes[] = {')
 classes = open(directory + '/s57objectclasses.csv').readlines()
 
 for line in classes:
-    print('"%s",' % EscapeLine(string.strip(line)))
+    print('"%s",' % EscapeLine(line.strip()))
 
 print('NULL };')
 
@@ -74,6 +74,6 @@ print('char *gpapszS57attributes[] = {')
 classes = open(directory + '/s57attributes.csv').readlines()
 
 for line in classes:
-    print('"%s",' % EscapeLine(string.strip(line)))
+    print('"%s",' % EscapeLine(line.strip()))
 
 print('NULL };')

--- a/gdal/swig/python/scripts/epsg_tr.py
+++ b/gdal/swig/python/scripts/epsg_tr.py
@@ -217,7 +217,7 @@ if __name__ == '__main__':
                 if c_offset > 0:
                     line = line[:c_offset]
 
-                code = string.atoi(line)
+                code = int(line)
             except:
                 code = -1
 

--- a/gdal/swig/python/scripts/epsg_tr.py
+++ b/gdal/swig/python/scripts/epsg_tr.py
@@ -31,7 +31,6 @@
 #  DEALINGS IN THE SOFTWARE.
 # ******************************************************************************
 
-import string
 import sys
 
 from osgeo import osr

--- a/gdal/swig/python/scripts/esri2wkt.py
+++ b/gdal/swig/python/scripts/esri2wkt.py
@@ -44,7 +44,7 @@ prj_lines = prj_fd.readlines()
 prj_fd.close()
 
 for i in range(len(prj_lines)):
-    prj_lines[i] = string.rstrip(prj_lines[i])
+    prj_lines[i] = prj_lines[i].rstrip()
 
 prj_srs = osr.SpatialReference()
 err = prj_srs.ImportFromESRI(prj_lines)

--- a/gdal/swig/python/scripts/esri2wkt.py
+++ b/gdal/swig/python/scripts/esri2wkt.py
@@ -29,7 +29,6 @@
 #  DEALINGS IN THE SOFTWARE.
 # ******************************************************************************
 
-import string
 import sys
 
 from osgeo import osr


### PR DESCRIPTION
## What does this PR do?

Pylint warns about uses of `string.split` and `string.strip`. This patch calls `strip()` and `split()` methods on string objects rather than calling the module functions `string.strip` and `string.split` which are not in Python 3. It's also more object oriented. :-)