### PR TITLE
Add logging capabilities for /vsicurl, /vsis3 and the like

### DIFF
--- a/gdal/port/cpl_json.cpp
+++ b/gdal/port/cpl_json.cpp
@@ -621,6 +621,26 @@ void CPLJSONObject::Add(const std::string &osName, const CPLJSONObject &oValue)
 
 /**
  * Add new key - value pair to json object.
+ * @param osName  Key name (do not split it on '/')
+ * @param oValue   Json object value.
+ *
+ * @since GDAL 3.2
+ */
+void CPLJSONObject::AddNoSplitName(const std::string &osName, const CPLJSONObject &oValue)
+{
+    if( m_osKey == INVALID_OBJ_KEY )
+        m_osKey.clear();
+    if( IsValid() &&
+        json_object_get_type(TO_JSONOBJ(m_poJsonObject)) == json_type_object )
+    {
+        json_object_object_add( TO_JSONOBJ(GetInternalHandle()),
+                                osName.c_str(),
+                                json_object_get( TO_JSONOBJ(oValue.GetInternalHandle()) ) );
+    }
+}
+
+/**
+ * Add new key - value pair to json object.
  * @param osName  Key name.
  * @param bValue   Boolean value.
  *

--- a/gdal/port/cpl_json.h
+++ b/gdal/port/cpl_json.h
@@ -101,6 +101,7 @@ public:
     void Add(const std::string &osName, GInt64 nValue);
     void Add(const std::string &osName, const CPLJSONArray &oValue);
     void Add(const std::string &osName, const CPLJSONObject &oValue);
+    void AddNoSplitName(const std::string &osName, const CPLJSONObject &oValue);
     void Add(const std::string &osName, bool bValue);
     void AddNull(const std::string &osName);
 

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -373,6 +373,9 @@ int CPL_DLL VSISync( const char* pszSource, const char* pszTarget,
 char CPL_DLL *VSIStrerror( int );
 GIntBig CPL_DLL VSIGetDiskFreeSpace(const char *pszDirname);
 
+void CPL_DLL VSINetworkStatsReset( void );
+char CPL_DLL *VSINetworkStatsGetAsSerializedJSON( char** papszOptions );
+
 /* ==================================================================== */
 /*      Install special file access handlers.                           */
 /* ==================================================================== */

--- a/gdal/port/cpl_vsil_curl_class.h
+++ b/gdal/port/cpl_vsil_curl_class.h
@@ -33,6 +33,7 @@
 
 #include "cpl_aws.h"
 #include "cpl_port.h"
+#include "cpl_json.h"
 #include "cpl_string.h"
 #include "cpl_vsil_curl_priv.h"
 #include "cpl_mem_cache.h"
@@ -42,6 +43,7 @@
 #include <set>
 #include <map>
 #include <memory>
+#include <mutex>
 
 //! @cond Doxygen_Suppress
 
@@ -506,6 +508,7 @@ class VSIS3WriteHandle final : public VSIVirtualHandle
     CPLString           m_osCurlErrBuf{};
     size_t              m_nChunkedBufferOff = 0;
     size_t              m_nChunkedBufferSize = 0;
+    size_t              m_nWrittenInPUT = 0;
 
     int                 m_nMaxRetry = 0;
     double              m_dfRetryDelay = 0.0;
@@ -599,6 +602,148 @@ struct CurlRequestHelper
                  VSICurlFilesystemHandler *poFS,
                  IVSIS3LikeHandleHelper *poS3HandleHelper);
 };
+
+/************************************************************************/
+/*                       NetworkStatisticsLogger                        */
+/************************************************************************/
+
+class NetworkStatisticsLogger
+{
+    static int gnEnabled;
+    static NetworkStatisticsLogger gInstance;
+
+    NetworkStatisticsLogger() = default;
+
+    std::mutex m_mutex{};
+
+    struct Counters
+    {
+        GIntBig nHEAD = 0;
+        GIntBig nGET = 0;
+        GIntBig nPUT = 0;
+        GIntBig nPOST = 0;
+        GIntBig nDELETE = 0;
+        GIntBig nGETDownloadedBytes = 0;
+        GIntBig nPUTUploadedBytes = 0;
+        GIntBig nPOSTDownloadedBytes = 0;
+        GIntBig nPOSTUploadedBytes = 0;
+    };
+
+    enum class ContextPathType
+    {
+        FILESYSTEM,
+        FILE,
+        ACTION,
+    };
+
+    struct ContextPathItem
+    {
+        ContextPathType eType;
+        CPLString       osName;
+
+        ContextPathItem(ContextPathType eTypeIn, const CPLString& osNameIn):
+            eType(eTypeIn), osName(osNameIn) {}
+
+        bool operator< (const ContextPathItem& other ) const
+        {
+            if( static_cast<int>(eType) < static_cast<int>(other.eType) )
+                return true;
+            if( static_cast<int>(eType) > static_cast<int>(other.eType) )
+                return false;
+            return osName < other.osName;
+        }
+    };
+
+    struct Stats
+    {
+        Counters counters{};
+        std::map<ContextPathItem, Stats> children{};
+
+        void AsJSON(CPLJSONObject& oJSON) const;
+    };
+
+    Stats m_stats{};
+    std::map<GIntBig, std::vector<ContextPathItem>> m_mapThreadIdToContextPath{};
+
+    static void ReadEnabled();
+
+    std::vector<Counters*> GetCountersForContext();
+
+public:
+
+    static inline bool IsEnabled()
+    {
+        if( gnEnabled < 0)
+        {
+            ReadEnabled();
+        }
+        return gnEnabled == TRUE;
+    }
+
+    static void EnterFileSystem(const char* pszName);
+
+    static void LeaveFileSystem();
+
+    static void EnterFile(const char* pszName);
+
+    static void LeaveFile();
+
+    static void EnterAction(const char* pszName);
+
+    static void LeaveAction();
+
+    static void LogHEAD();
+
+    static void LogGET(size_t nDownloadedBytes);
+
+    static void LogPUT(size_t nUploadedBytes);
+
+    static void LogPOST(size_t nUploadedBytes,
+                        size_t nDownloadedBytes);
+
+    static void LogDELETE();
+
+    static void Reset();
+
+    static CPLString GetReportAsSerializedJSON();
+};
+
+struct NetworkStatisticsFileSystem
+{
+    inline explicit NetworkStatisticsFileSystem(const char* pszName) {
+        NetworkStatisticsLogger::EnterFileSystem(pszName);
+    }
+
+    inline ~NetworkStatisticsFileSystem()
+    {
+        NetworkStatisticsLogger::LeaveFileSystem();
+    }
+};
+
+struct NetworkStatisticsFile
+{
+    inline explicit NetworkStatisticsFile(const char* pszName) {
+        NetworkStatisticsLogger::EnterFile(pszName);
+    }
+
+    inline ~NetworkStatisticsFile()
+    {
+        NetworkStatisticsLogger::LeaveFile();
+    }
+};
+
+struct NetworkStatisticsAction
+{
+    inline explicit NetworkStatisticsAction(const char* pszName) {
+        NetworkStatisticsLogger::EnterAction(pszName);
+    }
+
+    inline ~NetworkStatisticsAction()
+    {
+        NetworkStatisticsLogger::LeaveAction();
+    }
+};
+
 
 int VSICURLGetDownloadChunkSize();
 

--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -184,6 +184,8 @@ void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* psz
 %rename (FileFromMemBuffer) wrapper_VSIFileFromMemBuffer;
 %rename (Unlink) VSIUnlink;
 %rename (HasThreadSupport) wrapper_HasThreadSupport;
+%rename (NetworkStatsReset) VSINetworkStatsReset;
+%rename (NetworkStatsGetAsSerializedJSON) VSINetworkStatsGetAsSerializedJSON;
 
 retStringAndCPLFree*
 GOA2GetAuthorizationURL( const char *pszScope );
@@ -773,6 +775,9 @@ void VSIStdoutUnsetRedirection()
 
 void VSICurlClearCache();
 void VSICurlPartialClearCache( const char* utf8_path );
+
+void VSINetworkStatsReset();
+retStringAndCPLFree* VSINetworkStatsGetAsSerializedJSON( char** options = NULL );
 
 #endif /* !defined(SWIGJAVA) */
 

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -13017,6 +13017,101 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_NetworkStatsReset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  
+  if (!PyArg_ParseTuple(args,(char *)":NetworkStatsReset")) SWIG_fail;
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      VSINetworkStatsReset();
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NetworkStatsGetAsSerializedJSON(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  char **arg1 = (char **) NULL ;
+  PyObject * obj0 = 0 ;
+  retStringAndCPLFree *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"|O:NetworkStatsGetAsSerializedJSON",&obj0)) SWIG_fail;
+  if (obj0) {
+    {
+      /* %typemap(in) char **options */
+      int bErr = FALSE;
+      arg1 = CSLFromPySequence(obj0, &bErr);
+      if( bErr )
+      {
+        SWIG_fail;
+      }
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (retStringAndCPLFree *)VSINetworkStatsGetAsSerializedJSON(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    /* %typemap(out) (retStringAndCPLFree*) */
+    Py_XDECREF(resultobj);
+    if(result)
+    {
+      resultobj = GDALPythonObjectFromCStr( (const char *)result);
+      CPLFree(result);
+    }
+    else
+    {
+      resultobj = Py_None;
+      Py_INCREF(resultobj);
+    }
+  }
+  {
+    /* %typemap(freearg) char **options */
+    CSLDestroy( arg1 );
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  {
+    /* %typemap(freearg) char **options */
+    CSLDestroy( arg1 );
+  }
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ParseCommandLine(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   char *arg1 = (char *) 0 ;
@@ -41590,6 +41685,8 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"VSIFWriteL", _wrap_VSIFWriteL, METH_VARARGS, (char *)"VSIFWriteL(int nLen, int size, int memb, VSILFILE fp) -> int"},
 	 { (char *)"VSICurlClearCache", _wrap_VSICurlClearCache, METH_VARARGS, (char *)"VSICurlClearCache()"},
 	 { (char *)"VSICurlPartialClearCache", _wrap_VSICurlPartialClearCache, METH_VARARGS, (char *)"VSICurlPartialClearCache(char const * utf8_path)"},
+	 { (char *)"NetworkStatsReset", _wrap_NetworkStatsReset, METH_VARARGS, (char *)"NetworkStatsReset()"},
+	 { (char *)"NetworkStatsGetAsSerializedJSON", _wrap_NetworkStatsGetAsSerializedJSON, METH_VARARGS, (char *)"NetworkStatsGetAsSerializedJSON(char ** options=None) -> retStringAndCPLFree *"},
 	 { (char *)"ParseCommandLine", _wrap_ParseCommandLine, METH_VARARGS, (char *)"ParseCommandLine(char const * utf8_path) -> char **"},
 	 { (char *)"MajorObject_GetDescription", _wrap_MajorObject_GetDescription, METH_VARARGS, (char *)"MajorObject_GetDescription(MajorObject self) -> char const *"},
 	 { (char *)"MajorObject_SetDescription", _wrap_MajorObject_SetDescription, METH_VARARGS, (char *)"MajorObject_SetDescription(MajorObject self, char const * pszNewDesc)"},

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -1832,6 +1832,14 @@ def VSICurlPartialClearCache(*args):
     """VSICurlPartialClearCache(char const * utf8_path)"""
     return _gdal.VSICurlPartialClearCache(*args)
 
+def NetworkStatsReset(*args):
+    """NetworkStatsReset()"""
+    return _gdal.NetworkStatsReset(*args)
+
+def NetworkStatsGetAsSerializedJSON(*args):
+    """NetworkStatsGetAsSerializedJSON(char ** options=None) -> retStringAndCPLFree *"""
+    return _gdal.NetworkStatsGetAsSerializedJSON(*args)
+
 def ParseCommandLine(*args):
     """ParseCommandLine(char const * utf8_path) -> char **"""
     return _gdal.ParseCommandLine(*args)


### PR DESCRIPTION
* Add VSINetworkStatsGetAsSerializedJSON() to return collected
  statistics as a JSON serialized string

  e.g.
```json
       {
            "methods": {
                "PUT": {
                    "count": 1,
                    "uploaded_bytes": 6
                }
            },
            "handlers": {
                "vsis3": {
                    "files": {
                        "/vsis3/s3_fake_bucket3/another_file.bin": {
                            "methods": {
                                "PUT": {
                                    "count": 1,
                                    "uploaded_bytes": 6
                                }
                            },
                            "actions": {
                                "Write": {
                                    "methods": {
                                        "PUT": {
                                            "count": 1,
                                            "uploaded_bytes": 6
                                        }
                                    }
                                }
                            }
                        }
                    },
                    "methods": {
                        "PUT": {
                            "count": 1,
                            "uploaded_bytes": 6
                        }
                    }
                }
            }
        }
```

  Statistics collecting should be enabled with the CPL_VSIL_NETWORK_STATS_ENABLED
  configuration option set to YES before any network activity starts
  (for efficiency, reading it is cached on first access, until VSINetworkStatsReset() is called)

  Statistics can also be emitted on standard output at process termination if
  the CPL_VSIL_SHOW_NETWORK_STATS configuration option is set to YES.

* Add VSINetworkStatsReset() to clear statistics

* Map both functions to SWIG
