### PR TITLE
GNUmakefile: split long line

### DIFF
--- a/gdal/GNUmakefile
+++ b/gdal/GNUmakefile
@@ -64,8 +64,17 @@ $(GDAL_SLIB):	$(GDAL_OBJ) $(GDAL_LIB)
 	$(LD_SHARED) $(GDAL_SLIB_SONAME) $(GDAL_OBJ) $(GDAL_LIBS) $(LDFLAGS) $(LIBS) \
 		-o $(GDAL_SLIB)
 
+#  split potentially long lines
+SORTED  := $(sort $(wildcard $(GDAL_OBJ:.o=.lo)))
+NSORTED := $(words $(SORTED))
+#  mid left and right indices
+MIDL := $(shell echo $$(( $(NSORTED) / 2 )) )
+MIDR := $(shell echo $$(( $(MIDL) + 1 )) )
+
 $(LIBGDAL):	$(GDAL_OBJ:.o=.lo)
-	$(LD) $(LDFLAGS) $(LIBS) -o $@ $(sort $(wildcard $(GDAL_OBJ:.o=.lo))) \
+	$(LD) $(LDFLAGS) $(LIBS) -o $@ \
+	$(wordlist 1,$(MIDL),$(SORTED)) \
+	$(wordlist $(MIDR),$(words $(SORTED)),$(SORTED)) \
 	    -rpath $(INST_LIB) \
 	    -no-undefined \
 	    -version-info $(LIBGDAL_CURRENT):$(LIBGDAL_REVISION):$(LIBGDAL_AGE)


### PR DESCRIPTION
## What does this PR do?

Splits the $(LIBGDAL) call in GNUmakefile across several lines.  

Otherwise it can exceed the 32,000 character limit on MSYS2 and similar systems.


## What are related issues/pull requests?

#2077 helps in many cases, but is still not sufficient when there are many files to be compiled in.  

This should also be a more robust fix for #1429 


## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:  Windows with MSYS2/MSYS/Cygwin or similar
* Compiler:  gcc 7.1.0
