### PR TITLE
MRF: Finish create call when closing dataset

### DIFF
--- a/gdal/frmts/mrf/marfa_dataset.cpp
+++ b/gdal/frmts/mrf/marfa_dataset.cpp
@@ -149,8 +149,9 @@ int MRFDataset::CloseDependentDatasets()
 MRFDataset::~MRFDataset()
 
 {   // Make sure everything gets written
+    if (eAccess != GA_ReadOnly && !bCrystalized)
+        Crystalize();
     MRFDataset::FlushCache();
-
     MRFDataset::CloseDependentDatasets();
 
     if (ifp.FP)
@@ -207,6 +208,8 @@ CPLErr MRFDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSiz
         static_cast<int>(nPixelSpace), static_cast<int>(nLineSpace),
         static_cast<int>(nBandSpace));
 
+    if (eRWFlag == GF_Write && !bCrystalized)
+        Crystalize();
     //
     // Call the parent implementation, which splits it into bands and calls their IRasterIO
     //


### PR DESCRIPTION
Bug fix.
The Create call does write the files on disk if no data is every written before closing the newly created dataset.
The fix is to check that the files have been written in the dataset destructor, and force the write otherwise.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
