### PR TITLE
gdal2tiles: fix regression of #2808 when tmaxz != nativezoom (fixes #2932)

### DIFF
--- a/gdal/swig/python/scripts/gdal2tiles.py
+++ b/gdal/swig/python/scripts/gdal2tiles.py
@@ -1872,12 +1872,15 @@ class GDAL2Tiles(object):
             # Get the maximal zoom level (native resolution of the raster)
             if self.tmaxz is None:
                 self.tmaxz = self.nativezoom
+            elif self.tmaxz > self.nativezoom:
+                print('Clamping max zoom level to %d' % self.nativezoom)
+                self.tmaxz = self.nativezoom
 
             # Generate table with min max tile coordinates for all zoomlevels
             self.tminmax = list(range(0, self.tmaxz + 1))
             self.tsize = list(range(0, self.tmaxz + 1))
             for tz in range(0, self.tmaxz + 1):
-                tsize = 2.0**(self.tmaxz - tz) * self.tile_size
+                tsize = 2.0**(self.nativezoom - tz) * self.tile_size
                 tminx, tminy = 0, 0
                 tmaxx = int(math.ceil(self.warped_input_dataset.RasterXSize / tsize)) - 1
                 tmaxy = int(math.ceil(self.warped_input_dataset.RasterYSize / tsize)) - 1
@@ -2114,8 +2117,7 @@ class GDAL2Tiles(object):
                     tsize = int(self.tsize[tz])   # tile_size in raster coordinates for actual zoom
                     xsize = self.warped_input_dataset.RasterXSize     # size of the raster in pixels
                     ysize = self.warped_input_dataset.RasterYSize
-                    if tz >= self.tmaxz:
-                        querysize = self.tile_size
+                    querysize = self.tile_size
 
                     rx = tx * tsize
                     rxsize = 0
@@ -2865,9 +2867,9 @@ class GDAL2Tiles(object):
 
         elif self.options.profile == 'raster':
 
-            base_res =  2**(self.tmaxz) * self.out_gt[1]
-            args['maxres'] = base_res
+            base_res =  2**(self.nativezoom) * self.out_gt[1]
             resolutions = [ base_res / 2**i for i in range(self.tmaxz+1) ]
+            args['maxres'] = resolutions[self.tminz]
             args['resolutions'] = '[' + ','.join('%.18g' % res for res in resolutions) + ']'
             args['tilegrid_extent'] = '[%.18g,%.18g,%.18g,%.18g]' % (self.ominx, self.ominy, self.omaxx, self.omaxy)
 


### PR DESCRIPTION
@dminor Could you look at this pull request ? It fixes the issue reported in #2932 which is due to your changes in #2808. Basically with #2808, --zoom=0-0 or --zoom=10-10 produce the same tiles, which match the native resolution of the raster. This is rather unexpected to me and to the reporter of #2932. So this pull request partially reverts #2808, while hopefully still fixing it.