### PR TITLE
WCS: pass user-supplied progress function to curl HTTP request when u…

### DIFF
--- a/gdal/frmts/wcs/wcsdataset.h
+++ b/gdal/frmts/wcs/wcsdataset.h
@@ -101,6 +101,7 @@ class WCSDataset CPL_NON_FINAL: public GDALPamDataset
                              int nXSize, int nYSize,
                              int nBufXSize, int nBufYSize,
                              int nBandCount, int *panBandList,
+                             GDALRasterIOExtraArg *psExtraArg,
                              CPLHTTPResult **ppsResult );
 
     virtual CPLString   DescribeCoverageRequest() {return "";}

--- a/gdal/frmts/wcs/wcsrasterband.cpp
+++ b/gdal/frmts/wcs/wcsrasterband.cpp
@@ -155,7 +155,7 @@ CPLErr WCSRasterBand::IReadBlock( int nBlockXOff, int nBlockYOff,
                                nBlockXSize * nResFactor,
                                nBlockYSize * nResFactor,
                                nBlockXSize, nBlockYSize,
-                               band_count, &nBand, &psResult );
+                               band_count, &nBand, nullptr, &psResult );
     if( eErr != CE_None )
         return eErr;
 


### PR DESCRIPTION
## What does this PR do?

This is a small patch which passes a user-supplied GDALProgressFunc, if any, to CPLHTTPFetchEx when using DirectRasterIO with WCS. This allows for progress monitoring of potentially large image requests. 

## Environment

* Compiler: MSVC 19.16
