### PR TITLE
Flush cache in block order for TileDB global writes

### DIFF
--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -110,6 +110,9 @@ class TileDBDataset final: public GDALPamDataset
         static void             SetBlockSize( GDALRasterBand* poBand,
                                                 char ** &papszOptions );
 
+        virtual void            FlushCache( void ) override;
+
+
 };
 
 /************************************************************************/
@@ -125,6 +128,8 @@ class TileDBRasterBand final: public GDALPamRasterBand
         TileDBDataset  *poGDS;
         bool bStats;
         CPLString osAttrName;
+        int nCurrBlockX = 0;
+        int nCurrBlockY = 0;
         std::unique_ptr<tiledb::Query> m_query;
         std::unique_ptr<tiledb::Query> m_roQuery;
         void   Finalize( );
@@ -359,6 +364,23 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
 
         m_query->set_subarray( oaSubarray );
     }
+    else
+    {
+        // global order requires ordered blocks (see FlushCache())
+        if ( ( nCurrBlockX != nBlockXOff ) || ( nCurrBlockY != nBlockYOff ) )
+        {   CPLError( CE_Failure, CPLE_AppDefined,
+                    "Non-sequential global write to TileDB.\n");
+            return CE_Failure;
+        }
+        else
+        {
+            if ( ++nCurrBlockX == poGDS->nBlocksX )
+            {
+                nCurrBlockX = 0;
+                nCurrBlockY++;
+            }
+        }
+    }
 
     std::vector<std::unique_ptr<void, decltype(&VSIFree)>> aBlocks;
 
@@ -494,6 +516,16 @@ TileDBDataset::~TileDBDataset()
     CPLDestroyXMLNode( psSubDatasetsTree );
     CSLDestroy( papszSubDatasets );
     CSLDestroy( papszAttributes );
+}
+
+/************************************************************************/
+/*                             FlushCache()                             */
+/************************************************************************/
+
+void TileDBDataset::FlushCache()
+
+{
+    BlockBasedFlushCache();
 }
 
 /************************************************************************/


### PR DESCRIPTION
## What does this PR do?

When creating a TileDB array global order is used for performance, if the file is large and exceeds `GDAL_CACHEMAX` then the tiles can be written out of order in `TileDBRasterBand::IWriteBlock`.

This PR uses `BlockBasedFlushCache` and checks the tile order on global writes.

This is an internal change and the related issue is https://github.com/TileDB-Inc/TileDB-Geospatial/issues/7

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed