### PR TITLE
Update the keyword GEOTIFF to GEO_TIFF in the Earth Engine data access API.

### DIFF
--- a/gdal/frmts/eeda/eedaidataset.cpp
+++ b/gdal/frmts/eeda/eedaidataset.cpp
@@ -1179,7 +1179,7 @@ bool GDALEEDAIDataset::ComputeQueryStrategy()
             {
                 if( GetRasterBand(i)->GetRasterDataType() != GDT_Byte )
                 {
-                    m_osPixelEncoding = "GEOTIFF";
+                    m_osPixelEncoding = "GEO_TIFF";
                 }
             }
         }
@@ -1651,7 +1651,7 @@ void GDALRegister_EEDAI()
 "       <Value>AUTO</Value>"
 "       <Value>PNG</Value>"
 "       <Value>JPEG</Value>"
-"       <Value>GEOTIFF</Value>"
+"       <Value>GEO_TIFF</Value>"
 "       <Value>AUTO_PNG_JPEG</Value>"
 "       <Value>NPY</Value>"
 "   </Option>"

--- a/gdal/frmts/eeda/frmt_eedai.html
+++ b/gdal/frmts/eeda/frmt_eedai.html
@@ -27,7 +27,7 @@ The following open options are available :
 <li><b>ASSET</b>=string: To specify the asset if not specified in
 the connection string.</li>
 <li><b>BANDS</b>=bandname1[,bandnameX]*: Comma separated list of band names.</li>
-<li><b>PIXEL_ENCODING</b>=AUTO/PNG/JPEG/AUTO_PNG_JPEG/GEOTIFF/NPY: Format in which to
+<li><b>PIXEL_ENCODING</b>=AUTO/PNG/JPEG/AUTO_PNG_JPEG/GEO_TIFF/NPY: Format in which to
 request pixels.</li>
 <li><b>BLOCK_SIZE</b>=integer: Size of a GDAL block, which is the minimum unit
 to query pixels. Default is 256.</li>


### PR DESCRIPTION
It looks like this last-minute change to the API fell through the cracks here.