### PR TITLE
osgeo/__init__.py: add hint&workaround for ImportError on Windows Python >= 3.8

### DIFF
--- a/gdal/swig/python/osgeo/__init__.py
+++ b/gdal/swig/python/osgeo/__init__.py
@@ -1,7 +1,14 @@
 # __init__ for osgeo package.
 
 # making the osgeo package version the same as the gdal version:
-from sys import version_info
+from sys import platform, version_info
+if version_info >= (3, 8, 0) and platform == 'win32':
+    import os
+    if 'USE_PATH_FOR_GDAL_PYTHON' in os.environ and 'PATH' in os.environ:
+        for p in os.environ['PATH'].split(';'):
+            if p:
+                os.add_dll_directory(p)
+
 if version_info >= (2, 6, 0):
     def swig_import_helper():
         from os.path import dirname
@@ -15,6 +22,19 @@ if version_info >= (2, 6, 0):
         if fp is not None:
             try:
                 _mod = imp.load_module('_gdal', fp, pathname, description)
+            except ImportError as e:
+                if version_info >= (3, 8, 0) and platform == 'win32':
+                    import os
+                    if not 'USE_PATH_FOR_GDAL_PYTHON' in os.environ:
+                        msg = 'On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.\n'
+                        msg += 'If gdalXXX.dll is in the PATH, then set the USE_PATH_FOR_GDAL_PYTHON=YES environment variable\n'
+                        msg += 'to feed the PATH into os.add_dll_directory().'
+
+                        import sys
+                        import traceback
+                        traceback_string = ''.join(traceback.format_exception(*sys.exc_info()))
+                        raise ImportError(traceback_string + '\n' + msg)
+                raise
             finally:
                 fp.close()
             return _mod


### PR DESCRIPTION
Since Python 3.8 on Windows, the PATH is no longer used to try to load
.dlls from which the .pyd extensions depend on.
https://docs.python.org/fr/3/whatsnew/3.8.html#bpo-36085-whatsnew

This is a bit annoying in a development environment, so add a hint when
this sitation occurs. And allow the user to define the USE_PATH_FOR_GDAL_PYTHON
environment variable to allow the PATH to still be considered.
