### PR TITLE
Transform MAX_OBJECT_SIZE to runtime environment option - OGR_GEOJSON…

### DIFF
--- a/gdal/doc/source/drivers/vector/geojson.rst
+++ b/gdal/doc/source/drivers/vector/geojson.rst
@@ -148,6 +148,8 @@ Environment variables
    geometries: YES - wrap geometries with OGRGeometryCollection type
 -  **ATTRIBUTES_SKIP** - controls translation of attributes: YES - skip
    all attributes
+-  **OGR_GEOJSON_MAX_OBJ_SIZE** - (GDAL >= 3.0.2) size in MBytes of the maximum
+   accepted single feature, default value is 200MB
 
 Open options
 ------------


### PR DESCRIPTION
Would it be possible to consider this pull request for transforming MAX_OBJECT_SIZE in the GeoJSON driver to a runtime option?
For me this is a major breakage when upgrading from Debian 9 (GDAL 2.1) to Debian 10 (GDAL 2.4). In GDAL 2.1 GeoJSON objects were limited only by the available memory. In fact, I think it would be impossible to have a hard-coded value that works for both the notebook users and the big iron. I agree that GeoJSON is a horrible format that should not be used for applications meant to scale, but we need at least some way of importing this data.