### PR TITLE
JPEG: makefile.vc: always pass $(JPEG12_FLAGS) when external jpeg library is used (fixes #1014)

### DIFF
--- a/gdal/frmts/jpeg/makefile.vc
+++ b/gdal/frmts/jpeg/makefile.vc
@@ -6,7 +6,7 @@ OBJ	=    jpgdataset.obj jpgdataset_12.obj vsidataio.obj vsidataio_12.obj
 
 
 !IFDEF JPEG_EXTERNAL_LIB
-EXTRAFLAGS      = -I$(JPEGDIR) -I..\mem
+EXTRAFLAGS      = -I$(JPEGDIR) $(JPEG12_FLAGS) -I..\mem
 !ELSE
 EXTRAFLAGS = 	-Ilibjpeg $(JPEG12_FLAGS) -I..\mem
 !ENDIF


### PR DESCRIPTION
pass $(JPEG12_FLAGS) when external jpeg library is used

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/1014

## Tasklist

 - [ x ] All CI builds and checks have passed

## Environment

Windows builds of gdal-2.3.0 with external jpeg library and jpeg12 enabled with internal jpeg12 source

* OS: Windows
* Compiler: msvc141
