### PR TITLE
Prefix * globs with ./

### DIFF
--- a/gdal/frmts/gtiff/libgeotiff/dump_symbols.sh
+++ b/gdal/frmts/gtiff/libgeotiff/dump_symbols.sh
@@ -2,7 +2,7 @@
 # GDAL specific script to extract exported libtiff symbols that can be renamed
 # to keep them internal to GDAL as much as possible
 
-gcc *.c -fPIC -shared -o libgeotiff.so -I. -I../../../port
+gcc ./*.c -fPIC -shared -o libgeotiff.so -I. -I../../../port
 
 OUT_FILE=gdal_libgeotiff_symbol_rename.h
 

--- a/gdal/frmts/gtiff/libtiff/dump_symbols.sh
+++ b/gdal/frmts/gtiff/libtiff/dump_symbols.sh
@@ -2,7 +2,7 @@
 # GDAL specific script to extract exported libtiff symbols that can be renamed
 # to keep them internal to GDAL as much as possible
 
-gcc *.c -fPIC -shared -o libtiff.so -I. -I../../../port  -DPIXARLOG_SUPPORT -DZIP_SUPPORT -DOJPEG_SUPPORT -DLZMA_SUPPORT -DZSTD_SUPPORT ${ZSTD_INCLUDE}
+gcc ./*.c -fPIC -shared -o libtiff.so -I. -I../../../port  -DPIXARLOG_SUPPORT -DZIP_SUPPORT -DOJPEG_SUPPORT -DLZMA_SUPPORT -DZSTD_SUPPORT ${ZSTD_INCLUDE}
 
 OUT_FILE=gdal_libtiff_symbol_rename.h
 

--- a/gdal/fuzzers/build_seed_corpus.sh
+++ b/gdal/fuzzers/build_seed_corpus.sh
@@ -70,19 +70,19 @@ rm test.tar
 echo "Building gtiff_fuzzer_seed_corpus.zip"
 rm -f $OUT/gtiff_fuzzer_seed_corpus.zip
 cd $(dirname $0)/../../autotest/gcore/data
-zip -r $OUT/gtiff_fuzzer_seed_corpus.zip *.tif >/dev/null
+zip -r $OUT/gtiff_fuzzer_seed_corpus.zip ./*.tif >/dev/null
 cd $OLDPWD
 cd $(dirname $0)/../../autotest/gdrivers/data
-zip -r $OUT/gtiff_fuzzer_seed_corpus.zip *.tif >/dev/null
+zip -r $OUT/gtiff_fuzzer_seed_corpus.zip ./*.tif >/dev/null
 cd $OLDPWD
 
 echo "Building hfa_fuzzer_seed_corpus.zip"
 rm -f $OUT/hfa_fuzzer_seed_corpus.zip
 cd $(dirname $0)/../../autotest/gcore/data
-zip -r $OUT/hfa_fuzzer_seed_corpus.zip *.img >/dev/null
+zip -r $OUT/hfa_fuzzer_seed_corpus.zip ./*.img >/dev/null
 cd $OLDPWD
 cd $(dirname $0)/../../autotest/gdrivers/data
-zip -r $OUT/hfa_fuzzer_seed_corpus.zip *.img >/dev/null
+zip -r $OUT/hfa_fuzzer_seed_corpus.zip ./*.img >/dev/null
 cd $OLDPWD
 
 echo "Building adrg_fuzzer_seed_corpus.zip"
@@ -280,7 +280,7 @@ cd $(dirname $0)/../../autotest/ogr/data
 rm -f $OUT/ogr_fuzzer_seed_corpus.zip
 zip -r $OUT/ogr_fuzzer_seed_corpus.zip . >/dev/null
 cd mvt
-zip $OUT/ogr_fuzzer_seed_corpus.zip * >/dev/null
+zip $OUT/ogr_fuzzer_seed_corpus.zip ./* >/dev/null
 cd ..
 cd $CUR_DIR
 
@@ -293,7 +293,7 @@ cd $OLDPWD
 echo "Building csv_fuzzer_seed_corpus.zip"
 cd $(dirname $0)/../../autotest/ogr/data
 rm -f $OUT/csv_fuzzer_seed_corpus.zip
-zip -r $OUT/csv_fuzzer_seed_corpus.zip *.csv >/dev/null
+zip -r $OUT/csv_fuzzer_seed_corpus.zip ./*.csv >/dev/null
 cd $OLDPWD
 
 echo "Building bna_fuzzer_seed_corpus.zip"
@@ -444,7 +444,7 @@ echo "Building avce00_fuzzer_seed_corpus.zip"
 rm -f $OUT/avce00_fuzzer_seed_corpus.zip
 cd $(dirname $0)/../../autotest/ogr/data
 rm -f $OUT/avce00_fuzzer_seed_corpus.zip
-zip -r $OUT/avce00_fuzzer_seed_corpus.zip *.e00 >/dev/null
+zip -r $OUT/avce00_fuzzer_seed_corpus.zip ./*.e00 >/dev/null
 cd $OLDPWD
 
 echo "Building gml_fuzzer_seed_corpus.zip"


### PR DESCRIPTION
## What does this PR do?

Suggestion from Shellcheck: Prefix `*` globs with `./` to ensure that filenames such as `--foo` become `./--foo` and won't be treated as an `--` command line option.