### PR TITLE
Flatgeobuf write performance improvements

### DIFF
--- a/gdal/doc/source/drivers/vector/flatgeobuf.rst
+++ b/gdal/doc/source/drivers/vector/flatgeobuf.rst
@@ -51,6 +51,12 @@ Layer Creation Options
 
 -  **SPATIAL_INDEX=**\ *YES/NO*: Set to YES to create a
    spatial index. Defaults to YES.
+-  **TEMPORARY_DIR=**\ path: Path to an existing directory where temporary
+   files should be created. Only used if SPATIAL_INDEX=YES. If not specified,
+   the directory of the output file will be used for regular filenames. For
+   other VSI file systems, the temporary directory will be the one decided by
+   the :cpp:func:`CPLGenerateTempFilename` function.
+   "/vsimem/" can be used for in-memory temporary files.
 
 Examples
 --------

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -102,6 +102,7 @@ class OGRFlatGeobufLayer final : public OGRLayer
         uint64_t m_writeOffset = 0; // current write offset
         uint16_t m_indexNodeSize = 0;
         std::string m_oTempFile; // holds generated temp file name for two pass writing
+        uint32_t m_maxFeatureSize  = 0;
 
         // shared
         GByte *m_featureBuf = nullptr; // reusable/resizable feature data buffer

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
@@ -136,6 +136,7 @@ void RegisterOGRFlatGeobuf()
     poDriver->SetMetadataItem(GDAL_DS_LAYER_CREATIONOPTIONLIST,
 "<LayerCreationOptionList>"
 "  <Option name='SPATIAL_INDEX' type='boolean' description='Whether to create a spatial index' default='YES'/>"
+"  <Option name='TEMPORARY_DIR' type='string' description='Directory where temporary file should be created'/>"
 "</LayerCreationOptionList>");
     poDriver->SetMetadataItem(GDAL_DMD_OPENOPTIONLIST,
 "<OpenOptionList>"
@@ -438,8 +439,11 @@ OGRLayer* OGRFlatGeobufDataset::ICreateLayer( const char *pszLayerName,
         CPLDebug("FlatGeobuf", "Spatial index requested will write to temp file and do second pass on close");
         const CPLString osDirname(CPLGetPath(osFilename.c_str()));
         const CPLString osBasename(CPLGetBasename(osFilename.c_str()));
-        osTempFile = (STARTS_WITH(osFilename, "/vsi") &&
-                      !STARTS_WITH(osFilename, "/vsimem/")) ?
+        const char* pszTempDir = CSLFetchNameValue(papszOptions, "TEMPORARY_DIR");
+        osTempFile = pszTempDir ?
+            CPLFormFilename(pszTempDir, osBasename, nullptr) :
+            (STARTS_WITH(osFilename, "/vsi") &&
+            !STARTS_WITH(osFilename, "/vsimem/")) ?
             CPLGenerateTempFilename(osBasename) :
             CPLFormFilename(osDirname, osBasename, nullptr);
         osTempFile += "_temp.fgb";


### PR DESCRIPTION
Fixes #2287

- add a TEMPORARY_DIR layer creation option
- write final file in a batch way to minimize switches between reads and writes

In the example mentionned in #2287, conversion time is now:
- 4m24 when using -lco TEMPORARY_DIR=/vsimem/
- 5m15 without option (vs presumably several hours before)

CC @bjornharrtell 