### PR TITLE
Allow setting band-specific scale and offset values

### DIFF
--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -282,6 +282,14 @@ def test_gdal_edit_py_7():
     ds = gdal.Open('tmp/test_gdal_edit_py.tif')
     assert ds.GetRasterBand(1).GetScale() == 2
     assert ds.GetRasterBand(1).GetOffset() == 3
+    
+    shutil.copy('../gcore/data/1bit_2bands.tif', 'tmp/test_gdal_edit_py.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -scale 2 4 -offset 10 20")
+
+    ds = gdal.Open('tmp/test_gdal_edit_py.tif')
+    for i in [1, 2]:
+        assert ds.GetRasterBand(i).GetScale() == i*2
+        assert ds.GetRasterBand(i).GetOffset() == i*10
 
 ###############################################################################
 # Test -colorinterp_X

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -278,10 +278,10 @@ def test_gdal_edit_py_7():
     shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
 
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -scale 2 -offset 3")
-
     ds = gdal.Open('tmp/test_gdal_edit_py.tif')
     assert ds.GetRasterBand(1).GetScale() == 2
-    assert ds.GetRasterBand(1).GetOffset() == 3
+    assert ds.GetRasterBand(1).GetOffset() == 3  
+    ds = None
     
     shutil.copy('../gcore/data/1bit_2bands.tif', 'tmp/test_gdal_edit_py.tif')
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -scale 2 4 -offset 10 20")
@@ -290,6 +290,8 @@ def test_gdal_edit_py_7():
     for i in [1, 2]:
         assert ds.GetRasterBand(i).GetScale() == i*2
         assert ds.GetRasterBand(i).GetOffset() == i*10
+        
+    ds = None
 
 ###############################################################################
 # Test -colorinterp_X

--- a/gdal/swig/python/scripts/gdal_edit.dox
+++ b/gdal/swig/python/scripts/gdal_edit.dox
@@ -87,7 +87,9 @@ Assign a specified nodata value to output bands.</dd>
 Remove existing nodata values.</dd>
 
 <dt> <b>-scale</b> <i>value</i>:</dt><dd> (GDAL >= 2.2)
-Assign a specified scale value to output bands. If no scale is needed, it
+Assign a specified scale value to output bands. If a single scale value is provided it will be 
+set for all bands. Alternatively one scale value per band can be provided, in which case the 
+the number of scale values must match the number of bands. If no scale is needed, it
 it recommended to set the value to 1. Scale and Offset are generally used
 together. For example, scale and offset might be used to store elevations in 
 a unsigned 16bit integer file with a precision of 0.1, and starting from -100.
@@ -96,7 +98,9 @@ true_value = (pixel_value * scale) + offset
 Note: these values can be applied using -unscale during a gdal_translate run.</dd> 
 
 <dt> <b>-offset</b> <i>value</i>:</dt><dd> (GDAL >= 2.2)
-Assign a specified offset value to output bands. If no offset is needed, it
+Assign a specified offset value to output bands. If a single offset value is provided it will be 
+set for all bands. Alternatively one offset value per band can be provided, in which case the 
+the number of offset values must match the number of bands. If no offset is needed, it
 recommended to set the value to 0. For more see scale.</dd> 
 
 <dt> <b>-colorinterp_X</b> <i>red|green|blue|alpha|gray|undefined</i>:</dt><dd>
@@ -130,6 +134,9 @@ the existing metadata items, unless -unsetmd is also specified.</dd>
 
 \verbatim
 gdal_edit -mo DATUM=WGS84 -mo PROJ=GEODETIC -a_ullr 7 47 8 46 test.ecw
+
+gdal_edit -scale 1e3 1e4 -offset 0 10 twoBand.tif
+
 \endverbatim
 
 \if man

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -30,7 +30,6 @@
 ###############################################################################
 
 import sys
-import re
 from osgeo import gdal
 from osgeo import osr
 
@@ -90,7 +89,6 @@ def gdal_edit(argv):
     scale = []
     colorinterp = {}
     unsetrpc = False
-    isarg=re.compile('-\D')
 
     i = 1
     argc = len(argv)
@@ -117,16 +115,16 @@ def gdal_edit(argv):
         elif argv[i] == '-a_nodata' and i < len(argv) - 1:
             nodata = float(argv[i + 1])
             i = i + 1
-        elif argv[i] == '-scale' and i < len(argv) - 1:
+        elif argv[i] == '-scale' and i < len(argv) :
             scale.append(float(argv[i+1]))
             i = i + 1
-            while not isarg.match(argv[i+1][:2]) and i < len(argv) - 2:
+            while i < len(argv) - 1 and ArgIsNumeric(argv[i+1]):
                 scale.append(float(argv[i+1]))
                 i = i + 1
         elif argv[i] == '-offset' and i < len(argv) - 1:
             offset.append(float(argv[i+1]))
             i = i + 1
-            while not isarg.match(argv[i+1][:2]) and i < len(argv) - 2:
+            while i < len(argv) - 1 and ArgIsNumeric(argv[i+1]):
                 offset.append(float(argv[i+1]))
                 i = i + 1
         elif argv[i] == '-mo' and i < len(argv) - 1:
@@ -210,7 +208,7 @@ def gdal_edit(argv):
                 return Usage()
             colorinterp[band] = val
             i = i + 1
-        elif isarg.match(argv[i][:1]):
+        elif argv[i][0] == '-':
             sys.stderr.write('Unrecognized option : %s\n' % argv[i])
             return Usage()
         elif datasetname is None:

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -30,7 +30,7 @@
 ###############################################################################
 
 import sys
-
+import re
 from osgeo import gdal
 from osgeo import osr
 
@@ -86,10 +86,11 @@ def gdal_edit(argv):
     molist = []
     gcp_list = []
     open_options = []
-    offset = None
-    scale = None
+    offset = []
+    scale = []
     colorinterp = {}
     unsetrpc = False
+    isarg=re.compile('-\D')
 
     i = 1
     argc = len(argv)
@@ -117,11 +118,17 @@ def gdal_edit(argv):
             nodata = float(argv[i + 1])
             i = i + 1
         elif argv[i] == '-scale' and i < len(argv) - 1:
-            scale = float(argv[i + 1])
+            scale.append(float(argv[i+1]))
             i = i + 1
+            while not isarg.match(argv[i+1][:2]) and i < len(argv) - 2:
+                scale.append(float(argv[i+1]))
+                i = i + 1
         elif argv[i] == '-offset' and i < len(argv) - 1:
-            offset = float(argv[i + 1])
+            offset.append(float(argv[i+1]))
             i = i + 1
+            while not isarg.match(argv[i+1][:2]) and i < len(argv) - 2:
+                offset.append(float(argv[i+1]))
+                i = i + 1
         elif argv[i] == '-mo' and i < len(argv) - 1:
             molist.append(argv[i + 1])
             i = i + 1
@@ -203,7 +210,7 @@ def gdal_edit(argv):
                 return Usage()
             colorinterp[band] = val
             i = i + 1
-        elif argv[i][0] == '-':
+        elif isarg.match(argv[i][:1]):
             sys.stderr.write('Unrecognized option : %s\n' % argv[i])
             return Usage()
         elif datasetname is None:
@@ -261,6 +268,22 @@ def gdal_edit(argv):
     if ds is None:
         return -1
 
+    if scale:
+        if len(scale) == 1:
+            scale = scale * ds.RasterCount 
+        elif len(scale) != ds.RasterCount:
+            print('If more than one scale value is provided, their number must match the number of bands.')
+            print('')
+            return Usage()
+    
+    if offset:
+        if len(offset) == 1:
+            offset = offset * ds.RasterCount
+        elif len(offset) != ds.RasterCount:
+            print('If more than one offset value is provided, their number must match the number of bands.')
+            print('')
+            return Usage()
+    
     wkt = None
     if srs == '' or srs == 'None':
         ds.SetProjection('')
@@ -308,13 +331,13 @@ def gdal_edit(argv):
         for i in range(ds.RasterCount):
             ds.GetRasterBand(i + 1).DeleteNoDataValue()
 
-    if scale is not None:
+    if scale:
         for i in range(ds.RasterCount):
-            ds.GetRasterBand(i + 1).SetScale(scale)
+            ds.GetRasterBand(i + 1).SetScale(scale[i])
 
-    if offset is not None:
+    if offset:
         for i in range(ds.RasterCount):
-            ds.GetRasterBand(i + 1).SetOffset(offset)
+            ds.GetRasterBand(i + 1).SetOffset(offset[i])
 
     if unsetstats:
         for i in range(ds.RasterCount):


### PR DESCRIPTION
Previously, only a single scale and/or offset value could be set by gdal_edit.py, which was applied to all layers. Now, one can also specify one value per band, like this:

`gdal_edit.py -scale 1 10 100 -offset 0 -10 10 ThreeLayerFile.tif`

This functionality is useful for files with different scaling factors, which can, for example, be produced with `gdal_translate -scale_1 -scale_2 ...`

