### PR TITLE
Openjpeg driver: Memory corruption due to a wrong condition logic

### DIFF
--- a/gdal/frmts/openjpeg/openjpegdataset.cpp
+++ b/gdal/frmts/openjpeg/openjpegdataset.cpp
@@ -529,8 +529,8 @@ void JP2OpenJPEGDataset::JP2OpenJPEGReadBlockInThread(void* userdata)
         return;
     }
 
-    while( (nPair = CPLAtomicInc(&(poJob->nCurPair))) < nPairs ||
-           !poJob->bSuccess )
+    while( (nPair = CPLAtomicInc(&(poJob->nCurPair))) < nPairs &&
+            poJob->bSuccess )
     {
         int nBlockXOff = poJob->oPairs[nPair].first;
         int nBlockYOff = poJob->oPairs[nPair].second;


### PR DESCRIPTION
## What does this PR do?
` while( (nPair = CPLAtomicInc(&(poJob->nCurPair))) < nPairs ||  !poJob->bSuccess )`
The logic allows accessing poJob->oPairs[nPair] even if nPair >=nPairs in case when !poJob->bSuccess is true
Correct logic should continue the cycle if nPair<nPairs and poJob->bSuccess is true. And break the cycle if nPair>=nPairs or poJob->bSuccess is false.
