### PR TITLE
redirect vsis3 calls to tiledb s3 direct calls

### DIFF
--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -1052,6 +1052,9 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
                 poDS->SetSubdatasetName( pszAttr );
             }
 
+        if ( STARTS_WITH_CI( poOpenInfo->pszFilename, "/VSIS3/") )
+            osArrayPath.Printf("s3://%s", poOpenInfo->pszFilename + 7);
+        else
             osArrayPath = poOpenInfo->pszFilename;
         }
 


### PR DESCRIPTION
## What does this PR do?

If a user specify a vsis3 prefix then the TileDB driver can use this as a direct s3 uri internally. 

## What are related issues/pull requests?

This was discovered when using the Rasterio library to open arrays from s3.

https://github.com/mapbox/rasterio/issues/1864

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed