### PR TITLE
MSSQLSpatial: Accept date/time-valued feature attributes

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -29,6 +29,7 @@
 
 #include "cpl_conv.h"
 #include "ogr_mssqlspatial.h"
+#include "ogr_p.h"
 #ifdef SQLNCLI_VERSION
 #include <sqlncli.h>
 #endif
@@ -2266,6 +2267,33 @@ void OGRMSSQLSpatialTableLayer::AppendFieldValue(CPLODBCStatement *poStatement,
         char* pszBytes = GByteArrayToHexString( pabyData, nLen);
         poStatement->Append( pszBytes );
         CPLFree(pszBytes);
+        return;
+    }
+
+    // Datetime values need special handling as SQL Server's datetime type
+    // accepts values only in ISO 8601 format and only without time zone
+    // information
+    else if( nOGRFieldType == OFTDateTime )
+    {
+        char *pszStrValue = OGRGetXMLDateTime( (*poFeature)[i].GetRawValue() );
+
+        int nRetCode = SQLBindParameter( poStatement->GetStatement(),
+            (SQLUSMALLINT)((*bind_num) + 1), SQL_PARAM_INPUT, SQL_C_CHAR,
+            SQL_VARCHAR, strlen(pszStrValue) + 1, 0, (SQLPOINTER)pszStrValue,
+            0, nullptr );
+        if( nRetCode == SQL_SUCCESS || nRetCode == SQL_SUCCESS_WITH_INFO )
+        {
+            bind_buffer[*bind_num] = pszStrValue;
+            ++(*bind_num);
+            poStatement->Append(
+                "CAST(CAST(? AS datetimeoffset) AS datetime)" );
+        }
+        else {
+            poStatement->Append(
+                CPLSPrintf( "CAST(CAST('%s' AS datetimeoffset) AS datetime)",
+                    pszStrValue ) );
+            CPLFree( pszStrValue );
+        }
         return;
     }
 


### PR DESCRIPTION
## What does this PR do?

Allows date/time-valued feature attributes to be loaded into a Microsoft SQL Server database by modifying `OGRMSSQLSpatialTableLayer::AppendFieldValue()` to handle `OFTDateTime` fields specially,

- Formatting their value as an RFC 8601-compliant string and
- Adding an explicit `CAST` (to datetimeoffset, then datetime) to remove time zone information

so the field's value will be accepted by SQL Server.

## What are related issues/pull requests?

Fixes issue #841.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 16.04.5 64-bit (via Windows Subsystem for Linux on Windows 10)
* Compiler: g++ 5.4.0
