### PR TITLE
KEA: return error when deleting metadata item rather than crashing

### DIFF
--- a/gdal/frmts/kea/keaband.cpp
+++ b/gdal/frmts/kea/keaband.cpp
@@ -378,6 +378,11 @@ CPLErr KEARasterBand::SetMetadataItem(const char *pszName, const char *pszValue,
     // only deal with 'default' domain - no geolocation etc
     if( ( pszDomain != nullptr ) && ( *pszDomain != '\0' ) )
         return CE_Failure;
+
+    // kealib doesn't currently support removing values
+    if( pszValue == nullptr )
+        return CE_Failure;
+
     try
     {
         // if it is LAYER_TYPE handle it separately


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Currently, in the KEA driver when passing a `nullptr` as a metadata value results in a crash instead of deleting the item. `kealib` doesn't support deleting of metadata, so this PR simply returns failure instead.

This fixes situations where GDAL was crashing when trying to remove a metadata item on a KEA file (for example, running `ComputeStatistics()` multiple times with `bApproxOK=TRUE`).

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:

cc: @bhjolly @petebunting @neilflood