### PR TITLE
ogr2ogr: fix compilation error with Crypto++ 7.0.0 (fix #541)

### DIFF
--- a/gdal/port/cpl_sha256.cpp
+++ b/gdal/port/cpl_sha256.cpp
@@ -605,7 +605,7 @@ GByte* CPL_RSA_SHA256_Sign(const char* pszPrivateKey,
     CryptoPP::Base64Decoder decoder;
 
     decoder.Attach(new CryptoPP::Redirector(queue));
-    decoder.Put(reinterpret_cast<const byte*>(osKeyB64.data()), osKeyB64.length());
+    decoder.Put(reinterpret_cast<const CryptoPP::byte*>(osKeyB64.data()), osKeyB64.length());
     decoder.MessageEnd();
 
     CryptoPP::RSA::PrivateKey rsaPrivate;

--- a/gdal/port/cpl_sha256.cpp
+++ b/gdal/port/cpl_sha256.cpp
@@ -508,6 +508,13 @@ void CPL_HMAC_SHA256( const void *pKey, size_t nKeyLen,
 #include "cryptopp/base64.h"
 #include "cryptopp/osrng.h"
 
+// Fix compatibility with Crypto++
+#if CRYPTOPP_VERSION >= 600
+typedef CryptoPP::byte cryptopp_byte;
+#else
+typedef byte cryptopp_byte;
+#endif
+
 #ifdef _MSC_VER
 #pragma warning( pop )
 #endif
@@ -605,7 +612,7 @@ GByte* CPL_RSA_SHA256_Sign(const char* pszPrivateKey,
     CryptoPP::Base64Decoder decoder;
 
     decoder.Attach(new CryptoPP::Redirector(queue));
-    decoder.Put(reinterpret_cast<const CryptoPP::byte*>(osKeyB64.data()), osKeyB64.length());
+    decoder.Put(reinterpret_cast<const cryptopp_byte*>(osKeyB64.data()), osKeyB64.length());
     decoder.MessageEnd();
 
     CryptoPP::RSA::PrivateKey rsaPrivate;

--- a/gdal/port/cpl_vsil_crypt.cpp
+++ b/gdal/port/cpl_vsil_crypt.cpp
@@ -447,7 +447,7 @@ VSICryptFileHeader::CryptKeyCheck( CryptoPP::BlockCipher* poEncCipher )
     CryptoPP::StringSink* poSink = new CryptoPP::StringSink(osKeyCheckRes);
     CryptoPP::StreamTransformation* poMode =
         new CryptoPP::CBC_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const byte*>(osCheckIV.c_str()));
+            *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osCheckIV.c_str()));
     CryptoPP::StreamTransformationFilter* poEnc =
         new CryptoPP::StreamTransformationFilter(
             *poMode, poSink,
@@ -455,7 +455,7 @@ VSICryptFileHeader::CryptKeyCheck( CryptoPP::BlockCipher* poEncCipher )
     // Not sure if it is add extra security, but pick up something that is
     // unlikely to be a plain text (random number).
     poEnc->Put(
-        reinterpret_cast<const byte*>(
+        reinterpret_cast<const CryptoPP::byte*>(
             "\xDB\x31\xB9\x1B\xD3\x1C\xFA\x3E\x84\x06\xC1\x42\xC3\xEC\xCD\x9A"
             "\x02\x36\x22\x15\x58\x88\x74\x65\x00\x2F\x98\xBC\x69\x22\xE1\x63"),
         std::min(32U, poEncCipher->BlockSize()));
@@ -592,7 +592,7 @@ int VSICryptFileHeader::ReadFromFile( VSIVirtualHandle* fp,
             {
                 const int nKeySize =
                     std::min(nMaxKeySize, static_cast<int>(osKey.size()));
-                poEncCipher->SetKey(reinterpret_cast<const byte*>(osKey.c_str()), nKeySize);
+                poEncCipher->SetKey(reinterpret_cast<const CryptoPP::byte*>(osKey.c_str()), nKeySize);
             }
             else if( pabyGlobalKey )
             {
@@ -843,8 +843,8 @@ int VSICryptFileHandle::Init( const CPLString& osKey, bool bWriteHeader )
         {
             const int nKeySize =
                 std::min(nMaxKeySize, static_cast<int>(osKey.size()));
-            poEncCipher->SetKey(reinterpret_cast<const byte*>(osKey.c_str()), nKeySize);
-            poDecCipher->SetKey(reinterpret_cast<const byte*>(osKey.c_str()), nKeySize);
+            poEncCipher->SetKey(reinterpret_cast<const CryptoPP::byte*>(osKey.c_str()), nKeySize);
+            poDecCipher->SetKey(reinterpret_cast<const CryptoPP::byte*>(osKey.c_str()), nKeySize);
         }
         else if( pabyGlobalKey )
         {
@@ -903,19 +903,19 @@ void VSICryptFileHandle::EncryptBlock( GByte* pabyData, vsi_l_offset nOffset )
     CryptoPP::StreamTransformation* poMode;
     if( poHeader->eMode == MODE_CBC )
         poMode = new CryptoPP::CBC_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
     else if( poHeader->eMode == MODE_CFB )
         poMode = new CryptoPP::CFB_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
     else if( poHeader->eMode == MODE_OFB )
         poMode = new CryptoPP::OFB_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
     else if( poHeader->eMode == MODE_CTR )
         poMode = new CryptoPP::CTR_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
     else
         poMode = new CryptoPP::CBC_CTS_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
     CryptoPP::StreamTransformationFilter* poEnc =
         new CryptoPP::StreamTransformationFilter(
             *poMode, poSink, CryptoPP::StreamTransformationFilter::NO_PADDING);
@@ -947,22 +947,22 @@ bool VSICryptFileHandle::DecryptBlock( GByte* pabyData, vsi_l_offset nOffset )
         // Yes, some modes need the encryption cipher.
         if( poHeader->eMode == MODE_CBC )
             poMode = new CryptoPP::CBC_Mode_ExternalCipher::Decryption(
-                *poDecCipher, reinterpret_cast<const byte*>(osIV.c_str()) );
+                *poDecCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
         else if( poHeader->eMode == MODE_CFB )
             poMode = new CryptoPP::CFB_Mode_ExternalCipher::Decryption(
-                *poEncCipher, reinterpret_cast<const byte*>(osIV.c_str()) );
+                *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
         else if( poHeader->eMode == MODE_OFB )
             poMode = new CryptoPP::OFB_Mode_ExternalCipher::Decryption(
-                *poEncCipher, reinterpret_cast<const byte*>(osIV.c_str()) );
+                *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
         else if( poHeader->eMode == MODE_CTR )
             poMode = new CryptoPP::CTR_Mode_ExternalCipher::Decryption(
-                *poEncCipher, reinterpret_cast<const byte*>(osIV.c_str()) );
+                *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
         else
             poMode = new CryptoPP::CBC_CTS_Mode_ExternalCipher::Decryption(
-                *poDecCipher, reinterpret_cast<const byte*>(osIV.c_str()) );
+                *poDecCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
         poDec = new CryptoPP::StreamTransformationFilter(
             *poMode, poSink, CryptoPP::StreamTransformationFilter::NO_PADDING);
-        poDec->Put(reinterpret_cast<const byte*>(pabyData), poHeader->nSectorSize);
+        poDec->Put(reinterpret_cast<const CryptoPP::byte*>(pabyData), poHeader->nSectorSize);
         poDec->MessageEnd();
         delete poDec;
         delete poMode;
@@ -1358,7 +1358,7 @@ int VSICryptFileHandle::Flush()
 #endif
                 CryptoPP::OS_GenerateRandomBlock(
                     false, // Do not need cryptographic randomness.
-                    reinterpret_cast<byte*>(pabyWB +
+                    reinterpret_cast<CryptoPP::byte*>(pabyWB +
                             poHeader->nPayloadFileSize - nLastSectorOffset),
                     static_cast<int>(
                         poHeader->nSectorSize -
@@ -1649,7 +1649,7 @@ VSIVirtualHandle *VSICryptFilesystemHandler::Open( const char *pszFilename,
             osIV.resize(nBlockSize);
             CryptoPP::OS_GenerateRandomBlock(
                 false,  // Do not need cryptographic randomness.
-                reinterpret_cast<byte*>(const_cast<char*>(osIV.c_str())), osIV.size());
+                reinterpret_cast<CryptoPP::byte*>(const_cast<char*>(osIV.c_str())), osIV.size());
         }
 
         if( EQUAL(osKey, "GENERATE_IT") )
@@ -1662,7 +1662,7 @@ VSIVirtualHandle *VSICryptFilesystemHandler::Open( const char *pszFilename,
                 // Config option for speeding tests.
                 CPLTestBool(CPLGetConfigOption("VSICRYPT_CRYPTO_RANDOM",
                                                "TRUE")),
-                reinterpret_cast<byte*>(const_cast<char*>(osKey.c_str())), osKey.size());
+                reinterpret_cast<CryptoPP::byte*>(const_cast<char*>(osKey.c_str())), osKey.size());
 
             char* pszB64 = CPLBase64Encode(static_cast<int>(osKey.size()),
                                            reinterpret_cast<const GByte*>(osKey.c_str()));

--- a/gdal/port/cpl_vsil_crypt.cpp
+++ b/gdal/port/cpl_vsil_crypt.cpp
@@ -101,6 +101,14 @@ constexpr unsigned int VSICRYPT_WRITE = 0x2;
 #ifdef _MSC_VER
 #pragma warning( pop )
 #endif
+
+// Fix compatibility with Crypto++
+#if CRYPTOPP_VERSION >= 600
+typedef CryptoPP::byte cryptopp_byte;
+#else
+typedef byte cryptopp_byte;
+#endif
+
 /* End of crypto++ headers */
 
 // I don't really understand why this is necessary, especially
@@ -447,7 +455,7 @@ VSICryptFileHeader::CryptKeyCheck( CryptoPP::BlockCipher* poEncCipher )
     CryptoPP::StringSink* poSink = new CryptoPP::StringSink(osKeyCheckRes);
     CryptoPP::StreamTransformation* poMode =
         new CryptoPP::CBC_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osCheckIV.c_str()));
+            *poEncCipher, reinterpret_cast<const cryptopp_byte*>(osCheckIV.c_str()));
     CryptoPP::StreamTransformationFilter* poEnc =
         new CryptoPP::StreamTransformationFilter(
             *poMode, poSink,
@@ -455,7 +463,7 @@ VSICryptFileHeader::CryptKeyCheck( CryptoPP::BlockCipher* poEncCipher )
     // Not sure if it is add extra security, but pick up something that is
     // unlikely to be a plain text (random number).
     poEnc->Put(
-        reinterpret_cast<const CryptoPP::byte*>(
+        reinterpret_cast<const cryptopp_byte*>(
             "\xDB\x31\xB9\x1B\xD3\x1C\xFA\x3E\x84\x06\xC1\x42\xC3\xEC\xCD\x9A"
             "\x02\x36\x22\x15\x58\x88\x74\x65\x00\x2F\x98\xBC\x69\x22\xE1\x63"),
         std::min(32U, poEncCipher->BlockSize()));
@@ -592,7 +600,7 @@ int VSICryptFileHeader::ReadFromFile( VSIVirtualHandle* fp,
             {
                 const int nKeySize =
                     std::min(nMaxKeySize, static_cast<int>(osKey.size()));
-                poEncCipher->SetKey(reinterpret_cast<const CryptoPP::byte*>(osKey.c_str()), nKeySize);
+                poEncCipher->SetKey(reinterpret_cast<const cryptopp_byte*>(osKey.c_str()), nKeySize);
             }
             else if( pabyGlobalKey )
             {
@@ -843,8 +851,8 @@ int VSICryptFileHandle::Init( const CPLString& osKey, bool bWriteHeader )
         {
             const int nKeySize =
                 std::min(nMaxKeySize, static_cast<int>(osKey.size()));
-            poEncCipher->SetKey(reinterpret_cast<const CryptoPP::byte*>(osKey.c_str()), nKeySize);
-            poDecCipher->SetKey(reinterpret_cast<const CryptoPP::byte*>(osKey.c_str()), nKeySize);
+            poEncCipher->SetKey(reinterpret_cast<const cryptopp_byte*>(osKey.c_str()), nKeySize);
+            poDecCipher->SetKey(reinterpret_cast<const cryptopp_byte*>(osKey.c_str()), nKeySize);
         }
         else if( pabyGlobalKey )
         {
@@ -903,19 +911,19 @@ void VSICryptFileHandle::EncryptBlock( GByte* pabyData, vsi_l_offset nOffset )
     CryptoPP::StreamTransformation* poMode;
     if( poHeader->eMode == MODE_CBC )
         poMode = new CryptoPP::CBC_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const cryptopp_byte *>(osIV.c_str()) );
     else if( poHeader->eMode == MODE_CFB )
         poMode = new CryptoPP::CFB_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const cryptopp_byte *>(osIV.c_str()) );
     else if( poHeader->eMode == MODE_OFB )
         poMode = new CryptoPP::OFB_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const cryptopp_byte *>(osIV.c_str()) );
     else if( poHeader->eMode == MODE_CTR )
         poMode = new CryptoPP::CTR_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const cryptopp_byte *>(osIV.c_str()) );
     else
         poMode = new CryptoPP::CBC_CTS_Mode_ExternalCipher::Encryption(
-            *poEncCipher, reinterpret_cast<const CryptoPP::byte *>(osIV.c_str()) );
+            *poEncCipher, reinterpret_cast<const cryptopp_byte *>(osIV.c_str()) );
     CryptoPP::StreamTransformationFilter* poEnc =
         new CryptoPP::StreamTransformationFilter(
             *poMode, poSink, CryptoPP::StreamTransformationFilter::NO_PADDING);
@@ -947,22 +955,22 @@ bool VSICryptFileHandle::DecryptBlock( GByte* pabyData, vsi_l_offset nOffset )
         // Yes, some modes need the encryption cipher.
         if( poHeader->eMode == MODE_CBC )
             poMode = new CryptoPP::CBC_Mode_ExternalCipher::Decryption(
-                *poDecCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
+                *poDecCipher, reinterpret_cast<const cryptopp_byte*>(osIV.c_str()) );
         else if( poHeader->eMode == MODE_CFB )
             poMode = new CryptoPP::CFB_Mode_ExternalCipher::Decryption(
-                *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
+                *poEncCipher, reinterpret_cast<const cryptopp_byte*>(osIV.c_str()) );
         else if( poHeader->eMode == MODE_OFB )
             poMode = new CryptoPP::OFB_Mode_ExternalCipher::Decryption(
-                *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
+                *poEncCipher, reinterpret_cast<const cryptopp_byte*>(osIV.c_str()) );
         else if( poHeader->eMode == MODE_CTR )
             poMode = new CryptoPP::CTR_Mode_ExternalCipher::Decryption(
-                *poEncCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
+                *poEncCipher, reinterpret_cast<const cryptopp_byte*>(osIV.c_str()) );
         else
             poMode = new CryptoPP::CBC_CTS_Mode_ExternalCipher::Decryption(
-                *poDecCipher, reinterpret_cast<const CryptoPP::byte*>(osIV.c_str()) );
+                *poDecCipher, reinterpret_cast<const cryptopp_byte*>(osIV.c_str()) );
         poDec = new CryptoPP::StreamTransformationFilter(
             *poMode, poSink, CryptoPP::StreamTransformationFilter::NO_PADDING);
-        poDec->Put(reinterpret_cast<const CryptoPP::byte*>(pabyData), poHeader->nSectorSize);
+        poDec->Put(reinterpret_cast<const cryptopp_byte*>(pabyData), poHeader->nSectorSize);
         poDec->MessageEnd();
         delete poDec;
         delete poMode;
@@ -1358,7 +1366,7 @@ int VSICryptFileHandle::Flush()
 #endif
                 CryptoPP::OS_GenerateRandomBlock(
                     false, // Do not need cryptographic randomness.
-                    reinterpret_cast<CryptoPP::byte*>(pabyWB +
+                    reinterpret_cast<cryptopp_byte*>(pabyWB +
                             poHeader->nPayloadFileSize - nLastSectorOffset),
                     static_cast<int>(
                         poHeader->nSectorSize -
@@ -1649,7 +1657,7 @@ VSIVirtualHandle *VSICryptFilesystemHandler::Open( const char *pszFilename,
             osIV.resize(nBlockSize);
             CryptoPP::OS_GenerateRandomBlock(
                 false,  // Do not need cryptographic randomness.
-                reinterpret_cast<CryptoPP::byte*>(const_cast<char*>(osIV.c_str())), osIV.size());
+                reinterpret_cast<cryptopp_byte*>(const_cast<char*>(osIV.c_str())), osIV.size());
         }
 
         if( EQUAL(osKey, "GENERATE_IT") )
@@ -1662,7 +1670,7 @@ VSIVirtualHandle *VSICryptFilesystemHandler::Open( const char *pszFilename,
                 // Config option for speeding tests.
                 CPLTestBool(CPLGetConfigOption("VSICRYPT_CRYPTO_RANDOM",
                                                "TRUE")),
-                reinterpret_cast<CryptoPP::byte*>(const_cast<char*>(osKey.c_str())), osKey.size());
+                reinterpret_cast<cryptopp_byte*>(const_cast<char*>(osKey.c_str())), osKey.size());
 
             char* pszB64 = CPLBase64Encode(static_cast<int>(osKey.size()),
                                            reinterpret_cast<const GByte*>(osKey.c_str()));


### PR DESCRIPTION
This issue is fixed up by replacing byte type to CtyptoPP:byte in the following files:
gdal/port/cpl_sha256.cpp
gdal/port/cpl_vsil_crypt.cpp

## Environment
* OS: Arch Linux
* Compiler: gcc/g++
