### PR TITLE
Scripts: Avoid cd in shell scripts

### DIFF
--- a/gdal/ci/travis/csa_common/before_install.sh
+++ b/gdal/ci/travis/csa_common/before_install.sh
@@ -61,9 +61,7 @@ make -j4
 sudo make install
 cd ../..
 sudo ldconfig
-cd gdal
-wget http://even.rouault.free.fr/clang-3.7.0-light/libstdc++.so.6.tar.bz2
-wget http://even.rouault.free.fr/clang-3.7.0-light/install-llvm-3.7.0-light.tar.bz2
-tar xJf libstdc++.so.6.tar.bz2
-tar xJf install-llvm-3.7.0-light.tar.bz2
-cd ..
+wget -P gdal http://even.rouault.free.fr/clang-3.7.0-light/libstdc++.so.6.tar.bz2
+wget -P gdal http://even.rouault.free.fr/clang-3.7.0-light/install-llvm-3.7.0-light.tar.bz2
+tar CxJf gdal libstdc++.so.6.tar.bz2
+tar CxJf gdal install-llvm-3.7.0-light.tar.bz2

--- a/gdal/ci/travis/csa_common/before_install.sh
+++ b/gdal/ci/travis/csa_common/before_install.sh
@@ -61,7 +61,9 @@ make -j4
 sudo make install
 cd ../..
 sudo ldconfig
-wget -P gdal http://even.rouault.free.fr/clang-3.7.0-light/libstdc++.so.6.tar.bz2
-wget -P gdal http://even.rouault.free.fr/clang-3.7.0-light/install-llvm-3.7.0-light.tar.bz2
-tar CxJf gdal libstdc++.so.6.tar.bz2
-tar CxJf gdal install-llvm-3.7.0-light.tar.bz2
+(cd gdal
+ wget http://even.rouault.free.fr/clang-3.7.0-light/libstdc++.so.6.tar.bz2
+ wget http://even.rouault.free.fr/clang-3.7.0-light/install-llvm-3.7.0-light.tar.bz2
+ tar xJf libstdc++.so.6.tar.bz2
+ tar xJf install-llvm-3.7.0-light.tar.bz2
+)

--- a/gdal/ci/travis/csa_common/install.sh
+++ b/gdal/ci/travis/csa_common/install.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-cd gdal
 # For libstdc++.so.6
-export LD_LIBRARY_PATH=$PWD
-export PATH=$PWD/install-llvm-3.7.0-light/bin:$PATH
-CXXFLAGS="-std=c++11" scan-build -o scanbuildoutput -plist -v -enable-checker alpha.unix.cstring.OutOfBounds,alpha.unix.cstring.BufferOverlap ./configure --prefix=/usr --without-libtool --enable-debug --with-jpeg12 --with-poppler --with-podofo --with-spatialite --with-mysql --with-liblzma --with-webp --with-java --with-mdb --with-jvm-lib-add-rpath --with-epsilon --with-ecw=/usr/local --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local --with-fgdb=/usr/local --with-libkml --with-openjpeg=/usr/local --without-grib
-
-cd ..
+export LD_LIBRARY_PATH=$PWD/gdal
+export PATH=$PWD/gdal/install-llvm-3.7.0-light/bin:$PATH
+(cd gdal && CXXFLAGS="-std=c++11" scan-build -o scanbuildoutput -plist -v -enable-checker alpha.unix.cstring.OutOfBounds,alpha.unix.cstring.BufferOverlap ./configure --prefix=/usr --without-libtool --enable-debug --with-jpeg12 --with-poppler --with-podofo --with-spatialite --with-mysql --with-liblzma --with-webp --with-java --with-mdb --with-jvm-lib-add-rpath --with-epsilon --with-ecw=/usr/local --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local --with-fgdb=/usr/local --with-libkml --with-openjpeg=/usr/local --without-grib)

--- a/gdal/ci/travis/csa_common/script.sh
+++ b/gdal/ci/travis/csa_common/script.sh
@@ -2,8 +2,4 @@
 
 set -e
 
-cd gdal
-
-if grep -r "\.c" scanbuildoutput | grep "<string>" | grep -v "<key>" | grep -v degrib | grep -v libjpeg | grep -v libpng | grep -v EHapi | grep -v GDapi | grep -v SWapi | grep -v osr_cs_wkt_parser | grep -v ods_formula_parser | grep -v swq_parser; then echo "error" && /bin/false; else echo "ok"; fi 
-
-cd ..
+(cd gdal && if grep -r "\.c" scanbuildoutput | grep "<string>" | grep -v "<key>" | grep -v degrib | grep -v libjpeg | grep -v libpng | grep -v EHapi | grep -v GDapi | grep -v SWapi | grep -v osr_cs_wkt_parser | grep -v ods_formula_parser | grep -v swq_parser; then echo "error" && /bin/false; else echo "ok"; fi)

--- a/gdal/ci/travis/csa_part_1/install.sh
+++ b/gdal/ci/travis/csa_part_1/install.sh
@@ -4,16 +4,8 @@ set -e
 
 . $(dirname $0)/../csa_common/install.sh
 
-cd gdal
-
-for dirname in port gcore frmts alg gnm; do
-    cd $dirname
-    scan-build -o scanbuildoutput -plist -v -enable-checker alpha.unix.cstring.OutOfBounds,alpha.unix.cstring.BufferOverlap make -j4
-    cd ..
+for dirname in gdal/port gdal/gcore gdal/frmts gdal/alg gdal/gnm ; do
+    (cd $dirname; scan-build -o scanbuildoutput -plist -v -enable-checker alpha.unix.cstring.OutOfBounds,alpha.unix.cstring.BufferOverlap make -j4)
 done
 
-cd apps
-scan-build -o scanbuildoutput -plist -v -enable-checker alpha.unix.cstring.OutOfBounds,alpha.unix.cstring.BufferOverlap make -j4 appslib
-cd ..
-
-cd ..
+(cd gdal/apps; scan-build -o scanbuildoutput -plist -v -enable-checker alpha.unix.cstring.OutOfBounds,alpha.unix.cstring.BufferOverlap make -j4 appslib)

--- a/gdal/ci/travis/osx/script.sh
+++ b/gdal/ci/travis/osx/script.sh
@@ -2,14 +2,10 @@
 
 set -e
 
-cd gdal
-export PYTHONPATH=$PWD/swig/python/build/lib.macosx-10.12-intel-2.7:$PWD/swig/python/build/lib.macosx-10.11-x86_64-2.7
+export PYTHONPATH=$PWD/gdal/swig/python/build/lib.macosx-10.12-intel-2.7:$PWD/gdal/swig/python/build/lib.macosx-10.11-x86_64-2.7
 
 # CPP unit tests
-cd ../autotest
-cd cpp
-GDAL_SKIP=JP2ECW make quick_test
-cd ..
+(cd autotest/cpp && GDAL_SKIP=JP2ECW make quick_test)
+
 # Run all the Python autotests
-#make -j test
-python run_all.py
+(cd autotest && python run_all.py)

--- a/gdal/ci/travis/precise/install.sh
+++ b/gdal/ci/travis/precise/install.sh
@@ -21,18 +21,14 @@ cd apps
 make USER_DEFS="-Wextra -Werror" test_ogrsf
 cd ..
 
-cd swig/java
-cp java.opt java.opt.bak
-cat java.opt | sed "s/JAVA_HOME =.*/JAVA_HOME = \/usr\/lib\/jvm\/java-7-openjdk-amd64\//" > java.opt.tmp
-mv java.opt.tmp java.opt
-make
-mv java.opt.bak java.opt
-cd ../..
+(cd swig/java
+ sed -i.bak "s,JAVA_HOME =.*,JAVA_HOME = /usr/lib/jvm/java-7-openjdk-amd64/," java.opt
+ make
+ mv java.opt.bak java.opt
+)
 
-cd swig/perl
-make generate
-make
-cd ../..
+(cd swig/perl && make generate && make)
+
 sudo rm -f /usr/lib/libgdal.so*
 sudo make install
 sudo ldconfig

--- a/gdal/ci/travis/precise/script.sh
+++ b/gdal/ci/travis/precise/script.sh
@@ -35,25 +35,20 @@ mkdir disabled
 mv ogr_fgdb.* disabled
 cd ..
 # Run ogr_pgeo.py in isolation from the rest
-cd ogr
-python ogr_pgeo.py
-mv ogr_pgeo.* disabled
-cd ..
+(cd ogr && python ogr_pgeo.py && mv ogr_pgeo.* disabled)
 
 # ABI issue with mongodb
-cd ogr
-mv ogr_mongodb.* disabled
-cd ..
+(cd ogr && mv ogr_mongodb.* disabled)
 
 # Run all the Python autotests
 GDAL_SKIP="JP2ECW ECW" python run_all.py
 # A bit messy, but force testing with libspatialite 4.0dev (that has been patched a bit to remove any hard-coded SRS definition so it is very small)
-cd ogr
-wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
-tar xzf libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
-ln -s install-libspatialite-4.0dev/lib/libspatialite.so.5.0.1 libspatialite.so.3
-LD_LIBRARY_PATH=$PWD python ogr_sqlite.py
-cd ..
+(cd ogr
+  wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
+  tar xzf libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
+  ln -s install-libspatialite-4.0dev/lib/libspatialite.so.5.0.1 libspatialite.so.3
+  LD_LIBRARY_PATH=$PWD python ogr_sqlite.py
+)
 
 git checkout ogr/ogr_fgdb.py
 git checkout ogr/ogr_pgeo.py

--- a/gdal/ci/travis/python3/script.sh
+++ b/gdal/ci/travis/python3/script.sh
@@ -43,7 +43,9 @@ cd ..
 # Run all the Python autotests
 GDAL_SKIP="JP2ECW ECW" python3 run_all.py
 # A bit messy, but force testing with libspatialite 4.0dev (that has been patched a bit to remove any hard-coded SRS definition so it is very small)
-wget -P ogr http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
-tar Cxzf ogr libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
-ln -s ogr/install-libspatialite-4.0dev/lib/libspatialite.so.5.0.1 ogr/libspatialite.so.3
-(cd ogr && LD_LIBRARY_PATH=$PWD python3 ogr_sqlite.py)
+(cd ogr
+ wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
+ tar xzf libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
+ ln -s install-libspatialite-4.0dev/lib/libspatialite.so.5.0.1 libspatialite.so.3
+ LD_LIBRARY_PATH=$PWD python3 ogr_sqlite.py
+)

--- a/gdal/ci/travis/python3/script.sh
+++ b/gdal/ci/travis/python3/script.sh
@@ -43,9 +43,7 @@ cd ..
 # Run all the Python autotests
 GDAL_SKIP="JP2ECW ECW" python3 run_all.py
 # A bit messy, but force testing with libspatialite 4.0dev (that has been patched a bit to remove any hard-coded SRS definition so it is very small)
-cd ogr
-wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
-tar xzf libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
-ln -s install-libspatialite-4.0dev/lib/libspatialite.so.5.0.1 libspatialite.so.3
-LD_LIBRARY_PATH=$PWD python3 ogr_sqlite.py
-cd ..
+wget -P ogr http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
+tar Cxzf ogr libspatialite4.0dev_ubuntu12.04-64bit_srs_stripped.tar.gz
+ln -s ogr/install-libspatialite-4.0dev/lib/libspatialite.so.5.0.1 ogr/libspatialite.so.3
+(cd ogr && LD_LIBRARY_PATH=$PWD python3 ogr_sqlite.py)

--- a/gdal/ci/travis/trusty_clang/install.sh
+++ b/gdal/ci/travis/trusty_clang/install.sh
@@ -23,20 +23,16 @@ CFLAGS=$ARCH_FLAGS CXXFLAGS=$ARCH_FLAGS CC="ccache clang" CXX="ccache clang" LDF
 sudo ln -s /usr/local/clang-3.5.0/bin/clang /usr/bin/clang
 sudo ln -s /usr/local/clang-3.5.0/bin/clang++ /usr/bin/clang++
 make USER_DEFS="-Wextra -Werror" -j3
-cd apps
-make USER_DEFS="-Wextra -Werror" test_ogrsf
-cd ..
+(cd apps && make USER_DEFS="-Wextra -Werror" test_ogrsf)
 
-cd swig/java
-cp java.opt java.opt.bak
-cat java.opt | sed "s/JAVA_HOME =.*/JAVA_HOME = \/usr\/lib\/jvm\/java-8-openjdk-amd64\//" > java.opt.tmp
-mv java.opt.tmp java.opt
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-export PATH=$JAVA_HOME/jre/bin:$PATH
-java -version
-make
-mv java.opt.bak java.opt
-cd ../..
+(cd swig/java
+  sed -i.bak "s,JAVA_HOME =.*,JAVA_HOME = /usr/lib/jvm/java-8-openjdk-amd64/," java.opt
+  export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+  export PATH=$JAVA_HOME/jre/bin:$PATH
+  java -version
+  make
+  mv java.opt.bak java.opt
+)
 
 cd swig/perl
 make generate

--- a/gdal/ci/travis/trusty_clang/script.sh
+++ b/gdal/ci/travis/trusty_clang/script.sh
@@ -33,16 +33,11 @@ unzip PGeoTest.zip
 cd ../../..
 # Run ogr_fgdb.py in isolation from the rest
 export PYTHONPATH=/usr/lib/python2.7/dist-packages
-cd ogr
-python ogr_fgdb.py
-mkdir disabled
-mv ogr_fgdb.* disabled
-cd ..
+(cd ogr && python ogr_fgdb.py)
+(cd ogr && mkdir disabled && mv ogr_fgdb.* disabled)
 # Run ogr_pgeo.py in isolation from the rest
-cd ogr
 # This crashes on Trusty since travis-ci upgraded their Trusty workers
 #python ogr_pgeo.py
-mv ogr_pgeo.* disabled
-cd ..
+(cd ogr && mv ogr_pgeo.* disabled)
 # Run all the Python autotests
 GDAL_SKIP="JP2ECW ECW" python run_all.py

--- a/gdal/fuzzers/build_seed_corpus.sh
+++ b/gdal/fuzzers/build_seed_corpus.sh
@@ -328,14 +328,12 @@ CUR_DIR=$PWD
 cd  $(dirname $0)/../../autotest/ogr/data
 for filename in *.ods; do
     mkdir tmpods
-    cd tmpods
-    unzip ../$filename >/dev/null
+    unzip -d tmpods $filename >/dev/null
     printf "FUZZER_FRIENDLY_ARCHIVE\n" > $CUR_DIR/ods_$filename.tar
-    for i in `find -type f`; do
+    for i in $(find -type f); do
         printf "***NEWFILE***:$i\n" >> $CUR_DIR/ods_$filename.tar
         cat $i >> $CUR_DIR/ods_$filename.tar
     done
-    cd ..
     rm -rf tmpods
 done
 cd $CUR_DIR

--- a/gdal/mkgdaldist.sh
+++ b/gdal/mkgdaldist.sh
@@ -164,13 +164,11 @@ echo "SWIG C# interfaces *NOT* generated !"
 #
 echo "* Generating SWIG Perl interfaces..."
 CWD=${PWD}
-cd gdal/swig/perl
 
-rm *wrap*
-touch ../../GDALmake.opt
-make generate
-rm -f ../../GDALmake.opt
-cd ${CWD}
+rm gdal/swig/perl/*wrap*
+touch gdal/GDALmake.opt
+(cd gdal/swig/perl && make generate)
+rm gdal/GDALmake.opt
 
 #
 # Make distribution packages

--- a/gdal/scripts/fix_typos.sh
+++ b/gdal/scripts/fix_typos.sh
@@ -50,9 +50,7 @@ if ! test -d fix_typos; then
     mkdir fix_typos
     cd fix_typos
     git clone https://github.com/rouault/codespell
-    cd codespell
-    git checkout gdal_improvements
-    cd ..
+    git checkout codespell/gdal_improvements
     # Aggregate base dictionary + QGIS one + Debian Lintian one
     curl https://raw.githubusercontent.com/qgis/QGIS/master/scripts/spelling.dat | sed "s/:/->/" | grep -v "colour->" | grep -v "colours->" > qgis.txt
     curl https://anonscm.debian.org/cgit/lintian/lintian.git/plain/data/spelling/corrections| grep "||" | grep -v "#" | sed "s/||/->/" > debian.txt


### PR DESCRIPTION
## What does this PR do?

Avoids using `cd` in shell scripts -- it can be so fragile. In some cases, we use subshells and in others, we can just update paths so that a directory change isn't needed.