### PR TITLE
Also search for proj lib in prefix/lib64

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -24244,14 +24244,15 @@ $as_echo "$as_me: proj.h found" >&6;}
   else
 
     ORIG_LIBS="$LIBS"
-    LIBS="-L$with_proj/lib -lproj $ORIG_LIBS"
-    ac_ext=cpp
+    for libdir in "$with_proj/lib" "$with_proj/lib64"; do
+      LIBS="-L$libdir/lib -lproj $ORIG_LIBS"
+      ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_create_from_wkt in -lproj" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_create_from_wkt in -lproj" >&5
 $as_echo_n "checking for proj_create_from_wkt in -lproj... " >&6; }
 if ${ac_cv_lib_proj_proj_create_from_wkt+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -24293,22 +24294,22 @@ else
   PROJ_FOUND=no
 fi
 
-    ac_ext=c
+      ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-    if test "$PROJ_FOUND" = "no"; then
-        LIBS="-L$with_proj/lib -lproj -lsqlite3 $ORIG_LIBS"
-        unset ac_cv_lib_proj_proj_create_from_wkt
-        ac_ext=cpp
+      if test "$PROJ_FOUND" = "no"; then
+          LIBS="-L$libdir -lproj -lsqlite3 $ORIG_LIBS"
+          unset ac_cv_lib_proj_proj_create_from_wkt
+          ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_create_from_wkt in -lproj" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_create_from_wkt in -lproj" >&5
 $as_echo_n "checking for proj_create_from_wkt in -lproj... " >&6; }
 if ${ac_cv_lib_proj_proj_create_from_wkt+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -24350,22 +24351,22 @@ else
   PROJ_FOUND=no
 fi
 
-        ac_ext=c
+          ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-    fi
-    if test "$PROJ_FOUND" = "no"; then
-        LIBS="-L$with_proj/lib -lproj $ORIG_LIBS"
-        ac_ext=cpp
+      fi
+      if test "$PROJ_FOUND" = "no"; then
+          LIBS="-L$libdir -lproj $ORIG_LIBS"
+          ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -lproj" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -lproj" >&5
 $as_echo_n "checking for internal_proj_create_from_wkt in -lproj... " >&6; }
 if ${ac_cv_lib_proj_internal_proj_create_from_wkt+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -24407,22 +24408,22 @@ else
   PROJ_FOUND=no
 fi
 
-        ac_ext=c
+          ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-        if test "$PROJ_FOUND" = "no"; then
-            LIBS="-L$with_proj/lib -lproj -lsqlite3 $ORIG_LIBS"
-            unset ac_cv_lib_proj_internal_proj_create_from_wkt
-            ac_ext=cpp
+          if test "$PROJ_FOUND" = "no"; then
+              LIBS="-L$libdir -lproj -lsqlite3 $ORIG_LIBS"
+              unset ac_cv_lib_proj_internal_proj_create_from_wkt
+              ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -lproj" >&5
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -lproj" >&5
 $as_echo_n "checking for internal_proj_create_from_wkt in -lproj... " >&6; }
 if ${ac_cv_lib_proj_internal_proj_create_from_wkt+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -24464,26 +24465,26 @@ else
   PROJ_FOUND=no
 fi
 
-            ac_ext=c
+              ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-        fi
-        if test "$PROJ_FOUND" = "yes"; then
-            PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
-        fi
-    fi
-    if test "$PROJ_FOUND" = "no"; then
-        LIBS="-L$with_proj/lib -linternalproj $ORIG_LIBS"
-        ac_ext=cpp
+          fi
+          if test "$PROJ_FOUND" = "yes"; then
+              PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
+          fi
+      fi
+      if test "$PROJ_FOUND" = "no"; then
+          LIBS="-L$libdir/lib -linternalproj $ORIG_LIBS"
+          ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -linternalproj" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -linternalproj" >&5
 $as_echo_n "checking for internal_proj_create_from_wkt in -linternalproj... " >&6; }
 if ${ac_cv_lib_internalproj_internal_proj_create_from_wkt+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -24525,22 +24526,22 @@ else
   PROJ_FOUND=no
 fi
 
-        ac_ext=c
+          ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-        if test "$PROJ_FOUND" = "no"; then
-            LIBS="-L$with_proj/lib -linternalproj -lsqlite3 $ORIG_LIBS"
-            unset ac_cv_lib_internal_proj_internal_proj_create_from_wkt
-            ac_ext=cpp
+          if test "$PROJ_FOUND" = "no"; then
+              LIBS="-L$libdir -linternalproj -lsqlite3 $ORIG_LIBS"
+              unset ac_cv_lib_internal_proj_internal_proj_create_from_wkt
+              ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -linternalproj" >&5
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for internal_proj_create_from_wkt in -linternalproj" >&5
 $as_echo_n "checking for internal_proj_create_from_wkt in -linternalproj... " >&6; }
 if ${ac_cv_lib_internalproj_internal_proj_create_from_wkt+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -24582,17 +24583,18 @@ else
   PROJ_FOUND=no
 fi
 
-            ac_ext=c
+              ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-        fi
-        if test "$PROJ_FOUND" = "yes"; then
-            PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
-        fi
-    fi
+          fi
+          if test "$PROJ_FOUND" = "yes"; then
+              PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
+          fi
+      fi
+    done
     if test "$PROJ_FOUND" = "no"; then
         as_fn_error $? "PROJ 6 symbols not found" "$LINENO" 5
     fi

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -1256,49 +1256,51 @@ else
   else
 
     ORIG_LIBS="$LIBS"
-    LIBS="-L$with_proj/lib -lproj $ORIG_LIBS"
-    AC_LANG_PUSH([C++])
-    AC_CHECK_LIB(proj,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
-    AC_LANG_POP([C++])
-    if test "$PROJ_FOUND" = "no"; then
-        LIBS="-L$with_proj/lib -lproj -lsqlite3 $ORIG_LIBS"
-        unset ac_cv_lib_proj_proj_create_from_wkt
-        AC_LANG_PUSH([C++])
-        AC_CHECK_LIB(proj,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
-        AC_LANG_POP([C++])
-    fi
-    if test "$PROJ_FOUND" = "no"; then
-        LIBS="-L$with_proj/lib -lproj $ORIG_LIBS"
-        AC_LANG_PUSH([C++])
-        AC_CHECK_LIB(proj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
-        AC_LANG_POP([C++])
-        if test "$PROJ_FOUND" = "no"; then
-            LIBS="-L$with_proj/lib -lproj -lsqlite3 $ORIG_LIBS"
-            unset ac_cv_lib_proj_internal_proj_create_from_wkt
-            AC_LANG_PUSH([C++])
-            AC_CHECK_LIB(proj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
-            AC_LANG_POP([C++])
-        fi
-        if test "$PROJ_FOUND" = "yes"; then
-            PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
-        fi
-    fi
-    if test "$PROJ_FOUND" = "no"; then
-        LIBS="-L$with_proj/lib -linternalproj $ORIG_LIBS"
-        AC_LANG_PUSH([C++])
-        AC_CHECK_LIB(internalproj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
-        AC_LANG_POP([C++])
-        if test "$PROJ_FOUND" = "no"; then
-            LIBS="-L$with_proj/lib -linternalproj -lsqlite3 $ORIG_LIBS"
-            unset ac_cv_lib_internal_proj_internal_proj_create_from_wkt
-            AC_LANG_PUSH([C++])
-            AC_CHECK_LIB(internalproj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
-            AC_LANG_POP([C++])
-        fi
-        if test "$PROJ_FOUND" = "yes"; then
-            PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
-        fi
-    fi
+    for libdir in "$with_proj/lib" "$with_proj/lib64"; do
+      LIBS="-L$libdir/lib -lproj $ORIG_LIBS"
+      AC_LANG_PUSH([C++])
+      AC_CHECK_LIB(proj,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+      AC_LANG_POP([C++])
+      if test "$PROJ_FOUND" = "no"; then
+          LIBS="-L$libdir -lproj -lsqlite3 $ORIG_LIBS"
+          unset ac_cv_lib_proj_proj_create_from_wkt
+          AC_LANG_PUSH([C++])
+          AC_CHECK_LIB(proj,proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+          AC_LANG_POP([C++])
+      fi
+      if test "$PROJ_FOUND" = "no"; then
+          LIBS="-L$libdir -lproj $ORIG_LIBS"
+          AC_LANG_PUSH([C++])
+          AC_CHECK_LIB(proj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+          AC_LANG_POP([C++])
+          if test "$PROJ_FOUND" = "no"; then
+              LIBS="-L$libdir -lproj -lsqlite3 $ORIG_LIBS"
+              unset ac_cv_lib_proj_internal_proj_create_from_wkt
+              AC_LANG_PUSH([C++])
+              AC_CHECK_LIB(proj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+              AC_LANG_POP([C++])
+          fi
+          if test "$PROJ_FOUND" = "yes"; then
+              PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
+          fi
+      fi
+      if test "$PROJ_FOUND" = "no"; then
+          LIBS="-L$libdir/lib -linternalproj $ORIG_LIBS"
+          AC_LANG_PUSH([C++])
+          AC_CHECK_LIB(internalproj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+          AC_LANG_POP([C++])
+          if test "$PROJ_FOUND" = "no"; then
+              LIBS="-L$libdir -linternalproj -lsqlite3 $ORIG_LIBS"
+              unset ac_cv_lib_internal_proj_internal_proj_create_from_wkt
+              AC_LANG_PUSH([C++])
+              AC_CHECK_LIB(internalproj,internal_proj_create_from_wkt,PROJ_FOUND=yes,PROJ_FOUND=no,)
+              AC_LANG_POP([C++])
+          fi
+          if test "$PROJ_FOUND" = "yes"; then
+              PROJ_INCLUDE="-DPROJ_RENAME_SYMBOLS"
+          fi
+      fi
+    done
     if test "$PROJ_FOUND" = "no"; then
         AC_MSG_ERROR([PROJ 6 symbols not found])
     fi


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

If using `--with-proj=prefix_path` gdal would so far only look for the libproj.so in `$prefix_path/lib`, whereas proj on (some?) 64 bit systems installs the library into `$prefix_path/lib64`. This PR checks for both locations.

## What are related issues/pull requests?
I assume https://gis.stackexchange.com/questions/317109/build-gdal-with-proj-version-6

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Fedora 31
* Compiler: irrelevant
