### PR TITLE
fix use opencl memory leak

### DIFF
--- a/gdal/alg/gdalwarpkernel_opencl.cpp
+++ b/gdal/alg/gdalwarpkernel_opencl.cpp
@@ -1818,12 +1818,13 @@ cl_int execute_kern(struct oclWarper *warper, cl_kernel kern, size_t loc_size)
                                             sizeof(size_t), &end_time, nullptr));
     assert(end_time != 0);
     assert(start_time != 0);
-    handleErr(err = clReleaseEvent(ev));
     if (kern == warper->kern4)
         vecTxt = "(vec)";
 
     CPLDebug("OpenCL", "Kernel Time: %6s %10lu", vecTxt, (long int)((end_time-start_time)/100000));
 #endif
+
+    handleErr(err = clReleaseEvent(ev));
     return CL_SUCCESS;
 }
 


### PR DESCRIPTION
[fix use opencl memory leak](https://github.com/OSGeo/gdal/issues/610)

Provide environment details, if relevant:

* OS:Windows10
* Compiler:Visual Studio2017
