### PR TITLE
Python code: netcdf.py: Remove duplicate 'valid_range_s' key in vals_band.

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -985,8 +985,7 @@ def netcdf_24_nc4():
                  'valid_range_l': '0,255',
                  'valid_range_ul': '0,4000000000',
                  'valid_range_d': '0.1111112222222,255.555555555556',
-                 'valid_range_f': '0.1111111,255.5556',
-                 'valid_range_s': '0,255'}
+                 'valid_range_f': '0.1111111,255.5556'}
 
     return netcdf_check_vars('data/nc4_vars.nc', vals_global, vals_band)
 


### PR DESCRIPTION
## What does this PR do?

Removes a duplicate key in the `vals_band` dictionary.