### PR TITLE
.travis.yml: move python3 config to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       compiler: gcc
       language: cpp
       sudo: required
-      dist: trusty
+      dist: xenial
       cache:
         apt: true
         directories:

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -36,13 +36,14 @@ from osgeo import gdal
 
 import gdaltest
 
-sys.path.append('../../gdal/swig/python/samples') # For validate_cloud_optimized_geotiff
-
 ###############################################################################
 
 
 def _check_cog(filename):
 
+    path = '../../gdal/swig/python/samples'
+    if path not in sys.path:
+        sys.path.append(path)
     import validate_cloud_optimized_geotiff
     try:
         _, errors, _ = validate_cloud_optimized_geotiff.validate(filename, full_check=True)

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -37,11 +37,24 @@ from osgeo import gdal
 from osgeo import osr
 import pytest
 
-sys.path.append('../../gdal/swig/python/samples')
-
 import gdaltest
 
 run_tiff_write_api_proxy = True
+
+###############################################################################
+
+
+def _check_cog(filename, check_tiled=True, full_check=False):
+
+    path = '../../gdal/swig/python/samples'
+    if path not in sys.path:
+        sys.path.append(path)
+    import validate_cloud_optimized_geotiff
+    try:
+        _, errors, _ = validate_cloud_optimized_geotiff.validate(filename, check_tiled=check_tiled, full_check=full_check)
+        assert not errors, 'validate_cloud_optimized_geotiff failed'
+    except OSError:
+        pytest.fail('validate_cloud_optimized_geotiff failed')
 
 ###############################################################################
 # Get the GeoTIFF driver, and verify a few things about it.
@@ -2977,12 +2990,7 @@ def test_tiff_write_87():
 
     ds = None
 
-    import validate_cloud_optimized_geotiff
-    try:
-        _, errors, _ = validate_cloud_optimized_geotiff.validate('tmp/tiff_write_87_dst.tif', check_tiled=False, full_check=True)
-        assert not errors, 'validate_cloud_optimized_geotiff failed'
-    except OSError:
-        pytest.fail('validate_cloud_optimized_geotiff failed')
+    _check_cog('tmp/tiff_write_87_dst.tif', check_tiled=False, full_check=True)
 
     gdaltest.tiff_drv.Delete('tmp/tiff_write_87_src.tif')
     gdaltest.tiff_drv.Delete('tmp/tiff_write_87_dst.tif')
@@ -3395,12 +3403,7 @@ def test_tiff_write_96(other_options = [], nbands = 1, nbits = 8):
             'did not get expected checksums'
         assert ds.GetMetadataItem('HAS_USED_READ_ENCODED_API', '_DEBUG_') == '0'
 
-    import validate_cloud_optimized_geotiff
-    try:
-        _, errors, _ = validate_cloud_optimized_geotiff.validate('tmp/tiff_write_96_dst.tif', check_tiled=False, full_check=True)
-        assert not errors, 'validate_cloud_optimized_geotiff failed'
-    except OSError:
-        pytest.fail('validate_cloud_optimized_geotiff failed')
+    _check_cog('tmp/tiff_write_96_dst.tif', check_tiled=False, full_check=True)
 
     gdaltest.tiff_drv.Delete('tmp/tiff_write_96_src.tif')
     gdaltest.tiff_drv.Delete('tmp/tiff_write_96_dst.tif')

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -38,42 +38,43 @@ if os.path.basename(sys.argv[0]) == os.path.basename(__file__):
     if os.path.dirname(sys.argv[0]) != '':
         os.chdir(os.path.dirname(sys.argv[0]))
 
-sys.path.append('../../gdal/swig/python/samples')
-
 from osgeo import osr, gdal, ogr
 import gdaltest
 
 ###############################################################################
 # Validate a geopackage
 
-try:
-    import validate_gpkg
-    has_validate = True
-except ImportError:
-    has_validate = False
-
 
 def validate(filename, quiet=False):
-    if has_validate:
-        my_filename = filename
-        if my_filename.startswith('/vsimem/'):
-            my_filename = 'tmp/validate.gpkg'
-            f = gdal.VSIFOpenL(filename, 'rb')
-            if f is None:
-                print('Cannot open %s' % filename)
-                return False
-            content = gdal.VSIFReadL(1, 10000000, f)
-            gdal.VSIFCloseL(f)
-            open(my_filename, 'wb').write(content)
-        try:
-            validate_gpkg.check(my_filename)
-        except Exception as e:
-            if not quiet:
-                print(e)
+
+    path = '../../gdal/swig/python/samples'
+    if path not in sys.path:
+        sys.path.append(path)
+    try:
+        import validate_gpkg
+    except ImportError:
+        print('Cannot import validate_gpkg')
+        return True
+
+    my_filename = filename
+    if my_filename.startswith('/vsimem/'):
+        my_filename = 'tmp/validate.gpkg'
+        f = gdal.VSIFOpenL(filename, 'rb')
+        if f is None:
+            print('Cannot open %s' % filename)
             return False
-        finally:
-            if my_filename != filename:
-                os.unlink(my_filename)
+        content = gdal.VSIFReadL(1, 10000000, f)
+        gdal.VSIFCloseL(f)
+        open(my_filename, 'wb').write(content)
+    try:
+        validate_gpkg.check(my_filename)
+    except Exception as e:
+        if not quiet:
+            print(e)
+        return False
+    finally:
+        if my_filename != filename:
+            os.unlink(my_filename)
     return True
 
 ###############################################################################

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -38,8 +38,6 @@ from osgeo import ogr
 from osgeo import osr
 import pytest
 
-sys.path.append('../../gdal/swig/python/samples')
-
 import gdaltest
 
 ###############################################################################
@@ -111,6 +109,9 @@ def test_jp2lura_invalid_license_num():
 
 def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=None, inspire_tg=True):
 
+    path = '../../gdal/swig/python/samples'
+    if path not in sys.path:
+        sys.path.append(path)
     try:
         import validate_jp2
     except ImportError:

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -37,9 +37,6 @@ from osgeo import ogr
 from osgeo import osr
 import pytest
 
-sys.path.append('../ogr')
-sys.path.append('../../gdal/swig/python/samples')
-
 import gdaltest
 
 ###############################################################################
@@ -809,6 +806,10 @@ def test_jp2openjpeg_25():
 
 
 def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=None, inspire_tg=True):
+
+    for path in ('../ogr', '../../gdal/swig/python/samples'):
+        if path not in sys.path:
+            sys.path.append(path)
 
     try:
         import validate_jp2

--- a/autotest/gdrivers/test_validate_jp2.py
+++ b/autotest/gdrivers/test_validate_jp2.py
@@ -34,8 +34,6 @@ import sys
 from osgeo import gdal
 import pytest
 
-sys.path.append('../../gdal/swig/python/samples')
-
 import gdaltest
 
 ###############################################################################
@@ -48,6 +46,11 @@ def test_validate_jp2_1():
     gdaltest.jp2openjpeg_drv = gdal.GetDriverByName('JP2OpenJPEG')
     if gdaltest.jp2openjpeg_drv is None:
         pytest.skip()
+
+
+    path = '../../gdal/swig/python/samples'
+    if path not in sys.path:
+        sys.path.append(path)
 
     try:
         import validate_jp2
@@ -77,6 +80,10 @@ def validate(filename, inspire_tg=True, expected_gmljp2=True, oidoc=None):
             xmlvalidate.validate  # to make pyflakes happy
         except (ImportError, AttributeError):
             ogc_schemas_location = 'disabled'
+
+    path = '../../gdal/swig/python/samples'
+    if path not in sys.path:
+        sys.path.append(path)
 
     import validate_jp2
     error_report = validate_jp2.ErrorReport(collect_internally=True)

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -1956,7 +1956,7 @@ def test_ogr_fgdb_21():
         pytest.skip('SDK 1.4 required')
 
     # Fails on MULTIPOINT ZM
-    if gdaltest.is_travis_branch('ubuntu_1804') or gdaltest.is_travis_branch('ubuntu_1604'):
+    if gdaltest.is_travis_branch('ubuntu_1804') or gdaltest.is_travis_branch('ubuntu_1604') or gdaltest.is_travis_branch('python3'):
         pytest.skip()
 
     try:

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -52,6 +52,7 @@ def _validate_check(filename):
     try:
         import validate_gpkg
     except ImportError:
+        print('Cannot import validate_gpkg')
         return
     validate_gpkg.check(filename)
 

--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -294,7 +294,7 @@ def test_ogr_mvt_point_polygon_clip():
         pytest.skip()
     if sys.platform == 'darwin' and gdal.GetConfigOption('TRAVIS', None) is not None:
         pytest.skip()
-    if gdaltest.is_travis_branch('sanitize'):
+    if gdaltest.is_travis_branch('sanitize') or gdaltest.is_travis_branch('python3'):
         pytest.skip()
 
     ds = ogr.Open('data/mvt/point_polygon/1')

--- a/autotest/utilities/test_ogr2ogr.py
+++ b/autotest/utilities/test_ogr2ogr.py
@@ -34,8 +34,6 @@ import os
 import shutil
 import pytest
 
-sys.path.append('../ogr')
-
 from osgeo import gdal, ogr, osr
 import gdaltest
 import ogrtest
@@ -173,23 +171,29 @@ def test_ogr2ogr_5():
 
     ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('tmp/poly.shp')
 
+
+def check_if_has_ogr_pg():
+    path = '../ogr'
+    if path not in sys.path:
+        sys.path.append(path)
+    import ogr_pg
+    ogr_pg.test_ogr_pg_1()
+    if gdaltest.pg_ds is None:
+        pytest.skip()
+    gdaltest.pg_ds.Destroy()
+
 ###############################################################################
 # Test -overwrite
 
 
 def test_ogr2ogr_6():
 
-    import ogr_pg
+    check_if_has_ogr_pg()
 
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip()
     if test_cli_utilities.get_ogrinfo_path() is None:
         pytest.skip()
-
-    ogr_pg.test_ogr_pg_1()
-    if gdaltest.pg_ds is None:
-        pytest.skip()
-    gdaltest.pg_ds.Destroy()
 
     gdaltest.runexternal(test_cli_utilities.get_ogrinfo_path() + ' PG:"' + gdaltest.pg_connection_string + '" -sql "DELLAYER:tpoly"')
 
@@ -208,17 +212,12 @@ def test_ogr2ogr_6():
 
 def test_ogr2ogr_7():
 
-    import ogr_pg
+    check_if_has_ogr_pg()
 
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip()
     if test_cli_utilities.get_ogrinfo_path() is None:
         pytest.skip()
-
-    ogr_pg.test_ogr_pg_1()
-    if gdaltest.pg_ds is None:
-        pytest.skip()
-    gdaltest.pg_ds.Destroy()
 
     gdaltest.runexternal(test_cli_utilities.get_ogrinfo_path() + ' PG:"' + gdaltest.pg_connection_string + '" -sql "DELLAYER:tpoly"')
 
@@ -1344,14 +1343,10 @@ def test_ogr2ogr_40():
 
 def test_ogr2ogr_41():
 
-    import ogr_pg
+    check_if_has_ogr_pg()
+
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip()
-
-    ogr_pg.test_ogr_pg_1()
-    if gdaltest.pg_ds is None:
-        pytest.skip()
-    gdaltest.pg_ds.Destroy()
 
     ds = ogr.Open('PG:' + gdaltest.pg_connection_string)
     ds.ExecuteSQL('DELLAYER:test_ogr2ogr_41_src')

--- a/gdal/ci/travis/python3/before_install.sh
+++ b/gdal/ci/travis/python3/before_install.sh
@@ -3,7 +3,7 @@
 set -e
 
 sudo dpkg -l | grep geos
-sudo apt-get purge -y libgeos* libspatialite*
+sudo apt-get purge -y libgeos*
 find  /etc/apt/sources.list.d
 sudo mv /etc/apt/sources.list.d/pgdg* /tmp
 #sudo apt-get remove postgis libpq5 libpq-dev postgresql-9.1-postgis postgresql-9.2-postgis postgresql-9.3-postgis postgresql-9.1 postgresql-9.2 postgresql-9.3 libgdal1
@@ -12,7 +12,7 @@ sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
 #sudo add-apt-repository -y ppa:marlam/gta
 sudo apt-get update
 # postgis postgresql-9.5 postgresql-client-9.5 postgresql-9.5-postgis-2.2 libpq-dev
-sudo apt-get install -y --allow-unauthenticated ccache python3-dev python3-numpy libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libpodofo-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev  libepsilon-dev  liblcms2-2 libpcre3-dev mercurial cmake libcrypto++-dev
+sudo apt-get install -y --allow-unauthenticated ccache python3-dev python3-numpy libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libhdf5-dev libpodofo-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev  libepsilon-dev  liblcms2-2 libpcre3-dev mercurial cmake libcrypto++-dev libkml-dev libopenjp2-7-dev libzstd1-dev openjdk-8-jdk ant
 # libgta-dev
 sudo apt-get install -y python3-lxml
 sudo apt-get install -y libqhull-dev
@@ -26,47 +26,33 @@ sudo apt-get install -y libogdi3.2-dev
 #mysql -e "create database autotest;"
 #mysql -e "GRANT ALL ON autotest.* TO 'root'@'localhost';" -u root
 #mysql -e "GRANT ALL ON autotest.* TO 'travis'@'localhost';" -u root
-wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/FileGDB_API_1_2-64.tar.gz
-wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44.tar.gz
+
+#wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44.tar.gz
 wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/install-libecwj2-ubuntu12.04-64bit.tar.gz
-wget http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/install-libkml-r864-64bit.tar.gz
-wget https://github.com/uclouvain/openjpeg/releases/download/v2.3.0/openjpeg-v2.3.0-linux-x86_64.tar.gz
 #wget http://even.rouault.free.fr/mongo-cxx-1.0.2-install-ubuntu12.04-64bit.tar.gz
-tar xzf MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44.tar.gz
-sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Raster_DSDK/include/* /usr/local/include
-sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Raster_DSDK/lib/* /usr/local/lib
-sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Lidar_DSDK/include/* /usr/local/include
-sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Lidar_DSDK/lib/* /usr/local/lib
-tar xzf FileGDB_API_1_2-64.tar.gz
-sudo cp -r FileGDB_API/include/* /usr/local/include
-sudo cp -r FileGDB_API/lib/* /usr/local/lib
+#tar xzf MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44.tar.gz
+#sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Raster_DSDK/include/* /usr/local/include
+#sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Raster_DSDK/lib/* /usr/local/lib
+#sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Lidar_DSDK/include/* /usr/local/include
+#sudo cp -r MrSID_DSDK-8.5.0.3422-linux.x86-64.gcc44/Lidar_DSDK/lib/* /usr/local/lib
+
+wget https://github.com/Esri/file-geodatabase-api/raw/master/FileGDB_API_1.5/FileGDB_API_1_5_64gcc51.tar.gz
+tar xzf FileGDB_API_1_5_64gcc51.tar.gz
+sudo cp -r FileGDB_API-64gcc51/include/* /usr/local/include
+sudo cp -r FileGDB_API-64gcc51/lib/* /usr/local/lib
+
 tar xzf install-libecwj2-ubuntu12.04-64bit.tar.gz
 sudo cp -r install-libecwj2/include/* /usr/local/include
 sudo cp -r install-libecwj2/lib/* /usr/local/lib
-tar xzf install-libkml-r864-64bit.tar.gz
-sudo cp -r install-libkml/include/* /usr/local/include
-sudo cp -r install-libkml/lib/* /usr/local/lib
-tar xzf openjpeg-v2.3.0-linux-x86_64.tar.gz
-sudo cp -r openjpeg-v2.3.0-linux-x86_64/include/* /usr/local/include
-sudo cp -r openjpeg-v2.3.0-linux-x86_64/lib/* /usr/local/lib
 #tar xzf mongo-cxx-1.0.2-install-ubuntu12.04-64bit.tar.gz
 #sudo cp -r mongo-cxx-1.0.2-install/include/* /usr/local/include
 #sudo cp -r mongo-cxx-1.0.2-install/lib/* /usr/local/lib
-wget https://bitbucket.org/chchrsc/kealib/get/c6d36f3db5e4.zip
-unzip c6d36f3db5e4.zip
-cd chchrsc-kealib-c6d36f3db5e4/trunk
-cmake . -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DHDF5_INCLUDE_DIR=/usr/include -DHDF5_LIB_PATH=/usr/lib -DLIBKEA_WITH_GDAL=OFF
-make -j4
-sudo make install
-cd ../..
-
-# Build zstd
-wget https://github.com/facebook/zstd/archive/v1.3.3.tar.gz
-tar xvzf v1.3.3.tar.gz
-cd zstd-1.3.3/lib
-# Faster build
-make -j3 PREFIX=/usr ZSTD_LEGACY_SUPPORT=0 CFLAGS=-O1
-sudo make install PREFIX=/usr ZSTD_LEGACY_SUPPORT=0 CFLAGS=-O1
-cd ../..
+#wget https://bitbucket.org/chchrsc/kealib/get/c6d36f3db5e4.zip
+#unzip c6d36f3db5e4.zip
+#cd chchrsc-kealib-c6d36f3db5e4/trunk
+#cmake . -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DHDF5_INCLUDE_DIR=/usr/include -DHDF5_LIB_PATH=/usr/lib -DLIBKEA_WITH_GDAL=OFF
+#make -j4
+#sudo make install
+#cd ../..
 
 sudo ldconfig

--- a/gdal/ci/travis/python3/install.sh
+++ b/gdal/ci/travis/python3/install.sh
@@ -27,7 +27,8 @@ $SCRIPT_DIR/../common_install.sh
 cd gdal
 # --with-mongocxx=/usr/local
 
-CFLAGS=$ARCH_FLAGS CXXFLAGS=$ARCH_FLAGS ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-podofo --with-spatialite --with-mysql --with-liblzma --with-webp --with-java --with-mdb --with-jvm-lib-add-rpath --with-epsilon --with-ecw=/usr/local --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local --with-fgdb=/usr/local --with-libkml --with-null -with-libtiff=internal --with-proj=/usr/local
+CFLAGS=$ARCH_FLAGS CXXFLAGS=$ARCH_FLAGS ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-podofo --with-spatialite --with-mysql --with-liblzma --with-webp --with-java --with-mdb --with-jvm-lib-add-rpath --with-epsilon --with-ecw=/usr/local  --with-fgdb=/usr/local --with-libkml --with-null -with-libtiff=internal --with-proj=/usr/local
+# --with-mrsid=/usr/local --with-mrsid-lidar=/usr/local
 # --with-gta
 
 make USER_DEFS="-Wextra -Werror" -j3
@@ -63,6 +64,6 @@ make -j3
 cd ../../gdal
 wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mdb-sqlite/mdb-sqlite-1.0.2.tar.bz2
 tar xjvf mdb-sqlite-1.0.2.tar.bz2
-sudo cp mdb-sqlite-1.0.2/lib/*.jar /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext
+sudo cp mdb-sqlite-1.0.2/lib/*.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext
 
 ccache -s


### PR DESCRIPTION
Latest pip version only supports Python >= 3.5, thus Trusty is too old.

Also fixes a number of import patterns that didn't play nice with pytest & python 3