### PR TITLE
gdal.org - Fix typo in "Multidimensional Raster Data Model" documentation

### DIFF
--- a/gdal/doc/source/user/multidim_raster_data_model.rst
+++ b/gdal/doc/source/user/multidim_raster_data_model.rst
@@ -50,7 +50,7 @@ convention used for NumPy arrays, the MEM driver and the HDF5 and netCDF APIs.
 The GDAL API is mostly agnostic
 about that convention, except when passing a NULL array as the *stride* parameter
 for the :cpp:func:`GDALAbstractMDArray::Read` and  :cpp:func:`GDALAbstractMDArray::Write` methods.
-You can refer to `NumPy documentation about multidimensional array indeing order issues <https://docs.scipy.org/doc/numpy/reference/internals.html#multidimensional-array-indexing-order-issues>`_
+You can refer to `NumPy documentation about multidimensional array indexing order issues <https://docs.scipy.org/doc/numpy/reference/internals.html#multidimensional-array-indexing-order-issues>`_
 
 a GDALMDArray has also optional properties:
 


### PR DESCRIPTION
Fixed typo in link to: NumPy documentation about multidimensional array _indexing_ order issues

Page: https://gdal.org/user/multidim_raster_data_model.html