### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.m4            text eol=lf
+*.sh            text eol=lf
+configure       text eol=lf
+configure.ac    text eol=lf
+config.guess    text eol=lf
+config.sub      text eol=lf
+install-sh      text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat           text eol=crlf
+*.cmd           text eol=crlf
+*.ps1           text eol=crlf


### PR DESCRIPTION
Unix shell scripts use eol=LF and Windows scripts use eol=crlf.

-----

This is helpful in hybrid environments eg. WSL where `git clone` is run on Windows with `autocrlf=true`, then `./autogen.sh` is executed on Linux.