### PR TITLE
Docs: Add missing -optim option in gdal_rasterize

### DIFF
--- a/gdal/doc/source/programs/gdal_rasterize.rst
+++ b/gdal/doc/source/programs/gdal_rasterize.rst
@@ -22,7 +22,8 @@ Synopsis
         [-co "NAME=VALUE"]* [-a_nodata value] [-init value]*
         [-te xmin ymin xmax ymax] [-tr xres yres] [-tap] [-ts width height]
         [-ot {Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/
-                CInt16/CInt32/CFloat32/CFloat64}] [-q]
+                CInt16/CInt32/CFloat32/CFloat64}]
+        [-optim {[AUTO]/VECTOR/RASTER}] [-q]
         <src_datasource> <dst_filename>
 
 Description
@@ -159,6 +160,16 @@ raster data is only supported since GDAL 2.1.0.
 .. option:: -ot <type>
 
     Force the output bands to be of the indicated data type. Defaults to ``Float64``
+
+.. option:: -optim {[AUTO]/VECTOR/RASTER}}
+
+    Force the algorithm used (results are identical). The raster mode is used in most cases and
+    optimise read/write operations. The vector mode is usefull with a decent amount of input 
+    features and optimise the CPU use. That mode have to be used with tiled images to be 
+    efficient. The auto mode (the default) will chose the algorithm based on input and output 
+    properties.
+
+    .. versionadded:: 2.3
 
 .. option:: -q
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Adds missing documentation for the `-optim` option of GDAL rasterize. This was done in the original PR, but the documentation has become lost at some point. This PR is more or less a straight copy-paste of the original documentation:

https://github.com/OSGeo/gdal/pull/222/files#diff-ec9a80598d8c1071fb421f9b9eb560d7

I'm not sure if there's any additional documentation files for the C++ API, or other wrappers such as the Python API, that need to be updated.

## What are related issues/pull requests?

#222

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
