### PR TITLE
VRT driver: add 'vrt://{gdal_dataset}?bands=num1,...,numN' syntax

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1310,3 +1310,27 @@ def test_vrt_shared_no_proxy_pool_error():
     with gdaltest.error_handler():
         ds = gdal.Open(vrt_text)
     assert not ds
+
+
+def test_vrt_protocol():
+
+    with gdaltest.error_handler():
+        assert not gdal.Open('vrt://')
+        assert not gdal.Open('vrt://i_do_not_exist')
+        assert not gdal.Open('vrt://i_do_not_exist?')
+
+    ds = gdal.Open('vrt://data/byte.tif')
+    assert ds.RasterCount == 1
+    assert ds.GetRasterBand(1).Checksum() == 4672
+
+    with gdaltest.error_handler():
+        assert not gdal.Open('vrt://data/byte.tif?foo=bar')
+        assert not gdal.Open('vrt://data/byte.tif?bands=foo')
+        assert not gdal.Open('vrt://data/byte.tif?bands=0')
+        assert not gdal.Open('vrt://data/byte.tif?bands=2')
+
+    ds = gdal.Open('vrt://data/byte.tif?bands=1,mask,1')
+    assert ds.RasterCount == 3
+    assert ds.GetRasterBand(1).Checksum() == 4672
+    assert ds.GetRasterBand(2).Checksum() == 4873
+    assert ds.GetRasterBand(3).Checksum() == 4672

--- a/gdal/doc/source/drivers/raster/vrt.rst
+++ b/gdal/doc/source/drivers/raster/vrt.rst
@@ -1414,14 +1414,43 @@ See the dedicated :ref:`vrt_multidimensional` page.
 
    vrt_multidimensional
 
+vrt:// connection string
+------------------------
+
+.. versionadded:: 3.1
+
+In some contexts, it might be useful to benefit from features of VRT without
+having to create a file or to provide the rather verbose VRT XML content as
+the connection string. For that purpose, the following URI syntax is supported for
+the dataset name since GDAL 3.1
+
+::
+
+    vrt://{path_to_gdal_dataset}?[bands=num1,...,numN]
+
+For example:
+
+::
+
+    vrt://my.tif?bands=3,2,1
+
+The only supported option currently is bands. Other may be added in the future.
+
+The effect of this option is to change the band composition. The values specified
+are the source band numbers (between 1 and N), possibly out-of-order or with repetitions.
+The ``mask`` value can be used to specify the global mask band. This can also
+be seen as an equivalent of running `gdal_translate -of VRT -b num1 ... -b numN`.
+
 Multi-threading issues
 ----------------------
 
-The below section applies to GDAL <= 2.2. Starting with GDAL 2.3, the use
-of VRT datasets is subject to the standard GDAL dataset multi-threaded rules
-(that is a VRT dataset handle may only be used by a same thread at a time,
-but you may open several dataset handles on the same VRT file and use them
-in different threads)
+.. warning::
+
+    The below section applies to GDAL <= 2.2. Starting with GDAL 2.3, the use
+    of VRT datasets is subject to the standard GDAL dataset multi-threaded rules
+    (that is a VRT dataset handle may only be used by a same thread at a time,
+    but you may open several dataset handles on the same VRT file and use them
+    in different threads)
 
 When using VRT datasets in a multi-threading environment, you should be
 careful to open the VRT dataset by the thread that will use it afterwards. The

--- a/gdal/frmts/vrt/vrtdataset.cpp
+++ b/gdal/frmts/vrt/vrtdataset.cpp
@@ -33,15 +33,17 @@
 #include "cpl_string.h"
 #include "gdal_frmts.h"
 #include "ogr_spatialref.h"
+#include "gdal_utils.h"
 
 #include <algorithm>
 #include <typeinfo>
 #include "gdal_proxy.h"
 
-
 /*! @cond Doxygen_Suppress */
 
 CPL_CVSID("$Id$")
+
+#define VRT_PROTOCOL_PREFIX "vrt://"
 
 /************************************************************************/
 /*                            VRTDataset()                             */
@@ -737,6 +739,9 @@ int VRTDataset::Identify( GDALOpenInfo * poOpenInfo )
     if( strstr(poOpenInfo->pszFilename,"<VRTDataset") != nullptr )
         return TRUE;
 
+    if( STARTS_WITH_CI(poOpenInfo->pszFilename, VRT_PROTOCOL_PREFIX) )
+        return TRUE;
+
     return FALSE;
 }
 
@@ -753,6 +758,9 @@ GDALDataset *VRTDataset::Open( GDALOpenInfo * poOpenInfo )
 /* -------------------------------------------------------------------- */
     if( !Identify( poOpenInfo ) )
         return nullptr;
+
+    if( STARTS_WITH_CI(poOpenInfo->pszFilename, VRT_PROTOCOL_PREFIX) )
+        return OpenVRTProtocol(poOpenInfo->pszFilename);
 
 /* -------------------------------------------------------------------- */
 /*      Try to read the whole file into memory.                         */
@@ -903,6 +911,103 @@ GDALDataset *VRTDataset::Open( GDALOpenInfo * poOpenInfo )
         poDS->m_poRootGroup->SetFilename(poOpenInfo->pszFilename);
     }
 
+    return poDS;
+}
+
+/************************************************************************/
+/*                         OpenVRTProtocol()                            */
+/*                                                                      */
+/*      Create an open VRTDataset from a vrt:// string.                 */
+/************************************************************************/
+
+GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
+
+{
+    CPLAssert( STARTS_WITH_CI(pszSpec, VRT_PROTOCOL_PREFIX) );
+    CPLString osFilename(pszSpec + strlen(VRT_PROTOCOL_PREFIX) );
+    const auto nPosQuotationMark = osFilename.find('?');
+    CPLString osQueryString;
+    if( nPosQuotationMark != std::string::npos )
+    {
+        osQueryString = osFilename.substr(nPosQuotationMark+1);
+        osFilename.resize(nPosQuotationMark);
+    }
+    auto poSrcDS =
+        GDALDataset::Open(osFilename, GDAL_OF_RASTER | GDAL_OF_SHARED,
+                          nullptr, nullptr, nullptr);
+    if( poSrcDS == nullptr )
+    {
+        return nullptr;
+    }
+
+    // Parse query string
+    CPLStringList aosTokens(CSLTokenizeString2(osQueryString, "&", 0));
+    std::vector<int> anBands;
+    for( int i = 0; i < aosTokens.size(); i++ )
+    {
+        char* pszKey = nullptr;
+        const char* pszValue = CPLParseNameValue(aosTokens[i], &pszKey);
+        if( pszKey && pszValue )
+        {
+            if( EQUAL(pszKey, "bands") )
+            {
+                CPLStringList aosBands(CSLTokenizeString2(pszValue, ",", 0));
+                for( int j = 0; j < aosBands.size(); j++ )
+                {
+                    if( EQUAL(aosBands[j], "mask") )
+                    {
+                        anBands.push_back(0);
+                    }
+                    else
+                    {
+                        const int nBand = atoi(aosBands[j]);
+                        if( nBand <= 0 || nBand > poSrcDS->GetRasterCount() )
+                        {
+                            CPLError(CE_Failure, CPLE_IllegalArg,
+                                    "Invalid band number: %s", aosBands[j]);
+                            poSrcDS->ReleaseRef();
+                            return nullptr;
+                        }
+                        anBands.push_back(nBand);
+                    }
+                }
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Unknown option: %s", pszKey);
+                poSrcDS->ReleaseRef();
+                return nullptr;
+            }
+        }
+        CPLFree(pszKey);
+    }
+
+    CPLStringList argv;
+    argv.AddString("-of");
+    argv.AddString("VRT");
+
+    for( const int nBand: anBands )
+    {
+        argv.AddString("-b");
+        argv.AddString(nBand == 0 ? "mask" : CPLSPrintf("%d", nBand));
+    }
+
+    GDALTranslateOptions* psOptions = GDALTranslateOptionsNew(argv.List(), nullptr);
+
+    auto hRet = GDALTranslate("", GDALDataset::ToHandle(poSrcDS),
+                              psOptions, nullptr);
+
+    GDALTranslateOptionsFree( psOptions );
+
+    poSrcDS->ReleaseRef();
+
+    auto poDS = cpl::down_cast<VRTDataset*>(GDALDataset::FromHandle(hRet));
+    if( poDS )
+    {
+        poDS->SetDescription(pszSpec);
+        poDS->SetWritable(false);
+    }
     return poDS;
 }
 

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -194,6 +194,7 @@ class CPL_DLL VRTDataset CPL_NON_FINAL: public GDALDataset
 
     VRTRasterBand*      InitBand(const char* pszSubclass, int nBand,
                                  bool bAllowPansharpened);
+    static GDALDataset *OpenVRTProtocol( const char* pszSpec );
 
     CPL_DISALLOW_COPY_ASSIGN(VRTDataset)
 


### PR DESCRIPTION
as a convenient way of creating a on-the-fly VRT with a subset of bands