### PR TITLE
Fix #716: 12 bit JPEG-in-TIFF support

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -25197,7 +25197,18 @@ fi
 TIFF_JPEG12_ENABLED=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for jpeg12" >&5
 $as_echo_n "checking for jpeg12... " >&6; }
-if test "$with_jpeg12" = yes ; then
+if test "$with_jpeg12" =  no ; then
+    JPEG12_ENABLED=no
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled by user" >&5
+$as_echo "disabled by user" >&6; }
+
+elif test "$JPEG_SETTING" = "internal" -a "$TIFF_SETTING" = "internal" ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: enabled" >&5
+$as_echo "enabled" >&6; }
+    JPEG12_ENABLED=yes
+    TIFF_JPEG12_ENABLED=yes
+
+elif test "$with_jpeg12" = yes ; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: enabled" >&5
 $as_echo "enabled" >&6; }
     JPEG12_ENABLED=yes
@@ -25219,21 +25230,10 @@ $as_echo "$as_me: WARNING: Internal libjpeg12 has not the same ABI as libjpeg 8 
     fi
     rm -f check_jpeg_abi.*
 
-elif test x"$with_jpeg12" = x ; then
-    if test "$JPEG_SETTING" = "internal" -a "$TIFF_SETTING" = "internal" ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: enabled" >&5
-$as_echo "enabled" >&6; }
-      JPEG12_ENABLED=yes
-      TIFF_JPEG12_ENABLED=yes
-    else
-      JPEG12_ENABLED=no
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled, libjpeg or libtiff not internal" >&5
-$as_echo "disabled, libjpeg or libtiff not internal" >&6; }
-    fi
 else
     JPEG12_ENABLED=no
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled by user" >&5
-$as_echo "disabled by user" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled, libjpeg or libtiff not internal" >&5
+$as_echo "disabled, libjpeg or libtiff not internal" >&6; }
 fi
 
 JPEG12_ENABLED=$JPEG12_ENABLED

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -1864,7 +1864,16 @@ AC_ARG_WITH([jpeg12],
 
 TIFF_JPEG12_ENABLED=no
 AC_MSG_CHECKING([for jpeg12])
-if test "$with_jpeg12" = yes ; then
+if test "$with_jpeg12" =  no ; then
+    JPEG12_ENABLED=no
+    AC_MSG_RESULT([disabled by user])
+
+elif test "$JPEG_SETTING" = "internal" -a "$TIFF_SETTING" = "internal" ; then
+    AC_MSG_RESULT([enabled])
+    JPEG12_ENABLED=yes
+    TIFF_JPEG12_ENABLED=yes
+
+elif test "$with_jpeg12" = yes ; then
     AC_MSG_RESULT([enabled])
     JPEG12_ENABLED=yes
 
@@ -1884,18 +1893,9 @@ if test "$with_jpeg12" = yes ; then
     fi
     rm -f check_jpeg_abi.*
 
-elif test x"$with_jpeg12" = x ; then
-    if test "$JPEG_SETTING" = "internal" -a "$TIFF_SETTING" = "internal" ; then
-      AC_MSG_RESULT([enabled])
-      JPEG12_ENABLED=yes
-      TIFF_JPEG12_ENABLED=yes
-    else
-      JPEG12_ENABLED=no
-      AC_MSG_RESULT([disabled, libjpeg or libtiff not internal])
-    fi
 else
     JPEG12_ENABLED=no
-    AC_MSG_RESULT([disabled by user])
+    AC_MSG_RESULT([disabled, libjpeg or libtiff not internal])
 fi
 
 AC_SUBST(JPEG12_ENABLED,$JPEG12_ENABLED)


### PR DESCRIPTION
## What does this PR do?

Enable 12 bit JPEG-in-TIFF support when using internal tiff and jpeg librairies.

I have just changed the "if elif" statements order.

## What are related issues/pull requests?

Fix #716

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
