### PR TITLE
autotest: support out of source tut tests

### DIFF
--- a/autotest/cpp/gdal_unit_test.cpp
+++ b/autotest/cpp/gdal_unit_test.cpp
@@ -34,6 +34,7 @@
 #include "gdal.h"
 #include "ogr_api.h"
 #include "ogrsf_frmts.h"
+#include "test_data.h"
 
 #include <tut_reporter.hpp>
 
@@ -45,9 +46,8 @@ namespace tut
     test_runner_singleton runner;
 
     // Common test data path
-    // Customize these paths if you need.
-    std::string const common::data_basedir("data");
-    std::string const common::tmp_basedir("tmp");
+    std::string const common::data_basedir(TUT_ROOT_DATA_DIR);
+    std::string const common::tmp_basedir(TUT_ROOT_TMP_DIR);
 
     static void check_test_group(char const* name)
     {

--- a/autotest/cpp/test_data.h
+++ b/autotest/cpp/test_data.h
@@ -28,11 +28,29 @@
 
 // Use GDAL_TEST_ROOT_DIR for the root directory of test project's source
 #ifdef GDAL_TEST_ROOT_DIR
-#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR "/gcore/data/"
-#define GDRIVERS_DIR GDAL_TEST_ROOT_DIR "/gdrivers/"
+
+#ifndef SEP
+#if defined(WIN32)
+#define SEP "\\"
 #else
+#define SEP "/"
+#endif
+#endif
+
+#define GCORE_DATA_DIR GDAL_TEST_ROOT_DIR SEP "gcore" SEP "data" SEP
+#define GDRIVERS_DIR GDAL_TEST_ROOT_DIR SEP "gdrivers" SEP
+
+#define TUT_ROOT_DATA_DIR GDAL_TEST_ROOT_DIR SEP "cpp" SEP "data"
+#define TUT_ROOT_TMP_DIR GDAL_TEST_ROOT_DIR  SEP "cpp" SEP "tmp"
+
+#else
+
 #define GCORE_DATA_DIR "../gcore/data/"
 #define GDRIVERS_DIR "../gdrivers/"
+
+#define TUT_ROOT_DATA_DIR "data"
+#define TUT_ROOT_TMP_DIR "tmp"
+
 #endif
 
 #endif //GDAL_TEST_DATA_H

--- a/autotest/cpp/tut/tut_gdal.h
+++ b/autotest/cpp/tut/tut_gdal.h
@@ -36,9 +36,9 @@ namespace tut
 {
 
 #if defined(WIN32)
-#define SEP '\\'
+#define SEP "\\"
 #else
-#define SEP '/'
+#define SEP "/"
 #endif
 
 //


### PR DESCRIPTION
Support out of source compilation

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What does this PR do?
tut test assumes run it in source.
This PR allows out of source execution.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
