### PR TITLE
Fix buffer overflow in GDALDefaultCSVFilename with GDAL_NO_HARDCODED_FIND

### DIFF
--- a/gdal/port/cpl_csv.cpp
+++ b/gdal/port/cpl_csv.cpp
@@ -1405,22 +1405,21 @@ const char * GDALDefaultCSVFilename( const char *pszBasename )
               "Failed to find file in GDALDefaultCSVFilename.  "
               "Returning original basename: %s",
               pszBasename );
-    strcpy( pTLSData->szPath, pszBasename );
+    CPLStrlcpy(pTLSData->szPath, pszBasename, sizeof(pTLSData->szPath));
     return pTLSData->szPath;
 #else
 
 #ifdef GDAL_PREFIX
   #ifdef MACOSX_FRAMEWORK
     strcpy( pTLSData->szPath, GDAL_PREFIX "/Resources/epsg_csv/" );
-    CPLStrlcat( pTLSData->szPath, pszBasename, sizeof(pTLSData->szPath) );
   #else
     strcpy( pTLSData->szPath, GDAL_PREFIX "/share/epsg_csv/" );
-    CPLStrlcat( pTLSData->szPath, pszBasename, sizeof(pTLSData->szPath) );
   #endif
 #else
     strcpy( pTLSData->szPath, "/usr/local/share/epsg_csv/" );
-    CPLStrlcat( pTLSData->szPath, pszBasename, sizeof(pTLSData->szPath) );
 #endif  // GDAL_PREFIX
+
+    CPLStrlcat( pTLSData->szPath, pszBasename, sizeof(pTLSData->szPath) );
 
     VSILFILE *fp = VSIFOpenL( pTLSData->szPath, "rt" );
     if( fp == nullptr )


### PR DESCRIPTION
Found with ASan and autofuzz.

Also, stop duplicating CPLStrlcat calls in the hardcoded find case.