### PR TITLE
Adding cmath include in `ogr/ogrlinestring`

### DIFF
--- a/gdal/ogr/ogrlinestring.cpp
+++ b/gdal/ogr/ogrlinestring.cpp
@@ -35,6 +35,7 @@
 #include <cstdlib>
 #include <algorithm>
 #include <limits>
+#include <cmath>
 
 CPL_CVSID("$Id$")
 


### PR DESCRIPTION
When building the project in Visual Studio 2019 I obtain an error when compiling ogr/ogrlinestring.cpp regarding the fact that `std::fabs` was missing. I've added the `cmath` include in order to fix it.

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Windows 10 Professional 64bit
* Compiler: Visual Studio 2019
* Tools: vcpkg for installing gdal
