### PR TITLE
avc: fix non existent member reference

### DIFF
--- a/gdal/ogr/ogrsf_frmts/avc/avc_e00write.cpp
+++ b/gdal/ogr/ogrsf_frmts/avc/avc_e00write.cpp
@@ -703,7 +703,7 @@ void  _AVCE00WriteCloseCoverFile(AVCE00WritePtr psInfo)
      *----------------------------------------------------------------*/
     if (psInfo->eCurFileType == AVCFilePRJ)
     {
-        AVCBinWriteObject(psInfo->hFile, psInfo->hParseInfo->cur.papszPrj);
+        AVCBinWriteObject(psInfo->hFile, psInfo->hParseInfo->aosPrj.List());
     }
 
     AVCBinWriteClose(psInfo->hFile);


### PR DESCRIPTION
avc: fix non existent member reference compile error

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What does this PR do?
Fix compile error

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
