### PR TITLE
Vagrant tweaks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,9 +46,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     lxc.customize 'aa_allow_incomplete', 1
     lxc.container_name = "gdal-vagrant"
     # allow android adb connection from guest
-    #config.vm.synced_folder('/dev/bus', '/dev/bus')
+    #ovrd.vm.synced_folder('/dev/bus', '/dev/bus')
     # allow runnng wine inside lxc
-    config.vm.synced_folder('/tmp/.X11-unix/', '/tmp/.X11-unix/')
+    ovrd.vm.synced_folder('/tmp/.X11-unix/', '/tmp/.X11-unix/')
   end
 
   config.vm.provider :hyperv do |hyperv,ovrd|

--- a/gdal/scripts/vagrant/gdal.sh
+++ b/gdal/scripts/vagrant/gdal.sh
@@ -18,15 +18,29 @@ echo rsync -a /vagrant/gdal/ /home/vagrant/gnumake-build-gcc4.8/ > /home/vagrant
 echo rsync -a /vagrant/autotest/ /home/vagrant/gnumake-build-gcc4.8/autotest >> /home/vagrant/gnumake-build-gcc4.8/resync.sh
 
 chmod +x /home/vagrant/gnumake-build-gcc4.8/resync.sh
-cd gnumake-build-gcc4.8
+cd /home/vagrant/gnumake-build-gcc4.8
 
-#  --with-ecw=/usr/local --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local --with-fgdb=/usr/local
+export CCACHE_CPP2=yes
+
+ARCH_FLAGS=""
+AVX2_AVAIL=1
+grep avx2 /proc/cpuinfo >/dev/null || AVX2_AVAIL=0
+if [[ "${AVX2_AVAIL}" == "1" ]]; then
+        ARCH_FLAGS="-mavx2"
+        echo "AVX2 available on CPU"
+else
+        echo "AVX2 not available on CPU."
+        grep flags /proc/cpuinfo | head -n 1
+fi
+
+CFLAGS=$ARCH_FLAGS CXXFLAGS=$ARCH_FLAGS CC="ccache gcc" CXX="ccache g++" LDFLAGS="-lstdc++" \
 ./configure  --prefix=/usr --without-libtool --enable-debug --with-jpeg12 \
             --with-python --with-poppler \
             --with-podofo --with-spatialite --with-java --with-mdb \
             --with-jvm-lib-add-rpath --with-epsilon --with-gta \
             --with-mysql --with-liblzma --with-webp --with-libkml \
             --with-openjpeg=/usr/local --with-armadillo
+#  --with-ecw=/usr/local --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local --with-fgdb=/usr/local
 
 make clean >/dev/null
 make -j $NUMTHREADS


### PR DESCRIPTION
## What does this PR do?

### 1. Fixes the default vagrant config for Virtualbox under OSX

https://github.com/OSGeo/gdal/blob/9ec6971ca0dd41df454461387954def4f904cc60/Vagrantfile#L51

if the folder doesn't exist (eg. Virtualbox on OSX, no LXC/HyperV) then you get:

```
$ vagrant up
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* The host path of the shared folder is missing: /tmp/.X11-unix/
```

The patch swaps it to use the override so it's LXC-specific rather than adding to the shared config object.

Certainly fixes it for my Virtualbox setup, but I don't have an LXC setup atm. @miurahr do you?

### 2. Enables ccache for vagrant builds

Just use the same approach as the [travis config](https://github.com/OSGeo/gdal/blob/master/gdal/ci/travis/trusty_clang/install.sh)

ccache was already installed, just wasn't being used. I can't see any reason _not_ to use it?

## What are related issues/pull requests?

There's been a few recent tweaks to Vagrant setup by @miurahr.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Vagrant 2.0.0, Virtualbox 5.1.28, OSX 10.13.6

