### PR TITLE
flatgeobuf.rst: Add ogr2ogr example

### DIFF
--- a/gdal/doc/source/drivers/vector/flatgeobuf.rst
+++ b/gdal/doc/source/drivers/vector/flatgeobuf.rst
@@ -39,6 +39,17 @@ Layer Creation Options
 -  **SPATIAL_INDEX=**\ *YES/NO*: Set the YES to create a
    spatial index. Defaults to YES.
 
+Examples
+--------
+-  Simple translation of a single shapefile into a FlatGeobuf file. The file
+   'filename.fgb' will be created with the features from abc.shp and attributes
+   from abc.dbf. The file ``filename.fgb`` must **not** already exist,
+   as it will be created.
+
+   ::
+
+      % ogr2ogr -f FlatGeobuf filename.fgb abc.shp
+
 See Also
 --------
 

--- a/gdal/doc/source/drivers/vector/flatgeobuf.rst
+++ b/gdal/doc/source/drivers/vector/flatgeobuf.rst
@@ -41,6 +41,7 @@ Layer Creation Options
 
 Examples
 --------
+
 -  Simple translation of a single shapefile into a FlatGeobuf file. The file
    'filename.fgb' will be created with the features from abc.shp and attributes
    from abc.dbf. The file ``filename.fgb`` must **not** already exist,


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Adds an example of ogr2ogr usage with FlatGeobuf. It took me a while to figure out that the output file MUST have the `.fgb` extension