### PR TITLE
morphToESRI: The projection node may be deleted, so make and use a copy of the name.

### DIFF
--- a/gdal/ogr/ogr_srs_esri.cpp
+++ b/gdal/ogr/ogr_srs_esri.cpp
@@ -1886,7 +1886,7 @@ OGRErr OGRSpatialReference::morphToESRI()
 
         // pszProjection might be deleted in DeleteParamBasedOnPrjName,
         // so make and use a copy.
-        const string osProjection(pszProjection);
+        const std::string osProjection(pszProjection);
         DeleteParamBasedOnPrjName(
             this, osProjection.c_str(),
             apszDeleteParametersBasedOnProjection);

--- a/gdal/ogr/ogr_srs_esri.cpp
+++ b/gdal/ogr/ogr_srs_esri.cpp
@@ -40,6 +40,7 @@
 #include <cstring>
 #include <algorithm>
 #include <limits>
+#include <string>
 
 #include "cpl_conv.h"
 #include "cpl_csv.h"

--- a/gdal/ogr/ogr_srs_esri.cpp
+++ b/gdal/ogr/ogr_srs_esri.cpp
@@ -1884,17 +1884,20 @@ OGRErr OGRSpatialReference::morphToESRI()
           }
         }
 
+        // pszProjection might be deleted in DeleteParamBasedOnPrjName,
+        // so make and use a copy.
+        const string osProjection(pszProjection);
         DeleteParamBasedOnPrjName(
-            this, pszProjection,
+            this, osProjection.c_str(),
             apszDeleteParametersBasedOnProjection);
         AddParamBasedOnPrjName(
-            this, pszProjection,
+            this, osProjection.c_str(),
             apszAddParametersBasedOnProjection);
         RemapPValuesBasedOnProjCSAndPName(
-            this, pszProjection,
+            this, osProjection.c_str(),
             apszParamValueMapping);
         RemapPNamesBasedOnProjCSAndPName(
-            this, pszProjection,
+            this, osProjection.c_str(),
             apszParamNameMapping,
             true /* to ESRI */ );
       }


### PR DESCRIPTION
ogr_srs_esri_fuzzer - Heap Use-After-Free at strncasecmp

Input was: PROJCS(PARAMETER(latitude_of_center[[(Projection(Miller_Cylindrical))]],GEOGCS())

Found with autofuzz ASan