### PR TITLE
autotest: rmf: import gdal from osgeo

### DIFF
--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -34,7 +34,7 @@ import sys
 sys.path.append('../pymod')
 
 import gdaltest
-import gdal
+from osgeo import gdal
 from osgeo import osr
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

It read osge.gdal instead of obsolete module path.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
