### PR TITLE
SQLITE: fix crash in loading sqlite extensions on ios (fixes #1820)

### DIFF
--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -2590,7 +2590,7 @@ int OGR2SQLITE_static_register (sqlite3 * hDB, char **pzErrMsg, void * _pApi)
 {
     const sqlite3_api_routines * pApi = (const sqlite3_api_routines * )_pApi;
 #ifndef WIN32
-    if( pApi->create_module == nullptr )
+    if( ( pApi == nullptr ) || ( pApi->create_module == nullptr ) )
     {
         pApi = &OGRSQLITE_static_routines;
     }


### PR DESCRIPTION
* OS: iOS 12.4
* Compiler: clang (cross for iOS)
