### PR TITLE
WIP: Respect COMPRESS option in netCDF vector driver

### DIFF
--- a/gdal/doc/source/drivers/vector/netcdf.rst
+++ b/gdal/doc/source/drivers/vector/netcdf.rst
@@ -51,10 +51,10 @@ section `Geometry <#geometry>`__ for more details) are supported. Other geometri
 
 Furthermore, multiple layer writing is not yet supported. This functionality will be added in a future update.
 
-Finally, writing a very large CF-1.8 dataset may incur a lot of unneccessary I/O, slowing down the creation process.
+Finally, writing a very large CF-1.8 dataset may incur a lot of unnecessary I/O, slowing down the creation process.
 This is largely part in due to dimension resizing for netCDF-3 files. In the future,
-this will be amelioriated by providing an option to take advantage of multiple infinite dimension support within NC4
-(though writing such a file in NC4, may reduce read performance). Generally, the performance penalty from dimension resizing
+this will be ameliorated by providing an option to take advantage of multiple infinite dimension support within NC4
+(though writing such a file in NC4 may reduce read performance). Generally, the performance penalty from dimension resizing
 is greatly reduced by `specifying a larger- but still reasonable- buffer size <#layer-creation-options>`__.
 
 CF-1.6/WKT datasets, however, are not limited to these restrictions.
@@ -212,7 +212,7 @@ In the below example, the station_name and time variables may be indexed
 by the profile dimension (the geometry is assumed to be also indexed by
 the profile dimension), since all records that have the same value for
 one of those variables have same values for the other ones, whereas
-temparature and Z should be indexed by the default dimension.
+temperature and Z should be indexed by the default dimension.
 
 ============ ==================== ================== =========== ===
 station_name time                 geometry           temperature Z
@@ -246,6 +246,12 @@ Dataset creation options
    concept of groups, etc...) only available in netCDF v4 library. NC4C
    is a restriction of the NC4 format to the concepts supported by the
    classic netCDF format. Default is NC.
+-  **COMPRESS=[NONE/DEFLATE]**: Set the compression to use. DEFLATE is
+   only available if netCDF has been compiled with netCDF-4 support.
+   NC4C format is the default if DEFLATE compression is used.
+-  **ZLEVEL=[1-9]**: Set the level of compression when using DEFLATE
+   compression. A value of 9 is best, and 1 is least compression. The
+   default is 1, which offers the best time/compression ratio.
 -  **WRITE_GDAL_TAGS**\ =YES/NO: Whether to write GDAL specific
    information as netCDF attributes. Default is YES.
 -  **CONFIG_FILE**\ =string. Path to a `XML configuration

--- a/gdal/frmts/netcdf/netcdflayer.cpp
+++ b/gdal/frmts/netcdf/netcdflayer.cpp
@@ -309,6 +309,9 @@ bool netCDFLayer::Create(char **papszOptions,
             return false;
         }
 
+        status = m_poDS->DefVarDeflate(m_nXVarID, false);
+        NCDF_ERR(status);
+
         if(!m_bLegacyCreateMode)
         {
             status = nc_put_att_text(m_nLayerCDFId, m_nXVarID, CF_AXIS, strlen(CF_SG_X_AXIS), CF_SG_X_AXIS);
@@ -331,6 +334,9 @@ bool netCDFLayer::Create(char **papszOptions,
         {
             return false;
         }
+
+        status = m_poDS->DefVarDeflate(m_nYVarID, false);
+        NCDF_ERR(status);
 
         if(!m_bLegacyCreateMode)
         {
@@ -382,6 +388,9 @@ bool netCDFLayer::Create(char **papszOptions,
             {
                 return false;
             }
+
+            status = m_poDS->DefVarDeflate(m_nZVarID, false);
+            NCDF_ERR(status);
 
             aoAutoVariables.push_back(
                 std::pair<CPLString, int>(pszZVarName, m_nZVarID));
@@ -455,6 +464,9 @@ bool netCDFLayer::Create(char **papszOptions,
         {
             return false;
         }
+
+        status = m_poDS->DefVarDeflate(m_nWKTVarID, false);
+        NCDF_ERR(status);
 
         aoAutoVariables.push_back(
             std::pair<CPLString, int>(m_osWKTVarName, m_nWKTVarID));
@@ -2370,6 +2382,7 @@ OGRErr netCDFLayer::CreateField(OGRFieldDefn *poFieldDefn, int /* bApproxOK */)
             nDimCount = 2;
             int anDims[2] = {nMainDimId, nSecDimId};
             nType = NC_CHAR;
+
             status = nc_def_var(m_nLayerCDFId, pszVarName, nType, 2, anDims,
                                 &nVarID);
         }
@@ -2581,6 +2594,8 @@ OGRErr netCDFLayer::CreateField(OGRFieldDefn *poFieldDefn, int /* bApproxOK */)
         netCDFWriteAttributesFromConf(m_nLayerCDFId, nVarID,
                                       poConfig->m_aoAttributes);
     }
+
+    m_poDS->DefVarDeflate(nVarID, false);
 
     m_poFeatureDefn->AddFieldDefn(poFieldDefn);
     return OGRERR_NONE;


### PR DESCRIPTION
## What does this PR do?

Fixes #1738 by compressing fields written by the vector driver, if instructed to do by the `COMPRESS` dataset option.

## What are related issues/pull requests?

#1738 

## Tasklist

 - [X] Compress attribute fields
-  [x] Compress geometry fields
-  [ ] Update documentation
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
