### PR TITLE
Update broken links in ogr_spatialref.h (fixes  #1767)

### DIFF
--- a/gdal/ogr/ogr_spatialref.h
+++ b/gdal/ogr/ogr_spatialref.h
@@ -146,11 +146,12 @@ class CPL_DLL OGR_SRSNode
  * SRS using GetAttrValue(), but in special cases the underlying parse tree
  * (or OGR_SRSNode objects) can be accessed more directly.
  *
- * See <a href="osr_tutorial.html">the tutorial</a> for more information on
- * how to use this class.
+ * See <a href="https://gdal.org/tutorials/osr_api_tut.html">the tutorial
+ * </a> for more information on how to use this class.
  * 
- * Consult also the <a href="wktproblems.html">OGC WKT Coordinate System Issues</a> page
- * for implementation details of WKT in OGR.
+ * Consult also the <a href="https://gdal.org/tutorials/wktproblems.html">
+ * OGC WKT Coordinate System Issues</a> page for implementation details of 
+ * WKT in OGR.
  */
 
 class CPL_DLL OGRSpatialReference


### PR DESCRIPTION
Two links in the documentation of ogr_spatialref.h point to the wrong location.

## What does this PR do?
Updates two links to the new correct location.
## What are related issues/pull requests?
#1767
## Tasklist
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
