### PR TITLE
Add `apps/gdalmdimtranslate` to .gitignore

### DIFF
--- a/gdal/.gitignore
+++ b/gdal/.gitignore
@@ -59,6 +59,7 @@ apps/gdaldem
 apps/gdalenhance
 apps/gdalinfo
 apps/gdalmdiminfo
+apps/gdalmdimtranslate
 apps/gdallocationinfo
 apps/gdalmanage
 apps/gdalsrsinfo


### PR DESCRIPTION
Follow up for commit 9598f66a2e, which introduced the new executable `gdalmdimtranslate`.

The executable is in the `git status` after compiling the latest on the master branch.