### PR TITLE
MSSQLSPATIAL: Adding configuration option MSSQLSPATIAL_ALWAYS_OUTPUT_FID

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/drv_mssqlspatial.html
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/drv_mssqlspatial.html
@@ -133,6 +133,7 @@ Options</a> which help control the behavior of this driver.</p>
     this parameter is TRUE, otherwise the parameter is ignored by the driver.</li>
 <li><b>MSSQLSPATIAL_BCP_SIZE</b>: (From GDAL 2.1.0) Specifies the bulk insert batch size. The larger value makes the insert faster, but consumes more memory. Default = 1000.</li>
 <li><b>MSSQLSPATIAL_OGR_FID</b>: Override FID column name. Default = ogr_fid.</li>
+<li><b>MSSQLSPATIAL_ALWAYS_OUTPUT_FID</b>: Always return the OGR_FID column - even if it is not a true IDENTITY column - when creating features. Default = "NO".</li>
 <li><b>MSSQLSPATIAL_USE_GEOMETRY_COLUMNS</b>: Use/create geometry_columns metadata table in the database. Default = "YES".</li>
 <li><b>MSSQLSPATIAL_LIST_ALL_TABLES</b>: Use mssql catalog to list available layers. Default = "NO".</li>
 </ul>

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
@@ -449,6 +449,7 @@ class OGRMSSQLSpatialDataSource final: public OGRDataSource
     int                 nGeometryFormat;
 
     int                 bUseGeometryColumns;
+    int                 bAlwaysOutputFid;
 
     int                 bListAllTables;
 
@@ -487,6 +488,7 @@ class OGRMSSQLSpatialDataSource final: public OGRDataSource
 
     int                 GetGeometryFormat() { return nGeometryFormat; }
     int                 UseGeometryColumns() { return bUseGeometryColumns; }
+    int                 AlwaysOutputFid() { return bAlwaysOutputFid; }
 
     virtual OGRErr       DeleteLayer( int iLayer ) override;
     virtual OGRLayer    *ICreateLayer( const char *,

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
@@ -449,7 +449,7 @@ class OGRMSSQLSpatialDataSource final: public OGRDataSource
     int                 nGeometryFormat;
 
     int                 bUseGeometryColumns;
-    int                 bAlwaysOutputFid;
+    bool                bAlwaysOutputFid;
 
     int                 bListAllTables;
 
@@ -488,7 +488,7 @@ class OGRMSSQLSpatialDataSource final: public OGRDataSource
 
     int                 GetGeometryFormat() { return nGeometryFormat; }
     int                 UseGeometryColumns() { return bUseGeometryColumns; }
-    int                 AlwaysOutputFid() { return bAlwaysOutputFid; }
+    bool                AlwaysOutputFid() { return bAlwaysOutputFid; }
 
     virtual OGRErr       DeleteLayer( int iLayer ) override;
     virtual OGRLayer    *ICreateLayer( const char *,

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -53,6 +53,7 @@ OGRMSSQLSpatialDataSource::OGRMSSQLSpatialDataSource() :
     pszConnection = nullptr;
 
     bUseGeometryColumns = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_USE_GEOMETRY_COLUMNS", "YES"));
+    bAlwaysOutputFid = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_ALWAYS_OUTPUT_FID", "YES"));
     bListAllTables = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_LIST_ALL_TABLES", "NO"));
 
     const char* nBCPSizeParam = CPLGetConfigOption("MSSQLSPATIAL_BCP_SIZE", nullptr);

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -53,7 +53,7 @@ OGRMSSQLSpatialDataSource::OGRMSSQLSpatialDataSource() :
     pszConnection = nullptr;
 
     bUseGeometryColumns = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_USE_GEOMETRY_COLUMNS", "YES"));
-    bAlwaysOutputFid = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_ALWAYS_OUTPUT_FID", "YES"));
+    bAlwaysOutputFid = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_ALWAYS_OUTPUT_FID", "NO"));
     bListAllTables = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_LIST_ALL_TABLES", "NO"));
 
     const char* nBCPSizeParam = CPLGetConfigOption("MSSQLSPATIAL_BCP_SIZE", nullptr);

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -2060,7 +2060,8 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
     if (oStatement.GetCommand()[strlen(oStatement.GetCommand()) - 1] != ']')
     {
         /* no fields were added */
-        if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
+
+        if (nFID == OGRNullFID && pszFIDColumn != nullptr && (bIsIdentityFid || poDS->AlwaysOutputFid() ))
             oStatement.Appendf(" OUTPUT INSERTED.[%s] DEFAULT VALUES;", GetFIDColumn());
         else
             oStatement.Appendf( "DEFAULT VALUES;" );
@@ -2068,7 +2069,7 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
     else
     {
         /* prepend VALUES section */
-        if (nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
+        if (nFID == OGRNullFID && pszFIDColumn != nullptr && (bIsIdentityFid || poDS->AlwaysOutputFid() ))
             oStatement.Appendf(") OUTPUT INSERTED.[%s] VALUES (", GetFIDColumn());
         else
             oStatement.Appendf( ") VALUES (" );

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -2267,7 +2267,7 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature( OGRFeature *poFeature )
 
         return OGRERR_FAILURE;
     }
-    else if(nFID == OGRNullFID && pszFIDColumn != nullptr && bIsIdentityFid)
+    else if(nFID == OGRNullFID && pszFIDColumn != nullptr && (bIsIdentityFid || poDS->AlwaysOutputFid() ))
     {
         // fetch new ID and set it into the feature
         if (oStatement.Fetch())


### PR DESCRIPTION
When set to YES, MSSQLSPATIAL will always set the OGR_FID column using an OUTPUT clause when inserting features. This way, views (which will never have IDENTITY columns) or sequence generated ID columns are also supported.

Related to #1502 and #1053 in that it was still impossible to insert features in views (which are insertable/updatable)