### PR TITLE
Add missing CPL_DLL to GDALAutoCreateWarpedVRTEx

### DIFF
--- a/gdal/alg/gdalwarper.h
+++ b/gdal/alg/gdalwarper.h
@@ -288,7 +288,7 @@ GDALAutoCreateWarpedVRT( GDALDatasetH hSrcDS,
                          GDALResampleAlg eResampleAlg,
                          double dfMaxError, const GDALWarpOptions *psOptions );
 
-GDALDatasetH CPL_STDCALL
+GDALDatasetH CPL_DLL CPL_STDCALL
 GDALAutoCreateWarpedVRTEx( GDALDatasetH hSrcDS,
                            const char *pszSrcWKT, const char *pszDstWKT,
                            GDALResampleAlg eResampleAlg,


### PR DESCRIPTION
QGIS builds on windows were failing when trying to use the newly added GDALAutoCreateWarpedVRTEx function. Only now I have realized I have missed to add CPL_DLL to the header, causing the linker to complain about unresolved external symbol GDALAutoCreateWarpedVRTEx

https://cdash.orfeo-toolbox.org/viewBuildError.php?buildid=42309