### PR TITLE
Doc: remove "The" from title and organization in CITATION

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,14 +1,14 @@
 To cite GDAL/OGR in publications use:
 
-  GDAL/OGR contributors (2018). The GDAL/OGR Geospatial Data Abstraction
-  software Library. The Open Source Geospatial Foundation. URL http://gdal.org
+  GDAL/OGR contributors (2018). GDAL/OGR Geospatial Data Abstraction
+  software Library. Open Source Geospatial Foundation. URL http://gdal.org
 
 A BibTeX entry for LaTeX users is
 
   @Manual{,
-    title = {The {GDAL/OGR} Geospatial Data Abstraction software Library},
+    title = {{GDAL/OGR} Geospatial Data Abstraction software Library},
     author = {{GDAL/OGR contributors}},
-    organization = {The Open Source Geospatial Foundation},
+    organization = {Open Source Geospatial Foundation},
     year = {2018},
     url = {http://gdal.org},
   }


### PR DESCRIPTION
I don't think the definitive article "The" is part of the proper nouns of either the title or organization names, so I'm suggesting them to be removed. But it's fine to use "the" while wording (e.g.) the Open Source Geospatial Foundation.