### PR TITLE
Update gdal_datamodel.dox with correct link to osr_tutorial

### DIFF
--- a/gdal/doc/gdal_datamodel.dox
+++ b/gdal/doc/gdal_datamodel.dox
@@ -40,7 +40,7 @@ from authorities such as EPSG.
 </ul>
 
 For more information on OpenGIS WKT coordinate system definitions, and
-mechanisms to manipulate them, refer to the <a href="ogr/osr_tutorial.html">
+mechanisms to manipulate them, refer to the <a href="osr_tutorial.html">
 osr_tutorial</a> document and/or the OGRSpatialReference class documentation.
 
 The coordinate system returned by GDALDataset::GetProjectionRef()


### PR DESCRIPTION
Corrected link to osr_tutorial from /ogr/osr_tutorial.html to /osr_tutorial.html

## What does this PR do?

Fixes broken website link: https://www.gdal.org/gdal_datamodel.html (gdal_datamodel.dox) links to https://www.gdal.org/ogr/osr_tutorial.html however while the osr_tutorial.dox file lives under /ogr/, the website serves it at the root: https://www.gdal.org/osr_tutorial.html


## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
