### PR TITLE
GDALUnrolledCopy<GByte,2,1>: fix SSE2-only implementation

### DIFF
--- a/autotest/cpp/testcopywords.cpp
+++ b/autotest/cpp/testcopywords.cpp
@@ -630,7 +630,7 @@ int main(int /* argc */, char* /* argv */ [])
             memset(pIn, 0xff, 256);
             for(int i=0;i<17;i++)
             {
-                pIn[spacing*i] = (GByte)i;
+                pIn[spacing*i] = (GByte)(17-i);
             }
             memset(pOut, 0xff, 256);
             GDALCopyWords(pIn, GDT_Byte, spacing,
@@ -638,21 +638,21 @@ int main(int /* argc */, char* /* argv */ [])
                         17);
             for(int i=0;i<17;i++)
             {
-                AssertRes(GDT_Byte, i, GDT_Byte, i, pOut[i], __LINE__);
+                AssertRes(GDT_Byte, 17-i, GDT_Byte, 17-i, pOut[i], __LINE__);
             }
 
             memset(pIn, 0xff, 256);
             memset(pOut, 0xff, 256);
             for(int i=0;i<17;i++)
             {
-                pIn[i] = (GByte)i;
+                pIn[i] = (GByte)(17-i);
             }
             GDALCopyWords(pIn, GDT_Byte, 1,
                         pOut, GDT_Byte, spacing,
                         17);
             for(int i=0;i<17;i++)
             {
-                AssertRes(GDT_Byte, i, GDT_Byte, i, pOut[i*spacing], __LINE__);
+                AssertRes(GDT_Byte, 17-i, GDT_Byte, 17-i, pOut[i*spacing], __LINE__);
                 for(int j=1;j<spacing;j++)
                 {
                     AssertRes(GDT_Byte, 0xff, GDT_Byte, 0xff, pOut[i*spacing+j], __LINE__);

--- a/gdal/gcore/rasterio.cpp
+++ b/gdal/gcore/rasterio.cpp
@@ -2899,6 +2899,7 @@ template<> void GDALUnrolledCopy<GByte,2,1>( GByte* CPL_RESTRICT pDest,
         }
 #endif
 
+        const __m128i xmm_zero = _mm_setzero_si128();
         const __m128i xmm_mask = _mm_set1_epi16(0xff);
         // If we were sure that there would always be 1 trailing byte, we could
         // check against nIters - 15
@@ -2910,8 +2911,8 @@ template<> void GDALUnrolledCopy<GByte,2,1>( GByte* CPL_RESTRICT pDest,
             xmm0 = _mm_and_si128(xmm0, xmm_mask);
             xmm1 = _mm_and_si128(xmm1, xmm_mask);
             // Pack int16 to uint8
-            xmm0 = _mm_packus_epi16(xmm0, xmm0);
-            xmm1 = _mm_packus_epi16(xmm1, xmm1);
+            xmm0 = _mm_packus_epi16(xmm0, xmm_zero);
+            xmm1 = _mm_packus_epi16(xmm1, xmm_zero);
 
             // Move 64 lower bits of xmm1 to 64 upper bits of xmm0
             xmm1 = _mm_slli_si128(xmm1, 8);


### PR DESCRIPTION
(when SSSE3 is not available)

Fix issue reported on https://lists.osgeo.org/pipermail/gdal-dev/2019-December/051371.html
