### PR TITLE
Docs: clarify criteria for advertising providers of binary packages

### DIFF
--- a/gdal/doc/source/download.rst
+++ b/gdal/doc/source/download.rst
@@ -48,8 +48,8 @@ command
 Binaries
 ------------------------------------------------------------------------------
 
-In this section we list a number of the binary distributions of GDAL.
-
+In this section we list a number of the binary distributions of GDAL
+all of which should have fully reproducible open source build recipes.
 
 Windows
 ................................................................................
@@ -58,7 +58,6 @@ Windows builds are available via `Conda Forge`_ (64-bit only). See the
 :ref:`conda` section for more detailed information.
 
 .. _`Conda Forge`: https://anaconda.org/conda-forge/gdal
-
 
 Debian
 ................................................................................


### PR DESCRIPTION
## What does this PR do?

The download pages should indicate criteria behind advertising the selection of providers of GDAL binaries; to address potential questions why X is not listed.

## What are related issues/pull requests?

- https://github.com/OSGeo/gdal/pull/1866#discussion_r326299551 and https://github.com/OSGeo/gdal/pull/1866#issuecomment-533248059
- #1641 

## Tasklist

 - [ ] Review
 - [ ] All CI builds and checks have passed

