### PR TITLE
Require pytest 3.6.0+

### DIFF
--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -1,2 +1,2 @@
-pytest>=3
+pytest>=3.6.0
 pytest-sugar


### PR DESCRIPTION
## What does this PR do?

We use node.iter_markers which was added in 3.6.0

## What are related issues/pull requests?

Fixes #1165

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
