### PR TITLE
MSSQLSpatial: Adding improved extent queries for MSSQLServer driver

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
@@ -353,6 +353,9 @@ class OGRMSSQLSpatialTableLayer final: public OGRMSSQLSpatialLayer
     OGRErr              CreateSpatialIndex();
     void                DropSpatialIndex();
 
+    virtual OGRErr      GetExtent(OGREnvelope *psExtent, int bForce) override { return GetExtent(0, psExtent, bForce); }
+    virtual OGRErr      GetExtent(int iGeomField, OGREnvelope *psExtent, int bForce) override;
+
     virtual void        ResetReading() override;
     virtual GIntBig     GetFeatureCount( int ) override;
 
@@ -443,6 +446,14 @@ class OGRMSSQLSpatialSelectLayer final: public OGRMSSQLSpatialLayer
 
 class OGRMSSQLSpatialDataSource final: public OGRDataSource
 {
+    typedef struct
+    {
+        int nMajor;
+        int nMinor;
+        int nBuild;
+        int nRevision;
+    } MSSQLVer;
+
     OGRMSSQLSpatialTableLayer    **papoLayers;
     int                 nLayers;
 
@@ -471,9 +482,13 @@ class OGRMSSQLSpatialDataSource final: public OGRDataSource
 
     OGRMSSQLSpatialTableLayer *poLayerInCopyMode;
 
+    static void               OGRMSSQLDecodeVersionString(MSSQLVer* psVersion, const char* pszVer);
+
     char                *pszConnection;
 
-  public:
+public:
+    MSSQLVer            sMSSQLVersion;
+
                         OGRMSSQLSpatialDataSource();
                         virtual ~OGRMSSQLSpatialDataSource();
 

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -52,6 +52,11 @@ OGRMSSQLSpatialDataSource::OGRMSSQLSpatialDataSource() :
     nGeometryFormat = MSSQLGEOMETRY_NATIVE;
     pszConnection = nullptr;
 
+    sMSSQLVersion.nMajor = 0;
+    sMSSQLVersion.nMinor = 0;
+    sMSSQLVersion.nBuild = 0;
+    sMSSQLVersion.nRevision = 0;
+
     bUseGeometryColumns = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_USE_GEOMETRY_COLUMNS", "YES"));
     bAlwaysOutputFid = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_ALWAYS_OUTPUT_FID", "NO"));
     bListAllTables = CPLTestBool(CPLGetConfigOption("MSSQLSPATIAL_LIST_ALL_TABLES", "NO"));
@@ -93,6 +98,70 @@ OGRMSSQLSpatialDataSource::~OGRMSSQLSpatialDataSource()
     CPLFree( papoSRS );
     CPLFree( pszConnection );
 }
+/************************************************************************/
+/*                      OGRMSSQLDecodeVersionString()                   */
+/************************************************************************/
+
+void OGRMSSQLSpatialDataSource::OGRMSSQLDecodeVersionString(MSSQLVer* psVersion, const char* pszVer)
+{
+    while (*pszVer == ' ') pszVer++;
+
+    const char* ptr = pszVer;
+    // get Version string
+    while (*ptr && *ptr != ' ') ptr++;
+    GUInt32 iLen = static_cast<int>(ptr - pszVer);
+    char szVer[20] = {};
+    if (iLen > sizeof(szVer) - 1) iLen = sizeof(szVer) - 1;
+    strncpy(szVer, pszVer, iLen);
+    szVer[iLen] = '\0';
+
+    ptr = pszVer = szVer;
+
+    // get Major number
+    while (*ptr && *ptr != '.') ptr++;
+    iLen = static_cast<int>(ptr - pszVer);
+    char szNum[20] = {};
+    if (iLen > sizeof(szNum) - 1) iLen = sizeof(szNum) - 1;
+    strncpy(szNum, pszVer, iLen);
+    szNum[iLen] = '\0';
+    psVersion->nMajor = atoi(szNum);
+
+    if (*ptr == 0)
+        return;
+    pszVer = ++ptr;
+
+    // get Minor number
+    while (*ptr && *ptr != '.') ptr++;
+    iLen = static_cast<int>(ptr - pszVer);
+    if (iLen > sizeof(szNum) - 1) iLen = sizeof(szNum) - 1;
+    strncpy(szNum, pszVer, iLen);
+    szNum[iLen] = '\0';
+    psVersion->nMinor = atoi(szNum);
+
+    if (*ptr == 0)
+        return;
+    pszVer = ++ptr;
+
+    // get Build number
+    while (*ptr && *ptr != '.') ptr++;
+    iLen = static_cast<int>(ptr - pszVer);
+    if (iLen > sizeof(szNum) - 1) iLen = sizeof(szNum) - 1;
+    strncpy(szNum, pszVer, iLen);
+    szNum[iLen] = '\0';
+    psVersion->nBuild = atoi(szNum);
+
+    if (*ptr == 0)
+        return;
+    pszVer = ++ptr;
+
+    // get Revision number
+    while (*ptr && *ptr != '.') ptr++;
+    iLen = static_cast<int>(ptr - pszVer);
+    if (iLen > sizeof(szNum) - 1) iLen = sizeof(szNum) - 1;
+    strncpy(szNum, pszVer, iLen);
+    szNum[iLen] = '\0';
+    psVersion->nRevision = atoi(szNum);
+}
 
 /************************************************************************/
 /*                           TestCapability()                           */
@@ -108,6 +177,8 @@ int OGRMSSQLSpatialDataSource::TestCapability( const char * pszCap )
     if( EQUAL(pszCap,ODsCCreateLayer) || EQUAL(pszCap,ODsCDeleteLayer) )
         return TRUE;
     if( EQUAL(pszCap,ODsCRandomLayerWrite) )
+        return TRUE;
+    if (EQUAL(pszCap, OLCFastGetExtent))
         return TRUE;
     else
         return FALSE;
@@ -813,6 +884,29 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
         CPLFree(pszGeometryFormat);
         CPLFree(pszConnectionName);
         return FALSE;
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Find out SQLServer version                                      */
+    /* -------------------------------------------------------------------- */
+    if (true) {
+        sMSSQLVersion.nMajor = -1;
+        sMSSQLVersion.nMinor = -1;
+        sMSSQLVersion.nBuild = -1;
+        sMSSQLVersion.nRevision = -1;
+
+        CPLODBCStatement oStmt(&oSession);
+
+        /* Use join to make sure the existence of the referred column/table */
+        oStmt.Append("SELECT SERVERPROPERTY('ProductVersion') AS ProductVersion;");
+
+        if (oStmt.ExecuteSQL())
+        {
+            while (oStmt.Fetch())
+            {
+                OGRMSSQLDecodeVersionString(&sMSSQLVersion, oStmt.GetColData(0));
+            }
+        }
     }
 
     char** papszTypes = nullptr;

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -678,6 +678,95 @@ OGRFeature *OGRMSSQLSpatialTableLayer::GetFeature( GIntBig nFeatureId )
     return GetNextRawFeature();
 }
 
+
+/************************************************************************/
+/*                             GetExtent()                              */
+/*                                                                      */
+/*      For Geometry or Geography types we can use an optimized         */
+/*      statement in other cases we use standard OGRLayer::GetExtent()  */
+/************************************************************************/
+
+OGRErr OGRMSSQLSpatialTableLayer::GetExtent(int iGeomField, OGREnvelope *psExtent, int bForce)
+{
+    // Make sure we have a geometry field:
+    if (iGeomField < 0 || iGeomField >= poFeatureDefn->GetGeomFieldCount() ||
+        poFeatureDefn->GetGeomFieldDefn(iGeomField)->GetType() == wkbNone)
+    {
+        if (iGeomField != 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                "Invalid geometry field index : %d", iGeomField);
+        }
+        return OGRERR_FAILURE;
+    }
+
+    // If we have a geometry or geography type:
+    if (nGeomColumnType == MSSQLCOLTYPE_GEOGRAPHY || nGeomColumnType == MSSQLCOLTYPE_GEOMETRY)
+    {
+        // Prepare statement
+        poStmt = new CPLODBCStatement(poDS->GetSession());
+
+        if (poDS->sMSSQLVersion.nMajor >= 11) {
+            // SQLServer 2012 or later:
+
+            if (nGeomColumnType == MSSQLCOLTYPE_GEOGRAPHY)
+                poStmt->Appendf("WITH extent(extentcol) AS (SELECT geography::EnvelopeAggregate(%s) AS extentcol FROM [%s].[%s])", pszGeomColumn, pszSchemaName, pszTableName);
+            else
+                poStmt->Appendf("WITH extent(extentcol) AS (SELECT geometry::EnvelopeAggregate(%s) AS extentcol FROM [%s].[%s])", pszGeomColumn, pszSchemaName, pszTableName);
+
+            poStmt->Appendf("SELECT COALESCE(extentcol.STPointN(1).STX, 0) as MinX, COALESCE(extentcol.STPointN(1).STY, 0) as MinY,");
+            poStmt->Appendf("COALESCE(extentcol.STPointN(3).STX, 0) as MaxX, COALESCE(extentcol.STPointN(3).STY, 0) as MaxY FROM extent;");
+
+        }
+        else
+        {
+            // Before 2012 use two CTE's:
+            poStmt->Appendf("WITH ENVELOPE as (SELECT %s.STEnvelope() as envelope from [%s].[%s]),", pszGeomColumn, pszSchemaName, pszTableName);
+            poStmt->Appendf("      CORNERS  as (SELECT envelope.STPointN(1) as point from ENVELOPE UNION ALL select envelope.STPointN(3) from ENVELOPE)");
+            poStmt->Appendf("SELECT COALESCE(MIN(point.STX), 0) as MinX, COALESCE(MIN(point.STY), 0) as MinY, COALESCE(MAX(point.STX),0) as MaxX, COALESCE(MAX(point.STY),0) as MaxY FROM CORNERS;");
+        }
+
+        // Execute
+        if (!poStmt->ExecuteSQL())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                "Error getting extents, %s",
+                poDS->GetSession()->GetLastError());   
+        }
+        else
+        {
+            // Try to update
+            while (poStmt->Fetch()) {
+
+                const char *minx = poStmt->GetColData(0);
+                const char *miny = poStmt->GetColData(1);
+                const char *maxx = poStmt->GetColData(2);
+                const char *maxy = poStmt->GetColData(3);
+
+                if (!(minx == nullptr || miny == nullptr || maxx == nullptr || maxy == nullptr)) {
+                    psExtent->MinX = CPLAtof(minx);
+                    psExtent->MinY = CPLAtof(miny);
+                    psExtent->MaxX = CPLAtof(maxx);
+                    psExtent->MaxY = CPLAtof(maxy);
+                    return OGRERR_NONE;
+                }
+                else
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                        "MSSQL extents query returned a NULL value");
+                }
+            }
+        }
+
+    }
+
+    // Fall back to generic implementation (loading all features)
+    if (iGeomField == 0)
+        return OGRLayer::GetExtent(psExtent, bForce);
+    else
+        return OGRLayer::GetExtent(iGeomField, psExtent, bForce);
+}
+
 /************************************************************************/
 /*                         SetAttributeFilter()                         */
 /************************************************************************/


### PR DESCRIPTION
## What does this PR do?
 - Adds methods and a MSSQL version type to the OGRMSSQLSpatial data source class to get and parse the database version
 - Adds overrides for the GetExtent methods of the OGRLayer implementation for MSSQLSpatial which are more performant for large datasets

## What are related issues/pull requests?
None that I know off

## Tasklist
 - [x] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed