### PR TITLE
Python code: Rename 'format' -> 'frmt' to avoid shadowing the built-in format().

### DIFF
--- a/gdal/swig/python/samples/hsv_merge.py
+++ b/gdal/swig/python/samples/hsv_merge.py
@@ -129,7 +129,7 @@ argv = gdal.GeneralCmdLineProcessor(sys.argv)
 if argv is None:
     sys.exit(0)
 
-format = 'GTiff'
+frmt = 'GTiff'
 src_color_filename = None
 src_greyscale_filename = None
 dst_color_filename = None
@@ -142,7 +142,7 @@ while i < len(argv):
 
     if arg == '-of':
         i = i + 1
-        format = argv[i]
+        frmt = argv[i]
 
     elif arg == '-q' or arg == '-quiet':
         quiet = True
@@ -174,7 +174,7 @@ if (colordataset.RasterCount != 3 and colordataset.RasterCount != 4):
     sys.exit(1)
 
 # define output format, name, size, type and set projection
-out_driver = gdal.GetDriverByName(format)
+out_driver = gdal.GetDriverByName(frmt)
 outdataset = out_driver.Create(dst_color_filename, colordataset.RasterXSize,
                                colordataset.RasterYSize, colordataset.RasterCount, datatype)
 outdataset.SetProjection(hilldataset.GetProjection())

--- a/gdal/swig/python/samples/ogr_dispatch.py
+++ b/gdal/swig/python/samples/ogr_dispatch.py
@@ -295,7 +295,7 @@ def ogr_dispatch(argv, progress=None, progress_arg=None):
 
     src_filename = None
     dst_filename = None
-    format = "ESRI Shapefile"
+    frmt = "ESRI Shapefile"
     options = Options()
     lco = []
     dsco = []
@@ -315,7 +315,7 @@ def ogr_dispatch(argv, progress=None, progress_arg=None):
             dst_filename = argv[i]
         elif EQUAL(arg, '-f') and i + 1 < len(argv):
             i = i + 1
-            format = argv[i]
+            frmt = argv[i]
 
         elif EQUAL(arg, '-a_srs') and i + 1 < len(argv):
             i = i + 1
@@ -384,7 +384,7 @@ def ogr_dispatch(argv, progress=None, progress_arg=None):
             print('-dsco should not be specified for an existing datasource')
             return 1
     else:
-        dst_ds = ogr.GetDriverByName(format).CreateDataSource(dst_filename, options=dsco)
+        dst_ds = ogr.GetDriverByName(frmt).CreateDataSource(dst_filename, options=dsco)
     if dst_ds is None:
         print('Cannot open or create target datasource %s' % dst_filename)
         return 1

--- a/gdal/swig/python/samples/ogr_layer_algebra.py
+++ b/gdal/swig/python/samples/ogr_layer_algebra.py
@@ -124,7 +124,7 @@ def CreateLayer(output_ds, output_lyr_name, srs, geom_type, lco,
 
 def main(argv=None):
 
-    format = 'ESRI Shapefile'
+    frmt = 'ESRI Shapefile'
     quiet_flag = 0
     input_ds_name = None
     input_lyr_name = None
@@ -154,7 +154,7 @@ def main(argv=None):
 
         if arg == '-f' and i + 1 < len(argv):
             i = i + 1
-            format = argv[i]
+            frmt = argv[i]
 
         elif arg == '-input_ds' and i + 1 < len(argv):
             i = i + 1
@@ -364,9 +364,9 @@ def main(argv=None):
             print('Output datasource "%s" exists, but cannot be opened in update mode' % output_ds_name)
             return 1
 
-        drv = ogr.GetDriverByName(format)
+        drv = ogr.GetDriverByName(frmt)
         if drv is None:
-            print('Cannot find driver %s' % format)
+            print('Cannot find driver %s' % frmt)
             return 1
 
         output_ds = drv.CreateDataSource(output_ds_name, options=dsco)

--- a/gdal/swig/python/samples/rel.py
+++ b/gdal/swig/python/samples/rel.py
@@ -106,7 +106,7 @@ def ParseType(type):
 infile = None
 outfile = None
 iBand = 1	    # The first band will be converted by default
-format = 'GTiff'
+frmt = 'GTiff'
 type = gdal.GDT_Byte
 
 lsrcaz = None
@@ -191,7 +191,7 @@ if indataset.RasterXSize < 3 or indataset.RasterYSize < 3:
     print('Input image is too small to process, minimum size is 3x3')
     sys.exit(3)
 
-out_driver = gdal.GetDriverByName(format)
+out_driver = gdal.GetDriverByName(frmt)
 outdataset = out_driver.Create(outfile, indataset.RasterXSize, indataset.RasterYSize, indataset.RasterCount, type)
 outband = outdataset.GetRasterBand(1)
 

--- a/gdal/swig/python/samples/val_repl.py
+++ b/gdal/swig/python/samples/val_repl.py
@@ -71,7 +71,7 @@ inNoData = None
 outNoData = None
 infile = None
 outfile = None
-format = 'GTiff'
+frmt = 'GTiff'
 type = gdal.GDT_Byte
 
 # Parse command line arguments.
@@ -89,7 +89,7 @@ while i < len(sys.argv):
 
     elif arg == '-of':
         i = i + 1
-        format = sys.argv[i]
+        frmt = sys.argv[i]
 
     elif arg == '-ot':
         i = i + 1
@@ -117,7 +117,7 @@ if outNoData is None:
 
 indataset = gdal.Open(infile, gdal.GA_ReadOnly)
 
-out_driver = gdal.GetDriverByName(format)
+out_driver = gdal.GetDriverByName(frmt)
 outdataset = out_driver.Create(outfile, indataset.RasterXSize, indataset.RasterYSize, indataset.RasterCount, type)
 
 gt = indataset.GetGeoTransform()

--- a/gdal/swig/python/scripts/gdal2xyz.py
+++ b/gdal/swig/python/scripts/gdal2xyz.py
@@ -143,9 +143,9 @@ if __name__ == '__main__':
     if abs(gt[0]) < 180 and abs(gt[3]) < 180 \
        and abs(srcds.RasterXSize * gt[1]) < 180 \
        and abs(srcds.RasterYSize * gt[5]) < 180:
-        format = '%.10g' + delim + '%.10g' + delim + '%s'
+        frmt = '%.10g' + delim + '%.10g' + delim + '%s'
     else:
-        format = '%.3f' + delim + '%.3f' + delim + '%s'
+        frmt = '%.3f' + delim + '%.3f' + delim + '%s'
 
     # Loop emitting data.
 
@@ -171,6 +171,6 @@ if __name__ == '__main__':
 
             band_str = band_format % tuple(x_i_data)
 
-            line = format % (float(geo_x), float(geo_y), band_str)
+            line = frmt % (float(geo_x), float(geo_y), band_str)
 
             dst_fh.write(line)

--- a/gdal/swig/python/scripts/gdal_fillnodata.py
+++ b/gdal/swig/python/scripts/gdal_fillnodata.py
@@ -62,7 +62,7 @@ src_filename = None
 src_band = 1
 
 dst_filename = None
-format = 'GTiff'
+frmt = 'GTiff'
 creation_options = []
 
 mask = 'default'
@@ -79,7 +79,7 @@ while i < len(argv):
 
     if arg == '-of' or arg == '-f':
         i = i + 1
-        format = argv[i]
+        frmt = argv[i]
 
     elif arg == '-co':
         i = i + 1
@@ -169,7 +169,7 @@ else:
 
 if dst_filename is not None:
 
-    drv = gdal.GetDriverByName(format)
+    drv = gdal.GetDriverByName(frmt)
     dst_ds = drv.Create(dst_filename, src_ds.RasterXSize, src_ds.RasterYSize, 1,
                         srcband.DataType, creation_options)
     wkt = src_ds.GetProjection()

--- a/gdal/swig/python/scripts/gdal_merge.py
+++ b/gdal/swig/python/scripts/gdal_merge.py
@@ -347,7 +347,7 @@ def main(argv=None):
     verbose = 0
     quiet = 0
     names = []
-    format = None
+    frmt = None
     out_file = 'out.tif'
 
     ulx = None
@@ -420,7 +420,7 @@ def main(argv=None):
 
         elif arg == '-f' or arg == '-of':
             i = i + 1
-            format = argv[i]
+            frmt = argv[i]
 
         elif arg == '-co':
             i = i + 1
@@ -456,17 +456,17 @@ def main(argv=None):
         Usage()
         sys.exit(1)
 
-    if format is None:
-        format = GetOutputDriverFor(out_file)
+    if frmt is None:
+        frmt = GetOutputDriverFor(out_file)
 
-    Driver = gdal.GetDriverByName(format)
+    Driver = gdal.GetDriverByName(frmt)
     if Driver is None:
-        print('Format driver %s not found, pick a supported driver.' % format)
+        print('Format driver %s not found, pick a supported driver.' % frmt)
         sys.exit(1)
 
     DriverMD = Driver.GetMetadata()
     if 'DCAP_CREATE' not in DriverMD:
-        print('Format driver %s does not support creation and piecewise writing.\nPlease select a format that does, such as GTiff (the default) or HFA (Erdas Imagine).' % format)
+        print('Format driver %s does not support creation and piecewise writing.\nPlease select a format that does, such as GTiff (the default) or HFA (Erdas Imagine).' % frmt)
         sys.exit(1)
 
     # Collect information on all the source files.

--- a/gdal/swig/python/scripts/gdal_pansharpen.py
+++ b/gdal/swig/python/scripts/gdal_pansharpen.py
@@ -109,7 +109,7 @@ def gdal_pansharpen(argv):
     out_name = None
     bands = []
     weights = []
-    format = None
+    frmt = None
     creation_options = []
     callback = gdal.TermProgress_nocb
     resampling = None
@@ -123,7 +123,7 @@ def gdal_pansharpen(argv):
     argc = len(argv)
     while i < argc:
         if (argv[i] == '-of' or argv[i] == '-f') and i < len(argv) - 1:
-            format = argv[i + 1]
+            frmt = argv[i + 1]
             i = i + 1
         elif argv[i] == '-r' and i < len(argv) - 1:
             resampling = argv[i + 1]
@@ -190,8 +190,8 @@ def gdal_pansharpen(argv):
         return Usage()
     out_name = last_name
 
-    if format is None:
-        format = GetOutputDriverFor(out_name)
+    if frmt is None:
+        frmt = GetOutputDriverFor(out_name)
 
     if len(bands) == 0:
         bands = [j + 1 for j in range(len(spectral_bands))]
@@ -243,7 +243,7 @@ def gdal_pansharpen(argv):
         vrt_xml += '      <SpatialExtentAdjustment>%s</SpatialExtentAdjustment>\n' % spat_adjust
 
     pan_relative = '0'
-    if format.upper() == 'VRT':
+    if frmt.upper() == 'VRT':
         if not os.path.isabs(pan_name):
             pan_relative = '1'
             pan_name = os.path.relpath(pan_name, os.path.dirname(out_name))
@@ -262,7 +262,7 @@ def gdal_pansharpen(argv):
 
         ms_relative = '0'
         ms_name = spectral_ds[i].GetDescription()
-        if format.upper() == 'VRT':
+        if frmt.upper() == 'VRT':
             if not os.path.isabs(ms_name):
                 ms_relative = '1'
                 ms_name = os.path.relpath(ms_name, os.path.dirname(out_name))
@@ -275,7 +275,7 @@ def gdal_pansharpen(argv):
     vrt_xml += """  </PansharpeningOptions>\n"""
     vrt_xml += """</VRTDataset>\n"""
 
-    if format.upper() == 'VRT':
+    if frmt.upper() == 'VRT':
         f = gdal.VSIFOpenL(out_name, 'wb')
         if f is None:
             print('Cannot create %s' % out_name)
@@ -293,7 +293,7 @@ def gdal_pansharpen(argv):
         return 0
 
     vrt_ds = gdal.Open(vrt_xml)
-    out_ds = gdal.GetDriverByName(format).CreateCopy(out_name, vrt_ds, 0, creation_options, callback=callback)
+    out_ds = gdal.GetDriverByName(frmt).CreateCopy(out_name, vrt_ds, 0, creation_options, callback=callback)
     if out_ds is None:
         return 1
     return 0

--- a/gdal/swig/python/scripts/gdal_polygonize.py
+++ b/gdal/swig/python/scripts/gdal_polygonize.py
@@ -93,7 +93,7 @@ def GetOutputDriverFor(filename):
 # =============================================================================
 
 
-format = None
+frmt = None
 options = []
 quiet_flag = 0
 src_filename = None
@@ -118,7 +118,7 @@ while i < len(argv):
 
     if arg == '-f' or arg == '-of':
         i = i + 1
-        format = argv[i]
+        frmt = argv[i]
 
     elif arg == '-q' or arg == '-quiet':
         quiet_flag = 1
@@ -160,8 +160,8 @@ while i < len(argv):
 if src_filename is None or dst_filename is None:
     Usage()
 
-if format is None:
-    format = GetOutputDriverFor(dst_filename)
+if frmt is None:
+    frmt = GetOutputDriverFor(dst_filename)
 
 if dst_layername is None:
     dst_layername = 'out'
@@ -222,9 +222,9 @@ except:
 # 	Create output file.
 # =============================================================================
 if dst_ds is None:
-    drv = ogr.GetDriverByName(format)
+    drv = ogr.GetDriverByName(frmt)
     if not quiet_flag:
-        print('Creating output %s of format %s.' % (dst_filename, format))
+        print('Creating output %s of format %s.' % (dst_filename, frmt))
     dst_ds = drv.CreateDataSource(dst_filename)
 
 # =============================================================================

--- a/gdal/swig/python/scripts/gdal_proximity.py
+++ b/gdal/swig/python/scripts/gdal_proximity.py
@@ -100,7 +100,7 @@ def GetOutputDriverFor(filename):
 # =============================================================================
 
 
-format = None
+frmt = None
 creation_options = []
 options = []
 src_filename = None
@@ -122,7 +122,7 @@ while i < len(argv):
 
     if arg == '-of' or arg == '-f':
         i = i + 1
-        format = argv[i]
+        frmt = argv[i]
 
     elif arg == '-co':
         i = i + 1
@@ -211,10 +211,10 @@ except:
 #     Create output file.
 # =============================================================================
 if dst_ds is None:
-    if format is None:
-        format = GetOutputDriverFor(dst_filename)
+    if frmt is None:
+        frmt = GetOutputDriverFor(dst_filename)
 
-    drv = gdal.GetDriverByName(format)
+    drv = gdal.GetDriverByName(frmt)
     dst_ds = drv.Create(dst_filename,
                         src_ds.RasterXSize, src_ds.RasterYSize, 1,
                         gdal.GetDataTypeByName(creation_type), creation_options)

--- a/gdal/swig/python/scripts/gdal_sieve.py
+++ b/gdal/swig/python/scripts/gdal_sieve.py
@@ -103,7 +103,7 @@ quiet_flag = 0
 src_filename = None
 
 dst_filename = None
-format = None
+frmt = None
 
 mask = 'default'
 
@@ -119,7 +119,7 @@ while i < len(argv):
 
     if arg == '-of' or arg == '-f':
         i = i + 1
-        format = argv[i]
+        frmt = argv[i]
 
     elif arg == '-4':
         connectedness = 4
@@ -202,10 +202,10 @@ else:
 # =============================================================================
 
 if dst_filename is not None:
-    if format is None:
-        format = GetOutputDriverFor(dst_filename)
+    if frmt is None:
+        frmt = GetOutputDriverFor(dst_filename)
 
-    drv = gdal.GetDriverByName(format)
+    drv = gdal.GetDriverByName(frmt)
     dst_ds = drv.Create(dst_filename, src_ds.RasterXSize, src_ds.RasterYSize, 1,
                         srcband.DataType)
     wkt = src_ds.GetProjection()

--- a/gdal/swig/python/scripts/rgb2pct.py
+++ b/gdal/swig/python/scripts/rgb2pct.py
@@ -94,7 +94,7 @@ def GetOutputDriverFor(filename):
 
 
 color_count = 256
-format = None
+frmt = None
 src_filename = None
 dst_filename = None
 pct_filename = None
@@ -111,7 +111,7 @@ while i < len(argv):
 
     if arg == '-of' or arg == '-f':
         i = i + 1
-        format = argv[i]
+        frmt = argv[i]
 
     elif arg == '-n':
         i = i + 1
@@ -149,12 +149,12 @@ if src_ds.RasterCount < 3:
 
 # Ensure we recognise the driver.
 
-if format is None:
-    format = GetOutputDriverFor(dst_filename)
+if frmt is None:
+    frmt = GetOutputDriverFor(dst_filename)
 
-dst_driver = gdal.GetDriverByName(format)
+dst_driver = gdal.GetDriverByName(frmt)
 if dst_driver is None:
-    print('"%s" driver not registered.' % format)
+    print('"%s" driver not registered.' % frmt)
     sys.exit(1)
 
 # Generate palette


### PR DESCRIPTION
## What does this PR do?

Renames variables called `format` -> `frmt` to silence warnings from Pylint about shadowing the built-in `format()`.