### PR TITLE
* gdal/swig/python/scripts/gdal2tiles.py: Use explicit numpy_available

### DIFF
--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -55,9 +55,10 @@ try:
     from PIL import Image
     import numpy
     import osgeo.gdal_array as gdalarray
+    numpy_available = True
 except ImportError:
     # 'antialias' resampling is not available
-    numpy = None
+    numpy_available = False
 
 __version__ = "$Id$"
 
@@ -613,7 +614,7 @@ def scale_query_to_tile(dsquery, dstile, tiledriver, options, tilefilename=''):
                 exit_with_error("RegenerateOverview() failed on %s, error %d" % (
                     tilefilename, res))
 
-    elif options.resampling == 'antialias':
+    elif options.resampling == 'antialias' and numpy_available:
 
         # Scaling by PIL (Python Imaging Library) - improved Lanczos
         array = numpy.zeros((querysize, querysize, tilebands), numpy.uint8)
@@ -1258,13 +1259,9 @@ def options_post_processing(options, input_file, output_folder):
             exit_with_error("'average' resampling algorithm is not available.",
                             "Please use -r 'near' argument or upgrade to newer version of GDAL.")
 
-    elif options.resampling == 'antialias':
-        try:
-            if numpy is not None:
-                pass
-        except Exception:
-            exit_with_error("'antialias' resampling algorithm is not available.",
-                            "Install PIL (Python Imaging Library) and numpy.")
+    elif options.resampling == 'antialias' and not numpy_available:
+        exit_with_error("'antialias' resampling algorithm is not available.",
+                        "Install PIL (Python Imaging Library) and numpy.")
 
     try:
         os.path.basename(input_file).encode('ascii')


### PR DESCRIPTION
## What does this PR do?

Use explicit `numpy_available` variable and don't overload the use of the `numpy` name. This clean-up silences the following false positive warnings from Pylint (but we should still make the code clearer).

```
gdal/swig/python/scripts/gdal2tiles.py:619: [E1101(no-member), scale_query_to_tile] Instance of 'bool' has no 'zeros' member
gdal/swig/python/scripts/gdal2tiles.py:619: [E1101(no-member), scale_query_to_tile] Instance of 'bool' has no 'uint8' member
```