### PR TITLE
Add template class CPLAutoClose

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -2458,7 +2458,6 @@ namespace tut
     void object::test<36>()
     {
         static int counter = 0;
-#if __cplusplus >= 201103L
         class AutoCloseTest{
         public:
             AutoCloseTest() {
@@ -2482,9 +2481,6 @@ namespace tut
             CPL_AUTO_CLOSE_WARP(p2,AutoCloseTest::Destory);
 
         }
-#else
-        counter = 400;
-#endif
         ensure_equals(counter,400);
     }
 

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -39,6 +39,7 @@
 #include "cpl_json_streaming_parser.h"
 #include "cpl_mem_cache.h"
 #include "cpl_http.h"
+#include "cpl_auto_close.h"
 
 #include <fstream>
 #include <string>
@@ -2450,5 +2451,41 @@ namespace tut
         szDate[nRet] = 0;
         ensure_equals( std::string(szDate), std::string("Wed, 20 Jun 2018 12:34:56 GMT") );
     }
+
+    // Test CPLAutoClose
+    template<>
+    template<>
+    void object::test<36>()
+    {
+		static int counter = 0;
+#if __cplusplus >= 201103L
+        class AutoCloseTest{
+		public:
+			AutoCloseTest() {
+				counter += 222;
+			}
+            virtual ~AutoCloseTest() { 
+				counter -= 22;
+			}
+			static AutoCloseTest* Create() {
+				return new AutoCloseTest;
+			}
+			static void Destory(AutoCloseTest* p) {
+				delete p;
+			}
+        };
+		{
+			AutoCloseTest* p1 = AutoCloseTest::Create();
+			CPL_AUTO_CLOSE_WARP(p1,AutoCloseTest::Destory);
+
+			AutoCloseTest* p2 = AutoCloseTest::Create();
+			CPL_AUTO_CLOSE_WARP(p2,AutoCloseTest::Destory);
+
+		}
+#else
+		counter = 400;
+#endif
+		ensure_equals(counter,400);
+	}
 
 } // namespace tut

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -2457,35 +2457,35 @@ namespace tut
     template<>
     void object::test<36>()
     {
-		static int counter = 0;
+        static int counter = 0;
 #if __cplusplus >= 201103L
         class AutoCloseTest{
-		public:
-			AutoCloseTest() {
-				counter += 222;
-			}
+        public:
+            AutoCloseTest() {
+                counter += 222;
+            }
             virtual ~AutoCloseTest() { 
-				counter -= 22;
-			}
-			static AutoCloseTest* Create() {
-				return new AutoCloseTest;
-			}
-			static void Destory(AutoCloseTest* p) {
-				delete p;
-			}
+                counter -= 22;
+            }
+            static AutoCloseTest* Create() {
+                return new AutoCloseTest;
+            }
+            static void Destory(AutoCloseTest* p) {
+                delete p;
+            }
         };
-		{
-			AutoCloseTest* p1 = AutoCloseTest::Create();
-			CPL_AUTO_CLOSE_WARP(p1,AutoCloseTest::Destory);
+        {
+            AutoCloseTest* p1 = AutoCloseTest::Create();
+            CPL_AUTO_CLOSE_WARP(p1,AutoCloseTest::Destory);
 
-			AutoCloseTest* p2 = AutoCloseTest::Create();
-			CPL_AUTO_CLOSE_WARP(p2,AutoCloseTest::Destory);
+            AutoCloseTest* p2 = AutoCloseTest::Create();
+            CPL_AUTO_CLOSE_WARP(p2,AutoCloseTest::Destory);
 
-		}
+        }
 #else
-		counter = 400;
+        counter = 400;
 #endif
-		ensure_equals(counter,400);
-	}
+        ensure_equals(counter,400);
+    }
 
 } // namespace tut

--- a/gdal/port/GNUmakefile
+++ b/gdal/port/GNUmakefile
@@ -110,7 +110,8 @@ INST_H_FILES = \
 	cpl_vsi.h \
 	cpl_vsi_error.h \
 	cpl_vsi_virtual.h \
-	gdal_csv.h
+	gdal_csv.h \
+	cpl_auto_close.h
 
 install:
 	for f in $(INST_H_FILES) ; do $(INSTALL_DATA) $$f $(DESTDIR)$(INST_INCLUDE) ; done

--- a/gdal/port/cpl_auto_close.h
+++ b/gdal/port/cpl_auto_close.h
@@ -31,7 +31,7 @@
 #ifndef CPL_AUTO_CLOSE_H_INCLUDED
 #define CPL_AUTO_CLOSE_H_INCLUDED
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if defined(__cplusplus)
 #include <type_traits>
 
 /************************************************************************/

--- a/gdal/port/cpl_auto_close.h
+++ b/gdal/port/cpl_auto_close.h
@@ -4,10 +4,10 @@
  * Name:     cpl_auto_close.h
  * Project:  CPL - Common Portability Library
  * Purpose:  CPL Auto Close handling
- * Author:   liuyimin, ymwh@foxmail.com
+ * Author:   Liu Yimin, ymwh@foxmail.com
  *
  **********************************************************************
- * Copyright (c) 1998, Daniel Morissette
+ * Copyright (c) 2018, Liu Yimin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -57,12 +57,11 @@ class CPLAutoClose {
 		{
 			if(m_ResourcePtr && m_CloseFunc)
 			  m_CloseFunc(m_ResourcePtr);
-			m_ResourcePtr = nullptr;
 		}
 };
 
-#define CPL_AUTO_CLOSE_WARP(ptr,closefn) \
-	CPLAutoClose<decltype(ptr),decltype(closefn)*> tAutoClose##ptr##closefn(ptr,closefn)
+#define CPL_AUTO_CLOSE_WARP(hObject,closeFunc) \
+	CPLAutoClose<decltype(hObject),decltype(closeFunc)*> tAutoClose##hObject(hObject,closeFunc)
 
 #endif /* __cplusplus */
 

--- a/gdal/port/cpl_auto_close.h
+++ b/gdal/port/cpl_auto_close.h
@@ -40,28 +40,28 @@
 
 template<typename _Ty,typename _Dx>
 class CPLAutoClose {
-	static_assert( !std::is_const<_Ty>::value && std::is_pointer<_Ty>::value,
-					"_Ty must is pointer type,_Dx must is function type");
-	private:
-	_Ty& m_ResourcePtr;
-	_Dx  m_CloseFunc;
-	private:
-	CPLAutoClose(const CPLAutoClose&) = delete;
-	void operator=(const CPLAutoClose&) = delete;
-	public:
-		explicit CPLAutoClose(_Ty& ptr,_Dx dt) :
-			m_ResourcePtr(ptr),
-			m_CloseFunc(dt)
-		{}
-		~CPLAutoClose()
-		{
-			if(m_ResourcePtr && m_CloseFunc)
-			  m_CloseFunc(m_ResourcePtr);
-		}
+    static_assert( !std::is_const<_Ty>::value && std::is_pointer<_Ty>::value,
+                    "_Ty must is pointer type,_Dx must is function type");
+    private:
+    _Ty& m_ResourcePtr;
+    _Dx  m_CloseFunc;
+    private:
+    CPLAutoClose(const CPLAutoClose&) = delete;
+    void operator=(const CPLAutoClose&) = delete;
+    public:
+        explicit CPLAutoClose(_Ty& ptr,_Dx dt) :
+            m_ResourcePtr(ptr),
+            m_CloseFunc(dt)
+        {}
+        ~CPLAutoClose()
+        {
+            if(m_ResourcePtr && m_CloseFunc)
+              m_CloseFunc(m_ResourcePtr);
+        }
 };
 
 #define CPL_AUTO_CLOSE_WARP(hObject,closeFunc) \
-	CPLAutoClose<decltype(hObject),decltype(closeFunc)*> tAutoClose##hObject(hObject,closeFunc)
+    CPLAutoClose<decltype(hObject),decltype(closeFunc)*> tAutoClose##hObject(hObject,closeFunc)
 
 #endif /* __cplusplus */
 

--- a/gdal/port/cpl_auto_close.h
+++ b/gdal/port/cpl_auto_close.h
@@ -38,6 +38,15 @@
 /*                           CPLAutoClose                               */
 /************************************************************************/
 
+/**
+ * The class use the destructor to automatically close the resource.
+ * Example:
+ *     GDALDatasetH hDset = GDALOpen(path,GA_ReadOnly);
+ *     CPLAutoClose<GDALDatasetH,void(*)(void*)> autoclosehDset(hDset,GDALClose);
+ * Or:
+ *     GDALDatasetH hDset = GDALOpen(path,GA_ReadOnly);
+ *     CPL_AUTO_CLOSE_WARP(hDset,GDALClose);
+ */
 template<typename _Ty,typename _Dx>
 class CPLAutoClose {
     static_assert( !std::is_const<_Ty>::value && std::is_pointer<_Ty>::value,
@@ -49,10 +58,18 @@ class CPLAutoClose {
     CPLAutoClose(const CPLAutoClose&) = delete;
     void operator=(const CPLAutoClose&) = delete;
     public:
+        /**
+         * @brief Constructor.
+         * @param ptr Pointer to the resource object.
+         * @param dt  Resource release(close) function.
+         */
         explicit CPLAutoClose(_Ty& ptr,_Dx dt) :
             m_ResourcePtr(ptr),
             m_CloseFunc(dt)
         {}
+        /**
+         * @brief Destructor.
+         */
         ~CPLAutoClose()
         {
             if(m_ResourcePtr && m_CloseFunc)

--- a/gdal/port/cpl_auto_close.h
+++ b/gdal/port/cpl_auto_close.h
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * $Id$
+ *
+ * Name:     cpl_auto_close.h
+ * Project:  CPL - Common Portability Library
+ * Purpose:  CPL Auto Close handling
+ * Author:   liuyimin, ymwh@foxmail.com
+ *
+ **********************************************************************
+ * Copyright (c) 1998, Daniel Morissette
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef CPL_AUTO_CLOSE_H_INCLUDED
+#define CPL_AUTO_CLOSE_H_INCLUDED
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#include <type_traits>
+
+/************************************************************************/
+/*                           CPLAutoClose                               */
+/************************************************************************/
+
+template<typename _Ty,typename _Dx>
+class CPLAutoClose {
+	static_assert( !std::is_const<_Ty>::value && std::is_pointer<_Ty>::value,
+					"_Ty must is pointer type,_Dx must is function type");
+	private:
+	_Ty& m_ResourcePtr;
+	_Dx  m_CloseFunc;
+	private:
+	CPLAutoClose(const CPLAutoClose&) = delete;
+	void operator=(const CPLAutoClose&) = delete;
+	public:
+		explicit CPLAutoClose(_Ty& ptr,_Dx dt) :
+			m_ResourcePtr(ptr),
+			m_CloseFunc(dt)
+		{}
+		~CPLAutoClose()
+		{
+			if(m_ResourcePtr && m_CloseFunc)
+			  m_CloseFunc(m_ResourcePtr);
+			m_ResourcePtr = nullptr;
+		}
+};
+
+#define CPL_AUTO_CLOSE_WARP(ptr,closefn) \
+	CPLAutoClose<decltype(ptr),decltype(closefn)*> tAutoClose##ptr##closefn(ptr,closefn)
+
+#endif /* __cplusplus */
+
+#endif /* CPL_AUTO_CLOSE_H_INCLUDED */


### PR DESCRIPTION
## What does this PR do?
Sorry, my English is not good.
In the process of using GDAL, I often encounter places where resources need to be released.

In most cases, std::unique_ptr can be used to automatically release the resources used, but some special places can make it difficult to use or cause the code to be very messy.

For example, when using GDALBuildVRTOptions, I have to do some packaging to use std::unique_ptr, I feel very troublesome, so I simply wrote a template class CPLAutoClose, I think this can be shared.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Windows10 / Linux 4.16.3-1(ArchLinux)
* Compiler: MSVC 14.0 / gcc 7.3.1
