### PR TITLE
http/vsicurl: Improvements to error handling [WIP]

### DIFF
--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -514,7 +514,9 @@ double CPLHTTPGetNewRetryDelay(int response_code, double dfOldDelay,
     if( response_code == 429 || response_code == 500 ||
         (response_code >= 502 && response_code <= 504) ||
         // S3 sends some client timeout errors as 400 Client Error
-        (response_code == 400 && pszErrBuf && strstr(pszErrBuf, "RequestTimeout")) )
+        (response_code == 400 && pszErrBuf && strstr(pszErrBuf, "RequestTimeout")) ||
+        pszErrBuf  // any transfer/connection/socket error
+        )
     {
         // Use an exponential backoff factor of 2 plus some random jitter
         // We don't care about cryptographic quality randomness, hence:

--- a/gdal/port/cpl_vsil_curl_class.h
+++ b/gdal/port/cpl_vsil_curl_class.h
@@ -548,7 +548,7 @@ void VSICURLInitWriteFuncStruct( WriteFuncStruct   *psStruct,
                                         void              *pReadCbkUserData );
 size_t VSICurlHandleWriteFunc( void *buffer, size_t count,
                                       size_t nmemb, void *req );
-void MultiPerform(CURLM* hCurlMultiHandle,
+CURLcode MultiPerform(CURLM* hCurlMultiHandle,
                          CURL* hEasyHandle = nullptr);
 void VSICURLResetHeaderAndWriterFunctions(CURL* hCurlHandle);
 


### PR DESCRIPTION
Currently the curl/http error handling is quite adhoc.

* there's a lot of code dealing with HTTP error codes, including the retry handling.
* failed requests (eg. closed sockets) may have good response codes, which _seem_ to be leaving it up to the driver to complain about short reads, rather than the HTTP stack clearly saying "this request failed".
* non-HTTP errors (connection errors, socket drops) aren't handled consistently

## What does this PR do?

This is very much a prototype/feedback-request for changes to improve this:

1. make `MultiPerform()` return the `CURLcode` request status
2. use curl request status for error handling checks in preference to `szErrBuf` string checking
3. make retry handling work for requests that fail due to socket/connection errors
4. disable retries on successful bad-request responses (most 4xx). Though there are a pile of edge cases coded, so need to verify/check them.
5. check vsicurl code is reporting, and drivers are handling, failed IO

Current changes work for this test case:
```
$ export GDAL_HTTP_MAX_RETRY=3 \
  GDAL_HTTP_TIMEOUT=60 \
  GDAL_HTTP_RETRY_DELAY=1 \
  GDAL_HTTP_UNSAFESSL=YES \
  GDAL_DISABLE_READDIR_ON_OPEN=TRUE \
  GDAL_HTTP_PROXY=localhost:8888
$ gdal_translate -of GTiff -co TILED=YES /vsis3/mybucket/my.tif /tmp/out.tif
``` 
tested with Charles Proxy 4.2.7, setting Throttling Reliability to 99% and toggling Throttling on/off. With the patch it'll happily retry _each request_ (not each file) if it encounters socket errors, without the patch the first failed connection aborts the process.

1. Approach seem reasonable? (I haven't used curl multi apis before)
2. There's a tonne more places using `MultiPerform()`/`curl_easy_perform()`/`curl_multi_perform()` all of which need addressing and reviewing for consistency.
3.  Current thoughts on testing: Find a lightweight programmable proxy we can integrate for unit tests. (Maybe [toxiproxy](https://github.com/Shopify/toxiproxy)?) Other suggestions welcome.

## What are related issues/pull requests?

* #1031
* #901 
* I'm sure there are others

## Tasklist

```
$ ack "(MultiPerform\(|curl_(easy|multi)_perform)" -l
gdal/frmts/wms/gdalhttp.cpp
gdal/port/cpl_vsil_swift.cpp
gdal/port/cpl_vsil_s3.cpp
gdal/port/cpl_http.cpp
gdal/port/cpl_vsil_curl.cpp
gdal/port/cpl_vsil_webhdfs.cpp
gdal/port/cpl_vsil_curl_class.h
gdal/port/cpl_vsil_az.cpp
gdal/port/cpl_vsil_curl_streaming.cpp
```

 - [ ] Approach feedback
 - [ ] More coding
 - [ ] Add test cases
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
