### PR TITLE
Add MULTI_LOAD option to OpenOptions (fixes #1233)

### DIFF
--- a/gdal/ogr/ogrsf_frmts/oci/ogrocidriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/oci/ogrocidriver.cpp
@@ -118,6 +118,7 @@ void RegisterOGROCI()
 "  <Option name='PASSWORD' type='string' description='Password'/>"
 "  <Option name='TABLES' type='string' description='Restricted set of tables to list (comma separated)'/>"
 "  <Option name='WORKSPACE' type='string' description='Workspace'/>"
+"  <Option name='MULTI_LOAD' type='boolean' description='If enabled new features will be created in groups of 100 per SQL INSERT command' default='YES'/>"
 "  <Option name='MULTI_LOAD_COUNT' type='int' description='Number of itens for a group INSERT' default='100'/>"
 "  <Option name='FIRST_ID' type='int' description='First id value to be used on append'/>"
 "</OpenOptionList>");


### PR DESCRIPTION
When appending to an oci  data source, this option allows to disable MULTI_LOAD mode which is enabled by default.

## Add MULTI_LOAD option to OpenOptions
Duplicated setting from Layer Creation Options to Layer Open Options. Due to the missing in OpenOptions MULTI_LOAD is enabled by default and can't be disabled.