### PR TITLE
S57: report attributes tagged as list in S57 dictionaries as StringList fields

### DIFF
--- a/autotest/ogr/ogr_s57.py
+++ b/autotest/ogr/ogr_s57.py
@@ -61,7 +61,7 @@ def test_ogr_s57_1():
 # matches our expectations.
 
 
-def test_ogr_s57_2():
+def test_ogr_s57_check_layers():
     if gdaltest.s57_ds is None:
         pytest.skip()
 
@@ -101,7 +101,7 @@ def test_ogr_s57_2():
 # Check the COALNE feature.
 
 
-def test_ogr_s57_3():
+def test_ogr_s57_COALNE():
     if gdaltest.s57_ds is None:
         pytest.skip()
 
@@ -120,7 +120,7 @@ def test_ogr_s57_3():
 # Check the M_QUAL feature.
 
 
-def test_ogr_s57_4():
+def test_ogr_s57_M_QUAL():
     if gdaltest.s57_ds is None:
         pytest.skip()
 
@@ -139,7 +139,7 @@ def test_ogr_s57_4():
 # Check the SOUNDG feature.
 
 
-def test_ogr_s57_5():
+def test_ogr_s57_SOUNDG():
     if gdaltest.s57_ds is None:
         pytest.skip()
 
@@ -149,6 +149,8 @@ def test_ogr_s57_5():
 
     assert feat.GetField('RCID') == 20 and feat.GetField('OBJL') == 129 and feat.GetField('AGEN') == 65535, \
         'SOUNDG: did not get expected attributes'
+
+    assert feat.GetField('QUASOU') == ['1']
 
     wkt = 'MULTIPOINT (60.98164400 -32.49449000 3.400,60.98134400 -32.49642400 1.400,60.97814200 -32.49487400 -3.200,60.98071200 -32.49519600 1.200)'
 
@@ -160,7 +162,7 @@ def test_ogr_s57_5():
 # Test reading features from dataset with some double byte attributes. (#1526)
 
 
-def test_ogr_s57_6():
+def test_ogr_s57_double_byte_attrs():
 
     ds = ogr.Open('data/s57/bug1526.000')
 
@@ -175,7 +177,7 @@ def test_ogr_s57_6():
 # Test handling of a dataset with a multilinestring feature (#2147).
 
 
-def test_ogr_s57_7():
+def test_ogr_s57_multilinestring():
 
     ds = ogr.Open('data/s57/bug2147_3R7D0889.000')
 
@@ -191,7 +193,7 @@ def test_ogr_s57_7():
 # Run test_ogrsf
 
 
-def test_ogr_s57_8():
+def test_ogr_s57_test_ogrsf():
 
     import test_cli_utilities
     if test_cli_utilities.get_test_ogrsf_path() is None:
@@ -205,7 +207,7 @@ def test_ogr_s57_8():
 # Test S57 to S57 conversion
 
 
-def test_ogr_s57_9():
+def test_ogr_s57_write():
 
     gdal.Unlink('tmp/ogr_s57_9.000')
 
@@ -228,17 +230,17 @@ def test_ogr_s57_9():
     assert ds is not None
 
     gdaltest.s57_ds = ds
-    test_ogr_s57_2()
-    test_ogr_s57_3()
-    test_ogr_s57_4()
-    test_ogr_s57_5()
+    test_ogr_s57_check_layers()
+    test_ogr_s57_COALNE()
+    test_ogr_s57_M_QUAL()
+    test_ogr_s57_SOUNDG()
 
     gdaltest.s57_ds = None
 
     gdal.Unlink('tmp/ogr_s57_9.000')
 
     gdal.SetConfigOption('OGR_S57_OPTIONS', 'RETURN_PRIMITIVES=ON,RETURN_LINKAGES=ON,LNAM_REFS=ON')
-    gdal.VectorTranslate('tmp/ogr_s57_9.000', 'data/s57/1B5X02NE.000', options="-f S57 IsolatedNode ConnectedNode Edge Face M_QUAL")
+    gdal.VectorTranslate('tmp/ogr_s57_9.000', 'data/s57/1B5X02NE.000', options="-f S57 IsolatedNode ConnectedNode Edge Face M_QUAL SOUNDG")
     gdal.SetConfigOption('OGR_S57_OPTIONS', None)
 
     ds = gdal.OpenEx('tmp/ogr_s57_9.000', open_options=['RETURN_PRIMITIVES=ON'])
@@ -247,7 +249,8 @@ def test_ogr_s57_9():
     assert ds.GetLayerByName('IsolatedNode') is not None
 
     gdaltest.s57_ds = ds
-    test_ogr_s57_4()
+    test_ogr_s57_M_QUAL()
+    test_ogr_s57_SOUNDG()
 
     gdaltest.s57_ds = None
 

--- a/gdal/doc/source/drivers/vector/s57.rst
+++ b/gdal/doc/source/drivers/vector/s57.rst
@@ -166,6 +166,10 @@ They can also be specified independently as open options to the driver.
 -  **RECODE_BY_DSSI**\ =ON/OFF: Should attribute values be
    recoded to UTF-8 from the character encoding specified in the S57
    DSSI record. Default is OFF.
+-  **LIST_AS_STRING**\ =ON/OFF: (GDAL >= 3.2) Whether attributes tagged as list in S57
+   dictionaries should be reported as a String field, instead of a StringList.
+   Default is OFF. Before GDAL 3.2, the behaviour was equivalent to setting
+   this option to ON.
 
 Example:
 

--- a/gdal/ogr/ogrsf_frmts/s57/ogrs57datasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/ogrs57datasource.cpp
@@ -212,6 +212,11 @@ int OGRS57DataSource::Open( const char * pszFilename )
             CSLSetNameValue( papszReaderOptions, S57O_RECODE_BY_DSSI,
                              GetOption(S57O_RECODE_BY_DSSI) );
 
+    if( GetOption(S57O_LIST_AS_STRING) != nullptr )
+        papszReaderOptions =
+            CSLSetNameValue( papszReaderOptions, S57O_LIST_AS_STRING,
+                             GetOption(S57O_LIST_AS_STRING) );
+
     S57Reader *poModule = new S57Reader( pszFilename );
     bool bRet = poModule->SetOptions( papszReaderOptions );
     CSLDestroy( papszReaderOptions );

--- a/gdal/ogr/ogrsf_frmts/s57/ogrs57driver.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/ogrs57driver.cpp
@@ -188,6 +188,7 @@ void RegisterOGRS57()
         "  <Option name='" S57O_LNAM_REFS "' type='boolean' description='Should LNAM and LNAM_REFS fields be attached to features capturing the feature to feature relationships in the FFPT group of the S-57 file' default='YES'/>"
         "  <Option name='" S57O_RETURN_LINKAGES "' type='boolean' description='Should additional attributes relating features to their underlying geometric primitives be attached' default='NO'/>"
         "  <Option name='" S57O_RECODE_BY_DSSI "' type='boolean' description='Should attribute values be recoded to UTF-8 from the character encoding specified in the S57 DSSI record.' default='NO'/>"
+        "  <Option name='" S57O_LIST_AS_STRING "' type='boolean' description='Whether attributes tagged as list in S57 dictionaries should be reported as a String field' default='NO'/>"
         "</OpenOptionList>");
     poDriver->SetMetadataItem(
         GDAL_DMD_CREATIONOPTIONLIST,

--- a/gdal/ogr/ogrsf_frmts/s57/s57.h
+++ b/gdal/ogr/ogrsf_frmts/s57/s57.h
@@ -56,6 +56,7 @@ char **S57FileCollector( const char * pszDataset );
 #define S57O_RETURN_LINKAGES "RETURN_LINKAGES"
 #define S57O_RETURN_DSID     "RETURN_DSID"
 #define S57O_RECODE_BY_DSSI  "RECODE_BY_DSSI"
+#define S57O_LIST_AS_STRING "LIST_AS_STRING"
 
 #define S57M_UPDATES                    0x01
 #define S57M_LNAM_REFS                  0x02
@@ -66,6 +67,7 @@ char **S57FileCollector( const char * pszDataset );
 #define S57M_RETURN_LINKAGES            0x40
 #define S57M_RETURN_DSID                0x80
 #define S57M_RECODE_BY_DSSI             0x100
+#define S57M_LIST_AS_STRING             0x200
 
 /* -------------------------------------------------------------------- */
 /*      RCNM values.                                                    */

--- a/gdal/ogr/ogrsf_frmts/s57/s57featuredefns.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/s57featuredefns.cpp
@@ -421,7 +421,15 @@ OGRFeatureDefn *S57GenerateObjectClassDefn(
             break;
 
           case SAT_LIST:
-            oField.SetType( OFTString );
+            if( (nOptionFlags & S57M_LIST_AS_STRING) )
+            {
+                // Legacy behaviour
+                oField.SetType( OFTString );
+            }
+            else
+            {
+                oField.SetType( OFTStringList );
+            }
             break;
         }
 

--- a/gdal/ogr/ogrsf_frmts/s57/s57writer.cpp
+++ b/gdal/ogr/ogrsf_frmts/s57/s57writer.cpp
@@ -1015,11 +1015,11 @@ bool S57Writer::WriteATTF( DDFRecord *poRec, OGRFeature *poFeature )
     for( int iAttr = 0; papszAttrList[iAttr] != nullptr; iAttr++ )
     {
         const int iField = poFeature->GetFieldIndex( papszAttrList[iAttr] );
-        OGRFieldType eFldType =
-            poFeature->GetDefnRef()->GetFieldDefn(iField)->GetType();
-
         if( iField < 0 )
             continue;
+
+        const OGRFieldType eFldType =
+            poFeature->GetDefnRef()->GetFieldDefn(iField)->GetType();
 
         if( !poFeature->IsFieldSetAndNotNull( iField ) )
             continue;
@@ -1033,15 +1033,29 @@ bool S57Writer::WriteATTF( DDFRecord *poRec, OGRFeature *poFeature )
         memcpy( achRawData + nRawSize, &nATTL, 2 );
         nRawSize += 2;
 
-        const char *pszATVL = poFeature->GetFieldAsString( iField );
+        CPLString osATVL;
+        if( eFldType == OFTStringList )
+        {
+            const char* const* papszTokens = poFeature->GetFieldAsStringList(iField);
+            for( auto papszIter = papszTokens; papszIter && *papszIter; ++papszIter )
+            {
+                if( !osATVL.empty() )
+                    osATVL += ',';
+                osATVL += *papszIter;
+            }
+        }
+        else
+        {
+            osATVL = poFeature->GetFieldAsString( iField );
+        }
 
         // Special hack to handle special "empty" marker in integer fields.
-        if( atoi(pszATVL) == EMPTY_NUMBER_MARKER
-            && (eFldType == OFTInteger || eFldType == OFTReal) )
-            pszATVL = "";
+        if( (eFldType == OFTInteger || eFldType == OFTReal) &&
+            atoi(osATVL) == EMPTY_NUMBER_MARKER  )
+            osATVL.clear();
 
         // Watch for really long data.
-        if( strlen(pszATVL) + nRawSize + 10 > sizeof(achRawData) )
+        if( osATVL.size() + nRawSize + 10 > sizeof(achRawData) )
         {
             CPLError( CE_Failure, CPLE_AppDefined,
                       "Too much ATTF data for fixed buffer size." );
@@ -1049,8 +1063,11 @@ bool S57Writer::WriteATTF( DDFRecord *poRec, OGRFeature *poFeature )
         }
 
         // copy data into record buffer.
-        memcpy( achRawData + nRawSize, pszATVL, strlen(pszATVL) );
-        nRawSize += static_cast<int>(strlen(pszATVL));
+        if( !osATVL.empty() )
+        {
+            memcpy( achRawData + nRawSize, osATVL.data(), osATVL.size() );
+            nRawSize += static_cast<int>(osATVL.size());
+        }
         achRawData[nRawSize++] = DDF_UNIT_TERMINATOR;
 
         nACount++;


### PR DESCRIPTION
Add a LIST_AS_STRINGLIST open option that can be set to OFF to restore GDAL < 3.2 behaviour 

(fixes #2660)
