### PR TITLE
DOC: expand general docs for -ot, except gdal_proximity.py [skip ci]

### DIFF
--- a/gdal/doc/source/programs/gdal_proximity.rst
+++ b/gdal/doc/source/programs/gdal_proximity.rst
@@ -17,7 +17,7 @@ Synopsis
 
     gdal_proximity.py <srcfile> <dstfile> [-srcband n] [-dstband n]
                       [-of format] [-co name=value]*
-                      [-ot Byte/Int16/Int32/Float32/etc]
+                      [-ot Byte/UInt16/UInt32/Float32/etc]
                       [-values n,n,n] [-distunits PIXEL/GEO]
                       [-maxdist n] [-nodata n] [-use_input_nodata YES/NO]
                       [-fixed-buf-val n]
@@ -54,7 +54,11 @@ raster for which the raster pixel value is in the set of target pixel values.
 
 .. include:: options/co.rst
 
-.. include:: options/ot.rst
+.. option:: -ot <type>
+
+    Specify a data type supported by the driver, which may be one of the
+    following: ``Byte``, ``UInt16``, ``Int16``, ``UInt32``, ``Int32``,
+    ``Float32`` (default), or ``Float64``.
 
 .. option:: -values <n>,<n>,<n>
 

--- a/gdal/doc/source/programs/options/ot.rst
+++ b/gdal/doc/source/programs/options/ot.rst
@@ -1,4 +1,6 @@
 .. option:: -ot <type>
 
-    Force the output image bands to have a specific type. Use type names
-    (i.e. ``Byte``, ``Int16``,...)
+    Force the output image bands to have a specific data type supported by the
+    driver, which may be one of the following: ``Byte``, ``UInt16``,
+    ``Int16``, ``UInt32``, ``Int32``, ``Float32``, ``Float64``, ``CInt16``,
+    ``CInt32``, ``CFloat32`` or ``CFloat64``.

--- a/gdal/swig/python/scripts/gdal_proximity.py
+++ b/gdal/swig/python/scripts/gdal_proximity.py
@@ -40,7 +40,7 @@ def Usage():
     print("""
 gdal_proximity.py srcfile dstfile [-srcband n] [-dstband n]
                   [-of format] [-co name=value]*
-                  [-ot Byte/Int16/Int32/Float32/etc]
+                  [-ot Byte/UInt16/UInt32/Float32/etc]
                   [-values n,n,n] [-distunits PIXEL/GEO]
                   [-maxdist n] [-nodata n] [-use_input_nodata YES/NO]
                   [-fixed-buf-val n] [-q] """)


### PR DESCRIPTION
Two related but separate documentation edits are done here:

* The general documentation for `-ot` is expanded to the complete list of datatypes supported by GDAL conditioned with "supported by the driver" (I assume the driver will log/raise and exception if a chosen data type is not supported).
* The documentation for `-ot` for `gdal_proximity.py` is detailed separately, as it should recommend a subset of these data types and document the default of Float32. Unsigned integer types should be preferred, since proximity results are positive, so this is reflected in a change with the command usage information.