### PR TITLE
Fix wrong IO of subpixel shifted window

### DIFF
--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -2033,7 +2033,13 @@ CPLErr GDALDataset::IRasterIO( GDALRWFlag eRWFlag,
 
     CPLAssert(nullptr != pData);
 
-    if (nXSize == nBufXSize && nYSize == nBufYSize && nBandCount > 1 &&
+    const bool bHasSubpixelShift =
+       psExtraArg->bFloatingPointWindowValidity &&
+       psExtraArg->eResampleAlg != GRIORA_NearestNeighbour &&
+       (nXOff != psExtraArg->dfXOff || nYOff != psExtraArg->dfYOff);
+
+    if (!bHasSubpixelShift &&
+        nXSize == nBufXSize && nYSize == nBufYSize && nBandCount > 1 &&
         (pszInterleave = GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE")) !=
             nullptr &&
         EQUAL(pszInterleave, "PIXEL"))


### PR DESCRIPTION
Fix wrong IO of subpixel shifted window when buffer size is equal to window size and image has pixel interleaving (fixes #2507).

This case cannot be tested using current autotests because python dataset.ReadRaster() does not support subpixel shifts.

## Error description

Given GeoTIFF with ```INTERLEAVE=PIXEL```. Try to read buffer shifted by 0.5 pixels:

```c++
int bufferSize = 100;
GDALRasterIOExtraArg args;
INIT_RASTERIO_EXTRA_ARG(args);
args.eResampleAlg = GRIORA_Bilinear;
args.bFloatingPointWindowValidity = true;
args.dfXOff = 0.5;
args.dfYOff = 0.5;
args.dfXSize = bufferSize;
args.dfYSize = bufferSize;
dataset->RasterIO(GF_Read, 0, 0, bufferSize, bufferSize, buffer, bufferSize, bufferSize, GDT_Byte, 3, nullptr, 0, 0, 0, &args);
```

### Results

Expected (when using band interleaving image)
![img_expected_bi_0 5](https://user-images.githubusercontent.com/3948696/81483442-e674c600-9246-11ea-8599-52f5d93d58ce.png)

Got
![img_got_bi_0 5](https://user-images.githubusercontent.com/3948696/81483443-e7a5f300-9246-11ea-862f-0b6a09233e69.png)

