### PR TITLE
MITAB: Update WindowsLatin2 definition

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -544,7 +544,7 @@ static const char* const apszCharsets[][2] = {
     { "ISO8859_9", "ISO-8859-9" }, //ISO 8859-9 (UNIX)
     { "PackedEUCJapaese", "EUC-JP" }, //UNIX, standard Japanese implementation.
     { "WindowsLatin1", "CP1252" },
-    { "WindowsLatin2", "" },
+    { "WindowsLatin2", "CP1250" },
     { "WindowsArabic", "CP1256" },
     { "WindowsCyrillic", "CP1251" },
     { "WindowsGreek", "CP1253" },


### PR DESCRIPTION
Update mitab_imapinfofile.cpp WindowsLatin2 definition for WindowsLatin2 to {"WindowsLatin2", "CP1250"} (fixes #1571)