### PR TITLE
buffered reader has configurable size, and makes reads filling whole buffer

### DIFF
--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -541,6 +541,7 @@ typedef struct {
     VSIFilesystemPluginFlushCallback            flush; /**< sync bytes (w) */
     VSIFilesystemPluginTruncateCallback         truncate; /**< truncate handle (w?) */
     VSIFilesystemPluginCloseCallback            close; /**< close handle  (rw) */
+    size_t                                      nBufferSize; /**< buffer small reads (makes handler read only) */
 /* 
     Callbacks are defined as a struct allocated by a call to VSIAllocFilesystemPluginCallbacksStruct
     in order to try to maintain ABI stability when eventually adding a new member.

--- a/gdal/port/cpl_vsi_virtual.h
+++ b/gdal/port/cpl_vsi_virtual.h
@@ -263,10 +263,11 @@ struct CPL_DLL VSIDIR
 
 #endif /* #ifndef DOXYGEN_SKIP */
 
-VSIVirtualHandle CPL_DLL *VSICreateBufferedReaderHandle(VSIVirtualHandle* poBaseHandle);
+VSIVirtualHandle CPL_DLL *VSICreateBufferedReaderHandle(VSIVirtualHandle* poBaseHandle, size_t bufferSize=65536);
 VSIVirtualHandle* VSICreateBufferedReaderHandle(VSIVirtualHandle* poBaseHandle,
                                                 const GByte* pabyBeginningContent,
-                                                vsi_l_offset nCheatFileSize);
+                                                vsi_l_offset nCheatFileSize,
+                                                size_t bufferSize=65536);
 VSIVirtualHandle CPL_DLL *VSICreateCachedFile( VSIVirtualHandle* poBaseHandle, size_t nChunkSize = 32768, size_t nCacheSize = 0 );
 
 const int CPL_DEFLATE_TYPE_GZIP = 0;

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -131,7 +131,11 @@ VSIVirtualHandle* VSIPluginFilesystemHandler::Open( const char *pszFilename,
         }
         return nullptr;
     }
-    return new VSIPluginHandle(this, cbData);
+    if ( m_cb->nBufferSize<=0 ) {
+        return new VSIPluginHandle(this, cbData);
+    } else {
+        return VSICreateBufferedReaderHandle(new VSIPluginHandle(this, cbData), m_cb->nBufferSize);
+    }
 }
 
 const char* VSIPluginFilesystemHandler::GetCallbackFilename(const char *pszFilename) {

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -131,7 +131,7 @@ VSIVirtualHandle* VSIPluginFilesystemHandler::Open( const char *pszFilename,
         }
         return nullptr;
     }
-    if ( m_cb->nBufferSize<=0 ) {
+    if ( m_cb->nBufferSize==0 ) {
         return new VSIPluginHandle(this, cbData);
     } else {
         return VSICreateBufferedReaderHandle(new VSIPluginHandle(this, cbData), m_cb->nBufferSize);


### PR DESCRIPTION
This PR modifies `VSIBufferedReaderHandle` so that it emits reads to its underlying `VSIVirtualHandle` that fill up the private buffer. The buffer size becomes configurable.