### PR TITLE
Add vs2019 compatibility

### DIFF
--- a/gdal/generate_vcxproj.bat
+++ b/gdal/generate_vcxproj.bat
@@ -52,7 +52,10 @@ set _vcver_=%1
 set _clver_=1600
 set _vstoolset_=v100
 
-if "%_vcver_%"=="15.0" (
+if "%_vcver_%"=="16.0" (
+	set _clver_=1920
+	set _vstoolset_=v142
+) else if "%_vcver_%"=="15.0" (
 	set _clver_=1910
 	set _vstoolset_=v141
 ) else if "%_vcver_%"=="14.0" (
@@ -103,6 +106,7 @@ echo Examples:
 echo    generate_vcxproj 12.0 64 gdal_vs2013
 echo    generate_vcxproj 14.0 64 gdal_vs2015
 echo    generate_vcxproj 15.0 64 gdal_vs2017
+echo    generate_vcxproj 16.0 64 gdal_vs2019
 echo WARNING: GDAL requires C++11. It is not guaranteed to build with VS2013.
 
 goto :end

--- a/gdal/nmake.opt
+++ b/gdal/nmake.opt
@@ -39,6 +39,12 @@
 !IFNDEF MSVC_VER
 #assume msvc VS2015.
 MSVC_VER=1900
+VSFRIENDLYVERSION=vs2015
+!ENDIF
+!IF $(MSVC_VER) >= 1920
+VSFRIENDLYVERSION=vs2019
+!ELSEIF $(MSVC_VER) >= 1910
+VSFRIENDLYVERSION=vs2017
 !ENDIF
 
 ###############################################################################

--- a/gdal/nmake.opt
+++ b/gdal/nmake.opt
@@ -36,6 +36,10 @@
 # 1910 = 15.0(2017)
 # 1900 = 14.0(2015)
 #
+#The VSFRIENDLYVERSION variable is not used by GDAL itself, but can help customizing path to
+#dependencies built with Visual Studio
+#
+
 !IFNDEF MSVC_VER
 #assume msvc VS2015.
 MSVC_VER=1900

--- a/gdal/nmake.opt
+++ b/gdal/nmake.opt
@@ -36,19 +36,10 @@
 # 1910 = 15.0(2017)
 # 1900 = 14.0(2015)
 #
-#The VSFRIENDLYVERSION variable is not used by GDAL itself, but can help customizing path to
-#dependencies built with Visual Studio
-#
 
 !IFNDEF MSVC_VER
 #assume msvc VS2015.
 MSVC_VER=1900
-VSFRIENDLYVERSION=vs2015
-!ENDIF
-!IF $(MSVC_VER) >= 1920
-VSFRIENDLYVERSION=vs2019
-!ELSEIF $(MSVC_VER) >= 1910
-VSFRIENDLYVERSION=vs2017
 !ENDIF
 
 ###############################################################################
@@ -369,8 +360,10 @@ JPEG12_SUPPORTED = 1
 # Uncomment the following and update to enable ECW read support with the 5.0+ SDK
 #!IF $(MSVC_VER) < 1910
 #ECW_PLATFORM_TOOLSET_DIR = vc140
-#!ELSE
+#!ELSEIF $(MSVC_VER) < 1920
 #ECW_PLATFORM_TOOLSET_DIR = vc141
+#ELSE
+#ECW_PLATFORM_TOOLSET_DIR = vc142
 #!ENDIF
 
 #!IF "$(DEBUG)" == "1"


### PR DESCRIPTION
Add vs2019 compatibility
vcver is 16.0, for v142 toolset
added a VSFRIENDLYVERSION to nmake.opt to help using dependencies built with different versions of VS

address #2676