### PR TITLE
Doc gdallocationinfo: Add stdin example

### DIFF
--- a/gdal/doc/source/programs/gdallocationinfo.rst
+++ b/gdal/doc/source/programs/gdallocationinfo.rst
@@ -138,3 +138,26 @@ Query a VRT file providing the location in WGS84, and getting the result in xml.
             <Value>16</Value>
         </BandReport>
     </Report>
+
+Reading location from stdin.
+
+::
+
+	$ cat coordinates.tsv 
+	443020	3748359
+	441197	3749005
+	443852	3747743
+	
+	$ cat coordinates.tsv | gdallocationinfo -geoloc utmsmall.tif 
+	Report:
+	  Location: (38P,49L)
+	  Band 1:
+		Value: 214
+	Report:
+	  Location: (7P,38L)
+	  Band 1:
+		Value: 107
+	Report:
+	  Location: (52P,59L)
+	  Band 1:
+		Value: 148

--- a/gdal/doc/source/programs/gdallocationinfo.rst
+++ b/gdal/doc/source/programs/gdallocationinfo.rst
@@ -143,21 +143,21 @@ Reading location from stdin.
 
 ::
 
-	$ cat coordinates.tsv 
-	443020	3748359
-	441197	3749005
-	443852	3747743
-	
-	$ cat coordinates.tsv | gdallocationinfo -geoloc utmsmall.tif 
-	Report:
-	  Location: (38P,49L)
-	  Band 1:
-		Value: 214
-	Report:
-	  Location: (7P,38L)
-	  Band 1:
-		Value: 107
-	Report:
-	  Location: (52P,59L)
-	  Band 1:
-		Value: 148
+    $ cat coordinates.tsv 
+    443020	3748359
+    441197	3749005
+    443852	3747743
+    
+    $ cat coordinates.tsv | gdallocationinfo -geoloc utmsmall.tif 
+    Report:
+      Location: (38P,49L)
+      Band 1:
+        Value: 214
+    Report:
+      Location: (7P,38L)
+      Band 1:
+        Value: 107
+    Report:
+      Location: (52P,59L)
+      Band 1:
+        Value: 148

--- a/gdal/doc/source/programs/gdallocationinfo.rst
+++ b/gdal/doc/source/programs/gdallocationinfo.rst
@@ -143,12 +143,12 @@ Reading location from stdin.
 
 ::
 
-    $ cat coordinates.tsv 
-    443020	3748359
-    441197	3749005
-    443852	3747743
+    $ cat coordinates.txt
+    443020 3748359
+    441197 3749005
+    443852 3747743
     
-    $ cat coordinates.tsv | gdallocationinfo -geoloc utmsmall.tif 
+    $ cat coordinates.tsv | gdallocationinfo -geoloc utmsmall.tif
     Report:
       Location: (38P,49L)
       Band 1:


### PR DESCRIPTION
Usage of gdallocationinfo is not very intuitive. When not supplied with a location it will simply wait for input, not exit or print a message. This example of stdin input will hopefully make it more clear.

Uses autotest/utilities/data/utmsmall.tif