### PR TITLE
Doc: split Common Portability Library C++ API

### DIFF
--- a/gdal/doc/source/api/cpl.rst
+++ b/gdal/doc/source/api/cpl.rst
@@ -1,7 +1,7 @@
 .. _cpl_api:
 
 ================================================================================
-Common Portability Library
+Common Portability Library C API
 ================================================================================
 
 cpl_conv.h
@@ -38,12 +38,6 @@ cpl_multiproc.h
 ---------------
 
 .. doxygenfile:: cpl_multiproc.h
-   :project: api
-
-cpl_odbc.h
-----------
-
-.. doxygenfile:: cpl_odbc.h
    :project: api
 
 cpl_port.h
@@ -88,9 +82,6 @@ cpl_vsi.h
 .. doxygenfile:: cpl_vsi.h
    :project: api
 
-cpl_vsi_virtual.h
------------------
+.. seealso::
 
-.. doxygenfile:: cpl_vsi_virtual.h
-   :project: api
-
+   :ref:`cpl_cpp_api`.

--- a/gdal/doc/source/api/cpl_cpp.rst
+++ b/gdal/doc/source/api/cpl_cpp.rst
@@ -1,0 +1,21 @@
+.. _cpl_cpp_api:
+
+================================================================================
+Common Portability Library C++ API
+================================================================================
+
+cpl_odbc.h
+----------
+
+.. doxygenfile:: cpl_odbc.h
+   :project: api
+
+cpl_vsi_virtual.h
+-----------------
+
+.. doxygenfile:: cpl_vsi_virtual.h
+   :project: api
+
+.. seealso::
+
+   :ref:`cpl_api`.

--- a/gdal/doc/source/api/index.rst
+++ b/gdal/doc/source/api/index.rst
@@ -68,12 +68,13 @@ API
        gdalattribute_cpp
        gdalextendeddatatype_cpp
 
-   Geographic networks API
+   Miscellaneous C++ API
    ++++++++++++++++++++++++++++
 
    .. toctree::
        :maxdepth: 1
 
+       cpl_cpp
        gnm_cpp
 
    Python API


### PR DESCRIPTION
The Common Portability Library is primarily a C API, however there are currently two C++ API components. This PR splits these off the C API section, and into a renamed "Miscellaneous C++ API" section.

Here is the HTML output from these changes in the TOC:
![image](https://user-images.githubusercontent.com/895458/85276600-34cbe480-b4d6-11ea-8dba-5533ccdc7143.png)
![image](https://user-images.githubusercontent.com/895458/85276674-50cf8600-b4d6-11ea-8689-0e051c214e70.png)
