### PR TITLE
logging: Remove debug messages from GNM registration

### DIFF
--- a/gdal/gnm/gnm_frmts/gnmregisterall.cpp
+++ b/gdal/gnm/gnm_frmts/gnmregisterall.cpp
@@ -34,14 +34,11 @@ CPL_CVSID("$Id$")
 
 void GNMRegisterAllInternal()
 {
-    CPLDebug("GNM", "GNMRegisterAllInternal");
 #ifdef GNMFILE_ENABLED
-    CPLDebug("GNM", "RegisterGNMFile");
     RegisterGNMFile();
 #endif
 
 #ifdef GNMDB_ENABLED
-    CPLDebug("GNM", "RegisterGNMdatabase");
     RegisterGNMDatabase();
 #endif
 


### PR DESCRIPTION
GDAL initialisation with `CPL_DEBUG=ON` looks like:

```
GNM: GNMRegisterAllInternal
GNM: RegisterGNMFile
GNM: RegisterGNMdatabase
... useful stuff relating to what you're doing ...
```

No other drivers or infrastructure log any messages on _registering_, only when they're actually used (eg. HTTP printing libcurl/libssl versions).

## What does this PR do?

Strip these debug messages out.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
