### PR TITLE
gitignore: aware of CMake file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 __pycache__/
 .env*/
 .venv*/
+
+# CMake
+CMakeLists.txt
+*.cmake


### PR DESCRIPTION
## What does this PR do?

Current GDAL does not support build using CMake but there are external project to add CMake project files to GDAL. To avoid merging CMake related files  into GDAL project, gitignore CMake related files.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

