### PR TITLE
Fixes corruption with geometry data when reading large features from pgeo driver

### DIFF
--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -990,6 +990,11 @@ int CPLODBCStatement::Fetch( int nOrientation, int nOffset )
                 if( nFetchType == SQL_C_CHAR )
                     while( (cbDataLen > 1) && (szWrkData[cbDataLen - 1] == 0) )
                         --cbDataLen;  // Trimming the extra terminators: bug 990
+                else if( nFetchType == SQL_C_BINARY )
+                {
+                    if( (cbDataLen > 1) && (szWrkData[cbDataLen - 1] == 0) )
+                        --cbDataLen;  // Trim the extra terminator: bug 990
+                }
                 else if( nFetchType == SQL_C_WCHAR )
                     while( (cbDataLen > 1) && (szWrkData[cbDataLen - 1] == 0 )
                         && (szWrkData[cbDataLen - 2] == 0))
@@ -1029,6 +1034,12 @@ int CPLODBCStatement::Fetch( int nOrientation, int nOffset )
                         while( (nChunkLen > 1)
                                && (szWrkData[nChunkLen - 1] == 0) )
                             --nChunkLen;  // Trimming the extra terminators.
+                    else if ( nFetchType == SQL_C_BINARY )
+                    {
+                        if( (nChunkLen > 1)
+                            && (szWrkData[nChunkLen - 1] == 0) )
+                            --nChunkLen;  // Trim the extra terminator.
+                    }
                     else if( nFetchType == SQL_C_WCHAR )
                         while( (nChunkLen > 1)
                                && (szWrkData[nChunkLen - 1] == 0)


### PR DESCRIPTION
Fix data from binary ole fields can be incorrectly retrieved if multiple calls to SQLGetData are required and one call
ends with multiple null characters, which are actually part of the binary content

Fixes corruption with geometry data when reading large features from pgeo driver
