### PR TITLE
Drop deprecated INFINITY_XERCES definition

### DIFF
--- a/gdal/ogr/ogrsf_frmts/ili/ili2reader.h
+++ b/gdal/ogr/ogrsf_frmts/ili/ili2reader.h
@@ -30,12 +30,6 @@
 #ifndef CPL_ILI2READER_H_INCLUDED
 #define CPL_ILI2READER_H_INCLUDED
 
-// This works around problems with math.h on some platforms #defining INFINITY
-#ifdef INFINITY
-#undef  INFINITY
-#define INFINITY INFINITY_XERCES
-#endif
-
 #include "imdreader.h"
 #include <list>
 


### PR DESCRIPTION
Missing patch for #2532

#2532 is incompleted (sorry). Here is another part of dead block.

## What does this PR do?

There had been INFINITY definition in Xerces-C long time ago.
It had been removed in May 2002.
apache/xerces-c@15272ee

## Related issue

#2532