### PR TITLE
Block cache: fix corruption on multithreaded write on datasets (fixes #2011)

### DIFF
--- a/autotest/cpp/testblockcachewrite.cpp
+++ b/autotest/cpp/testblockcachewrite.cpp
@@ -76,30 +76,28 @@ class MyDataset: public GDALDataset
         }
 };
 
-static void thread_func(void* /* unused */ )
+static void thread_func1(void* /* unused */ )
 {
     printf("begin thread\n");
     GDALFlushCacheBlock();
     printf("end of thread\n\n");
 }
 
-int main(int argc, char* argv[])
+static void test1()
 {
     CPLJoinableThread* hThread;
 
+    printf("Start test1\n");
     printf("main thread %p\n", (void*)CPLGetPID());
 
-    argc = GDALGeneralCmdLineProcessor( argc, &argv, 0 );
-
-    CPLSetConfigOption("GDAL_CACHEMAX", "0");
-    CPLSetConfigOption("GDAL_DEBUG_BLOCK_CACHE", "ON");
+    GDALSetCacheMax(0);
 
     MyDataset* poDS = new MyDataset();
 
     char buf1[] = { 1 } ;
     CPL_IGNORE_RET_VAL(GDALRasterIO(GDALGetRasterBand(poDS, 1), GF_Write, 0, 0, 1, 1, buf1, 1, 1, GDT_Byte, 0, 0));
 
-    hThread = CPLCreateJoinableThread(thread_func, nullptr);
+    hThread = CPLCreateJoinableThread(thread_func1, nullptr);
     CPLSleep(0.3);
     CPL_IGNORE_RET_VAL(GDALRasterIO(GDALGetRasterBand(poDS, 1), GF_Write, 1, 0, 1, 1, buf1, 1, 1, GDT_Byte, 0, 0));
     GDALFlushCacheBlock();
@@ -107,6 +105,65 @@ int main(int argc, char* argv[])
     CPLJoinThread(hThread);
 
     delete poDS;
+    printf("End test1\n");
+}
+
+
+static void thread_func2(void* /* unused */)
+{
+    printf("begin thread %p\n", (void*)CPLGetPID());
+    GDALDatasetH hDS = GDALOpen("data/byte.tif", GA_ReadOnly);
+    GByte c = 0;
+    CPL_IGNORE_RET_VAL(GDALDataset::FromHandle(hDS)->GetRasterBand(1)->RasterIO(GF_Read, 0,0,1,1,&c,1,1,GDT_Byte,0,0,nullptr));
+    GDALClose(hDS);
+    printf("end of thread\n\n");
+}
+
+static void test2()
+{
+    printf("Start test2\n");
+    printf("main thread %p\n", (void*)CPLGetPID());
+
+    CPLJoinableThread* hThread;
+
+    CPLSetConfigOption("GDAL_RB_INTERNALIZE_SLEEP_AFTER_DETACH_BEFORE_WRITE", "0.5");
+    GDALSetCacheMax(1000*1000);
+
+    auto poDS = GetGDALDriverManager()->GetDriverByName("GTiff")->Create("/vsimem/foo.tif", 1, 1, 2, GDT_Byte, nullptr);
+    poDS->GetRasterBand(1)->Fill(0);
+    poDS->GetRasterBand(2)->Fill(0);
+    poDS->FlushCache();
+    GDALSetCacheMax(0);
+
+    poDS->GetRasterBand(1)->Fill(1);
+    hThread = CPLCreateJoinableThread(thread_func2, nullptr);
+    CPLSleep(0.2);
+
+    GByte c = 0;
+    CPL_IGNORE_RET_VAL(poDS->GetRasterBand(1)->RasterIO(GF_Read,0,0,1,1,&c,1,1,GDT_Byte,0,0,nullptr));
+    printf("%d\n", c);
+    assert(c == 1);
+    CPLJoinThread(hThread);
+
+    CPLSetConfigOption("GDAL_RB_INTERNALIZE_SLEEP_AFTER_DETACH_BEFORE_WRITE", nullptr);
+    delete poDS;
+    VSIUnlink("/vsimem/foo.tif");
+    printf("End test2\n");
+}
+
+
+int main(int argc, char* argv[])
+{
+    argc = GDALGeneralCmdLineProcessor( argc, &argv, 0 );
+
+    CPLSetConfigOption("GDAL_DEBUG_BLOCK_CACHE", "ON");
+    GDALGetCacheMax();
+
+    GDALAllRegister();
+
+    test1();
+    test2();
+
     GDALDestroyDriverManager();
     CSLDestroy( argv );
 

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -1057,7 +1057,6 @@ class GDALAbstractBandBlockCache
 
         void              FreeDanglingBlocks();
         void              UnreferenceBlockBase();
-        void              WaitKeepAliveCounter();
 
         void              StartDirtyBlockFlushingLog();
         void              UpdateDirtyBlockFlushingLog();
@@ -1070,6 +1069,7 @@ class GDALAbstractBandBlockCache
             GDALRasterBlock* CreateBlock(int nXBlockOff, int nYBlockOff);
             void             AddBlockToFreeList( GDALRasterBlock * );
             void             IncDirtyBlocks(int nInc);
+            void             WaitCompletionPendingTasks();
 
             virtual bool             Init() = 0;
             virtual bool             IsInitOK() = 0;
@@ -1101,6 +1101,7 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     friend class GDALArrayBandBlockCache;
     friend class GDALHashSetBandBlockCache;
     friend class GDALRasterBlock;
+    friend class GDALDataset;
 
     CPLErr eFlushBlockErr = CE_None;
     GDALAbstractBandBlockCache* poBandBlockCache = nullptr;
@@ -1136,7 +1137,6 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
 
     void        InvalidateMaskBand();
 
-    friend class GDALDataset;
     friend class GDALProxyRasterBand;
     friend class GDALDefaultOverviews;
 

--- a/gdal/gcore/gdalabstractbandblockcache.cpp
+++ b/gdal/gcore/gdalabstractbandblockcache.cpp
@@ -114,7 +114,7 @@ void GDALAbstractBandBlockCache::AddBlockToFreeList( GDALRasterBlock *poBlock )
         psListBlocksToFree = poBlock;
     }
 
-    // If no more blocks in transient state, then warn WaitKeepAliveCounter()
+    // If no more blocks in transient state, then warn WaitCompletionPendingTasks()
     CPLAcquireMutex(hCondMutex, 1000);
     if( CPLAtomicDec(&nKeepAliveCounter) == 0 )
     {
@@ -124,13 +124,13 @@ void GDALAbstractBandBlockCache::AddBlockToFreeList( GDALRasterBlock *poBlock )
 }
 
 /************************************************************************/
-/*                         WaitKeepAliveCounter()                       */
+/*                      WaitCompletionPendingTasks()                    */
 /************************************************************************/
 
-void GDALAbstractBandBlockCache::WaitKeepAliveCounter()
+void GDALAbstractBandBlockCache::WaitCompletionPendingTasks()
 {
 #ifdef DEBUG_VERBOSE
-    CPLDebug("GDAL", "WaitKeepAliveCounter()");
+    CPLDebug("GDAL", "WaitCompletionPendingTasks()");
 #endif
 
     CPLAcquireMutex(hCondMutex, 1000);

--- a/gdal/gcore/gdalarraybandblockcache.cpp
+++ b/gdal/gcore/gdalarraybandblockcache.cpp
@@ -322,7 +322,7 @@ CPLErr GDALArrayBandBlockCache::FlushCache()
 
     EndDirtyBlockFlushingLog();
 
-    WaitKeepAliveCounter();
+    WaitCompletionPendingTasks();
 
     return( eGlobalErr );
 }

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -7284,8 +7284,20 @@ int GDALDataset::EnterReadWrite(GDALRWFlag eRWFlag)
                      CPLGetPID(), GetDescription());
 #endif
             CPLCreateOrAcquireMutex(&(m_poPrivate->hMutex), 1000.0);
-            // Not sure if we can have recursive calls, so...
-            m_poPrivate->oMapThreadToMutexTakenCount[CPLGetPID()]++;
+
+            const int nCountMutex = m_poPrivate->oMapThreadToMutexTakenCount[CPLGetPID()]++;
+            if( nCountMutex == 0 && eRWFlag == GF_Read )
+            {
+                CPLReleaseMutex(m_poPrivate->hMutex);
+                for( int i = 0; i < nBands; i++ )
+                {
+                    auto blockCache = papoBands[i]->poBandBlockCache;
+                    if( blockCache )
+                        blockCache->WaitCompletionPendingTasks();
+                }
+                CPLCreateOrAcquireMutex(&(m_poPrivate->hMutex), 1000.0);
+            }
+
             return TRUE;
         }
     }

--- a/gdal/gcore/gdalhashsetbandblockcache.cpp
+++ b/gdal/gcore/gdalhashsetbandblockcache.cpp
@@ -186,7 +186,7 @@ CPLErr GDALHashSetBandBlockCache::FlushCache()
     }
     EndDirtyBlockFlushingLog();
 
-    WaitKeepAliveCounter();
+    WaitCompletionPendingTasks();
 
     return( eGlobalErr );
 }

--- a/gdal/gcore/gdalrasterband.cpp
+++ b/gdal/gcore/gdalrasterband.cpp
@@ -546,6 +546,7 @@ CPLErr GDALRasterBand::ReadBlock( int nXBlockOff, int nYBlockOff,
 /* -------------------------------------------------------------------- */
 /*      Invoke underlying implementation method.                        */
 /* -------------------------------------------------------------------- */
+
     int bCallLeaveReadWrite = EnterReadWrite(GF_Read);
     CPLErr eErr = IReadBlock( nXBlockOff, nYBlockOff, pImage );
     if( bCallLeaveReadWrite) LeaveReadWrite();


### PR DESCRIPTION
When writing several GDAL datasets in parallel from several threads, a
thread can force a dirty block of another thread/dataset to be written. By
doing so, it will remove it from the list of cached blocks, so if the thread
that explictly manipulates this dataset reacquire the block, it will see an
old version of the block. The effect of this can be particularly seen with
GeoTIFF files with multi band pixel leaving organization, where acquiring
a block of a band causes corresponding blocks of other bands to be cached.

The main fix done here is in GDALRasterBlock::Internalize() to avoid evicting
a dirty block of another dataset when there are other candidates. This considerably
reduces the likelihood of the bug.

Another fix is done in GDALDataset::EnterReadWrite() to wait for the completion
of the flushing of pending dirty blocks of the dataset before reading new blocks.

I believe there could still be problems if the block cache size is too
small regarding the number of threads.
