### PR TITLE
Python code: netcdf.py: Change 'is' to '='

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1139,7 +1139,7 @@ def netcdf_test_4dfile(ofile):
         gdaltest.post_reason('copy has %d bands (expected 8) and has %d subdatasets'
                              ' (expected 0)' % (ds.RasterCount, subds_count))
         return 'fail'
-    ds is None
+    ds = None
 
     # get file header with ncdump (if available)
     try:


### PR DESCRIPTION
## What does this PR do?

Initialises `ds` to `None` using the `=` operator instead of `is`. Thanks to Even for clarifying what was meant here.