### PR TITLE
Fixed GNUMakefile to force libstdc++ for macOS

### DIFF
--- a/gdal/frmts/pdf/GNUmakefile
+++ b/gdal/frmts/pdf/GNUmakefile
@@ -6,8 +6,7 @@ PLUGIN_DL =	gdal_PDF.so
 
 ifeq ($(MACOSX_FRAMEWORK),yes)
 PLUGIN_DL = gdal_PDF.dylib
-LDFLAGS += -Wl,-undefined -Wl,dynamic_lookup -stdlib=libstdc++
-CPPFLAGS += -stdlib=libstdc++
+LDFLAGS += -Wl,-undefined -Wl,dynamic_lookup
 LD_SHARED = $(LD) -bundle
 endif
 


### PR DESCRIPTION
## What does this PR do?
GDAL 2.3.0+ requires C++11, but on macOS it requires to be using `-stdlib=libc++`


## What are related issues/pull requests?
Probably no issue yet created.


## Environment

Provide environment details, if relevant:

* OS: macOS 10.12 Sierra
* Compiler: clang
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin16.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin