### PR TITLE
Python code: Replace grep -v | grep -v | .. pipelines with grep -v -e .. -e ..

### DIFF
--- a/gdal/ci/travis/csa_common/script.sh
+++ b/gdal/ci/travis/csa_common/script.sh
@@ -2,4 +2,8 @@
 
 set -e
 
-(cd gdal && if grep -r "\.c" scanbuildoutput | grep "<string>" | grep -v "<key>" | grep -v degrib | grep -v libjpeg | grep -v libpng | grep -v EHapi | grep -v GDapi | grep -v SWapi | grep -v osr_cs_wkt_parser | grep -v ods_formula_parser | grep -v swq_parser; then echo "error" && /bin/false; else echo "ok"; fi)
+if grep -r "\\.c" gdal/scanbuildoutput | grep "<string>" | grep -v -e "<key>" -e degrib -e libjpeg -e libpng -e EHapi -e GDapi -e SWapi -e osr_cs_wkt_parser -e ods_formula_parser -e swq_parser; then
+    echo error && /bin/false
+else
+    echo ok
+fi

--- a/gdal/ci/travis/precise/before_install.sh
+++ b/gdal/ci/travis/precise/before_install.sh
@@ -21,7 +21,7 @@ sudo apt-get install doxygen texlive-latex-base
 pyflakes autotest
 pyflakes gdal/swig/python/scripts
 pyflakes gdal/swig/python/samples
-if pyflakes gdal/swig/python/osgeo/*.py | grep -v redefinition | grep -v 'unable to detect' | grep -v 'imported but unused'; then echo 'fail'; /bin/false; fi
+if pyflakes gdal/swig/python/osgeo/*.py | grep -v -e redefinition -e 'unable to detect' -e 'imported but unused'; then echo fail; /bin/false; fi
 psql -c "drop database if exists autotest" -U postgres
 psql -c "create database autotest" -U postgres
 psql -c "create extension postgis" -d autotest -U postgres

--- a/gdal/ci/travis/precise/install.sh
+++ b/gdal/ci/travis/precise/install.sh
@@ -13,7 +13,7 @@ scripts/detect_suspicious_char_digit_zero.sh
 CC="ccache gcc-4.8" CXX="ccache g++-4.8" ./configure --prefix=/usr --without-libtool --without-cpp11 --enable-debug --with-jpeg12 --with-python --with-poppler --with-podofo --with-spatialite --with-mysql --with-liblzma --with-webp --with-java --with-mdb --with-jvm-lib-add-rpath --with-epsilon --with-ecw=/usr/local --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local --with-fgdb=/usr/local --with-libkml --with-mongocxx=/usr/local
 #  --with-gta
 make docs >docs_log.txt 2>&1
-if grep -i warning docs_log.txt | grep -v russian | grep -v brazilian; then echo "Doxygen warnings found" && cat docs_log.txt && /bin/false; else echo "No Doxygen warnings found"; fi
+if grep -i warning docs_log.txt | grep -v -e russian -e brazilian; then echo "Doxygen warnings found" && cat docs_log.txt && /bin/false; else echo "No Doxygen warnings found"; fi
 make man >man_log.txt 2>&1
 if grep -i warning man_log.txt ; then echo "Doxygen warnings found" && cat docs_log.txt && /bin/false; else echo "No Doxygen warnings found"; fi
 make USER_DEFS="-Wextra -Werror" -j3

--- a/gdal/ci/travis/ubuntu_1604/install.sh
+++ b/gdal/ci/travis/ubuntu_1604/install.sh
@@ -12,9 +12,9 @@ sudo chroot "$chroot" sh -c "cd $PWD/gdal && CC=$PWD/clang+llvm-3.9.0-x86_64-lin
 sudo chroot "$chroot" bash -c "cd $PWD/gdal && scripts/cppcheck.sh"
 
 sudo chroot "$chroot" sh -c "cd $PWD/gdal && make docs >docs_log.txt 2>&1"
-sudo chroot "$chroot" sh -c "cd $PWD/gdal && if cat docs_log.txt | grep -i warning | grep -v russian | grep -v brazilian | grep -v setlocale | grep -v 'has become obsolete' | grep -v 'To avoid this warning'; then echo 'Doxygen warnings found' && cat docs_log.txt && /bin/false; else echo 'No Doxygen warnings found'; fi"
+sudo chroot "$chroot" sh -c "cd $PWD/gdal && if grep -i warning docs_log.txt | grep -v -e russian -e brazilian -e setlocale -e 'has become obsolete' -e 'To avoid this warning'; then echo 'Doxygen warnings found' && cat docs_log.txt && /bin/false; else echo 'No Doxygen warnings found'; fi"
 sudo chroot "$chroot" sh -c "cd $PWD/gdal && make man >man_log.txt 2>&1"
-sudo chroot "$chroot" sh -c "cd $PWD/gdal && if cat man_log.txt | grep -i warning | grep -v setlocale | grep -v 'has become obsolete' | grep -v 'To avoid this warning'; then echo 'Doxygen warnings found' && cat docs_log.txt && /bin/false; else echo 'No Doxygen warnings found'; fi"
+sudo chroot "$chroot" sh -c "cd $PWD/gdal && if grep -i warning man_log.txt | grep -v -e setlocale -e 'has become obsolete' -e 'To avoid this warning'; then echo 'Doxygen warnings found' && cat docs_log.txt && /bin/false; else echo 'No Doxygen warnings found'; fi"
 sudo chroot "$chroot" sh -c "cd $PWD/gdal && make USER_DEFS=-Werror -j3"
 sudo chroot "$chroot" sh -c "cd $PWD/gdal/apps && make USER_DEFS=-Werror -j3 test_ogrsf"
 sudo chroot "$chroot" sh -c "rm -f /usr/lib/libgdal.so*"

--- a/gdal/frmts/gtiff/libgeotiff/dump_symbols.sh
+++ b/gdal/frmts/gtiff/libgeotiff/dump_symbols.sh
@@ -10,7 +10,7 @@ rm $OUT_FILE 2>/dev/null
 
 echo "/* This is a generated file by dump_symbols.h. *DO NOT EDIT MANUALLY !* */" >> $OUT_FILE
 
-symbol_list=$(objdump -t libgeotiff.so  | grep .text | awk '{print $6}' | grep -v .text | grep -v __do_global | grep -v __bss_start | grep -v _edata | grep -v _end | grep -v _fini | grep -v _init | sort)
+symbol_list=$(objdump -t libgeotiff.so  | grep .text | awk '{print $6}' | grep -v -e .text -e __do_global -e __bss_start -e _edata -e _end -e _fini -e _init | sort)
 for symbol in $symbol_list
 do
     echo "#define $symbol gdal_$symbol" >> $OUT_FILE

--- a/gdal/frmts/gtiff/libtiff/dump_symbols.sh
+++ b/gdal/frmts/gtiff/libtiff/dump_symbols.sh
@@ -10,7 +10,7 @@ rm $OUT_FILE 2>/dev/null
 
 echo "/* This is a generated file by dump_symbols.h. *DO NOT EDIT MANUALLY !* */" >> $OUT_FILE
 
-symbol_list=$(objdump -t libtiff.so  | grep .text | awk '{print $6}' | grep -v .text | grep -v TIFFInit | grep -v __do_global | grep -v __bss_start | grep -v _edata | grep -v _end | grep -v _fini | grep -v _init | grep -v call_gmon_start | grep -v CPL_IGNORE_RET_VAL_INT | grep -v register_tm_clones | sort)
+symbol_list=$(objdump -t libtiff.so  | grep .text | awk '{print $6}' | grep -v -e .text -e TIFFInit -e __do_global -e __bss_start -e _edata -e _end -e _fini -e _init -e call_gmon_start -e CPL_IGNORE_RET_VAL_INT -e register_tm_clones | sort)
 for symbol in $symbol_list
 do
     echo "#define $symbol gdal_$symbol" >> $OUT_FILE
@@ -22,7 +22,7 @@ do
     echo "#define $symbol gdal_$symbol" >> $OUT_FILE
 done
 
-data_symbol_list=$(objdump -t libtiff.so  | grep "\.data"  | grep -v __dso_handle | grep -v __TMC_END__ |  awk '{print $6}' | grep -v "\.")
+data_symbol_list=$(objdump -t libtiff.so  | grep "\.data"  | grep -v -e __dso_handle -e __TMC_END__ |  awk '{print $6}' | grep -v "\.")
 for symbol in $data_symbol_list
 do
     echo "#define $symbol gdal_$symbol" >> $OUT_FILE

--- a/gdal/ogr/ogrsf_frmts/shape/dump_symbols.sh
+++ b/gdal/ogr/ogrsf_frmts/shape/dump_symbols.sh
@@ -8,7 +8,7 @@ OUT_FILE=gdal_shapelib_symbol_rename.h
 
 rm $OUT_FILE 2>/dev/null
 
-symbol_list=$(objdump -t shapelib.so  | grep .text | awk '{print $6}' | grep -v .text | grep -v __do_global | grep -v __bss_start | grep -v _edata | grep -v _end | grep -v _fini | grep -v _init | grep -v call_gmon_start | grep -v register_tm_clones | sort)
+symbol_list=$(objdump -t shapelib.so  | grep .text | awk '{print $6}' | grep -v -e .text -e __do_global -e __bss_start -e _edata -e _end -e _fini -e _init -e call_gmon_start -e register_tm_clones | sort)
 for symbol in $symbol_list
 do
     echo "#define $symbol gdal_$symbol" >> $OUT_FILE
@@ -20,7 +20,7 @@ do
     echo "#define $symbol gdal_$symbol" >> $OUT_FILE
 done
 
-data_symbol_list=$(objdump -t shapelib.so  | grep "\.data" | grep -v __dso_handle | grep -v "__TMC_END__" | awk '{print $6}' | grep -v "\.")
+data_symbol_list=$(objdump -t shapelib.so | grep "\\.data" | grep -v -e __dso_handle -e __TMC_END__ | awk '{print $6}' | grep -v "\\.")
 for symbol in $data_symbol_list
 do
     echo "#define $symbol gdal_$symbol" >> $OUT_FILE

--- a/gdal/scripts/cppcheck.sh
+++ b/gdal/scripts/cppcheck.sh
@@ -80,7 +80,7 @@ done
 
 ret_code=0
 
-grep -v "unmatchedSuppression" ${LOG_FILE} | grep -v " yacc.c" | grep -v PublicDecompWT | grep -v "kdu_cache_wrapper.h"  > ${LOG_FILE}.tmp
+grep -v "unmatchedSuppression" ${LOG_FILE} | grep -v -e " yacc.c" -e PublicDecompWT -e "kdu_cache_wrapper.h" > ${LOG_FILE}.tmp
 mv ${LOG_FILE}.tmp ${LOG_FILE}
 
 if grep "null pointer" ${LOG_FILE} ; then
@@ -126,7 +126,7 @@ fi
 grep "memleakOnRealloc" ${LOG_FILE} | grep frmts/hdf4/hdf-eos > /dev/null && echo "memleakOnRealloc issues in frmts/hdf4/hdf-eos ignored"
 grep "memleakOnRealloc" ${LOG_FILE} | grep frmts/grib/degrib > /dev/null && echo "memleakOnRealloc issues in frmts/grib/degrib ignored"
 
-if grep "memleakOnRealloc" ${LOG_FILE} | grep -v frmts/hdf4/hdf-eos | grep -v frmts/grib/degrib ; then
+if grep "memleakOnRealloc" ${LOG_FILE} | grep -v -e frmts/hdf4/hdf-eos -e frmts/grib/degrib ; then
     echo "memleakOnRealloc check failed"
     ret_code=1
 fi
@@ -151,7 +151,7 @@ fi
 
 grep "memleak," ${LOG_FILE} | grep frmts/hdf4/hdf-eos > /dev/null && echo "memleak issues in frmts/hdf4/hdf-eos ignored"
 grep "memleak," ${LOG_FILE} | grep frmts/grib/degrib > /dev/null && echo "memleak issues in frmts/grib/degrib ignored"
-if grep "memleak," ${LOG_FILE} | grep -v frmts/hdf4/hdf-eos | grep -v frmts/grib/degrib ; then
+if grep "memleak," ${LOG_FILE} | grep -v -e frmts/hdf4/hdf-eos -e frmts/grib/degrib ; then
     echo "memleak check failed"
     ret_code=1
 fi
@@ -177,16 +177,11 @@ grep "uninitvar," ${LOG_FILE} | grep frmts/png/libpng > /dev/null && echo "(pote
 grep "uninitvar," ${LOG_FILE} | grep frmts/zlib > /dev/null && echo "(potential) uninitvar issues in frmts/zlib ignored"
 grep "uninitvar," ${LOG_FILE} | grep ogr/ogrsf_frmts/geojson/libjson > /dev/null && echo "(potential) uninitvar issues in ogr/ogrsf_frmts/geojson/libjson ignored"
 
-if grep "uninitvar," ${LOG_FILE} | grep -v frmts/hdf4/hdf-eos | \
-                                grep -v frmts/grib/degrib | \
-                                grep -v frmts/gtiff/libtiff | \
-                                grep -v frmts/gtiff/libgeotiff | \
-                                grep -v frmts/jpeg/libjpeg | \
-                                grep -v frmts/gif/giflib | \
-                                grep -v frmts/png/libpng | \
-                                grep -v frmts/zlib | \
-                                grep -v ogr/ogrsf_frmts/geojson/libjson | \
-                                grep -v osr_cs_wkt_parser.c ; then
+if grep "uninitvar," ${LOG_FILE} | grep -v -e frmts/hdf4/hdf-eos \
+        -e frmts/grib/degrib -e frmts/gtiff/libtiff -e frmts/gtiff/libgeotiff \
+        -e frmts/jpeg/libjpeg -e frmts/gif/giflib -e frmts/png/libpng \
+        -e frmts/zlib -e ogr/ogrsf_frmts/geojson/libjson \
+        -e osr_cs_wkt_parser.c ; then
     echo "uninitvar check failed"
     ret_code=1
 fi
@@ -218,7 +213,7 @@ if grep "operatorEqVarError" ${LOG_FILE} ; then
     ret_code=1
 fi
 
-if grep "uselessAssignmentPtrArg" ${LOG_FILE} | grep -v swq_parser.cpp | grep -v osr_cs_wkt_parser.c | grep -v ods_formula_parser.cpp ; then
+if grep "uselessAssignmentPtrArg" ${LOG_FILE} | grep -v -e swq_parser.cpp -e osr_cs_wkt_parser.c -e ods_formula_parser.cpp ; then
     echo "uselessAssignmentPtrArg check failed"
     ret_code=1
 fi
@@ -308,7 +303,9 @@ if grep "stlIfStrFind" ${LOG_FILE} ; then
     ret_code=1
 fi
 
-if grep "functionStatic" ${LOG_FILE} | grep -v "OGRSQLiteDataSource::OpenRaster" | grep -v "OGRSQLiteDataSource::OpenRasterSubDataset" | grep -v cpl_mem_cache ; then
+if grep "functionStatic" ${LOG_FILE} | grep -v -e OGRSQLiteDataSource::OpenRaster \
+                                            -e OGRSQLiteDataSource::OpenRasterSubDataset \
+                                            -e cpl_mem_cache ; then
     echo "functionStatic check failed"
     ret_code=1
 fi
@@ -333,7 +330,7 @@ if grep "redundantCondition" ${LOG_FILE} ; then
     ret_code=1
 fi
 
-if grep "unusedStructMember" ${LOG_FILE} | grep -v frmts/jpeg/libjpeg | grep -v frmts/gtiff/libtiff | grep -v frmts/zlib ; then
+if grep "unusedStructMember" ${LOG_FILE} | grep -v -e frmts/jpeg/libjpeg -e frmts/gtiff/libtiff -e frmts/zlib ; then
     echo "unusedStructMember check failed"
     ret_code=1
 fi
@@ -403,7 +400,7 @@ if grep "unassignedVariable" ${LOG_FILE} | grep -v frmts/png/libpng ; then
     ret_code=1
 fi
 
-if grep "redundantAssignment" ${LOG_FILE} | grep -v frmts/grib/degrib/g2clib | grep -v frmts/hdf4/hdf-eos | grep -v frmts/png/libpng ; then
+if grep "redundantAssignment" ${LOG_FILE} | grep -v -e frmts/grib/degrib/g2clib -e frmts/hdf4/hdf-eos -e frmts/png/libpng ; then
     echo "redundantAssignment check failed"
     ret_code=1
 fi

--- a/gdal/scripts/detect_printf.sh
+++ b/gdal/scripts/detect_printf.sh
@@ -21,7 +21,7 @@ ret_code=0
 
 echo "Checking for printf() statements..."
 # apps is voluntarily missing in the list of directories, due to lots of legitimate uses of such statements in programs
-if grep -r --include="*.c*" " printf" alg gnm port ogr gcore frmts | grep -v "/*ok" | grep -v "printf()" | grep -v "printf-like" | grep -v "printf style" | grep -v "with printf"  | grep -v "/\\* printf" |  grep -v "//" | grep -v degrib | grep -v aitest | grep -v dted_test | grep -v giflib | grep -v 8211view | grep -v 8211dump | grep -v timetest | grep -v 8211createfromxml | grep -v hfatest | grep -v zlib | grep -v libtiff | grep -v envisat_dump | grep -v dumpgeo | grep -v nitfdump | grep -v ceostest| grep -v libpng | grep -v generate_encoding | grep -v capi_test | grep -v ntfdump | grep -v test_load_virtual_ogr | grep -v ocitest | grep -v fastload | grep -v s57dump | grep -v dgndump | grep -v test_geo_utils | grep -v testparser | grep -v internal_libqhull ; then
+if grep -r --include="*.c*" " printf" alg gnm port ogr gcore frmts | grep -v -e "/*ok" -e "printf()" -e "printf-like" -e "printf style" -e "with printf"  -e "/\\* printf" -e "//" -e degrib -e aitest -e dted_test -e giflib -e 8211view -e 8211dump -e timetest -e 8211createfromxml -e hfatest -e zlib -e libtiff -e envisat_dump -e dumpgeo -e nitfdump -e ceostest-e libpng -e generate_encoding -e capi_test -e ntfdump -e test_load_virtual_ogr -e ocitest -e fastload -e s57dump -e dgndump -e test_geo_utils -e testparser -e internal_libqhull ; then
     echo "FAIL: suspicious printf found. Remove or tag it with /*ok*/"
     ret_code=1
 else
@@ -31,7 +31,7 @@ fi
 
 echo "Checking for fprintf(stderr,) statements..."
 # apps is voluntarily missing in the list of directories, due to lots of legitimate uses of such statements in programs
-if grep fprintf -r  alg gnm port ogr gcore frmts --include="*.cpp" | grep stderr | grep -v -G "/[/|*][ ]*fprintf" | grep -v "/*ok" | grep -v sdts2shp | grep -v degrib  | grep -v 8211view | grep -v 8211createfromxml | grep -v 8211dump | grep -v pcidskexception | grep -v vsipreload | grep -v fprintfstderr | grep -v cpl_multiproc | grep -v "truncation occurred" | grep -v xmlreformat | grep -v cpl_error ; then
+if grep fprintf -r alg gnm port ogr gcore frmts --include="*.cpp" | grep stderr | grep -v -G -e "/[/|*][ ]*fprintf" -e "/*ok" -e sdts2shp -e degrib  -e 8211view -e 8211createfromxml -e 8211dump -e pcidskexception -e vsipreload -e fprintfstderr -e cpl_multiproc -e "truncation occurred" -e xmlreformat -e cpl_error ; then
     echo "FAIL: suspicious fprintf(stder,...) found. Remove or tag it with /*ok*/"
     ret_code=1
 else

--- a/gdal/scripts/detect_tabulations.sh
+++ b/gdal/scripts/detect_tabulations.sh
@@ -19,7 +19,7 @@ cd "$GDAL_ROOT"
 ret_code=0
 
 echo "Checking for tabulation characters..."
-if find alg gnm port ogr gcore frmts apps \( -name "*.cpp" -o -name "*.h" \) -exec sh -c "grep -P '\\t' {} >/dev/null && echo {}" \; | grep -v frmts/msg/PublicDecompWT | grep -v frmts/jpeg/libjpeg | grep -v frmts/gtiff/libtiff | grep -v frmts/gtiff/libgeotiff | grep -v frmts/grib/degrib | grep -v ogr/ogrsf_frmts/geojson/libjson | grep -v frmts/hdf4/hdf-eos | grep -v frmts/gif/giflib | grep -v frmts/pcraster/libcsf | grep -v frmts/png/libpng | grep -v cpl_mem_cache ; then
+if find alg gnm port ogr gcore frmts apps \( -name "*.cpp" -o -name "*.h" \) -exec sh -c "grep -P '\\t' {} >/dev/null && echo {}" \; | grep -v -e frmts/msg/PublicDecompWT -e frmts/jpeg/libjpeg -e frmts/gtiff/libtiff -e frmts/gtiff/libgeotiff -e frmts/grib/degrib -e ogr/ogrsf_frmts/geojson/libjson -e frmts/hdf4/hdf-eos -e frmts/gif/giflib -e frmts/pcraster/libcsf -e frmts/png/libpng -e cpl_mem_cache ; then
     echo "FAIL: tabulations detected. Please remove them!"
     ret_code=1
 else


### PR DESCRIPTION
## What does this PR do?

Simplifies the long command lines that pipe `grep -v` into `grep -v` etcetera by replacing them with a single `grep -v` command and multiple `-e` expressions.