### PR TITLE
BYN - Change driver long name, fix Identify() and Scale issues

### DIFF
--- a/gdal/frmts/formats_list.html
+++ b/gdal/frmts/formats_list.html
@@ -128,7 +128,7 @@
 </td><td> Yes
 </td></tr>
 
-<tr><td> <a href="frmt_byn.html">Natural Resource's Canada BYN format (.byn)</a>
+<tr><td> <a href="frmt_byn.html">Natural Resources Canada's Geoid BYN (.byn)</a>
 </td><td> BYN
 </td><td> Yes
 </td><td> Yes

--- a/gdal/frmts/raw/byndataset.cpp
+++ b/gdal/frmts/raw/byndataset.cpp
@@ -188,42 +188,42 @@ int BYNDataset::Identify( GDALOpenInfo *poOpenInfo )
 
     buffer2header( poOpenInfo->pabyHeader, &hHeader );
 
-    if( hHeader.nGlobal    < -1 || hHeader.nGlobal    > 2 ||
-        hHeader.nSizeOf    <  2 || hHeader.nSizeOf    > 4 ||
-        hHeader.nVDatum    < -1 || hHeader.nVDatum    > 3 ||
-        hHeader.nDatum     < -1 || hHeader.nDatum     > 1 ||
-        hHeader.nDescrip   < -1 || hHeader.nDescrip   > 3 ||
-        hHeader.nByteOrder < -1 || hHeader.nByteOrder > 1 )
+    if( hHeader.nGlobal    < 0 || hHeader.nGlobal    > 1 ||
+        hHeader.nType      < 0 || hHeader.nType      > 9 ||
+      ( hHeader.nSizeOf   != 2 && hHeader.nSizeOf   != 4 ) ||
+        hHeader.nVDatum    < 0 || hHeader.nVDatum    > 3 ||
+        hHeader.nDescrip   < 0 || hHeader.nDescrip   > 3 ||
+        hHeader.nSubType   < 0 || hHeader.nSubType   > 9 ||
+        hHeader.nDatum     < 0 || hHeader.nDatum     > 1 ||
+        hHeader.nEllipsoid < 0 || hHeader.nEllipsoid > 7 ||
+        hHeader.nByteOrder < 0 || hHeader.nByteOrder > 1 ||
+        hHeader.nScale     < 0 || hHeader.nScale     > 1 ||
+        hHeader.nTideSys   < 0 || hHeader.nTideSys   > 2 ||
+        hHeader.nPtType    < 0 || hHeader.nPtType    > 1 )
         return FALSE;
-
-    /* Move from cell center to upper left, lower right */
-
-    hHeader.nSouth = static_cast<GInt32>( std::abs( 
-            static_cast<GIntBig>( hHeader.nSouth ) - ( hHeader.nDLat / 2 ) ) );
-
-    hHeader.nNorth = static_cast<GInt32>( std::abs( 
-            static_cast<GIntBig>( hHeader.nNorth ) + ( hHeader.nDLat / 2 ) ) );
-
-    hHeader.nWest  = static_cast<GInt32>( std::abs( 
-            static_cast<GIntBig>( hHeader.nWest )  - ( hHeader.nDLon / 2 ) ) );
-
-    hHeader.nEast  = static_cast<GInt32>( std::abs( 
-            static_cast<GIntBig>( hHeader.nEast )  + ( hHeader.nDLon / 2 ) ) );
 
     if( hHeader.nScale == 0 )
     {
-        if( ( hHeader.nSouth > BYN_MAX_LAT ) ||
-            ( hHeader.nNorth > BYN_MAX_LAT ) ||
-            ( hHeader.nWest  > BYN_MAX_LON ) ||
-            ( hHeader.nEast  > BYN_MAX_LON ) )
+        if( ( std::abs( static_cast<GIntBig>( hHeader.nSouth ) - 
+                        ( hHeader.nDLat / 2 ) ) > BYN_MAX_LAT ) ||
+            ( std::abs( static_cast<GIntBig>( hHeader.nNorth ) + 
+                        ( hHeader.nDLat / 2 ) ) > BYN_MAX_LAT ) ||
+            ( std::abs( static_cast<GIntBig>( hHeader.nWest ) - 
+                        ( hHeader.nDLon / 2 ) ) > BYN_MAX_LON ) ||
+            ( std::abs( static_cast<GIntBig>( hHeader.nEast ) + 
+                        ( hHeader.nDLon / 2 ) ) > BYN_MAX_LON ) )
             return FALSE;
     }
     else
     {
-        if( ( hHeader.nSouth > BYN_MAX_LAT_SCL ) ||
-            ( hHeader.nNorth > BYN_MAX_LAT_SCL ) ||
-            ( hHeader.nWest  > BYN_MAX_LON_SCL ) ||
-            ( hHeader.nEast  > BYN_MAX_LON_SCL ) )
+        if( ( std::abs( static_cast<GIntBig>( hHeader.nSouth ) - 
+                        ( hHeader.nDLat / 2 ) ) > BYN_MAX_LAT_SCL ) ||
+            ( std::abs( static_cast<GIntBig>( hHeader.nNorth ) + 
+                        ( hHeader.nDLat / 2 ) ) > BYN_MAX_LAT_SCL ) ||
+            ( std::abs( static_cast<GIntBig>( hHeader.nWest ) - 
+                        ( hHeader.nDLon / 2 ) ) > BYN_MAX_LON_SCL ) ||
+            ( std::abs( static_cast<GIntBig>( hHeader.nEast ) + 
+                        ( hHeader.nDLon / 2 ) ) > BYN_MAX_LON_SCL ) )
             return FALSE;
     }
 

--- a/gdal/frmts/raw/byndataset.cpp
+++ b/gdal/frmts/raw/byndataset.cpp
@@ -35,7 +35,6 @@
 #include "gdal_frmts.h"
 #include "ogr_spatialref.h"
 #include "ogr_srs_api.h"
-#include "cpl_safemaths.hpp"
 
 #include <cstdlib>
 
@@ -199,17 +198,17 @@ int BYNDataset::Identify( GDALOpenInfo *poOpenInfo )
 
     /* Move from cell center to upper left, lower right */
 
-    try
-    {
-        hHeader.nSouth = std::abs( hHeader.nSouth - ( hHeader.nDLat / 2 ) );
-        hHeader.nNorth = std::abs( hHeader.nNorth + ( hHeader.nDLat / 2 ) );
-        hHeader.nWest  = std::abs( hHeader.nWest  - ( hHeader.nDLon / 2 ) );
-        hHeader.nEast  = std::abs( hHeader.nEast  + ( hHeader.nDLon / 2 ) );
-    }
-    catch( const CPLSafeIntOverflow& )
-    {
-        return FALSE;
-    }
+    hHeader.nSouth = static_cast<GInt32>( std::abs( 
+            static_cast<GIntBig>( hHeader.nSouth ) - ( hHeader.nDLat / 2 ) ) );
+
+    hHeader.nNorth = static_cast<GInt32>( std::abs( 
+            static_cast<GIntBig>( hHeader.nNorth ) + ( hHeader.nDLat / 2 ) ) );
+
+    hHeader.nWest  = static_cast<GInt32>( std::abs( 
+            static_cast<GIntBig>( hHeader.nWest )  - ( hHeader.nDLon / 2 ) ) );
+
+    hHeader.nEast  = static_cast<GInt32>( std::abs( 
+            static_cast<GIntBig>( hHeader.nEast )  + ( hHeader.nDLon / 2 ) ) );
 
     if( hHeader.nScale == 0 )
     {

--- a/gdal/frmts/raw/byndataset.h
+++ b/gdal/frmts/raw/byndataset.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Project:  National Resources Canada - Vertical Datum Transformation
+ * Project:  Natural Resources Canada's Geoid BYN file format
  * Purpose:  Implementation of BYN format
  * Author:   Ivan Lucena, ivan.lucena@outlook.com
  *
@@ -196,8 +196,11 @@ constexpr int BYN_VDATUM_3         = 6357;  /* NAVD88 */
 
 /* Maximum ordinates values for Identify() */
 
-constexpr GInt32 BYN_MAX_LAT       =  90 * 3600;
-constexpr GInt32 BYN_MAX_LON       = 180 * 3600;
+constexpr GInt32 BYN_SCALE         = 1000;
+constexpr GInt32 BYN_MAX_LAT       =   90 * 3600 * 2;
+constexpr GInt32 BYN_MAX_LON       =  180 * 3600 * 2;
+constexpr GInt32 BYN_MAX_LAT_SCL   =  BYN_MAX_LAT / BYN_SCALE;
+constexpr GInt32 BYN_MAX_LON_SCL   =  BYN_MAX_LON / BYN_SCALE;
 
 /************************************************************************/
 /* ==================================================================== */

--- a/gdal/frmts/raw/frmt_byn.html
+++ b/gdal/frmts/raw/frmt_byn.html
@@ -1,9 +1,9 @@
 <html>
 	<head>
-		<title>BYN --- Natural Resources Canada ".byn" format</title>
+		<title>BYN - Natural Resources Canada's Geoid</title>
 	</head>
 	<body bgcolor="#ffffff">
-		<h1>BYN --- Natural Resources Canada's ".byn" format</h1>
+		<h1>BYN - Natural Resources Canada's Geoid file format (.byn)</h1>
 		<P class="MsoNormal">
 		Files with extension ".byn" have a binary format. 
 		The format includes two sections which are the Header


### PR DESCRIPTION
Change driver long name at users request.

Apply suggested fixes to Identify() by taking scale into account.

Fix memory leak on GetProjectionRef ( return "" instead of return nullptr).

Reverse the formula for scaling of ordinates. According to the documentation if the header varaible scale is not 0 the boundaries and spacing should be multiplied by 1000 instead of divided like first coded.

```
#  Variable    Description        Type   Byte Sum Comments/(Units)
--:-----------:------------------:------:----:---:---------------------------
18 Scale       Scale Boundaries   short  2    52  0: No scale applied to boundaries and spacing
                                                  1: Scale is applied (x1000)

```