### PR TITLE
TileDB support for pixel interleave and single formats

### DIFF
--- a/gdal/frmts/tiledb/tiledb_headers.h
+++ b/gdal/frmts/tiledb/tiledb_headers.h
@@ -37,4 +37,11 @@
 
 #include "tiledb/tiledb"
 
+
+typedef enum {
+    BAND=0,
+    PIXEL=1,
+    ATTRIBUTES=2
+} TILEDB_INTERLEAVE_MODE;
+
 #endif // TILEDB_HEADERS_H

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -1264,15 +1264,27 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
 
         char ** papszStructMeta = poDS->GetMetadata( "IMAGE_STRUCTURE" );
         const char* pszXSize = CSLFetchNameValue( papszStructMeta, "X_SIZE");
-        if ( pszXSize )
+        if ( pszXSize > 0 )
         {
             poDS->nRasterXSize = atoi( pszXSize );
         }
+        else
+        {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                "Width %i should be greater than zero.", pszXSize );
+            return nullptr;
+        }
 
         const char* pszYSize = CSLFetchNameValue( papszStructMeta, "Y_SIZE");
-        if ( pszYSize )
+        if ( pszYSize > 0 )
         {
             poDS->nRasterYSize = atoi( pszYSize );
+        }
+        else
+        {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                "Height %i should be greater than zero.", pszYSize );
+            return nullptr;
         }
 
         const char* pszNBits = CSLFetchNameValue( papszStructMeta, "NBITS");
@@ -1288,7 +1300,15 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
             GDALDataType eDT = GDALGetDataTypeByName( pszDataType );
             if ( eDT == GDT_Unknown )
             {
-                poDS->eDataType = static_cast<GDALDataType>( atoi( pszDataType ) );
+                int t = atoi( pszDataType );
+                if ( ( t > 0 ) && ( t < GDT_TypeCount ) )
+                    poDS->eDataType = static_cast<GDALDataType>( atoi( pszDataType ) );
+                else
+                {
+                    CPLError( CE_Failure, CPLE_AppDefined,
+                        "Unknown data type %s.", pszDataType );
+                    return nullptr;
+                }
             }
             else
             {

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -66,6 +66,7 @@ class TileDBDataset final: public GDALPamDataset
         CPLStringList m_osSubdatasetMD{};
         CPLXMLNode*   psSubDatasetsTree = nullptr;
         CPLString     osMetaDoc;
+        TILEDB_INTERLEAVE_MODE eIndexMode = BAND;
 
         std::unique_ptr<tiledb::Context> m_ctx;
         std::unique_ptr<tiledb::Context> m_roCtx;
@@ -81,6 +82,16 @@ class TileDBDataset final: public GDALPamDataset
         CPLErr AddFilter( const char* pszFilterName, const int level );
         CPLErr CreateAttribute( GDALDataType eType, const CPLString& osAttrName,
                                 const int nSubRasterCount=1 );
+        CPLErr AddDimensions( tiledb::Domain& domain,
+                             tiledb::Dimension& y,
+                             tiledb::Dimension& x,
+                             tiledb::Dimension* poBands=nullptr );
+        CPLErr IRasterIO( GDALRWFlag, int, int, int, int,
+                        void *, int, int, GDALDataType,
+                        int, int *,
+                        GSpacing nPixelSpace, GSpacing nLineSpace,
+                        GSpacing nBandSpace,
+                        GDALRasterIOExtraArg* psExtraArg ) override;
     public:
         virtual ~TileDBDataset();
 
@@ -97,7 +108,7 @@ class TileDBDataset final: public GDALPamDataset
                                                 void *pProgressData );
         static TileDBDataset    *CreateLL( const char * pszFilename,
                                     int nXSize, int nYSize, int nBands,
-                                    char ** papszOptions );
+                                    GDALDataType eType, char ** papszOptions );
         static GDALDataset      *Create( const char * pszFilename,
                                     int nXSize, int nYSize, int nBands,
                                     GDALDataType eType, char ** papszOptions );
@@ -151,6 +162,49 @@ static CPLString vsi_to_s3( const char* pszUri )
         osUri = pszUri;
 
     return osUri;
+}
+
+static CPLErr option_to_index_type( const char* pszIndexingType, TILEDB_INTERLEAVE_MODE& eMode )
+{
+    CPLErr eErr = CE_None;
+
+    if ( pszIndexingType )
+    {
+        if EQUAL( pszIndexingType, "BAND" )
+            eMode = BAND;
+        else if EQUAL( pszIndexingType, "ATTRIBUTES" )
+            eMode = ATTRIBUTES;
+        else if EQUAL( pszIndexingType, "PIXEL" )
+            eMode = PIXEL;
+        else
+        {
+            eErr = CE_Failure;
+            CPLError( eErr, CPLE_AppDefined,
+                "Unable to identify TileDB index mode %s.",
+                pszIndexingType );
+        }
+    }
+    else
+    {
+        eMode = BAND;
+    }
+
+    return eErr;
+}
+
+static const char* index_type_name( TILEDB_INTERLEAVE_MODE eMode )
+{
+    switch ( eMode )
+    {
+        case PIXEL:
+            return "PIXEL";
+        case ATTRIBUTES:
+            return "ATTRIBUTES";
+        case BAND:
+            return "BAND";
+        default:
+            return nullptr;
+    }
 }
 
 /************************************************************************/
@@ -254,6 +308,10 @@ TileDBRasterBand::TileDBRasterBand(
 
         if ( poGDS->m_array->schema().domain().ndim() == 3 )
         {
+            if ( poGDS->eIndexMode == PIXEL )
+                std::rotate( oaSubarray.begin(),
+                            oaSubarray.begin() + 2,
+                            oaSubarray.end() );
             m_query->set_subarray( oaSubarray );
         }
         else
@@ -301,6 +359,11 @@ CPLErr TileDBRasterBand::IReadBlock( int nBlockXOff,
                                     (uint64_t) nEndY - 1,
                                     (uint64_t) nStartX,
                                     (uint64_t) nEndX - 1 };
+
+    if ( poGDS->eIndexMode == PIXEL )
+        std::rotate( oaSubarray.begin(),
+                    oaSubarray.begin() + 2,
+                    oaSubarray.end() );
 
     tiledb::Query* q;
     if ( ( eAccess == GA_Update ) && ( poGDS->m_roArray ) )
@@ -374,7 +437,21 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
                                         (uint64_t) nStartX,
                                         (uint64_t) nEndX - 1 };
 
-        m_query->set_subarray( oaSubarray );
+        if ( poGDS->eIndexMode == PIXEL )
+            std::rotate( oaSubarray.begin(),
+                        oaSubarray.begin() + 2,
+                        oaSubarray.end() );
+
+        if ( poGDS->eIndexMode == ATTRIBUTES )
+        {
+            m_query->set_subarray( std::vector<uint64_t> (
+                                        oaSubarray.cbegin() + 2,
+                                        oaSubarray.cend() ) );
+        }
+        else
+        {
+            m_query->set_subarray( oaSubarray );
+        }
     }
     else
     {
@@ -422,13 +499,13 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
                 nYSize = nRasterYSize - nBlockYOff;
 
             poAttrBand->AdviseRead(
-                nBlockXOff, nBlockXOff, nXSize, nYSize,
+                nBlockXOff, nBlockYOff, nXSize, nYSize,
                 nBlockXSize, nBlockYSize, eAttrType, nullptr
             );
 
             CPLErr eErr = poAttrBand->RasterIO(
                 GF_Read,
-                nBlockXOff, nBlockXOff, nXSize, nYSize,
+                nBlockXOff, nBlockYOff, nXSize, nYSize,
                 pAttrBlock, nBlockXSize, nBlockYSize,
                 eAttrType, 0, 0, nullptr );
 
@@ -448,22 +525,42 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
         }
     }
 
-    SetBuffer( m_query.get(), eDataType, osAttrName, 
-                pImage, nBlockXSize * nBlockYSize );
-
-    if ( bStats )
-        tiledb::Stats::enable();
-
-    auto status = m_query->submit();
-
-    if ( bStats )
+    if ( poGDS->eIndexMode == ATTRIBUTES )
     {
-        tiledb::Stats::dump(stdout);
-        tiledb::Stats::disable();
+        if ( nBand != poGDS->GetRasterCount() )
+        {
+            tiledb::Query* q = ( ( TileDBRasterBand* ) poGDS->GetRasterBand( poGDS->nBands ) )->m_query.get();
+            SetBuffer( q, eDataType, osAttrName,
+                       pImage, nBlockXSize * nBlockYSize );
+        }
+        else
+        {
+            SetBuffer( m_query.get(), eDataType, osAttrName, pImage, nBlockXSize * nBlockYSize );
+        }
+    }
+    else
+    {
+        SetBuffer( m_query.get(), eDataType, osAttrName,
+                    pImage, nBlockXSize * nBlockYSize );
     }
 
-    if (status == tiledb::Query::Status::FAILED)
-        return CE_Failure;
+    if ( ( poGDS->eIndexMode != ATTRIBUTES) ||
+         ( nBand == poGDS->GetRasterCount() ) )
+    {
+        if ( bStats )
+            tiledb::Stats::enable();
+
+        auto status = m_query->submit();
+
+        if ( bStats )
+        {
+            tiledb::Stats::dump(stdout);
+            tiledb::Stats::disable();
+        }
+
+        if (status == tiledb::Query::Status::FAILED)
+            return CE_Failure;
+    }
 
     return CE_None;
 }
@@ -528,6 +625,36 @@ TileDBDataset::~TileDBDataset()
     CPLDestroyXMLNode( psSubDatasetsTree );
     CSLDestroy( papszSubDatasets );
     CSLDestroy( papszAttributes );
+}
+
+/************************************************************************/
+/*                             AddDimensions()                          */
+/************************************************************************/
+
+CPLErr TileDBDataset::AddDimensions( tiledb::Domain& domain,
+                                     tiledb::Dimension& y,
+                                     tiledb::Dimension& x,
+                                     tiledb::Dimension* poBands )
+
+{
+    CPLErr eErr = CE_None;
+    switch ( eIndexMode )
+    {
+    case ATTRIBUTES:
+        domain.add_dimensions( y, x );
+        CreateAttribute( eDataType, TILEDB_VALUES, nBands );
+        break;
+    case PIXEL:
+        domain.add_dimensions( y, x, *poBands );
+        CreateAttribute( eDataType, TILEDB_VALUES, 1 );
+        break;
+    default: // BAND
+        domain.add_dimensions( *poBands, y, x );
+        CreateAttribute( eDataType, TILEDB_VALUES, 1 );
+        break;
+    }
+
+    return eErr;
 }
 
 /************************************************************************/
@@ -1135,44 +1262,6 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
 
         tiledb::ArraySchema schema = poDS->m_array->schema();
 
-        std::vector<tiledb::Dimension> dims = schema.domain().dimensions();
-
-        if( ( dims.size() == 2 ) || ( dims.size() == 3) )
-        {
-            if ( dims.size() == 3 )
-            {
-                if ( ( pszAttr != nullptr ) && ( schema.attributes().count( pszAttr ) == 0 ) )
-                {
-                    CPLError( CE_Failure, CPLE_NotSupported,
-                        "%s attribute is not found in TileDB schema.",
-                        pszAttr );
-                    return nullptr;
-                }
-                poDS->nBandStart = dims[0].domain<uint64_t>().first;
-                poDS->nBands = dims[0].domain<uint64_t>().second
-                                - dims[0].domain<uint64_t>().first + 1;
-                poDS->nBlockYSize = dims[1].tile_extent<uint64_t>();
-                poDS->nBlockXSize = dims[2].tile_extent<uint64_t>();
-            }
-            else
-            {
-                const char* pszBands = poDS->GetMetadataItem("NUM_BANDS", 
-                                                            "IMAGE_STRUCTURE");
-                if ( pszBands )
-                {
-                    poDS->nBands = atoi( pszBands );
-                    poDS->nBlockYSize = dims[0].tile_extent<uint64_t>();
-                    poDS->nBlockXSize = dims[1].tile_extent<uint64_t>();
-                }
-            }
-        }
-        else
-        {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                "Wrong number of dimensions %li expected 2 or 3.", dims.size() );
-            return nullptr;
-        }
-
         char ** papszStructMeta = poDS->GetMetadata( "IMAGE_STRUCTURE" );
         const char* pszXSize = CSLFetchNameValue( papszStructMeta, "X_SIZE");
         if ( pszXSize )
@@ -1207,6 +1296,55 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
             }
         }
 
+        const char* pszIndexMode = CSLFetchNameValue( papszStructMeta, "INTERLEAVE");
+
+        if ( pszIndexMode )
+            option_to_index_type( pszIndexMode, poDS->eIndexMode );
+
+        std::vector<tiledb::Dimension> dims = schema.domain().dimensions();
+
+        if( ( dims.size() == 2 ) || ( dims.size() == 3) )
+        {
+            if ( dims.size() == 3 )
+            {
+                if ( ( pszAttr != nullptr ) && ( schema.attributes().count( pszAttr ) == 0 ) )
+                {
+                    CPLError( CE_Failure, CPLE_NotSupported,
+                        "%s attribute is not found in TileDB schema.",
+                        pszAttr );
+                    return nullptr;
+                }
+
+                if ( poDS->eIndexMode == PIXEL )
+                    std::rotate( dims.begin(), dims.begin() + 2, dims.end() );
+
+                poDS->nBandStart = dims[0].domain<uint64_t>().first;
+                poDS->nBands = dims[0].domain<uint64_t>().second
+                                - dims[0].domain<uint64_t>().first + 1;
+                poDS->nBlockYSize = dims[1].tile_extent<uint64_t>();
+                poDS->nBlockXSize = dims[2].tile_extent<uint64_t>();
+            }
+            else
+            {
+                const char* pszBands = poDS->GetMetadataItem("NUM_BANDS", 
+                                                            "IMAGE_STRUCTURE");
+                if ( pszBands )
+                {
+                    poDS->nBands = atoi( pszBands );
+                    poDS->nBlockYSize = dims[0].tile_extent<uint64_t>();
+                    poDS->nBlockXSize = dims[1].tile_extent<uint64_t>();
+                }
+
+                poDS->eIndexMode = ATTRIBUTES;
+            }
+        }
+        else
+        {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                "Wrong number of dimensions %li expected 2 or 3.", dims.size() );
+            return nullptr;
+        }
+
         poDS->nBlocksX = DIV_ROUND_UP( poDS->nRasterXSize, poDS->nBlockXSize );
         poDS->nBlocksY = DIV_ROUND_UP( poDS->nRasterYSize, poDS->nBlockYSize );
 
@@ -1223,9 +1361,10 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
                             poDS.get(), i, CPLString( pszAttr ) ) );
             }
         }
-        else // subdatasets
+        else // subdatasets or only attributes
         {
-            if( poOpenInfo->eAccess == GA_Update )
+            if ( ( poOpenInfo->eAccess == GA_Update ) &&
+                 ( poDS->GetMetadata( "SUBDATASETS" ) != nullptr ) )
             {
                 CPLError( CE_Failure, CPLE_NotSupported,
                         "The TileDB driver does not support update access "
@@ -1277,6 +1416,22 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
                             CSLFetchNameValueDef(poDS->papszSubDatasets,
                                                 "SUBDATASET_1_NAME", "");
                         return (GDALDataset *)GDALOpen( osDSName, poOpenInfo->eAccess );
+                    }
+                }
+                else if ( poDS->eIndexMode == ATTRIBUTES )
+                {
+                    poDS->nBands = schema.attribute_num();
+                    poDS->nBlockYSize = dims[0].tile_extent<uint64_t>();
+                    poDS->nBlockXSize = dims[1].tile_extent<uint64_t>();
+
+                    // Create band information objects.
+                    for ( int i = 1;i <= poDS->nBands;++i )
+                    {
+                        CPLString osAttr = TILEDB_VALUES + CPLString().Printf( "_%i", i+1 );
+                        poDS->SetBand( i,
+                            new TileDBRasterBand(
+                                poDS.get(), i,
+                                osAttr ) );
                     }
                 }
                 else
@@ -1333,7 +1488,8 @@ CPLErr TileDBDataset::CreateAttribute( GDALDataType eType,
             osName.replaceAll( "/", "_" );
             CPLString osPrettyName = osName;
 
-            if ( ( bHasSubDatasets ) && ( nSubRasterCount > 1 ) )
+            if ( ( eIndexMode == ATTRIBUTES ) ||
+               ( ( bHasSubDatasets ) && ( nSubRasterCount > 1 ) ) )
             {
                 osName = CPLString().Printf( "%s_%d", osName.c_str(), i + 1);
             }
@@ -1550,6 +1706,7 @@ void TileDBDataset::SetBlockSize( GDALRasterBand* poBand, char** &papszOptions)
 
 TileDBDataset* TileDBDataset::CreateLL( const char *pszFilename,
                          int nXSize, int nYSize, int nBands,
+                         GDALDataType eType,
                          char **papszOptions )
 {
     try
@@ -1562,9 +1719,23 @@ TileDBDataset* TileDBDataset::CreateLL( const char *pszFilename,
         std::unique_ptr<TileDBDataset> poDS(new TileDBDataset());
         poDS->nRasterXSize = nXSize;
         poDS->nRasterYSize = nYSize;
+        poDS->eDataType = eType;
         poDS->nBands = nBands;
         poDS->eAccess = GA_Update;
         poDS->bGlobalOrder = true;
+
+        if ( nBands == 0 ) // subdatasets
+        {
+            poDS->eIndexMode = ATTRIBUTES;
+        }
+        else
+        {
+            const char* pszIndexMode = CSLFetchNameValue(
+                                    papszOptions, "INTERLEAVE" );
+
+            if ( option_to_index_type( pszIndexMode, poDS->eIndexMode ) )
+                return nullptr;
+        }
 
         const char* pszConfig = CSLFetchNameValue( papszOptions, "TILEDB_CONFIG" );
         if( pszConfig != nullptr )
@@ -1629,20 +1800,20 @@ TileDBDataset* TileDBDataset::CreateLL( const char *pszFilename,
         auto d1 = tiledb::Dimension::create<uint64_t>(
                     *poDS->m_ctx, "X", {0, w},
                     uint64_t( poDS->nBlockXSize ) );
-        auto d2 = tiledb::Dimension::create<uint64_t>( *poDS->m_ctx, "Y", {0, h}, uint64_t( poDS->nBlockYSize ) );
+        auto d2 = tiledb::Dimension::create<uint64_t>(
+                    *poDS->m_ctx, "Y",{0, h},
+                    uint64_t( poDS->nBlockYSize ) );
 
-        if ( nBands > 0 )
+        if ( ( nBands == 0 ) || ( poDS->eIndexMode == ATTRIBUTES ) )
         {
-            auto d3 = tiledb::Dimension::create<uint64_t>( *poDS->m_ctx, "BANDS", {1, uint64_t( nBands )}, 1);
-            // row-major
-            domain.add_dimensions( d3, d2, d1 );
+            poDS->AddDimensions( domain, d2, d1, nullptr );
         }
         else
         {
-            // row-major
-            domain.add_dimensions( d2, d1 );
+            auto d3 = tiledb::Dimension::create<uint64_t>( *poDS->m_ctx, "BANDS", {1, uint64_t( nBands )}, 1);
+            poDS->AddDimensions( domain, d2, d1, &d3 );
         }
-        
+
         poDS->m_schema->set_domain( domain ).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});;
 
         // register additional attributes to the pixel value, these will be
@@ -1706,6 +1877,7 @@ TileDBDataset* TileDBDataset::CreateLL( const char *pszFilename,
                         poDS->papszAttributes[i]);
             }
         }
+
         return poDS.release();
     }
     catch(const tiledb::TileDBError& e)
@@ -1762,6 +1934,7 @@ CPLErr TileDBDataset::CopySubDatasets( GDALDataset* poSrcDS,
         uint64_t nSubYSize = poSubDataset->GetRasterYSize();
 
         const char* pszAttrName = apszTokens[2];
+
         poDstDS->CreateAttribute( poSubDataset->GetRasterBand( 1 )
                                                     ->GetRasterDataType(),
                                                 pszAttrName,
@@ -1926,19 +2099,24 @@ TileDBDataset::Create( const char * pszFilename, int nXSize, int nYSize, int nBa
 
         std::unique_ptr<TileDBDataset> poDS(
             TileDBDataset::CreateLL( osArrayPath, nXSize, nYSize,
-                                    nBands, papszOptions ));
+                                    nBands, eType, papszOptions ));
+
+        tiledb::Array::create( osArrayPath, *poDS->m_schema );
+        poDS->m_array.reset( new tiledb::Array( *poDS->m_ctx, osArrayPath, TILEDB_WRITE ) );
+
         if( !poDS )
             return nullptr;
 
-        poDS->eDataType = eType;
-
-        poDS->CreateAttribute( eType, TILEDB_VALUES );
-        tiledb::Array::create( osArrayPath, *poDS->m_schema );
-
-        poDS->m_array.reset( new tiledb::Array( *poDS->m_ctx, osArrayPath, TILEDB_WRITE ) );
-
         for( int i = 0; i < poDS->nBands;i++ )
-            poDS->SetBand( i+1, new TileDBRasterBand( poDS.get(), i+1 ) );
+        {
+            if ( poDS->eIndexMode == ATTRIBUTES )
+            {
+                poDS->SetBand( i+1, new TileDBRasterBand( poDS.get(), i+1,
+                               TILEDB_VALUES + CPLString().Printf( "_%i", i+1 ) ) );
+            }
+            else
+                poDS->SetBand( i+1, new TileDBRasterBand( poDS.get(), i+1 ) );
+        }
 
         char** papszImageStruct = nullptr;
         papszImageStruct = CSLAddNameValue(papszImageStruct, "NBITS",
@@ -1949,6 +2127,8 @@ TileDBDataset::Create( const char * pszFilename, int nXSize, int nYSize, int nBa
                         CPLString().Printf( "%d", poDS->nRasterXSize ) );
         papszImageStruct = CSLAddNameValue(papszImageStruct, "Y_SIZE",
                         CPLString().Printf( "%d", poDS->nRasterYSize ) );
+        papszImageStruct = CSLAddNameValue(papszImageStruct, "INTERLEAVE",
+                                            index_type_name( poDS->eIndexMode ) );
 
         if ( poDS->lpoAttributeDS.size() > 0 )
         {
@@ -2089,10 +2269,10 @@ TileDBDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
                         GDALRasterBand* poBand = poSubDataset->GetRasterBand( 1 );
 
                         TileDBDataset::SetBlockSize( poBand, papszCopyOptions );
-
                         poDstDS.reset(TileDBDataset::CreateLL(
                                     osArrayPath, poBand->GetXSize(),
-                                    poBand->GetYSize(), 0, papszCopyOptions ));
+                                    poBand->GetYSize(), 0, poBand->GetRasterDataType(),
+                                    papszCopyOptions ));
 
                         if ( poDstDS &&
                             TileDBDataset::CopySubDatasets( poSrcDS, poDstDS.get(),
@@ -2129,6 +2309,42 @@ TileDBDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
         CSLDestroy( papszCopyOptions );
         return nullptr;
     }
+}
+
+/************************************************************************/
+/*                             IRasterIO()                              */
+/*                                                                      */
+/*      Multi-band raster io handler.  We will use block based          */
+/*      loading for attribute only arrays and for                       */
+/*      arrays that are indexed band last as they                       */
+/*      are effectively pixel interleaved, so processing all bands      */
+/*      for a given block together avoid extra seeks.                   */
+/************************************************************************/
+
+CPLErr TileDBDataset::IRasterIO( GDALRWFlag eRWFlag,
+                              int nXOff, int nYOff, int nXSize, int nYSize,
+                              void *pData, int nBufXSize, int nBufYSize,
+                              GDALDataType eBufType,
+                              int nBandCount, int *panBandMap,
+                              GSpacing nPixelSpace, GSpacing nLineSpace,
+                              GSpacing nBandSpace,
+                              GDALRasterIOExtraArg* psExtraArg )
+
+{
+    if ( ( eIndexMode == PIXEL ) ||
+         ( eIndexMode == ATTRIBUTES ))
+    {
+        return GDALDataset::BlockBasedRasterIO(
+            eRWFlag, nXOff, nYOff, nXSize, nYSize,
+            pData, nBufXSize, nBufYSize, eBufType,
+            nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace, psExtraArg );
+    }
+    else
+        return
+            GDALDataset::IRasterIO( eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                    pData, nBufXSize, nBufYSize, eBufType,
+                                    nBandCount, panBandMap,
+                                    nPixelSpace, nLineSpace, nBandSpace, psExtraArg );
 }
 
 /************************************************************************/
@@ -2170,7 +2386,12 @@ void GDALRegister_TileDB()
 "   <Option name='BLOCKYSIZE' type='int' description='Tile Height'/>"
 "   <Option name='STATS' type='boolean' description='Dump TileDB stats'/>"
 "   <Option name='TILEDB_CONFIG' type='string' description='location of configuration file for TileDB'/>"
-"   <Option name='TILEDB_ATTRIBUTE' type='string' description='co-registered file to add as TileDB attributes'/>"
+"   <Option name='TILEDB_ATTRIBUTE' type='string' description='co-registered file to add as TileDB attributes, only applicable for interleave types of band or pixel'/>"
+"   <Option name='INTERLEAVE' type='string-select' description='Indexing order' default='BAND'>\n"
+"        <Value>BAND</Value>\n"
+"        <Value>PIXEL</Value>\n"
+"        <Value>ATTRIBUTES</Value>\n"
+"   </Option>\n"
 "</CreationOptionList>\n" );
 
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,

--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -1264,27 +1264,27 @@ GDALDataset *TileDBDataset::Open( GDALOpenInfo * poOpenInfo )
 
         char ** papszStructMeta = poDS->GetMetadata( "IMAGE_STRUCTURE" );
         const char* pszXSize = CSLFetchNameValue( papszStructMeta, "X_SIZE");
-        if ( pszXSize > 0 )
+        if ( pszXSize )
         {
             poDS->nRasterXSize = atoi( pszXSize );
-        }
-        else
-        {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                "Width %i should be greater than zero.", pszXSize );
-            return nullptr;
+            if ( poDS->nRasterXSize <= 0 )
+            {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                    "Width %i should be greater than zero.", pszXSize );
+                return nullptr;
+            }
         }
 
         const char* pszYSize = CSLFetchNameValue( papszStructMeta, "Y_SIZE");
-        if ( pszYSize > 0 )
+        if ( pszYSize )
         {
             poDS->nRasterYSize = atoi( pszYSize );
-        }
-        else
-        {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                "Height %i should be greater than zero.", pszYSize );
-            return nullptr;
+            if ( poDS->nRasterYSize <= 0 )
+            {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                    "Height %i should be greater than zero.", pszYSize );
+                return nullptr;
+            }
         }
 
         const char* pszNBits = CSLFetchNameValue( papszStructMeta, "NBITS");


### PR DESCRIPTION
## What does this PR do?

The previous TileDB driver supported indexing an image by band, however a user may wish to use pixel interleave format. In addition with TileDB support multiple attributes per location in an image they may wish to collapse the band dimension and have the values represented solely by attributes.

This PR maintains the existing support for a pixel value in a separate band but also adds support for interleave and multiple attributes per location.

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
