### PR TITLE
tiledb: use array metadata to store xml

### DIFF
--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -177,10 +177,6 @@ def test_tiledb_write_subdatasets():
     new_ds = None
     src_ds = None
 
-    src_ds = gdal.Open('tmp/test_sds_array')
-    assert 'tmp/test_sds_array/test_sds_array.tdb.aux.xml' in src_ds.GetFileList()
-    src_ds = None
-  
     src_ds = gdal.Open('TILEDB:"tmp/test_sds_array":viewing_zenith_angle')
     assert src_ds.GetRasterBand(1).Checksum() == 42472
     src_ds = None

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -468,7 +468,9 @@ TileDBDataset::~TileDBDataset()
     try
     {
         if( m_array )
+        {
             m_array->close();
+        }
     }
     catch(const tiledb::TileDBError& e)
     {
@@ -726,15 +728,15 @@ CPLErr TileDBDataset::TryLoadCachedXML( char ** /*papszSiblingFiles*/, bool bRel
             if ( bReload )
             {
                 tiledb_datatype_t v_type = TILEDB_UINT8; // CPLSerializeXMLTree returns char*
-                const void* v_r;
-                uint32_t v_num;
+                const void* v_r = NULL;
+                uint32_t v_num = 0;
                 if ( eAccess == GA_Update )
                 {
                     auto oMeta = std::unique_ptr<tiledb::Array>( 
                         new tiledb::Array( *m_ctx, m_array->uri(), TILEDB_READ )
                     );
                     oMeta->get_metadata("_gdal", &v_type, &v_num, &v_r);
-                    if ( v_r != NULL )
+                    if ( v_r )
                     {
                         osMetaDoc = static_cast<const char*>( v_r );
                     }
@@ -742,7 +744,7 @@ CPLErr TileDBDataset::TryLoadCachedXML( char ** /*papszSiblingFiles*/, bool bRel
                 else
                 {
                     m_array->get_metadata("_gdal", &v_type, &v_num, &v_r);
-                    if ( v_r != NULL )
+                    if ( v_r )
                     {
                         osMetaDoc = static_cast<const char*>( v_r );
                     }

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -728,7 +728,7 @@ CPLErr TileDBDataset::TryLoadCachedXML( char ** /*papszSiblingFiles*/, bool bRel
             if ( bReload )
             {
                 tiledb_datatype_t v_type = TILEDB_UINT8; // CPLSerializeXMLTree returns char*
-                const void* v_r = NULL;
+                const void* v_r = nullptr;
                 uint32_t v_num = 0;
                 if ( eAccess == GA_Update )
                 {


### PR DESCRIPTION
##  What does this PR do?

This PR uses the metadata feature that is available in TileDB 1.7+ rather than creating a sidecar file. The benefits are API compatibility with TileDB as well as supporting versioned metadata. Backwards compatibility with the sidecar approach has been maintained where possible. 

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed