### PR TITLE
update ogr2ogr -explodecollections documentation with order relative to -sql

### DIFF
--- a/gdal/doc/source/programs/ogr2ogr.rst
+++ b/gdal/doc/source/programs/ogr2ogr.rst
@@ -337,7 +337,7 @@ output coordinate system or even reprojecting the features during translation.
 .. option:: -explodecollections
 
     Produce one feature for each geometry in any kind of geometry collection in
-    the source file
+    the source file, applied after any ``-sql`` option.
 
 .. option:: -zfield <field_name>
 


### PR DESCRIPTION
## What does this PR do?

documents the fact that ogr2ogr's -explodecollections happens after any operations from -sql and not before.