### PR TITLE
MSSQLSpatial: Support creating 3D features

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -1003,7 +1003,7 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature( OGRFeature *poFeature )
             int nWKBLen = poGeom->WkbSize();
             GByte *pabyWKB = (GByte *) CPLMalloc(nWKBLen + 1);
 
-            if( poGeom->exportToWkb( wkbNDR, pabyWKB ) == OGRERR_NONE && (nGeomColumnType == MSSQLCOLTYPE_GEOMETRY
+            if( poGeom->exportToWkb( wkbNDR, pabyWKB, wkbVariantIso ) == OGRERR_NONE && (nGeomColumnType == MSSQLCOLTYPE_GEOMETRY
                 || nGeomColumnType == MSSQLCOLTYPE_GEOGRAPHY))
             {
                 nWKBLenBindParameter = nWKBLen;
@@ -2080,7 +2080,7 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
                 int nWKBLen = poGeom->WkbSize();
                 GByte *pabyWKB = (GByte *) CPLMalloc(nWKBLen + 1);
 
-                if( poGeom->exportToWkb( wkbNDR, pabyWKB ) == OGRERR_NONE && (nGeomColumnType == MSSQLCOLTYPE_GEOMETRY
+                if( poGeom->exportToWkb( wkbNDR, pabyWKB, wkbVariantIso ) == OGRERR_NONE && (nGeomColumnType == MSSQLCOLTYPE_GEOMETRY
                     || nGeomColumnType == MSSQLCOLTYPE_GEOGRAPHY))
                 {
                     nWKBLenBindParameter = nWKBLen;


### PR DESCRIPTION
## What does this PR do?

Allows features that specify a Z value to be created in a SQL Server database, by modifying `OGRMSSQLSpatialTableLayer` so it requests a suitable WKB variant when formatting geometry data to be passed to the database server.

It also extends the new test suite, `ogr_mssqlspatial.py`, to

- Identify the version of the database engine in use, to determine whether it supports features that have Z or M values (so tests that cannot pass can be skipped); and

- Test adding features of various types to the database (with code mostly duplicated from `ogr_pg.py`), including a 3D point type that happens to demonstrate the problem this PR corrects.

## What are related issues/pull requests?

Fixes issue #852.

## Tasklist

 - [X] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [X] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 16.04.5 64-bit (via Windows Subsystem for Linux on Windows 10)
* Compiler: g++ 5.4.0
