### PR TITLE
Python code: Use anonymous var for loop index

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -323,7 +323,7 @@ def basic_test_11():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    ar_ds = [gdal.OpenEx('data/byte.tif', gdal.OF_SHARED) for i in range(1024)]
+    ar_ds = [gdal.OpenEx('data/byte.tif', gdal.OF_SHARED) for _ in range(1024)]
     if ar_ds[1023] is None:
         gdaltest.post_reason('fail')
         return 'fail'
@@ -658,7 +658,7 @@ def basic_test_17():
 
     from osgeo import ogr
 
-    for i in range(2):
+    for _ in range(2):
         ogr.UseExceptions()
         gdal.UseExceptions()
         try:
@@ -674,7 +674,7 @@ def basic_test_17():
             gdaltest.post_reason('fail')
             return 'fail'
 
-    for i in range(2):
+    for _ in range(2):
         ogr.UseExceptions()
         gdal.UseExceptions()
         try:

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -619,7 +619,7 @@ def misc_12():
             if gdal_translate_path is not None:
                 # Test to detect memleaks
                 ds = gdal.GetDriverByName('VRT').CreateCopy('tmp/misc_12.vrt', src_ds)
-                (out, err) = gdaltest.runexternal_out_and_err(gdal_translate_path + ' -of ' + drv.ShortName + ' tmp/misc_12.vrt /nonexistingpath/' + get_filename(drv, ''), check_memleak=False)
+                (out, _) = gdaltest.runexternal_out_and_err(gdal_translate_path + ' -of ' + drv.ShortName + ' tmp/misc_12.vrt /nonexistingpath/' + get_filename(drv, ''), check_memleak=False)
                 del ds
                 gdal.Unlink('tmp/misc_12.vrt')
 

--- a/autotest/gcore/overviewds.py
+++ b/autotest/gcore/overviewds.py
@@ -155,7 +155,7 @@ def overviewds_3():
     ds.SetGCPs(src_gcps, src_ds.GetProjectionRef())
 
     tr = gdal.Transformer(ds, None, ['METHOD=GCP_POLYNOMIAL'])
-    (ref_success, ref_pnt) = tr.TransformPoint(0, 20, 10)
+    (_, ref_pnt) = tr.TransformPoint(0, 20, 10)
 
     ds.BuildOverviews('NEAR', overviewlist=[2, 4])
     ds = None
@@ -170,7 +170,7 @@ def overviewds_3():
 
     # Really check that the transformer works
     tr = gdal.Transformer(ds, None, ['METHOD=GCP_POLYNOMIAL'])
-    (success, pnt) = tr.TransformPoint(0, 20 / 2.0, 10 / 2.0)
+    (_, pnt) = tr.TransformPoint(0, 20 / 2.0, 10 / 2.0)
 
     for i in range(3):
         if abs(ref_pnt[i] - pnt[i]) > 1e-5:
@@ -201,7 +201,7 @@ def overviewds_4():
     rpc_md = ds.GetMetadata('RPC')
 
     tr = gdal.Transformer(ds, None, ['METHOD=RPC'])
-    (ref_success, ref_pnt) = tr.TransformPoint(0, 20, 10)
+    (_, ref_pnt) = tr.TransformPoint(0, 20, 10)
 
     ds.BuildOverviews('NEAR', overviewlist=[2, 4])
     ds = None
@@ -229,7 +229,7 @@ def overviewds_4():
 
     # Really check that the transformer works
     tr = gdal.Transformer(ds, None, ['METHOD=RPC'])
-    (success, pnt) = tr.TransformPoint(0, 20 / 2.0, 10 / 2.0)
+    (_, pnt) = tr.TransformPoint(0, 20 / 2.0, 10 / 2.0)
 
     for i in range(3):
         if abs(ref_pnt[i] - pnt[i]) > 1e-5:
@@ -260,7 +260,7 @@ def overviewds_5():
     geoloc_md = ds.GetMetadata('GEOLOCATION')
 
     tr = gdal.Transformer(ds, None, ['METHOD=GEOLOC_ARRAY'])
-    (ref_success, ref_pnt) = tr.TransformPoint(0, 20, 10)
+    (_, ref_pnt) = tr.TransformPoint(0, 20, 10)
 
     ds.BuildOverviews('NEAR', overviewlist=[2, 4])
     ds = None
@@ -296,7 +296,7 @@ def overviewds_5():
     # Really check that the transformer works
     tr = gdal.Transformer(ds, None, ['METHOD=GEOLOC_ARRAY'])
     expected_xyz = (20.0 / 2, 10.0 / 2, 0)
-    (success, pnt) = tr.TransformPoint(1, ref_pnt[0], ref_pnt[1])
+    (_, pnt) = tr.TransformPoint(1, ref_pnt[0], ref_pnt[1])
 
     for i in range(3):
         if abs(pnt[i] - expected_xyz[i]) > 0.5:

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -611,7 +611,7 @@ def tiff_g4_split():
 
     ds = gdal.Open('data/slim_g4.tif')
 
-    (blockx, blocky) = ds.GetRasterBand(1).GetBlockSize()
+    (_, blocky) = ds.GetRasterBand(1).GetBlockSize()
 
     if blocky != 1:
         gdaltest.post_reason('Did not get scanline sized blocks.')
@@ -2481,7 +2481,7 @@ def tiff_read_strace_check():
         "ds.GetRasterBand(1).GetMetadata('IMAGE_STRUCTURE');"
         " \" ")
     try:
-        (out, err) = gdaltest.runexternal_out_and_err(cmd)
+        (_, err) = gdaltest.runexternal_out_and_err(cmd)
     except:
         # strace not available
         return 'skip'

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2964,7 +2964,7 @@ def tiff_write_78():
     # new_ds = gdal.Open('tmp/tiff_write_78.tif')
 
     if 'GetBlockSize' in dir(gdal.Band):
-        (blockx, blocky) = new_ds.GetRasterBand(1).GetBlockSize()
+        (_, blocky) = new_ds.GetRasterBand(1).GetBlockSize()
         if blocky != 1:
             print('')
             print('using regular band (libtiff <= 3.9.2 or <= 4.0.0beta5, or SplitBand disabled by config option)')

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2652,15 +2652,15 @@ def tiff_write_71():
     # Write StripByteCounts tag
     # 100,000 in little endian
     if version_info >= (3, 0, 0):
-        for i in range(100000):
+        for _ in range(100000):
             exec("f.write(b'\\xa0\\x86\\x01\\x00\\x00\\x00\\x00\\x00')")
     else:
-        for i in range(100000):
+        for _ in range(100000):
             f.write('\xa0\x86\x01\x00\x00\x00\x00\x00')
 
     # Write StripOffsets tag
     offset = 1600252
-    for i in range(100000):
+    for _ in range(100000):
         f.write(struct.pack('<Q', offset))
         offset = offset + 100000
 
@@ -4325,7 +4325,7 @@ def tiff_write_101():
     else:
         import random
         rand_array = array.array('B')
-        for i in range(10 * 1024 * 1024):
+        for _ in range(10 * 1024 * 1024):
             rand_array.append(random.randint(0, 255))
 
     f = open('tmp/tiff_write_101.bin', 'wb')
@@ -4757,7 +4757,7 @@ def tiff_write_117():
     ds.GetRasterBand(1).ReadRaster(0, 0, 256, 256)
 
     # The new bytecount will be greater than 2048
-    data = ''.join([('%c' % random.randint(0, 255)) for i in range(256 * 256)])
+    data = ''.join([('%c' % random.randint(0, 255)) for _ in range(256 * 256)])
     ds.GetRasterBand(1).WriteRaster(0, 0, 256, 256, data)
 
     # Make sure that data is written now

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -457,7 +457,7 @@ def transformer_9():
     ds_dem.SetGeoTransform([125.647968621436, 1.2111052640051412e-05, 0, 39.869926216038, 0, -8.6569068979969188e-06])
     import random
     random.seed(0)
-    data = ''.join([chr(40 + int(10 * random.random())) for i in range(100 * 100)])
+    data = ''.join([chr(40 + int(10 * random.random())) for _ in range(100 * 100)])
     ds_dem.GetRasterBand(1).WriteRaster(0, 0, 100, 100, data)
     ds_dem = None
 
@@ -520,7 +520,7 @@ def transformer_10():
     ds_dem.SetGeoTransform([125.647968621436, 1.2111052640051412e-05, 0, 39.869926216038, 0, -8.6569068979969188e-06])
     import random
     random.seed(0)
-    data = ''.join([chr(40 + int(10 * random.random())) for i in range(100 * 100)])
+    data = ''.join([chr(40 + int(10 * random.random())) for _ in range(100 * 100)])
     ds_dem.GetRasterBand(1).WriteRaster(0, 0, 100, 100, data)
     ds_dem = None
 

--- a/autotest/gcore/vsicrypt.py
+++ b/autotest/gcore/vsicrypt.py
@@ -434,13 +434,13 @@ def vsicrypt_4():
         import random
         random.seed(seed)
 
-        for i in range(20):
+        for _ in range(20):
             random_offset = random.randint(0, 1000)
             gdal.VSIFSeekL(test_f, random_offset, 0)
             gdal.VSIFSeekL(ref_f, random_offset, 0)
 
             random_size = random.randint(1, 80)
-            random_content = ''.join([chr(40 + int(10 * random.random())) for i in range(random_size)])
+            random_content = ''.join([chr(40 + int(10 * random.random())) for _ in range(random_size)])
             gdal.VSIFWriteL(random_content, 1, random_size, test_f)
             gdal.VSIFWriteL(random_content, 1, random_size, ref_f)
 

--- a/autotest/gdrivers/aaigrid.py
+++ b/autotest/gdrivers/aaigrid.py
@@ -325,7 +325,7 @@ def aaigrid_12():
     aai = open('tmp/aaigrid.tmp')
     if not aai:
         return 'fail'
-    for i in range(5):
+    for _ in range(5):
         aai.readline()
     ndv = aai.readline().strip().lower()
     aai.close()
@@ -354,7 +354,7 @@ def aaigrid_13():
     aai = open('tmp/aaigrid.tmp')
     if not aai:
         return 'fail'
-    for i in range(5):
+    for _ in range(5):
         aai.readline()
     ndv = aai.readline().strip().lower()
     aai.close()

--- a/autotest/gdrivers/arg.py
+++ b/autotest/gdrivers/arg.py
@@ -131,7 +131,7 @@ def arg_unsupported():
 
     # int8 is unsupported
     for d in gdaltest.argTests:
-        for (name, fmt, nodata) in d['formats']:
+        for (name, _, _) in d['formats']:
             if name == 'int64' or name == 'uint64':
                 with gdaltest.error_handler('CPLQuietErrorHandler'):
                     ds = gdal.Open('data/arg-' + name + '.arg')
@@ -150,7 +150,7 @@ def arg_getrastercount():
         return 'skip'
 
     for d in gdaltest.argTests:
-        for (name, fmt, nodata) in d['formats']:
+        for (name, _, _) in d['formats']:
             with gdaltest.error_handler('CPLQuietErrorHandler'):
                 ds = gdal.Open('data/arg-' + name + '.arg')
             if ds is None:
@@ -167,7 +167,7 @@ def arg_getgeotransform():
         return 'skip'
 
     for d in gdaltest.argTests:
-        for (name, fmt, nodata) in d['formats']:
+        for (name, _, _) in d['formats']:
             with gdaltest.error_handler('CPLQuietErrorHandler'):
                 ds = gdal.Open('data/arg-' + name + '.arg')
             if ds is None:
@@ -294,7 +294,7 @@ def arg_byteorder():
         return 'fail'
 
     for d in gdaltest.argTests:
-        for (name, fmt, nodata) in d['formats']:
+        for (name, _, _) in d['formats']:
 
             basename = 'data/arg-' + name
             with gdaltest.error_handler('CPLQuietErrorHandler'):
@@ -337,7 +337,7 @@ def arg_destroy():
         return 'skip'
 
     for d in gdaltest.argTests:
-        for (name, fmt, nodata) in d['formats']:
+        for (name, _, _) in d['formats']:
             os.remove('data/arg-' + name + '.arg')
             os.remove('data/arg-' + name + '.json')
 

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -1116,8 +1116,8 @@ def ecw_29():
                 data2 = ds2.ReadRaster(i * int(tile / 2), j * int(tile / 2), tile, tile)
                 tmp_ds1.WriteRaster(0, 0, tile, tile, data1)
                 tmp_ds2.WriteRaster(0, 0, tile, tile, data2)
-                (ignored, ignored, mean1, stddev1) = tmp_ds1.GetRasterBand(1).GetStatistics(1, 1)
-                (ignored, ignored, mean2, stddev2) = tmp_ds2.GetRasterBand(1).GetStatistics(1, 1)
+                (_, _, mean1, stddev1) = tmp_ds1.GetRasterBand(1).GetStatistics(1, 1)
+                (_, _, mean2, stddev2) = tmp_ds2.GetRasterBand(1).GetStatistics(1, 1)
                 nvals = nvals + 1
                 sum_abs_diff_mean = sum_abs_diff_mean + abs(mean1 - mean2)
                 sum_abs_diff_stddev = sum_abs_diff_stddev + abs(stddev1 - stddev2)

--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -532,7 +532,7 @@ def mem_10():
 
     # Single band case
     ds = gdal.GetDriverByName('MEM').CreateCopy('', gdal.Open('data/byte.tif'))
-    for i in range(2):
+    for _ in range(2):
         ret = ds.BuildOverviews('NEAR', [2])
         if ret != 0:
             gdaltest.post_reason('fail')

--- a/autotest/gdrivers/netcdf_cf.py
+++ b/autotest/gdrivers/netcdf_cf.py
@@ -374,7 +374,7 @@ def netcdf_cfproj_testcopy(projTuples, origTiff, interFormats, inPath, outPath,
 
     # Test if ncdump is available
     try:
-        (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h')
+        (_, err) = gdaltest.runexternal_out_and_err('ncdump -h')
     except:
         # nothing is supported as ncdump not found
         print('NOTICE: netcdf version not found')

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -997,13 +997,13 @@ def nitf_36():
         gdaltest.post_reason('Did not expect to have minimum value at that point.')
         return 'fail'
 
-    (minval, maxval, mean, stddev) = ds.GetRasterBand(1).GetStatistics(False, False)
+    (_, _, mean, stddev) = ds.GetRasterBand(1).GetStatistics(False, False)
     if stddev >= 0:
         gdaltest.post_reason('Did not expect to have statistics at that point.')
         return 'fail'
 
     (exp_mean, exp_stddev) = (65.4208, 47.254550335)
-    (minval, maxval, mean, stddev) = ds.GetRasterBand(1).GetStatistics(False, True)
+    (_, _, mean, stddev) = ds.GetRasterBand(1).GetStatistics(False, True)
 
     if abs(exp_mean - mean) > 0.1 or abs(exp_stddev - stddev) > 0.1:
         print(mean, stddev)
@@ -1024,7 +1024,7 @@ def nitf_36():
         gdaltest.post_reason('Should have minimum value at that point.')
         return 'fail'
 
-    (minval, maxval, mean, stddev) = ds.GetRasterBand(1).GetStatistics(False, False)
+    (_, _, mean, stddev) = ds.GetRasterBand(1).GetStatistics(False, False)
     if abs(exp_mean - mean) > 0.1 or abs(exp_stddev - stddev) > 0.1:
         print(mean, stddev)
         gdaltest.post_reason('Should have statistics at that point.')
@@ -1369,7 +1369,7 @@ def nitf_44():
     ds = gdal.Open('tmp/nitf44.ntf')
 
     if 'GetBlockSize' in dir(gdal.Band):
-        (blockx, blocky) = ds.GetRasterBand(1).GetBlockSize()
+        (blockx, _) = ds.GetRasterBand(1).GetBlockSize()
         if blockx != 10000:
             return 'fail'
 
@@ -2159,7 +2159,7 @@ def nitf_65():
     ds = None
 
     ds = gdal.Open('/vsimem/nitf_65.ntf')
-    (block_xsize, block_ysize) = ds.GetRasterBand(1).GetBlockSize()
+    (block_xsize, _) = ds.GetRasterBand(1).GetBlockSize()
     ds.GetRasterBand(1).Checksum()
     ds = None
 
@@ -2181,7 +2181,7 @@ def nitf_66():
     ds = None
 
     ds = gdal.Open('/vsimem/nitf_66.ntf')
-    (block_xsize, block_ysize) = ds.GetRasterBand(1).GetBlockSize()
+    (_, block_ysize) = ds.GetRasterBand(1).GetBlockSize()
     ds.GetRasterBand(1).Checksum()
     ds = None
 

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -101,7 +101,7 @@ def pdf_checksum_available():
         gdaltest.pdf_is_checksum_available = True
         return gdaltest.pdf_is_checksum_available
 
-    (out, err) = gdaltest.runexternal_out_and_err("pdftoppm -v")
+    (_, err) = gdaltest.runexternal_out_and_err("pdftoppm -v")
     if err.find('pdftoppm version') == 0:
         gdaltest.pdf_is_checksum_available = True
         return gdaltest.pdf_is_checksum_available

--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -258,7 +258,7 @@ def rmf_build_ov(source, testid, options, ov_sizes, crs, reopen=False, pass_coun
         gdaltest.post_reason('Failed to create test dataset copy.')
         return 'fail'
 
-    for pass_n in range(pass_count):
+    for _ in range(pass_count):
         if reopen:
             src_ds = None
             src_ds = gdal.Open(test_ds_name, gdal.GA_Update)

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -930,7 +930,7 @@ def vrtderived_15_worker(args_dict):
 </VRTDataset>
 """
     ds = gdal.Open(content)
-    for j in range(5):
+    for _ in range(5):
         cs = ds.GetRasterBand(1).Checksum()
         if cs != 2304:
             print(cs)

--- a/autotest/gdrivers/vrtmask.py
+++ b/autotest/gdrivers/vrtmask.py
@@ -356,7 +356,7 @@ def vrtmask_9():
     src_ds = gdal.GetDriverByName('GTiff').Create('tmp/vrtmask_9_src.tif', 10, 10, 4)
     del src_ds
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/vrtmask_9_src.tif tmp/vrtmask_9_dst.tif -b 1 -b 2 -b 3')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/vrtmask_9_src.tif tmp/vrtmask_9_dst.tif -b 1 -b 2 -b 3')
 
     ds = gdal.Open('tmp/vrtmask_9_dst.tif')
     flags = ds.GetRasterBand(1).GetMaskFlags()

--- a/autotest/gdrivers/vrtrawlink.py
+++ b/autotest/gdrivers/vrtrawlink.py
@@ -317,7 +317,7 @@ def vrtrawlink_7():
 
 def vrtrawlink_8():
 
-    for i in range(2):
+    for _ in range(2):
         with gdaltest.error_handler():
             ds = gdal.Open("""<VRTDataset rasterXSize="200000" rasterYSize="1">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTRawRasterBand">

--- a/autotest/gdrivers/wcs.py
+++ b/autotest/gdrivers/wcs.py
@@ -372,9 +372,9 @@ class WCSHTTPHandler(BaseHTTPRequestHandler):
             test = query2['test'][0]
         key = server + '-' + version
         if key in urls and test in urls[key]:
-            tmp, got = self.path.split('SERVICE=WCS')
+            _, got = self.path.split('SERVICE=WCS')
             got = re.sub('\&test=.*', '', got)
-            tmp, have = urls[key][test].split('SERVICE=WCS')
+            _, have = urls[key][test].split('SERVICE=WCS')
             have += '&server=' + server
             if got == have:
                 ok = 'ok'

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -456,7 +456,7 @@ def ogr_basic_11():
         return 'skip'
 
     used_exceptions_before = ogr.GetUseExceptions()
-    for i in range(2):
+    for _ in range(2):
         ogr.UseExceptions()
         geom = ogr.CreateGeometryFromWkt('POLYGON ((-65 0, -30 -30, -30 0, -65 -30, -65 0))')
         with gdaltest.error_handler():

--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -308,7 +308,7 @@ def ogr_dxf_8():
 def ogr_dxf_9():
 
     # Skip two dimensions each with a line, two arrowheads and text.
-    for x in range(8):
+    for _ in range(8):
         feat = gdaltest.dxf_layer.GetNextFeature()
 
     # block (merged geometries)
@@ -3808,7 +3808,7 @@ def ogr_dxf_52():
         f.DumpReadable()
         return 'fail'
 
-    for x in range(2):
+    for _ in range(2):
         f = lyr.GetNextFeature()
 
     f = lyr.GetNextFeature()
@@ -3824,7 +3824,7 @@ def ogr_dxf_52():
         f.DumpReadable()
         return 'fail'
 
-    for x in range(8):
+    for _ in range(8):
         f = lyr.GetNextFeature()
 
     f = lyr.GetNextFeature()

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -904,7 +904,7 @@ def ogr_fgdb_14():
     if ogrtest.fgdb_drv is None:
         return 'skip'
 
-    for i in range(3):
+    for _ in range(3):
         ds1 = ogr.Open("tmp/test.gdb")
         if ds1 is None:
             gdaltest.post_reason('fail')

--- a/autotest/ogr/ogr_fgdb_stress_test.py
+++ b/autotest/ogr/ogr_fgdb_stress_test.py
@@ -99,8 +99,7 @@ def ogr_fgdb_stress_test_1():
     random.seed(0)
     in_transaction = False
     nfeatures_created = 0
-    for i in range(100000):
-        # print(i)
+    for _ in range(100000):
         function = random.randrange(0, 500)
         if function == 0:
             if not in_transaction:

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -537,7 +537,7 @@ def ogr_gml_13():
     if not gdaltest.have_gml_reader:
         return 'skip'
 
-    for i in range(2):
+    for _ in range(2):
         ds = ogr.Open('data/testlistfields.gml')
         lyr = ds.GetLayer(0)
         feat = lyr.GetNextFeature()
@@ -1196,7 +1196,7 @@ def ogr_gml_29():
         if lyr.GetGeomType() != expected_results[j][0]:
             gdaltest.post_reason('layer %d, did not get expected layer geometry type' % j)
             return 'fail'
-        for i in range(2):
+        for _ in range(2):
             feat = lyr.GetNextFeature()
             geom = feat.GetGeometryRef()
             got_wkt = geom.ExportToWkt()
@@ -1219,7 +1219,7 @@ def ogr_gml_30():
         return 'skip'
 
     field1 = " "
-    for i in range(11):
+    for _ in range(11):
         field1 = field1 + field1
 
     geom = "0 1 "
@@ -2191,7 +2191,7 @@ def ogr_gml_52():
     except OSError:
         pass
 
-    for i in range(2):
+    for _ in range(2):
 
         ds = ogr.Open('data/fake_mtkgml.xml')
 
@@ -2833,7 +2833,7 @@ def ogr_gml_60():
     except OSError:
         pass
 
-    for i in range(2):
+    for _ in range(2):
         ds = ogr.Open('data/wfs_200_multiplelayers.gml')
         lyr = ds.GetLayerByName('road')
         if lyr.GetFeatureCount() != 1:
@@ -3045,7 +3045,7 @@ def ogr_gml_64():
         return 'skip'
 
     for parser in ['XERCES', 'EXPAT']:
-        for i in range(2):
+        for _ in range(2):
             gdal.SetConfigOption('GML_PARSER', parser)
             ds = ogr.Open('data/rnf_eg.gml')
             gdal.SetConfigOption('GML_PARSER', None)

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -1275,7 +1275,7 @@ def ogr_mitab_27():
     lyr = ds.GetLayer(0)
 
     f = lyr.GetFeature(1)
-    for i in range(100):
+    for _ in range(100):
         f.SetGeometryDirectly(ogr.CreateGeometryFromWkt('POINT (2 3)'))
         if lyr.SetFeature(f) != 0:
             gdaltest.post_reason('fail')
@@ -1315,7 +1315,7 @@ def ogr_mitab_27():
 
 def generate_permutation(n):
     tab = [i for i in range(n)]
-    for i in range(10 * n):
+    for _ in range(10 * n):
         ind = random.randint(0, n - 1)
         tmp = tab[0]
         tab[0] = tab[ind]
@@ -1547,7 +1547,7 @@ def ogr_mitab_30(update=0):
                 gdaltest.post_reason('fail')
                 return 'fail'
             lyr2.ResetReading()
-            for k in range(j + 1):
+            for _ in range(j + 1):
                 feat2 = lyr2.GetNextFeature()
             if feat2.GetField('ID') != j + 1 or feat2.GetGeometryRef().ExportToWkt() != 'POINT (%d %d)' % (j, j):
                 print(j)
@@ -1690,7 +1690,7 @@ def ogr_mitab_34():
     geom = ogr.Geometry(ogr.wkbLineString)
     for i in range(1000):
         geom.AddPoint_2D(i, i)
-    for j in range(2):
+    for _ in range(2):
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetGeometry(geom)
         lyr.CreateFeature(f)
@@ -2164,7 +2164,7 @@ def ogr_mitab_40():
             ds = ogr.Open('/vsimem/ogr_mitab_40.mif')
             if ds is not None:
                 lyr = ds.GetLayer(0)
-                for f in lyr:
+                for _ in lyr:
                     pass
 
     gdal.Unlink('/vsimem/ogr_mitab_40.mif')

--- a/autotest/ogr/ogr_rfc41.py
+++ b/autotest/ogr/ogr_rfc41.py
@@ -155,7 +155,7 @@ def ogr_rfc41_2():
         return 'fail'
 
     # Check setting to wkbNone and implicitly destroying the field.
-    for i in range(2):
+    for _ in range(2):
         feature_defn.SetGeomType(ogr.wkbNone)
         if feature_defn.GetGeomFieldCount() != 0:
             gdaltest.post_reason('fail')

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -4330,12 +4330,12 @@ def ogr_shape_91():
 
     ds = ogr.Open('data/arcm_without_m.shp')
     lyr = ds.GetLayer(0)
-    for f in lyr:
+    for _ in lyr:
         pass
 
     ds = ogr.Open('data/polygonm_without_m.shp')
     lyr = ds.GetLayer(0)
-    for f in lyr:
+    for _ in lyr:
         pass
 
     return 'success'

--- a/autotest/ogr/ogr_shape_qix.py
+++ b/autotest/ogr/ogr_shape_qix.py
@@ -243,7 +243,7 @@ def ogr_shape_qix_4():
 
     # The 1000,200,10 figures are such that there are
     # a bit of overlapping between the geometries
-    for x in range(1000):
+    for _ in range(1000):
         feat = ogr.Feature(lyr.GetLayerDefn())
         x1 = random.randint(0, 200)
         y1 = random.randint(0, 200)
@@ -254,7 +254,7 @@ def ogr_shape_qix_4():
         feat = None
 
     # And add statistically non overlapping features
-    for x in range(1000):
+    for _ in range(1000):
         feat = ogr.Feature(lyr.GetLayerDefn())
         x1 = random.randint(0, 10000)
         y1 = random.randint(0, 10000)

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -407,7 +407,7 @@ def ogr_sql_sqlite_2():
         print(layer_srs)
         return 'fail'
 
-    for i in range(2):
+    for _ in range(2):
         feat = sql_lyr.GetNextFeature()
         if feat.GetGeometryRef().ExportToWkt() != 'POINT (0 1)':
             gdaltest.post_reason('failure')
@@ -942,7 +942,7 @@ def ogr_sql_sqlite_14_and_15(sql):
     got_two = False
 
     sql_lyr = ds.ExecuteSQL(sql, dialect='SQLite')
-    for i in range(2):
+    for _ in range(2):
         feat = sql_lyr.GetNextFeature()
         i1 = feat.GetField('intfield')
         i2 = feat.GetField('intfield2')

--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -1080,7 +1080,7 @@ def ogr_sql_34():
 def ogr_sql_35():
 
     cols = "area"
-    for i in range(10):
+    for _ in range(10):
         cols = cols + "," + cols
     sql_lyr = gdaltest.ds.ExecuteSQL("select %s from poly" % cols)
 

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -702,7 +702,7 @@ def ogr_sqlite_14():
 
     # Check the 2 records
     gdaltest.sl_lyr.ResetReading()
-    for i in range(2):
+    for _ in range(2):
         feat_read = gdaltest.sl_lyr.GetNextFeature()
         if feat_read.GetField('INTEGER') != 1 or \
            feat_read.GetField('FLOAT') != 1.2 or \
@@ -867,7 +867,7 @@ def ogr_sqlite_16():
         return 'fail'
 
     # Test invalid geometries
-    for i in range(3):
+    for _ in range(3):
         feat = gdaltest.sl_lyr.GetNextFeature()
         geom = feat.GetGeometryRef()
         if geom is not None:
@@ -2635,7 +2635,7 @@ def ogr_sqlite_34():
         return 'fail'
 
     # Test cache
-    for j in range(2):
+    for _ in range(2):
         for i in range(17):
             regexp = chr(ord('a') + i)
             sql_lyr = gdaltest.sl_ds.ExecuteSQL("SELECT '%s' REGEXP '%s'" % (regexp, regexp))

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -256,7 +256,7 @@ def summarize():
     sys.path.append('../gcore')
     import testnonboundtoswig
     # Do it twice to ensure that cleanup routines properly do their jobs
-    for i in range(2):
+    for _ in range(2):
         testnonboundtoswig.OSRCleanup()
         testnonboundtoswig.GDALDestroyDriverManager()
         testnonboundtoswig.OGRCleanupAll()

--- a/autotest/utilities/test_gdal_contour.py
+++ b/autotest/utilities/test_gdal_contour.py
@@ -95,7 +95,7 @@ def test_gdal_contour_1():
 
     ds = None
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_contour_path() + ' -a elev -i 10 tmp/gdal_contour.tif tmp/contour.shp')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_contour_path() + ' -a elev -i 10 tmp/gdal_contour.tif tmp/contour.shp')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)

--- a/autotest/utilities/test_gdal_grid.py
+++ b/autotest/utilities/test_gdal_grid.py
@@ -103,7 +103,7 @@ def test_gdal_grid_1():
     shape_ds.Destroy()
 
     # Create a GDAL dataset from the previous generated OGR grid
-    (out, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -a nearest:radius1=0.0:radius2=0.0:angle=0.0 -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
+    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -a nearest:radius1=0.0:radius2=0.0:angle=0.0 -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -275,7 +275,7 @@ def test_gdal_grid_3():
 
     # Create a GDAL dataset from the values of "grid.csv".
     print('Step 1: Disabling AVX/SSE optimized versions...')
-    (out, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' --debug on --config GDAL_USE_AVX NO --config GDAL_USE_SSE NO -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
+    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' --debug on --config GDAL_USE_AVX NO --config GDAL_USE_SSE NO -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
     pos = err.find(' threads')
     if pos >= 0:
         pos_blank = err[0:pos - 1].rfind(' ')
@@ -304,7 +304,7 @@ def test_gdal_grid_3():
 
     # Create a GDAL dataset from the values of "grid.csv".
     print('Step 2: Trying SSE optimized version...')
-    (out, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' --debug on --config GDAL_USE_AVX NO -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
+    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' --debug on --config GDAL_USE_AVX NO -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
     if err.find('SSE') >= 0:
         print('...SSE optimized version used')
     else:
@@ -332,7 +332,7 @@ def test_gdal_grid_3():
 
     # Create a GDAL dataset from the values of "grid.csv".
     print('Step 3: Trying AVX optimized version...')
-    (out, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' --debug on -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
+    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' --debug on -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
     if err.find('AVX') >= 0:
         print('...AVX optimized version used')
     else:
@@ -825,7 +825,7 @@ def test_gdal_grid_11():
     outfiles.append('tmp/n43_linear.tif')
 
     # Create a GDAL dataset from the previous generated OGR grid
-    (out, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -l n43 -a linear -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
+    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -l n43 -a linear -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -860,7 +860,7 @@ def test_gdal_grid_12():
         pass
 
     # Create a GDAL dataset from the values of "grid.csv".
-    (out, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=2.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
+    (_, _) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=2.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
 
     # We should get the same values as in "ref_data/gdal_invdistnn.tif"
     ds = gdal.Open(outfiles[-1])

--- a/autotest/utilities/test_gdal_rasterize.py
+++ b/autotest/utilities/test_gdal_rasterize.py
@@ -104,7 +104,7 @@ def test_gdal_rasterize_1():
     rast_ogr_ds.Destroy()
 
     # Run the algorithm.
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_rasterize_path() + ' -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l rast1 tmp/rast1.tab tmp/rast1.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_rasterize_path() + ' -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l rast1 tmp/rast1.tab tmp/rast1.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -46,7 +46,7 @@ def test_gdal_translate_1():
     if test_cli_utilities.get_gdal_translate_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test1.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test1.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -502,7 +502,7 @@ def test_gdal_translate_18():
 
     gdaltest.runexternal(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/8bit_pal.bmp -of VRT tmp/test18_1.vrt')
     gdaltest.runexternal(test_cli_utilities.get_gdal_translate_path() + ' tmp/test18_1.vrt -expand rgb -of VRT tmp/test18_2.vrt')
-    (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/test18_2.vrt tmp/test18_2.tif')
+    (_, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/test18_2.vrt tmp/test18_2.tif')
 
     # Check that all datasets are closed
     if ret_stderr.find('Open GDAL Datasets') != -1:
@@ -815,7 +815,7 @@ def test_gdal_translate_29():
     if test_cli_utilities.get_gdal_translate_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test_gdal_translate_29.tif -outsize 50% 50% -r cubic')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test_gdal_translate_29.tif -outsize 50% 50% -r cubic')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -833,12 +833,12 @@ def test_gdal_translate_29():
 
     ds = None
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test_gdal_translate_29.vrt -outsize 50% 50% -r cubic -of VRT')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test_gdal_translate_29.vrt -outsize 50% 50% -r cubic -of VRT')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
         return 'fail'
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/test_gdal_translate_29.vrt tmp/test_gdal_translate_29.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/test_gdal_translate_29.vrt tmp/test_gdal_translate_29.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -957,7 +957,7 @@ def test_gdal_translate_33():
 
     os.unlink('tmp/test_gdal_translate_33.tif')
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' -outsize 0 0 ../gdrivers/data/small_world.tif tmp/test_gdal_translate_33.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' -outsize 0 0 ../gdrivers/data/small_world.tif tmp/test_gdal_translate_33.tif')
     if err.find('-outsize 0 0 invalid') < 0:
         gdaltest.post_reason('fail')
         return 'fail'
@@ -992,25 +992,25 @@ def test_gdal_translate_35():
     if test_cli_utilities.get_gdal_translate_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path())
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path())
     if err.find('No source dataset specified') < 0:
         gdaltest.post_reason('fail')
         print(err)
         return 'fail'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif')
     if err.find('No target dataset specified') < 0:
         gdaltest.post_reason('fail')
         print(err)
         return 'fail'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' /non_existing_path/non_existing.tif /vsimem/out.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' /non_existing_path/non_existing.tif /vsimem/out.tif')
     if err.find('does not exist in the file system') < 0 and err.find('No such file or directory') < 0:
         gdaltest.post_reason('fail')
         print(err)
         return 'fail'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif /non_existing_path/non_existing.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif /non_existing_path/non_existing.tif')
     if err.find('Attempt to create new tiff file') < 0:
         gdaltest.post_reason('fail')
         print(err)

--- a/autotest/utilities/test_gdaladdo.py
+++ b/autotest/utilities/test_gdaladdo.py
@@ -52,7 +52,7 @@ def test_gdaladdo_1():
     shutil.copy('../gcore/data/mfloat32.vrt', 'tmp/mfloat32.vrt')
     shutil.copy('../gcore/data/float32.tif', 'tmp/float32.tif')
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaladdo_path() + ' tmp/mfloat32.vrt 2 4')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaladdo_path() + ' tmp/mfloat32.vrt 2 4')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)

--- a/autotest/utilities/test_gdalbuildvrt.py
+++ b/autotest/utilities/test_gdalbuildvrt.py
@@ -107,7 +107,7 @@ def test_gdalbuildvrt_1():
     ds.GetRasterBand(1).Fill(255)
     ds = None
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalbuildvrt_path() + ' tmp/mosaic.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalbuildvrt_path() + ' tmp/mosaic.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -442,7 +442,7 @@ def test_gdalbuildvrt_12():
     if test_cli_utilities.get_gdalbuildvrt_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalbuildvrt_path() + ' -tap tmp/gdalbuildvrt12.vrt ../gcore/data/byte.tif',
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalbuildvrt_path() + ' -tap tmp/gdalbuildvrt12.vrt ../gcore/data/byte.tif',
                                                   check_memleak=False)
     if err.find('-tap option cannot be used without using -tr') == -1:
         gdaltest.post_reason('expected error')

--- a/autotest/utilities/test_gdaldem.py
+++ b/autotest/utilities/test_gdaldem.py
@@ -47,7 +47,7 @@ def test_gdaldem_hillshade():
     if test_cli_utilities.get_gdaldem_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -93,7 +93,7 @@ def test_gdaldem_hillshade_compressed_tiled_output():
     if test_cli_utilities.get_gdaldem_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade_compressed_tiled.tif -co TILED=YES -co COMPRESS=DEFLATE --config GDAL_CACHEMAX 0')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade_compressed_tiled.tif -co TILED=YES -co COMPRESS=DEFLATE --config GDAL_CACHEMAX 0')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)

--- a/autotest/utilities/test_gdalinfo.py
+++ b/autotest/utilities/test_gdalinfo.py
@@ -309,7 +309,7 @@ def test_gdalinfo_14():
     if test_cli_utilities.get_gdalinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --config', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --config', check_memleak=False)
     if err.find('--config option given without a key and value argument') < 0:
         print(err)
         return 'fail'
@@ -324,7 +324,7 @@ def test_gdalinfo_15():
     if test_cli_utilities.get_gdalinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --mempreload', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --mempreload', check_memleak=False)
     if err.find('--mempreload option given without directory path') < 0:
         print(err)
         return 'fail'
@@ -339,7 +339,7 @@ def test_gdalinfo_16():
     if test_cli_utilities.get_gdalinfo_path() is None:
         return 'skip'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --debug on --mempreload ../gcore/data /vsimem/byte.tif', check_memleak=False)
+    (ret, _) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --debug on --mempreload ../gcore/data /vsimem/byte.tif', check_memleak=False)
     if ret.find('Driver: GTiff/GeoTIFF') != 0:
         print(ret)
         return 'fail'
@@ -354,7 +354,7 @@ def test_gdalinfo_17():
     if test_cli_utilities.get_gdalinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --debug', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --debug', check_memleak=False)
     if err.find('--debug option given without debug level') < 0:
         print(err)
         return 'fail'
@@ -369,13 +369,13 @@ def test_gdalinfo_18():
     if test_cli_utilities.get_gdalinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --optfile', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --optfile', check_memleak=False)
     if err.find('--optfile option given without filename') < 0:
         gdaltest.post_reason('fail')
         print(err)
         return 'fail'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --optfile /foo/bar', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --optfile /foo/bar', check_memleak=False)
     if err.find('Unable to open optfile') < 0:
         gdaltest.post_reason('fail')
         print(err)
@@ -426,13 +426,13 @@ def test_gdalinfo_21():
     if test_cli_utilities.get_gdalinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --format', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --format', check_memleak=False)
     if err.find('--format option given without a format code') < 0:
         gdaltest.post_reason('fail')
         print(err)
         return 'fail'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --format foo_bar', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalinfo_path() + ' --format foo_bar', check_memleak=False)
     if err.find('--format option given with format') < 0:
         gdaltest.post_reason('fail')
         print(err)

--- a/autotest/utilities/test_gdalsrsinfo.py
+++ b/autotest/utilities/test_gdalsrsinfo.py
@@ -224,7 +224,7 @@ def test_gdalsrsinfo_9():
     if test_cli_utilities.get_gdalsrsinfo_path() is None:
         return 'skip'
 
-    ret, err = gdaltest.runexternal_out_and_err(
+    _, err = gdaltest.runexternal_out_and_err(
         test_cli_utilities.get_gdalsrsinfo_path() + ' nonexistent_file')
 
     if err.strip() != "ERROR 1: ERROR - failed to load SRS definition from nonexistent_file":
@@ -371,7 +371,7 @@ def test_gdalsrsinfo_16():
         ' GTIFF_RAW:../gcore/data/byte.tif'
 
     try:
-        (ret, err) = gdaltest.runexternal_out_and_err(cmd)
+        (_, err) = gdaltest.runexternal_out_and_err(cmd)
     except:
         gdaltest.post_reason('gdalsrsinfo execution failed')
         return 'fail'

--- a/autotest/utilities/test_gdaltindex.py
+++ b/autotest/utilities/test_gdaltindex.py
@@ -88,7 +88,7 @@ def test_gdaltindex_1():
     ds.SetGeoTransform([48, 0.1, 0, 3, 0, -0.1])
     ds = None
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' tmp/tileindex.shp tmp/gdaltindex1.tif tmp/gdaltindex2.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' tmp/tileindex.shp tmp/gdaltindex1.tif tmp/gdaltindex2.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -135,7 +135,7 @@ def test_gdaltindex_2():
     if test_cli_utilities.get_gdaltindex_path() is None:
         return 'skip'
 
-    (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' tmp/tileindex.shp tmp/gdaltindex1.tif tmp/gdaltindex2.tif tmp/gdaltindex3.tif tmp/gdaltindex4.tif')
+    (_, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' tmp/tileindex.shp tmp/gdaltindex1.tif tmp/gdaltindex2.tif tmp/gdaltindex3.tif tmp/gdaltindex4.tif')
 
     if ret_stderr.find('File tmp/gdaltindex1.tif is already in tileindex. Skipping it.') == -1 or \
        ret_stderr.find('File tmp/gdaltindex2.tif is already in tileindex. Skipping it.') == -1 or \
@@ -169,7 +169,7 @@ def test_gdaltindex_3():
     ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
     ds = None
 
-    (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -skip_different_projection tmp/tileindex.shp tmp/gdaltindex5.tif')
+    (_, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -skip_different_projection tmp/tileindex.shp tmp/gdaltindex5.tif')
 
     if ret_stderr.find('Warning : tmp/gdaltindex5.tif is not using the same projection system as other files in the tileindex.') == -1 or \
        ret_stderr.find('Use -t_srs option to set target projection system (not supported by MapServer).') == -1:
@@ -201,7 +201,7 @@ def test_gdaltindex_4():
     ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
     ds = None
 
-    (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -t_srs EPSG:4326 tmp/tileindex.shp tmp/gdaltindex5.tif')
+    _ = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -t_srs EPSG:4326 tmp/tileindex.shp tmp/gdaltindex5.tif')
 
     ds = ogr.Open('tmp/tileindex.shp')
     if ds.GetLayer(0).GetFeatureCount() != 5:
@@ -232,7 +232,7 @@ def test_gdaltindex_5():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
         ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/test_gdaltindex_5.shp')
         gdal.PopErrorHandler()
-        (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -src_srs_name src_srs %s -t_srs EPSG:4326 tmp/test_gdaltindex_5.shp tmp/gdaltindex1.tif tmp/gdaltindex6.tif' % src_srs_format)
+        _ = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -src_srs_name src_srs %s -t_srs EPSG:4326 tmp/test_gdaltindex_5.shp tmp/gdaltindex1.tif tmp/gdaltindex6.tif' % src_srs_format)
 
         ds = ogr.Open('tmp/test_gdaltindex_5.shp')
         lyr = ds.GetLayer(0)
@@ -272,7 +272,7 @@ def test_gdaltindex_6():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
         ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/test_gdaltindex_6.mif')
         gdal.PopErrorHandler()
-        (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -f "MapInfo File" %s tmp/test_gdaltindex_6.mif tmp/gdaltindex1.tif' % option)
+        _ = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -f "MapInfo File" %s tmp/test_gdaltindex_6.mif tmp/gdaltindex1.tif' % option)
         ds = ogr.Open('tmp/test_gdaltindex_6.mif')
         lyr = ds.GetLayer(0)
         if lyr.GetFeatureCount() != 1:

--- a/autotest/utilities/test_gdaltindex.py
+++ b/autotest/utilities/test_gdaltindex.py
@@ -201,7 +201,7 @@ def test_gdaltindex_4():
     ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
     ds = None
 
-    _ = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -t_srs EPSG:4326 tmp/tileindex.shp tmp/gdaltindex5.tif')
+    gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -t_srs EPSG:4326 tmp/tileindex.shp tmp/gdaltindex5.tif')
 
     ds = ogr.Open('tmp/tileindex.shp')
     if ds.GetLayer(0).GetFeatureCount() != 5:
@@ -232,7 +232,7 @@ def test_gdaltindex_5():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
         ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/test_gdaltindex_5.shp')
         gdal.PopErrorHandler()
-        _ = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -src_srs_name src_srs %s -t_srs EPSG:4326 tmp/test_gdaltindex_5.shp tmp/gdaltindex1.tif tmp/gdaltindex6.tif' % src_srs_format)
+        gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -src_srs_name src_srs %s -t_srs EPSG:4326 tmp/test_gdaltindex_5.shp tmp/gdaltindex1.tif tmp/gdaltindex6.tif' % src_srs_format)
 
         ds = ogr.Open('tmp/test_gdaltindex_5.shp')
         lyr = ds.GetLayer(0)
@@ -272,7 +272,7 @@ def test_gdaltindex_6():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
         ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/test_gdaltindex_6.mif')
         gdal.PopErrorHandler()
-        _ = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -f "MapInfo File" %s tmp/test_gdaltindex_6.mif tmp/gdaltindex1.tif' % option)
+        gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaltindex_path() + ' -f "MapInfo File" %s tmp/test_gdaltindex_6.mif tmp/gdaltindex1.tif' % option)
         ds = ogr.Open('tmp/test_gdaltindex_6.mif')
         lyr = ds.GetLayer(0)
         if lyr.GetFeatureCount() != 1:

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -47,7 +47,7 @@ def test_gdalwarp_1():
     if test_cli_utilities.get_gdalwarp_path() is None:
         return 'skip'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + ' ../gcore/data/byte.tif tmp/testgdalwarp1.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + ' ../gcore/data/byte.tif tmp/testgdalwarp1.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -471,7 +471,7 @@ def test_gdalwarp_18():
     if test_cli_utilities.get_gdalwarp_path() is None:
         return 'skip'
 
-    (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + ' -wm 20 -multi ../gcore/data/byte.tif tmp/testgdalwarp18.tif')
+    (_, ret_stderr) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + ' -wm 20 -multi ../gcore/data/byte.tif tmp/testgdalwarp18.tif')
 
     # This error will be returned if GDAL is not compiled with thread support
     if ret_stderr.find('CPLCreateThread() failed in ChunkAndWarpMulti()') != -1:
@@ -886,13 +886,13 @@ def test_gdalwarp_31():
     cs1 = ds.GetRasterBand(1).Checksum()
     ds = None
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326")
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326")
 
     ds = gdal.Open('tmp/testgdalwarp31.tif')
     cs2 = ds.GetRasterBand(1).Checksum()
     ds = None
 
-    (out, err2) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326 -overwrite")
+    (_, err2) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326 -overwrite")
 
     ds = gdal.Open('tmp/testgdalwarp31.tif')
     cs3 = ds.GetRasterBand(1).Checksum()
@@ -914,7 +914,7 @@ def test_gdalwarp_32():
     if test_cli_utilities.get_gdalwarp_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + ' -tap ../gcore/data/byte.tif tmp/testgdalwarp32.tif',
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + ' -tap ../gcore/data/byte.tif tmp/testgdalwarp32.tif',
                                                   check_memleak=False)
     if err.find('-tap option cannot be used without using -tr') == -1:
         gdaltest.post_reason('expected error')

--- a/autotest/utilities/test_gnmutils.py
+++ b/autotest/utilities/test_gnmutils.py
@@ -48,7 +48,7 @@ def test_gnmmanage_1():
     if test_cli_utilities.get_gnmmanage_path() is None:
         return 'skip'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' create -f GNMFile -t_srs EPSG:4326 -dsco net_name=test_gnm -dsco net_description="Test file based GNM" tmp')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' create -f GNMFile -t_srs EPSG:4326 -dsco net_name=test_gnm -dsco net_description="Test file based GNM" tmp')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -72,13 +72,13 @@ def test_gnmmanage_2():
     if test_cli_utilities.get_gnmmanage_path() is None:
         return 'skip'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' import ../gnm/data/pipes.shp tmp/test_gnm')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' import ../gnm/data/pipes.shp tmp/test_gnm')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
         return 'fail'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' import ../gnm/data/wells.shp tmp/test_gnm')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' import ../gnm/data/wells.shp tmp/test_gnm')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -166,7 +166,7 @@ def test_gnm_cleanup():
     if test_cli_utilities.get_gnmmanage_path() is None:
         return 'skip'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' delete tmp/test_gnm')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gnmmanage_path() + ' delete tmp/test_gnm')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)

--- a/autotest/utilities/test_nearblack.py
+++ b/autotest/utilities/test_nearblack.py
@@ -47,7 +47,7 @@ def test_nearblack_1():
     if test_cli_utilities.get_nearblack_path() is None:
         return 'skip'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' ../gdrivers/data/rgbsmall.tif -nb 0 -of GTiff -o tmp/nearblack1.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' ../gdrivers/data/rgbsmall.tif -nb 0 -of GTiff -o tmp/nearblack1.tif')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -251,7 +251,7 @@ def test_nearblack_8():
     gdal.GetDriverByName('GTiff').CreateCopy('tmp/nearblack8.tif', src_ds)
     src_ds = None
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' tmp/nearblack8.tif -nb 0')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' tmp/nearblack8.tif -nb 0')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)

--- a/autotest/utilities/test_ogr2ogr.py
+++ b/autotest/utilities/test_ogr2ogr.py
@@ -55,7 +55,7 @@ def test_ogr2ogr_1():
     except (OSError, AttributeError):
         pass
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogr2ogr_path() + ' tmp/poly.shp ../ogr/data/poly.shp')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogr2ogr_path() + ' tmp/poly.shp ../ogr/data/poly.shp')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)

--- a/autotest/utilities/test_ogrinfo.py
+++ b/autotest/utilities/test_ogrinfo.py
@@ -250,7 +250,7 @@ def test_ogrinfo_13():
     if test_cli_utilities.get_ogrinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --config', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --config', check_memleak=False)
     if err.find('--config option given without a key and value argument') < 0:
         print(err)
         return 'fail'
@@ -265,7 +265,7 @@ def test_ogrinfo_14():
     if test_cli_utilities.get_ogrinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --mempreload', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --mempreload', check_memleak=False)
     if err.find('--mempreload option given without directory path') < 0:
         print(err)
         return 'fail'
@@ -280,7 +280,7 @@ def test_ogrinfo_15():
     if test_cli_utilities.get_ogrinfo_path() is None:
         return 'skip'
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --debug on --mempreload ../ogr/data /vsimem/poly.shp', check_memleak=False)
+    (ret, _) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --debug on --mempreload ../ogr/data /vsimem/poly.shp', check_memleak=False)
     if ret.find("ESRI Shapefile") < 0:
         print(ret)
         return 'fail'
@@ -295,7 +295,7 @@ def test_ogrinfo_16():
     if test_cli_utilities.get_ogrinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --debug', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --debug', check_memleak=False)
     if err.find('--debug option given without debug level') < 0:
         print(err)
         return 'fail'
@@ -310,13 +310,13 @@ def test_ogrinfo_17():
     if test_cli_utilities.get_ogrinfo_path() is None:
         return 'skip'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --optfile', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --optfile', check_memleak=False)
     if err.find('--optfile option given without filename') < 0:
         gdaltest.post_reason('fail')
         print(err)
         return 'fail'
 
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --optfile /foo/bar', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --optfile /foo/bar', check_memleak=False)
     if err.find('Unable to open optfile') < 0:
         gdaltest.post_reason('fail')
         print(err)
@@ -325,7 +325,7 @@ def test_ogrinfo_17():
     f = open('tmp/optfile.txt', 'wt')
     f.write('--config foo\n')
     f.close()
-    (out, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --optfile tmp/optfile.txt', check_memleak=False)
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrinfo_path() + ' --optfile tmp/optfile.txt', check_memleak=False)
     os.unlink('tmp/optfile.txt')
     if err.find('--config option given without a key and value argument') < 0:
         gdaltest.post_reason('fail')

--- a/autotest/utilities/test_ogrlineref.py
+++ b/autotest/utilities/test_ogrlineref.py
@@ -50,7 +50,7 @@ def test_ogrlineref_1():
     if os.path.exists('tmp/parts.shp'):
         ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/parts.shp')
 
-    ret, err = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrlineref_path() + ' -create -l data/path.shp -p data/mstones.shp -pm pos -o tmp/parts.shp -s 1000')
+    _, err = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrlineref_path() + ' -create -l data/path.shp -p data/mstones.shp -pm pos -o tmp/parts.shp -s 1000')
     if err is not None and err != '':
         gdaltest.post_reason('got error/warning: "%s"' % err)
         return 'fail'

--- a/autotest/utilities/test_ogrtindex.py
+++ b/autotest/utilities/test_ogrtindex.py
@@ -85,7 +85,7 @@ def test_ogrtindex_1(srs=None):
 
     shape_ds.Destroy()
 
-    (ret, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrtindex_path() + ' -skip_different_projection tmp/tileindex.shp tmp/point1.shp tmp/point2.shp tmp/point3.shp tmp/point4.shp')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_ogrtindex_path() + ' -skip_different_projection tmp/tileindex.shp tmp/point1.shp tmp/point2.shp tmp/point3.shp tmp/point4.shp')
     if not (err is None or err == ''):
         gdaltest.post_reason('got error/warning')
         print(err)
@@ -192,7 +192,7 @@ def test_ogrtindex_3():
             output_filename = 'tmp/tileindex.db'
             output_format = ' -f SQLite'
 
-        (ret, err) = gdaltest.runexternal_out_and_err(
+        (_, err) = gdaltest.runexternal_out_and_err(
             test_cli_utilities.get_ogrtindex_path() +
             ' -src_srs_name src_srs -t_srs EPSG:4326 ' + output_filename + ' tmp/point1.shp tmp/point2.shp ' + src_srs_format + output_format)
 

--- a/gdal/swig/python/samples/crs2crs2grid.py
+++ b/gdal/swig/python/samples/crs2crs2grid.py
@@ -81,7 +81,7 @@ def read_grid_crs_to_crs(filename, shape):
     grid = numpy.zeros(shape)
 
     # report the file header defining the transformation
-    for i in range(5):
+    for _ in range(5):
         print(fd.readline().rstrip())
 
     points_found = 0

--- a/gdal/swig/python/samples/densify.py
+++ b/gdal/swig/python/samples/densify.py
@@ -256,7 +256,7 @@ class Densify(Translator):
 
                     x = x0
                     y = y0
-                    for p in range(1, segcount):
+                    for _ in range(1, segcount):
                         x = x + dx
                         y = y + dy
                         g.AddPoint(x, y)
@@ -265,7 +265,7 @@ class Densify(Translator):
                     segcount = int(math.floor(d / threshold))
                     xa = None
                     ya = None
-                    for p in range(1, segcount):
+                    for _ in range(1, segcount):
                         if not xa:
                             xn, yn = self.calcpoint(x0, x1, y0, y1, threshold)
                             d = self.distance(x0, xn, y0, yn)
@@ -288,7 +288,7 @@ class Densify(Translator):
                     # xb = x0
                     # yb = y0
                     remainder = d % threshold
-                    for p in range(segcount):
+                    for _ in range(segcount):
                         if not xa:
                             xn, yn = self.calcpoint(x0, x1, y0, y1, remainder)
 

--- a/gdal/swig/python/samples/gdal_cp.py
+++ b/gdal/swig/python/samples/gdal_cp.py
@@ -98,7 +98,7 @@ def gdal_cp_single(srcfile, targetfile, progress):
 
     if (stat_res is None and targetfile.endswith('/')) or \
        (stat_res is not None and stat.S_ISDIR(stat_res.mode)):
-        (head, tail) = os.path.split(srcfile)
+        (_, tail) = os.path.split(srcfile)
         if targetfile.endswith('/'):
             targetfile = targetfile + tail
         else:

--- a/gdal/swig/python/samples/gdalpythonserver.py
+++ b/gdal/swig/python/samples/gdalpythonserver.py
@@ -388,7 +388,7 @@ def read_str():
 def read_strlist():
     count = read_int()
     strlist = []
-    for i in range(count):
+    for _ in range(count):
         strlist.append(read_str())
     return strlist
 

--- a/gdal/swig/python/samples/ogr2ogr.py
+++ b/gdal/swig/python/samples/ogr2ogr.py
@@ -759,7 +759,7 @@ def main(args=None, progress_func=TermProgress, progress_data=None):
         # }
 
         nSrcLayerCount = poDS.GetLayerCount()
-        pasAssocLayers = [AssociatedLayers() for i in range(nSrcLayerCount)]
+        pasAssocLayers = [AssociatedLayers() for _ in range(nSrcLayerCount)]
 
 # --------------------------------------------------------------------
 #      Special case to improve user experience when translating into

--- a/gdal/swig/python/samples/validate_gpkg.py
+++ b/gdal/swig/python/samples/validate_gpkg.py
@@ -97,7 +97,7 @@ class GPKGChecker:
         for (_, expected_name, expected_type, expected_notnull,
              expected_default, expected_pk) in expected_columns:
             found = False
-            for (_, name, _, notnull, default, pk) in columns:
+            for (_, name, type, notnull, default, pk) in columns:
                 if name != expected_name:
                     continue
 

--- a/gdal/swig/python/samples/validate_gpkg.py
+++ b/gdal/swig/python/samples/validate_gpkg.py
@@ -97,7 +97,7 @@ class GPKGChecker:
         for (_, expected_name, expected_type, expected_notnull,
              expected_default, expected_pk) in expected_columns:
             found = False
-            for (_, name, type, notnull, default, pk) in columns:
+            for (_, name, _, notnull, default, pk) in columns:
                 if name != expected_name:
                     continue
 


### PR DESCRIPTION
## What does this PR do?

Pylint warns about loop index varables that are not referenced inside a `for` loop. A convention for anonymous variables in Python is to name them `_` (underscore) as is done in Prolog. Pylint recognises this and silences its warning if the variable is marked as anonymous in this way.

If this single change is acceptable, please don't merge this PR and I will add a raft of other similar changes across the source tree to this branch.