### PR TITLE
Add post-install tests to build apps using gdal.h with pkg-config

### DIFF
--- a/autotest/postinstall/README.md
+++ b/autotest/postinstall/README.md
@@ -1,0 +1,9 @@
+## Post-install tests
+
+These tests are performed with an *installed* GDAL library. The script checks that pkg-config on *nix platforms can discover the correct compilation and linking options to build C and C++ applications.
+
+To run these tests, use the test script with the install prefix as the first argument, for example if GDAL was configured with `--prefix=/tmp/gdal`:
+```bash
+./autotest/postinstall/test_pkg-config.sh /tmp/gdal
+```
+the prefix is used to set both `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` (or `DYLD_LIBRARY_PATH`) environment variables during testing.

--- a/autotest/postinstall/test_c/Makefile
+++ b/autotest/postinstall/test_c/Makefile
@@ -1,0 +1,15 @@
+PROGRAM = test_c
+OBJECTS = test_c.o
+
+override CFLAGS += -g -Wall -Werror $(shell pkg-config gdal --cflags)
+override LDFLAGS += $(shell pkg-config gdal --libs)
+
+all: $(PROGRAM)
+
+$(PROGRAM): $(OBJECTS)
+	$(CC) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) $(PROGRAM) $(OBJECTS)
+
+.PHONY: clean

--- a/autotest/postinstall/test_c/test_c.c
+++ b/autotest/postinstall/test_c/test_c.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+
+/* C API */
+#include <gdal.h>
+#include <cpl_conv.h>
+#include <cpl_csv.h>
+#include <cpl_error.h>
+#include <cpl_http.h>
+#include <cpl_minixml.h>
+#include <cpl_multiproc.h>
+#include <cpl_port.h>
+#include <cpl_progress.h>
+#include <cpl_string.h>
+#include <cpl_time.h>
+#include <cpl_virtualmem.h>
+#include <cpl_vsi_error.h>
+#include <cpl_vsi.h>
+
+int main(int argc, char *argv[]) {
+    printf("%s\n", GDALVersionInfo("RELEASE_NAME"));
+    return(0);
+}

--- a/autotest/postinstall/test_cpp/Makefile
+++ b/autotest/postinstall/test_cpp/Makefile
@@ -1,0 +1,15 @@
+PROGRAM = test_cpp
+OBJECTS = test_cpp.o
+
+override CXXFLAGS += -std=c++11 -g -Wall -Werror $(shell pkg-config gdal --cflags)
+override LDFLAGS += $(shell pkg-config gdal --libs)
+
+all: $(PROGRAM)
+
+$(PROGRAM): $(OBJECTS)
+	$(CXX) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) $(PROGRAM) $(OBJECTS)
+
+.PHONY: clean

--- a/autotest/postinstall/test_cpp/test_cpp.cpp
+++ b/autotest/postinstall/test_cpp/test_cpp.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+
+/* C API */
+#include <gdal.h>
+
+/* C++ API */
+#include <cpl_odbc.h>
+#include <cpl_vsi_virtual.h>
+#include <ogr_geometry.h>
+
+int main(int argc, char** argv) {
+    OGRGeometry* poGeom = nullptr;
+    OGRGeometryFactory::createFromWkt("POINT(1 2)", nullptr, &poGeom);
+    OGRGeometryFactory::destroyGeometry(poGeom);
+    std::cout << GDALVersionInfo("RELEASE_NAME") << std::endl;
+    return(0);
+}

--- a/autotest/postinstall/test_pkg-config.sh
+++ b/autotest/postinstall/test_pkg-config.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+# Post-install tests with pkg-config
+#
+# First required argument is the installed prefix, which
+# is used to set PKG_CONFIG_PATH and LD_LIBRARY_PATH/DYLD_LIBRARY_PATH
+
+echo "Running post-install tests with pkg-config"
+
+prefix=$1
+if [ -z "$prefix" ]; then
+    echo "First positional argument to the the installed prefix is required"
+    exit 1
+fi
+
+export PKG_CONFIG_PATH=$prefix/lib/pkgconfig
+
+# Run tests from shell, count any errors
+ERRORS=0
+NTESTS=0
+
+UNAME=$(uname)
+case $UNAME in
+  Darwin*)
+    alias ldd="otool -L"
+    export DYLD_LIBRARY_PATH=$prefix/lib
+    ;;
+  Linux*)
+    export LD_LIBRARY_PATH=$prefix/lib
+    ;;
+  *)
+    echo "no ldd equivalent found for UNAME=$UNAME"
+    exit 1 ;;
+esac
+
+check_ldd(){
+  printf "Testing expected ldd output ... "
+  NTESTS=$(($NTESTS + 1))
+  LDD_OUTPUT=$(ldd ./$1 | grep libgdal)
+  LDD_SUBSTR=$LD_LIBRARY_PATH/libgdal.
+  case "$LDD_OUTPUT" in
+    *$LDD_SUBSTR*)
+      echo "passed" ;;
+    *)
+      ERRORS=$(($ERRORS + 1))
+      echo "failed: ldd output '$LDD_OUTPUT' does not contain '$LDD_SUBSTR'" ;;
+  esac
+}
+
+PKG_CONFIG_MODVERSION=$(pkg-config gdal --modversion)
+
+check_version(){
+  printf "Testing expected version ... "
+  NTESTS=$(($NTESTS + 1))
+  VERSION_OUTPUT=$(./$1)
+  case "$VERSION_OUTPUT" in
+    $PKG_CONFIG_MODVERSION*)
+      echo "passed" ;;
+    *)
+      ERRORS=$(($ERRORS + 1))
+      echo "failed: '$VERSION_OUTPUT' != '$PKG_CONFIG_MODVERSION'" ;;
+  esac
+}
+
+cd $(dirname $0)
+
+echo Testing C app
+cd test_c
+make clean
+make
+
+check_ldd test_c
+check_version test_c
+
+make clean
+cd ..
+
+echo Testing C++ app
+cd test_cpp
+make clean
+make
+
+check_ldd test_cpp
+check_version test_cpp
+
+make clean
+cd ..
+
+echo "$ERRORS tests failed out of $NTESTS"
+exit $ERRORS

--- a/gdal/ci/travis/osx/install.sh
+++ b/gdal/ci/travis/osx/install.sh
@@ -63,3 +63,6 @@ cd ../../gdal
 ln -s /tmp/install/lib/libinternalproj.15.dylib /tmp/install/lib/libproj.15.dylib
 
 ccache -s
+
+# Post-install testing
+../autotest/postinstall/test_pkg-config.sh $HOME/install-gdal

--- a/gdal/ci/travis/ubuntu_1804/install.sh
+++ b/gdal/ci/travis/ubuntu_1804/install.sh
@@ -51,3 +51,6 @@ cd "$CURRENT_DIR"
 (cd autotest/cpp && CCACHE_CPP2=yes make -j3)
 
 ccache -s
+
+# Post-install testing
+./autotest/postinstall/test_pkg-config.sh /usr


### PR DESCRIPTION
This PR adds some post-install tests that check to build C and C++ apps that link to an installed version of libgdal.

pkg-config is also tested, to ensure the correct include and library paths are provided.

This test suite currently only works for *nix.

A running example looks like:
```
$ ./gdal/autotest/postinstall/test_pkg-config.sh /tmp/gdal/prefix
Running post-install tests with pkg-config
Testing C app
rm -f test_c test_c.o
cc -g -Wall -Werror -I/tmp/gdal/prefix/include   -c -o test_c.o test_c.c
cc -o test_c test_c.o -L/tmp/gdal/prefix/lib -lgdal
Testing expected ldd output ... passed
Testing expected version ... passed
rm -f test_c test_c.o
Testing C++ app
rm -f test_cpp test_cpp.o
g++ -std=c++11 -g -Wall -Werror -I/tmp/gdal/prefix/include   -c -o test_cpp.o test_cpp.cpp
g++ -o test_cpp test_cpp.o -L/tmp/gdal/prefix/lib -lgdal
Testing expected ldd output ... passed
Testing expected version ... passed
rm -f test_cpp test_cpp.o
0 tests failed out of 4
```