### PR TITLE
Update poppler build configuration requirement

### DIFF
--- a/gdal/doc/source/drivers/raster/pdf.rst
+++ b/gdal/doc/source/drivers/raster/pdf.rst
@@ -518,7 +518,8 @@ available.
 Poppler
 ~~~~~~~
 
-libpoppler itself must have been configured with --enable-xpdf-headers
+libpoppler itself must have been configured with
+-DENABLE_UNSTABLE_API_ABI_HEADERS=ON
 so that the xpdf C++ headers are available. Note: the poppler C++ API
 isn't stable, so the driver compilation may fail with too old or too
 recent poppler versions.


### PR DESCRIPTION
Poppler switched to a CMake-based build system a while ago. Even for CMake, the parameter was initially called `ENABLE_XPDF_HEADERS`, but this was changed to `ENABLE_UNSTABLE_API_ABI_HEADERS` in poppler 0.73.0 (Jan 2019).