### PR TITLE
GPKG: always set sqlite3_busy_timeout and emit errors if SQLITE_BUSY …

### DIFF
--- a/gdal/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
@@ -938,6 +938,14 @@ GByte* GDALGPKGMBTilesLikePseudoDataset::ReadTile( int nRow, int nCol, GByte *pa
         VSIUnlink(osMemFileName);
         sqlite3_finalize(hStmt);
     }
+    else if( rc == SQLITE_BUSY )
+    {
+        FillEmptyTile(pabyData);
+        CPLError( CE_Failure, CPLE_AppDefined, "sqlite3_step(%s) failed (SQLITE_BUSY): %s",
+                      sqlite3_sql( hStmt ), sqlite3_errmsg( IGetDB() ) );
+        sqlite3_finalize(hStmt);
+        return pabyData;
+    }
     else
     {
         sqlite3_finalize( hStmt );

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -798,6 +798,11 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, int bRegisterOGR2SQLite
         return FALSE;
     }
 
+    const char* pszVal = CPLGetConfigOption("SQLITE_BUSY_TIMEOUT", "5000");
+    if ( pszVal != nullptr ) {
+        sqlite3_busy_timeout(hDB, atoi(pszVal));
+    }
+
     if( (flagsIn & SQLITE_OPEN_CREATE) == 0 )
     {
         if( CPLTestBool(CPLGetConfigOption("OGR_VFK_DB_READ", "NO")) )


### PR DESCRIPTION
…is returned during tile read (fixes #1370)

sqlite3_busy_timeout is called on gpkg open with a default timeout of 5000 milliseconds.
SQLITE_BUSY_TIMEOUT config option can be used to override the timeout value at runtime.

If sqlite returns SQLITE_BUSY(5) when decoding a tile, then emit a CPLError with all available information, clean up, and return an empty tile.

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Sets a default 5 second timeout in sqlite when opening a GPKG dataset for read.  This causes sqlite to wait up to the timeout value before returning SQLITE_BUSY.  The timeout value can be controlled via SQLITE_BUSY_TIMEOUT config value

## What are related issues/pull requests?

Fixes #1370 

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

* OS: Windows (doesn't appear to be a problem on linux)
* Compiler: msvc141 (1916)
