### PR TITLE
vsis3 compatibility

### DIFF
--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -141,6 +141,18 @@ class TileDBRasterBand final: public GDALPamRasterBand
 
 };
 
+static CPLString vsi_to_s3( const char* pszUri )
+{
+    CPLString osUri;
+
+    if ( STARTS_WITH_CI( pszUri, "/VSIS3/") )
+        osUri.Printf("s3://%s", pszUri + 7);
+    else
+        osUri = pszUri;
+
+    return osUri;
+}
+
 /************************************************************************/
 /*                             SetBuffer()                              */
 /************************************************************************/
@@ -526,6 +538,9 @@ void TileDBDataset::FlushCache()
 
 {
     BlockBasedFlushCache();
+
+    if( nPamFlags & GPF_DIRTY )
+        TrySaveXML();
 }
 
 /************************************************************************/
@@ -633,7 +648,6 @@ CPLErr TileDBDataset::TrySaveXML()
         char* pszTree = CPLSerializeXMLTree( psTree );
 
 #if TILEDB_VERSION_MAJOR >= 1 && TILEDB_VERSION_MINOR >= 7
-
         if ( eAccess == GA_ReadOnly )
         {
             auto oMeta = std::unique_ptr<tiledb::Array>( 
@@ -974,9 +988,11 @@ CPLErr TileDBDataset::Delete( const char * pszFilename )
     {
         tiledb::Context ctx;
         tiledb::VFS vfs( ctx );
-        if ( vfs.is_dir( pszFilename ) )
+        CPLString osArrayPath = vsi_to_s3( pszFilename );
+
+        if ( vfs.is_dir( osArrayPath ) )
         {
-            vfs.remove_dir( pszFilename );
+            vfs.remove_dir( osArrayPath );
             return CE_None;
         }
         else
@@ -1011,10 +1027,12 @@ int TileDBDataset::Identify( GDALOpenInfo * poOpenInfo )
             return TRUE;
         }
 
-        if( poOpenInfo->bIsDirectory )
+        if( poOpenInfo->bIsDirectory ||
+                STARTS_WITH_CI( poOpenInfo->pszFilename, "/VSIS3/" ) )
         {
             tiledb::Context ctx;
-            return tiledb::Object::object( ctx, poOpenInfo->pszFilename ).type() == tiledb::Object::Type::Array;
+            CPLString osArrayPath = vsi_to_s3( poOpenInfo->pszFilename );
+            return tiledb::Object::object( ctx, osArrayPath ).type() == tiledb::Object::Type::Array;
         }
 
         return FALSE;
@@ -1085,10 +1103,7 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
                 poDS->SetSubdatasetName( pszAttr );
             }
 
-        if ( STARTS_WITH_CI( poOpenInfo->pszFilename, "/VSIS3/") )
-            osArrayPath.Printf("s3://%s", poOpenInfo->pszFilename + 7);
-        else
-            osArrayPath = poOpenInfo->pszFilename;
+            osArrayPath = vsi_to_s3( poOpenInfo->pszFilename );
         }
 
         const char* pszArrayName = CPLGetBasename( osArrayPath );
@@ -1267,7 +1282,7 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
                 {
                     CPLError( CE_Failure, CPLE_NotSupported,
                         "%s is missing required TileDB subdataset metadata.",
-                        poOpenInfo->pszFilename );
+                        osArrayPath.c_str() );
                     return nullptr;
                 }
             }
@@ -1906,8 +1921,10 @@ TileDBDataset::Create( const char * pszFilename, int nXSize, int nYSize, int nBa
 {
     try
     {
+        CPLString osArrayPath = vsi_to_s3( pszFilename );
+
         std::unique_ptr<TileDBDataset> poDS(
-            TileDBDataset::CreateLL( pszFilename, nXSize, nYSize,
+            TileDBDataset::CreateLL( osArrayPath, nXSize, nYSize,
                                     nBands, papszOptions ));
         if( !poDS )
             return nullptr;
@@ -1915,9 +1932,9 @@ TileDBDataset::Create( const char * pszFilename, int nXSize, int nYSize, int nBa
         poDS->eDataType = eType;
 
         poDS->CreateAttribute( eType, TILEDB_VALUES );
-        tiledb::Array::create( pszFilename, *poDS->m_schema );
+        tiledb::Array::create( osArrayPath, *poDS->m_schema );
 
-        poDS->m_array.reset( new tiledb::Array( *poDS->m_ctx, pszFilename, TILEDB_WRITE ) );
+        poDS->m_array.reset( new tiledb::Array( *poDS->m_ctx, osArrayPath, TILEDB_WRITE ) );
 
         for( int i = 0; i < poDS->nBands;i++ )
             poDS->SetBand( i+1, new TileDBRasterBand( poDS.get(), i+1 ) );
@@ -1967,6 +1984,8 @@ TileDBDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
 
 {
     char** papszCopyOptions = CSLDuplicate( papszOptions );
+    CPLString osArrayPath = vsi_to_s3( pszFilename );
+
     try
     {
         std::unique_ptr<TileDBDataset> poDstDS;
@@ -2005,7 +2024,7 @@ TileDBDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
                 }
 
                 poDstDS.reset(
-                    static_cast<TileDBDataset*>(TileDBDataset::Create( pszFilename, 
+                    static_cast<TileDBDataset*>(TileDBDataset::Create( osArrayPath,
                             poSrcDS->GetRasterXSize(),
                             poSrcDS->GetRasterYSize(), 
                             nBands, eType, papszOptions )));
@@ -2071,7 +2090,7 @@ TileDBDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
                         TileDBDataset::SetBlockSize( poBand, papszCopyOptions );
 
                         poDstDS.reset(TileDBDataset::CreateLL(
-                                    pszFilename, poBand->GetXSize(),
+                                    osArrayPath, poBand->GetXSize(),
                                     poBand->GetYSize(), 0, papszCopyOptions ));
 
                         if ( poDstDS &&

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -1572,7 +1572,8 @@ class CPL_DLL GDALDriver : public GDALMajorObject
                                            GDALProgressFunc pfnProgress,
                                            void * pProgressData );
 //! @endcond
-    static CPLErr       QuietDelete( const char * pszName );
+    static CPLErr       QuietDelete( const char * pszName,
+                                     const char *const *papszAllowedDrivers = nullptr);
 
 //! @cond Doxygen_Suppress
     static CPLErr       DefaultRename( const char * pszNewName,

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -3221,7 +3221,6 @@ GDALDatasetH CPL_STDCALL GDALOpenEx( const char *pszFilename,
                                      const char *const *papszSiblingFiles )
 {
     VALIDATE_POINTER1(pszFilename, "GDALOpen", nullptr);
-
 /* -------------------------------------------------------------------- */
 /*      In case of shared dataset, first scan the existing list to see  */
 /*      if it could already contain the requested dataset.              */
@@ -3311,11 +3310,16 @@ GDALDatasetH CPL_STDCALL GDALOpenEx( const char *pszFilename,
     oOpenInfo.papszOpenOptions = papszOpenOptionsCleaned;
 
     const int nDriverCount = poDM->GetDriverCount();
+    const int nAllowedDrivers = CSLCount( papszAllowedDrivers );
+
     for( int iDriver = -1; iDriver < nDriverCount; ++iDriver )
     {
         GDALDriver *poDriver = nullptr;
 
-        if( iDriver < 0 )
+        if ( (iDriver == -1 ) && ( nAllowedDrivers == 1 ) )
+            continue;
+
+        if ( iDriver < 0 )
         {
             poDriver = GDALGetAPIPROXYDriver();
         }

--- a/gdal/gcore/gdaldriver.cpp
+++ b/gdal/gcore/gdaldriver.cpp
@@ -250,7 +250,10 @@ GDALDataset * GDALDriver::Create( const char * pszFilename,
         if( !EQUAL(GetDescription(), "MEM") &&
             !EQUAL(GetDescription(), "Memory") )
         {
-            QuietDelete( pszFilename );
+            char** papszAllowedDrivers = nullptr;
+            papszAllowedDrivers = CSLAddString(papszAllowedDrivers, GetDescription() );
+            QuietDelete( pszFilename, papszAllowedDrivers );
+            CSLDestroy( papszAllowedDrivers );
         }
     }
 
@@ -1021,7 +1024,10 @@ GDALDataset *GDALDriver::CreateCopy( const char * pszFilename,
         if( !EQUAL(GetDescription(), "MEM") &&
             !EQUAL(GetDescription(), "Memory") )
         {
-            QuietDelete( pszFilename );
+            char** papszAllowedDrivers = nullptr;
+            papszAllowedDrivers = CSLAddString(papszAllowedDrivers, GetDescription() );
+            QuietDelete( pszFilename, papszAllowedDrivers );
+            CSLDestroy( papszAllowedDrivers );
         }
     }
 
@@ -1161,10 +1167,14 @@ GDALDatasetH CPL_STDCALL GDALCreateCopy( GDALDriverH hDriver,
  * using Identify().
  *
  * @param pszName the dataset name to try and delete.
+ * @param papszAllowedDrivers NULL to consider all candidate drivers, or a NULL
+ * terminated list of strings with the driver short names that must be
+ * considered.
  * @return CE_None if the dataset does not exist, or is deleted without issues.
  */
 
-CPLErr GDALDriver::QuietDelete( const char *pszName )
+CPLErr GDALDriver::QuietDelete( const char *pszName,
+                                const char *const *papszAllowedDrivers )
 
 {
     VSIStatBufL sStat;
@@ -1187,7 +1197,7 @@ CPLErr GDALDriver::QuietDelete( const char *pszName )
 
     CPLPushErrorHandler(CPLQuietErrorHandler);
     GDALDriver * const poDriver =
-        GDALDriver::FromHandle( GDALIdentifyDriver( pszName, nullptr ) );
+        GDALDriver::FromHandle( GDALIdentifyDriver( pszName, papszAllowedDrivers ) );
     CPLPopErrorHandler();
 
     if( poDriver == nullptr )


### PR DESCRIPTION
## What does this PR do?

This PR provides compatiblity with the `vsis3` prefix used in Rasterio. It also provides a fix for setting the metadata in FlushCache when using s3.

As TileDB can perform updates directly on s3 I removed the error check in `vsicurl`, if this should be retained then I can make the changes required to add a conditional compilation.

I was testing with Rasterio so I haven't added a GDAL specific test case here.