### PR TITLE
Python: Disable some Pylint messages

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -362,6 +362,7 @@ def rasterio_8_progress_callback(pct, message, user_data):
 
 
 def rasterio_8_progress_interrupt_callback(pct, message, user_data):
+    # pylint: disable=unused-argument
     user_data[0] = pct
     if pct >= 0.5:
         return 0

--- a/autotest/gdrivers/dods.py
+++ b/autotest/gdrivers/dods.py
@@ -108,6 +108,7 @@ def dods_6():
 
     return 'skip'
 
+    # pylint: disable=unreachable
     gdaltest.dods_grid_ds = gdal.Open('http://g0dup05u.ecs.nasa.gov/opendap/AIRS/AIRX3STD.003/2004.12.28/AIRS.2004.12.28.L3.RetStd001.v4.0.9.0.G05253115303.hdf?TotH2OVap_A[y][x]')
     nd = gdaltest.dods_grid_ds.GetRasterBand(1).GetNoDataValue()
     if nd != -9999.0:

--- a/autotest/gdrivers/jpipkak.py
+++ b/autotest/gdrivers/jpipkak.py
@@ -43,6 +43,7 @@ def jpipkak_1():
 
     return 'skip'
 
+    # pylint: disable=unreachable
     gdaltest.jpipkak_drv = gdal.GetDriverByName('JPIPKAK')
     if gdaltest.jpipkak_drv is None:
         return 'skip'
@@ -71,6 +72,7 @@ def jpipkak_2():
 
     return 'skip'
 
+    # pylint: disable=unreachable
     if gdaltest.jpipkak_drv is None:
         return 'skip'
 
@@ -104,6 +106,7 @@ def jpipkak_3():
 
     return 'skip'
 
+    # pylint: disable=unreachable
     if gdaltest.jpipkak_drv is None:
         return 'skip'
 
@@ -131,6 +134,7 @@ def jpipkak_4():
 
     return 'skip'
 
+    # pylint: disable=unreachable
     if gdaltest.jpipkak_drv is None:
         return 'skip'
 
@@ -158,6 +162,7 @@ def jpipkak_5():
 
     return 'skip'
 
+    # pylint: disable=unreachable
     if gdaltest.jpipkak_drv is None:
         return 'skip'
 

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -105,6 +105,7 @@ def pds4_1():
 
 
 def hide_substitution_warnings_error_handler_cbk(typ, errno, msg):
+    # pylint: disable=unused-argument
     if msg.find('substituted') < 0 and msg.find('VAR_TITLE not defined') < 0:
         print(msg)
 

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -678,6 +678,7 @@ def my_func(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize,
 
 
 def one_pix_func(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize, r, gt, **kwargs):
+    # pylint: disable=unused-argument
     out_ar.fill(1)
 
 

--- a/autotest/ogr/ogr_ingres.py
+++ b/autotest/ogr/ogr_ingres.py
@@ -170,6 +170,7 @@ def ogr_ingres_5():
 
     return 'skip'
 
+    # pylint: disable=unused-argument
     sql_lyr = gdaltest.ingres_ds.ExecuteSQL(
         "select * from tpoly where prfedea = '35043413'")
 

--- a/autotest/ogr/ogr_osm.py
+++ b/autotest/ogr/ogr_osm.py
@@ -813,6 +813,7 @@ def ogr_osm_15_progresscbk_return_true(pct, msg, user_data):
 
 
 def ogr_osm_15_progresscbk_return_false(pct, msg, user_data):
+    # pylint: disable=unused-argument
     return 0
 
 

--- a/autotest/ogr/ogr_rfc35_mem.py
+++ b/autotest/ogr/ogr_rfc35_mem.py
@@ -88,6 +88,8 @@ def ogr_rfc35_mem_1():
 
 
 def Truncate(val, lyr_defn, fieldname):
+    # pylint: disable=argument-unused
+
     # if val is None:
     #    return val
 

--- a/autotest/ogr/ogr_rfc35_sqlite.py
+++ b/autotest/ogr/ogr_rfc35_sqlite.py
@@ -111,10 +111,7 @@ def ogr_rfc35_sqlite_1():
 
 
 def Truncate(val, lyr_defn, fieldname):
-    # if val is None:
-    #    return val
-
-    # return val[0:lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex(fieldname)).GetWidth()]
+    # pylint: disable=unused-argument
     # Mem driver doesn't actually truncate
     return val
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -73,6 +73,7 @@ def test_gdal_translate_lib_1():
 
 
 def mycallback(pct, msg, user_data):
+    # pylint: disable=unused-argument
     user_data[0] = pct
     return 1
 

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -89,6 +89,7 @@ def test_gdalbuildvrt_lib_1():
 
 
 def mycallback(pct, msg, user_data):
+    # pylint: disable=unused-argument
     user_data[0] = pct
     return 1
 

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -537,6 +537,7 @@ def test_gdalwarp_lib_46():
 
 
 def mycallback(pct, msg, user_data):
+    # pylint: disable=unused-argument
     user_data[0] = pct
     return 1
 


### PR DESCRIPTION
## What does this PR do?

Disable some `unused-argument` and `unreachable` Pylint messages.
