### PR TITLE
ogrinfo: fix to output WKT2 SRS by default. Was done correctly for several geometry column, but not single one

### DIFF
--- a/autotest/utilities/test_ogrinfo.py
+++ b/autotest/utilities/test_ogrinfo.py
@@ -74,7 +74,7 @@ def test_ogrinfo_3():
     assert ret.find('Geometry: Polygon') != -1
     assert ret.find('Feature Count: 10') != -1
     assert ret.find('Extent: (478315') != -1
-    assert ret.find('PROJCS["OSGB') != -1
+    assert ret.find('PROJCRS["OSGB') != -1
     assert ret.find('AREA: Real (') != -1
 
 ###############################################################################
@@ -486,141 +486,16 @@ def test_ogrinfo_24():
     f.close()
 
     ret = gdaltest.runexternal(test_cli_utilities.get_ogrinfo_path() + ' -ro -al tmp/test_ogrinfo_24.vrt -so', check_memleak=False)
-    expected_ret = """INFO: Open of `tmp/test_ogrinfo_24.vrt'
-      using driver `OGR_VRT' successful.
-Metadata:
-  foo=bar
+    assert 'foo=bar' in ret
+    assert 'bar=baz' in ret
 
-Layer name: poly
-Metadata:
-  bar=baz
-Geometry: Polygon
-Feature Count: 10
-Extent: (478315.531250, 4762880.500000) - (481645.312500, 4765610.500000)
-Layer SRS WKT:
-PROJCS["OSGB 1936 / British National Grid",
-    GEOGCS["OSGB 1936",
-        DATUM["OSGB_1936",
-            SPHEROID["Airy 1830",6377563.396,299.3249646,
-                AUTHORITY["EPSG","7001"]],
-            AUTHORITY["EPSG","6277"]],
-        PRIMEM["Greenwich",0,
-            AUTHORITY["EPSG","8901"]],
-        UNIT["degree",0.0174532925199433,
-            AUTHORITY["EPSG","9122"]],
-        AUTHORITY["EPSG","4277"]],
-    PROJECTION["Transverse_Mercator"],
-    PARAMETER["latitude_of_origin",49],
-    PARAMETER["central_meridian",-2],
-    PARAMETER["scale_factor",0.9996012717],
-    PARAMETER["false_easting",400000],
-    PARAMETER["false_northing",-100000],
-    UNIT["metre",1,
-        AUTHORITY["EPSG","9001"]],
-    AXIS["Easting",EAST],
-    AXIS["Northing",NORTH],
-    AUTHORITY["EPSG","27700"]]
-"""
-    expected_lines = expected_ret.splitlines()
-    lines = ret.splitlines()
-    for i, exp_line in enumerate(expected_lines):
-        if exp_line != lines[i]:
-            if gdaltest.is_travis_branch('mingw'):
-                return 'expected_fail'
-            pytest.fail(ret)
     ret = gdaltest.runexternal(test_cli_utilities.get_ogrinfo_path() + ' -ro -al tmp/test_ogrinfo_24.vrt -so -mdd all', check_memleak=False)
-    expected_ret = """INFO: Open of `tmp/test_ogrinfo_24.vrt'
-      using driver `OGR_VRT' successful.
-Metadata:
-  foo=bar
-Metadata (other_domain):
-  baz=foo
-
-Layer name: poly
-Metadata:
-  bar=baz
-Geometry: Polygon
-Feature Count: 10
-Extent: (478315.531250, 4762880.500000) - (481645.312500, 4765610.500000)
-Layer SRS WKT:
-PROJCS["OSGB 1936 / British National Grid",
-    GEOGCS["OSGB 1936",
-        DATUM["OSGB_1936",
-            SPHEROID["Airy 1830",6377563.396,299.3249646,
-                AUTHORITY["EPSG","7001"]],
-            AUTHORITY["EPSG","6277"]],
-        PRIMEM["Greenwich",0,
-            AUTHORITY["EPSG","8901"]],
-        UNIT["degree",0.0174532925199433,
-            AUTHORITY["EPSG","9122"]],
-        AUTHORITY["EPSG","4277"]],
-    PROJECTION["Transverse_Mercator"],
-    PARAMETER["latitude_of_origin",49],
-    PARAMETER["central_meridian",-2],
-    PARAMETER["scale_factor",0.9996012717],
-    PARAMETER["false_easting",400000],
-    PARAMETER["false_northing",-100000],
-    UNIT["metre",1,
-        AUTHORITY["EPSG","9001"]],
-    AXIS["Easting",EAST],
-    AXIS["Northing",NORTH],
-    AUTHORITY["EPSG","27700"]]
-Data axis to CRS axis mapping: 1,2
-AREA: Real (12.3)
-EAS_ID: Integer64 (11.0)
-PRFEDEA: String (16.0)
-"""
-    expected_lines = expected_ret.splitlines()
-    lines = ret.splitlines()
-    for i, exp_line in enumerate(expected_lines):
-        if exp_line != lines[i]:
-            if gdaltest.is_travis_branch('mingw'):
-                return 'expected_fail'
-            pytest.fail(ret)
+    assert 'foo=bar' in ret
+    assert 'baz=foo' in ret
+    assert 'bar=baz' in ret
 
     ret = gdaltest.runexternal(test_cli_utilities.get_ogrinfo_path() + ' -ro -al tmp/test_ogrinfo_24.vrt -so -nomd', check_memleak=False)
-    expected_ret = """INFO: Open of `tmp/test_ogrinfo_24.vrt'
-      using driver `OGR_VRT' successful.
-
-Layer name: poly
-Geometry: Polygon
-Feature Count: 10
-Extent: (478315.531250, 4762880.500000) - (481645.312500, 4765610.500000)
-Layer SRS WKT:
-PROJCS["OSGB 1936 / British National Grid",
-    GEOGCS["OSGB 1936",
-        DATUM["OSGB_1936",
-            SPHEROID["Airy 1830",6377563.396,299.3249646,
-                AUTHORITY["EPSG","7001"]],
-            AUTHORITY["EPSG","6277"]],
-        PRIMEM["Greenwich",0,
-            AUTHORITY["EPSG","8901"]],
-        UNIT["degree",0.0174532925199433,
-            AUTHORITY["EPSG","9122"]],
-        AUTHORITY["EPSG","4277"]],
-    PROJECTION["Transverse_Mercator"],
-    PARAMETER["latitude_of_origin",49],
-    PARAMETER["central_meridian",-2],
-    PARAMETER["scale_factor",0.9996012717],
-    PARAMETER["false_easting",400000],
-    PARAMETER["false_northing",-100000],
-    UNIT["metre",1,
-        AUTHORITY["EPSG","9001"]],
-    AXIS["Easting",EAST],
-    AXIS["Northing",NORTH],
-    AUTHORITY["EPSG","27700"]]
-Data axis to CRS axis mapping: 1,2
-AREA: Real (12.3)
-EAS_ID: Integer64 (11.0)
-PRFEDEA: String (16.0)
-"""
-    expected_lines = expected_ret.splitlines()
-    lines = ret.splitlines()
-    for i, exp_line in enumerate(expected_lines):
-        if exp_line != lines[i]:
-            if gdaltest.is_travis_branch('mingw'):
-                return 'expected_fail'
-            pytest.fail(ret)
+    assert 'Metadata' not in ret
 
     os.unlink('tmp/test_ogrinfo_24.vrt')
 

--- a/gdal/apps/ogrinfo.cpp
+++ b/gdal/apps/ogrinfo.cpp
@@ -350,7 +350,11 @@ static void ReportOnLayer( OGRLayer * poLayer, const char *pszWHERE,
             }
             else
             {
-                poSRS->exportToPrettyWkt(&pszWKT);
+                CPLString osWKTFormat("FORMAT=");
+                osWKTFormat += pszWKTFormat;
+                const char* const apszWKTOptions[] =
+                    { osWKTFormat.c_str(), "MULTILINE=YES", nullptr };
+                poSRS->exportToWkt(&pszWKT, apszWKTOptions);
             }
 
             printf("Layer SRS WKT:\n%s\n", pszWKT);


### PR DESCRIPTION
Discovered when reading https://github.com/OSGeo/gdal/pull/2113#issuecomment-566868430
