### PR TITLE
ogrshapedriver: do not claim to support DateTime data type

### DIFF
--- a/gdal/ogr/ogrsf_frmts/shape/ogrshapedriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/shape/ogrshapedriver.cpp
@@ -384,7 +384,7 @@ void RegisterOGRShape()
 "</LayerCreationOptionList>");
 
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,
-                               "Integer Integer64 Real String Date DateTime" );
+                               "Integer Integer64 Real String Date" );
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
 
     poDriver->pfnOpen = OGRShapeDriverOpen;


### PR DESCRIPTION
Shapefiles support Date, but not DateTime. This is leading to issues like https://github.com/qgis/QGIS/issues/38011 in QGIS.