### PR TITLE
Remove SWIG C# testing from trusty CI setup

### DIFF
--- a/gdal/ci/travis/trusty_clang/before_install.sh
+++ b/gdal/ci/travis/trusty_clang/before_install.sh
@@ -32,8 +32,6 @@ sudo apt-get install -y --allow-unauthenticated ccache libpng12-dev libjpeg-dev 
 # libgta-dev
 sudo apt-get install -y libqhull-dev
 sudo apt-get install -y libogdi3.2-dev
-# MONO
-sudo apt-get install -y mono-mcs libmono-system-drawing4.0-cil
 # Boost for Mongo
 #sudo apt-get install -y libboost-regex-dev libboost-system-dev libboost-thread-dev
 

--- a/gdal/ci/travis/trusty_clang/install.sh
+++ b/gdal/ci/travis/trusty_clang/install.sh
@@ -64,10 +64,6 @@ cd swig/perl
 make generate
 make
 cd ../..
-cd swig/csharp
-make generate
-make 2>/tmp/log.txt || cat /tmp/log.txt
-cd ../..
 sudo rm -f /usr/lib/libgdal.so*
 sudo rm -f /usr/include/gdal*.h /usr/include/ogr*.h /usr/include/gnm*.h /usr/include/cpl*.h 
 sudo make install

--- a/gdal/ci/travis/trusty_clang/script.sh
+++ b/gdal/ci/travis/trusty_clang/script.sh
@@ -17,9 +17,6 @@ cd ../..
 cd swig/java
 make test
 cd ../..
-cd swig/csharp
-make test
-cd ../..
 # CPP unit tests
 cd ../autotest
 cd cpp


### PR DESCRIPTION
Trusty has an old an unsupported version of Mono which fx. does not work with unsafe code that is planned to be introduced with.

In https://github.com/OSGeo/gdal/pull/2802 testing with a more up to date Mono is introduced in the new CI for Ubuntu 20.04.

This PR removes the old test setup for trusty.