### PR TITLE
Correct misspelling in info message

### DIFF
--- a/gdal/swig/csharp/apps/GDALCreateCopy.cs
+++ b/gdal/swig/csharp/apps/GDALCreateCopy.cs
@@ -89,7 +89,7 @@ class GDALWrite {
 
             if (ds == null)
             {
-                Console.WriteLine("Can't open source dataset " + args[1]);
+                Console.WriteLine("Can't open source dataset " + args[0]);
                 System.Environment.Exit(-1);
             }
 


### PR DESCRIPTION
args[1] should be args[0], because “we can’t load SOURCE file, not DEST”