### PR TITLE
gdal_edit.py: add -a_ulurll switch

### DIFF
--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -94,6 +94,28 @@ def test_gdal_edit_py_1():
     assert units == 'metre'
 
 ###############################################################################
+# Test -a_ulurll
+
+def test_gdal_edit_py_1b():
+
+    script = 'gdal_edit'
+    folder = test_py_scripts.get_py_script(script)
+    if folder is None:
+        pytest.skip()
+
+    image = 'tmp/test_gdal_edit_py.tif'
+    shutil.copy('../gcore/data/byte.tif', image)
+
+    for points, expected in (
+        ('2 50 3 50 2 49', (2, 0.05, 0, 50, 0, -0.05)),  # not rotated
+        ('25 70 55 80 35 40', (25, 1.5, 0.5, 70, 0.5, -1.5)),  # rotated CCW
+        ('25 70 55 65 20 40', (25, 1.5, -0.25, 70, -0.25, -1.5)),  # rotated CW
+    ):
+        arguments = image + ' -a_ulurll ' + points
+        assert test_py_scripts.run_py_script(folder, script, arguments) == ''
+        assert gdal.Open(image).GetGeoTransform() == pytest.approx(expected)
+
+###############################################################################
 # Test -unsetgt
 
 

--- a/gdal/NEWS
+++ b/gdal/NEWS
@@ -132,6 +132,7 @@ All:
 * gdal2tiles.py: check that min zoom <= max zoom (#2161)
 * gdal_translate / gdalwarp / ogrct: allow dealing with non-WKT1 representable SRS (#1856)
 * gdal_edit.py: add a -units switch
+* gdal_edit.py: add -a_ulurll switch
 * gdal_fillnodata.py/GDALFillNodata: fix crash when smooth_iterations is used, and with some progress functions such as the one used by Python (#1184)
 * Python scripts and samples: use python3 for shebang (#2168)
 

--- a/gdal/doc/source/programs/gdal_edit.rst
+++ b/gdal/doc/source/programs/gdal_edit.rst
@@ -15,7 +15,8 @@ Synopsis
 
 .. code-block::
 
-    gdal_edit [--help-general] [-ro] [-a_srs srs_def] [-a_ullr ulx uly lrx lry]
+    gdal_edit [--help-general] [-ro] [-a_srs srs_def]
+            [-a_ullr ulx uly lrx lry] [-a_ulurll ulx uly urx ury llx lly]
             [-tr xres yres] [-unsetgt] [-unsetrpc] [-a_nodata value] [-unsetnodata]
             [-unsetstats] [-stats] [-approx_stats]
             [-setstats min max mean stddev]
@@ -63,6 +64,14 @@ It works only with raster formats that support update access to existing dataset
 .. option:: -a_ullr ulx uly lrx lry:
 
     Assign/override the georeferenced bounds of the dataset.
+
+.. option:: -a_ulurll ulx uly urx ury llx lly:
+
+    Assign/override the georeferenced bounds of the dataset from three points:
+    upper-left, upper-right and lower-left. Unlike :option:`-a_ullr`, this also
+    supports rotated datasets (edges not parallel to coordinate system axes).
+
+    .. versionadded:: 3.1
 
 .. option:: -tr <xres> <yres>
 
@@ -180,7 +189,7 @@ It works only with raster formats that support update access to existing dataset
 
     .. versionadded:: 2.0
 
-The :option:`-a_ullr`, :option:`-tr` and :option:`-unsetgt` options are exclusive.
+The :option:`-a_ullr`, :option:`-a_ulurll`, :option:`-tr` and :option:`-unsetgt` options are exclusive.
 
 The :option:`-unsetstats` and either :option:`-stats` or :option:`-approx_stats` options are exclusive.
 

--- a/gdal/scripts/gdal-bash-completion.sh
+++ b/gdal/scripts/gdal-bash-completion.sh
@@ -173,7 +173,7 @@ _gdal_edit.py()
   _get_comp_words_by_ref cur prev
   case "$cur" in
     -*)
-      key_list="--help-general -ro -a_srs -a_ullr -tr -unsetgt -unsetrpc -a_nodata -unsetnodata -offset -scale -colorinterp_X -unsetstats -stats -approx_stats -setstats -gcp -unsetmd -oo -mo --version --license --formats --format --optfile --config --debug --pause --locale "
+      key_list="--help-general -ro -a_srs -a_ullr -a_ulurll -tr -unsetgt -unsetrpc -a_nodata -unsetnodata -offset -scale -colorinterp_X -unsetstats -stats -approx_stats -setstats -gcp -unsetmd -oo -mo --version --license --formats --format --optfile --config --debug --pause --locale "
       mapfile -t COMPREPLY < <(compgen -W "$key_list" -- "$cur")
       return 0
       ;;

--- a/gdal/swig/python/scripts/gdal_edit.py
+++ b/gdal/swig/python/scripts/gdal_edit.py
@@ -35,7 +35,8 @@ from osgeo import osr
 
 
 def Usage():
-    print('Usage: gdal_edit [--help-general] [-ro] [-a_srs srs_def] [-a_ullr ulx uly lrx lry]')
+    print('Usage: gdal_edit [--help-general] [-ro] [-a_srs srs_def]')
+    print('                 [-a_ullr ulx uly lrx lry] [-a_ulurll ulx uly urx ury llx lly]')
     print('                 [-tr xres yres] [-unsetgt] [-unsetrpc] [-a_nodata value] [-unsetnodata]')
     print('                 [-offset value] [-scale value] [-units value]')
     print('                 [-colorinterp_X red|green|blue|alpha|gray|undefined]*')
@@ -69,6 +70,10 @@ def gdal_edit(argv):
     srs = None
     ulx = None
     uly = None
+    urx = None
+    ury = None
+    llx = None
+    lly = None
     lrx = None
     lry = None
     nodata = None
@@ -107,6 +112,19 @@ def gdal_edit(argv):
             lrx = float(argv[i + 1])
             i = i + 1
             lry = float(argv[i + 1])
+            i = i + 1
+        elif argv[i] == '-a_ulurll' and i < len(argv) - 6:
+            ulx = float(argv[i + 1])
+            i = i + 1
+            uly = float(argv[i + 1])
+            i = i + 1
+            urx = float(argv[i + 1])
+            i = i + 1
+            ury = float(argv[i + 1])
+            i = i + 1
+            llx = float(argv[i + 1])
+            i = i + 1
+            lly = float(argv[i + 1])
             i = i + 1
         elif argv[i] == '-tr' and i < len(argv) - 2:
             xres = float(argv[i + 1])
@@ -238,12 +256,14 @@ def gdal_edit(argv):
     exclusive_option = 0
     if lry is not None:
         exclusive_option = exclusive_option + 1
+    if lly is not None:  # -a_ulurll
+        exclusive_option = exclusive_option + 1
     if yres is not None:
         exclusive_option = exclusive_option + 1
     if unsetgt:
         exclusive_option = exclusive_option + 1
     if exclusive_option > 1:
-        print('-a_ullr, -tr and -unsetgt options are exclusive.')
+        print('-a_ullr, -a_ulurll, -tr and -unsetgt options are exclusive.')
         print('')
         return Usage()
 
@@ -301,6 +321,11 @@ def gdal_edit(argv):
     if lry is not None:
         gt = [ulx, (lrx - ulx) / ds.RasterXSize, 0,
               uly, 0, (lry - uly) / ds.RasterYSize]
+        ds.SetGeoTransform(gt)
+
+    elif lly is not None:  # -a_ulurll
+        gt = [ulx, (urx - ulx) / ds.RasterXSize, (llx - ulx) / ds.RasterYSize,
+              uly, (ury - uly) / ds.RasterXSize, (lly - uly) / ds.RasterYSize]
         ds.SetGeoTransform(gt)
 
     if yres is not None:


### PR DESCRIPTION
Assign/override the georeferenced bounds of the dataset from three points: upper-left, upper-right and lower-left. Unlike option `-a_ullr`, this also supports rotated datasets (edges not parallel to coordinate system axes).