### PR TITLE
Fix issues with thread_local and C++ objects that don't work well with DLL on Windows

### DIFF
--- a/gdal/ogr/ogr_proj_p.cpp
+++ b/gdal/ogr/ogr_proj_p.cpp
@@ -27,6 +27,7 @@
  ****************************************************************************/
 
 #include "cpl_error.h"
+#include "cpl_multiproc.h"
 #include "cpl_string.h"
 
 #include "ogr_proj_p.h"
@@ -98,12 +99,49 @@ void OSRPJContextHolder::deinit()
     context = nullptr;
 }
 
+#ifdef WIN32
+// Currently thread_local and C++ objects don't work well with DLL on Windows
+static void FreeProjTLSContextHolder( void* pData )
+{
+    delete static_cast<OSRPJContextHolder*>(pData);
+}
 
+static OSRPJContextHolder& GetProjTLSContextHolder()
+{
+    static OSRPJContextHolder dummy;
+    int bMemoryErrorOccured = false;
+    void* pData = CPLGetTLSEx(CTLS_PROJCONTEXTHOLDER, &bMemoryErrorOccured);
+    if( bMemoryErrorOccured )
+    {
+        return dummy;
+    }
+    if( pData == nullptr)
+    {
+        auto pHolder = new OSRPJContextHolder();
+        CPLSetTLSWithFreeFuncEx( CTLS_PROJCONTEXTHOLDER,
+                                 pHolder,
+                                 FreeProjTLSContextHolder, &bMemoryErrorOccured );
+        if( bMemoryErrorOccured )
+        {
+            delete pHolder;
+            return dummy;
+        }
+        return *pHolder;
+    }
+    return *static_cast<OSRPJContextHolder*>(pData);
+}
+#else
 static thread_local OSRPJContextHolder g_tls_projContext;
+static OSRPJContextHolder& GetProjTLSContextHolder()
+{
+    return g_tls_projContext;
+}
+#endif
+
 
 PJ_CONTEXT* OSRGetProjTLSContext()
 {
-    auto& l_projContext = g_tls_projContext;
+    auto& l_projContext = GetProjTLSContextHolder();
     l_projContext.init();
     {
         // If OSRSetPROJSearchPaths() has been called since we created the context,
@@ -129,7 +167,7 @@ PJ_CONTEXT* OSRGetProjTLSContext()
 
 void OSRCleanupTLSContext()
 {
-    g_tls_projContext.deinit();
+    GetProjTLSContextHolder().deinit();
 }
 
 /*! @endcond */

--- a/gdal/port/cpl_multiproc.h
+++ b/gdal/port/cpl_multiproc.h
@@ -214,10 +214,10 @@ class CPL_DLL CPLLockHolder
 #define CTLS_CSVTABLEPTR                 3         /* cpl_csv.cpp */
 #define CTLS_CSVDEFAULTFILENAME          4         /* cpl_csv.cpp */
 #define CTLS_ERRORCONTEXT                5         /* cpl_error.cpp */
-/* 6: unused */
+#define CTLS_VSICURL_CACHEDCONNECTION    6         /* cpl_vsil_curl.cpp */
 #define CTLS_PATHBUF                     7         /* cpl_path.cpp */
 #define CTLS_ABSTRACTARCHIVE_SPLIT       8         /* cpl_vsil_abstract_archive.cpp */
-#define CTLS_UNUSED4                     9
+#define CTLS_GDALOPEN_ANTIRECURSION      9         /* gdaldataset.cpp */
 #define CTLS_CPLSPRINTF                 10         /* cpl_string.h */
 #define CTLS_RESPONSIBLEPID             11         /* gdaldataset.cpp */
 #define CTLS_VERSIONINFO                12         /* gdal_misc.cpp */
@@ -226,6 +226,7 @@ class CPL_DLL CPLLockHolder
 #define CTLS_FINDFILE                   15         /* cpl_findfile.cpp */
 #define CTLS_VSIERRORCONTEXT            16         /* cpl_vsi_error.cpp */
 #define CTLS_ERRORHANDLERACTIVEDATA     17         /* cpl_error.cpp */
+#define CTLS_PROJCONTEXTHOLDER          18         /* ogr_proj_p.cpp */
 
 #define CTLS_MAX                        32
 

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -2367,6 +2367,7 @@ VSICurlFilesystemHandler::VSICurlFilesystemHandler():
 /*                           CachedConnection                           */
 /************************************************************************/
 
+namespace {
 struct CachedConnection
 {
     CURLM          *hCurlMultiHandle = nullptr;
@@ -2374,9 +2375,47 @@ struct CachedConnection
 
     ~CachedConnection() { clear(); }
 };
+} // namespace
+
+#ifdef WIN32
+// Currently thread_local and C++ objects don't work well with DLL on Windows
+static void FreeCachedConnection( void* pData )
+{
+    delete static_cast<std::map<VSICurlFilesystemHandler*, CachedConnection>*>(pData);
+}
 
 // Per-thread and per-filesystem Curl connection cache.
-static thread_local std::map<VSICurlFilesystemHandler*, CachedConnection> cachedConnection;
+static std::map<VSICurlFilesystemHandler*, CachedConnection>& GetConnectionCache()
+{
+    static std::map<VSICurlFilesystemHandler*, CachedConnection> dummyCache;
+    int bMemoryErrorOccured = false;
+    void* pData = CPLGetTLSEx(CTLS_VSICURL_CACHEDCONNECTION, &bMemoryErrorOccured);
+    if( bMemoryErrorOccured )
+    {
+        return dummyCache;
+    }
+    if( pData == nullptr)
+    {
+        auto cachedConnection = new std::map<VSICurlFilesystemHandler*, CachedConnection>();
+        CPLSetTLSWithFreeFuncEx( CTLS_VSICURL_CACHEDCONNECTION,
+                                 cachedConnection,
+                                 FreeCachedConnection, &bMemoryErrorOccured );
+        if( bMemoryErrorOccured )
+        {
+            delete cachedConnection;
+            return dummyCache;
+        }
+        return *cachedConnection;
+    }
+    return *static_cast<std::map<VSICurlFilesystemHandler*, CachedConnection>*>(pData);
+}
+#else
+static thread_local std::map<VSICurlFilesystemHandler*, CachedConnection> g_tls_connectionCache;
+static std::map<VSICurlFilesystemHandler*, CachedConnection>& GetConnectionCache()
+{
+    return g_tls_connectionCache;
+}
+#endif
 
 /************************************************************************/
 /*                              clear()                                 */
@@ -2402,7 +2441,7 @@ VSICurlFilesystemHandler::~VSICurlFilesystemHandler()
     VSICurlFilesystemHandler::ClearCache();
     if( !GDALIsInGlobalDestructor() )
     {
-        cachedConnection.erase(this);
+        GetConnectionCache().erase(this);
     }
 
     if( hMutex != nullptr )
@@ -2437,7 +2476,7 @@ bool VSICurlFilesystemHandler::AllowCachedDataFor(const char* pszFilename)
 
 CURLM* VSICurlFilesystemHandler::GetCurlMultiHandleFor(const CPLString& /*osURL*/)
 {
-    auto& conn = cachedConnection[this];
+    auto& conn = GetConnectionCache()[this];
     if( conn.hCurlMultiHandle == nullptr )
     {
         conn.hCurlMultiHandle = curl_multi_init();
@@ -2621,7 +2660,7 @@ void VSICurlFilesystemHandler::ClearCache()
 
     if( !GDALIsInGlobalDestructor() )
     {
-        cachedConnection[this].clear();
+        GetConnectionCache()[this].clear();
     }
 }
 


### PR DESCRIPTION
See https://developercommunity.visualstudio.com/content/problem/124121/thread-local-variables-fail-to-be-initialized-when.html