### PR TITLE
CARTO: Overwrite tables in single transactions

### DIFF
--- a/autotest/ogr/ogr_carto.py
+++ b/autotest/ogr/ogr_carto.py
@@ -732,14 +732,11 @@ Error""")
     gdal.PopErrorHandler()
     assert lyr is None
 
-    with gdaltest.tempfile("""/vsimem/carto&POSTFIELDS=q=DROP TABLE "table1"&api_key=foo""",
+    with gdaltest.tempfile("""/vsimem/carto&POSTFIELDS=q=BEGIN; DROP TABLE IF EXISTS "table1";CREATE TABLE "table1" ( cartodb_id SERIAL,the_geom Geometry(MULTIPOLYGON,0),PRIMARY KEY (cartodb_id) );DROP SEQUENCE IF EXISTS "table1_cartodb_id_seq" CASCADE;CREATE SEQUENCE "table1_cartodb_id_seq" START 1;ALTER SEQUENCE "table1_cartodb_id_seq" OWNED BY "table1".cartodb_id;ALTER TABLE "table1" ALTER COLUMN cartodb_id SET DEFAULT nextval('"table1_cartodb_id_seq"'); COMMIT;&api_key=foo""",
                            """{"rows":[], "fields":{}}"""):
         lyr = ds.CreateLayer('table1', geom_type=ogr.wkbPolygon, options=['OVERWRITE=YES', 'CARTODBFY=NO'])
-
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetGeometry(ogr.CreateGeometryFromWkt('POLYGON((0 0,0 1,1 0,0 0))'))
-    with gdaltest.tempfile("""/vsimem/carto&POSTFIELDS=q=CREATE TABLE "table1" ( cartodb_id SERIAL,the_geom Geometry(MULTIPOLYGON,0),PRIMARY KEY (cartodb_id) );DROP SEQUENCE IF EXISTS "table1_cartodb_id_seq" CASCADE;CREATE SEQUENCE "table1_cartodb_id_seq" START 1;ALTER SEQUENCE "table1_cartodb_id_seq" OWNED BY "table1".cartodb_id;ALTER TABLE "table1" ALTER COLUMN cartodb_id SET DEFAULT nextval('"table1_cartodb_id_seq"')&api_key=foo""",
-                           """{"rows":[], "fields":{}}"""):
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt('POLYGON((0 0,0 1,1 0,0 0))'))
         assert lyr.CreateFeature(f) == 0
 
     gdal.ErrorReset()
@@ -751,15 +748,12 @@ Error""")
 
     ds = gdal.OpenEx('CARTO:foo', gdal.OF_VECTOR | gdal.OF_UPDATE, open_options=['COPY_MODE=NO'])
 
-    with gdaltest.tempfile("""/vsimem/carto&POSTFIELDS=q=DROP TABLE "table1"&api_key=foo""",
+    with gdaltest.tempfile("""/vsimem/carto&POSTFIELDS=q=BEGIN; DROP TABLE IF EXISTS "table1";CREATE TABLE "table1" ( cartodb_id SERIAL,the_geom Geometry(MULTIPOLYGON,0),PRIMARY KEY (cartodb_id) );DROP SEQUENCE IF EXISTS "table1_cartodb_id_seq" CASCADE;CREATE SEQUENCE "table1_cartodb_id_seq" START 1;ALTER SEQUENCE "table1_cartodb_id_seq" OWNED BY "table1".cartodb_id;ALTER TABLE "table1" ALTER COLUMN cartodb_id SET DEFAULT nextval('"table1_cartodb_id_seq"'); COMMIT;&api_key=foo""",
                            """{"rows":[], "fields":{}}"""):
         lyr = ds.CreateLayer('table1', geom_type=ogr.wkbPolygon, options=['OVERWRITE=YES', 'CARTODBFY=NO'])
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetFID(100)
 
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetFID(100)
-
-    with gdaltest.tempfile("""/vsimem/carto&POSTFIELDS=q=CREATE TABLE "table1" ( cartodb_id SERIAL,the_geom Geometry(MULTIPOLYGON,0),PRIMARY KEY (cartodb_id) );DROP SEQUENCE IF EXISTS "table1_cartodb_id_seq" CASCADE;CREATE SEQUENCE "table1_cartodb_id_seq" START 1;ALTER SEQUENCE "table1_cartodb_id_seq" OWNED BY "table1".cartodb_id;ALTER TABLE "table1" ALTER COLUMN cartodb_id SET DEFAULT nextval('"table1_cartodb_id_seq"')&api_key=foo""",
-                           """{"rows":[], "fields":{}}"""):
         with gdaltest.tempfile("""/vsimem/carto&POSTFIELDS=q=BEGIN;INSERT INTO "table1" ("cartodb_id") VALUES (100);COMMIT;&api_key=foo""",
                                """{"rows":[], "fields":{}}"""):
             assert lyr.CreateFeature(f) == 0

--- a/gdal/ogr/ogrsf_frmts/carto/drv_carto.html
+++ b/gdal/ogr/ogrsf_frmts/carto/drv_carto.html
@@ -96,6 +96,10 @@ in chunks until they reach 15 MB (can be changed with the CARTO_MAX_CHUNK_SIZE
 configuration option, with a value in MB), at which point they are transferred
 to the server. By setting CARTO_MAX_CHUNK_SIZE to 0, immediate transfer occurs.<p>
 
+<b>WARNING</b>: Don't use DeleteLayer() + CreateLayer() to overwrite a table.
+Instead only call CreateLayer() with OVERWRITE=YES. This will avoid CARTO
+deleting maps that depend on this table<p>
+
 <h2>SQL</h2>
 
 SQL commands provided to the OGRDataSource::ExecuteSQL() call are executed on the server side, unless the OGRSQL

--- a/gdal/ogr/ogrsf_frmts/carto/ogr_carto.h
+++ b/gdal/ogr/ogrsf_frmts/carto/ogr_carto.h
@@ -138,6 +138,8 @@ class OGRCARTOTableLayer : public OGRCARTOLayer
     bool                bCartodbfy;
     int                 nMaxChunkSize;
 
+    bool                bDropOnCreation;
+
     void                BuildWhere();
     std::vector<bool>   m_abFieldSetForInsert;
 
@@ -201,6 +203,11 @@ class OGRCARTOTableLayer : public OGRCARTOLayer
                                             bool bHasUserFieldMatchingFID, 
                                             bool bHasJustGotNextFID );
     char *              OGRCARTOGetHexGeometry( OGRGeometry* poGeom, int i );
+
+    void                SetDropOnCreation( bool bFlag )
+        { bDropOnCreation = bFlag; }
+    bool                GetDropOnCreation() const
+        { return bDropOnCreation; }
 };
 
 /************************************************************************/

--- a/gdal/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
@@ -417,16 +417,21 @@ OGRLayer   *OGRCARTODataSource::ICreateLayer( const char *pszNameIn,
     }
 
 /* -------------------------------------------------------------------- */
-/*      Do we already have this layer?  If so, should we blow it        */
+/*      Do we already have this layer?  If so, set it up for overwrite  */
 /*      away?                                                           */
 /* -------------------------------------------------------------------- */
+    bool bOverwriteOption = CSLFetchNameValue( papszOptions, "OVERWRITE" ) != nullptr
+                            && !EQUAL(CSLFetchNameValue(papszOptions,"OVERWRITE"),"NO");
+
     for( int iLayer = 0; iLayer < nLayers; iLayer++ )
     {
-        if( EQUAL(pszNameIn,papoLayers[iLayer]->GetName()) )
+        if( EQUAL(pszNameIn, papoLayers[iLayer]->GetName()) )
         {
-            if( CSLFetchNameValue( papszOptions, "OVERWRITE" ) != nullptr
-                && !EQUAL(CSLFetchNameValue(papszOptions,"OVERWRITE"),"NO") )
+            if( bOverwriteOption )
             {
+                /* We set DropOnCreation so the remote table isn't dropped */
+                /* As we are going to overwrite it in a single transaction */
+                papoLayers[iLayer]->SetDropOnCreation( true );
                 DeleteLayer( iLayer );
             }
             else
@@ -450,6 +455,9 @@ OGRLayer   *OGRCARTODataSource::ICreateLayer( const char *pszNameIn,
     }
 
     OGRCARTOTableLayer* poLayer = new OGRCARTOTableLayer(this, osName);
+    if ( bOverwriteOption )
+        poLayer->SetDropOnCreation( true );
+
     const bool bGeomNullable =
         CPLFetchBool(papszOptions, "GEOMETRY_NULLABLE", true);
     int nSRID = (poSpatialRef && eGType != wkbNone) ? FetchSRSId( poSpatialRef ) : 0;
@@ -519,6 +527,7 @@ OGRErr OGRCARTODataSource::DeleteLayer(int iLayer)
     CPLDebug( "CARTO", "DeleteLayer(%s)", osLayerName.c_str() );
 
     int bDeferredCreation = papoLayers[iLayer]->GetDeferredCreation();
+    bool bDropOnCreation = papoLayers[iLayer]->GetDropOnCreation();
     papoLayers[iLayer]->CancelDeferredCreation();
     delete papoLayers[iLayer];
     memmove( papoLayers + iLayer, papoLayers + iLayer + 1,
@@ -528,7 +537,7 @@ OGRErr OGRCARTODataSource::DeleteLayer(int iLayer)
     if (osLayerName.empty())
         return OGRERR_NONE;
 
-    if( !bDeferredCreation )
+    if( !bDeferredCreation && !bDropOnCreation )
     {
         CPLString osSQL;
         osSQL.Printf("DROP TABLE %s",

--- a/gdal/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
@@ -154,6 +154,7 @@ OGRCARTOTableLayer::OGRCARTOTableLayer(OGRCARTODataSource* poDSIn,
     bCartodbfy = false;
     nMaxChunkSize = atoi(CPLGetConfigOption("CARTO_MAX_CHUNK_SIZE",
             CPLGetConfigOption("CARTODB_MAX_CHUNK_SIZE", "15"))) * 1024 * 1024;
+    bDropOnCreation = false;
 }
 
 /************************************************************************/
@@ -1875,9 +1876,14 @@ OGRErr OGRCARTOTableLayer::RunDeferredCreationIfNecessary()
     bDeferredCreation = false;
 
     CPLString osSQL;
-    osSQL.Printf("CREATE TABLE %s ( %s SERIAL,",
-                 OGRCARTOEscapeIdentifier(osName).c_str(),
-                 osFIDColName.c_str());
+    CPLDebug( "CARTO", "Overwrite on creation (%d)", bDropOnCreation );
+    if ( bDropOnCreation )
+        osSQL.Printf("BEGIN; DROP TABLE IF EXISTS %s;",
+                     OGRCARTOEscapeIdentifier(osName).c_str());
+
+    osSQL += CPLSPrintf("CREATE TABLE %s ( %s SERIAL,",
+                        OGRCARTOEscapeIdentifier(osName).c_str(),
+                        osFIDColName.c_str());
 
     for( int i = 0; i < poFeatureDefn->GetGeomFieldCount(); i++ )
     {
@@ -1936,6 +1942,11 @@ OGRErr OGRCARTOTableLayer::RunDeferredCreationIfNecessary()
     osSQL += CPLSPrintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT nextval('%s')",
                         OGRCARTOEscapeIdentifier(osName).c_str(),
                         osFIDColName.c_str(), osSeqName.c_str());
+
+    if ( bDropOnCreation )
+        osSQL += "; COMMIT;";
+
+    bDropOnCreation = false;
 
     json_object* poObj = poDS->RunSQL(osSQL);
     if( poObj == nullptr )


### PR DESCRIPTION
## What does this PR do?

Changes how a table is overwritten in CARTO. Instead of 2 calls, first the DROP and then the CREATE TABLE, it defers the table drop and sends them both as a single transaction:
- `BEGIN; DROP TABLE "x"; CREATE TABLE "x" ...; COMMIT;`

It does this to avoid an issue in the CARTO platform where a map depending on a table could be dropped if it was "checked" during the update, that is between the drop and the creation of the table. It also enables future changes on how this dependency is handled internally.

## What are related issues/pull requests?

Closes https://github.com/OSGeo/gdal/issues/1305.

## Tasklist

 - [X] Add test case(s).
 - [ ] Review
 - [X] Adjust for comments
 - [ ] All CI builds and checks have passed
