### PR TITLE
Docs: fix typo in virtual_file_systems.rst

### DIFF
--- a/gdal/doc/source/user/virtual_file_systems.rst
+++ b/gdal/doc/source/user/virtual_file_systems.rst
@@ -558,4 +558,4 @@ The default size of caching for each file is 25 MB (25 MB for each file that is 
 
 /vsicrypt/ is a special file handler is installed that allows reading/creating/update encrypted files on the fly, with random access capabilities.
 
-Refert to :cpp:func:`VSIInstallCryptFileHandler` for more details.
+Refer to :cpp:func:`VSIInstallCryptFileHandler` for more details.


### PR DESCRIPTION
This is a typo as well but I don't know the intended meaning so can't fix it.

"/vsicrypt/ is a special file handler **is** installed that allows reading..."
could mean:
"/vsicrypt/ is a special file handler **if** installed that allows reading..."
which is odd phrasing.  If that is what is meant, could consider:
"If installed, /vsicrypt/ is a special file handler that allows reading..."

Doing nothing works fine too since I think that the information is conveyed as is.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
