### PR TITLE
Make GDALTermProgress streaming-friendly: write to stderr, not stdout.

### DIFF
--- a/autotest/gdrivers/vrtmask.py
+++ b/autotest/gdrivers/vrtmask.py
@@ -300,7 +300,7 @@ def test_vrtmask_9():
     src_ds = gdal.GetDriverByName('GTiff').Create('tmp/vrtmask_9_src.tif', 10, 10, 4)
     del src_ds
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/vrtmask_9_src.tif tmp/vrtmask_9_dst.tif -b 1 -b 2 -b 3')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' tmp/vrtmask_9_src.tif tmp/vrtmask_9_dst.tif -q -b 1 -b 2 -b 3')
 
     ds = gdal.Open('tmp/vrtmask_9_dst.tif')
     flags = ds.GetRasterBand(1).GetMaskFlags()

--- a/autotest/utilities/test_gdal_contour.py
+++ b/autotest/utilities/test_gdal_contour.py
@@ -94,7 +94,7 @@ def test_gdal_contour_1():
 
     ds = None
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_contour_path() + ' -a elev -i 10 tmp/gdal_contour.tif tmp/contour.shp')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_contour_path() + ' -q -a elev -i 10 tmp/gdal_contour.tif tmp/contour.shp')
     assert (err is None or err == ''), 'got error/warning'
 
     ds = ogr.Open('tmp/contour.shp')

--- a/autotest/utilities/test_gdal_grid.py
+++ b/autotest/utilities/test_gdal_grid.py
@@ -104,7 +104,7 @@ def test_gdal_grid_1():
     shape_ds.Destroy()
 
     # Create a GDAL dataset from the previous generated OGR grid
-    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -a nearest:radius1=0.0:radius2=0.0:angle=0.0 -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
+    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -q -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -a nearest:radius1=0.0:radius2=0.0:angle=0.0 -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
     assert (err is None or err == ''), 'got error/warning'
 
     # We should get the same values as in n43.td0
@@ -771,7 +771,7 @@ def test_gdal_grid_11():
     outfiles.append('tmp/n43_linear.tif')
 
     # Create a GDAL dataset from the previous generated OGR grid
-    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -l n43 -a linear -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
+    (_, err) = gdaltest.runexternal_out_and_err(gdal_grid + ' -q -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -l n43 -a linear -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 tmp/n43.shp ' + outfiles[-1])
     assert (err is None or err == ''), 'got error/warning'
 
     # We should get the same values as in n43.td0

--- a/autotest/utilities/test_gdal_rasterize.py
+++ b/autotest/utilities/test_gdal_rasterize.py
@@ -104,7 +104,7 @@ def test_gdal_rasterize_1():
     rast_ogr_ds.Destroy()
 
     # Run the algorithm.
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_rasterize_path() + ' -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l rast1 tmp/rast1.tab tmp/rast1.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_rasterize_path() + ' -q -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l rast1 tmp/rast1.tab tmp/rast1.tif')
     assert (err is None or err == ''), 'got error/warning'
 
     # Check results.

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -45,7 +45,7 @@ def test_gdal_translate_1():
     if test_cli_utilities.get_gdal_translate_path() is None:
         pytest.skip()
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test1.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' -q ../gcore/data/byte.tif tmp/test1.tif')
     assert (err is None or err == ''), 'got error/warning'
 
     ds = gdal.Open('tmp/test1.tif')
@@ -626,7 +626,7 @@ def test_gdal_translate_29():
     if test_cli_utilities.get_gdal_translate_path() is None:
         pytest.skip()
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test_gdal_translate_29.tif -outsize 50% 50% -r cubic')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_translate_path() + ' ../gcore/data/byte.tif tmp/test_gdal_translate_29.tif -q -outsize 50% 50% -r cubic')
     assert (err is None or err == ''), 'got error/warning'
 
     ds = gdal.Open('tmp/test_gdal_translate_29.tif')

--- a/autotest/utilities/test_gdaladdo.py
+++ b/autotest/utilities/test_gdaladdo.py
@@ -49,7 +49,7 @@ def test_gdaladdo_1():
     shutil.copy('../gcore/data/mfloat32.vrt', 'tmp/mfloat32.vrt')
     shutil.copy('../gcore/data/float32.tif', 'tmp/float32.tif')
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaladdo_path() + ' tmp/mfloat32.vrt 2 4')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaladdo_path() + ' -q tmp/mfloat32.vrt 2 4')
     assert (err is None or err == ''), 'got error/warning'
 
     ds = gdal.Open('tmp/mfloat32.vrt')

--- a/autotest/utilities/test_gdalbuildvrt.py
+++ b/autotest/utilities/test_gdalbuildvrt.py
@@ -99,7 +99,7 @@ def test_gdalbuildvrt_1():
     ds.GetRasterBand(1).Fill(255)
     ds = None
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalbuildvrt_path() + ' tmp/mosaic.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalbuildvrt_path() + ' -q tmp/mosaic.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif')
     assert (err is None or err == ''), 'got error/warning'
 
     return gdalbuildvrt_check()

--- a/autotest/utilities/test_gdaldem.py
+++ b/autotest/utilities/test_gdaldem.py
@@ -46,7 +46,7 @@ def test_gdaldem_hillshade():
     if test_cli_utilities.get_gdaldem_path() is None:
         pytest.skip()
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -q -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade.tif')
     assert (err is None or err == ''), 'got error/warning'
 
     src_ds = gdal.Open('../gdrivers/data/n43.dt0')
@@ -77,7 +77,7 @@ def test_gdaldem_hillshade_compressed_tiled_output():
     if test_cli_utilities.get_gdaldem_path() is None:
         pytest.skip()
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade_compressed_tiled.tif -co TILED=YES -co COMPRESS=DEFLATE --config GDAL_CACHEMAX 0')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdaldem_path() + ' hillshade -q -s 111120 -z 30 ../gdrivers/data/n43.dt0 tmp/n43_hillshade_compressed_tiled.tif -co TILED=YES -co COMPRESS=DEFLATE --config GDAL_CACHEMAX 0')
     assert (err is None or err == ''), 'got error/warning'
 
     ds = gdal.Open('tmp/n43_hillshade_compressed_tiled.tif')

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -683,13 +683,13 @@ def test_gdalwarp_31():
     cs1 = ds.GetRasterBand(1).Checksum()
     ds = None
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326")
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -q -t_srs EPSG:4326")
 
     ds = gdal.Open('tmp/testgdalwarp31.tif')
     cs2 = ds.GetRasterBand(1).Checksum()
     ds = None
 
-    (_, err2) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326 -overwrite")
+    (_, err2) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdalwarp_path() + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -q -t_srs EPSG:4326 -overwrite")
 
     ds = gdal.Open('tmp/testgdalwarp31.tif')
     cs3 = ds.GetRasterBand(1).Checksum()

--- a/autotest/utilities/test_nearblack.py
+++ b/autotest/utilities/test_nearblack.py
@@ -46,7 +46,7 @@ def test_nearblack_1():
     if test_cli_utilities.get_nearblack_path() is None:
         pytest.skip()
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' ../gdrivers/data/rgbsmall.tif -nb 0 -of GTiff -o tmp/nearblack1.tif')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' ../gdrivers/data/rgbsmall.tif -q -nb 0 -of GTiff -o tmp/nearblack1.tif')
     assert (err is None or err == ''), 'got error/warning'
 
     src_ds = gdal.Open('../gdrivers/data/rgbsmall.tif')
@@ -195,7 +195,7 @@ def test_nearblack_8():
     gdal.GetDriverByName('GTiff').CreateCopy('tmp/nearblack8.tif', src_ds)
     src_ds = None
 
-    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' tmp/nearblack8.tif -nb 0')
+    (_, err) = gdaltest.runexternal_out_and_err(test_cli_utilities.get_nearblack_path() + ' tmp/nearblack8.tif -q -nb 0')
     assert (err is None or err == ''), 'got error/warning'
 
     ds = gdal.Open('tmp/nearblack8.tif')

--- a/autotest/utilities/test_ogr2ogr.py
+++ b/autotest/utilities/test_ogr2ogr.py
@@ -474,8 +474,8 @@ def test_ogr2ogr_17():
     except (OSError, AttributeError):
         pass
 
-    ret = gdaltest.runexternal(test_cli_utilities.get_ogr2ogr_path() + ' -progress tmp/poly.shp ../ogr/data/poly.shp')
-    assert ret.find('0...10...20...30...40...50...60...70...80...90...100 - done.') != -1
+    (_, err) = gdaltest.runexternal(test_cli_utilities.get_ogr2ogr_path() + ' -progress tmp/poly.shp ../ogr/data/poly.shp')
+    assert err.find('0...10...20...30...40...50...60...70...80...90...100 - done.') != -1
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10

--- a/gdal/port/cpl_progress.cpp
+++ b/gdal/port/cpl_progress.cpp
@@ -240,8 +240,6 @@ int CPL_STDCALL GDALTermProgress( double dfComplete,
 
     if( nThisTick == 40 )
         fprintf( stderr, " - done.\n" );
-    else
-        fflush( stderr );
 
     return TRUE;
 }

--- a/gdal/port/cpl_progress.cpp
+++ b/gdal/port/cpl_progress.cpp
@@ -233,15 +233,15 @@ int CPL_STDCALL GDALTermProgress( double dfComplete,
     {
         ++nLastTick;
         if( nLastTick % 4 == 0 )
-            fprintf( stdout, "%d", (nLastTick / 4) * 10 );
+            fprintf( stderr, "%d", (nLastTick / 4) * 10 );
         else
-            fprintf( stdout, "." );
+            fprintf( stderr, "." );
     }
 
     if( nThisTick == 40 )
-        fprintf( stdout, " - done.\n" );
+        fprintf( stderr, " - done.\n" );
     else
-        fflush( stdout );
+        fflush( stderr );
 
     return TRUE;
 }


### PR DESCRIPTION
Streaming input and output through a shell pipeline saves one from writing large intermediate files to disk. For example:

```sh
gdal_contour -a elev -i 100 -f PGDump elev48i0100a.tif /dev/stdout | psql ned
```

However, this results in a strange error:

```
ERROR:  syntax error at or near "0"
LINE 1: 0INSERT INTO "public"."contour" ("wkb_geometry" , "id", "ele...
```

This happens because the `0...10...20...` progress bar is written by `GDALTermProgress()` to `stdout` rather than `stderr`, the standard place for progress reporting.

Note that `fflush(3)` is now unnecessary because [`stdout` is line-buffered, but `stderr` is unbuffered](https://linux.die.net/man/3/stderr).