### PR TITLE
Python code: Remove unnecessary else statements under returns

### DIFF
--- a/autotest/alg/polygonize.py
+++ b/autotest/alg/polygonize.py
@@ -85,10 +85,7 @@ def polygonize_1(is_int_polygonize=True):
             tr = 0
         feat_read.Destroy()
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 def polygonize_1_float():
@@ -130,10 +127,7 @@ def polygonize_2():
 
     tr = ogrtest.check_features_against_list(mem_layer, 'DN', expect)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # A more involved case with a complex looping.
@@ -176,10 +170,7 @@ def polygonize_3():
         tr = 1
     feat_read.Destroy()
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test a simple case without masking but with 8-connectedness.
@@ -217,10 +208,7 @@ def polygonize_4():
 
     tr = ogrtest.check_features_against_list(mem_layer, 'DN', expect)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 gdaltest_list = [

--- a/autotest/alg/proximity.py
+++ b/autotest/alg/proximity.py
@@ -65,8 +65,7 @@ def proximity_1():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Try several options
@@ -101,8 +100,7 @@ def proximity_2():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Try input nodata option
@@ -137,8 +135,7 @@ def proximity_3():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 
 gdaltest_list = [

--- a/autotest/alg/reproject.py
+++ b/autotest/alg/reproject.py
@@ -64,8 +64,7 @@ def reproject_1():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Test a real reprojection case.
@@ -98,8 +97,7 @@ def reproject_2():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Test nodata values

--- a/autotest/alg/sieve.py
+++ b/autotest/alg/sieve.py
@@ -66,8 +66,7 @@ def sieve_1():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Try eight connected.
@@ -98,8 +97,7 @@ def sieve_2():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Do a sieve resulting in unmergable polygons.
@@ -131,8 +129,7 @@ def sieve_3():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Try the bug 2634 simplified data.
@@ -163,8 +160,7 @@ def sieve_4():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 
 ###############################################################################
@@ -196,8 +192,7 @@ def sieve_5():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Performance test. When increasing the 'size' parameter, performance
@@ -294,8 +289,7 @@ NODATA_value 0
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Test propagation in our search of biggest neighbour
@@ -344,8 +338,7 @@ cellsize     60.000000000000
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 
 gdaltest_list = [

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1165,10 +1165,7 @@ def warp_29():
 
 def warp_30_progress_callback(pct, message, user_data):
     # pylint: disable=unused-argument
-    if pct > 0.2:
-        return 0  # stop
-    else:
-        return 1  # continue
+    return bool(pct <= 0.2)
 
 
 def warp_30():

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -54,9 +54,8 @@ def basic_test_1():
     gdal.PopErrorHandler()
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return 'success'
-    else:
-        gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
-        return 'fail'
+    gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
+    return 'fail'
 
 
 def basic_test_2():
@@ -65,9 +64,8 @@ def basic_test_2():
     gdal.PopErrorHandler()
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return 'success'
-    else:
-        gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
-        return 'fail'
+    gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
+    return 'fail'
 
 
 def basic_test_3():
@@ -76,9 +74,8 @@ def basic_test_3():
     gdal.PopErrorHandler()
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return 'success'
-    else:
-        gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
-        return 'fail'
+    gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
+    return 'fail'
 
 
 def basic_test_4():
@@ -87,9 +84,8 @@ def basic_test_4():
     gdal.PopErrorHandler()
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return 'success'
-    else:
-        gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
-        return 'fail'
+    gdaltest.post_reason('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
+    return 'fail'
 
 
 def basic_test_5():
@@ -100,8 +96,7 @@ def basic_test_5():
     expected = '`data/doctype.xml\' not recognized as a supported file format'
     if ds is None and expected in last_error:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Issue several AllRegister() to check that GDAL drivers are good citizens

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -271,10 +271,7 @@ class misc_6_interrupt_callback_class:
 
     def cbk(self, pct, message, user_data):
         # pylint: disable=unused-argument
-        if pct > 0.5:
-            return 0  # to stop
-        else:
-            return 1  # to continue
+        return pct <= 0.5
 
 ###############################################################################
 # Test CreateCopy() with a source dataset with various band numbers (including 0) and datatype

--- a/autotest/gcore/testnonboundtoswig.py
+++ b/autotest/gcore/testnonboundtoswig.py
@@ -254,20 +254,19 @@ def GDALTypeToCTypes(gdaltype):
 
     if gdaltype == gdal.GDT_Byte:
         return ctypes.c_ubyte
-    elif gdaltype == gdal.GDT_Int16:
+    if gdaltype == gdal.GDT_Int16:
         return ctypes.c_short
-    elif gdaltype == gdal.GDT_UInt16:
+    if gdaltype == gdal.GDT_UInt16:
         return ctypes.c_ushort
-    elif gdaltype == gdal.GDT_Int32:
+    if gdaltype == gdal.GDT_Int32:
         return ctypes.c_int
-    elif gdaltype == gdal.GDT_UInt32:
+    if gdaltype == gdal.GDT_UInt32:
         return ctypes.c_uint
-    elif gdaltype == gdal.GDT_Float32:
+    if gdaltype == gdal.GDT_Float32:
         return ctypes.c_float
-    elif gdaltype == gdal.GDT_Float64:
+    if gdaltype == gdal.GDT_Float64:
         return ctypes.c_double
-    else:
-        return None
+    return None
 
 
 def my_pyDerivedPixelFunc(papoSources, nSources, pData, nBufXSize, nBufYSize, eSrcType, eBufType, nPixelSpace, nLineSpace):

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -909,8 +909,7 @@ def tiff_ovr_22():
 
     if err != 0:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Same as before, but BigTIFF might be not needed as we use a compression

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -288,9 +288,8 @@ def tiff_read_ojpeg():
     if ds is None:
         if gdal.GetLastErrorMsg().find('Cannot open TIFF file due to missing codec') == 0:
             return 'skip'
-        else:
-            print(gdal.GetLastErrorMsg())
-            return 'fail'
+        print(gdal.GetLastErrorMsg())
+        return 'fail'
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     got_cs = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/aaigrid.py
+++ b/autotest/gdrivers/aaigrid.py
@@ -240,8 +240,7 @@ def aaigrid_9():
 
     if abs(got_minmax[0] - -0.84) < 1e-7:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test AAIGRID_DATATYPE configuration option and DATATYPE open options
@@ -308,8 +307,7 @@ def aaigrid_11():
 
     if abs(got_minmax[0] - -0.84) < 1e-7:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test no data is written to correct precision with DECIMAL_PRECISION.

--- a/autotest/gdrivers/db2.py
+++ b/autotest/gdrivers/db2.py
@@ -143,8 +143,7 @@ def check_tile_format(out_ds, expected_format, expected_band_count, expected_ct,
     if expected_format is None:
         if mime_type is None:
             return 'success'
-        else:
-            return 'fail'
+        return 'fail'
 
     if expected_format == 'PNG':
         expected_mime_type = 'image/png'

--- a/autotest/gdrivers/dods.py
+++ b/autotest/gdrivers/dods.py
@@ -114,8 +114,7 @@ def dods_6():
         gdaltest.post_reason('nodata value wrong or missing.')
         print(nd)
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Cleanup

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -1599,12 +1599,10 @@ def ecw_40():
         if gdaltest.ecw_drv.major_version < 5:
             if gdal.GetLastErrorMsg().find('requires ECW SDK 5.0') >= 0:
                 return 'skip'
-            else:
-                gdaltest.post_reason('explicit error message expected')
-                return 'fail'
-        else:
-            gdaltest.post_reason('fail')
+            gdaltest.post_reason('explicit error message expected')
             return 'fail'
+        gdaltest.post_reason('fail')
+        return 'fail'
 
     expected_md = [
         ('CLOCKWISE_ROTATION_DEG', '0.000000'),

--- a/autotest/gdrivers/georaster.py
+++ b/autotest/gdrivers/georaster.py
@@ -48,8 +48,7 @@ def get_connection_str():
     if oci_dsname is None:
         # TODO: Spelling - informe?
         return '<error: informe ORACLE connection>'
-    else:
-        return 'geor:' + oci_dsname.split(':')[1]
+    return 'geor:' + oci_dsname.split(':')[1]
 
 ###############################################################################
 #

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -175,8 +175,7 @@ def check_tile_format(out_ds, expected_format, expected_band_count, expected_ct,
     if expected_format is None:
         if mime_type is None:
             return 'success'
-        else:
-            return 'fail'
+        return 'fail'
 
     if expected_format == 'PNG':
         expected_mime_type = 'image/png'

--- a/autotest/gdrivers/hfa.py
+++ b/autotest/gdrivers/hfa.py
@@ -583,8 +583,7 @@ def hfa_mapinformation_units():
 
     if gdaltest.equal_srs_from_wkt(expected_wkt, wkt):
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Write nodata value.

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -144,10 +144,9 @@ def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=Non
     res = validate_jp2.validate(filename, oidoc, inspire_tg, expected_gmljp2, ogc_schemas_location)
     if return_error_count:
         return (res.error_count, res.warning_count)
-    elif res.error_count == 0 and res.warning_count == 0:
+    if res.error_count == 0 and res.warning_count == 0:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Open byte.jp2

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -1073,10 +1073,9 @@ def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=Non
     res = validate_jp2.validate(filename, oidoc, inspire_tg, expected_gmljp2, ogc_schemas_location)
     if return_error_count:
         return (res.error_count, res.warning_count)
-    elif res.error_count == 0 and res.warning_count == 0:
+    if res.error_count == 0 and res.warning_count == 0:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test INSPIRE_TG support

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -662,9 +662,8 @@ def netcdf_15():
         ds = gdal.Open('data/trmm-nc2.nc')
         if ds is None:
             return 'fail'
-        else:
-            ds = None
-            return 'success'
+        ds = None
+        return 'success'
     else:
         return 'skip'
 

--- a/autotest/gdrivers/netcdf_cf.py
+++ b/autotest/gdrivers/netcdf_cf.py
@@ -583,8 +583,7 @@ def netcdf_cf_1():
 
     if result != 'fail' and result_cf != 'fail':
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 
 ###############################################################################
@@ -602,8 +601,7 @@ def netcdf_cf_2():
 
     if result != 'fail' and result_cf != 'fail':
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 
 ###############################################################################
@@ -630,8 +628,7 @@ def netcdf_cf_3():
 
     if result != 'fail' and result_cf != 'fail':
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # test support for various CF projections

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -93,10 +93,7 @@ class CFVersion(object):
             self.tuple = value
 
     def __nonzero__(self):
-        if self.tuple:
-            return True
-        else:
-            return False
+        return bool(self.tuple)
 
     def __str__(self):
         return "CF-%s" % '.'.join(map(str, self.tuple))

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -581,12 +581,11 @@ class CFChecker:
         if self.err:
             # Return number of errors found
             return self.err
-        elif self.warn:
+        if self.warn:
             # No errors, but some warnings found
             return -(self.warn)
-        else:
-            # No errors or warnings - return success!
-            return 0
+        # No errors or warnings - return success!
+        return 0
 
         # -----------------------------
     def setUpAttributeList(self):
@@ -678,8 +677,7 @@ class CFChecker:
         bits = attDict[attName].split()
         if bits:
             return bits[0]
-        else:
-            return ""
+        return ""
 
         # -------------------------
     def getStdName(self, var):
@@ -696,13 +694,12 @@ class CFChecker:
         if len(bits) == 1:
             # Only standard_name part present
             return (bits[0], "")
-        elif len(bits) == 0:
+        if len(bits) == 0:
             # Standard Name is blank
             return ("", "")
-        else:
-            # At least 2 elements so return the first 2.
-            # If there are more than 2, which is invalid syntax, this will have been picked up by chkDescription()
-            return (bits[0], bits[1])
+        # At least 2 elements so return the first 2.
+        # If there are more than 2, which is invalid syntax, this will have been picked up by chkDescription()
+        return (bits[0], bits[1])
 
         # --------------------------------------------------
     def getInterpretation(self, units, positive=None):
@@ -1055,8 +1052,7 @@ class CFChecker:
         """Parse blank separated list"""
         if re.match("^[a-zA-Z0-9_ ]*$", lst):
             return 1
-        else:
-            return 0
+        return 0
 
         # -------------------------------------------
     def extendedBlankSeparatedList(self, lst):
@@ -1065,8 +1061,7 @@ class CFChecker:
         plus underscore '_', period '.', plus '+', hyphen '-', or "at" sign '@'."""
         if re.match("^[a-zA-Z0-9_ @\-\+\.]*$", lst):
             return 1
-        else:
-            return 0
+        return 0
 
         # -------------------------------------------
     def commaOrBlankSeparatedList(self, lst):
@@ -1075,8 +1070,7 @@ class CFChecker:
         characters plus underscore '_', period '.', plus '+', hyphen '-', or "at" sign '@'."""
         if re.match("^[a-zA-Z0-9_ @\-\+\.,]*$", lst):
             return 1
-        else:
-            return 0
+        return 0
 
         # ------------------------------
     def chkGlobalAttributes(self):
@@ -2441,15 +2435,14 @@ class CFChecker:
         if isinstance(arg, numpy.ndarray):
             return "array"
 
-        elif type(arg) == str:
+        if type(arg) == str:
             return "str"
 
-        elif type(arg) == list:
+        if type(arg) == list:
             return "list"
 
-        else:
-            print("<cfchecker> ERROR: Unknown Type in getType(" + arg + ")")
-            return 0
+        print("<cfchecker> ERROR: Unknown Type in getType(" + arg + ")")
+        return 0
 
         # ----------------------------------------
     def equalNumOfValues(self, arg1, arg2):

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -114,8 +114,8 @@ class CFVersion(object):
             else:
                 if in_o:  # and not in_s
                     return -1  # e.g. 3.2 < 3.2.1
-                else:  # not in_s and not in_o
-                    return 0  # e.g. 3.2 == 3.2
+                # not in_s and not in_o
+                return 0  # e.g. 3.2 == 3.2
             pos += 1
 
 

--- a/autotest/gdrivers/nwt_grd.py
+++ b/autotest/gdrivers/nwt_grd.py
@@ -52,8 +52,7 @@ def nwt_grd_1():
     status4 = tst4.testOpen()
     if status1 == 'success' and status2 == 'success' and status3 == 'success' and status4 == 'success':
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 
 def nwt_grd_2():

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -68,8 +68,7 @@ def pdf_is_poppler():
     val = gdal.GetConfigOption("GDAL_PDF_LIB", "POPPLER")
     if val == 'POPPLER' and 'HAVE_POPPLER' in md:
         return not pdf_is_pdfium()
-    else:
-        return False
+    return False
 
 ###############################################################################
 # Returns True if we run with pdfium
@@ -81,8 +80,7 @@ def pdf_is_pdfium():
     val = gdal.GetConfigOption("GDAL_PDF_LIB", "PDFIUM")
     if val == 'PDFIUM' and 'HAVE_PDFIUM' in md:
         return True
-    else:
-        return False
+    return False
 
 ###############################################################################
 # Returns True if we can compute the checksum

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -103,11 +103,10 @@ def pdf_checksum_available():
     if err.find('pdftoppm version') == 0:
         gdaltest.pdf_is_checksum_available = True
         return gdaltest.pdf_is_checksum_available
-    else:
-        print('Cannot compute to checksum due to missing pdftoppm')
-        print(err)
-        gdaltest.pdf_is_checksum_available = False
-        return gdaltest.pdf_is_checksum_available
+    print('Cannot compute to checksum due to missing pdftoppm')
+    print(err)
+    gdaltest.pdf_is_checksum_available = False
+    return gdaltest.pdf_is_checksum_available
 
 ###############################################################################
 # Test OGC best practice geospatial PDF

--- a/autotest/gdrivers/plmosaic.py
+++ b/autotest/gdrivers/plmosaic.py
@@ -50,8 +50,7 @@ def plmosaic_1():
 
     if gdaltest.plmosaic_drv is not None:
         return 'success'
-    else:
-        return 'skip'
+    return 'skip'
 
 ###############################################################################
 # Error: no API_KEY

--- a/autotest/gdrivers/postgisraster.py
+++ b/autotest/gdrivers/postgisraster.py
@@ -78,8 +78,7 @@ def postgisraster_test_open_error1():
                    "table='nonexistent'")
     if ds is None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 #
@@ -93,8 +92,7 @@ def postgisraster_test_open_error2():
     ds = gdal.Open(gdaltest.postgisraster_connection_string + "table='utm'")
     if ds is None:
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 #
@@ -111,10 +109,7 @@ def postgisraster_compare_utm():
     dst_ds = gdal.Open(dst_ds.GetMetadata('SUBDATASETS')['SUBDATASET_1_NAME'])
 
     diff = gdaltest.compare_ds(src_ds, dst_ds, width=100, height=100, verbose=1)
-    if diff == 0:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if diff == 0 else 'fail'
 
 ###############################################################################
 #
@@ -131,10 +126,7 @@ def postgisraster_compare_small_world():
     dst_ds = gdal.Open(dst_ds.GetMetadata('SUBDATASETS')['SUBDATASET_1_NAME'])
 
     diff = gdaltest.compare_ds(src_ds, dst_ds, width=40, height=20, verbose=1)
-    if diff == 0:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if diff == 0 else 'fail'
 
 ###############################################################################
 #
@@ -244,10 +236,7 @@ def postgisraster_test_create_copy_bad_conn_string():
 
     new_ds = gdaltest.postgisrasterDriver.CreateCopy("bogus connection string", src_ds, strict=True)
 
-    if new_ds is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if new_ds is None else 'fail'
 
 
 def postgisraster_test_create_copy_no_dbname():
@@ -262,10 +251,7 @@ def postgisraster_test_create_copy_no_dbname():
 
     new_ds = gdaltest.postgisrasterDriver.CreateCopy("PG: no database name", src_ds, strict=True, options=options)
 
-    if new_ds is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if new_ds is None else 'fail'
 
 
 def postgisraster_test_create_copy_no_tablename():
@@ -280,10 +266,7 @@ def postgisraster_test_create_copy_no_tablename():
 
     new_ds = gdaltest.postgisrasterDriver.CreateCopy(gdaltest.postgisraster_connection_string, src_ds, strict=True, options=options)
 
-    if new_ds is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if new_ds is None else 'fail'
 
 
 def postgisraster_test_create_copy_and_delete():
@@ -303,10 +286,7 @@ def postgisraster_test_create_copy_and_delete():
 
     deleted = gdaltest.postgisrasterDriver.Delete(gdaltest.postgisraster_connection_string + "table='small_world_copy'")
 
-    if deleted:
-        return 'fail'
-    else:
-        return 'success'
+    return 'fail' if deleted else 'success'
 
 
 def postgisraster_test_create_copy_and_delete_phases():

--- a/autotest/gdrivers/rasdaman.py
+++ b/autotest/gdrivers/rasdaman.py
@@ -78,10 +78,7 @@ def rasdaman_2():
         return 'skip'
 
     ds = gdal.Open("rasdaman:query='select a[$x_lo:$x_hi,$y_lo:$y_hi] from notexisting as a'")
-    if ds is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if ds is None else 'fail'
 
 ###############################################################################
 # Test syntax error
@@ -92,10 +89,8 @@ def rasdaman_3():
         return 'skip'
 
     ds = gdal.Open("rasdaman:query='select'")
-    if ds is None:
-        return 'success'
-    else:
-        return 'fail'
+    
+    return 'success' if ds is None else 'fail'
 
 
 gdaltest_list = [

--- a/autotest/gdrivers/rasterlite.py
+++ b/autotest/gdrivers/rasterlite.py
@@ -88,8 +88,7 @@ def rasterlite_2():
             gdaltest.rasterlite_drv = None
             gdaltest.post_reason('Please upgrade your sqlite3 library to be able to read Rasterlite DBs!')
             return 'skip'
-        else:
-            return 'fail'
+        return 'fail'
 
     if ds.RasterCount != 3:
         gdaltest.post_reason('expected 3 bands')

--- a/autotest/gdrivers/wcs.py
+++ b/autotest/gdrivers/wcs.py
@@ -67,8 +67,7 @@ def wcs_1():
     gdaltest.wcs_ds = None
     if gdaltest.wcs_drv is None:
         return 'skip'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Open the GeoServer WCS service.
@@ -87,9 +86,8 @@ def wcs_2():
 
     if gdaltest.wcs_ds is not None:
         return 'success'
-    else:
-        gdaltest.post_reason('open failed.')
-        return 'fail'
+    gdaltest.post_reason('open failed.')
+    return 'fail'
 
 ###############################################################################
 # Check various things about the configuration.
@@ -198,9 +196,8 @@ def old_wcs_2():
 
     if gdaltest.wcs_ds is not None:
         return 'success'
-    else:
-        gdaltest.post_reason('open failed.')
-        return 'fail'
+    gdaltest.post_reason('open failed.')
+    return 'fail'
 
 ###############################################################################
 # Check various things about the configuration.
@@ -571,10 +568,8 @@ def wcs_6():
             else:
                 print(server + ' ' + version + ' non_scaled skipped (no response file)')
     webserver.server_stop(process, port)
-    if wcs_6_ok:
-        return 'success'
-    else:
-        return 'fail'
+    
+    return 'success' if  wcs_6_ok else 'fail'
 
 ###############################################################################
 

--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -50,8 +50,7 @@ def wms_1():
     gdaltest.wms_drv = gdal.GetDriverByName('WMS')
     if gdaltest.wms_drv is None:
         return 'skip'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Open the WMS dataset
@@ -77,9 +76,8 @@ def wms_2():
 
     if gdaltest.wms_ds is not None:
         return 'success'
-    else:
-        gdaltest.post_reason('open failed.')
-        return 'fail'
+    gdaltest.post_reason('open failed.')
+    return 'fail'
 
 ###############################################################################
 # Check various things about the configuration.

--- a/autotest/gdrivers/wmts.py
+++ b/autotest/gdrivers/wmts.py
@@ -56,8 +56,7 @@ def wmts_1():
         gdal.SetConfigOption('GDAL_DEFAULT_WMS_CACHE_PATH', '/vsimem/cache')
 
         return 'success'
-    else:
-        return 'skip'
+    return 'skip'
 
 ###############################################################################
 # Error: no URL and invalid GDAL_WMTS service file documents

--- a/autotest/ogr/ogr_avc.py
+++ b/autotest/ogr/ogr_avc.py
@@ -73,8 +73,7 @@ def ogr_avc_1():
 
     if avc_ds is not None:
         return check_content(avc_ds)
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Open AVCBin datasource.
@@ -89,8 +88,7 @@ def ogr_avc_2():
 
     if avc_ds is not None:
         return check_content(avc_ds)
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Try opening a compressed E00 (which is not supported)

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -46,8 +46,7 @@ def ogr_basic_1():
 
     if gdaltest.ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test Feature counting.

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -49,8 +49,7 @@ def ogr_csv_1():
 
     if gdaltest.csv_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_csw.py
+++ b/autotest/ogr/ogr_csw.py
@@ -59,9 +59,8 @@ def ogr_csw_init():
         gdaltest.csw_drv = None
         if gdal.GetLastErrorMsg().find('Xerces') != -1:
             return 'skip'
-        else:
-            gdaltest.post_reason('failed to open test file.')
-            return 'skip'
+        gdaltest.post_reason('failed to open test file.')
+        return 'skip'
 
     return 'success'
 

--- a/autotest/ogr/ogr_dgn.py
+++ b/autotest/ogr/ogr_dgn.py
@@ -150,10 +150,7 @@ def ogr_dgn_5():
     tr = ogrtest.check_features_against_list(gdaltest.dgn_lyr, 'Type', [15])
     gdaltest.dgn_lyr.SetAttributeFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Use spatial filter to just pick the big circle.
@@ -171,10 +168,7 @@ def ogr_dgn_6():
     tr = ogrtest.check_features_against_list(gdaltest.dgn_lyr, 'Type', [15])
     gdaltest.dgn_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Copy our small dgn file to a new dgn file.

--- a/autotest/ogr/ogr_dods.py
+++ b/autotest/ogr/ogr_dods.py
@@ -70,8 +70,7 @@ def ogr_dods_1():
         gdaltest.dods_ds = None
         gdaltest.post_reason('profiles layer missing, likely AIS stuff not working.')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Read a single feature from the profiles layer and verify a few things.

--- a/autotest/ogr/ogr_factory.py
+++ b/autotest/ogr/ogr_factory.py
@@ -56,8 +56,7 @@ def ogr_factory_1():
 
     if ogrtest.check_feature_geometry(geom, expected_geom):
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Test forceToPolygon()

--- a/autotest/ogr/ogr_feature.py
+++ b/autotest/ogr/ogr_feature.py
@@ -133,8 +133,7 @@ def check(feat, fieldname, value):
                              frames=3)
         feat.DumpReadable()
         return 0
-    else:
-        return 1
+    return 1
 
 ###############################################################################
 # Copy to Integer

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -209,8 +209,7 @@ def ogr_geojson_1():
 
     if gdaltest.geojson_drv is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test file-based DS with standalone "Point" feature object.

--- a/autotest/ogr/ogr_gml_fgd_read.py
+++ b/autotest/ogr/ogr_gml_fgd_read.py
@@ -60,9 +60,8 @@ def ogr_gml_fgd_1():
     if ds is None:
         if gdal.GetLastErrorMsg().find('Xerces') != -1:
             return 'skip'
-        else:
-            gdaltest.post_reason('failed to open test file.')
-            return 'fail'
+        gdaltest.post_reason('failed to open test file.')
+        return 'fail'
 
     # we have gml reader for fgd
     gdaltest.have_gml_fgd_reader = 1

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -55,9 +55,8 @@ def ogr_gml_1():
     if gml_ds is None:
         if gdal.GetLastErrorMsg().find('Xerces') != -1:
             return 'skip'
-        else:
-            gdaltest.post_reason('failed to open test file.')
-            return 'fail'
+        gdaltest.post_reason('failed to open test file.')
+        return 'fail'
 
     gdaltest.have_gml_reader = 1
 

--- a/autotest/ogr/ogr_gmt.py
+++ b/autotest/ogr/ogr_gmt.py
@@ -128,10 +128,7 @@ def ogr_gmt_3():
     gdaltest.gmt_lyr = None
     gdaltest.gmt_ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify reading of multilinestring file. (#3802)

--- a/autotest/ogr/ogr_index_test.py
+++ b/autotest/ogr/ogr_index_test.py
@@ -156,10 +156,7 @@ def ogr_index_5():
     expect = ['Value 5']
 
     tr = ogrtest.check_features_against_list(gdaltest.s_lyr, 'VALUE', expect)
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Check that indexable single string lookup works.
@@ -179,10 +176,8 @@ def ogr_index_6():
     expect = [5]
 
     tr = ogrtest.check_features_against_list(gdaltest.s_lyr, 'SKEY', expect)
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
+
 
 ###############################################################################
 # Check that range query that isn't currently implemented using index works.
@@ -196,10 +191,7 @@ def ogr_index_7():
 
     tr = ogrtest.check_features_against_list(gdaltest.s_lyr, 'SKEY', expect)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Try join again.
@@ -218,10 +210,7 @@ def ogr_index_8():
 
     gdaltest.p_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that dropping both indexes gets rid of them, and that results still

--- a/autotest/ogr/ogr_index_test.py
+++ b/autotest/ogr/ogr_index_test.py
@@ -129,10 +129,7 @@ def ogr_index_3():
 
     gdaltest.p_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Create an INDEX on the SKEY and VALUE field in the join table.

--- a/autotest/ogr/ogr_ingres.py
+++ b/autotest/ogr/ogr_ingres.py
@@ -134,10 +134,7 @@ def ogr_ingres_3():
     # automating this in the driver.
     read_feat = gdaltest.ingres_lyr.GetNextFeature()
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers without geometry.
@@ -156,10 +153,7 @@ def ogr_ingres_4():
 
     gdaltest.ingres_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -190,10 +184,7 @@ def ogr_ingres_5():
 
     gdaltest.ingres_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -216,10 +207,7 @@ def ogr_ingres_6():
 
     gdaltest.ingres_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test adding a new field.
@@ -266,10 +254,7 @@ def ogr_ingres_7():
 
     gdaltest.ingres_lyr.SetAttributeFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test deleting a feature.

--- a/autotest/ogr/ogr_join_test.py
+++ b/autotest/ogr/ogr_join_test.py
@@ -398,8 +398,7 @@ def ogr_join_16():
 
     if sql_lyr is None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test non-support of a secondarytable.fieldname in a order by clause
@@ -421,8 +420,7 @@ def ogr_join_17():
 
     if sql_lyr is None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test inverted order of fields in ON
@@ -460,8 +458,7 @@ def ogr_join_19():
 
     if sql_lyr is None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test unrecognized secondary field
@@ -481,8 +478,7 @@ def ogr_join_20():
 
     if sql_lyr is None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test unexpected secondary table
@@ -504,8 +500,7 @@ def ogr_join_21():
 
     if sql_lyr is None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test join with a complex expression as ON

--- a/autotest/ogr/ogr_join_test.py
+++ b/autotest/ogr/ogr_join_test.py
@@ -72,10 +72,7 @@ def ogr_join_2():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Try various naming conversions for the selected fields.
@@ -94,10 +91,7 @@ def ogr_join_3():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that records for which a join can't be found work ok.
@@ -116,10 +110,7 @@ def ogr_join_4():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that table aliases work
@@ -138,10 +129,7 @@ def ogr_join_5():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Again, ordering by a primary field.
@@ -160,10 +148,7 @@ def ogr_join_6():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test joining to an external datasource.
@@ -182,10 +167,7 @@ def ogr_join_7():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test doing two joins at once.
@@ -205,10 +187,7 @@ def ogr_join_8():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify fix for #2788 (memory corruption on wildcard expansion in SQL request
@@ -228,10 +207,7 @@ def ogr_join_9():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 
@@ -248,10 +224,7 @@ def ogr_join_10():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test join on string field
@@ -268,10 +241,7 @@ def ogr_join_11():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test fix for #4112 (join between 2 datasources)
@@ -308,10 +278,7 @@ def ogr_join_13():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test joining a string column with a float column (#4321, actually addressed by #4259)
@@ -329,10 +296,7 @@ def ogr_join_14():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test multiple joins with expressions (#4521)

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -134,10 +134,7 @@ def ogr_mem_3():
     gdaltest.poly_feat = None
     gdaltest.shp_ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write more features with a bunch of different geometries, and verify the
@@ -192,10 +189,7 @@ def ogr_mem_5():
 
     gdaltest.mem_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -218,10 +212,7 @@ def ogr_mem_6():
 
     gdaltest.mem_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -248,10 +239,7 @@ def ogr_mem_7():
 
     gdaltest.mem_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test adding a new field.
@@ -292,10 +280,7 @@ def ogr_mem_8():
 
     gdaltest.mem_lyr.SetAttributeFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test deleting a feature.

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -53,8 +53,7 @@ def ogr_mitab_1():
 
     if gdaltest.mapinfo_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Create table from data/poly.shp
@@ -148,10 +147,7 @@ def ogr_mitab_3():
     gdaltest.poly_feat = None
     gdaltest.shp_ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -174,10 +170,7 @@ def ogr_mitab_4():
 
     gdaltest.mapinfo_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -198,10 +191,7 @@ def ogr_mitab_5():
 
     gdaltest.mapinfo_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that Non-WGS84 datums are populated correctly
@@ -234,8 +224,7 @@ def ogr_mitab_7():
 
     if gdaltest.mapinfo_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Create table from data/poly.shp
@@ -319,10 +308,7 @@ def ogr_mitab_9():
     gdaltest.poly_feat = None
     gdaltest.shp_ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Read mif file with 2 character .mid delimiter and verify operation.

--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -62,8 +62,7 @@ def ogr_mysql_1():
     gdaltest.mysql_ds = ogr.Open('MYSQL:autotest', update=1)
     if gdaltest.mysql_ds is not None:
         return 'success'
-    else:
-        return 'skip'
+    return 'skip'
 
 ###############################################################################
 # Create table from data/poly.shp
@@ -172,10 +171,7 @@ def ogr_mysql_3():
     gdaltest.poly_feat = None
     gdaltest.shp_ds.Destroy()
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write more features with a bunch of different geometries, and verify the
@@ -262,10 +258,7 @@ def ogr_mysql_5():
 
     gdaltest.mysql_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -302,10 +295,7 @@ def ogr_mysql_6():
 
     gdaltest.mysql_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -340,10 +330,7 @@ def ogr_mysql_7():
 
     gdaltest.mysql_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write a feature with too long a text value for a fixed length text field.
@@ -496,10 +483,7 @@ def ogr_mysql_15():
                                              'eas_id', expect)
     gdaltest.mysql_lyr.SetAttributeFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 ###############################################################################
@@ -525,10 +509,7 @@ def ogr_mysql_16():
 
     gdaltest.mysql_ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test requesting a non-existent table by name (bug 1480).
@@ -627,8 +608,7 @@ def ogr_mysql_20():
     feat = layer.GetNextFeature()
     if feat.desc == 'desc' and feat.select == 'select':
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Test inserting NULL geometries into a table with a spatial index -> must FAIL

--- a/autotest/ogr/ogr_oci.py
+++ b/autotest/ogr/ogr_oci.py
@@ -57,8 +57,7 @@ def ogr_oci_1():
 
     if gdaltest.oci_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Create Oracle table from data/poly.shp
@@ -180,10 +179,7 @@ def ogr_oci_3():
     gdaltest.poly_feat = None
     gdaltest.shp_ds.Destroy()
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write more features with a bunch of different geometries, and verify the
@@ -244,10 +240,7 @@ def ogr_oci_5():
 
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -273,10 +266,7 @@ def ogr_oci_6():
 
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -299,10 +289,7 @@ def ogr_oci_7():
 
     gdaltest.oci_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test that we can create a layer with a coordinate system that is mapped
@@ -444,10 +431,7 @@ SDO_ORDINATE_ARRAY(1,1, 5,7) -- only 2 points needed to
     feat_read.Destroy()
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test handling of specialized Oracle circle Geometries.
@@ -486,10 +470,7 @@ SDO_ORDINATE_ARRAY(8,7, 10,9, 8,11)
     feat_read.Destroy()
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test handling of specialized Oracle circular arc linestring Geometries.
@@ -527,10 +508,8 @@ SDO_ORDINATE_ARRAY(0,0, 1,1, 0,2, -1,3, 0,4, 2,2, 0,0 )
     feat_read.Destroy()
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
+
 ###############################################################################
 # Test handling of specialized Oracle circular arc polygon Geometries.
 
@@ -568,10 +547,7 @@ SDO_ORDINATE_ARRAY(0,0, 1,1, 0,2, -1,3, 0,4, 2,2, 0,0 )
     feat_read.Destroy()
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test handling of compount linestring.
@@ -610,10 +586,7 @@ SDO_ORDINATE_ARRAY(10,10, 10,14, 6,10, 14,10)
     feat_read.Destroy()
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test handling of compount polygon.
@@ -652,10 +625,7 @@ SDO_ORDINATE_ARRAY(-10,10, 10,10, 0,0, -10,10)
     feat_read.Destroy()
     gdaltest.oci_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test deleting an existing layer.

--- a/autotest/ogr/ogr_pdf.py
+++ b/autotest/ogr/ogr_pdf.py
@@ -241,8 +241,7 @@ def ogr_pdf_4_podofo():
         ret = ogr_pdf_4()
         gdal.SetConfigOption("GDAL_PDF_LIB", None)
         return ret
-    else:
-        return 'skip'
+    return 'skip'
 
 ###############################################################################
 # Test read support with OGR_PDF_READ_NON_STRUCTURED=YES

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -273,10 +273,7 @@ def ogr_pg_3():
 
     gdaltest.poly_feat = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write more features with a bunch of different geometries, and verify the
@@ -345,10 +342,7 @@ def ogr_pg_5():
 
     gdaltest.pg_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -386,10 +380,7 @@ def ogr_pg_6():
 
     gdaltest.pg_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -424,10 +415,7 @@ def ogr_pg_7():
 
     gdaltest.pg_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write a feature with too long a text value for a fixed length text field.
@@ -787,10 +775,8 @@ def ogr_pg_15():
                                              'eas_id', expect)
     gdaltest.pg_lyr.SetAttributeFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
+
 
 
 ###############################################################################
@@ -816,10 +802,7 @@ def ogr_pg_16():
 
     gdaltest.pg_ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test requesting a non-existent table by name (bug 1480).

--- a/autotest/ogr/ogr_plscenes.py
+++ b/autotest/ogr/ogr_plscenes.py
@@ -48,8 +48,7 @@ def ogr_plscenes_init():
 
     if gdaltest.plscenes_drv is not None:
         return 'success'
-    else:
-        return 'skip'
+    return 'skip'
 
 ###############################################################################
 # Test Data V1 API catalog listing with a single catalog

--- a/autotest/ogr/ogr_selafin.py
+++ b/autotest/ogr/ogr_selafin.py
@@ -57,8 +57,7 @@ def ogr_selafin_create_ds():
 
     if gdaltest.selafin_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Add a few points to the datasource

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -53,8 +53,7 @@ def ogr_shape_1():
 
     if gdaltest.shape_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Create table from data/poly.shp
@@ -132,10 +131,7 @@ def ogr_shape_3():
 
     gdaltest.poly_feat = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write a feature without a geometry, and verify that it works OK.
@@ -187,10 +183,7 @@ def ogr_shape_5():
 
     gdaltest.shape_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -213,10 +206,7 @@ def ogr_shape_6():
 
     gdaltest.shape_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -239,10 +229,7 @@ def ogr_shape_7():
 
     gdaltest.shape_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Create spatial index, and verify we get the same results.
@@ -320,10 +307,7 @@ def ogr_shape_10():
     tr = ogrtest.check_features_against_list(gdaltest.shape_lyr, 'FID',
                                              [0, 4, 8])
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Do a mixed indexed attribute and spatial query.
@@ -352,10 +336,7 @@ def ogr_shape_11():
     gdaltest.shape_lyr.SetAttributeFilter(None)
     gdaltest.shape_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Check that multipolygon of asm.shp is properly returned.

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -288,10 +288,9 @@ def ogr_shape_9():
 
     if ogrtest.have_geos() and gdaltest.shape_lyr.GetFeatureCount() == 0:
         return 'success'
-    elif not ogrtest.have_geos() and gdaltest.shape_lyr.GetFeatureCount() == 1:
+    if not ogrtest.have_geos() and gdaltest.shape_lyr.GetFeatureCount() == 1:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Do a fair size query that should pull in a few shapes.
@@ -882,8 +881,7 @@ def ogr_shape_23_write_geom(layer_name, geom, expected_geom, wkbType):
         if feat_read.GetGeometryRef() is not None:
             print(feat_read.GetGeometryRef().ExportToWkt())
             return 'fail'
-        else:
-            return 'success'
+        return 'success'
 
     if ogrtest.check_feature_geometry(feat_read, expected_geom,
                                       max_error=0.000000001) != 0:

--- a/autotest/ogr/ogr_sql_rfc28.py
+++ b/autotest/ogr/ogr_sql_rfc28.py
@@ -178,10 +178,7 @@ def ogr_rfc28_8_wrong_quoting():
 
     gdaltest.ds.ReleaseResultSet(ql)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 def ogr_rfc28_8_good_quoting():
@@ -197,10 +194,7 @@ def ogr_rfc28_8_good_quoting():
 
     gdaltest.ds.ReleaseResultSet(ql)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test with quoted funky (non-identifier) name.
@@ -218,10 +212,7 @@ def ogr_rfc28_9():
 
     expect = ['8902']
     tr = ogrtest.check_features_against_list(lyr, 'PRIME_MERIDIAN_CODE', expect)
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 # TODO: unparse quoting?
 ###############################################################################
@@ -241,10 +232,7 @@ def ogr_rfc28_10():
     tr = ogrtest.check_features_against_list(lyr, 'PRIME_MERIDIAN_CODE', expect)
     ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # test quoted funky names in output columns list.
@@ -263,10 +251,7 @@ def ogr_rfc28_11():
     tr = ogrtest.check_features_against_list(lyr, 'Funky @Name', expect)
     ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # test selecting fixed string fields.
@@ -295,10 +280,7 @@ def ogr_rfc28_12():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test SUBSTR operator in the context of a WHERE clause.
@@ -327,10 +309,7 @@ def ogr_rfc28_14():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test CONCAT with more than two arguments.
@@ -344,10 +323,7 @@ def ogr_rfc28_15():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test parse support for negative numbers (#3724)
@@ -377,10 +353,7 @@ def ogr_rfc28_16():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test evaluation of division - had a problem with type conversion.
@@ -406,10 +379,7 @@ def ogr_rfc28_17():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 ###############################################################################
@@ -427,10 +397,7 @@ def ogr_rfc28_18():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 ###############################################################################
@@ -611,10 +578,7 @@ def ogr_rfc28_26():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test that we correctly let floating point values as floating point, and not as integer (#4634)"
@@ -628,10 +592,7 @@ def ogr_rfc28_27():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if count == 10:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if count == 10 else 'fail'
 
 ###############################################################################
 # Extensive test of the evaluation of arithmetic and logical operators
@@ -743,10 +704,7 @@ def ogr_rfc28_29():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if count == 0:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if count == 0 else 'fail'
 
 ###############################################################################
 # Test behaviour of binary operations on strings when one operand is a NULL value
@@ -760,10 +718,7 @@ def ogr_rfc28_30():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if count == 0:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if count == 0 else 'fail'
 
 ###############################################################################
 # Test UNION ALL
@@ -777,10 +732,8 @@ def ogr_rfc28_31():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if count != 6 + 7:
-        return 'success'
-    else:
-        return 'fail'
+    
+    return 'success' if count != 6 + 7 else 'fail'
 
 ###############################################################################
 # Test UNION ALL with parenthesis
@@ -794,10 +747,7 @@ def ogr_rfc28_32():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if count != 6 + 7:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if count != 6 + 7 else 'fail'
 
 ###############################################################################
 # Test lack of end-of-string character
@@ -809,10 +759,7 @@ def ogr_rfc28_33():
     lyr = gdaltest.ds.ExecuteSQL("select * from idlink where name='foo")
     gdal.PopErrorHandler()
 
-    if lyr is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if lyr is None else 'fail'
 
 ###############################################################################
 # Test wildcard expansion of an unknown table.
@@ -828,10 +775,7 @@ def ogr_rfc28_34():
         print(gdal.GetLastErrorMsg())
         return 'fail'
 
-    if lyr is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if lyr is None else 'fail'
 
 ###############################################################################
 # Test selecting more than one distinct
@@ -846,10 +790,7 @@ def ogr_rfc28_35():
         print(gdal.GetLastErrorMsg())
         return 'fail'
 
-    if lyr is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if lyr is None else 'fail'
 
 ###############################################################################
 # Test selecting more than one distinct
@@ -864,10 +805,7 @@ def ogr_rfc28_35_bis():
         print(gdal.GetLastErrorMsg())
         return 'fail'
 
-    if lyr is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if lyr is None else 'fail'
 
 ###############################################################################
 # Test selecting more than one distinct
@@ -882,10 +820,7 @@ def ogr_rfc28_35_ter():
         print(gdal.GetLastErrorMsg())
         return 'fail'
 
-    if lyr is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if lyr is None else 'fail'
 
 ###############################################################################
 # Test ORDER BY a DISTINCT list by more than one key
@@ -963,10 +898,7 @@ def ogr_rfc28_39():
 
     gdaltest.ds.ReleaseResultSet(lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test MIN(), MAX() and AVG() on a date (#5333)

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -1050,7 +1050,7 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 <!-- nws03.maps.bf1.yahoo.com uncompressed/chunked Sat Dec 29 04:59:06 PST 2012 -->
 <!-- wws09.geotech.bf1.yahoo.com uncompressed/chunked Sat Dec 29 04:59:06 PST 2012 -->""".encode('ascii'))
                     return
-                elif self.path == '/yahoogeocoding?q=NonExistingPlace':
+                if self.path == '/yahoogeocoding?q=NonExistingPlace':
                     self.send_response(200)
                     self.send_header('Content-type', 'application/xml')
                     self.end_headers()
@@ -1059,9 +1059,8 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 <!-- wws08.geotech.bf1.yahoo.com uncompressed/chunked Sat Dec 29 05:00:45 PST 2012 -->""".encode('ascii'))
                     return
 
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             elif self.path.find('/geonamesgeocoding') != -1:
                 if self.path == '/geonamesgeocoding?q=Paris&username=demo':
@@ -1084,7 +1083,7 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 </geoname>
 </geonames>""".encode('ascii'))
                     return
-                elif self.path == '/geonamesgeocoding?q=NonExistingPlace&username=demo':
+                if self.path == '/geonamesgeocoding?q=NonExistingPlace&username=demo':
                     self.send_response(200)
                     self.send_header('Content-type', 'application/xml')
                     self.end_headers()
@@ -1094,9 +1093,8 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 </geonames>""".encode('ascii'))
                     return
 
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             elif self.path.find('/binggeocoding') != -1:
                 if self.path == '/binggeocoding?q=Paris&key=fakekey':
@@ -1139,7 +1137,7 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
   </ResourceSets>
 </Response>""".encode('ascii'))
                     return
-                elif self.path == '/binggeocoding?q=NonExistingPlace&key=fakekey':
+                if self.path == '/binggeocoding?q=NonExistingPlace&key=fakekey':
                     self.send_response(200)
                     self.send_header('Content-type', 'application/xml')
                     self.end_headers()
@@ -1153,9 +1151,8 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 </Response>""".encode('ascii'))
                     return
 
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             # Below is for reverse geocoding
             elif self.path.find('/reversegeocoding') != -1:
@@ -1179,9 +1176,8 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
   </addressparts>
 </reversegeocode>""".encode('ascii'))
                     return
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             elif self.path.find('/yahooreversegeocoding') != -1:
                 if self.path == '/yahooreversegeocoding?q=49.00000000,2.00000000&gflags=R':

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -626,10 +626,7 @@ def ogr_sql_sqlite_8():
 
     ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Check parsing of sub-selects
@@ -1035,15 +1032,14 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
   </place>
 </searchresults>""".encode('ascii'))
                     return
-                elif self.path == '/geocoding?q=NonExistingPlace&addressdetails=1&limit=1&email=foo%40bar':
+                if self.path == '/geocoding?q=NonExistingPlace&addressdetails=1&limit=1&email=foo%40bar':
                     self.send_response(200)
                     self.send_header('Content-type', 'application/xml')
                     self.end_headers()
                     self.wfile.write("""<?xml version="1.0" encoding="UTF-8"?><searchresults></searchresults>""".encode('ascii'))
                     return
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             elif self.path.find('/yahoogeocoding') != -1:
                 if self.path == '/yahoogeocoding?q=Paris':
@@ -1196,9 +1192,8 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 <!-- nws02.maps.bf1.yahoo.com uncompressed/chunked Sat Dec 29 05:03:31 PST 2012 -->
 <!-- wws05.geotech.bf1.yahoo.com uncompressed/chunked Sat Dec 29 05:03:31 PST 2012 -->""".encode('ascii'))
                     return
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             elif self.path.find('/geonamesreversegeocoding') != -1:
                 if self.path == '/geonamesreversegeocoding?lat=49.00000000&lng=2.00000000&username=demo':
@@ -1221,9 +1216,8 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 </geoname>
 </geonames>""".encode('ascii'))
                     return
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             elif self.path.find('/bingreversegeocoding') != -1:
                 if self.path == '/bingreversegeocoding?49.00000000,2.00000000&key=fakekey':
@@ -1266,9 +1260,8 @@ class GeocodingHTTPHandler(BaseHTTPRequestHandler):
   </ResourceSets>
 </Response>""".encode('ascii'))
                     return
-                else:
-                    self.send_error(404, 'File Not Found: %s' % self.path)
-                    return
+                self.send_error(404, 'File Not Found: %s' % self.path)
+                return
 
             return
         except IOError:

--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -302,10 +302,7 @@ def ogr_sql_14():
     ds.ReleaseResultSet(sql_lyr)
     ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that selecting with filtering by FID works properly.
@@ -321,10 +318,7 @@ def ogr_sql_15():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 
@@ -341,10 +335,7 @@ def ogr_sql_16():
     ds.ReleaseResultSet(sql_lyr)
     ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 ###############################################################################
@@ -396,10 +387,7 @@ def ogr_sql_17():
     ds.ReleaseResultSet(sql_lyr)
     ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 ###############################################################################
@@ -667,10 +655,7 @@ def ogr_sql_27():
     ds.ReleaseResultSet(sql_lyr)
     ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 ###############################################################################
@@ -911,10 +896,7 @@ def ogr_sql_30():
     if gdal.GetLastErrorMsg() != '':
         return 'fail'
 
-    if val_count == 10:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if val_count == 10 else 'fail'
 
 ###############################################################################
 # Regression test for #4022
@@ -934,10 +916,7 @@ def ogr_sql_31():
     if gdal.GetLastErrorMsg() != '':
         return 'fail'
 
-    if val is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if val is None else 'fail'
 
 ###############################################################################
 # Regression test for #4022 (same as above, but with dialect = 'OGRSQL')
@@ -958,10 +937,7 @@ def ogr_sql_32():
     if gdal.GetLastErrorMsg() != '':
         return 'fail'
 
-    if val is None:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if val is None else 'fail'
 
 ###############################################################################
 # Check ALTER TABLE commands
@@ -1052,10 +1028,7 @@ def ogr_sql_35():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if count_cols == 1024:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if count_cols == 1024 else 'fail'
 
 ###############################################################################
 # Test select distinct on null values (#4353)
@@ -1222,9 +1195,8 @@ def ogr_sql_38():
 
     if abs(val - 1634833.39062) < 1e-5:
         return 'success'
-    else:
-        print(val)
-        return 'fail'
+    print(val)
+    return 'fail'
 
 ###############################################################################
 # Test ORDER BY on a float special field
@@ -1241,9 +1213,8 @@ def ogr_sql_39():
 
     if abs(val - 5268.813) < 1e-5:
         return 'success'
-    else:
-        print(val)
-        return 'fail'
+    print(val)
+    return 'fail'
 
 ###############################################################################
 # Test ORDER BY on a int special field
@@ -1257,10 +1228,7 @@ def ogr_sql_40():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if feat.GetFID() == 9:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if feat.GetFID() == 9 else 'fail'
 
 ###############################################################################
 # Test ORDER BY on a string special field
@@ -1274,10 +1242,7 @@ def ogr_sql_41():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if feat.GetFID() == 0:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if feat.GetFID() == 0 else 'fail'
 
 ###############################################################################
 # Test comparing to empty string

--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -73,10 +73,7 @@ def ogr_sql_2():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ORDER BY handling
@@ -92,10 +89,7 @@ def ogr_sql_3():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ORDER BY DESC handling
@@ -111,10 +105,7 @@ def ogr_sql_3_desc():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test DISTINCT and ORDER BY on strings.
@@ -130,10 +121,7 @@ def ogr_sql_4():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test column functions.
@@ -181,10 +169,7 @@ def ogr_sql_6():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that selecting the FID works properly.
@@ -200,10 +185,7 @@ def ogr_sql_7():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that wildcard expansion works properly.
@@ -219,10 +201,7 @@ def ogr_sql_8():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify that quoted table names work.
@@ -238,10 +217,7 @@ def ogr_sql_9():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test the ILIKE operator.
@@ -257,10 +233,7 @@ def ogr_sql_10():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test MAX() on empty dataset.
@@ -276,10 +249,7 @@ def ogr_sql_11():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test DISTINCT on empty dataset.
@@ -295,10 +265,7 @@ def ogr_sql_12():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify selection of, and on ogr_geometry.
@@ -315,10 +282,7 @@ def ogr_sql_13():
 
     gdaltest.ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Verify selection of, and on ogr_style and ogr_geom_wkt.

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -76,8 +76,7 @@ def ogr_sqlite_1():
 
     if gdaltest.sl_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Create table from data/poly.shp
@@ -244,10 +243,7 @@ def ogr_sqlite_3():
     gdaltest.poly_feat = None
     gdaltest.shp_ds = None
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Write more features with a bunch of different geometries, and verify the
@@ -311,10 +307,7 @@ def ogr_sqlite_5():
 
     gdaltest.sl_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test ExecuteSQL() results layers with geometry.
@@ -336,10 +329,7 @@ def ogr_sqlite_6():
 
     gdaltest.sl_ds.ReleaseResultSet(sql_lyr)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test spatial filtering.
@@ -374,10 +364,7 @@ def ogr_sqlite_7():
 
     gdaltest.sl_lyr.SetSpatialFilter(None)
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test transactions with rollback.
@@ -1757,10 +1744,7 @@ def ogr_spatialite_3():
 
     ds.Destroy()
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test updating a spatialite DB (#3471 and #3474)

--- a/autotest/ogr/ogr_sxf.py
+++ b/autotest/ogr/ogr_sxf.py
@@ -46,8 +46,7 @@ def ogr_sxf_1():
 
     if gdaltest.sxf_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_vrt.py
+++ b/autotest/ogr/ogr_vrt.py
@@ -51,8 +51,7 @@ def ogr_vrt_1():
 
     if gdaltest.vrt_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Verify the geometries, in the "test2" layer based on x,y,z columns.

--- a/autotest/ogr/ogr_wasp.py
+++ b/autotest/ogr/ogr_wasp.py
@@ -53,8 +53,7 @@ def ogr_wasp_create_ds():
 
     if gdaltest.wasp_ds is not None:
         return 'success'
-    else:
-        return 'fail'
+    return 'fail'
 
 ###############################################################################
 # Create elevation .map from linestrings z
@@ -325,8 +324,7 @@ def ogr_wasp_roughness_from_polygon_z():
         if ogrtest.have_geos():
             gdaltest.post_reason('unable to create layer')
             return 'fail'
-        else:
-            return 'success'
+        return 'success'
 
     dfn = ogr.FeatureDefn()
 
@@ -397,8 +395,7 @@ def ogr_wasp_roughness_from_polygon_field():
         if ogrtest.have_geos():
             gdaltest.post_reason('unable to create layer')
             return 'fail'
-        else:
-            return 'success'
+        return 'success'
 
     layer.CreateField(ogr.FieldDefn('roughness', ogr.OFTReal))
     layer.CreateField(ogr.FieldDefn('dummy', ogr.OFTString))
@@ -472,8 +469,7 @@ def ogr_wasp_merge():
         if ogrtest.have_geos():
             gdaltest.post_reason('unable to create layer')
             return 'fail'
-        else:
-            return 'success'
+        return 'success'
 
     dfn = ogr.FeatureDefn()
 

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -68,9 +68,8 @@ def ogr_wfs_init():
         gdaltest.wfs_drv = None
         if gdal.GetLastErrorMsg().find('Xerces') != -1:
             return 'skip'
-        else:
-            gdaltest.post_reason('failed to open test file.')
-            return 'skip'
+        gdaltest.post_reason('failed to open test file.')
+        return 'skip'
 
     return 'success'
 

--- a/autotest/ogr/ogr_wktempty.py
+++ b/autotest/ogr/ogr_wktempty.py
@@ -63,8 +63,7 @@ class TestWktEmpty:
         if wkt == self.expectedOutString:
             if self.isEmpty(geom) == 'fail':
                 return 'fail'
-            else:
-                return 'success'
+            return 'success'
         else:
             gdaltest.post_reason('WKT is wrong: ' + wkt + '. Expected value is: ' + self.expectedOutString)
             return 'fail'

--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -67,9 +67,8 @@ def osr_ct_1():
         if gdal.GetLastErrorMsg().find('Unable to load PROJ.4') != -1:
             gdaltest.post_reason('PROJ.4 missing, transforms not available.')
             return 'skip'
-        else:
-            gdaltest.post_reason(gdal.GetLastErrorMsg())
-            return 'fail'
+        gdaltest.post_reason(gdal.GetLastErrorMsg())
+        return 'fail'
 
     if ct is None or ct.this is None:
         gdaltest.post_reason('Unable to create simple CoordinateTransformat.')
@@ -103,8 +102,7 @@ def osr_ct_2():
        or abs(result[2] - 0.0) > 0.01:
         gdaltest.post_reason('Wrong LL to UTM result')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Transform an OGR geometry ... this is mostly aimed at ensuring that

--- a/autotest/osr/osr_ct_proj.py
+++ b/autotest/osr/osr_ct_proj.py
@@ -102,9 +102,8 @@ class ProjTest:
             if gdal.GetLastErrorMsg().find('Unable to load PROJ.4') != -1:
                 gdaltest.post_reason('PROJ.4 missing, transforms not available.')
                 return 'skip'
-            else:
-                gdaltest.post_reason('failed to create coordinate transformation. %s' % gdal.GetLastErrorMsg())
-                return 'fail'
+            gdaltest.post_reason('failed to create coordinate transformation. %s' % gdal.GetLastErrorMsg())
+            return 'fail'
         except:
             gdal.PopErrorHandler()
             gdaltest.post_reason('failed to create coordinate transformation. %s' % gdal.GetLastErrorMsg())

--- a/autotest/osr/osr_metacrs.py
+++ b/autotest/osr/osr_metacrs.py
@@ -99,12 +99,10 @@ class MetaCRSTest:
             srs = osr.SpatialReference()
             if srs.ImportFromEPSGA(int(crstext)) == 0:
                 return srs
-            else:
-                gdaltest.post_reason('failed to translate EPSG:' + crstext)
-                return None
-        else:
-            gdaltest.post_reason('unsupported srs type: ' + typ)
+            gdaltest.post_reason('failed to translate EPSG:' + crstext)
             return None
+        gdaltest.post_reason('unsupported srs type: ' + typ)
+        return None
 
     def testMetaCRS(self):
         result = self.parse_line()
@@ -123,9 +121,8 @@ class MetaCRSTest:
             if gdal.GetLastErrorMsg().find('Unable to load PROJ.4') != -1:
                 gdaltest.post_reason('PROJ.4 missing, transforms not available.')
                 return 'skip'
-            else:
-                gdaltest.post_reason('failed to create coordinate transformation. %s' % gdal.GetLastErrorMsg())
-                return 'fail'
+            gdaltest.post_reason('failed to create coordinate transformation. %s' % gdal.GetLastErrorMsg())
+            return 'fail'
         except:
             gdal.PopErrorHandler()
             gdaltest.post_reason('failed to create coordinate transformation. %s' % gdal.GetLastErrorMsg())

--- a/autotest/osr/osr_url.py
+++ b/autotest/osr/osr_url.py
@@ -59,9 +59,8 @@ def osr_url_test(url, expected_wkt):
         if gdal.GetLastErrorMsg() == "GDAL/OGR not compiled with libcurl support, remote requests not supported." or \
            gdal.GetLastErrorMsg().find("timed out") != -1:
             return 'skip'
-        else:
-            gdaltest.post_reason('exception: ' + gdal.GetLastErrorMsg())
-            return 'fail'
+        gdaltest.post_reason('exception: ' + gdal.GetLastErrorMsg())
+        return 'fail'
 
     gdal.PopErrorHandler()
     if gdal.GetLastErrorMsg() == "GDAL/OGR not compiled with libcurl support, remote requests not supported." or \

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -376,10 +376,7 @@ def clean_tmp():
 
 def testCreateCopyInterruptCallback(pct, message, user_data):
     # pylint: disable=unused-argument
-    if pct > 0.5:
-        return 0  # to stop
-    else:
-        return 1  # to continue
+    return pct <= 0.5
 
 ###############################################################################
 

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -607,12 +607,11 @@ class GDALTest:
 
         if skip_checksum is not None:
             return 'success'
-        elif self.chksum is None or chksum == self.chksum:
+        if self.chksum is None or chksum == self.chksum:
             return 'success'
-        else:
-            post_reason('Checksum for band %d in "%s" is %d, but expected %d.'
-                        % (self.band, self.filename, chksum, self.chksum))
-            return 'fail'
+        post_reason('Checksum for band %d in "%s" is %d, but expected %d.'
+                    % (self.band, self.filename, chksum, self.chksum))
+        return 'fail'
 
     def testCreateCopy(self, check_minmax=1, check_gt=0, check_srs=None,
                        vsimem=0, new_filename=None, strict_in=0,
@@ -665,11 +664,10 @@ class GDALTest:
                 self.driver.Delete(new_filename)
                 gdal.PopErrorHandler()
                 return 'success'
-            else:
-                post_reason('CreateCopy() should have failed due to interruption')
-                new_ds = None
-                self.driver.Delete(new_filename)
-                return 'fail'
+            post_reason('CreateCopy() should have failed due to interruption')
+            new_ds = None
+            self.driver.Delete(new_filename)
+            return 'fail'
 
         if new_ds is None:
             post_reason('Failed to create test file using CreateCopy method.' +
@@ -1205,8 +1203,7 @@ def approx_equal(a, b):
 
     if abs(b / a - 1.0) > .00000000001:
         return 0
-    else:
-        return 1
+    return 1
 
 
 def user_srs_to_wkt(user_text):
@@ -1224,12 +1221,11 @@ def equal_srs_from_wkt(expected_wkt, got_wkt):
 
     if got_srs.IsSame(expected_srs):
         return 1
-    else:
-        print('Expected:\n%s' % expected_wkt)
-        print('Got:     \n%s' % got_wkt)
+    print('Expected:\n%s' % expected_wkt)
+    print('Got:     \n%s' % got_wkt)
 
-        post_reason('SRS differs from expected.')
-        return 0
+    post_reason('SRS differs from expected.')
+    return 0
 
 ###############################################################################
 # Compare two sets of RPC metadata, and establish if they are essentially
@@ -1622,10 +1618,8 @@ def isnan(val):
         val_str = '%f' % val
         if val_str == 'nan':
             return True
-        else:
-            return False
-    else:
-        return True
+        return False
+    return True
 
 
 ###############################################################################
@@ -1887,14 +1881,13 @@ def find_lib_windows(libname):
 def find_lib(mylib):
     if sys.platform.startswith('linux'):
         return find_lib_linux(mylib)
-    elif sys.platform.startswith('sunos'):
+    if sys.platform.startswith('sunos'):
         return find_lib_sunos(mylib)
-    elif sys.platform.startswith('win32'):
+    if sys.platform.startswith('win32'):
         return find_lib_windows(mylib)
-    else:
-        # sorry mac users or other BSDs
-        # should be doable
-        return None
+    # sorry mac users or other BSDs
+    # should be doable
+    return None
 
 ###############################################################################
 # get_opened_files()

--- a/autotest/pymod/test_cli_utilities.py
+++ b/autotest/pymod/test_cli_utilities.py
@@ -91,9 +91,8 @@ def get_cli_utility_path(cli_utility_name):
     global cli_exe_path
     if cli_utility_name in cli_exe_path:
         return cli_exe_path[cli_utility_name]
-    else:
-        cli_exe_path[cli_utility_name] = get_cli_utility_path_internal(cli_utility_name)
-        return cli_exe_path[cli_utility_name]
+    cli_exe_path[cli_utility_name] = get_cli_utility_path_internal(cli_utility_name)
+    return cli_exe_path[cli_utility_name]
 
 ###############################################################################
 #

--- a/autotest/pymod/test_py_scripts.py
+++ b/autotest/pymod/test_py_scripts.py
@@ -81,8 +81,7 @@ def run_py_script(script_path, script_name, concatenated_argv):
 
     if run_as_external_script == 'yes' or run_as_external_script == 'YES':
         return run_py_script_as_external_script(script_path, script_name, concatenated_argv)
-    else:
-        return run_py_script_as_py_module(script_path, script_name, concatenated_argv)
+    return run_py_script_as_py_module(script_path, script_name, concatenated_argv)
 
 
 ###############################################################################

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -253,10 +253,8 @@ def _test_utf8(should_raise_unicode=False,
     except UnicodeEncodeError:
         if should_raise_unicode:
             return 'success'
-        else:
-            gdaltest.post_reason(
-                'Should be handling filenames with utf8 characters in this context')
-            return 'fail'
+        gdaltest.post_reason('Should be handling filenames with utf8 characters in this context')
+        return 'fail'
 
     if should_raise_unicode:
         gdaltest.post_reason(

--- a/autotest/pyscripts/test_gdal_polygonize.py
+++ b/autotest/pyscripts/test_gdal_polygonize.py
@@ -98,10 +98,7 @@ def test_gdal_polygonize_1():
     shp_drv = ogr.GetDriverByName('ESRI Shapefile')
     shp_drv.DeleteDataSource('tmp/poly.shp')
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 ###############################################################################
 # Test a simple case without masking.
@@ -142,10 +139,7 @@ def test_gdal_polygonize_2():
     shp_drv = ogr.GetDriverByName('ESRI Shapefile')
     shp_drv.DeleteDataSource('tmp/out.shp')
 
-    if tr:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if tr else 'fail'
 
 
 def test_gdal_polygonize_3():
@@ -179,9 +173,8 @@ def test_gdal_polygonize_3():
 
     if geom_is_polygon:
         return 'success'
-    else:
-        gdaltest.post_reason('GetGeomType() returned %d instead of %d or %d (ogr.wkbPolygon or ogr.wkbMultiPolygon)' % (geom_type, ogr.wkbPolygon, ogr.wkbMultiPolygon))
-        return 'fail'
+    gdaltest.post_reason('GetGeomType() returned %d instead of %d or %d (ogr.wkbPolygon or ogr.wkbMultiPolygon)' % (geom_type, ogr.wkbPolygon, ogr.wkbMultiPolygon))
+    return 'fail'
 
 ###############################################################################
 # Test -b mask

--- a/autotest/pyscripts/test_gdal_proximity.py
+++ b/autotest/pyscripts/test_gdal_proximity.py
@@ -68,8 +68,7 @@ def test_gdal_proximity_1():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Try several options
@@ -96,8 +95,7 @@ def test_gdal_proximity_2():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Try input nodata option
@@ -124,8 +122,7 @@ def test_gdal_proximity_3():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 ###############################################################################
 # Cleanup

--- a/autotest/pyscripts/test_gdal_sieve.py
+++ b/autotest/pyscripts/test_gdal_sieve.py
@@ -73,8 +73,7 @@ def test_gdal_sieve_1():
         print('Got: ', cs)
         gdaltest.post_reason('got wrong checksum')
         return 'fail'
-    else:
-        return 'success'
+    return 'success'
 
 
 gdaltest_list = [

--- a/autotest/pyscripts/test_ogr2ogr_py.py
+++ b/autotest/pyscripts/test_ogr2ogr_py.py
@@ -607,10 +607,7 @@ def test_ogr2ogr_py_18():
     ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/wrapdateline_src.shp')
     ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/wrapdateline_dst.shp')
 
-    if ret == 0:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if ret == 0 else 'fail'
 
 ###############################################################################
 # Test -clipsrc

--- a/autotest/utilities/test_gdal_contour.py
+++ b/autotest/utilities/test_gdal_contour.py
@@ -353,10 +353,7 @@ def test_gdal_contour_4():
     ds.ReleaseResultSet(lyr)
     ds.Destroy()
 
-    if test_failed:
-        return 'fail'
-    else:
-        return 'success'
+    return 'fail' if test_failed else 'success'
 
 ###############################################################################
 # Test contour orientation
@@ -405,10 +402,7 @@ def test_gdal_contour_5():
     ds.ReleaseResultSet(lyr)
     ds.Destroy()
 
-    if test_failed:
-        return 'fail'
-    else:
-        return 'success'
+    return 'fail' if test_failed else 'success'
 
 ###############################################################################
 # Cleanup

--- a/autotest/utilities/test_ogr2ogr.py
+++ b/autotest/utilities/test_ogr2ogr.py
@@ -599,9 +599,8 @@ def test_ogr2ogr_18():
 
     if ret == 0:
         return 'success'
-    else:
-        print(got_wkt)
-        return 'fail'
+    print(got_wkt)
+    return 'fail'
 
 ###############################################################################
 # Test -clipsrc
@@ -1003,10 +1002,7 @@ def test_ogr2ogr_28():
     ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/wrapdateline_src.shp')
     ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/wrapdateline_dst.shp')
 
-    if ret == 0:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if ret == 0 else 'fail'
 
 ###############################################################################
 # Test -wrapdateline on polygons
@@ -2775,10 +2771,7 @@ def check_identity_transformation(x, y, srid):
     shape_drv.DeleteDataSource('tmp/output_point.shp')
     os.remove('tmp/input_point.csv')
 
-    if ok:
-        return 'success'
-    else:
-        return 'fail'
+    return 'success' if ok else 'fail'
 
 ###############################################################################
 # Test coordinates values are preserved for identity transformations

--- a/gdal/swig/include/python/docs/doxy2swig.py
+++ b/gdal/swig/include/python/docs/doxy2swig.py
@@ -32,15 +32,13 @@ import os.path
 def my_open_read(source):
     if hasattr(source, "read"):
         return source
-    else:
-        return open(source)
+    return open(source)
 
 
 def my_open_write(dest):
     if hasattr(dest, "write"):
         return dest
-    else:
-        return open(dest, 'w')
+    return open(dest, 'w')
 
 
 class Doxy2SWIG:

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -578,8 +578,7 @@ def Warp(destNameOrDestDS, srcDSOrSrcDSTab, **kwargs):
 
     if _is_str_or_unicode(destNameOrDestDS):
         return wrapper_GDALWarpDestName(destNameOrDestDS, srcDSTab, opts, callback, callback_data)
-    else:
-        return wrapper_GDALWarpDestDS(destNameOrDestDS, srcDSTab, opts, callback, callback_data)
+    return wrapper_GDALWarpDestDS(destNameOrDestDS, srcDSTab, opts, callback, callback_data)
 
 
 def VectorTranslateOptions(options = None, format = None,

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -724,8 +724,7 @@ def VectorTranslate(destNameOrDestDS, srcDS, **kwargs):
 
     if _is_str_or_unicode(destNameOrDestDS):
         return wrapper_GDALVectorTranslateDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
-    else:
-        return wrapper_GDALVectorTranslateDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
+    return wrapper_GDALVectorTranslateDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 def DEMProcessingOptions(options = None, colorFilename = None, format = None,
               creationOptions = None, computeEdges = False, alg = 'Horn', band = 1,
@@ -885,8 +884,7 @@ def Nearblack(destNameOrDestDS, srcDS, **kwargs):
 
     if _is_str_or_unicode(destNameOrDestDS):
         return wrapper_GDALNearblackDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
-    else:
-        return wrapper_GDALNearblackDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
+    return wrapper_GDALNearblackDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 
 def GridOptions(options = None, format = None,
@@ -1116,8 +1114,7 @@ def Rasterize(destNameOrDestDS, srcDS, **kwargs):
 
     if _is_str_or_unicode(destNameOrDestDS):
         return wrapper_GDALRasterizeDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
-    else:
-        return wrapper_GDALRasterizeDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
+    return wrapper_GDALRasterizeDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 
 def BuildVRTOptions(options = None,
@@ -1239,8 +1236,7 @@ def BuildVRT(destName, srcDSOrSrcDSTab, **kwargs):
 
     if len(srcDSTab) > 0:
         return BuildVRTInternalObjects(destName, srcDSTab, opts, callback, callback_data)
-    else:
-        return BuildVRTInternalNames(destName, srcDSNamesTab, opts, callback, callback_data)
+    return BuildVRTInternalNames(destName, srcDSNamesTab, opts, callback, callback_data)
 
 
 

--- a/gdal/swig/python/samples/fft.py
+++ b/gdal/swig/python/samples/fft.py
@@ -51,28 +51,27 @@ def Usage():
 def ParseType(type):
     if type == 'Byte':
         return gdal.GDT_Byte
-    elif type == 'Int16':
+    if type == 'Int16':
         return gdal.GDT_Int16
-    elif type == 'UInt16':
+    if type == 'UInt16':
         return gdal.GDT_UInt16
-    elif type == 'Int32':
+    if type == 'Int32':
         return gdal.GDT_Int32
-    elif type == 'UInt32':
+    if type == 'UInt32':
         return gdal.GDT_UInt32
-    elif type == 'Float32':
+    if type == 'Float32':
         return gdal.GDT_Float32
-    elif type == 'Float64':
+    if type == 'Float64':
         return gdal.GDT_Float64
-    elif type == 'CInt16':
+    if type == 'CInt16':
         return gdal.GDT_CInt16
-    elif type == 'CInt32':
+    if type == 'CInt32':
         return gdal.GDT_CInt32
-    elif type == 'CFloat32':
+    if type == 'CFloat32':
         return gdal.GDT_CFloat32
-    elif type == 'CFloat64':
+    if type == 'CFloat64':
         return gdal.GDT_CFloat64
-    else:
-        return gdal.GDT_Byte
+    return gdal.GDT_Byte
 # =============================================================================
 
 

--- a/gdal/swig/python/samples/gdal_cp.py
+++ b/gdal/swig/python/samples/gdal_cp.py
@@ -313,8 +313,7 @@ def gdal_cp(argv, progress=None):
     (srcdir, pattern) = os.path.split(srcfile)
     if pattern.find('*') != -1 or pattern.find('?') != -1:
         return gdal_cp_pattern_match(srcdir, pattern, targetfile, progress, skip_failure)
-    else:
-        return gdal_cp_single(srcfile, targetfile, progress)
+    return gdal_cp_single(srcfile, targetfile, progress)
 
 
 if __name__ == '__main__':

--- a/gdal/swig/python/samples/gdal_rm.py
+++ b/gdal/swig/python/samples/gdal_rm.py
@@ -70,8 +70,7 @@ def gdal_rm_recurse(filename, simulate=False):
         if simulate:
             print('Unlink(%s)' % filename)
             return 0
-        else:
-            return gdal.Unlink(filename)
+        return gdal.Unlink(filename)
 
 
 def gdal_rm(argv, progress=None):

--- a/gdal/swig/python/samples/gdalpythonserver.py
+++ b/gdal/swig/python/samples/gdalpythonserver.py
@@ -357,22 +357,19 @@ VERBOSE = 0
 def read_int():
     if sys.version_info >= (3, 0, 0):
         return struct.unpack('i', sys.stdin.read(4).encode('latin1'))[0]
-    else:
-        return struct.unpack('i', sys.stdin.read(4))[0]
+    return struct.unpack('i', sys.stdin.read(4))[0]
 
 
 def read_bigint():
     if sys.version_info >= (3, 0, 0):
         return struct.unpack('q', sys.stdin.read(8).encode('latin1'))[0]
-    else:
-        return struct.unpack('q', sys.stdin.read(8))[0]
+    return struct.unpack('q', sys.stdin.read(8))[0]
 
 
 def read_double():
     if sys.version_info >= (3, 0, 0):
         return struct.unpack('d', sys.stdin.read(8).encode('latin1'))[0]
-    else:
-        return struct.unpack('d', sys.stdin.read(8))[0]
+    return struct.unpack('d', sys.stdin.read(8))[0]
 
 
 def read_str():

--- a/gdal/swig/python/samples/ogr_dispatch.py
+++ b/gdal/swig/python/samples/ogr_dispatch.py
@@ -137,7 +137,7 @@ def GeometryTypeToName(eGeomType, options):
     if eGeomType == ogr.wkbMultiLineString25D:
         return 'LINESTRING25D' if options.bMultiAsSingle else 'MULTILINESTRING25D'
     if eGeomType == ogr.wkbMultiPolygon25D:
-        return 'POLYGON25D' if if options.bMultiAsSingle else 'MULTIPOLYGON25D'
+        return 'POLYGON25D' if options.bMultiAsSingle else 'MULTIPOLYGON25D'
     if eGeomType == ogr.wkbGeometryCollection25D:
         return 'GEOMETRYCOLLECTION25D'
     # Shouldn't happen

--- a/gdal/swig/python/samples/ogr_dispatch.py
+++ b/gdal/swig/python/samples/ogr_dispatch.py
@@ -114,47 +114,34 @@ def GeometryTypeToName(eGeomType, options):
 
     if eGeomType == ogr.wkbPoint:
         return 'POINT'
-    elif eGeomType == ogr.wkbLineString:
+    if eGeomType == ogr.wkbLineString:
         return 'LINESTRING'
-    elif eGeomType == ogr.wkbPolygon:
+    if eGeomType == ogr.wkbPolygon:
         return 'POLYGON'
-    elif eGeomType == ogr.wkbMultiPoint:
+    if eGeomType == ogr.wkbMultiPoint:
         return 'MULTIPOINT'
-    elif eGeomType == ogr.wkbMultiLineString:
-        if options.bMultiAsSingle:
-            return 'LINESTRING'
-        else:
-            return 'MULTILINESTRING'
-    elif eGeomType == ogr.wkbMultiPolygon:
-        if options.bMultiAsSingle:
-            return 'POLYGON'
-        else:
-            return 'MULTIPOLYGON'
-    elif eGeomType == ogr.wkbGeometryCollection:
+    if eGeomType == ogr.wkbMultiLineString:
+        return 'LINESTRING' if options.bMultiAsSingle else 'MULTILINESTRING'
+    if eGeomType == ogr.wkbMultiPolygon:
+        return 'POLYGON' if options.bMultiAsSingle else 'MULTIPOLYGON'
+    if eGeomType == ogr.wkbGeometryCollection:
         return 'GEOMETRYCOLLECTION'
-    elif eGeomType == ogr.wkbPoint25D:
+    if eGeomType == ogr.wkbPoint25D:
         return 'POINT25D'
-    elif eGeomType == ogr.wkbLineString25D:
+    if eGeomType == ogr.wkbLineString25D:
         return 'LINESTRING25D'
-    elif eGeomType == ogr.wkbPolygon25D:
+    if eGeomType == ogr.wkbPolygon25D:
         return 'POLYGON25D'
-    elif eGeomType == ogr.wkbMultiPoint25D:
+    if eGeomType == ogr.wkbMultiPoint25D:
         return 'MULTIPOINT25D'
-    elif eGeomType == ogr.wkbMultiLineString25D:
-        if options.bMultiAsSingle:
-            return 'LINESTRING25D'
-        else:
-            return 'MULTILINESTRING25D'
-    elif eGeomType == ogr.wkbMultiPolygon25D:
-        if options.bMultiAsSingle:
-            return 'POLYGON25D'
-        else:
-            return 'MULTIPOLYGON25D'
-    elif eGeomType == ogr.wkbGeometryCollection25D:
+    if eGeomType == ogr.wkbMultiLineString25D:
+        return 'LINESTRING25D' if options.bMultiAsSingle else 'MULTILINESTRING25D'
+    if eGeomType == ogr.wkbMultiPolygon25D:
+        return 'POLYGON25D' if if options.bMultiAsSingle else 'MULTIPOLYGON25D'
+    if eGeomType == ogr.wkbGeometryCollection25D:
         return 'GEOMETRYCOLLECTION25D'
-    else:
-        # Shouldn't happen
-        return 'UNKNOWN'
+    # Shouldn't happen
+    return 'UNKNOWN'
 
 ###############################################################
 # get_out_lyr_name()

--- a/gdal/swig/python/samples/ogrupdate.py
+++ b/gdal/swig/python/samples/ogrupdate.py
@@ -262,12 +262,11 @@ def AreFeaturesEqual(src_feat, dst_feat):
     dst_geom = dst_feat.GetGeometryRef()
     if src_geom is None and dst_geom is not None:
         return False
-    elif src_geom is not None and dst_geom is None:
+    if src_geom is not None and dst_geom is None:
         return False
-    elif src_geom is not None and dst_geom is not None:
+    if src_geom is not None and dst_geom is not None:
         return src_geom.Equals(dst_geom)
-    else:
-        return True
+    return True
 
 ###############################################################
 # ogrupdate_process()

--- a/gdal/swig/python/samples/rel.py
+++ b/gdal/swig/python/samples/rel.py
@@ -78,28 +78,27 @@ def Usage():
 def ParseType(type):
     if type == 'Byte':
         return gdal.GDT_Byte
-    elif type == 'Int16':
+    if type == 'Int16':
         return gdal.GDT_Int16
-    elif type == 'UInt16':
+    if type == 'UInt16':
         return gdal.GDT_UInt16
-    elif type == 'Int32':
+    if type == 'Int32':
         return gdal.GDT_Int32
-    elif type == 'UInt32':
+    if type == 'UInt32':
         return gdal.GDT_UInt32
-    elif type == 'Float32':
+    if type == 'Float32':
         return gdal.GDT_Float32
-    elif type == 'Float64':
+    if type == 'Float64':
         return gdal.GDT_Float64
-    elif type == 'CInt16':
+    if type == 'CInt16':
         return gdal.GDT_CInt16
-    elif type == 'CInt32':
+    if type == 'CInt32':
         return gdal.GDT_CInt32
-    elif type == 'CFloat32':
+    if type == 'CFloat32':
         return gdal.GDT_CFloat32
-    elif type == 'CFloat64':
+    if type == 'CFloat64':
         return gdal.GDT_CFloat64
-    else:
-        return gdal.GDT_Byte
+    return gdal.GDT_Byte
 # =============================================================================
 
 

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -294,8 +294,7 @@ class GlobalMercator(object):
             if pixelSize > self.Resolution(i):
                 if i != -1:
                     return i - 1
-                else:
-                    return 0    # We don't want to scale up
+                return 0    # We don't want to scale up
 
     def GoogleTile(self, tx, ty, zoom):
         "Converts TMS tile coordinates to Google Tile coordinates"
@@ -400,8 +399,7 @@ class GlobalGeodetic(object):
             if pixelSize > self.Resolution(i):
                 if i != 0:
                     return i - 1
-                else:
-                    return 0    # We don't want to scale up
+                return 0    # We don't want to scale up
 
     def TileBounds(self, tx, ty, zoom):
         "Returns bounds of the given tile"
@@ -904,8 +902,7 @@ def nb_data_bands(dataset):
             dataset.RasterCount == 4 or
             dataset.RasterCount == 2):
         return dataset.RasterCount - 1
-    else:
-        return dataset.RasterCount
+    return dataset.RasterCount
 
 
 def gettempfilename(suffix):

--- a/gdal/swig/python/scripts/gdal_retile.py
+++ b/gdal/swig/python/scripts/gdal_retile.py
@@ -309,8 +309,7 @@ def getTileIndexFromFiles(inputTiles, driverTyp):
 def getTargetDir(level=-1):
     if level == -1:
         return TargetDir
-    else:
-        return TargetDir + str(level) + os.sep
+    return TargetDir + str(level) + os.sep
 
 
 def tileImage(minfo, ti):

--- a/gdal/swig/python/scripts/gdalmove.py
+++ b/gdal/swig/python/scripts/gdalmove.py
@@ -39,8 +39,7 @@ from osgeo import gdal, osr
 def fmt_loc(srs_obj, loc):
     if srs_obj.IsProjected():
         return '%12.3f %12.3f' % (loc[0], loc[1])
-    else:
-        return '%12.8f %12.8f' % (loc[0], loc[1])
+    return '%12.8f %12.8f' % (loc[0], loc[1])
 
 ###############################################################################
 

--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -70,8 +70,7 @@ libraries = ['gdal']
 def get_numpy_include():
     if HAVE_NUMPY:
         return numpy.get_include()
-    else:
-        return '.'
+    return '.'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Pylint warns about `unnecessary  else statements under returns`. This patch removes these which simplifies the code somewhat. In some cases, I simplified further:

```
    if x:
        return 'success'
    else:
        return 'failure'
````
with `return 'success' if x else 'fail'`.