### PR TITLE
GDAL_HTTPS_PROXY

### DIFF
--- a/autotest/pymod/gdaltest_python2.py
+++ b/autotest/pymod/gdaltest_python2.py
@@ -70,18 +70,25 @@ def urlescape(url):
 def gdalurlopen(url, timeout=10):
     old_timeout = socket.getdefaulttimeout()
     socket.setdefaulttimeout(timeout)
+    proxy = None
 
     if 'GDAL_HTTP_PROXY' in os.environ:
         proxy = os.environ['GDAL_HTTP_PROXY']
+        protocol = 'http'
 
+    if 'GDAL_HTTPS_PROXY' in os.environ and url.startswith('https'):
+        proxy = os.environ['GDAL_HTTPS_PROXY']
+        protocol = 'https'
+
+    if proxy is not None:
         if 'GDAL_HTTP_PROXYUSERPWD' in os.environ:
             proxyuserpwd = os.environ['GDAL_HTTP_PROXYUSERPWD']
-            proxyHandler = urllib2.ProxyHandler({"http":
-                                                 "http://%s@%s" % (proxyuserpwd, proxy)})
+            proxyHandler = urllib2.ProxyHandler({"%s" % protocol:
+                                                 "%s://%s@%s" % (protocol, proxyuserpwd, proxy)})
         else:
             proxyuserpwd = None
-            proxyHandler = urllib2.ProxyHandler({"http":
-                                                 "http://%s" % (proxy)})
+            proxyHandler = urllib2.ProxyHandler({"%s" % protocol:
+                                                 "%s://%s" % (protocol, proxy)})
 
         opener = urllib2.build_opener(proxyHandler, urllib2.HTTPHandler)
 

--- a/autotest/pymod/gdaltest_python3.py
+++ b/autotest/pymod/gdaltest_python3.py
@@ -75,18 +75,25 @@ def urlescape(url):
 def gdalurlopen(url, timeout=10):
     old_timeout = socket.getdefaulttimeout()
     socket.setdefaulttimeout(timeout)
+    proxy = None
 
     if 'GDAL_HTTP_PROXY' in os.environ:
         proxy = os.environ['GDAL_HTTP_PROXY']
+        protocol = 'http'
 
+    if 'GDAL_HTTPS_PROXY' in os.environ and url.startswith('https'):
+        proxy = os.environ['GDAL_HTTPS_PROXY']
+        protocol = 'https'
+
+    if proxy is not None:
         if 'GDAL_HTTP_PROXYUSERPWD' in os.environ:
             proxyuserpwd = os.environ['GDAL_HTTP_PROXYUSERPWD']
-            proxyHandler = urllib.request.ProxyHandler({"http":
-                                                        "http://%s@%s" % (proxyuserpwd, proxy)})
+            proxyHandler = urllib.request.ProxyHandler({"%s" % protocol:
+                                                        "%s://%s@%s" % (protocol, proxyuserpwd, proxy)})
         else:
             proxyuserpwd = None
-            proxyHandler = urllib.request.ProxyHandler({"http":
-                                                        "http://%s" % (proxy)})
+            proxyHandler = urllib.request.ProxyHandler({"%s" % protocol:
+                                                        "%s://%s" % (protocol, proxy)})
 
         opener = urllib.request.build_opener(proxyHandler, urllib.request.HTTPHandler)
 

--- a/gdal/frmts/wms/gdalhttp.cpp
+++ b/gdal/frmts/wms/gdalhttp.cpp
@@ -84,7 +84,6 @@ void WMSHTTPInitializeRequest(WMSHTTPRequest *psRequest) {
     if (!psRequest->Range.empty())
         curl_easy_setopt(psRequest->m_curl_handle, CURLOPT_RANGE, psRequest->Range.c_str());
 
-    curl_easy_setopt(psRequest->m_curl_handle, CURLOPT_URL, psRequest->URL.c_str());
     curl_easy_setopt(psRequest->m_curl_handle, CURLOPT_WRITEDATA, psRequest);
     curl_easy_setopt(psRequest->m_curl_handle, CURLOPT_WRITEFUNCTION, CPLHTTPWriteFunc);
 
@@ -92,7 +91,7 @@ void WMSHTTPInitializeRequest(WMSHTTPRequest *psRequest) {
     curl_easy_setopt(psRequest->m_curl_handle, CURLOPT_ERRORBUFFER, &psRequest->m_curl_error[0]);
 
     psRequest->m_headers = static_cast<struct curl_slist*>(
-            CPLHTTPSetOptions(psRequest->m_curl_handle, psRequest->options));
+            CPLHTTPSetOptions(psRequest->m_curl_handle, psRequest->URL.c_str(), psRequest->options));
     if( psRequest->m_headers != nullptr )
         curl_easy_setopt(psRequest->m_curl_handle, CURLOPT_HTTPHEADER,
                          psRequest->m_headers);

--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -575,7 +575,10 @@ static void CPLHTTPEmitFetchDebug(const char* pszURL,
  * <li>POSTFIELDS=val, where val is a nul-terminated string to be passed to the server
  *                     with a POST request.</li>
  * <li>PROXY=val, to make requests go through a proxy server, where val is of the
- *                form proxy.server.com:port_number</li>
+ *                form proxy.server.com:port_number. This option affects both HTTP and HTTPS
+ *                URLs.</li>
+ * <li>HTTPS_PROXY=val, the same meaning as PROXY, but this option is taken into account only
+ *                 for HTTPS URLs.</li>
  * <li>PROXYUSERPWD=val, where val is of the form username:password</li>
  * <li>PROXYAUTH=[BASIC/NTLM/DIGEST/ANY] to specify an proxy authentication scheme to use.</li>
  * <li>NETRC=[YES/NO] to enable or disable use of $HOME/.netrc, default YES.</li>
@@ -608,12 +611,12 @@ static void CPLHTTPEmitFetchDebug(const char* pszURL,
  *
  * Alternatively, if not defined in the papszOptions arguments, the
  * CONNECTTIMEOUT, TIMEOUT,
- * LOW_SPEED_TIME, LOW_SPEED_LIMIT, USERPWD, PROXY, PROXYUSERPWD, PROXYAUTH, NETRC,
+ * LOW_SPEED_TIME, LOW_SPEED_LIMIT, USERPWD, PROXY, HTTPS_PROXY, PROXYUSERPWD, PROXYAUTH, NETRC,
  * MAX_RETRY and RETRY_DELAY, HEADER_FILE, HTTP_VERSION, SSL_VERIFYSTATUS, USE_CAPI_STORE
  * values are searched in the configuration
  * options respectively named GDAL_HTTP_CONNECTTIMEOUT, GDAL_HTTP_TIMEOUT,
  * GDAL_HTTP_LOW_SPEED_TIME, GDAL_HTTP_LOW_SPEED_LIMIT, GDAL_HTTP_USERPWD,
- * GDAL_HTTP_PROXY, GDAL_HTTP_PROXYUSERPWD, GDAL_PROXY_AUTH,
+ * GDAL_HTTP_PROXY, GDAL_HTTPS_PROXY, GDAL_HTTP_PROXYUSERPWD, GDAL_PROXY_AUTH,
  * GDAL_HTTP_NETRC, GDAL_HTTP_MAX_RETRY, GDAL_HTTP_RETRY_DELAY,
  * GDAL_HTTP_HEADER_FILE, GDAL_HTTP_VERSION, GDAL_HTTP_SSL_VERIFYSTATUS,
  * GDAL_HTTP_USE_CAPI_STORE

--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -577,7 +577,7 @@ static void CPLHTTPEmitFetchDebug(const char* pszURL,
  * <li>PROXY=val, to make requests go through a proxy server, where val is of the
  *                form proxy.server.com:port_number. This option affects both HTTP and HTTPS
  *                URLs.</li>
- * <li>HTTPS_PROXY=val, the same meaning as PROXY, but this option is taken into account only
+ * <li>HTTPS_PROXY=val (GDAL >= 2.4), the same meaning as PROXY, but this option is taken into account only
  *                 for HTTPS URLs.</li>
  * <li>PROXYUSERPWD=val, where val is of the form username:password</li>
  * <li>PROXYAUTH=[BASIC/NTLM/DIGEST/ANY] to specify an proxy authentication scheme to use.</li>

--- a/gdal/port/cpl_http.h
+++ b/gdal/port/cpl_http.h
@@ -136,7 +136,7 @@ CPL_C_END
 #if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)
 /*! @cond Doxygen_Suppress */
 // Not sure if this belong here, used in cpl_http.cpp, cpl_vsil_curl.cpp and frmts/wms/gdalhttp.cpp
-void* CPLHTTPSetOptions(void *pcurl, const char * const* papszOptions);
+void* CPLHTTPSetOptions(void *pcurl, const char *pszURL, const char * const* papszOptions);
 char** CPLHTTPGetOptionsFromEnv();
 double CPLHTTPGetNewRetryDelay(int response_code, double dfOldDelay, const char* pszErrBuf);
 void* CPLHTTPIgnoreSigPipe();

--- a/gdal/port/cpl_vsil_az.cpp
+++ b/gdal/port/cpl_vsil_az.cpp
@@ -448,15 +448,15 @@ bool VSIAzureWriteHandle::SendInternal(bool bInitOnly, bool bIsLastBlock)
             m_poHandleHelper->AddQueryParameter("comp", "appendblock");
         }
 
-        curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                            m_poHandleHelper->GetURL().c_str());
         curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
         curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION, ReadCallBackBuffer);
         curl_easy_setopt(hCurlHandle, CURLOPT_READDATA,
                          static_cast<VSIAppendWriteHandle*>(this));
 
         struct curl_slist* headers = static_cast<struct curl_slist*>(
-            CPLHTTPSetOptions(hCurlHandle, nullptr));
+            CPLHTTPSetOptions(hCurlHandle,
+                              m_poHandleHelper->GetURL().c_str(),
+                              nullptr));
 
         CPLString osContentLength; // leave it in this scope
         if( bSingleBlock )

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -3982,10 +3982,8 @@ struct curl_slist* VSICurlSetOptions(
                         CURL* hCurlHandle, const char* pszURL,
                         const char * const* papszOptions )
 {
-    curl_easy_setopt(hCurlHandle, CURLOPT_URL, pszURL);
-
     struct curl_slist* headers = static_cast<struct curl_slist*>(
-        CPLHTTPSetOptions(hCurlHandle, papszOptions));
+        CPLHTTPSetOptions(hCurlHandle, pszURL, papszOptions));
 
 // 7.16
 #if LIBCURL_VERSION_NUM >= 0x071000

--- a/gdal/port/cpl_vsil_s3.cpp
+++ b/gdal/port/cpl_vsil_s3.cpp
@@ -442,12 +442,12 @@ bool VSIS3WriteHandle::InitiateMultipartUpload()
         bGoOn = false;
         CURL* hCurlHandle = curl_easy_init();
         m_poS3HandleHelper->AddQueryParameter("uploads", "");
-        curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                         m_poS3HandleHelper->GetURL().c_str());
         curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "POST");
 
         struct curl_slist* headers = static_cast<struct curl_slist*>(
-            CPLHTTPSetOptions(hCurlHandle, nullptr));
+            CPLHTTPSetOptions(hCurlHandle,
+                              m_poS3HandleHelper->GetURL().c_str(),
+                              nullptr));
         headers = VSICurlMergeHeaders(headers,
                         m_poS3HandleHelper->GetCurlHeaders("POST", headers));
         curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
@@ -578,15 +578,15 @@ bool VSIS3WriteHandle::UploadPart()
     m_poS3HandleHelper->AddQueryParameter("partNumber",
                                           CPLSPrintf("%d", m_nPartNumber));
     m_poS3HandleHelper->AddQueryParameter("uploadId", m_osUploadID);
-    curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                     m_poS3HandleHelper->GetURL().c_str());
     curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
     curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION, ReadCallBackBuffer);
     curl_easy_setopt(hCurlHandle, CURLOPT_READDATA, this);
     curl_easy_setopt(hCurlHandle, CURLOPT_INFILESIZE, m_nBufferOff);
 
     struct curl_slist* headers = static_cast<struct curl_slist*>(
-        CPLHTTPSetOptions(hCurlHandle, nullptr));
+        CPLHTTPSetOptions(hCurlHandle,
+                          m_poS3HandleHelper->GetURL().c_str(),
+                          nullptr));
     headers = VSICurlMergeHeaders(headers,
                     m_poS3HandleHelper->GetCurlHeaders("PUT", headers,
                                                         m_pabyBuffer,
@@ -697,15 +697,15 @@ VSIS3WriteHandle::WriteChunked( const void *pBuffer, size_t nSize, size_t nMemb 
     {
         m_hCurlMulti = curl_multi_init();
         CURL* hCurlHandle = curl_easy_init();
-        curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                        m_poS3HandleHelper->GetURL().c_str());
         curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
         curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION,
                          ReadCallBackBufferChunked);
         curl_easy_setopt(hCurlHandle, CURLOPT_READDATA, this);
 
         headers = static_cast<struct curl_slist*>(
-            CPLHTTPSetOptions(hCurlHandle, nullptr));
+            CPLHTTPSetOptions(hCurlHandle,
+                              m_poS3HandleHelper->GetURL().c_str(),
+                              nullptr));
         headers = VSICurlMergeHeaders(headers,
                         m_poS3HandleHelper->GetCurlHeaders("PUT", headers));
         curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
@@ -912,15 +912,15 @@ bool VSIS3WriteHandle::DoSinglePartPUT()
         bGoOn = false;
         m_nBufferOffReadCallback = 0;
         CURL* hCurlHandle = curl_easy_init();
-        curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                         m_poS3HandleHelper->GetURL().c_str());
         curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
         curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION, ReadCallBackBuffer);
         curl_easy_setopt(hCurlHandle, CURLOPT_READDATA, this);
         curl_easy_setopt(hCurlHandle, CURLOPT_INFILESIZE, m_nBufferOff);
 
         struct curl_slist* headers = static_cast<struct curl_slist*>(
-            CPLHTTPSetOptions(hCurlHandle, nullptr));
+            CPLHTTPSetOptions(hCurlHandle,
+                              m_poS3HandleHelper->GetURL().c_str(),
+                              nullptr));
         headers = VSICurlMergeHeaders(headers,
                         m_poS3HandleHelper->GetCurlHeaders("PUT", headers,
                                                            m_pabyBuffer,
@@ -1027,8 +1027,6 @@ bool VSIS3WriteHandle::CompleteMultipart()
     m_nOffsetInXML = 0;
     CURL* hCurlHandle = curl_easy_init();
     m_poS3HandleHelper->AddQueryParameter("uploadId", m_osUploadID);
-    curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                     m_poS3HandleHelper->GetURL().c_str());
     curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
     curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION, ReadCallBackXML);
     curl_easy_setopt(hCurlHandle, CURLOPT_READDATA, this);
@@ -1037,7 +1035,9 @@ bool VSIS3WriteHandle::CompleteMultipart()
     curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "POST");
 
     struct curl_slist* headers = static_cast<struct curl_slist*>(
-        CPLHTTPSetOptions(hCurlHandle, nullptr));
+        CPLHTTPSetOptions(hCurlHandle,
+                          m_poS3HandleHelper->GetURL().c_str(),
+                          nullptr));
     headers = VSICurlMergeHeaders(headers,
                     m_poS3HandleHelper->GetCurlHeaders("POST", headers,
                                                         m_osXML.c_str(),
@@ -1091,12 +1091,12 @@ bool VSIS3WriteHandle::AbortMultipart()
 
     CURL* hCurlHandle = curl_easy_init();
     m_poS3HandleHelper->AddQueryParameter("uploadId", m_osUploadID);
-    curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                     m_poS3HandleHelper->GetURL().c_str());
     curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
 
     struct curl_slist* headers = static_cast<struct curl_slist*>(
-        CPLHTTPSetOptions(hCurlHandle, nullptr));
+        CPLHTTPSetOptions(hCurlHandle,
+                          m_poS3HandleHelper->GetURL().c_str(),
+                          nullptr));
     headers = VSICurlMergeHeaders(headers,
                     m_poS3HandleHelper->GetCurlHeaders("DELETE", headers));
     curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
@@ -1547,12 +1547,12 @@ int IVSIS3LikeFSHandler::DeleteObject( const char *pszFilename )
     {
         bGoOn = false;
         CURL* hCurlHandle = curl_easy_init();
-        curl_easy_setopt(hCurlHandle, CURLOPT_URL,
-                         poS3HandleHelper->GetURL().c_str());
         curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
 
         struct curl_slist* headers = static_cast<struct curl_slist*>(
-            CPLHTTPSetOptions(hCurlHandle, nullptr));
+            CPLHTTPSetOptions(hCurlHandle,
+                              poS3HandleHelper->GetURL().c_str(),
+                              nullptr));
         headers = VSICurlMergeHeaders(headers,
                         poS3HandleHelper->GetCurlHeaders("DELETE", headers));
         curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);

--- a/gdal/port/cpl_vsil_webhdfs.cpp
+++ b/gdal/port/cpl_vsil_webhdfs.cpp
@@ -314,9 +314,8 @@ retry:
     CURL* hCurlHandle = curl_easy_init();
 
     struct curl_slist* headers = static_cast<struct curl_slist*>(
-        CPLHTTPSetOptions(hCurlHandle, nullptr));
+        CPLHTTPSetOptions(hCurlHandle, osURL.c_str(), nullptr));
 
-    curl_easy_setopt(hCurlHandle, CURLOPT_URL, osURL.c_str());
     curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "PUT");
     curl_easy_setopt(hCurlHandle, CURLOPT_INFILESIZE, 0);
 
@@ -397,9 +396,8 @@ bool VSIWebHDFSWriteHandle::Append()
     CURL* hCurlHandle = curl_easy_init();
 
     struct curl_slist* headers = static_cast<struct curl_slist*>(
-        CPLHTTPSetOptions(hCurlHandle, nullptr));
+        CPLHTTPSetOptions(hCurlHandle, osURL.c_str(), nullptr));
 
-    curl_easy_setopt(hCurlHandle, CURLOPT_URL, osURL.c_str());
     curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "POST");
     curl_easy_setopt(hCurlHandle, CURLOPT_FOLLOWLOCATION, 0);
     curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
@@ -457,10 +455,9 @@ bool VSIWebHDFSWriteHandle::Append()
     hCurlHandle = curl_easy_init();
 
     headers = static_cast<struct curl_slist*>(
-        CPLHTTPSetOptions(hCurlHandle, nullptr));
+        CPLHTTPSetOptions(hCurlHandle, osURL.c_str(), nullptr));
     headers = curl_slist_append(headers, "Content-Type: application/octet-stream");
 
-    curl_easy_setopt(hCurlHandle, CURLOPT_URL, osURL.c_str());
     curl_easy_setopt(hCurlHandle, CURLOPT_POSTFIELDS, m_pabyBuffer);
     curl_easy_setopt(hCurlHandle, CURLOPT_POSTFIELDSIZE , m_nBufferOff);
     curl_easy_setopt(hCurlHandle, CURLOPT_FOLLOWLOCATION, 0);


### PR DESCRIPTION
## What does this PR do?

This PR adds new environment variable `GDAL_HTTPS_PROXY` which is taken into account only for https URLS. If this variable is not set then `GDAL_HTTP_PROXY` affects both http and https URLs (this behavior is preserved). It is meant to overcome this issue: https://github.com/OSGeo/gdal/issues/878

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed