### PR TITLE
python: support plugin loading for swig/python

### DIFF
--- a/gdal/swig/python/osgeo/__init__.py
+++ b/gdal/swig/python/osgeo/__init__.py
@@ -1,4 +1,29 @@
 # __init__ for osgeo package.
+import sys
+import os
+
+# On UNIX-based platforms,
+# The default mode for dynamic loading keeps all the symbol private and not
+# visible to other libraries that may be loaded. Setting the mode to
+# RTLD_GLOBAL to make the symbols visible.
+
+_use_rtld_global = (hasattr(sys, 'getdlopenflags')
+                    and hasattr(sys, 'setdlopenflags'))
+if _use_rtld_global:
+    _default_dlopen_flags = sys.getdlopenflags()
+
+def set_dlopen_flags():
+    if _use_rtld_global:
+        if version_info >= (3, 3, 0):
+            RTLD_GLOBAL = os.RTLD_GLOBAL
+        else:
+            import ctypes
+            RTLD_GLOBAL = ctypes.RTLD_GLOBAL
+        sys.setdlopenflags(_default_dlopen_flags | RTLD_GLOBAL)
+
+def reset_dlopen_flags():
+    if _use_rtld_global:
+        sys.setdlopenflags(_default_dlopen_flags)
 
 # making the osgeo package version the same as the gdal version:
 from sys import version_info
@@ -18,7 +43,9 @@ if version_info >= (2, 6, 0):
             finally:
                 fp.close()
             return _mod
+    set_dlopen_flags()
     _gdal = swig_import_helper()
+    reset_dlopen_flags()
     del swig_import_helper
 else:
     import _gdal


### PR DESCRIPTION
SWIG/Python dlopen with LOCAL namespace in default.
This prevent gdal plugins loading because plugin
cannot register itself to call function in libgdal.so

Here is a fix to specify GLOBAL namespace for libgdal
binding. For Mac OSX, GLOBAL is default, but others not.

It reset a flag into RTLD_LOCAL after loading osgeo/_gdal extensions.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What does this PR do?

Fix problem related to plugin dlopen() and python bindings.

## What are related issues/pull requests?

#857 

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

- Linux
