### PR TITLE
Strip TOWGS84 when datum is known, in GTiff, Spatialite and GPKG drivers

### DIFF
--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -362,13 +362,23 @@ def test_tiff_srs_imagine_localcs_citation():
 # override the default coming from EPSG
 
 
-def test_tiff_srs_towgs84_override():
+def test_tiff_srs_towgs84_override_OSR_STRIP_TOWGS84_NO():
+
+    with gdaltest.config_option('OSR_STRIP_TOWGS84', 'NO'):
+        ds = gdal.Open('data/gtiff_towgs84_override.tif')
+        wkt = ds.GetProjectionRef()
+    ds = None
+
+    assert 'TOWGS84[584.8,67,400.3,0.105,0.013,-2.378,10.29]' in wkt, wkt
+
+
+def test_tiff_srs_towgs84_override_OSR_STRIP_TOWGS84_default():
 
     ds = gdal.Open('data/gtiff_towgs84_override.tif')
     wkt = ds.GetProjectionRef()
     ds = None
 
-    assert 'TOWGS84[584.8,67,400.3,0.105,0.013,-2.378,10.29]' in wkt, wkt
+    assert 'TOWGS84' not in wkt
 
 ###############################################################################
 # Test reading PCSCitationGeoKey (#7199)
@@ -689,9 +699,10 @@ def test_tiff_srs_towgs84_from_epsg_force_write_it():
         ds.SetSpatialRef(srs_in)
         ds = None
 
-    ds = gdal.Open(filename)
-    with gdaltest.config_option('OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG', 'NO'):
-        srs = ds.GetSpatialRef()
+    with gdaltest.config_option('OSR_STRIP_TOWGS84', 'NO'):
+        ds = gdal.Open(filename)
+        with gdaltest.config_option('OSR_ADD_TOWGS84_ON_IMPORT_FROM_EPSG', 'NO'):
+            srs = ds.GetSpatialRef()
     assert srs.HasTOWGS84()
 
 
@@ -726,8 +737,9 @@ def test_tiff_srs_towgs84_with_epsg_code_but_non_default_TOWGS84():
     ds.SetSpatialRef(srs_in)
     ds = None
 
-    ds = gdal.Open(filename)
-    srs = ds.GetSpatialRef()
+    with gdaltest.config_option('OSR_STRIP_TOWGS84', 'NO'):
+        ds = gdal.Open(filename)
+        srs = ds.GetSpatialRef()
     assert srs.GetTOWGS84() == (1,2,3,4,5,6,7)
 
 

--- a/gdal/frmts/gtiff/gt_wkt_srs.cpp
+++ b/gdal/frmts/gtiff/gt_wkt_srs.cpp
@@ -939,7 +939,17 @@ OGRSpatialReferenceH GTIFGetOGISDefnAsOSR( GTIF *hGTIF, GTIFDefn * psDefn )
     }
 
 #if !defined(GEO_NORMALIZE_DISABLE_TOWGS84)
-    if( psDefn->TOWGS84Count > 0 )
+    if( psDefn->TOWGS84Count > 0 &&
+        bGotFromEPSG  &&
+        CPLTestBool(CPLGetConfigOption("OSR_STRIP_TOWGS84", "YES")) )
+    {
+        CPLDebug("OSR", "TOWGS84 information has been removed. "
+                 "It can be kept by setting the OSR_STRIP_TOWGS84 "
+                 "configuration option to NO");
+    }
+    else if( psDefn->TOWGS84Count > 0 &&
+        (!bGotFromEPSG ||
+         !CPLTestBool(CPLGetConfigOption("OSR_STRIP_TOWGS84", "YES"))) )
     {
         if( bGotFromEPSG )
         {
@@ -1380,6 +1390,8 @@ OGRSpatialReferenceH GTIFGetOGISDefnAsOSR( GTIF *hGTIF, GTIFDefn * psDefn )
         }
         CPLFree(pszWKT);
     }
+
+    oSRS.StripTOWGS84IfKnownDatumAndAllowed();
 
     return OGRSpatialReference::ToHandle(oSRS.Clone());
 }

--- a/gdal/ogr/ogr_spatialref.h
+++ b/gdal/ogr/ogr_spatialref.h
@@ -248,6 +248,9 @@ class CPL_DLL OGRSpatialReference
     OGRErr      Validate() const;
     OGRErr      StripVertical();
 
+    bool        StripTOWGS84IfKnownDatumAndAllowed();
+    bool        StripTOWGS84IfKnownDatum();
+
     int         EPSGTreatsAsLatLong() const;
     int         EPSGTreatsAsNorthingEasting() const;
     int         GetAxesCount() const;

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -323,6 +323,7 @@ OGRSpatialReference* GDALGeoPackageDataset::GetSpatialRef(int iSrsId)
     }
 
     SQLResultFree(&oResult);
+    poSpatialRef->StripTOWGS84IfKnownDatumAndAllowed();
     m_oMapSrsIdToSrs[iSrsId] = poSpatialRef;
     poSpatialRef->Reference();
     return poSpatialRef;

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -3731,6 +3731,9 @@ OGRSpatialReference *OGRSQLiteDataSource::FetchSRS( int nId )
         }
     }
 
+    if( poSRS )
+        poSRS->StripTOWGS84IfKnownDatumAndAllowed();
+
 /* -------------------------------------------------------------------- */
 /*      Add to the cache.                                               */
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Addresses https://github.com/qgis/QGIS/issues/34993

Implements a simplified version of the idea mentioned in
https://lists.osgeo.org/pipermail/gdal-dev/2020-March/051881.html
with a variant of the more radical approach suggested in
https://lists.osgeo.org/pipermail/gdal-dev/2020-March/051885.html

That is the new method OGRSpatialReference::StripTOWGS84IfKnownDatumAndAllowed()
will remove TOWGS84 information from SRS whose datum name is known,
unless the OSR_STRIP_TOWGS84 configuration option is set to NO.
When TOWGS84 information is striped, a debug message is emitted.
