### PR TITLE
DTED: Add support for E96 DTED files for COMPD_CS 

### DIFF
--- a/gdal/frmts/dted/dteddataset.cpp
+++ b/gdal/frmts/dted/dteddataset.cpp
@@ -555,7 +555,7 @@ const char *DTEDDataset::_GetProjectionRef()
     {
 
         pszVertDatum = GetMetadataItem("DTED_VerticalDatum");
-        if (EQUAL(pszVertDatum, "MSL") &&
+        if ( (EQUAL(pszVertDatum, "MSL") || EQUAL(pszVertDatum, "E96") ) &&
             CPLTestBool( CPLGetConfigOption("REPORT_COMPD_CS", "NO") ) )
         {
                 return "COMPD_CS[\"WGS 84 + EGM96 geoid height\", GEOGCS[\"WGS 84\", DATUM[\"WGS_1984\", SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\",0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\",0.0174532925199433, AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST], AUTHORITY[\"EPSG\",\"4326\"]], VERT_CS[\"EGM96 geoid height\", VERT_DATUM[\"EGM96 geoid\",2005, AUTHORITY[\"EPSG\",\"5171\"]], UNIT[\"metre\",1, AUTHORITY[\"EPSG\",\"9001\"]], AXIS[\"Up\",UP], AUTHORITY[\"EPSG\",\"5773\"]]]";


### PR DESCRIPTION
DTED: Adds EGM96 (DTED_VerticalDatum=E96) in addition to MSL for COMPD_CS support
