### PR TITLE
vsicurl: Ignore CONNECT response headers from proxy

### DIFF
--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -1731,6 +1731,11 @@ void *CPLHTTPSetOptions(void *pcurl, const char* pszURL,
     }
 #endif
 
+    // CURLOPT_SUPPRESS_CONNECT_HEADERS is defined in curl 7.54.0 or newer.
+#if LIBCURL_VERSION_NUM >= 0x073600
+    curl_easy_setopt(http_handle, CURLOPT_SUPPRESS_CONNECT_HEADERS, 1L);
+#endif
+
     // Enable following redirections.  Requires libcurl 7.10.1 at least.
     curl_easy_setopt(http_handle, CURLOPT_FOLLOWLOCATION, 1 );
     curl_easy_setopt(http_handle, CURLOPT_MAXREDIRS, 10 );

--- a/gdal/port/cpl_vsil_curl_class.h
+++ b/gdal/port/cpl_vsil_curl_class.h
@@ -107,6 +107,13 @@ typedef struct
     VSICurlReadCbkFunc  pfnReadCbk;
     void               *pReadCbkUserData;
     bool                bInterrupted;
+
+#if LIBCURL_VERSION_NUM < 0x073600
+    // Workaround to ignore extra HTTP response headers from
+    // proxies in older versions of curl.
+    // CURLOPT_SUPPRESS_CONNECT_HEADERS fixes this
+    bool            bIsProxyConnectHeader;
+#endif
 } WriteFuncStruct;
 
 /************************************************************************/


### PR DESCRIPTION
This fixes an issue where a keep-alive'd connection via a proxy is closed by the server (`Connection: close`), and subsequent range requests fail because the proxy's headers are treated as the response headers.

Slightly sanitised log:
```
...
VSICURL: Downloading 141768-152378 (https://mybucket.s3.amazonaws.com/my.tif)...
* Couldn't find host mybucket.s3.amazonaws.com in the .netrc file; using defaults
* Found bundle for host mybucket.s3.amazonaws.com: 0x7feda3f05830 [can pipeline]
* Re-using existing connection! (#1) with proxy localhost
* Connected to localhost (::1) port 8888 (#1)
> GET /my.tif HTTP/1.1
Host: mybucket.s3.amazonaws.com
Accept: */*
Range: bytes=141768-152378
x-amz-date: 20190117T135937Z
x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Security-Token: ...

< HTTP/1.1 206 Partial Content
< x-amz-id-2: ...
< x-amz-request-id: ...
< Date: Thu, 17 Jan 2019 13:59:38 GMT
< x-amz-replication-status: COMPLETED
< Last-Modified: Fri, 09 Nov 2018 04:02:35 GMT
< ETag: "df347ccaf4742428675e5b6980bdbae7-8"
< x-amz-meta-s3b-last-modified: 20180611T063044Z
< x-amz-version-id: QCXunbFjcWyaCoroGMglkwkSFn9MknCq
< Accept-Ranges: bytes
< Content-Range: bytes 141768-152378/61434648
< Content-Type: image/tiff
< Content-Length: 10611
< Server: AmazonS3
< Connection: close
<
* Closing connection 1
VSICURL: Download completed
VSICURL: Downloading 152379-163020 (https://mybucket.s3.amazonaws.com/my.tif)...
* Couldn't find host mybucket.s3.amazonaws.com in the .netrc file; using defaults
* Hostname localhost was found in DNS cache
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8888 (#2)
* Establish HTTP proxy tunnel to mybucket.s3.amazonaws.com:443
> CONNECT mybucket.s3.amazonaws.com:443 HTTP/1.1
Host: mybucket.s3.amazonaws.com:443
Proxy-Connection: Keep-Alive

< HTTP/1.1 200 Connection established
<
ERROR 1: Range downloading not supported by this server!
* Failed writing header
ERROR 1: Request for 152379-163020 failed
* stopped the pause stream!
* Closing connection 2
VSICURL: Download completed
```

Has been reproduced and tested via Charles Proxy (v4) under both OSX & Linux, and fix works.

`GDAL_HTTP_PROXY=proxyhost:port gdalinfo -checksum /vsis3/mybucket/my.tif` for a reasonably sized GTiff. In my testing S3 tends to only close the connection reliably if `CPL_VSIL_CURL_ALLOWED_EXTENSIONS` & `GDAL_DISABLE_READDIR_ON_OPEN` are both _unset_ (ie. it does >100 requests)

## What does this PR do?

In Curl>=7.54 there's an option ([`CURLOPT_SUPPRESS_CONNECT_HEADERS`](https://curl.haxx.se/libcurl/c/CURLOPT_SUPPRESS_CONNECT_HEADERS.html)) to suppress passing proxy response headers through to the application, but for older libcurl versions I've added a reasonably conservative workaround (Looking for `2xx Connection established`).

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s) — not sure how we'd do this.
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Linux/Ubuntu
* Compiler: gcc
