### PR TITLE
LizardTech corporate name change to Extensis

### DIFF
--- a/gdal/frmts/mrsid/frmt_jp2mrsid.html
+++ b/gdal/frmts/mrsid/frmt_jp2mrsid.html
@@ -51,7 +51,7 @@ lossless compression.  Twenty would indicate a 20:1 compression ratio (the
 image would be compressed to 1/20 its original size).
   <p>
 
-<li> <strong>XMLPROFILE=[path to file]</strong>: Indicates a path to a LizardTech-specific
+<li> <strong>XMLPROFILE=[path to file]</strong>: Indicates a path to an Extensis-specific
   XML profile that can be used to set JPEG2000 encoding parameters. They can
   be created
   using
@@ -63,7 +63,7 @@ a template:
 &lt;Jp2Profile version="1.0"&gt;
   &lt;Header&gt;
     &lt;name&gt;Default&lt;/name&gt;
-    &lt;description&gt;LizardTech preferred settings (20051216)&lt;/description&gt;
+    &lt;description&gt;Extensis preferred settings (20051216)&lt;/description&gt;
   &lt;/Header&gt;
   &lt;Codestream&gt;
     &lt;layers&gt;
@@ -101,7 +101,7 @@ a template:
 <ul>
 <li> Implemented as <tt>gdal/frmts/mrsid/mrsiddataset.cpp</tt>.<p>
 
-<li> <a href="http://www.lizardtech.com">LizardTech's Web site</a><p>
+<li> <a href="http://www.extensis.com/support/developers">Extensis web site</a><p>
 
 </ul>
 

--- a/gdal/frmts/mrsid/frmt_mrsid.html
+++ b/gdal/frmts/mrsid/frmt_mrsid.html
@@ -11,11 +11,11 @@ MrSID is a wavelet-based image compression technology which can utilize both
 lossy and lossless encoding. This technology was acquired in its original
 form from Los Alamos National Laboratories (LANL), where it was developed
 under the aegis of the U.S. government for storing fingerprints for the FBI.
-Now it is developed and distributed by the LizardTech, Inc.<p>
+Now it is developed and distributed by Extensis.<p>
 
-This driver supports reading of MrSID image files using LizardTech's decoding
+This driver supports reading of MrSID image files using Extensis' decoding
 software development kit (DSDK). <b>This DSDK is not free software, you should
-contact LizardTech to obtain it (see link at end of this page).</b> If you are
+contact Extensis to obtain it (see link at end of this page).</b> If you are
 using GCC, please, ensure that you have the same compiler as was used
 for DSDK compilation. It is C++ library, so you may get incompatibilities
 in C++ name mangling between different GCC versions (2.95.x and 3.x).<p>
@@ -35,8 +35,8 @@ in tag names. These characters replaced in GDAL with `_' during translation.
 So if you are using other software to work with MrSID be ready that names
 of metadata keys will be shown differently in GDAL.<p>
 
-Starting with GDAL 1.9.0, XMP metadata can be extracted from JPEG2000 files, and will be
-stored as XML raw content in the xml:XMP metadata domain.<p>
+Starting with GDAL 1.9.0, XMP metadata can be extracted from JPEG2000 files,
+and will be stored as XML raw content in the xml:XMP metadata domain.<p>
 
 <h2>Georeference</h2>
 
@@ -53,7 +53,7 @@ georeference information from them.<p>
 <ul>
 <li> Implemented as <tt>gdal/frmts/mrsid/mrsiddataset.cpp</tt>.<p>
 
-<li> <a href="http://www.lizardtech.com">LizardTech's web site<a><p>
+<li> <a href="http://www.extensis.com/support/developers">Extensis web site<a><p>
 
 </ul>
 

--- a/gdal/frmts/mrsid_lidar/frmt_mrsid_lidar.html
+++ b/gdal/frmts/mrsid_lidar/frmt_mrsid_lidar.html
@@ -22,10 +22,10 @@ output.</b>  The contents of the View file are described in the specification
 
 <p>MrSID/MG4 is a wavelet-based point-cloud compression technology. You may
 think of it like a LAS file, only smaller and with a built in spatial index.
-It is developed and distributed by LizardTech. This driver supports reading
-of MG4 LiDAR files using LizardTech's decoding software development kit (DSDK).
+It is developed and distributed by Extensis. This driver supports reading
+of MG4 LiDAR files using Extensis' decoding software development kit (DSDK).
 <b>This DSDK is freely distributed; but, it is not open source software.
-You should contact LizardTech to obtain it (see link at end of this page).</b>
+You should contact Extensis to obtain it (see link at end of this page).</b>
 </p>
 
 <h2>Example View files (from View Document specification)</h2>
@@ -139,7 +139,7 @@ parameters.  Many invalid entries will likely fail silently.</p>
 <ul>
  <li>Implemented as <i>gdal/frmts/mrsid_lidar/gdal_MG4Lidar.cpp</i></li>
  <li><a href="frmt_mrsid_lidar_view_point_cloud.html">MrSID/MG4 LiDAR View Document Specification</a></li>
- <li><a href="http://www.lizardtech.com">LizardTech's Web site</a></li>
+ <li><a href="http://www.extensis.com/support/developers">Extensis web site</a></li>
 </ul>
 
 </body>

--- a/gdal/frmts/mrsid_lidar/frmt_mrsid_lidar_view_point_cloud.html
+++ b/gdal/frmts/mrsid_lidar/frmt_mrsid_lidar_view_point_cloud.html
@@ -773,7 +773,7 @@ View Documents</p>
 
 <p class=MsoNoSpacing align=right style='text-align:right'>Michael Rosen, et al</p>
 
-<p class=MsoNoSpacing align=right style='text-align:right'><span class=SpellE>LizardTech</span></p>
+<p class=MsoNoSpacing align=right style='text-align:right'><span class=SpellE>Extensis</span></p>
 
 <p class=MsoNoSpacing align=right style='text-align:right'>March 2010</p>
 


### PR DESCRIPTION
## What does this PR do?
Updates references to LizardTech in the MrSID format docs.  LizardTech corporate name is going away and the company is operating under the name of Extensis now.

## What are related issues/pull requests?
None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

This is an html-only change, no code involved.

* OS:
* Compiler:
