### PR TITLE
Fix Coverity Scan Issue CID 1404242 and Broken Malformed CF Rejection

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -3112,9 +3112,7 @@ def test_bad_cf1_8():
     assert(corrupt_poly_1 is None)
     assert(corrupt_poly_2 is None)
     assert(corrupt_poly_3 is None)
-
-    # this error is no longer fatal
-    assert(uneq_x_y != None)
+    assert(uneq_x_y is None)
 
 def test_point_read():
     if gdaltest.netcdf_drv is None:

--- a/gdal/frmts/netcdf/netcdfsg.cpp
+++ b/gdal/frmts/netcdf/netcdfsg.cpp
@@ -357,7 +357,8 @@ namespace nccfdriver
          * (3) there are at least two node coordinate variable ids
          */
 
-        int all_dim = INVALID_VAR_ID; bool dim_set = false;
+        int all_dim = INVALID_VAR_ID;
+        bool dim_set = false;
         int dimC = 0;
         //(1) one dimension check, each node_coordinates have same dimension
         for(size_t nvitr = 0; nvitr < nodec_varIds.size(); nvitr++)
@@ -380,6 +381,7 @@ namespace nccfdriver
             if(!dim_set)
             {
                 all_dim = inter_dim[0];
+                dim_set = true;
             }    
 
             else


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Suppose a netCDF file uses different node coordinate dimensions for any two of its node coordinate variables. This PR makes it so that these datasets consisting of malformed CF-1.8 do not create layers.

Specifically, this PR also addresses Coverity Scan Issue CID 1404242. See the related issue below.

Thanks to @rouault for finding this issue and providing a fix.

## What are related issues/pull requests?
Issue #1770 

## Tasklist
 - [x] Modify existing Test Case
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: openSUSE Tumbleweed
* Compiler: GCC 9.1.1 (revision 273734)
