### PR TITLE
Python code: Remove some more bare exceptions

### DIFF
--- a/autotest/gcore/hfa_srs.py
+++ b/autotest/gcore/hfa_srs.py
@@ -116,11 +116,9 @@ for item in hfa_srs_list:
     try:
         epsg_code = item[0]
         epsg_broken = item[1]
-        # epsg_proj4_broken = item[2]
-    except:
+    except TypeError:
         epsg_code = item
         epsg_broken = False
-        # epsg_proj4_broken = False
 
     ut = TestHFASRS(epsg_code, 1, epsg_broken)
     gdaltest_list.append((ut.test, "hfa_srs_epsg_%d" % epsg_code))

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -854,7 +854,7 @@ def netcdf_21():
 
         try:
             (ret, err) = gdaltest.runexternal_out_and_err(warp_cmd)
-        except:
+        except OSError:
             gdaltest.post_reason('gdalwarp execution failed')
             return 'fail'
 
@@ -1143,7 +1143,7 @@ def netcdf_test_4dfile(ofile):
     # get file header with ncdump (if available)
     try:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h')
-    except:
+    except OSError:
         print('NOTICE: ncdump not found')
         return 'success'
     if err is None or 'netcdf library version' not in err:
@@ -1223,7 +1223,7 @@ def netcdf_29():
         (test_cli_utilities.get_gdalwarp_path(), ifile, ofile1)
     try:
         (ret, err) = gdaltest.runexternal_out_and_err(warp_cmd)
-    except:
+    except OSError:
         gdaltest.post_reason('gdalwarp execution failed')
         return 'fail'
 
@@ -2593,7 +2593,7 @@ def netcdf_62_ncdump_check():
     # get file header with ncdump (if available)
     try:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h')
-    except:
+    except OSError:
         err = None
     if err is not None and 'netcdf library version' in err:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h tmp/netcdf_62.nc')
@@ -2678,7 +2678,7 @@ def netcdf_63_ncdump_check():
     # get file header with ncdump (if available)
     try:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h')
-    except:
+    except OSError:
         err = None
     if err is not None and 'netcdf library version' in err:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h tmp/netcdf_63.nc')
@@ -2882,7 +2882,7 @@ def netcdf_66_ncdump_check():
     # get file header with ncdump (if available)
     try:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h')
-    except:
+    except OSError:
         err = None
     if err is not None and 'netcdf library version' in err:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h tmp/netcdf_66.nc')

--- a/autotest/gdrivers/netcdf_cf.py
+++ b/autotest/gdrivers/netcdf_cf.py
@@ -116,7 +116,7 @@ def netcdf_cf_setup():
     success = False
     try:
         (ret, err) = gdaltest.runexternal_out_and_err('curl')
-    except:
+    except OSError:
         print('no curl executable')
     else:
         # make sure script is responding
@@ -182,7 +182,7 @@ def netcdf_cf_check_file(ifile, version='auto', silent=True):
         if gdaltest.netcdf_cf_method == 'http':
             print('calling ' + command)
         (ret, err) = gdaltest.runexternal_out_and_err(command)
-    except:
+    except OSError:
         gdaltest.post_reason('ERROR with command - ' + command)
         return 'fail'
 
@@ -375,7 +375,7 @@ def netcdf_cfproj_testcopy(projTuples, origTiff, interFormats, inPath, outPath,
     # Test if ncdump is available
     try:
         (_, err) = gdaltest.runexternal_out_and_err('ncdump -h')
-    except:
+    except OSError:
         # nothing is supported as ncdump not found
         print('NOTICE: netcdf version not found')
         return 'skip'

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -1397,7 +1397,7 @@ def ogr_mitab_29():
                 os.stat('tmp/cache/compr_symb_deleted_records.tab')
             except OSError:
                 return 'skip'
-        except:
+        except OSError:
             return 'skip'
 
     shutil.copy('tmp/cache/compr_symb_deleted_records.tab', 'tmp')

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -108,7 +108,7 @@ def run_tests(test_list):
     before_vsimem = gdal.ReadDirRecursive('/vsimem/')
     try:
         git_status_before = git_status()
-    except:
+    except OSError:
         git_status_before = ''
 
     set_time = start_time is None
@@ -186,7 +186,7 @@ def run_tests(test_list):
 
     try:
         git_status_after = git_status()
-    except:
+    except OSError:
         git_status_after = ''
     if git_status_after != git_status_before:
         failure_counter = failure_counter + 1
@@ -1552,7 +1552,7 @@ def filesystem_supports_sparse_files(path):
 
     try:
         (ret, err) = runexternal_out_and_err('stat -f -c "%T" ' + path)
-    except:
+    except OSError:
         return False
 
     if err != '':

--- a/autotest/pymod/gdaltest_python2.py
+++ b/autotest/pymod/gdaltest_python2.py
@@ -280,7 +280,7 @@ def runexternal_out_and_err(cmd, check_memleak=True):
             import shlex
             if hasattr(subprocess, 'Popen') and hasattr(shlex, 'split'):
                 has_subprocess = True
-        except (ImportError, AttributeError):
+        except ImportError:
             pass
         if has_subprocess:
             return _runexternal_out_and_err_subprocess(cmd, check_memleak=check_memleak)

--- a/autotest/pymod/test_cli_utilities.py
+++ b/autotest/pymod/test_cli_utilities.py
@@ -55,7 +55,7 @@ def get_cli_utility_path_internal(cli_utility_name):
 
             if ret.find('GDAL') != -1:
                 return cli_utility_path
-    except:
+    except OSError:
         pass
 
     # Second try : the autotest directory is a subdirectory of gdal/ (FrankW's layout)
@@ -68,7 +68,7 @@ def get_cli_utility_path_internal(cli_utility_name):
 
             if ret.find('GDAL') != -1:
                 return cli_utility_path
-    except:
+    except OSError:
         pass
 
     # Otherwise look up in the system path
@@ -78,7 +78,7 @@ def get_cli_utility_path_internal(cli_utility_name):
 
         if ret.find('GDAL') != -1:
             return cli_utility_path
-    except:
+    except OSError:
         pass
 
     return None


### PR DESCRIPTION
## What does this PR do?

Silences more Pylint warnings about bare exceptions. In this patch, we catch most of the `OSError` exceptions.