### PR TITLE
CPL: Fix assertion in CPLGetValueType when working with non-ASCII strings (fixes #1322)

### DIFF
--- a/gdal/port/cpl_string.cpp
+++ b/gdal/port/cpl_string.cpp
@@ -2581,7 +2581,7 @@ CPLValueType CPLGetValueType( const char* pszValue )
     const char* pszValueInit = pszValue;
 
     // Skip leading spaces.
-    while( isspace( *pszValue ) )
+    while( isspace(static_cast<unsigned char>( *pszValue )) )
         ++pszValue;
 
     if( *pszValue == '\0' )
@@ -2600,15 +2600,15 @@ CPLValueType CPLGetValueType( const char* pszValue )
 
     for( ; *pszValue != '\0'; ++pszValue )
     {
-        if( isdigit( *pszValue))
+        if( isdigit(static_cast<unsigned char>( *pszValue )) )
         {
             bIsLastCharExponent = false;
             bFoundMantissa = true;
         }
-        else if( isspace( *pszValue ) )
+        else if( isspace(static_cast<unsigned char>( *pszValue )) )
         {
             const char* pszTmp = pszValue;
-            while( isspace( *pszTmp ) )
+            while( isspace(static_cast<unsigned char>( *pszTmp )) )
                 ++pszTmp;
             if( *pszTmp == 0 )
                 break;


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Avoid assertions in CPLGetValueType by adding `static_cast<unsigned char>` to all uses of isspace/isdigit.

## What are related issues/pull requests?
Fixes https://github.com/OSGeo/gdal/issues/1322

## Tasklist
 - [x] Edit CPLGetValueType
 - [x] Ad-hoc testing
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment
Reproduced/tested on:
* Windows 10 x64 (msvc)

Also ran tests on:
* Ubuntu 18.04.02 x64 (g++)