### PR TITLE
Use LABEL instead of deprecated MAINTAINER

### DIFF
--- a/gdal/docker/alpine-normal/Dockerfile
+++ b/gdal/docker/alpine-normal/Dockerfile
@@ -9,7 +9,7 @@ ARG ALPINE_VERSION=3.11
 FROM alpine:${ALPINE_VERSION} as builder
 
 # Derived from osgeo/proj by Howard Butler <howard@hobu.co>
-MAINTAINER Even Rouault <even.rouault@spatialys.com>
+LABEL maintainer="Even Rouault <even.rouault@spatialys.com>"
 
 # Setup build env for PROJ
 RUN apk add --no-cache wget curl unzip make libtool autoconf automake pkgconfig g++ sqlite sqlite-dev

--- a/gdal/docker/alpine-small/Dockerfile
+++ b/gdal/docker/alpine-small/Dockerfile
@@ -9,7 +9,7 @@ ARG ALPINE_VERSION=3.11
 FROM alpine:${ALPINE_VERSION} as builder
 
 # Derived from osgeo/proj by Howard Butler <howard@hobu.co>
-MAINTAINER Even Rouault <even.rouault@spatialys.com>
+LABEL maintainer="Even Rouault <even.rouault@spatialys.com>"
 
 # Setup build env for PROJ
 RUN apk add --no-cache wget curl unzip make libtool autoconf automake pkgconfig g++ sqlite sqlite-dev

--- a/gdal/docker/alpine-ultrasmall/Dockerfile
+++ b/gdal/docker/alpine-ultrasmall/Dockerfile
@@ -9,7 +9,7 @@ ARG ALPINE_VERSION=3.11
 FROM alpine:${ALPINE_VERSION} as builder
 
 # Derived from osgeo/proj by Howard Butler <howard@hobu.co>
-MAINTAINER Even Rouault <even.rouault@spatialys.com>
+LABEL maintainer="Even Rouault <even.rouault@spatialys.com>"
 
 # Setup build env for PROJ
 RUN apk add --no-cache wget curl unzip make libtool autoconf automake pkgconfig g++ sqlite sqlite-dev

--- a/gdal/docker/ubuntu-full/Dockerfile
+++ b/gdal/docker/ubuntu-full/Dockerfile
@@ -10,7 +10,7 @@ ARG PROJ_INSTALL_PREFIX=/usr/local
 FROM ubuntu:18.04 as builder
 
 # Derived from osgeo/proj by Howard Butler <howard@hobu.co>
-MAINTAINER Even Rouault <even.rouault@spatialys.com>
+LABEL maintainer="Even Rouault <even.rouault@spatialys.com>"
 
 # Setup build env for PROJ
 RUN apt-get update -y \

--- a/gdal/docker/ubuntu-small/Dockerfile
+++ b/gdal/docker/ubuntu-small/Dockerfile
@@ -10,7 +10,7 @@ ARG PROJ_INSTALL_PREFIX=/usr/local
 FROM ubuntu:18.04 as builder
 
 # Derived from osgeo/proj by Howard Butler <howard@hobu.co>
-MAINTAINER Even Rouault <even.rouault@spatialys.com>
+LABEL maintainer="Even Rouault <even.rouault@spatialys.com>"
 
 # Setup build env for PROJ
 RUN apt-get update -y \


### PR DESCRIPTION
## What does this PR do?
Use `LABEL` instruction instead of deprecated `MAINTAINER` in Dockerfiles

Reasoning:
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
> The MAINTAINER instruction sets the Author field of the generated images. The LABEL instruction is a much more flexible version of this and you should use it instead, as it enables setting any metadata you require, and can be viewed easily, for example with docker inspect. To set a label corresponding to the MAINTAINER field you could use:
`LABEL maintainer="SvenDowideit@home.org.au"`
This will then be visible from docker inspect with the other labels.