### PR TITLE
NaN empty data in gdal_merge.py

### DIFF
--- a/gdal/swig/python/scripts/gdal_merge.py
+++ b/gdal/swig/python/scripts/gdal_merge.py
@@ -151,7 +151,11 @@ def raster_copy_with_nodata(s_fh, s_xoff, s_yoff, s_xsize, s_ysize, s_band_n,
                                   t_xsize, t_ysize)
     data_dst = t_band.ReadAsArray(t_xoff, t_yoff, t_xsize, t_ysize)
 
-    nodata_test = Numeric.equal(data_src, nodata)
+    if not Numeric.isnan(nodata):
+        nodata_test = Numeric.equal(data_src, nodata)
+    else:
+        nodata_test = Numeric.isnan(data_src)
+
     to_write = Numeric.choose(nodata_test, (data_src, data_dst))
 
     t_band.WriteArray(to_write, t_xoff, t_yoff)


### PR DESCRIPTION
COMPONENT_NAME: gdal_merge.py

Applied NaN check for raster copy. This allows geotiffs with NaN for empty data to be merged correctly.

## What does this PR do?
Implements an explicit check for nan data in gdal_merge.py.

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: ubuntu 16.04
* Compiler: icecc/gcc
