### PR TITLE
frmts/netcdf; Allow "radian" value for the X/Y axis units (geos projection)

### DIFF
--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -3639,7 +3639,7 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
                             xMinMax[0] = xMinMax[0] * satelliteHeight * 0.000001;
                             xMinMax[1] = xMinMax[1] * satelliteHeight * 0.000001;
                         }
-                        else if( EQUAL( szUnits, "rad" ) )
+                        else if( EQUAL( szUnits, "rad" ) || EQUAL( szUnits, "radian" ) )
                         {
                             xMinMax[0] = xMinMax[0] * satelliteHeight;
                             xMinMax[1] = xMinMax[1] * satelliteHeight;
@@ -3657,7 +3657,7 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
                             yMinMax[0] = yMinMax[0] * satelliteHeight * 0.000001;
                             yMinMax[1] = yMinMax[1] * satelliteHeight * 0.000001;
                         }
-                        else if( EQUAL( szUnits, "rad" ) )
+                        else if( EQUAL( szUnits, "rad" ) || EQUAL( szUnits, "radian" ) )
                         {
                             yMinMax[0] = yMinMax[0] * satelliteHeight;
                             yMinMax[1] = yMinMax[1] * satelliteHeight;


### PR DESCRIPTION
According with the NUWG NetCDF Conventions for naming units, the value "rad" for radian unit shouldn't be used. Instead, the correct value should be "radian".
As one can see in the end of the following document:
https://www.unidata.ucar.edu/software/netcdf/netcdf/Units.html

Issues: #1799

In order to solve this issue, the value "radian" is being added as possible value for the X/Y axis/coordinates unit.
The value "rad", which instead means "absorbed dose", still being allowed, to keep retro-compatibility.
