### PR TITLE
NUMPYDataset::Open() / gdal_array.OpenArray(): honour writeable flag of the numpy array to decide if the GDAL dataset is read-only or updateable

### DIFF
--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -730,6 +730,32 @@ def test_numpy_rw_failure_in_readasarray():
     assert exception_raised
 
 
+###############################################################################
+# Test permission handling
+
+
+def test_numpy_rw_gdal_array_openarray_permissions():
+
+    if gdaltest.numpy_drv is None:
+        pytest.skip()
+
+    import numpy
+    from osgeo import gdal_array
+
+    # Writeable array
+    ar = numpy.zeros([1, 1], dtype=numpy.uint8)
+    ds = gdal_array.OpenArray(ar)
+    assert ds.GetRasterBand(1).Fill(1) == 0
+    assert ds.GetRasterBand(1).Checksum() != 0
+
+    # Non-writeable array
+    ar = numpy.zeros([1, 1], dtype=numpy.uint8)
+    ar.setflags(write=False)
+    ds = gdal_array.OpenArray(ar)
+    with gdaltest.error_handler():
+        assert ds.GetRasterBand(1).Fill(1) != 0
+    assert ds.GetRasterBand(1).Checksum()  == 0
+
 
 def test_numpy_rw_cleanup():
     gdaltest.numpy_drv = None

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -465,7 +465,7 @@ GDALDataset* NUMPYDataset::Open( PyArrayObject *psArray, bool binterleave )
 
     poDS->psArray = psArray;
 
-    poDS->eAccess = GA_ReadOnly;
+    poDS->eAccess = (PyArray_FLAGS(psArray) & NPY_ARRAY_WRITEABLE) ? GA_Update : GA_ReadOnly;
 
 /* -------------------------------------------------------------------- */
 /*      Add a reference to the array.                                   */

--- a/gdal/swig/python/extensions/gdal_array_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_array_wrap.cpp
@@ -3913,7 +3913,7 @@ GDALDataset* NUMPYDataset::Open( PyArrayObject *psArray, bool binterleave )
 
     poDS->psArray = psArray;
 
-    poDS->eAccess = GA_ReadOnly;
+    poDS->eAccess = (PyArray_FLAGS(psArray) & NPY_ARRAY_WRITEABLE) ? GA_Update : GA_ReadOnly;
 
 /* -------------------------------------------------------------------- */
 /*      Add a reference to the array.                                   */


### PR DESCRIPTION
Fixes issue reported in https://lists.osgeo.org/pipermail/gdal-dev/2020-March/051817.html