### PR TITLE
Elasticsearch: Fixed index comparison bug when a index have atleast one mapping

### DIFF
--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
@@ -228,7 +228,7 @@ OGRLayer* OGRElasticDataSource::GetLayerByName(const char* pszName)
         }
         for( auto& poLayer: m_apoLayers )
         {
-            if( EQUAL( poLayer->GetName(), pszName) )
+            if( EQUAL( poLayer->GetIndexName(), pszName) )
             {
                 return poLayer.get();
             }


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Fixes an issue when an Elasticsearch index have at least one mapping. If there is at least one mapping, currently it will not be possible to use these indices with the GDAL Elasticsearch driver as the layer name is compared to index name and these differ when there is at least one mapping. This error was introduced in GDAL 2.4.0 and from what I can see, commit fe55a01bed92b4fe751c5d5f9ea7a5bd1addc95d.

## What are related issues/pull requests?
None, as far as I know.

## Environment
Happens in every environment I've tested (Linux, Windows).
