### PR TITLE
Python code: Remove useless returns

### DIFF
--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -644,8 +644,6 @@ class CFChecker:
             self.AttrList['instance_dimension'] = ['S', 'D']
             self.AttrList['sample_dimension'] = ['S', 'D']
 
-        return
-
         # ---------------------------
     def uniqueList(self, lst):
         # ---------------------------

--- a/autotest/gdrivers/wcs.py
+++ b/autotest/gdrivers/wcs.py
@@ -315,7 +315,7 @@ class WCSHTTPHandler(BaseHTTPRequestHandler):
 
     def log_request(self, code=',', size=','):
         # pylint: disable=unused-argument
-        return
+        pass
 
     def Headers(self, typ):
         self.send_response(200)
@@ -384,7 +384,6 @@ class WCSHTTPHandler(BaseHTTPRequestHandler):
                 wcs_6_ok = False
             print('test ' + server + ' ' + test + ' WCS ' + version + ' ' + ok)
         self.Respond(request, server, version, test)
-        return
 
 
 def setupFct():

--- a/autotest/kml_generate_test_files.py
+++ b/autotest/kml_generate_test_files.py
@@ -319,8 +319,6 @@ eiffel_tower_highlight:SYMBOL(id:"http://upload.wikimedia.org/wikipedia/commons/
 
     ds = None
 
-    return
-
 ###############################################################################
 # Generate a .kml file with OGR LIBKML driver covering the Update KML features
 #
@@ -346,8 +344,6 @@ def generate_libkml_update(filename):
     lyr.DeleteFeature(1)
     ds = None
 
-    return
-
 ###############################################################################
 # Generate a .kml file with GDAL KMLSuperOverlay driver covering the GroundOverlay KML features
 #
@@ -364,8 +360,6 @@ def generate_kmlsuperoverlay(filename):
     ds = gdal.GetDriverByName('KMLSuperOverlay').CreateCopy(filename, src_ds)
     del ds
     src_ds = None
-
-    return
 
 
 gdaltest_list = []

--- a/autotest/ogr/ogr_gmlas.py
+++ b/autotest/ogr/ogr_gmlas.py
@@ -1136,7 +1136,7 @@ do_log = False
 class GMLASHTTPHandler(BaseHTTPRequestHandler):
 
     def log_request(self, code='-', size='-'):
-        return
+        pass
 
     def do_GET(self):
 

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -2552,8 +2552,7 @@ def ogr_shape_54_create_layer(ds, layer_index):
         feat.SetGeometry(ogr.CreateGeometryFromWkt('POINT (%d %d)' % (layer_index, layer_index + 1)))
     lyr.CreateFeature(feat)
     feat = None
-    return
-
+ 
 
 def ogr_shape_54_test_layer(ds, layer_index):
     lyr = ds.GetLayerByName('layer%03d' % layer_index)

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -1010,7 +1010,7 @@ do_log = False
 class GeocodingHTTPHandler(BaseHTTPRequestHandler):
 
     def log_request(self, code='-', size='-'):
-        return
+        pass
 
     def do_GET(self):
 

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -510,7 +510,7 @@ do_log = False
 class WFSHTTPHandler(BaseHTTPRequestHandler):
 
     def log_request(self, code='-', size='-'):
-        return
+        pass
 
     def do_GET(self):
 

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -205,7 +205,7 @@ class DispatcherHttpHandler(BaseHTTPRequestHandler):
 
     def log_request(self, code='-', size='-'):
         # pylint: disable=unused-argument
-        return
+        pass
 
     def do_HEAD(self):
 
@@ -256,7 +256,7 @@ class DispatcherHttpHandler(BaseHTTPRequestHandler):
 class GDAL_Handler(BaseHTTPRequestHandler):
     # pylint: disable=unused-argument
     def log_request(self, code='-', size='-'):
-        return
+        pass
 
     def do_HEAD(self):
         if do_log:

--- a/gdal/swig/python/samples/gdalpythonserver.py
+++ b/gdal/swig/python/samples/gdalpythonserver.py
@@ -175,7 +175,6 @@ class GDALPythonServerDataset:
 
     def FlushCache(self):
         self.gdal_ds.FlushCache()
-        return
 
     def IRasterIO_Read(self, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize,
                        nBufType, panBandMap, nPixelSpace, nLineSpace, nBandSpace):

--- a/gdal/swig/python/samples/ogrinfo.py
+++ b/gdal/swig/python/samples/ogrinfo.py
@@ -465,8 +465,6 @@ def DumpReadableFeature(poFeature, options=None):
 
     print('')
 
-    return
-
 
 def DumpReadableGeometry(poGeometry, pszPrefix, options):
 
@@ -523,8 +521,6 @@ def DumpReadableGeometry(poGeometry, pszPrefix, options):
             or EQUAL(options['DISPLAY_GEOMETRY'], 'WKT'):
 
         print("%s%s" % (pszPrefix, poGeometry.ExportToWkt()))
-
-    return
 
 
 if __name__ == '__main__':

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -358,9 +358,6 @@ def doit(opts, args):
 
     if not opts.quiet:
         print("100 - Done")
-    # print("Finished - Results written to %s" %opts.outF)
-
-    return
 
 ################################################################
 


### PR DESCRIPTION
## What does this PR do?

Silences  `useless-return` warnings from Pylint. For stub functions, I used the common idiom of using `pass` instead of `return` to show that the function is a placeholder.