### PR TITLE
EEDA: Replace usage of deprecated paths/field names

### DIFF
--- a/autotest/gdrivers/eedai.py
+++ b/autotest/gdrivers/eedai.py
@@ -72,7 +72,7 @@ def eedai_2():
     if gdaltest.eedai_drv is None:
         return 'skip'
 
-    gdal.FileFromMemBuffer('/vsimem/ee/assets/image', json.dumps({
+    gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/image', json.dumps({
         'type': 'IMAGE',
         'properties':
         {
@@ -320,7 +320,7 @@ def eedai_2():
     npy_serialized += ''.encode('ascii').join(val for i in range(38 * 39))
 
     gdal.FileFromMemBuffer(
-        '/vsimem/ee/assets:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "path": "image", "fileFormat": "NPY", "bandIds": [ "B1", "B9" ], "grid": { "affineTransform": { "translateX": 607500.0, "translateY": 4092480.0, "scaleX": 60.0, "scaleY": -60.0, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 38, "height": 39 } } }', npy_serialized)
+        '/vsimem/ee/projects/earthengine-public/assets/image:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "fileFormat": "NPY", "bandIds": [ "B1", "B9" ], "grid": { "affineTransform": { "translateX": 607500.0, "translateY": 4092480.0, "scaleX": 60.0, "scaleY": -60.0, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 38, "height": 39 } } }', npy_serialized)
     got_data = ds.GetRasterBand(1).ReadRaster(1800, 1810, 1, 1)
     got_data = struct.unpack('h', got_data)[0]
     if got_data != 12345:
@@ -552,7 +552,7 @@ def eedai_4():
     if gdaltest.eedai_drv is None:
         return 'skip'
 
-    gdal.FileFromMemBuffer('/vsimem/ee/assets/image', json.dumps({
+    gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/image', json.dumps({
         'type': 'IMAGE',
         'bands':
         [
@@ -641,7 +641,7 @@ def eedai_4():
     gdal.Unlink('/vsimem/out.png')
 
     gdal.FileFromMemBuffer(
-        '/vsimem/ee/assets:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "path": "image", "fileFormat": "PNG", "bandIds": [ "B1", "B2", "B3" ], "grid": { "affineTransform": { "translateX": 499980.0, "translateY": 4200000.0, "scaleX": 60.0, "scaleY": -60.0, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 256, "height": 256 } } }', png_data)
+        '/vsimem/ee/projects/earthengine-public/assets/image:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "fileFormat": "PNG", "bandIds": [ "B1", "B2", "B3" ], "grid": { "affineTransform": { "translateX": 499980.0, "translateY": 4200000.0, "scaleX": 60.0, "scaleY": -60.0, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 256, "height": 256 } } }', png_data)
     got_data = ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
     got_data = struct.unpack('B', got_data)[0]
     if got_data != 127:
@@ -668,7 +668,7 @@ def eedai_4():
 
     # Sub-sampled query
     gdal.FileFromMemBuffer(
-        '/vsimem/ee/assets:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "path": "image", "fileFormat": "PNG", "bandIds": [ "B1", "B2", "B3" ], "grid": { "affineTransform": { "translateX": 499980.0, "translateY": 4200000.0, "scaleX": 120.0, "scaleY": -120.06557377049181, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 256, "height": 256 } } }', png_data)
+        '/vsimem/ee/projects/earthengine-public/assets/image:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "fileFormat": "PNG", "bandIds": [ "B1", "B2", "B3" ], "grid": { "affineTransform": { "translateX": 499980.0, "translateY": 4200000.0, "scaleX": 120.0, "scaleY": -120.06557377049181, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 256, "height": 256 } } }', png_data)
     got_data = ds.GetRasterBand(1).ReadRaster(
         0, 0, 2, 2, buf_xsize=1, buf_ysize=1)
     got_data = struct.unpack('B', got_data)[0]
@@ -701,7 +701,7 @@ def eedai_geotiff():
     if gdaltest.eedai_drv is None:
         return 'skip'
 
-    gdal.FileFromMemBuffer('/vsimem/ee/assets/image', json.dumps({
+    gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/image', json.dumps({
         'type': 'IMAGE',
         'bands':
         [
@@ -744,7 +744,7 @@ def eedai_geotiff():
     gdal.Unlink('/vsimem/out.tif')
 
     gdal.FileFromMemBuffer(
-        '/vsimem/ee/assets:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "path": "image", "fileFormat": "GEO_TIFF", "bandIds": [ "B1" ], "grid": { "affineTransform": { "translateX": 499980.0, "translateY": 4200000.0, "scaleX": 60.0, "scaleY": -60.0, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 256, "height": 256 } } }', data)
+        '/vsimem/ee/projects/earthengine-public/assets/image:getPixels&CUSTOMREQUEST=POST&POSTFIELDS={ "fileFormat": "GEO_TIFF", "bandIds": [ "B1" ], "grid": { "affineTransform": { "translateX": 499980.0, "translateY": 4200000.0, "scaleX": 60.0, "scaleY": -60.0, "shearX": 0.0, "shearY": 0.0 }, "dimensions": { "width": 256, "height": 256 } } }', data)
     got_data = ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
     got_data = struct.unpack('H', got_data)[0]
     if got_data != 12345:
@@ -782,7 +782,7 @@ def eedai_real_service():
         gdaltest.post_reason('fail')
         return 'fail'
     res = gdal.Info(ds, format='json')
-    expected = {'files': [], 'cornerCoordinates': {'upperRight': [415016.0, 4435536.0], 'lowerLeft': [408970.0, 4427936.0], 'lowerRight': [415016.0, 4427936.0], 'upperLeft': [408970.0, 4435536.0], 'center': [411993.0, 4431736.0]}, 'wgs84Extent': {'type': 'Polygon', 'coordinates': [[[-100.067433, 40.0651671], [-100.0663662, 39.9967049], [-99.9955511, 39.9973349], [-99.9965471, 40.0657986], [-100.067433, 40.0651671]]]}, 'description': 'EEDAI:USDA/NAIP/DOQQ/n_4010064_se_14_2_20070725', 'driverShortName': 'EEDAI', 'driverLongName': 'Earth Engine Data API Image', 'bands': [{'description': 'R', 'band': 1, 'colorInterpretation': 'Red', 'overviews': [{'size': [1511, 1900]}, {'size': [755, 950]}, {'size': [377, 475]}, {'size': [188, 237]}], 'type': 'Byte', 'block': [256, 256], 'metadata': {}}, {'description': 'G', 'band': 2, 'colorInterpretation': 'Green', 'overviews': [{'size': [1511, 1900]}, {'size': [755, 950]}, {'size': [377, 475]}, {'size': [188, 237]}], 'type': 'Byte', 'block': [256, 256], 'metadata': {}}, {'description': 'B', 'band': 3, 'colorInterpretation': 'Blue', 'overviews': [{'size': [1511, 1900]}, {'size': [755, 950]}, {'size': [377, 475]}, {'size': [188, 237]}], 'type': 'Byte', 'block': [256, 256], 'metadata': {}}], 'coordinateSystem': {'wkt': 'PROJCS["NAD83 / UTM zone 14N",\n    GEOGCS["NAD83",\n        DATUM["North_American_Datum_1983",\n            SPHEROID["GRS 1980",6378137,298.257222101,\n                AUTHORITY["EPSG","7019"]],\n            TOWGS84[0,0,0,0,0,0,0],\n            AUTHORITY["EPSG","6269"]],\n        PRIMEM["Greenwich",0,\n            AUTHORITY["EPSG","8901"]],\n        UNIT["degree",0.0174532925199433,\n            AUTHORITY["EPSG","9122"]],\n        AUTHORITY["EPSG","4269"]],\n    PROJECTION["Transverse_Mercator"],\n    PARAMETER["latitude_of_origin",0],\n    PARAMETER["central_meridian",-99],\n    PARAMETER["scale_factor",0.9996],\n    PARAMETER["false_easting",500000],\n    PARAMETER["false_northing",0],\n    UNIT["metre",1,\n        AUTHORITY["EPSG","9001"]],\n    AXIS["Easting",EAST],\n    AXIS["Northing",NORTH],\n    AUTHORITY["EPSG","26914"]]'}, 'geoTransform': [408970.0, 2.0, 0.0, 4435536.0, 0.0, -2.0], 'metadata': {'IMAGE_STRUCTURE': {'INTERLEAVE': 'PIXEL'}}, 'size': [3023, 3800]}
+    expected = {'files': [], 'cornerCoordinates': {'upperRight': [415016.0, 4435536.0], 'lowerLeft': [408970.0, 4427936.0], 'lowerRight': [415016.0, 4427936.0], 'upperLeft': [408970.0, 4435536.0], 'center': [411993.0, 4431736.0]}, 'wgs84Extent': {'type': 'Polygon', 'coordinates': [[]]}, 'description': 'EEDAI:USDA/NAIP/DOQQ/n_4010064_se_14_2_20070725', 'driverShortName': 'EEDAI', 'driverLongName': 'Earth Engine Data API Image', 'bands': [{'description': 'R', 'band': 1, 'colorInterpretation': 'Red', 'overviews': [{'size': [1511, 1900]}, {'size': [755, 950]}, {'size': [377, 475]}, {'size': [188, 237]}], 'type': 'Byte', 'block': [256, 256], 'metadata': {}}, {'description': 'G', 'band': 2, 'colorInterpretation': 'Green', 'overviews': [{'size': [1511, 1900]}, {'size': [755, 950]}, {'size': [377, 475]}, {'size': [188, 237]}], 'type': 'Byte', 'block': [256, 256], 'metadata': {}}, {'description': 'B', 'band': 3, 'colorInterpretation': 'Blue', 'overviews': [{'size': [1511, 1900]}, {'size': [755, 950]}, {'size': [377, 475]}, {'size': [188, 237]}], 'type': 'Byte', 'block': [256, 256], 'metadata': {}}], 'coordinateSystem': {'wkt': 'PROJCS["NAD83 / UTM zone 14N",\n    GEOGCS["NAD83",\n        DATUM["North_American_Datum_1983",\n            SPHEROID["GRS 1980",6378137,298.257222101,\n                AUTHORITY["EPSG","7019"]],\n            TOWGS84[0,0,0,0,0,0,0],\n            AUTHORITY["EPSG","6269"]],\n        PRIMEM["Greenwich",0,\n            AUTHORITY["EPSG","8901"]],\n        UNIT["degree",0.0174532925199433,\n            AUTHORITY["EPSG","9122"]],\n        AUTHORITY["EPSG","4269"]],\n    PROJECTION["Transverse_Mercator"],\n    PARAMETER["latitude_of_origin",0],\n    PARAMETER["central_meridian",-99],\n    PARAMETER["scale_factor",0.9996],\n    PARAMETER["false_easting",500000],\n    PARAMETER["false_northing",0],\n    UNIT["metre",1,\n        AUTHORITY["EPSG","9001"]],\n    AXIS["Easting",EAST],\n    AXIS["Northing",NORTH],\n    AUTHORITY["EPSG","26914"]]'}, 'geoTransform': [408970.0, 2.0, 0.0, 4435536.0, 0.0, -2.0], 'metadata': {'IMAGE_STRUCTURE': {'INTERLEAVE': 'PIXEL'}}, 'size': [3023, 3800]}
     if expected != res:
         gdaltest.post_reason('fail')
         print(res)
@@ -825,7 +825,7 @@ def eedai_cleanup():
     gdal.SetConfigOption('GOA2_NOW', None)
     gdal.SetConfigOption('GOOGLE_APPLICATION_CREDENTIALS', gdaltest.GOOGLE_APPLICATION_CREDENTIALS)
 
-    gdal.Unlink('/vsimem/ee/assets/image')
+    gdal.Unlink('/vsimem/ee/projects/earthengine-public/assets/image')
     gdal.RmdirRecursive('/vsimem/ee/')
 
     return 'success'

--- a/autotest/ogr/ogr_eeda.py
+++ b/autotest/ogr/ogr_eeda.py
@@ -63,7 +63,7 @@ def eeda_2():
     if ogrtest.eeda_drv is None:
         return 'skip'
 
-    gdal.FileFromMemBuffer('/vsimem/ee/assets:listImages?parentPath=collection&pageSize=1', json.dumps({
+    gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageSize=1', json.dumps({
         'assets': [
             {
                 'properties':
@@ -95,7 +95,7 @@ def eeda_2():
         gdaltest.post_reason('fail')
         return 'fail'
 
-    if lyr.GetLayerDefn().GetFieldCount() != 6 + 7 + 4:
+    if lyr.GetLayerDefn().GetFieldCount() != 8 + 7 + 4:
         gdaltest.post_reason('fail')
         print(lyr.GetLayerDefn().GetFieldCount())
         return 'fail'
@@ -110,10 +110,12 @@ def eeda_2():
         print(lyr.GetFeatureCount())
         return 'fail'
 
-    gdal.FileFromMemBuffer('/vsimem/ee/assets:listImages?parentPath=collection', json.dumps({
+    gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages', json.dumps({
         'assets': [
             {
-                'path': 'first_feature',
+                'name': 'projects/earthengine-public/assets/collection/first_feature',
+                'id': 'collection/first_feature',
+                'path': 'collection/first_feature',
                 'time': '2017-01-02T12:34:56.789Z',
                 'updateTime': '2017-01-03T12:34:56.789Z',
                 'sizeBytes': 1,
@@ -152,15 +154,17 @@ def eeda_2():
                 ]
             },
             {
-                'path': 'second_feature'
+                'name': 'projects/earthengine-public/assets/collection/second_feature'
             }
         ],
         'nextPageToken': 'myToken'
     }))
 
     f = lyr.GetNextFeature()
-    if f.GetField('path') != 'first_feature' or \
-       f.GetField('gdal_dataset') != 'EEDAI:first_feature' or \
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/first_feature' or \
+       f.GetField('id') != 'collection/first_feature' or \
+       f.GetField('path') != 'collection/first_feature' or \
+       f.GetField('gdal_dataset') != 'EEDAI:projects/earthengine-public/assets/collection/first_feature' or \
        f.GetField('time') != '2017/01/02 12:34:56.789+00' or \
        f.GetField('updateTime') != '2017/01/03 12:34:56.789+00' or \
        f.GetField('sizeBytes') != 1 or \
@@ -182,21 +186,21 @@ def eeda_2():
         return 'fail'
 
     f = lyr.GetNextFeature()
-    if f.GetField('path') != 'second_feature':
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/second_feature':
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'
 
-    gdal.FileFromMemBuffer('/vsimem/ee/assets:listImages?parentPath=collection&pageToken=myToken', json.dumps({
+    gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageToken=myToken', json.dumps({
         'assets': [
             {
-                'path': 'third_feature'
+                'name': 'projects/earthengine-public/assets/collection/third_feature'
             }
         ]
     }))
 
     f = lyr.GetNextFeature()
-    if f.GetField('path') != 'third_feature':
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/third_feature':
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'
@@ -209,23 +213,23 @@ def eeda_2():
     lyr.ResetReading()
 
     f = lyr.GetNextFeature()
-    if f.GetField('path') != 'first_feature':
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/first_feature':
         gdaltest.post_reason('fail')
         f.DumpReadable()
         return 'fail'
 
     lyr.SetAttributeFilter('EEDA:raw_filter')
 
-    gdal.FileFromMemBuffer('/vsimem/ee/assets:listImages?parentPath=collection&filter=raw%5Ffilter', json.dumps({
+    gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?filter=raw%5Ffilter', json.dumps({
         'assets': [
             {
-                'path': 'raw_filter'
+                'name': 'projects/earthengine-public/assets/collection/raw_filter'
             }
         ]
     }))
 
     f = lyr.GetNextFeature()
-    if f.GetField('path') != 'raw_filter':
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/raw_filter':
         gdaltest.post_reason('fail')
         return 'fail'
 
@@ -241,11 +245,11 @@ def eeda_2():
                            "string_field IN ('bar', 'baz') AND " +
                            "NOT( int_field IN (0) OR double_field IN (3.5) )")
 
-    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/assets:listImages?parentPath=collection&region=%7B%20%22type%22%3A%20%22Polygon%22%2C%20%22coordinates%22%3A%20%5B%20%5B%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%20%5D%20%5D%20%7D&filter=%28%28%28%28%28%28%28string%5Ffield%20%3D%20%22bar%22%20AND%20int%5Ffield%20%3E%200%29%20AND%20int%5Ffield%20%3C%202%29%20AND%20int64%5Ffield%20%3E%3D%200%29%20AND%20int64%5Ffield%20%3C%3D%209999999999999%29%20AND%20double%5Ffield%20%21%3D%203%2E5%29%20AND%20string%5Ffield%20%3D%20%22bar%22%20OR%20string%5Ffield%20%3D%20%22baz%22%29%20AND%20%28NOT%20%28int%5Ffield%20%3D%200%20OR%20double%5Ffield%20%3D%203%2E5%29%29%29&startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=2100%2D01%2D01T00%3A00%3A00Z'
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/collection:listImages?region=%7B%20%22type%22%3A%20%22Polygon%22%2C%20%22coordinates%22%3A%20%5B%20%5B%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%20%5D%20%5D%20%7D&filter=%28%28%28%28%28%28%28string%5Ffield%20%3D%20%22bar%22%20AND%20int%5Ffield%20%3E%200%29%20AND%20int%5Ffield%20%3C%202%29%20AND%20int64%5Ffield%20%3E%3D%200%29%20AND%20int64%5Ffield%20%3C%3D%209999999999999%29%20AND%20double%5Ffield%20%21%3D%203%2E5%29%20AND%20string%5Ffield%20%3D%20%22bar%22%20OR%20string%5Ffield%20%3D%20%22baz%22%29%20AND%20%28NOT%20%28int%5Ffield%20%3D%200%20OR%20double%5Ffield%20%3D%203%2E5%29%29%29&startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=2100%2D01%2D01T00%3A00%3A00Z'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
         'assets': [
             {
-                'path': 'filtered_feature',
+                'name': 'projects/earthengine-public/assets/collection/filtered_feature',
                 'time': '2017-01-02T12:34:56.789Z',
                 'updateTime': '2017-01-03T12:34:56.789Z',
                 'sizeBytes': 1,
@@ -260,7 +264,7 @@ def eeda_2():
                 }
             },
             {
-                'path': 'second_feature'
+                'name': 'projects/earthengine-public/assets/collection/second_feature'
             }
         ]
     }))
@@ -270,7 +274,7 @@ def eeda_2():
     f = lyr.GetNextFeature()
     gdal.Unlink(ogrtest.eeda_drv_tmpfile)
 
-    if f.GetField('path') != 'filtered_feature':
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/filtered_feature':
         gdaltest.post_reason('fail')
         return 'fail'
 
@@ -279,15 +283,15 @@ def eeda_2():
     # Test time equality with second granularity
     lyr.SetAttributeFilter("time = '1980-01-01T00:00:00Z'")
 
-    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/assets:listImages?parentPath=collection&startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D01T00%3A00%3A01Z'
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D01T00%3A00%3A01Z'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
         'assets': [
             {
-                'path': 'filtered_feature',
-                'time': '1980-01-01T00:00:00Z',
+                'name': 'projects/earthengine-public/assets/collection/filtered_feature',
+                'time': '1980-01-01T00:00:00Z'
             },
             {
-                'path': 'second_feature'
+                'name': 'projects/earthengine-public/assets/collection/second_feature'
             }
         ]
     }))
@@ -295,22 +299,22 @@ def eeda_2():
     f = lyr.GetNextFeature()
     gdal.Unlink(ogrtest.eeda_drv_tmpfile)
 
-    if f.GetField('path') != 'filtered_feature':
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/filtered_feature':
         gdaltest.post_reason('fail')
         return 'fail'
 
     # Test time equality with day granularity
     lyr.SetAttributeFilter("time = '1980-01-01'")
 
-    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/assets:listImages?parentPath=collection&startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D01T23%3A59%3A59Z'
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D01T23%3A59%3A59Z'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
         'assets': [
             {
-                'path': 'filtered_feature',
+                'name': 'projects/earthengine-public/assets/collection/filtered_feature',
                 'time': '1980-01-01T12:00:00Z',
             },
             {
-                'path': 'second_feature'
+                'name': 'projects/earthengine-public/assets/collection/second_feature'
             }
         ]
     }))
@@ -318,7 +322,7 @@ def eeda_2():
     f = lyr.GetNextFeature()
     gdal.Unlink(ogrtest.eeda_drv_tmpfile)
 
-    if f.GetField('path') != 'filtered_feature':
+    if f.GetField('name') != 'projects/earthengine-public/assets/collection/filtered_feature':
         gdaltest.post_reason('fail')
         return 'fail'
 
@@ -344,13 +348,108 @@ def eeda_3():
 
     lyr = ds.GetLayer(0)
 
-    if lyr.GetLayerDefn().GetFieldCount() != 6 + 7 + 4:
+    if lyr.GetLayerDefn().GetFieldCount() != 8 + 7 + 4:
         gdaltest.post_reason('fail')
         print(lyr.GetLayerDefn().GetFieldCount())
         return 'fail'
     ds = None
 
     gdal.SetConfigOption('EEDA_BEARER', None)
+
+    return 'success'
+
+###############################################################################
+# Test that name and id variants are handled correctly.
+
+
+def eeda_4():
+
+    if ogrtest.eeda_drv is None:
+        return 'skip'
+
+    gdal.SetConfigOption('EEDA_BEARER', 'mybearer')
+    gdal.SetConfigOption('EEDA_URL', '/vsimem/ee/')
+
+    # User asset ID ("users/**").
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-legacy/assets/users/foo:listImages?pageSize=1'
+    gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
+        'assets': [
+            {
+                'name': 'projects/earthengine-legacy/assets/users/foo/bar'
+            }
+        ]
+    }))
+    if not ogr.Open('EEDA:users/foo').GetLayer(0):
+        gdaltest.post_reason('fail')
+        return 'fail'
+    gdal.Unlink(ogrtest.eeda_drv_tmpfile)
+
+    # Project asset ID ("projects/**").
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-legacy/assets/projects/foo:listImages?pageSize=1'
+    gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
+        'assets': [
+            {
+                'name': 'projects/earthengine-legacy/assets/projects/foo/bar'
+            }
+        ]
+    }))
+    ds = ogr.Open('EEDA:projects/foo')
+    if not ds.GetLayer(0):
+        gdaltest.post_reason('fail')
+        return 'fail'
+    gdal.Unlink(ogrtest.eeda_drv_tmpfile)
+    ds = None
+
+    # Multi-folder project asset ID ("projects/foo/bar/baz").
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-legacy/assets/projects/foo/bar/baz:listImages?pageSize=1'
+    gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
+        'assets': [
+            {
+                'name': 'projects/earthengine-legacy/assets/projects/foo/bar/baz/qux'
+            }
+        ]
+    }))
+    ds = ogr.Open('EEDA:projects/foo/bar/baz')
+    if not ds.GetLayer(0):
+        gdaltest.post_reason('fail')
+        return 'fail'
+    gdal.Unlink(ogrtest.eeda_drv_tmpfile)
+    ds = None
+
+    # Public-catalog asset ID (e.g. "LANDSAT").
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/foo:listImages?pageSize=1'
+    gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
+        'assets': [
+            {
+                'name': 'projects/earthengine-public/assets/foo/bar'
+            }
+        ]
+    }))
+    ds = ogr.Open('EEDA:foo')
+    if not ds.GetLayer(0):
+        gdaltest.post_reason('fail')
+        return 'fail'
+    gdal.Unlink(ogrtest.eeda_drv_tmpfile)
+    ds = None
+
+    # Asset name ("projects/*/assets/**").
+    ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/foo/assets/bar:listImages?pageSize=1'
+    gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
+        'assets': [
+            {
+                'name': 'projects/foo/assets/bar/baz'
+            }
+        ]
+    }))
+    ds = ogr.Open('EEDA:projects/foo/assets/bar')
+    if not ds.GetLayer(0):
+        gdaltest.post_reason('fail')
+        return 'fail'
+    gdal.Unlink(ogrtest.eeda_drv_tmpfile)
+    ds = None
+
+    gdal.SetConfigOption('EEDA_BEARER', None)
+    gdal.SetConfigOption('EEDA_URL', None)
 
     return 'success'
 
@@ -372,9 +471,9 @@ def eeda_cleanup():
     gdal.SetConfigOption('GOA2_NOW', None)
 
     gdal.Unlink('/vsimem/ee/')
-    gdal.Unlink('/vsimem/ee/assets:listImages?parentPath=collection&pageSize=1')
-    gdal.Unlink('/vsimem/ee/assets:listImages?parentPath=collection&pageToken=myToken')
-    gdal.Unlink('/vsimem/ee/assets:listImages?parentPath=collection&filter=raw%5Ffilter')
+    gdal.Unlink('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageSize=1')
+    gdal.Unlink('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageToken=myToken')
+    gdal.Unlink('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?filter=raw%5Ffilter')
 
     return 'success'
 
@@ -383,6 +482,7 @@ gdaltest_list = [
     eeda_1,
     eeda_2,
     eeda_3,
+    eeda_4,
     eeda_cleanup]
 
 if __name__ == '__main__':

--- a/gdal/frmts/eeda/drv_eeda.html
+++ b/gdal/frmts/eeda/drv_eeda.html
@@ -16,7 +16,7 @@ as a vector layer, using Google Earth Engine REST API.<p>
 
 The minimal syntax to open a datasource is : <pre>EEDA:[collection]</pre><p>
 
-where collection is something like COPERNICUS/S2.
+where collection is something like projects/earthengine-public/assets/COPERNICUS/S2.
 
 <h2>Open options</h2>
 
@@ -85,8 +85,10 @@ will not done.</p>
 <th>Server-side filter compatible</th>
 </tr>
 
-<tr><td>path</td><td>String</td><td>Image path (e.g. COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG)</td><td>No</td></tr>
-<tr><td>gdal_dataset</td><td>String</td><td>GDAL dataset name (e.g. EEDAI:COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG)<br/>hat can be opened with the <a href="frmt_eedai.html">Google Earth Engine Data API Image driver</a></td><td>No</td></tr>
+<tr><td>name</td><td>String</td><td>Image name (e.g. projects/earthengine-public/assets/COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG)</td><td>No</td></tr>
+<tr><td>id</td><td>String</td><td>Image ID; equivalent to name without the "projects/*/assets/" prefix (e.g. users/USER/ASSET)</td><td>No</td></tr>
+<tr><td>path</td><td>String</td><td>(Deprecated) Image path; equivalent to id</td><td>No</td></tr>
+<tr><td>gdal_dataset</td><td>String</td><td>GDAL dataset name (e.g. EEDAI:projects/earthengine-public/assets/COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG)<br/>hat can be opened with the <a href="frmt_eedai.html">Google Earth Engine Data API Image driver</a></td><td>No</td></tr>
 <tr><td>time</td><td>DateTime</td><td>Acquisition date</td><td><b>Yes</b></td></tr>
 <tr><td>updateTime</td><td>DateTime</td><td>Update date</td><td>No</td></tr>
 <tr><td>sizeBytes</td><td>Integer64</td><td>File size in bytes</td><td>No</td></tr>
@@ -134,25 +136,25 @@ server.
 <li>
 Listing all images available:
 <pre>
-ogrinfo -ro -al "EEDA:" -oo COLLECTION=COPERNICUS/S2 --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
+ogrinfo -ro -al "EEDA:" -oo COLLECTION=projects/earthengine-public/assets/COPERNICUS/S2 --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
 </pre>
 or
 <pre>
-ogrinfo -ro -al "EEDA:COPERNICUS/S2" --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
+ogrinfo -ro -al "EEDA:projects/earthengine-public/assets/COPERNICUS/S2" --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
 </pre>
 <p>
 
 <li>
 Listing all images under a point of (lat,lon)=(40,-100) :
 <pre>
-ogrinfo -ro -al "EEDA:COPERNICUS/S2" -spat -100 40 -100 40 --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
+ogrinfo -ro -al "EEDA:projects/earthengine-public/assets/COPERNICUS/S2" -spat -100 40 -100 40 --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
 </pre>
 <p>
 
 <li>
 Listing all images available matching criteria :
 <pre>
-ogrinfo -ro -al "EEDA:COPERNICUS/S2" -where "time &gt;= '2015/03/26 00:00:00' AND CLOUDY_PIXEL_PERCENTAGE &lt; 10" --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
+ogrinfo -ro -al "EEDA:projects/earthengine-public/assets/COPERNICUS/S2" -where "time &gt;= '2015/03/26 00:00:00' AND CLOUDY_PIXEL_PERCENTAGE &lt; 10" --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
 </pre>
 <p>
 

--- a/gdal/frmts/eeda/eeda.h
+++ b/gdal/frmts/eeda/eeda.h
@@ -85,6 +85,7 @@ class GDALEEDABaseDataset: public GDALDataset
             GIntBig     m_nExpirationTime;
 
             char      **GetBaseHTTPOptions();
+            static CPLString ConvertPathToName(const CPLString& path);
 
     public:
                 GDALEEDABaseDataset();

--- a/gdal/frmts/eeda/frmt_eedai.html
+++ b/gdal/frmts/eeda/frmt_eedai.html
@@ -16,7 +16,8 @@ using Google Earth Engine REST API.<p>
 
 The minimal syntax to open a datasource is : <pre>EEDAI:[asset][:band_names]</pre><p>
 
-where asset is something like COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG,
+where asset is something like
+projects/earthengine-public/assets/COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG,
 and band_names a comma separated list of band names (typically indicated by
 subdatasets on the main image)
 
@@ -101,11 +102,11 @@ AUTO_PNG_JPEG can only be used with bands of type Byte.
 <li>
 Get metadata on an image:
 <pre>
-gdalinfo "EEDAI:" -oo ASSET=COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
+gdalinfo "EEDAI:" -oo ASSET=projects/earthengine-public/assets/COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
 </pre>
 or
 <pre>
-gdalinfo "EEDAI:COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG" --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
+gdalinfo "EEDAI:projects/earthengine-public/assets/COPERNICUS/S2/20170430T190351_20170430T190351_T10SEG" --config EEDA_CLIENT_EMAIL "my@email" --config EEDA_PRIVATE_KEY_FILE my.pem
 </pre>
 <p>
 


### PR DESCRIPTION
## What does this PR do?
Replace:
- usage of `path` with `name`
- calls to "/v1/assets/**" with "/v1/projects/\*/assets/\*\*"
- calls to "/v1/assets:listImages" with "/v1/projects/\*/assets/\*\*:listImages"
- calls to "/v1/assets:getPixels" with "/v1/projects/\*/assets/\*\*:getPixels"

## Tasklist

 - [x] Add test case(s)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed