### PR TITLE
 Allow mdb files to be opened with the generic ODBC driver on non-windows systems

### DIFF
--- a/gdal/doc/source/drivers/vector/odbc.rst
+++ b/gdal/doc/source/drivers/vector/odbc.rst
@@ -71,6 +71,10 @@ Access Driver (\*.mdb)" ODBC driver is installed, non-spatial MS Access
 Databases (not Personal Geodabases or Geomedia databases) can be opened
 directly by their filenames.
 
+On Linux opening non-spatial MS Access Databases using the ODBC driver
+is possible via installation of unixODBC and mdbtools. See
+:ref:`MDB <vector.pgeo>` for instructions on how to enable this.
+
 Creation Issues
 ---------------
 

--- a/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdriver.cpp
@@ -59,9 +59,7 @@ OGRDataSource *OGRODBCDriver::Open( const char * pszFilename,
 
 {
     if( !STARTS_WITH_CI(pszFilename, "ODBC:")
-#ifdef WIN32
         && !EQUAL(CPLGetExtension(pszFilename), "MDB")
-#endif
         )
         return nullptr;
 


### PR DESCRIPTION
This works fine, at least with updated versions of mdbtools (and for reference the pgeo and geomedia drivers don't have this ifdef in place)