### PR TITLE
Python code: Typo fix in autotest/gdrivers/db2.py

### DIFF
--- a/autotest/gdrivers/db2.py
+++ b/autotest/gdrivers/db2.py
@@ -184,7 +184,7 @@ def gpkg_1():
 #   clamped_expected_cs = get_expected_checksums(ds, gdaltest.png_dr, 1, clamp_output = False)[0]
     expected_gt = ds.GetGeoTransform()
     expected_wkt = ds.GetProjectionRef()
-    out_ds = gdaltest.db2_dr.CreateCopy('DB2ODBC:database=samp105;DSN=SAMP105A', ds, options=['TILE_FORMAT=PNG'])
+    out_ds = gdaltest.db2_drv.CreateCopy('DB2ODBC:database=samp105;DSN=SAMP105A', ds, options=['TILE_FORMAT=PNG'])
     out_ds = None
     ds = None
 


### PR DESCRIPTION
## What does this PR do?

Fixes a suspected typo in `db2.py`. Not sure how this ever worked?