### PR TITLE
FlatGeobuf: add null check for readMultiPolygon

### DIFF
--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/geometryreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/geometryreader.cpp
@@ -259,13 +259,10 @@ OGRMultiPolygon *GeometryReader::readMultiPolygon()
     auto mp = std::unique_ptr<OGRMultiPolygon>(new OGRMultiPolygon());
     for (uoffset_t i = 0; i < parts->size(); i++) {
         GeometryReader reader { parts->Get(i), GeometryType::Polygon, m_hasZ, m_hasM };
-        auto g = reader.read();
+        auto g = std::unique_ptr<OGRGeometry>(reader.read());
         if (g == nullptr)
             return nullptr;
-        auto p = std::unique_ptr<OGRPolygon>(g->toPolygon());
-        if (p == nullptr)
-            return nullptr;
-        mp->addGeometryDirectly(p.release());
+        mp->addGeometryDirectly(g.release()->toPolygon());
     }
     return mp.release();
 }

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/geometryreader.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/geometryreader.cpp
@@ -259,7 +259,10 @@ OGRMultiPolygon *GeometryReader::readMultiPolygon()
     auto mp = std::unique_ptr<OGRMultiPolygon>(new OGRMultiPolygon());
     for (uoffset_t i = 0; i < parts->size(); i++) {
         GeometryReader reader { parts->Get(i), GeometryType::Polygon, m_hasZ, m_hasM };
-        auto p = std::unique_ptr<OGRPolygon>(reader.read()->toPolygon());
+        auto g = reader.read();
+        if (g == nullptr)
+            return nullptr;
+        auto p = std::unique_ptr<OGRPolygon>(g->toPolygon());
         if (p == nullptr)
             return nullptr;
         mp->addGeometryDirectly(p.release());


### PR DESCRIPTION
ref https://github.com/OSGeo/gdal/issues/2459

I'm not sure this is the correct fix though and wonder why the other similar cases are slightly different (the ->toCurve ones).