### PR TITLE
gdal_calc.py: fixes streaking with --allBands option

### DIFF
--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -249,9 +249,6 @@ def doit(opts, args):
 
     # use the block size of the first layer to read efficiently
     myBlockSize = myFiles[0].GetRasterBand(myBands[0]).GetBlockSize()
-    # store these numbers in variables that may change later
-    nXValid = myBlockSize[0]
-    nYValid = myBlockSize[1]
     # find total x and y blocks to be read
     nXBlocks = (int)((DimensionsCheck[0] + myBlockSize[0] - 1) / myBlockSize[0])
     nYBlocks = (int)((DimensionsCheck[1] + myBlockSize[1] - 1) / myBlockSize[1])
@@ -274,15 +271,18 @@ def doit(opts, args):
         ################################################################
         # start looping through blocks of data
         ################################################################
+        
+        # store these numbers in variables that may change later
+        nXValid = myBlockSize[0]
+        nYValid = myBlockSize[1]
 
         # loop through X-lines
         for X in range(0, nXBlocks):
 
-            # in the rare (impossible?) case that the blocks don't fit perfectly
+            # in case the blocks don't fit perfectly
             # change the block size of the final piece
             if X == nXBlocks - 1:
                 nXValid = DimensionsCheck[0] - X * myBlockSize[0]
-                myBufSize = nXValid * nYValid
 
             # find X offset
             myX = X * myBlockSize[0]


### PR DESCRIPTION
## What does this PR do?
Fixes NaN-streaking in the output file when gdal_calc.py --allBands is used with tiled images.

## To replicate
gdal_calc --calc="A-B" --outfile=diff.tif -A A.tif -B B.tif --allBands=A --B_band=3
(where A.tif and B.tif are TILED GeoTIFF's with multiple bands).

## Detailed description
This issue is because gdalc_calc.py gets the block size to work on from GetRasterBand().GetBlockSize(), which on a tiled image is typically something like 256x256. For the final block in the x-range, the block and buffer size is changed to fit the image. But these values aren't reverted back to their original values before looping to the next band. So when called with –allBands and TILED=YES, the block size and buffer is reduced for subsequent bands. If TILED=NO, the x-buffer will always be the image width (as far as I can tell), so the bug won't occur in this case.

The streak width depends on the image extent, and the distance between streaks depends on the image's BLOCKXSIZE, e.g. on a single test file:
BLOCKXSIZE | streak width | distance between streaks
128 | 36 | 92
256 | 36 | 220
512 | 36 | 476

This issue is in all versions of gdal that I've tested between 2.2 and 2.4.

This pull request also removes a (related) redundant calculation for myBufSize.

## Environment
Python logic issue: all environments (tested on 64-bit Windows 10 and SUSE Linux).