### PR TITLE
Python code: Silence unused argument warnings from Pylint

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1003,7 +1003,7 @@ def warp_26():
 
 
 def warp_27_progress_callback(pct, message, user_data):
-    # print(pct)
+    # pylint: disable=unused-argument
     return 1  # 1 to continue, 0 to stop
 
 
@@ -1164,6 +1164,7 @@ def warp_29():
 
 
 def warp_30_progress_callback(pct, message, user_data):
+    # pylint: disable=unused-argument
     if pct > 0.2:
         return 0  # stop
     else:

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -587,10 +587,12 @@ def basic_test_15_cbk_no_argument():
 
 
 def basic_test_15_cbk_no_ret(a, b, c):
+    # pylint: disable=unused-argument
     return None
 
 
 def basic_test_15_cbk_bad_ret(a, b, c):
+    # pylint: disable=unused-argument
     return 'ok'
 
 

--- a/autotest/gcore/gdal_stats.py
+++ b/autotest/gcore/gdal_stats.py
@@ -311,6 +311,7 @@ def stats_nan_8():
 
 
 def stats_nodata_inf_progress_cbk(value, string, extra):
+    # pylint: disable=unused-argument
     extra[0] = value
 
 

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -270,6 +270,7 @@ class misc_6_interrupt_callback_class:
         pass
 
     def cbk(self, pct, message, user_data):
+        # pylint: disable=unused-argument
         if pct > 0.5:
             return 0  # to stop
         else:

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -648,6 +648,7 @@ def numpy_rw_13():
 
 
 def numpy_rw_14_progress_callback(pct, message, user_data):
+    # pylint: disable=unused-argument
     if abs(pct - user_data[0]) > 1e-5:
         print('Expected %f, got %f' % (user_data[0], pct))
         user_data[1] = False
@@ -656,6 +657,7 @@ def numpy_rw_14_progress_callback(pct, message, user_data):
 
 
 def numpy_rw_14_progress_interrupt_callback(pct, message, user_data):
+    # pylint: disable=unused-argument
     user_data[0] = pct
     if pct >= 0.5:
         return 0
@@ -663,6 +665,7 @@ def numpy_rw_14_progress_interrupt_callback(pct, message, user_data):
 
 
 def numpy_rw_14_progress_callback_2(pct, message, user_data):
+    # pylint: disable=unused-argument
     if pct < user_data[0]:
         print('Got %f, last pct was %f' % (pct, user_data[0]))
         return 0

--- a/autotest/gcore/thread_test.py
+++ b/autotest/gcore/thread_test.py
@@ -39,6 +39,7 @@ from osgeo import gdal
 
 
 def my_error_handler(err_type, err_no, err_msg):
+    # pylint: disable=unused-argument
     pass
 
 

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -2907,6 +2907,7 @@ class myHandlerClass:
         self.msg = None
 
     def handler(self, eErrClass, err_no, msg):
+        # pylint: disable=unused-argument
         if msg.find('File open of') >= 0:
             self.msg = msg
 

--- a/autotest/gdrivers/isis.py
+++ b/autotest/gdrivers/isis.py
@@ -1013,6 +1013,7 @@ def isis_23():
 
 
 def cancel_cbk(pct, msg, user_data):
+    # pylint: disable=unused-argument
     return 0
 
 # Test error cases

--- a/autotest/gdrivers/wcs.py
+++ b/autotest/gdrivers/wcs.py
@@ -313,7 +313,8 @@ wcs_6_ok = True
 
 class WCSHTTPHandler(BaseHTTPRequestHandler):
 
-    def log_request(self, code='-', size='-'):
+    def log_request(self, code, size):
+        # pylint: disable=unused-argument
         return
 
     def Headers(self, typ):

--- a/autotest/gdrivers/wcs.py
+++ b/autotest/gdrivers/wcs.py
@@ -313,7 +313,7 @@ wcs_6_ok = True
 
 class WCSHTTPHandler(BaseHTTPRequestHandler):
 
-    def log_request(self, code, size):
+    def log_request(self, code=',', size=','):
         # pylint: disable=unused-argument
         return
 

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -375,6 +375,7 @@ def clean_tmp():
 
 
 def testCreateCopyInterruptCallback(pct, message, user_data):
+    # pylint: disable=unused-argument
     if pct > 0.5:
         return 0  # to stop
     else:

--- a/autotest/pymod/gdaltest_python2.py
+++ b/autotest/pymod/gdaltest_python2.py
@@ -145,6 +145,7 @@ def wait_process(process):
 
 
 def _runexternal_subprocess(cmd, strin=None, check_memleak=True, display_live_on_parent_stdout=False, encoding=None):
+    # pylint: disable=unused-argument
     import subprocess
     import shlex
     command = shlex.split(cmd)
@@ -236,6 +237,7 @@ def read_in_thread(f, q):
 
 
 def _runexternal_out_and_err_subprocess(cmd, check_memleak=True):
+    # pylint: disable=unused-argument
     import subprocess
     import shlex
     command = shlex.split(cmd)

--- a/autotest/pymod/gdaltest_python3.py
+++ b/autotest/pymod/gdaltest_python3.py
@@ -160,6 +160,7 @@ def read_in_thread(f, q):
 
 
 def runexternal_out_and_err(cmd, check_memleak=True):
+    # pylint: disable=unused-argument
     command = shlex.split(cmd)
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 

--- a/autotest/pymod/gdaltest_python3.py
+++ b/autotest/pymod/gdaltest_python3.py
@@ -122,6 +122,7 @@ def wait_process(process):
 
 
 def runexternal(cmd, strin=None, check_memleak=True, display_live_on_parent_stdout=False, encoding='latin1'):
+    # pylint: disable=unused-argument
     command = shlex.split(cmd)
     if strin is None:
         p = subprocess.Popen(command, stdout=subprocess.PIPE)

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -249,7 +249,7 @@ class DispatcherHttpHandler(BaseHTTPRequestHandler):
 
 
 class GDAL_Handler(BaseHTTPRequestHandler):
-
+    # pylint: disable=unused-argument
     def log_request(self, code='-', size='-'):
         return
 

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -200,6 +200,7 @@ class DispatcherHttpHandler(BaseHTTPRequestHandler):
     # protocol_version = 'HTTP/1.1'
 
     def log_request(self, code='-', size='-'):
+        # pylint: disable=unused-argument
         return
 
     def do_HEAD(self):

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -293,6 +293,7 @@ def test_ogr2ogr_lib_11():
 
 
 def mycallback(pct, msg, user_data):
+    # pylint: disable=unused-argument
     user_data[0] = pct
     return 1
 

--- a/gdal/swig/python/samples/build_jp2_from_xml.py
+++ b/gdal/swig/python/samples/build_jp2_from_xml.py
@@ -107,6 +107,7 @@ def write_hexstring_as_binary(hex_binary_content, out_f):
 
 
 def parse_field(xml_tree, out_f, src_jp2file):
+    # pylint: disable=unused-argument
     if not(xml_tree[XML_TYPE_IDX] == gdal.CXT_Element and xml_tree[XML_VALUE_IDX] == 'Field'):
         print('Not a Field element')
         return False

--- a/gdal/swig/python/samples/densify.py
+++ b/gdal/swig/python/samples/densify.py
@@ -146,6 +146,7 @@ class Translator(object):
                 self.output.CreateField(fld)
 
     def translate(self, geometry_callback=None, attribute_callback=None):
+        # pylint: disable=unused-argument
         f = self.input.GetNextFeature()
         trans = None
         if self.options.t_srs:

--- a/gdal/swig/python/samples/gdal_cp.py
+++ b/gdal/swig/python/samples/gdal_cp.py
@@ -50,7 +50,7 @@ class TermProgress:
         self.nLastTick = -1
 
     def Progress(self, dfComplete, message):
-
+        # pylint: disable=unused-argument
         self.nThisTick = int(dfComplete * 40.0)
         if self.nThisTick > 40:
             self.nThisTick = 40

--- a/gdal/swig/python/samples/gdal_mkdir.py
+++ b/gdal/swig/python/samples/gdal_mkdir.py
@@ -39,6 +39,7 @@ def Usage():
 
 
 def gdal_mkdir(argv, progress=None):
+    # pylint: disable=unused-argument
     filename = None
 
     argv = gdal.GeneralCmdLineProcessor(argv)

--- a/gdal/swig/python/samples/gdal_rm.py
+++ b/gdal/swig/python/samples/gdal_rm.py
@@ -75,6 +75,7 @@ def gdal_rm_recurse(filename, simulate=False):
 
 
 def gdal_rm(argv, progress=None):
+    # pylint: disable=unused-argument
     filename = None
     recurse = False
     simulate = False

--- a/gdal/swig/python/samples/gdal_rmdir.py
+++ b/gdal/swig/python/samples/gdal_rmdir.py
@@ -39,6 +39,7 @@ def Usage():
 
 
 def gdal_rm(argv, progress=None):
+    # pylint: disable=unused-argument
     filename = None
 
     argv = gdal.GeneralCmdLineProcessor(argv)

--- a/gdal/swig/python/samples/ogr_dispatch.py
+++ b/gdal/swig/python/samples/ogr_dispatch.py
@@ -292,7 +292,7 @@ def convert_layer(src_lyr, dst_ds, layerMap, options):
 
 
 def ogr_dispatch(argv, progress=None, progress_arg=None):
-
+    # pylint: disable=unused-argument
     src_filename = None
     dst_filename = None
     format = "ESRI Shapefile"

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -114,6 +114,7 @@ def GetOutputDriverFor(filename):
 
 
 def doit(opts, args):
+    # pylint: disable=unused-argument
 
     if opts.debug:
         print("gdal_calc.py starting calculation %s" % (opts.calc))
@@ -400,6 +401,7 @@ def Calc(calc, outfile, NoDataValue=None, type=None, format=None, creation_optio
 
 
 def store_input_file(option, opt_str, value, parser):
+    # pylint: disable=unused-argument
     if not hasattr(parser.values, 'input_files'):
         parser.values.input_files = {}
     parser.values.input_files[opt_str.lstrip('-')] = value

--- a/gdal/swig/python/scripts/gdalcompare.py
+++ b/gdal/swig/python/scripts/gdalcompare.py
@@ -39,6 +39,7 @@ from osgeo import osr
 
 
 def compare_metadata(golden_md, new_md, id, options=[]):
+    # pylint: disable=unused-argument
     if golden_md is None and new_md is None:
         return 0
 
@@ -66,6 +67,7 @@ def compare_metadata(golden_md, new_md, id, options=[]):
 #######################################################
 # Review and report on the actual image pixels that differ.
 def compare_image_pixels(golden_band, new_band, id, options=[]):
+    # pylint: disable=unused-argument
     diff_count = 0
     max_diff = 0
 


### PR DESCRIPTION
## What does this PR do?

Silences warnings from Pylint about unused arguments. I did not want to (yet) remove the argument and change the function signatures because I don't want to break the existing API. I will re-assess later.