### PR TITLE
Apps: Fix  compile error of non default app

### DIFF
--- a/gdal/apps/gdalasyncread.cpp
+++ b/gdal/apps/gdalasyncread.cpp
@@ -29,6 +29,7 @@
 #include "cpl_vsi.h"
 #include "cpl_conv.h"
 #include "cpl_string.h"
+#include "gdal_version"
 #include "gdal_priv.h"
 #include "ogr_spatialref.h"
 


### PR DESCRIPTION
Here is a missing modification for https://github.com/OSGeo/gdal/commit/9bae05435e199592be48a2a6c8ef5f649fa5d113 

apps/gdalasyncread compilation fails with GDAL_RELEASE_NAME declaration not found error.

## What does this PR do?
Fix compile error

## What are related issues/pull requests?

## Tasklist

 - [x] compile test on linux
 - [ ] Add it as compile target for Travis-CI test
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

