### PR TITLE
Python: Removed calls to imp module (fixes #2264)

### DIFF
--- a/gdal/swig/python/osgeo/__init__.py
+++ b/gdal/swig/python/osgeo/__init__.py
@@ -12,16 +12,16 @@ if version_info >= (3, 8, 0) and platform == 'win32':
 if version_info >= (2, 6, 0):
     def swig_import_helper():
         from os.path import dirname
-        import imp
-        fp = None
+        import importlib.machinery
+        spec = None
         try:
-            fp, pathname, description = imp.find_module('_gdal', [dirname(__file__)])
+            spec = importlib.machinery.PathFinder().find_spec('_gdal', [dirname(__file__)])
         except ImportError:
             import _gdal
             return _gdal
-        if fp is not None:
+        if spec is not None:
             try:
-                _mod = imp.load_module('_gdal', fp, pathname, description)
+                _mod = spec.loader.load_module()
             except ImportError as e:
                 if version_info >= (3, 8, 0) and platform == 'win32':
                     import os
@@ -35,8 +35,6 @@ if version_info >= (2, 6, 0):
                         traceback_string = ''.join(traceback.format_exception(*sys.exc_info()))
                         raise ImportError(traceback_string + '\n' + msg)
                 raise
-            finally:
-                fp.close()
             return _mod
     _gdal = swig_import_helper()
     del swig_import_helper

--- a/gdal/swig/python/osgeo/__init__.py
+++ b/gdal/swig/python/osgeo/__init__.py
@@ -9,19 +9,41 @@ if version_info >= (3, 8, 0) and platform == 'win32':
             if p:
                 os.add_dll_directory(p)
 
-if version_info >= (2, 6, 0):
+if version_info >= (2, 7, 0):
+    def swig_import_helper():
+        import importlib
+        from os.path import dirname, basename
+        mname = basename(dirname(__file__)) + '._gdal'
+        try:
+            return importlib.import_module(mname)
+        except ImportError as e:
+            if version_info >= (3, 8, 0) and platform == 'win32':
+                import os
+                if not 'USE_PATH_FOR_GDAL_PYTHON' in os.environ:
+                    msg = 'On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.\n'
+                    msg += 'If gdalXXX.dll is in the PATH, then set the USE_PATH_FOR_GDAL_PYTHON=YES environment variable\n'
+                    msg += 'to feed the PATH into os.add_dll_directory().'
+
+                    import sys
+                    import traceback
+                    traceback_string = ''.join(traceback.format_exception(*sys.exc_info()))
+                    raise ImportError(traceback_string + '\n' + msg)
+            return importlib.import_module('_gdal', pkg)
+    _gdal = swig_import_helper()
+    del swig_import_helper
+elif version_info >= (2, 6, 0):
     def swig_import_helper():
         from os.path import dirname
-        import importlib.machinery
-        spec = None
+        import imp
+        fp = None
         try:
-            spec = importlib.machinery.PathFinder().find_spec('_gdal', [dirname(__file__)])
+            fp, pathname, description = imp.find_module('_gdal', [dirname(__file__)])
         except ImportError:
             import _gdal
             return _gdal
-        if spec is not None:
+        if fp is not None:
             try:
-                _mod = spec.loader.load_module()
+                _mod = imp.load_module('_gdal', fp, pathname, description)
             except ImportError as e:
                 if version_info >= (3, 8, 0) and platform == 'win32':
                     import os
@@ -35,6 +57,8 @@ if version_info >= (2, 6, 0):
                         traceback_string = ''.join(traceback.format_exception(*sys.exc_info()))
                         raise ImportError(traceback_string + '\n' + msg)
                 raise
+            finally:
+                fp.close()
             return _mod
     _gdal = swig_import_helper()
     del swig_import_helper


### PR DESCRIPTION
Remove deprecated reference to Python imp module, which caused a startup
warning on QGIS. Replaced those references with a call to importlib. Fixes #2264.


