### PR TITLE
gdal_contours tests: Fix an off-by-one when accessing ring points (fixes #960)

### DIFF
--- a/autotest/cpp/test_marching_squares_contour.cpp
+++ b/autotest/cpp/test_marching_squares_contour.cpp
@@ -113,11 +113,11 @@ private:
         // we represent them with a vector, we need to find a common "first" point
         Point pfirst = aRing[0];
         size_t offset = 0;
-        for ( ; pfirst != bRing[offset]; offset++ ) {
-            if ( offset >= bRing.size() ) {
-                // can't find a common point
-                return false;
-            }
+        while ( offset < bRing.size() && pfirst != bRing[offset] )
+            offset++;
+        if ( offset >= bRing.size() ) {
+            // can't find a common point
+            return false;
         }
         // now compare each point of the two rings
         for ( size_t i = 0; i < aRing.size(); i++ ) {


### PR DESCRIPTION
## What does this PR do?

This should fix the problem seen by valgrind in #960.
A for loop was accessing the memory one byte too far.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
