### PR TITLE
RMF: Fix issues #779 & #780

### DIFF
--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1264,6 +1264,21 @@ do {                                                                    \
         return nullptr;
     }
 
+    GUInt64 nMaxTileBits = 2ULL *
+                           static_cast<GUInt64>(poDS->sHeader.nTileWidth) *
+                           static_cast<GUInt64>(poDS->sHeader.nTileHeight) *
+                           static_cast<GUInt64>(poDS->sHeader.nBitDepth);
+    if(nMaxTileBits > static_cast<GUInt64>(std::numeric_limits<GUInt32>::max()))
+    {
+        CPLError(CE_Warning, CPLE_IllegalArg,
+                 "Invalid tile size. Width %lu, height %lu, bit depth %lu.",
+                 static_cast<unsigned long>(poDS->sHeader.nTileWidth),
+                 static_cast<unsigned long>(poDS->sHeader.nTileHeight),
+                 static_cast<unsigned long>(poDS->sHeader.nBitDepth));
+        delete poDS;
+        return nullptr;
+    }
+
     if( poParentDS != nullptr )
     {
         if( 0 != memcmp( poDS->sHeader.bySignature,

--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1539,7 +1539,11 @@ do {                                                                    \
                 poDS->nBands = 1;
                 break;
             default:
-                break;
+                CPLError(CE_Warning, CPLE_IllegalArg,
+                         "Invalid RSW bit depth %lu.",
+                         static_cast<unsigned long>(poDS->sHeader.nBitDepth));
+                delete poDS;
+                return nullptr;
         }
         eType = GDT_Byte;
     }
@@ -1547,13 +1551,29 @@ do {                                                                    \
     {
         poDS->nBands = 1;
         if( poDS->sHeader.nBitDepth == 8 )
+        {
             eType = GDT_Byte;
+        }
         else if( poDS->sHeader.nBitDepth == 16 )
+        {
             eType = GDT_Int16;
+        }
         else if( poDS->sHeader.nBitDepth == 32 )
+        {
             eType = GDT_Int32;
+        }
         else if( poDS->sHeader.nBitDepth == 64 )
+        {
             eType = GDT_Float64;
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_IllegalArg,
+                     "Invalid MTW bit depth %lu.",
+                     static_cast<unsigned long>(poDS->sHeader.nBitDepth));
+            delete poDS;
+            return nullptr;
+        }
     }
 
     if( poDS->sHeader.nTileWidth == 0 || poDS->sHeader.nTileWidth > INT_MAX ||

--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1256,6 +1256,14 @@ do {                                                                    \
         RMF_READ_ULONG( abyHeader, poDS->sHeader.nExtHdrSize, 316 );
     }
 
+    if(poDS->sHeader.nTileTblSize % (sizeof(GUInt32)*2))
+    {
+        CPLError( CE_Warning, CPLE_IllegalArg,
+                  "Invalid tile table size." );
+        delete poDS;
+        return nullptr;
+    }
+
     if( poParentDS != nullptr )
     {
         if( 0 != memcmp( poDS->sHeader.bySignature,

--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -1279,6 +1279,20 @@ do {                                                                    \
         return nullptr;
     }
 
+    if(poDS->sHeader.nLastTileWidth > poDS->sHeader.nTileWidth ||
+       poDS->sHeader.nLastTileHeight > poDS->sHeader.nTileHeight)
+    {
+        CPLError(CE_Warning, CPLE_IllegalArg,
+                 "Invalid last tile size %lu x %lu. "
+                 "It can't be greater than %lu x %lu.",
+                 static_cast<unsigned long>(poDS->sHeader.nLastTileWidth),
+                 static_cast<unsigned long>(poDS->sHeader.nLastTileHeight),
+                 static_cast<unsigned long>(poDS->sHeader.nTileWidth),
+                 static_cast<unsigned long>(poDS->sHeader.nTileHeight));
+        delete poDS;
+        return nullptr;
+    }
+
     if( poParentDS != nullptr )
     {
         if( 0 != memcmp( poDS->sHeader.bySignature,


### PR DESCRIPTION
* Main  buffer overflow fix 308e5fa
* Added tile table check (pointed by GCC ASAN) 6bd647d
* Added more header values check. Many of the values generated by oss-fuzz are random and can lead to buffer overflow next time. (74eea35 , e7f6b55, ecac52e)