### PR TITLE
RMF: Add optional projection import/export from EPSG code

### DIFF
--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1853,27 +1853,10 @@ do {                                                                    \
                                  poDS->sExtHeader.nEllipsoid, padfPrjParams );
         }
 
-        if(poDS->sHeader.iEPSGCode > RMF_EPSG_MIN_CODE)
+        if(poDS->sHeader.iEPSGCode > RMF_EPSG_MIN_CODE &&
+           (OGRERR_NONE != res || oSRS.IsLocal()))
         {
-            if(OGRERR_NONE != res || oSRS.IsLocal())
-            {
-                oSRS.importFromEPSG(poDS->sHeader.iEPSGCode);
-            }
-            else
-            {
-                OGRSpatialReference oEPSG;
-                if(OGRERR_NONE != oEPSG.importFromEPSG(poDS->sHeader.iEPSGCode) &&
-                   oSRS.IsProjected() && oEPSG.IsProjected())
-                {
-                    const char* pszProjSrs = oSRS.GetAttrValue("PROJECTION");
-                    const char* pszProjEPSG = oEPSG.GetAttrValue("PROJECTION");
-                    if(pszProjSrs != nullptr && pszProjEPSG != nullptr &&
-                       EQUAL(pszProjSrs, pszProjEPSG))
-                    {
-                        oSRS.SetAuthority(nullptr, "EPSG", poDS->sHeader.iEPSGCode);
-                    }
-                }
-            }
+            oSRS.importFromEPSG(poDS->sHeader.iEPSGCode);
         }
 
         if( poDS->pszProjection )

--- a/gdal/frmts/rmf/rmfdataset.h
+++ b/gdal/frmts/rmf/rmfdataset.h
@@ -86,6 +86,7 @@ typedef struct
     GUInt32     nTileTblSize;                   // tile offsets/sizes table
     GInt32      iMapType;
     GInt32      iProjection;
+    GInt32      iEPSGCode;
     double      dfScale;
     double      dfResolution;
     double      dfPixelSize;


### PR DESCRIPTION
Latest versions of GIS Panorama support EPSG code as projection reference. 