### PR TITLE
Python code: Remove some enumerate() calls when the index variable isn't used

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -761,10 +761,10 @@ def warp_19():
 
     sizes = [1, 2, 3, 7]
 
-    for k, size in enumerate(sizes):
+    for size in sizes:
         print('Testing size = %d ...' % size)
-        for j, method in enumerate(methods):
-            for i, datatype in enumerate(datatypes):
+        for method in methods:
+            for datatype in datatypes:
                 if warp_19_internal(size, datatype, method) != 'success':
                     print('fail with size = %d, data type = %d and method %s' % (size, datatype, method))
                     return 'fail'

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -2370,7 +2370,7 @@ def ogr_mitab_45():
                                          ' from dataset :' + dsName)
                     return 'fail'
 
-            for featN, featName in enumerate(featNames):
+            for featName in featNames:
                 feat = lyr.GetNextFeature()
                 for fldN, fldName in enumerate(fldNames):
                     expectedValue = fldName + ' ' + featName

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -2338,10 +2338,10 @@ def ogr_mitab_45():
                 fld_defn.SetWidth(254)
                 lyr.CreateField(fld_defn)
 
-            for featN, featName in enumerate(featNames):
+            for featName in featNames:
                 feat = ogr.Feature(lyr.GetLayerDefn())
                 feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT (25 72)"))
-                for fldN, fldName in enumerate(fldNames):
+                for fldName in fldNames:
                     featValue = fldName + ' ' + featName
                     feat.SetField(fldName, featValue)
                 lyr.CreateFeature(feat)


### PR DESCRIPTION
## What does this PR do?

Now that `enumerate()` is used instead of `range(len(x))`, Pylint discovers which loops don't use the index and can be replaced with `for elt in lst:`