### PR TITLE
CPL: Propagate error handler user data correctly (fixes #1098)

### DIFF
--- a/gdal/port/cpl_error.cpp
+++ b/gdal/port/cpl_error.cpp
@@ -185,12 +185,90 @@ static CPLErrorContext *CPLGetErrorContext()
 
 void* CPL_STDCALL CPLGetErrorHandlerUserData(void)
 {
+    int bError = FALSE;
+
+    // check if there is an active error being propagated through the handlers
+    void **pActiveUserData = reinterpret_cast<void **>(
+            CPLGetTLSEx( CTLS_ERRORHANDLERACTIVEDATA, &bError ) );
+    if( bError )
+        return nullptr;
+
+    if ( pActiveUserData != nullptr)
+    {
+        return *pActiveUserData;
+    }
+
+    // get the current threadlocal or global error context user data
     CPLErrorContext *psCtx = CPLGetErrorContext();
     if( psCtx == nullptr || IS_PREFEFINED_ERROR_CTX(psCtx) )
         abort();
     return reinterpret_cast<void*>(
         psCtx->psHandlerStack ?
         psCtx->psHandlerStack->pUserData : pErrorHandlerUserData );
+}
+
+
+void ApplyErrorHandler( CPLErrorContext *psCtx, CPLErr eErrClass,
+                        CPLErrorNum err_no, const char *pszMessage,
+                        bool is_cpldebug )
+{
+    void **pActiveUserData;
+    bool bProcessed = false;
+
+    // CTLS_ERRORHANDLERACTIVEDATA holds the active error handler userData
+
+    if( psCtx->psHandlerStack != nullptr )
+    {
+        // iterate through the threadlocal handler stack
+        if( !is_cpldebug || psCtx->psHandlerStack->bCatchDebug )
+        {
+            // call the error handler
+            pActiveUserData = &(psCtx->psHandlerStack->pUserData);
+            CPLSetTLS( CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData, false );
+            psCtx->psHandlerStack->pfnHandler(eErrClass, err_no, pszMessage);
+            bProcessed = true;
+        }
+        else
+        {
+            // need to iterate to a parent handler for debug messages
+            CPLErrorHandlerNode *psNode = psCtx->psHandlerStack->psNext;
+            while( psNode != nullptr )
+            {
+                if( psNode->bCatchDebug )
+                {
+                    pActiveUserData = &(psNode->pUserData);
+                    CPLSetTLS( CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData, false );
+                    psNode->pfnHandler( CE_Debug, CPLE_None, pszMessage );
+                    bProcessed = true;
+                    break;
+                }
+                psNode = psNode->psNext;
+            }
+        }
+    }
+
+    if( !bProcessed )
+    {
+        // hit the global error handler
+        CPLMutexHolderD( &hErrorMutex );
+        if( !is_cpldebug || gbCatchDebug )
+        {
+            if( pfnErrorHandler != nullptr )
+            {
+                pActiveUserData = &pErrorHandlerUserData;
+                CPLSetTLS( CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData, false );
+                pfnErrorHandler(eErrClass, err_no, pszMessage);
+            }
+        }
+        else if( is_cpldebug )
+        {
+            // for CPLDebug messages we propagate to the default error handler
+            pActiveUserData = nullptr;
+            CPLSetTLS( CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData, false );
+            CPLDefaultErrorHandler(eErrClass, err_no, pszMessage);
+        }
+    }
+    CPLSetTLS( CTLS_ERRORHANDLERACTIVEDATA, nullptr, false );
 }
 
 /**********************************************************************
@@ -384,17 +462,7 @@ void CPLErrorV( CPLErr eErrClass, CPLErrorNum err_no, const char *fmt,
 /* -------------------------------------------------------------------- */
 /*      Invoke the current error handler.                               */
 /* -------------------------------------------------------------------- */
-    if( psCtx->psHandlerStack != nullptr )
-    {
-        psCtx->psHandlerStack->pfnHandler(eErrClass, err_no,
-                                          psCtx->szLastErrMsg);
-    }
-    else
-    {
-        CPLMutexHolderD( &hErrorMutex );
-        if( pfnErrorHandler != nullptr )
-            pfnErrorHandler(eErrClass, err_no, psCtx->szLastErrMsg);
-    }
+    ApplyErrorHandler(psCtx, eErrClass, err_no, psCtx->szLastErrMsg, false);
 
     if( eErrClass == CE_Fatal )
         abort();
@@ -432,15 +500,7 @@ void CPLEmergencyError( const char *pszMessage )
         CPLErrorContext *psCtx =
             static_cast<CPLErrorContext *>(CPLGetTLS( CTLS_ERRORCONTEXT ));
 
-        if( psCtx != nullptr && psCtx->psHandlerStack != nullptr )
-        {
-            psCtx->psHandlerStack->pfnHandler( CE_Fatal, CPLE_AppDefined,
-                                               pszMessage );
-        }
-        else if( pfnErrorHandler != nullptr )
-        {
-            pfnErrorHandler( CE_Fatal, CPLE_AppDefined, pszMessage );
-        }
+        ApplyErrorHandler(psCtx, CE_Fatal, CPLE_AppDefined, pszMessage, false);
     }
 
     // Ultimate fallback.
@@ -651,46 +711,7 @@ void CPLDebug( const char * pszCategory,
 /* -------------------------------------------------------------------- */
 /*      Invoke the current error handler.                               */
 /* -------------------------------------------------------------------- */
-    bool bDebugProcessed = false;
-    if( psCtx->psHandlerStack != nullptr )
-    {
-        if( psCtx->psHandlerStack->bCatchDebug )
-        {
-            bDebugProcessed = true;
-            psCtx->psHandlerStack->pfnHandler( CE_Debug, CPLE_None,
-                                               pszMessage );
-        }
-        else
-        {
-            CPLErrorHandlerNode *psNode = psCtx->psHandlerStack->psNext;
-            while( psNode != nullptr )
-            {
-                if( psNode->bCatchDebug )
-                {
-                    bDebugProcessed = true;
-                    psNode->pfnHandler( CE_Debug, CPLE_None, pszMessage );
-                    break;
-                }
-                psNode = psNode->psNext;
-            }
-        }
-    }
-
-    if( !bDebugProcessed )
-    {
-        CPLMutexHolderD( &hErrorMutex );
-        if( gbCatchDebug )
-        {
-            if( pfnErrorHandler != nullptr )
-            {
-                pfnErrorHandler( CE_Debug, CPLE_None, pszMessage );
-            }
-        }
-        else
-        {
-            CPLDefaultErrorHandler( CE_Debug, CPLE_None, pszMessage );
-        }
-    }
+    ApplyErrorHandler(psCtx, CE_Debug, CPLE_None, pszMessage, true);
 
     VSIFree( pszMessage );
 }

--- a/gdal/port/cpl_multiproc.h
+++ b/gdal/port/cpl_multiproc.h
@@ -218,6 +218,7 @@ class CPL_DLL CPLLockHolder
 #define CTLS_CONFIGOPTIONS              14         /* cpl_conv.cpp */
 #define CTLS_FINDFILE                   15         /* cpl_findfile.cpp */
 #define CTLS_VSIERRORCONTEXT            16         /* cpl_vsi_error.cpp */
+#define CTLS_ERRORHANDLERACTIVEDATA     17         /* cpl_error.cpp */
 
 #define CTLS_MAX                        32
 


### PR DESCRIPTION
## What does this PR do?

Fixes [crashes in logging where error handlers receive the wrong context data](https://github.com/OSGeo/gdal/issues/1098).

Solves this by:
1. centralising error propagation (thread local handler stack + global) via a new local `ApplyHandler()` function.
2. pushing the active handler's user data onto a threadlocal variable (`CTLS_ERRORHANDLERACTIVEDATA`). 
3. it is represented there as a `void**` (because "no active userData" != "active userData that is 0")
4. make `CPLGetErrorHandlerUserData()` look at the threadlocal variable first.

I've kept the existing behaviour/semantics, including the differences between `CPLDebug(...)` & `CPLError(CE_Debug, ...)`.

The testcase from #1098 passes ok ("_ERROR:gdal:AppDefined: Cannot open TIFF file due to missing codec._"), as do the existing tests in `misc.py`.

## What are related issues/pull requests?

#1098

## Tasklist

 - ~Add test case(s)~
 - [x] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed
