### PR TITLE
FlatGeobuf: constify and pass more arguments by reference in PackedRTree and Rect classes

### DIFF
--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/packedrtree.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/packedrtree.cpp
@@ -3,7 +3,7 @@
 namespace FlatGeobuf
 {
 
-void Rect::expand(Rect r)
+void Rect::expand(const Rect& r)
 {
     if (r.minX < minX) minX = r.minX;
     if (r.minY < minY) minY = r.minY;
@@ -21,7 +21,7 @@ Rect Rect::createInvertedInfiniteRect()
     };
 }
 
-bool Rect::intersects(Rect r) const
+bool Rect::intersects(const Rect& r) const
 {
     if (maxX < r.minX) return false;
     if (maxY < r.minY) return false;
@@ -85,7 +85,7 @@ uint32_t hilbert(uint32_t x, uint32_t y)
     return value;
 }
 
-uint32_t hilbert(Rect r, uint32_t hilbertMax, Rect extent)
+uint32_t hilbert(const Rect& r, uint32_t hilbertMax, const Rect& extent)
 {
     uint32_t x = static_cast<uint32_t>(floor(hilbertMax * ((r.minX + r.maxX) / 2 - extent.minX) / extent.width()));
     uint32_t y = static_cast<uint32_t>(floor(hilbertMax * ((r.minY + r.maxY) / 2 - extent.minY) / extent.height()));
@@ -108,16 +108,16 @@ void hilbertSort(std::vector<std::shared_ptr<Item>> &items)
     });
 }
 
-Rect calcExtent(std::vector<Rect> &rects)
+Rect calcExtent(const std::vector<Rect> &rects)
 {
-    Rect extent = std::accumulate(rects.begin(), rects.end(), Rect::createInvertedInfiniteRect(), [] (Rect a, Rect b) {
+    Rect extent = std::accumulate(rects.begin(), rects.end(), Rect::createInvertedInfiniteRect(), [] (Rect a, const Rect& b) {
         a.expand(b);
         return a;
     });
     return extent;
 }
 
-Rect calcExtent(std::vector<std::shared_ptr<Item>> &rectitems)
+Rect calcExtent(const std::vector<std::shared_ptr<Item>> &rectitems)
 {
     Rect extent = std::accumulate(rectitems.begin(), rectitems.end(), Rect::createInvertedInfiniteRect(), [] (Rect a, std::shared_ptr<Item> b) {
         a.expand(b->rect);
@@ -129,7 +129,7 @@ Rect calcExtent(std::vector<std::shared_ptr<Item>> &rectitems)
 void hilbertSort(std::vector<Rect> &items)
 {
     Rect extent = calcExtent(items);
-    std::sort(items.begin(), items.end(), [&extent] (Rect a, Rect b) {
+    std::sort(items.begin(), items.end(), [&extent] (const Rect& a, const Rect& b) {
         uint32_t ha = hilbert(a, hilbertMax, extent);
         uint32_t hb = hilbert(b, hilbertMax, extent);
         return ha > hb;
@@ -200,7 +200,7 @@ void PackedRTree::fromData(const void *data)
         _indices[i] = *pi++;
 }
 
-static std::vector<Rect> convert(std::vector<std::shared_ptr<Item>> &items)
+static std::vector<Rect> convert(const std::vector<std::shared_ptr<Item>> &items)
 {
     std::vector<Rect> rects;
     for (const std::shared_ptr<Item> item: items)
@@ -208,7 +208,7 @@ static std::vector<Rect> convert(std::vector<std::shared_ptr<Item>> &items)
     return rects;
 }
 
-PackedRTree::PackedRTree(std::vector<std::shared_ptr<Item>> &items, Rect extent, const uint16_t nodeSize) :
+PackedRTree::PackedRTree(const std::vector<std::shared_ptr<Item>> &items, const Rect& extent, const uint16_t nodeSize) :
     _extent(extent),
     _rects(convert(items)),
     _numItems(_rects.size())
@@ -217,7 +217,7 @@ PackedRTree::PackedRTree(std::vector<std::shared_ptr<Item>> &items, Rect extent,
     generateNodes();
 }
 
-PackedRTree::PackedRTree(std::vector<Rect> &rects, Rect extent, const uint16_t nodeSize) :
+PackedRTree::PackedRTree(const std::vector<Rect> &rects, const Rect& extent, const uint16_t nodeSize) :
     _extent(extent),
     _rects(rects),
     _numItems(_rects.size())
@@ -264,7 +264,7 @@ std::vector<uint64_t> PackedRTree::search(double minX, double minY, double maxX,
 }
 
 std::vector<uint64_t> PackedRTree::streamSearch(
-    const uint64_t numItems, const uint16_t nodeSize, Rect r,
+    const uint64_t numItems, const uint16_t nodeSize, const Rect& r,
     const std::function<void(uint8_t *, size_t, size_t)> &readNode)
 {
     auto levelBounds = generateLevelBounds(numItems, nodeSize);

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/packedrtree.h
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/packedrtree.h
@@ -13,15 +13,15 @@ struct Rect {
     double minY;
     double maxX;
     double maxY;
-    double width() { return maxX - minX; }
-    double height() { return maxY - minY; }
-    static Rect sum(Rect a, Rect b) {
+    double width() const { return maxX - minX; }
+    double height() const { return maxY - minY; }
+    static Rect sum(Rect a, const Rect& b) {
         a.expand(b);
         return a;
     }
     static Rect createInvertedInfiniteRect();
-    void expand(Rect r);
-    bool intersects(Rect r) const;
+    void expand(const Rect& r);
+    bool intersects(const Rect& r) const;
     std::vector<double> toVector();
 };
 
@@ -32,11 +32,11 @@ struct Item {
 std::ostream& operator << (std::ostream& os, Rect const& value);
 
 uint32_t hilbert(uint32_t x, uint32_t y);
-uint32_t hilbert(Rect r, uint32_t hilbertMax, Rect extent);
+uint32_t hilbert(const Rect& r, uint32_t hilbertMax, const Rect& extent);
 void hilbertSort(std::vector<std::shared_ptr<Item>> &items);
 void hilbertSort(std::vector<Rect> &items);
-Rect calcExtent(std::vector<std::shared_ptr<Item>> &rectitems);
-Rect calcExtent(std::vector<Rect> &rects);
+Rect calcExtent(const std::vector<std::shared_ptr<Item>> &rectitems);
+Rect calcExtent(const std::vector<Rect> &rects);
 
 /**
  * Packed R-Tree
@@ -57,12 +57,12 @@ class PackedRTree {
     void generateNodes();
     void fromData(const void *data);
 public:
-    PackedRTree(std::vector<std::shared_ptr<Item>> &items, Rect extent, const uint16_t nodeSize = 16);
-    PackedRTree(std::vector<Rect> &rects, Rect extent, const uint16_t nodeSize = 16);
+    PackedRTree(const std::vector<std::shared_ptr<Item>> &items, const Rect& extent, const uint16_t nodeSize = 16);
+    PackedRTree(const std::vector<Rect> &rects, const Rect& extent, const uint16_t nodeSize = 16);
     PackedRTree(const void *data, const uint64_t numItems, const uint16_t nodeSize = 16);
     std::vector<uint64_t> search(double minX, double minY, double maxX, double maxY) const;
     static std::vector<uint64_t> streamSearch(
-        const uint64_t numItems, const uint16_t nodeSize, Rect r,
+        const uint64_t numItems, const uint16_t nodeSize, const Rect& r,
         const std::function<void(uint8_t *, size_t, size_t)> &readNode);
     uint64_t size() const;
     static uint64_t size(const uint64_t numItems, const uint16_t nodeSize = 16);


### PR DESCRIPTION
CC @bjornharrtell 

I haven't tested the performance impact. Passing by reference could possibly speed up things a tiny bit, but not sure that's measurable in practice.