### PR TITLE
Revise drivers GDAL_DMD_HELPTOPIC

### DIFF
--- a/gdal/frmts/aaigrid/aaigriddataset.cpp
+++ b/gdal/frmts/aaigrid/aaigriddataset.cpp
@@ -1506,7 +1506,7 @@ void GDALRegister_AAIGrid()
     poDriver->SetDescription("AAIGrid");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Arc/Info ASCII Grid");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_various.html#AAIGrid");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/aaigrid.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "asc");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES,
                               "Byte UInt16 Int16 Int32 Float32");
@@ -1550,7 +1550,7 @@ void GDALRegister_GRASSASCIIGrid()
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "GRASS ASCII Grid");
     poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
-                              "frmt_various.html#GRASSASCIIGrid");
+                              "drivers/raster/grassasciigrid.html");
 
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
 

--- a/gdal/frmts/aaigrid/aaigriddataset.cpp
+++ b/gdal/frmts/aaigrid/aaigriddataset.cpp
@@ -1576,7 +1576,7 @@ void GDALRegister_ISG()
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "International Service for the Geoid");
     poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
-                              "isg.html");
+                              "drivers/raster/isg.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "isg");
 
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");

--- a/gdal/frmts/adrg/adrgdataset.cpp
+++ b/gdal/frmts/adrg/adrgdataset.cpp
@@ -2377,7 +2377,7 @@ void GDALRegister_ADRG()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "ARC Digitized Raster Graphics" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#ADRG" );
+                               "drivers/raster/adrg.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "gen" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte" );

--- a/gdal/frmts/adrg/srpdataset.cpp
+++ b/gdal/frmts/adrg/srpdataset.cpp
@@ -1671,7 +1671,7 @@ void GDALRegister_SRP()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Standard Raster Product (ASRP/USRP)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#SRP" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/srp.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "img" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/aigrid/aigdataset.cpp
+++ b/gdal/frmts/aigrid/aigdataset.cpp
@@ -1067,7 +1067,7 @@ void GDALRegister_AIGrid()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Arc/Info Binary Grid" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#AIG" );
+                               "drivers/raster/aig.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = AIGDataset::Open;

--- a/gdal/frmts/airsar/airsardataset.cpp
+++ b/gdal/frmts/airsar/airsardataset.cpp
@@ -641,7 +641,7 @@ void GDALRegister_AirSAR()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "AirSAR Polarimetric Image" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_airsar.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/airsar.html" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/arg/argdataset.cpp
+++ b/gdal/frmts/arg/argdataset.cpp
@@ -804,7 +804,7 @@ void GDALRegister_ARG()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Azavea Raster Grid format" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#ARG" );
+                               "drivers/raster/arg.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnIdentify = ARGDataset::Identify;

--- a/gdal/frmts/blx/blxdataset.cpp
+++ b/gdal/frmts/blx/blxdataset.cpp
@@ -435,7 +435,7 @@ void GDALRegister_BLX()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Magellan topo (.blx)" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#BLX" );
+                               "drivers/raster/blx.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "blx" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/bmp/bmpdataset.cpp
+++ b/gdal/frmts/bmp/bmpdataset.cpp
@@ -1609,7 +1609,7 @@ void GDALRegister_BMP()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "MS Windows Device Independent Bitmap" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_bmp.html" );
+                               "drivers/raster/bmp.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "bmp" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONOPTIONLIST,

--- a/gdal/frmts/bpg/bpgdataset.cpp
+++ b/gdal/frmts/bpg/bpgdataset.cpp
@@ -339,7 +339,7 @@ void GDALRegister_BPG()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Better Portable Graphics" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_bpg.html" );
+                               "drivers/raster/bpg.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "bpg" );
     // poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/bpg" );
 

--- a/gdal/frmts/bsb/bsbdataset.cpp
+++ b/gdal/frmts/bsb/bsbdataset.cpp
@@ -1167,7 +1167,7 @@ void GDALRegister_BSB()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Maptech BSB Nautical Charts" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#BSB" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/bsb.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 #ifdef BSB_CREATE
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );

--- a/gdal/frmts/cals/calsdataset.cpp
+++ b/gdal/frmts/cals/calsdataset.cpp
@@ -608,7 +608,7 @@ void GDALRegister_CALS()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "CALS (Type 1)" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_cals.html" );
+                               "drivers/raster/cals.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "cal ct1");
 

--- a/gdal/frmts/ceos/ceosdataset.cpp
+++ b/gdal/frmts/ceos/ceosdataset.cpp
@@ -232,7 +232,7 @@ void GDALRegister_CEOS()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "CEOS Image" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#CEOS" );
+                               "drivers/raster/ceos.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = CEOSDataset::Open;

--- a/gdal/frmts/ceos2/sar_ceosdataset.cpp
+++ b/gdal/frmts/ceos2/sar_ceosdataset.cpp
@@ -2196,7 +2196,7 @@ void GDALRegister_SAR_CEOS()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "CEOS SAR Image" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#SAR_CEOS" );
+                               "drivers/raster/sar_ceos.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = SAR_CEOSDataset::Open;

--- a/gdal/frmts/coasp/coasp_dataset.cpp
+++ b/gdal/frmts/coasp/coasp_dataset.cpp
@@ -567,7 +567,7 @@ void GDALRegister_COASP()
                                "DRDC COASP SAR Processor Raster" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION,
                                "hdr" );
-    // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/coasp.html");
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/coasp.html");
     poDriver->pfnIdentify = COASPDataset::Identify;
     poDriver->pfnOpen = COASPDataset::Open;
     GetGDALDriverManager()->RegisterDriver( poDriver );

--- a/gdal/frmts/coasp/coasp_dataset.cpp
+++ b/gdal/frmts/coasp/coasp_dataset.cpp
@@ -567,7 +567,7 @@ void GDALRegister_COASP()
                                "DRDC COASP SAR Processor Raster" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION,
                                "hdr" );
-    // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_coasp.html");
+    // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/coasp.html");
     poDriver->pfnIdentify = COASPDataset::Identify;
     poDriver->pfnOpen = COASPDataset::Open;
     GetGDALDriverManager()->RegisterDriver( poDriver );

--- a/gdal/frmts/cosar/cosar_dataset.cpp
+++ b/gdal/frmts/cosar/cosar_dataset.cpp
@@ -217,7 +217,7 @@ void GDALRegister_COSAR()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "COSAR Annotated Binary Matrix (TerraSAR-X)");
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_cosar.html");
+                               "drivers/raster/cosar.html");
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->pfnOpen = COSARDataset::Open;
     GetGDALDriverManager()->RegisterDriver(poDriver);

--- a/gdal/frmts/ctg/ctgdataset.cpp
+++ b/gdal/frmts/ctg/ctgdataset.cpp
@@ -586,7 +586,7 @@ void GDALRegister_CTG()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "USGS LULC Composite Theme Grid" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#CTG" );
+                               "drivers/raster/ctg.html" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/daas/daasdataset.cpp
+++ b/gdal/frmts/daas/daasdataset.cpp
@@ -2639,7 +2639,7 @@ void GDALRegister_DAAS()
                                "Airbus DS Intelligence "
                                "Data As A Service driver" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_daas.html" );
+                               "drivers/raster/daas.html" );
 
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
 "<OpenOptionList>"

--- a/gdal/frmts/derived/deriveddataset.cpp
+++ b/gdal/frmts/derived/deriveddataset.cpp
@@ -213,7 +213,7 @@ void GDALRegister_Derived()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
 #endif
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Derived datasets using VRT pixel functions" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_derived.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/derived.html" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "NO" );
 
     poDriver->pfnOpen = DerivedDataset::Open;

--- a/gdal/frmts/dimap/dimapdataset.cpp
+++ b/gdal/frmts/dimap/dimapdataset.cpp
@@ -1611,7 +1611,7 @@ void GDALRegister_DIMAP()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "SPOT DIMAP" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#DIMAP" );
+                               "drivers/raster/dimap.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = DIMAPDataset::Open;

--- a/gdal/frmts/dods/dodsdataset2.cpp
+++ b/gdal/frmts/dods/dodsdataset2.cpp
@@ -1717,7 +1717,7 @@ void GDALRegister_DODS()
     poDriver->SetDescription( "DODS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "DAP 3.x servers" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#DODS" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/dods.html" );
 
     poDriver->pfnOpen = DODSDataset::Open;
 

--- a/gdal/frmts/dted/dteddataset.cpp
+++ b/gdal/frmts/dted/dteddataset.cpp
@@ -918,7 +918,7 @@ void GDALRegister_DTED()
                                "DTED Elevation Raster" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "dt0 dt1 dt2" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#DTED" );
+                               "drivers/raster/dted.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16" );
 

--- a/gdal/frmts/e00grid/e00griddataset.cpp
+++ b/gdal/frmts/e00grid/e00griddataset.cpp
@@ -921,7 +921,7 @@ void GDALRegister_E00GRID()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Arc/Info Export E00 GRID" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#E00GRID" );
+                               "drivers/raster/e00grid.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "e00" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/ecw/ecwdataset.cpp
+++ b/gdal/frmts/ecw/ecwdataset.cpp
@@ -3555,7 +3555,7 @@ void GDALRegister_ECW()
     osLongName += ")";
 
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, osLongName );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_ecw.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/ecw.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ecw" );
 
     poDriver->pfnIdentify = ECWDataset::IdentifyECW;
@@ -3652,7 +3652,7 @@ void GDALRegister_JP2ECW()
     osLongName += ")";
 
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, osLongName );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_jp2ecw.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/jp2ecw.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "jp2" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/eeda/eedadataset.cpp
+++ b/gdal/frmts/eeda/eedadataset.cpp
@@ -1230,7 +1230,7 @@ void GDALRegister_EEDA()
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Earth Engine Data API" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_eeda.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/vector/eeda.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CONNECTION_PREFIX, "EEDA:" );
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
 "<OpenOptionList>"

--- a/gdal/frmts/eeda/eedaidataset.cpp
+++ b/gdal/frmts/eeda/eedaidataset.cpp
@@ -1645,7 +1645,7 @@ void GDALRegister_EEDAI()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Earth Engine Data API Image" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_eedai.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/eedai.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CONNECTION_PREFIX, "EEDAI:" );
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
 "<OpenOptionList>"

--- a/gdal/frmts/envisat/envisatdataset.cpp
+++ b/gdal/frmts/envisat/envisatdataset.cpp
@@ -1159,7 +1159,7 @@ void GDALRegister_Envisat()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Envisat Image Format" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#Envisat" );
+                               "drivers/raster/esat.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "n1" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/epsilon/epsilondataset.cpp
+++ b/gdal/frmts/epsilon/epsilondataset.cpp
@@ -1006,7 +1006,7 @@ void GDALRegister_EPSILON()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
 
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Epsilon wavelets" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_epsilon.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/epsilon.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );
 
     CPLString osMethods;

--- a/gdal/frmts/ers/ersdataset.cpp
+++ b/gdal/frmts/ers/ersdataset.cpp
@@ -1512,7 +1512,7 @@ void GDALRegister_ERS()
     poDriver->SetDescription( "ERS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "ERMapper .ers Labelled" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_ers.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/ers.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ers" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Int32 UInt32 "

--- a/gdal/frmts/fit/fitdataset.cpp
+++ b/gdal/frmts/fit/fitdataset.cpp
@@ -1350,7 +1350,7 @@ void GDALRegister_FIT()
     poDriver->SetDescription( "FIT" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "FIT Image" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/fit.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/fits/fitsdataset.cpp
+++ b/gdal/frmts/fits/fitsdataset.cpp
@@ -1579,7 +1579,7 @@ void GDALRegister_FITS()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Flexible Image Transport System" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#FITS" );
+                               "drivers/raster/fits.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte UInt16 Int16 UInt32 Int32 Float32 Float64" );
 

--- a/gdal/frmts/georaster/georaster_dataset.cpp
+++ b/gdal/frmts/georaster/georaster_dataset.cpp
@@ -2936,7 +2936,7 @@ void CPL_DLL GDALRegister_GEOR()
     poDriver->SetDescription(  "GeoRaster" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Oracle Spatial GeoRaster" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_georaster.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/georaster.html" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte UInt16 Int16 UInt32 Int32 Float32 "

--- a/gdal/frmts/gff/gff_dataset.cpp
+++ b/gdal/frmts/gff/gff_dataset.cpp
@@ -345,7 +345,7 @@ void GDALRegister_GFF()
     poDriver->SetMetadataItem(
         GDAL_DMD_LONGNAME,
         "Ground-based SAR Applications Testbed File Format (.gff)");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_various.html#GFF");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/gff.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "gff");
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
     poDriver->pfnOpen = GFFDataset::Open;

--- a/gdal/frmts/gif/biggifdataset.cpp
+++ b/gdal/frmts/gif/biggifdataset.cpp
@@ -387,7 +387,7 @@ void GDALRegister_BIGGIF()
      poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                 "Graphics Interchange Format (.gif)" );
      poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                                "frmt_gif.html" );
+                                "drivers/raster/gif.html" );
      poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "gif" );
      poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/gif" );
      poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/gif/gifdataset.cpp
+++ b/gdal/frmts/gif/gifdataset.cpp
@@ -713,7 +713,7 @@ void GDALRegister_GIF()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Graphics Interchange Format (.gif)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_gif.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gif.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "gif" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/gif" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );

--- a/gdal/frmts/grass/grass57dataset.cpp
+++ b/gdal/frmts/grass/grass57dataset.cpp
@@ -1053,7 +1053,7 @@ void GDALRegister_GRASS()
     poDriver->SetDescription( "GRASS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "GRASS Rasters (5.7+)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_grass.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/grass.html" );
 
     poDriver->pfnOpen = GRASSDataset::Open;
 

--- a/gdal/frmts/grass/grassdataset.cpp
+++ b/gdal/frmts/grass/grassdataset.cpp
@@ -585,7 +585,7 @@ void GDALRegister_GRASS()
     poDriver->SetDescription( "GRASS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "GRASS Database Rasters" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_grass.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/grass.html" );
 
     poDriver->pfnOpen = GRASSDataset::Open;
 

--- a/gdal/frmts/grib/gribdataset.cpp
+++ b/gdal/frmts/grib/gribdataset.cpp
@@ -2258,7 +2258,7 @@ GDALGRIBDriver::GDALGRIBDriver() : bHasFullInitMetadata(false)
 {
     aosMetadata.SetNameValue(GDAL_DCAP_RASTER, "YES");
     aosMetadata.SetNameValue(GDAL_DMD_LONGNAME, "GRIdded Binary (.grb, .grb2)");
-    aosMetadata.SetNameValue(GDAL_DMD_HELPTOPIC, "frmt_grib.html");
+    aosMetadata.SetNameValue(GDAL_DMD_HELPTOPIC, "drivers/raster/grib.html");
     aosMetadata.SetNameValue(GDAL_DMD_EXTENSIONS, "grb grb2 grib2");
     aosMetadata.SetNameValue(GDAL_DCAP_VIRTUALIO, "YES");
 

--- a/gdal/frmts/gsg/gs7bgdataset.cpp
+++ b/gdal/frmts/gsg/gs7bgdataset.cpp
@@ -1318,7 +1318,7 @@ void GDALRegister_GS7BG()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Golden Software 7 Binary Grid (.grd)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#GS7BG" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gs7bg.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "grd" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Float32 Float64" );

--- a/gdal/frmts/gsg/gsagdataset.cpp
+++ b/gdal/frmts/gsg/gsagdataset.cpp
@@ -1728,7 +1728,7 @@ void GDALRegister_GSAG()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Golden Software ASCII Grid (.grd)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#GSAG" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gsag.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "grd" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Int32 UInt32 "

--- a/gdal/frmts/gsg/gsbgdataset.cpp
+++ b/gdal/frmts/gsg/gsbgdataset.cpp
@@ -1116,7 +1116,7 @@ void GDALRegister_GSBG()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Golden Software Binary Grid (.grd)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#GSBG" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gsbg.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "grd" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Float32" );

--- a/gdal/frmts/gta/gtadataset.cpp
+++ b/gdal/frmts/gta/gtadataset.cpp
@@ -1704,7 +1704,7 @@ void GDALRegister_GTA()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Generic Tagged Arrays (.gta)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_gta.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gta.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "gta" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte UInt16 Int16 UInt32 Int32 Float32 Float64 "

--- a/gdal/frmts/gtiff/cogdriver.cpp
+++ b/gdal/frmts/gtiff/cogdriver.cpp
@@ -876,7 +876,7 @@ void GDALRegister_COG()
     poDriver->SetDescription( "COG" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Cloud optimized GeoTIFF generator" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "cog.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/cog.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONOPTIONLIST, osOptions );
 
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -19926,7 +19926,7 @@ void GDALRegister_GTiff()
     poDriver->SetDescription( "GTiff" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "GeoTIFF" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_gtiff.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gtiff.html" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/tiff" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "tif" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "tif tiff" );

--- a/gdal/frmts/gxf/gxfdataset.cpp
+++ b/gdal/frmts/gxf/gxfdataset.cpp
@@ -384,7 +384,7 @@ void GDALRegister_GXF()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "GeoSoft Grid Exchange Format" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#GXF" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gxf.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "gxf" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/hdf4/hdf4dataset.cpp
+++ b/gdal/frmts/hdf4/hdf4dataset.cpp
@@ -1349,7 +1349,7 @@ void GDALRegister_HDF4()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Hierarchical Data Format Release 4" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_hdf4.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/hdf4.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "hdf" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
 

--- a/gdal/frmts/hdf4/hdf4imagedataset.cpp
+++ b/gdal/frmts/hdf4/hdf4imagedataset.cpp
@@ -4088,7 +4088,7 @@ void GDALRegister_HDF4Image()
     poDriver->SetDescription( "HDF4Image" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "HDF4 Dataset" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_hdf4.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/hdf4.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Int32 UInt32 "
                                "Float32 Float64" );

--- a/gdal/frmts/hdf5/bagdataset.cpp
+++ b/gdal/frmts/hdf5/bagdataset.cpp
@@ -4495,7 +4495,7 @@ void GDALRegister_BAG()
     poDriver->SetDescription("BAG");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Bathymetry Attributed Grid");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_bag.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/bag.html");
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "bag");
 

--- a/gdal/frmts/hdf5/hdf5dataset.cpp
+++ b/gdal/frmts/hdf5/hdf5dataset.cpp
@@ -99,7 +99,7 @@ void GDALRegister_HDF5()
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME,
                               "Hierarchical Data Format Release 5");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_hdf5.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/hdf5.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSIONS, "h5 hdf5");
     poDriver->SetMetadataItem(GDAL_DMD_SUBDATASETS, "YES");
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/hdf5/hdf5imagedataset.cpp
+++ b/gdal/frmts/hdf5/hdf5imagedataset.cpp
@@ -600,7 +600,7 @@ void GDALRegister_HDF5Image()
     poDriver->SetDescription("HDF5Image");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "HDF5 Dataset");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_hdf5.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/hdf5.html");
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = HDF5ImageDataset::Open;

--- a/gdal/frmts/hf2/hf2dataset.cpp
+++ b/gdal/frmts/hf2/hf2dataset.cpp
@@ -1175,7 +1175,7 @@ void GDALRegister_HF2()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "HF2/HFZ heightfield raster" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_hf2.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/hf2.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "hf2" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONOPTIONLIST,
 "<CreationOptionList>"

--- a/gdal/frmts/hfa/hfadataset.cpp
+++ b/gdal/frmts/hfa/hfadataset.cpp
@@ -6094,7 +6094,7 @@ void GDALRegister_HFA()
     poDriver->SetDescription("HFA");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Erdas Imagine Images (.img)");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_hfa.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/hfa.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "img");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES,
                               "Byte Int16 UInt16 Int32 UInt32 Float32 Float64 "

--- a/gdal/frmts/idrisi/IdrisiDataset.cpp
+++ b/gdal/frmts/idrisi/IdrisiDataset.cpp
@@ -3429,7 +3429,7 @@ void GDALRegister_IDRISI()
     poDriver->SetDescription( "RST" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, rstVERSION );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_Idrisi.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/Idrisi.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, extRST );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 Float32" );

--- a/gdal/frmts/ignfheightasciigrid/ignfheightasciigrid.cpp
+++ b/gdal/frmts/ignfheightasciigrid/ignfheightasciigrid.cpp
@@ -709,7 +709,7 @@ void GDALRegister_IGNFHeightASCIIGrid()
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME,
                               "IGN France height correction ASCII Grid");
     poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
-                              "frmt_various.html#IGNFHeightASCIIGrid");
+                              "drivers/raster/ignfheightasciigrid.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSIONS, "mnt txt gra");
 
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");

--- a/gdal/frmts/ingr/IntergraphDataset.cpp
+++ b/gdal/frmts/ingr/IntergraphDataset.cpp
@@ -883,7 +883,7 @@ void GDALRegister_INGR()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Intergraph Raster" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_IntergraphRaster.html" );
+                               "drivers/raster/intergraphraster.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 Int32 Float32 Float64" );

--- a/gdal/frmts/iris/irisdataset.cpp
+++ b/gdal/frmts/iris/irisdataset.cpp
@@ -1160,7 +1160,7 @@ void GDALRegister_IRIS()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "IRIS data (.PPI, .CAPPi etc)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#IRIS" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/iris.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ppi" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/jaxapalsar/jaxapalsardataset.cpp
+++ b/gdal/frmts/jaxapalsar/jaxapalsardataset.cpp
@@ -658,7 +658,7 @@ void GDALRegister_PALSARJaxa()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "JAXA PALSAR Product Reader (Level 1.1/1.5)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_palsar.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/palsar.html" );
 
     poDriver->pfnOpen = PALSARJaxaDataset::Open;
     poDriver->pfnIdentify = PALSARJaxaDataset::Identify;

--- a/gdal/frmts/jdem/jdemdataset.cpp
+++ b/gdal/frmts/jdem/jdemdataset.cpp
@@ -370,7 +370,7 @@ void GDALRegister_JDEM()
     poDriver->SetDescription("JDEM");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Japanese DEM (.mem)");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_various.html#JDEM");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/jdem.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "mem");
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
 

--- a/gdal/frmts/jp2kak/jp2kakdataset.cpp
+++ b/gdal/frmts/jp2kak/jp2kakdataset.cpp
@@ -2703,7 +2703,7 @@ void GDALRegister_JP2KAK()
     poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "YES");
     poDriver->SetMetadataItem(
         GDAL_DMD_LONGNAME, "JPEG-2000 (based on Kakadu " KDU_CORE_VERSION ")");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_jp2kak.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/jp2kak.html");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES, "Byte Int16 UInt16");
     poDriver->SetMetadataItem(GDAL_DMD_MIMETYPE, "image/jp2");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "jp2 j2k");

--- a/gdal/frmts/jp2lura/jp2luradataset.cpp
+++ b/gdal/frmts/jp2lura/jp2luradataset.cpp
@@ -2511,7 +2511,7 @@ void GDALRegister_JP2Lura()
         poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                 "JPEG-2000 driver based on Lurawave library" );
         poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                                   "frmt_jp2lura.html" );
+                                   "drivers/raster/jp2lura.html" );
         poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/jp2" );
         poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "jp2" );
         poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "jp2 j2f j2k" );

--- a/gdal/frmts/jpeg/jpgdataset.cpp
+++ b/gdal/frmts/jpeg/jpgdataset.cpp
@@ -3527,7 +3527,7 @@ void GDALRegister_JPEG()
     poDriver->SetDescription("JPEG");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "JPEG JFIF");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_jpeg.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/jpeg.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "jpg");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSIONS, "jpg jpeg");
     poDriver->SetMetadataItem(GDAL_DMD_MIMETYPE, "image/jpeg");

--- a/gdal/frmts/jpeg2000/jpeg2000dataset.cpp
+++ b/gdal/frmts/jpeg2000/jpeg2000dataset.cpp
@@ -1393,7 +1393,7 @@ void GDALRegister_JPEG2000()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "JPEG-2000 part 1 (ISO/IEC 15444-1), "
                                "based on Jasper library" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_jpeg2000.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/jpeg2000.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Int32 UInt32" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/jp2" );

--- a/gdal/frmts/jpegls/jpeglsdataset.cpp
+++ b/gdal/frmts/jpegls/jpeglsdataset.cpp
@@ -772,7 +772,7 @@ void GDALRegister_JPEGLS()
     poDriver->SetDescription( "JPEGLS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "JPEGLS" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_jpegls.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/jpegls.html" );
     // poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/jls" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "jls" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte Int16" );

--- a/gdal/frmts/jpipkak/jpipkakdataset.cpp
+++ b/gdal/frmts/jpipkak/jpipkakdataset.cpp
@@ -1506,7 +1506,7 @@ void GDALRegister_JPIPKAK()
     poDriver->SetDescription( "JPIPKAK" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "JPIP (based on Kakadu)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_jpipkak.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/jpipkak.html" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/jpp-stream" );
 
     poDriver->pfnOpen = JPIPKAKDataset::Open;

--- a/gdal/frmts/kea/keadriver.cpp
+++ b/gdal/frmts/kea/keadriver.cpp
@@ -47,7 +47,7 @@ void GDALRegister_KEA()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "KEA Image Format (.kea)" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "kea" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_kea.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/kea.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Int32 UInt32 "
                                "Float32 Float64" );

--- a/gdal/frmts/l1b/l1bdataset.cpp
+++ b/gdal/frmts/l1b/l1bdataset.cpp
@@ -3550,7 +3550,7 @@ void GDALRegister_L1B()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "NOAA Polar Orbiter Level 1b Data Set" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_l1b.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/l1b.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
 

--- a/gdal/frmts/leveller/levellerdataset.cpp
+++ b/gdal/frmts/leveller/levellerdataset.cpp
@@ -1561,7 +1561,7 @@ void GDALRegister_Leveller()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ter" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Leveller heightfield" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_leveller.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/leveller.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnIdentify = LevellerDataset::Identify;

--- a/gdal/frmts/map/mapdataset.cpp
+++ b/gdal/frmts/map/mapdataset.cpp
@@ -498,7 +498,7 @@ void GDALRegister_MAP()
     poDriver->SetDescription( "MAP" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "OziExplorer .MAP" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_map.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/map.html" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/mbtiles/mbtilesdataset.cpp
+++ b/gdal/frmts/mbtiles/mbtilesdataset.cpp
@@ -3543,7 +3543,7 @@ void GDALRegister_MBTiles()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "MBTiles" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_mbtiles.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/mbtiles.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "mbtiles" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );
 

--- a/gdal/frmts/mrf/mrf_util.cpp
+++ b/gdal/frmts/mrf/mrf_util.cpp
@@ -597,7 +597,7 @@ void GDALRegister_mrf()
     GDALDriver *driver = new GDALDriver();
     driver->SetDescription("MRF");
     driver->SetMetadataItem(GDAL_DMD_LONGNAME, "Meta Raster Format");
-    driver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_marfa.html");
+    driver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/marfa.html");
     driver->SetMetadataItem(GDAL_DMD_EXTENSION, "mrf");
     driver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
 

--- a/gdal/frmts/mrsid/mrsiddataset.cpp
+++ b/gdal/frmts/mrsid/mrsiddataset.cpp
@@ -3551,7 +3551,7 @@ void GDALRegister_MrSID()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Multi-resolution Seamless Image Database "
                                "(MrSID)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_mrsid.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/mrsid.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "sid" );
 
 #ifdef MRSID_ESDK
@@ -3592,7 +3592,7 @@ void GDALRegister_MrSID()
     poDriver->SetDescription( "JP2MrSID" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "MrSID JPEG2000" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_jp2mrsid.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/jp2mrsid.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "jp2" );
 
 #ifdef MRSID_ESDK

--- a/gdal/frmts/mrsid_lidar/gdal_MG4Lidar.cpp
+++ b/gdal/frmts/mrsid_lidar/gdal_MG4Lidar.cpp
@@ -927,7 +927,7 @@ void GDALRegister_MG4Lidar()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "MrSID Generation 4 / Lidar (.sid)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,  "frmt_mrsid_lidar.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,  "drivers/raster/mg4lidar.html" );
 
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "view" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Float64" );

--- a/gdal/frmts/msgn/msgndataset.cpp
+++ b/gdal/frmts/msgn/msgndataset.cpp
@@ -559,7 +559,7 @@ void GDALRegister_MSGN()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "EUMETSAT Archive native (.nat)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_msgn.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/msgn.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "nat" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/netcdf/gmtdataset.cpp
+++ b/gdal/frmts/netcdf/gmtdataset.cpp
@@ -640,7 +640,7 @@ void GDALRegister_GMT()
     poDriver->SetDescription( "GMT" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "GMT NetCDF Grid Format" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#GMT" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/gmt.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "nc" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Int16 Int32 Float32 Float64" );

--- a/gdal/frmts/netcdf/netcdfdataset.cpp
+++ b/gdal/frmts/netcdf/netcdfdataset.cpp
@@ -9102,7 +9102,7 @@ void GDALRegister_netCDF()
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Network Common Data Format");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_netcdf.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/netcdf.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "nc");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST,
 "<CreationOptionList>"

--- a/gdal/frmts/ngsgeoid/ngsgeoiddataset.cpp
+++ b/gdal/frmts/ngsgeoid/ngsgeoiddataset.cpp
@@ -467,7 +467,7 @@ void GDALRegister_NGSGEOID()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "NOAA NGS Geoid Height Grids" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_ngsgeoid.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/ngsgeoid.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "bin" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/nitf/ecrgtocdataset.cpp
+++ b/gdal/frmts/nitf/ecrgtocdataset.cpp
@@ -1190,7 +1190,7 @@ void GDALRegister_ECRGTOC()
     poDriver->pfnOpen = ECRGTOCDataset::Open;
 
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#ECRGTOC" );
+                               "drivers/raster/ecrgtoc.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "xml" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );

--- a/gdal/frmts/nitf/nitfdataset.cpp
+++ b/gdal/frmts/nitf/nitfdataset.cpp
@@ -6162,7 +6162,7 @@ void GDALRegister_NITF()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "National Imagery Transmission Format" );
 
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_nitf.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/nitf.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ntf" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,

--- a/gdal/frmts/nitf/rpftocdataset.cpp
+++ b/gdal/frmts/nitf/rpftocdataset.cpp
@@ -1344,7 +1344,7 @@ void GDALRegister_RPFTOC()
     poDriver->pfnOpen = RPFTOCDataset::Open;
 
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#RPFTOC" );
+                               "drivers/raster/rpftoc.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "toc" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );

--- a/gdal/frmts/northwood/grcdataset.cpp
+++ b/gdal/frmts/northwood/grcdataset.cpp
@@ -411,7 +411,7 @@ void GDALRegister_NWT_GRC()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Northwood Classified Grid Format .grc/.tab");
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#northwood_grc" );
+                               "drivers/raster/nwtgrd.html#driver-capabilities-nwt-grc" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "grc" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/northwood/grddataset.cpp
+++ b/gdal/frmts/northwood/grddataset.cpp
@@ -1036,7 +1036,7 @@ void GDALRegister_NWT_GRD() {
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME,
             "Northwood Numeric Grid Format .grd/.tab");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_nwtgrd.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/nwtgrd.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "grd");
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES, "Float32");

--- a/gdal/frmts/openjpeg/openjpegdataset.cpp
+++ b/gdal/frmts/openjpeg/openjpegdataset.cpp
@@ -4102,7 +4102,7 @@ void GDALRegister_JP2OpenJPEG()
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "JPEG-2000 driver based on OpenJPEG library" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_jp2openjpeg.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/jp2openjpeg.html" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/jp2" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "jp2" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "jp2 j2k" );

--- a/gdal/frmts/ozi/ozidataset.cpp
+++ b/gdal/frmts/ozi/ozidataset.cpp
@@ -680,7 +680,7 @@ void GDALRegister_OZI()
     poDriver->SetDescription( "OZI" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "OziExplorer Image File" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_ozi.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/ozi.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = OZIDataset::Open;

--- a/gdal/frmts/pcidsk/pcidskdataset2.cpp
+++ b/gdal/frmts/pcidsk/pcidskdataset2.cpp
@@ -2251,7 +2251,7 @@ void GDALRegister_PCIDSK()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "PCIDSK Database File" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_pcidsk.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/pcidsk.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "pix" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,

--- a/gdal/frmts/pcraster/pcrastermisc.cpp
+++ b/gdal/frmts/pcraster/pcrastermisc.cpp
@@ -47,7 +47,7 @@ void GDALRegister_PCRaster()
 
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "PCRaster Raster File");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES, "Byte Int32 Float32");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_various.html#PCRaster");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/pcraster.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "map" );
 
     poDriver->pfnOpen = PCRasterDataset::open;

--- a/gdal/frmts/pdf/pdfdataset.cpp
+++ b/gdal/frmts/pdf/pdfdataset.cpp
@@ -7201,7 +7201,7 @@ void GDALRegister_PDF()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Geospatial PDF" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_pdf.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/pdf.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "pdf" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,

--- a/gdal/frmts/pds/isis2dataset.cpp
+++ b/gdal/frmts/pds/isis2dataset.cpp
@@ -1177,7 +1177,7 @@ void GDALRegister_ISIS2()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "USGS Astrogeology ISIS cube (Version 2)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_isis2.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/isis2.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Float32 Float64");

--- a/gdal/frmts/pds/isis3dataset.cpp
+++ b/gdal/frmts/pds/isis3dataset.cpp
@@ -4341,7 +4341,7 @@ void GDALRegister_ISIS3()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "USGS Astrogeology ISIS cube (Version 3)" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_isis3.html" );
+                               "drivers/raster/isis3.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "lbl cub" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,

--- a/gdal/frmts/pds/pds4dataset.cpp
+++ b/gdal/frmts/pds/pds4dataset.cpp
@@ -4554,7 +4554,7 @@ void GDALRegister_PDS4()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "NASA Planetary Data System 4" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_pds4.html" );
+                               "drivers/raster/pds4.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "xml" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte UInt16 Int16 UInt32 Int32 Float32 "

--- a/gdal/frmts/pds/pdsdataset.cpp
+++ b/gdal/frmts/pds/pdsdataset.cpp
@@ -1571,7 +1571,7 @@ void GDALRegister_PDS()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "NASA Planetary Data System" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_pds.html" );
+                               "drivers/raster/pds.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = PDSDataset::Open;

--- a/gdal/frmts/pds/vicardataset.cpp
+++ b/gdal/frmts/pds/vicardataset.cpp
@@ -2922,7 +2922,7 @@ void GDALRegister_VICAR()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "MIPL VICAR file" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_vicar.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/vicar.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 Int32 Float32 Float64 CFloat32" );

--- a/gdal/frmts/plmosaic/plmosaicdataset.cpp
+++ b/gdal/frmts/plmosaic/plmosaicdataset.cpp
@@ -1490,7 +1490,7 @@ void GDALRegister_PLMOSAIC()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Planet Labs Mosaics API" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_plmosaic.html" );
+                               "drivers/raster/plmosaic.html" );
 
     poDriver->SetMetadataItem( GDAL_DMD_CONNECTION_PREFIX, "PLMOSAIC:" );
 

--- a/gdal/frmts/png/pngdataset.cpp
+++ b/gdal/frmts/png/pngdataset.cpp
@@ -2071,7 +2071,7 @@ void GDALRegister_PNG()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Portable Network Graphics" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#PNG" );
+                               "drivers/raster/png.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "png" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/png" );
 

--- a/gdal/frmts/prf/phprfdataset.cpp
+++ b/gdal/frmts/prf/phprfdataset.cpp
@@ -663,7 +663,7 @@ void GDALRegister_PRF()
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "prf" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_prf.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/prf.html" );
     poDriver->pfnIdentify = PhPrfDataset::Identify;
     poDriver->pfnOpen = PhPrfDataset::Open;
     GDALRegisterDriver( (GDALDriverH)poDriver );

--- a/gdal/frmts/r/rdataset.cpp
+++ b/gdal/frmts/r/rdataset.cpp
@@ -602,7 +602,7 @@ void GDALRegister_R()
     poDriver->SetDescription("R");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "R Object Data Store");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_r.html");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/r.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "rda");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES, "Float32");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST,

--- a/gdal/frmts/rasdaman/rasdamandataset.cpp
+++ b/gdal/frmts/rasdaman/rasdamandataset.cpp
@@ -709,7 +709,7 @@ void GDALRegister_RASDAMAN()
   poDriver->SetDescription( "RASDAMAN" );
   poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
   poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "RASDAMAN" );
-  poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_rasdaman.html" );
+  poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/rasdaman.html" );
 
   poDriver->pfnOpen = RasdamanDataset::Open;
 

--- a/gdal/frmts/rasterlite/rasterlitedataset.cpp
+++ b/gdal/frmts/rasterlite/rasterlitedataset.cpp
@@ -1471,7 +1471,7 @@ void GDALRegister_Rasterlite()
     poDriver->SetDescription( "Rasterlite" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Rasterlite" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_rasterlite.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/rasterlite.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "sqlite" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,

--- a/gdal/frmts/raw/ace2dataset.cpp
+++ b/gdal/frmts/raw/ace2dataset.cpp
@@ -394,7 +394,7 @@ void GDALRegister_ACE2()
     poDriver->SetDescription( "ACE2" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "ACE2" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#ACE2" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/ace2.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ACE2" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/raw/btdataset.cpp
+++ b/gdal/frmts/raw/btdataset.cpp
@@ -978,7 +978,7 @@ void GDALRegister_BT()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                    "VTP .bt (Binary Terrain) 1.3 Format" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                                   "frmt_various.html#BT" );
+                                   "drivers/raster/bt.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "bt" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Int16 Int32 Float32" );

--- a/gdal/frmts/raw/byndataset.cpp
+++ b/gdal/frmts/raw/byndataset.cpp
@@ -894,7 +894,7 @@ void GDALRegister_BYN()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Natural Resources Canada's Geoid" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "byn err" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_byn.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/byn.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Int16 Int32" );
 
     poDriver->pfnOpen = BYNDataset::Open;

--- a/gdal/frmts/raw/doq1dataset.cpp
+++ b/gdal/frmts/raw/doq1dataset.cpp
@@ -410,7 +410,7 @@ void GDALRegister_DOQ1()
     poDriver->SetDescription( "DOQ1" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "USGS DOQ (Old Style)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#DOQ1" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/doq1.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = DOQ1Dataset::Open;

--- a/gdal/frmts/raw/doq2dataset.cpp
+++ b/gdal/frmts/raw/doq2dataset.cpp
@@ -478,7 +478,7 @@ void GDALRegister_DOQ2()
     poDriver->SetDescription( "DOQ2" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "USGS DOQ (New Style)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#DOQ2" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/doq2.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = DOQ2Dataset::Open;

--- a/gdal/frmts/raw/ehdrdataset.cpp
+++ b/gdal/frmts/raw/ehdrdataset.cpp
@@ -2077,7 +2077,7 @@ void GDALRegister_EHdr()
     poDriver->SetDescription("EHdr");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "ESRI .hdr Labelled");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_various.html#EHdr");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/ehdr.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "bil");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES,
                               "Byte Int16 UInt16 Int32 UInt32 Float32");

--- a/gdal/frmts/raw/eirdataset.cpp
+++ b/gdal/frmts/raw/eirdataset.cpp
@@ -562,7 +562,7 @@ void GDALRegister_EIR()
     poDriver->SetDescription( "EIR" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Erdas Imagine Raw" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#EIR" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/eir.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = EIRDataset::Open;

--- a/gdal/frmts/raw/envidataset.cpp
+++ b/gdal/frmts/raw/envidataset.cpp
@@ -2807,7 +2807,7 @@ void GDALRegister_ENVI()
     poDriver->SetDescription("ENVI");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "ENVI .hdr Labelled");
-    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "frmt_various.html#ENVI");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/raster/envi.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES,
                               "Byte Int16 UInt16 Int32 UInt32 "

--- a/gdal/frmts/raw/fastdataset.cpp
+++ b/gdal/frmts/raw/fastdataset.cpp
@@ -1207,7 +1207,7 @@ void GDALRegister_FAST()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "EOSAT FAST Format" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_fast.html" );
+                               "drivers/raster/fast.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = FASTDataset::Open;

--- a/gdal/frmts/raw/fujibasdataset.cpp
+++ b/gdal/frmts/raw/fujibasdataset.cpp
@@ -249,7 +249,7 @@ void GDALRegister_FujiBAS()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Fuji BAS Scanner Image" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#FujiBAS" );
+                               "drivers/raster/fujibas.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = FujiBASDataset::Open;

--- a/gdal/frmts/raw/genbindataset.cpp
+++ b/gdal/frmts/raw/genbindataset.cpp
@@ -913,7 +913,7 @@ void GDALRegister_GenBin()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Generic Binary (.hdr Labelled)" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#GenBin" );
+                               "drivers/raster/genbin.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = GenBinDataset::Open;

--- a/gdal/frmts/raw/gscdataset.cpp
+++ b/gdal/frmts/raw/gscdataset.cpp
@@ -227,8 +227,8 @@ void GDALRegister_GSC()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "GSC Geogrid" );
-    // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-    //                            "drivers/raster/gsc.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
+                               "drivers/raster/gsc.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = GSCDataset::Open;

--- a/gdal/frmts/raw/gscdataset.cpp
+++ b/gdal/frmts/raw/gscdataset.cpp
@@ -228,7 +228,7 @@ void GDALRegister_GSC()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "GSC Geogrid" );
     // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-    //                            "frmt_various.html#GSC" );
+    //                            "drivers/raster/gsc.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = GSCDataset::Open;

--- a/gdal/frmts/raw/hkvdataset.cpp
+++ b/gdal/frmts/raw/hkvdataset.cpp
@@ -1879,7 +1879,7 @@ void GDALRegister_HKV()
     poDriver->SetDescription( "MFF2" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Vexcel MFF2 (HKV) Raster" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_mff2.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/mff2.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Int32 UInt32 CInt16 "
                                "CInt32 Float32 Float64 CFloat32 CFloat64" );

--- a/gdal/frmts/raw/idadataset.cpp
+++ b/gdal/frmts/raw/idadataset.cpp
@@ -1088,7 +1088,7 @@ void GDALRegister_IDA()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Image Data and Analysis" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#IDA" );
+                               "drivers/raster/ida.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/raw/iscedataset.cpp
+++ b/gdal/frmts/raw/iscedataset.cpp
@@ -936,7 +936,7 @@ void GDALRegister_ISCE()
 
     poDriver->SetDescription( "ISCE" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "ISCE raster" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#ISCE" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/isce.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 Int32 Int64 Float32"
                                " Float64 CInt16 CInt64 CFloat32 "

--- a/gdal/frmts/raw/landataset.cpp
+++ b/gdal/frmts/raw/landataset.cpp
@@ -1042,7 +1042,7 @@ void GDALRegister_LAN()
     poDriver->SetDescription( "LAN" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Erdas .LAN/.GIS" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#LAN" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/lan.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte Int16" );
 

--- a/gdal/frmts/raw/lcpdataset.cpp
+++ b/gdal/frmts/raw/lcpdataset.cpp
@@ -1680,7 +1680,7 @@ void GDALRegister_LCP()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "FARSITE v.4 Landscape File (.lcp)" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "lcp" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_lcp.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/lcp.html" );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/raw/mffdataset.cpp
+++ b/gdal/frmts/raw/mffdataset.cpp
@@ -1648,7 +1648,7 @@ void GDALRegister_MFF()
     poDriver->SetDescription( "MFF" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Vexcel MFF Raster" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#MFF" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/mff.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "hdr" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte UInt16 Float32 CInt16 CFloat32" );

--- a/gdal/frmts/raw/ndfdataset.cpp
+++ b/gdal/frmts/raw/ndfdataset.cpp
@@ -449,7 +449,7 @@ void GDALRegister_NDF()
     poDriver->SetDescription( "NDF" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "NLAPS Data Format" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#NDF" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/ndf.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnIdentify = NDFDataset::Identify;

--- a/gdal/frmts/raw/pauxdataset.cpp
+++ b/gdal/frmts/raw/pauxdataset.cpp
@@ -1112,7 +1112,7 @@ void GDALRegister_PAux()
     poDriver->SetDescription( "PAux" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "PCI .aux Labelled" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#PAux" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/paux.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Float32" );
     poDriver->SetMetadataItem(

--- a/gdal/frmts/raw/pnmdataset.cpp
+++ b/gdal/frmts/raw/pnmdataset.cpp
@@ -425,7 +425,7 @@ void GDALRegister_PNM()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Portable Pixmap Format (netpbm)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#PNM" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/pnm.html" );
     // pgm : grey
     // ppm : RGB
     // pnm : ??

--- a/gdal/frmts/raw/roipacdataset.cpp
+++ b/gdal/frmts/raw/roipacdataset.cpp
@@ -941,7 +941,7 @@ void GDALRegister_ROIPAC()
     poDriver->SetDescription( "ROI_PAC" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "ROI_PAC raster" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#ROI_PAC" );
+                               "drivers/raster/roi_pac.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/raw/rrasterdataset.cpp
+++ b/gdal/frmts/raw/rrasterdataset.cpp
@@ -1559,7 +1559,7 @@ void GDALRegister_RRASTER()
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "grd" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "R Raster" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#RRASTER" );
+                               "drivers/raster/rraster.html" );
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES,
                               "Byte Int16 UInt16 Int32 UInt32 Float32 Float64");
 

--- a/gdal/frmts/raw/snodasdataset.cpp
+++ b/gdal/frmts/raw/snodasdataset.cpp
@@ -522,7 +522,7 @@ void GDALRegister_SNODAS()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Snow Data Assimilation System" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#SNODAS" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/snodas.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "hdr" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/rda/rdadataset.cpp
+++ b/gdal/frmts/rda/rdadataset.cpp
@@ -2284,7 +2284,7 @@ void GDALRegister_RDA()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "DigitalGlobe Raster Data Access driver" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_rda.html" );
+                               "drivers/raster/rda.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "dgrda" );
 
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,

--- a/gdal/frmts/rdb/rdbdataset.cpp
+++ b/gdal/frmts/rdb/rdbdataset.cpp
@@ -778,7 +778,7 @@ void GDALRegister_RDB()
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "RIEGL RDB Map Pixel (.mpx)");
     // TODO:
     // poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
-    //                          "");
+    //                          "drivers/raster/");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "mpx");
     poDriver->pfnOpen = rdb::RDBDataset::Open;
     poDriver->pfnIdentify = rdb::RDBDataset::Identify;

--- a/gdal/frmts/rdb/rdbdataset.cpp
+++ b/gdal/frmts/rdb/rdbdataset.cpp
@@ -776,9 +776,8 @@ void GDALRegister_RDB()
     poDriver->SetDescription("RDB");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "RIEGL RDB Map Pixel (.mpx)");
-    // TODO:
-    // poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
-    //                          "drivers/raster/");
+    poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
+                              "drivers/raster/rdb.html");
     poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "mpx");
     poDriver->pfnOpen = rdb::RDBDataset::Open;
     poDriver->pfnIdentify = rdb::RDBDataset::Identify;

--- a/gdal/frmts/rik/rikdataset.cpp
+++ b/gdal/frmts/rik/rikdataset.cpp
@@ -1303,7 +1303,7 @@ void GDALRegister_RIK()
     poDriver->SetDescription( "RIK" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Swedish Grid RIK (.rik)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#RIK" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/rik.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "rik" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/rmf/rmfdataset.cpp
+++ b/gdal/frmts/rmf/rmfdataset.cpp
@@ -3070,7 +3070,7 @@ void GDALRegister_RMF()
     poDriver->SetDescription( "RMF" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Raster Matrix Format" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_rmf.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/rmf.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "rsw" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 Int32 Float64" );

--- a/gdal/frmts/rs2/rs2dataset.cpp
+++ b/gdal/frmts/rs2/rs2dataset.cpp
@@ -1509,7 +1509,7 @@ void GDALRegister_RS2()
     poDriver->SetDescription( "RS2" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "RadarSat 2 XML Product" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_rs2.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/rs2.html" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/safe/safedataset.cpp
+++ b/gdal/frmts/safe/safedataset.cpp
@@ -1219,7 +1219,7 @@ void GDALRegister_SAFE()
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "Sentinel-1 SAR SAFE Product" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_safe.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/safe.html" );
 
     poDriver->pfnOpen = SAFEDataset::Open;
     poDriver->pfnIdentify = SAFEDataset::Identify;

--- a/gdal/frmts/saga/sagadataset.cpp
+++ b/gdal/frmts/saga/sagadataset.cpp
@@ -1104,7 +1104,7 @@ void GDALRegister_SAGA()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "SAGA GIS Binary Grid (.sdat, .sg-grd-z)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#SAGA" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/sdat.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSIONS, "sdat sg-grd-z" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte Int16 "
                                "UInt16 Int32 UInt32 Float32 Float64" );

--- a/gdal/frmts/sde/sdedataset.cpp
+++ b/gdal/frmts/sde/sdedataset.cpp
@@ -509,7 +509,7 @@ void GDALRegister_SDE()
     poDriver->SetDescription( "SDE" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "ESRI ArcSDE" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,  "frmt_various.html#SDE" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,  "drivers/raster/sde.html" );
 
     poDriver->pfnOpen = SDEDataset::Open;
 

--- a/gdal/frmts/sdts/sdtsdataset.cpp
+++ b/gdal/frmts/sdts/sdtsdataset.cpp
@@ -406,7 +406,7 @@ void GDALRegister_SDTS()
     poDriver->SetDescription( "SDTS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "SDTS Raster" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#SDTS" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/sdts.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ddf" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/sentinel2/sentinel2dataset.cpp
+++ b/gdal/frmts/sentinel2/sentinel2dataset.cpp
@@ -3835,7 +3835,7 @@ void GDALRegister_SENTINEL2()
 #endif
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Sentinel 2" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_sentinel2.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/sentinel2.html" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
 
 #ifdef GDAL_DMD_OPENOPTIONLIST

--- a/gdal/frmts/sgi/sgidataset.cpp
+++ b/gdal/frmts/sgi/sgidataset.cpp
@@ -842,7 +842,7 @@ void GDALRegister_SGI()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "SGI Image File Format 1.0" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "rgb" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/rgb" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#SGI" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/sgi.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 

--- a/gdal/frmts/sigdem/sigdemdataset.cpp
+++ b/gdal/frmts/sigdem/sigdemdataset.cpp
@@ -99,7 +99,7 @@ void GDALRegister_SIGDEM() {
         poDriver->SetMetadataItem(GDAL_DMD_LONGNAME,
                 "Scaled Integer Gridded DEM .sigdem");
         poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
-                "frmt_various.html#SIGDEM");
+                "drivers/raster/sigdem.html");
         poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "sigdem");
 
         poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");

--- a/gdal/frmts/srtmhgt/srtmhgtdataset.cpp
+++ b/gdal/frmts/srtmhgt/srtmhgtdataset.cpp
@@ -671,7 +671,7 @@ void GDALRegister_SRTMHGT()
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "SRTMHGT File Format");
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "hgt");
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
-                               "frmt_various.html#SRTMHGT" );
+                               "drivers/raster/srtmhgt.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gdal/frmts/terragen/terragendataset.cpp
+++ b/gdal/frmts/terragen/terragendataset.cpp
@@ -1078,7 +1078,7 @@ void GDALRegister_Terragen()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "ter" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Terragen heightfield" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_terragen.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/terragen.html" );
 
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONOPTIONLIST,
 "<CreationOptionList>"

--- a/gdal/frmts/til/tildataset.cpp
+++ b/gdal/frmts/til/tildataset.cpp
@@ -489,7 +489,7 @@ void GDALRegister_TIL()
     poDriver->SetDescription( "TIL" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "EarthWatch .TIL" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_til.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/til.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = TILDataset::Open;

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -2095,7 +2095,7 @@ void GDALRegister_TileDB()
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_SUBCREATECOPY, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "TileDB" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_tiledb.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/tiledb.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte UInt16 Int16 UInt32 Int32 Float32 "
                                "Float64 CInt16 CInt32 CFloat32 CFloat64" );

--- a/gdal/frmts/tsx/tsxdataset.cpp
+++ b/gdal/frmts/tsx/tsxdataset.cpp
@@ -802,7 +802,7 @@ void GDALRegister_TSX()
     poDriver->SetDescription( "TSX" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "TerraSAR-X Product" );
-    // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/tsx.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/tsx.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = TSXDataset::Open;

--- a/gdal/frmts/tsx/tsxdataset.cpp
+++ b/gdal/frmts/tsx/tsxdataset.cpp
@@ -802,7 +802,7 @@ void GDALRegister_TSX()
     poDriver->SetDescription( "TSX" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "TerraSAR-X Product" );
-    // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_tsx.html" );
+    // poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/tsx.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = TSXDataset::Open;

--- a/gdal/frmts/usgsdem/usgsdemdataset.cpp
+++ b/gdal/frmts/usgsdem/usgsdemdataset.cpp
@@ -948,7 +948,7 @@ void GDALRegister_USGSDEM()
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "dem" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
                                "USGS Optional ASCII DEM (and CDED)" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_usgsdem.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/usgsdem.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Int16" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONOPTIONLIST,
 "<CreationOptionList>"

--- a/gdal/frmts/vrt/vrtdriver.cpp
+++ b/gdal/frmts/vrt/vrtdriver.cpp
@@ -409,7 +409,7 @@ void GDALRegister_VRT()
     poDriver->SetMetadataItem( GDAL_DCAP_MULTIDIM_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Virtual Raster" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "vrt" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "gdal_vrttut.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/vrt.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
                                "Byte Int16 UInt16 Int32 UInt32 Float32 Float64 "
                                "CInt16 CInt32 CFloat32 CFloat64" );

--- a/gdal/frmts/wcs/wcsdataset.cpp
+++ b/gdal/frmts/wcs/wcsdataset.cpp
@@ -1689,7 +1689,7 @@ void GDALRegister_WCS()
     poDriver->SetDescription( "WCS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "OGC Web Coverage Service" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_wcs.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/wcs.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
 

--- a/gdal/frmts/webp/webpdataset.cpp
+++ b/gdal/frmts/webp/webpdataset.cpp
@@ -874,7 +874,7 @@ void GDALRegister_WEBP()
     poDriver->SetDescription( "WEBP" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "WEBP" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_webp.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/webp.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "webp" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/webp" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );

--- a/gdal/frmts/wms/wmsdriver.cpp
+++ b/gdal/frmts/wms/wmsdriver.cpp
@@ -1063,7 +1063,7 @@ void GDALRegister_WMS()
     poDriver->SetDescription("WMS");
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "OGC Web Map Service" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_wms.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/wms.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
 

--- a/gdal/frmts/wmts/wmtsdataset.cpp
+++ b/gdal/frmts/wmts/wmtsdataset.cpp
@@ -2235,7 +2235,7 @@ void GDALRegister_WMTS()
     poDriver->SetDescription( "WMTS" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "OGC Web Map Tile Service" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_wmts.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/wmts.html" );
 
     poDriver->SetMetadataItem( GDAL_DMD_CONNECTION_PREFIX, "WMTS:" );
 

--- a/gdal/frmts/xpm/xpmdataset.cpp
+++ b/gdal/frmts/xpm/xpmdataset.cpp
@@ -442,7 +442,7 @@ void GDALRegister_XPM()
     poDriver->SetDescription( "XPM" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "X11 PixMap Format" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#XPM" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/xpm.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "xpm" );
     poDriver->SetMetadataItem( GDAL_DMD_MIMETYPE, "image/x-xpixmap" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte" );

--- a/gdal/frmts/xyz/xyzdataset.cpp
+++ b/gdal/frmts/xyz/xyzdataset.cpp
@@ -1435,7 +1435,7 @@ void GDALRegister_XYZ()
     poDriver->SetDescription( "XYZ" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "ASCII Gridded XYZ" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_xyz.html" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/xyz.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "xyz" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONOPTIONLIST,
 "<CreationOptionList>"

--- a/gdal/frmts/zmap/zmapdataset.cpp
+++ b/gdal/frmts/zmap/zmapdataset.cpp
@@ -724,7 +724,7 @@ void GDALRegister_ZMap()
     poDriver->SetDescription( "ZMap" );
     poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "ZMap Plus Grid" );
-    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "frmt_various.html#ZMap" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/zmap.html" );
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "dat" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 


### PR DESCRIPTION
## What does this PR do?

This PR makes the drivers' GDAL_DMD_HELPTOPIC data point to the actual driver info path on gdal.org. 

This improves the user experience when this meta data is actually used in UI or for deriving documentation such as https://www.openorienteering.org/mapper-manual/pages/gdal.html.

The changed links use real paths instead of relying on redirects. Thus the change also solves the problem of the current anchors (`frmt_various.html#ZMap`) not being effective due to the redirect to `drivers/raster/index.html`.

The vector drivers do not have generic links. But like most other raster drivers, they depend on redirects on gdal.org.

## Tasklist

 - [x] Revise raster drivers which point to `frmt_various#...` at the moment.
 - [x] Revise raster drivers which point to `frmt_...` at the moment.
 - [x] Revise commented-out help topics

## Known issues

There is no page for the GTX raster driver. Left unchanged.
https://github.com/OSGeo/gdal/blob/9e2dd00d241151338ddf53dddac905d5017713b9/gdal/frmts/raw/gtxdataset.cpp#L471-L472
