### PR TITLE
Fix wrong doublequote charactes in OCI manual

### DIFF
--- a/gdal/ogr/ogrsf_frmts/oci/drv_oci.html
+++ b/gdal/ogr/ogrsf_frmts/oci/drv_oci.html
@@ -102,11 +102,11 @@ in USER_SDO_GEOM_METADATA and rebuilding the spatial index.<p>
 
 <li> <b>OVERWRITE</b>: This may be "YES" to force an existing layer (=table) of the
 same desired name to be destroyed before creating the requested layer.
-The default value is “NO"<p>
+The default value is "NO"<p>
 
 <li> <b>TRUNCATE</b>: This may be "YES" to force the existing table to
 be reused, but to first truncate all records in the table, preserving
-indexes or dependencies. The default value is “NO".<p>
+indexes or dependencies. The default value is "NO".<p>
 
 <li> <b>LAUNDER</b>: This may be "YES" to force new fields created on this
 layer to have their field names "laundered" into a form more compatible with


### PR DESCRIPTION
## What does this PR do?
Fixes gabled text in the OCI driver documentation:
The default value is â€œNO" 