### PR TITLE
Vagrant: change libkml repository

### DIFF
--- a/gdal/scripts/vagrant/libkml.sh
+++ b/gdal/scripts/vagrant/libkml.sh
@@ -12,9 +12,11 @@ fi
 #NUMTHREADS=1 # disable MP
 export NUMTHREADS
 
-#svn checkout http://libkml.googlecode.com/svn/trunk/ libkml-read-only
-#cd libkml-read-only
-#git clone https://github.com/google/libkml.git
-svn co https://github.com/google/libkml/trunk libkml
+git clone https://github.com/libkml/libkml.git libkml
+mkdir libkml/build
+cd libkml/build
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake --build .
+sudo cmake --build . --target install
 
-(cd libkml && ./autogen.sh && ./configure && make -j $NUMTHREADS; sudo make install)
+cd ../..


### PR DESCRIPTION
github.com/libkml/libkml is considered as a offical source
according to following comment from google developer;
https://github.com/google/libkml/issues/4#issuecomment-390439274

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What does this PR do?
Update vagrant script to use github.com/libkml/libkml rather than github.com/google/libkml.

