### PR TITLE
pgdump: Fix emitted SQL when UNLOGGED=ON

### DIFF
--- a/gdal/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
@@ -460,7 +460,7 @@ OGRPGDumpDataSource::ICreateLayer( const char * pszLayerName,
     }
     else
     {
-        osCreateTable.Printf("CREATE TABLE%s \"%s\".\"%s\"",
+        osCreateTable.Printf("CREATE%s TABLE \"%s\".\"%s\"",
                              CPLFetchBool( papszOptions, "UNLOGGED", false ) ?
                              " UNLOGGED": "",
                              pszSchemaName, pszTableName);


### PR DESCRIPTION
## What does this PR do?
This fixes the generated SQL for the pgdump driver.
Previously the driver emitted invalid SQL with UNLOGGED=ON.
According to documentation, Postgres has never recognized "CREATE TABLE UNLOGGED" as valid syntax.

## What are related issues/pull requests?
None found.
