### PR TITLE
Python: import paths in swig interface files and regenerate

### DIFF
--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1077,8 +1077,8 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 %pythoncode %{
 import numpy
 
-import gdalconst
-import gdal
+from osgeo import gdalconst
+from osgeo import gdal
 gdal.AllRegister()
 
 codes = {gdalconst.GDT_Byte: numpy.uint8,

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -79,8 +79,8 @@ static void update_buffer_size(void* obj, char* data, char* data_aligned, size_t
          DeprecationWarning)
 
 
-  from gdalconst import *
-  import gdalconst
+  from osgeo.gdalconst import *
+  from osgeo import gdalconst
 
 
   import sys
@@ -490,7 +490,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
       parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
-      import gdalnumeric
+      from osgeo import gdalnumeric
 
       return gdalnumeric.BandReadAsArray(self, xoff, yoff,
                                          win_xsize, win_ysize,
@@ -503,7 +503,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
                  resample_alg=gdalconst.GRIORA_NearestNeighbour,
                  callback=None,
                  callback_data=None):
-      import gdalnumeric
+      from osgeo import gdalnumeric
 
       return gdalnumeric.BandWriteArray(self, array, xoff, yoff,
                                         resample_alg=resample_alg,
@@ -520,7 +520,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
            Any reference to the array must be dropped before the last reference to the
            related dataset is also dropped.
         """
-        import gdalnumeric
+        from osgeo import gdalnumeric
         if xsize is None:
             xsize = self.XSize
         if ysize is None:
@@ -543,7 +543,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
            Any reference to the array must be dropped before the last reference to the
            related dataset is also dropped.
         """
-        import gdalnumeric
+        from osgeo import gdalnumeric
         if options is None:
             virtualmem = self.GetVirtualMemAuto(eAccess)
         else:
@@ -560,7 +560,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
            Any reference to the array must be dropped before the last reference to the
            related dataset is also dropped.
         """
-        import gdalnumeric
+        from osgeo import gdalnumeric
         if xsize is None:
             xsize = self.XSize
         if ysize is None:
@@ -698,7 +698,7 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
         """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
         parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
-        import gdalnumeric
+        from osgeo import gdalnumeric
         return gdalnumeric.DatasetReadAsArray(self, xoff, yoff, xsize, ysize, buf_obj,
                                               buf_xsize, buf_ysize, buf_type,
                                               resample_alg=resample_alg,
@@ -767,7 +767,7 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
            Any reference to the array must be dropped before the last reference to the
            related dataset is also dropped.
         """
-        import gdalnumeric
+        from osgeo import gdalnumeric
         if xsize is None:
             xsize = self.RasterXSize
         if ysize is None:
@@ -802,7 +802,7 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
            Any reference to the array must be dropped before the last reference to the
            related dataset is also dropped.
         """
-        import gdalnumeric
+        from osgeo import gdalnumeric
         if xsize is None:
             xsize = self.RasterXSize
         if ysize is None:
@@ -894,12 +894,12 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
 %extend GDALRasterAttributeTableShadow {
 %pythoncode %{
   def WriteArray(self, array, field, start=0):
-      import gdalnumeric
+      from osgeo import gdalnumeric
 
       return gdalnumeric.RATWriteArray(self, array, field, start)
 
   def ReadAsArray(self, field, start=0, length=None):
-      import gdalnumeric
+      from osgeo import gdalnumeric
 
       return gdalnumeric.RATReadArray(self, field, start, length)
 %}

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -107,8 +107,8 @@ def deprecation_warn(module):
        DeprecationWarning)
 
 
-from gdalconst import *
-import gdalconst
+from osgeo.gdalconst import *
+from osgeo import gdalconst
 
 
 import sys
@@ -2105,7 +2105,7 @@ class Dataset(MajorObject):
         """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
         parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
-        import gdalnumeric
+        from osgeo import gdalnumeric
         return gdalnumeric.DatasetReadAsArray(self, xoff, yoff, xsize, ysize, buf_obj,
                                               buf_xsize, buf_ysize, buf_type,
                                               resample_alg=resample_alg,
@@ -2174,7 +2174,7 @@ class Dataset(MajorObject):
            Any reference to the array must be dropped before the last reference to the
            related dataset is also dropped.
         """
-        import gdalnumeric
+        from osgeo import gdalnumeric
         if xsize is None:
             xsize = self.RasterXSize
         if ysize is None:
@@ -2209,7 +2209,7 @@ class Dataset(MajorObject):
            Any reference to the array must be dropped before the last reference to the
            related dataset is also dropped.
         """
-        import gdalnumeric
+        from osgeo import gdalnumeric
         if xsize is None:
             xsize = self.RasterXSize
         if ysize is None:
@@ -2628,7 +2628,7 @@ class Band(MajorObject):
         """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
         parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
-        import gdalnumeric
+        from osgeo import gdalnumeric
 
         return gdalnumeric.BandReadAsArray(self, xoff, yoff,
                                            win_xsize, win_ysize,
@@ -2641,7 +2641,7 @@ class Band(MajorObject):
                    resample_alg=gdalconst.GRIORA_NearestNeighbour,
                    callback=None,
                    callback_data=None):
-        import gdalnumeric
+        from osgeo import gdalnumeric
 
         return gdalnumeric.BandWriteArray(self, array, xoff, yoff,
                                           resample_alg=resample_alg,
@@ -2658,7 +2658,7 @@ class Band(MajorObject):
              Any reference to the array must be dropped before the last reference to the
              related dataset is also dropped.
           """
-          import gdalnumeric
+          from osgeo import gdalnumeric
           if xsize is None:
               xsize = self.XSize
           if ysize is None:
@@ -2681,7 +2681,7 @@ class Band(MajorObject):
              Any reference to the array must be dropped before the last reference to the
              related dataset is also dropped.
           """
-          import gdalnumeric
+          from osgeo import gdalnumeric
           if options is None:
               virtualmem = self.GetVirtualMemAuto(eAccess)
           else:
@@ -2698,7 +2698,7 @@ class Band(MajorObject):
              Any reference to the array must be dropped before the last reference to the
              related dataset is also dropped.
           """
-          import gdalnumeric
+          from osgeo import gdalnumeric
           if xsize is None:
               xsize = self.XSize
           if ysize is None:
@@ -2900,12 +2900,12 @@ class RasterAttributeTable(_object):
 
 
     def WriteArray(self, array, field, start=0):
-        import gdalnumeric
+        from osgeo import gdalnumeric
 
         return gdalnumeric.RATWriteArray(self, array, field, start)
 
     def ReadAsArray(self, field, start=0, length=None):
-        import gdalnumeric
+        from osgeo import gdalnumeric
 
         return gdalnumeric.RATReadArray(self, field, start, length)
 

--- a/gdal/swig/python/osgeo/gdal_array.py
+++ b/gdal/swig/python/osgeo/gdal_array.py
@@ -160,8 +160,8 @@ def RATValuesIONumPyRead(poRAT, nField, nStart, nLength):
 
 import numpy
 
-import gdalconst
-import gdal
+from osgeo import gdalconst
+from osgeo import gdal
 gdal.AllRegister()
 
 codes = {gdalconst.GDT_Byte: numpy.uint8,


### PR DESCRIPTION
Current python imports are all under osgeo (ex. osgeo.gdal) but interface file defines it as
without osgeo.  Add `from osgeo` for imports and regenerate python files with SWIG 3.0.8.

It helps future deprecation of backward compatibility python files.
Autotest will run without (removing) compatibility python files where there are python2.7/dist-packages/gdal.py etc.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
