### PR TITLE
Add BILINEAR to list of resampling method names

### DIFF
--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -1462,7 +1462,8 @@ CPLErr CPL_STDCALL GDALSetGCPs( GDALDatasetH hDS, int nGCPCount,
  * This method is the same as the C function GDALBuildOverviews().
  *
  * @param pszResampling one of "NEAREST", "GAUSS", "CUBIC", "AVERAGE", "MODE",
- * "AVERAGE_MAGPHASE" or "NONE" controlling the downsampling method applied.
+ * "AVERAGE_MAGPHASE", "BILINEAR",  or "NONE" controlling the downsampling
+ * method applied.
  * @param nOverviews number of overviews to build, or 0 to clean overviews.
  * @param panOverviewList the list of overview decimation factors to build, or
  *                        NULL if nOverviews == 0.


### PR DESCRIPTION
This PR fixes a small documentation bug by adding "BILINEAR" to the list of permitted resampling algorithm names for GDALBuildOverviews.