### PR TITLE
Proxy pool: Load band block sizes if not provided at creation time.

### DIFF
--- a/gdal/frmts/prf/phprfdataset.cpp
+++ b/gdal/frmts/prf/phprfdataset.cpp
@@ -134,7 +134,9 @@ bool PhPrfDataset::AddTile( const char* pszPartName, GDALAccess eAccessType,
             return false;
         }
 
-        //! \todo What reason for nBlockXSize&nBlockYSize passed to AddSrcBandDescription
+        // Block sizes (nBlockXSize&nBlockYSize) passed as zeros.
+        // They will be loaded when RefUnderlyingRasterBand
+        // function is called on first open of tile's dataset 'poTileDataset'.
         poTileDataset->AddSrcBandDescription(poBand->GetRasterDataType(), 0, 0);
         GDALRasterBand* poTileBand = poTileDataset->GetRasterBand( nBand );
 

--- a/gdal/gcore/gdal_proxy.h
+++ b/gdal/gcore/gdal_proxy.h
@@ -252,6 +252,11 @@ class CPL_DLL GDALProxyPoolDataset : public GDALProxyDataset
     ~GDALProxyPoolDataset() override;
 
     void SetOpenOptions( char** papszOpenOptions );
+
+    // If size (nBlockXSize&nBlockYSize) parameters is zero
+    // they will be loaded when RefUnderlyingRasterBand function is called.
+    // But in this case we cannot use them in other non-virtual methods before
+    // RefUnderlyingRasterBand fist call.
     void AddSrcBandDescription( GDALDataType eDataType, int nBlockXSize,
                                 int nBlockYSize );
 

--- a/gdal/gcore/gdalproxypool.cpp
+++ b/gdal/gcore/gdalproxypool.cpp
@@ -1134,6 +1134,17 @@ GDALRasterBand* GDALProxyPoolRasterBand::RefUnderlyingRasterBand(bool bForceOpen
     {
         (cpl::down_cast<GDALProxyPoolDataset*>(poDS))->UnrefUnderlyingDataset(poUnderlyingDataset);
     }
+    else
+    if(nBlockXSize <= 0 || nBlockYSize <= 0)
+    {
+        // Here we try to load nBlockXSize&nBlockYSize from underlying band
+        // but we must guarantee that we will not access directly to
+        // nBlockXSize/nBlockYSize before RefUnderlyingRasterBand() is called
+        int nSrcBlockXSize, nSrcBlockYSize;
+        poBand->GetBlockSize(&nSrcBlockXSize, &nSrcBlockYSize);
+        nBlockXSize = nSrcBlockXSize;
+        nBlockYSize = nSrcBlockYSize;
+    }
 
     return poBand;
 }


### PR DESCRIPTION
Fixes floating point exception on copy overviews from PRF dataset to destination dataset.
Sample command line:
```
gdal_translate \
-co COPY_SRC_OVERVIEWS=YES \
-of GTiff ./input.prf ./output.tif
```
Error occurs when passing zero block dimensions at the PRF driver ([see: phprfdataset.cpp:138](https://github.com/drons/gdal/blob/fixCoreDumpOnZeroBlockSize/gdal/frmts/prf/phprfdataset.cpp#L138) ).
