### PR TITLE
VRTDataset::IRasterIO(): fix excessive recursion prevention

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1379,3 +1379,34 @@ def test_vrt_dataset_rasterio_recursion_detection():
     with gdaltest.error_handler():
         ds.ReadRaster(0,0,20,20,10,10)
     gdal.Unlink('/vsimem/test.vrt')
+
+def test_vrt_dataset_rasterio_recursion_detection_does_not_trigger():
+
+    vrt_text = """<VRTDataset rasterXSize="50" rasterYSize="50">
+  <VRTRasterBand dataType="Byte" band="1">
+    <ColorInterp>Red</ColorInterp>
+    <ComplexSource>
+      <SourceFilename>data/rgbsmall.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+    </ComplexSource>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2">
+    <ColorInterp>Green</ColorInterp>
+    <ComplexSource>
+      <SourceFilename>data/rgbsmall.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+    </ComplexSource>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3">
+    <ColorInterp>Blue</ColorInterp>
+    <ComplexSource>
+      <SourceFilename>data/rgbsmall.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+    </ComplexSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+    ds = gdal.Open(vrt_text)
+    got_data = ds.ReadRaster(0,0,50,50,25,25,resample_alg=gdal.GRIORA_Cubic)
+    ds = gdal.Open('data/rgbsmall.tif')
+    ref_data = ds.ReadRaster(0,0,50,50,25,25,resample_alg=gdal.GRIORA_Cubic)
+    assert got_data == ref_data

--- a/gdal/frmts/vrt/vrtdataset.cpp
+++ b/gdal/frmts/vrt/vrtdataset.cpp
@@ -1775,7 +1775,8 @@ CPLErr VRTDataset::IRasterIO( GDALRWFlag eRWFlag,
                               GSpacing nBandSpace,
                               GDALRasterIOExtraArg* psExtraArg )
 {
-    if( m_nRecursionCounter > 0 )
+    // It may be valid to recurse one when dealing with a subsampled request
+    if( m_nRecursionCounter > 1 )
     {
         CPLError(
             CE_Failure, CPLE_AppDefined,


### PR DESCRIPTION
This fixes an issue introduced in master per 4efd242aa51366a06299dd74aefd608404d5016a
that triggers on the test case of #2911

But this fix doesn't fix #2911. It just avoids this new regression.