### PR TITLE
Doc: allow user full control over installation directory

### DIFF
--- a/gdal/GDALmake.opt.in
+++ b/gdal/GDALmake.opt.in
@@ -58,6 +58,7 @@ OSX_VERSION_FRAMEWORK_PREFIX = ${OSX_FRAMEWORK_PREFIX}/Versions/@GDAL_VERSION_MA
 
 prefix		=	@prefix@
 exec_prefix	=	@exec_prefix@
+datarootdir	=	@datarootdir@
 INST_PREFIX	=	@exec_prefix@
 INST_INCLUDE	=	@includedir@
 INST_DATA 	=	@datadir@

--- a/gdal/GDALmake.opt.in
+++ b/gdal/GDALmake.opt.in
@@ -56,19 +56,23 @@ GNM_ENABLED = @GNM_ENABLED@
 OSX_FRAMEWORK_PREFIX = /Library/Frameworks/GDAL.framework
 OSX_VERSION_FRAMEWORK_PREFIX = ${OSX_FRAMEWORK_PREFIX}/Versions/@GDAL_VERSION_MAJOR@.@GDAL_VERSION_MINOR@
 
+PACKAGE = @PACKAGE@
+
 prefix		=	@prefix@
 exec_prefix	=	@exec_prefix@
 datarootdir	=	@datarootdir@
+docdir	=	@docdir@
+htmldir	=	@htmldir@
 INST_PREFIX	=	@exec_prefix@
 INST_INCLUDE	=	@includedir@
-INST_DATA 	=	@datadir@
+INST_DATA 	=	@datadir@/gdal
 INST_LIB	=	@libdir@
 INST_BIN	=	@bindir@
 INST_BASH_COMPLETION	=	@bashcompdir@
 INST_PYMOD      =       @pymoddir@
-INST_DOCS	=	@exec_prefix@/doc
+INST_DOCS	=	@htmldir@
 INST_MAN	=	@mandir@
-INST_HTML	=	$(HOME)/www/gdal
+INST_WEB	=	$(HOME)/www/gdal
 
 CPPFLAGS	:= @CPPFLAGS@ -I$(GDAL_ROOT)/port @EXTRA_INCLUDES@ -DGDAL_COMPILATION
 CFLAGS		= @CFLAGS@ @C_WFLAGS@ $(USER_DEFS)

--- a/gdal/GNUmakefile
+++ b/gdal/GNUmakefile
@@ -174,16 +174,16 @@ man:
 all:	default ogr-all
 
 install-docs:
-	$(INSTALL_DIR) $(DESTDIR)$(INST_DOCS)/gdal
-	cp -r doc/build/html/* $(DESTDIR)$(INST_DOCS)/gdal
+	$(INSTALL_DIR) $(DESTDIR)$(INST_DOCS)
+	cp -r doc/build/html/* $(DESTDIR)$(INST_DOCS)
 
 install-man:
 	$(INSTALL_DIR) $(DESTDIR)$(INST_MAN)/man1
 	for f in $(wildcard doc/build/man/*.1) ; do $(INSTALL_DATA) $$f $(DESTDIR)$(INST_MAN)/man1 ; done
 
 web-update:	docs
-	$(INSTALL_DIR) $(INST_HTML)
-	cp html/*.* $(INST_HTML)
+	$(INSTALL_DIR) $(INST_WEB)
+	cp html/*.* $(INST_WEB)
 
 install:	install-actions
 

--- a/gdal/configure
+++ b/gdal/configure
@@ -918,6 +918,7 @@ build_os
 build_vendor
 build_cpu
 build
+PACKAGE
 target_alias
 host_alias
 build_alias
@@ -3427,6 +3428,8 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
+
+PACKAGE=gdal
 
 
 ac_config_headers="$ac_config_headers port/cpl_config.h:port/cpl_config.h.in"
@@ -40662,17 +40665,6 @@ export BINTRUE
 
 BINTRUE=$BINTRUE
 
-
-if test "$datadir" = '${prefix}/share' ; then
-  datadir='${prefix}/share/gdal'
-fi
-
-if test "$datadir" = '${datarootdir}' \
-     -a "$datarootdir" = '${prefix}/share' ; then
-  datarootdir='${prefix}/share/gdal'
-fi
-
-mandir='${prefix}/man'
 
 
 if test "$prefix" = "NONE" ; then

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -33,6 +33,7 @@ define([AC_CACHE_SAVE], )
 
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(GDALmake.opt.in)
+AC_SUBST(PACKAGE, gdal)
 AC_CONFIG_MACRO_DIR(m4)
 AC_CONFIG_HEADERS([port/cpl_config.h:port/cpl_config.h.in])
 AH_BOTTOM([#include "cpl_config_extras.h"])
@@ -5166,25 +5167,6 @@ fi
 export BINTRUE
 
 AC_SUBST(BINTRUE,$BINTRUE)
-
-dnl ---------------------------------------------------------------------------
-dnl If datadir is set to @prefix@/share, the modify it to be
-dnl @prefix@/share/gdal.  I wish we could default this.
-dnl ---------------------------------------------------------------------------
-if test "$datadir" = '${prefix}/share' ; then
-  datadir='${prefix}/share/gdal'
-fi
-
-if test "$datadir" = '${datarootdir}' \
-     -a "$datarootdir" = '${prefix}/share' ; then
-  datarootdir='${prefix}/share/gdal'
-fi
-
-dnl ---------------------------------------------------------------------------
-dnl By default mandir is $datarootdir/man which would be
-dnl /usr/local/share/gdal/man but we want man pages in /usr/local/man.
-dnl ---------------------------------------------------------------------------
-mandir='${prefix}/man'
 
 dnl ---------------------------------------------------------------------------
 dnl Capture GDAL_PREFIX for the cpl_config.h include file.


### PR DESCRIPTION
## What does this PR do?

- Don't modify datarootdir, datadir and mandir in configure.
- Use htmldir for installing docs (which are html). This will default to
  docdir but also allows a special html directory to be specified.
- Rename INST_HTML to reduce confusion because it is only used for
  the project web-update target, not the normal install-docs.

(also a simple commit to ensure datarootdir is specified which is causing warnings)

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Gentoo Linux
* Compiler: gcc
