### PR TITLE
Python: Add numpy as extras_require dependency (fixes #2158)

### DIFF
--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -463,7 +463,8 @@ setup_kwargs = dict(
     data_files=data_files,
     ext_modules=ext_modules,
     scripts=glob('scripts/*.py'),
-    cmdclass={'build_ext': gdal_ext}
+    cmdclass={'build_ext': gdal_ext},
+    extras_require={'numpy': ['numpy > 1.0.0']},
 )
 
 # This section can be greatly simplified with python >= 3.5 using **


### PR DESCRIPTION
fixes #2158
Doing `pip install gdal[numpy]` will install `gdal` with `numpy > 1.0.0`.
`pip` will ensure that `numpy` is installed first so that it's detected
and the releveant features/bindings/etc. are compiled and made available
for users.

FYI I did not touch how `numpy` was installed in the various CI scripts, being a bit afraid of breaking things and/or making a mess.