### PR TITLE
Python: add package to modules

### DIFF
--- a/gdal/swig/include/MajorObject.i
+++ b/gdal/swig/include/MajorObject.i
@@ -37,6 +37,8 @@
 %module "Geo::GDAL"
 #elif defined(SWIGCSHARP)
 %module Gdal
+#elif defined(SWIGPYTHON)
+%module (package="osgeo") gdal
 #else
 %module gdal
 #endif

--- a/gdal/swig/python/osgeo/gdal_array.py
+++ b/gdal/swig/python/osgeo/gdal_array.py
@@ -90,7 +90,7 @@ except AttributeError:
     _newclass = 0
 
 
-import gdal
+import osgeo.gdal
 class VirtualMem(_object):
     """Proxy of C++ CPLVirtualMemShadow class."""
 


### PR DESCRIPTION
## What does this PR do?

Remove dependency for deprecated module in python binding.
replace `import gdal` with `import osgeo.gdal`

Same as #921  but here is a  missing modification 

## What are related issues/pull requests?

#921 

Signed-off-by: Hiroshi Miura <miurahr@linux.com>