### PR TITLE
MITAB: Expose font family to feature style symbol ID

### DIFF
--- a/autotest/ogr/data/all_geoms.mif.golden.csv
+++ b/autotest/ogr/data/all_geoms.mif.golden.csv
@@ -1,7 +1,7 @@
 WKT,ogr_style
 "POINT (0 1)","SYMBOL(a:0,c:#000000,s:12pt,id:""mapinfo-sym-35,ogr-sym-10"")"
 "POINT (2 3)","SYMBOL(a:0,c:#000000,s:1pt,id:""mapinfo-sym-35,ogr-sym-10"")"
-"POINT (4 5)","SYMBOL(a:30,c:#000001,s:2pt,id:""mapinfo-sym-99,ogr-sym-1"",f:""foo"")"
+"POINT (4 5)","SYMBOL(a:30,c:#000001,s:2pt,id:""font-sym-99,ogr-sym-9"",f:""foo"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"

--- a/autotest/ogr/data/all_geoms.mif.golden.csv
+++ b/autotest/ogr/data/all_geoms.mif.golden.csv
@@ -1,7 +1,7 @@
 WKT,ogr_style
 "POINT (0 1)","SYMBOL(a:0,c:#000000,s:12pt,id:""mapinfo-sym-35,ogr-sym-10"")"
 "POINT (2 3)","SYMBOL(a:0,c:#000000,s:1pt,id:""mapinfo-sym-35,ogr-sym-10"")"
-"POINT (4 5)","SYMBOL(a:30,c:#000001,s:2pt,id:""mapinfo-sym-99,ogr-sym-1"")"
+"POINT (4 5)","SYMBOL(a:30,c:#000001,s:2pt,id:""mapinfo-sym-99,ogr-sym-1"",f:foo)"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"

--- a/autotest/ogr/data/all_geoms.mif.golden.csv
+++ b/autotest/ogr/data/all_geoms.mif.golden.csv
@@ -1,7 +1,7 @@
 WKT,ogr_style
 "POINT (0 1)","SYMBOL(a:0,c:#000000,s:12pt,id:""mapinfo-sym-35,ogr-sym-10"")"
 "POINT (2 3)","SYMBOL(a:0,c:#000000,s:1pt,id:""mapinfo-sym-35,ogr-sym-10"")"
-"POINT (4 5)","SYMBOL(a:30,c:#000001,s:2pt,id:""mapinfo-sym-99,ogr-sym-1"",f:foo)"
+"POINT (4 5)","SYMBOL(a:30,c:#000001,s:2pt,id:""mapinfo-sym-99,ogr-sym-1"",f:""foo"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"

--- a/gdal/ogr/ogr_core.h
+++ b/gdal/ogr/ogr_core.h
@@ -873,7 +873,7 @@ typedef enum ogr_style_tool_param_symbol_id
     OGRSTSymbolPerp     = 7, /**< Perpendicular */
     OGRSTSymbolOffset   = 8, /**< Offset */
     OGRSTSymbolPriority = 9, /**< Priority */
-    OGRSTSymbolFontName = 10, /**< OBSOLETE; do not use */
+    OGRSTSymbolFontName = 10, /**< Font name */
     OGRSTSymbolOColor   = 11, /**< Outline color */
 #ifndef DOXYGEN_SKIP
     OGRSTSymbolLast     = 12

--- a/gdal/ogr/ogr_feature_style.html
+++ b/gdal/ogr/ogr_feature_style.html
@@ -608,7 +608,9 @@ a name, a filename, etc.).
       <P>The following conventions will be used for common system-specific symbol ids:</P>
       <UL>
         <LI>&quot;bmp-filename.bmp&quot; for Windows BMP symbols
-
+        <LI>&quot;font-sym-%d&quot; for a font symbols,
+            where %d is a glyph number inside a font,
+            font family is defined by <B>f</B> style field.
       </UL>
       <P>Other conventions may be added in the future (such as vector symbols, WMF, etc).
       </TD>

--- a/gdal/ogr/ogr_feature_style.html
+++ b/gdal/ogr/ogr_feature_style.html
@@ -697,7 +697,7 @@ higher priority ones are drawn on top.
       Comma-delimited list of fonts names.  Works like the CSS font-family
 property: the list of font names is scanned until a known font name is encountered.
 <BR>
-      Example: SYMBOL(c:#00FF00,s:12pt,id:"mapinfo-sym-75",f:"MapInfo_Cartographic")
+      Example: SYMBOL(c:#00FF00,s:12pt,id:"font-sym-75,ogr-sym-9",f:"MapInfo_Cartographic")
 
     </TD>
   </TR>

--- a/gdal/ogr/ogr_feature_style.html
+++ b/gdal/ogr/ogr_feature_style.html
@@ -10,12 +10,14 @@
 GDAL - Feature Style Specification</H1></CENTER>
 
 <CENTER>
-  <H2>Version 0.015 - 2018-01-08</H2>
+  <H2>Version 0.016 - 2018-12-03</H2>
 </CENTER>
 
 <HR WIDTH=50%>
 <H2>REVISION HISTORY</H2>
 <UL>
+<LI><B>Version 0.016 - 2018-12-03 - Andrew Sudorgin</B><BR>
+    Restored and documented font property for point symbols
 <LI><B>Version 0.015 - 2018-01-08 - Alan Thomas</B><BR>
     Update outdated material; minor changes to BRUSH 'id' and LABEL 't', 'bo', 'it', 'un', 'st'; clarify BRUSH 'fc', 'bc', SYMBOL 'o' and LABEL 's', 'w', 'p'
 <LI><B>Version 0.014 - 2011-07-24 - Even Rouault</B><BR>
@@ -686,6 +688,18 @@ parts should be drawn. Lower priority style parts are drawn first, and
 higher priority ones are drawn on top.
 <BR>If priority level is unspecified, the default is 1.</TD>
 </TR>
+
+  <TR>
+    <TD ALIGN=CENTER>f</TD>
+    <TD><B>Font Name</B> -
+      Comma-delimited list of fonts names.  Works like the CSS font-family
+property: the list of font names is scanned until a known font name is encountered.
+<BR>
+      Example: SYMBOL(c:#00FF00,s:12pt,id:"mapinfo-sym-75",f:"MapInfo_Cartographic")
+
+    </TD>
+  </TR>
+
 </TABLE>
 
 <H3>

--- a/gdal/ogr/ogr_featurestyle.h
+++ b/gdal/ogr/ogr_featurestyle.h
@@ -399,6 +399,10 @@ class CPL_DLL OGRStyleSymbol : public OGRStyleTool
     void SetPerp(double dfPerp){SetParamDbl(OGRSTSymbolPerp,dfPerp  );}
     int  Priority(GBool &bDefault){return GetParamNum(OGRSTSymbolPriority,bDefault);}
     void SetPriority(int nPriority){SetParamNum(OGRSTSymbolPriority,nPriority);}
+    const char *FontName(GBool &bDefault)
+        {return GetParamStr(OGRSTSymbolFontName,bDefault);}
+    void SetFontName(const char *pszFontName)
+        {SetParamStr(OGRSTSymbolFontName,pszFontName);}
     const char *OColor(GBool &bDefault){return GetParamStr(OGRSTSymbolOColor,bDefault);}
     void SetOColor(const char *pszColor){SetParamStr(OGRSTSymbolOColor,pszColor);}
 

--- a/gdal/ogr/ogrfeaturestyle.cpp
+++ b/gdal/ogr/ogrfeaturestyle.cpp
@@ -89,7 +89,7 @@ static const OGRStyleParamId asStyleSymbol[] =
     {OGRSTSymbolPerp, "dp", TRUE, OGRSTypeDouble},
     {OGRSTSymbolOffset, "di", TRUE, OGRSTypeDouble},
     {OGRSTSymbolPriority, "l", FALSE, OGRSTypeInteger},
-    {-1, nullptr, FALSE, OGRSTypeUnused}, // was OGRSTSymbolFontName
+    {OGRSTSymbolFontName, "f", FALSE, OGRSTypeString},
     {OGRSTSymbolOColor, "o", FALSE, OGRSTypeString}
 };
 

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab.h
@@ -956,6 +956,7 @@ class ITABFeatureSymbol
 
     virtual const char *GetSymbolStyleString(double dfAngle = 0.0) const;
     void        SetSymbolFromStyleString(const char *pszStyleString);
+    virtual void SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle);
 
     void        DumpSymbolDef(FILE *fpOut = nullptr);
 };
@@ -1157,6 +1158,7 @@ class TABFontPoint final : public TABPoint,
 
     virtual const char *GetSymbolStyleString(double dfAngle = 0.0) const override;
     virtual const char *GetStyleString() const override;
+    virtual void SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle) override;
 
     GBool       QueryFontStyle(TABFontStyle eStyleToQuery);
     void        ToggleFontStyle(TABFontStyle eStyleToToggle, GBool bStatus);

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab.h
@@ -954,7 +954,7 @@ class ITABFeatureSymbol
     void        SetSymbolSize(GInt16 val)   { m_sSymbolDef.nPointSize = val;}
     void        SetSymbolColor(GInt32 clr)  { m_sSymbolDef.rgbColor = clr;}
 
-    const char *GetSymbolStyleString(double dfAngle = 0.0) const;
+    virtual const char *GetSymbolStyleString(double dfAngle = 0.0) const;
     void        SetSymbolFromStyleString(const char *pszStyleString);
 
     void        DumpSymbolDef(FILE *fpOut = nullptr);
@@ -1155,6 +1155,7 @@ class TABFontPoint final : public TABPoint,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
+    virtual const char *GetSymbolStyleString(double dfAngle = 0.0) const override;
     virtual const char *GetStyleString() const override;
 
     GBool       QueryFontStyle(TABFontStyle eStyleToQuery);

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1558,6 +1558,27 @@ const char *TABFontPoint::GetStyleString() const
     return m_pszStyleString;
 }
 
+void TABFontPoint::SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle)
+{
+    ITABFeatureSymbol::SetSymbolFromStyle(poSymbolStyle);
+
+    GBool bIsNull = 0;
+
+    // Try to set font glyph number
+    const char* pszSymbolId = poSymbolStyle->Id(bIsNull);
+    if((!bIsNull) && pszSymbolId && strstr(pszSymbolId, "font-sym-"))
+    {
+        const int nSymbolId = atoi(pszSymbolId+9);
+        SetSymbolNo(static_cast<GInt16>(nSymbolId));
+    }
+
+    const char* pszFontName = poSymbolStyle->FontName(bIsNull);
+    if((!bIsNull) && pszFontName)
+    {
+        SetFontName(pszFontName);
+    }
+}
+
 /*=====================================================================
  *                      class TABCustomPoint
  *====================================================================*/
@@ -8871,55 +8892,11 @@ const char *ITABFeatureSymbol::GetSymbolStyleString(double dfAngle) const
 /**********************************************************************
  *                   ITABFeatureSymbol::SetSymbolFromStyleString()
  *
- *  Set all Symbol var from a StyleString. Use StyleMgr to do so.
+ *  Set all Symbol var from a OGRStyleSymbol.
  **********************************************************************/
-void ITABFeatureSymbol::SetSymbolFromStyleString(const char *pszStyleString)
+void ITABFeatureSymbol::SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle)
 {
     GBool bIsNull = 0;
-
-    // Use the Style Manager to retrieve all the information we need.
-    OGRStyleMgr *poStyleMgr = new OGRStyleMgr(nullptr);
-    OGRStyleTool *poStylePart = nullptr;
-
-    // Init the StyleMgr with the StyleString.
-    poStyleMgr->InitStyleString(pszStyleString);
-
-    // Retrieve the Symbol info.
-    const int numParts = poStyleMgr->GetPartCount();
-    for( int i = 0; i < numParts; i++ )
-    {
-        poStylePart = poStyleMgr->GetPart(i);
-        if( poStylePart == nullptr )
-            continue;
-
-        if(poStylePart->GetType() == OGRSTCSymbol)
-        {
-            break;
-        }
-        else
-        {
-            delete poStylePart;
-            poStylePart = nullptr;
-        }
-    }
-
-    // If the no Symbol found, do nothing.
-    if(poStylePart == nullptr)
-    {
-        delete poStyleMgr;
-        return;
-    }
-
-    OGRStyleSymbol *poSymbolStyle = cpl::down_cast<OGRStyleSymbol*>(poStylePart);
-
-    // With Symbol, we always want to output points
-    //
-    // It's very important to set the output unit of the feature.
-    // The default value is meter. If we don't do it all numerical values
-    // will be assumed to be converted from the input unit to meter when we
-    // will get them via GetParam...() functions.
-    // See OGRStyleTool::Parse() for more details.
-    poSymbolStyle->SetUnit(OGRSTUPoints, (72.0 * 39.37));
 
     // Set the Symbol Id (SymbolNo)
     const char *pszSymbolId = poSymbolStyle->Id(bIsNull);
@@ -8995,6 +8972,60 @@ void ITABFeatureSymbol::SetSymbolFromStyleString(const char *pszStyleString)
         int nSymbolColor = static_cast<int>(strtol(pszSymbolColor, nullptr, 16));
         SetSymbolColor(static_cast<GInt32>(nSymbolColor));
     }
+}
+
+/**********************************************************************
+ *                   ITABFeatureSymbol::SetSymbolFromStyleString()
+ *
+ *  Set all Symbol var from a StyleString. Use StyleMgr to do so.
+ **********************************************************************/
+void ITABFeatureSymbol::SetSymbolFromStyleString(const char *pszStyleString)
+{
+    // Use the Style Manager to retrieve all the information we need.
+    OGRStyleMgr *poStyleMgr = new OGRStyleMgr(nullptr);
+    OGRStyleTool *poStylePart = nullptr;
+
+    // Init the StyleMgr with the StyleString.
+    poStyleMgr->InitStyleString(pszStyleString);
+
+    // Retrieve the Symbol info.
+    const int numParts = poStyleMgr->GetPartCount();
+    for( int i = 0; i < numParts; i++ )
+    {
+        poStylePart = poStyleMgr->GetPart(i);
+        if( poStylePart == nullptr )
+            continue;
+
+        if(poStylePart->GetType() == OGRSTCSymbol)
+        {
+            break;
+        }
+        else
+        {
+            delete poStylePart;
+            poStylePart = nullptr;
+        }
+    }
+
+    // If the no Symbol found, do nothing.
+    if(poStylePart == nullptr)
+    {
+        delete poStyleMgr;
+        return;
+    }
+
+    OGRStyleSymbol *poSymbolStyle = cpl::down_cast<OGRStyleSymbol*>(poStylePart);
+
+    // With Symbol, we always want to output points
+    //
+    // It's very important to set the output unit of the feature.
+    // The default value is meter. If we don't do it all numerical values
+    // will be assumed to be converted from the input unit to meter when we
+    // will get them via GetParam...() functions.
+    // See OGRStyleTool::Parse() for more details.
+    poSymbolStyle->SetUnit(OGRSTUPoints, (72.0 * 39.37));
+
+    SetSymbolFromStyle(poSymbolStyle);
 
     delete poStyleMgr;
     delete poStylePart;

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1512,6 +1512,36 @@ void TABFontPoint::SetSymbolAngle(double dAngle)
 }
 
 /**********************************************************************
+ *                   TABFontPoint::GetSymbolStyleString()
+ *
+ *  Return a Symbol() string. All representations info for the Symbol are here.
+ **********************************************************************/
+const char* TABFontPoint::GetSymbolStyleString(double dfAngle) const
+{
+    /* Get the SymbolStyleString, and add the outline Color
+       (halo/border in MapInfo Symbol terminology) */
+    const char *outlineColor = nullptr;
+    if (m_nFontStyle & 16)
+        outlineColor = ",o:#000000";
+    else if (m_nFontStyle & 512)
+        outlineColor = ",o:#ffffff";
+    else
+        outlineColor = "";
+
+    int         nAngle = static_cast<int>(dfAngle);
+    const char* pszStyle;
+
+    pszStyle=CPLSPrintf("SYMBOL(a:%d,c:#%6.6x,s:%dpt,id:\"font-sym-%d,ogr-sym-9\"%s,f:\"%s\")",
+                        nAngle,
+                        m_sSymbolDef.rgbColor,
+                        m_sSymbolDef.nPointSize,
+                        m_sSymbolDef.nSymbolNo,
+                        outlineColor,
+                        GetFontNameRef());
+    return pszStyle;
+}
+
+/**********************************************************************
  *                   TABFontPoint::GetStyleString() const
  *
  * Return style string for this feature.
@@ -1522,25 +1552,7 @@ const char *TABFontPoint::GetStyleString() const
 {
     if (m_pszStyleString == nullptr)
     {
-        /* Get the SymbolStyleString, and add the outline Color
-           (halo/border in MapInfo Symbol terminology) */
-        char *pszSymbolStyleString =
-            CPLStrdup(GetSymbolStyleString(GetSymbolAngle()));
-        int nStyleStringlen = static_cast<int>(strlen(pszSymbolStyleString));
-        pszSymbolStyleString[nStyleStringlen - 1] = '\0';
-
-        const char *outlineColor = nullptr;
-        if (m_nFontStyle & 16)
-            outlineColor = ",o:#000000";
-        else if (m_nFontStyle & 512)
-            outlineColor = ",o:#ffffff";
-        else
-            outlineColor = "";
-
-        m_pszStyleString =
-            CPLStrdup(CPLSPrintf("%s%s,f:\"%s\")", pszSymbolStyleString,
-            outlineColor, GetFontNameRef()));
-        CPLFree(pszSymbolStyleString);
+        m_pszStyleString = CPLStrdup(GetSymbolStyleString(GetSymbolAngle()));
     }
 
     return m_pszStyleString;

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1566,7 +1566,7 @@ void TABFontPoint::SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle)
 
     // Try to set font glyph number
     const char* pszSymbolId = poSymbolStyle->Id(bIsNull);
-    if((!bIsNull) && pszSymbolId && strstr(pszSymbolId, "font-sym-"))
+    if((!bIsNull) && pszSymbolId && STARTS_WITH(pszSymbolId, "font-sym-"))
     {
         const int nSymbolId = atoi(pszSymbolId+9);
         SetSymbolNo(static_cast<GInt16>(nSymbolId));
@@ -8902,16 +8902,14 @@ void ITABFeatureSymbol::SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle)
     const char *pszSymbolId = poSymbolStyle->Id(bIsNull);
     if(bIsNull) pszSymbolId = nullptr;
 
-    if(pszSymbolId &&
-       (strstr(pszSymbolId, "mapinfo-sym-") ||
-        strstr(pszSymbolId, "ogr-sym-")) )
+    if(pszSymbolId)
     {
-        if(strstr(pszSymbolId, "mapinfo-sym-"))
+        if(STARTS_WITH(pszSymbolId, "mapinfo-sym-"))
         {
             const int nSymbolId = atoi(pszSymbolId+12);
             SetSymbolNo(static_cast<GByte>(nSymbolId));
         }
-        else if(strstr(pszSymbolId, "ogr-sym-"))
+        else if(STARTS_WITH(pszSymbolId, "ogr-sym-"))
         {
             const int nSymbolId = atoi(pszSymbolId+8);
 

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1538,7 +1538,8 @@ const char *TABFontPoint::GetStyleString() const
             outlineColor = "";
 
         m_pszStyleString =
-            CPLStrdup(CPLSPrintf("%s%s)", pszSymbolStyleString, outlineColor));
+            CPLStrdup(CPLSPrintf("%s%s,f:%s)", pszSymbolStyleString,
+            outlineColor, GetFontNameRef()));
         CPLFree(pszSymbolStyleString);
     }
 

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1538,7 +1538,7 @@ const char *TABFontPoint::GetStyleString() const
             outlineColor = "";
 
         m_pszStyleString =
-            CPLStrdup(CPLSPrintf("%s%s,f:%s)", pszSymbolStyleString,
+            CPLStrdup(CPLSPrintf("%s%s,f:\"%s\")", pszSymbolStyleString,
             outlineColor, GetFontNameRef()));
         CPLFree(pszSymbolStyleString);
     }


### PR DESCRIPTION
This PR expose font family as additional style ID.

MapInfo Interchange Format (mif/mid) provides symbol style based on font, but now it is ignored when exporting style from TABFontPoint::GetStyleString() [(see: Appendix J: MapInfo Data Interchange Format, Symbol Clause – TrueType Font Syntax section)](https://web.archive.org/web/20060909054240/http://resource.mapinfo.com/static/files/document/1074660800077/interchange_file.pdf)

Previously, a font field was provided by OGRStyleSymbol, but it was deleted in b98fd4b51bda2f5de0b8c5876b704e5a2fa3ca95.
If it could be brought back, in my opinion, it would be a good place to store the symbol font.