### PR TITLE
OGRGetXMLDateTime(): Interpret TZFlag correctly (fixes #996)

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -25,6 +25,7 @@
 
 #include "gdal_unit_test.h"
 
+#include "ogr_p.h"
 #include "ogrsf_frmts.h"
 #include "../../gdal/ogr/ogrsf_frmts/osm/gpb.h"
 
@@ -1355,4 +1356,118 @@ namespace tut
         poFeatureDefn->Release();
     }
 
+    // Test OGRGetXMLDateTime()
+    template<>
+    template<>
+    void object::test<15>()
+    {
+        OGRField sField;
+        char *pszDateTime;
+
+        sField.Date.Year = 2001;
+        sField.Date.Month = 2;
+        sField.Date.Day = 3;
+        sField.Date.Hour = 4;
+        sField.Date.Minute = 5;
+
+        // Unknown time zone (TZFlag = 0), no millisecond count
+        sField.Date.TZFlag = 0;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "unknown time zone, no millisecond count",
+               strcmp("2001-02-03T04:05:06", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Unknown time zone (TZFlag = 0), millisecond count
+        sField.Date.TZFlag = 0;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "unknown time zone, millisecond count",
+               strcmp("2001-02-03T04:05:06.789", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Local time zone (TZFlag = 1), no millisecond count
+        sField.Date.TZFlag = 1;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "local time zone, no millisecond count",
+               strcmp("2001-02-03T04:05:06", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Local time zone (TZFlag = 1), millisecond count
+        sField.Date.TZFlag = 1;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "local time zone, millisecond count",
+               strcmp("2001-02-03T04:05:06.789", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // GMT time zone (TZFlag = 100), no millisecond count
+        sField.Date.TZFlag = 100;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "GMT time zone, no millisecond count",
+               strcmp("2001-02-03T04:05:06Z", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // GMT time zone (TZFlag = 100), millisecond count
+        sField.Date.TZFlag = 100;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "GMT time zone, millisecond count",
+               strcmp("2001-02-03T04:05:06.789Z", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Positive time-zone offset, no millisecond count
+        sField.Date.TZFlag = 111;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "positive time-zone offset, no millisecond count",
+               strcmp("2001-02-03T04:05:06+02:45", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Positive time-zone offset, millisecond count
+        sField.Date.TZFlag = 111;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "positive time-zone offset, millisecond count",
+               strcmp("2001-02-03T04:05:06.789+02:45", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Negative time-zone offset, no millisecond count
+        sField.Date.TZFlag = 88;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "negative time-zone offset, no millisecond count",
+               strcmp("2001-02-03T04:05:06-03:00", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Negative time-zone offset, millisecond count
+        sField.Date.TZFlag = 88;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "negative time-zone offset, millisecond count",
+               strcmp("2001-02-03T04:05:06.789-03:00", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+    }
 } // namespace tut

--- a/autotest/ogr/data/gmlas/gmlas_test1_generated.xml
+++ b/autotest/ogr/data/gmlas/gmlas_test1_generated.xml
@@ -32,7 +32,7 @@
       <myns:dt_array>2012-01-01T12:34:56Z</myns:dt_array>
       <myns:dt_array>2012-01-02T12:34:56Z</myns:dt_array>
       <myns:date>2012-01-01</myns:date>
-      <myns:time>12:34:56Z</myns:time>
+      <myns:time>12:34:56</myns:time>
       <myns:boolean>true</myns:boolean>
       <myns:boolean_array>true</myns:boolean_array>
       <myns:boolean_array>false</myns:boolean_array>

--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -998,7 +998,7 @@ def ogr_mvt_write_one_layer():
        out_f['int64field'] != 123456789012345 or \
        out_f['realfield'] != 1.25 or \
        out_f['datefield'] != '2018-02-01' or \
-       out_f['datetimefield'] != '2018-02-01T12:34:56Z' or \
+       out_f['datetimefield'] != '2018-02-01T12:34:56' or \
        out_f['boolfield'] is False or \
        ogrtest.check_feature_geometry(out_f, 'POINT (498980.920645632 997961.84129126)') != 0:
         gdaltest.post_reason('fail')
@@ -1011,7 +1011,7 @@ def ogr_mvt_write_one_layer():
        out_f['int64field'] != 123456789012345 or \
        out_f['realfield'] != 1.25 or \
        out_f['datefield'] != '2018-02-01' or \
-       out_f['datetimefield'] != '2018-02-01T12:34:56Z' or \
+       out_f['datetimefield'] != '2018-02-01T12:34:56' or \
        out_f['boolfield'] is False or \
        ogrtest.check_feature_geometry(out_f, 'MULTILINESTRING ((498980.920645632 997961.84129126,508764.860266134 1007745.78091176,518548.799886636 1017529.72053226))') != 0:
         gdaltest.post_reason('fail')
@@ -1181,7 +1181,7 @@ def ogr_mvt_write_one_layer():
                             "count": 1,
                             "type": "string",
                             "values": [
-                                "2018-02-01T12:34:56Z"
+                                "2018-02-01T12:34:56"
                             ]
                         },
                         {

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -950,9 +950,6 @@ class RL2RasterBand final: public GDALPamRasterBand
 CPLString OGRSQLiteFieldDefnToSQliteFieldDefn( OGRFieldDefn* poFieldDefn,
                                                int bSQLiteDialectInternalUse );
 
-int OGRSQLITEStringToDateTimeField( OGRFeature* poFeature, int iField,
-                                    const char* pszValue );
-
 typedef void (*pfnNotifyFileOpenedType)(void* pfnUserData, const char* pszFilename, VSILFILE* fp);
 sqlite3_vfs* OGRSQLiteCreateVFS(pfnNotifyFileOpenedType pfn, void* pfnUserData);
 

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -1554,11 +1554,9 @@ static OGRFeature* OGR2SQLITE_FeatureFromArgs(OGRLayer* poLayer,
                     case OFTDate:
                     case OFTTime:
                     case OFTDateTime:
-                    {
-                        if( !OGRSQLITEStringToDateTimeField( poFeature, i, pszValue ) )
+                        if( !OGRParseDate( pszValue, poFeature->GetRawFieldRef(i), 0 ) )
                             poFeature->SetField(i, pszValue);
                         break;
-                    }
 
                     default:
                         poFeature->SetField(i, pszValue);


### PR DESCRIPTION
## What does this PR do?

Modifies [the `OGRGetXMLDateTime()` function](https://github.com/OSGeo/gdal/blob/cdbba83cc3eea4ef48b3205865432f40fe0bbc52/gdal/ogr/ogrutils.cpp#L1378) to interpret a date/time field's `TZFlag` member in accordance with [the documentation](https://gdal.org/classOGRFeature.html#a4ca0f1bca72c88fe9f881871cdc401a5). Specifically, when formatting a date/time field, the function now

- Appends no timestamp qualifier for an unknown (`TZFlag` = 0) or local (`TZFlag` = 1) time zone;
- Appends "Z" for the GMT time zone (TZFlag = 100); and
- Appends a computed time-zone offset for all other `TZFlag` values.

I've reviewed every use of this function in the library and can see no areas where these changes would cause issues. No driver appears to modify either the field members before or the returned string after the function call to accommodate its existing behaviour (the one exception being [the GMLAS driver](https://github.com/OSGeo/gdal/tree/cdbba83cc3eea4ef48b3205865432f40fe0bbc52/gdal/ogr/ogrsf_frmts/gmlas), which only [splits the returned string](https://github.com/OSGeo/gdal/blob/cdbba83cc3eea4ef48b3205865432f40fe0bbc52/gdal/ogr/ogrsf_frmts/gmlas/ogrgmlaswriter.cpp#L2320-L2336) into its component date and time values).

In addition to the above, this change

- Refactors `OGRGetXMLDateTime()` to eliminate redundant code, and
- Adds a set of test cases that exercises each of the function's code paths.

## What are related issues/pull requests?

Fixes issue #996.

## Tasklist

 - [X] Add test case(s)
 - [X] Modify implementation
 - [X] Review use of function across library
 - [ ] Review pull request
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 16.04.5 64-bit (via Windows Subsystem for Linux on Windows 10)
* Compiler: gcc 5.4.0
