### PR TITLE
AWS: Fix error in loading ~/.aws/config file

### DIFF
--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -2300,7 +2300,7 @@ aws_secret_access_key = bar
 # a non default profile
 
 
-def test_vsis3_read_credentials_config_file_non_default_profile(tmpdir, monkeypatch):
+def test_vsis3_read_credentials_config_file_non_default_profile(tmpdir):
 
     if gdaltest.webserver_port == 0:
         pytest.skip()
@@ -2311,10 +2311,6 @@ def test_vsis3_read_credentials_config_file_non_default_profile(tmpdir, monkeypa
     gdal.SetConfigOption('AWS_CONFIG_FILE', None)
     gdal.SetConfigOption('AWS_DEFAULT_PROFILE', 'myprofile')
 
-    if sys.platform == 'win32':
-        monkeypatch.setenv('USERPROFILE', str(tmpdir))
-    else:
-        monkeypatch.setenv('HOME', str(tmpdir))
     os_aws = tmpdir.mkdir(".aws")
 
     gdal.VSICurlClearCache()
@@ -2345,7 +2341,10 @@ aws_secret_access_key = bar
     handler = webserver.SequentialHandler()
     handler.add('GET', '/s3_fake_bucket/resource', custom_method=get_s3_fake_bucket_resource_method)
     with webserver.install_http_handler(handler):
-        f = open_for_read('/vsis3/s3_fake_bucket/resource')
+        with gdaltest.config_option(
+            'USERPROFILE' if sys.platform == 'win32' else 'HOME', str(tmpdir)
+        ):
+            f = open_for_read('/vsis3/s3_fake_bucket/resource')
         assert f is not None
         data = gdal.VSIFReadL(1, 4, f).decode('ascii')
         gdal.VSIFCloseL(f)

--- a/gdal/port/cpl_aws.cpp
+++ b/gdal/port/cpl_aws.cpp
@@ -887,7 +887,7 @@ bool VSIS3HandleHelper::GetConfigurationFromAWSConfigFiles(
     {
         osConfig = osDotAws;
         osConfig += SEP_STRING;
-        osConfig += "credentials";
+        osConfig += "config";
     }
     fp = VSIFOpenL( osConfig, "rb" );
     if( fp != nullptr )


### PR DESCRIPTION
## What does this PR do?

This PR fixes a copy/paste error at line 890 of `port/cpl_aws.cpp` that caused `~/.aws/credentials` to be loaded instead of `~/.aws/config` here:

https://github.com/OSGeo/gdal/blob/cdd65c9ce4f9ed11b53620c79c25df4bdd29797c/gdal/port/cpl_aws.cpp#L878-L890

This caused issues when using a non-default AWS region stored in the default `~/.aws/config` file, as this file was never parsed.

The test in autotest checking for non-default profiles did not catch this error, because it was using the `AWS_CONFIG_FILE` config option to point to a non-default config file. I have modified the test to make it use the default config file so that the non-tested lines are now covered (I had to play around with `$HOME` in order to do this without tampering with the user's real config/credentials files).

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed