### PR TITLE
grib: allow 64 bit file offsets if supported

### DIFF
--- a/gdal/frmts/grib/degrib/degrib/filedatasource.cpp
+++ b/gdal/frmts/grib/degrib/degrib/filedatasource.cpp
@@ -58,7 +58,7 @@ long FileDataSource::DataSourceFtell()
 {
     vsi_l_offset nOffset = VSIFTellL( fp );
     // FIXME ? change return type
-    if( nOffset > INT_MAX )
-        nOffset = INT_MAX;
+    if( nOffset > LONG_MAX )
+        nOffset = LONG_MAX;
     return static_cast<long>(nOffset);
 }

--- a/gdal/frmts/grib/degrib/degrib/inventory.cpp
+++ b/gdal/frmts/grib/degrib/degrib/inventory.cpp
@@ -135,13 +135,13 @@ void GRIB2InventoryPrint (inventoryType *Inv, uInt4 LenInv)
       delta = (Inv[i].validTime - Inv[i].refTime) / 3600.;
       delta = myRound (delta, 2);
       if (Inv[i].comment == nullptr) {
-         printf ("%u.%u, %d, %d, %s, %s, %s, %s, %.2f\n",
+         printf ("%u.%u, %ld, %d, %s, %s, %s, %s, %.2f\n",
                  Inv[i].msgNum, Inv[i].subgNum, Inv[i].start,
                  Inv[i].GribVersion, Inv[i].element, Inv[i].shortFstLevel,
                  refTime, validTime, delta);
          fflush (stdout);
       } else {
-         printf ("%u.%u, %d, %d, %s=\"%s\", %s, %s, %s, %.2f\n",
+         printf ("%u.%u, %ld, %d, %s=\"%s\", %s, %s, %s, %.2f\n",
                  Inv[i].msgNum, Inv[i].subgNum, Inv[i].start,
                  Inv[i].GribVersion, Inv[i].element, Inv[i].comment,
                  Inv[i].shortFstLevel, refTime, validTime, delta);
@@ -959,7 +959,7 @@ int GRIB2Inventory (DataSource &fp, inventoryType **Inv, uInt4 *LenInv,
                     int numMsg, int *MsgNum)
 {
    //FileDataSource fp (filename);            /* The opened GRIB2 file. */
-   sInt4 offset = 0;    /* Where we are in the file. */
+   long  offset = 0;    /* Where we are in the file. */
    sInt4 msgNum;        /* Which GRIB2 message we are on. */
    uInt4 gribLen;       /* Length of the current GRIB message. */
    uInt4 secLen;        /* Length of current section. */
@@ -983,7 +983,7 @@ int GRIB2Inventory (DataSource &fp, inventoryType **Inv, uInt4 *LenInv,
                          * in the file.  If not found, is not a GRIB file. */
    int c;               /* Determine if end of the file without fileLen. */
 #ifdef DEBUG
-   sInt4 fileLen;       /* Length of the GRIB2 file. */
+   long fileLen;        /* Length of the GRIB2 file. */
 #endif
    unsigned short int center, subcenter; /* Who produced it. */
    uChar mstrVersion;   /* The master table version (is it 255?) */
@@ -1050,9 +1050,9 @@ int GRIB2Inventory (DataSource &fp, inventoryType **Inv, uInt4 *LenInv,
 #ifdef DEBUG
             /* find out how big the file is. */
             fp.DataSourceFseek (0L, SEEK_END);
-            fileLen = static_cast<int>(fp.DataSourceFtell());
+            fileLen = fp.DataSourceFtell();
             /* fseek (fp, 0L, SEEK_SET); */
-            printf ("There were %d trailing bytes in the file.\n",
+            printf ("There were %ld trailing bytes in the file.\n",
                     fileLen - offset);
 #endif
             free (buffer);
@@ -1223,7 +1223,7 @@ int GRIB2Inventory (DataSource &fp, inventoryType **Inv, uInt4 *LenInv,
       {
          increment = buffLen + gribLen;
       }
-      if( increment < buffLen || increment > (uInt4)(INT_MAX - offset) )
+      if( increment < buffLen || increment > (LONG_MAX - offset) )
           break;
       offset += increment;
       }
@@ -1239,7 +1239,7 @@ int GRIB2Inventory (DataSource &fp, inventoryType **Inv, uInt4 *LenInv,
 int GRIB2RefTime (const char *filename, double *refTime)
 {
    FileDataSource fp (filename);            /* The opened GRIB2 file. */
-   sInt4 offset = 0;    /* Where we are in the file. */
+   long  offset = 0;    /* Where we are in the file. */
    sInt4 msgNum;        /* Which GRIB2 message we are on. */
    uInt4 gribLen;       /* Length of the current GRIB message. */
    uInt4 secLen;        /* Length of current section. */
@@ -1260,7 +1260,7 @@ int GRIB2RefTime (const char *filename, double *refTime)
                          * in the file.  If not found, is not a GRIB file. */
    int c;               /* Determine if end of the file without fileLen. */
 #ifdef DEBUG
-   sInt4 fileLen;       /* Length of the GRIB2 file. */
+   long fileLen;        /* Length of the GRIB2 file. */
 #endif
    const char *ptr;           /* used to find the file extension. */
    double refTime1;
@@ -1314,9 +1314,9 @@ int GRIB2RefTime (const char *filename, double *refTime)
 #ifdef DEBUG
             /* find out how big the file is. */
             fp.DataSourceFseek (0L, SEEK_END);
-            fileLen = static_cast<int>(fp.DataSourceFtell());
+            fileLen = fp.DataSourceFtell();
             /* fseek (fp, 0L, SEEK_SET); */
-            printf ("There were %d trailing bytes in the file.\n",
+            printf ("There were %ld trailing bytes in the file.\n",
                     fileLen - offset);
 #endif
             free (buffer);

--- a/gdal/frmts/grib/degrib/degrib/inventory.h
+++ b/gdal/frmts/grib/degrib/degrib/inventory.h
@@ -26,7 +26,7 @@ extern "C" {
 
 typedef struct {
    sChar GribVersion;        /* 1 if GRIB1, 2 if GRIB2, -1 if it is TDLP */
-   sInt4 start;           /* Where this message starts in file. */
+   long start;               /* Where this message starts in file. */
    unsigned short int msgNum; /* Which "GRIB2" message we are working on. */
    unsigned short int subgNum; /* 0 for the first grid in the GRIB2 message
                               * NOT file, 1 for the second, etc. */

--- a/gdal/frmts/grib/gribdataset.cpp
+++ b/gdal/frmts/grib/gribdataset.cpp
@@ -758,7 +758,7 @@ double GRIBRasterBand::GetNoDataValue( int *pbSuccess )
 /*                            ReadGribData()                            */
 /************************************************************************/
 
-void GRIBRasterBand::ReadGribData( DataSource &fp, sInt4 start, int subgNum,
+void GRIBRasterBand::ReadGribData( DataSource &fp, long start, int subgNum,
                                    double **data, grib_MetaData **metaData)
 {
     // Initialization, for calling the ReadGrib2Record function.

--- a/gdal/frmts/grib/gribdataset.h
+++ b/gdal/frmts/grib/gribdataset.h
@@ -133,9 +133,9 @@ private:
     CPLErr       LoadData();
     void    FindNoDataGrib2(bool bSeekToStart = true);
 
-    static void ReadGribData( DataSource &, sInt4, int, double **,
+    static void ReadGribData( DataSource &, long, int, double **,
                               grib_MetaData ** );
-    sInt4 start;
+    long start;
     int subgNum;
     char *longFstLevel;
 


### PR DESCRIPTION
This is a minimal invasive patch to allow reading grib files over 4GB in size on supported systems (where long >= 8 bytes). The existing DataSource implementation already uses long for tell / seek so only a few minor type changes were needed to complete full 64 bit file offset support in the grib reader.

Tested on a file which first only reported 1218 bands and now properly reports 2400 bands.