### PR TITLE
Python code: Use KeyError where appopriate

### DIFF
--- a/gdal/swig/include/python/ogr_python.i
+++ b/gdal/swig/include/python/ogr_python.i
@@ -273,7 +273,7 @@
             if isinstance(key, (str, type(u''))):
                 fld_index = self.GetGeomFieldIndex(key)
             if fld_index < 0:
-                raise ValueError("Illegal field requested in GetField()")
+                raise KeyError("Illegal field requested in GetField()")
             else:
                 return self.GetGeomFieldRef(fld_index)
         else:
@@ -292,7 +292,7 @@
             if isinstance(key, (str, type(u''))):
                 fld_index = self.GetGeomFieldIndex(key)
             if fld_index < 0:
-                raise ValueError("Illegal field requested in SetField()")
+                raise KeyError("Illegal field requested in SetField()")
             else:
                 return self.SetGeomField(fld_index, value)
         else:
@@ -302,7 +302,7 @@
         if isinstance(fld_index, (str, type(u''))):
             fld_index = self.GetFieldIndex(fld_index)
         if (fld_index < 0) or (fld_index > self.GetFieldCount()):
-            raise ValueError("Illegal field requested in GetField()")
+            raise KeyError("Illegal field requested in GetField()")
         if not (self.IsFieldSet(fld_index)) or self.IsFieldNull(fld_index):
             return None
         fld_type = self.GetFieldType(fld_index)
@@ -367,7 +367,7 @@
         if isinstance(fld_index, str) or isinstance(fld_index, type(u'')):
             fld_index = self.GetFieldIndex(fld_index)
         if (fld_index < 0) or (fld_index > self.GetFieldCount()):
-            raise ValueError("Illegal field requested in SetField2()")
+            raise KeyErrror("Illegal field requested in SetField2()")
 
         if value is None:
             self.SetFieldNull(fld_index)


### PR DESCRIPTION
## What does this PR do?

The Python library should raise `KeyError` when appropriate, not always `ValueError`'.