### PR TITLE
gtiff.rst: respelled ambigious Byte word

### DIFF
--- a/gdal/doc/source/drivers/raster/gtiff.rst
+++ b/gdal/doc/source/drivers/raster/gtiff.rst
@@ -14,7 +14,7 @@ and somewhat less varieties can be written.
 GDAL also supports reading and writing BigTIFF files (evolution of the TIFF format
 to support files larger than 4 GB).
 
-Currently band types of Byte, UInt16, Int16, UInt32, Int32, Float32,
+Currently band types of byte: UInt16, Int16, UInt32, Int32, Float32,
 Float64, CInt16, CInt32, CFloat32 and CFloat64 are supported for reading
 and writing. Paletted images will return palette information associated
 with the band. The compression formats listed below should be supported


### PR DESCRIPTION
The Byte capitalized before a comma make it like Byte is an available band type. I sadly lost too much time over this, trying to make Byte work like it was a Int8.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] Docs CI build