### PR TITLE
Minor improvement to the XSD documentation for PDF Composition

### DIFF
--- a/gdal/data/pdfcomposition.xsd
+++ b/gdal/data/pdfcomposition.xsd
@@ -521,6 +521,9 @@
             - another one, when the georeferencingId attribute is defined, and
               reference a georeferenced area. In that case, the vector georeferenced
               coordinates will be used to correctly place it in the georeferenced area.
+
+            Note: OGR Feature Style strings containing a LABEL tool will not work with
+            this element, to display labels use a VectorLabel element instead.
         </xs:documentation></xs:annotation>
         <xs:sequence>
             <xs:element name="Blending" type="BlendingType" minOccurs="0"/>


### PR DESCRIPTION
##  What does this PR do?
Makes a minor improvement to the XSD documentation for the PDF Composition XML format. My colleagues and I struggled to get labels working because we didn't realise that any features with a OGR Style String containing a `LABEL` tool needed to be in a separate `<VectorLabel>` element. This adds an extra sentence to the documentation that clarifies this.

## What are related issues/pull requests?
None