### PR TITLE
FlatGeobuf: disable most CPLDebug() for non-DEBUG builds

### DIFF
--- a/gdal/port/cpl_error.h
+++ b/gdal/port/cpl_error.h
@@ -174,6 +174,18 @@ void CPL_DLL CPL_STDCALL CPLDebug(const char *, CPL_FORMAT_STRING(const char *),
     CPL_PRINT_FUNC_FORMAT(2, 3);
 #endif
 
+#ifdef DEBUG
+/** Same as CPLDebug(), but expands to nothing for non-DEBUG builds.
+ * @since GDAL 3.1
+ */
+#define CPLDebugOnly(...) CPLDebug(__VA_ARGS__)
+#else
+/** Same as CPLDebug(), but expands to nothing for non-DEBUG builds.
+ * @since GDAL 3.1
+ */
+#define CPLDebugOnly(...)
+#endif
+
 void CPL_DLL CPL_STDCALL _CPLAssert( const char *, const char *, int ) CPL_NO_RETURN;
 
 #if defined(DEBUG) && !defined(CPPCHECK)


### PR DESCRIPTION
@bjornharrtell I find the Flatgeobuf driver super verbose. This PR disables most CPLDebug() for non-DEBUG builds as they are presumably only useful for the developer, and not for users, and even if they are not displayed they still burn a bit of CPU to figure they must not be displayed. I've just kept a few instances where there was debug messages in CPLError() cases.