### PR TITLE
Tests: Skip the 3 slowest tests by default

### DIFF
--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -667,6 +667,10 @@ def test_wms_16():
     if gdaltest.wms_drv is None:
         pytest.skip()
 
+    if not gdaltest.run_slow_tests():
+        # server often returns a 504 after ages; this test can take minutes
+        pytest.skip()
+
     name = "WMS:http://demo.opengeo.org/geoserver/gwc/service/wms?tiled=TRUE"
     ds = gdal.Open(name)
     if ds is None:

--- a/autotest/ogr/ogr_gft.py
+++ b/autotest/ogr/ogr_gft.py
@@ -212,6 +212,9 @@ def test_ogr_gft_ogr2ogr_non_spatial():
 
 
 def test_ogr_gft_ogr2ogr_spatial():
+    if not gdaltest.run_slow_tests():
+        pytest.skip()
+
     if ogrtest.gft_drv is None:
         pytest.skip()
 


### PR DESCRIPTION

## What does this PR do?

Output from pytest --durations=10:
```
137.55s call     gdrivers/wms.py::test_wms_16
127.26s call     gcore/vsis3.py::test_vsis3_read_credentials_ec2_expiration
27.98s call     ogr/ogr_gft.py::test_ogr_gft_ogr2ogr_spatial
17.39s call     ogr/ogr_carto.py::test_ogr_carto_test_ogrsf
16.74s call     ogr/ogr_gft.py::test_ogr_gft_write
16.21s call     gdrivers/mrf.py::test_mrf_lerc_with_huffman
14.00s call     gdrivers/gdalhttp.py::test_http_2
12.88s call     ogr/ogr_gft.py::test_ogr_gft_ogr2ogr_non_spatial
12.30s call     gdrivers/wms.py::test_wms_11
12.19s call     gdrivers/mbtiles.py::test_mbtiles_3
```

This skips the top three (so should save ~ 5 minutes on test runs!)

They can be run manually by adding `GDAL_RUN_SLOW_TESTS=YES` in the environment, same as a bunch of other tests.

## What are related issues/pull requests?

n/a

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

those times are from my vagrant (ubuntu trusty) box, GDAL master from a few days ago.

