### PR TITLE
use returned length to truncate string for tiledb metadata

### DIFF
--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -797,15 +797,16 @@ CPLErr TileDBDataset::TryLoadCachedXML( char ** /*papszSiblingFiles*/, bool bRel
                     m_roArray->get_metadata("_gdal", &v_type, &v_num, &v_r);
                     if ( v_r )
                     {
-                        osMetaDoc = static_cast<const char*>( v_r );
+                        osMetaDoc = CPLString( static_cast<const char*>( v_r ), v_num);
                     }
                 }
                 else
                 {
                     m_array->get_metadata("_gdal", &v_type, &v_num, &v_r);
+
                     if ( v_r )
                     {
-                        osMetaDoc = static_cast<const char*>( v_r );
+                        osMetaDoc = CPLString( static_cast<const char*>( v_r ), v_num);
                     }
                 }
                 psTree = CPLParseXMLString( osMetaDoc );


### PR DESCRIPTION
This is a check that the returned metadata is truncated if necessary to provide a valid XML string for metadata parsing in GDAL. By not using the returned `v_num` we could potentially have an invalid XML string. 

Can we backport this on to v3.1?