### PR TITLE
MSSQLSpatial: Create features using a valid, sensible SRID

### DIFF
--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -325,6 +325,22 @@ def ogr_mssqlspatial_create_feature_in_unregistered_table():
         gdaltest.post_reason('CreateFeature failed')
         return 'fail'
 
+    # Verify the created feature received the spatial-reference system of the
+    # original, as none was associated with the table
+    unregistered_layer.ResetReading()
+    created_feature = unregistered_layer.GetNextFeature()
+    if created_feature is None:
+        gdaltest.post_reason('did not get feature')
+        return 'fail'
+
+    created_feature_geometry = created_feature.GetGeometryRef()
+    created_spatial_reference = created_feature_geometry.GetSpatialReference()
+    if not ((created_spatial_reference == spatial_reference)
+            or ((created_spatial_reference is not None)
+                and created_spatial_reference.IsSame(spatial_reference))):
+        gdaltest.post_reason('created-feature SRS does not match original')
+        return 'fail'
+
     # Clean up
     test_ds.Destroy()
     feature.Destroy()

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -37,6 +37,7 @@ import gdaltest
 import ogrtest
 from osgeo import gdal
 from osgeo import ogr
+from osgeo import osr
 
 ###############################################################################
 # Open Database.
@@ -266,6 +267,71 @@ def ogr_mssqlspatial_test_ogrsf():
     return 'success'
 
 ###############################################################################
+# Verify features can be created in an existing table that includes a geometry
+# column but is not registered in the "geometry_columns" table.
+
+
+def ogr_mssqlspatial_create_feature_in_unregistered_table():
+    if gdaltest.mssqlspatial_ds is None:
+        return 'skip'
+
+    # Create a feature that specifies a spatial-reference system
+    spatial_reference = osr.SpatialReference()
+    spatial_reference.ImportFromEPSG(4326)
+
+    feature = ogr.Feature(ogr.FeatureDefn('Unregistered'))
+    feature.SetGeometryDirectly(ogr.CreateGeometryFromWkt('POINT (10 20)',
+                                                          spatial_reference))
+
+    # Create a table that includes a geometry column but is not registered in
+    # the "geometry_columns" table
+    gdaltest.mssqlspatial_ds.ExecuteSQL(
+        'CREATE TABLE Unregistered'
+        + '('
+        +   'ObjectID int IDENTITY(1,1) NOT NULL PRIMARY KEY,'
+        +   'Shape geometry NOT NULL'
+        + ');')
+
+    # Create a new MSSQLSpatial data source, one that will find the table just
+    # created and make it available via GetLayerByName()
+    use_geometry_columns = gdal.GetConfigOption(
+        'MSSQLSPATIAL_USE_GEOMETRY_COLUMNS')
+    gdal.SetConfigOption('MSSQLSPATIAL_USE_GEOMETRY_COLUMNS', 'NO')
+
+    test_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=1)
+
+    gdal.SetConfigOption('MSSQLSPATIAL_USE_GEOMETRY_COLUMNS',
+                         use_geometry_columns)
+
+    if test_ds is None:
+        gdaltest.post_reason('cannot open data source')
+        return 'fail'
+
+    # Get a layer backed by the newly created table and verify that (as it is
+    # unregistered) it has no associated spatial-reference system
+    unregistered_layer = test_ds.GetLayerByName('Unregistered');
+    if unregistered_layer is None:
+        gdaltest.post_reason('did not get Unregistered layer')
+        return 'fail'
+
+    unregistered_spatial_reference = unregistered_layer.GetSpatialRef()
+    if unregistered_spatial_reference is not None:
+        gdaltest.post_reason('layer Unregistered unexpectedly has an SRS')
+        return 'fail'
+
+    # Verify creating the feature in the layer succeeds despite the lack of an
+    # associated spatial-reference system
+    if unregistered_layer.CreateFeature(feature) != ogr.OGRERR_NONE:
+        gdaltest.post_reason('CreateFeature failed')
+        return 'fail'
+
+    # Clean up
+    test_ds.Destroy()
+    feature.Destroy()
+
+    return 'success'
+
+###############################################################################
 #
 
 
@@ -277,6 +343,7 @@ def ogr_mssqlspatial_cleanup():
     gdaltest.mssqlspatial_ds = None
 
     gdaltest.mssqlspatial_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=1)
+    gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE Unregistered')
     gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE tpoly')
 
     gdaltest.mssqlspatial_ds = None
@@ -290,6 +357,7 @@ gdaltest_list = [
     ogr_mssqlspatial_3,
     ogr_mssqlspatial_4,
     ogr_mssqlspatial_test_ogrsf,
+    ogr_mssqlspatial_create_feature_in_unregistered_table,
     ogr_mssqlspatial_cleanup
 ]
 

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
@@ -209,7 +209,7 @@ class OGRMSSQLSpatialLayer : public OGRLayer
 
     // Layer spatial reference system, and srid.
     OGRSpatialReference *poSRS = nullptr;
-    int                 nSRSId = -1;
+    int                 nSRSId = 0;
 
     GIntBig             iNextShapeId = 0;
 

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -941,7 +941,7 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
         if (papszSRIds != nullptr)
             nSRId = atoi(papszSRIds[iTable]);
         else
-            nSRId = -1;
+            nSRId = 0;
 
         if (papszCoordDimensions != nullptr)
             nCoordDimension = atoi(papszCoordDimensions[iTable]);

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialselectlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialselectlayer.cpp
@@ -54,7 +54,7 @@ OGRMSSQLSpatialSelectLayer::OGRMSSQLSpatialSelectLayer( OGRMSSQLSpatialDataSourc
     poDS = poDSIn;
 
     iNextShapeId = 0;
-    nSRSId = -1;
+    nSRSId = 0;
     poFeatureDefn = nullptr;
 
     poStmt = poStmtIn;

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -311,11 +311,14 @@ CPLErr OGRMSSQLSpatialTableLayer::Initialize( const char *pszSchema,
 
     if (!poSRS)
     {
-        if (nSRSId < 0)
+        if (nSRSId <= 0)
             nSRSId = FetchSRSId();
 
         GetSpatialRef();
     }
+
+    if (nSRSId < 0)
+        nSRSId = 0;
 
     return CE_None;
 }
@@ -337,6 +340,8 @@ int OGRMSSQLSpatialTableLayer::FetchSRSId()
         {
             if ( oStatement.GetColData( 0 ) )
                 nSRSId = atoi( oStatement.GetColData( 0 ) );
+            if( nSRSId < 0 )
+                nSRSId = 0;
         }
     }
 
@@ -590,7 +595,7 @@ CPLODBCStatement* OGRMSSQLSpatialTableLayer::BuildStatement(const char* pszColum
                 if ( m_sFilterEnvelope.MinX == m_sFilterEnvelope.MaxX ||
                     m_sFilterEnvelope.MinY == m_sFilterEnvelope.MaxY)
                     poStatement->Appendf("STGeomFromText('POINT(%.15g %.15g)',%d)) = 1",
-                                m_sFilterEnvelope.MinX, m_sFilterEnvelope.MinY, nSRSId >= 0? nSRSId : 0);
+                                m_sFilterEnvelope.MinX, m_sFilterEnvelope.MinY, nSRSId);
                 else
                     poStatement->Appendf( "STGeomFromText('POLYGON((%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g))',%d)) = 1",
                                                 m_sFilterEnvelope.MinX, m_sFilterEnvelope.MinY,
@@ -598,7 +603,7 @@ CPLODBCStatement* OGRMSSQLSpatialTableLayer::BuildStatement(const char* pszColum
                                                 m_sFilterEnvelope.MaxX, m_sFilterEnvelope.MaxY,
                                                 m_sFilterEnvelope.MinX, m_sFilterEnvelope.MaxY,
                                                 m_sFilterEnvelope.MinX, m_sFilterEnvelope.MinY,
-                                                nSRSId >= 0? nSRSId : 0 );
+                                                nSRSId );
             }
         }
         else


### PR DESCRIPTION
## What does this PR do?

Modify the MSSQLSpatial driver so that when creating features, it

- Uses only SRIDs considered valid by the database engine, with 0 (instead of -1) indicating an unknown spatial-reference system; and
- Preserves the SRID of the supplied feature's geometry, if its spatial-reference system is known, defaulting to the table's SRID otherwise.

Together these changes 

- Accommodate the fact tables in SQL Server generally do not have an associated SRID; and
- Allow features to be added to tables not registered in the `geometry_columns` table, without error and without modifying the interpretation of the original feature.

## What are related issues/pull requests?

Fixes issue #860.

## Tasklist

 - [X] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [X] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 16.04.5 64-bit (via Windows Subsystem for Linux on Windows 10)
* Compiler: gcc 5.4.0
