### PR TITLE
swq_op_general.cpp: Fix arithmetic expression

### DIFF
--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -1408,10 +1408,36 @@ def test_ogr_sql_48():
     ds.ReleaseResultSet(sql_lyr)
     assert i == 1001
 
+###############################################################################
+# Test arithmetic expressions
+
+
+def test_ogr_sql_49():
+
+    # expressions and expected result
+    expressions = [ ( "1/1", 1),
+                    ( "1/1.", 1.),
+                    ( "cast((1) as integer)/1." , 1. ),
+                    ( "1./cast((1) as integer)" , 1. ),
+                    ( "1.5+1" , 2.5 ),
+                    ( "(1*1)+1.5" , 2.5 ),
+                    ( "1+1" , 2 ),
+                    ( "cast(1 as integer)+ 1234567890123" , 1234567890124 ),
+                    ( "cast(1 as integer)* 1234567890123" , 1234567890123 )
+    ]
+
+    for expression, expected in expressions:
+        sql_lyr = gdaltest.ds.ExecuteSQL('select {} as result from poly limit 1'.format( expression ) )
+        tr = ogrtest.check_features_against_list(sql_lyr, 'result', [expected])
+
+        gdaltest.ds.ReleaseResultSet(sql_lyr)
+
+        assert tr
+
+
+###############################################################################
+
 
 def test_ogr_sql_cleanup():
     gdaltest.lyr = None
     gdaltest.ds = None
-
-
-

--- a/gdal/ogr/swq_op_general.cpp
+++ b/gdal/ogr/swq_op_general.cpp
@@ -1182,12 +1182,12 @@ swq_field_type SWQGeneralChecker( swq_expr_node *poNode,
             eRetType = SWQ_STRING;
             eArgType = SWQ_STRING;
         }
-        else if( poNode->papoSubExpr[0]->field_type == SWQ_FLOAT )
+        else if( poNode->papoSubExpr[0]->field_type == SWQ_FLOAT || poNode->papoSubExpr[1]->field_type == SWQ_FLOAT )
         {
             eRetType = SWQ_FLOAT;
             eArgType = SWQ_FLOAT;
         }
-        else if( poNode->papoSubExpr[0]->field_type == SWQ_INTEGER64 )
+        else if( poNode->papoSubExpr[0]->field_type == SWQ_INTEGER64 || poNode->papoSubExpr[1]->field_type == SWQ_INTEGER64 )
         {
             eRetType = SWQ_INTEGER64;
             eArgType = SWQ_INTEGER64;
@@ -1206,12 +1206,12 @@ swq_field_type SWQGeneralChecker( swq_expr_node *poNode,
         if( !SWQCheckSubExprAreNotGeometries(poNode) )
             return SWQ_ERROR;
         SWQAutoPromoteIntegerToInteger64OrFloat( poNode );
-        if( poNode->papoSubExpr[0]->field_type == SWQ_FLOAT )
+        if( poNode->papoSubExpr[0]->field_type == SWQ_FLOAT || poNode->papoSubExpr[1]->field_type == SWQ_FLOAT )
         {
             eRetType = SWQ_FLOAT;
             eArgType = SWQ_FLOAT;
         }
-        else if( poNode->papoSubExpr[0]->field_type == SWQ_INTEGER64 )
+        else if( poNode->papoSubExpr[0]->field_type == SWQ_INTEGER64 || poNode->papoSubExpr[1]->field_type == SWQ_INTEGER64 )
         {
             eRetType = SWQ_INTEGER64;
             eArgType = SWQ_INTEGER64;


### PR DESCRIPTION
## What does this PR do?

Second part of arithmetic expression were not taken into account for type conversion, leading to calculus errors. 

This example returned bad result
```shell
$ ogrinfo -sql "select cast((1) as integer)/1.  from division" division_shp/division.shp
...
OGRFeature(division):0
  FIELD_1 (Integer) = 0

$ ogrinfo -sql "select (1*1)/1.  from division" division_shp/division.shp
...
OGRFeature(division):0
  FIELD_1 (Integer) = 0
```

## What are related issues/pull requests?

This fixes the following QGIS issue https://github.com/qgis/QGIS/issues/35449

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Debian 10
* Compiler: gcc 9.2.1
