### PR TITLE
DIMAP: don't look inside Dataset_Components if Raster_Data is present

### DIFF
--- a/gdal/frmts/dimap/dimapdataset.cpp
+++ b/gdal/frmts/dimap/dimapdataset.cpp
@@ -663,16 +663,19 @@ GDALDataset *DIMAPDataset::Open( GDALOpenInfo * poOpenInfo )
 
                     if( strlen(pszHref) > 0 )  // STRIP product found.
                     {
+                        VSIStatBufL sStat;
                         CPLString osPath = CPLGetPath(osDIMAPFilename);
                         osSTRIPFilename =
                             CPLFormCIFilename( osPath, pszHref, nullptr );
-
-                        break;
+                        if (VSIStatL(osSTRIPFilename, &sStat) == 0)
+                        {
+                            psProductStrip = CPLParseXMLFile(osSTRIPFilename);
+                            break;
+                        }
                     }
                 }
             }
 
-            psProductStrip = CPLParseXMLFile( osSTRIPFilename );
         }
 
         CPLXMLNode *psDatasetRFMComponents =


### PR DESCRIPTION
Some Dimap files do not contain the <Dataset_Components> element. We don't want to error out on these if the needed <Raster_Data> is present