### PR TITLE
importFromEPSG(): append ' (deprecated)' at end of deprecated GCS

### DIFF
--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -405,6 +405,18 @@ def osr_epsg_13():
 ###############################################################################
 
 
+def osr_epsg_gcs_deprecated():
+
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(4268)
+    if sr.ExportToWkt().find('NAD27 Michigan (deprecated)') < 0:
+        print(sr.ExportToWkt())
+        return 'fail'
+    return 'success'
+
+###############################################################################
+
+
 gdaltest_list = [
     osr_epsg_1,
     osr_epsg_2,
@@ -419,6 +431,7 @@ gdaltest_list = [
     osr_epsg_11,
     osr_epsg_12,
     osr_epsg_13,
+    osr_epsg_gcs_deprecated,
     None]
 
 if __name__ == '__main__':

--- a/gdal/ogr/ogr_fromepsg.cpp
+++ b/gdal/ogr/ogr_fromepsg.cpp
@@ -589,20 +589,23 @@ EPSGGetGCSInfo( int nGCSCode, char ** ppszName,
     char szSearchKey[24] = { '\0' };
     snprintf( szSearchKey, sizeof(szSearchKey), "%d", nGCSCode );
 
-    int nDatum = atoi(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                         szSearchKey, CC_Integer,
-                                         "DATUM_CODE" ) );
+    char **papszRecord = CSVScanFileByName( pszFilename, "COORD_REF_SYS_CODE",
+                                            szSearchKey, CC_Integer );
 
-    if( nDatum < 1 )
+    if( papszRecord == nullptr )
     {
-        pszFilename = CSVFilename("gcs.csv");
+        pszFilename = CSVFilename( "gcs.csv" );
         snprintf( szSearchKey, sizeof(szSearchKey), "%d", nGCSCode );
-
-        nDatum = atoi(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                   szSearchKey, CC_Integer,
-                                   "DATUM_CODE" ) );
+        papszRecord = CSVScanFileByName( pszFilename, "COORD_REF_SYS_CODE",
+                                         szSearchKey, CC_Integer );
     }
 
+    if( papszRecord == nullptr )
+        return false;
+
+    int nDatum = atoi(CSLGetField( papszRecord,
+                         CSVGetFileFieldId(pszFilename,
+                                           "DATUM_CODE")));
     if( nDatum < 1 )
         return false;
 
@@ -612,9 +615,9 @@ EPSGGetGCSInfo( int nGCSCode, char ** ppszName,
 /* -------------------------------------------------------------------- */
 /*      Get the PM.                                                     */
 /* -------------------------------------------------------------------- */
-    const int nPM = atoi(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                      szSearchKey, CC_Integer,
-                                      "PRIME_MERIDIAN_CODE" ) );
+    const int nPM = atoi(CSLGetField( papszRecord,
+                            CSVGetFileFieldId(pszFilename,
+                                           "PRIME_MERIDIAN_CODE" ) ));
 
     if( nPM < 1 )
         return false;
@@ -625,9 +628,9 @@ EPSGGetGCSInfo( int nGCSCode, char ** ppszName,
 /* -------------------------------------------------------------------- */
 /*      Get the Ellipsoid.                                              */
 /* -------------------------------------------------------------------- */
-    const int nEllipsoid = atoi(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                             szSearchKey, CC_Integer,
-                                             "ELLIPSOID_CODE" ) );
+    const int nEllipsoid = atoi(CSLGetField( papszRecord,
+                                    CSVGetFileFieldId(pszFilename,
+                                           "ELLIPSOID_CODE" ) ));
 
     if( nEllipsoid < 1 )
         return false;
@@ -638,9 +641,9 @@ EPSGGetGCSInfo( int nGCSCode, char ** ppszName,
 /* -------------------------------------------------------------------- */
 /*      Get the angular units.                                          */
 /* -------------------------------------------------------------------- */
-    const int nUOMAngle = atoi(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                            szSearchKey, CC_Integer,
-                                            "UOM_CODE" ) );
+    const int nUOMAngle = atoi(CSLGetField( papszRecord,
+                                    CSVGetFileFieldId(pszFilename,
+                                            "UOM_CODE" ) ));
 
     if( nUOMAngle < 1 )
         return false;
@@ -652,26 +655,38 @@ EPSGGetGCSInfo( int nGCSCode, char ** ppszName,
 /*      Get the name, if requested.                                     */
 /* -------------------------------------------------------------------- */
     if( ppszName != nullptr )
-        *ppszName =
-            CPLStrdup(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                   szSearchKey, CC_Integer,
-                                   "COORD_REF_SYS_NAME" ));
+    {
+        CPLString osGCSName =
+            CSLGetField( papszRecord,
+                         CSVGetFileFieldId(pszFilename,
+                                           "COORD_REF_SYS_NAME" ));
+
+        const char *pszDeprecated =
+            CSLGetField( papszRecord,
+                         CSVGetFileFieldId(pszFilename,
+                                           "DEPRECATED") );
+
+        if( pszDeprecated != nullptr && *pszDeprecated == '1' )
+            osGCSName += " (deprecated)";
+
+        *ppszName = CPLStrdup(osGCSName);
+    }
 
 /* -------------------------------------------------------------------- */
 /*      Get the datum name, if requested.                               */
 /* -------------------------------------------------------------------- */
     if( ppszDatumName != nullptr )
         *ppszDatumName =
-            CPLStrdup(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                   szSearchKey, CC_Integer,
-                                   "DATUM_NAME" ));
+            CPLStrdup(CSLGetField( papszRecord,
+                         CSVGetFileFieldId(pszFilename,
+                                           "DATUM_NAME" )));
 
 /* -------------------------------------------------------------------- */
 /*      Get the CoordSysCode                                            */
 /* -------------------------------------------------------------------- */
-    const int nCSC = atoi(CSVGetField( pszFilename, "COORD_REF_SYS_CODE",
-                                       szSearchKey, CC_Integer,
-                                       "COORD_SYS_CODE" ) );
+    const int nCSC = atoi(CSLGetField( papszRecord,
+                         CSVGetFileFieldId(pszFilename,
+                                           "COORD_SYS_CODE" ) ));
 
     if( pnCoordSysCode != nullptr )
         *pnCoordSysCode = nCSC;


### PR DESCRIPTION
See  https://lists.osgeo.org/pipermail/gdal-dev/2018-May/048495.html
