### PR TITLE
Revise how SRS methods deal with TOWGS84

### DIFF
--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -517,6 +517,7 @@ def test_tiff_srs_towgs84_from_epsg_do_not_write_it():
     ds = gdal.GetDriverByName('GTiff').Create(filename, 1, 1)
     srs_in = osr.SpatialReference()
     srs_in.ImportFromEPSG(31468)
+    srs_in.AddGuessedTOWGS84()
     assert srs_in.HasTOWGS84()
     ds.SetSpatialRef(srs_in)
     ds = None
@@ -533,6 +534,7 @@ def test_tiff_srs_towgs84_from_epsg_force_write_it():
     ds = gdal.GetDriverByName('GTiff').Create(filename, 1, 1)
     srs_in = osr.SpatialReference()
     srs_in.ImportFromEPSG(31468)
+    srs_in.AddGuessedTOWGS84()
     assert srs_in.HasTOWGS84()
     with gdaltest.config_option('GTIFF_WRITE_TOWGS84', 'YES'):
         ds.SetSpatialRef(srs_in)

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2053,7 +2053,7 @@ def test_tiff_write_64():
     wkt = ds.GetProjection()
     ds = None
 
-    expected_wkt = """GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]"""
+    expected_wkt = """GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]"""
 
     assert wkt == expected_wkt, 'coordinate system does not exactly match.'
 

--- a/autotest/gdrivers/dted.py
+++ b/autotest/gdrivers/dted.py
@@ -147,8 +147,7 @@ def test_dted_7():
 
     assert gdal.GetLastErrorMsg() is not None, 'An expected warning was not emitted'
 
-    assert prj == 'GEOGCS["WGS 72",DATUM["World_Geodetic_System_1972",SPHEROID["WGS 72",6378135,298.26]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4322"]]', \
-        ('Projection does not match expected:\n%s' % prj)
+    assert prj.startswith('GEOGCS["WGS 72"')
 
 ###############################################################################
 # Test a file whose checksum is corrupted

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -3813,7 +3813,6 @@ def test_ogr_shape_99():
         DATUM["CH1903",
             SPHEROID["Bessel 1841",6377397.155,299.1528128,
                 AUTHORITY["EPSG","7004"]],
-            TOWGS84[674.374,15.056,405.346,0,0,0,0],
             AUTHORITY["EPSG","6149"]],
         PRIMEM["Greenwich",0,
             AUTHORITY["EPSG","8901"]],

--- a/autotest/osr/osr_compd.py
+++ b/autotest/osr/osr_compd.py
@@ -178,7 +178,6 @@ def test_osr_compd_5():
             DATUM["North_American_Datum_1983",
                 SPHEROID["GRS 1980",6378137,298.257222101,
                     AUTHORITY["EPSG","7019"]],
-                TOWGS84[0,0,0,0,0,0,0],
                 AUTHORITY["EPSG","6269"]],
             PRIMEM["Greenwich",0,
                 AUTHORITY["EPSG","8901"]],
@@ -211,7 +210,7 @@ def test_osr_compd_5():
         print('warning they are equivalent, but not completely the same')
         print(wkt)
 
-    exp_proj4 = '+proj=utm +zone=11 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +vunits=m +no_defs'
+    exp_proj4 = '+proj=utm +zone=11 +datum=NAD83 +units=m +vunits=m +no_defs'
     proj4 = srs.ExportToProj4()
     assert proj4 == exp_proj4, ('Did not get expected proj.4 string, got:' + proj4)
 

--- a/autotest/osr/osr_ct_proj.py
+++ b/autotest/osr/osr_ct_proj.py
@@ -131,7 +131,17 @@ transform_list = [
      'EPSG:4326', (49.9988573027651,9.99881145557889, 0.0), 1e-8,
      'DHDN -> WGS84 using BETA2007', None, 'GRID:BETA2007.gsb'),
 
-    ('EPSG:4314', (50, 10, 0.0), 1e-8,
+    ("""GEOGCS["DHDN",
+    DATUM["Deutsches_Hauptdreiecksnetz",
+        SPHEROID["Bessel 1841",6377397.155,299.1528128,
+            AUTHORITY["EPSG","7004"]],
+        TOWGS84[598.1,73.7,418.2,0.202,0.045,-2.455,6.7],
+        AUTHORITY["EPSG","6314"]],
+    PRIMEM["Greenwich",0,
+        AUTHORITY["EPSG","8901"]],
+    UNIT["degree",0.0174532925199433,
+        AUTHORITY["EPSG","9122"]],
+    AUTHORITY["EPSG","4314"]]""", (50, 10, 0.0), 1e-8,
      'EPSG:4326', (49.9988572643058,9.99881392529464,0), 1e-8,
      'DHDN -> WGS84 using TOWGS84 automatically set', 'OSR_CT_USE_DEFAULT_EPSG_TOWGS84=YES', None),
 

--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -47,14 +47,13 @@ def test_osr_epsg_1():
     assert srs.GetAuthorityCode(None) == '3003'
 
 ###############################################################################
-# Check that EPSG:4312 lookup has the towgs84 values set properly
-# from gcs.override.csv.
-
+# Check that EPSG:4312 w.r.t towgs84 values
 
 def test_osr_epsg_2():
 
     srs = osr.SpatialReference()
-    srs.ImportFromEPSG(4312)
+    with gdaltest.config_option('OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG', 'YES'):
+        srs.ImportFromEPSG(4312)
 
     if abs(float(srs.GetAttrValue('TOWGS84', 6)) -
            2.4232) > 0.0005:
@@ -72,6 +71,7 @@ def test_osr_epsg_3():
     for epsg in [3120, 2172, 2173, 2174, 2175, 3328]:
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(epsg)
+        srs.AddGuessedTOWGS84()
 
         expected_towgs84 = [33.4, -146.6, -76.3, -0.359, -0.053, 0.844, -0.84]
 

--- a/gdal/ci/travis/osx/install.sh
+++ b/gdal/ci/travis/osx/install.sh
@@ -31,7 +31,7 @@ find /tmp/install/lib
 
 # build GDAL
 cd gdal
-./configure --prefix=$HOME/install-gdal --enable-debug --with-jpeg12 --with-geotiff=internal --with-png=internal --with-proj=/tmp/install --with-sqlite3=/usr/local/opt/sqlite --without-pg --without-jasper --without-webp
+./configure --prefix=$HOME/install-gdal --enable-debug --with-jpeg12 --with-geotiff=internal --with-png=internal --with-proj=/tmp/install --with-sqlite3=/usr/local/opt/sqlite --without-pg --without-jasper --without-webp --without-netcdf
 make USER_DEFS="-Wextra -Werror" -j3
 cd apps
 make USER_DEFS="-Wextra -Werror" test_ogrsf

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -12646,29 +12646,12 @@ void GTiffDataset::LookForProjection()
 
         if( GTIFGetDefn( hGTIF, psGTIFDefn ) )
         {
-            char* pszProjection = GTIFGetOGISDefn( hGTIF, psGTIFDefn );
-            if( pszProjection )
+            OGRSpatialReferenceH hSRS = GTIFGetOGISDefnAsOSR( hGTIF, psGTIFDefn );
+            if( hSRS )
             {
-                oSRS.SetFromUserInput(pszProjection);
-                double adfTOWGS84[7];
-                bool bHasTOWGS84 = oSRS.GetTOWGS84(&adfTOWGS84[0], 7) == OGRERR_NONE;
-                const char* pszCode = oSRS.GetAuthorityCode(nullptr);
-                if( pszCode )
-                {
-                    oSRS.importFromEPSG(atoi(pszCode));
-                    if( bHasTOWGS84 )
-                    {
-                        oSRS.SetTOWGS84(adfTOWGS84[0],
-                                        adfTOWGS84[1],
-                                        adfTOWGS84[2],
-                                        adfTOWGS84[3],
-                                        adfTOWGS84[4],
-                                        adfTOWGS84[5],
-                                        adfTOWGS84[6]);
-                    }
-                }
+                oSRS = *(OGRSpatialReference::FromHandle(hSRS));
+                OSRDestroySpatialReference(hSRS);
             }
-            CPLFree(pszProjection);
 
             if( oSRS.IsCompound() )
             {

--- a/gdal/frmts/gtiff/gt_wkt_srs.h
+++ b/gdal/frmts/gtiff/gt_wkt_srs.h
@@ -34,6 +34,7 @@
 #define GT_WKT_SRS_H_INCLUDED
 
 #include "cpl_port.h"
+#include "ogr_srs_api.h"
 
 #include "geo_normalize.h"
 #include "geotiff.h"
@@ -49,6 +50,8 @@ typedef enum
 } GTIFFKeysFlavorEnum;
 
 int GTIFSetFromOGISDefnEx( GTIF *, const char *, GTIFFKeysFlavorEnum );
+
+OGRSpatialReferenceH GTIFGetOGISDefnAsOSR( GTIF *, GTIFDefn * );
 
 CPL_C_END
 

--- a/gdal/ogr/ogr_spatialref.h
+++ b/gdal/ogr/ogr_spatialref.h
@@ -361,6 +361,7 @@ class CPL_DLL OGRSpatialReference
                             double = 0.0, double = 0.0, double = 0.0,
                             double = 0.0 );
     OGRErr      GetTOWGS84( double *padfCoef, int nCoeff = 7 ) const;
+    OGRErr      AddGuessedTOWGS84();
 
     double      GetSemiMajor( OGRErr * = nullptr ) const;
     double      GetSemiMinor( OGRErr * = nullptr ) const;

--- a/gdal/ogr/ogr_srs_api.h
+++ b/gdal/ogr/ogr_srs_api.h
@@ -566,6 +566,7 @@ OGRErr CPL_DLL OSRSetTOWGS84( OGRSpatialReferenceH hSRS,
                               double, double, double,
                               double, double, double, double );
 OGRErr CPL_DLL OSRGetTOWGS84( OGRSpatialReferenceH hSRS, double *, int );
+OGRErr CPL_DLL OSRAddGuessedTOWGS84( OGRSpatialReferenceH hSRS);
 
 OGRErr CPL_DLL OSRSetCompoundCS( OGRSpatialReferenceH hSRS,
                                  const char *pszName,

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -821,10 +821,11 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
     else if( !bWebMercatorToWGS84LongLat )
     {
         const auto CanUseAuthorityDef = [](const OGRSpatialReference* poSRS1,
-                                           const OGRSpatialReference* poSRS2,
+                                           OGRSpatialReference* poSRSFromAuth,
                                            const char* pszAuth)
         {
-            if( EQUAL(pszAuth, "EPSG") )
+            if( EQUAL(pszAuth, "EPSG") &&
+                CPLTestBool(CPLGetConfigOption("OSR_CT_USE_DEFAULT_EPSG_TOWGS84", "NO")) )
             {
                 // We don't want by default to honour 'default' TOWGS84 terms that come with the EPSG code
                 // because there might be a better transformation from that
@@ -835,10 +836,12 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
                 // OSR_CT_USE_DEFAULT_EPSG_TOWGS84 configuration option to YES
                 double adfTOWGS84_1[7];
                 double adfTOWGS84_2[7];
+
+                poSRSFromAuth->AddGuessedTOWGS84();
+
                 if( poSRS1->GetTOWGS84(adfTOWGS84_1) == OGRERR_NONE &&
-                    poSRS2->GetTOWGS84(adfTOWGS84_2) == OGRERR_NONE &&
-                    memcmp(adfTOWGS84_1, adfTOWGS84_2, sizeof(adfTOWGS84_1)) == 0 &&
-                    CPLTestBool(CPLGetConfigOption("OSR_CT_USE_DEFAULT_EPSG_TOWGS84", "NO")) )
+                    poSRSFromAuth->GetTOWGS84(adfTOWGS84_2) == OGRERR_NONE &&
+                    memcmp(adfTOWGS84_1, adfTOWGS84_2, sizeof(adfTOWGS84_1)) == 0 )
                 {
                     return false;
                 }

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -1334,6 +1334,44 @@ OGRErr OGRSpatialReference::exportToWkt( char ** ppszResult ) const
 }
 
 /************************************************************************/
+/*                GDAL_proj_crs_create_bound_crs_to_WGS84()             */
+/************************************************************************/
+
+static PJ* GDAL_proj_crs_create_bound_crs_to_WGS84(PJ_CONTEXT* ctx, PJ* pj,
+                                                   bool onlyIfEPSGCode)
+{
+    PJ* ret = nullptr;
+    if( proj_get_type(pj) == PJ_TYPE_COMPOUND_CRS )
+    {
+        auto horizCRS = proj_crs_get_sub_crs(ctx, pj, 0);
+        auto vertCRS = proj_crs_get_sub_crs(ctx, pj, 1);
+        if( horizCRS && proj_get_type(horizCRS) != PJ_TYPE_BOUND_CRS && vertCRS &&
+            (!onlyIfEPSGCode || proj_get_id_auth_name(horizCRS, 0) != nullptr) )
+        {
+            auto boundHoriz = proj_crs_create_bound_crs_to_WGS84(
+                ctx, horizCRS, nullptr);
+            if( boundHoriz )
+            {
+                ret = proj_create_compound_crs(
+                        ctx, proj_get_name(pj),
+                        boundHoriz,
+                        vertCRS);
+            }
+            proj_destroy(boundHoriz);
+        }
+        proj_destroy(horizCRS);
+        proj_destroy(vertCRS);
+    }
+    else if( proj_get_type(pj) != PJ_TYPE_BOUND_CRS &&
+             (!onlyIfEPSGCode || proj_get_id_auth_name(pj, 0) != nullptr) )
+    {
+        ret = proj_crs_create_bound_crs_to_WGS84(
+                ctx, pj, nullptr);
+    }
+    return ret;
+}
+
+/************************************************************************/
 /*                            exportToWkt()                             */
 /************************************************************************/
 
@@ -1361,6 +1399,11 @@ OGRErr OGRSpatialReference::exportToWkt( char ** ppszResult ) const
  * </li>
  * </ul>
  *
+ * Starting with GDAL 3.0.3, if the OSR_ADD_TOWGS84_ON_EXPORT_TO_WKT1 configuration
+ * option is set to YES, when exporting to WKT1_GDAL, this method will try
+ * to add a TOWGS84[] node, if there's none attached yet to the SRS and if the SRS has a EPSG code.
+ * See the AddGuessedTOWGS84() method for how this TOWGS84[] node may be added.
+ *
  * @return OGRERR_NONE if successful.
  * @since GDAL 3.0
  */
@@ -1385,6 +1428,7 @@ OGRErr OGRSpatialReference::exportToWkt( char ** ppszResult,
         return d->m_poRoot->exportToWkt(ppszResult);
     }
 
+    auto ctxt = d->getPROJContext();
     auto wktFormat = d->m_bMorphToESRI ? PJ_WKT1_ESRI : PJ_WKT1_GDAL;
     const char* pszFormat = CSLFetchNameValueDef(papszOptions, "FORMAT",
                                     CPLGetConfigOption("OSR_WKT_FORMAT", ""));
@@ -1430,13 +1474,25 @@ OGRErr OGRSpatialReference::exportToWkt( char ** ppszResult,
     aosOptions.SetNameValue("MULTILINE",
                     CSLFetchNameValueDef(papszOptions, "MULTILINE", "NO"));
 
+
+    PJ* boundCRS = nullptr;
+    if( wktFormat == PJ_WKT1_GDAL &&
+        CPLTestBool(
+            CSLFetchNameValueDef(papszOptions, "ADD_TOWGS84_ON_EXPORT_TO_WKT1",
+                                    CPLGetConfigOption("OSR_ADD_TOWGS84_ON_EXPORT_TO_WKT1", "NO"))) )
+    {
+        boundCRS = GDAL_proj_crs_create_bound_crs_to_WGS84(
+            ctxt, d->m_pj_crs, true);
+    }
+
     const char* pszWKT = proj_as_wkt(
-        d->getPROJContext(), d->m_pj_crs,
+        ctxt, boundCRS ? boundCRS : d->m_pj_crs,
         wktFormat, aosOptions.List());
 
     if( !pszWKT )
     {
         *ppszResult = CPLStrdup("");
+        proj_destroy(boundCRS);
         return OGRERR_FAILURE;
     }
 
@@ -1456,10 +1512,12 @@ OGRErr OGRSpatialReference::exportToWkt( char ** ppszResult,
             eErr = oRoot.exportToPrettyWkt( ppszResult, 1 );
         else
             eErr = oRoot.exportToWkt( ppszResult );
+        proj_destroy(boundCRS);
         return eErr;
     }
 
     *ppszResult = CPLStrdup( pszWKT );
+    proj_destroy(boundCRS);
     return OGRERR_NONE;
 }
 
@@ -2929,7 +2987,7 @@ OGRErr OGRSpatialReference::SetWellKnownGeogCS( const char * pszName )
         pszWKT =
             "GEOGCS[\"WGS 72\",DATUM[\"WGS_1972\","
             "SPHEROID[\"WGS 72\",6378135,298.26,AUTHORITY[\"EPSG\",\"7043\"]],"
-            "TOWGS84[0,0,4.5,0,0,0.554,0.2263],AUTHORITY[\"EPSG\",\"6322\"]],"
+            "AUTHORITY[\"EPSG\",\"6322\"]],"
             "PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],"
             "UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],"
             "AUTHORITY[\"EPSG\",\"4322\"]]";
@@ -9677,6 +9735,12 @@ OGRErr CPL_STDCALL OSRExportToProj4( OGRSpatialReferenceH hSRS,
  * set to YES, the PROJ definition built from the SRS will use the +approx flag
  * for the tmerc and utm projection methods, rather than the more accurate method.
  *
+ * Starting with GDAL 3.0.3, this method will try to add a +towgs84 parameter,
+ * if there's none attached yet to the SRS and if the SRS has a EPSG code.
+ * See the AddGuessedTOWGS84() method for how this +towgs84 parameter may be added.
+ * This automatic addition may be disabled by setting the
+ * OSR_ADD_TOWGS84_ON_EXPORT_TO_PROJ4 configuration option to NO.
+ *
  * This method is the equivalent of the C function OSRExportToProj4().
  *
  * @param ppszProj4 pointer to which dynamically allocated PROJ definition
@@ -9729,14 +9793,33 @@ OGRErr OGRSpatialReference::exportToProj4( char ** ppszProj4 ) const
         bForceApproxTMerc ? "USE_APPROX_TMERC=YES" : nullptr,
         nullptr
     };
+
     const char* projString = proj_as_proj_string(d->getPROJContext(),
-                                                     d->m_pj_crs, PJ_PROJ_4, options);
+                                                 d->m_pj_crs, PJ_PROJ_4, options);
+
+    PJ* boundCRS = nullptr;
+    if( projString &&
+        strstr(projString, "+datum=") == nullptr &&
+        CPLTestBool(
+            CPLGetConfigOption("OSR_ADD_TOWGS84_ON_EXPORT_TO_PROJ4", "YES")) )
+    {
+        boundCRS = GDAL_proj_crs_create_bound_crs_to_WGS84(
+            d->getPROJContext(), d->m_pj_crs, true);
+        if( boundCRS )
+        {
+            projString = proj_as_proj_string(d->getPROJContext(),
+                                             boundCRS, PJ_PROJ_4, options);
+        }
+    }
+
     if( projString == nullptr )
     {
         *ppszProj4 = CPLStrdup("");
+        proj_destroy(boundCRS);
         return OGRERR_FAILURE;
     }
     *ppszProj4 = CPLStrdup(projString);
+    proj_destroy(boundCRS);
     char* pszTypeCrs = strstr(*ppszProj4, " +type=crs");
     if( pszTypeCrs )
         *pszTypeCrs = '\0';
@@ -9951,11 +10034,13 @@ OGRSpatialReferenceH* OGRSpatialReference::FindMatches(
  *
  * Since GDAL 3.0, this method is identical to importFromEPSG().
  *
- * This method try to attach a 3-parameter or 7-parameter Helmert transformation
- * to WGS84 when there is one and only one such method available for the CRS.
+ * Before GDAL 3.0.3, this method try to attach a 3-parameter or 7-parameter
+ * Helmert transformation to WGS84 when there is one and only one such method
+ * available for the CRS.
  * This behaviour might not always be desirable, so starting with GDAL 3.0.3,
- * the OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG configuration option can be set to
- * NO to disable this behaviour.
+ * this is no longer done. However the OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG
+ * configuration option can be set to YES to enable past behaviour.
+ * The AddGuessedTOWGS84() method can also be used for that purpose.
  *
  * This method is the same as the C function OSRImportFromEPSGA().
  *
@@ -9972,7 +10057,7 @@ OGRErr OGRSpatialReference::importFromEPSGA( int nCode )
     const bool bUseNonDeprecated = CPLTestBool(
                 CPLGetConfigOption("OSR_USE_NON_DEPRECATED", "YES"));
     const bool bAddTOWGS84 = CPLTestBool(
-            CPLGetConfigOption("OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG", "YES"));
+            CPLGetConfigOption("OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG", "NO"));
     auto tlsCache = OSRGetProjTLSCache();
     if( tlsCache )
     {
@@ -10033,6 +10118,61 @@ OGRErr OGRSpatialReference::importFromEPSGA( int nCode )
     }
 
     return OGRERR_NONE;
+}
+
+/************************************************************************/
+/*                          AddGuessedTOWGS84()                         */
+/************************************************************************/
+
+/**
+ * \brief  Try to add a a 3-parameter or 7-parameter Helmert transformation
+ * to WGS84.
+ *
+ * This method try to attach a 3-parameter or 7-parameter Helmert transformation
+ * to WGS84 when there is one and only one such method available for the CRS.
+ * Note: this is more restrictive to how GDAL < 3 worked.
+ *
+ * This method is the same as the C function OSRAddGuessedTOWGS84().
+ *
+ * @return OGRERR_NONE on success, or an error code on failure (the CRS has
+ * already a transformation to WGS84 or none matching could be found).
+ *
+ * @since GDAL 3.0.3
+ */
+OGRErr OGRSpatialReference::AddGuessedTOWGS84()
+{
+    d->refreshProjObj();
+    if( !d->m_pj_crs )
+        return OGRERR_FAILURE;
+    auto boundCRS = GDAL_proj_crs_create_bound_crs_to_WGS84(
+        d->getPROJContext(), d->m_pj_crs, false);
+    if( !boundCRS )
+    {
+        return OGRERR_FAILURE;
+    }
+    d->setPjCRS(boundCRS);
+    return OGRERR_NONE;
+}
+
+/************************************************************************/
+/*                         OSRImportFromEPSGA()                         */
+/************************************************************************/
+
+/**
+ * \brief  Try to add a a 3-parameter or 7-parameter Helmert transformation
+ * to WGS84.
+ *
+ * This function is the same as OGRSpatialReference::AddGuessedTOWGS84().
+ *
+ * @since GDAL 3.0.3
+ */
+
+OGRErr OSRAddGuessedTOWGS84( OGRSpatialReferenceH hSRS)
+
+{
+    VALIDATE_POINTER1( hSRS, "OSRAddGuessedTOWGS84", OGRERR_FAILURE );
+
+    return OGRSpatialReference::FromHandle(hSRS)->AddGuessedTOWGS84();
 }
 
 /************************************************************************/

--- a/gdal/swig/include/osr.i
+++ b/gdal/swig/include/osr.i
@@ -909,6 +909,10 @@ public:
     return OSRGetTOWGS84( self, argout, 7 );
   }
 
+  OGRErr AddGuessedTOWGS84() {
+    return OSRAddGuessedTOWGS84( self );
+  }
+
   OGRErr SetLocalCS( const char *pszName ) {
     return OSRSetLocalCS( self, pszName );
   }

--- a/gdal/swig/python/extensions/osr_wrap.cpp
+++ b/gdal/swig/python/extensions/osr_wrap.cpp
@@ -4146,6 +4146,9 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
 SWIGINTERN OGRErr OSRSpatialReferenceShadow_GetTOWGS84(OSRSpatialReferenceShadow *self,double argout[7]){
     return OSRGetTOWGS84( self, argout, 7 );
   }
+SWIGINTERN OGRErr OSRSpatialReferenceShadow_AddGuessedTOWGS84(OSRSpatialReferenceShadow *self){
+    return OSRAddGuessedTOWGS84( self );
+  }
 SWIGINTERN OGRErr OSRSpatialReferenceShadow_SetLocalCS(OSRSpatialReferenceShadow *self,char const *pszName){
     return OSRSetLocalCS( self, pszName );
   }
@@ -14157,6 +14160,58 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SpatialReference_AddGuessedTOWGS84(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  OSRSpatialReferenceShadow *arg1 = (OSRSpatialReferenceShadow *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  OGRErr result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:SpatialReference_AddGuessedTOWGS84",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_OSRSpatialReferenceShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SpatialReference_AddGuessedTOWGS84" "', argument " "1"" of type '" "OSRSpatialReferenceShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< OSRSpatialReferenceShadow * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    result = (OGRErr)OSRSpatialReferenceShadow_AddGuessedTOWGS84(arg1);
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    /* %typemap(out) OGRErr */
+    if ( result != 0 && bUseExceptions) {
+      const char* pszMessage = CPLGetLastErrorMsg();
+      if( pszMessage[0] != '\0' )
+      PyErr_SetString( PyExc_RuntimeError, pszMessage );
+      else
+      PyErr_SetString( PyExc_RuntimeError, OGRErrMessages(result) );
+      SWIG_fail;
+    }
+  }
+  {
+    /* %typemap(ret) OGRErr */
+    if ( ReturnSame(resultobj == Py_None || resultobj == 0) ) {
+      resultobj = PyInt_FromLong( result );
+    }
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SpatialReference_SetLocalCS(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   OSRSpatialReferenceShadow *arg1 = (OSRSpatialReferenceShadow *) 0 ;
@@ -19552,6 +19607,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SpatialReference_SetTOWGS84", _wrap_SpatialReference_SetTOWGS84, METH_VARARGS, (char *)"SpatialReference_SetTOWGS84(SpatialReference self, double p1, double p2, double p3, double p4=0.0, double p5=0.0, double p6=0.0, double p7=0.0) -> OGRErr"},
 	 { (char *)"SpatialReference_HasTOWGS84", _wrap_SpatialReference_HasTOWGS84, METH_VARARGS, (char *)"SpatialReference_HasTOWGS84(SpatialReference self) -> bool"},
 	 { (char *)"SpatialReference_GetTOWGS84", _wrap_SpatialReference_GetTOWGS84, METH_VARARGS, (char *)"SpatialReference_GetTOWGS84(SpatialReference self) -> OGRErr"},
+	 { (char *)"SpatialReference_AddGuessedTOWGS84", _wrap_SpatialReference_AddGuessedTOWGS84, METH_VARARGS, (char *)"SpatialReference_AddGuessedTOWGS84(SpatialReference self) -> OGRErr"},
 	 { (char *)"SpatialReference_SetLocalCS", _wrap_SpatialReference_SetLocalCS, METH_VARARGS, (char *)"SpatialReference_SetLocalCS(SpatialReference self, char const * pszName) -> OGRErr"},
 	 { (char *)"SpatialReference_SetGeogCS", _wrap_SpatialReference_SetGeogCS, METH_VARARGS, (char *)"SpatialReference_SetGeogCS(SpatialReference self, char const * pszGeogName, char const * pszDatumName, char const * pszEllipsoidName, double dfSemiMajor, double dfInvFlattening, char const * pszPMName, double dfPMOffset=0.0, char const * pszUnits, double dfConvertToRadians=0.0174532925199433) -> OGRErr"},
 	 { (char *)"SpatialReference_SetProjCS", _wrap_SpatialReference_SetProjCS, METH_VARARGS, (char *)"SpatialReference_SetProjCS(SpatialReference self, char const * name) -> OGRErr"},

--- a/gdal/swig/python/osgeo/osr.py
+++ b/gdal/swig/python/osgeo/osr.py
@@ -1178,6 +1178,11 @@ class SpatialReference(_object):
         return _osr.SpatialReference_GetTOWGS84(self, *args)
 
 
+    def AddGuessedTOWGS84(self, *args):
+        """AddGuessedTOWGS84(SpatialReference self) -> OGRErr"""
+        return _osr.SpatialReference_AddGuessedTOWGS84(self, *args)
+
+
     def SetLocalCS(self, *args):
         """SetLocalCS(SpatialReference self, char const * pszName) -> OGRErr"""
         return _osr.SpatialReference_SetLocalCS(self, *args)


### PR DESCRIPTION
When importing from EPSG, GDAL 3.0.0 to 3.0.2 followed the scheme used in
GDAL 1.x and GDAL 2.x, that is they tried to attach a TOWGS84 transformation.
While the intent was to have some sort of backward compatibility, this may
be a pain for the future.
So do the following changes:
- importFromEPSG(): no longer attach a TOWGS84 transformation, unless the
  user set the OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG=YES configuration option
- Add a OGRSpatialReference::AddGuessedTOWGS84() to attach such a transformation,
  when possible (note: this will do it in a more prudent way than GDAL 1.x/2.x,
  that is only if a transformation is found for the whole area of use of the CRS)
- exportToProj4(): if the SRS has no transformation to WGS84,
  attach a +towgs84 if the SRS has a EPSG code and AddGuessedToWGS84() succeeds.
  Can be disabled with the OSR_ADD_TOWGS84_ON_EXPORT_TO_PROJ4 = NO configuration
  option
- exportToWkt() with WKT1 format:
  Add a OSR_ADD_TOWGS84_ON_EXPORT_TO_WKT1 = YES/NO configuration option, which
  defaults to NO. If set to  YES, then a transformation to WGS84 using
  AddGuessedToWGS84() logic is researched to add a TOWGS84[] node.
