### PR TITLE
Added more functionality to GDALViewshedGenerate

### DIFF
--- a/autotest/utilities/test_gdal_viewshed.py
+++ b/autotest/utilities/test_gdal_viewshed.py
@@ -57,10 +57,42 @@ def test_gdal_viewshed():
 
 ###############################################################################
 
+
+def test_gdal_viewshed_alternative_modes():
+
+    gdaltest.runexternal(test_cli_utilities.get_gdalwarp_path() + ' -t_srs EPSG:32617 -overwrite ../gdrivers/data/n43.dt0 tmp/test_gdal_viewshed_in.tif')
+
+    _, err = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_viewshed_path() + ' -om DEM -oz 100 -ox 621528 -oy 4817617 tmp/test_gdal_viewshed_in.tif tmp/test_gdal_viewshed_out.tif')
+    assert err is None or err == ''
+    ds = gdal.Open('tmp/test_gdal_viewshed_out.tif')
+    assert ds
+    cs = ds.GetRasterBand(1).Checksum()
+    nodata = ds.GetRasterBand(1).GetNoDataValue()
+    ds = None
+    gdal.Unlink('tmp/test_gdal_viewshed_out.tif')
+    assert cs == 48478
+    assert nodata is None
+
+    _, err = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_viewshed_path() + ' -om GROUND -oz 100 -ox 621528 -oy 4817617 tmp/test_gdal_viewshed_in.tif tmp/test_gdal_viewshed_out.tif')
+    assert err is None or err == ''
+    ds = gdal.Open('tmp/test_gdal_viewshed_out.tif')
+    assert ds
+    cs = ds.GetRasterBand(1).Checksum()
+    nodata = ds.GetRasterBand(1).GetNoDataValue()
+    ds = None
+    gdal.Unlink('tmp/test_gdal_viewshed_in.tif')
+    gdal.Unlink('tmp/test_gdal_viewshed_out.tif')
+    assert cs == 49633
+    assert nodata is None
+
+
+###############################################################################
+
+
 def test_gdal_viewshed_all_options():
 
     gdaltest.runexternal(test_cli_utilities.get_gdalwarp_path() + ' -t_srs EPSG:32617 -overwrite ../gdrivers/data/n43.dt0 tmp/test_gdal_viewshed_in.tif')
-    _, err = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_viewshed_path() + ' -f GTiff -oz 10 -ox 621528 -oy 4817617 -b 1 -a_nodata 0 -tz 5 -md 20000 -cc 0.85714 -iv 127 -vv 254 -ov 0 tmp/test_gdal_viewshed_in.tif tmp/test_gdal_viewshed_out.tif')
+    _, err = gdaltest.runexternal_out_and_err(test_cli_utilities.get_gdal_viewshed_path() + ' -om NORMAL -f GTiff -oz 10 -ox 621528 -oy 4817617 -b 1 -a_nodata 0 -tz 5 -md 20000 -cc 0.85714 -iv 127 -vv 254 -ov 0 tmp/test_gdal_viewshed_in.tif tmp/test_gdal_viewshed_out.tif')
     assert err is None or err == ''
     ds = gdal.Open('tmp/test_gdal_viewshed_out.tif')
     assert ds

--- a/gdal/alg/gdal_alg.h
+++ b/gdal/alg/gdal_alg.h
@@ -354,6 +354,13 @@ typedef enum {
     GVM_Min = 4
 } GDALViewshedMode;
 
+/** Viewshed output types */
+typedef enum {
+    GVOT_NORMAL = 1,
+    GVOT_MIN_TARGET_HEIGHT_FROM_DEM = 2,
+    GVOT_MIN_TARGET_HEIGHT_FROM_GROUND = 3
+} GDALViewshedOutputType;
+
 GDALDatasetH CPL_DLL
 GDALViewshedGenerate(GDALRasterBandH hBand,
                      const char* pszDriverName,
@@ -364,7 +371,7 @@ GDALViewshedGenerate(GDALRasterBandH hBand,
                      double dfOutOfRangeVal, double dfNoDataVal, double dfCurvCoeff,
                      GDALViewshedMode eMode, double dfMaxDistance,
                      GDALProgressFunc pfnProgress, void *pProgressArg,
-                     CSLConstList papszExtraOptions);
+                     GDALViewshedOutputType heightMode, CSLConstList papszExtraOptions);
 
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */

--- a/gdal/alg/viewshed.cpp
+++ b/gdal/alg/viewshed.cpp
@@ -122,13 +122,13 @@ inline static double CalcHeight(double dfZ, double dfZ2, GDALViewshedMode eMode)
  * Create viewshed from raster DEM.
  *
  * This algorithm will generate a viewshed raster from an input DEM raster
- * by using a modified algorithm of "Generating Viewsheds without Using Sightlines" 
+ * by using a modified algorithm of "Generating Viewsheds without Using Sightlines"
  * published at https://www.asprs.org/wp-content/uploads/pers/2000journal/january/2000_jan_87-90.pdf
  * This appoach provides a relatively fast calculation, since the output raster is
  * generated in a single scan.
  * The gdal/apps/gdal_viewshed.cpp mainline can be used as an example of
  * how to use this function.
- * The output raster will be of type Byte.
+ * The output raster will be of type Byte or Float64.
  *
  * \note The algorithm as implemented currently will only output meaningful results
  * if the georeferencing is in a projected coordinate reference system.
@@ -180,6 +180,18 @@ inline static double CalcHeight(double dfZ, double dfZ2, GDALViewshedMode eMode)
  *
  * @param pProgressArg The callback data for the pfnProgress function.
  *
+ * @param heightMode Type of information contained in output raster. Possible values
+ *                   GVOT_NORMAL = 1 (default), GVOT_MIN_TARGET_HEIGHT_FROM_DEM = 2,
+ *                   GVOT_MIN_TARGET_HEIGHT_FROM_GROUND = 3
+ *
+ *                   GVOT_NORMAL returns a raster of type Byte containing visible locations.
+ *
+ *                   GVOT_MIN_TARGET_HEIGHT_FROM_DEM and GVOT_MIN_TARGET_HEIGHT_FROM_GROUND
+ *                   will return a raster of type Float64 containing the minimum target height
+ *                   for target to be visible from the DEM surface or ground level respectively.
+ *                   Parameters dfTargetHeight, dfVisibleVal and dfInvisibleVal will be ignored.
+ *
+ *
  * @param papszExtraOptions Future extra options. Must be set to NULL currently.
  *
  * @return not NULL output dataset on success (to be closed with GDALClose()) or NULL if an error occurs.
@@ -195,7 +207,8 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
                     double dfTargetHeight, double dfVisibleVal, double dfInvisibleVal,
                     double dfOutOfRangeVal, double dfNoDataVal, double dfCurvCoeff,
                     GDALViewshedMode eMode, double dfMaxDistance,
-                    GDALProgressFunc pfnProgress, void *pProgressArg, CSLConstList papszExtraOptions)
+                    GDALProgressFunc pfnProgress, void *pProgressArg,
+                    GDALViewshedOutputType heightMode, CSLConstList papszExtraOptions)
 
 {
     VALIDATE_POINTER1( hBand, "GDALViewshedGenerate", nullptr );
@@ -216,6 +229,9 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
     const GByte byVisibleVal = dfVisibleVal >= 0 && dfVisibleVal <= 255 ? static_cast<GByte>(dfVisibleVal) : 255;
     const GByte byInvisibleVal = dfInvisibleVal >= 0 && dfInvisibleVal <= 255 ? static_cast<GByte>(dfInvisibleVal) : 0;
     const GByte byOutOfRangeVal = dfOutOfRangeVal >= 0 && dfOutOfRangeVal <= 255 ? static_cast<GByte>(dfOutOfRangeVal) : 0;
+
+    if(heightMode != GVOT_MIN_TARGET_HEIGHT_FROM_DEM && heightMode != GVOT_MIN_TARGET_HEIGHT_FROM_GROUND)
+        heightMode = GVOT_NORMAL;
 
     /* set up geotransformation */
     std::array<double, 6> adfGeoTransform {{0.0, 1.0, 0.0, 0.0, 0.0, 1.0}};
@@ -262,6 +278,7 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
     std::vector<double> vLastLineVal;
     std::vector<double> vThisLineVal;
     std::vector<GByte> vResult;
+    std::vector<double> vHeightResult;
 
     try
     {
@@ -269,6 +286,9 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
         vLastLineVal.resize(nXSize);
         vThisLineVal.resize(nXSize);
         vResult.resize(nXSize);
+
+        if(heightMode != GVOT_NORMAL)
+            vHeightResult.resize(nXSize);
     } catch (...)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
@@ -280,6 +300,7 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
     double *padfLastLineVal = vLastLineVal.data();
     double *padfThisLineVal = vThisLineVal.data();
     GByte *pabyResult = vResult.data();
+    double *dfHeightResult = vHeightResult.data();
 
     GDALDriverManager *hMgr = GetGDALDriverManager();
     GDALDriver *hDriver = hMgr->GetDriverByName(pszDriverName ? pszDriverName : "GTiff");
@@ -290,7 +311,8 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
     }
 
     /* create output raster */
-    auto poDstDS = std::unique_ptr<GDALDataset>(hDriver->Create(pszTargetRasterName, nXSize, nYStop - nYStart, 1, GDT_Byte, const_cast<char**>(papszCreationOptions)));
+    auto poDstDS = std::unique_ptr<GDALDataset>(hDriver->Create(pszTargetRasterName, nXSize, nYStop - nYStart, 1, heightMode != GVOT_NORMAL ? GDT_Float64 : GDT_Byte,
+                                                const_cast<char**>(papszCreationOptions)));
     if (!poDstDS)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
@@ -319,7 +341,7 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
     }
 
     if (dfNoDataVal >= 0)
-        GDALSetRasterNoDataValue(hTargetBand, byNoDataVal);
+        GDALSetRasterNoDataValue(hTargetBand, heightMode != GVOT_NORMAL ? dfNoDataVal : byNoDataVal);
 
     /* process first line */
     if (GDALRasterIO(hBand, GF_Read, nXStart, nY, nXSize, 1,
@@ -353,9 +375,14 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
     }
 
     /* mark the observer point as visible */
+    double dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfFirstLineVal[nX] : 0.0;
     pabyResult[nX] = byVisibleVal;
+    if(heightMode != GVOT_NORMAL)
+        dfHeightResult[nX] = dfGroundLevel;
+
     if (nX > 0)
     {
+        dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfFirstLineVal[nX - 1] : 0.0;
         CPL_IGNORE_RET_VAL(
             AdjustHeightInRange(adfGeoTransform.data(),
                             1,
@@ -365,9 +392,12 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
                             dfCurvCoeff,
                             dfSphereDiameter));
         pabyResult[nX - 1] = byVisibleVal;
+        if(heightMode != GVOT_NORMAL)
+            dfHeightResult[nX - 1] = dfGroundLevel;
     }
     if (nX < nXSize - 1)
     {
+        dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfFirstLineVal[nX + 1] : 0.0;
         CPL_IGNORE_RET_VAL(
             AdjustHeightInRange(adfGeoTransform.data(),
                             1,
@@ -377,11 +407,14 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
                             dfCurvCoeff,
                             dfSphereDiameter));
         pabyResult[nX + 1] = byVisibleVal;
+        if(heightMode != GVOT_NORMAL)
+            dfHeightResult[nX + 1] = dfGroundLevel;
     }
 
     /* process left direction */
     for (int iPixel = nX - 2; iPixel >= 0; iPixel--)
     {
+        dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfFirstLineVal[iPixel] : 0.0;
         bool adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                             nX - iPixel,
                                             0,
@@ -394,6 +427,10 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             dfZ = CalcHeightLine(nX - iPixel,
                                  padfFirstLineVal[iPixel + 1],
                                  dfZObserver);
+
+            if(heightMode != GVOT_NORMAL)
+                dfHeightResult[iPixel] = std::max(0.0, (dfZ - padfFirstLineVal[iPixel] + dfGroundLevel));
+
             SetVisibility(  iPixel,
                             dfZ,
                             dfTargetHeight,
@@ -405,12 +442,17 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
         else
         {
             for (; iPixel >= 0; iPixel--)
+            {
                 pabyResult[iPixel] = byOutOfRangeVal;
+                if(heightMode != GVOT_NORMAL)
+                    dfHeightResult[iPixel] = dfOutOfRangeVal;
+            }
         }
     }
     /* process right direction */
     for (int iPixel = nX + 2; iPixel < nXSize; iPixel++)
     {
+        dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfFirstLineVal[iPixel] : 0.0;
         bool adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                             iPixel - nX,
                                             0,
@@ -423,6 +465,10 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             dfZ = CalcHeightLine(iPixel - nX,
                                  padfFirstLineVal[iPixel - 1],
                                  dfZObserver);
+
+            if(heightMode != GVOT_NORMAL)
+                dfHeightResult[iPixel] = std::max(0.0, (dfZ - padfFirstLineVal[iPixel] + dfGroundLevel));
+
             SetVisibility(iPixel,
                           dfZ,
                           dfTargetHeight,
@@ -434,13 +480,17 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
         else
         {
             for (; iPixel < nXSize; iPixel++)
+            {
                 pabyResult[iPixel] = byOutOfRangeVal;
+                if(heightMode != GVOT_NORMAL)
+                    dfHeightResult[iPixel] = dfOutOfRangeVal;
+            }
         }
     }
     /* write result line */
 
     if (GDALRasterIO(hTargetBand, GF_Write, 0, nY - nYStart, nXSize, 1,
-        pabyResult, nXSize, 1, GDT_Byte, 0, 0))
+        heightMode != GVOT_NORMAL ? static_cast<void*>(dfHeightResult) : static_cast<void*>(pabyResult), nXSize, 1, heightMode != GVOT_NORMAL ? GDT_Float64 : GDT_Byte, 0, 0))
     {
         CPLError(CE_Failure, CPLE_AppDefined,
             "RasterIO error when writing target raster at position (%d,%d), size (%d,%d)", 0, nY - nYStart, nXSize, 1);
@@ -462,6 +512,7 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
         }
 
         /* set up initial point on the scanline */
+        dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfThisLineVal[nX] : 0.0;
         bool adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                             0,
                                             nY - iLine,
@@ -474,6 +525,10 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             dfZ = CalcHeightLine(nY - iLine,
                                  padfLastLineVal[nX],
                                  dfZObserver);
+
+            if(heightMode != GVOT_NORMAL)
+                dfHeightResult[nX] = std::max(0.0, (dfZ - padfThisLineVal[nX] + dfGroundLevel));
+
             SetVisibility(nX,
                           dfZ,
                           dfTargetHeight,
@@ -485,11 +540,14 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
         else
         {
             pabyResult[nX] = byOutOfRangeVal;
+            if(heightMode != GVOT_NORMAL)
+                dfHeightResult[nX] = dfOutOfRangeVal;
         }
 
         /* process left direction */
         for (int iPixel = nX - 1; iPixel >= 0; iPixel--)
         {
+            dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfThisLineVal[iPixel] : 0.0;
             bool left_adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                                      nX - iPixel,
                                                      nY - iLine,
@@ -522,6 +580,9 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
                     dfZ = CalcHeight(dfZ, dfZ2, eMode);
                 }
 
+                if(heightMode != GVOT_NORMAL)
+                    dfHeightResult[iPixel] = std::max(0.0, (dfZ - padfThisLineVal[iPixel] + dfGroundLevel));
+
                 SetVisibility(iPixel,
                               dfZ,
                               dfTargetHeight,
@@ -533,12 +594,17 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             else
             {
                 for (; iPixel >= 0; iPixel--)
+                {
                     pabyResult[iPixel] = byOutOfRangeVal;
+                    if(heightMode != GVOT_NORMAL)
+                        dfHeightResult[iPixel] = dfOutOfRangeVal;
+                }
             }
         }
         /* process right direction */
         for (int iPixel = nX + 1; iPixel < nXSize; iPixel++)
         {
+            dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfThisLineVal[iPixel] : 0.0;
             bool right_adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                                       iPixel - nX,
                                                       nY - iLine,
@@ -571,6 +637,9 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
                     dfZ = CalcHeight(dfZ, dfZ2, eMode);
                 }
 
+                if(heightMode != GVOT_NORMAL)
+                    dfHeightResult[iPixel] = std::max(0.0, (dfZ - padfThisLineVal[iPixel] + dfGroundLevel));
+
                 SetVisibility(iPixel,
                               dfZ,
                               dfTargetHeight,
@@ -582,13 +651,17 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             else
             {
                 for (; iPixel < nXSize; iPixel++)
+                {
                     pabyResult[iPixel] = byOutOfRangeVal;
+                    if(heightMode != GVOT_NORMAL)
+                        dfHeightResult[iPixel] = dfOutOfRangeVal;
+                }
             }
         }
 
         /* write result line */
         if (GDALRasterIO(hTargetBand, GF_Write, 0, iLine - nYStart, nXSize, 1,
-            pabyResult, nXSize, 1, GDT_Byte, 0, 0))
+            heightMode != GVOT_NORMAL ? static_cast<void*>(dfHeightResult) : static_cast<void*>(pabyResult), nXSize, 1, heightMode != GVOT_NORMAL ? GDT_Float64 : GDT_Byte, 0, 0))
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                 "RasterIO error when writing target raster at position (%d,%d), size (%d,%d)", 0, iLine - nYStart, nXSize, 1);
@@ -617,6 +690,7 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
         }
 
         /* set up initial point on the scanline */
+        dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfThisLineVal[nX] : 0.0;
         bool adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                             0,
                                             iLine - nY,
@@ -629,6 +703,10 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             dfZ = CalcHeightLine(iLine - nY,
                                  padfLastLineVal[nX],
                                  dfZObserver);
+
+            if(heightMode != GVOT_NORMAL)
+                dfHeightResult[nX] = std::max(0.0, (dfZ - padfThisLineVal[nX] + dfGroundLevel));
+
             SetVisibility(nX,
                           dfZ,
                           dfTargetHeight,
@@ -640,11 +718,14 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
         else
         {
             pabyResult[nX] = byOutOfRangeVal;
+            if(heightMode != GVOT_NORMAL)
+                dfHeightResult[nX] = dfOutOfRangeVal;
         }
 
         /* process left direction */
         for (int iPixel = nX - 1; iPixel >= 0; iPixel--)
         {
+            dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfThisLineVal[iPixel] : 0.0;
             bool left_adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                                      nX - iPixel,
                                                      iLine - nY,
@@ -674,6 +755,9 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
                     dfZ = CalcHeight(dfZ, dfZ2, eMode);
                 }
 
+                if(heightMode != GVOT_NORMAL)
+                    dfHeightResult[iPixel] = std::max(0.0, (dfZ - padfThisLineVal[iPixel] + dfGroundLevel));
+
                 SetVisibility(iPixel,
                               dfZ,
                               dfTargetHeight,
@@ -685,12 +769,17 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             else
             {
                 for (; iPixel >= 0; iPixel--)
+                {
                     pabyResult[iPixel] = byOutOfRangeVal;
+                    if(heightMode != GVOT_NORMAL)
+                        dfHeightResult[iPixel] = dfOutOfRangeVal;
+                }
             }
         }
         /* process right direction */
         for (int iPixel = nX + 1; iPixel < nXSize; iPixel++)
         {
+            dfGroundLevel = heightMode == GVOT_MIN_TARGET_HEIGHT_FROM_DEM ? padfThisLineVal[iPixel] : 0.0;
             bool right_adjusted = AdjustHeightInRange(adfGeoTransform.data(),
                                                       iPixel - nX,
                                                       iLine - nY,
@@ -723,6 +812,9 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
                     dfZ = CalcHeight(dfZ, dfZ2, eMode);
                 }
 
+                if(heightMode != GVOT_NORMAL)
+                    dfHeightResult[iPixel] = std::max(0.0, (dfZ - padfThisLineVal[iPixel] + dfGroundLevel));
+
                 SetVisibility(iPixel,
                               dfZ,
                               dfTargetHeight,
@@ -734,13 +826,17 @@ GDALDatasetH GDALViewshedGenerate(GDALRasterBandH hBand,
             else
             {
                 for (; iPixel < nXSize; iPixel++)
+                {
                     pabyResult[iPixel] = byOutOfRangeVal;
+                    if(heightMode != GVOT_NORMAL)
+                        dfHeightResult[iPixel] = dfOutOfRangeVal;
+                }
             }
         }
 
         /* write result line */
         if (GDALRasterIO(hTargetBand, GF_Write, 0, iLine - nYStart, nXSize, 1,
-            pabyResult, nXSize, 1, GDT_Byte, 0, 0))
+            heightMode != GVOT_NORMAL ? static_cast<void*>(dfHeightResult) : static_cast<void*>(pabyResult), nXSize, 1, heightMode != GVOT_NORMAL ? GDT_Float64 : GDT_Byte, 0, 0))
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                 "RasterIO error when writing target raster at position (%d,%d), size (%d,%d)", 0, iLine - nYStart, nXSize, 1);

--- a/gdal/doc/source/programs/gdal_viewshed.rst
+++ b/gdal/doc/source/programs/gdal_viewshed.rst
@@ -24,15 +24,15 @@ Synopsis
                  [-vv <visibility>] [-iv <invisibility>]
                  [-ov <out_of_range>] [-cc <curvature_coef>]
                  [[-co NAME=VALUE] ...]
-                 [-q]
+                 [-q] [-om <output mode>]
                  <src_filename> <dst_filename>
 
 Description
 -----------
 
-The :program:`gdal_viewshed` generates a binary visibility raster from one band
+By default the :program:`gdal_viewshed` generates a binary visibility raster from one band
 of the input raster elevation model (DEM). The output raster will be of type
-Byte.
+Byte. With the -mode flag can also return a minimum visible height raster of type Float64.
 
 .. note::
     The algorithm as implemented currently will only output meaningful results
@@ -100,6 +100,20 @@ Byte.
 .. option:: -vv <value>
 
    Pixel value to set for visible areas. Default: 255
+
+.. option:: -om <output mode>
+
+  Sets what information the output contains.
+
+  Possible values: VISIBLE, DEM, GROUND
+ 
+  VISIBLE returns a raster of type Byte containing visible locations.
+ 
+  DEM and GROUND will return a raster of type Float64 containing the minimum target
+  height for target to be visible from the DEM surface or ground level respectively.
+  Flags -tz, -iv and -vv will be ignored.
+
+  Default VISIBLE
 
 C API
 -----

--- a/gdal/swig/include/Operations.i
+++ b/gdal/swig/include/Operations.i
@@ -581,6 +581,12 @@ typedef enum {
     GVM_Min = 4
 } GDALViewshedMode;
 
+%rename (ViewshedOutputType) GDALViewshedOutputType;
+typedef enum {
+    GVOT_NORMAL = 1,
+    GVOT_MIN_TARGET_HEIGHT_FROM_DEM = 2,
+    GVOT_MIN_TARGET_HEIGHT_FROM_GROUND = 3
+} GDALViewshedOutputType;
 
 %newobject ViewshedGenerate;
 #ifndef SWIGJAVA
@@ -597,6 +603,7 @@ GDALDatasetShadow *ViewshedGenerate( GDALRasterBandShadow *srcBand,
                         double outOfRangeVal,  double noDataVal, double dfCurvCoeff,
                         GDALViewshedMode mode, double maxDistance,
                         GDALProgressFunc callback = NULL, void* callback_data = NULL,
+                        GDALViewshedOutputType heightMode = GVOT_NORMAL,
                         char** papszOptions = NULL)
 {
     GDALDatasetShadow* ds = GDALViewshedGenerate( srcBand,
@@ -616,6 +623,7 @@ GDALDatasetShadow *ViewshedGenerate( GDALRasterBandShadow *srcBand,
                                  maxDistance,
                                  callback,
                                  callback_data,
+                                 heightMode,
                                  papszOptions);
   if (ds == 0) {
     /*throw CPLGetLastErrorMsg(); causes a SWIG_exception later*/

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -3041,41 +3041,42 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_GDALTranslateOptions swig_types[30]
 #define SWIGTYPE_p_GDALVectorTranslateOptions swig_types[31]
 #define SWIGTYPE_p_GDALViewshedMode swig_types[32]
-#define SWIGTYPE_p_GDALWarpAppOptions swig_types[33]
-#define SWIGTYPE_p_GDAL_GCP swig_types[34]
-#define SWIGTYPE_p_GIntBig swig_types[35]
-#define SWIGTYPE_p_GUIntBig swig_types[36]
-#define SWIGTYPE_p_OGRFeatureShadow swig_types[37]
-#define SWIGTYPE_p_OGRGeometryShadow swig_types[38]
-#define SWIGTYPE_p_OGRLayerShadow swig_types[39]
-#define SWIGTYPE_p_OGRStyleTableShadow swig_types[40]
-#define SWIGTYPE_p_OSRSpatialReferenceShadow swig_types[41]
-#define SWIGTYPE_p_StatBuf swig_types[42]
-#define SWIGTYPE_p_VSIDIR swig_types[43]
-#define SWIGTYPE_p_VSILFILE swig_types[44]
-#define SWIGTYPE_p_char swig_types[45]
-#define SWIGTYPE_p_double swig_types[46]
-#define SWIGTYPE_p_f_double_p_q_const__char_p_void__int swig_types[47]
-#define SWIGTYPE_p_int swig_types[48]
-#define SWIGTYPE_p_p_GByte swig_types[49]
-#define SWIGTYPE_p_p_GDALDatasetShadow swig_types[50]
-#define SWIGTYPE_p_p_GDALDimensionHS swig_types[51]
-#define SWIGTYPE_p_p_GDALEDTComponentHS swig_types[52]
-#define SWIGTYPE_p_p_GDALRasterBandShadow swig_types[53]
-#define SWIGTYPE_p_p_GDAL_GCP swig_types[54]
-#define SWIGTYPE_p_p_GUIntBig swig_types[55]
-#define SWIGTYPE_p_p_OGRLayerShadow swig_types[56]
-#define SWIGTYPE_p_p_char swig_types[57]
-#define SWIGTYPE_p_p_double swig_types[58]
-#define SWIGTYPE_p_p_int swig_types[59]
-#define SWIGTYPE_p_p_p_GDALAttributeHS swig_types[60]
-#define SWIGTYPE_p_p_p_GDALDimensionHS swig_types[61]
-#define SWIGTYPE_p_p_p_GDALEDTComponentHS swig_types[62]
-#define SWIGTYPE_p_p_void swig_types[63]
-#define SWIGTYPE_p_size_t swig_types[64]
-#define SWIGTYPE_p_vsi_l_offset swig_types[65]
-static swig_type_info *swig_types[67];
-static swig_module_info swig_module = {swig_types, 66, 0, 0, 0, 0};
+#define SWIGTYPE_p_GDALViewshedOutputType swig_types[33]
+#define SWIGTYPE_p_GDALWarpAppOptions swig_types[34]
+#define SWIGTYPE_p_GDAL_GCP swig_types[35]
+#define SWIGTYPE_p_GIntBig swig_types[36]
+#define SWIGTYPE_p_GUIntBig swig_types[37]
+#define SWIGTYPE_p_OGRFeatureShadow swig_types[38]
+#define SWIGTYPE_p_OGRGeometryShadow swig_types[39]
+#define SWIGTYPE_p_OGRLayerShadow swig_types[40]
+#define SWIGTYPE_p_OGRStyleTableShadow swig_types[41]
+#define SWIGTYPE_p_OSRSpatialReferenceShadow swig_types[42]
+#define SWIGTYPE_p_StatBuf swig_types[43]
+#define SWIGTYPE_p_VSIDIR swig_types[44]
+#define SWIGTYPE_p_VSILFILE swig_types[45]
+#define SWIGTYPE_p_char swig_types[46]
+#define SWIGTYPE_p_double swig_types[47]
+#define SWIGTYPE_p_f_double_p_q_const__char_p_void__int swig_types[48]
+#define SWIGTYPE_p_int swig_types[49]
+#define SWIGTYPE_p_p_GByte swig_types[50]
+#define SWIGTYPE_p_p_GDALDatasetShadow swig_types[51]
+#define SWIGTYPE_p_p_GDALDimensionHS swig_types[52]
+#define SWIGTYPE_p_p_GDALEDTComponentHS swig_types[53]
+#define SWIGTYPE_p_p_GDALRasterBandShadow swig_types[54]
+#define SWIGTYPE_p_p_GDAL_GCP swig_types[55]
+#define SWIGTYPE_p_p_GUIntBig swig_types[56]
+#define SWIGTYPE_p_p_OGRLayerShadow swig_types[57]
+#define SWIGTYPE_p_p_char swig_types[58]
+#define SWIGTYPE_p_p_double swig_types[59]
+#define SWIGTYPE_p_p_int swig_types[60]
+#define SWIGTYPE_p_p_p_GDALAttributeHS swig_types[61]
+#define SWIGTYPE_p_p_p_GDALDimensionHS swig_types[62]
+#define SWIGTYPE_p_p_p_GDALEDTComponentHS swig_types[63]
+#define SWIGTYPE_p_p_void swig_types[64]
+#define SWIGTYPE_p_size_t swig_types[65]
+#define SWIGTYPE_p_vsi_l_offset swig_types[66]
+static swig_type_info *swig_types[68];
+static swig_module_info swig_module = {swig_types, 67, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -7148,6 +7149,7 @@ GDALDatasetShadow *ViewshedGenerate( GDALRasterBandShadow *srcBand,
                         double outOfRangeVal,  double noDataVal, double dfCurvCoeff,
                         GDALViewshedMode mode, double maxDistance,
                         GDALProgressFunc callback = NULL, void* callback_data = NULL,
+                        GDALViewshedOutputType heightMode = GVOT_NORMAL,
                         char** papszOptions = NULL)
 {
     GDALDatasetShadow* ds = GDALViewshedGenerate( srcBand,
@@ -7167,6 +7169,7 @@ GDALDatasetShadow *ViewshedGenerate( GDALRasterBandShadow *srcBand,
                                  maxDistance,
                                  callback,
                                  callback_data,
+                                 heightMode,
                                  papszOptions);
   if (ds == 0) {
     /*throw CPLGetLastErrorMsg(); causes a SWIG_exception later*/
@@ -34906,7 +34909,8 @@ SWIGINTERN PyObject *_wrap_ViewshedGenerate(PyObject *SWIGUNUSEDPARM(self), PyOb
   double arg15 ;
   GDALProgressFunc arg16 = (GDALProgressFunc) NULL ;
   void *arg17 = (void *) NULL ;
-  char **arg18 = (char **) NULL ;
+  GDALViewshedOutputType arg18 = (GDALViewshedOutputType) GVOT_NORMAL ;
+  char **arg19 = (char **) NULL ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   int res2 ;
@@ -34939,8 +34943,10 @@ SWIGINTERN PyObject *_wrap_ViewshedGenerate(PyObject *SWIGUNUSEDPARM(self), PyOb
   int ecode14 = 0 ;
   double val15 ;
   int ecode15 = 0 ;
-  void *argp18 = 0 ;
-  int res18 = 0 ;
+  int val18 ;
+  int ecode18 = 0 ;
+  void *argp19 = 0 ;
+  int res19 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -34959,8 +34965,9 @@ SWIGINTERN PyObject *_wrap_ViewshedGenerate(PyObject *SWIGUNUSEDPARM(self), PyOb
   PyObject * obj15 = 0 ;
   PyObject * obj16 = 0 ;
   PyObject * obj17 = 0 ;
+  PyObject * obj18 = 0 ;
   char *  kwnames[] = {
-    (char *) "srcBand",(char *) "driverName",(char *) "targetRasterName",(char *) "creationOptions",(char *) "observerX",(char *) "observerY",(char *) "observerHeight",(char *) "targetHeight",(char *) "visibleVal",(char *) "invisibleVal",(char *) "outOfRangeVal",(char *) "noDataVal",(char *) "dfCurvCoeff",(char *) "mode",(char *) "maxDistance",(char *) "callback",(char *) "callback_data",(char *) "papszOptions", NULL 
+    (char *) "srcBand",(char *) "driverName",(char *) "targetRasterName",(char *) "creationOptions",(char *) "observerX",(char *) "observerY",(char *) "observerHeight",(char *) "targetHeight",(char *) "visibleVal",(char *) "invisibleVal",(char *) "outOfRangeVal",(char *) "noDataVal",(char *) "dfCurvCoeff",(char *) "mode",(char *) "maxDistance",(char *) "callback",(char *) "callback_data",(char *) "heightMode",(char *) "papszOptions", NULL 
   };
   GDALDatasetShadow *result = 0 ;
   
@@ -34971,7 +34978,7 @@ SWIGINTERN PyObject *_wrap_ViewshedGenerate(PyObject *SWIGUNUSEDPARM(self), PyOb
   psProgressInfo->psPyCallback = NULL;
   psProgressInfo->psPyCallbackData = NULL;
   arg17 = psProgressInfo;
-  if (!PyArg_ParseTupleAndKeywords(args,kwargs,(char *)"OOOOOOOOOOOOOOO|OOO:ViewshedGenerate",kwnames,&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9,&obj10,&obj11,&obj12,&obj13,&obj14,&obj15,&obj16,&obj17)) SWIG_fail;
+  if (!PyArg_ParseTupleAndKeywords(args,kwargs,(char *)"OOOOOOOOOOOOOOO|OOOO:ViewshedGenerate",kwnames,&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9,&obj10,&obj11,&obj12,&obj13,&obj14,&obj15,&obj16,&obj17,&obj18)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_GDALRasterBandShadow, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ViewshedGenerate" "', argument " "1"" of type '" "GDALRasterBandShadow *""'"); 
@@ -35092,11 +35099,18 @@ SWIGINTERN PyObject *_wrap_ViewshedGenerate(PyObject *SWIGUNUSEDPARM(self), PyOb
     }
   }
   if (obj17) {
-    res18 = SWIG_ConvertPtr(obj17, &argp18,SWIGTYPE_p_p_char, 0 |  0 );
-    if (!SWIG_IsOK(res18)) {
-      SWIG_exception_fail(SWIG_ArgError(res18), "in method '" "ViewshedGenerate" "', argument " "18"" of type '" "char **""'"); 
+    ecode18 = SWIG_AsVal_int(obj17, &val18);
+    if (!SWIG_IsOK(ecode18)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode18), "in method '" "ViewshedGenerate" "', argument " "18"" of type '" "GDALViewshedOutputType""'");
+    } 
+    arg18 = static_cast< GDALViewshedOutputType >(val18);
+  }
+  if (obj18) {
+    res19 = SWIG_ConvertPtr(obj18, &argp19,SWIGTYPE_p_p_char, 0 |  0 );
+    if (!SWIG_IsOK(res19)) {
+      SWIG_exception_fail(SWIG_ArgError(res19), "in method '" "ViewshedGenerate" "', argument " "19"" of type '" "char **""'"); 
     }
-    arg18 = reinterpret_cast< char ** >(argp18);
+    arg19 = reinterpret_cast< char ** >(argp19);
   }
   {
     if (!arg1) {
@@ -35109,7 +35123,7 @@ SWIGINTERN PyObject *_wrap_ViewshedGenerate(PyObject *SWIGUNUSEDPARM(self), PyOb
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      result = (GDALDatasetShadow *)ViewshedGenerate(arg1,(char const *)arg2,(char const *)arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18);
+      result = (GDALDatasetShadow *)ViewshedGenerate(arg1,(char const *)arg2,(char const *)arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -41547,7 +41561,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"RegenerateOverview", (PyCFunction) _wrap_RegenerateOverview, METH_VARARGS | METH_KEYWORDS, (char *)"RegenerateOverview(Band srcBand, Band overviewBand, char const * resampling, GDALProgressFunc callback=0, void * callback_data=None) -> int"},
 	 { (char *)"ContourGenerate", (PyCFunction) _wrap_ContourGenerate, METH_VARARGS | METH_KEYWORDS, (char *)"ContourGenerate(Band srcBand, double contourInterval, double contourBase, int fixedLevelCount, int useNoData, double noDataValue, Layer dstLayer, int idField, int elevField, GDALProgressFunc callback=0, void * callback_data=None) -> int"},
 	 { (char *)"ContourGenerateEx", (PyCFunction) _wrap_ContourGenerateEx, METH_VARARGS | METH_KEYWORDS, (char *)"ContourGenerateEx(Band srcBand, Layer dstLayer, char ** options=None, GDALProgressFunc callback=0, void * callback_data=None) -> int"},
-	 { (char *)"ViewshedGenerate", (PyCFunction) _wrap_ViewshedGenerate, METH_VARARGS | METH_KEYWORDS, (char *)"ViewshedGenerate(Band srcBand, char const * driverName, char const * targetRasterName, char ** creationOptions, double observerX, double observerY, double observerHeight, double targetHeight, double visibleVal, double invisibleVal, double outOfRangeVal, double noDataVal, double dfCurvCoeff, GDALViewshedMode mode, double maxDistance, GDALProgressFunc callback=0, void * callback_data=None, char ** papszOptions=None) -> Dataset"},
+	 { (char *)"ViewshedGenerate", (PyCFunction) _wrap_ViewshedGenerate, METH_VARARGS | METH_KEYWORDS, (char *)"ViewshedGenerate(Band srcBand, char const * driverName, char const * targetRasterName, char ** creationOptions, double observerX, double observerY, double observerHeight, double targetHeight, double visibleVal, double invisibleVal, double outOfRangeVal, double noDataVal, double dfCurvCoeff, GDALViewshedMode mode, double maxDistance, GDALProgressFunc callback=0, void * callback_data=None, GDALViewshedOutputType heightMode=GVOT_NORMAL, char ** papszOptions=None) -> Dataset"},
 	 { (char *)"AutoCreateWarpedVRT", _wrap_AutoCreateWarpedVRT, METH_VARARGS, (char *)"AutoCreateWarpedVRT(Dataset src_ds, char const * src_wkt=None, char const * dst_wkt=None, GDALResampleAlg eResampleAlg, double maxerror=0.0) -> Dataset"},
 	 { (char *)"CreatePansharpenedVRT", _wrap_CreatePansharpenedVRT, METH_VARARGS, (char *)"CreatePansharpenedVRT(char const * pszXML, Band panchroBand, int nInputSpectralBands) -> Dataset"},
 	 { (char *)"delete_GDALTransformerInfoShadow", _wrap_delete_GDALTransformerInfoShadow, METH_VARARGS, (char *)"delete_GDALTransformerInfoShadow(GDALTransformerInfoShadow self)"},
@@ -41690,6 +41704,7 @@ static swig_type_info _swigt__p_GDALTransformerInfoShadow = {"_p_GDALTransformer
 static swig_type_info _swigt__p_GDALTranslateOptions = {"_p_GDALTranslateOptions", "GDALTranslateOptions *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GDALVectorTranslateOptions = {"_p_GDALVectorTranslateOptions", "GDALVectorTranslateOptions *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GDALViewshedMode = {"_p_GDALViewshedMode", "enum GDALViewshedMode *|GDALViewshedMode *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_GDALViewshedOutputType = {"_p_GDALViewshedOutputType", "enum GDALViewshedOutputType *|GDALViewshedOutputType *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GDALWarpAppOptions = {"_p_GDALWarpAppOptions", "GDALWarpAppOptions *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GDAL_GCP = {"_p_GDAL_GCP", "GDAL_GCP *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GIntBig = {"_p_GIntBig", "GIntBig *", 0, 0, (void*)0, 0};
@@ -41758,6 +41773,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_GDALTranslateOptions,
   &_swigt__p_GDALVectorTranslateOptions,
   &_swigt__p_GDALViewshedMode,
+  &_swigt__p_GDALViewshedOutputType,
   &_swigt__p_GDALWarpAppOptions,
   &_swigt__p_GDAL_GCP,
   &_swigt__p_GIntBig,
@@ -41826,6 +41842,7 @@ static swig_cast_info _swigc__p_GDALTransformerInfoShadow[] = {  {&_swigt__p_GDA
 static swig_cast_info _swigc__p_GDALTranslateOptions[] = {  {&_swigt__p_GDALTranslateOptions, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GDALVectorTranslateOptions[] = {  {&_swigt__p_GDALVectorTranslateOptions, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GDALViewshedMode[] = {  {&_swigt__p_GDALViewshedMode, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_GDALViewshedOutputType[] = {  {&_swigt__p_GDALViewshedOutputType, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GDALWarpAppOptions[] = {  {&_swigt__p_GDALWarpAppOptions, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GDAL_GCP[] = {  {&_swigt__p_GDAL_GCP, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GIntBig[] = {  {&_swigt__p_GIntBig, 0, 0, 0},{0, 0, 0, 0}};
@@ -41894,6 +41911,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_GDALTranslateOptions,
   _swigc__p_GDALVectorTranslateOptions,
   _swigc__p_GDALViewshedMode,
+  _swigc__p_GDALViewshedOutputType,
   _swigc__p_GDALWarpAppOptions,
   _swigc__p_GDAL_GCP,
   _swigc__p_GIntBig,
@@ -42638,6 +42656,9 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "GVM_Edge",SWIG_From_int(static_cast< int >(GVM_Edge)));
   SWIG_Python_SetConstant(d, "GVM_Max",SWIG_From_int(static_cast< int >(GVM_Max)));
   SWIG_Python_SetConstant(d, "GVM_Min",SWIG_From_int(static_cast< int >(GVM_Min)));
+  SWIG_Python_SetConstant(d, "GVOT_NORMAL",SWIG_From_int(static_cast< int >(GVOT_NORMAL)));
+  SWIG_Python_SetConstant(d, "GVOT_MIN_TARGET_HEIGHT_FROM_DEM",SWIG_From_int(static_cast< int >(GVOT_MIN_TARGET_HEIGHT_FROM_DEM)));
+  SWIG_Python_SetConstant(d, "GVOT_MIN_TARGET_HEIGHT_FROM_GROUND",SWIG_From_int(static_cast< int >(GVOT_MIN_TARGET_HEIGHT_FROM_GROUND)));
   
   /* Initialize threading */
   SWIG_PYTHON_INITIALIZE_THREADS;

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -4010,9 +4010,12 @@ GVM_Diagonal = _gdal.GVM_Diagonal
 GVM_Edge = _gdal.GVM_Edge
 GVM_Max = _gdal.GVM_Max
 GVM_Min = _gdal.GVM_Min
+GVOT_NORMAL = _gdal.GVOT_NORMAL
+GVOT_MIN_TARGET_HEIGHT_FROM_DEM = _gdal.GVOT_MIN_TARGET_HEIGHT_FROM_DEM
+GVOT_MIN_TARGET_HEIGHT_FROM_GROUND = _gdal.GVOT_MIN_TARGET_HEIGHT_FROM_GROUND
 
 def ViewshedGenerate(*args, **kwargs):
-    """ViewshedGenerate(Band srcBand, char const * driverName, char const * targetRasterName, char ** creationOptions, double observerX, double observerY, double observerHeight, double targetHeight, double visibleVal, double invisibleVal, double outOfRangeVal, double noDataVal, double dfCurvCoeff, GDALViewshedMode mode, double maxDistance, GDALProgressFunc callback=0, void * callback_data=None, char ** papszOptions=None) -> Dataset"""
+    """ViewshedGenerate(Band srcBand, char const * driverName, char const * targetRasterName, char ** creationOptions, double observerX, double observerY, double observerHeight, double targetHeight, double visibleVal, double invisibleVal, double outOfRangeVal, double noDataVal, double dfCurvCoeff, GDALViewshedMode mode, double maxDistance, GDALProgressFunc callback=0, void * callback_data=None, GDALViewshedOutputType heightMode=GVOT_NORMAL, char ** papszOptions=None) -> Dataset"""
     return _gdal.ViewshedGenerate(*args, **kwargs)
 
 def AutoCreateWarpedVRT(*args):


### PR DESCRIPTION
By setting the MINIMUM_HEIGHT extra argument GDALViewshedGenerate can also return a raster containing the minimum height from either ground level or the DEM surface in order for it to be visible.
