### PR TITLE
improve handling of --with-pg

### DIFF
--- a/gdal/MIGRATION_GUIDE.TXT
+++ b/gdal/MIGRATION_GUIDE.TXT
@@ -11,7 +11,7 @@ MIGRATION GUIDE FROM GDAL 2.4 to GDAL 3.0
 
 - Unix Build: ./configure arguments --without-bsb, --without-grib,
   and --without-mrf have been renamed to --disable-driver-bsb,
-  --disable-driver-grib and --disable-driver-mrf
+  --disable-driver-grib and --disable-driver-mrf; Arguments of --with-pg changed.
 - Substantial changes, sometimes backward incompatible, in coordinate reference
   system and coordinate transformations have been introduced per
   https://trac.osgeo.org/gdal/wiki/rfc73_proj6_wkt2_srsbarn

--- a/gdal/MIGRATION_GUIDE.TXT
+++ b/gdal/MIGRATION_GUIDE.TXT
@@ -11,7 +11,8 @@ MIGRATION GUIDE FROM GDAL 2.4 to GDAL 3.0
 
 - Unix Build: ./configure arguments --without-bsb, --without-grib,
   and --without-mrf have been renamed to --disable-driver-bsb,
-  --disable-driver-grib and --disable-driver-mrf; Arguments of --with-pg changed.
+  --disable-driver-grib and --disable-driver-mrf
+ - Unix build: Arguments of --with-pg changed to yes/no only.
 - Substantial changes, sometimes backward incompatible, in coordinate reference
   system and coordinate transformations have been introduced per
   https://trac.osgeo.org/gdal/wiki/rfc73_proj6_wkt2_srsbarn
@@ -427,4 +428,3 @@ Changes that should likely not impact anybody :
    * OGRGeometryFactory::getGEOSGeometryFactory() has been removed.
      This method returned NULL since 2006
      ( http://trac.osgeo.org/gdal/changeset/9899/trunk/ogr/ogrgeometryfactory.cpp )
-

--- a/gdal/configure
+++ b/gdal/configure
@@ -28680,6 +28680,8 @@ fi
 
 if test "x$with_pg" = "xyes" -o "x$with_pg" = "x" ; then
   PG_CONFIG=yes
+elif test "x$with_pg" != "xno"; then
+  as_fn_error $? "Only --with-pg=yes/no supported" "$LINENO" 5
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PostgreSQL" >&5

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -1578,6 +1578,8 @@ AC_ARG_WITH(pg,
 
 if test "x$with_pg" = "xyes" -o "x$with_pg" = "x" ; then
   PG_CONFIG=yes
+elif test "x$with_pg" != "xno"; then
+  AC_MSG_ERROR([Only --with-pg=yes/no supported])
 fi
 
 AC_MSG_CHECKING([for PostgreSQL])


### PR DESCRIPTION
for 3.0 https://github.com/OSGeo/gdal/commit/45e06386d9099cbbe4f8eb7b4c2b8edca09ed144 / #1412 changed the arguments of `--with-pg` configure option from taking a path to taking a boolean. This is easily overlooked by users upgrading from earlier versions and effectively disables PostgreSQL support despite this option defaults to `yes`. Packagers are having trouble with this too, see https://github.com/OSGeo/homebrew-osgeo4mac/issues/1291 and https://github.com/PostgresApp/PostgresApp/issues/548
To mitigate the issue, I add a configure error if the argument of `--with-pg` is in the old form (similar to what you did with the equivalent change for `--with-xml2` in https://github.com/OSGeo/gdal/commit/bfdf002a53e4ef7ce935b365c4490c96dee6f605 / #2173) and mention the breaking change in the migration guide.