### PR TITLE
KEA: Backport thread safety fixes and nullptr tests from standalone driver

### DIFF
--- a/gdal/frmts/kea/keaband.cpp
+++ b/gdal/frmts/kea/keaband.cpp
@@ -42,9 +42,12 @@
 CPL_CVSID("$Id$")
 
 // constructor
-KEARasterBand::KEARasterBand( KEADataset *pDataset, int nSrcBand, GDALAccess eAccessIn, kealib::KEAImageIO *pImageIO, int *pRefCount ):
+KEARasterBand::KEARasterBand( KEADataset *pDataset, int nSrcBand, GDALAccess eAccessIn, kealib::KEAImageIO *pImageIO, LockedRefCount *pRefCount ):
     m_eKEADataType(pImageIO->getImageBandDataType(nSrcBand)) // get the data type as KEA enum
 {
+    this->m_hMutex = CPLCreateMutex();
+    CPLReleaseMutex( this->m_hMutex );
+
     this->poDS = pDataset; // our pointer onto the dataset
     this->nBand = nSrcBand; // this is the band we are
     this->eDataType = KEA_to_GDAL_Type( m_eKEADataType );       // convert to GDAL enum
@@ -66,9 +69,9 @@ KEARasterBand::KEARasterBand( KEADataset *pDataset, int nSrcBand, GDALAccess eAc
 
     // grab the imageio class and its refcount
     this->m_pImageIO = pImageIO;
-    this->m_pnRefCount = pRefCount;
+    this->m_pRefCount = pRefCount;
     // increment the refcount as we now have a reference to imageio
-    (*this->m_pnRefCount)++;
+    this->m_pRefCount->IncRef();
 
     // Initialize overview variables
     m_nOverviews = 0;
@@ -93,32 +96,34 @@ KEARasterBand::KEARasterBand( KEADataset *pDataset, int nSrcBand, GDALAccess eAc
 // destructor
 KEARasterBand::~KEARasterBand()
 {
-    // destroy RAT if any
-    delete this->m_pAttributeTable;
-    // destroy color table if any
-    delete this->m_pColorTable;
-    // destroy the metadata
-    CSLDestroy(this->m_papszMetadataList);
-    if( this->m_pszHistoBinValues != nullptr )
     {
-        // histogram bin values as a string
-        CPLFree(this->m_pszHistoBinValues);
-    }
-    // delete any overview bands
-    this->deleteOverviewObjects();
+        CPLMutexHolderD( &m_hMutex );
+        // destroy RAT if any
+        delete this->m_pAttributeTable;
+        // destroy color table if any
+        delete this->m_pColorTable;
+        // destroy the metadata
+        CSLDestroy(this->m_papszMetadataList);
+        if( this->m_pszHistoBinValues != nullptr )
+        {
+            // histogram bin values as a string
+            CPLFree(this->m_pszHistoBinValues);
+        }
+        // delete any overview bands
+        this->deleteOverviewObjects();
 
-    // if GDAL created the mask it will delete it
-    if( m_bMaskBandOwned )
-    {
-        delete m_pMaskBand;
+        // if GDAL created the mask it will delete it
+        if( m_bMaskBandOwned )
+        {
+            delete m_pMaskBand;
+        }
     }
 
     // according to the docs, this is required
     this->FlushCache();
 
     // decrement the recount and delete if needed
-    (*m_pnRefCount)--;
-    if( *m_pnRefCount == 0 )
+    if( m_pRefCount->DecRef() )
     {
         try
         {
@@ -128,13 +133,14 @@ KEARasterBand::~KEARasterBand()
         {
         }
         delete m_pImageIO;
-        delete m_pnRefCount;
+        delete m_pRefCount;
     }
 }
 
 // internal method that updates the metadata into m_papszMetadataList
 void KEARasterBand::UpdateMetadataList()
 {
+    CPLMutexHolderD( &m_hMutex );
     std::vector< std::pair<std::string, std::string> > data;
 
     // get all the metadata and iterate through
@@ -157,16 +163,18 @@ void KEARasterBand::UpdateMetadataList()
 
     // STATISTICS_HISTONUMBINS
     const GDALRasterAttributeTable *pTable = KEARasterBand::GetDefaultRAT();
-    CPLString osWorkingResult;
-    osWorkingResult.Printf( "%lu", (unsigned long)pTable->GetRowCount());
-    m_papszMetadataList = CSLSetNameValue(m_papszMetadataList, "STATISTICS_HISTONUMBINS", osWorkingResult);
-
-    // attribute table chunksize
-    if( this->m_nAttributeChunkSize != -1 )
+    if( pTable != nullptr )
     {
-        char szTemp[100];
-        snprintf(szTemp, 100, "%d", this->m_nAttributeChunkSize );
-        m_papszMetadataList = CSLSetNameValue(m_papszMetadataList, "ATTRIBUTETABLE_CHUNKSIZE", szTemp );
+        CPLString osWorkingResult;
+        osWorkingResult.Printf( "%lu", (unsigned long)pTable->GetRowCount());
+        m_papszMetadataList = CSLSetNameValue(m_papszMetadataList, "STATISTICS_HISTONUMBINS", osWorkingResult);
+
+        // attribute table chunksize
+        if( this->m_nAttributeChunkSize != -1 )
+        {
+            osWorkingResult.Printf( "%d", this->m_nAttributeChunkSize );
+            m_papszMetadataList = CSLSetNameValue(m_papszMetadataList, "ATTRIBUTETABLE_CHUNKSIZE", osWorkingResult );
+        }
     }
 }
 
@@ -189,6 +197,9 @@ CPLErr KEARasterBand::SetHistogramFromString(const char *pszString)
     }
 
     GDALRasterAttributeTable *pTable = this->GetDefaultRAT();
+    if( pTable == nullptr )
+        return CE_Failure;
+        
     // find histogram column if it exists
     int nCol = pTable->GetColOfUsage(GFU_PixelCount);
     if( nCol == -1 )
@@ -227,8 +238,9 @@ CPLErr KEARasterBand::SetHistogramFromString(const char *pszString)
 char *KEARasterBand::GetHistogramAsString()
 {
     const GDALRasterAttributeTable *pTable = this->GetDefaultRAT();
+    if( pTable == nullptr )
+        return nullptr;
     int nRows = pTable->GetRowCount();
-
     // find histogram column if it exists
     int nCol = pTable->GetColOfUsage(GFU_PixelCount);
     if( nCol == -1 )
@@ -267,6 +279,7 @@ char *KEARasterBand::GetHistogramAsString()
 // internal method to create the overviews
 void KEARasterBand::CreateOverviews(int nOverviews, int *panOverviewList)
 {
+    CPLMutexHolderD( &m_hMutex );
     // delete any existing overview bands
     this->deleteOverviewObjects();
 
@@ -288,7 +301,7 @@ void KEARasterBand::CreateOverviews(int nOverviews, int *panOverviewList)
 
         // create one of our objects to represent it
         m_panOverviewBands[nCount] = new KEAOverview((KEADataset*)this->poDS, this->nBand, GA_Update,
-                                        this->m_pImageIO, this->m_pnRefCount, nCount + 1, nXSize, nYSize);
+                                        this->m_pImageIO, this->m_pRefCount, nCount + 1, nXSize, nYSize);
     }
 }
 
@@ -375,6 +388,7 @@ void KEARasterBand::SetDescription(const char *pszDescription)
 // set a metadata item
 CPLErr KEARasterBand::SetMetadataItem(const char *pszName, const char *pszValue, const char *pszDomain)
 {
+    CPLMutexHolderD( &m_hMutex );
     // only deal with 'default' domain - no geolocation etc
     if( ( pszDomain != nullptr ) && ( *pszDomain != '\0' ) )
         return CE_Failure;
@@ -407,7 +421,8 @@ CPLErr KEARasterBand::SetMetadataItem(const char *pszName, const char *pszValue,
         else if( EQUAL( pszName, "STATISTICS_HISTONUMBINS" ) )
         {
             GDALRasterAttributeTable *pTable = this->GetDefaultRAT();
-            pTable->SetRowCount(atoi(pszValue));
+            if( pTable != nullptr )
+                pTable->SetRowCount(atoi(pszValue));
             // leave to update m_papszMetadataList below
         }
         else
@@ -428,6 +443,7 @@ CPLErr KEARasterBand::SetMetadataItem(const char *pszName, const char *pszValue,
 // get a single metdata item
 const char *KEARasterBand::GetMetadataItem (const char *pszName, const char *pszDomain)
 {
+    CPLMutexHolderD( &m_hMutex );
     // only deal with 'default' domain - no geolocation etc
     if( ( pszDomain != nullptr ) && ( *pszDomain != '\0' ) )
         return nullptr;
@@ -460,6 +476,7 @@ char **KEARasterBand::GetMetadata(const char *pszDomain)
 // set the metdata as a CSLStringList
 CPLErr KEARasterBand::SetMetadata(char **papszMetadata, const char *pszDomain)
 {
+    CPLMutexHolderD( &m_hMutex );
     // only deal with 'default' domain - no geolocation etc
     if( ( pszDomain != nullptr ) && ( *pszDomain != '\0' ) )
         return CE_Failure;
@@ -612,6 +629,8 @@ CPLErr KEARasterBand::GetDefaultHistogram( double *pdfMin, double *pdfMax,
         // I've used the RAT interface here as it deals with data type
         // conversions. Would be nice to have GUIntBig support in RAT though...
         GDALRasterAttributeTable *pTable = this->GetDefaultRAT();
+        if( pTable == nullptr )
+            return CE_Failure;
         int nRows = pTable->GetRowCount();
 
         // find histogram column if it exists
@@ -661,6 +680,8 @@ CPLErr KEARasterBand::SetDefaultHistogram( double /*dfMin*/, double /*dfMax*/,
 {
 
     GDALRasterAttributeTable *pTable = this->GetDefaultRAT();
+    if( pTable == nullptr )
+        return CE_Failure;
     int nRows = pTable->GetRowCount();
 
     // find histogram column if it exists
@@ -702,11 +723,13 @@ CPLErr KEARasterBand::SetDefaultHistogram( double /*dfMin*/, double /*dfMax*/,
 
 GDALRasterAttributeTable *KEARasterBand::GetDefaultRAT()
 {
+    CPLMutexHolderD( &m_hMutex );
     if( this->m_pAttributeTable == nullptr )
     {
         try
         {
             // we assume this is never NULL - creates a new one if none exists
+            // (or raises exception)
             kealib::KEAAttributeTable *pKEATable = this->m_pImageIO->getAttributeTable(kealib::kea_att_file, this->nBand);
             this->m_pAttributeTable = new KEARasterAttributeTable(pKEATable, this);
         }
@@ -726,7 +749,9 @@ CPLErr KEARasterBand::SetDefaultRAT(const GDALRasterAttributeTable *poRAT)
     try
     {
         KEARasterAttributeTable *pKEATable = (KEARasterAttributeTable*)this->GetDefaultRAT();
-
+        if( pKEATable == nullptr )
+            return CE_Failure;
+            
         int numRows = poRAT->GetRowCount();
         pKEATable->SetRowCount(numRows);
 
@@ -818,6 +843,7 @@ CPLErr KEARasterBand::SetDefaultRAT(const GDALRasterAttributeTable *poRAT)
 
 GDALColorTable *KEARasterBand::GetColorTable()
 {
+    CPLMutexHolderD( &m_hMutex );
     if( this->m_pColorTable == nullptr )
     {
         try
@@ -877,9 +903,12 @@ CPLErr KEARasterBand::SetColorTable(GDALColorTable *poCT)
     if( poCT == nullptr )
         return CE_Failure;
 
+    CPLMutexHolderD( &m_hMutex );
     try
     {
         GDALRasterAttributeTable *pKEATable = this->GetDefaultRAT();
+        if( pKEATable == nullptr )
+            return CE_Failure;
         int nRedIdx = -1;
         int nGreenIdx = -1;
         int nBlueIdx = -1;
@@ -1110,6 +1139,7 @@ CPLErr KEARasterBand::SetColorInterpretation(GDALColorInterp egdalinterp)
 }
 
 // clean up our overview objects
+// assumes mutex being held by caller
 void KEARasterBand::deleteOverviewObjects()
 {
     // deletes the objects - not the overviews themselves
@@ -1126,6 +1156,7 @@ void KEARasterBand::deleteOverviewObjects()
 // read in any overviews in the file into our array of objects
 void KEARasterBand::readExistingOverviews()
 {
+    CPLMutexHolderD( &m_hMutex );
     // delete any existing overview bands
     this->deleteOverviewObjects();
 
@@ -1137,7 +1168,7 @@ void KEARasterBand::readExistingOverviews()
     {
         this->m_pImageIO->getOverviewSize(this->nBand, nCount + 1, &nXSize, &nYSize);
         m_panOverviewBands[nCount] = new KEAOverview((KEADataset*)this->poDS, this->nBand, GA_ReadOnly,
-                                        this->m_pImageIO, this->m_pnRefCount, nCount + 1, nXSize, nYSize);
+                                        this->m_pImageIO, this->m_pRefCount, nCount + 1, nXSize, nYSize);
     }
 }
 
@@ -1162,6 +1193,7 @@ GDALRasterBand* KEARasterBand::GetOverview(int nOverview)
 
 CPLErr KEARasterBand::CreateMaskBand(int)
 {
+    CPLMutexHolderD( &m_hMutex );
     if( m_bMaskBandOwned )
         delete m_pMaskBand;
     m_pMaskBand = nullptr;
@@ -1179,13 +1211,14 @@ CPLErr KEARasterBand::CreateMaskBand(int)
 
 GDALRasterBand* KEARasterBand::GetMaskBand()
 {
+    CPLMutexHolderD( &m_hMutex );
     if( m_pMaskBand == nullptr )
     {
         try
         {
             if( this->m_pImageIO->maskCreated(this->nBand) )
             {
-                m_pMaskBand = new KEAMaskBand(this, this->m_pImageIO, this->m_pnRefCount);
+                m_pMaskBand = new KEAMaskBand(this, this->m_pImageIO, this->m_pRefCount);
                 m_bMaskBandOwned = true;
             }
             else

--- a/gdal/frmts/kea/keaband.cpp
+++ b/gdal/frmts/kea/keaband.cpp
@@ -374,6 +374,7 @@ CPLErr KEARasterBand::IWriteBlock( int nBlockXOff, int nBlockYOff, void * pImage
 
 void KEARasterBand::SetDescription(const char *pszDescription)
 {
+    CPLMutexHolderD( &m_hMutex );
     try
     {
         this->m_pImageIO->setImageBandDescription(this->nBand, pszDescription);

--- a/gdal/frmts/kea/keaband.h
+++ b/gdal/frmts/kea/keaband.h
@@ -41,7 +41,7 @@ class KEAMaskBand;
 class KEARasterBand CPL_NON_FINAL: public GDALPamRasterBand
 {
 private:
-    int                 *m_pnRefCount = nullptr; // reference count of m_pImageIO
+    LockedRefCount      *m_pRefCount = nullptr; // reference count of m_pImageIO
 
     int                  m_nOverviews = 0; // number of overviews
     KEAOverview        **m_panOverviewBands = nullptr; // array of overview objects
@@ -56,7 +56,7 @@ private:
     int                  m_nAttributeChunkSize = 0; // for reporting via the metadata
 public:
     // constructor/destructor
-    KEARasterBand( KEADataset *pDataset, int nSrcBand, GDALAccess eAccess, kealib::KEAImageIO *pImageIO, int *pRefCount );
+    KEARasterBand( KEADataset *pDataset, int nSrcBand, GDALAccess eAccess, kealib::KEAImageIO *pImageIO, LockedRefCount *pRefCount );
     ~KEARasterBand();
 
     // virtual methods for overview support
@@ -128,6 +128,7 @@ protected:
     kealib::KEAImageIO  *m_pImageIO = nullptr; // our image access pointer - refcounted
     char               **m_papszMetadataList = nullptr; // CPLStringList of metadata
     kealib::KEADataType  m_eKEADataType; // data type as KEA enum
+    CPLMutex            *m_hMutex;
 };
 
 #endif //KEABAND_H

--- a/gdal/frmts/kea/keadataset.h
+++ b/gdal/frmts/kea/keadataset.h
@@ -141,7 +141,7 @@ private:
     CPL_DISALLOW_COPY_ASSIGN(LockedRefCount)
 
 public:
-    LockedRefCount(int initCount=1)
+    explicit LockedRefCount(int initCount=1)
     {
         m_nRefCount = initCount;
         m_hMutex = CPLCreateMutex();

--- a/gdal/frmts/kea/keadataset.h
+++ b/gdal/frmts/kea/keadataset.h
@@ -32,8 +32,10 @@
 #define KEADATASET_H
 
 #include "gdal_pam.h"
-
+#include "cpl_multiproc.h"
 #include "libkea_headers.h"
+
+class LockedRefCount;
 
 // class that implements a GDAL dataset
 class KEADataset final: public GDALPamDataset
@@ -114,10 +116,11 @@ protected:
 private:
     // pointer to KEAImageIO class and the refcount for it
     kealib::KEAImageIO  *m_pImageIO;
-    int                 *m_pnRefcount;
+    LockedRefCount      *m_pRefcount;
     char               **m_papszMetadataList; // CSLStringList for metadata
     GDAL_GCP            *m_pGCPs;
     char                *m_pszGCPProjection;
+    CPLMutex            *m_hMutex;
 };
 
 // conversion functions
@@ -126,5 +129,43 @@ kealib::KEADataType GDAL_to_KEA_Type( GDALDataType egdalType );
 
 // For unloading the VFL
 void KEADatasetDriverUnload(GDALDriver*);
+
+// A thresafe reference count. Used to manage shared pointer to
+// the kealib::KEAImageIO instance between bands and dataset.
+class LockedRefCount
+{
+private:
+    int m_nRefCount;
+    CPLMutex *m_hMutex;
+
+    CPL_DISALLOW_COPY_ASSIGN(LockedRefCount)
+
+public:
+    LockedRefCount(int initCount=1)
+    {
+        m_nRefCount = initCount;
+        m_hMutex = CPLCreateMutex();
+        CPLReleaseMutex( m_hMutex );
+    }
+    ~LockedRefCount()
+    {
+        CPLDestroyMutex( m_hMutex );
+        m_hMutex = nullptr;
+    }
+
+    void IncRef()
+    {
+        CPLMutexHolderD( &m_hMutex );
+        m_nRefCount++;
+    }
+
+    // returns true if reference count now 0
+    bool DecRef()
+    {
+        CPLMutexHolderD( &m_hMutex );
+        m_nRefCount--;
+        return m_nRefCount <= 0;
+    }
+};
 
 #endif //KEADATASET_H

--- a/gdal/frmts/kea/keamaskband.cpp
+++ b/gdal/frmts/kea/keamaskband.cpp
@@ -33,7 +33,7 @@ CPL_CVSID("$Id$")
 
 // constructor
 KEAMaskBand::KEAMaskBand(GDALRasterBand *pParent,
-                kealib::KEAImageIO *pImageIO, int *pRefCount)
+                kealib::KEAImageIO *pImageIO, LockedRefCount *pRefCount)
 {
     m_nSrcBand = pParent->GetBand();
     poDS = nullptr;
@@ -48,9 +48,9 @@ KEAMaskBand::KEAMaskBand(GDALRasterBand *pParent,
 
     // grab the imageio class and its refcount
     this->m_pImageIO = pImageIO;
-    this->m_pnRefCount = pRefCount;
+    this->m_pRefCount = pRefCount;
     // increment the refcount as we now have a reference to imageio
-    (*this->m_pnRefCount)++;
+    this->m_pRefCount->IncRef();
 }
 
 KEAMaskBand::~KEAMaskBand()
@@ -59,8 +59,7 @@ KEAMaskBand::~KEAMaskBand()
     this->FlushCache();
 
     // decrement the recount and delete if needed
-    (*m_pnRefCount)--;
-    if( *m_pnRefCount == 0 )
+    if( m_pRefCount->DecRef() )
     {
         try
         {
@@ -70,7 +69,7 @@ KEAMaskBand::~KEAMaskBand()
         {
         }
         delete m_pImageIO;
-        delete m_pnRefCount;
+        delete m_pRefCount;
     }
 }
 

--- a/gdal/frmts/kea/keamaskband.h
+++ b/gdal/frmts/kea/keamaskband.h
@@ -34,12 +34,13 @@
 #include "gdal_priv.h"
 
 #include "libkea_headers.h"
+#include "keadataset.h"
 
 class KEAMaskBand final: public GDALRasterBand
 {
     int m_nSrcBand;
     kealib::KEAImageIO  *m_pImageIO; // our image access pointer - refcounted
-    int                 *m_pRefCount; // reference count of m_pImageIO
+    LockedRefCount      *m_pRefCount; // reference count of m_pImageIO
 public:
     KEAMaskBand(GDALRasterBand *pParent, kealib::KEAImageIO *pImageIO, LockedRefCount *pRefCount );
     ~KEAMaskBand();

--- a/gdal/frmts/kea/keamaskband.h
+++ b/gdal/frmts/kea/keamaskband.h
@@ -39,9 +39,9 @@ class KEAMaskBand final: public GDALRasterBand
 {
     int m_nSrcBand;
     kealib::KEAImageIO  *m_pImageIO; // our image access pointer - refcounted
-    int                 *m_pnRefCount; // reference count of m_pImageIO
+    int                 *m_pRefCount; // reference count of m_pImageIO
 public:
-    KEAMaskBand(GDALRasterBand *pParent, kealib::KEAImageIO *pImageIO, int *pRefCount );
+    KEAMaskBand(GDALRasterBand *pParent, kealib::KEAImageIO *pImageIO, LockedRefCount *pRefCount );
     ~KEAMaskBand();
 
 protected:

--- a/gdal/frmts/kea/keaoverview.cpp
+++ b/gdal/frmts/kea/keaoverview.cpp
@@ -33,7 +33,7 @@ CPL_CVSID("$Id$")
 
 // constructor
 KEAOverview::KEAOverview(KEADataset *pDataset, int nSrcBand, GDALAccess eAccessIn,
-                kealib::KEAImageIO *pImageIO, int *pRefCount,
+                kealib::KEAImageIO *pImageIO, LockedRefCount *pRefCount,
                 int nOverviewIndex, uint64_t nXSize, uint64_t nYSize)
  : KEARasterBand( pDataset, nSrcBand, eAccessIn, pImageIO, pRefCount )
 {

--- a/gdal/frmts/kea/keaoverview.h
+++ b/gdal/frmts/kea/keaoverview.h
@@ -41,7 +41,7 @@ class KEAOverview final: public KEARasterBand
     int         m_nOverviewIndex; // the index of this overview
 public:
     KEAOverview(KEADataset *pDataset, int nSrcBand, GDALAccess eAccess,
-                kealib::KEAImageIO *pImageIO, int *pRefCount,
+                kealib::KEAImageIO *pImageIO, LockedRefCount *pRefCount,
                 int nOverviewIndex, uint64_t nXSize, uint64_t nYSize );
     ~KEAOverview();
 

--- a/gdal/frmts/kea/kearat.cpp
+++ b/gdal/frmts/kea/kearat.cpp
@@ -34,6 +34,8 @@ CPL_CVSID("$Id$")
 KEARasterAttributeTable::KEARasterAttributeTable(kealib::KEAAttributeTable *poKEATable,
                             KEARasterBand *poBand)
 {
+    this->m_hMutex = CPLCreateMutex();
+    CPLReleaseMutex( this->m_hMutex );
     for( size_t nColumnIndex = 0; nColumnIndex < poKEATable->getMaxGlobalColIdx(); nColumnIndex++ )
     {
         kealib::KEAATTField sKEAField;
@@ -56,6 +58,8 @@ KEARasterAttributeTable::~KEARasterAttributeTable()
 {
     // can't just delete thanks to Windows
     kealib::KEAAttributeTable::destroyAttributeTable(m_poKEATable);
+    CPLDestroyMutex( m_hMutex );
+    m_hMutex = nullptr;
 }
 
 GDALDefaultRasterAttributeTable *KEARasterAttributeTable::Clone() const
@@ -365,6 +369,7 @@ CPLErr KEARasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField, int iSt
             "Dataset not open in update mode");
         return CE_Failure;
     }*/
+    CPLMutexHolderD( &m_hMutex );
 
     if( iField < 0 || iField >= (int) m_aoFields.size() )
     {
@@ -496,6 +501,7 @@ CPLErr KEARasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField, int iSt
             "Dataset not open in update mode");
         return CE_Failure;
     }*/
+    CPLMutexHolderD( &m_hMutex );
 
     if( iField < 0 || iField >= (int) m_aoFields.size() )
     {
@@ -689,6 +695,7 @@ CPLErr KEARasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField, int iSt
             "Dataset not open in update mode");
         return CE_Failure;
     }*/
+    CPLMutexHolderD( &m_hMutex );
 
     if( iField < 0 || iField >= (int) m_aoFields.size() )
     {
@@ -849,6 +856,7 @@ CPLErr KEARasterAttributeTable::CreateColumn( const char *pszFieldName,
             "Dataset not open in update mode");
         return CE_Failure;
     }*/
+    CPLMutexHolderD( &m_hMutex );
 
     std::string strUsage = "Generic";
     switch(eFieldUsage)

--- a/gdal/frmts/kea/kearat.h
+++ b/gdal/frmts/kea/kearat.h
@@ -43,6 +43,7 @@ private:
     std::vector<kealib::KEAATTField> m_aoFields;
     CPLString osWorkingResult;
     KEARasterBand *m_poBand;
+    CPLMutex            *m_hMutex;
 
 public:
     KEARasterAttributeTable(kealib::KEAAttributeTable *poKEATable, KEARasterBand *poBand);


### PR DESCRIPTION
## What does this PR do?

Ports fixes from kealib 1.4.13's standalone driver. These include:
- Locks around internal data structures for thread safety
- Checking the result of GetDefaultRAT() as this can be `nullptr` in certain circumstances (generally partially corrupt files)

## What are related issues/pull requests?

Relevant changes from `kealib` are in the `gdal` subdir files from: https://github.com/ubarsc/kealib/compare/190ef7a..HEAD

Note: `kealib` 1.4.13 now prints a warning if being compiled against an `hdf5` that **isn't** thread safe.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
