### PR TITLE
Add COG Metadata Shortcut

### DIFF
--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -14445,6 +14445,7 @@ char** GTiffDataset::GetSiblingFiles()
     }
 
     m_bHasGotSiblingFiles = true;
+
     const int nMaxFiles =
         atoi(CPLGetConfigOption("GDAL_READDIR_LIMIT_ON_OPEN", "1000"));
     char** papszSiblingFiles =
@@ -14456,6 +14457,15 @@ char** GTiffDataset::GetSiblingFiles()
         CSLDestroy(papszSiblingFiles);
         papszSiblingFiles = nullptr;
     }
+
+    if ((papszSiblingFiles == nullptr) &&
+        (CPLTestBool(CPLGetConfigOption("GDAL_COG_SHORTCUT", "FALSE"))))
+    {
+      papszSiblingFiles = static_cast<char **>(calloc(3, sizeof(char *)));
+      papszSiblingFiles[0] = strdup(CPLGetFilename(osFilename));
+      papszSiblingFiles[1] = nullptr;
+    }
+
     oOvManager.TransferSiblingFiles( papszSiblingFiles );
 
     return papszSiblingFiles;


### PR DESCRIPTION
## What does this PR do?

This PR adds a new configuration option, `GDAL_COG_SHORTCUT` that speeds up metadata retrieval of COGs (and perhaps other GeoTIFFs) in certain scenarios.  For example, without this change I observe the following timings from the following commands (sorry for the verbosity, but I want to show that the metadata are the same [at least for this example]):

```
gdal/gdal% time gdalinfo '/vsis3/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif'                                                            
Driver: GTiff/GeoTIFF
Files: /vsis3/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif
Size is 6196, 6003
Coordinate System is:
PROJCRS["WGS 84 / Pseudo-Mercator",
    BASEGEOGCRS["WGS 84",
        DATUM["World Geodetic System 1984",
            ELLIPSOID["WGS 84",6378137,298.257223563,
                LENGTHUNIT["metre",1]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433]]],
    CONVERSION["Popular Visualisation Pseudo-Mercator",
        METHOD["Popular Visualisation Pseudo Mercator",
            ID["EPSG",1024]],
        PARAMETER["Latitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8801]],
        PARAMETER["Longitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]],
        PARAMETER["False easting",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]],
        PARAMETER["False northing",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]]],
    CS[Cartesian,2],
        AXIS["easting (X)",east,
            ORDER[1],
            LENGTHUNIT["metre",1]],
        AXIS["northing (Y)",north,
            ORDER[2],
            LENGTHUNIT["metre",1]],
    USAGE[
        SCOPE["unknown"],
        AREA["World - 85°S to 85°N"],
        BBOX[-85.06,-180,85.06,180]],
    ID["EPSG",3857]]
Data axis to CRS axis mapping: 1,2
Origin = (3440101.017569109331816,-2294035.527693799231201)
Pixel Size = (3.620251897830532,-3.620251897830532)
Metadata:
  AREA_OR_POINT=Area
Image Structure Metadata:
  COMPRESSION=LZW
  INTERLEAVE=PIXEL
Corner Coordinates:
Upper Left  ( 3440101.018,-2294035.528) ( 30d54'10.63"E, 20d10'37.95"S)
Lower Left  ( 3440101.018,-2315767.900) ( 30d54'10.63"E, 20d21'37.24"S)
Upper Right ( 3462532.098,-2294035.528) ( 31d 6'16.04"E, 20d10'37.95"S)
Lower Right ( 3462532.098,-2315767.900) ( 31d 6'16.04"E, 20d21'37.24"S)
Center      ( 3451316.558,-2304901.714) ( 31d 0'13.33"E, 20d16' 7.69"S)
Band 1 Block=256x256 Type=Byte, ColorInterp=Red
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
Band 2 Block=256x256 Type=Byte, ColorInterp=Green
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
Band 3 Block=256x256 Type=Byte, ColorInterp=Blue
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
gdalinfo   0.17s user 0.02s system 13% cpu 1.357 total
```
while `vsicurl` is much slower
```
gdal/gdal% time gdalinfo '/vsicurl/https://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif'                       
Driver: GTiff/GeoTIFF
Files: /vsicurl/https://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif
Size is 6196, 6003
Coordinate System is:
PROJCRS["WGS 84 / Pseudo-Mercator",
    BASEGEOGCRS["WGS 84",
        DATUM["World Geodetic System 1984",
            ELLIPSOID["WGS 84",6378137,298.257223563,
                LENGTHUNIT["metre",1]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433]]],
    CONVERSION["Popular Visualisation Pseudo-Mercator",
        METHOD["Popular Visualisation Pseudo Mercator",
            ID["EPSG",1024]],
        PARAMETER["Latitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8801]],
        PARAMETER["Longitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]],
        PARAMETER["False easting",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]],
        PARAMETER["False northing",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]]],
    CS[Cartesian,2],
        AXIS["easting (X)",east,
            ORDER[1],
            LENGTHUNIT["metre",1]],
        AXIS["northing (Y)",north,
            ORDER[2],
            LENGTHUNIT["metre",1]],
    USAGE[
        SCOPE["unknown"],
        AREA["World - 85°S to 85°N"],
        BBOX[-85.06,-180,85.06,180]],
    ID["EPSG",3857]]
Data axis to CRS axis mapping: 1,2
Origin = (3440101.017569109331816,-2294035.527693799231201)
Pixel Size = (3.620251897830532,-3.620251897830532)
Metadata:
  AREA_OR_POINT=Area
Image Structure Metadata:
  COMPRESSION=LZW
  INTERLEAVE=PIXEL
Corner Coordinates:
Upper Left  ( 3440101.018,-2294035.528) ( 30d54'10.63"E, 20d10'37.95"S)
Lower Left  ( 3440101.018,-2315767.900) ( 30d54'10.63"E, 20d21'37.24"S)
Upper Right ( 3462532.098,-2294035.528) ( 31d 6'16.04"E, 20d10'37.95"S)
Lower Right ( 3462532.098,-2315767.900) ( 31d 6'16.04"E, 20d21'37.24"S)
Center      ( 3451316.558,-2304901.714) ( 31d 0'13.33"E, 20d16' 7.69"S)
Band 1 Block=256x256 Type=Byte, ColorInterp=Red
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
Band 2 Block=256x256 Type=Byte, ColorInterp=Green
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
Band 3 Block=256x256 Type=Byte, ColorInterp=Blue
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
gdalinfo   0.11s user 0.04s system 2% cpu 4.830 total
```
but with these changes I observe
```
gdal/gdal% time GDAL_COG_SHORTCUT=TRUE gdalinfo '/vsicurl/https://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif'
Driver: GTiff/GeoTIFF
Files: /vsicurl/https://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif
Size is 6196, 6003
Coordinate System is:
PROJCRS["WGS 84 / Pseudo-Mercator",
    BASEGEOGCRS["WGS 84",
        DATUM["World Geodetic System 1984",
            ELLIPSOID["WGS 84",6378137,298.257223563,
                LENGTHUNIT["metre",1]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433]]],
    CONVERSION["Popular Visualisation Pseudo-Mercator",
        METHOD["Popular Visualisation Pseudo Mercator",
            ID["EPSG",1024]],
        PARAMETER["Latitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8801]],
        PARAMETER["Longitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]],
        PARAMETER["False easting",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]],
        PARAMETER["False northing",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]]],
    CS[Cartesian,2],
        AXIS["easting (X)",east,
            ORDER[1],
            LENGTHUNIT["metre",1]],
        AXIS["northing (Y)",north,
            ORDER[2],
            LENGTHUNIT["metre",1]],
    USAGE[
        SCOPE["unknown"],
        AREA["World - 85°S to 85°N"],
        BBOX[-85.06,-180,85.06,180]],
    ID["EPSG",3857]]
Data axis to CRS axis mapping: 1,2
Origin = (3440101.017569109331816,-2294035.527693799231201)
Pixel Size = (3.620251897830532,-3.620251897830532)
Metadata:
  AREA_OR_POINT=Area
Image Structure Metadata:
  COMPRESSION=LZW
  INTERLEAVE=PIXEL
Corner Coordinates:
Upper Left  ( 3440101.018,-2294035.528) ( 30d54'10.63"E, 20d10'37.95"S)
Lower Left  ( 3440101.018,-2315767.900) ( 30d54'10.63"E, 20d21'37.24"S)
Upper Right ( 3462532.098,-2294035.528) ( 31d 6'16.04"E, 20d10'37.95"S)
Lower Right ( 3462532.098,-2315767.900) ( 31d 6'16.04"E, 20d21'37.24"S)
Center      ( 3451316.558,-2304901.714) ( 31d 0'13.33"E, 20d16' 7.69"S)
Band 1 Block=256x256 Type=Byte, ColorInterp=Red
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
Band 2 Block=256x256 Type=Byte, ColorInterp=Green
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
Band 3 Block=256x256 Type=Byte, ColorInterp=Blue
  Overviews: 3098x3002, 1549x1501, 775x751, 388x376, 194x188
GDAL_COG_SHORTCUT=TRUE gdalinfo   0.10s user 0.02s system 13% cpu 0.927 total
```
bringing http performance into line with s3.

The issue appears to be the fact that one cannot take a directory listing of an S3 prefix over http (`vsicurl`).  That causes the `ReadDirEx` that is supposed to find the metadata to fail, which causes GDAL to begin guessing sidecar file names and `open`ing those names, which causes a delay.

In contrast, when using S3 (`vsis3`), S3 returns a directory listing which (coincidentally, I guess) begins with the name of the actual COG, so the metadata are quickly and directly extracted from it.

This PR attempts to replicate this fortunate behavior in order to speed up metadata access.

Note: I tried various options such as `GDAL_DISABLE_READDIR_ON_OPEN`, but to no apparent avail.  I also tried making use of the variables set from `GDAL_GEOREF_SOURCES` (in particular, having the behavior only fire when that variable is set to `"INTERNAL"`), but `GDAL_GEOREF_SOURCES` seems to have other effects that prevented my changes to `GetSiblingFiles` from being reached.

I am happy to close this PR if there is already a way to do this or modify it as necessary (the name `GDAL_COG_SHORTCUT` is provisional, and the fact that the behavior only fires if the directory listing fails can also be questioned).

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

* OS: Ubuntu 18.04
* Compiler: gcc 7.3.0
