### PR TITLE
ODBC: Fetch wide-char strings on UNIX (fixes #839)

### DIFF
--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -27,6 +27,8 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#include <wchar.h>
+
 #include "cpl_odbc.h"
 #include "cpl_vsi.h"
 #include "cpl_string.h"
@@ -1029,7 +1031,24 @@ int CPLODBCStatement::Fetch( int nOrientation, int nOffset )
         if( nFetchType == SQL_C_WCHAR && m_papszColValues[iCol] != nullptr
             && m_panColValueLengths[iCol] > 0 )
         {
+#if WCHAR_MAX == 0xFFFFu
             wchar_t *pwszSrc = reinterpret_cast<wchar_t*>(m_papszColValues[iCol]);
+#else
+            unsigned int i = 0;
+            GUInt16 *panColValue =
+                reinterpret_cast<GUInt16 *>(m_papszColValues[iCol]);
+            wchar_t *pwszSrc =
+                static_cast<wchar_t *>(CPLMalloc((m_panColValueLengths[iCol] / 2 + 1)
+                                                 * sizeof(wchar_t)));
+
+            while( panColValue[i] != 0 ) {
+                pwszSrc[i] = static_cast<wchar_t>(panColValue[i]);
+                i += 1;
+            }
+            pwszSrc[i] = L'\0';
+
+            CPLFree( panColValue );
+#endif
 
             m_papszColValues[iCol] =
                 CPLRecodeFromWChar( pwszSrc, CPL_ENC_UCS2, CPL_ENC_UTF8 );


### PR DESCRIPTION
## What does this PR do?

Correct an issue on Linux (and other UNIX systems) where wide-character string data is incorrectly retrieved from an ODBC database, due to the `wchar_t` wide-character type being greater than sixteen bits in length.

## What are related issues/pull requests?

Fixes issue #839.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Ubuntu 16.04.5 64-bit (via Windows Subsystem for Linux on Windows 10)
* Compiler: gcc 5.4.0
