### PR TITLE
PDS3/VICAR: add a GDAL_TRY_PDS3_WITH_VICAR configuration option 

### DIFF
--- a/gdal/doc/source/drivers/raster/pds.rst
+++ b/gdal/doc/source/drivers/raster/pds.rst
@@ -23,6 +23,12 @@ selected other header metadata.
 Implementation of this driver was supported by the United States
 Geological Survey.
 
+.. note::
+    PDS3 datasets can incorporate a VICAR header. By default, GDAL will use the
+    PDS driver in that situation. Starting with GDAL 3.1, if the
+    :decl_configoption:`GDAL_TRY_PDS3_WITH_VICAR` configuration option is set
+    to YES, the dataset will be opened by the :ref:`VICAR <raster.vicar>` driver.
+
 Driver capabilities
 -------------------
 

--- a/gdal/doc/source/drivers/raster/vicar.rst
+++ b/gdal/doc/source/drivers/raster/vicar.rst
@@ -8,6 +8,12 @@ VICAR -- VICAR
 
 .. built_in_by_default::
 
+.. note::
+    PDS3 datasets can incorporate a VICAR header. By default, GDAL will use the
+    :ref:`PDS <raster.pds>` driver in that situation. Starting with GDAL 3.1, if
+    the :decl_configoption:`GDAL_TRY_PDS3_WITH_VICAR` configuration option is
+    set to YES, the dataset will be opened by the VICAR driver.
+
 Driver capabilities
 -------------------
 

--- a/gdal/frmts/pds/pdsdataset.cpp
+++ b/gdal/frmts/pds/pdsdataset.cpp
@@ -47,6 +47,7 @@ constexpr double NULL3 = -3.4028226550889044521e+38;
 #include "ogr_spatialref.h"
 #include "rawdataset.h"
 #include "cpl_safemaths.hpp"
+#include "vicardataset.h"
 
 CPL_CVSID("$Id$")
 
@@ -1259,13 +1260,31 @@ int PDSDataset::ParseCompressedImage()
 int PDSDataset::Identify( GDALOpenInfo * poOpenInfo )
 
 {
-    if( poOpenInfo->pabyHeader == nullptr )
+    if( poOpenInfo->pabyHeader == nullptr || poOpenInfo->fpL == nullptr )
         return FALSE;
 
-    return strstr(reinterpret_cast<char *>( poOpenInfo->pabyHeader ),
-                  "PDS_VERSION_ID") != nullptr ||
-           strstr(reinterpret_cast<char *>( poOpenInfo->pabyHeader ),
-                  "ODL_VERSION_ID") != nullptr;
+    const char* pszHdr = reinterpret_cast<char *>( poOpenInfo->pabyHeader );
+    if( strstr(pszHdr, "PDS_VERSION_ID") == nullptr &&
+        strstr(pszHdr, "ODL_VERSION_ID") == nullptr )
+    {
+        return FALSE;
+    }
+
+    // Some PDS3 images include a VICAR header pointed by ^IMAGE_HEADER.
+    // If the user sets GDAL_TRY_PDS3_WITH_VICAR=YES, then we will gracefully
+    // hand over the file to the VICAR dataset.
+    std::string unused;
+    if( CPLTestBool(CPLGetConfigOption("GDAL_TRY_PDS3_WITH_VICAR", "NO")) &&
+        !STARTS_WITH(poOpenInfo->pszFilename, "/vsisubfile/") &&
+        VICARDataset::GetVICARLabelOffsetFromPDS3(pszHdr, poOpenInfo->fpL, unused) > 0 )
+    {
+        CPLDebug("PDS3",
+                    "File is detected to have a VICAR header. "
+                    "Handing it over to the VICAR driver");
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 /************************************************************************/
@@ -1274,12 +1293,12 @@ int PDSDataset::Identify( GDALOpenInfo * poOpenInfo )
 
 GDALDataset *PDSDataset::Open( GDALOpenInfo * poOpenInfo )
 {
-    if( !Identify( poOpenInfo ) || poOpenInfo->fpL == nullptr )
+    if( !Identify( poOpenInfo ) )
         return nullptr;
 
-    if( strstr(reinterpret_cast<char *>( poOpenInfo->pabyHeader ),
-                  "PDS_VERSION_ID") != nullptr &&
-        strstr((const char *)poOpenInfo->pabyHeader,"PDS3") == nullptr )
+    const char* pszHdr = reinterpret_cast<char *>( poOpenInfo->pabyHeader );
+    if( strstr(pszHdr, "PDS_VERSION_ID") != nullptr &&
+        strstr(pszHdr, "PDS3") == nullptr )
     {
         CPLError( CE_Failure, CPLE_OpenFailed,
                   "It appears this is an older PDS image type.  Only PDS_VERSION_ID = PDS3 are currently supported by this gdal PDS reader.");
@@ -1297,10 +1316,10 @@ GDALDataset *PDSDataset::Open( GDALOpenInfo * poOpenInfo )
     poDS->SetDescription( poOpenInfo->pszFilename );
     poDS->eAccess = poOpenInfo->eAccess;
 
-    const char* pszPDSVersionID = strstr((const char *)poOpenInfo->pabyHeader,"PDS_VERSION_ID");
+    const char* pszPDSVersionID = strstr(pszHdr,"PDS_VERSION_ID");
     int nOffset = 0;
     if (pszPDSVersionID)
-        nOffset = static_cast<int>(pszPDSVersionID - (const char *)poOpenInfo->pabyHeader);
+        nOffset = static_cast<int>(pszPDSVersionID - pszHdr);
 
     if( ! poDS->oKeywords.Ingest( fpQube, nOffset ) )
     {

--- a/gdal/frmts/pds/vicardataset.cpp
+++ b/gdal/frmts/pds/vicardataset.cpp
@@ -37,6 +37,7 @@ constexpr double NULL3 = -32768.0;
 #include "cpl_vax.h"
 #include "cpl_vsi_error.h"
 #include "vicardataset.h"
+#include "nasakeywordhandler.h"
 #include "vicarkeywordhandler.h"
 
 #include <exception>
@@ -1126,35 +1127,60 @@ CPLErr VICARDataset::SetGeoTransform( double * padfTransform )
 }
 
 /************************************************************************/
-/*                              Identify()                              */
+/*                         GetLabelOffset()                             */
 /************************************************************************/
 
-int VICARDataset::Identify( GDALOpenInfo * poOpenInfo )
+int VICARDataset::GetLabelOffset( GDALOpenInfo * poOpenInfo )
 
 {
-    if( poOpenInfo->pabyHeader == nullptr )
-        return FALSE;
+    if( poOpenInfo->pabyHeader == nullptr || poOpenInfo->fpL == nullptr )
+        return -1;
 
+    std::string osHeader;
     const char *pszHeader = reinterpret_cast<const char *>(poOpenInfo->pabyHeader);
+    // Some PDS3 images include a VICAR header pointed by ^IMAGE_HEADER.
+    // If the user sets GDAL_TRY_PDS3_WITH_VICAR=YES, then we will gracefully
+    // hand over the file to the VICAR dataset.
+    vsi_l_offset nOffset = 0;
+    if( CPLTestBool(CPLGetConfigOption("GDAL_TRY_PDS3_WITH_VICAR", "NO")) &&
+        !STARTS_WITH(poOpenInfo->pszFilename, "/vsisubfile/") &&
+        (nOffset = VICARDataset::GetVICARLabelOffsetFromPDS3(pszHeader, poOpenInfo->fpL, osHeader)) > 0 )
+    {
+        pszHeader = osHeader.c_str();
+    }
+
     if( (poOpenInfo->nOpenFlags & GDAL_OF_RASTER) == 0 &&
         (poOpenInfo->nOpenFlags & GDAL_OF_VECTOR) != 0 )
     {
         // If opening in vector-only mode, then check when have NBB != 0
         const char* pszNBB = strstr(pszHeader, "NBB");
         if( pszNBB == nullptr )
-            return false;
+            return -1;
         const char* pszEqualSign = strchr(pszNBB, '=');
         if( pszEqualSign == nullptr )
-            return false;
+            return -1;
         if( atoi(pszEqualSign+1) == 0 )
-            return false;
+            return -1;
     }
-    return
-        strstr(pszHeader, "LBLSIZE") != nullptr &&
+    if( strstr(pszHeader, "LBLSIZE") != nullptr &&
         strstr(pszHeader, "FORMAT") != nullptr &&
         strstr(pszHeader, "NL") != nullptr &&
         strstr(pszHeader, "NS") != nullptr &&
-        strstr(pszHeader, "NB") != nullptr;
+        strstr(pszHeader, "NB") != nullptr )
+    {
+        return static_cast<int>(nOffset);
+    }
+    return -1;
+}
+
+/************************************************************************/
+/*                              Identify()                              */
+/************************************************************************/
+
+int VICARDataset::Identify( GDALOpenInfo * poOpenInfo )
+
+{
+    return GetLabelOffset(poOpenInfo) >= 0;
 }
 
 /************************************************************************/
@@ -1771,8 +1797,18 @@ GDALDataset *VICARDataset::Open( GDALOpenInfo * poOpenInfo )
 /* -------------------------------------------------------------------- */
 /*      Does this look like a VICAR dataset?                            */
 /* -------------------------------------------------------------------- */
-    if( !Identify( poOpenInfo ) || poOpenInfo->fpL == nullptr )
+    const int nLabelOffset = GetLabelOffset( poOpenInfo );
+    if( nLabelOffset < 0 )
         return nullptr;
+    if( nLabelOffset > 0 )
+    {
+        CPLString osSubFilename;
+        osSubFilename.Printf("/vsisubfile/%d,%s",
+                             nLabelOffset,
+                             poOpenInfo->pszFilename);
+        GDALOpenInfo oOpenInfo(osSubFilename.c_str(), poOpenInfo->eAccess);
+        return Open(&oOpenInfo);
+    }
 
     VICARDataset *poDS = new VICARDataset();
     poDS->fpImage = poOpenInfo->fpL;
@@ -2832,6 +2868,43 @@ GDALDataset* VICARDataset::CreateCopy( const char *pszFilename,
     }
 
     return poDS;
+}
+
+/************************************************************************/
+/*                     GetVICARLabelOffsetFromPDS3()                    */
+/************************************************************************/
+
+vsi_l_offset VICARDataset::GetVICARLabelOffsetFromPDS3(const char* pszHdr,
+                                                       VSILFILE* fp,
+                                                       std::string& osVICARHeader)
+{
+    const char* pszPDSVersionID = strstr(pszHdr,"PDS_VERSION_ID");
+    int nOffset = 0;
+    if (pszPDSVersionID)
+        nOffset = static_cast<int>(pszPDSVersionID - pszHdr);
+
+    NASAKeywordHandler  oKeywords;
+    if( oKeywords.Ingest( fp, nOffset ) )
+    {
+        const int nRecordBytes = atoi(oKeywords.GetKeyword("RECORD_BYTES", "0"));
+        const int nImageHeader = atoi(oKeywords.GetKeyword("^IMAGE_HEADER", "0"));
+        if( nRecordBytes > 0 && nImageHeader > 0 )
+        {
+            const auto nImgHeaderOffset =
+                static_cast<vsi_l_offset>(nImageHeader - 1) * nRecordBytes;
+            osVICARHeader.resize(1024);
+            size_t nMemb;
+            if( VSIFSeekL( fp, nImgHeaderOffset, SEEK_SET ) == 0 &&
+                (nMemb = VSIFReadL( &osVICARHeader[0], 1,
+                            osVICARHeader.size(), fp )) != 0 &&
+                osVICARHeader.find("LBLSIZE") != std::string::npos )
+            {
+                osVICARHeader.resize(nMemb);
+                return nImgHeaderOffset;
+            }
+        }
+    }
+    return 0;
 }
 
 /************************************************************************/

--- a/gdal/frmts/pds/vicardataset.h
+++ b/gdal/frmts/pds/vicardataset.h
@@ -119,6 +119,7 @@ public:
         return (m_poLayer && i == 0) ? m_poLayer.get() : nullptr; }
 
     static int          Identify( GDALOpenInfo * );
+    static int          GetLabelOffset( GDALOpenInfo * );
     static GDALDataset *Open( GDALOpenInfo * );
     static GDALDataset *Create( const char * pszFilename,
                                 int nXSize, int nYSize, int nBands,
@@ -138,6 +139,10 @@ public:
                                     GUInt64& nImageOffsetWithoutNBB,
                                     GUInt64& nNBB,
                                     GUInt64& nImageSize);
+
+    static vsi_l_offset GetVICARLabelOffsetFromPDS3(const char* pszHdr,
+                                                    VSILFILE* fp,
+                                                    std::string& osVICARHeader);
 };
 
 #endif // VICARDATASET_H

--- a/gdal/frmts/pds/vicarkeywordhandler.cpp
+++ b/gdal/frmts/pds/vicarkeywordhandler.cpp
@@ -68,7 +68,7 @@ VICARKeywordHandler::~VICARKeywordHandler()
 /*                               Ingest()                               */
 /************************************************************************/
 
-bool VICARKeywordHandler::Ingest( VSILFILE *fp, GByte *pabyHeader )
+bool VICARKeywordHandler::Ingest( VSILFILE *fp, const GByte *pabyHeader )
 
 {
 /* -------------------------------------------------------------------- */
@@ -78,7 +78,7 @@ bool VICARKeywordHandler::Ingest( VSILFILE *fp, GByte *pabyHeader )
         return false;
 
     // Find LBLSIZE Entry
-    const char* pszLBLSIZE = strstr(reinterpret_cast<char *>( pabyHeader ), "LBLSIZE");
+    const char* pszLBLSIZE = strstr(reinterpret_cast<const char *>( pabyHeader ), "LBLSIZE");
     if( !pszLBLSIZE )
         return false;
 

--- a/gdal/frmts/pds/vicarkeywordhandler.h
+++ b/gdal/frmts/pds/vicarkeywordhandler.h
@@ -53,7 +53,7 @@ public:
     VICARKeywordHandler();
     ~VICARKeywordHandler();
 
-    bool    Ingest( VSILFILE *fp, GByte *pabyHeader );
+    bool    Ingest( VSILFILE *fp, const GByte *pabyHeader );
 
     const char *GetKeyword( const char *pszPath, const char *pszDefault ) const;
     const CPLJSONObject& GetJsonObject() const { return oJSon; }


### PR DESCRIPTION
...that can be set to YES so that PDS3 datasets that contain a VICAR label are opened by the VICAR driver
