### PR TITLE
JP2KAK: fix issue with multi-threaded reads

### DIFF
--- a/gdal/frmts/jp2kak/jp2kakdataset.cpp
+++ b/gdal/frmts/jp2kak/jp2kakdataset.cpp
@@ -1329,11 +1329,11 @@ JP2KAKDataset::DirectRasterIO( GDALRWFlag /* eRWFlag */,
             wrk_jp2_src.open(&wrk_family);
             wrk_jp2_src.read_header();
 
-            oWCodeStream.create(&wrk_jp2_src);
+            oWCodeStream.create(&wrk_jp2_src, poThreadEnv);
         }
         else
         {
-            oWCodeStream.create(&subfile_src);
+            oWCodeStream.create(&subfile_src, poThreadEnv);
         }
 
         if( bFussy )


### PR DESCRIPTION
Concurrently decoding from multiple jp2 files results in an error being raised:

 

>  ERROR 1: Kakadu Core Error:
>  Multi-threaded implementation error detected.  Before passing a `kdu_thread_env' reference into any 
>  of the `kdu_codestream' machinery's interface functions you need to pass a `kdu_thread_env' 
>  reference into one of the top-level interface functions that configures the codestream for multi- 
>  threaded processing.  The main functions of this form are `kdu_codestream::create' and 
>  `kdu_codestream::open_tile', although there are others which can see a `kdu_thread_env' 
>  environment for the first time.


I have not digged deep into the issue, but the proposed patch fixes that error.