### PR TITLE
VSI Plugin: add caching option

### DIFF
--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -541,6 +541,8 @@ typedef struct {
     VSIFilesystemPluginFlushCallback            flush; /**< sync bytes (w) */
     VSIFilesystemPluginTruncateCallback         truncate; /**< truncate handle (w?) */
     VSIFilesystemPluginCloseCallback            close; /**< close handle  (rw) */
+    size_t                                      nBufferSize; /**< buffer small reads (makes handler read only) */
+    size_t                                      nCacheSize; /**< max mem to use per file when buffering */
 /* 
     Callbacks are defined as a struct allocated by a call to VSIAllocFilesystemPluginCallbacksStruct
     in order to try to maintain ABI stability when eventually adding a new member.

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -131,7 +131,13 @@ VSIVirtualHandle* VSIPluginFilesystemHandler::Open( const char *pszFilename,
         }
         return nullptr;
     }
-    return new VSIPluginHandle(this, cbData);
+    if ( m_cb->nBufferSize<=0 ) {
+        return new VSIPluginHandle(this, cbData);
+    } else {
+        return VSICreateCachedFile(
+            new VSIPluginHandle(this, cbData), m_cb->nBufferSize,
+            (m_cb->nCacheSize<m_cb->nBufferSize) ? m_cb->nBufferSize : m_cb->nCacheSize);
+    }
 }
 
 const char* VSIPluginFilesystemHandler::GetCallbackFilename(const char *pszFilename) {

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -131,7 +131,7 @@ VSIVirtualHandle* VSIPluginFilesystemHandler::Open( const char *pszFilename,
         }
         return nullptr;
     }
-    if ( m_cb->nBufferSize<=0 ) {
+    if ( m_cb->nBufferSize==0 ) {
         return new VSIPluginHandle(this, cbData);
     } else {
         return VSICreateCachedFile(


### PR DESCRIPTION
This PR adds an option to wrap a plugin handler with `VSICreateCachedFile`
Can/should be backported
Replaces #2817 