### PR TITLE
Add amin and amax parameter for gdal_contour to be used with option -p

### DIFF
--- a/gdal/alg/contour.cpp
+++ b/gdal/alg/contour.cpp
@@ -43,7 +43,7 @@
 #include "ogr_srs_api.h"
 #include "ogr_geometry.h"
 
-static CPLErr OGRPolygonContourWriter( double dfLevel,
+static CPLErr OGRPolygonContourWriter( double dfLevelMin, double dfLevelMax,
                                 const OGRMultiPolygon& multipoly,
                                 void *pInfo )
 
@@ -58,8 +58,11 @@ static CPLErr OGRPolygonContourWriter( double dfLevel,
     if( poInfo->nIDField != -1 )
         OGR_F_SetFieldInteger( hFeat, poInfo->nIDField, poInfo->nNextID++ );
 
-    if( poInfo->nElevField != -1 )
-        OGR_F_SetFieldDouble( hFeat, poInfo->nElevField, dfLevel );
+    if( poInfo->nElevFieldMin != -1 )
+        OGR_F_SetFieldDouble( hFeat, poInfo->nElevFieldMin, dfLevelMin );
+
+    if( poInfo->nElevFieldMax != -1 )
+        OGR_F_SetFieldDouble( hFeat, poInfo->nElevFieldMax, dfLevelMax );
 
     const bool bHasZ = wkbHasZ(OGR_FD_GetGeomType(hFDefn));
     OGRGeometryH hGeom = OGR_G_CreateGeometry(
@@ -86,7 +89,7 @@ static CPLErr OGRPolygonContourWriter( double dfLevel,
                     + poInfo->adfGeoTransform[4] * poRing->getX(iPoint)
                     + poInfo->adfGeoTransform[5] * poRing->getY(iPoint);
                 if( bHasZ )
-                    OGR_G_SetPoint( OGRGeometry::ToHandle( poNewRing ), iPoint, dfX, dfY, dfLevel );
+                    OGR_G_SetPoint( OGRGeometry::ToHandle( poNewRing ), iPoint, dfX, dfY, dfLevelMax );
                 else
                     OGR_G_SetPoint_2D( OGRGeometry::ToHandle( poNewRing ), iPoint, dfX, dfY );
             }
@@ -108,10 +111,11 @@ struct PolygonContourWriter
 {
     CPL_DISALLOW_COPY_ASSIGN(PolygonContourWriter)
 
-    explicit PolygonContourWriter( OGRContourWriterInfo* poInfo ) : poInfo_( poInfo ) {}
+    explicit PolygonContourWriter( OGRContourWriterInfo* poInfo, double minLevel ) : poInfo_( poInfo ), previousLevel_( minLevel ) {}
 
     void startPolygon( double level )
     {
+        previousLevel_ = currentLevel_;
         currentGeometry_.reset( new OGRMultiPolygon() );
         currentLevel_ = level;
     }
@@ -122,7 +126,7 @@ struct PolygonContourWriter
             currentGeometry_->addGeometryDirectly(currentPart_);
         }
 
-        OGRPolygonContourWriter( currentLevel_, *currentGeometry_, poInfo_ );
+        OGRPolygonContourWriter( previousLevel_, currentLevel_, *currentGeometry_, poInfo_ );
 
         currentGeometry_.reset( nullptr );
         currentPart_ = nullptr;
@@ -158,8 +162,9 @@ struct PolygonContourWriter
 
     std::unique_ptr<OGRMultiPolygon> currentGeometry_ = {};
     OGRPolygon* currentPart_ = nullptr;
-    double currentLevel_ = 0.0;
     OGRContourWriterInfo* poInfo_ = nullptr;
+    double currentLevel_ = 0;
+    double previousLevel_; 
 };
 
 struct GDALRingAppender
@@ -498,6 +503,16 @@ an averaged value from the two nearby points (in this case (12+3+5)/3).
  * This will be used as a field index to indicate where the elevation value
  * of the contour should be written.
  *
+ *   ELEV_FIELD_MIN=d
+ *
+ * This will be used as a field index to indicate where the minimum elevation value
+ * of the polygon contour should be written.
+ *
+ *   ELEV_FIELD_MAX=d
+ *
+ * This will be used as a field index to indicate where the maximum elevation value
+ * of the polygon contour should be written.
+ *
  *   POLYGONIZE=YES|NO
  *
  * If YES, contour polygons will be created, rather than polygon lines.
@@ -563,6 +578,18 @@ CPLErr GDALContourGenerateEx( GDALRasterBandH hBand, void *hLayer,
         elevField = atoi( opt );
     }
 
+    int elevFieldMin = -1;
+    opt = CSLFetchNameValue( options, "ELEV_FIELD_MIN" );
+    if ( opt ) {
+        elevFieldMin = atoi( opt );
+    }
+
+    int elevFieldMax = -1;
+    opt = CSLFetchNameValue( options, "ELEV_FIELD_MAX" );
+    if ( opt ) {
+        elevFieldMax = atoi( opt );
+    }
+
     bool polygonize = CPLFetchBool( options, "POLYGONIZE", false );
 
     using namespace marching_squares;
@@ -570,6 +597,8 @@ CPLErr GDALContourGenerateEx( GDALRasterBandH hBand, void *hLayer,
     OGRContourWriterInfo oCWI;
     oCWI.hLayer = static_cast<OGRLayerH>(hLayer);
     oCWI.nElevField = elevField;
+    oCWI.nElevFieldMin = elevFieldMin;
+    oCWI.nElevFieldMax = elevFieldMax;
     oCWI.nIDField = idField;
     oCWI.adfGeoTransform[0] = 0.0;
     oCWI.adfGeoTransform[1] = 1.0;
@@ -586,11 +615,12 @@ CPLErr GDALContourGenerateEx( GDALRasterBandH hBand, void *hLayer,
     {
         if ( polygonize )
         {
-            PolygonContourWriter w( &oCWI );
+            int bSuccess; 
+            PolygonContourWriter w( &oCWI, GDALGetRasterMinimum( hBand, &bSuccess ) );
             typedef PolygonRingAppender<PolygonContourWriter> RingAppender;
             RingAppender appender( w );
             if ( ! fixedLevels.empty() ) {
-                FixedLevelRangeIterator levels( &fixedLevels[0], fixedLevels.size() );
+                FixedLevelRangeIterator levels( &fixedLevels[0], fixedLevels.size(), GDALGetRasterMaximum( hBand, &bSuccess ) );
                 SegmentMerger<RingAppender, FixedLevelRangeIterator> writer(appender, levels, /* polygonize */ true);
                 ContourGeneratorFromRaster<decltype(writer), FixedLevelRangeIterator> cg( hBand, useNoData, noDataValue, writer, levels );
                 cg.process( pfnProgress, pProgressArg );

--- a/gdal/alg/gdal_alg.h
+++ b/gdal/alg/gdal_alg.h
@@ -306,6 +306,8 @@ typedef struct
     double adfGeoTransform[6];
 
     int    nElevField;
+    int    nElevFieldMin;
+    int    nElevFieldMax;
     int    nIDField;
     int    nNextID;
 } OGRContourWriterInfo;

--- a/gdal/alg/marching_squares/level_generator.h
+++ b/gdal/alg/marching_squares/level_generator.h
@@ -77,7 +77,7 @@ class FixedLevelRangeIterator
 {
 public:
     typedef RangeIterator<FixedLevelRangeIterator> Iterator;
-    FixedLevelRangeIterator( const double* levels, size_t count ) : levels_( levels ), count_( count )
+    FixedLevelRangeIterator( const double* levels, size_t count, double maxLevel = Inf ) : levels_( levels ), count_( count ), maxLevel_( maxLevel )
     {
     }
 
@@ -97,13 +97,14 @@ public:
     double level( int idx ) const
     {
         if ( idx >= int(count_) )
-            return Inf;
+            return maxLevel_;
         return levels_[size_t(idx)];
     }
 
 private:
     const double* levels_;
     size_t count_;
+    double maxLevel_;
 };
 
 struct IntervalLevelRangeIterator

--- a/gdal/apps/gdal_utilities.dox
+++ b/gdal/apps/gdal_utilities.dox
@@ -969,7 +969,8 @@ Builds vector contour lines from a raster elevation model.
 \section gdal_contour_synopsis SYNOPSIS
 
 \verbatim
-Usage: gdal_contour [-b <band>] [-a <attribute_name>] [-3d] [-inodata]
+Usage: gdal_contour [-b <band>] [-a <attribute_name>] [-amin <attribute_name>] [-amax <attribute_name>]
+       		    [-3d] [-inodata]
                     [-snodata n] [-i <interval>]
                     [-f <formatname>] [[-dsco NAME=VALUE] ...] [[-lco NAME=VALUE] ...]
                     [-off <offset>] [-fl <level> <level>...] [-e <exp_base>]
@@ -991,6 +992,11 @@ clockwise around a top.
 <dt> <b>-b</b> <em>band</em>:</dt><dd> picks a particular band to get the DEM from.  Defaults to band 1.</dd>
 
 <dt> <b>-a</b> <em>name</em>:</dt><dd>provides a name for the attribute in which to put the elevation. If not provided no elevation attribute is attached. </dd>
+
+<dt> <b>-amin</b> <em>name</em>:</dt><dd>(Since GDAL 2.4) provides a name for the attribute in which to put the minimum elevation of contour polygon. If not provided no minimum elevation attribute is attached. </dd>
+
+<dt> <b>-amax</b> <em>name</em>:</dt><dd>(Since GDAL 2.4) provides a name for the attribute in which to put the maximum elevation of contour polygon. If not provided no maximim elevation attribute is attached. </dd>
+
 <dt> <b>-3d</b>:</dt> <dd>
       Force production of 3D vectors instead of 2D.  Includes elevation at
       every vertex.</dd>


### PR DESCRIPTION
## What does this PR do?
As proposed in mail thread "Gdal contour number of contour with -p", this PR adds amin and amax parameter for gdal_contour when command is used with option -p that generates polygons instead of lines.

## What are related issues/pull requests?
N/A

## Tasklist

 - [x] Modify test file contour.py
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment
N/A