### PR TITLE
include the hdf-eos object files into the plugin build or HDF4Image w…

### DIFF
--- a/gdal/frmts/hdf4/GNUmakefile
+++ b/gdal/frmts/hdf4/GNUmakefile
@@ -18,10 +18,12 @@ lib-hdfeos:
 
 install-obj:	$(SUBLIBS) $(O_OBJ:.o=.$(OBJ_EXT))
 
+EOS_SO          = ../o/EHapi.o ../o/GDapi.o ../o/SWapi.o ../o/gctp_wrap.o
+
 PLUGIN_SO       = gdal_HDF4.$(SO_EXT)
 
 plugin: $(PLUGIN_SO)
 
 $(PLUGIN_SO):   $(OBJ)
-	$(LD_SHARED) $(LNK_FLAGS) $(OBJ) $(CONFIG_LIBS_INS) $(LIBS) \
+	$(LD_SHARED) $(LNK_FLAGS) $(OBJ) $(EOS_SO) $(CONFIG_LIBS_INS) $(LIBS) \
 		-o $(PLUGIN_SO)


### PR DESCRIPTION

## What does this PR do?

Fix HDF4 plugin build. Include the hdf-eos object files into the plugin. Otherwise the driver HDF4Image does not get registered when the gdal_HDF4 plugin is loaded.

* OS: Linux and OSX
