### PR TITLE
OGRShapeDataSource::RefreshLockFile(): fix threading issue

### DIFF
--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -4658,9 +4658,6 @@ def test_ogr_shape_114_shz():
 
 def test_ogr_shape_115_shp_zip():
 
-    if sys.platform == 'darwin':
-        pytest.skip("Regularly angs on MacOSX. Not sure why.")
-
     dirname = 'tmp/test_ogr_shape_115'
     gdal.RmdirRecursive(dirname)
     os.mkdir(dirname)

--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
@@ -1428,17 +1428,12 @@ void OGRShapeDataSource::RefreshLockFile(void* _self)
     CPLAcquireMutex(self->m_poRefreshLockFileMutex, 1000);
     CPLCondSignal(self->m_poRefreshLockFileCond);
     unsigned int nInc = 0;
-    while(true)
+    while(!(self->m_bExitRefreshLockFileThread))
     {
         auto ret = CPLCondTimedWait(self->m_poRefreshLockFileCond,
                                     self->m_poRefreshLockFileMutex,
                                     self->m_dfRefreshLockDelay);
-        if( ret == COND_TIMED_WAIT_COND )
-        {
-            if( self->m_bExitRefreshLockFileThread )
-                break;
-        }
-        else if( ret == COND_TIMED_WAIT_TIME_OUT )
+        if( ret == COND_TIMED_WAIT_TIME_OUT )
         {
             CPLAssert(self->m_psLockFile);
             VSIFSeekL(self->m_psLockFile, 0, SEEK_SET);


### PR DESCRIPTION
that should hopefully fix random hangs on test_ogr_shape_115_shp_zip()