### PR TITLE
Python code: Rename file

### DIFF
--- a/autotest/gdrivers/kmlsuperoverlay.py
+++ b/autotest/gdrivers/kmlsuperoverlay.py
@@ -248,14 +248,14 @@ def kmlsuperoverlay_5():
         'tmp/1/1/1.kml',
     ]
 
-    for file in files:
-        res = ElementTree.parse(file)
+    for f in files:
+        res = ElementTree.parse(f)
         for tag in res.findall('.//{http://earth.google.com/kml/2.1}LatLonAltBox'):
             east = tag.find('{http://earth.google.com/kml/2.1}east').text
             west = tag.find('{http://earth.google.com/kml/2.1}west').text
 
             if float(east) < float(west):
-                gdaltest.post_reason('East is less than west in LatLonAltBox %s, (%s < %s)' % (file, east, west))
+                gdaltest.post_reason('East is less than west in LatLonAltBox %s, (%s < %s)' % (f, east, west))
                 return 'fail'
 
     shutil.rmtree('tmp/0')

--- a/autotest/gdrivers/netcdf_cfchecks.py
+++ b/autotest/gdrivers/netcdf_cfchecks.py
@@ -2620,6 +2620,6 @@ if __name__ == '__main__':
     (badc, coards, uploader, useFileName, standardName, areaTypes, udunitsDat, version, files) = getargs(sys.argv)
 
     inst = CFChecker(uploader=uploader, useFileName=useFileName, badc=badc, coards=coards, cfStandardNamesXML=standardName, cfAreaTypesXML=areaTypes, udunitsDat=udunitsDat, version=version)
-    for file in files:
-        rc = inst.checker(file)
+    for f in files:
+        rc = inst.checker(f)
         sys.exit(rc)

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -577,8 +577,8 @@ def ogr_gml_14():
         return 'skip'
 
     files = ['xlink1.gml', 'xlink2.gml', 'expected1.gml', 'expected2.gml']
-    for file in files:
-        if not gdaltest.download_file('http://download.osgeo.org/gdal/data/gml/' + file, file):
+    for f in files:
+        if not gdaltest.download_file('http://download.osgeo.org/gdal/data/gml/' + f, f):
             return 'skip'
 
     gdal.SetConfigOption('GML_SKIP_RESOLVE_ELEMS', 'NONE')

--- a/autotest/ogr/ogr_ili.py
+++ b/autotest/ogr/ogr_ili.py
@@ -243,8 +243,8 @@ def ogr_interlis1_5():
 
     dst_ds = None
 
-    with open(outfile) as file:
-        itf = file.read()
+    with open(outfile) as f:
+        itf = f.read()
         expected = """MTID INTERLIS1
 MODL OGR
 ETOP
@@ -289,8 +289,8 @@ def ogr_interlis1_6():
 
     dst_ds = None
 
-    with open(outfile) as file:
-        itf = file.read()
+    with open(outfile) as f:
+        itf = f.read()
         expected = """MTID INTERLIS1
 MODL FormatDefault
 TOPI FormatTests
@@ -369,10 +369,10 @@ def ogr_interlis1_7():
 
     try:
         # Python 3
-        file = open(outfile, encoding='iso-8859-1')
-    except:
-        file = open(outfile)
-    itf = file.read()
+        f = open(outfile, encoding='iso-8859-1')
+    except TypeError:
+        f = open(outfile)
+    itf = f.read()
     expected = """MTID INTERLIS1
 MODL FormatDefault
 TABL FormatTable
@@ -1037,8 +1037,8 @@ def ogr_interlis1_14():
 
     dst_ds = None
 
-    with open(outfile) as file:
-        itf = file.read()
+    with open(outfile) as f:
+        itf = f.read()
         expected = """////
 MTID INTERLIS1
 MODL Beispiel
@@ -1236,8 +1236,8 @@ def ogr_interlis2_3():
 
     dst_ds = None
 
-    with open(outfile) as file:
-        xtf = file.read()
+    with open(outfile) as f:
+        xtf = f.read()
         expected = """<?xml version="1.0" encoding="utf-8" ?>
 <TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
 <HEADERSECTION SENDER="OGR/GDAL"""

--- a/autotest/ogr/ogr_pdf.py
+++ b/autotest/ogr/ogr_pdf.py
@@ -104,8 +104,8 @@ def ogr_pdf_1(name='tmp/ogr_pdf_1.pdf', write_attributes='YES'):
         '(super tex !) Tj\n' + \
         'ET'
 
-    with open(name, 'rb') as file:
-        data = file.read(8192)
+    with open(name, 'rb') as f:
+        data = f.read(8192)
         if wantedstream.encode('utf-8') not in data:
             gdaltest.post_reason('Wrong text data in written PDF stream')
             return 'fail'

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -729,9 +729,8 @@ def ogr_shape_21():
              'data/buggymultiline.shp',
              'data/buggymultipoly.shp',
              'data/buggymultipoly2.shp']
-    for file in files:
-
-        ds = ogr.Open(file)
+    for f in files:
+        ds = ogr.Open(f)
         lyr = ds.GetLayer(0)
         lyr.ResetReading()
         gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -1164,25 +1163,25 @@ def ogr_shape_28():
     os.remove('tmp/hugedbf.shp')
     os.remove('tmp/hugedbf.shx')
 
-    file = open("tmp/hugedbf.dbf", "rb+")
+    f = open("tmp/hugedbf.dbf", "rb+")
 
     # Set record count to 24,000,000
-    file.seek(4, 0)
-    file.write("\x00".encode('latin1'))
-    file.write("\x36".encode('latin1'))
-    file.write("\x6e".encode('latin1'))
-    file.write("\x01".encode('latin1'))
+    f.seek(4, 0)
+    f.write("\x00".encode('latin1'))
+    f.write("\x36".encode('latin1'))
+    f.write("\x6e".encode('latin1'))
+    f.write("\x01".encode('latin1'))
 
     # Set value for record 23,900,000 at
     # offset 2,390,000,066 = (23,900,000 * (99 + 1) + 65) + 1
-    file.seek(2390000066, 0)
-    file.write("value_over_2GB".encode('latin1'))
+    f.seek(2390000066, 0)
+    f.write("value_over_2GB".encode('latin1'))
 
     # Extend to 3 GB file
-    file.seek(3000000000, 0)
-    file.write("0".encode('latin1'))
+    f.seek(3000000000, 0)
+    f.write("0".encode('latin1'))
 
-    file.close()
+    f.close()
 
     ds = ogr.Open('tmp/hugedbf.dbf', update=1)
     if ds is None:

--- a/autotest/pymod/xmlvalidate.py
+++ b/autotest/pymod/xmlvalidate.py
@@ -202,8 +202,8 @@ def validate(xml_filename_or_content, xsd_filename=None,
 
 
 def transform_abs_links_to_ref_links(path, level=0):
-    for file in os.listdir(path):
-        filename = path + '/' + file
+    for filename in os.listdir(path):
+        filename = os.path.join(path, filename)
         if os.path.isdir(filename) and filename.find('examples') < 0:
             transform_abs_links_to_ref_links(filename, level + 1)
         elif filename.endswith('.xsd'):
@@ -251,8 +251,8 @@ def transform_abs_links_to_ref_links(path, level=0):
 
 
 def transform_inspire_abs_links_to_ref_links(path, level=0):
-    for file in os.listdir(path):
-        filename = path + '/' + file
+    for filename in os.listdir(path):
+        filename = os.path.join(path, filename)
         if os.path.isdir(filename) and filename.find('examples') < 0:
             transform_inspire_abs_links_to_ref_links(filename, level + 1)
         elif filename.endswith('.xsd'):

--- a/gdal/swig/python/scripts/gdalident.py
+++ b/gdal/swig/python/scripts/gdalident.py
@@ -105,5 +105,5 @@ while i < len(argv):
 if not files:
     Usage()
 
-for file in files:
-    ProcessTarget(file, recursive, report_failure)
+for f in files:
+    ProcessTarget(f, recursive, report_failure)


### PR DESCRIPTION
## What does this PR do?

Pylint warns about variables called `file`, which collide with the `file` type. Rename them sensibly to silence such warnings.