### PR TITLE
/vsiswift/: V3 authentication method, handling auth token expiration

### DIFF
--- a/gdal/doc/source/user/virtual_file_systems.rst
+++ b/gdal/doc/source/user/virtual_file_systems.rst
@@ -378,10 +378,20 @@ Recognized filenames are of the form :file:`/vsiswift/bucket/key` where ``bucket
 
 The generalities of :ref:`/vsicurl/ </vsicurl/>` apply.
 
-Two authentication methods are possible, and are attempted in the following order:
+Three authentication methods are possible, and are attempted in the following order:
 
 1. The :decl_configoption:`SWIFT_STORAGE_URL` and :decl_configoption:`SWIFT_AUTH_TOKEN` configuration options are set respectively to the storage URL (e.g http://127.0.0.1:12345/v1/AUTH_something) and the value of the x-auth-token authorization token.
 2. The :decl_configoption:`SWIFT_AUTH_V1_URL`, :decl_configoption:`SWIFT_USER` and :decl_configoption:`SWIFT_KEY` configuration options are set respectively to the endpoint of the Auth V1 authentication (e.g http://127.0.0.1:12345/auth/v1.0), the user name and the key/password. This authentication endpoint will be used to retrieve the storage URL and authorization token mentioned in the first authentication method.
+3. Authentication with Keystone v3 is using the same options as python-swiftclient, see https://docs.openstack.org/python-swiftclient/latest/cli/index.html#authentication for more details. GDAL (>= 3.1) supports the following options:
+
+   - `OS_IDENTITY_API_VERSION=3`
+   - `OS_AUTH_URL`
+   - `OS_USERNAME`
+   - `OS_PASSWORD`
+   - `OS_USER_DOMAIN_NAME`
+   - `OS_PROJECT_NAME`
+   - `OS_PROJECT_DOMAIN_NAME`
+   - `OS_REGION_NAME`
 
 This file system handler also allows sequential writing of files (no seeks or read operations are then allowed)
 

--- a/gdal/port/cpl_swift.cpp
+++ b/gdal/port/cpl_swift.cpp
@@ -29,6 +29,7 @@
 #include "cpl_vsi_error.h"
 #include "cpl_http.h"
 #include "cpl_multiproc.h"
+#include "cpl_json.h"
 
 // HOWTO setup a Docker-based SWIFT server:
 // https://github.com/MorrisJobke/docker-swift-onlyone
@@ -106,33 +107,46 @@ bool VSISwiftHandleHelper::GetConfiguration(CPLString& osStorageURL,
         return true;
     }
 
+    CPLString osAuthV1URL = CPLGetConfigOption("SWIFT_AUTH_V1_URL", "");
+    if ( ! osAuthV1URL.empty() )
+    {
+        if( ! CheckCredentialsV1() )
+            return false;
+        if( GetCached("SWIFT_AUTH_V1_URL", "SWIFT_USER", "SWIFT_KEY", osStorageURL, osAuthToken) )
+            return true;
+        if( AuthV1(osStorageURL, osAuthToken) )
+            return true;
+    }
+
+    CPLString osAuthVersion = CPLGetConfigOption("OS_IDENTITY_API_VERSION", "");
+    if ( osAuthVersion == "3" )
+    {
+        if( ! CheckCredentialsV3() )
+            return false;
+        if( GetCached("OS_AUTH_URL", "OS_USERNAME", "OS_PASSWORD", osStorageURL, osAuthToken) )
+            return true;
+        if( AuthV3(osStorageURL, osAuthToken) )
+            return true;
+    }
+
+    const char* pszMsg = "Missing SWIFT_STORAGE_URL+SWIFT_AUTH_TOKEN or "
+                         "appropriate authentication options";
+    CPLDebug("SWIFT", "%s", pszMsg);
+    VSIError(VSIE_AWSInvalidCredentials, "%s", pszMsg);
+
+    return false;
+}
+
+/************************************************************************/
+/*                               AuthV1()                               */
+/************************************************************************/
+
+bool VSISwiftHandleHelper::AuthV1(CPLString& osStorageURL,
+                                  CPLString& osAuthToken)
+{
     CPLString osAuthURL = CPLGetConfigOption("SWIFT_AUTH_V1_URL", "");
     CPLString osUser = CPLGetConfigOption("SWIFT_USER", "");
     CPLString osKey = CPLGetConfigOption("SWIFT_KEY", "");
-    if( osAuthURL.empty() || osUser.empty() || osKey.empty() )
-    {
-        const char* pszMsg = "Missing SWIFT_STORAGE_URL+SWIFT_AUTH_TOKEN or "
-                             "SWIFT_AUTH_V1_URL+SWIFT_USER+SWIFT_KEY "
-                             "configuration options";
-        CPLDebug("SWIFT", "%s", pszMsg);
-        VSIError(VSIE_AWSInvalidCredentials, "%s", pszMsg);
-        return false;
-    }
-
-    // Re-use cached credentials if available
-    {
-        CPLMutexHolder oHolder( &g_hMutex );
-        // coverity[tainted_data]
-        if( osAuthURL == g_osLastAuthURL &&
-            osUser == g_osLastUser &&
-            osKey == g_osLastKey )
-        {
-            osStorageURL = g_osLastStorageURL;
-            osAuthToken = g_osLastAuthToken;
-            return true;
-        }
-    }
-
     char** papszHeaders = CSLSetNameValue(nullptr, "HEADERS",
         CPLSPrintf("X-Auth-User: %s\r\n"
                    "X-Auth-Key: %s",
@@ -170,6 +184,287 @@ bool VSISwiftHandleHelper::GetConfiguration(CPLString& osStorageURL,
     return true;
 }
 
+/************************************************************************/
+/*                      CreateAuthV3RequestObject()                     */
+/************************************************************************/
+
+CPLJSONObject VSISwiftHandleHelper::CreateAuthV3RequestObject()
+{
+    CPLString osUser = CPLGetConfigOption("OS_USERNAME", "");
+    CPLString osPassword = CPLGetConfigOption("OS_PASSWORD", "");
+
+    CPLJSONObject user;
+    user.Add("name", osUser);
+    user.Add("password", osPassword);
+
+    CPLString osUserDomainName = CPLGetConfigOption("OS_USER_DOMAIN_NAME", "");
+    if( ! osUserDomainName.empty() )
+    {
+        CPLJSONObject userDomain;
+        userDomain.Add("name", osUserDomainName);
+        user.Add("domain", userDomain);
+    }
+
+    CPLJSONObject password;
+    password.Add("user", user);
+
+    CPLJSONArray methods;
+    methods.Add("password");
+
+    CPLJSONObject identity;
+    identity.Add("methods", methods);
+    identity.Add("password", password);
+
+    CPLJSONObject scope;
+    CPLString osProjectName = CPLGetConfigOption("OS_PROJECT_NAME", "");
+    if( ! osProjectName.empty() )
+    {
+        CPLJSONObject project;
+        project.Add("name", osProjectName);
+
+        CPLString osProjectDomainName = CPLGetConfigOption("OS_PROJECT_DOMAIN_NAME", "");
+        if( ! osProjectDomainName.empty() )
+        {
+            CPLJSONObject projectDomain;
+            projectDomain.Add("name", osProjectDomainName);
+            project.Add("domain", projectDomain);
+        }
+
+        scope.Add("project", project);
+    }
+
+    CPLJSONObject auth;
+    auth.Add("identity", identity);
+    if( ! scope.GetChildren().empty() )
+        auth.Add("scope", scope);
+
+    CPLJSONObject obj;
+    obj.Add("auth", auth);
+    return obj;
+}
+
+/************************************************************************/
+/*                      GetAuthV3StorageURL()                           */
+/************************************************************************/
+
+bool VSISwiftHandleHelper::GetAuthV3StorageURL(const CPLHTTPResult *psResult,
+                                               CPLString& storageURL)
+{
+    if( psResult->pabyData == nullptr )
+        return false;
+
+    CPLJSONDocument resultJson;
+    resultJson.LoadMemory(psResult->pabyData);
+    CPLJSONObject result(resultJson.GetRoot());
+
+    CPLJSONObject token(result.GetObj("token"));
+    if( ! token.IsValid() )
+        return false;
+
+    CPLJSONArray catalog(token.GetArray("catalog"));
+    if( ! catalog.IsValid() )
+        return false;
+
+    CPLJSONArray endpoints;
+    for(int i = 0; i < catalog.Size(); ++i)
+    {
+        CPLJSONObject item(catalog[i]);
+        if( item.GetString("name") == "swift" )
+        {
+            endpoints = item.GetArray("endpoints");
+            break;
+        }
+    }
+
+    if( endpoints.Size() == 0 )
+        return false;
+
+    CPLString osRegionName = CPLGetConfigOption("OS_REGION_NAME", "");
+    if( osRegionName.empty() )
+    {
+        CPLJSONObject endpoint(endpoints[0]);
+        storageURL = endpoint.GetString("url");
+        return true;
+    }
+
+    for(int i = 0; i < endpoints.Size(); ++i)
+    {
+        CPLJSONObject endpoint(endpoints[i]);
+        if( endpoint.GetString("region") == osRegionName )
+        {
+            storageURL = endpoint.GetString("url");
+            CPLDebug("SWIFT", "Storage URL '%s' for region '%s'", storageURL.c_str(), osRegionName.c_str());
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/************************************************************************/
+/*                                AuthV3()                              */
+/************************************************************************/
+
+bool VSISwiftHandleHelper::AuthV3(CPLString& osStorageURL,
+                                  CPLString& osAuthToken)
+{
+    CPLString osUser = CPLGetConfigOption("OS_USERNAME", "");
+    CPLString osPass = CPLGetConfigOption("OS_PASSWORD", "");
+    CPLJSONObject postObject(CreateAuthV3RequestObject());
+    std::string post = postObject.Format(CPLJSONObject::PrettyFormat::Plain);
+
+    CPLString osAuthURL = CPLGetConfigOption("OS_AUTH_URL", "");
+    std::string url = osAuthURL;
+    if( !url.empty() && url.back() != '/' )
+        url += '/';
+    url += "auth/tokens";
+
+    char** papszOptions = CSLSetNameValue(nullptr, "POSTFIELDS", post.data());
+    papszOptions = CSLSetNameValue(papszOptions, "HEADERS", "Content-Type: application/json");
+    CPLHTTPResult *psResult = CPLHTTPFetchEx( url.c_str(), papszOptions,
+                                              nullptr, nullptr,
+                                              nullptr, nullptr );
+    CSLDestroy( papszOptions );
+
+    if( psResult == nullptr )
+        return false;
+
+    osAuthToken = CSLFetchNameValueDef(psResult->papszHeaders,
+                                       "X-Subject-Token", "");
+
+    if( !GetAuthV3StorageURL(psResult, osStorageURL) )
+    {
+        CPLHTTPDestroyResult(psResult);
+        return false;
+    }
+
+    if( osStorageURL.empty() || osAuthToken.empty() )
+    {
+        CPLString osErrorMsg = reinterpret_cast<const char*>(psResult->pabyData);
+        CPLDebug("SWIFT", "Authentication failed: %s", osErrorMsg.c_str());
+        VSIError(VSIE_AWSInvalidCredentials,
+                 "Authentication failed: %s", osErrorMsg.c_str());
+        CPLHTTPDestroyResult(psResult);
+        return false;
+    }
+
+    CPLHTTPDestroyResult(psResult);
+
+    // Cache credentials
+    {
+        CPLMutexHolder oHolder( &g_hMutex );
+        g_osLastAuthURL = osAuthURL;
+        g_osLastUser = osUser;
+        g_osLastKey = osPass;
+        g_osLastStorageURL = osStorageURL;
+        g_osLastAuthToken = osAuthToken;
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                           Authenticate()                             */
+/************************************************************************/
+
+bool VSISwiftHandleHelper::Authenticate()
+{
+    CPLString osAuthV1URL = CPLGetConfigOption("SWIFT_AUTH_V1_URL", "");
+    if( !osAuthV1URL.empty() && AuthV1(m_osStorageURL, m_osAuthToken) )
+    {
+        RebuildURL();
+        return true;
+    }
+
+    CPLString osAuthVersion = CPLGetConfigOption("OS_IDENTITY_API_VERSION", "");
+    if( osAuthVersion == "3" && AuthV3(m_osStorageURL, m_osAuthToken) )
+    {
+        RebuildURL();
+        return true;
+    }
+
+    return false;
+}
+
+/************************************************************************/
+/*                         CheckCredentialsV1()                         */
+/************************************************************************/
+
+bool VSISwiftHandleHelper::CheckCredentialsV1()
+{
+    const char* pszMissingKey = nullptr;
+    CPLString osUser = CPLGetConfigOption("SWIFT_USER", "");
+    CPLString osKey = CPLGetConfigOption("SWIFT_KEY", "");
+    if( osUser.empty() )
+    {
+        pszMissingKey = "SWIFT_USER";
+    }
+    else if( osKey.empty() )
+    {
+        pszMissingKey = "SWIFT_KEY";
+    }
+
+    if ( pszMissingKey )
+    {
+        CPLDebug("SWIFT", "Missing %s configuration option", pszMissingKey);
+        VSIError(VSIE_AWSInvalidCredentials, "%s", pszMissingKey);
+        return false;
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                         CheckCredentialsV3()                         */
+/************************************************************************/
+
+bool VSISwiftHandleHelper::CheckCredentialsV3()
+{
+    const char* papszManatoryOptionKeys[] = {
+        "OS_AUTH_URL",
+        "OS_USERNAME",
+        "OS_PASSWORD",
+    };
+    for( auto const * pszOptionKey : papszManatoryOptionKeys )
+    {
+        CPLString option = CPLGetConfigOption(pszOptionKey, "");
+        if( option.empty() )
+        {
+            CPLDebug("SWIFT", "Missing %s configuration option", pszOptionKey);
+            VSIError(VSIE_AWSInvalidCredentials, "%s", pszOptionKey);
+            return false;
+        }
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                         GetCachedAuth()                            */
+/************************************************************************/
+
+bool VSISwiftHandleHelper::GetCached(const char* pszURLKey,
+                                     const char* pszUserKey,
+                                     const char* pszPasswordKey,
+                                     CPLString& osStorageURL,
+                                     CPLString& osAuthToken)
+{
+    CPLString osAuthURL = CPLGetConfigOption(pszURLKey, "");
+    CPLString osUser = CPLGetConfigOption(pszUserKey, "");
+    CPLString osKey = CPLGetConfigOption(pszPasswordKey, "");
+
+    CPLMutexHolder oHolder( &g_hMutex );
+    // Re-use cached credentials if available
+    // coverity[tainted_data]
+    if( osAuthURL == g_osLastAuthURL &&
+        osUser == g_osLastUser &&
+        osKey == g_osLastKey )
+    {
+        osStorageURL = g_osLastStorageURL;
+        osAuthToken = g_osLastAuthToken;
+        return true;
+    }
+    return false;
+}
 
 /************************************************************************/
 /*                          BuildFromURI()                              */

--- a/gdal/port/cpl_swift.h
+++ b/gdal/port/cpl_swift.h
@@ -35,6 +35,7 @@
 #include <curl/curl.h>
 #include "cpl_http.h"
 #include "cpl_aws.h"
+#include "cpl_json.h"
 #include <map>
 
 class VSISwiftHandleHelper final: public IVSIS3LikeHandleHelper
@@ -48,11 +49,30 @@ class VSISwiftHandleHelper final: public IVSIS3LikeHandleHelper
         static bool     GetConfiguration(CPLString& osStorageURL,
                                          CPLString& osAuthToken);
 
+        static bool GetCached(const char* pszURLKey,
+                              const char* pszUserKey,
+                              const char* pszPasswordKey,
+                              CPLString& osStorageURL,
+                              CPLString& osAuthToken);
+
         static CPLString BuildURL(const CPLString& osStorageURL,
                                   const CPLString& osBucket,
                                   const CPLString& osObjectKey);
 
         void RebuildURL() override;
+
+        // V1 Authentication
+        static bool CheckCredentialsV1();
+        static bool AuthV1(CPLString& osStorageURL,
+                           CPLString& osAuthToken);
+
+        // V3 Authentication
+        static bool CheckCredentialsV3();
+        static bool AuthV3(CPLString& osStorageURL,
+                           CPLString& osAuthToken);
+        static CPLJSONObject CreateAuthV3RequestObject();
+        static bool GetAuthV3StorageURL(const CPLHTTPResult *psResult,
+                                        CPLString& storageURL);
 
     public:
         VSISwiftHandleHelper(const CPLString& osStorageURL,
@@ -60,6 +80,8 @@ class VSISwiftHandleHelper final: public IVSIS3LikeHandleHelper
                              const CPLString& osBucket,
                              const CPLString& osObjectKey);
        ~VSISwiftHandleHelper();
+
+        bool Authenticate();
 
         static VSISwiftHandleHelper* BuildFromURI(const char* pszURI,
                                                const char* pszFSPrefix);

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -1348,6 +1348,18 @@ retry:
         goto retry;
     }
 
+    if( response_code == 401 && nRetryCount < m_nMaxRetry )
+    {
+        CPLDebug("VSICURL", "Unauthorized, trying to authenticate");
+        CPLFree(sWriteFuncData.pBuffer);
+        CPLFree(sWriteFuncHeaderData.pBuffer);
+        curl_easy_cleanup(hCurlHandle);
+        nRetryCount++;
+        if( Authenticate() )
+            goto retry;
+        return std::string();
+    }
+
     CPLString osEffectiveURL;
     {
         char *pszEffectiveURL = nullptr;

--- a/gdal/port/cpl_vsil_curl_class.h
+++ b/gdal/port/cpl_vsil_curl_class.h
@@ -323,6 +323,7 @@ class VSICurlHandle : public VSIVirtualHandle
     virtual bool IsDirectoryFromExists( const char* /*pszVerb*/, int /*response_code*/ ) { return false; }
     virtual void ProcessGetFileSizeResult(const char* /* pszContent */ ) {}
     void SetURL(const char* pszURL);
+    virtual bool Authenticate() { return false; }
 
   public:
 

--- a/gdal/port/cpl_vsil_swift.cpp
+++ b/gdal/port/cpl_vsil_swift.cpp
@@ -267,6 +267,7 @@ class VSISwiftHandle final : public IVSIS3LikeHandle
     struct curl_slist* GetCurlHeaders(
         const CPLString& osVerb,
         const struct curl_slist* psExistingHeaders ) override;
+    virtual bool Authenticate() override;
 
   public:
     VSISwiftHandle( VSISwiftFSHandler* poFS,
@@ -682,6 +683,15 @@ struct curl_slist* VSISwiftHandle::GetCurlHeaders( const CPLString& osVerb,
                                 const struct curl_slist* psExistingHeaders )
 {
     return m_poHandleHelper->GetCurlHeaders(osVerb, psExistingHeaders);
+}
+
+/************************************************************************/
+/*                           Authenticate()                             */
+/************************************************************************/
+
+bool VSISwiftHandle::Authenticate()
+{
+    return m_poHandleHelper->Authenticate();
 }
 
 


### PR DESCRIPTION
Addresses https://github.com/OSGeo/gdal/issues/2239.

Implements re-issue of the auth token when expired. To allow the re-issue, `GDAL_HTTP_MAX_RETRY` needs to be set at least to `1`.

Adds authentication using OpenStack Identity API v3. It might not be complete implementation. I have implemented it to the extent I was able to connect to a Swift instance I have access to.

