### PR TITLE
Correctly handle datetime fields provided by the mdbtools ODBC driver

### DIFF
--- a/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomedialayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomedialayer.cpp
@@ -165,6 +165,7 @@ CPLErr OGRGeomediaLayer::BuildFeatureDefn( const char *pszLayerName,
             break;
 
           case SQL_C_TIMESTAMP:
+          case SQL_C_TYPE_TIMESTAMP:
             oField.SetType( OFTDateTime );
             break;
 

--- a/gdal/ogr/ogrsf_frmts/odbc/ogrodbclayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/odbc/ogrodbclayer.cpp
@@ -153,6 +153,7 @@ CPLErr OGRODBCLayer::BuildFeatureDefn( const char *pszLayerName,
                 break;
 
             case SQL_C_TIMESTAMP:
+            case SQL_C_TYPE_TIMESTAMP:
                 oField.SetType( OFTDateTime );
                 break;
 

--- a/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeolayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeolayer.cpp
@@ -168,6 +168,7 @@ CPLErr OGRPGeoLayer::BuildFeatureDefn( const char *pszLayerName,
             break;
 
           case SQL_C_TIMESTAMP:
+          case SQL_C_TYPE_TIMESTAMP:
             oField.SetType( OFTDateTime );
             break;
 


### PR DESCRIPTION
Avoids forced conversion of these fields to strings
