### PR TITLE
Spatial Index

### DIFF
--- a/gdal/doc/source/drivers/vector/mssqlspatial.rst
+++ b/gdal/doc/source/drivers/vector/mssqlspatial.rst
@@ -1,6 +1,6 @@
 .. _vector.mssqlspatial:
 
-MSSQLSpatial - Microsoft SQL Server Spatial Database
+MSSQLSpatial - Microsoft SQL Server Spatial  Database
 ====================================================
 
 .. shortname:: MSSQLSpatial


### PR DESCRIPTION
The new driver does create a SQL Server spatial index by default.   The documentation correctly notes this.

However, the section explaining how to create a spatial index manually was left there.  It might be removed, or should include a note that the index is now default.

Didn't make any actual changes to the doc file, I'm just suggesting it to be edited.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [x] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
