### PR TITLE
libkea repo: new URL

### DIFF
--- a/gdal/doc/source/drivers/raster/kea.rst
+++ b/gdal/doc/source/drivers/raster/kea.rst
@@ -97,8 +97,8 @@ the working of the underlying HDF5 format.
 See Also
 --------
 
--  `libkea bitbucket
-   repository <https://bitbucket.org/chchrsc/kealib>`__
+-  `libkea GitHub
+   repository <https://github.com/ubarsc/kealib>`__
 -  `The KEAimage file format, by Peter Bunting and Sam Gillingham,
    published in
    Computers&Geosciences <http://www.sciencedirect.com/science/article/pii/S0098300413001015>`__


### PR DESCRIPTION
## What does this PR do?

- the former bitbucket repo points to this newish GH repo: URL update

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
