### PR TITLE
Tests: Skip oracle tests when no OCI_DSNAME in environment

### DIFF
--- a/autotest/gdrivers/georaster.py
+++ b/autotest/gdrivers/georaster.py
@@ -36,6 +36,13 @@ from osgeo import ogr
 import gdaltest
 import pytest
 
+
+pytestmark = [
+    pytest.mark.skipif('OCI_DSNAME' not in os.environ, reason='no OCI_DSNAME in environment'),
+    pytest.mark.require_driver('GeoRaster'),
+]
+
+
 ###############################################################################
 #
 
@@ -58,13 +65,8 @@ def test_georaster_init():
     gdaltest.oci_ds = None
 
     gdaltest.georasterDriver = gdal.GetDriverByName('GeoRaster')
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
 
-    if os.environ.get('OCI_DSNAME') is None:
-        pytest.skip()
-
-    gdaltest.oci_ds = ogr.Open(os.environ.get('OCI_DSNAME'))
+    gdaltest.oci_ds = ogr.Open(os.environ['OCI_DSNAME'])
 
     if gdaltest.oci_ds is None:
         pytest.skip()
@@ -90,10 +92,6 @@ def test_georaster_init():
 
 
 def test_georaster_byte():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -117,10 +115,6 @@ def test_georaster_byte():
 
 
 def test_georaster_int16():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -146,10 +140,6 @@ def test_georaster_int16():
 
 
 def test_georaster_int32():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -175,10 +165,6 @@ def test_georaster_int32():
 
 
 def test_georaster_rgb_b1():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -203,10 +189,6 @@ def test_georaster_rgb_b1():
 
 
 def test_georaster_rgb_b2():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -231,10 +213,6 @@ def test_georaster_rgb_b2():
 
 
 def test_georaster_rgb_b3_bsq():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -259,10 +237,6 @@ def test_georaster_rgb_b3_bsq():
 
 
 def test_georaster_rgb_b3_bip():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -287,10 +261,6 @@ def test_georaster_rgb_b3_bip():
 
 
 def test_georaster_rgb_b3_bil():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -315,10 +285,6 @@ def test_georaster_rgb_b3_bil():
 
 
 def test_georaster_byte_deflate():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -343,10 +309,6 @@ def test_georaster_byte_deflate():
 
 
 def test_georaster_rgb_deflate_b3():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -371,10 +333,6 @@ def test_georaster_rgb_deflate_b3():
 
 
 def test_georaster_1bit():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -399,10 +357,6 @@ def test_georaster_1bit():
 
 
 def test_georaster_2bit():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -427,10 +381,6 @@ def test_georaster_2bit():
 
 
 def test_georaster_4bit():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -455,10 +405,6 @@ def test_georaster_4bit():
 
 
 def test_georaster_cleanup():
-
-    if gdaltest.georasterDriver is None:
-        pytest.skip()
-
     if gdaltest.oci_ds is None:
         pytest.skip()
 
@@ -470,6 +416,3 @@ def test_georaster_cleanup():
 
 ###############################################################################
 #
-
-
-

--- a/autotest/ogr/ogr_oci.py
+++ b/autotest/ogr/ogr_oci.py
@@ -36,6 +36,12 @@ from osgeo import osr
 from osgeo import gdal
 import pytest
 
+
+pytestmark = [
+    pytest.mark.skipif('OCI_DSNAME' not in os.environ, reason='no OCI_DSNAME in environment'),
+    pytest.mark.require_driver('OCI'),
+]
+
 ###############################################################################
 # Open ORACLE.
 
@@ -43,14 +49,6 @@ import pytest
 def test_ogr_oci_1():
 
     gdaltest.oci_ds = None
-
-    try:
-        ogr.GetDriverByName('OCI')
-    except:
-        pytest.skip()
-
-    if 'OCI_DSNAME' not in os.environ:
-        pytest.skip()
 
     gdaltest.oci_ds = ogr.Open(os.environ['OCI_DSNAME'])
 


### PR DESCRIPTION


## What does this PR do?

This is an alternative fix for #1062 

I actually 'fixed' the issue with the oracle scripts waiting forever,
by accidentally removing the code that read stdin. (in 9412c2dbf8b37d031c09bc7d3389a40055993175)

However, actually running the oracle tests (ie with the drivers enabled,
but without the OCI_DSNAME in the environment) would probably have been
erroring since the pytestify branch was merged, since it didn't skip the tests
in that case, and it also didn't read the required OCI_DSNAME from stdin.

This fixes the issue by skipping the oracle tests if no OCI_DSNAME was provided.

Note I don't have Oracle to test with, so am relying on someone who does to
check this for me.

cc @miurahr @rouault

## What are related issues/pull requests?

This is an alternative fix for #1062 

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
