### PR TITLE
Increasing DOWNLOAD_CHUNK_SIZE to 128K

### DIFF
--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -94,7 +94,7 @@ int VSICurlUninstallReadCbk( VSILFILE* /* fp */ )
 #define ENABLE_DEBUG_VERBOSE 0
 
 static int N_MAX_REGIONS = 1000;
-static int DOWNLOAD_CHUNK_SIZE = 16384;
+static int DOWNLOAD_CHUNK_SIZE = 131072;
 
 namespace cpl {
 


### PR DESCRIPTION
When dealing with http protocol the round trip latency could be with high latency.
Why not create bigger requests to improve overall performance for user using vsicurl and all object storage(for example vsis3) usage.
Increasing this variable will decrease the amount of requests.

## What does this PR do?
Increasing DOWNLOAD_CHUNK_SIZE to 128K
## What are related issues/pull requests?
None, this will improve performance significantly 

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Not relevant