### PR TITLE
Typo in dyxogen

### DIFF
--- a/gdal/doc/source/api/index.rst
+++ b/gdal/doc/source/api/index.rst
@@ -6,7 +6,7 @@ API
 
 .. only:: not latex
 
-   `Full Doyxgen output <../doxygen/index.html>`_
+   `Full Doxygen output <../doxygen/index.html>`_
    ----------------------------------------------
 
    C API


### PR DESCRIPTION
Typo in doc - `doyxgen` instead of `doxygen`