### PR TITLE
Bindings: OGR: SRS: add C-wrappers and SWIG bindings for `{Set,Get}Extension` functions

### DIFF
--- a/gdal/ogr/ogr_srs_api.h
+++ b/gdal/ogr/ogr_srs_api.h
@@ -569,6 +569,16 @@ OGRErr CPL_DLL OSRSetTOWGS84( OGRSpatialReferenceH hSRS,
                               double, double, double, double );
 OGRErr CPL_DLL OSRGetTOWGS84( OGRSpatialReferenceH hSRS, double *, int );
 
+const char * CPL_DLL OSRGetExtension( OGRSpatialReferenceH hSRS,
+                                      const char *pszTargetKey,
+                                      const char *pszName,
+                                      const char *pszDefault /* = NULL */ );
+
+OGRErr CPL_DLL OSRSetExtension( OGRSpatialReferenceH hSRS,
+                                const char *pszTargetKey,
+                                const char *pszName,
+                                const char *pszValue );
+
 OGRErr CPL_DLL OSRSetCompoundCS( OGRSpatialReferenceH hSRS,
                                  const char *pszName,
                                  OGRSpatialReferenceH hHorizSRS,

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -8986,6 +8986,26 @@ const char *OGRSpatialReference::GetExtension( const char *pszTargetKey,
 }
 
 /************************************************************************/
+/*                           OSRGetExtension()                          */
+/************************************************************************/
+
+/**
+ * \brief Fetch extension value.
+ *
+ * This function is the same as OGRSpatialReference::GetExtension().
+ */
+const char *OSRGetExtension( OGRSpatialReferenceH hSRS,
+                             const char *pszTargetKey,
+                             const char *pszName,
+                             const char *pszDefault )
+
+{
+    VALIDATE_POINTER1( hSRS, "OSRGetExtension", nullptr );
+
+    return ToPointer(hSRS)->GetExtension( pszTargetKey, pszName, pszDefault);
+}
+
+/************************************************************************/
 /*                            SetExtension()                            */
 /************************************************************************/
 /**
@@ -9047,6 +9067,26 @@ OGRErr OGRSpatialReference::SetExtension( const char *pszTargetKey,
     poNode->AddChild( poAuthNode );
 
     return OGRERR_NONE;
+}
+
+/************************************************************************/
+/*                           OSRSetExtension()                          */
+/************************************************************************/
+
+/**
+ * \brief Set extension value.
+ *
+ * This function is the same as OGRSpatialReference::SetExtension().
+ */
+OGRErr OSRSetExtension( OGRSpatialReferenceH hSRS,
+                        const char *pszTargetKey,
+                        const char *pszName,
+                        const char *pszValue )
+
+{
+    VALIDATE_POINTER1( hSRS, "OSRSetExtension", OGRERR_FAILURE );
+
+    return ToPointer(hSRS)->SetExtension( pszTargetKey, pszName, pszValue);
 }
 
 /************************************************************************/

--- a/gdal/swig/include/osr.i
+++ b/gdal/swig/include/osr.i
@@ -924,6 +924,18 @@ public:
     return OSRGetTOWGS84( self, argout, 7 );
   }
 
+  OGRErr SetExtension( const char *pszTargetKey,
+                       const char *pszName,
+                       const char *pszValue) {
+    return OSRSetExtension( self, pszTargetKey, pszName, pszValue);
+  }
+
+  const char * GetExtension( const char *pszTargetKey,
+                             const char *pszName,
+                             const char *pszDefault) {
+    return OSRGetExtension( self, pszTargetKey, pszName, pszDefault);
+  }
+
   OGRErr SetLocalCS( const char *pszName ) {
     return OSRSetLocalCS( self, pszName );
   }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->
### Summary
Add C-wrappers and SWIG bindings for `{Set,Get}Extension` functions.

I didn't found C-wrappers for these functions and decided to create them by my own. I hope it will be helpful for users. 

I'd like to get your review, please, tell me if there is something to improve in this PR.
