### PR TITLE
Avoid implicit const cast in GDALPDFObjectPoppler::GetString()

### DIFF
--- a/gdal/frmts/pdf/pdfobject.cpp
+++ b/gdal/frmts/pdf/pdfobject.cpp
@@ -1055,7 +1055,7 @@ const CPLString& GDALPDFObjectPoppler::GetString()
 {
     if (GetType() == PDFObjectType_String)
     {
-        GooString* gooString = m_po->getString();
+        const GooString* gooString = m_po->getString();
         return (osStr = GDALPDFGetUTF8StringFromBytes(reinterpret_cast<const GByte*>(gooString->getCString()),
                                                       static_cast<int>(gooString->getLength())));
     }


### PR DESCRIPTION
Just pleasing the compiler (gcc 7.3.1)
