### PR TITLE
Fix --with-proj in autoconf on Linux

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -32223,7 +32223,11 @@ fi
     if test "$NETCDF_SETTING" = "yes" ; then
       EXTRA_INCLUDES="-I$NETCDF_INCLUDEDIR $EXTRA_INCLUDES"
       NETCDF_ROOT=$NETCDF_PREFIX
-      LIBS="$NETCDF_LIBS $LIBS"
+      if test "$with_netcdf" = "yes" -o "$with_netcdf" = "" ; then
+        LIBS="$LIBS $NETCDF_LIBS"
+      else
+        LIBS="$NETCDF_LIBS $LIBS"
+      fi
     fi
 
 
@@ -38747,7 +38751,7 @@ if test "${HAVE_GEOS}" = "yes" ; then
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: Using C API from GEOS $GEOS_VERSION" >&5
 $as_echo "$as_me: Using C API from GEOS $GEOS_VERSION" >&6;}
-  LIBS="${GEOS_LIBS} ${LIBS}"
+  LIBS="${LIBS} ${GEOS_LIBS}"
   HAVE_GEOS_RESULT="yes"
 fi
 

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -2900,7 +2900,11 @@ else
     if test "$NETCDF_SETTING" = "yes" ; then
       EXTRA_INCLUDES="-I$NETCDF_INCLUDEDIR $EXTRA_INCLUDES"
       NETCDF_ROOT=$NETCDF_PREFIX
-      LIBS="$NETCDF_LIBS $LIBS"
+      if test "$with_netcdf" = "yes" -o "$with_netcdf" = "" ; then
+        LIBS="$LIBS $NETCDF_LIBS"
+      else
+        LIBS="$NETCDF_LIBS $LIBS"
+      fi
     fi
 
 dnl previous behaviour without nc-config
@@ -4537,7 +4541,7 @@ HAVE_GEOS_RESULT="no"
 if test "${HAVE_GEOS}" = "yes" ; then
 
   AC_MSG_NOTICE([Using C API from GEOS $GEOS_VERSION])
-  LIBS="${GEOS_LIBS} ${LIBS}"
+  LIBS="${LIBS} ${GEOS_LIBS}"
   HAVE_GEOS_RESULT="yes"
 fi
 


### PR DESCRIPTION
Currently --with-proj is broken on Linux if one has proj4 installed in the default location
The system proj4 is usually in the same directory as netcdf and geos and these will insert that directory before the --with-proj= directory
configure will use libproj6 when checking and then libtool will miserably fail trying to link with libproj4
As most people that will be building gdal 3.x from source will be building with a custom proj6 library and against the system libraries for everything else, this can be a serious problem

I am not an autoconf expert and it is possible that I broke another platform, maybe the GDAL autoconf expert should look into this issue
