### PR TITLE
Add GDALAutoCreateWarpedVRTEx function to GDAL API

### DIFF
--- a/gdal/alg/gdalwarper.h
+++ b/gdal/alg/gdalwarper.h
@@ -288,6 +288,13 @@ GDALAutoCreateWarpedVRT( GDALDatasetH hSrcDS,
                          GDALResampleAlg eResampleAlg,
                          double dfMaxError, const GDALWarpOptions *psOptions );
 
+GDALDatasetH CPL_STDCALL
+GDALAutoCreateWarpedVRTEx( GDALDatasetH hSrcDS,
+                           const char *pszSrcWKT, const char *pszDstWKT,
+                           GDALResampleAlg eResampleAlg,
+                           double dfMaxError, const GDALWarpOptions *psOptions,
+                           CSLConstList papszTransformerOptions );
+
 GDALDatasetH CPL_DLL CPL_STDCALL
 GDALCreateWarpedVRT( GDALDatasetH hSrcDS,
                      int nPixels, int nLines, double *padfGeoTransform,

--- a/gdal/frmts/vrt/vrtwarped.cpp
+++ b/gdal/frmts/vrt/vrtwarped.cpp
@@ -123,6 +123,7 @@ GDALAutoCreateWarpedVRT( GDALDatasetH hSrcDS,
  * Compared to GDALAutoCreateWarpedVRT() this function adds one extra
  * argument: options to be passed to GDALCreateGenImgProjTransformer2().
  *
+ * @since 3.2
  */
 
 GDALDatasetH CPL_STDCALL

--- a/gdal/frmts/vrt/vrtwarped.cpp
+++ b/gdal/frmts/vrt/vrtwarped.cpp
@@ -107,7 +107,32 @@ GDALAutoCreateWarpedVRT( GDALDatasetH hSrcDS,
                          GDALResampleAlg eResampleAlg,
                          double dfMaxError,
                          const GDALWarpOptions *psOptionsIn )
+{
+  return GDALAutoCreateWarpedVRTEx(
+        hSrcDS, pszSrcWKT, pszDstWKT, eResampleAlg,
+        dfMaxError, psOptionsIn, nullptr );
+}
 
+/************************************************************************/
+/*                     GDALAutoCreateWarpedVRTEx()                      */
+/************************************************************************/
+
+/**
+ * Create virtual warped dataset automatically.
+ *
+ * Compared to GDALAutoCreateWarpedVRT() this function adds one extra
+ * argument: options to be passed to GDALCreateGenImgProjTransformer2().
+ *
+ */
+
+GDALDatasetH CPL_STDCALL
+GDALAutoCreateWarpedVRTEx( GDALDatasetH hSrcDS,
+                           const char *pszSrcWKT,
+                           const char *pszDstWKT,
+                           GDALResampleAlg eResampleAlg,
+                           double dfMaxError,
+                           const GDALWarpOptions *psOptionsIn,
+                           CSLConstList papszTransformerOptions )
 {
     VALIDATE_POINTER1( hSrcDS, "GDALAutoCreateWarpedVRT", nullptr );
 
@@ -167,10 +192,17 @@ GDALAutoCreateWarpedVRT( GDALDatasetH hSrcDS,
 /*      Create the transformer.                                         */
 /* -------------------------------------------------------------------- */
     psWO->pfnTransformer = GDALGenImgProjTransform;
+
+    char **papszOptions = nullptr;
+    if( pszSrcWKT != nullptr )
+        papszOptions = CSLSetNameValue( papszOptions, "SRC_SRS", pszSrcWKT );
+    if( pszDstWKT != nullptr )
+        papszOptions = CSLSetNameValue( papszOptions, "DST_SRS", pszDstWKT );
+    papszOptions = CSLMerge( papszOptions, papszTransformerOptions );
     psWO->pTransformerArg =
-        GDALCreateGenImgProjTransformer( psWO->hSrcDS, pszSrcWKT,
-                                         nullptr, pszDstWKT,
-                                         TRUE, 1.0, 0 );
+        GDALCreateGenImgProjTransformer2( psWO->hSrcDS, nullptr,
+                                          papszOptions );
+    CSLDestroy( papszOptions );
 
     if( psWO->pTransformerArg == nullptr )
     {


### PR DESCRIPTION
## What does this PR do?

This function allows specifying extra options for transformer.
Thanks to that, it is for example possible to set RPC_HEIGHT
to get better aligned rasters with RPC georeferencing metadata.

## What are related issues/pull requests?

Originally suggested by Even in https://github.com/qgis/QGIS/pull/36385

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
