### PR TITLE
autotest: gdriver_loslas: see inside jar file for downloaded data

### DIFF
--- a/autotest/gdrivers/loslas.py
+++ b/autotest/gdrivers/loslas.py
@@ -48,7 +48,15 @@ def loslas_online_1():
     except OSError:
         return 'skip'
 
-    tst = gdaltest.GDALTest('LOSLAS', '/vsizip/tmp/cache/NADCON.zip/wyhpgn.los', 1, 0, filename_absolute=1)
+    try:
+        gdaltest.unzip('tmp/cache/NADCON', 'tmp/cache/NADCON.zip')
+        os.stat('tmp/cache/NADCON/nadcon.jar')
+        gdaltest.unzip('tmp/cache/NADCON', 'tmp/cache/NADCON/nadcon.jar')
+        os.stat('tmp/cache/NADCON/grids/wyhpgn.los')
+    except OSError:
+        return 'skip'
+
+    tst = gdaltest.GDALTest('LOSLAS', 'tmp/cache/NADCON/grids/wyhpgn.los', 1, 0, filename_absolute=1)
     gt = (-111.625, 0.25, 0.0, 45.625, 0.0, -0.25)
     stats = (-0.0080000003799796, 0.031125999987125001, 0.0093017323318172005, 0.0075646520354096004)
     return tst.testOpen(check_gt=gt, check_stat=stats, check_prj='WGS84')


### PR DESCRIPTION
## What does this PR do?

Fix loslas test failure not to found a test data.

Downloaded file NADCON.zip has nadcon.jar for grids data container.
try to unzip NADCON.zip and nadcon.jar to extract test data.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What are related issues/pull requests?
N.A.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
