### PR TITLE
gdal_fillnodata.py: preserve color interpretation and color table

### DIFF
--- a/gdal/swig/python/scripts/gdal_fillnodata.py
+++ b/gdal/swig/python/scripts/gdal_fillnodata.py
@@ -183,6 +183,12 @@ if dst_filename is not None:
     if ndv is not None:
         dstband.SetNoDataValue(ndv)
 
+    color_interp = srcband.GetColorInterpretation()
+    dstband.SetColorInterpretation(color_interp)
+    if color_interp == gdal.GCI_PaletteIndex:
+        color_table = srcband.GetColorTable()
+        dstband.SetColorTable(color_table)
+
 else:
     dstband = srcband
 


### PR DESCRIPTION
`gdal_fillnodata.py` will preserve color interpretation and color table (if set) from the source band.