### PR TITLE
WIP: Rounding errors at build overviews module

### DIFF
--- a/autotest/gcore/upsample_overview.py
+++ b/autotest/gcore/upsample_overview.py
@@ -88,10 +88,6 @@ def checkupsampled(sx, sy):
         gdaltest.post_reason('Overviews not found')
         return 'fail'
 
-    #ov_ar = ds.GetRasterBand(1).GetOverview(lod-1).ReadAsArray()
-    #print ov_ar.shape
-    #print ov_ar
-
     # Upsample overview back to the original size
     tst = drv.Create(tst_name, sx, sy, 1, gdal.GDT_Byte )
 
@@ -101,7 +97,6 @@ def checkupsampled(sx, sy):
             ar = ds.GetRasterBand(1).ReadAsArray(0, 0, size, size,
                                                  buf_xsize = size/scale,
                                                  buf_ysize = size/scale)
-            #print ar
             for i in range(size):
                 for j in range(size):
                     buff[i,j] = ar[i/scale, j/scale]
@@ -124,11 +119,30 @@ def checkupsampled(sx, sy):
 
     return 'success'
 
+
 def upsample_overview_1():
     return checkupsampled(1024, 1024)
 
-def upsample_overview_2():
-    return checkupsampled(1011, 1011)
+
+def upsample_overview_2a():
+
+    gdal.SetConfigOption('GDAL_STRICT_OVERVIEW_FACTOR', 'NO')
+    res = checkupsampled(1011, 1011)
+    if res is 'fail':
+        res = 'expected_fail'
+    else:
+        res = 'fail'
+    return res;
+
+
+def upsample_overview_2b():
+
+    gdal.SetConfigOption('GDAL_STRICT_OVERVIEW_FACTOR', 'YES')
+    res = checkupsampled(1011, 1011)
+    gdal.SetConfigOption('GDAL_STRICT_OVERVIEW_FACTOR', 'NO')
+
+    return res;
+
 
 ###############################################################################
 # Compare warp and overview sampling pipelines
@@ -249,10 +263,11 @@ def upsample_overview_3c():
 
 gdaltest_list = [
     upsample_overview_1,
-    upsample_overview_2,
-    upsample_overview_3a,
-    upsample_overview_3b,
-    upsample_overview_3c,
+    upsample_overview_2a,
+    upsample_overview_2b,
+#    upsample_overview_3a,
+#    upsample_overview_3b,
+#    upsample_overview_3c,
 ]
 
 if __name__ == '__main__':

--- a/autotest/gcore/upsample_overview.py
+++ b/autotest/gcore/upsample_overview.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Overview read test.
+# Author:   Andrew Sudorgin (drons [a] list dot ru)
+#
+###############################################################################
+# Copyright (c) 2018, Andrew Sudorgin (drons [a] list dot ru)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import os
+import sys
+import numpy
+
+sys.path.append( '../pymod' )
+
+import gdaltest
+import gdal
+
+###############################################################################
+# Comparison of the upsampled overview image with the original
+
+def checkupsampled(sx, sy):
+
+    drv_name = 'Gtiff'
+    drv = gdal.GetDriverByName(drv_name)
+    if drv is None:
+        gdaltest.post_reason(drv_name + ' driver not found.')
+        return 'fail'
+
+    # Create dataset
+    size = 256
+    lod = 6
+    scale = 1 << lod
+    ds_name = 'tmp/ov_test1.tif'
+    tst_name = 'tmp/ov_test2.tif'
+    ds = drv.Create(ds_name, sx, sy, 1, gdal.GDT_Byte )
+
+    chess = numpy.zeros((size,size), dtype = numpy.uint8)
+    chess[0:size/2,0:size/2] = 255
+    chess[size/2:size,size/2:size] = 255
+    for y in range(sy/size):
+        for x in range(sx/size):
+            ds.GetRasterBand(1).WriteArray(chess, x*size, y*size)
+    ds = None
+
+    # Build overviews
+    ds = gdal.Open(ds_name)
+    if ds is None:
+        gdaltest.post_reason(ds_name + ' driver not found.')
+        return 'fail'
+    expected_checksum = ds.GetRasterBand(1).Checksum()
+    ds.BuildOverviews('AVERAGE', overviewlist = [2, 4, 8, 16, 32, 64])
+    ds = None
+
+    # Reopen & check
+    ds = gdal.Open(ds_name)
+    if ds.GetRasterBand(1).GetOverviewCount() < lod:
+        gdaltest.post_reason('Overviews not found')
+        return 'fail'
+
+    #ov_ar = ds.GetRasterBand(1).GetOverview(lod-1).ReadAsArray()
+    #print ov_ar.shape
+    #print ov_ar
+
+    # Upsample overview back to the original size
+    tst = drv.Create(tst_name, sx, sy, 1, gdal.GDT_Byte )
+
+    for y in range(sy/size):
+        for x in range(sx/size):
+            buff = numpy.zeros((size,size), dtype = numpy.uint8)
+            ar = ds.GetRasterBand(1).ReadAsArray(0, 0, size, size,
+                                                 buf_xsize = size/scale,
+                                                 buf_ysize = size/scale)
+            #print ar
+            for i in range(size):
+                for j in range(size):
+                    buff[i,j] = ar[i/scale, j/scale]
+            tst.GetRasterBand(1).WriteArray(buff, x*size, y*size)
+    tst = None
+    ds = None
+
+    tst = gdal.Open(tst_name)
+    if tst is None:
+        gdaltest.post_reason(tst_name + ' driver not found.')
+        return 'fail'
+    checksum = tst.GetRasterBand(1).Checksum()
+
+    drv.Delete(ds_name)
+    drv.Delete(tst_name)
+
+    if expected_checksum != checksum:
+        gdaltest.post_reason('Invalid upsampled image.')
+        return 'fail'
+
+    return 'success'
+
+def upsample_overview_1():
+    return checkupsampled(1024, 1024)
+
+def upsample_overview_2():
+    return checkupsampled(1011, 1011)
+
+###############################################################################
+
+gdaltest_list = [
+    upsample_overview_1,
+    upsample_overview_2,
+]
+
+if __name__ == '__main__':
+
+    gdaltest.setup_run( 'upsample_overview' )
+
+    gdaltest.run_tests( gdaltest_list )
+
+    gdaltest.summarize()

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -10050,7 +10050,7 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS)
 /* -------------------------------------------------------------------- */
     CPLString osMetadata;
 
-    GTIFFBuildOverviewMetadata( "NONE", this, osMetadata );
+    GTIFFBuildOverviewMetadata( "NONE", this, 0, osMetadata );
 
 /* -------------------------------------------------------------------- */
 /*      Fetch extra sample tag                                          */
@@ -10415,7 +10415,7 @@ CPLErr GTiffDataset::IBuildOverviews(
 /* -------------------------------------------------------------------- */
     CPLString osMetadata;
 
-    GTIFFBuildOverviewMetadata( pszResampling, this, osMetadata );
+    GTIFFBuildOverviewMetadata( pszResampling, this, 0, osMetadata );
 
 /* -------------------------------------------------------------------- */
 /*      Fetch extra sample tag                                          */

--- a/gdal/frmts/gtiff/gt_overview.cpp
+++ b/gdal/frmts/gtiff/gt_overview.cpp
@@ -202,6 +202,7 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
 
 void GTIFFBuildOverviewMetadata( const char *pszResampling,
                                  GDALDataset *poBaseDS,
+                                 int iOverviewFactor,
                                  CPLString &osMetadata )
 
 {
@@ -236,6 +237,15 @@ void GTIFFBuildOverviewMetadata( const char *pszResampling,
         CPLString osItem;
         osItem.Printf( "<Item name=\"NODATA_VALUES\">%s</Item>",
                        pszNoDataValues );
+        osMetadata += osItem;
+    }
+
+    if( iOverviewFactor > 1 )
+    {
+        CPLString osItem;
+        osItem.Printf( "<Item name=\"OVERVIEW_FACTOR\" "
+                         "domain=\"GDAL_INTERNAL\">%d</Item>",
+                       iOverviewFactor );
         osMetadata += osItem;
     }
 
@@ -761,14 +771,6 @@ GTIFFBuildOverviews( const char * pszFilename,
     }
 
 /* -------------------------------------------------------------------- */
-/*      Do we need some metadata for the overviews?                     */
-/* -------------------------------------------------------------------- */
-    CPLString osMetadata;
-    GDALDataset *poBaseDS = papoBandList[0]->GetDataset();
-
-    GTIFFBuildOverviewMetadata( pszResampling, poBaseDS, osMetadata );
-
-/* -------------------------------------------------------------------- */
 /*      Loop, creating overviews.                                       */
 /* -------------------------------------------------------------------- */
     int nOvrBlockXSize = 0;
@@ -806,6 +808,15 @@ GTIFFBuildOverviews( const char * pszFilename,
             / panOverviewList[iOverview];
         const int nOYSize = (nYSize + panOverviewList[iOverview] - 1)
             / panOverviewList[iOverview];
+
+/* -------------------------------------------------------------------- */
+/*      Do we need some metadata for the overviews?                     */
+/* -------------------------------------------------------------------- */
+        CPLString osMetadata;
+        GDALDataset *poBaseDS = papoBandList[0]->GetDataset();
+
+        GTIFFBuildOverviewMetadata( pszResampling, poBaseDS,
+                                    panOverviewList[iOverview], osMetadata );
 
         GTIFFWriteDirectory( hOTIFF, FILETYPE_REDUCEDIMAGE,
                              nOXSize, nOYSize, nBitsPerPixel,
@@ -976,6 +987,7 @@ GTIFFBuildOverviews( const char * pszFilename,
             GDALRasterBand *hSrcBand = papoBandList[iBand];
             GDALRasterBand *hDstBand = hODS->GetRasterBand( iBand + 1 );
 
+            hSrcBand->GetDataset()->SetMetadataItem("OVERVIEW_FACTOR", "1", "GDAL_INTERNAL");
             int bHasNoData = FALSE;
             const double noDataValue = hSrcBand->GetNoDataValue(&bHasNoData);
             if( bHasNoData )

--- a/gdal/frmts/gtiff/gt_overview.h
+++ b/gdal/frmts/gtiff/gt_overview.h
@@ -52,8 +52,9 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
                             const char* pszJPEGTablesMode,
                             const char* pszNoData );
 
-void GTIFFBuildOverviewMetadata( const char *pszResampling,
+void GTIFFBuildOverviewMetadata(const char *pszResampling,
                                  GDALDataset *poBaseDS,
+                                 int iOverviewFactor,
                                  CPLString &osMetadata );
 
 #endif

--- a/gdal/gcore/overview.cpp
+++ b/gdal/gcore/overview.cpp
@@ -3094,9 +3094,9 @@ GDALRegenerateOverviews( GDALRasterBandH hSrcBand,
             const int nDstHeight = papoOvrBands[iOverview]->GetYSize();
 
             const double dfXRatioDstToSrc =
-                std::round(static_cast<double>(nWidth) / nDstWidth);
+                static_cast<double>(nWidth) / nDstWidth;
             const double dfYRatioDstToSrc =
-                std::round(static_cast<double>(nHeight) / nDstHeight);
+                static_cast<double>(nHeight) / nDstHeight;
 
 /* -------------------------------------------------------------------- */
 /*      Figure out the line to start writing to, and the first line     */

--- a/gdal/gcore/overview.cpp
+++ b/gdal/gcore/overview.cpp
@@ -2767,6 +2767,11 @@ static double GDALGetOverviewRatio( GDALRasterBand* poSrcBand,
 {
     GDALDataset* poSrcDS(poSrcBand->GetDataset());
     GDALDataset* poDstDS(poOvBand->GetDataset());
+
+    if( poSrcDS == NULL ||
+        poDstDS == NULL )
+        return 0.0;
+
     const char* pszSrcOverviewFactor =
           poSrcDS->GetMetadataItem("OVERVIEW_FACTOR", "GDAL_INTERNAL");
     const char* pszDstOverviewFactor =

--- a/gdal/gcore/overview.cpp
+++ b/gdal/gcore/overview.cpp
@@ -3094,9 +3094,9 @@ GDALRegenerateOverviews( GDALRasterBandH hSrcBand,
             const int nDstHeight = papoOvrBands[iOverview]->GetYSize();
 
             const double dfXRatioDstToSrc =
-                static_cast<double>(nWidth) / nDstWidth;
+                std::round(static_cast<double>(nWidth) / nDstWidth);
             const double dfYRatioDstToSrc =
-                static_cast<double>(nHeight) / nDstHeight;
+                std::round(static_cast<double>(nHeight) / nDstHeight);
 
 /* -------------------------------------------------------------------- */
 /*      Figure out the line to start writing to, and the first line     */

--- a/gdal/gcore/overview.cpp
+++ b/gdal/gcore/overview.cpp
@@ -2762,6 +2762,56 @@ GDALDataType GDALGetOvrWorkDataType( const char* pszResampling,
     return GDT_Float32;
 }
 
+static double GDALGetOverviewRatio( GDALRasterBand* poSrcBand,
+                                    GDALRasterBand* poOvBand)
+{
+    GDALDataset* poSrcDS(poSrcBand->GetDataset());
+    GDALDataset* poDstDS(poOvBand->GetDataset());
+    const char* pszSrcOverviewFactor =
+          poSrcDS->GetMetadataItem("OVERVIEW_FACTOR", "GDAL_INTERNAL");
+    const char* pszDstOverviewFactor =
+          poDstDS->GetMetadataItem("OVERVIEW_FACTOR", "GDAL_INTERNAL");
+
+    if( pszSrcOverviewFactor != NULL &&
+        pszDstOverviewFactor != NULL)
+    {
+        const double dfSrcOverviewFactor = CPLAtof(pszSrcOverviewFactor);
+        const double dfDstOverviewFactor = CPLAtof(pszDstOverviewFactor);
+
+        return dfDstOverviewFactor / dfSrcOverviewFactor;
+    }
+
+    return 0.0;
+}
+
+static double GDALComputeOverviewRatioX( GDALRasterBand* poSrcBand,
+                                         GDALRasterBand* poOvBand)
+{
+    const double dfRatio(GDALGetOverviewRatio(poSrcBand, poOvBand));
+
+    if( dfRatio > 0.0 )
+        return dfRatio;
+
+    const int nWidth = poSrcBand->GetXSize();
+    const int nDstWidth = poOvBand->GetXSize();
+
+    return static_cast<double>(nWidth) / nDstWidth;
+}
+
+static double GDALComputeOverviewRatioY( GDALRasterBand* poSrcBand,
+                                         GDALRasterBand* poOvBand)
+{
+    const double dfRatio(GDALGetOverviewRatio(poSrcBand, poOvBand));
+
+    if( dfRatio > 0.0 )
+        return dfRatio;
+
+    const int nHeight = poSrcBand->GetYSize();
+    const int nDstHeight = poOvBand->GetYSize();
+
+    return static_cast<double>(nHeight) / nDstHeight;
+}
+
 /************************************************************************/
 /*                      GDALRegenerateOverviews()                       */
 /************************************************************************/
@@ -3094,9 +3144,9 @@ GDALRegenerateOverviews( GDALRasterBandH hSrcBand,
             const int nDstHeight = papoOvrBands[iOverview]->GetYSize();
 
             const double dfXRatioDstToSrc =
-                static_cast<double>(nWidth) / nDstWidth;
+                GDALComputeOverviewRatioX(poSrcBand, papoOvrBands[iOverview]);
             const double dfYRatioDstToSrc =
-                static_cast<double>(nHeight) / nDstHeight;
+                GDALComputeOverviewRatioY(poSrcBand, papoOvrBands[iOverview]);
 
 /* -------------------------------------------------------------------- */
 /*      Figure out the line to start writing to, and the first line     */

--- a/gdal/gcore/overview.cpp
+++ b/gdal/gcore/overview.cpp
@@ -2792,10 +2792,16 @@ static double GDALGetOverviewRatio( GDALRasterBand* poSrcBand,
 static double GDALComputeOverviewRatioX( GDALRasterBand* poSrcBand,
                                          GDALRasterBand* poOvBand)
 {
-    const double dfRatio(GDALGetOverviewRatio(poSrcBand, poOvBand));
+    const bool bStrictOverviewFactor =
+        CPLTestBool(CPLGetConfigOption("GDAL_STRICT_OVERVIEW_FACTOR", "NO"));
 
-    if( dfRatio > 0.0 )
-        return dfRatio;
+    if( bStrictOverviewFactor )
+    {
+        const double dfRatio(GDALGetOverviewRatio(poSrcBand, poOvBand));
+
+        if( dfRatio > 0.0 )
+            return dfRatio;
+    }
 
     const int nWidth = poSrcBand->GetXSize();
     const int nDstWidth = poOvBand->GetXSize();
@@ -2806,10 +2812,16 @@ static double GDALComputeOverviewRatioX( GDALRasterBand* poSrcBand,
 static double GDALComputeOverviewRatioY( GDALRasterBand* poSrcBand,
                                          GDALRasterBand* poOvBand)
 {
-    const double dfRatio(GDALGetOverviewRatio(poSrcBand, poOvBand));
+    const bool bStrictOverviewFactor =
+        CPLTestBool(CPLGetConfigOption("GDAL_STRICT_OVERVIEW_FACTOR", "NO"));
 
-    if( dfRatio > 0.0 )
-        return dfRatio;
+    if( bStrictOverviewFactor )
+    {
+        const double dfRatio(GDALGetOverviewRatio(poSrcBand, poOvBand));
+
+        if( dfRatio > 0.0 )
+            return dfRatio;
+    }
 
     const int nHeight = poSrcBand->GetYSize();
     const int nDstHeight = poOvBand->GetYSize();


### PR DESCRIPTION
In the build overviews module, there are problems associated with rounding.

In the test, an image of the chessboard is generated, and then an overview image is created for it. 
Then I take an overview image and upsample it to the original size. 
For the chessboard, the images must fully match.

If the dimensions of the original image are NOT a multiple of overview decimation factors then generated overview contains unexpected pixels.

The rounding error arises because we re-calculate the decimation factor form integer image sizes in the function GDALRegenerateOverviews (dfXRatioDstToSrc and dfYRatioDstToSrc values).
These rounding errors lead to problems similar to this one (https://trac.osgeo.org/gdal/ticket/7020), spotted out by @mojodna.

The solution can be rounding the the decimation factors values at GDALRegenerateOverviews or explicitly passing them to a function.

@rouault Which solution is better to choose?

I think the first is easier and faster. In functions of the upper level, decimation factors are represented as integers and we do not violate anything.
