### PR TITLE
Coordinate transformation: add a OGR_CT_OP_SELECTION=PROJ/BEST_ACCURACY/FIRST_MATCHING config option

### DIFF
--- a/gdal/ogr/ogr_proj_p.cpp
+++ b/gdal/ogr/ogr_proj_p.cpp
@@ -50,6 +50,10 @@ static void osr_proj_logger(void * /* user_data */,
     {
         CPLDebug("PROJ", "%s", message);
     }
+    else if( level == PJ_LOG_TRACE )
+    {
+        CPLDebug("PROJ_TRACE", "%s", message);
+    }
 }
 
 static unsigned g_searchPathGenerationCounter = 0;

--- a/gdal/ogr/ogr_proj_p.cpp
+++ b/gdal/ogr/ogr_proj_p.cpp
@@ -48,7 +48,7 @@ static void osr_proj_logger(void * /* user_data */,
     }
     else if( level == PJ_LOG_DEBUG )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "PROJ: %s", message);
+        CPLDebug("PROJ", "%s", message);
     }
 }
 

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -492,17 +492,22 @@ OGRCreateCoordinateTransformation( const OGRSpatialReference *poSource,
  * allowed if a custom coordinate operation is set through the hOptions argument.
  *
  * Starting with GDAL 3.0.3, the OGR_CT_OP_SELECTION configuration option can be
- * set to PROJ (default if PROJ >= 6.3), BEST_ACCURACY or FIRST_MATCHING to decide of the strategy to
- * select the operation to use among candidates, whose area of use is compatible with
- * the points to transform.
+ * set to PROJ (default if PROJ >= 6.3), BEST_ACCURACY or FIRST_MATCHING to decide
+ * of the strategy to select the operation to use among candidates, whose area of
+ * use is compatible with the points to transform. It is only taken into account
+ * if no user defined coordinate transformation pipeline has been specified.
  * <ul>
- * <li>PROJ means the default used by PROJ proj_create_crs_to_crs().</li>
- * <li>BEST_ACCURACY means the operation whose accuracy is best. It is evaluated
+ * <li>PROJ means the default behaviour used by PROJ proj_create_crs_to_crs().
+ *     In particular the operation to use among several initial candidates is
+ *     evaluated for each point to transform.</li>
+ * <li>BEST_ACCURACY means the operation whose accuracy is best. It should be
+ *     close to PROJ behaviour, except that the operation to select is decided
  *     for the average point of the coordinates passed in a single Transform() call.</li>
  * <li>FIRST_MATCHING is the operation ordered first in the list of candidates:
  *     it will not necessarily have the best accuracy, but generally a larger area of
  *     use.  It is evaluated for the average point of the coordinates passed in a
- *     single Transform() call.</li>
+ *     single Transform() call. This was the default behaviour for GDAL 3.0.0 to
+ *     3.0.2</li>
  * </ul>
  *
  * If options contains a user defined coordinate transformation pipeline, it

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -313,6 +313,18 @@ class OGRProjCT : public OGRCoordinateTransformation
 
     bool        bNoTransform = false;
 
+    enum class Strategy
+    {
+        PROJ,
+        BEST_ACCURACY,
+        FIRST_MATCHING
+    };
+#if PROJ_VERSION_MAJOR > 6 || PROJ_VERSION_MINOR >= 3
+    Strategy    m_eStrategy = Strategy::PROJ;
+#else
+    Strategy    m_eStrategy = Strategy::BEST_ACCURACY;
+#endif
+
     bool        ListCoordinateOperations(const char* pszSrcSRS,
                                          const char* pszTargetSRS,
                                          const OGRCoordinateTransformationOptions& options );
@@ -326,24 +338,38 @@ class OGRProjCT : public OGRCoordinateTransformation
         PJ* pj = nullptr;
         CPLString osName{};
         CPLString osProjString{};
+        double accuracy = 0.0;
 
         Transformation(double minxIn, double minyIn, double maxxIn, double maxyIn,
                        PJ* pjIn,
                        const CPLString& osNameIn,
-                       const CPLString& osProjStringIn):
+                       const CPLString& osProjStringIn,
+                       double accuracyIn):
             minx(minxIn), miny(minyIn), maxx(maxxIn), maxy(maxyIn),
-            pj(pjIn), osName(osNameIn), osProjString(osProjStringIn) {}
+            pj(pjIn), osName(osNameIn), osProjString(osProjStringIn),
+            accuracy(accuracyIn) {}
 
         Transformation(const Transformation&) = delete;
+        Transformation(Transformation&& other):
+            minx(other.minx), miny(other.miny), maxx(other.maxx), maxy(other.maxy),
+            pj(other.pj), osName(std::move(other.osName)),
+            osProjString(std::move(other.osProjString)),
+            accuracy(other.accuracy)
+        {
+            other.pj = nullptr;
+        }
         Transformation& operator=(const Transformation&) = delete;
 
         ~Transformation()
         {
-            proj_assign_context(pj, OSRGetProjTLSContext());
-            proj_destroy(pj);
+            if( pj )
+            {
+                proj_assign_context(pj, OSRGetProjTLSContext());
+                proj_destroy(pj);
+            }
         }
     };
-    std::list<Transformation> m_oTransformations{};
+    std::vector<Transformation> m_oTransformations{};
     int m_iCurTransformation = -1;
 
 public:
@@ -464,6 +490,20 @@ OGRCreateCoordinateTransformation( const OGRSpatialReference *poSource,
  *
  * The source SRS and target SRS should generally not be NULL. This is only
  * allowed if a custom coordinate operation is set through the hOptions argument.
+ *
+ * Starting with GDAL 3.0.3, the OGR_CT_OP_SELECTION configuration option can be
+ * set to PROJ (default if PROJ >= 6.3), BEST_ACCURACY or FIRST_MATCHING to decide of the strategy to
+ * select the operation to use among candidates, whose area of use is compatible with
+ * the points to transform.
+ * <ul>
+ * <li>PROJ means the default used by PROJ proj_create_crs_to_crs().</li>
+ * <li>BEST_ACCURACY means the operation whose accuracy is best. It is evaluated
+ *     for the average point of the coordinates passed in a single Transform() call.</li>
+ * <li>FIRST_MATCHING is the operation ordered first in the list of candidates:
+ *     it will not necessarily have the best accuracy, but generally a larger area of
+ *     use.  It is evaluated for the average point of the coordinates passed in a
+ *     single Transform() call.</li>
+ * </ul>
  *
  * If options contains a user defined coordinate transformation pipeline, it
  * will be unconditionally used.
@@ -820,6 +860,20 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
         CPLFree(pszDstProj4Defn);
     }
 
+    const char* pszCTOpSelection = CPLGetConfigOption("OGR_CT_OP_SELECTION", nullptr);
+    if( pszCTOpSelection )
+    {
+        if( EQUAL(pszCTOpSelection, "PROJ") )
+            m_eStrategy = Strategy::PROJ;
+        else if( EQUAL(pszCTOpSelection, "BEST_ACCURACY") )
+            m_eStrategy = Strategy::BEST_ACCURACY;
+        else if( EQUAL(pszCTOpSelection, "FIRST_MATCHING") )
+            m_eStrategy = Strategy::FIRST_MATCHING;
+        else
+            CPLError(CE_Warning, CPLE_NotSupported,
+                     "OGR_CT_OP_SELECTION=%s not supported", pszCTOpSelection);
+    }
+
     if( !options.d->osCoordOperation.empty() )
     {
         auto ctx = OSRGetProjTLSContext();
@@ -911,7 +965,35 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
         char* pszSrcSRS = exportSRSToText(poSRSSource);
         char* pszTargetSRS = exportSRSToText(poSRSTarget);
 
-        if( !ListCoordinateOperations(pszSrcSRS, pszTargetSRS, options) )
+        if( m_eStrategy == Strategy::PROJ )
+        {
+            PJ_AREA* area = nullptr;
+            if( options.d->bHasAreaOfInterest )
+            {
+                area = proj_area_create();
+                proj_area_set_bbox(area,
+                    options.d->dfWestLongitudeDeg,
+                    options.d->dfSouthLatitudeDeg,
+                    options.d->dfEastLongitudeDeg,
+                    options.d->dfNorthLatitudeDeg);
+            }
+            auto ctx = OSRGetProjTLSContext();
+            m_pj = proj_create_crs_to_crs(ctx, pszSrcSRS, pszTargetSRS, area);
+            if( area )
+                proj_area_destroy(area);
+            if( m_pj == nullptr )
+            {
+                CPLError( CE_Failure, CPLE_NotSupported,
+                            "Cannot find coordinate operations from `%s' to `%s'",
+                            pszSrcSRS,
+                            pszTargetSRS );
+                CPLFree( pszSrcSRS );
+                CPLFree( pszTargetSRS );
+                return FALSE;
+            }
+
+        }
+        else if( !ListCoordinateOperations(pszSrcSRS, pszTargetSRS, options) )
         {
             CPLError( CE_Failure, CPLE_NotSupported,
                         "Cannot find coordinate operations from `%s' to `%s'",
@@ -1194,6 +1276,7 @@ bool OGRProjCT::ListCoordinateOperations(const char* pszSrcSRS,
         if( minx <= maxx )
         {
             CPLString osProjString;
+            const double accuracy = proj_coordoperation_get_accuracy(ctx, op);
             auto pj = op_to_pj(ctx, op, &osProjString);
             CPLString osName;
             auto name = proj_get_name(op);
@@ -1204,7 +1287,7 @@ bool OGRProjCT::ListCoordinateOperations(const char* pszSrcSRS,
             if( pj )
             {
                 m_oTransformations.emplace_back(
-                    minx, miny, maxx, maxy, pj, osName, osProjString);
+                    minx, miny, maxx, maxy, pj, osName, osProjString, accuracy);
             }
         }
         return op;
@@ -1565,37 +1648,101 @@ int OGRProjCT::Transform( int nCount, double *x, double *y, double *z,
             avgX /= nCountValid;
             avgY /= nCountValid;
         }
-        int iBestTransf = -1;
-        const char* pszProjString = nullptr;
-        const char* pszOpName = nullptr;
-        // The first transformation whose BBOX match our data is the best
-        // one given the sorting order.
+
+        constexpr int N_MAX_RETRY = 2;
+        int iExcluded[N_MAX_RETRY] = {-1, -1};
+
+        const int nOperations = static_cast<int>(m_oTransformations.size());
+        PJ_COORD coord;
+        coord.xyzt.x = avgX;
+        coord.xyzt.y = avgY;
+        coord.xyzt.z = z ? z[0] : 0;
+        coord.xyzt.t = t ? t[0] : HUGE_VAL;
+
+        // We may need several attempts. For example the point at
+        // lon=-111.5 lat=45.26 falls into the bounding box of the Canadian
+        // ntv2_0.gsb grid, except that it is not in any of the subgrids, being
+        // in the US. We thus need another retry that will select the conus
+        // grid.
+        for( int iRetry = 0; iRetry <= N_MAX_RETRY; iRetry++ )
         {
-            int i = 0;
-            for( const auto& transf: m_oTransformations )
+            int iBestTransf = -1;
+            // Select transform whose BBOX match our data and has the best accuracy
+            // if m_eStrategy == BEST_ACCURACY. Or just the first BBOX matching one, if
+            //  m_eStrategy == FIRST_MATCHING
+            double dfBestAccuracy = std::numeric_limits<double>::infinity();
+            for( int i = 0; i < nOperations; i++ )
             {
-                if( avgX >= transf.minx && avgX <= transf.maxx &&
-                    avgY >= transf.miny && avgY <= transf.maxy )
+                if( i == iExcluded[0] || i == iExcluded[1] )
                 {
-                    pj = transf.pj;
-                    pszProjString = transf.osProjString.c_str();
-                    pszOpName = transf.osName.c_str();
-                    iBestTransf = i;
-                    break;
+                    continue;
                 }
-                i++;
+                const auto& transf = m_oTransformations[i];
+                if( avgX >= transf.minx && avgX <= transf.maxx &&
+                    avgY >= transf.miny && avgY <= transf.maxy &&
+                    (iBestTransf < 0 || (transf.accuracy >= 0 &&
+                                        transf.accuracy < dfBestAccuracy)) )
+                {
+                    iBestTransf = i;
+                    dfBestAccuracy = transf.accuracy;
+                    if( m_eStrategy == Strategy::FIRST_MATCHING )
+                        break;
+                }
             }
-        }
-        if( pj )
-        {
+            if( iBestTransf < 0 )
+            {
+                break;
+            }
+            const auto& transf = m_oTransformations[iBestTransf];
+            pj = transf.pj;
+            proj_assign_context( pj, ctx );
             if( iBestTransf != m_iCurTransformation )
             {
                 CPLDebug("OGRCT", "Selecting transformation %s (%s)",
-                         pszProjString, pszOpName);
+                        transf.osProjString.c_str(),
+                        transf.osName.c_str());
                 m_iCurTransformation = iBestTransf;
             }
+
+            auto res = proj_trans(pj, m_bReversePj ? PJ_INV : PJ_FWD, coord);
+            if( res.xyzt.x != HUGE_VAL ) {
+                break;
+            }
+            pj = nullptr;
+            CPLDebug("OGRCT", 
+                     "Did not result in valid result. "
+                     "Attempting a retry with another operation.");
+            if( iRetry == N_MAX_RETRY ) {
+                break;
+            }
+            iExcluded[iRetry] = iBestTransf;
         }
-        else
+
+        if( !pj )
+        {
+            // In case we did not find an operation whose area of use is compatible
+            // with the input coordinate, then goes through again the list, and
+            // use the first operation that does not require grids.
+            for( int i = 0; i < nOperations; i++ )
+            {
+                const auto& transf = m_oTransformations[i];
+                if( proj_coordoperation_get_grid_used_count(ctx, transf.pj) == 0 )
+                {
+                    pj = transf.pj;
+                    proj_assign_context( pj, ctx );
+                    if( i != m_iCurTransformation )
+                    {
+                        CPLDebug("OGRCT", "Selecting transformation %s (%s)",
+                                transf.osProjString.c_str(),
+                                transf.osName.c_str());
+                        m_iCurTransformation = i;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if( !pj )
         {
             if( m_bEmitErrors && ++nErrorCount < 20 )
             {


### PR DESCRIPTION
With PROJ >= 6.3, make PROJ the default. Otherwise default to BEST_ACCURACY
Previous behaviour was FIRST_MATCHING
BEST_ACCURACY matches closely the behaviour of PROJ 6.3.0, except that it
is evaluated just once per call to OGRProjCT::Transform()

