### PR TITLE
JPEG: tune sanity check for multiple-scan images

### DIFF
--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -2904,8 +2904,12 @@ def test_tiff_read_progressive_jpeg_denial_of_service():
     # Should error out with 'JPEGPreDecode:Reading this strip would require
     # libjpeg to allocate at least...'
     gdal.ErrorReset()
-    ds = gdal.Open('/vsizip/data/eofloop_valid_huff.tif.zip')
     with gdaltest.error_handler():
+        os.environ['JPEGMEM'] = '10M'
+        os.environ['LIBTIFF_JPEG_MAX_ALLOWED_SCAN_NUMBER'] = '1000'
+        ds = gdal.Open('/vsizip/data/eofloop_valid_huff.tif.zip')
+        del os.environ['LIBTIFF_JPEG_MAX_ALLOWED_SCAN_NUMBER']
+        del os.environ['JPEGMEM']
         cs = ds.GetRasterBand(1).Checksum()
         assert cs == 0 and gdal.GetLastErrorMsg() != ''
 
@@ -2918,9 +2922,8 @@ def test_tiff_read_progressive_jpeg_denial_of_service():
         cs = ds.GetRasterBand(1).Checksum()
         del os.environ['LIBTIFF_ALLOW_LARGE_LIBJPEG_MEM_ALLOC']
         del os.environ['LIBTIFF_JPEG_MAX_ALLOWED_SCAN_NUMBER']
-        assert gdal.GetLastErrorMsg() != ''
+        assert cs == 0 and gdal.GetLastErrorMsg() != ''
 
-    
 
 ###############################################################################
 # Test reading old-style LZW


### PR DESCRIPTION
 to allow up to the limit set by JPEGMEM (500 MB) instead of a 100 MB limit (fixes for o17855_k004.jpg of https://github.com/qgis/QGIS/issues/35957 and should also address https://github.com/qgis/QGIS/issues/35982 for most cases)
