### PR TITLE
mssql: username/password example

### DIFF
--- a/gdal/doc/source/drivers/vector/mssqlspatial.rst
+++ b/gdal/doc/source/drivers/vector/mssqlspatial.rst
@@ -221,3 +221,9 @@ Creating a spatial index
    ::
 
       ogrinfo -sql "create spatial index on rivers" "MSSQL:server=.\MSSQLSERVER2008;database=geodb;trusted_connection=yes"
+
+Connecting with username/password
+
+   ::
+   
+      ogrinfo -al   MSSQL:server=.\MSSQLSERVER2008;database=geodb;trusted_connection=no;UID=user;PWD=pwd


### PR DESCRIPTION
I very often connect to MSSQL using username/password instead of integrated windows authentication. Usage of UID/PWD in the connection string is well documented in the provided link to ODBC connection string parameters. However, I believe an example connection string is useful to GDAL users.

