### PR TITLE
GTiff: improve performance of internal overview creation (fixes #1442)

### DIFF
--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -368,7 +368,7 @@ class GTiffDataset final : public GDALPamDataset
     bool        m_bScanDeferred:1;
     bool        m_bBase:1;
     // Useful for closing TIFF handle opened by GTIFF_DIR:
-    bool        m_bCloseTIFFHandle:1;
+    bool        m_bCloseFile:1;
     bool        m_bLoadedBlockDirty:1;
     bool        m_bWriteErrorInFlushBlockBuf:1;
     bool        m_bLookedForProjection:1;
@@ -420,7 +420,8 @@ class GTiffDataset final : public GDALPamDataset
     void        Crystalize();  // TODO: Spelling.
 
     void        WriteGeoTIFFInfo();
-    bool        SetDirectory( toff_t nDirOffset = 0 );
+    bool        SetDirectory();
+    void        ReloadDirectory();
 
     int         GetJPEGOverviewCount();
 
@@ -7301,7 +7302,7 @@ GTiffDataset::GTiffDataset():
     m_bStreamingOut(false),
     m_bScanDeferred(true),
     m_bBase(true),
-    m_bCloseTIFFHandle(false),
+    m_bCloseFile(false),
     m_bLoadedBlockDirty(false),
     m_bWriteErrorInFlushBlockBuf(false),
     m_bLookedForProjection(false),
@@ -7501,10 +7502,14 @@ int GTiffDataset::Finalize()
         delete m_poColorTable;
     m_poColorTable = nullptr;
 
-    if( m_bBase || m_bCloseTIFFHandle )
+    if( m_hTIFF )
     {
         XTIFFClose( m_hTIFF );
         m_hTIFF = nullptr;
+    }
+
+    if( m_bBase || m_bCloseFile )
+    {
         if( m_fpL != nullptr )
         {
             if( VSIFCloseL( m_fpL ) != 0 )
@@ -9993,7 +9998,7 @@ CPLErr GTiffDataset::RegisterNewOverviewDataset(toff_t nOverviewOffset,
            sizeof(m_anLercAddCompressionAndVersion));
 #endif
 
-    if( poODS->OpenOffset( m_hTIFF, m_ppoActiveDSRef, nOverviewOffset, false,
+    if( poODS->OpenOffset( VSI_TIFFOpenChild(m_hTIFF), m_ppoActiveDSRef, nOverviewOffset, false,
                             GA_Update ) != CE_None )
     {
         delete poODS;
@@ -10195,6 +10200,10 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS)
             eErr = RegisterNewOverviewDataset(nOverviewOffset, nOvrJpegQuality);
     }
 
+    // For directory reloading, so that the chaining to the next directory is
+    // reloaded, as well as compression parameters.
+    ReloadDirectory();
+
     CPLFree(panExtraSampleValues);
     panExtraSampleValues = nullptr;
 
@@ -10208,6 +10217,17 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS)
     }
 
     return eErr;
+}
+
+/************************************************************************/
+/*                           ReloadDirectory()                          */
+/************************************************************************/
+
+void GTiffDataset::ReloadDirectory()
+{
+    TIFFSetSubDirectory( m_hTIFF, 0 );
+    *m_ppoActiveDSRef = nullptr;
+    CPL_IGNORE_RET_VAL( SetDirectory() );
 }
 
 /************************************************************************/
@@ -10264,7 +10284,7 @@ CPLErr GTiffDataset::CreateInternalMaskOverviews(int nOvrBlockXSize,
                 GTiffDataset *poODS = new GTiffDataset();
                 poODS->ShareLockWithParentDataset(this);
                 poODS->m_pszFilename = CPLStrdup(m_pszFilename);
-                if( poODS->OpenOffset( m_hTIFF, m_ppoActiveDSRef,
+                if( poODS->OpenOffset( VSI_TIFFOpenChild(m_hTIFF), m_ppoActiveDSRef,
                                        nOverviewOffset, false,
                                        GA_Update ) != CE_None )
                 {
@@ -10290,6 +10310,8 @@ CPLErr GTiffDataset::CreateInternalMaskOverviews(int nOvrBlockXSize,
             }
         }
     }
+
+    ReloadDirectory();
 
     return eErr;
 }
@@ -10620,6 +10642,8 @@ CPLErr GTiffDataset::IBuildOverviews(
 
     CPLFree(panExtraSampleValues);
     panExtraSampleValues = nullptr;
+
+    ReloadDirectory();
 
 /* -------------------------------------------------------------------- */
 /*      Create overviews for the mask.                                  */
@@ -11925,33 +11949,26 @@ void GTiffDataset::UnsetNoDataValue( TIFF *l_hTIFF )
 /*                            SetDirectory()                            */
 /************************************************************************/
 
-bool GTiffDataset::SetDirectory( toff_t nNewOffset )
+bool GTiffDataset::SetDirectory()
 
 {
     Crystalize();
 
-    if( nNewOffset == 0 )
-        nNewOffset = m_nDirOffset;
-
-    if( TIFFCurrentDirOffset(m_hTIFF) == nNewOffset )
+    if( GetAccess() == GA_Update &&
+        *m_ppoActiveDSRef != nullptr && *m_ppoActiveDSRef != this )
     {
-        CPLAssert( *m_ppoActiveDSRef == this || *m_ppoActiveDSRef == nullptr );
+        (*m_ppoActiveDSRef)->FlushDirectory();
+    }
+
+    if( TIFFCurrentDirOffset(m_hTIFF) == m_nDirOffset )
+    {
         *m_ppoActiveDSRef = this;
         return true;
     }
 
-    if( GetAccess() == GA_Update )
-    {
-        if( *m_ppoActiveDSRef != nullptr )
-            (*m_ppoActiveDSRef)->FlushDirectory();
-    }
-
-    if( nNewOffset == 0)
-        return true;
-
     (*m_ppoActiveDSRef) = this;
 
-    const int nSetDirResult = TIFFSetSubDirectory( m_hTIFF, nNewOffset );
+    const int nSetDirResult = TIFFSetSubDirectory( m_hTIFF, m_nDirOffset );
     if( !nSetDirResult )
         return false;
 
@@ -11975,7 +11992,9 @@ bool GTiffDataset::SetDirectory( toff_t nNewOffset )
 
         TIFFGetField( m_hTIFF, TIFFTAG_JPEGCOLORMODE, &nColorMode );
         if( nColorMode != JPEGCOLORMODE_RGB )
+        {
             TIFFSetField(m_hTIFF, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
+        }
     }
 
 /* -------------------------------------------------------------------- */
@@ -12384,7 +12403,6 @@ GDALDataset *GTiffDataset::Open( GDALOpenInfo * poOpenInfo )
     std::vector<GTIFFErrorStruct> aoErrors;
     CPLPushErrorHandlerEx(GTIFFErrorHandler, &aoErrors);
     CPLSetCurrentErrorHandlerCatchDebug( FALSE );
-    // Open and disable "strip chopping" (c option)
     TIFF *l_hTIFF =
         VSI_TIFFOpen( pszFilename,
                       poOpenInfo->eAccess == GA_ReadOnly ? "r" : "r+",
@@ -13002,7 +13020,7 @@ GDALDataset *GTiffDataset::OpenDir( GDALOpenInfo * poOpenInfo )
     poDS->m_poActiveDS = poDS;
     poDS->m_fpL = l_fpL;
     poDS->m_hTIFF = l_hTIFF;
-    poDS->m_bCloseTIFFHandle = true;
+    poDS->m_bCloseFile = true;
 
     uint16 l_nCompression = 0;
     TIFFGetFieldDefaulted( l_hTIFF, TIFFTAG_COMPRESSION, &(l_nCompression) );
@@ -13498,6 +13516,9 @@ CPLErr GTiffDataset::OpenOffset( TIFF *hTIFFIn,
                                  bool bReadGeoTransform )
 
 {
+    if( !hTIFFIn )
+        return CE_Failure;
+
     eAccess = eAccessIn;
 
     m_hTIFF = hTIFFIn;
@@ -13505,7 +13526,7 @@ CPLErr GTiffDataset::OpenOffset( TIFF *hTIFFIn,
 
     m_nDirOffset = nDirOffsetIn;
 
-    if( !SetDirectory( nDirOffsetIn ) )
+    if( !SetDirectory() )
         return CE_Failure;
 
     m_bBase = bBaseIn;
@@ -13572,7 +13593,9 @@ CPLErr GTiffDataset::OpenOffset( TIFF *hTIFFIn,
         int nColorMode = 0;
         if( !TIFFGetField( m_hTIFF, TIFFTAG_JPEGCOLORMODE, &nColorMode ) ||
             nColorMode != JPEGCOLORMODE_RGB )
+        {
             TIFFSetField(m_hTIFF, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
+        }
     }
 
 /* -------------------------------------------------------------------- */
@@ -14843,7 +14866,7 @@ void GTiffDataset::ScanDirectories()
             GTiffDataset *poODS = new GTiffDataset();
             poODS->ShareLockWithParentDataset(this);
             poODS->m_pszFilename = CPLStrdup(m_pszFilename);
-            if( poODS->OpenOffset( m_hTIFF, m_ppoActiveDSRef, nThisDir, false,
+            if( poODS->OpenOffset( VSI_TIFFOpenChild(m_hTIFF), m_ppoActiveDSRef, nThisDir, false,
                                    eAccess ) != CE_None
                 || poODS->GetRasterCount() != GetRasterCount() )
             {
@@ -14882,7 +14905,7 @@ void GTiffDataset::ScanDirectories()
             // have a higher resolution than the main image, what we don't
             // support here.
 
-            if( m_poMaskDS->OpenOffset( m_hTIFF, m_ppoActiveDSRef, nThisDir,
+            if( m_poMaskDS->OpenOffset( VSI_TIFFOpenChild(m_hTIFF), m_ppoActiveDSRef, nThisDir,
                                       false, eAccess ) != CE_None
                 || m_poMaskDS->GetRasterCount() == 0
                 || !(m_poMaskDS->GetRasterCount() == 1
@@ -14915,7 +14938,7 @@ void GTiffDataset::ScanDirectories()
             GTiffDataset* poDS = new GTiffDataset();
             poDS->ShareLockWithParentDataset(this);
             poDS->m_pszFilename = CPLStrdup(m_pszFilename);
-            if( poDS->OpenOffset( m_hTIFF, m_ppoActiveDSRef, nThisDir, FALSE,
+            if( poDS->OpenOffset( VSI_TIFFOpenChild(m_hTIFF), m_ppoActiveDSRef, nThisDir, FALSE,
                                   eAccess ) != CE_None
                 || poDS->GetRasterCount() == 0
                 || poDS->GetRasterBand(1)->GetRasterDataType() != GDT_Byte)
@@ -18740,12 +18763,14 @@ CPLErr GTiffDataset::CreateMaskBand(int nFlagsIn)
         if( nOffset == 0 )
             return CE_Failure;
 
+        ReloadDirectory();
+
         m_poMaskDS = new GTiffDataset();
         m_poMaskDS->ShareLockWithParentDataset(this);
         m_poMaskDS->m_bPromoteTo8Bits =
             CPLTestBool(
                 CPLGetConfigOption("GDAL_TIFF_INTERNAL_MASK_TO_8BIT", "YES"));
-        if( m_poMaskDS->OpenOffset( m_hTIFF, m_ppoActiveDSRef, nOffset,
+        if( m_poMaskDS->OpenOffset( VSI_TIFFOpenChild(m_hTIFF), m_ppoActiveDSRef, nOffset,
                                   false, GA_Update ) != CE_None)
         {
             delete m_poMaskDS;

--- a/gdal/frmts/gtiff/tifvsi.cpp
+++ b/gdal/frmts/gtiff/tifvsi.cpp
@@ -34,6 +34,7 @@
 #include "cpl_port.h"
 #include "tifvsi.h"
 
+#include <assert.h>
 #include <string.h>
 #include <cerrno>
 #if HAVE_FCNTL_H
@@ -64,11 +65,24 @@ CPL_C_END
 
 constexpr int BUFFER_SIZE = 65536;
 
-typedef struct
+struct GDALTiffHandle;
+
+struct GDALTiffHandleShared
 {
-    VSILFILE*   fpL;
-    bool        bAtEndOfFile;
-    vsi_l_offset nExpectedPos;
+    VSILFILE       *fpL;
+    bool            bReadOnly;
+    char           *pszName;
+    GDALTiffHandle *psActiveHandle; // only used on the parent
+    int             nUserCounter;
+    bool            bAtEndOfFile;
+    vsi_l_offset    nExpectedPos;
+};
+
+struct GDALTiffHandle
+{
+    GDALTiffHandle* psParent; // nullptr for the parent itself
+    GDALTiffHandleShared* psShared;
+
     GByte      *abyWriteBuffer;
     int         nWriteBufferSize;
 
@@ -81,16 +95,33 @@ typedef struct
     void**       ppCachedData;
     vsi_l_offset* panCachedOffsets;
     size_t*       panCachedSizes;
-} GDALTiffHandle;
+};
+
+static bool GTHFlushBuffer( thandle_t th );
+
+static void SetActiveGTH(GDALTiffHandle* psGTH)
+{
+    auto psShared = psGTH->psShared;
+    if( psShared->psActiveHandle != psGTH )
+    {
+        if( psShared->psActiveHandle != nullptr )
+        {
+            GTHFlushBuffer( static_cast<thandle_t>(psShared->psActiveHandle) );
+        }
+        psShared->bAtEndOfFile = false;
+        psShared->psActiveHandle = psGTH;
+    }
+}
 
 static tsize_t
 _tiffReadProc( thandle_t th, tdata_t buf, tsize_t size )
 {
     GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle *>(th);
+    //SetActiveGTH(psGTH);
 
     if( psGTH->nCachedRanges )
     {
-        const vsi_l_offset nCurOffset = VSIFTellL( psGTH->fpL );
+        const vsi_l_offset nCurOffset = VSIFTellL( psGTH->psShared->fpL );
         for( int i = 0; i < psGTH->nCachedRanges; i++ )
         {
             if( nCurOffset >= psGTH->panCachedOffsets[i] &&
@@ -100,7 +131,7 @@ _tiffReadProc( thandle_t th, tdata_t buf, tsize_t size )
                 memcpy( buf,
                         static_cast<GByte*>(psGTH->ppCachedData[i]) +
                             (nCurOffset - psGTH->panCachedOffsets[i]), size );
-                VSIFSeekL( psGTH->fpL, nCurOffset + size, SEEK_SET );
+                VSIFSeekL( psGTH->psShared->fpL, nCurOffset + size, SEEK_SET );
                 return size;
             }
             if( nCurOffset < psGTH->panCachedOffsets[i] )
@@ -108,7 +139,7 @@ _tiffReadProc( thandle_t th, tdata_t buf, tsize_t size )
         }
     }
 
-    return VSIFReadL( buf, 1, size, psGTH->fpL );
+    return VSIFReadL( buf, 1, size, psGTH->psShared->fpL );
 }
 
 static bool GTHFlushBuffer( thandle_t th )
@@ -118,7 +149,7 @@ static bool GTHFlushBuffer( thandle_t th )
     if( psGTH->abyWriteBuffer && psGTH->nWriteBufferSize )
     {
         const tsize_t nRet = VSIFWriteL( psGTH->abyWriteBuffer, 1,
-                                         psGTH->nWriteBufferSize, psGTH->fpL );
+                                         psGTH->nWriteBufferSize, psGTH->psShared->fpL );
         bRet = nRet == psGTH->nWriteBufferSize;
         if( !bRet )
         {
@@ -133,10 +164,11 @@ static tsize_t
 _tiffWriteProc( thandle_t th, tdata_t buf, tsize_t size )
 {
     GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle *>( th );
+    SetActiveGTH(psGTH);
 
     // If we have a write buffer and are at end of file, then accumulate
     // the bytes until the buffer is full.
-    if( psGTH->bAtEndOfFile && psGTH->abyWriteBuffer )
+    if( psGTH->psShared->bAtEndOfFile && psGTH->abyWriteBuffer )
     {
         const GByte* pabyData = reinterpret_cast<GByte *>( buf );
         tsize_t nRemainingBytes = size;
@@ -147,7 +179,7 @@ _tiffWriteProc( thandle_t th, tdata_t buf, tsize_t size )
                 memcpy( psGTH->abyWriteBuffer + psGTH->nWriteBufferSize,
                         pabyData, nRemainingBytes );
                 psGTH->nWriteBufferSize += static_cast<int>(nRemainingBytes);
-                psGTH->nExpectedPos += size;
+                psGTH->psShared->nExpectedPos += size;
                 return size;
             }
 
@@ -155,7 +187,7 @@ _tiffWriteProc( thandle_t th, tdata_t buf, tsize_t size )
             memcpy( psGTH->abyWriteBuffer + psGTH->nWriteBufferSize, pabyData,
                     nAppendable );
             const tsize_t nRet = VSIFWriteL( psGTH->abyWriteBuffer, 1,
-                                             BUFFER_SIZE, psGTH->fpL );
+                                             BUFFER_SIZE, psGTH->psShared->fpL );
             psGTH->nWriteBufferSize = 0;
             if( nRet != BUFFER_SIZE )
             {
@@ -168,14 +200,14 @@ _tiffWriteProc( thandle_t th, tdata_t buf, tsize_t size )
         }
     }
 
-    const tsize_t nRet = VSIFWriteL( buf, 1, size, psGTH->fpL );
+    const tsize_t nRet = VSIFWriteL( buf, 1, size, psGTH->psShared->fpL );
     if( nRet < size )
     {
         TIFFErrorExt( th, "_tiffWriteProc", "%s", VSIStrerror( errno ) );
     }
-    if( psGTH->bAtEndOfFile )
+    if( psGTH->psShared->bAtEndOfFile )
     {
-        psGTH->nExpectedPos += nRet;
+        psGTH->psShared->nExpectedPos += nRet;
     }
     return nRet;
 }
@@ -184,33 +216,34 @@ static toff_t
 _tiffSeekProc( thandle_t th, toff_t off, int whence )
 {
     GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle *>( th );
+    SetActiveGTH(psGTH);
 
     // Optimization: if we are already at end, then no need to
     // issue a VSIFSeekL().
     if( whence == SEEK_END )
     {
-        if( psGTH->bAtEndOfFile )
+        if( psGTH->psShared->bAtEndOfFile )
         {
-            return static_cast<toff_t>( psGTH->nExpectedPos );
+            return static_cast<toff_t>( psGTH->psShared->nExpectedPos );
         }
 
-        if( VSIFSeekL( psGTH->fpL, off, whence ) != 0 )
+        if( VSIFSeekL( psGTH->psShared->fpL, off, whence ) != 0 )
         {
             TIFFErrorExt( th, "_tiffSeekProc", "%s", VSIStrerror( errno ) );
             return static_cast<toff_t>( -1 );
         }
-        psGTH->bAtEndOfFile = true;
-        psGTH->nExpectedPos = VSIFTellL( psGTH->fpL );
-        return static_cast<toff_t>(psGTH->nExpectedPos);
+        psGTH->psShared->bAtEndOfFile = true;
+        psGTH->psShared->nExpectedPos = VSIFTellL( psGTH->psShared->fpL );
+        return static_cast<toff_t>(psGTH->psShared->nExpectedPos);
     }
 
     GTHFlushBuffer(th);
-    psGTH->bAtEndOfFile = false;
-    psGTH->nExpectedPos = 0;
+    psGTH->psShared->bAtEndOfFile = false;
+    psGTH->psShared->nExpectedPos = 0;
 
-    if( VSIFSeekL( psGTH->fpL, off, whence ) == 0 )
+    if( VSIFSeekL( psGTH->psShared->fpL, off, whence ) == 0 )
     {
-        return static_cast<toff_t>( VSIFTellL( psGTH->fpL ) );
+        return static_cast<toff_t>( VSIFTellL( psGTH->psShared->fpL ) );
     }
     else
     {
@@ -219,16 +252,34 @@ _tiffSeekProc( thandle_t th, toff_t off, int whence )
     }
 }
 
-static int
-_tiffCloseProc( thandle_t th )
+static void FreeGTH(GDALTiffHandle* psGTH)
 {
-    GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle*>( th );
-    GTHFlushBuffer(th);
+    psGTH->psShared->nUserCounter --;
+    if( psGTH->psParent == nullptr )
+    {
+        assert( psGTH->psShared->nUserCounter == 0 );
+        CPLFree(psGTH->psShared->pszName);
+        CPLFree(psGTH->psShared);
+    }
+    else
+    {
+        if( psGTH->psShared->psActiveHandle == psGTH )
+            psGTH->psShared->psActiveHandle = nullptr;
+    }
     CPLFree(psGTH->abyWriteBuffer);
     CPLFree(psGTH->ppCachedData);
     CPLFree(psGTH->panCachedOffsets);
     CPLFree(psGTH->panCachedSizes);
     CPLFree(psGTH);
+}
+
+static int
+_tiffCloseProc( thandle_t th )
+{
+    GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle*>( th );
+    SetActiveGTH(psGTH);
+    GTHFlushBuffer(th);
+    FreeGTH(psGTH);
     return 0;
 }
 
@@ -236,16 +287,18 @@ static toff_t
 _tiffSizeProc( thandle_t th )
 {
     GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle*>( th );
-    if( psGTH->bAtEndOfFile )
+    SetActiveGTH(psGTH);
+
+    if( psGTH->psShared->bAtEndOfFile )
     {
-        return static_cast<toff_t>( psGTH->nExpectedPos );
+        return static_cast<toff_t>( psGTH->psShared->nExpectedPos );
     }
 
-    const vsi_l_offset old_off = VSIFTellL( psGTH->fpL );
-    CPL_IGNORE_RET_VAL(VSIFSeekL( psGTH->fpL, 0, SEEK_END ));
+    const vsi_l_offset old_off = VSIFTellL( psGTH->psShared->fpL );
+    CPL_IGNORE_RET_VAL(VSIFSeekL( psGTH->psShared->fpL, 0, SEEK_END ));
 
-    const toff_t file_size = static_cast<toff_t>(VSIFTellL( psGTH->fpL ));
-    CPL_IGNORE_RET_VAL(VSIFSeekL( psGTH->fpL, old_off, SEEK_SET ));
+    const toff_t file_size = static_cast<toff_t>(VSIFTellL( psGTH->psShared->fpL ));
+    CPL_IGNORE_RET_VAL(VSIFSeekL( psGTH->psShared->fpL, old_off, SEEK_SET ));
 
     return file_size;
 }
@@ -254,6 +307,8 @@ static int
 _tiffMapProc( thandle_t th, tdata_t* pbase , toff_t* psize )
 {
     GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle*>( th );
+    //SetActiveGTH(psGTH);
+
     if( psGTH->pBase )
     {
         *pbase = psGTH->pBase;
@@ -270,14 +325,16 @@ _tiffUnmapProc( thandle_t /* th */, tdata_t /* base */, toff_t /* size */ )
 VSILFILE* VSI_TIFFGetVSILFile( thandle_t th )
 {
     GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle *>( th );
+    SetActiveGTH(psGTH);
     VSI_TIFFFlushBufferedWrite(th);
-    return psGTH->fpL;
+    return psGTH->psShared->fpL;
 }
 
 int VSI_TIFFFlushBufferedWrite( thandle_t th )
 {
     GDALTiffHandle* psGTH = reinterpret_cast<GDALTiffHandle*>( th );
-    psGTH->bAtEndOfFile = false;
+    SetActiveGTH(psGTH);
+    psGTH->psShared->bAtEndOfFile = false;
     return GTHFlushBuffer(th);
 }
 
@@ -316,23 +373,11 @@ void VSI_TIFFSetCachedRanges( thandle_t th, int nRanges,
     }
 }
 
-// Open a TIFF file for read/writing.
-TIFF* VSI_TIFFOpen( const char* name, const char* mode,
-                    VSILFILE* fpL )
+static bool IsReadOnly(const char* mode)
 {
-    char access[32] = { '\0' };
     bool bReadOnly = true;
-    int a_out = 0;
     for( int i = 0; mode[i] != '\0'; i++ )
     {
-        if( mode[i] == 'r'
-            || mode[i] == 'w'
-            || mode[i] == '+'
-            || mode[i] == 'a' )
-        {
-            access[a_out++] = mode[i];
-            access[a_out] = '\0';
-        }
         if( mode[i] == 'w'
             || mode[i] == '+'
             || mode[i] == 'a' )
@@ -340,28 +385,22 @@ TIFF* VSI_TIFFOpen( const char* name, const char* mode,
             bReadOnly = false;
         }
     }
+    return bReadOnly;
+}
 
-    strcat( access, "b" );
-
-    if( VSIFSeekL(fpL, 0, SEEK_SET) < 0 )
-        return nullptr;
-
-    GDALTiffHandle* psGTH = static_cast<GDALTiffHandle *>(
-        CPLCalloc(1, sizeof(GDALTiffHandle)) );
-    psGTH->fpL = fpL;
-    psGTH->nExpectedPos = 0;
-    psGTH->bAtEndOfFile = false;
-
+static void InitializeWriteBuffer(GDALTiffHandle* psGTH, const char* pszMode)
+{
     // No need to buffer on /vsimem/
+    const bool bReadOnly = IsReadOnly(pszMode);
     bool bAllocBuffer = !bReadOnly;
-    if( STARTS_WITH(name, "/vsimem/") )
+    if( STARTS_WITH(psGTH->psShared->pszName, "/vsimem/") )
     {
         if( bReadOnly &&
             CPLTestBool(CPLGetConfigOption("GTIFF_USE_MMAP", "NO")) )
         {
             psGTH->nDataLength = 0;
             psGTH->pBase = 
-                VSIGetMemFileBuffer(name, &psGTH->nDataLength, FALSE);
+                VSIGetMemFileBuffer(psGTH->psShared->pszName, &psGTH->nDataLength, FALSE);
         }
         bAllocBuffer = false;
     }
@@ -370,15 +409,63 @@ TIFF* VSI_TIFFOpen( const char* name, const char* mode,
         bAllocBuffer ? static_cast<GByte *>( VSIMalloc(BUFFER_SIZE) ) : nullptr;
     psGTH->nWriteBufferSize = 0;
 
+}
+
+static TIFF* VSI_TIFFOpen_common(GDALTiffHandle* psGTH, const char* pszMode)
+{
+    InitializeWriteBuffer(psGTH, pszMode);
 
     TIFF *tif =
-        XTIFFClientOpen( name, mode,
+        XTIFFClientOpen( psGTH->psShared->pszName,
+                         pszMode,
                          reinterpret_cast<thandle_t>(psGTH),
                          _tiffReadProc, _tiffWriteProc,
                          _tiffSeekProc, _tiffCloseProc, _tiffSizeProc,
                          _tiffMapProc, _tiffUnmapProc );
     if( tif == nullptr )
-        CPLFree(psGTH);
+        FreeGTH(psGTH);
 
     return tif;
+}
+
+// Open a TIFF file for read/writing.
+TIFF* VSI_TIFFOpen( const char* name, const char* mode,
+                    VSILFILE* fpL )
+{
+
+    if( VSIFSeekL(fpL, 0, SEEK_SET) < 0 )
+        return nullptr;
+
+    GDALTiffHandle* psGTH = static_cast<GDALTiffHandle *>(
+        CPLCalloc(1, sizeof(GDALTiffHandle)) );
+    psGTH->psParent = nullptr;
+    psGTH->psShared = static_cast<GDALTiffHandleShared *>(
+        CPLCalloc(1, sizeof(GDALTiffHandleShared)) );
+    psGTH->psShared->bReadOnly = (strchr(mode, '+') == nullptr);
+    psGTH->psShared->pszName = CPLStrdup(name);
+    psGTH->psShared->fpL = fpL;
+    psGTH->psShared->psActiveHandle = psGTH;
+    psGTH->psShared->nExpectedPos = 0;
+    psGTH->psShared->bAtEndOfFile = false;
+    psGTH->psShared->nUserCounter = 1;
+
+    return VSI_TIFFOpen_common(psGTH, mode);
+}
+
+TIFF* VSI_TIFFOpenChild( TIFF* parent )
+{
+    GDALTiffHandle* psGTHParent =
+        reinterpret_cast<GDALTiffHandle*>(TIFFClientdata(parent));
+
+    GDALTiffHandle* psGTH = static_cast<GDALTiffHandle *>(
+        CPLCalloc(1, sizeof(GDALTiffHandle)) );
+    psGTH->psParent = psGTHParent;
+    psGTH->psShared = psGTHParent->psShared;
+    psGTH->psShared->nUserCounter ++;
+
+    SetActiveGTH(psGTH);
+    VSIFSeekL( psGTH->psShared->fpL, 0, SEEK_SET );
+
+    const char* mode = psGTH->psShared->bReadOnly ? "r" : "r+";
+    return VSI_TIFFOpen_common(psGTH, mode);
 }

--- a/gdal/frmts/gtiff/tifvsi.h
+++ b/gdal/frmts/gtiff/tifvsi.h
@@ -38,6 +38,7 @@
 #include "tiffio.h"
 
 TIFF* VSI_TIFFOpen( const char* name, const char* mode, VSILFILE* fp );
+TIFF* VSI_TIFFOpenChild( TIFF* parent ); // the returned handle must be closed before the parent. They share the same underlying VSILFILE
 VSILFILE* VSI_TIFFGetVSILFile( thandle_t th );
 int VSI_TIFFFlushBufferedWrite( thandle_t th );
 int VSI_TIFFHasCachedRanges( thandle_t th );


### PR DESCRIPTION
Or multiple level external overview.

This was a long standing problem. The issue was that each overview level (this
also applies to mask) within a same TIFF file shared the same TIFF* handle.
When switching between overviews, the handle had to be reset to point to a
new TIFF IFD, and reloading of the StripOffset/StripByteCount/TileOffset/TileByteCount
was done. For really big files, those can be several ten to hundred of MB large.

Now, each overview (mask) owns its own TIFF handle, sharing the underlying file
pointer though. Some care is needed in the tifvsi layer regarding some write
optimizations, as well when creating overviews, we must take care of forcing
a reload of the main TIFF handle so that the in-memory TIFF structure points
correctly to the next IFD.

Test case:
```
from osgeo import gdal
gdal.GetDriverByName('GTiff').Create('large.tif', 100000, 100000, 1, options = ['TILED=YES', 'SPARSE_OK=YES'])
```

With this improvement:
$ cp large.tif input.tif; time gdaladdo input.tif 2 4 8 --debug on
real	0m54.913s

Without:
real	3m0.175s
