### PR TITLE
ogr/mysql: Add SRID to geometry when creating layer table(fixes #1015)

### DIFF
--- a/gdal/ci/travis/ubuntu_1804/before_install.sh
+++ b/gdal/ci/travis/ubuntu_1804/before_install.sh
@@ -14,7 +14,7 @@ sleep 10
 docker exec -it sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB;"
 
 # MySQL 8
-docker run --name mysql1 -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33060:3306 -d mysql/mysql-server:8.0.1 mysqld --default-authentication-plugin=mysql_native_password
+docker run --name mysql1 -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33060:3306 -d mysql/mysql-server:8.0.18 mysqld --default-authentication-plugin=mysql_native_password
 
 # MariaDB 10.3.9
 docker run --name mariadb -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33061:3306 -d mariadb:10.3.9

--- a/gdal/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -1098,7 +1098,6 @@ OGRMySQLDataSource::ICreateLayer( const char * pszLayerNameIn,
 /* -------------------------------------------------------------------- */
     if( GetMajorVersion() < 8 || IsMariaDB() )
     {
-        nSRSId = GetUnknownSRID();
         if (poSRS != nullptr)
             nSRSId = FetchSRSId(poSRS);
     }


### PR DESCRIPTION
## What does this PR do?

Support MySQL 8.0 use SRID for  indexing geometry by creating table with geom column
as 'NOT NULL SRID <#srid>'

Also update CI test by updating MySQL from 8.0.1 to 8.0.18. 
(SRID index is supported from 8.0.3)

## What are related issues/pull requests?

#1015

## Tasklist

 - [x] Clarify a behavior when specified unsupported SRID (discussion on #1015)
 - [x] May add some code to handle an unsupported SRID. 
 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

MySQL 8.0, MariaDB