### PR TITLE
gdal2tiles: warn when input raster has non-Byte data type (fixes #1956)

### DIFF
--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -38,6 +38,13 @@ SuperOverlay), in case the supplied map uses EPSG:4326 projection.
 World files and embedded georeferencing is used during tile generation, but you
 can publish a picture without proper georeferencing too.
 
+.. note::
+
+    Inputs with non-Byte data type (i.e. ``Int16``, ``UInt16``,...) will be clamped to
+    the ``Byte`` data type, causing wrong results. To awoid this it is necessary to
+    rescale input to the ``Byte`` data type using `gdal_translate` utility.
+
+
 .. program:: gdal_translate
 
 .. option:: -p <PROFILE>, --profile=<PROFILE>

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -1477,6 +1477,15 @@ class GDAL2Tiles(object):
                 "gdal2tiles temp.vrt" % self.input_file
             )
 
+        if input_dataset.GetRasterBand(1).DataType != gdal.GDT_Byte:
+            exit_with_error(
+                "Please convert this file to 8-bit and run gdal2tiles on the result.",
+                "To scale pixel values you can use:\n"
+                "gdal_translate -of VRT -ot Byte -scale %s temp.vrt\n"
+                "then run:\n"
+                "gdal2tiles temp.vrt" % self.input_file
+            )
+
         in_nodata = setup_no_data_values(input_dataset, self.options)
 
         if self.options.verbose:
@@ -2886,7 +2895,7 @@ def multi_threaded_tiling(input_file, output_folder, options):
 
     if options.verbose:
         print("Tiles details calc complete.")
-        
+
     if not options.verbose and not options.quiet:
         progress_bar = ProgressBar(len(tile_details))
         progress_bar.start()


### PR DESCRIPTION
## What does this PR do?

Add a warning when `gdal2tiles.py` input is a raster with non-Byte data type. Also add note to the documentation.

## What are related issues/pull requests?

Fixes #1956