### PR TITLE
Several TOWGS84 related changes

### DIFF
--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -28,7 +28,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -642,3 +642,73 @@ def test_tiff_srs_write_ob_tran_eqc():
     ds = None
 
     gdal.GetDriverByName('GTiff').Delete('/vsimem/src.tif')
+
+
+def test_tiff_srs_towgs84_from_epsg_do_not_write_it():
+
+    filename = '/vsimem/test.tif'
+    ds = gdal.GetDriverByName('GTiff').Create(filename, 1, 1)
+    srs_in = osr.SpatialReference()
+    srs_in.ImportFromEPSG(31468)
+    assert srs_in.HasTOWGS84()
+    ds.SetSpatialRef(srs_in)
+    ds = None
+
+    ds = gdal.Open(filename)
+    with gdaltest.config_option('OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG', 'NO'):
+        srs = ds.GetSpatialRef()
+    assert not srs.HasTOWGS84()
+
+
+def test_tiff_srs_towgs84_from_epsg_force_write_it():
+
+    filename = '/vsimem/test.tif'
+    ds = gdal.GetDriverByName('GTiff').Create(filename, 1, 1)
+    srs_in = osr.SpatialReference()
+    srs_in.ImportFromEPSG(31468)
+    assert srs_in.HasTOWGS84()
+    with gdaltest.config_option('GTIFF_WRITE_TOWGS84', 'YES'):
+        ds.SetSpatialRef(srs_in)
+        ds = None
+
+    ds = gdal.Open(filename)
+    with gdaltest.config_option('OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG', 'NO'):
+        srs = ds.GetSpatialRef()
+    assert srs.HasTOWGS84()
+
+
+def test_tiff_srs_towgs84_with_epsg_code_but_non_default_TOWGS84():
+
+    filename = '/vsimem/test.tif'
+    ds = gdal.GetDriverByName('GTiff').Create(filename, 1, 1)
+    srs_in = osr.SpatialReference()
+    srs_in.SetFromUserInput("""PROJCS["DHDN / 3-degree Gauss-Kruger zone 4",
+    GEOGCS["DHDN",
+        DATUM["Deutsches_Hauptdreiecksnetz",
+            SPHEROID["Bessel 1841",6377397.155,299.1528128,
+                AUTHORITY["EPSG","7004"]],
+            TOWGS84[1,2,3,4,5,6,7],
+            AUTHORITY["EPSG","6314"]],
+        PRIMEM["Greenwich",0,
+            AUTHORITY["EPSG","8901"]],
+        UNIT["degree",0.0174532925199433,
+            AUTHORITY["EPSG","9122"]],
+        AUTHORITY["EPSG","4314"]],
+    PROJECTION["Transverse_Mercator"],
+    PARAMETER["latitude_of_origin",0],
+    PARAMETER["central_meridian",12],
+    PARAMETER["scale_factor",1],
+    PARAMETER["false_easting",4500000],
+    PARAMETER["false_northing",0],
+    UNIT["metre",1,
+        AUTHORITY["EPSG","9001"]],
+    AXIS["Northing",NORTH],
+    AXIS["Easting",EAST],
+    AUTHORITY["EPSG","31468"]]""")
+    ds.SetSpatialRef(srs_in)
+    ds = None
+
+    ds = gdal.Open(filename)
+    srs = ds.GetSpatialRef()
+    assert srs.GetTOWGS84() == (1,2,3,4,5,6,7)
+

--- a/gdal/doc/source/drivers/raster/gtiff.rst
+++ b/gdal/doc/source/drivers/raster/gtiff.rst
@@ -708,6 +708,14 @@ the default behaviour of the GTiff driver.
    LZMA. Will be ignored for JPEG. Default is compression in the main
    thread. Note: this configuration option also apply to other parts to
    GDAL (warping, gridding, ...).
+-  GTIFF_WRITE_TOWGS84=AUTO/YES/NO: (GDAL >= 3.0.3). When set to AUTO, a
+   GeogTOWGS84GeoKey geokey will be written with TOWGS84 3 or 7-parameter
+   Helmert transformation, if the CRS has no EPSG code attached to it, or if
+   the TOWGS84 transformation attached to the CRS doesn't match the one imported
+   from the EPSG code.
+   If set to YES, then the TOWGS84 transformation attached to the CRS will be
+   always written. If set to NO, then the transformation will not be written in
+   any situation.
 
 See Also
 --------

--- a/gdal/frmts/gtiff/gt_wkt_srs.cpp
+++ b/gdal/frmts/gtiff/gt_wkt_srs.cpp
@@ -2757,24 +2757,48 @@ int GTIFSetFromOGISDefnEx( GTIF * psGTIF, const char *pszOGCWKT,
     double adfTOWGS84[7] = { 0.0 };
 
     if( (nGCS == KvUserDefined || eVersion == GEOTIFF_VERSION_1_0 ) &&
-        poSRS->GetTOWGS84( adfTOWGS84 ) == OGRERR_NONE &&
-        CPLTestBool(CPLGetConfigOption("GTIFF_WRITE_TOWGS84", "YES")) )
+        poSRS->GetTOWGS84( adfTOWGS84 ) == OGRERR_NONE )
     {
-        if( adfTOWGS84[3] == 0.0 && adfTOWGS84[4] == 0.0
-            && adfTOWGS84[5] == 0.0 && adfTOWGS84[6] == 0.0 )
+        // If we are writing a SRS with a EPSG code, and that the EPSG code
+        // of the current SRS object and the one coming from the EPSG code
+        // are the same, then by default, do not write them.
+        bool bUseReferenceTOWGS84 = false;
+        const char* pszAuthName = poSRS->GetAuthorityName(nullptr);
+        const char* pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        if( pszAuthName && EQUAL(pszAuthName, "EPSG") && pszAuthCode )
         {
-            if( nGCS == GCS_WGS_84 && adfTOWGS84[0] == 0.0
-                && adfTOWGS84[1] == 0.0 && adfTOWGS84[2] == 0.0 )
+            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            OGRSpatialReference oRefSRS;
+            double adfRefTOWGS84[7] = { 0.0 };
+            if( oRefSRS.importFromEPSG(atoi(pszAuthCode)) == OGRERR_NONE &&
+                oRefSRS.GetTOWGS84(adfRefTOWGS84) == OGRERR_NONE &&
+                memcmp(adfRefTOWGS84, adfTOWGS84, sizeof(adfTOWGS84)) == 0 )
             {
-                ; // Do nothing.
+                bUseReferenceTOWGS84 = true;
+            }
+        }
+        const char* pszWriteTOWGS84 =
+            CPLGetConfigOption("GTIFF_WRITE_TOWGS84", "AUTO");
+        if( (EQUAL(pszWriteTOWGS84, "YES") || EQUAL(pszWriteTOWGS84, "TRUE") ||
+             EQUAL(pszWriteTOWGS84, "ON")) ||
+            (!bUseReferenceTOWGS84 && EQUAL(pszWriteTOWGS84, "AUTO") ) )
+        {
+            if( adfTOWGS84[3] == 0.0 && adfTOWGS84[4] == 0.0
+                && adfTOWGS84[5] == 0.0 && adfTOWGS84[6] == 0.0 )
+            {
+                if( nGCS == GCS_WGS_84 && adfTOWGS84[0] == 0.0
+                    && adfTOWGS84[1] == 0.0 && adfTOWGS84[2] == 0.0 )
+                {
+                    ; // Do nothing.
+                }
+                else
+                    GTIFKeySet( psGTIF, GeogTOWGS84GeoKey, TYPE_DOUBLE, 3,
+                                adfTOWGS84 );
             }
             else
-                GTIFKeySet( psGTIF, GeogTOWGS84GeoKey, TYPE_DOUBLE, 3,
+                GTIFKeySet( psGTIF, GeogTOWGS84GeoKey, TYPE_DOUBLE, 7,
                             adfTOWGS84 );
         }
-        else
-            GTIFKeySet( psGTIF, GeogTOWGS84GeoKey, TYPE_DOUBLE, 7,
-                        adfTOWGS84 );
     }
 #endif
 

--- a/gdal/ogr/ogr_proj_p.cpp
+++ b/gdal/ogr/ogr_proj_p.cpp
@@ -180,11 +180,12 @@ void OSRProjTLSCache::clear()
     m_oCacheWKT.clear();
 }
 
-PJ* OSRProjTLSCache::GetPJForEPSGCode(int nCode)
+PJ* OSRProjTLSCache::GetPJForEPSGCode(int nCode, bool bUseNonDeprecated, bool bAddTOWGS84)
 {
     try
     {
-        const auto& cached = m_oCacheEPSG.get(nCode);
+        const EPSGCacheKey key(nCode, bUseNonDeprecated, bAddTOWGS84);
+        const auto& cached = m_oCacheEPSG.get(key);
         return proj_clone(OSRGetProjTLSContext(), cached.get());
     }
     catch( const lru11::KeyNotFound& )
@@ -193,9 +194,10 @@ PJ* OSRProjTLSCache::GetPJForEPSGCode(int nCode)
     }
 }
 
-void OSRProjTLSCache::CachePJForEPSGCode(int nCode, PJ* pj)
+void OSRProjTLSCache::CachePJForEPSGCode(int nCode, bool bUseNonDeprecated, bool bAddTOWGS84, PJ* pj)
 {
-    m_oCacheEPSG.insert(nCode, std::shared_ptr<PJ>(
+    const EPSGCacheKey key(nCode, bUseNonDeprecated, bAddTOWGS84);
+    m_oCacheEPSG.insert(key, std::shared_ptr<PJ>(
                     proj_clone(OSRGetProjTLSContext(), pj), OSRPJDeleter()));
 }
 

--- a/gdal/ogr/ogr_proj_p.cpp
+++ b/gdal/ogr/ogr_proj_p.cpp
@@ -248,6 +248,28 @@ void OSRSetPROJSearchPaths( const char* const * papszPaths )
 }
 
 /************************************************************************/
+/*                        OSRGetPROJSearchPaths()                       */
+/************************************************************************/
+
+/** \brief Get the search path(s) for PROJ resource files.
+ *
+ * @return NULL terminated list of directory paths. To be freed with CSLDestroy()
+ * @since GDAL 3.0.3
+ */
+char** OSRGetPROJSearchPaths()
+{
+    std::lock_guard<std::mutex> oLock(g_oSearchPathMutex);
+    const char* pszSep =
+#ifdef _WIN32
+                        ";"
+#else
+                        ":"
+#endif
+    ;
+    return CSLTokenizeString2( proj_info().searchpath, pszSep, 0);
+}
+
+/************************************************************************/
 /*                         OSRGetPROJVersion()                          */
 /************************************************************************/
 

--- a/gdal/ogr/ogr_proj_p.h
+++ b/gdal/ogr/ogr_proj_p.h
@@ -33,7 +33,9 @@
 
 #include "cpl_mem_cache.h"
 
+#include <unordered_map>
 #include <memory>
+#include <utility>
 
 /*! @cond Doxygen_Suppress */
 
@@ -42,7 +44,39 @@ void OSRCleanupTLSContext();
 
 class OSRProjTLSCache
 {
-        lru11::Cache<int, std::shared_ptr<PJ>> m_oCacheEPSG{};
+        struct EPSGCacheKey
+        {
+            int nCode_;
+            bool bUseNonDeprecated_;
+            bool bAddTOWGS84_;
+
+            EPSGCacheKey(int nCode, bool bUseNonDeprecated, bool bAddTOWGS84):
+                nCode_(nCode), bUseNonDeprecated_(bUseNonDeprecated), bAddTOWGS84_(bAddTOWGS84) {}
+
+            bool operator==(const EPSGCacheKey& other) const
+            {
+                return nCode_ == other.nCode_ &&
+                       bUseNonDeprecated_ == other.bUseNonDeprecated_ &&
+                       bAddTOWGS84_ == other.bAddTOWGS84_;
+            }
+        };
+        struct EPSGCacheKeyHasher
+        {
+            std::size_t operator()(const EPSGCacheKey& k) const
+            {
+                return k.nCode_ |
+                       ((k.bUseNonDeprecated_ ? 1 : 0) << 16) |
+                       ((k.bAddTOWGS84_ ? 1 : 0) << 17);
+            }
+        };
+
+        lru11::Cache<EPSGCacheKey, std::shared_ptr<PJ>,
+                     lru11::NullLock,
+                      std::unordered_map<
+                        EPSGCacheKey,
+                        typename std::list<lru11::KeyValuePair<EPSGCacheKey,
+                            std::shared_ptr<PJ>>>::iterator,
+                            EPSGCacheKeyHasher>> m_oCacheEPSG{};
         lru11::Cache<std::string, std::shared_ptr<PJ>> m_oCacheWKT{};
 
     public:
@@ -50,8 +84,8 @@ class OSRProjTLSCache
 
         void clear();
 
-        PJ* GetPJForEPSGCode(int nCode);
-        void CachePJForEPSGCode(int nCode, PJ* pj);
+        PJ* GetPJForEPSGCode(int nCode, bool bUseNonDeprecated, bool bAddTOWGS84);
+        void CachePJForEPSGCode(int nCode, bool bUseNonDeprecated, bool bAddTOWGS84, PJ* pj);
 
         PJ* GetPJForWKT(const std::string& wkt);
         void CachePJForWKT(const std::string& wkt, PJ* pj);

--- a/gdal/ogr/ogr_srs_api.h
+++ b/gdal/ogr/ogr_srs_api.h
@@ -464,6 +464,7 @@ typedef void *OGRCoordinateTransformationH;
 #endif
 
 void CPL_DLL OSRSetPROJSearchPaths( const char* const * papszPaths );
+char CPL_DLL **OSRGetPROJSearchPaths( void );
 void CPL_DLL OSRGetPROJVersion( int* pnMajor, int* pnMinor, int* pnPatch );
 
 OGRSpatialReferenceH CPL_DLL CPL_STDCALL

--- a/gdal/swig/include/osr.i
+++ b/gdal/swig/include/osr.i
@@ -1425,6 +1425,15 @@ void SetPROJSearchPaths( char** paths )
 %}
 %clear (char **);
 
+%apply (char **CSL) {(char **)};
+%inline %{
+char** GetPROJSearchPaths()
+{
+    return OSRGetPROJSearchPaths();
+}
+%}
+%clear (char **);
+
 %inline %{
 int GetPROJVersionMajor()
 {
@@ -1437,6 +1446,13 @@ int GetPROJVersionMinor()
 {
     int num;
     OSRGetPROJVersion(NULL, &num, NULL);
+    return num;
+}
+
+int GetPROJVersionMicro()
+{
+    int num;
+    OSRGetPROJVersion(NULL, NULL, &num);
     return num;
 }
 %}

--- a/gdal/swig/include/osr.i
+++ b/gdal/swig/include/osr.i
@@ -920,6 +920,11 @@ public:
     return OSRSetTOWGS84( self, p1, p2, p3, p4, p5, p6, p7 );
   }
 
+  bool HasTOWGS84() {
+    double ignored[7];
+    return OSRGetTOWGS84( self, ignored, 7 ) == OGRERR_NONE;
+  }
+
   OGRErr GetTOWGS84( double argout[7] ) {
     return OSRGetTOWGS84( self, argout, 7 );
   }

--- a/gdal/swig/python/extensions/osr_wrap.cpp
+++ b/gdal/swig/python/extensions/osr_wrap.cpp
@@ -4644,6 +4644,12 @@ void SetPROJSearchPaths( char** paths )
 }
 
 
+char** GetPROJSearchPaths()
+{
+    return OSRGetPROJSearchPaths();
+}
+
+
 int GetPROJVersionMajor()
 {
     int num;
@@ -4655,6 +4661,13 @@ int GetPROJVersionMinor()
 {
     int num;
     OSRGetPROJVersion(NULL, &num, NULL);
+    return num;
+}
+
+int GetPROJVersionMicro()
+{
+    int num;
+    OSRGetPROJVersion(NULL, NULL, &num);
     return num;
 }
 
@@ -17309,6 +17322,49 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_GetPROJSearchPaths(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  char **result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":GetPROJSearchPaths")) SWIG_fail;
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    result = (char **)GetPROJSearchPaths();
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    /* %typemap(out) char **CSL -> ( string ) */
+    char **stringarray = result;
+    if ( stringarray == NULL ) {
+      resultobj = Py_None;
+      Py_INCREF( resultobj );
+    }
+    else {
+      int len = CSLCount( stringarray );
+      resultobj = PyList_New( len );
+      for ( int i = 0; i < len; ++i ) {
+        PyObject *o = GDALPythonObjectFromCStr( stringarray[i] );
+        PyList_SetItem(resultobj, i, o );
+      }
+    }
+    CSLDestroy(result);
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_GetPROJVersionMajor(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   int result;
@@ -17346,6 +17402,33 @@ SWIGINTERN PyObject *_wrap_GetPROJVersionMinor(PyObject *SWIGUNUSEDPARM(self), P
       ClearErrorState();
     }
     result = (int)GetPROJVersionMinor();
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_GetPROJVersionMicro(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)":GetPROJVersionMicro")) SWIG_fail;
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    result = (int)GetPROJVersionMicro();
 #ifndef SED_HACKS
     if ( bUseExceptions ) {
       CPLErr eclass = CPLGetLastErrorType();
@@ -17564,8 +17647,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"GetCRSInfoListFromDatabase", _wrap_GetCRSInfoListFromDatabase, METH_VARARGS, (char *)"GetCRSInfoListFromDatabase(char const * authName)"},
 	 { (char *)"SetPROJSearchPath", _wrap_SetPROJSearchPath, METH_VARARGS, (char *)"SetPROJSearchPath(char const * utf8_path)"},
 	 { (char *)"SetPROJSearchPaths", _wrap_SetPROJSearchPaths, METH_VARARGS, (char *)"SetPROJSearchPaths(char ** paths)"},
+	 { (char *)"GetPROJSearchPaths", _wrap_GetPROJSearchPaths, METH_VARARGS, (char *)"GetPROJSearchPaths() -> char **"},
 	 { (char *)"GetPROJVersionMajor", _wrap_GetPROJVersionMajor, METH_VARARGS, (char *)"GetPROJVersionMajor() -> int"},
 	 { (char *)"GetPROJVersionMinor", _wrap_GetPROJVersionMinor, METH_VARARGS, (char *)"GetPROJVersionMinor() -> int"},
+	 { (char *)"GetPROJVersionMicro", _wrap_GetPROJVersionMicro, METH_VARARGS, (char *)"GetPROJVersionMicro() -> int"},
 	 { NULL, NULL, 0, NULL }
 };
 

--- a/gdal/swig/python/extensions/osr_wrap.cpp
+++ b/gdal/swig/python/extensions/osr_wrap.cpp
@@ -4245,6 +4245,17 @@ SWIGINTERN OGRErr OSRSpatialReferenceShadow_SetTOWGS84(OSRSpatialReferenceShadow
 
     return OSRSetTOWGS84( self, p1, p2, p3, p4, p5, p6, p7 );
   }
+SWIGINTERN bool OSRSpatialReferenceShadow_HasTOWGS84(OSRSpatialReferenceShadow *self){
+    double ignored[7];
+    return OSRGetTOWGS84( self, ignored, 7 ) == OGRERR_NONE;
+  }
+
+SWIGINTERNINLINE PyObject*
+  SWIG_From_bool  (bool value)
+{
+  return PyBool_FromLong(value ? 1 : 0);
+}
+
 
 static PyObject *
 CreateTupleFromDoubleArray( const double *first, size_t size ) {
@@ -4375,13 +4386,6 @@ SWIGINTERN bool OGRCoordinateTransformationOptions_SetAreaOfInterest(OGRCoordina
         westLongitudeDeg, southLatitudeDeg,
         eastLongitudeDeg, northLatitudeDeg);
   }
-
-SWIGINTERNINLINE PyObject*
-  SWIG_From_bool  (bool value)
-{
-  return PyBool_FromLong(value ? 1 : 0);
-}
-
 SWIGINTERN bool OGRCoordinateTransformationOptions_SetOperation(OGRCoordinateTransformationOptions *self,char const *operation){
     return OCTCoordinateTransformationOptionsSetOperation(self, operation, false);
   }
@@ -12360,6 +12364,42 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SpatialReference_HasTOWGS84(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  OSRSpatialReferenceShadow *arg1 = (OSRSpatialReferenceShadow *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:SpatialReference_HasTOWGS84",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_OSRSpatialReferenceShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SpatialReference_HasTOWGS84" "', argument " "1"" of type '" "OSRSpatialReferenceShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< OSRSpatialReferenceShadow * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    result = (bool)OSRSpatialReferenceShadow_HasTOWGS84(arg1);
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SpatialReference_GetTOWGS84(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   OSRSpatialReferenceShadow *arg1 = (OSRSpatialReferenceShadow *) 0 ;
@@ -17439,6 +17479,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SpatialReference_SetFromUserInput", _wrap_SpatialReference_SetFromUserInput, METH_VARARGS, (char *)"SpatialReference_SetFromUserInput(SpatialReference self, char const * name) -> OGRErr"},
 	 { (char *)"SpatialReference_CopyGeogCSFrom", _wrap_SpatialReference_CopyGeogCSFrom, METH_VARARGS, (char *)"SpatialReference_CopyGeogCSFrom(SpatialReference self, SpatialReference rhs) -> OGRErr"},
 	 { (char *)"SpatialReference_SetTOWGS84", _wrap_SpatialReference_SetTOWGS84, METH_VARARGS, (char *)"SpatialReference_SetTOWGS84(SpatialReference self, double p1, double p2, double p3, double p4=0.0, double p5=0.0, double p6=0.0, double p7=0.0) -> OGRErr"},
+	 { (char *)"SpatialReference_HasTOWGS84", _wrap_SpatialReference_HasTOWGS84, METH_VARARGS, (char *)"SpatialReference_HasTOWGS84(SpatialReference self) -> bool"},
 	 { (char *)"SpatialReference_GetTOWGS84", _wrap_SpatialReference_GetTOWGS84, METH_VARARGS, (char *)"SpatialReference_GetTOWGS84(SpatialReference self) -> OGRErr"},
 	 { (char *)"SpatialReference_SetLocalCS", _wrap_SpatialReference_SetLocalCS, METH_VARARGS, (char *)"SpatialReference_SetLocalCS(SpatialReference self, char const * pszName) -> OGRErr"},
 	 { (char *)"SpatialReference_SetGeogCS", _wrap_SpatialReference_SetGeogCS, METH_VARARGS, (char *)"SpatialReference_SetGeogCS(SpatialReference self, char const * pszGeogName, char const * pszDatumName, char const * pszEllipsoidName, double dfSemiMajor, double dfInvFlattening, char const * pszPMName, double dfPMOffset=0.0, char const * pszUnits, double dfConvertToRadians=0.0174532925199433) -> OGRErr"},

--- a/gdal/swig/python/osgeo/osr.py
+++ b/gdal/swig/python/osgeo/osr.py
@@ -1212,6 +1212,10 @@ def SetPROJSearchPaths(*args):
     """SetPROJSearchPaths(char ** paths)"""
     return _osr.SetPROJSearchPaths(*args)
 
+def GetPROJSearchPaths(*args):
+    """GetPROJSearchPaths() -> char **"""
+    return _osr.GetPROJSearchPaths(*args)
+
 def GetPROJVersionMajor(*args):
     """GetPROJVersionMajor() -> int"""
     return _osr.GetPROJVersionMajor(*args)
@@ -1219,6 +1223,10 @@ def GetPROJVersionMajor(*args):
 def GetPROJVersionMinor(*args):
     """GetPROJVersionMinor() -> int"""
     return _osr.GetPROJVersionMinor(*args)
+
+def GetPROJVersionMicro(*args):
+    """GetPROJVersionMicro() -> int"""
+    return _osr.GetPROJVersionMicro(*args)
 # This file is compatible with both classic and new-style classes.
 
 

--- a/gdal/swig/python/osgeo/osr.py
+++ b/gdal/swig/python/osgeo/osr.py
@@ -836,6 +836,11 @@ class SpatialReference(_object):
         return _osr.SpatialReference_SetTOWGS84(self, *args)
 
 
+    def HasTOWGS84(self, *args):
+        """HasTOWGS84(SpatialReference self) -> bool"""
+        return _osr.SpatialReference_HasTOWGS84(self, *args)
+
+
     def GetTOWGS84(self, *args):
         """GetTOWGS84(SpatialReference self) -> OGRErr"""
         return _osr.SpatialReference_GetTOWGS84(self, *args)


### PR DESCRIPTION
*  Add a OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG=YES/NO config option for importFromEPSG(). And in the GTiff driver, do not write TOWGS84 that come from EPSG codes, unless GTIFF_WRITE_TOWGS84=YES is explicitly set
* Add a OSRGetPROJSearchPaths() function
*  OSR_CT: add a OSR_CT_USE_DEFAULT_EPSG_TOWGS84 configuration option that can be set to YES to explicit honour default TOWGS84 terms of a EPSG code


