### PR TITLE
MRF: LERC V1 support for NaN and other bug fixes

### DIFF
--- a/gdal/frmts/esric/esric/x64/Debug/esric.log
+++ b/gdal/frmts/esric/esric/x64/Debug/esric.log
@@ -1,8 +1,0 @@
-﻿  
-  Microsoft (R) Program Maintenance Utility Version 14.26.28805.0
-  Copyright (C) Microsoft Corporation.  All rights reserved.
-  
-  	mkdir ""\GDAL\bin"\gdalplugins"
-  A subdirectory or file \GDAL\bin\gdalplugins already exists.
-  	xcopy /y /r /d /f /I gdal_ESRIC.dll ""\GDAL\bin"\gdalplugins"
-  0 File(s) copied

--- a/gdal/frmts/esric/esric/x64/Debug/esric.log
+++ b/gdal/frmts/esric/esric/x64/Debug/esric.log
@@ -1,0 +1,8 @@
+﻿  
+  Microsoft (R) Program Maintenance Utility Version 14.26.28805.0
+  Copyright (C) Microsoft Corporation.  All rights reserved.
+  
+  	mkdir ""\GDAL\bin"\gdalplugins"
+  A subdirectory or file \GDAL\bin\gdalplugins already exists.
+  	xcopy /y /r /d /f /I gdal_ESRIC.dll ""\GDAL\bin"\gdalplugins"
+  0 File(s) copied

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
@@ -203,7 +203,6 @@ static bool blockwrite(Byte** ppByte, const std::vector<unsigned int>& d) {
     return true;
 }
 
-
 static bool blockread(Byte** ppByte, size_t& size, std::vector<unsigned int>& d) {
     if (!ppByte || !size)
         return false;
@@ -293,7 +292,6 @@ unsigned int Lerc1Image::computeNumBytesNeededToWriteVoidImage() {
     sz += 3 * sizeof(int) + sizeof(float) + 1;
     return sz; // 67
 }
-
 
 unsigned int Lerc1Image::computeNumBytesNeededToWrite(double maxZError,
     bool onlyZPart, InfoFromComputeNumBytes* info) const
@@ -559,7 +557,6 @@ bool Lerc1Image::writeTiles(double maxZError, int numTilesV, int numTilesH,
     return true;
 }
 
-
 bool Lerc1Image::readTiles(double maxZErrorInFile,  int numTilesV, int numTilesH,
     float maxValInImg, Byte* bArr, size_t nRemainingBytes)
 {
@@ -584,7 +581,6 @@ bool Lerc1Image::readTiles(double maxZErrorInFile,  int numTilesV, int numTilesH
     return true;
 }
 
-
 void Lerc1Image::computeCntStats(float& cntMin, float& cntMax) const {
     cntMin = cntMax = static_cast<float>(mask.IsValid(0) ? 1.0f : 0.0f);
     for (int k = 0; k < getSize() && cntMin == cntMax; k++)
@@ -608,7 +604,7 @@ bool Lerc1Image::computeZStats(int r0, int r1, int c0, int c1,
                 numValidPixel++;
                 float val = (*this)(row, col);
                 if (!std::isfinite(val))
-                    zMin = val;
+                    zMin = NAN; // Serves as a flag, this block will be stored
                 if (val < zMin)
                     zMin = val;
                 if (val > zMax)
@@ -719,7 +715,6 @@ static float readFlt(const Byte* ptr, int n) {
     }
     return static_cast<float>(static_cast<signed char>(*ptr));
 }
-
 
 bool Lerc1Image::readZTile(Byte** ppByte, size_t& nRemainingBytes,
     int r0, int r1, int c0, int c1, double maxZErrorInFile, float maxZInImg)

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
@@ -611,7 +611,7 @@ bool Lerc1Image::computeZStats(int r0, int r1, int c0, int c1,
             if (IsValid(row, col)) {
                 numValidPixel++;
                 float val = (*this)(row, col);
-                if (!isfinite(val))
+                if (!std::isfinite(val))
                     zMin = val;
                 if (val < zMin)
                     zMin = val;
@@ -646,7 +646,8 @@ static Byte* writeFlt(Byte* ptr, float z, int n) {
 int Lerc1Image::numBytesZTile(int numValidPixel, float zMin, float zMax, double maxZError) {
     if (numValidPixel == 0 || (zMin == 0 && zMax == 0))
         return 1;
-    if (maxZError == 0 || !isfinite(zMin) || !isfinite(zMax) || ((double)zMax - zMin) / (2 * maxZError) > 0x10000000)
+    if (maxZError == 0 || !std::isfinite(zMin) || !std::isfinite(zMax)
+        || ((double)zMax - zMin) / (2 * maxZError) > 0x10000000)
         return(int)(1 + numValidPixel * sizeof(float));
     unsigned int maxElem = (unsigned int)(((double)zMax - zMin) / (2 * maxZError) + 0.5);
     return 1 + numBytesFlt(zMin) + (maxElem ? computeNumBytesNeededByStuffer(numValidPixel, maxElem) : 0);
@@ -669,7 +670,7 @@ bool Lerc1Image::writeZTile(Byte** ppByte, int& numBytes,
         return true;
     }
 
-    if (maxZError == 0 || !isfinite(zMin) || !isfinite(zMax) ||
+    if (maxZError == 0 || !std::isfinite(zMin) || !std::isfinite(zMax) ||
         ((double)zMax - zMin) / (2 * maxZError) > 0x10000000) {  // we'd need > 28 bit
         // write z's as flt arr uncompressed
         *ptr++ = 0; // flag

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.h
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.h
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2015 - 2020 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -149,16 +148,6 @@ public:
 
     static unsigned int computeNumBytesNeededToWriteVoidImage();
 
-    // Read and write into a memory buffer
-    bool write(Byte** ppByte,
-        double maxZError = 0,
-        bool onlyZPart = false) const;
-
-    bool read(Byte** ppByte,
-        size_t& nRemainingBytes,
-        double maxZError,
-        bool onlyZPart = false);
-
     bool resize(int width, int height) {
         setsize(width, height);
         mask.resize(getWidth(), getHeight());
@@ -169,10 +158,12 @@ public:
         return mask.IsValid(row * getWidth() + col) != 0;
     }
 
+    // Read and write into a memory buffer
+    bool write(Byte** ppByte, double maxZError = 0, bool onlyZPart = false) const;
+    bool read(Byte** ppByte, size_t& nRemainingBytes, double maxZError, bool onlyZPart = false);
+
     BitMaskV1 mask;
 };
-
-// -------------------------------------------------------------------------- ;
 
 NAMESPACE_LERC1_END
 #endif

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.h
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.h
@@ -119,7 +119,7 @@ protected:
         Byte* bArr, int& numBytes, float& maxValInImg) const;
 
     bool readTiles(double maxZErrorInFile,
-        int numTilesVert, int numTilesHori, float maxValInImg, Byte* bArr, size_t &nRemainingBytes);
+        int numTilesVert, int numTilesHori, float maxValInImg, Byte* bArr, size_t nRemainingBytes);
 
     void computeCntStats(float& cntMin, float& cntMax) const; // Across the whole image, always works
     bool computeZStats(int r0, int r1, int c0, int c1,

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.h
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.h
@@ -119,18 +119,18 @@ protected:
         Byte* bArr, int& numBytes, float& maxValInImg) const;
 
     bool readTiles(double maxZErrorInFile,
-        int numTilesVert, int numTilesHori, float maxValInImg, Byte* bArr, size_t nRemainingBytes);
+        int numTilesVert, int numTilesHori, float maxValInImg, Byte* bArr, size_t &nRemainingBytes);
 
     void computeCntStats(float& cntMin, float& cntMax) const; // Across the whole image, always works
-    bool computeZStats(int i0, int i1, int j0, int j1,
+    bool computeZStats(int r0, int r1, int c0, int c1,
         float& zMin, float& zMax, int& numValidPixel) const;
 
     static int numBytesZTile(int numValidPixel, float zMin, float zMax, double maxZError);
 
-    bool writeZTile(Byte** ppByte, int& numBytes, int i0, int i1, int j0, int j1,
+    bool writeZTile(Byte** ppByte, int& numBytes, int r0, int r1, int c0, int c1,
         int numValidPixel, float zMin, float zMax, double maxZError) const;
 
-    bool readZTile(Byte** ppByte, size_t& nRemainingBytes, int i0, int i1, int j0, int j1,
+    bool readZTile(Byte** ppByte, size_t& nRemainingBytes, int r0, int r1, int c0, int c1,
         double maxZErrorInFile, float maxZInImg);
 
     std::vector<unsigned int> idataVec;    // temporary buffer, reused in readZTile

--- a/gdal/frmts/mrf/LERC_band.cpp
+++ b/gdal/frmts/mrf/LERC_band.cpp
@@ -256,7 +256,7 @@ static CPLErr DecompressLERC1(buf_mgr &dst, buf_mgr &src, const ILImage &img)
         }
 #undef UFILL
         if (!success) {
-            CPLError(CE_Failure, CPLE_AppDefined, "MRF: Error during LERC compression");
+            CPLError(CE_Failure, CPLE_AppDefined, "MRF: Error during LERC decompression");
             return CE_Failure;
         }
     }

--- a/gdal/frmts/mrf/LERC_band.cpp
+++ b/gdal/frmts/mrf/LERC_band.cpp
@@ -150,20 +150,20 @@ template <typename T> static void Lerc1ImgFill(Lerc1Image& zImg, T* src, const I
     zImg.resize(w, h);
     const float ndv = static_cast<float>(img.hasNoData ? img.NoDataValue : 0);
     if (stride == 1) {
-        for (int i = 0; i < h; i++)
-            for (int j = 0; j < w; j++) {
+        for (int row = 0; row < h; row++)
+            for (int col = 0; col < w; col++) {
                 float val = static_cast<float>(*src++);
-                zImg(i, j) = val;
-                zImg.mask.Set(i * zImg.getWidth() + j, !CPLIsEqual(ndv, val));
+                zImg(row, col) = val;
+                zImg.mask.Set(row * w + col, !CPLIsEqual(ndv, val));
             }
         return;
     }
-    for (int i = 0; i < h; i++)
-        for (int j = 0; j < w; j++) {
+    for (int row = 0; row < h; row++)
+        for (int col = 0; col < w; col++) {
             float val = static_cast<float>(*src);
             src += stride;
-            zImg(i, j) = val;
-            zImg.mask.Set(i * zImg.getWidth() + j, !CPLIsEqual(ndv, val));
+            zImg(row, col) = val;
+            zImg.mask.Set(row * w + col, !CPLIsEqual(ndv, val));
         }
 }
 
@@ -173,15 +173,17 @@ template <typename T> static bool Lerc1ImgUFill(Lerc1Image &zImg, T *dst, const 
     const T ndv = static_cast<T>(img.hasNoData ? img.NoDataValue : 0);
     if (img.pagesize.y != zImg.getHeight() || img.pagesize.x != zImg.getWidth())
         return false;
+    int w = img.pagesize.x;
+    int h = img.pagesize.y;
     if (1 == stride) {
-        for (int i = 0; i < zImg.getHeight(); i++)
-            for (int j = 0; j < zImg.getWidth(); j++)
-                *dst++ = zImg.IsValid(i, j) ? static_cast<T>(zImg(i, j)) : ndv;
+        for (int row = 0; row < h; row++)
+            for (int col = 0; col < w; col++)
+                *dst++ = zImg.IsValid(row, col) ? static_cast<T>(zImg(row, col)) : ndv;
         return true;
     }
-    for (int i = 0; i < zImg.getHeight(); i++)
-        for (int j = 0; j < zImg.getWidth(); j++) {
-            *dst = zImg.IsValid(i, j) ? static_cast<T>(zImg(i, j)) : ndv;
+    for (int row = 0; row < h; row++)
+        for (int col = 0; col < w; col++) {
+            *dst = zImg.IsValid(row, col) ? static_cast<T>(zImg(row, col)) : ndv;
             dst += stride;
         }
     return true;
@@ -264,7 +266,7 @@ static CPLErr DecompressLERC1(buf_mgr &dst, buf_mgr &src, const ILImage &img)
     return CE_None;
 }
 
-// Populate a bitmask based on comparison with the image no data value
+// Populate a LERC2 bitmask based on comparison with the image no data value
 // Returns the number of NoData values found
 template <typename T> static int MaskFill(BitMask &bitMask, T *src, const ILImage &img)
 {
@@ -281,18 +283,18 @@ template <typename T> static int MaskFill(BitMask &bitMask, T *src, const ILImag
     if (!img.hasNoData) ndv = 0; // It really doesn't get called when img doesn't have NoDataValue
 
     if (1 == stride) {
-        for (int i = 0; i < h; i++)
-            for (int j = 0; j < w; j++)
+        for (int row = 0; row < h; row++)
+            for (int col = 0; col < w; col++)
                 if (ndv == *src++) {
-                    bitMask.SetInvalid(i, j);
+                    bitMask.SetInvalid(row, col);
                     count++;
                 }
     } else {
         // Test only the first band for the ndv value
-        for (int i = 0; i < h; i++)
-            for (int j = 0; j < w; j++, src += stride)
+        for (int row = 0; row < h; row++)
+            for (int col = 0; col < w; col++, src += stride)
                 if (ndv == *src) {
-                    bitMask.SetInvalid(i, j);
+                    bitMask.SetInvalid(row, col);
                     count++;
                 }
     }
@@ -378,15 +380,15 @@ template <typename T> static void UnMask(BitMask &bitMask, T *arr, const ILImage
     T ndv = T(img.NoDataValue);
     if (!img.hasNoData) ndv = 0; // It doesn't get called when img doesn't have NoDataValue
     if (1 == stride) {
-        for (int i = 0; i < h; i++)
-            for (int j = 0; j < w; j++, ptr++)
-                if (!bitMask.IsValid(i, j))
+        for (int row = 0; row < h; row++)
+            for (int col = 0; col < w; col++, ptr++)
+                if (!bitMask.IsValid(row, col))
                     *ptr = ndv;
     }
     else {
-        for (int i = 0; i < h; i++)
-            for (int j = 0; j < w; j++, ptr += stride)
-                if (!bitMask.IsValid(i, j))
+        for (int row = 0; row < h; row++)
+            for (int col = 0; col < w; col++, ptr += stride)
+                if (!bitMask.IsValid(row, col))
                     for (int c = 0 ; c < stride; c++)
                         ptr[c] = ndv;
     }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
- When compressing floating point data, if NAN or INF values are present, LERC compression fails.  This change makes it possible to use LERC 1 with such data, including reading back those non-finite values.

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
