### PR TITLE
LVBAG; bugfixes and improvements

### DIFF
--- a/autotest/ogr/data/lvbag/inval_polygon.xml
+++ b/autotest/ogr/data/lvbag/inval_polygon.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sl-bag-extract:bagStand xmlns:DatatypenNEN3610="www.kadaster.nl/schemas/lvbag/imbag/datatypennen3610/v20180601" xmlns:Objecten="www.kadaster.nl/schemas/lvbag/imbag/objecten/v20180601" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:Historie="www.kadaster.nl/schemas/lvbag/imbag/historie/v20180601" xmlns:Objecten-ref="www.kadaster.nl/schemas/lvbag/imbag/objecten-ref/v20180601" xmlns:nen5825="www.kadaster.nl/schemas/lvbag/imbag/nen5825/v20180601" xmlns:KenmerkInOnderzoek="www.kadaster.nl/schemas/lvbag/imbag/kenmerkinonderzoek/v20180601" xmlns:selecties-extract="http://www.kadaster.nl/schemas/lvbag/extract-selecties/v20180601" xmlns:sl-bag-extract="http://www.kadaster.nl/schemas/lvbag/extract-deelbestand-lvc/v20180601" xmlns:sl="http://www.kadaster.nl/schemas/standlevering-generiek/1.0">
+    <sl-bag-extract:bagInfo>
+        <selecties-extract:Gebied-Registratief>
+            <selecties-extract:Gebied-GEM>
+                <selecties-extract:GemeenteCollectie>
+                    <selecties-extract:Gemeente>
+                        <selecties-extract:GemeenteIdentificatie>1581</selecties-extract:GemeenteIdentificatie>
+                    </selecties-extract:Gemeente>
+                </selecties-extract:GemeenteCollectie>
+            </selecties-extract:Gebied-GEM>
+        </selecties-extract:Gebied-Registratief>
+        <selecties-extract:LVC-Extract>
+            <selecties-extract:StandTechnischeDatum>2020-05-01</selecties-extract:StandTechnischeDatum>
+        </selecties-extract:LVC-Extract>
+    </sl-bag-extract:bagInfo>
+    <sl:standBestand>
+        <sl:dataset>LVBAG</sl:dataset>
+        <sl:inhoud>
+            <sl:gebied>GEMEENTE</sl:gebied>
+            <sl:leveringsId>0000000001</sl:leveringsId>
+            <sl:objectTypen>
+                <sl:objectType>PND</sl:objectType>
+            </sl:objectTypen>
+        </sl:inhoud>
+        <sl:stand>
+            <sl-bag-extract:bagObject>
+                <Objecten:Pand>
+                    <Objecten:identificatie>
+                        <DatatypenNEN3610:namespace>NL.IMBAG.Pand</DatatypenNEN3610:namespace>
+                        <DatatypenNEN3610:lokaalID>1581100000007976</DatatypenNEN3610:lokaalID>
+                    </Objecten:identificatie>
+                    <Objecten:geometrie>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" srsDimension="3" gml:id="PND_1581100000007976_1_1294065634">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList count="12">148270.573 451918.6 0.0 148263.223 451926.981 0.0 148263.822 451927.512 0.0 148261.813 451929.805 0.0 148261.601 451929.625 0.0 148261.725 451929.48 0.0 148261.387 451929.194 0.0 148257.832 451926.178 0.0 148261.567 451921.773 0.0 148261.021 451921.31 0.0 148266.354 451915.022 0.0 148270.573 451918.6 0.0</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </Objecten:geometrie>
+                    <Objecten:oorspronkelijkBouwjaar>1920</Objecten:oorspronkelijkBouwjaar>
+                    <Objecten:status>Pand in gebruik</Objecten:status>
+                    <Objecten:geconstateerd>N</Objecten:geconstateerd>
+                    <Objecten:documentdatum>1920-12-31</Objecten:documentdatum>
+                    <Objecten:documentnummer>DR.004713</Objecten:documentnummer>
+                    <Objecten:voorkomen>
+                        <Historie:Voorkomen>
+                            <Historie:voorkomenidentificatie>1</Historie:voorkomenidentificatie>
+                            <Historie:beginGeldigheid>1920-12-31</Historie:beginGeldigheid>
+                            <Historie:eindGeldigheid>2011-03-25</Historie:eindGeldigheid>
+                            <Historie:tijdstipRegistratie>2011-01-03T15:31:58.000</Historie:tijdstipRegistratie>
+                            <Historie:eindRegistratie>2011-10-11T15:51:35.000</Historie:eindRegistratie>
+                            <Historie:BeschikbaarLV>
+<Historie:tijdstipRegistratieLV>2011-01-03T15:40:34.052</Historie:tijdstipRegistratieLV>
+<Historie:tijdstipEindRegistratieLV>2011-10-11T16:02:02.073</Historie:tijdstipEindRegistratieLV>
+                            </Historie:BeschikbaarLV>
+                        </Historie:Voorkomen>
+                    </Objecten:voorkomen>
+                </Objecten:Pand>
+            </sl-bag-extract:bagObject>
+        </sl:stand>
+        <sl:stand>
+            <sl-bag-extract:bagObject>
+                <Objecten:Pand>
+                    <Objecten:identificatie>
+                        <DatatypenNEN3610:namespace>NL.IMBAG.Pand</DatatypenNEN3610:namespace>
+                        <DatatypenNEN3610:lokaalID>1581100000007976</DatatypenNEN3610:lokaalID>
+                    </Objecten:identificatie>
+                    <Objecten:geometrie>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" srsDimension="3" gml:id="PND_1581100000007976_2_1318341722">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList count="32">148260.379 451929.55 0.0 148259.428 451930.663 0.0 148257.628 451929.125 0.0 148257.593 451928.6 0.0 148257.953 451928.184 0.0 148255.496 451926.061 0.0 148256.18 451925.269 0.0 148255.974 451925.09 0.0 148255.937 451924.565 0.0 148257.094 451923.196 0.0 148257.69 451923.151 0.0 148257.894 451923.315 0.0 148259.871 451920.868 0.0 148258.591 451919.834 0.0 148258.591 451918.356 0.0 148262.771 451913.843 0.0 148263.868 451913.792 0.0 148264.928 451914.631 0.0 148264.694 451914.926 0.0 148265.707 451915.785 0.0 148266.354 451915.022 0.0 148270.573 451918.6 0.0 148263.223 451926.981 0.0 148263.822 451927.512 0.0 148261.813 451929.805 0.0 148261.601 451929.625 0.0 148261.725 451929.48 0.0 148261.387 451929.194 0.0 148260.789 451929.898 0.0 148260.379 451929.55 0.0 148256.68 451926.413 0.0 148260.379 451929.55 0.0</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </Objecten:geometrie>
+                    <Objecten:oorspronkelijkBouwjaar>1920</Objecten:oorspronkelijkBouwjaar>
+                    <Objecten:status>Pand in gebruik (niet ingemeten)</Objecten:status>
+                    <Objecten:geconstateerd>N</Objecten:geconstateerd>
+                    <Objecten:documentdatum>2011-03-08</Objecten:documentdatum>
+                    <Objecten:documentnummer>N11.00043</Objecten:documentnummer>
+                    <Objecten:voorkomen>
+                        <Historie:Voorkomen>
+                            <Historie:voorkomenidentificatie>2</Historie:voorkomenidentificatie>
+                            <Historie:beginGeldigheid>2011-03-25</Historie:beginGeldigheid>
+                            <Historie:eindGeldigheid>2016-02-10</Historie:eindGeldigheid>
+                            <Historie:tijdstipRegistratie>2011-10-11T15:51:35.000</Historie:tijdstipRegistratie>
+                            <Historie:eindRegistratie>2016-02-10T15:52:03.000</Historie:eindRegistratie>
+                            <Historie:BeschikbaarLV>
+<Historie:tijdstipRegistratieLV>2011-10-11T16:02:02.073</Historie:tijdstipRegistratieLV>
+<Historie:tijdstipEindRegistratieLV>2016-02-10T16:00:09.301</Historie:tijdstipEindRegistratieLV>
+                            </Historie:BeschikbaarLV>
+                        </Historie:Voorkomen>
+                    </Objecten:voorkomen>
+                </Objecten:Pand>
+            </sl-bag-extract:bagObject>
+        </sl:stand>
+        <sl:stand>
+            <sl-bag-extract:bagObject>
+                <Objecten:Pand>
+                    <Objecten:identificatie>
+                        <DatatypenNEN3610:namespace>NL.IMBAG.Pand</DatatypenNEN3610:namespace>
+                        <DatatypenNEN3610:lokaalID>1581100000007976</DatatypenNEN3610:lokaalID>
+                    </Objecten:identificatie>
+                    <Objecten:geometrie>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" srsDimension="3" gml:id="PND_1581100000007976_3_1455116409">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList count="13">148256.68 451926.413 0.0 148261.014 451921.303 0.0 148259.588 451920.094 0.0 148259.515 451919.217 0.0 148263.396 451914.641 0.0 148264.273 451914.569 0.0 148265.707 451915.785 0.0 148266.354 451915.022 0.0 148270.573 451918.6 0.0 148263.223 451926.981 0.0 148261.555 451929.336 0.0 148260.912 451930.002 0.0 148256.68 451926.413 0.0</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </Objecten:geometrie>
+                    <Objecten:oorspronkelijkBouwjaar>1920</Objecten:oorspronkelijkBouwjaar>
+                    <Objecten:status>Pand in gebruik</Objecten:status>
+                    <Objecten:geconstateerd>N</Objecten:geconstateerd>
+                    <Objecten:documentdatum>2016-02-10</Objecten:documentdatum>
+                    <Objecten:documentnummer>N16.00035</Objecten:documentnummer>
+                    <Objecten:voorkomen>
+                        <Historie:Voorkomen>
+                            <Historie:voorkomenidentificatie>3</Historie:voorkomenidentificatie>
+                            <Historie:beginGeldigheid>2016-02-10</Historie:beginGeldigheid>
+                            <Historie:eindGeldigheid>2019-06-13</Historie:eindGeldigheid>
+                            <Historie:tijdstipRegistratie>2016-02-10T15:52:03.000</Historie:tijdstipRegistratie>
+                            <Historie:eindRegistratie>2019-06-13T09:56:11.000</Historie:eindRegistratie>
+                            <Historie:BeschikbaarLV>
+<Historie:tijdstipRegistratieLV>2016-02-10T16:00:09.301</Historie:tijdstipRegistratieLV>
+<Historie:tijdstipEindRegistratieLV>2019-06-13T10:00:57.675</Historie:tijdstipEindRegistratieLV>
+                            </Historie:BeschikbaarLV>
+                        </Historie:Voorkomen>
+                    </Objecten:voorkomen>
+                </Objecten:Pand>
+            </sl-bag-extract:bagObject>
+        </sl:stand>
+        <sl:stand>
+            <sl-bag-extract:bagObject>
+                <Objecten:Pand>
+                    <Objecten:identificatie>
+                        <DatatypenNEN3610:namespace>NL.IMBAG.Pand</DatatypenNEN3610:namespace>
+                        <DatatypenNEN3610:lokaalID>1581100000007976</DatatypenNEN3610:lokaalID>
+                    </Objecten:identificatie>
+                    <Objecten:geometrie>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" srsDimension="3" gml:id="PND_1581100000007976_4_1560412857">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList count="13">148270.573 451918.6 0.0 148263.223 451926.981 0.0 148263.822 451927.512 0.0 148261.248 451930.287 0.0 148256.68 451926.413 0.0 148261.014 451921.303 0.0 148259.588 451920.094 0.0 148259.515 451919.217 0.0 148263.396 451914.641 0.0 148264.273 451914.569 0.0 148265.707 451915.785 0.0 148266.354 451915.022 0.0 148270.573 451918.6 0.0</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </Objecten:geometrie>
+                    <Objecten:oorspronkelijkBouwjaar>1920</Objecten:oorspronkelijkBouwjaar>
+                    <Objecten:status>Pand in gebruik</Objecten:status>
+                    <Objecten:geconstateerd>N</Objecten:geconstateerd>
+                    <Objecten:documentdatum>2019-06-13</Objecten:documentdatum>
+                    <Objecten:documentnummer>N19.00351</Objecten:documentnummer>
+                    <Objecten:voorkomen>
+                        <Historie:Voorkomen>
+                            <Historie:voorkomenidentificatie>4</Historie:voorkomenidentificatie>
+                            <Historie:beginGeldigheid>2019-06-13</Historie:beginGeldigheid>
+                            <Historie:tijdstipRegistratie>2019-06-13T09:56:11.000</Historie:tijdstipRegistratie>
+                            <Historie:BeschikbaarLV>
+<Historie:tijdstipRegistratieLV>2019-06-13T10:00:57.675</Historie:tijdstipRegistratieLV>
+                            </Historie:BeschikbaarLV>
+                        </Historie:Voorkomen>
+                    </Objecten:voorkomen>
+                </Objecten:Pand>
+            </sl-bag-extract:bagObject>
+        </sl:stand>
+    </sl:standBestand>
+</sl-bag-extract:bagStand>

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -59,64 +59,70 @@ def test_ogr_lvbag_dataset_lig():
 
     assert 'Amersfoort' in lyr.GetSpatialRef().ExportToWkt()
 
-    assert lyr.GetLayerDefn().GetFieldCount() == 17
+    assert lyr.GetLayerDefn().GetFieldCount() == 19
 
     assert lyr.GetLayerDefn().GetGeomFieldCount() == 1
 
-    assert (lyr.GetLayerDefn().GetFieldDefn(0).GetNameRef() == 'namespace' and \
-       lyr.GetLayerDefn().GetFieldDefn(1).GetNameRef() == 'lokaalID' and \
-       lyr.GetLayerDefn().GetFieldDefn(2).GetNameRef() == 'versie' and \
-       lyr.GetLayerDefn().GetFieldDefn(3).GetNameRef() == 'status' and \
-       lyr.GetLayerDefn().GetFieldDefn(4).GetNameRef() == 'geconstateerd' and \
-       lyr.GetLayerDefn().GetFieldDefn(5).GetNameRef() == 'documentdatum' and \
-       lyr.GetLayerDefn().GetFieldDefn(6).GetNameRef() == 'documentnummer' and \
-       lyr.GetLayerDefn().GetFieldDefn(7).GetNameRef() == 'voorkomenidentificatie' and \
-       lyr.GetLayerDefn().GetFieldDefn(8).GetNameRef() == 'beginGeldigheid' and \
-       lyr.GetLayerDefn().GetFieldDefn(9).GetNameRef() == 'eindGeldigheid' and \
-       lyr.GetLayerDefn().GetFieldDefn(10).GetNameRef() == 'tijdstipRegistratie' and \
-       lyr.GetLayerDefn().GetFieldDefn(11).GetNameRef() == 'eindRegistratie' and \
-       lyr.GetLayerDefn().GetFieldDefn(12).GetNameRef() == 'tijdstipInactief' and \
-       lyr.GetLayerDefn().GetFieldDefn(13).GetNameRef() == 'tijdstipRegistratieLV' and \
-       lyr.GetLayerDefn().GetFieldDefn(14).GetNameRef() == 'tijdstipEindRegistratieLV' and \
-       lyr.GetLayerDefn().GetFieldDefn(15).GetNameRef() == 'tijdstipInactiefLV' and \
-       lyr.GetLayerDefn().GetFieldDefn(16).GetNameRef() == 'tijdstipNietBagLV')
+    assert (lyr.GetLayerDefn().GetFieldDefn(0).GetNameRef().lower() == 'nummeraanduidingref' and \
+       lyr.GetLayerDefn().GetFieldDefn(1).GetNameRef().lower() == 'lvid' and \
+       lyr.GetLayerDefn().GetFieldDefn(2).GetNameRef().lower() == 'namespace' and \
+       lyr.GetLayerDefn().GetFieldDefn(3).GetNameRef().lower() == 'lokaalid' and \
+       lyr.GetLayerDefn().GetFieldDefn(4).GetNameRef().lower() == 'versie' and \
+       lyr.GetLayerDefn().GetFieldDefn(5).GetNameRef().lower() == 'status' and \
+       lyr.GetLayerDefn().GetFieldDefn(6).GetNameRef().lower() == 'geconstateerd' and \
+       lyr.GetLayerDefn().GetFieldDefn(7).GetNameRef().lower() == 'documentdatum' and \
+       lyr.GetLayerDefn().GetFieldDefn(8).GetNameRef().lower() == 'documentnummer' and \
+       lyr.GetLayerDefn().GetFieldDefn(9).GetNameRef().lower() == 'voorkomenidentificatie' and \
+       lyr.GetLayerDefn().GetFieldDefn(10).GetNameRef().lower() == 'begingeldigheid' and \
+       lyr.GetLayerDefn().GetFieldDefn(11).GetNameRef().lower() == 'eindgeldigheid' and \
+       lyr.GetLayerDefn().GetFieldDefn(12).GetNameRef().lower() == 'tijdstipregistratie' and \
+       lyr.GetLayerDefn().GetFieldDefn(13).GetNameRef().lower() == 'eindregistratie' and \
+       lyr.GetLayerDefn().GetFieldDefn(14).GetNameRef().lower() == 'tijdstipinactief' and \
+       lyr.GetLayerDefn().GetFieldDefn(15).GetNameRef().lower() == 'tijdstipregistratielv' and \
+       lyr.GetLayerDefn().GetFieldDefn(16).GetNameRef().lower() == 'tijdstipeindregistratielv' and \
+       lyr.GetLayerDefn().GetFieldDefn(17).GetNameRef().lower() == 'tijdstipinactieflv' and \
+       lyr.GetLayerDefn().GetFieldDefn(18).GetNameRef().lower() == 'tijdstipnietbaglv')
 
     assert (lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTString and \
        lyr.GetLayerDefn().GetFieldDefn(1).GetType() == ogr.OFTString and \
        lyr.GetLayerDefn().GetFieldDefn(2).GetType() == ogr.OFTString and \
        lyr.GetLayerDefn().GetFieldDefn(3).GetType() == ogr.OFTString and \
-       lyr.GetLayerDefn().GetFieldDefn(4).GetType() == ogr.OFTInteger and \
-       lyr.GetLayerDefn().GetFieldDefn(5).GetType() == ogr.OFTDate and \
-       lyr.GetLayerDefn().GetFieldDefn(6).GetType() == ogr.OFTString and \
-       lyr.GetLayerDefn().GetFieldDefn(7).GetType() == ogr.OFTInteger and \
-       lyr.GetLayerDefn().GetFieldDefn(8).GetType() == ogr.OFTDate and \
-       lyr.GetLayerDefn().GetFieldDefn(9).GetType() == ogr.OFTDate and \
-       lyr.GetLayerDefn().GetFieldDefn(10).GetType() == ogr.OFTDateTime and \
-       lyr.GetLayerDefn().GetFieldDefn(11).GetType() == ogr.OFTDateTime and \
+       lyr.GetLayerDefn().GetFieldDefn(4).GetType() == ogr.OFTString and \
+       lyr.GetLayerDefn().GetFieldDefn(5).GetType() == ogr.OFTString and \
+       lyr.GetLayerDefn().GetFieldDefn(6).GetType() == ogr.OFTInteger and \
+       lyr.GetLayerDefn().GetFieldDefn(7).GetType() == ogr.OFTDate and \
+       lyr.GetLayerDefn().GetFieldDefn(8).GetType() == ogr.OFTString and \
+       lyr.GetLayerDefn().GetFieldDefn(9).GetType() == ogr.OFTInteger and \
+       lyr.GetLayerDefn().GetFieldDefn(10).GetType() == ogr.OFTDate and \
+       lyr.GetLayerDefn().GetFieldDefn(11).GetType() == ogr.OFTDate and \
        lyr.GetLayerDefn().GetFieldDefn(12).GetType() == ogr.OFTDateTime and \
        lyr.GetLayerDefn().GetFieldDefn(13).GetType() == ogr.OFTDateTime and \
        lyr.GetLayerDefn().GetFieldDefn(14).GetType() == ogr.OFTDateTime and \
        lyr.GetLayerDefn().GetFieldDefn(15).GetType() == ogr.OFTDateTime and \
-       lyr.GetLayerDefn().GetFieldDefn(16).GetType() == ogr.OFTDateTime)
+       lyr.GetLayerDefn().GetFieldDefn(16).GetType() == ogr.OFTDateTime and \
+       lyr.GetLayerDefn().GetFieldDefn(17).GetType() == ogr.OFTDateTime and \
+       lyr.GetLayerDefn().GetFieldDefn(18).GetType() == ogr.OFTDateTime)
 
     feat = lyr.GetNextFeature()
-    if feat.GetFieldAsString(0) != 'NL.IMBAG.Ligplaats' or \
-       feat.GetFieldAsString(1) != '0106020000000003' or \
-       feat.GetField(2) != None or \
-       feat.GetFieldAsString(3) != 'Plaats aangewezen' or \
-       feat.GetFieldAsInteger(4) != 0 or \
-       feat.GetFieldAsString(5) != '2009/05/26' or \
-       feat.GetFieldAsString(6) != '2009-01000' or \
-       feat.GetFieldAsInteger(7) != 1 or \
-       feat.GetFieldAsString(8) != '2009/05/26' or \
-       feat.GetField(9) != None or \
-       feat.GetFieldAsString(10) != '2009/11/06 13:37:22' or \
+    if feat.GetFieldAsString(0) != 'NL.IMBAG.NUMMERAANDUIDING.0106200000005333' or \
+       feat.GetFieldAsString(1) != 'NL.IMBAG.LIGPLAATS.0106020000000003' or \
+       feat.GetFieldAsString(2) != 'NL.IMBAG.Ligplaats' or \
+       feat.GetFieldAsString(3) != '0106020000000003' or \
+       feat.GetField(4) != None or \
+       feat.GetFieldAsString(5) != 'Plaats aangewezen' or \
+       feat.GetFieldAsInteger(6) != 0 or \
+       feat.GetFieldAsString(7) != '2009/05/26' or \
+       feat.GetFieldAsString(8) != '2009-01000' or \
+       feat.GetFieldAsInteger(9) != 1 or \
+       feat.GetFieldAsString(10) != '2009/05/26' or \
        feat.GetField(11) != None or \
-       feat.GetField(12) != None or \
-       feat.GetFieldAsString(13) != '2009/11/06 14:07:51.498' or \
+       feat.GetFieldAsString(12) != '2009/11/06 13:37:22' or \
+       feat.GetField(13) != None or \
        feat.GetField(14) != None or \
-       feat.GetField(15) != None or \
-       feat.GetField(16) != None:
+       feat.GetFieldAsString(15) != '2009/11/06 14:07:51.498' or \
+       feat.GetField(16) != None or \
+       feat.GetField(17) != None or \
+       feat.GetField(18) != None:
         feat.DumpReadable()
         pytest.fail()
 
@@ -141,14 +147,16 @@ def test_ogr_lvbag_dataset_num():
     assert lyr.GetSpatialRef() is None, 'bad spatial ref'
     assert lyr.TestCapability(ogr.OLCStringsAsUTF8) == 1
 
-    assert lyr.GetLayerDefn().GetFieldCount() == 22
+    assert lyr.GetLayerDefn().GetFieldCount() == 24
 
     feat = lyr.GetNextFeature()
     if feat.GetField('namespace') != 'NL.IMBAG.Nummeraanduiding' or \
        feat.GetField('lokaalID') != '0106200000002798' or \
+       feat.GetField('lvID') != 'NL.IMBAG.NUMMERAANDUIDING.0106200000002798' or \
        feat.GetFieldAsInteger('huisnummer') != 23 or \
        feat.GetField('postcode') != '9403KB' or \
        feat.GetField('typeAdresseerbaarObject') != 'Verblijfsobject' or \
+       feat.GetField('openbareruimteRef') != 'NL.IMBAG.OPENBARERUIMTE.0106300000002560' or \
        feat.GetField('status') != 'Naamgeving uitgegeven' or \
        feat.GetFieldAsInteger('geconstateerd') != 0 or \
        feat.GetFieldAsString('documentdatum') != '2009/09/14' or \
@@ -177,7 +185,7 @@ def test_ogr_lvbag_dataset_opr():
     assert lyr.GetGeomType() == ogr.wkbUnknown, 'bad layer geometry type'
     assert lyr.GetSpatialRef() is None, 'bad spatial ref'
     assert lyr.GetFeatureCount() == 3
-    assert lyr.GetLayerDefn().GetFieldCount() == 19
+    assert lyr.GetLayerDefn().GetFieldCount() == 21
 
 def test_ogr_lvbag_dataset_pnd():
 
@@ -189,7 +197,7 @@ def test_ogr_lvbag_dataset_pnd():
     assert lyr.GetName() == 'Pand', 'bad layer name'
     assert lyr.GetGeomType() == ogr.wkbMultiPolygon, 'bad layer geometry type'
     assert lyr.GetFeatureCount() == 6
-    assert lyr.GetLayerDefn().GetFieldCount() == 18
+    assert lyr.GetLayerDefn().GetFieldCount() == 19
 
     sr = lyr.GetSpatialRef()
 
@@ -231,7 +239,7 @@ def test_ogr_lvbag_dataset_sta():
     assert lyr.GetName() == 'Standplaats', 'bad layer name'
     assert lyr.GetGeomType() == ogr.wkbPolygon, 'bad layer geometry type'
     assert lyr.GetFeatureCount() == 2
-    assert lyr.GetLayerDefn().GetFieldCount() == 17
+    assert lyr.GetLayerDefn().GetFieldCount() == 19
 
 def test_ogr_lvbag_dataset_vbo():
 
@@ -241,9 +249,9 @@ def test_ogr_lvbag_dataset_vbo():
 
     lyr = ds.GetLayer(0)
     assert lyr.GetName() == 'Verblijfsobject', 'bad layer name'
-    # assert lyr.GetGeomType() == ogr.wkbUnknown, 'bad layer geometry type'
+    assert lyr.GetGeomType() == ogr.wkbPoint, 'bad layer geometry type'
     assert lyr.GetFeatureCount() == 3
-    assert lyr.GetLayerDefn().GetFieldCount() == 19
+    assert lyr.GetLayerDefn().GetFieldCount() == 22
 
 def test_ogr_lvbag_dataset_wpl():
 
@@ -255,7 +263,7 @@ def test_ogr_lvbag_dataset_wpl():
     assert lyr.GetName() == 'Woonplaats', 'bad layer name'
     assert lyr.GetGeomType() == ogr.wkbMultiPolygon, 'bad layer geometry type'
     assert lyr.GetFeatureCount() == 2
-    assert lyr.GetLayerDefn().GetFieldCount() == 18
+    assert lyr.GetLayerDefn().GetFieldCount() == 19
 
     feat = lyr.GetNextFeature()
     if feat.GetField('naam') != 'Assen' or \

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -305,7 +305,7 @@ def test_ogr_lvbag_read_zip_3():
 
 def test_ogr_lvbag_invalid_polygon():
 
-    if not ogrtest.have_geos():
+    if not ogrtest.have_geos() and not ogrtest.have_sfcgal():
         pytest.skip()
 
     ds = ogr.Open('data/lvbag/inval_polygon.xml')
@@ -344,7 +344,7 @@ def test_ogr_lvbag_read_errors():
 # Run test_ogrsf
 
 
-def test_ogr_lvbag_test_ogrsf():
+def test_ogr_lvbag_test_ogrsf_wpl():
 
     import test_cli_utilities
     if test_cli_utilities.get_test_ogrsf_path() is None:

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -305,6 +305,8 @@ def test_ogr_lvbag_read_zip_3():
 
 def test_ogr_lvbag_invalid_polygon():
 
+    pytest.skip()
+
     if not ogrtest.have_geos() and not ogrtest.have_sfcgal():
         pytest.skip()
 

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -186,7 +186,7 @@ def test_ogr_lvbag_dataset_pnd():
 
     lyr = ds.GetLayer(0)
     assert lyr.GetName() == 'Pand', 'bad layer name'
-    assert lyr.GetGeomType() == ogr.wkbPolygon25D, 'bad layer geometry type'
+    assert lyr.GetGeomType() == ogr.wkbPolygon, 'bad layer geometry type'
     assert lyr.GetFeatureCount() == 6
     assert lyr.GetLayerDefn().GetFieldCount() == 18
 
@@ -252,7 +252,7 @@ def test_ogr_lvbag_dataset_wpl():
 
     lyr = ds.GetLayer(0)
     assert lyr.GetName() == 'Woonplaats', 'bad layer name'
-    assert lyr.GetGeomType() == ogr.wkbPolygon, 'bad layer geometry type'
+    assert lyr.GetGeomType() == ogr.wkbMultiPolygon, 'bad layer geometry type'
     assert lyr.GetFeatureCount() == 2
     assert lyr.GetLayerDefn().GetFieldCount() == 18
 

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -195,6 +195,31 @@ def test_ogr_lvbag_dataset_pnd():
     assert sr.GetAuthorityName(None) == 'EPSG'
     assert sr.GetAuthorityCode(None) == '28992'
 
+    feat = lyr.GetNextFeature()
+    if feat.GetField('oorspronkelijkBouwjaar') != '2009/01/01':
+        feat.DumpReadable()
+        pytest.fail()
+
+    feat = lyr.GetNextFeature()
+    feat = lyr.GetNextFeature()
+    feat = lyr.GetNextFeature()
+    if feat.GetField('oorspronkelijkBouwjaar') != '2007/01/01':
+        feat.DumpReadable()
+        pytest.fail()
+
+    feat = lyr.GetNextFeature()
+    if feat.GetField('oorspronkelijkBouwjaar') != '1975/01/01':
+        feat.DumpReadable()
+        pytest.fail()
+
+    feat = lyr.GetNextFeature()
+    if feat.GetField('oorspronkelijkBouwjaar') != '2001/01/01':
+        feat.DumpReadable()
+        pytest.fail()
+
+    feat = lyr.GetNextFeature()
+    assert feat is None
+
 def test_ogr_lvbag_dataset_sta():
 
     ds = ogr.Open('data/lvbag/sta.xml')

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -33,6 +33,7 @@
 
 from osgeo import ogr
 import gdaltest
+import ogrtest
 import pytest
 
 pytestmark = pytest.mark.require_driver('LVBAG')
@@ -301,6 +302,31 @@ def test_ogr_lvbag_read_zip_3():
     lyr = ds.GetLayer(1)
     assert lyr.GetName() == 'Pand', 'bad layer name'
     assert lyr.GetFeatureCount() == 9
+
+def test_ogr_lvbag_invalid_polygon():
+
+    if not ogrtest.have_geos():
+        pytest.skip()
+
+    ds = ogr.Open('data/lvbag/inval_polygon.xml')
+    assert ds is not None, 'cannot open dataset'
+    assert ds.GetLayerCount() == 1, 'bad layer count'
+    
+    lyr = ds.GetLayer(0)
+    
+    feat = lyr.GetNextFeature()
+    assert feat.GetGeomFieldRef(0).IsValid()
+
+    feat = lyr.GetNextFeature()
+    assert feat.GetGeomFieldRef(0).IsValid()
+
+    feat = lyr.GetNextFeature()
+    assert feat.GetGeomFieldRef(0).IsValid()
+
+    feat = lyr.GetNextFeature()
+    assert feat.GetGeomFieldRef(0).IsValid()
+
+    assert feat is None
 
 def test_ogr_lvbag_read_errors():
 

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -326,6 +326,7 @@ def test_ogr_lvbag_invalid_polygon():
     feat = lyr.GetNextFeature()
     assert feat.GetGeomFieldRef(0).IsValid()
 
+    feat = lyr.GetNextFeature()
     assert feat is None
 
 def test_ogr_lvbag_read_errors():
@@ -351,5 +352,27 @@ def test_ogr_lvbag_test_ogrsf():
 
     import gdaltest
     ret = gdaltest.runexternal(test_cli_utilities.get_test_ogrsf_path() + ' -ro data/lvbag/wpl.xml')
+
+    assert 'INFO' in ret and 'ERROR' not in ret
+
+def test_ogr_lvbag_test_ogrsf_pnd():
+
+    import test_cli_utilities
+    if test_cli_utilities.get_test_ogrsf_path() is None:
+        pytest.skip()
+
+    import gdaltest
+    ret = gdaltest.runexternal(test_cli_utilities.get_test_ogrsf_path() + ' -ro data/lvbag/pnd.xml')
+
+    assert 'INFO' in ret and 'ERROR' not in ret
+
+def test_ogr_lvbag_test_ogrsf_num():
+
+    import test_cli_utilities
+    if test_cli_utilities.get_test_ogrsf_path() is None:
+        pytest.skip()
+
+    import gdaltest
+    ret = gdaltest.runexternal(test_cli_utilities.get_test_ogrsf_path() + ' -ro data/lvbag/num.xml')
 
     assert 'INFO' in ret and 'ERROR' not in ret

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -187,7 +187,7 @@ def test_ogr_lvbag_dataset_pnd():
 
     lyr = ds.GetLayer(0)
     assert lyr.GetName() == 'Pand', 'bad layer name'
-    assert lyr.GetGeomType() == ogr.wkbPolygon, 'bad layer geometry type'
+    assert lyr.GetGeomType() == ogr.wkbMultiPolygon, 'bad layer geometry type'
     assert lyr.GetFeatureCount() == 6
     assert lyr.GetLayerDefn().GetFieldCount() == 18
 

--- a/gdal/doc/source/drivers/vector/lvbag.rst
+++ b/gdal/doc/source/drivers/vector/lvbag.rst
@@ -24,10 +24,21 @@ More information about the LV BAG 2.0 can be found at https://zakelijk.kadaster.
 
 LV BAG model definitions are available at https://zakelijk.kadaster.nl/documents/20838/87954/XSD%27s+BAG+2.0+Extract
 
-Note 1 : the earlier BAG 1.0 extract is not supported by this driver.
+Note 1 : the earlier BAG 1.0 extract is **not supported**\ by this driver.
 
 Note 2 : the driver will only read ST (Standaard Levering) extract files. Mutation
 ML (Mutatie Levering) files are not supported.
+
+Open options
+------------
+
+The following open options can be specified
+(typically with the -oo name=value parameters of ogrinfo or ogr2ogr):
+
+-  **AUTOCORRECT_INVALID_DATA**\ =YES/NO (defaults to YES). Whether or not the driver must
+   try to adjust the data if a feature contains invalid or corrupted data. This typically
+   includes fixing invalid geometries (with GEOS >= 3.8.0), dates, object status etc. If
+   performance is essential set this option to NO.
 
 VSI Virtual File System API support
 -----------------------------------
@@ -73,6 +84,14 @@ Examples
        -f "PostgreSQL" PG:dbname="my_database" \
        9999PND18122019/ \
        -nln "name_of_new_table"
+
+- Create GeoPackage from 'Nummeraanduiding' dataset:
+
+   ::
+
+     ogr2ogr \
+       -f "GPKG" nummeraanduiding.gpkg \
+       0000NUM01052020/
 
 See Also
 --------

--- a/gdal/doc/source/drivers/vector/lvbag.rst
+++ b/gdal/doc/source/drivers/vector/lvbag.rst
@@ -18,7 +18,8 @@ The driver is only available if GDAL/OGR is compiled against the Expat
 library.
 
 Each extract XML file is presented as a single OGR layer. The layers are
-georeferenced in their native (EPSG:28992) SRS.
+georeferenced in their native (EPSG:28992) SRS. Each dataset exposes the LvID
+field according to the BAG 2.0 specfication.
 
 More information about the LV BAG 2.0 can be found at https://zakelijk.kadaster.nl/bag-2.0
 

--- a/gdal/ogr/ogrsf_frmts/lvbag/GNUmakefile
+++ b/gdal/ogr/ogrsf_frmts/lvbag/GNUmakefile
@@ -5,7 +5,11 @@ include ../../../GDALmake.opt
 OBJ	=	ogrlvbagdriver.o ogrlvbagdatasource.o ogrlvbaglayer.o
 
 ifeq ($(HAVE_EXPAT),yes)
-CPPFLAGS +=   -DHAVE_EXPAT
+CPPFLAGS += -DHAVE_EXPAT
+endif
+
+ifeq ($(HAVE_GEOS),yes)
+CPPFLAGS += -DHAVE_GEOS
 endif
 
 CPPFLAGS	:=	-I.. -I../.. -I../generic $(EXPAT_INCLUDE) $(CPPFLAGS)

--- a/gdal/ogr/ogrsf_frmts/lvbag/GNUmakefile
+++ b/gdal/ogr/ogrsf_frmts/lvbag/GNUmakefile
@@ -9,7 +9,7 @@ CPPFLAGS += -DHAVE_EXPAT
 endif
 
 ifeq ($(HAVE_GEOS),yes)
-CPPFLAGS += -DHAVE_GEOS
+CPPFLAGS += -DHAVE_GEOS $(GEOS_CFLAGS)
 endif
 
 CPPFLAGS	:=	-I.. -I../.. -I../generic $(EXPAT_INCLUDE) $(CPPFLAGS)

--- a/gdal/ogr/ogrsf_frmts/lvbag/makefile.vc
+++ b/gdal/ogr/ogrsf_frmts/lvbag/makefile.vc
@@ -6,9 +6,9 @@ GDAL_ROOT	=	..\..\..
 !INCLUDE $(GDAL_ROOT)\nmake.opt
 
 !IFDEF EXPAT_DIR
-EXTRAFLAGS =	-I.. -I..\.. -I..\generic $(EXPAT_INCLUDE) -DHAVE_EXPAT=1 
+EXTRAFLAGS =	-I.. -I..\.. -I..\generic $(EXPAT_INCLUDE) $(GEOS_CFLAGS) -DHAVE_EXPAT=1 
 !ELSE
-EXTRAFLAGS =	-I.. -I..\.. -I..\generic
+EXTRAFLAGS =	-I.. -I..\.. -I..\generic $(GEOS_CFLAGS)
 !ENDIF
 
 default:	$(OBJ)

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
@@ -119,7 +119,7 @@ class OGRLVBAGLayer final: public OGRAbstractProxiedLayer, public OGRGetNextFeat
     friend class OGRLVBAGDataSource;
 
 public:
-    explicit OGRLVBAGLayer( const char *pszFilename, OGRLayerPool* poPoolIn );
+    explicit OGRLVBAGLayer( const char *pszFilename, OGRLayerPool* poPoolIn, char **papszOpenOptions );
     ~OGRLVBAGLayer();
 
     void                ResetReading() override;
@@ -146,7 +146,7 @@ class OGRLVBAGDataSource final: public GDALDataset
 public:
                         OGRLVBAGDataSource();
 
-    int                 Open( const char* pszFilename );
+    int                 Open( const char* pszFilename, char **papszOpenOptions );
 
     int                 GetLayerCount() override;
     OGRLayer*           GetLayer( int ) override;

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
@@ -42,37 +42,14 @@ typedef enum
 } LayerType;
 
 /**
- * Deleter for unique pointer.
- *
- * This functor will free the XML kept resources once the unique pointer goes
- * out of scope or is reset.
+ * Layer pool unique pointer.
  */
-
-struct XMLParserUniquePtrDeleter
-{
-    void operator()(XML_Parser oParser) const noexcept
-    {
-        XML_ParserFree(oParser);
-    }
-};
-
-/**
- * XML parser unique pointer type.
- *
- * The XML parser unique pointer holds the resources used by the parser for as long
- * as the pointers stays inscope. Once the pointer leaves operation scope the deleter
- * is called and the resources are freed.
- */
-
-typedef std::unique_ptr<XML_ParserStruct, XMLParserUniquePtrDeleter> XMLParserUniquePtr;
-
-using LayerUniquePtr = std::unique_ptr<OGRLayer>;
 using LayerPoolUniquePtr = std::unique_ptr<OGRLayerPool>;
 
 /**
  * Vector holding pointers to OGRLayer.
  */
-using LayerVector = std::vector<std::pair<LayerType, LayerUniquePtr>>;
+using LayerVector = std::vector<std::pair<LayerType, OGRLayerUniquePtr>>;
 
 }
 

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
@@ -76,7 +76,7 @@ class OGRLVBAGLayer final: public OGRAbstractProxiedLayer, public OGRGetNextFeat
     
     FileDescriptorState eFileDescriptorsState;
 
-    OGRLVBAG::XMLParserUniquePtr  oParser;
+    OGRExpatUniquePtr   oParser;
     
     bool                bSchemaOnly;
     bool                bHasReadSchema;

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
@@ -80,6 +80,7 @@ class OGRLVBAGLayer final: public OGRAbstractProxiedLayer, public OGRGetNextFeat
     
     bool                bSchemaOnly;
     bool                bHasReadSchema;
+    bool                bFitInvalidData;
     
     int                 nCurrentDepth;
     int                 nGeometryElementDepth;

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogr_lvbag.h
@@ -92,6 +92,7 @@ class OGRLVBAGLayer final: public OGRAbstractProxiedLayer, public OGRGetNextFeat
 
     char                aBuf[BUFSIZ];
 
+    void                AddSpatialRef(OGRwkbGeometryType eTypeIn);
     void                AddOccurrenceFieldDefn();
     void                AddIdentifierFieldDefn();
     void                AddDocumentFieldDefn();

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdatasource.cpp
@@ -151,18 +151,18 @@ void OGRLVBAGDataSource::TryCoalesceLayers()
         CPLFree(papoGeomFields);
         CPLFree(papoFields);
 
-        // Erase all released pointers
-        auto it = papoLayers.begin();
-        while( it != papoLayers.end() )
-        {
-            if( !it->second )
-                it = papoLayers.erase(it);
-            else
-                ++it;
-        }
-
         papoLayers.push_back({ OGRLVBAG::LayerType::LYR_RAW,
-            OGRLVBAG::LayerUniquePtr{ poLayer.release() } });
+            OGRLayerUniquePtr{ poLayer.release() } });
+    }
+
+    // Erase all released pointers
+    auto it = papoLayers.begin();
+    while( it != papoLayers.end() )
+    {
+        if( !it->second )
+            it = papoLayers.erase(it);
+        else
+            ++it;
     }
 }
 

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdatasource.cpp
@@ -51,10 +51,10 @@ OGRLVBAGDataSource::OGRLVBAGDataSource() :
 /*                                Open()                                */
 /************************************************************************/
 
-int OGRLVBAGDataSource::Open( const char* pszFilename )
+int OGRLVBAGDataSource::Open( const char* pszFilename, char **papszOpenOptionsIn )
 {
     auto poLayer = std::unique_ptr<OGRLVBAGLayer>{
-        new OGRLVBAGLayer{ pszFilename, poPool.get() } };
+        new OGRLVBAGLayer{ pszFilename, poPool.get(), papszOpenOptionsIn } };
     if( poLayer && !poLayer->TouchLayer() )
         return FALSE;
 

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdriver.cpp
@@ -76,7 +76,7 @@ GDALDataset *OGRLVBAGDriverOpen( GDALOpenInfo* poOpenInfo )
 
     if( !poOpenInfo->bIsDirectory && poOpenInfo->fpL != nullptr )
     {
-        if( !poDS->Open( poOpenInfo->pszFilename ) )
+        if( !poDS->Open( poOpenInfo->pszFilename, poOpenInfo->papszOpenOptions ) )
             poDS.reset();
     }
     else if( poOpenInfo->bIsDirectory && poOpenInfo->fpL == nullptr )
@@ -98,7 +98,7 @@ GDALDataset *OGRLVBAGDriverOpen( GDALOpenInfo* poOpenInfo )
             if( !OGRLVBAGDriverIdentify(&oOpenInfo) )
                 continue;
 
-            if( !poDS->Open( oSubFilename ) )
+            if( !poDS->Open( oSubFilename, poOpenInfo->papszOpenOptions ) )
                 continue;
         }
 
@@ -135,6 +135,11 @@ void RegisterOGRLVBAG()
     poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "xml" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/vector/lvbag.html" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
+
+    poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
+"<OpenOptionList>"
+"  <Option name='AUTOCORRECT_INVALID_DATA' type='boolean' description='whether driver should try to fix invalid data' default='YES'/>"
+"</OpenOptionList>" );
 
     poDriver->pfnOpen = OGRLVBAGDriverOpen;
     poDriver->pfnIdentify = OGRLVBAGDriverIdentify;

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbagdriver.cpp
@@ -127,7 +127,7 @@ void RegisterOGRLVBAG()
     if( GDALGetDriverByName( "LVBAG" ) != nullptr )
         return;
 
-    std::unique_ptr<GDALDriver> poDriver = std::unique_ptr<GDALDriver>(new GDALDriver());
+    std::unique_ptr<GDALDriver> poDriver = std::unique_ptr<GDALDriver>{ new GDALDriver };
 
     poDriver->SetDescription( "LVBAG" );
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -503,6 +503,17 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                 }
                 else
                     poFeature->SetField(iFieldIndex, pszValue);
+                
+                if( bFitInvalidData
+                    && (poFieldDefn->GetType() == OFTDate || poFieldDefn->GetType() == OFTDateTime) )
+                {
+                    int nYear;
+                    poFeature->GetFieldAsDateTime(iFieldIndex, &nYear, nullptr, nullptr,
+                                                nullptr, nullptr,
+                                                static_cast<float*>(nullptr), nullptr);
+                    if( nYear > 2100 )
+                        poFeature->SetFieldNull(iFieldIndex);
+                }
             }
         }
         osElementString.Clear();

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -552,7 +552,7 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                                 poGeom.reset(poPoint.release());
 #else
                             CPLError( CE_Warning, CPLE_AppDefined,
-                                "Cannot convert polygon to point, enable GEOS support" );
+                                "Cannot shape geometry, GEOS support not enabled." );
                             poGeom.reset(poPoint.release());
 #endif
                             break;
@@ -561,6 +561,13 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                         default:
                             break;
                     }
+                }
+                else if( poGeomField->GetType() == wkbMultiPolygon
+                    && poGeom->getGeometryType() == wkbPolygon )
+                {
+                    std::unique_ptr<OGRMultiPolygon> poMultiPolygon = std::unique_ptr<OGRMultiPolygon>{ new OGRMultiPolygon };
+                    poMultiPolygon->addGeometry(poGeom.get());
+                    poGeom.reset(poMultiPolygon.release());
                 }
 
                 poGeom->assignSpatialReference(GetSpatialRef());

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -39,7 +39,7 @@ constexpr const char *pszSpecificationUrn = "urn:ogc:def:crs:EPSG::28992";
 /*      file pointer.                                                   */
 /************************************************************************/
 
-OGRLVBAGLayer::OGRLVBAGLayer( const char *pszFilename, OGRLayerPool* poPoolIn ) :
+OGRLVBAGLayer::OGRLVBAGLayer( const char *pszFilename, OGRLayerPool* poPoolIn, char **papszOpenOptions ) :
     OGRAbstractProxiedLayer{ poPoolIn },
     poFeatureDefn{ new OGRFeatureDefn{} },
     poFeature{ nullptr },
@@ -50,7 +50,7 @@ OGRLVBAGLayer::OGRLVBAGLayer( const char *pszFilename, OGRLayerPool* poPoolIn ) 
     oParser{ nullptr },
     bSchemaOnly{ false },
     bHasReadSchema{ false },
-    bFitInvalidData{ true },
+    bFitInvalidData{ CPLFetchBool(papszOpenOptions, "AUTOCORRECT_INVALID_DATA", true) },
     nCurrentDepth{ 0 },
     nGeometryElementDepth{ 0 },
     nFeatureCollectionDepth{ 0 },
@@ -59,9 +59,9 @@ OGRLVBAGLayer::OGRLVBAGLayer( const char *pszFilename, OGRLayerPool* poPoolIn ) 
     bCollectData{ false }
 {
     SetDescription(CPLGetBasename(pszFilename));
-    
+
     poFeatureDefn->Reference();
-    
+
     memset(aBuf, '\0', sizeof(aBuf));
 }
 

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -581,7 +581,8 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                     poGeom.reset(poMultiPolygon.release());
                 }
 
-                poGeom->assignSpatialReference(GetSpatialRef());
+                if( !poGeomField->GetSpatialRef() )
+                    poGeom->assignSpatialReference(poGeomField->GetSpatialRef());
                 poFeature->SetGeometryDirectly(poGeom.release());
             }
             else

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -234,12 +234,14 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
         OGRFieldDefn oField2("huisnummertoevoeging", OFTString);
         OGRFieldDefn oField3("postcode", OFTString);
         OGRFieldDefn oField4("typeAdresseerbaarObject", OFTString);
+        OGRFieldDefn oField5("openbareruimteref", OFTString);
   
         poFeatureDefn->AddFieldDefn(&oField0);
         poFeatureDefn->AddFieldDefn(&oField1);
         poFeatureDefn->AddFieldDefn(&oField2);
         poFeatureDefn->AddFieldDefn(&oField3);
         poFeatureDefn->AddFieldDefn(&oField4);
+        poFeatureDefn->AddFieldDefn(&oField5);
  
         AddIdentifierFieldDefn();
         AddDocumentFieldDefn();
@@ -250,6 +252,10 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
     }
     else if( EQUAL("lig", pszDataset) )
     {
+        OGRFieldDefn oField0("nummeraanduidingref", OFTString);
+
+        poFeatureDefn->AddFieldDefn(&oField0);
+
         AddIdentifierFieldDefn();
         AddDocumentFieldDefn();
         AddOccurrenceFieldDefn();
@@ -261,6 +267,10 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
     }
     else if( EQUAL("sta", pszDataset) )
     {
+        OGRFieldDefn oField0("nummeraanduidingref", OFTString);
+
+        poFeatureDefn->AddFieldDefn(&oField0);
+
         AddIdentifierFieldDefn();
         AddDocumentFieldDefn();
         AddOccurrenceFieldDefn();
@@ -274,9 +284,11 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
     {
         OGRFieldDefn oField0("naam", OFTString);
         OGRFieldDefn oField1("type", OFTString);
+        OGRFieldDefn oField2("woonplaatsref", OFTString);
 
         poFeatureDefn->AddFieldDefn(&oField0);
         poFeatureDefn->AddFieldDefn(&oField1);
+        poFeatureDefn->AddFieldDefn(&oField2);
  
         AddIdentifierFieldDefn();
         AddDocumentFieldDefn();
@@ -289,9 +301,13 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
     {
         OGRFieldDefn oField0("gebruiksdoel", OFTString);
         OGRFieldDefn oField1("oppervlakte", OFTInteger);
+        OGRFieldDefn oField2("nummeraanduidingref", OFTString);
+        OGRFieldDefn oField3("pandref", OFTString);
 
         poFeatureDefn->AddFieldDefn(&oField0);
         poFeatureDefn->AddFieldDefn(&oField1);
+        poFeatureDefn->AddFieldDefn(&oField2);
+        poFeatureDefn->AddFieldDefn(&oField3);
  
         AddIdentifierFieldDefn();
         AddDocumentFieldDefn();
@@ -418,6 +434,17 @@ void OGRLVBAGLayer::StartElementCbk( const char *pszName, const char **ppszAttr 
     else if( nFeatureElementDepth > 0 && nAttributeElementDepth == 0 &&
         nGeometryElementDepth == 0 && STARTS_WITH_CI(pszName, "objecten") )
         nAttributeElementDepth = nCurrentDepth;
+    else if( nFeatureElementDepth > 0 && nAttributeElementDepth > 0 &&
+             nGeometryElementDepth == 0 && STARTS_WITH_CI(pszName, "objecten-ref")  )
+    {
+        const char** papszIter = ppszAttr;
+        while( papszIter && *papszIter != nullptr )
+        {
+            if( EQUAL("xlink:href", papszIter[0]) )
+                osElementString = papszIter[1];
+            papszIter += 2;
+        }
+    }
     else if( nFeatureElementDepth > 0 && nAttributeElementDepth > 0 &&
              nGeometryElementDepth == 0 )
         StartDataCollect();

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -30,6 +30,8 @@
 #include "ogr_lvbag.h"
 #include "ogr_p.h"
 
+constexpr const char *pszSpecificationUrn = "urn:ogc:def:crs:EPSG::28992";
+
 /************************************************************************/
 /*                           OGRLVBAGLayer()                            */
 /*                                                                      */
@@ -127,6 +129,20 @@ static inline const char* XMLTagSplit( const char *pszName )
 }
 
 /************************************************************************/
+/*                           AddSpatialRef()                            */
+/************************************************************************/
+
+void OGRLVBAGLayer::AddSpatialRef( OGRwkbGeometryType eTypeIn )
+{
+    OGRGeomFieldDefn *poGeomField = poFeatureDefn->GetGeomFieldDefn(0);
+    OGRSpatialReference* poSRS = new OGRSpatialReference{};
+    poSRS->importFromURN(pszSpecificationUrn);
+    poGeomField->SetSpatialRef(poSRS);
+    poGeomField->SetType(eTypeIn);
+    poSRS->Release();
+}
+
+/************************************************************************/
 /*                      AddIdentifierFieldDefn()                        */
 /************************************************************************/
 
@@ -206,6 +222,8 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
 
         poFeatureDefn->SetName("Pand");
         SetDescription(poFeatureDefn->GetName());
+
+        AddSpatialRef(wkbPolygon);
     }
     else if( EQUAL("num", pszDataset) )
     {
@@ -236,6 +254,8 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
 
         poFeatureDefn->SetName("Ligplaats");
         SetDescription(poFeatureDefn->GetName());
+
+        AddSpatialRef(wkbPolygon);
     }
     else if( EQUAL("sta", pszDataset) )
     {
@@ -245,6 +265,8 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
 
         poFeatureDefn->SetName("Standplaats");
         SetDescription(poFeatureDefn->GetName());
+
+        AddSpatialRef(wkbPolygon);
     }
     else if( EQUAL("opr", pszDataset) )
     {
@@ -275,6 +297,8 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
 
         poFeatureDefn->SetName("Verblijfsobject");
         SetDescription(poFeatureDefn->GetName());
+
+        AddSpatialRef(wkbPoint);
     }
     else if( EQUAL("wpl", pszDataset) )
     {
@@ -288,6 +312,8 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
 
         poFeatureDefn->SetName("Woonplaats");
         SetDescription(poFeatureDefn->GetName());
+
+        AddSpatialRef(wkbMultiPolygon);
     }
     else
         CPLError(CE_Failure, CPLE_AppDefined,

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -581,7 +581,7 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                     poGeom.reset(poMultiPolygon.release());
                 }
 
-                if( !poGeomField->GetSpatialRef() )
+                if( poGeomField->GetSpatialRef() )
                     poGeom->assignSpatialReference(poGeomField->GetSpatialRef());
                 poFeature->SetGeometryDirectly(poGeom.release());
             }

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -578,7 +578,7 @@ void OGRLVBAGLayer::ConfigureParser()
         static_cast<OGRLVBAGLayer *>(pUserData)->DataHandlerCbk(data, nLen);
     };
 
-    oParser = OGRLVBAG::XMLParserUniquePtr{ OGRCreateExpatXMLParser() };
+    oParser = OGRExpatUniquePtr{ OGRCreateExpatXMLParser() };
     XML_SetElementHandler(oParser.get(), startElementWrapper, endElementWrapper);
     XML_SetCharacterDataHandler(oParser.get(), dataHandlerWrapper);
     XML_SetUserData(oParser.get(), this);

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -27,6 +27,7 @@
  ****************************************************************************/
 
 #include "cpl_conv.h"
+#include "ogr_geos.h"
 #include "ogr_lvbag.h"
 #include "ogr_p.h"
 
@@ -539,7 +540,9 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                 if( poGeom->Is3D() )
                     poGeom->flattenTo2D();
 
-#if defined(HAVE_SFCGAL) || defined(HAVE_GEOS)
+// GEOS >= 3.8.0 for MakeValid.
+#ifdef HAVE_GEOS
+#if GEOS_VERSION_MAJOR > 3 || (GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 8)
                 if( !poGeom->IsValid() && bFitInvalidData )
                 {
                     std::unique_ptr<OGRGeometry> poSubGeom = std::unique_ptr<OGRGeometry>{
@@ -547,6 +550,7 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                     if( poSubGeom && poSubGeom->IsValid() )
                         poGeom.reset(poSubGeom.release());
                 }
+#endif
 #endif
 
                 OGRGeomFieldDefn *poGeomField = poFeatureDefn->GetGeomFieldDefn(0);

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -467,7 +467,7 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                 {
                     const char *pszValue = osElementString.c_str();
                     const OGRFieldDefn *poFieldDefn = poFeatureDefn->GetFieldDefn(iFieldIndex);
-                    if (poFieldDefn->GetSubType() == OGRFieldSubType::OFSTBoolean)
+                    if( poFieldDefn->GetSubType() == OGRFieldSubType::OFSTBoolean )
                     {
                         if( EQUAL("n", pszValue) )
                             poFeature->SetField(iFieldIndex, 0);
@@ -478,6 +478,12 @@ void OGRLVBAGLayer::EndElementCbk( const char *pszName )
                             CPLError(CE_Failure, CPLE_AppDefined, "Parsing boolean failed");
                             XML_StopParser(oParser.get(), XML_FALSE);
                         }
+                    }
+                    else if( poFieldDefn->GetType() == OFTDate && osElementString.length() == 4 )
+                    {
+                        CPLString oFullDate{ pszValue };
+                        oFullDate += "-01-01";
+                        poFeature->SetField(iFieldIndex, oFullDate.c_str());
                     }
                     else
                         poFeature->SetField(iFieldIndex, pszValue);


### PR DESCRIPTION
## What does this PR do?

Many bugfixes and improvements for the LVBAG driver
- FIX: Remove unionized source layers from the dataset _after_ unioning is done
- Rewrite code to use the internal C++11 memory functions
- Make nMaxSimultaneouslyOpened configurable for testing
- FIX: Parse year as Date type
- Add SRS/Geom type based on dataset name and LVBAG 2.0 kadaster specification
- Fit invalid data if possible
- Set invalid dates to null

## What are related issues/pull requests?

Fixes: https://github.com/OSGeo/gdal/issues/2707
Fixes: https://github.com/OSGeo/gdal/issues/2636

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
