### PR TITLE
gdalinfo: allow list of cli-style string 

### DIFF
--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -114,6 +114,7 @@ def test_gdalinfo_lib_6():
 
     ret = gdal.Info('../gcore/data/byte.tif', options='-json')
     assert ret['driverShortName'] == 'GTiff', 'wrong value for driverShortName.'
+    assert type(ret) == dict
 
 ###############################################################################
 # Test with unicode strings
@@ -123,6 +124,17 @@ def test_gdalinfo_lib_7():
 
     ret = gdal.Info('../gcore/data/byte.tif'.encode('ascii').decode('ascii'), options='-json'.encode('ascii').decode('ascii'))
     assert ret['driverShortName'] == 'GTiff', 'wrong value for driverShortName.'
+    assert type(ret) == dict
+
+###############################################################################
+# Test with list of strings
+
+
+def test_gdalinfo_lib_8():
+
+    ret = gdal.Info('../gcore/data/byte.tif', options=['-json'])
+    assert ret['driverShortName'] == 'GTiff', 'wrong value for driverShortName.'
+    assert type(ret) == dict
 
 ###############################################################################
 

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1206,6 +1206,8 @@ def InfoOptions(options=None, format='text', deserialize=True,
         new_options = options
         if format == 'json':
             new_options += ['-json']
+        if '-json' in new_options:
+            format = 'json'
         if computeMinMax:
             new_options += ['-mm']
         if reportHistograms:

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -223,6 +223,8 @@ def InfoOptions(options=None, format='text', deserialize=True,
         new_options = options
         if format == 'json':
             new_options += ['-json']
+        if '-json' in new_options:
+            format = 'json'
         if computeMinMax:
             new_options += ['-mm']
         if reportHistograms:


### PR DESCRIPTION
## What does this PR do?

The python gdalinfo call should be able to accept cli-style args as either a string or a list of strings. However, in order to return results in json format, the format arg must be explicitly set. This happens when providing a single string of arguments for options but NOT for a list of strings.

This fixes the issue by setting format directly, checking if '-json' is in new_options (allowing it to be set directly with the format option or to be an option in a string list) and modifies/adds tests to confirm that it works properly. The fix was made to the swig interface and includes the resulting gdal.py

Test case added that would fail with the old setup but works now: https://github.com/OSGeo/gdal/commit/fa7ba8d3ae0c7d27c7848038b88d0ad376ee22a7#diff-4af94d498c1e509ba178f04b7758bedeR133-R137

## What are related issues/pull requests?

N/A

## Tasklist

 - [x] Regenerated python swig bindings
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
