### PR TITLE
SWIG bindings: validate range of resample_alg algorithm

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -1018,3 +1018,18 @@ def test_rasterio_dataset_write_on_readonly():
     with gdaltest.error_handler():
         err = ds.WriteRaster(0, 0, 20, 20, ds.ReadRaster())
     assert err != 0
+
+
+@pytest.mark.parametrize('resample_alg', [-1, 8])
+def test_rasterio_dataset_invalid_resample_alg(resample_alg):
+
+    mem_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)
+    with gdaltest.error_handler():
+        with pytest.raises(Exception):
+            assert mem_ds.ReadRaster(buf_xsize=1, buf_ysize=1, resample_alg=resample_alg) is None
+        with pytest.raises(Exception):
+            assert mem_ds.GetRasterBand(1).ReadRaster(buf_xsize=1, buf_ysize=1, resample_alg=resample_alg) is None
+        with pytest.raises(Exception):
+            assert mem_ds.ReadAsArray(buf_xsize=1, buf_ysize=1, resample_alg=resample_alg) is None
+        with pytest.raises(Exception):
+            assert mem_ds.GetRasterBand(1).ReadAsArray(buf_xsize=1, buf_ysize=1, resample_alg=resample_alg) is None

--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -135,8 +135,11 @@ typedef enum
     /*! Average */                                      GRIORA_Average = 5,
     /*! Mode (selects the value which appears most often of all the sampled points) */
                                                         GRIORA_Mode = 6,
-    /*! Gauss blurring */                               GRIORA_Gauss = 7
+    /*! Gauss blurring */                               GRIORA_Gauss = 7,
     /* NOTE: values 8 to 12 are reserved for max,min,med,Q1,Q3 */
+/*! @cond Doxygen_Suppress */
+                                                        GRIORA_LAST = GRIORA_Gauss
+/*! @endcond */
 } GDALRIOResampleAlg;
 
 /* NOTE to developers: only add members, and if so edit INIT_RASTERIO_EXTRA_ARG */

--- a/gdal/swig/include/gdal.i
+++ b/gdal/swig/include/gdal.i
@@ -253,6 +253,19 @@ typedef enum {
 %include "gdal_typemaps.i"
 #endif
 
+%typemap(check) GDALRIOResampleAlg
+{
+    // %typemap(check) GDALRIOResampleAlg
+    // This check is a bit too late, since $1 has already been cast
+    // to GDALRIOResampleAlg, so we are a bit in undefined behaviour land,
+    // but compilers should hopefully do the right thing
+    if( static_cast<int>($1) < 0 ||
+        static_cast<int>($1) > static_cast<int>(GRIORA_LAST) )
+    {
+        SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
+    }
+}
+
 /* Default memberin typemaps required to support SWIG 1.3.39 and above */
 %typemap(memberin) char *Info %{
 /* char* Info memberin typemap */

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -63,6 +63,19 @@
 typedef int CPLErr;
 typedef int GDALRIOResampleAlg;
 
+%typemap(check) GDALRIOResampleAlg
+{
+    // %typemap(check) GDALRIOResampleAlg
+    // This check is a bit too late, since $1 has already been cast
+    // to GDALRIOResampleAlg, so we are a bit in undefined behaviour land,
+    // but compilers should hopefully do the right thing
+    if( static_cast<int>($1) < 0 ||
+        static_cast<int>($1) > static_cast<int>(GRIORA_LAST) )
+    {
+        SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
+    }
+}
+
 %include "python_strings.i"
 
 %{

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -343,6 +343,15 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
                      GDALRIOResampleAlg resample_alg = GRIORA_NearestNeighbour,
                      GDALProgressFunc callback = NULL,
                      void* callback_data=NULL) {
+    // This check is a bit too late. resample_alg should already have been
+    // validated, so we are a bit in undefined behaviour land, but compilers
+    // should hopefully do the right thing
+    if( static_cast<int>(resample_alg) < 0 ||
+        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
+        return CE_Failure;
+    }
     int nxsize = (buf_xsize==0) ? static_cast<int>(xsize) : *buf_xsize;
     int nysize = (buf_ysize==0) ? static_cast<int>(ysize) : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
@@ -652,6 +661,15 @@ CPLErr ReadRaster1(  int xoff, int yoff, int xsize, int ysize,
                     GDALProgressFunc callback = NULL,
                     void* callback_data=NULL )
 {
+    // This check is a bit too late. resample_alg should already have been
+    // validated, so we are a bit in undefined behaviour land, but compilers
+    // should hopefully do the right thing
+    if( static_cast<int>(resample_alg) < 0 ||
+        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
+        return CE_Failure;
+    }
     int nxsize = (buf_xsize==0) ? xsize : *buf_xsize;
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype;

--- a/gdal/swig/python/extensions/gdal_array_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_array_wrap.cpp
@@ -5436,6 +5436,17 @@ SWIGINTERN PyObject *_wrap_BandRasterIONumPy(PyObject *SWIGUNUSEDPARM(self), PyO
     }
   }
   {
+    // %typemap(check) GDALRIOResampleAlg
+    // This check is a bit too late, since arg9 has already been cast
+    // to GDALRIOResampleAlg, so we are a bit in undefined behaviour land,
+    // but compilers should hopefully do the right thing
+    if( static_cast<int>(arg9) < 0 ||
+      static_cast<int>(arg9) > static_cast<int>(GRIORA_LAST) )
+    {
+      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
+    }
+  }
+  {
     SWIG_PYTHON_THREAD_BEGIN_ALLOW;
     result = (CPLErr)BandRasterIONumPy(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11);
     SWIG_PYTHON_THREAD_END_ALLOW;
@@ -5618,6 +5629,17 @@ SWIGINTERN PyObject *_wrap_DatasetIONumPy(PyObject *SWIGUNUSEDPARM(self), PyObje
       SWIG_exception_fail(SWIG_ArgError(ecode12), "in method '" "DatasetIONumPy" "', argument " "12"" of type '" "bool""'");
     } 
     arg12 = static_cast< bool >(val12);
+  }
+  {
+    // %typemap(check) GDALRIOResampleAlg
+    // This check is a bit too late, since arg9 has already been cast
+    // to GDALRIOResampleAlg, so we are a bit in undefined behaviour land,
+    // but compilers should hopefully do the right thing
+    if( static_cast<int>(arg9) < 0 ||
+      static_cast<int>(arg9) > static_cast<int>(GRIORA_LAST) )
+    {
+      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
+    }
   }
   {
     SWIG_PYTHON_THREAD_BEGIN_ALLOW;

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -3965,7 +3965,7 @@ void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* psz
     if( GDALIsInGlobalDestructor() )
     {
         // this is typically during Python interpreter shutdown, and ends up in a crash
-        // because error handling tries to do thread initialisation.
+        // because error handling tries to do thread initialization.
         return;
     }
 
@@ -5299,6 +5299,15 @@ SWIGINTERN OGRErr GDALDatasetShadow_RollbackTransaction(GDALDatasetShadow *self)
     return GDALDatasetRollbackTransaction(self);
   }
 SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,int xoff,int yoff,int xsize,int ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,GDALDataType *buf_type=0,int band_list=0,int *pband_list=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GIntBig *buf_band_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL){
+    // This check is a bit too late. resample_alg should already have been
+    // validated, so we are a bit in undefined behaviour land, but compilers
+    // should hopefully do the right thing
+    if( static_cast<int>(resample_alg) < 0 ||
+        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
+        return CE_Failure;
+    }
     int nxsize = (buf_xsize==0) ? xsize : *buf_xsize;
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype;
@@ -6577,6 +6586,15 @@ SWIGINTERN GDALMDArrayHS *GDALRasterBandShadow_AsMDArray(GDALRasterBandShadow *s
     return GDALRasterBandAsMDArray(self);
   }
 SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,double xoff,double yoff,double xsize,double ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,int *buf_type=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL){
+    // This check is a bit too late. resample_alg should already have been
+    // validated, so we are a bit in undefined behaviour land, but compilers
+    // should hopefully do the right thing
+    if( static_cast<int>(resample_alg) < 0 ||
+        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
+        return CE_Failure;
+    }
     int nxsize = (buf_xsize==0) ? static_cast<int>(xsize) : *buf_xsize;
     int nysize = (buf_ysize==0) ? static_cast<int>(ysize) : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
@@ -20822,6 +20840,17 @@ SWIGINTERN PyObject *_wrap_Dataset_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), P
     }
   }
   {
+    // %typemap(check) GDALRIOResampleAlg
+    // This check is a bit too late, since arg15 has already been cast
+    // to GDALRIOResampleAlg, so we are a bit in undefined behaviour land,
+    // but compilers should hopefully do the right thing
+    if( static_cast<int>(arg15) < 0 ||
+      static_cast<int>(arg15) > static_cast<int>(GRIORA_LAST) )
+    {
+      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
+    }
+  }
+  {
     if ( bUseExceptions ) {
       ClearErrorState();
     }
@@ -30920,6 +30949,17 @@ SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyOb
     {
       /* %typemap(in) ( void* callback_data=NULL)  */
       psProgressInfo->psPyCallbackData = obj12 ;
+    }
+  }
+  {
+    // %typemap(check) GDALRIOResampleAlg
+    // This check is a bit too late, since arg12 has already been cast
+    // to GDALRIOResampleAlg, so we are a bit in undefined behaviour land,
+    // but compilers should hopefully do the right thing
+    if( static_cast<int>(arg12) < 0 ||
+      static_cast<int>(arg12) > static_cast<int>(GRIORA_LAST) )
+    {
+      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
     }
   }
   {


### PR DESCRIPTION
(fixes for GDAL bindings similar issue reported in refs #2587)