### PR TITLE
Set minimum pkg-config version to 0.21

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -26201,7 +26201,7 @@ fi
 
 fi
 if test -n "$PKG_CONFIG"; then
-	_pkg_min_version=0.25
+	_pkg_min_version=0.21
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
 $as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
 	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
@@ -27290,7 +27290,7 @@ fi
 
 fi
 if test -n "$PKG_CONFIG"; then
-	_pkg_min_version=0.25
+	_pkg_min_version=0.21
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
 $as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
 	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
@@ -29574,7 +29574,7 @@ fi
 
 fi
 if test -n "$PKG_CONFIG"; then
-	_pkg_min_version=0.25
+	_pkg_min_version=0.21
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
 $as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
 	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -2334,7 +2334,7 @@ elif test "$with_hdf5" = "yes" -o "$with_hdf5" = "" ; then
 
   HDF5_CFLAGS=""
   HDF5_LIBS=""
-  PKG_PROG_PKG_CONFIG([0.25]) # check and set $PKG_CONFIG
+  PKG_PROG_PKG_CONFIG([0.21]) # check and set $PKG_CONFIG
   PKG_CHECK_MODULES([HDF5], [hdf5], [HAVE_HDF5=yes], [HAVE_HDF5=no])
 
   if test "$HAVE_HDF5" = "yes"; then
@@ -2685,7 +2685,7 @@ if test "$with_openjpeg" = "no" ; then
 
 else
 
-  PKG_PROG_PKG_CONFIG([0.25])
+  PKG_PROG_PKG_CONFIG([0.21])
   PKG_CHECK_MODULES([OPENJPEG], [libopenjp2 >= 2.1.0],
         [OPENJPEG_VERSION=`$PKG_CONFIG --modversion libopenjp2`],
         [OPENJPEG_VERSION=;])


### PR DESCRIPTION
This unblocks building GDAL 2.3.1 with OpenJPEG on Python's manylinux1 platform based on CentOS 5, which has pkg-config 0.21.

Specifically, it resolves https://github.com/mapbox/rasterio/issues/1453 and an issue reported on the main Rasterio discussion group. I'm patching GDAL 2.3.1 and successfully building it with OpenJPEG in a manylinux1 container at https://travis-ci.com/sgillies/rasterio-wheels/jobs/145131192.