### PR TITLE
CARTO: Improve documentation and warnings around CARTODBFY

### DIFF
--- a/gdal/ogr/ogrsf_frmts/carto/drv_carto.html
+++ b/gdal/ogr/ogrsf_frmts/carto/drv_carto.html
@@ -123,7 +123,14 @@ layer name to be created. Defaults to NO.</li>
 can be NULL. Defaults to YES.</li>
 
 <li><b>CARTODBFY</b>=YES/NO: Whether the created layer should be "Cartodbifi'ed"
- (i.e. registered in dashboard). Defaults to YES.</li>
+ (i.e. registered in dashboard). Defaults to YES. Requires:
+   <ul>
+   <li><b>SRS</b>: Output SRS must be  EPSG:4326. You can use <tt>-a_srs</tt> or
+   <tt>-t_srs</tt> to assign or transform to 4326 before importing.</li>
+   <li><b>Geometry type</b>: Must be different than NONE. You can set to
+    something generic with <tt>-nlt GEOMETRY</tt>.</li>
+   </ul>
+</li>
 
 <li> <b>LAUNDER</b>=YES/NO: This may be "YES" to force new fields created on this
 layer to have their field names "laundered" into a form more compatible with
@@ -135,20 +142,29 @@ The default value is "YES".  If enabled the table (layer) name will also be laun
 
 
 <h2>Examples</h2>
-
+<ul>
 <li>
-Acceccing data from a public table:
+Accessing data from a public table:
 <pre>
 ogrinfo -ro "Carto:gdalautotest2 tables=tm_world_borders_simpl_0_3"
 </pre>
-<p>
 
 <li>
 Creating and populating a table from a shapefile:
 <pre>
 ogr2ogr --config CARTO_API_KEY abcdefghijklmnopqrstuvw -f Carto "Carto:myaccount" myshapefile.shp
 </pre>
-<p>
+</li>
+
+<li>
+Creating and populating a table from a CSV containing geometries on EPSG:4326:
+<pre>
+ogr2ogr --config CARTO_API_KEY abcdefghijklmnopqrstuvw -f Carto "Carto:myaccount" file.csv -a_srs 4326 -nlt GEOMETRY
+</pre>
+<b>NOTE</b>: <tt>-a_srs</tt> and <tt>-nlt</tt> must be provided to CARTODBFY
+since the information isn't extracted from the CSV.
+</li>
+</ul>
 
 <h2>See Also</h2>
 

--- a/gdal/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
@@ -452,7 +452,7 @@ OGRLayer   *OGRCARTODataSource::ICreateLayer( const char *pszNameIn,
     OGRCARTOTableLayer* poLayer = new OGRCARTOTableLayer(this, osName);
     const bool bGeomNullable =
         CPLFetchBool(papszOptions, "GEOMETRY_NULLABLE", true);
-    int nSRID = (poSpatialRef && eGType != wkbNone) ? FetchSRSId( poSpatialRef ) : 0;
+    int nSRID = poSpatialRef ? FetchSRSId( poSpatialRef ) : 0;
     bool bCartoify = CPLFetchBool(papszOptions, "CARTODBFY",
                                   CPLFetchBool(papszOptions, "CARTODBIFY",
                                                true));
@@ -460,12 +460,19 @@ OGRLayer   *OGRCARTODataSource::ICreateLayer( const char *pszNameIn,
     {
         if( nSRID != 4326 )
         {
-            if( eGType != wkbNone )
-            {
-                CPLError(CE_Warning, CPLE_AppDefined,
-                        "Cannot register table in dashboard with "
-                        "cdb_cartodbfytable() since its SRS is not EPSG:4326");
-            }
+            CPLError(CE_Warning, CPLE_AppDefined,
+                    "Cannot register table in dashboard with "
+                    "cdb_cartodbfytable() since its SRS is not EPSG:4326."
+                    " Check the documentation for more information"
+                );
+            bCartoify = false;
+        } else if( eGType == wkbNone )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                    "Cannot register table in dashboard with "
+                    "cdb_cartodbfytable() since its geometry type isn't defined."
+                    " Check the documentation for more information"
+                );
             bCartoify = false;
         }
     }


### PR DESCRIPTION
## What does this PR do?

Improves the documentation around the CARTODBFY option. This is changed with CSV imports in mind since those don't set neither the output SRS or geometry type automatically.

## What are related issues/pull requests?

Closes https://github.com/OSGeo/gdal/issues/1399

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
