### PR TITLE
Fix SegmentMerger list iterator skipping and out of bounds error.

### DIFF
--- a/gdal/alg/marching_squares/segment_merger.h
+++ b/gdal/alg/marching_squares/segment_merger.h
@@ -109,9 +109,15 @@ struct SegmentMerger
 
         for ( auto& l : lines_ ) {
             const int levelIdx = l.first;
-            for ( auto it = l.second.begin(); it != l.second.end(); it++ ) {
+            auto it = l.second.begin();
+            while ( it != l.second.end() ) {
                 if ( ! it->isMerged ) {
+                    // Note that emitLine_ erases `it` and returns an iterator advanced
+                    // to the next element.
                     it = emitLine_( levelIdx, it, /* closed */ false );
+                }
+                else {
+                    ++it;
                 }
             }
         }


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Don't double increment iterator returned from `emitLine_` function.

Another thing I noticed here. In `emitLines_`, `lines` is erased from the member `lines_` if it is empty, the function then continues. I believe this is therefore unsafe? I think `emitLines_` shouldn't erase from `lines_`. We should be careful with iterators.

## What are related issues/pull requests?
#1670 

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Windows 10 x64 (and Ubuntu 18.04.2 LTS x64)
* Compiler: MSVC 1900 (and gcc 7.4.0)
