### PR TITLE
OSM: Fix tag filtering inconsistencies

### DIFF
--- a/gdal/data/osmconf.ini
+++ b/gdal/data/osmconf.ini
@@ -9,6 +9,11 @@ closed_ways_are_polygons=aeroway,amenity,boundary,building,craft,geological,hist
 # comment to avoid laundering of keys ( ':' turned into '_' )
 attribute_name_laundering=yes
 
+# Some tags, set on ways and when building multipolygons, multilinestrings or other_relations,
+# are normally filtered out early, independent of the 'ignore' configuration below.
+# Uncomment to disable early filtering. The 'ignore' lines below remain active.
+#report_all_tags=yes
+
 # uncomment to report all nodes, including the ones without any (significant) tag
 #report_all_nodes=yes
 

--- a/gdal/data/osmconf.ini
+++ b/gdal/data/osmconf.ini
@@ -34,7 +34,7 @@ attributes=name,barrier,highway,ref,address,is_in,place,man_made
 # keys that, alone, are not significant enough to report a node as a OGR point
 unsignificant=created_by,converted_by,source,time,ele,attribution
 # keys that should NOT be reported in the "other_tags" field
-ignore=created_by,converted_by,source,time,ele,note,openGeoDB:,fixme,FIXME
+ignore=created_by,converted_by,source,time,ele,note,todo,openGeoDB:,fixme,FIXME
 # uncomment to avoid creation of "other_tags" field
 #other_tags=no
 # uncomment to create "all_tags" field. "all_tags" and "other_tags" are exclusive
@@ -56,7 +56,7 @@ attributes=name,highway,waterway,aerialway,barrier,man_made
 #foo_type=Integer/Real/String/DateTime
 
 # keys that should NOT be reported in the "other_tags" field
-ignore=created_by,converted_by,source,time,ele,note,openGeoDB:,fixme,FIXME
+ignore=created_by,converted_by,source,time,ele,note,todo,openGeoDB:,fixme,FIXME
 # uncomment to avoid creation of "other_tags" field
 #other_tags=no
 # uncomment to create "all_tags" field. "all_tags" and "other_tags" are exclusive
@@ -84,7 +84,7 @@ osm_changeset=no
 # keys to report as OGR fields
 attributes=name,type,aeroway,amenity,admin_level,barrier,boundary,building,craft,geological,historic,land_area,landuse,leisure,man_made,military,natural,office,place,shop,sport,tourism
 # keys that should NOT be reported in the "other_tags" field
-ignore=area,created_by,converted_by,source,time,ele,note,openGeoDB:,fixme,FIXME
+ignore=area,created_by,converted_by,source,time,ele,note,todo,openGeoDB:,fixme,FIXME
 # uncomment to avoid creation of "other_tags" field
 #other_tags=no
 # uncomment to create "all_tags" field. "all_tags" and "other_tags" are exclusive
@@ -102,7 +102,7 @@ osm_changeset=no
 # keys to report as OGR fields
 attributes=name,type
 # keys that should NOT be reported in the "other_tags" field
-ignore=area,created_by,converted_by,source,time,ele,note,openGeoDB:,fixme,FIXME
+ignore=area,created_by,converted_by,source,time,ele,note,todo,openGeoDB:,fixme,FIXME
 # uncomment to avoid creation of "other_tags" field
 #other_tags=no
 # uncomment to create "all_tags" field. "all_tags" and "other_tags" are exclusive
@@ -120,7 +120,7 @@ osm_changeset=no
 # keys to report as OGR fields
 attributes=name,type
 # keys that should NOT be reported in the "other_tags" field
-ignore=area,created_by,converted_by,source,time,ele,note,openGeoDB:,fixme,FIXME
+ignore=area,created_by,converted_by,source,time,ele,note,todo,openGeoDB:,fixme,FIXME
 # uncomment to avoid creation of "other_tags" field
 #other_tags=no
 # uncomment to create "all_tags" field. "all_tags" and "other_tags" are exclusive

--- a/gdal/ogr/ogrsf_frmts/osm/ogr_osm.h
+++ b/gdal/ogr/ogrsf_frmts/osm/ogr_osm.h
@@ -36,6 +36,7 @@
 #include "ogrsf_frmts.h"
 #include "cpl_string.h"
 
+#include <array>
 #include <set>
 #include <unordered_set>
 #include <map>
@@ -328,6 +329,8 @@ class OGROSMDataSource final: public OGRDataSource
     int                 nMaxSizeKeysInSetClosedWaysArePolygons;
 
     std::vector<LonLat> m_asLonLatCache{};
+
+    std::array<const char*, 7>  m_ignoredKeys;
 
     bool                bReportAllNodes;
     bool                bReportAllWays;

--- a/gdal/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -3602,6 +3602,11 @@ bool OGROSMDataSource::ParseConf( char** papszOpenOptionsIn )
                 for(int i=0;papszTokens2[i] != nullptr;i++)
                 {
                     papoLayers[iCurLayer]->AddField(papszTokens2[i], OFTString);
+                    for( const char*& pszIgnoredKey : m_ignoredKeys )
+                    {
+                        if( strcmp( papszTokens2[i], pszIgnoredKey ) == 0 )
+                            pszIgnoredKey = "";
+                    }
                 }
                 CSLDestroy(papszTokens2);
             }

--- a/gdal/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -3468,6 +3468,14 @@ bool OGROSMDataSource::ParseConf( char** papszOpenOptionsIn )
             CSLDestroy(papszTokens2);
         }
 
+        else if(STARTS_WITH(pszLine, "report_all_tags="))
+        {
+            if( strcmp(pszLine + strlen("report_all_tags="), "yes") == 0 )
+            {
+                std::fill( begin(m_ignoredKeys), end(m_ignoredKeys), "" );
+            }
+        }
+
         else if(STARTS_WITH(pszLine, "report_all_nodes="))
         {
             if( strcmp(pszLine + strlen("report_all_nodes="), "no") == 0 )

--- a/gdal/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -247,6 +247,7 @@ OGROSMDataSource::OGROSMDataSource() :
     nNodesInTransaction(0),
     nMinSizeKeysInSetClosedWaysArePolygons(0),
     nMaxSizeKeysInSetClosedWaysArePolygons(0),
+    m_ignoredKeys({{"area","created_by","converted_by","note","todo","fixme","FIXME"}}),
     bReportAllNodes(false),
     bReportAllWays(false),
     bFeatureAdded(false),
@@ -2053,20 +2054,11 @@ void OGROSMDataSource::NotifyWay( OSMWay* psWay )
             const char* pszK = psWay->pasTags[iTag].pszK;
             const char* pszV = psWay->pasTags[iTag].pszV;
 
-            if( strcmp(pszK, "area") == 0 )
+            if( std::any_of(begin(m_ignoredKeys), end(m_ignoredKeys),
+                    [pszK](const char* pszIgnoredKey) { return strcmp(pszK, pszIgnoredKey) == 0; }) )
+            {
                 continue;
-            if( strcmp(pszK, "created_by") == 0 )
-                continue;
-            if( strcmp(pszK, "converted_by") == 0 )
-                continue;
-            if( strcmp(pszK, "note") == 0 )
-                continue;
-            if( strcmp(pszK, "todo") == 0 )
-                continue;
-            if( strcmp(pszK, "fixme") == 0 )
-                continue;
-            if( strcmp(pszK, "FIXME") == 0 )
-                continue;
+            }
 
             std::map<const char*, KeyDesc*, ConstCharComp>::iterator oIterK =
                 aoMapIndexedKeys.find(pszK);


### PR DESCRIPTION
This series of commit provides two ways of customizing the early dropping of some tags:
- Disable the dropping globally, by enabling `report_all_tags` in `osmconf.ini`.
  This is in analogy to the existing `report_all_nodes` and `report_all_ways`. However, the per-type `ignore` continue to remove the tags they list.
- Disable the early dropping for attributes which are listed in the per-type `attribute` list. This fixes a surprising behaviour that some tags simply didn't work in the attribute list. However, the new behaviour means that a key listed as an `attribute`for just one type now is also handled for the other types, either by the other types' `ignore` and `attribute` lists, or appearing in `other_tags` or `all_tags`.

The variable of globally ignored keys is explicitly chosen as fixed-size array, not as vector, so that the compiler can do its best to optimize as before (e.g. unroll the filtering loop).

I hope I managed to match the coding style ;-)