### PR TITLE
Enable -Weffc++ on port/ and gcore/

### DIFF
--- a/gdal/GDALmake.opt.in
+++ b/gdal/GDALmake.opt.in
@@ -80,6 +80,7 @@ NO_SIGN_COMPARE = @NO_SIGN_COMPARE@
 NO_NON_VIRTUAL_DTOR_FLAG = @NO_NON_VIRTUAL_DTOR_FLAG@
 NO_LOGICAL_OP_FLAG = @NO_LOGICAL_OP_FLAG@
 WARN_OLD_STYLE_CAST = @WARN_OLD_STYLE_CAST@
+WARN_EFFCPLUSPLUS = @WARN_EFFCPLUSPLUS@
 
 # Also available -DAFL_FRIENDLY for strcmp(), etc.. variants that will
 # work better with American Fuzzy Lop branch examination logic

--- a/gdal/alg/gdalwarper.h
+++ b/gdal/alg/gdalwarper.h
@@ -317,6 +317,8 @@ CPL_C_END
  */
 class CPL_DLL GDALWarpKernel
 {
+    CPL_DISALLOW_COPY_ASSIGN(GDALWarpKernel)
+
 public:
     /** Warp options */
     char              **papszWarpOptions;
@@ -436,6 +438,9 @@ typedef struct _GDALWarpChunk GDALWarpChunk;
 /*! @endcond */
 
 class CPL_DLL GDALWarpOperation {
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALWarpOperation)
+
 private:
     GDALWarpOptions *psOptions;
 

--- a/gdal/configure
+++ b/gdal/configure
@@ -875,6 +875,7 @@ LIBTOOL
 OBJDUMP
 DLLTOOL
 AS
+WARN_EFFCPLUSPLUS
 WARN_OLD_STYLE_CAST
 NO_LOGICAL_OP_FLAG
 NO_NON_VIRTUAL_DTOR_FLAG
@@ -5406,7 +5407,74 @@ else
   :
 fi
 
+as_CACHEVAR=`$as_echo "ax_cv_check_cxxflags_$ERROR_ON_UNKNOWN_OPTIONS_-Weffc++" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -Weffc++" >&5
+$as_echo_n "checking whether C++ compiler accepts -Weffc++... " >&6; }
+if eval \${$as_CACHEVAR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS $ERROR_ON_UNKNOWN_OPTIONS -Weffc++"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  eval "$as_CACHEVAR=yes"
+else
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
+  WARN_EFFCPLUSPLUS="-Weffc++"
+else
+  :
+fi
+
+
+if test "$WARN_EFFCPLUSPLUS" != ""; then
+    SAVED_CXXFLAGS=$CXXFLAGS
+    CXXFLAGS="$CXXFLAGS $WARN_EFFCPLUSPLUS -Werror"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if -Weffc++ should be enabled" >&5
+$as_echo_n "checking if -Weffc++ should be enabled... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    class Base {};
+    class A: public Base {};
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  WARN_EFFCPLUSPLUS=""
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    CXXFLAGS=$SAVED_CXXFLAGS
+fi
 
 as_CACHEVAR=`$as_echo "ax_cv_check_cxxflags_$ERROR_ON_UNKNOWN_OPTIONS_-Woverloaded-virtual" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -Woverloaded-virtual" >&5
@@ -7228,6 +7296,8 @@ NO_NON_VIRTUAL_DTOR_FLAG=$NO_NON_VIRTUAL_DTOR_FLAG
 NO_LOGICAL_OP_FLAG=$NO_LOGICAL_OP_FLAG
 
 WARN_OLD_STYLE_CAST=$WARN_OLD_STYLE_CAST
+
+WARN_EFFCPLUSPLUS=$WARN_EFFCPLUSPLUS
 
 
 ac_ext=c

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -129,7 +129,23 @@ AX_CHECK_COMPILE_FLAG([-Wmissing-prototypes], [CXX_WFLAGS="$CXX_WFLAGS -Wmissing
 AX_CHECK_COMPILE_FLAG([-Wmissing-declarations], [CXX_WFLAGS="$CXX_WFLAGS -Wmissing-declarations"],,[$ERROR_ON_UNKNOWN_OPTIONS])
 AX_CHECK_COMPILE_FLAG([-Wnon-virtual-dtor], [CXX_WFLAGS="$CXX_WFLAGS -Wnon-virtual-dtor" NO_NON_VIRTUAL_DTOR_FLAG="-Wno-non-virtual-dtor"],,[$ERROR_ON_UNKNOWN_OPTIONS])
 AX_CHECK_COMPILE_FLAG([-Wold-style-cast], [WARN_OLD_STYLE_CAST="-Wold-style-cast"],,[$ERROR_ON_UNKNOWN_OPTIONS])
+AX_CHECK_COMPILE_FLAG([-Weffc++], [WARN_EFFCPLUSPLUS="-Weffc++"],,[$ERROR_ON_UNKNOWN_OPTIONS])
 
+dnl g++-4.8 complain a bit too much with -Weffc++
+if test "$WARN_EFFCPLUSPLUS" != ""; then
+    SAVED_CXXFLAGS=$CXXFLAGS
+    CXXFLAGS="$CXXFLAGS $WARN_EFFCPLUSPLUS -Werror"
+    AC_MSG_CHECKING([if -Weffc++ should be enabled])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+    [[
+    class Base {};
+    class A: public Base {};
+    ]])],
+    [AC_MSG_RESULT([yes])],
+    [WARN_EFFCPLUSPLUS=""]
+    [AC_MSG_RESULT([no])])
+    CXXFLAGS=$SAVED_CXXFLAGS
+fi
 
 dnl Clang enables -Woverloaded-virtual if -Wall is defined, but not GCC
 AX_CHECK_COMPILE_FLAG([-Woverloaded-virtual], [CXX_WFLAGS="$CXX_WFLAGS -Woverloaded-virtual"],,[$ERROR_ON_UNKNOWN_OPTIONS])
@@ -198,6 +214,7 @@ AC_SUBST(NO_SIGN_COMPARE,$NO_SIGN_COMPARE)
 AC_SUBST(NO_NON_VIRTUAL_DTOR_FLAG,$NO_NON_VIRTUAL_DTOR_FLAG)
 AC_SUBST(NO_LOGICAL_OP_FLAG,$NO_LOGICAL_OP_FLAG)
 AC_SUBST(WARN_OLD_STYLE_CAST,$WARN_OLD_STYLE_CAST)
+AC_SUBST(WARN_EFFCPLUSPLUS,$WARN_EFFCPLUSPLUS)
 
 dnl Checks for programs.
 AC_PROG_CC

--- a/gdal/frmts/mem/memdataset.h
+++ b/gdal/frmts/mem/memdataset.h
@@ -54,6 +54,8 @@ class MEMRasterBand;
 
 class CPL_DLL MEMDataset : public GDALDataset
 {
+    CPL_DISALLOW_COPY_ASSIGN(MEMDataset)
+
     friend class MEMRasterBand;
 
     int         bGeoTransformSet;
@@ -126,6 +128,8 @@ class CPL_DLL MEMRasterBand : public GDALPamRasterBand
   private:
                 MEMRasterBand( GByte *pabyDataIn, GDALDataType eTypeIn,
                                int nXSizeIn, int nYSizeIn );
+
+    CPL_DISALLOW_COPY_ASSIGN(MEMRasterBand)
 
   protected:
     friend      class MEMDataset;

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -60,13 +60,24 @@ void* VRTDeserializeWarpedOverviewTransformer( CPLXMLNode *psTree );
 /************************************************************************/
 class VRTOverviewInfo
 {
-public:
-    CPLString       osFilename;
-    int             nBand;
-    GDALRasterBand *poBand;
-    int             bTriedToOpen;
+    CPL_DISALLOW_COPY_ASSIGN(VRTOverviewInfo)
 
-    VRTOverviewInfo() : nBand(0), poBand(nullptr), bTriedToOpen(FALSE) {}
+public:
+    CPLString       osFilename{};
+    int             nBand = 0;
+    GDALRasterBand *poBand = nullptr;
+    int             bTriedToOpen = FALSE;
+
+    VRTOverviewInfo() = default;
+    VRTOverviewInfo(VRTOverviewInfo&& oOther):
+        osFilename(std::move(oOther.osFilename)),
+        nBand(oOther.nBand),
+        poBand(oOther.poBand),
+        bTriedToOpen(oOther.bTriedToOpen)
+    {
+        oOther.poBand = nullptr;
+    }
+
     ~VRTOverviewInfo() {
         if( poBand == nullptr )
             /* do nothing */;
@@ -159,6 +170,8 @@ class CPL_DLL VRTDataset : public GDALDataset
 
     VRTRasterBand*      InitBand(const char* pszSubclass, int nBand,
                                  bool bAllowPansharpened);
+
+    CPL_DISALLOW_COPY_ASSIGN(VRTDataset)
 
   protected:
     virtual int         CloseDependentDatasets() override;
@@ -266,6 +279,8 @@ class CPL_DLL VRTWarpedDataset : public VRTDataset
 
     friend class VRTWarpedRasterBand;
 
+    CPL_DISALLOW_COPY_ASSIGN(VRTWarpedDataset)
+
   protected:
     virtual int         CloseDependentDatasets() override;
 
@@ -340,6 +355,8 @@ class VRTPansharpenedDataset : public VRTDataset
 
     std::vector<GDALDataset*> m_apoDatasetsToClose;
 
+    CPL_DISALLOW_COPY_ASSIGN(VRTPansharpenedDataset)
+
   protected:
     virtual int         CloseDependentDatasets() override;
 
@@ -410,6 +427,8 @@ class CPL_DLL VRTRasterBand : public GDALRasterBand
     VRTRasterBand *m_poMaskBand;
 
     std::unique_ptr<GDALRasterAttributeTable> m_poRAT;
+
+    CPL_DISALLOW_COPY_ASSIGN(VRTRasterBand)
 
   public:
 
@@ -502,6 +521,8 @@ class CPL_DLL VRTSourcedRasterBand : public VRTRasterBand
 
     bool           CanUseSourcesMinMaxImplementations();
     void           CheckSource( VRTSimpleSource *poSS );
+
+    CPL_DISALLOW_COPY_ASSIGN(VRTSourcedRasterBand)
 
   public:
     int            nSources;
@@ -730,6 +751,8 @@ class CPL_DLL VRTRawRasterBand : public VRTRasterBand
     char           *m_pszSourceFilename;
     int            m_bRelativeToVRT;
 
+    CPL_DISALLOW_COPY_ASSIGN(VRTRawRasterBand)
+
   public:
                    VRTRawRasterBand( GDALDataset *poDS, int nBand,
                                      GDALDataType eType = GDT_Unknown );
@@ -765,6 +788,8 @@ class CPL_DLL VRTRawRasterBand : public VRTRasterBand
 
 class VRTDriver : public GDALDriver
 {
+    CPL_DISALLOW_COPY_ASSIGN(VRTDriver)
+
   public:
                  VRTDriver();
     virtual ~VRTDriver();
@@ -788,6 +813,8 @@ class VRTDriver : public GDALDriver
 
 class CPL_DLL VRTSimpleSource : public VRTSource
 {
+    CPL_DISALLOW_COPY_ASSIGN(VRTSimpleSource)
+
 protected:
     friend class VRTSourcedRasterBand;
 
@@ -901,6 +928,8 @@ public:
 
 class VRTAveragedSource : public VRTSimpleSource
 {
+    CPL_DISALLOW_COPY_ASSIGN(VRTAveragedSource)
+
 public:
                     VRTAveragedSource();
     virtual CPLErr  RasterIO( GDALDataType eBandDataType,
@@ -944,6 +973,8 @@ typedef enum
 
 class CPL_DLL VRTComplexSource : public VRTSimpleSource
 {
+    CPL_DISALLOW_COPY_ASSIGN(VRTComplexSource)
+
 protected:
     VRTComplexSourceScaling m_eScalingType;
     double         m_dfScaleOff;  // For linear scaling.
@@ -1026,6 +1057,8 @@ class VRTFilteredSource : public VRTComplexSource
 private:
     int          IsTypeSupported( GDALDataType eTestType ) const;
 
+    CPL_DISALLOW_COPY_ASSIGN(VRTFilteredSource)
+
 protected:
     int          m_nSupportedTypesCount;
     GDALDataType m_aeSupportedTypes[20];
@@ -1056,6 +1089,8 @@ public:
 
 class VRTKernelFilteredSource : public VRTFilteredSource
 {
+    CPL_DISALLOW_COPY_ASSIGN(VRTKernelFilteredSource)
+
 protected:
     int     m_nKernelSize;
 
@@ -1085,6 +1120,8 @@ public:
 
 class VRTAverageFilteredSource : public VRTKernelFilteredSource
 {
+    CPL_DISALLOW_COPY_ASSIGN(VRTAverageFilteredSource)
+
 public:
             explicit VRTAverageFilteredSource( int nKernelSize );
     virtual ~VRTAverageFilteredSource();
@@ -1098,6 +1135,8 @@ public:
 /************************************************************************/
 class VRTFuncSource : public VRTSource
 {
+    CPL_DISALLOW_COPY_ASSIGN(VRTFuncSource)
+
 public:
             VRTFuncSource();
     virtual ~VRTFuncSource();

--- a/gdal/gcore/GNUmakefile
+++ b/gdal/gcore/GNUmakefile
@@ -29,7 +29,7 @@ ifeq ($(HAVE_GEOS),yes)
 CPPFLAGS 	:=	$(CPPFLAGS) -DHAVE_GEOS=1 $(GEOS_CFLAGS)
 endif
 
-CXXFLAGS        :=      $(WARN_OLD_STYLE_CAST) $(CXXFLAGS)
+CXXFLAGS        :=      $(WARN_EFFCPLUSPLUS) $(WARN_OLD_STYLE_CAST) $(CXXFLAGS)
 
 GENERATE_GDAL_VERSION_H := $(shell ./generate_gdal_version_h.sh)
 

--- a/gdal/gcore/gdal_mdreader.cpp
+++ b/gdal/gcore/gdal_mdreader.cpp
@@ -94,9 +94,7 @@ static const char * const apszRPCTXT20ValItems[] =
 /**
  * GDALMDReaderManager()
  */
-GDALMDReaderManager::GDALMDReaderManager() :
-    m_pReader(nullptr)
-{}
+GDALMDReaderManager::GDALMDReaderManager() = default;
 
 /**
  * ~GDALMDReaderManager()

--- a/gdal/gcore/gdal_mdreader.h
+++ b/gdal/gcore/gdal_mdreader.h
@@ -97,6 +97,9 @@ typedef enum {
  * The base class for all metadata readers
  */
 class GDALMDReaderBase{
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALMDReaderBase)
+
 public:
     GDALMDReaderBase(const char *pszPath, char **papszSiblingFiles);
     virtual ~GDALMDReaderBase();
@@ -161,11 +164,11 @@ protected:
                                          const char *pszValue);
 protected:
 //! @cond Doxygen_Suppress
-    char **m_papszIMDMD;
-    char **m_papszRPCMD;
-    char **m_papszIMAGERYMD;
-    char **m_papszDEFAULTMD;
-    bool m_bIsMetadataLoad;
+    char **m_papszIMDMD = nullptr;
+    char **m_papszRPCMD = nullptr;
+    char **m_papszIMAGERYMD = nullptr;
+    char **m_papszDEFAULTMD = nullptr;
+    bool m_bIsMetadataLoad = false;
 //! @endcond
 };
 
@@ -175,6 +178,9 @@ protected:
  * for provided path.
  */
 class CPL_DLL GDALMDReaderManager{
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALMDReaderManager)
+
 public:
     GDALMDReaderManager();
     virtual ~GDALMDReaderManager();
@@ -194,7 +200,7 @@ public:
                                         GUInt32 nType = MDR_ANY);
 protected:
 //! @cond Doxygen_Suppress
-    GDALMDReaderBase *m_pReader;
+    GDALMDReaderBase *m_pReader = nullptr;
 //! @endcond
 };
 

--- a/gdal/gcore/gdal_pam.h
+++ b/gdal/gcore/gdal_pam.h
@@ -87,22 +87,22 @@ class GDALPamRasterBand;
 class GDALDatasetPamInfo
 {
 public:
-    char        *pszPamFilename;
+    char        *pszPamFilename = nullptr;
 
-    char        *pszProjection;
+    char        *pszProjection = nullptr;
 
-    int         bHaveGeoTransform;
-    double      adfGeoTransform[6];
+    int         bHaveGeoTransform = false;
+    double      adfGeoTransform[6]{0,0,0,0,0,0};
 
-    int         nGCPCount;
-    GDAL_GCP   *pasGCPList;
-    char       *pszGCPProjection;
+    int         nGCPCount = 0;
+    GDAL_GCP   *pasGCPList = nullptr;
+    char       *pszGCPProjection = nullptr;
 
-    CPLString   osPhysicalFilename;
-    CPLString   osSubdatasetName;
-    CPLString   osAuxFilename;
+    CPLString   osPhysicalFilename{};
+    CPLString   osSubdatasetName{};
+    CPLString   osAuxFilename{};
 
-    int         bHasMetadata;
+    int         bHasMetadata = false;
 };
 //! @endcond
 
@@ -122,8 +122,8 @@ class CPL_DLL GDALPamDataset : public GDALDataset
 
                 GDALPamDataset(void);
 //! @cond Doxygen_Suppress
-    int         nPamFlags;
-    GDALDatasetPamInfo *psPam;
+    int         nPamFlags = 0;
+    GDALDatasetPamInfo *psPam = nullptr;
 
     virtual CPLXMLNode *SerializeToXML( const char *);
     virtual CPLErr      XMLInit( CPLXMLNode *, const char * );
@@ -249,7 +249,7 @@ class CPL_DLL GDALPamRasterBand : public GDALRasterBand
     void   PamInitialize();
     void   PamClear();
 
-    GDALRasterBandPamInfo *psPam;
+    GDALRasterBandPamInfo *psPam = nullptr;
 //! @endcond
 
   public:

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -134,8 +134,8 @@ class CPL_DLL GDALMajorObject
   protected:
 //! @cond Doxygen_Suppress
     int                 nFlags; // GMO_* flags.
-    CPLString           sDescription;
-    GDALMultiDomainMetadata oMDMD;
+    CPLString           sDescription{};
+    GDALMultiDomainMetadata oMDMD{};
 
 //! @endcond
 
@@ -187,7 +187,7 @@ class CPL_DLL GDALDefaultOverviews
     GDALDataset *poDS;
     GDALDataset *poODS;
 
-    CPLString   osOvrFilename;
+    CPLString   osOvrFilename{};
 
     bool        bOvrIsAux;
 
@@ -348,26 +348,24 @@ class CPL_DLL GDALDataset : public GDALMajorObject
 
     void AddToDatasetOpenList();
 
-    void           Init( bool bForceCachedIO );
-
   protected:
 //! @cond Doxygen_Suppress
-    GDALDriver  *poDriver;
-    GDALAccess  eAccess;
+    GDALDriver  *poDriver = nullptr;
+    GDALAccess  eAccess = GA_ReadOnly;
 
     // Stored raster information.
-    int         nRasterXSize;
-    int         nRasterYSize;
-    int         nBands;
-    GDALRasterBand **papoBands;
+    int         nRasterXSize = 512;
+    int         nRasterYSize = 512;
+    int         nBands = 0;
+    GDALRasterBand **papoBands = nullptr;
 
-    int         nOpenFlags;
+    int         nOpenFlags = 0;
 
-    int         nRefCount;
-    bool        bForceCachedIO;
-    bool        bShared;
-    bool        bIsInternal;
-    bool        bSuppressOnClose;
+    int         nRefCount = 1;
+    bool        bForceCachedIO = false;
+    bool        bShared = false;
+    bool        bIsInternal = true;
+    bool        bSuppressOnClose = false;
 
                 GDALDataset(void);
     explicit    GDALDataset(int bForceCachedIO);
@@ -375,7 +373,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     void        RasterInitialize( int, int );
     void        SetBand( int, GDALRasterBand * );
 
-    GDALDefaultOverviews oOvManager;
+    GDALDefaultOverviews oOvManager{};
 
     virtual CPLErr IBuildOverviews( const char *, int, int *,
                                     int, int *, GDALProgressFunc, void * );
@@ -431,7 +429,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
 //! @cond Doxygen_Suppress
     int                 ValidateLayerCreationOptions( const char* const* papszLCO );
 
-    char            **papszOpenOptions;
+    char            **papszOpenOptions = nullptr;
 
     friend class GDALRasterBand;
 
@@ -617,10 +615,10 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     struct FeatureLayerPair
     {
         /** Unique pointer to a OGRFeature. */
-        OGRFeatureUniquePtr feature;
+        OGRFeatureUniquePtr feature{};
 
         /** Layer to which the feature belongs to. */
-        OGRLayer* layer;
+        OGRLayer* layer = nullptr;
     };
 
 private:
@@ -631,7 +629,7 @@ private:
                                              OGRGeometry *poSpatialFilter,
                                              const char *pszDialect,
                                              swq_select_parse_options* poSelectParseOptions);
-    CPLStringList oDerivedMetadataList;
+    CPLStringList oDerivedMetadataList{};
 
   public:
 
@@ -791,7 +789,7 @@ private:
     OGRErr              ProcessSQLAlterTableAlterColumn( const char * );
     OGRErr              ProcessSQLAlterTableRenameColumn( const char * );
 
-    OGRStyleTable      *m_poStyleTable;
+    OGRStyleTable      *m_poStyleTable = nullptr;
 //! @endcond
 
   private:
@@ -940,7 +938,7 @@ class CPL_DLL GDALColorTable
 {
     GDALPaletteInterp eInterp;
 
-    std::vector<GDALColorEntry> aoEntries;
+    std::vector<GDALColorEntry> aoEntries{};
 
 public:
     explicit     GDALColorTable( GDALPaletteInterp = GPI_RGB );
@@ -985,13 +983,15 @@ public:
 class CPL_DLL GDALAbstractBandBlockCache
 {
         // List of blocks that can be freed or recycled, and its lock
-        CPLLock          *hSpinLock;
-        GDALRasterBlock  *psListBlocksToFree;
+        CPLLock          *hSpinLock = nullptr;
+        GDALRasterBlock  *psListBlocksToFree = nullptr;
 
         // Band keep alive counter, and its lock & condition
-        CPLCond          *hCond;
-        CPLMutex         *hCondMutex;
-        volatile int      nKeepAliveCounter;
+        CPLCond          *hCond = nullptr;
+        CPLMutex         *hCondMutex = nullptr;
+        volatile int      nKeepAliveCounter = 0;
+
+        CPL_DISALLOW_COPY_ASSIGN(GDALAbstractBandBlockCache)
 
     protected:
         GDALRasterBand   *poBand;
@@ -1036,37 +1036,35 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     friend class GDALHashSetBandBlockCache;
     friend class GDALRasterBlock;
 
-    CPLErr eFlushBlockErr;
-    GDALAbstractBandBlockCache* poBandBlockCache;
+    CPLErr eFlushBlockErr = CE_None;
+    GDALAbstractBandBlockCache* poBandBlockCache = nullptr;
 
     void           SetFlushBlockErr( CPLErr eErr );
     CPLErr         UnreferenceBlock( GDALRasterBlock* poBlock );
 
-    void           Init(int bForceCachedIO);
-
   protected:
 //! @cond Doxygen_Suppress
-    GDALDataset *poDS;
-    int         nBand; /* 1 based */
+    GDALDataset *poDS = nullptr;
+    int         nBand = 0; /* 1 based */
 
-    int         nRasterXSize;
-    int         nRasterYSize;
+    int         nRasterXSize = 0;
+    int         nRasterYSize = 0;
 
-    GDALDataType eDataType;
-    GDALAccess  eAccess;
+    GDALDataType eDataType = GDT_Byte;
+    GDALAccess  eAccess = GA_ReadOnly;
 
     /* stuff related to blocking, and raster cache */
-    int         nBlockXSize;
-    int         nBlockYSize;
-    int         nBlocksPerRow;
-    int         nBlocksPerColumn;
+    int         nBlockXSize = -1;
+    int         nBlockYSize = -1;
+    int         nBlocksPerRow = 0;
+    int         nBlocksPerColumn = 0;
 
-    int         nBlockReads;
-    int         bForceCachedIO;
+    int         nBlockReads = 0;
+    int         bForceCachedIO = 0;
 
-    GDALRasterBand *poMask;
-    bool        bOwnMask;
-    int         nMaskFlags;
+    GDALRasterBand *poMask = nullptr;
+    bool        bOwnMask = false;
+    int         nMaskFlags = 0;
 
     void        InvalidateMaskBand();
 
@@ -1267,6 +1265,8 @@ class CPL_DLL GDALAllValidMaskBand : public GDALRasterBand
   protected:
     CPLErr IReadBlock( int, int, void * ) override;
 
+    CPL_DISALLOW_COPY_ASSIGN(GDALAllValidMaskBand)
+
   public:
     explicit     GDALAllValidMaskBand( GDALRasterBand * );
     ~GDALAllValidMaskBand() override;
@@ -1283,6 +1283,8 @@ class CPL_DLL GDALNoDataMaskBand : public GDALRasterBand
 {
     double          dfNoDataValue;
     GDALRasterBand *poParent;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALNoDataMaskBand)
 
   protected:
     CPLErr IReadBlock( int, int, void * ) override;
@@ -1303,6 +1305,8 @@ class CPL_DLL GDALNoDataValuesMaskBand : public GDALRasterBand
 {
     double      *padfNodataValues;
 
+    CPL_DISALLOW_COPY_ASSIGN(GDALNoDataValuesMaskBand)
+
   protected:
     CPLErr IReadBlock( int, int, void * ) override;
 
@@ -1319,6 +1323,8 @@ class GDALRescaledAlphaBand : public GDALRasterBand
 {
     GDALRasterBand *poParent;
     void           *pTemp;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALRescaledAlphaBand)
 
   protected:
     CPLErr IReadBlock( int, int, void * ) override;
@@ -1492,9 +1498,9 @@ private:
 
 class CPL_DLL GDALDriverManager : public GDALMajorObject
 {
-    int         nDrivers;
-    GDALDriver  **papoDrivers;
-    std::map<CPLString, GDALDriver*> oMapNameToDrivers;
+    int         nDrivers = 0;
+    GDALDriver  **papoDrivers = nullptr;
+    std::map<CPLString, GDALDriver*> oMapNameToDrivers{};
 
     GDALDriver  *GetDriver_unlocked( int iDriver )
             { return (iDriver >= 0 && iDriver < nDrivers) ?
@@ -1502,6 +1508,8 @@ class CPL_DLL GDALDriverManager : public GDALMajorObject
 
     GDALDriver  *GetDriverByName_unlocked( const char * pszName )
             { return oMapNameToDrivers[CPLString(pszName).toupper()]; }
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALDriverManager)
 
  public:
                 GDALDriverManager();
@@ -1534,6 +1542,9 @@ CPL_C_END
  */
 class CPL_DLL GDALAsyncReader
 {
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALAsyncReader)
+
   protected:
 //! @cond Doxygen_Suppress
     GDALDataset* poDS;

--- a/gdal/gcore/gdal_proxy.h
+++ b/gdal/gcore/gdal_proxy.h
@@ -208,20 +208,20 @@ class     GDALProxyPoolRasterBand;
 class CPL_DLL GDALProxyPoolDataset : public GDALProxyDataset
 {
   private:
-        GIntBig          responsiblePID;
+        GIntBig          responsiblePID = -1;
 
-        char            *pszProjectionRef;
-        double           adfGeoTransform[6];
-        int              bHasSrcProjection;
-        int              bHasSrcGeoTransform;
-        char            *pszGCPProjection;
-        int              nGCPCount;
-        GDAL_GCP        *pasGCPList;
-        CPLHashSet      *metadataSet;
-        CPLHashSet      *metadataItemSet;
+        char            *pszProjectionRef = nullptr;
+        double           adfGeoTransform[6]{0,1,0,0,0,1};
+        int              bHasSrcProjection = false;
+        int              bHasSrcGeoTransform = false;
+        char            *pszGCPProjection = nullptr;
+        int              nGCPCount = 0;
+        GDAL_GCP        *pasGCPList = nullptr;
+        CPLHashSet      *metadataSet = nullptr;
+        CPLHashSet      *metadataItemSet = nullptr;
 
-        GDALProxyPoolCacheEntry* cacheEntry;
-        char            *m_pszOwner;
+        GDALProxyPoolCacheEntry* cacheEntry = nullptr;
+        char            *m_pszOwner = nullptr;
 
         GDALDataset *RefUnderlyingDataset(bool bForceOpen);
 
@@ -279,17 +279,15 @@ class GDALProxyPoolMaskBand;
 class CPL_DLL GDALProxyPoolRasterBand : public GDALProxyRasterBand
 {
   private:
-    CPLHashSet      *metadataSet;
-    CPLHashSet      *metadataItemSet;
-    char            *pszUnitType;
-    char           **papszCategoryNames;
-    GDALColorTable  *poColorTable;
+    CPLHashSet      *metadataSet = nullptr;
+    CPLHashSet      *metadataItemSet = nullptr;
+    char            *pszUnitType = nullptr;
+    char           **papszCategoryNames = nullptr;
+    GDALColorTable  *poColorTable = nullptr;
 
-    int                               nSizeProxyOverviewRasterBand;
-    GDALProxyPoolOverviewRasterBand **papoProxyOverviewRasterBand;
-    GDALProxyPoolMaskBand            *poProxyMaskBand;
-
-    void Init();
+    int                               nSizeProxyOverviewRasterBand = 0;
+    GDALProxyPoolOverviewRasterBand **papoProxyOverviewRasterBand = nullptr;
+    GDALProxyPoolMaskBand            *poProxyMaskBand = nullptr;
 
     GDALRasterBand* RefUnderlyingRasterBand( bool bForceOpen );
 
@@ -338,11 +336,13 @@ class CPL_DLL GDALProxyPoolRasterBand : public GDALProxyRasterBand
 class GDALProxyPoolOverviewRasterBand : public GDALProxyPoolRasterBand
 {
   private:
-    GDALProxyPoolRasterBand *poMainBand;
-    int                      nOverviewBand;
+    GDALProxyPoolRasterBand *poMainBand = nullptr;
+    int                      nOverviewBand = 0;
 
-    GDALRasterBand          *poUnderlyingMainRasterBand;
-    int                      nRefCountUnderlyingMainRasterBand;
+    GDALRasterBand          *poUnderlyingMainRasterBand = nullptr;
+    int                      nRefCountUnderlyingMainRasterBand = 0;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALProxyPoolOverviewRasterBand)
 
   protected:
     GDALRasterBand* RefUnderlyingRasterBand() override;
@@ -364,10 +364,12 @@ class GDALProxyPoolOverviewRasterBand : public GDALProxyPoolRasterBand
 class GDALProxyPoolMaskBand : public GDALProxyPoolRasterBand
 {
   private:
-    GDALProxyPoolRasterBand *poMainBand;
+    GDALProxyPoolRasterBand *poMainBand = nullptr;
 
-    GDALRasterBand          *poUnderlyingMainRasterBand;
-    int                      nRefCountUnderlyingMainRasterBand;
+    GDALRasterBand          *poUnderlyingMainRasterBand = nullptr;
+    int                      nRefCountUnderlyingMainRasterBand = 0;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALProxyPoolMaskBand)
 
   protected:
     GDALRasterBand* RefUnderlyingRasterBand() override;

--- a/gdal/gcore/gdal_rat.cpp
+++ b/gdal/gcore/gdal_rat.cpp
@@ -1080,24 +1080,6 @@ GDALRATDumpReadable( GDALRasterAttributeTableH hRAT, FILE *fp )
  */
 
 /************************************************************************/
-/*                  GDALDefaultRasterAttributeTable()                   */
-/*                                                                      */
-/*      Simple initialization constructor.                              */
-/************************************************************************/
-
-//! Construct empty table.
-
-GDALDefaultRasterAttributeTable::GDALDefaultRasterAttributeTable() :
-    bLinearBinning(false),
-    dfRow0Min(-0.5),
-    dfBinSize(1.0),
-    bColumnsAnalysed(false),
-    nMinCol(-1),
-    nMaxCol(-1),
-    nRowCount(0)
-{}
-
-/************************************************************************/
 /*                   GDALCreateRasterAttributeTable()                   */
 /************************************************************************/
 
@@ -1111,20 +1093,6 @@ GDALRasterAttributeTableH CPL_STDCALL GDALCreateRasterAttributeTable()
 
 {
     return new GDALDefaultRasterAttributeTable();
-}
-
-/************************************************************************/
-/*                  GDALDefaultRasterAttributeTable()                   */
-/************************************************************************/
-
-//! Copy constructor.
-
-GDALDefaultRasterAttributeTable::GDALDefaultRasterAttributeTable(
-    const GDALDefaultRasterAttributeTable &oOther ) : GDALRasterAttributeTable()
-
-{
-    // We have tried to be careful to allow wholesale assignment
-    *this = oOther;
 }
 
 /************************************************************************/

--- a/gdal/gcore/gdal_rat.h
+++ b/gdal/gcore/gdal_rat.h
@@ -296,15 +296,15 @@ public:
 class GDALRasterAttributeField
 {
  public:
-    CPLString         sName;
+    CPLString         sName{};
 
-    GDALRATFieldType  eType;
+    GDALRATFieldType  eType = GFT_Integer;
 
-    GDALRATFieldUsage eUsage;
+    GDALRATFieldUsage eUsage = GFU_Generic;
 
-    std::vector<GInt32> anValues;
-    std::vector<double> adfValues;
-    std::vector<CPLString> aosValues;
+    std::vector<GInt32> anValues{};
+    std::vector<double> adfValues{};
+    std::vector<CPLString> aosValues{};
 };
 //! @endcond
 
@@ -314,28 +314,25 @@ class GDALRasterAttributeField
 
 //! Raster Attribute Table container.
 
-// cppcheck-suppress copyCtorAndEqOperator
 class CPL_DLL GDALDefaultRasterAttributeTable : public GDALRasterAttributeTable
 {
  private:
-    std::vector<GDALRasterAttributeField> aoFields;
+    std::vector<GDALRasterAttributeField> aoFields{};
 
-    int bLinearBinning;  // TODO(schwehr): Can this be a bool?
-    double dfRow0Min;
-    double dfBinSize;
+    int bLinearBinning = false;  // TODO(schwehr): Can this be a bool?
+    double dfRow0Min = -0.5;
+    double dfBinSize = 1.0;
 
     void  AnalyseColumns();
-    int   bColumnsAnalysed;  // TODO(schwehr): Can this be a bool?
-    int   nMinCol;
-    int   nMaxCol;
+    int   bColumnsAnalysed = false;  // TODO(schwehr): Can this be a bool?
+    int   nMinCol = -1;
+    int   nMaxCol = -1;
 
-    int   nRowCount;
+    int   nRowCount = 0;
 
-    CPLString osWorkingResult;
+    CPLString osWorkingResult{};
 
  public:
-    GDALDefaultRasterAttributeTable();
-    GDALDefaultRasterAttributeTable( const GDALDefaultRasterAttributeTable& );
     ~GDALDefaultRasterAttributeTable() override;
 
     GDALDefaultRasterAttributeTable *Clone() const override;

--- a/gdal/gcore/gdalabstractbandblockcache.cpp
+++ b/gdal/gcore/gdalabstractbandblockcache.cpp
@@ -51,12 +51,10 @@ static int nAllBandsKeptAlivedBlocks = 0;
 GDALAbstractBandBlockCache::GDALAbstractBandBlockCache(
     GDALRasterBand* poBandIn ) :
     hSpinLock(CPLCreateLock(LOCK_SPIN)),
-    psListBlocksToFree(nullptr),
     hCond(CPLCreateCond()),
     hCondMutex(CPLCreateMutex()),
-    nKeepAliveCounter(0)
+    poBand(poBandIn)
 {
-    poBand = poBandIn;
     if( hCondMutex )
         CPLReleaseMutex(hCondMutex);
 }

--- a/gdal/gcore/gdalarraybandblockcache.cpp
+++ b/gdal/gcore/gdalarraybandblockcache.cpp
@@ -53,14 +53,18 @@ CPL_CVSID("$Id$")
 
 class GDALArrayBandBlockCache final : public GDALAbstractBandBlockCache
 {
-    bool              bSubBlockingActive;
-    int               nSubBlocksPerRow;
-    int               nSubBlocksPerColumn;
-    union
+    bool              bSubBlockingActive = false;
+    int               nSubBlocksPerRow = 0;
+    int               nSubBlocksPerColumn = 0;
+    union u
     {
         GDALRasterBlock **papoBlocks;
         GDALRasterBlock ***papapoBlocks;
-    } u;
+
+        u(): papoBlocks(nullptr) {}
+    } u{};
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALArrayBandBlockCache)
 
   public:
     explicit GDALArrayBandBlockCache( GDALRasterBand* poBand );
@@ -91,12 +95,8 @@ GDALAbstractBandBlockCache* GDALArrayBandBlockCacheCreate(GDALRasterBand* poBand
 /************************************************************************/
 
 GDALArrayBandBlockCache::GDALArrayBandBlockCache(GDALRasterBand* poBandIn) :
-    GDALAbstractBandBlockCache(poBandIn),
-    bSubBlockingActive(false),
-    nSubBlocksPerRow(0),
-    nSubBlocksPerColumn(0)
+    GDALAbstractBandBlockCache(poBandIn)
 {
-    u.papoBlocks = nullptr;
 }
 
 /************************************************************************/

--- a/gdal/gcore/gdalclientserver.cpp
+++ b/gdal/gcore/gdalclientserver.cpp
@@ -464,17 +464,17 @@ static void MyChdirRootDirectory()
 
 class GDALClientDataset final: public GDALPamDataset
 {
-    GDALServerSpawnedProcess                         *ssp;
-    GDALPipe                                         *p;
-    CPLString                                         osProjection;
-    CPLString                                         osGCPProjection;
-    bool                                              bFreeDriver;
-    int                                               nGCPCount;
-    GDAL_GCP                                         *pasGCPs;
-    std::map<CPLString, char**>                       aoMapMetadata;
-    std::map< std::pair<CPLString,CPLString>, char*>  aoMapMetadataItem;
-    GDALServerAsyncProgress                          *async;
-    GByte                                             abyCaps[16]; /* 16 * 8 = 128 > INSTR_END */
+    GDALServerSpawnedProcess                         *ssp = nullptr;
+    GDALPipe                                         *p = nullptr;
+    CPLString                                         osProjection{};
+    CPLString                                         osGCPProjection{};
+    bool                                              bFreeDriver = false;
+    int                                               nGCPCount = 0;
+    GDAL_GCP                                         *pasGCPs = nullptr;
+    std::map<CPLString, char**>                       aoMapMetadata{};
+    std::map< std::pair<CPLString,CPLString>, char*>  aoMapMetadataItem{};
+    GDALServerAsyncProgress                          *async = nullptr;
+    GByte                                             abyCaps[16]{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; /* 16 * 8 = 128 > INSTR_END */
 
         int                      mCreateCopy(const char* pszFilename,
                                              GDALDataset* poSrcDS,
@@ -489,6 +489,8 @@ class GDALClientDataset final: public GDALPamDataset
                          explicit GDALClientDataset(GDALServerSpawnedProcess* ssp);
 
         static GDALClientDataset* CreateAndConnect();
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALClientDataset)
 
     protected:
        virtual CPLErr IBuildOverviews( const char *, int, int *,
@@ -569,19 +571,19 @@ class GDALClientRasterBand final: public GDALPamRasterBand
 {
     friend class GDALClientDataset;
 
-    GDALPipe                                        *p;
-    int                                              iSrvBand;
-    std::map<int, GDALRasterBand*>                   aMapOvrBands;
-    std::map<int, GDALRasterBand*>                   aMapOvrBandsCurrent;
-    GDALRasterBand                                  *poMaskBand;
-    std::map<CPLString, char**>                      aoMapMetadata;
-    std::map< std::pair<CPLString,CPLString>, char*> aoMapMetadataItem;
-    char                                           **papszCategoryNames;
-    GDALColorTable                                  *poColorTable;
-    char                                            *pszUnitType;
-    GDALRasterAttributeTable                        *poRAT;
-    std::vector<GDALRasterBand*>                     apoOldMaskBands;
-    GByte                                            abyCaps[16]; /* 16 * 8 = 128 > INSTR_END */
+    GDALPipe                                        *p = nullptr;
+    int                                              iSrvBand = 0;
+    std::map<int, GDALRasterBand*>                   aMapOvrBands{};
+    std::map<int, GDALRasterBand*>                   aMapOvrBandsCurrent{};
+    GDALRasterBand                                  *poMaskBand = nullptr;
+    std::map<CPLString, char**>                      aoMapMetadata{};
+    std::map< std::pair<CPLString,CPLString>, char*> aoMapMetadataItem{};
+    char                                           **papszCategoryNames = nullptr;
+    GDALColorTable                                  *poColorTable = nullptr;
+    char                                            *pszUnitType =nullptr;
+    GDALRasterAttributeTable                        *poRAT = nullptr;
+    std::vector<GDALRasterBand*>                     apoOldMaskBands{};
+    GByte                                            abyCaps[16]{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; /* 16 * 8 = 128 > INSTR_END */
 
     int                WriteInstr(InstrEnum instr);
 
@@ -590,14 +592,14 @@ class GDALClientRasterBand final: public GDALPamRasterBand
 
     GDALRasterBand    *CreateFakeMaskBand();
 
-    bool                                             bEnableLineCaching;
-    int                                              nSuccessiveLinesRead;
-    GDALDataType                                     eLastBufType;
-    int                                              nLastYOff;
-    GByte                                           *pabyCachedLines;
-    GDALDataType                                     eCachedBufType;
-    int                                              nCachedYStart;
-    int                                              nCachedLines;
+    bool                                             bEnableLineCaching = false;
+    int                                              nSuccessiveLinesRead = 0;
+    GDALDataType                                     eLastBufType = GDT_Unknown;
+    int                                              nLastYOff = -1;
+    GByte                                           *pabyCachedLines = nullptr;
+    GDALDataType                                     eCachedBufType = GDT_Unknown;
+    int                                              nCachedYStart = -1;
+    int                                              nCachedLines = 0;
 
     void    InvalidateCachedLines();
     CPLErr  IRasterIO_read_internal(
@@ -605,6 +607,9 @@ class GDALClientRasterBand final: public GDALPamRasterBand
                                 void * pData, int nBufXSize, int nBufYSize,
                                 GDALDataType eBufType,
                                 GSpacing nPixelSpace, GSpacing nLineSpace );
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALClientRasterBand)
+
   protected:
 
     CPLErr IReadBlock(int nBlockXOff, int nBlockYOff, void* pImage) override;
@@ -1940,19 +1945,21 @@ static int CPL_STDCALL RunSyncProgress(double dfComplete,
 
 class GDALServerInstance
 {
+    CPL_DISALLOW_COPY_ASSIGN(GDALServerInstance)
+
 public:
-    GDALPipe* p;
-    GDALDataset* poDS;
-    std::vector<GDALRasterBand*> aBands;
-    void* pBuffer;
-    int nBufferSize;
+    GDALPipe* p = nullptr;
+    GDALDataset* poDS = nullptr;
+    std::vector<GDALRasterBand*> aBands{};
+    void* pBuffer = nullptr;
+    int nBufferSize = 0;
 
         explicit GDALServerInstance(GDALPipe* p);
        ~GDALServerInstance();
 };
 
 GDALServerInstance::GDALServerInstance(GDALPipe* pIn) :
-        p(pIn), poDS(nullptr), pBuffer(nullptr), nBufferSize(0)
+        p(pIn)
 {
 }
 
@@ -3653,11 +3660,6 @@ GDALClientDataset::GDALClientDataset(GDALServerSpawnedProcess* sspIn)
 {
     ssp = sspIn;
     p = ssp->p;
-    bFreeDriver = false;
-    nGCPCount = 0;
-    pasGCPs = nullptr;
-    async = nullptr;
-    memset(abyCaps, 0, sizeof(abyCaps));
 }
 
 /************************************************************************/
@@ -3668,11 +3670,6 @@ GDALClientDataset::GDALClientDataset(GDALPipe* pIn)
 {
     ssp = nullptr;
     p = pIn;
-    bFreeDriver = false;
-    nGCPCount = 0;
-    pasGCPs = nullptr;
-    async = nullptr;
-    memset(abyCaps, 0, sizeof(abyCaps));
 }
 /************************************************************************/
 /*                       ~GDALClientDataset()                           */
@@ -4406,10 +4403,10 @@ GDALClientRasterBand::GDALClientRasterBand(GDALPipe* pIn, int iSrvBandIn,
                                            int nRasterXSizeIn, int nRasterYSizeIn,
                                            GDALDataType eDataTypeIn,
                                            int nBlockXSizeIn, int nBlockYSizeIn,
-                                           GByte abyCapsIn[16])
+                                           GByte abyCapsIn[16]):
+    p(pIn),
+    iSrvBand(iSrvBandIn)
 {
-    p = pIn;
-    iSrvBand = iSrvBandIn;
     poDS = poDSIn;
     nBand = nBandIn;
     eAccess = eAccessIn;
@@ -4418,21 +4415,9 @@ GDALClientRasterBand::GDALClientRasterBand(GDALPipe* pIn, int iSrvBandIn,
     eDataType = eDataTypeIn;
     nBlockXSize = nBlockXSizeIn;
     nBlockYSize = nBlockYSizeIn;
-    papszCategoryNames = nullptr;
-    poColorTable = nullptr;
-    pszUnitType = nullptr;
-    poMaskBand = nullptr;
-    poRAT = nullptr;
     memcpy(abyCaps, abyCapsIn, sizeof(abyCaps));
     bEnableLineCaching = CPLTestBool(CPLGetConfigOption(
         "GDAL_API_PROXY_LINE_CACHING", "YES"));
-    nSuccessiveLinesRead = 0;
-    eLastBufType = GDT_Unknown;
-    nLastYOff = -1;
-    pabyCachedLines = nullptr;
-    eCachedBufType = GDT_Unknown;
-    nCachedYStart = -1;
-    nCachedLines = 0;
 }
 
 /************************************************************************/

--- a/gdal/gcore/gdaldefaultasync.cpp
+++ b/gdal/gcore/gdaldefaultasync.cpp
@@ -282,7 +282,9 @@ void CPL_STDCALL GDALARUnlockBuffer(GDALAsyncReaderH hARIO)
 class GDALDefaultAsyncReader : public GDALAsyncReader
 {
   private:
-    char **papszOptions;
+    char **papszOptions = nullptr;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALDefaultAsyncReader)
 
   public:
     GDALDefaultAsyncReader(GDALDataset* poDS,

--- a/gdal/gcore/gdaldrivermanager.cpp
+++ b/gdal/gcore/gdaldrivermanager.cpp
@@ -114,9 +114,7 @@ GDALDriverManager * GetGDALDriverManager()
 /*                         GDALDriverManager()                          */
 /************************************************************************/
 
-GDALDriverManager::GDALDriverManager() :
-    nDrivers(0),
-    papoDrivers(nullptr)
+GDALDriverManager::GDALDriverManager()
 {
     CPLAssert( poDM == nullptr );
 

--- a/gdal/gcore/gdalgeorefpamdataset.h
+++ b/gdal/gcore/gdalgeorefpamdataset.h
@@ -59,6 +59,8 @@ class CPL_DLL GDALGeorefPamDataset : public GDALPamDataset
     bool        m_bPAMLoaded;
     char**      m_papszMainMD;
 
+    CPL_DISALLOW_COPY_ASSIGN(GDALGeorefPamDataset)
+
   public:
     GDALGeorefPamDataset();
     ~GDALGeorefPamDataset() override;

--- a/gdal/gcore/gdalhashsetbandblockcache.cpp
+++ b/gdal/gcore/gdalhashsetbandblockcache.cpp
@@ -65,8 +65,10 @@ class GDALHashSetBandBlockCache final : public GDALAbstractBandBlockCache
         }
     };
 
-    std::set<GDALRasterBlock*, BlockComparator> m_oSet;
-    CPLLock        *hLock;
+    std::set<GDALRasterBlock*, BlockComparator> m_oSet{};
+    CPLLock        *hLock = nullptr;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALHashSetBandBlockCache)
 
   public:
     explicit GDALHashSetBandBlockCache( GDALRasterBand* poBand );

--- a/gdal/gcore/gdaljp2abstractdataset.cpp
+++ b/gdal/gcore/gdaljp2abstractdataset.cpp
@@ -52,12 +52,7 @@
 /*                     GDALJP2AbstractDataset()                         */
 /************************************************************************/
 
-GDALJP2AbstractDataset::GDALJP2AbstractDataset() :
-    pszWldFilename(nullptr),
-    poMemDS(nullptr),
-    papszMetadataFiles(nullptr),
-    m_nWORLDFILEIndex(-1)
-{}
+GDALJP2AbstractDataset::GDALJP2AbstractDataset() = default;
 
 /************************************************************************/
 /*                     ~GDALJP2AbstractDataset()                        */

--- a/gdal/gcore/gdaljp2abstractdataset.h
+++ b/gdal/gcore/gdaljp2abstractdataset.h
@@ -36,11 +36,13 @@
 
 class CPL_DLL GDALJP2AbstractDataset: public GDALGeorefPamDataset
 {
-    char*               pszWldFilename;
+    char*               pszWldFilename = nullptr;
 
-    GDALDataset*        poMemDS;
-    char**              papszMetadataFiles;
-    int                 m_nWORLDFILEIndex;
+    GDALDataset*        poMemDS = nullptr;
+    char**              papszMetadataFiles = nullptr;
+    int                 m_nWORLDFILEIndex = -1;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALJP2AbstractDataset)
 
   protected:
     int CloseDependentDatasets() override;

--- a/gdal/gcore/gdaljp2metadata.cpp
+++ b/gdal/gcore/gdaljp2metadata.cpp
@@ -1674,58 +1674,51 @@ static void GDALGMLJP2PatchFeatureCollectionSubstitutionGroup(CPLXMLNode* psRoot
 class GMLJP2V2GMLFileDesc
 {
     public:
-        CPLString osFile;
-        CPLString osRemoteResource;
-        CPLString osNamespace;
-        CPLString osNamespacePrefix;
-        CPLString osSchemaLocation;
-        int       bInline;
-        int       bParentCoverageCollection;
-
-            GMLJP2V2GMLFileDesc(): bInline(TRUE), bParentCoverageCollection(TRUE) {}
+        CPLString osFile{};
+        CPLString osRemoteResource{};
+        CPLString osNamespace{};
+        CPLString osNamespacePrefix{};
+        CPLString osSchemaLocation{};
+        int       bInline = true;
+        int       bParentCoverageCollection = true;
 };
 
 class GMLJP2V2AnnotationDesc
 {
     public:
-        CPLString osFile;
+        CPLString osFile{};
 };
 
 class GMLJP2V2MetadataDesc
 {
     public:
-        CPLString osFile;
-        CPLString osContent;
-        CPLString osTemplateFile;
-        CPLString osSourceFile;
-        int       bGDALMetadata;
-        int       bParentCoverageCollection;
-
-            GMLJP2V2MetadataDesc(): bGDALMetadata(FALSE), bParentCoverageCollection(TRUE) {}
+        CPLString osFile{};
+        CPLString osContent{};
+        CPLString osTemplateFile{};
+        CPLString osSourceFile{};
+        int       bGDALMetadata = false;
+        int       bParentCoverageCollection = true;
 };
 
 class GMLJP2V2StyleDesc
 {
     public:
-        CPLString osFile;
-        int       bParentCoverageCollection;
-
-            GMLJP2V2StyleDesc(): bParentCoverageCollection(TRUE) {}
+        CPLString osFile{};
+        int       bParentCoverageCollection = true;
 };
 
 class GMLJP2V2ExtensionDesc
 {
     public:
-        CPLString osFile;
-        int       bParentCoverageCollection;
-
-            GMLJP2V2ExtensionDesc(): bParentCoverageCollection(TRUE) {}
+        CPLString osFile{};
+        int       bParentCoverageCollection = true;
 };
+
 class GMLJP2V2BoxDesc
 {
     public:
-        CPLString osFile;
-        CPLString osLabel;
+        CPLString osFile{};
+        CPLString osLabel{};
 };
 
 GDALJP2Box *GDALJP2Metadata::CreateGMLJP2V2( int nXSize, int nYSize,

--- a/gdal/gcore/gdaljp2metadata.h
+++ b/gdal/gcore/gdaljp2metadata.h
@@ -59,6 +59,8 @@ class CPL_DLL GDALJP2Box
 
     GByte      *pabyData;
 
+    CPL_DISALLOW_COPY_ASSIGN(GDALJP2Box)
+
 public:
     explicit    GDALJP2Box( VSILFILE * = nullptr );
                 ~GDALJP2Box();
@@ -139,6 +141,8 @@ private:
     static CPLXMLNode* CreateGDALMultiDomainMetadataXML(
                                        GDALDataset* poSrcDS,
                                        int bMainMDDomainOnly );
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALJP2Metadata)
 
 public:
     char  **papszGMLMetadata;

--- a/gdal/gcore/gdaljp2metadatagenerator.cpp
+++ b/gdal/gcore/gdaljp2metadatagenerator.cpp
@@ -72,7 +72,7 @@ class GDALGMLJP2Expr
 
   public:
     GDALGMLJP2ExprType           eType;
-    CPLString                    osValue;
+    CPLString                    osValue{};
 
     GDALGMLJP2Expr() : eType(GDALGMLJP2Expr_Unknown) {}
     GDALGMLJP2Expr( const char* pszVal ) :

--- a/gdal/gcore/gdaloverviewdataset.cpp
+++ b/gdal/gcore/gdaloverviewdataset.cpp
@@ -60,16 +60,16 @@ class GDALOverviewDataset final: public GDALDataset
   private:
     friend class GDALOverviewBand;
 
-    GDALDataset* poMainDS;
+    GDALDataset* poMainDS = nullptr;
 
-    GDALDataset* poOvrDS;  // Will be often NULL.
-    int          nOvrLevel;
-    int          bThisLevelOnly;
+    GDALDataset* poOvrDS = nullptr;  // Will be often NULL.
+    int          nOvrLevel = 0;
+    int          bThisLevelOnly = 0;
 
-    int          nGCPCount;
-    GDAL_GCP    *pasGCPList;
-    char       **papszMD_RPC;
-    char       **papszMD_GEOLOCATION;
+    int          nGCPCount = 0;
+    GDAL_GCP    *pasGCPList = nullptr;
+    char       **papszMD_RPC = nullptr;
+    char       **papszMD_GEOLOCATION = nullptr;
 
     static void  Rescale( char**& papszMD, const char* pszItem,
                           double dfRatio, double dfDefaultVal );
@@ -113,7 +113,7 @@ class GDALOverviewBand final: public GDALProxyRasterBand
   protected:
     friend class GDALOverviewDataset;
 
-    GDALRasterBand*         poUnderlyingBand;
+    GDALRasterBand*         poUnderlyingBand = nullptr;
     GDALRasterBand* RefUnderlyingRasterBand() override;
 
   public:
@@ -169,11 +169,7 @@ GDALOverviewDataset::GDALOverviewDataset( GDALDataset* poMainDSIn,
                                           int bThisLevelOnlyIn ) :
     poMainDS(poMainDSIn),
     nOvrLevel(nOvrLevelIn),
-    bThisLevelOnly(bThisLevelOnlyIn),
-    nGCPCount(0),
-    pasGCPList(nullptr),
-    papszMD_RPC(nullptr),
-    papszMD_GEOLOCATION(nullptr)
+    bThisLevelOnly(bThisLevelOnlyIn)
 {
     poMainDSIn->Reference();
     eAccess = poMainDS->GetAccess();

--- a/gdal/gcore/gdalpamdataset.cpp
+++ b/gdal/gcore/gdalpamdataset.cpp
@@ -313,14 +313,6 @@ void GDALPamDataset::PamInitialize()
         nPamFlags |= GPF_AUXMODE;
 
     psPam = new GDALDatasetPamInfo;
-    psPam->pszPamFilename = nullptr;
-    psPam->pszProjection = nullptr;
-    psPam->bHaveGeoTransform = FALSE;
-    psPam->nGCPCount = 0;
-    psPam->pasGCPList = nullptr;
-    psPam->pszGCPProjection = nullptr;
-    psPam->bHasMetadata = FALSE;
-
     for( int iBand = 0; iBand < GetRasterCount(); iBand++ )
     {
         GDALRasterBand *poBand = GetRasterBand(iBand+1);

--- a/gdal/gcore/gdalpamproxydb.cpp
+++ b/gdal/gcore/gdalpamproxydb.cpp
@@ -64,14 +64,12 @@ CPL_CVSID("$Id$")
 class GDALPamProxyDB
 {
   public:
-    GDALPamProxyDB() { nUpdateCounter = -1; }
+    CPLString   osProxyDBDir{};
 
-    CPLString   osProxyDBDir;
+    int         nUpdateCounter = -1;
 
-    int         nUpdateCounter;
-
-    std::vector<CPLString> aosOriginalFiles;
-    std::vector<CPLString> aosProxyFiles;
+    std::vector<CPLString> aosOriginalFiles{};
+    std::vector<CPLString> aosProxyFiles{};
 
     void        CheckLoadDB();
     void        LoadDB();

--- a/gdal/gcore/gdalpamrasterband.cpp
+++ b/gdal/gcore/gdalpamrasterband.cpp
@@ -58,7 +58,6 @@ CPL_CVSID("$Id$")
 GDALPamRasterBand::GDALPamRasterBand()
 
 {
-    psPam = nullptr;
     SetMOFlags( GetMOFlags() | GMO_PAM_CLASS );
 }
 
@@ -70,7 +69,6 @@ GDALPamRasterBand::GDALPamRasterBand()
 GDALPamRasterBand::GDALPamRasterBand( int bForceCachedIOIn ) :
     GDALRasterBand(bForceCachedIOIn)
 {
-    psPam = nullptr;
     SetMOFlags( GetMOFlags() | GMO_PAM_CLASS );
 }
 //! @endcond

--- a/gdal/gcore/gdalproxypool.cpp
+++ b/gdal/gcore/gdalproxypool.cpp
@@ -80,18 +80,18 @@ struct _GDALProxyPoolCacheEntry
 class GDALDatasetPool
 {
     private:
-        bool bInDestruction;
+        bool bInDestruction = false;
 
         /* Ref count of the pool singleton */
         /* Taken by "toplevel" GDALProxyPoolDataset in its constructor and released */
         /* in its destructor. See also refCountOfDisableRefCount for the difference */
         /* between toplevel and inner GDALProxyPoolDataset */
-        int refCount;
+        int refCount = 0;
 
-        int maxSize;
-        int currentSize;
-        GDALProxyPoolCacheEntry* firstEntry;
-        GDALProxyPoolCacheEntry* lastEntry;
+        int maxSize = 0;
+        int currentSize = 0;
+        GDALProxyPoolCacheEntry* firstEntry = nullptr;
+        GDALProxyPoolCacheEntry* lastEntry = nullptr;
 
         /* This variable prevents a dataset that is going to be opened in GDALDatasetPool::_RefDataset */
         /* from increasing refCount if, during its opening, it creates a GDALProxyPoolDataset */
@@ -99,7 +99,7 @@ class GDALDatasetPool
         /* The typical use case is a VRT made of simple sources that are VRT */
         /* We don't want the "inner" VRT to take a reference on the pool, otherwise there is */
         /* a high chance that this reference will not be dropped and the pool remain ghost */
-        int refCountOfDisableRefCount;
+        int refCountOfDisableRefCount= 0;
 
         /* Caution : to be sure that we don't run out of entries, size must be at */
         /* least greater or equal than the maximum number of threads */
@@ -118,6 +118,8 @@ class GDALDatasetPool
         void ShowContent();
         void CheckLinks();
 #endif
+
+        CPL_DISALLOW_COPY_ASSIGN(GDALDatasetPool)
 
     public:
         static void Ref();
@@ -139,15 +141,8 @@ class GDALDatasetPool
 /*                         GDALDatasetPool()                            */
 /************************************************************************/
 
-GDALDatasetPool::GDALDatasetPool(int maxSizeIn)
+GDALDatasetPool::GDALDatasetPool(int maxSizeIn): maxSize(maxSizeIn)
 {
-    bInDestruction = false;
-    maxSize = maxSizeIn;
-    currentSize = 0;
-    firstEntry = nullptr;
-    lastEntry = nullptr;
-    refCount = 0;
-    refCountOfDisableRefCount = 0;
 }
 
 /************************************************************************/
@@ -606,7 +601,10 @@ GDALProxyPoolDataset::GDALProxyPoolDataset(const char* pszSourceDatasetDescripti
                                    GDALAccess eAccessIn, int bSharedIn,
                                    const char * pszProjectionRefIn,
                                    double * padfGeoTransform,
-                                   const char* pszOwner)
+                                   const char* pszOwner):
+    responsiblePID(GDALGetResponsiblePIDForCurrentThread()),
+    pszProjectionRef(pszProjectionRefIn ? CPLStrdup(pszProjectionRefIn): nullptr),
+    bHasSrcProjection(pszProjectionRefIn != nullptr)
 {
     GDALDatasetPool::Ref();
 
@@ -619,18 +617,6 @@ GDALProxyPoolDataset::GDALProxyPoolDataset(const char* pszSourceDatasetDescripti
     bShared = CPL_TO_BOOL(bSharedIn);
     m_pszOwner = pszOwner ? CPLStrdup(pszOwner) : nullptr;
 
-    responsiblePID = GDALGetResponsiblePIDForCurrentThread();
-
-    if (pszProjectionRefIn)
-    {
-        pszProjectionRef = nullptr;
-        bHasSrcProjection = FALSE;
-    }
-    else
-    {
-        pszProjectionRef = CPLStrdup(pszProjectionRefIn);
-        bHasSrcProjection = TRUE;
-    }
     if (padfGeoTransform)
     {
         memcpy(adfGeoTransform, padfGeoTransform,6 * sizeof(double));
@@ -992,8 +978,6 @@ GDALProxyPoolRasterBand::GDALProxyPoolRasterBand(GDALProxyPoolDataset* poDSIn, i
     nRasterYSize = poDSIn->GetRasterYSize();
     nBlockXSize  = nBlockXSizeIn;
     nBlockYSize  = nBlockYSizeIn;
-
-    Init();
 }
 
 /* ******************************************************************** */
@@ -1009,25 +993,6 @@ GDALProxyPoolRasterBand::GDALProxyPoolRasterBand(GDALProxyPoolDataset* poDSIn,
     nRasterXSize = poUnderlyingRasterBand->GetXSize();
     nRasterYSize = poUnderlyingRasterBand->GetYSize();
     poUnderlyingRasterBand->GetBlockSize(&nBlockXSize, &nBlockYSize);
-
-    Init();
-}
-
-/* ******************************************************************** */
- /*                                  Init()                             */
-/* ******************************************************************** */
-
-void GDALProxyPoolRasterBand::Init()
-{
-    metadataSet = nullptr;
-    metadataItemSet = nullptr;
-    pszUnitType = nullptr;
-    papszCategoryNames = nullptr;
-    poColorTable = nullptr;
-
-    nSizeProxyOverviewRasterBand = 0;
-    papoProxyOverviewRasterBand = nullptr;
-    poProxyMaskBand = nullptr;
 }
 
 /* ******************************************************************** */
@@ -1336,13 +1301,10 @@ GDALProxyPoolOverviewRasterBand::GDALProxyPoolOverviewRasterBand(GDALProxyPoolDa
                                                                  GDALRasterBand* poUnderlyingOverviewBand,
                                                                  GDALProxyPoolRasterBand* poMainBandIn,
                                                                  int nOverviewBandIn) :
-        GDALProxyPoolRasterBand(poDSIn, poUnderlyingOverviewBand)
+        GDALProxyPoolRasterBand(poDSIn, poUnderlyingOverviewBand),
+        poMainBand(poMainBandIn),
+        nOverviewBand(nOverviewBandIn)
 {
-    poMainBand = poMainBandIn;
-    nOverviewBand = nOverviewBandIn;
-
-    poUnderlyingMainRasterBand = nullptr;
-    nRefCountUnderlyingMainRasterBand = 0;
 }
 
 /* ******************************************************************** */
@@ -1402,12 +1364,9 @@ GDALProxyPoolMaskBand::GDALProxyPoolMaskBand(GDALProxyPoolDataset* poDSIn,
                                              GDALProxyPoolRasterBand* poMainBandIn,
                                              GDALDataType eDataTypeIn,
                                              int nBlockXSizeIn, int nBlockYSizeIn) :
-        GDALProxyPoolRasterBand(poDSIn, 1, eDataTypeIn, nBlockXSizeIn, nBlockYSizeIn)
+        GDALProxyPoolRasterBand(poDSIn, 1, eDataTypeIn, nBlockXSizeIn, nBlockYSizeIn),
+        poMainBand(poMainBandIn)
 {
-    poMainBand = poMainBandIn;
-
-    poUnderlyingMainRasterBand = nullptr;
-    nRefCountUnderlyingMainRasterBand = 0;
 }
 
 /* ******************************************************************** */

--- a/gdal/gcore/gdalrasterband.cpp
+++ b/gdal/gcore/gdalrasterband.cpp
@@ -60,45 +60,18 @@ CPL_CVSID("$Id$")
 
 /*! Constructor. Applications should never create GDALRasterBands directly. */
 
-GDALRasterBand::GDALRasterBand()
-
+GDALRasterBand::GDALRasterBand() :
+    GDALRasterBand(CPLTestBool( CPLGetConfigOption( "GDAL_FORCE_CACHING", "NO") ) )
 {
-    Init(CPLTestBool( CPLGetConfigOption( "GDAL_FORCE_CACHING", "NO") ) );
 }
 
 /** Constructor. Applications should never create GDALRasterBands directly.
  * @param bForceCachedIOIn Whether cached IO should be forced.
  */
-GDALRasterBand::GDALRasterBand(int bForceCachedIOIn)
+GDALRasterBand::GDALRasterBand(int bForceCachedIOIn):
+    bForceCachedIO(bForceCachedIOIn)
 
 {
-    Init(bForceCachedIOIn);
-}
-
-void GDALRasterBand::Init(int bForceCachedIOIn)
-{
-    poDS = nullptr;
-    nBand = 0;
-    nRasterXSize = 0;
-    nRasterYSize = 0;
-
-    eAccess = GA_ReadOnly;
-    nBlockXSize = -1;
-    nBlockYSize = -1;
-    eDataType = GDT_Byte;
-
-    nBlocksPerRow = 0;
-    nBlocksPerColumn = 0;
-
-    poMask = nullptr;
-    bOwnMask = false;
-    nMaskFlags = 0;
-
-    nBlockReads = 0;
-    bForceCachedIO = bForceCachedIOIn;
-
-    eFlushBlockErr = CE_None;
-    poBandBlockCache = nullptr;
 }
 
 /************************************************************************/

--- a/gdal/gcore/gdalsse_priv.h
+++ b/gdal/gcore/gdalsse_priv.h
@@ -96,10 +96,17 @@ class XMMReg2Double
   public:
     __m128d xmm;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#endif
     /* coverity[uninit_member] */
-    XMMReg2Double() {}
+    XMMReg2Double() = default;
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
-    XMMReg2Double(double  val)  { xmm = _mm_load_sd (&val); }
+    XMMReg2Double(double  val): xmm(_mm_load_sd (&val)) {}
     XMMReg2Double(const XMMReg2Double& other) : xmm(other.xmm) {}
 
     static inline XMMReg2Double Zero()
@@ -1001,7 +1008,16 @@ class XMMReg4Double
   public:
     XMMReg2Double low, high;
 
-    XMMReg4Double() {}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#endif
+    /* coverity[uninit_member] */
+    XMMReg4Double() = default;
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
     XMMReg4Double(const XMMReg4Double& other) : low(other.low), high(other.high) {}
 
     static inline XMMReg4Double Zero()

--- a/gdal/gcore/gdalvirtualmem.cpp
+++ b/gdal/gcore/gdalvirtualmem.cpp
@@ -50,23 +50,23 @@ typedef int spacing_type;
 
 class GDALVirtualMem
 {
-    GDALDatasetH hDS;
-    GDALRasterBandH hBand;
-    coord_type nXOff;
-    coord_type nYOff;
+    GDALDatasetH hDS = nullptr;
+    GDALRasterBandH hBand = nullptr;
+    coord_type nXOff = 0;
+    coord_type nYOff = 0;
     // int nXSize;
     // int nYSize;
-    coord_type nBufXSize;
-    coord_type nBufYSize;
-    GDALDataType eBufType;
-    int nBandCount;
-    int* panBandMap;
-    int nPixelSpace;
-    GIntBig nLineSpace;
-    GIntBig nBandSpace;
+    coord_type nBufXSize = 0;
+    coord_type nBufYSize = 0;
+    GDALDataType eBufType = GDT_Byte;
+    int nBandCount = 0;
+    int* panBandMap = nullptr;
+    int nPixelSpace = 0;
+    GIntBig nLineSpace = 0;
+    GIntBig nBandSpace = 0;
 
-    bool bIsCompact;
-    bool bIsBandSequential;
+    bool bIsCompact = false;
+    bool bIsBandSequential = false;
 
     bool IsCompact() const { return bIsCompact; }
     bool IsBandSequential() const { return bIsBandSequential; }
@@ -80,6 +80,8 @@ class GDALVirtualMem
                              void* pPage, size_t nBytes ) const;
     void DoIOPixelInterleaved( GDALRWFlag eRWFlag, size_t nOffset,
                                void* pPage, size_t nBytes ) const;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALVirtualMem)
 
 public:
              GDALVirtualMem( GDALDatasetH hDS,
@@ -1103,21 +1105,23 @@ CPLVirtualMem* GDALRasterBandGetVirtualMem( GDALRasterBandH hBand,
 
 class GDALTiledVirtualMem
 {
-    GDALDatasetH hDS;
-    GDALRasterBandH hBand;
-    int nXOff;
-    int nYOff;
-    int nXSize;
-    int nYSize;
-    int nTileXSize;
-    int nTileYSize;
-    GDALDataType eBufType;
-    int nBandCount;
-    int* panBandMap;
-    GDALTileOrganization eTileOrganization;
+    GDALDatasetH hDS = nullptr;
+    GDALRasterBandH hBand = nullptr;
+    int nXOff = 0;
+    int nYOff = 0;
+    int nXSize = 0;
+    int nYSize = 0;
+    int nTileXSize = 0;
+    int nTileYSize = 0;
+    GDALDataType eBufType = GDT_Byte;
+    int nBandCount = 0;
+    int* panBandMap = nullptr;
+    GDALTileOrganization eTileOrganization = GTO_TIP;
 
     void DoIO( GDALRWFlag eRWFlag, size_t nOffset,
                void* pPage, size_t nBytes ) const;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALTiledVirtualMem)
 
 public:
              GDALTiledVirtualMem( GDALDatasetH hDS,

--- a/gdal/gcore/mdreader/reader_alos.h
+++ b/gdal/gcore/mdreader/reader_alos.h
@@ -60,9 +60,9 @@ protected:
     char** LoadRPCTxtFile();
     virtual time_t GetAcquisitionTimeFromString(const char* pszDateTime) override;
 protected:
-    CPLString m_osIMDSourceFilename;
-    CPLString m_osHDRSourceFilename;
-    CPLString m_osRPBSourceFilename;
+    CPLString m_osIMDSourceFilename{};
+    CPLString m_osHDRSourceFilename{};
+    CPLString m_osRPBSourceFilename{};
 };
 
 #endif // READER_ALOS_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_digital_globe.h
+++ b/gdal/gcore/mdreader/reader_digital_globe.h
@@ -66,9 +66,9 @@ protected:
     char** LoadRPBXmlNode(CPLXMLNode* psNode);
     char** LoadIMDXmlNode(CPLXMLNode* psNode);
 protected:
-    CPLString m_osXMLSourceFilename;
-    CPLString m_osIMDSourceFilename;
-    CPLString m_osRPBSourceFilename;
+    CPLString m_osXMLSourceFilename{};
+    CPLString m_osIMDSourceFilename{};
+    CPLString m_osRPBSourceFilename{};
 };
 
 #endif //READER_DIGITAL_GLOBE_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_eros.h
+++ b/gdal/gcore/mdreader/reader_eros.h
@@ -56,8 +56,8 @@ protected:
     char** LoadImdTxtFile();
     virtual time_t GetAcquisitionTimeFromString(const char* pszDateTime) override;
 protected:
-    CPLString m_osIMDSourceFilename;
-    CPLString m_osRPBSourceFilename;
+    CPLString m_osIMDSourceFilename{};
+    CPLString m_osRPBSourceFilename{};
 };
 
 #endif // READER_EROS_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_geo_eye.h
+++ b/gdal/gcore/mdreader/reader_geo_eye.h
@@ -60,8 +60,8 @@ protected:
     char **LoadRPCWktFile() const;
     char **LoadIMDWktFile() const;
 protected:
-    CPLString m_osIMDSourceFilename;
-    CPLString m_osRPBSourceFilename;
+    CPLString m_osIMDSourceFilename{};
+    CPLString m_osRPBSourceFilename{};
 };
 
 #endif // READER_GEO_EYE_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_kompsat.h
+++ b/gdal/gcore/mdreader/reader_kompsat.h
@@ -57,8 +57,8 @@ protected:
     char** ReadTxtToList();
     virtual time_t GetAcquisitionTimeFromString(const char* pszDateTime) override;
 protected:
-    CPLString m_osIMDSourceFilename;
-    CPLString m_osRPBSourceFilename;
+    CPLString m_osIMDSourceFilename{};
+    CPLString m_osRPBSourceFilename{};
 };
 
 #endif // READER_KOMPSAT_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_landsat.h
+++ b/gdal/gcore/mdreader/reader_landsat.h
@@ -59,7 +59,7 @@ public:
 protected:
     virtual void LoadMetadata() override;
 protected:
-    CPLString m_osIMDSourceFilename;
+    CPLString m_osIMDSourceFilename{};
 };
 
 #endif // READER_LANDSAT_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_orb_view.h
+++ b/gdal/gcore/mdreader/reader_orb_view.h
@@ -55,8 +55,8 @@ public:
 protected:
     virtual void LoadMetadata() override;
 protected:
-    CPLString m_osIMDSourceFilename;
-    CPLString m_osRPBSourceFilename;
+    CPLString m_osIMDSourceFilename{};
+    CPLString m_osRPBSourceFilename{};
 };
 
 #endif // READER_ORB_VIEW_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_pleiades.h
+++ b/gdal/gcore/mdreader/reader_pleiades.h
@@ -61,9 +61,9 @@ public:
 protected:
     virtual void LoadMetadata() override;
 protected:
-    CPLString m_osBaseFilename;
-    CPLString m_osIMDSourceFilename;
-    CPLString m_osRPBSourceFilename;
+    CPLString m_osBaseFilename{};
+    CPLString m_osIMDSourceFilename{};
+    CPLString m_osRPBSourceFilename{};
 private:
     GDALMDReaderPleiades();
 };

--- a/gdal/gcore/mdreader/reader_rapid_eye.h
+++ b/gdal/gcore/mdreader/reader_rapid_eye.h
@@ -56,7 +56,7 @@ public:
 protected:
     virtual void LoadMetadata() override;
 protected:
-    CPLString m_osXMLSourceFilename;
+    CPLString m_osXMLSourceFilename{};
 };
 
 #endif // READER_RAPID_EYE_H_INCLUDED

--- a/gdal/gcore/mdreader/reader_rdk1.h
+++ b/gdal/gcore/mdreader/reader_rdk1.h
@@ -58,7 +58,7 @@ protected:
     virtual char** AddXMLNameValueToList(char** papszList, const char *pszName,
                                          const char *pszValue) override;
 protected:
-    CPLString m_osXMLSourceFilename;
+    CPLString m_osXMLSourceFilename{};
 };
 
 #endif // READER_RDK1_H_INCLUDED

--- a/gdal/ogr/ogr_feature.h
+++ b/gdal/ogr/ogr_feature.h
@@ -816,6 +816,9 @@ class CPL_DLL OGRFeatureQuery
     OGRErr      Compile( OGRLayer *, OGRFeatureDefn*, const char *,
                          int bCheck,
                          swq_custom_func_registrar* poCustomFuncRegistrar );
+
+    CPL_DISALLOW_COPY_ASSIGN(OGRFeatureQuery)
+
   public:
                 OGRFeatureQuery();
                ~OGRFeatureQuery();

--- a/gdal/ogr/ogr_featurestyle.h
+++ b/gdal/ogr/ogr_featurestyle.h
@@ -89,6 +89,8 @@ class CPL_DLL OGRStyleTable
     CPLString osLastRequestedStyleName;
     int iNextStyle;
 
+    CPL_DISALLOW_COPY_ASSIGN(OGRStyleTable)
+
   public:
     OGRStyleTable();
     ~OGRStyleTable();
@@ -119,6 +121,8 @@ class CPL_DLL OGRStyleMgr
   private:
     OGRStyleTable   *m_poDataSetStyleTable;
     char            *m_pszStyleString;
+
+    CPL_DISALLOW_COPY_ASSIGN(OGRStyleMgr)
 
   public:
     explicit OGRStyleMgr(OGRStyleTable *poDataSetStyleTable = nullptr);
@@ -169,6 +173,8 @@ class CPL_DLL OGRStyleTool
     char *m_pszStyleString;
 
     virtual GBool Parse() = 0;
+
+    CPL_DISALLOW_COPY_ASSIGN(OGRStyleTool)
 
   protected:
 #ifndef DOXYGEN_SKIP
@@ -264,6 +270,8 @@ class CPL_DLL OGRStylePen : public OGRStyleTool
 
     GBool Parse() override;
 
+    CPL_DISALLOW_COPY_ASSIGN(OGRStylePen)
+
   public:
 
     OGRStylePen();
@@ -312,6 +320,8 @@ class CPL_DLL OGRStyleBrush : public OGRStyleTool
 
     GBool Parse() override;
 
+    CPL_DISALLOW_COPY_ASSIGN(OGRStyleBrush)
+
   public:
 
     OGRStyleBrush();
@@ -357,6 +367,8 @@ class CPL_DLL OGRStyleSymbol : public OGRStyleTool
     OGRStyleValue    *m_pasStyleValue;
 
     GBool Parse() override;
+
+    CPL_DISALLOW_COPY_ASSIGN(OGRStyleSymbol)
 
   public:
 
@@ -411,6 +423,8 @@ class CPL_DLL OGRStyleLabel : public OGRStyleTool
     OGRStyleValue    *m_pasStyleValue;
 
     GBool Parse() override;
+
+    CPL_DISALLOW_COPY_ASSIGN(OGRStyleLabel)
 
   public:
 

--- a/gdal/ogr/ogr_spatialref.h
+++ b/gdal/ogr/ogr_spatialref.h
@@ -74,6 +74,8 @@ class CPL_DLL OGR_SRSNode
     int         NeedsQuoting() const;
     OGRErr      importFromWkt( const char **, int nRecLevel, int* pnNodes );
 
+    CPL_DISALLOW_COPY_ASSIGN(OGR_SRSNode)
+
   public:
     explicit     OGR_SRSNode(const char * = nullptr);
                 ~OGR_SRSNode();

--- a/gdal/ogr/ogrsf_frmts/generic/ogr_gensql.h
+++ b/gdal/ogr/ogrsf_frmts/generic/ogr_gensql.h
@@ -112,6 +112,8 @@ class OGRGenSQLResultsLayer final: public OGRLayer
 
     int         MustEvaluateSpatialFilterOnGenSQL();
 
+    CPL_DISALLOW_COPY_ASSIGN(OGRGenSQLResultsLayer)
+
   public:
                 OGRGenSQLResultsLayer( GDALDataset *poSrcDS,
                                        void *pSelectInfo,

--- a/gdal/ogr/ogrsf_frmts/generic/ogrunionlayer.h
+++ b/gdal/ogr/ogrsf_frmts/generic/ogrunionlayer.h
@@ -66,6 +66,8 @@ typedef enum
 
 class OGRUnionLayer : public OGRLayer
 {
+    CPL_DISALLOW_COPY_ASSIGN(OGRUnionLayer)
+
   protected:
     CPLString           osName;
     int                 nSrcLayers;

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.h
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.h
@@ -71,28 +71,16 @@ class OGRCoordinateTransformation;
 class OGRGeoJSONWriteOptions
 {
     public:
-        bool bWriteBBOX;
-        bool bBBOXRFC7946;
-        int  nCoordPrecision;
-        int  nSignificantFigures;
-        bool bPolygonRightHandRule;
-        bool bCanPatchCoordinatesWithNativeData;
-        bool bHonourReservedRFC7946Members;
-        CPLString osIDField;
-        bool bForceIDFieldType;
-        OGRFieldType eForcedIDFieldType;
-
-        OGRGeoJSONWriteOptions():
-            bWriteBBOX(false),
-            bBBOXRFC7946(false),
-            nCoordPrecision(-1),
-            nSignificantFigures(-1),
-            bPolygonRightHandRule(false),
-            bCanPatchCoordinatesWithNativeData(true),
-            bHonourReservedRFC7946Members(false),
-            bForceIDFieldType(false),
-            eForcedIDFieldType(OFTString)
-        {}
+        bool bWriteBBOX = false;
+        bool bBBOXRFC7946 = false;
+        int  nCoordPrecision = -1;
+        int  nSignificantFigures = -1;
+        bool bPolygonRightHandRule = false;
+        bool bCanPatchCoordinatesWithNativeData = true;
+        bool bHonourReservedRFC7946Members = false;
+        CPLString osIDField{};
+        bool bForceIDFieldType = false;
+        OGRFieldType eForcedIDFieldType = OFTString;
 
         void SetRFC7946Settings();
 };

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -351,7 +351,7 @@ int OGRMSSQLSpatialTableLayer::FetchSRSId()
 {
     if ( poDS->UseGeometryColumns() )
     {
-        CPLODBCStatement oStatement = CPLODBCStatement( poDS->GetSession() );
+        CPLODBCStatement oStatement( poDS->GetSession() );
         oStatement.Appendf( "select srid from geometry_columns "
                         "where f_table_schema = '%s' and f_table_name = '%s'",
                         pszSchemaName, pszTableName );

--- a/gdal/ogr/ogrsf_frmts/ogr_attrind.h
+++ b/gdal/ogr/ogrsf_frmts/ogr_attrind.h
@@ -72,6 +72,7 @@ protected:
     char        *pszIndexPath;
 
                 OGRLayerAttrIndex();
+    CPL_DISALLOW_COPY_ASSIGN(OGRLayerAttrIndex)
 
 public:
     virtual     ~OGRLayerAttrIndex();

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.h
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.h
@@ -46,17 +46,15 @@ OGRLayer * OGRSQLiteExecuteSQL( GDALDataset* poDS,
 class LayerDesc
 {
     public:
-        LayerDesc() {}
-
         bool operator < ( const LayerDesc& other ) const
         {
             return osOriginalStr < other.osOriginalStr;
         }
 
-        CPLString osOriginalStr;
-        CPLString osSubstitutedName;
-        CPLString osDSName;
-        CPLString osLayerName;
+        CPLString osOriginalStr{};
+        CPLString osSubstitutedName{};
+        CPLString osDSName{};
+        CPLString osLayerName{};
 };
 
 std::set<LayerDesc> OGRSQLiteGetReferencedLayers(const char* pszStatement);

--- a/gdal/ogr/swq.h
+++ b/gdal/ogr/swq.h
@@ -107,6 +107,9 @@ typedef swq_field_type (*swq_op_checker)( swq_expr_node *op,
 class swq_custom_func_registrar;
 
 class swq_expr_node {
+
+    CPL_DISALLOW_COPY_ASSIGN(swq_expr_node)
+
 public:
     swq_expr_node();
 
@@ -302,17 +305,15 @@ public:
         bool    operator() (const CPLString&, const CPLString &) const;
     };
 
-    GIntBig     count;
+    GIntBig     count = 0;
 
-    std::vector<CPLString>          oVectorDistinctValues;
-    std::set<CPLString, Comparator> oSetDistinctValues;
-    double      sum;
-    double      min;
-    double      max;
-    CPLString   osMin;
-    CPLString   osMax;
-
-        swq_summary() : count(0), sum(0.0), min(0.0), max(0.0) {}
+    std::vector<CPLString>          oVectorDistinctValues{};
+    std::set<CPLString, Comparator> oSetDistinctValues{};
+    double      sum = 0.0;
+    double      min = 0.0;
+    double      max = 0.0;
+    CPLString   osMin{};
+    CPLString   osMax{};
 };
 
 typedef struct {
@@ -349,6 +350,8 @@ public:
 class swq_select
 {
     void        postpreparse();
+
+    CPL_DISALLOW_COPY_ASSIGN(swq_select)
 
 public:
     swq_select();

--- a/gdal/port/GNUmakefile
+++ b/gdal/port/GNUmakefile
@@ -15,7 +15,7 @@ endif
 
 CPPFLAGS	:= $(CPPFLAGS)	$(CURL_INC) $(JSON_INCLUDE) $(XTRA_OPT) -DINST_DATA=\"$(INST_DATA)\"
 
-CXXFLAGS	:=	$(WARN_OLD_STYLE_CAST) $(CXXFLAGS)
+CXXFLAGS	:=	$(WARN_EFFCPLUSPLUS) $(WARN_OLD_STYLE_CAST) $(CXXFLAGS)
 
 OBJ =	cpl_conv.o cpl_error.o cpl_string.o cplgetsymbol.o cplstringlist.o \
 	cpl_strtod.o cpl_path.o cpl_csv.o cpl_findfile.o cpl_minixml.o \

--- a/gdal/port/cpl_alibaba_oss.h
+++ b/gdal/port/cpl_alibaba_oss.h
@@ -45,14 +45,16 @@
 
 class VSIOSSHandleHelper final: public IVSIS3LikeHandleHelper
 {
-        CPLString m_osURL;
-        CPLString m_osSecretAccessKey;
-        CPLString m_osAccessKeyId;
-        CPLString m_osEndpoint;
-        CPLString m_osBucket;
-        CPLString m_osObjectKey;
-        bool m_bUseHTTPS;
-        bool m_bUseVirtualHosting;
+        CPL_DISALLOW_COPY_ASSIGN(VSIOSSHandleHelper)
+
+        CPLString m_osURL{};
+        CPLString m_osSecretAccessKey{};
+        CPLString m_osAccessKeyId{};
+        CPLString m_osEndpoint{};
+        CPLString m_osBucket{};
+        CPLString m_osObjectKey{};
+        bool m_bUseHTTPS = false;
+        bool m_bUseVirtualHosting = false;
 
         void RebuildURL() override;
 
@@ -104,9 +106,9 @@ class VSIOSSHandleHelper final: public IVSIS3LikeHandleHelper
 class VSIOSSUpdateParams
 {
     public:
-        CPLString m_osEndpoint;
+        CPLString m_osEndpoint{};
 
-        VSIOSSUpdateParams() {}
+        VSIOSSUpdateParams() = default;
 
         explicit VSIOSSUpdateParams(const VSIOSSHandleHelper* poHelper) :
             m_osEndpoint(poHelper->GetEndpoint()) {}

--- a/gdal/port/cpl_aws.h
+++ b/gdal/port/cpl_aws.h
@@ -83,15 +83,17 @@ CPLString CPLGetAWS_SIGN4_Authorization(const CPLString& osSecretAccessKey,
 
 class IVSIS3LikeHandleHelper
 {
+        CPL_DISALLOW_COPY_ASSIGN(IVSIS3LikeHandleHelper)
+
 protected:
-        std::map<CPLString, CPLString> m_oMapQueryParameters;
+        std::map<CPLString, CPLString> m_oMapQueryParameters{};
 
         virtual void RebuildURL() = 0;
         CPLString GetQueryString(bool bAddEmptyValueAfterEqual) const;
 
 public:
-        IVSIS3LikeHandleHelper() {}
-        virtual ~IVSIS3LikeHandleHelper() {}
+        IVSIS3LikeHandleHelper() = default;
+        virtual ~IVSIS3LikeHandleHelper() = default;
 
         void ResetQueryParameters();
         void AddQueryParameter(const CPLString& osKey, const CPLString& osValue);
@@ -121,17 +123,19 @@ public:
 
 class VSIS3HandleHelper final: public IVSIS3LikeHandleHelper
 {
-        CPLString m_osURL;
-        CPLString m_osSecretAccessKey;
-        CPLString m_osAccessKeyId;
-        CPLString m_osSessionToken;
-        CPLString m_osEndpoint;
-        CPLString m_osRegion;
-        CPLString m_osRequestPayer;
-        CPLString m_osBucket;
-        CPLString m_osObjectKey;
-        bool m_bUseHTTPS;
-        bool m_bUseVirtualHosting;
+        CPL_DISALLOW_COPY_ASSIGN(VSIS3HandleHelper)
+
+        CPLString m_osURL{};
+        CPLString m_osSecretAccessKey{};
+        CPLString m_osAccessKeyId{};
+        CPLString m_osSessionToken{};
+        CPLString m_osEndpoint{};
+        CPLString m_osRegion{};
+        CPLString m_osRequestPayer{};
+        CPLString m_osBucket{};
+        CPLString m_osObjectKey{};
+        bool m_bUseHTTPS = false;
+        bool m_bUseVirtualHosting = false;
 
         void RebuildURL() override;
 
@@ -206,13 +210,12 @@ class VSIS3HandleHelper final: public IVSIS3LikeHandleHelper
 class VSIS3UpdateParams
 {
     public:
-        CPLString m_osRegion;
-        CPLString m_osEndpoint;
-        CPLString m_osRequestPayer;
-        bool m_bUseVirtualHosting;
+        CPLString m_osRegion{};
+        CPLString m_osEndpoint{};
+        CPLString m_osRequestPayer{};
+        bool m_bUseVirtualHosting = false;
 
-        VSIS3UpdateParams() :
-            m_bUseVirtualHosting(false) {}
+        VSIS3UpdateParams() = default;
 
         explicit VSIS3UpdateParams(const VSIS3HandleHelper* poHelper) :
             m_osRegion(poHelper->GetRegion()),

--- a/gdal/port/cpl_conv.cpp
+++ b/gdal/port/cpl_conv.cpp
@@ -2836,15 +2836,18 @@ class CPLThreadLocaleCPrivate
 {
         locale_t nNewLocale;
         locale_t nOldLocale;
+
+        CPL_DISALLOW_COPY_ASSIGN(CPLThreadLocaleCPrivate)
+
     public:
         CPLThreadLocaleCPrivate();
        ~CPLThreadLocaleCPrivate();
 };
 
-CPLThreadLocaleCPrivate::CPLThreadLocaleCPrivate()
+CPLThreadLocaleCPrivate::CPLThreadLocaleCPrivate():
+    nNewLocale(newlocale(LC_NUMERIC_MASK, "C", nullptr)),
+    nOldLocale(uselocale(nNewLocale))
 {
-    nNewLocale = newlocale(LC_NUMERIC_MASK, "C", nullptr);
-    nOldLocale = uselocale(nNewLocale);
 }
 
 CPLThreadLocaleCPrivate::~CPLThreadLocaleCPrivate()
@@ -2859,6 +2862,9 @@ class CPLThreadLocaleCPrivate
 {
         int   nOldValConfigThreadLocale;
         char *pszOldLocale;
+
+        CPL_DISALLOW_COPY_ASSIGN(CPLThreadLocaleCPrivate)
+
     public:
         CPLThreadLocaleCPrivate();
        ~CPLThreadLocaleCPrivate();
@@ -2887,14 +2893,17 @@ CPLThreadLocaleCPrivate::~CPLThreadLocaleCPrivate()
 class CPLThreadLocaleCPrivate
 {
         char *pszOldLocale;
+
+        CPL_DISALLOW_COPY_ASSIGN(CPLThreadLocaleCPrivate)
+
     public:
         CPLThreadLocaleCPrivate();
        ~CPLThreadLocaleCPrivate();
 };
 
-CPLThreadLocaleCPrivate::CPLThreadLocaleCPrivate()
+CPLThreadLocaleCPrivate::CPLThreadLocaleCPrivate():
+    pszOldLocale(CPLStrdup(CPLsetlocale(LC_NUMERIC, nullptr)))
 {
-    pszOldLocale = CPLStrdup(CPLsetlocale(LC_NUMERIC, nullptr));
     if( EQUAL(pszOldLocale, "C")
         || EQUAL(pszOldLocale, "POSIX")
         || CPLsetlocale(LC_NUMERIC, "C") == nullptr )
@@ -2920,10 +2929,9 @@ CPLThreadLocaleCPrivate::~CPLThreadLocaleCPrivate()
 /*                        CPLThreadLocaleC()                            */
 /************************************************************************/
 
-CPLThreadLocaleC::CPLThreadLocaleC()
-
+CPLThreadLocaleC::CPLThreadLocaleC():
+    m_private(new CPLThreadLocaleCPrivate)
 {
-    m_private = new CPLThreadLocaleCPrivate;
 }
 
 /************************************************************************/

--- a/gdal/port/cpl_conv.h
+++ b/gdal/port/cpl_conv.h
@@ -296,13 +296,10 @@ extern "C++"
 {
 class CPL_DLL CPLLocaleC
 {
+    CPL_DISALLOW_COPY_ASSIGN(CPLLocaleC)
 public:
     CPLLocaleC();
     ~CPLLocaleC();
-
-    /* Make it non-copyable */
-    CPLLocaleC(const CPLLocaleC&) = delete;
-    CPLLocaleC& operator=(const CPLLocaleC&) = delete;
 
 private:
     char *pszOldLocale;
@@ -315,13 +312,11 @@ private:
 class CPLThreadLocaleCPrivate;
 class CPL_DLL CPLThreadLocaleC
 {
+    CPL_DISALLOW_COPY_ASSIGN(CPLThreadLocaleC)
+
 public:
     CPLThreadLocaleC();
     ~CPLThreadLocaleC();
-
-    /* Make it non-copyable */
-    CPLThreadLocaleC(const CPLThreadLocaleC&) = delete;
-    CPLThreadLocaleC& operator=(const CPLThreadLocaleC&) = delete;
 
 private:
     CPLThreadLocaleCPrivate* m_private;
@@ -344,14 +339,11 @@ extern "C++"
 {
 class CPL_DLL CPLConfigOptionSetter
 {
+    CPL_DISALLOW_COPY_ASSIGN(CPLConfigOptionSetter)
 public:
     CPLConfigOptionSetter(const char* pszKey, const char* pszValue,
                           bool bSetOnlyIfUndefined);
     ~CPLConfigOptionSetter();
-
-    /* Make it non-copyable */
-    CPLConfigOptionSetter(const CPLConfigOptionSetter&) = delete;
-    CPLConfigOptionSetter& operator=(const CPLConfigOptionSetter&) = delete;
 
 private:
     char* m_pszKey;

--- a/gdal/port/cpl_google_cloud.h
+++ b/gdal/port/cpl_google_cloud.h
@@ -43,6 +43,8 @@
 
 class VSIGSHandleHelper final: public IVSIS3LikeHandleHelper
 {
+        CPL_DISALLOW_COPY_ASSIGN(VSIGSHandleHelper)
+
         CPLString m_osURL;
         CPLString m_osEndpoint;
         CPLString m_osBucketObjectKey;

--- a/gdal/port/cpl_google_oauth2.cpp
+++ b/gdal/port/cpl_google_oauth2.cpp
@@ -553,11 +553,7 @@ char** GOA2GetAccessTokenFromServiceAccount(const char* pszPrivateKey,
 /************************************************************************/
 
 /** Constructor */
-GOA2Manager::GOA2Manager() :
-    m_nExpirationTime(0),
-    m_eMethod(NONE)
-{
-}
+GOA2Manager::GOA2Manager() = default;
 
 /************************************************************************/
 /*                         SetAuthFromGCE()                             */

--- a/gdal/port/cpl_http.h
+++ b/gdal/port/cpl_http.h
@@ -193,22 +193,22 @@ class GOA2Manager
 
     private:
 
-        mutable CPLString       m_osCurrentBearer;
-        mutable time_t          m_nExpirationTime;
-        AuthMethod      m_eMethod;
+        mutable CPLString       m_osCurrentBearer{};
+        mutable time_t          m_nExpirationTime = 0;
+        AuthMethod      m_eMethod = NONE;
 
         // for ACCESS_TOKEN_FROM_REFRESH
-        CPLString       m_osClientId;
-        CPLString       m_osClientSecret;
-        CPLString       m_osRefreshToken;
+        CPLString       m_osClientId{};
+        CPLString       m_osClientSecret{};
+        CPLString       m_osRefreshToken{};
 
         // for SERVICE_ACCOUNT
-        CPLString       m_osPrivateKey;
-        CPLString       m_osClientEmail;
-        CPLString       m_osScope;
-        CPLStringList   m_aosAdditionalClaims;
+        CPLString       m_osPrivateKey{};
+        CPLString       m_osClientEmail{};
+        CPLString       m_osScope{};
+        CPLStringList   m_aosAdditionalClaims{};
 
-        CPLStringList   m_aosOptions;
+        CPLStringList   m_aosOptions{};
 };
 
 

--- a/gdal/port/cpl_json.cpp
+++ b/gdal/port/cpl_json.cpp
@@ -54,9 +54,9 @@ CPLJSONDocument::~CPLJSONDocument()
         json_object_put( TO_JSONOBJ(m_poRootJsonObject) );
 }
 
-CPLJSONDocument::CPLJSONDocument(const CPLJSONDocument& other)
+CPLJSONDocument::CPLJSONDocument(const CPLJSONDocument& other):
+    m_poRootJsonObject(json_object_get( TO_JSONOBJ(other.m_poRootJsonObject) ))
 {
-    m_poRootJsonObject = json_object_get( TO_JSONOBJ(other.m_poRootJsonObject) );
 }
 
 CPLJSONDocument& CPLJSONDocument::operator=(const CPLJSONDocument& other)

--- a/gdal/port/cpl_json.h
+++ b/gdal/port/cpl_json.h
@@ -149,8 +149,8 @@ protected:
 /*! @endcond */
 
 private:
-    JSONObjectH m_poJsonObject;
-    std::string m_osKey;
+    JSONObjectH m_poJsonObject = nullptr;
+    std::string m_osKey{};
 };
 
 /**

--- a/gdal/port/cpl_json_streaming_parser.cpp
+++ b/gdal/port/cpl_json_streaming_parser.cpp
@@ -43,17 +43,7 @@
 /*                       CPLJSonStreamingParser()                       */
 /************************************************************************/
 
-CPLJSonStreamingParser::CPLJSonStreamingParser() :
-    m_bExceptionOccurred(false),
-    m_bElementFound(false),
-    m_nLastChar(0),
-    m_nLineCounter(1),
-    m_nCharCounter(1),
-    m_bInStringEscape(false),
-    m_bInUnicode(false),
-    m_nMaxDepth(1024),
-    m_nMaxStringSize(10000000)
-
+CPLJSonStreamingParser::CPLJSonStreamingParser()
 {
     m_aState.push_back(INIT);
 }

--- a/gdal/port/cpl_json_streaming_parser.h
+++ b/gdal/port/cpl_json_streaming_parser.h
@@ -39,6 +39,8 @@
 
 class CPL_DLL CPLJSonStreamingParser
 {
+        CPL_DISALLOW_COPY_ASSIGN(CPLJSonStreamingParser)
+
         enum State
         {
             INIT,
@@ -51,19 +53,19 @@ class CPL_DLL CPLJSonStreamingParser
             STATE_NULL
         };
 
-        bool m_bExceptionOccurred;
-        bool m_bElementFound;
-        int m_nLastChar;
-        int m_nLineCounter;
-        int m_nCharCounter;
-        std::vector<State> m_aState;
-        std::string m_osToken;
-        std::vector<bool> m_abFirstElement;
-        bool m_bInStringEscape;
-        bool m_bInUnicode;
-        std::string m_osUnicodeHex;
-        size_t m_nMaxDepth;
-        size_t m_nMaxStringSize;
+        bool m_bExceptionOccurred = false;
+        bool m_bElementFound = false;
+        int m_nLastChar = 0;
+        int m_nLineCounter = 1;
+        int m_nCharCounter = 1;
+        std::vector<State> m_aState{};
+        std::string m_osToken{};
+        std::vector<bool> m_abFirstElement{};
+        bool m_bInStringEscape = false;
+        bool m_bInUnicode = false;
+        std::string m_osUnicodeHex{};
+        size_t m_nMaxDepth = 1024;
+        size_t m_nMaxStringSize = 10000000;
 
         enum MemberState
         {
@@ -72,7 +74,7 @@ class CPL_DLL CPLJSonStreamingParser
             KEY_FINISHED,
             IN_VALUE
         };
-        std::vector<MemberState> m_aeObjectState;
+        std::vector<MemberState> m_aeObjectState{};
 
         enum State currentState() { return m_aState.back(); }
         void SkipSpace(const char*& pStr, size_t& nLength);

--- a/gdal/port/cpl_multiproc.h
+++ b/gdal/port/cpl_multiproc.h
@@ -144,6 +144,8 @@ class CPL_DLL CPLMutexHolder
     const char *pszFile;
     int         nLine;
 
+    CPL_DISALLOW_COPY_ASSIGN(CPLMutexHolder)
+
   public:
 
     /** Instantiates the mutex if not already done. */
@@ -175,6 +177,8 @@ class CPL_DLL CPLLockHolder
     CPLLock    *hLock;
     const char *pszFile;
     int         nLine;
+
+    CPL_DISALLOW_COPY_ASSIGN(CPLLockHolder)
 
   public:
 

--- a/gdal/port/cpl_multiproc.h
+++ b/gdal/port/cpl_multiproc.h
@@ -139,10 +139,10 @@ CPL_C_END
 class CPL_DLL CPLMutexHolder
 {
   private:
-    CPLMutex   *hMutex;
+    CPLMutex   *hMutex = nullptr;
     // Only used for debugging.
-    const char *pszFile;
-    int         nLine;
+    const char *pszFile = nullptr;
+    int         nLine = 0;
 
     CPL_DISALLOW_COPY_ASSIGN(CPLMutexHolder)
 
@@ -174,9 +174,9 @@ class CPL_DLL CPLMutexHolder
 class CPL_DLL CPLLockHolder
 {
   private:
-    CPLLock    *hLock;
-    const char *pszFile;
-    int         nLine;
+    CPLLock    *hLock = nullptr;
+    const char *pszFile = nullptr;
+    int         nLine = 0;
 
     CPL_DISALLOW_COPY_ASSIGN(CPLLockHolder)
 

--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -157,11 +157,7 @@ int CPLODBCDriverInstaller::RemoveDriver( const char* pszDriverName,
 /************************************************************************/
 
 /** Constructor */
-CPLODBCSession::CPLODBCSession() :
-    m_hEnv(nullptr),
-    m_hDBC(nullptr),
-    m_bInTransaction(FALSE),
-    m_bAutoCommit(TRUE)
+CPLODBCSession::CPLODBCSession()
 {
     m_szLastError[0] = '\0';
 }
@@ -468,21 +464,7 @@ const char *CPLODBCSession::GetLastError()
 
 /** Constructor */
 CPLODBCStatement::CPLODBCStatement( CPLODBCSession *poSession ) :
-    m_poSession(poSession),
-    m_hStmt(nullptr),
-    m_nColCount(0),
-    m_papszColNames(nullptr),
-    m_panColType(nullptr),
-    m_papszColTypeNames(nullptr),
-    m_panColSize(nullptr),
-    m_panColPrecision(nullptr),
-    m_panColNullable(nullptr),
-    m_papszColColumnDef(nullptr),
-    m_papszColValues(nullptr),
-    m_panColValueLengths(nullptr),
-    m_pszStatement(nullptr),
-    m_nStatementMax(0),
-    m_nStatementLen(0)
+    m_poSession(poSession)
 {
 
     if( Failed(SQLAllocStmt(poSession->GetConnection(), &m_hStmt)) )

--- a/gdal/port/cpl_odbc.h
+++ b/gdal/port/cpl_odbc.h
@@ -159,11 +159,14 @@ class CPLODBCStatement;
  */
 
 class CPL_DLL CPLODBCSession {
-    char      m_szLastError[SQL_MAX_MESSAGE_LENGTH + 1];
-    HENV      m_hEnv;
-    HDBC      m_hDBC;
-    int       m_bInTransaction;
-    int       m_bAutoCommit;
+
+    CPL_DISALLOW_COPY_ASSIGN(CPLODBCSession)
+
+    char      m_szLastError[SQL_MAX_MESSAGE_LENGTH + 1] = { '\0' };
+    HENV      m_hEnv = nullptr;
+    HDBC      m_hDBC = nullptr;
+    int       m_bInTransaction = false;
+    int       m_bAutoCommit = true;
 
   public:
     CPLODBCSession();
@@ -205,26 +208,28 @@ class CPL_DLL CPLODBCSession {
 
 class CPL_DLL CPLODBCStatement {
 
-    CPLODBCSession     *m_poSession;
-    HSTMT               m_hStmt;
+    CPL_DISALLOW_COPY_ASSIGN(CPLODBCStatement)
 
-    SQLSMALLINT    m_nColCount;
-    char         **m_papszColNames;
-    SQLSMALLINT   *m_panColType;
-    char         **m_papszColTypeNames;
-    CPL_SQLULEN      *m_panColSize;
-    SQLSMALLINT   *m_panColPrecision;
-    SQLSMALLINT   *m_panColNullable;
-    char         **m_papszColColumnDef;
+    CPLODBCSession     *m_poSession = nullptr;
+    HSTMT               m_hStmt = nullptr;
 
-    char         **m_papszColValues;
-    CPL_SQLLEN       *m_panColValueLengths;
+    SQLSMALLINT    m_nColCount = 0;
+    char         **m_papszColNames = nullptr;
+    SQLSMALLINT   *m_panColType = nullptr;
+    char         **m_papszColTypeNames = nullptr;
+    CPL_SQLULEN      *m_panColSize = nullptr;
+    SQLSMALLINT   *m_panColPrecision = nullptr;
+    SQLSMALLINT   *m_panColNullable = nullptr;
+    char         **m_papszColColumnDef = nullptr;
+
+    char         **m_papszColValues = nullptr;
+    CPL_SQLLEN       *m_panColValueLengths = nullptr;
 
     int            Failed( int );
 
-    char          *m_pszStatement;
-    size_t         m_nStatementMax;
-    size_t         m_nStatementLen;
+    char          *m_pszStatement = nullptr;
+    size_t         m_nStatementMax = 0;
+    size_t         m_nStatementLen = 0;
 
   public:
     explicit CPLODBCStatement( CPLODBCSession * );

--- a/gdal/port/cpl_string.h
+++ b/gdal/port/cpl_string.h
@@ -446,13 +446,12 @@ CPLString CPL_DLL CPLURLAddKVP(const char* pszURL, const char* pszKey,
 //! String list class designed around our use of C "char**" string lists.
 class CPL_DLL CPLStringList
 {
-    char **papszList;
-    mutable int nCount;
-    mutable int nAllocation;
-    bool   bOwnList;
-    bool   bIsSorted;
+    char **papszList = nullptr;
+    mutable int nCount = 0;
+    mutable int nAllocation = 0;
+    bool   bOwnList = false;
+    bool   bIsSorted = false;
 
-    void   Initialize();
     void   MakeOurOwnCopy();
     void   EnsureAllocation( int nMaxLength );
     int    FindSortedInsertionPoint( const char *pszLine );

--- a/gdal/port/cpl_vsi_virtual.h
+++ b/gdal/port/cpl_vsi_virtual.h
@@ -124,12 +124,14 @@ public:
 class CPL_DLL VSIFileManager
 {
 private:
-    VSIFilesystemHandler *poDefaultHandler;
-    std::map<std::string, VSIFilesystemHandler *> oHandlers;
+    VSIFilesystemHandler *poDefaultHandler = nullptr;
+    std::map<std::string, VSIFilesystemHandler *> oHandlers{};
 
     VSIFileManager();
 
     static VSIFileManager *Get();
+
+    CPL_DISALLOW_COPY_ASSIGN(VSIFileManager)
 
 public:
     ~VSIFileManager();
@@ -170,12 +172,11 @@ typedef struct
 class VSIArchiveContent
 {
 public:
-    time_t       mTime;
-    vsi_l_offset nFileSize;
-    int nEntries;
-    VSIArchiveEntry* entries;
+    time_t       mTime = 0;
+    vsi_l_offset nFileSize = 0;
+    int nEntries = 0;
+    VSIArchiveEntry* entries = nullptr;
 
-    VSIArchiveContent() : mTime(0), nFileSize(0), nEntries(0), entries(nullptr) {}
     ~VSIArchiveContent();
 };
 
@@ -195,12 +196,14 @@ class VSIArchiveReader
 
 class VSIArchiveFilesystemHandler : public VSIFilesystemHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIArchiveFilesystemHandler)
+
 protected:
-    CPLMutex* hMutex;
+    CPLMutex* hMutex = nullptr;
     /* We use a cache that contains the list of files contained in a VSIArchive file as */
     /* unarchive.c is quite inefficient in listing them. This speeds up access to VSIArchive files */
     /* containing ~1000 files like a CADRG product */
-    std::map<CPLString,VSIArchiveContent*>   oFileList;
+    std::map<CPLString,VSIArchiveContent*>   oFileList{};
 
     virtual const char* GetPrefix() = 0;
     virtual std::vector<CPLString> GetExtensions() = 0;

--- a/gdal/port/cpl_vsil_buffered_reader.cpp
+++ b/gdal/port/cpl_vsil_buffered_reader.cpp
@@ -56,14 +56,16 @@ CPL_CVSID("$Id$")
 
 class VSIBufferedReaderHandle final : public VSIVirtualHandle
 {
-    VSIVirtualHandle* m_poBaseHandle;
-    GByte*            pabyBuffer;
-    GUIntBig          nBufferOffset;
-    int               nBufferSize;
-    GUIntBig          nCurOffset;
-    bool              bNeedBaseHandleSeek;
-    bool              bEOF;
-    vsi_l_offset      nCheatFileSize;
+    CPL_DISALLOW_COPY_ASSIGN(VSIBufferedReaderHandle)
+
+    VSIVirtualHandle* m_poBaseHandle = nullptr;
+    GByte*            pabyBuffer = nullptr;
+    GUIntBig          nBufferOffset = 0;
+    int               nBufferSize = 0;
+    GUIntBig          nCurOffset = 0;
+    bool              bNeedBaseHandleSeek = false;
+    bool              bEOF =  false;
+    vsi_l_offset      nCheatFileSize = 0;
 
     int               SeekBaseTo( vsi_l_offset nTargetOffset );
 
@@ -117,13 +119,7 @@ VSIVirtualHandle* VSICreateBufferedReaderHandle(
 VSIBufferedReaderHandle::VSIBufferedReaderHandle(
     VSIVirtualHandle* poBaseHandle) :
     m_poBaseHandle(poBaseHandle),
-    pabyBuffer(static_cast<GByte*>(CPLMalloc(MAX_BUFFER_SIZE))),
-    nBufferOffset(0),
-    nBufferSize(0),
-    nCurOffset(0),
-    bNeedBaseHandleSeek(false),
-    bEOF(false),
-    nCheatFileSize(0)
+    pabyBuffer(static_cast<GByte*>(CPLMalloc(MAX_BUFFER_SIZE)))
 {}
 
 VSIBufferedReaderHandle::VSIBufferedReaderHandle(

--- a/gdal/port/cpl_vsil_crypt.cpp
+++ b/gdal/port/cpl_vsil_crypt.cpp
@@ -382,33 +382,28 @@ static VSICryptMode GetMode( const char* pszName )
 
 class VSICryptFileHeader
 {
+        CPL_DISALLOW_COPY_ASSIGN(VSICryptFileHeader)
+
         std::string CryptKeyCheck( CryptoPP::BlockCipher* poEncCipher );
 
     public:
-        VSICryptFileHeader() : nHeaderSize(0),
-                               nMajorVersion(0),
-                               nMinorVersion(0),
-                               nSectorSize(512),
-                               eAlg(ALG_AES),
-                               eMode(MODE_CBC),
-                               bAddKeyCheck(false),
-                               nPayloadFileSize(0) {}
+        VSICryptFileHeader() = default;
 
         int ReadFromFile( VSIVirtualHandle* fp, const CPLString& osKey );
         int WriteToFile( VSIVirtualHandle* fp,
                          CryptoPP::BlockCipher* poEncCipher );
 
-        GUInt16 nHeaderSize;
-        GByte nMajorVersion;
-        GByte nMinorVersion;
-        GUInt16 nSectorSize;
-        VSICryptAlg eAlg;
-        VSICryptMode eMode;
-        CPLString osIV;
-        bool bAddKeyCheck;
-        GUIntBig nPayloadFileSize;
-        CPLString osFreeText;
-        CPLString osExtraContent;
+        GUInt16 nHeaderSize = 0;
+        GByte nMajorVersion = 0;
+        GByte nMinorVersion = 0;
+        GUInt16 nSectorSize = 512;
+        VSICryptAlg eAlg = ALG_AES;
+        VSICryptMode eMode = MODE_CBC;
+        CPLString osIV{};
+        bool bAddKeyCheck = false;
+        GUIntBig nPayloadFileSize = 0;
+        CPLString osFreeText{};
+        CPLString osExtraContent{};
 };
 
 /************************************************************************/
@@ -737,25 +732,27 @@ int VSICryptFileHeader::WriteToFile( VSIVirtualHandle* fp,
 
 class VSICryptFileHandle final : public VSIVirtualHandle
 {
+        CPL_DISALLOW_COPY_ASSIGN(VSICryptFileHandle)
+
   private:
-        CPLString           osBaseFilename;
-        int                 nPerms;
-        VSIVirtualHandle   *poBaseHandle;
-        VSICryptFileHeader *poHeader;
-        bool                bUpdateHeader;
-        vsi_l_offset        nCurPos;
-        bool                bEOF;
+        CPLString           osBaseFilename{};
+        int                 nPerms = 0;
+        VSIVirtualHandle   *poBaseHandle = nullptr;
+        VSICryptFileHeader *poHeader = nullptr;
+        bool                bUpdateHeader = false;
+        vsi_l_offset        nCurPos = 0;
+        bool                bEOF = false;
 
-        CryptoPP::BlockCipher* poEncCipher;
-        CryptoPP::BlockCipher* poDecCipher;
-        int                 nBlockSize;
+        CryptoPP::BlockCipher* poEncCipher = nullptr;
+        CryptoPP::BlockCipher* poDecCipher = nullptr;
+        int                 nBlockSize = 0;
 
-        vsi_l_offset        nWBOffset;
-        GByte*              pabyWB;
-        int                 nWBSize;
-        bool                bWBDirty;
+        vsi_l_offset        nWBOffset = 0;
+        GByte*              pabyWB = nullptr;
+        int                 nWBSize = 0;
+        bool                bWBDirty = false;
 
-        bool                bLastSectorWasModified;
+        bool                bLastSectorWasModified = false;
 
         void             EncryptBlock( GByte* pabyData, vsi_l_offset nOffset );
         bool             DecryptBlock( GByte* pabyData, vsi_l_offset nOffset );
@@ -792,18 +789,7 @@ VSICryptFileHandle::VSICryptFileHandle( CPLString osBaseFilenameIn,
     osBaseFilename(osBaseFilenameIn),
     nPerms(nPermsIn),
     poBaseHandle(poBaseHandleIn),
-    poHeader(poHeaderIn),
-    bUpdateHeader(false),
-    nCurPos(0),
-    bEOF(false),
-    poEncCipher(nullptr),
-    poDecCipher(nullptr),
-    nBlockSize(0),
-    nWBOffset(0),
-    pabyWB(nullptr),
-    nWBSize(0),
-    bWBDirty(false),
-    bLastSectorWasModified(false)
+    poHeader(poHeaderIn)
 {}
 
 /************************************************************************/

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -143,24 +143,14 @@ typedef enum
 class CachedFileProp
 {
   public:
-    ExistStatus     eExists;
-    bool            bHasComputedFileSize;
-    vsi_l_offset    fileSize;
-    bool            bIsDirectory;
-    time_t          mTime;
-    bool            bS3LikeRedirect;
-    time_t          nExpireTimestampLocal;
-    CPLString       osRedirectURL;
-
-                    CachedFileProp() :
-                        eExists(EXIST_UNKNOWN),
-                        bHasComputedFileSize(false),
-                        fileSize(0),
-                        bIsDirectory(false),
-                        mTime(0),
-                        bS3LikeRedirect(false),
-                        nExpireTimestampLocal(0)
-                        {}
+    ExistStatus     eExists = EXIST_UNKNOWN;
+    bool            bHasComputedFileSize = false;
+    vsi_l_offset    fileSize = 0;
+    bool            bIsDirectory = false;
+    time_t          mTime = 0;
+    bool            bS3LikeRedirect = false;
+    time_t          nExpireTimestampLocal = 0;
+    CPLString       osRedirectURL{};
 };
 
 typedef struct
@@ -288,16 +278,18 @@ class VSICurlHandle;
 
 class VSICurlFilesystemHandler : public VSIFilesystemHandler
 {
-    CachedRegion  **papsRegions;
-    int             nRegions;
+    CPL_DISALLOW_COPY_ASSIGN(VSICurlFilesystemHandler)
 
-    std::map<CPLString, CachedFileProp*>   cacheFileSize;
-    std::map<CPLString, CachedDirList*>        cacheDirList;
+    CachedRegion  **papsRegions = nullptr;
+    int             nRegions = 0;
 
-    bool            bUseCacheDisk;
+    std::map<CPLString, CachedFileProp*>   cacheFileSize{};
+    std::map<CPLString, CachedDirList*>        cacheDirList{};
+
+    bool            bUseCacheDisk = false;
 
     // Per-thread Curl connection cache.
-    std::map<GIntBig, CachedConnection*> mapConnections;
+    std::map<GIntBig, CachedConnection*> mapConnections{};
 
     char**              ParseHTMLFileList(const char* pszFilename,
                                           int nMaxFiles,
@@ -305,7 +297,7 @@ class VSICurlFilesystemHandler : public VSIFilesystemHandler
                                           bool* pbGotFileList);
 
 protected:
-    CPLMutex       *hMutex;
+    CPLMutex       *hMutex = nullptr;
 
     virtual VSICurlHandle* CreateFileHandle(const char* pszFilename);
     virtual char** GetFileList(const char *pszFilename,
@@ -409,44 +401,45 @@ public:
 
 class VSICurlHandle : public VSIVirtualHandle
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSICurlHandle)
 
   protected:
-    VSICurlFilesystemHandler* poFS;
+    VSICurlFilesystemHandler* poFS = nullptr;
 
-    bool            m_bCached;
+    bool            m_bCached = true;
 
-    vsi_l_offset    fileSize;
-    bool            bHasComputedFileSize;
-    ExistStatus     eExists;
-    bool            bIsDirectory;
-    CPLString       m_osFilename; // e.g "/vsicurl/http://example.com/foo"
-    char*           m_pszURL;     // e.g "http://example.com/foo"
+    vsi_l_offset    fileSize = 0;
+    bool            bHasComputedFileSize = false;
+    ExistStatus     eExists = EXIST_UNKNOWN;
+    bool            bIsDirectory = false;
+    CPLString       m_osFilename{}; // e.g "/vsicurl/http://example.com/foo"
+    char*           m_pszURL = nullptr;     // e.g "http://example.com/foo"
 
-    char          **m_papszHTTPOptions;
+    char          **m_papszHTTPOptions = nullptr;
 
   private:
 
-    vsi_l_offset    curOffset;
-    time_t          mTime;
+    vsi_l_offset    curOffset = 0;
+    time_t          mTime = 0;
 
-    vsi_l_offset    lastDownloadedOffset;
-    int             nBlocksToDownload;
-    bool            bEOF;
+    vsi_l_offset    lastDownloadedOffset = VSI_L_OFFSET_MAX;
+    int             nBlocksToDownload = 1;
+    bool            bEOF = false;
 
     bool            DownloadRegion(vsi_l_offset startOffset, int nBlocks);
 
-    VSICurlReadCbkFunc  pfnReadCbk;
-    void               *pReadCbkUserData;
-    bool                bStopOnInterruptUntilUninstall;
-    bool                bInterrupted;
+    VSICurlReadCbkFunc  pfnReadCbk = nullptr;
+    void               *pReadCbkUserData = nullptr;
+    bool                bStopOnInterruptUntilUninstall = false;
+    bool                bInterrupted = false;
 
-    bool                m_bS3LikeRedirect;
-    time_t              m_nExpireTimestampLocal;
-    CPLString           m_osRedirectURL;
+    bool                m_bS3LikeRedirect = false;
+    time_t              m_nExpireTimestampLocal = 0;
+    CPLString           m_osRedirectURL{};
 
-    int                 m_nMaxRetry;
-    double              m_dfRetryDelay;
-    bool                m_bUseHead;
+    int                 m_nMaxRetry = 0;
+    double              m_dfRetryDelay = 0.0;
+    bool                m_bUseHead = false;
 
     int          ReadMultiRangeSingleGet( int nRanges, void ** ppData,
                                          const vsi_l_offset* panOffsets,
@@ -623,17 +616,6 @@ VSICurlHandle::VSICurlHandle( VSICurlFilesystemHandler* poFSIn,
                               const char* pszFilename,
                               const char* pszURLIn ) :
     poFS(poFSIn),
-    m_bCached(true),
-    curOffset(0),
-    lastDownloadedOffset(VSI_L_OFFSET_MAX),
-    nBlocksToDownload(1),
-    bEOF(false),
-    pfnReadCbk(nullptr),
-    pReadCbkUserData(nullptr),
-    bStopOnInterruptUntilUninstall(false),
-    bInterrupted(false),
-    m_bS3LikeRedirect(false),
-    m_nExpireTimestampLocal(0),
     m_nMaxRetry(atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
                                    CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)))),
     m_dfRetryDelay(CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
@@ -2574,13 +2556,10 @@ int       VSICurlHandle::Close()
 /*                   VSICurlFilesystemHandler()                         */
 /************************************************************************/
 
-VSICurlFilesystemHandler::VSICurlFilesystemHandler()
+VSICurlFilesystemHandler::VSICurlFilesystemHandler():
+    bUseCacheDisk(
+        CPLTestBool(CPLGetConfigOption("CPL_VSIL_CURL_USE_CACHE", "NO")))
 {
-    hMutex = nullptr;
-    papsRegions = nullptr;
-    nRegions = 0;
-    bUseCacheDisk =
-        CPLTestBool(CPLGetConfigOption("CPL_VSIL_CURL_USE_CACHE", "NO"));
 }
 
 /************************************************************************/
@@ -4742,6 +4721,8 @@ char** VSICurlFilesystemHandler::ReadDirEx( const char *pszDirname,
 
 class IVSIS3LikeFSHandler: public VSICurlFilesystemHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(IVSIS3LikeFSHandler)
+
   protected:
     char** GetFileList( const char *pszFilename,
                         int nMaxFiles,
@@ -4749,6 +4730,8 @@ class IVSIS3LikeFSHandler: public VSICurlFilesystemHandler
 
     virtual IVSIS3LikeHandleHelper* CreateHandleHelper(
             const char* pszURI, bool bAllowNoObject) = 0;
+
+    IVSIS3LikeFSHandler() = default;
 
   public:
     int Unlink( const char *pszFilename ) override;
@@ -4771,7 +4754,9 @@ class IVSIS3LikeFSHandler: public VSICurlFilesystemHandler
 
 class VSIS3FSHandler final : public IVSIS3LikeFSHandler
 {
-    std::map< CPLString, VSIS3UpdateParams > oMapBucketsToS3Params;
+    CPL_DISALLOW_COPY_ASSIGN(VSIS3FSHandler)
+
+    std::map< CPLString, VSIS3UpdateParams > oMapBucketsToS3Params{};
 
   protected:
     VSICurlHandle* CreateFileHandle( const char* pszFilename ) override;
@@ -4787,7 +4772,7 @@ class VSIS3FSHandler final : public IVSIS3LikeFSHandler
     void ClearCache() override;
 
   public:
-    VSIS3FSHandler() {}
+    VSIS3FSHandler() = default;
     ~VSIS3FSHandler() override;
 
     VSIVirtualHandle *Open( const char *pszFilename,
@@ -4810,6 +4795,8 @@ class VSIS3FSHandler final : public IVSIS3LikeFSHandler
 
 class IVSIS3LikeHandle:  public VSICurlHandle
 {
+    CPL_DISALLOW_COPY_ASSIGN(IVSIS3LikeHandle)
+
   protected:
     bool UseLimitRangeGetInsteadOfHead() override { return true; }
     bool IsDirectoryFromExists( const char* pszVerb,
@@ -4838,7 +4825,9 @@ class IVSIS3LikeHandle:  public VSICurlHandle
 
 class VSIS3Handle final : public IVSIS3LikeHandle
 {
-    VSIS3HandleHelper* m_poS3HandleHelper;
+    CPL_DISALLOW_COPY_ASSIGN(VSIS3Handle)
+
+    VSIS3HandleHelper* m_poS3HandleHelper = nullptr;
 
   protected:
     struct curl_slist* GetCurlHeaders(
@@ -4861,30 +4850,32 @@ class VSIS3Handle final : public IVSIS3LikeHandle
 
 class VSIS3WriteHandle final : public VSIVirtualHandle
 {
-    IVSIS3LikeFSHandler     *m_poFS;
-    CPLString           m_osFilename;
-    IVSIS3LikeHandleHelper  *m_poS3HandleHelper;
-    bool                m_bUseChunked;
+    CPL_DISALLOW_COPY_ASSIGN(VSIS3WriteHandle)
 
-    vsi_l_offset        m_nCurOffset;
-    int                 m_nBufferOff;
-    int                 m_nBufferSize;
-    int                 m_nBufferOffReadCallback;
-    bool                m_bClosed;
-    GByte              *m_pabyBuffer;
-    CPLString           m_osUploadID;
-    int                 m_nPartNumber;
-    std::vector<CPLString> m_aosEtags;
-    CPLString           m_osXML;
-    int                 m_nOffsetInXML;
-    bool                m_bError;
+    IVSIS3LikeFSHandler     *m_poFS = nullptr;
+    CPLString           m_osFilename{};
+    IVSIS3LikeHandleHelper  *m_poS3HandleHelper = nullptr;
+    bool                m_bUseChunked = false;
 
-    CURLM              *m_hCurlMulti;
-    CURL               *m_hCurl;
-    const void         *m_pBuffer;
-    CPLString           m_osCurlErrBuf;
-    size_t              m_nChunkedBufferOff;
-    size_t              m_nChunkedBufferSize;
+    vsi_l_offset        m_nCurOffset = 0;
+    int                 m_nBufferOff = 0;
+    int                 m_nBufferSize = 0;
+    int                 m_nBufferOffReadCallback = 0;
+    bool                m_bClosed = false;
+    GByte              *m_pabyBuffer = nullptr;
+    CPLString           m_osUploadID{};
+    int                 m_nPartNumber = 0;
+    std::vector<CPLString> m_aosEtags{};
+    CPLString           m_osXML{};
+    int                 m_nOffsetInXML = 0;
+    bool                m_bError = false;
+
+    CURLM              *m_hCurlMulti = nullptr;
+    CURL               *m_hCurl = nullptr;
+    const void         *m_pBuffer = nullptr;
+    CPLString           m_osCurlErrBuf{};
+    size_t              m_nChunkedBufferOff = 0;
+    size_t              m_nChunkedBufferSize = 0;
 
     static size_t       ReadCallBackBuffer( char *buffer, size_t size,
                                             size_t nitems, void *instream );
@@ -4931,21 +4922,7 @@ VSIS3WriteHandle::VSIS3WriteHandle( IVSIS3LikeFSHandler* poFS,
                                     bool bUseChunked ) :
         m_poFS(poFS), m_osFilename(pszFilename),
         m_poS3HandleHelper(poS3HandleHelper),
-        m_bUseChunked(bUseChunked),
-        m_nCurOffset(0),
-        m_nBufferOff(0),
-        m_nBufferSize(0),
-        m_nBufferOffReadCallback(0),
-        m_bClosed(false),
-        m_pabyBuffer(nullptr),
-        m_nPartNumber(0),
-        m_nOffsetInXML(0),
-        m_bError(false),
-        m_hCurlMulti(nullptr),
-        m_hCurl(nullptr),
-        m_pBuffer(nullptr),
-        m_nChunkedBufferOff(0),
-        m_nChunkedBufferSize(0)
+        m_bUseChunked(bUseChunked)
 {
     // AWS S3 does not support chunked PUT in a convenient way, since you must
     // know in advance the total size... See
@@ -6464,6 +6441,8 @@ bool VSIS3Handle::CanRestartOnError(const char* pszErrorMsg,
 
 class VSIGSFSHandler final : public IVSIS3LikeFSHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIGSFSHandler)
+
   protected:
     VSICurlHandle* CreateFileHandle( const char* pszFilename ) override;
     const char* GetDebugKey() const override { return "GS"; }
@@ -6477,7 +6456,7 @@ class VSIGSFSHandler final : public IVSIS3LikeFSHandler
     void ClearCache() override;
 
   public:
-    VSIGSFSHandler() {}
+    VSIGSFSHandler() = default;
     ~VSIGSFSHandler() override;
 
     VSIVirtualHandle *Open( const char *pszFilename,
@@ -6495,7 +6474,9 @@ class VSIGSFSHandler final : public IVSIS3LikeFSHandler
 
 class VSIGSHandle final : public IVSIS3LikeHandle
 {
-    VSIGSHandleHelper* m_poHandleHelper;
+    CPL_DISALLOW_COPY_ASSIGN(VSIGSHandle)
+
+    VSIGSHandleHelper* m_poHandleHelper = nullptr;
 
   protected:
     struct curl_slist* GetCurlHeaders( const CPLString& osVerb,
@@ -6709,6 +6690,8 @@ struct curl_slist* VSIGSHandle::GetCurlHeaders( const CPLString& osVerb,
 
 class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIAzureFSHandler)
+
   protected:
     VSICurlHandle* CreateFileHandle( const char* pszFilename ) override;
     CPLString GetURLFromDirname( const CPLString& osDirname ) override;
@@ -6723,7 +6706,7 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
     void InvalidateRecursive( const CPLString& osDirnameIn );
 
   public:
-    VSIAzureFSHandler() {}
+    VSIAzureFSHandler() = default;
     ~VSIAzureFSHandler() override;
 
     CPLString GetFSPrefix() override { return "/vsiaz/"; }
@@ -6753,7 +6736,9 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
 
 class VSIAzureHandle final : public VSICurlHandle
 {
-    VSIAzureBlobHandleHelper* m_poHandleHelper;
+    CPL_DISALLOW_COPY_ASSIGN(VSIAzureHandle)
+
+    VSIAzureBlobHandleHelper* m_poHandleHelper = nullptr;
 
   protected:
         virtual struct curl_slist* GetCurlHeaders( const CPLString& osVerb,
@@ -6795,17 +6780,19 @@ VSICurlHandle* VSIAzureFSHandler::CreateFileHandle(const char* pszFilename)
 
 class VSIAzureWriteHandle final : public VSIVirtualHandle
 {
-    VSIAzureFSHandler  *m_poFS;
-    CPLString           m_osFilename;
-    VSIAzureBlobHandleHelper  *m_poHandleHelper;
+    CPL_DISALLOW_COPY_ASSIGN(VSIAzureWriteHandle)
 
-    vsi_l_offset        m_nCurOffset;
-    int                 m_nBufferOff;
-    int                 m_nBufferSize;
-    int                 m_nBufferOffReadCallback;
-    bool                m_bClosed;
-    GByte              *m_pabyBuffer;
-    bool                m_bError;
+    VSIAzureFSHandler  *m_poFS = nullptr;
+    CPLString           m_osFilename{};
+    VSIAzureBlobHandleHelper  *m_poHandleHelper = nullptr;
+
+    vsi_l_offset        m_nCurOffset = 0;
+    int                 m_nBufferOff = 0;
+    int                 m_nBufferSize = 0;
+    int                 m_nBufferOffReadCallback = 0;
+    bool                m_bClosed = false;
+    GByte              *m_pabyBuffer = nullptr;
+    bool                m_bError = false;
 
     static size_t       ReadCallBackBuffer( char *buffer, size_t size,
                                             size_t nitems, void *instream );
@@ -6838,14 +6825,7 @@ VSIAzureWriteHandle::VSIAzureWriteHandle( VSIAzureFSHandler* poFS,
                                     VSIAzureBlobHandleHelper* poHandleHelper) :
         m_poFS(poFS),
         m_osFilename(pszFilename),
-        m_poHandleHelper(poHandleHelper),
-        m_nCurOffset(0),
-        m_nBufferOff(0),
-        m_nBufferSize(0),
-        m_nBufferOffReadCallback(0),
-        m_bClosed(false),
-        m_pabyBuffer(nullptr),
-        m_bError(false)
+        m_poHandleHelper(poHandleHelper)
 {
     int nChunkSizeMB = atoi(CPLGetConfigOption("VSIAZ_CHUNK_SIZE", "4"));
     if( nChunkSizeMB <= 0 || nChunkSizeMB > 4 )
@@ -7589,7 +7569,9 @@ bool VSIAzureHandle::IsDirectoryFromExists( const char* /*pszVerb*/,
 
 class VSIOSSFSHandler final : public IVSIS3LikeFSHandler
 {
-    std::map< CPLString, VSIOSSUpdateParams > oMapBucketsToOSSParams;
+    CPL_DISALLOW_COPY_ASSIGN(VSIOSSFSHandler)
+
+    std::map< CPLString, VSIOSSUpdateParams > oMapBucketsToOSSParams{};
 
 protected:
         VSICurlHandle* CreateFileHandle( const char* pszFilename ) override;
@@ -7605,7 +7587,7 @@ protected:
         void ClearCache() override;
 
 public:
-        VSIOSSFSHandler() {}
+        VSIOSSFSHandler() = default;
         ~VSIOSSFSHandler() override;
 
         VSIVirtualHandle *Open( const char *pszFilename,
@@ -7628,7 +7610,9 @@ public:
 
 class VSIOSSHandle final : public IVSIS3LikeHandle
 {
-    VSIOSSHandleHelper* m_poHandleHelper;
+    CPL_DISALLOW_COPY_ASSIGN(VSIOSSHandle)
+
+    VSIOSSHandleHelper* m_poHandleHelper = nullptr;
 
   protected:
     struct curl_slist* GetCurlHeaders(
@@ -7895,6 +7879,8 @@ bool VSIOSSHandle::CanRestartOnError(const char* pszErrorMsg,
 
 class VSISwiftFSHandler final : public IVSIS3LikeFSHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSISwiftFSHandler)
+
 protected:
         VSICurlHandle* CreateFileHandle( const char* pszFilename ) override;
         CPLString GetURLFromDirname( const CPLString& osDirname ) override;
@@ -7913,7 +7899,7 @@ protected:
         void ClearCache() override;
 
 public:
-        VSISwiftFSHandler() {}
+        VSISwiftFSHandler() = default;
         ~VSISwiftFSHandler() override;
 
         VSIVirtualHandle *Open( const char *pszFilename,
@@ -7932,7 +7918,9 @@ public:
 
 class VSISwiftHandle final : public IVSIS3LikeHandle
 {
-    VSISwiftHandleHelper* m_poHandleHelper;
+    CPL_DISALLOW_COPY_ASSIGN(VSISwiftHandle)
+
+    VSISwiftHandleHelper* m_poHandleHelper = nullptr;
 
   protected:
     struct curl_slist* GetCurlHeaders(

--- a/gdal/port/cpl_vsil_curl_streaming.cpp
+++ b/gdal/port/cpl_vsil_curl_streaming.cpp
@@ -103,10 +103,12 @@ void VSICurlStreamingClearCache( void );  // used in cpl_vsil_curl.cpp
 
 class RingBuffer
 {
-    GByte* pabyBuffer;
-    size_t nCapacity;
-    size_t nOffset;
-    size_t nLength;
+    CPL_DISALLOW_COPY_ASSIGN(RingBuffer)
+
+    GByte* pabyBuffer = nullptr;
+    size_t nCapacity = 0;
+    size_t nOffset = 0;
+    size_t nLength = 0;
 
     public:
         RingBuffer(size_t nCapacity = BKGND_BUFFER_SIZE);
@@ -122,9 +124,7 @@ class RingBuffer
 
 RingBuffer::RingBuffer( size_t nCapacityIn ) :
     pabyBuffer(static_cast<GByte*>(CPLMalloc(nCapacityIn))),
-    nCapacity(nCapacityIn),
-    nOffset(0),
-    nLength(0)
+    nCapacity(nCapacityIn)
 {}
 
 RingBuffer::~RingBuffer()
@@ -207,10 +207,12 @@ class VSICurlStreamingHandle;
 
 class VSICurlStreamingFSHandler : public VSIFilesystemHandler
 {
-    std::map<CPLString, CachedFileProp*>   cacheFileSize;
+    CPL_DISALLOW_COPY_ASSIGN(VSICurlStreamingFSHandler)
+
+    std::map<CPLString, CachedFileProp*>   cacheFileSize{};
 
 protected:
-    CPLMutex           *hMutex;
+    CPLMutex           *hMutex = nullptr;
 
     virtual CPLString GetFSPrefix() { return "/vsicurl_streaming/"; }
     virtual VSICurlStreamingHandle* CreateFileHandle(const char* pszURL);
@@ -244,50 +246,52 @@ public:
 
 class VSICurlStreamingHandle : public VSIVirtualHandle
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSICurlStreamingHandle)
+
   protected:
-    VSICurlStreamingFSHandler* m_poFS;
-    char**          m_papszHTTPOptions;
+    VSICurlStreamingFSHandler* m_poFS = nullptr;
+    char**          m_papszHTTPOptions = nullptr;
 
   private:
-    char*           m_pszURL;
+    char*           m_pszURL = nullptr;
 
 #ifdef notdef
-    unsigned int    nRecomputedChecksumOfFirst1024Bytes;
+    unsigned int    nRecomputedChecksumOfFirst1024Bytes = 0;
 #endif
-    vsi_l_offset    curOffset;
-    vsi_l_offset    fileSize;
-    int             bHasComputedFileSize;
-    ExistStatus     eExists;
-    int             bIsDirectory;
+    vsi_l_offset    curOffset = 0;
+    vsi_l_offset    fileSize = 0;
+    int             bHasComputedFileSize = 0;
+    ExistStatus     eExists = EXIST_UNKNOWN;
+    int             bIsDirectory = 0;
 
-    int             bCanTrustCandidateFileSize;
-    int             bHasCandidateFileSize;
-    vsi_l_offset    nCandidateFileSize;
+    bool            bCanTrustCandidateFileSize = true;
+    bool            bHasCandidateFileSize = false;
+    vsi_l_offset    nCandidateFileSize = 0;
 
-    int             bEOF;
+    bool            bEOF = false;
 
-    size_t          nCachedSize;
-    GByte          *pCachedData;
+    size_t          nCachedSize = 0;
+    GByte          *pCachedData = nullptr;
 
-    CURL*           hCurlHandle;
+    CURL*           hCurlHandle = nullptr;
 
-    volatile int    bDownloadInProgress;
-    volatile int    bDownloadStopped;
-    volatile int    bAskDownloadEnd;
-    vsi_l_offset    nRingBufferFileOffset;
-    CPLJoinableThread *hThread;
-    CPLMutex       *hRingBufferMutex;
-    CPLCond        *hCondProducer;
-    CPLCond        *hCondConsumer;
-    RingBuffer      oRingBuffer;
+    volatile int    bDownloadInProgress = FALSE;
+    volatile int    bDownloadStopped = FALSE;
+    volatile int    bAskDownloadEnd = FALSE;
+    vsi_l_offset    nRingBufferFileOffset = 0;
+    CPLJoinableThread *hThread = nullptr;
+    CPLMutex       *hRingBufferMutex = nullptr;
+    CPLCond        *hCondProducer = nullptr;
+    CPLCond        *hCondConsumer = nullptr;
+    RingBuffer      oRingBuffer{};
     void            StartDownload();
     void            StopDownload();
     void            PutRingBufferInCache();
 
-    GByte          *pabyHeaderData;
-    size_t          nHeaderSize;
-    vsi_l_offset    nBodySize;
-    int             nHTTPCode;
+    GByte          *pabyHeaderData = nullptr;
+    size_t          nHeaderSize = 0;
+    vsi_l_offset    nBodySize = 0;
+    int             nHTTPCode = 0;
 
     void                AcquireMutex();
     void                ReleaseMutex();
@@ -340,16 +344,11 @@ class VSICurlStreamingHandle : public VSIVirtualHandle
 /************************************************************************/
 
 VSICurlStreamingHandle::VSICurlStreamingHandle( VSICurlStreamingFSHandler* poFS,
-                                                const char* pszURL )
+                                                const char* pszURL ):
+    m_poFS(poFS),
+    m_papszHTTPOptions(CPLHTTPGetOptionsFromEnv()),
+    m_pszURL(CPLStrdup(pszURL))
 {
-    m_poFS = poFS;
-    m_pszURL = CPLStrdup(pszURL);
-    m_papszHTTPOptions = CPLHTTPGetOptionsFromEnv();
-
-#ifdef notdef
-    nRecomputedChecksumOfFirst1024Bytes = 0;
-#endif
-    curOffset = 0;
 
     poFS->AcquireMutex();
     CachedFileProp* cachedFileProp = poFS->GetCachedFileProp(pszURL);
@@ -359,32 +358,10 @@ VSICurlStreamingHandle::VSICurlStreamingHandle( VSICurlStreamingFSHandler* poFS,
     bIsDirectory = cachedFileProp->bIsDirectory;
     poFS->ReleaseMutex();
 
-    bCanTrustCandidateFileSize = TRUE;
-    bHasCandidateFileSize = FALSE;
-    nCandidateFileSize = 0;
-
-    nCachedSize = 0;
-    pCachedData = nullptr;
-
-    bEOF = FALSE;
-
-    hCurlHandle = nullptr;
-
-    hThread = nullptr;
     hRingBufferMutex = CPLCreateMutex();
     ReleaseMutex();
     hCondProducer = CPLCreateCond();
     hCondConsumer = CPLCreateCond();
-
-    bDownloadInProgress = FALSE;
-    bDownloadStopped = FALSE;
-    bAskDownloadEnd = FALSE;
-    nRingBufferFileOffset = 0;
-
-    pabyHeaderData = nullptr;
-    nHeaderSize = 0;
-    nBodySize = 0;
-    nHTTPCode = 0;
 }
 
 /************************************************************************/
@@ -470,7 +447,7 @@ int VSICurlStreamingHandle::Seek( vsi_l_offset nOffset, int nWhence )
     {
         curOffset = GetFileSize() + nOffset;
     }
-    bEOF = FALSE;
+    bEOF = false;
     return 0;
 }
 
@@ -987,7 +964,7 @@ size_t VSICurlStreamingHandle::ReceivedBytesHeader( GByte *buffer, size_t count,
             {
                 const char* pszVal =
                     pszContentLength + strlen("Content-Length: ");
-                bHasCandidateFileSize = TRUE;
+                bHasCandidateFileSize = true;
                 nCandidateFileSize =
                     CPLScanUIntBig(pszVal,
                                    static_cast<int>(pszEndOfLine - pszVal));
@@ -1012,7 +989,7 @@ size_t VSICurlStreamingHandle::ReceivedBytesHeader( GByte *buffer, size_t count,
                         CPLDebug("VSICURL",
                                  "GZip compression enabled --> "
                                  "cannot trust candidate file size");
-                    bCanTrustCandidateFileSize = FALSE;
+                    bCanTrustCandidateFileSize = false;
                 }
             }
         }
@@ -1222,7 +1199,7 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
     if( bHasComputedFileSizeLocal && curOffset >= fileSizeLocal )
     {
         CPLDebug("VSICURL", "Read attempt beyond end of file");
-        bEOF = TRUE;
+        bEOF = true;
     }
     if( bEOF )
         return 0;
@@ -1301,7 +1278,7 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
         pabyBuffer += nSz;
         curOffset += nSz;
         nRemaining -= nSz;
-        bEOF = TRUE;
+        bEOF = true;
     }
 
     // Has a Seek() being done since the last Read()?
@@ -1361,7 +1338,7 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
 
         if( nBytesToSkip != 0 )
         {
-            bEOF = TRUE;
+            bEOF = true;
             return 0;
         }
     }
@@ -1416,7 +1393,7 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
                  static_cast<int>(nBufferRequestSize - nRemaining));
     size_t nRet = (nBufferRequestSize - nRemaining) / nSize;
     if( nRet < nMemb )
-        bEOF = TRUE;
+        bEOF = true;
 
     // Give a chance to specialized filesystem to deal with errors to redirect
     // elsewhere.
@@ -1441,7 +1418,7 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
         {
             curOffset = 0;
             nRingBufferFileOffset = 0;
-            bEOF = FALSE;
+            bEOF = false;
             AcquireMutex();
             eExists = EXIST_UNKNOWN;
             bHasComputedFileSize = FALSE;
@@ -1723,8 +1700,10 @@ const char* VSICurlStreamingFSHandler::GetActualURL(const char* pszFilename)
 
 class IVSIS3LikeStreamingFSHandler: public VSICurlStreamingFSHandler
 {
+        CPL_DISALLOW_COPY_ASSIGN(IVSIS3LikeStreamingFSHandler)
+
 public:
-        IVSIS3LikeStreamingFSHandler() {}
+        IVSIS3LikeStreamingFSHandler() = default;
 
         virtual void UpdateMapFromHandle( IVSIS3LikeHandleHelper * /*poHandleHelper*/ ) {}
         virtual void UpdateHandleFromMap( IVSIS3LikeHandleHelper * /*poHandleHelper*/ ) {}
@@ -1736,15 +1715,17 @@ public:
 
 class VSIS3StreamingFSHandler final: public IVSIS3LikeStreamingFSHandler
 {
-    std::map< CPLString, VSIS3UpdateParams > oMapBucketsToS3Params;
+    CPL_DISALLOW_COPY_ASSIGN(VSIS3StreamingFSHandler)
+
+    std::map< CPLString, VSIS3UpdateParams > oMapBucketsToS3Params{};
 
 protected:
     CPLString GetFSPrefix() override { return "/vsis3_streaming/"; }
     VSICurlStreamingHandle* CreateFileHandle( const char* pszURL ) override;
 
 public:
-    VSIS3StreamingFSHandler() {}
-    ~VSIS3StreamingFSHandler() override {}
+    VSIS3StreamingFSHandler() = default;
+    ~VSIS3StreamingFSHandler() override = default;
 
     const char* GetOptions() override
                             { return VSIGetFileSystemOptions("/vsis3/"); }
@@ -1801,7 +1782,9 @@ void VSIS3StreamingFSHandler::UpdateHandleFromMap(
 
 class VSIS3LikeStreamingHandle final: public VSICurlStreamingHandle
 {
-    IVSIS3LikeHandleHelper* m_poS3HandleHelper;
+    CPL_DISALLOW_COPY_ASSIGN(VSIS3LikeStreamingHandle)
+
+    IVSIS3LikeHandleHelper* m_poS3HandleHelper = nullptr;
 
   protected:
     struct curl_slist* GetCurlHeaders(
@@ -1966,15 +1949,17 @@ VSIAzureStreamingFSHandler::CreateFileHandle( const char* pszURL )
 
 class VSIOSSStreamingFSHandler final: public IVSIS3LikeStreamingFSHandler
 {
-    std::map< CPLString, VSIOSSUpdateParams > oMapBucketsToOSSParams;
+    CPL_DISALLOW_COPY_ASSIGN(VSIOSSStreamingFSHandler)
+
+    std::map< CPLString, VSIOSSUpdateParams > oMapBucketsToOSSParams{};
 
   protected:
     CPLString GetFSPrefix() override { return "/vsioss_streaming/"; }
     VSICurlStreamingHandle* CreateFileHandle( const char* pszURL ) override;
 
   public:
-    VSIOSSStreamingFSHandler() {}
-    ~VSIOSSStreamingFSHandler() override {}
+    VSIOSSStreamingFSHandler() = default;
+    ~VSIOSSStreamingFSHandler() override = default;
 
     const char* GetOptions() override
                         { return VSIGetFileSystemOptions("/vsioss/"); }

--- a/gdal/port/cpl_vsil_gzip.cpp
+++ b/gdal/port/cpl_vsil_gzip.cpp
@@ -148,33 +148,33 @@ typedef struct
 
 class VSIGZipHandle final : public VSIVirtualHandle
 {
-    VSIVirtualHandle* m_poBaseHandle;
+    VSIVirtualHandle* m_poBaseHandle = nullptr;
 #ifdef DEBUG
-    vsi_l_offset      m_offset;
+    vsi_l_offset      m_offset = 0;
 #endif
-    vsi_l_offset      m_compressed_size;
-    vsi_l_offset      m_uncompressed_size;
-    vsi_l_offset      offsetEndCompressedData;
-    uLong             m_expected_crc;
-    char             *m_pszBaseFileName; /* optional */
-    bool              m_bWriteProperties;
-    bool              m_bCanSaveInfo;
+    vsi_l_offset      m_compressed_size = 0;
+    vsi_l_offset      m_uncompressed_size = 0;
+    vsi_l_offset      offsetEndCompressedData = 0;
+    uLong             m_expected_crc = 0;
+    char             *m_pszBaseFileName = nullptr; /* optional */
+    bool              m_bWriteProperties = false;
+    bool              m_bCanSaveInfo = false;
 
     /* Fields from gz_stream structure */
     z_stream stream;
-    int      z_err;   /* error code for last stream operation */
-    int      z_eof;   /* set if end of input file (but not necessarily of the uncompressed stream ! "in" must be null too ) */
-    Byte     *inbuf;  /* input buffer */
-    Byte     *outbuf; /* output buffer */
-    uLong    crc;     /* crc32 of uncompressed data */
-    int      m_transparent; /* 1 if input file is not a .gz file */
-    vsi_l_offset  startOff;   /* startOff of compressed data in file (header skipped) */
-    vsi_l_offset  in;      /* bytes into deflate or inflate */
-    vsi_l_offset  out;     /* bytes out of deflate or inflate */
-    vsi_l_offset  m_nLastReadOffset;
+    int      z_err = Z_OK;   /* error code for last stream operation */
+    int      z_eof = 0;   /* set if end of input file (but not necessarily of the uncompressed stream ! "in" must be null too ) */
+    Byte     *inbuf = nullptr;  /* input buffer */
+    Byte     *outbuf = nullptr; /* output buffer */
+    uLong    crc = 0;     /* crc32 of uncompressed data */
+    int      m_transparent = 0; /* 1 if input file is not a .gz file */
+    vsi_l_offset  startOff = 0;   /* startOff of compressed data in file (header skipped) */
+    vsi_l_offset  in = 0;      /* bytes into deflate or inflate */
+    vsi_l_offset  out = 0;     /* bytes out of deflate or inflate */
+    vsi_l_offset  m_nLastReadOffset = 0;
 
-    GZipSnapshot* snapshots;
-    vsi_l_offset snapshot_byte_interval; /* number of compressed bytes at which we create a "snapshot" */
+    GZipSnapshot* snapshots = nullptr;
+    vsi_l_offset snapshot_byte_interval = 0; /* number of compressed bytes at which we create a "snapshot" */
 
     void check_header();
     int get_byte();
@@ -221,12 +221,14 @@ class VSIGZipHandle final : public VSIVirtualHandle
 
 class VSIGZipFilesystemHandler final : public VSIFilesystemHandler
 {
-    CPLMutex* hMutex;
-    VSIGZipHandle* poHandleLastGZipFile;
-    bool           m_bInSaveInfo;
+    CPL_DISALLOW_COPY_ASSIGN(VSIGZipFilesystemHandler)
+
+    CPLMutex* hMutex = nullptr;
+    VSIGZipHandle* poHandleLastGZipFile = nullptr;
+    bool           m_bInSaveInfo = false;
 
 public:
-    VSIGZipFilesystemHandler();
+    VSIGZipFilesystemHandler() = default;
     ~VSIGZipFilesystemHandler() override;
 
     VSIVirtualHandle *Open( const char *pszFilename,
@@ -326,23 +328,16 @@ VSIGZipHandle::VSIGZipHandle( VSIVirtualHandle* poBaseHandle,
 #ifdef DEBUG
     m_offset(offset),
 #endif
+    m_uncompressed_size(uncompressed_size),
     m_expected_crc(expected_crc),
     m_pszBaseFileName(pszBaseFileName ? CPLStrdup(pszBaseFileName) : nullptr),
     m_bWriteProperties(CPLTestBool(
         CPLGetConfigOption("CPL_VSIL_GZIP_WRITE_PROPERTIES", "YES"))),
     m_bCanSaveInfo(CPLTestBool(
         CPLGetConfigOption("CPL_VSIL_GZIP_SAVE_INFO", "YES"))),
-    z_err(Z_OK),
-    z_eof(0),
-    outbuf(nullptr),
+    stream(),
     crc(crc32(0L, nullptr, 0)),
-    m_transparent(transparent),
-    startOff(0),
-    in(0),
-    out(0),
-    m_nLastReadOffset(0),
-    snapshots(nullptr),
-    snapshot_byte_interval(0)
+    m_transparent(transparent)
 {
     if( compressed_size || transparent )
     {
@@ -355,7 +350,6 @@ VSIGZipHandle::VSIGZipHandle( VSIVirtualHandle* poBaseHandle,
         m_compressed_size = VSIFTellL(reinterpret_cast<VSILFILE*>(poBaseHandle)) - offset;
         compressed_size = m_compressed_size;
     }
-    m_uncompressed_size = uncompressed_size;
     offsetEndCompressedData = offset + compressed_size;
 
     if( VSIFSeekL(reinterpret_cast<VSILFILE*>(poBaseHandle), offset, SEEK_SET) != 0 )
@@ -1198,15 +1192,17 @@ int VSIGZipHandle::Close()
 
 class VSIGZipWriteHandle final : public VSIVirtualHandle
 {
-    VSIVirtualHandle*  m_poBaseHandle;
+    CPL_DISALLOW_COPY_ASSIGN(VSIGZipWriteHandle)
+
+    VSIVirtualHandle*  m_poBaseHandle = nullptr;
     z_stream           sStream;
-    Byte              *pabyInBuf;
-    Byte              *pabyOutBuf;
-    bool               bCompressActive;
-    vsi_l_offset       nCurOffset;
-    uLong              nCRC;
-    bool               bRegularZLib;
-    bool               bAutoCloseBaseHandle;
+    Byte              *pabyInBuf = nullptr;
+    Byte              *pabyOutBuf = nullptr;
+    bool               bCompressActive = false;
+    vsi_l_offset       nCurOffset = 0;
+    uLong              nCRC = 0;
+    bool               bRegularZLib = false;
+    bool               bAutoCloseBaseHandle = false;
 
   public:
     VSIGZipWriteHandle( VSIVirtualHandle* poBaseHandle, bool bRegularZLib,
@@ -1231,10 +1227,9 @@ VSIGZipWriteHandle::VSIGZipWriteHandle( VSIVirtualHandle *poBaseHandle,
                                         bool bRegularZLibIn,
                                         bool bAutoCloseBaseHandleIn ) :
     m_poBaseHandle(poBaseHandle),
+    sStream(),
     pabyInBuf(static_cast<Byte *>(CPLMalloc( Z_BUFSIZE ))),
     pabyOutBuf(static_cast<Byte *>(CPLMalloc( Z_BUFSIZE ))),
-    bCompressActive(false),
-    nCurOffset(0),
     nCRC(crc32(0L, nullptr, 0)),
     bRegularZLib(bRegularZLibIn),
     bAutoCloseBaseHandle(bAutoCloseBaseHandleIn)
@@ -1467,18 +1462,6 @@ vsi_l_offset VSIGZipWriteHandle::Tell()
 /*                       VSIGZipFilesystemHandler                       */
 /* ==================================================================== */
 /************************************************************************/
-
-/************************************************************************/
-/*                   VSIGZipFilesystemHandler()                         */
-/************************************************************************/
-
-VSIGZipFilesystemHandler::VSIGZipFilesystemHandler()
-{
-    hMutex = nullptr;
-
-    poHandleLastGZipFile = nullptr;
-    m_bInSaveInfo = false;
-}
 
 /************************************************************************/
 /*                  ~VSIGZipFilesystemHandler()                         */
@@ -1844,7 +1827,8 @@ class VSIZipEntryFileOffset final : public VSIArchiveEntryFileOffset
 public:
         unz_file_pos m_file_pos;
 
-        explicit VSIZipEntryFileOffset( unz_file_pos file_pos )
+        explicit VSIZipEntryFileOffset( unz_file_pos file_pos ):
+            m_file_pos()
         {
             m_file_pos.pos_in_zip_directory = file_pos.pos_in_zip_directory;
             m_file_pos.num_of_file = file_pos.num_of_file;
@@ -1859,12 +1843,14 @@ public:
 
 class VSIZipReader final : public VSIArchiveReader
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIZipReader)
+
   private:
-    unzFile unzF;
+    unzFile unzF = nullptr;
     unz_file_pos file_pos;
-    GUIntBig nNextFileSize;
-    CPLString osNextFileName;
-    GIntBig nModifiedTime;
+    GUIntBig nNextFileSize = 0;
+    CPLString osNextFileName{};
+    GIntBig nModifiedTime = 0;
 
     bool SetInfo();
 
@@ -1890,11 +1876,10 @@ class VSIZipReader final : public VSIArchiveReader
 /*                           VSIZipReader()                             */
 /************************************************************************/
 
-VSIZipReader::VSIZipReader( const char* pszZipFileName ) :
-    nNextFileSize(0),
-    nModifiedTime(0)
+VSIZipReader::VSIZipReader( const char* pszZipFileName ):
+    unzF(cpl_unzOpen(pszZipFileName)),
+    file_pos()
 {
-    unzF = cpl_unzOpen(pszZipFileName);
     file_pos.pos_in_zip_directory = 0;
     file_pos.num_of_file = 0;
 }
@@ -2003,11 +1988,14 @@ class VSIZipWriteHandle;
 
 class VSIZipFilesystemHandler final : public VSIArchiveFilesystemHandler
 {
-    std::map<CPLString, VSIZipWriteHandle*> oMapZipWriteHandles;
+    CPL_DISALLOW_COPY_ASSIGN(VSIZipFilesystemHandler)
+
+    std::map<CPLString, VSIZipWriteHandle*> oMapZipWriteHandles{};
     VSIVirtualHandle *OpenForWrite_unlocked( const char *pszFilename,
                                             const char *pszAccess );
 
   public:
+    VSIZipFilesystemHandler() = default;
     ~VSIZipFilesystemHandler() override;
 
     const char* GetPrefix() override { return "/vsizip"; }
@@ -2037,12 +2025,14 @@ class VSIZipFilesystemHandler final : public VSIArchiveFilesystemHandler
 
 class VSIZipWriteHandle final : public VSIVirtualHandle
 {
-   VSIZipFilesystemHandler *m_poFS;
-   void                    *m_hZIP;
-   VSIZipWriteHandle       *poChildInWriting;
-   VSIZipWriteHandle       *m_poParent;
-   bool                     bAutoDeleteParent;
-   vsi_l_offset             nCurOffset;
+   CPL_DISALLOW_COPY_ASSIGN(VSIZipWriteHandle)
+
+   VSIZipFilesystemHandler *m_poFS = nullptr;
+   void                    *m_hZIP = nullptr;
+   VSIZipWriteHandle       *poChildInWriting = nullptr;
+   VSIZipWriteHandle       *m_poParent = nullptr;
+   bool                     bAutoDeleteParent = false;
+   vsi_l_offset             nCurOffset = 0;
 
   public:
     VSIZipWriteHandle( VSIZipFilesystemHandler* poFS,
@@ -2464,10 +2454,7 @@ VSIZipWriteHandle::VSIZipWriteHandle( VSIZipFilesystemHandler* poFS,
                                       VSIZipWriteHandle* poParent ) :
     m_poFS(poFS),
     m_hZIP(hZIP),
-    poChildInWriting(nullptr),
-    m_poParent(poParent),
-    bAutoDeleteParent(false),
-    nCurOffset(0)
+    m_poParent(poParent)
 {}
 
 /************************************************************************/

--- a/gdal/port/cpl_vsil_sparsefile.cpp
+++ b/gdal/port/cpl_vsil_sparsefile.cpp
@@ -55,16 +55,13 @@ CPL_CVSID("$Id$")
 
 class SFRegion {
 public:
-    SFRegion() : fp(nullptr), nDstOffset(0), nSrcOffset(0), nLength(0),
-                 byValue(0), bTriedOpen(false) {}
-
-    CPLString     osFilename;
-    VSILFILE     *fp;
-    GUIntBig      nDstOffset;
-    GUIntBig      nSrcOffset;
-    GUIntBig      nLength;
-    GByte         byValue;
-    bool          bTriedOpen;
+    CPLString     osFilename{};
+    VSILFILE     *fp = nullptr;
+    GUIntBig      nDstOffset = 0;
+    GUIntBig      nSrcOffset = 0;
+    GUIntBig      nLength = 0;
+    GByte         byValue = 0;
+    bool          bTriedOpen = false;
 };
 
 /************************************************************************/
@@ -77,17 +74,19 @@ class VSISparseFileFilesystemHandler;
 
 class VSISparseFileHandle : public VSIVirtualHandle
 {
-    VSISparseFileFilesystemHandler* m_poFS;
-    bool               bEOF;
+    CPL_DISALLOW_COPY_ASSIGN(VSISparseFileHandle)
+
+    VSISparseFileFilesystemHandler* m_poFS = nullptr;
+    bool               bEOF = false;
 
   public:
     explicit VSISparseFileHandle(VSISparseFileFilesystemHandler* poFS) :
-                m_poFS(poFS), bEOF(false), nOverallLength(0), nCurOffset(0) {}
+                m_poFS(poFS) {}
 
-    GUIntBig           nOverallLength;
-    GUIntBig           nCurOffset;
+    GUIntBig           nOverallLength = 0;
+    GUIntBig           nCurOffset = 0;
 
-    std::vector<SFRegion> aoRegions;
+    std::vector<SFRegion> aoRegions{};
 
     int Seek( vsi_l_offset nOffset, int nWhence ) override;
     vsi_l_offset Tell() override;
@@ -105,11 +104,12 @@ class VSISparseFileHandle : public VSIVirtualHandle
 
 class VSISparseFileFilesystemHandler : public VSIFilesystemHandler
 {
-    std::map<GIntBig, int> oRecOpenCount;
+    std::map<GIntBig, int> oRecOpenCount{};
+    CPL_DISALLOW_COPY_ASSIGN(VSISparseFileFilesystemHandler)
 
 public:
-    VSISparseFileFilesystemHandler();
-    ~VSISparseFileFilesystemHandler() override;
+    VSISparseFileFilesystemHandler() = default;
+    ~VSISparseFileFilesystemHandler() override = default;
 
     int              DecomposePath( const char *pszPath,
                                     CPLString &osFilename,
@@ -353,18 +353,6 @@ int VSISparseFileHandle::Eof()
 /*                       VSISparseFileFilesystemHandler                 */
 /* ==================================================================== */
 /************************************************************************/
-
-/************************************************************************/
-/*                      VSISparseFileFilesystemHandler()                */
-/************************************************************************/
-
-VSISparseFileFilesystemHandler::VSISparseFileFilesystemHandler() {}
-
-/************************************************************************/
-/*                      ~VSISparseFileFilesystemHandler()               */
-/************************************************************************/
-
-VSISparseFileFilesystemHandler::~VSISparseFileFilesystemHandler() {}
 
 /************************************************************************/
 /*                                Open()                                */

--- a/gdal/port/cpl_vsil_stdin.cpp
+++ b/gdal/port/cpl_vsil_stdin.cpp
@@ -87,6 +87,8 @@ static void VSIStdinInit()
 
 class VSIStdinFilesystemHandler final : public VSIFilesystemHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIStdinFilesystemHandler)
+
   public:
     VSIStdinFilesystemHandler();
     ~VSIStdinFilesystemHandler() override;
@@ -107,12 +109,14 @@ class VSIStdinFilesystemHandler final : public VSIFilesystemHandler
 class VSIStdinHandle final : public VSIVirtualHandle
 {
   private:
-    GUIntBig nCurOff;
+    CPL_DISALLOW_COPY_ASSIGN(VSIStdinHandle)
+
+    GUIntBig nCurOff = 0;
     int               ReadAndCache( void* pBuffer, int nToRead );
 
   public:
-    VSIStdinHandle();
-    ~VSIStdinHandle() override;
+    VSIStdinHandle() = default;
+    ~VSIStdinHandle() override = default;
 
     int Seek( vsi_l_offset nOffset, int nWhence ) override;
     vsi_l_offset Tell() override;
@@ -121,23 +125,6 @@ class VSIStdinHandle final : public VSIVirtualHandle
     int Eof() override;
     int Close() override;
 };
-
-/************************************************************************/
-/*                           VSIStdinHandle()                           */
-/************************************************************************/
-
-VSIStdinHandle::VSIStdinHandle()
-{
-    nCurOff = 0;
-}
-
-/************************************************************************/
-/*                          ~VSIStdinHandle()                           */
-/************************************************************************/
-
-VSIStdinHandle::~VSIStdinHandle()
-{
-}
 
 /************************************************************************/
 /*                              ReadAndCache()                          */

--- a/gdal/port/cpl_vsil_stdout.cpp
+++ b/gdal/port/cpl_vsil_stdout.cpp
@@ -77,7 +77,11 @@ void VSIStdoutSetRedirection( VSIWriteFunction pFct, FILE* stream )
 
 class VSIStdoutFilesystemHandler final : public VSIFilesystemHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIStdoutFilesystemHandler)
+
   public:
+    VSIStdoutFilesystemHandler() = default;
+
     VSIVirtualHandle *Open( const char *pszFilename,
                             const char *pszAccess,
                             bool bSetError ) override;
@@ -93,11 +97,13 @@ class VSIStdoutFilesystemHandler final : public VSIFilesystemHandler
 
 class VSIStdoutHandle final : public VSIVirtualHandle
 {
-    vsi_l_offset      m_nOffset;
+    CPL_DISALLOW_COPY_ASSIGN(VSIStdoutHandle)
+
+    vsi_l_offset      m_nOffset = 0;
 
   public:
-    VSIStdoutHandle() : m_nOffset(0) {}
-    ~VSIStdoutHandle() override {}
+    VSIStdoutHandle() = default;
+    ~VSIStdoutHandle() override = default;
 
     int Seek( vsi_l_offset nOffset, int nWhence ) override;
     vsi_l_offset Tell() override;
@@ -259,7 +265,10 @@ class VSIStdoutRedirectFilesystemHandler final : public VSIFilesystemHandler
 
 class VSIStdoutRedirectHandle final : public VSIVirtualHandle
 {
-    VSIVirtualHandle* m_poHandle;
+    VSIVirtualHandle* m_poHandle = nullptr;
+
+    CPL_DISALLOW_COPY_ASSIGN(VSIStdoutRedirectHandle)
+
   public:
     explicit VSIStdoutRedirectHandle( VSIVirtualHandle* poHandle );
     ~VSIStdoutRedirectHandle() override;
@@ -277,9 +286,9 @@ class VSIStdoutRedirectHandle final : public VSIVirtualHandle
 /*                        VSIStdoutRedirectHandle()                    */
 /************************************************************************/
 
-VSIStdoutRedirectHandle::VSIStdoutRedirectHandle(VSIVirtualHandle* poHandle)
+VSIStdoutRedirectHandle::VSIStdoutRedirectHandle(VSIVirtualHandle* poHandle):
+    m_poHandle(poHandle)
 {
-    m_poHandle = poHandle;
 }
 
 /************************************************************************/

--- a/gdal/port/cpl_vsil_subfile.cpp
+++ b/gdal/port/cpl_vsil_subfile.cpp
@@ -52,15 +52,16 @@ CPL_CVSID("$Id$")
 
 class VSISubFileHandle : public VSIVirtualHandle
 {
-  public:
-    VSILFILE     *fp;
-    vsi_l_offset  nSubregionOffset;
-    vsi_l_offset  nSubregionSize;
-    bool          bAtEOF;
+    CPL_DISALLOW_COPY_ASSIGN(VSISubFileHandle)
 
-    VSISubFileHandle() : fp(nullptr), nSubregionOffset(0),
-                         nSubregionSize(0), bAtEOF(false) {}
-    ~VSISubFileHandle() override {}
+  public:
+    VSILFILE     *fp = nullptr;
+    vsi_l_offset  nSubregionOffset = 0;
+    vsi_l_offset  nSubregionSize = 0;
+    bool          bAtEOF = false;
+
+    VSISubFileHandle() = default;
+    ~VSISubFileHandle() override = default;
 
     int Seek( vsi_l_offset nOffset, int nWhence ) override;
     vsi_l_offset Tell() override;
@@ -78,9 +79,11 @@ class VSISubFileHandle : public VSIVirtualHandle
 
 class VSISubFileFilesystemHandler : public VSIFilesystemHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSISubFileFilesystemHandler)
+
   public:
-    VSISubFileFilesystemHandler();
-    ~VSISubFileFilesystemHandler() override;
+    VSISubFileFilesystemHandler() = default;
+    ~VSISubFileFilesystemHandler() override = default;
 
     static int              DecomposePath( const char *pszPath,
                                     CPLString &osFilename,
@@ -258,18 +261,6 @@ int VSISubFileHandle::Eof()
 /*                       VSISubFileFilesystemHandler                    */
 /* ==================================================================== */
 /************************************************************************/
-
-/************************************************************************/
-/*                      VSISubFileFilesystemHandler()                   */
-/************************************************************************/
-
-VSISubFileFilesystemHandler::VSISubFileFilesystemHandler() {}
-
-/************************************************************************/
-/*                      ~VSISubFileFilesystemHandler()                  */
-/************************************************************************/
-
-VSISubFileFilesystemHandler::~VSISubFileFilesystemHandler() {}
 
 /************************************************************************/
 /*                           DecomposePath()                            */

--- a/gdal/port/cpl_vsil_unix_stdio_64.cpp
+++ b/gdal/port/cpl_vsil_unix_stdio_64.cpp
@@ -141,13 +141,15 @@ CPL_CVSID("$Id$")
 
 class VSIUnixStdioFilesystemHandler final : public VSIFilesystemHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIUnixStdioFilesystemHandler)
+
 #ifdef VSI_COUNT_BYTES_READ
-    vsi_l_offset  nTotalBytesRead;
-    CPLMutex     *hMutex;
+    vsi_l_offset  nTotalBytesRead  = 0;
+    CPLMutex     *hMutex = nullptr;
 #endif
 
 public:
-    VSIUnixStdioFilesystemHandler();
+    VSIUnixStdioFilesystemHandler() = default;
 #ifdef VSI_COUNT_BYTES_READ
     ~VSIUnixStdioFilesystemHandler() override;
 #endif
@@ -178,20 +180,22 @@ public:
 
 class VSIUnixStdioHandle final : public VSIVirtualHandle
 {
-    FILE          *fp;
-    vsi_l_offset  m_nOffset;
-    bool          bReadOnly;
-    bool          bLastOpWrite;
-    bool          bLastOpRead;
-    bool          bAtEOF;
+    CPL_DISALLOW_COPY_ASSIGN(VSIUnixStdioHandle)
+
+    FILE          *fp = nullptr;
+    vsi_l_offset  m_nOffset = 0;
+    bool          bReadOnly = true;
+    bool          bLastOpWrite = false;
+    bool          bLastOpRead = false;
+    bool          bAtEOF = false;
     // In a+ mode, disable any optimization since the behaviour of the file
     // pointer on Mac and other BSD system is to have a seek() to the end of
     // file and thus a call to our Seek(0, SEEK_SET) before a read will be a
     // no-op.
-    bool          bModeAppendReadWrite;
+    bool          bModeAppendReadWrite = false;
 #ifdef VSI_COUNT_BYTES_READ
-    vsi_l_offset  nTotalBytesRead;
-    VSIUnixStdioFilesystemHandler *poFS;
+    vsi_l_offset  nTotalBytesRead = 0;
+    VSIUnixStdioFilesystemHandler *poFS = nullptr;
 #endif
   public:
     VSIUnixStdioHandle( VSIUnixStdioFilesystemHandler *poFSIn,
@@ -224,15 +228,10 @@ CPL_UNUSED
                                        FILE* fpIn, bool bReadOnlyIn,
                                        bool bModeAppendReadWriteIn) :
     fp(fpIn),
-    m_nOffset(0),
     bReadOnly(bReadOnlyIn),
-    bLastOpWrite(false),
-    bLastOpRead(false),
-    bAtEOF(false),
     bModeAppendReadWrite(bModeAppendReadWriteIn)
 #ifdef VSI_COUNT_BYTES_READ
     ,
-    nTotalBytesRead(0),
     poFS(poFSIn)
 #endif
 {}
@@ -587,17 +586,6 @@ VSIRangeStatus VSIUnixStdioHandle::GetRangeStatus( vsi_l_offset
 /*                       VSIUnixStdioFilesystemHandler                  */
 /* ==================================================================== */
 /************************************************************************/
-
-/************************************************************************/
-/*                      VSIUnixStdioFilesystemHandler()                 */
-/************************************************************************/
-
-VSIUnixStdioFilesystemHandler::VSIUnixStdioFilesystemHandler()
-#ifdef VSI_COUNT_BYTES_READ
-     : nTotalBytesRead(0),
-       hMutex(nullptr)
-#endif
-{}
 
 #ifdef VSI_COUNT_BYTES_READ
 /************************************************************************/

--- a/gdal/port/cpl_vsil_win32.cpp
+++ b/gdal/port/cpl_vsil_win32.cpp
@@ -57,9 +57,13 @@ CPL_CVSID("$Id$")
 
 class VSIWin32FilesystemHandler final : public VSIFilesystemHandler
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIWin32FilesystemHandler)
+
 public:
     // TODO(schwehr): Fix Open call to remove the need for this using call.
     using VSIFilesystemHandler::Open;
+
+    VSIWin32FilesystemHandler() = default;
 
     virtual VSIVirtualHandle *Open( const char *pszFilename,
                                     const char *pszAccess,
@@ -84,9 +88,13 @@ public:
 
 class VSIWin32Handle final : public VSIVirtualHandle
 {
+    CPL_DISALLOW_COPY_ASSIGN(VSIWin32Handle)
+
   public:
-    HANDLE       hFile;
-    int          bEOF;
+    HANDLE       hFile = nullptr;
+    bool         bEOF = false;
+
+    VSIWin32Handle() = default;
 
     virtual int       Seek( vsi_l_offset nOffset, int nWhence ) override;
     virtual vsi_l_offset Tell() override;
@@ -209,7 +217,7 @@ int VSIWin32Handle::Seek( vsi_l_offset nOffset, int nWhence )
     GUInt32       nMoveLow;
     LARGE_INTEGER li;
 
-    bEOF = FALSE;
+    bEOF = false;
 
     switch(nWhence)
     {
@@ -310,7 +318,7 @@ size_t VSIWin32Handle::Read( void * pBuffer, size_t nSize, size_t nCount )
         nResult = dwSizeRead / nSize;
 
     if( nResult != nCount )
-        bEOF = TRUE;
+        bEOF = true;
 
     return nResult;
 }
@@ -675,7 +683,6 @@ VSIVirtualHandle *VSIWin32FilesystemHandler::Open( const char *pszFilename,
     VSIWin32Handle *poHandle = new VSIWin32Handle;
 
     poHandle->hFile = hFile;
-    poHandle->bEOF = FALSE;
 
     if (strchr(pszAccess, 'a') != nullptr)
         poHandle->Seek(0, SEEK_END);

--- a/gdal/port/cpl_worker_thread_pool.cpp
+++ b/gdal/port/cpl_worker_thread_pool.cpp
@@ -49,14 +49,8 @@ CPL_CVSID("$Id$")
  * must be called.
  */
 CPLWorkerThreadPool::CPLWorkerThreadPool() :
-    hCond(nullptr),
-    eState(CPLWTS_OK),
-    psJobQueue(nullptr),
-    nPendingJobs(0),
-    psWaitingWorkerThreadsList(nullptr),
-    nWaitingWorkerThreads(0)
+    hMutex( CPLCreateMutexEx(CPL_MUTEX_REGULAR) )
 {
-    hMutex = CPLCreateMutexEx(CPL_MUTEX_REGULAR);
     CPLReleaseMutex(hMutex);
 }
 

--- a/gdal/port/cpl_worker_thread_pool.h
+++ b/gdal/port/cpl_worker_thread_pool.h
@@ -74,15 +74,17 @@ typedef enum
 /** Pool of worker threads */
 class CPL_DLL CPLWorkerThreadPool
 {
-        std::vector<CPLWorkerThread> aWT;
-        CPLCond* hCond;
-        CPLMutex* hMutex;
-        volatile CPLWorkerThreadState eState;
-        CPLList* psJobQueue;
-        volatile int nPendingJobs;
+        CPL_DISALLOW_COPY_ASSIGN(CPLWorkerThreadPool)
 
-        CPLList* psWaitingWorkerThreadsList;
-        int nWaitingWorkerThreads;
+        std::vector<CPLWorkerThread> aWT{};
+        CPLCond* hCond = nullptr;
+        CPLMutex* hMutex = nullptr;
+        volatile CPLWorkerThreadState eState = CPLWTS_OK;
+        CPLList* psJobQueue = nullptr;
+        volatile int nPendingJobs = 0;
+
+        CPLList* psWaitingWorkerThreadsList = nullptr;
+        int nWaitingWorkerThreads = 0;
 
         static void WorkerThreadFunction(void* user_data);
 

--- a/gdal/port/cplkeywordparser.cpp
+++ b/gdal/port/cplkeywordparser.cpp
@@ -54,9 +54,7 @@ CPL_CVSID("$Id$")
 /*                         CPLKeywordParser()                          */
 /************************************************************************/
 
-CPLKeywordParser::CPLKeywordParser() :
-    papszKeywordList(nullptr), pszHeaderNext(nullptr)
-{ }
+CPLKeywordParser::CPLKeywordParser() = default;
 
 /************************************************************************/
 /*                        ~CPLKeywordParser()                          */

--- a/gdal/port/cplkeywordparser.h
+++ b/gdal/port/cplkeywordparser.h
@@ -55,6 +55,8 @@ class CPLKeywordParser
     bool    ReadPair( CPLString &osName, CPLString &osValue );
     bool    ReadGroup( const char *pszPathPrefix, int nRecLevel );
 
+    CPL_DISALLOW_COPY_ASSIGN(CPLKeywordParser)
+
 public:
     CPLKeywordParser();
     ~CPLKeywordParser();

--- a/gdal/port/cplkeywordparser.h
+++ b/gdal/port/cplkeywordparser.h
@@ -45,10 +45,10 @@
 
 class CPLKeywordParser
 {
-    char     **papszKeywordList;
+    char     **papszKeywordList = nullptr;
 
-    CPLString osHeaderText;
-    const char *pszHeaderNext;
+    CPLString osHeaderText{};
+    const char *pszHeaderNext = nullptr;
 
     void    SkipWhite();
     bool    ReadWord( CPLString &osWord );

--- a/gdal/port/cplstringlist.cpp
+++ b/gdal/port/cplstringlist.cpp
@@ -47,13 +47,7 @@ CPL_CVSID("$Id$")
 /*                           CPLStringList()                            */
 /************************************************************************/
 
-CPLStringList::CPLStringList() :
-    papszList(nullptr),
-    nCount(0),
-    nAllocation(0),
-    bOwnList(false),
-    bIsSorted(false)
-{}
+CPLStringList::CPLStringList() = default;
 
 /************************************************************************/
 /*                           CPLStringList()                            */
@@ -67,10 +61,10 @@ CPLStringList::CPLStringList() :
  * of the list of strings which implies responsibility to free them.
  */
 
-CPLStringList::CPLStringList( char **papszListIn, int bTakeOwnership )
+CPLStringList::CPLStringList( char **papszListIn, int bTakeOwnership ):
+    CPLStringList()
 
 {
-    Initialize();
     Assign( papszListIn, bTakeOwnership );
 }
 
@@ -86,10 +80,10 @@ CPLStringList::CPLStringList( char **papszListIn, int bTakeOwnership )
  * @param papszListIn the NULL terminated list of strings to ingest.
  */
 
-CPLStringList::CPLStringList( CSLConstList papszListIn )
+CPLStringList::CPLStringList( CSLConstList papszListIn ):
+    CPLStringList()
 
 {
-    Initialize();
     Assign( CSLDuplicate(papszListIn) );
 }
 
@@ -98,10 +92,10 @@ CPLStringList::CPLStringList( CSLConstList papszListIn )
 /************************************************************************/
 
 //! Copy constructor
-CPLStringList::CPLStringList( const CPLStringList &oOther )
+CPLStringList::CPLStringList( const CPLStringList &oOther ):
+    CPLStringList()
 
 {
-    Initialize();
     Assign( oOther.papszList, FALSE );
 
     // We don't want to just retain a reference to the others list
@@ -144,20 +138,6 @@ CPLStringList &CPLStringList::operator=( CSLConstList papszListIn )
     }
 
     return *this;
-}
-
-/************************************************************************/
-/*                             Initialize()                             */
-/************************************************************************/
-
-void CPLStringList::Initialize()
-
-{
-    papszList = nullptr;
-    nCount = 0;
-    nAllocation = 0;
-    bOwnList = false;
-    bIsSorted = false;
 }
 
 /************************************************************************/


### PR DESCRIPTION
Helps ensuring copy constructor + assignment operators are defined (or suppressed) when pointers are used in member functions
And helps using initialized list or initialization in declaration