### PR TITLE
Introduce pytest-runner

### DIFF
--- a/autotest/GNUmakefile
+++ b/autotest/GNUmakefile
@@ -24,3 +24,20 @@ pyscripts-test:
 
 test check:
 	@$(MAKE) $(MFLAGS) gcore-test gdrivers-test alg-test ogr-test osr-test utilities-test pyscripts-test
+
+
+include ../gdal/GDALmake.opt
+
+ifndef PYTHON
+        PYTHON=python
+endif
+
+PYTHON_LIB := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('BLDLIBRARY'))" )
+PYTHON_INCLUDE_DIRS := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_path('include'))" )
+CXXFLAGS += -I$(PYTHON_INCLUDE_DIRS)
+
+pytest_runner: pytest_runner.o
+	$(CXX) $(LDFLAGS) $< $(PYTHON_LIB) -o $@
+
+pytest_runner.o: pytest_runner.cpp
+	$(CXX) $(CXXFLAGS) -c $<

--- a/autotest/pytest_runner.cpp
+++ b/autotest/pytest_runner.cpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+ * $Id$
+ *
+ * Project:  GDAL
+ * Purpose:  Run autotest/pytest from C
+ * Author:   Even Rouault, even.rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2019, Hiroshi Miura <miurahr@linux.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include <string>
+#include <Python.h>
+
+
+int main(int argc, char **argv)
+{
+    std::string args;
+    if ( argc > 1) {
+        args.append("[");
+        for (int i = 1; i < argc; i++) {
+            if (i > 2)
+                args.append(",");
+            args.append("\"");
+            args.append(argv[i]);
+            args.append("\"");
+        }
+        args.append("]");
+    }
+    std::string pycode = "import pytest\npytest.main(" + args + ")\n";
+
+    wchar_t * program_name = Py_DecodeLocale(argv[0], NULL);
+    Py_SetProgramName(program_name);
+    Py_Initialize();
+    PyRun_SimpleString(&*pycode.begin());
+    Py_Finalize();
+    return 0;
+}


### PR DESCRIPTION
## What does this PR do?

It is necessary  to have a native executable to run autotest  to launch a integrated debugger from IDEs such as CLion.

pytest_runner can get arguments which is passed to pytest as same as
`python -m pytest <arguments>`

When developer find a  regression and want to debug a autotest session,
he/she can  configure IDE to run autotest with pytest_runner such as

```
pytest_runner autotest/ogr/ogr_mysql.py
```

I've used this utility with JetBrains CLion and cmake4gdal project.

## What are related issues/pull requests?

No.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
