### PR TITLE
enable commit notifications to dedicated #gdal-activity IRC channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,8 +187,8 @@ notifications:
     channels:
        - "irc.freenode.org#gdal-activity"    
       #- "irc.freenode.org#gdal"
-   use_notice: true
-   on_success: change
+    use_notice: true
+    on_success: change
 #
 #   email:
 #     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,13 +182,15 @@ install:
 script:
   - ./gdal/ci/travis/${BUILD_NAME}/script.sh
 
-# notifications:
+notifications:
+  irc:
+    channels:
+       - "irc.freenode.org#gdal-activity"    
+      #- "irc.freenode.org#gdal"
+   use_notice: true
+   on_success: change
+#
 #   email:
 #     recipients:
 #       - gdal-commits@lists.osgeo.org
-#
-#   irc:
-#     channels:
-#       - "irc.freenode.org#gdal"
-#     use_notice: true
-#     on_success: change
+


### PR DESCRIPTION
 - enable commit notifications to dedicated IRC channel "gdal-activity"
 - this follows how other projects handle this as QGIS, PostGIS (pushing commit notifications into dedicated <PROJECT>-activity channel, so packagers and developers get notices of changes, if they wish).

@rouault has also been set as founder of the new activity channel.