### PR TITLE
Python code: Rename buffer -> buf (and friends)

### DIFF
--- a/gdal/swig/python/samples/gdal_cp.py
+++ b/gdal/swig/python/samples/gdal_cp.py
@@ -122,7 +122,7 @@ def gdal_cp_single(srcfile, targetfile, progress):
         total_size = gdal.VSIFTellL(fin)
         gdal.VSIFSeekL(fin, 0, 0)
 
-    buffer_max_size = 4096
+    buf_max_size = 4096
     copied = 0
     ret = 0
     # print('Copying %s...' % srcfile)
@@ -132,28 +132,28 @@ def gdal_cp_single(srcfile, targetfile, progress):
             ret = -2
 
     while ret == 0:
-        if total_size != 0 and copied + buffer_max_size > total_size:
+        if total_size != 0 and copied + buf_max_size > total_size:
             to_read = total_size - copied
         else:
-            to_read = buffer_max_size
-        buffer = gdal.VSIFReadL(1, to_read, fin)
-        if buffer is None:
+            to_read = buf_max_size
+        buf = gdal.VSIFReadL(1, to_read, fin)
+        if buf is None:
             if copied == 0:
                 print('Cannot read %d bytes in %s' % (to_read, srcfile))
                 ret = -1
             break
-        buffer_size = len(buffer)
-        if gdal.VSIFWriteL(buffer, 1, buffer_size, fout) != buffer_size:
-            print('Error writing %d bytes' % buffer_size)
+        buf_size = len(buf)
+        if gdal.VSIFWriteL(buf, 1, buf_size, fout) != buf_size:
+            print('Error writing %d bytes' % buf_size)
             ret = -1
             break
-        copied += buffer_size
+        copied += buf_size
         if progress is not None and total_size != 0:
             if not progress.Progress(copied * 1.0 / total_size, 'Copying %s' % srcfile):
                 print('Copy stopped by user')
                 ret = -2
                 break
-        if to_read < buffer_max_size or buffer_size != buffer_max_size:
+        if to_read < buf_max_size or buf_size != buf_max_size:
             break
 
     gdal.VSIFCloseL(fin)


### PR DESCRIPTION
## What does this PR do?

Renames `buffer` to `buf` to silence Pylint warnings about `buffer` being re-defined. For consistency, other variables in this function starting with `buffer_` have been renamed accordingly.