### PR TITLE
Remove GDAL_SKIP=JP2ECW, see how CI reacts

### DIFF
--- a/gdal/ci/travis/osx/script.sh
+++ b/gdal/ci/travis/osx/script.sh
@@ -6,7 +6,7 @@ export PYTHONPATH=$PWD/gdal/swig/python/build/lib.macosx-10.13-x86_64-2.7:$PWD/g
 export PYTEST="pytest -vv -p no:sugar --color=no"
 
 echo 'Running CPP unit tests'
-(cd autotest/cpp && GDAL_SKIP=JP2ECW make quick_test)
+(cd autotest/cpp && make quick_test)
 
 echo 'Running Python unit tests'
 # install test dependencies

--- a/gdal/ci/travis/python3/script.sh
+++ b/gdal/ci/travis/python3/script.sh
@@ -19,7 +19,7 @@ cd ../..
 # CPP unit tests
 cd ../autotest
 cd cpp
-GDAL_SKIP=JP2ECW make quick_test
+make quick_test
 # Compile and test vsipreload
 make vsipreload.so
 LD_PRELOAD=./vsipreload.so gdalinfo /vsicurl/http://download.osgeo.org/gdal/data/ecw/spif83.ecw
@@ -52,4 +52,4 @@ PYTESTARGS="$PYTESTARGS --ignore gdrivers/test_validate_jp2.py"
 
 # Run all the Python autotests
 
-GDAL_SKIP="JP2ECW ECW" $PYTEST $PYTESTARGS
+$PYTEST $PYTESTARGS

--- a/gdal/ci/travis/python3/script.sh
+++ b/gdal/ci/travis/python3/script.sh
@@ -52,4 +52,4 @@ PYTESTARGS="$PYTESTARGS --ignore gdrivers/test_validate_jp2.py"
 
 # Run all the Python autotests
 
-$PYTEST $PYTESTARGS
+GDAL_SKIP="JP2ECW ECW" $PYTEST $PYTESTARGS

--- a/gdal/ci/travis/trusty_clang/script.sh
+++ b/gdal/ci/travis/trusty_clang/script.sh
@@ -23,7 +23,7 @@ cd ../..
 # CPP unit tests
 cd ../autotest
 cd cpp
-GDAL_SKIP=JP2ECW make quick_test
+make quick_test
 # Compile and test vsipreload
 make vsipreload.so
 LD_PRELOAD=./vsipreload.so gdalinfo /vsicurl/http://download.osgeo.org/gdal/data/ecw/spif83.ecw
@@ -48,4 +48,4 @@ PYTESTARGS="--ignore ogr/ogr_fgdb.py"
 PYTESTARGS="$PYTESTARGS --ignore ogr/ogr_pgeo.py"
 
 # Run all the Python autotests
-GDAL_SKIP="JP2ECW ECW" $PYTEST $PYTESTARGS
+$PYTEST $PYTESTARGS


### PR DESCRIPTION
I noticed that a lot of the CI tests are using `GDAL_SKIP JP2ECW`, so this is just a test to see what happens when this is removed.

Edit: I'm still not entirely sure what this controls, but it appears that this is no longer needed in most cases.