### PR TITLE
checkout output buffer matches expected count

### DIFF
--- a/gdal/frmts/gtiff/libtiff/tif_webp.c
+++ b/gdal/frmts/gtiff/libtiff/tif_webp.c
@@ -158,7 +158,8 @@ TWebPDecode(TIFF* tif, uint8* op, tmsize_t occ, uint16 s)
     /* Returns the RGB/A image decoded so far */
     buf = WebPIDecGetRGB(sp->psDecoder, &current_y, NULL, NULL, &stride);
     
-    if ((buf != NULL) && (current_y > sp->last_y)) {
+    if ((buf != NULL) &&
+        (occ == stride * (current_y - sp->last_y))) {
       memcpy(op,   
          buf + (sp->last_y * stride),
          occ);


### PR DESCRIPTION
## What does this PR do?

This adds a check that the output buffer is the correct size when decoding a tiff with webp compression.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/1006