### PR TITLE
RasterBand/Dataset::RasterIO(): enforce access mode on write

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -34,6 +34,7 @@ import sys
 
 
 from osgeo import gdal
+import gdaltest
 import pytest
 
 ###############################################################################
@@ -951,3 +952,19 @@ def test_rasterio_dataset_readarray_cint16():
     assert got[0] == numpy.array([[1 + 2j]])
     assert got[1] == numpy.array([[3 + 4j]])
 
+
+def test_rasterio_rasterband_write_on_readonly():
+
+    ds = gdal.Open('data/byte.tif')
+    band = ds.GetRasterBand(1)
+    with gdaltest.error_handler():
+        err = band.WriteRaster(0, 0, 20, 20, band.ReadRaster())
+    assert err != 0
+
+
+def test_rasterio_dataset_write_on_readonly():
+
+    ds = gdal.Open('data/byte.tif')
+    with gdaltest.error_handler():
+        err = ds.WriteRaster(0, 0, 20, 20, ds.ReadRaster())
+    assert err != 0

--- a/autotest/gdrivers/kea.py
+++ b/autotest/gdrivers/kea.py
@@ -159,16 +159,16 @@ def test_kea_4():
         gdal.PopErrorHandler()
         assert ret != 0
 
-    gdal.PushErrorHandler('CPLQuietErrorHandler')
-    ret = ds.AddBand(gdal.GDT_Byte)
-    gdal.PopErrorHandler()
+    with gdaltest.error_handler():
+        ret = ds.AddBand(gdal.GDT_Byte)
     assert ret != 0
 
-    ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, '\0')
-    gdal.ErrorReset()
-    gdal.PushErrorHandler('CPLQuietErrorHandler')
-    ds.FlushCache()
-    gdal.PopErrorHandler()
+    with gdaltest.error_handler():
+        ret = ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, '\0')
+    assert ret != 0
+    with gdaltest.error_handler():
+        ret = ds.FlushCache()
+    assert ret != 0
     assert ds.GetRasterBand(1).Checksum() == 3
 
     ds = None

--- a/gdal/frmts/arg/argdataset.cpp
+++ b/gdal/frmts/arg/argdataset.cpp
@@ -727,6 +727,7 @@ GDALDataset *ARGDataset::CreateCopy( const char *pszFilename,
                                                   bNative,
                                                   nXSize, nYSize,
                                                   RawRasterBand::OwnFP::NO);
+    poDstBand->SetAccess(GA_Update);
 
     int nXBlockSize, nYBlockSize;
     poSrcBand->GetBlockSize(&nXBlockSize, &nYBlockSize);

--- a/gdal/frmts/hfa/hfadataset.cpp
+++ b/gdal/frmts/hfa/hfadataset.cpp
@@ -1895,6 +1895,7 @@ HFARasterBand::HFARasterBand( HFADataset *poDSIn, int nBandIn, int iOverview ) :
         poDS = nullptr;
 
     nBand = nBandIn;
+    eAccess = poDSIn->GetAccess();
 
     int nCompression = 0;
     HFAGetBandInfo(hHFA, nBand, &eHFADataType,

--- a/gdal/frmts/mbtiles/mbtilesdataset.cpp
+++ b/gdal/frmts/mbtiles/mbtilesdataset.cpp
@@ -1215,6 +1215,11 @@ bool MBTilesDataset::InitRaster ( MBTilesDataset* poParentDS,
         return false;
     }
 
+    if( poParentDS )
+    {
+        eAccess = poParentDS->eAccess;
+    }
+
     for(int i = 1; i <= nBandCount; i ++)
         SetBand( i, new MBTilesBand(this, nTileSize) );
 
@@ -1227,7 +1232,6 @@ bool MBTilesDataset::InitRaster ( MBTilesDataset* poParentDS,
     {
         m_poParentDS = poParentDS;
         poMainDS = poParentDS;
-        eAccess = poParentDS->eAccess;
         hDS = poParentDS->hDS;
         hDB = poParentDS->hDB;
         m_eTF = poParentDS->m_eTF;

--- a/gdal/frmts/pcidsk/pcidskdataset2.cpp
+++ b/gdal/frmts/pcidsk/pcidskdataset2.cpp
@@ -517,8 +517,9 @@ void PCIDSK2Band::RefreshOverviewList()
 /* -------------------------------------------------------------------- */
     for( int iOver = 0; iOver < poChannel->GetOverviewCount(); iOver++ )
     {
-        apoOverviews.push_back(
-            new PCIDSK2Band( poChannel->GetOverview(iOver) ) );
+        auto poOvrBand = new PCIDSK2Band( poChannel->GetOverview(iOver) );
+        poOvrBand->eAccess = eAccess;
+        apoOverviews.push_back( poOvrBand );
     }
 }
 

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -2454,6 +2454,17 @@ CPLErr GDALDataset::RasterIO( GDALRWFlag eRWFlag,
         return CE_Failure;
     }
 
+    if( eRWFlag == GF_Write )
+    {
+        if( eAccess != GA_Update )
+        {
+            ReportError( CE_Failure, CPLE_AppDefined,
+                        "Write operation not permitted on dataset opened "
+                        "in read-only mode" );
+            return CE_Failure;
+        }
+    }
+
     int bStopProcessing = FALSE;
     CPLErr eErr = ValidateRasterIOOrAdviseReadParameters(
         "RasterIO()", &bStopProcessing, nXOff, nYOff, nXSize, nYSize, nBufXSize,

--- a/gdal/gcore/gdalrasterband.cpp
+++ b/gdal/gcore/gdalrasterband.cpp
@@ -301,14 +301,24 @@ CPLErr GDALRasterBand::RasterIO( GDALRWFlag eRWFlag,
         return CE_None;
     }
 
-    if( eRWFlag == GF_Write && eFlushBlockErr != CE_None )
+    if( eRWFlag == GF_Write )
     {
-        ReportError(eFlushBlockErr, CPLE_AppDefined,
-                    "An error occurred while writing a dirty block "
-                    "from GDALRasterBand::RasterIO");
-        CPLErr eErr = eFlushBlockErr;
-        eFlushBlockErr = CE_None;
-        return eErr;
+        if( eFlushBlockErr != CE_None )
+        {
+            ReportError(eFlushBlockErr, CPLE_AppDefined,
+                        "An error occurred while writing a dirty block "
+                        "from GDALRasterBand::RasterIO");
+            CPLErr eErr = eFlushBlockErr;
+            eFlushBlockErr = CE_None;
+            return eErr;
+        }
+        if( eAccess != GA_Update )
+        {
+            ReportError( CE_Failure, CPLE_AppDefined,
+                        "Write operation not permitted on dataset opened "
+                        "in read-only mode" );
+            return CE_Failure;
+        }
     }
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
When doing a RasterIO(GF_Write, ...) operation, check that the dataset/rasterband
access mode is GA_Update.
Fix a few drivers where access mode was not set correctly.
