### PR TITLE
$(ZLIB_FLAGS) had an extra parenthesis.

### DIFF
--- a/gdal/frmts/mbtiles/makefile.vc
+++ b/gdal/frmts/mbtiles/makefile.vc
@@ -1,7 +1,7 @@
 
 OBJ	=	mbtilesdataset.obj
 
-EXTRAFLAGS = -I../../ogr -I../../ogr/ogrsf_frmts/gpkg  -I../../ogr/ogrsf_frmts/sqlite $(SQLITE_INC) -I../../ogr/ogrsf_frmts/geojson -I../../ogr/ogrsf_frmts/geojson/libjson -I../../ogr/ogrsf_frmts/mvt $(ZLIB_FLAGS)) $(GEOS_CFLAGS) -DHAVE_SQLITE
+EXTRAFLAGS = -I../../ogr -I../../ogr/ogrsf_frmts/gpkg  -I../../ogr/ogrsf_frmts/sqlite $(SQLITE_INC) -I../../ogr/ogrsf_frmts/geojson -I../../ogr/ogrsf_frmts/geojson/libjson -I../../ogr/ogrsf_frmts/mvt $(ZLIB_FLAGS) $(GEOS_CFLAGS) -DHAVE_SQLITE
 
 GDAL_ROOT	=	..\..
 


### PR DESCRIPTION
## What does this PR do?
Fixes an issue that prevented linking against an external zlib
 
## Environment

Provide environment details, if relevant:

* OS:
Win10
* Compiler:
VS2017

