### PR TITLE
MySQL: Replace my_bool with bool for >=8.0

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -233,9 +233,13 @@ int OGRMySQLDataSource::Open( const char * pszNewName, char** papszOpenOptionsIn
     else
     {
         // Enable automatic reconnection
+#if defined(LIBMYSQL_VERSION_ID) && (LIBMYSQL_VERSION_ID >= 80000)
+        bool reconnect = 1;
+#else
+        my_bool reconnect = 1;
+#endif
         // Must be called after mysql_real_connect() on MySQL < 5.0.19
         // and at any point on more recent versions.
-        my_bool reconnect = 1;
         mysql_options(hConn, MYSQL_OPT_RECONNECT, &reconnect);
     }
 


### PR DESCRIPTION
## What does this PR do?

Submits patch from vcpkg port of GDAL 2.3.0 to catch up with changes in libmysql from MySQL 8.0:

[MySQL 8.0 Reference Manual](https://dev.mysql.com/doc/refman/8.0/en/c-api-data-structures.html):
> The my_bool type was used before MySQL 8.0.
> As of MySQL 8.0, use the bool or int C type instead.

## What are related issues/pull requests?

https://github.com/Microsoft/vcpkg/pull/3478

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

