### PR TITLE
Use ST_GEOMETRY_COLUMNS table for metadata in MySQL 8.0 and later (Enhance #1015)

### DIFF
--- a/gdal/ogr/ogrsf_frmts/mysql/ogr_mysql.h
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogr_mysql.h
@@ -240,6 +240,10 @@ class OGRMySQLDataSource final: public OGRDataSource
     OGRSpatialReference *FetchSRS( int nSRSId );
 
     OGRErr              InitializeMetadataTables();
+    OGRErr              UpdateMetadataTables(const char *pszLayerName,
+                                             OGRwkbGeometryType eType,
+                                             const char *pszGeomColumnName,
+                                             const int nSRSId);
 
     int                 Open( const char *, char** papszOpenOptions, int bUpdate );
     int                 OpenTable( const char *, int bUpdate );

--- a/gdal/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -387,6 +387,10 @@ OGRLayer *OGRMySQLDataSource::GetLayer( int iLayer )
         return papoLayers[iLayer];
 }
 
+/* =====================================================================*/
+/* Handle spatial reference id and index for older MySQL and MariaDB    */
+/* =====================================================================*/
+
 /************************************************************************/
 /*                      InitializeMetadataTables()                      */
 /*                                                                      */
@@ -402,37 +406,37 @@ OGRErr OGRMySQLDataSource::InitializeMetadataTables()
     MYSQL_RES       *hResult;
     OGRErr          eErr = OGRERR_NONE;
 
-    pszCommand = "DESCRIBE geometry_columns";
-    if( mysql_query(GetConn(), pszCommand ) )
-    {
-        pszCommand =
-                "CREATE TABLE geometry_columns "
-                "( F_TABLE_CATALOG VARCHAR(256), "
-                "F_TABLE_SCHEMA VARCHAR(256), "
-                "F_TABLE_NAME VARCHAR(256) NOT NULL,"
-                "F_GEOMETRY_COLUMN VARCHAR(256) NOT NULL, "
-                "COORD_DIMENSION INT, "
-                "SRID INT,"
-                "TYPE VARCHAR(256) NOT NULL)";
-        if( mysql_query(GetConn(), pszCommand ) )
-        {
-            ReportError( pszCommand );
-            eErr = OGRERR_FAILURE;
-        }
-        else
-            CPLDebug("MYSQL","Creating geometry_columns metadata table");
-    }
-
-    // make sure to attempt to free results of successful queries
-    hResult = mysql_store_result( GetConn() );
-    if( hResult != nullptr )
-    {
-        mysql_free_result( hResult );
-        hResult = nullptr;
-    }
-
     if( GetMajorVersion() < 8 || IsMariaDB() )
     {
+        pszCommand = "DESCRIBE geometry_columns";
+        if( mysql_query(GetConn(), pszCommand ) )
+        {
+            pszCommand =
+                    "CREATE TABLE geometry_columns "
+                    "( F_TABLE_CATALOG VARCHAR(256), "
+                    "F_TABLE_SCHEMA VARCHAR(256), "
+                    "F_TABLE_NAME VARCHAR(256) NOT NULL,"
+                    "F_GEOMETRY_COLUMN VARCHAR(256) NOT NULL, "
+                    "COORD_DIMENSION INT, "
+                    "SRID INT,"
+                    "TYPE VARCHAR(256) NOT NULL)";
+            if( mysql_query(GetConn(), pszCommand ) )
+            {
+                ReportError( pszCommand );
+                eErr = OGRERR_FAILURE;
+            }
+            else
+                CPLDebug("MYSQL","Creating geometry_columns metadata table");
+        }
+
+        // make sure to attempt to free results of successful queries
+        hResult = mysql_store_result( GetConn() );
+        if( hResult != nullptr )
+        {
+            mysql_free_result( hResult );
+            hResult = nullptr;
+        }
+
         pszCommand = "DESCRIBE spatial_ref_sys";
         if( mysql_query(GetConn(), pszCommand ) )
         {
@@ -462,6 +466,8 @@ OGRErr OGRMySQLDataSource::InitializeMetadataTables()
 
     return eErr;
 }
+
+/* =====================================================================*/
 
 /************************************************************************/
 /*                              FetchSRS()                              */
@@ -1099,64 +1105,21 @@ OGRMySQLDataSource::ICreateLayer( const char * pszLayerNameIn,
         mysql_free_result( hResult );
     hResult = nullptr;
 
+/* =====================================================================*/
+/*  Handle spatial id and index separately for older MySQL and MariaDB  */
+/* -------------------------------------------------------------------- */
+
+    if( GetMajorVersion() < 8 || IsMariaDB() )
+    {
 /* -------------------------------------------------------------------- */
 /*      Sometimes there is an old crufty entry in the geometry_columns  */
 /*      table if things were not properly cleaned up before.  We make   */
 /*      an effort to clean out such cruft.                              */
 /*                                                                      */
 /* -------------------------------------------------------------------- */
-    osCommand.Printf(
-             "DELETE FROM geometry_columns WHERE f_table_name = '%s'",
-             pszLayerName );
-
-    if( mysql_query(GetConn(), osCommand ) )
-    {
-        ReportError( osCommand );
-        return nullptr;
-    }
-
-    // make sure to attempt to free results of successful queries
-    hResult = mysql_store_result( GetConn() );
-    if( hResult != nullptr )
-        mysql_free_result( hResult );
-    hResult = nullptr;
-
-/* -------------------------------------------------------------------- */
-/*      Attempt to add this table to the geometry_columns table, if     */
-/*      it is a spatial layer.                                          */
-/* -------------------------------------------------------------------- */
-    if( eType != wkbNone )
-    {
-        const int nCoordDimension = eType == wkbFlatten(eType) ? 2 : 3;
-
-        pszGeometryType = OGRToOGCGeomType(eType);
-
-        if( nSRSId == GetUnknownSRID() )
-            osCommand.Printf(
-                     "INSERT INTO geometry_columns "
-                     " (F_TABLE_NAME, "
-                     "  F_GEOMETRY_COLUMN, "
-                     "  COORD_DIMENSION, "
-                     "  TYPE) values "
-                     "  ('%s', '%s', %d, '%s')",
-                     pszLayerName,
-                     pszGeomColumnName,
-                     nCoordDimension,
-                     pszGeometryType );
-        else
-            osCommand.Printf(
-                     "INSERT INTO geometry_columns "
-                     " (F_TABLE_NAME, "
-                     "  F_GEOMETRY_COLUMN, "
-                     "  COORD_DIMENSION, "
-                     "  SRID, "
-                     "  TYPE) values "
-                     "  ('%s', '%s', %d, %d, '%s')",
-                     pszLayerName,
-                     pszGeomColumnName,
-                     nCoordDimension,
-                     nSRSId,
-                     pszGeometryType );
+        osCommand.Printf(
+                 "DELETE FROM geometry_columns WHERE f_table_name = '%s'",
+                 pszLayerName );
 
         if( mysql_query(GetConn(), osCommand ) )
         {
@@ -1169,7 +1132,58 @@ OGRMySQLDataSource::ICreateLayer( const char * pszLayerNameIn,
         if( hResult != nullptr )
             mysql_free_result( hResult );
         hResult = nullptr;
+
+/* -------------------------------------------------------------------- */
+/*      Attempt to add this table to the geometry_columns table, if     */
+/*      it is a spatial layer.                                          */
+/* -------------------------------------------------------------------- */
+        if( eType != wkbNone )
+        {
+            const int nCoordDimension = eType == wkbFlatten(eType) ? 2 : 3;
+
+            pszGeometryType = OGRToOGCGeomType(eType);
+
+            if( nSRSId == GetUnknownSRID() )
+                osCommand.Printf(
+                         "INSERT INTO geometry_columns "
+                         " (F_TABLE_NAME, "
+                         "  F_GEOMETRY_COLUMN, "
+                         "  COORD_DIMENSION, "
+                         "  TYPE) values "
+                         "  ('%s', '%s', %d, '%s')",
+                         pszLayerName,
+                         pszGeomColumnName,
+                         nCoordDimension,
+                         pszGeometryType );
+            else
+                osCommand.Printf(
+                         "INSERT INTO geometry_columns "
+                         " (F_TABLE_NAME, "
+                         "  F_GEOMETRY_COLUMN, "
+                         "  COORD_DIMENSION, "
+                         "  SRID, "
+                         "  TYPE) values "
+                         "  ('%s', '%s', %d, %d, '%s')",
+                         pszLayerName,
+                         pszGeomColumnName,
+                         nCoordDimension,
+                         nSRSId,
+                         pszGeometryType );
+
+            if( mysql_query(GetConn(), osCommand ) )
+            {
+                ReportError( osCommand );
+                return nullptr;
+            }
+
+            // make sure to attempt to free results of successful queries
+            hResult = mysql_store_result( GetConn() );
+            if( hResult != nullptr )
+                mysql_free_result( hResult );
+            hResult = nullptr;
+        }
     }
+/* =====================================================================*/
 
 /* -------------------------------------------------------------------- */
 /*      Create the spatial index.                                       */

--- a/gdal/ogr/ogrsf_frmts/mysql/ogrmysqllayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogrmysqllayer.cpp
@@ -316,10 +316,20 @@ int OGRMySQLLayer::FetchSRSId()
         mysql_free_result( hResultSet );
     hResultSet = nullptr;
 
-    osCommand.Printf(
-             "SELECT srid FROM geometry_columns "
-             "WHERE f_table_name = '%s'",
-             pszGeomColumnTable );
+    if( poDS->GetMajorVersion() < 8 || poDS->IsMariaDB() )
+    {
+        osCommand.Printf(
+                 "SELECT srid FROM geometry_columns "
+                 "WHERE f_table_name = '%s'",
+                 pszGeomColumnTable );
+    }
+    else
+    {
+        osCommand.Printf(
+                "SELECT SRS_ID FROM INFORMATION_SCHEMA.ST_GEOMETRY_COLUMNS "
+                "WHERE TABLE_NAME = '%s'",
+                pszGeomColumnTable );
+    }
 
     if( !mysql_query( poDS->GetConn(), osCommand ) )
         hResultSet = mysql_store_result( poDS->GetConn() );

--- a/gdal/ogr/ogrsf_frmts/mysql/ogrmysqlresultlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogrmysqlresultlayer.cpp
@@ -235,9 +235,18 @@ OGRFeatureDefn *OGRMySQLResultLayer::ReadResultDefinition()
         poDefn->SetGeomType( wkbUnknown );
         poDefn->GetGeomFieldDefn(0)->SetName( pszGeomColumn );
 
-        osCommand.Printf(
-                "SELECT type FROM geometry_columns WHERE f_table_name='%s'",
-                pszGeomColumnTable );
+        if( poDS->GetMajorVersion() < 8 || poDS->IsMariaDB() ) {
+            osCommand.Printf(
+                    "SELECT type FROM geometry_columns WHERE f_table_name='%s'",
+                    pszGeomColumnTable);
+        }
+        else
+        {
+            osCommand.Printf(
+                    "SELECT GEOMETRY_TYPE_NAME FROM INFORMATION_SCHEMA.ST_GEOMETRY_COLUMNS "
+                    "WHERE TABLE_NAME = '%s'",
+                    pszGeomColumnTable);
+        }
 
         if( hResultSet != nullptr )
             mysql_free_result( hResultSet );

--- a/gdal/ogr/ogrsf_frmts/mysql/ogrmysqltablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogrmysqltablelayer.cpp
@@ -406,8 +406,9 @@ OGRFeatureDefn *OGRMySQLTableLayer::ReadTableDefinition( const char *pszTable )
 
             OGRwkbGeometryType l_nGeomType = OGRFromOGCGeomType(pszType);
 
-            if( papszRow[1] != nullptr && atoi(papszRow[1]) == 3 )
-                l_nGeomType = wkbSetZ(l_nGeomType);
+            if( poDS->GetMajorVersion() < 8 || poDS->IsMariaDB() )
+                if( papszRow[1] != nullptr && atoi(papszRow[1]) == 3 )
+                    l_nGeomType = wkbSetZ(l_nGeomType);
 
             poDefn->SetGeomType( l_nGeomType );
         }

--- a/gdal/ogr/ogrsf_frmts/mysql/ogrmysqltablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mysql/ogrmysqltablelayer.cpp
@@ -383,9 +383,13 @@ OGRFeatureDefn *OGRMySQLTableLayer::ReadTableDefinition( const char *pszTable )
         poDefn->SetGeomType( wkbUnknown );
         poDefn->GetGeomFieldDefn(0)->SetName( pszGeomColumn );
 
-        osCommand = "SELECT type, coord_dimension FROM geometry_columns WHERE f_table_name='";
-        osCommand += pszTable;
-        osCommand += "'";
+        if( poDS->GetMajorVersion() < 8 || poDS->IsMariaDB() )
+            osCommand.Printf("SELECT type, coord_dimension FROM geometry_columns WHERE f_table_name='%s'",
+                             pszTable);
+
+        else
+            osCommand.Printf("SELECT GEOMETRY_TYPE_NAME FROM INFORMATION_SCHEMA.ST_GEOMETRY_COLUMNS "
+                             "WHERE TABLE_NAME = '%s'", pszTable);
 
         hResult = nullptr;
         if( !mysql_query( poDS->GetConn(), osCommand ) )


### PR DESCRIPTION
#What does this PR do?

When using MySQL 8.0.3 and later, utilize System geometry metadata table instead of manual management.

## What are related issues/pull requests?

#1015

## Tasklist

 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

MySQL 8.0 / MariaDB

## Dependency

This improvement is depends on #2111 
