### PR TITLE
Travis: Run Shellcheck (on 32-bit Trusty only)

### DIFF
--- a/gdal/ci/travis/trusty_32bit/script.sh
+++ b/gdal/ci/travis/trusty_32bit/script.sh
@@ -21,4 +21,4 @@ mv autotest/gcore/vsigs.py autotest/gcore/vsigs.py.disabled
 sudo i386 chroot "$chroot" sh -c "cd $PWD/autotest && python run_all.py"
 
 # Run Shellcheck
-shellcheck -e SC2086,SC2046 $(find . -name '*.sh' -a -not -name ltmain.sh -a -not -name gdal-bash-completion.sh)
+shellcheck -e SC2086,SC2046 $(find $PWD/gdal -name '*.sh' -a -not -name ltmain.sh -a -not -name gdal-bash-completion.sh)

--- a/gdal/ci/travis/trusty_32bit/script.sh
+++ b/gdal/ci/travis/trusty_32bit/script.sh
@@ -21,4 +21,4 @@ mv autotest/gcore/vsigs.py autotest/gcore/vsigs.py.disabled
 sudo i386 chroot "$chroot" sh -c "cd $PWD/autotest && python run_all.py"
 
 # Run Shellcheck
-shellcheck -e SC2086,SC2046 -f gcc $(find . -name *.sh -a -not -name ltmain.sh -a -not -name gdal-bash-completion.sh)
+shellcheck -e SC2086,SC2046 $(find . -name '*.sh' -a -not -name ltmain.sh -a -not -name gdal-bash-completion.sh)

--- a/gdal/ci/travis/trusty_32bit/script.sh
+++ b/gdal/ci/travis/trusty_32bit/script.sh
@@ -19,3 +19,6 @@ mv autotest/gcore/vsigs.py autotest/gcore/vsigs.py.disabled
 
 # Run all the Python autotests
 sudo i386 chroot "$chroot" sh -c "cd $PWD/autotest && python run_all.py"
+
+# Run Shellcheck
+shellcheck -e SC2086,SC2046 -f gcc $(find . -name *.sh -a -not -name ltmain.sh -a -not -name gdal-bash-completion.sh)


### PR DESCRIPTION
## What does this PR do?

Runs Shellcheck over the shell scripts to keep the shell scripts in order. Skip `SC2046` and `SC2086` for now.