### PR TITLE
Modify amigocloud URL endpoint.

### DIFF
--- a/gdal/ogr/ogrsf_frmts/amigocloud/drv_amigocloud.html
+++ b/gdal/ogr/ogrsf_frmts/amigocloud/drv_amigocloud.html
@@ -42,7 +42,7 @@ If no datset_id is provided, the driver will print list of available datasets fo
 
 The following configuration options are available :
 <ul>
-<li>AMIGOCLOUD_API_URL: defaults to https://www.amigocloud.com/api/v1.
+<li>AMIGOCLOUD_API_URL: defaults to https://app.amigocloud.com/api/v1.
 Can be used to point to another server.</li>
 <li>AMIGOCLOUD_API_KEY: see following paragraph.</li>
 </ul>
@@ -175,8 +175,8 @@ Show list of datasets.
 <h2>See Also</h2>
 
 <ul>
-<li> <a href="https://www.amigocloud.com/accounts/tokens">AmigoCloud API Token management</a><p>
-<li> <a href="https://www.amigocloud.com/api/v1/">AmigoCloud API Browser</a><p>
+<li> <a href="https://app.amigocloud.com/accounts/tokens">AmigoCloud API Token management</a><p>
+<li> <a href="https://app.amigocloud.com/api/v1/">AmigoCloud API Browser</a><p>
 </ul>
 
 </body>

--- a/gdal/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
@@ -289,9 +289,9 @@ const char* OGRAmigoCloudDataSource::GetAPIURL() const
         return pszAPIURL;
 
     else if( bUseHTTPS )
-        return CPLSPrintf("https://www.amigocloud.com/api/v1");
+        return CPLSPrintf("https://app.amigocloud.com/api/v1");
     else
-        return CPLSPrintf("http://www.amigocloud.com/api/v1");
+        return CPLSPrintf("http://app.amigocloud.com/api/v1");
 }
 
 /************************************************************************/


### PR DESCRIPTION
AmigoCloud moved its backend URL from www.amigocloud.com to app.amigocloud.com.
The requests are being redirected www -> app, so current build works fine, but we'd like to make this change for the future.

## What does this PR do?
Replaces the default endpoint URL.