### PR TITLE
Backward compatibility for BAG metadata reading

### DIFF
--- a/autotest/gdrivers/bag.py
+++ b/autotest/gdrivers/bag.py
@@ -128,6 +128,34 @@ def test_bag_3():
 #
 
 
+def test_bag_read_resolution():
+    if gdaltest.bag_drv is None:
+        pytest.skip()
+
+    # BAG version 1.1
+    ds = gdal.Open('data/true_n_nominal.bag')
+    gt = ds.GetGeoTransform()
+    # UpperLeft corner, resX, resY 
+    got = (gt[0], gt[3], gt[1], gt[5])
+    assert got == (12344.12345678, 22142.12345678, 2.0, -2.0)
+
+    # BAG version 1.4
+    ds = gdal.Open('data/southern_hemi_false_northing.bag')
+    gt = ds.GetGeoTransform()
+    got = (gt[0], gt[3], gt[1], gt[5])
+    assert got == (615037.5,  9559387.5, 75.0, -75.0)
+    
+    # BAG version 1.6
+    ds = gdal.Open('data/test_offset_ne_corner.bag')
+    gt = ds.GetGeoTransform()
+    got = (gt[0], gt[3], gt[1], gt[5])
+    assert got == (85.0, 500112.0, 30.0, -32.0)
+
+
+###############################################################################
+#
+
+
 def test_bag_vr_normal():
     if gdaltest.bag_drv is None:
         pytest.skip()

--- a/gdal/frmts/hdf5/bagdataset.cpp
+++ b/gdal/frmts/hdf5/bagdataset.cpp
@@ -3304,10 +3304,18 @@ void BAGDataset::LoadMetadata()
         {
             if( strcmp(psIter->pszValue, "axisDimensionProperties") == 0 )
             {
-                const char* pszDim = CPLGetXMLValue(
-                    psIter, "MD_Dimension.dimensionName.MD_DimensionNameTypeCode", nullptr);
-                const char* pszRes = CPLGetXMLValue(
-                    psIter, "MD_Dimension.resolution.Measure", nullptr);
+                const char* pszDim = CPLGetXMLValue(psIter, "MD_Dimension.dimensionName.MD_DimensionNameTypeCode", nullptr);
+                const char* pszRes = nullptr;
+                    if(pszDim)
+                    {
+                        pszRes = CPLGetXMLValue(psIter, "MD_Dimension.resolution.Measure", nullptr);
+					}
+					else
+					{
+ 						pszDim = CPLGetXMLValue(psIter, "MD_Dimension.dimensionName", nullptr);
+                    	pszRes = CPLGetXMLValue(psIter, "MD_Dimension.resolution.Measure.value", nullptr);
+					}
+
                 if( pszDim && EQUAL(pszDim, "row") && pszRes )
                 {
                     osResHeight = pszRes;

--- a/gdal/frmts/hdf5/bagdataset.cpp
+++ b/gdal/frmts/hdf5/bagdataset.cpp
@@ -3304,17 +3304,19 @@ void BAGDataset::LoadMetadata()
         {
             if( strcmp(psIter->pszValue, "axisDimensionProperties") == 0 )
             {
+                // since BAG format 1.5 version
                 const char* pszDim = CPLGetXMLValue(psIter, "MD_Dimension.dimensionName.MD_DimensionNameTypeCode", nullptr);
                 const char* pszRes = nullptr;
-                    if(pszDim)
-                    {
-                        pszRes = CPLGetXMLValue(psIter, "MD_Dimension.resolution.Measure", nullptr);
-					}
-					else
-					{
- 						pszDim = CPLGetXMLValue(psIter, "MD_Dimension.dimensionName", nullptr);
-                    	pszRes = CPLGetXMLValue(psIter, "MD_Dimension.resolution.Measure.value", nullptr);
-					}
+                if(pszDim)
+                {
+                    pszRes = CPLGetXMLValue(psIter, "MD_Dimension.resolution.Measure", nullptr);
+                }
+                else
+                {
+                    // prior to BAG format 1.5 version
+                    pszDim = CPLGetXMLValue(psIter, "MD_Dimension.dimensionName", nullptr);
+                    pszRes = CPLGetXMLValue(psIter, "MD_Dimension.resolution.Measure.value", nullptr);
+                }
 
                 if( pszDim && EQUAL(pszDim, "row") && pszRes )
                 {


### PR DESCRIPTION
BAG XML metadata schema has been modified with version 1.5; actually, GDAL only handles latest format, this pull request proposes to handle backward compatibility (from 1.0 to 1.6 versions)

