### PR TITLE
tiledb: zero tile data on read when updating

### DIFF
--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -30,7 +30,6 @@
 ###############################################################################
 
 from osgeo import gdal
-import numpy as np
 import pytest
 
 import gdaltest
@@ -72,6 +71,11 @@ def test_tiledb_write_custom_blocksize():
 
 @pytest.mark.require_driver('TileDB')
 def test_tiledb_write_update():
+    try:
+        import numpy as np
+    except (ImportError):
+        pytest.skip()
+
     gdaltest.tiledb_drv = gdal.GetDriverByName('TileDB')
 
     new_ds = gdaltest.tiledb_drv.Create('tmp/tiledb_update', 20, 20, 1, gdal.GDT_Byte)

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -262,6 +262,14 @@ CPLErr TileDBRasterBand::IReadBlock( int nBlockXOff,
                                     int nBlockYOff,
                                     void * pImage )
 {
+    if( poGDS->eAccess == GA_Update )
+    {
+        memset( pImage, 0,
+                nBlockXSize * nBlockYSize
+                * GDALGetDataTypeSizeBytes(eDataType) );
+        return CE_None;
+    }
+
     int nStartX = nBlockXSize * nBlockXOff;
     int nStartY = nBlockYSize * nBlockYOff;
     uint64_t nEndX =  nStartX + nBlockXSize;


### PR DESCRIPTION
## What does this PR do?

Zeros the tile read when the array is being updated. This is a pattern followed by other drivers e.g. https://github.com/OSGeo/gdal/blob/master/gdal/frmts/hdf4/hdf4imagedataset.cpp#L300 and prevents artifacts when updating

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed