### PR TITLE
OSX: fix build failures due to json-c

### DIFF
--- a/gdal/ci/travis/osx/before_install.sh
+++ b/gdal/ci/travis/osx/before_install.sh
@@ -3,5 +3,12 @@
 set -e
 
 brew update
-brew uninstall postgis gdal
+if brew ls --versions postgis >/dev/null
+then
+	brew uninstall postgis
+fi
+if brew ls --versions gdal >/dev/null
+then
+	brew uninstall gdal
+fi
 brew install sqlite3 ccache

--- a/gdal/ci/travis/osx/install.sh
+++ b/gdal/ci/travis/osx/install.sh
@@ -33,7 +33,8 @@ make install
 export PATH=$HOME/install-gdal/bin:$PWD/apps/.libs:$PATH
 export DYLD_LIBRARY_PATH=$HOME/install-gdal/lib
 export GDAL_DATA=$HOME/install-gdal/share/gdal
-export PYTHONPATH=$PWD/swig/python/build/lib.macosx-10.12-intel-2.7:$PWD/swig/python/build/lib.macosx-10.11-x86_64-2.7
+export PYTHONPATH=$PWD/swig/python/build/lib.macosx-10.12-intel-2.7:$PWD/swig/python/build/lib.macosx-10.11-x86_64-2.7:$PWD/swig/python/build/lib.macosx-10.12-x86_64-2.7
+
 cd ../autotest/cpp
 echo $PATH
 #sudo rm -rf /usr/local/Cellar/gdal/1.10.1_1/*

--- a/gdal/ci/travis/osx/script.sh
+++ b/gdal/ci/travis/osx/script.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export PYTHONPATH=$PWD/gdal/swig/python/build/lib.macosx-10.12-intel-2.7:$PWD/gdal/swig/python/build/lib.macosx-10.11-x86_64-2.7
+export PYTHONPATH=$PWD/gdal/swig/python/build/lib.macosx-10.12-intel-2.7:$PWD/gdal/swig/python/build/lib.macosx-10.11-x86_64-2.7:$PWD/gdal/swig/python/build/lib.macosx-10.12-x86_64-2.7
 export PYTEST="pytest -vv -p no:sugar --color=no"
 
 echo 'Running CPP unit tests'

--- a/gdal/frmts/eeda/eedacommon.cpp
+++ b/gdal/frmts/eeda/eedacommon.cpp
@@ -36,10 +36,10 @@
 std::vector<EEDAIBandDesc> BuildBandDescArray(json_object* poBands,
                                 std::map<CPLString, CPLString>& oMapCodeToWKT)
 {
-    const int nBandCount = json_object_array_length( poBands );
+    const auto nBandCount = json_object_array_length( poBands );
     std::vector<EEDAIBandDesc> aoBandDesc;
 
-    for(int i = 0; i < nBandCount; i++)
+    for(auto i = decltype(nBandCount){0}; i < nBandCount; i++)
     {
         json_object* poBand = json_object_array_get_idx(poBands, i);
         if( poBand == nullptr || json_object_get_type(poBand) != json_type_object )

--- a/gdal/frmts/eeda/eedadataset.cpp
+++ b/gdal/frmts/eeda/eedadataset.cpp
@@ -260,8 +260,8 @@ GDALEEDALayer::GDALEEDALayer(GDALEEDADataset* poDS,
             return;
         }
 
-        const int nFields = json_object_array_length(poFields);
-        for( int i=0; i<nFields; i++ )
+        const auto nFields = json_object_array_length(poFields);
+        for( auto i=decltype(nFields){0}; i<nFields; i++ )
         {
             json_object* poField = json_object_array_get_idx(poFields, i);
             if( poField && json_object_get_type(poField) == json_type_object )
@@ -381,7 +381,7 @@ OGRFeature* GDALEEDALayer::GetNextRawFeature()
 {
     CPLString osNextPageToken;
     if( m_poCurPageAssets != nullptr &&
-        m_nIndexInPage >= json_object_array_length(m_poCurPageAssets) )
+        m_nIndexInPage >= static_cast<int>(json_object_array_length(m_poCurPageAssets)) )
     {
         json_object* poToken =
             CPL_json_object_object_get(m_poCurPageObj, "nextPageToken");

--- a/gdal/frmts/hdf5/bagdataset.cpp
+++ b/gdal/frmts/hdf5/bagdataset.cpp
@@ -74,7 +74,7 @@ constexpr float fDEFAULT_NODATA = 1000000.0f;
 /************************************************************************/
 
 #ifdef DEBUG
-static int h5check(int ret, const char* filename, int line)
+template<class T> static T h5check(T ret, const char* filename, int line)
 {
     if( ret < 0 )
     {

--- a/gdal/frmts/mbtiles/mbtilesdataset.cpp
+++ b/gdal/frmts/mbtiles/mbtilesdataset.cpp
@@ -534,12 +534,11 @@ char* MBTilesDataset::FindKey(int iPixel, int iLine)
     }
     if (poGrid != nullptr && json_object_is_type(poGrid, json_type_array))
     {
-        int nLines;
         int nFactor;
         json_object* poRow;
         char* pszRow = nullptr;
 
-        nLines = json_object_array_length(poGrid);
+        const auto nLines = json_object_array_length(poGrid);
         if (nLines == 0)
             goto end;
 

--- a/gdal/frmts/plmosaic/plmosaicdataset.cpp
+++ b/gdal/frmts/plmosaic/plmosaicdataset.cpp
@@ -1108,8 +1108,8 @@ std::vector<CPLString> PLMosaicDataset::ListSubdatasets()
             return aosNameList;
         }
 
-        const int nMosaics = json_object_array_length(poMosaics);
-        for(int i=0;i< nMosaics;i++)
+        const auto nMosaics = json_object_array_length(poMosaics);
+        for(auto i=decltype(nMosaics){0};i< nMosaics;i++)
         {
             const char* pszName = nullptr;
             const char* pszCoordinateSystem = nullptr;
@@ -1416,7 +1416,8 @@ const char* PLMosaicDataset::GetLocationInfo(int nPixel, int nLine)
         {
             CPLXMLNode* psScenes =
                 CPLCreateXMLNode(psRoot, CXT_Element, "Scenes");
-            for(int i = 0; i < json_object_array_length(poItems); i++ )
+            const auto nItemsLength = json_object_array_length(poItems);
+            for(auto i = decltype(nItemsLength){0}; i < nItemsLength; i++ )
             {
                 json_object* poObj = json_object_array_get_idx(poItems, i);
                 if ( poObj && json_object_get_type(poObj) == json_type_object )

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -717,8 +717,8 @@ bool GDALRDADataset::ParseConnectionString( GDALOpenInfo* poOpenInfo )
 
         if(poParams != nullptr &&
            json_object_get_type(poParams) == json_type_array ) {
-            const int nSize = json_object_array_length(poParams);
-            for (int i = 0; i < nSize; ++i) {
+            const auto nSize = json_object_array_length(poParams);
+            for (auto i = decltype(nSize){0}; i < nSize; ++i) {
                 json_object *ds = json_object_array_get_idx(poParams, i);
                 if (ds != nullptr) {
                     json_object_iter it;

--- a/gdal/ogr/ogrfeature.cpp
+++ b/gdal/ogr/ogrfeature.cpp
@@ -3941,39 +3941,39 @@ void OGRFeature::SetField( int iField, const char * pszValue )
         if( pszValue[0] == '[' && pszValue[strlen(pszValue)-1] == ']' &&
             OGRJSonParse(pszValue, &poJSonObj, false) )
         {
-            const int nLength = json_object_array_length(poJSonObj);
+            const auto nLength = json_object_array_length(poJSonObj);
             if( eType == OFTIntegerList && nLength > 0 )
             {
                 std::vector<int> anValues;
-                for( int i = 0; i < nLength; i++ )
+                for( auto i = decltype(nLength){0}; i < nLength; i++ )
                 {
                     json_object* poItem =
                         json_object_array_get_idx(poJSonObj, i);
                     anValues.push_back( json_object_get_int( poItem ) );
                 }
-                SetField( iField, nLength, &(anValues[0]) );
+                SetField( iField, static_cast<int>(nLength), &(anValues[0]) );
             }
             else if( eType == OFTInteger64List && nLength > 0 )
             {
                 std::vector<GIntBig> anValues;
-                for( int i = 0; i < nLength; i++ )
+                for( auto i = decltype(nLength){0}; i < nLength; i++ )
                 {
                     json_object* poItem =
                         json_object_array_get_idx(poJSonObj, i);
                     anValues.push_back( json_object_get_int64( poItem ) );
                 }
-                SetField( iField, nLength, &(anValues[0]) );
+                SetField( iField, static_cast<int>(nLength), &(anValues[0]) );
             }
             else if( eType == OFTRealList && nLength > 0 )
             {
                 std::vector<double> adfValues;
-                for( int i = 0; i < nLength; i++ )
+                for( auto i = decltype(nLength){0}; i < nLength; i++ )
                 {
                     json_object* poItem =
                         json_object_array_get_idx(poJSonObj, i);
                     adfValues.push_back( json_object_get_double( poItem ) );
                 }
-                SetField( iField, nLength, &(adfValues[0]) );
+                SetField( iField, static_cast<int>(nLength), &(adfValues[0]) );
             }
 
             json_object_put(poJSonObj);
@@ -4078,8 +4078,8 @@ void OGRFeature::SetField( int iField, const char * pszValue )
                      OGRJSonParse(pszValue, &poJSonObj, false) )
             {
                 CPLStringList aoList;
-                const int nLength = json_object_array_length(poJSonObj);
-                for( int i = 0; i < nLength; i++ )
+                const auto nLength = json_object_array_length(poJSonObj);
+                for( auto i = decltype(nLength){0}; i < nLength; i++ )
                 {
                     json_object* poItem =
                         json_object_array_get_idx(poJSonObj, i);

--- a/gdal/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
@@ -166,8 +166,8 @@ bool OGRAmigoCloudDataSource::ListDatasets()
                 CPLprintf("List of available datasets for project id: %s\n", GetProjectId());
                 CPLprintf("| id \t | name\n");
                 CPLprintf("|--------|-------------------\n");
-                const int nSize = json_object_array_length(poResults);
-                for(int i = 0; i < nSize; ++i) {
+                const auto nSize = json_object_array_length(poResults);
+                for(auto i = decltype(nSize){0}; i < nSize; ++i) {
                     json_object *ds = json_object_array_get_idx(poResults, i);
                     if(ds!=nullptr) {
                         const char *name = nullptr;

--- a/gdal/ogr/ogrsf_frmts/amigocloud/ogramigocloudlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/amigocloud/ogramigocloudlayer.cpp
@@ -234,7 +234,7 @@ OGRFeature *OGRAmigoCloudLayer::GetNextRawFeature()
             json_object_put(poCachedObj);
         poCachedObj = poObj;
 
-        nFetchedObjects = json_object_array_length(poRows);
+        nFetchedObjects = static_cast<decltype(nFetchedObjects)>(json_object_array_length(poRows));
         iNextInFetchedObjects = 0;
     }
 
@@ -334,9 +334,9 @@ void OGRAmigoCloudLayer::EstablishLayerDefn(const char* pszLayerName,
         return;
     }
 
-    int size = json_object_array_length(poFields);
+    auto size = json_object_array_length(poFields);
 
-    for(int i=0; i< size; i++)
+    for(auto i=decltype(size){0}; i< size; i++)
     {
         json_object *obj = json_object_array_get_idx(poFields, i);
 

--- a/gdal/ogr/ogrsf_frmts/amigocloud/ogramigocloudtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/amigocloud/ogramigocloudtablelayer.cpp
@@ -156,8 +156,8 @@ OGRFeatureDefn * OGRAmigoCloudTableLayer::GetLayerDefnInternal(CPL_UNUSED json_o
             if(poRows!=nullptr && json_object_get_type(poRows) == json_type_array)
             {
                 mFIDs.clear();
-                auto nLength = json_object_array_length(poRows);
-                for(decltype(nLength) i = 0; i < nLength; i++)
+                const auto nLength = json_object_array_length(poRows);
+                for(auto i = decltype(nLength){0}; i < nLength; i++)
                 {
                     json_object *obj = json_object_array_get_idx(poRows, i);
 

--- a/gdal/ogr/ogrsf_frmts/carto/ogrcartolayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/carto/ogrcartolayer.cpp
@@ -235,7 +235,7 @@ OGRFeature *OGRCARTOLayer::GetNextRawFeature()
             json_object_put(poCachedObj);
         poCachedObj = poObj;
 
-        nFetchedObjects = json_object_array_length(poRows);
+        nFetchedObjects = static_cast<decltype(nFetchedObjects)>(json_object_array_length(poRows));
         iNextInFetchedObjects = 0;
     }
 

--- a/gdal/ogr/ogrsf_frmts/cloudant/ogrcloudantdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/cloudant/ogrcloudantdatasource.cpp
@@ -199,9 +199,9 @@ int OGRCloudantDataSource::Open( const char * pszFilename, int bUpdateIn)
         }
     }
 
-    int nTables = json_object_array_length(poAnswerObj);
+    auto nTables = json_object_array_length(poAnswerObj);
 
-    for(int i=0;i<nTables;i++)
+    for(auto i=decltype(nTables){0};i<nTables;i++)
     {
         json_object* poAnswerObjDBName = json_object_array_get_idx(poAnswerObj, i);
         if ( json_object_is_type(poAnswerObjDBName, json_type_string) )

--- a/gdal/ogr/ogrsf_frmts/cloudant/ogrcloudanttablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/cloudant/ogrcloudanttablelayer.cpp
@@ -155,8 +155,8 @@ bool OGRCloudantTableLayer::RunSpatialFilterQueryIfNecessary()
         return false;
     }
 
-    int nRows = json_object_array_length(poRows);
-    for(int i=0;i<nRows;i++)
+    auto nRows = json_object_array_length(poRows);
+    for(auto i=decltype(nRows){0};i<nRows;i++)
     {
         json_object* poRow = json_object_array_get_idx(poRows, i);
         if ( poRow == nullptr ||
@@ -495,8 +495,8 @@ void OGRCloudantTableLayer::LoadMetadata()
         OGRFieldDefn oFieldRev("_rev", OFTString);
         poFeatureDefn->AddFieldDefn(&oFieldRev);
 
-        int nFields = json_object_array_length(poFields);
-        for(int i=0;i<nFields;i++)
+        auto nFields = json_object_array_length(poFields);
+        for(auto i=decltype(nFields){0};i<nFields;i++)
         {
             json_object* poField = json_object_array_get_idx(poFields, i);
             if (poField && json_object_is_type(poField, json_type_object))

--- a/gdal/ogr/ogrsf_frmts/couchdb/ogrcouchdbdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/couchdb/ogrcouchdbdatasource.cpp
@@ -286,8 +286,8 @@ int OGRCouchDBDataSource::Open( const char * pszFilename, int bUpdateIn)
         }
     }
 
-    int nTables = json_object_array_length(poAnswerObj);
-    for(int i=0;i<nTables;i++)
+    const auto nTables = json_object_array_length(poAnswerObj);
+    for(auto i=decltype(nTables){0};i<nTables;i++)
     {
         json_object* poAnswerObjDBName = json_object_array_get_idx(poAnswerObj, i);
         if ( json_object_is_type(poAnswerObjDBName, json_type_string) )
@@ -893,7 +893,7 @@ OGRLayer * OGRCouchDBDataSource::ExecuteSQLStats( const char *pszSQLCommand )
         return nullptr;
     }
 
-    int nLength = json_object_array_length(poRows);
+    const auto nLength = json_object_array_length(poRows);
     if (nLength != 1)
     {
         json_object_put(poAnswerObj);

--- a/gdal/ogr/ogrsf_frmts/couchdb/ogrcouchdblayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/couchdb/ogrcouchdblayer.cpp
@@ -285,15 +285,15 @@ void OGRCouchDBLayer::ParseFieldValue(OGRFeature* poFeature,
         {
             if ( json_object_get_type(poValue) == json_type_array )
             {
-                int nLength = json_object_array_length(poValue);
+                const auto nLength = json_object_array_length(poValue);
                 int* panVal = static_cast<int *>(
                     CPLMalloc(sizeof(int) * nLength));
-                for( int i = 0; i < nLength; i++ )
+                for( auto i = decltype(nLength){0}; i < nLength; i++ )
                 {
                     json_object* poRow = json_object_array_get_idx(poValue, i);
                     panVal[i] = json_object_get_int(poRow);
                 }
-                poFeature->SetField( nField, nLength, panVal );
+                poFeature->SetField( nField, static_cast<int>(nLength), panVal );
                 CPLFree(panVal);
             }
         }
@@ -301,15 +301,15 @@ void OGRCouchDBLayer::ParseFieldValue(OGRFeature* poFeature,
         {
             if ( json_object_get_type(poValue) == json_type_array )
             {
-                const int nLength = json_object_array_length(poValue);
+                const auto nLength = json_object_array_length(poValue);
                 double* padfVal = static_cast<double *>(
                     CPLMalloc(sizeof(double) * nLength));
-                for( int i = 0; i < nLength; i++ )
+                for( auto i = decltype(nLength){0}; i < nLength; i++ )
                 {
                     json_object* poRow = json_object_array_get_idx(poValue, i);
                     padfVal[i] = json_object_get_double(poRow);
                 }
-                poFeature->SetField( nField, nLength, padfVal );
+                poFeature->SetField( nField, static_cast<int>(nLength), padfVal );
                 CPLFree(padfVal);
             }
         }
@@ -317,10 +317,10 @@ void OGRCouchDBLayer::ParseFieldValue(OGRFeature* poFeature,
         {
             if ( json_object_get_type(poValue) == json_type_array )
             {
-                int nLength = json_object_array_length(poValue);
+                const auto nLength = json_object_array_length(poValue);
                 char** papszVal = static_cast<char **>(
                     CPLMalloc(sizeof(char*) * (nLength+1)));
-                int i = 0;  // Used after for.
+                auto i = decltype(nLength){0};  // Used after for.
                 for( ; i < nLength; i++ )
                 {
                     json_object* poRow = json_object_array_get_idx(poValue, i);
@@ -421,10 +421,10 @@ bool OGRCouchDBLayer::BuildFeatureDefnFromRows( json_object* poAnswerObj )
         return false;
     }
 
-    int nRows = json_object_array_length(poRows);
+    const auto nRows = json_object_array_length(poRows);
 
     json_object* poRow = nullptr;
-    for(int i=0;i<nRows;i++)
+    for(auto i=decltype(nRows){0};i<nRows;i++)
     {
         json_object* poTmpRow = json_object_array_get_idx(poRows, i);
         if (poTmpRow != nullptr &&
@@ -494,8 +494,8 @@ bool OGRCouchDBLayer::FetchNextRowsAnalyseDocs( json_object* poAnswerObj )
         return false;
     }
 
-    int nRows = json_object_array_length(poRows);
-    for(int i=0;i<nRows;i++)
+    const auto nRows = json_object_array_length(poRows);
+    for(auto i=decltype(nRows){0};i<nRows;i++)
     {
         json_object* poRow = json_object_array_get_idx(poRows, i);
         if ( poRow == nullptr ||
@@ -527,7 +527,7 @@ bool OGRCouchDBLayer::FetchNextRowsAnalyseDocs( json_object* poAnswerObj )
         }
     }
 
-    bEOF = nRows < GetFeaturesToFetch();
+    bEOF = static_cast<int>(nRows) < GetFeaturesToFetch();
 
     poFeatures = poAnswerObj;
 

--- a/gdal/ogr/ogrsf_frmts/couchdb/ogrcouchdbtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/couchdb/ogrcouchdbtablelayer.cpp
@@ -285,8 +285,8 @@ bool OGRCouchDBTableLayer::RunSpatialFilterQueryIfNecessary()
         return false;
     }
 
-    int nRows = json_object_array_length(poRows);
-    for(int i=0;i<nRows;i++)
+    const auto nRows = json_object_array_length(poRows);
+    for(auto i=decltype(nRows){0};i<nRows;i++)
     {
         json_object* poRow = json_object_array_get_idx(poRows, i);
         if ( poRow == nullptr ||
@@ -933,7 +933,7 @@ GIntBig OGRCouchDBTableLayer::GetFeatureCount(int bForce)
                 (poRows = CPL_json_object_object_get(poAnswerObj, "rows")) != nullptr &&
                 json_object_is_type(poRows, json_type_array))
             {
-                int nLength = json_object_array_length(poRows);
+                const auto nLength = json_object_array_length(poRows);
                 if (nLength == 0)
                 {
                     json_object_put(poAnswerObj);
@@ -1029,8 +1029,8 @@ int OGRCouchDBTableLayer::GetTotalFeatureCount()
 
     bHasOGRSpatial = FALSE;
 
-    int nSpecialRows = json_object_array_length(poRows);
-    for(int i=0;i<nSpecialRows;i++)
+    const auto nSpecialRows = json_object_array_length(poRows);
+    for(auto i=decltype(nSpecialRows){0};i<nSpecialRows;i++)
     {
         json_object* poRow = json_object_array_get_idx(poRows, i);
         if ( poRow != nullptr &&
@@ -1050,7 +1050,7 @@ int OGRCouchDBTableLayer::GetTotalFeatureCount()
         bServerSideSpatialFilteringWorks = false;
     }
 
-    if (nTotalRows >= nSpecialRows)
+    if (nTotalRows >= static_cast<int>(nSpecialRows))
         nTotalRows -= nSpecialRows;
 
     json_object_put(poAnswerObj);
@@ -1226,7 +1226,7 @@ int OGRCouchDBTableLayer::GetMaximumId()
         return -1;
     }
 
-    int nRows = json_object_array_length(poRows);
+    const auto nRows = json_object_array_length(poRows);
     if (nRows != 1)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "GetMaximumId() failed");
@@ -1640,8 +1640,8 @@ OGRErr OGRCouchDBTableLayer::CommitTransaction()
         return OGRERR_FAILURE;
     }
 
-    int nRows = json_object_array_length(poAnswerObj);
-    for(int i=0;i<nRows;i++)
+    const auto nRows = json_object_array_length(poAnswerObj);
+    for(auto i=decltype(nRows){0};i<nRows;i++)
     {
         json_object* poRow = json_object_array_get_idx(poAnswerObj, i);
         if ( poRow != nullptr &&
@@ -1917,8 +1917,8 @@ void OGRCouchDBTableLayer::LoadMetadata()
         OGRFieldDefn oFieldRev("_rev", OFTString);
         poFeatureDefn->AddFieldDefn(&oFieldRev);
 
-        int nFields = json_object_array_length(poFields);
-        for(int i=0;i<nFields;i++)
+        const auto nFields = json_object_array_length(poFields);
+        for(auto i=decltype(nFields){0};i<nFields;i++)
         {
             json_object* poField = json_object_array_get_idx(poFields, i);
             if (poField && json_object_is_type(poField, json_type_object))

--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -561,14 +561,14 @@ void OGRElasticLayer::FinalizeFeatureDefn(bool bReadFeatures)
                 json_object_put(poResponse);
                 break;
             }
-            int nHits = json_object_array_length(poHits);
+            const auto nHits = json_object_array_length(poHits);
             if( nHits == 0 )
             {
                 m_osScrollID = "";
                 json_object_put(poResponse);
                 break;
             }
-            for(int i=0;i<nHits;i++)
+            for(auto i=decltype(nHits){0};i<nHits;i++)
             {
                 json_object* poHit = json_object_array_get_idx(poHits, i);
                 if( poHit == nullptr || json_object_get_type(poHit) != json_type_object )
@@ -1081,7 +1081,7 @@ OGRFeature *OGRElasticLayer::GetNextRawFeature()
         json_object_put(poResponse);
         return nullptr;
     }
-    int nHits = json_object_array_length(poHits);
+    const auto nHits = json_object_array_length(poHits);
     if( nHits == 0 )
     {
         m_osScrollID = "";
@@ -1089,7 +1089,7 @@ OGRFeature *OGRElasticLayer::GetNextRawFeature()
         json_object_put(poResponse);
         return nullptr;
     }
-    for(int i=0;i<nHits;i++)
+    for(auto i=decltype(nHits){0};i<nHits;i++)
     {
         json_object* poHit = json_object_array_get_idx(poHits, i);
         if( poHit == nullptr || json_object_get_type(poHit) != json_type_object )
@@ -1234,47 +1234,53 @@ void OGRElasticLayer::BuildFeature(OGRFeature* poFeature, json_object* poSource,
                     if( m_poFeatureDefn->GetFieldDefn(oIter->second)->GetType() == OFTIntegerList )
                     {
                         std::vector<int> anValues;
-                        int nLength = json_object_array_length(it.val);
-                        for(int i=0;i<nLength;i++)
+                        const auto nLength = json_object_array_length(it.val);
+                        for(auto i=decltype(nLength){0};i<nLength;i++)
                         {
                             anValues.push_back( json_object_get_int( json_object_array_get_idx( it.val, i ) ) );
                         }
                         if( nLength )
-                            poFeature->SetField( oIter->second, nLength, &anValues[0] );
+                            poFeature->SetField( oIter->second,
+                                                 static_cast<int>(nLength),
+                                                 &anValues[0] );
                     }
                     else if( m_poFeatureDefn->GetFieldDefn(oIter->second)->GetType() == OFTInteger64List )
                     {
                         std::vector<GIntBig> anValues;
-                        int nLength = json_object_array_length(it.val);
-                        for(int i=0;i<nLength;i++)
+                        const auto nLength = json_object_array_length(it.val);
+                        for(auto i=decltype(nLength){0};i<nLength;i++)
                         {
                             anValues.push_back( json_object_get_int64( json_object_array_get_idx( it.val, i ) ) );
                         }
                         if( nLength )
-                            poFeature->SetField( oIter->second, nLength, &anValues[0] );
+                            poFeature->SetField( oIter->second,
+                                                 static_cast<int>(nLength),
+                                                 &anValues[0] );
                     }
                     else if( m_poFeatureDefn->GetFieldDefn(oIter->second)->GetType() == OFTRealList )
                     {
                         std::vector<double> adfValues;
-                        int nLength = json_object_array_length(it.val);
-                        for(int i=0;i<nLength;i++)
+                        const auto nLength = json_object_array_length(it.val);
+                        for(auto i=decltype(nLength){0};i<nLength;i++)
                         {
                             adfValues.push_back( json_object_get_double( json_object_array_get_idx( it.val, i ) ) );
                         }
                         if( nLength )
-                            poFeature->SetField( oIter->second, nLength, &adfValues[0] );
+                            poFeature->SetField( oIter->second,
+                                                 static_cast<int>(nLength),
+                                                 &adfValues[0] );
                     }
                     else if( m_poFeatureDefn->GetFieldDefn(oIter->second)->GetType() == OFTStringList )
                     {
                         std::vector<char*> apszValues;
-                        int nLength = json_object_array_length(it.val);
-                        for(int i=0;i<nLength;i++)
+                        const auto nLength = json_object_array_length(it.val);
+                        for(auto i=decltype(nLength){0};i<nLength;i++)
                         {
                             apszValues.push_back( CPLStrdup(json_object_get_string( json_object_array_get_idx( it.val, i ) )) );
                         }
                         apszValues.push_back( nullptr);
                         poFeature->SetField( oIter->second, &apszValues[0] );
-                        for(int i=0;i<nLength;i++)
+                        for(auto i=decltype(nLength){0};i<nLength;i++)
                         {
                             CPLFree(apszValues[i]);
                         }

--- a/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
@@ -175,8 +175,8 @@ bool OGRESRIJSONReader::GenerateLayerDefn()
     if( nullptr != poFields &&
         json_type_array == json_object_get_type( poFields ) )
     {
-        const int nFeatures = json_object_array_length( poFields );
-        for( int i = 0; i < nFeatures; ++i )
+        const auto nFeatures = json_object_array_length( poFields );
+        for( auto i = decltype(nFeatures){0}; i < nFeatures; ++i )
         {
             json_object* poField =
                 json_object_array_get_idx( poFields, i );
@@ -429,8 +429,8 @@ OGRESRIJSONReader::ReadFeatureCollection( json_object* poObj )
 
     if( json_type_array == json_object_get_type( poObjFeatures ) )
     {
-        const int nFeatures = json_object_array_length( poObjFeatures );
-        for( int i = 0; i < nFeatures; ++i )
+        const auto nFeatures = json_object_array_length( poObjFeatures );
+        for( auto i = decltype(nFeatures){0}; i < nFeatures; ++i )
         {
             json_object* poObjFeature
                 = json_object_array_get_idx( poObjFeatures, i );
@@ -610,7 +610,7 @@ static bool OGRESRIJSONReaderParseXYZMArray( json_object* poObjCoords,
         return false;
     }
 
-    int coordDimension = json_object_array_length( poObjCoords );
+    const auto coordDimension = json_object_array_length( poObjCoords );
 
     // Allow 4 coordinates if M is present, but it is eventually ignored.
     if( coordDimension < 2 || coordDimension > 4 )
@@ -702,7 +702,7 @@ static bool OGRESRIJSONReaderParseXYZMArray( json_object* poObjCoords,
     }
 
     if( pnNumCoords != nullptr )
-        *pnNumCoords = coordDimension;
+        *pnNumCoords = static_cast<int>(coordDimension);
     if( pdfX != nullptr )
         *pdfX = dfX;
     if( pdfY != nullptr )
@@ -747,8 +747,8 @@ OGRGeometry* OGRESRIJSONReadLineString( json_object* poObj )
 
     OGRMultiLineString* poMLS = nullptr;
     OGRGeometry* poRet = nullptr;
-    const int nPaths = json_object_array_length( poObjPaths );
-    for( int iPath = 0; iPath < nPaths; iPath++ )
+    const auto nPaths = json_object_array_length( poObjPaths );
+    for( auto iPath = decltype(nPaths){0}; iPath < nPaths; iPath++ )
     {
         json_object* poObjPath = json_object_array_get_idx( poObjPaths, iPath );
         if( poObjPath == nullptr ||
@@ -773,8 +773,8 @@ OGRGeometry* OGRESRIJSONReadLineString( json_object* poObj )
         {
             poRet = poLine;
         }
-        const int nPoints = json_object_array_length( poObjPath );
-        for( int i = 0; i < nPoints; i++ )
+        const auto nPoints = json_object_array_length( poObjPath );
+        for( auto i = decltype(nPoints){0}; i < nPoints; i++ )
         {
             int nNumCoords = 2;
             json_object* poObjCoords =
@@ -849,15 +849,15 @@ OGRGeometry* OGRESRIJSONReadPolygon( json_object* poObj)
         return nullptr;
     }
 
-    const int nRings = json_object_array_length( poObjRings );
+    const auto nRings = json_object_array_length( poObjRings );
     OGRGeometry** papoGeoms = new OGRGeometry*[nRings];
-    for( int iRing = 0; iRing < nRings; iRing++ )
+    for( auto iRing = decltype(nRings){0}; iRing < nRings; iRing++ )
     {
         json_object* poObjRing = json_object_array_get_idx( poObjRings, iRing );
         if( poObjRing == nullptr ||
             json_type_array != json_object_get_type( poObjRing ) )
         {
-            for( int j = 0; j < iRing; j++ )
+            for( auto j = decltype(iRing){0}; j < iRing; j++ )
                 delete papoGeoms[j];
             delete[] papoGeoms;
             CPLDebug( "ESRIJSON",
@@ -870,8 +870,8 @@ OGRGeometry* OGRESRIJSONReadPolygon( json_object* poObj)
         poPoly->addRingDirectly(poLine);
         papoGeoms[iRing] = poPoly;
 
-        const int nPoints = json_object_array_length( poObjRing );
-        for( int i = 0; i < nPoints; i++ )
+        const auto nPoints = json_object_array_length( poObjRing );
+        for( auto i = decltype(nPoints){0}; i < nPoints; i++ )
         {
             int nNumCoords = 2;
             json_object* poObjCoords =
@@ -883,7 +883,7 @@ OGRGeometry* OGRESRIJSONReadPolygon( json_object* poObj)
             if( !OGRESRIJSONReaderParseXYZMArray (
               poObjCoords, bHasZ, bHasM, &dfX, &dfY, &dfZ, &dfM, &nNumCoords) )
             {
-                for( int j = 0; j <= iRing; j++ )
+                for( auto j = decltype(iRing){0}; j <= iRing; j++ )
                     delete papoGeoms[j];
                 delete[] papoGeoms;
                 return nullptr;
@@ -909,7 +909,7 @@ OGRGeometry* OGRESRIJSONReadPolygon( json_object* poObj)
     }
 
     OGRGeometry* poRet = OGRGeometryFactory::organizePolygons( papoGeoms,
-                                                               nRings,
+                                                               static_cast<int>(nRings),
                                                                nullptr,
                                                                nullptr);
     delete[] papoGeoms;
@@ -953,8 +953,8 @@ OGRMultiPoint* OGRESRIJSONReadMultiPoint( json_object* poObj)
 
     OGRMultiPoint* poMulti = new OGRMultiPoint();
 
-    const int nPoints = json_object_array_length( poObjPoints );
-    for( int i = 0; i < nPoints; i++ )
+    const auto nPoints = json_object_array_length( poObjPoints );
+    for( auto i = decltype(nPoints){0}; i < nPoints; i++ )
     {
         int nNumCoords = 2;
         json_object* poObjCoords =

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
@@ -1446,8 +1446,8 @@ bool OGRGeoJSONReader::GenerateLayerDefn( OGRGeoJSONLayer* poLayer,
         if( nullptr != poObjFeatures
             && json_type_array == json_object_get_type( poObjFeatures ) )
         {
-            const int nFeatures = json_object_array_length( poObjFeatures );
-            for( int i = 0; i < nFeatures; ++i )
+            const auto nFeatures = json_object_array_length( poObjFeatures );
+            for( auto i = decltype(nFeatures){0}; i < nFeatures; ++i )
             {
                 json_object* poObjFeature =
                     json_object_array_get_idx( poObjFeatures, i );
@@ -2206,14 +2206,14 @@ void OGRGeoJSONReaderSetField( OGRLayer* poLayer,
         const enum json_type eJSonType(json_object_get_type(poVal));
         if( eJSonType == json_type_array )
         {
-            const int nLength = json_object_array_length(poVal);
+            const auto nLength = json_object_array_length(poVal);
             int* panVal = static_cast<int *>(CPLMalloc(sizeof(int) * nLength));
-            for( int i = 0; i < nLength; i++ )
+            for( auto i = decltype(nLength){0}; i < nLength; i++ )
             {
                 json_object* poRow = json_object_array_get_idx(poVal, i);
                 panVal[i] = json_object_get_int(poRow);
             }
-            poFeature->SetField( nField, nLength, panVal );
+            poFeature->SetField( nField, static_cast<int>(nLength), panVal );
             CPLFree(panVal);
         }
         else if ( eJSonType == json_type_boolean ||
@@ -2227,15 +2227,15 @@ void OGRGeoJSONReaderSetField( OGRLayer* poLayer,
         const enum json_type eJSonType(json_object_get_type(poVal));
         if( eJSonType == json_type_array )
         {
-            const int nLength = json_object_array_length(poVal);
+            const auto nLength = json_object_array_length(poVal);
             GIntBig* panVal =
                 static_cast<GIntBig *>(CPLMalloc(sizeof(GIntBig) * nLength));
-            for( int i = 0; i < nLength; i++ )
+            for( auto i = decltype(nLength){0}; i < nLength; i++ )
             {
                 json_object* poRow = json_object_array_get_idx(poVal, i);
                 panVal[i] = static_cast<GIntBig>(json_object_get_int64(poRow));
             }
-            poFeature->SetField( nField, nLength, panVal );
+            poFeature->SetField( nField, static_cast<int>(nLength), panVal );
             CPLFree(panVal);
         }
         else if ( eJSonType == json_type_boolean ||
@@ -2250,15 +2250,15 @@ void OGRGeoJSONReaderSetField( OGRLayer* poLayer,
         const enum json_type eJSonType(json_object_get_type(poVal));
         if( eJSonType == json_type_array )
         {
-            const int nLength = json_object_array_length(poVal);
+            const auto nLength = json_object_array_length(poVal);
             double* padfVal =
                 static_cast<double *>(CPLMalloc(sizeof(double) * nLength));
-            for( int i = 0; i < nLength;i++ )
+            for( auto i = decltype(nLength){0}; i < nLength;i++ )
             {
                 json_object* poRow = json_object_array_get_idx(poVal, i);
                 padfVal[i] = json_object_get_double(poRow);
             }
-            poFeature->SetField( nField, nLength, padfVal );
+            poFeature->SetField( nField, static_cast<int>(nLength), padfVal );
             CPLFree(padfVal);
         }
         else if ( eJSonType == json_type_boolean ||
@@ -2272,9 +2272,9 @@ void OGRGeoJSONReaderSetField( OGRLayer* poLayer,
         const enum json_type eJSonType(json_object_get_type(poVal));
         if( eJSonType == json_type_array )
         {
-            const int nLength = json_object_array_length(poVal);
+            const auto nLength = json_object_array_length(poVal);
             char** papszVal = (char**)CPLMalloc(sizeof(char*) * (nLength+1));
-            int i = 0;
+            auto i = decltype(nLength){0};
             for( ; i < nLength; i++ )
             {
                 json_object* poRow = json_object_array_get_idx(poVal, i);
@@ -2481,8 +2481,8 @@ OGRGeoJSONReader::ReadFeatureCollection( OGRGeoJSONLayer* poLayer,
 
     if( json_type_array == json_object_get_type( poObjFeatures ) )
     {
-        const int nFeatures = json_object_array_length( poObjFeatures );
-        for( int i = 0; i < nFeatures; ++i )
+        const auto nFeatures = json_object_array_length( poObjFeatures );
+        for( auto i = decltype(nFeatures){0}; i < nFeatures; ++i )
         {
             json_object* poObjFeature
                 = json_object_array_get_idx( poObjFeatures, i );
@@ -2727,7 +2727,7 @@ bool OGRGeoJSONReadRawPoint( json_object* poObj, OGRPoint& point )
 
     if( json_type_array == json_object_get_type( poObj ) )
     {
-        const int nSize = json_object_array_length( poObj );
+        const auto nSize = json_object_array_length( poObj );
 
         if( nSize < GeoJSONObject::eMinCoordinateDimension )
         {
@@ -2808,11 +2808,11 @@ OGRMultiPoint* OGRGeoJSONReadMultiPoint( json_object* poObj )
     OGRMultiPoint* poMultiPoint = nullptr;
     if( json_type_array == json_object_get_type( poObjPoints ) )
     {
-        const int nPoints = json_object_array_length( poObjPoints );
+        const auto nPoints = json_object_array_length( poObjPoints );
 
         poMultiPoint = new OGRMultiPoint();
 
-        for( int i = 0; i < nPoints; ++i)
+        for( auto i = decltype(nPoints){0}; i < nPoints; ++i)
         {
             json_object* poObjCoords =
                 json_object_array_get_idx( poObjPoints, i );
@@ -2863,12 +2863,12 @@ OGRLineString* OGRGeoJSONReadLineString( json_object* poObj , bool bRaw )
 
     if( json_type_array == json_object_get_type( poObjPoints ) )
     {
-        const int nPoints = json_object_array_length( poObjPoints );
+        const auto nPoints = json_object_array_length( poObjPoints );
 
         poLine = new OGRLineString();
-        poLine->setNumPoints( nPoints );
+        poLine->setNumPoints( static_cast<int>(nPoints) );
 
-        for( int i = 0; i < nPoints; ++i)
+        for( auto i = decltype(nPoints){0}; i < nPoints; ++i)
         {
             json_object* poObjCoords =
                 json_object_array_get_idx(poObjPoints, i);
@@ -2890,11 +2890,11 @@ OGRLineString* OGRGeoJSONReadLineString( json_object* poObj , bool bRaw )
             }
             if( pt.getCoordinateDimension() == 2 )
             {
-                poLine->setPoint( i, pt.getX(), pt.getY());
+                poLine->setPoint( static_cast<int>(i), pt.getX(), pt.getY());
             }
             else
             {
-                poLine->setPoint( i, pt.getX(), pt.getY(), pt.getZ() );
+                poLine->setPoint( static_cast<int>(i), pt.getX(), pt.getY(), pt.getZ() );
             }
         }
     }
@@ -2923,11 +2923,11 @@ OGRMultiLineString* OGRGeoJSONReadMultiLineString( json_object* poObj )
 
     if( json_type_array == json_object_get_type( poObjLines ) )
     {
-        const int nLines = json_object_array_length( poObjLines );
+        const auto nLines = json_object_array_length( poObjLines );
 
         poMultiLine = new OGRMultiLineString();
 
-        for( int i = 0; i < nLines; ++i)
+        for( auto i = decltype(nLines){0}; i < nLines; ++i)
         {
             json_object* poObjLine = json_object_array_get_idx( poObjLines, i );
 
@@ -2959,12 +2959,12 @@ OGRLinearRing* OGRGeoJSONReadLinearRing( json_object* poObj )
 
     if( json_type_array == json_object_get_type( poObj ) )
     {
-        const int nPoints = json_object_array_length( poObj );
+        const auto nPoints = json_object_array_length( poObj );
 
         poRing= new OGRLinearRing();
-        poRing->setNumPoints( nPoints );
+        poRing->setNumPoints( static_cast<int>(nPoints) );
 
-        for( int i = 0; i < nPoints; ++i)
+        for( auto i = decltype(nPoints){0}; i < nPoints; ++i)
         {
             json_object* poObjCoords = json_object_array_get_idx( poObj, i );
             if( poObjCoords == nullptr )
@@ -2985,9 +2985,9 @@ OGRLinearRing* OGRGeoJSONReadLinearRing( json_object* poObj )
             }
 
             if( 2 == pt.getCoordinateDimension() )
-                poRing->setPoint( i, pt.getX(), pt.getY());
+                poRing->setPoint( static_cast<int>(i), pt.getX(), pt.getY());
             else
-                poRing->setPoint( i, pt.getX(), pt.getY(), pt.getZ() );
+                poRing->setPoint( static_cast<int>(i), pt.getX(), pt.getY(), pt.getZ() );
         }
     }
 
@@ -3024,7 +3024,7 @@ OGRPolygon* OGRGeoJSONReadPolygon( json_object* poObj , bool bRaw )
 
     if( json_type_array == json_object_get_type( poObjRings ) )
     {
-        const int nRings = json_object_array_length( poObjRings );
+        const auto nRings = json_object_array_length( poObjRings );
         if( nRings > 0 )
         {
             json_object* poObjPoints = json_object_array_get_idx(poObjRings, 0);
@@ -3043,7 +3043,7 @@ OGRPolygon* OGRGeoJSONReadPolygon( json_object* poObj , bool bRaw )
                 }
             }
 
-            for( int i = 1; i < nRings && nullptr != poPolygon; ++i )
+            for( auto i = decltype(nRings){1}; i < nRings && nullptr != poPolygon; ++i )
             {
                 poObjPoints = json_object_array_get_idx( poObjRings, i );
                 if( poObjPoints == nullptr )
@@ -3088,11 +3088,11 @@ OGRMultiPolygon* OGRGeoJSONReadMultiPolygon( json_object* poObj )
 
     if( json_type_array == json_object_get_type( poObjPolys ) )
     {
-        const int nPolys = json_object_array_length( poObjPolys );
+        const auto nPolys = json_object_array_length( poObjPolys );
 
         poMultiPoly = new OGRMultiPolygon();
 
-        for( int i = 0; i < nPolys; ++i)
+        for( auto i = decltype(nPolys){0}; i < nPolys; ++i)
         {
             json_object* poObjPoly = json_object_array_get_idx( poObjPolys, i );
             if( poObjPoly == nullptr )
@@ -3138,8 +3138,8 @@ OGRGeometryCollection* OGRGeoJSONReadGeometryCollection( json_object* poObj,
         poCollection = new OGRGeometryCollection();
         poCollection->assignSpatialReference(poSRS);
 
-        const int nGeoms = json_object_array_length( poObjGeoms );
-        for( int i = 0; i < nGeoms; ++i )
+        const auto nGeoms = json_object_array_length( poObjGeoms );
+        for( auto i = decltype(nGeoms){0}; i < nGeoms; ++i )
         {
             json_object* poObjGeom = json_object_array_get_idx( poObjGeoms, i );
             if( poObjGeom == nullptr )

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
@@ -710,13 +710,13 @@ OGRFieldType GeoJSONPropertyToFieldType( json_object* poObject,
     {
         if( bArrayAsString )
             return OFTString;
-        const int nSize = json_object_array_length(poObject);
+        const auto nSize = json_object_array_length(poObject);
         if( nSize == 0 )
             // We don't know, so let's assume it is a string list.
             return OFTStringList;
         OGRFieldType eType = OFTIntegerList;
         bool bOnlyBoolean = true;
-        for( int i = 0; i < nSize; i++ )
+        for( auto i = decltype(nSize){0}; i < nSize; i++ )
         {
             json_object* poRow = json_object_array_get_idx(poObject, i);
             if( poRow != nullptr )

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
@@ -143,8 +143,8 @@ static bool OGRGeoJSONIsCompatiblePosition( json_object* poJSonCoordinates,
 static void OGRGeoJSONPatchPosition( json_object* poJSonCoordinates,
                                      json_object* poNativeCoordinates )
 {
-    const int nLength = json_object_array_length(poNativeCoordinates);
-    for( int i = 3; i < nLength; i++ )
+    const auto nLength = json_object_array_length(poNativeCoordinates);
+    for( auto i = decltype(nLength){3}; i < nLength; i++ )
     {
         json_object_array_add(poJSonCoordinates,
             json_object_get(
@@ -166,7 +166,7 @@ static bool OGRGeoJSONIsPatchableArray( json_object* poJSonArray,
     if( json_object_get_type(poJSonArray) == json_type_array &&
         json_object_get_type(poNativeArray) == json_type_array )
     {
-        auto nLength = json_object_array_length(poJSonArray);
+        const auto nLength = json_object_array_length(poJSonArray);
         if( nLength == json_object_array_length(poNativeArray) )
         {
             if( nLength > 0 )
@@ -217,10 +217,10 @@ static bool OGRGeoJSONComputePatchableOrCompatibleArrayInternal(
     if( json_object_get_type(poJSonArray) == json_type_array &&
         json_object_get_type(poNativeArray) == json_type_array )
     {
-        auto nLength = json_object_array_length(poJSonArray);
+        const auto nLength = json_object_array_length(poJSonArray);
         if (nLength == json_object_array_length(poNativeArray) )
         {
-            for( decltype(nLength) i=0; i < nLength; i++ )
+            for( auto i = decltype(nLength){0}; i < nLength; i++ )
             {
                 json_object* poJSonChild =
                     json_object_array_get_idx(poJSonArray, i);
@@ -276,8 +276,8 @@ static void OGRGeoJSONPatchArray( json_object* poJSonArray,
         OGRGeoJSONPatchPosition(poJSonArray, poNativeArray);
         return;
     }
-    const int nLength = json_object_array_length(poJSonArray);
-    for( int i = 0; i<nLength; i++ )
+    const auto nLength = json_object_array_length(poJSonArray);
+    for( auto i = decltype(nLength){0}; i<nLength; i++ )
     {
         json_object* poJSonChild = json_object_array_get_idx(poJSonArray, i);
         json_object* poNativeChild =
@@ -348,10 +348,10 @@ static bool OGRGeoJSONIsPatchableGeometry( json_object* poJSonGeometry,
             if( json_object_get_type(poJSonGeometries) == json_type_array &&
                 json_object_get_type(poNativeGeometries) == json_type_array )
             {
-                auto nLength = json_object_array_length(poJSonGeometries);
+                const auto nLength = json_object_array_length(poJSonGeometries);
                 if( nLength == json_object_array_length(poNativeGeometries) )
                 {
-                    for( decltype(nLength) i=0; i < nLength; i++ )
+                    for( auto i = decltype(nLength){0}; i < nLength; i++ )
                     {
                         json_object* poJSonChild =
                             json_object_array_get_idx(poJSonGeometries, i);
@@ -423,8 +423,8 @@ static void OGRGeoJSONPatchGeometry( json_object* poJSonGeometry,
             json_object* poJSonGeometries =
                 CPL_json_object_object_get(poJSonGeometry, "geometries");
             json_object* poNativeGeometries = it.val;
-            int nLength = json_object_array_length(poJSonGeometries);
-            for( int i=0; i < nLength; i++ )
+            const auto nLength = json_object_array_length(poJSonGeometries);
+            for( auto i=decltype(nLength){0}; i < nLength; i++ )
             {
                 json_object* poJSonChild =
                     json_object_array_get_idx(poJSonGeometries, i);

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrtopojsonreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrtopojsonreader.cpp
@@ -117,11 +117,11 @@ static void ParseArc( OGRLineString* poLS, json_object* poArcsDB, int nArcID,
     json_object* poArcDB = json_object_array_get_idx(poArcsDB, nArcID);
     if( poArcDB == nullptr || json_type_array != json_object_get_type(poArcDB) )
         return;
-    int nPoints = json_object_array_length(poArcDB);
+    auto nPoints = json_object_array_length(poArcDB);
     double dfAccX = 0.0;
     double dfAccY = 0.0;
     int nBaseIndice = poLS->getNumPoints();
-    for( int i = 0; i < nPoints; i++ )
+    for( auto i = decltype(nPoints){0}; i < nPoints; i++ )
     {
         json_object* poPoint = json_object_array_get_idx(poArcDB, i);
         double dfX = 0.0;
@@ -144,25 +144,29 @@ static void ParseArc( OGRLineString* poLS, json_object* poArcsDB, int nArcID,
             {
                 if( !bReverse && poLS->getNumPoints() > 0 )
                 {
-                    poLS->setNumPoints( nBaseIndice + nPoints - 1 );
+                    poLS->setNumPoints( nBaseIndice +
+                                        static_cast<int>(nPoints) - 1 );
                     nBaseIndice --;
                     continue;
                 }
                 else if( bReverse && poLS->getNumPoints() > 0 )
                 {
-                    poLS->setNumPoints( nBaseIndice + nPoints - 1 );
+                    poLS->setNumPoints( nBaseIndice +
+                                        static_cast<int>(nPoints) - 1 );
                     nPoints --;
                     if( nPoints == 0 )
                         break;
                 }
                 else
-                    poLS->setNumPoints( nBaseIndice + nPoints );
+                    poLS->setNumPoints( nBaseIndice +
+                                        static_cast<int>(nPoints) );
             }
 
             if( !bReverse )
-                poLS->setPoint(nBaseIndice + i, dfX, dfY);
+                poLS->setPoint(nBaseIndice + static_cast<int>(i), dfX, dfY);
             else
-                poLS->setPoint(nBaseIndice + nPoints - 1 - i, dfX, dfY);
+                poLS->setPoint(nBaseIndice + static_cast<int>(nPoints) - 1 -
+                               static_cast<int>(i), dfX, dfY);
         }
     }
 }
@@ -174,10 +178,10 @@ static void ParseArc( OGRLineString* poLS, json_object* poArcsDB, int nArcID,
 static void ParseLineString( OGRLineString* poLS, json_object* poRing,
                              json_object* poArcsDB, ScalingParams* psParams )
 {
-    const int nArcsDB = json_object_array_length(poArcsDB);
+    const auto nArcsDB = json_object_array_length(poArcsDB);
 
-    const int nArcsRing = json_object_array_length(poRing);
-    for( int j = 0; j < nArcsRing; j++ )
+    const auto nArcsRing = json_object_array_length(poRing);
+    for( auto j = decltype(nArcsRing){0}; j < nArcsRing; j++ )
     {
         json_object* poArcId = json_object_array_get_idx(poRing, j);
         if( poArcId != nullptr && json_type_int == json_object_get_type(poArcId) )
@@ -189,7 +193,7 @@ static void ParseLineString( OGRLineString* poLS, json_object* poRing,
                 nArcId = -(nArcId + 1);
                 bReverse = true;
             }
-            if( nArcId < nArcsDB )
+            if( nArcId < static_cast<int>(nArcsDB) )
             {
                 ParseArc(poLS, poArcsDB, nArcId, bReverse, psParams);
             }
@@ -204,8 +208,8 @@ static void ParseLineString( OGRLineString* poLS, json_object* poRing,
 static void ParsePolygon( OGRPolygon* poPoly, json_object* poArcsObj,
                           json_object* poArcsDB, ScalingParams* psParams )
 {
-    const int nRings = json_object_array_length(poArcsObj);
-    for( int i = 0; i < nRings; i++ )
+    const auto nRings = json_object_array_length(poArcsObj);
+    for( auto i = decltype(nRings){0}; i < nRings; i++ )
     {
         OGRLinearRing* poLR = new OGRLinearRing();
 
@@ -237,8 +241,8 @@ static void ParseMultiLineString( OGRMultiLineString* poMLS,
                                   json_object* poArcsDB,
                                   ScalingParams* psParams )
 {
-    const int nRings = json_object_array_length(poArcsObj);
-    for( int i = 0; i < nRings; i++ )
+    const auto nRings = json_object_array_length(poArcsObj);
+    for( auto i = decltype(nRings){0}; i < nRings; i++ )
     {
         OGRLineString* poLS = new OGRLineString();
         poMLS->addGeometryDirectly(poLS);
@@ -259,8 +263,8 @@ static void ParseMultiPolygon( OGRMultiPolygon* poMultiPoly,
                                json_object* poArcsObj,
                                json_object* poArcsDB, ScalingParams* psParams )
 {
-    const int nPolys = json_object_array_length(poArcsObj);
-    for( int i = 0; i < nPolys; i++ )
+    const auto nPolys = json_object_array_length(poArcsObj);
+    for( auto i = decltype(nPolys){0}; i < nPolys; i++ )
     {
         OGRPolygon* poPoly = new OGRPolygon();
 
@@ -362,8 +366,8 @@ static void ParseObject( const char* pszId,
     {
         OGRMultiPoint* poMP = new OGRMultiPoint();
         poGeom = poMP;
-        int nTuples = json_object_array_length(poCoordinatesObj);
-        for( int i = 0; i < nTuples; i++ )
+        const auto nTuples = json_object_array_length(poCoordinatesObj);
+        for( auto i = decltype(nTuples){0}; i < nTuples; i++ )
         {
             json_object* poPair =
                 json_object_array_get_idx(poCoordinatesObj, i);
@@ -483,10 +487,11 @@ static bool ParseObjectMain( const char* pszId, json_object* poObj,
                         poDefn->AddFieldDefn( &fldDefn );
                     }
 
-                    const int nGeometries =
+                    const auto nGeometries =
                         json_object_array_length(poGeometries);
                     // First pass to establish schema.
-                    for( int i = 0; i < nGeometries; i++ )
+                    for( auto i = decltype(nGeometries){0}; i < nGeometries;
+                         i++ )
                     {
                         json_object* poGeom =
                             json_object_array_get_idx(poGeometries, i);
@@ -499,7 +504,8 @@ static bool ParseObjectMain( const char* pszId, json_object* poObj,
                     }
 
                     // Second pass to build objects.
-                    for( int i = 0; i < nGeometries; i++ )
+                    for( auto i = decltype(nGeometries){0}; i < nGeometries;
+                         i++ )
                     {
                         json_object* poGeom =
                             json_object_array_get_idx(poGeometries, i);
@@ -657,9 +663,9 @@ void OGRTopoJSONReader::ReadLayers( OGRGeoJSONDataSource* poDS )
     }
     else if( json_type_array == json_object_get_type( poObjects ) )
     {
-        const int nObjects = json_object_array_length(poObjects);
+        const auto nObjects = json_object_array_length(poObjects);
         bool bNeedSecondPass = false;
-        for( int i = 0; i < nObjects; i++ )
+        for( auto i = decltype(nObjects){0}; i < nObjects; i++ )
         {
             json_object* poObj = json_object_array_get_idx(poObjects, i);
             bNeedSecondPass |= ParseObjectMain(nullptr, poObj, poDS, &poMainLayer,
@@ -668,7 +674,7 @@ void OGRTopoJSONReader::ReadLayers( OGRGeoJSONDataSource* poDS )
         }
         if( bNeedSecondPass )
         {
-            for( int i = 0; i < nObjects; i++ )
+            for( auto i = decltype(nObjects){0}; i < nObjects; i++ )
             {
                 json_object* poObj = json_object_array_get_idx(poObjects, i);
                 ParseObjectMain(nullptr, poObj, poDS, &poMainLayer, poArcs,

--- a/gdal/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1dataset.cpp
+++ b/gdal/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1dataset.cpp
@@ -149,8 +149,8 @@ bool OGRPLScenesDataV1Dataset::ParseItemTypes(json_object* poObj,
                 "Missing item_types object, or not of type array");
         return false;
     }
-    const int nCatalogsLength = json_object_array_length(poItemTypes);
-    for( int i=0; i<nCatalogsLength; i++ )
+    const auto nCatalogsLength = json_object_array_length(poItemTypes);
+    for( auto i=decltype(nCatalogsLength){0}; i<nCatalogsLength; i++ )
     {
         json_object* poItemType = json_object_array_get_idx(poItemTypes, i);
         ParseItemType(poItemType);

--- a/gdal/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp
+++ b/gdal/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp
@@ -183,8 +183,8 @@ void OGRPLScenesDataV1Layer::EstablishLayerDefn()
         OGRFieldDefn oFieldDefn("id", OFTString);
         RegisterField(&oFieldDefn, "id", "id");
     }
-    const int nFields = json_object_array_length(poFields);
-    for( int i=0; i<nFields; i++ )
+    const auto nFields = json_object_array_length(poFields);
+    for( auto i=decltype(nFields){0}; i<nFields; i++ )
     {
         json_object* poField = json_object_array_get_idx(poFields, i);
         if( poField && json_object_get_type(poField) == json_type_object )
@@ -253,8 +253,8 @@ void OGRPLScenesDataV1Layer::EstablishLayerDefn()
             return;
         }
 
-        const int nAssets = json_object_array_length(poAssets);
-        for( int i=0; i<nAssets; i++ )
+        const auto nAssets = json_object_array_length(poAssets);
+        for( auto i=decltype(nAssets){0}; i<nAssets; i++ )
         {
             json_object* poAsset = json_object_array_get_idx(poAssets, i);
             if( poAsset && json_object_get_type(poAsset) == json_type_string )
@@ -1003,10 +1003,11 @@ OGRFeature* OGRPLScenesDataV1Layer::GetNextRawFeature()
         if( oIter != m_oMapPrefixedJSonFieldNameToFieldIdx.end() )
         {
             const int iField = oIter->second;
-            const int nStrings = json_object_array_length(poPermissions);
+            const auto nStrings = json_object_array_length(poPermissions);
             char** papszPermissions =
                 static_cast<char**>(CPLCalloc(nStrings+1, sizeof(char*)));
-            for(int i=0, j=0;i<nStrings;i++)
+            for(auto i=decltype(nStrings){0}, j=decltype(nStrings){0};
+                i<nStrings;i++)
             {
                 json_object* poPerm = json_object_array_get_idx(poPermissions,i);
                 if( poPerm && json_object_get_type(poPerm) == json_type_string )
@@ -1262,8 +1263,8 @@ GIntBig OGRPLScenesDataV1Layer::GetFeatureCount(int bForce)
                                                             json_type_array )
             {
                 GIntBig nRes = 0;
-                const int nBuckets = json_object_array_length(poBuckets);
-                for( int i=0; i<nBuckets;i++ )
+                const auto nBuckets = json_object_array_length(poBuckets);
+                for( auto i=decltype(nBuckets){0}; i<nBuckets;i++ )
                 {
                     json_object* poBucket =
                                 json_object_array_get_idx(poBuckets, i);

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -1713,6 +1713,9 @@ static const struct sqlite3_module sOGR2SQLITEModule =
     nullptr,  // xSavepoint
     nullptr,  // xRelease
     nullptr,  // xRollbackTo
+#if SQLITE_VERSION_NUMBER >= 3025003L /* should be the first version with the below symbols */
+    nullptr,  // xShadowName
+#endif
 #endif
 };
 

--- a/gdal/port/cpl_json.cpp
+++ b/gdal/port/cpl_json.cpp
@@ -1165,7 +1165,7 @@ CPLJSONArray::CPLJSONArray(const CPLJSONObject &other) : CPLJSONObject(other)
 int CPLJSONArray::Size() const
 {
     if( m_poJsonObject )
-        return json_object_array_length( TO_JSONOBJ(m_poJsonObject) );
+        return static_cast<int>(json_object_array_length( TO_JSONOBJ(m_poJsonObject) ));
     return 0;
 }
 


### PR DESCRIPTION

## What does this PR do?

Resolve 64-bit build failures on OSX 10.12.6., following .travis.yml and using gdal/ci/travis/osx/*.sh. Updates assignment of the return value from json_object_array_lenght() to type 'auto' instead of 'int'. Some issues resolved by applying static_cast<int>().

## What are related issues/pull requests?

None.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

OSX 10.12.6, xcode, homebrew