### PR TITLE
Update CITATION and HOWTO-RELEASE

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,7 +1,7 @@
 To cite GDAL/OGR in publications use:
 
-  GDAL/OGR contributors (2018). GDAL/OGR Geospatial Data Abstraction
-  software Library. Open Source Geospatial Foundation. URL http://gdal.org
+  GDAL/OGR contributors (2019). GDAL/OGR Geospatial Data Abstraction
+  software Library. Open Source Geospatial Foundation. URL https://gdal.org
 
 A BibTeX entry for LaTeX users is
 
@@ -9,6 +9,6 @@ A BibTeX entry for LaTeX users is
     title = {{GDAL/OGR} Geospatial Data Abstraction software Library},
     author = {{GDAL/OGR contributors}},
     organization = {Open Source Geospatial Foundation},
-    year = {2018},
-    url = {http://gdal.org},
+    year = {2019},
+    url = {https://gdal.org},
   }

--- a/gdal/HOWTO-RELEASE
+++ b/gdal/HOWTO-RELEASE
@@ -40,9 +40,11 @@ Process :
       if new command line switches have been added. scripts/completionFinder.py
       must also be edited before if new utilities/scripts are added/removed.
 
-2) Update the release date, and number information in gcore/gdal_version.h.in
-   (*NOT* gdal_version.h which is a generated file)
-   Note: the format of GDAL_RELEASE_DATE should be YYYYMMDD.
+2.1) Update the release date, and number information in gcore/gdal_version.h.in
+     (*NOT* gdal_version.h which is a generated file)
+     Note: the format of GDAL_RELEASE_DATE should be YYYYMMDD.
+
+2.2) Update two instances of year in ../CITATION file to the current year.
 
 3) Update the VERSION file.
 


### PR DESCRIPTION
Fixes #1499 

Also updating CITATION to use HTTPS links, as are now supported.

HOWTO-RELEASE was updated as discussed in #1499, by splitting step 2 into 2.1 and 2.2.