### PR TITLE
TileDB: Added support for raster band metadata

### DIFF
--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -152,3 +152,23 @@ def test_tiledb_write_subdatasets():
     assert not src_ds
 
     gdaltest.tiledb_drv.Delete('tmp/test_sds_array')
+
+@pytest.mark.require_driver('TileDB')
+def test_tiledb_write_band_meta():
+    gdaltest.tiledb_drv = gdal.GetDriverByName('TileDB')
+
+    src_ds = gdal.Open('../gcore/data/rgbsmall.tif')
+
+    new_ds = gdaltest.tiledb_drv.CreateCopy('tmp/tiledb_meta', src_ds)
+
+    bnd = new_ds.GetRasterBand(1)
+    bnd.SetMetadataItem('Item', 'Value')
+
+    bnd = None
+    new_ds = None
+    src_ds = None
+    
+    new_ds = gdal.Open('tmp/tiledb_meta')
+    assert new_ds.GetRasterBand(1).GetMetadataItem('Item') == 'Value'
+
+    gdaltest.tiledb_drv.Delete('tmp/tiledb_meta')

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -63,14 +63,15 @@ class TileDBDataset : public GDALPamDataset
         char          **papszSubDatasets = nullptr;
         CPLStringList m_osSubdatasetMD{};
         CPLXMLNode*   psSubDatasetsTree = nullptr;
+        CPLString     osMetaDoc;
 
         std::unique_ptr<tiledb::Context> m_ctx;
         std::unique_ptr<tiledb::Array> m_array;
         std::unique_ptr<tiledb::ArraySchema> m_schema;
         std::unique_ptr<tiledb::FilterList> m_filterList;
 
-         char          **papszAttributes = nullptr;
-         std::list<std::unique_ptr<GDALDataset>> lpoAttributeDS = {};
+        char          **papszAttributes = nullptr;
+        std::list<std::unique_ptr<GDALDataset>> lpoAttributeDS = {};
 
         bool bStats = FALSE;
         CPLErr AddFilter( const char* pszFilterName, const int level );
@@ -79,6 +80,7 @@ class TileDBDataset : public GDALPamDataset
     public:
         virtual ~TileDBDataset();
 
+        CPLErr TryLoadCachedXML(char **papszSiblingFiles = nullptr, bool bReload=true);
         CPLErr TryLoadXML(char **papszSiblingFiles = nullptr) override;
         CPLErr TrySaveXML() override;
         char** GetMetadata(const char *pszDomain) override;
@@ -126,6 +128,7 @@ class TileDBRasterBand : public GDALPamRasterBand
         virtual CPLErr IReadBlock( int, int, void * ) override;
         virtual CPLErr IWriteBlock( int, int, void * ) override;
         virtual GDALColorInterp GetColorInterpretation() override;
+
 };
 
 /************************************************************************/
@@ -620,7 +623,17 @@ CPLErr TileDBDataset::TrySaveXML()
 /*                           TryLoadXML()                               */
 /************************************************************************/
 
-CPLErr TileDBDataset::TryLoadXML( char ** /*papszSiblingFiles*/ )
+CPLErr TileDBDataset::TryLoadXML( char ** papszSiblingFiles )
+
+{
+    return TryLoadCachedXML( papszSiblingFiles, true );
+}
+
+/************************************************************************/
+/*                           TryLoadCachedXML()                               */
+/************************************************************************/
+
+CPLErr TileDBDataset::TryLoadCachedXML( char ** /*papszSiblingFiles*/, bool bReload )
 
 {
     CPLXMLNode *psTree = nullptr;
@@ -661,15 +674,22 @@ CPLErr TileDBDataset::TryLoadXML( char ** /*papszSiblingFiles*/ )
 
             if ( vfs.is_file( psPam->pszPamFilename ) )
             {
-                auto nBytes = vfs.file_size( psPam->pszPamFilename );
-                tiledb::VFS::filebuf fbuf( vfs );
-                fbuf.open( psPam->pszPamFilename, std::ios::in );
-                std::istream is ( &fbuf );
-                CPLString osDoc;
-                osDoc.resize(nBytes);
-                is.read( ( char* ) osDoc.data(), nBytes );
-                fbuf.close();
-                psTree = CPLParseXMLString( osDoc );
+                if ( bReload )
+                {
+                    auto nBytes = vfs.file_size( psPam->pszPamFilename );
+                    tiledb::VFS::filebuf fbuf( vfs );
+                    fbuf.open( psPam->pszPamFilename, std::ios::in );
+                    std::istream is ( &fbuf );
+                    osMetaDoc.resize(nBytes);
+                    is.read( ( char* ) osMetaDoc.data(), nBytes );
+                    fbuf.close();
+                    psTree = CPLParseXMLString( osMetaDoc );
+                }
+                else
+                {
+                    psTree = CPLParseXMLString( osMetaDoc );
+                }
+                
             }
         }
         CPLErrorReset();
@@ -1118,6 +1138,9 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
                 }
             }
         }
+
+        // reload metadata now that bands are created to populate band metadata
+        poDS->TryLoadCachedXML( nullptr, false );
         
         tiledb::VFS vfs( *poDS->m_ctx, poDS->m_ctx->config() );
 


### PR DESCRIPTION
## What does this PR do?

When loading a TileDB array the band metadata wasn't being populated in the initial `XMLInit` call. This is because the TileDB driver needs to read the metadata first to determine the number of bands before creating the band objects. 

This PR adds a reload function that caches the XML and reloads the file after the bands have been created.

## What are related issues/pull requests?

None

## Tasklist

 - [X] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
