### PR TITLE
Adding ODA lib requirements to compile GDAL with ODA 2021

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -38347,14 +38347,30 @@ fi
         HAVE_TEIGHA=yes
         TEIGHA_PLT=$with_teigha_plt
         LIBS="${LIBS} ${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TG_Db.tx"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TD_DbEntities.tx"; then
+            LIBS="${LIBS} ${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TD_DbEntities.tx"
+            LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_DrawingsExamplesCommon.a"
+        fi
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTG_ExamplesCommon.a"
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_ExamplesCommon.a"
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_Key.a"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Db"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/libTD_DbCore.*"; then
+            LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_DbCore"
+        fi
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_DbRoot"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Gi"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_SpatialIndex"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Root"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Ge"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/libTD_Zlib.*"; then
+            LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Zlib"
+        fi
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Alloc"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -loless"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/liblibcrypto.*"; then
+            LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -llibcrypto"
+        fi
         if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/libTD_Db.so"; then
             TEIGHA_CPPFLAGS="-D_TOOLKIT_IN_DLL_"
         fi

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -4387,14 +4387,22 @@ else
         HAVE_TEIGHA=yes
         TEIGHA_PLT=$with_teigha_plt
         LIBS="${LIBS} ${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TG_Db.tx"
+        LIBS="${LIBS} ${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TD_DbEntities.tx"
+        LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_DrawingsExamplesCommon.a"
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTG_ExamplesCommon.a"
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_ExamplesCommon.a"
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_Key.a"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Db"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_DbCore"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_DbRoot"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Gi"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_SpatialIndex"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Root"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Ge"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Zlib"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Alloc"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -loless"
+        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -llibcrypto"
         if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/libTD_Db.so"; then
             TEIGHA_CPPFLAGS="-D_TOOLKIT_IN_DLL_"
         fi

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -4387,22 +4387,30 @@ else
         HAVE_TEIGHA=yes
         TEIGHA_PLT=$with_teigha_plt
         LIBS="${LIBS} ${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TG_Db.tx"
-        LIBS="${LIBS} ${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TD_DbEntities.tx"
-        LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_DrawingsExamplesCommon.a"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TD_DbEntities.tx"; then
+            LIBS="${LIBS} ${TEIGHA_DIR}/bin/${TEIGHA_PLT}/TD_DbEntities.tx"
+            LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_DrawingsExamplesCommon.a"
+        fi
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTG_ExamplesCommon.a"
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_ExamplesCommon.a"
         LIBS="${LIBS} ${TEIGHA_DIR}/lib/${TEIGHA_PLT}/libTD_Key.a"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Db"
-        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_DbCore"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/libTD_DbCore.*"; then
+            LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_DbCore"
+        fi
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_DbRoot"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Gi"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_SpatialIndex"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Root"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Ge"
-        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Zlib"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/libTD_Zlib.*"; then
+            LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Zlib"
+        fi
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -lTD_Alloc"
         LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -loless"
-        LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -llibcrypto"
+        if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/liblibcrypto.*"; then
+            LIBS="${LIBS} -L${TEIGHA_DIR}/bin/${TEIGHA_PLT} -llibcrypto"
+        fi
         if test -f "${TEIGHA_DIR}/bin/${TEIGHA_PLT}/libTD_Db.so"; then
             TEIGHA_CPPFLAGS="-D_TOOLKIT_IN_DLL_"
         fi

--- a/gdal/doc/source/drivers/vector/dgnv8.rst
+++ b/gdal/doc/source/drivers/vector/dgnv8.rst
@@ -149,6 +149,12 @@ The layer creation supports the following options:
 -  **DIM=**\ *2/3*: Dimension (ie 2D vs 3D) of the layer. By default, 3,
    unless the model is reused from the seed file.
 
+
+Building
+--------
+
+See :ref:`ODA platform support <vector.oda>` for building GDAL with ODA support.
+
 --------------
 
 -  :ref:`DGN (v7) driver <vector.dgn>`

--- a/gdal/doc/source/drivers/vector/dgnv8.rst
+++ b/gdal/doc/source/drivers/vector/dgnv8.rst
@@ -155,6 +155,11 @@ Building
 
 See :ref:`ODA platform support <vector.oda>` for building GDAL with ODA support.
 
+.. toctree::
+   :hidden:
+
+   oda
+
 --------------
 
 -  :ref:`DGN (v7) driver <vector.dgn>`

--- a/gdal/doc/source/drivers/vector/dwg.rst
+++ b/gdal/doc/source/drivers/vector/dwg.rst
@@ -63,6 +63,4 @@ will be available via the blocks layer.
 Building
 --------
 
-Currently DWG building is somewhat adhoc. On linux the normal practice
-is to hand edit gdal/ogr/ogrsf_frmts/dwg/GNUmakefile, update paths, and
-then build the driver as a plugin using the "make plugin" target.
+See :ref:`ODA platform support <vector.oda>` for building GDAL with ODA support.

--- a/gdal/doc/source/drivers/vector/index.rst
+++ b/gdal/doc/source/drivers/vector/index.rst
@@ -83,7 +83,6 @@ Vector drivers
    ntf
    oapif
    oci
-   oda
    odbc
    ods
    ogdi

--- a/gdal/doc/source/drivers/vector/index.rst
+++ b/gdal/doc/source/drivers/vector/index.rst
@@ -83,6 +83,7 @@ Vector drivers
    ntf
    oapif
    oci
+   oda
    odbc
    ods
    ogdi

--- a/gdal/doc/source/drivers/vector/oda.rst
+++ b/gdal/doc/source/drivers/vector/oda.rst
@@ -1,0 +1,186 @@
+.. _vector.oda:
+
+Open Design Alliance - ODA Platform
+===================================
+
+ODA Platform (previously named Teigha) is required to enable GDAL support for reading AutoCAD DWG and Microstation DGN v8 files. 
+GDAL/OGR must be built with ODA support in order to enable these drivers.
+
+ODA required products
+---------------------
+
+ODA Platform includes several SDK. Drawings SDK provides access to all data in .dwg and .dgn through an object-oriented API. It is required to compile GDAL. 
+Since Kernel SDK is required by all products, these two products must be downloaded:
+
+-  Kernel
+-  Drawings
+
+These libraries are not publicly available. You have to became a member to get access to the libraries. 
+Upon authentication the libraries are available from: 
+`ODA Member Downloads <https://www.opendesign.com/members/memberfiles>`__
+
+Get the libraries
+-----------------
+
+To selected the appropriate files to download, consider the following ODA name conventions (for Linux):
+
+-  lnx - Linux
+-  X86, X64 - indicates X86 or X64 platform
+-  4.4, 4.7, 4.8, 4.9, 5.2, 5.3, 6.3, 7.2, 8.3 - GCC versions
+-  dll - indicates a shared library version
+-  pic - compiled with Position Independent Code option
+
+ODA archives also contains a release suffix in order to distinguish between releases, like 21.2 or 21.6.
+
+To download the required files for Linux, the following files could be downloaded:
+
+-  `Kernel_lnxX64_7.2dll_21.6.tar.gz`
+-  `Drawings_lnxX64_7.2dll_21.6.tar.gz`
+
+In this example, the files names are:
+
+-  `lnx` for Linux
+-  `X64` for X64 architecture
+-  `7.2` for gcc 7.2
+-  `dll` for shared library version
+-  `21.6` ODA 2021 release, build 6
+
+Compiling the libraries
+-----------------------
+
+The libraries must be merged before compiling.
+
+.. code:: bash
+
+   cd ~/dev/cpp/ODA21.6
+   mkdir base_7.2
+   tar xvzf Kernel_lnxX64_7.2dll_21.6.tar.gz -C base_7.2
+   tar xvzf Drawings_lnxX64_7.2dll_21.6.tar.gz -C base_7.2
+
+To compile, an activation key is required. It can be requested from ODA Products Activation. 
+The activation key must be copied to `ThirdParty/activation/`.
+
+::
+
+   cp OdActivationInfo base_7.2/ThirdParty/activation/
+
+Compile the ODA libraries with:
+
+::
+
+   cd base_7.2
+   ./configure
+   make -j8
+
+Make sure your gcc major version matches ODA libs gcc version. On Ubuntu, for example, you can install different gcc/g++ versions, like 7, 8 and 9. Switch between them with:
+
+::
+
+   sudo update-alternatives --config gcc
+   sudo update-alternatives --config g++
+
+ODA libraries path
+------------------
+
+After compiling ODA, the resulting libs are in a non standard search path. 
+There is no `make install` included to copy the libraries to a standard location.
+This might be an issue.
+
+You have different alternative options to compile and run GDAL/OGR with ODA:
+
+-  set LD_LIBRARY_PATH (like `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll`).
+-  Adding ODA folder to the system library path (`echo "/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll" | sudo tee -a /etc/ld.so.conf.d/z_gdal-ODA.conf`)
+-  Setting a run time path (`rpath`) when compiling GDAL (like `LDFLAGS="-Wl,-rpath=/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll"`).
+
+Compiling GDAL
+--------------
+
+After compiling ODA libraries, GDAL can be build using two additional options:
+
+-  `--with-teigha=/home/jgr/dev/cpp/ODA21.6/base_7.2`
+-  `--with-teigha-plt=lnxX64_7.2dll`
+
+The value of `--with-teigha` is the full path of the folder where the libraries were merged and compiled.
+
+The value of `--with-teigha-plt` must match the platform name used by ODA. The platform name is the folder name under `Platforms`:
+
+::
+
+   ls -l Platforms/
+   lnxX64_7.2dll
+
+GDAL compilation
+----------------
+
+Use your own GDAL build configuration and add the previous mentioned options. After running `configure`, make sure that `Teigha (DWG and DGNv8)` support is configured.
+
+As an example, compiling GDAL can be:
+
+::
+
+   cd gdal
+   ./autogen.sh
+   ./configure --without-libtool LDFLAGS="-L/usr/lib/x86_64-linux-gnu" --with-python=python3 --with-proj=/usr/local --with-pg=yes --with-poppler --with-teigha=/home/jgr/dev/cpp/ODA21.6/base_7.2 --with-teigha-plt=lnxX64_7.2dll  
+   make -j8
+   sudo make install
+   sudo ldconfig
+   # Python support
+   cd swig/python
+   python3 setup.py build
+   sudo python3 setup.py install   
+
+We added `LDFLAGS="-L/usr/lib/x86_64-linux-gnu"` to use system libs over ODA's `libpcre`, `libcurl`, etc.
+
+Testing
+-------
+
+After compiling GDAL, you can check if the new drivers `DGNV8` and `DWG` are supported with:
+
+::
+
+   ./apps/ogrinfo --formats | grep 'AutoCAD\|Microstation'
+   DGN -vector- (rw+v): Microstation DGN
+   DWG -vector- (ro): AutoCAD DWG
+   DGNV8 -vector- (rw+): Microstation DGNv8
+   DXF -vector- (rw+v): AutoCAD DXF
+   CAD -raster,vector- (rovs): AutoCAD Driver
+
+If a file is DGNv8, you will see that driver in action when opening the file:
+
+::
+
+   ogrinfo 275_2_13_MNT.dgn
+   INFO: Open of `275_2_13_MNT.dgn'
+      using driver `DGNV8' successful.
+   1: Model-1
+   2: LouriceiraMesmoFinal
+
+Troubleshooting
+---------------
+
+If you find linking errors, you can set `LD_LIBRARY_PATH` or `LDFLAGS` environment variables to make sure you are able to get the ODA libraries from their location.
+
+Use `ldconfig -v` to check if ODA's library folder is listed.
+
+For example, you can try:
+
+::
+
+   export LD_LIBRARY_PATH=/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll
+   ./configure --without-libtool LDFLAGS="-L/usr/lib/x86_64-linux-gnu" --with-python=python3 --with-proj=/usr/local --with-pg=yes --with-poppler --with-teigha=/home/jgr/dev/cpp/ODA21.6/base_7.2 --with-teigha-plt=lnxX64_7.2dll   
+
+You can force a run time location (with `rpath`) with:
+
+::
+
+   ./configure --without-libtool LDFLAGS="-L/usr/lib/x86_64-linux-gnu -Wl,-rpath=/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll" --with-python=python3 --with-proj=/usr/local --with-pg=yes --with-poppler --with-teigha=/home/jgr/dev/cpp/ODA21.6/base_7.2 --with-teigha-plt=lnxX64_7.2dll   
+
+
+Adjust these settings, according to your build environment.
+
+See Also
+--------
+
+-  `Introducing the ODA Platform <https://www.opendesign.com/products>`__
+-  :ref:`AutoCAD DWG <vector.dwg>`
+-  :ref:`Microstation DGN v8 <vector.dgnv8>`

--- a/gdal/doc/source/drivers/vector/oda.rst
+++ b/gdal/doc/source/drivers/vector/oda.rst
@@ -93,6 +93,24 @@ You have different alternative options to compile and run GDAL/OGR with ODA:
 -  Adding ODA folder to the system library path (`echo "/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll" | sudo tee -a /etc/ld.so.conf.d/z_gdal-ODA.conf`)
 -  Setting a run time path (`rpath`) when compiling GDAL (like `LDFLAGS="-Wl,-rpath=/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll"`).
 
+
+ODA library names
+
+Some ODA library names do not conform the usual Linux standard `lib*.so`. If you don't use `rpath`, for the other alternatives listed above, you might have to create symbolic links from the actual names. Example:
+
+::
+
+   cd ~/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll
+   for f in *.tx
+   do
+      echo "Processing $f"
+      ln -s $f lib$f.so
+   done
+   sudo ldconfig
+
+Check with `ldconfig -v` if all ODA libraries are now visible.
+
+
 Compiling GDAL
 --------------
 
@@ -150,11 +168,10 @@ If a file is DGNv8, you will see that driver in action when opening the file:
 
 ::
 
-   ogrinfo 275_2_13_MNT.dgn
-   INFO: Open of `275_2_13_MNT.dgn'
-      using driver `DGNV8' successful.
-   1: Model-1
-   2: LouriceiraMesmoFinal
+   ogrinfo ~/dev/cpp/gdal/autotest/ogr/data/dgnv8/test_dgnv8.dgn
+   INFO: Open of `/home/jgr/dev/cpp/gdal/autotest/ogr/data/dgnv8/test_dgnv8.dgn'
+         using driver `DGNV8' successful.
+   1: my_model
 
 Troubleshooting
 ---------------
@@ -177,7 +194,7 @@ You can force a run time location (with `rpath`) with:
    ./configure --without-libtool LDFLAGS="-L/usr/lib/x86_64-linux-gnu -Wl,-rpath=/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll" --with-python=python3 --with-proj=/usr/local --with-pg=yes --with-poppler --with-teigha=/home/jgr/dev/cpp/ODA21.6/base_7.2 --with-teigha-plt=lnxX64_7.2dll   
 
 
-Adjust these settings, according to your build environment.
+Adjust these settings, according to your build environment. 
 
 See Also
 --------

--- a/gdal/doc/source/drivers/vector/oda.rst
+++ b/gdal/doc/source/drivers/vector/oda.rst
@@ -88,6 +88,7 @@ This might be an issue.
 
 You have different alternative options to compile and run GDAL/OGR with ODA:
 
+-  copy the ODA libraries to a standard location
 -  set LD_LIBRARY_PATH (like `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll`).
 -  Adding ODA folder to the system library path (`echo "/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll" | sudo tee -a /etc/ld.so.conf.d/z_gdal-ODA.conf`)
 -  Setting a run time path (`rpath`) when compiling GDAL (like `LDFLAGS="-Wl,-rpath=/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll"`).

--- a/gdal/ogr/ogrsf_frmts/dwg/GNUmakefile
+++ b/gdal/ogr/ogrsf_frmts/dwg/GNUmakefile
@@ -3,6 +3,12 @@ TDXXFLAGS = \
 	-I$(TEIGHA_DIR)/Core/Include \
 	-I$(TEIGHA_DIR)/Core/Extensions/ExServices \
 	-I$(TEIGHA_DIR)/Core/Examples/Common \
+	-I$(TEIGHA_DIR)/ThirdParty/activation \
+	-I$(TEIGHA_DIR)/KernelBase/Include \
+	-I$(TEIGHA_DIR)/Kernel/Include \
+	-I$(TEIGHA_DIR)/Kernel/Extensions/ExServices \
+	-I$(TEIGHA_DIR)/Drawing/Include \
+	-I$(TEIGHA_DIR)/Drawing/Extensions/ExServices \
 	-I$(TEIGHA_DIR)/Dgn/include \
 	-I$(TEIGHA_DIR)/Dgn/Extensions/ExServices
 


### PR DESCRIPTION
## What does this PR do?

This PR adds support for current ODA versions. ODA is a proprietary library from [Open Design Alliance](https://www.opendesign.com/products).

The previous [commit](https://github.com/OSGeo/gdal/commit/0b85844a85ddf0feee424fd05f92bc4a3604d577), regarding ODA support has more than 3 years now.

This PR also adds building instructions to compile GDAL/OGR with ODA support.

### Requirements

To compile GDAL with ODA 2021, two ODA libraries are required (Kernel and Drawings). These libraries must be merged and compiled before building GDAL.

### Merging ODA Kernel and Drawings libraries

```bash
cd ~/dev/cpp/ODA2021.2
mkdir base_7.2
tar xvzf Kernel_lnxX64_7.2dll.tar.gz -C base_7.2
tar xvzf Drawings_lnxX64_7.2dll.tar.gz -C base_7.2
```

### Compiling ODA libraries

To compile, an activation key is required. It can be requested from [ODA Products Activation](https://www.opendesign.com/members/activation). The activation key must be copied to `ThirdParty/activation/` folder.

```bash
cp OdActivationInfo base_7.2/ThirdParty/activation/
```

```bash
cd base_7.2
./configure
make -j8
```

### Compiling GDAL

After compiling ODA libraries, GDAL can be build using two additional options:
* `--with-teigha=/home/jgr/dev/cpp/ODA2021.2/base_7.2`
* `--with-teigha-plt=lnxX64_7.2dll`

Example:
```bash
./configure --without-libtool --with-python=python3 --with-proj=/usr/local --with-pg=yes --with-poppler --with-teigha=/home/jgr/dev/cpp/ODA2021.2/base_7.2 --with-teigha-plt=lnxX64_7.2dll
```

## What are related issues/pull requests?

Previous [commit](https://github.com/OSGeo/gdal/commit/0b85844a85ddf0feee424fd05f92bc4a3604d577) regarding ODA support, by @rouault 

## Tasklist

 - [X] Build documentation regarding ODA support
 - [x] All CI builds and checks have passed
-  [x] Added ODA documention to `doc/source/drivers/vector/index.rst` toctree (`make docs` was failing)

## Environment

Provide environment details, if relevant:

* OS: Tested on Ubuntu 18.04, 19.10
* Compiler: gcc 7.5.0, gcc 8.4.0
* Tested with ODA 2021, build 2 and build 6, for gcc 7.2 and 8.3

The gcc version must match ODA libraries gcc version. We used gcc 7.5.0 to compile ODA based on gcc 7.2; we used gcc 8.4.0 to compile ODA based on 8.3.
