### PR TITLE
ogrsf_frmts/sqlite: simplify to one #include sqlite3.h

### DIFF
--- a/gdal/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -42,29 +42,23 @@
 #include "ogrsf_frmts.h"
 #include "ogrsf_frmts.h"
 #include "rasterlite2_header.h"
-#include "sqlite3.h"
 
-#ifdef HAVE_SPATIALITE
-  #ifdef SPATIALITE_AMALGAMATION
-    /*
-    / using an AMALGAMATED version of SpatiaLite
-    / a private internal copy of SQLite is included:
-    / so we are required including the SpatiaLite's
-    / own header
-    /
-    / IMPORTANT NOTICE: using AMALAGATION is only
-    / useful on Windows (to skip DLL hell related oddities)
-    */
-    #include <spatialite/sqlite3.h>
-  #else
-    /*
-    / You MUST NOT use AMALGAMATION on Linux or any
-    / other "sane" operating system !!!!
-    */
-    #include "sqlite3.h"
-  #endif
+#ifdef SPATIALITE_AMALGAMATION
+/*
+/ using an AMALGAMATED version of SpatiaLite
+/ a private internal copy of SQLite is included:
+/ so we are required including the SpatiaLite's
+/ own header
+/
+/ IMPORTANT NOTICE: using AMALAGATION is only
+/ useful on Windows (to skip DLL hell related oddities)
+/
+/ You MUST NOT use AMALGAMATION on Linux or any
+/ other "sane" operating system !!!!
+*/
+#include <spatialite/sqlite3.h>
 #else
-#include "sqlite3.h"
+#include <sqlite3.h>
 #endif
 
 #ifndef DO_NOT_INCLUDE_SQLITE_CLASSES


### PR DESCRIPTION
SPATIALITE_AMALGAMATION is only defined with HAVE_SPATIALITE.

## What does this PR do?
sqlite3.h was always being included by line 45 anyway https://github.com/OSGeo/gdal/blob/84d972714a80fa019fd11f53b86fa3d5eb2db6c6/gdal/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h#L45
having two conditional includes as well seems wrong.
sqlite3.h is being located using -I so #include should have <>.

## What are related issues/pull requests?

This code does look like the result of several reports and associated changes:

https://trac.osgeo.org/gdal/ticket/3342
https://trac.osgeo.org/gdal/ticket/4269
https://trac.osgeo.org/gdal/changeset/41503

There is even a symlink in the Debian/Ubuntu package because of gdal:
```
spatialite (2.4.0~rc2-4) unstable; urgency=medium

  * Now -dev package depends also on libsqlite3-dev.
  * Added a symlink for sqlite3.h within /usr/include/spatialite because other
    softwares could look for that at configure time (e.g. ATM gdal).

 -- Francesco Paolo Lovergine <frankie@debian.org>  Fri, 07 May 2010 14:53:21 +0200
```
https://metadata.ftp-master.debian.org/changelogs//main/s/spatialite/spatialite_4.3.0a-5_changelog

I haven't tested with SPATIALITE_AMALGAMATION defined. Hopefully the Windows CI will do that.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Gentoo Linux
* Compiler: GCC
