### PR TITLE
gdal_python.i - adding overviewLevel option to WarpOptions

### DIFF
--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1220,6 +1220,7 @@ def WarpOptions(options=None, format=None,
          cutlineLayer=None, cutlineWhere=None, cutlineSQL=None, cutlineBlend=None, cropToCutline = False,
          copyMetadata = True, metadataConflictValue=None,
          setColorInterpretation = False,
+         overviewLevel = 'AUTO',
          callback=None, callback_data=None):
     """ Create a WarpOptions() object that can be passed to gdal.Warp()
         Keyword arguments are :
@@ -1259,6 +1260,7 @@ def WarpOptions(options=None, format=None,
           copyMetadata --- whether to copy source metadata
           metadataConflictValue --- metadata data conflict value
           setColorInterpretation --- whether to force color interpretation of input bands to output bands
+          overviewLevel --- To specify which overview level of source files must be used
           callback --- callback method
           callback_data --- user data for callback
     """
@@ -1356,6 +1358,19 @@ def WarpOptions(options=None, format=None,
             new_options += ['-cvmd', str(metadataConflictValue)]
         if setColorInterpretation:
             new_options += ['-setci']
+        if overviewLevel is not None:
+            if _is_str_or_unicode(overviewLevel):
+                overviewLevelStr = overviewLevel
+            else:
+                overviewLevelStr = ''
+                if overviewLevel is None:
+                    overviewLevelStr = 'NONE'
+                if isinstance(overviewLevel, int):
+                    if overviewLevel < 0:
+                        overviewLevelStr = 'AUTO'
+                    overviewLevelStr = overviewLevelStr + str(overviewLevel)
+            if overviewLevelStr != '':
+                new_options += ['-ovr', overviewLevelStr]
 
     return (GDALWarpAppOptions(new_options), callback, callback_data)
 

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1358,19 +1358,22 @@ def WarpOptions(options=None, format=None,
             new_options += ['-cvmd', str(metadataConflictValue)]
         if setColorInterpretation:
             new_options += ['-setci']
-        if overviewLevel is not None:
-            if _is_str_or_unicode(overviewLevel):
-                overviewLevelStr = overviewLevel
+        
+        
+        if overviewLevel is None:
+            overviewLevel = 'NONE'
+        elif _is_str_or_unicode(overviewLevel):
+            pass
+        elif isinstance(overviewLevel, int):
+            if overviewLevel < 0:
+                overviewLevel = 'AUTO' + str(overviewLevel)
             else:
-                overviewLevelStr = ''
-                if overviewLevel is None:
-                    overviewLevelStr = 'NONE'
-                if isinstance(overviewLevel, int):
-                    if overviewLevel < 0:
-                        overviewLevelStr = 'AUTO'
-                    overviewLevelStr = overviewLevelStr + str(overviewLevel)
-            if overviewLevelStr != '':
-                new_options += ['-ovr', overviewLevelStr]
+                overviewLevel = str(overviewLevel)
+        else:
+            overviewLevel = ''
+            
+        if overviewLevel:
+            new_options += ['-ovr', overviewLevelStr]
 
     return (GDALWarpAppOptions(new_options), callback, callback_data)
 


### PR DESCRIPTION
Hi,
This is my first pull request to gdal :)

I was trying to use -ovr level option for gdalwarp in Python. 
Although it is available in the command line app I couldn't find it in the python API and I think it is missing. This pull request is to add this functionality to the Python API.

I added the support in WarpOptions in gdal.py and it works for me (I've tested only the 'level' option. I added support for AUTO and AUTO-n but didn't test them, so I don't know if I set these correctly).

In this pull request I applied the same change to gdal_python.i as I understand gdal.py is auto generated from this file. 
I didn't test the swig file because I don't know how.
