### PR TITLE
Set StringsAsUTF8 flag to TRUE for GeoJSON

### DIFF
--- a/gdal/NEWS
+++ b/gdal/NEWS
@@ -1,3 +1,11 @@
+= Release Notes =
+
+== GDAL drivers ==
+
+GeoJSON driver:
+ * Advertise UTF-8 encoding of strings. In other words: the StringsAsUTF8 flag is TRUE (#2151).
+
+
 = GDAL/OGR 3.0.2 Release Notes =
 
 The 3.0.2 release is a bug fix release.

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
@@ -454,6 +454,8 @@ int OGRGeoJSONLayer::TestCapability( const char * pszCap )
 {
     if( EQUAL(pszCap, OLCCurveGeometries) )
         return FALSE;
+    else if( EQUAL(pszCap, OLCStringsAsUTF8) )
+        return TRUE;
     return OGRMemLayer::TestCapability(pszCap);
 }
 

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
@@ -318,6 +318,6 @@ int OGRGeoJSONWriteLayer::TestCapability( const char* pszCap )
     else if( EQUAL(pszCap, OLCSequentialWrite) )
         return TRUE;
     else if( EQUAL(pszCap, OLCStringsAsUTF8) )
-	return TRUE;
+        return TRUE;
     return FALSE;
 }

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
@@ -317,6 +317,7 @@ int OGRGeoJSONWriteLayer::TestCapability( const char* pszCap )
         return TRUE;
     else if( EQUAL(pszCap, OLCSequentialWrite) )
         return TRUE;
-
+    else if( EQUAL(pszCap, OLCStringsAsUTF8) )
+	return TRUE;
     return FALSE;
 }


### PR DESCRIPTION
Resolves #2151.