### PR TITLE
treat "scheme://.." filenames as absolute

### DIFF
--- a/gdal/port/cpl_path.cpp
+++ b/gdal/port/cpl_path.cpp
@@ -818,7 +818,9 @@ int CPLIsFilenameRelative( const char *pszFilename )
 {
     if( (pszFilename[0] != '\0'
          && (STARTS_WITH(pszFilename+1, ":\\")
-             || STARTS_WITH(pszFilename+1, ":/")))
+             || STARTS_WITH(pszFilename+1, ":/")
+             || strstr(pszFilename+1,"://") // http://, ftp:// etc....
+            ))
         || STARTS_WITH(pszFilename, "\\\\?\\")  // Windows extended Length Path.
         || pszFilename[0] == '\\'
         || pszFilename[0] == '/' )


### PR DESCRIPTION
VSI handlers can be attached to any prefix, however attaching them to "scheme://" prefixes (e.g. https://) to enable gdal to directly open urls without having to rewrite them will lead to them being considered as relative.

e.g. `gdalbuildvrt output.vrt http://file1.tif http://file2.tif` will create a vrt file who's `SourceFileName` will have `relativeToVrt` set to `1`.

This patch marks filenames containing `://` to be absolute.
