### PR TITLE
Pyton code: Use new-style classes

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -218,7 +218,7 @@ def basic_test_9():
 # Test gdal.PushErrorHandler() with a Python error handler as a method (#5186)
 
 
-class my_python_error_handler_class:
+class my_python_error_handler_class(object):
     def __init__(self):
         self.eErrClass = None
         self.err_no = None

--- a/autotest/gcore/hfa_srs.py
+++ b/autotest/gcore/hfa_srs.py
@@ -41,7 +41,7 @@ import gdaltest
 ###############################################################################
 # Write a HFA/Imagine and read it back to check its SRS
 
-class TestHFASRS:
+class TestHFASRS(object):
     def __init__(self, epsg_code, use_epsg_code, expected_fail):
         self.epsg_code = epsg_code
         self.use_epsg_code = use_epsg_code

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -265,7 +265,7 @@ def misc_5():
 
 
 ###############################################################################
-class misc_6_interrupt_callback_class:
+class misc_6_interrupt_callback_class(object):
     def __init__(self):
         pass
 

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -2901,7 +2901,7 @@ def tiff_read_gcp_internal_and_auxxml():
 # Test reading .tif + .aux
 
 
-class myHandlerClass:
+class myHandlerClass(object):
     def __init__(self):
         self.msg = None
 

--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -41,7 +41,7 @@ import gdaltest
 ###############################################################################
 # Write a geotiff and read it back to check its SRS
 
-class TestTiffSRS:
+class TestTiffSRS(object):
     def __init__(self, epsg_code, use_epsg_code, expected_fail):
         self.epsg_code = epsg_code
         self.use_epsg_code = use_epsg_code

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -584,7 +584,7 @@ def vsis3_2():
     # Test temporary redirect
     handler = webserver.SequentialHandler()
 
-    class HandlerClass:
+    class HandlerClass(object):
         def __init__(self, response_value):
             self.old_authorization = None
             self.response_value = response_value
@@ -936,7 +936,7 @@ def vsis3_3():
     # Test temporary redirect
     handler = webserver.SequentialHandler()
 
-    class HandlerClass:
+    class HandlerClass(object):
         def __init__(self, response_value):
             self.old_authorization = None
             self.response_value = response_value

--- a/autotest/gdrivers/envisat.py
+++ b/autotest/gdrivers/envisat.py
@@ -75,7 +75,7 @@ def _get_mds_num(filename):
 #
 
 
-class TestEnvisat:
+class TestEnvisat(object):
     # Just a base class
 
     def __init__(self, downloadURL, fileName, size, checksum):

--- a/autotest/gdrivers/fit.py
+++ b/autotest/gdrivers/fit.py
@@ -39,7 +39,7 @@ import gdaltest
 #
 
 
-class TestFIT:
+class TestFIT(object):
     def __init__(self, fileName):
         self.fileName = fileName
         self.fitDriver = gdal.GetDriverByName('FIT')

--- a/autotest/gdrivers/fits.py
+++ b/autotest/gdrivers/fits.py
@@ -51,7 +51,7 @@ def fits_init():
 #
 
 
-class TestFITS:
+class TestFITS(object):
     def __init__(self, fileName):
         self.fileName = fileName
 

--- a/autotest/gdrivers/gxf.py
+++ b/autotest/gdrivers/gxf.py
@@ -73,7 +73,7 @@ def gxf_2():
 #
 
 
-class TestGXF:
+class TestGXF(object):
     def __init__(self, downloadURL, fileName, checksum, download_size):
         self.downloadURL = downloadURL
         self.fileName = fileName

--- a/autotest/gdrivers/hdf5.py
+++ b/autotest/gdrivers/hdf5.py
@@ -557,7 +557,7 @@ def hdf5_17():
     return 'success'
 
 
-class TestHDF5:
+class TestHDF5(object):
     def __init__(self, downloadURL, fileName, subdatasetname, checksum, download_size):
         self.downloadURL = downloadURL
         self.fileName = fileName

--- a/autotest/gdrivers/l1b.py
+++ b/autotest/gdrivers/l1b.py
@@ -40,7 +40,7 @@ import gdaltest
 
 ###############################################################################
 #
-class TestL1B:
+class TestL1B(object):
     def __init__(self, downloadURL, fileName, checksum, download_size, gcpNumber):
         self.downloadURL = downloadURL
         self.fileName = fileName

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -730,7 +730,7 @@ def mrf_cleanup():
 gdaltest_list = []
 
 
-class myTestCreateCopyWrapper:
+class myTestCreateCopyWrapper(object):
 
     def __init__(self, ut):
         self.ut = ut

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -294,7 +294,7 @@ def chkDerivedName(name):
 # ======================
 # Checking class
 # ======================
-class CFChecker:
+class CFChecker(object):
 
     def __init__(self, uploader=None, useFileName="yes", badc=None, coards=None, cfStandardNamesXML=None, cfAreaTypesXML=None, udunitsDat=None, version=newest_version):
         self.uploader = uploader

--- a/autotest/gdrivers/xmp.py
+++ b/autotest/gdrivers/xmp.py
@@ -41,7 +41,7 @@ import gdaltest
 #
 
 
-class TestXMPRead:
+class TestXMPRead(object):
     def __init__(self, drivername, filename, expect_xmp):
         self.drivername = drivername
         self.filename = filename

--- a/autotest/gdrivers/xpm.py
+++ b/autotest/gdrivers/xpm.py
@@ -38,7 +38,7 @@ import gdaltest
 
 ###############################################################################
 #
-class TestXPM:
+class TestXPM(object):
     def __init__(self, downloadURL, fileName, checksum, download_size):
         self.downloadURL = downloadURL
         self.fileName = fileName

--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -41,7 +41,7 @@ from osgeo import gdal
 ###############################################################################
 
 
-class gml_geom_unit:
+class gml_geom_unit(object):
     def __init__(self, unit):
         self.unit = unit
 

--- a/autotest/ogr/ogr_gmlas.py
+++ b/autotest/ogr/ogr_gmlas.py
@@ -712,7 +712,7 @@ def ogr_gmlas_abstractgeometry():
 # Test validation against schema
 
 
-class MyHandler:
+class MyHandler(object):
     def __init__(self):
         self.error_list = []
 

--- a/autotest/ogr/ogr_wkbwkt_geom.py
+++ b/autotest/ogr/ogr_wkbwkt_geom.py
@@ -39,7 +39,7 @@ from osgeo import gdal
 ###############################################################################
 
 
-class wkb_wkt_unit:
+class wkb_wkt_unit(object):
     def __init__(self, unit):
         self.unit = unit
 

--- a/autotest/ogr/ogr_wktempty.py
+++ b/autotest/ogr/ogr_wktempty.py
@@ -34,7 +34,7 @@ import gdaltest
 from osgeo import ogr
 
 
-class TestWktEmpty:
+class TestWktEmpty(object):
     def __init__(self, inString, expectedOutString):
         self.inString = inString
         self.expectedOutString = expectedOutString

--- a/autotest/osr/osr_ct_proj.py
+++ b/autotest/osr/osr_ct_proj.py
@@ -44,7 +44,7 @@ bonne = 'PROJCS["bonne",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1
 # Class to perform the tests.
 
 
-class ProjTest:
+class ProjTest(object):
     def __init__(self, src_srs, src_xyz, src_error,
                  dst_srs, dst_xyz, dst_error, options, requirements):
         self.src_srs = src_srs

--- a/autotest/osr/osr_metacrs.py
+++ b/autotest/osr/osr_metacrs.py
@@ -43,7 +43,7 @@ from osgeo import osr, gdal
 # Class to perform the tests.
 
 
-class MetaCRSTest:
+class MetaCRSTest(object):
     def __init__(self, test_line):
         self.test_line = test_line
         self.src_xyz = None

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -381,7 +381,7 @@ def testCreateCopyInterruptCallback(pct, message, user_data):
 ###############################################################################
 
 
-class GDALTest:
+class GDALTest(object):
     def __init__(self, drivername, filename, band, chksum,
                  xoff=0, yoff=0, xsize=0, ysize=0, options=None,
                  filename_absolute=0, chksum_after_reopening=None, open_options=None):

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -55,7 +55,7 @@ def install_http_handler(handler_instance):
         custom_handler = None
 
 
-class RequestResponse:
+class RequestResponse(object):
     def __init__(self, method, path, code, headers=None, body=None, custom_method=None, expected_headers=None, expected_body=None):
         self.method = method
         self.path = path
@@ -67,7 +67,7 @@ class RequestResponse:
         self.expected_body = expected_body
 
 
-class FileHandler:
+class FileHandler(object):
     def __init__(self, _dict):
         self.dict = _dict
 
@@ -108,7 +108,7 @@ class FileHandler:
             request.wfile.write(filedata[start:end])
 
 
-class SequentialHandler:
+class SequentialHandler(object):
     def __init__(self):
         self.req_count = 0
         self.req_resp = []

--- a/gdal/swig/include/python/docs/doxy2swig.py
+++ b/gdal/swig/include/python/docs/doxy2swig.py
@@ -41,7 +41,7 @@ def my_open_write(dest):
     return open(dest, 'w')
 
 
-class Doxy2SWIG:
+class Doxy2SWIG(object):
     """Converts Doxygen generated XML files into a file containing
     docstrings that can be used by SWIG-1.3.x that have support for
     feature("docstring").  Once the data is parsed it is stored in

--- a/gdal/swig/python/samples/build_jp2_from_xml.py
+++ b/gdal/swig/python/samples/build_jp2_from_xml.py
@@ -400,7 +400,7 @@ def parse_jp2file(inpath, xml_tree, out_f):
 # Wrapper class for GDAL VSI*L API with class Python file interface
 
 
-class VSILFile:
+class VSILFile(object):
     def __init__(self, filename, access):
         self.f = gdal.VSIFOpenL(filename, access)
 

--- a/gdal/swig/python/samples/gdal_cp.py
+++ b/gdal/swig/python/samples/gdal_cp.py
@@ -45,7 +45,7 @@ def Usage():
     return -1
 
 
-class TermProgress:
+class TermProgress(object):
     def __init__(self):
         self.nLastTick = -1
         self.nThisTick = 0
@@ -79,7 +79,7 @@ class TermProgress:
         return True
 
 
-class ScaledProgress:
+class ScaledProgress(object):
     def __init__(self, dfMin, dfMax, UnderlyingProgress):
         self.dfMin = dfMin
         self.dfMax = dfMax

--- a/gdal/swig/python/samples/gdal_vrtmerge.py
+++ b/gdal/swig/python/samples/gdal_vrtmerge.py
@@ -53,7 +53,7 @@ def names_to_fileinfos(names):
 # *****************************************************************************
 
 
-class file_info:
+class file_info(object):
     """A class holding information about a GDAL file."""
 
     def __init__(self):

--- a/gdal/swig/python/samples/gdalpythonserver.py
+++ b/gdal/swig/python/samples/gdalpythonserver.py
@@ -38,7 +38,7 @@ import sys
 from osgeo import gdal
 
 
-class GDALPythonServerRasterBand:
+class GDALPythonServerRasterBand(object):
 
     def __init__(self, gdal_band):
         self.gdal_band = gdal_band
@@ -124,7 +124,7 @@ class GDALPythonServerRasterBand:
         return self.gdal_band.GetHistogram(dfMin, dfMax, nBuckets, include_out_of_range=bIncludeOutOfRange, approx_ok=bApproxOK)
 
 
-class GDALPythonServerDataset:
+class GDALPythonServerDataset(object):
 
     def __init__(self, filename, access=gdal.GA_ReadOnly, open_options=None):
         nFlags = 0

--- a/gdal/swig/python/samples/loslas2ntv2.py
+++ b/gdal/swig/python/samples/loslas2ntv2.py
@@ -30,8 +30,8 @@
 #  DEALINGS IN THE SOFTWARE.
 # ******************************************************************************
 
-import sys
 from osgeo import gdal
+import sys
 
 # dummy object to hold options
 

--- a/gdal/swig/python/samples/loslas2ntv2.py
+++ b/gdal/swig/python/samples/loslas2ntv2.py
@@ -30,13 +30,13 @@
 #  DEALINGS IN THE SOFTWARE.
 # ******************************************************************************
 
-from osgeo import gdal
 import sys
+from osgeo import gdal
 
 # dummy object to hold options
 
 
-class Options:
+class Options(object):
     def __init__(self):
         self.verbose_flag = 0
         self.append = 0

--- a/gdal/swig/python/samples/ogr2ogr.py
+++ b/gdal/swig/python/samples/ogr2ogr.py
@@ -46,7 +46,7 @@ from osgeo import osr
 ###############################################################################
 
 
-class ScaledProgressObject:
+class ScaledProgressObject(object):
     def __init__(self, min, max, cbk, cbk_data=None):
         self.min = min
         self.max = max
@@ -107,7 +107,7 @@ def TermProgress(dfComplete, pszMessage, pProgressArg):
     return True
 
 
-class TargetLayerInfo:
+class TargetLayerInfo(object):
     def __init__(self):
         self.poDstLayer = None
         self.poCT = None
@@ -116,7 +116,7 @@ class TargetLayerInfo:
         self.iSrcZField = None
 
 
-class AssociatedLayers:
+class AssociatedLayers(object):
     def __init__(self):
         self.poSrcLayer = None
         self.psInfo = None

--- a/gdal/swig/python/samples/ogr_dispatch.py
+++ b/gdal/swig/python/samples/ogr_dispatch.py
@@ -89,7 +89,7 @@ def wkbFlatten(x):
 ###############################################################
 
 
-class Options:
+class Options(object):
     def __init__(self):
         self.lco = []
         self.dispatch_fields = []

--- a/gdal/swig/python/samples/tigerpoly.py
+++ b/gdal/swig/python/samples/tigerpoly.py
@@ -36,7 +36,7 @@ from osgeo import osr
 
 
 #############################################################################
-class Module:
+class Module(object):
 
     def __init__(self):
         self.lines = {}

--- a/gdal/swig/python/samples/validate_gpkg.py
+++ b/gdal/swig/python/samples/validate_gpkg.py
@@ -63,7 +63,7 @@ class GPKGCheckException(Exception):
     pass
 
 
-class GPKGChecker:
+class GPKGChecker(object):
 
     EXT_GEOM_TYPES = ('CIRCULARSTRING', 'COMPOUNDCURVE', 'CURVEPOLYGON',
                       'MULTICURVE', 'MULTISURFACE', 'CURVE', 'SURFACE')

--- a/gdal/swig/python/samples/validate_jp2.py
+++ b/gdal/swig/python/samples/validate_jp2.py
@@ -189,7 +189,7 @@ def get_gmljp2(filename):
     return mdd[0]
 
 
-class ErrorReport:
+class ErrorReport(object):
     def __init__(self, collect_internally=False):
         self.error_count = 0
         self.warning_count = 0

--- a/gdal/swig/python/scripts/gdal_merge.py
+++ b/gdal/swig/python/scripts/gdal_merge.py
@@ -209,7 +209,7 @@ def names_to_fileinfos(names):
 # *****************************************************************************
 
 
-class file_info:
+class file_info(object):
     """A class holding information about a GDAL file."""
 
     def __init__(self):

--- a/gdal/swig/python/scripts/gdal_retile.py
+++ b/gdal/swig/python/scripts/gdal_retile.py
@@ -40,7 +40,7 @@ from osgeo import osr
 progress = gdal.TermProgress_nocb
 
 
-class AffineTransformDecorator:
+class AffineTransformDecorator(object):
     """ A class providing some useful methods for affine Transformations """
 
     def __init__(self, transform):
@@ -71,7 +71,7 @@ class AffineTransformDecorator:
         return [xlist, ylist]
 
 
-class DataSetCache:
+class DataSetCache(object):
     """ A class for caching source tiles """
 
     def __init__(self):
@@ -101,7 +101,7 @@ class DataSetCache:
         del self.dict
 
 
-class tile_info:
+class tile_info(object):
     """ A class holding info how to tile """
 
     def __init__(self, xsize, ysize, tileWidth, tileHeight, overlap):
@@ -125,7 +125,7 @@ class tile_info:
         print('overlap:     %d' % self.overlap)
 
 
-class mosaic_info:
+class mosaic_info(object):
     """A class holding information about a GDAL file or a GDAL fileset"""
 
     def __init__(self, filename, inputDS):

--- a/gdal/swig/python/scripts/ogrmerge.py
+++ b/gdal/swig/python/scripts/ogrmerge.py
@@ -149,7 +149,7 @@ def _Esc(x):
     return gdal.EscapeString(x, gdal.CPLES_XML)
 
 
-class XMLWriter:
+class XMLWriter(object):
 
     def __init__(self, f):
         self.f = f


### PR DESCRIPTION
## What does this PR do?

Pylint warns about old-style classes. Best to inherit `object` until Python 3 becomes standard.