### PR TITLE
Elasticsearch: rename driver to Elasticsearch, update geometry type name for Points

### DIFF
--- a/autotest/ogr/ogr_elasticsearch.py
+++ b/autotest/ogr/ogr_elasticsearch.py
@@ -3,7 +3,7 @@
 # $Id$
 #
 # Project:  GDAL/OGR Test Suite
-# Purpose:  ElasticSearch driver testing (with fake server)
+# Purpose:  Elasticsearch driver testing (with fake server)
 # Author:   Even Rouault <even dot rouault at spatialys.com>
 #
 ###############################################################################
@@ -48,14 +48,14 @@ def test_ogr_elasticsearch_init():
     ogrtest.srs_wgs84 = osr.SpatialReference()
     ogrtest.srs_wgs84.SetFromUserInput('WGS84')
 
-    ogrtest.elasticsearch_drv = ogr.GetDriverByName('ElasticSearch')
+    ogrtest.elasticsearch_drv = ogr.GetDriverByName('Elasticsearch')
     if ogrtest.elasticsearch_drv is None:
         pytest.skip()
 
     gdal.SetConfigOption('CPL_CURL_ENABLE_VSIMEM', 'YES')
 
 ###############################################################################
-# Test writing into an nonexistent ElasticSearch datastore.
+# Test writing into an nonexistent Elasticsearch datastore.
 
 
 def test_ogr_elasticsearch_nonexistent_server():
@@ -65,36 +65,36 @@ def test_ogr_elasticsearch_nonexistent_server():
     with gdaltest.error_handler():
         ds = ogrtest.elasticsearch_drv.CreateDataSource(
             '/vsimem/nonexistent_host')
-    assert ds is None, 'managed to open nonexistent ElasticSearch datastore.'
+    assert ds is None, 'managed to open nonexistent Elasticsearch datastore.'
 
     with gdaltest.error_handler():
         ds = ogrtest.elasticsearch_drv.Open('ES:/vsimem/nonexistent_host')
-    assert ds is None, 'managed to open nonexistent ElasticSearch datastore.'
+    assert ds is None, 'managed to open nonexistent Elasticsearch datastore.'
 
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch", """{}""")
 
     with gdaltest.error_handler():
         ds = ogrtest.elasticsearch_drv.Open('ES:/vsimem/fakeelasticsearch')
-    assert ds is None, 'managed to open invalid ElasticSearch datastore.'
+    assert ds is None, 'managed to open invalid Elasticsearch datastore.'
 
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch", """{"version":null}""")
 
     with gdaltest.error_handler():
         ds = ogrtest.elasticsearch_drv.Open('ES:/vsimem/fakeelasticsearch')
-    assert ds is None, 'managed to open invalid ElasticSearch datastore.'
+    assert ds is None, 'managed to open invalid Elasticsearch datastore.'
 
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch", """{"version":{}}""")
 
     with gdaltest.error_handler():
         ds = ogrtest.elasticsearch_drv.Open('ES:/vsimem/fakeelasticsearch')
-    assert ds is None, 'managed to open invalid ElasticSearch datastore.'
+    assert ds is None, 'managed to open invalid Elasticsearch datastore.'
 
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch",
                            """{"version":{"number":null}}""")
 
     with gdaltest.error_handler():
         ds = ogrtest.elasticsearch_drv.Open('ES:/vsimem/fakeelasticsearch')
-    assert ds is None, 'managed to open invalid ElasticSearch datastore.'
+    assert ds is None, 'managed to open invalid Elasticsearch datastore.'
 
 ###############################################################################
 # Simple test
@@ -109,7 +109,7 @@ def test_ogr_elasticsearch_1():
 
     ds = ogrtest.elasticsearch_drv.CreateDataSource(
         "/vsimem/fakeelasticsearch")
-    assert ds is not None, 'did not managed to open ElasticSearch datastore'
+    assert ds is not None, 'did not managed to open Elasticsearch datastore'
 
     assert ds.TestCapability(ogr.ODsCCreateLayer) != 0
     assert ds.TestCapability(ogr.ODsCDeleteLayer) != 0
@@ -237,7 +237,7 @@ def test_ogr_elasticsearch_1():
 
     # Success
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/foo2/FeatureCollection&POSTFIELDS={ "geometry": { "type": "POINT", "coordinates": [ 0.0, 1.0 ] }, "type": "Feature", "properties": { "str_field": "a", "int_field": 1, "int64_field": 123456789012, "real_field": 2.34, "boolean_field": true, "strlist_field": [ "a", "b" ], "intlist_field": [ 1, 2 ], "int64list_field": [ 123456789012, 2 ], "reallist_field": [ 1.23, 4.56 ], "date_field": "2015\/08\/12", "datetime_field": "2015\/08\/12 12:34:56.789", "time_field": "12:34:56.789", "binary_field": "ASNGV4mrze8=" } }', '{ "_id": "my_id" }')
+        '/vsimem/fakeelasticsearch/foo2/FeatureCollection&POSTFIELDS={ "geometry": { "type": "Point", "coordinates": [ 0.0, 1.0 ] }, "type": "Feature", "properties": { "str_field": "a", "int_field": 1, "int64_field": 123456789012, "real_field": 2.34, "boolean_field": true, "strlist_field": [ "a", "b" ], "intlist_field": [ 1, 2 ], "int64list_field": [ 123456789012, 2 ], "reallist_field": [ 1.23, 4.56 ], "date_field": "2015\/08\/12", "datetime_field": "2015\/08\/12 12:34:56.789", "time_field": "12:34:56.789", "binary_field": "ASNGV4mrze8=" } }', '{ "_id": "my_id" }')
     ret = lyr.CreateFeature(feat)
     assert ret == 0
     assert feat['_id'] == 'my_id'
@@ -284,7 +284,7 @@ def test_ogr_elasticsearch_1():
                          'GEOM_MAPPING_TYPE=GEO_POINT', 'GEOM_PRECISION=1m', 'BULK_INSERT=NO'])
 
     gdal.FileFromMemBuffer(
-        '/vsimem/fakeelasticsearch/foo3/FeatureCollection&POSTFIELDS={ "ogc_fid": 1, "geometry": { "type": "POINT", "coordinates": [ 0.5, 0.5 ] }, "type": "Feature", "properties": { } }', '{}')
+        '/vsimem/fakeelasticsearch/foo3/FeatureCollection&POSTFIELDS={ "ogc_fid": 1, "geometry": { "type": "Point", "coordinates": [ 0.5, 0.5 ] }, "type": "Feature", "properties": { } }', '{}')
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt('LINESTRING(0 0,1 1)'))
     ret = lyr.CreateFeature(feat)
@@ -344,7 +344,7 @@ def test_ogr_elasticsearch_2():
 
     ds = ogrtest.elasticsearch_drv.CreateDataSource(
         "/vsimem/fakeelasticsearch")
-    assert ds is not None, 'did not managed to open ElasticSearch datastore'
+    assert ds is not None, 'did not managed to open Elasticsearch datastore'
 
     gdal.FileFromMemBuffer(
         '/vsimem/fakeelasticsearch/foo&CUSTOMREQUEST=PUT', '{}')
@@ -387,7 +387,7 @@ def test_ogr_elasticsearch_3():
 
     ds = ogrtest.elasticsearch_drv.CreateDataSource(
         "/vsimem/fakeelasticsearch")
-    assert ds is not None, 'did not managed to open ElasticSearch datastore'
+    assert ds is not None, 'did not managed to open Elasticsearch datastore'
 
     gdal.FileFromMemBuffer(
         '/vsimem/fakeelasticsearch/name_laundering&CUSTOMREQUEST=PUT', '{}')
@@ -617,7 +617,7 @@ def test_ogr_elasticsearch_4():
                 "type": "Feature",
                 "my_fid": 5,
                 "a_geopoint" : {
-                    "type": "POINT",
+                    "type": "Point",
                     "coordinates": [2,49]
                 },
                 "a_geoshape": {
@@ -664,7 +664,7 @@ def test_ogr_elasticsearch_4():
             "_source": {
                 "type": "Feature",
                 "a_geopoint" : {
-                    "type": "POINT",
+                    "type": "Point",
                     "coordinates": [2,49]
                 },
                 "a_geoshape": {
@@ -762,7 +762,7 @@ def test_ogr_elasticsearch_4():
             "_source": {
                 "type": "Feature",
                 "a_geoshape" : {
-                    "type": "POINT",
+                    "type": "Point",
                     "coordinates": [2,49]
                 },
                 "properties": {
@@ -786,7 +786,7 @@ def test_ogr_elasticsearch_4():
             "_source": {
                 "type": "Feature",
                 "a_geopoint" : {
-                    "type": "POINT",
+                    "type": "Point",
                     "coordinates": [2,49]
                 },
                 "properties": {
@@ -825,7 +825,7 @@ def test_ogr_elasticsearch_4():
             "_source": {
                 "type": "Feature",
                 "a_geoshape" : {
-                    "type": "POINT",
+                    "type": "Point",
                     "coordinates": [2,49]
                 },
                 "properties": {
@@ -1050,7 +1050,7 @@ def test_ogr_elasticsearch_5():
         {
             "_source": {
                 "a_geopoint" : {
-                    "type": "POINT",
+                    "type": "Point",
                     "coordinates": [2,49]
                 },
                 "a_geoshape": {
@@ -1113,7 +1113,7 @@ def test_ogr_elasticsearch_5():
 
     f['_id'] = 'my_id'
     gdal.FileFromMemBuffer(
-        """/vsimem/fakeelasticsearch/non_geojson/my_mapping/my_id&POSTFIELDS={ "a_geoshape": { "type": "linestring", "coordinates": [ [ 2.0, 49.0 ], [ 3.0, 50.0 ] ] }, "a_geopoint": { "type": "POINT", "coordinates": [ 2.0, 49.0 ] }, "another_geopoint": [ 2.5, 49.5 ], "superobject": { "another_geoshape": { "type": "point", "coordinates": [ 3.0, 50.0 ] }, "another_geoshape2": { "type": "point", "coordinates": [ 2.0, 50.0 ] }, "subfield": "5", "subobject": { "subfield": "foo", "another_subfield": 6 } }, "str_field": "foo" }""", "{}")
+        """/vsimem/fakeelasticsearch/non_geojson/my_mapping/my_id&POSTFIELDS={ "a_geoshape": { "type": "linestring", "coordinates": [ [ 2.0, 49.0 ], [ 3.0, 50.0 ] ] }, "a_geopoint": { "type": "Point", "coordinates": [ 2.0, 49.0 ] }, "another_geopoint": [ 2.5, 49.5 ], "superobject": { "another_geoshape": { "type": "point", "coordinates": [ 3.0, 50.0 ] }, "another_geoshape2": { "type": "point", "coordinates": [ 2.0, 50.0 ] }, "subfield": "5", "subobject": { "subfield": "foo", "another_subfield": 6 } }, "str_field": "foo" }""", "{}")
     ret = lyr.SetFeature(f)
     assert ret == 0
 
@@ -1142,9 +1142,9 @@ def test_ogr_elasticsearch_5():
     f['superobject.subfield2'] = 'foo'
     f['superobject.another_geoshape3'] = ogr.CreateGeometryFromWkt(
         'POINT (3 50)')
-    gdal.FileFromMemBuffer("""/vsimem/fakeelasticsearch/non_geojson/_mapping/my_mapping&POSTFIELDS={ "my_mapping": { "properties": { "str_field": { "type": "string" }, "superobject": { "properties": { "subfield": { "type": "string" }, "subobject": { "properties": { "subfield": { "type": "string" }, "another_subfield": { "type": "integer" } } }, "subfield2": { "type": "string" }, "another_geoshape": { "type": "geo_shape" }, "another_geoshape2": { "type": "geo_shape" }, "another_geoshape3": { "properties": { "type": { "type": "string" }, "coordinates": { "type": "geo_point" } } } } }, "another_field": { "type": "string" }, "a_geoshape": { "type": "geo_shape" }, "a_geopoint": { "properties": { "type": { "type": "string" }, "coordinates": { "type": "geo_point" } } }, "another_geopoint": { "type": "geo_point" } }, "_meta": { "geomfields": { "superobject.another_geoshape2": "POINT" } } } }""", '{}')
+    gdal.FileFromMemBuffer("""/vsimem/fakeelasticsearch/non_geojson/_mapping/my_mapping&POSTFIELDS={ "my_mapping": { "properties": { "str_field": { "type": "string" }, "superobject": { "properties": { "subfield": { "type": "string" }, "subobject": { "properties": { "subfield": { "type": "string" }, "another_subfield": { "type": "integer" } } }, "subfield2": { "type": "string" }, "another_geoshape": { "type": "geo_shape" }, "another_geoshape2": { "type": "geo_shape" }, "another_geoshape3": { "properties": { "type": { "type": "string" }, "coordinates": { "type": "geo_point" } } } } }, "another_field": { "type": "string" }, "a_geoshape": { "type": "geo_shape" }, "a_geopoint": { "properties": { "type": { "type": "string" }, "coordinates": { "type": "geo_point" } } }, "another_geopoint": { "type": "geo_point" } }, "_meta": { "geomfields": { "superobject.another_geoshape2": "Point" } } } }""", '{}')
     gdal.FileFromMemBuffer(
-        """/vsimem/fakeelasticsearch/non_geojson/my_mapping&POSTFIELDS={ "superobject": { "another_geoshape3": { "type": "POINT", "coordinates": [ 3.0, 50.0 ] }, "subfield2": "foo" } }""", "{}")
+        """/vsimem/fakeelasticsearch/non_geojson/my_mapping&POSTFIELDS={ "superobject": { "another_geoshape3": { "type": "Point", "coordinates": [ 3.0, 50.0 ] }, "subfield2": "foo" } }""", "{}")
     gdal.FileFromMemBuffer(
         """/vsimem/fakeelasticsearch/non_geojson/my_mapping/_count?pretty""", "{}")
     lyr.CreateFeature(f)
@@ -1376,7 +1376,7 @@ def test_ogr_elasticsearch_8():
     assert ret == 0
 
 ###############################################################################
-# Test ElasticSearch 5.X
+# Test Elasticsearch 5.X
 
 
 def test_ogr_elasticsearch_9():

--- a/gdal/doc/source/drivers/vector/elasticsearch.rst
+++ b/gdal/doc/source/drivers/vector/elasticsearch.rst
@@ -1,19 +1,19 @@
 .. _vector.elasticsearch:
 
-ElasticSearch: Geographically Encoded Objects for ElasticSearch
+Elasticsearch: Geographically Encoded Objects for Elasticsearch
 ===============================================================
 
-.. shortname:: ElasticSearch
+.. shortname:: Elasticsearch
 
 .. build_dependencies:: libcurl
 
 | Driver is read-write starting with GDAL 2.1 (was write only in GDAL
   2.0 or earlier)
-| As of GDAL 2.1, ElasticSearch 1.X and, partially, 2.X versions are
+| As of GDAL 2.1, Elasticsearch 1.X and, partially, 2.X versions are
   supported (5.0 known not to work). GDAL 2.2 adds supports for
-  ElasticSearch 2.X and 5.X
+  Elasticsearch 2.X and 5.X
 
-`ElasticSearch <http://elasticsearch.org/>`__ is an Enterprise-level
+`Elasticsearch <http://elasticsearch.org/>`__ is an Enterprise-level
 search engine for a variety of data sources. It supports full-text
 indexing and geospatial querying of those data in a fast and efficient
 manor using a predefined REST API.
@@ -29,7 +29,7 @@ Opening dataset name syntax
 ---------------------------
 
 Starting with GDAL 2.1, the driver supports reading existing indices
-from a ElasticSearch host. There are two main possible syntaxes to open
+from a Elasticsearch host. There are two main possible syntaxes to open
 a dataset:
 
 -  Using *ES:http://hostname:port* (where port is typically 9200)
@@ -56,41 +56,41 @@ The open options available are :
    Defaults to 'ogc_fid'
 -  **FORWARD_HTTP_HEADERS_FROM_ENV**\ =string. (GDAL >= 3.1)
    Can be used to specify HTTP headers,
-   typically for authentication purposes, that must be passed to ElasticSearch.
+   typically for authentication purposes, that must be passed to Elasticsearch.
    The value of string is a comma separated list of http_header_name=env_variable_name,
    where http_header_name is the name of a HTTP header and env_variable_name
    the name of the environment variable / configuration option from which th value
    of the HTTP header should be retrieved. This is intended for a use case where
-   the OGR ElasticSearch driver is invoked from a web server that stores the HTTP
+   the OGR Elasticsearch driver is invoked from a web server that stores the HTTP
    headers of incoming request into environment variables.
    The ES_FORWARD_HTTP_HEADERS_FROM_ENV configuration option can also be used.
 
-ElasticSearch vs OGR concepts
+Elasticsearch vs OGR concepts
 -----------------------------
 
-Each mapping type inside a ElasticSearch index will be considered as a
-OGR layer. A ElasticSearch document is considered as a OGR feature.
+Each mapping type inside a Elasticsearch index will be considered as a
+OGR layer. A Elasticsearch document is considered as a OGR feature.
 
 Field definitions
 -----------------
 
 Fields are dynamically mapped from the input OGR data source. However,
-the driver will take advantage of advanced options within ElasticSearch
+the driver will take advantage of advanced options within Elasticsearch
 as defined in a `field mapping
 file <http://code.google.com/p/ogr2elasticsearch/wiki/ModifyingtheIndex>`__.
 
 The mapping file allows you to modify the mapping according to the
-`ElasticSearch field-specific
+`Elasticsearch field-specific
 types <http://www.elasticsearch.org/guide/reference/mapping/core-types.html>`__.
 There are many options to choose from, however, most of the
 functionality is based on all the different things you are able to do
-with text fields within ElasticSearch.
+with text fields within Elasticsearch.
 
 ::
 
-   ogr2ogr -progress --config ES_WRITEMAP /path/to/file/map.txt -f "ElasticSearch" http://localhost:9200 my_shapefile.shp
+   ogr2ogr -progress --config ES_WRITEMAP /path/to/file/map.txt -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
 
-The ElasticSearch writer supports the following Configuration Options.
+The Elasticsearch writer supports the following Configuration Options.
 Starting with GDAL 2.1, layer creation options are also available and
 should be preferred:
 
@@ -104,7 +104,7 @@ should be preferred:
    layer creation option should rather be used.
 -  **ES_BULK**\ =5000000. Identifies the maximum size in bytes of the
    buffer to store documents to be inserted at a time. Lower record
-   counts help with memory consumption within ElasticSearch but take
+   counts help with memory consumption within Elasticsearch but take
    longer to insert. Starting with GDAL 2.1, the **BULK_SIZE** layer
    creation option should rather be used.
 -  **ES_OVERWRITE**\ =1. Overwrites the current index by deleting an
@@ -122,7 +122,7 @@ and the "center" of the polygon is used as value of the point. Starting
 with GDAL 2.1,
 `geo_shape <https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-geo-shape-type.html>`__
 is used to store all geometry types (except curve geometries that are
-not handled by ElasticSearch and will be approximated to their linear
+not handled by Elasticsearch and will be approximated to their linear
 equivalents).
 
 Filtering
@@ -132,11 +132,11 @@ The driver will forward any spatial filter set with SetSpatialFilter()
 to the server.
 
 Starting with GDAL 2.2, SQL attribute filters set with
-SetAttributeFilter() are converted to `ElasticSearch filter
+SetAttributeFilter() are converted to `Elasticsearch filter
 syntax <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filters.html>`__.
 They will be combined with the potentially defined spatial filter.
 
-It is also possible to directly use a ElasticSearch filter by setting
+It is also possible to directly use a Elasticsearch filter by setting
 the string passed to SetAttributeFilter() as a JSon serialized object,
 e.g.
 
@@ -190,7 +190,7 @@ ExecuteSQL() interface
 ----------------------
 
 Starting with GDAL 2.2, SQL requests, involving a single layer, with
-WHERE and ORDER BY statements will be translated as ElasticSearch
+WHERE and ORDER BY statements will be translated as Elasticsearch
 queries.
 
 Otherwise, if specifying "ES" as the dialect of ExecuteSQL(), a JSon
@@ -204,7 +204,7 @@ contain the \_index and \_type special fields to indicate the provenance
 of the features.
 
 The following filter can be used to restrict the search to the "poly"
-index and its "FeatureCollection" type mapping (ElasticSearch 1.X and
+index and its "FeatureCollection" type mapping (Elasticsearch 1.X and
 2.X)
 
 ::
@@ -223,7 +223,7 @@ index and its "FeatureCollection" type mapping (ElasticSearch 1.X and
        }
    }
 
-For ElasticSearch 5.X (works also with 2.X) :
+For Elasticsearch 5.X (works also with 2.X) :
 
 ::
 
@@ -251,7 +251,7 @@ Getting metadata
 Getting feature count is efficient.
 
 Getting extent is efficient, only on geometry columns mapped to
-ElasticSearch type geo_point. On geo_shape fields, feature retrieval of
+Elasticsearch type geo_point. On geo_shape fields, feature retrieval of
 the whole layer is done, which might be slow.
 
 Write support
@@ -291,7 +291,7 @@ options:
    will be written as GeoJSON Feature objects. If another mapping name
    is chosen, a more "flat" structure will be used.  This option is
    ignored when converting to Elasticsearch >=7 (see `Removal of mapping types <https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html>`__).
-   With ElasticSearch 7 or later, a "flat" structure is always used.
+   With Elasticsearch 7 or later, a "flat" structure is always used.
 -  **MAPPING**\ =filename or JSon. Filename from which to read a
    user-defined mapping, or mapping as serialized JSon.
 -  **WRITE_MAPPING**\ =filename. Creates a mapping file that can be
@@ -306,7 +306,7 @@ options:
    the index. In case there are several type mappings, the whole index
    need to be destroyed (it is unsafe to destroy a mapping and the
    documents that use it, since they might be used by other mappings.
-   This was possible in ElasticSearch 1.X, but no longer in later
+   This was possible in Elasticsearch 1.X, but no longer in later
    versions).
 -  **GEOMETRY_NAME**\ =name. Name of geometry column. Defaults to
    'geometry'.
@@ -340,14 +340,14 @@ options:
    `"index"
    property <https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-core-types.html>`__
    of the field mapping set to "not_analyzed" (the default in
-   ElasticSearch is "analyzed"). A same field should not be specified
+   Elasticsearch is "analyzed"). A same field should not be specified
    both in NOT_ANALYZED_FIELDS and NOT_INDEXED_FIELDS. Starting with
    GDAL 2.2, the {ALL} value can be used to designate all fields. This
    option is without effect if MAPPING is specified.
 -  **NOT_INDEXED_FIELDS**\ =List of comma separated field names that
    should not be indexed. Those fields will have their `"index"
    property <https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-core-types.html>`__
-   of the field mapping set to "no" (the default in ElasticSearch is
+   of the field mapping set to "no" (the default in Elasticsearch is
    "analyzed"). A same field should not be specified both in
    NOT_ANALYZED_FIELDS and NOT_INDEXED_FIELDS. This option is without
    effect if MAPPING is specified.
@@ -398,14 +398,14 @@ Examples
 
    C:\GDAL_on_Windows>ogrinfo ES: my_type -where "{\"query\": { \"match\": { \"properties.NAME\": \"Helsinki\" } } }"
 
-**Load an ElasticSearch index with a shapefile:**
+**Load an Elasticsearch index with a shapefile:**
 
 ::
 
-   ogr2ogr -f "ElasticSearch" http://localhost:9200 my_shapefile.shp
+   ogr2ogr -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
 
 **Create a Mapping File:** The mapping file allows you to modify the
-mapping according to the `ElasticSearch field-specific
+mapping according to the `Elasticsearch field-specific
 types <http://www.elasticsearch.org/guide/reference/mapping/core-types.html>`__.
 There are many options to choose from, however, most of the
 functionality is based on all the different things you are able to do
@@ -413,26 +413,26 @@ with text fields.
 
 ::
 
-   ogr2ogr -progress --config ES_WRITEMAP /path/to/file/map.txt -f "ElasticSearch" http://localhost:9200 my_shapefile.shp
+   ogr2ogr -progress --config ES_WRITEMAP /path/to/file/map.txt -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
 
 or (GDAL >= 2.1):
 
 ::
 
-   ogr2ogr -progress -lco WRITE_MAPPING=/path/to/file/map.txt -f "ElasticSearch" http://localhost:9200 my_shapefile.shp
+   ogr2ogr -progress -lco WRITE_MAPPING=/path/to/file/map.txt -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
 
 **Read the Mapping File:** Reads the mapping file during the
 transformation
 
 ::
 
-   ogr2ogr -progress --config ES_META /path/to/file/map.txt -f "ElasticSearch" http://localhost:9200 my_shapefile.shp
+   ogr2ogr -progress --config ES_META /path/to/file/map.txt -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
 
 or (GDAL >= 2.1):
 
 ::
 
-   ogr2ogr -progress -lco MAPPING=/path/to/file/map.txt -f "ElasticSearch" http://localhost:9200 my_shapefile.shp
+   ogr2ogr -progress -lco MAPPING=/path/to/file/map.txt -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
 
 **Bulk Uploading (for larger datasets):** Bulk loading helps when
 uploading a lot of data. The integer value is the number of bytes that
@@ -441,20 +441,20 @@ considerations <https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk
 
 ::
 
-   ogr2ogr -progress --config ES_BULK 5000000 -f "ElasticSearch" http://localhost:9200 PG:"host=localhost user=postgres dbname=my_db password=password" "my_table" -nln thetable
+   ogr2ogr -progress --config ES_BULK 5000000 -f "Elasticsearch" http://localhost:9200 PG:"host=localhost user=postgres dbname=my_db password=password" "my_table" -nln thetable
 
 or (GDAL >= 2.1):
 
 ::
 
-   ogr2ogr -progress -lco BULK_SIZE=5000000 -f "ElasticSearch" http://localhost:9200 my_shapefile.shp
+   ogr2ogr -progress -lco BULK_SIZE=5000000 -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
 
 **Overwrite the current Index:** If specified, this will overwrite the
 current index. Otherwise, the data will be appended.
 
 ::
 
-   ogr2ogr -progress --config ES_OVERWRITE 1 -f "ElasticSearch" http://localhost:9200 PG:"host=localhost user=postgres dbname=my_db password=password" "my_table" -nln thetable
+   ogr2ogr -progress --config ES_OVERWRITE 1 -f "Elasticsearch" http://localhost:9200 PG:"host=localhost user=postgres dbname=my_db password=password" "my_table" -nln thetable
 
 or (GDAL >= 2.1):
 
@@ -465,6 +465,6 @@ or (GDAL >= 2.1):
 See Also
 --------
 
--  `Home page for ElasticSearch <http://elasticsearch.org/>`__
+-  `Home page for Elasticsearch <http://elasticsearch.org/>`__
 -  `Examples Wiki <http://code.google.com/p/ogr2elasticsearch/w/list>`__
 -  `Google Group <http://groups.google.com/group/ogr2elasticsearch>`__

--- a/gdal/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -1,7 +1,7 @@
 /******************************************************************************
  * $Id$
  *
- * Project:  ElasticSearch Translator
+ * Project:  Elasticsearch Translator
  * Purpose:
  * Author:
  *

--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Project:  ElasticSearch Translator
+ * Project:  Elasticsearch Translator
  * Purpose:
  * Author:
  *

--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticdriver.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Project:  ElasticSearch Translator
+ * Project:  Elasticsearch Translator
  * Purpose:
  * Author:
  *
@@ -32,23 +32,23 @@
 CPL_CVSID("$Id$")
 
 /************************************************************************/
-/*                   OGRElasticSearchDriverIdentify()                   */
+/*                   OGRElasticsearchDriverIdentify()                   */
 /************************************************************************/
 
-static int OGRElasticSearchDriverIdentify( GDALOpenInfo* poOpenInfo )
+static int OGRElasticsearchDriverIdentify( GDALOpenInfo* poOpenInfo )
 
 {
     return STARTS_WITH_CI(poOpenInfo->pszFilename, "ES:");
 }
 
 /************************************************************************/
-/*                  OGRElasticSearchDriverOpen()                        */
+/*                  OGRElasticsearchDriverOpen()                        */
 /************************************************************************/
 
-static GDALDataset* OGRElasticSearchDriverOpen( GDALOpenInfo* poOpenInfo )
+static GDALDataset* OGRElasticsearchDriverOpen( GDALOpenInfo* poOpenInfo )
 
 {
-    if( !OGRElasticSearchDriverIdentify(poOpenInfo) )
+    if( !OGRElasticsearchDriverIdentify(poOpenInfo) )
         return nullptr;
 
     OGRElasticDataSource *poDS = new OGRElasticDataSource();
@@ -61,9 +61,9 @@ static GDALDataset* OGRElasticSearchDriverOpen( GDALOpenInfo* poOpenInfo )
 }
 
 /************************************************************************/
-/*                     OGRElasticSearchDriverCreate()                   */
+/*                     OGRElasticsearchDriverCreate()                   */
 /************************************************************************/
-static GDALDataset* OGRElasticSearchDriverCreate( const char * pszName,
+static GDALDataset* OGRElasticsearchDriverCreate( const char * pszName,
                                                   CPL_UNUSED int nXSize,
                                                   CPL_UNUSED int nYSize,
                                                   CPL_UNUSED int nBands,
@@ -88,12 +88,12 @@ void RegisterOGRElastic() {
     if (!GDAL_CHECK_VERSION("OGR/Elastic Search driver"))
         return;
 
-    if( GDALGetDriverByName( "ElasticSearch" ) != nullptr )
+    if( GDALGetDriverByName( "Elasticsearch" ) != nullptr )
       return;
 
     GDALDriver  *poDriver = new GDALDriver();
 
-    poDriver->SetDescription( "ElasticSearch" );
+    poDriver->SetDescription( "Elasticsearch" );
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "Elastic Search" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drv_elasticsearch.html" );
@@ -151,9 +151,9 @@ void RegisterOGRElastic() {
                                "Time IntegerList Integer64List RealList "
                                "StringList Binary" );
 
-    poDriver->pfnIdentify = OGRElasticSearchDriverIdentify;
-    poDriver->pfnOpen = OGRElasticSearchDriverOpen;
-    poDriver->pfnCreate = OGRElasticSearchDriverCreate;
+    poDriver->pfnIdentify = OGRElasticsearchDriverIdentify;
+    poDriver->pfnOpen = OGRElasticsearchDriverOpen;
+    poDriver->pfnCreate = OGRElasticsearchDriverCreate;
 
     GetGDALDriverManager()->RegisterDriver( poDriver );
 }

--- a/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Project:  ElasticSearch Translator
+ * Project:  Elasticsearch Translator
  * Purpose:
  * Author:
  *
@@ -2093,7 +2093,7 @@ CPLString OGRElasticLayer::BuildJSonFromFeature(OGRFeature *poFeature)
                     {
                         json_object *geometry = json_object_new_object();
                         json_object_object_add(poContainer, pszLastComponent, geometry);
-                        json_object_object_add(geometry, "type", json_object_new_string("POINT"));
+                        json_object_object_add(geometry, "type", json_object_new_string("Point"));
                         json_object_object_add(geometry, "coordinates", coordinates);
                     }
                     else
@@ -3187,7 +3187,7 @@ OGRErr OGRElasticLayer::SetAttributeFilter(const char* pszFilter)
         if( !m_osESSearch.empty() )
         {
             CPLError(CE_Failure, CPLE_AppDefined,
-                "Setting an ElasticSearch filter on a resulting layer "
+                "Setting an Elasticsearch filter on a resulting layer "
                 "is not supported");
             return OGRERR_FAILURE;
         }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR updates point layer creation of geometry objects with `Point` instead of `POINT`.

In addition, while ES support is going through breaking changes in GDAL 3.1.x, renaming the driver name to `Elasticsearch` for consistency.

## What are related issues/pull requests?

- https://github.com/geopython/pygeoapi/pull/385#issuecomment-603290464

## Tasklist

 - [x] `s/POINT/Point/g`
 - [x] `s/ElasticSearch/Elasticsearch/g`
 - [x] Add/update test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu bionic
* Compiler: gcc
