### PR TITLE
CI tweaks (ubuntu_1804 environment)

### DIFF
--- a/gdal/ci/travis/ubuntu_1804/before_install.sh
+++ b/gdal/ci/travis/ubuntu_1804/before_install.sh
@@ -5,7 +5,7 @@ set -e
 export chroot="$PWD"/bionic
 mkdir -p "$chroot$PWD"
 sudo apt-get update
-sudo apt-get install -y debootstrap libcap2-bin dpkg docker
+sudo apt-get install -y debootstrap libcap2-bin dpkg
 
 # MSSQL: server side
 docker pull microsoft/mssql-server-linux:2017-latest
@@ -14,12 +14,10 @@ sleep 10
 docker exec -it sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB;"
 
 # MySQL 8
-docker pull mysql/mysql-server:8.0.1
-docker run --name mysql1 -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33060:3306 -d mysql/mysql-server mysqld --default-authentication-plugin=mysql_native_password
+docker run --name mysql1 -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33060:3306 -d mysql/mysql-server:8.0.1 mysqld --default-authentication-plugin=mysql_native_password
 
 # MariaDB 10.3.9
-docker pull mariadb:10.3.9
-docker run --name mariadb -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33061:3306 -d mariadb
+docker run --name mariadb -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33061:3306 -d mariadb:10.3.9
 
 # PostGIS
 docker run -v /home:/home --name "postgis" -p 25432:5432 -e ALLOW_IP_RANGE=0.0.0.0/0 -d -t kartoza/postgis
@@ -46,10 +44,7 @@ sudo chroot "$chroot" apt-get update
 # postgis postgresql-9.1 postgresql-client-9.1 postgresql-9.1-postgis-2.1 postgresql-9.1-postgis-2.1-scripts libpq-dev
 sudo chroot "$chroot" apt-get install -y --allow-unauthenticated python-numpy libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libkml-dev libmysqlclient-dev mysql-client-core-5.7 libogdi3.2-dev libcfitsio-dev openjdk-8-jdk libzstd1-dev ccache bash zip curl libpq-dev postgresql-client postgis
 # libpodofo-dev : FIXME incompatibilities at runtime with that version
-sudo chroot "$chroot" apt-get install -y doxygen texlive-latex-base
-sudo chroot "$chroot" apt-get install -y make
-sudo chroot "$chroot" apt-get install -y python-dev
-sudo chroot "$chroot" apt-get install -y g++
+sudo chroot "$chroot" apt-get install -y doxygen texlive-latex-base make python-dev g++
 #sudo chroot "$chroot" apt-get install -y --allow-unauthenticated libsfcgal-dev
 sudo chroot "$chroot" apt-get install -y --allow-unauthenticated fossil libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev
 


### PR DESCRIPTION

## What does this PR do?

Minor tweaks for the ubuntu_1804 CI environment, saving some bandwidth/time.

* The `docker` package in ubuntu isn't actually docker. Docker is preinstalled in travis.
* It was pulling one version of the docker containers for mariadb/mysql,
  and then implicitly running ':latest' (which implicitly pulled again).
  I removed the pull command since it was unnecessary.
* Consolidate some apt-get installs to save a couple seconds


## What are related issues/pull requests?

nothing relevant

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
