### PR TITLE
Python code: autotest/ogr/ogr_vrt.py (ogr_vrt_33): Use i, not j.

### DIFF
--- a/autotest/ogr/ogr_vrt.py
+++ b/autotest/ogr/ogr_vrt.py
@@ -2710,7 +2710,7 @@ def ogr_vrt_33():
                 if lyr.GetGeometryColumn() != 'foo':
                     gdaltest.post_reason('fail')
                     return 'fail'
-            elif j == 3:
+            elif i == 3:
                 if lyr.TestCapability(ogr.OLCFastGetExtent) != 1:
                     gdaltest.post_reason('fail')
                     return 'fail'


### PR DESCRIPTION
## What does this PR do?

Pylint noticed that `j` was possibly undefined in this function. The wrong variable is referenced here. It should be `i`.