### PR TITLE
Fix autotest/scripts issues raised by Flake8 F632 'use ==/!= to compare str, bytes, and int literals'

### DIFF
--- a/autotest/gcore/gdal_api_proxy.py
+++ b/autotest/gcore/gdal_api_proxy.py
@@ -41,7 +41,7 @@ import pytest
 # Test forked gdalserver
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def gdalserver_path():
     import test_cli_utilities
     gdalserver_path = test_cli_utilities.get_cli_utility_path('gdalserver')
@@ -413,19 +413,19 @@ if __name__ == '__main__':
 
         gdal.SetConfigOption('GDAL_API_PROXY', 'YES')
         if sys.platform == 'win32':
-            gdalserver_path = sys.argv[1]  # noqa
-            gdal.SetConfigOption('GDAL_API_PROXY_SERVER', gdalserver_path)
+            arg_gdalserver_path = sys.argv[1]  # noqa
+            gdal.SetConfigOption('GDAL_API_PROXY_SERVER', arg_gdalserver_path)
 
         gdaltest.api_proxy_server_p = None
         gdaltest_list = [_gdal_api_proxy_sub]
 
     elif len(sys.argv) >= 3 and sys.argv[2] == '-2':
 
-        gdalserver_path = sys.argv[1]
+        arg_gdalserver_path = sys.argv[1]
 
         p = None
         for port in [8080, 8081, 8082]:
-            p = subprocess.Popen([gdalserver_path, '-tcpserver', '%d' % port])
+            p = subprocess.Popen([arg_gdalserver_path, '-tcpserver', '%d' % port])
             time.sleep(1)
             if p.poll() is None:
                 break
@@ -447,9 +447,9 @@ if __name__ == '__main__':
 
     elif len(sys.argv) >= 3 and sys.argv[2] == '-3':
 
-        gdalserver_path = sys.argv[1]
+        arg_gdalserver_path = sys.argv[1]
 
-        p = subprocess.Popen([gdalserver_path, '-unixserver', 'tmp/gdalapiproxysocket'])
+        p = subprocess.Popen([arg_gdalserver_path, '-unixserver', 'tmp/gdalapiproxysocket'])
         time.sleep(1)
         if p.poll() is None:
             gdal.SetConfigOption('GDAL_API_PROXY', 'YES')
@@ -466,9 +466,9 @@ if __name__ == '__main__':
 
     elif len(sys.argv) >= 3 and sys.argv[2] == '-4':
 
-        gdalserver_path = sys.argv[1]
+        arg_gdalserver_path = sys.argv[1]
 
-        p = subprocess.Popen([gdalserver_path, '-nofork', '-unixserver', 'tmp/gdalapiproxysocket'])
+        p = subprocess.Popen([arg_gdalserver_path, '-nofork', '-unixserver', 'tmp/gdalapiproxysocket'])
         time.sleep(1)
         if p.poll() is None:
             gdal.SetConfigOption('GDAL_API_PROXY', 'YES')

--- a/autotest/gcore/vsicrypt.py
+++ b/autotest/gcore/vsicrypt.py
@@ -37,6 +37,7 @@ import gdaltest
 import pytest
 
 from gcore.testnonboundtoswig import setup as testnonboundtoswig_setup  # noqa
+testnonboundtoswig_setup; # to please pyflakes
 
 ###############################################################################
 # Use common test for /vsicrypt

--- a/autotest/gdrivers/netcdf_cf.py
+++ b/autotest/gdrivers/netcdf_cf.py
@@ -32,6 +32,7 @@
 import os
 import imp  # for netcdf_cf_setup()
 from gdrivers.netcdf import netcdf_setup, netcdf_test_copy  # noqa
+netcdf_setup; # to please pyflakes
 from osgeo import gdal
 from osgeo import osr
 

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -31,6 +31,7 @@
 from osgeo import gdal
 from osgeo import osr
 from gdrivers.netcdf import netcdf_setup  # noqa
+netcdf_setup; # to please pyflakes
 
 import gdaltest
 import pytest

--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -92,7 +92,7 @@ def test_ogr_esrijson_read_point():
     ds = ogr.Open('data/esripoint.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('esripoint')
     assert lyr is not None, 'Missing layer called esripoint'
@@ -141,7 +141,7 @@ def test_ogr_esrijson_read_linestring():
     ds = ogr.Open('data/esrilinestring.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -191,7 +191,7 @@ def test_ogr_esrijson_read_polygon():
     ds = ogr.Open('data/esripolygon.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -229,7 +229,7 @@ def test_ogr_esrijson_read_multipoint():
     ds = ogr.Open('data/esrimultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -256,7 +256,7 @@ def test_ogr_esrijson_read_pointz():
     ds = ogr.Open('data/esrizpoint.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -305,7 +305,7 @@ def test_ogr_esrijson_read_linestringz():
     ds = ogr.Open('data/esrizlinestring.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -333,7 +333,7 @@ def test_ogr_esrijson_read_multipointz():
     ds = ogr.Open('data/esrizmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -361,7 +361,7 @@ def test_ogr_esrijson_read_polygonz():
     ds = ogr.Open('data/esrizpolygon.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -389,7 +389,7 @@ def test_ogr_esrijson_read_multipointm():
     ds = ogr.Open('data/esrihasmnozmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -416,7 +416,7 @@ def test_ogr_esrijson_read_pointz_withou_z():
     ds = ogr.Open('data/esriinvalidhaszmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 
@@ -443,7 +443,7 @@ def test_ogr_esrijson_read_multipointzm():
     ds = ogr.Open('data/esrizmmultipoint.json')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayer(0)
 

--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -667,3 +667,26 @@ def test_ogr_esrijson_create_geometry_from_esri_json():
 
     g = ogr.CreateGeometryFromEsriJson('{ "x": 2, "y": 49 }')
     assert g.ExportToWkt() == 'POINT (2 49)'
+
+
+###############################################################################
+# Test for https://github.com/OSGeo/gdal/issues/2007
+
+def test_ogr_esrijson_identify_srs():
+
+    data = """
+        {
+        "objectIdFieldName" : "objectid",
+        "geometryType" : "esriGeometryPoint",
+        "spatialReference":{"wkt":"PROJCS[\\"NAD_1983_StatePlane_Arizona_Central_FIPS_0202_IntlFeet\\",GEOGCS[\\"GCS_North_American_1983\\",DATUM[\\"D_North_American_1983\\",SPHEROID[\\"GRS_1980\\",6378137.0,298.257222101]],PRIMEM[\\"Greenwich\\",0.0],UNIT[\\"Degree\\",0.0174532925199433]],PROJECTION[\\"Transverse_Mercator\\"],PARAMETER[\\"False_Easting\\",700000.0],PARAMETER[\\"False_Northing\\",0.0],PARAMETER[\\"Central_Meridian\\",-111.9166666666667],PARAMETER[\\"Scale_Factor\\",0.9999],PARAMETER[\\"Latitude_Of_Origin\\",31.0],UNIT[\\"Foot\\",0.3048]]"},
+        "fields" : [],
+        "features" : []
+        }
+        """
+
+    ds = ogr.Open(data)
+    assert ds is not None
+    lyr = ds.GetLayer(0)
+    sr = lyr.GetSpatialRef()
+    assert sr
+    assert sr.GetAuthorityCode(None) == '2223'

--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  ESRIJson driver test suite.
+# Author:   Even Rouault <even dot rouault at spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2009-2019, Even Rouault <even dot rouault at spatialys.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import contextlib
+
+from osgeo import ogr
+from osgeo import gdal
+
+import gdaltest
+import ogrtest
+import pytest
+
+pytestmark = pytest.mark.require_driver('ESRIJson')
+
+###############################################################################
+# Test utilities
+
+
+def validate_layer(lyr, name, features, typ, fields, box):
+
+    if name is not None and name != lyr.GetName():
+        print('Wrong layer name')
+        return False
+
+    if features != lyr.GetFeatureCount():
+        print('Wrong number of features')
+        return False
+
+    lyrDefn = lyr.GetLayerDefn()
+    if lyrDefn is None:
+        print('Layer definition is none')
+        return False
+
+    if typ != lyrDefn.GetGeomType():
+        print('Wrong geometry type')
+        print(lyrDefn.GetGeomType())
+        return False
+
+    if fields != lyrDefn.GetFieldCount():
+        print('Wrong number of fields')
+        return False
+
+    extent = lyr.GetExtent()
+
+    minx = abs(extent[0] - box[0])
+    maxx = abs(extent[1] - box[1])
+    miny = abs(extent[2] - box[2])
+    maxy = abs(extent[3] - box[3])
+
+    if max(minx, maxx, miny, maxy) > 0.0001:
+        print('Wrong spatial extent of layer')
+        print(extent)
+        return False
+
+    return True
+
+
+###############################################################################
+# Test reading ESRI point file
+
+
+def test_ogr_esrijson_read_point():
+
+    ds = ogr.Open('data/esripoint.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayerByName('esripoint')
+    assert lyr is not None, 'Missing layer called esripoint'
+
+    extent = (2, 2, 49, 49)
+
+    rc = validate_layer(lyr, 'esripoint', 1, ogr.wkbPoint, 4, extent)
+    assert rc
+
+    ref = lyr.GetSpatialRef()
+    gcs = int(ref.GetAuthorityCode('GEOGCS'))
+
+    assert gcs == 4326, "Spatial reference was not valid"
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('POINT(2 49)')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFID() != 1:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFieldAsInteger('fooInt') != 2:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFieldAsDouble('fooDouble') != 3.4:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFieldAsString('fooString') != '56':
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI linestring file
+
+
+def test_ogr_esrijson_read_linestring():
+
+    ds = ogr.Open('data/esrilinestring.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    extent = (2, 3, 49, 50)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('LINESTRING (2 49,3 50)')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+    # MultiLineString
+    ds = ogr.Open("""{
+  "geometryType": "esriGeometryPolyline",
+  "fields": [],
+  "features": [
+  {
+   "geometry": {
+      "paths" : [
+       [ [2,49],[2.1,49.1] ],
+       [ [3,50],[3.1,50.1] ]
+      ]
+   }
+  }
+ ]
+}""")
+    lyr = ds.GetLayer(0)
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('MULTILINESTRING ((2 49,2.1 49.1),(3 50,3.1 50.1))')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+
+###############################################################################
+# Test reading ESRI polygon file
+
+
+def test_ogr_esrijson_read_polygon():
+
+    ds = ogr.Open('data/esripolygon.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    extent = (-3, 3, 49, 50)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOLYGON (((2 49,2 50,3 50,3 49,2 49),(2.1 49.1,2.1 49.9,2.9 49.9,2.9 49.1,2.1 49.1)),((-2 49,-2 50,-3 50,-3 49,-2 49)))')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+    ds = ogr.Open('data/esripolygonempty.json')
+    assert ds is not None, 'Failed to open datasource'
+    lyr = ds.GetLayer(0)
+    feature = lyr.GetNextFeature()
+    if feature.GetGeometryRef().ExportToWkt() != 'POLYGON EMPTY':
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI multipoint file
+
+
+def test_ogr_esrijson_read_multipoint():
+
+    ds = ogr.Open('data/esrimultipoint.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    extent = (2, 3, 49, 50)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49,3 50)')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI point file with z value
+
+
+def test_ogr_esrijson_read_pointz():
+
+    ds = ogr.Open('data/esrizpoint.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    # validate layer doesn't check z, but put it in
+    extent = (2, 2, 49, 49, 1, 1)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbPoint, 4, extent)
+    assert rc
+
+    ref = lyr.GetSpatialRef()
+    gcs = int(ref.GetAuthorityCode('GEOGCS'))
+
+    assert gcs == 4326, "Spatial reference was not valid"
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('POINT(2 49 1)')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFID() != 1:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFieldAsInteger('fooInt') != 2:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFieldAsDouble('fooDouble') != 3.4:
+        feature.DumpReadable()
+        pytest.fail()
+
+    if feature.GetFieldAsString('fooString') != '56':
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI linestring file with z
+
+
+def test_ogr_esrijson_read_linestringz():
+
+    ds = ogr.Open('data/esrizlinestring.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    # validate layer doesn't check z, but put it in
+    extent = (2, 3, 49, 50, 1, 2)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('LINESTRING (2 49 1,3 50 2)')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI multipoint file with z
+
+
+def test_ogr_esrijson_read_multipointz():
+
+    ds = ogr.Open('data/esrizmultipoint.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    # validate layer doesn't check z, but put it in
+    extent = (2, 3, 49, 50, 1, 2)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49 1,3 50 2)')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI polygon file with z
+
+
+def test_ogr_esrijson_read_polygonz():
+
+    ds = ogr.Open('data/esrizpolygon.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    # validate layer doesn't check z, but put it in
+    extent = (2, 3, 49, 50, 1, 4)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('POLYGON ((2 49 1,2 50 2,3 50 3,3 49 4,2 49 1))')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI multipoint file with m, but no z (hasM=true, hasZ omitted)
+
+
+def test_ogr_esrijson_read_multipointm():
+
+    ds = ogr.Open('data/esrihasmnozmultipoint.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    extent = (2, 3, 49, 50)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT M ((2 49 1),(3 50 2))')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI multipoint file with hasZ=true, but only 2 components.
+
+
+def test_ogr_esrijson_read_pointz_withou_z():
+
+    ds = ogr.Open('data/esriinvalidhaszmultipoint.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    extent = (2, 3, 49, 50)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49,3 50)')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test reading ESRI multipoint file with z and m
+
+
+def test_ogr_esrijson_read_multipointzm():
+
+    ds = ogr.Open('data/esrizmmultipoint.json')
+    assert ds is not None, 'Failed to open datasource'
+
+    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+
+    lyr = ds.GetLayer(0)
+
+    extent = (2, 3, 49, 50)
+
+    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
+    assert rc
+
+    feature = lyr.GetNextFeature()
+    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT ZM ((2 49 1 100),(3 50 2 100))')
+    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
+        feature.DumpReadable()
+        pytest.fail()
+
+    lyr = None
+    ds = None
+
+###############################################################################
+# Test ESRI FeatureService scrolling
+
+
+def test_ogr_esrijson_featureservice_scrolling():
+
+    @contextlib.contextmanager
+    def cleanup_after_me():
+        yield
+        files = gdal.ReadDir('/vsimem/esrijson')
+        if files:
+            for f in files:
+                gdal.Unlink('/vsimem/esrijson/' + f)
+
+
+    with cleanup_after_me():
+        with gdaltest.config_option('CPL_CURL_ENABLE_VSIMEM', 'YES'):
+
+            resultOffset0 = """
+        { "type":"FeatureCollection",
+        "properties" : {
+            "exceededTransferLimit" : true
+        },
+        "features" :
+        [
+            {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [ 2, 49 ]
+            },
+            "properties": {
+                "id": 1,
+                "a_property": 1,
+            }
+            } ] }"""
+
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=1', resultOffset0)
+            ds = ogr.Open('/vsimem/esrijson/test.json?resultRecordCount=1')
+            lyr = ds.GetLayer(0)
+            f = lyr.GetNextFeature()
+            assert f is not None and f.GetFID() == 1
+            f = lyr.GetNextFeature()
+            assert f is None
+            ds = None
+            gdal.Unlink('/vsimem/esrijson/test.json?resultRecordCount=1')
+
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=10', resultOffset0)
+            gdal.PushErrorHandler()
+            ds = ogr.Open('/vsimem/esrijson/test.json?resultRecordCount=10')
+            gdal.PopErrorHandler()
+            lyr = ds.GetLayer(0)
+            f = lyr.GetNextFeature()
+            assert f is not None and f.GetFID() == 1
+            f = lyr.GetNextFeature()
+            assert f is None
+            ds = None
+            gdal.Unlink('/vsimem/esrijson/test.json?resultRecordCount=10')
+
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?', resultOffset0)
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=1&resultOffset=0', resultOffset0)
+
+            ds = ogr.Open('/vsimem/esrijson/test.json?')
+            lyr = ds.GetLayer(0)
+            f = lyr.GetNextFeature()
+            assert f is not None and f.GetFID() == 1
+            f = lyr.GetNextFeature()
+            assert f is None
+            lyr.ResetReading()
+            f = lyr.GetNextFeature()
+            assert f is not None and f.GetFID() == 1
+
+            resultOffset1 = """
+        { "type":"FeatureCollection",
+        "features" :
+        [
+            {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [ 2, 49 ]
+            },
+            "properties": {
+                "id": 2,
+                "a_property": 1,
+            }
+            } ] }"""
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=1&resultOffset=1', resultOffset1)
+            f = lyr.GetNextFeature()
+            assert f is not None and f.GetFID() == 2
+            f = lyr.GetNextFeature()
+            assert f is None
+
+            gdal.PushErrorHandler()
+            fc = lyr.GetFeatureCount()
+            gdal.PopErrorHandler()
+            assert fc == 2
+
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=1&returnCountOnly=true',
+                                """{ "count": 123456}""")
+            fc = lyr.GetFeatureCount()
+            assert fc == 123456
+
+            gdal.PushErrorHandler()
+            extent = lyr.GetExtent()
+            gdal.PopErrorHandler()
+            assert extent == (2, 2, 49, 49)
+
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=1&returnExtentOnly=true&f=geojson',
+                                """{"type":"FeatureCollection","bbox":[1, 2, 3, 4],"features":[]}""")
+            extent = lyr.GetExtent()
+            assert extent == (1.0, 3.0, 2.0, 4.0)
+
+            assert lyr.TestCapability(ogr.OLCFastFeatureCount) == 1
+
+            assert lyr.TestCapability(ogr.OLCFastGetExtent) == 0
+
+            assert lyr.TestCapability('foo') == 0
+
+            # Test scrolling with ESRI json
+            resultOffset0 = """
+        {
+        "objectIdFieldName" : "objectid",
+        "geometryType" : "esriGeometryPoint",
+        "fields" : [
+            {
+            "name" : "objectid",
+            "alias" : "Object ID",
+            "type" : "esriFieldTypeOID"
+            },
+
+        ],
+        "features" : [
+            {
+            "geometry" : {
+                "x" : 2,
+                "y" : 49,
+                "z" : 1
+            },
+            "attributes" : {
+                "objectid" : 1
+            }
+            }
+        ],
+        "exceededTransferLimit": true
+        }
+        """
+
+            resultOffset1 = """
+        {
+        "objectIdFieldName" : "objectid",
+        "geometryType" : "esriGeometryPoint",
+        "fields" : [
+            {
+            "name" : "objectid",
+            "alias" : "Object ID",
+            "type" : "esriFieldTypeOID"
+            },
+
+        ],
+        "features" : [
+            {
+            "geometry": null,
+            "attributes" : {
+                "objectid" : 20
+            }
+            }
+        ]
+        }
+        """
+
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=1', resultOffset0)
+            gdal.FileFromMemBuffer('/vsimem/esrijson/test.json?resultRecordCount=1&resultOffset=1', resultOffset1)
+            ds = ogr.Open('/vsimem/esrijson/test.json?resultRecordCount=1')
+            lyr = ds.GetLayer(0)
+            f = lyr.GetNextFeature()
+            assert f is not None and f.GetFID() == 1
+            f = lyr.GetNextFeature()
+            assert f is not None and f.GetFID() == 20
+            ds = None
+            gdal.Unlink('/vsimem/esrijson/test.json?resultRecordCount=1')
+            gdal.Unlink('/vsimem/esrijson/test.json?resultRecordCount=1&resultOffset=1')
+
+###############################################################################
+# Test reading ESRIJSON files starting with {"features":[{"geometry":.... (#7198)
+
+def test_ogr_esrijson_read_starting_with_features_geometry():
+
+    ds = ogr.Open('data/esrijsonstartingwithfeaturesgeometry.json')
+    assert ds is not None
+    assert ds.GetDriver().GetName() == 'ESRIJSON'
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 1
+
+
+###############################################################################
+# Test ogr.CreateGeometryFromEsriJson()
+
+
+def test_ogr_esrijson_create_geometry_from_esri_json():
+
+    with gdaltest.error_handler():
+        assert not ogr.CreateGeometryFromEsriJson('error')
+
+    g = ogr.CreateGeometryFromEsriJson('{ "x": 2, "y": 49 }')
+    assert g.ExportToWkt() == 'POINT (2 49)'

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -40,6 +40,18 @@ from osgeo import gdal
 import gdaltest
 import ogrtest
 import pytest
+
+pytestmark = [pytest.mark.require_driver('GeoJSON'), pytest.mark.usefixtures("startup_and_cleanup")]
+
+###############################################################################
+
+@pytest.fixture(scope="module")
+def startup_and_cleanup():
+
+    gdaltest.geojson_drv = ogr.GetDriverByName('GeoJSON')
+
+    yield
+
 ###############################################################################
 # Test utilities
 
@@ -83,13 +95,12 @@ def validate_layer(lyr, name, features, typ, fields, box):
     return True
 
 
-def verify_geojson_copy(name, fids, names):
+def verify_geojson_copy(fname, fids, names):
 
     if gdaltest.gjpoint_feat is None:
         print('Missing features collection')
         return False
 
-    fname = os.path.join('tmp', name + '.geojson')
     ds = ogr.Open(fname)
     if ds is None:
         print('Can not open \'' + fname + '\'')
@@ -140,9 +151,6 @@ def verify_geojson_copy(name, fids, names):
 
 def copy_shape_to_geojson(gjname, compress=None):
 
-    if gdaltest.geojson_drv is None:
-        return False
-
     if compress is not None:
         if compress[0:5] == '/vsig':
             dst_name = os.path.join('/vsigzip/', 'tmp', gjname + '.geojson' + '.gz')
@@ -151,19 +159,19 @@ def copy_shape_to_geojson(gjname, compress=None):
         elif compress == '/vsistdout/':
             dst_name = compress
         else:
-            return False
+            return False, None
     else:
         dst_name = os.path.join('tmp', gjname + '.geojson')
 
     ds = gdaltest.geojson_drv.CreateDataSource(dst_name)
     if ds is None:
-        return False
+        return False, dst_name
 
     ######################################################
     # Create layer
     lyr = ds.CreateLayer(gjname)
     if lyr is None:
-        return False
+        return False, dst_name
 
     ######################################################
     # Setup schema (all test shapefiles use common schmea)
@@ -197,28 +205,13 @@ def copy_shape_to_geojson(gjname, compress=None):
 
     ds = None
 
-    return True
-
-###############################################################################
-# Find GeoJSON driver
-
-
-def test_ogr_geojson_1():
-
-    gdaltest.geojson_drv = ogr.GetDriverByName('GeoJSON')
-
-    if gdaltest.geojson_drv is not None:
-        return
-    pytest.fail()
+    return True, dst_name
 
 ###############################################################################
 # Test file-based DS with standalone "Point" feature object.
 
 
 def test_ogr_geojson_2():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('data/point.geojson')
     assert ds is not None, 'Failed to open datasource'
@@ -241,9 +234,6 @@ def test_ogr_geojson_2():
 
 def test_ogr_geojson_3():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/linestring.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -264,9 +254,6 @@ def test_ogr_geojson_3():
 
 
 def test_ogr_geojson_4():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('data/polygon.geojson')
     assert ds is not None, 'Failed to open datasource'
@@ -289,9 +276,6 @@ def test_ogr_geojson_4():
 
 def test_ogr_geojson_5():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/geometrycollection.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -312,9 +296,6 @@ def test_ogr_geojson_5():
 
 
 def test_ogr_geojson_6():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('data/multipoint.geojson')
     assert ds is not None, 'Failed to open datasource'
@@ -337,9 +318,6 @@ def test_ogr_geojson_6():
 
 def test_ogr_geojson_7():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/multilinestring.geojson')
     assert ds is not None, 'Failed to open datasource'
 
@@ -360,9 +338,6 @@ def test_ogr_geojson_7():
 
 
 def test_ogr_geojson_8():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('data/multipolygon.geojson')
     assert ds is not None, 'Failed to open datasource'
@@ -385,10 +360,7 @@ def test_ogr_geojson_8():
 
 def test_ogr_geojson_9():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    gdaltest.tests = [
+    tests = [
         ['gjpoint', [1], ['Point 1']],
         ['gjline', [1], ['Line 1']],
         ['gjpoly', [1], ['Polygon 1']],
@@ -397,15 +369,17 @@ def test_ogr_geojson_9():
         ['gjmultipoly', [2], ['MultiPoly 1']]
     ]
 
-    for i in range(len(gdaltest.tests)):
-        test = gdaltest.tests[i]
+    for test in tests:
 
-        rc = copy_shape_to_geojson(test[0])
-        assert rc, ('Failed making copy of ' + test[0] + '.shp')
+        rc, dstname = copy_shape_to_geojson(test[0])
+        try:
+            assert rc, ('Failed making copy of ' + test[0] + '.shp')
 
-        rc = verify_geojson_copy(test[0], test[1], test[2])
-        assert rc, ('Verification of copy of ' + test[0] + '.shp failed')
-
+            rc = verify_geojson_copy(dstname, test[1], test[2])
+            assert rc, ('Verification of copy of ' + test[0] + '.shp failed')
+        finally:
+            if dstname:
+                gdal.Unlink(dstname)
 
 ##############################################################################
 # Test translation of data/gjpoint.shp to GZip compressed GeoJSON file
@@ -413,10 +387,7 @@ def test_ogr_geojson_9():
 
 def test_ogr_geojson_10():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    gdaltest.tests = [
+    tests = [
         ['gjpoint', [1], ['Point 1']],
         ['gjline', [1], ['Line 1']],
         ['gjpoly', [1], ['Polygon 1']],
@@ -425,23 +396,24 @@ def test_ogr_geojson_10():
         ['gjmultipoly', [2], ['MultiPoly 1']]
     ]
 
-    for i in range(len(gdaltest.tests)):
-        test = gdaltest.tests[i]
+    for test in tests:
 
-        rc = copy_shape_to_geojson(test[0], '/vsigzip/')
-        assert rc, ('Failed making copy of ' + test[0] + '.shp')
+        rc, dstname = copy_shape_to_geojson(test[0], '/vsigzip/')
+        try:
+            assert rc, ('Failed making copy of ' + test[0] + '.shp')
 
-        rc = verify_geojson_copy(test[0], test[1], test[2])
-        assert rc, ('Verification of copy of ' + test[0] + '.shp failed')
-
+            rc = verify_geojson_copy(dstname, test[1], test[2])
+            assert rc, ('Verification of copy of ' + test[0] + '.shp failed')
+        finally:
+            if dstname:
+                dstname = dstname[len("/vsigzip/"):]
+                gdal.Unlink(dstname)
+                gdal.Unlink(dstname + ".properties")
 
 ###############################################################################
 
 
 def test_ogr_geojson_11():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('data/srs_name.geojson')
     assert ds is not None, 'Failed to open datasource'
@@ -475,9 +447,6 @@ def test_ogr_geojson_11():
 
 def test_ogr_geojson_12():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     if os.name == 'nt':
         pytest.skip()
 
@@ -495,12 +464,9 @@ def test_ogr_geojson_12():
 
 def test_ogr_geojson_13():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     test = ['gjpoint', [1], ['Point 1']]
 
-    rc = copy_shape_to_geojson(test[0], '/vsistdout/')
+    rc, _ = copy_shape_to_geojson(test[0], '/vsistdout/')
     assert rc, ('Failed making copy of ' + test[0] + '.shp')
 
 ###############################################################################
@@ -509,29 +475,29 @@ def test_ogr_geojson_13():
 
 def test_ogr_geojson_14():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    if int(gdal.VersionInfo('VERSION_NUM')) < 1800:
-        pytest.skip()
-
     with gdaltest.error_handler():
         ds = ogr.Open('data/ogr_geojson_14.geojson')
     lyr = ds.GetLayer(0)
 
-    out_ds = gdaltest.geojson_drv.CreateDataSource('tmp/out_ogr_geojson_14.geojson')
-    out_lyr = out_ds.CreateLayer('lyr')
+    try:
+        out_ds = gdaltest.geojson_drv.CreateDataSource('tmp/out_ogr_geojson_14.geojson')
+        out_lyr = out_ds.CreateLayer('lyr')
 
-    with gdaltest.error_handler():
-        for feat in lyr:
-            geom = feat.GetGeometryRef()
-            if geom is not None:
-                # print(geom)
-                out_feat = ogr.Feature(feature_def=out_lyr.GetLayerDefn())
-                out_feat.SetGeometry(geom)
-                out_lyr.CreateFeature(out_feat)
+        with gdaltest.error_handler():
+            for feat in lyr:
+                geom = feat.GetGeometryRef()
+                if geom is not None:
+                    # print(geom)
+                    out_feat = ogr.Feature(feature_def=out_lyr.GetLayerDefn())
+                    out_feat.SetGeometry(geom)
+                    out_lyr.CreateFeature(out_feat)
 
-    out_ds = None
+        out_ds = None
+    finally:
+        try:
+            os.remove('tmp/out_ogr_geojson_14.geojson')
+        except OSError:
+            pass
 
 ###############################################################################
 # Test Feature.ExportToJson (#3870)
@@ -571,189 +537,10 @@ def test_ogr_geojson_15():
     assert out == expected_out
 
 ###############################################################################
-# Test reading ESRI point file
-
-
-def test_ogr_geojson_16():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esripoint.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayerByName('esripoint')
-    assert lyr is not None, 'Missing layer called esripoint'
-
-    extent = (2, 2, 49, 49)
-
-    rc = validate_layer(lyr, 'esripoint', 1, ogr.wkbPoint, 4, extent)
-    assert rc
-
-    ref = lyr.GetSpatialRef()
-    gcs = int(ref.GetAuthorityCode('GEOGCS'))
-
-    assert gcs == 4326, "Spatial reference was not valid"
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('POINT(2 49)')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFID() != 1:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFieldAsInteger('fooInt') != 2:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFieldAsDouble('fooDouble') != 3.4:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFieldAsString('fooString') != '56':
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI linestring file
-
-
-def test_ogr_geojson_17():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrilinestring.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    extent = (2, 3, 49, 50)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('LINESTRING (2 49,3 50)')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-    # MultiLineString
-    ds = ogr.Open("""{
-  "geometryType": "esriGeometryPolyline",
-  "fields": [],
-  "features": [
-  {
-   "geometry": {
-      "paths" : [
-       [ [2,49],[2.1,49.1] ],
-       [ [3,50],[3.1,50.1] ]
-      ]
-   }
-  }
- ]
-}""")
-    lyr = ds.GetLayer(0)
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('MULTILINESTRING ((2 49,2.1 49.1),(3 50,3.1 50.1))')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-
-###############################################################################
-# Test reading ESRI polygon file
-
-
-def test_ogr_geojson_18():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esripolygon.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    extent = (-3, 3, 49, 50)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOLYGON (((2 49,2 50,3 50,3 49,2 49),(2.1 49.1,2.1 49.9,2.9 49.9,2.9 49.1,2.1 49.1)),((-2 49,-2 50,-3 50,-3 49,-2 49)))')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-    ds = ogr.Open('data/esripolygonempty.json')
-    assert ds is not None, 'Failed to open datasource'
-    lyr = ds.GetLayer(0)
-    feature = lyr.GetNextFeature()
-    if feature.GetGeometryRef().ExportToWkt() != 'POLYGON EMPTY':
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI multipoint file
-
-
-def test_ogr_geojson_19():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrimultipoint.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    extent = (2, 3, 49, 50)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49,3 50)')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
 # Test reading files with no extension (#4314)
 
 
 def test_ogr_geojson_20():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     from glob import glob
 
@@ -786,9 +573,6 @@ def test_ogr_geojson_20():
 
 def test_ogr_geojson_21():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature",
  "geometry": {"type":"Point","coordinates":[1,2]},
@@ -815,9 +599,6 @@ def test_ogr_geojson_21():
 
 
 def test_ogr_geojson_22():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature",
@@ -860,9 +641,6 @@ def test_ogr_geojson_22():
 
 def test_ogr_geojson_23():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = gdaltest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_23.json')
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(4322)
@@ -900,9 +678,6 @@ def test_ogr_geojson_23():
 
 
 def test_ogr_geojson_24():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     content = """loadGeoJSON({"layerFoo": { "type": "Feature",
   "geometry": {
@@ -957,9 +732,6 @@ def test_ogr_geojson_24():
 
 
 def test_ogr_geojson_25():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('data/topojson1.topojson')
     lyr = ds.GetLayer(0)
@@ -1045,9 +817,6 @@ def test_ogr_geojson_25():
 
 def test_ogr_geojson_26():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature", "id": 1,
  "geometry": {"type":"Point","coordinates":[1,2]},
@@ -1112,9 +881,6 @@ def test_ogr_geojson_26():
 
 def test_ogr_geojson_27():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler('CPLQuietErrorHandler')
     # Warning 1: Integer values probably ranging out of 64bit integer range
     # have been found. Will be clamped to INT64_MIN/INT64_MAX
@@ -1145,248 +911,10 @@ def test_ogr_geojson_27():
     ds = None
 
 ###############################################################################
-# Test reading ESRI point file with z value
-
-
-def test_ogr_geojson_28():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrizpoint.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    # validate layer doesn't check z, but put it in
-    extent = (2, 2, 49, 49, 1, 1)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbPoint, 4, extent)
-    assert rc
-
-    ref = lyr.GetSpatialRef()
-    gcs = int(ref.GetAuthorityCode('GEOGCS'))
-
-    assert gcs == 4326, "Spatial reference was not valid"
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('POINT(2 49 1)')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFID() != 1:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFieldAsInteger('fooInt') != 2:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFieldAsDouble('fooDouble') != 3.4:
-        feature.DumpReadable()
-        pytest.fail()
-
-    if feature.GetFieldAsString('fooString') != '56':
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI linestring file with z
-
-
-def test_ogr_geojson_29():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrizlinestring.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    # validate layer doesn't check z, but put it in
-    extent = (2, 3, 49, 50, 1, 2)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbLineString, 0, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('LINESTRING (2 49 1,3 50 2)')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI multipoint file with z
-
-
-def test_ogr_geojson_30():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrizmultipoint.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    # validate layer doesn't check z, but put it in
-    extent = (2, 3, 49, 50, 1, 2)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49 1,3 50 2)')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI polygon file with z
-
-
-def test_ogr_geojson_31():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrizpolygon.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    # validate layer doesn't check z, but put it in
-    extent = (2, 3, 49, 50, 1, 4)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbPolygon, 0, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('POLYGON ((2 49 1,2 50 2,3 50 3,3 49 4,2 49 1))')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI multipoint file with m, but no z (hasM=true, hasZ omitted)
-
-
-def test_ogr_geojson_32():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrihasmnozmultipoint.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    extent = (2, 3, 49, 50)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT M ((2 49 1),(3 50 2))')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI multipoint file with hasZ=true, but only 2 components.
-
-
-def test_ogr_geojson_33():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esriinvalidhaszmultipoint.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    extent = (2, 3, 49, 50)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT (2 49,3 50)')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
-# Test reading ESRI multipoint file with z and m
-
-
-def test_ogr_geojson_34():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    ds = ogr.Open('data/esrizmmultipoint.json')
-    assert ds is not None, 'Failed to open datasource'
-
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
-
-    lyr = ds.GetLayer(0)
-
-    extent = (2, 3, 49, 50)
-
-    rc = validate_layer(lyr, None, 1, ogr.wkbMultiPoint, 4, extent)
-    assert rc
-
-    feature = lyr.GetNextFeature()
-    ref_geom = ogr.CreateGeometryFromWkt('MULTIPOINT ZM ((2 49 1 100),(3 50 2 100))')
-    if ogrtest.check_feature_geometry(feature, ref_geom) != 0:
-        feature.DumpReadable()
-        pytest.fail()
-
-    lyr = None
-    ds = None
-
-###############################################################################
 # Test handling of huge coordinates (#5377)
 
 
 def test_ogr_geojson_35():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = gdaltest.geojson_drv.CreateDataSource('/vsimem/ogr_geojson_35.json')
     lyr = ds.CreateLayer('foo')
@@ -1482,9 +1010,6 @@ def test_ogr_geojson_35():
 
 def test_ogr_geojson_36():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open('data/point_with_utf8bom.json')
     assert ds is not None, 'Failed to open datasource'
     ds = None
@@ -1494,9 +1019,6 @@ def test_ogr_geojson_36():
 
 
 def test_ogr_geojson_37():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     # Test read support
     ds = ogr.Open("""{"type": "FeatureCollection","features": [
@@ -1539,9 +1061,6 @@ def test_ogr_geojson_37():
 
 def test_ogr_geojson_38():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # Test read support
     ds = gdal.OpenEx("""{"type": "FeatureCollection", "features": [
 { "type": "Feature", "properties": { "dt": "2014-11-20 12:34:56+0100", "dt2": "2014\/11\/20", "date":"2014\/11\/20", "time":"12:34:56", "no_dt": "2014-11-20 12:34:56+0100", "no_dt2": "2014-11-20 12:34:56+0100" }, "geometry": null },
@@ -1582,9 +1101,6 @@ def test_ogr_geojson_38():
 
 
 def test_ogr_geojson_39():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open("""{"type": "FeatureCollection", "features": [
 { "type": "Feature", "id" : "foo", "properties": { "bar" : "baz" }, "geometry": null },
@@ -1742,9 +1258,6 @@ def test_ogr_geojson_39():
 
 def test_ogr_geojson_40():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = gdal.OpenEx("""{
   "type": "FeatureCollection",
   "features" :
@@ -1794,9 +1307,6 @@ def test_ogr_geojson_40():
 
 def test_ogr_geojson_41():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     # Check that by default we return a WGS 84 SRS
     g = ogr.CreateGeometryFromJson("{ 'type': 'Point', 'coordinates' : [ 2, 49] }")
     assert g.ExportToWkt() == 'POINT (2 49)'
@@ -1816,188 +1326,10 @@ def test_ogr_geojson_41():
     assert not srs
 
 ###############################################################################
-# Test ESRI FeatureService scrolling
-
-
-def test_ogr_geojson_42():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    gdal.SetConfigOption('CPL_CURL_ENABLE_VSIMEM', 'YES')
-
-    resultOffset0 = """
-{ "type":"FeatureCollection",
-  "properties" : {
-    "exceededTransferLimit" : true
-  },
-  "features" :
-  [
-    {
-      "type": "Feature",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [ 2, 49 ]
-      },
-      "properties": {
-        "id": 1,
-        "a_property": 1,
-      }
-    } ] }"""
-
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=1', resultOffset0)
-    ds = ogr.Open('/vsimem/geojson/test.json?resultRecordCount=1')
-    lyr = ds.GetLayer(0)
-    f = lyr.GetNextFeature()
-    assert f is not None and f.GetFID() == 1
-    f = lyr.GetNextFeature()
-    assert f is None
-    ds = None
-    gdal.Unlink('/vsimem/geojson/test.json?resultRecordCount=1')
-
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=10', resultOffset0)
-    gdal.PushErrorHandler()
-    ds = ogr.Open('/vsimem/geojson/test.json?resultRecordCount=10')
-    gdal.PopErrorHandler()
-    lyr = ds.GetLayer(0)
-    f = lyr.GetNextFeature()
-    assert f is not None and f.GetFID() == 1
-    f = lyr.GetNextFeature()
-    assert f is None
-    ds = None
-    gdal.Unlink('/vsimem/geojson/test.json?resultRecordCount=10')
-
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?', resultOffset0)
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=1&resultOffset=0', resultOffset0)
-
-    ds = ogr.Open('/vsimem/geojson/test.json?')
-    lyr = ds.GetLayer(0)
-    f = lyr.GetNextFeature()
-    assert f is not None and f.GetFID() == 1
-    f = lyr.GetNextFeature()
-    assert f is None
-    lyr.ResetReading()
-    f = lyr.GetNextFeature()
-    assert f is not None and f.GetFID() == 1
-
-    resultOffset1 = """
-{ "type":"FeatureCollection",
-  "features" :
-  [
-    {
-      "type": "Feature",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [ 2, 49 ]
-      },
-      "properties": {
-        "id": 2,
-        "a_property": 1,
-      }
-    } ] }"""
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=1&resultOffset=1', resultOffset1)
-    f = lyr.GetNextFeature()
-    assert f is not None and f.GetFID() == 2
-    f = lyr.GetNextFeature()
-    assert f is None
-
-    gdal.PushErrorHandler()
-    fc = lyr.GetFeatureCount()
-    gdal.PopErrorHandler()
-    assert fc == 2
-
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=1&returnCountOnly=true',
-                           """{ "count": 123456}""")
-    fc = lyr.GetFeatureCount()
-    assert fc == 123456
-
-    gdal.PushErrorHandler()
-    extent = lyr.GetExtent()
-    gdal.PopErrorHandler()
-    assert extent == (2, 2, 49, 49)
-
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=1&returnExtentOnly=true&f=geojson',
-                           """{"type":"FeatureCollection","bbox":[1, 2, 3, 4],"features":[]}""")
-    extent = lyr.GetExtent()
-    assert extent == (1.0, 3.0, 2.0, 4.0)
-
-    assert lyr.TestCapability(ogr.OLCFastFeatureCount) == 1
-
-    assert lyr.TestCapability(ogr.OLCFastGetExtent) == 0
-
-    assert lyr.TestCapability('foo') == 0
-
-    # Test scrolling with ESRI json
-    resultOffset0 = """
-{
-  "objectIdFieldName" : "objectid",
-  "geometryType" : "esriGeometryPoint",
-  "fields" : [
-    {
-      "name" : "objectid",
-      "alias" : "Object ID",
-      "type" : "esriFieldTypeOID"
-    },
-
-  ],
-  "features" : [
-    {
-      "geometry" : {
-        "x" : 2,
-        "y" : 49,
-        "z" : 1
-      },
-      "attributes" : {
-        "objectid" : 1
-      }
-    }
-  ],
-  "exceededTransferLimit": true
-}
-"""
-
-    resultOffset1 = """
-{
-  "objectIdFieldName" : "objectid",
-  "geometryType" : "esriGeometryPoint",
-  "fields" : [
-    {
-      "name" : "objectid",
-      "alias" : "Object ID",
-      "type" : "esriFieldTypeOID"
-    },
-
-  ],
-  "features" : [
-    {
-      "geometry": null,
-      "attributes" : {
-        "objectid" : 20
-      }
-    }
-  ]
-}
-"""
-
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=1', resultOffset0)
-    gdal.FileFromMemBuffer('/vsimem/geojson/test.json?resultRecordCount=1&resultOffset=1', resultOffset1)
-    ds = ogr.Open('/vsimem/geojson/test.json?resultRecordCount=1')
-    lyr = ds.GetLayer(0)
-    f = lyr.GetNextFeature()
-    assert f is not None and f.GetFID() == 1
-    f = lyr.GetNextFeature()
-    assert f is not None and f.GetFID() == 20
-    ds = None
-    gdal.Unlink('/vsimem/geojson/test.json?resultRecordCount=1')
-    gdal.Unlink('/vsimem/geojson/test.json?resultRecordCount=1&resultOffset=1')
-
-###############################################################################
 # Test Feature without geometry
 
 
 def test_ogr_geojson_43():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature", "properties": {"foo": "bar"}}]}""")
@@ -2018,8 +1350,6 @@ def test_ogr_geojson_43():
 
 
 def test_ogr_geojson_44():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     with gdaltest.error_handler():
         ogr.Open("""{"type": "FeatureCollection", "features":[ null ]}""")
@@ -2030,8 +1360,6 @@ def test_ogr_geojson_44():
 
 
 def test_ogr_geojson_45():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     # Test read support
     content = """{"type": "FeatureCollection", "foo": "bar", "bar": "baz",
@@ -2153,8 +1481,6 @@ def test_ogr_geojson_45():
 
 
 def test_ogr_geojson_46():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_46.json')
     lyr = ds.CreateLayer('test')
@@ -2177,8 +1503,6 @@ def test_ogr_geojson_46():
 
 
 def test_ogr_geojson_47():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     # ERROR 6: Update from inline definition not supported
     with gdaltest.error_handler():
@@ -2332,8 +1656,6 @@ def test_ogr_geojson_47():
 
 
 def test_ogr_geojson_48():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     gdal.FileFromMemBuffer('/vsimem/ogr_geojson_48.json',
                            """{ "type": "Feature", "bar": "baz", "bbox": [2,49,2,49], "properties": { "myprop": "myvalue" }, "geometry": {"type": "Point", "coordinates": [ 2, 49]} }""")
@@ -2368,8 +1690,6 @@ def test_ogr_geojson_48():
 
 
 def test_ogr_geojson_49():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     gdal.FileFromMemBuffer('/vsimem/ogr_geojson_49.json',
                            """{ "type": "Feature", "properties": { "foo": ["bar"] }, "geometry": null }""")
@@ -2391,8 +1711,6 @@ def test_ogr_geojson_49():
 
 
 def test_ogr_geojson_50():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_50.json')
     lyr = ds.CreateLayer('test')
@@ -2459,8 +1777,6 @@ def test_ogr_geojson_50():
 
 
 def test_ogr_geojson_51():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_51.json')
     lyr = ds.CreateLayer('test')
@@ -2521,8 +1837,6 @@ def test_ogr_geojson_51():
 
 
 def test_ogr_geojson_52():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('data/nullvalues.geojson')
     assert ds is not None, 'Failed to open datasource'
@@ -2547,8 +1861,6 @@ def test_ogr_geojson_52():
 
 
 def test_ogr_geojson_53():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.GetDriverByName('GeoJSON').CreateDataSource('/vsimem/ogr_geojson_53.json')
     lyr = ds.CreateLayer('test')
@@ -2570,8 +1882,6 @@ def test_ogr_geojson_53():
 
 
 def test_ogr_geojson_54():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open("""{
    "type": "FeatureCollection",
@@ -2613,8 +1923,6 @@ def read_file(filename):
 
 
 def test_ogr_geojson_55():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     # Basic test for standard bbox and coordinate truncation
     gdal.VectorTranslate('/vsimem/out.json', """{
@@ -2715,8 +2023,7 @@ def test_ogr_geojson_55():
 
 
 def test_ogr_geojson_56():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
+
     if not ogrtest.have_geos():
         pytest.skip()
 
@@ -2783,8 +2090,7 @@ def test_ogr_geojson_56():
 
 
 def test_ogr_geojson_57():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
+
     if not ogrtest.have_geos():
         pytest.skip()
 
@@ -3002,8 +2308,6 @@ def test_ogr_geojson_57():
 
 
 def test_ogr_geojson_58():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('{ "type": "FeatureCollection", "name": "layer_name", "features": []}')
     assert ds is not None, 'Failed to open datasource'
@@ -3025,8 +2329,6 @@ def test_ogr_geojson_58():
 
 
 def test_ogr_geojson_59():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = ogr.Open('{ "type": "FeatureCollection", "description": "my_description", "features": []}')
     assert ds is not None, 'Failed to open datasource'
@@ -3050,8 +2352,6 @@ def test_ogr_geojson_59():
 
 
 def test_ogr_geojson_60():
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     ds = gdal.OpenEx("""{ "type": "FeatureCollection", "features": [
 { "type": "Feature", "properties" : { "foo" : "bar" } },
@@ -3292,18 +2592,6 @@ def test_ogr_geojson_67():
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 1
 
-
-###############################################################################
-# Test reading ESRIJSON files starting with {"features":[{"geometry":.... (#7198)
-
-def test_ogr_geojson_68():
-
-    ds = ogr.Open('data/esrijsonstartingwithfeaturesgeometry.json')
-    assert ds is not None
-    assert ds.GetDriver().GetName() == 'ESRIJSON'
-    lyr = ds.GetLayer(0)
-    assert lyr.GetFeatureCount() == 1
-
 ###############################################################################
 
 
@@ -3474,34 +2762,6 @@ def test_ogr_geojson_empty_geometrycollection():
 
     g = ogr.CreateGeometryFromJson('{"type": "GeometryCollection", "geometries": []}')
     assert g.ExportToWkt() == 'GEOMETRYCOLLECTION EMPTY'
-
-
-###############################################################################
-
-
-def test_ogr_esrijson_without_geometryType():
-
-    ds = ogr.Open("""{
-  "spatialReference" : {
-    "wkid" : 4326
-  },
-  "fields": [],
-  "fieldAliases": {},
-  "features" : [
-    {
-      "geometry" : {
-        "x" : 2,
-        "y" : 49
-      },
-      "attributes" : {
-      }
-    }
-  ]
-}
-""")
-    lyr = ds.GetLayer(0)
-    f = lyr.GetNextFeature()
-    assert f.GetGeometryRef() is not None
 
 
 ###############################################################################
@@ -3697,9 +2957,6 @@ def test_ogr_geojson_single_feature_random_reading_with_id():
 
 def test_ogr_geojson_3D_geom_type():
 
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
     ds = ogr.Open("""{"type": "FeatureCollection", "features":[
 {"type": "Feature", "geometry": {"type":"Point","coordinates":[1,2,3]}, "properties": null},
 {"type": "Feature", "geometry": {"type":"Point","coordinates":[1,2,4]}, "properties": null}
@@ -3724,9 +2981,6 @@ def test_ogr_geojson_3D_geom_type():
 ###############################################################################
 
 def test_ogr_geojson_update_in_loop():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
 
     tmpfilename = '/vsimem/temp.json'
 
@@ -3764,61 +3018,4 @@ def test_ogr_geojson_update_in_loop():
     assert fids == [1, 3]
     ds = None
 
-
     gdal.Unlink(tmpfilename)
-
-
-###############################################################################
-# Test ogr.CreateGeometryFromEsriJson()
-
-
-def test_ogr_esrijson_create_geometry_from_esri_json():
-
-    if gdaltest.geojson_drv is None:
-        pytest.skip()
-
-    with gdaltest.error_handler():
-        assert not ogr.CreateGeometryFromEsriJson('error')
-
-    g = ogr.CreateGeometryFromEsriJson('{ "x": 2, "y": 49 }')
-    assert g.ExportToWkt() == 'POINT (2 49)'
-
-
-###############################################################################
-
-
-def test_ogr_geojson_cleanup():
-
-    gdal.SetConfigOption('CPL_CURL_ENABLE_VSIMEM', None)
-
-    try:
-        if gdaltest.tests is not None:
-            gdal.PushErrorHandler('CPLQuietErrorHandler')
-            for i in range(len(gdaltest.tests)):
-
-                fname = os.path.join('tmp', gdaltest.tests[i][0] + '.geojson')
-                ogr.GetDriverByName('GeoJSON').DeleteDataSource(fname)
-
-                fname = os.path.join('tmp', gdaltest.tests[i][0] + '.geojson.gz')
-                gdal.Unlink(fname)
-
-                fname = os.path.join('tmp', gdaltest.tests[i][0] + '.geojson.gz.properties')
-                gdal.Unlink(fname)
-
-            gdal.PopErrorHandler()
-
-        gdaltest.tests = None
-    except:
-        pass
-
-    try:
-        os.remove('tmp/out_ogr_geojson_14.geojson')
-    except OSError:
-        pass
-
-    for f in gdal.ReadDir('/vsimem/geojson'):
-        gdal.Unlink('/vsimem/geojson/' + f)
-
-
-
-

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -216,7 +216,7 @@ def test_ogr_geojson_2():
     ds = ogr.Open('data/point.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('point')
     assert lyr is not None, 'Missing layer called point'
@@ -237,7 +237,7 @@ def test_ogr_geojson_3():
     ds = ogr.Open('data/linestring.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('linestring')
     assert lyr is not None, 'Missing layer called linestring'
@@ -258,7 +258,7 @@ def test_ogr_geojson_4():
     ds = ogr.Open('data/polygon.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('polygon')
     assert lyr is not None, 'Missing layer called polygon'
@@ -279,7 +279,7 @@ def test_ogr_geojson_5():
     ds = ogr.Open('data/geometrycollection.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('geometrycollection')
     assert lyr is not None, 'Missing layer called geometrycollection'
@@ -300,7 +300,7 @@ def test_ogr_geojson_6():
     ds = ogr.Open('data/multipoint.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('multipoint')
     assert lyr is not None, 'Missing layer called multipoint'
@@ -321,7 +321,7 @@ def test_ogr_geojson_7():
     ds = ogr.Open('data/multilinestring.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('multilinestring')
     assert lyr is not None, 'Missing layer called multilinestring'
@@ -342,7 +342,7 @@ def test_ogr_geojson_8():
     ds = ogr.Open('data/multipolygon.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('multipolygon')
     assert lyr is not None, 'Missing layer called multipolygon'
@@ -418,7 +418,7 @@ def test_ogr_geojson_11():
     ds = ogr.Open('data/srs_name.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('srs_name')
     assert lyr is not None, 'Missing layer called srs_name'
@@ -1841,7 +1841,7 @@ def test_ogr_geojson_52():
     ds = ogr.Open('data/nullvalues.geojson')
     assert ds is not None, 'Failed to open datasource'
 
-    assert ds.GetLayerCount() is 1, 'Wrong number of layers'
+    assert ds.GetLayerCount() == 1, 'Wrong number of layers'
 
     lyr = ds.GetLayerByName('nullvalues')
     assert lyr is not None, 'Missing layer called nullvalues'

--- a/autotest/ogr/ogr_ingres.py
+++ b/autotest/ogr/ogr_ingres.py
@@ -220,7 +220,7 @@ def test_ogr_ingres_7():
     result = gdaltest.ingres_lyr.CreateField(field_defn)
     field_defn.Destroy()
 
-    assert result is 0, 'CreateField failed!'
+    assert result == 0, 'CreateField failed!'
 
     ####################################################################
     # Apply a value to this field in one feature.

--- a/autotest/ogr/ogr_rfc41.py
+++ b/autotest/ogr/ogr_rfc41.py
@@ -36,6 +36,7 @@ from osgeo import gdal
 import pytest
 
 from ogr.ogr_sql_sqlite import require_ogr_sql_sqlite  # noqa
+require_ogr_sql_sqlite; # to make pyflakes happy
 
 ###############################################################################
 # Test OGRGeomFieldDefn class

--- a/autotest/ogr/ogr_virtualogr.py
+++ b/autotest/ogr/ogr_virtualogr.py
@@ -39,6 +39,7 @@ import pytest
 
 # Linter says this isn't used, but it actually is via pytest magic :)
 from ogr.ogr_sql_sqlite import require_ogr_sql_sqlite  # noqa
+require_ogr_sql_sqlite; # to make pyflakes happy
 
 ###############################################################################
 

--- a/gdal/ci/travis/trusty_clang/before_install.sh
+++ b/gdal/ci/travis/trusty_clang/before_install.sh
@@ -39,7 +39,7 @@ sudo apt-get install -y mono-mcs libmono-system-drawing4.0-cil
 
 sudo apt-get install doxygen texlive-latex-base
 # flake8 codes to just emulate pyflakes (http://flake8.pycqa.org/en/latest/user/error-codes.html)
-FLAKE8="flake8 --select=F401,F402,F403,F404,F405,F406,F407,F601,F602,F621,F622,F631,F701,F702,F703,F704,F705,F706,F707,F721,F722,F811,F812,F821,F822,F823,F831,F841,F901"
+FLAKE8="flake8 --select=F401,F402,F403,F404,F405,F406,F407,F601,F602,F621,F622,F631,F632,F633,F701,F702,F703,F704,F705,F706,F707,F721,F722,F811,F812,F821,F822,F823,F831,F841,F901"
 $FLAKE8 autotest
 $FLAKE8 gdal/swig/python/scripts
 $FLAKE8 gdal/swig/python/samples

--- a/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
@@ -1053,6 +1053,21 @@ OGRSpatialReference* OGRESRIJSONReadSpatialReference( json_object* poObj )
                 delete poSRS;
                 poSRS = nullptr;
             }
+            else
+            {
+                int nEntries = 0;
+                int* panMatchConfidence = nullptr;
+                OGRSpatialReferenceH* pahSRS = poSRS->FindMatches(
+                    nullptr, &nEntries, &panMatchConfidence);
+                if( nEntries == 1 && panMatchConfidence[0] >= 70 )
+                {
+                    delete poSRS;
+                    poSRS = OGRSpatialReference::FromHandle(pahSRS[0])->Clone();
+                    poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+                }
+                OSRFreeSRSArray(pahSRS);
+                CPLFree(panMatchConfidence);
+            }
 
             return poSRS;
         }

--- a/gdal/swig/python/scripts/mkgraticule.py
+++ b/gdal/swig/python/scripts/mkgraticule.py
@@ -166,7 +166,7 @@ if not connected:
             if ct is not None:
                 err = geom.Transform(ct)
 
-            if err is 0:
+            if err == 0:
                 feat.SetGeometry(geom)
                 layer.CreateFeature(feat)
 
@@ -182,7 +182,7 @@ if not connected:
             if ct is not None:
                 err = geom.Transform(ct)
 
-            if err is 0:
+            if err == 0:
                 feat.SetGeometry(geom)
                 layer.CreateFeature(feat)
 
@@ -208,7 +208,7 @@ if connected:
         if ct is not None:
             err = geom.Transform(ct)
 
-        if err is 0:
+        if err == 0:
             feat.SetGeometry(geom)
             layer.CreateFeature(feat)
 
@@ -226,7 +226,7 @@ if connected:
         if ct is not None:
             err = geom.Transform(ct)
 
-        if err is 0:
+        if err == 0:
             feat.SetGeometry(geom)
             layer.CreateFeature(feat)
 


### PR DESCRIPTION
On top of PR #2069. Only last commit is specific to this PR