### PR TITLE
Python logging improvements

### DIFF
--- a/gdal/gcore/gdaldllmain.cpp
+++ b/gdal/gcore/gdaldllmain.cpp
@@ -72,8 +72,11 @@ void GDALDestroy(void)
         return;
     bGDALDestroyAlreadyCalled = true;
 
-    CPLDebug("GDAL", "In GDALDestroy - unloading GDAL shared library.");
     bInGDALGlobalDestructor = true;
+
+    // logging/error handling may call GDALIsInGlobalDestructor()
+    CPLDebug("GDAL", "In GDALDestroy - unloading GDAL shared library.");
+
     GDALDestroyDriverManager();
 
     OGRCleanupAll();

--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -50,20 +50,14 @@ typedef char retStringAndCPLFree;
     CPLDebug( msg_class, "%s", message );
   }
 
-  CPLErr SetErrorHandler( char const * pszCallbackName = NULL )
+  CPLErr SetErrorHandler( CPLErrorHandler pfnErrorHandler = NULL, void* user_data = NULL )
   {
-    CPLErrorHandler pfnHandler = NULL;
-    if( pszCallbackName == NULL || EQUAL(pszCallbackName,"CPLQuietErrorHandler") )
-      pfnHandler = CPLQuietErrorHandler;
-    else if( EQUAL(pszCallbackName,"CPLDefaultErrorHandler") )
-      pfnHandler = CPLDefaultErrorHandler;
-    else if( EQUAL(pszCallbackName,"CPLLoggingErrorHandler") )
-      pfnHandler = CPLLoggingErrorHandler;
+    if( pfnErrorHandler == NULL )
+    {
+        pfnErrorHandler = CPLDefaultErrorHandler;
+    }
 
-    if ( pfnHandler == NULL )
-      return CE_Fatal;
-
-    CPLSetErrorHandler( pfnHandler );
+    CPLSetErrorHandlerEx( pfnErrorHandler, user_data );
 
     return CE_None;
   }

--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -74,8 +74,17 @@ typedef char retStringAndCPLFree;
 %nothread;
 
 %{
+extern "C" int CPL_DLL GDALIsInGlobalDestructor();
+
 void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* pszErrorMsg)
 {
+    if( GDALIsInGlobalDestructor() )
+    {
+        // this is typically during Python interpreter shutdown, and ends up in a crash
+        // because error handling tries to do thread initialisation.
+        return;
+    }
+
     void* user_data = CPLGetErrorHandlerUserData();
     PyObject *psArgs;
 

--- a/gdal/swig/include/gdalconst.i
+++ b/gdal/swig/include/gdalconst.i
@@ -150,6 +150,13 @@
 %constant CPLE_AssertionFailed            = CPLE_AssertionFailed;
 %constant CPLE_NoWriteAccess              = CPLE_NoWriteAccess;
 %constant CPLE_UserInterrupt              = CPLE_UserInterrupt;
+%constant CPLE_ObjectNull                 = CPLE_ObjectNull;
+%constant CPLE_HttpResponse               = CPLE_HttpResponse;
+%constant CPLE_AWSBucketNotFound          = CPLE_AWSBucketNotFound;
+%constant CPLE_AWSObjectNotFound          = CPLE_AWSObjectNotFound;
+%constant CPLE_AWSAccessDenied            = CPLE_AWSAccessDenied;
+%constant CPLE_AWSInvalidCredentials      = CPLE_AWSInvalidCredentials;
+%constant CPLE_AWSSignatureDoesNotMatch   = CPLE_AWSSignatureDoesNotMatch;
 
 // Open flags
 %constant OF_ALL     = GDAL_OF_ALL;

--- a/gdal/swig/include/python/python_exceptions.i
+++ b/gdal/swig/include/python/python_exceptions.i
@@ -56,8 +56,9 @@ void UseExceptions() {
                    CPLGetConfigOption("__chain_python_error_handlers", "")));
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
+    // if the previous logger was custom, we need the user data available
     pfnPreviousHandler =
-        CPLSetErrorHandler( (CPLErrorHandler) PythonBindingErrorHandler );
+        CPLSetErrorHandlerEx( (CPLErrorHandler) PythonBindingErrorHandler, CPLGetErrorHandlerUserData() );
   }
 }
 
@@ -81,7 +82,8 @@ void DontUseExceptions() {
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
     bUseExceptions = 0;
-    CPLSetErrorHandler( pfnPreviousHandler );
+    // if the previous logger was custom, we need the user data available. Preserve it.
+    CPLSetErrorHandlerEx( pfnPreviousHandler, CPLGetErrorHandlerUserData());
   }
 }
 %}

--- a/gdal/swig/include/python/python_exceptions.i
+++ b/gdal/swig/include/python/python_exceptions.i
@@ -24,10 +24,10 @@ PythonBindingErrorHandler(CPLErr eclass, int code, const char *msg )
   }
 
   /*
-  ** We do not want to interfere with warnings or debug messages since
+  ** We do not want to interfere with non-failure messages since
   ** they won't be translated into exceptions.
   */
-  else if (eclass == CE_Warning || eclass == CE_Debug ) {
+  else if (eclass != CE_Failure ) {
     pfnPreviousHandler(eclass, code, msg );
   }
   else {

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -3278,10 +3278,10 @@ PythonBindingErrorHandler(CPLErr eclass, int code, const char *msg )
   }
 
   /*
-  ** We do not want to interfere with warnings or debug messages since
+  ** We do not want to interfere with non-failure messages since
   ** they won't be translated into exceptions.
   */
-  else if (eclass == CE_Warning || eclass == CE_Debug ) {
+  else if (eclass != CE_Failure ) {
     pfnPreviousHandler(eclass, code, msg );
   }
   else {
@@ -3309,8 +3309,9 @@ void UseExceptions() {
                    CPLGetConfigOption("__chain_python_error_handlers", "")));
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
+    // if the previous logger was custom, we need the user data available
     pfnPreviousHandler =
-        CPLSetErrorHandler( (CPLErrorHandler) PythonBindingErrorHandler );
+        CPLSetErrorHandlerEx( (CPLErrorHandler) PythonBindingErrorHandler, CPLGetErrorHandlerUserData() );
   }
 }
 
@@ -3334,7 +3335,8 @@ void DontUseExceptions() {
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
     bUseExceptions = 0;
-    CPLSetErrorHandler( pfnPreviousHandler );
+    // if the previous logger was custom, we need the user data available. Preserve it.
+    CPLSetErrorHandlerEx( pfnPreviousHandler, CPLGetErrorHandlerUserData());
   }
 }
 
@@ -3885,27 +3887,30 @@ typedef char retStringAndCPLFree;
     CPLDebug( msg_class, "%s", message );
   }
 
-  CPLErr SetErrorHandler( char const * pszCallbackName = NULL )
+  CPLErr SetErrorHandler( CPLErrorHandler pfnErrorHandler = NULL, void* user_data = NULL )
   {
-    CPLErrorHandler pfnHandler = NULL;
-    if( pszCallbackName == NULL || EQUAL(pszCallbackName,"CPLQuietErrorHandler") )
-      pfnHandler = CPLQuietErrorHandler;
-    else if( EQUAL(pszCallbackName,"CPLDefaultErrorHandler") )
-      pfnHandler = CPLDefaultErrorHandler;
-    else if( EQUAL(pszCallbackName,"CPLLoggingErrorHandler") )
-      pfnHandler = CPLLoggingErrorHandler;
+    if( pfnErrorHandler == NULL )
+    {
+        pfnErrorHandler = CPLDefaultErrorHandler;
+    }
 
-    if ( pfnHandler == NULL )
-      return CE_Fatal;
-
-    CPLSetErrorHandler( pfnHandler );
+    CPLSetErrorHandlerEx( pfnErrorHandler, user_data );
 
     return CE_None;
   }
 
 
+extern "C" int CPL_DLL GDALIsInGlobalDestructor();
+
 void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* pszErrorMsg)
 {
+    if( GDALIsInGlobalDestructor() )
+    {
+        // this is typically during Python interpreter shutdown, and ends up in a crash
+        // because error handling tries to do thread initialisation.
+        return;
+    }
+
     void* user_data = CPLGetErrorHandlerUserData();
     PyObject *psArgs;
 
@@ -7222,20 +7227,48 @@ fail:
 
 SWIGINTERN PyObject *_wrap_SetErrorHandler(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
-  char *arg1 = (char *) NULL ;
-  int res1 ;
-  char *buf1 = 0 ;
-  int alloc1 = 0 ;
+  CPLErrorHandler arg1 = (CPLErrorHandler) NULL ;
+  void *arg2 = (void *) NULL ;
   PyObject * obj0 = 0 ;
   CPLErr result;
   
   if (!PyArg_ParseTuple(args,(char *)"|O:SetErrorHandler",&obj0)) SWIG_fail;
   if (obj0) {
-    res1 = SWIG_AsCharPtrAndSize(obj0, &buf1, NULL, &alloc1);
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SetErrorHandler" "', argument " "1"" of type '" "char const *""'");
+    {
+      /* %typemap(in) (CPLErrorHandler pfnErrorHandler = NULL, void* user_data = NULL) */
+      int alloc = 0;
+      char* pszCallbackName = NULL;
+      arg2 = NULL;
+      if( SWIG_IsOK(SWIG_AsCharPtrAndSize(obj0, &pszCallbackName, NULL, &alloc)) )
+      {
+        if( pszCallbackName == NULL || EQUAL(pszCallbackName,"CPLQuietErrorHandler") )
+        arg1 = CPLQuietErrorHandler;
+        else if( EQUAL(pszCallbackName,"CPLDefaultErrorHandler") )
+        arg1 = CPLDefaultErrorHandler;
+        else if( EQUAL(pszCallbackName,"CPLLoggingErrorHandler") )
+        arg1 = CPLLoggingErrorHandler;
+        else
+        {
+          if (alloc == SWIG_NEWOBJ) delete[] pszCallbackName;
+          PyErr_SetString( PyExc_RuntimeError, "Unhandled value for passed string" );
+          SWIG_fail;
+        }
+        
+        if (alloc == SWIG_NEWOBJ) delete[] pszCallbackName;
+      }
+      else if (!PyCallable_Check(obj0))
+      {
+        PyErr_SetString( PyExc_RuntimeError,
+          "Object given is not a String or a Python function" );
+        SWIG_fail;
+      }
+      else
+      {
+        Py_INCREF(obj0);
+        arg1 = PyCPLErrorHandler;
+        arg2 = obj0;
+      }
     }
-    arg1 = reinterpret_cast< char * >(buf1);
   }
   {
     if ( bUseExceptions ) {
@@ -7243,7 +7276,7 @@ SWIGINTERN PyObject *_wrap_SetErrorHandler(PyObject *SWIGUNUSEDPARM(self), PyObj
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      CPL_IGNORE_RET_VAL(result = (CPLErr)SetErrorHandler((char const *)arg1));
+      CPL_IGNORE_RET_VAL(result = (CPLErr)SetErrorHandler(arg1,arg2));
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -7256,11 +7289,9 @@ SWIGINTERN PyObject *_wrap_SetErrorHandler(PyObject *SWIGUNUSEDPARM(self), PyObj
 #endif
   }
   resultobj = SWIG_From_int(static_cast< int >(result));
-  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
   if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
   return resultobj;
 fail:
-  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
   return NULL;
 }
 
@@ -34350,7 +34381,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"VSIFReadL", _wrap_VSIFReadL, METH_VARARGS, (char *)"VSIFReadL(unsigned int nMembSize, unsigned int nMembCount, VSILFILE fp) -> unsigned int"},
 	 { (char *)"VSIGetMemFileBuffer_unsafe", _wrap_VSIGetMemFileBuffer_unsafe, METH_VARARGS, (char *)"VSIGetMemFileBuffer_unsafe(char const * utf8_path)"},
 	 { (char *)"Debug", _wrap_Debug, METH_VARARGS, (char *)"Debug(char const * msg_class, char const * message)"},
-	 { (char *)"SetErrorHandler", _wrap_SetErrorHandler, METH_VARARGS, (char *)"SetErrorHandler(char const * pszCallbackName=None) -> CPLErr"},
+	 { (char *)"SetErrorHandler", _wrap_SetErrorHandler, METH_VARARGS, (char *)"SetErrorHandler(CPLErrorHandler pfnErrorHandler=0) -> CPLErr"},
 	 { (char *)"PushErrorHandler", _wrap_PushErrorHandler, METH_VARARGS, (char *)"PushErrorHandler(CPLErrorHandler pfnErrorHandler=0) -> CPLErr"},
 	 { (char *)"PopErrorHandler", _wrap_PopErrorHandler, METH_VARARGS, (char *)"PopErrorHandler()"},
 	 { (char *)"Error", _wrap_Error, METH_VARARGS, (char *)"Error(CPLErr msg_class, int err_code=0, char const * msg)"},

--- a/gdal/swig/python/extensions/gdalconst_wrap.c
+++ b/gdal/swig/python/extensions/gdalconst_wrap.c
@@ -3936,6 +3936,83 @@ SWIGINTERN PyObject *CPLE_UserInterrupt_swigconstant(PyObject *SWIGUNUSEDPARM(se
 }
 
 
+SWIGINTERN PyObject *CPLE_ObjectNull_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "CPLE_ObjectNull",SWIG_From_int((int)(CPLE_ObjectNull)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *CPLE_HttpResponse_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "CPLE_HttpResponse",SWIG_From_int((int)(CPLE_HttpResponse)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *CPLE_AWSBucketNotFound_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "CPLE_AWSBucketNotFound",SWIG_From_int((int)(CPLE_AWSBucketNotFound)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *CPLE_AWSObjectNotFound_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "CPLE_AWSObjectNotFound",SWIG_From_int((int)(CPLE_AWSObjectNotFound)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *CPLE_AWSAccessDenied_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "CPLE_AWSAccessDenied",SWIG_From_int((int)(CPLE_AWSAccessDenied)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *CPLE_AWSInvalidCredentials_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "CPLE_AWSInvalidCredentials",SWIG_From_int((int)(CPLE_AWSInvalidCredentials)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *CPLE_AWSSignatureDoesNotMatch_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "CPLE_AWSSignatureDoesNotMatch",SWIG_From_int((int)(CPLE_AWSSignatureDoesNotMatch)));
+  return SWIG_Py_Void();
+}
+
+
 SWIGINTERN PyObject *OF_ALL_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *module;
   PyObject *d;
@@ -4786,6 +4863,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"CPLE_AssertionFailed_swigconstant", CPLE_AssertionFailed_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"CPLE_NoWriteAccess_swigconstant", CPLE_NoWriteAccess_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"CPLE_UserInterrupt_swigconstant", CPLE_UserInterrupt_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"CPLE_ObjectNull_swigconstant", CPLE_ObjectNull_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"CPLE_HttpResponse_swigconstant", CPLE_HttpResponse_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"CPLE_AWSBucketNotFound_swigconstant", CPLE_AWSBucketNotFound_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"CPLE_AWSObjectNotFound_swigconstant", CPLE_AWSObjectNotFound_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"CPLE_AWSAccessDenied_swigconstant", CPLE_AWSAccessDenied_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"CPLE_AWSInvalidCredentials_swigconstant", CPLE_AWSInvalidCredentials_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"CPLE_AWSSignatureDoesNotMatch_swigconstant", CPLE_AWSSignatureDoesNotMatch_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"OF_ALL_swigconstant", OF_ALL_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"OF_RASTER_swigconstant", OF_RASTER_swigconstant, METH_VARARGS, NULL},
 	 { (char *)"OF_VECTOR_swigconstant", OF_VECTOR_swigconstant, METH_VARARGS, NULL},

--- a/gdal/swig/python/extensions/gnm_wrap.cpp
+++ b/gdal/swig/python/extensions/gnm_wrap.cpp
@@ -3200,10 +3200,10 @@ PythonBindingErrorHandler(CPLErr eclass, int code, const char *msg )
   }
 
   /*
-  ** We do not want to interfere with warnings or debug messages since
+  ** We do not want to interfere with non-failure messages since
   ** they won't be translated into exceptions.
   */
-  else if (eclass == CE_Warning || eclass == CE_Debug ) {
+  else if (eclass != CE_Failure ) {
     pfnPreviousHandler(eclass, code, msg );
   }
   else {
@@ -3231,8 +3231,9 @@ void UseExceptions() {
                    CPLGetConfigOption("__chain_python_error_handlers", "")));
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
+    // if the previous logger was custom, we need the user data available
     pfnPreviousHandler =
-        CPLSetErrorHandler( (CPLErrorHandler) PythonBindingErrorHandler );
+        CPLSetErrorHandlerEx( (CPLErrorHandler) PythonBindingErrorHandler, CPLGetErrorHandlerUserData() );
   }
 }
 
@@ -3256,7 +3257,8 @@ void DontUseExceptions() {
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
     bUseExceptions = 0;
-    CPLSetErrorHandler( pfnPreviousHandler );
+    // if the previous logger was custom, we need the user data available. Preserve it.
+    CPLSetErrorHandlerEx( pfnPreviousHandler, CPLGetErrorHandlerUserData());
   }
 }
 

--- a/gdal/swig/python/extensions/ogr_wrap.cpp
+++ b/gdal/swig/python/extensions/ogr_wrap.cpp
@@ -3265,10 +3265,10 @@ PythonBindingErrorHandler(CPLErr eclass, int code, const char *msg )
   }
 
   /*
-  ** We do not want to interfere with warnings or debug messages since
+  ** We do not want to interfere with non-failure messages since
   ** they won't be translated into exceptions.
   */
-  else if (eclass == CE_Warning || eclass == CE_Debug ) {
+  else if (eclass != CE_Failure ) {
     pfnPreviousHandler(eclass, code, msg );
   }
   else {
@@ -3296,8 +3296,9 @@ void UseExceptions() {
                    CPLGetConfigOption("__chain_python_error_handlers", "")));
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
+    // if the previous logger was custom, we need the user data available
     pfnPreviousHandler =
-        CPLSetErrorHandler( (CPLErrorHandler) PythonBindingErrorHandler );
+        CPLSetErrorHandlerEx( (CPLErrorHandler) PythonBindingErrorHandler, CPLGetErrorHandlerUserData() );
   }
 }
 
@@ -3321,7 +3322,8 @@ void DontUseExceptions() {
     CPLSetConfigOption("__chain_python_error_handlers", pszNewValue);
     CPLFree(pszNewValue);
     bUseExceptions = 0;
-    CPLSetErrorHandler( pfnPreviousHandler );
+    // if the previous logger was custom, we need the user data available. Preserve it.
+    CPLSetErrorHandlerEx( pfnPreviousHandler, CPLGetErrorHandlerUserData());
   }
 }
 

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -1247,13 +1247,50 @@ def BuildVRT(destName, srcDSOrSrcDSTab, **kwargs):
         return BuildVRTInternalNames(destName, srcDSNamesTab, opts, callback, callback_data)
 
 
+# Logging Helpers
+def _pylog_handler(err_level, err_no, err_msg):
+    if err_no != gdalconst.CPLE_None:
+        typ = _pylog_handler.errcode_map.get(err_no, str(err_no))
+        message = "%s: %s" % (typ, err_msg)
+    else:
+        message = err_msg
+
+    level = _pylog_handler.level_map.get(err_level, 20)  # default level is INFO
+    _pylog_handler.logger.log(level, message)
+
+def ConfigurePythonLogging(logger_name='gdal', enable_debug=True):
+    """ Configure GDAL to use Python's logging framework """
+    import logging
+
+    _pylog_handler.logger = logging.getLogger(logger_name)
+
+# map CPLE_* constants to names
+    _pylog_handler.errcode_map = {_num: _name[5:] for _name, _num in gdalconst.__dict__.items() if _name.startswith('CPLE_')}
+
+# Map GDAL log levels to Python's
+    _pylog_handler.level_map = {
+        CE_None: logging.INFO,
+        CE_Debug: logging.DEBUG,
+        CE_Warning: logging.WARN,
+        CE_Failure: logging.ERROR,
+        CE_Fatal: logging.CRITICAL,
+    }
+
+# Set CPL_DEBUG so debug messages are passed through the logger
+    if enable_debug:
+        SetConfigOption("CPL_DEBUG", "ON")
+
+# Install as the default GDAL log handler
+    SetErrorHandler(_pylog_handler)
+
+
 
 def Debug(*args):
     """Debug(char const * msg_class, char const * message)"""
     return _gdal.Debug(*args)
 
 def SetErrorHandler(*args):
-    """SetErrorHandler(char const * pszCallbackName=None) -> CPLErr"""
+    """SetErrorHandler(CPLErrorHandler pfnErrorHandler=0) -> CPLErr"""
     return _gdal.SetErrorHandler(*args)
 
 def PushErrorHandler(*args):

--- a/gdal/swig/python/osgeo/gdalconst.py
+++ b/gdal/swig/python/osgeo/gdalconst.py
@@ -325,6 +325,27 @@ CPLE_NoWriteAccess = _gdalconst.CPLE_NoWriteAccess
 _gdalconst.CPLE_UserInterrupt_swigconstant(_gdalconst)
 CPLE_UserInterrupt = _gdalconst.CPLE_UserInterrupt
 
+_gdalconst.CPLE_ObjectNull_swigconstant(_gdalconst)
+CPLE_ObjectNull = _gdalconst.CPLE_ObjectNull
+
+_gdalconst.CPLE_HttpResponse_swigconstant(_gdalconst)
+CPLE_HttpResponse = _gdalconst.CPLE_HttpResponse
+
+_gdalconst.CPLE_AWSBucketNotFound_swigconstant(_gdalconst)
+CPLE_AWSBucketNotFound = _gdalconst.CPLE_AWSBucketNotFound
+
+_gdalconst.CPLE_AWSObjectNotFound_swigconstant(_gdalconst)
+CPLE_AWSObjectNotFound = _gdalconst.CPLE_AWSObjectNotFound
+
+_gdalconst.CPLE_AWSAccessDenied_swigconstant(_gdalconst)
+CPLE_AWSAccessDenied = _gdalconst.CPLE_AWSAccessDenied
+
+_gdalconst.CPLE_AWSInvalidCredentials_swigconstant(_gdalconst)
+CPLE_AWSInvalidCredentials = _gdalconst.CPLE_AWSInvalidCredentials
+
+_gdalconst.CPLE_AWSSignatureDoesNotMatch_swigconstant(_gdalconst)
+CPLE_AWSSignatureDoesNotMatch = _gdalconst.CPLE_AWSSignatureDoesNotMatch
+
 _gdalconst.OF_ALL_swigconstant(_gdalconst)
 OF_ALL = _gdalconst.OF_ALL
 


### PR DESCRIPTION
## What does this PR do?

1. Fixes an exit-time segfault when a custom error handler is installed and `CPL_DEBUG` is set.
2. Support a custom error handler via `gdal.SetErrorHandler()`. This also allows capturing logs for all  threads, which Push/Pop don't.
3. Fix some other error-handling bugs/omissions (eg. `CE_None` messages went nowhere)
4. Add a helper method, `gdal.ConfigurePythonLogging()` which:
    * sets a default GDAL error handler
    * passes all logged messages to Python's logging framework
    * turns on `CPL_DEBUG` so the log framework can decide to filter debug messages
    * maps GDAL's log levels to Python's
    * maps `CPLE_*` error codes to names

https://gist.github.com/rcoup/ba0786ead611ed21b8e24ce364e4df1f has a test script:

* `test_errhandler.py --basic` is a simple testcase for the crash
* `test_errhandler.py` will do a whole pile of tests
* `test_errhandler.py --configure` will show the `ConfigureLogging()` behaviour

## What are related issues/pull requests?

https://github.com/mapbox/rasterio/issues/902 & various others

## Tasklist

 - [ ] Review. Commits are broken out tidily.
 - [x] Assemble some of the gist into unit tests
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Linux