### PR TITLE
Doc: ogr2ogr: Clarify use of -select, -fieldmap

### DIFF
--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -33,7 +33,7 @@ import sys
 
 sys.path.append('../pymod')
 
-from osgeo import gdal, ogr
+from osgeo import gdal, gdalconst, ogr
 import gdaltest
 import ogrtest
 
@@ -503,6 +503,37 @@ def test_ogr2ogr_lib_20():
     return 'success'
 
 
+###############################################################################
+# Verify -append and -select options are an invalid combination
+
+def test_ogr2ogr_lib_21():
+
+    src_ds = gdal.GetDriverByName('Memory').Create('', 0, 0, 0)
+    lyr = src_ds.CreateLayer('layer')
+    lyr.CreateField(ogr.FieldDefn('foo'))
+    lyr.CreateField(ogr.FieldDefn('bar'))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f['foo'] = 'bar'
+    f['bar'] = 'foo'
+    lyr.CreateFeature(f)
+
+    ds = gdal.VectorTranslate('', src_ds, format='Memory')
+    with gdaltest.error_handler():
+        gdal.VectorTranslate(ds, src_ds, accessMode='append',
+                             selectFields=['foo'])
+
+    ds = None
+    f.Destroy()
+    src_ds = None
+
+    if gdal.GetLastErrorNo() != gdalconst.CPLE_IllegalArg:
+        gdaltest.post_reason(
+            'expected use of -select and -append together to be invalid')
+        return 'fail'
+
+    return 'success'
+
+
 gdaltest_list = [
     test_ogr2ogr_lib_1,
     test_ogr2ogr_lib_2,
@@ -524,6 +555,7 @@ gdaltest_list = [
     test_ogr2ogr_lib_18,
     test_ogr2ogr_lib_19,
     test_ogr2ogr_lib_20,
+    test_ogr2ogr_lib_21,
 ]
 
 if __name__ == '__main__':

--- a/gdal/apps/ogr2ogr_lib.cpp
+++ b/gdal/apps/ogr2ogr_lib.cpp
@@ -1994,6 +1994,16 @@ GDALDatasetH GDALVectorTranslate( const char *pszDest, GDALDatasetH hDstDS, int 
         return nullptr;
     }
 
+    if (psOptions->papszSelFields && bAppend && !psOptions->bAddMissingFields)
+    {
+        CPLError( CE_Failure, CPLE_IllegalArg, "if -append is specified, -select cannot be used "
+                  "(use -fieldmap or -sql instead)." );
+        if(pbUsageError)
+            *pbUsageError = TRUE;
+        GDALVectorTranslateOptionsFree(psOptions);
+        return nullptr;
+    }
+
     if( psOptions->papszFieldTypesToString && psOptions->papszMapFieldType )
     {
         CPLError( CE_Failure, CPLE_IllegalArg, "-fieldTypeToString and -mapFieldType are exclusive.");

--- a/gdal/apps/ogr_utilities.dox
+++ b/gdal/apps/ogr_utilities.dox
@@ -317,7 +317,10 @@ fields from input layer to copy to the new layer. A field is skipped if
 mentioned previously in the list even if the input layer has duplicate field
 names.  (Defaults to all; any field is skipped if a subsequent field with
 same name is found.) Starting with OGR 1.11, geometry fields can also be specified
-in the list.</dd>
+in the list.
+
+Note this setting cannot be used together with -append. To control the selection
+of fields when appending to a layer, use -fieldmap or -sql.</dd>
 <dt> <b>-progress</b>:</dt><dd> (starting with GDAL 1.7.0) Display progress on terminal. Only works if input layers have the "fast feature count" capability.</dd>
 <dt> <b>-sql</b> <em>sql_statement</em>:</dt><dd> SQL statement to execute.
 The resulting table/layer will be saved to the output. Starting with GDAL 2.1, the \@filename syntax
@@ -451,9 +454,9 @@ available GCPs.</dd>
 <dt> <b>-fieldmap</b>:</dt><dd>(starting with GDAL 1.10.0) Specifies the list of field indexes to be copied
 from the source to the destination. The (n)th value specified in the list is the index of the field in the
 target layer definition in which the n(th) field of the source layer must be copied. Index count starts at
-zero. There must be exactly as many values in the list as the count of the fields in the source layer.
-We can use the 'identity' setting to specify that the fields should be transferred by using the same order.
-This setting should be used along with the -append setting.</dd>
+zero. To omit a field, specify a value of -1. There must be exactly as many values in the list as the count
+of the fields in the source layer.  We can use the 'identity' setting to specify that the fields should be
+transferred by using the same order.  This setting should be used along with the -append setting.</dd>
 <dt> <b>-addfields</b>:</dt><dd>(starting with GDAL 1.11) This is a specialized version of
 -append. Contrary to -append, -addfields has the effect of adding, to existing target layers,
 the new fields found in source layers. This option is useful when merging files that have non-strictly


### PR DESCRIPTION
## What does this PR do?

Extend `ogr2ogr`'s documentation to clarify the use of the "-select" and "-fieldmap" options. This would have saved me time this morning when I was trying to get `ogr2ogr` to omit a foreign-key column from a layer being loaded from a GeoPackage.

As I eventually discovered,

- [The "-select" option is quietly ignored when "-append" is specified.](https://github.com/OSGeo/gdal/blob/d1f5a1634136677bacd04fc6e07d2673b42d0f1c/gdal/apps/ogr2ogr_lib.cpp#L3394)

- "-fieldmap" can be used instead to omit source fields by specifying a value of -1 for their target index, [as shown in the last example on the page](https://www.gdal.org/ogr2ogr.html#ogr2ogr_example).

Since it's a little hard to tell from the diff, the specific text added to the page is:

"Note this setting is ignored when -append is used. To control the selection of fields when appending to a layer, use the -fieldmap setting."

"To omit a field, specify a value of -1."

## What are related issues/pull requests?

None.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed