### PR TITLE
Python code: Use [x] * n instead of [x for i in range(n)]

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -4743,7 +4743,7 @@ def tiff_write_117():
 
     # Write first tile so that its byte count of that tile is 2048 (a multiple of 1024)
     adjust = 1254
-    data = ''.join(['0' for i in range(65536 - adjust)]) + ''.join([('%c' % random.randint(0, 255)) for i in range(adjust)])
+    data = [0] * (65536 - adjust) + ''.join([('%c' % random.randint(0, 255)) for i in range(adjust)])
     ds.GetRasterBand(1).WriteRaster(0, 0, 256, 256, data)
 
     # Second tile will be implicitly written at closing, or we could write

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -4743,7 +4743,7 @@ def tiff_write_117():
 
     # Write first tile so that its byte count of that tile is 2048 (a multiple of 1024)
     adjust = 1254
-    data = [0] * (65536 - adjust) + ''.join([('%c' % random.randint(0, 255)) for i in range(adjust)])
+    data = '0' * (65536 - adjust) + ''.join([('%c' % random.randint(0, 255)) for i in range(adjust)])
     ds.GetRasterBand(1).WriteRaster(0, 0, 256, 256, data)
 
     # Second tile will be implicitly written at closing, or we could write

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -1222,9 +1222,7 @@ def ogr_gml_30():
     for i in range(11):
         field1 = field1 + field1
 
-    geom = "0 1 "
-    for i in range(9):
-        geom = geom + geom
+    geom = "0 1 " * 512
 
     data = """<FeatureCollection xmlns:gml="http://www.opengis.net/gml">
   <gml:featureMember>

--- a/autotest/ogr/ogr_wasp.py
+++ b/autotest/ogr/ogr_wasp.py
@@ -518,7 +518,7 @@ def ogr_wasp_merge():
         gdaltest.post_reason('there should be 6 boundaries and there are %d' % j)
         return 'fail'
 
-    if res != [(0, 1) for k in range(6)]:
+    if res != [(0, 1)] * 6:
         print(res)
         gdaltest.post_reason('wrong values f=in boundaries')
         return 'fail'

--- a/gdal/swig/python/samples/gdalpythonserver.py
+++ b/gdal/swig/python/samples/gdalpythonserver.py
@@ -89,7 +89,7 @@ class GDALPythonServerRasterBand:
 
     def GetOverview(self, iovr):
         if self.ovr_bands is None:
-            self.ovr_bands = [None for i in range(self.GetOverviewCount())]
+            self.ovr_bands = [None] * self.GetOverviewCount()
         if self.ovr_bands[iovr] is None:
             gdal_ovr_band = self.gdal_band.GetOverview(iovr)
             if gdal_ovr_band is not None:

--- a/gdal/swig/python/samples/ogr2ogr.py
+++ b/gdal/swig/python/samples/ogr2ogr.py
@@ -784,7 +784,7 @@ def main(args=None, progress_func=TermProgress, progress_data=None):
 #      If no target layer specified, use all source layers.
 # --------------------------------------------------------------------
         if len(papszLayers) == 0:
-            papszLayers = [None for i in range(nSrcLayerCount)]
+            papszLayers = [None] * nSrcLayerCount
             for iLayer in range(nSrcLayerCount):
                 poLayer = poDS.GetLayer(iLayer)
                 if poLayer is None:
@@ -897,7 +897,7 @@ def main(args=None, progress_func=TermProgress, progress_data=None):
 # --------------------------------------------------------------------
         if len(papszLayers) == 0:
             nLayerCount = poDS.GetLayerCount()
-            papoLayers = [None for i in range(nLayerCount)]
+            papoLayers = [None] * nLayerCount
             iLayer = 0
 
             for iLayer in range(nLayerCount):
@@ -915,7 +915,7 @@ def main(args=None, progress_func=TermProgress, progress_data=None):
 # --------------------------------------------------------------------
         else:
             nLayerCount = len(papszLayers)
-            papoLayers = [None for i in range(nLayerCount)]
+            papoLayers = [None] * nLayerCount
             iLayer = 0
 
             for layername in papszLayers:
@@ -928,7 +928,7 @@ def main(args=None, progress_func=TermProgress, progress_data=None):
                 papoLayers[iLayer] = poLayer
                 iLayer = iLayer + 1
 
-        panLayerCountFeatures = [0 for i in range(nLayerCount)]
+        panLayerCountFeatures = [0] * nLayerCount
         nCountLayersFeatures = 0
         nAccCountFeatures = 0
 
@@ -1357,7 +1357,7 @@ def SetupTargetLayer(poSrcDS, poSrcLayer, poDstDS, papszLCO, pszNewLayerName,
 
     # Initialize the index-to-index map to -1's
     nSrcFieldCount = poSrcFDefn.GetFieldCount()
-    panMap = [-1 for i in range(nSrcFieldCount)]
+    panMap = [-1] * nSrcFieldCount
 
     poDstFDefn = poDstLayer.GetLayerDefn()
 

--- a/gdal/swig/python/scripts/ogrmerge.py
+++ b/gdal/swig/python/scripts/ogrmerge.py
@@ -157,7 +157,7 @@ class XMLWriter:
         self.elements = []
 
     def _indent(self):
-        return ''.join(['  ' for i in range(self.inc)])
+        return '  ' * self.inc
 
     def open_element(self, name, attrs=None):
         xml_attrs = ''


### PR DESCRIPTION
## What does this PR do?

Changes list constructions from the form `[x for i  in range(n)]` to `[x] * n`. Not only is it clearer and more compact, it eliminates a `for` loop with an unreferenced loop index variable. ;-)