### PR TITLE
CSharp bindings: Fixed implementation of Utf8BytesToString

### DIFF
--- a/gdal/swig/csharp/GNUmakefile
+++ b/gdal/swig/csharp/GNUmakefile
@@ -64,7 +64,7 @@ $(CSHARP_MODULES): lib%csharp.$(SO_EXT): %_wrap.$(OBJ_EXT)
 
 gdal_csharp:
 	$(CSC) /debug:full /target:library /out:osr_csharp.dll osr/*.cs AssemblyInfo.cs
-	$(CSC) /debug:full /target:library /out:ogr_csharp.dll /r:osr_csharp.dll ogr/*.cs AssemblyInfo.cs
+	$(CSC) /unsafe /debug:full /target:library /out:ogr_csharp.dll /r:osr_csharp.dll ogr/*.cs AssemblyInfo.cs
 	$(CSC) /debug:full /target:library /out:gdal_csharp.dll /r:ogr_csharp.dll /r:osr_csharp.dll gdal/*.cs AssemblyInfo.cs
 	$(CSC) /debug:full /target:library /out:gdalconst_csharp.dll const/*.cs AssemblyInfo.cs
 

--- a/gdal/swig/csharp/GNUmakefile
+++ b/gdal/swig/csharp/GNUmakefile
@@ -63,10 +63,10 @@ $(CSHARP_MODULES): lib%csharp.$(SO_EXT): %_wrap.$(OBJ_EXT)
 	$(CC) $(CFLAGS) $(SUPPRESSW) $(GDAL_INCLUDE) -c $<
 
 gdal_csharp:
-	$(CSC) /debug:full /target:library /out:osr_csharp.dll osr/*.cs AssemblyInfo.cs
+	$(CSC) /unsafe /debug:full /target:library /out:osr_csharp.dll osr/*.cs AssemblyInfo.cs
 	$(CSC) /unsafe /debug:full /target:library /out:ogr_csharp.dll /r:osr_csharp.dll ogr/*.cs AssemblyInfo.cs
-	$(CSC) /debug:full /target:library /out:gdal_csharp.dll /r:ogr_csharp.dll /r:osr_csharp.dll gdal/*.cs AssemblyInfo.cs
-	$(CSC) /debug:full /target:library /out:gdalconst_csharp.dll const/*.cs AssemblyInfo.cs
+	$(CSC) /unsafe /debug:full /target:library /out:gdal_csharp.dll /r:ogr_csharp.dll /r:osr_csharp.dll gdal/*.cs AssemblyInfo.cs
+	$(CSC) /unsafe /debug:full /target:library /out:gdalconst_csharp.dll const/*.cs AssemblyInfo.cs
 
 samples:
 	$(CSC) /r:ogr_csharp.dll /r:osr_csharp.dll /out:ogrinfo.exe apps/ogrinfo.cs

--- a/gdal/swig/csharp/makefile.vc
+++ b/gdal/swig/csharp/makefile.vc
@@ -99,21 +99,21 @@ gdal_csharp: template.csproj
 !IFDEF NETSTANDARD
     cd const
     copy ..\template.csproj gdalconst_csharp.csproj
-    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd osr
     copy ..\template.csproj osr_csharp.csproj
-    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd ogr
     copy ..\template.csproj ogr_csharp.csproj
     dotnet add reference ..\osr\osr_csharp.csproj
-    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd gdal
     copy ..\template.csproj gdal_csharp.csproj
     dotnet add reference ..\osr\osr_csharp.csproj ..\ogr\ogr_csharp.csproj
-    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
 !ELSE
     $(CSC) $(CSDEBUG) /unsafe /target:library /out:osr_csharp.dll osr\*.cs AssemblyInfo.cs

--- a/gdal/swig/csharp/makefile.vc
+++ b/gdal/swig/csharp/makefile.vc
@@ -72,6 +72,7 @@ template.csproj:
     echo ^<PropertyGroup^> >> $@
     echo ^<TargetFramework^>$(NETSTANDARD)^</TargetFramework^> >> $@
     echo ^<AssemblyVersion^>$(GDAL_VERSION).0^</AssemblyVersion^> >> $@
+	echo ^<AllowUnsafeBlocks^>true^</AllowUnsafeBlocks^> >> $@
     echo ^</PropertyGroup^> >> $@
     echo ^</Project^> >> $@
 !ELSE
@@ -99,21 +100,21 @@ gdal_csharp: template.csproj
 !IFDEF NETSTANDARD
     cd const
     copy ..\template.csproj gdalconst_csharp.csproj
-    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd osr
     copy ..\template.csproj osr_csharp.csproj
-    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd ogr
     copy ..\template.csproj ogr_csharp.csproj
     dotnet add reference ..\osr\osr_csharp.csproj
-    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd gdal
     copy ..\template.csproj gdal_csharp.csproj
     dotnet add reference ..\osr\osr_csharp.csproj ..\ogr\ogr_csharp.csproj
-    dotnet build -p:unsafe=true -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
 !ELSE
     $(CSC) $(CSDEBUG) /unsafe /target:library /out:osr_csharp.dll osr\*.cs AssemblyInfo.cs

--- a/gdal/swig/csharp/makefile.vc
+++ b/gdal/swig/csharp/makefile.vc
@@ -99,27 +99,27 @@ gdal_csharp: template.csproj
 !IFDEF NETSTANDARD
     cd const
     copy ..\template.csproj gdalconst_csharp.csproj
-    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd osr
     copy ..\template.csproj osr_csharp.csproj
-    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd ogr
     copy ..\template.csproj ogr_csharp.csproj
     dotnet add reference ..\osr\osr_csharp.csproj
-    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
     cd gdal
     copy ..\template.csproj gdal_csharp.csproj
     dotnet add reference ..\osr\osr_csharp.csproj ..\ogr\ogr_csharp.csproj
-    dotnet build -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
+    dotnet build -unsafe -c $(DOTNET_CONFIG) -o "." -r $(DOTNET_RID)
     cd ..
 !ELSE
-    $(CSC) $(CSDEBUG) /target:library /out:osr_csharp.dll osr\*.cs AssemblyInfo.cs
-    $(CSC) $(CSDEBUG) /target:library /out:ogr_csharp.dll /r:osr_csharp.dll ogr\*.cs AssemblyInfo.cs
-    $(CSC) $(CSDEBUG) /target:library /out:gdal_csharp.dll /r:ogr_csharp.dll /r:osr_csharp.dll gdal\*.cs AssemblyInfo.cs
-    $(CSC) $(CSDEBUG) /target:library /out:gdalconst_csharp.dll const\*.cs AssemblyInfo.cs
+    $(CSC) $(CSDEBUG) /unsafe /target:library /out:osr_csharp.dll osr\*.cs AssemblyInfo.cs
+    $(CSC) $(CSDEBUG) /unsafe /target:library /out:ogr_csharp.dll /r:osr_csharp.dll ogr\*.cs AssemblyInfo.cs
+    $(CSC) $(CSDEBUG) /unsafe /target:library /out:gdal_csharp.dll /r:ogr_csharp.dll /r:osr_csharp.dll gdal\*.cs AssemblyInfo.cs
+    $(CSC) $(CSDEBUG) /unsafe /target:library /out:gdalconst_csharp.dll const\*.cs AssemblyInfo.cs
 !ENDIF
     link /dll $(OGR_INCLUDE) $(BASE_INCLUDE) ogr_wrap.obj \
 		$(EXTERNAL_LIBS) $(GDALLIB)\

--- a/gdal/swig/include/csharp/typemaps_csharp.i
+++ b/gdal/swig/include/csharp/typemaps_csharp.i
@@ -440,15 +440,15 @@ OPTIONAL_POD(int, int);
     return bytes;
   }
 
-  internal static string Utf8BytesToString(IntPtr pNativeData)
+  internal unsafe static string Utf8BytesToString(IntPtr pNativeData)
   {
     if (pNativeData == IntPtr.Zero)
         return null;
 
-    int length = Marshal.PtrToStringAnsi(pNativeData).Length;
-    byte[] strbuf = new byte[length];
-    Marshal.Copy(pNativeData, strbuf, 0, length);
-    return System.Text.Encoding.UTF8.GetString(strbuf);
+    byte* pStringUtf8 = (byte*) pNativeData;
+    int len = 0;
+    while (pStringUtf8[len] != 0) len++;
+    return System.Text.Encoding.UTF8.GetString(pStringUtf8, len);
   }
 %}
 


### PR DESCRIPTION
The existing implementation has shown to corrupt strings when bindings are generated and used with .NET Core.

I'm not sure why the existing implementation seem to work in .NET Framework. It does seem buggy - length is number of characters not bytes.

The proposed implementation in this PR has been verified working in .NET Core but is not verified with .NET Framework but I believe it should work.


