### PR TITLE
Geopackage srs_id fix for negative values

### DIFF
--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -1841,14 +1841,12 @@ bool GDALGeoPackageDataset::OpenRaster( const char* pszTableName,
 
     m_bRecordInsertedInGPKGContent = true;
     m_nSRID = nSRSId;
-    if( nSRSId > 0 )
+
+    OGRSpatialReference* poSRS = GetSpatialRef( nSRSId );
+    if( poSRS )
     {
-        OGRSpatialReference* poSRS = GetSpatialRef( nSRSId );
-        if( poSRS )
-        {
-            poSRS->exportToWkt(&m_pszProjection);
-            poSRS->Release();
-        }
+        poSRS->exportToWkt(&m_pszProjection);
+        poSRS->Release();
     }
 
     /* Various sanity checks added in the SELECT */


### PR DESCRIPTION
GPKG: Negative values other than -1 are valid for column `srs_id` in tables `gpkg_contents` and `gpkg_spatial_ref_sys`. There is no explicit mention that all negative values are invalid.

This is issue was discovered while working with a geopackage where one of the raster datasets in `gpkg_contents` has an `srs_id` with a value of -3. The `gpkg_spatial_ref_sys` table does contain a valid entry for -3.

![image](https://user-images.githubusercontent.com/9702913/52089755-32c15880-2564-11e9-8719-e0c0201e7300.png)

![image](https://user-images.githubusercontent.com/9702913/52089783-47055580-2564-11e9-963b-a3cdaffebfd3.png)

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
