### PR TITLE
Tests: Some test cleanup, mostly boilerplate removal

### DIFF
--- a/autotest/README.md
+++ b/autotest/README.md
@@ -47,6 +47,39 @@ Practically, this means that you should avoid using:
 
 This will hopefully be addressed in the future. When writing new tests, please try to make them independent of each other.
 
+## Writing tests
+
+Tests are automatically discovered in all files under `autotest/`. Tests should be functions with names starting with `test_`.
+
+A few helpers are available in `conftest.py`. In particular, `require_driver` and `require_ogr_driver` skip tests when GDAL is not built with the given driver:
+
+```python
+import pytest
+import gdaltest
+import ogrtest
+
+@pytest.mark.require_driver('JPIPKAK')
+def test_jpipkak_driver_1():
+    # this test will only run if GDAL is built with the JPIPKAK driver.
+    # The driver itself becomes available on the gdaltest or ogrtest module
+    # (name is lowercased and spaces replaced with underscores)
+    assert gdaltest.jpipkak_drv
+
+@pytest.mark.require_ogr_driver('Mapinfo File')
+def test_mapinfo_file_1():
+    # (name is lowercased and spaces replaced with underscores)
+    assert ogrtest.mapinfo_file_drv
+```
+
+This can also be done for an entire test module by setting the `pytestmark` property.
+
+```python
+import pytest
+
+pytestmark = pytest.mark.require_driver('JPIPKAK')
+```
+
+For more information, see the [pytest docs](https://docs.pytest.org/en/latest/)
 
 ## Notes about availability of GDAL sample and test data
 
@@ -54,6 +87,8 @@ The GDAL Team makes every effort to assure that all sample data files
 available from GDAL download server (http://download.osgeo.org/gdal/data/) and
 test data files used in GDAL Autotest package (https://github.com/OSGeo/gdal/tree/master/autotest)
 are available as public and freely redistributable geodata.
+
+
 
 --
 

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -50,12 +50,8 @@ import struct
 # Upsampling
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_1():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_near.vrt')
     ref_ds = gdal.Open('data/utmsmall_near.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -65,12 +61,8 @@ def test_warp_1():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_1_short():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_near_short.vrt')
     ref_ds = gdal.Open('data/utmsmall_near.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -80,12 +72,8 @@ def test_warp_1_short():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_1_ushort():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_near_ushort.vrt')
     ref_ds = gdal.Open('data/utmsmall_near.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -95,12 +83,8 @@ def test_warp_1_ushort():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_1_float():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_near_float.vrt')
     ref_ds = gdal.Open('data/utmsmall_near.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -110,12 +94,8 @@ def test_warp_1_float():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_2():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_blinear.vrt')
     ref_ds = gdal.Open('data/utmsmall_blinear.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -125,12 +105,8 @@ def test_warp_2():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_2_short():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_blinear_short.vrt')
     ref_ds = gdal.Open('data/utmsmall_blinear.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -140,12 +116,8 @@ def test_warp_2_short():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_2_ushort():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_blinear_ushort.vrt')
     ref_ds = gdal.Open('data/utmsmall_blinear.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -155,12 +127,8 @@ def test_warp_2_ushort():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_2_downsize():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_bilinear_2.vrt')
     ref_ds = gdal.Open('data/utmsmall_bilinear_2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -170,12 +138,8 @@ def test_warp_2_downsize():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_3():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubic.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubic.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -185,12 +149,8 @@ def test_warp_3():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_3_short():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubic_short.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubic.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -200,12 +160,8 @@ def test_warp_3_short():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_3_ushort():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubic_ushort.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubic.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -215,12 +171,8 @@ def test_warp_3_ushort():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_3_downsize():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubic_2.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubic_2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -230,12 +182,8 @@ def test_warp_3_downsize():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_3_float_downsize():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubic_2_float.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubic_2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -245,12 +193,8 @@ def test_warp_3_float_downsize():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_4():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubicspline.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubicspline.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -260,12 +204,8 @@ def test_warp_4():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_4_short():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubicspline_short.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubicspline.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -275,12 +215,8 @@ def test_warp_4_short():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_4_ushort():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubicspline_ushort.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubicspline.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -290,12 +226,8 @@ def test_warp_4_ushort():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_4_downsize():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubicspline_2.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubicspline_2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -305,12 +237,8 @@ def test_warp_4_downsize():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_4_short_downsize():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubicspline_wt_short.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubicspline_2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -320,12 +248,8 @@ def test_warp_4_short_downsize():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_4_float_downsize():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_cubicspline_wt_float32.vrt')
     ref_ds = gdal.Open('data/utmsmall_cubicspline_2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -335,12 +259,8 @@ def test_warp_4_float_downsize():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_5():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_lanczos.vrt')
     ref_ds = gdal.Open('data/utmsmall_lanczos.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -350,12 +270,8 @@ def test_warp_5():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_5_downsize():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_lanczos_2.vrt')
     ref_ds = gdal.Open('data/utmsmall_lanczos_2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -367,45 +283,29 @@ def test_warp_5_downsize():
 # Downsampling
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_6():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('VRT', 'utmsmall_ds_near.vrt', 1, 4770)
 
     return tst.testOpen()
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_7():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('VRT', 'utmsmall_ds_blinear.vrt', 1, 4755)
 
     return tst.testOpen()
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_8():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('VRT', 'utmsmall_ds_cubic.vrt', 1, 4833)
 
     return tst.testOpen()
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_9():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_ds_cubicspline.vrt')
     ref_ds = gdal.Open('data/utmsmall_ds_cubicspline.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -415,12 +315,8 @@ def test_warp_9():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_10():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_ds_lanczos.vrt')
     ref_ds = gdal.Open('data/utmsmall_ds_lanczos.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -430,12 +326,8 @@ def test_warp_10():
     assert maxdiff <= 1, 'Image too different from reference'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_11():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('VRT', 'rgbsmall_dstalpha.vrt', 4, 30658)
 
     return tst.testOpen()
@@ -443,13 +335,9 @@ def test_warp_11():
 # Test warping an empty RGBA with bilinear resampling
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_12():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.tiff_drv.Create('tmp/empty.tif', 20, 20, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/empty.tif', 20, 20, 4)
     ds.GetRasterBand(1).Fill(0)
     ds.GetRasterBand(2).Fill(0)
     ds.GetRasterBand(3).Fill(0)
@@ -461,20 +349,16 @@ def test_warp_12():
 
     ret = tst.testOpen()
 
-    gdaltest.tiff_drv.Delete('tmp/empty.tif')
+    gdaltest.gtiff_drv.Delete('tmp/empty.tif')
 
     return ret
 
 # Test warping an empty RGBA with cubic resampling
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_13():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.tiff_drv.Create('tmp/empty.tif', 20, 20, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/empty.tif', 20, 20, 4)
     ds.GetRasterBand(1).Fill(0)
     ds.GetRasterBand(2).Fill(0)
     ds.GetRasterBand(3).Fill(0)
@@ -486,20 +370,16 @@ def test_warp_13():
 
     ret = tst.testOpen()
 
-    gdaltest.tiff_drv.Delete('tmp/empty.tif')
+    gdaltest.gtiff_drv.Delete('tmp/empty.tif')
 
     return ret
 
 # Test warping an empty RGBA with cubic spline resampling
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_14():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.tiff_drv.Create('tmp/empty.tif', 20, 20, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/empty.tif', 20, 20, 4)
     ds.GetRasterBand(1).Fill(0)
     ds.GetRasterBand(2).Fill(0)
     ds.GetRasterBand(3).Fill(0)
@@ -511,20 +391,16 @@ def test_warp_14():
 
     ret = tst.testOpen()
 
-    gdaltest.tiff_drv.Delete('tmp/empty.tif')
+    gdaltest.gtiff_drv.Delete('tmp/empty.tif')
 
     return ret
 
 # Test GWKNearestFloat with transparent source alpha band
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_15():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.tiff_drv.Create('tmp/test.tif', 20, 20, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/test.tif', 20, 20, 4)
     ds.GetRasterBand(1).Fill(0)
     ds.GetRasterBand(2).Fill(0)
     ds.GetRasterBand(3).Fill(0)
@@ -536,20 +412,16 @@ def test_warp_15():
 
     ret = tst.testOpen()
 
-    gdaltest.tiff_drv.Delete('tmp/test.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test.tif')
 
     return ret
 
 # Test GWKNearestFloat with opaque source alpha band
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_16():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.tiff_drv.Create('tmp/test.tif', 20, 20, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/test.tif', 20, 20, 4)
     ds.GetRasterBand(1).Fill(255)
     ds.GetRasterBand(2).Fill(0)
     ds.GetRasterBand(3).Fill(0)
@@ -561,20 +433,16 @@ def test_warp_16():
 
     ret = tst.testOpen()
 
-    gdaltest.tiff_drv.Delete('tmp/test.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test.tif')
 
     return ret
 
 # Test GWKNearestShort with transparent source alpha band
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_17():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.tiff_drv.Create('tmp/test.tif', 20, 20, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/test.tif', 20, 20, 4)
     ds.GetRasterBand(1).Fill(0)
     ds.GetRasterBand(2).Fill(0)
     ds.GetRasterBand(3).Fill(0)
@@ -586,20 +454,16 @@ def test_warp_17():
 
     ret = tst.testOpen()
 
-    gdaltest.tiff_drv.Delete('tmp/test.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test.tif')
 
     return ret
 
 # Test GWKNearestShort with opaque source alpha band
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_18():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.tiff_drv.Create('tmp/test.tif', 20, 20, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/test.tif', 20, 20, 4)
     ds.GetRasterBand(1).Fill(255)
     ds.GetRasterBand(2).Fill(0)
     ds.GetRasterBand(3).Fill(0)
@@ -611,14 +475,14 @@ def test_warp_18():
 
     ret = tst.testOpen()
 
-    gdaltest.tiff_drv.Delete('tmp/test.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test.tif')
 
     return ret
 
 
 def warp_19_internal(size, datatype, resampling_string):
 
-    ds = gdaltest.tiff_drv.Create('tmp/test.tif', size, size, 1, datatype)
+    ds = gdaltest.gtiff_drv.Create('tmp/test.tif', size, size, 1, datatype)
     ds.SetGeoTransform((10, 5, 0, 30, 0, -5))
     ds.SetProjection('GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]')
     ds.GetRasterBand(1).Fill(10.1, 20.1)
@@ -633,21 +497,17 @@ def warp_19_internal(size, datatype, resampling_string):
     ds = None
     ref_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/testwarp.tif')
+    gdaltest.gtiff_drv.Delete('tmp/testwarp.tif')
 
     assert checksum == checksum_ref
 
-    gdaltest.tiff_drv.Delete('tmp/test.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test.tif')
 
 
 # Test all data types and resampling methods for very small images
 # to test edge behaviour
+@pytest.mark.require_driver('GTiff')
 def test_warp_19():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     datatypes = [gdal.GDT_Byte,
                  gdal.GDT_Int16,
                  gdal.GDT_CInt16,
@@ -672,12 +532,8 @@ def test_warp_19():
 
 
 # Test fix for #2724 (initialization of destination area to nodata in warped VRT)
+@pytest.mark.require_driver('GTiff')
 def test_warp_20():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('VRT', 'white_nodata.vrt', 1, 1705)
 
     return tst.testOpen()
@@ -709,12 +565,13 @@ def test_warp_21():
 # Would have detected issue of #3458
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_22():
 
     # Generate source image with non uniform data
     w = 1001
     h = 1001
-    ds = gdal.GetDriverByName('GTiff').Create("tmp/warp_22_src.tif", w, h, 1)
+    ds = gdaltest.gtiff_drv.Create("tmp/warp_22_src.tif", w, h, 1)
     ds.SetGeoTransform([2, 0.01, 0, 49, 0, -0.01])
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(4326)
@@ -763,6 +620,7 @@ def test_warp_22():
 # Test warping with datasets where some RasterIO() requests involve nBufXSize == 0 (#3582)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_23():
 
     gcp1 = gdal.GCP()
@@ -817,7 +675,7 @@ def test_warp_23():
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(4326)
 
-    ds = gdal.GetDriverByName('GTiff').Create('tmp/test3582.tif', 70, 170, 4, options=['SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/test3582.tif', 70, 170, 4, options=['SPARSE_OK=YES'])
     for i, gcp in enumerate(gcps):
         gcps[i].GCPPixel = gcp.GCPPixel / 10
         gcps[i].GCPLine = gcp.GCPLine / 10
@@ -892,6 +750,7 @@ def warp_27_progress_callback(pct, message, user_data):
     return 1  # 1 to continue, 0 to stop
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_27():
 
     # Open source dataset
@@ -917,7 +776,7 @@ def test_warp_27():
     tmp_ds = None
 
     # Now create the true target dataset
-    dst_ds = gdal.GetDriverByName('GTiff').Create('tmp/warp_27.tif', dst_xsize, dst_ysize,
+    dst_ds = gdaltest.gtiff_drv.Create('tmp/warp_27.tif', dst_xsize, dst_ysize,
                                                   src_ds.RasterCount)
     dst_ds.SetProjection(dst_wkt)
     dst_ds.SetGeoTransform(dst_gt)
@@ -1034,6 +893,7 @@ def warp_30_progress_callback(pct, message, user_data):
     return bool(pct <= 0.2)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_30():
 
     # Open source dataset
@@ -1059,7 +919,7 @@ def test_warp_30():
     tmp_ds = None
 
     # Now create the true target dataset
-    dst_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/warp_30.tif', dst_xsize, dst_ysize,
+    dst_ds = gdaltest.gtiff_drv.Create('/vsimem/warp_30.tif', dst_xsize, dst_ysize,
                                                   src_ds.RasterCount)
     dst_ds.SetProjection(dst_wkt)
     dst_ds.SetGeoTransform(dst_gt)
@@ -1105,12 +965,8 @@ def test_warp_30():
 # Average (Byte)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_31():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_average.vrt')
     ref_ds = gdal.Open('data/utmsmall_average.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1122,12 +978,8 @@ def test_warp_31():
 # Average (Float)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_32():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_average_float.vrt')
     ref_ds = gdal.Open('data/utmsmall_average_float.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1139,12 +991,8 @@ def test_warp_32():
 # Mode (Byte)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_33():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_mode.vrt')
     ref_ds = gdal.Open('data/utmsmall_mode.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1156,12 +1004,8 @@ def test_warp_33():
 # Mode (Int16)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_34():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_mode_int16.vrt')
     ref_ds = gdal.Open('data/utmsmall_mode_int16.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1173,12 +1017,8 @@ def test_warp_34():
 # Mode (Int16 - signed with negative values)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_35():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall-int16-neg_mode.vrt')
     ref_ds = gdal.Open('data/utmsmall-int16-neg_mode.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1190,12 +1030,8 @@ def test_warp_35():
 # Mode (Int32) - this uses algorithm 2 (inefficient)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_36():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_mode_int32.vrt')
     ref_ds = gdal.Open('data/utmsmall_mode_int32.tiff')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1236,11 +1072,12 @@ def test_warp_37():
 # Test a warp with GCPs on the *destination* image.
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_38():
 
     # Create an output file with GCPs.
     out_file = 'tmp/warp_38.tif'
-    ds = gdal.GetDriverByName('GTiff').Create(out_file, 50, 50, 3)
+    ds = gdaltest.gtiff_drv.Create(out_file, 50, 50, 3)
 
     gcp_list = [
         gdal.GCP(397000, 5642000, 0, 0, 0),
@@ -1268,11 +1105,12 @@ def test_warp_38():
 # Test a warp with GCPs for TPS on the *destination* image.
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_39():
 
     # Create an output file with GCPs.
     out_file = 'tmp/warp_39.tif'
-    ds = gdal.GetDriverByName('GTiff').Create(out_file, 50, 50, 3)
+    ds = gdaltest.gtiff_drv.Create(out_file, 50, 50, 3)
 
     gcp_list = [
         gdal.GCP(397000, 5642000, 0, 0, 0),
@@ -1300,12 +1138,8 @@ def test_warp_39():
 # test average (#5311)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_40():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/2by2.vrt')
     ref_ds = gdal.Open('data/2by2.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1347,12 +1181,8 @@ def test_warp_41():
 # Maximum
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_42():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_max.vrt')
     ref_ds = gdal.Open('data/utmsmall_max.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1364,12 +1194,8 @@ def test_warp_42():
 # Minimum
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_43():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_min.vrt')
     ref_ds = gdal.Open('data/utmsmall_min.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1381,12 +1207,8 @@ def test_warp_43():
 # Median
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_44():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_med.vrt')
     ref_ds = gdal.Open('data/utmsmall_med.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1398,12 +1220,8 @@ def test_warp_44():
 # Quartile 1
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_45():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_Q1.vrt')
     ref_ds = gdal.Open('data/utmsmall_Q1.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1415,12 +1233,8 @@ def test_warp_45():
 # Quartile 3
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_46():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall_Q3.vrt')
     ref_ds = gdal.Open('data/utmsmall_Q3.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1432,12 +1246,8 @@ def test_warp_46():
 # Maximum (Int16 - signed with negative values)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_47():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall-int16-neg_max.vrt')
     ref_ds = gdal.Open('data/utmsmall-int16-neg_max.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1449,12 +1259,8 @@ def test_warp_47():
 # Minimum (Int16 - signed with negative values)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_48():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall-int16-neg_min.vrt')
     ref_ds = gdal.Open('data/utmsmall-int16-neg_min.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1466,12 +1272,8 @@ def test_warp_48():
 # Median (Int16 - signed with negative values)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_49():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall-int16-neg_med.vrt')
     ref_ds = gdal.Open('data/utmsmall-int16-neg_med.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1483,12 +1285,8 @@ def test_warp_49():
 # Quartile 1 (Int16 - signed with negative values)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_50():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall-int16-neg_Q1.vrt')
     ref_ds = gdal.Open('data/utmsmall-int16-neg_Q1.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)
@@ -1500,12 +1298,8 @@ def test_warp_50():
 # Quartile 3 (Int16 - signed with negative values)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_warp_51():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.tiff_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/utmsmall-int16-neg_Q3.vrt')
     ref_ds = gdal.Open('data/utmsmall-int16-neg_Q3.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds)

--- a/autotest/gcore/gdal_stats.py
+++ b/autotest/gcore/gdal_stats.py
@@ -40,12 +40,8 @@ import pytest
 # Test handling NaN with GDT_Float32 data
 
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_nan_1():
-
-    gdaltest.gtiff_drv = gdal.GetDriverByName('GTiff')
-    if gdaltest.gtiff_drv is None:
-        pytest.skip()
-
     stats = (50.0, 58.0, 54.0, 2.5819888974716)
 
     shutil.copyfile('data/nan32.tif', 'tmp/nan32.tif')
@@ -61,11 +57,8 @@ def test_stats_nan_1():
 # Test handling NaN with GDT_Float64 data
 
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_nan_2():
-
-    if gdaltest.gtiff_drv is None:
-        pytest.skip()
-
     stats = (50.0, 58.0, 54.0, 2.5819888974716)
 
     shutil.copyfile('data/nan64.tif', 'tmp/nan64.tif')
@@ -81,11 +74,8 @@ def test_stats_nan_2():
 # Test stats on signed byte (#3151)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_signedbyte():
-
-    if gdaltest.gtiff_drv is None:
-        pytest.skip()
-
     stats = (-128.0, 127.0, -0.2, 80.64)
 
     shutil.copyfile('data/stats_signed_byte.img', 'tmp/stats_signed_byte.img')
@@ -102,6 +92,7 @@ def test_stats_signedbyte():
 # Test return of GetStatistics() when we don't have stats and don't
 # force their computation (#3572)
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_dont_force():
 
     gdal.Unlink('data/byte.tif.aux.xml')
@@ -114,6 +105,7 @@ def test_stats_dont_force():
 # Test statistics when stored nodata value doesn't accurately match the nodata
 # value used in the imagery (#3573)
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_approx_nodata():
 
     shutil.copyfile('data/minfloat.tif', 'tmp/minfloat.tif')
@@ -151,6 +143,7 @@ def test_stats_approx_nodata():
 ###############################################################################
 # Test read and copy of dataset with nan as nodata value (#3576)
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_nan_3():
 
     src_ds = gdal.Open('data/nan32_nodata.tif')
@@ -188,13 +181,14 @@ def test_stats_nan_4():
 
     assert cs == 874, 'did not get expected checksum'
 
-    assert gdaltest.isnan(nodata), ('expected nan, got %f' % nodata)
+    assert gdaltest.isnan(nodata)
 
 ###############################################################################
 # Test reading a VRT with a complex source that define 0 as band nodata
 # and complex source nodata (nan must be translated to 0 then) (#3576)
 
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_nan_5():
 
     ds = gdal.Open('data/nan32_nodata_nan_to_zero.vrt')
@@ -260,6 +254,7 @@ def stats_nodata_inf_progress_cbk(value, string, extra):
     extra[0] = value
 
 
+@pytest.mark.require_driver('HFA')
 def test_stats_nodata_inf():
 
     ds = gdal.GetDriverByName('HFA').Create('/vsimem/stats_nodata_inf.img', 3, 1, 1, gdal.GDT_Float32)
@@ -290,14 +285,17 @@ def stats_nodata_check(filename, expected_nodata):
     assert nodata == expected_nodata, 'did not get expected nodata value'
 
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_nodata_neginf_linux():
     return stats_nodata_check('data/stats_nodata_neginf.tif', gdaltest.neginf())
 
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_nodata_neginf_msvc():
     return stats_nodata_check('data/stats_nodata_neginf_msvc.tif', gdaltest.neginf())
 
 
+@pytest.mark.require_driver('GTiff')
 def test_stats_nodata_posinf_linux():
     return stats_nodata_check('data/stats_nodata_posinf.tif', gdaltest.posinf())
 

--- a/autotest/gcore/hdf4_read.py
+++ b/autotest/gcore/hdf4_read.py
@@ -34,6 +34,9 @@ from osgeo import gdal
 
 pytestmark = pytest.mark.require_driver('HDF4')
 
+pytestmark = pytest.mark.require_driver('HDF4')
+
+
 init_list = [
     ('byte_3.hdf', 4672),
     ('int16_3.hdf', 4672),
@@ -95,12 +98,6 @@ def test_hdf4_read_gr_palette():
 
 
 def test_hdf4_read_online_1():
-
-    gdaltest.hdf4_drv = gdal.GetDriverByName('HDF4')
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/hdf4/A2004259075000.L2_LAC_SST.hdf', 'A2004259075000.L2_LAC_SST.hdf'):
         pytest.skip()
 
@@ -113,10 +110,6 @@ def test_hdf4_read_online_1():
 
 
 def test_hdf4_read_online_2():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/hdf4/A2006005182000.L2_LAC_SST.x.hdf', 'A2006005182000.L2_LAC_SST.x.hdf'):
         pytest.skip()
 
@@ -136,10 +129,6 @@ def test_hdf4_read_online_2():
 # Test HDF4_EOS:EOS_GRID
 
 def test_hdf4_read_online_3():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/hdf4/MO36MW14.chlor_MODIS.ADD2001089.004.2002186190207.hdf', 'MO36MW14.chlor_MODIS.ADD2001089.004.2002186190207.hdf'):
         pytest.skip()
 
@@ -163,10 +152,6 @@ def test_hdf4_read_online_3():
 
 
 def test_hdf4_read_online_4():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/hdf4/S2002196124536.L1A_HDUN.BartonBendish.extract.hdf', 'S2002196124536.L1A_HDUN.BartonBendish.extract.hdf'):
         pytest.skip()
 
@@ -184,10 +169,6 @@ def test_hdf4_read_online_4():
 
 
 def test_hdf4_read_online_5():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     # 13 MB
     if not gdaltest.download_file('ftp://data.nodc.noaa.gov/pub/data.nodc/pathfinder/Version5.0/Monthly/1991/199101.s04m1pfv50-sst-16b.hdf', '199101.s04m1pfv50-sst-16b.hdf'):
         pytest.skip()
@@ -201,10 +182,6 @@ def test_hdf4_read_online_5():
 
 
 def test_hdf4_read_online_6():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     # 1 MB
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/hdf4/MOD09Q1G_EVI.A2006233.h07v03.005.2008338190308.hdf', 'MOD09Q1G_EVI.A2006233.h07v03.005.2008338190308.hdf'):
         pytest.skip()
@@ -230,10 +207,6 @@ def test_hdf4_read_online_6():
 
 
 def test_hdf4_read_online_7():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     # 4 MB
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/hdf4/MOD09A1.A2010041.h06v03.005.2010051001103.hdf', 'MOD09A1.A2010041.h06v03.005.2010051001103.hdf'):
         pytest.skip()
@@ -259,10 +232,6 @@ def test_hdf4_read_online_7():
 # but that will lead to very poor performance (#3386)
 
 def test_hdf4_read_online_8():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     # 5 MB
     if not gdaltest.download_file('https://e4ftl01.cr.usgs.gov/MOLT/MOD13Q1.006/2006.06.10/MOD13Q1.A2006161.h34v09.006.2015161173716.hdf', 'MOD13Q1.A2006161.h34v09.006.2015161173716.hdf'):
         pytest.skip()
@@ -289,10 +258,6 @@ def test_hdf4_read_online_8():
 
 
 def test_hdf4_read_online_9():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.geogratis.cgdi.gc.ca/download/landsat_7/hdf/L71002025_02520010722/L71002025_02520010722_MTL.L1G', 'L71002025_02520010722_MTL.L1G'):
         pytest.skip()
 
@@ -313,10 +278,6 @@ def test_hdf4_read_online_9():
 
 
 def test_hdf4_read_online_10():
-
-    if gdaltest.hdf4_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://trac.osgeo.org/gdal/raw-attachment/ticket/4672/MOD16A2.A2000M01.h14v02.105.2010357183410.hdf', 'MOD16A2.A2000M01.h14v02.105.2010357183410.hdf'):
         pytest.skip()
 

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -30,17 +30,19 @@
 ###############################################################################
 
 
-
 import gdaltest
 from osgeo import gdal
 import pytest
+
+
+pytestmark = pytest.mark.require_driver('NUMPY')
 
 ###############################################################################
 # verify that we can load Numeric python, and find the Numpy driver.
 
 
-def test_numpy_rw_1():
-
+@pytest.fixture(autouse=True, scope='module')
+def numpy_init():
     gdaltest.numpy_drv = None
     try:
         from osgeo import gdalnumeric
@@ -50,18 +52,14 @@ def test_numpy_rw_1():
 
     gdal.AllRegister()
 
-    gdaltest.numpy_drv = gdal.GetDriverByName('NUMPY')
-    assert gdaltest.numpy_drv is not None, 'NUMPY driver not found!'
+    yield
+
 
 ###############################################################################
 # Load a test file into a memory Numpy array, and verify the checksum.
 
 
 def test_numpy_rw_2():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     from osgeo import gdalnumeric
 
     array = gdalnumeric.LoadFile('data/utmsmall.tif')
@@ -79,10 +77,6 @@ def test_numpy_rw_2():
 
 
 def test_numpy_rw_3():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/cint_sar.tif')
     array = ds.ReadAsArray()
 
@@ -93,10 +87,6 @@ def test_numpy_rw_3():
 
 
 def test_numpy_rw_4():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte.tif')
     array = ds.GetRasterBand(1).ReadAsArray(0, 0, 20, 20, 5, 5)
 
@@ -108,10 +98,6 @@ def test_numpy_rw_4():
 
 
 def test_numpy_rw_5():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     from osgeo import gdalnumeric
 
     array = gdalnumeric.LoadFile('data/rgbsmall.tif', 35, 21, 1, 1)
@@ -140,10 +126,6 @@ def test_numpy_rw_5():
 
 
 def test_numpy_rw_6():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     from osgeo import gdalnumeric
 
@@ -161,10 +143,6 @@ def test_numpy_rw_6():
 
 
 def test_numpy_rw_7():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     from osgeo import gdalnumeric
 
@@ -201,10 +179,6 @@ def test_numpy_rw_7():
 
 
 def test_numpy_rw_8():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     from osgeo import gdalnumeric
 
@@ -222,10 +196,6 @@ def test_numpy_rw_8():
 
 
 def test_numpy_rw_9():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte.tif')
     array = ds.ReadAsArray()
 
@@ -242,10 +212,6 @@ def test_numpy_rw_9():
 
 
 def test_numpy_rw_10():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
 
     ds = gdal.GetDriverByName('GTiff').Create('/vsimem/signed8.tif', 2, 1, options=['PIXELTYPE=SIGNEDBYTE'])
@@ -272,10 +238,6 @@ def test_numpy_rw_10():
 
 
 def test_numpy_rw_11():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     from osgeo import gdal_array
 
@@ -334,10 +296,6 @@ def test_numpy_rw_11():
 
 
 def test_numpy_rw_12():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
 
     ar = numpy.empty([2, 2], dtype=numpy.uint8)
@@ -363,10 +321,6 @@ def test_numpy_rw_12():
 
 
 def test_numpy_rw_13():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
 
     drv = gdal.GetDriverByName('MEM')
@@ -538,10 +492,6 @@ def numpy_rw_14_progress_callback_2(pct, message, user_data):
 
 
 def test_numpy_rw_14():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     # Progress not implemented yet
     if gdal.GetConfigOption('GTIFF_DIRECT_IO') == 'YES' or \
        gdal.GetConfigOption('GTIFF_VIRTUAL_MEM_IO') == 'YES':
@@ -602,10 +552,6 @@ def test_numpy_rw_14():
 
 
 def test_numpy_rw_15():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     from osgeo import gdal_array
 
@@ -622,10 +568,6 @@ def test_numpy_rw_15():
 
 
 def test_numpy_rw_16():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     from osgeo import gdal_array
 
@@ -652,10 +594,6 @@ def test_numpy_rw_16():
 
 
 def test_numpy_rw_17():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     from osgeo import gdal_array
 
@@ -680,10 +618,6 @@ def test_numpy_rw_17():
 
 
 def test_numpy_rw_18():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     import numpy
     import numpy.random
     from osgeo import gdal_array
@@ -706,10 +640,6 @@ def test_numpy_rw_18():
 # The VRT references a non existing TIF file, but using the proxy pool dataset API (#2837)
 
 def test_numpy_rw_failure_in_readasarray():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/idontexist2.vrt')
     assert ds is not None
 
@@ -728,11 +658,3 @@ def test_numpy_rw_failure_in_readasarray():
         except RuntimeError:
             exception_raised = True
     assert exception_raised
-
-
-
-def test_numpy_rw_cleanup():
-    gdaltest.numpy_drv = None
-
-
-

--- a/autotest/gcore/numpy_rw_multidim.py
+++ b/autotest/gcore/numpy_rw_multidim.py
@@ -30,36 +30,30 @@
 
 
 
-import gdaltest
 from osgeo import gdal
 import pytest
 import struct
 
+
 ###############################################################################
 # verify that we can load Numeric python, and find the Numpy driver.
 
+pytestmark = pytest.mark.require_driver('NUMPY')
 
-def test_numpy_rw_multidim_init():
 
-    gdaltest.numpy_drv = None
+@pytest.fixture(autouse=True, scope='module')
+def gdalnumeric_is_present():
     try:
         from osgeo import gdalnumeric
         gdalnumeric.zeros
     except (ImportError, AttributeError):
         pytest.skip()
 
-    gdal.AllRegister()
-
-    gdaltest.numpy_drv = gdal.GetDriverByName('NUMPY')
-    assert gdaltest.numpy_drv is not None, 'NUMPY driver not found!'
 
 ###############################################################################
 
 
 def test_numpy_rw_multidim_readasarray_writearray():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
     import numpy as np
 
     drv = gdal.GetDriverByName('MEM')
@@ -84,9 +78,6 @@ def test_numpy_rw_multidim_readasarray_writearray():
 
 
 def test_numpy_rw_multidim_numpy_array_as_dataset():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
     from osgeo import gdalnumeric
     import numpy as np
 
@@ -104,9 +95,6 @@ def test_numpy_rw_multidim_numpy_array_as_dataset():
 
 
 def test_numpy_rw_multidim_readasarray_writearray_negative_strides():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
     import numpy as np
 
     drv = gdal.GetDriverByName('MEM')
@@ -132,9 +120,6 @@ def test_numpy_rw_multidim_readasarray_writearray_negative_strides():
 
 
 def test_numpy_rw_multidim_numpy_array_as_dataset_negative_strides():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
     from osgeo import gdalnumeric
     import numpy as np
 
@@ -153,9 +138,6 @@ def test_numpy_rw_multidim_numpy_array_as_dataset_negative_strides():
 
 
 def test_numpy_rw_multidim_compound_datatype():
-
-    if gdaltest.numpy_drv is None:
-        pytest.skip()
     from osgeo import gdalnumeric
     import numpy as np
 

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -43,6 +43,9 @@ import pytest
 import gdaltest
 
 
+pytestmark = pytest.mark.require_driver('GTiff')
+
+
 @pytest.fixture(params=['invert', 'dont-invert'])
 def both_endian(request):
     """
@@ -86,14 +89,11 @@ def tiff_ovr_check(src_ds):
 
 
 def test_tiff_ovr_1(both_endian):
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-
     src_ds = gdal.Open('data/mfloat32.vrt')
 
     assert src_ds is not None, 'Failed to open test dataset.'
 
-    gdaltest.tiff_drv.CreateCopy('tmp/mfloat32.tif', src_ds,
+    gdaltest.gtiff_drv.CreateCopy('tmp/mfloat32.tif', src_ds,
                                  options=['INTERLEAVE=PIXEL'])
     src_ds = None
 
@@ -319,7 +319,7 @@ def test_tiff_ovr_8(both_endian):
 
 
 def test_tiff_ovr_9(both_endian):
-    gdaltest.tiff_drv.Delete('tmp/ovr9.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr9.tif')
 
     shutil.copyfile('data/rgbsmall.tif', 'tmp/ovr9.tif')
 
@@ -358,7 +358,7 @@ def test_tiff_ovr_10(both_endian):
 
     assert src_ds is not None, 'Failed to open test dataset.'
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/ovr10.tif', src_ds, options=['COMPRESS=JPEG', 'PHOTOMETRIC=YCBCR'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/ovr10.tif', src_ds, options=['COMPRESS=JPEG', 'PHOTOMETRIC=YCBCR'])
     src_ds = None
 
     assert ds is not None, 'Failed to apply JPEG compression.'
@@ -387,7 +387,7 @@ def test_tiff_ovr_11(both_endian):
 
     assert src_ds is not None, 'Failed to open test dataset.'
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/ovr11.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/ovr11.tif', src_ds)
     src_ds = None
 
     ds.BuildOverviews('AVERAGE', overviewlist=[2])
@@ -416,7 +416,7 @@ def test_tiff_ovr_12(both_endian):
 
     assert src_ds is not None, 'Failed to open test dataset.'
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/ovr12.tif', src_ds, options=['COMPRESS=DEFLATE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/ovr12.tif', src_ds, options=['COMPRESS=DEFLATE'])
     src_ds = None
 
     ds.BuildOverviews('AVERAGE', overviewlist=[2])
@@ -439,14 +439,11 @@ def test_tiff_ovr_12(both_endian):
 # Test gaussian resampling
 
 def test_tiff_ovr_13(both_endian):
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-
     src_ds = gdal.Open('data/mfloat32.vrt')
 
     assert src_ds is not None, 'Failed to open test dataset.'
 
-    gdaltest.tiff_drv.CreateCopy('tmp/mfloat32.tif', src_ds,
+    gdaltest.gtiff_drv.CreateCopy('tmp/mfloat32.tif', src_ds,
                                  options=['INTERLEAVE=PIXEL'])
     src_ds = None
 
@@ -496,7 +493,7 @@ def test_tiff_ovr_15(both_endian):
 
     assert src_ds is not None, 'Failed to open test dataset.'
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/ovr15.tif', src_ds, options=['COMPRESS=DEFLATE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/ovr15.tif', src_ds, options=['COMPRESS=DEFLATE'])
     src_ds = None
 
     ds.BuildOverviews('GAUSS', overviewlist=[2])
@@ -519,14 +516,11 @@ def test_tiff_ovr_15(both_endian):
 # Test mode resampling on non-byte dataset
 
 def test_tiff_ovr_16(both_endian):
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-
     src_ds = gdal.Open('data/mfloat32.vrt')
 
     assert src_ds is not None, 'Failed to open test dataset.'
 
-    gdaltest.tiff_drv.CreateCopy('tmp/ovr16.tif', src_ds,
+    gdaltest.gtiff_drv.CreateCopy('tmp/ovr16.tif', src_ds,
                                  options=['INTERLEAVE=PIXEL'])
     src_ds = None
 
@@ -619,7 +613,7 @@ def test_tiff_ovr_19(both_endian):
 
 def test_tiff_ovr_20(both_endian):
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr20.tif', 100, 100, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr20.tif', 100, 100, 1)
     ds = None
 
     ds = gdal.Open('tmp/ovr20.tif')
@@ -646,7 +640,7 @@ def test_tiff_ovr_20(both_endian):
 
 def test_tiff_ovr_21(both_endian):
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr21.tif', 170000, 100000, 1, options=['SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr21.tif', 170000, 100000, 1, options=['SPARSE_OK=YES'])
     ds = None
 
     ds = gdal.Open('tmp/ovr21.tif')
@@ -673,8 +667,7 @@ def test_tiff_ovr_21(both_endian):
 
 
 def test_tiff_ovr_22(both_endian):
-
-    ds = gdaltest.tiff_drv.Create('tmp/ovr22.tif', 170000, 100000, 1, options=['SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr22.tif', 170000, 100000, 1, options=['SPARSE_OK=YES'])
     ds = None
 
     ds = gdal.Open('tmp/ovr22.tif')
@@ -699,8 +692,7 @@ def test_tiff_ovr_22(both_endian):
 
 
 def test_tiff_ovr_23(both_endian):
-
-    ds = gdaltest.tiff_drv.Create('tmp/ovr23.tif', 170000, 100000, 1, options=['SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr23.tif', 170000, 100000, 1, options=['SPARSE_OK=YES'])
     ds = None
 
     ds = gdal.Open('tmp/ovr23.tif')
@@ -727,8 +719,7 @@ def test_tiff_ovr_23(both_endian):
 
 
 def test_tiff_ovr_24(both_endian):
-
-    ds = gdaltest.tiff_drv.Create('tmp/ovr24.tif', 85000, 100000, 1, options=['SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr24.tif', 85000, 100000, 1, options=['SPARSE_OK=YES'])
     ds = None
 
     ds = gdal.Open('tmp/ovr24.tif')
@@ -758,7 +749,7 @@ def test_tiff_ovr_24(both_endian):
 
 def test_tiff_ovr_25(both_endian):
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr25.tif', 100, 100, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr25.tif', 100, 100, 1)
     ds.GetRasterBand(1).Fill(1)
     ds.GetRasterBand(1).FlushCache()
     ds.BuildOverviews('NEAR', overviewlist=[2])
@@ -779,7 +770,7 @@ def test_tiff_ovr_25(both_endian):
 
 def test_tiff_ovr_26(both_endian):
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr26.tif', 100, 100, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr26.tif', 100, 100, 1)
     ds.GetRasterBand(1).Fill(1)
     ds.GetRasterBand(1).FlushCache()
     ds.BuildOverviews('NEAR', overviewlist=[2])
@@ -798,7 +789,7 @@ def test_tiff_ovr_26(both_endian):
 
 def test_tiff_ovr_27(both_endian):
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr27.tif', 100, 100, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr27.tif', 100, 100, 1)
     ds.GetRasterBand(1).Fill(1)
     ds.GetRasterBand(1).FlushCache()
     ds.BuildOverviews('NEAR', overviewlist=[2, 4])
@@ -874,7 +865,7 @@ def test_tiff_ovr_29(both_endian):
 
 def test_tiff_ovr_30(both_endian):
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr30.tif', 20, 20, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr30.tif', 20, 20, 1)
     ds.BuildOverviews(overviewlist=[2])
     ds = None
 
@@ -882,7 +873,7 @@ def test_tiff_ovr_30(both_endian):
     ds.SetMetadata({'TEST_KEY': 'TestValue'})
     ds = None
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr30.tif', 20, 20, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr30.tif', 20, 20, 1)
     ds.BuildOverviews(overviewlist=[2])
     ds = None
 
@@ -901,7 +892,7 @@ def test_tiff_ovr_30(both_endian):
 
 def test_tiff_ovr_31(both_endian):
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr31.tif', 100, 100, 4)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr31.tif', 100, 100, 4)
     ds.GetRasterBand(1).Fill(255)
     ds.GetRasterBand(2).Fill(255)
     ds.GetRasterBand(3).Fill(255)
@@ -937,7 +928,7 @@ def test_tiff_ovr_32(both_endian):
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ovr32.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr32.tif')
 
     # Same, but with non-byte data type (help testing the non-SSE2 code path)
     src_ds = gdal.Open('data/stefan_full_rgba_photometric_rgb.tif')
@@ -962,8 +953,8 @@ def test_tiff_ovr_32(both_endian):
     src_ds = None
     tmp_ds = None
     tmp2_ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/ovr32_float.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/ovr32_byte.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/ovr32_float.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/ovr32_byte.tif')
 
     # Test GDALRegenerateOverviewsMultiBand
     shutil.copyfile('data/stefan_full_rgba_photometric_rgb.tif', 'tmp/ovr32.tif')
@@ -985,7 +976,7 @@ def test_tiff_ovr_32(both_endian):
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ovr32.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr32.tif')
 
     # 3 bands + alpha
     shutil.copyfile('data/stefan_full_rgba.tif', 'tmp/ovr32.tif')
@@ -1005,7 +996,7 @@ def test_tiff_ovr_32(both_endian):
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ovr32.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr32.tif')
 
     # Same, but with non-byte data type (help testing the non-SSE2 code path)
     src_ds = gdal.Open('data/stefan_full_rgba.tif')
@@ -1031,8 +1022,8 @@ def test_tiff_ovr_32(both_endian):
     src_ds = None
     tmp_ds = None
     tmp2_ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/ovr32_float.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/ovr32_byte.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/ovr32_float.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/ovr32_byte.tif')
 
     # Same test with a compressed dataset
     src_ds = gdal.Open('data/stefan_full_rgba.tif')
@@ -1051,7 +1042,7 @@ def test_tiff_ovr_32(both_endian):
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ovr32.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr32.tif')
 
 
 ###############################################################################
@@ -1064,13 +1055,13 @@ def test_tiff_ovr_33(both_endian):
     except OSError:
         pass
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr33.tif', 1, 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr33.tif', 1, 1, 1)
     ds = None
     ds = gdal.Open('tmp/ovr33.tif')
     ds.BuildOverviews('NEAREST', overviewlist=[2, 4])
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ovr33.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr33.tif')
 
 
 ###############################################################################
@@ -1079,7 +1070,7 @@ def test_tiff_ovr_33(both_endian):
 def test_tiff_ovr_34(both_endian):
 
     ds_in = gdal.Open('data/byte.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/ovr34.tif', ds_in)
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/ovr34.tif', ds_in)
     ds.BuildOverviews('NEAREST', overviewlist=[2])
     ds.GetRasterBand(1).GetOverview(0).Fill(32.0)
     ds = None
@@ -1093,7 +1084,7 @@ def test_tiff_ovr_34(both_endian):
         print('[%s]' % data)
         pytest.fail('did not get expected cleared overview.')
 
-    gdaltest.tiff_drv.Delete('tmp/ovr34.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr34.tif')
 
 ###############################################################################
 # Confirm that overviews are used on a Band.RasterIO().
@@ -1102,7 +1093,7 @@ def test_tiff_ovr_34(both_endian):
 def test_tiff_ovr_35(both_endian):
 
     ds_in = gdal.Open('data/byte.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/ovr35.tif', ds_in)
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/ovr35.tif', ds_in)
     ds.BuildOverviews('NEAREST', overviewlist=[2])
     ds.GetRasterBand(1).GetOverview(0).Fill(32.0)
     ds = None
@@ -1116,7 +1107,7 @@ def test_tiff_ovr_35(both_endian):
         print('[%s]' % data)
         pytest.fail('did not get expected cleared overview.')
 
-    gdaltest.tiff_drv.Delete('tmp/ovr35.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr35.tif')
 
 ###############################################################################
 # Confirm that overviews are used on a Band.RasterIO() when using BlockBasedRasterIO() (#3124)
@@ -1163,7 +1154,7 @@ def test_tiff_ovr_37(both_endian):
 def test_tiff_ovr_38(both_endian):
 
     src_ds = gdal.Open('../gdrivers/data/n43.dt0')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/ovr38.tif', src_ds, options=['COMPRESS=LZW', 'PREDICTOR=2'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/ovr38.tif', src_ds, options=['COMPRESS=LZW', 'PREDICTOR=2'])
     ds.BuildOverviews(overviewlist=[2, 4])
     ds = None
 
@@ -1295,7 +1286,7 @@ def test_tiff_ovr_41(both_endian):
     ds.BuildOverviews('NEAREST', overviewlist=[2])
     ds = None
 
-    # ds = gdaltest.tiff_drv.Create('tmp/ovr41.tif.handmade.ovr',50,50,1,options=['NBITS=1'])
+    # ds = gdaltest.gtiff_drv.Create('tmp/ovr41.tif.handmade.ovr',50,50,1,options=['NBITS=1'])
     # ds.GetRasterBand(1).WriteRaster(0,0,50,50,data)
     # ds = None
 
@@ -1317,7 +1308,7 @@ def test_tiff_ovr_42(both_endian):
     for i, data in enumerate(ct_data):
         ct.SetColorEntry(i, data)
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr42.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr42.tif', 1, 1)
     ds.GetRasterBand(1).SetRasterColorTable(ct)
     ds = None
 
@@ -1343,7 +1334,7 @@ def test_tiff_ovr_42(both_endian):
 
 def test_tiff_ovr_43(both_endian):
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -1361,7 +1352,7 @@ def test_tiff_ovr_43(both_endian):
         sys.stdout.write('(12bit jpeg not available) ... ')
         pytest.skip()
 
-    ds = gdaltest.tiff_drv.Create('tmp/ovr43.tif', 16, 16, 1, gdal.GDT_UInt16)
+    ds = gdaltest.gtiff_drv.Create('tmp/ovr43.tif', 16, 16, 1, gdal.GDT_UInt16)
     ds.GetRasterBand(1).Fill(4000)
     ds = None
 
@@ -1384,7 +1375,7 @@ def test_tiff_ovr_43(both_endian):
 
     assert cs == 642, 'did not get expected checksum'
 
-    gdaltest.tiff_drv.Delete('tmp/ovr43.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr43.tif')
 
 ###############################################################################
 # Test that we can change overview block size through GDAL_TIFF_OVR_BLOCKSIZE configuration
@@ -1407,7 +1398,7 @@ def test_tiff_ovr_44(both_endian):
     cs = ovr_band.Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ovr44.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr44.tif')
 
     assert cs == 1087, 'did not get expected checksum'
 
@@ -1431,7 +1422,7 @@ def test_tiff_ovr_45(both_endian):
     cs = ovr_band.Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ovr45.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr45.tif')
 
     assert cs == 1087, 'did not get expected checksum'
 
@@ -1446,31 +1437,31 @@ def test_tiff_ovr_46():
 
     # Test NEAREST
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
         ds.BuildOverviews('NEAREST', overviewlist=[2])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
     # Test AVERAGE in optimized case (x2 reduction)
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
         ds.BuildOverviews('AVERAGE', overviewlist=[2])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
     # Test AVERAGE in un-optimized case (x3 reduction)
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
         ds.BuildOverviews('AVERAGE', overviewlist=[3])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
     # Test AVERAGE in un-optimized case (color table)
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
 
         ct = gdal.ColorTable()
         ct.SetColorEntry(0, (255, 0, 0))
@@ -1479,19 +1470,19 @@ def test_tiff_ovr_46():
         ds.BuildOverviews('AVERAGE', overviewlist=[2])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
     # Test GAUSS
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
         ds.BuildOverviews('GAUSS', overviewlist=[2])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
     # Test GAUSS with color table
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
 
         ct = gdal.ColorTable()
         ct.SetColorEntry(0, (255, 0, 0))
@@ -1500,23 +1491,23 @@ def test_tiff_ovr_46():
         ds.BuildOverviews('GAUSS', overviewlist=[2])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
     # Test MODE
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
         ds.BuildOverviews('MODE', overviewlist=[2])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
     # Test CUBIC
     with gdaltest.config_option('GTIFF_DONT_WRITE_BLOCKS', 'YES'):
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_ovr_46.tif', 50000, 50000, options=['SPARSE_OK=YES'])
         ds.BuildOverviews('CUBIC', overviewlist=[2])
         ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_ovr_46.tif')
 
 ###############################################################################
 # Test workaround with libtiff 3.X when creating interleaved overviews
@@ -1834,35 +1825,35 @@ def test_tiff_ovr_average_multiband_vs_singleband():
 # Cleanup
 
 def test_tiff_ovr_cleanup():
-    gdaltest.tiff_drv.Delete('tmp/mfloat32.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr4.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr5.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr6.tif')
-    gdaltest.tiff_drv.Delete('tmp/test_average_palette.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr9.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr10.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr11.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr12.tif')
-    gdaltest.tiff_drv.Delete('tmp/test_gauss_palette.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr15.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr16.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr17.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr18.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr19.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr20.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr21.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr22.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr23.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr24.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr25.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr26.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr27.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr30.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr31.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr37.dt0')
-    gdaltest.tiff_drv.Delete('tmp/ovr38.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr39.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr40.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr41.tif')
-    gdaltest.tiff_drv.Delete('tmp/ovr42.tif')
-    gdaltest.tiff_drv.Delete('tmp/rgba_with_alpha_0_and_255.tif')
+    gdaltest.gtiff_drv.Delete('tmp/mfloat32.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr4.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr5.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr6.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_average_palette.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr9.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr10.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr11.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr12.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_gauss_palette.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr15.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr16.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr17.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr18.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr19.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr20.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr21.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr22.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr23.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr24.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr25.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr26.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr27.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr30.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr31.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr37.dt0')
+    gdaltest.gtiff_drv.Delete('tmp/ovr38.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr39.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr40.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr41.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ovr42.tif')
+    gdaltest.gtiff_drv.Delete('tmp/rgba_with_alpha_0_and_255.tif')

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -43,16 +43,15 @@ import gdaltest
 
 run_tiff_write_api_proxy = True
 
+
+pytestmark = pytest.mark.require_driver('GTiff')
+
 ###############################################################################
 # Get the GeoTIFF driver, and verify a few things about it.
 
 
 def test_tiff_write_1():
-
-    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
-    assert gdaltest.tiff_drv is not None, 'GTiff driver not found!'
-
-    drv_md = gdaltest.tiff_drv.GetMetadata()
+    drv_md = gdaltest.gtiff_drv.GetMetadata()
     assert drv_md['DMD_MIMETYPE'] == 'image/tiff', 'mime type is wrong'
 
 ###############################################################################
@@ -63,7 +62,7 @@ def test_tiff_write_2():
 
     src_ds = gdal.Open('data/cfloat64.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_2.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_2.tif', src_ds)
 
     bnd = new_ds.GetRasterBand(1)
     assert bnd.Checksum() == 5028, 'Didnt get expected checksum on still-open file'
@@ -83,7 +82,7 @@ def test_tiff_write_2():
     bnd = None
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_2.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_2.tif')
 
 ###############################################################################
 # Create a simple file by copying from an existing one.
@@ -95,7 +94,7 @@ def test_tiff_write_3():
 
     options = ['TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32']
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_3.tif', src_ds,
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_3.tif', src_ds,
                                           options=options)
 
     bnd = new_ds.GetRasterBand(1)
@@ -104,7 +103,7 @@ def test_tiff_write_3():
     bnd = None
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_3.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_3.tif')
 
 ###############################################################################
 # Create a tiled file.
@@ -119,7 +118,7 @@ def test_tiff_write_4():
 
     options = ['TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32']
 
-    new_ds = gdaltest.tiff_drv.Create('tmp/test_4.tif', 40, 50, 3,
+    new_ds = gdaltest.gtiff_drv.Create('tmp/test_4.tif', 40, 50, 3,
                                       gdal.GDT_Byte, options)
 
     try:
@@ -181,7 +180,7 @@ def test_tiff_write_4():
 
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_4.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_4.tif')
 
 ###############################################################################
 # Write a file with GCPs.
@@ -191,7 +190,7 @@ def test_tiff_write_5():
 
     src_ds = gdal.Open('data/gcps.vrt')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_5.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_5.tif', src_ds)
 
     assert (new_ds.GetGCPProjection().find(
             'AUTHORITY["EPSG","26711"]') != -1), 'GCP Projection not set properly.'
@@ -201,10 +200,10 @@ def test_tiff_write_5():
 
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_5.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_5.tif')
 
     # Test SetGCPs on a new GTiff
-    new_ds = gdaltest.tiff_drv.Create('tmp/test_5.tif', 10, 10, 1)
+    new_ds = gdaltest.gtiff_drv.Create('tmp/test_5.tif', 10, 10, 1)
     new_ds.SetGCPs(gcps, src_ds.GetGCPProjection())
     new_ds = None
 
@@ -213,7 +212,7 @@ def test_tiff_write_5():
     assert len(gcps) == 4, 'GCP count wrong.'
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_5.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_5.tif')
 
 ###############################################################################
 # Test a mixture of reading and writing on a DEFLATE compressed file.
@@ -222,7 +221,7 @@ def test_tiff_write_6():
 
     options = ['TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32',
                'COMPRESS=DEFLATE', 'PREDICTOR=2']
-    ds = gdaltest.tiff_drv.Create('tmp/test_6.tif', 200, 200, 1,
+    ds = gdaltest.gtiff_drv.Create('tmp/test_6.tif', 200, 200, 1,
                                   gdal.GDT_Byte, options)
 
     # make a 32x32 byte buffer
@@ -241,7 +240,7 @@ def test_tiff_write_6():
     ds = None
 
     gdaltest.tiff_write_6_failed = False
-    gdaltest.tiff_drv.Delete('tmp/test_6.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_6.tif')
 
 ###############################################################################
 # Test a mixture of reading and writing on a LZW compressed file.
@@ -249,7 +248,7 @@ def test_tiff_write_6():
 def test_tiff_write_7():
 
     options = ['TILED=YES', 'COMPRESS=LZW', 'PREDICTOR=2']
-    ds = gdaltest.tiff_drv.Create('tmp/test_7.tif', 200, 200, 1,
+    ds = gdaltest.gtiff_drv.Create('tmp/test_7.tif', 200, 200, 1,
                                   gdal.GDT_Byte, options)
 
     # make a 32x32 byte buffer
@@ -265,7 +264,7 @@ def test_tiff_write_7():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_7.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_7.tif')
 
 ###############################################################################
 # Test a mixture of reading and writing on a PACKBITS compressed file.
@@ -274,7 +273,7 @@ def test_tiff_write_7():
 def test_tiff_write_8():
 
     options = ['TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32', 'COMPRESS=PACKBITS']
-    ds = gdaltest.tiff_drv.Create('tmp/test_8.tif', 200, 200, 1,
+    ds = gdaltest.gtiff_drv.Create('tmp/test_8.tif', 200, 200, 1,
                                   gdal.GDT_Byte, options)
 
     # make a 32x32 byte buffer
@@ -291,7 +290,7 @@ def test_tiff_write_8():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_8.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_8.tif')
 
 ###############################################################################
 # Create a simple file by copying from an existing one.
@@ -300,7 +299,7 @@ def test_tiff_write_8():
 def test_tiff_write_9():
 
     src_ds = gdal.Open('data/byte.tif')
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_9.tif', src_ds,
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_9.tif', src_ds,
                                           options=['NBITS=5'])
     with gdaltest.error_handler():
         new_ds = None
@@ -312,7 +311,7 @@ def test_tiff_write_9():
     bnd = None
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_9.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_9.tif')
 
 ###############################################################################
 # 1bit file but with band interleaving, and odd size (not multiple of 8) #1957
@@ -340,7 +339,7 @@ def test_tiff_write_11():
 
 def test_tiff_write_12():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -354,12 +353,12 @@ def test_tiff_write_12():
 
 def test_tiff_write_13():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
     src_ds = gdal.Open('data/sasha.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/sasha.tif', src_ds, options=['PROFILE=BASELINE',
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/sasha.tif', src_ds, options=['PROFILE=BASELINE',
                                                                         'TILED=YES',
                                                                         'COMPRESS=JPEG',
                                                                         'PHOTOMETRIC=YCBCR',
@@ -372,7 +371,7 @@ def test_tiff_write_13():
 
     size = os.stat('tmp/sasha.tif').st_size
 
-    gdaltest.tiff_drv.Delete('tmp/sasha.tif')
+    gdaltest.gtiff_drv.Delete('tmp/sasha.tif')
     assert cs == 17347 or cs == 14445, 'fail: bad checksum'
 
     if md['LIBTIFF'] == 'INTERNAL':
@@ -398,7 +397,7 @@ def test_tiff_write_15():
 
     ds_in = gdal.Open('data/byte.vrt')
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tw_15.tif', ds_in, options=['PROFILE=BASELINE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tw_15.tif', ds_in, options=['PROFILE=BASELINE'])
 
     ds_in = None
     ds = None
@@ -428,7 +427,7 @@ def test_tiff_write_15():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_15.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_15.tif')
 
 ###############################################################################
 # Test that we can restrict metadata and georeferencing in the output
@@ -439,7 +438,7 @@ def test_tiff_write_16():
 
     ds_in = gdal.Open('data/byte.vrt')
 
-    ds = gdaltest.tiff_drv.Create('tmp/tw_16.tif', 20, 20, gdal.GDT_Byte,
+    ds = gdaltest.gtiff_drv.Create('tmp/tw_16.tif', 20, 20, gdal.GDT_Byte,
                                   options=['PROFILE=BASELINE'])
 
     ds.SetMetadata({'test': 'testvalue'})
@@ -483,7 +482,7 @@ def test_tiff_write_16():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_16.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_16.tif')
 
 ###############################################################################
 # Test writing a TIFF with an RPC tag.
@@ -497,7 +496,7 @@ def test_tiff_write_17():
     rpc_md = ds_in.GetMetadata('RPC')
 
     tmpfilename = '/vsimem/tiff_write_17.tif'
-    ds = gdaltest.tiff_drv.CreateCopy(tmpfilename, ds_in)
+    ds = gdaltest.gtiff_drv.CreateCopy(tmpfilename, ds_in)
 
     ds_in = None
     ds = None
@@ -539,7 +538,7 @@ def test_tiff_write_17():
     assert not ds.GetMetadata('RPC'), 'got RPC, but was not expected'
     ds = None
 
-    gdaltest.tiff_drv.Delete(tmpfilename)
+    gdaltest.gtiff_drv.Delete(tmpfilename)
 
 ###############################################################################
 # Test that above test still work with the optimization in the GDAL_DISABLE_READDIR_ON_OPEN
@@ -564,7 +563,7 @@ def test_tiff_write_18():
     ds_in = gdal.Open('data/rpc.vrt')
     rpc_md = ds_in.GetMetadata('RPC')
 
-    gdaltest.tiff_drv.CreateCopy('tmp/tw_18.tif', ds_in,
+    gdaltest.gtiff_drv.CreateCopy('tmp/tw_18.tif', ds_in,
                                       options=['PROFILE=BASELINE'])
 
     # Ensure there is no .aux.xml file which might hold the RPC.
@@ -597,7 +596,7 @@ def test_tiff_write_18():
         "wrong value for GetMetadataItem('version', 'IMD')"
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_18.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_18.tif')
 
     # Confirm IMD and RPC files are cleaned up.  If not likely the
     # file list functionality is not working properly.
@@ -606,14 +605,14 @@ def test_tiff_write_18():
     assert not gdal.VSIStatL('tmp/tw_18.IMD'), 'IMD did not get cleaned up.'
 
     # Remove the RPC
-    gdaltest.tiff_drv.CreateCopy('tmp/tw_18.tif', ds_in,
+    gdaltest.gtiff_drv.CreateCopy('tmp/tw_18.tif', ds_in,
                                       options=['PROFILE=BASELINE'])
     ds = gdal.Open('tmp/tw_18.tif', gdal.GA_Update)
     ds.SetMetadata(None, 'RPC')
     ds = None
     assert not os.path.exists('tmp/tw_18.RPB'), 'RPB did not get removed'
 
-    gdaltest.tiff_drv.Delete('tmp/tw_18.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_18.tif')
 
 ###############################################################################
 # Test that above test still work with the optimization in the GDAL_DISABLE_READDIR_ON_OPEN
@@ -645,7 +644,7 @@ def test_tiff_write_rpc_txt():
 
     rpc_md = ds_in.GetMetadata('RPC')
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_rpc_txt.tif', ds_in_without_imd,
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_rpc_txt.tif', ds_in_without_imd,
                                       options=['PROFILE=BASELINE', 'RPCTXT=YES'])
 
     ds_in = None
@@ -668,7 +667,7 @@ def test_tiff_write_rpc_txt():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_rpc_txt.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_rpc_txt.tif')
 
     # Confirm _RPC.TXT file is cleaned up.  If not likely the
     # file list functionality is not working properly.
@@ -684,7 +683,7 @@ def test_tiff_write_rpc_in_pam():
     ds_in = gdal.Open('data/rpc.vrt')
     rpc_md = ds_in.GetMetadata('RPC')
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_rpc_in_pam.tif', ds_in,
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_rpc_in_pam.tif', ds_in,
                                       options=['PROFILE=BASELINE', 'RPB=NO'])
 
     ds_in = None
@@ -706,7 +705,7 @@ def test_tiff_write_rpc_in_pam():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_rpc_in_pam.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_rpc_in_pam.tif')
 ###############################################################################
 # Test the write of a pixel-interleaved image with NBITS = 7
 
@@ -715,7 +714,7 @@ def test_tiff_write_19():
 
     src_ds = gdal.Open('data/contig_strip.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/contig_strip_7.tif', src_ds,
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/contig_strip_7.tif', src_ds,
                                           options=['NBITS=7', 'INTERLEAVE=PIXEL'])
 
     new_ds = None
@@ -731,7 +730,7 @@ def test_tiff_write_19():
     new_ds = None
     src_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/contig_strip_7.tif')
+    gdaltest.gtiff_drv.Delete('tmp/contig_strip_7.tif')
 
 ###############################################################################
 # Test write and read of some TIFF tags
@@ -739,7 +738,7 @@ def test_tiff_write_19():
 
 def test_tiff_write_20():
 
-    new_ds = gdaltest.tiff_drv.Create('tmp/tags.tif', 1, 1, 1)
+    new_ds = gdaltest.gtiff_drv.Create('tmp/tags.tif', 1, 1, 1)
 
     values = [('TIFFTAG_DOCUMENTNAME', 'document_name'),
               ('TIFFTAG_IMAGEDESCRIPTION', 'image_description'),
@@ -799,7 +798,7 @@ def test_tiff_write_20():
 
     assert got_md == {}, 'expected empty metadata list, but got some'
 
-    gdaltest.tiff_drv.Delete('tmp/tags.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tags.tif')
 
 ###############################################################################
 # Test RGBA images with TIFFTAG_EXTRASAMPLES=EXTRASAMPLE_ASSOCALPHA
@@ -809,7 +808,7 @@ def test_tiff_write_21():
 
     src_ds = gdal.Open('data/stefan_full_rgba.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/stefan_full_rgba.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/stefan_full_rgba.tif', src_ds)
 
     new_ds = None
 
@@ -822,7 +821,7 @@ def test_tiff_write_21():
     new_ds = None
     src_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/stefan_full_rgba.tif')
+    gdaltest.gtiff_drv.Delete('tmp/stefan_full_rgba.tif')
 
 ###############################################################################
 # Test RGBA images with TIFFTAG_EXTRASAMPLES=EXTRASAMPLE_UNSPECIFIED
@@ -832,7 +831,7 @@ def test_tiff_write_22():
 
     src_ds = gdal.Open('data/stefan_full_rgba_photometric_rgb.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/stefan_full_rgba_photometric_rgb.tif', src_ds, options=['PHOTOMETRIC=RGB'])
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/stefan_full_rgba_photometric_rgb.tif', src_ds, options=['PHOTOMETRIC=RGB'])
 
     new_ds = None
 
@@ -845,7 +844,7 @@ def test_tiff_write_22():
     new_ds = None
     src_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/stefan_full_rgba_photometric_rgb.tif')
+    gdaltest.gtiff_drv.Delete('tmp/stefan_full_rgba_photometric_rgb.tif')
 
 ###############################################################################
 # Test grey+alpha images with ALPHA=YES
@@ -855,7 +854,7 @@ def test_tiff_write_23():
 
     src_ds = gdal.Open('data/stefan_full_greyalpha.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/stefan_full_greyalpha.tif', src_ds, options=['ALPHA=YES'])
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/stefan_full_greyalpha.tif', src_ds, options=['ALPHA=YES'])
 
     new_ds = None
 
@@ -868,7 +867,7 @@ def test_tiff_write_23():
     new_ds = None
     src_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/stefan_full_greyalpha.tif')
+    gdaltest.gtiff_drv.Delete('tmp/stefan_full_greyalpha.tif')
 
 ###############################################################################
 # Test grey+alpha images without ALPHA=YES
@@ -878,7 +877,7 @@ def test_tiff_write_24():
 
     src_ds = gdal.Open('data/stefan_full_greyalpha.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/stefan_full_greyunspecified.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/stefan_full_greyunspecified.tif', src_ds)
 
     new_ds = None
 
@@ -891,7 +890,7 @@ def test_tiff_write_24():
     new_ds = None
     src_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/stefan_full_greyunspecified.tif')
+    gdaltest.gtiff_drv.Delete('tmp/stefan_full_greyunspecified.tif')
 
 ###############################################################################
 # Read a CIELAB image to test the RGBA image TIFF interface
@@ -917,7 +916,7 @@ def test_tiff_write_25():
 
 def test_tiff_write_26():
 
-    ds = gdaltest.tiff_drv.Create('tmp/ct8.tif', 1, 1, 1, gdal.GDT_Byte)
+    ds = gdaltest.gtiff_drv.Create('tmp/ct8.tif', 1, 1, 1, gdal.GDT_Byte)
 
     ct = gdal.ColorTable()
     ct.SetColorEntry(0, (255, 255, 255, 255))
@@ -942,7 +941,7 @@ def test_tiff_write_26():
     ct = None
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ct8.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ct8.tif')
 
 ###############################################################################
 # Test color table in a 16 bit image
@@ -950,7 +949,7 @@ def test_tiff_write_26():
 
 def test_tiff_write_27():
 
-    ds = gdaltest.tiff_drv.Create('tmp/ct16.tif', 1, 1, 1, gdal.GDT_UInt16)
+    ds = gdaltest.gtiff_drv.Create('tmp/ct16.tif', 1, 1, 1, gdal.GDT_UInt16)
 
     ct = gdal.ColorTable()
     ct.SetColorEntry(0, (255, 255, 255, 255))
@@ -964,7 +963,7 @@ def test_tiff_write_27():
     ds = None
 
     ds = gdal.Open('tmp/ct16.tif')
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/ct16_copy.tif', ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/ct16_copy.tif', ds)
     del new_ds
     ds = None
 
@@ -980,8 +979,8 @@ def test_tiff_write_27():
     ct = None
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/ct16.tif')
-    gdaltest.tiff_drv.Delete('tmp/ct16_copy.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ct16.tif')
+    gdaltest.gtiff_drv.Delete('tmp/ct16_copy.tif')
 
 ###############################################################################
 # Test SetRasterColorInterpretation on a 2 channel image
@@ -989,7 +988,7 @@ def test_tiff_write_27():
 
 def test_tiff_write_28():
 
-    ds = gdaltest.tiff_drv.Create('tmp/greyalpha.tif', 1, 1, 2)
+    ds = gdaltest.gtiff_drv.Create('tmp/greyalpha.tif', 1, 1, 2)
 
     assert ds.GetRasterBand(2).GetRasterColorInterpretation() == gdal.GCI_Undefined
 
@@ -1004,7 +1003,7 @@ def test_tiff_write_28():
     assert ds.GetRasterBand(2).GetRasterColorInterpretation() == gdal.GCI_AlphaBand
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/greyalpha.tif')
+    gdaltest.gtiff_drv.Delete('tmp/greyalpha.tif')
 
 ###############################################################################
 # Test SetRasterColorInterpretation on a 4 channel image
@@ -1014,7 +1013,7 @@ def test_tiff_write_29():
 
     # When creating a 4 channel image with PHOTOMETRIC=RGB,
     # TIFFTAG_EXTRASAMPLES=EXTRASAMPLE_UNSPECIFIED
-    ds = gdaltest.tiff_drv.Create('/vsimem/rgba.tif', 1, 1, 4, options=['PHOTOMETRIC=RGB'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/rgba.tif', 1, 1, 4, options=['PHOTOMETRIC=RGB'])
     assert ds.GetMetadataItem('TIFFTAG_EXTRASAMPLES', '_DEBUG_') == '0'
     assert ds.GetRasterBand(4).GetRasterColorInterpretation() == gdal.GCI_Undefined
 
@@ -1032,7 +1031,7 @@ def test_tiff_write_29():
     assert ds.GetRasterBand(4).GetRasterColorInterpretation() == gdal.GCI_AlphaBand
 
     # Test cancelling alpha
-    gdaltest.tiff_drv.CreateCopy('/vsimem/rgb_no_alpha.tif', ds, options=['ALPHA=NO'])
+    gdaltest.gtiff_drv.CreateCopy('/vsimem/rgb_no_alpha.tif', ds, options=['ALPHA=NO'])
     ds = None
 
     assert gdal.VSIStatL('/vsimem/rgb_no_alpha.tif.aux.xml') is None
@@ -1042,7 +1041,7 @@ def test_tiff_write_29():
     assert ds.GetRasterBand(4).GetRasterColorInterpretation() == gdal.GCI_Undefined
 
     # Test re-adding alpha
-    gdaltest.tiff_drv.CreateCopy('/vsimem/rgb_added_alpha.tif', ds, options=['ALPHA=YES'])
+    gdaltest.gtiff_drv.CreateCopy('/vsimem/rgb_added_alpha.tif', ds, options=['ALPHA=YES'])
     ds = None
 
     assert gdal.VSIStatL('/vsimem/rgb_added_alpha.tif.aux.xml') is None
@@ -1052,17 +1051,16 @@ def test_tiff_write_29():
     assert ds.GetRasterBand(4).GetRasterColorInterpretation() == gdal.GCI_AlphaBand
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/rgba.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/rgb_no_alpha.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/rgb_added_alpha.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/rgba.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/rgb_no_alpha.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/rgb_added_alpha.tif')
 
 
 ###############################################################################
 # Create a BigTIFF image with BigTIFF=YES
 
 def test_tiff_write_30():
-
-    ds = gdaltest.tiff_drv.Create('tmp/bigtiff.tif', 1, 1, 1, options=['BigTIFF=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/bigtiff.tif', 1, 1, 1, options=['BigTIFF=YES'])
     ds = None
 
     ds = gdal.Open('tmp/bigtiff.tif')
@@ -1074,7 +1072,7 @@ def test_tiff_write_30():
     binvalues.fromfile(fileobj, 4)
     fileobj.close()
 
-    gdaltest.tiff_drv.Delete('tmp/bigtiff.tif')
+    gdaltest.gtiff_drv.Delete('tmp/bigtiff.tif')
 
     # Check BigTIFF signature
     assert (not ((binvalues[2] != 0x2B or binvalues[3] != 0) and
@@ -1086,7 +1084,7 @@ def test_tiff_write_30():
 
 def test_tiff_write_31():
 
-    ds = gdaltest.tiff_drv.Create('tmp/bigtiff.tif', 100000, 100000, 1,
+    ds = gdaltest.gtiff_drv.Create('tmp/bigtiff.tif', 100000, 100000, 1,
                                   options=['SPARSE_OK=TRUE'])
     ds = None
 
@@ -1099,7 +1097,7 @@ def test_tiff_write_31():
     binvalues.fromfile(fileobj, 4)
     fileobj.close()
 
-    gdaltest.tiff_drv.Delete('tmp/bigtiff.tif')
+    gdaltest.gtiff_drv.Delete('tmp/bigtiff.tif')
 
     # Check BigTIFF signature
     assert (not ((binvalues[2] != 0x2B or binvalues[3] != 0) and
@@ -1114,7 +1112,7 @@ def test_tiff_write_32():
     ds_in = gdal.Open('data/byte.vrt')
 
     # Test creation
-    ds = gdaltest.tiff_drv.Create('tmp/byte_rotated.tif', 20, 20, gdal.GDT_Byte)
+    ds = gdaltest.gtiff_drv.Create('tmp/byte_rotated.tif', 20, 20, gdal.GDT_Byte)
 
     gt = (10, 3.53553390593, 3.53553390593, 30, 3.53553390593, -3.53553390593)
     ds.SetGeoTransform(gt)
@@ -1125,7 +1123,7 @@ def test_tiff_write_32():
     ds_in = None
 
     # Test copy
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/byte_rotated_copy.tif', ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/byte_rotated_copy.tif', ds)
     del new_ds
 
     # Check copy
@@ -1140,8 +1138,8 @@ def test_tiff_write_32():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/byte_rotated.tif')
-    gdaltest.tiff_drv.Delete('tmp/byte_rotated_copy.tif')
+    gdaltest.gtiff_drv.Delete('tmp/byte_rotated.tif')
+    gdaltest.gtiff_drv.Delete('tmp/byte_rotated_copy.tif')
 
 ###############################################################################
 # Test that metadata is written in .aux.xml file in GeoTIFF profile with CreateCopy
@@ -1152,7 +1150,7 @@ def test_tiff_write_33():
 
     ds_in = gdal.Open('data/byte.vrt')
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tw_33.tif', ds_in, options=['PROFILE=GeoTIFF'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tw_33.tif', ds_in, options=['PROFILE=GeoTIFF'])
 
     ds_in = None
 
@@ -1186,7 +1184,7 @@ def test_tiff_write_33():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_33.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_33.tif')
 
 ###############################################################################
 # Test that metadata is written in .aux.xml file in GeoTIFF profile with Create
@@ -1195,7 +1193,7 @@ def test_tiff_write_33():
 
 def test_tiff_write_34():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tw_34.tif', 1, 1, gdal.GDT_Byte,
+    ds = gdaltest.gtiff_drv.Create('tmp/tw_34.tif', 1, 1, gdal.GDT_Byte,
                                   options=['PROFILE=GeoTIFF'])
     ds.SetMetadata({'test': 'testvalue'})
     ds.GetRasterBand(1).SetMetadata({'testBand': 'testvalueBand'})
@@ -1230,7 +1228,7 @@ def test_tiff_write_34():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_34.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_34.tif')
 
 ###############################################################################
 # Test fallback from internal storage of Geotiff metadata to PAM storage
@@ -1258,7 +1256,7 @@ def test_tiff_write_35():
     big_string = big_string + big_string
     big_string = big_string + big_string
 
-    ds = gdaltest.tiff_drv.Create('tmp/tw_35.tif', 1, 1, gdal.GDT_Byte)
+    ds = gdaltest.gtiff_drv.Create('tmp/tw_35.tif', 1, 1, gdal.GDT_Byte)
 
     md = {}
     md['test'] = big_string
@@ -1284,7 +1282,7 @@ def test_tiff_write_35():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_35.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_35.tif')
 
 ###############################################################################
 # Generic functions for the 8 following tests
@@ -1293,7 +1291,7 @@ def test_tiff_write_35():
 def tiff_write_big_odd_bits(vrtfilename, tmpfilename, nbits, interleaving):
     ds_in = gdal.Open(vrtfilename)
 
-    ds = gdaltest.tiff_drv.CreateCopy(tmpfilename, ds_in, options=['NBITS=' + str(nbits), 'INTERLEAVE=' + interleaving])
+    ds = gdaltest.gtiff_drv.CreateCopy(tmpfilename, ds_in, options=['NBITS=' + str(nbits), 'INTERLEAVE=' + interleaving])
 
     ds_in = None
 
@@ -1317,7 +1315,7 @@ def tiff_write_big_odd_bits(vrtfilename, tmpfilename, nbits, interleaving):
 
     ds = None
 
-    gdaltest.tiff_drv.Delete(tmpfilename)
+    gdaltest.gtiff_drv.Delete(tmpfilename)
 
 
 ###############################################################################
@@ -1381,7 +1379,7 @@ def test_tiff_write_43():
 
 def test_tiff_write_44():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tw_44.tif', 1, 1, 1, gdal.GDT_UInt16, options=['NBITS=9'])
+    ds = gdaltest.gtiff_drv.Create('tmp/tw_44.tif', 1, 1, 1, gdal.GDT_UInt16, options=['NBITS=9'])
     ds = None
     ds = gdal.Open('tmp/tw_44.tif')
     bnd = ds.GetRasterBand(1)
@@ -1389,7 +1387,7 @@ def test_tiff_write_44():
     bnd = None
     assert md['NBITS'] == '9', 'Didnt get expected NBITS value'
 
-    ds2 = gdaltest.tiff_drv.CreateCopy('tmp/tw_44_copy.tif', ds)
+    ds2 = gdaltest.gtiff_drv.CreateCopy('tmp/tw_44_copy.tif', ds)
     ds2 = None
 
     ds2 = gdal.Open('tmp/tw_44_copy.tif')
@@ -1401,8 +1399,8 @@ def test_tiff_write_44():
     ds = None
     ds2 = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_44.tif')
-    gdaltest.tiff_drv.Delete('tmp/tw_44_copy.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_44.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_44_copy.tif')
 
 ###############################################################################
 # Test create with NBITS=17 and preservation through CreateCopy of NBITS
@@ -1410,7 +1408,7 @@ def test_tiff_write_44():
 
 def test_tiff_write_45():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tw_45.tif', 1, 1, 1, gdal.GDT_UInt32, options=['NBITS=17'])
+    ds = gdaltest.gtiff_drv.Create('tmp/tw_45.tif', 1, 1, 1, gdal.GDT_UInt32, options=['NBITS=17'])
     ds = None
     ds = gdal.Open('tmp/tw_45.tif')
     bnd = ds.GetRasterBand(1)
@@ -1418,7 +1416,7 @@ def test_tiff_write_45():
     bnd = None
     assert md['NBITS'] == '17', 'Didnt get expected NBITS value'
 
-    ds2 = gdaltest.tiff_drv.CreateCopy('tmp/tw_45_copy.tif', ds)
+    ds2 = gdaltest.gtiff_drv.CreateCopy('tmp/tw_45_copy.tif', ds)
     ds2 = None
 
     ds2 = gdal.Open('tmp/tw_45_copy.tif')
@@ -1430,8 +1428,8 @@ def test_tiff_write_45():
     ds = None
     ds2 = None
 
-    gdaltest.tiff_drv.Delete('tmp/tw_45.tif')
-    gdaltest.tiff_drv.Delete('tmp/tw_45_copy.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_45.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tw_45_copy.tif')
 
 
 ###############################################################################
@@ -1441,10 +1439,10 @@ def test_tiff_write_46():
 
     with gdaltest.SetCacheMax(0):
 
-        ds = gdaltest.tiff_drv.Create("tmp/tiff_write_46_1.tif", 10, 10, 1, options=['NBITS=1'])
+        ds = gdaltest.gtiff_drv.Create("tmp/tiff_write_46_1.tif", 10, 10, 1, options=['NBITS=1'])
         ds.GetRasterBand(1).Fill(0)
 
-        ds2 = gdaltest.tiff_drv.Create("tmp/tiff_write_46_2.tif", 10, 10, 1, options=['NBITS=1'])
+        ds2 = gdaltest.gtiff_drv.Create("tmp/tiff_write_46_2.tif", 10, 10, 1, options=['NBITS=1'])
         ds2.GetRasterBand(1).Fill(1)
         ones = ds2.ReadRaster(0, 0, 10, 1)
 
@@ -1455,7 +1453,7 @@ def test_tiff_write_46():
         ds.WriteRaster(0, 0, 10, 1, ones)
 
         # This will discard the cached block for ds
-        ds3 = gdaltest.tiff_drv.Create("tmp/tiff_write_46_3.tif", 10, 10, 1)
+        ds3 = gdaltest.gtiff_drv.Create("tmp/tiff_write_46_3.tif", 10, 10, 1)
         ds3.GetRasterBand(1).Fill(1)
 
         # Load the working block again
@@ -1469,9 +1467,9 @@ def test_tiff_write_46():
     ds = None
     ds2 = None
     ds3 = None
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_46_1.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_46_2.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_46_3.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_46_1.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_46_2.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_46_3.tif')
 
 ###############################################################################
 # Test #2457
@@ -1505,7 +1503,7 @@ def test_tiff_write_48():
 
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_48.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_48.tif')
 
 
 ###############################################################################
@@ -1533,7 +1531,7 @@ def test_tiff_write_49():
     src_ds = None
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_49.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_49.tif')
 
 
 ###############################################################################
@@ -1563,7 +1561,7 @@ def test_tiff_write_50():
     src_ds = None
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_50.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_50.tif')
 
 
 ###############################################################################
@@ -1585,7 +1583,7 @@ def test_tiff_write_51():
     ds = None
 
     # Create a new GeoTIFF file with same projection
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_51_ref.tif', 1, 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_51_ref.tif', 1, 1, 1)
     ds.SetProjection(srs.ExportToWkt())
     ds = None
 
@@ -1602,8 +1600,8 @@ def test_tiff_write_51():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_51.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_51_ref.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_51.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_51_ref.tif')
 
 ###############################################################################
 # Test the ability to update a paletted TIFF files color table.
@@ -1630,7 +1628,7 @@ def test_tiff_write_52():
     ct = None
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_52.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_52.tif')
 
 ###############################################################################
 # Test the ability to create a paletted image and then update later.
@@ -1643,7 +1641,7 @@ def test_tiff_write_53():
     for i, data in enumerate(test_ct_data):
         test_ct.SetColorEntry(i, data)
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_53.tif',
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_53.tif',
                                   30, 50, 1,
                                   options=['PHOTOMETRIC=PALETTE'])
     ds.GetRasterBand(1).Fill(10)
@@ -1661,7 +1659,7 @@ def test_tiff_write_53():
     ct = None
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_53.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_53.tif')
 
 
 ###############################################################################
@@ -1675,7 +1673,7 @@ def test_tiff_write_53_bis():
     for i, data in enumerate(test_ct_data):
         test_ct.SetColorEntry(i, data)
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_53_bis.tif',
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_53_bis.tif',
                                   30, 50, 1,
                                   options=['PHOTOMETRIC=PALETTE'])
     ds.GetRasterBand(1).Fill(10)
@@ -1694,7 +1692,7 @@ def test_tiff_write_53_bis():
     ct = None
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_53_bis.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_53_bis.tif')
 
 ###############################################################################
 # Test the ability to create a JPEG compressed TIFF, with PHOTOMETRIC=YCBCR
@@ -1703,11 +1701,11 @@ def test_tiff_write_53_bis():
 
 def test_tiff_write_54():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_54.tif',
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_54.tif',
                                   256, 256, 3,
                                   options=['TILED=YES', 'COMPRESS=JPEG', 'PHOTOMETRIC=YCBCR'])
     ds.GetRasterBand(1).Fill(255)
@@ -1718,7 +1716,7 @@ def test_tiff_write_54():
     cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_54.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_54.tif')
 
     assert cs != 0, 'did not get expected checksum'
 
@@ -1728,7 +1726,7 @@ def test_tiff_write_54():
 
 def test_tiff_write_55():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_55.tif',
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_55.tif',
                                   256, 256, 1)
     srs_expected = 'PROJCS["Equirectangular Mars",GEOGCS["GCS_Mars",DATUM["unknown",SPHEROID["unnamed",3394813.85797594,0]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Equirectangular"],PARAMETER["latitude_of_origin",-2],PARAMETER["central_meridian",184.412994384766],PARAMETER["standard_parallel_1",-15],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]'
 
@@ -1744,7 +1742,7 @@ def test_tiff_write_55():
     assert srs == srs_expected, \
         'failed to preserve Equirectangular projection as expected, old libgeotiff?'
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_55.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_55.tif')
 
 ###############################################################################
 # Test clearing the colormap from an existing paletted TIFF file.
@@ -1758,7 +1756,7 @@ def test_tiff_write_56():
     for i, data in enumerate(test_ct_data):
         test_ct.SetColorEntry(i, data)
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_56.tif',
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_56.tif',
                                   30, 50, 1,
                                   options=['PHOTOMETRIC=PALETTE'])
     ds.GetRasterBand(1).Fill(10)
@@ -1778,7 +1776,7 @@ def test_tiff_write_56():
     ct = None
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_56.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_56.tif')
 
 ###############################################################################
 # Test replacing normal norm up georef with rotated georef (#2625)
@@ -1802,7 +1800,7 @@ def test_tiff_write_57():
     assert gt == (100, 1, 3, 200, 3, 1), \
         'did not get expected geotransform, perhaps unset is not working?'
 
-    gdaltest.tiff_drv.Delete('tmp/tiff57.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff57.tif')
 
 ###############################################################################
 # Test writing partial end strips (#2748)
@@ -1810,12 +1808,12 @@ def test_tiff_write_57():
 
 def test_tiff_write_58():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
 
     for compression in ('NONE', 'JPEG', 'LZW', 'DEFLATE', 'PACKBITS'):
 
         if md['DMD_CREATIONOPTIONLIST'].find(compression) != -1:
-            ds = gdaltest.tiff_drv.Create('tmp/tiff_write_58.tif', 4, 4000, 1, options=['COMPRESS=' + compression])
+            ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_58.tif', 4, 4000, 1, options=['COMPRESS=' + compression])
             ds.GetRasterBand(1).Fill(255)
             ds = None
 
@@ -1823,7 +1821,7 @@ def test_tiff_write_58():
             assert ds.GetRasterBand(1).Checksum() == 65241, 'wrong checksum'
             ds = None
 
-            gdaltest.tiff_drv.Delete('tmp/tiff_write_58.tif')
+            gdaltest.gtiff_drv.Delete('tmp/tiff_write_58.tif')
         else:
             print(('Skipping compression method %s' % compression))
 
@@ -1849,7 +1847,7 @@ def test_tiff_write_59():
                 gdal_type = gdal.GDT_UInt32
                 ctype = 'i'
 
-            ds = gdaltest.tiff_drv.Create("tmp/tiff_write_59.tif", 10, 10, nbands, gdal_type, options=['NBITS=%d' % nbits])
+            ds = gdaltest.gtiff_drv.Create("tmp/tiff_write_59.tif", 10, 10, nbands, gdal_type, options=['NBITS=%d' % nbits])
             ds.GetRasterBand(1).Fill(1)
 
             ds = None
@@ -1873,7 +1871,7 @@ def test_tiff_write_59():
                     break
 
             ds = None
-            gdaltest.tiff_drv.Delete('tmp/tiff_write_59.tif')
+            gdaltest.gtiff_drv.Delete('tmp/tiff_write_59.tif')
 
     return ret
 
@@ -1889,7 +1887,7 @@ def test_tiff_write_60():
     for options_tuple in tuples:
         # Create case
         with gdaltest.error_handler():
-            ds = gdaltest.tiff_drv.Create('tmp/tiff_write_60.tif', 10, 10, options=[options_tuple[0], 'PROFILE=BASELINE'])
+            ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_60.tif', 10, 10, options=[options_tuple[0], 'PROFILE=BASELINE'])
         gt = (0.0, 1.0, 0.0, 50.0, 0.0, -1.0)
         ds.SetGeoTransform(gt)
         ds = None
@@ -1899,14 +1897,14 @@ def test_tiff_write_60():
         assert ds.GetGeoTransform() == gt, ('case1: %s != %s' % (ds.GetGeoTransform(), gt))
 
         ds = None
-        gdaltest.tiff_drv.Delete('tmp/tiff_write_60.tif')
+        gdaltest.gtiff_drv.Delete('tmp/tiff_write_60.tif')
 
         assert not os.path.exists(options_tuple[1])
 
         # CreateCopy case
         src_ds = gdal.Open('data/byte.tif')
         with gdaltest.error_handler():
-            ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_60.tif', src_ds, options=[options_tuple[0], 'PROFILE=BASELINE'])
+            ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_60.tif', src_ds, options=[options_tuple[0], 'PROFILE=BASELINE'])
         gt = (0.0, 1.0, 0.0, 50.0, 0.0, -1.0)
         ds.SetGeoTransform(gt)
         ds = None
@@ -1917,7 +1915,7 @@ def test_tiff_write_60():
             ('case2: %s != %s' % (ds.GetGeoTransform(), gt))
 
         ds = None
-        gdaltest.tiff_drv.Delete('tmp/tiff_write_60.tif')
+        gdaltest.gtiff_drv.Delete('tmp/tiff_write_60.tif')
 
         assert not os.path.exists(options_tuple[1])
 
@@ -1928,7 +1926,7 @@ def test_tiff_write_60():
 
 def test_tiff_write_61():
 
-    ds = gdaltest.tiff_drv.Create('tmp/bigtiff.tif', 50000, 50000, 1,
+    ds = gdaltest.gtiff_drv.Create('tmp/bigtiff.tif', 50000, 50000, 1,
                                   options=['BIGTIFF=IF_NEEDED', 'SPARSE_OK=TRUE'])
     ds = None
 
@@ -1941,7 +1939,7 @@ def test_tiff_write_61():
     binvalues.fromfile(fileobj, 4)
     fileobj.close()
 
-    gdaltest.tiff_drv.Delete('tmp/bigtiff.tif')
+    gdaltest.gtiff_drv.Delete('tmp/bigtiff.tif')
 
     # Check classical TIFF signature
     assert (not ((binvalues[2] != 0x2A or binvalues[3] != 0) and
@@ -1953,7 +1951,7 @@ def test_tiff_write_61():
 
 def test_tiff_write_62():
 
-    ds = gdaltest.tiff_drv.Create('tmp/bigtiff.tif', 50000, 50000, 1,
+    ds = gdaltest.gtiff_drv.Create('tmp/bigtiff.tif', 50000, 50000, 1,
                                   options=['BIGTIFF=IF_SAFER', 'SPARSE_OK=TRUE'])
     ds = None
 
@@ -1966,7 +1964,7 @@ def test_tiff_write_62():
     binvalues.fromfile(fileobj, 4)
     fileobj.close()
 
-    gdaltest.tiff_drv.Delete('tmp/bigtiff.tif')
+    gdaltest.gtiff_drv.Delete('tmp/bigtiff.tif')
 
     # Check BigTIFF signature
     assert (not ((binvalues[2] != 0x2B or binvalues[3] != 0) and
@@ -1979,7 +1977,7 @@ def test_tiff_write_62():
 def test_tiff_write_63():
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
-    ds = gdaltest.tiff_drv.Create('tmp/bigtiff.tif', 150000, 150000, 1,
+    ds = gdaltest.gtiff_drv.Create('tmp/bigtiff.tif', 150000, 150000, 1,
                                   options=['BIGTIFF=NO'])
     gdal.PopErrorHandler()
 
@@ -1994,7 +1992,7 @@ def test_tiff_write_63():
 
 def test_tiff_write_64():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_64.tif', 1, 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_64.tif', 1, 1, 1)
     srs = osr.SpatialReference()
     srs.SetFromUserInput('WGS84')
     ds.SetProjection(srs.ExportToWkt())
@@ -2008,7 +2006,7 @@ def test_tiff_write_64():
 
     assert wkt == expected_wkt, 'coordinate system does not exactly match.'
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_64.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_64.tif')
 
 ###############################################################################
 # Verify that we can write XML metadata.
@@ -2016,7 +2014,7 @@ def test_tiff_write_64():
 
 def test_tiff_write_65():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_65.tif', 10, 10)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_65.tif', 10, 10)
 
     doc = '<doc><test xml:attr="abc"/></doc>'
     ds.SetMetadata([doc], 'xml:test')
@@ -2029,7 +2027,7 @@ def test_tiff_write_65():
 
     assert len(md) == 1 and md[0] == doc, 'did not get xml back clean'
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_65.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_65.tif')
 
 
 ###############################################################################
@@ -2040,7 +2038,7 @@ def test_tiff_write_66():
     if gdal.GetConfigOption('SKIP_MEM_INTENSIVE_TEST') is not None:
         pytest.skip()
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_66.tif', 1, 1, 65535, options=['INTERLEAVE=BAND'])
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_66.tif', 1, 1, 65535, options=['INTERLEAVE=BAND'])
     ds = None
 
     ds = gdal.Open('tmp/tiff_write_66.tif')
@@ -2052,7 +2050,7 @@ def test_tiff_write_66():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_66.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_66.tif')
 
 
 ###############################################################################
@@ -2063,7 +2061,7 @@ def test_tiff_write_67():
     if gdal.GetConfigOption('SKIP_MEM_INTENSIVE_TEST') is not None:
         pytest.skip()
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_67.tif', 1, 1, 65535, options=['INTERLEAVE=PIXEL'])
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_67.tif', 1, 1, 65535, options=['INTERLEAVE=PIXEL'])
     ds = None
 
     ds = gdal.Open('tmp/tiff_write_67.tif')
@@ -2075,7 +2073,7 @@ def test_tiff_write_67():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_67.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_67.tif')
 
 ###############################################################################
 # Verify that we can set the color table after a Create() (scenario hit by map.tif in #2820)
@@ -2083,7 +2081,7 @@ def test_tiff_write_67():
 
 def test_tiff_write_68():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_68.tif', 151, 161, options=['COMPRESS=LZW'])
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_68.tif', 151, 161, options=['COMPRESS=LZW'])
     ct = gdal.ColorTable()
     ct.SetColorEntry(0, (255, 255, 255, 255))
     ct.SetColorEntry(1, (255, 255, 0, 255))
@@ -2097,7 +2095,7 @@ def test_tiff_write_68():
     assert ds.GetRasterBand(1).Checksum() != 0
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_68.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_68.tif')
 
 ###############################################################################
 # Verify GTiffRasterBand::NullBlock() when reading empty block without any nodata value set
@@ -2105,14 +2103,14 @@ def test_tiff_write_68():
 
 def test_tiff_write_69():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_69.tif', 32, 32, 1, gdal.GDT_Int16, options=['SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_69.tif', 32, 32, 1, gdal.GDT_Int16, options=['SPARSE_OK=YES'])
     ds = None
 
     ds = gdal.Open('tmp/tiff_write_69.tif')
     assert ds.GetRasterBand(1).Checksum() == 0
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_69.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_69.tif')
 
 ###############################################################################
 # Verify GTiffRasterBand::NullBlock() when reading empty block with nodata value set
@@ -2120,7 +2118,7 @@ def test_tiff_write_69():
 
 def test_tiff_write_70():
 
-    ref_ds = gdaltest.tiff_drv.Create('tmp/tiff_write_70_ref.tif', 32, 32, 1, gdal.GDT_Int16)
+    ref_ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_70_ref.tif', 32, 32, 1, gdal.GDT_Int16)
     ref_ds.GetRasterBand(1).Fill(-32768)
     ref_ds = None
 
@@ -2128,7 +2126,7 @@ def test_tiff_write_70():
     expected_cs = ref_ds.GetRasterBand(1).Checksum()
     ref_ds = None
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_70.tif', 32, 32, 1, gdal.GDT_Int16, options=['SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_70.tif', 32, 32, 1, gdal.GDT_Int16, options=['SPARSE_OK=YES'])
     ds.GetRasterBand(1).SetNoDataValue(0)
     assert os.stat('tmp/tiff_write_70.tif').st_size <= 8, \
         'directory should not be crystallized'
@@ -2155,8 +2153,8 @@ def test_tiff_write_70():
     assert ds.GetRasterBand(1).GetNoDataValue() is None
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_70.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_70_ref.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_70.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_70_ref.tif')
 
 
 ###############################################################################
@@ -2195,7 +2193,7 @@ def test_tiff_write_71():
     assert struct.unpack('b', data)[0] == 0x78
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_71.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_71.tif')
 
 ###############################################################################
 # With CreateCopy(), check that TIFF directory is in the first bytes of the file
@@ -2211,7 +2209,7 @@ def test_tiff_write_72():
 
     for profile in ('GDALGeotiff', 'GEOTIFF', 'BASELINE'):
         src_ds = gdal.Open('tmp/byte.tif')
-        out_ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_72.tif', src_ds, options=['ENDIANNESS=LITTLE', 'PROFILE=' + profile])
+        out_ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_72.tif', src_ds, options=['ENDIANNESS=LITTLE', 'PROFILE=' + profile])
         del out_ds
         src_ds = None
 
@@ -2228,8 +2226,8 @@ def test_tiff_write_72():
         assert (binvalues[0] == 0x08 and binvalues[1] == 0x00 and binvalues[2] == 0x00 and binvalues[3] == 0x00), \
             ('Failed with profile %s' % profile)
 
-    gdaltest.tiff_drv.Delete('tmp/byte.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_72.tif')
+    gdaltest.gtiff_drv.Delete('tmp/byte.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_72.tif')
 
 ###############################################################################
 # With Create(), check that TIFF directory is in the first bytes of the file
@@ -2238,7 +2236,7 @@ def test_tiff_write_72():
 
 def test_tiff_write_73():
 
-    out_ds = gdaltest.tiff_drv.Create('tmp/tiff_write_73.tif', 10, 10, options=['ENDIANNESS=LITTLE'])
+    out_ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_73.tif', 10, 10, options=['ENDIANNESS=LITTLE'])
     out_ds.SetGeoTransform([1, 0.01, 0, 1, 0, -0.01])
     srs = osr.SpatialReference()
     srs.SetFromUserInput('EPSG:32601')
@@ -2277,7 +2275,7 @@ def test_tiff_write_73():
     # Directory should be at offset 8 of the file
     assert (binvalues[0] == 0x08 and binvalues[1] == 0x00 and binvalues[2] == 0x00 and binvalues[3] == 0x00)
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_73.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_73.tif')
 
 ###############################################################################
 # Verify we can write 12bit jpeg encoded tiff.
@@ -2285,7 +2283,7 @@ def test_tiff_write_73():
 
 def test_tiff_write_74():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -2347,7 +2345,7 @@ def test_tiff_write_74():
 
         dst_ds = None
 
-        gdaltest.tiff_drv.Delete('tmp/test_74.tif')
+        gdaltest.gtiff_drv.Delete('tmp/test_74.tif')
 
     
 ###############################################################################
@@ -2356,11 +2354,11 @@ def test_tiff_write_74():
 
 def test_tiff_write_75():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_75.tif', 1, 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_75.tif', 1, 1, 1)
     ds.FlushCache()
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_75.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_75.tif')
 
 ###############################################################################
 # Test generating a G4 band to use the TIFFWriteScanline()
@@ -2370,7 +2368,7 @@ def test_tiff_write_76():
 
     src_ds = gdal.Open('data/slim_g4.tif')
     compression = src_ds.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION']
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_76.tif', src_ds, options=['BLOCKYSIZE=%d' % src_ds.RasterYSize, 'COMPRESS=' + compression])
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_76.tif', src_ds, options=['BLOCKYSIZE=%d' % src_ds.RasterYSize, 'COMPRESS=' + compression])
     new_ds = None
     new_ds = gdal.Open('tmp/tiff_write_76.tif')
 
@@ -2380,7 +2378,7 @@ def test_tiff_write_76():
     src_ds = None
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_76.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_76.tif')
 
 ###############################################################################
 # Test generating & reading a 8bit all-in-one-strip multiband TIFF (#3904)
@@ -2388,11 +2386,11 @@ def test_tiff_write_76():
 
 def test_tiff_write_77():
 
-    src_ds = gdaltest.tiff_drv.Create('tmp/tiff_write_77_src.tif', 1, 5000, 3)
+    src_ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_77_src.tif', 1, 5000, 3)
     src_ds.GetRasterBand(2).Fill(255)
 
     for interleaving in ('PIXEL', 'BAND'):
-        new_ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_77.tif', src_ds,
+        new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_77.tif', src_ds,
                                               options=['BLOCKYSIZE=%d' % src_ds.RasterYSize,
                                                        'COMPRESS=LZW',
                                                        'INTERLEAVE=' + interleaving])
@@ -2422,10 +2420,10 @@ def test_tiff_write_77():
 
         new_ds = None
 
-        gdaltest.tiff_drv.Delete('tmp/tiff_write_77.tif')
+        gdaltest.gtiff_drv.Delete('tmp/tiff_write_77.tif')
 
     src_ds = None
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_77_src.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_77_src.tif')
 
 ###############################################################################
 # Test generating & reading a YCbCr JPEG all-in-one-strip multiband TIFF (#3259)
@@ -2433,14 +2431,14 @@ def test_tiff_write_77():
 
 def test_tiff_write_78():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
-    src_ds = gdaltest.tiff_drv.Create('tmp/tiff_write_78_src.tif', 16, 2048, 3)
+    src_ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_78_src.tif', 16, 2048, 3)
     src_ds.GetRasterBand(2).Fill(255)
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_78.tif', src_ds,
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_78.tif', src_ds,
                                           options=['BLOCKYSIZE=%d' % src_ds.RasterYSize,
                                                    'COMPRESS=JPEG',
                                                    'PHOTOMETRIC=YCBCR'])
@@ -2484,10 +2482,10 @@ def test_tiff_write_78():
         assert cs == expected_cs, 'Got wrong checksum'
 
     new_ds = None
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_78.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_78.tif')
 
     src_ds = None
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_78_src.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_78_src.tif')
 
 ###############################################################################
 # Test reading & updating GDALMD_AREA_OR_POINT (#3522)
@@ -2495,7 +2493,7 @@ def test_tiff_write_78():
 
 def test_tiff_write_79():
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_79.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_79.tif', 1, 1)
     srs = osr.SpatialReference()
     srs.SetFromUserInput('EPSG:32601')
     ds.SetProjection(srs.ExportToWkt())
@@ -2571,7 +2569,7 @@ def test_tiff_write_79():
             assert mdi == 'Area', '(6) did not get expected value'
             ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_79.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_79.tif')
 
 ###############################################################################
 # Test SetOffset() & SetScale()
@@ -2580,7 +2578,7 @@ def test_tiff_write_79():
 def test_tiff_write_80():
 
     # First part : test storing and retrieving scale & offsets from internal metadata
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_80.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_80.tif', 1, 1)
     ds.GetRasterBand(1).SetScale(100)
     ds.GetRasterBand(1).SetOffset(1000)
     ds = None
@@ -2596,7 +2594,7 @@ def test_tiff_write_80():
 
     # Test CreateCopy()
     src_ds = gdal.Open('tmp/tiff_write_80.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_80_copy.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_80_copy.tif', src_ds)
     src_ds = None
     ds = None
     ds = gdal.Open('tmp/tiff_write_80_copy.tif')
@@ -2604,7 +2602,7 @@ def test_tiff_write_80():
     offset = ds.GetRasterBand(1).GetOffset()
     assert scale == 100 and offset == 1000, 'did not get expected values in copy'
     ds = None
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_80_copy.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_80_copy.tif')
 
     # Second part : test unsetting scale & offsets from internal metadata
     ds = gdal.Open('tmp/tiff_write_80.tif', gdal.GA_Update)
@@ -2619,10 +2617,10 @@ def test_tiff_write_80():
     assert not offset
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_80.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_80.tif')
 
     # Third part : test storing and retrieving scale & offsets from PAM metadata
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_80_bis.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_80_bis.tif', 1, 1)
     assert ds.GetRasterBand(1).GetScale() is None and ds.GetRasterBand(1).GetOffset() is None, \
         'expected None values'
     ds = None
@@ -2660,7 +2658,7 @@ def test_tiff_write_80():
     assert not offset
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_80_bis.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_80_bis.tif')
 
 ###############################################################################
 # Test retrieving GCP from PAM
@@ -2691,7 +2689,7 @@ def test_tiff_write_81():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_81.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_81.tif')
 
 ###############################################################################
 # Test writing & reading a signedbyte 8 bit geotiff
@@ -2700,7 +2698,7 @@ def test_tiff_write_81():
 def test_tiff_write_82():
 
     src_ds = gdal.Open('data/byte.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_82.tif', src_ds, options=['PIXELTYPE=SIGNEDBYTE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_82.tif', src_ds, options=['PIXELTYPE=SIGNEDBYTE'])
     src_ds = None
     ds = None
 
@@ -2709,7 +2707,7 @@ def test_tiff_write_82():
     assert md['PIXELTYPE'] == 'SIGNEDBYTE', 'did not get SIGNEDBYTE'
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_82.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_82.tif')
 
 
 ###############################################################################
@@ -2718,7 +2716,7 @@ def test_tiff_write_82():
 def test_tiff_write_83():
 
     # Test Create() method
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_83.tif', 1, 1, 2)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_83.tif', 1, 1, 2)
     ct = gdal.ColorTable()
     ct.SetColorEntry(127, (255, 255, 255, 255))
     ds.GetRasterBand(1).SetRasterColorTable(ct)
@@ -2728,7 +2726,7 @@ def test_tiff_write_83():
 
     # Test CreateCopy() method
     src_ds = gdal.Open('tmp/tiff_write_83.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_83_2.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_83_2.tif', src_ds)
     src_ds = None
     ds = None
 
@@ -2743,8 +2741,8 @@ def test_tiff_write_83():
     assert cs2 == 255 % 7, 'did not get expected checksum for band 2'
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_83.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_83_2.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_83.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_83_2.tif')
 
 ###############################################################################
 # Test propagation of non-standard JPEG quality when the current directory
@@ -2753,7 +2751,7 @@ def test_tiff_write_83():
 
 def test_tiff_write_84():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
 
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
@@ -2776,7 +2774,7 @@ def test_tiff_write_84():
         gdal.SetConfigOption('COMPRESS_OVERVIEW', None)
         gdal.SetConfigOption('JPEG_QUALITY_OVERVIEW', None)
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_84.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_84.tif')
 
     assert cs == 0, 'did not get expected checksum'
 
@@ -2787,7 +2785,7 @@ def test_tiff_write_84():
 def test_tiff_write_85():
 
     # First part : test storing and retrieving unittype from internal metadata
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_85.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_85.tif', 1, 1)
     ds.GetRasterBand(1).SetUnitType('ft')
     ds = None
 
@@ -2800,14 +2798,14 @@ def test_tiff_write_85():
 
     # Test CreateCopy()
     src_ds = gdal.Open('tmp/tiff_write_85.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_85_copy.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_85_copy.tif', src_ds)
     src_ds = None
     ds = None
     ds = gdal.Open('tmp/tiff_write_85_copy.tif')
     unittype = ds.GetRasterBand(1).GetUnitType()
     assert unittype == 'ft', 'did not get expected values in copy'
     ds = None
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_85_copy.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_85_copy.tif')
 
     # Second part : test unsetting unittype from internal metadata
     ds = gdal.Open('tmp/tiff_write_85.tif', gdal.GA_Update)
@@ -2819,10 +2817,10 @@ def test_tiff_write_85():
     assert unittype == '', 'did not get expected values in internal case (2)'
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_85.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_85.tif')
 
     # Third part : test storing and retrieving unittype from PAM metadata
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_85_bis.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_85_bis.tif', 1, 1)
     assert not ds.GetRasterBand(1).GetUnitType(), 'expected None values'
     ds = None
 
@@ -2853,7 +2851,7 @@ def test_tiff_write_85():
     assert unittype == '', 'did not get expected values in PAM case (2)'
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_85_bis.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_85_bis.tif')
 
 ###############################################################################
 # Test special handling of xml:ESRI domain.  When the ESRI_XML_PAM config
@@ -2866,7 +2864,7 @@ def test_tiff_write_86():
 
     gdal.SetConfigOption('ESRI_XML_PAM', 'YES')
 
-    ds = gdaltest.tiff_drv.Create('tmp/tiff_write_86.tif', 100, 100,
+    ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_86.tif', 100, 100,
                                   1, gdal.GDT_Byte)
     ds.SetMetadata(['<abc></abc>'], 'xml:ESRI')
     ds.SetMetadataItem('BaseTest', 'Value')
@@ -2903,7 +2901,7 @@ def test_tiff_write_86():
               'tmp/tiff_write_86.tif.aux.xml')
 
     ds_src = gdal.Open('tmp/tiff_write_86.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_86_cc.tif', ds_src)
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_86_cc.tif', ds_src)
     ds_src = None
     ds = None
 
@@ -2935,8 +2933,8 @@ def test_tiff_write_86():
 
     gdal.SetConfigOption('ESRI_XML_PAM', 'NO')
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_86.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_86_cc.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_86.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_86_cc.tif')
 
 
 ###############################################################################
@@ -2950,7 +2948,7 @@ def test_tiff_write_87():
     src_ds.BuildOverviews('NEAR', overviewlist=[2, 4])
     expected_cs1 = src_ds.GetRasterBand(1).GetOverview(0).Checksum()
     expected_cs2 = src_ds.GetRasterBand(1).GetOverview(1).Checksum()
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_87_dst.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES', 'ENDIANNESS=LITTLE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_87_dst.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES', 'ENDIANNESS=LITTLE'])
     ds = None
     src_ds = None
 
@@ -2984,8 +2982,8 @@ def test_tiff_write_87():
     except OSError:
         pytest.fail('validate_cloud_optimized_geotiff failed')
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_87_src.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_87_dst.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_87_src.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_87_dst.tif')
 
     # Check checksums
     assert cs1 == expected_cs1 and cs2 == expected_cs2, 'did not get expected checksums'
@@ -3002,7 +3000,7 @@ def test_tiff_write_87():
 def test_tiff_write_88():
 
     # The file would be > 4.2 GB without SPARSE_OK
-    src_ds = gdaltest.tiff_drv.Create('tmp/tiff_write_88_src.tif', 60000, 60000, 1,
+    src_ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_88_src.tif', 60000, 60000, 1,
                                       options=['TILED=YES', 'SPARSE_OK=YES'])
     src_ds.BuildOverviews('NONE', overviewlist=[2, 4])
     # Just write one data block so that we can truncate it
@@ -3027,7 +3025,7 @@ def test_tiff_write_88():
     gdal.SetConfigOption('GTIFF_DELETE_ON_ERROR', 'NO')
     gdal.SetConfigOption('CHECK_DISK_FREE_SPACE', 'NO')  # we don't want free space to be an issue here
     gdal.PushErrorHandler('CPLQuietErrorHandler')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_88_dst.tif', src_ds,
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_88_dst.tif', src_ds,
                                       options=['TILED=YES', 'COPY_SRC_OVERVIEWS=YES', 'ENDIANNESS=LITTLE'])
     gdal.PopErrorHandler()
     gdal.SetConfigOption('GTIFF_DELETE_ON_ERROR', None)
@@ -3052,7 +3050,7 @@ def test_tiff_write_88():
 
 
 def test_tiff_write_89():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -3094,14 +3092,14 @@ def test_tiff_write_89():
 
         last_size = size
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_89.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_89.tif')
 
 ###############################################################################
 # Test JPEG_QUALITY propagation while creating (internal) overviews
 
 
 def test_tiff_write_90():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -3133,14 +3131,14 @@ def test_tiff_write_90():
 
         last_size = size
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_90.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_90.tif')
 
 
 ###############################################################################
 # Test JPEG_QUALITY propagation while creating (internal) overviews after re-opening
 
 def test_tiff_write_91():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -3177,7 +3175,7 @@ def test_tiff_write_91():
 
         last_size = size
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_91.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_91.tif')
 
 
 ###############################################################################
@@ -3185,7 +3183,7 @@ def test_tiff_write_91():
 # This will test that we correctly guess the quality of the main dataset
 
 def test_tiff_write_92():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -3226,14 +3224,14 @@ def test_tiff_write_92():
 
         last_size = size
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_92.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_92.tif')
 
 ###############################################################################
 # Test JPEG_QUALITY_OVERVIEW propagation while creating external overviews
 
 
 def test_tiff_write_93():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -3282,7 +3280,7 @@ def test_tiff_write_93():
 
         last_size = size
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_93.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_93.tif')
 
 
 ###############################################################################
@@ -3290,7 +3288,7 @@ def test_tiff_write_93():
 # and check JPEG_QUALITY propagation without warning
 
 def test_tiff_write_94():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -3312,8 +3310,8 @@ def test_tiff_write_94():
     cs = ds.GetRasterBand(1).GetMaskBand().Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_94_src.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_94_dst.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_94_src.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_94_dst.tif')
 
     assert cs == 3, 'wrong checksum'
 
@@ -3324,17 +3322,17 @@ def test_tiff_write_94():
 
 def test_tiff_write_95():
 
-    src_ds = gdaltest.tiff_drv.Create('tmp/tiff_write_95_src.tif', 7171, 6083, options=['SPARSE_OK=YES'])
+    src_ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_95_src.tif', 7171, 6083, options=['SPARSE_OK=YES'])
     src_ds.BuildOverviews('NONE', overviewlist=[2, 4, 8, 16, 32, 64])
     gdal.SetConfigOption('GTIFF_DONT_WRITE_BLOCKS', 'YES')
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_95_dst.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_95_dst.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
     gdal.SetConfigOption('GTIFF_DONT_WRITE_BLOCKS', None)
     ok = ds is not None
     ds = None
     src_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_95_src.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_95_dst.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_95_src.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_95_dst.tif')
 
     assert ok
 
@@ -3345,7 +3343,7 @@ def test_tiff_write_95():
 def test_tiff_write_96(other_options = [], nbands = 1, nbits = 8):
 
     gdal.SetConfigOption('GDAL_TIFF_INTERNAL_MASK', 'YES')
-    src_ds = gdaltest.tiff_drv.Create('tmp/tiff_write_96_src.tif', 100, 100, nbands, options = ['NBITS=' + str(nbits)])
+    src_ds = gdaltest.gtiff_drv.Create('tmp/tiff_write_96_src.tif', 100, 100, nbands, options = ['NBITS=' + str(nbits)])
     src_ds.GetRasterBand(1).Fill(255 if nbits == 8 else 127)
     src_ds.CreateMaskBand(gdal.GMF_PER_DATASET)
     from sys import version_info
@@ -3361,7 +3359,7 @@ def test_tiff_write_96(other_options = [], nbands = 1, nbits = 8):
     expected_cs_ovr_2 = src_ds.GetRasterBand(1).GetOverview(1).Checksum()
     expected_cs_ovr_mask_2 = src_ds.GetRasterBand(1).GetOverview(1).GetMaskBand().Checksum()
 
-    ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_96_dst.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'] + other_options + ['NBITS=' + str(nbits)])
+    ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_96_dst.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'] + other_options + ['NBITS=' + str(nbits)])
     ds = None
     src_ds = None
     gdal.SetConfigOption('GDAL_TIFF_INTERNAL_MASK', None)
@@ -3402,8 +3400,8 @@ def test_tiff_write_96(other_options = [], nbands = 1, nbits = 8):
     except OSError:
         pytest.fail('validate_cloud_optimized_geotiff failed')
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_96_src.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_96_dst.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_96_src.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_96_dst.tif')
 
 
 def test_tiff_write_96_tiled_threads_nbits7_nbands1():
@@ -3493,7 +3491,7 @@ def test_tiff_write_97():
 
     src_ds = gdal.Open('data/byte_point.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_97.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_97.tif', src_ds)
 
     gt = new_ds.GetGeoTransform()
     md = new_ds.GetMetadataItem('AREA_OR_POINT')
@@ -3505,13 +3503,13 @@ def test_tiff_write_97():
 
     assert md == 'Point', 'did not get expected AREA_OR_POINT value'
 
-    gdaltest.tiff_drv.Delete('tmp/test_97.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_97.tif')
 
     # Again, but ignoring PixelIsPoint
 
     gdal.SetConfigOption('GTIFF_POINT_GEO_IGNORE', 'TRUE')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_97_2.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_97_2.tif', src_ds)
 
     gt = new_ds.GetGeoTransform()
     md = new_ds.GetMetadataItem('AREA_OR_POINT')
@@ -3542,7 +3540,7 @@ def test_tiff_write_97():
 
     assert md == 'Point', 'did not get expected AREA_OR_POINT value'
 
-    gdaltest.tiff_drv.Delete('tmp/test_97_2.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_97_2.tif')
 
 ###############################################################################
 # Create a rotated geotiff file (uses a geomatrix) with - PixelIsPoint
@@ -3554,7 +3552,7 @@ def test_tiff_write_98():
         src_ds = gdal.Open('data/geomatrix.tif')
 
     with gdaltest.config_option('GTIFF_POINT_GEO_IGNORE', 'TRUE'):
-        new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_98.tif', src_ds)
+        new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_98.tif', src_ds)
 
         gt = new_ds.GetGeoTransform()
         md = new_ds.GetMetadataItem('AREA_OR_POINT')
@@ -3582,7 +3580,7 @@ def test_tiff_write_98():
 
     assert md == 'Point', 'did not get expected AREA_OR_POINT value'
 
-    gdaltest.tiff_drv.Delete('tmp/test_98.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_98.tif')
 
 ###############################################################################
 # Create copy into a RGB JPEG-IN-TIFF (#3887)
@@ -3591,7 +3589,7 @@ def test_tiff_write_98():
 def test_tiff_write_99():
 
     src_ds = gdal.Open('data/rgbsmall.tif')
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_99.tif', src_ds, options=['COMPRESS=JPEG'])
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_99.tif', src_ds, options=['COMPRESS=JPEG'])
     del new_ds
     src_ds = None
 
@@ -3601,7 +3599,7 @@ def test_tiff_write_99():
     cs3 = ds.GetRasterBand(3).Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_99.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_99.tif')
 
     assert (cs1, cs2, cs3) == (21629, 21651, 21371), ('%d,%d,%d' % (cs1, cs2, cs3))
 
@@ -3611,9 +3609,9 @@ def test_tiff_write_99():
 
 def test_tiff_write_100():
 
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/test_100_src.tif', 16, 16, 2)
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/test_100_src.tif', 16, 16, 2)
     src_ds.GetRasterBand(1).Fill(255)
-    new_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/test_100_dst.tif', src_ds, options=['COMPRESS=JPEG'])
+    new_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/test_100_dst.tif', src_ds, options=['COMPRESS=JPEG'])
     del new_ds
     src_ds = None
 
@@ -3622,8 +3620,8 @@ def test_tiff_write_100():
     cs2 = ds.GetRasterBand(2).Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/test_100_src.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/test_100_dst.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/test_100_src.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/test_100_dst.tif')
 
     assert (cs1, cs2) == (3118, 0), ('%d,%d' % (cs1, cs2))
 
@@ -3635,7 +3633,7 @@ def test_tiff_write_100():
 
 def test_tiff_write_101():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if not gdaltest.run_slow_tests():
         pytest.skip()
 
@@ -3676,7 +3674,7 @@ Band 1}""".encode('ascii'))
         if md['DMD_CREATIONOPTIONLIST'].find(compression_method) == -1:
             continue
 
-        ds = gdaltest.tiff_drv.CreateCopy('tmp/tiff_write_101.tif', src_ds,
+        ds = gdaltest.gtiff_drv.CreateCopy('tmp/tiff_write_101.tif', src_ds,
                                           options=['COMPRESS=' + compression_method, 'BLOCKXSIZE=2500', 'BLOCKYSIZE=4000'])
         ds = None
 
@@ -3686,20 +3684,20 @@ Band 1}""".encode('ascii'))
         error_msg = gdal.GetLastErrorMsg()
         ds = None
 
-        gdaltest.tiff_drv.Delete('tmp/tiff_write_101.tif')
+        gdaltest.gtiff_drv.Delete('tmp/tiff_write_101.tif')
 
         if error_msg != '':
             src_ds = None
-            gdaltest.tiff_drv.Delete('tmp/tiff_write_101.bin')
+            gdaltest.gtiff_drv.Delete('tmp/tiff_write_101.bin')
             pytest.fail()
 
         if compression_method != 'JPEG' and cs != expected_cs:
             src_ds = None
-            gdaltest.tiff_drv.Delete('tmp/tiff_write_101.bin')
+            gdaltest.gtiff_drv.Delete('tmp/tiff_write_101.bin')
             pytest.fail('for compression method %s, got %d instead of %d' % (compression_method, cs, expected_cs))
 
     src_ds = None
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_101.bin')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_101.bin')
 
 ###############################################################################
 # Test writing and reading back COMPD_CS
@@ -3707,7 +3705,7 @@ Band 1}""".encode('ascii'))
 
 def test_tiff_write_102():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_102.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_102.tif', 1, 1)
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(7401)
     name = sr.GetAttrValue('COMPD_CS')
@@ -3723,7 +3721,7 @@ def test_tiff_write_102():
         wkt2 = ds.GetProjectionRef()
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_102.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_102.tif')
 
     assert wkt1.startswith('COMPD_CS'), 'expected COMPD_CS, but got something else'
 
@@ -3754,8 +3752,8 @@ def test_tiff_write_103():
     src_ds = None
     dst_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_103_src.tif')
-    gdaltest.tiff_drv.Delete('tmp/tiff_write_103_dst.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_103_src.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiff_write_103_dst.tif')
 
     assert src_cs == dst_cs, 'did not get expected checksum'
 
@@ -3767,7 +3765,7 @@ def test_tiff_write_103():
 def test_tiff_write_104():
 
     src_ds = gdal.Open('data/spaf27_correct.tif')
-    dst_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_104.tif', src_ds)
+    dst_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_104.tif', src_ds)
 
     src_ds = None
     del dst_ds
@@ -3780,7 +3778,7 @@ def test_tiff_write_104():
     fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
     assert fe == pytest.approx(2000000.0, abs=0.001), 'did not get expected false easting'
 
-    gdaltest.tiff_drv.Delete('tmp/test_104.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_104.tif')
 
 ###############################################################################
 # Confirm as best we can that we can write geotiff files with detailed
@@ -3805,7 +3803,7 @@ def test_tiff_write_105():
 
     ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/bug4468.tif')
+    gdaltest.gtiff_drv.Delete('tmp/bug4468.tif')
 
 ###############################################################################
 # Test the direct copy mechanism of JPEG source
@@ -3816,7 +3814,7 @@ def test_tiff_write_106(filename='../gdrivers/data/byte_with_xmp.jpg', options=N
     if options is None:
         options = ['COMPRESS=JPEG']
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -3826,7 +3824,7 @@ def test_tiff_write_106(filename='../gdrivers/data/byte_with_xmp.jpg', options=N
     for i in range(nbands):
         src_cs.append(src_ds.GetRasterBand(i + 1).Checksum())
 
-    out_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_106.tif', src_ds, options=options)
+    out_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_106.tif', src_ds, options=options)
     out_ds = None
 
     out_ds = gdal.Open('/vsimem/tiff_write_106.tif')
@@ -3904,14 +3902,14 @@ def test_tiff_write_114():
 
 
 def test_tiff_write_115():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
     tmpfilename = '/vsimem/tiff_write_115.tif'
 
     src_ds = gdal.Open('data/stefan_full_rgba.tif')
-    ds = gdaltest.tiff_drv.CreateCopy(tmpfilename, src_ds, options=['COMPRESS=JPEG'])
+    ds = gdaltest.gtiff_drv.CreateCopy(tmpfilename, src_ds, options=['COMPRESS=JPEG'])
     assert ds is not None
     ds = None
     src_ds = None
@@ -3950,14 +3948,14 @@ def test_tiff_write_115():
 
 
 def test_tiff_write_116():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
     tmpfilename = '/vsimem/tiff_write_116.tif'
 
     src_ds = gdal.Open('data/stefan_full_rgba.tif')
-    ds = gdaltest.tiff_drv.CreateCopy(tmpfilename, src_ds, options=['COMPRESS=JPEG', 'INTERLEAVE=BAND'])
+    ds = gdaltest.gtiff_drv.CreateCopy(tmpfilename, src_ds, options=['COMPRESS=JPEG', 'INTERLEAVE=BAND'])
     assert ds is not None
     ds = None
     src_ds = None
@@ -3997,7 +3995,7 @@ def test_tiff_write_116():
 
 def test_tiff_write_117():
     # This fail with a libtiff 4.x older than 2012-08-13
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['LIBTIFF'] != 'INTERNAL':
         pytest.skip()
 
@@ -4116,7 +4114,7 @@ def test_tiff_write_121():
   </VRTRasterBand>
 </VRTDataset>""")
     gdal.PushErrorHandler('CPLQuietErrorHandler')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_121.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_121.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
     gdal.PopErrorHandler()
     assert ds is None
     src_ds = None
@@ -4141,7 +4139,7 @@ def test_tiff_write_121():
   </VRTRasterBand>
 </VRTDataset>""")
     gdal.PushErrorHandler('CPLQuietErrorHandler')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_121.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_121.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
     gdal.PopErrorHandler()
     assert ds is None
     src_ds = None
@@ -4170,7 +4168,7 @@ def test_tiff_write_121():
   </VRTRasterBand>
 </VRTDataset>""")
     gdal.PushErrorHandler('CPLQuietErrorHandler')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_121.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_121.tif', src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
     gdal.PopErrorHandler()
     assert ds is None
     src_ds = None
@@ -4182,7 +4180,7 @@ def test_tiff_write_121():
 
 
 def test_tiff_write_122():
-    new_ds = gdaltest.tiff_drv.Create('tmp/tags122.tif', 1, 1, 1)
+    new_ds = gdaltest.gtiff_drv.Create('tmp/tags122.tif', 1, 1, 1)
 
     new_ds.SetMetadata({
         'TIFFTAG_RESOLUTIONUNIT': '*',
@@ -4202,7 +4200,7 @@ def test_tiff_write_122():
 
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/tags122.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tags122.tif')
 
 ###############################################################################
 # Test implicit photometric interpretation
@@ -4210,7 +4208,7 @@ def test_tiff_write_122():
 
 def test_tiff_write_123():
 
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_123_src.tif', 1, 1, 5, gdal.GDT_Int16)
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_123_src.tif', 1, 1, 5, gdal.GDT_Int16)
     src_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_GreenBand)
     src_ds.GetRasterBand(5).SetColorInterpretation(gdal.GCI_AlphaBand)
     src_ds.GetRasterBand(3).SetColorInterpretation(gdal.GCI_BlueBand)
@@ -4227,7 +4225,7 @@ def test_tiff_write_123():
     assert src_ds.GetRasterBand(5).GetColorInterpretation() == gdal.GCI_AlphaBand
     assert src_ds.GetMetadataItem('TIFFTAG_EXTRASAMPLES', '_DEBUG_') == '0,2'
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_123.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_123.tif', src_ds)
     del new_ds
     statBuf = gdal.VSIStatL('/vsimem/tiff_write_123.tif.aux.xml', gdal.VSI_STAT_EXISTS_FLAG | gdal.VSI_STAT_NATURE_FLAG | gdal.VSI_STAT_SIZE_FLAG)
     assert statBuf is None, 'did not expect PAM file'
@@ -4240,11 +4238,11 @@ def test_tiff_write_123():
     assert ds.GetMetadataItem('TIFFTAG_EXTRASAMPLES', '_DEBUG_') == '0,2'
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_src.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_src.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123.tif')
 
     # From implicit RGB to BGR (with Photometric = MinIsBlack)
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_123_bgr.tif', 1, 1, 3, gdal.GDT_Byte)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_123_bgr.tif', 1, 1, 3, gdal.GDT_Byte)
     assert ds.GetMetadataItem('TIFFTAG_PHOTOMETRIC', '_DEBUG_') == '2'
     assert ds.GetMetadataItem('TIFFTAG_EXTRASAMPLES', '_DEBUG_') is None
     ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_BlueBand)
@@ -4277,10 +4275,10 @@ def test_tiff_write_123():
     assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
     assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_RedBand
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_bgr.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_bgr.tif')
 
     # Create a BGR with PROFILE=BASELINE --> no TIFFTAG_GDAL_METADATA tag, but .aux.xml instead
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_123_bgr.tif', 1, 1, 3,
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_123_bgr.tif', 1, 1, 3,
                                   options=['PROFILE=BASELINE'])
     ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_BlueBand)
     ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_GreenBand)
@@ -4296,10 +4294,10 @@ def test_tiff_write_123():
     assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
     assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_RedBand
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_bgr.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_bgr.tif')
 
     # From implicit RGBA to MINISBLACK
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_123_rgba.tif', 1, 1, 4, gdal.GDT_Byte)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_123_rgba.tif', 1, 1, 4, gdal.GDT_Byte)
     assert ds.GetMetadataItem('TIFFTAG_PHOTOMETRIC', '_DEBUG_') == '2'
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
     assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
@@ -4311,11 +4309,11 @@ def test_tiff_write_123():
     assert ds.GetMetadataItem('TIFFTAG_EXTRASAMPLES', '_DEBUG_') == '0,0,2'
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_rgba.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_rgba.tif')
 
     # From that implicit RGBA to Gray,Undefined,Undefined,Alpha doesn't
     # produce PAM file
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_123_guua.tif', 1, 1, 4, gdal.GDT_Byte)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_123_guua.tif', 1, 1, 4, gdal.GDT_Byte)
     ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_GrayIndex)
     ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_Undefined)
     ds.GetRasterBand(3).SetColorInterpretation(gdal.GCI_Undefined)
@@ -4329,42 +4327,42 @@ def test_tiff_write_123():
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_GrayIndex
     assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_guua.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_guua.tif')
 
     # Test that CreateCopy() from a RGB UInt16 doesn't generate ExtraSamples
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_123_rgb_src.tif',
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_123_rgb_src.tif',
                                       1, 1, 3, gdal.GDT_UInt16, options=['PHOTOMETRIC=RGB'])
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_123_rgb.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_123_rgb.tif', src_ds)
     src_ds = None
     assert ds.GetMetadataItem('TIFFTAG_PHOTOMETRIC', '_DEBUG_') == '2'
     assert ds.GetMetadataItem('TIFFTAG_EXTRASAMPLES', '_DEBUG_') is None
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_rgb_src.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_rgb.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_rgb_src.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_rgb.tif')
 
     # Test that PHOTOMETRIC=RGB overrides the source color interpretation of the
     # first 3 bands
     src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1, 3)
-    gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_123_rgb.tif', src_ds,
+    gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_123_rgb.tif', src_ds,
                                  options=['PHOTOMETRIC=RGB'])
     ds = gdal.Open('/vsimem/tiff_write_123_rgb.tif')
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_rgb.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_rgb.tif')
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1, 5)
     src_ds.GetRasterBand(5).SetColorInterpretation(gdal.GCI_AlphaBand)
-    gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_123_rgbua.tif', src_ds,
+    gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_123_rgbua.tif', src_ds,
                                  options=['PHOTOMETRIC=RGB'])
     ds = gdal.Open('/vsimem/tiff_write_123_rgbua.tif')
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
     assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_Undefined
     assert ds.GetRasterBand(5).GetColorInterpretation() == gdal.GCI_AlphaBand
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_rgbua.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_rgbua.tif')
 
     # Test updating alpha to undefined
-    gdaltest.tiff_drv.Create('/vsimem/tiff_write_123_rgba_to_undefined.tif', 1, 1, 4,
+    gdaltest.gtiff_drv.Create('/vsimem/tiff_write_123_rgba_to_undefined.tif', 1, 1, 4,
                              options=['PHOTOMETRIC=RGB', 'ALPHA=YES'])
     ds = gdal.Open('/vsimem/tiff_write_123_rgba_to_undefined.tif', gdal.GA_Update)
     ds.GetRasterBand(4).SetColorInterpretation(gdal.GCI_Undefined)
@@ -4374,7 +4372,7 @@ def test_tiff_write_123():
     ds = gdal.Open('/vsimem/tiff_write_123_rgba_to_undefined.tif')
     assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_Undefined
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_123_rgba_to_undefined.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_123_rgba_to_undefined.tif')
 
 ###############################################################################
 # Test error cases with palette creation
@@ -4382,7 +4380,7 @@ def test_tiff_write_123():
 
 def test_tiff_write_124():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_124.tif', 1, 1, 3, gdal.GDT_Byte)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_124.tif', 1, 1, 3, gdal.GDT_Byte)
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     # Test "SetColorTable() can only be called on band 1"
@@ -4398,7 +4396,7 @@ def test_tiff_write_124():
 
     ds = None
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_124.tif', 1, 1, 1, gdal.GDT_UInt32)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_124.tif', 1, 1, 1, gdal.GDT_UInt32)
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     # Test "SetColorTable() only supported for Byte or UInt16 bands in TIFF format."
     ret = ds.GetRasterBand(1).SetColorTable(gdal.ColorTable())
@@ -4408,11 +4406,11 @@ def test_tiff_write_124():
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     # Test "SetColorTable() only supported for Byte or UInt16 bands in TIFF format."
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_124.tif', 1, 1, 1, gdal.GDT_UInt32, options=['PHOTOMETRIC=PALETTE'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_124.tif', 1, 1, 1, gdal.GDT_UInt32, options=['PHOTOMETRIC=PALETTE'])
     gdal.PopErrorHandler()
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_124.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_124.tif')
 
 ###############################################################################
 # Test out-of-memory conditions with SplitBand and SplitBitmapBand
@@ -4423,7 +4421,7 @@ def test_tiff_write_125():
     if gdal.GetConfigOption('SKIP_MEM_INTENSIVE_TEST') is not None:
         pytest.skip()
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_125.tif', 2147000000, 5000, 65535, options=['SPARSE_OK=YES', 'BLOCKYSIZE=5000', 'COMPRESS=LZW', 'BIGTIFF=NO'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_125.tif', 2147000000, 5000, 65535, options=['SPARSE_OK=YES', 'BLOCKYSIZE=5000', 'COMPRESS=LZW', 'BIGTIFF=NO'])
     ds = None
 
     ds = gdal.Open('/vsimem/tiff_write_125.tif')
@@ -4451,7 +4449,7 @@ def test_tiff_write_125():
 
 def test_tiff_write_126():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -4472,7 +4470,7 @@ def test_tiff_write_126():
 
     for (options, cs1, cs2, cs3, cs4) in options_list:
         os.environ['JPEGMEM'] = '500M'
-        ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_126.tif', src_ds, options=options)
+        ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_126.tif', src_ds, options=options)
         ds = None
         del os.environ['JPEGMEM']
 
@@ -4495,7 +4493,7 @@ def test_tiff_write_126():
         assert ovr_1_data == subsampled_data, options
         ds = None
 
-        gdaltest.tiff_drv.Delete('/vsimem/tiff_write_126.tif')
+        gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_126.tif')
 
     src_ds = gdal.Open('../gdrivers/data/small_world_400pct_1band.vrt')
 
@@ -4507,7 +4505,7 @@ def test_tiff_write_126():
 
     for (options, cs1, cs3, cs4) in options_list:
         os.environ['JPEGMEM'] = '500M'
-        ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_126.tif', src_ds, options=options)
+        ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_126.tif', src_ds, options=options)
         ds = None
         del os.environ['JPEGMEM']
 
@@ -4526,14 +4524,14 @@ def test_tiff_write_126():
         assert ovr_1_data == subsampled_data, options
         ds = None
 
-        gdaltest.tiff_drv.Delete('/vsimem/tiff_write_126.tif')
+        gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_126.tif')
 
     # Test single-strip, opened as split band
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_126_src.tif', 8, 2001)
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_126_src.tif', 8, 2001)
     src_ds.GetRasterBand(1).Fill(255)
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_126.tif', src_ds, options=['COMPRESS=JPEG', 'BLOCKYSIZE=2001'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_126.tif', src_ds, options=['COMPRESS=JPEG', 'BLOCKYSIZE=2001'])
     src_ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_126_src.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_126_src.tif')
     ds = None
 
     ds = gdal.Open('/vsimem/tiff_write_126.tif')
@@ -4544,7 +4542,7 @@ def test_tiff_write_126():
     assert ovr_1_data == subsampled_data
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_126.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_126.tif')
 
     # We need libtiff 4.0.4 (unreleased at that time)
     if md['LIBTIFF'] != 'INTERNAL':
@@ -4552,7 +4550,7 @@ def test_tiff_write_126():
         return
 
     # Test with completely sparse file
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_126.tif', 1024, 1024, options=['COMPRESS=JPEG', 'SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_126.tif', 1024, 1024, options=['COMPRESS=JPEG', 'SPARSE_OK=YES'])
     ds = None
 
     ds = gdal.Open('/vsimem/tiff_write_126.tif')
@@ -4561,10 +4559,10 @@ def test_tiff_write_126():
     assert ds.GetRasterBand(1).GetMetadataItem('BLOCK_OFFSET_0_0', 'TIFF') is None
     assert ds.GetRasterBand(1).GetMetadataItem('BLOCK_SIZE_0_0', 'TIFF') is None
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_126.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_126.tif')
 
     # Test with partially sparse file
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_126.tif', 1024, 1024, 3, options=['COMPRESS=JPEG', 'SPARSE_OK=YES', 'INTERLEAVE=BAND'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_126.tif', 1024, 1024, 3, options=['COMPRESS=JPEG', 'SPARSE_OK=YES', 'INTERLEAVE=BAND'])
     # Fill band 3, but let blocks of band 1 unwritten.
     ds.GetRasterBand(3).Fill(0)
     ds = None
@@ -4573,7 +4571,7 @@ def test_tiff_write_126():
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     assert cs == 0
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_126.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_126.tif')
 
 ###############################################################################
 # Test setting/unsetting metadata in update mode (#5628)
@@ -4581,7 +4579,7 @@ def test_tiff_write_126():
 
 def test_tiff_write_127():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_127.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_127.tif', 1, 1)
     ds = None
 
     for i in range(2):
@@ -4626,7 +4624,7 @@ def test_tiff_write_127():
             print(i)
             pytest.fail('unexpected PAM file')
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_127.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_127.tif')
 
 ###############################################################################
 # Test lossless copying of a CMYK JPEG into JPEG-in-TIFF (#5712)
@@ -4634,7 +4632,7 @@ def test_tiff_write_127():
 
 def test_tiff_write_128():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -4645,7 +4643,7 @@ def test_tiff_write_128():
     # Will received implicitly CMYK photometric interpretation.
     old_val = gdal.GetConfigOption('GDAL_PAM_ENABLED')
     gdal.SetConfigOption('GDAL_PAM_ENABLED', 'NO')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_128.tif', src_ds, options=['COMPRESS=JPEG'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_128.tif', src_ds, options=['COMPRESS=JPEG'])
     ds = None
     gdal.SetConfigOption('GDAL_PAM_ENABLED', old_val)
 
@@ -4656,12 +4654,12 @@ def test_tiff_write_128():
         assert src_ds.GetRasterBand(i + 1).Checksum() == ds.GetRasterBand(i + 1).Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_128.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_128.tif')
 
     # Try with explicit CMYK photometric interpretation
     old_val = gdal.GetConfigOption('GDAL_PAM_ENABLED')
     gdal.SetConfigOption('GDAL_PAM_ENABLED', 'NO')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_128.tif', src_ds, options=['COMPRESS=JPEG', 'PHOTOMETRIC=CMYK'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_128.tif', src_ds, options=['COMPRESS=JPEG', 'PHOTOMETRIC=CMYK'])
     ds = None
     gdal.SetConfigOption('GDAL_PAM_ENABLED', old_val)
 
@@ -4672,12 +4670,12 @@ def test_tiff_write_128():
         assert src_ds.GetRasterBand(i + 1).Checksum() == ds.GetRasterBand(i + 1).Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_128.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_128.tif')
 
     # Try with more neutral colorspace in the case the source JPEG is not really CMYK (yes that happens !)
     old_val = gdal.GetConfigOption('GDAL_PAM_ENABLED')
     gdal.SetConfigOption('GDAL_PAM_ENABLED', 'NO')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_128.tif', src_ds, options=['COMPRESS=JPEG', 'PHOTOMETRIC=MINISBLACK', 'PROFILE=BASELINE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_128.tif', src_ds, options=['COMPRESS=JPEG', 'PHOTOMETRIC=MINISBLACK', 'PROFILE=BASELINE'])
     ds = None
     gdal.SetConfigOption('GDAL_PAM_ENABLED', old_val)
 
@@ -4689,14 +4687,14 @@ def test_tiff_write_128():
         assert src_ds.GetRasterBand(i + 1).Checksum() == ds.GetRasterBand(i + 1).Checksum()
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_128.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_128.tif')
 
 ###############################################################################
 # Check effective guessing of existing JPEG quality
 
 
 def test_tiff_write_129():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -4704,7 +4702,7 @@ def test_tiff_write_129():
         for photometric in ['RGB', 'YCBCR']:
             cs_ref = 0
             for i in range(2):
-                ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_129.tif', 64, 32, 3,
+                ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_129.tif', 64, 32, 3,
                                               options=['COMPRESS=JPEG', 'TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32', 'JPEG_QUALITY=50', 'PHOTOMETRIC=' + photometric, 'JPEGTABLESMODE=' + jpegtablesmode])
                 src_ds = gdal.Open('data/rgbsmall.tif')
                 data = src_ds.ReadRaster(0, 0, 32, 32)
@@ -4721,7 +4719,7 @@ def test_tiff_write_129():
                 with gdaltest.SetCacheMax(0):
                     cs = ds.GetRasterBand(1).Checksum()
                 ds = None
-                gdaltest.tiff_drv.Delete('/vsimem/tiff_write_129.tif')
+                gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_129.tif')
 
                 if i == 0:
                     cs_ref = cs
@@ -4736,7 +4734,7 @@ def test_tiff_write_129():
 
 
 def test_tiff_write_130():
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -4770,13 +4768,13 @@ def test_tiff_write_130():
 
 def test_tiff_write_131(level=1):
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LZMA') == -1:
         pytest.skip()
 
     filename = '/vsimem/tiff_write_131.tif'
     src_ds = gdal.Open('data/byte.tif')
-    ds = gdaltest.tiff_drv.CreateCopy(filename, src_ds,
+    ds = gdaltest.gtiff_drv.CreateCopy(filename, src_ds,
                                  options=['COMPRESS=LZMA', 'LZMA_PRESET=' + str(level)])
     assert ds.GetRasterBand(1).Checksum() == 4672
     ds = None
@@ -4805,7 +4803,7 @@ def test_tiff_write_132():
 
     for i in range(2):
 
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_132.tif', 1, 1)
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_132.tif', 1, 1)
         ds = None
 
         # Open in read-only
@@ -4834,7 +4832,7 @@ def test_tiff_write_132():
         assert ds.GetMetadataItem('FOO') == 'BAZ' and ds.GetRasterBand(1).GetMetadataItem('FOO') == 'BAZ'
         ds = None
 
-        gdaltest.tiff_drv.Delete('/vsimem/tiff_write_132.tif')
+        gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_132.tif')
 
     
 ###############################################################################
@@ -4843,7 +4841,7 @@ def test_tiff_write_132():
 
 def test_tiff_write_133():
 
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES'])
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES'])
     src_ds.SetGeoTransform([1, 2, 0, 3, 0, -2])
     srs = osr.SpatialReference()
     srs.SetFromUserInput('EPSG:32601')
@@ -4885,7 +4883,7 @@ def test_tiff_write_133():
     assert ret != 0
 
     # Pixel interleaved
-    out_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'BLOCKYSIZE=32'])
+    out_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'BLOCKYSIZE=32'])
     out_ds = None
 
     gdal.SetConfigOption('TIFF_READ_STREAMING', 'YES')
@@ -4908,10 +4906,10 @@ def test_tiff_write_133():
         gdal.PopErrorHandler()
         assert got_data is None
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
 
     # Tiled
-    out_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'TILED=YES'])
+    out_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'TILED=YES'])
     out_ds = None
 
     gdal.SetConfigOption('TIFF_READ_STREAMING', 'YES')
@@ -4937,10 +4935,10 @@ def test_tiff_write_133():
                 assert got_data is not None
 
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
 
     # Band interleaved
-    out_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'INTERLEAVE=BAND'])
+    out_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'INTERLEAVE=BAND'])
     out_ds = None
 
     gdal.SetConfigOption('TIFF_READ_STREAMING', 'YES')
@@ -4954,12 +4952,12 @@ def test_tiff_write_133():
                 got_data = ds.GetRasterBand(band + 1).ReadRaster(0, y, 1024, 1)
                 assert got_data is not None
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
 
     # BIGTIFF
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('BigTIFF') >= 0:
-        out_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'BIGTIFF=YES'])
+        out_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'BIGTIFF=YES'])
         out_ds = None
 
         gdal.SetConfigOption('TIFF_READ_STREAMING', 'YES')
@@ -4973,20 +4971,20 @@ def test_tiff_write_133():
                 assert got_data is not None
 
         ds = None
-        gdaltest.tiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
+        gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_133_dst.tif')
 
     # Compression not supported
     gdal.PushErrorHandler()
-    out_ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'COMPRESS=DEFLATE'])
+    out_ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_133_dst.tif', src_ds, options=['STREAMABLE_OUTPUT=YES', 'COMPRESS=DEFLATE'])
     gdal.PopErrorHandler()
     assert out_ds is None
 
     # Test writing into a non authorized file
-    ds = gdaltest.tiff_drv.Create('/foo/bar', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'BLOCKYSIZE=1'])
+    ds = gdaltest.gtiff_drv.Create('/foo/bar', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'BLOCKYSIZE=1'])
     assert ds is None
 
     gdal.PushErrorHandler()
-    out_ds = gdaltest.tiff_drv.CreateCopy('/foo/bar', src_ds, options=['STREAMABLE_OUTPUT=YES'])
+    out_ds = gdaltest.gtiff_drv.CreateCopy('/foo/bar', src_ds, options=['STREAMABLE_OUTPUT=YES'])
     gdal.PopErrorHandler()
     assert out_ds is None
 
@@ -5002,7 +5000,7 @@ def test_tiff_write_133():
 
     # BigTIFF with IFD not at offset 16
     if md['DMD_CREATIONOPTIONLIST'].find('BigTIFF') >= 0:
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['BIGTIFF=YES'])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['BIGTIFF=YES'])
         ds.GetRasterBand(1).Fill(0)
         ds.FlushCache()
         ds.SetGeoTransform([1, 2, 0, 3, 0, -2])
@@ -5016,7 +5014,7 @@ def test_tiff_write_133():
         assert ds is None
 
     # Test reading strips in not increasing order
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['BLOCKYSIZE=1'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['BLOCKYSIZE=1'])
     for y in range(1000):
         ds.WriteRaster(0, 1000 - y - 1, 1024, 1, 'a' * (3 * 1024))
         ds.FlushCache()
@@ -5035,7 +5033,7 @@ def test_tiff_write_133():
             assert got_data is not None
 
     # Test writing strips in not increasing order in a streamable output
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'BLOCKYSIZE=1'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'BLOCKYSIZE=1'])
     gdal.ErrorReset()
     gdal.PushErrorHandler()
     ret = ds.WriteRaster(0, 999, 1024, 1, 'a' * (3 * 1024))
@@ -5045,7 +5043,7 @@ def test_tiff_write_133():
     ds = None
 
     # Test writing tiles in not increasing order in a streamable output
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'TILED=YES'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_133.tif', 1024, 1000, 3, options=['STREAMABLE_OUTPUT=YES', 'TILED=YES'])
     gdal.ErrorReset()
     gdal.PushErrorHandler()
     ret = ds.WriteRaster(256, 256, 256, 256, 'a' * (3 * 256 * 256))
@@ -5054,7 +5052,7 @@ def test_tiff_write_133():
     assert gdal.GetLastErrorMsg() != ''
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_133.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_133.tif')
 
 ###############################################################################
 # Test DISCARD_LSB
@@ -5063,7 +5061,7 @@ def test_tiff_write_133():
 def test_tiff_write_134():
 
     for interleave in ['BAND', 'PIXEL']:
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1, 3, options=['DISCARD_LSB=0,1,3', 'INTERLEAVE='+interleave])
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1, 3, options=['DISCARD_LSB=0,1,3', 'INTERLEAVE='+interleave])
         ds.GetRasterBand(1).Fill(127)
         ds.GetRasterBand(2).Fill(127)
         ds.GetRasterBand(3).Fill(127)
@@ -5074,13 +5072,13 @@ def test_tiff_write_134():
         val3 = struct.unpack('B', ds.GetRasterBand(3).ReadRaster())[0]
         assert val1 == 127 and val2 == 126 and val3 == 124
         ds = None
-        gdaltest.tiff_drv.Delete('/vsimem/tiff_write_134.tif')
+        gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_134.tif')
 
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_134_src.tif', 1, 1, 3)
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_134_src.tif', 1, 1, 3)
     src_ds.GetRasterBand(1).Fill(127)
     src_ds.GetRasterBand(2).Fill(127)
     src_ds.GetRasterBand(3).Fill(255)
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_134.tif', src_ds, options=['DISCARD_LSB=0,1,3'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_134.tif', src_ds, options=['DISCARD_LSB=0,1,3'])
     ds = None
     ds = gdal.Open('/vsimem/tiff_write_134.tif')
     val1 = struct.unpack('B', ds.GetRasterBand(1).ReadRaster())[0]
@@ -5088,12 +5086,12 @@ def test_tiff_write_134():
     val3 = struct.unpack('B', ds.GetRasterBand(3).ReadRaster())[0]
     assert val1 == 127 and val2 == 126 and val3 == 255
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_134_src.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_134.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_134_src.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_134.tif')
 
     for interleave in ['BAND', 'PIXEL']:
         for dt in [gdal.GDT_Byte, gdal.GDT_UInt16, gdal.GDT_UInt32]:
-            ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1, 3, dt, options=['DISCARD_LSB=3', 'INTERLEAVE='+interleave])
+            ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1, 3, dt, options=['DISCARD_LSB=3', 'INTERLEAVE='+interleave])
             ds.GetRasterBand(1).Fill(127)
             ds.GetRasterBand(2).Fill(127)
             ds.GetRasterBand(3).Fill(127)
@@ -5104,26 +5102,26 @@ def test_tiff_write_134():
             val3 = struct.unpack('B', ds.GetRasterBand(3).ReadRaster(0,0,1,1,1,1,gdal.GDT_Byte))[0]
             assert val1 == 124 and val2 == 124 and val3 == 124
             ds = None
-            gdaltest.tiff_drv.Delete('/vsimem/tiff_write_134.tif')
+            gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_134.tif')
 
     # Error cases
     gdal.ErrorReset()
     with gdaltest.error_handler():
-        gdaltest.tiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1,
+        gdaltest.gtiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1,
                                  options=['DISCARD_LSB=1', 'PHOTOMETRIC=PALETTE'])
     assert gdal.GetLastErrorMsg() != ''
 
     gdal.ErrorReset()
     with gdaltest.error_handler():
         # Too many elements
-        gdaltest.tiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1,
+        gdaltest.gtiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1,
                                  options=['DISCARD_LSB=1,2'])
     assert gdal.GetLastErrorMsg() != ''
 
     gdal.ErrorReset()
     with gdaltest.error_handler():
         # Too many elements
-        gdaltest.tiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1,
+        gdaltest.gtiff_drv.Create('/vsimem/tiff_write_134.tif', 1, 1,
                                  options=['DISCARD_LSB=1', 'NBITS=7'])
     assert gdal.GetLastErrorMsg() != ''
 
@@ -5135,7 +5133,7 @@ def test_tiff_write_135():
 
     # Simple clear
     src_ds = gdal.Open('data/gcps.vrt')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_135.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_135.tif', src_ds)
     ds = None
 
     ds = gdal.Open('/vsimem/tiff_write_135.tif', gdal.GA_Update)
@@ -5149,7 +5147,7 @@ def test_tiff_write_135():
 
     # Double clear
     src_ds = gdal.Open('data/gcps.vrt')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_135.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_135.tif', src_ds)
     ds = None
 
     ds = gdal.Open('/vsimem/tiff_write_135.tif', gdal.GA_Update)
@@ -5164,7 +5162,7 @@ def test_tiff_write_135():
 
     # Clear + set geotransform and new projection
     src_ds = gdal.Open('data/gcps.vrt')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_135.tif', src_ds)
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_135.tif', src_ds)
     ds = None
 
     ds = gdal.Open('/vsimem/tiff_write_135.tif', gdal.GA_Update)
@@ -5189,10 +5187,10 @@ def test_tiff_write_135():
 
 def test_tiff_write_136():
 
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_136_src.tif', 8, 2001)
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_136_src.tif', 8, 2001)
     src_ds.GetRasterBand(1).Fill(1)
     expected_cs = src_ds.GetRasterBand(1).Checksum()
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_136.tif', src_ds, options=['NBITS=1', 'COMPRESS=DEFLATE', 'BLOCKYSIZE=2001'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_136.tif', src_ds, options=['NBITS=1', 'COMPRESS=DEFLATE', 'BLOCKYSIZE=2001'])
     src_ds = None
     ds = None
     ds = gdal.Open('/vsimem/tiff_write_136.tif')
@@ -5209,13 +5207,13 @@ def test_tiff_write_136():
 
 def test_tiff_write_137():
 
-    src_ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_137_src.tif', 4000, 4000)
+    src_ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_137_src.tif', 4000, 4000)
     src_ds.GetRasterBand(1).Fill(1)
     data = src_ds.GetRasterBand(1).ReadRaster()
     expected_cs = src_ds.GetRasterBand(1).Checksum()
 
     # Test NUM_THREADS as creation option
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_137.tif', src_ds,
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_137.tif', src_ds,
                                       options=['BLOCKYSIZE=16', 'COMPRESS=DEFLATE', 'NUM_THREADS=ALL_CPUS'])
     src_ds = None
     ds = None
@@ -5225,7 +5223,7 @@ def test_tiff_write_137():
     assert cs == expected_cs
 
     # Test NUM_THREADS as creation option with Create()
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_137.tif', 4000, 4000, 1,
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_137.tif', 4000, 4000, 1,
                                   options=['BLOCKYSIZE=16', 'COMPRESS=DEFLATE', 'NUM_THREADS=ALL_CPUS'])
     ds.GetRasterBand(1).WriteRaster(0, 0, 4000, 4000, data)
     ds = None
@@ -5235,7 +5233,7 @@ def test_tiff_write_137():
     assert cs == expected_cs
 
     # Test NUM_THREADS as open option
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_137.tif', 4000, 4000,
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_137.tif', 4000, 4000,
                                   options=['TILED=YES', 'COMPRESS=DEFLATE', 'PREDICTOR=2', 'SPARSE_OK=YES'])
     ds = None
     ds = gdal.OpenEx('/vsimem/tiff_write_137.tif', gdal.OF_UPDATE, open_options=['NUM_THREADS=4'])
@@ -5247,7 +5245,7 @@ def test_tiff_write_137():
     assert cs == expected_cs
 
     # Ask data immediately while the block is compressed
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_137.tif', 4000, 4000,
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_137.tif', 4000, 4000,
                                   options=['BLOCKYSIZE=3999', 'COMPRESS=DEFLATE', 'NUM_THREADS=4'])
     ds.WriteRaster(0, 0, 1, 1, 'A')
     ds.FlushCache()
@@ -5260,7 +5258,7 @@ def test_tiff_write_137():
 
     # Test NUM_THREADS with raster == tile
     src_ds = gdal.Open('data/byte.tif')
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_137.tif', src_ds,
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_137.tif', src_ds,
                                       options=['BLOCKYSIZE=20', 'COMPRESS=DEFLATE', 'NUM_THREADS=ALL_CPUS'])
     src_ds = None
     ds = None
@@ -5423,7 +5421,7 @@ def test_tiff_write_139():
 def test_tiff_write_140():
 
     # Nominal case: set alpha to last band
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_140.tif', 1, 1, 5)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_140.tif', 1, 1, 5)
     ds.GetRasterBand(5).SetColorInterpretation(gdal.GCI_AlphaBand)
     ds = None
     statBuf = gdal.VSIStatL('/vsimem/tiff_write_140.tif.aux.xml', gdal.VSI_STAT_EXISTS_FLAG | gdal.VSI_STAT_NATURE_FLAG | gdal.VSI_STAT_SIZE_FLAG)
@@ -5433,7 +5431,7 @@ def test_tiff_write_140():
     ds = None
 
     # Strange case: set alpha to a band, but it is already set on another one
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_140.tif', 1, 1, 5)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_140.tif', 1, 1, 5)
     ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
     # Should emit a warning
     gdal.ErrorReset()
@@ -5450,7 +5448,7 @@ def test_tiff_write_140():
     ds = None
 
     # Strange case: set alpha to a band, but it is already set on another one (because of ALPHA=YES)
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_140.tif', 1, 1, 5, options=['ALPHA=YES'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_140.tif', 1, 1, 5, options=['ALPHA=YES'])
     # Should emit a warning mentioning ALPHA creation option.
     gdal.ErrorReset()
     with gdaltest.error_handler():
@@ -5465,7 +5463,7 @@ def test_tiff_write_140():
     assert ds.GetRasterBand(5).GetColorInterpretation() == gdal.GCI_AlphaBand
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_140.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_140.tif')
 
 ###############################################################################
 # Test GEOTIFF_KEYS_FLAVOR=ESRI_PE with EPSG:3857
@@ -5473,7 +5471,7 @@ def test_tiff_write_140():
 
 def test_tiff_write_141():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_141.tif', 1, 1, options=['GEOTIFF_KEYS_FLAVOR=ESRI_PE'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_141.tif', 1, 1, options=['GEOTIFF_KEYS_FLAVOR=ESRI_PE'])
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(3857)
     ds.SetProjection(srs.ExportToWkt())
@@ -5487,7 +5485,7 @@ def test_tiff_write_141():
 
     assert 'EXTENSION["PROJ4"' in wkt
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_141.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_141.tif')
 
 
 ###############################################################################
@@ -5495,13 +5493,13 @@ def test_tiff_write_141():
 
 def test_tiff_write_142():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_142.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_142.tif', 1, 1)
     ds.SetMetadataItem('AREA_OR_POINT', 'Point')
     ds.SetGeoTransform([10, 1, 0, 100, 0, -1])
     ds = None
 
     src_ds = gdal.Open('/vsimem/tiff_write_142.tif')
-    gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_142_2.tif', src_ds)
+    gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_142_2.tif', src_ds)
     src_ds = None
 
     ds = gdal.Open('/vsimem/tiff_write_142_2.tif')
@@ -5509,8 +5507,8 @@ def test_tiff_write_142():
     md = ds.GetMetadataItem('AREA_OR_POINT')
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_142.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_142_2.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_142.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_142_2.tif')
 
     gt_expected = (10, 1, 0, 100, 0, -1)
     assert gt == gt_expected, 'did not get expected geotransform'
@@ -5524,7 +5522,7 @@ def test_tiff_write_142():
 def test_tiff_write_143():
 
     with gdaltest.error_handler():
-        ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_143.tif', 1000000000, 1000000000)
+        ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_143.tif', 1000000000, 1000000000)
     assert ds is None
 
 ###############################################################################
@@ -5602,7 +5600,7 @@ def test_tiff_write_145():
         gdal.Unlink(filename)
         gdal.ErrorReset()
         with gdaltest.error_handler():
-            ds = gdaltest.tiff_drv.Create(filename, xsize, ysize, bands, datatype, options=creation_options)
+            ds = gdaltest.gtiff_drv.Create(filename, xsize, ysize, bands, datatype, options=creation_options)
         if ds is not None and options.get('expected_failure', False):
             print(options)
             pytest.fail('expected failure, but did not get it')
@@ -5624,7 +5622,7 @@ def test_tiff_write_145():
 
 def test_tiff_write_146():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -5649,7 +5647,7 @@ def test_tiff_write_146():
 
 def test_tiff_write_147():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -5669,7 +5667,7 @@ def test_tiff_write_147():
 
 def test_tiff_write_148():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -5700,18 +5698,18 @@ def test_tiff_write_148():
 def test_tiff_write_149():
 
     # Power-of-two bit depth
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_149.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_149.tif', 1, 1)
     ds.GetRasterBand(1).SetNoDataValue(127)
     ds = None
     ds = gdal.Open('/vsimem/tiff_write_149.tif')
     cs = ds.GetRasterBand(1).Checksum()
     ds = None
     assert cs == 1
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_149.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_149.tif')
 
     # Test implicit blocks
     expected_cs = 13626
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_149.tif', 40, 30, 2, gdal.GDT_UInt16, options=['NBITS=12', 'TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=16', 'INTERLEAVE=BAND', 'SPARSE_OK=YES'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_149.tif', 40, 30, 2, gdal.GDT_UInt16, options=['NBITS=12', 'TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=16', 'INTERLEAVE=BAND', 'SPARSE_OK=YES'])
     ds.GetRasterBand(1).SetNoDataValue(127)
     ds.GetRasterBand(2).SetNoDataValue(127)
     ds = None
@@ -5719,10 +5717,10 @@ def test_tiff_write_149():
     cs = ds.GetRasterBand(1).Checksum()
     ds = None
     assert cs == expected_cs
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_149.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_149.tif')
 
     # NBITS=12, SEPARATE. Checksum must be the same as in the implicit blocks case
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_149.tif', 40, 30, 2, gdal.GDT_UInt16, options=['NBITS=12', 'TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=16', 'INTERLEAVE=BAND'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_149.tif', 40, 30, 2, gdal.GDT_UInt16, options=['NBITS=12', 'TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=16', 'INTERLEAVE=BAND'])
     ds.GetRasterBand(1).SetNoDataValue(127)
     ds.GetRasterBand(2).SetNoDataValue(127)
     ds = None
@@ -5730,10 +5728,10 @@ def test_tiff_write_149():
     cs = ds.GetRasterBand(1).Checksum()
     ds = None
     assert cs == expected_cs
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_149.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_149.tif')
 
     # NBITS=12, CONTIG. Checksum must be the same as in the implicit blocks case
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_149.tif', 40, 30, 2, gdal.GDT_UInt16, options=['NBITS=12', 'TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=16', 'INTERLEAVE=PIXEL'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_149.tif', 40, 30, 2, gdal.GDT_UInt16, options=['NBITS=12', 'TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=16', 'INTERLEAVE=PIXEL'])
     ds.GetRasterBand(1).SetNoDataValue(127)
     ds.GetRasterBand(2).SetNoDataValue(127)
     ds = None
@@ -5741,7 +5739,7 @@ def test_tiff_write_149():
     cs = ds.GetRasterBand(1).Checksum()
     ds = None
     assert cs == expected_cs
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_149.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_149.tif')
 
 ###############################################################################
 # Test failure when loading block from disk in IWriteBlock()
@@ -5757,7 +5755,7 @@ def test_tiff_write_150():
         ds.FlushCache()
     assert gdal.GetLastErrorMsg() != ''
     ds = None
-    gdaltest.tiff_drv.Delete('tmp/tiled_bad_offset.tif')
+    gdaltest.gtiff_drv.Delete('tmp/tiled_bad_offset.tif')
 
 ###############################################################################
 # Test IWriteBlock() with more than 10 bands
@@ -5765,7 +5763,7 @@ def test_tiff_write_150():
 
 def test_tiff_write_151():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_151.tif', 1, 1, 11)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_151.tif', 1, 1, 11)
     ds = None
     ds = gdal.Open('/vsimem/tiff_write_151.tif', gdal.GA_Update)
     ds.GetRasterBand(1).Fill(1)
@@ -5780,7 +5778,7 @@ def test_tiff_write_151():
     assert ds.GetRasterBand(2).Checksum() == 1
     assert ds.GetRasterBand(3).Checksum() == 1
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_151.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_151.tif')
 
 ###############################################################################
 # Test flushing of blocks in a contig multi band file with Create()
@@ -5788,7 +5786,7 @@ def test_tiff_write_151():
 
 def test_tiff_write_152():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_152.tif', 1, 1, 2, options=['NBITS=2'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_152.tif', 1, 1, 2, options=['NBITS=2'])
     ds.GetRasterBand(2).SetNoDataValue(3)
     ds.GetRasterBand(2).Fill(1)
     ds = None
@@ -5796,7 +5794,7 @@ def test_tiff_write_152():
     assert ds.GetRasterBand(1).Checksum() == 0
     assert ds.GetRasterBand(2).Checksum() == 1
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_152.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_152.tif')
 
 ###############################################################################
 # Test that empty blocks are created in a filesystem sparse way
@@ -5809,13 +5807,13 @@ def test_tiff_write_153():
     if gdal.VSISupportsSparseFiles(target_dir) == 0:
         pytest.skip()
 
-    gdaltest.tiff_drv.Create(target_dir + '/tiff_write_153.tif', 500, 500)
+    gdaltest.gtiff_drv.Create(target_dir + '/tiff_write_153.tif', 500, 500)
 
     f = gdal.VSIFOpenL(target_dir + '/tiff_write_153.tif', 'rb')
     ret = gdal.VSIFGetRangeStatusL(f, 500 * 500, 1)
     gdal.VSIFCloseL(f)
 
-    gdaltest.tiff_drv.Delete(target_dir + '/tiff_write_153.tif')
+    gdaltest.gtiff_drv.Delete(target_dir + '/tiff_write_153.tif')
 
     assert ret != gdal.VSI_RANGE_STATUS_DATA
 
@@ -5827,25 +5825,25 @@ def test_tiff_write_154():
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 500, 500)
 
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['BLOCKYSIZE=256'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['BLOCKYSIZE=256'])
     ds.FlushCache()
     # At that point empty blocks have not yet been flushed
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 162
     ds = None
     # Now they are and that's done in a filesystem sparse way. TODO: check this
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 256162
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_154.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_154.tif')
 
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['BLOCKYSIZE=256', 'COMPRESS=DEFLATE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['BLOCKYSIZE=256', 'COMPRESS=DEFLATE'])
     ds.FlushCache()
     # With compression, empty blocks are written right away
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 462
     ds = None
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 462
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_154.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_154.tif')
 
     # SPARSE_OK in CreateCopy(): blocks are not written
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES', 'BLOCKYSIZE=256'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES', 'BLOCKYSIZE=256'])
     ds = None
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 162
     # SPARSE_OK in Open()/update: blocks are not written
@@ -5860,19 +5858,19 @@ def test_tiff_write_154():
     ds = None
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 250162
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_154.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_154.tif')
 
     # SPARSE_OK in CreateCopy() in compressed case (strips): blocks are not written
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES', 'BLOCKYSIZE=256', 'COMPRESS=DEFLATE'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES', 'BLOCKYSIZE=256', 'COMPRESS=DEFLATE'])
     ds = None
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 174
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_154.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_154.tif')
 
     # SPARSE_OK in CreateCopy() in compressed case (tiling): blocks are not written
-    ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES', 'TILED=YES'])
+    ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES', 'TILED=YES'])
     ds = None
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 190
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_154.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_154.tif')
 
     # Test detection of 0 blocks for all data types
     for dt in ['signedbyte', gdal.GDT_Int16, gdal.GDT_UInt16,
@@ -5885,7 +5883,7 @@ def test_tiff_write_154():
         else:
             src_ds = gdal.GetDriverByName('MEM').Create('', 500, 500, 1, dt)
             options = ['SPARSE_OK=YES', 'BLOCKYSIZE=256']
-        gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=options)
+        gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=options)
         assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 162, dt
 
     # Test detection of nodata blocks with nodata != 0 for all data types
@@ -5901,7 +5899,7 @@ def test_tiff_write_154():
             options = ['SPARSE_OK=YES', 'BLOCKYSIZE=256']
         src_ds.GetRasterBand(1).Fill(1)
         src_ds.GetRasterBand(1).SetNoDataValue(1)
-        ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=options)
+        ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=options)
         ds = None
         assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 174, dt
 
@@ -5909,10 +5907,10 @@ def test_tiff_write_154():
     src_ds = gdal.GetDriverByName('MEM').Create('', 100, 1, 1)
     src_ds.GetRasterBand(1).Fill(0)
     src_ds.GetRasterBand(1).WriteRaster(99, 0, 1, 1, struct.pack('B' * 1, 1))
-    gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES'])
+    gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_154.tif', src_ds, options=['SPARSE_OK=YES'])
     assert gdal.VSIStatL('/vsimem/tiff_write_154.tif').size == 246
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_154.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_154.tif')
 
     # Test that setting nodata doesn't prevent blocks to be written (#6706)
     ds = gdal.GetDriverByName('GTiff').Create('/vsimem/tiff_write_154.tif', 1, 100, 1)
@@ -5921,7 +5919,7 @@ def test_tiff_write_154():
     ds = gdal.Open('/vsimem/tiff_write_154.tif')
     offset = ds.GetRasterBand(1).GetMetadataItem('BLOCK_OFFSET_0_0', 'TIFF')
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_154.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_154.tif')
     assert not (offset is None or int(offset) == 0)
 
 ###############################################################################
@@ -5930,7 +5928,7 @@ def test_tiff_write_154():
 
 def test_tiff_write_155():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_155.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_155.tif', 1, 1)
     ds.GetRasterBand(1).SetDescription('foo')
     ds = None
 
@@ -5939,9 +5937,9 @@ def test_tiff_write_155():
     ds = gdal.Open('/vsimem/tiff_write_155.tif')
     assert ds.GetRasterBand(1).GetDescription() == 'foo'
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_155.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_155.tif')
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_155.tif', 1, 1, options=['PROFILE=GeoTIFF'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_155.tif', 1, 1, options=['PROFILE=GeoTIFF'])
     ds.GetRasterBand(1).SetDescription('foo')
     ds = None
 
@@ -5950,7 +5948,7 @@ def test_tiff_write_155():
     ds = gdal.Open('/vsimem/tiff_write_155.tif')
     assert ds.GetRasterBand(1).GetDescription() == 'foo'
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_155.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_155.tif')
 
 ###############################################################################
 # Test GetDataCoverageStatus()
@@ -5958,7 +5956,7 @@ def test_tiff_write_155():
 
 def test_tiff_write_156():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_156.tif', 64, 64, options=['SPARSE_OK=YES', 'TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_156.tif', 64, 64, options=['SPARSE_OK=YES', 'TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32'])
     ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, 'X')
 
     (flags, pct) = ds.GetRasterBand(1).GetDataCoverageStatus(0, 0, 32, 32)
@@ -5971,17 +5969,17 @@ def test_tiff_write_156():
     assert flags == gdal.GDAL_DATA_COVERAGE_STATUS_DATA | gdal.GDAL_DATA_COVERAGE_STATUS_EMPTY and pct == 25.0
 
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_156.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_156.tif')
 
     # Test fix for #6703
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_156.tif', 1, 512, options=['SPARSE_OK=YES', 'BLOCKYSIZE=1'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_156.tif', 1, 512, options=['SPARSE_OK=YES', 'BLOCKYSIZE=1'])
     ds.GetRasterBand(1).WriteRaster(0, 100, 1, 1, 'X')
     ds = None
     ds = gdal.Open('/vsimem/tiff_write_156.tif')
     flags, _ = ds.GetRasterBand(1).GetDataCoverageStatus(0, 100, 1, 1)
     assert flags == gdal.GDAL_DATA_COVERAGE_STATUS_DATA
     ds = None
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_156.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_156.tif')
 
 ###############################################################################
 # Test Float16
@@ -6007,7 +6005,7 @@ def test_tiff_write_157():
                        0x8400,  # Smallest negative normalized value
                       )
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_157.tif', 14, 1, 1, gdal.GDT_Float32, options=['NBITS=16'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_157.tif', 14, 1, 1, gdal.GDT_Float32, options=['NBITS=16'])
     ds = None
     ds = gdal.Open('/vsimem/tiff_write_157.tif')
     offset = int(ds.GetRasterBand(1).GetMetadataItem('BLOCK_OFFSET_0_0', 'TIFF'))
@@ -6048,11 +6046,11 @@ def test_tiff_write_157():
         print(struct.unpack('H' * 14, vals))
         pytest.fail(struct.unpack('H' * 14, vals_copied))
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_157.tif')
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_157_dst.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_157.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_157_dst.tif')
 
     # Now try Float32 -> Float16 conversion
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_157.tif', 18, 1, 1, gdal.GDT_Float32, options=['NBITS=16'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_157.tif', 18, 1, 1, gdal.GDT_Float32, options=['NBITS=16'])
     vals = struct.pack('I' * 18,
                        0x00000000,  # Positive zero
                        0x80000000,  # Negative zero
@@ -6092,7 +6090,7 @@ def test_tiff_write_157():
         else:
             assert got[i] == pytest.approx(expected[i], abs=1e-15)
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_157.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_157.tif')
 
     # Test pixel interleaved
     gdal.Translate('/vsimem/tiff_write_157.tif', '../gdrivers/data/small_world.tif', options='-co NBITS=16 -ot Float32')
@@ -6103,7 +6101,7 @@ def test_tiff_write_157():
     assert cs == 32302
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_157.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_157.tif')
 
 ###############################################################################
 # Test GetActualBlockSize() (perhaps not the best place for that...)
@@ -6111,7 +6109,7 @@ def test_tiff_write_157():
 
 def test_tiff_write_158():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_158.tif', 20, 40, 1, options=['TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=32'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_158.tif', 20, 40, 1, options=['TILED=YES', 'BLOCKXSIZE=16', 'BLOCKYSIZE=32'])
     (w, h) = ds.GetRasterBand(1).GetActualBlockSize(0, 0)
     assert (w, h) == (16, 32)
     (w, h) = ds.GetRasterBand(1).GetActualBlockSize(1, 1)
@@ -6126,7 +6124,7 @@ def test_tiff_write_158():
     assert res is None
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_158.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_158.tif')
 
 ###############################################################################
 # Test that COPY_SRC_OVERVIEWS creation option with JPEG compression
@@ -6135,7 +6133,7 @@ def test_tiff_write_158():
 
 def test_tiff_write_159():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
@@ -6144,7 +6142,7 @@ def test_tiff_write_159():
 
         src_ds = gdal.Translate('', '../gdrivers/data/small_world.tif', format='MEM')
         src_ds.BuildOverviews('NEAR', overviewlist=[2, 4])
-        ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_159.tif', src_ds,
+        ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_159.tif', src_ds,
                                           options=['COPY_SRC_OVERVIEWS=YES', 'COMPRESS=JPEG'] + options)
         ds = None
         src_ds = None
@@ -6171,13 +6169,13 @@ def test_tiff_write_159():
         prev_table = table_main
         ds = None
 
-        gdaltest.tiff_drv.Delete('/vsimem/tiff_write_159.tif')
+        gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_159.tif')
 
     for value in range(4):
 
         src_ds = gdal.Translate('', 'data/byte.tif', format='MEM')
         src_ds.BuildOverviews('NEAR', overviewlist=[2])
-        ds = gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_159.tif', src_ds,
+        ds = gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_159.tif', src_ds,
                                           options=['COPY_SRC_OVERVIEWS=YES', 'COMPRESS=JPEG', 'JPEGTABLESMODE=%d' % value])
         ds = None
         src_ds = None
@@ -6188,7 +6186,7 @@ def test_tiff_write_159():
         assert cs0 == 4743 and cs1 == 1133, value
         ds = None
 
-        gdaltest.tiff_drv.Delete('/vsimem/tiff_write_159.tif')
+        gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_159.tif')
 
     
 
@@ -6197,7 +6195,7 @@ def test_tiff_write_159():
 
 def test_tiff_write_160():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_160.tif', 10, 10, options=['BLOCKYSIZE=11'])
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_160.tif', 10, 10, options=['BLOCKYSIZE=11'])
     ds.GetRasterBand(1).Fill(255)
     ds = None
 
@@ -6206,7 +6204,7 @@ def test_tiff_write_160():
     assert cs == 1218
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_160.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_160.tif')
 
 ###############################################################################
 # Test setting GCPs on an image with already a geotransform and vice-versa (#6751)
@@ -6214,7 +6212,7 @@ def test_tiff_write_160():
 
 def test_tiff_write_161():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/tiff_write_161.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/tiff_write_161.tif', 1, 1)
     ds.SetGeoTransform([0, 1, 2, 3, 4, 5])
     ds = None
 
@@ -6239,7 +6237,7 @@ def test_tiff_write_161():
     assert ds.GetGeoTransform() == (0.0, 1.0, 2.0, 3.0, 4.0, 5.0)
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_161.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_161.tif')
 
 ###############################################################################
 # Test creating a JPEG compressed file with big tiles (#6757)
@@ -6251,12 +6249,12 @@ def test_tiff_write_162():
 
     options = ['TILED=YES', 'BLOCKXSIZE=512', 'BLOCKYSIZE=512', 'COMPRESS=JPEG']
 
-    gdaltest.tiff_drv.CreateCopy('/vsimem/tiff_write_162.tif', src_ds,
+    gdaltest.gtiff_drv.CreateCopy('/vsimem/tiff_write_162.tif', src_ds,
                                  options=options)
 
     assert gdal.GetLastErrorMsg() == ''
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_162.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_162.tif')
 
 ###############################################################################
 # Test creating a file that would trigger strip chopping (#6924)
@@ -6265,7 +6263,7 @@ def test_tiff_write_162():
 def test_tiff_write_163():
 
     # Was a libtiff 4.0.8 regression
-    if gdaltest.tiff_drv.GetMetadataItem('LIBTIFF').find('4.0.8') >= 0:
+    if gdaltest.gtiff_drv.GetMetadataItem('LIBTIFF').find('4.0.8') >= 0:
         pytest.skip('Test broken with libtiff 4.0.8')
 
     gdal.Translate('/vsimem/tiff_write_163.tif', 'data/byte.tif',
@@ -6278,7 +6276,7 @@ def test_tiff_write_163():
     assert offset_0_2 == str(146 + 2 * 8192)
     ds = None
 
-    gdaltest.tiff_drv.Delete('/vsimem/tiff_write_163.tif')
+    gdaltest.gtiff_drv.Delete('/vsimem/tiff_write_163.tif')
 
 ###############################################################################
 # Test that we handle [0,1,0,0,0,1] geotransform as a regular geotransform
@@ -6286,7 +6284,7 @@ def test_tiff_write_163():
 
 def test_tiff_write_164():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/test.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/test.tif', 1, 1)
     ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
     ds = None
 
@@ -6297,7 +6295,7 @@ def test_tiff_write_164():
     assert gt == (0, 1, 0, 0, 0, 1)
 
     # Test [0,1,0,0,0,-1] as well
-    ds = gdaltest.tiff_drv.Create('/vsimem/test.tif', 1, 1)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/test.tif', 1, 1)
     ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     ds = None
 
@@ -6315,7 +6313,7 @@ def test_tiff_write_164():
 
 def test_tiff_write_165():
 
-    ds = gdaltest.tiff_drv.Create('/vsimem/test.tif', 1, 1, 3)
+    ds = gdaltest.gtiff_drv.Create('/vsimem/test.tif', 1, 1, 3)
     ret = ds.GetRasterBand(1).SetNoDataValue(100)
     assert ret == 0
 
@@ -6501,7 +6499,7 @@ def test_tiff_write_170_invalid_compresion():
 
 def test_tiff_write_171_zstd():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('ZSTD') == -1:
         pytest.skip()
 
@@ -6515,7 +6513,7 @@ def test_tiff_write_171_zstd():
 
 def test_tiff_write_171_zstd_predictor():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('ZSTD') == -1:
         pytest.skip()
 
@@ -6529,7 +6527,7 @@ def test_tiff_write_171_zstd_predictor():
 
 def test_tiff_write_webp():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('WEBP') == -1:
         pytest.skip()
 
@@ -6543,7 +6541,7 @@ def test_tiff_write_webp():
 
 def test_tiff_write_tiled_webp():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('WEBP') == -1:
         pytest.skip()
 
@@ -6552,7 +6550,7 @@ def test_tiff_write_tiled_webp():
 
     filename = '/vsimem/tiff_write_tiled_webp.tif'
     src_ds = gdal.Open('data/md_ge_rgb_0010000.tif')
-    gdaltest.tiff_drv.CreateCopy(filename, src_ds,
+    gdaltest.gtiff_drv.CreateCopy(filename, src_ds,
                                  options=['COMPRESS=WEBP',
                                           'WEBP_LOSSLESS=true',
                                           'TILED=true'])
@@ -6560,7 +6558,7 @@ def test_tiff_write_tiled_webp():
     cs = [ds.GetRasterBand(i+1).Checksum() for i in range(3)]
     assert cs == [21212, 21053, 21349]
 
-    gdaltest.tiff_drv.Delete(filename)
+    gdaltest.gtiff_drv.Delete(filename)
     gdal.Unlink('data/md_ge_rgb_0010000.tif.aux.xml')
 
 ###############################################################################
@@ -6569,13 +6567,13 @@ def test_tiff_write_tiled_webp():
 
 def test_tiff_write_webp_huge_single_strip():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('WEBP') == -1:
         pytest.skip()
 
     filename = '/vsimem/tif_webp_huge_single_strip.tif'
     src_ds = gdal.Open('data/tif_webp_huge_single_strip.tif')
-    gdaltest.tiff_drv.CreateCopy(filename, src_ds,
+    gdaltest.gtiff_drv.CreateCopy(filename, src_ds,
                                  options=['COMPRESS=WEBP',
                                           'BLOCKYSIZE=2001'])
     ds = gdal.Open(filename)
@@ -6589,7 +6587,7 @@ def test_tiff_write_webp_huge_single_strip():
             assert original_stats[i][j] == pytest.approx(got_stats[i][j], abs=1e-1 * abs(original_stats[i][j])), \
                 'did not get expected statistics'
 
-    gdaltest.tiff_drv.Delete(filename)
+    gdaltest.gtiff_drv.Delete(filename)
     gdal.Unlink('data/tif_webp_huge_single_strip.tif.aux.xml')
 
 
@@ -6624,7 +6622,7 @@ def test_tiff_write_172_geometadata_tiff_rsid():
 
 def test_tiff_write_173_lerc():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
@@ -6638,7 +6636,7 @@ def test_tiff_write_173_lerc():
 
 def test_tiff_write_174_lerc_deflate():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC_DEFLATE') == -1:
         pytest.skip()
 
@@ -6652,7 +6650,7 @@ def test_tiff_write_174_lerc_deflate():
 
 def test_tiff_write_174_lerc_deflate_with_level():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC_DEFLATE') == -1:
         pytest.skip()
 
@@ -6666,7 +6664,7 @@ def test_tiff_write_174_lerc_deflate_with_level():
 
 def test_tiff_write_175_lerc_zstd():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC_ZSTD') == -1:
         pytest.skip()
 
@@ -6680,7 +6678,7 @@ def test_tiff_write_175_lerc_zstd():
 
 def test_tiff_write_175_lerc_zstd_with_level():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC_ZSTD') == -1:
         pytest.skip()
 
@@ -6694,7 +6692,7 @@ def test_tiff_write_175_lerc_zstd_with_level():
 
 def test_tiff_write_176_lerc_max_z_error():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
@@ -6708,7 +6706,7 @@ def test_tiff_write_176_lerc_max_z_error():
 
 def test_tiff_write_177_lerc_several_bands_tiling():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
@@ -6727,7 +6725,7 @@ def test_tiff_write_177_lerc_several_bands_tiling():
 
 def test_tiff_write_178_lerc_with_alpha():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
@@ -6746,7 +6744,7 @@ def test_tiff_write_178_lerc_with_alpha():
 
 def test_tiff_write_178_lerc_with_alpha_0_and_255():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
@@ -6765,7 +6763,7 @@ def test_tiff_write_178_lerc_with_alpha_0_and_255():
 
 def test_tiff_write_179_lerc_data_types():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
@@ -6803,7 +6801,7 @@ def test_tiff_write_179_lerc_data_types():
 
 def test_tiff_write_180_lerc_separate():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
@@ -6824,7 +6822,7 @@ def test_tiff_write_181_xmp():
 
     src_ds = gdal.Open('data/utmsmall.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_181.tif', src_ds)
+    new_ds = gdaltest.gtiff_drv.CreateCopy('tmp/test_181.tif', src_ds)
     src_ds = None
 
     xmp_ds = gdal.Open('../gdrivers/data/byte_with_xmp.tif')
@@ -6843,7 +6841,7 @@ def test_tiff_write_181_xmp():
         'No XMP data written in output file'
     new_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_181.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_181.tif')
 
 ###############################################################################
 # Test delete XMP from a dataset
@@ -6865,7 +6863,7 @@ def test_tiff_write_182_xmp_delete():
     assert not read_xmp, 'XMP data not removed'
     again_ds = None
 
-    gdaltest.tiff_drv.Delete('tmp/test_182.tif')
+    gdaltest.gtiff_drv.Delete('tmp/test_182.tif')
 
 ###############################################################################
 
@@ -6914,12 +6912,12 @@ def test_tiff_write_184_create_append_subdataset():
 
 def test_tiff_write_185_lerc_create_and_overview():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LERC') == -1:
         pytest.skip()
 
     filename = '/vsimem/test_tiff_write_185_lerc_create_and_overview.tif'
-    ds = gdaltest.tiff_drv.Create(filename, 20, 20, options=['COMPRESS=LERC_DEFLATE'])
+    ds = gdaltest.gtiff_drv.Create(filename, 20, 20, options=['COMPRESS=LERC_DEFLATE'])
     src_ds = gdal.Open('data/byte.tif')
     ds.WriteRaster(0,0,20,20,src_ds.ReadRaster())
     gdal.ErrorReset()
@@ -7015,7 +7013,7 @@ def test_tiff_write_overviews_mask_no_ovr_on_mask():
 
     tmpfile = '/vsimem/test_tiff_write_overviews_mask_no_ovr_on_mask.tif'
     with gdaltest.config_option('GDAL_TIFF_INTERNAL_MASK', 'YES'):
-        ds = gdaltest.tiff_drv.Create(tmpfile, 100, 100)
+        ds = gdaltest.gtiff_drv.Create(tmpfile, 100, 100)
         ds.GetRasterBand(1).Fill(255)
         ds.CreateMaskBand(gdal.GMF_PER_DATASET)
 
@@ -7032,7 +7030,7 @@ def test_tiff_write_overviews_mask_no_ovr_on_mask():
     src_ds = gdal.Open(tmpfile)
     gdal.ErrorReset()
     with gdaltest.error_handler():
-        ds = gdaltest.tiff_drv.CreateCopy(tmpfile2, src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
+        ds = gdaltest.gtiff_drv.CreateCopy(tmpfile2, src_ds, options=['COPY_SRC_OVERVIEWS=YES'])
     assert gdal.GetLastErrorMsg() == 'Source dataset has a mask band on full resolution, overviews on the regular bands, but lacks overviews on the mask band.'
     assert ds
     ds = None
@@ -7044,8 +7042,8 @@ def test_tiff_write_overviews_mask_no_ovr_on_mask():
     assert ds.GetRasterBand(1).GetOverview(0).GetMaskFlags() == gdal.GMF_ALL_VALID
     ds = None
 
-    gdaltest.tiff_drv.Delete(tmpfile)
-    gdaltest.tiff_drv.Delete(tmpfile2)
+    gdaltest.gtiff_drv.Delete(tmpfile)
+    gdaltest.gtiff_drv.Delete(tmpfile2)
 
 
 ###############################################################################
@@ -7053,12 +7051,12 @@ def test_tiff_write_overviews_mask_no_ovr_on_mask():
 
 def test_tiff_write_no_gdal_metadata_tag_for_ycbcr_jpeg():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('JPEG') == -1:
         pytest.skip()
 
     tmpfile = '/vsimem/test_tiff_write_no_gdal_metadata_tag_for_ycbcr_jpeg.tif'
-    assert gdaltest.tiff_drv.Create(tmpfile, 16, 16, 3, gdal.GDT_Byte, options=['PHOTOMETRIC=YCBCR', 'COMPRESS=JPEG'])
+    assert gdaltest.gtiff_drv.Create(tmpfile, 16, 16, 3, gdal.GDT_Byte, options=['PHOTOMETRIC=YCBCR', 'COMPRESS=JPEG'])
     statBuf = gdal.VSIStatL(tmpfile + '.aux.xml', gdal.VSI_STAT_EXISTS_FLAG | gdal.VSI_STAT_NATURE_FLAG | gdal.VSI_STAT_SIZE_FLAG)
     assert statBuf is None, 'did not expect PAM file'
 
@@ -7068,7 +7066,7 @@ def test_tiff_write_no_gdal_metadata_tag_for_ycbcr_jpeg():
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
 
     tmpfile2 = tmpfile + "2"
-    assert gdaltest.tiff_drv.CreateCopy(tmpfile2, ds, options=['PHOTOMETRIC=YCBCR', 'COMPRESS=JPEG'])
+    assert gdaltest.gtiff_drv.CreateCopy(tmpfile2, ds, options=['PHOTOMETRIC=YCBCR', 'COMPRESS=JPEG'])
     ds = None
 
     ds = gdal.Open(tmpfile2)
@@ -7077,8 +7075,8 @@ def test_tiff_write_no_gdal_metadata_tag_for_ycbcr_jpeg():
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
     ds = None
 
-    gdaltest.tiff_drv.Delete(tmpfile)
-    gdaltest.tiff_drv.Delete(tmpfile2)
+    gdaltest.gtiff_drv.Delete(tmpfile)
+    gdaltest.gtiff_drv.Delete(tmpfile2)
 
 
 ###############################################################################
@@ -7097,14 +7095,14 @@ def test_tiff_write_setgeotransform_flush():
 
     assert gdal.VSIStatL(tmpfile).size < 1000
 
-    gdaltest.tiff_drv.Delete(tmpfile)
+    gdaltest.gtiff_drv.Delete(tmpfile)
 
 ###############################################################################
 # Test that compression parameters are taken into account in Create() mode
 
 def test_tiff_write_compression_create_and_createcopy():
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    md = gdaltest.gtiff_drv.GetMetadata()
     tests = []
 
     if 'DEFLATE' in md['DMD_CREATIONOPTIONLIST']:
@@ -7139,24 +7137,24 @@ def test_tiff_write_compression_create_and_createcopy():
     src_ds = gdal.Open('data/rgbsmall.tif')
     data = src_ds.ReadRaster()
     for (before, after) in tests:
-        ds = gdaltest.tiff_drv.Create(tmpfile, src_ds.RasterXSize, src_ds.RasterYSize, src_ds.RasterCount, options = before)
+        ds = gdaltest.gtiff_drv.Create(tmpfile, src_ds.RasterXSize, src_ds.RasterYSize, src_ds.RasterCount, options = before)
         ds.WriteRaster(0, 0, src_ds.RasterXSize, src_ds.RasterYSize, data)
         ds = None
         size_before = gdal.VSIStatL(tmpfile).size
-        ds = gdaltest.tiff_drv.Create(tmpfile, src_ds.RasterXSize, src_ds.RasterYSize, src_ds.RasterCount, options = after)
+        ds = gdaltest.gtiff_drv.Create(tmpfile, src_ds.RasterXSize, src_ds.RasterYSize, src_ds.RasterCount, options = after)
         ds.WriteRaster(0, 0, src_ds.RasterXSize, src_ds.RasterYSize, data)
         ds = None
         size_after = gdal.VSIStatL(tmpfile).size
         assert size_after < size_before, (before, after, size_before, size_after)
         print(before, after, size_before, size_after)
 
-        gdaltest.tiff_drv.CreateCopy(tmpfile, src_ds, options = before)
+        gdaltest.gtiff_drv.CreateCopy(tmpfile, src_ds, options = before)
         size_before = gdal.VSIStatL(tmpfile).size
-        gdaltest.tiff_drv.CreateCopy(tmpfile, src_ds, options = after)
+        gdaltest.gtiff_drv.CreateCopy(tmpfile, src_ds, options = after)
         size_after = gdal.VSIStatL(tmpfile).size
         assert size_after < size_before, (before, after, size_before, size_after)
 
-    gdaltest.tiff_drv.Delete(tmpfile)
+    gdaltest.gtiff_drv.Delete(tmpfile)
 
 ###############################################################################
 # Attempt at creating a file with more than 4 billion tiles
@@ -7183,9 +7181,3 @@ def tiff_write_api_proxy():
     ret = test_py_scripts.run_py_script_as_external_script('.', 'tiff_write', ' -api_proxy', display_live_on_parent_stdout=True)
 
     assert ret.find('Failed:    0') != -1
-
-###############################################################################
-
-
-def test_tiff_write_cleanup():
-    gdaltest.tiff_drv = None

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -7164,7 +7164,7 @@ def test_tiff_write_too_many_tiles():
 
     src_ds = gdal.Open('<VRTDataset rasterXSize="100000000" rasterYSize="100000000"><VRTRasterBand dataType="Byte" band="1"/></VRTDataset>')
     with gdaltest.error_handler():
-        assert not gdaltest.tiff_drv.CreateCopy('/vsimem/tmp.tif', src_ds, options = ['TILED=YES'])
+        assert not gdaltest.gtiff_drv.CreateCopy('/vsimem/tmp.tif', src_ds, options = ['TILED=YES'])
     assert 'File too large regarding tile size' in gdal.GetLastErrorMsg()
 
 

--- a/autotest/gdrivers/bag.py
+++ b/autotest/gdrivers/bag.py
@@ -55,9 +55,6 @@ def check_no_file_leaks():
 
 
 def test_bag_2():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/true_n_nominal.bag')
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -99,9 +96,6 @@ def test_bag_2():
 
 
 def test_bag_3():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/southern_hemi_false_northing.bag')
 
     nr = ds.RasterCount
@@ -124,9 +118,6 @@ def test_bag_3():
 
 
 def test_bag_vr_normal():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/test_vr.bag')
     assert ds is not None
 
@@ -188,9 +179,6 @@ def test_bag_vr_normal():
 
 
 def test_bag_vr_list_supergrids():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx('data/test_vr.bag', open_options=['MODE=LIST_SUPERGRIDS'])
     assert ds is not None
     sub_ds = ds.GetSubDatasets()
@@ -245,9 +233,6 @@ def test_bag_vr_list_supergrids():
 
 
 def test_bag_vr_open_supergrids():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('BAG:"data/test_vr.bag":supergrid:0:0')
     assert ds is not None
 
@@ -315,9 +300,6 @@ def test_bag_vr_open_supergrids():
 
 
 def test_bag_vr_resampled():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx('data/test_vr.bag', open_options=['MODE=RESAMPLED_GRID'])
     assert ds is not None
 
@@ -557,9 +539,6 @@ def test_bag_vr_resampled():
 
 
 def test_bag_vr_resampled_mask():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx('data/test_vr.bag',
                      open_options=['MODE=RESAMPLED_GRID',
                                    'SUPERGRIDS_MASK=YES'])
@@ -576,9 +555,6 @@ def test_bag_vr_resampled_mask():
 
 
 def test_bag_vr_resampled_interpolated():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx('data/test_vr.bag',
                      open_options=['MODE=RESAMPLED_GRID',
                                    'INTERPOLATION=INVDIST'])
@@ -605,9 +581,6 @@ def test_bag_vr_resampled_interpolated():
 
 
 def test_bag_write_single_band():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('BAG', 'byte.tif', 1, 4672)
     ret = tst.testCreateCopy(quiet_error_handler=False,
                              new_filename='/vsimem/out.bag')
@@ -619,9 +592,6 @@ def test_bag_write_single_band():
 
 
 def test_bag_write_two_bands():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('BAG', 'test_vr.bag', 2, 60,
                             options=['BLOCK_SIZE=2',
                                      'VAR_ABSTRACT=foo',
@@ -643,9 +613,6 @@ def test_bag_write_two_bands():
 
 
 def test_bag_write_south_up():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     # Generate a south-up dataset
     src_ds = gdal.Warp('', 'data/byte.tif',
                        format='MEM',
@@ -671,17 +638,11 @@ def test_bag_write_south_up():
 
 
 def test_bag_read_invalid_bag_vlen_bag_version():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/invalid_bag_vlen_bag_version.bag')
     assert not ds
 
 
 def test_bag_read_incorrect_northeast_corner():
-    if gdaltest.bag_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/test_offset_ne_corner.bag')
 
     geotransform = ds.GetGeoTransform()

--- a/autotest/gdrivers/daas.py
+++ b/autotest/gdrivers/daas.py
@@ -40,17 +40,14 @@ import gdaltest
 import webserver
 import pytest
 
+pytestmark = pytest.mark.require_driver('DAAS')
+
+
 ###############################################################################
 # Find DAAS driver
 
 
 def test_daas_test_presence():
-
-    gdaltest.daas_drv = gdal.GetDriverByName('DAAS')
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
-
     gdaltest.daas_vars = {}
     for var in ('GDAL_DAAS_API_KEY', 'GDAL_DAAS_CLIENT_ID', 'GDAL_DAAS_AUTH_URL'):
         gdaltest.daas_vars[var] = gdal.GetConfigOption(var)
@@ -66,9 +63,6 @@ def test_daas_test_presence():
 
 
 def test_daas_missing_parameters():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -80,9 +74,6 @@ def test_daas_missing_parameters():
 
 
 def test_daas_authentication_failure():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -135,9 +126,6 @@ def test_daas_authentication_failure():
 
 
 def test_daas_authentication():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -205,9 +193,6 @@ def test_daas_authentication():
 
 
 def test_daas_getimagemetadata_failure():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -362,9 +347,6 @@ def test_daas_getimagemetadata_failure():
 
 
 def test_daas_getimagemetadata():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -491,9 +473,6 @@ def test_daas_getimagemetadata():
 
 
 def test_daas_getimagemetadata_http_retry():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -571,9 +550,6 @@ def test_daas_getimagemetadata_http_retry():
 
 
 def test_daas_getbuffer_failure():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
     metadata_response = json.dumps({"response": {"payload": {"payload": {"imageMetadata": {"properties": {
@@ -779,9 +755,6 @@ Content-Type: application/json
 
 
 def test_daas_getbuffer_pixel_encoding_failures():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -874,9 +847,6 @@ def test_daas_getbuffer_pixel_encoding_failures():
 
 
 def test_daas_getbuffer_raw():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -972,9 +942,6 @@ Content-Type: application/json
 
 
 def _daas_getbuffer(pixel_encoding, drv_name, drv_options, mime_type):
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
     drv = gdal.GetDriverByName(drv_name)
@@ -1078,9 +1045,6 @@ def test_daas_getbuffer_jpeg2000_jp2openjpeg():
 
 
 def test_daas_getbuffer_overview():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -1174,9 +1138,6 @@ Content-Type: application/json
 
 
 def test_daas_rasterio():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -1350,9 +1311,6 @@ Content-Type: application/json
 
 
 def test_daas_mask():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -1433,9 +1391,6 @@ Content-Type: application/json
 
 
 def test_daas_png_response_4_bands_for_a_one_band_request():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
@@ -1507,9 +1462,6 @@ Content-Type: application/json
 
 
 def test_daas_cleanup():
-
-    if gdaltest.daas_drv is None:
-        pytest.skip()
 
     if gdaltest.webserver_port != 0:
         webserver.server_stop(gdaltest.webserver_process,

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -52,9 +52,15 @@ def has_write_support():
     if hasattr(gdaltest, 'b_ecw_has_write_support'):
         return gdaltest.b_ecw_has_write_support
     gdaltest.b_ecw_has_write_support = False
-    if test_ecw_1() != 'success':
+    try:
+        test_ecw_1()
+    except Exception:
         return False
-    if test_ecw_3() == 'success':
+    try:
+        test_ecw_3()
+    except Exception:
+        pass
+    else:
         gdaltest.b_ecw_has_write_support = True
     try:
         os.remove('tmp/jrc_out.ecw')
@@ -75,32 +81,27 @@ def test_ecw_init():
 
 
 def test_ecw_1():
-
-    gdaltest.ecw_drv = gdal.GetDriverByName('ECW')
-    gdaltest.jp2ecw_drv = gdal.GetDriverByName('JP2ECW')
-
     gdaltest.ecw_write = 0
 
-    if gdaltest.ecw_drv is not None:
-        if gdaltest.ecw_drv.GetMetadataItem('DMD_CREATIONDATATYPES') is not None:
-            gdaltest.ecw_write = 1
+    if gdaltest.ecw_drv.GetMetadataItem('DMD_CREATIONDATATYPES') is not None:
+        gdaltest.ecw_write = 1
 
-        longname = gdaltest.ecw_drv.GetMetadataItem('DMD_LONGNAME')
+    longname = gdaltest.ecw_drv.GetMetadataItem('DMD_LONGNAME')
 
-        sdk_off = longname.find('SDK ')
-        if sdk_off != -1:
-            gdaltest.ecw_drv.major_version = int(float(longname[sdk_off + 4]))
-            sdk_minor_off = longname.find('.', sdk_off)
-            if sdk_minor_off >= 0:
-                if longname[sdk_minor_off + 1] == 'x':
-                    gdaltest.ecw_drv.minor_version = 3
-                else:
-                    gdaltest.ecw_drv.minor_version = int(longname[sdk_minor_off + 1])
+    sdk_off = longname.find('SDK ')
+    if sdk_off != -1:
+        gdaltest.ecw_drv.major_version = int(float(longname[sdk_off + 4]))
+        sdk_minor_off = longname.find('.', sdk_off)
+        if sdk_minor_off >= 0:
+            if longname[sdk_minor_off + 1] == 'x':
+                gdaltest.ecw_drv.minor_version = 3
             else:
-                gdaltest.ecw_drv.minor_version = 0
+                gdaltest.ecw_drv.minor_version = int(longname[sdk_minor_off + 1])
         else:
-            gdaltest.ecw_drv.major_version = 3
-            gdaltest.ecw_drv.minor_version = 3
+            gdaltest.ecw_drv.minor_version = 0
+    else:
+        gdaltest.ecw_drv.major_version = 3
+        gdaltest.ecw_drv.minor_version = 3
 
     # we set ECW to not resolve projection and datum strings to get 3.x behavior.
     gdal.SetConfigOption("ECW_DO_NOT_RESOLVE_DATUM_PROJECTION", "YES")

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -43,6 +43,8 @@ from osgeo import osr
 import gdaltest
 import pytest
 
+pytestmark = pytest.mark.require_driver('ECW')
+
 ###############################################################################
 
 
@@ -107,11 +109,8 @@ def test_ecw_1():
 # Verify various information about our test image.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_2():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
 
     if gdaltest.ecw_drv.major_version == 3:
@@ -136,7 +135,7 @@ def test_ecw_2():
 
 
 def test_ecw_3():
-    if gdaltest.ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('data/jrc.ecw')
@@ -159,8 +158,7 @@ def test_ecw_3():
 
 
 def test_ecw_4():
-
-    if gdaltest.ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     gdal.Unlink('tmp/jrc_out.ecw.aux.xml')
@@ -192,8 +190,9 @@ def test_ecw_4():
 # Now try writing a JPEG2000 compressed version of the same with the ECW driver
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_5():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('data/small.vrt')
@@ -207,9 +206,10 @@ def test_ecw_5():
 # Verify various information about our generated image.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_6():
 
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('tmp/ecw_5.jp2')
@@ -250,8 +250,9 @@ def test_ecw_6():
 # Write the same image to NITF.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_7():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('data/small.vrt')
@@ -263,9 +264,10 @@ def test_ecw_7():
 # Verify various information about our generated image.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_8():
 
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('tmp/ecw_7.ntf')
@@ -290,8 +292,9 @@ def test_ecw_8():
 # Try writing 16bit JP2 file directly using Create().
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_9():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     # This always crashes on Frank's machine - some bug in old sdk.
@@ -315,8 +318,9 @@ def test_ecw_9():
 # Verify previous 16bit file.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_10():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     # This always crashes on Frank's machine - some bug in old sdk.
@@ -339,8 +343,9 @@ def test_ecw_10():
 # Test direct creation of an NITF/JPEG2000 file.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_11():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     drv = gdal.GetDriverByName('NITF')
@@ -366,8 +371,9 @@ def test_ecw_11():
 # Verify previous file
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_12():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('tmp/test_11.ntf')
@@ -394,10 +400,8 @@ def test_ecw_12():
 # type and select an altered band list.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_13():
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/rgb16_ecwsdk.jp2')
 
     wrktype = gdal.GDT_Float32
@@ -421,8 +425,9 @@ def test_ecw_13():
 # Write out image with GCPs.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_14():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('data/rgb_gcp.vrt')
@@ -432,9 +437,9 @@ def test_ecw_14():
 # Verify various information about our generated image.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_15():
-
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('tmp/rgb_gcp.jp2')
@@ -454,10 +459,8 @@ def test_ecw_15():
 # Open byte.jp2
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_16():
-
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
 
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
@@ -487,11 +490,8 @@ def test_ecw_16():
 # Open int16.jp2
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_17():
-
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
-
     if gdaltest.ecw_drv.major_version == 4:
         pytest.skip('4.x SDK gets unreliable results for jp2')
 
@@ -510,10 +510,8 @@ def test_ecw_17():
 # Open byte.jp2.gz (test use of the VSIL API)
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_18():
-
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
 
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
@@ -543,10 +541,8 @@ def test_ecw_18():
 # Test a JPEG2000 with the 3 bands having 13bit depth and the 4th one 1 bit
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_19():
-
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/3_13bit_and_1bit.jp2')
 
@@ -563,11 +559,8 @@ def test_ecw_19():
 # are as expected.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_20():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
 
     band = ds.GetRasterBand(1)
@@ -599,11 +592,8 @@ def test_ecw_20():
 # line by line.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_21():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
     mem_ds = gdal.GetDriverByName('MEM').CreateCopy('xxxyyy', ds, options=['INTERLEAVE=PIXEL'])
     ds = None
@@ -626,11 +616,8 @@ def test_ecw_21():
 # ECW file.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_22():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/spif83.ecw')
 
     expected_wkt = """PROJCS["L2CAL6M",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",32.7833333078095],PARAMETER["standard_parallel_2",33.8833333208765],PARAMETER["latitude_of_origin",32.166666682432],PARAMETER["central_meridian",-116.249999974595],PARAMETER["false_easting",2000000],PARAMETER["false_northing",500000],UNIT["Metre",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]"""
@@ -643,11 +630,8 @@ def test_ecw_22():
 # preserving the ecw derived georeferencing.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_23():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     shutil.copyfile('data/spif83.ecw', 'tmp/spif83.ecw')
     shutil.copyfile('data/spif83_hidden.ecw.aux.xml', 'tmp/spif83.ecw.aux.xml')
 
@@ -673,11 +657,8 @@ def test_ecw_23():
 # Test that we can alter geotransform on existing ECW
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_24():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     shutil.copyfile('data/spif83.ecw', 'tmp/spif83.ecw')
     try:
         os.remove('tmp/spif83.ecw.aux.xml')
@@ -716,11 +697,8 @@ def test_ecw_24():
 # Test that we can alter projection info on existing ECW (through SetProjection())
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_25():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     shutil.copyfile('data/spif83.ecw', 'tmp/spif83.ecw')
     try:
         os.remove('tmp/spif83.ecw.aux.xml')
@@ -771,11 +749,8 @@ def test_ecw_25():
 # Test that we can alter projection info on existing ECW (through SetMetadataItem())
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_26():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     shutil.copyfile('data/spif83.ecw', 'tmp/spif83.ecw')
     try:
         os.remove('tmp/spif83.ecw.aux.xml')
@@ -829,9 +804,10 @@ def test_ecw_26():
 # Check that we can use .j2w world files (#4651)
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_27():
 
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.Open('data/byte_without_geotransform.jp2')
@@ -846,11 +822,8 @@ def test_ecw_27():
 # Check picking use case
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_28():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     x = y = 50
 
     ds = gdal.Open('data/jrc.ecw')
@@ -871,11 +844,8 @@ def test_ecw_28():
 # Test supersampling
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_29():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
     data_b1 = ds.GetRasterBand(1).ReadRaster(0, 0, 400, 400)
     ds = None
@@ -942,11 +912,8 @@ def test_ecw_29():
 # Test IReadBlock()
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_30():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
     (blockxsize, blockysize) = ds.GetRasterBand(1).GetBlockSize()
     data_readraster = ds.GetRasterBand(1).ReadRaster(0, 0, blockxsize, blockysize)
@@ -959,11 +926,8 @@ def test_ecw_30():
 # Test async reader interface ( SDK >= 4.x )
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_31():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     if gdaltest.ecw_drv.major_version < 4:
         pytest.skip()
 
@@ -1003,11 +967,8 @@ def test_ecw_31():
 # It ignores the content of panBandMap. (#4234)
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_32():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
     data_123 = ds.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize, band_list=[1, 2, 3])
     data_321 = ds.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize, band_list=[3, 2, 1])
@@ -1041,11 +1002,8 @@ def test_ecw_32():
 # Test heuristics that detect successive band reading pattern
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_33():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
     multiband_data = ds.ReadRaster(100, 100, 50, 50)
     ds = None
@@ -1093,11 +1051,8 @@ def test_ecw_33():
 # Check bugfix for #5262
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_33_bis():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jrc.ecw')
     data_ref = ds.ReadRaster(0, 0, 50, 50)
 
@@ -1130,7 +1085,7 @@ def test_ecw_33_bis():
 
 def test_ecw_34():
 
-    if gdaltest.ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
     if gdaltest.ecw_drv.major_version < 5:
         pytest.skip()
@@ -1154,8 +1109,9 @@ def test_ecw_34():
 # Verify that an write the imagery out to a new JP2 file. Source file is 16 bit.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_35():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     ds = gdal.GetDriverByName('MEM').Create('MEM:::', 128, 128, 1, gdal.GDT_UInt16)
@@ -1177,7 +1133,7 @@ def test_ecw_35():
 
 def test_ecw_36():
 
-    if gdaltest.ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
     if gdaltest.ecw_drv.major_version < 5:
         pytest.skip()
@@ -1234,7 +1190,7 @@ def test_ecw_36():
 
 def test_ecw_37():
 
-    if gdaltest.ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
     if gdaltest.ecw_drv.major_version < 5:
         pytest.skip()
@@ -1267,11 +1223,8 @@ def test_ecw_37():
 # Check opening unicode files.
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_38():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     gdaltest.ecw_38_fname = ''
     if version_info >= (3, 0, 0):
         exec("""gdaltest.ecw_38_fname = 'tmp/za\u017C\u00F3\u0142\u0107g\u0119\u015Bl\u0105ja\u017A\u0144.ecw'""")
@@ -1302,7 +1255,7 @@ def test_ecw_38():
 
 def test_ecw_39():
 
-    if gdaltest.ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
     if gdaltest.ecw_drv.major_version < 5:
         pytest.skip()
@@ -1327,11 +1280,8 @@ def test_ecw_39():
 # Check reading a ECW v3 file
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_40():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/stefan_full_rgba_ecwv3_meta.ecw')
     if ds is None:
         if gdaltest.ecw_drv.major_version < 5:
@@ -1375,7 +1325,7 @@ def test_ecw_40():
 
 def test_ecw_41():
 
-    if gdaltest.ecw_drv is None or gdaltest.ecw_drv.major_version < 5:
+    if gdaltest.ecw_drv.major_version < 5:
         pytest.skip()
 
     shutil.copy('data/stefan_full_rgba_ecwv3_meta.ecw', 'tmp/stefan_full_rgba_ecwv3_meta.ecw')
@@ -1446,7 +1396,7 @@ def test_ecw_41():
 
 def test_ecw_42():
 
-    if gdaltest.ecw_drv is None or gdaltest.ecw_drv.major_version < 5:
+    if gdaltest.ecw_drv.major_version < 5:
         pytest.skip()
 
     shutil.copy('data/stefan_full_rgba_ecwv3_meta.ecw', 'tmp/stefan_full_rgba_ecwv3_meta.ecw')
@@ -1515,10 +1465,8 @@ def test_ecw_42():
 # Note: only works on reversible files like this one
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_43():
-
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/stefan_full_rgba_alpha_1bit.jp2')
     fourth_band = ds.GetRasterBand(4)
@@ -1551,10 +1499,8 @@ def test_ecw_43():
 # Test metadata retrieval from JP2 file
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_44():
-
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
     if gdaltest.ecw_drv.major_version < 5 or (gdaltest.ecw_drv.major_version == 5 and gdaltest.ecw_drv.minor_version < 1):
         pytest.skip()
 
@@ -1599,8 +1545,9 @@ def RemoveDriverMetadata(md):
     return md
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_45():
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     # No metadata
@@ -1673,9 +1620,10 @@ def test_ecw_45():
 # Test non nearest upsampling
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_46():
 
-    if gdaltest.jp2ecw_drv is None or gdaltest.ecw_write == 0:
+    if gdaltest.ecw_write == 0:
         pytest.skip()
 
     tmp_ds = gdaltest.jp2ecw_drv.CreateCopy('/vsimem/ecw_46.jp2', gdal.Open('data/int16.tif'))
@@ -1701,11 +1649,8 @@ def test_ecw_46():
 # /vsi reading with ECW (#6482)
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_47():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     if gdaltest.ecw_drv.major_version == 3:
         pytest.skip()
 
@@ -1733,11 +1678,8 @@ def test_ecw_47():
 # Test "Upward" orientation is forced by default
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_48():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ecw_upward = gdal.GetConfigOption('ECW_ALWAYS_UPWARD', 'TRUE')
     assert ecw_upward == 'TRUE' or ecw_upward == 'ON', \
         'ECW_ALWAYS_UPWARD default value must be TRUE.'
@@ -1753,11 +1695,8 @@ def test_ecw_48():
 # Test "Upward" orientation can be overridden with ECW_ALWAYS_UPWARD=FALSE
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_49():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     ecw_upward_old = gdal.GetConfigOption('ECW_ALWAYS_UPWARD', 'TRUE')
     gdal.SetConfigOption('ECW_ALWAYS_UPWARD', 'FALSE')
     ds = gdal.Open('data/spif83_downward.ecw')
@@ -1771,10 +1710,8 @@ def test_ecw_49():
 ###############################################################################
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_online_1():
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k', '7sisters200.j2k'):
         pytest.skip()
 
@@ -1790,10 +1727,8 @@ def test_ecw_online_1():
 ###############################################################################
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_online_2():
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2', 'gcp.jp2'):
         pytest.skip()
 
@@ -1814,9 +1749,8 @@ def test_ecw_online_2():
 ###############################################################################
 
 
+@pytest.mark.require_driver('JP2ECW')
 def ecw_online_3():
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
     if gdaltest.ecw_drv.major_version == 4:
         pytest.skip('4.x SDK gets unreliable results for jp2')
 
@@ -1845,10 +1779,8 @@ def ecw_online_3():
 ###############################################################################
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_online_4():
-
-    if gdaltest.jp2ecw_drv is None:
-        pytest.skip()
 
     if gdaltest.ecw_drv.major_version == 5 and gdaltest.ecw_drv.minor_version == 2:
         pytest.skip('This test hangs on Linux in a mutex in the SDK 5.2.1')
@@ -1878,11 +1810,8 @@ def test_ecw_online_4():
 ###############################################################################
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_online_5():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/ecw/red_flower.ecw', 'red_flower.ecw'):
         pytest.skip()
 
@@ -1909,11 +1838,8 @@ def test_ecw_online_5():
 # and in particular the .ecw extension, to make the ECW driver happy
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_online_6():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     drv = gdal.GetDriverByName('HTTP')
     if drv is None:
         pytest.skip()
@@ -1946,11 +1872,8 @@ def test_ecw_online_6():
 # ECWv2 file with alpha channel (#6028)
 
 
+@pytest.mark.require_driver('JP2ECW')
 def test_ecw_online_7():
-
-    if gdaltest.ecw_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/ecw/sandiego2m_null.ecw', 'sandiego2m_null.ecw'):
         pytest.skip()
 
@@ -2047,6 +1970,3 @@ def test_ecw_cleanup():
     except OSError:
         pass
     gdaltest.reregister_all_jpeg2000_drivers()
-
-
-

--- a/autotest/gdrivers/fast.py
+++ b/autotest/gdrivers/fast.py
@@ -38,23 +38,14 @@ import pytest
 ###############################################################################
 # Verify we have the driver.
 
+pytestmark = pytest.mark.require_driver('FAST')
 
-def test_fast_1():
 
-    gdaltest.fast_drv = gdal.GetDriverByName('FAST')
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
-    
 ###############################################################################
 # Perform simple read test.
 
 
 def test_fast_2():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     # Actually, the band (a placeholder) is of 0 bytes size,
     # so the checksum is 0 expected.
 
@@ -67,10 +58,6 @@ def test_fast_2():
 
 
 def test_fast_3():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     gdaltest.fast_ds = gdal.Open('data/L71118038_03820020111_HPN.FST')
     ds = gdaltest.fast_ds
     assert ds is not None, 'Missing test dataset'
@@ -103,10 +90,6 @@ def test_fast_3():
 
 
 def test_fast_4():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     ds = gdaltest.fast_ds
     assert ds is not None, 'Missing test dataset'
 
@@ -126,10 +109,6 @@ def test_fast_4():
 # Test 2 bands dataset with checking projections and geotransform.
 
 def test_fast_5():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('fast', 'L71230079_07920021111_HTM.FST', 2, 19110,
                             0, 0, 7000, 1)
 
@@ -165,10 +144,6 @@ def test_fast_5():
 # Test Euromap LISS3 dataset
 
 def test_fast_6():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('fast', 'n0o0y867.0fl', 1, 0, 0, 0, 2741, 1)
 
     # Expected parameters of the geotransform
@@ -186,10 +161,6 @@ def test_fast_6():
 # Test Euromap PAN dataset
 
 def test_fast_7():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('fast', 'h0o0y867.1ah', 1, 0, 0, 0, 5815, 1)
 
     # Expected parameters of the geotransform
@@ -218,10 +189,6 @@ def test_fast_7():
 
 
 def test_fast_8():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('fast', 'w0y13a4t.010', 1, 0, 0, 0, 4748, 1)
 
     # Expected parameters of the geotransform
@@ -252,10 +219,6 @@ def test_fast_8():
 
 
 def test_fast_9():
-
-    if gdaltest.fast_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/HEADER.DAT')
     assert ds.GetMetadataItem('SENSOR') == '', 'Did not get expected SENSOR value.'
 

--- a/autotest/gdrivers/gif.py
+++ b/autotest/gdrivers/gif.py
@@ -29,33 +29,30 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import pytest
+
 from osgeo import gdal
 
-
 import gdaltest
+
 
 ###############################################################################
 # Get the GIF driver, and verify a few things about it.
 
+pytestmark = pytest.mark.require_driver('GIF', 'BIGGIF')
 
-def test_gif_1():
 
-    gdaltest.gif_drv = gdal.GetDriverByName('GIF')
-    if gdaltest.gif_drv is None:
-        gdaltest.post_reason('GIF driver not found!')
-        return 'false'
-
+@pytest.fixture(autouse=True, scope='module')
+def gif_init():
     # Move the BIGGIF driver after the GIF driver.
     drv = gdal.GetDriverByName('BIGGIF')
     drv.Deregister()
     drv.Register()
 
     drv_md = gdaltest.gif_drv.GetMetadata()
-    if drv_md['DMD_MIMETYPE'] != 'image/gif':
-        gdaltest.post_reason('mime type is wrong')
-        return 'false'
+    assert drv_md['DMD_MIMETYPE'] == 'image/gif'
 
-    
+
 ###############################################################################
 # Read test of simple byte reference data.
 
@@ -114,14 +111,10 @@ def test_gif_6():
     src_ds = gdal.Open('../gcore/data/nodata_byte.tif')
 
     new_ds = gdaltest.gif_drv.CreateCopy('tmp/nodata_byte.gif', src_ds)
-    if new_ds is None:
-        gdaltest.post_reason('Create copy operation failure')
-        return 'false'
+    assert new_ds, 'Create copy operation failure'
 
     bnd = new_ds.GetRasterBand(1)
-    if bnd.Checksum() != 4440:
-        gdaltest.post_reason('Wrong checksum')
-        return 'false'
+    assert bnd.Checksum() == 4440
 
     bnd = None
     new_ds = None
@@ -130,15 +123,11 @@ def test_gif_6():
     new_ds = gdal.Open('tmp/nodata_byte.gif')
 
     bnd = new_ds.GetRasterBand(1)
-    if bnd.Checksum() != 4440:
-        gdaltest.post_reason('Wrong checksum')
-        return 'false'
+    assert bnd.Checksum() == 4440
 
     # NOTE - mloskot: condition may fail as nodata is a float-point number
     nodata = bnd.GetNoDataValue()
-    if nodata != 0:
-        gdaltest.post_reason('Got unexpected nodata value.')
-        return 'false'
+    assert nodata == 0
 
     bnd = None
     new_ds = None

--- a/autotest/gdrivers/gmt.py
+++ b/autotest/gdrivers/gmt.py
@@ -28,23 +28,19 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-from osgeo import gdal
-
 
 import gdaltest
 import pytest
+
+
+pytestmark = pytest.mark.require_driver('GMT')
+
 
 ###############################################################################
 # Perform simple read test.
 
 
 def test_gmt_1():
-
-    gdaltest.gmt_drv = gdal.GetDriverByName('GMT')
-
-    if gdaltest.gmt_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('GMT', 'gmt_1.grd', 1, 34762)
 
     gt = (59.958333333333336, 0.083333333333333, 0.0,
@@ -57,15 +53,7 @@ def test_gmt_1():
 
 
 def test_gmt_2():
-
-    if gdaltest.gmt_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('GMT', 'int16.tif', 1, 4672)
     return tst.testCreateCopy(check_gt=1)
 
 ###############################################################################
-
-
-
-

--- a/autotest/gdrivers/grass.py
+++ b/autotest/gdrivers/grass.py
@@ -28,8 +28,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-from osgeo import gdal
-
 
 import gdaltest
 import pytest
@@ -38,22 +36,14 @@ import pytest
 ###############################################################################
 # Test if GRASS driver is present
 
-def test_grass_1():
+pytestmark = pytest.mark.require_driver('GRASS')
 
-    gdaltest.grass_drv = gdal.GetDriverByName('GRASS')
-    if gdaltest.grass_drv is None:
-        pytest.skip()
 
-    
 ###############################################################################
 # Read existing simple 1 band GRASS dataset.
 
 
 def test_grass_2():
-
-    if gdaltest.grass_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('GRASS', 'small_grass_dataset/demomapset/cellhd/elevation', 1, 41487)
 
     srs = """PROJCS["UTM Zone 18, Northern Hemisphere",
@@ -71,11 +61,6 @@ def test_grass_2():
     PARAMETER["false_northing",0],
     UNIT["meter",1]]"""
 
-    ret = tst.testOpen(check_prj=srs)
-    if ret != 'success':
-        gdaltest.post_reason('If that test fails, checks that the GISBASE environment variable point to the root of your GRASS install. For example GIS_BASE=/usr/local/grass-6.4.svn')
-    return ret
-
-
-
-
+    # If this test fails, check that the GISBASE environment variable points to the root of your GRASS install.
+    # For example GIS_BASE=/usr/local/grass-6.4.svn
+    tst.testOpen(check_prj=srs)

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -33,12 +33,14 @@
 import os
 import struct
 import shutil
+import sys
 from osgeo import gdal
 from osgeo import osr
 import pytest
 
 import gdaltest
 
+sys.path.append('../osr')
 
 pytestmark = pytest.mark.require_driver('GRIB')
 
@@ -1069,9 +1071,9 @@ def test_grib_grib2_write_data_encodings():
         cs = out_ds.GetRasterBand(1).Checksum()
         out_ds = None
         gdal.Unlink(tmpfilename)
-        if cs == 0 or cs == 50235:  # 50235: lossless checksum
-            gdaltest.post_reason('did not get expected checksum for lossy JPEG2000 with ' + drvname)
-            print(cs)
+
+        # 50235: lossless checksum
+        assert cs not in (0, 50235), 'did not get expected checksum for lossy JPEG2000 with ' + drvname
 
 
 ###############################################################################
@@ -1195,10 +1197,6 @@ def test_grib_grib2_write_temperatures():
 
 
 def test_grib_grib2_write_nodata():
-
-    if gdaltest.grib_drv is None:
-        pytest.skip()
-
     for src_type in [ gdal.GDT_Byte, gdal.GDT_Float32 ]:
         src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2, 1, src_type)
         src_ds.SetGeoTransform([2, 1, 0, 49, 0, -1])

--- a/autotest/gdrivers/gta.py
+++ b/autotest/gdrivers/gta.py
@@ -53,23 +53,14 @@ init_list = [
 ###############################################################################
 # Verify we have the driver.
 
+pytestmark = pytest.mark.require_driver('GTA')
 
-def test_gta_1():
 
-    gdaltest.gta_drv = gdal.GetDriverByName('GTA')
-    if gdaltest.gta_drv is None:
-        pytest.skip()
-
-    
 ###############################################################################
 # Test updating existing dataset, check srs, check gt
 
 
 def test_gta_2():
-
-    if gdaltest.gta_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.tif')
     out_ds = gdaltest.gta_drv.CreateCopy('/vsimem/byte.gta', src_ds)
     out_ds = None
@@ -108,10 +99,6 @@ def test_gta_2():
 
 
 def test_gta_3():
-
-    if gdaltest.gta_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/gcps.vrt')
 
     new_ds = gdaltest.gta_drv.CreateCopy('/vsimem/gta_3.gta', src_ds)
@@ -140,10 +127,6 @@ def test_gta_3():
 
 
 def test_gta_4():
-
-    if gdaltest.gta_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1, 17)
     src_ds.GetRasterBand(1).Fill(255)
     src_ds.GetRasterBand(1).ComputeStatistics(False)
@@ -185,10 +168,6 @@ def test_gta_4():
 
 
 def test_gta_5():
-
-    if gdaltest.gta_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.tif')
 
     compress_list = ['NONE',
@@ -217,12 +196,8 @@ def test_gta_5():
     init_list,
     ids=[tup[0].split('.')[0] for tup in init_list],
 )
-@pytest.mark.require_driver('GTA')
 def test_gta_create(filename, checksum):
     if filename != 'byte_signed.tif':
         filename = '../../gcore/data/' + filename
     ut = gdaltest.GDALTest('GTA', filename, 1, checksum, options=[])
     ut.testCreateCopy()
-
-
-

--- a/autotest/gdrivers/jp2kak.py
+++ b/autotest/gdrivers/jp2kak.py
@@ -36,18 +36,22 @@ from osgeo import gdal
 import gdaltest
 import pytest
 
+
+pytestmark = pytest.mark.require_driver('JP2KAK')
+
+
+@pytest.fixture(autouse=True, scope='module')
+def jp2kak_init():
+    gdaltest.deregister_all_jpeg2000_drivers_but('JP2KAK')
+    yield
+    gdaltest.reregister_all_jpeg2000_drivers()
+
+
 ###############################################################################
 # Read test of simple byte reference data.
 
 
 def test_jp2kak_1():
-
-    gdaltest.jp2kak_drv = gdal.GetDriverByName('JP2KAK')
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
-    gdaltest.deregister_all_jpeg2000_drivers_but('JP2KAK')
-
     tst = gdaltest.GDALTest('JP2KAK', 'byte.jp2', 1, 50054)
     return tst.testOpen()
 
@@ -56,10 +60,6 @@ def test_jp2kak_1():
 
 
 def test_jp2kak_2():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', 'int16.jp2', 1, 4587)
     return tst.testOpen()
 
@@ -68,10 +68,6 @@ def test_jp2kak_2():
 
 
 def test_jp2kak_3():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', 'byte.jp2', 1, 50054,
                             options=['QUALITY=100'])
 
@@ -82,10 +78,6 @@ def test_jp2kak_3():
 
 
 def test_jp2kak_4():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', 'rgbsmall.tif', 0, 0,
                             options=['GMLJP2=OFF'])
 
@@ -96,10 +88,6 @@ def test_jp2kak_4():
 
 
 def test_jp2kak_5():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', 'rgbsmall.tif', 0, 0,
                             options=['GEOJP2=OFF'])
 
@@ -111,10 +99,6 @@ def test_jp2kak_5():
 
 
 def test_jp2kak_8():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', 'byte.jp2', 1, 50054,
                             options=['QUALITY=100'])
 
@@ -127,10 +111,6 @@ def test_jp2kak_8():
 
 
 def test_jp2kak_9():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', 'rgbwcmyk01_YeGeo_kakadu.jp2', 2, 32141)
     return tst.testOpen()
 
@@ -141,10 +121,6 @@ def test_jp2kak_9():
 
 
 def test_jp2kak_10():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/rgbwcmyk01_YeGeo_kakadu.jp2')
     data = ds.ReadRaster(0, 0, 800, 100, band_list=[2, 3]).decode('latin1')
     ds = None
@@ -164,10 +140,6 @@ def test_jp2kak_10():
 
 
 def test_jp2kak_11():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/gtsmall_11_int16.jp2')
     cs = ds.GetRasterBand(1).Checksum()
     assert cs in (63475, 63472, 63452, 63471)
@@ -178,10 +150,6 @@ def test_jp2kak_11():
 
 
 def test_jp2kak_12():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/gtsmall_10_uint16.jp2')
     cs = ds.GetRasterBand(1).Checksum()
     assert cs == 63360 or cs == 63357 or cs == 63358
@@ -192,10 +160,6 @@ def test_jp2kak_12():
 #
 
 def test_jp2kak_13():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/utm.pix')
     jp2_ds = gdaltest.jp2kak_drv.CreateCopy('tmp/jp2kak_13.jp2', src_ds)
     src_ds = None
@@ -220,10 +184,6 @@ def test_jp2kak_13():
 
 
 def test_jp2kak_14():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     jp2_ds = gdal.Open('tmp/jp2kak_13.jp2')
 
     jp2_ds.BuildOverviews('NEAREST', overviewlist=[2, 4])
@@ -255,10 +215,6 @@ def test_jp2kak_14():
 
 
 def test_jp2kak_15():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     jp2_ds = gdal.Open('data/small_200ppcm.jp2')
 
     md = jp2_ds.GetMetadata()
@@ -275,10 +231,6 @@ def test_jp2kak_15():
 
 
 def test_jp2kak_16():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     jp2_ds = gdal.Open('data/small_200ppcm.jp2')
     out_ds = gdaltest.jp2kak_drv.CreateCopy('tmp/jp2kak_16.jp2', jp2_ds)
     del out_ds
@@ -305,10 +257,6 @@ def test_jp2kak_16():
 
 
 def test_jp2kak_17():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('GDAL_JP2K_ALT_OFFSETVECTOR_ORDER', 'YES')
 
     ds = gdal.Open('data/gmljp2_dtedsm_epsg_4326_axes_alt_offsetVector.jp2')
@@ -336,10 +284,6 @@ def test_jp2kak_17():
 
 
 def test_jp2kak_18():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', 'int16.tif', 1, 4672,
                             options=['QUALITY=100'])
 
@@ -350,10 +294,6 @@ def test_jp2kak_18():
 
 
 def test_jp2kak_19():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2KAK', '../gcore/data/uint16.tif', 1, 4672,
                             options=['QUALITY=100'], filename_absolute=1)
 
@@ -364,10 +304,6 @@ def test_jp2kak_19():
 
 
 def test_jp2kak_20():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/stefan_full_rgba_alpha_1bit.jp2')
     fourth_band = ds.GetRasterBand(4)
     assert fourth_band.GetMetadataItem('NBITS', 'IMAGE_STRUCTURE') is None
@@ -409,10 +345,6 @@ def test_jp2kak_20():
 
 
 def test_jp2kak_21():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     tmp_ds = gdaltest.jp2kak_drv.CreateCopy(
         '/vsimem/jp2kak_21.jp2',
         gdal.Open('data/int16.tif'), options=['QUALITY=100'])
@@ -441,10 +373,6 @@ def test_jp2kak_21():
 
 
 def test_jp2kak_22():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/stefan_full_rgba.tif')
     gdaltest.jp2kak_drv.CreateCopy('/vsimem/jp2kak_22.jp2', src_ds, options=['QUALITY=100'])
     ds = gdal.Open('/vsimem/jp2kak_22.jp2')
@@ -464,23 +392,9 @@ def test_jp2kak_22():
 
 
 def test_jp2kak_odd_dimensions():
-
-    if gdaltest.jp2kak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/513x513.jp2')
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     ds = None
 
     assert cs == 29642
-
-
-###############################################################################
-# Cleanup.
-
-def test_jp2kak_cleanup():
-
-    gdaltest.reregister_all_jpeg2000_drivers()
-
-
 

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -38,9 +38,10 @@ from osgeo import ogr
 from osgeo import osr
 import pytest
 
+import gdaltest
+
 sys.path.append('../../gdal/swig/python/samples')
 
-import gdaltest
 
 ###############################################################################
 # Verify we have the driver.
@@ -65,16 +66,11 @@ def test_jp2lura_1():
         gdaltest.jp2lura_drv = None
         pytest.skip('Driver JP2Lura is registered, but issue with license')
 
-    
 ###############################################################################
 #
 
 
 def test_jp2lura_missing_license_num():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     old_num_1 = gdal.GetConfigOption('LURA_LICENSE_NUM_1')
     old_num_2 = gdal.GetConfigOption('LURA_LICENSE_NUM_2')
     gdal.SetConfigOption('LURA_LICENSE_NUM_1', '')
@@ -91,10 +87,6 @@ def test_jp2lura_missing_license_num():
 
 
 def test_jp2lura_invalid_license_num():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     old_num_1 = gdal.GetConfigOption('LURA_LICENSE_NUM_1')
     old_num_2 = gdal.GetConfigOption('LURA_LICENSE_NUM_2')
     gdal.SetConfigOption('LURA_LICENSE_NUM_1', '1')
@@ -143,10 +135,6 @@ def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=Non
 
 
 def test_jp2lura_2():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
         DATUM["North_American_Datum_1927",
@@ -176,10 +164,6 @@ def test_jp2lura_2():
 
 
 def test_jp2lura_3():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/int16.jp2')
     ds_ref = gdal.Open('data/int16.tif')
 
@@ -201,10 +185,6 @@ def test_jp2lura_3():
 
 
 def test_jp2lura_4(out_filename='tmp/jp2lura_4.jp2'):
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.jp2')
     src_wkt = src_ds.GetProjectionRef()
     src_gt = src_ds.GetGeoTransform()
@@ -264,10 +244,6 @@ def test_jp2lura_4_vsimem():
 
 
 def test_jp2lura_5():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2Lura', 'int16.jp2', 1, None, options=['REVERSIBLE=YES', 'CODEC=J2K'])
     return tst.testCreateCopy()
 
@@ -276,10 +252,6 @@ def test_jp2lura_5():
 
 
 def test_jp2lura_6():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2Lura', 'll.jp2', 1, None)
 
     tst.testOpen()
@@ -293,10 +265,6 @@ def test_jp2lura_6():
 
 
 def test_jp2lura_7():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2Lura', '/vsigzip/data/byte.jp2.gz', 1, 50054, filename_absolute=1)
     return tst.testOpen()
 
@@ -305,10 +273,6 @@ def test_jp2lura_7():
 
 
 def test_jp2lura_8():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/3_13bit_and_1bit.jp2')
 
     expected_checksums = [64570, 57277, 56048]  # 61292]
@@ -324,10 +288,6 @@ def test_jp2lura_8():
 
 
 def test_jp2lura_9():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_without_geotransform.jp2')
 
     geotransform = ds.GetGeoTransform()
@@ -341,10 +301,6 @@ def test_jp2lura_9():
 
 
 def DISABLED_jp2lura_10():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/rgbsmall.tif')
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_10.jp2', src_ds, options=['YCBCR420=YES', 'RESOLUTIONS=3'])
     maxdiff = gdaltest.compare_ds(src_ds, out_ds)
@@ -363,10 +319,6 @@ def DISABLED_jp2lura_10():
 
 
 def DISABLED_jp2lura_11():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/stefan_full_rgba_alpha_1bit.jp2')
     fourth_band = ds.GetRasterBand(4)
     assert fourth_band.GetMetadataItem('NBITS', 'IMAGE_STRUCTURE') is None
@@ -399,10 +351,6 @@ def DISABLED_jp2lura_11():
 
 
 def test_jp2lura_12():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # Override projection
     shutil.copy('data/byte.jp2', 'tmp/jp2lura_12.jp2')
 
@@ -440,10 +388,6 @@ def test_jp2lura_12():
 
 
 def test_jp2lura_13():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # Create a dataset with GCPs
     src_ds = gdal.Open('data/rgb_gcp.vrt')
     ds = gdaltest.jp2lura_drv.CreateCopy('tmp/jp2lura_13.jp2', src_ds)
@@ -486,10 +430,6 @@ def test_jp2lura_13():
 
 
 def test_jp2lura_14():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_2gcps.jp2')
     assert ds.GetGCPCount() == 2
 
@@ -498,10 +438,6 @@ def test_jp2lura_14():
 
 
 def test_jp2lura_16():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_point.jp2')
     gt = ds.GetGeoTransform()
     assert ds.GetMetadataItem('AREA_OR_POINT') == 'Point', \
@@ -530,10 +466,6 @@ def test_jp2lura_16():
 
 
 def test_jp2lura_17():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte_point.jp2')
     ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_17.jp2', src_ds)
     ds = None
@@ -559,10 +491,6 @@ def test_jp2lura_17():
 
 
 def test_jp2lura_18():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('Mem').Create('', 2000, 2000)
     ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_18.jp2', src_ds, options=['TILEXSIZE=2000', 'TILEYSIZE=2000'])
     ds = None
@@ -580,10 +508,6 @@ def test_jp2lura_18():
 
 
 def test_jp2lura_19():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_gmljp2_with_nul_car.jp2')
     assert ds.GetProjectionRef() != ''
     ds = None
@@ -593,10 +517,6 @@ def test_jp2lura_19():
 
 
 def test_jp2lura_20():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     try:
         import xmlvalidate
     except ImportError:
@@ -658,10 +578,6 @@ def test_jp2lura_20():
 
 
 def test_jp2lura_22():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # RGBA
     src_ds = gdal.Open('../gcore/data/stefan_full_rgba.tif')
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_22.jp2', src_ds, options=['REVERSIBLE=YES'])
@@ -765,10 +681,6 @@ def test_jp2lura_22():
 
 
 def DISABLED_jp2lura_23():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/uint16.tif')
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_23.jp2', src_ds, options=['NBITS=9', 'QUALITY=100', 'REVERSIBLE=YES'])
     maxdiff = gdaltest.compare_ds(src_ds, out_ds)
@@ -793,10 +705,6 @@ def DISABLED_jp2lura_23():
 
 
 def test_jp2lura_24():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     #  Grey+alpha
     src_ds = gdal.Open('../gcore/data/stefan_full_greyalpha.tif')
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_24.jp2', src_ds, options=['REVERSIBLE=YES'])
@@ -839,10 +747,6 @@ def test_jp2lura_24():
 
 
 def test_jp2lura_25():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 5)
     src_ds.GetRasterBand(1).Fill(255)
     src_ds.GetRasterBand(2).Fill(250)
@@ -868,10 +772,6 @@ def test_jp2lura_25():
 
 
 def test_jp2lura_27():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # Test optimization in GDALCopyWholeRasterGetSwathSize()
     # Not sure how we can check that except looking at logs with CPL_DEBUG=GDAL
     # for "GDAL: GDALDatasetCopyWholeRaster(): 2048*2048 swaths, bInterleave=1"
@@ -952,10 +852,6 @@ def jp2lura_test_codeblock(filename, codeblock_width, codeblock_height):
 
 
 def test_jp2lura_28():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
 
     tests = [(['CODEBLOCK_WIDTH=2'], 64, 64, True),
@@ -987,10 +883,6 @@ def test_jp2lura_28():
 
 
 def test_jp2lura_30():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
     ct = gdal.ColorTable()
     ct.SetColorEntry(0, (255, 255, 255, 255))
@@ -1010,10 +902,6 @@ def test_jp2lura_30():
 
 
 def DISABLED_jp2lura_31():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 3)
     src_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_GreenBand)
     src_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_BlueBand)
@@ -1050,10 +938,6 @@ def DISABLED_jp2lura_31():
 
 
 def DISABLED_jp2lura_33():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open("""<VRTDataset rasterXSize="100000" rasterYSize="100000">
   <VRTRasterBand dataType="Byte" band="1">
   </VRTRasterBand>
@@ -1070,10 +954,6 @@ def DISABLED_jp2lura_33():
 
 
 def test_jp2lura_34():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('data/dimensions_above_31bit.jp2')
     gdal.PopErrorHandler()
@@ -1084,10 +964,6 @@ def test_jp2lura_34():
 # Test opening a truncated file
 
 def test_jp2lura_35():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('data/truncated.jp2')
     gdal.PopErrorHandler()
@@ -1098,10 +974,6 @@ def test_jp2lura_35():
 
 
 def test_jp2lura_36():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2, 16385)
     gdal.PushErrorHandler()
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_36.jp2', src_ds)
@@ -1113,10 +985,6 @@ def test_jp2lura_36():
 
 
 def test_jp2lura_37():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_37.jp2', src_ds, options=['WRITE_METADATA=YES'])
@@ -1207,10 +1075,6 @@ def test_jp2lura_37():
 
 
 def test_jp2lura_38():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)
     wkt = """PROJCS["UTM Zone 31, Northern Hemisphere",GEOGCS["unnamed ellipse",DATUM["unknown",SPHEROID["unnamed",100,1]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",3],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]"""
@@ -1243,10 +1107,6 @@ def test_jp2lura_38():
 
 
 def test_jp2lura_39():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
     src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
@@ -1312,10 +1172,6 @@ def test_jp2lura_39():
 
 
 def test_jp2lura_40():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
     src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
@@ -1388,10 +1244,6 @@ def test_jp2lura_40():
 
 
 def test_jp2lura_41():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.jp2')
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_41.jp2', src_ds,
                                              options=['USE_SRC_CODESTREAM=YES', '@PROFILE=PROFILE_1', 'GEOJP2=NO', 'GMLJP2=NO'])
@@ -1438,12 +1290,8 @@ def test_jp2lura_43():
 # Test GMLJP2v2
 
 
+@pytest.mark.require_driver('GML')
 def test_jp2lura_45():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-    if gdal.GetDriverByName('GML') is None:
-        pytest.skip()
     if gdal.GetDriverByName('KML') is None and gdal.GetDriverByName('LIBKML') is None:
         pytest.skip()
 
@@ -1523,10 +1371,6 @@ def test_jp2lura_45():
 
 
 def test_jp2lura_47():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/byte_rpc.tif')
     out_ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_47.jp2', src_ds)
     del out_ds
@@ -1543,10 +1387,6 @@ def test_jp2lura_47():
 
 
 def test_jp2lura_48():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_tile_2048.jp2')
     (blockxsize, blockysize) = ds.GetRasterBand(1).GetBlockSize()
     assert (blockxsize, blockysize) == (20, 20)
@@ -1557,10 +1397,6 @@ def test_jp2lura_48():
 
 
 def test_jp2lura_online_1():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k', '7sisters200.j2k'):
         pytest.skip()
 
@@ -1577,10 +1413,6 @@ def test_jp2lura_online_1():
 
 
 def test_jp2lura_online_2():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2', 'gcp.jp2'):
         pytest.skip()
 
@@ -1602,10 +1434,6 @@ def test_jp2lura_online_2():
 
 
 def test_jp2lura_online_3():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.j2k', 'Bretagne1.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.bmp', 'Bretagne1.bmp'):
@@ -1631,10 +1459,6 @@ def test_jp2lura_online_3():
 
 
 def test_jp2lura_online_4():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.j2k', 'Bretagne2.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.bmp', 'Bretagne2.bmp'):
@@ -1661,10 +1485,6 @@ def test_jp2lura_online_4():
 
 
 def test_jp2lura_online_5():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9.jp2', 'file9.jp2'):
         pytest.skip()
 
@@ -1680,10 +1500,6 @@ def test_jp2lura_online_5():
 
 
 def test_jp2lura_online_6():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_03/file3.jp2', 'file3.jp2'):
         pytest.skip()
 
@@ -1703,10 +1519,6 @@ def test_jp2lura_online_6():
 
 
 def test_jp2lura_49():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     tests = [(None, True, True, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
              (None, True, False, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
              (None, False, True, '', (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
@@ -1825,10 +1637,6 @@ def test_jp2lura_49():
 # Test reading split IEEE-754 Float32
 
 def test_jp2lura_50():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2Lura', 'float32_ieee754_split_reversible.jp2', 1, 4672)
     return tst.testOpen()
 
@@ -1837,10 +1645,6 @@ def test_jp2lura_50():
 
 
 def test_jp2lura_51():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # Don't allow it by default
     src_ds = gdal.Open('data/float32.tif')
     with gdaltest.error_handler():
@@ -1898,10 +1702,6 @@ def test_jp2lura_51():
 
 
 def test_jp2lura_52():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     tests = [[-32768, gdal.GDT_Int16, 'h'],
              [-1, gdal.GDT_Int16, 'h'],
              [32767, gdal.GDT_Int16, 'h'],
@@ -1932,10 +1732,6 @@ def test_jp2lura_52():
 
 
 def test_jp2lura_53():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.tif')
 
     ds = gdaltest.jp2lura_drv.CreateCopy('/vsimem/jp2lura_53.jp2', src_ds,
@@ -1977,10 +1773,6 @@ def test_jp2lura_53():
 
 
 def test_jp2lura_54():
-
-    if gdaltest.jp2lura_drv is None:
-        pytest.skip()
-
     # Tiled with incomplete boundary tiles
     src_ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 1)
     src_ds.GetRasterBand(1).Fill(100)

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -42,27 +42,21 @@ sys.path.append('../../gdal/swig/python/samples')
 
 import gdaltest
 
-###############################################################################
-# Verify we have the driver.
+pytestmark = pytest.mark.require_driver('JP2OpenJPEG')
 
 
-def test_jp2openjpeg_1():
-
-    gdaltest.jp2openjpeg_drv = gdal.GetDriverByName('JP2OpenJPEG')
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
+@pytest.fixture(autouse=True, scope='module')
+def jp2openjpeg_init():
     gdaltest.deregister_all_jpeg2000_drivers_but('JP2OpenJPEG')
+    yield
+    gdaltest.reregister_all_jpeg2000_drivers()
+
 
 ###############################################################################
 # Open byte.jp2
 
 
 def test_jp2openjpeg_2():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
         DATUM["North_American_Datum_1927",
@@ -92,10 +86,6 @@ def test_jp2openjpeg_2():
 
 
 def test_jp2openjpeg_3():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/int16.jp2')
     ds_ref = gdal.Open('data/int16.tif')
 
@@ -117,10 +107,6 @@ def test_jp2openjpeg_3():
 
 
 def test_jp2openjpeg_4(out_filename='tmp/jp2openjpeg_4.jp2'):
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.jp2')
     src_wkt = src_ds.GetProjectionRef()
     src_gt = src_ds.GetGeoTransform()
@@ -178,10 +164,6 @@ def test_jp2openjpeg_4_vsimem():
 
 
 def test_jp2openjpeg_5():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2OpenJPEG', 'int16.jp2', 1, None, options=['REVERSIBLE=YES', 'QUALITY=100', 'CODEC=J2K'])
     return tst.testCreateCopy()
 
@@ -190,10 +172,6 @@ def test_jp2openjpeg_5():
 
 
 def test_jp2openjpeg_6():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2OpenJPEG', 'll.jp2', 1, None)
 
     tst.testOpen()
@@ -207,10 +185,6 @@ def test_jp2openjpeg_6():
 
 
 def test_jp2openjpeg_7():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2OpenJPEG', '/vsigzip/data/byte.jp2.gz', 1, 50054, filename_absolute=1)
     return tst.testOpen()
 
@@ -219,10 +193,6 @@ def test_jp2openjpeg_7():
 
 
 def test_jp2openjpeg_8():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/3_13bit_and_1bit.jp2')
 
     expected_checksums = [64570, 57277, 56048, 61292]
@@ -238,10 +208,6 @@ def test_jp2openjpeg_8():
 
 
 def test_jp2openjpeg_9():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_without_geotransform.jp2')
 
     geotransform = ds.GetGeoTransform()
@@ -255,10 +221,6 @@ def test_jp2openjpeg_9():
 
 
 def test_jp2openjpeg_10():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/rgbsmall.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_10.jp2', src_ds, options=['YCBCR420=YES', 'RESOLUTIONS=3'])
     maxdiff = gdaltest.compare_ds(src_ds, out_ds)
@@ -277,10 +239,6 @@ def test_jp2openjpeg_10():
 
 
 def test_jp2openjpeg_11():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/stefan_full_rgba_alpha_1bit.jp2')
     fourth_band = ds.GetRasterBand(4)
     assert fourth_band.GetMetadataItem('NBITS', 'IMAGE_STRUCTURE') is None
@@ -313,10 +271,6 @@ def test_jp2openjpeg_11():
 
 
 def test_jp2openjpeg_12():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # Override projection
     shutil.copy('data/byte.jp2', 'tmp/jp2openjpeg_12.jp2')
 
@@ -354,10 +308,6 @@ def test_jp2openjpeg_12():
 
 
 def test_jp2openjpeg_13():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # Create a dataset with GCPs
     src_ds = gdal.Open('data/rgb_gcp.vrt')
     ds = gdaltest.jp2openjpeg_drv.CreateCopy('tmp/jp2openjpeg_13.jp2', src_ds)
@@ -400,10 +350,6 @@ def test_jp2openjpeg_13():
 
 
 def test_jp2openjpeg_14():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_2gcps.jp2')
     assert ds.GetGCPCount() == 2
 
@@ -412,10 +358,6 @@ def test_jp2openjpeg_14():
 
 
 def test_jp2openjpeg_15():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 256, 256)
     src_ds.GetRasterBand(1).Fill(255)
     data = src_ds.ReadRaster()
@@ -431,10 +373,6 @@ def test_jp2openjpeg_15():
 
 
 def test_jp2openjpeg_16():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_point.jp2')
     gt = ds.GetGeoTransform()
     assert ds.GetMetadataItem('AREA_OR_POINT') == 'Point', \
@@ -463,10 +401,6 @@ def test_jp2openjpeg_16():
 
 
 def test_jp2openjpeg_17():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte_point.jp2')
     ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_17.jp2', src_ds)
     ds = None
@@ -492,10 +426,6 @@ def test_jp2openjpeg_17():
 
 
 def test_jp2openjpeg_18():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('Mem').Create('', 2000, 2000)
     ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_18.jp2', src_ds, options=['BLOCKXSIZE=2000', 'BLOCKYSIZE=2000'])
     ds = None
@@ -513,10 +443,6 @@ def test_jp2openjpeg_18():
 
 
 def test_jp2openjpeg_19():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_gmljp2_with_nul_car.jp2')
     assert ds.GetProjectionRef() != ''
     ds = None
@@ -526,10 +452,6 @@ def test_jp2openjpeg_19():
 
 
 def test_jp2openjpeg_20():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     try:
         import xmlvalidate
     except ImportError:
@@ -591,10 +513,6 @@ def test_jp2openjpeg_20():
 
 
 def test_jp2openjpeg_21():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/rgbsmall.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_21.jp2', src_ds, options=['QUALITY=100', 'REVERSIBLE=YES', 'YCC=NO'])
     maxdiff = gdaltest.compare_ds(src_ds, out_ds)
@@ -610,10 +528,6 @@ def test_jp2openjpeg_21():
 
 
 def test_jp2openjpeg_22():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # RGBA
     src_ds = gdal.Open('../gcore/data/stefan_full_rgba.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_22.jp2', src_ds, options=['QUALITY=100', 'REVERSIBLE=YES'])
@@ -712,10 +626,6 @@ def test_jp2openjpeg_22():
 
 
 def test_jp2openjpeg_23():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/uint16.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_23.jp2', src_ds, options=['NBITS=9', 'QUALITY=100', 'REVERSIBLE=YES'])
     maxdiff = gdaltest.compare_ds(src_ds, out_ds)
@@ -740,10 +650,6 @@ def test_jp2openjpeg_23():
 
 
 def test_jp2openjpeg_24():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     #  Grey+alpha
     src_ds = gdal.Open('../gcore/data/stefan_full_greyalpha.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_24.jp2', src_ds, options=['QUALITY=100', 'REVERSIBLE=YES'])
@@ -781,10 +687,6 @@ def test_jp2openjpeg_24():
 
 
 def test_jp2openjpeg_25():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 5)
     src_ds.GetRasterBand(1).Fill(255)
     src_ds.GetRasterBand(2).Fill(250)
@@ -842,10 +744,6 @@ def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=Non
 
 
 def test_jp2openjpeg_26():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 2048, 2048, 1)
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(32631)
@@ -986,10 +884,6 @@ def test_jp2openjpeg_26():
 
 
 def test_jp2openjpeg_27():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # Test optimization in GDALCopyWholeRasterGetSwathSize()
     # Not sure how we can check that except looking at logs with CPL_DEBUG=GDAL
     # for "GDAL: GDALDatasetCopyWholeRaster(): 2048*2048 swaths, bInterleave=1"
@@ -1070,10 +964,6 @@ def jp2openjpeg_test_codeblock(filename, codeblock_width, codeblock_height):
 
 
 def test_jp2openjpeg_28():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
 
     tests = [(['CODEBLOCK_WIDTH=2'], 64, 64, True),
@@ -1105,10 +995,6 @@ def test_jp2openjpeg_28():
 
 
 def test_jp2openjpeg_29():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 128, 128, 1)
 
     tests = [(['TILEPARTS=DISABLED'], False),
@@ -1140,10 +1026,6 @@ def test_jp2openjpeg_29():
 
 
 def test_jp2openjpeg_30():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
     ct = gdal.ColorTable()
     ct.SetColorEntry(0, (255, 255, 255, 255))
@@ -1229,10 +1111,6 @@ def test_jp2openjpeg_30():
 
 
 def test_jp2openjpeg_31():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 3)
     src_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_GreenBand)
     src_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_BlueBand)
@@ -1269,10 +1147,6 @@ def test_jp2openjpeg_31():
 
 
 def test_jp2openjpeg_32():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
     gdal.PushErrorHandler()
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_32.jp2', src_ds, options=['JP2C_XLBOX=YES'])
@@ -1286,10 +1160,6 @@ def test_jp2openjpeg_32():
 
 
 def test_jp2openjpeg_33():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open("""<VRTDataset rasterXSize="100000" rasterYSize="100000">
   <VRTRasterBand dataType="Byte" band="1">
   </VRTRasterBand>
@@ -1308,10 +1178,6 @@ def test_jp2openjpeg_33():
 
 
 def test_jp2openjpeg_34():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('data/dimensions_above_31bit.jp2')
     gdal.PopErrorHandler()
@@ -1322,10 +1188,6 @@ def test_jp2openjpeg_34():
 # Test opening a truncated file
 
 def test_jp2openjpeg_35():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('data/truncated.jp2')
     gdal.PopErrorHandler()
@@ -1336,10 +1198,6 @@ def test_jp2openjpeg_35():
 
 
 def test_jp2openjpeg_36():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2, 16385)
     gdal.PushErrorHandler()
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_36.jp2', src_ds)
@@ -1351,10 +1209,6 @@ def test_jp2openjpeg_36():
 
 
 def test_jp2openjpeg_37():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_37.jp2', src_ds, options=['WRITE_METADATA=YES'])
@@ -1446,10 +1300,6 @@ def test_jp2openjpeg_37():
 
 
 def test_jp2openjpeg_38():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)
     wkt = """PROJCS["UTM Zone 31, Northern Hemisphere",GEOGCS["unnamed ellipse",DATUM["unknown",SPHEROID["unnamed",100,1]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",3],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]"""
@@ -1483,10 +1333,6 @@ def test_jp2openjpeg_38():
 
 
 def test_jp2openjpeg_39():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
     src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
@@ -1552,10 +1398,6 @@ def test_jp2openjpeg_39():
 
 
 def test_jp2openjpeg_40():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
     src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
@@ -1628,10 +1470,6 @@ def test_jp2openjpeg_40():
 
 
 def test_jp2openjpeg_41():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.jp2')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_41.jp2', src_ds,
                                                  options=['USE_SRC_CODESTREAM=YES', 'PROFILE=PROFILE_1', 'GEOJP2=NO', 'GMLJP2=NO'])
@@ -1668,10 +1506,6 @@ def test_jp2openjpeg_41():
 
 
 def test_jp2openjpeg_42():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
     gdal.PushErrorHandler()
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_42.jp2', src_ds, options=['JP2C_LENGTH_ZERO=YES'])
@@ -1818,10 +1652,6 @@ def test_jp2openjpeg_43():
 
 
 def test_jp2openjpeg_44():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/utm.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_44.jp2', src_ds, options=['INSPIRE_TG=YES'])
     del out_ds
@@ -1836,10 +1666,6 @@ def test_jp2openjpeg_44():
 
 
 def test_jp2openjpeg_45():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     with gdaltest.error_handler():
         if ogr.Open('../ogr/data/ionic_wfs.gml') is None:
             pytest.skip('GML read support missing')
@@ -2534,10 +2360,6 @@ def test_jp2openjpeg_45():
 
 
 def test_jp2openjpeg_46():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     import json
 
     conf = {
@@ -2696,10 +2518,6 @@ yeah: """ not in gmljp2:
 
 
 def test_jp2openjpeg_47():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/byte_rpc.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_47.jp2', src_ds)
     del out_ds
@@ -2716,10 +2534,6 @@ def test_jp2openjpeg_47():
 
 
 def test_jp2openjpeg_48():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_tile_2048.jp2')
     (blockxsize, blockysize) = ds.GetRasterBand(1).GetBlockSize()
     assert (blockxsize, blockysize) == (20, 20)
@@ -2730,10 +2544,6 @@ def test_jp2openjpeg_48():
 
 
 def test_jp2openjpeg_online_1():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k', '7sisters200.j2k'):
         pytest.skip()
 
@@ -2750,10 +2560,6 @@ def test_jp2openjpeg_online_1():
 
 
 def test_jp2openjpeg_online_2():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2', 'gcp.jp2'):
         pytest.skip()
 
@@ -2775,10 +2581,6 @@ def test_jp2openjpeg_online_2():
 
 
 def test_jp2openjpeg_online_3():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.j2k', 'Bretagne1.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.bmp', 'Bretagne1.bmp'):
@@ -2804,10 +2606,6 @@ def test_jp2openjpeg_online_3():
 
 
 def test_jp2openjpeg_online_4():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.j2k', 'Bretagne2.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.bmp', 'Bretagne2.bmp'):
@@ -2834,10 +2632,6 @@ def test_jp2openjpeg_online_4():
 
 
 def test_jp2openjpeg_online_5():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9.jp2', 'file9.jp2'):
         pytest.skip()
 
@@ -2853,10 +2647,6 @@ def test_jp2openjpeg_online_5():
 
 
 def test_jp2openjpeg_online_6():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_03/file3.jp2', 'file3.jp2'):
         pytest.skip()
 
@@ -2874,10 +2664,6 @@ def test_jp2openjpeg_online_6():
 
 
 def test_jp2openjpeg_49():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     tests = [(None, True, True, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
              (None, True, False, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
              (None, False, True, '', (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
@@ -2996,10 +2782,6 @@ def test_jp2openjpeg_49():
 
 
 def test_jp2openjpeg_50():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/fake_sent2_preview.jp2')
     blockxsize, blockysize = ds.GetRasterBand(1).GetBlockSize()
     assert blockxsize == ds.RasterXSize and blockysize == ds.RasterYSize, \
@@ -3012,10 +2794,6 @@ def test_jp2openjpeg_50():
 
 
 def test_jp2openjpeg_codeblock_style():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('CODEBLOCK_STYLE') < 0:
         pytest.skip()
 
@@ -3048,10 +2826,6 @@ def test_jp2openjpeg_codeblock_style():
 
 
 def test_jp2openjpeg_external_overviews_single_band():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     filename = '/vsimem/jp2openjpeg_external_overviews_single_band.jp2'
     gdaltest.jp2openjpeg_drv.CreateCopy(filename,
                                         gdal.Open('../gcore/data/utmsmall.tif'),
@@ -3073,10 +2847,6 @@ def test_jp2openjpeg_external_overviews_single_band():
 
 
 def test_jp2openjpeg_external_overviews_multiple_band():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     filename = '/vsimem/jp2openjpeg_external_overviews_multiple_band.jp2'
     gdaltest.jp2openjpeg_drv.CreateCopy(filename,
                                         gdal.Open('data/small_world.tif'),
@@ -3099,10 +2869,6 @@ def test_jp2openjpeg_external_overviews_multiple_band():
 
 
 def test_jp2openjpeg_odd_dimensions():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/513x513.jp2')
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     ds = None
@@ -3113,10 +2879,6 @@ def test_jp2openjpeg_odd_dimensions():
 
 
 def test_jp2openjpeg_odd_dimensions_overviews():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # Only try the rest with openjpeg >= 2.3 to avoid potential memory issues
     if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('CODEBLOCK_STYLE') < 0:
         pytest.skip()
@@ -3128,8 +2890,3 @@ def test_jp2openjpeg_odd_dimensions_overviews():
     ds = None
 
 ###############################################################################
-
-
-def test_jp2openjpeg_cleanup():
-
-    gdaltest.reregister_all_jpeg2000_drivers()

--- a/autotest/gdrivers/jpeg2000.py
+++ b/autotest/gdrivers/jpeg2000.py
@@ -34,6 +34,20 @@ from osgeo import gdal
 import gdaltest
 import pytest
 
+
+pytestmark = pytest.mark.require_driver('JPEG2000')
+
+###############################################################################
+# Verify we have the driver.
+
+
+@pytest.fixture(autouse=True, scope='module')
+def jpeg2000_init():
+    gdaltest.deregister_all_jpeg2000_drivers_but('JPEG2000')
+    yield
+    gdaltest.reregister_all_jpeg2000_drivers()
+
+
 gdaltest.buggy_jasper = None
 
 
@@ -42,8 +56,6 @@ def is_buggy_jasper():
         return gdaltest.buggy_jasper
 
     gdaltest.buggy_jasper = False
-    if gdal.GetDriverByName('JPEG2000') is None:
-        return False
 
     # This test will cause a crash with an unpatched version of Jasper, such as the one of Ubuntu 8.04 LTS
     # --> "jpc_dec.c:1072: jpc_dec_tiledecode: Assertion `dec->numcomps == 3' failed."
@@ -60,24 +72,10 @@ def is_buggy_jasper():
     return False
 
 ###############################################################################
-# Verify we have the driver.
-
-
-def test_jpeg2000_1():
-
-    gdaltest.jpeg2000_drv = gdal.GetDriverByName('JPEG2000')
-
-    gdaltest.deregister_all_jpeg2000_drivers_but('JPEG2000')
-
-###############################################################################
 # Open byte.jp2
 
 
 def test_jpeg2000_2():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
         DATUM["North_American_Datum_1927",
@@ -107,10 +105,6 @@ def test_jpeg2000_2():
 
 
 def test_jpeg2000_3():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/int16.jp2')
     ds_ref = gdal.Open('data/int16.tif')
 
@@ -129,10 +123,6 @@ def test_jpeg2000_3():
 
 
 def test_jpeg2000_4():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JPEG2000', 'byte.jp2', 1, 50054)
     tst.testCreateCopy()
 
@@ -147,10 +137,6 @@ def test_jpeg2000_4():
 
 
 def test_jpeg2000_5():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JPEG2000', 'int16.jp2', 1, None)
     return tst.testCreateCopy()
 
@@ -159,10 +145,6 @@ def test_jpeg2000_5():
 
 
 def test_jpeg2000_6():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JPEG2000', 'll.jp2', 1, None)
 
     tst.testOpen()
@@ -176,10 +158,6 @@ def test_jpeg2000_6():
 
 
 def test_jpeg2000_7():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JPEG2000', '/vsigzip/data/byte.jp2.gz', 1, 50054, filename_absolute=1)
     return tst.testOpen()
 
@@ -188,8 +166,7 @@ def test_jpeg2000_7():
 
 
 def test_jpeg2000_8():
-
-    if gdaltest.jpeg2000_drv is None or is_buggy_jasper():
+    if is_buggy_jasper():
         pytest.skip()
 
     ds = gdal.Open('data/3_13bit_and_1bit.jp2')
@@ -207,10 +184,6 @@ def test_jpeg2000_8():
 
 
 def test_jpeg2000_9():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_without_geotransform.jp2')
 
     geotransform = ds.GetGeoTransform()
@@ -224,10 +197,6 @@ def test_jpeg2000_9():
 
 
 def test_jpeg2000_10():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/jpeg2000_10_src.tif', 128, 128, 5)
     for i in range(src_ds.RasterCount):
         src_ds.GetRasterBand(i + 1).Fill(10 * i + 1)
@@ -251,8 +220,7 @@ def test_jpeg2000_10():
 
 
 def test_jpeg2000_11():
-
-    if gdaltest.jpeg2000_drv is None or is_buggy_jasper():
+    if is_buggy_jasper():
         pytest.skip()
 
     ds = gdal.Open('data/stefan_full_rgba_alpha_1bit.jp2')
@@ -286,10 +254,6 @@ def test_jpeg2000_11():
 
 
 def test_jpeg2000_online_1():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k', '7sisters200.j2k'):
         pytest.skip()
 
@@ -306,10 +270,6 @@ def test_jpeg2000_online_1():
 
 
 def test_jpeg2000_online_2():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2', 'gcp.jp2'):
         pytest.skip()
 
@@ -331,10 +291,6 @@ def test_jpeg2000_online_2():
 
 
 def test_jpeg2000_online_3():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.j2k', 'Bretagne1.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.bmp', 'Bretagne1.bmp'):
@@ -361,10 +317,6 @@ def test_jpeg2000_online_3():
 
 
 def test_jpeg2000_online_4():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.j2k', 'Bretagne2.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.bmp', 'Bretagne2.bmp'):
@@ -395,10 +347,6 @@ def test_jpeg2000_online_4():
 
 
 def test_jpeg2000_online_5():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9.jp2', 'file9.jp2'):
         pytest.skip()
 
@@ -416,10 +364,6 @@ def test_jpeg2000_online_5():
 
 
 def test_jpeg2000_online_6():
-
-    if gdaltest.jpeg2000_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_03/file3.jp2', 'file3.jp2'):
         pytest.skip()
 
@@ -431,13 +375,3 @@ def test_jpeg2000_online_6():
         'Did not get expected checksums'
 
     ds = None
-
-###############################################################################
-
-
-def test_jpeg2000_cleanup():
-
-    gdaltest.reregister_all_jpeg2000_drivers()
-
-
-

--- a/autotest/gdrivers/jpipkak.py
+++ b/autotest/gdrivers/jpipkak.py
@@ -35,10 +35,7 @@ import gdaltest
 import pytest
 
 
-pytestmark = [
-    pytest.mark.skip(),
-    pytest.mark.require_driver('JPIPKAK'),
-]
+pytestmark = pytest.mark.require_driver('JPIPKAK')
 
 ###############################################################################
 # Read test of simple byte reference data.

--- a/autotest/gdrivers/jpipkak.py
+++ b/autotest/gdrivers/jpipkak.py
@@ -34,6 +34,12 @@ from osgeo import gdal
 import gdaltest
 import pytest
 
+
+pytestmark = [
+    pytest.mark.skip(),
+    pytest.mark.require_driver('JPIPKAK'),
+]
+
 ###############################################################################
 # Read test of simple byte reference data.
 
@@ -43,10 +49,6 @@ def test_jpipkak_1():
     pytest.skip()
 
     # pylint: disable=unreachable
-    gdaltest.jpipkak_drv = gdal.GetDriverByName('JPIPKAK')
-    if gdaltest.jpipkak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('jpip://216.150.195.220/JP2Server/qb_boulder_msi_uint')
     assert ds is not None, 'failed to open jpip stream.'
 
@@ -66,9 +68,6 @@ def test_jpipkak_2():
     pytest.skip()
 
     # pylint: disable=unreachable
-    if gdaltest.jpipkak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('jpip://216.150.195.220/JP2Server/qb_boulder_pan_byte')
     assert ds is not None, 'failed to open jpip stream.'
 
@@ -93,9 +92,6 @@ def test_jpipkak_3():
     pytest.skip()
 
     # pylint: disable=unreachable
-    if gdaltest.jpipkak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('jpip://216.150.195.220/JP2Server/qb_boulder_pan_11bit')
     assert ds is not None, 'failed to open jpip stream.'
 
@@ -115,9 +111,6 @@ def test_jpipkak_4():
     pytest.skip()
 
     # pylint: disable=unreachable
-    if gdaltest.jpipkak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('jpip://216.150.195.220/JP2Server/qb_boulder_pan_20bit')
     assert ds is not None, 'failed to open jpip stream.'
 
@@ -137,9 +130,6 @@ def test_jpipkak_5():
     pytest.skip()
 
     # pylint: disable=unreachable
-    if gdaltest.jpipkak_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('jpip://216.150.195.220/JP2Server/qb_boulder_pan_byte')
     assert ds is not None, 'failed to open jpip stream.'
 

--- a/autotest/gdrivers/mbtiles.py
+++ b/autotest/gdrivers/mbtiles.py
@@ -38,23 +38,15 @@ import gdaltest
 import webserver
 import pytest
 
-###############################################################################
-# Get the mbtiles driver
 
+pytestmark = pytest.mark.require_driver('MBTiles')
 
-def test_mbtiles_1():
-
-    gdaltest.mbtiles_drv = gdal.GetDriverByName('MBTiles')
 
 ###############################################################################
 # Basic test
 
 
 def test_mbtiles_2():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('JPEG') is None:
         pytest.skip()
 
@@ -104,10 +96,6 @@ def test_mbtiles_2():
 
 
 def test_mbtiles_3():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('HTTP') is None:
         pytest.skip()
 
@@ -149,10 +137,6 @@ def test_mbtiles_3():
 
 
 def test_mbtiles_start_webserver():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('HTTP') is None:
         pytest.skip()
 
@@ -166,10 +150,6 @@ def test_mbtiles_start_webserver():
 
 
 def test_mbtiles_http_jpeg_three_bands():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('HTTP') is None:
         pytest.skip()
 
@@ -190,10 +170,6 @@ def test_mbtiles_http_jpeg_three_bands():
 
 
 def test_mbtiles_http_jpeg_single_band():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('HTTP') is None:
         pytest.skip()
 
@@ -214,10 +190,6 @@ def test_mbtiles_http_jpeg_single_band():
 
 
 def test_mbtiles_http_png():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('HTTP') is None:
         pytest.skip()
 
@@ -238,10 +210,6 @@ def test_mbtiles_http_png():
 
 
 def test_mbtiles_stop_webserver():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('HTTP') is None:
         pytest.skip()
 
@@ -254,10 +222,6 @@ def test_mbtiles_stop_webserver():
 
 
 def test_mbtiles_4():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('JPEG') is None:
         pytest.skip()
 
@@ -283,10 +247,6 @@ def test_mbtiles_4():
 
 
 def test_mbtiles_5():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('PNG') is None:
         pytest.skip()
 
@@ -319,10 +279,6 @@ def test_mbtiles_5():
 
 
 def test_mbtiles_6():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('JPEG') is None:
         pytest.skip()
 
@@ -354,10 +310,6 @@ def test_mbtiles_6():
 
 
 def test_mbtiles_7():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('PNG') is None:
         pytest.skip()
 
@@ -408,10 +360,6 @@ def test_mbtiles_7():
 
 
 def test_mbtiles_8():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('PNG') is None:
         pytest.skip()
 
@@ -451,10 +399,6 @@ def test_mbtiles_8():
 
 
 def test_mbtiles_9():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('PNG') is None:
         pytest.skip()
 
@@ -478,10 +422,6 @@ def test_mbtiles_9():
 
 
 def test_mbtiles_10():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdal.GetDriverByName('PNG') is None:
         pytest.skip()
 
@@ -503,10 +443,6 @@ def test_mbtiles_10():
 
 
 def test_mbtiles_11():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     if gdaltest.mbtiles_drv.GetMetadataItem("ENABLE_SQL_SQLITE_FORMAT") != 'YES':
         pytest.skip()
 
@@ -519,10 +455,6 @@ def test_mbtiles_11():
 
 
 def test_mbtiles_raster_open_in_vector_mode():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/byte.mbtiles')
     assert ds is None
 
@@ -530,10 +462,6 @@ def test_mbtiles_raster_open_in_vector_mode():
 
 
 def test_mbtiles_create():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()
-
     filename = '/vsimem/mbtiles_create.mbtiles'
     gdaltest.mbtiles_drv.Create(filename, 1, 1, 1)
     with gdaltest.error_handler():
@@ -588,12 +516,3 @@ def test_mbtiles_create():
     ds = None
 
     gdal.Unlink(filename)
-
-
-###############################################################################
-# Cleanup
-
-def test_mbtiles_cleanup():
-
-    if gdaltest.mbtiles_drv is None:
-        pytest.skip()

--- a/autotest/gdrivers/mrsid.py
+++ b/autotest/gdrivers/mrsid.py
@@ -37,16 +37,15 @@ from osgeo import gdal
 import gdaltest
 import pytest
 
+
+pytestmark = pytest.mark.require_driver('MrSID')
+
+
 ###############################################################################
 # Read a simple byte file, checking projections and geotransform.
 
 
 def test_mrsid_1():
-
-    gdaltest.mrsid_drv = gdal.GetDriverByName('MrSID')
-    if gdaltest.mrsid_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('MrSID', 'mercator.sid', 1, None)
 
     gt = (-15436.385771224039, 60.0, 0.0, 3321987.8617962394, 0.0, -60.0)
@@ -135,10 +134,6 @@ def test_mrsid_1():
 
 
 def test_mrsid_2():
-
-    if gdaltest.mrsid_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/mercator.sid')
 
     try:
@@ -167,10 +162,6 @@ def test_mrsid_2():
 
 
 def test_mrsid_3():
-
-    if gdaltest.mrsid_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/mercator.sid')
 
     band = ds.GetRasterBand(1)
@@ -194,10 +185,6 @@ def test_mrsid_3():
 
 
 def test_mrsid_4():
-
-    if gdaltest.mrsid_drv is None:
-        pytest.skip()
-
     try:
         os.remove('data/mercator_new.sid.aux.xml')
     except OSError:
@@ -239,22 +226,22 @@ def test_mrsid_4():
 # Test JP2MrSID driver
 
 
-def test_mrsid_5():
+@pytest.fixture(scope='module')
+def jp2mrsid():
     gdaltest.jp2mrsid_drv = gdal.GetDriverByName('JP2MrSID')
     if gdaltest.jp2mrsid_drv is None:
         pytest.skip()
 
     gdaltest.deregister_all_jpeg2000_drivers_but('JP2MrSID')
+    yield
+    gdaltest.reregister_all_jpeg2000_drivers()
+
 
 ###############################################################################
 # Open byte.jp2
 
 
-def test_mrsid_6():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_6(jp2mrsid):
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
         DATUM["North_American_Datum_1927",
@@ -283,11 +270,7 @@ def test_mrsid_6():
 ###############################################################################
 # Open int16.jp2
 
-def test_mrsid_7():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_7(jp2mrsid):
     ds = gdal.Open('data/int16.jp2')
     ds_ref = gdal.Open('data/int16.tif')
 
@@ -309,10 +292,6 @@ def test_mrsid_7():
 
 
 def test_mrsid_8():
-
-    if gdaltest.mrsid_drv is None:
-        pytest.skip()
-
     new_gt = (10000, 50, 0, 20000, 0, -50)
     new_srs = """PROJCS["OSGB 1936 / British National Grid",GEOGCS["OSGB 1936",DATUM["OSGB_1936",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],AUTHORITY["EPSG","6277"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4277"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",49],PARAMETER["central_meridian",-2],PARAMETER["scale_factor",0.9996012717],PARAMETER["false_easting",400000],PARAMETER["false_northing",-100000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","27700"]]"""
 
@@ -346,10 +325,6 @@ def test_mrsid_8():
 
 
 def test_mrsid_9():
-
-    if gdaltest.mrsid_drv is None:
-        pytest.skip()
-
     f = open('data/mercator.sid', 'rb')
     data = f.read()
     f.close()
@@ -368,11 +343,7 @@ def test_mrsid_9():
 # Test VSI*L IO with .jp2
 
 
-def test_mrsid_10():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_10(jp2mrsid):
     f = open('data/int16.jp2', 'rb')
     data = f.read()
     f.close()
@@ -391,11 +362,7 @@ def test_mrsid_10():
 # Check that we can use .j2w world files (#4651)
 
 
-def test_mrsid_11():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_11(jp2mrsid):
     ds = gdal.Open('data/byte_without_geotransform.jp2')
 
     geotransform = ds.GetGeoTransform()
@@ -407,11 +374,7 @@ def test_mrsid_11():
 ###############################################################################
 
 
-def test_mrsid_online_1():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_online_1(jp2mrsid):
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k', '7sisters200.j2k'):
         pytest.skip()
 
@@ -427,11 +390,7 @@ def test_mrsid_online_1():
 ###############################################################################
 
 
-def test_mrsid_online_2():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_online_2(jp2mrsid):
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2', 'gcp.jp2'):
         pytest.skip()
 
@@ -457,11 +416,7 @@ def test_mrsid_online_2():
 ###############################################################################
 
 
-def test_mrsid_online_3():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_online_3(jp2mrsid):
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.j2k', 'Bretagne1.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.bmp', 'Bretagne1.bmp'):
@@ -491,11 +446,7 @@ def test_mrsid_online_3():
 ###############################################################################
 
 
-def test_mrsid_online_4():
-
-    if gdaltest.jp2mrsid_drv is None:
-        pytest.skip()
-
+def test_mrsid_online_4(jp2mrsid):
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.j2k', 'Bretagne2.j2k'):
         pytest.skip()
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.bmp', 'Bretagne2.bmp'):
@@ -531,8 +482,3 @@ def test_mrsid_cleanup():
         os.remove('data/mercator_new.sid.aux.xml')
     except OSError:
         pass
-
-    gdaltest.reregister_all_jpeg2000_drivers()
-
-
-

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -101,6 +101,7 @@ def netcdf_setup():
 
 @pytest.fixture(autouse=True, scope='module')
 def netcdf_teardown():
+    yield
     diff = len(gdaltest.get_opened_files()) - gdaltest.count_opened_files
     assert diff == 0, 'Leak of file handles: %d leaked' % diff
 
@@ -707,19 +708,9 @@ def test_netcdf_22():
 # check support for hdf4 - make sure  hdf4 file is not read by netcdf driver
 
 
+@pytest.mark.require_driver('HDF4')
+@pytest.mark.require_driver('HDF4Image')
 def test_netcdf_23():
-
-    # don't skip if netcdf is not enabled in GDAL
-    # if gdaltest.netcdf_drv is None:
-    #    return 'skip'
-    # if not gdaltest.netcdf_drv_has_hdf4:
-    #    return 'skip'
-
-    # skip test if Hdf4 is not enabled in GDAL
-    if gdal.GetDriverByName('HDF4') is None and \
-            gdal.GetDriverByName('HDF4Image') is None:
-        pytest.skip()
-
     ifile = 'data/hdifftst2.hdf'
 
     # test with Open()

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -48,6 +48,8 @@ import test_cli_utilities
 
 from uffd import uffd_compare
 
+pytestmark = pytest.mark.require_driver('NetCDF')
+
 ###############################################################################
 # Netcdf Functions
 ###############################################################################
@@ -65,11 +67,6 @@ def netcdf_setup():
     gdaltest.netcdf_drv_has_nc4 = False
     gdaltest.netcdf_drv_has_hdf4 = False
     gdaltest.netcdf_drv_silent = False
-
-    gdaltest.netcdf_drv = gdal.GetDriverByName('NETCDF')
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip('NOTICE: netcdf not supported, skipping checks')
 
     # get capabilities from driver
     metadata = gdaltest.netcdf_drv.GetMetadata()
@@ -163,10 +160,6 @@ def netcdf_test_deflate(ifile, checksum, zlevel=1, timeout=None):
         Process.is_alive
     except (ImportError, AttributeError):
         pytest.skip('from multiprocessing import Process failed')
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -242,10 +235,6 @@ def netcdf_check_vars(ifile, vals_global=None, vals_band=None):
 # Perform simple read test.
 
 def test_netcdf_1():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('NetCDF', 'NETCDF:"data/bug636.nc":tas', 1, 31621,
                             filename_absolute=1)
 
@@ -261,10 +250,6 @@ def test_netcdf_1():
 
 
 def test_netcdf_2():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.tif')
 
     gdaltest.netcdf_drv.CreateCopy('tmp/netcdf2.nc', src_ds)
@@ -305,10 +290,6 @@ def test_netcdf_2():
 
 
 def test_netcdf_3():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/sombrero.grd')
     bnd = ds.GetRasterBand(1)
     minmax = bnd.ComputeRasterMinMax()
@@ -324,10 +305,6 @@ def test_netcdf_3():
 
 
 def test_netcdf_4():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('NetCDF',
                             'NETCDF:data/foo_5dimensional.nc:temperature',
                             3, 1218, filename_absolute=1)
@@ -347,10 +324,6 @@ def test_netcdf_4():
 
 
 def test_netcdf_5():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('NetCDF',
                             'NETCDF:data/foo_5dimensional.nc:temperature',
                             7, 1227, filename_absolute=1)
@@ -370,10 +343,6 @@ def test_netcdf_5():
 
 
 def test_netcdf_6():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/cf_lcc1sp.nc')
     prj = ds.GetProjection()
 
@@ -392,10 +361,6 @@ def test_netcdf_6():
 
 
 def test_netcdf_7():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/cf_lcc2sp.nc')
     prj = ds.GetProjection()
 
@@ -418,10 +383,6 @@ def test_netcdf_7():
 
 
 def test_netcdf_8():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/cf_aea2sp_invf.nc')
 
     srs = osr.SpatialReference()
@@ -444,10 +405,6 @@ def test_netcdf_8():
 
 
 def test_netcdf_9():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/cf_no_sphere.nc')
 
     prj = ds.GetProjection()
@@ -467,10 +424,6 @@ def test_netcdf_9():
 
 
 def test_netcdf_10():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/cf_no_sphere.nc')
 
     prj = ds.GetProjection()
@@ -498,10 +451,6 @@ def test_netcdf_10():
 
 
 def test_netcdf_11():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/cf_geog.nc')
 
     gt = ds.GetGeoTransform()
@@ -515,10 +464,6 @@ def test_netcdf_11():
 
 
 def test_netcdf_12():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/scale_offset.nc')
 
     scale = ds.GetRasterBand(1).GetScale()
@@ -534,10 +479,6 @@ def test_netcdf_12():
 
 
 def test_netcdf_13():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/no_scale_offset.nc')
 
     scale = ds.GetRasterBand(1).GetScale()
@@ -552,10 +493,6 @@ def test_netcdf_13():
 
 
 def test_netcdf_14():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('NETCDF:data/two_vars_scale_offset.nc:z')
 
     scale = ds.GetRasterBand(1).GetScale()
@@ -583,10 +520,6 @@ def test_netcdf_14():
 
 
 def test_netcdf_15():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if gdaltest.netcdf_drv_has_nc2:
         ds = gdal.Open('data/trmm-nc2.nc')
         assert ds is not None
@@ -601,10 +534,6 @@ def test_netcdf_15():
 
 
 def test_netcdf_16():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/trmm-nc4.nc'
 
     if gdaltest.netcdf_drv_has_nc4:
@@ -632,10 +561,6 @@ def test_netcdf_16():
 
 
 def test_netcdf_17():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/groups.h5'
 
     # skip test if Hdf5 is not enabled
@@ -668,10 +593,6 @@ def test_netcdf_17():
 
 
 def test_netcdf_18():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/trmm-nc4c.nc'
 
     if gdaltest.netcdf_drv_has_nc4:
@@ -699,10 +620,6 @@ def test_netcdf_18():
 
 
 def test_netcdf_19():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -718,10 +635,6 @@ def test_netcdf_19():
 
 
 def test_netcdf_20():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -733,10 +646,6 @@ def test_netcdf_20():
 # check support for writing large file with DEFLATE compression
 # if chunking is not defined properly within the netcdf driver, this test can take 1h
 def test_netcdf_21():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -778,10 +687,6 @@ def test_netcdf_21():
 ###############################################################################
 # check support for hdf4
 def test_netcdf_22():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_hdf4:
         pytest.skip()
 
@@ -836,10 +741,6 @@ def test_netcdf_23():
 
 
 def test_netcdf_24():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     vals_global = {'NC_GLOBAL#test': 'testval',
                    'NC_GLOBAL#valid_range_i': '0,255',
                    'NC_GLOBAL#valid_min': '10.1',
@@ -858,10 +759,6 @@ def test_netcdf_24():
 
 
 def netcdf_24_nc4():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -893,10 +790,6 @@ def netcdf_24_nc4():
 
 
 def test_netcdf_25():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     netcdf_test_copy('data/nc_vars.nc', 1, None, 'tmp/netcdf_25.nc')
 
     vals_global = {'NC_GLOBAL#test': 'testval',
@@ -917,10 +810,6 @@ def test_netcdf_25():
 
 
 def netcdf_25_nc4():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -956,10 +845,6 @@ def netcdf_25_nc4():
 
 
 def test_netcdf_26():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # test default config
     test = gdaltest.GDALTest('NETCDF', '../data/int16-nogeo.nc', 1, 4672)
     gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -977,10 +862,6 @@ def test_netcdf_26():
 
 
 def test_netcdf_27():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # test default config
     test = gdaltest.GDALTest('NETCDF', '../data/int16-nogeo.nc', 1, 4672)
     config_bak = gdal.GetConfigOption('GDAL_NETCDF_BOTTOMUP')
@@ -1048,10 +929,6 @@ def netcdf_test_4dfile(ofile):
 
 
 def test_netcdf_28():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/netcdf-4d.nc'
     ofile = 'tmp/netcdf_28.nc'
 
@@ -1072,10 +949,6 @@ def test_netcdf_28():
 
 
 def test_netcdf_29():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # create tif file using gdalwarp
     if test_cli_utilities.get_gdalwarp_path() is None:
         pytest.skip('gdalwarp not found')
@@ -1105,10 +978,6 @@ def test_netcdf_29():
 
 
 def test_netcdf_30():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('NetCDF', 'trmm-nan.nc', 1, 62519)
 
     # We don't want to gum up the test stream output with the
@@ -1125,10 +994,6 @@ def test_netcdf_30():
 
 
 def test_netcdf_31():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/trmm-2x2.nc')
 
     ds.GetProjection()
@@ -1146,10 +1011,6 @@ def test_netcdf_31():
 
 
 def test_netcdf_32():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -1167,10 +1028,6 @@ def test_netcdf_32():
 
 
 def test_netcdf_33():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/nc_vars.nc'
     ofile = 'tmp/netcdf_33.nc'
 
@@ -1188,10 +1045,6 @@ def test_netcdf_34():
     filename = 'utm-big-chunks.nc'
     # this timeout is more than enough - on my system takes <1s with fix, about 25 seconds without
     timeout = 5
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -1230,10 +1083,6 @@ def test_netcdf_34():
 
 
 def test_netcdf_35():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/netcdf_fixes.nc'
     ofile = 'tmp/netcdf_35.nc'
 
@@ -1256,10 +1105,6 @@ def test_netcdf_35():
 
 
 def test_netcdf_36():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/netcdf_fixes.nc'
 
     ds = gdal.Open(ifile)
@@ -1277,10 +1122,6 @@ def test_netcdf_36():
 
 
 def test_netcdf_36_lonwrap():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/nc_lonwrap.nc'
 
     ds = gdal.Open(ifile)
@@ -1298,10 +1139,6 @@ def test_netcdf_36_lonwrap():
 
 
 def test_netcdf_37():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/reduce-cgcms.nc'
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -1326,10 +1163,6 @@ def test_netcdf_37():
 
 
 def test_netcdf_38():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ifile = 'data/bug5118.nc'
 
     gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -1348,10 +1181,6 @@ def test_netcdf_38():
 
 
 def test_netcdf_39():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     shutil.copy('data/two_vars_scale_offset.nc', 'tmp')
     src_ds = gdal.Open('NETCDF:tmp/two_vars_scale_offset.nc:z')
     out_ds = gdal.GetDriverByName('VRT').CreateCopy('tmp/netcdf_39.vrt', src_ds)
@@ -1412,7 +1241,7 @@ def test_netcdf_39():
 
 def test_netcdf_40():
 
-    if gdaltest.netcdf_drv is None or not gdaltest.netcdf_drv_has_nc4:
+    if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
     return netcdf_test_copy('data/bug5291.nc', 0, None, 'tmp/netcdf_40.nc')
@@ -1422,10 +1251,6 @@ def test_netcdf_40():
 
 
 def test_netcdf_41():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     with gdaltest.error_handler():
         ds = gdal.Open('data/byte_no_cf.nc')
     assert ds.GetGeoTransform() == (440720, 60, 0, 3751320, 0, -60)
@@ -1436,10 +1261,6 @@ def test_netcdf_41():
 
 
 def test_netcdf_42():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 60, 39, 1)
     src_ds.SetMetadata([
         'LINE_OFFSET=0',
@@ -1480,10 +1301,6 @@ def test_netcdf_42():
 
 
 def test_netcdf_43():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.tif')
     gdaltest.netcdf_drv.CreateCopy('tmp/netcdf_43.nc', src_ds, options=['WRITE_LONLAT=YES'])
 
@@ -1510,10 +1327,6 @@ def test_netcdf_43():
 
 
 def test_netcdf_44():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -1525,10 +1338,6 @@ def test_netcdf_44():
 
 
 def test_netcdf_45():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # Test that a vector cannot be opened in raster-only mode
     ds = gdal.OpenEx('data/test_ogr_nc3.nc', gdal.OF_RASTER)
     assert ds is None
@@ -1569,10 +1378,6 @@ def test_netcdf_45():
 
 
 def test_netcdf_46():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if test_cli_utilities.get_test_ogrsf_path() is None:
         pytest.skip()
 
@@ -1585,10 +1390,6 @@ def test_netcdf_46():
 
 
 def test_netcdf_47():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -1629,10 +1430,6 @@ def test_netcdf_47():
 
 
 def test_netcdf_48():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     with gdaltest.error_handler():
         ds = gdal.OpenEx('data/test_ogr_no_xyz_var.nc', gdal.OF_VECTOR)
     lyr = ds.GetLayer(0)
@@ -1645,10 +1442,6 @@ def test_netcdf_48():
 
 
 def test_netcdf_49():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     with gdaltest.error_handler():
         ds = gdal.OpenEx('data/test_ogr_xyz_float.nc', gdal.OF_VECTOR)
         gdal.VectorTranslate('/vsimem/netcdf_49.csv', ds, format='CSV', layerCreationOptions=['LINEFORMAT=LF', 'GEOMETRY=AS_WKT', 'STRING_QUOTING=IF_NEEDED'])
@@ -1671,10 +1464,6 @@ def test_netcdf_49():
 
 
 def test_netcdf_50():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx('../ogr/data/poly.shp', gdal.OF_VECTOR)
     out_ds = gdal.VectorTranslate('tmp/netcdf_50.nc', ds, format='netCDF', layerCreationOptions=['WKT_DEFAULT_WIDTH=1'], datasetCreationOptions=['GEOMETRY_ENCODING=WKT'])
     src_lyr = ds.GetLayer(0)
@@ -1707,10 +1496,6 @@ def test_netcdf_50():
 
 
 def test_netcdf_51():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx('data/test_ogr_nc3.nc', gdal.OF_VECTOR)
     # Test autogrow of string fields
     gdal.VectorTranslate('tmp/netcdf_51.nc', ds, format='netCDF', layerCreationOptions=['STRING_DEFAULT_WIDTH=1'], datasetCreationOptions=['GEOMETRY_ENCODING=WKT'])
@@ -1774,10 +1559,6 @@ def test_netcdf_51():
 
 
 def test_netcdf_51_no_gdal_tags():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx('data/test_ogr_nc3.nc', gdal.OF_VECTOR)
     gdal.VectorTranslate('tmp/netcdf_51_no_gdal_tags.nc', ds, format='netCDF', datasetCreationOptions=['WRITE_GDAL_TAGS=NO', 'GEOMETRY_ENCODING=WKT'])
 
@@ -1817,10 +1598,6 @@ def test_netcdf_51_no_gdal_tags():
 
 
 def test_netcdf_52():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -1887,10 +1664,6 @@ def test_netcdf_52():
 
 
 def test_netcdf_53():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -1926,10 +1699,6 @@ def test_netcdf_53():
 
 
 def test_netcdf_54():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -1966,10 +1735,6 @@ def test_netcdf_54():
 
 
 def test_netcdf_55():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -2003,10 +1768,6 @@ def test_netcdf_55():
 
 
 def test_netcdf_56():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('netCDF').CreateDataSource('tmp/netcdf_56.nc', options=['GEOMETRY_ENCODING=WKT'])
     # Test auto-grow of WKT field
     lyr = ds.CreateLayer('netcdf_56', options=['AUTOGROW_STRINGS=NO', 'STRING_DEFAULT_WIDTH=5', 'WKT_DEFAULT_WIDTH=5'])
@@ -2034,10 +1795,6 @@ def test_netcdf_56():
 
 
 def test_netcdf_57():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     try:
         shutil.rmtree('tmp/netcdf_57')
     except OSError:
@@ -2078,10 +1835,6 @@ def test_netcdf_57():
 
 
 def test_netcdf_58():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -2109,10 +1862,6 @@ def test_netcdf_58():
 
 
 def test_netcdf_59():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # get
     ds = gdal.Open('data/unittype.nc')
 
@@ -2133,10 +1882,6 @@ def test_netcdf_59():
 
 
 def test_netcdf_60():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # Test that a vector cannot be opened in raster-only mode
     ds = gdal.OpenEx('data/profile.nc', gdal.OF_RASTER)
     assert ds is None
@@ -2166,10 +1911,6 @@ def test_netcdf_60():
 
 
 def test_netcdf_61():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     shutil.copy('data/profile.nc', 'tmp/netcdf_61.nc')
     ds = gdal.VectorTranslate('tmp/netcdf_61.nc', 'data/profile.nc', accessMode='append')
     gdal.VectorTranslate('/vsimem/netcdf_61.csv', ds, format='CSV', layerCreationOptions=['LINEFORMAT=LF', 'GEOMETRY=AS_WKT', 'STRING_QUOTING=IF_NEEDED'])
@@ -2198,10 +1939,6 @@ def test_netcdf_61():
 
 
 def test_netcdf_62():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.VectorTranslate('tmp/netcdf_62.nc', 'data/profile.nc', format='netCDF', layerCreationOptions=['FEATURE_TYPE=PROFILE', 'PROFILE_DIM_INIT_SIZE=1',
         'PROFILE_VARIABLES=station'], datasetCreationOptions=['GEOMETRY_ENCODING=WKT'])
     gdal.VectorTranslate('/vsimem/netcdf_62.csv', ds, format='CSV', layerCreationOptions=['LINEFORMAT=LF', 'GEOMETRY=AS_WKT', 'STRING_QUOTING=IF_NEEDED'])
@@ -2223,10 +1960,6 @@ def test_netcdf_62():
 
 
 def test_netcdf_62_ncdump_check():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # get file header with ncdump (if available)
     try:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h')
@@ -2247,10 +1980,6 @@ def test_netcdf_62_ncdump_check():
     
 
 def test_netcdf_62_cf_check():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     import netcdf_cf
     netcdf_cf.netcdf_cf_setup()
     if gdaltest.netcdf_cf_method is not None:
@@ -2263,10 +1992,6 @@ def test_netcdf_62_cf_check():
 
 
 def test_netcdf_63():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -2293,10 +2018,6 @@ def test_netcdf_63():
 
 
 def test_netcdf_63_ncdump_check():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -2325,10 +2046,6 @@ def test_netcdf_63_ncdump_check():
 
 
 def test_netcdf_64():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     gdal.VectorTranslate('tmp/netcdf_64.nc', 'data/profile.nc', format='netCDF', selectFields=['id,station,foo'], layerCreationOptions=['FEATURE_TYPE=PROFILE',
         'PROFILE_DIM_NAME=profile_dim', 'PROFILE_DIM_INIT_SIZE=1', 'LEGACY=WKT'], datasetCreationOptions=['GEOMETRY_ENCODING=WKT'])
     gdal.VectorTranslate('/vsimem/netcdf_64.csv', 'tmp/netcdf_64.nc', format='CSV', layerCreationOptions=['LINEFORMAT=LF', 'GEOMETRY=AS_WKT', 'STRING_QUOTING=IF_NEEDED'])
@@ -2355,10 +2072,6 @@ def test_netcdf_64():
 
 
 def test_netcdf_65():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -2385,10 +2098,6 @@ def test_netcdf_65():
 
 
 def test_netcdf_66():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # First trying with no so good configs
 
     with gdaltest.error_handler():
@@ -2483,10 +2192,6 @@ def test_netcdf_66():
 
 
 def test_netcdf_66_ncdump_check():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # get file header with ncdump (if available)
     try:
         (ret, err) = gdaltest.runexternal_out_and_err('ncdump -h')
@@ -2514,10 +2219,6 @@ def test_netcdf_66_ncdump_check():
 
 
 def test_netcdf_67():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -2545,10 +2246,6 @@ def test_netcdf_67():
 # Test reading SRS from srid attribute (#6613)
 
 def test_netcdf_68():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/srid.nc')
     wkt = ds.GetProjectionRef()
     assert '6933' in wkt
@@ -2558,10 +2255,6 @@ def test_netcdf_68():
 
 
 def test_netcdf_69():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/test6645.nc')
     assert ds is not None
 
@@ -2570,10 +2263,6 @@ def test_netcdf_69():
 
 
 def test_netcdf_70():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/test6759.nc')
     gt = ds.GetGeoTransform()
     expected_gt = [304250.0, 250.0, 0.0, 4952500.0, 0.0, -250.0]
@@ -2585,10 +2274,6 @@ def test_netcdf_70():
 
 
 def test_netcdf_71():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/test_coord_scale_offset.nc')
     gt = ds.GetGeoTransform()
     expected_gt = (-690769.999174516, 1015.8812500000931, 0.0, 2040932.1838741193, 0.0, 1015.8812499996275)
@@ -2599,10 +2284,6 @@ def test_netcdf_71():
 
 
 def test_netcdf_72():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()
 
@@ -2615,10 +2296,6 @@ def test_netcdf_72():
 
 
 def test_netcdf_73():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/geos_rad.nc')
     gt = ds.GetGeoTransform()
     expected_gt = (-5979486.362104082, 1087179.4077774752, 0.0, -5979487.123448145, 0.0, 1087179.4077774752)
@@ -2629,10 +2306,6 @@ def test_netcdf_73():
 
 
 def test_netcdf_74():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/geos_microradian.nc')
     gt = ds.GetGeoTransform()
     expected_gt = (-5739675.119757546, 615630.8078590936, 0.0, -1032263.7666924844, 0.0, 615630.8078590936)
@@ -2643,10 +2316,6 @@ def test_netcdf_74():
 
 
 def test_netcdf_75():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if gdaltest.netcdf_drv.GetMetadataItem("ENABLE_NCDUMP") != 'YES':
         pytest.skip()
 
@@ -2679,10 +2348,6 @@ def test_netcdf_75():
 
 
 def test_netcdf_76():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if gdaltest.netcdf_drv.GetMetadataItem("ENABLE_NCDUMP") != 'YES':
         pytest.skip()
 
@@ -2699,10 +2364,6 @@ def test_netcdf_76():
 
 
 def test_netcdf_77():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/fake_Oa01_radiance.nc')
     subdatasets = ds.GetMetadata('SUBDATASETS')
     assert len(subdatasets) == 2 * 2
@@ -2716,10 +2377,6 @@ def test_netcdf_77():
 # negative nodata value
 
 def test_netcdf_78():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_with_valid_range.nc')
     assert ds.GetRasterBand(1).GetNoDataValue() == 240
     data = ds.GetRasterBand(1).ReadRaster()
@@ -2732,10 +2389,6 @@ def test_netcdf_78():
 
 
 def test_netcdf_79():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte_with_neg_fillvalue_and_unsigned_hint.nc')
     assert ds.GetRasterBand(1).GetNoDataValue() == 240
     data = ds.GetRasterBand(1).ReadRaster()
@@ -2747,10 +2400,6 @@ def test_netcdf_79():
 
 
 def test_netcdf_80():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     test = gdaltest.GDALTest('NETCDF', '../data/byte.tif', 1, 4672)
     return test.testCreateCopy(new_filename='test\xc3\xa9.nc', check_gt=0, check_srs=0, check_minmax=0)
 
@@ -2759,10 +2408,6 @@ def test_netcdf_80():
 
 
 def test_netcdf_81():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/rotated_pole.nc')
 
     assert ds.RasterXSize == 137 and ds.RasterYSize == 108, \
@@ -2784,10 +2429,6 @@ def test_netcdf_81():
 
 
 def test_netcdf_82():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     with gdaltest.error_handler():
         ds = gdal.Open('data/oddly_indexed_extra_dims.nc')
     md = ds.GetMetadata()
@@ -2816,9 +2457,6 @@ def test_netcdf_82():
 
 def test_netcdf_83():
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/complex.nc')
     sds_list = ds.GetMetadata('SUBDATASETS')
 
@@ -2838,9 +2476,6 @@ def test_netcdf_83():
 
 def test_netcdf_84():
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('NETCDF:"data/complex.nc":f32')
     assert ds.GetRasterBand(1).DataType == gdal.GDT_CFloat32
 
@@ -2852,9 +2487,6 @@ def test_netcdf_84():
 
 def test_netcdf_85():
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('NETCDF:"data/complex.nc":f64')
     assert ds.GetRasterBand(1).DataType == gdal.GDT_CFloat64
 
@@ -2865,9 +2497,6 @@ def test_netcdf_85():
 # Check for groups support
 
 def test_netcdf_86():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('NETCDF:"data/complex.nc":/group/fmul')
     assert ds.GetRasterBand(1).DataType == gdal.GDT_CFloat32
@@ -2883,10 +2512,6 @@ def test_netcdf_86():
 
 ###############################################################################
 def test_netcdf_uffd():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     if uffd_compare('orog_CRCM1.nc') is None:
         pytest.skip()
 
@@ -2906,9 +2531,6 @@ def test_netcdf_uffd():
 
 def test_netcdf_mixed_raster_vector():
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('NETCDF:data/nc_mixed_raster_vector.nc:Band1')
     assert ds.GetRasterBand(1).Checksum() == 4672
 
@@ -2924,9 +2546,6 @@ def test_netcdf_mixed_raster_vector():
 
 def test_netcdf_open_empty_double_attr():
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/empty_double_attr.nc')
     assert ds
 
@@ -2935,9 +2554,6 @@ def test_netcdf_open_empty_double_attr():
 # Test writing and reading a file with huge block size
 
 def test_netcdf_huge_block_size():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     if not gdaltest.run_slow_tests():
         pytest.skip()
     if sys.maxsize < 2**32:
@@ -2972,9 +2588,6 @@ def test_netcdf_huge_block_size():
 # geoloc arrays reflect the georeferencing correctly
 
 def test_netcdf_swapped_x_y_dimension():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/swapedxy.nc')
     assert ds.RasterXSize == 4
@@ -3025,9 +2638,6 @@ def test_netcdf_swapped_x_y_dimension():
 # expanded form
 
 def test_netcdf_expanded_form_of_grid_mapping():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/expanded_form_of_grid_mapping.nc')
     wkt = ds.GetProjectionRef()
@@ -3115,8 +2725,7 @@ def test_bad_cf1_8():
     assert(uneq_x_y is None)
 
 def test_point_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     singleton_pt = ogr.Open("data/netcdf-sg/point_test.nc")
 
     lc = singleton_pt.GetLayerCount()
@@ -3152,8 +2761,7 @@ def test_point_read():
     assert(ft_wkt == "POINT (5 -5)")
 
 def test_point3D_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     singleton_pt = ogr.Open("data/netcdf-sg/point3D_test.nc")
 
     lc = singleton_pt.GetLayerCount()
@@ -3189,8 +2797,7 @@ def test_point3D_read():
     assert(ft_wkt == "POINT (5 -5 5)")
 
 def test_multipoint_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     multipoints = ogr.Open("data/netcdf-sg/multipoint_test.nc")
     assert(multipoints != None) 
 
@@ -3225,8 +2832,7 @@ def test_multipoint_read():
     assert(ft_wkt == "MULTIPOINT (-7 7,-8 8,-9 9,-10 10)")
 
 def test_multipoint3D_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     multipoints = ogr.Open("data/netcdf-sg/multipoint3D_test.nc")
     assert(multipoints != None) 
 
@@ -3261,8 +2867,7 @@ def test_multipoint3D_read():
     assert(ft_wkt == "MULTIPOINT (-7 7 -7,-8 8 8,-9 9 -9,-10 10 10)")
 
 def test_line_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     line = ogr.Open("data/netcdf-sg/line_test.nc")
     assert(line != None) 
 
@@ -3297,8 +2902,7 @@ def test_line_read():
     assert(ft_wkt == "LINESTRING (-7 7,-8 8,-9 9,-10 10)")
      
 def test_line3D_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     line = ogr.Open("data/netcdf-sg/line3D_test.nc")
     assert(line != None) 
 
@@ -3333,8 +2937,7 @@ def test_line3D_read():
     assert(ft_wkt == "LINESTRING (-7 7 7,-8 8 -8,-9 9 9,-10 10 -10)")
 
 def test_multiline_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     multiline = ogr.Open("data/netcdf-sg/multiline_test.nc")
     assert(multiline != None) 
 
@@ -3369,8 +2972,7 @@ def test_multiline_read():
     assert(ft_wkt == "MULTILINESTRING ((-7 7,-8 8,-9 9,-10 10))")
 
 def test_multiline3D_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     multiline = ogr.Open("data/netcdf-sg/multiline3D_test.nc")
     assert(multiline != None) 
 
@@ -3405,8 +3007,7 @@ def test_multiline3D_read():
     assert(ft_wkt == "MULTILINESTRING ((-7 7 -7,-8 8 8,-9 9 -9,-10 10 10))")
 
 def test_polygon_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     polygon = ogr.Open("data/netcdf-sg/polygon_test.nc")
     assert(polygon != None)
     
@@ -3425,8 +3026,7 @@ def test_polygon_read():
     assert(ft_wkt == "POLYGON ((3 0,4 0,4 1,3 1,3 0))")
 
 def test_polygon3D_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     polygon = ogr.Open("data/netcdf-sg/polygon3D_test.nc")
     assert(polygon != None)
     
@@ -3445,8 +3045,7 @@ def test_polygon3D_read():
     assert(ft_wkt == "POLYGON ((3 0 1,4 0 1,4 1 1,3 1 1,3 0 1))")
 
 def test_multipolygon_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     multipolygon = ogr.Open("data/netcdf-sg/multipolygon_test.nc")
     assert(multipolygon != None) 
 
@@ -3465,8 +3064,7 @@ def test_multipolygon_read():
     assert(ft_wkt == "MULTIPOLYGON (((3 0,4 0,4 1,3 0)),((3 0,4 1,3 1,3 0)))")
 
 def test_multipolygon3D_read():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     multipolygon = ogr.Open("data/netcdf-sg/multipolygon3D_test.nc")
     assert(multipolygon != None) 
 
@@ -3485,8 +3083,7 @@ def test_multipolygon3D_read():
     assert(ft_wkt == "MULTIPOLYGON (((3 0 5,4 0 10,4 1 10,3 0 5)),((3 0 10,4 1 15,3 1 15,3 0 10)))")
 
 def test_serpenski_two_ring():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     s = ogr.Open("data/netcdf-sg/serpenski_2nd.nc")
 
     assert(s != None)
@@ -3507,8 +3104,7 @@ def test_serpenski_two_ring():
 	"MULTIPOLYGON (((0 0,1 0,0.5 0.866025403784439,0 0),(0.5 0.0,0.75 0.433012701892219,0.25 0.433012701892219,0.5 0.0)))") 
 
 def test_serpenski3D_two_ring():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     s = ogr.Open("data/netcdf-sg/serpenski3D_2nd.nc")
 
     assert(s != None)
@@ -3529,10 +3125,7 @@ def test_serpenski3D_two_ring():
 	"MULTIPOLYGON (((0 0 1,1 0 1,0.5 0.866025403784439 1,0 0 1),(0.5 0.0 1,0.75 0.433012701892219 1,0.25 0.433012701892219 1,0.5 0.0 1)))") 
 
 def test_flipped_axis():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     # similar to simple polygon test, but with flipped axis
-
     polygon = ogr.Open("data/netcdf-sg/flipped_axes_test.nc")
     assert(polygon != None)
     
@@ -3544,8 +3137,7 @@ def test_flipped_axis():
     assert(ft_wkt == "POLYGON ((0 0,1 0,1 1,0 0))")
 
 def test_arbitrary_3Daxis_order_():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     polygon = ogr.Open("data/netcdf-sg/arbitrary_axis_order_test.nc")
     assert(polygon != None)
     
@@ -3562,8 +3154,6 @@ def test_arbitrary_3Daxis_order_():
     assert(ft_wkt == "POLYGON ((3 0 1,4 0 1,4 1 1,3 1 1,3 0 1))")
 
 def test_multiple_layers_one_nc():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     # tests whether or not an NC with multiple geometry containers can be read
     # each geometry container a layer
 
@@ -3594,8 +3184,6 @@ def test_multiple_layers_one_nc():
 #  advanced tests
 
 def test_yahara():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     yahara = ogr.Open("data/netcdf-sg/Yahara_alb.nc")
     assert(yahara != None)
 
@@ -3621,8 +3209,7 @@ def test_yahara():
     assert(fSRS.ExportToWkt() == "PROJCS[\"unnamed\",GEOGCS[\"unknown\",DATUM[\"unnamed\",SPHEROID[\"Spheroid\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]") 
 
 def test_states_full_layer():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()			
+
     states = ogr.Open("data/netcdf-sg/cf1.8_states.nc")
     assert(states != None)
 
@@ -3658,8 +3245,6 @@ def test_states_full_layer():
 #  simple geometry writing tests
 
 def test_point_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/point_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     gdal.VectorTranslate("tmp/test_point_write.nc", src, format="netCDF");
@@ -3703,8 +3288,6 @@ def test_point_write():
     assert(fnam == "FishingSpot4")
 
 def test_point3D_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/point3D_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     gdal.VectorTranslate("tmp/test_point3D_write.nc", src, format="netCDF");
@@ -3748,8 +3331,6 @@ def test_point3D_write():
     assert(fnam == "FishingSpot4")
 
 def test_line_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/line_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -3787,8 +3368,6 @@ def test_line_write():
     assert(fnam == "seg3")
 
 def test_line3D_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/line3D_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -3826,8 +3405,6 @@ def test_line3D_write():
     assert(fnam == "path3")
 
 def test_polygon_no_ir_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/polygon_no_ir_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -3862,8 +3439,6 @@ def test_polygon_no_ir_write():
 
 
 def test_polygon_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/polygon_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -3904,8 +3479,6 @@ def test_polygon_write():
     assert(fnam == "Triangle_Flipped")
 
 def test_polygon3D_no_ir_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/polygon3D_no_ir_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -3939,8 +3512,6 @@ def test_polygon3D_no_ir_write():
     assert(fid == 1)
 
 def test_polygon3D_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/polygon3D_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -3981,8 +3552,6 @@ def test_polygon3D_write():
     assert(fnam == "Trianglyflipped")
 
 def test_multipoint_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multipoint_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4020,8 +3589,6 @@ def test_multipoint_write():
     assert(fnam == "Peaks3")
 
 def test_multipoint3D_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multipoint3D_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4052,8 +3619,6 @@ def test_multipoint3D_write():
     assert(fnam == "site2")
 
 def test_multiline_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multiline_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4091,8 +3656,6 @@ def test_multiline_write():
     assert(fnam == "not_fresh_river")
 
 def test_multiline3D_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multiline3D_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4123,8 +3686,6 @@ def test_multiline3D_write():
     assert(fnam == "not_fresh_river")
 
 def test_multipolygon_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multipolygon_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4158,8 +3719,6 @@ def test_multipolygon_write():
     assert(fnam == "Square_in_Square_and_Triangle")
 
 def test_multipolygon3D_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multipolygon3D_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4201,8 +3760,6 @@ def test_multipolygon3D_write():
     assert(fnam == "Single_Triangly")
 
 def test_multipolygon_with_no_ir_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multipolygon_no_ir_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4233,8 +3790,6 @@ def test_multipolygon_with_no_ir_write():
     assert(fnam == "DoubleTriangle")
 
 def test_multipolygon3D_with_no_ir_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multipolygon3D_no_ir_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4265,8 +3820,6 @@ def test_multipolygon3D_with_no_ir_write():
     assert(fnam == "DoubleTriangle")
 
 def test_write_buffer_restrict_correctness():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     # Tests whether or not having the write buffer restriction
     # Writes correct data.
     src = gdal.OpenEx("data/netcdf-sg/write-tests/Yahara_alb.json")
@@ -4292,8 +3845,6 @@ def test_write_buffer_restrict_correctness():
         assert(lftgeo.Equal(dftgeo))
 
 def test_write_nc_from_nc():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     # Tests writing a netCDF file (of different name than source) out from another netCDF source file
     src = gdal.OpenEx("data/netcdf-sg/multipoint_test.nc", gdal.OF_VECTOR) 
     assert(src is not None)
@@ -4332,9 +3883,6 @@ def test_write_nc_from_nc():
     assert(ft_wkt == "MULTIPOINT (-7 7,-8 8,-9 9,-10 10)")
 
 def test_multipolygon_with_no_ir_NC4_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # Almost identical to test_multipolygon_with_no_ir
     # except this time, it is writing an NC4 file
 
@@ -4368,8 +3916,6 @@ def test_multipolygon_with_no_ir_NC4_write():
     assert(fnam == "DoubleTriangle")
 
 def test_multipolygon3D_NC4C_write():
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
     src = gdal.OpenEx("data/netcdf-sg/write-tests/multipolygon3D_write_test.json", gdal.OF_VECTOR) 
     assert(src is not None)
     assert(src.GetLayerCount() == 1)
@@ -4414,9 +3960,6 @@ def test_multipolygon3D_NC4C_write():
     assert(fnam == "Single_Triangly")
 
 def test_netcdf_dimension_labels_with_null():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     if not gdaltest.netcdf_drv_has_nc4:
         pytest.skip()

--- a/autotest/gdrivers/netcdf_cf.py
+++ b/autotest/gdrivers/netcdf_cf.py
@@ -39,6 +39,8 @@ from osgeo import osr
 import gdaltest
 import pytest
 
+pytestmark = pytest.mark.require_driver('NetCDF')
+
 ###############################################################################
 # Netcdf CF compliance Functions
 ###############################################################################
@@ -53,10 +55,6 @@ def netcdf_cf_setup():
     gdaltest.netcdf_cf_method = None
     gdaltest.netcdf_cf_files = None
     gdaltest.netcdf_cf_check_error = ''
-
-    # if netcdf is not supported, skip detection
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     # skip if on windows
     if os.name != 'posix':
@@ -552,9 +550,6 @@ def test_netcdf_cf_1(netcdf_setup):  # noqa
     # setup netcdf and netcdf_cf environment
     netcdf_cf_setup()
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     # tst1 = gdaltest.GDALTest( 'NETCDF', 'trmm.tif', 1, 14 )
     # result = tst1.testCreateCopy(check_gt=1, check_srs=1, new_filename='tmp/netcdf_cf_1.nc', delete_copy = 0)
     result = netcdf_test_copy('data/trmm.nc', 1, 14, 'tmp/netcdf_cf_1.nc')
@@ -576,9 +571,6 @@ def test_netcdf_cf_1(netcdf_setup):  # noqa
 # test copy and CF compliance for lat/lon (no datum, no GEOGCS) file, nc->nc
 def test_netcdf_cf_2():
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     result = netcdf_test_copy('data/trmm.nc', 1, 14, 'tmp/netcdf_cf_2.nc')
 
     result_cf = 'success'
@@ -594,9 +586,6 @@ def test_netcdf_cf_2():
 # test copy and CF compliance for lat/lon (W*S84) file, tif->nc->tif
 # note: this test fails in trunk (before r23246)
 def test_netcdf_cf_3():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     result = 'success'
     result_cf = 'success'
@@ -622,9 +611,6 @@ def test_netcdf_cf_3():
 
 def test_netcdf_cf_4():
 
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
-
     result = netcdf_cfproj_testcopy(netcdf_cfproj_tuples, 'melb-small.tif',
                                     netcdf_cfproj_int_fmt_maps,
                                     'data', 'tmp', 'translate_results.txt')
@@ -638,9 +624,6 @@ def test_netcdf_cf_4():
 
 
 def test_netcdf_cf_5():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     ifiles = ['NETCDF:data/orog_CRCM1.nc:orog', 'NETCDF:data/orog_CRCM2.nc:orog']
     for ifile in ifiles:
@@ -658,9 +641,6 @@ def test_netcdf_cf_5():
 # test CF support for dims and variables in different groups 
 
 def test_netcdf_cf_6():
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     ifiles = ('data/cf_dimsindiff_4326.nc',
               'NETCDF:data/cf_nasa_4326.nc:/science/grids/data/temp',
@@ -680,9 +660,6 @@ def test_netcdf_cf_6():
 def test_netcdf_cf_7(netcdf_setup):  # noqa
     # setup netcdf and netcdf_cf environment
     netcdf_cf_setup()
-
-    if gdaltest.netcdf_drv is None:
-        pytest.skip()
 
     checks = (('data/cf_dimsindiff_4326.nc', 1, 2041),
               ('NETCDF:data/cf_nasa_4326.nc:/science/grids/data/temp', 1, 2041),

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -37,6 +37,10 @@ import pytest
 import struct
 import sys
 
+
+pytestmark = pytest.mark.require_driver('NetCDF')
+
+
 def test_netcdf_multidim_invalid_file(netcdf_setup):  # noqa
 
     if not gdaltest.netcdf_drv_has_nc4:

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -1141,6 +1141,7 @@ def test_nitf_43_jasper():
     return nitf_43('JPEG2000', ['IC=C8'])
 
 
+@pytest.mark.require_driver('ECW')
 def test_nitf_43_jp2ecw():
     import ecw
     if not ecw.has_write_support():

--- a/autotest/gdrivers/pcraster.py
+++ b/autotest/gdrivers/pcraster.py
@@ -34,17 +34,14 @@ from osgeo import gdal
 import gdaltest
 import pytest
 
+pytestmark = pytest.mark.require_driver('PCRaster')
+
+
 ###############################################################################
 # Perform simple read test.
 
 
 def test_pcraster_1():
-
-    gdaltest.pcraster_drv = gdal.GetDriverByName('PCRaster')
-
-    if gdaltest.pcraster_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('PCRaster', 'ldd.map', 1, 4528)
     return tst.testOpen()
 
@@ -53,10 +50,6 @@ def test_pcraster_1():
 
 
 def test_pcraster_2():
-
-    if gdaltest.pcraster_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/ldd.map')
 
     gt = ds.GetGeoTransform()
@@ -66,7 +59,3 @@ def test_pcraster_2():
 
     band1 = ds.GetRasterBand(1)
     assert band1.GetNoDataValue() == 255, 'PCRaster NODATA value wrong or missing.'
-
-
-
-

--- a/autotest/gdrivers/plmosaic.py
+++ b/autotest/gdrivers/plmosaic.py
@@ -35,31 +35,41 @@ import struct
 
 
 from osgeo import gdal
-
-import gdaltest
 import pytest
 
-###############################################################################
-# Find PLMosaic driver
+
+pytestmark = pytest.mark.require_driver('PLMosaic')
 
 
-def test_plmosaic_1():
+@pytest.fixture(autouse=True, scope='module')
+def plmosaic_init():
+    yield
 
-    gdaltest.plmosaic_drv = gdal.GetDriverByName('PLMosaic')
+    gdal.Unlink('/vsimem/root_no_mosaics')
+    gdal.Unlink('/vsimem/root')
+    gdal.Unlink('/vsimem/root/?page=2')
+    gdal.Unlink('/vsimem/root/?name__is=my_mosaic')
+    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/0-2047/full')
+    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/0-2047/items')
+    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/455-1272/full')
+    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/455-1272/items')
+    gdal.Unlink('/vsimem/root/?name__is=mosaic_uint16')
+    gdal.Unlink('/vsimem/root/?name__is=mosaic_without_tiles')
 
-    if gdaltest.plmosaic_drv is not None:
-        return
-    pytest.skip()
+    if gdal.ReadDir('/vsimem/root') is not None:
+        print(gdal.ReadDir('/vsimem/root'))
+
+    try:
+        shutil.rmtree('tmp/plmosaic_cache')
+    except OSError:
+        pass
+
 
 ###############################################################################
 # Error: no API_KEY
 
 
 def test_plmosaic_2():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     ds = gdal.OpenEx('PLMosaic:', gdal.OF_RASTER)
@@ -72,10 +82,6 @@ def test_plmosaic_2():
 
 
 def test_plmosaic_3():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     gdal.SetConfigOption('PL_URL', '/vsimem/does_not_exist/')
     ds = gdal.OpenEx('PLMosaic:', gdal.OF_RASTER, open_options=['API_KEY=foo'])
@@ -88,10 +94,6 @@ def test_plmosaic_3():
 
 
 def test_plmosaic_4():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root', """{""")
 
     gdal.PushErrorHandler()
@@ -106,10 +108,6 @@ def test_plmosaic_4():
 
 
 def test_plmosaic_5():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root', """null""")
 
     gdal.PushErrorHandler()
@@ -124,10 +122,6 @@ def test_plmosaic_5():
 
 
 def test_plmosaic_6():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root', """{}""")
 
     gdal.PushErrorHandler()
@@ -142,10 +136,6 @@ def test_plmosaic_6():
 
 
 def test_plmosaic_7():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root', """{
     "mosaics": [],
 }""")
@@ -161,10 +151,6 @@ def test_plmosaic_7():
 
 
 def test_plmosaic_8():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root', """{
     "_links" : { "_next": "/vsimem/root/?page=2" },
     "mosaics": [
@@ -214,10 +200,6 @@ def test_plmosaic_8():
 
 
 def test_plmosaic_9():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     ds = gdal.OpenEx('PLMosaic:', gdal.OF_RASTER, open_options=['API_KEY=foo', 'MOSAIC=does_not_exist'])
@@ -230,10 +212,6 @@ def test_plmosaic_9():
 
 
 def test_plmosaic_9bis():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{""")
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     gdal.PushErrorHandler()
@@ -247,10 +225,6 @@ def test_plmosaic_9bis():
 
 
 def test_plmosaic_9ter():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{}""")
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     gdal.PushErrorHandler()
@@ -264,10 +238,6 @@ def test_plmosaic_9ter():
 
 
 def test_plmosaic_10():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -286,10 +256,6 @@ def test_plmosaic_10():
 
 
 def test_plmosaic_11():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -314,10 +280,6 @@ def test_plmosaic_11():
 
 
 def test_plmosaic_12():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -342,10 +304,6 @@ def test_plmosaic_12():
 
 
 def test_plmosaic_13():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -370,10 +328,6 @@ def test_plmosaic_13():
 
 
 def test_plmosaic_14():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -398,10 +352,6 @@ def test_plmosaic_14():
 
 
 def test_plmosaic_15():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/root/?name__is=my_mosaic', """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -435,10 +385,6 @@ def test_plmosaic_15():
 
 
 def test_plmosaic_16():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     try:
         shutil.rmtree('tmp/plmosaic_cache')
     except OSError:
@@ -497,10 +443,6 @@ def test_plmosaic_16():
 
 
 def test_plmosaic_17():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     ds = gdal.OpenEx('PLMosaic:', gdal.OF_RASTER, open_options=['API_KEY=foo', 'MOSAIC=my_mosaic', 'CACHE_PATH=tmp'])
     gdal.SetConfigOption('PL_URL', None)
@@ -618,10 +560,6 @@ def test_plmosaic_17():
 
 
 def test_plmosaic_18():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     shutil.rmtree('tmp/plmosaic_cache')
 
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
@@ -659,10 +597,6 @@ def test_plmosaic_18():
 
 
 def test_plmosaic_19():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     ds = gdal.OpenEx('PLMosaic:', gdal.OF_RASTER, open_options=['API_KEY=foo', 'MOSAIC=my_mosaic', 'CACHE_PATH=/does_not_exist'])
     gdal.SetConfigOption('PL_URL', None)
@@ -682,10 +616,6 @@ def test_plmosaic_19():
 
 
 def test_plmosaic_20():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     ds = gdal.OpenEx('PLMosaic:', gdal.OF_RASTER, open_options=['API_KEY=foo', 'MOSAIC=my_mosaic', 'CACHE_PATH='])
     gdal.SetConfigOption('PL_URL', None)
@@ -703,10 +633,6 @@ def test_plmosaic_20():
 
 
 def test_plmosaic_21():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('PL_URL', '/vsimem/root')
     ds = gdal.OpenEx('PLMosaic:', gdal.OF_RASTER, open_options=['API_KEY=foo', 'MOSAIC=my_mosaic', 'CACHE_PATH=', 'USE_TILES=YES'])
     gdal.SetConfigOption('PL_URL', None)
@@ -787,10 +713,6 @@ def test_plmosaic_21():
 
 
 def test_plmosaic_with_bbox():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
     try:
         shutil.rmtree('tmp/plmosaic_cache')
     except OSError:
@@ -870,35 +792,5 @@ def test_plmosaic_with_bbox():
   </Scenes>
 </LocationInfo>
 """
-
-###############################################################################
-#
-
-
-def test_plmosaic_cleanup():
-
-    if gdaltest.plmosaic_drv is None:
-        pytest.skip()
-
-    gdal.Unlink('/vsimem/root_no_mosaics')
-    gdal.Unlink('/vsimem/root')
-    gdal.Unlink('/vsimem/root/?page=2')
-    gdal.Unlink('/vsimem/root/?name__is=my_mosaic')
-    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/0-2047/full')
-    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/0-2047/items')
-    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/455-1272/full')
-    gdal.Unlink('/vsimem/root/my_mosaic_id/quads/455-1272/items')
-    gdal.Unlink('/vsimem/root/?name__is=mosaic_uint16')
-    gdal.Unlink('/vsimem/root/?name__is=mosaic_without_tiles')
-
-    if gdal.ReadDir('/vsimem/root') is not None:
-        print(gdal.ReadDir('/vsimem/root'))
-
-    try:
-        shutil.rmtree('tmp/plmosaic_cache')
-    except OSError:
-        pass
-
-    
 
 

--- a/autotest/gdrivers/rl2.py
+++ b/autotest/gdrivers/rl2.py
@@ -33,31 +33,26 @@ from osgeo import gdal, ogr
 
 
 import gdaltest
+import ogrtest
 import pytest
 
 ###############################################################################
 # Get the rl2 driver
 
+pytestmark = pytest.mark.require_driver('SQLite')
 
-def test_rl2_1():
 
-    gdaltest.rl2_drv = gdal.GetDriverByName('SQLite')
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-    if gdaltest.rl2_drv.GetMetadataItem('DCAP_RASTER') is None:
-        gdaltest.rl2_drv = None
-        pytest.skip()
+@pytest.fixture(autouse=True, scope='module')
+def rl2_init():
+    if gdaltest.sqlite_drv.GetMetadataItem('DCAP_RASTER') is None:
+        pytest.skip('DCAP_RASTER not enabled')
 
-    
+
 ###############################################################################
 # Test opening a rl2 DB gray level
 
 
 def test_rl2_2():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/byte.rl2')
 
     assert ds.RasterCount == 1, 'expected 1 band'
@@ -99,10 +94,6 @@ def test_rl2_2():
 
 
 def test_rl2_3():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/small_world.rl2')
 
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
@@ -139,10 +130,6 @@ def test_rl2_3():
 
 
 def test_rl2_4():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/small_world_pct.rl2')
 
     assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_PaletteIndex
@@ -165,10 +152,6 @@ def test_rl2_4():
 
 
 def test_rl2_5():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/multi_type.rl2')
 
     subds = ds.GetSubDatasets()
@@ -198,10 +181,6 @@ def test_rl2_5():
 
 
 def test_rl2_6():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', 'byte.tif', 1, 4672)
     return tst.testCreateCopy(vsimem=1, check_minmax=False)
 
@@ -210,10 +189,6 @@ def test_rl2_6():
 
 
 def test_rl2_7():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', 'small_world.tif', 1, 30111, options=['COMPRESS=PNG'])
     return tst.testCreateCopy(vsimem=1)
 
@@ -222,10 +197,6 @@ def test_rl2_7():
 
 
 def test_rl2_8():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', 'small_world_pct.tif', 1, 14890, options=['COMPRESS=PNG'])
     return tst.testCreateCopy(vsimem=1, check_minmax=False)
 
@@ -234,10 +205,6 @@ def test_rl2_8():
 
 
 def test_rl2_9():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', '../../gcore/data/uint16.tif', 1, 4672)
     return tst.testCreateCopy(vsimem=1)
 
@@ -246,10 +213,6 @@ def test_rl2_9():
 
 
 def test_rl2_10():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', '../../gcore/data/int16.tif', 1, 4672)
     return tst.testCreateCopy(vsimem=1)
 
@@ -258,10 +221,6 @@ def test_rl2_10():
 
 
 def test_rl2_11():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', '../../gcore/data/uint32.tif', 1, 4672)
     return tst.testCreateCopy(vsimem=1)
 
@@ -270,10 +229,6 @@ def test_rl2_11():
 
 
 def test_rl2_12():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', '../../gcore/data/int32.tif', 1, 4672)
     return tst.testCreateCopy(vsimem=1)
 
@@ -282,10 +237,6 @@ def test_rl2_12():
 
 
 def test_rl2_13():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', '../../gcore/data/float32.tif', 1, 4672)
     return tst.testCreateCopy(vsimem=1)
 
@@ -294,10 +245,6 @@ def test_rl2_13():
 
 
 def test_rl2_14():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', '../../gcore/data/float64.tif', 1, 4672)
     return tst.testCreateCopy(vsimem=1)
 
@@ -306,10 +253,6 @@ def test_rl2_14():
 
 
 def test_rl2_15():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', '../../gcore/data/1bit.bmp', 1, 200)
     return tst.testCreateCopy(vsimem=1, check_minmax=False)
 
@@ -318,10 +261,6 @@ def test_rl2_15():
 
 
 def test_rl2_16():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', 'byte.tif', 1, 4873, options=['NBITS=1', 'COMPRESS=CCITTFAX4'])
     return tst.testCreateCopy(vsimem=1, check_minmax=False)
 
@@ -330,10 +269,6 @@ def test_rl2_16():
 
 
 def test_rl2_17():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', 'byte.tif', 1, 4873, options=['NBITS=2', 'COMPRESS=DEFLATE'])
     return tst.testCreateCopy(vsimem=1, check_minmax=False)
 
@@ -342,10 +277,6 @@ def test_rl2_17():
 
 
 def test_rl2_18():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', 'byte.tif', 1, 2541, options=['NBITS=4'])
     return tst.testCreateCopy(vsimem=1, check_minmax=False)
 
@@ -354,10 +285,6 @@ def test_rl2_18():
 
 
 def test_rl2_19():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('SQLite', 'byte.tif', 1, 4873, options=['PIXEL_TYPE=MONOCHROME'])
     return tst.testCreateCopy(vsimem=1, check_minmax=False)
 
@@ -367,10 +294,6 @@ def test_rl2_19():
 
 
 def test_rl2_20():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tests = [('MONOCHROME', 2, gdal.GDT_Byte, 'NONE', None, None),
              ('MONOCHROME', 1, gdal.GDT_UInt16, 'NONE', None, None),
              ('PALETTE', 1, gdal.GDT_Byte, 'NONE', None, None),
@@ -403,7 +326,7 @@ def test_rl2_20():
             src_ds.GetRasterBand(1).SetMetadataItem('NBITS', nbits, 'IMAGE_STRUCTURE')
         options = ['PIXEL_TYPE=' + pixel_type, 'COMPRESS=' + compress]
         with gdaltest.error_handler():
-            out_ds = gdaltest.rl2_drv.CreateCopy('/vsimem/rl2_20.rl2', src_ds, options=options)
+            out_ds = gdaltest.sqlite_drv.CreateCopy('/vsimem/rl2_20.rl2', src_ds, options=options)
         assert out_ds is None, \
             ('Expected error for %s, band=%d, dt=%d, %s, nbits=%s' % (pixel_type, band_count, dt, compress, nbits))
 
@@ -414,10 +337,6 @@ def test_rl2_20():
 
 
 def test_rl2_21():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     tests = [('DEFLATE', None),
              ('LZMA', None),
              ('PNG', None),
@@ -435,14 +354,14 @@ def test_rl2_21():
     src_ds = gdal.Open('data/byte.tif')
     for (compress, quality) in tests:
 
-        if gdaltest.rl2_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find(compress) < 0:
+        if gdaltest.sqlite_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find(compress) < 0:
             print('Skipping test of %s, since it is not available in the run-time librasterlite2' % compress)
             continue
 
         options = ['COMPRESS=' + compress]
         if quality is not None:
             options += ['QUALITY=' + str(quality)]
-        out_ds = gdaltest.rl2_drv.CreateCopy('/vsimem/rl2_21.rl2', src_ds, options=options)
+        out_ds = gdaltest.sqlite_drv.CreateCopy('/vsimem/rl2_21.rl2', src_ds, options=options)
         assert out_ds is not None, \
             ('Got error with %s, quality=%d' % (compress, quality))
         assert out_ds.GetMetadataItem('COMPRESSION', 'IMAGE_STRUCTURE').find(compress) >= 0, \
@@ -454,17 +373,16 @@ def test_rl2_21():
 # Test APPEND_SUBDATASET
 
 
+@pytest.mark.require_ogr_driver('SQLite')
 def test_rl2_22():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.tif')
 
-    ds = ogr.GetDriverByName('SQLite').CreateDataSource('/vsimem/rl2_22.rl2', options=['SPATIALITE=YES'])
+    ogr_driver = ogrtest.sqlite_drv
+
+    ds = ogr_driver.CreateDataSource('/vsimem/rl2_22.rl2', options=['SPATIALITE=YES'])
     ds.CreateLayer('foo', None, ogr.wkbPoint)
     ds = None
-    ds = gdaltest.rl2_drv.CreateCopy('/vsimem/rl2_22.rl2', src_ds, options=['APPEND_SUBDATASET=YES', 'COVERAGE=byte'])
+    ds = gdaltest.sqlite_drv.CreateCopy('/vsimem/rl2_22.rl2', src_ds, options=['APPEND_SUBDATASET=YES', 'COVERAGE=byte'])
     assert ds.GetRasterBand(1).Checksum() == 4672
     ds = None
     ds = gdal.OpenEx('/vsimem/rl2_22.rl2')
@@ -474,12 +392,12 @@ def test_rl2_22():
     left_ds = gdal.Translate('left', src_ds, srcWin=[0, 0, 10, 20], format='MEM')
     right_ds = gdal.Translate('', src_ds, srcWin=[10, 0, 10, 20], format='MEM')
 
-    gdaltest.rl2_drv.CreateCopy('/vsimem/rl2_22.rl2', left_ds, options=['COVERAGE=left_right'])
-    ds = gdaltest.rl2_drv.CreateCopy('/vsimem/rl2_22.rl2', right_ds, options=['APPEND_SUBDATASET=YES', 'COVERAGE=left_right', 'SECTION=right'])
+    gdaltest.sqlite_drv.CreateCopy('/vsimem/rl2_22.rl2', left_ds, options=['COVERAGE=left_right'])
+    ds = gdaltest.sqlite_drv.CreateCopy('/vsimem/rl2_22.rl2', right_ds, options=['APPEND_SUBDATASET=YES', 'COVERAGE=left_right', 'SECTION=right'])
     assert ds.GetRasterBand(1).Checksum() == 4672
 
     src_ds = gdal.Open('data/rgbsmall.tif')
-    ds = gdaltest.rl2_drv.CreateCopy('/vsimem/rl2_22.rl2', src_ds, options=['APPEND_SUBDATASET=YES', 'COVERAGE=rgbsmall'])
+    ds = gdaltest.sqlite_drv.CreateCopy('/vsimem/rl2_22.rl2', src_ds, options=['APPEND_SUBDATASET=YES', 'COVERAGE=rgbsmall'])
     assert ds.GetRasterBand(1).Checksum() == src_ds.GetRasterBand(1).Checksum()
     ds = None
 
@@ -490,13 +408,9 @@ def test_rl2_22():
 
 
 def test_rl2_23():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/byte.tif')
     src_ds = gdal.Translate('', src_ds, format='MEM', width=2048, height=2048)
-    ds = gdaltest.rl2_drv.CreateCopy('/vsimem/rl2_23.rl2', src_ds)
+    ds = gdaltest.sqlite_drv.CreateCopy('/vsimem/rl2_23.rl2', src_ds)
     ret = ds.BuildOverviews('NEAR', [2])
     assert ret == 0
     assert ds.GetRasterBand(1).GetOverviewCount() == 5
@@ -515,11 +429,7 @@ def test_rl2_23():
 
 
 def test_rl2_24():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
-    if gdal.GetDriverByName('SQLite').GetMetadataItem("ENABLE_SQL_SQLITE_FORMAT") != 'YES':
+    if gdaltest.sqlite_drv.GetMetadataItem("ENABLE_SQL_SQLITE_FORMAT") != 'YES':
         pytest.skip()
 
     ds = gdal.Open('data/byte.rl2.sql')
@@ -530,12 +440,5 @@ def test_rl2_24():
 
 
 def test_rl2_error_create():
-
-    if gdaltest.rl2_drv is None:
-        pytest.skip()
-
     with gdaltest.error_handler():
-        assert gdaltest.rl2_drv.Create('/vsimem/out.db', 1, 1) is None
-    
-
-
+        assert gdaltest.sqlite_drv.Create('/vsimem/out.db', 1, 1) is None

--- a/autotest/gdrivers/test_validate_jp2.py
+++ b/autotest/gdrivers/test_validate_jp2.py
@@ -41,14 +41,11 @@ import gdaltest
 ###############################################################################
 # Verify we have the JP2OpenJPEG driver.
 
+pytestmark = pytest.mark.require_driver('JP2OpenJPEG')
 
-def test_validate_jp2_1():
 
-    gdaltest.has_validate_jp2_and_build_jp2 = False
-    gdaltest.jp2openjpeg_drv = gdal.GetDriverByName('JP2OpenJPEG')
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
+@pytest.fixture(autouse=True, scope='module')
+def validate_jp2_init():
     try:
         import validate_jp2
         import build_jp2_from_xml
@@ -57,8 +54,9 @@ def test_validate_jp2_1():
     except (ImportError, AttributeError):
         pytest.skip()
 
-    gdaltest.has_validate_jp2_and_build_jp2 = True
     gdaltest.deregister_all_jpeg2000_drivers_but('JP2OpenJPEG')
+    yield
+    gdaltest.reregister_all_jpeg2000_drivers()
 
 ###############################################################################
 
@@ -87,10 +85,6 @@ def validate(filename, inspire_tg=True, expected_gmljp2=True, oidoc=None):
 
 
 def test_validate_jp2_2():
-
-    if not gdaltest.has_validate_jp2_and_build_jp2:
-        pytest.skip()
-
     import build_jp2_from_xml
 
     build_jp2_from_xml.build_file('data/test_validate_jp2/byte_corrupted.xml', '/vsimem/out.jp2')
@@ -152,10 +146,6 @@ def test_validate_jp2_2():
 
 
 def test_validate_jp2_3():
-
-    if not gdaltest.has_validate_jp2_and_build_jp2:
-        pytest.skip()
-
     import build_jp2_from_xml
 
     build_jp2_from_xml.build_file('data/test_validate_jp2/stefan_full_rgba_corrupted.xml', '/vsimem/out.jp2')
@@ -206,10 +196,6 @@ def test_validate_jp2_3():
 
 
 def test_validate_jp2_4():
-
-    if not gdaltest.has_validate_jp2_and_build_jp2:
-        pytest.skip()
-
     import build_jp2_from_xml
 
     build_jp2_from_xml.build_file('data/test_validate_jp2/almost_nojp2box.xml', '/vsimem/out.jp2')
@@ -248,10 +234,6 @@ def test_validate_jp2_4():
 
 
 def test_validate_jp2_5():
-
-    if not gdaltest.has_validate_jp2_and_build_jp2:
-        pytest.skip()
-
     import build_jp2_from_xml
 
     build_jp2_from_xml.build_file('data/test_validate_jp2/utmsmall_pct_corrupted.xml', '/vsimem/out.jp2')
@@ -292,10 +274,6 @@ def test_validate_jp2_5():
 
 
 def test_validate_jp2_6():
-
-    if not gdaltest.has_validate_jp2_and_build_jp2:
-        pytest.skip()
-
     error_report = validate('data/test_validate_jp2/byte.jp2', oidoc='data/test_validate_jp2/byte_oi.xml')
     gdal.Unlink('/vsimem/out.jp2')
 
@@ -319,10 +297,6 @@ def test_validate_jp2_6():
 
 
 def test_validate_jp2_7():
-
-    if not gdaltest.has_validate_jp2_and_build_jp2:
-        pytest.skip()
-
     error_report = validate('data/test_validate_jp2/stefan_full_rgba.jp2', oidoc='data/test_validate_jp2/stefan_full_rgba_oi.xml', expected_gmljp2=False)
     gdal.Unlink('/vsimem/out.jp2')
 
@@ -346,10 +320,6 @@ def test_validate_jp2_7():
 
 
 def test_validate_jp2_8():
-
-    if not gdaltest.has_validate_jp2_and_build_jp2:
-        pytest.skip()
-
     error_report = validate('data/test_validate_jp2/utmsmall_pct.jp2', oidoc='data/test_validate_jp2/utmsmall_pct_oi.xml')
     gdal.Unlink('/vsimem/out.jp2')
 
@@ -366,16 +336,3 @@ def test_validate_jp2_8():
         pp = pprint.PrettyPrinter()
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
-
-    
-###############################################################################
-
-
-def test_validate_jp2_cleanup():
-
-    if gdaltest.has_validate_jp2_and_build_jp2:
-        gdaltest.reregister_all_jpeg2000_drivers()
-
-    
-
-

--- a/autotest/gdrivers/webp.py
+++ b/autotest/gdrivers/webp.py
@@ -35,26 +35,15 @@ from osgeo import gdal
 import gdaltest
 import pytest
 
-###############################################################################
-# Test if WEBP driver is present
+
+pytestmark = pytest.mark.require_driver('WEBP')
 
 
-def test_webp_1():
-
-    gdaltest.webp_drv = gdal.GetDriverByName('WEBP')
-    if gdaltest.webp_drv is None:
-        pytest.skip()
-
-    
 ###############################################################################
 # Open() test
 
 
 def test_webp_2():
-
-    if gdaltest.webp_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/rgbsmall.webp')
     cs = ds.GetRasterBand(1).Checksum()
     assert cs == 21464 or cs == 21450 or cs == 21459, \
@@ -65,10 +54,6 @@ def test_webp_2():
 
 
 def test_webp_3():
-
-    if gdaltest.webp_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/rgbsmall.tif')
     out_ds = gdaltest.webp_drv.CreateCopy('/vsimem/webp_3.webp', src_ds, options=['QUALITY=80'])
     src_ds = None
@@ -86,10 +71,6 @@ def test_webp_3():
 
 
 def test_webp_4():
-
-    if gdaltest.webp_drv is None:
-        pytest.skip()
-
     md = gdaltest.webp_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LOSSLESS') == -1:
         pytest.skip()
@@ -113,10 +94,6 @@ def test_webp_4():
 
 
 def test_webp_5():
-
-    if gdaltest.webp_drv is None:
-        pytest.skip()
-
     md = gdaltest.webp_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('LOSSLESS') == -1:
         pytest.skip()

--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -43,22 +43,14 @@ import pytest
 ###############################################################################
 # Verify we have the driver.
 
+pytestmark = pytest.mark.require_driver('WMS')
 
-def test_wms_1():
 
-    gdaltest.wms_drv = gdal.GetDriverByName('WMS')
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-    
 ###############################################################################
 # Open the WMS dataset
 
 
 def wms_2():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     # NOTE - mloskot:
     # This is a dirty hack checking if remote WMS service is online.
     # Nothing genuine but helps to keep the buildbot waterfall green.
@@ -81,8 +73,7 @@ def wms_2():
 
 
 def wms_3():
-
-    if gdaltest.wms_drv is None or gdaltest.wms_ds is None:
+    if gdaltest.wms_ds is None:
         pytest.skip()
 
     if not gdaltest.wms_srv1_ok:
@@ -108,8 +99,7 @@ def wms_3():
 
 
 def wms_4():
-
-    if gdaltest.wms_drv is None or gdaltest.wms_ds is None:
+    if gdaltest.wms_ds is None:
         pytest.skip()
 
     if not gdaltest.wms_srv1_ok:
@@ -135,10 +125,6 @@ def wms_4():
 
 
 def test_wms_5():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     # We don't need to check if the remote service is online as we
     # don't need a connection for this test
 
@@ -158,10 +144,6 @@ def test_wms_5():
 
 
 def test_wms_6():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     # We don't need to check if the remote service is online as we
     # don't need a connection for this test
 
@@ -181,10 +163,6 @@ def test_wms_6():
 
 
 def test_wms_7():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     srv = 'http://tilecache.osgeo.org/wms-c/Basic.py'
     gdaltest.metacarta_tms = False
     if gdaltest.gdalurlopen(srv) is None:
@@ -230,10 +208,6 @@ def test_wms_7():
 # Test TMS with cache
 
 def test_wms_8():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     # server_url = 'http://tilecache.osgeo.org/wms-c/Basic.py'
     # wmstms_version = '/1.0.0/basic'
     # zero_tile = wmstms_version + '/0/0/0.png'
@@ -445,10 +419,6 @@ def test_wms_8():
 
 
 def wms_9():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     tms = """<GDAL_WMS>
     <Service name="TiledWMS">
         <ServerUrl>http://onearth.jpl.nasa.gov/wms.cgi?</ServerUrl>
@@ -477,10 +447,6 @@ def wms_9():
 
 
 def wms_10():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     if not gdaltest.wms_srv1_ok:
         pytest.skip()
 
@@ -504,10 +470,6 @@ def wms_10():
 
 
 def test_wms_11():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     if gdaltest.skip_on_travis():
         pytest.skip()
 
@@ -535,10 +497,6 @@ def test_wms_11():
 
 
 def test_wms_12():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     if gdaltest.metacarta_tms is not True:
         pytest.skip()
 
@@ -571,10 +529,6 @@ def test_wms_12():
 
 
 def test_wms_13():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     ds = gdal.Open("data/DNEC_250K.vrt")
     if ds.ReadRaster(0, 0, 1024, 682) is None:
         srv = 'http://wms.geobase.ca/wms-bin/cubeserv.cgi?SERVICE=WMS&VERSION=1.1.1&REQUEST=GeCapabilities'
@@ -588,9 +542,6 @@ def test_wms_13():
 # Test reading Virtual Earth layer
 
 def test_wms_14():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
     ds = gdal.Open("""<GDAL_WMS>
   <Service name="VirtualEarth">
     <ServerUrl>http://a${server_num}.ortho.tiles.virtualearth.net/tiles/a${quadkey}.jpeg?g=90</ServerUrl>
@@ -623,9 +574,6 @@ def test_wms_14():
 
 
 def test_wms_15():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
     src_ds = gdal.Open("http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer?f=json&pretty=true")
     if src_ds is None:
         srv = 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer?f=json&pretty=true'
@@ -663,10 +611,6 @@ def test_wms_15():
 
 
 def test_wms_16():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     if not gdaltest.run_slow_tests():
         # server often returns a 504 after ages; this test can take minutes
         pytest.skip()
@@ -744,10 +688,6 @@ def test_wms_16():
 
 
 def wms_17():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     srv = 'http://onmoon.lmmp.nasa.gov/sites/wms.cgi?'
     if gdaltest.gdalurlopen(srv) is None:
         pytest.skip()
@@ -766,10 +706,6 @@ def wms_17():
 
 
 def test_wms_18():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     # We don't need to check if the remote service is online as we
     # don't need a connection for this test.
 
@@ -799,10 +735,6 @@ def test_wms_18():
 
 
 def test_wms_19():
-
-    if gdaltest.wms_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('IIP:http://merovingio.c2rmf.cnrs.fr/fcgi-bin/iipsrv.fcgi?FIF=globe.256x256.tif')
 
     if ds is None:

--- a/autotest/gdrivers/wmts.py
+++ b/autotest/gdrivers/wmts.py
@@ -41,31 +41,20 @@ import pytest
 # Find WMTS driver
 
 
-def test_wmts_1():
+pytestmark = [
+    pytest.mark.require_driver('WMTS', 'WMS'),
+    pytest.mark.config_options(
+        CPL_CURL_ENABLE_VSIMEM='YES',
+        GDAL_DEFAULT_WMS_CACHE_PATH='/vsimem/cache',
+    )
+]
 
-    gdaltest.wmts_drv = gdal.GetDriverByName('WMTS')
-
-    if gdaltest.wmts_drv is not None and gdal.GetDriverByName('WMS') is None:
-        print('Missing WMS driver')
-        gdaltest.wmts_drv = None
-
-    if gdaltest.wmts_drv is not None:
-
-        gdal.SetConfigOption('CPL_CURL_ENABLE_VSIMEM', 'YES')
-        gdal.SetConfigOption('GDAL_DEFAULT_WMS_CACHE_PATH', '/vsimem/cache')
-
-        return
-    pytest.skip()
 
 ###############################################################################
 # Error: no URL and invalid GDAL_WMTS service file documents
 
 
 def test_wmts_2():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('WMTS:')
     gdal.PopErrorHandler()
@@ -91,10 +80,6 @@ def test_wmts_2():
 
 
 def test_wmts_3():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('WMTS:https://non_existing')
     gdal.PopErrorHandler()
@@ -105,10 +90,6 @@ def test_wmts_3():
 
 
 def test_wmts_4():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('WMTS:/vsimem/non_existing')
     gdal.PopErrorHandler()
@@ -119,10 +100,6 @@ def test_wmts_4():
 
 
 def test_wmts_5():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/invalid_getcapabilities.xml', '<invalid_xml')
 
     gdal.PushErrorHandler()
@@ -135,10 +112,6 @@ def test_wmts_5():
 
 
 def test_wmts_6():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/invalid_getcapabilities.xml', '<Capabilities/>')
 
     gdal.PushErrorHandler()
@@ -151,10 +124,6 @@ def test_wmts_6():
 
 
 def test_wmts_7():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/empty_getcapabilities.xml', '<Capabilities><Contents/></Capabilities>')
 
     gdal.PushErrorHandler()
@@ -167,10 +136,6 @@ def test_wmts_7():
 
 
 def test_wmts_8():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/missing.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -189,10 +154,6 @@ def test_wmts_8():
 
 
 def test_wmts_9():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/missing_tms.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -218,10 +179,6 @@ def test_wmts_9():
 
 
 def test_wmts_10():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/missing_SupportedCRS.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -250,10 +207,6 @@ def test_wmts_10():
 
 
 def test_wmts_11():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/no_tilematrix.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -283,10 +236,6 @@ def test_wmts_11():
 
 
 def test_wmts_12():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/missing_required_element_in_tilematrix.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -317,10 +266,6 @@ def test_wmts_12():
 
 
 def test_wmts_12bis():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_12bis.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -358,10 +303,6 @@ def test_wmts_12bis():
 
 
 def test_wmts_13():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/minimal.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -458,10 +399,6 @@ def test_wmts_13():
 
 
 def test_wmts_14():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/nominal.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -690,10 +627,6 @@ def test_wmts_14():
 
 
 def test_wmts_15():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/nominal_kvp.xml?service=WMTS&request=GetCapabilities', """<Capabilities xmlns="http://www.opengis.net/wmts/1.0">
     <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
@@ -832,10 +765,6 @@ def test_wmts_15():
 
 
 def test_wmts_16():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_16.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -907,10 +836,6 @@ def test_wmts_16():
 
 
 def test_wmts_17():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_17.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -981,10 +906,6 @@ def test_wmts_17():
 
 
 def test_wmts_18():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_18.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -1055,10 +976,6 @@ def test_wmts_18():
 
 
 def test_wmts_19():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_19.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -1134,10 +1051,6 @@ def test_wmts_19():
 
 
 def test_wmts_20():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_20.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -1217,10 +1130,6 @@ def test_wmts_20():
 
 
 def test_wmts_21():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_21.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -1310,10 +1219,6 @@ def test_wmts_21():
 
 
 def test_wmts_22():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/wmts_22.xml', """<Capabilities>
     <Contents>
         <Layer>
@@ -1365,10 +1270,6 @@ def test_wmts_22():
 
 
 def wmts_23(imagetype, expected_cs):
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     inputXml = '/vsimem/' + imagetype + '.xml'
     serviceUrl = '/vsimem/wmts_23/' + imagetype
     gdal.FileFromMemBuffer(inputXml, """<Capabilities>
@@ -1438,10 +1339,6 @@ def test_wmts_23_rgba():
 
 
 def test_wmts_invalid_global_to_tm_reprojection():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     inputXml = '/vsimem/wmts_invalid_global_to_tm_reprojection.xml'
     gdal.FileFromMemBuffer(inputXml, """<?xml version="1.0"?>
 <Capabilities xmlns="http://www.opengis.net/wmts/1.0"
@@ -1496,10 +1393,6 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0">
 
 
 def test_wmts_check_no_overflow_zoom_level():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     inputXml = '/vsimem/wmts_check_no_overflow_zoom_level.xml'
     gdal.FileFromMemBuffer(inputXml, """<?xml version="1.0"?>
 <Capabilities xmlns="http://www.opengis.net/wmts/1.0"
@@ -1778,10 +1671,6 @@ def wmts_CleanCache():
 
 
 def test_wmts_cleanup():
-
-    if gdaltest.wmts_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('CPL_CURL_ENABLE_VSIMEM', None)
     gdal.SetConfigOption('GDAL_DEFAULT_WMS_CACHE_PATH', None)
 

--- a/autotest/ogr/ogr_csw.py
+++ b/autotest/ogr/ogr_csw.py
@@ -40,16 +40,13 @@ from osgeo import gdal
 # Test underlying OGR drivers
 #
 
-pytestmark = pytest.mark.require_driver('CSW')
+pytestmark = pytest.mark.require_ogr_driver('CSW')
 
 
 @pytest.fixture(autouse=True, scope='module')
 def ogr_csw_init():
-    gdaltest.csw_drv = ogr.GetDriverByName('CSW')
-
     gml_ds = ogr.Open('data/ionic_wfs.gml')
     if gml_ds is None:
-        gdaltest.csw_drv = None
         if gdal.GetLastErrorMsg().find('Xerces') != -1:
             pytest.skip()
         pytest.skip('failed to open test file.')

--- a/autotest/ogr/ogr_dgnv8.py
+++ b/autotest/ogr/ogr_dgnv8.py
@@ -37,16 +37,14 @@ import ogrtest
 from osgeo import gdal, ogr
 import pytest
 
+
+pytestmark = pytest.mark.require_ogr_driver('DGNv8')
+
 ###############################################################################
 # Verify we can open the test file.
 
 
 def test_ogr_dgnv8_1():
-
-    gdaltest.dgnv8_drv = ogr.GetDriverByName('DGNv8')
-    if gdaltest.dgnv8_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/test_dgnv8.dgn')
     assert ds is not None, 'failed to open test file.'
 
@@ -55,10 +53,6 @@ def test_ogr_dgnv8_1():
 
 
 def test_ogr_dgnv8_2():
-
-    if gdaltest.dgnv8_drv is None:
-        pytest.skip()
-
     gdal.VectorTranslate('/vsimem/ogr_dgnv8_2.csv', 'data/test_dgnv8.dgn',
                          options='-f CSV  -dsco geometry=as_wkt -sql "select *, ogr_style from my_model"')
 
@@ -66,21 +60,15 @@ def test_ogr_dgnv8_2():
     lyr_ref = ds_ref.GetLayer(0)
     ds = ogr.Open('data/test_dgnv8_ref.csv')
     lyr = ds.GetLayer(0)
-    ret = ogrtest.compare_layers(lyr, lyr_ref, excluded_fields=['WKT'])
+    ogrtest.compare_layers(lyr, lyr_ref, excluded_fields=['WKT'])
 
     gdal.Unlink('/vsimem/ogr_dgnv8_2.csv')
-
-    return ret
 
 ###############################################################################
 # Run test_ogrsf
 
 
 def test_ogr_dgnv8_3():
-
-    if gdaltest.dgnv8_drv is None:
-        pytest.skip()
-
     import test_cli_utilities
     if test_cli_utilities.get_test_ogrsf_path() is None:
         pytest.skip()
@@ -100,10 +88,6 @@ def test_ogr_dgnv8_3():
 
 
 def test_ogr_dgnv8_4():
-
-    if gdaltest.dgnv8_drv is None:
-        pytest.skip()
-
     tmp_dgn = 'tmp/ogr_dgnv8_4.dgn'
     gdal.VectorTranslate(tmp_dgn, 'data/test_dgnv8.dgn', format='DGNv8')
 
@@ -116,21 +100,15 @@ def test_ogr_dgnv8_4():
     lyr_ref = ds_ref.GetLayer(0)
     ds = ogr.Open('data/test_dgnv8_write_ref.csv')
     lyr = ds.GetLayer(0)
-    ret = ogrtest.compare_layers(lyr, lyr_ref, excluded_fields=['WKT'])
+    ogrtest.compare_layers(lyr, lyr_ref, excluded_fields=['WKT'])
 
     gdal.Unlink(tmp_csv)
-
-    return ret
 
 ###############################################################################
 # Test creation options
 
 
 def test_ogr_dgnv8_5():
-
-    if gdaltest.dgnv8_drv is None:
-        pytest.skip()
-
     tmp_dgn = 'tmp/ogr_dgnv8_5.dgn'
     options = ['APPLICATION=application',
                'TITLE=title',
@@ -183,13 +161,3 @@ def test_ogr_dgnv8_5():
 
     gdal.Unlink(tmp_dgn)
     gdal.Unlink(tmp2_dgn)
-
-
-###############################################################################
-#  Cleanup
-
-def test_ogr_dgnv8_cleanup():
-
-    pass
-
-

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -50,27 +50,16 @@ pytestmark = pytest.mark.require_ogr_driver('GeoJSON')
 
 def validate_layer(lyr, name, features, typ, fields, box):
 
-    if name is not None and name != lyr.GetName():
-        print('Wrong layer name')
-        return False
+    assert name is None or name == lyr.GetName(), 'Wrong layer name'
 
-    if features != lyr.GetFeatureCount():
-        print('Wrong number of features')
-        return False
+    assert features == lyr.GetFeatureCount()
 
     lyrDefn = lyr.GetLayerDefn()
-    if lyrDefn is None:
-        print('Layer definition is none')
-        return False
+    assert lyrDefn is not None
 
-    if typ != lyrDefn.GetGeomType():
-        print('Wrong geometry type')
-        print(lyrDefn.GetGeomType())
-        return False
+    assert typ == lyrDefn.GetGeomType(), lyrDefn.GetGeomType()
 
-    if fields != lyrDefn.GetFieldCount():
-        print('Wrong number of fields')
-        return False
+    assert fields == lyrDefn.GetFieldCount()
 
     extent = lyr.GetExtent()
 
@@ -79,12 +68,7 @@ def validate_layer(lyr, name, features, typ, fields, box):
     miny = abs(extent[2] - box[2])
     maxy = abs(extent[3] - box[3])
 
-    if max(minx, maxx, miny, maxy) > 0.0001:
-        print('Wrong spatial extent of layer')
-        print(extent)
-        return False
-
-    return True
+    assert max(minx, maxx, miny, maxy) <= 0.0001, extent
 
 
 def verify_geojson_copy(name, fids, names):
@@ -215,8 +199,7 @@ def test_ogr_geojson_2():
 
     extent = (100.0, 100.0, 0.0, 0.0)
 
-    rc = validate_layer(lyr, 'point', 1, ogr.wkbPoint, 0, extent)
-    assert rc
+    validate_layer(lyr, 'point', 1, ogr.wkbPoint, 0, extent)
 
     lyr = None
 
@@ -235,8 +218,7 @@ def test_ogr_geojson_3():
 
     extent = (100.0, 101.0, 0.0, 1.0)
 
-    rc = validate_layer(lyr, 'linestring', 1, ogr.wkbLineString, 0, extent)
-    assert rc
+    validate_layer(lyr, 'linestring', 1, ogr.wkbLineString, 0, extent)
 
     lyr = None
 
@@ -255,8 +237,7 @@ def test_ogr_geojson_4():
 
     extent = (100.0, 101.0, 0.0, 1.0)
 
-    rc = validate_layer(lyr, 'polygon', 1, ogr.wkbPolygon, 0, extent)
-    assert rc
+    validate_layer(lyr, 'polygon', 1, ogr.wkbPolygon, 0, extent)
 
     lyr = None
 
@@ -275,8 +256,7 @@ def test_ogr_geojson_5():
 
     extent = (100.0, 102.0, 0.0, 1.0)
 
-    rc = validate_layer(lyr, 'geometrycollection', 1, ogr.wkbGeometryCollection, 0, extent)
-    assert rc
+    validate_layer(lyr, 'geometrycollection', 1, ogr.wkbGeometryCollection, 0, extent)
 
     lyr = None
 
@@ -295,8 +275,7 @@ def test_ogr_geojson_6():
 
     extent = (100.0, 101.0, 0.0, 1.0)
 
-    rc = validate_layer(lyr, 'multipoint', 1, ogr.wkbMultiPoint, 0, extent)
-    assert rc
+    validate_layer(lyr, 'multipoint', 1, ogr.wkbMultiPoint, 0, extent)
 
     lyr = None
 
@@ -315,8 +294,7 @@ def test_ogr_geojson_7():
 
     extent = (100.0, 103.0, 0.0, 3.0)
 
-    rc = validate_layer(lyr, 'multilinestring', 1, ogr.wkbMultiLineString, 0, extent)
-    assert rc
+    validate_layer(lyr, 'multilinestring', 1, ogr.wkbMultiLineString, 0, extent)
 
     lyr = None
 
@@ -335,8 +313,7 @@ def test_ogr_geojson_8():
 
     extent = (100.0, 103.0, 0.0, 3.0)
 
-    rc = validate_layer(lyr, 'multipolygon', 1, ogr.wkbMultiPolygon, 0, extent)
-    assert rc
+    validate_layer(lyr, 'multipolygon', 1, ogr.wkbMultiPolygon, 0, extent)
 
     lyr = None
 
@@ -402,8 +379,7 @@ def test_ogr_geojson_11():
 
     extent = (100.0, 102.0, 0.0, 1.0)
 
-    rc = validate_layer(lyr, 'srs_name', 1, ogr.wkbGeometryCollection, 0, extent)
-    assert rc
+    validate_layer(lyr, 'srs_name', 1, ogr.wkbGeometryCollection, 0, extent)
 
     ref = lyr.GetSpatialRef()
     pcs = int(ref.GetAuthorityCode('PROJCS'))
@@ -522,8 +498,7 @@ def test_ogr_geojson_16():
 
     extent = (2, 2, 49, 49)
 
-    rc = validate_layer(lyr, 'esripoint', 1, ogr.wkbPoint, 4, extent)
-    assert rc
+    validate_layer(lyr, 'esripoint', 1, ogr.wkbPoint, 4, extent)
 
     ref = lyr.GetSpatialRef()
     gcs = int(ref.GetAuthorityCode('GEOGCS'))
@@ -569,8 +544,7 @@ def test_ogr_geojson_17():
 
     extent = (2, 3, 49, 50)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('LINESTRING (2 49,3 50)')
@@ -618,8 +592,7 @@ def test_ogr_geojson_18():
 
     extent = (-3, 3, 49, 50)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('MULTIPOLYGON (((2 49,2 50,3 50,3 49,2 49),(2.1 49.1,2.1 49.9,2.9 49.9,2.9 49.1,2.1 49.1)),((-2 49,-2 50,-3 50,-3 49,-2 49)))')
@@ -655,8 +628,7 @@ def test_ogr_geojson_19():
 
     extent = (2, 3, 49, 50)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49,3 50)')
@@ -1048,8 +1020,7 @@ def test_ogr_geojson_28():
     # validate layer doesn't check z, but put it in
     extent = (2, 2, 49, 49, 1, 1)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbPoint, 4, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbPoint, 4, extent)
 
     ref = lyr.GetSpatialRef()
     gcs = int(ref.GetAuthorityCode('GEOGCS'))
@@ -1096,8 +1067,7 @@ def test_ogr_geojson_29():
     # validate layer doesn't check z, but put it in
     extent = (2, 3, 49, 50, 1, 2)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('LINESTRING (2 49 1,3 50 2)')
@@ -1123,8 +1093,7 @@ def test_ogr_geojson_30():
     # validate layer doesn't check z, but put it in
     extent = (2, 3, 49, 50, 1, 2)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49 1,3 50 2)')
@@ -1150,8 +1119,7 @@ def test_ogr_geojson_31():
     # validate layer doesn't check z, but put it in
     extent = (2, 3, 49, 50, 1, 4)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('POLYGON ((2 49 1,2 50 2,3 50 3,3 49 4,2 49 1))')
@@ -1176,8 +1144,7 @@ def test_ogr_geojson_32():
 
     extent = (2, 3, 49, 50)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT M ((2 49 1),(3 50 2))')
@@ -1202,8 +1169,7 @@ def test_ogr_geojson_33():
 
     extent = (2, 3, 49, 50)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49,3 50)')
@@ -1228,8 +1194,7 @@ def test_ogr_geojson_34():
 
     extent = (2, 3, 49, 50)
 
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
+    validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
 
     feature = lyr.GetNextFeature()
     ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT ZM ((2 49 1 100),(3 50 2 100))')

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -40,6 +40,10 @@ from osgeo import gdal
 import gdaltest
 import ogrtest
 import pytest
+
+
+pytestmark = pytest.mark.require_ogr_driver('GeoJSON')
+
 ###############################################################################
 # Test utilities
 
@@ -139,10 +143,6 @@ def verify_geojson_copy(name, fids, names):
 
 
 def copy_shape_to_geojson(gjname, compress=None):
-
-    if gdaltest.geojson_drv is None:
-        return False
-
     if compress is not None:
         if compress[0:5] == '/vsig':
             dst_name = os.path.join('/vsigzip/', 'tmp', gjname + '.geojson' + '.gz')
@@ -155,7 +155,7 @@ def copy_shape_to_geojson(gjname, compress=None):
     else:
         dst_name = os.path.join('tmp', gjname + '.geojson')
 
-    ds = gdaltest.geojson_drv.CreateDataSource(dst_name)
+    ds = ogrtest.geojson_drv.CreateDataSource(dst_name)
     if ds is None:
         return False
 
@@ -199,27 +199,12 @@ def copy_shape_to_geojson(gjname, compress=None):
 
     return True
 
-###############################################################################
-# Find GeoJSON driver
-
-
-def test_ogr_geojson_1():
-
-    gdaltest.geojson_drv = ogr.GetDriverByName('GeoJSON')
-
-    if gdaltest.geojson_drv is not None:
-        return
-    pytest.fail()
 
 ###############################################################################
 # Test file-based DS with standalone "Point" feature object.
 
 
 def test_ogr_geojson_2():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/point.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -240,10 +225,6 @@ def test_ogr_geojson_2():
 
 
 def test_ogr_geojson_3():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/linestring.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -264,10 +245,6 @@ def test_ogr_geojson_3():
 
 
 def test_ogr_geojson_4():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/polygon.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -288,10 +265,6 @@ def test_ogr_geojson_4():
 
 
 def test_ogr_geojson_5():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/geometrycollection.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -312,10 +285,6 @@ def test_ogr_geojson_5():
 
 
 def test_ogr_geojson_6():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/multipoint.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -336,10 +305,6 @@ def test_ogr_geojson_6():
 
 
 def test_ogr_geojson_7():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/multilinestring.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -360,10 +325,6 @@ def test_ogr_geojson_7():
 
 
 def test_ogr_geojson_8():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/multipolygon.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -384,10 +345,6 @@ def test_ogr_geojson_8():
 
 
 def test_ogr_geojson_9():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     gdaltest.tests = [
         ['gjpoint', [1], ['Point 1']],
         ['gjline', [1], ['Line 1']],
@@ -412,10 +369,6 @@ def test_ogr_geojson_9():
 
 
 def test_ogr_geojson_10():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     gdaltest.tests = [
         ['gjpoint', [1], ['Point 1']],
         ['gjline', [1], ['Line 1']],
@@ -439,10 +392,6 @@ def test_ogr_geojson_10():
 
 
 def test_ogr_geojson_11():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/srs_name.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -474,10 +423,6 @@ def test_ogr_geojson_11():
 
 
 def test_ogr_geojson_12():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     if os.name == 'nt':
         pytest.skip()
 
@@ -494,10 +439,6 @@ def test_ogr_geojson_12():
 # Test writing to stdout (#3381)
 
 def test_ogr_geojson_13():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     test = ['gjpoint', [1], ['Point 1']]
 
     rc = copy_shape_to_geojson(test[0], '/vsistdout/')
@@ -508,10 +449,6 @@ def test_ogr_geojson_13():
 
 
 def test_ogr_geojson_14():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     if int(gdal.VersionInfo('VERSION_NUM')) < 1800:
         pytest.skip()
 
@@ -519,7 +456,7 @@ def test_ogr_geojson_14():
         ds = ogr.Open('data/ogr_geojson_14.geojson')
     lyr = ds.GetLayer(0)
 
-    out_ds = gdaltest.geojson_drv.CreateDataSource('tmp/out_ogr_geojson_14.geojson')
+    out_ds = ogrtest.geojson_drv.CreateDataSource('tmp/out_ogr_geojson_14.geojson')
     out_lyr = out_ds.CreateLayer('lyr')
 
     with gdaltest.error_handler():
@@ -575,10 +512,6 @@ def test_ogr_geojson_15():
 
 
 def test_ogr_geojson_16():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esripoint.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -627,10 +560,6 @@ def test_ogr_geojson_16():
 
 
 def test_ogr_geojson_17():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrilinestring.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -680,10 +609,6 @@ def test_ogr_geojson_17():
 
 
 def test_ogr_geojson_18():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esripolygon.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -721,10 +646,6 @@ def test_ogr_geojson_18():
 
 
 def test_ogr_geojson_19():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrimultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -751,10 +672,6 @@ def test_ogr_geojson_19():
 
 
 def test_ogr_geojson_20():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     from glob import glob
 
     geojson_files = glob('data/*.json')
@@ -785,10 +702,6 @@ def test_ogr_geojson_20():
 
 
 def test_ogr_geojson_21():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature",
  "geometry": {"type":"Point","coordinates":[1,2]},
@@ -815,10 +728,6 @@ def test_ogr_geojson_21():
 
 
 def test_ogr_geojson_22():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature",
  "geometry": {"type":"Point","coordinates":[1,2]},
@@ -859,11 +768,7 @@ def test_ogr_geojson_22():
 
 
 def test_ogr_geojson_23():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_23.json')
+    ds = ogrtest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_23.json')
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(4322)
     lyr = ds.CreateLayer('foo', srs=sr, options=['WRITE_BBOX=YES'])
@@ -900,10 +805,6 @@ def test_ogr_geojson_23():
 
 
 def test_ogr_geojson_24():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     content = """loadGeoJSON({"layerFoo": { "type": "Feature",
   "geometry": {
     "type": "Point",
@@ -957,10 +858,6 @@ def test_ogr_geojson_24():
 
 
 def test_ogr_geojson_25():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/topojson1.topojson')
     lyr = ds.GetLayer(0)
     assert lyr.GetName() == 'a_layer'
@@ -1044,10 +941,6 @@ def test_ogr_geojson_25():
 
 
 def test_ogr_geojson_26():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature", "id": 1,
  "geometry": {"type":"Point","coordinates":[1,2]},
@@ -1086,7 +979,7 @@ def test_ogr_geojson_26():
     lyr = None
     ds = None
 
-    ds = gdaltest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_26.json')
+    ds = ogrtest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_26.json')
     lyr = ds.CreateLayer('test')
     lyr.CreateField(ogr.FieldDefn('int64', ogr.OFTInteger64))
     lyr.CreateField(ogr.FieldDefn('int64list', ogr.OFTInteger64List))
@@ -1111,10 +1004,6 @@ def test_ogr_geojson_26():
 
 
 def test_ogr_geojson_27():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     # Warning 1: Integer values probably ranging out of 64bit integer range
     # have been found. Will be clamped to INT64_MIN/INT64_MAX
@@ -1149,10 +1038,6 @@ def test_ogr_geojson_27():
 
 
 def test_ogr_geojson_28():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrizpoint.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -1201,10 +1086,6 @@ def test_ogr_geojson_28():
 
 
 def test_ogr_geojson_29():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrizlinestring.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -1232,10 +1113,6 @@ def test_ogr_geojson_29():
 
 
 def test_ogr_geojson_30():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrizmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -1263,10 +1140,6 @@ def test_ogr_geojson_30():
 
 
 def test_ogr_geojson_31():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrizpolygon.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -1294,10 +1167,6 @@ def test_ogr_geojson_31():
 
 
 def test_ogr_geojson_32():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrihasmnozmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -1324,10 +1193,6 @@ def test_ogr_geojson_32():
 
 
 def test_ogr_geojson_33():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esriinvalidhaszmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -1354,10 +1219,6 @@ def test_ogr_geojson_33():
 
 
 def test_ogr_geojson_34():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/esrizmmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
@@ -1384,11 +1245,7 @@ def test_ogr_geojson_34():
 
 
 def test_ogr_geojson_35():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_35.json')
+    ds = ogrtest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_35.json')
     lyr = ds.CreateLayer('foo')
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetFID(1)
@@ -1481,10 +1338,6 @@ def test_ogr_geojson_35():
 
 
 def test_ogr_geojson_36():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/point_with_utf8bom.json')
     assert ds is not None, 'Failed to open datasource'
     ds = None
@@ -1494,10 +1347,6 @@ def test_ogr_geojson_36():
 
 
 def test_ogr_geojson_37():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # Test read support
     ds = ogr.Open("""{"type": "FeatureCollection","features": [
 { "type": "Feature", "properties": { "bool" : false, "not_bool": false, "bool_list" : [false, true], "notbool_list" : [false, 3]}, "geometry": null  },
@@ -1538,10 +1387,6 @@ def test_ogr_geojson_37():
 
 
 def test_ogr_geojson_38():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # Test read support
     ds = gdal.OpenEx("""{"type": "FeatureCollection", "features": [
 { "type": "Feature", "properties": { "dt": "2014-11-20 12:34:56+0100", "dt2": "2014\/11\/20", "date":"2014\/11\/20", "time":"12:34:56", "no_dt": "2014-11-20 12:34:56+0100", "no_dt2": "2014-11-20 12:34:56+0100" }, "geometry": null },
@@ -1582,10 +1427,6 @@ def test_ogr_geojson_38():
 
 
 def test_ogr_geojson_39():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features": [
 { "type": "Feature", "id" : "foo", "properties": { "bar" : "baz" }, "geometry": null },
 ] }""")
@@ -1741,10 +1582,6 @@ def test_ogr_geojson_39():
 
 
 def test_ogr_geojson_40():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx("""{
   "type": "FeatureCollection",
   "features" :
@@ -1793,10 +1630,6 @@ def test_ogr_geojson_40():
 
 
 def test_ogr_geojson_41():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # Check that by default we return a WGS 84 SRS
     g = ogr.CreateGeometryFromJson("{ 'type': 'Point', 'coordinates' : [ 2, 49] }")
     assert g.ExportToWkt() == 'POINT (2 49)'
@@ -1820,10 +1653,6 @@ def test_ogr_geojson_41():
 
 
 def test_ogr_geojson_42():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('CPL_CURL_ENABLE_VSIMEM', 'YES')
 
     resultOffset0 = """
@@ -1996,9 +1825,6 @@ def test_ogr_geojson_42():
 
 
 def test_ogr_geojson_43():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature", "properties": {"foo": "bar"}}]}""")
     assert ds is not None, 'Failed to open datasource'
@@ -2018,9 +1844,6 @@ def test_ogr_geojson_43():
 
 
 def test_ogr_geojson_44():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     with gdaltest.error_handler():
         ogr.Open("""{"type": "FeatureCollection", "features":[ null ]}""")
 
@@ -2030,9 +1853,6 @@ def test_ogr_geojson_44():
 
 
 def test_ogr_geojson_45():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # Test read support
     content = """{"type": "FeatureCollection", "foo": "bar", "bar": "baz",
     "features":[ { "type": "Feature", "foo": ["bar", "baz", 1.0, true, false,[],{}], "properties": { "myprop": "myvalue" }, "geometry": null } ]}"""
@@ -2153,9 +1973,6 @@ def test_ogr_geojson_45():
 
 
 def test_ogr_geojson_46():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_46.json')
     lyr = ds.CreateLayer('test')
     lyr.CreateField(ogr.FieldDefn('myprop'))
@@ -2177,9 +1994,6 @@ def test_ogr_geojson_46():
 
 
 def test_ogr_geojson_47():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # ERROR 6: Update from inline definition not supported
     with gdaltest.error_handler():
         ds = ogr.Open('{"type": "FeatureCollection", "features":[]}', update=1)
@@ -2332,9 +2146,6 @@ def test_ogr_geojson_47():
 
 
 def test_ogr_geojson_48():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/ogr_geojson_48.json',
                            """{ "type": "Feature", "bar": "baz", "bbox": [2,49,2,49], "properties": { "myprop": "myvalue" }, "geometry": {"type": "Point", "coordinates": [ 2, 49]} }""")
 
@@ -2368,9 +2179,6 @@ def test_ogr_geojson_48():
 
 
 def test_ogr_geojson_49():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/ogr_geojson_49.json',
                            """{ "type": "Feature", "properties": { "foo": ["bar"] }, "geometry": null }""")
 
@@ -2391,9 +2199,6 @@ def test_ogr_geojson_49():
 
 
 def test_ogr_geojson_50():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_50.json')
     lyr = ds.CreateLayer('test')
     lyr.CreateField(ogr.FieldDefn('val', ogr.OFTReal))
@@ -2459,9 +2264,6 @@ def test_ogr_geojson_50():
 
 
 def test_ogr_geojson_51():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_51.json')
     lyr = ds.CreateLayer('test')
     lyr.CreateField(ogr.FieldDefn('id', ogr.OFTInteger))
@@ -2521,9 +2323,6 @@ def test_ogr_geojson_51():
 
 
 def test_ogr_geojson_52():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/nullvalues.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -2547,9 +2346,6 @@ def test_ogr_geojson_52():
 
 
 def test_ogr_geojson_53():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_53.json')
     lyr = ds.CreateLayer('test')
     f = ogr.Feature(lyr.GetLayerDefn())
@@ -2570,9 +2366,6 @@ def test_ogr_geojson_53():
 
 
 def test_ogr_geojson_54():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{
    "type": "FeatureCollection",
 
@@ -2613,9 +2406,6 @@ def read_file(filename):
 
 
 def test_ogr_geojson_55():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # Basic test for standard bbox and coordinate truncation
     gdal.VectorTranslate('/vsimem/out.json', """{
    "type": "FeatureCollection",
@@ -2715,8 +2505,6 @@ def test_ogr_geojson_55():
 
 
 def test_ogr_geojson_56():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
     if not ogrtest.have_geos():
         pytest.skip()
 
@@ -2783,8 +2571,6 @@ def test_ogr_geojson_56():
 
 
 def test_ogr_geojson_57():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
     if not ogrtest.have_geos():
         pytest.skip()
 
@@ -3002,9 +2788,6 @@ def test_ogr_geojson_57():
 
 
 def test_ogr_geojson_58():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('{ "type": "FeatureCollection", "name": "layer_name", "features": []}')
     assert ds is not None, 'Failed to open datasource'
 
@@ -3025,9 +2808,6 @@ def test_ogr_geojson_58():
 
 
 def test_ogr_geojson_59():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('{ "type": "FeatureCollection", "description": "my_description", "features": []}')
     assert ds is not None, 'Failed to open datasource'
 
@@ -3050,9 +2830,6 @@ def test_ogr_geojson_59():
 
 
 def test_ogr_geojson_60():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx("""{ "type": "FeatureCollection", "features": [
 { "type": "Feature", "properties" : { "foo" : "bar" } },
 { "type": "Feature", "properties" : { "foo": null } },
@@ -3688,9 +3465,6 @@ def test_ogr_geojson_single_feature_random_reading_with_id():
 
 def test_ogr_geojson_3D_geom_type():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature", "geometry": {"type":"Point","coordinates":[1,2,3]}, "properties": null},
 {"type": "Feature", "geometry": {"type":"Point","coordinates":[1,2,4]}, "properties": null}
@@ -3715,9 +3489,6 @@ def test_ogr_geojson_3D_geom_type():
 ###############################################################################
 
 def test_ogr_geojson_update_in_loop():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     tmpfilename = '/vsimem/temp.json'
 

--- a/autotest/ogr/ogr_gmt.py
+++ b/autotest/ogr/ogr_gmt.py
@@ -29,11 +29,29 @@
 ###############################################################################
 
 
-
 import gdaltest
 import ogrtest
 from osgeo import gdal
 from osgeo import ogr
+
+import pytest
+
+
+pytestmark = pytest.mark.require_ogr_driver('GMT')
+
+
+@pytest.fixture(autouse=True, scope='module')
+def ogr_gmt_cleanup():
+    gdaltest.gmt_ds = None
+    gdaltest.gmt_lyr = None
+
+    yield
+
+    gdaltest.gmt_lyr = None
+    gdaltest.gmt_ds = None
+
+    gdaltest.clean_tmp()
+
 
 ###############################################################################
 # Open Memory datasource.
@@ -221,17 +239,3 @@ def test_ogr_gmt_coord_only():
         lyr = ds.GetLayer(0)
         f = lyr.GetNextFeature()
         assert not ogrtest.check_feature_geometry(f, 'POINT Z (1 2 3)'), f.GetGeometryRef().ExportToIsoWkt()
-
-###############################################################################
-#
-
-def test_ogr_gmt_cleanup():
-
-    if gdaltest.gmt_ds is not None:
-        gdaltest.gmt_lyr = None
-        gdaltest.gmt_ds = None
-
-    gdaltest.clean_tmp()
-
-
-

--- a/autotest/ogr/ogr_grass.py
+++ b/autotest/ogr/ogr_grass.py
@@ -31,29 +31,17 @@
 from osgeo import ogr
 
 
-import gdaltest
 import pytest
 
 
-###############################################################################
-# Test if GRASS driver is present
+pytestmark = pytest.mark.require_ogr_driver('GRASS')
 
-def test_ogr_grass_1():
 
-    gdaltest.ogr_grass_drv = ogr.GetDriverByName('GRASS')
-    if gdaltest.ogr_grass_drv is None:
-        pytest.skip()
-
-    
 ###############################################################################
 # Read 'point' datasource
 
 
 def test_ogr_grass_2():
-
-    if gdaltest.ogr_grass_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('./data/PERMANENT/vector/point/head')
     assert ds is not None, 'Cannot open datasource'
 
@@ -66,7 +54,3 @@ def test_ogr_grass_2():
     assert feat.GetFieldAsString('name') == 'my point'
 
     ds = None
-
-
-
-

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -37,6 +37,7 @@ from osgeo import ogr
 from osgeo import gdal
 import pytest
 
+
 ###############################################################################
 # Open Memory datasource.
 

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -42,14 +42,19 @@ from osgeo import gdal
 import test_cli_utilities
 import pytest
 
+
+pytestmark = pytest.mark.require_ogr_driver('MapInfo File')
+
+
+from .ogr_gml_read import gml_ds  # noqa
+
+
 ###############################################################################
 # Create TAB file.
 
 
 def test_ogr_mitab_1():
-
-    gdaltest.mapinfo_drv = ogr.GetDriverByName('MapInfo File')
-    gdaltest.mapinfo_ds = gdaltest.mapinfo_drv.CreateDataSource('tmp')
+    gdaltest.mapinfo_ds = ogrtest.mapinfo_file_drv.CreateDataSource('tmp')
 
     if gdaltest.mapinfo_ds is not None:
         return
@@ -60,7 +65,6 @@ def test_ogr_mitab_1():
 
 
 def test_ogr_mitab_2():
-
     if gdaltest.mapinfo_ds is None:
         pytest.skip()
 
@@ -114,9 +118,6 @@ def test_ogr_mitab_2():
 
 
 def test_ogr_mitab_3():
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     gdaltest.mapinfo_ds = ogr.Open('tmp')
     gdaltest.mapinfo_lyr = gdaltest.mapinfo_ds.GetLayer(0)
 
@@ -150,7 +151,6 @@ def test_ogr_mitab_3():
 
 
 def test_ogr_mitab_4():
-
     if gdaltest.mapinfo_ds is None:
         pytest.skip()
 
@@ -173,7 +173,6 @@ def test_ogr_mitab_4():
 
 
 def test_ogr_mitab_5():
-
     if gdaltest.mapinfo_ds is None:
         pytest.skip()
 
@@ -194,10 +193,6 @@ def test_ogr_mitab_5():
 
 
 def test_ogr_mitab_6():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     srs = gdaltest.mapinfo_lyr.GetSpatialRef()
     datum_name = srs.GetAttrValue('PROJCS|GEOGCS|DATUM')
 
@@ -209,22 +204,19 @@ def test_ogr_mitab_6():
 
 
 def test_ogr_mitab_7():
-
     gdaltest.mapinfo_ds = None
-    gdaltest.mapinfo_drv.DeleteDataSource('tmp')
+    ogrtest.mapinfo_file_drv.DeleteDataSource('tmp')
 
-    gdaltest.mapinfo_ds = gdaltest.mapinfo_drv.CreateDataSource('tmp/wrk.mif')
+    gdaltest.mapinfo_ds = ogrtest.mapinfo_file_drv.CreateDataSource('tmp/wrk.mif')
 
-    if gdaltest.mapinfo_ds is not None:
-        return
-    pytest.fail()
+    if gdaltest.mapinfo_ds is None:
+        pytest.fail()
 
 ###############################################################################
 # Create table from data/poly.shp
 
 
 def test_ogr_mitab_8():
-
     if gdaltest.mapinfo_ds is None:
         pytest.skip()
 
@@ -270,9 +262,6 @@ def test_ogr_mitab_8():
 
 
 def test_ogr_mitab_9():
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     gdaltest.mapinfo_ds = ogr.Open('tmp')
     gdaltest.mapinfo_lyr = gdaltest.mapinfo_ds.GetLayer(0)
 
@@ -304,9 +293,6 @@ def test_ogr_mitab_9():
 
 
 def test_ogr_mitab_10():
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/small.mif')
     lyr = ds.GetLayer(0)
 
@@ -336,10 +322,6 @@ def test_ogr_mitab_10():
 
 
 def test_ogr_mitab_11():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/small_ntf.mif')
     srs = ds.GetLayer(0).GetSpatialRef()
     ds = None
@@ -353,11 +335,7 @@ def test_ogr_mitab_11():
 
 
 def test_ogr_mitab_12():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
-    ds = gdaltest.mapinfo_drv.CreateDataSource('tmp', options=['FORMAT=MIF'])
+    ds = ogrtest.mapinfo_file_drv.CreateDataSource('tmp', options=['FORMAT=MIF'])
     lyr = ds.CreateLayer('testlyrdef')
     defn = lyr.GetLayerDefn()
 
@@ -371,14 +349,8 @@ def test_ogr_mitab_12():
 # Verify that field widths and precisions are propagated correctly in TAB.
 
 
+@pytest.mark.usefixtures('gml_ds')
 def test_ogr_mitab_13():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
-    import ogr_gml_read
-    ogr_gml_read.test_ogr_gml_1()
-
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip()
 
@@ -416,14 +388,8 @@ def test_ogr_mitab_13():
 # Verify that field widths and precisions are propagated correctly in MIF.
 
 
+@pytest.mark.usefixtures('gml_ds')
 def test_ogr_mitab_14():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
-    import ogr_gml_read
-    ogr_gml_read.test_ogr_gml_1()
-
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip()
 
@@ -465,10 +431,6 @@ def test_ogr_mitab_14():
 
 
 def test_ogr_mitab_15():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/nomid.mif')
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
@@ -499,10 +461,6 @@ def test_ogr_mitab_15():
 
 
 def test_ogr_mitab_16():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource('tmp/empty.mif')
     lyr = ds.CreateLayer('empty')
     lyr.CreateField(ogr.FieldDefn('ID', ogr.OFTInteger))
@@ -516,14 +474,8 @@ def test_ogr_mitab_16():
 # Run test_ogrsf
 
 
+@pytest.mark.usefixtures('gml_ds')
 def test_ogr_mitab_17():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
-    import ogr_gml_read
-    ogr_gml_read.test_ogr_gml_1()
-
     if test_cli_utilities.get_test_ogrsf_path() is None:
         pytest.skip()
 
@@ -539,10 +491,6 @@ def test_ogr_mitab_17():
 
 
 def test_ogr_mitab_18():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource('/vsimem/ogr_mitab_18.tab')
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(2154)
@@ -571,10 +519,6 @@ def test_ogr_mitab_18():
 
 
 def test_ogr_mitab_19():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/utm31.TAB')
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
@@ -591,10 +535,6 @@ def test_ogr_mitab_19():
 # Also test BOUNDS layer creation option (http://trac.osgeo.org/gdal/ticket/5642)
 
 def test_ogr_mitab_20():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     # Pass i==0: without MITAB_BOUNDS_FILE
     # Pass i==1: with MITAB_BOUNDS_FILE and French bounds : first load
     # Pass i==2: with MITAB_BOUNDS_FILE and French bounds : should use already loaded file
@@ -727,10 +667,6 @@ Destination=CoordSys Earth Projection 3, 33, "m", 3, 46.5, 44, 49.00000000002, 7
 
 
 def test_ogr_mitab_21():
-
-    if gdaltest.mapinfo_drv is None:
-        pytest.skip()
-
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource('/vsimem/ogr_mitab_21.tab')
     lyr = ds.CreateLayer('test')
     feat = ogr.Feature(lyr.GetLayerDefn())
@@ -755,7 +691,6 @@ def test_ogr_mitab_21():
 
 
 def test_ogr_mitab_22():
-
     filename = '/vsimem/ogr_mitab_22.tab'
     for nb_features in (2, 1000):
         if nb_features == 2:
@@ -804,7 +739,6 @@ def test_ogr_mitab_22():
 
 
 def test_ogr_mitab_23():
-
     filename = '/vsimem/ogr_mitab_23.tab'
 
     for nb_features in (0, 1, 2, 100, 1000):
@@ -833,7 +767,6 @@ def test_ogr_mitab_23():
 
 
 def test_ogr_mitab_24():
-
     filename = '/vsimem/ogr_mitab_24.tab'
 
     for nb_features in (2, 100, 1000):
@@ -877,7 +810,6 @@ def test_ogr_mitab_24():
 
 
 def test_ogr_mitab_25():
-
     filename = 'tmp/ogr_mitab_25.tab'
 
     for nb_features in (2, 1000):
@@ -940,7 +872,6 @@ def test_ogr_mitab_25():
 
 
 def test_ogr_mitab_26():
-
     filename = '/vsimem/ogr_mitab_26.tab'
 
     for nb_features in (2, 1000):
@@ -1009,7 +940,6 @@ def test_ogr_mitab_26():
 
 
 def test_ogr_mitab_27():
-
     filename = '/vsimem/ogr_mitab_27.tab'
 
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource(filename)
@@ -1155,7 +1085,6 @@ def generate_permutation(n):
 
 
 def test_ogr_mitab_28():
-
     filename = '/vsimem/ogr_mitab_28.tab'
 
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource(filename)
@@ -1369,7 +1298,6 @@ def test_ogr_mitab_31():
 
 
 def test_ogr_mitab_32():
-
     for update in (0, 1):
         ds = ogr.Open('data/aspatial-table.tab', update=update)
         lyr = ds.GetLayer(0)
@@ -1387,7 +1315,6 @@ def test_ogr_mitab_32():
 
 
 def test_ogr_mitab_33():
-
     for update in (0, 1):
         ds = ogr.Open('data/single_point_mapinfo.tab', update=update)
         lyr = ds.GetLayer(0)
@@ -1448,7 +1375,6 @@ def test_ogr_mitab_33():
 
 
 def test_ogr_mitab_34():
-
     filename = '/vsimem/ogr_mitab_34.tab'
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource(filename)
     lyr = ds.CreateLayer('ogr_mitab_34', options=['BOUNDS=-1000,0,1000,3000'])
@@ -1545,7 +1471,6 @@ def get_coordsys_from_srs(srs):
 
 
 def test_ogr_mitab_35():
-
     # Local/non-earth
     srs = osr.SpatialReference()
     coordsys = get_coordsys_from_srs(srs)
@@ -1696,7 +1621,6 @@ def test_ogr_mitab_35():
 
 
 def test_ogr_mitab_36():
-
     # Test modifying a new object
     shutil.copy('data/polygon_without_index.tab', 'tmp')
     shutil.copy('data/polygon_without_index.dat', 'tmp')
@@ -1735,7 +1659,6 @@ def test_ogr_mitab_36():
 
 
 def test_ogr_mitab_37():
-
     ds = ogr.Open('data/seamless.tab')
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 4
@@ -1769,7 +1692,6 @@ def test_ogr_mitab_37():
 
 
 def test_ogr_mitab_38():
-
     ds = ogr.Open('data/empty_first_field_with_tab_delimiter.mif')
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
@@ -1783,7 +1705,6 @@ def test_ogr_mitab_38():
 
 
 def test_ogr_mitab_39():
-
     ds = ogr.Open('data/all_geoms.mif')
     lyr = ds.GetLayer(0)
     ds_ref = ogr.Open('data/all_geoms.mif.golden.csv')
@@ -1807,7 +1728,6 @@ def test_ogr_mitab_39():
 
 
 def test_ogr_mitab_40():
-
     content = open('data/all_geoms.mif', 'rt').read()
 
     for i in range(len(content)):
@@ -1826,7 +1746,6 @@ def test_ogr_mitab_40():
 
 
 def test_ogr_mitab_41():
-
     ds = ogr.Open('data/all_geoms.tab')
     lyr = ds.GetLayer(0)
     ds_ref = ogr.Open('data/all_geoms.mif.golden.csv')
@@ -1850,7 +1769,6 @@ def test_ogr_mitab_41():
 
 
 def test_ogr_mitab_42():
-
     ds = ogr.Open('/vsizip/data/all_geoms_block_32256.zip')
     lyr = ds.GetLayer(0)
     ds_ref = ogr.Open('data/all_geoms.mif.golden.csv')
@@ -1874,7 +1792,6 @@ def test_ogr_mitab_42():
 
 
 def test_ogr_mitab_43():
-
     src_ds = gdal.OpenEx('/vsizip/data/all_geoms_block_32256.zip')
     gdal.VectorTranslate('/vsimem/all_geoms_block_512.tab', src_ds, format='MapInfo File')
     gdal.VectorTranslate('/vsimem/all_geoms_block_32256.tab', src_ds, format='MapInfo File', datasetCreationOptions=['BLOCKSIZE=32256'])
@@ -1907,8 +1824,8 @@ def test_ogr_mitab_43():
             f_ref.DumpReadable()
             pytest.fail()
 
-    gdaltest.mapinfo_drv.DeleteDataSource('/vsimem/all_geoms_block_512.tab')
-    gdaltest.mapinfo_drv.DeleteDataSource('/vsimem/all_geoms_block_32256.tab')
+    ogrtest.mapinfo_file_drv.DeleteDataSource('/vsimem/all_geoms_block_512.tab')
+    ogrtest.mapinfo_file_drv.DeleteDataSource('/vsimem/all_geoms_block_32256.tab')
     gdal.Unlink('/vsimem/all_geoms_block_32768.dat')
 
 ###############################################################################
@@ -1916,8 +1833,7 @@ def test_ogr_mitab_43():
 
 
 def test_ogr_mitab_44():
-
-    ds = gdaltest.mapinfo_drv.CreateDataSource('/vsimem/ogr_mitab_44.mif')
+    ds = ogrtest.mapinfo_file_drv.CreateDataSource('/vsimem/ogr_mitab_44.mif')
     lyr = ds.CreateLayer('test')
     fld_defn = ogr.FieldDefn('test', ogr.OFTReal)
     fld_defn.SetWidth(30)
@@ -1931,14 +1847,13 @@ def test_ogr_mitab_44():
     assert fld_defn.GetWidth() == 20 and fld_defn.GetPrecision() == 16
     ds = None
 
-    gdaltest.mapinfo_drv.DeleteDataSource('/vsimem/ogr_mitab_44.mif')
+    ogrtest.mapinfo_file_drv.DeleteDataSource('/vsimem/ogr_mitab_44.mif')
 
 ###############################################################################
 # Test read/write MapInfo layers with encoding specified
 
 
 def test_ogr_mitab_45():
-
     lyrNames = ['lyr1', 'lyr2']
     #                     0         1         2         3
     #                     012345678901234567890123456789012
@@ -1955,7 +1870,7 @@ def test_ogr_mitab_45():
         ext = dsExts[formatN]
         dsName = '/vsimem/45/ogr_mitab_45_%s_%s%s' % (frmt, lyrCount, ext)
 
-        ds = gdaltest.mapinfo_drv.CreateDataSource(dsName, options=['FORMAT=' + frmt])
+        ds = ogrtest.mapinfo_file_drv.CreateDataSource(dsName, options=['FORMAT=' + frmt])
 
         assert ds is not None, ('Can\'t create dataset: ' + dsName)
 
@@ -2019,7 +1934,7 @@ def test_ogr_mitab_45():
                                              ' from layer : ' + lyrNames[i] +
                                              ' from dataset :' + dsName)
 
-        gdaltest.mapinfo_drv.DeleteDataSource(dsName)
+        ogrtest.mapinfo_file_drv.DeleteDataSource(dsName)
 
     
 ###############################################################################
@@ -2027,7 +1942,6 @@ def test_ogr_mitab_45():
 
 
 def test_ogr_mitab_46():
-
     dsNames = ['data/mitab/tab-win1251.TAB',
                'data/mitab/win1251.mif']
     fldNames = ['Поле_А', 'Поле_Б', 'Поле_В', 'Поле_Г', 'Поле_Д']
@@ -2076,7 +1990,6 @@ def test_ogr_mitab_46():
 
 
 def test_ogr_mitab_47():
-
     ds = ogr.Open('data/poly_indexed.tab')
     lyr = ds.GetLayer(0)
     lyr.SetAttributeFilter("PRFEDEA = '35043413'")
@@ -2099,7 +2012,6 @@ def test_ogr_mitab_47():
 
 
 def test_ogr_mitab_48():
-
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource('/vsimem/test.mif')
     sr = osr.SpatialReference()
     sr.SetFromUserInput("""PROJCS["NTF (Paris) / France IV (deprecated)",
@@ -2158,7 +2070,6 @@ def test_ogr_mitab_48():
 
 
 def test_ogr_mitab_49_aspatial():
-
     ds = ogr.GetDriverByName('MapInfo File').Open('data/mitab/aspatial.tab')
     lyr = ds.GetLayer(0)
 
@@ -2174,7 +2085,6 @@ def test_ogr_mitab_49_aspatial():
 
 
 def test_ogr_mitab_tab_field_index_creation():
-
     layername = 'ogr_mitab_tab_field_index_creation'
     filename = '/vsimem/' + layername + '.tab'
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource(filename)
@@ -2211,7 +2121,6 @@ def test_ogr_mitab_tab_field_index_creation():
 
 
 def test_ogr_mitab_tab_view():
-
     ds = ogr.Open('data/mitab/view_first_table_second_table.tab')
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetFieldCount() == 2, 'bad field count'
@@ -2235,7 +2144,6 @@ def test_ogr_mitab_tab_view():
 
 
 def test_ogr_mitab_style():
-
     tmpfile = '/vsimem/ogr_mitab_style.tab'
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource(tmpfile)
     lyr = ds.CreateLayer('test')
@@ -2276,7 +2184,6 @@ def test_ogr_mitab_style():
 
 
 def test_ogr_mitab_tab_write_field_name_with_dot():
-
     tmpfile = '/vsimem/ogr_mitab_tab_write_field_name_with_dot.tab'
     ds = ogr.GetDriverByName('MapInfo File').CreateDataSource(tmpfile)
     lyr = ds.CreateLayer('test')
@@ -2302,7 +2209,6 @@ def test_ogr_mitab_tab_write_field_name_with_dot():
 
 
 def test_ogr_mitab_local_encoding_label():
-
     dsNames = ['data/mitab/win1251_text.mif',
                'data/mitab/tab-win1251_text.tab']
     expectedStyles = ['LABEL(t:"Поле",a:0.000000,s:2.070000g,c:#ff0000,p:2,f:"DejaVu Serif")',
@@ -2321,7 +2227,7 @@ def test_ogr_mitab_local_encoding_label():
         feat = lyr.GetNextFeature()
         assert lyr is not None, ('Can\'t find text feature in' + dsName)
 
-        assert feat.GetStyleString() == expectedStyle, (feat.GetStyleString(), expectedStyle)
+        assert feat.GetStyleString() == expectedStyle
 
 
 ###############################################################################
@@ -2408,7 +2314,6 @@ def test_ogr_mitab_custom_datum_export():
 
 
 def test_ogr_mitab_cleanup():
-
     if gdaltest.mapinfo_ds is None:
         pytest.skip()
 
@@ -2417,6 +2322,4 @@ def test_ogr_mitab_cleanup():
         print(fl)
 
     gdaltest.mapinfo_ds = None
-    gdaltest.mapinfo_drv.DeleteDataSource('tmp')
-
-
+    ogrtest.mapinfo_file_drv.DeleteDataSource('tmp')

--- a/autotest/ogr/ogr_oapif.py
+++ b/autotest/ogr/ogr_oapif.py
@@ -41,28 +41,23 @@ import pytest
 #
 
 
-def test_ogr_opaif_init():
+pytestmark = pytest.mark.require_ogr_driver('OAPIF')
 
-    gdaltest.opaif_drv = ogr.GetDriverByName('OAPIF')
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
 
-    (gdaltest.webserver_process, gdaltest.webserver_port) = \
+@pytest.fixture(autouse=True, scope='module')
+def ogr_opaif_init():
+    (webserver_process, gdaltest.webserver_port) = \
         webserver.launch(handler=webserver.DispatcherHttpHandler)
     if gdaltest.webserver_port == 0:
         pytest.skip()
+    yield
+    webserver.server_stop(webserver_process, gdaltest.webserver_port)
 
     
 ###############################################################################
 
 
 def test_ogr_opaif_errors():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 404)
     with webserver.install_http_handler(handler):
@@ -127,12 +122,6 @@ def test_ogr_opaif_errors():
 
 
 def test_ogr_opaif_collections_paging():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200,
                 {'Content-Type': 'application/json'},
@@ -152,12 +141,6 @@ def test_ogr_opaif_collections_paging():
 
 
 def test_ogr_opaif_empty_layer_and_user_query_parameters():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections?FOO=BAR', 200,
                 {'Content-Type': 'application/json'},
@@ -181,12 +164,6 @@ def test_ogr_opaif_empty_layer_and_user_query_parameters():
 
 
 def test_ogr_opaif_open_by_collection_and_legacy_wfs3_prefix():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections/foo', 200,
                 {'Content-Type': 'application/json'},
@@ -210,12 +187,6 @@ def test_ogr_opaif_open_by_collection_and_legacy_wfs3_prefix():
 
 
 def test_ogr_opaif_fc_links_next_geojson():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200, {'Content-Type': 'application/json'},
                 '{ "collections" : [ { "name": "foo" }] }')
@@ -280,12 +251,6 @@ def test_ogr_opaif_fc_links_next_geojson():
 
 
 def test_ogr_opaif_id_is_integer():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200, {'Content-Type': 'application/json'},
                 '{ "collections" : [ { "name": "foo" }] }')
@@ -342,12 +307,6 @@ def test_ogr_opaif_id_is_integer():
 
 
 def NO_LONGER_USED_test_ogr_opaif_fc_links_next_headers():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200, {'Content-Type': 'application/json'},
                 '{ "collections" : [ { "name": "foo" }] }')
@@ -412,12 +371,6 @@ def NO_LONGER_USED_test_ogr_opaif_fc_links_next_headers():
 
 
 def test_ogr_opaif_spatial_filter():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     # Deprecated API
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200, {'Content-Type': 'application/json'},
@@ -566,12 +519,6 @@ def test_ogr_opaif_spatial_filter():
 
 
 def test_ogr_opaif_get_feature_count():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200, {'Content-Type': 'application/json'},
                 """{ "collections" : [ {
@@ -632,12 +579,6 @@ def test_ogr_opaif_get_feature_count():
 
 
 def test_ogr_opaif_get_feature_count_from_numberMatched():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200, {'Content-Type': 'application/json'},
                 """{ "collections" : [ {
@@ -661,12 +602,6 @@ def test_ogr_opaif_get_feature_count_from_numberMatched():
 
 
 def test_ogr_opaif_attribute_filter():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
     handler = webserver.SequentialHandler()
     handler.add('GET', '/oapif/collections', 200, {'Content-Type': 'application/json'},
                 """{ "collections" : [ {
@@ -877,16 +812,3 @@ def test_ogr_opaif_attribute_filter():
     assert f is not None
 
 ###############################################################################
-
-
-def test_ogr_opaif_cleanup():
-
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port != 0:
-        webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)
-
-    
-
-

--- a/autotest/ogr/ogr_plscenes.py
+++ b/autotest/ogr/ogr_plscenes.py
@@ -30,34 +30,21 @@
 ###############################################################################
 
 
-
 from osgeo import ogr
 from osgeo import gdal
 
 import gdaltest
 import pytest
 
-###############################################################################
-# Find PLScenes driver
 
+pytestmark = pytest.mark.require_driver('PLScenes')
 
-def test_ogr_plscenes_init():
-
-    gdaltest.plscenes_drv = ogr.GetDriverByName('PLScenes')
-
-    if gdaltest.plscenes_drv is not None:
-        return
-    pytest.skip()
 
 ###############################################################################
 # Test Data V1 API catalog listing with a single catalog
 
 
 def test_ogr_plscenes_data_v1_catalog_no_paging():
-
-    if gdaltest.plscenes_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/data_v1/item-types', '{ "item_types": [ { "id": "PSScene3Band" } ] }')
     gdal.SetConfigOption('PL_URL', '/vsimem/data_v1/')
     ds = gdal.OpenEx('PLScenes:', gdal.OF_VECTOR, open_options=['VERSION=data_v1', 'API_KEY=foo'])
@@ -77,10 +64,6 @@ def test_ogr_plscenes_data_v1_catalog_no_paging():
 
 
 def test_ogr_plscenes_data_v1_catalog_paging():
-
-    if gdaltest.plscenes_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/data_v1/item-types', '{"_links": { "_next" : "/vsimem/data_v1/item-types/page_2"}, "item_types": [ { "id": "PSScene3Band" } ] }')
     gdal.FileFromMemBuffer('/vsimem/data_v1/item-types/page_2', '{ "item_types": [ { "id": "PSScene4Band" } ] }')
     gdal.SetConfigOption('PL_URL', '/vsimem/data_v1/')
@@ -106,10 +89,6 @@ def test_ogr_plscenes_data_v1_catalog_paging():
 
 
 def test_ogr_plscenes_data_v1_nominal():
-
-    if gdaltest.plscenes_drv is None:
-        pytest.skip()
-
     gdal.FileFromMemBuffer('/vsimem/data_v1/item-types',
                            """{ "item_types": [
     {"display_description" : "display_description",
@@ -523,10 +502,6 @@ def test_ogr_plscenes_data_v1_nominal():
 
 
 def test_ogr_plscenes_data_v1_errors():
-
-    if gdaltest.plscenes_drv is None:
-        pytest.skip()
-
     # No PL_API_KEY
     gdal.SetConfigOption('PL_URL', '/vsimem/data_v1/')
     old_key = gdal.GetConfigOption('PL_API_KEY')
@@ -623,10 +598,6 @@ def test_ogr_plscenes_data_v1_errors():
 
 
 def test_ogr_plscenes_data_v1_live():
-
-    if gdaltest.plscenes_drv is None:
-        pytest.skip()
-
     api_key = gdal.GetConfigOption('PL_API_KEY')
     if api_key is None:
         pytest.skip('Skipping test as PL_API_KEY not defined')
@@ -703,6 +674,3 @@ def test_ogr_plscenes_data_v1_live():
     ds = gdal.Open('PLScenes:version=data_v1,itemtypes=%s,scene=%s,asset=%s' % (catalog, scene, asset_name))
     assert ds is not None
     assert ds.RasterCount != 0
-
-
-

--- a/autotest/ogr/ogr_selafin.py
+++ b/autotest/ogr/ogr_selafin.py
@@ -31,40 +31,36 @@
 import os
 import math
 
-
-import gdaltest
 from osgeo import ogr
 from osgeo import osr
 import pytest
 
-###############################################################################
-# Create wasp datasource
+pytestmark = pytest.mark.require_driver('Selafin')
 
 
-def test_ogr_selafin_create_ds():
+@pytest.fixture(autouse=True, scope='module')
+def selafin_cleanup():
+    yield
+    selafin_drv = ogr.GetDriverByName('Selafin')
+    selafin_drv.DeleteDataSource('tmp/tmp.slf')
 
-    gdaltest.selafin_ds = None
+
+def test_ogr_selafin_create_nodes():
+    # Create wasp datasource
+    selafin_ds = None
     try:
         os.remove('tmp/tmp.slf')
     except OSError:
         pass
     selafin_drv = ogr.GetDriverByName('Selafin')
 
-    gdaltest.selafin_ds = selafin_drv.CreateDataSource('tmp/tmp.slf')
+    selafin_ds = selafin_drv.CreateDataSource('tmp/tmp.slf')
+    assert selafin_ds is not None
 
-    if gdaltest.selafin_ds is not None:
-        return
-    pytest.fail()
-
-###############################################################################
-# Add a few points to the datasource
-
-
-def test_ogr_selafin_create_nodes():
-    test_ogr_selafin_create_ds()
+    # Add a few points to the datasource
     ref = osr.SpatialReference()
     ref.ImportFromEPSG(4326)
-    layer = gdaltest.selafin_ds.CreateLayer('name', ref, geom_type=ogr.wkbPoint)
+    layer = selafin_ds.CreateLayer('name', ref, geom_type=ogr.wkbPoint)
     assert layer is not None, 'unable to create layer'
     layer.CreateField(ogr.FieldDefn('value', ogr.OFTReal))
     dfn = layer.GetLayerDefn()
@@ -79,8 +75,8 @@ def test_ogr_selafin_create_nodes():
     # do some checks
     assert layer.GetFeatureCount() == 25, \
         'wrong number of features after point layer creation'
-    # return
-    del gdaltest.selafin_ds
+
+    del selafin_ds
     del layer
 
 ###############################################################################
@@ -88,19 +84,18 @@ def test_ogr_selafin_create_nodes():
 
 
 def test_ogr_selafin_create_elements():
-
-    gdaltest.selafin_ds = ogr.Open('tmp/tmp.slf', 1)
-    if gdaltest.selafin_ds is None:
+    selafin_ds = ogr.Open('tmp/tmp.slf', 1)
+    if selafin_ds is None:
         pytest.skip()
-    layerCount = gdaltest.selafin_ds.GetLayerCount()
+    layerCount = selafin_ds.GetLayerCount()
     assert layerCount >= 2, 'elements layer not created with nodes layer'
     for i in range(layerCount):
-        name = gdaltest.selafin_ds.GetLayer(i).GetName()
+        name = selafin_ds.GetLayer(i).GetName()
         if '_e' in name:
             j = i
         if '_p' in name:
             k = i
-    layere = gdaltest.selafin_ds.GetLayer(j)
+    layere = selafin_ds.GetLayer(j)
     dfn = layere.GetLayerDefn()
     for i in range(4):
         for j in range(4):
@@ -127,34 +122,32 @@ def test_ogr_selafin_create_elements():
     feat.SetGeometry(pol)
     assert layere.CreateFeature(feat) == 0, 'unable to create element feature'
     # do some checks
-    assert gdaltest.selafin_ds.GetLayer(k).GetFeatureCount() == 28, \
+    assert selafin_ds.GetLayer(k).GetFeatureCount() == 28, \
         'wrong number of point features after elements layer creation'
     assert math.fabs(layere.GetFeature(5).GetFieldAsDouble(0) - 9) <= 0.01, \
         'wrong value of attribute in element layer'
     assert math.fabs(layere.GetFeature(10).GetFieldAsDouble(0) - 15) <= 0.01, \
         'wrong value of attribute in element layer'
-    # return
-    del gdaltest.selafin_ds
+    del selafin_ds
 
 ###############################################################################
 # Add a field and set its values for point features
 
 
 def test_ogr_selafin_set_field():
-
-    gdaltest.selafin_ds = ogr.Open('tmp/tmp.slf', 1)
-    if gdaltest.selafin_ds is None:
+    selafin_ds = ogr.Open('tmp/tmp.slf', 1)
+    if selafin_ds is None:
         pytest.skip()
-    layerCount = gdaltest.selafin_ds.GetLayerCount()
+    layerCount = selafin_ds.GetLayerCount()
     assert layerCount >= 2, 'elements layer not created with nodes layer'
     for i in range(layerCount):
-        name = gdaltest.selafin_ds.GetLayer(i).GetName()
+        name = selafin_ds.GetLayer(i).GetName()
         if '_e' in name:
             j = i
         if '_p' in name:
             k = i
-    layern = gdaltest.selafin_ds.GetLayer(k)
-    gdaltest.selafin_ds.GetLayer(j)
+    layern = selafin_ds.GetLayer(k)
+    selafin_ds.GetLayer(j)
     layern.CreateField(ogr.FieldDefn('reverse', ogr.OFTReal))
     layern.AlterFieldDefn(0, ogr.FieldDefn('new', ogr.OFTReal), ogr.ALTER_NAME_FLAG)
     layern.ReorderFields([1, 0])
@@ -167,17 +160,4 @@ def test_ogr_selafin_set_field():
     # do some checks
     assert math.fabs(layern.GetFeature(11).GetFieldAsDouble(0) - 110) <= 0.01, \
         'wrong value of attribute in point layer'
-    # return
-    del gdaltest.selafin_ds
-
-
-###############################################################################
-# Cleanup
-
-def test_ogr_selafin_cleanup():
-
-    selafin_drv = ogr.GetDriverByName('Selafin')
-    selafin_drv.DeleteDataSource('tmp/tmp.slf')
-
-
-
+    del selafin_ds

--- a/autotest/ogr/ogr_vfk.py
+++ b/autotest/ogr/ogr_vfk.py
@@ -38,17 +38,15 @@ from osgeo import gdal
 from osgeo import ogr
 import pytest
 
+
+pytestmark = pytest.mark.require_driver('VFK')
+
 ###############################################################################
 # Open file, check number of layers, get first layer,
 # check number of fields and features
 
 
 def test_ogr_vfk_1():
-
-    gdaltest.vfk_drv = ogr.GetDriverByName('VFK')
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdal.SetConfigOption('OGR_VFK_DB_OVERWRITE', 'YES')
 
     gdaltest.vfk_ds = ogr.Open('data/bylany.vfk')
@@ -76,10 +74,6 @@ def test_ogr_vfk_1():
 
 
 def test_ogr_vfk_2():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdaltest.vfk_layer_par.ResetReading()
 
     feat = gdaltest.vfk_layer_par.GetNextFeature()
@@ -102,10 +96,6 @@ def test_ogr_vfk_2():
 
 
 def test_ogr_vfk_3():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdaltest.vfk_layer_sobr = gdaltest.vfk_ds.GetLayer(43)
 
     assert gdaltest.vfk_layer_sobr.GetName() == 'SOBR', \
@@ -128,10 +118,6 @@ def test_ogr_vfk_3():
 
 
 def test_ogr_vfk_4():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdaltest.vfk_layer_sbp = gdaltest.vfk_ds.GetLayerByName('SBP')
 
     assert gdaltest.vfk_layer_sbp, 'did not get expected layer name "SBP"'
@@ -146,10 +132,6 @@ def test_ogr_vfk_4():
 
 
 def test_ogr_vfk_5():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdaltest.vfk_layer_hp = gdaltest.vfk_ds.GetLayerByName('HP')
 
     assert gdaltest.vfk_layer_hp != 'HP', 'did not get expected layer name "HP"'
@@ -164,10 +146,6 @@ def test_ogr_vfk_5():
 
 
 def test_ogr_vfk_6():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdaltest.vfk_layer_par = None
     gdaltest.vfk_layer_sobr = None
     gdaltest.vfk_ds = None
@@ -196,10 +174,6 @@ def test_ogr_vfk_6():
 
 
 def test_ogr_vfk_7():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     defn = gdaltest.vfk_layer_par.GetLayerDefn()
 
     for idx, name, ctype in ((0, "ID", ogr.OFTInteger64),
@@ -216,10 +190,6 @@ def test_ogr_vfk_7():
 
 
 def test_ogr_vfk_8():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     # open by SQLite driver first
     vfk_ds_db = ogr.Open('data/bylany.db')
     count1 = vfk_ds_db.GetLayerCount()
@@ -241,10 +211,6 @@ def test_ogr_vfk_8():
 
 
 def test_ogr_vfk_9():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     # open with suppressing geometry
     vfk_ds = None
     vfk_ds = gdal.OpenEx('data/bylany.vfk', open_options=['SUPPRESS_GEOMETRY=YES'])
@@ -265,10 +231,6 @@ def test_ogr_vfk_9():
 
 
 def test_ogr_vfk_10():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     # open with suppressing geometry
     vfk_ds = None
     vfk_ds = gdal.OpenEx('data/bylany.vfk', open_options=['FILE_FIELD=YES'])
@@ -300,10 +262,6 @@ def test_ogr_vfk_11():
             count += 1
 
         return count
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     count = gdaltest.vfk_layer_par.GetFeatureCount()
     for i in range(2):  # perform check twice, mix with random access
         if count != count_features():
@@ -316,10 +274,6 @@ def test_ogr_vfk_11():
 
 
 def test_ogr_vfk_12():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdaltest.vfk_layer_sbp = gdaltest.vfk_ds.GetLayerByName('SBP')
 
     gdaltest.vfk_layer_sbp.SetAttributeFilter("PARAMETRY_SPOJENI = '16'")
@@ -337,10 +291,6 @@ def test_ogr_vfk_12():
 
 
 def test_ogr_vfk_cleanup():
-
-    if gdaltest.vfk_drv is None:
-        pytest.skip()
-
     gdaltest.vfk_layer_par = None
     gdaltest.vfk_layer_hp = None
     gdaltest.vfk_layer_sobr = None

--- a/autotest/ogr/ogr_wasp.py
+++ b/autotest/ogr/ogr_wasp.py
@@ -39,28 +39,33 @@ from osgeo import ogr
 from osgeo import osr
 import pytest
 
+
+@pytest.fixture(autouse=True, scope='module')
+def ogr_wasp_cleanup():
+    yield
+    wasp_drv = ogr.GetDriverByName('WAsP')
+    wasp_drv.DeleteDataSource('tmp.map')
+
+
 ###############################################################################
 # Create wasp datasource
 
 
-def test_ogr_wasp_create_ds():
-
+def _ogr_wasp_create_ds():
     wasp_drv = ogr.GetDriverByName('WAsP')
     wasp_drv.DeleteDataSource('tmp.map')
 
     gdaltest.wasp_ds = wasp_drv.CreateDataSource('tmp.map')
 
-    if gdaltest.wasp_ds is not None:
-        return
-    pytest.fail()
+    assert gdaltest.wasp_ds is not None
+
 
 ###############################################################################
 # Create elevation .map from linestrings z
 
 
 def test_ogr_wasp_elevation_from_linestring_z():
-
-    test_ogr_wasp_create_ds()
+    _ogr_wasp_create_ds()
 
     ref = osr.SpatialReference()
     ref.ImportFromProj4('+proj=lcc +lat_1=46.8 +lat_0=46.8 +lon_0=0 +k_0=0.99987742 +x_0=600000 +y_0=2200000 +a=6378249.2 +b=6356514.999978254 +pm=2.337229167 +units=m +no_defs')
@@ -102,13 +107,13 @@ def test_ogr_wasp_elevation_from_linestring_z():
 
     assert j == 10, ('nb of feature should be 10 and is %d' % j)
 
+
 ###############################################################################
 # Create elevation .map from linestrings z with simplification
 
 
 def test_ogr_wasp_elevation_from_linestring_z_toler():
-
-    test_ogr_wasp_create_ds()
+    _ogr_wasp_create_ds()
 
     ref = osr.SpatialReference()
     ref.ImportFromProj4('+proj=lcc +lat_1=46.8 +lat_0=46.8 +lon_0=0 +k_0=0.99987742 +x_0=600000 +y_0=2200000 +a=6378249.2 +b=6356514.999978254 +pm=2.337229167 +units=m +no_defs')
@@ -164,8 +169,7 @@ def test_ogr_wasp_elevation_from_linestring_z_toler():
 # Create elevation .map from linestrings field
 
 def test_ogr_wasp_elevation_from_linestring_field():
-
-    test_ogr_wasp_create_ds()
+    _ogr_wasp_create_ds()
 
     layer = gdaltest.wasp_ds.CreateLayer('mylayer',
                                          options=['WASP_FIELDS=elevation'],
@@ -203,14 +207,13 @@ def test_ogr_wasp_elevation_from_linestring_field():
             j += 1
         i += 1
 
-    
+
 ###############################################################################
 # Create roughness .map from linestrings fields
 
 
 def test_ogr_wasp_roughness_from_linestring_fields():
-
-    test_ogr_wasp_create_ds()
+    _ogr_wasp_create_ds()
 
     layer = gdaltest.wasp_ds.CreateLayer('mylayer',
                                          options=['WASP_FIELDS=z_left,z_right'],
@@ -260,8 +263,7 @@ def test_ogr_wasp_roughness_from_linestring_fields():
 
 
 def test_ogr_wasp_roughness_from_polygon_z():
-
-    test_ogr_wasp_create_ds()
+    _ogr_wasp_create_ds()
 
     if not ogrtest.have_geos():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -318,8 +320,7 @@ def test_ogr_wasp_roughness_from_polygon_z():
 
 
 def test_ogr_wasp_roughness_from_polygon_field():
-
-    test_ogr_wasp_create_ds()
+    _ogr_wasp_create_ds()
 
     if not ogrtest.have_geos():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -381,8 +382,7 @@ def test_ogr_wasp_roughness_from_polygon_field():
 
 
 def test_ogr_wasp_merge():
-
-    test_ogr_wasp_create_ds()
+    _ogr_wasp_create_ds()
 
     if not ogrtest.have_geos():
         gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -456,14 +456,3 @@ def test_ogr_wasp_reading():
         i += 1
 
     assert i == 10
-###############################################################################
-# Cleanup
-
-
-def test_ogr_wasp_cleanup():
-
-    wasp_drv = ogr.GetDriverByName('WAsP')
-    wasp_drv.DeleteDataSource('tmp.map')
-
-
-

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -50,20 +50,17 @@ import webserver
 #
 
 
-pytestmark = pytest.mark.require_driver('WFS')
+pytestmark = pytest.mark.require_ogr_driver('WFS')
 
 
 @pytest.fixture(autouse=True, scope='module')
 def ogr_wfs_init():
-    gdaltest.wfs_drv = ogr.GetDriverByName('WFS')
-
     gdaltest.geoserver_wfs = None
     gdaltest.deegree_wfs = None
     gdaltest.ionic_wfs = None
 
     gml_ds = ogr.Open('data/ionic_wfs.gml')
     if gml_ds is None:
-        gdaltest.wfs_drv = None
         if gdal.GetLastErrorMsg().find('Xerces') != -1:
             pytest.skip()
         pytest.skip('failed to open test file.')
@@ -85,9 +82,6 @@ def with_and_without_streaming(request):
 
 @pytest.mark.skip()
 def test_ogr_wfs_mapserver():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if gdaltest.gdalurlopen('http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap') is None:
         pytest.skip('cannot open URL')
 
@@ -122,9 +116,6 @@ def test_ogr_wfs_mapserver():
 
 @pytest.mark.skip('FIXME: re-enable after adapting test')
 def test_ogr_wfs_geoserver():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if gdaltest.gdalurlopen('http://demo.opengeo.org/geoserver/wfs?TYPENAME=za:za_points&SERVICE=WFS&VERSION=1.1.0&REQUEST=DescribeFeatureType') is None:
         gdaltest.geoserver_wfs = False
         pytest.skip('cannot open URL')
@@ -215,9 +206,6 @@ def test_ogr_wfs_geoserver():
 
 @pytest.mark.skip('FIXME: re-enable after adapting test')
 def test_ogr_wfs_geoserver_json():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if not gdaltest.geoserver_wfs:
         pytest.skip()
 
@@ -249,9 +237,6 @@ def test_ogr_wfs_geoserver_json():
 
 @pytest.mark.skip('FIXME: re-enable after adapting test')
 def test_ogr_wfs_geoserver_shapezip():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if not gdaltest.geoserver_wfs:
         pytest.skip()
 
@@ -283,9 +268,6 @@ def test_ogr_wfs_geoserver_shapezip():
 
 @pytest.mark.skip('FIXME: re-enable after adapting test')
 def test_ogr_wfs_geoserver_paging():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if not gdaltest.geoserver_wfs:
         pytest.skip()
 
@@ -337,9 +319,6 @@ def test_ogr_wfs_geoserver_paging():
 
 @pytest.mark.skip()
 def test_ogr_wfs_deegree():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if gdaltest.gdalurlopen('http://demo.deegree.org:80/utah-workspace') is None:
         gdaltest.deegree_wfs = False
         pytest.skip('cannot open URL')
@@ -392,9 +371,6 @@ def test_ogr_wfs_deegree():
 
 @pytest.mark.skip()
 def test_ogr_wfs_test_ogrsf():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if not gdaltest.deegree_wfs:
         pytest.skip()
 
@@ -468,9 +444,6 @@ class WFSHTTPHandler(BaseHTTPRequestHandler):
 
 
 def test_ogr_wfs_fake_wfs_server():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     (process, port) = webserver.launch(handler=WFSHTTPHandler)
     if port == 0:
         pytest.skip()
@@ -512,9 +485,6 @@ def test_ogr_wfs_fake_wfs_server():
 
 @pytest.mark.skip('FIXME: re-enable after adapting test')
 def test_ogr_wfs_geoserver_wfst():
-    if gdaltest.wfs_drv is None:
-        pytest.skip()
-
     if not gdaltest.geoserver_wfs:
         pytest.skip()
 
@@ -4499,7 +4469,3 @@ def test_ogr_wfs_vsimem_cleanup(with_and_without_streaming):
 
     for f in gdal.ReadDir('/vsimem/'):
         gdal.Unlink('/vsimem/' + f)
-
-    
-
-

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1611,7 +1611,11 @@ def config_option(key, val):
 
 
 @contextlib.contextmanager
-def config_options(options):
+def config_options(_a_dict=None, **options):
+    # Handle either config_options({'A': 'b'}) or config_options(A='b')
+    if _a_dict is not None:
+        options.update(_a_dict)
+
     oldvals = {key: gdal.GetConfigOption(key) for key in options}
     for key in options:
         gdal.SetConfigOption(key, options[key])

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -10,5 +10,7 @@ env =
 #  GDAL_DRIVER_PATH=/usr/lib/gdal/gdalplugins
 
 markers =
-    require_driver: Skip test(s) if driver isn't present
+    require_driver: Skip test(s) if GDAL driver isn't present
+    require_ogr_driver: Skip test(s) if OGR driver isn't present
     require_run_on_demand: Skip test(s) if RUN_ON_DEMAND environment variable is not set
+    config_options: Run test(s) with particular config options (given as keyword arguments)


### PR DESCRIPTION
## What does this PR do?

This turns most `gdaltest.<name>_drv` usage into uses of the `require_driver(name)` mark.
I also removed many individual tests which exist solely for the purpose of initialisation and/or cleanup, and replaced them with pytest fixtures.

This not only looks prettier but it is a step toward tests not being dependent on
the other tests in their module.

As a crude way of measuring the progress towards that goal, I installed [pytest-random-order](https://pypi.org/project/pytest-random-order/0.8.0/) and ran the (gcore and gdrivers) tests in a random order before and after this change:

before:
```
    2382 passed
     329 failed
       4 xfailed
     497 skipped
```

after:
```
    2492 passed
     180 failed
       4 xfailed
     500 skipped
```

Results vary a bit with each run, but there's a modest but fairly consistent reduced failure rate, which shows a reduction in test interdependence.

note that unlike [my previous PR](https://github.com/osgeo/gdal/pull/963), this is all manual refactoring, not automated.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
