### PR TITLE
Fix DSN string construction for Windows Access ODBC driver, template candidate preference order

### DIFF
--- a/autotest/ogr/ogr_odbc.py
+++ b/autotest/ogr/ogr_odbc.py
@@ -28,6 +28,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import os
 import sys
 import shutil
 from osgeo import ogr
@@ -165,8 +166,12 @@ def test_extensions():
     lyr = ds.GetLayerByName('Line Symbols')
     assert lyr is not None
 
-    ds = ogrtest.odbc_drv.Open('data/mdb/empty.accdb')
-    assert ds is not None
+    if os.environ.get('GITHUB_WORKFLOW', '') != 'Windows builds':
+        # can't run this on Github "Windows builds" workflow, as that has the older
+        # 'Microsoft Access Driver (*.mdb)' ODBC driver only, which doesn't support accdb
+        # databases
+        ds = ogrtest.odbc_drv.Open('data/mdb/empty.accdb')
+        assert ds is not None
 
 ###############################################################################
 # Cleanup

--- a/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomediadatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomediadatasource.cpp
@@ -116,9 +116,15 @@ int OGRGeomediaDataSource::Open( const char * pszNewName, int bUpdate,
         pszDSN = CPLStrdup( pszNewName + 9 );
     else
     {
-        const char *pszDSNStringTemplate = 
-            CPLGetConfigOption( "GEOMEDIA_DRIVER_TEMPLATE",
-                            "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"");
+#ifdef WIN32
+        const char *pszDSNStringTemplate =
+            CPLGetConfigOption("GEOMEDIA_DRIVER_TEMPLATE",
+                "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s");
+#else
+        const char *pszDSNStringTemplate =
+            CPLGetConfigOption("GEOMEDIA_DRIVER_TEMPLATE",
+                "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"");
+#endif
         if (!CheckDSNStringTemplate(pszDSNStringTemplate))
         {
             CPLError( CE_Failure, CPLE_AppDefined,

--- a/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomediadatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomediadatasource.cpp
@@ -111,48 +111,34 @@ int OGRGeomediaDataSource::Open( const char * pszNewName, int bUpdate,
 /*      get the DSN.                                                    */
 /*                                                                      */
 /* -------------------------------------------------------------------- */
-    char *pszDSN = nullptr;
     if( STARTS_WITH_CI(pszNewName, "GEOMEDIA:") )
-        pszDSN = CPLStrdup( pszNewName + 9 );
+    {
+        char *pszDSN = CPLStrdup( pszNewName + 9 );
+
+        CPLDebug( "Geomedia", "EstablishSession(%s)", pszDSN );
+        if( !oSession.EstablishSession( pszDSN, nullptr, nullptr ) )
+        {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "Unable to initialize ODBC connection to DSN for %s,\n"
+                      "%s", pszDSN, oSession.GetLastError() );
+            CPLFree( pszDSN );
+            return FALSE;
+        }
+    }
     else
     {
-#ifdef WIN32
-        const char *pszDSNStringTemplate =
-            CPLGetConfigOption("GEOMEDIA_DRIVER_TEMPLATE",
-                "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s");
-#else
-        const char *pszDSNStringTemplate =
-            CPLGetConfigOption("GEOMEDIA_DRIVER_TEMPLATE",
-                "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"");
-#endif
-        if (!CheckDSNStringTemplate(pszDSNStringTemplate))
+        const char* pszDSNStringTemplate = CPLGetConfigOption( "GEOMEDIA_DRIVER_TEMPLATE", nullptr );
+        if( pszDSNStringTemplate && !CheckDSNStringTemplate(pszDSNStringTemplate))
         {
             CPLError( CE_Failure, CPLE_AppDefined,
                       "Illegal value for GEOMEDIA_DRIVER_TEMPLATE option");
             return FALSE;
         }
-        pszDSN = (char *) CPLMalloc(strlen(pszNewName)+strlen(pszDSNStringTemplate)+100);
-        /* coverity[tainted_string] */
-        snprintf( pszDSN,
-                  strlen(pszNewName)+strlen(pszDSNStringTemplate)+100,
-                  pszDSNStringTemplate,  pszNewName );
+        if ( !oSession.ConnectToMsAccess( pszNewName, pszDSNStringTemplate ) )
+        {
+            return FALSE;
+        }
     }
-
-/* -------------------------------------------------------------------- */
-/*      Initialize based on the DSN.                                    */
-/* -------------------------------------------------------------------- */
-    CPLDebug( "Geomedia", "EstablishSession(%s)", pszDSN );
-
-    if( !oSession.EstablishSession( pszDSN, nullptr, nullptr ) )
-    {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Unable to initialize ODBC connection to DSN for %s,\n"
-                  "%s", pszDSN, oSession.GetLastError() );
-        CPLFree( pszDSN );
-        return FALSE;
-    }
-
-    CPLFree( pszDSN );
 
     pszName = CPLStrdup( pszNewName );
 

--- a/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdatasource.cpp
@@ -116,7 +116,7 @@ int OGRODBCDataSource::OpenMDB( const char * pszNewName, int bUpdate )
             pszOptionName = "";
         }
     }
-    if (!CheckDSNStringTemplate(pszDSNStringTemplate))
+    if (pszDSNStringTemplate && !CheckDSNStringTemplate(pszDSNStringTemplate))
     {
         CPLError( CE_Failure, CPLE_AppDefined,
                     "Illegal value for %s option", pszOptionName );

--- a/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdatasource.cpp
@@ -114,7 +114,11 @@ int OGRODBCDataSource::OpenMDB( const char * pszNewName, int bUpdate )
         if( pszDSNStringTemplate == nullptr )
         {
             pszOptionName = "";
+#ifdef WIN32
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s";
+#else
             pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
+#endif
         }
     }
     if (!CheckDSNStringTemplate(pszDSNStringTemplate))
@@ -140,7 +144,11 @@ int OGRODBCDataSource::OpenMDB( const char * pszNewName, int bUpdate )
         if( EQUAL(pszOptionName, "") )
         {
             // Trying with another template (#5594)
+#ifdef WIN32
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=%s";
+#else
             pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=\"%s\"";
+#endif
             CPLFree( pszDSN );
             pszDSN = (char *) CPLMalloc(strlen(pszNewName)+strlen(pszDSNStringTemplate)+100);
             snprintf( pszDSN,

--- a/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/odbc/ogrodbcdatasource.cpp
@@ -115,9 +115,9 @@ int OGRODBCDataSource::OpenMDB( const char * pszNewName, int bUpdate )
         {
             pszOptionName = "";
 #ifdef WIN32
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=%s";
 #else
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=\"%s\"";
 #endif
         }
     }
@@ -145,9 +145,9 @@ int OGRODBCDataSource::OpenMDB( const char * pszNewName, int bUpdate )
         {
             // Trying with another template (#5594)
 #ifdef WIN32
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=%s";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s";
 #else
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=\"%s\"";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
 #endif
             CPLFree( pszDSN );
             pszDSN = (char *) CPLMalloc(strlen(pszNewName)+strlen(pszDSNStringTemplate)+100);

--- a/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
@@ -115,7 +115,11 @@ int OGRPGeoDataSource::Open( const char * pszNewName, int bUpdate,
         pszDSNStringTemplate = CPLGetConfigOption( "PGEO_DRIVER_TEMPLATE", nullptr );
         if( pszDSNStringTemplate == nullptr )
         {
+#ifdef WIN32
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s";
+#else
             pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
+#endif
         }
         if (!CheckDSNStringTemplate(pszDSNStringTemplate))
         {
@@ -141,7 +145,11 @@ int OGRPGeoDataSource::Open( const char * pszNewName, int bUpdate,
         if( !STARTS_WITH_CI(pszNewName, "PGEO:") )
         {
             // Trying with another template (#5594)
+#ifdef WIN32
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=%s";
+#else
             pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=\"%s\"";
+#endif
             CPLFree( pszDSN );
             pszDSN = (char *) CPLMalloc(strlen(pszNewName)+strlen(pszDSNStringTemplate)+100);
             snprintf( pszDSN,

--- a/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
@@ -116,9 +116,9 @@ int OGRPGeoDataSource::Open( const char * pszNewName, int bUpdate,
         if( pszDSNStringTemplate == nullptr )
         {
 #ifdef WIN32
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=%s";
 #else
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=\"%s\"";
 #endif
         }
         if (!CheckDSNStringTemplate(pszDSNStringTemplate))
@@ -146,9 +146,9 @@ int OGRPGeoDataSource::Open( const char * pszNewName, int bUpdate,
         {
             // Trying with another template (#5594)
 #ifdef WIN32
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=%s";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s";
 #else
-            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=\"%s\"";
+            pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
 #endif
             CPLFree( pszDSN );
             pszDSN = (char *) CPLMalloc(strlen(pszNewName)+strlen(pszDSNStringTemplate)+100);

--- a/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
@@ -108,8 +108,7 @@ int OGRPGeoDataSource::Open( const char * pszNewName, int bUpdate,
 /* -------------------------------------------------------------------- */
     if( STARTS_WITH_CI(pszNewName, "PGEO:") )
     {
-        char *pszDSN = nullptr;
-        pszDSN = CPLStrdup( pszNewName + 5 );
+        char *pszDSN = CPLStrdup( pszNewName + 5 );
         CPLDebug( "PGeo", "EstablishSession(%s)", pszDSN );
         if( !oSession.EstablishSession( pszDSN, nullptr, nullptr ) )
         {

--- a/gdal/ogr/ogrsf_frmts/walk/ogrwalkdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/walk/ogrwalkdatasource.cpp
@@ -72,8 +72,7 @@ int OGRWalkDataSource::Open( const char * pszNewName, int /* bUpdate */ )
 /* -------------------------------------------------------------------- */
     if( STARTS_WITH_CI(pszNewName, "WALK:") )
     {
-        char *pszDSN = nullptr;
-        pszDSN = CPLStrdup( pszNewName + 5 );
+        char *pszDSN = CPLStrdup( pszNewName + 5 );
         CPLDebug( "Walk", "EstablishSession(%s)", pszDSN );
         if( !oSession.EstablishSession( pszDSN, nullptr, nullptr ) )
         {

--- a/gdal/ogr/ogrsf_frmts/walk/ogrwalkdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/walk/ogrwalkdatasource.cpp
@@ -78,7 +78,11 @@ int OGRWalkDataSource::Open( const char * pszNewName, int /* bUpdate */ )
     }
     else
     {
+#ifdef WIN32
+        const char *pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=%s";
+#else
         const char *pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
+#endif
         pszDSN = (char *) CPLMalloc(strlen(pszNewName)+strlen(pszDSNStringTemplate)+100);
 
         snprintf( pszDSN,

--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -446,7 +446,7 @@ bool CPLODBCSession::ConnectToMsAccess(const char *pszName, const char *pszDSNSt
         pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb, *.accdb);DBQ=\"%s\"";
 #endif
     }
-    pszDSN = (char *) CPLMalloc(strlen(pszName)+strlen(pszDSNStringTemplate)+100);
+    pszDSN = static_cast< char * >( CPLMalloc(strlen(pszName)+strlen(pszDSNStringTemplate)+100) );
     /* coverity[tainted_string] */
     snprintf( pszDSN,
         strlen(pszName)+strlen(pszDSNStringTemplate)+100,
@@ -463,7 +463,7 @@ bool CPLODBCSession::ConnectToMsAccess(const char *pszName, const char *pszDSNSt
         pszDSNStringTemplate = "DRIVER=Microsoft Access Driver (*.mdb);DBQ=\"%s\"";
 #endif
         CPLFree( pszDSN );
-        pszDSN = (char *) CPLMalloc(strlen(pszName)+strlen(pszDSNStringTemplate)+100);
+        pszDSN = static_cast< char * >( CPLMalloc(strlen(pszName)+strlen(pszDSNStringTemplate)+100) );
         snprintf( pszDSN,
             strlen(pszName)+strlen(pszDSNStringTemplate)+100,
             pszDSNStringTemplate,  pszName );
@@ -477,11 +477,11 @@ bool CPLODBCSession::ConnectToMsAccess(const char *pszName, const char *pszDSNSt
                   "Unable to initialize ODBC connection to DSN for %s,\n"
                   "%s", pszDSN, GetLastError() );
         CPLFree( pszDSN );
-        return FALSE;
+        return false;
     }
 
     CPLFree( pszDSN );
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/

--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -416,7 +416,22 @@ int CPLODBCSession::Failed( int nRetCode, HSTMT hStmt )
 /*                          ConnectToMsAccess()                          */
 /************************************************************************/
 
-
+/**
+ * Connects to a Microsoft Access database.
+ *
+ * @param pszName The file name of the Access database to connect to.  This is not
+ * optional.
+ *
+ * @param pszDSNStringTemplate optional DSN string template for Microsoft Access
+ * ODBC Driver. If not specified, then a set of known driver templates will
+ * be used automatically as a fallback. If specified, it is the caller's responsibility
+ * to ensure that the template is correctly formatted.
+ *
+ * @return TRUE on success or FALSE on failure. Errors will automatically be reported
+ * via CPLError.
+ *
+ * @since GDAL 3.2
+ */
 bool CPLODBCSession::ConnectToMsAccess(const char *pszName, const char *pszDSNStringTemplate)
 {
     char *pszDSN = nullptr;

--- a/gdal/port/cpl_odbc.h
+++ b/gdal/port/cpl_odbc.h
@@ -195,6 +195,9 @@ class CPL_DLL CPLODBCSession {
     HDBC        GetConnection() { return m_hDBC; }
     /** Return GetEnvironment handle */
     HENV        GetEnvironment()  { return m_hEnv; }
+
+    bool ConnectToMsAccess( const char * pszName, const char* pszDSNStringTemplate );
+
 };
 
 /**


### PR DESCRIPTION
The Windows ODBC driver does not like quoted filenames, yet the UnixODBC driver requires these (for filenames with spaces). So
ifdef the expected formats for the corresponding platforms. Follow up https://github.com/OSGeo/gdal/pull/2837

Also flip the order of the candidate DSN string templates, to try the more common/modern "Microsoft Access Driver (*.mdb, *.accdb)" driver name first.
