### PR TITLE
VRTRawRasterBand: add GetVirtualMemAuto interface to enable mmap io

### DIFF
--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -817,6 +817,11 @@ class CPL_DLL VRTRawRasterBand CPL_NON_FINAL: public VRTRasterBand
 
     void           ClearRawLink();
 
+    CPLVirtualMem *GetVirtualMemAuto( GDALRWFlag eRWFlag,
+                                      int *pnPixelSpace,
+                                      GIntBig *pnLineSpace,
+                                      char **papszOptions ) override;
+
     virtual void   GetFileList( char*** ppapszFileList, int *pnSize,
                                 int *pnMaxSize, CPLHashSet* hSetFiles ) override;
 };
@@ -1357,7 +1362,7 @@ public:
                                                 const CPLXMLNode* psNode);
 
     std::shared_ptr<GDALMDArray> GetIndexingVariable() const override;
-   
+
     bool SetIndexingVariable(std::shared_ptr<GDALMDArray> poIndexingVariable) override;
 
     void Serialize(CPLXMLNode* psParent) const;

--- a/gdal/frmts/vrt/vrtrawrasterband.cpp
+++ b/gdal/frmts/vrt/vrtrawrasterband.cpp
@@ -323,6 +323,27 @@ void VRTRawRasterBand::ClearRawLink()
 }
 
 /************************************************************************/
+/*                            GetVirtualMemAuto()                       */
+/************************************************************************/
+
+CPLVirtualMem * VRTRawRasterBand::GetVirtualMemAuto( GDALRWFlag eRWFlag,
+                                                     int *pnPixelSpace,
+                                                     GIntBig *pnLineSpace,
+                                                     char **papszOptions )
+
+{
+    // check the pointer to RawRasterBand
+    if( m_poRawRaster == nullptr )
+    {
+        // use the super class method
+        return VRTRasterBand::GetVirtualMemAuto(eRWFlag, pnPixelSpace, pnLineSpace, papszOptions);
+    }
+    // if available, use the RawRasterBand method (use mmap if available)
+    return m_poRawRaster->GetVirtualMemAuto(eRWFlag, pnPixelSpace, pnLineSpace, papszOptions);
+}
+
+
+/************************************************************************/
 /*                              XMLInit()                               */
 /************************************************************************/
 


### PR DESCRIPTION
We need mmap-based io for raw dataset wrapped with vrt. Currently, two methods of GetVirtualMemAuto, buffer, or filemap,  are controlled by the option "USE_DEFAULT_IMPLEMENTATION"="YES/NO". 

This PR adds an explicit GetVirtualMemAuto interface to VRTRawRasterBand so that the RawRasterBand method can be called. The FileMapping (mmap) method can be selected by setting  USE_DEFAULT_IMPLEMENTATION=NO.  Without the interface, VRTRawRasterBand uses its parent class method, which returns a buffer-based VirtualMem (USE_DEFAULT_IMPLEMENTATION=YES) or nullptr (USE_DEFAULT_IMPLEMENTATION=NO). 

 