### PR TITLE
Set the application name in PostgreSQL connections

### DIFF
--- a/gdal/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/gdal/frmts/postgisraster/postgisrasterdataset.cpp
@@ -2905,8 +2905,8 @@ GetConnectionInfo(const char * pszFilename,
      * Set application name if not found in connection string
      **********************************************************/
 
-    nPos = CSLFindName(papszParams, "application_name");
-    if (nPos == -1) {
+    if (CSLFindName(papszParams, "application_name") == -1 &&
+        getenv("PGAPPNAME") == nullptr) {
         osConnectionString += "application_name=";
         osConnectionString += "'";
         osConnectionString += "GDAL ";

--- a/gdal/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/gdal/frmts/postgisraster/postgisrasterdataset.cpp
@@ -2900,6 +2900,21 @@ GetConnectionInfo(const char * pszFilename,
         osConnectionString += papszParams[i];
         osConnectionString += " ";
     }
+
+    /**********************************************************
+     * Set application name if not found in connection string
+     **********************************************************/
+
+    nPos = CSLFindName(papszParams, "application_name");
+    if (nPos == -1) {
+        osConnectionString += "application_name=";
+        osConnectionString += "'";
+        osConnectionString += "GDAL ";
+        osConnectionString += GDALVersionInfo("RELEASE_NAME");
+        osConnectionString += "'";
+        osConnectionString += " ";
+    }
+
     *ppszConnectionString = CPLStrdup(osConnectionString);
 
     nPos = CSLFindName(papszParams, "host");

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -385,8 +385,8 @@ int OGRPGDataSource::Open( const char * pszNewName, int bUpdate,
 /*      Set application name if not found in connection string          */
 /* -------------------------------------------------------------------- */
 
-    char *pszApplicationNameStart = strstr(pszName, "application_name=");
-    if( pszApplicationNameStart == nullptr )
+    if (strstr(pszName, "application_name=") == nullptr &&
+        getenv("PGAPPNAME") == nullptr )
     {
         if( osConnectionName.back() != ':' )
             osConnectionName += " ";

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -381,6 +381,22 @@ int OGRPGDataSource::Open( const char * pszNewName, int bUpdate,
         }
     }
 
+/* -------------------------------------------------------------------- */
+/*      Set application name if not found in connection string          */
+/* -------------------------------------------------------------------- */
+
+    char *pszApplicationNameStart = strstr(pszName, "application_name=");
+    if( pszApplicationNameStart == nullptr )
+    {
+        if( osConnectionName.back() != ':' )
+            osConnectionName += " ";
+        osConnectionName += "application_name=";
+        osConnectionName += "'";
+        osConnectionName += "GDAL ";
+        osConnectionName += GDALVersionInfo("RELEASE_NAME");
+        osConnectionName += "'";
+    }
+
     char* pszConnectionName = CPLStrdup(osConnectionName);
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## What does this PR do?

If the application name is not set in the connection string then set the application name to the current GDAL version. PostgreSQL connections can take a long time before they are closed and they do show up in the database session list. Being able to identify database sessions makes diagnostics easier.

Ran valgrind, no mem leaks.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
