### PR TITLE
Fix spelling errors.

### DIFF
--- a/gdal/frmts/gtiff/libgeotiff/geo_normalize.c
+++ b/gdal/frmts/gtiff/libgeotiff/geo_normalize.c
@@ -3050,14 +3050,14 @@ void GTIFAttachPROJContext( GTIF *psGTIF, void* pjContext )
 /*                         GTIFGetPROJContext()                         */
 /*                                                                      */
 /*      Return the PROJ context attached to the GTIF handle.            */
-/*      If it has not yet been instanciated and instanciateIfNeeded=TRUE*/
-/*      then, it will be instanciated (and owned by GTIF handle).       */
+/*      If it has not yet been instantiated and instantiateIfNeeded=TRUE*/
+/*      then, it will be instantiated (and owned by GTIF handle).       */
 /************************************************************************/
 
-void *GTIFGetPROJContext( GTIF *psGTIF, int instanciateIfNeeded,
+void *GTIFGetPROJContext( GTIF *psGTIF, int instantiateIfNeeded,
                           int* out_gtif_own_pj_context )
 {
-    if( psGTIF->pj_context || !instanciateIfNeeded )
+    if( psGTIF->pj_context || !instantiateIfNeeded )
     {
         if( out_gtif_own_pj_context )
         {

--- a/gdal/frmts/gtiff/libgeotiff/geo_normalize.h
+++ b/gdal/frmts/gtiff/libgeotiff/geo_normalize.h
@@ -175,7 +175,7 @@ void GTIF_DLL GTIFFreeMemory( char * );
 
 /* The void* should be a PJ_CONTEXT* */
 void GTIF_DLL GTIFAttachPROJContext( GTIF *psGTIF, void* pjContext );
-void GTIF_DLL *GTIFGetPROJContext( GTIF *psGTIF, int instanciateIfNeeded,
+void GTIF_DLL *GTIFGetPROJContext( GTIF *psGTIF, int instantiateIfNeeded,
                                    int* out_gtif_own_pj_context );
 
 int GTIF_DLL GTIFGetDefn( GTIF *psGTIF, GTIFDefn * psDefn );

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -765,7 +765,7 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
         if( !m_pj )
         {
             CPLError( CE_Failure, CPLE_NotSupported,
-                      "Cannot instanciate pipeline %s",
+                      "Cannot instantiate pipeline %s",
                       options.d->osCoordOperation.c_str() );
             return FALSE;
         }
@@ -915,13 +915,13 @@ bool OGRProjCT::ListCoordinateOperations(const char* pszSrcSRS,
 
     auto src = proj_create(ctx, pszSrcSRS);
     if( !src ) {
-        CPLError(CE_Failure, CPLE_AppDefined, "Cannot instanciate source_crs");
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot instantiate source_crs");
         return false;
     }
 
     auto dst = proj_create(ctx, pszTargetSRS);
     if( !dst ) {
-        CPLError(CE_Failure, CPLE_AppDefined, "Cannot instanciate target_crs");
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot instantiate target_crs");
         proj_destroy(src);
         return false;
     }

--- a/gdal/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
+++ b/gdal/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
@@ -47,7 +47,7 @@ extern "C" void CPL_DLL RegisterOGRMongoDBv3();
 using bsoncxx::builder::basic::kvp;
 
 static mongocxx::instance* g_pInst = nullptr;
-static bool g_bCanInstanciateMongo = true;
+static bool g_bCanInstantiateMongo = true;
 
 namespace {
 typedef struct _IntOrMap IntOrMap;
@@ -2561,7 +2561,7 @@ static GDALDataset* OGRMongoDBv3DriverOpen( GDALOpenInfo* poOpenInfo )
         std::lock_guard<std::mutex> oLock(oMutex);
         if( g_pInst == nullptr )
         {
-            if( !g_bCanInstanciateMongo )
+            if( !g_bCanInstantiateMongo )
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "MongoDB client has been previously shut down and "
@@ -2615,7 +2615,7 @@ static void OGRMongoDBv3DriverUnload( GDALDriver* )
     {
         delete g_pInst;
         g_pInst = nullptr;
-        g_bCanInstanciateMongo = false;
+        g_bCanInstantiateMongo = false;
     }
 }
 /************************************************************************/


### PR DESCRIPTION
The lintian QA tool reported a spelling error for GDAL 2.5.0-beta1:

 * instanciate -> instantiate