### PR TITLE
nitf: add TREs in support of Spectral NITF Implementation Profile

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2560,6 +2560,106 @@ def test_nitf_75():
     assert data == expected_data
 
 ###############################################################################
+# Test parsing MATESA TRE (STDI-0002 App AK)
+
+def test_nitf_76():
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_76.ntf', 1, 1, options=['FILE_TRE=MATESA=EO-1_HYPERION                             FTITLE          006307APR2005_Hyperion_331406N0442000E_SWIR172_001_L1R-01B-BIB-GLAS0005RADIOMTRC_CALIB         0001EO-1_HYPERION                             FILENAME        0020HypGain_revC.dat.svfPARENT                  0001EO-1_HYPERION                             FILENAME        0032EO12005097_020D020C_r1_WPS_01.L0PRE_DARKCOLLECT         0001EO-1_HYPERION                             FILENAME        0032EO12005097_020A0209_r1_WPS_01.L0POST_DARKCOLLECT        0001EO-1_HYPERION                             FILENAME        0032EO12005097_020F020E_r1_WPS_01.L0PARENT                  0003EO-1_HYPERION                             FILENAME        0026EO1H1680372005097110PZ.L1REO-1_HYPERION                             FILENAME        0026EO1H1680372005097110PZ.AUXEO-1_HYPERION                             FILENAME        0026EO1H1680372005097110PZ.MET'])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_76.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_76.ntf')
+
+    expected_data = """<tres>
+  <tre name="MATESA" location="file">
+    <field name="CUR_SOURCE" value="EO-1_HYPERION" />
+    <field name="CUR_MATE_TYPE" value="FTITLE" />
+    <field name="CUR_FILE_ID_LEN" value="0063" />
+    <field name="CUR_FILE_ID" value="07APR2005_Hyperion_331406N0442000E_SWIR172_001_L1R-01B-BIB-GLAS" />
+    <field name="NUM_GROUPS" value="0005" />
+    <repeated name="GROUPS" number="5">
+      <group index="0">
+        <field name="RELATIONSHIP" value="RADIOMTRC_CALIB" />
+        <field name="NUM_MATES" value="0001" />
+        <repeated name="MATES" number="1">
+          <group index="0">
+            <field name="SOURCE" value="EO-1_HYPERION" />
+            <field name="MATE_TYPE" value="FILENAME" />
+            <field name="MATE_ID_LEN" value="0020" />
+            <field name="MATE_ID" value="HypGain_revC.dat.svf" />
+          </group>
+        </repeated>
+      </group>
+      <group index="1">
+        <field name="RELATIONSHIP" value="PARENT" />
+        <field name="NUM_MATES" value="0001" />
+        <repeated name="MATES" number="1">
+          <group index="0">
+            <field name="SOURCE" value="EO-1_HYPERION" />
+            <field name="MATE_TYPE" value="FILENAME" />
+            <field name="MATE_ID_LEN" value="0032" />
+            <field name="MATE_ID" value="EO12005097_020D020C_r1_WPS_01.L0" />
+          </group>
+        </repeated>
+      </group>
+      <group index="2">
+        <field name="RELATIONSHIP" value="PRE_DARKCOLLECT" />
+        <field name="NUM_MATES" value="0001" />
+        <repeated name="MATES" number="1">
+          <group index="0">
+            <field name="SOURCE" value="EO-1_HYPERION" />
+            <field name="MATE_TYPE" value="FILENAME" />
+            <field name="MATE_ID_LEN" value="0032" />
+            <field name="MATE_ID" value="EO12005097_020A0209_r1_WPS_01.L0" />
+          </group>
+        </repeated>
+      </group>
+      <group index="3">
+        <field name="RELATIONSHIP" value="POST_DARKCOLLECT" />
+        <field name="NUM_MATES" value="0001" />
+        <repeated name="MATES" number="1">
+          <group index="0">
+            <field name="SOURCE" value="EO-1_HYPERION" />
+            <field name="MATE_TYPE" value="FILENAME" />
+            <field name="MATE_ID_LEN" value="0032" />
+            <field name="MATE_ID" value="EO12005097_020F020E_r1_WPS_01.L0" />
+          </group>
+        </repeated>
+      </group>
+      <group index="4">
+        <field name="RELATIONSHIP" value="PARENT" />
+        <field name="NUM_MATES" value="0003" />
+        <repeated name="MATES" number="3">
+          <group index="0">
+            <field name="SOURCE" value="EO-1_HYPERION" />
+            <field name="MATE_TYPE" value="FILENAME" />
+            <field name="MATE_ID_LEN" value="0026" />
+            <field name="MATE_ID" value="EO1H1680372005097110PZ.L1R" />
+          </group>
+          <group index="1">
+            <field name="SOURCE" value="EO-1_HYPERION" />
+            <field name="MATE_TYPE" value="FILENAME" />
+            <field name="MATE_ID_LEN" value="0026" />
+            <field name="MATE_ID" value="EO1H1680372005097110PZ.AUX" />
+          </group>
+          <group index="2">
+            <field name="SOURCE" value="EO-1_HYPERION" />
+            <field name="MATE_TYPE" value="FILENAME" />
+            <field name="MATE_ID_LEN" value="0026" />
+            <field name="MATE_ID" value="EO1H1680372005097110PZ.MET" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2660,6 +2660,38 @@ def test_nitf_76():
     assert data == expected_data
 
 ###############################################################################
+# Test parsing MATESA TRE (STDI-0002 App AK)
+
+def test_nitf_77():
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_77.ntf', 1, 1, options=['TRE=GRDPSB=01+000027.81PIX_LATLON0000000000010000000000010000000000000000000000'])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_77.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_77.ntf')
+
+    expected_data = """<tres>
+  <tre name="GRDPSB" location="image">
+    <field name="NUM_GRDS" value="01" />
+    <repeated name="GRDS" number="1">
+      <group index="0">
+        <field name="ZVL" value="+000027.81" />
+        <field name="BAD" value="PIX_LATLON" />
+        <field name="LOD" value="000000000001" />
+        <field name="LAD" value="000000000001" />
+        <field name="LSO" value="00000000000" />
+        <field name="PSO" value="00000000000" />
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -335,6 +335,19 @@
         <field name="ZNA" length="4" type="integer" minval="0"/>
     </tre>
 
+    <!-- STDI-0002-1, App. P Table P-4 Grid Reference Data (GRDPSB) TRE -->
+    <tre name="GRDPSB" location="image">
+        <field name="NUM_GRDS" length="2" minval="1" type="integer"/>
+        <loop counter="NUM_GRDS" md_prefix="GRD_%02d_" name="GRDS">
+            <field name="ZVL" length="10" unit="m" type="real"/>
+            <field name="BAD" length="10" type="string"/>
+            <field name="LOD" length="12" type="real"/>
+            <field name="LAD" length="12" type="real"/>
+            <field name="LSO" length="11" type="real"/>
+            <field name="PSO" length="11" type="real"/>
+        </loop>
+    </tre>
+
     <tre name="HISTOA" minlength="115" maxlength="83512" location="image">
         <field name="SYSTYPE" length="20"/>
         <field name="PC" length="12"/>

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -439,6 +439,25 @@
         <field name="PSO" length="15" type="real"/>
     </tre>
 
+    <!-- STDI-0002-1 Appendix AK: Table AK.6-5: MATESA -->
+    <tre name="MATESA" location="file">
+        <field name="CUR_SOURCE" length="42" type="string"/>
+        <field name="CUR_MATE_TYPE" length="16" type="string"/>
+        <field name="CUR_FILE_ID_LEN" length="4" type="integer" minval="1" maxval="9999"/>
+        <field name="CUR_FILE_ID" length_var="CUR_FILE_ID_LEN" type="string"/>
+        <field name="NUM_GROUPS" length="4" type="integer" minval="1" maxval="9999"/>
+        <loop counter="NUM_GROUPS" md_prefix="GROUP_%d" name="GROUPS">
+            <field name="RELATIONSHIP" length="24" type="string"/>
+            <field name="NUM_MATES" length="4" type="integer" minval="1" maxval="9999"/>
+            <loop counter="NUM_MATES" md_prefix="MATE_%d" name="MATES">
+                 <field name="SOURCE" length="42" type="string"/>
+                 <field name="MATE_TYPE" length="16" type="string"/>
+                 <field name="MATE_ID_LEN" length="4" type="integer" minval="1" maxval="9999"/>
+                 <field name="MATE_ID" length_var="MATE_ID_LEN" type="string"/>
+            </loop>
+        </loop>
+    </tre>
+
     <tre name="MENSRB" location="image">
         <field name="ACFT_LOC" length="25" type="string"/>
         <field name="ACFT_LOC_ACCY" length ="6" type="real"/>


### PR DESCRIPTION
## What does this PR do?
Adds additional NITF TREs in support of the Spectral NITF Implementation Profile (SNIP)

The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2. 
MATESA is defined in STDI-0002 Appendix AK. 
GRDPSB is defined in STDI-0002 Appendix P.

The test examples are from the SNIP Reference Implementation Product 1B, which is public released.

## What are related issues/pull requests?
N/A

## Tasklist

 - [X] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [X] All CI builds and checks have passed

## Environment
N/A