### PR TITLE
Shape: expose .dbf and .cpg source encodings in the SHAPEFILE metadata domain

### DIFF
--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -1098,6 +1098,13 @@ def test_ogr_shape_29():
 
     ds = ogr.Open('tmp/UPPERCASE', update=1)
     lyr = ds.GetLayer(0)
+
+    assert lyr.GetMetadata_Dict('SHAPEFILE') == {
+        'CPG_VALUE': 'UTF-8',
+        'ENCODING_FROM_CPG': 'UTF-8',
+        'SOURCE_ENCODING': 'UTF-8'
+    }
+
     lyr.DeleteFeature(0)
     ds.ExecuteSQL('REPACK UPPERCASE')
     ds = None
@@ -1773,6 +1780,12 @@ def test_ogr_shape_49():
     ds = ogr.Open('data/facility_surface_dd.dbf')
     lyr = ds.GetLayer(0)
 
+    assert lyr.GetMetadata_Dict('SHAPEFILE') == {
+        'ENCODING_FROM_LDID': 'ISO-8859-1',
+        'LDID_VALUE': '87',
+        'SOURCE_ENCODING': 'ISO-8859-1'
+    }
+
     feat = lyr.GetFeature(91)
 
     name = feat.GetField('NAME')
@@ -1804,6 +1817,12 @@ def test_ogr_shape_50():
             'Recode failed, but TestCapability(OLCStringsAsUTF8) returns TRUE'
 
         pytest.skip('skipping test: iconv support needed')
+
+    assert lyr.GetMetadata_Dict('SHAPEFILE') == {
+        'ENCODING_FROM_LDID': 'CP936',
+        'LDID_VALUE': '77',
+        'SOURCE_ENCODING': 'CP936'
+    }
 
     # Setup the utf-8 string.
     if sys.version_info >= (3, 0, 0):
@@ -4762,6 +4781,42 @@ def test_ogr_shape_116_invalid_layer_name():
     assert ds.GetLayerCount() == 1
     ds = None
     gdal.RmdirRecursive(dirname)
+
+
+###############################################################################
+# Test case where a file with LDID/87 is overriden by a .cpg file
+
+
+def test_ogr_shape_ldid_and_cpg():
+
+    gdal.FileFromMemBuffer('/vsimem/tmp.dbf',
+                           open('data/facility_surface_dd.dbf', 'rb').read())
+    gdal.FileFromMemBuffer('/vsimem/tmp.cpg', 'UTF-8')
+    ds = gdal.OpenEx('/vsimem/tmp.dbf')
+    lyr = ds.GetLayer(0)
+    assert lyr.GetMetadata_Dict('SHAPEFILE') == {
+        'CPG_VALUE': 'UTF-8',
+        'ENCODING_FROM_CPG': 'UTF-8',
+        'ENCODING_FROM_LDID': 'ISO-8859-1',
+        'LDID_VALUE': '87',
+        'SOURCE_ENCODING': 'UTF-8'
+    }
+    ds = None
+
+    # Disable recoding
+    ds = gdal.OpenEx('/vsimem/tmp.dbf', open_options = ['ENCODING='])
+    lyr = ds.GetLayer(0)
+    assert lyr.GetMetadata_Dict('SHAPEFILE') == {
+        'CPG_VALUE': 'UTF-8',
+        'ENCODING_FROM_CPG': 'UTF-8',
+        'ENCODING_FROM_LDID': 'ISO-8859-1',
+        'LDID_VALUE': '87',
+        'SOURCE_ENCODING': ''
+    }
+    ds = None
+
+    gdal.Unlink('/vsimem/tmp.dbf')
+    gdal.Unlink('/vsimem/tmp.cpg')
 
 ###############################################################################
 

--- a/gdal/doc/source/drivers/vector/shapefile.rst
+++ b/gdal/doc/source/drivers/vector/shapefile.rst
@@ -26,7 +26,7 @@ applies for SHPT_POLYGON shapefiles, reported as layers of type
 wkbPolygon, but depending on the number of parts of each geometry, the
 actual type can be either OGRPolygon or OGRMultiPolygon.
 
-Starting with GDAL 2.1 measures (M coordinate) are supported. A
+Measures (M coordinate) are supported. A
 Shapefile with measures is created if the specified geometry type is
 measured or an appropriate layer creation option is used. When a
 shapefile which may have measured geometries is opened, the first shape
@@ -53,29 +53,39 @@ topological relationships of the parts of the polygons so that the
 resulting polygons are correctly defined in the OGC Simple Feature
 convention.
 
+Encoding
+--------
+
 An attempt is made to read the code page setting in the .cpg file, or as
 a fallback in the LDID/codepage setting from the .dbf file, and use it
 to translate string fields to UTF-8 on read, and back when writing. LDID
 "87 / 0x57" is treated as ISO-8859-1 which may not be appropriate. The
-SHAPE_ENCODING `configuration
-option <http://trac.osgeo.org/gdal/wiki/ConfigOptions>`__ may be used to
+:decl_configoption:`SHAPE_ENCODING` configuration option may be used to
 override the encoding interpretation of the shapefile with any encoding
-supported by CPLRecode or to "" to avoid any recoding. (Recoding support
-is new for GDAL/OGR 1.9.0)
+supported by CPLRecode or to "" to avoid any recoding.
 
-Driver capabilities
--------------------
+Starting with GDAL 3.1, the following metadata items are available in the
+"SHAPEFILE" domain:
 
-.. supports_create::
-
-.. supports_georeferencing::
-
-.. supports_virtualio::
+-  **LDID_VALUE**\ =integer: Raw LDID value from the DBF header. Only present
+   if this value is not zero.
+-  **ENCODING_FROM_LDID**\ = string: Encoding name deduced from LDID_VALUE. Only
+   present if LDID_VALUE is present
+-  **CPG_VALUE**\ =string: Content of the .cpg file. Only present if the file
+   exists.
+-  **ENCODING_FROM_CPG**\ = string: Encoding name deduced from CPG_VALUE. Only
+   present if CPG_VALUE is present
+-  **SOURCE_ENCODING**\= string: Encoding used by GDAL to encode/recode strings.
+   If the user has provided the ``SHAPE_ENCODING`` configuration option or
+   ``ENCODING`` open option have been provided (included to empty value), then
+   their value is used to fill this metadata item.
+   Otherwise it is equal to ENCODING_FROM_CPG if it is present. Otherwise it is
+   equal to ENCODING_FROM_LDID.
 
 Open options
 ------------
 
-Starting with GDAL 2.0, the following open options are available.
+The following open options are available.
 
 -  **ENCODING**\ =encoding_name: to override the encoding interpretation
    of the shapefile with any encoding supported by CPLRecode or to "" to
@@ -285,12 +295,12 @@ effect. If nothing is set, a warning will be emitted when the 2GB limit
 is reached.
 
 Dataset Creation Options
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 None
 
 Layer Creation Options
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 -  **SHPT=type**: Override the type of shapefile created. Can be one of
    NULL for a simple .dbf file with no .shp file, POINT, ARC, POLYGON or
@@ -322,14 +332,14 @@ Layer Creation Options
    Previous GDAL versions did not write one.
 
 VSI Virtual File System API support
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 
 The driver supports reading from files managed by VSI Virtual File
 System API, which include "regular" files, as well as files in the
 /vsizip/, /vsigzip/ , /vsicurl/ domains.
 
 Compressed files
-~~~~~~~~~~~~~~~~
+----------------
 
 Starting with GDAL 3.1, the driver can also support reading, creating and
 editing .shz files (ZIP files containing the .shp, .shx, .dbf and other side-car
@@ -337,7 +347,7 @@ files of a single layer) and .shp.zip files (ZIP files contains one or several
 layers). Creation and editing involves the creation of temporary files.
 
 Examples
-~~~~~~~~
+--------
 
 -  A merge of two shapefiles 'file1.shp' and 'file2.shp' into a new file
    'file_merged.shp' is performed like this:
@@ -366,7 +376,7 @@ Examples
       % ogrinfo file1.dbf -sql "RESIZE file1"
 
 Advanced topics
-~~~~~~~~~~~~~~~
+---------------
 
 (GDAL >= 2.0) The SHAPE_REWIND_ON_WRITE configuration option/environment
 variable can be set to NO to prevent the shapefile writer to correct the
@@ -380,8 +390,17 @@ from a MultiPatch object (from a Shapefile/FileGDB/PGeo datasource).
 variable can be set to YES (default NO) to restore broken or absent .shx
 file from associated .shp file during opening.
 
+Driver capabilities
+-------------------
+
+.. supports_create::
+
+.. supports_georeferencing::
+
+.. supports_virtualio::
+
 See Also
-~~~~~~~~
+--------
 
 -  `Shapelib Page <http://shapelib.maptools.org/>`__
 -  `User Notes on OGR Shapefile

--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -420,6 +420,7 @@ static CPLString GetEncodingFromLDIDNumber(int nLDID)
 
 static CPLString GetEncodingFromCPG( const char* pszCPG )
 {
+    // see https://support.esri.com/en/technical-article/000013192
     CPLString osEncodingFromCPG;
     const int nCPG = atoi(pszCPG);
     if( (nCPG >= 437 && nCPG <= 950)
@@ -434,7 +435,8 @@ static CPLString GetEncodingFromCPG( const char* pszCPG )
         else
             osEncodingFromCPG.Printf( "ISO-8859-%s", pszCPG + 4 );
     }
-    else if( STARTS_WITH_CI(pszCPG, "UTF-8") )
+    else if( STARTS_WITH_CI(pszCPG, "UTF-8") ||
+             STARTS_WITH_CI(pszCPG, "UTF8") )
         osEncodingFromCPG =  CPL_ENC_UTF8;
     else if( STARTS_WITH_CI(pszCPG, "ANSI 1251") )
         osEncodingFromCPG = "CP1251";

--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -177,6 +177,7 @@ OGRShapeLayer::OGRShapeLayer( OGRShapeDataSource* poDSIn,
             osEncoding = "";
         }
     }
+    SetMetadataItem("SOURCE_ENCODING", osEncoding, "SHAPEFILE");
 
     poFeatureDefn = SHPReadOGRFeatureDefn(
         CPLGetBasename(pszFullName),
@@ -339,6 +340,113 @@ void OGRShapeLayer::SetWriteDBFEOFChar( bool b )
 /*                          ConvertCodePage()                           */
 /************************************************************************/
 
+static CPLString GetEncodingFromLDIDNumber(int nLDID)
+{
+    int nCP = -1;  // Windows code page.
+
+    // http://www.autopark.ru/ASBProgrammerGuide/DBFSTRUC.HTM
+    switch( nLDID )
+    {
+        case 1: nCP = 437;      break;
+        case 2: nCP = 850;      break;
+        case 3: nCP = 1252;     break;
+        case 4: nCP = 10000;    break;
+        case 8: nCP = 865;      break;
+        case 10: nCP = 850;     break;
+        case 11: nCP = 437;     break;
+        case 13: nCP = 437;     break;
+        case 14: nCP = 850;     break;
+        case 15: nCP = 437;     break;
+        case 16: nCP = 850;     break;
+        case 17: nCP = 437;     break;
+        case 18: nCP = 850;     break;
+        case 19: nCP = 932;     break;
+        case 20: nCP = 850;     break;
+        case 21: nCP = 437;     break;
+        case 22: nCP = 850;     break;
+        case 23: nCP = 865;     break;
+        case 24: nCP = 437;     break;
+        case 25: nCP = 437;     break;
+        case 26: nCP = 850;     break;
+        case 27: nCP = 437;     break;
+        case 28: nCP = 863;     break;
+        case 29: nCP = 850;     break;
+        case 31: nCP = 852;     break;
+        case 34: nCP = 852;     break;
+        case 35: nCP = 852;     break;
+        case 36: nCP = 860;     break;
+        case 37: nCP = 850;     break;
+        case 38: nCP = 866;     break;
+        case 55: nCP = 850;     break;
+        case 64: nCP = 852;     break;
+        case 77: nCP = 936;     break;
+        case 78: nCP = 949;     break;
+        case 79: nCP = 950;     break;
+        case 80: nCP = 874;     break;
+        case 87: return CPL_ENC_ISO8859_1;
+        case 88: nCP = 1252;     break;
+        case 89: nCP = 1252;     break;
+        case 100: nCP = 852;     break;
+        case 101: nCP = 866;     break;
+        case 102: nCP = 865;     break;
+        case 103: nCP = 861;     break;
+        case 104: nCP = 895;     break;
+        case 105: nCP = 620;     break;
+        case 106: nCP = 737;     break;
+        case 107: nCP = 857;     break;
+        case 108: nCP = 863;     break;
+        case 120: nCP = 950;     break;
+        case 121: nCP = 949;     break;
+        case 122: nCP = 936;     break;
+        case 123: nCP = 932;     break;
+        case 124: nCP = 874;     break;
+        case 134: nCP = 737;     break;
+        case 135: nCP = 852;     break;
+        case 136: nCP = 857;     break;
+        case 150: nCP = 10007;   break;
+        case 151: nCP = 10029;   break;
+        case 200: nCP = 1250;    break;
+        case 201: nCP = 1251;    break;
+        case 202: nCP = 1254;    break;
+        case 203: nCP = 1253;    break;
+        case 204: nCP = 1257;    break;
+        default: break;
+    }
+
+    if( nCP < 0 )
+        return CPLString();
+    return CPLString().Printf("CP%d", nCP);
+}
+
+static CPLString GetEncodingFromCPG( const char* pszCPG )
+{
+    CPLString osEncodingFromCPG;
+    const int nCPG = atoi(pszCPG);
+    if( (nCPG >= 437 && nCPG <= 950)
+        || (nCPG >= 1250 && nCPG <= 1258) )
+    {
+        osEncodingFromCPG.Printf( "CP%d", nCPG );
+    }
+    else if( STARTS_WITH_CI(pszCPG, "8859") )
+    {
+        if( pszCPG[4] == '-' )
+            osEncodingFromCPG.Printf( "ISO-8859-%s", pszCPG + 5 );
+        else
+            osEncodingFromCPG.Printf( "ISO-8859-%s", pszCPG + 4 );
+    }
+    else if( STARTS_WITH_CI(pszCPG, "UTF-8") )
+        osEncodingFromCPG =  CPL_ENC_UTF8;
+    else if( STARTS_WITH_CI(pszCPG, "ANSI 1251") )
+        osEncodingFromCPG = "CP1251";
+    else
+    {
+        // Try just using the CPG value directly.  Works for stuff like Big5.
+        osEncodingFromCPG = pszCPG;
+    }
+    return osEncodingFromCPG;
+}
+
+
 CPLString OGRShapeLayer::ConvertCodePage( const char *pszCodePage )
 
 {
@@ -347,110 +455,40 @@ CPLString OGRShapeLayer::ConvertCodePage( const char *pszCodePage )
     if( pszCodePage == nullptr )
         return l_osEncoding;
 
-    if( STARTS_WITH_CI(pszCodePage, "LDID/") )
+    CPLString osEncodingFromLDID;
+    if( hDBF->iLanguageDriver != 0 )
     {
-        int nCP = -1;  // Windows code page.
+        SetMetadataItem("LDID_VALUE",
+                        CPLSPrintf("%d", hDBF->iLanguageDriver),
+                        "SHAPEFILE");
 
-        // http://www.autopark.ru/ASBProgrammerGuide/DBFSTRUC.HTM
-        switch( atoi(pszCodePage+5) )
-        {
-          case 1: nCP = 437;      break;
-          case 2: nCP = 850;      break;
-          case 3: nCP = 1252;     break;
-          case 4: nCP = 10000;    break;
-          case 8: nCP = 865;      break;
-          case 10: nCP = 850;     break;
-          case 11: nCP = 437;     break;
-          case 13: nCP = 437;     break;
-          case 14: nCP = 850;     break;
-          case 15: nCP = 437;     break;
-          case 16: nCP = 850;     break;
-          case 17: nCP = 437;     break;
-          case 18: nCP = 850;     break;
-          case 19: nCP = 932;     break;
-          case 20: nCP = 850;     break;
-          case 21: nCP = 437;     break;
-          case 22: nCP = 850;     break;
-          case 23: nCP = 865;     break;
-          case 24: nCP = 437;     break;
-          case 25: nCP = 437;     break;
-          case 26: nCP = 850;     break;
-          case 27: nCP = 437;     break;
-          case 28: nCP = 863;     break;
-          case 29: nCP = 850;     break;
-          case 31: nCP = 852;     break;
-          case 34: nCP = 852;     break;
-          case 35: nCP = 852;     break;
-          case 36: nCP = 860;     break;
-          case 37: nCP = 850;     break;
-          case 38: nCP = 866;     break;
-          case 55: nCP = 850;     break;
-          case 64: nCP = 852;     break;
-          case 77: nCP = 936;     break;
-          case 78: nCP = 949;     break;
-          case 79: nCP = 950;     break;
-          case 80: nCP = 874;     break;
-          case 87: return CPL_ENC_ISO8859_1;
-          case 88: nCP = 1252;     break;
-          case 89: nCP = 1252;     break;
-          case 100: nCP = 852;     break;
-          case 101: nCP = 866;     break;
-          case 102: nCP = 865;     break;
-          case 103: nCP = 861;     break;
-          case 104: nCP = 895;     break;
-          case 105: nCP = 620;     break;
-          case 106: nCP = 737;     break;
-          case 107: nCP = 857;     break;
-          case 108: nCP = 863;     break;
-          case 120: nCP = 950;     break;
-          case 121: nCP = 949;     break;
-          case 122: nCP = 936;     break;
-          case 123: nCP = 932;     break;
-          case 124: nCP = 874;     break;
-          case 134: nCP = 737;     break;
-          case 135: nCP = 852;     break;
-          case 136: nCP = 857;     break;
-          case 150: nCP = 10007;   break;
-          case 151: nCP = 10029;   break;
-          case 200: nCP = 1250;    break;
-          case 201: nCP = 1251;    break;
-          case 202: nCP = 1254;    break;
-          case 203: nCP = 1253;    break;
-          case 204: nCP = 1257;    break;
-          default: break;
-        }
-
-        if( nCP != -1 )
-        {
-            l_osEncoding.Printf( "CP%d", nCP );
-            return l_osEncoding;
-        }
+        osEncodingFromLDID = GetEncodingFromLDIDNumber(hDBF->iLanguageDriver);
+    }
+    if( !osEncodingFromLDID.empty() )
+    {
+        SetMetadataItem("ENCODING_FROM_LDID",
+                        osEncodingFromLDID.c_str(),
+                        "SHAPEFILE");
     }
 
-    // From the CPG file
-    // http://resources.arcgis.com/fr/content/kbase?fa=articleShow&d=21106
-
-    if( (atoi(pszCodePage) >= 437 && atoi(pszCodePage) <= 950)
-        || (atoi(pszCodePage) >= 1250 && atoi(pszCodePage) <= 1258) )
+    CPLString osEncodingFromCPG;
+    if( !STARTS_WITH_CI(pszCodePage, "LDID/") )
     {
-        l_osEncoding.Printf( "CP%d", atoi(pszCodePage) );
-        return l_osEncoding;
-    }
-    if( STARTS_WITH_CI(pszCodePage, "8859") )
-    {
-        if( pszCodePage[4] == '-' )
-            l_osEncoding.Printf( "ISO-8859-%s", pszCodePage + 5 );
-        else
-            l_osEncoding.Printf( "ISO-8859-%s", pszCodePage + 4 );
-        return l_osEncoding;
-    }
-    if( STARTS_WITH_CI(pszCodePage, "UTF-8") )
-        return CPL_ENC_UTF8;
-    if( STARTS_WITH_CI(pszCodePage, "ANSI 1251") )
-        return "CP1251";
+        SetMetadataItem("CPG_VALUE", pszCodePage, "SHAPEFILE");
 
-    // Try just using the CPG value directly.  Works for stuff like Big5.
-    return pszCodePage;
+        osEncodingFromCPG = GetEncodingFromCPG(pszCodePage);
+
+        if( !osEncodingFromCPG.empty() )
+            SetMetadataItem("ENCODING_FROM_CPG", osEncodingFromCPG, "SHAPEFILE");
+
+        l_osEncoding = osEncodingFromCPG;
+    }
+    else if( !osEncodingFromLDID.empty() )
+    {
+        l_osEncoding = osEncodingFromLDID;
+    }
+
+    return l_osEncoding;
 }
 
 /************************************************************************/


### PR DESCRIPTION
Should help for use case raised by https://github.com/qgis/QGIS/pull/34381