### PR TITLE
Addition of -tr option for gdal_grid

### DIFF
--- a/autotest/utilities/test_gdal_grid.py
+++ b/autotest/utilities/test_gdal_grid.py
@@ -888,6 +888,52 @@ def test_gdal_grid_clipsrc():
     ds = None
 
 ###############################################################################
+# Test -tr
+
+
+def test_gdal_grid_tr():
+    if gdal_grid is None:
+        pytest.skip()
+
+    #################
+    outfiles.append('tmp/grid_count_70_70.tif')
+    try:
+        os.remove(outfiles[-1])
+    except OSError:
+        pass
+
+    # Create a GDAL dataset from the values of "grid.csv".
+    gdaltest.runexternal(gdal_grid + ' -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -tr 60 60 -ot Byte -l grid -a count:radius1=70.0:radius2=70.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
+
+    # We should get the same values as in "ref_data/grid_count_70_70.tif"
+    ds = gdal.Open(outfiles[-1])
+    ds_ref = gdal.Open('ref_data/grid_count_70_70.tif')
+    assert ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum(), \
+        ('bad checksum : got %d, expected %d' %
+              (ds.GetRasterBand(1).Checksum(), ds_ref.GetRasterBand(1).checksum_ref))
+    ds_ref = None
+    ds = None
+
+    #################
+    outfiles.append('tmp/grid_count_300_300.tif')
+    try:
+        os.remove(outfiles[-1])
+    except OSError:
+        pass
+
+    # Create a GDAL dataset from the values of "grid.csv".
+    gdaltest.runexternal(gdal_grid + ' -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -tr 60 60 -ot Byte -l grid -a count:radius1=300.0:radius2=300.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
+
+    # We should get the same values as in "ref_data/grid_count_300_300.tif"
+    ds = gdal.Open(outfiles[-1])
+    ds_ref = gdal.Open('ref_data/grid_count_300_300.tif')
+    assert ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum(), \
+        ('bad checksum : got %d, expected %d' %
+              (ds.GetRasterBand(1).Checksum(), ds_ref.GetRasterBand(1).checksum_ref))
+    ds_ref = None
+    ds = None
+
+###############################################################################
 # Cleanup
 
 

--- a/autotest/utilities/test_gdal_grid.py
+++ b/autotest/utilities/test_gdal_grid.py
@@ -914,25 +914,6 @@ def test_gdal_grid_tr():
     ds_ref = None
     ds = None
 
-    #################
-    outfiles.append('tmp/grid_count_300_300.tif')
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
-
-    # Create a GDAL dataset from the values of "grid.csv".
-    gdaltest.runexternal(gdal_grid + ' -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -tr 60 60 -ot Byte -l grid -a count:radius1=300.0:radius2=300.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt ' + outfiles[-1])
-
-    # We should get the same values as in "ref_data/grid_count_300_300.tif"
-    ds = gdal.Open(outfiles[-1])
-    ds_ref = gdal.Open('ref_data/grid_count_300_300.tif')
-    assert ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum(), \
-        ('bad checksum : got %d, expected %d' %
-              (ds.GetRasterBand(1).Checksum(), ds_ref.GetRasterBand(1).checksum_ref))
-    ds_ref = None
-    ds = None
-
 ###############################################################################
 # Cleanup
 

--- a/gdal/apps/gdal_grid_bin.cpp
+++ b/gdal/apps/gdal_grid_bin.cpp
@@ -51,7 +51,7 @@ static void Usage(const char* pszErrorMsg = nullptr)
         "    [-clipsrcsql sql_statement] [-clipsrclayer layer]\n"
         "    [-clipsrcwhere expression]\n"
         "    [-l layername]* [-where expression] [-sql select_statement]\n"
-        "    [-txe xmin xmax] [-tye ymin ymax] [-outsize xsize ysize]\n"
+        "    [-txe xmin xmax] [-tye ymin ymax] [-tr xres yres] [-outsize xsize ysize]\n"
         "    [-a algorithm[:parameter1=value1]*]"
         "    [-q]\n"
         "    <src_datasource> <dst_filename>\n"

--- a/gdal/apps/gdal_grid_lib.cpp
+++ b/gdal/apps/gdal_grid_lib.cpp
@@ -845,7 +845,7 @@ GDALDatasetH GDALGrid( const char *pszDest, GDALDatasetH hSrcDataset,
             nXSize = static_cast<int>(dfXSize);
             nYSize = static_cast<int>(dfYSize);
         } else {
-            CPLError( CE_Failure, CPLE_AppDefined, "Invalid output size detected. Please check your -tr argument");
+            CPLError( CE_Failure, CPLE_IllegalArg, "Invalid output size detected. Please check your -tr argument");
 
             if(pbUsageError)
                 *pbUsageError = TRUE;
@@ -1137,7 +1137,7 @@ GDALGridOptions *GDALGridOptionsNew(char** papszArgv, GDALGridOptionsForBinary* 
         {
             psOptions->dfXRes = CPLAtofM(papszArgv[++i]);
             psOptions->dfYRes = CPLAtofM(papszArgv[++i]);
-            if( psOptions->dfXRes == 0 || psOptions->dfYRes == 0 )
+            if( psOptions->dfXRes <= 0 || psOptions->dfYRes <= 0 )
             {
                 CPLError(CE_Failure, CPLE_IllegalArg, "Wrong value for -tr parameters.");
                 GDALGridOptionsFree(psOptions);

--- a/gdal/apps/gdal_grid_lib.cpp
+++ b/gdal/apps/gdal_grid_lib.cpp
@@ -772,7 +772,7 @@ GDALDatasetH GDALGrid( const char *pszDest, GDALDatasetH hSrcDataset,
         return nullptr;
     }
 
-    if ( (psOptions->nXSize || psOptions->nYSize) && (psOptions->dfXRes || psOptions->dfYRes) ) {
+    if ( (psOptions->nXSize != 0 || psOptions->nYSize != 0) && (psOptions->dfXRes != 0 || psOptions->dfYRes != 0) ) {
         CPLError(CE_Failure, CPLE_IllegalArg, "-outsize and -tr options cannot be used at the same time.");
         GDALGridOptionsFree(psOptionsToFree);
         return nullptr;
@@ -837,7 +837,7 @@ GDALDatasetH GDALGrid( const char *pszDest, GDALDatasetH hSrcDataset,
     int nYSize;
     if ( psOptions->dfXRes != 0 && psOptions->dfYRes != 0 )
     {
-        if (!(psOptions->dfXMax - psOptions->dfXMin) || !(psOptions->dfYMax - psOptions->dfYMin)) {
+        if ((psOptions->dfXMax == psOptions->dfXMin) || (psOptions->dfYMax == psOptions->dfYMin)) {
             CPLError( CE_Failure, CPLE_IllegalArg,
                     "Invalid txe or tye paramaters detected. Please check your -txe or -tye argument.");
 

--- a/gdal/apps/gdal_grid_lib.cpp
+++ b/gdal/apps/gdal_grid_lib.cpp
@@ -835,7 +835,7 @@ GDALDatasetH GDALGrid( const char *pszDest, GDALDatasetH hSrcDataset,
 
     int nXSize;
     int nYSize;
-    if ( psOptions->dfXRes && psOptions->dfYRes )
+    if ( psOptions->dfXRes != 0 && psOptions->dfYRes != 0 )
     {
         if (!(psOptions->dfXMax - psOptions->dfXMin) || !(psOptions->dfYMax - psOptions->dfYMin)) {
             CPLError( CE_Failure, CPLE_IllegalArg,

--- a/gdal/apps/gdal_grid_lib.cpp
+++ b/gdal/apps/gdal_grid_lib.cpp
@@ -32,6 +32,7 @@
 #include "gdal_utils_priv.h"
 #include "commonutils.h"
 
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -836,9 +837,18 @@ GDALDatasetH GDALGrid( const char *pszDest, GDALDatasetH hSrcDataset,
     int nYSize;
     if ( psOptions->dfXRes && psOptions->dfYRes )
     {
-        double dfXSize = (psOptions->dfXMax - psOptions->dfXMin + (psOptions->dfXRes/2.0)) /
+        if (!(psOptions->dfXMax - psOptions->dfXMin) || !(psOptions->dfYMax - psOptions->dfYMin)) {
+            CPLError( CE_Failure, CPLE_IllegalArg,
+                    "Invalid txe or tye paramaters detected. Please check your -txe or -tye argument.");
+
+            if(pbUsageError)
+                *pbUsageError = TRUE;
+            return nullptr;
+        }
+
+        double dfXSize = (std::fabs(psOptions->dfXMax - psOptions->dfXMin) + (psOptions->dfXRes/2.0)) /
             psOptions->dfXRes;
-        double dfYSize = (psOptions->dfYMax - psOptions->dfYMin + (psOptions->dfYRes/2.0)) /
+        double dfYSize = (std::fabs(psOptions->dfYMax - psOptions->dfYMin) + (psOptions->dfYRes/2.0)) /
             psOptions->dfYRes;
 
         if (dfXSize >= 1 && dfXSize <= INT_MAX && dfYSize >= 1 && dfYSize <= INT_MAX) {

--- a/gdal/doc/source/programs/gdal_grid.rst
+++ b/gdal/doc/source/programs/gdal_grid.rst
@@ -56,7 +56,8 @@ computer.
 
 .. option:: -tr <xres> <yres>
 
-    Set output file resolution (in target georeferenced units)
+    Set output file resolution (in target georeferenced units).
+    Note that :option:`-tr` just works in combination with a valid input from :option:`-txe` and :option:`-tye`
 
     .. versionadded:: 3.2
 

--- a/gdal/doc/source/programs/gdal_grid.rst
+++ b/gdal/doc/source/programs/gdal_grid.rst
@@ -58,6 +58,8 @@ computer.
 
     Set output file resolution (in target georeferenced units)
 
+    .. versionadded:: 3.2
+
 .. option:: -outsize <xsize ysize>
 
     Set the size of the output file in pixels and lines.

--- a/gdal/doc/source/programs/gdal_grid.rst
+++ b/gdal/doc/source/programs/gdal_grid.rst
@@ -24,7 +24,7 @@ Synopsis
               [-clipsrcsql sql_statement] [-clipsrclayer layer]
               [-clipsrcwhere expression]
               [-l layername]* [-where expression] [-sql select_statement]
-              [-txe xmin xmax] [-tye ymin ymax] [-outsize xsize ysize]
+              [-txe xmin xmax] [-tye ymin ymax] [-tr xres yres] [-outsize xsize ysize]
               [-a algorithm[:parameter1=value1]*] [-q]
               <src_datasource> <dst_filename>
 
@@ -54,9 +54,14 @@ computer.
 
     Set georeferenced Y extents of output file to be created.
 
+.. option:: -tr <xres> <yres>
+
+    Set output file resolution (in target georeferenced units)
+
 .. option:: -outsize <xsize ysize>
 
     Set the size of the output file in pixels and lines.
+    Note that :option:`-outsize` cannot be used with :option:`-tr`
 
 .. option:: -a_srs <srs_def>
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This pull requests implements the -tr parameter (mentioned here: https://lists.osgeo.org/pipermail/gdal-dev/2020-January/051472.html) to gdal_grid. The code is similar to already existing code in other binaries.
Tests have been added in PyTest, to show the equality of the -outsize and -tr parameter. Also documentation have been edited.

## Tasklist
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
