### PR TITLE
Force eol=lf for GNU Autoconf files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,13 +4,19 @@
 # Declare files that will always have LF line endings on checkout.
 *.m4            text eol=lf
 *.sh            text eol=lf
+config.h.in     text eol=lf
 configure       text eol=lf
 configure.ac    text eol=lf
 config.guess    text eol=lf
 config.sub      text eol=lf
+gdal.pc.in      text eol=lf
 install-sh      text eol=lf
+GNUmakefile     text eol=lf
+GNUmake.opt*    text eol=lf
+VERSION         text eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 *.bat           text eol=crlf
 *.cmd           text eol=crlf
 *.ps1           text eol=crlf
+config.h.vc*    text eol=lf


### PR DESCRIPTION
## What does this PR do?

GNU Autoconf scripts are sensitive to CRLF. Specifically, `cpl_config.h.in` apparently must be LF  otherwise it is not updated correctly.
It is important for Windows/Linux hybrid environments, WSL or Docker.

## What are related issues/pull requests?

Refines PR #984
