### PR TITLE
Docker/ubuntu-full: Add support for FileGDB and MDB drivers

### DIFF
--- a/gdal/docker/ubuntu-full/Dockerfile
+++ b/gdal/docker/ubuntu-full/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update -y \
             libtiff5-dev \
     && rm -rf /var/lib/apt/lists/*
 
+ARG JAVA_VERSION=11
 # Setup build env for GDAL
 RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
@@ -29,11 +30,11 @@ RUN apt-get update -y \
        libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev \
        curl libxml2-dev libexpat-dev libxerces-c-dev \
        libnetcdf-dev libpoppler-dev libpoppler-private-dev \
-       libspatialite-dev swig libhdf4-alt-dev libhdf5-serial-dev \
+       libspatialite-dev swig ant libhdf4-alt-dev libhdf5-serial-dev \
        libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev \
        liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev \
        libkml-dev libmysqlclient-dev libogdi-dev \
-       libcfitsio-dev openjdk-8-jdk libzstd-dev \
+       libcfitsio-dev openjdk-"$JAVA_VERSION"-jdk libzstd-dev \
        libpq-dev libssl-dev libboost-dev \
        autoconf automake bash-completion libarmadillo-dev \
        libopenexr-dev libheif-dev \
@@ -128,6 +129,32 @@ RUN if test "${OPENJPEG_VERSION}" != ""; then ( \
     && rm -rf openjpeg-${OPENJPEG_VERSION} \
     ); fi
 
+# Install MDB Driver Jars
+RUN wget -q https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mdb-sqlite/mdb-sqlite-1.0.2.tar.bz2 \
+  && tar -xjf mdb-sqlite-1.0.2.tar.bz2 \
+  && mkdir -p /build/usr/share/java \
+  && cp mdb-sqlite-1.0.2/lib/*.jar /build/usr/share/java \
+  && rm -rf mdb-sqlite-1.0.2.tar.bz2 && rm -rf mdb-sqlite-1.0.2
+
+#Set CLASSPATH so jars are found
+ENV CLASSPATH="/build/usr/share/java/jackcess-1.1.14.jar:/build/usr/share/java/commons-logging-1.1.1.jar:/build/usr/share/java/commons-lang-2.4.jar"
+
+#Build File Geodatabase
+
+ARG WITH_FILEGDB=
+RUN if echo "$WITH_FILEGDB" | grep -Eiq "^(y(es)?|1|true)$"  ; then ( \
+  wget -q https://github.com/Esri/file-geodatabase-api/raw/master/FileGDB_API_1.5.1/FileGDB_API_1_5_1-64gcc51.tar.gz \
+  && tar -xzf FileGDB_API_1_5_1-64gcc51.tar.gz \
+  && chown -R root:root FileGDB_API-64gcc51 \
+  && mv FileGDB_API-64gcc51 /usr/local/FileGDB_API \
+  && rm -rf /usr/local/FileGDB_API/lib/libstdc++* \
+  && cp /usr/local/FileGDB_API/lib/* /build_thirdparty/usr/lib \
+  && cp /usr/local/FileGDB_API/include/* /usr/include \
+  && rm -rf FileGDB_API_1_5_1-64gcc51.tar.gz \
+  ) ; fi
+
+
+
 RUN apt-get update -y \
     && apt-get install -y --fix-missing --no-install-recommends rsync ccache \
     && rm -rf /var/lib/apt/lists/*
@@ -153,6 +180,7 @@ RUN /buildscripts/bh-gdal.sh
 FROM $BASE_IMAGE as runner
 
 RUN date
+ARG JAVA_VERSION=11
 
 RUN apt-get update \
 # PROJ dependencies
@@ -168,7 +196,7 @@ RUN apt-get update \
         libhdf4-0-alt libhdf5-103 libhdf5-cpp-103 poppler-utils libfreexl1 unixodbc libwebp6 \
         libepsilon1 liblcms2-2 libpcre3 libcrypto++6 libdap25 libdapclient6v5 libfyba0 \
         libkmlbase1 libkmlconvenience1 libkmldom1 libkmlengine1 libkmlregionator1 libkmlxsd1 \
-        libmysqlclient21 libogdi4.1 libcfitsio8 openjdk-8-jre \
+        libmysqlclient21 libogdi4.1 libcfitsio8 openjdk-"$JAVA_VERSION"-jre \
         libzstd1 bash bash-completion libpq5 libssl1.1 \
         libarmadillo9 libpython3.8 libopenexr24 libheif1 \
         python-is-python3 \
@@ -179,6 +207,7 @@ RUN apt-get update \
 # Attempt to order layers starting with less frequently varying ones
 
 COPY --from=builder  /build_thirdparty/usr/ /usr/
+COPY --from=builder  /build/usr/share/java /usr/share/java
 
 ARG PROJ_DATUMGRID_LATEST_LAST_MODIFIED
 ARG PROJ_INSTALL_PREFIX=/usr/local
@@ -195,3 +224,6 @@ COPY --from=builder  /build_gdal_python/usr/ /usr/
 COPY --from=builder  /build_gdal_version_changing/usr/ /usr/
 
 RUN ldconfig
+
+#Set CLASSPATH so jars are found
+ENV CLASSPATH="/usr/share/java/jackcess-1.1.14.jar:/usr/share/java/commons-logging-1.1.1.jar:/usr/share/java/commons-lang-2.4.jar"

--- a/gdal/swig/java/GNUmakefile
+++ b/gdal/swig/java/GNUmakefile
@@ -18,7 +18,7 @@ endif
 EXTRA_DIST = org
 
 LINK = $(LD_SHARED)
-LINK_EXTRAFLAGS = 
+LINK_EXTRAFLAGS =
 OBJ_EXT = o
 ifeq ($(HAVE_LIBTOOL),yes)
 LINK = $(LD)
@@ -78,6 +78,12 @@ install: build
 		for f in *.dylib; do $(INSTALL_LIB) $$f $(DESTDIR)$(INST_LIB) ; done ; \
 	fi
 
+	ant maven ; \
+	mkdir -p $(DESTDIR)${datarootdir}/java ; \
+	echo $(DESTDIR)${datarootdir}/java ; \
+	cp build/maven/* $(DESTDIR)${datarootdir}/java ; \
+
+
 JAVA_RUN = java -Djava.library.path=. -cp gdal.jar:build/apps
 
 test:
@@ -104,7 +110,7 @@ ifdef INCLUDE_GDAL_LIB
     LIB_GDAL=$(GDAL_LIB)
 endif
 
-$(JAVA_MODULES): $(JAVA_OBJECTS) 
+$(JAVA_MODULES): $(JAVA_OBJECTS)
 	$(LINK) $(LDFLAGS) $^ $(LIB_GDAL) $(CONFIG_LIBS) -o $@ $(LINK_EXTRAFLAGS)
 
 # Do not remove -fno-strict-aliasing while SWIG generates weird code in upcast methods


### PR DESCRIPTION
1. Adds support for FileGDB drivers
    *  Ubuntu-Full isn't really full without write support for one of the most common GIS formats.

2. Adds support for MDB driver
    *  You still occasionally encounter personal geodatabases in the wild

3. Updates OpenJDK 8 to OpenJDK 11
    *  Current LTS