### PR TITLE
Docs: Update copyright year in site footer

### DIFF
--- a/gdal/doc/source/conf.py
+++ b/gdal/doc/source/conf.py
@@ -10,6 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 sys.path.insert(0, os.path.abspath('_extensions'))
@@ -18,7 +19,7 @@ sys.path.insert(0, os.path.abspath('_extensions'))
 # -- Project information -----------------------------------------------------
 
 project = 'GDAL'
-copyright = '1998-2019'
+copyright = f"1998-{datetime.date.today().year}"
 author = 'Frank Warmerdam, Even Rouault, and others'
 
 


### PR DESCRIPTION
The copyright year is still showing 2019. Let's welcome 2020.