### PR TITLE
Python code: Rename foo, bar, baz, baq -> field1, field2, field3, field4

### DIFF
--- a/autotest/ogr/ogr_rfc35_mem.py
+++ b/autotest/ogr/ogr_rfc35_mem.py
@@ -96,7 +96,7 @@ def Truncate(val, lyr_defn, fieldname):
     return val
 
 
-def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
+def CheckFeatures(lyr, field1='foo5', field2='bar10', field3='baz15', field4='baw20'):
 
     expected_values = [
         ['foo0', None, None, None],
@@ -111,10 +111,10 @@ def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
     feat = lyr.GetNextFeature()
     i = 0
     while feat is not None:
-        if (foo is not None and feat.GetField(foo) != Truncate(expected_values[i][0], lyr_defn, foo)) or \
-           (bar is not None and feat.GetField(bar) != Truncate(expected_values[i][1], lyr_defn, bar)) or \
-           (baz is not None and feat.GetField(baz) != Truncate(expected_values[i][2], lyr_defn, baz)) or \
-           (baw is not None and feat.GetField(baw) != Truncate(expected_values[i][3], lyr_defn, baw)):
+        if (field1 is not None and feat.GetField(field1) != Truncate(expected_values[i][0], lyr_defn, field1)) or \
+           (field2 is not None and feat.GetField(field2) != Truncate(expected_values[i][1], lyr_defn, field2)) or \
+           (field3 is not None and feat.GetField(field3) != Truncate(expected_values[i][2], lyr_defn, field3)) or \
+           (field4 is not None and feat.GetField(field4) != Truncate(expected_values[i][3], lyr_defn, field4)):
             feat.DumpReadable()
             return 'fail'
         feat = lyr.GetNextFeature()

--- a/autotest/ogr/ogr_rfc35_mem.py
+++ b/autotest/ogr/ogr_rfc35_mem.py
@@ -237,7 +237,7 @@ def ogr_rfc35_mem_3():
 
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz15"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz25')
+    ret = CheckFeatures(lyr, field3='baz25')
     if ret != 'success':
         return ret
 
@@ -247,7 +247,7 @@ def ogr_rfc35_mem_3():
     lyr_defn = lyr.GetLayerDefn()
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz25"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -256,7 +256,7 @@ def ogr_rfc35_mem_3():
     if fld_defn.GetWidth() != 5:
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -294,7 +294,7 @@ def ogr_rfc35_mem_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -307,7 +307,7 @@ def ogr_rfc35_mem_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -321,7 +321,7 @@ def ogr_rfc35_mem_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -336,7 +336,7 @@ def ogr_rfc35_mem_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -367,7 +367,7 @@ def ogr_rfc35_mem_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -400,21 +400,21 @@ def ogr_rfc35_mem_5():
     if lyr.DeleteField(0) != 0:
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
     if lyr.DeleteField(lyr_defn.GetFieldIndex('baw20')) != 0:
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5', baw=None)
+    ret = CheckFeatures(lyr, field3='baz5', field4=None)
     if ret != 'success':
         return ret
 
     if lyr.DeleteField(lyr_defn.GetFieldIndex('baz5')) != 0:
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field3=None, field4=None)
     if ret != 'success':
         return ret
 
@@ -424,7 +424,7 @@ def ogr_rfc35_mem_5():
     if lyr.DeleteField(lyr_defn.GetFieldIndex('bar10')) != 0:
         return 'fail'
 
-    ret = CheckFeatures(lyr, foo=None, bar=None, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
     if ret != 'success':
         return ret
 

--- a/autotest/ogr/ogr_rfc35_mitab.py
+++ b/autotest/ogr/ogr_rfc35_mitab.py
@@ -323,7 +323,7 @@ def ogr_rfc35_mitab_3():
 
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz15"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz25')
+    ret = CheckFeatures(lyr, field3='baz25')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -334,7 +334,7 @@ def ogr_rfc35_mitab_3():
     lyr_defn = lyr.GetLayerDefn()
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz25"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -349,7 +349,7 @@ def ogr_rfc35_mitab_3():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -395,7 +395,7 @@ def ogr_rfc35_mitab_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -411,7 +411,7 @@ def ogr_rfc35_mitab_4():
             return 'fail'
         feat = None
 
-        ret = CheckFeatures(lyr, baz='baz5')
+        ret = CheckFeatures(lyr, field3='baz5')
         if ret != 'success':
             gdaltest.post_reason(ret)
             return ret
@@ -433,7 +433,7 @@ def ogr_rfc35_mitab_4():
             return 'fail'
         feat = None
 
-        ret = CheckFeatures(lyr, baz='baz5')
+        ret = CheckFeatures(lyr, field3='baz5')
         if ret != 'success':
             gdaltest.post_reason(ret)
             return ret
@@ -461,7 +461,7 @@ def ogr_rfc35_mitab_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -479,7 +479,7 @@ def ogr_rfc35_mitab_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -515,7 +515,7 @@ def ogr_rfc35_mitab_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -533,7 +533,7 @@ def ogr_rfc35_mitab_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -572,7 +572,7 @@ def ogr_rfc35_mitab_5():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -593,7 +593,7 @@ def ogr_rfc35_mitab_5():
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
 
-    ret = CheckFeatures(lyr, baz='baz5', baw=None)
+    ret = CheckFeatures(lyr, field3='baz5', field4=None)
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -602,7 +602,7 @@ def ogr_rfc35_mitab_5():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field3=None, field4=None)
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -619,7 +619,7 @@ def ogr_rfc35_mitab_5():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    ret = CheckFeatures(lyr, foo=None, bar=None, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret
@@ -630,7 +630,7 @@ def ogr_rfc35_mitab_5():
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
 
-    ret = CheckFeatures(lyr, foo=None, bar=None, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
     if ret != 'success':
         gdaltest.post_reason(ret)
         return ret

--- a/autotest/ogr/ogr_rfc35_mitab.py
+++ b/autotest/ogr/ogr_rfc35_mitab.py
@@ -117,7 +117,7 @@ def Truncate(val, lyr_defn, fieldname):
     return val[0:lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex(fieldname)).GetWidth()]
 
 
-def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
+def CheckFeatures(lyr, field1='foo5', field2='bar10', field3='baz15', field4='baw20'):
 
     expected_values = [
         ['foo0', '', '', ''],
@@ -132,10 +132,10 @@ def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
     feat = lyr.GetNextFeature()
     i = 0
     while feat is not None:
-        if (foo is not None and feat.GetField(foo) != Truncate(expected_values[i][0], lyr_defn, foo)) or \
-           (bar is not None and feat.GetField(bar) != Truncate(expected_values[i][1], lyr_defn, bar)) or \
-           (baz is not None and feat.GetField(baz) != Truncate(expected_values[i][2], lyr_defn, baz)) or \
-           (baw is not None and feat.GetField(baw) != Truncate(expected_values[i][3], lyr_defn, baw)):
+        if (field1 is not None and feat.GetField(field1) != Truncate(expected_values[i][0], lyr_defn, field1)) or \
+           (field2 is not None and feat.GetField(field2) != Truncate(expected_values[i][1], lyr_defn, field2)) or \
+           (field3 is not None and feat.GetField(field3) != Truncate(expected_values[i][2], lyr_defn, field3)) or \
+           (field4 is not None and feat.GetField(field4) != Truncate(expected_values[i][3], lyr_defn, field4)):
             feat.DumpReadable()
             return 'fail'
         feat = lyr.GetNextFeature()

--- a/autotest/ogr/ogr_rfc35_shape.py
+++ b/autotest/ogr/ogr_rfc35_shape.py
@@ -117,7 +117,7 @@ def Truncate(val, lyr_defn, fieldname):
     return val[0:lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex(fieldname)).GetWidth()]
 
 
-def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
+def CheckFeatures(lyr, field1='foo5', field2='bar10', field3='baz15', field4='baw20'):
 
     expected_values = [
         ['foo0', None, None, None],
@@ -132,10 +132,10 @@ def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
     feat = lyr.GetNextFeature()
     i = 0
     while feat is not None:
-        if (foo is not None and feat.GetField(foo) != Truncate(expected_values[i][0], lyr_defn, foo)) or \
-           (bar is not None and feat.GetField(bar) != Truncate(expected_values[i][1], lyr_defn, bar)) or \
-           (baz is not None and feat.GetField(baz) != Truncate(expected_values[i][2], lyr_defn, baz)) or \
-           (baw is not None and feat.GetField(baw) != Truncate(expected_values[i][3], lyr_defn, baw)):
+        if (field1 is not None and feat.GetField(field1) != Truncate(expected_values[i][0], lyr_defn, field1)) or \
+           (field2 is not None and feat.GetField(field2) != Truncate(expected_values[i][1], lyr_defn, field2)) or \
+           (field3 is not None and feat.GetField(field3) != Truncate(expected_values[i][2], lyr_defn, field3)) or \
+           (field4 is not None and feat.GetField(field4) != Truncate(expected_values[i][3], lyr_defn, field4)):
             feat.DumpReadable()
             return 'fail'
         feat = lyr.GetNextFeature()
@@ -284,7 +284,7 @@ def ogr_rfc35_shape_3():
 
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz15"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz25')
+    ret = CheckFeatures(lyr, field3='baz25')
     if ret != 'success':
         return ret
 
@@ -294,7 +294,7 @@ def ogr_rfc35_shape_3():
     lyr_defn = lyr.GetLayerDefn()
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz25"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -307,7 +307,7 @@ def ogr_rfc35_shape_3():
     if fld_defn.GetWidth() != 5:
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -346,7 +346,7 @@ def ogr_rfc35_shape_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -359,7 +359,7 @@ def ogr_rfc35_shape_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -378,7 +378,7 @@ def ogr_rfc35_shape_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -403,7 +403,7 @@ def ogr_rfc35_shape_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -419,7 +419,7 @@ def ogr_rfc35_shape_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -450,7 +450,7 @@ def ogr_rfc35_shape_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -466,7 +466,7 @@ def ogr_rfc35_shape_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -500,7 +500,7 @@ def ogr_rfc35_shape_5():
     if ret == 0:
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         return ret
 
@@ -518,14 +518,14 @@ def ogr_rfc35_shape_5():
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
 
-    ret = CheckFeatures(lyr, baz='baz5', baw=None)
+    ret = CheckFeatures(lyr, field3='baz5', field4=None)
     if ret != 'success':
         return ret
 
     if lyr.DeleteField(lyr_defn.GetFieldIndex('baz5')) != 0:
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field3=None, field4=None)
     if ret != 'success':
         return ret
 
@@ -535,7 +535,7 @@ def ogr_rfc35_shape_5():
     if lyr.DeleteField(lyr_defn.GetFieldIndex('bar10')) != 0:
         return 'fail'
 
-    ret = CheckFeatures(lyr, foo=None, bar=None, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
     if ret != 'success':
         return ret
 
@@ -545,7 +545,7 @@ def ogr_rfc35_shape_5():
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
 
-    ret = CheckFeatures(lyr, foo=None, bar=None, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
     if ret != 'success':
         return ret
 

--- a/autotest/ogr/ogr_rfc35_sqlite.py
+++ b/autotest/ogr/ogr_rfc35_sqlite.py
@@ -119,7 +119,7 @@ def Truncate(val, lyr_defn, fieldname):
     return val
 
 
-def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
+def CheckFeatures(lyr, field1='foo5', field2='bar10', field3='baz15', field4='baw20'):
 
     expected_values = [
         ['foo0', None, None, None],
@@ -134,10 +134,10 @@ def CheckFeatures(lyr, foo='foo5', bar='bar10', baz='baz15', baw='baw20'):
     feat = lyr.GetNextFeature()
     i = 0
     while feat is not None:
-        if (foo is not None and feat.GetField(foo) != Truncate(expected_values[i][0], lyr_defn, foo)) or \
-           (bar is not None and feat.GetField(bar) != Truncate(expected_values[i][1], lyr_defn, bar)) or \
-           (baz is not None and feat.GetField(baz) != Truncate(expected_values[i][2], lyr_defn, baz)) or \
-           (baw is not None and feat.GetField(baw) != Truncate(expected_values[i][3], lyr_defn, baw)):
+        if (field1 is not None and feat.GetField(field1) != Truncate(expected_values[i][0], lyr_defn, field1)) or \
+           (field2 is not None and feat.GetField(field2) != Truncate(expected_values[i][1], lyr_defn, field2)) or \
+           (field3 is not None and feat.GetField(field3) != Truncate(expected_values[i][2], lyr_defn, field3)) or \
+           (field4 is not None and feat.GetField(field4) != Truncate(expected_values[i][3], lyr_defn, field4)):
             feat.DumpReadable()
             return 'fail'
         feat = lyr.GetNextFeature()

--- a/autotest/ogr/ogr_rfc35_sqlite.py
+++ b/autotest/ogr/ogr_rfc35_sqlite.py
@@ -280,7 +280,7 @@ def ogr_rfc35_sqlite_3():
 
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz15"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz25')
+    ret = CheckFeatures(lyr, field3='baz25')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -291,7 +291,7 @@ def ogr_rfc35_sqlite_3():
     lyr_defn = lyr.GetLayerDefn()
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz25"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -302,7 +302,7 @@ def ogr_rfc35_sqlite_3():
         gdaltest.post_reason('failed')
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -346,7 +346,7 @@ def ogr_rfc35_sqlite_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -361,7 +361,7 @@ def ogr_rfc35_sqlite_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -377,7 +377,7 @@ def ogr_rfc35_sqlite_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -394,7 +394,7 @@ def ogr_rfc35_sqlite_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -430,7 +430,7 @@ def ogr_rfc35_sqlite_4():
         return 'fail'
     feat = None
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -471,7 +471,7 @@ def ogr_rfc35_sqlite_5():
         gdaltest.post_reason('failed')
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5')
+    ret = CheckFeatures(lyr, field3='baz5')
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -480,7 +480,7 @@ def ogr_rfc35_sqlite_5():
         gdaltest.post_reason('failed')
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz='baz5', baw=None)
+    ret = CheckFeatures(lyr, field3='baz5', field4=None)
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -489,7 +489,7 @@ def ogr_rfc35_sqlite_5():
         gdaltest.post_reason('failed')
         return 'fail'
 
-    ret = CheckFeatures(lyr, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field3=None, field4=None)
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret
@@ -502,7 +502,7 @@ def ogr_rfc35_sqlite_5():
         gdaltest.post_reason('failed')
         return 'fail'
 
-    ret = CheckFeatures(lyr, foo=None, bar=None, baz=None, baw=None)
+    ret = CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
     if ret != 'success':
         gdaltest.post_reason('failed')
         return ret


### PR DESCRIPTION
## What does this PR do?

Fixes issue #534 by renaming some argument names blacklisted by Pylint.