### PR TITLE
ILI: support  plugin by adding  -DILI_PLUGIN when compile

### DIFF
--- a/gdal/ogr/ogrsf_frmts/ili/ogrili1driver.cpp
+++ b/gdal/ogr/ogrsf_frmts/ili/ogrili1driver.cpp
@@ -113,4 +113,7 @@ void RegisterOGRILI1() {
     poDriver->pfnCreate = OGRILI1DriverCreate;
 
     GetGDALDriverManager()->RegisterDriver( poDriver );
+#ifdef ILI_PLUGIN
+    RegisterOGRILI2();
+#endif
 }


### PR DESCRIPTION
## What does this PR do?

Allow build ILI driver as plugin by adding  -DILI_PLUGIN option.
This helps a future improvement for plugin build support.

ILI driver has two driver internal, one is ILI1 and another is ILI2.
When building as plugin, it need a mechanism to initialize both drivers.

This patch allow build plugin as ogr_ILI1.so, then automatically initialize
ILI2 when gdal loading plugins.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
