### PR TITLE
Python code: Fix 'is' comparisons with literals

### DIFF
--- a/autotest/gdrivers/netcdf_cf.py
+++ b/autotest/gdrivers/netcdf_cf.py
@@ -146,12 +146,12 @@ def netcdf_cf_get_command(ifile, version='auto'):
     # fetch method obtained previously
     method = gdaltest.netcdf_cf_method
     if method is not None:
-        if method is 'local':
+        if method == 'local':
             command = './netcdf_cfchecks.py -a ' + gdaltest.netcdf_cf_files['a'] \
                 + ' -s ' + gdaltest.netcdf_cf_files['s'] \
                 + ' -u ' + gdaltest.netcdf_cf_files['u'] \
                 + ' -v ' + version + ' ' + ifile
-        elif method is 'http':
+        elif method == 'http':
             # command = shlex.split( 'curl --form cfversion="1.5" --form upload=@' + ifile + ' --form submit=\"Check file\" "http://puma.nerc.ac.uk/cgi-bin/cf-checker.pl"' )
             # switch to 1.5 as driver now supports, and auto when it becomes available
             version = '1.5'

--- a/autotest/gdrivers/snodas.py
+++ b/autotest/gdrivers/snodas.py
@@ -56,7 +56,7 @@ def snodas_1():
     AUTHORITY["EPSG","4326"]]"""
     ret = tst.testOpen(check_gt=expected_gt, check_prj=expected_srs, skip_checksum=True)
 
-    if ret is 'success':
+    if ret == 'success':
         ds = gdal.Open('data/fake_snodas.hdr')
         ds.GetFileList()
         if ds.GetRasterBand(1).GetNoDataValue() != -9999:

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -145,7 +145,7 @@ def ogr_openfilegdb_make_test_data():
             feat.SetFieldBinaryFromHexString("binary2", "123456")
             lyr.CreateFeature(feat)
 
-        if data[0] is 'none':
+        if data[0] == 'none':
             # Create empty feature
             feat = ogr.Feature(lyr.GetLayerDefn())
             lyr.CreateFeature(feat)

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -516,7 +516,7 @@ def ogr_shape_15():
         count = count + 1
         feat = gdaltest.shape_lyr.GetNextFeature()
 
-    if count is not 10:
+    if count != 10:
         gdaltest.post_reason('Did not get expected FID count.')
         return 'fail'
 
@@ -547,7 +547,7 @@ def ogr_shape_16():
         count = count + 1
         feat = gdaltest.shape_lyr.GetNextFeature()
 
-    if count is not 10:
+    if count != 10:
         gdaltest.post_reason('Did not get expected FID count.')
         return 'fail'
 

--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -182,7 +182,7 @@ def osr_basic_3():
         gdaltest.post_reason('Got a PROJCS Authority but we should not')
         return 'fail'
 
-    if str(srs.GetAuthorityCode('PROJCS|UNIT')) is '9001':
+    if str(srs.GetAuthorityCode('PROJCS|UNIT')) == '9001':
         gdaltest.post_reason('Got METER authority code on linear units.')
         return 'fail'
 

--- a/gdal/swig/python/scripts/gdal_fillnodata.py
+++ b/gdal/swig/python/scripts/gdal_fillnodata.py
@@ -155,9 +155,9 @@ if src_ds is None:
 
 srcband = src_ds.GetRasterBand(src_band)
 
-if mask != 'default':
+if mask == 'default':
     maskband = srcband.GetMaskBand()
-elif mask != 'none':
+elif mask == 'none':
     maskband = None
 else:
     mask_ds = gdal.Open(mask)

--- a/gdal/swig/python/scripts/gdal_fillnodata.py
+++ b/gdal/swig/python/scripts/gdal_fillnodata.py
@@ -155,9 +155,9 @@ if src_ds is None:
 
 srcband = src_ds.GetRasterBand(src_band)
 
-if mask is 'default':
+if mask != 'default':
     maskband = srcband.GetMaskBand()
-elif mask is 'none':
+elif mask != 'none':
     maskband = None
 else:
     mask_ds = gdal.Open(mask)

--- a/gdal/swig/python/scripts/gdal_polygonize.py
+++ b/gdal/swig/python/scripts/gdal_polygonize.py
@@ -199,9 +199,9 @@ elif isinstance(src_band_n, str) and src_band_n.startswith('mask,'):
 else:
     srcband = src_ds.GetRasterBand(src_band_n)
 
-if mask is 'default':
+if mask == 'default':
     maskband = srcband.GetMaskBand()
-elif mask is 'none':
+elif mask == 'none':
     maskband = None
 else:
     mask_ds = gdal.Open(mask)

--- a/gdal/swig/python/scripts/gdal_sieve.py
+++ b/gdal/swig/python/scripts/gdal_sieve.py
@@ -189,9 +189,9 @@ if src_ds is None:
 
 srcband = src_ds.GetRasterBand(1)
 
-if mask is 'default':
+if mask == 'default':
     maskband = srcband.GetMaskBand()
-elif mask is 'none':
+elif mask == 'none':
     maskband = None
 else:
     mask_ds = gdal.Open(mask)


### PR DESCRIPTION
## What does this PR do?

Pylint warns about `is` comparisons with literals because it can return false negatives in some cases Two strings may have the same value but not be the same object. `==` returns `True` and `is` returns `False`. It is best to use `==`.