### PR TITLE
Python code: gdal/swig/python/samples/tolatlong.py: 'int' -> 'lon'.

### DIFF
--- a/gdal/swig/python/samples/tolatlong.py
+++ b/gdal/swig/python/samples/tolatlong.py
@@ -105,9 +105,9 @@ if srs.ImportFromWkt(indataset.GetProjection()) != 0:
 
 srsLatLong = srs.CloneGeogCS()
 ct = osr.CoordinateTransformation(srs, srsLatLong)
-(int, lat, height) = ct.TransformPoint(X, Y)
+(lon, lat, height) = ct.TransformPoint(X, Y)
 
 # Report results
 print('pixel: %g\t\t\tline: %g' % (pixel, line))
-print('latitude: %fd\t\tlongitude: %fd' % (lat, int))
-print('latitude: %s\t\tlongitude: %s' % (gdal.DecToDMS(lat, 'Lat', 2), gdal.DecToDMS(int, 'Long', 2)))
+print('latitude: %fd\t\tlongitude: %fd' % (lat, lon))
+print('latitude: %s\t\tlongitude: %s' % (gdal.DecToDMS(lat, 'Lat', 2), gdal.DecToDMS(lon, 'Long', 2)))


### PR DESCRIPTION
## What does this PR do?

I was confused as to why a variable representing longitude was called `int` (and reported by Pylint). I worked out that someone probably did a `long` -> `int` bulk replace at some point. ;-) Let's call it `lon` instead.