### PR TITLE
Python code: Don't shadow exit().

### DIFF
--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -2633,11 +2633,9 @@ def getargs(arglist):
 
 if __name__ == '__main__':
 
-    from sys import argv, exit
-
-    (badc, coards, uploader, useFileName, standardName, areaTypes, udunitsDat, version, files) = getargs(argv)
+    (badc, coards, uploader, useFileName, standardName, areaTypes, udunitsDat, version, files) = getargs(sys.argv)
 
     inst = CFChecker(uploader=uploader, useFileName=useFileName, badc=badc, coards=coards, cfStandardNamesXML=standardName, cfAreaTypesXML=areaTypes, udunitsDat=udunitsDat, version=version)
     for file in files:
         rc = inst.checker(file)
-        exit(rc)
+        sys.exit(rc)


### PR DESCRIPTION
## What does this PR do?

Pylint warns about `sys.exit` shadowing the built-in `exit()`. Best to import `sys` and just refer to `sys.exit` for no ambiguity.