### PR TITLE
Fix JNI library installation

### DIFF
--- a/gdal/swig/java/GNUmakefile
+++ b/gdal/swig/java/GNUmakefile
@@ -56,13 +56,13 @@ generate: makedir ${WRAPPERS}
 build: generate ${JAVA_OBJECTS} ${JAVA_MODULES}
 ifeq ($(HAVE_LIBTOOL),yes)
 
-	if [ -f ".libs/libgdaljni.so" ] ; then \
+	if [ -f ".libs/libgdalalljni.so" ] ; then \
 		cp .libs/*.so . ; \
 	fi
 
 	echo "$(wildcard .libs/*.dylib)"
 
-	if [ -f ".libs/libgdaljni.dylib" ] ; then \
+	if [ -f ".libs/libgdalalljni.dylib" ] ; then \
 		cp .libs/*.dylib . ; \
 	fi
 


### PR DESCRIPTION
## What does this PR do?

When the new single JNI library introduced in #286, the Makefile was not fully updated to copy the new libraries from the .lib dir into the source directory for later copying during the install phase. This patch addresses that.

## What are related issues/pull requests?

#286
First reported by a user via the Homebrew tap. OSGeo/homebrew-osgeo4mac#397

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Tested on MacOS High Sierra.