### PR TITLE
Introduce "setstats" option in gdal_edit.py

### DIFF
--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -282,10 +282,68 @@ def test_gdal_edit_py_5():
     return 'success'
 
 ###############################################################################
-# Test -scale and -offset
+# Test -setstats
 
 
 def test_gdal_edit_py_6():
+
+    script_path = test_py_scripts.get_py_script('gdal_edit')
+    if script_path is None:
+        return 'skip'
+
+    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+
+    # original values should be min=74, max=255, mean=126.765 StdDev=22.928470838676
+    test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -setstats None None None None")
+
+    ds = gdal.Open('tmp/test_gdal_edit_py.tif')
+    stat_min = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_MINIMUM')
+    if stat_min is None or float(stat_min) != 74:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    stat_max = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_MAXIMUM')
+    if stat_max is None or float(stat_max) != 255:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    stat_mean = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_MEAN')
+    if stat_mean is None or abs(float(stat_mean) - 126.765)>0.001:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    stat_stddev = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_STDDEV')
+    if stat_stddev is None or abs(float(stat_stddev) - 22.928)>0.001:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    
+    ds = None
+
+    test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -setstats 22 217 100 30")
+
+    ds = gdal.Open('tmp/test_gdal_edit_py.tif')
+    stat_min = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_MINIMUM')
+    if stat_min is None or float(stat_min) != 22:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    stat_max = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_MAXIMUM')
+    if stat_max is None or float(stat_max) != 217:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    stat_mean = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_MEAN')
+    if stat_mean is None or float(stat_mean) != 100:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    stat_stddev = ds.GetRasterBand(1).GetMetadataItem('STATISTICS_STDDEV')
+    if stat_stddev is None or float(stat_stddev) != 30:
+        gdaltest.post_reason('fail')
+        return 'fail'
+    ds = None
+    
+    print(stat_min,stat_max,stat_mean,stat_stddev)
+    return 'success'
+
+###############################################################################
+# Test -scale and -offset
+
+def test_gdal_edit_py_7():
 
     script_path = test_py_scripts.get_py_script('gdal_edit')
     if script_path is None:
@@ -309,7 +367,7 @@ def test_gdal_edit_py_6():
 # Test -colorinterp_X
 
 
-def test_gdal_edit_py_7():
+def test_gdal_edit_py_8():
 
     script_path = test_py_scripts.get_py_script('gdal_edit')
     if script_path is None:

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -412,6 +412,7 @@ gdaltest_list = [
     test_gdal_edit_py_5,
     test_gdal_edit_py_6,
     test_gdal_edit_py_7,
+    test_gdal_edit_py_8,
     test_gdal_edit_py_cleanup,
 ]
 

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -337,7 +337,6 @@ def test_gdal_edit_py_6():
         return 'fail'
     ds = None
     
-    print(stat_min,stat_max,stat_mean,stat_stddev)
     return 'success'
 
 ###############################################################################

--- a/gdal/swig/python/scripts/gdal_edit.dox
+++ b/gdal/swig/python/scripts/gdal_edit.dox
@@ -71,8 +71,8 @@ Calculate and store band statistics.</dd>
 
 <dt> <b>-setstats</b>min max mean stddev:</dt><dd> (GDAL >= 2.4)
 Store user-defined values for band statistics (minimum, maximum, mean and standard deviation).
-If any of the values is set to -1, the real statistics are calclulated from the file
-and the ones set to -1 are used from the real statistics.</dd>
+If any of the values is set to None, the real statistics are calclulated from the file
+and the ones set to None are used from the real statistics.</dd>
 
 <dt> <b>-approx_stats</b></dt>:<dd> (GDAL >= 2.0)
 Calculate and store approximate band statistics.</dd>

--- a/gdal/swig/python/scripts/gdal_edit.dox
+++ b/gdal/swig/python/scripts/gdal_edit.dox
@@ -14,6 +14,7 @@ Edit in place various information of an existing GDAL dataset.
 gdal_edit [--help-general] [-ro] [-a_srs srs_def] [-a_ullr ulx uly lrx lry]
           [-tr xres yres] [-unsetgt] [-a_nodata value] [-unsetnodata]
           [-unsetstats] [-stats] [-approx_stats]
+          [-setstats min max mean stddev]
           [-scale value] [-offset value]
           [-colorinterp_X red|green|blue|alpha|gray|undefined]*
           [-gcp pixel line easting northing [elevation]]*
@@ -67,6 +68,11 @@ Remove band statistics information.</dd>
 
 <dt> <b>-stats</b></dt>:<dd> (GDAL >= 2.0)
 Calculate and store band statistics.</dd>
+
+<dt> <b>-setstats</b>min max mean stddev:</dt><dd> (GDAL >= 2.4)
+Store user-defined values for band statistics (minimum, maximum, mean and standard deviation).
+If any of the values is set to -1, the real statistics are calclulated from the file
+and the ones set to -1 are used from the real statistics.</dd>
 
 <dt> <b>-approx_stats</b></dt>:<dd> (GDAL >= 2.0)
 Calculate and store approximate band statistics.</dd>

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -314,10 +314,17 @@ def gdal_edit(argv):
 
     if setstats:
         for i in range(ds.RasterCount):
-            #TODO, if one parameter is set to -1, get the value from the file:
-            #if statsmin == -1 or statsmax == -1 or statsmean == -1 or statsdev == -1:
-            #   ds.GetRasterBand(i+1).ComputeStatistics(approx_stats)
-            #   min,max,mean,stdev = ds.GetRasterBand(i+1).GetStatistics(approx_stats,True)
+            if statsmin == -1 or statsmax == -1 or statsmean == -1 or statsdev == -1:
+                ds.GetRasterBand(i+1).ComputeStatistics(approx_stats)
+                min,max,mean,stdev = ds.GetRasterBand(i+1).GetStatistics(approx_stats,True)
+                if statsmin == -1:
+                    statsmin = min
+                if statsmax == -1:
+                    statsmax = max
+                if statsmean == -1:
+                    statsmean = mean
+                if statsdev == -1:
+                    statsdev = stdev
             ds.GetRasterBand(i+1).SetStatistics(statsmin, statsmax, statsmean, statsdev)
 
     if molist:

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -41,6 +41,7 @@ def Usage():
     print('                 [-offset value] [-scale value]')
     print('                 [-colorinterp_X red|green|blue|alpha|gray|undefined]*')
     print('                 [-unsetstats] [-stats] [-approx_stats]')
+    print('                 [-setstats min max mean stddev]')
     print('                 [-gcp pixel line easting northing [elevation]]*')
     print('                 [-unsetmd] [-oo NAME=VALUE]* [-mo "META-TAG=VALUE"]*  datasetname')
     print('')
@@ -78,6 +79,7 @@ def gdal_edit(argv):
     unsetgt = False
     unsetstats = False
     stats = False
+    setstats = False
     approx_stats = False
     unsetmd = False
     ro = False
@@ -147,6 +149,17 @@ def gdal_edit(argv):
             approx_stats = True
         elif argv[i] == '-stats':
             stats = True
+        elif argv[i] == '-setstats' and i < len(argv)-4:
+            stats = True
+            setstats = True
+            statsmin = float(argv[i + 1])
+            i = i + 1
+            statsmax = float(argv[i + 1])
+            i = i + 1
+            statsmean = float(argv[i + 1])
+            i = i + 1
+            statsdev = float(argv[i + 1])
+            i = i + 1
         elif argv[i] == '-unsetmd':
             unsetmd = True
         elif argv[i] == '-unsetnodata':
@@ -190,7 +203,7 @@ def gdal_edit(argv):
         return Usage()
 
     if (srs is None and lry is None and yres is None and not unsetgt and
-            not unsetstats and not stats and nodata is None and
+            not unsetstats and not stats and not setstats and nodata is None and
             not molist and not unsetmd and not gcp_list and
             not unsetnodata and not colorinterp and
             scale is None and offset is None):
@@ -298,6 +311,14 @@ def gdal_edit(argv):
     if stats:
         for i in range(ds.RasterCount):
             ds.GetRasterBand(i + 1).ComputeStatistics(approx_stats)
+
+    if setstats:
+        for i in range(ds.RasterCount):
+            #TODO, if one parameter is set to -1, get the value from the file:
+            #if statsmin == -1 or statsmax == -1 or statsmean == -1 or statsdev == -1:
+            #   ds.GetRasterBand(i+1).ComputeStatistics(approx_stats)
+            #   min,max,mean,stdev = ds.GetRasterBand(i+1).GetStatistics(approx_stats,True)
+            ds.GetRasterBand(i+1).SetStatistics(statsmin, statsmax, statsmean, statsdev)
 
     if molist:
         if unsetmd:

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -152,22 +152,22 @@ def gdal_edit(argv):
         elif argv[i] == '-setstats' and i < len(argv)-4:
             stats = True
             setstats = True
-            if statsmin != 'None':
+            if argv[i + 1] != 'None':
                 statsmin = float(argv[i + 1])
             else:
                 statsmin = None
             i = i + 1
-            if statsmax != 'None':
+            if argv[i + 1] != 'None':
                 statsmax = float(argv[i + 1])
             else:
                 statsmax = None
             i = i + 1
-            if statsmean != 'None':
+            if argv[i + 1] != 'None':
                 statsmean = float(argv[i + 1])
             else:
                 statsmean = None
             i = i + 1
-            if statsdev != 'None':
+            if argv[i + 1] != 'None':
                 statsdev = float(argv[i + 1])
             else:
                 statsdev = None

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -154,19 +154,23 @@ def gdal_edit(argv):
             setstats = True
             if statsmin != 'None':
                 statsmin = float(argv[i + 1])
-            else statsmin = None
+            else:
+                statsmin = None
             i = i + 1
             if statsmax != 'None':
                 statsmax = float(argv[i + 1])
-            else statsmax = None
+            else:
+                statsmax = None
             i = i + 1
             if statsmean != 'None':
                 statsmean = float(argv[i + 1])
-            else statsmean = None
+            else:
+                statsmean = None
             i = i + 1
             if statsdev != 'None':
                 statsdev = float(argv[i + 1])
-            else statsdev = None
+            else:
+                statsdev = None
             i = i + 1
         elif argv[i] == '-unsetmd':
             unsetmd = True
@@ -322,16 +326,16 @@ def gdal_edit(argv):
 
     if setstats:
         for i in range(ds.RasterCount):
-            if statsmin == None or statsmax == None or statsmean == None or statsdev == None:
+            if statsmin is None or statsmax is None or statsmean is None or statsdev is None:
                 ds.GetRasterBand(i+1).ComputeStatistics(approx_stats)
                 min,max,mean,stdev = ds.GetRasterBand(i+1).GetStatistics(approx_stats,True)
-                if statsmin == None:
+                if statsmin is None:
                     statsmin = min
-                if statsmax == None:
+                if statsmax is None:
                     statsmax = max
-                if statsmean == None:
+                if statsmean is None:
                     statsmean = mean
-                if statsdev == None:
+                if statsdev is None:
                     statsdev = stdev
             ds.GetRasterBand(i+1).SetStatistics(statsmin, statsmax, statsmean, statsdev)
 

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -152,13 +152,21 @@ def gdal_edit(argv):
         elif argv[i] == '-setstats' and i < len(argv)-4:
             stats = True
             setstats = True
-            statsmin = float(argv[i + 1])
+            if statsmin != 'None':
+                statsmin = float(argv[i + 1])
+            else statsmin = None
             i = i + 1
-            statsmax = float(argv[i + 1])
+            if statsmax != 'None':
+                statsmax = float(argv[i + 1])
+            else statsmax = None
             i = i + 1
-            statsmean = float(argv[i + 1])
+            if statsmean != 'None':
+                statsmean = float(argv[i + 1])
+            else statsmean = None
             i = i + 1
-            statsdev = float(argv[i + 1])
+            if statsdev != 'None':
+                statsdev = float(argv[i + 1])
+            else statsdev = None
             i = i + 1
         elif argv[i] == '-unsetmd':
             unsetmd = True
@@ -314,16 +322,16 @@ def gdal_edit(argv):
 
     if setstats:
         for i in range(ds.RasterCount):
-            if statsmin == -1 or statsmax == -1 or statsmean == -1 or statsdev == -1:
+            if statsmin == None or statsmax == None or statsmean == None or statsdev == None:
                 ds.GetRasterBand(i+1).ComputeStatistics(approx_stats)
                 min,max,mean,stdev = ds.GetRasterBand(i+1).GetStatistics(approx_stats,True)
-                if statsmin == -1:
+                if statsmin == None:
                     statsmin = min
-                if statsmax == -1:
+                if statsmax == None:
                     statsmax = max
-                if statsmean == -1:
+                if statsmean == None:
                     statsmean = mean
-                if statsdev == -1:
+                if statsdev == None:
                     statsdev = stdev
             ds.GetRasterBand(i+1).SetStatistics(statsmin, statsmax, statsmean, statsdev)
 


### PR DESCRIPTION
With "-setstats" we can "fake" statistics which is very useful for tricking GIS programs to set the symbology as we want to. Can also eliminate outliers, etc...
