### PR TITLE
kmlsuperoverlay: Add `RESAMPLE` creation option

### DIFF
--- a/gdal/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/gdal/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -42,6 +42,8 @@
 #include "cpl_string.h"
 #include "cpl_vsi.h"
 #include "gdal_frmts.h"
+#include "gdalwarper.h"
+#include "gdal_alg.h"
 #include "ogr_spatialref.h"
 #include "../vrt/gdal_vrt.h"
 #include "../vrt/vrtdataset.h"
@@ -64,112 +66,106 @@ static void GenerateTiles(std::string filename,
                    GDALDataset* poSrcDs,
                    GDALDriver* poOutputTileDriver,
                    GDALDriver* poMemDriver,
-                   bool isJpegDriver)
+                   bool isJpegDriver,
+                   GDALResampleAlg eResampleAlg)
 {
     GDALDataset* poTmpDataset = nullptr;
-    GDALRasterBand* alphaBand = nullptr;
-
-    GByte* pabyScanline = new GByte[dxsize];
-    bool* hadnoData = new bool[dxsize];
 
     if (isJpegDriver && bands == 4)
+    {
         bands = 3;
+    }
 
     poTmpDataset = poMemDriver->Create("", dxsize, dysize, bands, GDT_Byte, nullptr);
 
-    if (!isJpegDriver)//Jpeg dataset only has one or three bands
-    {
-        if (bands < 4)//add transparency to files with one band or three bands
-        {
-            poTmpDataset->AddBand(GDT_Byte);
-            alphaBand = poTmpDataset->GetRasterBand(poTmpDataset->GetRasterCount());
-        }
-    }
+    double adfSrcGeoTransform[6];
+    double adfDstGeoTransform[6];
+    poSrcDs->GetGeoTransform(adfSrcGeoTransform);
+    adfDstGeoTransform[0] = adfSrcGeoTransform[0] + (rx * adfSrcGeoTransform[1]);
+    adfDstGeoTransform[3] = adfSrcGeoTransform[3] + (ry * adfSrcGeoTransform[5]);
 
-    const int rowOffset = rysize/dysize;
-    const int loopCount = rysize/rowOffset;
-    for (int row = 0; row < loopCount; row++)
-    {
-        if (!isJpegDriver)
-        {
-            for (int i = 0; i < dxsize; i++)
-            {
-                hadnoData[i] = false;
-            }
-        }
+    adfDstGeoTransform[1] = adfSrcGeoTransform[1] * (rysize / dysize);
+    adfDstGeoTransform[5] = adfSrcGeoTransform[5] * (rxsize / dxsize);
 
+    adfDstGeoTransform[2] = adfSrcGeoTransform[2];
+    adfDstGeoTransform[4] = adfSrcGeoTransform[4];
+
+    GDALWarpOptions* psWarpOptions = GDALCreateWarpOptions();
+    psWarpOptions->hSrcDS = poSrcDs;
+    psWarpOptions->hDstDS = poTmpDataset;
+
+    psWarpOptions->nBandCount = bands;
+     if (isJpegDriver == false) //Jpeg dataset only has one or three bands
+     {
+         if (bands < 4) //add transparency to files with one band or three bands
+         {
+             poTmpDataset->AddBand(GDT_Byte);
+         }
+        psWarpOptions->nDstAlphaBand = poTmpDataset->GetRasterCount();
+     }
+ 
+    psWarpOptions->panSrcBands = (int *) CPLMalloc(sizeof(int) * psWarpOptions->nBandCount );
+    for (int i = 0; i < bands; i++)
+        psWarpOptions->panSrcBands[i] = i + 1;
+ 
+    psWarpOptions->panDstBands = (int *) CPLMalloc(sizeof(int) * psWarpOptions->nBandCount );
+    for (int i = 0; i < bands; i++)
+        psWarpOptions->panDstBands[i] = i + 1;
+ 
+    psWarpOptions->eResampleAlg = eResampleAlg;
+    psWarpOptions->eWorkingDataType = GDT_Byte;
+ 
+    psWarpOptions->pTransformerArg =
+        GDALCreateGenImgProjTransformer3(nullptr, adfSrcGeoTransform, nullptr, adfDstGeoTransform);
+ 
+    psWarpOptions->pfnTransformer = GDALGenImgProjTransform;
+ 
+    GDALWarpOperation oOperation;
+    oOperation.Initialize(psWarpOptions);
+    
+    oOperation.WarpRegion( 0, 0, dxsize, dysize, rx, ry, rxsize, rysize);
+ 
+    GDALDestroyGenImgProjTransformer( psWarpOptions->pTransformerArg );
+    GDALDestroyWarpOptions( psWarpOptions );
+    if ( !isJpegDriver )
+    {
+        int hasNoData = 0;
+        GByte* pafScanline = new GByte[dxsize];
+        GByte* pafAlphaScanline = new GByte[dxsize];
+        GDALRasterBand* poAlphaBand = poTmpDataset->GetRasterBand(psWarpOptions->nDstAlphaBand);
+ 
         for (int band = 1; band <= bands; band++)
         {
-            GDALRasterBand* poBand = poSrcDs->GetRasterBand(band);
-            int hasNoData = 0;
-            const double noDataValue = poBand->GetNoDataValue(&hasNoData);
-            const char* pixelType = poBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
-            const bool isSigned = ( pixelType && (strcmp(pixelType, "SIGNEDBYTE") == 0) );
-
-            int yOffset = ry + row * rowOffset;
-            CPLErr errTest =
-                poBand->RasterIO( GF_Read, rx, yOffset, rxsize, rowOffset, pabyScanline, dxsize, 1, GDT_Byte, 0, 0, nullptr);
-
-            const bool bReadFailed = ( errTest == CE_Failure );
-            if ( bReadFailed )
-            {
-                hasNoData = 1;
+            GDALRasterBand* poBand = poTmpDataset->GetRasterBand(band);
+            int noDataValue = poSrcDs->GetRasterBand(band)->GetNoDataValue(&hasNoData);
+ 
+            if ( !( hasNoData || band == 4 ) ){
+                continue;
             }
-
-            //fill the true or false for hadnoData array if the source data has nodata value
-            if (!isJpegDriver)
+            for (int row = 0; row < dysize; row++)
             {
-                if (hasNoData == 1)
-                {
-                    for (int j = 0; j < dxsize; j++)
-                    {
-                        double v = pabyScanline[j];
-                        double tmpv = v;
-                        if (isSigned)
-                        {
-                            tmpv -= 128;
-                        }
-                        if (tmpv == noDataValue || bReadFailed)
-                        {
-                            hadnoData[j] = true;
-                        }
-                    }
-                }
-            }
-
-            if (!bReadFailed)
-            {
-                GDALRasterBand* poBandtmp = poTmpDataset->GetRasterBand(band);
-                CPL_IGNORE_RET_VAL( poBandtmp->RasterIO(GF_Write, 0, row, dxsize, 1, pabyScanline, dxsize, 1, GDT_Byte,
-                                    0, 0, nullptr) );
-            }
-        }
-
-        //fill the values for alpha band
-        if (!isJpegDriver)
-        {
-            if (alphaBand)
-            {
+                CPL_IGNORE_RET_VAL( poBand->RasterIO( GF_Read, 0, row, dxsize, 1, pafScanline, dxsize, 1, GDT_Byte,
+                    0, 0, nullptr) );
                 for (int i = 0; i < dxsize; i++)
                 {
-                    if (hadnoData[i])
+                    if ( (band != 4 && pafScanline[i] == noDataValue ) || (band == 4 && pafScanline[i] == 0 ) )
                     {
-                        pabyScanline[i] = 0;
+                        pafAlphaScanline[i] = 0;
                     }
                     else
                     {
-                        pabyScanline[i] = 255;
+                        pafAlphaScanline[i] = 255;
                     }
                 }
-
-                CPL_IGNORE_RET_VAL( alphaBand->RasterIO(GF_Write, 0, row, dxsize, 1, pabyScanline, dxsize, 1, GDT_Byte,
-                                    0, 0, nullptr) );
+ 
+                CPL_IGNORE_RET_VAL( poAlphaBand->RasterIO( GF_Write, 0, row, dxsize, 1, pafAlphaScanline, dxsize, 1, GDT_Byte,
+                    0, 0, nullptr) );
             }
         }
+        delete[] pafScanline;
+        delete[] pafAlphaScanline;
     }
 
-    delete [] pabyScanline;
-    delete [] hadnoData;
 
     CPLString osOpenAfterCopy = CPLGetConfigOption("GDAL_OPEN_AFTER_COPY", "");
     CPLSetThreadLocalConfigOption("GDAL_OPEN_AFTER_COPY", "NO");
@@ -842,6 +838,24 @@ GDALDataset *KmlSuperOverlayCreateCopy( const char * pszFilename,
     std::map<std::pair<int,int>,std::vector<std::pair<std::pair<int,int>,bool> > > currentTiles;
     std::pair<int,int> childXYKey;
     std::pair<int,int> parentXYKey;
+
+    GDALResampleAlg eResampleAlg = GRA_NearestNeighbour;
+    const char* pszResampleAlg = CSLFetchNameValueDef(papszOptions, "RESAMPLE", "NEAREST");
+    if (EQUAL(pszResampleAlg, "NEAREST"))
+        eResampleAlg = GRA_NearestNeighbour;
+    else if (EQUAL(pszResampleAlg, "BILINEAR"))
+        eResampleAlg = GRA_Bilinear;
+    else if (EQUAL(pszResampleAlg, "CUBIC"))
+        eResampleAlg = GRA_Cubic;
+    else if (EQUAL(pszResampleAlg, "CUBICSPLINE"))
+        eResampleAlg = GRA_CubicSpline;
+    else if (EQUAL(pszResampleAlg, "LANCZOS"))
+        eResampleAlg = GRA_Lanczos;
+    else
+    {
+        CPLError( CE_Failure, CPLE_None, "Resample algorithm is invalid" );
+    }
+
     for (zoom = maxzoom; zoom >= 0; --zoom)
     {
         int rmaxxsize = tilexsize * (1 << (maxzoom-zoom));
@@ -914,7 +928,7 @@ GDALDataset *KmlSuperOverlayCreateCopy( const char * pszFilename,
                 }
 
                 GenerateTiles(filename, zoom, rxsize, rysize, ix, iy, rx, ry, dxsize,
-                              dysize, bands, poSrcDS, poOutputTileDriver, poMemDriver, isJpegDriver);
+                              dysize, bands, poSrcDS, poOutputTileDriver, poMemDriver, isJpegDriver, eResampleAlg);
                 std::string childKmlfile = zoomDir + "/" + iyStr.str() + ".kml";
                 if (isKmz)
                 {
@@ -2816,6 +2830,13 @@ void CPL_DLL GDALRegister_KMLSUPEROVERLAY()
 "       <Value>AUTO</Value>"
 "   </Option>"
 "   <Option name='FIX_ANTIMERIDIAN' type='boolean' description='Fix for images crossing the antimeridian causing errors in Google Earth' />"
+"   <Option name='RESAMPLE' type='string-select' default='NEAREST' description='Resmpling method when creating the tiles'>"
+"       <Value>NEAREST</Value>"
+"       <Value>BILINEAR</Value>"
+"       <Value>CUBIC</Value>"
+"       <Value>CUBICSPLINE</Value>"
+"       <Value>LANCZOS</Value>"
+"   </Option>"
 "</CreationOptionList>" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );


### PR DESCRIPTION
Adds optional resampling to the kmlsuperoverlay driver.

## What does this PR do?

I dusted off [this old patch](https://trac.osgeo.org/gdal/ticket/4747#no1) which we used on an ancient GDAL (~1.8?) to make our kml superoverlays look pretty.

Since each image in the kmlsuperoverlays is created from the next image in, everything's getting resized even if you're doing a 1:1 translate from another image. The result with nearest-neighbour resampling is that images look choppy and pixelated.

This adds a creation option to kmlsuperoverlay format that allows resampling via a warp kernel.

Note: I got the old patch and polished it up, but I don't guarantee it's all completely sensible, not being particular familiar with this code. (I also haven't written tests yet). It does seem to have the desired effect on a few images I've tried though :)

## What are related issues/pull requests?

Ancient ticket https://trac.osgeo.org/gdal/ticket/4747

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment
n/a