### PR TITLE
GeoJSON writer: use JSON_C_TO_STRING_NOSLASHESCAPE when available to …

### DIFF
--- a/gdal/apps/gdalinfo_lib.cpp
+++ b/gdal/apps/gdalinfo_lib.cpp
@@ -1406,7 +1406,11 @@ char *GDALInfo( GDALDatasetH hDataset, const GDALInfoOptions *psOptions )
         json_object_object_add(poJsonObject, "bands", poBands);
         Concat(osStr, psOptions->bStdoutOutput, "%s",
                json_object_to_json_string_ext(poJsonObject,
-                                              JSON_C_TO_STRING_PRETTY));
+                                              JSON_C_TO_STRING_PRETTY
+#ifdef JSON_C_TO_STRING_NOSLASHESCAPE
+                                              | JSON_C_TO_STRING_NOSLASHESCAPE
+#endif
+                                             ));
         json_object_put(poJsonObject);
     }
 

--- a/gdal/ogr/ogrsf_frmts/geojson/libjson/json_object.c
+++ b/gdal/ogr/ogrsf_frmts/geojson/libjson/json_object.c
@@ -88,49 +88,71 @@ static void json_object_fini(void) {
 
 /* string escaping */
 
-static int json_escape_str(struct printbuf *pb, char *str, int len)
+static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int flags)
 {
-  int pos = 0, start_offset = 0;
-  unsigned char c;
-  while (len--) {
-    c = str[pos];
-    switch(c) {
-    case '\b':
-    case '\n':
-    case '\r':
-    case '\t':
-    case '\f':
-    case '"':
-    case '\\':
-    case '/':
-      if(pos - start_offset > 0)
-	printbuf_memappend(pb, str + start_offset, pos - start_offset);
-      if(c == '\b') printbuf_memappend(pb, "\\b", 2);
-      else if(c == '\n') printbuf_memappend(pb, "\\n", 2);
-      else if(c == '\r') printbuf_memappend(pb, "\\r", 2);
-      else if(c == '\t') printbuf_memappend(pb, "\\t", 2);
-      else if(c == '\f') printbuf_memappend(pb, "\\f", 2);
-      else if(c == '"') printbuf_memappend(pb, "\\\"", 2);
-      else if(c == '\\') printbuf_memappend(pb, "\\\\", 2);
-      else if(c == '/') printbuf_memappend(pb, "\\/", 2);
-      start_offset = ++pos;
-      break;
-    default:
-      if(c < ' ') {
-	if(pos - start_offset > 0)
-	  printbuf_memappend(pb, str + start_offset, pos - start_offset);
-	sprintbuf(pb, "\\u00%c%c",
-		  json_hex_chars[c >> 4],
-		  json_hex_chars[c & 0xf]);
-	start_offset = ++pos;
-      } else pos++;
-    }
-  }
-  if(pos - start_offset > 0)
-    printbuf_memappend(pb, str + start_offset, pos - start_offset);
-  return 0;
-}
+	int pos = 0, start_offset = 0;
+	unsigned char c;
+	while (len--)
+	{
+		c = str[pos];
+		switch (c)
+		{
+		case '\b':
+		case '\n':
+		case '\r':
+		case '\t':
+		case '\f':
+		case '"':
+		case '\\':
+		case '/':
+			if ((flags & JSON_C_TO_STRING_NOSLASHESCAPE) && c == '/')
+			{
+				pos++;
+				break;
+			}
 
+			if (pos - start_offset > 0)
+				printbuf_memappend(pb, str + start_offset, pos - start_offset);
+
+			if (c == '\b')
+				printbuf_memappend(pb, "\\b", 2);
+			else if (c == '\n')
+				printbuf_memappend(pb, "\\n", 2);
+			else if (c == '\r')
+				printbuf_memappend(pb, "\\r", 2);
+			else if (c == '\t')
+				printbuf_memappend(pb, "\\t", 2);
+			else if (c == '\f')
+				printbuf_memappend(pb, "\\f", 2);
+			else if (c == '"')
+				printbuf_memappend(pb, "\\\"", 2);
+			else if (c == '\\')
+				printbuf_memappend(pb, "\\\\", 2);
+			else if (c == '/')
+				printbuf_memappend(pb, "\\/", 2);
+
+			start_offset = ++pos;
+			break;
+		default:
+			if (c < ' ')
+			{
+				char sbuf[7];
+				if (pos - start_offset > 0)
+					printbuf_memappend(pb, str + start_offset,
+					                   pos - start_offset);
+				snprintf(sbuf, sizeof(sbuf), "\\u00%c%c", json_hex_chars[c >> 4],
+				         json_hex_chars[c & 0xf]);
+				printbuf_memappend_fast(pb, sbuf, (int)sizeof(sbuf) - 1);
+				start_offset = ++pos;
+			}
+			else
+				pos++;
+		}
+	}
+	if (pos - start_offset > 0)
+		printbuf_memappend(pb, str + start_offset, pos - start_offset);
+	return 0;
+}
 
 /* reference counting */
 
@@ -316,7 +338,7 @@ static int json_object_object_to_json_string(struct json_object* jso,
 			sprintbuf(pb, " ");
 		indent(pb, level+1, flags);
 		sprintbuf(pb, "\"");
-		json_escape_str(pb, iter.key, (int)strlen(iter.key));
+		json_escape_str(pb, iter.key, (int)strlen(iter.key), flags);
 		if (flags & JSON_C_TO_STRING_SPACED)
 			sprintbuf(pb, "\": ");
 		else
@@ -628,10 +650,10 @@ double json_object_get_double(struct json_object *jso)
 static int json_object_string_to_json_string(struct json_object* jso,
 					     struct printbuf *pb,
 					     CPL_UNUSED int level,
-                                             CPL_UNUSED int flags)
+                                             int flags)
 {
   sprintbuf(pb, "\"");
-  json_escape_str(pb, jso->o.c_string.str, jso->o.c_string.len);
+  json_escape_str(pb, jso->o.c_string.str, jso->o.c_string.len, flags);
   sprintbuf(pb, "\"");
   return 0;
 }

--- a/gdal/ogr/ogrsf_frmts/geojson/libjson/json_object.c
+++ b/gdal/ogr/ogrsf_frmts/geojson/libjson/json_object.c
@@ -92,8 +92,9 @@ static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int
 {
 	int pos = 0, start_offset = 0;
 	unsigned char c;
-	while (len--)
+	while (len)
 	{
+                len--;
 		c = str[pos];
 		switch (c)
 		{

--- a/gdal/ogr/ogrsf_frmts/geojson/libjson/json_object.h
+++ b/gdal/ogr/ogrsf_frmts/geojson/libjson/json_object.h
@@ -50,6 +50,11 @@ extern "C" {
  */
 #define JSON_C_TO_STRING_NOZERO     (1<<2)
 
+/**
+ * Don't escape forward slashes.
+ */
+#define JSON_C_TO_STRING_NOSLASHESCAPE (1 << 4)
+
 #undef FALSE
 #define FALSE ((json_bool)0)
 

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
@@ -195,7 +195,12 @@ OGRErr OGRGeoJSONWriteLayer::ICreateFeature( OGRFeature* poFeature )
         /* Separate "Feature" entries in "FeatureCollection" object. */
         VSIFPrintfL( fp, ",\n" );
     }
-    VSIFPrintfL( fp, "%s", json_object_to_json_string( poObj ) );
+    VSIFPrintfL( fp, "%s", json_object_to_json_string_ext( poObj,
+        JSON_C_TO_STRING_SPACED
+#ifdef JSON_C_TO_STRING_NOSLASHESCAPE
+        | JSON_C_TO_STRING_NOSLASHESCAPE
+#endif
+    ) );
 
     json_object_put( poObj );
 


### PR DESCRIPTION
…avoid escaping forward slash, and very partial resync of internal libjson-c to get it

CC @hobu