### PR TITLE
autotest: fix UnicodeEncodeError when test fails in python2

### DIFF
--- a/autotest/ogr/ogr_gmlas.py
+++ b/autotest/ogr/ogr_gmlas.py
@@ -75,7 +75,7 @@ def compare_ogrinfo_output(gmlfile, reffile, options=''):
     if ret != expected:
         gdaltest.post_reason('fail')
         print('Got:')
-        print(ret)
+        print(ret.encode('utf-8'))
         open(tmpfilename, 'wb').write(ret.encode('utf-8'))
         print('Diff:')
         os.system('diff -u ' + reffile + ' ' + tmpfilename)


### PR DESCRIPTION
## What does this PR do?

When calling ogr_gmlas.py test and its test fails, python2 warns UnicodeEncodeError instead of showing
test result.
A patch fix print of debug message.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

