### PR TITLE
Fix docstring typo in gdal_sieve

### DIFF
--- a/gdal/alg/gdalsievefilter.cpp
+++ b/gdal/alg/gdalsievefilter.cpp
@@ -154,7 +154,7 @@ static inline void CompareNeighbour( int nPolyId1, int nPolyId2,
  * Removes small raster polygons.
  *
  * The function removes raster polygons smaller than a provided
- * threshold size (in pixels) and replaces replaces them with the pixel value
+ * threshold size (in pixels) and replaces them with the pixel value
  * of the largest neighbour polygon.
  *
  * Polygon are determined (per GDALRasterPolygonEnumerator) as regions of

--- a/gdal/doc/source/programs/gdal_sieve.rst
+++ b/gdal/doc/source/programs/gdal_sieve.rst
@@ -22,7 +22,7 @@ Description
 -----------
 
 :program:`gdal_sieve.py` script removes raster polygons smaller than
-a provided threshold size (in pixels) and replaces replaces them with the
+a provided threshold size (in pixels) and replaces them with the
 pixel value of the largest neighbour polygon. The result can be written
 back to the existing raster band, or copied into a new file.
 

--- a/gdal/swig/java/javadoc.java
+++ b/gdal/swig/java/javadoc.java
@@ -900,7 +900,7 @@ public class gdal:public static int FillNodata(Band targetBand, Band maskBand, d
  * Removes small raster polygons.
  * <p>
  * The function removes raster polygons smaller than a provided
- * threshold size (in pixels) and replaces replaces them with the pixel value
+ * threshold size (in pixels) and replaces them with the pixel value
  * of the largest neighbour polygon.
  * <p>
  * Polygon are determined (per GDALRasterPolygonEnumerator) as regions of


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Corrects a typo in gdal_sieve docstring
## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
