### PR TITLE
MVT: fix 'random' failures in test_ogr_mvt_point_polygon_clip()

### DIFF
--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -29,8 +29,6 @@
 ###############################################################################
 
 import json
-import sys
-
 
 import gdaltest
 import ogrtest
@@ -290,18 +288,10 @@ def test_ogr_mvt_point_polygon_clip():
     if not ogrtest.have_geos() or gdal.GetConfigOption('OGR_MVT_CLIP') is not None:
         pytest.skip()
 
-    if gdal.GetConfigOption('APPVEYOR') is not None:
-        pytest.skip()
-    if sys.platform == 'darwin' and gdal.GetConfigOption('TRAVIS', None) is not None:
-        pytest.skip()
-    if gdaltest.is_travis_branch('sanitize') or gdaltest.is_travis_branch('python3') or gdaltest.is_travis_branch('s390x'):
-        pytest.skip()
-
     ds = ogr.Open('data/mvt/point_polygon/1')
     lyr = ds.GetLayer(1)
     f = lyr.GetNextFeature()
-    if ogrtest.check_feature_geometry(f, 'MULTIPOLYGON (((445169.252732867 450061.222543117,445169.252732867 0.0,220138.641461308 0.0,220138.641461308 225030.61127156,0.0 225030.61127156,0.0 450061.222543117,445169.252732867 450061.222543117)),((107623.335825528 58703.6377230138,107623.335825528 0.0,53811.6679127641 0.0,53811.6679127641 58703.6377230138,107623.335825528 58703.6377230138)))') != 0 and \
-       ogrtest.check_feature_geometry(f, 'MULTIPOLYGON (((445169.252732867 0.0,445169.252732867 -445169.252732867,0.0 -445169.252732867,0.0 -220138.641461308,220138.641461308 -220138.641461308,220138.641461308 0.0,445169.252732867 0.0)),((107623.335825528 0.0,107623.335825528 -53811.6679127641,53811.6679127641 -53811.6679127641,53811.6679127641 0.0,107623.335825528 0.0)))') != 0:
+    if ogrtest.check_feature_geometry(f, 'MULTIPOLYGON (((0.0 112515.30563578,0 0,-112515.30563578 0.0,-112515.30563578 112515.30563578,0.0 112515.30563578)))') != 0:
         f.DumpReadable()
         pytest.fail()
 

--- a/gdal/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/gdal/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -1387,7 +1387,7 @@ static CPLStringList StripDummyEntries(const CPLStringList& aosInput)
             aosOutput.AddString( aosInput[i] );
         }
     }
-    return aosOutput;
+    return aosOutput.Sort();
 }
 
 /************************************************************************/
@@ -1597,7 +1597,7 @@ void OGRMVTDirectoryLayer::OpenTile()
         int nX = (m_bUseReadDir || !m_aosDirContent.empty()) ?
                         atoi(m_aosDirContent[m_nXIndex]) : m_nXIndex;
         int nY = m_bUseReadDir ? atoi(m_aosSubDirContent[m_nYIndex]) : m_nYIndex;
-        m_nFIDBase = (static_cast<GIntBig>(nY) << m_nZ) | nX;
+        m_nFIDBase = (static_cast<GIntBig>(nX) << m_nZ) | nY;
     }
 }
 


### PR DESCRIPTION
by sorting sub-directory names, and also revise logic to attribute FID when reading directories
