### PR TITLE
VSIZipFilesystemHandler::Open: Fix leaks of poVirtualHandle

### DIFF
--- a/gdal/port/cpl_vsil_gzip.cpp
+++ b/gdal/port/cpl_vsil_gzip.cpp
@@ -2195,6 +2195,7 @@ VSIVirtualHandle* VSIZipFilesystemHandler::Open( const char *pszFilename,
         CPLError(CE_Failure, CPLE_AppDefined,
                  "cpl_unzOpenCurrentFile() failed");
         delete poReader;
+        delete poVirtualHandle;
         return nullptr;
     }
 
@@ -2208,6 +2209,7 @@ VSIVirtualHandle* VSIZipFilesystemHandler::Open( const char *pszFilename,
                  "cpl_unzGetCurrentFileInfo() failed");
         cpl_unzCloseCurrentFile(unzF);
         delete poReader;
+        delete poVirtualHandle;
         return nullptr;
     }
 


### PR DESCRIPTION
Found with autofuzz using openfilegdbdatasource_fuzzer b/76119614