### PR TITLE
OGR GeoJSON driver: transform MAX_OBJECT_SIZE to a runtime environment option

### DIFF
--- a/gdal/doc/source/drivers/vector/geojson.rst
+++ b/gdal/doc/source/drivers/vector/geojson.rst
@@ -148,6 +148,8 @@ Environment variables
    geometries: YES - wrap geometries with OGRGeometryCollection type
 -  **ATTRIBUTES_SKIP** - controls translation of attributes: YES - skip
    all attributes
+-  **OGR_GEOJSON_MAX_OBJ_SIZE** - (GDAL >= 3.0.2) size in MBytes of the maximum
+   accepted single feature, default value is 200MB
 
 Open options
 ------------


### PR DESCRIPTION
This PR adds a new runtime environment option OGR_GEOJSON_MAX_OBJ_SIZE allowing to specify a higher memory limit for a single GeoJSON feature
Value in MBytes, default is still 200MB