### PR TITLE
swig/python/setup.py: Fix swig python wheel on darwin

### DIFF
--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -269,17 +269,17 @@ class gdal_ext(build_ext):
                     if ext.name != 'osgeo._gdalconst':
                         ext.extra_compile_args += [cxx11_flag]
 
-        # Adding arch flags here if OS X and compiler is clang
-        if sys.platform == 'darwin' and [int(x) for x in os.uname()[2].split('.')] >= [11, 0, 0]:
-            # since MacOS X 10.9, clang no longer accepts -mno-fused-madd
-            # extra_compile_args.append('-Qunused-arguments')
-            clang_flag = '-Wno-error=unused-command-line-argument-hard-error-in-future'
-            if has_flag(self.compiler, clang_flag): 
-                ext.extra_compile_args += [clang_flag]
-            else:
-                clang_flag = '-Wno-error=unused-command-line-argument'
-                if has_flag(self.compiler, clang_flag):
-                    ext.extra_compile_args += [clang_flag]
+                    # Adding arch flags here if OS X and compiler is clang
+                    if sys.platform == 'darwin' and [int(x) for x in os.uname()[2].split('.')] >= [11, 0, 0]:
+                        # since MacOS X 10.9, clang no longer accepts -mno-fused-madd
+                        # extra_compile_args.append('-Qunused-arguments')
+                        clang_flag = '-Wno-error=unused-command-line-argument-hard-error-in-future'
+                        if has_flag(self.compiler, clang_flag):
+                            ext.extra_compile_args += [clang_flag]
+                        else:
+                            clang_flag = '-Wno-error=unused-command-line-argument'
+                            if has_flag(self.compiler, clang_flag):
+                                ext.extra_compile_args += [clang_flag]
 
         build_ext.build_extensions(self)
 


### PR DESCRIPTION
## What does this PR do?
Upstream fix to the packaging of the swig wheel.

This PR fixes scope issues around adding compile flags to clang during the build of darwin wheels. More specifically, the darwin options try to extend the extension object bound to ext, however, it's only in scope under the for loop, so I moved all the logic under the for loop as that seems like intended behavior and does in fact fix the build on darwin.

## What are related issues/pull requests?
https://github.com/NixOS/nixpkgs/pull/64551

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: macOS 10.14.5
* Compiler: clang 7.1.0
