### PR TITLE
ConfigurePythonLogging: Don't turn cpl_debug on by default

### DIFF
--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -676,7 +676,7 @@ def misc_14():
 
     prev_debug = gdal.GetConfigOption("CPL_DEBUG")
     try:
-        gdal.ConfigurePythonLogging(logger_name='gdal_logging_test')
+        gdal.ConfigurePythonLogging(logger_name='gdal_logging_test', enable_debug=True)
 
         if gdal.GetConfigOption("CPL_DEBUG") != "ON":
             gdaltest.post_reason("should have enabled debug")
@@ -704,7 +704,7 @@ def misc_14():
         handler.messages.clear()
         gdal.SetConfigOption('CPL_DEBUG', "OFF")
 
-        gdal.ConfigurePythonLogging(logger_name='gdal_logging_test', enable_debug=False)
+        gdal.ConfigurePythonLogging(logger_name='gdal_logging_test')
 
         if gdal.GetConfigOption("CPL_DEBUG") != "OFF":
             gdaltest.post_reason("shouldn't have enabled debug")

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -2046,7 +2046,7 @@ def _pylog_handler(err_level, err_no, err_msg):
     level = _pylog_handler.level_map.get(err_level, 20)  # default level is INFO
     _pylog_handler.logger.log(level, message)
 
-def ConfigurePythonLogging(logger_name='gdal', enable_debug=True):
+def ConfigurePythonLogging(logger_name='gdal', enable_debug=False):
     """ Configure GDAL to use Python's logging framework """
     import logging
 

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -1258,7 +1258,7 @@ def _pylog_handler(err_level, err_no, err_msg):
     level = _pylog_handler.level_map.get(err_level, 20)  # default level is INFO
     _pylog_handler.logger.log(level, message)
 
-def ConfigurePythonLogging(logger_name='gdal', enable_debug=True):
+def ConfigurePythonLogging(logger_name='gdal', enable_debug=False):
     """ Configure GDAL to use Python's logging framework """
     import logging
 


### PR DESCRIPTION
It's too verbose in many cases, with lots of noise from vsicurl and warping in particular. While you can filter it in Python, it requires additional configuration work.

Future idea is probably to increase some useful messages from CE_Debug up to CE_None, or add a CE_Trace level below CE_Debug.

## What does this PR do?

Change the default value for the `enable_debug` parameter to `gdal.ConfigurePythonLogging()`

If the user has previously set `CPL_DEBUG=ON` in their environment, it'll keep propagating debug messages up.

## What are related issues/pull requests?

#1017 

## Tasklist

 - [ ] All CI builds and checks have passed
