### PR TITLE
KEA: add support for /vsi file systems

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -119,7 +119,7 @@ install:
       $env:NMAKE_LOCAL+="HDF5_DIR = `$(SDK_PREFIX)`n"
       $env:NMAKE_LOCAL+="HDF5_LIB = `$(SDK_LIB)\hdf5.lib`n"
       $env:NMAKE_LOCAL+="KEA_CFLAGS = -I`$(SDK_INC)`n"
-      $env:NMAKE_LOCAL+="KEA_LIB = `$(SDK_LIB)\libkea.lib`n"
+      $env:NMAKE_LOCAL+="KEA_LIB = `$(SDK_LIB)\libkea.lib `$(SDK_LIB)\hdf5_cpp.lib`n"
       $env:NMAKE_LOCAL+="NETCDF_SETTING=yes`n"
       $env:NMAKE_LOCAL+="NETCDF_LIB=`$(SDK_LIB)\netcdf.lib`n"
       $env:NMAKE_LOCAL+="NETCDF_INC_DIR=`$(SDK_INC)`n"

--- a/autotest/gdrivers/kea.py
+++ b/autotest/gdrivers/kea.py
@@ -50,7 +50,7 @@ def test_kea_1():
         pytest.skip()
 
     tst = gdaltest.GDALTest('KEA', 'byte.tif', 1, 4672, options=['IMAGEBLOCKSIZE=15', 'THEMATIC=YES'])
-    return tst.testCreateCopy(check_srs=True, check_gt=1)
+    return tst.testCreateCopy(check_srs=True, check_gt=1, new_filename='tmp/byte.kea')
 
 ###############################################################################
 # Test CreateCopy() for various data types
@@ -607,4 +607,29 @@ def test_kea_14():
     gdaltest.kea_driver.Delete('tmp/out2.kea')
 
 
+###############################################################################
+# Test /vsi functionality
 
+
+def test_kea_15():
+    if gdaltest.kea_driver is None:
+        pytest.skip()
+
+    # create an temp image
+    ds = gdaltest.kea_driver.Create('tmp/vsitest.kea', 1, 1)
+    ds.GetRasterBand(1).Fill(255)
+    ds = None
+
+    # load it into /vsimem and try and open it
+    gdal.FileFromMemBuffer('/vsimem/foo.kea', open('tmp/vsitest.kea', 'rb').read())
+    ds = gdal.Open('/vsimem/foo.kea')
+    assert ds.GetDriver().ShortName == "KEA"
+    ds = None
+
+    gdal.Unlink('/vsimem/foo.kea')
+    gdaltest.kea_driver.Delete('tmp/vsitest.kea')
+
+def test_kea_destroy():
+    # there is always a 'tmp/out.kea.aux.xml' left behind by
+    # a few of the tests
+    gdal.Unlink('tmp/out.kea.aux.xml')

--- a/gdal/frmts/hdf5/hdf5dataset.cpp
+++ b/gdal/frmts/hdf5/hdf5dataset.cpp
@@ -32,11 +32,9 @@
 #include "cpl_port.h"
 
 #include "hdf5_api.h"
-
 #include "hdf5dataset.h"
+#include "hdf5vfl.h"
 
-#include <algorithm>
-#include <mutex>
 #include <stdio.h>
 #include <string.h>
 #include <string>
@@ -48,193 +46,9 @@
 #include "gdal_frmts.h"
 #include "gdal_priv.h"
 
-extern "C" int CPL_DLL GDALIsInGlobalDestructor(void);
-
 CPL_CVSID("$Id$")
 
 constexpr size_t MAX_METADATA_LEN = 32768;
-
-#ifdef H5FD_FEAT_SUPPORTS_SWMR_IO
-#define HDF5_1_10_OR_LATER
-#endif
-
-static std::mutex gMutex;
-static hid_t hFileDriver = -1;
-
-static H5FD_t *HDF5_vsil_open(const char *name, unsigned flags, hid_t fapl_id,
-            haddr_t maxaddr);
-static herr_t HDF5_vsil_close(H5FD_t *_file);
-static herr_t HDF5_vsil_query(const H5FD_t *_f1, unsigned long *flags);
-static haddr_t HDF5_vsil_get_eoa(const H5FD_t *_file, H5FD_mem_t type);
-static herr_t HDF5_vsil_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t addr);
-static haddr_t HDF5_vsil_get_eof(const H5FD_t *_file
-#ifdef HDF5_1_10_OR_LATER
-                                 , H5FD_mem_t type
-#endif
-);
-static herr_t HDF5_vsil_read(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
-                             haddr_t addr, size_t size, void *buf);
-static herr_t HDF5_vsil_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
-                              haddr_t addr, size_t size, const void *buf);
-static herr_t HDF5_vsil_truncate(H5FD_t *_file, hid_t dxpl_id, hbool_t closing);
-
-#define MAXADDR (((haddr_t)1<<(8*sizeof(haddr_t)-1))-1)
-
-/* See https://support.hdfgroup.org/HDF5/doc/TechNotes/VFL.html */
-static const H5FD_class_t HDF5_vsil_g = {
-    "vsil",                     /* name */
-    MAXADDR,                    /* maxaddr  */
-    H5F_CLOSE_WEAK,             /* fc_degree  */
-#ifdef HDF5_1_10_OR_LATER
-    nullptr,                    /* terminate */
-#endif
-    nullptr,                    /* sb_size  */
-    nullptr,                    /* sb_encode */
-    nullptr,                    /* sb_decode */
-    0,                          /* fapl_size */
-    nullptr,                    /* fapl_get  */
-    nullptr,                    /* fapl_copy */
-    nullptr,                    /* fapl_free */
-    0,                          /* dxpl_size */
-    nullptr,                    /* dxpl_copy */
-    nullptr,                    /* dxpl_free */
-    HDF5_vsil_open,             /* open */
-    HDF5_vsil_close,            /* close */
-    nullptr,                    /* cmp  */
-    HDF5_vsil_query,            /* query */
-    nullptr,                    /* get_type_map */
-    nullptr,                    /* alloc */
-    nullptr,                    /* free */
-    HDF5_vsil_get_eoa,          /* get_eoa */
-    HDF5_vsil_set_eoa,          /* set_eoa */
-    HDF5_vsil_get_eof,          /* get_eof */
-    nullptr,                    /* get_handle */
-    HDF5_vsil_read,             /* read */
-    HDF5_vsil_write,            /* write */
-    nullptr,                    /* flush */
-    HDF5_vsil_truncate,         /* truncate */
-    nullptr,                    /* lock */
-    nullptr,                    /* unlock */
-    H5FD_FLMAP_DICHOTOMY        /* fl_map */
-};
-
-typedef struct  {
-    H5FD_t          pub;            /* must be first */
-    VSILFILE       *fp = nullptr;
-    haddr_t         eoa = 0;
-    haddr_t         eof = 0;
-} HDF5_vsil_t;
-
-static H5FD_t *HDF5_vsil_open(const char *name, unsigned flags,
-                              hid_t /*fapl_id*/, haddr_t /*maxaddr*/)
-{
-    const char* openFlags = "rb";
-    if( (H5F_ACC_RDWR & flags) )
-        openFlags = "rb+";
-    if( (H5F_ACC_TRUNC & flags) || (H5F_ACC_CREAT & flags) )
-        openFlags = "wb+";
-
-    VSILFILE* fp = VSIFOpenL(name, openFlags);
-    if( !fp )
-    {
-        return nullptr;
-    }
-    if( (H5F_ACC_TRUNC & flags) )
-    {
-        VSIFTruncateL(fp, 0);
-    }
-
-    HDF5_vsil_t* fh = new HDF5_vsil_t;
-    memset(&fh->pub, 0, sizeof(fh->pub));
-    if( !fh )
-    {
-        VSIFCloseL(fp);
-        return nullptr;
-    }
-    fh->fp = fp;
-
-    VSIFSeekL(fh->fp, 0, SEEK_END);
-    fh->eof = static_cast<haddr_t>(VSIFTellL(fh->fp));
-
-    return reinterpret_cast<H5FD_t*>(fh);
-}
-
-static herr_t HDF5_vsil_close(H5FD_t *_file)
-{
-    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
-    int ret = VSIFCloseL(fh->fp);
-    delete fh;
-    return ret;
-}
-
-static herr_t HDF5_vsil_query(const H5FD_t *, unsigned long *flags /* out */)
-{
-    *flags = H5FD_FEAT_AGGREGATE_METADATA |
-             H5FD_FEAT_ACCUMULATE_METADATA |
-             H5FD_FEAT_DATA_SIEVE |
-             H5FD_FEAT_AGGREGATE_SMALLDATA;
-    return 0;
-}
-
-static haddr_t HDF5_vsil_get_eoa(const H5FD_t *_file, H5FD_mem_t /*type*/)
-{
-    const HDF5_vsil_t* fh = reinterpret_cast<const HDF5_vsil_t*>(_file);
-    return fh->eoa;
-}
-
-static herr_t HDF5_vsil_set_eoa(H5FD_t *_file, H5FD_mem_t /*type*/,
-                                haddr_t addr)
-{
-    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
-    fh->eoa = addr;
-    return 0;
-}
-
-static haddr_t HDF5_vsil_get_eof(const H5FD_t *_file
-#ifdef HDF5_1_10_OR_LATER
-                                 , H5FD_mem_t /* type */
-#endif
-                                )
-{
-    const HDF5_vsil_t* fh = reinterpret_cast<const HDF5_vsil_t*>(_file);
-    return fh->eof;
-}
-
-static herr_t HDF5_vsil_read(H5FD_t *_file, H5FD_mem_t /* type */, 
-                             hid_t /* dxpl_id */,
-                             haddr_t addr, size_t size, void *buf /*out*/)
-{
-    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
-    VSIFSeekL(fh->fp, static_cast<vsi_l_offset>(addr), SEEK_SET);
-    return VSIFReadL(buf, size, 1, fh->fp) == 1 ? 0 : -1;
-}
-
-static herr_t HDF5_vsil_write(H5FD_t *_file, H5FD_mem_t /* type */,
-                              hid_t /* dxpl_id */,
-                              haddr_t addr, size_t size,
-                              const void *buf /*out*/)
-{
-    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
-    VSIFSeekL(fh->fp, static_cast<vsi_l_offset>(addr), SEEK_SET);
-    int ret = VSIFWriteL(buf, size, 1, fh->fp) == 1 ? 0 : -1;
-    fh->eof = std::max(fh->eof, static_cast<haddr_t>(VSIFTellL(fh->fp)));
-    return ret;
-}
-
-static herr_t HDF5_vsil_truncate(H5FD_t *_file, hid_t /* dxpl_id*/,
-                                 hbool_t /*closing*/)
-{
-    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
-    if(fh->eoa != fh->eof)
-    {
-        if( VSIFTruncateL(fh->fp, fh->eoa) < 0 )
-        {
-            return -1;
-        }
-        fh->eof = fh->eoa;
-    }
-    return 0;
-}
 
 /************************************************************************/
 /*                          HDF5GetFileDriver()                         */
@@ -242,12 +56,7 @@ static herr_t HDF5_vsil_truncate(H5FD_t *_file, hid_t /* dxpl_id*/,
 
 hid_t HDF5GetFileDriver()
 {
-    std::lock_guard<std::mutex> oLock(gMutex);
-    if( hFileDriver < 0 )
-    {
-        hFileDriver = H5FDregister(&HDF5_vsil_g);
-    }
-    return hFileDriver;
+    return HDF5VFLGetFileDriver();
 }
 
 /************************************************************************/
@@ -256,15 +65,7 @@ hid_t HDF5GetFileDriver()
 
 void HDF5UnloadFileDriver()
 {
-    if( !GDALIsInGlobalDestructor() )
-    {
-        std::lock_guard<std::mutex> oLock(gMutex);
-        if( hFileDriver >= 0 )
-        {
-            H5FDunregister(hFileDriver);
-            hFileDriver = -1;
-        }
-    }
+    HDF5VFLUnloadFileDriver();
 }
 
 /************************************************************************/
@@ -275,7 +76,6 @@ static void HDF5DatasetDriverUnload(GDALDriver*)
 {
     HDF5UnloadFileDriver();
 }
-
 
 /************************************************************************/
 /* ==================================================================== */

--- a/gdal/frmts/hdf5/hdf5vfl.h
+++ b/gdal/frmts/hdf5/hdf5vfl.h
@@ -1,0 +1,267 @@
+/******************************************************************************
+ *
+ * Project:  Hierarchical Data Format Release 5 (HDF5)
+ * Authors:  Denis Nadeau <denis.nadeau@gmail.com>
+ *           Sam Gillingham <gillingham.sam@gmail.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2008-2018, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+ 
+ // This file contains the Virtual File Layer implementation that calls through 
+ // to the VSI functions and should be included by HDF5 based drivers that wish 
+ // to use the VFL for /vsi file system support.
+ 
+#ifndef HDF5VFL_H_INCLUDED_
+#define HDF5VFL_H_INCLUDED_
+
+#include "cpl_port.h"
+
+#include <algorithm>
+#include <mutex>
+
+extern "C" int CPL_DLL GDALIsInGlobalDestructor(void);
+
+#ifdef H5FD_FEAT_SUPPORTS_SWMR_IO
+#define HDF5_1_10_OR_LATER
+#endif
+
+static std::mutex gMutex;
+static hid_t hFileDriver = -1;
+
+static H5FD_t *HDF5_vsil_open(const char *name, unsigned flags, hid_t fapl_id,
+            haddr_t maxaddr);
+static herr_t HDF5_vsil_close(H5FD_t *_file);
+static herr_t HDF5_vsil_query(const H5FD_t *_f1, unsigned long *flags);
+static haddr_t HDF5_vsil_get_eoa(const H5FD_t *_file, H5FD_mem_t type);
+static herr_t HDF5_vsil_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t addr);
+static haddr_t HDF5_vsil_get_eof(const H5FD_t *_file
+#ifdef HDF5_1_10_OR_LATER
+                                 , H5FD_mem_t type
+#endif
+);
+static herr_t HDF5_vsil_read(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
+                             haddr_t addr, size_t size, void *buf);
+static herr_t HDF5_vsil_write(H5FD_t *_file, H5FD_mem_t type, hid_t fapl_id,
+                              haddr_t addr, size_t size, const void *buf);
+static herr_t HDF5_vsil_truncate(H5FD_t *_file, hid_t dxpl_id, hbool_t closing);
+
+static hid_t HDF5VFLGetFileDriver();
+static void HDF5VFLUnloadFileDriver();
+
+#define MAXADDR (((haddr_t)1<<(8*sizeof(haddr_t)-1))-1)
+
+/* See https://support.hdfgroup.org/HDF5/doc/TechNotes/VFL.html */
+static const H5FD_class_t HDF5_vsil_g = {
+    "vsil",                     /* name */
+    MAXADDR,                    /* maxaddr  */
+    H5F_CLOSE_WEAK,             /* fc_degree  */
+#ifdef HDF5_1_10_OR_LATER
+    nullptr,                    /* terminate */
+#endif
+    nullptr,                    /* sb_size  */
+    nullptr,                    /* sb_encode */
+    nullptr,                    /* sb_decode */
+    0,                          /* fapl_size */
+    nullptr,                    /* fapl_get  */
+    nullptr,                    /* fapl_copy */
+    nullptr,                    /* fapl_free */
+    0,                          /* dxpl_size */
+    nullptr,                    /* dxpl_copy */
+    nullptr,                    /* dxpl_free */
+    HDF5_vsil_open,             /* open */
+    HDF5_vsil_close,            /* close */
+    nullptr,                    /* cmp  */
+    HDF5_vsil_query,            /* query */
+    nullptr,                    /* get_type_map */
+    nullptr,                    /* alloc */
+    nullptr,                    /* free */
+    HDF5_vsil_get_eoa,          /* get_eoa */
+    HDF5_vsil_set_eoa,          /* set_eoa */
+    HDF5_vsil_get_eof,          /* get_eof */
+    nullptr,                    /* get_handle */
+    HDF5_vsil_read,             /* read */
+    HDF5_vsil_write,            /* write */
+    nullptr,                    /* flush */
+    HDF5_vsil_truncate,         /* truncate */
+    nullptr,                    /* lock */
+    nullptr,                    /* unlock */
+    H5FD_FLMAP_DICHOTOMY        /* fl_map */
+};
+
+typedef struct  {
+    H5FD_t          pub;            /* must be first */
+    VSILFILE       *fp = nullptr;
+    haddr_t         eoa = 0;
+    haddr_t         eof = 0;
+} HDF5_vsil_t;
+
+static H5FD_t *HDF5_vsil_open(const char *name, unsigned flags,
+                              hid_t /*fapl_id*/, haddr_t /*maxaddr*/)
+{
+    const char* openFlags = "rb";
+    if( (H5F_ACC_RDWR & flags) )
+        openFlags = "rb+";
+    if( (H5F_ACC_TRUNC & flags) || (H5F_ACC_CREAT & flags) )
+        openFlags = "wb+";
+
+    VSILFILE* fp = VSIFOpenL(name, openFlags);
+    if( !fp )
+    {
+        return nullptr;
+    }
+    if( (H5F_ACC_TRUNC & flags) )
+    {
+        VSIFTruncateL(fp, 0);
+    }
+
+    HDF5_vsil_t* fh = new HDF5_vsil_t;
+    memset(&fh->pub, 0, sizeof(fh->pub));
+    if( !fh )
+    {
+        VSIFCloseL(fp);
+        return nullptr;
+    }
+    fh->fp = fp;
+
+    VSIFSeekL(fh->fp, 0, SEEK_END);
+    fh->eof = static_cast<haddr_t>(VSIFTellL(fh->fp));
+
+    return reinterpret_cast<H5FD_t*>(fh);
+}
+
+static herr_t HDF5_vsil_close(H5FD_t *_file)
+{
+    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
+    int ret = VSIFCloseL(fh->fp);
+    delete fh;
+    return ret;
+}
+
+static herr_t HDF5_vsil_query(const H5FD_t *, unsigned long *flags /* out */)
+{
+    *flags = H5FD_FEAT_AGGREGATE_METADATA |
+             H5FD_FEAT_ACCUMULATE_METADATA |
+             H5FD_FEAT_DATA_SIEVE |
+             H5FD_FEAT_AGGREGATE_SMALLDATA;
+    return 0;
+}
+
+static haddr_t HDF5_vsil_get_eoa(const H5FD_t *_file, H5FD_mem_t /*type*/)
+{
+    const HDF5_vsil_t* fh = reinterpret_cast<const HDF5_vsil_t*>(_file);
+    return fh->eoa;
+}
+
+static herr_t HDF5_vsil_set_eoa(H5FD_t *_file, H5FD_mem_t /*type*/,
+                                haddr_t addr)
+{
+    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
+    fh->eoa = addr;
+    return 0;
+}
+
+static haddr_t HDF5_vsil_get_eof(const H5FD_t *_file
+#ifdef HDF5_1_10_OR_LATER
+                                 , H5FD_mem_t /* type */
+#endif
+                                )
+{
+    const HDF5_vsil_t* fh = reinterpret_cast<const HDF5_vsil_t*>(_file);
+    return fh->eof;
+}
+
+static herr_t HDF5_vsil_read(H5FD_t *_file, H5FD_mem_t /* type */, 
+                             hid_t /* dxpl_id */,
+                             haddr_t addr, size_t size, void *buf /*out*/)
+{
+    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
+    VSIFSeekL(fh->fp, static_cast<vsi_l_offset>(addr), SEEK_SET);
+    return VSIFReadL(buf, size, 1, fh->fp) == 1 ? 0 : -1;
+}
+
+static herr_t HDF5_vsil_write(H5FD_t *_file, H5FD_mem_t /* type */,
+                              hid_t /* dxpl_id */,
+                              haddr_t addr, size_t size,
+                              const void *buf /*out*/)
+{
+    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
+    VSIFSeekL(fh->fp, static_cast<vsi_l_offset>(addr), SEEK_SET);
+    int ret = VSIFWriteL(buf, size, 1, fh->fp) == 1 ? 0 : -1;
+    fh->eof = std::max(fh->eof, static_cast<haddr_t>(VSIFTellL(fh->fp)));
+    return ret;
+}
+
+static herr_t HDF5_vsil_truncate(H5FD_t *_file, hid_t /* dxpl_id*/,
+                                 hbool_t /*closing*/)
+{
+    HDF5_vsil_t* fh = reinterpret_cast<HDF5_vsil_t*>(_file);
+    if(fh->eoa != fh->eof)
+    {
+        if( VSIFTruncateL(fh->fp, fh->eoa) < 0 )
+        {
+            return -1;
+        }
+        fh->eof = fh->eoa;
+    }
+    return 0;
+}
+
+/************************************************************************/
+/*                       HDF5VFLGetFileDriver()                         */
+/************************************************************************/
+
+static hid_t HDF5VFLGetFileDriver()
+{
+    std::lock_guard<std::mutex> oLock(gMutex);
+    if( hFileDriver < 0 )
+    {
+        hFileDriver = H5FDregister(&HDF5_vsil_g);
+#if H5E_auto_t_vers == 2
+        // also, don't print error messages from KEA driver. 
+        // (which uses H5E_auto_t_vers=2 - the default, hdf uses 1 for some reason).
+        // These tend to be meaningless - ie no GCP's found etc. 
+        // They didn't seem to be shown when we didn't use the VFL layer
+        // - maybe VFL turns them on?
+        H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
+#endif
+    }
+    return hFileDriver;
+}
+
+/************************************************************************/
+/*                     HDF5VFLUnloadFileDriver()                        */
+/************************************************************************/
+
+static void HDF5VFLUnloadFileDriver()
+{
+    if( !GDALIsInGlobalDestructor() )
+    {
+        std::lock_guard<std::mutex> oLock(gMutex);
+        if( hFileDriver >= 0 )
+        {
+            H5FDunregister(hFileDriver);
+            hFileDriver = -1;
+        }
+    }
+}
+
+#endif /* HDF5VFL_H_INCLUDED_ */

--- a/gdal/frmts/kea/frmt_kea.html
+++ b/gdal/frmts/kea/frmt_kea.html
@@ -51,6 +51,10 @@ of the underlying HDF5 format.</p>
 <li><p><b>THEMATIC</b>=YES/NO: If YES then all bands are set to thematic. Defaults to NO</li>
 </ul>
 
+<h2>VSI Virtual File System API support</h2>
+
+Since GDAL 2.5.0, read-only operations on /vsi file systems are supported.
+
 <h2>See Also:</h2>
 
 <ul>

--- a/gdal/frmts/kea/keadataset.cpp
+++ b/gdal/frmts/kea/keadataset.cpp
@@ -30,8 +30,18 @@
 #include "keadataset.h"
 #include "keaband.h"
 #include "keacopy.h"
+#include "../frmts/hdf5/hdf5vfl.h"
 
 CPL_CVSID("$Id$")
+
+/************************************************************************/
+/*                     KEADatasetDriverUnload()                        */
+/************************************************************************/
+
+void KEADatasetDriverUnload(GDALDriver*)
+{
+    HDF5VFLUnloadFileDriver();
+}
 
 // Function for converting a libkea type into a GDAL type
 GDALDataType KEA_to_GDAL_Type( kealib::KEADataType ekeaType )
@@ -113,10 +123,24 @@ GDALDataset *KEADataset::Open( GDALOpenInfo * poOpenInfo )
             H5::H5File *pH5File;
             if( poOpenInfo->eAccess == GA_ReadOnly )
             {
-                pH5File = kealib::KEAImageIO::openKeaH5RDOnly( poOpenInfo->pszFilename );
+                // use the virtual driver so we can open files using
+                // /vsicurl etc
+                // do this same as libkea
+                H5::FileAccPropList keaAccessPlist = H5::FileAccPropList(H5::FileAccPropList::DEFAULT);
+                keaAccessPlist.setCache(kealib::KEA_MDC_NELMTS, kealib::KEA_RDCC_NELMTS, 
+                            kealib::KEA_RDCC_NBYTES, kealib::KEA_RDCC_W0);
+                keaAccessPlist.setSieveBufSize(kealib::KEA_SIEVE_BUF);
+                hsize_t blockSize = kealib::KEA_META_BLOCKSIZE;
+                keaAccessPlist.setMetaBlockSize(blockSize);
+                // but set the driver
+                keaAccessPlist.setDriver(HDF5VFLGetFileDriver(), nullptr);
+                
+                const H5std_string keaImgFilePath(poOpenInfo->pszFilename);
+                pH5File = new H5::H5File(keaImgFilePath, H5F_ACC_RDONLY, H5::FileCreatPropList::DEFAULT, keaAccessPlist);
             }
             else
             {
+                // Must be a local file
                 pH5File = kealib::KEAImageIO::openKeaH5RW( poOpenInfo->pszFilename );
             }
             // create the KEADataset object
@@ -145,7 +169,6 @@ GDALDataset *KEADataset::Open( GDALOpenInfo * poOpenInfo )
 //
 int KEADataset::Identify( GDALOpenInfo * poOpenInfo )
 {
-    bool bisKEA = false;
 
 /* -------------------------------------------------------------------- */
 /*      Is it an HDF5 file?                                             */
@@ -155,19 +178,15 @@ int KEADataset::Identify( GDALOpenInfo * poOpenInfo )
     if( poOpenInfo->pabyHeader == nullptr ||
         memcmp(poOpenInfo->pabyHeader,achSignature,8) != 0 )
     {
-        return false;
+        return 0;
     }
 
-    try
-    {
-        // is this a KEA file?
-        bisKEA = kealib::KEAImageIO::isKEAImage( poOpenInfo->pszFilename );
-    }
-    catch (const kealib::KEAIOException &)
-    {
-        bisKEA = false;
-    }
-    if( bisKEA )
+    // avoid using kealib::KEAImageIO::isKEAImage as this is likely
+    // to be too slow over curl etc (and doesn't take a HDF5 file handle
+    // anyway).
+    // Just test the extension
+    CPLString osExt(CPLGetExtension(poOpenInfo->pszFilename));
+    if( EQUAL(osExt, "KEA") )
         return 1;
     else
         return 0;

--- a/gdal/frmts/kea/keadataset.h
+++ b/gdal/frmts/kea/keadataset.h
@@ -110,4 +110,7 @@ private:
 GDALDataType KEA_to_GDAL_Type( kealib::KEADataType ekeaType );
 kealib::KEADataType GDAL_to_KEA_Type( GDALDataType egdalType );
 
+// For unloading the VFL
+void KEADatasetDriverUnload(GDALDriver*);
+
 #endif //KEADATASET_H

--- a/gdal/frmts/kea/keadriver.cpp
+++ b/gdal/frmts/kea/keadriver.cpp
@@ -75,11 +75,13 @@ void GDALRegister_KEA()
         static_cast<int>(kealib::KEA_SIEVE_BUF),
         static_cast<int>(kealib::KEA_META_BLOCKSIZE),
         kealib::KEA_DEFLATE ) );
+    poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = KEADataset::Open;
     poDriver->pfnIdentify = KEADataset::Identify;
     poDriver->pfnCreate = KEADataset::Create;
     poDriver->pfnCreateCopy = KEADataset::CreateCopy;
+    poDriver->pfnUnloadDriver = KEADatasetDriverUnload;
 
     GetGDALDriverManager()->RegisterDriver( poDriver );
 }

--- a/gdal/frmts/kea/makefile.vc
+++ b/gdal/frmts/kea/makefile.vc
@@ -1,7 +1,7 @@
 
 OBJ	=	keaband.obj keacopy.obj keadataset.obj keadriver.obj keamaskband.obj keaoverview.obj kearat.obj
 
-EXTRAFLAGS 	= 	$(KEA_CFLAGS) 
+EXTRAFLAGS 	= 	$(KEA_CFLAGS) -DH5_BUILT_AS_DYNAMIC_LIB 
 
 GDAL_ROOT	=	..\..
 


### PR DESCRIPTION
This PR adapts the /vsi support added (using a Virtual File Layer) to the HDF5 driver in 2.4.0 for the KEA driver.

Since the KEA driver now calls directly into HDF5 (rather than via `kealib`) to set up the open properties the HDF5 C++ library must be linked in. This was already happening under Unix, but under Windows `hdf_cpp.lib` must be added to `KEA_LIB`. I'm not sure if there is a better way.

Here are some KEA files already online for testing:
https://bitbucket.org/chchrsc/kealib/downloads/classes.kea
https://bitbucket.org/chchrsc/kealib/downloads/utm.kea

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

cc: @danclewley @petebunting @neilflood
