### PR TITLE
Catch a NaN in FileGDBDoubleDateToOGRDate to prevent undefined behavior.

### DIFF
--- a/gdal/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
+++ b/gdal/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
@@ -1373,7 +1373,8 @@ int FileGDBDoubleDateToOGRDate(double dfVal, OGRField* psField)
 {
     // 25569: Number of days between 1899/12/30 00:00:00 and 1970/01/01 00:00:00
     double dfSeconds = (dfVal - 25569.0) * 3600.0 * 24.0;
-    if( dfSeconds < static_cast<double>(std::numeric_limits<GIntBig>::min())+1000 ||
+    if( CPLIsNan(dfSeconds) ||
+        dfSeconds < static_cast<double>(std::numeric_limits<GIntBig>::min())+1000 ||
         dfSeconds > static_cast<double>(std::numeric_limits<GIntBig>::max())-1000 )
     {
         CPLError(CE_Failure, CPLE_NotSupported,


### PR DESCRIPTION
This fix reveals a separate leak.  I am letting the fuzzers find that
and file another bug on me.  The leak is not found testing with asan,
only with asan in fuzzing mode.

Found with autofuzz.  float-cast-overflow