### PR TITLE
importFromEPSG(): append ' (deprecated)' at end of deprecated GeoCCS

### DIFF
--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -461,7 +461,7 @@ def osr_basic_13():
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(4328)
 
-    expected_wkt = 'GEOCCS["WGS 84 (geocentric)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Geocentric X",OTHER],AXIS["Geocentric Y",OTHER],AXIS["Geocentric Z",NORTH],AUTHORITY["EPSG","4328"]]'
+    expected_wkt = 'GEOCCS["WGS 84 (geocentric) (deprecated)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Geocentric X",OTHER],AXIS["Geocentric Y",OTHER],AXIS["Geocentric Z",NORTH],AUTHORITY["EPSG","4328"]]'
     wkt = srs.ExportToWkt()
 
     if wkt != expected_wkt:

--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -417,6 +417,18 @@ def osr_epsg_gcs_deprecated():
 ###############################################################################
 
 
+def osr_epsg_geoccs_deprecated():
+
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(4346)
+    if sr.ExportToWkt().find('ETRS89 (geocentric) (deprecated)') < 0:
+        print(sr.ExportToWkt())
+        return 'fail'
+    return 'success'
+
+###############################################################################
+
+
 gdaltest_list = [
     osr_epsg_1,
     osr_epsg_2,
@@ -432,6 +444,7 @@ gdaltest_list = [
     osr_epsg_12,
     osr_epsg_13,
     osr_epsg_gcs_deprecated,
+    osr_epsg_geoccs_deprecated,
     None]
 
 if __name__ == '__main__':

--- a/gdal/ogr/ogr_fromepsg.cpp
+++ b/gdal/ogr/ogr_fromepsg.cpp
@@ -1948,9 +1948,20 @@ static OGRErr SetEPSGGeocCS( OGRSpatialReference * poSRS, int nGCSCode )
 /*      Set the GEOCCS node with a name.                                */
 /* -------------------------------------------------------------------- */
     poSRS->Clear();
-    poSRS->SetGeocCS( CSLGetField( papszRecord,
-                                   CSVGetFileFieldId(pszFilename,
-                                                     "COORD_REF_SYS_NAME")) );
+    CPLString osGCCSName =
+        CSLGetField( papszRecord,
+                     CSVGetFileFieldId( pszFilename,
+                                        "COORD_REF_SYS_NAME" ));
+
+    const char *pszDeprecated =
+        CSLGetField( papszRecord,
+                     CSVGetFileFieldId( pszFilename,
+                                        "DEPRECATED") );
+
+    if ( pszDeprecated != nullptr && *pszDeprecated == '1' )
+         osGCCSName += " (deprecated)";
+
+    poSRS->SetGeocCS( osGCCSName );
 
 /* -------------------------------------------------------------------- */
 /*      Get datum related information.                                  */


### PR DESCRIPTION
## What does this PR do?

Appends ' (deprecated)' to the name of deprecated GEOCCSs like for PROJCSs and GEOGCSs.

## What are related issues/pull requests?

See 39ce2084e05d494deafb93b977a7c4c6c0b36417 (for PROJCS), PR #575 (for GEOGCS) and https://lists.osgeo.org/pipermail/gdal-dev/2018-May/048495.html
See also https://github.com/qgis/QGIS/commit/e15f7cc06950b35a5d2db8054a7da7105397f564 about QGIS 3 now relying on "(deprecated)" string in crs name to properly update the field 'deprecated' of its crs database.