### PR TITLE
cURL: added curl cookiefile and cookiejar variables (fixes #1000)

### DIFF
--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -586,6 +586,8 @@ static void CPLHTTPEmitFetchDebug(const char* pszURL,
  * <li>NETRC=[YES/NO] to enable or disable use of $HOME/.netrc, default YES.</li>
  * <li>CUSTOMREQUEST=val, where val is GET, PUT, POST, DELETE, etc.. (GDAL >= 1.9.0)</li>
  * <li>COOKIE=val, where val is formatted as COOKIE1=VALUE1; COOKIE2=VALUE2; ...</li>
+ * <li>COOKIEFILE=val, where val is file name to read cookies from (GDAL >= 2.4)</li>
+ * <li>COOKIEJAR=val, where val is file name to store cookies to (GDAL >= 2.4)</li>
  * <li>MAX_RETRY=val, where val is the maximum number of retry attempts if a 429, 502, 503 or
  *               504 HTTP error occurs. Default is 0. (GDAL >= 2.0)</li>
  * <li>RETRY_DELAY=val, where val is the number of seconds between retry attempts.

--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -1776,6 +1776,19 @@ void *CPLHTTPSetOptions(void *pcurl, const char* pszURL,
         pszCookie = CPLGetConfigOption("GDAL_HTTP_COOKIE", nullptr);
     if( pszCookie != nullptr )
         curl_easy_setopt(http_handle, CURLOPT_COOKIE, pszCookie);
+        
+    const char* pszCookieFile = CSLFetchNameValue(papszOptions, "COOKIEFILE");
+    if( pszCookieFile == nullptr )
+        pszCookieFile = CPLGetConfigOption("GDAL_HTTP_COOKIEFILE", nullptr);
+    if( pszCookieFile != nullptr )
+        curl_easy_setopt(http_handle, CURLOPT_COOKIEFILE, pszCookieFile);
+
+    const char* pszCookieJar = CSLFetchNameValue(papszOptions, "COOKIEJAR");
+    if( pszCookieJar == nullptr )
+        pszCookieJar = CPLGetConfigOption("GDAL_HTTP_COOKIEJAR", nullptr);
+    if( pszCookieJar != nullptr )
+        curl_easy_setopt(http_handle, CURLOPT_COOKIEJAR, pszCookieJar);
+
 
     struct curl_slist* headers = nullptr;
     const char *pszHeaderFile = CSLFetchNameValue( papszOptions, "HEADER_FILE" );


### PR DESCRIPTION
## What does this PR do?
Enable the cookie engine in gdal /vsicurl. In particular, allows users to specific the following environment variables, which permit command line interaction with NASA imagery on remote servers using single sign on authentication (https://urs.earthdata.nasa.gov).
GDAL_HTTP_COOKIEJAR
GDAL_HTTP_COOKIEFILE

**see example and output in comment below**

## What are related issues/pull requests?
#1000

## Tasklist
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment
* OS: Ubuntu 18.04.1 LTS
* Compiler: gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0