### PR TITLE
gdal2tiles: prevent accidental copy of full GeoTIFF into temporary .vrt file

### DIFF
--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -1509,8 +1509,8 @@ class GDAL2Tiles(object):
         if not self.warped_input_dataset:
             self.warped_input_dataset = input_dataset
 
-        self.warped_input_dataset.GetDriver().CreateCopy(self.tmp_vrt_filename,
-                                                         self.warped_input_dataset)
+        gdal.GetDriverByName('VRT').CreateCopy(self.tmp_vrt_filename,
+                                               self.warped_input_dataset)
 
         # Get alpha band (either directly or from NODATA value)
         self.alphaband = self.warped_input_dataset.GetRasterBand(1).GetMaskBand()


### PR DESCRIPTION
This line is used to write the temporary .vrt for the reprojected input.
However, if the input was already in the correct projection,
`self.warped_input_dataset` was the input GeoTIFF dataset directly due
to the previous line, so `GetDriver` returned the GeoTIFF driver rather
than VRT. It then created a .vrt file that was actually in GeoTIFF
format and copied the entire input into it.
