### PR TITLE
Add "-nogcp" option to gdal_translate binary and the python binding.

### DIFF
--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -838,6 +838,27 @@ def test_gdal_translate_38():
     ds = None
 
 ###############################################################################
+# Test -nogcp options
+
+
+def test_gdal_translate_39():
+    if test_cli_utilities.get_gdal_translate_path() is None:
+        pytest.skip()
+
+    gdaltest.runexternal(test_cli_utilities.get_gdal_translate_path() + ' -nogcp ../gcore/data/byte_gcp.tif tmp/test39.tif')
+
+    ds = gdal.Open('tmp/test39.tif')
+    assert ds is not None
+
+    assert ds.GetRasterBand(1).Checksum() == 4672, 'Bad checksum'
+
+    gcps = ds.GetGCPs()
+    assert len(gcps) == 0, 'GCP count wrong.'
+
+    ds = None
+
+
+###############################################################################
 # Cleanup
 
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -438,6 +438,23 @@ def test_gdal_translate_lib_colorinterp():
             gdal.Translate('', src_ds, options='-f MEM -colorinterp_0 alpha')
             
 
+###############################################################################
+# Test nogcp options
+
+
+def test_gdal_translate_lib_110():
+
+    ds = gdal.Open('../gcore/data/byte_gcp.tif')
+    ds = gdal.Translate('tmp/test110.tif', ds, nogcp='True')
+    assert ds is not None
+
+    assert ds.GetRasterBand(1).Checksum() == 4672, 'Bad checksum'
+
+    gcps = ds.GetGCPs()
+    assert len(gcps) == 0, 'GCP count wrong.'
+
+    ds = None
+
     
 ###############################################################################
 # Cleanup

--- a/gdal/apps/gdal_translate_bin.cpp
+++ b/gdal/apps/gdal_translate_bin.cpp
@@ -56,7 +56,7 @@ static void Usage(const char* pszErrorMsg, int bShort)
             "       [-projwin ulx uly lrx lry] [-projwin_srs srs_def]\n"
             "       [-a_srs srs_def] [-a_ullr ulx uly lrx lry] [-a_nodata value]\n"
             "       [-a_scale value] [-a_offset value]\n"
-            "       [-gcp pixel line easting northing [elevation]]*\n"
+            "       [-nogcp] [-gcp pixel line easting northing [elevation]]*\n"
             "       |-colorinterp{_bn} {red|green|blue|alpha|gray|undefined}]\n"
             "       |-colorinterp {red|green|blue|alpha|gray|undefined},...]\n"
             "       [-mo \"META-TAG=VALUE\"]* [-q] [-sds]\n"

--- a/gdal/apps/gdal_utilities.dox
+++ b/gdal/apps/gdal_utilities.dox
@@ -327,7 +327,7 @@ gdal_translate [--help-general]
        [-projwin ulx uly lrx lry] [-projwin_srs srs_def]
        [-a_srs srs_def] [-a_ullr ulx uly lrx lry] [-a_nodata value]
        [-a_scale value] [-a_offset value]
-       [-gcp pixel line easting northing [elevation]]*
+       [-nogcp] [-gcp pixel line easting northing [elevation]]*
        |-colorinterp{_bn} {red|green|blue|alpha|gray|undefined}]
        |-colorinterp {red|green|blue|alpha|gray|undefined},...]
        [-mo "META-TAG=VALUE"]* [-q] [-sds]
@@ -458,6 +458,9 @@ value to set on the output dataset if possible.</dd>
 output format driver.  Multiple <b>-co</b> options may be listed. See <a class="el"
 href="formats_list.html" title="GDAL Raster Formats">format specific
 documentation for legal creation options for each format</a>.</dd>
+<dt> <b>-nogcp</b></dt><dd>
+Do not copy the GCPs in the source dataset to the output dataset. 
+</dd>
 <dt> <b>-gcp</b> <i>pixel line easting northing elevation</i>:</dt><dd>
 Add the indicated ground control point to the output dataset.  This option
 may be provided multiple times to provide a set of GCPs.

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1076,7 +1076,7 @@ def TranslateOptions(options=None, format=None,
               creationOptions=None, srcWin=None, projWin=None, projWinSRS=None, strict = False,
               unscale = False, scaleParams=None, exponents=None,
               outputBounds=None, metadataOptions=None,
-              outputSRS=None, GCPs=None,
+              outputSRS=None, nogcp=False, GCPs=None,
               noData=None, rgbExpand=None,
               stats = False, rat = True, resampleAlg=None,
               callback=None, callback_data=None):
@@ -1104,6 +1104,7 @@ def TranslateOptions(options=None, format=None,
           outputBounds --- assigned output bounds: [ulx, uly, lrx, lry]
           metadataOptions --- list of metadata options
           outputSRS --- assigned output SRS
+          nogcp --- ignore GCP in the raster
           GCPs --- list of GCPs
           noData --- nodata value (or "none" to unset it)
           rgbExpand --- Color palette expansion mode: "gray", "rgb", "rgba"
@@ -1156,6 +1157,8 @@ def TranslateOptions(options=None, format=None,
                 new_options += ['-mo', opt]
         if outputSRS is not None:
             new_options += ['-a_srs', str(outputSRS)]
+        if nogcp:
+            new_options += ['-nogcp']
         if GCPs is not None:
             for gcp in GCPs:
                 new_options += ['-gcp', _strHighPrec(gcp.GCPPixel), _strHighPrec(gcp.GCPLine), _strHighPrec(gcp.GCPX), str(gcp.GCPY), _strHighPrec(gcp.GCPZ)]

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -282,7 +282,7 @@ def TranslateOptions(options=None, format=None,
               creationOptions=None, srcWin=None, projWin=None, projWinSRS=None, strict = False,
               unscale = False, scaleParams=None, exponents=None,
               outputBounds=None, metadataOptions=None,
-              outputSRS=None, GCPs=None,
+              outputSRS=None, nogcp=False, GCPs=None,
               noData=None, rgbExpand=None,
               stats = False, rat = True, resampleAlg=None,
               callback=None, callback_data=None):
@@ -310,6 +310,7 @@ def TranslateOptions(options=None, format=None,
           outputBounds --- assigned output bounds: [ulx, uly, lrx, lry]
           metadataOptions --- list of metadata options
           outputSRS --- assigned output SRS
+          nogcp --- ignore GCP in the raster
           GCPs --- list of GCPs
           noData --- nodata value (or "none" to unset it)
           rgbExpand --- Color palette expansion mode: "gray", "rgb", "rgba"
@@ -362,6 +363,8 @@ def TranslateOptions(options=None, format=None,
                 new_options += ['-mo', opt]
         if outputSRS is not None:
             new_options += ['-a_srs', str(outputSRS)]
+        if nogcp:
+            new_options += ['-nogcp']
         if GCPs is not None:
             for gcp in GCPs:
                 new_options += ['-gcp', _strHighPrec(gcp.GCPPixel), _strHighPrec(gcp.GCPLine), _strHighPrec(gcp.GCPX), str(gcp.GCPY), _strHighPrec(gcp.GCPZ)]


### PR DESCRIPTION
If "-nogcp" is specified, gdal_translate will ignore the GCPs in the source
dataset. By default, nogcp is false and the GCPs in the source dataset are
copied to the destination dataset.

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Add -nogcp option to gdal_translate. 

If "-nogcp" is specified, gdal_translate will ignore the GCPs in the source
dataset. By default, nogcp is false and the GCPs in the source dataset are
copied to the destination dataset.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
