### PR TITLE
Elasticsearch: Enable support for Elasticsearch 7 (fixes #1246)

### DIFF
--- a/autotest/ogr/ogr_elasticsearch.py
+++ b/autotest/ogr/ogr_elasticsearch.py
@@ -152,7 +152,7 @@ def test_ogr_elasticsearch_1():
     gdal.FileFromMemBuffer(
         '/vsimem/fakeelasticsearch/foo&CUSTOMREQUEST=DELETE', '{}')
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/foo/FeatureCollection/&POSTFIELDS={ }', '{}')
+        '/vsimem/fakeelasticsearch/foo/FeatureCollection&POSTFIELDS={ }', '{}')
     lyr = ds.CreateLayer('foo', geom_type=ogr.wkbNone, options=[
                          'OVERWRITE=TRUE', 'BULK_INSERT=NO', 'FID='])
     assert gdal.GetLastErrorType() == gdal.CE_None
@@ -166,7 +166,7 @@ def test_ogr_elasticsearch_1():
     feat = ogr.Feature(lyr.GetLayerDefn())
 
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/foo/FeatureCollection/&POSTFIELDS={ "properties": { } }', '{}')
+        '/vsimem/fakeelasticsearch/foo/FeatureCollection&POSTFIELDS={ "properties": { } }', '{}')
     ret = lyr.CreateFeature(feat)
     assert ret == 0
     feat = None
@@ -237,14 +237,14 @@ def test_ogr_elasticsearch_1():
 
     # Success
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/foo2/FeatureCollection/&POSTFIELDS={ "geometry": { "type": "POINT", "coordinates": [ 0.0, 1.0 ] }, "type": "Feature", "properties": { "str_field": "a", "int_field": 1, "int64_field": 123456789012, "real_field": 2.34, "boolean_field": true, "strlist_field": [ "a", "b" ], "intlist_field": [ 1, 2 ], "int64list_field": [ 123456789012, 2 ], "reallist_field": [ 1.23, 4.56 ], "date_field": "2015\/08\/12", "datetime_field": "2015\/08\/12 12:34:56.789", "time_field": "12:34:56.789", "binary_field": "ASNGV4mrze8=" } }', '{ "_id": "my_id" }')
+        '/vsimem/fakeelasticsearch/foo2/FeatureCollection&POSTFIELDS={ "geometry": { "type": "POINT", "coordinates": [ 0.0, 1.0 ] }, "type": "Feature", "properties": { "str_field": "a", "int_field": 1, "int64_field": 123456789012, "real_field": 2.34, "boolean_field": true, "strlist_field": [ "a", "b" ], "intlist_field": [ 1, 2 ], "int64list_field": [ 123456789012, 2 ], "reallist_field": [ 1.23, 4.56 ], "date_field": "2015\/08\/12", "datetime_field": "2015\/08\/12 12:34:56.789", "time_field": "12:34:56.789", "binary_field": "ASNGV4mrze8=" } }', '{ "_id": "my_id" }')
     ret = lyr.CreateFeature(feat)
     assert ret == 0
     assert feat['_id'] == 'my_id'
 
     # DateTime with TZ
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/foo2/FeatureCollection/&POSTFIELDS={ "properties": { "datetime_field": "2015\/08\/12 12:34:56.789+03:00" } }', '{}')
+        '/vsimem/fakeelasticsearch/foo2/FeatureCollection&POSTFIELDS={ "properties": { "datetime_field": "2015\/08\/12 12:34:56.789+03:00" } }', '{}')
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat['datetime_field'] = '2015/08/12 12:34:56.789+0300'
     ret = lyr.CreateFeature(feat)
@@ -284,7 +284,7 @@ def test_ogr_elasticsearch_1():
                          'GEOM_MAPPING_TYPE=GEO_POINT', 'GEOM_PRECISION=1m', 'BULK_INSERT=NO'])
 
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/foo3/FeatureCollection/&POSTFIELDS={ "ogc_fid": 1, "geometry": { "type": "POINT", "coordinates": [ 0.5, 0.5 ] }, "type": "Feature", "properties": { } }', '{}')
+        '/vsimem/fakeelasticsearch/foo3/FeatureCollection&POSTFIELDS={ "ogc_fid": 1, "geometry": { "type": "POINT", "coordinates": [ 0.5, 0.5 ] }, "type": "Feature", "properties": { } }', '{}')
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt('LINESTRING(0 0,1 1)'))
     ret = lyr.CreateFeature(feat)
@@ -358,7 +358,7 @@ def test_ogr_elasticsearch_2():
     feat.SetGeometry(ogr.CreateGeometryFromWkt(
         'GEOMETRYCOLLECTION(POINT(0 1),LINESTRING(0 1,2 3),POLYGON((0 0,0 10,10 10,0 0),(1 1,1 9,9 9,1 1)),MULTIPOINT(0 1, 2 3),MULTILINESTRING((0 1,2 3),(4 5,6 7)),MULTIPOLYGON(((0 0,0 10,10 10,0 0),(1 1,1 9,9 9,1 1)),((-1 -1,-1 -9,-9 -9,-1 -1))))'))
 
-    gdal.FileFromMemBuffer('/vsimem/fakeelasticsearch/foo/FeatureCollection/&POSTFIELDS={ "geometry": { "type": "geometrycollection", "geometries": [ { "type": "point", "coordinates": [ 0.0, 1.0 ] }, { "type": "linestring", "coordinates": [ [ 0.0, 1.0 ], [ 2.0, 3.0 ] ] }, { "type": "polygon", "coordinates": [ [ [ 0.0, 0.0 ], [ 0.0, 10.0 ], [ 10.0, 10.0 ], [ 0.0, 0.0 ] ], [ [ 1.0, 1.0 ], [ 1.0, 9.0 ], [ 9.0, 9.0 ], [ 1.0, 1.0 ] ] ] }, { "type": "multipoint", "coordinates": [ [ 0.0, 1.0 ], [ 2.0, 3.0 ] ] }, { "type": "multilinestring", "coordinates": [ [ [ 0.0, 1.0 ], [ 2.0, 3.0 ] ], [ [ 4.0, 5.0 ], [ 6.0, 7.0 ] ] ] }, { "type": "multipolygon", "coordinates": [ [ [ [ 0.0, 0.0 ], [ 0.0, 10.0 ], [ 10.0, 10.0 ], [ 0.0, 0.0 ] ], [ [ 1.0, 1.0 ], [ 1.0, 9.0 ], [ 9.0, 9.0 ], [ 1.0, 1.0 ] ] ], [ [ [ -1.0, -1.0 ], [ -1.0, -9.0 ], [ -9.0, -9.0 ], [ -1.0, -1.0 ] ] ] ] } ] }, "type": "Feature", "properties": { } }', '{}')
+    gdal.FileFromMemBuffer('/vsimem/fakeelasticsearch/foo/FeatureCollection&POSTFIELDS={ "geometry": { "type": "geometrycollection", "geometries": [ { "type": "point", "coordinates": [ 0.0, 1.0 ] }, { "type": "linestring", "coordinates": [ [ 0.0, 1.0 ], [ 2.0, 3.0 ] ] }, { "type": "polygon", "coordinates": [ [ [ 0.0, 0.0 ], [ 0.0, 10.0 ], [ 10.0, 10.0 ], [ 0.0, 0.0 ] ], [ [ 1.0, 1.0 ], [ 1.0, 9.0 ], [ 9.0, 9.0 ], [ 1.0, 1.0 ] ] ] }, { "type": "multipoint", "coordinates": [ [ 0.0, 1.0 ], [ 2.0, 3.0 ] ] }, { "type": "multilinestring", "coordinates": [ [ [ 0.0, 1.0 ], [ 2.0, 3.0 ] ], [ [ 4.0, 5.0 ], [ 6.0, 7.0 ] ] ] }, { "type": "multipolygon", "coordinates": [ [ [ [ 0.0, 0.0 ], [ 0.0, 10.0 ], [ 10.0, 10.0 ], [ 0.0, 0.0 ] ], [ [ 1.0, 1.0 ], [ 1.0, 9.0 ], [ 9.0, 9.0 ], [ 1.0, 1.0 ] ] ], [ [ [ -1.0, -1.0 ], [ -1.0, -9.0 ], [ -9.0, -9.0 ], [ -1.0, -1.0 ] ] ] ] } ] }, "type": "Feature", "properties": { } }', '{}')
     ret = lyr.CreateFeature(feat)
     assert ret == 0
     feat = None
@@ -986,7 +986,7 @@ def test_ogr_elasticsearch_5():
     feat['str'] = 'foo'
 
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/non_geojson/my_mapping/&POSTFIELDS={ "ogc_fid": 5, "str": "foo" }', '{}')
+        '/vsimem/fakeelasticsearch/non_geojson/my_mapping&POSTFIELDS={ "ogc_fid": 5, "str": "foo" }', '{}')
     ret = lyr.CreateFeature(feat)
     assert ret == 0
     feat = None
@@ -1144,7 +1144,7 @@ def test_ogr_elasticsearch_5():
         'POINT (3 50)')
     gdal.FileFromMemBuffer("""/vsimem/fakeelasticsearch/non_geojson/_mapping/my_mapping&POSTFIELDS={ "my_mapping": { "properties": { "str_field": { "type": "string" }, "superobject": { "properties": { "subfield": { "type": "string" }, "subobject": { "properties": { "subfield": { "type": "string" }, "another_subfield": { "type": "integer" } } }, "subfield2": { "type": "string" }, "another_geoshape": { "type": "geo_shape" }, "another_geoshape2": { "type": "geo_shape" }, "another_geoshape3": { "properties": { "type": { "type": "string" }, "coordinates": { "type": "geo_point" } } } } }, "another_field": { "type": "string" }, "a_geoshape": { "type": "geo_shape" }, "a_geopoint": { "properties": { "type": { "type": "string" }, "coordinates": { "type": "geo_point" } } }, "another_geopoint": { "type": "geo_point" } }, "_meta": { "geomfields": { "superobject.another_geoshape2": "POINT" } } } }""", '{}')
     gdal.FileFromMemBuffer(
-        """/vsimem/fakeelasticsearch/non_geojson/my_mapping/&POSTFIELDS={ "superobject": { "another_geoshape3": { "type": "POINT", "coordinates": [ 3.0, 50.0 ] }, "subfield2": "foo" } }""", "{}")
+        """/vsimem/fakeelasticsearch/non_geojson/my_mapping&POSTFIELDS={ "superobject": { "another_geoshape3": { "type": "POINT", "coordinates": [ 3.0, 50.0 ] }, "subfield2": "foo" } }""", "{}")
     gdal.FileFromMemBuffer(
         """/vsimem/fakeelasticsearch/non_geojson/my_mapping/_count?pretty""", "{}")
     lyr.CreateFeature(f)
@@ -2200,6 +2200,40 @@ def test_ogr_elasticsearch_11():
     assert ret == 0
     f = None
     assert lyr.SyncToDisk() == 0
+
+###############################################################################
+# Test Elasticsearch 7.x (ignore MAPPING_NAME)
+
+def test_ogr_elasticsearch_12():
+    if ogrtest.elasticsearch_drv is None:
+        pytest.skip()
+
+    ogr_elasticsearch_delete_files()
+
+    gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch",
+                           """{"version":{"number":"7.0.0"}}""")
+
+    ds = ogrtest.elasticsearch_drv.CreateDataSource(
+        "/vsimem/fakeelasticsearch")
+    assert ds is not None
+
+    gdal.FileFromMemBuffer(
+        '/vsimem/fakeelasticsearch/foo&CUSTOMREQUEST=PUT', '{}')
+    lyr = ds.CreateLayer('foo', srs=ogrtest.srs_wgs84, options=[
+        'WRITE_MAPPING=/vsimem/map.txt', 'FID='])
+    assert lyr is not None
+    f = ogr.Feature(lyr.GetLayerDefn())
+    lyr.CreateFeature(f)
+    ds = None
+
+    f = gdal.VSIFOpenL('/vsimem/map.txt', 'rb')
+    assert f is not None
+    data = gdal.VSIFReadL(1, 10000, f).decode('ascii')
+    gdal.VSIFCloseL(f)
+
+    gdal.Unlink('/vsimem/map.txt')
+
+    assert data == '{ "properties": { "geometry": { "type": "geo_shape" } } }'
 
 ###############################################################################
 # Test authentication

--- a/gdal/doc/source/drivers/vector/elasticsearch.rst
+++ b/gdal/doc/source/drivers/vector/elasticsearch.rst
@@ -279,7 +279,8 @@ options:
    will be written as GeoJSON Feature objects. If another mapping name
    is chosen, a more "flat" structure will be used.
 -  **MAPPING**\ =filename or JSon. Filename from which to read a
-   user-defined mapping, or mapping as serialized JSon.
+   user-defined mapping, or mapping as serialized JSon. This option is
+   ignored when converting to Elasticsearch >=7 (see `Removal of mapping types <https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html>`__).
 -  **WRITE_MAPPING**\ =filename. Creates a mapping file that can be
    modified by the user prior to insert in to the index. No feature will
    be written. This option is exclusive with MAPPING.

--- a/gdal/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -140,6 +140,8 @@ class OGRElasticLayer final: public OGRLayer {
                                                 char chNestedAttributeSeparator,
                                                 std::vector<CPLString>& aosPath);
 
+    CPLString                             BuildMappingURL(bool bMappingApi);
+
     CPLString                             BuildJSonFromFeature(OGRFeature *poFeature);
 
     static CPLString                      BuildPathFromArray(const std::vector<CPLString>& aosPath);

--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
@@ -157,46 +157,59 @@ void OGRElasticDataSource::FetchMapping(const char* pszIndexName)
             poMappings = CPL_json_object_object_get(poLayerObj, "mappings");
         if( poMappings && json_object_get_type(poMappings) == json_type_object )
         {
-            json_object_iter it;
-            it.key = nullptr;
-            it.val = nullptr;
-            it.entry = nullptr;
             std::vector<CPLString> aosMappings;
-            json_object_object_foreachC( poMappings, it )
+            if (m_nMajorVersion < 7)
             {
-                aosMappings.push_back(it.key);
-            }
-            if( aosMappings.size() == 1 &&
-                (aosMappings[0] == "FeatureCollection" || aosMappings[0] == "default") )
-            {
-                m_oSetLayers.insert(pszIndexName);
-                OGRElasticLayer* poLayer = new OGRElasticLayer(
-                    pszIndexName, pszIndexName, aosMappings[0], this, papszOpenOptions);
-                poLayer->InitFeatureDefnFromMapping(
-                    CPL_json_object_object_get(poMappings, aosMappings[0]),
-                    "", std::vector<CPLString>());
-                m_apoLayers.push_back(std::unique_ptr<OGRElasticLayer>(poLayer));
-            }
-            else
-            {
-                for(size_t i=0; i<aosMappings.size();i++)
+                json_object_iter it;
+                it.key = nullptr;
+                it.val = nullptr;
+                it.entry = nullptr;
+                json_object_object_foreachC( poMappings, it )
                 {
-                    CPLString osLayerName(pszIndexName + CPLString("_") + aosMappings[i]);
-                    if( m_oSetLayers.find(osLayerName) == m_oSetLayers.end() )
-                    {
-                        m_oSetLayers.insert(osLayerName);
-                        OGRElasticLayer* poLayer = new OGRElasticLayer(
-                            osLayerName,
-                            pszIndexName, aosMappings[i], this, papszOpenOptions);
-                        poLayer->InitFeatureDefnFromMapping(
-                            CPL_json_object_object_get(poMappings, aosMappings[i]),
-                            "", std::vector<CPLString>());
+                    aosMappings.push_back(it.key);
+                }
 
-                        m_apoLayers.push_back(std::unique_ptr<OGRElasticLayer>(poLayer));
+                if( aosMappings.size() == 1 &&
+                    (aosMappings[0] == "FeatureCollection" || aosMappings[0] == "default") )
+                {
+                    m_oSetLayers.insert(pszIndexName);
+                    OGRElasticLayer* poLayer = new OGRElasticLayer(
+                        pszIndexName, pszIndexName, aosMappings[0], this, papszOpenOptions);
+                    poLayer->InitFeatureDefnFromMapping(
+                        CPL_json_object_object_get(poMappings, aosMappings[0]),
+                        "", std::vector<CPLString>());
+                    m_apoLayers.push_back(std::unique_ptr<OGRElasticLayer>(poLayer));
+                }
+                else
+                {
+                    for(size_t i=0; i<aosMappings.size();i++)
+                    {
+                        CPLString osLayerName(pszIndexName + CPLString("_") + aosMappings[i]);
+                        if( m_oSetLayers.find(osLayerName) == m_oSetLayers.end() )
+                        {
+                            m_oSetLayers.insert(osLayerName);
+                            OGRElasticLayer* poLayer = new OGRElasticLayer(
+                                osLayerName,
+                                pszIndexName, aosMappings[i], this, papszOpenOptions);
+                            poLayer->InitFeatureDefnFromMapping(
+                                CPL_json_object_object_get(poMappings, aosMappings[i]),
+                                "", std::vector<CPLString>());
+
+                            m_apoLayers.push_back(std::unique_ptr<OGRElasticLayer>(poLayer));
+                        }
                     }
                 }
             }
+            else
+            {
+                m_oSetLayers.insert(pszIndexName);
+                OGRElasticLayer* poLayer = new OGRElasticLayer(
+                   pszIndexName, pszIndexName, "", this, papszOpenOptions);
+                poLayer->InitFeatureDefnFromMapping(poMappings, "", std::vector<CPLString>());
+                m_apoLayers.push_back(std::unique_ptr<OGRElasticLayer>(poLayer));
+            }
         }
+
 
         json_object_put(poRes);
     }
@@ -353,8 +366,9 @@ OGRLayer * OGRElasticDataSource::ICreateLayer(const char * pszLayerName,
     CPLErrorNum nLastErrorNo = CPLGetLastErrorNo();
     CPLString osLastErrorMsg = CPLGetLastErrorMsg();
 
-    const char* pszMappingName = CSLFetchNameValueDef(papszOptions,
-                                        "MAPPING_NAME", "FeatureCollection");
+    const char* pszMappingName = m_nMajorVersion < 7
+        ? CSLFetchNameValueDef(papszOptions, "MAPPING_NAME", "FeatureCollection")
+        : nullptr;
 
     // Check if the index and mapping exists
     bool bIndexExists = false;
@@ -373,16 +387,25 @@ OGRLayer * OGRElasticDataSource::ICreateLayer(const char * pszLayerName,
         bIndexExists = true;
         json_object* poIndex = CPL_json_object_object_get(poIndexResponse,
                                                           osLaunderedName);
-        if( poIndex != nullptr )
+        if (m_nMajorVersion < 7)
         {
-            json_object* poMappings = CPL_json_object_object_get(poIndex,
-                                                                 "mappings");
-            if( poMappings != nullptr )
+            if( poIndex != nullptr )
             {
-                bMappingExists = CPL_json_object_object_get(
-                                    poMappings, pszMappingName) != nullptr;
-                bSeveralMappings = json_object_object_length(poMappings) > 1;
+                json_object* poMappings = CPL_json_object_object_get(poIndex,
+                                                                     "mappings");
+                if( poMappings != nullptr )
+                {
+                    bMappingExists = CPL_json_object_object_get(
+                                        poMappings, pszMappingName) != nullptr;
+                    bSeveralMappings = json_object_object_length(poMappings) > 1;
+                }
             }
+        }
+        else
+        {
+            // Indexes in Elasticsearch 7+ can not have multiple types,
+            // so essentially this will always be true.
+            bMappingExists = true;
         }
         json_object_put(poIndexResponse);
     }
@@ -397,7 +420,16 @@ OGRLayer * OGRElasticDataSource::ICreateLayer(const char * pszLayerName,
         {
             // Deletion of one mapping in an index was supported in ES 1.X, but
             // considered unsafe and removed in later versions
-            if( bSeveralMappings )
+            if (m_nMajorVersion >= 7)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "The index %s already exists. "
+                         "You have to delete the whole index. You can do that "
+                         "with OVERWITE_INDEX=YES",
+                         osLaunderedName.c_str());
+                return nullptr;
+            }
+            else if( bSeveralMappings )
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                         "%s/%s already exists, but other mappings also exist "
@@ -411,8 +443,16 @@ OGRLayer * OGRElasticDataSource::ICreateLayer(const char * pszLayerName,
         }
         else
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "%s/%s already exists",
-                    osLaunderedName.c_str(), pszMappingName);
+            if (m_nMajorVersion < 7)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined, "%s/%s already exists",
+                         osLaunderedName.c_str(), pszMappingName);
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_AppDefined, "%s already exists",
+                         osLaunderedName.c_str());
+            }
             return nullptr;
         }
     }
@@ -468,8 +508,10 @@ OGRLayer * OGRElasticDataSource::ICreateLayer(const char * pszLayerName,
             }
         }
 
-        CPLString osMappingURL(CPLSPrintf("%s/%s/_mapping/%s",
-                            GetURL(), osLaunderedName.c_str(), pszMappingName));
+        CPLString osMappingURL = CPLSPrintf("%s/%s/_mapping",
+                            GetURL(), osLaunderedName.c_str());
+        if (m_nMajorVersion < 7)
+            osMappingURL += CPLSPrintf("/%s", pszMappingName);
         if( !UploadFile(osMappingURL, osLayerMapping.c_str()) )
         {
             return nullptr;
@@ -637,7 +679,7 @@ bool OGRElasticDataSource::CheckVersion()
         CPLError(CE_Failure, CPLE_AppDefined, "Server version not found");
         return false;
     }
-    if( m_nMajorVersion < 1 || m_nMajorVersion > 6 )
+    if( m_nMajorVersion < 1 || m_nMajorVersion > 7 )
     {
         CPLDebug("ES", "Server version untested with current driver");
     }

--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdriver.cpp
@@ -105,7 +105,7 @@ void RegisterOGRElastic() {
     "<LayerCreationOptionList>"
     "  <Option name='INDEX_NAME' type='string' description='Name of the index to create (or reuse). By default the index name is the layer name.'/>"
     "  <Option name='INDEX_DEFINITION' type='string' description='Filename from which to read a user-defined index definition, or index definition as serialized JSon.'/>"
-    "  <Option name='MAPPING_NAME' type='string' description='Name of the mapping type within the index.' default='FeatureCollection'/>"
+    "  <Option name='MAPPING_NAME' type='string' description='(ES &lt; 7) Name of the mapping type within the index.' default='FeatureCollection'/>."
     "  <Option name='MAPPING' type='string' description='Filename from which to read a user-defined mapping, or mapping as serialized JSon.'/>"
     "  <Option name='WRITE_MAPPING' type='string' description='Filename where to write the OGR generated mapping.'/>"
     "  <Option name='OVERWRITE' type='boolean' description='Whether to overwrite an existing type mapping with the layer name to be created' default='NO'/>"

--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -57,7 +57,10 @@ OGRElasticLayer::OGRElasticLayer( const char* pszLayerName,
 
     m_poDS(poDS),
     m_osIndexName(pszIndexName ? pszIndexName : ""),
-    m_osMappingName(pszMappingName ? pszMappingName : ""),
+    // Types are no longer supported in Elasticsearch 7+.
+    m_osMappingName(poDS->m_nMajorVersion < 7
+                    ? pszMappingName ? pszMappingName : ""
+                    : ""),
     m_poFeatureDefn(new OGRFeatureDefn(pszLayerName)),
     m_bFeatureDefnFinalized(false),
     m_bManualMapping(false),
@@ -529,9 +532,10 @@ void OGRElasticLayer::FinalizeFeatureDefn(bool bReadFeatures)
                     osPostData = m_osESSearch;
                 }
                 else
-                    osRequest = CPLSPrintf("%s/%s/%s/_search?scroll=1m&size=%d",
-                           m_poDS->GetURL(), m_osIndexName.c_str(),
-                           m_osMappingName.c_str(), m_poDS->m_nBatchSize);
+                {
+                    osRequest = BuildMappingURL(false);
+                    osRequest += CPLSPrintf("/_search?scroll=1m&size=%d", m_poDS->m_nBatchSize);
+                }
             }
             else
             {
@@ -587,18 +591,25 @@ void OGRElasticLayer::FinalizeFeatureDefn(bool bReadFeatures)
                     json_object* poIndex = CPL_json_object_object_get(poHit, "_index");
                     if( poIndex == nullptr || json_object_get_type(poIndex) != json_type_string )
                         break;
-                    json_object* poType = CPL_json_object_object_get(poHit, "_type");
-                    if( poType == nullptr || json_object_get_type(poType) != json_type_string )
-                        break;
+                    if (m_poDS->m_nMajorVersion < 7)
+                    {
+                        json_object* poType = CPL_json_object_object_get(poHit, "_type");
+                        if( poType == nullptr || json_object_get_type(poType) != json_type_string )
+                            break;
+                        m_osMappingName = json_object_get_string(poType);
+                    }
                     CPLString osIndex(json_object_get_string(poIndex));
-                    m_osMappingName = json_object_get_string(poType);
 
                     if( oVisited.find( std::pair<CPLString,CPLString>(osIndex, m_osMappingName) ) == oVisited.end() )
                     {
                         oVisited.insert( std::pair<CPLString,CPLString>(osIndex, m_osMappingName) );
 
-                        json_object* poMappingRes = m_poDS->RunRequest(
-                            (m_poDS->GetURL() + CPLString("/") + osIndex + CPLString("/_mapping/") + m_osMappingName + CPLString("?pretty")).c_str());
+                        CPLString osURL = CPLSPrintf("%s/%s/_mapping", m_poDS->GetURL(), osIndex.c_str());
+                        if (m_poDS->m_nMajorVersion < 7)
+                            osURL += CPLSPrintf("/%s", m_osMappingName.c_str());
+                        osURL += "?pretty";
+
+                        json_object* poMappingRes = m_poDS->RunRequest(osURL);
                         if( poMappingRes )
                         {
                             json_object* poLayerObj = CPL_json_object_object_get(poMappingRes, osIndex);
@@ -607,7 +618,9 @@ void OGRElasticLayer::FinalizeFeatureDefn(bool bReadFeatures)
                                 poMappings = CPL_json_object_object_get(poLayerObj, "mappings");
                             if( poMappings && json_object_get_type(poMappings) == json_type_object )
                             {
-                                json_object* poMapping = CPL_json_object_object_get(poMappings, m_osMappingName);
+                                json_object* poMapping = m_poDS->m_nMajorVersion < 7
+                                    ? CPL_json_object_object_get(poMappings, m_osMappingName)
+                                    : poMappings;
                                 if( poMapping)
                                 {
                                     InitFeatureDefnFromMapping(poMapping, "", std::vector<CPLString>());
@@ -1021,15 +1034,13 @@ OGRFeature *OGRElasticLayer::GetNextRawFeature()
         else if( (m_poSpatialFilter && m_osJSONFilter.empty()) || m_poJSONFilter )
         {
             osPostData = BuildQuery(false);
-            osRequest = CPLSPrintf("%s/%s/%s/_search?scroll=1m&size=%d",
-                        m_poDS->GetURL(), m_osIndexName.c_str(),
-                        m_osMappingName.c_str(), m_poDS->m_nBatchSize);
+            osRequest = BuildMappingURL(false);
+            osRequest += CPLSPrintf("/_search?scroll=1m&size=%d", m_poDS->m_nBatchSize);
         }
         else if( !m_aoSortColumns.empty() && m_osJSONFilter.empty() )
         {
-            osRequest = CPLSPrintf("%s/%s/%s/_search?scroll=1m&size=%d",
-                        m_poDS->GetURL(), m_osIndexName.c_str(),
-                        m_osMappingName.c_str(), m_poDS->m_nBatchSize);
+            osRequest = BuildMappingURL(false);
+            osRequest += CPLSPrintf("/_search?scroll=1m&size=%d", m_poDS->m_nBatchSize);
             json_object* poSort = BuildSort();
             osPostData = CPLSPrintf(
                 "{ \"sort\": %s }",
@@ -1038,10 +1049,8 @@ OGRFeature *OGRElasticLayer::GetNextRawFeature()
         }
         else
         {
-            osRequest =
-                CPLSPrintf("%s/%s/%s/_search?scroll=1m&size=%d",
-                           m_poDS->GetURL(), m_osIndexName.c_str(),
-                           m_osMappingName.c_str(), m_poDS->m_nBatchSize);
+            osRequest = BuildMappingURL(false);
+            osRequest += CPLSPrintf("/_search?scroll=1m&size=%d", m_poDS->m_nBatchSize);
             osPostData = m_osJSONFilter;
         }
     }
@@ -1529,12 +1538,20 @@ CPLString OGRElasticLayer::BuildMap() {
 
     std::map< std::vector<CPLString>, json_object* > oMap;
 
-    json_object *poMapping = json_object_new_object();
+    json_object *poMapping;
     json_object *poMappingProperties = json_object_new_object();
-    json_object_object_add(map, m_osMappingName, poMapping);
+    if (m_poDS->m_nMajorVersion < 7)
+    {
+        poMapping = json_object_new_object();
+        json_object_object_add(map, m_osMappingName, poMapping);
+    }
+    else
+    {
+        poMapping = map;
+    }
     json_object_object_add(poMapping, "properties", poMappingProperties);
 
-    if( m_osMappingName == "FeatureCollection" )
+    if( m_poDS->m_nMajorVersion < 7 && m_osMappingName == "FeatureCollection" )
     {
         json_object_object_add(poMappingProperties, "type", AddPropertyMap(
             m_poDS->m_nMajorVersion >= 5 ? "text" : "string"));
@@ -1952,7 +1969,8 @@ OGRErr OGRElasticLayer::WriteMapIfNecessary()
     if( m_osWriteMapFilename.empty() && m_bSerializeMapping )
     {
         m_bSerializeMapping = false;
-        if( !m_poDS->UploadFile(CPLSPrintf("%s/%s/_mapping/%s", m_poDS->GetURL(), m_osIndexName.c_str(), m_osMappingName.c_str()), BuildMap()) )
+        CPLString osURL = BuildMappingURL(true);
+        if( !m_poDS->UploadFile(osURL.c_str(), BuildMap()) )
         {
             return OGRERR_FAILURE;
         }
@@ -1987,6 +2005,19 @@ static json_object* GetContainerForFeature( json_object* poContainer,
          }
     }
     return poContainer;
+}
+
+/************************************************************************/
+/*                        BuildMappingURL()                             */
+/************************************************************************/
+CPLString OGRElasticLayer::BuildMappingURL(bool bMappingApi)
+{
+    CPLString osURL = CPLSPrintf("%s/%s", m_poDS->GetURL(), m_osIndexName.c_str());
+    if (bMappingApi)
+        osURL += "/_mapping";
+    if (m_poDS->m_nMajorVersion < 7)
+        osURL += CPLSPrintf("/%s", m_osMappingName.c_str());
+    return osURL;
 }
 
 /************************************************************************/
@@ -2272,7 +2303,9 @@ OGRErr OGRElasticLayer::ICreateFeature(OGRFeature *poFeature)
 
     // Check to see if we're using bulk uploading
     if (m_nBulkUpload > 0) {
-        m_osBulkContent += CPLSPrintf("{\"index\" :{\"_index\":\"%s\", \"_type\":\"%s\"", m_osIndexName.c_str(), m_osMappingName.c_str());
+        m_osBulkContent += CPLSPrintf("{\"index\" :{\"_index\":\"%s\"", m_osIndexName.c_str());
+        if(m_poDS->m_nMajorVersion < 7)
+            m_osBulkContent += CPLSPrintf(", \"_type\":\"%s\"", m_osMappingName.c_str());
         if( pszId )
             m_osBulkContent += CPLSPrintf(",\"_id\":\"%s\"", pszId);
         m_osBulkContent += "}}\n" + osFields + "\n\n";
@@ -2288,9 +2321,9 @@ OGRErr OGRElasticLayer::ICreateFeature(OGRFeature *poFeature)
     else
     {
         // Fall back to using single item upload for every feature.
-        CPLString osURL(CPLSPrintf("%s/%s/%s/", m_poDS->GetURL(), m_osIndexName.c_str(), m_osMappingName.c_str()));
-        if( pszId )
-            osURL += pszId;
+        CPLString osURL(BuildMappingURL(false));
+        if ( pszId )
+            osURL += CPLSPrintf("/%s", pszId);
         json_object* poRes = m_poDS->RunRequest(osURL, osFields);
         if( poRes == nullptr )
         {
@@ -2343,9 +2376,11 @@ OGRErr OGRElasticLayer::ISetFeature(OGRFeature *poFeature)
     CPLString osFields(BuildJSonFromFeature(poFeature));
 
     // TODO? we should theoretically detect if the provided _id doesn't exist
-    CPLString osURL(CPLSPrintf("%s/%s/%s/%s",
-                               m_poDS->GetURL(), m_osIndexName.c_str(),
-                               m_osMappingName.c_str(),poFeature->GetFieldAsString(0)));
+    CPLString osURL(CPLSPrintf("%s/%s",
+                               m_poDS->GetURL(), m_osIndexName.c_str()));
+    if(m_poDS->m_nMajorVersion < 7)
+        osURL += CPLSPrintf("/%s", m_osMappingName.c_str());
+    osURL += CPLSPrintf("/%s", poFeature->GetFieldAsString(0));
     json_object* poRes = m_poDS->RunRequest(osURL, osFields);
     if( poRes == nullptr )
     {
@@ -2553,45 +2588,45 @@ GIntBig OGRElasticLayer::GetFeatureCount( int bForce )
         return OGRLayer::GetFeatureCount(bForce);
 
     json_object* poResponse = nullptr;
+    CPLString osURL(CPLSPrintf("%s", m_poDS->GetURL()));
+    CPLString osFilter = "";
     if( !m_osESSearch.empty() )
     {
         if( m_osESSearch[0] != '{' )
             return OGRLayer::GetFeatureCount(bForce);
-        poResponse = m_poDS->RunRequest(
-            CPLSPrintf("%s/_search?pretty", m_poDS->GetURL()),
-            ("{ \"size\": 0, " + m_osESSearch.substr(1)).c_str());
+        osURL += "/_search?pretty";
+        osFilter = ("{ \"size\": 0, " + m_osESSearch.substr(1)).c_str();
     }
     else if( (m_poSpatialFilter && m_osJSONFilter.empty()) || m_poJSONFilter )
     {
-        CPLString osFilter = BuildQuery(true);
-        if( m_poDS->m_nMajorVersion >= 5 )
+        osFilter = BuildQuery(true);
+        osURL += CPLSPrintf("/%s", m_osIndexName.c_str());
+        if( m_poDS->m_nMajorVersion >= 5)
         {
-            poResponse = m_poDS->RunRequest(
-                CPLSPrintf("%s/%s/%s/_count?pretty", m_poDS->GetURL(),
-                           m_osIndexName.c_str(), m_osMappingName.c_str()),
-                osFilter.c_str());
+            if (m_poDS->m_nMajorVersion < 7)
+                osURL += CPLSPrintf("/%s", m_osMappingName.c_str());
+            osURL += "/_count?pretty";
         }
         else
         {
-            poResponse = m_poDS->RunRequest(
-                CPLSPrintf("%s/%s/%s/_search?pretty", m_poDS->GetURL(),
-                           m_osIndexName.c_str(), m_osMappingName.c_str()),
-                osFilter.c_str());
+            osURL += CPLSPrintf("/%s/_search?pretty", m_osMappingName.c_str());
         }
     }
     else if( !m_osJSONFilter.empty() )
     {
-        poResponse = m_poDS->RunRequest(
-            CPLSPrintf("%s/%s/%s/_search?&pretty", m_poDS->GetURL(),
-                       m_osIndexName.c_str(), m_osMappingName.c_str()),
-            ("{ \"size\": 0, " + m_osJSONFilter.substr(1)).c_str());
+        osURL += CPLSPrintf("/%s", m_osIndexName.c_str());
+        if (m_poDS->m_nMajorVersion < 7)
+            osURL += CPLSPrintf("/%s", m_osMappingName.c_str());
+        osFilter = ("{ \"size\": 0, " + m_osJSONFilter.substr(1));
     }
     else
     {
-        poResponse = m_poDS->RunRequest(
-            CPLSPrintf("%s/%s/%s/_count?pretty", m_poDS->GetURL(),
-                       m_osIndexName.c_str(), m_osMappingName.c_str()));
+        osURL += CPLSPrintf("/%s", m_osIndexName.c_str());
+        if (m_poDS->m_nMajorVersion < 7)
+            osURL += CPLSPrintf("/%s", m_osMappingName.c_str());
+        osURL += "/_count?pretty";
     }
+    poResponse = m_poDS->RunRequest(osURL.c_str(), osFilter.c_str());
 
     json_object* poCount = json_ex_get_object_by_path(poResponse, "hits.count");
     if( poCount == nullptr )
@@ -3308,11 +3343,11 @@ OGRErr OGRElasticLayer::GetExtent(int iGeomField, OGREnvelope *psExtent, int bFo
 
     CPLString osFilter = CPLSPrintf("{ \"size\": 0, \"aggs\" : { \"bbox\" : { \"geo_bounds\" : { \"field\" : \"%s\" } } } }",
                                     BuildPathFromArray(m_aaosGeomFieldPaths[iGeomField]).c_str() );
-    json_object* poResponse = m_poDS->RunRequest(
-        CPLSPrintf("%s/%s/%s/_search?pretty",
-                   m_poDS->GetURL(), m_osIndexName.c_str(),
-                   m_osMappingName.c_str()),
-        osFilter.c_str());
+    CPLString osURL = CPLSPrintf("%s/%s", m_poDS->GetURL(), m_osIndexName.c_str());
+    if (m_poDS->m_nMajorVersion < 7)
+        osURL += CPLSPrintf("/%s", m_osMappingName.c_str());
+    osURL += "/_search?pretty";
+    json_object* poResponse = m_poDS->RunRequest(osURL.c_str(), osFilter.c_str());
 
     json_object* poBounds = json_ex_get_object_by_path(poResponse, "aggregations.bbox.bounds");
     json_object* poTopLeft = json_ex_get_object_by_path(poBounds, "top_left");


### PR DESCRIPTION
## What does this PR do?
This enables the ElasticSearch driver to work with Elasticsearch 7.x. The `MAPPING_NAME` layer creation option is ignored when converting to Elasticsearch 7.x because mapping types are no longer used. The `MAPPING_NAME` option continues to work the same way in Elasticsearch version < 7.

## What are related issues/pull requests?
#1246 

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
