### PR TITLE
ogrinfo: capital letter in "Layer Name"

### DIFF
--- a/gdal/apps/ogrinfo.cpp
+++ b/gdal/apps/ogrinfo.cpp
@@ -243,7 +243,7 @@ static void ReportOnLayer( OGRLayer * poLayer, const char *pszWHERE,
     if( !bSuperQuiet )
     {
         printf("\n");
-        printf("Layer name: %s\n", poLayer->GetName());
+        printf("Layer Name: %s\n", poLayer->GetName());
     }
 
     GDALInfoReportMetadata(static_cast<GDALMajorObjectH>(poLayer),


### PR DESCRIPTION
In `ogrinfo` many properties consist of two words. Most of them are written with a capital letter e.g. "Feature Count", "FID Column", "Geometry Column". However, the "name" in "Layer name" is not written with a capital letter and is therefore inconsistent.
