### PR TITLE
gdal2tiles: Check that min zoom <= max zoom (fixes #2161)

### DIFF
--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -1433,6 +1433,9 @@ class GDAL2Tiles(object):
             zoom_min, zoom_max = minmax[:2]
             self.tminz = int(zoom_min)
             if zoom_max:
+                if int(zoom_max) < self.tminz:
+                    raise Exception('max zoom (%d) less than min zoom (%d)' %
+                                    (int(zoom_max), self.tminz))
                 self.tmaxz = int(zoom_max)
             else:
                 self.tmaxz = int(zoom_min)


### PR DESCRIPTION
## What does this PR do?
Adds a check for for the min/max zoom passed to gdal2tiles to ensure min <= max.

## What are related issues/pull requests?

#2161 

## Tasklist

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
