### PR TITLE
Python code: Use byte (b) prefix on Python 2 and 3

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2651,12 +2651,7 @@ def tiff_write_71():
 
     # Write StripByteCounts tag
     # 100,000 in little endian
-    if version_info >= (3, 0, 0):
-        for _ in range(100000):
-            exec("f.write(b'\\xa0\\x86\\x01\\x00\\x00\\x00\\x00\\x00')")
-    else:
-        for _ in range(100000):
-            f.write('\xa0\x86\x01\x00\x00\x00\x00\x00')
+    f.write(b'\xa0\x86\x01\x00\x00\x00\x00\x00')
 
     # Write StripOffsets tag
     offset = 1600252
@@ -2666,10 +2661,7 @@ def tiff_write_71():
 
     # Write 0x78 as value of pixel (99999, 99999)
     f.seek(10001600252 - 1, 0)
-    if version_info >= (3, 0, 0):
-        exec("f.write(b'\\x78')")
-    else:
-        f.write('\x78')
+    f.write(b'\\x78')
     f.close()
 
     ds = gdal.Open('tmp/tiff_write_71.tif')

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2647,8 +2647,6 @@ def tiff_write_71():
     f = open('tmp/tiff_write_71.tif', 'wb')
     f.write(header)
 
-    from sys import version_info
-
     # Write StripByteCounts tag
     # 100,000 in little endian
     f.write(b'\xa0\x86\x01\x00\x00\x00\x00\x00')

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -1729,18 +1729,11 @@ def nitf_53():
 
     # Patch ICORDS and IGEOLO
     f.seek(775)
-    if version_info >= (3, 0, 0):
-        exec("f.write(b'U')")
-        exec("f.write(b'31UBQ1000040000')")
-        exec("f.write(b'31UBQ2000040000')")
-        exec("f.write(b'31UBQ2000030000')")
-        exec("f.write(b'31UBQ1000030000')")
-    else:
-        f.write('U')
-        f.write('31UBQ1000040000')
-        f.write('31UBQ2000040000')
-        f.write('31UBQ2000030000')
-        f.write('31UBQ1000030000')
+    f.write(b'U')
+    f.write(b'31UBQ1000040000')
+    f.write(b'31UBQ2000040000')
+    f.write(b'31UBQ2000030000')
+    f.write(b'31UBQ1000030000')
 
     f.close()
 

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -33,7 +33,6 @@
 import copy
 import os
 import sys
-from sys import version_info
 import array
 import struct
 import shutil


### PR DESCRIPTION
## What does this PR do?

Removes Pylint warnings about the use of `exec()`.