### PR TITLE
Documentation setting block size for overview --config GDAL_TIFF_OVR_BL…

### DIFF
--- a/gdal/doc/source/programs/gdaladdo.rst
+++ b/gdal/doc/source/programs/gdaladdo.rst
@@ -155,7 +155,7 @@ documented in the GeoTIFF driver documentation.
 
 See the documentation of the :ref:`raster.gtiff` driver for further explanations on all those options.
 
-Setting blocksize in Geotiff overviewrs
+Setting blocksize in Geotiff overviews
 ---------------------------------------
 --config GDAL_TIFF_OVR_BLOCKSIZE <size> 
 example --config GDAL_TIFF_OVR_BLOCKSIZE 256

--- a/gdal/doc/source/programs/gdaladdo.rst
+++ b/gdal/doc/source/programs/gdaladdo.rst
@@ -155,6 +155,15 @@ documented in the GeoTIFF driver documentation.
 
 See the documentation of the :ref:`raster.gtiff` driver for further explanations on all those options.
 
+Setting blocksize in Geotiff overviewrs
+---------------------------------------
+--config GDAL_TIFF_OVR_BLOCKSIZE <size> 
+example --config GDAL_TIFF_OVR_BLOCKSIZE 256
+
+default value is 128
+Note: without setting, the file can have level 0 with blocksize diffrent from overviews blocksize.(e.g. level 0 blocksize 256 ,levels 1-7 blocksize 128)
+
+
 Multithreading
 --------------
 

--- a/gdal/doc/source/programs/gdaladdo.rst
+++ b/gdal/doc/source/programs/gdaladdo.rst
@@ -157,8 +157,10 @@ See the documentation of the :ref:`raster.gtiff` driver for further explanations
 
 Setting blocksize in Geotiff overviews
 ---------------------------------------
+
 --config GDAL_TIFF_OVR_BLOCKSIZE <size> 
-example --config GDAL_TIFF_OVR_BLOCKSIZE 256
+
+Example: --config GDAL_TIFF_OVR_BLOCKSIZE 256
 
 Default value is 128, or starting with GDAL 3.1, if creating overviews on a tiled GeoTIFF file, the tile size of the full resolution image.
 Note: without this setting, the file can have the full resoultion image with a blocksize different from overviews blocksize.(e.g. full resolution image at blocksize 256, overviews at blocksize 128)

--- a/gdal/doc/source/programs/gdaladdo.rst
+++ b/gdal/doc/source/programs/gdaladdo.rst
@@ -160,7 +160,7 @@ Setting blocksize in Geotiff overviews
 --config GDAL_TIFF_OVR_BLOCKSIZE <size> 
 example --config GDAL_TIFF_OVR_BLOCKSIZE 256
 
-default value is 128
+Default value is 128, or starting with GDAL 3.1, if creating overviews on a tiled GeoTIFF file, the tile size of the full resolution image.
 Note: without this setting, the file can have the full resoultion image with a blocksize different from overviews blocksize.(e.g. full resolution image at blocksize 256, overviews at blocksize 128)
 
 

--- a/gdal/doc/source/programs/gdaladdo.rst
+++ b/gdal/doc/source/programs/gdaladdo.rst
@@ -161,7 +161,7 @@ Setting blocksize in Geotiff overviews
 example --config GDAL_TIFF_OVR_BLOCKSIZE 256
 
 default value is 128
-Note: without setting, the file can have level 0 with blocksize diffrent from overviews blocksize.(e.g. level 0 blocksize 256 ,levels 1-7 blocksize 128)
+Note: without this setting, the file can have the full resoultion image with a blocksize different from overviews blocksize.(e.g. full resolution image at blocksize 256, overviews at blocksize 128)
 
 
 Multithreading


### PR DESCRIPTION
…OCKSIZE

using --config GDAL_TIFF_OVR_BLOCKSIZE 
can set blocksize of overviews
default value is 128. this caused a problem were base level of tiff had 256, and all other overviews had 128

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
