### PR TITLE
Docs: add Windows binaries available on GISInternals

### DIFF
--- a/gdal/doc/source/download.rst
+++ b/gdal/doc/source/download.rst
@@ -59,8 +59,12 @@ Windows builds are available via `Conda Forge`_ (64-bit only). See the
 
 .. _`Conda Forge`: https://anaconda.org/conda-forge/gdal
 
+Alternatively, [Tamas Szekeres](https://github.com/szekerest) provides packages
+with daily builds of latest stable releases as well as maintenance and
+development branches on his `GISInternals`_ site.
 
-Debian
+.. _`GISInternals`: https://www.gisinternals.com
+
 ................................................................................
 
 Debian packages are now available on `Debian Unstable`_.


### PR DESCRIPTION
## What does this PR do?

Port link from https://trac.osgeo.org/gdal/wiki/DownloadingGdalBinaries to Windows binaries offered by @szekerest 

## Tasklist

 - [ ] All CI builds and checks have passed

