### PR TITLE
FlatGeoBuf: implement Binary, Bool, Short and Float field types

### DIFF
--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -524,3 +524,32 @@ def test_ogr_wfs_fake_wfs_server():
         pytest.fail('did not get expected feature')
 
     webserver.server_stop(process, port)
+
+
+def test_ogr_flatgeobuf_binary():
+    ds = ogr.GetDriverByName('FlatGeobuf').CreateDataSource('/vsimem/test.fgb')
+    lyr = ds.CreateLayer('test', geom_type = ogr.wkbPoint)
+    lyr.CreateField(ogr.FieldDefn('bin', ogr.OFTBinary))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetFieldBinaryFromHexString('bin', '01FF')
+    f.SetGeometry(ogr.CreateGeometryFromWkt('POINT (0 0)'))
+    lyr.CreateFeature(f)
+
+    # Field of size 0
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetFieldBinaryFromHexString('bin', '')
+    f.SetGeometry(ogr.CreateGeometryFromWkt('POINT (0 0)'))
+    lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open('/vsimem/test.fgb')
+    lyr = ds.GetLayer(0)
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTBinary
+    f = lyr.GetNextFeature()
+    assert f.GetFieldAsBinary('bin') == b'\x01\xFF'
+    f = lyr.GetNextFeature()
+    assert f.GetFieldAsBinary('bin') == b''
+    ds = None
+
+    ogr.GetDriverByName('FlatGeobuf').DeleteDataSource('/vsimem/test.fgb')
+    assert not gdal.VSIStatL('/vsimem/test.fgb')

--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -526,9 +526,14 @@ def test_ogr_wfs_fake_wfs_server():
     webserver.server_stop(process, port)
 
 
-def test_ogr_flatgeobuf_short_float_binary():
+def test_ogr_flatgeobuf_bool_short_float_binary():
     ds = ogr.GetDriverByName('FlatGeobuf').CreateDataSource('/vsimem/test.fgb')
     lyr = ds.CreateLayer('test', geom_type = ogr.wkbPoint)
+
+    fld_defn = ogr.FieldDefn('bool', ogr.OFTInteger)
+    fld_defn.SetSubType(ogr.OFSTBoolean)
+    lyr.CreateField(fld_defn)
+
     fld_defn = ogr.FieldDefn('short', ogr.OFTInteger)
     fld_defn.SetSubType(ogr.OFSTInt16)
     lyr.CreateField(fld_defn)
@@ -540,6 +545,7 @@ def test_ogr_flatgeobuf_short_float_binary():
     lyr.CreateField(ogr.FieldDefn('bin', ogr.OFTBinary))
 
     f = ogr.Feature(lyr.GetLayerDefn())
+    f['bool'] = True
     f['short'] = -32768;
     f['float'] = 1.5;
     f.SetFieldBinaryFromHexString('bin', '01FF')
@@ -556,11 +562,14 @@ def test_ogr_flatgeobuf_short_float_binary():
     ds = ogr.Open('/vsimem/test.fgb')
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTInteger
-    assert lyr.GetLayerDefn().GetFieldDefn(0).GetSubType() == ogr.OFSTInt16
-    assert lyr.GetLayerDefn().GetFieldDefn(1).GetType() == ogr.OFTReal
-    assert lyr.GetLayerDefn().GetFieldDefn(1).GetSubType() == ogr.OFSTFloat32
-    assert lyr.GetLayerDefn().GetFieldDefn(2).GetType() == ogr.OFTBinary
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetSubType() == ogr.OFSTBoolean
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetType() == ogr.OFTInteger
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetSubType() == ogr.OFSTInt16
+    assert lyr.GetLayerDefn().GetFieldDefn(2).GetType() == ogr.OFTReal
+    assert lyr.GetLayerDefn().GetFieldDefn(2).GetSubType() == ogr.OFSTFloat32
+    assert lyr.GetLayerDefn().GetFieldDefn(3).GetType() == ogr.OFTBinary
     f = lyr.GetNextFeature()
+    assert f['bool'] == True
     assert f['short'] == -32768
     assert f['float'] == 1.5
     assert f.GetFieldAsBinary('bin') == b'\x01\xFF'

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -107,7 +107,7 @@ class OGRFlatGeobufLayer final : public OGRLayer
         OGRErr ensureFeatureBuf(uint32_t featureSize);
         OGRErr parseFeature(OGRFeature *poFeature);
         FlatGeobuf::ColumnType toColumnType(OGRFieldType fieldType, OGRFieldSubType subType);
-        static OGRFieldType toOGRFieldType(FlatGeobuf::ColumnType type);
+        static OGRFieldType toOGRFieldType(FlatGeobuf::ColumnType type, OGRFieldSubType& eSubType);
         const std::vector<flatbuffers::Offset<FlatGeobuf::Column>> writeColumns(flatbuffers::FlatBufferBuilder &fbb);
         void readColumns();
         OGRErr readIndex();

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -106,8 +106,6 @@ class OGRFlatGeobufLayer final : public OGRLayer
         void ensurePadfBuffers(size_t count);
         OGRErr ensureFeatureBuf(uint32_t featureSize);
         OGRErr parseFeature(OGRFeature *poFeature);
-        FlatGeobuf::ColumnType toColumnType(OGRFieldType fieldType, OGRFieldSubType subType);
-        static OGRFieldType toOGRFieldType(FlatGeobuf::ColumnType type, OGRFieldSubType& eSubType);
         const std::vector<flatbuffers::Offset<FlatGeobuf::Column>> writeColumns(flatbuffers::FlatBufferBuilder &fbb);
         void readColumns();
         OGRErr readIndex();

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
@@ -137,6 +137,10 @@ void RegisterOGRFlatGeobuf()
 "<LayerCreationOptionList>"
 "  <Option name='SPATIAL_INDEX' type='boolean' description='Whether to create a spatial index' default='YES'/>"
 "</LayerCreationOptionList>");
+    poDriver->SetMetadataItem(GDAL_DMD_OPENOPTIONLIST,
+"<OpenOptionList>"
+"  <Option name='VERIFY_BUFFERS' type='boolean' description='Verify flatbuffers integrity' default='YES'/>"
+"</OpenOptionList>");
 
     poDriver->pfnOpen = OGRFlatGeobufDataset::Open;
     poDriver->pfnCreate = OGRFlatGeobufDataset::Create;

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -172,7 +172,7 @@ OGRwkbGeometryType OGRFlatGeobufLayer::getOGRwkbGeometryType()
     return ogrType;
 }
 
-ColumnType OGRFlatGeobufLayer::toColumnType(OGRFieldType type, OGRFieldSubType subType)
+static ColumnType toColumnType(OGRFieldType type, OGRFieldSubType subType)
 {
     switch (type) {
         case OGRFieldType::OFTInteger:
@@ -190,7 +190,7 @@ ColumnType OGRFlatGeobufLayer::toColumnType(OGRFieldType type, OGRFieldSubType s
     return ColumnType::String;
 }
 
-OGRFieldType OGRFlatGeobufLayer::toOGRFieldType(ColumnType type, OGRFieldSubType& eSubType)
+static OGRFieldType toOGRFieldType(ColumnType type, OGRFieldSubType& eSubType)
 {
     eSubType = OFSTNone;
     switch (type) {

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -1047,7 +1047,7 @@ int OGRFlatGeobufLayer::TestCapability(const char *pszCap)
     else if (EQUAL(pszCap, OLCFastGetExtent))
         return m_sExtent.IsInit();
     else if (EQUAL(pszCap, OLCFastSpatialFilter))
-        return true;
+        return m_poHeader != nullptr && m_poHeader->index_node_size() > 0;
     else if (EQUAL(pszCap, OLCStringsAsUTF8))
         return true;
     else


### PR DESCRIPTION
And also remove CreateGeomField capability, that should only be
declared if OGRLayer::CreateGeomField() is implemented (for several
geometry fields per feature)

CC @bjornharrtell 