### PR TITLE
Correct dted.rst to reflect DTED driver supports CreateCopy() only

### DIFF
--- a/gdal/doc/source/drivers/raster/dted.rst
+++ b/gdal/doc/source/drivers/raster/dted.rst
@@ -16,7 +16,7 @@ header fields are returned dataset level metadata.
 Driver capabilities
 -------------------
 
-.. supports_create::
+.. supports_createcopy::
 
 .. supports_georeferencing::
 


### PR DESCRIPTION
## What does this PR do?
Corrects the documentation to reflect the support status of DTED for Create() and CreateCopy(). Currently the docs state that DTED supports Create(), however, the DTED driver reports that it only supports CreateCopy() via its metadata information. This is backed up by the fact that up until GDAL 3.1 you were unable to use gdalwarp directly to output a file in DTED format. GDAL 3.1 introduced the ability to output in formats that supported CreateCopy() and you can now use gdalwarp with the DTED format which highlights that DTED does in fact support CreateCopy() not Create().

## What are related issues/pull requests?
None found

## Tasklist
Nil

## Environment
Not relevant