### PR TITLE
Vagrant: change base image to trusty

### DIFF
--- a/gdal/scripts/vagrant/gdal.sh
+++ b/gdal/scripts/vagrant/gdal.sh
@@ -12,7 +12,11 @@ fi
 #NUMTHREADS=1 # disable MP
 export NUMTHREADS
 
-cd /vagrant
+rsync -a /vagrant/gdal/ /home/vagrant/gnumake-build-gcc4.8
+echo rsync -a /vagrant/gdal/ /home/vagrant/gnumake-build-gcc4.8/ > /home/vagrant/gnumake-build-gcc4.8/resync.sh
+chmod +x /home/vagrant/gnumake-build-gcc4.8/resync.sh
+cd gnumake-build-gcc4.8
+
 #  --with-ecw=/usr/local --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local --with-fgdb=/usr/local
 ./configure  --prefix=/usr --without-libtool --enable-debug --with-jpeg12 \
             --with-python --with-poppler \

--- a/gdal/scripts/vagrant/postgis.sh
+++ b/gdal/scripts/vagrant/postgis.sh
@@ -4,8 +4,8 @@
 set -o errexit
 set -o xtrace
 
-sudo sed -i  's/md5/trust/' /etc/postgresql/9.1/main/pg_hba.conf
-sudo sed -i  's/peer/trust/' /etc/postgresql/9.1/main/pg_hba.conf
+sudo sed -i  's/md5/trust/' /etc/postgresql/9.3/main/pg_hba.conf
+sudo sed -i  's/peer/trust/' /etc/postgresql/9.3/main/pg_hba.conf
 
 sudo ln -s /usr/lib/libgdal.so.2 /usr/lib/libgdal.so.1
 sudo service postgresql restart


### PR DESCRIPTION
- move Vagrantfile to project top
- change base image to Ubuntu trusty
- rsync sources to /home/vagrant
  in order to keep host source clean
- Use ubuntu mirror site and dynamic selection.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What does this PR do?
Update Vagrant script to use Trusty as base image 
Because  Precise Pangolin  had been  end of life in April 2017.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
