### PR TITLE
gdal_retile.py: respect nodata values on inputs

### DIFF
--- a/gdal/swig/python/scripts/gdal_retile.py
+++ b/gdal/swig/python/scripts/gdal_retile.py
@@ -148,6 +148,7 @@ class mosaic_info(object):
         self.bands = fhInputTile.RasterCount
         self.band_type = fhInputTile.GetRasterBand(1).DataType
         self.projection = fhInputTile.GetProjection()
+        self.nodata = fhInputTile.GetRasterBand(1).GetNoDataValue()
 
         dec = AffineTransformDecorator(fhInputTile.GetGeoTransform())
         self.scaleX = dec.scaleX
@@ -209,6 +210,12 @@ class mosaic_info(object):
         resultDS = self.TempDriver.Create("TEMP", resultSizeX, resultSizeY, self.bands, self.band_type, [])
         resultDS.SetGeoTransform([minx, self.scaleX, 0, maxy, 0, self.scaleY])
 
+        for bandNr in range(1, self.bands + 1):
+            t_band = resultDS.GetRasterBand(bandNr)
+            if self.nodata is not None:
+                t_band.Fill(self.nodata)
+                t_band.SetNoDataValue(self.nodata)
+
         for feature in features:
             featureName = feature.GetField(0)
             sourceDS = self.cache.get(featureName)
@@ -240,8 +247,6 @@ class mosaic_info(object):
             tw_yoff = int((tgw_uly - maxy) / self.scaleY + 0.5)
             tw_xsize = min(resultDS.RasterXSize, int((tgw_lrx - minx) / self.scaleX + 0.5)) - tw_xoff
             tw_ysize = min(resultDS.RasterYSize, int((tgw_lry - maxy) / self.scaleY + 0.5)) - tw_yoff
-            # print(sw_xoff, sw_yoff, sw_xsize, sw_ysize, sourceDS.RasterXSize, sourceDS.RasterYSize)
-            # print(tw_xoff, tw_yoff, tw_xsize, tw_ysize, resultDS.RasterXSize, resultDS.RasterYSize)
             if tw_xsize <= 0 or tw_ysize <= 0:
                 continue
 
@@ -456,6 +461,12 @@ def createPyramidTile(levelMosaicInfo, offsetX, offsetY, width, height, tileName
             t_band.SetRasterColorTable(levelMosaicInfo.ct)
         t_band.SetRasterColorInterpretation(levelMosaicInfo.ci[band - 1])
 
+    if levelMosaicInfo.nodata is not None:
+        for band in range(1, bands + 1):
+            t_band = t_fh.GetRasterBand(band)
+            t_band.Fill(levelMosaicInfo.nodata)
+            t_band.SetNoDataValue(levelMosaicInfo.nodata)
+
     res = gdal.ReprojectImage(s_fh, t_fh, None, None, ResamplingMethod)
     if res != 0:
         print("Reprojection failed for %s, error %d" % (tileName, res))
@@ -522,8 +533,10 @@ def createTile(minfo, offsetX, offsetY, width, height, tilename, OGRDS):
         t_band = t_fh.GetRasterBand(band)
         if minfo.ct is not None:
             t_band.SetRasterColorTable(minfo.ct)
+        if minfo.nodata is not None:
+            t_band.Fill(minfo.nodata)
+            t_band.SetNoDataValue(minfo.nodata)
 
-#        data = s_band.ReadRaster( offsetX,offsetY,width,height,width,height, t_band.DataType )
         data = s_band.ReadRaster(0, 0, readX, readY, readX, readY, t_band.DataType)
         t_band.WriteRaster(0, 0, readX, readY, data, readX, readY, t_band.DataType)
 


### PR DESCRIPTION
Issue #1314 - Modify `gdal_retile.py` to copy the NoData value from the input dataset to the output dataset.

## Tasklist

 - [x] Add test case(s)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed