### PR TITLE
gitignore: ignore IDEs and vagrant folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,12 @@
 *.so
 *~
 
-# eclipse ignore
+.vagrant
+
+# IDE ignore
 .project
 .settings
 .pydevproject
 .cproject
+.idea
+.vscode


### PR DESCRIPTION
## What does this PR do?

Add gitignore folders for IDEs such as Vagrant, CLion and VisualStudio Code
