### PR TITLE
check if file is only greater than 512px

### DIFF
--- a/gdal/swig/python/samples/validate_cloud_optimized_geotiff.py
+++ b/gdal/swig/python/samples/validate_cloud_optimized_geotiff.py
@@ -87,7 +87,7 @@ def validate(ds, check_tiled=True):
         errors += [
             'Overviews found in external .ovr file. They should be internal']
 
-    if main_band.XSize >= 512 or main_band.YSize >= 512:
+    if main_band.XSize > 512 or main_band.YSize > 512:
         if check_tiled:
             block_size = main_band.GetBlockSize()
             if block_size[0] == main_band.XSize and block_size[0] > 1024:


### PR DESCRIPTION
closes #1403 

## What does this PR do?

Change the size requirement for internal tiling and internal overview to be only `greater than` 512px 

## What are related issues/pull requests?

#1403 

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
