### PR TITLE
Allow Travis sanitize build to work on plain Ubuntu 16.04

### DIFF
--- a/gdal/ci/travis/sanitize/before_install.sh
+++ b/gdal/ci/travis/sanitize/before_install.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-sudo mv /etc/apt/sources.list.d/pgdg* /tmp
+
+if [ -f /etc/apt/sources.list.d/pgdg* ]; then
+   sudo mv /etc/apt/sources.list.d/pgdg* /tmp
+fi
 sudo apt-get update
 sudo apt-get install -y software-properties-common python-software-properties
 sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
@@ -12,8 +15,9 @@ sudo apt-get update
 sudo apt-get install -y --allow-unauthenticated python-numpy libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libsqlite3-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libpodofo-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libmysqlclient-dev libogdi3.2-dev libcfitsio-dev openjdk-8-jdk couchdb libzstd1-dev ccache curl autoconf automake sqlite3 libspatialite-dev
 sudo apt-get install -y doxygen texlive-latex-base
 sudo apt-get install -y make
-sudo apt-get install -y python-dev
+sudo apt-get install -y python-dev python-pip
 sudo apt-get install -y g++
+sudo apt-get install -y libssl-dev
 sudo apt-get install -y --allow-unauthenticated libsfcgal-dev
 sudo apt-get install -y --allow-unauthenticated fossil libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev
 

--- a/gdal/ci/travis/sanitize/before_install.sh
+++ b/gdal/ci/travis/sanitize/before_install.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-
-if [ -f /etc/apt/sources.list.d/pgdg* ]; then
-   sudo mv /etc/apt/sources.list.d/pgdg* /tmp
-fi
+sudo mv /etc/apt/sources.list.d/pgdg* /tmp
 sudo apt-get update
 sudo apt-get install -y software-properties-common python-software-properties
 sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable

--- a/gdal/ci/travis/sanitize/install.sh
+++ b/gdal/ci/travis/sanitize/install.sh
@@ -15,7 +15,7 @@ case $SCRIPT_DIR in
 esac
 $SCRIPT_DIR/../common_install.sh
 
-export ASAN_OPTIONS=allocator_may_return_null=1 
+export ASAN_OPTIONS=allocator_may_return_null=1
 
 export CCACHE_CPP2=yes
 export CC="ccache $PWD/clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-16.04/bin/clang"
@@ -26,7 +26,7 @@ ccache -s
 
 # Build proj
 (cd proj;  ./autogen.sh && CFLAGS='-DPROJ_RENAME_SYMBOLS' CXXFLAGS='-DPROJ_RENAME_SYMBOLS' ./configure --disable-static --prefix=/usr/local && make -j3)
-(cd proj; sudo make -j3 install && sudo mv /usr/local/lib/libproj.so.15.0.0 /usr/local/lib/libinternalproj.so.15.0.0 && sudo rm /usr/local/lib/libproj.so*  && sudo rm /usr/local/lib/libproj.la && sudo ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so.15 && sudo ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so)
+(cd proj; sudo make -j3 install && sudo mv /usr/local/lib/libproj.so.15.0.0 /usr/local/lib/libinternalproj.so.15.0.0 && sudo rm /usr/local/lib/libproj.so*  && sudo rm /usr/local/lib/libproj.la && sudo ln -f -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so.15 && sudo ln -f -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so)
 
 cd gdal
 

--- a/gdal/ci/travis/sanitize/script.sh
+++ b/gdal/ci/travis/sanitize/script.sh
@@ -9,15 +9,15 @@ cd gdal
 cd ../autotest
 
 # Don't run these
-rm ogr/ogr_fgdb.py ogr/ogr_pgeo.py
+rm -f ogr/ogr_fgdb.py ogr/ogr_pgeo.py
 
 # Too old spatialite version
-rm ogr/ogr_sqlite.py gdrivers/rasterlite.py
+rm -f ogr/ogr_sqlite.py gdrivers/rasterlite.py
 
 # install test dependencies
 sudo -H pip install -U pip
 sudo -H pip install -U -r ./requirements.txt
-sudo apt-get remove python-numpy
+sudo apt-get remove -y python-numpy
 sudo -H pip install -U numpy
 
 # Run each module in its own pytest process.
@@ -26,7 +26,7 @@ sudo -H pip install -U numpy
 # Unfortunately it's also a reasonably large slowdown since we have to wait
 # for a python interpreter and all modules to load between each module.
 # (and add a grep to get rid of the extra pytest header headers/etc)
-# 
+#
 # NOTE: `find ... -exec` always exits with 0 even when the tests failed.
 # That turns out to be what we want here though, since we want
 # to not fail when the address sanitizer finds errors.


### PR DESCRIPTION
Found out I could reuse the sanitize setup on a plain Ubuntu 16.04 with these changes. Should still work at Travis.