### PR TITLE
Python code: Comprehensively fix Pylint warnings in SWIG interface files

### DIFF
--- a/gdal/swig/include/Band.i
+++ b/gdal/swig/include/Band.i
@@ -209,12 +209,12 @@ public:
   // Preferred name to match C++ API
   /* Interface method added for GDAL 1.7.0 */
   GDALColorInterp GetColorInterpretation() {
-    return GDALGetRasterColorInterpretation( self );
+    return GDALGetRasterColorInterpretation(self);
   }
 
   // Deprecated name
   GDALColorInterp GetRasterColorInterpretation() {
-    return GDALGetRasterColorInterpretation( self );
+    return GDALGetRasterColorInterpretation(self);
   }
 
   // Preferred name to match C++ API
@@ -237,12 +237,12 @@ public:
   }
 
   CPLErr DeleteNoDataValue() {
-    return GDALDeleteRasterNoDataValue( self );
+    return GDALDeleteRasterNoDataValue(self);
   }
 
   /* Interface method added for GDAL 1.7.0 */
   const char* GetUnitType() {
-      return GDALGetRasterUnitType( self );
+      return GDALGetRasterUnitType(self);
   }
 
   /* Interface method added for GDAL 1.8.0 */
@@ -252,7 +252,7 @@ public:
 
   %apply (char **options) { (char **) };
   char** GetRasterCategoryNames( ) {
-    return GDALGetRasterCategoryNames( self );
+    return GDALGetRasterCategoryNames(self);
   }
   %clear (char **);
 
@@ -315,7 +315,7 @@ public:
   }
 
   int GetOverviewCount() {
-    return GDALGetOverviewCount( self );
+    return GDALGetOverviewCount(self);
   }
 
   GDALRasterBandShadow *GetOverview(int i) {

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1075,34 +1075,34 @@ import gdalconst
 import gdal
 gdal.AllRegister()
 
-codes = {   gdalconst.GDT_Byte      :   numpy.uint8,
-            gdalconst.GDT_UInt16    :   numpy.uint16,
-            gdalconst.GDT_Int16     :   numpy.int16,
-            gdalconst.GDT_UInt32    :   numpy.uint32,
-            gdalconst.GDT_Int32     :   numpy.int32,
-            gdalconst.GDT_Float32   :   numpy.float32,
-            gdalconst.GDT_Float64   :   numpy.float64,
-            gdalconst.GDT_CInt16    :   numpy.complex64,
-            gdalconst.GDT_CInt32    :   numpy.complex64,
-            gdalconst.GDT_CFloat32  :   numpy.complex64,
-            gdalconst.GDT_CFloat64  :   numpy.complex128
-        }
+codes = {gdalconst.GDT_Byte: numpy.uint8,
+         gdalconst.GDT_UInt16: numpy.uint16,
+         gdalconst.GDT_Int16: numpy.int16,
+         gdalconst.GDT_UInt32: numpy.uint32,
+         gdalconst.GDT_Int32: numpy.int32,
+         gdalconst.GDT_Float32: numpy.float32,
+         gdalconst.GDT_Float64: numpy.float64,
+         gdalconst.GDT_CInt16: numpy.complex64,
+         gdalconst.GDT_CInt32: numpy.complex64,
+         gdalconst.GDT_CFloat32:  numpy.complex64,
+         gdalconst.GDT_CFloat64: numpy.complex128}
 
-def OpenArray( array, prototype_ds = None ):
 
-    ds = OpenNumPyArray( array )
+def OpenArray(array, prototype_ds=None):
+
+    ds = OpenNumPyArray(array)
 
     if ds is not None and prototype_ds is not None:
         if type(prototype_ds).__name__ == 'str':
-            prototype_ds = gdal.Open( prototype_ds )
+            prototype_ds = gdal.Open(prototype_ds)
         if prototype_ds is not None:
-            CopyDatasetInfo( prototype_ds, ds )
+            CopyDatasetInfo(prototype_ds, ds)
 
     return ds
 
 
 def flip_code(code):
-    if isinstance(code, (numpy.dtype,type)):
+    if isinstance(code, (numpy.dtype, type)):
         # since several things map to complex64 we must carefully select
         # the opposite that is an exact match (ticket 1518)
         if code == numpy.int8:
@@ -1121,38 +1121,38 @@ def flip_code(code):
             return None
 
 def NumericTypeCodeToGDALTypeCode(numeric_type):
-    if not isinstance(numeric_type, (numpy.dtype,type)):
+    if not isinstance(numeric_type, (numpy.dtype, type)):
         raise TypeError("Input must be a type")
     return flip_code(numeric_type)
 
 def GDALTypeCodeToNumericTypeCode(gdal_code):
     return flip_code(gdal_code)
 
-def LoadFile( filename, xoff=0, yoff=0, xsize=None, ysize=None,
-              buf_xsize=None, buf_ysize=None, buf_type=None,
-              resample_alg = gdal.GRIORA_NearestNeighbour,
-              callback=None, callback_data=None ):
-    ds = gdal.Open( filename )
+def LoadFile(filename, xoff=0, yoff=0, xsize=None, ysize=None,
+             buf_xsize=None, buf_ysize=None, buf_type=None,
+             resample_alg=gdal.GRIORA_NearestNeighbour,
+             callback=None, callback_data=None):
+    ds = gdal.Open(filename)
     if ds is None:
         raise ValueError("Can't open "+filename+"\n\n"+gdal.GetLastErrorMsg())
 
-    return DatasetReadAsArray( ds, xoff, yoff, xsize, ysize,
-                               buf_xsize=buf_xsize, buf_ysize=buf_ysize, buf_type=buf_type,
-                               resample_alg=resample_alg,
-                               callback = callback, callback_data = callback_data )
+    return DatasetReadAsArray(ds, xoff, yoff, xsize, ysize,
+                              buf_xsize=buf_xsize, buf_ysize=buf_ysize, buf_type=buf_type,
+                              resample_alg=resample_alg,
+                              callback=callback, callback_data=callback_data)
 
-def SaveArray( src_array, filename, format = "GTiff", prototype = None ):
-    driver = gdal.GetDriverByName( format )
+def SaveArray(src_array, filename, format="GTiff", prototype=None):
+    driver = gdal.GetDriverByName(format)
     if driver is None:
         raise ValueError("Can't find driver "+format)
 
-    return driver.CreateCopy( filename, OpenArray(src_array,prototype) )
+    return driver.CreateCopy(filename, OpenArray(src_array, prototype))
 
 
-def DatasetReadAsArray( ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_obj=None,
-                        buf_xsize = None, buf_ysize = None, buf_type = None,
-                        resample_alg = gdal.GRIORA_NearestNeighbour,
-                        callback=None, callback_data=None ):
+def DatasetReadAsArray(ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_obj=None,
+                       buf_xsize=None, buf_ysize=None, buf_type=None,
+                       resample_alg=gdal.GRIORA_NearestNeighbour,
+                       callback=None, callback_data=None):
     """Pure python implementation of reading a chunk of a GDAL file
     into a numpy array.  Used by the gdal.Dataset.ReadAsArray method."""
 
@@ -1165,12 +1165,12 @@ def DatasetReadAsArray( ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_
         return None
 
     if ds.RasterCount == 1:
-        return BandReadAsArray( ds.GetRasterBand(1), xoff, yoff, win_xsize, win_ysize,
-                                buf_xsize = buf_xsize, buf_ysize = buf_ysize, buf_type = buf_type,
-                                buf_obj = buf_obj,
-                                resample_alg = resample_alg,
-                                callback = callback,
-                                callback_data = callback_data )
+        return BandReadAsArray(ds.GetRasterBand(1), xoff, yoff, win_xsize, win_ysize,
+                               buf_xsize=buf_xsize, buf_ysize=buf_ysize, buf_type=buf_type,
+                               buf_obj=buf_obj,
+                               resample_alg=resample_alg,
+                               callback=callback,
+                               callback_data=callback_data)
 
     if buf_obj is None:
         if buf_xsize is None:
@@ -1179,17 +1179,17 @@ def DatasetReadAsArray( ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_
             buf_ysize = win_ysize
         if buf_type is None:
             buf_type = ds.GetRasterBand(1).DataType
-            for band_index in range(2,ds.RasterCount+1):
+            for band_index in range(2, ds.RasterCount + 1):
                 if buf_type != ds.GetRasterBand(band_index).DataType:
                     buf_type = gdalconst.GDT_Float32
 
-        typecode = GDALTypeCodeToNumericTypeCode( buf_type )
+        typecode = GDALTypeCodeToNumericTypeCode(buf_type)
         if typecode is None:
             buf_type = gdalconst.GDT_Float32
             typecode = numpy.float32
         if buf_type == gdalconst.GDT_Byte and ds.GetRasterBand(1).GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
             typecode = numpy.int8
-        buf_obj = numpy.empty([ds.RasterCount, buf_ysize,buf_xsize], dtype = typecode)
+        buf_obj = numpy.empty([ds.RasterCount, buf_ysize, buf_xsize], dtype=typecode)
 
     else:
         if len(buf_obj.shape) != 3:
@@ -1204,23 +1204,23 @@ def DatasetReadAsArray( ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_
         if buf_obj.shape[0] != ds.RasterCount:
             raise ValueError('Array should have space for %d bands' % ds.RasterCount)
 
-        datatype = NumericTypeCodeToGDALTypeCode( buf_obj.dtype.type )
+        datatype = NumericTypeCodeToGDALTypeCode(buf_obj.dtype.type)
         if not datatype:
             raise ValueError("array does not have corresponding GDAL data type")
         if buf_type is not None and buf_type != datatype:
             raise ValueError("Specified buf_type not consistent with array type")
         buf_type = datatype
 
-    if DatasetIONumPy( ds, 0, xoff, yoff, win_xsize, win_ysize,
-                       buf_obj, buf_type, resample_alg, callback, callback_data ) != 0:
+    if DatasetIONumPy(ds, 0, xoff, yoff, win_xsize, win_ysize,
+                      buf_obj, buf_type, resample_alg, callback, callback_data) != 0:
         return None
 
     return buf_obj
 
-def BandReadAsArray( band, xoff = 0, yoff = 0, win_xsize = None, win_ysize = None,
-                     buf_xsize=None, buf_ysize=None, buf_type=None, buf_obj=None,
-                     resample_alg = gdal.GRIORA_NearestNeighbour,
-                     callback=None, callback_data=None):
+def BandReadAsArray(band, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
+                    buf_xsize=None, buf_ysize=None, buf_type=None, buf_obj=None,
+                    resample_alg=gdal.GRIORA_NearestNeighbour,
+                    callback=None, callback_data=None):
     """Pure python implementation of reading a chunk of a GDAL file
     into a numpy array.  Used by the gdal.Band.ReadAsArray method."""
 
@@ -1237,16 +1237,16 @@ def BandReadAsArray( band, xoff = 0, yoff = 0, win_xsize = None, win_ysize = Non
         if buf_type is None:
             buf_type = band.DataType
 
-        typecode = GDALTypeCodeToNumericTypeCode( buf_type )
+        typecode = GDALTypeCodeToNumericTypeCode(buf_type)
         if typecode is None:
             buf_type = gdalconst.GDT_Float32
             typecode = numpy.float32
         else:
-            buf_type = NumericTypeCodeToGDALTypeCode( typecode )
+            buf_type = NumericTypeCodeToGDALTypeCode(typecode)
 
         if buf_type == gdalconst.GDT_Byte and band.GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
             typecode = numpy.int8
-        buf_obj = numpy.empty([buf_ysize,buf_xsize], dtype = typecode)
+        buf_obj = numpy.empty([buf_ysize, buf_xsize], dtype=typecode)
 
     else:
         if len(buf_obj.shape) == 2:
@@ -1260,22 +1260,22 @@ def BandReadAsArray( band, xoff = 0, yoff = 0, win_xsize = None, win_ysize = Non
         if buf_ysize is not None and buf_ysize != shape_buf_ysize:
             raise ValueError('Specified buf_ysize not consistent with array shape')
 
-        datatype = NumericTypeCodeToGDALTypeCode( buf_obj.dtype.type )
+        datatype = NumericTypeCodeToGDALTypeCode(buf_obj.dtype.type)
         if not datatype:
             raise ValueError("array does not have corresponding GDAL data type")
         if buf_type is not None and buf_type != datatype:
             raise ValueError("Specified buf_type not consistent with array type")
         buf_type = datatype
 
-    if BandRasterIONumPy( band, 0, xoff, yoff, win_xsize, win_ysize,
-                          buf_obj, buf_type, resample_alg, callback, callback_data ) != 0:
+    if BandRasterIONumPy(band, 0, xoff, yoff, win_xsize, win_ysize,
+                         buf_obj, buf_type, resample_alg, callback, callback_data) != 0:
         return None
 
     return buf_obj
 
-def BandWriteArray( band, array, xoff=0, yoff=0,
-                    resample_alg = gdal.GRIORA_NearestNeighbour,
-                    callback=None, callback_data=None ):
+def BandWriteArray(band, array, xoff=0, yoff=0,
+                   resample_alg = gdal.GRIORA_NearestNeighbour,
+                   callback=None, callback_data=None):
     """Pure python implementation of writing a chunk of a GDAL file
     from a numpy array.  Used by the gdal.Band.WriteArray method."""
 
@@ -1288,20 +1288,20 @@ def BandWriteArray( band, array, xoff=0, yoff=0,
     if xsize + xoff > band.XSize or ysize + yoff > band.YSize:
         raise ValueError("array larger than output file, or offset off edge")
 
-    datatype = NumericTypeCodeToGDALTypeCode( array.dtype.type )
+    datatype = NumericTypeCodeToGDALTypeCode(array.dtype.type)
 
     # if we receive some odd type, like int64, try casting to a very
     # generic type we do support (#2285)
     if not datatype:
-        gdal.Debug( 'gdal_array', 'force array to float64' )
-        array = array.astype( numpy.float64 )
-        datatype = NumericTypeCodeToGDALTypeCode( array.dtype.type )
+        gdal.Debug('gdal_array', 'force array to float64')
+        array = array.astype(numpy.float64)
+        datatype = NumericTypeCodeToGDALTypeCode(array.dtype.type)
 
     if not datatype:
         raise ValueError("array does not have corresponding GDAL data type")
 
-    return BandRasterIONumPy( band, 1, xoff, yoff, xsize, ysize,
-                                array, datatype, resample_alg, callback, callback_data )
+    return BandRasterIONumPy(band, 1, xoff, yoff, xsize, ysize,
+                             array, datatype, resample_alg, callback, callback_data)
 
 def RATWriteArray(rat, array, field, start=0):
     """
@@ -1348,7 +1348,7 @@ def RATReadArray(rat, field, start=0, length=None):
 
     return RATValuesIONumPyRead(rat, field, start, length)
 
-def CopyDatasetInfo( src, dst, xoff=0, yoff=0 ):
+def CopyDatasetInfo(src, dst, xoff=0, yoff=0):
     """
     Copy georeferencing information and metadata from one dataset to another.
     src: input dataset
@@ -1360,28 +1360,28 @@ def CopyDatasetInfo( src, dst, xoff=0, yoff=0 ):
 
     """
 
-    dst.SetMetadata( src.GetMetadata() )
+    dst.SetMetadata(src.GetMetadata())
 
 
 
     #Check for geo transform
     gt = src.GetGeoTransform()
-    if gt != (0,1,0,0,0,1):
-        dst.SetProjection( src.GetProjectionRef() )
+    if gt != (0, 1, 0, 0, 0, 1):
+        dst.SetProjection(src.GetProjectionRef())
 
-        if (xoff == 0) and (yoff == 0):
-            dst.SetGeoTransform( gt  )
+        if xoff == 0 and yoff == 0:
+            dst.SetGeoTransform(gt)
         else:
-            ngt = [gt[0],gt[1],gt[2],gt[3],gt[4],gt[5]]
+            ngt = [gt[0], gt[1], gt[2], gt[3], gt[4], gt[5]]
             ngt[0] = gt[0] + xoff*gt[1] + yoff*gt[2]
             ngt[3] = gt[3] + xoff*gt[4] + yoff*gt[5]
-            dst.SetGeoTransform( ( ngt[0], ngt[1], ngt[2], ngt[3], ngt[4], ngt[5] ) )
+            dst.SetGeoTransform((ngt[0], ngt[1], ngt[2], ngt[3], ngt[4], ngt[5]))
 
     #Check for GCPs
     elif src.GetGCPCount() > 0:
 
         if (xoff == 0) and (yoff == 0):
-            dst.SetGCPs( src.GetGCPs(), src.GetGCPProjection() )
+            dst.SetGCPs(src.GetGCPs(), src.GetGCPProjection())
         else:
             gcps = src.GetGCPs()
             #Shift gcps
@@ -1398,7 +1398,7 @@ def CopyDatasetInfo( src, dst, xoff=0, yoff=0 ):
                 new_gcps.append(ngcp)
 
             try:
-                dst.SetGCPs( new_gcps , src.GetGCPProjection() )
+                dst.SetGCPs(new_gcps, src.GetGCPProjection())
             except:
                 print("Failed to set GCPs")
                 return

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -213,7 +213,7 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
              self.GCPX, self.GCPY, self.GCPZ, self.Info )
     return str
 
-  def serialize(self,with_Z=0):
+  def serialize(self, with_Z=0):
     base = [CXT_Element,'GCP']
     base.append([CXT_Attribute,'Id',[CXT_Text,self.Id]])
     pixval = '%0.15E' % self.GCPPixel
@@ -394,19 +394,19 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
         approx_ok = False
     elif approx_ok == 1:
         approx_ok = True
-    new_args = [ approx_ok ]
+    new_args = [approx_ok]
     for arg in args[1:]:
         new_args.append( arg )
 
     return _gdal.Band_ComputeStatistics(self, *new_args)
 
 
-  def ReadRaster(self, xoff = 0, yoff = 0, xsize = None, ysize = None,
-                   buf_xsize = None, buf_ysize = None, buf_type = None,
-                   buf_pixel_space = None, buf_line_space = None,
+  def ReadRaster(self, xoff = 0, yoff = 0, xsize=None, ysize=None,
+                   buf_xsize=None, buf_ysize=None, buf_type=None,
+                   buf_pixel_space=None, buf_line_space=None,
                    resample_alg = GRIORA_NearestNeighbour,
-                   callback = None,
-                   callback_data = None):
+                   callback=None,
+                   callback_data=None):
 
       if xsize is None:
           xsize = self.XSize
@@ -421,8 +421,8 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
   def ReadAsArray(self, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
                   buf_xsize=None, buf_ysize=None, buf_type=None, buf_obj=None,
                   resample_alg = GRIORA_NearestNeighbour,
-                  callback = None,
-                  callback_data = None):
+                  callback=None,
+                  callback_data=None):
       """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
       parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
@@ -437,8 +437,8 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
 
   def WriteArray(self, array, xoff=0, yoff=0,
                  resample_alg = GRIORA_NearestNeighbour,
-                 callback = None,
-                 callback_data = None):
+                 callback=None,
+                 callback_data=None):
       import gdalnumeric
 
       return gdalnumeric.BandWriteArray( self, array, xoff, yoff,
@@ -446,11 +446,11 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
                                          callback = callback,
                                          callback_data = callback_data )
 
-  def GetVirtualMemArray(self, eAccess = gdalconst.GF_Read, xoff=0, yoff=0,
+  def GetVirtualMemArray(self, eAccess=gdalconst.GF_Read, xoff=0, yoff=0,
                          xsize=None, ysize=None, bufxsize=None, bufysize=None,
-                         datatype = None,
+                         datatype=None,
                          cache_size = 10 * 1024 * 1024, page_size_hint = 0,
-                         options = None):
+                         options=None):
         """Return a NumPy array for the band, seen as a virtual memory mapping.
            An element is accessed with array[y][x].
            Any reference to the array must be dropped before the last reference to the
@@ -471,9 +471,9 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
             virtualmem = self.GetVirtualMem(eAccess,xoff,yoff,xsize,ysize,bufxsize,bufysize,datatype,cache_size,page_size_hint)
         else:
             virtualmem = self.GetVirtualMem(eAccess,xoff,yoff,xsize,ysize,bufxsize,bufysize,datatype,cache_size,page_size_hint,options)
-        return gdalnumeric.VirtualMemGetArray( virtualmem )
+              return gdalnumeric.VirtualMemGetArray(virtualmem)
 
-  def GetVirtualMemAutoArray(self, eAccess = gdalconst.GF_Read, options = None):
+  def GetVirtualMemAutoArray(self, eAccess=gdalconst.GF_Read, options=None):
         """Return a NumPy array for the band, seen as a virtual memory mapping.
            An element is accessed with array[y][x].
            Any reference to the array must be dropped before the last reference to the
@@ -486,10 +486,10 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
             virtualmem = self.GetVirtualMemAuto(eAccess,options)
         return gdalnumeric.VirtualMemGetArray( virtualmem )
 
-  def GetTiledVirtualMemArray(self, eAccess = gdalconst.GF_Read, xoff=0, yoff=0,
+  def GetTiledVirtualMemArray(self, eAccess=gdalconst.GF_Read, xoff=0, yoff=0,
                            xsize=None, ysize=None, tilexsize=256, tileysize=256,
-                           datatype = None,
-                           cache_size = 10 * 1024 * 1024, options = None):
+                           datatype=None,
+                           cache_size = 10 * 1024 * 1024, options=None):
         """Return a NumPy array for the band, seen as a virtual memory mapping with
            a tile organization.
            An element is accessed with array[tiley][tilex][y][x].
@@ -630,10 +630,10 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
 %pythoncode %{
 
     def ReadAsArray(self, xoff=0, yoff=0, xsize=None, ysize=None, buf_obj=None,
-                    buf_xsize = None, buf_ysize = None, buf_type = None,
+                    buf_xsize=None, buf_ysize=None, buf_type=None,
                     resample_alg = GRIORA_NearestNeighbour,
-                    callback = None,
-                    callback_data = None):
+                    callback=None,
+                    callback_data=None):
         """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
         parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
@@ -646,9 +646,9 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
 
     def WriteRaster(self, xoff, yoff, xsize, ysize,
                     buf_string,
-                    buf_xsize = None, buf_ysize = None, buf_type = None,
-                    band_list = None,
-                    buf_pixel_space = None, buf_line_space = None, buf_band_space = None ):
+                    buf_xsize=None, buf_ysize=None, buf_type=None,
+                    band_list=None,
+                    buf_pixel_space=None, buf_line_space=None, buf_band_space=None ):
 
         if buf_xsize is None:
             buf_xsize = xsize
@@ -664,13 +664,13 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
                 buf_string, buf_xsize, buf_ysize, buf_type, band_list,
                 buf_pixel_space, buf_line_space, buf_band_space )
 
-    def ReadRaster(self, xoff = 0, yoff = 0, xsize = None, ysize = None,
-                   buf_xsize = None, buf_ysize = None, buf_type = None,
-                   band_list = None,
-                   buf_pixel_space = None, buf_line_space = None, buf_band_space = None,
+    def ReadRaster(self, xoff = 0, yoff = 0, xsize=None, ysize=None,
+                   buf_xsize=None, buf_ysize=None, buf_type=None,
+                   band_list=None,
+                   buf_pixel_space=None, buf_line_space=None, buf_band_space=None,
                    resample_alg = GRIORA_NearestNeighbour,
-                   callback = None,
-                   callback_data = None):
+                   callback=None,
+                   callback_data=None):
 
         if xsize is None:
             xsize = self.RasterXSize
@@ -691,11 +691,11 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
                                             band_list, buf_pixel_space, buf_line_space, buf_band_space,
                                           resample_alg, callback, callback_data )
 
-    def GetVirtualMemArray(self, eAccess = gdalconst.GF_Read, xoff=0, yoff=0,
+    def GetVirtualMemArray(self, eAccess=gdalconst.GF_Read, xoff=0, yoff=0,
                            xsize=None, ysize=None, bufxsize=None, bufysize=None,
-                           datatype = None, band_list = None, band_sequential = True,
+                           datatype=None, band_list=None, band_sequential = True,
                            cache_size = 10 * 1024 * 1024, page_size_hint = 0,
-                           options = None):
+                           options=None):
         """Return a NumPy array for the dataset, seen as a virtual memory mapping.
            If there are several bands and band_sequential = True, an element is
            accessed with array[band][y][x].
@@ -724,10 +724,10 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
             virtualmem = self.GetVirtualMem(eAccess,xoff,yoff,xsize,ysize,bufxsize,bufysize,datatype,band_list,band_sequential,cache_size,page_size_hint, options)
         return gdalnumeric.VirtualMemGetArray( virtualmem )
 
-    def GetTiledVirtualMemArray(self, eAccess = gdalconst.GF_Read, xoff=0, yoff=0,
+    def GetTiledVirtualMemArray(self, eAccess=gdalconst.GF_Read, xoff=0, yoff=0,
                            xsize=None, ysize=None, tilexsize=256, tileysize=256,
-                           datatype = None, band_list = None, tile_organization = gdalconst.GTO_BSQ,
-                           cache_size = 10 * 1024 * 1024, options = None):
+                           datatype=None, band_list=None, tile_organization=gdalconst.GTO_BSQ,
+                           cache_size = 10 * 1024 * 1024, options=None):
         """Return a NumPy array for the dataset, seen as a virtual memory mapping with
            a tile organization.
            If there are several bands and tile_organization = gdal.GTO_TIP, an element is
@@ -769,7 +769,7 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
             i = i + 1
         return sd_list
 
-    def BeginAsyncReader(self, xoff, yoff, xsize, ysize, buf_obj = None, buf_xsize = None, buf_ysize = None, buf_type = None, band_list = None, options=None):
+    def BeginAsyncReader(self, xoff, yoff, xsize, ysize, buf_obj=None, buf_xsize=None, buf_ysize=None, buf_type=None, band_list=None, options=None):
         if band_list is None:
             band_list = range(1, self.RasterCount + 1)
         if buf_xsize is None:
@@ -788,15 +788,15 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
         if buf_obj is None:
             from sys import version_info
             nRequiredSize = int(buf_xsize * buf_ysize * len(band_list) * (_gdal.GetDataTypeSize(buf_type) / 8))
-            if version_info >= (3,0,0):
-                buf_obj_ar = [ None ]
+            if version_info >= (3, 0, 0):
+                buf_obj_ar = [None]
                 exec("buf_obj_ar[0] = b' ' * nRequiredSize")
                 buf_obj = buf_obj_ar[0]
             else:
                 buf_obj = ' ' * nRequiredSize
         return _gdal.Dataset_BeginAsyncReader(self, xoff, yoff, xsize, ysize, buf_obj, buf_xsize, buf_ysize, buf_type, band_list,  0, 0, 0, options)
 
-    def GetLayer(self,iLayer=0):
+    def GetLayer(self, iLayer=0):
         """Return the layer given an index or a name"""
         if isinstance(iLayer, str):
             return self.GetLayerByName(str(iLayer))
@@ -822,10 +822,10 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
 
 %extend GDALMajorObjectShadow {
 %pythoncode %{
-  def GetMetadata( self, domain = '' ):
+  def GetMetadata(self, domain=''):
     if domain[:4] == 'xml:':
-      return self.GetMetadata_List( domain )
-    return self.GetMetadata_Dict( domain )
+      return self.GetMetadata_List(domain)
+    return self.GetMetadata_Dict(domain)
 %}
 }
 
@@ -851,12 +851,12 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
 def _is_str_or_unicode(o):
     return isinstance(o, str) or str(type(o)) == "<type 'unicode'>"
 
-def InfoOptions(options = None, format = 'text', deserialize = True,
-         computeMinMax = False, reportHistograms = False, reportProj4 = False,
-         stats = False, approxStats = False, computeChecksum = False,
-         showGCPs = True, showMetadata = True, showRAT = True, showColorTable = True,
-         listMDD = False, showFileList = True, allMetadata = False,
-         extraMDDomains = None):
+def InfoOptions(options=None, format='text', deserialize=True,
+         computeMinMax=False, reportHistograms=False, reportProj4=False,
+         stats=False, approxStats=False, computeChecksum=False,
+         showGCPs=True, showMetadata=True, showRAT=True, showColorTable=True,
+         listMDD=False, showFileList=True, allMetadata=False,
+         extraMDDomains=None):
     """ Create a InfoOptions() object that can be passed to gdal.Info()
         options can be be an array of strings, a string or let empty and filled from other keywords."""
 
@@ -926,17 +926,17 @@ def Info(ds, **kwargs):
 def _strHighPrec(x):
     return x if _is_str_or_unicode(x) else '%.18g' % x
 
-def TranslateOptions(options = None, format = None,
-              outputType = GDT_Unknown, bandList = None, maskBand = None,
+def TranslateOptions(options=None, format=None,
+              outputType = GDT_Unknown, bandList=None, maskBand=None,
               width = 0, height = 0, widthPct = 0.0, heightPct = 0.0,
               xRes = 0.0, yRes = 0.0,
-              creationOptions = None, srcWin = None, projWin = None, projWinSRS = None, strict = False,
-              unscale = False, scaleParams = None, exponents = None,
-              outputBounds = None, metadataOptions = None,
-              outputSRS = None, GCPs = None,
-              noData = None, rgbExpand = None,
-              stats = False, rat = True, resampleAlg = None,
-              callback = None, callback_data = None):
+              creationOptions=None, srcWin=None, projWin=None, projWinSRS=None, strict = False,
+              unscale = False, scaleParams=None, exponents=None,
+              outputBounds=None, metadataOptions=None,
+              outputSRS=None, GCPs=None,
+              noData=None, rgbExpand=None,
+              stats = False, rat = True, resampleAlg=None,
+              callback=None, callback_data=None):
     """ Create a TranslateOptions() object that can be passed to gdal.Translate()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords.
@@ -979,19 +979,19 @@ def TranslateOptions(options = None, format = None,
         if format is not None:
             new_options += ['-of', format]
         if outputType != GDT_Unknown:
-            new_options += ['-ot', GetDataTypeName(outputType) ]
+            new_options += ['-ot', GetDataTypeName(outputType)]
         if maskBand != None:
-            new_options += ['-mask', str(maskBand) ]
+            new_options += ['-mask', str(maskBand)]
         if bandList != None:
             for b in bandList:
-                new_options += ['-b', str(b) ]
+                new_options += ['-b', str(b)]
         if width != 0 or height != 0:
             new_options += ['-outsize', str(width), str(height)]
         elif widthPct != 0 and heightPct != 0:
             new_options += ['-outsize', str(widthPct) + '%%', str(heightPct) + '%%']
         if creationOptions is not None:
             for opt in creationOptions:
-                new_options += ['-co', opt ]
+                new_options += ['-co', opt]
         if srcWin is not None:
             new_options += ['-srcwin', _strHighPrec(srcWin[0]), _strHighPrec(srcWin[1]), _strHighPrec(srcWin[2]), _strHighPrec(srcWin[3])]
         if strict:
@@ -1002,7 +1002,7 @@ def TranslateOptions(options = None, format = None,
             for scaleParam in scaleParams:
                 new_options += ['-scale']
                 for v in scaleParam:
-                    new_options += [ str(v) ]
+                    new_options += [str(v)]
         if exponents:
             for exponent in exponents:
                 new_options += ['-exponent', _strHighPrec(exponent)]
@@ -1010,20 +1010,20 @@ def TranslateOptions(options = None, format = None,
             new_options += ['-a_ullr', _strHighPrec(outputBounds[0]), _strHighPrec(outputBounds[1]), _strHighPrec(outputBounds[2]), _strHighPrec(outputBounds[3])]
         if metadataOptions is not None:
             for opt in metadataOptions:
-                new_options += ['-mo', opt ]
+                new_options += ['-mo', opt]
         if outputSRS is not None:
-            new_options += ['-a_srs', str(outputSRS) ]
+            new_options += ['-a_srs', str(outputSRS)]
         if GCPs is not None:
             for gcp in GCPs:
-                new_options += ['-gcp', _strHighPrec(gcp.GCPPixel), _strHighPrec(gcp.GCPLine), _strHighPrec(gcp.GCPX), str(gcp.GCPY), _strHighPrec(gcp.GCPZ) ]
+                new_options += ['-gcp', _strHighPrec(gcp.GCPPixel), _strHighPrec(gcp.GCPLine), _strHighPrec(gcp.GCPX), str(gcp.GCPY), _strHighPrec(gcp.GCPZ)]
         if projWin is not None:
             new_options += ['-projwin', _strHighPrec(projWin[0]), _strHighPrec(projWin[1]), _strHighPrec(projWin[2]), _strHighPrec(projWin[3])]
         if projWinSRS is not None:
-            new_options += ['-projwin_srs', str(projWinSRS) ]
+            new_options += ['-projwin_srs', str(projWinSRS)]
         if noData is not None:
-            new_options += ['-a_nodata', _strHighPrec(noData) ]
+            new_options += ['-a_nodata', _strHighPrec(noData)]
         if rgbExpand is not None:
-            new_options += ['-expand', str(rgbExpand) ]
+            new_options += ['-expand', str(rgbExpand)]
         if stats:
             new_options += ['-stats']
         if not rat:
@@ -1044,9 +1044,9 @@ def TranslateOptions(options = None, format = None,
             elif resampleAlg == GRA_Mode:
                 new_options += ['-r', 'mode']
             else:
-                new_options += ['-r', str(resampleAlg) ]
+                new_options += ['-r', str(resampleAlg)]
         if xRes != 0 and yRes != 0:
-            new_options += ['-tr', _strHighPrec(xRes), _strHighPrec(yRes) ]
+            new_options += ['-tr', _strHighPrec(xRes), _strHighPrec(yRes)]
 
     return (GDALTranslateOptions(new_options), callback, callback_data)
 
@@ -1069,23 +1069,23 @@ def Translate(destName, srcDS, **kwargs):
 
     return TranslateInternal(destName, srcDS, opts, callback, callback_data)
 
-def WarpOptions(options = None, format = None,
-         outputBounds = None,
-         outputBoundsSRS = None,
-         xRes = None, yRes = None, targetAlignedPixels = False,
+def WarpOptions(options=None, format=None,
+         outputBounds=None,
+         outputBoundsSRS=None,
+         xRes=None, yRes=None, targetAlignedPixels = False,
          width = 0, height = 0,
-         srcSRS = None, dstSRS = None,
+         srcSRS=None, dstSRS=None,
          srcAlpha = False, dstAlpha = False,
-         warpOptions = None, errorThreshold = None,
-         warpMemoryLimit = None, creationOptions = None, outputType = GDT_Unknown,
-         workingType = GDT_Unknown, resampleAlg = None,
-         srcNodata = None, dstNodata = None, multithread = False,
-         tps = False, rpc = False, geoloc = False, polynomialOrder = None,
-         transformerOptions = None, cutlineDSName = None,
-         cutlineLayer = None, cutlineWhere = None, cutlineSQL = None, cutlineBlend = None, cropToCutline = False,
-         copyMetadata = True, metadataConflictValue = None,
+         warpOptions=None, errorThreshold=None,
+         warpMemoryLimit=None, creationOptions=None, outputType = GDT_Unknown,
+         workingType = GDT_Unknown, resampleAlg=None,
+         srcNodata=None, dstNodata=None, multithread = False,
+         tps = False, rpc = False, geoloc = False, polynomialOrder=None,
+         transformerOptions=None, cutlineDSName=None,
+         cutlineLayer=None, cutlineWhere=None, cutlineSQL=None, cutlineBlend=None, cropToCutline = False,
+         copyMetadata = True, metadataConflictValue=None,
          setColorInterpretation = False,
-         callback = None, callback_data = None):
+         callback=None, callback_data=None):
     """ Create a WarpOptions() object that can be passed to gdal.Warp()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords.
@@ -1136,21 +1136,21 @@ def WarpOptions(options = None, format = None,
         if format is not None:
             new_options += ['-of', format]
         if outputType != GDT_Unknown:
-            new_options += ['-ot', GetDataTypeName(outputType) ]
+            new_options += ['-ot', GetDataTypeName(outputType)]
         if workingType != GDT_Unknown:
-            new_options += ['-wt', GetDataTypeName(workingType) ]
+            new_options += ['-wt', GetDataTypeName(workingType)]
         if outputBounds is not None:
-            new_options += ['-te', _strHighPrec(outputBounds[0]), _strHighPrec(outputBounds[1]), _strHighPrec(outputBounds[2]), _strHighPrec(outputBounds[3]) ]
+            new_options += ['-te', _strHighPrec(outputBounds[0]), _strHighPrec(outputBounds[1]), _strHighPrec(outputBounds[2]), _strHighPrec(outputBounds[3])]
         if outputBoundsSRS is not None:
-            new_options += ['-te_srs', str(outputBoundsSRS) ]
+            new_options += ['-te_srs', str(outputBoundsSRS)]
         if xRes is not None and yRes is not None:
-            new_options += ['-tr', _strHighPrec(xRes), _strHighPrec(yRes) ]
+            new_options += ['-tr', _strHighPrec(xRes), _strHighPrec(yRes)]
         if width != 0 or height != 0:
             new_options += ['-ts', str(width), str(height)]
         if srcSRS is not None:
-            new_options += ['-s_srs', str(srcSRS) ]
+            new_options += ['-s_srs', str(srcSRS)]
         if dstSRS is not None:
-            new_options += ['-t_srs', str(dstSRS) ]
+            new_options += ['-t_srs', str(dstSRS)]
         if targetAlignedPixels:
             new_options += ['-tap']
         if srcAlpha:
@@ -1180,16 +1180,16 @@ def WarpOptions(options = None, format = None,
             elif resampleAlg == GRIORA_Gauss:
                 new_options += ['-r', 'gauss']
             else:
-                new_options += ['-r', str(resampleAlg) ]
+                new_options += ['-r', str(resampleAlg)]
         if warpMemoryLimit is not None:
-            new_options += ['-wm', str(warpMemoryLimit) ]
+            new_options += ['-wm', str(warpMemoryLimit)]
         if creationOptions is not None:
             for opt in creationOptions:
-                new_options += ['-co', opt ]
+                new_options += ['-co', opt]
         if srcNodata is not None:
-            new_options += ['-srcnodata', str(srcNodata) ]
+            new_options += ['-srcnodata', str(srcNodata)]
         if dstNodata is not None:
-            new_options += ['-dstnodata', str(dstNodata) ]
+            new_options += ['-dstnodata', str(dstNodata)]
         if multithread:
             new_options += ['-multi']
         if tps:
@@ -1202,23 +1202,23 @@ def WarpOptions(options = None, format = None,
             new_options += ['-order', str(polynomialOrder)]
         if transformerOptions is not None:
             for opt in transformerOptions:
-                new_options += ['-to', opt ]
+                new_options += ['-to', opt]
         if cutlineDSName is not None:
-            new_options += ['-cutline', str(cutlineDSName) ]
+            new_options += ['-cutline', str(cutlineDSName)]
         if cutlineLayer is not None:
-            new_options += ['-cl', str(cutlineLayer) ]
+            new_options += ['-cl', str(cutlineLayer)]
         if cutlineWhere is not None:
-            new_options += ['-cwhere', str(cutlineWhere) ]
+            new_options += ['-cwhere', str(cutlineWhere)]
         if cutlineSQL is not None:
-            new_options += ['-csql', str(cutlineSQL) ]
+            new_options += ['-csql', str(cutlineSQL)]
         if cutlineBlend is not None:
-            new_options += ['-cblend', str(cutlineBlend) ]
+            new_options += ['-cblend', str(cutlineBlend)]
         if cropToCutline:
             new_options += ['-crop_to_cutline']
         if not copyMetadata:
             new_options += ['-nomd']
         if metadataConflictValue:
-            new_options += ['-cvmd', str(metadataConflictValue) ]
+            new_options += ['-cvmd', str(metadataConflictValue)]
         if setColorInterpretation:
             new_options += ['-setci']
 
@@ -1248,7 +1248,7 @@ def Warp(destNameOrDestDS, srcDSOrSrcDSTab, **kwargs):
             else:
                 srcDSTab.append(elt)
     else:
-        srcDSTab = [ srcDSOrSrcDSTab ]
+        srcDSTab = [srcDSOrSrcDSTab]
 
     if _is_str_or_unicode(destNameOrDestDS):
         return wrapper_GDALWarpDestName(destNameOrDestDS, srcDSTab, opts, callback, callback_data)
@@ -1256,24 +1256,24 @@ def Warp(destNameOrDestDS, srcDSOrSrcDSTab, **kwargs):
         return wrapper_GDALWarpDestDS(destNameOrDestDS, srcDSTab, opts, callback, callback_data)
 
 
-def VectorTranslateOptions(options = None, format = None,
-         accessMode = None,
-         srcSRS = None, dstSRS = None, reproject = True,
-         SQLStatement = None, SQLDialect = None, where = None, selectFields = None,
-         addFields = False,
-         forceNullable = False,
-         spatFilter = None, spatSRS = None,
-         datasetCreationOptions = None,
-         layerCreationOptions = None,
-         layers = None,
-         layerName = None,
-         geometryType = None,
-         dim = None,
+def VectorTranslateOptions(options=None, format=None,
+         accessMode=None,
+         srcSRS=None, dstSRS=None, reproject=True,
+         SQLStatement=None, SQLDialect=None, where=None, selectFields=None,
+         addFields=False,
+         forceNullable=False,
+         spatFilter=None, spatSRS=None,
+         datasetCreationOptions=None,
+         layerCreationOptions=None,
+         layers=None,
+         layerName=None,
+         geometryType=None,
+         dim=None,
          segmentizeMaxDist= None,
-         zField = None,
-         skipFailures = False,
-         limit = None,
-         callback = None, callback_data = None):
+         zField=None,
+         skipFailures=False,
+         limit=None,
+         callback=None, callback_data=None):
     """ Create a VectorTranslateOptions() object that can be passed to gdal.VectorTranslate()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords.
@@ -1312,18 +1312,18 @@ def VectorTranslateOptions(options = None, format = None,
         if format is not None:
             new_options += ['-f', format]
         if srcSRS is not None:
-            new_options += ['-s_srs', str(srcSRS) ]
+            new_options += ['-s_srs', str(srcSRS)]
         if dstSRS is not None:
             if reproject:
-                new_options += ['-t_srs', str(dstSRS) ]
+                new_options += ['-t_srs', str(dstSRS)]
             else:
-                new_options += ['-a_srs', str(dstSRS) ]
+                new_options += ['-a_srs', str(dstSRS)]
         if SQLStatement is not None:
-            new_options += ['-sql', str(SQLStatement) ]
+            new_options += ['-sql', str(SQLStatement)]
         if SQLDialect is not None:
-            new_options += ['-dialect', str(SQLDialect) ]
+            new_options += ['-dialect', str(SQLDialect)]
         if where is not None:
-            new_options += ['-where', str(where) ]
+            new_options += ['-where', str(where)]
         if accessMode is not None:
             if accessMode == 'update':
                 new_options += ['-update']
@@ -1340,28 +1340,28 @@ def VectorTranslateOptions(options = None, format = None,
         if selectFields is not None:
             val = ''
             for item in selectFields:
-                if len(val)>0:
+                if val:
                     val += ','
                 val += item
             new_options += ['-select', val]
         if datasetCreationOptions is not None:
             for opt in datasetCreationOptions:
-                new_options += ['-dsco', opt ]
+                new_options += ['-dsco', opt]
         if layerCreationOptions is not None:
             for opt in layerCreationOptions:
-                new_options += ['-lco', opt ]
+                new_options += ['-lco', opt]
         if layers is not None:
             if _is_str_or_unicode(layers):
-                new_options += [ layers ]
+                new_options += [layers]
             else:
                 for lyr in layers:
-                    new_options += [ lyr ]
+                    new_options += [lyr]
         if segmentizeMaxDist is not None:
-            new_options += ['-segmentize', str(segmentizeMaxDist) ]
+            new_options += ['-segmentize', str(segmentizeMaxDist)]
         if spatFilter is not None:
-            new_options += ['-spat', str(spatFilter[0]), str(spatFilter[1]), str(spatFilter[2]), str(spatFilter[3]) ]
+            new_options += ['-spat', str(spatFilter[0]), str(spatFilter[1]), str(spatFilter[2]), str(spatFilter[3])]
         if spatSRS is not None:
-            new_options += ['-spat_srs', str(spatSRS) ]
+            new_options += ['-spat_srs', str(spatSRS)]
         if layerName is not None:
             new_options += ['-nln', layerName]
         if geometryType is not None:
@@ -1375,7 +1375,7 @@ def VectorTranslateOptions(options = None, format = None,
         if limit is not None:
             new_options += ['-limit', str(limit)]
     if callback is not None:
-        new_options += [ '-progress' ]
+        new_options += ['-progress']
 
     return (GDALVectorTranslateOptions(new_options), callback, callback_data)
 
@@ -1401,13 +1401,13 @@ def VectorTranslate(destNameOrDestDS, srcDS, **kwargs):
     else:
         return wrapper_GDALVectorTranslateDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
-def DEMProcessingOptions(options = None, colorFilename = None, format = None,
-              creationOptions = None, computeEdges = False, alg = 'Horn', band = 1,
-              zFactor = None, scale = None, azimuth = None, altitude = None,
+def DEMProcessingOptions(options=None, colorFilename=None, format=None,
+              creationOptions=None, computeEdges = False, alg = 'Horn', band = 1,
+              zFactor=None, scale=None, azimuth=None, altitude=None,
               combined = False, multiDirectional = False,
-              slopeFormat = None, trigonometric = False, zeroForFlat = False,
-              addAlpha = None,
-              callback = None, callback_data = None):
+              slopeFormat=None, trigonometric = False, zeroForFlat = False,
+              addAlpha=None,
+              callback=None, callback_data=None):
     """ Create a DEMProcessingOptions() object that can be passed to gdal.DEMProcessing()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords.
@@ -1440,32 +1440,32 @@ def DEMProcessingOptions(options = None, colorFilename = None, format = None,
             new_options += ['-of', format]
         if creationOptions is not None:
             for opt in creationOptions:
-                new_options += ['-co', opt ]
+                new_options += ['-co', opt]
         if computeEdges:
-            new_options += ['-compute_edges' ]
-        if alg ==  'ZevenbergenThorne':
+            new_options += ['-compute_edges']
+        if alg == 'ZevenbergenThorne':
             new_options += ['-alg', 'ZevenbergenThorne']
-        new_options += ['-b', str(band) ]
+        new_options += ['-b', str(band)]
         if zFactor is not None:
-            new_options += ['-z', str(zFactor) ]
+            new_options += ['-z', str(zFactor)]
         if scale is not None:
-            new_options += ['-s', str(scale) ]
+            new_options += ['-s', str(scale)]
         if azimuth is not None:
-            new_options += ['-az', str(azimuth) ]
+            new_options += ['-az', str(azimuth)]
         if altitude is not None:
-            new_options += ['-alt', str(altitude) ]
+            new_options += ['-alt', str(altitude)]
         if combined:
-            new_options += ['-combined' ]
+            new_options += ['-combined']
         if multiDirectional:
-            new_options += ['-multidirectional' ]
+            new_options += ['-multidirectional']
         if slopeFormat == 'percent':
-            new_options += ['-p' ]
+            new_options += ['-p']
         if trigonometric:
-            new_options += ['-trigonometric' ]
+            new_options += ['-trigonometric']
         if zeroForFlat:
-            new_options += ['-zero_for_flat' ]
+            new_options += ['-zero_for_flat']
         if addAlpha:
-            new_options += [ '-alpha' ]
+            new_options += ['-alpha']
 
     return (GDALDEMProcessingOptions(new_options), colorFilename, callback, callback_data)
 
@@ -1490,10 +1490,10 @@ def DEMProcessing(destName, srcDS, processing, **kwargs):
     return DEMProcessingInternal(destName, srcDS, processing, colorFilename, opts, callback, callback_data)
 
 
-def NearblackOptions(options = None, format = None,
-         creationOptions = None, white = False, colors = None,
-         maxNonBlack = None, nearDist = None, setAlpha = False, setMask = False,
-         callback = None, callback_data = None):
+def NearblackOptions(options=None, format=None,
+         creationOptions=None, white = False, colors=None,
+         maxNonBlack=None, nearDist=None, setAlpha = False, setMask = False,
+         callback=None, callback_data=None):
     """ Create a NearblackOptions() object that can be passed to gdal.Nearblack()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords.
@@ -1518,7 +1518,7 @@ def NearblackOptions(options = None, format = None,
             new_options += ['-of', format]
         if creationOptions is not None:
             for opt in creationOptions:
-                new_options += ['-co', opt ]
+                new_options += ['-co', opt]
         if white:
             new_options += ['-white']
         if colors is not None:
@@ -1528,11 +1528,11 @@ def NearblackOptions(options = None, format = None,
                     if color_str != '':
                         color_str += ','
                     color_str += str(cpt)
-                new_options += ['-color',color_str]
+                new_options += ['-color', color_str]
         if maxNonBlack is not None:
-            new_options += ['-nb', str(maxNonBlack) ]
+            new_options += ['-nb', str(maxNonBlack)]
         if nearDist is not None:
-            new_options += ['-near', str(nearDist) ]
+            new_options += ['-near', str(nearDist)]
         if setAlpha:
             new_options += ['-setalpha']
         if setMask:
@@ -1563,22 +1563,22 @@ def Nearblack(destNameOrDestDS, srcDS, **kwargs):
         return wrapper_GDALNearblackDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 
-def GridOptions(options = None, format = None,
+def GridOptions(options=None, format=None,
               outputType = GDT_Unknown,
               width = 0, height = 0,
-              creationOptions = None,
-              outputBounds = None,
-              outputSRS = None,
-              noData = None,
-              algorithm = None,
-              layers = None,
-              SQLStatement = None,
-              where = None,
-              spatFilter = None,
-              zfield = None,
-              z_increase = None,
-              z_multiply = None,
-              callback = None, callback_data = None):
+              creationOptions=None,
+              outputBounds=None,
+              outputSRS=None,
+              noData=None,
+              algorithm=None,
+              layers=None,
+              SQLStatement=None,
+              where=None,
+              spatFilter=None,
+              zfield=None,
+              z_increase=None,
+              z_multiply=None,
+              callback=None, callback_data=None):
     """ Create a GridOptions() object that can be passed to gdal.Grid()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords.
@@ -1610,18 +1610,18 @@ def GridOptions(options = None, format = None,
         if format is not None:
             new_options += ['-of', format]
         if outputType != GDT_Unknown:
-            new_options += ['-ot', GetDataTypeName(outputType) ]
+            new_options += ['-ot', GetDataTypeName(outputType)]
         if width != 0 or height != 0:
             new_options += ['-outsize', str(width), str(height)]
         if creationOptions is not None:
             for opt in creationOptions:
-                new_options += ['-co', opt ]
+                new_options += ['-co', opt]
         if outputBounds is not None:
             new_options += ['-txe', _strHighPrec(outputBounds[0]), _strHighPrec(outputBounds[2]), '-tye', _strHighPrec(outputBounds[1]), _strHighPrec(outputBounds[3])]
         if outputSRS is not None:
-            new_options += ['-a_srs', str(outputSRS) ]
+            new_options += ['-a_srs', str(outputSRS)]
         if algorithm is not None:
-            new_options += ['-a', algorithm ]
+            new_options += ['-a', algorithm]
         if layers is not None:
             if type(layers) == type(()) or type(layers) == type([]):
                 for layer in layers:
@@ -1629,17 +1629,17 @@ def GridOptions(options = None, format = None,
             else:
                 new_options += ['-l', layers]
         if SQLStatement is not None:
-            new_options += ['-sql', str(SQLStatement) ]
+            new_options += ['-sql', str(SQLStatement)]
         if where is not None:
-            new_options += ['-where', str(where) ]
+            new_options += ['-where', str(where)]
         if zfield is not None:
-            new_options += ['-zfield', zfield ]
+            new_options += ['-zfield', zfield]
         if z_increase is not None:
-            new_options += ['-z_increase', str(z_increase) ]
+            new_options += ['-z_increase', str(z_increase)]
         if z_multiply is not None:
-            new_options += ['-z_multiply', str(z_multiply) ]
+            new_options += ['-z_multiply', str(z_multiply)]
         if spatFilter is not None:
-            new_options += ['-spat', str(spatFilter[0]), str(spatFilter[1]), str(spatFilter[2]), str(spatFilter[3]) ]
+            new_options += ['-spat', str(spatFilter[0]), str(spatFilter[1]), str(spatFilter[2]), str(spatFilter[3])]
 
     return (GDALGridOptions(new_options), callback, callback_data)
 
@@ -1662,17 +1662,17 @@ def Grid(destName, srcDS, **kwargs):
 
     return GridInternal(destName, srcDS, opts, callback, callback_data)
 
-def RasterizeOptions(options = None, format = None,
+def RasterizeOptions(options=None, format=None,
          outputType = GDT_Unknown,
-         creationOptions = None, noData = None, initValues = None,
-         outputBounds = None, outputSRS = None,
-         transformerOptions = None,
-         width = None, height = None,
-         xRes = None, yRes = None, targetAlignedPixels = False,
-         bands = None, inverse = False, allTouched = False,
-         burnValues = None, attribute = None, useZ = False, layers = None,
-         SQLStatement = None, SQLDialect = None, where = None, optim = None,
-         callback = None, callback_data = None):
+         creationOptions=None, noData=None, initValues=None,
+         outputBounds=None, outputSRS=None,
+         transformerOptions=None,
+         width=None, height=None,
+         xRes=None, yRes=None, targetAlignedPixels = False,
+         bands=None, inverse = False, allTouched = False,
+         burnValues=None, attribute=None, useZ = False, layers=None,
+         SQLStatement=None, SQLDialect=None, where=None, optim=None,
+         callback=None, callback_data=None):
     """ Create a RasterizeOptions() object that can be passed to gdal.Rasterize()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords.
@@ -1710,28 +1710,28 @@ def RasterizeOptions(options = None, format = None,
         if format is not None:
             new_options += ['-of', format]
         if outputType != GDT_Unknown:
-            new_options += ['-ot', GetDataTypeName(outputType) ]
+            new_options += ['-ot', GetDataTypeName(outputType)]
         if creationOptions is not None:
             for opt in creationOptions:
-                new_options += ['-co', opt ]
+                new_options += ['-co', opt]
         if bands is not None:
             for b in bands:
-                new_options += ['-b', str(b) ]
+                new_options += ['-b', str(b)]
         if noData is not None:
-            new_options += ['-a_nodata', str(noData) ]
+            new_options += ['-a_nodata', str(noData)]
         if initValues is not None:
             if type(initValues) == type(()) or type(initValues) == type([]):
                 for val in initValues:
-                    new_options += ['-init', str(val) ]
+                    new_options += ['-init', str(val)]
             else:
-                new_options += ['-init', str(initValues) ]
+                new_options += ['-init', str(initValues)]
         if outputBounds is not None:
             new_options += ['-te', _strHighPrec(outputBounds[0]), _strHighPrec(outputBounds[1]), _strHighPrec(outputBounds[2]), _strHighPrec(outputBounds[3])]
         if outputSRS is not None:
-            new_options += ['-a_srs', str(outputSRS) ]
+            new_options += ['-a_srs', str(outputSRS)]
         if transformerOptions is not None:
             for opt in transformerOptions:
-                new_options += ['-to', opt ]
+                new_options += ['-to', opt]
         if width is not None and height is not None:
             new_options += ['-ts', str(width), str(height)]
         if xRes is not None and yRes is not None:
@@ -1747,9 +1747,9 @@ def RasterizeOptions(options = None, format = None,
                 raise Exception('burnValues and attribute option are exclusive.')
             if type(burnValues) == type(()) or type(burnValues) == type([]):
                 for val in burnValues:
-                    new_options += ['-burn', str(val) ]
+                    new_options += ['-burn', str(val)]
             else:
-                new_options += ['-burn', str(burnValues) ]
+                new_options += ['-burn', str(burnValues)]
         if attribute is not None:
             new_options += ['-a', attribute]
         if useZ:
@@ -1761,13 +1761,13 @@ def RasterizeOptions(options = None, format = None,
             else:
                 new_options += ['-l', layers]
         if SQLStatement is not None:
-            new_options += ['-sql', str(SQLStatement) ]
+            new_options += ['-sql', str(SQLStatement)]
         if SQLDialect is not None:
-            new_options += ['-dialect', str(SQLDialect) ]
+            new_options += ['-dialect', str(SQLDialect)]
         if where is not None:
-            new_options += ['-where', str(where) ]
+            new_options += ['-where', str(where)]
         if optim is not None:
-            new_options += ['-optim', str(optim) ]
+            new_options += ['-optim', str(optim)]
 
     return (GDALRasterizeOptions(new_options), callback, callback_data)
 
@@ -1794,21 +1794,21 @@ def Rasterize(destNameOrDestDS, srcDS, **kwargs):
         return wrapper_GDALRasterizeDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 
-def BuildVRTOptions(options = None,
-                    resolution = None,
-                    outputBounds = None,
-                    xRes = None, yRes = None,
-                    targetAlignedPixels = None,
-                    separate = None,
-                    bandList = None,
-                    addAlpha = None,
-                    resampleAlg = None,
-                    outputSRS = None,
-                    allowProjectionDifference = None,
-                    srcNodata = None,
-                    VRTNodata = None,
-                    hideNodata = None,
-                    callback = None, callback_data = None):
+def BuildVRTOptions(options=None,
+                    resolution=None,
+                    outputBounds=None,
+                    xRes=None, yRes=None,
+                    targetAlignedPixels=None,
+                    separate=None,
+                    bandList=None,
+                    addAlpha=None,
+                    resampleAlg=None,
+                    outputSRS=None,
+                    allowProjectionDifference=None,
+                    srcNodata=None,
+                    VRTNodata=None,
+                    hideNodata=None,
+                    callback=None, callback_data=None):
     """ Create a BuildVRTOptions() object that can be passed to gdal.BuildVRT()
         Keyword arguments are :
           options --- can be be an array of strings, a string or let empty and filled from other keywords..
@@ -1835,7 +1835,7 @@ def BuildVRTOptions(options = None,
     else:
         new_options = options
         if resolution is not None:
-            new_options += ['-resolution', str(resolution) ]
+            new_options += ['-resolution', str(resolution)]
         if outputBounds is not None:
             new_options += ['-te', _strHighPrec(outputBounds[0]), _strHighPrec(outputBounds[1]), _strHighPrec(outputBounds[2]), _strHighPrec(outputBounds[3])]
         if xRes is not None and yRes is not None:
@@ -1846,7 +1846,7 @@ def BuildVRTOptions(options = None,
             new_options += ['-separate']
         if bandList != None:
             for b in bandList:
-                new_options += ['-b', str(b) ]
+                new_options += ['-b', str(b)]
         if addAlpha:
             new_options += ['-addalpha']
         if resampleAlg is not None:
@@ -1867,15 +1867,15 @@ def BuildVRTOptions(options = None,
             elif resampleAlg == GRIORA_Gauss:
                 new_options += ['-r', 'gauss']
             else:
-                new_options += ['-r', str(resampleAlg) ]
+                new_options += ['-r', str(resampleAlg)]
         if outputSRS is not None:
-            new_options += ['-a_srs', str(outputSRS) ]
+            new_options += ['-a_srs', str(outputSRS)]
         if allowProjectionDifference:
             new_options += ['-allow_projection_difference']
         if srcNodata is not None:
-            new_options += ['-srcnodata', str(srcNodata) ]
+            new_options += ['-srcnodata', str(srcNodata)]
         if VRTNodata is not None:
-            new_options += ['-vrtnodata', str(VRTNodata) ]
+            new_options += ['-vrtnodata', str(VRTNodata)]
         if hideNodata:
             new_options += ['-hidenodata']
 
@@ -1899,7 +1899,7 @@ def BuildVRT(destName, srcDSOrSrcDSTab, **kwargs):
     srcDSTab = []
     srcDSNamesTab = []
     if _is_str_or_unicode(srcDSOrSrcDSTab):
-        srcDSNamesTab = [ srcDSOrSrcDSTab ]
+        srcDSNamesTab = [srcDSOrSrcDSTab]
     elif type(srcDSOrSrcDSTab) == type([]):
         for elt in srcDSOrSrcDSTab:
             if _is_str_or_unicode(elt):
@@ -1909,7 +1909,7 @@ def BuildVRT(destName, srcDSOrSrcDSTab, **kwargs):
         if len(srcDSTab) != 0 and len(srcDSNamesTab) != 0:
             raise Exception('Mix of names and dataset objects not supported')
     else:
-        srcDSTab = [ srcDSOrSrcDSTab ]
+        srcDSTab = [srcDSOrSrcDSTab]
 
     if len(srcDSTab) > 0:
         return BuildVRTInternalObjects(destName, srcDSTab, opts, callback, callback_data)

--- a/gdal/swig/include/python/ogr_python.i
+++ b/gdal/swig/include/python/ogr_python.i
@@ -52,12 +52,12 @@
   %pythoncode {
     def Destroy(self):
       "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
-      _ogr.delete_DataSource( self )
+      _ogr.delete_DataSource(self)
       self.thisown = 0
 
     def Release(self):
       "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
-      _ogr.delete_DataSource( self )
+      _ogr.delete_DataSource(self)
       self.thisown = 0
 
     def Reference(self):
@@ -79,7 +79,7 @@
         ds[0:4] would return a list of the first four layers."""
         if isinstance(value, slice):
             output = []
-            for i in xrange(value.start,value.stop,value.step):
+            for i in xrange(value.start, value.stop, value.step):
                 try:
                     output.append(self.GetLayer(i))
                 except OGRError: #we're done because we're off the end
@@ -94,7 +94,7 @@
         else:
             raise TypeError('Input %s is not of String or Int type' % type(value))
 
-    def GetLayer(self,iLayer=0):
+    def GetLayer(self, iLayer=0):
         """Return the layer given an index or a name"""
         if isinstance(iLayer, str):
             return self.GetLayerByName(str(iLayer))
@@ -157,7 +157,7 @@
                 stop = len(self) - 1
             else:
                 stop = value.stop
-            for i in xrange(value.start,stop,value.step):
+            for i in xrange(value.start, stop, value.step):
                 feature = self.GetFeature(i)
                 if feature:
                     output.append(feature)
@@ -215,7 +215,7 @@
 
     def Destroy(self):
       "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
-      _ogr.delete_Feature( self )
+      _ogr.delete_Feature(self)
       self.thisown = 0
 
     def __cmp__(self, other):
@@ -251,7 +251,7 @@
         else:
             idx = self.GetFieldIndex(key)
             if idx != -1:
-                self.SetField2(idx,value)
+                self.SetField2(idx, value)
             else:
                 idx = self.GetGeomFieldIndex(key)
                 if idx != -1:
@@ -293,9 +293,9 @@
             if fld_index < 0:
                 raise ValueError("Illegal field requested in SetField()")
             else:
-                return self.SetGeomField( fld_index, value )
+                return self.SetGeomField(fld_index, value)
         else:
-            return self.SetField2( fld_index, value )
+            return self.SetField2(fld_index, value)
 
     def GetField(self, fld_index):
         if isinstance(fld_index, str) or isinstance(fld_index, type(u'')):
@@ -369,29 +369,29 @@
             raise ValueError("Illegal field requested in SetField2()")
 
         if value is None:
-            self.SetFieldNull( fld_index )
+            self.SetFieldNull(fld_index)
             return
 
-        if isinstance(value,list):
+        if isinstance(value, list):
             if len(value) == 0:
-                self.SetFieldNull( fld_index )
+                self.SetFieldNull(fld_index)
                 return
-            if isinstance(value[0],type(1)) or isinstance(value[0],type(12345678901234)):
-                self.SetFieldInteger64List(fld_index,value)
+            if isinstance(value[0], type(1)) or isinstance(value[0], type(12345678901234)):
+                self.SetFieldInteger64List(fld_index, value)
                 return
-            elif isinstance(value[0],float):
-                self.SetFieldDoubleList(fld_index,value)
+            elif isinstance(value[0], float):
+                self.SetFieldDoubleList(fld_index, value)
                 return
-            elif isinstance(value[0],str):
-                self.SetFieldStringList(fld_index,value)
+            elif isinstance(value[0], str):
+                self.SetFieldStringList(fld_index, value)
                 return
             else:
-                raise TypeError( 'Unsupported type of list in SetField2(). Type of element is %s' % str(type(value[0])) )
+                raise TypeError('Unsupported type of list in SetField2(). Type of element is %s' % str(type(value[0])))
 
         try:
-            self.SetField( fld_index, value )
+            self.SetField(fld_index, value)
         except:
-            self.SetField( fld_index, str(value) )
+            self.SetField(fld_index, str(value))
         return
 
     def keys(self):
@@ -410,7 +410,7 @@
     def geometry(self):
         return self.GetGeometryRef()
 
-    def ExportToJson(self, as_object = False, options = None):
+    def ExportToJson(self, as_object=False, options=None):
         """Exports a GeoJSON object which represents the Feature. The
            as_object parameter determines whether the returned value
            should be a Python object instead of a string. Defaults to False.
@@ -428,7 +428,7 @@
         if geom is not None:
             if options is None:
                 options = []
-            geom_json_string = geom.ExportToJson(options = options)
+            geom_json_string = geom.ExportToJson(options=options)
             geom_json_object = simplejson.loads(geom_json_string)
         else:
             geom_json_object = None
@@ -514,7 +514,7 @@
 %pythoncode {
   def Destroy(self):
     "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
-    _ogr.delete_FeatureDefn( self )
+    _ogr.delete_FeatureDefn(self)
     self.thisown = 0
 
 }
@@ -524,7 +524,7 @@
 %pythoncode %{
   def Destroy(self):
     "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
-    _ogr.delete_FieldDefn( self )
+    _ogr.delete_FieldDefn(self)
     self.thisown = 0
 %}
 }
@@ -537,10 +537,10 @@
 
 %extend GDALMajorObjectShadow {
 %pythoncode %{
-  def GetMetadata( self, domain = '' ):
+  def GetMetadata(self, domain=''):
     if domain[:4] == 'xml:':
-      return self.GetMetadata_List( domain )
-    return self.GetMetadata_Dict( domain )
+      return self.GetMetadata_List(domain)
+    return self.GetMetadata_Dict(domain)
 %}
 }
 #endif


### PR DESCRIPTION
These are a bit harder to manage, as Pylint reports errors in the generated files and the fixes belong in fragments of the `.i` files. These fixes will be inserted into the generated `.py` scripts once they are regenerated (please) :-)
    
The only non-whitespace changes are:

```    
    -        if (xoff == 0) and (yoff == 0):
    +        if xoff == 0 and yoff == 0:
```
and:
```
    -                if len(val)>0:
    +                if val:
```

The latter change fixes `len-as-condition (C1801): Do not use len(SEQUENCE) as condition value`.