### PR TITLE
Python: add package name osgeo to interface module definitions

### DIFF
--- a/gdal/swig/include/gdal.i
+++ b/gdal/swig/include/gdal.i
@@ -34,6 +34,8 @@
 %module "Geo::GDAL"
 #elif defined(SWIGCSHARP)
 %module Gdal
+#elif defined(SWIGPYTHON)
+%module (package="osgeo") gdal
 #else
 %module gdal
 #endif

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -30,7 +30,7 @@
 
 %feature("autodoc");
 
-%module gdal_array
+%module (package="osgeo") gdal_array
 
 %{
 // Define this unconditionally of whether DEBUG_BOOL is defined or not,

--- a/gdal/swig/include/gnm.i
+++ b/gdal/swig/include/gnm.i
@@ -38,6 +38,8 @@
 %module "Geo::GNM"
 #elif defined(SWIGCSHARP)
 %module Gnm
+#elif defined(SWIGPYTHON)
+%module (package="osgeo") gnm
 #else
 %module gnm
 #endif

--- a/gdal/swig/include/ogr.i
+++ b/gdal/swig/include/ogr.i
@@ -39,6 +39,8 @@
 %module "Geo::OGR"
 #elif defined(SWIGCSHARP)
 %module Ogr
+#elif defined(SWIGPYTHON)
+%module (package="osgeo") ogr
 #else
 %module ogr
 #endif

--- a/gdal/swig/include/osr.i
+++ b/gdal/swig/include/osr.i
@@ -37,6 +37,8 @@
 %module "Geo::OSR"
 #elif defined(SWIGCSHARP)
 %module Osr
+#elif defined(SWIGPYTHON)
+%module (package="osgeo") osr
 #else
 %module osr
 #endif

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -1647,8 +1647,8 @@ class Driver(MajorObject):
 Driver_swigregister = _gdal.Driver_swigregister
 Driver_swigregister(Driver)
 
-import ogr
-import osr
+import osgeo.ogr
+import osgeo.osr
 class ColorEntry(_object):
     """Proxy of C++ GDALColorEntry class."""
 

--- a/gdal/swig/python/osgeo/gnm.py
+++ b/gdal/swig/python/osgeo/gnm.py
@@ -102,8 +102,8 @@ def UseExceptions(*args):
 def DontUseExceptions(*args):
     """DontUseExceptions()"""
     return _gnm.DontUseExceptions(*args)
-import ogr
-import osr
+import osgeo.ogr
+import osgeo.osr
 
 _gnm.GATDijkstraShortestPath_swigconstant(_gnm)
 GATDijkstraShortestPath = _gnm.GATDijkstraShortestPath
@@ -130,15 +130,15 @@ def CastToNetwork(*args):
 def CastToGenericNetwork(*args):
     """CastToGenericNetwork(MajorObject base) -> GenericNetwork"""
     return _gnm.CastToGenericNetwork(*args)
-class Network(ogr.MajorObject):
+class Network(osgeo.ogr.MajorObject):
     """Proxy of C++ GNMNetworkShadow class."""
 
     __swig_setmethods__ = {}
-    for _s in [ogr.MajorObject]:
+    for _s in [osgeo.ogr.MajorObject]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, Network, name, value)
     __swig_getmethods__ = {}
-    for _s in [ogr.MajorObject]:
+    for _s in [osgeo.ogr.MajorObject]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, Network, name)
 

--- a/gdal/swig/python/osgeo/ogr.py
+++ b/gdal/swig/python/osgeo/ogr.py
@@ -546,7 +546,7 @@ def UseExceptions(*args):
 def DontUseExceptions(*args):
     """DontUseExceptions()"""
     return _ogr.DontUseExceptions(*args)
-import osr
+import osgeo.osr
 class MajorObject(_object):
     """Proxy of C++ GDALMajorObjectShadow class."""
 


### PR DESCRIPTION
## What does this PR do?

Improve Python bindings, removing dependency to compatibility module.
Specify package "osgeo" to imports.
Regenerate with SWIG 3.0.8.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
