### PR TITLE
ODBC: Get error message when truncated (fixes #850)

### DIFF
--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -353,7 +353,8 @@ int CPLODBCSession::Failed( int nRetCode, HSTMT hStmt )
                 achSQLState, &nNativeError,
                 reinterpret_cast<SQLCHAR *>(achCurErrMsg),
                 sizeof(achCurErrMsg) - 1, &nTextLength );
-        if (nDiagRetCode == SQL_SUCCESS)
+        if (nDiagRetCode == SQL_SUCCESS ||
+            nDiagRetCode == SQL_SUCCESS_WITH_INFO)
         {
             achCurErrMsg[nTextLength] = '\0';
             m_osLastError += CPLString().Printf("%s[%5s]%s(" CPL_FRMT_GIB ")",


### PR DESCRIPTION
## What does this PR do?

Modifies `CPLODBCSession::Failed()` so it retrieves the error message for a failed operation even when the driver reports the message has been truncated.

## What are related issues/pull requests?

Fixes issue #850.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [X] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 16.04.5 64-bit (via Windows Subsystem for Linux on Windows 10)
* Compiler: g++ 5.4.0
