### PR TITLE
MSSQLSpatial: driver does not assign new ID following an INSERT (fixes ticket #1052)

### DIFF
--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -226,6 +226,14 @@ def ogr_mssqlspatial_4():
             return 'fail'
 
         ######################################################################
+        # Before reading back the record, verify that the newly added feature 
+        # is returned from the CreateFeature method with a newly assigned FID.
+        
+        if dst_feat.GetFID() == -1:
+            gdaltest.post_reason('Assigned FID was not returned in the new feature')
+            return 'fail'
+
+        ######################################################################
         # Read back the feature and get the geometry.
 
         gdaltest.mssqlspatial_lyr.SetAttributeFilter("PRFEDEA = '%s'" % item)
@@ -241,6 +249,50 @@ def ogr_mssqlspatial_4():
         feat_read.Destroy()
 
     dst_feat.Destroy()
+    gdaltest.mssqlspatial_lyr.ResetReading()  # to close implicit transaction
+
+    return 'success'
+
+###############################################################################
+# Write more features and verify the newly assigned FIDs are returned in the 
+# feature.
+
+
+def ogr_mssqlspatial_5():
+    if gdaltest.mssqlspatial_ds is None:
+        return 'skip'
+
+    new_feat = ogr.Feature(
+        feature_def=gdaltest.mssqlspatial_lyr.GetLayerDefn())
+    wkt_list = ['10', '2', '1', '4', '5', '6']
+
+    for item in wkt_list:
+        wkt_filename = 'data/wkb_wkt/' + item + '.wkt'
+        wkt = open(wkt_filename).read()
+        geom = ogr.CreateGeometryFromWkt(wkt)
+
+        ######################################################################
+        # Write geometry as a new feature.
+
+        new_feat.SetGeometryDirectly(geom)
+        new_feat.SetField('PRFEDEA', item)
+        new_feat.SetFID(-1)
+        if gdaltest.mssqlspatial_lyr.CreateFeature(new_feat) \
+           != ogr.OGRERR_NONE:
+            gdaltest.post_reason('CreateFeature failed creating feature ' +
+                                 'from file "' + wkt_filename + '"')
+            return 'fail'
+
+        ######################################################################
+        # Newly added feature should be returned from CreateFeature method
+        # with newly assigned FID.
+        
+        if new_feat.GetFID() == -1:
+            gdaltest.post_reason('FID was not returned in the newly created feature')
+            return 'fail'
+
+        new_feat.Destroy()
+
     gdaltest.mssqlspatial_lyr.ResetReading()  # to close implicit transaction
 
     return 'success'
@@ -372,6 +424,7 @@ gdaltest_list = [
     ogr_mssqlspatial_2,
     ogr_mssqlspatial_3,
     ogr_mssqlspatial_4,
+    ogr_mssqlspatial_5,
     ogr_mssqlspatial_test_ogrsf,
     ogr_mssqlspatial_create_feature_in_unregistered_table,
     ogr_mssqlspatial_cleanup

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -254,50 +254,6 @@ def ogr_mssqlspatial_4():
     return 'success'
 
 ###############################################################################
-# Write more features and verify the newly assigned FIDs are returned in the 
-# feature.
-
-
-def ogr_mssqlspatial_5():
-    if gdaltest.mssqlspatial_ds is None:
-        return 'skip'
-
-    new_feat = ogr.Feature(
-        feature_def=gdaltest.mssqlspatial_lyr.GetLayerDefn())
-    wkt_list = ['10', '2', '1', '4', '5', '6']
-
-    for item in wkt_list:
-        wkt_filename = 'data/wkb_wkt/' + item + '.wkt'
-        wkt = open(wkt_filename).read()
-        geom = ogr.CreateGeometryFromWkt(wkt)
-
-        ######################################################################
-        # Write geometry as a new feature.
-
-        new_feat.SetGeometryDirectly(geom)
-        new_feat.SetField('PRFEDEA', item)
-        new_feat.SetFID(-1)
-        if gdaltest.mssqlspatial_lyr.CreateFeature(new_feat) \
-           != ogr.OGRERR_NONE:
-            gdaltest.post_reason('CreateFeature failed creating feature ' +
-                                 'from file "' + wkt_filename + '"')
-            return 'fail'
-
-        ######################################################################
-        # Newly added feature should be returned from CreateFeature method
-        # with newly assigned FID.
-        
-        if new_feat.GetFID() == -1:
-            gdaltest.post_reason('FID was not returned in the newly created feature')
-            return 'fail'
-
-        new_feat.Destroy()
-
-    gdaltest.mssqlspatial_lyr.ResetReading()  # to close implicit transaction
-
-    return 'success'
-
-###############################################################################
 # Run test_ogrsf
 
 
@@ -424,7 +380,6 @@ gdaltest_list = [
     ogr_mssqlspatial_2,
     ogr_mssqlspatial_3,
     ogr_mssqlspatial_4,
-    ogr_mssqlspatial_5,
     ogr_mssqlspatial_test_ogrsf,
     ogr_mssqlspatial_create_feature_in_unregistered_table,
     ogr_mssqlspatial_cleanup

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -2060,18 +2060,18 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
     if (oStatement.GetCommand()[strlen(oStatement.GetCommand()) - 1] != ']')
     {
         /* no fields were added */
-		if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
-			oStatement.Appendf(" OUTPUT INSERTED.[%s] DEFAULT VALUES;", GetFIDColumn());
-		else
-			oStatement.Appendf( "DEFAULT VALUES;" );
+        if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
+            oStatement.Appendf(" OUTPUT INSERTED.[%s] DEFAULT VALUES;", GetFIDColumn());
+        else
+            oStatement.Appendf( "DEFAULT VALUES;" );
     }
     else
     {
-		/* prepend VALUES section */
-		if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
-			oStatement.Appendf(") OUTPUT INSERTED.[%s] VALUES (", GetFIDColumn());
-		else
-			oStatement.Appendf( ") VALUES (" );
+        /* prepend VALUES section */
+        if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
+            oStatement.Appendf(") OUTPUT INSERTED.[%s] VALUES (", GetFIDColumn());
+        else
+            oStatement.Appendf( ") VALUES (" );
 
         /* Set the geometry */
         bNeedComma = FALSE;
@@ -2266,15 +2266,15 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
 
         return OGRERR_FAILURE;
     }
-	else if(pszFIDColumn != nullptr && bIsIdentityFid)
-	{
-		// fetch new ID and set it into the feature
-		if (oStatement.Fetch())
-		{
-			int newID = atoi(oStatement.GetColData(0));
-			poFeature->SetFID((GIntBig)newID);
-		}
-	}
+    else if(pszFIDColumn != nullptr && bIsIdentityFid)
+    {
+        // fetch new ID and set it into the feature
+        if (oStatement.Fetch())
+        {
+            GIntBig newID = atoll(oStatement.GetColData(0));
+            poFeature->SetFID(newID);
+        }
+    }
 
     for( i = 0; i < bind_num; i++ )
             CPLFree(bind_buffer[i]);

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -2266,7 +2266,7 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
 
         return OGRERR_FAILURE;
     }
-    else if(pszFIDColumn != nullptr && bIsIdentityFid)
+    else if(nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
     {
         // fetch new ID and set it into the feature
         if (oStatement.Fetch())

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -2060,11 +2060,18 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
     if (oStatement.GetCommand()[strlen(oStatement.GetCommand()) - 1] != ']')
     {
         /* no fields were added */
-        oStatement.Appendf( "DEFAULT VALUES;" );
+		if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
+			oStatement.Appendf(" OUTPUT INSERTED.[%s] DEFAULT VALUES;", GetFIDColumn());
+		else
+			oStatement.Appendf( "DEFAULT VALUES;" );
     }
     else
     {
-        oStatement.Appendf( ") VALUES (" );
+		/* prepend VALUES section */
+		if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
+			oStatement.Appendf(") OUTPUT INSERTED.[%s] VALUES (", GetFIDColumn());
+		else
+			oStatement.Appendf( ") VALUES (" );
 
         /* Set the geometry */
         bNeedComma = FALSE;
@@ -2259,6 +2266,15 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
 
         return OGRERR_FAILURE;
     }
+	else if(pszFIDColumn != nullptr && bIsIdentityFid)
+	{
+		// fetch new ID and set it into the feature
+		if (oStatement.Fetch())
+		{
+			int newID = atoi(oStatement.GetColData(0));
+			poFeature->SetFID((GIntBig)newID);
+		}
+	}
 
     for( i = 0; i < bind_num; i++ )
             CPLFree(bind_buffer[i]);


### PR DESCRIPTION
Method OGRMSSQLSpatialTableLayer::ICreateFeature (in source file ogrmssqlspatialtablelayer.cpp) has been modified such that the INSERT statement now includes the OUTPUT clause, requesting the newly assigned FID.

It only modifies the INSERT statement when the FID is an IDENTITY column, and following a successful execution, fetches the result and calls the SetFID method on the passed-in feature.