### PR TITLE
netcdfdataset.cpp: Disregard valid range if min > max.

### DIFF
--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -447,6 +447,16 @@ netCDFRasterBand::netCDFRasterBand( netCDFDataset *poNCDFDS,
                 }
             }
         }
+        if (bValidRangeValid && adfValidRange[0] > adfValidRange[1])
+        {
+            CPLError(
+                CE_Warning, CPLE_AppDefined,
+                "netCDFDataset::valid_range: min > max:\n"
+                "  min: %lf\n  max: %lf\n", adfValidRange[0], adfValidRange[1]);
+            bValidRangeValid = false;
+            adfValidRange[0] = 0.0;
+            adfValidRange[1] = 0.0;
+        }
     }
 
     // Special For Byte Bands: check for signed/unsigned byte.
@@ -11584,5 +11594,3 @@ bool NCDFIsUserDefinedType(int ncid, int type)
     return false;
 #endif
 }
-
-


### PR DESCRIPTION
This currently happens in GOES with the FDCF fire product (and other
products).  Rather than hide the data, drop the valid range and warn.
This does not fix the issue of the Power field's max valid being too
low.

The issues are known to the data provider.

https://www.ncdc.noaa.gov/data-access/satellite-data/goes-r-series-satellites#FDC

See #1811

The PR has been tested with a custom test not included here as I don't have a small test case.  Counting on the Travis CI tests to check for other things that might be impacted from having bad valid ranges.