### PR TITLE
Add missing line feed

### DIFF
--- a/gdal/apps/ogr2ogr_bin.cpp
+++ b/gdal/apps/ogr2ogr_bin.cpp
@@ -171,7 +171,7 @@ static void Usage( const char* pszAdditionalMsg = nullptr, bool bShort = true )
         "      starts at zero. There must be exactly as many values in the list as\n"
         "      the count of the fields in the source layer. We can use the 'identity'\n"
         "      setting to specify that the fields should be transferred by using the\n"
-        "      same order. This setting should be used along with the append setting.");
+        "      same order. This setting should be used along with the append setting.\n");
 
     printf(" -a_srs srs_def: Assign an output SRS\n"
            " -t_srs srs_def: Reproject/transform to this SRS on output\n"


### PR DESCRIPTION
Running `ogr2ogr --long-usage` currently generates output like this:

```
 ...
 -fieldmap index1,index2,...: Specifies the list of field indexes to be
      copied from the source to the destination. The (n)th value specified
      in the list is the index of the field in the target layer definition
      in which the n(th) field of the source layer must be copied. Index count
      starts at zero. There must be exactly as many values in the list as
      the count of the fields in the source layer. We can use the 'identity'
      setting to specify that the fields should be transferred by using the
      same order. This setting should be used along with the append setting. -a_srs srs_def: Assign an output SRS
 -t_srs srs_def: Reproject/transform to this SRS on output
 -s_srs srs_def: Override source SRS
 ...
```

This change is to get the `-a_srs srs_def` bit on a new line.
