### PR TITLE
Address buffer memory counting underflow in CF-1.8- issue #1772

### DIFF
--- a/gdal/frmts/netcdf/netcdfsgwriterutil.cpp
+++ b/gdal/frmts/netcdf/netcdfsgwriterutil.cpp
@@ -208,6 +208,21 @@ namespace nccfdriver
         this->geometry_ref = ft.GetGeometryRef();
     }
 
+    inline void WBuffer::addCount(unsigned long long memuse)
+    {
+        this->used_mem += memuse;
+    }
+
+    inline void WBuffer::subCount(unsigned long long memfree)
+    {
+        unsigned long long oldmem = this->used_mem;
+        this->used_mem -= memfree;
+        CPLAssert(used_mem <= oldmem);
+        /* detect underflow cases- if we subtract, then the new value better not 
+         * be larger!
+         */
+    }
+
     void ncLayer_SG_Metadata::initializeNewContainer(int containerVID)
     {
         this->containerVar_realID = containerVID;
@@ -724,6 +739,9 @@ namespace nccfdriver
         MTPtr m = this->wl.pop();
         if(m.get() != nullptr)
         {
+            // add it to the buffer count
+            this->buf.addCount(sizeof(m));
+            this->buf.addCount(m->count());
             return m;
         }
 
@@ -750,7 +768,6 @@ namespace nccfdriver
             wl.push(MTPtr(transactionQueue.front().release()));
             this->transactionQueue.pop();
         }
-
         this->buf.reset();
     }
 

--- a/gdal/frmts/netcdf/netcdfsgwriterutil.cpp
+++ b/gdal/frmts/netcdf/netcdfsgwriterutil.cpp
@@ -218,7 +218,7 @@ namespace nccfdriver
         /* detect underflow cases-
          * better not subtract more than we already counted...
          */
-        CPLAssert(used_mem >= memfree);
+        CPLAssert(this->used_mem >= memfree);
 
         this->used_mem -= memfree;
     }

--- a/gdal/frmts/netcdf/netcdfsgwriterutil.cpp
+++ b/gdal/frmts/netcdf/netcdfsgwriterutil.cpp
@@ -215,12 +215,12 @@ namespace nccfdriver
 
     inline void WBuffer::subCount(unsigned long long memfree)
     {
-        unsigned long long oldmem = this->used_mem;
-        this->used_mem -= memfree;
-        CPLAssert(used_mem <= oldmem);
-        /* detect underflow cases- if we subtract, then the new value better not 
-         * be larger!
+        /* detect underflow cases-
+         * better not subtract more than we already counted...
          */
+        CPLAssert(used_mem >= memfree);
+
+        this->used_mem -= memfree;
     }
 
     void ncLayer_SG_Metadata::initializeNewContainer(int containerVID)

--- a/gdal/frmts/netcdf/netcdfsgwriterutil.h
+++ b/gdal/frmts/netcdf/netcdfsgwriterutil.h
@@ -83,12 +83,12 @@ namespace nccfdriver
             /* addCount(...)
              * Takes in a size, and directly adds that size to memory count
              */
-             void addCount(unsigned long long memuse) { this->used_mem += memuse; }
+             void addCount(unsigned long long memuse);
 
             /* subCount(...)
              * Directly subtracts the specified size from used_mem
              */
-             void subCount(unsigned long long memfree) { this->used_mem -= memfree; }
+             void subCount(unsigned long long memfree);
              unsigned long long& getUsage() { return used_mem; }
 
              void reset() { this->used_mem = 0; }


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
The CF-1.8 portion of the netCDF Driver keeps an approximate count of memory usage during normal operation. If enough writes are logged, relative to the maximum buffer size, then underflow could possibly occur. This was in part, if not completely, because transactions received from the log, were not being re-recorded into the memory log but their usage were still being subtracted out. This PR fixes this issue by adding logged transactions back into the buffer memory counter.

This PR also adds an assert to the counter subtraction to have this check that it does not underflow be performed in tests.

Thanks to @rouault for reporting this issue.

## What are related issues/pull requests?
Issue #1772 

## Tasklist

 - [x] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: openSUSE Tumbleweed
* Compiler: GCC 9.1.1
