### PR TITLE
GDALDataset: Fix buffer overflow in BuildParseInfo for SQL query

### DIFF
--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -6264,6 +6264,11 @@ GDALDataset::BuildParseInfo(swq_select *psSelectInfo,
             (poSelectParseOptions &&
             poSelectParseOptions->bAddSecondaryTablesGeometryFields) )
             nFieldCount += poSrcLayer->GetLayerDefn()->GetGeomFieldCount();
+
+        const char* pszFID = poSrcLayer->GetFIDColumn();
+        if (pszFID && !EQUAL(pszFID, "") && !EQUAL(pszFID, "FID") &&
+            poSrcLayer->GetLayerDefn()->GetFieldIndex(pszFID) < 0)
+            nFieldCount++;
     }
 
 /* -------------------------------------------------------------------- */
@@ -6275,13 +6280,13 @@ GDALDataset::BuildParseInfo(swq_select *psSelectInfo,
 
     psParseInfo->sFieldList.count = 0;
     psParseInfo->sFieldList.names = static_cast<char **>(
-        CPLMalloc(sizeof(char *) * (nFieldCount + SPECIAL_FIELD_COUNT + 1)));
+        CPLMalloc(sizeof(char *) * (nFieldCount + SPECIAL_FIELD_COUNT)));
     psParseInfo->sFieldList.types = static_cast<swq_field_type *>(CPLMalloc(
-        sizeof(swq_field_type) * (nFieldCount + SPECIAL_FIELD_COUNT + 1)));
+        sizeof(swq_field_type) * (nFieldCount + SPECIAL_FIELD_COUNT)));
     psParseInfo->sFieldList.table_ids = static_cast<int *>(
-        CPLMalloc(sizeof(int) * (nFieldCount + SPECIAL_FIELD_COUNT + 1)));
+        CPLMalloc(sizeof(int) * (nFieldCount + SPECIAL_FIELD_COUNT)));
     psParseInfo->sFieldList.ids = static_cast<int *>(
-        CPLMalloc(sizeof(int) * (nFieldCount + SPECIAL_FIELD_COUNT + 1)));
+        CPLMalloc(sizeof(int) * (nFieldCount + SPECIAL_FIELD_COUNT)));
 
     bool bIsFID64 = false;
     for( int iTable = 0; iTable < psSelectInfo->table_count; iTable++ )


### PR DESCRIPTION
Fixed buffer overflow in GDALDataset::BuildParseInfo for SQL query when joining multiple tables that each have FID columns. An ESRI FileGDB dataset was crashing with a heap error: each table had "OBJECTID" for poSrcLayer->GetFIDColumn().

Previously, buffers for psParseInfo->sFieldList were allocated to (nFieldCount + SPECIAL_FIELD_COUNT + 1), where the '+1' seemed to be assuming a single FID column (added at the bottom of the function). This buffer was overrun when multiple tables each had such an FID column.

This fix increments the nFieldCount for each table that has a qualifying FID column, and removes the +1 on the buffer allocation.