### PR TITLE
Fix Python2 install to be synchronous and report all errors

### DIFF
--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -344,7 +344,8 @@ if sys.version_info < (3,):
             self.check_extensions_list(self.extensions)
 
             with Pool(num_jobs) as pool:
-                pool.map(self.build_extension, self.extensions)
+                # Note: map() returns an iterator that needs to be consumed.
+                list(pool.map(self.build_extension, self.extensions))
 
         build_ext.build_extensions = parallel_build_extensions
     except:


### PR DESCRIPTION
The Python 2 install uses ThreadedPoolExecutor.map() which returns an iterator.
That iterator needs to be consumed else errors are not reported and the module
install process does not wait for modules to be compiled.

Fixes #2515

## Environment

Provide environment details, if relevant:

* OS: windows
* Compiler: msvc
