### PR TITLE
gdal2tiles.py: Added support for XYZ tiles (OSM Slippy Map)

### DIFF
--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -157,7 +157,7 @@ def test_gdal2tiles_py_xyz():
     test_py_scripts.run_py_script(
         script_path,
         'gdal2tiles',
-        '-q --xyz --zoom=1 --webviewer=none out_gdal2tiles_smallworld_xyz.tif')
+        '-q --xyz --zoom=1 out_gdal2tiles_smallworld_xyz.tif')
     os.chdir('..')
 
     os.unlink('tmp/out_gdal2tiles_smallworld_xyz.tif')

--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -19,7 +19,7 @@ Synopsis
     gdal2tiles.py [-p profile] [-r resampling] [-s srs] [-z zoom]
                   [-e] [-a nodata] [-v] [-q] [-h] [-k] [-n] [-u url]
                   [-w webviewer] [-t title] [-c copyright]
-                  [--processes=NB_PROCESSES]
+                  [--processes=NB_PROCESSES] [--xyz]
                   --tilesize=TILESIZE
                   [-g googlekey] [-b bingkey] input_file [output_dir]
 
@@ -59,6 +59,12 @@ can publish a picture without proper georeferencing too.
 .. option:: -s <SRS>, --s_srs=<SRS>
 
   The spatial reference system used for the source input data.
+
+.. option:: --xyz
+
+  Generate XYZ tiles (OSM Slippy Map standard) instead of TSM
+
+  .. versionadded:: 3.1
 
 .. option:: -z <ZOOM>, --zoom=<ZOOM>
 

--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -735,7 +735,9 @@ def setup_input_srs(input_dataset, options):
             input_srs = osr.SpatialReference()
             input_srs.ImportFromWkt(input_srs_wkt)
 
-    input_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    if input_srs is not None:
+        input_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    
     return input_srs, input_srs_wkt
 
 


### PR DESCRIPTION
Added new `--xyz` option to generate tiles in the [OSM Slippy Map standard](https://wiki.openstreetmap.org/wiki/Slippy_Map) where the `Y` coordinate is flipped.

Also fixed incorrect indentation in a few places.

Fixes #2098 