### PR TITLE
Elasticsearch: GeoJSON type field should be mapped as text in ES>=5

### DIFF
--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -1674,7 +1674,8 @@ CPLString OGRElasticLayer::BuildMap() {
             if( bAddGeoJSONType )
             {
                 json_object *geometry = AppendGroup(poContainer, pszLastComponent);
-                json_object_object_add(geometry, "type", AddPropertyMap("string"));
+                json_object_object_add(geometry, "type", AddPropertyMap(
+                   m_poDS->m_nMajorVersion >= 5 ? "text" : "string"));
                 json_object_object_add(geometry, "coordinates", geo_point);
             }
             else


### PR DESCRIPTION
## What does this PR do?
When GeoJSON data was converted to Elasticsearch versions >=5, the GeoJSON type field was incorrectly mapped to a `string` instead of `text`. Elasticsearch would return an error on the unsupported field type. This PR fixes the field mapping similar to how it is done earlier in the BuildMap() function.

## What are related issues/pull requests?
N/A

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed