### PR TITLE
rasterize: fix crash when working buffer is larger than 2GB (fix for gvBurnPoint) (fixes  #1338)

### DIFF
--- a/gdal/alg/gdalrasterize.cpp
+++ b/gdal/alg/gdalrasterize.cpp
@@ -147,8 +147,8 @@ void gvBurnPoint( void *pCBData, int nY, int nX, double dfVariant )
         for( int iBand = 0; iBand < psInfo->nBands; iBand++ )
         {
             unsigned char *pbyInsert = psInfo->pabyChunkBuf
-                                      + iBand * psInfo->nXSize * psInfo->nYSize
-                                      + nY * psInfo->nXSize + nX;
+                                      + static_cast<GSpacing>(iBand) * psInfo->nXSize * psInfo->nYSize
+                                      + static_cast<GSpacing>(nY) * psInfo->nXSize + nX;
             double dfVal;
             if( psInfo->eMergeAlg == GRMA_Add ) {
                 dfVal = *pbyInsert + ( psInfo->padfBurnValue[iBand] +
@@ -172,8 +172,8 @@ void gvBurnPoint( void *pCBData, int nY, int nX, double dfVariant )
         for( int iBand = 0; iBand < psInfo->nBands; iBand++ )
         {
             double *pdfInsert = reinterpret_cast<double *>(psInfo->pabyChunkBuf)
-                                + iBand * psInfo->nXSize * psInfo->nYSize
-                                + nY * psInfo->nXSize + nX;
+                                + static_cast<GSpacing>(iBand) * psInfo->nXSize * psInfo->nYSize
+                                + static_cast<GSpacing>(nY) * psInfo->nXSize + nX;
 
             if( psInfo->eMergeAlg == GRMA_Add ) {
                 *pdfInsert += ( psInfo->padfBurnValue[iBand] +


### PR DESCRIPTION
## What does this PR do?

Fixes a similar issue with gvBurnPoint than was already fixed in gvBurnScanline

## What are related issues/pull requests?

#1338  573a97994e31c8f38580c70a9bee790c23d028e5
