### PR TITLE
GTiff: save XMP on field TIFFTAG_XMLPACKET

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -8258,6 +8258,67 @@ def tiff_write_180_lerc_separate():
     return 'success'
 
 ###############################################################################
+# Test set XMP metadata
+
+
+def tiff_write_181_xmp():
+
+    src_ds = gdal.Open('data/utmsmall.tif')
+
+    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_181.tif', src_ds)
+    src_ds = None
+
+    xmp_ds = gdal.Open('../gdrivers/data/byte_with_xmp.tif')
+    xmp = xmp_ds.GetMetadata('xml:XMP')
+    xmp_ds = None
+    if 'W5M0MpCehiHzreSzNTczkc9d' not in xmp[0]:
+        gdaltest.post_reason('Wrong input file without XMP')
+        return 'fail'
+
+    new_ds.SetMetadata(xmp, 'xml:XMP')
+    new_ds = None
+
+    # hopefully it's closed now!
+
+    new_ds = gdal.Open('tmp/test_181.tif')
+    read_xmp = new_ds.GetMetadata('xml:XMP')
+    if not read_xmp or 'W5M0MpCehiHzreSzNTczkc9d' not in read_xmp[0]:
+        gdaltest.post_reason('No XMP data written in output file')
+        return 'fail'
+    new_ds = None
+
+    gdaltest.tiff_drv.Delete('tmp/test_181.tif')
+
+    return 'success'
+
+###############################################################################
+# Test delete XMP from a dataset
+
+
+def tiff_write_182_xmp_delete():
+
+    shutil.copyfile('../gdrivers/data/byte_with_xmp.tif', 'tmp/test_182.tif')
+
+    chg_ds = gdal.Open('tmp/test_182.tif', gdal.GA_Update)
+    read_xmp = chg_ds.GetMetadata('xml:XMP')
+    if not read_xmp or 'W5M0MpCehiHzreSzNTczkc9d' not in read_xmp[0]:
+        gdaltest.post_reason('No XMP data written in output file')
+        return 'fail'
+    chg_ds.SetMetadata(None, 'xml:XMP')
+    chg_ds = None
+
+    again_ds = gdal.Open('tmp/test_182.tif')
+    read_xmp = again_ds.GetMetadata('xml:XMP')
+    if read_xmp:
+        gdaltest.post_reason('XMP data not removed')
+        return 'fail'
+    again_ds = None
+
+    gdaltest.tiff_drv.Delete('tmp/test_182.tif')
+
+    return 'success'
+
+###############################################################################
 # Ask to run again tests with GDAL_API_PROXY=YES
 
 
@@ -8475,6 +8536,8 @@ gdaltest_list = [
     tiff_write_178_lerc_with_alpha_0_and_255,
     tiff_write_179_lerc_data_types,
     tiff_write_180_lerc_separate,
+    tiff_write_181_xmp,
+    tiff_write_182_xmp_delete,
     # tiff_write_api_proxy,
     tiff_write_cleanup]
 

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -18244,6 +18244,12 @@ CPLErr GTiffDataset::SetMetadata( char ** papszMD, const char *pszDomain )
         }
     }
 
+    if( EQUAL(pszDomain, "xml:XMP") && papszMD && *papszMD )
+    {
+        int nTagSize = strlen(*papszMD) + 1;
+        TIFFSetField( hTIFF, TIFFTAG_XMLPACKET, nTagSize, *papszMD );
+    }
+
     return oGTiffMDMD.SetMetadata( papszMD, pszDomain );
 }
 

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -11195,6 +11195,8 @@ static void WriteMDMetadata( GDALMultiDomainMetadata *poMDMD, TIFF *hTIFF,
         if( EQUAL(papszDomainList[iDomain], "xml:ESRI")
             && CPLTestBool(CPLGetConfigOption( "ESRI_XML_PAM", "NO" )) )
             continue;  // Handled elsewhere.
+        if( EQUAL(papszDomainList[iDomain], "xml:XMP") )
+            continue;  // Handled in SetMetadata.
 
         if( STARTS_WITH_CI(papszDomainList[iDomain], "xml:") )
             bIsXML = true;
@@ -18244,10 +18246,23 @@ CPLErr GTiffDataset::SetMetadata( char ** papszMD, const char *pszDomain )
         }
     }
 
-    if( EQUAL(pszDomain, "xml:XMP") && papszMD && *papszMD )
+    if( pszDomain != nullptr && EQUAL(pszDomain, "xml:XMP") )
     {
-        int nTagSize = strlen(*papszMD) + 1;
-        TIFFSetField( hTIFF, TIFFTAG_XMLPACKET, nTagSize, *papszMD );
+        if( papszMD != nullptr && *papszMD != nullptr )
+        {
+            int nTagSize = static_cast<int>(strlen(*papszMD));
+            TIFFSetField( hTIFF, TIFFTAG_XMLPACKET, nTagSize, *papszMD );
+        }
+        else
+        {
+#ifdef HAVE_UNSETFIELD
+            TIFFUnsetField( hTIFF, TIFFTAG_XMLPACKET );
+#else
+            CPLDebug(
+                "GTiff",
+                "TIFFUnsetField() not supported, xml:XMP may not be cleared." );
+#endif
+        }
     }
 
     return oGTiffMDMD.SetMetadata( papszMD, pszDomain );


### PR DESCRIPTION
## What does this PR do?
This PR saves the XMP xml data in the field `TIFFTAG_XMLPACKET` when  `GTiffDataset::SetMetadata` is called with the domain `xml:XMP`.

The method `GTiffDataset::OpenOffset` reads the field `TIFFTAG_XMLPACKET` and sets the value on the metadata domain `xml:XMP`. That gives the user access to the XMP xml string (and read/parse it on their own).

However, there is not way to write the XMP data in the field `TIFFTAG_XMLPACKET`. Third party software (like Exiv2) is not able then to read the XMP from a tiff file created with GDAL.

## What are related issues/pull requests?
None

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
