### PR TITLE
Python bindings: Fix SWIG warning of missing path for input file

### DIFF
--- a/gdal/swig/python/GNUmakefile
+++ b/gdal/swig/python/GNUmakefile
@@ -48,7 +48,7 @@ ogr_wrap.cpp: ../include/python/ogr_python.i
 osr_wrap.cpp: ../include/python/osr_python.i
 
 gdal_array_wrap.cpp:  ../include/gdal_array.i ../include/python/typemaps_python.i
-	$(SWIG) $(SWIGARGS) $(SWIGDEFINES) -I$(GDAL_ROOT) -c++ -$(BINDING) -o $(SWIGOUTPUTDIR)$@ gdal_array.i
+	$(SWIG) $(SWIGARGS) $(SWIGDEFINES) -I$(GDAL_ROOT) -c++ -$(BINDING) -o $(SWIGOUTPUTDIR)$@ ../include/gdal_array.i
 
 generate: ${WRAPPERS} gdal_array_wrap.cpp
 	# Following is to prevent Coverity Scan to warn about Dereference before null check (REVERSE_INULL)


### PR DESCRIPTION
With SWIG-3.0.2:

SWIG:1: Warning 125: Use of the include path to find the input file is
deprecated and will not work with ccache. Please include the path when
specifying the input file.

## What does this PR do?

Add path to gdal_array.i in gdal/swig/python/GNUmakefile.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Gentoo Linux
* Compiler: GCC
