### PR TITLE
MITAB: Add friendly layer name (description) support.

### DIFF
--- a/gdal/doc/source/drivers/vector/mitab.rst
+++ b/gdal/doc/source/drivers/vector/mitab.rst
@@ -131,16 +131,20 @@ Layer Creation Options
    supported by CPLRecode (e.g. ISO-8859-1, CP1251, CP1252 ...) and
    internally converted to MapInfo charsets names. Default value is ''
    that equals to 'Neutral' MapInfo charset.
+-  **DESCRIPTION=**\ *value*: (GDAL >= 3.1.0) Friendly layer name (only for
+   TAB format). Friendly names can be up to 256 characters long and can include
+   most ASCII characters. Supported by MapInfo Pro v15.0 or higher.
 
 Configuration options
 ~~~~~~~~~~~~~~~~~~~~~
 
--  :decl_configoption:`MITAB_SET_TOWGS84_ON_KNOWN_DATUM` =YES/NO: (GDAL >= 3.0.3).
-   The default behaviour, starting with GDAL 3.0.3, is NO. That is,
-   the TOWGS84 parameters read from the .tab header will *not* be set on the
-   Datum object of the CRS, when the datum can be inferred.
+-  :decl_configoption:`MITAB_SET_TOWGS84_ON_KNOWN_DATUM` =YES/NO:
+   (GDAL >= 3.0.3). The default behaviour, starting with GDAL 3.0.3, is NO.
+   That is, the TOWGS84 parameters read from the .tab header will *not* be set
+   on the Datum object of the CRS, when the datum can be inferred.
 
 See Also
 ~~~~~~~~
 
 -  `MITAB Page <http://mitab.maptools.org/>`__
+-  `About friendly layer names <https://support.pitneybowes.com/SearchArticles/VFP05_KnowledgeWithSidebarHowTo?id=kA180000000CtuHCAS&popup=false&lang=en_US>`__

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab.h
@@ -284,6 +284,10 @@ class TABFile final : public IMapInfoFile
 
     virtual OGRErr      SyncToDisk() override;
 
+    virtual CPLErr SetMetadataItem( const char * pszName,
+                                    const char * pszValue,
+                                    const char * pszDomain = "" ) override;
+
     ///////////////
     // Read access specific stuff
     //

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
@@ -159,8 +159,8 @@ int OGRTABDataSource::Create( const char * pszName, char **papszOptions )
         else
         {
             TABFile *poTabFile = new TABFile;
-            if( poTabFile->Open(m_pszName, TABWrite, FALSE,
-                                m_nBlockSize, pszCharset) != 0 )
+            if( poTabFile->Open( m_pszName, TABWrite, FALSE,
+                                 m_nBlockSize, pszCharset) != 0 )
             {
                 delete poTabFile;
                 return FALSE;
@@ -318,7 +318,7 @@ OGRTABDataSource::ICreateLayer( const char *pszLayerName,
 
     const char *pszEncoding = CSLFetchNameValue( papszOptions, "ENCODING" );
     const char *pszCharset( IMapInfoFile::EncodingToCharset( pszEncoding ) );
-
+    const char *pszDescription( CSLFetchNameValue(papszOptions, "DESCRIPTION") );
 
     if( m_bSingleFile )
     {
@@ -335,6 +335,9 @@ OGRTABDataSource::ICreateLayer( const char *pszLayerName,
         poFile = m_papoLayers[0];
         if( pszEncoding )
             poFile->SetCharset( pszCharset );
+
+        if(poFile->GetFileClass() == TABFC_TABFile)
+            poFile->SetMetadataItem( "DESCRIPTION", pszDescription );
     }
 
     else
@@ -369,6 +372,7 @@ OGRTABDataSource::ICreateLayer( const char *pszLayerName,
                 return nullptr;
             }
             poFile = poTABFile;
+            poFile->SetMetadataItem( "DESCRIPTION", pszDescription );
         }
 
         m_nLayerCount++;

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.cpp
@@ -209,6 +209,7 @@ void RegisterOGRTAB()
 "<LayerCreationOptionList>"
 "  <Option name='BOUNDS' type='string' description='Custom bounds. Expect format is xmin,ymin,xmax,ymax'/>"
 "  <Option name='ENCODING' type='string' description='to override the encoding interpretation of the DAT/MID with any encoding supported by CPLRecode or to \"\" to avoid any recoding (Neutral charset)'/>"
+"  <Option name='DESCRIPTION' type='string' description='Friendly name of table. Only for tab format.'/>" // See https://support.pitneybowes.com/SearchArticles/VFP05_KnowledgeWithSidebarHowTo?id=kA180000000CtuHCAS&popup=false&lang=en_US
 "</LayerCreationOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST,


### PR DESCRIPTION
## What does this PR do?

Add support of friendly names (description) to MapInfo tab (MITAB). For details see https://support.pitneybowes.com/SearchArticles/VFP05_KnowledgeWithSidebarHowTo?id=kA180000000CtuHCAS&popup=false&lang=en_US 

## What are related issues/pull requests?

None

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed
