### PR TITLE
DBF: Add CP1251 codepage name synonym (ANSI 1251) for DBF files.

### DIFF
--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -445,6 +445,8 @@ CPLString OGRShapeLayer::ConvertCodePage( const char *pszCodePage )
     }
     if( STARTS_WITH_CI(pszCodePage, "UTF-8") )
         return CPL_ENC_UTF8;
+    if( STARTS_WITH_CI(pszCodePage, "ANSI 1251") )
+        return "CP1251";
 
     // Try just using the CPG value directly.  Works for stuff like Big5.
     return pszCodePage;


### PR DESCRIPTION
This synonym is found in the Russian-language OS Windows ArcGis.
