### PR TITLE
Docker: Allow https for ubuntu containers

### DIFF
--- a/gdal/docker/ubuntu-full/Dockerfile
+++ b/gdal/docker/ubuntu-full/Dockerfile
@@ -250,7 +250,7 @@ RUN date
 RUN apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         libsqlite3-0 \
-        curl unzip
+        curl unzip ca-certificates
 
 # GDAL dependencies
 RUN apt-get update; \

--- a/gdal/docker/ubuntu-small/Dockerfile
+++ b/gdal/docker/ubuntu-small/Dockerfile
@@ -170,7 +170,7 @@ RUN date
 RUN apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y  --no-install-recommends \
         libsqlite3-0 \
-        curl unzip
+        curl unzip ca-certificates
 
 # GDAL dependencies
 RUN apt-get update -y; \


### PR DESCRIPTION
alpine installs ca-certificates when libcurl is installed.

Fixes #2101 

## What does this PR do?

Adds ca-certificates to the base ubuntu images so that connection to https servers works.

## What are related issues/pull requests?

#2101
