### PR TITLE
RPC_DEM_SRS option for GDALCreateRPCTransformer to override SRS of RPC_DEM.

### DIFF
--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -251,7 +251,7 @@ def test_transformer_5():
     ds_dem.SetGeoTransform([213300, 200, 0, 4418700, 0, -200])
     ds_dem.GetRasterBand(1).Fill(15)
     ds_dem = None
-    import ipdb; ipdb.set_trace()
+    
     tr = gdal.Transformer(ds, None, ['METHOD=RPC', 'RPC_HEIGHT_SCALE=2', 'RPC_DEM=/vsimem/dem.tif', 'RPC_DEM_SRS=EPSG:32652+5773'])
 
     (success, pnt) = tr.TransformPoint(0, 0.5, 0.5, 0)

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -789,3 +789,5 @@ def test_transformer_dem_overrride_srs():
     (success, pnt) = tr.TransformPoint(1, pnt[0], pnt[1], pnt[2])
     assert success and pnt[0] == pytest.approx(0.5, abs=0.05) and pnt[1] == pytest.approx(0.5, abs=0.05), \
         'got wrong reverse transform result.'
+
+    gdal.Unlink('/vsimem/dem.tif')

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -243,29 +243,7 @@ def test_transformer_5():
 
     tr = None
 
-    # Test RPC_DEM_SRS by adding vertical component egm 96 geoid
-    ds_dem = gdal.GetDriverByName('GTiff').Create('/vsimem/dem.tif', 100, 100, 1)
-    sr = osr.SpatialReference()
-    sr.ImportFromEPSG(32652)
-    ds_dem.SetProjection(sr.ExportToWkt())
-    ds_dem.SetGeoTransform([213300, 200, 0, 4418700, 0, -200])
-    ds_dem.GetRasterBand(1).Fill(15)
-    ds_dem = None
-    
-    tr = gdal.Transformer(ds, None, ['METHOD=RPC', 'RPC_HEIGHT_SCALE=2', 'RPC_DEM=/vsimem/dem.tif', 'RPC_DEM_SRS=EPSG:32652+5773'])
-
-    (success, pnt) = tr.TransformPoint(0, 0.5, 0.5, 0)
-    assert success and pnt[0] == pytest.approx(125.64813723085801, abs=0.000001) and pnt[1] == pytest.approx(39.869345977927146, abs=0.000001), \
-        'got wrong forward transform result.'
-
-    (success, pnt) = tr.TransformPoint(1, pnt[0], pnt[1], pnt[2])
-    assert success and pnt[0] == pytest.approx(0.5, abs=0.05) and pnt[1] == pytest.approx(0.5, abs=0.05), \
-        'got wrong reverse transform result.'
-
-    tr = None
-
     gdal.Unlink('/vsimem/dem.tif')
-
 
 ###############################################################################
 # Test RPC convergence bug (bug # 5395)
@@ -789,3 +767,25 @@ def test_transformer_image_no_srs():
     assert success
     assert pnt[0] == pytest.approx(50), pnt
     assert pnt[1] == pytest.approx(-100), pnt
+
+###############################################################################
+# Test RPC_DEM_SRS by adding vertical component egm 96 geoid
+
+def test_transformer_dem_overrride_srs():
+    ds = gdal.Open('data/rpc.vrt')
+    ds_dem = gdal.GetDriverByName('GTiff').Create('/vsimem/dem.tif', 100, 100, 1)
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32652)
+    ds_dem.SetProjection(sr.ExportToWkt())
+    ds_dem.SetGeoTransform([213300, 200, 0, 4418700, 0, -200])
+    ds_dem.GetRasterBand(1).Fill(15)
+    ds_dem = None
+    tr = gdal.Transformer(ds, None, ['METHOD=RPC', 'RPC_HEIGHT_SCALE=2', 'RPC_DEM=/vsimem/dem.tif', 'RPC_DEM_SRS=EPSG:32652+5773'])
+
+    (success, pnt) = tr.TransformPoint(0, 0.5, 0.5, 0)
+    assert success and pnt[0] == pytest.approx(125.64813723085801, abs=0.000001) and pnt[1] == pytest.approx(39.869345977927146, abs=0.000001), \
+        'got wrong forward transform result.'
+
+    (success, pnt) = tr.TransformPoint(1, pnt[0], pnt[1], pnt[2])
+    assert success and pnt[0] == pytest.approx(0.5, abs=0.05) and pnt[1] == pytest.approx(0.5, abs=0.05), \
+        'got wrong reverse transform result.'

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -789,10 +789,3 @@ def test_transformer_image_no_srs():
     assert success
     assert pnt[0] == pytest.approx(50), pnt
     assert pnt[1] == pytest.approx(-100), pnt
-
-
-###############################################################################
-# Test RPC transform with DEM_SRS override of RPC_DEM
-
-def test_transform_rpc_dem_srs():
-    ds = gdal.Open('data/rpc.vrt')

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -2302,7 +2302,7 @@ CPLXMLNode *GDALSerializeRPCTransformer( void *pTransformArg )
         {
             CPLCreateXMLElementAndValue(
                 psTree, "DEMSRS",
-                CPLString().Printf( "%s", psInfo->pszDEMSRS ) );
+                psInfo->pszDEMSRS );
         }
     }
 

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -733,7 +733,7 @@ retry:
  *
  * <li> RPC_DEM_SRS: (GDAL >= 3.1) WKT SRS, or any string recognized by
  * OGRSpatialReference::SetFromUserInput(), to be used as an override for DEM SRS.
- * Useful if DEM SRS does not have an explicit vertical component.
+ * Useful if DEM SRS does not have an explicit vertical component. </li>
  *
  * <li> RPC_DEM_APPLY_VDATUM_SHIFT: whether the vertical component of a compound
  * SRS for the DEM should be used (when it is present). This is useful so as to
@@ -900,6 +900,7 @@ void *GDALCreateRPCTransformer( GDALRPCInfo *psRPCInfo, int bReversed,
     {
         psTransform->pszDEMSRS = CPLStrdup(pszDEMSRS);
     }
+
 /* -------------------------------------------------------------------- */
 /*      Whether to apply vdatum shift                                   */
 /* -------------------------------------------------------------------- */

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -731,7 +731,7 @@ retry:
  * cover the requested coordinate. When not specified, missing values will cause
  * a failed transform.</li>
  *
- * <li> RPC_DEM_SRS: (GDAL >= 3.1) WKT SRS, or any string recognized by
+ * <li> RPC_DEM_SRS: (GDAL >= 3.2) WKT SRS, or any string recognized by
  * OGRSpatialReference::SetFromUserInput(), to be used as an override for DEM SRS.
  * Useful if DEM SRS does not have an explicit vertical component. </li>
  *

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -731,6 +731,9 @@ retry:
  * cover the requested coordinate. When not specified, missing values will cause
  * a failed transform.</li>
  *
+ * <li> RPC_DEM_SRS: WKT SRS, or any string recognized by
+ * OGRSpatialReference::SetFromUserInput(), to be used as an override for DEM SRS.
+ *
  * <li> RPC_DEM_APPLY_VDATUM_SHIFT: whether the vertical component of a compound
  * SRS for the DEM should be used (when it is present). This is useful so as to
  * be able to transform the "raw" values from the DEM expressed with respect to
@@ -1920,7 +1923,7 @@ static bool GDALRPCOpenDEM( GDALRPCTransformInfo* psTransform )
         psTransform->nLastQueriedX = -1;
         psTransform->nLastQueriedY = -1;
 
-        OGRSpatialReference* poDEMSRS;
+        OGRSpatialReference* poDEMSRS = nullptr;
         if ( psTransform->pszDEMSRS != nullptr )
         {
             poDEMSRS = new OGRSpatialReference();

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -1926,14 +1926,14 @@ static bool GDALRPCOpenDEM( GDALRPCTransformInfo* psTransform )
         psTransform->nLastQueriedX = -1;
         psTransform->nLastQueriedY = -1;
 
-        OGRSpatialReference poDEMSRS;
+        OGRSpatialReference oDEMSRS;
         if ( psTransform->pszDEMSRS != nullptr )
         {
-            poDEMSRS.SetFromUserInput(psTransform->pszDEMSRS);
-            poDEMSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+            oDEMSRS.SetFromUserInput(psTransform->pszDEMSRS);
+            oDEMSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
         }
 
-        auto poDSSpaRefSrc = psTransform->pszDEMSRS != nullptr ? poDEMSRS : psTransform->poDS->GetSpatialRef();
+        auto poDSSpaRefSrc = psTransform->pszDEMSRS != nullptr ? &oDEMSRS : psTransform->poDS->GetSpatialRef();
         if( poDSSpaRefSrc )
         {
             auto poDSSpaRef = poDSSpaRefSrc->Clone();

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -1926,7 +1926,7 @@ static bool GDALRPCOpenDEM( GDALRPCTransformInfo* psTransform )
         psTransform->nLastQueriedX = -1;
         psTransform->nLastQueriedY = -1;
 
-        OGRSpatialReference* poDEMSRS = nullptr;
+        OGRSpatialReference* poDEMSRS;
         if ( psTransform->pszDEMSRS != nullptr )
         {
             poDEMSRS = new OGRSpatialReference();
@@ -2295,16 +2295,18 @@ CPLXMLNode *GDALSerializeRPCTransformer( void *pTransformArg )
         CPLCreateXMLElementAndValue(
                 psTree, "DEMApplyVDatumShift",
                 psInfo->bApplyDEMVDatumShift ? "true" : "false" );
-    }
 
 /* -------------------------------------------------------------------- */
 /*      Serialize DEM SRS                                               */
 /* -------------------------------------------------------------------- */
-    if( psInfo->pszDEMSRS != nullptr )
-    {
-        CPLCreateXMLElementAndValue(
-            psTree, "DEMSRS",
-            CPLString().Printf( "%s", psInfo->pszDEMSRS ) );
+        if( psInfo->pszDEMSRS != nullptr )
+        {
+            CPLCreateXMLElementAndValue(
+                psTree, "DEMSRS",
+                CPLString().Printf( "%s", psInfo->pszDEMSRS ) );
+        }
+    }
+
 /* -------------------------------------------------------------------- */
 /*      Serialize pixel error threshold.                                */
 /* -------------------------------------------------------------------- */

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -1076,6 +1076,7 @@ void GDALDestroyRPCTransformer( void *pTransformAlg )
         static_cast<GDALRPCTransformInfo *>(pTransformAlg);
 
     CPLFree( psTransform->pszDEMPath );
+    CPLFree( psTransform->pszDEMSRS );
 
     if( psTransform->poDS )
         GDALClose(psTransform->poDS);
@@ -2297,6 +2298,14 @@ CPLXMLNode *GDALSerializeRPCTransformer( void *pTransformArg )
     }
 
 /* -------------------------------------------------------------------- */
+/*      Serialize DEM SRS                                               */
+/* -------------------------------------------------------------------- */
+    if( psInfo->pszDEMSRS != nullptr )
+    {
+        CPLCreateXMLElementAndValue(
+            psTree, "DEMSRS",
+            CPLString().Printf( "%s", psInfo->pszDEMSRS ) );
+/* -------------------------------------------------------------------- */
 /*      Serialize pixel error threshold.                                */
 /* -------------------------------------------------------------------- */
     CPLCreateXMLElementAndValue(
@@ -2413,6 +2422,10 @@ void *GDALDeserializeRPCTransformer( CPLXMLNode *psTree )
         papszOptions = CSLSetNameValue(papszOptions,
                                        "RPC_DEM_APPLY_VDATUM_SHIFT",
                                        pszDEMApplyVDatumShift);
+    const char* pszDEMSRS =
+        CPLGetXMLValue(psTree, "DEMSRS", nullptr);
+    if( pszDEMSRS != nullptr )
+        papszOptions = CSLSetNameValue(papszOptions, "RPC_DEM_SRS", pszDEMSRS);
 
 /* -------------------------------------------------------------------- */
 /*      Generate transformation.                                        */

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -1926,12 +1926,11 @@ static bool GDALRPCOpenDEM( GDALRPCTransformInfo* psTransform )
         psTransform->nLastQueriedX = -1;
         psTransform->nLastQueriedY = -1;
 
-        OGRSpatialReference* poDEMSRS;
+        OGRSpatialReference poDEMSRS;
         if ( psTransform->pszDEMSRS != nullptr )
         {
-            poDEMSRS = new OGRSpatialReference();
-            poDEMSRS->SetFromUserInput(psTransform->pszDEMSRS);
-            poDEMSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+            poDEMSRS.SetFromUserInput(psTransform->pszDEMSRS);
+            poDEMSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
         }
 
         auto poDSSpaRefSrc = psTransform->pszDEMSRS != nullptr ? poDEMSRS : psTransform->poDS->GetSpatialRef();

--- a/gdal/alg/gdal_rpc.cpp
+++ b/gdal/alg/gdal_rpc.cpp
@@ -731,8 +731,9 @@ retry:
  * cover the requested coordinate. When not specified, missing values will cause
  * a failed transform.</li>
  *
- * <li> RPC_DEM_SRS: WKT SRS, or any string recognized by
+ * <li> RPC_DEM_SRS: (GDAL >= 3.1) WKT SRS, or any string recognized by
  * OGRSpatialReference::SetFromUserInput(), to be used as an override for DEM SRS.
+ * Useful if DEM SRS does not have an explicit vertical component.
  *
  * <li> RPC_DEM_APPLY_VDATUM_SHIFT: whether the vertical component of a compound
  * SRS for the DEM should be used (when it is present). This is useful so as to


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
New option `RPC_DEM_SRS`  for `GDALCreateRPCTransformer`, which can be used analogously to `SRC_SRS` or `DST_SRS` in `GDALCreateGenImgProjTransformer2`. This can be useful in cases where a DEM supplied to `RPC_DEM` does not have an explicit vertical SRS so height values sampled from the DEM are not transformed to be relative to the WGS84 ellipsoid. Previously, one workaround to this was to simply provide a VRT with the correct (explicit) SRS to `RPC_DEM`. 

I've checked with `valgrind --leak-check=yes echo "0 0" | gdaltransform -rpc -to RPC_DEM_SRS="EPSG:4326+5773" -to RPC_DEM=/path/to/dem.tif /path/to/image.tif` and there didn't seem to be any immediate issues.

## What are related issues/pull requests?

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] Squash commits

## Environment

Provide environment details, if relevant:


* OS: WSL 2 Ubuntu 20.04
* Compiler: gcc
* PROJ: 7.0.1
