### PR TITLE
OSR: fix issue with PROJ context and OSRCleanup() (fixes #2744)

### DIFF
--- a/autotest/cpp/test_osr_set_proj_search_paths.cpp
+++ b/autotest/cpp/test_osr_set_proj_search_paths.cpp
@@ -61,6 +61,30 @@ static void func2(void*)
     OSRDestroySpatialReference(hSRS);
 }
 
+static void func3(void*)
+{
+    OGRSpatialReferenceH hSRS = OSRNewSpatialReference(nullptr);
+    if( OSRImportFromEPSG(hSRS, 32631) != OGRERR_NONE )
+    {
+        fprintf(stderr, "failure not expected (3)\n");
+        exit(1);
+    }
+
+    // Test cleanup effect
+    OSRCleanup();
+
+    for(int epsg = 32601; epsg <= 32661; epsg++ )
+    {
+        if( OSRImportFromEPSG(hSRS, epsg) != OGRERR_NONE ||
+            OSRImportFromEPSG(hSRS, epsg+100) != OGRERR_NONE )
+        {
+            fprintf(stderr, "failure not expected (4)\n");
+            exit(1);
+        }
+    }
+    OSRDestroySpatialReference(hSRS);
+}
+
 int main()
 {
     auto tokens = OSRGetPROJSearchPaths();
@@ -87,6 +111,17 @@ int main()
 
     CSLDestroy(tokens);
     OSRCleanup();
+
+    // Test fix for #2744
+    CPLJoinableThread* ahThreads[4];
+    for( int i = 0; i< 4; i++ )
+    {
+        ahThreads[i] = CPLCreateJoinableThread(func3, nullptr);
+    }
+    for( int i = 0; i< 4; i++ )
+    {
+        CPLJoinThread(ahThreads[i]);
+    }
 
     return 0;
 }

--- a/gdal/ogr/ogr_proj_p.cpp
+++ b/gdal/ogr/ogr_proj_p.cpp
@@ -113,6 +113,7 @@ OSRPJContextHolder::~OSRPJContextHolder()
 
 void OSRPJContextHolder::deinit()
 {
+    searchPathGenerationCounter = 0;
     oCache.clear();
 
     // Destroy context in last
@@ -196,6 +197,10 @@ static OSRPJContextHolder& GetProjTLSContextHolder()
 PJ_CONTEXT* OSRGetProjTLSContext()
 {
     auto& l_projContext = GetProjTLSContextHolder();
+    // This .init() must be kept, even if OSRPJContextHolder constructor
+    // calls it. The reason is that OSRCleanupTLSContext() calls deinit(),
+    // so if reusing the object, we must re-init again.
+    l_projContext.init();
     {
         // If OSRSetPROJSearchPaths() has been called since we created the context,
         // set the new search paths on the context.


### PR DESCRIPTION
Fix a bug affecting PostGIS raster (#2744), and much likely GMT
(https://lists.osgeo.org/pipermail/gdal-dev/2020-July/052381.html)

If OSRCleanup() was called, deinit() was called on the
current OSRPJContextHolder object, but due to https://github.com/OSGeo/gdal/commit/e873aa230b2f960b9d5076d3849870c00387f096
that removed init(), the PROJ context was let at nullptr if
OSRGetProjTLSContext() was called afterwards. This could result
in a crash in PROJ due to a bug into it, for example if OGRSpatialReference::Clone()
was called , or more subtely to potential thread issues if OSRCleanup()
would be called in several threads using OSR API (due to the default nullptr
PROJ context being used concurrently)
