### PR TITLE
Fix warning C4251 if Visual Studio and shared for consumers of gdal lib

### DIFF
--- a/gdal/port/cpl_port.h
+++ b/gdal/port/cpl_port.h
@@ -344,7 +344,11 @@ typedef unsigned int  GUIntptr_t;
 
 #ifndef CPL_DLL
 #if defined(_MSC_VER) && !defined(CPL_DISABLE_DLL)
-#  define CPL_DLL     __declspec(dllexport)
+#  ifdef GDAL_COMPILATION
+#    define CPL_DLL __declspec(dllexport)
+#  else
+#    define CPL_DLL
+#  endif
 #  define CPL_INTERNAL
 #else
 #  if defined(USE_GCC_VISIBILITY_FLAG)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

For Visual Studio if GDAL is a shared library, this PR avoids defining `CPL_DLL` as `__declspec(dllexport)` when consumers use GDAL library (and therefore prevents from a lot of C4251 warnings).
Thereby, if GDAL is shared and compiled with Visual Studio, `CPL_DLL` is defined as :
- `__declspec(dllexport)` at compile time
- empty for consumers

Notes:
- `CPL_DLL` should be `__declspec(dllimport)` at consume time, but it also generates warnings due to stl classes exposed in public GDAL classes. `CPL_DLL` defined as empty is fine because GDAL doesn't have global variables in public headers.
- In this PR, GDAL executables are also built with `CPL_DLL` as `__declspec(dllexport)` (same behaviour than before) which is not very neat, but works (without warnings because C4251 is disabled in nmake fikes).

## What are related issues/pull requests?

closes https://github.com/OSGeo/gdal/issues/2664

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Windows
* Compiler: Visual Studio
