### PR TITLE
Fix selection of Poppler PDF layers with duplicate names

### DIFF
--- a/gdal/frmts/pdf/gdal_pdf.h
+++ b/gdal/frmts/pdf/gdal_pdf.h
@@ -268,7 +268,7 @@ class PDFDataset final: public GDALPamDataset
     void         ExploreLayersPoppler(GDALPDFArray* poArray, int nRecLevel, CPLString osTopLayer = "");
     void         FindLayersPoppler();
     void         TurnLayersOnOffPoppler();
-    std::map<CPLString, OptionalContentGroup*> oLayerOCGMapPoppler;
+    std::vector<std::pair<CPLString, OptionalContentGroup*> > oLayerOCGListPoppler;
 #endif
 
 #ifdef HAVE_PDFIUM


### PR DESCRIPTION
Apply selection to all layers with a given name,
rather than only one of those layers chosen at random.