### PR TITLE
Python code: vrtrawlink.py (_xmlsearch): Remove else: None

### DIFF
--- a/autotest/gdrivers/vrtrawlink.py
+++ b/autotest/gdrivers/vrtrawlink.py
@@ -43,8 +43,6 @@ def _xmlsearch(root, nodetype, name):
     for node in root[2:]:
         if node[0] == nodetype and node[1] == name:
             return node
-    else:
-        None
 
 ###############################################################################
 # Verify reading from simple existing raw definition.


### PR DESCRIPTION
## What does this PR do?

The function `_xmlsearch` contained a for-else loop that ended in `else: None`. Since the function will return None if it control falls off the end of the function, these two lines can simply be deleted.