### PR TITLE
* ogr_layer_algebra.py: Defensively initialise iLayer

### DIFF
--- a/gdal/swig/python/samples/ogr_layer_algebra.py
+++ b/gdal/swig/python/samples/ogr_layer_algebra.py
@@ -412,6 +412,7 @@ def main(argv=None):
 
         if overwrite:
             cnt = output_ds.GetLayerCount()
+            iLayer = None  # initialise in case there are no loop iterations
             for iLayer in range(cnt):
                 poLayer = output_ds.GetLayer(iLayer)
                 if poLayer is not None \


### PR DESCRIPTION
## What does this PR do?

Silences a Pylint warning about a possibly undefined loop index variable. Defensively initialise `iLayer` in case there are  no loop iterations (ie. `cnt` is zero).