### PR TITLE
VRT: add support for explicit virtual overviews 

### DIFF
--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -152,3 +152,34 @@ def test_gdalbuildvrt_lib_mem_sources():
 
     scenario_1()
     scenario_2()
+
+###############################################################################
+# Test BuildVRT() with virtual overviews
+
+
+def test_gdalbuildvrt_lib_virtual_overviews():
+
+    src1_ds = gdal.GetDriverByName('MEM').Create('', 1000, 1000)
+    src1_ds.SetGeoTransform([2,0.001,0,49,0,-0.001])
+    src1_ds.BuildOverviews('NEAR', [2, 4, 8])
+
+    src2_ds = gdal.GetDriverByName('MEM').Create('', 2000, 2000)
+    src2_ds.SetGeoTransform([3,0.001,0,49,0,-0.001])
+    src2_ds.BuildOverviews('NEAR', [2, 4, 16])
+
+    vrt_ds = gdal.BuildVRT('', [src1_ds, src2_ds])
+    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 2
+
+
+def test_gdalbuildvrt_lib_virtual_overviews_not_same_res():
+
+    src1_ds = gdal.GetDriverByName('MEM').Create('', 1000, 1000)
+    src1_ds.SetGeoTransform([2,0.001,0,49,0,-0.001])
+    src1_ds.BuildOverviews('NEAR', [2, 4])
+
+    src2_ds = gdal.GetDriverByName('MEM').Create('', 500, 500)
+    src2_ds.SetGeoTransform([3,0.002,0,49,0,-0.002])
+    src2_ds.BuildOverviews('NEAR', [2, 4])
+
+    vrt_ds = gdal.BuildVRT('', [src1_ds, src2_ds])
+    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 0

--- a/gdal/apps/gdalbuildvrt_lib.cpp
+++ b/gdal/apps/gdalbuildvrt_lib.cpp
@@ -40,6 +40,8 @@
 #include <cstring>
 
 #include <algorithm>
+#include <memory>
+#include <vector>
 
 #include "cpl_conv.h"
 #include "cpl_error.h"
@@ -73,38 +75,48 @@ typedef enum
     USER_RESOLUTION
 } ResolutionStrategy;
 
-typedef struct
+struct DatasetProperty
 {
-    int    isFileOK;
-    int    nRasterXSize;
-    int    nRasterYSize;
+    int    isFileOK = FALSE;
+    int    nRasterXSize = 0;
+    int    nRasterYSize = 0;
     double adfGeoTransform[6];
-    int    nBlockXSize;
-    int    nBlockYSize;
-    GDALDataType firstBandType;
-    bool*        pabHasNoData;
-    double*      padfNoDataValues;
-    bool*        pabHasOffset;
-    double*      padfOffset;
-    bool*        pabHasScale;
-    double*      padfScale;
-    int    bHasDatasetMask;
-    int    nMaskBlockXSize;
-    int    nMaskBlockYSize;
-} DatasetProperty;
+    int    nBlockXSize = 0;
+    int    nBlockYSize = 0;
+    GDALDataType firstBandType = GDT_Unknown;
+    std::vector<bool>   abHasNoData{};
+    std::vector<double> adfNoDataValues{};
+    std::vector<bool>   abHasOffset{};
+    std::vector<double> adfOffset{};
+    std::vector<bool>   abHasScale{};
+    std::vector<double> adfScale{};
+    int    bHasDatasetMask = 0;
+    int    nMaskBlockXSize = 0;
+    int    nMaskBlockYSize = 0;
 
-typedef struct
+    DatasetProperty()
+    {
+        adfGeoTransform[0] = 0;
+        adfGeoTransform[1] = 0;
+        adfGeoTransform[2] = 0;
+        adfGeoTransform[3] = 0;
+        adfGeoTransform[4] = 0;
+        adfGeoTransform[5] = 0;
+    }
+};
+
+struct BandProperty
 {
-    GDALColorInterp        colorInterpretation;
-    GDALDataType           dataType;
-    GDALColorTableH        colorTable;
-    bool                   bHasNoData;
-    double                 noDataValue;
-    bool                   bHasOffset;
-    double                 dfOffset;
-    bool                   bHasScale;
-    double                 dfScale;
-} BandProperty;
+    GDALColorInterp        colorInterpretation = GCI_Undefined;
+    GDALDataType           dataType = GDT_Unknown;
+    std::unique_ptr<GDALColorTable> colorTable{};
+    bool                   bHasNoData = false;
+    double                 noDataValue = 0;
+    bool                   bHasOffset = false;
+    double                 dfOffset = 0;
+    bool                   bHasScale = false;
+    double                 dfScale = 0;
+};
 
 /************************************************************************/
 /*                            ArgIsNumeric()                            */
@@ -229,12 +241,12 @@ class VRTBuilder
 
     /* Internal variables */
     char               *pszProjectionRef = nullptr;
-    BandProperty       *pasBandProperties = nullptr;
+    std::vector<BandProperty> asBandProperties{};
     int                 bFirst = TRUE;
     int                 bHasGeoTransform = 0;
     int                 nRasterXSize = 0;
     int                 nRasterYSize = 0;
-    DatasetProperty    *pasDatasetProperties = nullptr;
+    std::vector<DatasetProperty> asDatasetProperties{};
     int                 bUserExtent = 0;
     int                 bAllowSrcNoData = TRUE;
     double             *padfSrcNoData = nullptr;
@@ -368,29 +380,6 @@ VRTBuilder::~VRTBuilder()
     CPLFree(ppszInputFilenames);
     CPLFree(pahSrcDS);
 
-    if (pasDatasetProperties != nullptr)
-    {
-        for(int i=0;i<nInputFiles;i++)
-        {
-            CPLFree(pasDatasetProperties[i].padfNoDataValues);
-            CPLFree(pasDatasetProperties[i].pabHasNoData);
-            CPLFree(pasDatasetProperties[i].padfOffset);
-            CPLFree(pasDatasetProperties[i].pabHasOffset);
-            CPLFree(pasDatasetProperties[i].padfScale);
-            CPLFree(pasDatasetProperties[i].pabHasScale);
-        }
-    }
-    CPLFree(pasDatasetProperties);
-
-    if (!bSeparate && pasBandProperties != nullptr)
-    {
-        for(int j=0;j<nBands;j++)
-        {
-            GDALDestroyColorTable(pasBandProperties[j].colorTable);
-        }
-    }
-    CPLFree(pasBandProperties);
-
     CPLFree(pszProjectionRef);
     CPLFree(padfSrcNoData);
     CPLFree(padfVRTNoData);
@@ -443,15 +432,11 @@ static CPLString GetProjectionName(const char* pszProjection)
 
 int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetProperties)
 {
-    const char* dsFileName = GDALGetDescription(hDS);
-    char** papszMetadata = GDALGetMetadata( hDS, "SUBDATASETS" );
-    if( CSLCount(papszMetadata) > 0 && GDALGetRasterCount(hDS) == 0 )
+    GDALDataset* poDS = GDALDataset::FromHandle(hDS);
+    const char* dsFileName = poDS->GetDescription();
+    char** papszMetadata = poDS->GetMetadata( "SUBDATASETS" );
+    if( CSLCount(papszMetadata) > 0 && poDS->GetRasterCount() == 0 )
     {
-        pasDatasetProperties = static_cast<DatasetProperty *>(
-            CPLRealloc(pasDatasetProperties,
-                       (nInputFiles + CSLCount(papszMetadata)) *
-                       sizeof(DatasetProperty)));
-
         ppszInputFilenames = static_cast<char **>(
             CPLRealloc(ppszInputFilenames,
                        sizeof(char*) * (nInputFiles + CSLCount(papszMetadata))));
@@ -464,9 +449,10 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
             {
                 if (EQUALN(*papszMetadata, subdatasetNameKey, strlen(subdatasetNameKey)))
                 {
-                    memset(&pasDatasetProperties[nInputFiles], 0, sizeof(DatasetProperty));
-                    ppszInputFilenames[nInputFiles++] =
+                    asDatasetProperties.resize(nInputFiles+1);
+                    ppszInputFilenames[nInputFiles] =
                             CPLStrdup(*papszMetadata+strlen(subdatasetNameKey)+1);
+                    nInputFiles++;
                     count++;
                     snprintf(subdatasetNameKey, sizeof(subdatasetNameKey), "SUBDATASET_%d_NAME", count);
                 }
@@ -483,16 +469,17 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
             pszSubdatasetName = CSLFetchNameValue( papszMetadata, subdatasetNameKey );
             if ( pszSubdatasetName )
             {
-                memset( &pasDatasetProperties[nInputFiles], 0, sizeof(DatasetProperty) );
-                ppszInputFilenames[nInputFiles++] = CPLStrdup( pszSubdatasetName );
+                asDatasetProperties.resize(nInputFiles+1);
+                ppszInputFilenames[nInputFiles] = CPLStrdup( pszSubdatasetName );
+                nInputFiles++;
             }
         }
         return FALSE;
     }
 
-    const char* proj = GDALGetProjectionRef(hDS);
+    const char* proj = poDS->GetProjectionRef();
     double* padfGeoTransform = psDatasetProperties->adfGeoTransform;
-    int bGotGeoTransform = GDALGetGeoTransform(hDS, padfGeoTransform) == CE_None;
+    int bGotGeoTransform = poDS->GetGeoTransform(padfGeoTransform) == CE_None;
     if (bSeparate)
     {
         if (bFirst)
@@ -520,8 +507,8 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
             return FALSE;
         }
         else if (!bHasGeoTransform &&
-                    (nRasterXSize != GDALGetRasterXSize(hDS) ||
-                    nRasterYSize != GDALGetRasterYSize(hDS)))
+                    (nRasterXSize != poDS->GetRasterXSize() ||
+                    nRasterYSize != poDS->GetRasterYSize()))
         {
             CPLError(CE_Warning, CPLE_NotSupported,
                     "gdalbuildvrt -separate cannot stack ungeoreferenced images that have not the same dimensions. Skipping %s",
@@ -560,12 +547,12 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
         }
     }
 
-    psDatasetProperties->nRasterXSize = GDALGetRasterXSize(hDS);
-    psDatasetProperties->nRasterYSize = GDALGetRasterYSize(hDS);
+    psDatasetProperties->nRasterXSize = poDS->GetRasterXSize();
+    psDatasetProperties->nRasterYSize = poDS->GetRasterYSize();
     if (bFirst && bSeparate && !bGotGeoTransform)
     {
-        nRasterXSize = GDALGetRasterXSize(hDS);
-        nRasterYSize = GDALGetRasterYSize(hDS);
+        nRasterXSize = poDS->GetRasterXSize();
+        nRasterYSize = poDS->GetRasterYSize();
     }
 
     double ds_minX = padfGeoTransform[GEOTRSFRM_TOPLEFT_X];
@@ -576,10 +563,6 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
     double ds_minY = ds_maxY +
                 GDALGetRasterYSize(hDS) *
                 padfGeoTransform[GEOTRSFRM_NS_RES];
-
-    GDALGetBlockSize(GDALGetRasterBand( hDS, 1 ),
-                        &psDatasetProperties->nBlockXSize,
-                        &psDatasetProperties->nBlockYSize);
 
     int _nBands = GDALGetRasterCount(hDS);
 
@@ -604,62 +587,58 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
         _nBands = 1;
     }
 
+    GDALRasterBand* poFirstBand = poDS->GetRasterBand(1);
+    poFirstBand->GetBlockSize(
+                        &psDatasetProperties->nBlockXSize,
+                        &psDatasetProperties->nBlockYSize);
+
     /* For the -separate case */
-    psDatasetProperties->firstBandType = GDALGetRasterDataType(GDALGetRasterBand(hDS, 1));
+    psDatasetProperties->firstBandType = poFirstBand->GetRasterDataType();
 
-    psDatasetProperties->padfNoDataValues =
-        static_cast<double *>(CPLCalloc(sizeof(double), _nBands));
-    psDatasetProperties->pabHasNoData =
-        static_cast<bool *>(CPLCalloc(sizeof(bool), _nBands));
+    psDatasetProperties->adfNoDataValues.resize(_nBands);
+    psDatasetProperties->abHasNoData.resize(_nBands);
 
-    psDatasetProperties->padfOffset =
-        static_cast<double *>(CPLCalloc(sizeof(double), _nBands));
-    psDatasetProperties->pabHasOffset =
-        static_cast<bool *>(CPLCalloc(sizeof(bool), _nBands));
+    psDatasetProperties->adfOffset.resize(_nBands);
+    psDatasetProperties->abHasOffset.resize(_nBands);
 
-    psDatasetProperties->padfScale=
-        static_cast<double *>(CPLCalloc(sizeof(double), _nBands));
-    psDatasetProperties->pabHasScale =
-        static_cast<bool *>(CPLCalloc(sizeof(bool), _nBands));
+    psDatasetProperties->adfScale.resize(_nBands);
+    psDatasetProperties->abHasScale.resize(_nBands);
 
-    psDatasetProperties->bHasDatasetMask = GDALGetMaskFlags(GDALGetRasterBand(hDS, 1)) == GMF_PER_DATASET;
+    psDatasetProperties->bHasDatasetMask = poFirstBand->GetMaskFlags() == GMF_PER_DATASET;
     if (psDatasetProperties->bHasDatasetMask)
         bHasDatasetMask = TRUE;
-    GDALGetBlockSize(GDALGetMaskBand(GDALGetRasterBand( hDS, 1 )),
+    poFirstBand->GetMaskBand()->GetBlockSize(
                         &psDatasetProperties->nMaskBlockXSize,
                         &psDatasetProperties->nMaskBlockYSize);
 
-    int j;
-    for(j=0;j<_nBands;j++)
+    for(int j=0;j<_nBands;j++)
     {
+        GDALRasterBand* poBand = poDS->GetRasterBand(j+1);
         if (nSrcNoDataCount > 0)
         {
-            psDatasetProperties->pabHasNoData[j] = true;
+            psDatasetProperties->abHasNoData[j] = true;
             if (j < nSrcNoDataCount)
-                psDatasetProperties->padfNoDataValues[j] = padfSrcNoData[j];
+                psDatasetProperties->adfNoDataValues[j] = padfSrcNoData[j];
             else
-                psDatasetProperties->padfNoDataValues[j] = padfSrcNoData[nSrcNoDataCount - 1];
+                psDatasetProperties->adfNoDataValues[j] = padfSrcNoData[nSrcNoDataCount - 1];
         }
         else
         {
             int bHasNoData = false;
-            psDatasetProperties->padfNoDataValues[j]  =
-                GDALGetRasterNoDataValue(GDALGetRasterBand(hDS, j+1),
-                                         &bHasNoData);
-            psDatasetProperties->pabHasNoData[j] = bHasNoData != 0;
+            psDatasetProperties->adfNoDataValues[j]  =
+                poBand->GetNoDataValue(&bHasNoData);
+            psDatasetProperties->abHasNoData[j] = bHasNoData != 0;
         }
 
         int bHasOffset = false;
-        psDatasetProperties->padfOffset[j] =
-            GDALGetRasterOffset(GDALGetRasterBand(hDS, j+1), &bHasOffset);
-        psDatasetProperties->pabHasOffset[j] = bHasOffset != 0 &&
-                            psDatasetProperties->padfOffset[j] != 0.0;
+        psDatasetProperties->adfOffset[j] = poBand->GetOffset(&bHasOffset);
+        psDatasetProperties->abHasOffset[j] = bHasOffset != 0 &&
+                            psDatasetProperties->adfOffset[j] != 0.0;
 
         int bHasScale = false;
-        psDatasetProperties->padfScale[j] =
-            GDALGetRasterScale(GDALGetRasterBand(hDS, j+1), &bHasScale);
-        psDatasetProperties->pabHasScale[j] = bHasScale != 0 &&
-                            psDatasetProperties->padfScale[j] != 1.0;
+        psDatasetProperties->adfScale[j] = poBand->GetScale(&bHasScale);
+        psDatasetProperties->abHasScale[j] = bHasScale != 0 &&
+                            psDatasetProperties->adfScale[j] != 1.0;
     }
 
     if (bFirst)
@@ -680,7 +659,7 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
             nBands = _nBands;
             CPLFree(panBandList);
             panBandList = static_cast<int *>(CPLMalloc(nBands * sizeof(int)));
-            for(j=0;j<nBands;j++)
+            for(int j=0;j<nBands;j++)
             {
                 panBandList[j] = j + 1;
                 if(nMaxBandNo < j + 1)
@@ -689,54 +668,49 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
         }
         if (!bSeparate)
         {
-            pasBandProperties = static_cast<BandProperty *>(
-                CPLMalloc(nMaxBandNo * sizeof(BandProperty)));
-            for(j=0;j<nMaxBandNo;j++)
+            asBandProperties.resize(nMaxBandNo);
+            for(int j=0;j<nMaxBandNo;j++)
             {
-                GDALRasterBandH hRasterBand = GDALGetRasterBand( hDS, j+1 );
-                pasBandProperties[j].colorInterpretation =
-                        GDALGetRasterColorInterpretation(hRasterBand);
-                pasBandProperties[j].dataType = GDALGetRasterDataType(hRasterBand);
-                if (pasBandProperties[j].colorInterpretation == GCI_PaletteIndex)
+                GDALRasterBand* poBand = poDS->GetRasterBand(j+1 );
+                asBandProperties[j].colorInterpretation =
+                        poBand->GetColorInterpretation();
+                asBandProperties[j].dataType = poBand->GetRasterDataType();
+                if (asBandProperties[j].colorInterpretation == GCI_PaletteIndex)
                 {
-                    pasBandProperties[j].colorTable =
-                            GDALGetRasterColorTable( hRasterBand );
-                    if (pasBandProperties[j].colorTable)
+                    auto colorTable = poBand->GetColorTable();
+                    if (colorTable)
                     {
-                        pasBandProperties[j].colorTable =
-                                GDALCloneColorTable(pasBandProperties[j].colorTable);
+                        asBandProperties[j].colorTable.reset(colorTable->Clone());
                     }
                 }
                 else
-                    pasBandProperties[j].colorTable = nullptr;
+                    asBandProperties[j].colorTable = nullptr;
 
                 if (nVRTNoDataCount > 0)
                 {
-                    pasBandProperties[j].bHasNoData = true;
+                    asBandProperties[j].bHasNoData = true;
                     if (j < nVRTNoDataCount)
-                        pasBandProperties[j].noDataValue = padfVRTNoData[j];
+                        asBandProperties[j].noDataValue = padfVRTNoData[j];
                     else
-                        pasBandProperties[j].noDataValue = padfVRTNoData[nVRTNoDataCount - 1];
+                        asBandProperties[j].noDataValue = padfVRTNoData[nVRTNoDataCount - 1];
                 }
                 else
                 {
                     int bHasNoData = false;
-                    pasBandProperties[j].noDataValue =
-                            GDALGetRasterNoDataValue(hRasterBand, &bHasNoData);
-                    pasBandProperties[j].bHasNoData = bHasNoData != 0;
+                    asBandProperties[j].noDataValue =
+                            poBand->GetNoDataValue(&bHasNoData);
+                    asBandProperties[j].bHasNoData = bHasNoData != 0;
                 }
 
                 int bHasOffset = false;
-                pasBandProperties[j].dfOffset =
-                    GDALGetRasterOffset(hRasterBand, &bHasOffset);
-                pasBandProperties[j].bHasOffset = bHasOffset != 0 &&
-                                pasBandProperties[j].dfOffset != 0.0;
+                asBandProperties[j].dfOffset = poBand->GetOffset(&bHasOffset);
+                asBandProperties[j].bHasOffset = bHasOffset != 0 &&
+                                asBandProperties[j].dfOffset != 0.0;
 
                 int bHasScale = false;
-                pasBandProperties[j].dfScale =
-                    GDALGetRasterScale(hRasterBand, &bHasScale);
-                pasBandProperties[j].bHasScale = bHasScale != 0 && 
-                                pasBandProperties[j].dfScale != 1.0;
+                asBandProperties[j].dfScale = poBand->GetScale(&bHasScale);
+                asBandProperties[j].bHasScale = bHasScale != 0 &&
+                                asBandProperties[j].dfScale != 1.0;
             }
         }
     }
@@ -770,43 +744,42 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
                          _nBands, nMaxBandNo, dsFileName);
                 return FALSE;
             }
-            for(j=0;j<nMaxBandNo;j++)
+            for(int j=0;j<nMaxBandNo;j++)
             {
-                GDALRasterBandH hRasterBand = GDALGetRasterBand( hDS, j+1 );
-                if (pasBandProperties[j].colorInterpretation !=
-                            GDALGetRasterColorInterpretation(hRasterBand))
+                GDALRasterBand* poBand = poDS->GetRasterBand(j+1 );
+                if (asBandProperties[j].colorInterpretation !=
+                            poBand->GetColorInterpretation())
                 {
                     CPLError(CE_Warning, CPLE_NotSupported,
                              "gdalbuildvrt does not support heterogeneous "
                              "band color interpretation: expected %s, got %s. "
                              "Skipping %s",
                              GDALGetColorInterpretationName(
-                                 pasBandProperties[j].colorInterpretation),
+                                 asBandProperties[j].colorInterpretation),
                              GDALGetColorInterpretationName(
-                                 GDALGetRasterColorInterpretation(hRasterBand)),
+                                 poBand->GetColorInterpretation()),
                              dsFileName);
                     return FALSE;
                 }
-                if (pasBandProperties[j].dataType !=
-                                    GDALGetRasterDataType(hRasterBand))
+                if (asBandProperties[j].dataType != poBand->GetRasterDataType())
                 {
                     CPLError(CE_Warning, CPLE_NotSupported,
                              "gdalbuildvrt does not support heterogeneous "
                              "band data type: expected %s, got %s. "
                              "Skipping %s",
                              GDALGetDataTypeName(
-                                 pasBandProperties[j].dataType),
+                                 asBandProperties[j].dataType),
                              GDALGetDataTypeName(
-                                 GDALGetRasterDataType(hRasterBand)),
+                                 poBand->GetRasterDataType()),
                              dsFileName);
                     return FALSE;
                 }
-                if (pasBandProperties[j].colorTable)
+                if (asBandProperties[j].colorTable)
                 {
-                    GDALColorTableH colorTable = GDALGetRasterColorTable( hRasterBand );
-                    int nRefColorEntryCount = GDALGetColorEntryCount(pasBandProperties[j].colorTable);
+                    const GDALColorTable* colorTable = poBand->GetColorTable();
+                    int nRefColorEntryCount = asBandProperties[j].colorTable->GetColorEntryCount();
                     if (colorTable == nullptr ||
-                        GDALGetColorEntryCount(colorTable) != nRefColorEntryCount)
+                        colorTable->GetColorEntryCount() != nRefColorEntryCount)
                     {
                         CPLError(CE_Warning, CPLE_NotSupported,
                                     "gdalbuildvrt does not support rasters with different color tables (different number of color table entries). Skipping %s",
@@ -819,8 +792,8 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
                     /* should check that the end result is OK for him. */
                     for(int i=0;i<nRefColorEntryCount;i++)
                     {
-                        const GDALColorEntry* psEntry = GDALGetColorEntry(colorTable, i);
-                        const GDALColorEntry* psEntryRef = GDALGetColorEntry(pasBandProperties[j].colorTable, i);
+                        const GDALColorEntry* psEntry = colorTable->GetColorEntry(i);
+                        const GDALColorEntry* psEntryRef = asBandProperties[j].colorTable->GetColorEntry(i);
                         if (psEntry->c1 != psEntryRef->c1 || psEntry->c2 != psEntryRef->c2 ||
                             psEntry->c3 != psEntryRef->c3 || psEntry->c4 != psEntryRef->c4)
                         {
@@ -841,34 +814,34 @@ int VRTBuilder::AnalyseRaster( GDALDatasetH hDS, DatasetProperty* psDatasetPrope
                     }
                 }
 
-                if( psDatasetProperties->pabHasOffset[j] != pasBandProperties[j].bHasOffset ||
-                    (pasBandProperties[j].bHasOffset &&
-                     psDatasetProperties->padfOffset[j] != pasBandProperties[j].dfOffset) )
+                if( psDatasetProperties->abHasOffset[j] != asBandProperties[j].bHasOffset ||
+                    (asBandProperties[j].bHasOffset &&
+                     psDatasetProperties->adfOffset[j] != asBandProperties[j].dfOffset) )
                 {
                     CPLError(CE_Warning, CPLE_NotSupported,
                              "gdalbuildvrt does not support heterogeneous "
                              "band offset: expected (%d,%f), got (%d,%f). "
                              "Skipping %s",
-                             static_cast<int>(pasBandProperties[j].bHasOffset),
-                             pasBandProperties[j].dfOffset,
-                             static_cast<int>(psDatasetProperties->pabHasOffset[j]),
-                             psDatasetProperties->padfOffset[j],
+                             static_cast<int>(asBandProperties[j].bHasOffset),
+                             asBandProperties[j].dfOffset,
+                             static_cast<int>(psDatasetProperties->abHasOffset[j]),
+                             psDatasetProperties->adfOffset[j],
                              dsFileName);
                     return FALSE;
                 }
 
-                if( psDatasetProperties->pabHasScale[j] != pasBandProperties[j].bHasScale ||
-                    (pasBandProperties[j].bHasScale &&
-                     psDatasetProperties->padfScale[j] != pasBandProperties[j].dfScale) )
+                if( psDatasetProperties->abHasScale[j] != asBandProperties[j].bHasScale ||
+                    (asBandProperties[j].bHasScale &&
+                     psDatasetProperties->adfScale[j] != asBandProperties[j].dfScale) )
                 {
                     CPLError(CE_Warning, CPLE_NotSupported,
                              "gdalbuildvrt does not support heterogeneous "
                              "band scale: expected (%d,%f), got (%d,%f). "
                              "Skipping %s",
-                             static_cast<int>(pasBandProperties[j].bHasScale),
-                             pasBandProperties[j].dfScale,
-                             static_cast<int>(psDatasetProperties->pabHasScale[j]),
-                             psDatasetProperties->padfScale[j],
+                             static_cast<int>(asBandProperties[j].bHasScale),
+                             asBandProperties[j].dfScale,
+                             static_cast<int>(psDatasetProperties->abHasScale[j]),
+                             psDatasetProperties->adfScale[j],
                              dsFileName);
                     return FALSE;
                 }
@@ -922,7 +895,7 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
     int iBand = 1;
     for(int i=0; ppszInputFilenames != nullptr && i<nInputFiles;i++)
     {
-        DatasetProperty* psDatasetProperties = &pasDatasetProperties[i];
+        DatasetProperty* psDatasetProperties = &asDatasetProperties[i];
 
         if (psDatasetProperties->isFileOK == FALSE)
             continue;
@@ -972,11 +945,11 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
         VRTSourcedRasterBand* poVRTBand = static_cast<VRTSourcedRasterBand*>(hVRTBand);
 
         VRTSimpleSource* poSimpleSource;
-        if (bAllowSrcNoData && psDatasetProperties->pabHasNoData[0])
+        if (bAllowSrcNoData && psDatasetProperties->abHasNoData[0])
         {
-            GDALSetRasterNoDataValue(hVRTBand, psDatasetProperties->padfNoDataValues[0]);
+            GDALSetRasterNoDataValue(hVRTBand, psDatasetProperties->adfNoDataValues[0]);
             poSimpleSource = new VRTComplexSource();
-            poSimpleSource->SetNoDataValue( psDatasetProperties->padfNoDataValues[0] );
+            poSimpleSource->SetNoDataValue( psDatasetProperties->adfNoDataValues[0] );
         }
         else
             poSimpleSource = new VRTSimpleSource();
@@ -990,11 +963,11 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
                                     dfDstXOff, dfDstYOff,
                                     dfDstXSize, dfDstYSize );
 
-        if( psDatasetProperties->pabHasOffset[0] )
-            poVRTBand->SetOffset( psDatasetProperties->padfOffset[0] );
+        if( psDatasetProperties->abHasOffset[0] )
+            poVRTBand->SetOffset( psDatasetProperties->adfOffset[0] );
 
-        if( psDatasetProperties->pabHasScale[0] )
-            poVRTBand->SetScale( psDatasetProperties->padfScale[0] );
+        if( psDatasetProperties->abHasScale[0] )
+            poVRTBand->SetScale( psDatasetProperties->adfScale[0] );
 
         poVRTBand->AddSource( poSimpleSource );
 
@@ -1010,46 +983,45 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
 
 void VRTBuilder::CreateVRTNonSeparate(VRTDatasetH hVRTDS)
 {
+    VRTDataset* poVRTDS = reinterpret_cast<VRTDataset*>(hVRTDS);
     for(int j=0;j<nBands;j++)
     {
-        GDALRasterBandH hBand;
-        int nSelBand = panBandList[j]-1;
-        GDALAddBand(hVRTDS, pasBandProperties[nSelBand].dataType, nullptr);
-        hBand = GDALGetRasterBand(hVRTDS, j+1);
-        GDALSetRasterColorInterpretation(hBand, pasBandProperties[nSelBand].colorInterpretation);
-        if (pasBandProperties[nSelBand].colorInterpretation == GCI_PaletteIndex)
+        const int nSelBand = panBandList[j]-1;
+        poVRTDS->AddBand(asBandProperties[nSelBand].dataType);
+        GDALRasterBand *poBand = poVRTDS->GetRasterBand(j+1);
+        poBand->SetColorInterpretation(asBandProperties[nSelBand].colorInterpretation);
+        if (asBandProperties[nSelBand].colorInterpretation == GCI_PaletteIndex)
         {
-            GDALSetRasterColorTable(hBand, pasBandProperties[nSelBand].colorTable);
+            poBand->SetColorTable(asBandProperties[nSelBand].colorTable.get());
         }
-        if (bAllowVRTNoData && pasBandProperties[nSelBand].bHasNoData)
-            GDALSetRasterNoDataValue(hBand, pasBandProperties[nSelBand].noDataValue);
+        if (bAllowVRTNoData && asBandProperties[nSelBand].bHasNoData)
+            poBand->SetNoDataValue(asBandProperties[nSelBand].noDataValue);
         if ( bHideNoData )
-            GDALSetMetadataItem(hBand,"HideNoDataValue","1",nullptr);
+            poBand->SetMetadataItem("HideNoDataValue","1");
 
-        if( pasBandProperties[nSelBand].bHasOffset )
-            GDALSetRasterOffset( hBand, pasBandProperties[nSelBand].dfOffset );
+        if( asBandProperties[nSelBand].bHasOffset )
+            poBand->SetOffset( asBandProperties[nSelBand].dfOffset );
 
-        if( pasBandProperties[nSelBand].bHasScale )
-            GDALSetRasterScale( hBand, pasBandProperties[nSelBand].dfScale );
+        if( asBandProperties[nSelBand].bHasScale )
+            poBand->SetScale( asBandProperties[nSelBand].dfScale );
     }
 
     VRTSourcedRasterBand* poMaskVRTBand = nullptr;
     if (bAddAlpha)
     {
-        GDALRasterBandH hBand;
-        GDALAddBand(hVRTDS, GDT_Byte, nullptr);
-        hBand = GDALGetRasterBand(hVRTDS, nBands + 1);
-        GDALSetRasterColorInterpretation(hBand, GCI_AlphaBand);
+        poVRTDS->AddBand(GDT_Byte);
+        GDALRasterBand *poBand = poVRTDS->GetRasterBand(nBands + 1);
+        poBand->SetColorInterpretation(GCI_AlphaBand);
     }
     else if (bHasDatasetMask)
     {
-        GDALCreateDatasetMaskBand(hVRTDS, GMF_PER_DATASET);
-        poMaskVRTBand = static_cast<VRTSourcedRasterBand*>(GDALGetMaskBand(GDALGetRasterBand(hVRTDS, 1)));
+        poVRTDS->CreateMaskBand(GMF_PER_DATASET);
+        poMaskVRTBand = static_cast<VRTSourcedRasterBand*>(poVRTDS->GetRasterBand(1)->GetMaskBand());
     }
 
     for( int i = 0; ppszInputFilenames != nullptr && i < nInputFiles; i++ )
     {
-        DatasetProperty* psDatasetProperties = &pasDatasetProperties[i];
+        DatasetProperty* psDatasetProperties = &asDatasetProperties[i];
 
         if (psDatasetProperties->isFileOK == FALSE)
             continue;
@@ -1096,7 +1068,7 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDatasetH hVRTDS)
             for(int j=0;j<nMaxBandNo;j++)
             {
                 GDALProxyPoolDatasetAddSrcBandDescription(hProxyDS,
-                                                pasBandProperties[j].dataType,
+                                                asBandProperties[j].dataType,
                                                 psDatasetProperties->nBlockXSize,
                                                 psDatasetProperties->nBlockYSize);
             }
@@ -1114,17 +1086,17 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDatasetH hVRTDS)
         for(int j=0;j<nBands;j++)
         {
             VRTSourcedRasterBandH hVRTBand =
-                    static_cast<VRTSourcedRasterBandH>(GDALGetRasterBand(hVRTDS, j + 1));
+                    static_cast<VRTSourcedRasterBandH>(poVRTDS->GetRasterBand(j + 1));
 
             /* Place the raster band at the right position in the VRT */
             int nSelBand = panBandList[j] - 1;
             VRTSourcedRasterBand* poVRTBand = static_cast<VRTSourcedRasterBand*>(hVRTBand);
 
             VRTSimpleSource* poSimpleSource;
-            if (bAllowSrcNoData && psDatasetProperties->pabHasNoData[nSelBand])
+            if (bAllowSrcNoData && psDatasetProperties->abHasNoData[nSelBand])
             {
                 poSimpleSource = new VRTComplexSource();
-                poSimpleSource->SetNoDataValue( psDatasetProperties->padfNoDataValues[nSelBand] );
+                poSimpleSource->SetNoDataValue( psDatasetProperties->adfNoDataValues[nSelBand] );
             }
             else
                 poSimpleSource = new VRTSimpleSource();
@@ -1217,8 +1189,7 @@ GDALDataset* VRTBuilder::Build(GDALProgressFunc pfnProgress, void * pProgressDat
         we_res = ns_res = 0;
     }
 
-    pasDatasetProperties = static_cast<DatasetProperty *>(
-        CPLCalloc(nInputFiles, sizeof(DatasetProperty)));
+    asDatasetProperties.resize(nInputFiles);
 
     if (pszSrcNoData != nullptr)
     {
@@ -1293,13 +1264,13 @@ GDALDataset* VRTBuilder::Build(GDALProgressFunc pfnProgress, void * pProgressDat
                 GDALOpenEx( ppszInputFilenames[i],
                             GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR, nullptr,
                             papszOpenOptions, nullptr );
-        pasDatasetProperties[i].isFileOK = FALSE;
+        asDatasetProperties[i].isFileOK = FALSE;
 
         if (hDS)
         {
-            if (AnalyseRaster( hDS, &pasDatasetProperties[i] ))
+            if (AnalyseRaster( hDS, &asDatasetProperties[i] ))
             {
-                pasDatasetProperties[i].isFileOK = TRUE;
+                asDatasetProperties[i].isFileOK = TRUE;
                 nCountValid ++;
                 bFirst = FALSE;
             }

--- a/gdal/data/gdalvrt.xsd
+++ b/gdal/data/gdalvrt.xsd
@@ -45,6 +45,7 @@
                     <xs:element name="GDALWarpOptions" type="GDALWarpOptionsType"/> <!-- only if subClass="VRTWarpedDataset" -->
                     <xs:element name="PansharpeningOptions" type="PansharpeningOptionsType"/> <!-- only if subClass="VRTPansharpenedDataset" -->
                     <xs:element name="Group" type="GroupType"/> <!-- only for multidimensionnal dataset -->
+                    <xs:element name="OverviewList" type="OverviewListType"/>
                 </xs:choice>
             </xs:sequence>
             <xs:attribute name="subClass" type="xs:string"/>
@@ -52,6 +53,18 @@
             <xs:attribute name="rasterYSize" type="nonNegativeInteger32"/>
         </xs:complexType>
     </xs:element>
+
+    <xs:complexType name="OverviewListType">
+        <xs:simpleContent>
+            <xs:extension base="integerList">
+                <xs:attribute name="resampling" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="integerList">
+        <xs:list itemType="xs:integer"/>
+    </xs:simpleType>
 
     <xs:complexType name="SRSType">
         <xs:simpleContent>

--- a/gdal/doc/source/drivers/raster/vrt.rst
+++ b/gdal/doc/source/drivers/raster/vrt.rst
@@ -116,6 +116,22 @@ The **dataAxisToSRSAxisMapping** attribute is allowed since GDAL 3.0 to describe
     </VRTRasterBand>
   </MaskBand>
 
+- **OverviewList**: (GDAL >= 3.2.0, not valid for VRTPansharpenedDataset)
+  This elements contains a list of overview factors, separated by space, to
+  create "virtual overviews". For example ``2 4``. It can be used so that bands
+  of the VRT datasets declare overviews. This only makes sense to use if the
+  sources added in those bands have themselves overviews compatible of the
+  declared factor. It is generally not needed to use this mechanism, since
+  downsampling pixel requests on a VRT dataset/band are able to use  of the
+  sources, even when the VRT bands do not declare them. One situation where
+  explicit overviews are needed at the VRT level is for example warping a VRT
+  to a lower resolution.
+  This element can also be used to an existing VRT dataset by running
+  :cpp:func:`GDALDataset::BuildOverviews` or :program:`gdaladdo` with the
+  :decl_configoption:`VRT_VIRTUAL_OVERVIEWS` configuration option set to ``YES``.
+  Virtual overviews have the least priority compared to the **Overview** element
+  at the **VRTRasterBand** level, or to materialized .vrt.ovr files.
+
 
 - **VRTRasterBand**: This represents one band of a dataset.
 
@@ -436,7 +452,12 @@ Except if (from top priority to lesser priority) :
 
 - The **Overview** element is present in the VRTRasterBand element. See above.
 - or external .vrt.ovr overviews are built
-- (starting with GDAL 2.1) if the VRTRasterBand are made of a single SimpleSource or ComplexSource that has overviews. Those "virtual" overviews will be hidden by external .vrt.ovr overviews that might be built later.
+- (starting with GDAL 3.2) explicit virtual overviews, if a **OverviewList** element
+  is declared in the VRTDataset element (see above).
+  Those virtual overviews will be hidden by external .vrt.ovr overviews that might be built later.
+- (starting with GDAL 2.1) implicit virtual overviews, if the VRTRasterBand are made of
+  a single SimpleSource or ComplexSource that has overviews.
+  Those virtual overviews will be hidden by external .vrt.ovr overviews that might be built later.
 
 .vrt Descriptions for Raw Files
 -------------------------------

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -179,27 +179,33 @@ class CPL_DLL VRTDataset CPL_NON_FINAL: public GDALDataset
 
     OGRSpatialReference* m_poSRS = nullptr;
 
-    int            m_bGeoTransformSet;
+    int            m_bGeoTransformSet = false;
     double         m_adfGeoTransform[6];
 
-    int            m_nGCPCount;
-    GDAL_GCP      *m_pasGCPList;
+    int            m_nGCPCount = 0;
+    GDAL_GCP      *m_pasGCPList = nullptr;
     OGRSpatialReference *m_poGCP_SRS = nullptr;
 
-    int            m_bNeedsFlush;
-    int            m_bWritable;
+    bool           m_bNeedsFlush = false;
+    bool           m_bWritable = true;
+    bool           m_bCanTakeRef = true;
 
-    char          *m_pszVRTPath;
+    char          *m_pszVRTPath = nullptr;
 
-    VRTRasterBand *m_poMaskBand;
+    VRTRasterBand *m_poMaskBand = nullptr;
 
-    int            m_bCompatibleForDatasetIO;
+    int            m_bCompatibleForDatasetIO = -1;
     int            CheckCompatibleForDatasetIO();
     void           ExpandProxyBands();
 
+    // Virtual (ie not materialized) overviews, created either implicitly
+    // when it is cheap to do it, or explicitly.
     std::vector<GDALDataset*> m_apoOverviews{};
     std::vector<GDALDataset*> m_apoOverviewsBak{};
-    char         **m_papszXMLVRTMetadata;
+    CPLString           m_osOverviewResampling{};
+    std::vector<int>    m_anOverviewFactors{};
+
+    char         **m_papszXMLVRTMetadata = nullptr;
 
     std::map<CPLString, GDALDataset*> m_oMapSharedSources{};
     std::shared_ptr<VRTGroup> m_poRootGroup{};
@@ -209,6 +215,8 @@ class CPL_DLL VRTDataset CPL_NON_FINAL: public GDALDataset
     VRTRasterBand*      InitBand(const char* pszSubclass, int nBand,
                                  bool bAllowPansharpened);
     static GDALDataset *OpenVRTProtocol( const char* pszSpec );
+    bool                AddVirtualOverview(int nOvFactor,
+                                           const char* pszResampling);
 
     CPL_DISALLOW_COPY_ASSIGN(VRTDataset)
 
@@ -219,10 +227,10 @@ class CPL_DLL VRTDataset CPL_NON_FINAL: public GDALDataset
                  VRTDataset(int nXSize, int nYSize);
     virtual ~VRTDataset();
 
-    void          SetNeedsFlush() { m_bNeedsFlush = TRUE; }
+    void          SetNeedsFlush() { m_bNeedsFlush = true; }
     virtual void  FlushCache() override;
 
-    void SetWritable(int bWritableIn) { m_bWritable = bWritableIn; }
+    void SetWritable(int bWritableIn) { m_bWritable = CPL_TO_BOOL(bWritableIn); }
 
     virtual CPLErr          CreateMaskBand( int nFlags ) override;
     void SetMaskBand(VRTRasterBand* poMaskBand);
@@ -879,6 +887,7 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL: public VRTSource
 
 protected:
     friend class VRTSourcedRasterBand;
+    friend class VRTDataset;
 
     GDALRasterBand      *m_poRasterBand;
 
@@ -905,6 +914,8 @@ protected:
     int                 m_bRelativeToVRTOri;
     CPLString           m_osSourceFileNameOri{};
     int                 m_nExplicitSharedStatus; // -1 unknown, 0 = unshared, 1 = shared
+
+    bool                m_bDropRefOnSrcBand;
 
     int                 NeedMaxValAdjustment() const;
 

--- a/gdal/frmts/vrt/vrtsources.cpp
+++ b/gdal/frmts/vrt/vrtsources.cpp
@@ -111,7 +111,8 @@ VRTSimpleSource::VRTSimpleSource() :
     m_dfNoDataValue(VRT_NODATA_UNSET),
     m_nMaxValue(0),
     m_bRelativeToVRTOri(-1),
-    m_nExplicitSharedStatus(-1)
+    m_nExplicitSharedStatus(-1),
+    m_bDropRefOnSrcBand(true)
 {}
 
 /************************************************************************/
@@ -134,7 +135,8 @@ VRTSimpleSource::VRTSimpleSource( const VRTSimpleSource* poSrcSource,
     m_dfNoDataValue(poSrcSource->m_dfNoDataValue),
     m_nMaxValue(poSrcSource->m_nMaxValue),
     m_bRelativeToVRTOri(-1),
-    m_nExplicitSharedStatus(poSrcSource->m_nExplicitSharedStatus)
+    m_nExplicitSharedStatus(poSrcSource->m_nExplicitSharedStatus),
+    m_bDropRefOnSrcBand(poSrcSource->m_bDropRefOnSrcBand)
 {}
 
 /************************************************************************/
@@ -144,6 +146,9 @@ VRTSimpleSource::VRTSimpleSource( const VRTSimpleSource* poSrcSource,
 VRTSimpleSource::~VRTSimpleSource()
 
 {
+    if( !m_bDropRefOnSrcBand )
+        return;
+
     if( m_poMaskBandMainBand != nullptr )
     {
         if( m_poMaskBandMainBand->GetDataset() != nullptr )


### PR DESCRIPTION
- Explicit virtual overviews are overviews that are reported on VRT rasterbands,
and rely only on the fact that the source(s) making those bands have themselves
overviews, but this is not enforced.
Such virtual overviews are generally not needed, unless in some situations, like
wrapping a VRT dataset to a lower resolution.
The VRTDataset.OverviewList XML element is added to declare such overviews.
GDALDataset::BuildOverviews() can also 'build' them when the VRT_VIRTUAL_OVERVIEWS
configuration option is set to YES.

-  gdalbuildvrt: add support for automatically declaring virtual overviews in very restricted situations.
All sources must have the same resolution, and this must be the one of
the VRT dataset itself.

