### PR TITLE
OGR/OCI: Ensure table Dims and GTYPE are retrieved for the correct table

### DIFF
--- a/gdal/ogr/ogrsf_frmts/oci/ogrocitablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/oci/ogrocitablelayer.cpp
@@ -350,15 +350,32 @@ OGRFeatureDefn *OGROCITableLayer::ReadTableDefinition( const char * pszTable )
         char **papszResult;
         int iDim = -1;
 
-        const char* pszDimCmd = 
-            "SELECT COUNT(*)\n"
-            "FROM ALL_SDO_GEOM_METADATA u, TABLE(u.diminfo) t\n"
-            "WHERE u.table_name = :table_name\n"
-            "  AND u.column_name = :geometry_name";
+        if( osOwner != "" )
+        {
+            const char* pszDimCmdA =
+                "SELECT COUNT(*)\n"
+                "FROM ALL_SDO_GEOM_METADATA u, TABLE(u.diminfo) t\n"
+                "WHERE u.table_name = :table_name\n"
+                "  AND u.column_name = :geometry_name\n"
+                "  AND u.owner = :table_owner";
 
-        oDimStatement.Prepare( pszDimCmd );
-        oDimStatement.BindString( ":table_name", osTableName.c_str() );
-        oDimStatement.BindString( ":geometry_name", pszGeomName );
+            oDimStatement.Prepare( pszDimCmdA );
+            oDimStatement.BindString( ":table_name", osTableName.c_str() );
+            oDimStatement.BindString( ":geometry_name", pszGeomName );
+            oDimStatement.BindString( ":table_owner", osOwner.c_str() );
+        }
+        else
+        {
+            const char* pszDimCmdB =
+                "SELECT COUNT(*)\n"
+                "FROM USER_SDO_GEOM_METADATA u, TABLE(u.diminfo) t\n"
+                "WHERE u.table_name = :table_name\n"
+                "  AND u.column_name = :geometry_name";
+
+            oDimStatement.Prepare( pszDimCmdB );
+            oDimStatement.BindString( ":table_name", osTableName.c_str() );
+            oDimStatement.BindString( ":geometry_name", pszGeomName );
+        }
         oDimStatement.Execute( nullptr );
 
         papszResult = oDimStatement.SimpleFetchRow();
@@ -370,15 +387,31 @@ OGRFeatureDefn *OGROCITableLayer::ReadTableDefinition( const char * pszTable )
 
             CPLErrorReset();
 
-            const char* pszDimCmd2 =
-                "select m.sdo_index_dims\n"
-                "from   all_sdo_index_metadata m, all_sdo_index_info i\n"
-                "where  i.index_name = m.sdo_index_name\n"
-                "   and i.sdo_index_owner = m.sdo_index_owner\n"
-                "   and i.table_name = upper(:table_name)";
+            if( osOwner != "" )
+            {
+                const char* pszDimCmd2A =
+                    "select m.sdo_index_dims\n"
+                    "from   all_sdo_index_metadata m, all_sdo_index_info i\n"
+                    "where  i.index_name = m.sdo_index_name\n"
+                    "   and i.sdo_index_owner = m.sdo_index_owner\n"
+                    "   and i.sdo_index_owner = upper(:table_owner)\n"
+                    "   and i.table_name = upper(:table_name)";
 
-            oDimStatement2.Prepare( pszDimCmd2 );
-            oDimStatement2.BindString( ":table_name", osTableName.c_str());
+                oDimStatement2.Prepare( pszDimCmd2A );
+                oDimStatement2.BindString( ":table_owner", osOwner.c_str());
+                oDimStatement2.BindString( ":table_name", osTableName.c_str());
+            }
+            else
+            {
+                const char* pszDimCmd2B =
+                    "select m.sdo_index_dims\n"
+                    "from   user_sdo_index_metadata m, user_sdo_index_info i\n"
+                    "where  i.index_name = m.sdo_index_name\n"
+                    "   and i.table_name = upper(:table_name)";
+
+                oDimStatement2.Prepare( pszDimCmd2B );
+                oDimStatement2.BindString( ":table_name", osTableName.c_str());
+            }
             oDimStatement2.Execute( nullptr );
 
             papszResult2 = oDimStatement2.SimpleFetchRow();
@@ -412,15 +445,31 @@ OGRFeatureDefn *OGROCITableLayer::ReadTableDefinition( const char * pszTable )
             char **papszResult2;
 
             CPLErrorReset();
-            const char* pszLayerTypeCmd =
-                "select m.SDO_LAYER_GTYPE "
-                "from all_sdo_index_metadata m, all_sdo_index_info i "
-                "where i.index_name = m.sdo_index_name "
-                "and i.sdo_index_owner = m.sdo_index_owner "
-                "and i.table_name = upper(:table_name)";
+            if( osOwner != "" )
+            {
+                const char* pszLayerTypeCmdA =
+                    "select m.SDO_LAYER_GTYPE "
+                    "from all_sdo_index_metadata m, all_sdo_index_info i "
+                    "where i.index_name = m.sdo_index_name "
+                    "and i.sdo_index_owner = m.sdo_index_owner "
+                    "and i.sdo_index_owner = upper(:table_owner) "
+                    "and i.table_name = upper(:table_name)";
 
-            oDimStatement2.Prepare( pszLayerTypeCmd );
-            oDimStatement2.BindString( ":table_name", osTableName.c_str() );
+                oDimStatement2.Prepare( pszLayerTypeCmdA );
+                oDimStatement2.BindString( ":table_owner", osOwner.c_str() );
+                oDimStatement2.BindString( ":table_name", osTableName.c_str() );
+            }
+            else
+            {
+                const char* pszLayerTypeCmdB =
+                    "select m.SDO_LAYER_GTYPE "
+                    "from user_sdo_index_metadata m, user_sdo_index_info i "
+                    "where i.index_name = m.sdo_index_name "
+                    "and i.table_name = upper(:table_name)";
+                oDimStatement2.Prepare( pszLayerTypeCmdB );
+                oDimStatement2.BindString( ":table_name", osTableName.c_str() );
+            }
+
             oDimStatement2.Execute( nullptr );
 
             papszResult2 = oDimStatement2.SimpleFetchRow();


### PR DESCRIPTION
OGROCITableLayer::ReadTableDefinition - erroneous results for layer
dimensions and SDO_GTYPE information can be returned if multiple spatial
tables of the same name exist in the database (with different owners/schemas)
and the connecting user has select privileges over all of them.

In this situation the number of dimensions returned is either
1) the sum of the dimensions of all of the tables of the same name, or if
   that produces no results
2) (if no schema qualification is specified) the dimensions of the first
   table returned (which may or may not be the correct table)

A similar issue to No 2 above occurs when retrieving GTYPE information

To resolve this
a) when the tablename is not schema/owner qualified, use USER_SDO_* views
b) when the tablename is schema/owner qualified, ensure only the specified
   schema/owner's table/index information is retrieved from the ALL_SDO_*
   views

This ensures that when enumerating Dimensions and GTYPE that only the
information for one table/view will be returned (matching the table described
by OCIDescribeAny)
