### PR TITLE
MRF: missing data return on initial caching of nodata tiles

### DIFF
--- a/gdal/frmts/mrf/mrf_band.cpp
+++ b/gdal/frmts/mrf/mrf_band.cpp
@@ -531,6 +531,8 @@ CPLErr MRFRasterBand::FetchBlock(int xblk, int yblk, void *buffer)
     if (isAllVal(eDataType, ob, img.pageSizeBytes, val)) {
         // Mark it empty and checked, ignore the possible write error
         poDS->WriteTile((void *)1, infooffset, 0);
+        if (1 == cstride)
+            return CE_None;
         return ReadInterleavedBlock(xblk, yblk, buffer);
     }
 

--- a/gdal/frmts/mrf/mrf_band.cpp
+++ b/gdal/frmts/mrf/mrf_band.cpp
@@ -531,7 +531,7 @@ CPLErr MRFRasterBand::FetchBlock(int xblk, int yblk, void *buffer)
     if (isAllVal(eDataType, ob, img.pageSizeBytes, val)) {
         // Mark it empty and checked, ignore the possible write error
         poDS->WriteTile((void *)1, infooffset, 0);
-        return CE_None;
+        return ReadInterleavedBlock(xblk, yblk, buffer);
     }
 
     // Write the page in the local cache


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Fix a bug in caching MRF.  If a tile is all no-data, the first band IReadBlock didn't fill the return buffer.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
