### PR TITLE
Add VSIErrorReset() into SWIG bindings

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -838,6 +838,41 @@ def vsifile_21():
 
     return 'success'
 
+
+def vsifile_22():
+    # VSIOpenL doesn't set errorno
+    gdal.VSIErrorReset()
+    if gdal.VSIGetLastErrorNo() != 0:
+        gdaltest.post_reason("Expected Err=0 after VSIErrorReset(), got %d" % gdal.VSIGetLastErrorNo())
+        return 'fail'
+
+    fp = gdal.VSIFOpenL('tmp/not-existing', 'r')
+    if fp is not None:
+        gdaltest.post_reason("Expected None from VSIFOpenL")
+        return 'fail'
+    if gdal.VSIGetLastErrorNo() != 0:
+        gdaltest.post_reason("Expected Err=0 from VSIFOpenL, got %d" % gdal.VSIGetLastErrorNo())
+        return 'fail'
+
+    # VSIOpenExL does
+    fp = gdal.VSIFOpenExL('tmp/not-existing', 'r', 1)
+    if fp is not None:
+        gdaltest.post_reason("Expected None from VSIFOpenExL")
+        return 'fail'
+    if gdal.VSIGetLastErrorNo() != 1:
+        gdaltest.post_reason("Expected Err=1 from VSIFOpenExL, got %d" % gdal.VSIGetLastErrorNo())
+        return 'fail'
+    if len(gdal.VSIGetLastErrorMsg()) == 0:
+        gdaltest.post_reason("Expected a VSI error message")
+        return 'fail'
+    gdal.VSIErrorReset()
+    if gdal.VSIGetLastErrorNo() != 0:
+        gdaltest.post_reason("Expected Err=0 after VSIErrorReset(), got %d" % gdal.VSIGetLastErrorNo())
+        return 'fail'
+
+    return 'success'
+
+
 ###############################################################################
 # Test bugfix for https://github.com/OSGeo/gdal/issues/675
 
@@ -902,6 +937,7 @@ gdaltest_list = [vsifile_1,
                  vsifile_19,
                  vsifile_20,
                  vsifile_21,
+                 vsifile_22,
                  vsitar_bug_675,
                  vsigzip_multi_thread]
 

--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -308,6 +308,7 @@ unsigned int CPLGetErrorCounter();
 
 int VSIGetLastErrorNo();
 const char *VSIGetLastErrorMsg();
+void VSIErrorReset();
 
 void CPLPushFinderLocation( const char * utf8_path );
 

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -7926,6 +7926,36 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_VSIErrorReset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  
+  if (!PyArg_ParseTuple(args,(char *)":VSIErrorReset")) SWIG_fail;
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      VSIErrorReset();
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_PushFinderLocation(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   char *arg1 = (char *) 0 ;
@@ -34335,6 +34365,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"GetErrorCounter", _wrap_GetErrorCounter, METH_VARARGS, (char *)"GetErrorCounter() -> unsigned int"},
 	 { (char *)"VSIGetLastErrorNo", _wrap_VSIGetLastErrorNo, METH_VARARGS, (char *)"VSIGetLastErrorNo() -> int"},
 	 { (char *)"VSIGetLastErrorMsg", _wrap_VSIGetLastErrorMsg, METH_VARARGS, (char *)"VSIGetLastErrorMsg() -> char const *"},
+	 { (char *)"VSIErrorReset", _wrap_VSIErrorReset, METH_VARARGS, (char *)"VSIErrorReset()"},
 	 { (char *)"PushFinderLocation", _wrap_PushFinderLocation, METH_VARARGS, (char *)"PushFinderLocation(char const * utf8_path)"},
 	 { (char *)"PopFinderLocation", _wrap_PopFinderLocation, METH_VARARGS, (char *)"PopFinderLocation()"},
 	 { (char *)"FinderClean", _wrap_FinderClean, METH_VARARGS, (char *)"FinderClean()"},

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -1312,6 +1312,10 @@ def VSIGetLastErrorMsg(*args):
     """VSIGetLastErrorMsg() -> char const *"""
     return _gdal.VSIGetLastErrorMsg(*args)
 
+def VSIErrorReset(*args):
+    """VSIErrorReset()"""
+    return _gdal.VSIErrorReset(*args)
+
 def PushFinderLocation(*args):
     """PushFinderLocation(char const * utf8_path)"""
     return _gdal.PushFinderLocation(*args)


### PR DESCRIPTION
## What does this PR do?

Add support for [`VSIErrorReset()`](https://github.com/OSGeo/gdal/blob/d5f6bb89b0e0db0a06489419050d432e8f58ff47/gdal/port/cpl_vsi_error.cpp#L188-L197) into all the various SWIG bindings. Otherwise you can't clear [`VSIGetLastErrorNo()`](https://github.com/OSGeo/gdal/blob/d5f6bb89b0e0db0a06489419050d432e8f58ff47/gdal/port/cpl_vsi_error.cpp#L209-L222) which makes it hard to use.

This is a precursor to generally improving VSI error handling behaviour so VSI follows the `gdal.UseExceptions()` flag like the rest of GDAL. Currently there seems to be a mix of exceptions, error return codes, and ignoring...

## What are related issues/pull requests?

[#7145: Python: VSI functions never throw exceptions](https://trac.osgeo.org/gdal/ticket/7145)

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Bindings were rebuilt using v3.0.8 to match the existing code