### PR TITLE
swit-perl: fix make dep graph

### DIFF
--- a/gdal/swig/perl/GNUmakefile
+++ b/gdal/swig/perl/GNUmakefile
@@ -20,16 +20,14 @@ generate: ${WRAPPERS}
 	if [ -f OSR.pm ]; then mv OSR.pm lib/Geo; fi
 	if [ -f GNM.pm ]; then mv GNM.pm lib/Geo; fi
 
-build: gdal_wrap.cc Makefile_Geo__GDAL
+build: Makefile_Geo__GDAL
 	$(MAKE) -f Makefile_Geo__GDAL
 	$(MAKE) -f Makefile_Geo__GDAL__Const
 	$(MAKE) -f Makefile_Geo__OSR
 	if [ -f Makefile_Geo__OGR ]; then $(MAKE) -f Makefile_Geo__OGR; fi
 	if [ -f Makefile_Geo__GNM ]; then $(MAKE) -f Makefile_Geo__GNM; fi
 
-gdal_wrap.cc: generate
-
-Makefile_Geo__GDAL: gdal_wrap.cc
+Makefile_Geo__GDAL: Makefile.PL
 	perl Makefile.PL INSTALL_BASE=$(INST_PREFIX)
 
 test: build
@@ -66,3 +64,5 @@ doc: .FORCE
 
 .FORCE:
 	perl parse-for-doxygen.pl > all.pm; doxygen; rm -f all.pm
+
+.PHONY: generate


### PR DESCRIPTION
Makefile_Geo__GDAL must depend on Makefile.PL, instead on
non-existing gdal_wrap.cc, otherwise the module rebuilds on
every make hit.

Also the 'generate' target should be .PHONY.

## What does this PR do?
Fixes swig/perl build scripts.
