### PR TITLE
VSI plugins

### DIFF
--- a/gdal/port/GNUmakefile
+++ b/gdal/port/GNUmakefile
@@ -33,7 +33,7 @@ OBJ =	cpl_conv.o cpl_error.o cpl_string.o cplgetsymbol.o cplstringlist.o \
 	cpl_google_oauth2.o cpl_progress.o cpl_virtualmem.o cpl_worker_thread_pool.o \
 	cpl_vsil_crypt.o cpl_sha1.o cpl_sha256.o cpl_aws.o cpl_vsi_error.o cpl_cpu_features.o \
 	cpl_google_cloud.o cpl_azure.o cpl_alibaba_oss.o cpl_json_streaming_parser.o \
-	cpl_json.o cpl_md5.o cpl_swift.o \
+	cpl_json.o cpl_md5.o cpl_swift.o cpl_vsil_plugin.o \
 	cpl_vsil_hdfs.o cpl_userfaultfd.o
 
 ifeq ($(ODBC_SETTING),yes)

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -406,53 +406,148 @@ GByte CPL_DLL *VSIGetMemFileBuffer( const char *pszFilename,
 typedef size_t (*VSIWriteFunction)(const void* ptr, size_t size, size_t nmemb, FILE* stream);
 void CPL_DLL VSIStdoutSetRedirection( VSIWriteFunction pFct, FILE* stream );
 
+/**
+ * Return information about a handle. Optional (driver dependant) 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginStatCallback)          ( void *pUserData, const char *pszFilename, VSIStatBufL *pStatBuf, int nFlags );
+/** 
+ * Remove handle by name. Optional 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginUnlinkCallback)        ( void *pUserData, const char *pszFilename );
+/** 
+ * Rename handle. Optional 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginRenameCallback)        ( void *pUserData, const char *oldpath, const char *newpath );
+/**
+ * Create Directory. Optional
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginMkdirCallback)         ( void *pUserData, const char *pszDirname, long nMode );
+/**
+ *  Delete Directory. Optional 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginRmdirCallback)         ( void *pUserData, const char *pszDirname );
+/** 
+ * List directory content. Optional 
+ * @since GDAL 2.5
+ */
 typedef char**         (*VSIFilesystemPluginReadDirCallback)       ( void *pUserData, const char *pszDirname, int nMaxFiles );
+/** 
+ * Open a handle. Mandatory. Returns an opaque pointer that will be used in subsequent file I/O calls.
+ * Should return null and/or set errno if the handle does not exist or the access mode is incorrect.
+ * @since GDAL 2.5
+ */
 typedef void*          (*VSIFilesystemPluginOpenCallback)          ( void *pUserData, const char *pszFilename, const char *pszAccess );
+/** 
+ * Return current position in handle. Mandatory 
+ * @since GDAL 2.5
+ */
 typedef vsi_l_offset   (*VSIFilesystemPluginTellCallback)          ( void *pFile );
+/** 
+ * Seek to position in handle. Mandatory except for write only handles 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginSeekCallback)          ( void *pFile, vsi_l_offset nOffset, int nWhence );
+/** 
+ * Read data from current position, returns the number of blocks correctly read.
+ * Mandatory except for write only handles
+ * @since GDAL 2.5
+ */
 typedef size_t         (*VSIFilesystemPluginReadCallback)          ( void *pFile, void *pBuffer, size_t nSize, size_t nCount );
+/** 
+ * Read from multiple offsets. Optional, will be replaced by multiple calls to Read() if not provided 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginReadMultiRangeCallback)( void *pFile, int nRanges, void ** ppData,
                                                                      const vsi_l_offset* panOffsets, const size_t* panSizes );
+/** 
+ * Get empty ranges. Optional 
+ * @since GDAL 2.5
+ */
 typedef VSIRangeStatus (*VSIFilesystemPluginGetRangeStatusCallback)( void *pFile, vsi_l_offset nOffset, vsi_l_offset nLength );
+/** 
+ * Has end of file been reached. Mandatory? for read handles. 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginEofCallback)           ( void *pFile );
+/** 
+ * Write bytes at current offset. Mandatory for writable handles 
+ * @since GDAL 2.5
+ */
 typedef size_t         (*VSIFilesystemPluginWriteCallback)         ( void *pFile, const void *pBuffer, size_t nSize,size_t nCount);
+/** 
+ * Sync written bytes. Optional 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginFlushCallback)         ( void *pFile );
+/** 
+ * Truncate handle. Mandatory (driver dependant?) for write handles 
+ */
 typedef int            (*VSIFilesystemPluginTruncateCallback)      ( void *pFile, vsi_l_offset nNewSize );
+/** 
+ * Close file handle. Optional 
+ * @since GDAL 2.5
+ */
 typedef int            (*VSIFilesystemPluginCloseCallback)         ( void *pFile );
 
+/**
+ * struct containing callbacks to used by the handler.
+ * (rw), (r), (w) or () at the end indicate wether the given callback is mandatory
+ * for reading and or writing handlers. A (?) indicates that the callback might
+ * be mandatory for certain drivers only.
+ * @since GDAL 2.5
+ */
+typedef struct {
+    /** 
+     * Optional opaque pointer passed back to filemanager callbacks (e.g. open, stat, rmdir)
+     */ 
+    void                                        *pUserData;
+    VSIFilesystemPluginStatCallback             stat; /**< stat handle by name (rw)*/
+    VSIFilesystemPluginUnlinkCallback           unlink; /**< unlink handle by name ()*/
+    VSIFilesystemPluginRenameCallback           rename; /**< rename handle ()*/
+    VSIFilesystemPluginMkdirCallback            mkdir; /**< make directory ()*/
+    VSIFilesystemPluginRmdirCallback            rmdir; /**< remove directory ()*/
+    VSIFilesystemPluginReadDirCallback          read_dir; /**< list directory content (r?)*/
+    VSIFilesystemPluginOpenCallback             open; /**< open handle by name (rw) */
+    VSIFilesystemPluginTellCallback             tell; /**< get current position of handle (rw) */
+    VSIFilesystemPluginSeekCallback             seek; /**< set current position of handle (rw) */
+    VSIFilesystemPluginReadCallback             read; /**< read from current position (r) */
+    VSIFilesystemPluginReadMultiRangeCallback   read_multi_range; /**< read multiple blocks ()*/
+    VSIFilesystemPluginGetRangeStatusCallback   get_range_status; /**< get range status () */
+    VSIFilesystemPluginEofCallback              eof; /**< has end of file been reached (r?) */
+    VSIFilesystemPluginWriteCallback            write; /**< write bytes to current position (w) */
+    VSIFilesystemPluginFlushCallback            flush; /**< sync bytes (w) */
+    VSIFilesystemPluginTruncateCallback         truncate; /**< truncate handle (w?) */
+    VSIFilesystemPluginCloseCallback            close; /**< close handle  (rw) */
 /* 
     Callbacks are defined as a struct allocated by a call to VSIAllocFilesystemPluginCallbacksStruct
     in order to try to maintain ABI stability when eventually adding a new member.
     Any callbacks added to this struct SHOULD be added to the END of this struct
 */
-typedef struct {
-    void                                        *pUserData;
-    VSIFilesystemPluginStatCallback             stat;
-    VSIFilesystemPluginUnlinkCallback           unlink;
-    VSIFilesystemPluginRenameCallback           rename;
-    VSIFilesystemPluginMkdirCallback            mkdir;
-    VSIFilesystemPluginRmdirCallback            rmdir;
-    VSIFilesystemPluginReadDirCallback          read_dir;
-    VSIFilesystemPluginOpenCallback             open;
-    VSIFilesystemPluginTellCallback             tell;
-    VSIFilesystemPluginSeekCallback             seek;
-    VSIFilesystemPluginReadCallback             read;
-    VSIFilesystemPluginReadMultiRangeCallback   read_multi_range;
-    VSIFilesystemPluginGetRangeStatusCallback   get_range_status;
-    VSIFilesystemPluginEofCallback              eof;
-    VSIFilesystemPluginWriteCallback            write;
-    VSIFilesystemPluginFlushCallback            flush;
-    VSIFilesystemPluginTruncateCallback         truncate;
-    VSIFilesystemPluginCloseCallback            close;
 } VSIFilesystemPluginCallbacksStruct;
 
-VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct( void );
-void VSIFreeFilesystemPluginCallbacksStruct(VSIFilesystemPluginCallbacksStruct* poCb);
+/** 
+ * return a VSIFilesystemPluginCallbacksStruct to be populated at runtime with handler callbacks 
+ * @since GDAL 2.5
+ */
+VSIFilesystemPluginCallbacksStruct CPL_DLL *VSIAllocFilesystemPluginCallbacksStruct( void );
+
+/**
+ * free resources allocated by VSIAllocFilesystemPluginCallbacksStruct
+ * @since GDAL 2.5
+ */
+void CPL_DLL VSIFreeFilesystemPluginCallbacksStruct(VSIFilesystemPluginCallbacksStruct* poCb);
+
+/**
+ * register a handler on the given prefix. All IO on datasets opened with the filename /prefix/xxxxxx
+ * will go through these callbacks.
+ * pszPrefix must begin and end with a '/'
+ * @since GDAL 2.5
+ */
 int CPL_DLL VSIInstallPluginHandler( const char* pszPrefix, const VSIFilesystemPluginCallbacksStruct* poCb);
 
 /* ==================================================================== */

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -406,26 +406,27 @@ GByte CPL_DLL *VSIGetMemFileBuffer( const char *pszFilename,
 typedef size_t (*VSIWriteFunction)(const void* ptr, size_t size, size_t nmemb, FILE* stream);
 void CPL_DLL VSIStdoutSetRedirection( VSIWriteFunction pFct, FILE* stream );
 
-typedef int            (*VSIFilesystemPluginStatCallback)          ( const char *pszFilename, VSIStatBufL *pStatBuf, int nFlags );
-typedef int            (*VSIFilesystemPluginUnlinkCallback)        ( const char *pszFilename );
-typedef int            (*VSIFilesystemPluginRenameCallback)        ( const char *oldpath, const char *newpath );
-typedef int            (*VSIFilesystemPluginMkdirCallback)         ( const char *pszDirname, long nMode );
-typedef int            (*VSIFilesystemPluginRmdirCallback)         ( const char *pszDirname );
-typedef char**         (*VSIFilesystemPluginReadDirCallback)       ( const char *pszDirname, int nMaxFiles );
-typedef const void*    (*VSIFilesystemPluginOpenCallback)          ( const char *pszFilename, const char *pszAccess );
-typedef vsi_l_offset   (*VSIFilesystemPluginTellCallback)          ( const void *psData );
-typedef int            (*VSIFilesystemPluginSeekCallback)          ( const void *psData, vsi_l_offset nOffset, int nWhence );
-typedef size_t         (*VSIFilesystemPluginReadCallback)          ( const void *psData, void *pBuffer, size_t nSize, size_t nCount );
-typedef int            (*VSIFilesystemPluginReadMultiRangeCallback)( const void *psData, int nRanges, void ** ppData,
+typedef int            (*VSIFilesystemPluginStatCallback)          ( void *pUserData, const char *pszFilename, VSIStatBufL *pStatBuf, int nFlags );
+typedef int            (*VSIFilesystemPluginUnlinkCallback)        ( void *pUserData, const char *pszFilename );
+typedef int            (*VSIFilesystemPluginRenameCallback)        ( void *pUserData, const char *oldpath, const char *newpath );
+typedef int            (*VSIFilesystemPluginMkdirCallback)         ( void *pUserData, const char *pszDirname, long nMode );
+typedef int            (*VSIFilesystemPluginRmdirCallback)         ( void *pUserData, const char *pszDirname );
+typedef char**         (*VSIFilesystemPluginReadDirCallback)       ( void *pUserData, const char *pszDirname, int nMaxFiles );
+typedef void*          (*VSIFilesystemPluginOpenCallback)          ( void *pUserData, const char *pszFilename, const char *pszAccess );
+typedef vsi_l_offset   (*VSIFilesystemPluginTellCallback)          ( void *pFile );
+typedef int            (*VSIFilesystemPluginSeekCallback)          ( void *pFile, vsi_l_offset nOffset, int nWhence );
+typedef size_t         (*VSIFilesystemPluginReadCallback)          ( void *pFile, void *pBuffer, size_t nSize, size_t nCount );
+typedef int            (*VSIFilesystemPluginReadMultiRangeCallback)( void *pFile, int nRanges, void ** ppData,
                                                                      const vsi_l_offset* panOffsets, const size_t* panSizes );
-typedef VSIRangeStatus (*VSIFilesystemPluginGetRangeStatusCallback)( const void *psData, vsi_l_offset nOffset, vsi_l_offset nLength );
-typedef int            (*VSIFilesystemPluginEofCallback)           ( const void *psData );
-typedef size_t         (*VSIFilesystemPluginWriteCallback)         ( const void *psData, const void *pBuffer, size_t nSize,size_t nCount);
-typedef int            (*VSIFilesystemPluginFlushCallback)         ( const void *psData );
-typedef int            (*VSIFilesystemPluginTruncateCallback)      ( const void *psData, vsi_l_offset nNewSize );
-typedef int            (*VSIFilesystemPluginCloseCallback)         ( const void *psData );
+typedef VSIRangeStatus (*VSIFilesystemPluginGetRangeStatusCallback)( void *pFile, vsi_l_offset nOffset, vsi_l_offset nLength );
+typedef int            (*VSIFilesystemPluginEofCallback)           ( void *pFile );
+typedef size_t         (*VSIFilesystemPluginWriteCallback)         ( void *pFile, const void *pBuffer, size_t nSize,size_t nCount);
+typedef int            (*VSIFilesystemPluginFlushCallback)         ( void *pFile );
+typedef int            (*VSIFilesystemPluginTruncateCallback)      ( void *pFile, vsi_l_offset nNewSize );
+typedef int            (*VSIFilesystemPluginCloseCallback)         ( void *pFile );
 
 typedef struct {
+    void                                        *pUserData;
     VSIFilesystemPluginStatCallback             stat;
     VSIFilesystemPluginUnlinkCallback           unlink;
     VSIFilesystemPluginRenameCallback           rename;

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -406,6 +406,49 @@ GByte CPL_DLL *VSIGetMemFileBuffer( const char *pszFilename,
 typedef size_t (*VSIWriteFunction)(const void* ptr, size_t size, size_t nmemb, FILE* stream);
 void CPL_DLL VSIStdoutSetRedirection( VSIWriteFunction pFct, FILE* stream );
 
+typedef int            (*VSIFilesystemPluginStatCallback)          ( const char *pszFilename, VSIStatBufL *pStatBuf, int nFlags );
+typedef int            (*VSIFilesystemPluginUnlinkCallback)        ( const char *pszFilename );
+typedef int            (*VSIFilesystemPluginRenameCallback)        ( const char *oldpath, const char *newpath );
+typedef int            (*VSIFilesystemPluginMkdirCallback)         ( const char *pszDirname, long nMode );
+typedef int            (*VSIFilesystemPluginRmdirCallback)         ( const char *pszDirname );
+typedef char**         (*VSIFilesystemPluginReadDirCallback)       ( const char *pszDirname, int nMaxFiles );
+typedef const void*    (*VSIFilesystemPluginOpenCallback)          ( const char *pszFilename, const char *pszAccess );
+typedef vsi_l_offset   (*VSIFilesystemPluginTellCallback)          ( const void *psData );
+typedef int            (*VSIFilesystemPluginSeekCallback)          ( const void *psData, vsi_l_offset nOffset, int nWhence );
+typedef size_t         (*VSIFilesystemPluginReadCallback)          ( const void *psData, void *pBuffer, size_t nSize, size_t nCount );
+typedef int            (*VSIFilesystemPluginReadMultiRangeCallback)( const void *psData, int nRanges, void ** ppData,
+                                                                     const vsi_l_offset* panOffsets, const size_t* panSizes );
+typedef VSIRangeStatus (*VSIFilesystemPluginGetRangeStatusCallback)( const void *psData, vsi_l_offset nOffset, vsi_l_offset nLength );
+typedef int            (*VSIFilesystemPluginEofCallback)           ( const void *psData );
+typedef size_t         (*VSIFilesystemPluginWriteCallback)         ( const void *psData, const void *pBuffer, size_t nSize,size_t nCount);
+typedef int            (*VSIFilesystemPluginFlushCallback)         ( const void *psData );
+typedef int            (*VSIFilesystemPluginTruncateCallback)      ( const void *psData, vsi_l_offset nNewSize );
+typedef int            (*VSIFilesystemPluginCloseCallback)         ( const void *psData );
+
+typedef struct {
+    VSIFilesystemPluginStatCallback             stat;
+    VSIFilesystemPluginUnlinkCallback           unlink;
+    VSIFilesystemPluginRenameCallback           rename;
+    VSIFilesystemPluginMkdirCallback            mkdir;
+    VSIFilesystemPluginRmdirCallback            rmdir;
+    VSIFilesystemPluginReadDirCallback          read_dir;
+    VSIFilesystemPluginOpenCallback             open;
+    VSIFilesystemPluginTellCallback             tell;
+    VSIFilesystemPluginSeekCallback             seek;
+    VSIFilesystemPluginReadCallback             read;
+    VSIFilesystemPluginReadMultiRangeCallback   read_multi_range;
+    VSIFilesystemPluginGetRangeStatusCallback   get_range_status;
+    VSIFilesystemPluginEofCallback              eof;
+    VSIFilesystemPluginWriteCallback            write;
+    VSIFilesystemPluginFlushCallback            flush;
+    VSIFilesystemPluginTruncateCallback         truncate;
+    VSIFilesystemPluginCloseCallback            close;
+} VSIFilesystemPluginCallbacksStruct;
+
+VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct();
+void VSIFreeFilesystemPluginCallbacksStruct(VSIFilesystemPluginCallbacksStruct* poCb);
+int CPL_DLL VSIInstallPluginHandler( const char* pszPrefix, const VSIFilesystemPluginCallbacksStruct* poCb);
+
 /* ==================================================================== */
 /*      Time querying.                                                  */
 /* ==================================================================== */

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -425,6 +425,11 @@ typedef int            (*VSIFilesystemPluginFlushCallback)         ( void *pFile
 typedef int            (*VSIFilesystemPluginTruncateCallback)      ( void *pFile, vsi_l_offset nNewSize );
 typedef int            (*VSIFilesystemPluginCloseCallback)         ( void *pFile );
 
+/* 
+    Callbacks are defined as a struct allocated by a call to VSIAllocFilesystemPluginCallbacksStruct
+    in order to try to maintain ABI stability when eventually adding a new member.
+    Any callbacks added to this struct SHOULD be added to the END of this struct
+*/
 typedef struct {
     void                                        *pUserData;
     VSIFilesystemPluginStatCallback             stat;
@@ -446,7 +451,7 @@ typedef struct {
     VSIFilesystemPluginCloseCallback            close;
 } VSIFilesystemPluginCallbacksStruct;
 
-VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct();
+VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct( void );
 void VSIFreeFilesystemPluginCallbacksStruct(VSIFilesystemPluginCallbacksStruct* poCb);
 int CPL_DLL VSIInstallPluginHandler( const char* pszPrefix, const VSIFilesystemPluginCallbacksStruct* poCb);
 

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -175,8 +175,7 @@ VSIVirtualHandle* VSIPluginFilesystemHandler::Open( const char *pszFilename,
     const void *cbData = open_cb(GetCallbackFilename(pszFilename), pszAccess);
     if (cbData == nullptr) {
         if (bSetError) {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                 "plugin callback failed to open %s", GetCallbackFilename(pszFilename));
+            VSIError(VSIE_FileError, "%s: %s", pszFilename, strerror(errno));
         }
         return nullptr;
     }

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -256,12 +256,12 @@ int VSIPluginFilesystemHandler::ReadMultiRange( void *pFile, int nRanges, void *
         }
     }
 
-    delete mOffsets;
-    delete mSizes;
+    delete[] mOffsets;
+    delete[] mSizes;
     for ( int i=0; i<nMergedRanges; i++ ) {
-        delete mData[i];
+        delete[] mData[i];
     }
-    delete mData;
+    delete[] mData;
 
     return ret;
 }

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -34,9 +34,6 @@
 
 namespace cpl {
 
-/************************************************************************/
-/*                           VSIPluginHandle()                            */
-/************************************************************************/
 
 VSIPluginHandle::VSIPluginHandle( VSIPluginFilesystemHandler* poFSIn,
                                   void *cbDataIn) :
@@ -45,9 +42,6 @@ VSIPluginHandle::VSIPluginHandle( VSIPluginFilesystemHandler* poFSIn,
 {
 }
 
-/************************************************************************/
-/*                          ~VSIPluginHandle()                            */
-/************************************************************************/
 
 VSIPluginHandle::~VSIPluginHandle()
 {
@@ -57,9 +51,6 @@ VSIPluginHandle::~VSIPluginHandle()
 }
 
 
-/************************************************************************/
-/*                                Seek()                                */
-/************************************************************************/
 
 int VSIPluginHandle::Seek( vsi_l_offset nOffset, int nWhence )
 {
@@ -67,9 +58,6 @@ int VSIPluginHandle::Seek( vsi_l_offset nOffset, int nWhence )
 }
 
 
-/************************************************************************/
-/*                                  Tell()                              */
-/************************************************************************/
 
 vsi_l_offset VSIPluginHandle::Tell()
 {
@@ -114,9 +102,6 @@ int VSIPluginHandle::Truncate( vsi_l_offset nNewSize ) {
     return poFS->Truncate(cbData,nNewSize);
 }
 
-/************************************************************************/
-/*                   VSIPluginFilesystemHandler()                         */
-/************************************************************************/
 
 VSIPluginFilesystemHandler::VSIPluginFilesystemHandler( const char *pszPrefix,
                                 const VSIFilesystemPluginCallbacksStruct *cbIn):
@@ -132,9 +117,6 @@ VSIPluginFilesystemHandler::~VSIPluginFilesystemHandler()
 }
 
 
-/************************************************************************/
-/*                                Open()                                */
-/************************************************************************/
 
 VSIVirtualHandle* VSIPluginFilesystemHandler::Open( const char *pszFilename,
                                                   const char *pszAccess,
@@ -162,9 +144,6 @@ bool VSIPluginFilesystemHandler::IsValidFilename(const char *pszFilename) {
     return true;
 }
 
-/************************************************************************/
-/*                                Stat()                                */
-/************************************************************************/
 
 int VSIPluginFilesystemHandler::Stat( const char *pszFilename,
                                       VSIStatBufL *pStatBuf,
@@ -303,7 +282,7 @@ int VSIPluginFilesystemHandler::Rmdir(const char *pszDirname) {
         return -1;
     return m_cb->rmdir(m_cb->pUserData, GetCallbackFilename(pszDirname));
 }
-}
+} // namespace cpl
 #endif
 
 int VSIInstallPluginHandler( const char* pszPrefix, const VSIFilesystemPluginCallbacksStruct *poCb) {

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -313,7 +313,7 @@ int VSIInstallPluginHandler( const char* pszPrefix, const VSIFilesystemPluginCal
     return 0;
 }
 
-VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct() {
+VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct( void ) {
     return static_cast<VSIFilesystemPluginCallbacksStruct*>(VSI_CALLOC_VERBOSE(1, sizeof(VSIFilesystemPluginCallbacksStruct)));
 }
 void VSIFreeFilesystemPluginCallbacksStruct(VSIFilesystemPluginCallbacksStruct* poCb) {

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -283,7 +283,9 @@ int VSIPluginFilesystemHandler::Rmdir(const char *pszDirname) {
     return m_cb->rmdir(m_cb->pUserData, GetCallbackFilename(pszDirname));
 }
 } // namespace cpl
-#endif
+
+#endif //DOXYGEN_SKIP
+//! @endcond
 
 int VSIInstallPluginHandler( const char* pszPrefix, const VSIFilesystemPluginCallbacksStruct *poCb) {
     VSIFilesystemHandler* poHandler = new cpl::VSIPluginFilesystemHandler(pszPrefix, poCb);

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -1,0 +1,369 @@
+/******************************************************************************
+ *
+ * Project:  CPL - Common Portability Library
+ * Purpose:  Implement VSI large file api for plugins
+ * Author:   Thomas Bonfort, thomas.bonfort@airbus.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2019, Thomas Bonfort <thomas.bonfort@airbus.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_port.h"
+#include "cpl_vsil_plugin.h"
+
+//! @cond Doxygen_Suppress
+#ifndef DOXYGEN_SKIP
+
+namespace cpl {
+
+/************************************************************************/
+/*                           VSIPluginHandle()                            */
+/************************************************************************/
+
+VSIPluginHandle::VSIPluginHandle( VSIPluginFilesystemHandler* poFSIn,
+                                  const void *cbDataIn) :
+    poFS(poFSIn),
+    cbData(cbDataIn)
+{
+}
+
+/************************************************************************/
+/*                          ~VSIPluginHandle()                            */
+/************************************************************************/
+
+VSIPluginHandle::~VSIPluginHandle()
+{
+    if (cbData) {
+        Close();
+    }
+}
+
+
+/************************************************************************/
+/*                                Seek()                                */
+/************************************************************************/
+
+int VSIPluginHandle::Seek( vsi_l_offset nOffset, int nWhence )
+{
+    return poFS->Seek(cbData,nOffset,nWhence);
+}
+
+
+/************************************************************************/
+/*                                  Tell()                              */
+/************************************************************************/
+
+vsi_l_offset VSIPluginHandle::Tell()
+{
+    return poFS->Tell(cbData);
+}
+
+size_t VSIPluginHandle::Read( void * const pBuffer, size_t const nSize,
+                            size_t const  nMemb )
+{
+    return poFS->Read(cbData, pBuffer, nSize, nMemb);
+}
+
+int VSIPluginHandle::Eof()
+{
+    return poFS->Eof(cbData);
+}
+
+int VSIPluginHandle::Close()
+{
+    int ret = poFS->Close(cbData);
+    cbData = nullptr;
+    return ret;
+}
+
+int VSIPluginHandle::ReadMultiRange( int nRanges, void ** ppData, const vsi_l_offset* panOffsets, const size_t* panSizes ) {
+    return poFS->ReadMultiRange(cbData,nRanges,ppData,panOffsets,panSizes);
+}
+
+VSIRangeStatus VSIPluginHandle::GetRangeStatus( vsi_l_offset nOffset, vsi_l_offset nLength ) {
+    return poFS->GetRangeStatus(cbData,nOffset,nLength);
+}
+
+size_t VSIPluginHandle::Write( const void *pBuffer, size_t nSize,size_t nCount) {
+    return poFS->Write(cbData,pBuffer,nSize,nCount);
+}
+
+int VSIPluginHandle::Flush() {
+    return poFS->Flush(cbData);
+}
+
+int VSIPluginHandle::Truncate( vsi_l_offset nNewSize ) {
+    return poFS->Truncate(cbData,nNewSize);
+}
+
+/************************************************************************/
+/*                   VSIPluginFilesystemHandler()                         */
+/************************************************************************/
+
+VSIPluginFilesystemHandler::VSIPluginFilesystemHandler( const char *pszPrefix,
+                                VSIFilesystemPluginStatCallback             stat,
+                                VSIFilesystemPluginUnlinkCallback           unlink,
+                                VSIFilesystemPluginRenameCallback           rename,
+                                VSIFilesystemPluginMkdirCallback            mkdir,
+                                VSIFilesystemPluginRmdirCallback            rmdir,
+                                VSIFilesystemPluginReadDirCallback          read_dir,
+                                VSIFilesystemPluginOpenCallback             open,
+                                VSIFilesystemPluginTellCallback             tell,
+                                VSIFilesystemPluginSeekCallback             seek,
+                                VSIFilesystemPluginReadCallback             read,
+                                VSIFilesystemPluginReadMultiRangeCallback   read_multi_range,
+                                VSIFilesystemPluginGetRangeStatusCallback   get_range_status,
+                                VSIFilesystemPluginEofCallback              eof,
+                                VSIFilesystemPluginWriteCallback            write,
+                                VSIFilesystemPluginFlushCallback            flush,
+                                VSIFilesystemPluginTruncateCallback         truncate,
+                                VSIFilesystemPluginCloseCallback            close) :
+    m_Prefix(pszPrefix),
+    stat_cb(stat),
+    unlink_cb(unlink),
+    rename_cb(rename),
+    mkdir_cb(mkdir),
+    rmdir_cb(rmdir),
+    read_dir_cb(read_dir),
+    open_cb(open),
+    tell_cb(tell),
+    seek_cb(seek),
+    read_cb(read),
+    read_multi_range_cb(read_multi_range),
+    get_range_status_cb(get_range_status),
+    eof_cb(eof),
+    write_cb(write),
+    flush_cb(flush),
+    truncate_cb(truncate),
+    close_cb(close)
+{
+}
+
+VSIPluginFilesystemHandler::~VSIPluginFilesystemHandler()
+{
+}
+
+
+/************************************************************************/
+/*                                Open()                                */
+/************************************************************************/
+
+VSIVirtualHandle* VSIPluginFilesystemHandler::Open( const char *pszFilename,
+                                                  const char *pszAccess,
+                                                  bool bSetError )
+{
+    if( !IsValidFilename(pszFilename) )
+        return nullptr;
+    const void *cbData = open_cb(GetCallbackFilename(pszFilename), pszAccess);
+    if (cbData == nullptr) {
+        if (bSetError) {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                 "plugin callback failed to open %s", GetCallbackFilename(pszFilename));
+        }
+        return nullptr;
+    }
+    return new VSIPluginHandle(this, cbData);
+}
+
+const char* VSIPluginFilesystemHandler::GetCallbackFilename(const char *pszFilename) {
+    return pszFilename + strlen(m_Prefix);
+}
+
+bool VSIPluginFilesystemHandler::IsValidFilename(const char *pszFilename) {
+    if( !STARTS_WITH_CI(pszFilename, m_Prefix) )
+        return false;
+    return true;
+}
+
+/************************************************************************/
+/*                                Stat()                                */
+/************************************************************************/
+
+int VSIPluginFilesystemHandler::Stat( const char *pszFilename,
+                                      VSIStatBufL *pStatBuf,
+                                      int nFlags )
+{
+    if( !IsValidFilename(pszFilename) ) {
+        errno = EBADF;
+        return -1;
+    }
+
+
+    memset(pStatBuf, 0, sizeof(VSIStatBufL));
+
+    int nRet = 0;
+    if ( stat_cb != nullptr ) {
+        nRet = stat_cb(GetCallbackFilename(pszFilename), pStatBuf, nFlags);
+    } else {
+        nRet = -1;
+    }
+    return nRet;
+}
+
+int VSIPluginFilesystemHandler::Seek(const void *psData, vsi_l_offset nOffset, int nWhence) {
+    if (seek_cb != nullptr) {
+        return seek_cb(psData,static_cast<size_t>(nOffset),nWhence);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Seek not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+vsi_l_offset VSIPluginFilesystemHandler::Tell(const void *psData) {
+    if (tell_cb != nullptr) {
+        return tell_cb(psData);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Tell not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+size_t VSIPluginFilesystemHandler::Read(const void *psData, void *pBuffer, size_t nSize, size_t nCount) {
+    if (read_cb != nullptr) {
+        return read_cb(psData, pBuffer, nSize, nCount);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Read not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+int VSIPluginFilesystemHandler::HasOptimizedReadMultiRange(const char* /*pszPath*/ ) {
+    if (read_multi_range_cb != nullptr) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
+VSIRangeStatus VSIPluginFilesystemHandler::GetRangeStatus( const void *psData, vsi_l_offset nOffset, vsi_l_offset nLength) {
+    if (get_range_status_cb != nullptr) {
+        return get_range_status_cb(psData,nOffset,nLength);
+    }
+    return VSI_RANGE_STATUS_UNKNOWN;
+}
+
+int VSIPluginFilesystemHandler::ReadMultiRange( const void *psData, int nRanges, void ** ppData, const vsi_l_offset* panOffsets, const size_t* panSizes ) {
+    if (read_multi_range_cb != nullptr) {
+        return read_multi_range_cb(psData, nRanges, ppData, panOffsets, panSizes);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Read not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+int VSIPluginFilesystemHandler::Eof(const void *psData) {
+    if (eof_cb != nullptr) {
+        return eof_cb(psData);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Eof not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+int VSIPluginFilesystemHandler::Close(const void *psData) {
+    if (close_cb != nullptr) {
+        return close_cb(psData);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Close not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+size_t VSIPluginFilesystemHandler::Write(const void *psData, const void *psBuffer, size_t nSize, size_t nCount) {
+    if (write_cb != nullptr) {
+        return write_cb(psData,psBuffer,nSize,nCount);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Write not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+int VSIPluginFilesystemHandler::Flush(const void *psData) {
+    if (flush_cb != nullptr) {
+        return flush_cb(psData);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Flush not implemented for %s plugin", m_Prefix);
+    return -1;
+}
+
+int VSIPluginFilesystemHandler::Truncate(const void *psData, vsi_l_offset nNewSize) {
+    if (truncate_cb != nullptr) {
+        return truncate_cb(psData, nNewSize);
+    }
+    CPLError(CE_Failure, CPLE_AppDefined, "Truncate not implemented for %s plugin", m_Prefix);
+    return -1;
+
+}
+
+char ** VSIPluginFilesystemHandler::ReadDirEx( const char * pszDirname, int nMaxFiles ) {
+    if( !IsValidFilename(pszDirname) )
+        return nullptr;
+    if (read_dir_cb != nullptr) {
+        return read_dir_cb(GetCallbackFilename(pszDirname),nMaxFiles);
+    }
+    return nullptr;
+}
+
+int VSIPluginFilesystemHandler::Unlink(const char *pszFilename) {
+    if( unlink_cb == nullptr || !IsValidFilename(pszFilename) )
+        return -1;
+    return unlink_cb(GetCallbackFilename(pszFilename));
+}
+int VSIPluginFilesystemHandler::Rename(const char *oldpath, const char *newpath) {
+    if( rename_cb == nullptr || !IsValidFilename(oldpath) || !IsValidFilename(newpath) )
+        return -1;
+    return rename_cb(GetCallbackFilename(oldpath), GetCallbackFilename(newpath));
+}
+int VSIPluginFilesystemHandler::Mkdir(const char *pszDirname, long nMode) {
+    if( mkdir_cb == nullptr || !IsValidFilename(pszDirname) )
+        return -1;
+    return mkdir_cb(GetCallbackFilename(pszDirname), nMode);
+}
+int VSIPluginFilesystemHandler::Rmdir(const char *pszDirname) {
+    if( rmdir_cb == nullptr || !IsValidFilename(pszDirname) )
+        return -1;
+    return rmdir_cb(GetCallbackFilename(pszDirname));
+}
+}
+#endif
+
+int VSIInstallPluginHandler( const char* pszPrefix, const VSIFilesystemPluginCallbacksStruct *poCb) {
+    VSIFilesystemHandler* poHandler = new cpl::VSIPluginFilesystemHandler(pszPrefix,
+                poCb->stat,
+                poCb->unlink,
+                poCb->rename,
+                poCb->mkdir,
+                poCb->rmdir,
+                poCb->read_dir,
+                poCb->open,
+                poCb->tell,
+                poCb->seek,
+                poCb->read,
+                poCb->read_multi_range,
+                poCb->get_range_status,
+                poCb->eof,
+                poCb->write,
+                poCb->flush,
+                poCb->truncate,
+                poCb->close);
+    //TODO: check pszPrefix starts and ends with a /
+    VSIFileManager::InstallHandler( pszPrefix, poHandler );
+    return 0;
+}
+
+VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct() {
+    return static_cast<VSIFilesystemPluginCallbacksStruct*>(VSI_CALLOC_VERBOSE(1, sizeof(VSIFilesystemPluginCallbacksStruct)));
+}
+void VSIFreeFilesystemPluginCallbacksStruct(VSIFilesystemPluginCallbacksStruct* poCb) {
+    CPLFree(poCb);
+}

--- a/gdal/port/cpl_vsil_plugin.h
+++ b/gdal/port/cpl_vsil_plugin.h
@@ -1,0 +1,158 @@
+/******************************************************************************
+ *
+ * Project:  CPL - Common Portability Library
+ * Purpose:  Declarations for vsi filesystem plugin handlers
+ * Author:   Thomas Bonfort <thomas.bonfort@airbus.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2019, Thomas Bonfort <thomas.bonfort@airbus.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef CPL_VSIL_PLUGIN_H_INCLUDED
+#define CPL_VSIL_PLUGIN_H_INCLUDED
+
+#include "cpl_port.h"
+#include "cpl_string.h"
+#include "cpl_vsi.h"
+#include "cpl_vsi_virtual.h"
+
+//! @cond Doxygen_Suppress
+
+namespace cpl {
+
+/************************************************************************/
+/*                     VSIPluginFilesystemHandler                         */
+/************************************************************************/
+
+class VSIPluginHandle;
+
+class VSIPluginFilesystemHandler : public VSIFilesystemHandler
+{
+    CPL_DISALLOW_COPY_ASSIGN(VSIPluginFilesystemHandler)
+
+private:
+    const char*         m_Prefix;
+    VSIFilesystemPluginStatCallback             stat_cb;
+    VSIFilesystemPluginUnlinkCallback           unlink_cb;
+    VSIFilesystemPluginRenameCallback           rename_cb;
+    VSIFilesystemPluginMkdirCallback            mkdir_cb;
+    VSIFilesystemPluginRmdirCallback            rmdir_cb;
+    VSIFilesystemPluginReadDirCallback          read_dir_cb;
+    VSIFilesystemPluginOpenCallback             open_cb;
+    VSIFilesystemPluginTellCallback             tell_cb;
+    VSIFilesystemPluginSeekCallback             seek_cb;
+    VSIFilesystemPluginReadCallback             read_cb;
+    VSIFilesystemPluginReadMultiRangeCallback   read_multi_range_cb;
+    VSIFilesystemPluginGetRangeStatusCallback   get_range_status_cb;
+    VSIFilesystemPluginEofCallback              eof_cb;
+    VSIFilesystemPluginWriteCallback            write_cb;
+    VSIFilesystemPluginFlushCallback            flush_cb;
+    VSIFilesystemPluginTruncateCallback         truncate_cb;
+    VSIFilesystemPluginCloseCallback            close_cb;
+
+protected:
+    friend class VSIPluginHandle;
+    VSIPluginHandle* CreatePluginHandle(void *cbData);
+    const char* GetCallbackFilename(const char* pszFilename);
+    bool IsValidFilename(const char *pszFilename);
+
+    vsi_l_offset    Tell( const void *psData );
+    int             Seek( const void *psData, vsi_l_offset nOffset, int nWhence );
+    size_t          Read( const void *psData, void *pBuffer, size_t nSize, size_t nCount );
+    int             ReadMultiRange( const void *psData, int nRanges, void ** ppData, const vsi_l_offset* panOffsets, const size_t* panSizes );
+    VSIRangeStatus  GetRangeStatus( const void *psData, vsi_l_offset nOffset, vsi_l_offset nLength );
+    int             Eof( const void *psData );
+    size_t          Write( const void *psData, const void *pBuffer, size_t nSize,size_t nCount);
+    int             Flush( const void *psData );
+    int             Truncate( const void *psData, vsi_l_offset nNewSize );
+    int             Close( const void *psData );
+
+public:
+    VSIPluginFilesystemHandler( const char *pszPrefix,
+                                VSIFilesystemPluginStatCallback             stat,
+                                VSIFilesystemPluginUnlinkCallback           unlink,
+                                VSIFilesystemPluginRenameCallback           rename,
+                                VSIFilesystemPluginMkdirCallback            mkdir,
+                                VSIFilesystemPluginRmdirCallback            rmdir,
+                                VSIFilesystemPluginReadDirCallback          read_dir,
+                                VSIFilesystemPluginOpenCallback             open,
+                                VSIFilesystemPluginTellCallback             tell,
+                                VSIFilesystemPluginSeekCallback             seek,
+                                VSIFilesystemPluginReadCallback             read,
+                                VSIFilesystemPluginReadMultiRangeCallback   read_multi_range,
+                                VSIFilesystemPluginGetRangeStatusCallback   get_range_status,
+                                VSIFilesystemPluginEofCallback              eof,
+                                VSIFilesystemPluginWriteCallback            write,
+                                VSIFilesystemPluginFlushCallback            fush,
+                                VSIFilesystemPluginTruncateCallback         truncate,
+                                VSIFilesystemPluginCloseCallback            close);
+    ~VSIPluginFilesystemHandler() override;
+
+    VSIVirtualHandle *Open( const char *pszFilename,
+                            const char *pszAccess,
+                            bool bSetError ) override;
+
+    int Stat        ( const char *pszFilename, VSIStatBufL *pStatBuf, int nFlags ) override;
+    int Unlink      ( const char * pszFilename ) override;
+    int Rename      ( const char * oldpath, const char * /*newpath*/ ) override;
+    int Mkdir       ( const char * pszDirname, long nMode ) override;
+    int Rmdir       ( const char * pszDirname ) override;
+    char **ReadDir  ( const char *pszDirname ) override
+                        { return ReadDirEx(pszDirname, 0); }
+    char **ReadDirEx( const char * pszDirname, int nMaxFiles ) override;
+    int HasOptimizedReadMultiRange(const char* pszPath ) override;
+    
+};
+
+/************************************************************************/
+/*                           VSIPluginHandle                              */
+/************************************************************************/
+
+class VSIPluginHandle : public VSIVirtualHandle
+{
+    CPL_DISALLOW_COPY_ASSIGN(VSIPluginHandle)
+
+  protected:
+    VSIPluginFilesystemHandler* poFS;
+    const void *cbData;
+
+  public:
+
+    VSIPluginHandle( VSIPluginFilesystemHandler* poFS, const void *cbData);
+    ~VSIPluginHandle() override;
+
+    vsi_l_offset    Tell() override;
+    int             Seek( vsi_l_offset nOffset, int nWhence ) override;
+    size_t          Read( void *pBuffer, size_t nSize, size_t nCount ) override;
+    int             ReadMultiRange( int nRanges, void ** ppData, const vsi_l_offset* panOffsets, const size_t* panSizes ) override;
+    VSIRangeStatus  GetRangeStatus( vsi_l_offset nOffset, vsi_l_offset nLength ) override;
+    int             Eof() override;
+    size_t          Write( const void *pBuffer, size_t nSize,size_t nCount) override;
+    int             Flush() override;
+    int             Truncate( vsi_l_offset nNewSize ) override;
+    int             Close() override;
+};
+
+} // namespace cpl
+
+//! @endcond
+
+#endif // CPL_VSIL_PLUGIN_H_INCLUDED

--- a/gdal/port/cpl_vsil_plugin.h
+++ b/gdal/port/cpl_vsil_plugin.h
@@ -50,23 +50,7 @@ class VSIPluginFilesystemHandler : public VSIFilesystemHandler
 
 private:
     const char*         m_Prefix;
-    VSIFilesystemPluginStatCallback             stat_cb;
-    VSIFilesystemPluginUnlinkCallback           unlink_cb;
-    VSIFilesystemPluginRenameCallback           rename_cb;
-    VSIFilesystemPluginMkdirCallback            mkdir_cb;
-    VSIFilesystemPluginRmdirCallback            rmdir_cb;
-    VSIFilesystemPluginReadDirCallback          read_dir_cb;
-    VSIFilesystemPluginOpenCallback             open_cb;
-    VSIFilesystemPluginTellCallback             tell_cb;
-    VSIFilesystemPluginSeekCallback             seek_cb;
-    VSIFilesystemPluginReadCallback             read_cb;
-    VSIFilesystemPluginReadMultiRangeCallback   read_multi_range_cb;
-    VSIFilesystemPluginGetRangeStatusCallback   get_range_status_cb;
-    VSIFilesystemPluginEofCallback              eof_cb;
-    VSIFilesystemPluginWriteCallback            write_cb;
-    VSIFilesystemPluginFlushCallback            flush_cb;
-    VSIFilesystemPluginTruncateCallback         truncate_cb;
-    VSIFilesystemPluginCloseCallback            close_cb;
+    const VSIFilesystemPluginCallbacksStruct* m_cb;
 
 protected:
     friend class VSIPluginHandle;
@@ -74,36 +58,20 @@ protected:
     const char* GetCallbackFilename(const char* pszFilename);
     bool IsValidFilename(const char *pszFilename);
 
-    vsi_l_offset    Tell( const void *psData );
-    int             Seek( const void *psData, vsi_l_offset nOffset, int nWhence );
-    size_t          Read( const void *psData, void *pBuffer, size_t nSize, size_t nCount );
-    int             ReadMultiRange( const void *psData, int nRanges, void ** ppData, const vsi_l_offset* panOffsets, const size_t* panSizes );
-    VSIRangeStatus  GetRangeStatus( const void *psData, vsi_l_offset nOffset, vsi_l_offset nLength );
-    int             Eof( const void *psData );
-    size_t          Write( const void *psData, const void *pBuffer, size_t nSize,size_t nCount);
-    int             Flush( const void *psData );
-    int             Truncate( const void *psData, vsi_l_offset nNewSize );
-    int             Close( const void *psData );
+    vsi_l_offset    Tell( void *pFile );
+    int             Seek( void *pFile, vsi_l_offset nOffset, int nWhence );
+    size_t          Read( void *pFile, void *pBuffer, size_t nSize, size_t nCount );
+    int             ReadMultiRange( void *pFile, int nRanges, void ** ppData, const vsi_l_offset* panOffsets, const size_t* panSizes );
+    VSIRangeStatus  GetRangeStatus( void *pFile, vsi_l_offset nOffset, vsi_l_offset nLength );
+    int             Eof( void *pFile );
+    size_t          Write( void *pFile, const void *pBuffer, size_t nSize,size_t nCount);
+    int             Flush( void *pFile );
+    int             Truncate( void *pFile, vsi_l_offset nNewSize );
+    int             Close( void *pFile );
 
 public:
     VSIPluginFilesystemHandler( const char *pszPrefix,
-                                VSIFilesystemPluginStatCallback             stat,
-                                VSIFilesystemPluginUnlinkCallback           unlink,
-                                VSIFilesystemPluginRenameCallback           rename,
-                                VSIFilesystemPluginMkdirCallback            mkdir,
-                                VSIFilesystemPluginRmdirCallback            rmdir,
-                                VSIFilesystemPluginReadDirCallback          read_dir,
-                                VSIFilesystemPluginOpenCallback             open,
-                                VSIFilesystemPluginTellCallback             tell,
-                                VSIFilesystemPluginSeekCallback             seek,
-                                VSIFilesystemPluginReadCallback             read,
-                                VSIFilesystemPluginReadMultiRangeCallback   read_multi_range,
-                                VSIFilesystemPluginGetRangeStatusCallback   get_range_status,
-                                VSIFilesystemPluginEofCallback              eof,
-                                VSIFilesystemPluginWriteCallback            write,
-                                VSIFilesystemPluginFlushCallback            fush,
-                                VSIFilesystemPluginTruncateCallback         truncate,
-                                VSIFilesystemPluginCloseCallback            close);
+                                const VSIFilesystemPluginCallbacksStruct *cb);
     ~VSIPluginFilesystemHandler() override;
 
     VSIVirtualHandle *Open( const char *pszFilename,
@@ -132,11 +100,11 @@ class VSIPluginHandle : public VSIVirtualHandle
 
   protected:
     VSIPluginFilesystemHandler* poFS;
-    const void *cbData;
+    void *cbData;
 
   public:
 
-    VSIPluginHandle( VSIPluginFilesystemHandler* poFS, const void *cbData);
+    VSIPluginHandle( VSIPluginFilesystemHandler* poFS, void *cbData);
     ~VSIPluginHandle() override;
 
     vsi_l_offset    Tell() override;

--- a/gdal/port/makefile.vc
+++ b/gdal/port/makefile.vc
@@ -43,6 +43,7 @@ OBJ	=	cpl_conv.obj \
 		cpl_vsil_gs.obj \
 		cpl_vsil_az.obj \
 		cpl_vsil_oss.obj \
+		cpl_vsil_plugin.obj \
 		cpl_vsil_swift.obj \
 		cpl_vsil_webhdfs.obj \
 		cpl_vsil_hdfs.obj \


### PR DESCRIPTION
This PR allows to dynamically register a VSI handler at runtime by passing a select number of callback functions. Our principle use-case is to be able to bypass the vsicurl handler when accessing remote datasets, to provide observability, custom error handling, retrying, logging, fine-grained concurrency control, fine-grained caching, and better stability under heavily multi-threaded loads.


