### PR TITLE
Correct big level value parsing bug

### DIFF
--- a/gdal/alg/contour.cpp
+++ b/gdal/alg/contour.cpp
@@ -538,7 +538,7 @@ CPLErr GDALContourGenerateEx( GDALRasterBandH hBand, void *hLayer,
         char** values = CSLTokenizeStringComplex( opt, ",", FALSE, FALSE );
         fixedLevels.resize( CSLCount( values ) );
         for ( size_t i = 0; i < fixedLevels.size(); i++ ) {
-            fixedLevels[i] = atoi(values[i]);
+            fixedLevels[i] = CPLAtof(values[i]);
         }
         CSLDestroy( values );
     }


### PR DESCRIPTION
## What does this PR do?
When you set big value for level parameter like 10000000000.0, the number is truncated to maximum int value. This PR corrects this issue.

## What are related issues/pull requests?
N/A

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment
N/A
