### PR TITLE
MITAB: Fix long fields write in local encoding

### DIFF
--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -1940,7 +1940,9 @@ def test_ogr_mitab_44():
 def test_ogr_mitab_45():
 
     lyrNames = ['lyr1', 'lyr2']
-    fldNames = ['field1', 'поле1']
+    #                     0         1         2         3
+    #                     012345678901234567890123456789012
+    fldNames = ['field1', 'абвгдежзийклмнопрстуфхцчшщьъэюя']
     featNames = ['аз',
                  'буки',
                  'веди']

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab.h
@@ -85,7 +85,7 @@ class IMapInfoFile : public OGRLayer
     GBool               m_bBoundsSet;
 
     char                *m_pszCharset;
-
+    std::set<CPLString> m_oSetFields{};
     TABFeature*         CreateTABFeature(OGRFeature *poFeature);
 
   public:
@@ -178,6 +178,7 @@ class IMapInfoFile : public OGRLayer
     void SetEncoding( const char* );
     const char* GetEncoding() const;
     int TestUtf8Capability() const;
+    CPLString NormalizeFieldName(const char *pszName) const;
     ///////////////
     // semi-private.
     virtual int  GetProjInfo(TABProjInfo *poPI) = 0;
@@ -216,7 +217,6 @@ class TABFile final : public IMapInfoFile
     TABINDFile  *m_poINDFile;   // Attributes index file
 
     OGRFeatureDefn *m_poDefn;
-    std::set<CPLString> m_oSetFields{};
     OGRSpatialReference *m_poSpatialRef;
     int         bUseSpatialTraversal;
 
@@ -654,7 +654,6 @@ class MIFFile final : public IMapInfoFile
     MIDDATAFile  *m_poMIFFile;   // Mif File
 
     OGRFeatureDefn *m_poDefn;
-    std::set<CPLString> m_oSetFields{};
     OGRSpatialReference *m_poSpatialRef;
 
     int         m_nFeatureCount;

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -668,16 +668,16 @@ CPLString IMapInfoFile::NormalizeFieldName(const char *pszName) const
                   "for MapInfo format.", pszName );
     }
 
-    if( !EQUAL(osName.c_str(),szNewFieldName) )
-    {
-        CPLError( CE_Warning, CPLE_NotSupported,
-                  "Normalized/laundered field name: '%s' to '%s'",
-                  pszName, szNewFieldName );
-    }
-
     CPLString   osNewFieldName(szNewFieldName);
     if( strlen( GetEncoding() ) > 0 )
         osNewFieldName.Recode( GetEncoding(), CPL_ENC_UTF8 );
+
+    if( !EQUAL( pszName, osNewFieldName.c_str() ) )
+    {
+        CPLError( CE_Warning, CPLE_NotSupported,
+                  "Normalized/laundered field name: '%s' to '%s'",
+                  pszName, osNewFieldName.c_str() );
+    }
 
     return osNewFieldName;
 }

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -632,3 +632,53 @@ int IMapInfoFile::TestUtf8Capability() const
 
     return CPLCanRecode("test", GetEncoding(), CPL_ENC_UTF8);
 }
+
+CPLString IMapInfoFile::NormalizeFieldName(const char *pszName) const
+{
+    CPLString   osName(pszName);
+    if( strlen( GetEncoding() ) > 0 )
+        osName.Recode( CPL_ENC_UTF8, GetEncoding() );
+
+    char szNewFieldName[31+1]; /* 31 is the max characters for a field name*/
+    unsigned int nRenameNum = 1;
+
+    strncpy(szNewFieldName, osName.c_str(), sizeof(szNewFieldName)-1);
+    szNewFieldName[sizeof(szNewFieldName)-1] = '\0';
+
+    while (m_oSetFields.find(CPLString(szNewFieldName).toupper()) != m_oSetFields.end() &&
+           nRenameNum < 10)
+    {
+        CPLsnprintf( szNewFieldName, sizeof(szNewFieldName), "%.29s_%.1u",
+                     osName.c_str(), nRenameNum );
+        nRenameNum ++;
+    }
+
+    while (m_oSetFields.find(CPLString(szNewFieldName).toupper()) != m_oSetFields.end() &&
+           nRenameNum < 100)
+    {
+        CPLsnprintf( szNewFieldName, sizeof(szNewFieldName),
+                     "%.29s%.2u", osName.c_str(), nRenameNum );
+        nRenameNum ++;
+    }
+
+    if (m_oSetFields.find(CPLString(szNewFieldName).toupper()) != m_oSetFields.end())
+    {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "Too many field names like '%s' when truncated to 31 letters "
+                  "for MapInfo format.", pszName );
+    }
+
+    if( !EQUAL(osName.c_str(),szNewFieldName) )
+    {
+        CPLError( CE_Warning, CPLE_NotSupported,
+                  "Normalized/laundered field name: '%s' to '%s'",
+                  pszName, szNewFieldName );
+    }
+
+    CPLString   osNewFieldName(szNewFieldName);
+    if( strlen( GetEncoding() ) > 0 )
+        osNewFieldName.Recode( GetEncoding(), CPL_ENC_UTF8 );
+
+    return osNewFieldName;
+}
+


### PR DESCRIPTION
It seems that MITAB code was written before GDAL switched to UTF-8 encoding. 
I added a conversion from a UTF-8  to local encoding for the correct calculation of the number of characters in the field names.

Before my changes, field names were truncated to 16 characters, but the MITAB supports 31.