### PR TITLE
Backport from master for issue1024: Fix the issue by freeing the temporary lobs created by readCLob() and…

### DIFF
--- a/gdal/frmts/georaster/georaster_wrapper.cpp
+++ b/gdal/frmts/georaster/georaster_wrapper.cpp
@@ -526,7 +526,7 @@ GeoRasterWrapper* GeoRasterWrapper::Open( const char* pszStringId, bool bUpdate 
     //  Clean up
     //  -------------------------------------------------------------------
 
-    OCIDescriptorFree( phLocator, OCI_DTYPE_LOB );
+    poStmt->FreeLob(phLocator);
     CPLFree( pszXML );
     delete poStmt;
 
@@ -966,7 +966,7 @@ bool GeoRasterWrapper::Create( char* pszDescription,
         sDataTable = szBindRDT;
         nRasterId  = nBindRID;
 
-        OCIDescriptorFree( phLocator, OCI_DTYPE_LOB );
+        poStmt->FreeLob(phLocator);
 
         delete poStmt;
 
@@ -3185,13 +3185,13 @@ bool GeoRasterWrapper::SetNoData( int nLayer, const char* pszValue )
 
     if( ! poStmt->Execute() )
     {
-        OCIDescriptorFree( phLocatorR, OCI_DTYPE_LOB );
-        OCIDescriptorFree( phLocatorW, OCI_DTYPE_LOB );
+        poStmt->FreeLob(phLocatorR);
+        poStmt->FreeLob(phLocatorW);
         delete poStmt;
         return false;
     }
 
-    OCIDescriptorFree( phLocatorW, OCI_DTYPE_LOB );
+    poStmt->FreeLob(phLocatorW);
 
     // ------------------------------------------------------------
     //  Read the XML metadata from db to memory with nodata updates
@@ -3206,7 +3206,7 @@ bool GeoRasterWrapper::SetNoData( int nLayer, const char* pszValue )
         CPLFree( pszXML );
     }
 
-    OCIDescriptorFree( phLocatorR, OCI_DTYPE_LOB );
+    poStmt->FreeLob(phLocatorR);
 
     bFlushMetadata = true;
     delete poStmt;
@@ -3596,12 +3596,12 @@ bool GeoRasterWrapper::FlushMetadata()
 
     if( ! poStmt->Execute() )
     {
-        OCIDescriptorFree( phLocator, OCI_DTYPE_LOB );
+        poStmt->FreeLob(phLocator);
         delete poStmt;
         return false;
     }
 
-    OCIDescriptorFree( phLocator, OCI_DTYPE_LOB );
+    poStmt->FreeLob(phLocator);
 
     delete poStmt;
 

--- a/gdal/frmts/georaster/oci_wrapper.cpp
+++ b/gdal/frmts/georaster/oci_wrapper.cpp
@@ -1123,15 +1123,19 @@ void OWStatement::WriteCLob( OCILobLocator** pphLocator, char* pszData )
 {
     nNextCol++;
 
-    CheckError( OCIDescriptorAlloc(
+    if (CheckError( OCIDescriptorAlloc(
         poConnection->hEnv,
         (void**) pphLocator,
         OCI_DTYPE_LOB,
         (size_t) 0,
         (dvoid **) nullptr),
-        hError );
+        hError ))
+    {
+        CPLDebug("OCI", "Error in WriteCLob");
+        return;
+    }
 
-    CheckError( OCILobCreateTemporary(
+    if (CheckError( OCILobCreateTemporary(
         poConnection->hSvcCtx,
         poConnection->hError,
         (OCILobLocator*) *pphLocator,
@@ -1140,11 +1144,15 @@ void OWStatement::WriteCLob( OCILobLocator** pphLocator, char* pszData )
         (ub1) OCI_TEMP_CLOB,
         false,
         OCI_DURATION_SESSION ),
-        hError );
+        hError ))
+    {
+        CPLDebug("OCI", "Error in WriteCLob creating temporary lob");
+        return;
+    }
 
     ub4 nAmont = (ub4) strlen(pszData);
 
-    CheckError( OCILobWrite(
+    if (CheckError( OCILobWrite(
         poConnection->hSvcCtx,
         hError,
         *pphLocator,
@@ -1157,7 +1165,11 @@ void OWStatement::WriteCLob( OCILobLocator** pphLocator, char* pszData )
         nullptr,
         (ub2) 0,
         (ub1) SQLCS_IMPLICIT ),
-        hError );
+        hError ))
+    {
+        CPLDebug("OCI", "Error in WriteCLob writing the lob");
+        return;
+    }
 }
 
 void OWStatement::Define( OCIArray** pphData )
@@ -1587,6 +1599,44 @@ char* OWStatement::ReadCLob( OCILobLocator* phLocator )
     pszBuffer[nAmont] = '\0';
 
     return pszBuffer;
+}
+
+// Free OCIDescriptor for the LOB, if it is temporary lob, it is freed too.
+void OWStatement::FreeLob(OCILobLocator* phLocator)
+{
+    boolean        is_temporary;
+
+    if (phLocator == nullptr)
+        return;
+
+    if( CheckError( OCILobIsTemporary(
+        poConnection->hEnv,
+        hError,
+        phLocator,
+        &is_temporary), 
+        hError))
+    {
+        CPLDebug("OCI", "OCILobIsTemporary failed");
+        OCIDescriptorFree( phLocator, OCI_DTYPE_LOB );
+        return;
+    }
+
+    if(is_temporary)
+    {
+      if( CheckError( OCILobFreeTemporary(
+        poConnection->hSvcCtx,
+        hError,
+        phLocator),
+        hError))
+      {
+        CPLDebug("OCI", "OCILobFreeTemporary failed");
+        OCIDescriptorFree( phLocator, OCI_DTYPE_LOB );
+        return;
+      }
+
+    }
+
+    OCIDescriptorFree( phLocator, OCI_DTYPE_LOB );
 }
 
 void OWStatement::BindName( const char* pszName, int* pnData )

--- a/gdal/frmts/georaster/oci_wrapper.h
+++ b/gdal/frmts/georaster/oci_wrapper.h
@@ -417,6 +417,7 @@ public:
     unsigned long       ReadBlob( OCILobLocator* phLocator,
                             void* pBuffer, unsigned long nOffset, 
                                            unsigned long nSize );
+    void                FreeLob(OCILobLocator* phLocator);
     char*               ReadCLob( OCILobLocator* phLocator );
     void                WriteCLob( OCILobLocator** pphLocator, char* pszData );
     bool                WriteBlob( OCILobLocator* phLocator,


### PR DESCRIPTION
… writeCLOB().

Put the temporary lob release together with OCIDescriptorFree().

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?
#1024 

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
