### PR TITLE
Documentation: add FITS specific installation instructions in fits.rst.

### DIFF
--- a/gdal/doc/source/drivers/raster/fits.rst
+++ b/gdal/doc/source/drivers/raster/fits.rst
@@ -36,6 +36,7 @@ referred as metadata.
 NOTE: Implemented as ``gdal/frmts/fits/fitsdataset.cpp``.
 
 .. _notes-on-cfitsio-linking:
+
 Notes on CFITSIO linking in GDAL
 --------------------------------
 Linux

--- a/gdal/doc/source/drivers/raster/fits.rst
+++ b/gdal/doc/source/drivers/raster/fits.rst
@@ -12,7 +12,7 @@ images, and so has found its way into GDAL. FITS support is implemented
 in terms of the standard `CFITSIO
 library <http://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html>`__,
 which you must have on your system in order for FITS support to be
-enabled (see :ref:`notes-on-cfitsio-linking`).
+enabled (see :ref:`notes on CFITSIO linking <notes-on-cfitsio-linking>`).
 Both reading and writing of FITS files is supported. Starting from version 3.0
 georeferencing system support is implemented via the conversion of
 WCS (World Coordinate System) keywords.

--- a/gdal/doc/source/drivers/raster/fits.rst
+++ b/gdal/doc/source/drivers/raster/fits.rst
@@ -12,7 +12,7 @@ images, and so has found its way into GDAL. FITS support is implemented
 in terms of the standard `CFITSIO
 library <http://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html>`__,
 which you must have on your system in order for FITS support to be
-enabled (see `compilation instructions on trac <https://trac.osgeo.org/gdal/wiki/FITS>`__).
+enabled (see :ref:`notes-on-cfitsio-linking`).
 Both reading and writing of FITS files is supported. Starting from version 3.0
 georeferencing system support is implemented via the conversion of
 WCS (World Coordinate System) keywords.
@@ -35,6 +35,25 @@ referred as metadata.
 
 NOTE: Implemented as ``gdal/frmts/fits/fitsdataset.cpp``.
 
+.. _notes-on-cfitsio-linking:
+Notes on CFITSIO linking in GDAL
+--------------------------------
+Linux
+^^^^^
+From source
+"""""""""""
+Install CFITSIO headers from your distro (eg, cfitsio-devel on Fedora; libcfitsio-dev on Debian-Ubuntu), then compile GDAL as usual. CFITSIO will be automatically detected and linked.
+
+From distros
+""""""""""""
+On Fedora/CentOS install CFITSIO then GDAL with dnf (yum): cfitsio is automatically linked.
+
+Starting from Debian 10, Ubuntu 18.04 GDAL is packaged disabling CFITSIO link (see https://bugs.debian.org/422537): having GDAL linked against CFITSIO asks for recompile from source.
+
+MacOSX
+^^^^^^
+The last versions of the MacOSX packages are not linked against CFITSIO.
+Install CFITSIO as described in the `official documentation <https://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio_macosx.html>`__.
 
 Driver capabilities
 -------------------


### PR DESCRIPTION
Add to the documentation specific instructions for CFITSIO linking.
This was suggested in #1598.