### PR TITLE
vagrant: install python-lxml for autotest dependency

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,6 +75,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     "subversion",
     "python-numpy",
     "python-dev",
+    "python-lxml",
     "postgis",
     "postgresql-server-dev-9.3",
     "postgresql-9.3-postgis-2.2",


### PR DESCRIPTION
## What does this PR do?
Install python-lxml package in Vagrant environment.

Some autotest staff depends on lxml.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
