### PR TITLE
Python code Eliminate loop index variable in vec_tr.py

### DIFF
--- a/gdal/swig/python/samples/vec_tr.py
+++ b/gdal/swig/python/samples/vec_tr.py
@@ -83,10 +83,7 @@ infile = None
 outfile = None
 layer_name = None
 
-i = 1
-while i < len(sys.argv):
-    arg = sys.argv[i]
-
+for arg in sys.argv:
     if infile is None:
         infile = arg
 
@@ -98,8 +95,6 @@ while i < len(sys.argv):
 
     else:
         Usage()
-
-    i = i + 1
 
 if outfile is None:
     Usage()


### PR DESCRIPTION
## What does this PR do?

Eliminates the loop index variable to silence Pylint warning: `[W0621(redefined-outer-name),       WalkAndTransform] Redefining name 'i' from outer scope`.