### PR TITLE
gdalwarp: fix crash if warping a dataset without source or target CRSwhen -ct is specified

### DIFF
--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -756,3 +756,15 @@ def test_transformer_tps_precision():
     assert success, 'at least one point could not be transformed'
     assert maxDiffResult < 1e-3, 'at least one transformation exceeds the error bound'
 
+
+###############################################################################
+def test_transformer_image_no_srs():
+
+    ds = gdal.GetDriverByName('MEM').Create('', 1, 1)
+    ds.SetGeoTransform([0, 10, 0, 0, 0, -10])
+    tr = gdal.Transformer(ds, None, ['COORDINATE_OPERATION=+proj=unitconvert +xy_in=1 +xy_out=2'])
+    assert tr
+    (success, pnt) = tr.TransformPoint(0, 10, 20, 0)
+    assert success
+    assert pnt[0] == pytest.approx(50), pnt
+    assert pnt[1] == pytest.approx(-100), pnt

--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -36,6 +36,7 @@ import sys
 from osgeo import gdal
 from osgeo import osr
 from osgeo import ogr
+import gdaltest
 import pytest
 
 
@@ -172,8 +173,9 @@ def test_osr_ct_5():
 
 def test_osr_ct_6():
 
-    ct = osr.CreateCoordinateTransformation(None, None)
-    assert ct is None
+    with gdaltest.error_handler():
+        ct = osr.CreateCoordinateTransformation(None, None)
+        assert ct is None
 
     utm_srs = osr.SpatialReference()
     utm_srs.SetUTM(11)

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -1979,6 +1979,14 @@ def test_gdalwarp_lib_multiple_source_incompatible_buildvrt_to_cog_reprojection_
     gdal.Unlink('/vsimem/left.tif')
     gdal.Unlink('/vsimem/right.tif')
 
+###############################################################################
+
+def test_gdalwarp_lib_no_crs():
+
+    src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1)
+    src_ds.SetGeoTransform([0, 10, 0, 0, 0, -10])
+    out_ds = gdal.Warp('', src_ds, options = '-of MEM -ct "+proj=unitconvert +xy_in=1 +xy_out=2"')
+    assert out_ds.GetGeoTransform() == (0.0, 5.0, 0.0, 0.0, 0.0, -5.0)
 
 ###############################################################################
 # Cleanup

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -729,7 +729,12 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
     if( poSourceIn == nullptr || poTargetIn == nullptr )
     {
         if( options.d->osCoordOperation.empty() )
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "OGRProjCT::Initialize(): if source and/or target CRS "
+                     "are null, a coordinate operation must be specified");
             return FALSE;
+        }
     }
 
     if( poSourceIn )


### PR DESCRIPTION
(fixes #2675)
