### PR TITLE
Support for VSIFFlushL() in SWIG bindings

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -54,6 +54,10 @@ def vsifile_generic(filename):
         gdaltest.post_reason('failure')
         return 'fail'
 
+    if gdal.VSIFFlushL(fp) != 0:
+        gdaltest.post_reason('failure')
+        return 'fail'
+
     if gdal.VSIFTruncateL(fp, 20) != 0:
         gdaltest.post_reason('failure')
         return 'fail'

--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -551,6 +551,7 @@ VSILFILE   *wrapper_VSIFOpenExL( const char *utf8_path, const char *pszMode, int
 %}
 
 int VSIFEofL( VSILFILE* fp );
+int VSIFFlushL( VSILFILE* fp );
 
 VSI_RETVAL VSIFCloseL( VSILFILE* fp );
 

--- a/gdal/swig/include/perl/gdal_perl.i
+++ b/gdal/swig/include/perl/gdal_perl.i
@@ -2063,6 +2063,11 @@ sub Tell {
     Geo::GDAL::VSIFTellL($self);
 }
 
+sub Flush {
+    my ($self) = @_;
+    Geo::GDAL::VSIFFlushL($self);
+}
+
 sub Truncate {
     my ($self, $new_size) = @_;
     Geo::GDAL::VSIFTruncateL($self, $new_size);

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -9996,6 +9996,51 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_VSIFFlushL(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  VSILFILE *arg1 = (VSILFILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:VSIFFlushL",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_VSILFILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VSIFFlushL" "', argument " "1"" of type '" "VSILFILE *""'"); 
+  }
+  arg1 = reinterpret_cast< VSILFILE * >(argp1);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (int)VSIFFlushL(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_VSIFCloseL(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   VSILFILE *arg1 = (VSILFILE *) 0 ;
@@ -34327,6 +34372,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"VSIFOpenL", _wrap_VSIFOpenL, METH_VARARGS, (char *)"VSIFOpenL(char const * utf8_path, char const * pszMode) -> VSILFILE"},
 	 { (char *)"VSIFOpenExL", _wrap_VSIFOpenExL, METH_VARARGS, (char *)"VSIFOpenExL(char const * utf8_path, char const * pszMode, int bSetError) -> VSILFILE"},
 	 { (char *)"VSIFEofL", _wrap_VSIFEofL, METH_VARARGS, (char *)"VSIFEofL(VSILFILE fp) -> int"},
+	 { (char *)"VSIFFlushL", _wrap_VSIFFlushL, METH_VARARGS, (char *)"VSIFFlushL(VSILFILE fp) -> int"},
 	 { (char *)"VSIFCloseL", _wrap_VSIFCloseL, METH_VARARGS, (char *)"VSIFCloseL(VSILFILE fp) -> VSI_RETVAL"},
 	 { (char *)"VSIFSeekL", _wrap_VSIFSeekL, METH_VARARGS, (char *)"VSIFSeekL(VSILFILE fp, GIntBig offset, int whence) -> int"},
 	 { (char *)"VSIFTellL", _wrap_VSIFTellL, METH_VARARGS, (char *)"VSIFTellL(VSILFILE fp) -> GIntBig"},

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -1474,6 +1474,10 @@ def VSIFEofL(*args):
     """VSIFEofL(VSILFILE fp) -> int"""
     return _gdal.VSIFEofL(*args)
 
+def VSIFFlushL(*args):
+    """VSIFFlushL(VSILFILE fp) -> int"""
+    return _gdal.VSIFFlushL(*args)
+
 def VSIFCloseL(*args):
     """VSIFCloseL(VSILFILE fp) -> VSI_RETVAL"""
     return _gdal.VSIFCloseL(*args)


### PR DESCRIPTION
## What does this PR do?

Add [`VSIFFlushL()`](https://www.gdal.org/cpl__vsi_8h.html#ac52ca4651926531e79e047709c9ea346) support to the SWIG Bindings.

eg. Python:
```python
gdal.VSIFFlushL(f)
```

## Tasklist

 - [x] Simple unit test added
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Bindings regenerated with SWIG 3.0.8 on Linux