### PR TITLE
gtiff: make overview blocksize default to the same as the full-resolution 

### DIFF
--- a/gdal/doc/source/drivers/raster/gtiff.rst
+++ b/gdal/doc/source/drivers/raster/gtiff.rst
@@ -114,8 +114,10 @@ method.
 
 The block size (tile width and height) used for overviews (internal or
 external) can be specified by setting the GDAL_TIFF_OVR_BLOCKSIZE
-environment variable to a power-of-two value between 64 and 4096. The
-default value is 128.
+environment variable to a power-of-two value between 64 and 4096. The 
+default is 128, or starting with GDAL 3.1 to use the same block size 
+as the full-resolution dataset if possible (i.e. block height and width
+are equal, a power-of-two, and between 64 and 4096).
 
 Overviews and nodata masks
 --------------------------

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -177,28 +177,42 @@ void GTIFFSetInExternalOvr( bool b )
 /*                     GTIFFGetOverviewBlockSize()                      */
 /************************************************************************/
 
-void GTIFFGetOverviewBlockSize( int* pnBlockXSize, int* pnBlockYSize )
+void GTIFFGetOverviewBlockSize( GDALRasterBandH hBand, int* pnBlockXSize, int* pnBlockYSize )
 {
-    const char* pszVal = CPLGetConfigOption("GDAL_TIFF_OVR_BLOCKSIZE", "128");
-    int nOvrBlockSize = atoi(pszVal);
-    if( nOvrBlockSize < 64 || nOvrBlockSize > 4096 ||
-        !CPLIsPowerOfTwo(nOvrBlockSize) )
+    const char* pszVal = CPLGetConfigOption("GDAL_TIFF_OVR_BLOCKSIZE", nullptr);
+    if( ! pszVal )
     {
-        static bool bHasWarned = false;
-        if( !bHasWarned )
+        GDALRasterBand* const poBand = GDALRasterBand::FromHandle(hBand);
+        poBand->GetBlockSize(pnBlockXSize,pnBlockYSize);
+        if ( *pnBlockXSize != *pnBlockYSize ||
+             *pnBlockXSize < 64 || *pnBlockXSize > 4096 ||
+             !CPLIsPowerOfTwo(*pnBlockXSize) )
         {
-            CPLError( CE_Warning, CPLE_NotSupported,
-                      "Wrong value for GDAL_TIFF_OVR_BLOCKSIZE : %s. "
-                      "Should be a power of 2 between 64 and 4096. "
-                      "Defaulting to 128",
-                      pszVal );
-            bHasWarned = true;
+            *pnBlockXSize=*pnBlockYSize=128;
         }
-        nOvrBlockSize = 128;
     }
+    else
+    {
+        int nOvrBlockSize = atoi(pszVal);
+        if( nOvrBlockSize < 64 || nOvrBlockSize > 4096 ||
+            !CPLIsPowerOfTwo(nOvrBlockSize) )
+        {
+            static bool bHasWarned = false;
+            if( !bHasWarned )
+            {
+                CPLError( CE_Warning, CPLE_NotSupported,
+                          "Wrong value for GDAL_TIFF_OVR_BLOCKSIZE : %s. "
+                          "Should be a power of 2 between 64 and 4096. "
+                          "Defaulting to 128",
+                          pszVal );
+                bHasWarned = true;
+            }
+            nOvrBlockSize = 128;
+        }
 
-    *pnBlockXSize = nOvrBlockSize;
-    *pnBlockYSize = nOvrBlockSize;
+        *pnBlockXSize = nOvrBlockSize;
+        *pnBlockYSize = nOvrBlockSize;
+    }
 }
 
 enum
@@ -10278,7 +10292,7 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS)
         TIFFGetField( m_hTIFF, TIFFTAG_PREDICTOR, &nPredictor );
     int nOvrBlockXSize = 0;
     int nOvrBlockYSize = 0;
-    GTIFFGetOverviewBlockSize(&nOvrBlockXSize, &nOvrBlockYSize);
+    GTIFFGetOverviewBlockSize(poSrcDS->GetRasterBand(1), &nOvrBlockXSize, &nOvrBlockYSize);
 
     int nSrcOverviews = poSrcDS->GetRasterBand(1)->GetOverviewCount();
     CPLErr eErr = CE_None;
@@ -10638,7 +10652,7 @@ CPLErr GTiffDataset::IBuildOverviews(
 /* -------------------------------------------------------------------- */
     int nOvrBlockXSize = 0;
     int nOvrBlockYSize = 0;
-    GTIFFGetOverviewBlockSize(&nOvrBlockXSize, &nOvrBlockYSize);
+    GTIFFGetOverviewBlockSize(GetRasterBand(1), &nOvrBlockXSize, &nOvrBlockYSize);
     std::vector<bool> abRequireNewOverview(nOverviews, true);
     for( int i = 0; i < nOverviews && eErr == CE_None; ++i )
     {

--- a/gdal/frmts/gtiff/gt_overview.cpp
+++ b/gdal/frmts/gtiff/gt_overview.cpp
@@ -798,7 +798,7 @@ GTIFFBuildOverviews( const char * pszFilename,
 /* -------------------------------------------------------------------- */
     int nOvrBlockXSize = 0;
     int nOvrBlockYSize = 0;
-    GTIFFGetOverviewBlockSize(&nOvrBlockXSize, &nOvrBlockYSize);
+    GTIFFGetOverviewBlockSize(papoBandList[0], &nOvrBlockXSize, &nOvrBlockYSize);
 
     CPLString osNoData; // don't move this in inner scope
     const char* pszNoData = nullptr;

--- a/gdal/frmts/gtiff/gtiff.h
+++ b/gdal/frmts/gtiff/gtiff.h
@@ -43,7 +43,7 @@ void CPL_DLL LibgeotiffOneTimeInit();
 CPL_C_END
 
 void    GTIFFSetInExternalOvr( bool b );
-void    GTIFFGetOverviewBlockSize( int* pnBlockXSize, int* pnBlockYSize );
+void    GTIFFGetOverviewBlockSize( GDALRasterBandH hBand, int* pnBlockXSize, int* pnBlockYSize );
 void    GTIFFSetJpegQuality( GDALDatasetH hGTIFFDS, int nJpegQuality );
 void    GTIFFSetJpegTablesMode( GDALDatasetH hGTIFFDS, int nJpegTablesMode );
 int     GTIFFGetCompressionMethod( const char* pszValue,


### PR DESCRIPTION
The default overview blocksize is set to 128 whereas I'd argue that setting it to the same value as the full-resolution blocksize makes more sense.