### PR TITLE
Python code: Disable 'unreachable' warning from Pylint

### DIFF
--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -1403,6 +1403,7 @@ def ogr_shape_32():
 
     return 'skip'
 
+    # pylint: disable=unreachable
     from decimal import Decimal
 
     BigFilePath = '/tmp'


### PR DESCRIPTION
## What does this PR do?

Silences the last 'unreachable' warning from Pylint.