### PR TITLE
[WIP] 2.4.0 release notes

### DIFF
--- a/gdal/NEWS
+++ b/gdal/NEWS
@@ -1,3 +1,235 @@
+= GDAL/OGR 2.4.0 Release Notes =
+
+== In a nutshell... ==
+
+ * New GDAL drivers:
+ * New OGR drivers:
+
+== New installed files ==
+
+== Backward compatibility issues ==
+
+== GDAL/OGR 2.4.0 - General Changes ==
+
+Build(Unix):
+
+Build(Windows):
+
+== GDAL 2.4.0 - Overview of Changes ==
+
+Port:
+
+Core:
+
+Algorithms:
+
+Utilities:
+
+Multi driver changes:
+
+AAIGrid:
+
+ACE2 driver:
+
+ADRG driver:
+
+BAG driver:
+
+BT driver:
+
+CEOS2 driver:
+
+DIMAP driver:
+
+DTED driver:
+
+ECW driver:
+
+ENVI driver:
+
+ENVISAT driver:
+
+GeoRaster driver:
+
+GIF driver:
+
+GMT driver:
+
+GTiff driver:
+
+GRIB driver:
+
+GSAG driver:
+
+GS7BG driver:
+
+GTX driver:
+
+GXF driver:
+
+HDF4 driver:
+
+HDF5 driver:
+
+HFA driver:
+
+INGR driver:
+
+ISIS3 driver:
+
+JP2ECW driver:
+
+JP2KAK driver:
+
+JP2OpenJPEG driver:
+
+JPEG driver:
+
+JPEG2000 driver:
+
+KMLSuperOverlay driver:
+
+L1B driver:
+
+MG4Lidar driver:
+
+NetCDF driver:
+
+NITF driver:
+
+Northwood driver:
+
+PDF driver:
+
+PNG driver:
+
+PostgisRaster driver:
+
+Rasterlite driver:
+
+RMF driver:
+
+RPFTOC driver:
+
+RS2 driver:
+
+SDTS driver:
+
+SRP driver:
+
+TIL driver:
+
+TSX driver:
+
+VRT driver:
+
+WCS driver:
+
+WebP driver:
+
+WMS driver:
+
+XYZ driver:
+
+== OGR 2.4.0 - Overview of Changes ==
+
+Core:
+
+OGRSpatialReference:
+
+Utilities:
+
+Multi driver changes:
+
+AVCE00 driver:
+
+AVCBin driver:
+
+CSV driver:
+
+DGN driver:
+
+DXF driver:
+
+FileGDB driver:
+
+Geoconcept driver:
+
+GeoJSON driver:
+
+Geomedia driver:
+
+GFT driver:
+
+GML driver:
+
+ILI driver:
+
+Ingres driver:
+
+KML driver:
+
+Idrisi driver:
+
+LIBKML driver:
+
+MITAB driver:
+
+MSSQLSpatial driver:
+
+MySQL:
+
+NAS driver:
+
+NULL driver:
+
+OCI driver:
+
+ODBC driver:
+
+NTF driver:
+
+OCI driver:
+
+PGeo driver:
+
+PG driver:
+
+PGDump driver:
+
+REC driver:
+
+SDE driver:
+
+Shapefile driver:
+
+S57 driver:
+
+SQLite/Spatialite driver:
+
+TIGER driver:
+
+VFK driver:
+
+VRT driver:
+
+WFS driver:
+
+XLS driver:
+
+== SWIG Language Bindings ==
+
+All bindings:
+
+CSharp bindings:
+
+Java bindings:
+
+Perl bindings:
+
+Python bindings:
+
+
 = GDAL/OGR 2.3.0 Release Notes =
 
 Note: due to the change of SCM during the development, #XXXX still refers to


### PR DESCRIPTION
Toward resolving #1119.

I'm working off of a reversed git log that begins with 

```
commit 8c19ac003663d3658430f8e68577400e4d02792b
Author:     Even Rouault <even.rouault@spatialys.com>
AuthorDate: Fri Apr 20 12:47:18 2018 +0200
Commit:     Even Rouault <even.rouault@spatialys.com>
CommitDate: Fri Apr 20 12:47:18 2018 +0200

    gcore/gdal_version.h.in: set to 2.4.0dev
```

and ends at 

```
commit 241ddd6210cbfad84dd2e83fa061c64ae0a8560d
Author:     Even Rouault <even.rouault@spatialys.com>
AuthorDate: Fri Dec 7 11:58:04 2018 +0100
Commit:     Even Rouault <even.rouault@spatialys.com>
CommitDate: Fri Dec 7 11:58:34 2018 +0100

    gdal_grid: fix -clipsrc from a vector datasource (broken at least since GDAL 2.1)
```