### PR TITLE
WIP/RFC: read-only support for subdataset masks and overviews using tiff pages

### DIFF
--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -12548,12 +12548,12 @@ GDALDataset *GTiffDataset::Open( GDALOpenInfo * poOpenInfo )
     if (STARTS_WITH_CI(pszFilename, "GTIFF_PAGE:"))
     {
         pszFilename += strlen("GTIFF_PAGE:");
-        nPage = atol(pszFilename);
+        nPage = atoi(pszFilename);
         pszFilename += 1;
         while (*pszFilename != '\0' && pszFilename[-1] != ':')
             ++pszFilename;
 
-        if (*pszFilename == '\0' || nPage == -1)
+        if (*pszFilename == '\0' || nPage<0)
             return nullptr;
     }
 
@@ -15172,7 +15172,7 @@ void GTiffDataset::ScanDirectories()
             }
         }
         // Embedded mask of the main image.
-        else if ((nSubType & FILETYPE_MASK) != 0 &&
+        else if( (nSubType & FILETYPE_MASK) != 0 &&
                  (nSubType & FILETYPE_REDUCEDIMAGE) == 0 &&
                  iDirIndex != 1 &&
                  nPageNumber == m_nPage &&


### PR DESCRIPTION
Currently TIFF subdatasets do not support overviews or masks. When overview or mask IFDs are present in the TIFF file they will be assigned to the "first" subdataset (provided that they are compatible), which results in:
- subdataset 0 being potentially assigned invalid masks/overviews
- subdatasets n>0 not supporting masks or overviews

The present pull request proposes a read-only support of the TIFFTAG_PAGENUMBER to be able to associate a subdataset with its corresponding masks/overviews.

opening "multidataset.tif" will list all available tiff pages as subdatasets, and will associate all mask/overview ifds *without pagenumber set* to the current dataset
opening "GTIFF_PAGE:0:multidataset.tif" will describe the IFD with pagenumber==0 along with all masks/overviews with pagenumber==0

Backwards incompatibilities:
- ```SUBDATASET_1_NAME=GTIFF_DIR:1:filename.tif``` will not be emitted in the SUBDATASETS metadata when IFD 1 has a pagenumber set. the entry will be replaced by ```SUBDATASET_1_NAME=GTIFF_PAGE:1:filename.tif```
- Numbering/naming of subdatasets is no longer tied to the ifd number.
- When opening a tif file without specifying the page number, masks/overviews that have an explicit pagenumber set will not show up