### PR TITLE
Warn don't use -mo with WMTS

### DIFF
--- a/gdal/doc/source/programs/gdal_translate.rst
+++ b/gdal/doc/source/programs/gdal_translate.rst
@@ -213,7 +213,7 @@ resampling, and rescaling pixels in the process.
 
 .. option:: -mo META-TAG=VALUE
 
-    Passes a metadata key and value to set on the output dataset if possible.
+    Passes a metadata key and value to set on the output dataset if possible. Do not use -mo when using WMTS.
 
 .. include:: options/co.rst
 


### PR DESCRIPTION
Vague warning for #2598.
Please add all the other items that -mo will ruin too.