### PR TITLE
autotest: fix infinite wait when no real tty

### DIFF
--- a/autotest/gdrivers/georaster.py
+++ b/autotest/gdrivers/georaster.py
@@ -499,9 +499,13 @@ gdaltest_list = [
 if __name__ == '__main__':
 
     if 'OCI_DSNAME' not in os.environ:
-        print('Enter ORACLE connection (e.g. OCI:scott/tiger@orcl): ')
-        oci_dsname = sys.stdin.readline().strip()
-        os.environ['OCI_DSNAME'] = oci_dsname
+        if sys.stdout.isatty():
+            print('Enter ORACLE connection (e.g. OCI:scott/tiger@orcl): ')
+            oci_dsname = sys.stdin.readline().strip()
+            os.environ['OCI_DSNAME'] = oci_dsname
+        else:
+            print('Skip test due not to set OCI_DSNAME environment variable.')
+            sys.exit(0)
 
     gdaltest.setup_run('GeoRaster')
 

--- a/autotest/ogr/ogr_oci.py
+++ b/autotest/ogr/ogr_oci.py
@@ -1113,9 +1113,13 @@ gdaltest_list = [
 if __name__ == '__main__':
 
     if 'OCI_DSNAME' not in os.environ:
-        print('Enter ORACLE DataSource (e.g. OCI:scott/tiger):')
-        oci_dsname = sys.stdin.readline().strip()
-        os.environ['OCI_DSNAME'] = oci_dsname
+        if sys.stdout.isatty():
+            print('Enter ORACLE DataSource (e.g. OCI:scott/tiger):')
+            oci_dsname = sys.stdin.readline().strip()
+            os.environ['OCI_DSNAME'] = oci_dsname
+        else:
+            print('Skip test due not to set OCI_DSNAME environment variable.')
+            sys.exit(0)
 
     gdaltest.setup_run('ogr_oci')
 


### PR DESCRIPTION
## What does this PR do?

When calling test command in an environment where command result
pipe to other process, these test waiting input
in the condition environement variable OCI_DSNAME is not set.

A patch detect tty is a real or not then skip if process is
not connect to real terminal.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What are related issues/pull requests?
N.A.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
