### PR TITLE
How to open a netcdf file which path or file name contains unicode characters?

### DIFF
--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -6085,6 +6085,7 @@ bool netCDFDataset::GrowDim(int nLayerId, int nDimIdToGrow, size_t nNewSize)
 
     CPLString osFilenameForNCOpen(osFilename);
 #ifdef WIN32
+    CPLString oldLocale = setlocale(LC_ALL, nullptr);
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         char *p=setlocale(LC_ALL, "en_US.UTF-8");
@@ -6098,7 +6099,7 @@ bool netCDFDataset::GrowDim(int nLayerId, int nDimIdToGrow, size_t nNewSize)
 #ifdef WIN32
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        char *p=setlocale(LC_ALL, "");
+        char* p = setlocale(LC_ALL, (const char*)oldLocale);
         (void)p;
     }
 #endif
@@ -7001,6 +7002,7 @@ GDALDataset *netCDFDataset::Open( GDALOpenInfo *poOpenInfo )
                 (GDAL_OF_UPDATE | GDAL_OF_VECTOR)) ? NC_WRITE : NC_NOWRITE;
     CPLString osFilenameForNCOpen(poDS->osFilename);
 #ifdef WIN32
+    CPLString oldLocale = setlocale(LC_ALL, nullptr);
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         char *p= setlocale(LC_ALL, "en_US.UTF-8");
@@ -7031,7 +7033,7 @@ GDALDataset *netCDFDataset::Open( GDALOpenInfo *poOpenInfo )
 #ifdef WIN32
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        char *p=setlocale(LC_ALL, "");
+        char* p = setlocale(LC_ALL, (const char*)oldLocale);
         (void)p;
     }
 #endif

--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -6085,14 +6085,22 @@ bool netCDFDataset::GrowDim(int nLayerId, int nDimIdToGrow, size_t nNewSize)
 
     CPLString osFilenameForNCOpen(osFilename);
 #ifdef WIN32
+    char *oldLocale;
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        char* pszTemp = CPLRecode( osFilenameForNCOpen, CPL_ENC_UTF8, "CP_ACP" );
-        osFilenameForNCOpen = pszTemp;
-        CPLFree(pszTemp);
+        oldLocale=setlocale(LC_ALL, "en_US.UTF-8"); 
+        //char* pszTemp = CPLRecode( osFilenameForNCOpen, CPL_ENC_UTF8, "CP_ACP" );
+        //osFilenameForNCOpen = pszTemp;
+        //CPLFree(pszTemp);
     }
 #endif
     status = nc_open(osFilename, NC_WRITE, &cdfid);
+#ifdef WIN32
+    if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+    {
+        setlocale(LC_ALL, oldLocale);
+    }
+#endif
     NCDF_ERR(status);
     if( status != NC_NOERR )
         return false;
@@ -6992,11 +7000,13 @@ GDALDataset *netCDFDataset::Open( GDALOpenInfo *poOpenInfo )
                 (GDAL_OF_UPDATE | GDAL_OF_VECTOR)) ? NC_WRITE : NC_NOWRITE;
     CPLString osFilenameForNCOpen(poDS->osFilename);
 #ifdef WIN32
+    char *oldLocale;
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        char* pszTemp = CPLRecode( osFilenameForNCOpen, CPL_ENC_UTF8, "CP_ACP" );
-        osFilenameForNCOpen = pszTemp;
-        CPLFree(pszTemp);
+        oldLocale= setlocale(LC_ALL, "en_US.UTF-8");
+        //char* pszTemp = CPLRecode( osFilenameForNCOpen, CPL_ENC_UTF8, "CP_ACP" );
+        //osFilenameForNCOpen = pszTemp;
+        //CPLFree(pszTemp);
     }
 #endif
     int status2;
@@ -7016,6 +7026,12 @@ GDALDataset *netCDFDataset::Open( GDALOpenInfo *poOpenInfo )
       status2 = nc_open(osFilenameForNCOpen, nMode, &cdfid);
 #else
     status2 = nc_open(osFilenameForNCOpen, nMode, &cdfid);
+#endif
+#ifdef WIN32
+    if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
+    {
+        setlocale(LC_ALL, oldLocale);
+    }
 #endif
     if( status2 != NC_NOERR )
     {

--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -6085,10 +6085,10 @@ bool netCDFDataset::GrowDim(int nLayerId, int nDimIdToGrow, size_t nNewSize)
 
     CPLString osFilenameForNCOpen(osFilename);
 #ifdef WIN32
-    char *oldLocale;
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        oldLocale=setlocale(LC_ALL, "en_US.UTF-8"); 
+        char *p=setlocale(LC_ALL, "en_US.UTF-8");
+        (void)p;
         //char* pszTemp = CPLRecode( osFilenameForNCOpen, CPL_ENC_UTF8, "CP_ACP" );
         //osFilenameForNCOpen = pszTemp;
         //CPLFree(pszTemp);
@@ -6098,7 +6098,8 @@ bool netCDFDataset::GrowDim(int nLayerId, int nDimIdToGrow, size_t nNewSize)
 #ifdef WIN32
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        setlocale(LC_ALL, oldLocale);
+        char *p=setlocale(LC_ALL, "");
+        (void)p;
     }
 #endif
     NCDF_ERR(status);
@@ -7000,10 +7001,10 @@ GDALDataset *netCDFDataset::Open( GDALOpenInfo *poOpenInfo )
                 (GDAL_OF_UPDATE | GDAL_OF_VECTOR)) ? NC_WRITE : NC_NOWRITE;
     CPLString osFilenameForNCOpen(poDS->osFilename);
 #ifdef WIN32
-    char *oldLocale;
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        oldLocale= setlocale(LC_ALL, "en_US.UTF-8");
+        char *p= setlocale(LC_ALL, "en_US.UTF-8");
+        (void)p;
         //char* pszTemp = CPLRecode( osFilenameForNCOpen, CPL_ENC_UTF8, "CP_ACP" );
         //osFilenameForNCOpen = pszTemp;
         //CPLFree(pszTemp);
@@ -7030,7 +7031,8 @@ GDALDataset *netCDFDataset::Open( GDALOpenInfo *poOpenInfo )
 #ifdef WIN32
     if( CPLTestBool(CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
-        setlocale(LC_ALL, oldLocale);
+        char *p=setlocale(LC_ALL, "");
+        (void)p;
     }
 #endif
     if( status2 != NC_NOERR )


### PR DESCRIPTION
my os is windows 10 pro N english edition,download prebuilt binaries from 
http://www.gisinternals.com/query.html?content=filelist&file=release-1911-gdal-3-0-0-mapserver-7-4-0.zip
trying to open a file, file path is D:\日\1.nc, gdal returns nullptr.
i tried CPLSetConfigOption("GDAL_FILENAME_IS_UTF8", "YES"); ,but did not work.
i copied file D:\日\1.nc to D:\1\1.nc, everything is fine.


#include <ogrsf_frmts.h>
#pragma comment(lib,"gdal_i.lib")
`#include   <string>`

#include<Windows.h>
std::string utf16ToUtf8(const wchar_t* lpszSrc, int cp = 65001)
{
	std::string sResult;
	int  nUTF8Len = WideCharToMultiByte(cp, 0, lpszSrc, -1, NULL, 0, NULL, NULL);
	char* pUTF8 = new char[nUTF8Len + 1];
	ZeroMemory(pUTF8, nUTF8Len + 1);
	auto r = WideCharToMultiByte(cp, 0, lpszSrc, -1, pUTF8, nUTF8Len, NULL, NULL);
	sResult = pUTF8;
	delete[] pUTF8;

	return sResult;
}
int main()
{
	CPLSetConfigOption("GDAL_DRIVER_PATH", "D:\\release-1911-gdal-3-0-0-mapserver-7-4-0\\bin\\gdal\\plugins");
	GDALAllRegister();
	OGRRegisterAll();
	const char* pszFormat = "netCDF";
	GDALDriver* poDriver;
	poDriver = GetGDALDriverManager()->GetDriverByName(pszFormat);
	if (poDriver != nullptr) printf("drv ok\n");

	std::wstring wFile(L"d:\\日\\1.nc");
	std::string sFile(utf16ToUtf8(wFile.c_str()));
	CPLSetConfigOption("GDAL_FILENAME_IS_UTF8", "YES");
	GDALDataset* tmFile = ((GDALDataset*)GDALOpen(sFile.c_str(), GA_ReadOnly));
	if (tmFile != nullptr) printf("datasource-u8 ok\n");
	GDALClose(tmFile);


	GDALDataset* tmFile2 = ((GDALDataset*)GDALOpen("d:\\1\\1.nc", GA_ReadOnly));
	if (tmFile2 != nullptr) printf("datasource ok\n");
	GDALClose(tmFile2);
	return 0;
}

output:

drv ok
Warning 1: One or several characters could not be translated to CP0. This warning will not be emitted anymore.
ERROR 4: `d:\µùÑ\1.nc' not recognized as a supported file format.
Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute
datasource ok

D:\release-1911-gdal-3-0-0-mapserver-7-4-0\bin\Project1.exe (process 1040) exited with code 0.
Press any key to close this window . . .
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
