### PR TITLE
grib: disable dead code with `#if 0` instead of `#ifdef ENABLE_TDLPACK` (fixes #1648)

### DIFF
--- a/gdal/frmts/grib/degrib/degrib/degrib2.cpp
+++ b/gdal/frmts/grib/degrib/degrib/degrib2.cpp
@@ -29,7 +29,8 @@
 //#include "write.h"
 #include "degrib2.h"
 #include "degrib1.h"
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
 #include "tdlpack.h"
 #endif
 #include "grib2api.h"
@@ -124,7 +125,8 @@ int ReadSECT0 (VSILFILE *fp, char **buff, uInt4 *buffLen, sInt4 limit,
    } wordType;
 
    uChar gribMatch = 0; /* Counts how many letters in GRIB we've matched. */
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
    uChar tdlpMatch = 0; /* Counts how many letters in TDLP we've matched. */
 #endif
    wordType word;       /* Used to check that the edition is correct. */
@@ -154,7 +156,8 @@ int ReadSECT0 (VSILFILE *fp, char **buff, uInt4 *buffLen, sInt4 limit,
    }
 */
    while (
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
           (tdlpMatch != 4) && 
 #endif
           (gribMatch != 4)) {
@@ -169,7 +172,8 @@ int ReadSECT0 (VSILFILE *fp, char **buff, uInt4 *buffLen, sInt4 limit,
                }
             }
          }
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
          else if ((*buff)[i] == 'T') {
             if (((*buff)[i + 1] == 'D') && ((*buff)[i + 2] == 'L') &&
                 ((*buff)[i + 3] == 'P')) {
@@ -223,7 +227,8 @@ int ReadSECT0 (VSILFILE *fp, char **buff, uInt4 *buffLen, sInt4 limit,
    *buffLen = curLen;
 
    word.li = sect0[1];
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
    if (tdlpMatch == 4) {
       if (word.buffer[3] != 0) {
          errSprintf ("ERROR: unexpected version of TDLP in SECT0\n");
@@ -936,7 +941,8 @@ int ReadGrib2Record (VSILFILE *fp, sChar f_unit, double **Grib_Data,
          free (buff);
          return 0;
       }
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
       else if (version == -1) {
          if (ReadTDLPRecord (fp, Grib_Data, grib_DataLen, meta, IS,
                              sect0, gribLen, majEarth, minEarth) != 0) {

--- a/gdal/frmts/grib/degrib/degrib/inventory.cpp
+++ b/gdal/frmts/grib/degrib/degrib/inventory.cpp
@@ -26,7 +26,8 @@
 #include "tendian.h"
 #include "degrib2.h"
 #include "degrib1.h"
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
 #include "tdlpack.h"
 #endif
 #include "myerror.h"
@@ -1087,7 +1088,8 @@ int GRIB2Inventory (VSILFILE *fp, inventoryType **Inv, uInt4 *LenInv,
             //fclose (fp);
             return -12;
          }
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
       } else if (version == -1) {
          if (TDLP_Inventory (fp, gribLen, inv) != 0) {
             preErrSprintf ("Inside GRIB2Inventory \n");
@@ -1207,7 +1209,8 @@ int GRIB2Inventory (VSILFILE *fp, inventoryType **Inv, uInt4 *LenInv,
       {
       uInt4 increment;
       /* Continue on to the next GRIB2 message. */
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
       if (version == -1) {
          /* TDLPack uses 4 bytes for FORTRAN record size, then another 8
           * bytes for the size of the record (so FORTRAN can see it), then
@@ -1331,7 +1334,8 @@ int GRIB2RefTime (const char *filename, double *refTime)
             //fclose (fp);
             return -12;
          }
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
       } else if (version == -1) {
          if (TDLP_RefTime (fp, gribLen, &(refTime1)) != 0) {
             preErrSprintf ("Inside TDLP_RefTime\n");

--- a/gdal/frmts/grib/degrib/degrib/metaprint.cpp
+++ b/gdal/frmts/grib/degrib/degrib/metaprint.cpp
@@ -26,7 +26,8 @@
 #include "metaname.h"
 #include "myerror.h"
 #include "myutil.h"
-#ifdef ENABLE_TDLPACK
+#if 0
+/* tdlpack is no longer supported by GDAL */
 #include "tdlpack.h"
 #endif
 #include "myassert.h"

--- a/gdal/frmts/grib/degrib/degrib/tdlpack.cpp
+++ b/gdal/frmts/grib/degrib/degrib/tdlpack.cpp
@@ -1,3 +1,5 @@
+#if 0
+/* tdlpack is no longer supported by GDAL */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -4503,3 +4505,5 @@ int WriteTDLPRecord (FILE * fp, double *Data, sInt4 DataLen, int DSF,
 }
 
 #endif // unused_by_GDAL
+#endif
+/* tdlpack is no longer supported by GDAL */


### PR DESCRIPTION
Since nobody is maintaining the code in those blocks, we might as well not have a configuration to compile them.

## What does this PR do?

Unconditionally blocks out TDLPACK-related code, instead of offering a compile-time config option.

## What are related issues/pull requests?

 - These blocks have not compiled since #1009
 - I filed an issue about that (#1648)
