### PR TITLE
EEDA: Bump to v1alpha.

### DIFF
--- a/autotest/gdrivers/eedai.py
+++ b/autotest/gdrivers/eedai.py
@@ -82,7 +82,7 @@ def test_eedai_2():
             {
                 "id": "B1",
                 "dataType": {
-                    "precision": "INTEGER",
+                    "precision": "INT",
                     "range": {
                         "max": 65535
                     }
@@ -105,7 +105,7 @@ def test_eedai_2():
             {
                 "id": "B2",
                 "dataType": {
-                    "precision": "INTEGER",
+                    "precision": "INT",
                     "range": {
                         "max": 65535
                     }
@@ -128,7 +128,7 @@ def test_eedai_2():
             {
                 "id": "B9",
                 "dataType": {
-                    "precision": "INTEGER",
+                    "precision": "INT",
                     "range": {
                         "max": 65535
                     }
@@ -522,7 +522,7 @@ def test_eedai_4():
             {
                 "id": "B1",
                 "dataType": {
-                    "precision": "INTEGER",
+                    "precision": "INT",
                     "range": {
                         "max": 255
                     }
@@ -544,7 +544,7 @@ def test_eedai_4():
             {
                 "id": "B2",
                 "dataType": {
-                    "precision": "INTEGER",
+                    "precision": "INT",
                     "range": {
                         "max": 255
                     }
@@ -566,7 +566,7 @@ def test_eedai_4():
             {
                 "id": "B3",
                 "dataType": {
-                    "precision": "INTEGER",
+                    "precision": "INT",
                     "range": {
                         "max": 255
                     }
@@ -654,7 +654,7 @@ def test_eedai_geotiff():
             {
                 "id": "B1",
                 "dataType": {
-                    "precision": "INTEGER",
+                    "precision": "INT",
                     "range": {
                         "max": 65535
                     }

--- a/autotest/ogr/ogr_eeda.py
+++ b/autotest/ogr/ogr_eeda.py
@@ -60,7 +60,7 @@ def test_eeda_2():
         pytest.skip()
 
     gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageSize=1', json.dumps({
-        'assets': [
+        'images': [
             {
                 'properties':
                 {
@@ -94,13 +94,13 @@ def test_eeda_2():
     assert lyr.GetFeatureCount() == -1
 
     gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages', json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-public/assets/collection/first_feature',
                 'id': 'collection/first_feature',
-                'path': 'collection/first_feature',
-                'time': '2017-01-02T12:34:56.789Z',
-                'updateTime': '2017-01-03T12:34:56.789Z',
+                'updateTime': '2017-01-04T12:34:56.789Z',
+                'startTime': '2017-01-02T12:34:56.789Z',
+                'endTime': '2017-01-03T12:34:56.789Z',
                 'sizeBytes': 1,
                 'geometry': {'type': 'Polygon', 'coordinates': [[[2, 49], [2.1, 49], [2.1, 49.1], [2, 49.1], [2, 49]]]},
                 'properties':
@@ -115,7 +115,7 @@ def test_eeda_2():
                     {
                         "id": "B1",
                         "dataType": {
-                            "precision": "INTEGER",
+                            "precision": "INT",
                             "range": {
                                 "max": 255
                             }
@@ -146,10 +146,10 @@ def test_eeda_2():
     f = lyr.GetNextFeature()
     if f.GetField('name') != 'projects/earthengine-public/assets/collection/first_feature' or \
        f.GetField('id') != 'collection/first_feature' or \
-       f.GetField('path') != 'collection/first_feature' or \
        f.GetField('gdal_dataset') != 'EEDAI:projects/earthengine-public/assets/collection/first_feature' or \
-       f.GetField('time') != '2017/01/02 12:34:56.789+00' or \
-       f.GetField('updateTime') != '2017/01/03 12:34:56.789+00' or \
+       f.GetField('updateTime') != '2017/01/04 12:34:56.789+00' or \
+       f.GetField('startTime') != '2017/01/02 12:34:56.789+00' or \
+       f.GetField('endTime') != '2017/01/03 12:34:56.789+00' or \
        f.GetField('sizeBytes') != 1 or \
        f.GetField('band_count') != 1 or \
        f.GetField('band_max_width') != 1830 or \
@@ -173,7 +173,7 @@ def test_eeda_2():
         pytest.fail()
 
     gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageToken=myToken', json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-public/assets/collection/third_feature'
             }
@@ -198,7 +198,7 @@ def test_eeda_2():
     lyr.SetAttributeFilter('EEDA:raw_filter')
 
     gdal.FileFromMemBuffer('/vsimem/ee/projects/earthengine-public/assets/collection:listImages?filter=raw%5Ffilter', json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-public/assets/collection/raw_filter'
             }
@@ -209,8 +209,8 @@ def test_eeda_2():
     assert f.GetField('name') == 'projects/earthengine-public/assets/collection/raw_filter'
 
     lyr.SetAttributeFilter(None)
-    lyr.SetAttributeFilter("time >= '1980-01-01T00:00:00Z' AND " +
-                           "time <= '2100-01-01T00:00:00Z' AND " +
+    lyr.SetAttributeFilter("startTime >= '1980-01-01T00:00:00Z' AND " +
+                           "startTime <= '2100-01-01T00:00:00Z' AND " +
                            "string_field = 'bar' AND " +
                            "int_field > 0 AND " +
                            "int_field < 2 AND " +
@@ -222,11 +222,11 @@ def test_eeda_2():
 
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/collection:listImages?region=%7B%20%22type%22%3A%20%22Polygon%22%2C%20%22coordinates%22%3A%20%5B%20%5B%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%20%5D%20%5D%20%7D&filter=%28%28%28%28%28%28%28string%5Ffield%20%3D%20%22bar%22%20AND%20int%5Ffield%20%3E%200%29%20AND%20int%5Ffield%20%3C%202%29%20AND%20int64%5Ffield%20%3E%3D%200%29%20AND%20int64%5Ffield%20%3C%3D%209999999999999%29%20AND%20double%5Ffield%20%21%3D%203%2E5%29%20AND%20string%5Ffield%20%3D%20%22bar%22%20OR%20string%5Ffield%20%3D%20%22baz%22%29%20AND%20%28NOT%20%28int%5Ffield%20%3D%200%20OR%20double%5Ffield%20%3D%203%2E5%29%29%29&startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=2100%2D01%2D01T00%3A00%3A00Z'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-public/assets/collection/filtered_feature',
-                'time': '2017-01-02T12:34:56.789Z',
                 'updateTime': '2017-01-03T12:34:56.789Z',
+                'startTime': '2017-01-02T12:34:56.789Z',
                 'sizeBytes': 1,
                 'geometry': {'type': 'Polygon', 'coordinates': [[[2, 49], [2.1, 49], [2.1, 49.1], [2, 49.1], [2, 49]]]},
                 'properties':
@@ -254,14 +254,14 @@ def test_eeda_2():
     lyr.SetSpatialFilter(None)
 
     # Test time equality with second granularity
-    lyr.SetAttributeFilter("time = '1980-01-01T00:00:00Z'")
+    lyr.SetAttributeFilter("startTime = '1980-01-01T00:00:00Z'")
 
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D01T00%3A00%3A01Z'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-public/assets/collection/filtered_feature',
-                'time': '1980-01-01T00:00:00Z'
+                'startTime': '1980-01-01T00:00:00Z'
             },
             {
                 'name': 'projects/earthengine-public/assets/collection/second_feature'
@@ -275,14 +275,14 @@ def test_eeda_2():
     assert f.GetField('name') == 'projects/earthengine-public/assets/collection/filtered_feature'
 
     # Test time equality with day granularity
-    lyr.SetAttributeFilter("time = '1980-01-01'")
+    lyr.SetAttributeFilter("startTime = '1980-01-01'")
 
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D01T23%3A59%3A59Z'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-public/assets/collection/filtered_feature',
-                'time': '1980-01-01T12:00:00Z',
+                'startTime': '1980-01-01T12:00:00Z',
             },
             {
                 'name': 'projects/earthengine-public/assets/collection/second_feature'
@@ -335,7 +335,7 @@ def test_eeda_4():
     # User asset ID ("users/**").
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-legacy/assets/users/foo:listImages?pageSize=1'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-legacy/assets/users/foo/bar'
             }
@@ -347,7 +347,7 @@ def test_eeda_4():
     # Project asset ID ("projects/**").
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-legacy/assets/projects/foo:listImages?pageSize=1'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-legacy/assets/projects/foo/bar'
             }
@@ -361,7 +361,7 @@ def test_eeda_4():
     # Multi-folder project asset ID ("projects/foo/bar/baz").
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-legacy/assets/projects/foo/bar/baz:listImages?pageSize=1'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-legacy/assets/projects/foo/bar/baz/qux'
             }
@@ -375,7 +375,7 @@ def test_eeda_4():
     # Public-catalog asset ID (e.g. "LANDSAT").
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/earthengine-public/assets/foo:listImages?pageSize=1'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/earthengine-public/assets/foo/bar'
             }
@@ -389,7 +389,7 @@ def test_eeda_4():
     # Asset name ("projects/*/assets/**").
     ogrtest.eeda_drv_tmpfile = '/vsimem/ee/projects/foo/assets/bar:listImages?pageSize=1'
     gdal.FileFromMemBuffer(ogrtest.eeda_drv_tmpfile, json.dumps({
-        'assets': [
+        'images': [
             {
                 'name': 'projects/foo/assets/bar/baz'
             }

--- a/gdal/frmts/eeda/eedacommon.cpp
+++ b/gdal/frmts/eeda/eedacommon.cpp
@@ -65,7 +65,7 @@ std::vector<EEDAIBandDesc> BuildBandDescArray(json_object* poBands,
             continue;
         GDALDataType eDT = GDT_Byte;
         bool bSignedByte = false;
-        if( EQUAL(pszPrecision, "INTEGER") )
+        if( EQUAL(pszPrecision, "INT") )
         {
             json_object* poRange = CPL_json_object_object_get(poDataType,
                                                               "range");
@@ -108,11 +108,11 @@ std::vector<EEDAIBandDesc> BuildBandDescArray(json_object* poBands,
                 }
             }
         }
-        else if( EQUAL(pszPrecision, "FLOAT32") )
+        else if( EQUAL(pszPrecision, "FLOAT") )
         {
             eDT = GDT_Float32;
         }
-        else if( EQUAL(pszPrecision, "FLOAT64") )
+        else if( EQUAL(pszPrecision, "DOUBLE") )
         {
             eDT = GDT_Float64;
         }

--- a/gdal/frmts/eeda/eedadataset.cpp
+++ b/gdal/frmts/eeda/eedadataset.cpp
@@ -200,19 +200,19 @@ GDALEEDALayer::GDALEEDALayer(GDALEEDADataset* poDS,
         m_poFeatureDefn->AddFieldDefn(&oFieldDefn);
     }
     {
-        OGRFieldDefn oFieldDefn("path", OFTString);
-        m_poFeatureDefn->AddFieldDefn(&oFieldDefn);
-    }
-    {
         OGRFieldDefn oFieldDefn("gdal_dataset", OFTString);
         m_poFeatureDefn->AddFieldDefn(&oFieldDefn);
     }
     {
-        OGRFieldDefn oFieldDefn("time", OFTDateTime);
+        OGRFieldDefn oFieldDefn("updateTime", OFTDateTime);
         m_poFeatureDefn->AddFieldDefn(&oFieldDefn);
     }
     {
-        OGRFieldDefn oFieldDefn("updateTime", OFTDateTime);
+        OGRFieldDefn oFieldDefn("startTime", OFTDateTime);
+        m_poFeatureDefn->AddFieldDefn(&oFieldDefn);
+    }
+    {
+        OGRFieldDefn oFieldDefn("endTime", OFTDateTime);
         m_poFeatureDefn->AddFieldDefn(&oFieldDefn);
     }
     {
@@ -442,7 +442,7 @@ OGRFeature* GDALEEDALayer::GetNextRawFeature()
             return nullptr;
 
         m_poCurPageAssets = CPL_json_object_object_get(
-                                                m_poCurPageObj, "assets");
+                                                m_poCurPageObj, "images");
     }
 
     if( m_poCurPageAssets == nullptr ||
@@ -503,15 +503,8 @@ OGRFeature* GDALEEDALayer::GetNextRawFeature()
         poFeature->SetField("id", pszId);
     }
 
-    const char* pszPath =
-        json_object_get_string(CPL_json_object_object_get(poAsset, "path"));
-    if ( pszPath )
-    {
-        poFeature->SetField("path", pszPath);
-    }
-
     const char* const apszBaseProps[] =
-        { "time", "updateTime", "sizeBytes" };
+        { "updateTime", "startTime", "endTime", "sizeBytes" };
     for( size_t i = 0; i < CPL_ARRAYSIZE(apszBaseProps); i++ )
     {
         const char* pszVal = json_object_get_string(
@@ -806,7 +799,7 @@ CPLString GDALEEDALayer::BuildFilter(swq_expr_node* poNode, bool bIsAndTopLevel)
              poNode->papoSubExpr[0]->eNodeType == SNT_COLUMN &&
              poNode->papoSubExpr[1]->eNodeType == SNT_CONSTANT &&
              poNode->papoSubExpr[0]->field_index ==
-                    m_poFeatureDefn->GetFieldIndex("time") &&
+                    m_poFeatureDefn->GetFieldIndex("startTime") &&
              poNode->papoSubExpr[1]->field_type == SWQ_TIMESTAMP )
     {
         if( poNode->nOperation == SWQ_GE || poNode->nOperation == SWQ_EQ )
@@ -1120,7 +1113,7 @@ static json_object* GDALEEDADatasetGetConf()
 bool GDALEEDADataset::Open(GDALOpenInfo* poOpenInfo)
 {
     m_osBaseURL = CPLGetConfigOption("EEDA_URL",
-                            "https://earthengine.googleapis.com/v1/");
+                            "https://earthengine.googleapis.com/v1alpha/");
 
     CPLString osCollection =
             CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "COLLECTION", "");
@@ -1163,7 +1156,7 @@ bool GDALEEDADataset::Open(GDALOpenInfo* poOpenInfo)
     if( poRootAsset == nullptr )
         return false;
 
-    json_object* poAssets = CPL_json_object_object_get(poRootAsset, "assets");
+    json_object* poAssets = CPL_json_object_object_get(poRootAsset, "images");
     if( poAssets == nullptr ||
         json_object_get_type(poAssets) != json_type_array ||
         json_object_array_length(poAssets) != 1 )

--- a/gdal/frmts/eeda/eedaidataset.cpp
+++ b/gdal/frmts/eeda/eedaidataset.cpp
@@ -1191,7 +1191,7 @@ bool GDALEEDAIDataset::ComputeQueryStrategy()
 
     if( EQUAL(m_osPixelEncoding, "PNG") ||
         EQUAL(m_osPixelEncoding, "JPEG") ||
-        EQUAL(m_osPixelEncoding, "AUTO_PNG_JPEG") )
+        EQUAL(m_osPixelEncoding, "AUTO_JPEG_PNG") )
     {
         if( nBands != 1 && nBands != 3 )
         {
@@ -1253,7 +1253,7 @@ CPLErr GDALEEDAIDataset::GetGeoTransform( double* adfGeoTransform )
 bool GDALEEDAIDataset::Open(GDALOpenInfo* poOpenInfo)
 {
     m_osBaseURL = CPLGetConfigOption("EEDA_URL",
-                            "https://earthengine.googleapis.com/v1/");
+                            "https://earthengine.googleapis.com/v1alpha/");
 
     m_osAsset =
             CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "ASSET", "");
@@ -1658,7 +1658,7 @@ void GDALRegister_EEDAI()
 "       <Value>PNG</Value>"
 "       <Value>JPEG</Value>"
 "       <Value>GEO_TIFF</Value>"
-"       <Value>AUTO_PNG_JPEG</Value>"
+"       <Value>AUTO_JPEG_PNG</Value>"
 "       <Value>NPY</Value>"
 "   </Option>"
 "  <Option name='BLOCK_SIZE' type='integer' "

--- a/gdal/frmts/eeda/frmt_eedai.html
+++ b/gdal/frmts/eeda/frmt_eedai.html
@@ -28,7 +28,7 @@ The following open options are available :
 <li><b>ASSET</b>=string: To specify the asset if not specified in
 the connection string.</li>
 <li><b>BANDS</b>=bandname1[,bandnameX]*: Comma separated list of band names.</li>
-<li><b>PIXEL_ENCODING</b>=AUTO/PNG/JPEG/AUTO_PNG_JPEG/GEO_TIFF/NPY: Format in which to
+<li><b>PIXEL_ENCODING</b>=AUTO/PNG/JPEG/AUTO_JPEG_PNG/GEO_TIFF/NPY: Format in which to
 request pixels.</li>
 <li><b>BLOCK_SIZE</b>=integer: Size of a GDAL block, which is the minimum unit
 to query pixels. Default is 256.</li>
@@ -95,7 +95,7 @@ metadata.
 
 By default (PIXEL_ENCODING=AUTO), the driver will request pixels in a format
 compatible of the number and data types of the bands. The PNG, JPEG and
-AUTO_PNG_JPEG can only be used with bands of type Byte.
+AUTO_JPEG_PNG can only be used with bands of type Byte.
 
 <h3>Examples</h3>
 


### PR DESCRIPTION
- `EarthEngineAsset.path` is no longer returned.
- `PixelDataType.(INTEGER|FLOAT32|FLOAT64)` are renamed to
  `PixelDataType.(INT|FLOAT|DOUBLE)`.
- `EarthEngineAsset.time` is no longer returned (replaced by
  `EarthEngineAsset.(start|end)_time`.
- `ListImagesResponse.assets` is renamed to
  `ListImagesResponse.images`.