### PR TITLE
Vagrant: fix geos mingw package dependency problem

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   ppaRepos = [
     "ppa:openjdk-r/ppa",
-    "ppa:miurahr/gdal-dev-depends"
+    "ppa:ubuntugis/ubuntugis-unstable",
+    "ppa:miurahr/gdal-dev-additions"
   ]
 
   packageList = [

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,8 +64,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   ppaRepos = [
     "ppa:openjdk-r/ppa",
-    "ppa:ubuntugis/ubuntugis-unstable",
-    "ppa:miurahr/gdal-depends"
+    "ppa:miurahr/gdal-dev-depends"
   ]
 
   packageList = [
@@ -151,7 +150,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     "mingw-w64-tools",
     "gdb-mingw-w64-target",
     "libgeos-mingw-w64-dev",
-    #"libproj-mingw-w64-dev",
+    "libproj-mingw-w64-dev",
     "cmake3-curses-gui",
     "gdb",
     "gdbserver",
@@ -192,7 +191,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		  pkg_cmd << "apt-get update -qq; "
 	  end
 
-	  # install packages we need we need
+	  # install packages we need
 	  pkg_cmd << "apt-get --no-install-recommends install -q -y " + packageList.join(" ") << " ; "
 	  config.vm.provision :shell, :inline => pkg_cmd
     scripts = [

--- a/gdal/scripts/vagrant/gdal-mingw.sh
+++ b/gdal/scripts/vagrant/gdal-mingw.sh
@@ -15,9 +15,9 @@ fi
 export NUMTHREADS
 
 rsync -a /vagrant/gdal/ /home/vagrant/gnumake-build-mingw-w64
-rsync -a /vagrant/autotest/ /home/vagrant/gnumake-build-mingw-w64/autotest
+rsync -a --exclude='__pycache__' /vagrant/autotest/ /home/vagrant/gnumake-build-mingw-w64/autotest
 echo rsync -a /vagrant/gdal/ /home/vagrant/gnumake-build-mingw-w64/ > /home/vagrant/gnumake-build-mingw-w64/resync.sh
-echo rsync -a /vagrant/autotest/ /home/vagrant/gnumake-build-mingw-w64/autotest >> /home/vagrant/gnumake-build-mingw-w64/resync.sh
+echo rsync -a --exclude='__pycache__' /vagrant/autotest/ /home/vagrant/gnumake-build-mingw-w64/autotest >> /home/vagrant/gnumake-build-mingw-w64/resync.sh
 
 chmod +x /home/vagrant/gnumake-build-mingw-w64/resync.sh
 

--- a/gdal/scripts/vagrant/gdal.sh
+++ b/gdal/scripts/vagrant/gdal.sh
@@ -13,9 +13,9 @@ fi
 export NUMTHREADS
 
 rsync -a /vagrant/gdal/ /home/vagrant/gnumake-build-gcc4.8
-rsync -a /vagrant/autotest/ /home/vagrant/gnumake-build-gcc4.8/autotest
+rsync -a --exclude='__pycache__' /vagrant/autotest/ /home/vagrant/gnumake-build-gcc4.8/autotest
 echo rsync -a /vagrant/gdal/ /home/vagrant/gnumake-build-gcc4.8/ > /home/vagrant/gnumake-build-gcc4.8/resync.sh
-echo rsync -a /vagrant/autotest/ /home/vagrant/gnumake-build-gcc4.8/autotest >> /home/vagrant/gnumake-build-gcc4.8/resync.sh
+echo rsync -a --exclude='__pycache__'  /vagrant/autotest/ /home/vagrant/gnumake-build-gcc4.8/autotest >> /home/vagrant/gnumake-build-gcc4.8/resync.sh
 
 chmod +x /home/vagrant/gnumake-build-gcc4.8/resync.sh
 cd /home/vagrant/gnumake-build-gcc4.8

--- a/gdal/scripts/vagrant/postgis.sh
+++ b/gdal/scripts/vagrant/postgis.sh
@@ -8,6 +8,7 @@ sudo sed -i  's/md5/trust/' /etc/postgresql/9.3/main/pg_hba.conf
 sudo sed -i  's/peer/trust/' /etc/postgresql/9.3/main/pg_hba.conf
 
 sudo ln -s /usr/lib/libgdal.so.2 /usr/lib/libgdal.so.20
+sudo ln -s /usr/lib/libgdal.so.2 /usr/lib/libgdal.so.1
 sudo service postgresql restart
 psql -c "create database autotest" -U postgres
 psql -c "create extension postgis" -d autotest -U postgres


### PR DESCRIPTION
## What does this PR do?

resolve all the problem related to ubuntu PPA
Fix #1058 by removing root cause for dependency 
breakage of packages.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What is a root cause?
Ubuntugis-unstable PPA has a geos 3.5.0 package for trusty.
There are dependency chain for libgeos related to rasterlite. librasterlite depends on opensceangraph, which depends on gdal1h, that depends on libgeos 3.4.2.
Ubuntu Trusty has a geos 3.4.2 in standard release.

Similar things are happen on proj4 package. Multiple proj4 library versions causes crash, that is reported in #1058 

https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable

This patch removes ubuntugis-unstable PPA from apt repository, in order not to install geos 3.5.0.

## What are related issues/pull requests?

#1058 

## Tasklist

 - [ ] Fix test errors
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Vagrant