### PR TITLE
gcore: fix resampling over nodata blocks (fixes #1941)

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -850,26 +850,23 @@ def test_rasterio_nodata():
 	try:
 		from osgeo import gdalnumeric
 		gdalnumeric.zeros
-		import numpy
 	except (ImportError, AttributeError):
 		pytest.skip()
 
-        ndv = 123
-        btype = [ gdal.GDT_Byte, gdal.GDT_Int16, gdal.GDT_Int32, gdal.GDT_Float32, gdal.GDT_Float64 ]
+	ndv = 123
+	btype = [ gdal.GDT_Byte, gdal.GDT_Int16, gdal.GDT_Int32, gdal.GDT_Float32, gdal.GDT_Float64 ]
 
-        ### create a MEM dataset
-        for src_type in btype:
-                mem_ds = gdal.GetDriverByName('MEM').Create('', 10, 9, 1, src_type)
-                mem_ds.GetRasterBand(1).SetNoDataValue(ndv)
-                mem_ds.GetRasterBand(1).Fill(ndv)
+	### create a MEM dataset
+	for src_type in btype:
+		mem_ds = gdal.GetDriverByName('MEM').Create('', 10, 9, 1, src_type)
+		mem_ds.GetRasterBand(1).SetNoDataValue(ndv)
+		mem_ds.GetRasterBand(1).Fill(ndv)
 
-                for dst_type in btype:
-                        if ( dst_type > src_type ):
-
-                                ### read to a buffer of a wider type (and resample)
-                                data = mem_ds.GetRasterBand(1).ReadAsArray(0, 0, 10, 9, 4, 3, resample_alg=gdal.GRIORA_Bilinear, buf_type=dst_type)
-                                assert int(data[0,0]) == ndv, 'did not read expected band data via ReadAsArray() - src type -> dst type: ' + str( src_type ) + ' -> ' + str( dst_type )
-
+		for dst_type in btype:
+			if ( dst_type > src_type ):
+				### read to a buffer of a wider type (and resample)
+				data = mem_ds.GetRasterBand(1).ReadAsArray(0, 0, 10, 9, 4, 3, resample_alg=gdal.GRIORA_Bilinear, buf_type=dst_type)
+				assert int(data[0,0]) == ndv, 'did not read expected band data via ReadAsArray() - src type -> dst type: ' + str( src_type ) + ' -> ' + str( dst_type )
 
 
 ###############################################################################

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -847,6 +847,13 @@ cellsize     0
 
 def test_rasterio_nodata():
 
+	try:
+		from osgeo import gdalnumeric
+		gdalnumeric.zeros
+		import numpy
+	except (ImportError, AttributeError):
+		pytest.skip()
+
         ndv = 123
         btype = [ gdal.GDT_Byte, gdal.GDT_Int16, gdal.GDT_Int32, gdal.GDT_Float32, gdal.GDT_Float64 ]
 

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -845,6 +845,27 @@ cellsize     0
 
 ###############################################################################
 
+def test_rasterio_nodata():
+
+        ndv = 123
+        btype = [ gdal.GDT_Byte, gdal.GDT_Int16, gdal.GDT_Int32, gdal.GDT_Float32, gdal.GDT_Float64 ]
+
+        ### create a MEM dataset
+        for src_type in btype:
+                mem_ds = gdal.GetDriverByName('MEM').Create('', 10, 9, 1, src_type)
+                mem_ds.GetRasterBand(1).SetNoDataValue(ndv)
+                mem_ds.GetRasterBand(1).Fill(ndv)
+
+                for dst_type in btype:
+                        if ( dst_type > src_type ):
+
+                                ### read to a buffer of a wider type (and resample)
+                                data = mem_ds.GetRasterBand(1).ReadAsArray(0, 0, 10, 9, 4, 3, resample_alg=gdal.GRIORA_Bilinear, buf_type=dst_type)
+                                assert int(data[0,0]) == ndv, 'did not read expected band data via ReadAsArray() - src type -> dst type: ' + str( src_type ) + ' -> ' + str( dst_type )
+
+
+
+###############################################################################
 
 def test_rasterio_lanczos_nodata():
 

--- a/gdal/gcore/rasterio.cpp
+++ b/gdal/gcore/rasterio.cpp
@@ -1227,10 +1227,10 @@ CPLErr GDALRasterBand::RasterIOResampled(
                             {
                                 GDALCopyWords(
                                     &fNoDataValue, GDT_Float32, 0,
-                                    static_cast<GByte*>(pData) +
-                                    nLineSpace * (j + nDstYOff) +
-                                    nDstXOff * nPixelSpace,
-                                    eBufType, static_cast<int>(nPixelSpace),
+                                    static_cast<GByte*>(pDataMem) +
+                                    nLSMem * (j + nDstYOff) +
+                                    nDstXOff * nPSMem,
+                                    eDTMem, static_cast<int>(nPSMem),
                                     nDstXCount);
                             }
                             bSkipResample = true;


### PR DESCRIPTION
gcore: fix resampling over nodata blocks (fixes #1941)

This fixes GDALRasterBand::RasterIOResampled when dealing with interpolation over nodata blocks if the input buffer type differs from output buffer type.



