### PR TITLE
JP2OpenJPEG: add support for generating files with PLT marker segments and multithreaded encoding

### DIFF
--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -3164,6 +3164,36 @@ def test_jp2openjpeg_tilesize_16():
     assert ds.GetRasterBand(1).GetOverview(0).Checksum() == 61711
 
 ###############################################################################
+# Test generation of PLT marker segments
+
+
+def test_jp2openjpeg_generate_PLT():
+
+    if gdaltest.jp2openjpeg_drv is None:
+        pytest.skip()
+
+    # Only try the rest with openjpeg > 2.3.1 that supports it
+    if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('PLT') < 0:
+        pytest.skip()
+
+    filename = '/vsimem/temp.jp2'
+    gdaltest.jp2openjpeg_drv.CreateCopy(filename, gdal.Open('data/byte.tif'),
+                                        options=['PLT=YES',
+                                                 'REVERSIBLE=YES',
+                                                 'QUALITY=100'])
+
+    ds = gdal.Open(filename)
+    assert ds.GetRasterBand(1).Checksum() == 4672
+    ds = None
+
+    # Check presence of a PLT marker
+    ret = gdal.GetJPEG2000StructureAsString(filename, ['ALL=YES'])
+    assert '<Marker name="PLT"' in ret
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+
+###############################################################################
 
 
 def test_jp2openjpeg_cleanup():

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -39,6 +39,8 @@ import pytest
 
 import gdaltest
 
+pytestmark = pytest.mark.require_driver('JP2OpenJPEG')
+
 ###############################################################################
 # Verify we have the driver.
 
@@ -46,8 +48,7 @@ import gdaltest
 def test_jp2openjpeg_1():
 
     gdaltest.jp2openjpeg_drv = gdal.GetDriverByName('JP2OpenJPEG')
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
+    assert gdaltest.jp2openjpeg_drv is not None
 
     gdaltest.deregister_all_jpeg2000_drivers_but('JP2OpenJPEG')
 
@@ -56,9 +57,6 @@ def test_jp2openjpeg_1():
 
 
 def test_jp2openjpeg_2():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
@@ -90,9 +88,6 @@ def test_jp2openjpeg_2():
 
 def test_jp2openjpeg_3():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jpeg2000/int16.jp2')
     ds_ref = gdal.Open('data/int16.tif')
 
@@ -114,9 +109,6 @@ def test_jp2openjpeg_3():
 
 
 def test_jp2openjpeg_4(out_filename='tmp/jp2openjpeg_4.jp2'):
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.Open('data/jpeg2000/byte.jp2')
     src_wkt = src_ds.GetProjectionRef()
@@ -176,9 +168,6 @@ def test_jp2openjpeg_4_vsimem():
 
 def test_jp2openjpeg_5():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2OpenJPEG', 'jpeg2000/int16.jp2', 1, None, options=['REVERSIBLE=YES', 'QUALITY=100', 'CODEC=J2K'])
     return tst.testCreateCopy()
 
@@ -188,11 +177,7 @@ def test_jp2openjpeg_5():
 
 def test_jp2openjpeg_6():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2OpenJPEG', 'jpeg2000/ll.jp2', 1, None)
-
     tst.testOpen()
 
     ds = gdal.Open('data/jpeg2000/ll.jp2')
@@ -205,9 +190,6 @@ def test_jp2openjpeg_6():
 
 def test_jp2openjpeg_7():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     tst = gdaltest.GDALTest('JP2OpenJPEG', '/vsigzip/data/jpeg2000/byte.jp2.gz', 1, 50054, filename_absolute=1)
     ret = tst.testOpen()
     gdal.Unlink('data/jpeg2000/byte.jp2.gz.properties')
@@ -218,9 +200,6 @@ def test_jp2openjpeg_7():
 
 
 def test_jp2openjpeg_8():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/jpeg2000/3_13bit_and_1bit.jp2')
 
@@ -238,9 +217,6 @@ def test_jp2openjpeg_8():
 
 def test_jp2openjpeg_9():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jpeg2000/byte_without_geotransform.jp2')
 
     geotransform = ds.GetGeoTransform()
@@ -254,9 +230,6 @@ def test_jp2openjpeg_9():
 
 
 def test_jp2openjpeg_10():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.Open('data/rgbsmall.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_10.jp2', src_ds, options=['YCBCR420=YES', 'RESOLUTIONS=3'])
@@ -276,9 +249,6 @@ def test_jp2openjpeg_10():
 
 
 def test_jp2openjpeg_11():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/jpeg2000/stefan_full_rgba_alpha_1bit.jp2')
     fourth_band = ds.GetRasterBand(4)
@@ -312,9 +282,6 @@ def test_jp2openjpeg_11():
 
 
 def test_jp2openjpeg_12():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # Override projection
     shutil.copy('data/jpeg2000/byte.jp2', 'tmp/jp2openjpeg_12.jp2')
@@ -353,9 +320,6 @@ def test_jp2openjpeg_12():
 
 
 def test_jp2openjpeg_13():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # Create a dataset with GCPs
     src_ds = gdal.Open('data/rgb_gcp.vrt')
@@ -400,9 +364,6 @@ def test_jp2openjpeg_13():
 
 def test_jp2openjpeg_14():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jpeg2000/byte_2gcps.jp2')
     assert ds.GetGCPCount() == 2
 
@@ -411,9 +372,6 @@ def test_jp2openjpeg_14():
 
 
 def test_jp2openjpeg_15():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 256, 256)
     src_ds.GetRasterBand(1).Fill(255)
@@ -430,9 +388,6 @@ def test_jp2openjpeg_15():
 
 
 def test_jp2openjpeg_16():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/jpeg2000/byte_point.jp2')
     gt = ds.GetGeoTransform()
@@ -463,9 +418,6 @@ def test_jp2openjpeg_16():
 
 def test_jp2openjpeg_17():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/jpeg2000/byte_point.jp2')
     ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_17.jp2', src_ds)
     ds = None
@@ -492,9 +444,6 @@ def test_jp2openjpeg_17():
 
 def test_jp2openjpeg_18():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('Mem').Create('', 2000, 2000)
     ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_18.jp2', src_ds, options=['BLOCKXSIZE=2000', 'BLOCKYSIZE=2000'])
     ds = None
@@ -513,9 +462,6 @@ def test_jp2openjpeg_18():
 
 def test_jp2openjpeg_19():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jpeg2000/byte_gmljp2_with_nul_car.jp2')
     assert ds.GetProjectionRef() != ''
     ds = None
@@ -525,9 +471,6 @@ def test_jp2openjpeg_19():
 
 
 def test_jp2openjpeg_20():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     try:
         import xmlvalidate
@@ -591,9 +534,6 @@ def test_jp2openjpeg_20():
 
 def test_jp2openjpeg_21():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/rgbsmall.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_21.jp2', src_ds, options=['QUALITY=100', 'REVERSIBLE=YES', 'YCC=NO'])
     maxdiff = gdaltest.compare_ds(src_ds, out_ds)
@@ -609,9 +549,6 @@ def test_jp2openjpeg_21():
 
 
 def test_jp2openjpeg_22():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # RGBA
     src_ds = gdal.Open('../gcore/data/stefan_full_rgba.tif')
@@ -712,9 +649,6 @@ def test_jp2openjpeg_22():
 
 def test_jp2openjpeg_23():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/uint16.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_23.jp2', src_ds, options=['NBITS=9', 'QUALITY=100', 'REVERSIBLE=YES'])
     maxdiff = gdaltest.compare_ds(src_ds, out_ds)
@@ -739,9 +673,6 @@ def test_jp2openjpeg_23():
 
 
 def test_jp2openjpeg_24():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     #  Grey+alpha
     src_ds = gdal.Open('../gcore/data/stefan_full_greyalpha.tif')
@@ -780,9 +711,6 @@ def test_jp2openjpeg_24():
 
 
 def test_jp2openjpeg_25():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 5)
     src_ds.GetRasterBand(1).Fill(255)
@@ -845,9 +773,6 @@ def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=Non
 
 
 def test_jp2openjpeg_26():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 2048, 2048, 1)
     sr = osr.SpatialReference()
@@ -990,9 +915,6 @@ def test_jp2openjpeg_26():
 
 def test_jp2openjpeg_27():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # Test optimization in GDALCopyWholeRasterGetSwathSize()
     # Not sure how we can check that except looking at logs with CPL_DEBUG=GDAL
     # for "GDAL: GDALDatasetCopyWholeRaster(): 2048*2048 swaths, bInterleave=1"
@@ -1074,9 +996,6 @@ def jp2openjpeg_test_codeblock(filename, codeblock_width, codeblock_height):
 
 def test_jp2openjpeg_28():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
 
     tests = [(['CODEBLOCK_WIDTH=2'], 64, 64, True),
@@ -1109,9 +1028,6 @@ def test_jp2openjpeg_28():
 
 def test_jp2openjpeg_29():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 128, 128, 1)
 
     tests = [(['TILEPARTS=DISABLED'], False),
@@ -1143,9 +1059,6 @@ def test_jp2openjpeg_29():
 
 
 def test_jp2openjpeg_30():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
     ct = gdal.ColorTable()
@@ -1233,9 +1146,6 @@ def test_jp2openjpeg_30():
 
 def test_jp2openjpeg_31():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 3)
     src_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_GreenBand)
     src_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_BlueBand)
@@ -1273,9 +1183,6 @@ def test_jp2openjpeg_31():
 
 def test_jp2openjpeg_32():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 10, 10, 1)
     gdal.PushErrorHandler()
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_32.jp2', src_ds, options=['JP2C_XLBOX=YES'])
@@ -1289,9 +1196,6 @@ def test_jp2openjpeg_32():
 
 
 def test_jp2openjpeg_33():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.Open("""<VRTDataset rasterXSize="100000" rasterYSize="100000">
   <VRTRasterBand dataType="Byte" band="1">
@@ -1312,9 +1216,6 @@ def test_jp2openjpeg_33():
 
 def test_jp2openjpeg_34():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     gdal.PushErrorHandler()
     ds = gdal.Open('data/jpeg2000/dimensions_above_31bit.jp2')
     gdal.PopErrorHandler()
@@ -1325,9 +1226,6 @@ def test_jp2openjpeg_34():
 # Test opening a truncated file
 
 def test_jp2openjpeg_35():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     gdal.PushErrorHandler()
     ds = gdal.Open('data/jpeg2000/truncated.jp2')
@@ -1340,9 +1238,6 @@ def test_jp2openjpeg_35():
 
 def test_jp2openjpeg_36():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2, 16385)
     gdal.PushErrorHandler()
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_36.jp2', src_ds)
@@ -1354,9 +1249,6 @@ def test_jp2openjpeg_36():
 
 
 def test_jp2openjpeg_37():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)
@@ -1450,9 +1342,6 @@ def test_jp2openjpeg_37():
 
 def test_jp2openjpeg_38():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)
     wkt = """PROJCS["UTM Zone 31, Northern Hemisphere",GEOGCS["unnamed ellipse",DATUM["unknown",SPHEROID["unnamed",100,1]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",3],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]"""
@@ -1486,9 +1375,6 @@ def test_jp2openjpeg_38():
 
 
 def test_jp2openjpeg_39():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
@@ -1555,9 +1441,6 @@ def test_jp2openjpeg_39():
 
 
 def test_jp2openjpeg_40():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # No metadata
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
@@ -1632,9 +1515,6 @@ def test_jp2openjpeg_40():
 
 def test_jp2openjpeg_41():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/jpeg2000/byte.jp2')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_41.jp2', src_ds,
                                                  options=['USE_SRC_CODESTREAM=YES', 'PROFILE=PROFILE_1', 'GEOJP2=NO', 'GMLJP2=NO'])
@@ -1671,9 +1551,6 @@ def test_jp2openjpeg_41():
 
 
 def test_jp2openjpeg_42():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
     gdal.PushErrorHandler()
@@ -1822,9 +1699,6 @@ def test_jp2openjpeg_43():
 
 def test_jp2openjpeg_44():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('data/utm.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_44.jp2', src_ds, options=['INSPIRE_TG=YES'])
     del out_ds
@@ -1839,9 +1713,6 @@ def test_jp2openjpeg_44():
 
 
 def test_jp2openjpeg_45():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     with gdaltest.error_handler():
         if ogr.Open('../ogr/data/gml/ionic_wfs.gml') is None:
@@ -2539,9 +2410,6 @@ def test_jp2openjpeg_45():
 
 def test_jp2openjpeg_46():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     import json
 
     conf = {
@@ -2701,9 +2569,6 @@ yeah: """ not in gmljp2:
 
 def test_jp2openjpeg_47():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     src_ds = gdal.Open('../gcore/data/byte_rpc.tif')
     out_ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_47.jp2', src_ds)
     del out_ds
@@ -2721,9 +2586,6 @@ def test_jp2openjpeg_47():
 
 def test_jp2openjpeg_48():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jpeg2000/byte_tile_2048.jp2')
     (blockxsize, blockysize) = ds.GetRasterBand(1).GetBlockSize()
     assert (blockxsize, blockysize) == (20, 20)
@@ -2734,9 +2596,6 @@ def test_jp2openjpeg_48():
 
 
 def test_jp2openjpeg_online_1():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k', '7sisters200.j2k'):
         pytest.skip()
@@ -2754,9 +2613,6 @@ def test_jp2openjpeg_online_1():
 
 
 def test_jp2openjpeg_online_2():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     if not gdaltest.download_file('http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2', 'gcp.jp2'):
         pytest.skip()
@@ -2779,9 +2635,6 @@ def test_jp2openjpeg_online_2():
 
 
 def test_jp2openjpeg_online_3():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne1.j2k', 'Bretagne1.j2k'):
         pytest.skip()
@@ -2808,9 +2661,6 @@ def test_jp2openjpeg_online_3():
 
 
 def test_jp2openjpeg_online_4():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     if not gdaltest.download_file('http://www.openjpeg.org/samples/Bretagne2.j2k', 'Bretagne2.j2k'):
         pytest.skip()
@@ -2839,9 +2689,6 @@ def test_jp2openjpeg_online_4():
 
 def test_jp2openjpeg_online_5():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9.jp2', 'file9.jp2'):
         pytest.skip()
 
@@ -2857,9 +2704,6 @@ def test_jp2openjpeg_online_5():
 
 
 def test_jp2openjpeg_online_6():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     if not gdaltest.download_file('http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_03/file3.jp2', 'file3.jp2'):
         pytest.skip()
@@ -2878,9 +2722,6 @@ def test_jp2openjpeg_online_6():
 
 
 def test_jp2openjpeg_49():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     tests = [(None, True, True, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
              (None, True, False, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
@@ -3005,9 +2846,6 @@ def test_jp2openjpeg_49():
 
 def test_jp2openjpeg_50():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jpeg2000/fake_sent2_preview.jp2')
     blockxsize, blockysize = ds.GetRasterBand(1).GetBlockSize()
     assert blockxsize == ds.RasterXSize and blockysize == ds.RasterYSize, \
@@ -3020,9 +2858,6 @@ def test_jp2openjpeg_50():
 
 
 def test_jp2openjpeg_codeblock_style():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('CODEBLOCK_STYLE') < 0:
         pytest.skip()
@@ -3057,9 +2892,6 @@ def test_jp2openjpeg_codeblock_style():
 
 def test_jp2openjpeg_external_overviews_single_band():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     filename = '/vsimem/jp2openjpeg_external_overviews_single_band.jp2'
     gdaltest.jp2openjpeg_drv.CreateCopy(filename,
                                         gdal.Open('../gcore/data/utmsmall.tif'),
@@ -3081,9 +2913,6 @@ def test_jp2openjpeg_external_overviews_single_band():
 
 
 def test_jp2openjpeg_external_overviews_multiple_band():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     filename = '/vsimem/jp2openjpeg_external_overviews_multiple_band.jp2'
     gdaltest.jp2openjpeg_drv.CreateCopy(filename,
@@ -3108,9 +2937,6 @@ def test_jp2openjpeg_external_overviews_multiple_band():
 
 def test_jp2openjpeg_odd_dimensions():
 
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
-
     ds = gdal.Open('data/jpeg2000/513x513.jp2')
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     ds = None
@@ -3121,9 +2947,6 @@ def test_jp2openjpeg_odd_dimensions():
 
 
 def test_jp2openjpeg_odd_dimensions_overviews():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # Only try the rest with openjpeg >= 2.3 to avoid potential memory issues
     if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('CODEBLOCK_STYLE') < 0:
@@ -3140,9 +2963,6 @@ def test_jp2openjpeg_odd_dimensions_overviews():
 
 
 def test_jp2openjpeg_image_origin_not_zero():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     ds = gdal.Open('data/jpeg2000/byte_image_origin_not_zero.jp2')
     assert ds.GetRasterBand(1).Checksum() == 4672
@@ -3168,9 +2988,6 @@ def test_jp2openjpeg_tilesize_16():
 
 
 def test_jp2openjpeg_generate_PLT():
-
-    if gdaltest.jp2openjpeg_drv is None:
-        pytest.skip()
 
     # Only try the rest with openjpeg > 2.3.1 that supports it
     if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('PLT') < 0:

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -368,15 +368,17 @@ def test_jp2openjpeg_14():
     assert ds.GetGCPCount() == 2
 
 ###############################################################################
-# Test multi-threading reading
+# Test multi-threading reading and (possibly) writing
 
-
-def test_jp2openjpeg_15():
+@pytest.mark.parametrize('JP2OPENJPEG_USE_THREADED_IO', ['YES', 'NO'])
+def test_jp2openjpeg_15(JP2OPENJPEG_USE_THREADED_IO):
 
     src_ds = gdal.GetDriverByName('MEM').Create('', 256, 256)
     src_ds.GetRasterBand(1).Fill(255)
     data = src_ds.ReadRaster()
-    ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_15.jp2', src_ds, options=['BLOCKXSIZE=32', 'BLOCKYSIZE=32'])
+    # Setting only used for writing
+    with gdaltest.config_option('JP2OPENJPEG_USE_THREADED_IO', JP2OPENJPEG_USE_THREADED_IO):
+        ds = gdaltest.jp2openjpeg_drv.CreateCopy('/vsimem/jp2openjpeg_15.jp2', src_ds, options=['BLOCKXSIZE=33', 'BLOCKYSIZE=34'])
     src_ds = None
     got_data = ds.ReadRaster()
     ds = None

--- a/gdal/doc/source/drivers/raster/jp2openjpeg.rst
+++ b/gdal/doc/source/drivers/raster/jp2openjpeg.rst
@@ -67,13 +67,16 @@ the GDAL_NUM_THREADS configuration option that defaults to ALL_CPUS in
 that context. In case RAM is limited, it can be needed to set this
 configuration option to 1 to disable multi-threading
 
-Starting with OpenJPEG 2.2.0, multi-threading decoding can also be
-enabld at the code-block level. This must be enabled with the
+Starting with OpenJPEG 2.2.0, multi-threaded decoding can also be
+enabled at the code-block level. This must be enabled with the
 OPJ_NUM_THREADS environment variable (note: this is a system environment
 variable, not a GDAL configuration option), which can be set to a
 numeric value or NUM_CPUS. Its default value is 1. Starting with GDAL
 2.3, this multi-threading at code-block level is automatically enabled
-by GDAL
+by GDAL.
+Starting with GDAL 3.0.1 and OpenJPEG 2.3.2, multi-threaded encoding is
+automatically enabled and can be controlled with the OPJ_NUM_THREADS environment
+variable or the GDAL_NUM_THREADS configuration option.
 
 Both multi-threading mechanism can be combined together.
 

--- a/gdal/doc/source/drivers/raster/jp2openjpeg.rst
+++ b/gdal/doc/source/drivers/raster/jp2openjpeg.rst
@@ -258,6 +258,9 @@ Creation Options
    increase codestream size, but improve either coding/decoding speed or
    resilience/error detection.
 
+-  **PLT=YES/NO**: (GDAL >= 3.1.1 and OpenJPEG > 2.3.1) Whether to write a
+   PLT (Packet Length) marker segments in tile-part headers. Defaults to NO.
+
 -  **WRITE_METADATA=YES/NO**: Whether metadata should be
    written, in a dedicated JP2 'xml ' box. Defaults to NO. The content
    of the 'xml ' box will be like:

--- a/gdal/frmts/openjpeg/openjpegdataset.cpp
+++ b/gdal/frmts/openjpeg/openjpegdataset.cpp
@@ -224,7 +224,7 @@ class JP2OpenJPEGDataset final: public GDALJP2AbstractDataset
     JP2OpenJPEGDataset** papoOverviewDS = nullptr;
     bool        bUseSetDecodeArea = false;
     bool        bSingleTiled = false;
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     opj_codec_t**    m_ppCodec = nullptr;
     opj_stream_t **  m_ppStream = nullptr;
     opj_image_t **   m_ppsImage = nullptr;
@@ -819,7 +819,7 @@ CPLErr JP2OpenJPEGDataset::ReadBlock( int nBand, VSILFILE* fpIn,
     const int nHeightToRead =
         std::min(nBlockYSize, nRasterYSize - nBlockYOff * nBlockYSize);
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     if( m_ppCodec &&
         CPLTestBool(CPLGetConfigOption("USE_OPENJPEG_SINGLE_TILE_OPTIM", "YES")) )
     {
@@ -872,7 +872,7 @@ CPLErr JP2OpenJPEGDataset::ReadBlock( int nBand, VSILFILE* fpIn,
             goto end;
         }
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
         if( m_psJP2OpenJPEGFile )
         {
             pStream = JP2OpenJPEGCreateReadStream( m_psJP2OpenJPEGFile, nCodeStreamLength);
@@ -891,7 +891,7 @@ CPLErr JP2OpenJPEGDataset::ReadBlock( int nBand, VSILFILE* fpIn,
             goto end;
         }
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 2
+#if IS_OPENJPEG_OR_LATER(2,2,0)
         if( getenv("OPJ_NUM_THREADS") == nullptr )
         {
             if( m_nBlocksToLoad <= 1 )
@@ -904,7 +904,7 @@ CPLErr JP2OpenJPEGDataset::ReadBlock( int nBand, VSILFILE* fpIn,
         if(!opj_read_header(pStream,pCodec,&psImage))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "opj_read_header() failed (psImage=%p)", psImage);
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 2
+#if IS_OPENJPEG_OR_LATER(2,2,0)
             // Hopefully the situation is better on openjpeg 2.2 regarding cleanup
             eErr = CE_Failure;
             goto end;
@@ -1119,7 +1119,7 @@ CPLErr JP2OpenJPEGDataset::ReadBlock( int nBand, VSILFILE* fpIn,
     }
 
 end:
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     if( m_ppCodec != nullptr &&
         CPLTestBool(CPLGetConfigOption("USE_OPENJPEG_SINGLE_TILE_OPTIM", "YES")) )
     {
@@ -1225,7 +1225,7 @@ JP2OpenJPEGDataset::~JP2OpenJPEGDataset()
 {
     FlushCache();
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     if( iLevel == 0 )
     {
         if( m_ppCodec )
@@ -1706,7 +1706,7 @@ GDALDataset *JP2OpenJPEGDataset::Open( GDALOpenInfo * poOpenInfo )
         return nullptr;
     }
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     if( getenv("OPJ_NUM_THREADS") == nullptr )
     {
         JP2OpenJPEGDataset oTmpDS;
@@ -2165,7 +2165,7 @@ GDALDataset *JP2OpenJPEGDataset::Open( GDALOpenInfo * poOpenInfo )
     if( poCT != nullptr )
         numResolutions = 0;
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     if( poDS->bSingleTiled && poDS->bUseSetDecodeArea )
     {
         poDS->m_ppCodec = new opj_codec_t* (pCodec);
@@ -2220,7 +2220,7 @@ GDALDataset *JP2OpenJPEGDataset::Open( GDALOpenInfo * poOpenInfo )
         poODS->nCodeStreamLength = nCodeStreamLength;
         poODS->bIs420 = bIs420;
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
         if( poODS->bSingleTiled && poODS->bUseSetDecodeArea )
         {
             poODS->m_ppCodec = poDS->m_ppCodec;
@@ -2252,7 +2252,7 @@ GDALDataset *JP2OpenJPEGDataset::Open( GDALOpenInfo * poOpenInfo )
         poDS->papoOverviewDS[poDS->nOverviewCount ++] = poODS;
     }
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     if( poDS->bSingleTiled && poDS->bUseSetDecodeArea )
     {
         // nothing
@@ -2660,8 +2660,7 @@ GDALDataset * JP2OpenJPEGDataset::CreateCopy( const char * pszFilename,
     int bYCC = ((nBands == 3 || nBands == 4) &&
             CPLTestBool(CSLFetchNameValueDef(papszOptions, "YCC", "TRUE")));
 
-#if OPJ_VERSION_MAJOR == 2 && OPJ_VERSION_MINOR < 2
-    /* TODO: when OpenJPEG 2.2 is released, make this conditional */
+#if !(IS_OPENJPEG_OR_LATER(2,2,0))
     /* Depending on the way OpenJPEG <= r2950 is built, YCC with 4 bands might work on
      * Debug mode, but this relies on unreliable stack buffer overflows, so
      * better err on the safe side */
@@ -3085,7 +3084,7 @@ GDALDataset * JP2OpenJPEGDataset::CreateCopy( const char * pszFilename,
     parameters.cblockh_init = nCblockH;
     parameters.mode = 0;
 
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
     // Was buggy before for some of the options
     const char* pszCodeBlockStyle = CSLFetchNameValue(papszOptions, "CODEBLOCK_STYLE");
     if( pszCodeBlockStyle )
@@ -4193,7 +4192,7 @@ void GDALRegister_JP2OpenJPEG()
 "   <Option name='WRITE_METADATA' type='boolean' description='Whether metadata should be written, in a dedicated JP2 XML box' default='NO'/>"
 "   <Option name='MAIN_MD_DOMAIN_ONLY' type='boolean' description='(Only if WRITE_METADATA=YES) Whether only metadata from the main domain should be written' default='NO'/>"
 "   <Option name='USE_SRC_CODESTREAM' type='boolean' description='When source dataset is JPEG2000, whether to reuse the codestream of the source dataset unmodified' default='NO'/>"
-#if OPJ_VERSION_MAJOR > 2 || OPJ_VERSION_MINOR >= 3
+#if IS_OPENJPEG_OR_LATER(2,3,0)
 "   <Option name='CODEBLOCK_STYLE' type='string' description='Comma-separated combination of BYPASS, RESET, TERMALL, VSC, PREDICTABLE, SEGSYM or value between 0 and 63'/>"
 #endif
 #if IS_OPENJPEG_OR_LATER(2,3,2)

--- a/gdal/frmts/openjpeg/openjpegdataset.cpp
+++ b/gdal/frmts/openjpeg/openjpegdataset.cpp
@@ -3321,6 +3321,13 @@ GDALDataset * JP2OpenJPEGDataset::CreateCopy( const char * pszFilename,
     }
 
 #if IS_OPENJPEG_OR_LATER(2,3,2)
+
+    if( getenv("OPJ_NUM_THREADS") == nullptr )
+    {
+        JP2OpenJPEGDataset oTmpDS;
+        opj_codec_set_threads(pCodec, oTmpDS.GetNumThreads());
+    }
+
     if( CPLTestBool(CSLFetchNameValueDef(papszOptions, "PLT", "FALSE")) )
     {
         const char* const apszOptions[] = { "PLT=YES", nullptr };


### PR DESCRIPTION
Available with OpenJPEG > 2.3.1

Funded by ESA for S2-MPC project

