### PR TITLE
Replace SWIG Python obj0/swig_obj[0] with version agnostic $self

### DIFF
--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1110,18 +1110,12 @@ static bool CheckNumericDataType(GDALExtendedDataTypeHS* dt)
     }
 
     /* Keep a reference to the VirtualMem object */
-%#if SWIGVERSION >= 0x040000
-%#define obj0 swig_obj[0]
-%#endif
 %#if NPY_API_VERSION >= 0x00000007
-    PyArray_SetBaseObject(ar, obj0);
+    PyArray_SetBaseObject(ar, $self);
 %#else
-    PyArray_BASE(ar) = obj0;
+    PyArray_BASE(ar) = $self;
 %#endif
-    Py_INCREF(obj0);
-%#if SWIGVERSION >= 0x040000
-%#undef obj0
-%#endif
+    Py_INCREF($self);
     Py_DECREF($result);
     $result = (PyObject*) ar;
 }

--- a/gdal/swig/include/python/typemaps_python.i
+++ b/gdal/swig/include/python/typemaps_python.i
@@ -2101,13 +2101,7 @@ DecomposeSequenceOf4DCoordinates( PyObject *seq, int nCount, double *x, double *
   /* %typemap(argout) (void** pptr, size_t* pnsize, GDALDataType* pdatatype, int* preadonly)*/
   Py_buffer *buf=(Py_buffer*)malloc(sizeof(Py_buffer));
 
-  if (PyBuffer_FillInfo(buf,
-%#if SWIGVERSION >= 0x040000
-                        swig_obj[0],
-%#else
-                        obj0,
-%#endif
-                        *($1), *($2), *($4), PyBUF_ND)) {
+  if (PyBuffer_FillInfo(buf, $self, *($1), *($2), *($4), PyBUF_ND)) {
     // error, handle
   }
   if( *($3) == GDT_Byte )


### PR DESCRIPTION
"obj0" was only meant as a porting helper and should not be used, even
with swig 3.0, see swig/swig@cd8fc0a.
Use the correct "$self" notation, which is expanded to the correct
code regardless of swig version and options.