### PR TITLE
Set the length in the definition after extraction.

### DIFF
--- a/gdal/frmts/gtiff/libgeotiff/geo_normalize.c
+++ b/gdal/frmts/gtiff/libgeotiff/geo_normalize.c
@@ -1451,7 +1451,7 @@ int GTIFGetProjTRFInfoEx( PJ_CONTEXT* ctx,
         /* Get the projection method code */
         proj_coordoperation_get_method_info(ctx, transf,
                                             NULL, /* method name */
-                                            NULL, /* method auth name (should be EPSG) */ 
+                                            NULL, /* method auth name (should be EPSG) */
                                             &pszMethodCode);
         assert( pszMethodCode );
         nProjMethod = atoi(pszMethodCode);
@@ -2470,6 +2470,7 @@ int GTIFGetDefn( GTIF * psGTIF, GTIFDefn * psDefn )
 /* -------------------------------------------------------------------- */
     nGeogUOMLinear = 9001; /* Linear_Meter */
     GTIFKeyGetSHORT(psGTIF, GeogLinearUnitsGeoKey, &nGeogUOMLinear, 0, 1 );
+    psDefn->UOMLength = nGeogUOMLinear;
 
 /* -------------------------------------------------------------------- */
 /*      Try to get a PCS.                                               */


### PR DESCRIPTION
Close #1595

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

Set the definition's UOMLength field after determining the value.
