### PR TITLE
Add ID_GENERATE option to the GeoJSON driver for generating missing f…

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -2680,6 +2680,18 @@ def test_ogr_geojson_id_field_and_id_type():
     gdal.Unlink('/vsimem/out.json')
     assert '"id": 35043411, "properties": { "AREA": 215229.266, "EAS_ID": 168 }' in got
 
+    gdal.VectorTranslate('/vsimem/out.json', 'data/poly.shp', format='GeoJSON', layerCreationOptions=['ID_GENERATE=YES'], limit=1)
+    got = read_file('/vsimem/out.json')
+    assert '"id": 0, "properties": { "AREA": 215229.266, "EAS_ID": 168, "PRFEDEA": "35043411" }' in got
+
+    gdal.VectorTranslate('/vsimem/out.json', 'data/poly.shp', format='GeoJSON', layerCreationOptions=['ID_GENERATE=YES', 'ID_TYPE=Integer'], limit=1)
+    got = read_file('/vsimem/out.json')
+    assert '"id": 0, "properties": { "AREA": 215229.266, "EAS_ID": 168, "PRFEDEA": "35043411" }' in got
+
+    gdal.VectorTranslate('/vsimem/out.json', 'data/poly.shp', format='GeoJSON', layerCreationOptions=['ID_GENERATE=YES', 'ID_TYPE=String'], limit=1)
+    got = read_file('/vsimem/out.json')
+    assert '"id": "0", "properties": { "AREA": 215229.266, "EAS_ID": 168, "PRFEDEA": "35043411" }' in got
+
 ###############################################################################
 
 

--- a/gdal/doc/source/drivers/vector/geojson.rst
+++ b/gdal/doc/source/drivers/vector/geojson.rst
@@ -251,6 +251,7 @@ Layer creation options
    must be written as the 'id' member of Feature objects.
 -  **ID_TYPE**\ =AUTO/String/Integer. (OGR >= 2.3) Type of the 'id'
    memer of Feature objects.
+-  **ID_GENERATE**\ =YES/NO. (OGR >= 3.0.4) Auto-generate feature ids
 -  **WRITE_NON_FINITE_VALUES**\ =YES/NO. (OGR >= 2.4) Whether to write
    NaN / Infinity values. Such values are not allowed in strict JSon
    mode, but some JSon parsers (libjson-c >= 0.12 for exampl) can

--- a/gdal/doc/source/drivers/vector/geojson.rst
+++ b/gdal/doc/source/drivers/vector/geojson.rst
@@ -251,7 +251,7 @@ Layer creation options
    must be written as the 'id' member of Feature objects.
 -  **ID_TYPE**\ =AUTO/String/Integer. (OGR >= 2.3) Type of the 'id'
    memer of Feature objects.
--  **ID_GENERATE**\ =YES/NO. (OGR >= 3.0.4) Auto-generate feature ids
+-  **ID_GENERATE**\ =YES/NO. (OGR >= 3.1) Auto-generate feature ids
 -  **WRITE_NON_FINITE_VALUES**\ =YES/NO. (OGR >= 2.4) Whether to write
    NaN / Infinity values. Such values are not allowed in strict JSon
    mode, but some JSon parsers (libjson-c >= 0.12 for exampl) can

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
@@ -663,6 +663,7 @@ void RegisterOGRGeoJSON()
 "    <Value>String</Value>"
 "    <Value>Integer</Value>"
 "  </Option>"
+"  <Option name='ID_GENERATE' type='boolean' description='Auto-generate feature ids' />"
 "  <Option name='WRITE_NON_FINITE_VALUES' type='boolean' description='Whether to write NaN / Infinity values' default='NO'/>"
 "</LayerCreationOptionList>");
 

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
@@ -183,6 +183,9 @@ OGRErr OGRGeoJSONWriteLayer::ICreateFeature( OGRFeature* poFeature )
         poFeatureToWrite = poFeature;
     }
 
+    if (oWriteOptions_.bGenerateID && poFeatureToWrite->GetFID() == OGRNullFID) {
+        poFeatureToWrite->SetFID(nOutCounter_);
+    }
     json_object* poObj =
         OGRGeoJSONWriteFeature( poFeatureToWrite, oWriteOptions_ );
     CPLAssert( nullptr != poObj );

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
@@ -79,6 +79,7 @@ void OGRGeoJSONWriteOptions::SetIDOptions(CSLConstList papszOptions)
             eForcedIDFieldType = OFTInteger64;
         }
     }
+    bGenerateID = CSLFetchBoolean(papszOptions, "ID_GENERATE", false);
 }
 
 /*! @endcond */

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
@@ -79,7 +79,7 @@ void OGRGeoJSONWriteOptions::SetIDOptions(CSLConstList papszOptions)
             eForcedIDFieldType = OFTInteger64;
         }
     }
-    bGenerateID = CSLFetchBoolean(papszOptions, "ID_GENERATE", false);
+    bGenerateID = CPL_TO_BOOL(CSLFetchBoolean(papszOptions, "ID_GENERATE", false));
 }
 
 /*! @endcond */

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.h
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.h
@@ -80,6 +80,7 @@ class OGRGeoJSONWriteOptions
         bool bHonourReservedRFC7946Members = false;
         CPLString osIDField{};
         bool bForceIDFieldType = false;
+        bool bGenerateID = false;
         OGRFieldType eForcedIDFieldType = OFTString;
         bool bAllowNonFiniteValues = false;
 


### PR DESCRIPTION
Add ID_GENERATE option to the GeoJSON driver for generating missing feature ids

## What does this PR do?

Add an option to the old GeoJSON driver for generating feature ids when they are missing in the original dataset. The GeoJSONSEQ does this by default.

## What are related issues/pull requests?

#2406 

## Tasklist

Here is a geojson with no ids


