### PR TITLE
Doc: add examples commandline programs

### DIFF
--- a/gdal/doc/source/drivers/vector/csv.rst
+++ b/gdal/doc/source/drivers/vector/csv.rst
@@ -388,6 +388,18 @@ Examples
 
       ogr2ogr -f CSV -dialect sqlite -sql "select AsGeoJSON(geometry) AS geom, * from input" output.csv input.shp
 
+- Convert a CSV into a GeoPackage. Specify the names of the coordinate columns and assign a coordinate reference system.
+
+   ::
+
+     ogr2ogr \
+       -f GPKG output.gpkg \
+       input.csv \
+       -oo X_POSSIBLE_NAMES=longitude \
+       -oo Y_POSSIBLE_NAMES=latitude \
+       -a_srs 'EPSG:4326'
+
+
 Particular datasources
 ----------------------
 

--- a/gdal/doc/source/drivers/vector/pg.rst
+++ b/gdal/doc/source/drivers/vector/pg.rst
@@ -268,6 +268,41 @@ Examples
               gltp:/vrf/usr4/mpp1/v0eur/vmaplv0/eurnasia \
               -lco OVERWRITE=yes -nln polbndl_bnd 'polbndl@bnd(*)_line'
 
+- Export a single Postgres table to GeoPackage:
+
+   ::
+
+     ogr2ogr \
+       -f GPKG output.gpkg \
+       PG:dbname="my_database" "my_table"
+
+- Export many Postgres tables to GeoPackage:
+
+   ::
+
+     ogr2ogr \
+       -f GPKG output.gpkg \
+       PG:'dbname=my_database tables=table_1,table_3'
+
+- Export a whole Postgres database to GeoPackage:
+
+   ::
+
+     ogr2ogr \
+       -f GPKG output.gpkg \
+       PG:dbname=my_database
+
+
+- Load a single layer GeoPackage into Postgres:
+
+   ::
+
+     ogr2ogr \
+       -f "PostgreSQL" PG:dbname="my_database" \
+       input.gpkg \
+       -nln "name_of_new_table"
+
+
 -  In this example we merge tiger line data from two different
    directories of tiger files into one table. Note that the second
    invocation uses -append and no OVERWRITE=yes.

--- a/gdal/doc/source/drivers/vector/sqlite.rst
+++ b/gdal/doc/source/drivers/vector/sqlite.rst
@@ -390,6 +390,26 @@ and optimize it.
 
    ogrinfo db.sqlite -sql "VACUUM"
 
+
+Example
+-------
+
+- Convert a non-spatial SQLite table into a GeoPackage:
+
+.. code-block::
+
+  ogr2ogr \
+    -f "GPKG" output.gpkg \
+    input.sqlite \
+    -sql \
+    "SELECT
+       *,
+       MakePoint(longitude, latitude, 4326) AS geometry
+     FROM
+       my_table" \
+    -nln "location" \
+    -s_srs "EPSG:4326"
+
 Credits
 -------
 

--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -136,3 +136,13 @@ Options for generated HTML viewers a la Google Maps
 .. note::
 
     gdal2tiles.py is a Python script that needs to be run against Python GDAL binding.
+
+
+Examples
+--------
+
+Basic example:
+
+.. code-block::
+
+  gdal2tiles.py --zoom=2-5 input.tif output_folder

--- a/gdal/doc/source/programs/gdalwarp.rst
+++ b/gdal/doc/source/programs/gdalwarp.rst
@@ -334,6 +334,13 @@ a temporary file.
 Examples
 --------
 
+- Basic transformation:
+
+::
+
+  gdalwarp -t_srs EPSG:4326 input.tif output.tif
+
+
 - For instance, an eight bit spot scene stored in GeoTIFF with
   control points mapping the corners to lat/long could be warped to a UTM
   projection with a command like this:

--- a/gdal/doc/source/programs/ogr2ogr.rst
+++ b/gdal/doc/source/programs/ogr2ogr.rst
@@ -444,11 +444,49 @@ This utility is also callable from C with :cpp:func:`GDALVectorTranslate`.
 Examples
 --------
 
+Basic conversion from Shapefile to GeoPackage:
+
+.. code-block::
+
+  ogr2ogr \
+    -f GPKG output.gpkg \
+    input.shp
+
+Change the coordinate reference system from ``EPSG:4326`` to ``EPSG:3857``:
+
+.. code-block::
+
+  ogr2ogr \
+    -s_srs EPSG:4326 \
+    -t_srs EPSG:3857 \
+    -f GPKG output.gpkg \
+    input.gpkg
+
 Example appending to an existing layer (both ``-update`` and ``-append`` flags need to be used):
 
 .. code-block::
 
     ogr2ogr -update -append -f PostgreSQL PG:dbname=warmerda abc.tab
+
+Clip input layer with a bounding box (<xmin> <ymin> <xmax> <ymax>):
+
+.. code-block::
+
+  ogr2ogr \
+    -spat -13.931 34.886 46.23 74.12 \
+    -f GPKG output.gpkg \
+    natural_earth_vector.gpkg
+
+Filter Features by a ``-where`` clause:
+
+.. code-block::
+
+  ogr2ogr \
+    -where "\"POP_EST\" < 1000000" \
+    -f GPKG output.gpkg \
+    natural_earth_vector.gpkg \
+    ne_10m_admin_0_countries
+
 
 Example reprojecting from ETRS_1989_LAEA_52N_10E to EPSG:4326 and clipping to a bounding box:
 

--- a/gdal/doc/source/programs/ogrinfo.rst
+++ b/gdal/doc/source/programs/ogrinfo.rst
@@ -184,6 +184,40 @@ Example reporting all layers in an NTF file:
     # 3: BL2000_COLLECTIONS (None)
     # 4: FEATURE_CLASSES (None)
 
+Example of retrieving a summary (``-so``) of a layer without showing details about every single feature.
+
+.. code-block::
+
+    ogrinfo \
+      -so \
+      natural_earth_vector.gpkg \
+      ne_10m_admin_0_antarctic_claim_limit_lines
+
+      # INFO: Open of `natural_earth_vector.gpkg'
+      #      using driver `GPKG' successful.
+
+      # Layer name: ne_10m_admin_0_antarctic_claim_limit_lines
+      # Geometry: Line String
+      # Feature Count: 23
+      # Extent: (-150.000000, -90.000000) - (160.100000, -60.000000)
+      # Layer SRS WKT:
+      # GEOGCS["WGS 84",
+      #     DATUM["WGS_1984",
+      #         SPHEROID["WGS 84",6378137,298.257223563,
+      #             AUTHORITY["EPSG","7030"]],
+      #         AUTHORITY["EPSG","6326"]],
+      #     PRIMEM["Greenwich",0,
+      #         AUTHORITY["EPSG","8901"]],
+      #     UNIT["degree",0.0174532925199433,
+      #         AUTHORITY["EPSG","9122"]],
+      #     AUTHORITY["EPSG","4326"]]
+      # FID Column = fid
+      # Geometry Column = geom
+      # type: String (15.0)
+      # scalerank: Integer (0.0)
+      # featurecla: String (50.0)
+
+
 Example using an attribute query is used to restrict the output of the features
 in a layer:
 


### PR DESCRIPTION
# What does this PR do?

It adds some examples to the command line programs `ogr2ogr`, `ogrinfo`, `gdal2tiles` and `gdalwarp`. Also inside the drivers `pg`, `csv` and `sqlite`. 

I find the existing examples rather complex, therefore I added some rather simple examples. The idea behind it is to make it easier for new users to get started with the GDAL/OGR command line tools. 


