### PR TITLE
VFK: use a faster implementation of VFKDataBlockSQLite::LoadGeometryPolygon()

### DIFF
--- a/gdal/ogr/ogrsf_frmts/vfk/vfkdatablocksqlite.cpp
+++ b/gdal/ogr/ogrsf_frmts/vfk/vfkdatablocksqlite.cpp
@@ -30,6 +30,8 @@
  ****************************************************************************/
 
 #include <algorithm>
+#include <map>
+#include <utility>
 
 #include "vfkreader.h"
 #include "vfkreaderp.h"
@@ -572,6 +574,80 @@ int VFKDataBlockSQLite::LoadGeometryPolygon()
         poRingList.clear();
 
         /* collect rings from lines */
+#if 1
+        // Fast version using a map to identify quickly a ring from its end point.
+        std::map<std::pair<double,double>, PointList*> oMapEndRing;
+        while( !poLineList.empty() )
+        {
+            auto pGeom = poLineList.front()->GetGeometry();
+            if( pGeom )
+            {
+                auto poLine = pGeom->toLineString();
+                if( poLine == nullptr || poLine->getNumPoints() < 2 )
+                    continue;
+                poLineList.erase(poLineList.begin());
+                PointList* poList = new PointList();
+                FillPointList(poList, poLine);
+                poRingList.emplace_back(poList);
+                OGRPoint oFirst, oLast;
+                poLine->StartPoint(&oFirst);
+                poLine->EndPoint(&oLast);
+                oMapEndRing[std::pair<double,double>(
+                    oLast.getX(), oLast.getY())] = poList;
+
+                bool bWorkDone = true;
+                while( bWorkDone && (*poList).front() != (*poList).back() )
+                {
+                    bWorkDone = false;
+                    for( auto oIter = poLineList.begin(); oIter != poLineList.end(); ++oIter )
+                    {
+                        const auto& oCandidate = *oIter;
+                        auto poCandidateGeom = oCandidate->GetGeometry();
+                        if( poCandidateGeom == nullptr )
+                            continue;
+                        poLine = poCandidateGeom->toLineString();
+                        if( poLine == nullptr || poLine->getNumPoints() < 2 )
+                            continue;
+                        poLine->StartPoint(&oFirst);
+                        poLine->EndPoint(&oLast);
+                        // MER = MapEndRing
+                        auto oIterMER = oMapEndRing.find(std::pair<double,double>(
+                            oFirst.getX(), oFirst.getY()));
+                        if( oIterMER != oMapEndRing.end() )
+                        {
+                            auto ring = oIterMER->second;
+                            PointList oList;
+                            FillPointList(&oList, poLine);
+                            /* forward, skip first point */
+                            ring->insert(ring->end(), oList.begin()+1, oList.end());
+                            poLineList.erase(oIter);
+                            oMapEndRing.erase(oIterMER);
+                            oMapEndRing[std::pair<double,double>(
+                                oLast.getX(), oLast.getY())] = poList;
+                            bWorkDone = true;
+                            break;
+                        }
+                        oIterMER = oMapEndRing.find(std::pair<double,double>(
+                            oLast.getX(), oLast.getY()));
+                        if( oIterMER != oMapEndRing.end() )
+                        {
+                            auto ring = oIterMER->second;
+                            PointList oList;
+                            FillPointList(&oList, poLine);
+                            /* backward, skip first point */
+                            ring->insert(ring->end(), oList.rbegin()+1, oList.rend());
+                            poLineList.erase(oIter);
+                            oMapEndRing.erase(oIterMER);
+                            oMapEndRing[std::pair<double,double>(
+                                oFirst.getX(), oFirst.getY())] = ring;
+                            bWorkDone = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+#else
         bool bFound = false;
         int nCount = 0;
         const int nCountMax = static_cast<int>(nLines) * 2;
@@ -591,6 +667,7 @@ int VFKDataBlockSQLite::LoadGeometryPolygon()
             }
             nCount++;
         }
+#endif
         CPLDebug("OGR-VFK", "%s: fid = %ld nlines = %d -> nrings = %d", m_pszName,
                  iFID, (int)nLines, (int)poRingList.size());
 

--- a/gdal/ogr/ogrsf_frmts/vfk/vfkreader.h
+++ b/gdal/ogr/ogrsf_frmts/vfk/vfkreader.h
@@ -256,6 +256,8 @@ protected:
     virtual int        LoadGeometryLineStringHP() = 0;
     virtual int        LoadGeometryPolygon() = 0;
 
+    static void        FillPointList(PointList* poList, const OGRLineString *poLine);
+
 public:
     IVFKDataBlock(const char *, const IVFKReader *);
     virtual ~IVFKDataBlock();


### PR DESCRIPTION
This should end fixing the issue raised in
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16309 where a corrupted
.vfk files with a lot of line strings takes a long time to process.

The speed-up comes from using a hash map to map from a ring-in-building end
point to the ring, instead of iterating. This speeds up the reconstruction in
that case from ~20s to ~2s

@landam Could you review this and tests this work as expected with real datasets ?