### PR TITLE
OSM: Rectify attribute_name_laundering option

### DIFF
--- a/gdal/data/osmconf.ini
+++ b/gdal/data/osmconf.ini
@@ -6,8 +6,8 @@
 # see http://wiki.openstreetmap.org/wiki/Map_Features
 closed_ways_are_polygons=aeroway,amenity,boundary,building,craft,geological,historic,landuse,leisure,military,natural,office,place,shop,sport,tourism,highway=platform,public_transport=platform
 
-# comment to avoid laundering of keys ( ':' turned into '_' )
-attribute_name_laundering=yes
+# Uncomment to avoid laundering of keys ( ':' turned into '_' )
+#attribute_name_laundering=no
 
 # Some tags, set on ways and when building multipolygons, multilinestrings or other_relations,
 # are normally filtered out early, independent of the 'ignore' configuration below.


### PR DESCRIPTION
## What does this PR do?

This PR does not change any behaviour, but rectifies the documentation and default setup of the `attribute_name_laundering` option in `osmconf.ini`. Attribute name laundering is enabled by default:

https://github.com/OSGeo/gdal/blob/0452e8c57913f4744c3e704077f33310f91e3d86/gdal/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp#L265

Commenting, i.e. not providing, the parameter doesn't change the default. So attribute name laundering needs to be explicitly disabled in `osmconf.ini` if desired.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment