### PR TITLE
Update links for OGR Python driver examples

### DIFF
--- a/gdal/doc/source/development/rfc/rfc76_ogrpythondrivers.rst
+++ b/gdal/doc/source/development/rfc/rfc76_ogrpythondrivers.rst
@@ -356,9 +356,9 @@ bit artificial. The CityJSON driver mentioned below does not need it.
 Other examples:
 
 * a PASSTHROUGH driver that forwards calls to the GDAL SWIG Python API:
-  https://github.com/rouault/gdal/blob/pythondrivers/gdal/examples/pydrivers/ogr_PASSTHROUGH.py
+  https://github.com/OSGeo/gdal/blob/master/gdal/examples/pydrivers/ogr_PASSTHROUGH.py
 * a driver implemented a simple parsing of `CityJSON <https://www.cityjson.org/>`_:
-  https://github.com/rouault/gdal/blob/pythondrivers/gdal/examples/pydrivers/ogr_CityJSON.py
+  https://github.com/OSGeo/gdal/blob/master/gdal/examples/pydrivers/ogr_CityJSON.py
 
 Limitations and scope
 ---------------------


### PR DESCRIPTION
## What does this PR do?

Fix links for OGR Python driver examples
