### PR TITLE
Fix spelling errors.

### DIFF
--- a/gdal/apps/ogr2ogr_lib.cpp
+++ b/gdal/apps/ogr2ogr_lib.cpp
@@ -3767,7 +3767,7 @@ std::unique_ptr<TargetLayerInfo> SetupTargetLayer::Setup(OGRLayer* poSrcLayer,
             bPreserveFID = true;
         }
 
-        // If bAddOverwriteLCO is ON (set up when overwritting a CARTO layer),
+        // If bAddOverwriteLCO is ON (set up when overwriting a CARTO layer),
         // set OVERWRITE to YES so the new layer overwrites the old one
         if (bAddOverwriteLCO)
         {

--- a/gdal/frmts/pds/vicardataset.cpp
+++ b/gdal/frmts/pds/vicardataset.cpp
@@ -1372,7 +1372,7 @@ static std::string SanitizeItemName(const std::string& osItemName)
     if( osRet != osItemName )
     {
         CPLError(CE_Warning, CPLE_AppDefined,
-                 "Lable item name %s has been sanitized to %s",
+                 "Label item name %s has been sanitized to %s",
                  osItemName.c_str(), osRet.c_str());
     }
     return osRet;

--- a/gdal/gcore/gdalmultidim.cpp
+++ b/gdal/gcore/gdalmultidim.cpp
@@ -1202,7 +1202,7 @@ bool GDALAbstractMDArray::Read(const GUInt64* arrayStartIdx,
     if( !GetDataType().CanConvertTo(bufferDataType) )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "Array data type is not convertable to buffer data type");
+                 "Array data type is not convertible to buffer data type");
         return false;
     }
 
@@ -1319,7 +1319,7 @@ bool GDALAbstractMDArray::Write(const GUInt64* arrayStartIdx,
     if( !bufferDataType.CanConvertTo(GetDataType()) )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "Buffer data type is not convertable to array data type");
+                 "Buffer data type is not convertible to array data type");
         return false;
     }
 

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -1174,7 +1174,7 @@ OGRErr OGRFlatGeobufLayer::ICreateFeature(OGRFeature *poNewFeature)
 #endif
     if (ogrGeometry == nullptr || ogrGeometry->IsEmpty())
     {
-        CPLDebug("FlatGeobuf", "Skip writting feature without geometry");
+        CPLDebug("FlatGeobuf", "Skip writing feature without geometry");
         return OGRERR_NONE;
     }
     if (m_geometryType != GeometryType::Unknown && ogrGeometry->getGeometryType() != m_eGType) {


### PR DESCRIPTION
The lintian QA tool reported a couple spelling errors for the Debian package build of 3.1.0-rc1:

 * Lable       -> Label
 * convertable -> convertible
 * writting    -> writing