### PR TITLE
Shell scripts: Shellcheck fixes

### DIFF
--- a/gdal/fuzzers/build_seed_corpus.sh
+++ b/gdal/fuzzers/build_seed_corpus.sh
@@ -294,17 +294,21 @@ echo "Building ers_fuzzer_seed_corpus.zip"
 rm -f $OUT/ers_fuzzer_seed_corpus.zip
 CUR_DIR=$PWD
 cd  $(dirname $0)/../../autotest/gdrivers/data
-printf "FUZZER_FRIENDLY_ARCHIVE\\n" > $CUR_DIR/srtm.tar
-printf "***NEWFILE***:%s\\n" "test.ers" >> $CUR_DIR/srtm.tar
-cat srtm.ers >> $CUR_DIR/srtm.tar
-printf "***NEWFILE***:%s\\n" "test" >> $CUR_DIR/srtm.tar
-cat srtm >> $CUR_DIR/srtm.tar
+{
+    printf "FUZZER_FRIENDLY_ARCHIVE\\n"
+    printf "***NEWFILE***:%s\\n" "test.ers"
+    cat srtm.ers
+    printf "***NEWFILE***:%s\\n" "test"
+    cat srtm
+} > $CUR_DIR/srtm.tar
 
-printf "FUZZER_FRIENDLY_ARCHIVE\\n" > $CUR_DIR/ers_dem.tar
-printf "***NEWFILE***:%s\\n" "test.ers" >> $CUR_DIR/ers_dem.tar
-cat ers_dem.ers >> $CUR_DIR/ers_dem.tar
-printf "***NEWFILE***:%s\\n" "test" >> $CUR_DIR/ers_dem.tar
-cat ers_dem >> $CUR_DIR/ers_dem.tar
+{
+    printf "FUZZER_FRIENDLY_ARCHIVE\\n"
+    printf "***NEWFILE***:%s\\n" "test.ers"
+    cat ers_dem.ers
+    printf "***NEWFILE***:%s\\n" "test"
+    cat ers_dem
+} > $CUR_DIR/ers_dem.tar
 
 cd $CUR_DIR
 zip -r $OUT/ers_fuzzer_seed_corpus.zip srtm.tar ers_dem.tar >/dev/null

--- a/gdal/scripts/setdevenv.sh
+++ b/gdal/scripts/setdevenv.sh
@@ -14,6 +14,8 @@ if [[ $called == "$0" ]]; then
     exit 1
 fi
 
+# SC2164 is "Use cd ... || exit in case cd fails"
+# shellcheck disable=SC2164
 GDAL_ROOT=$(cd $(dirname ${BASH_SOURCE[0]})/..; pwd)
 
 if [[ ! ${PATH,,} =~ $GDAL_ROOT/apps ]]; then


### PR DESCRIPTION
## What does this PR do?

Silences the last of the non-word splitting warnings from Shellcheck over `*.sh`. These two messages are still prevalent and can be cleaned up over time:

```
warning: Quote this to prevent word splitting. [SC2046]
note: Double quote to prevent globbing and word splitting. [SC2086]
```