### PR TITLE
gdal2tiles.py: add remaining resample methods

### DIFF
--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -42,11 +42,11 @@ can publish a picture without proper georeferencing too.
 
 .. option:: -p <PROFILE>, --profile=<PROFILE>
 
-  Tile cutting profile (mercator,geodetic,raster) - default 'mercator' (Google Maps compatible).
+  Tile cutting profile (mercator, geodetic, raster) - default 'mercator' (Google Maps compatible).
 
 .. option:: -r <RESAMPLING>, --resampling=<RESAMPLING>
 
-  Resampling method (average,near,bilinear,cubic,cubicspline,lanczos,antialias) - default 'average'.
+  Resampling method (average, near, bilinear, cubic, cubicspline, lanczos, antialias, mode, max, min, med, q1, q3) - default 'average'.
 
 .. option:: -s <SRS>, --s_srs=<SRS>
 
@@ -114,7 +114,7 @@ Options for generated HTML viewers a la Google Maps
 
 .. option:: -w <WEBVIEWER>, --webviewer=<WEBVIEWER>
 
-  Web viewer to generate (all,google,openlayers,leaflet,none) - default 'all'.
+  Web viewer to generate (all, google, openlayers, leaflet, none) - default 'all'.
 
 .. option:: -t <TITLE>, --title=<TITLE>
 

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -64,7 +64,9 @@ except ImportError:
 
 __version__ = "$Id$"
 
-resampling_list = ('average', 'near', 'bilinear', 'cubic', 'cubicspline', 'lanczos', 'antialias')
+resampling_list = (
+    'average', 'near', 'bilinear', 'cubic', 'cubicspline', 'lanczos',
+    'antialias', 'mode', 'max', 'min', 'med', 'q1', 'q3')
 profile_list = ('mercator', 'geodetic', 'raster')
 webviewer_list = ('all', 'google', 'openlayers', 'leaflet', 'none')
 
@@ -644,6 +646,24 @@ def scale_query_to_tile(dsquery, dstile, tiledriver, options, tilefilename=''):
 
         elif options.resampling == 'lanczos':
             gdal_resampling = gdal.GRA_Lanczos
+
+        elif options.resampling == 'mode':
+            gdal_resampling = gdal.GRA_Mode
+
+        elif options.resampling == 'max':
+            gdal_resampling = gdal.GRA_Max
+
+        elif options.resampling == 'min':
+            gdal_resampling = gdal.GRA_Min
+
+        elif options.resampling == 'med':
+            gdal_resampling = gdal.GRA_Med
+
+        elif options.resampling == 'q1':
+            gdal_resampling = gdal.GRA_Q1
+
+        elif options.resampling == 'q3':
+            gdal_resampling = gdal.GRA_Q3
 
         # Other algorithms are implemented by gdal.ReprojectImage().
         dsquery.SetGeoTransform((0.0, tile_size / float(querysize), 0.0, 0.0, 0.0,


### PR DESCRIPTION
See https://lists.osgeo.org/pipermail/gdal-dev/2019-August/050696.html

Should there be basic tests for the `resample` option in `gdal/autotest/pyscripts/test_gdal2tiles.py`?