### PR TITLE
Drop dead code block

### DIFF
--- a/gdal/ogr/ogrsf_frmts/gml/xercesc_headers.h
+++ b/gdal/ogr/ogrsf_frmts/gml/xercesc_headers.h
@@ -33,12 +33,6 @@
 #pragma GCC system_header
 #endif
 
-// This works around problems with math.h on some platforms #defining INFINITY
-#ifdef INFINITY
-#undef  INFINITY
-#define INFINITY INFINITY_XERCES
-#endif
-
 #include <util/PlatformUtils.hpp>
 #include <sax2/DefaultHandler.hpp>
 #include <sax2/ContentHandler.hpp>

--- a/gdal/ogr/ogrsf_frmts/gmlas/xercesc_headers.h
+++ b/gdal/ogr/ogrsf_frmts/gmlas/xercesc_headers.h
@@ -33,12 +33,6 @@
 #pragma GCC system_header
 #endif
 
-// This works around problems with math.h on some platforms #defining INFINITY
-#ifdef INFINITY
-#undef  INFINITY
-#define INFINITY INFINITY_XERCES
-#endif
-
 #include <xercesc/framework/XMLGrammarPoolImpl.hpp>
 #include <xercesc/framework/psvi/XSAnnotation.hpp>
 #include <xercesc/framework/psvi/XSAttributeDeclaration.hpp>

--- a/gdal/ogr/ogrsf_frmts/ili/xercesc_headers.h
+++ b/gdal/ogr/ogrsf_frmts/ili/xercesc_headers.h
@@ -33,12 +33,6 @@
 #pragma GCC system_header
 #endif
 
-// This works around problems with math.h on some platforms #defining INFINITY
-#ifdef INFINITY
-#undef  INFINITY
-#define INFINITY INFINITY_XERCES
-#endif
-
 #include <util/PlatformUtils.hpp>
 #include <sax2/DefaultHandler.hpp>
 #include <sax2/ContentHandler.hpp>


### PR DESCRIPTION
## What does this PR do?

There had been INFINITY definition in Xerces-C long time ago.
It had been removed in May 2002.
https://github.com/apache/xerces-c/commit/15272ee3c915c49c73695c3532a0313979b6b841

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: mac os x
* Compiler: clang

In file included from /Users/runner/runners/2.169.1/work/cmake4gdal/cmake4gdal/gdal/gdal/gcore/gdal_priv.h:69:
/Applications/Xcode_11.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:661:56: error: use of undeclared identifier 'INFINITY_XERCES'
  if (__r >= ::nextafter(static_cast<_RealT>(_MaxVal), INFINITY)) {

The error can be observed in my private build experiment with cmake only.
