### PR TITLE
cog.rst: fix minor layout glitch

### DIFF
--- a/gdal/doc/source/drivers/raster/cog.rst
+++ b/gdal/doc/source/drivers/raster/cog.rst
@@ -170,8 +170,8 @@ General creation options
 
   .. note:: Write support for GeoTIFF 1.1 requires libgeotiff 1.6.0 or later.
 
-- **SPARSE_OK=TRUE/FALSE** ((GDAL >= 3.2): Should empty blocks be
-   omitted on disk? When this option is set, any attempt of writing a
+- **SPARSE_OK=TRUE/FALSE** ((GDAL >= 3.2): Should empty blocks be omitted on disk?
+   When this option is set, any attempt of writing a
    block whose all pixels are 0 or the nodata value will cause it not to
    be written at all (unless there is a corresponding block already
    allocated in the file). Sparse files have 0 tile/strip offsets for


### PR DESCRIPTION
## What does this PR do?

Improves layout of section in https://gdal.org/drivers/raster/cog.html#general-creation-options

Now: 

- SPARSE_OK=TRUE/FALSE ((GDAL >= 3.2): Should empty blocks be

With this PR:

- SPARSE_OK=TRUE/FALSE ((GDAL >= 3.2): Should empty blocks be omitted on disk?
