### PR TITLE
VSI: add callback to explicitely list sibling files

### DIFF
--- a/gdal/gcore/gdalopeninfo.cpp
+++ b/gdal/gcore/gdalopeninfo.cpp
@@ -345,25 +345,33 @@ retry:  // TODO(schwehr): Stop using goto.
     }
     else if( bStatOK && !bIsDirectory )
     {
-        const char* pszOptionVal =
-            CPLGetConfigOption( "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
-        if (EQUAL(pszOptionVal, "EMPTY_DIR"))
+        papszSiblingFiles = VSISiblingFiles(pszFilename);
+        if (papszSiblingFiles != nullptr)
         {
-            papszSiblingFiles =
-                CSLAddString( nullptr, CPLGetFilename(pszFilename) );
             bHasGotSiblingFiles = true;
         }
-        else if( CPLTestBool(pszOptionVal) )
+        else 
         {
-            /* skip reading the directory */
-            papszSiblingFiles = nullptr;
-            bHasGotSiblingFiles = true;
-        }
-        else
-        {
-            /* will be lazy loaded */
-            papszSiblingFiles = nullptr;
-            bHasGotSiblingFiles = false;
+            const char* pszOptionVal =
+                CPLGetConfigOption( "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
+            if (EQUAL(pszOptionVal, "EMPTY_DIR"))
+            {
+                papszSiblingFiles =
+                    CSLAddString( nullptr, CPLGetFilename(pszFilename) );
+                bHasGotSiblingFiles = true;
+            }
+            else if( CPLTestBool(pszOptionVal) )
+            {
+                /* skip reading the directory */
+                papszSiblingFiles = nullptr;
+                bHasGotSiblingFiles = true;
+            }
+            else
+            {
+                /* will be lazy loaded */
+                papszSiblingFiles = nullptr;
+                bHasGotSiblingFiles = false;
+            }
         }
     }
     else
@@ -401,6 +409,11 @@ char** GDALOpenInfo::GetSiblingFiles()
         return papszSiblingFiles;
     bHasGotSiblingFiles = true;
 
+    papszSiblingFiles = VSISiblingFiles( pszFilename );
+    if ( papszSiblingFiles != nullptr ) {
+        return papszSiblingFiles;
+    }
+
     CPLString osDir = CPLGetDirname( pszFilename );
     const int nMaxFiles =
         atoi(CPLGetConfigOption("GDAL_READDIR_LIMIT_ON_OPEN", "1000"));
@@ -413,14 +426,6 @@ char** GDALOpenInfo::GetSiblingFiles()
         papszSiblingFiles = nullptr;
     }
 
-    /* Small optimization to avoid unnecessary stat'ing from PAux or ENVI */
-    /* drivers. The MBTiles driver needs no companion file. */
-    if( papszSiblingFiles == nullptr &&
-        STARTS_WITH(pszFilename, "/vsicurl/") &&
-        EQUAL(CPLGetExtension( pszFilename ),"mbtiles") )
-    {
-        papszSiblingFiles = CSLAddString( nullptr, CPLGetFilename(pszFilename) );
-    }
 
     return papszSiblingFiles;
 }

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -312,6 +312,7 @@ GIntBig CPL_DLL CPLGetUsablePhysicalRAM(void);
 char CPL_DLL **VSIReadDir( const char * );
 char CPL_DLL **VSIReadDirRecursive( const char *pszPath );
 char CPL_DLL **VSIReadDirEx( const char *pszPath, int nMaxFiles );
+char CPL_DLL **VSISiblingFiles( const char *pszPath );
 
 /** Opaque type for a directory iterator */
 typedef struct VSIDIR VSIDIR;
@@ -455,6 +456,11 @@ typedef int            (*VSIFilesystemPluginRmdirCallback)         ( void *pUser
  */
 typedef char**         (*VSIFilesystemPluginReadDirCallback)       ( void *pUserData, const char *pszDirname, int nMaxFiles );
 /** 
+ * List related files. Optional 
+ * @since GDAL 3.2
+ */
+typedef char**         (*VSIFilesystemPluginSiblingFilesCallback)       ( void *pUserData, const char *pszDirname );
+/** 
  * Open a handle. Mandatory. Returns an opaque pointer that will be used in subsequent file I/O calls.
  * Should return null and/or set errno if the handle does not exist or the access mode is incorrect.
  * @since GDAL 3.0
@@ -543,6 +549,7 @@ typedef struct {
     VSIFilesystemPluginCloseCallback            close; /**< close handle  (rw) */
     size_t                                      nBufferSize; /**< buffer small reads (makes handler read only) */
     size_t                                      nCacheSize; /**< max mem to use per file when buffering */
+    VSIFilesystemPluginSiblingFilesCallback     sibling_files; /**< list related files*/
 /* 
     Callbacks are defined as a struct allocated by a call to VSIAllocFilesystemPluginCallbacksStruct
     in order to try to maintain ABI stability when eventually adding a new member.

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -456,7 +456,11 @@ typedef int            (*VSIFilesystemPluginRmdirCallback)         ( void *pUser
  */
 typedef char**         (*VSIFilesystemPluginReadDirCallback)       ( void *pUserData, const char *pszDirname, int nMaxFiles );
 /** 
- * List related files. Optional 
+ * List related files. Must return NULL if unknown, or a list of relative filenames
+ * that can be opened along the main file. If no other file than pszFilename needs to
+ * be opened, return static_cast<char**> (calloc(1,sizeof(char*)));
+ * 
+ * Optional
  * @since GDAL 3.2
  */
 typedef char**         (*VSIFilesystemPluginSiblingFilesCallback)       ( void *pUserData, const char *pszDirname );

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -458,7 +458,7 @@ typedef char**         (*VSIFilesystemPluginReadDirCallback)       ( void *pUser
 /** 
  * List related files. Must return NULL if unknown, or a list of relative filenames
  * that can be opened along the main file. If no other file than pszFilename needs to
- * be opened, return static_cast<char**> (calloc(1,sizeof(char*)));
+ * be opened, return static_cast<char**> (CPLCalloc(1,sizeof(char*)));
  * 
  * Optional
  * @since GDAL 3.2

--- a/gdal/port/cpl_vsi_virtual.h
+++ b/gdal/port/cpl_vsi_virtual.h
@@ -105,7 +105,7 @@ public:
                       { (void) pszDirname; return nullptr; }
     virtual char **ReadDirEx( const char *pszDirname, int /* nMaxFiles */ )
                       { return ReadDir(pszDirname); }
-    virtual char **SiblingFiles( const char */*pszFilename*/ )
+    virtual char **SiblingFiles( const char * /*pszFilename*/ )
                       { return nullptr; }
     virtual int Rename( const char *oldpath, const char *newpath )
                       { (void) oldpath; (void)newpath; errno=ENOENT; return -1; }

--- a/gdal/port/cpl_vsi_virtual.h
+++ b/gdal/port/cpl_vsi_virtual.h
@@ -105,6 +105,8 @@ public:
                       { (void) pszDirname; return nullptr; }
     virtual char **ReadDirEx( const char *pszDirname, int /* nMaxFiles */ )
                       { return ReadDir(pszDirname); }
+    virtual char **SiblingFiles( const char */*pszFilename*/ )
+                      { return nullptr; }
     virtual int Rename( const char *oldpath, const char *newpath )
                       { (void) oldpath; (void)newpath; errno=ENOENT; return -1; }
     virtual int IsCaseSensitive( const char* pszFilename )

--- a/gdal/port/cpl_vsil.cpp
+++ b/gdal/port/cpl_vsil.cpp
@@ -129,6 +129,8 @@ char **VSIReadDirEx( const char *pszPath, int nMaxFiles )
 
 /**
  * \brief Return related filenames
+  *
+  * This function is essentially meant at being used by GDAL internals.
  *
  * @param pszFilename the path of a filename to inspect
  * UTF-8 encoded.
@@ -138,7 +140,7 @@ char **VSIReadDirEx( const char *pszPath, int nMaxFiles )
  * Most implementations will return NULL, and a subsequent ReadDir will
  * list all files available in the file's directory. This function will be
  * overriden by VSI FilesystemHandlers that wish to force e.g. an empty list
- * to avoid opening non-existant files on slow filesystems.
+ * to avoid opening non-existant files on slow filesystems. The return value shall be destroyed with CSLDestroy()
  * @since GDAL 3.2
  */
 char **VSISiblingFiles( const char *pszFilename)

--- a/gdal/port/cpl_vsil.cpp
+++ b/gdal/port/cpl_vsil.cpp
@@ -123,6 +123,14 @@ char **VSIReadDirEx( const char *pszPath, int nMaxFiles )
     return poFSHandler->ReadDirEx( pszPath, nMaxFiles );
 }
 
+char **VSISiblingFiles( const char *pszPath)
+{
+    VSIFilesystemHandler *poFSHandler =
+        VSIFileManager::GetHandler( pszPath );
+
+    return poFSHandler->SiblingFiles( pszPath );
+}
+
 /************************************************************************/
 /*                             VSIReadRecursive()                       */
 /************************************************************************/

--- a/gdal/port/cpl_vsil.cpp
+++ b/gdal/port/cpl_vsil.cpp
@@ -123,12 +123,30 @@ char **VSIReadDirEx( const char *pszPath, int nMaxFiles )
     return poFSHandler->ReadDirEx( pszPath, nMaxFiles );
 }
 
-char **VSISiblingFiles( const char *pszPath)
+/************************************************************************/
+/*                             VSISiblingFiles()                        */
+/************************************************************************/
+
+/**
+ * \brief Return related filenames
+ *
+ * @param pszFilename the path of a filename to inspect
+ * UTF-8 encoded.
+ * @return The list of entries, relative to the directory, of all sidecar
+ * files available or NULL if the list is not known. 
+ * Filenames are returned in UTF-8 encoding.
+ * Most implementations will return NULL, and a subsequent ReadDir will
+ * list all files available in the file's directory. This function will be
+ * overriden by VSI FilesystemHandlers that wish to force e.g. an empty list
+ * to avoid opening non-existant files on slow filesystems.
+ * @since GDAL 3.2
+ */
+char **VSISiblingFiles( const char *pszFilename)
 {
     VSIFilesystemHandler *poFSHandler =
-        VSIFileManager::GetHandler( pszPath );
+        VSIFileManager::GetHandler( pszFilename );
 
-    return poFSHandler->SiblingFiles( pszPath );
+    return poFSHandler->SiblingFiles( pszFilename );
 }
 
 /************************************************************************/

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -4226,7 +4226,7 @@ char** VSICurlFilesystemHandler::SiblingFiles( const char *pszFilename )
     /* drivers. The MBTiles driver needs no companion file. */
     if( EQUAL(CPLGetExtension( pszFilename ),"mbtiles") )
     {
-        return static_cast<char**> (calloc(1,sizeof(char*)));
+        return static_cast<char**> (CPLCalloc(1,sizeof(char*)));
     }
     return nullptr;
     

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -4217,6 +4217,22 @@ char** VSICurlFilesystemHandler::ReadDirEx( const char *pszDirname,
 }
 
 /************************************************************************/
+/*                             SiblingFiles()                           */
+/************************************************************************/
+
+char** VSICurlFilesystemHandler::SiblingFiles( const char *pszFilename )
+{
+    /* Small optimization to avoid unnecessary stat'ing from PAux or ENVI */
+    /* drivers. The MBTiles driver needs no companion file. */
+    if( EQUAL(CPLGetExtension( pszFilename ),"mbtiles") )
+    {
+        return CSLAddString( nullptr, CPLGetFilename(pszFilename) );
+    }
+    return nullptr;
+    
+}
+
+/************************************************************************/
 /*                          GetFileMetadata()                           */
 /************************************************************************/
 

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -4226,7 +4226,7 @@ char** VSICurlFilesystemHandler::SiblingFiles( const char *pszFilename )
     /* drivers. The MBTiles driver needs no companion file. */
     if( EQUAL(CPLGetExtension( pszFilename ),"mbtiles") )
     {
-        return CSLAddString( nullptr, CPLGetFilename(pszFilename) );
+        return static_cast<char**> (calloc(1,sizeof(char*)));
     }
     return nullptr;
     

--- a/gdal/port/cpl_vsil_curl_class.h
+++ b/gdal/port/cpl_vsil_curl_class.h
@@ -243,6 +243,7 @@ public:
     char **ReadDir( const char *pszDirname ) override
         { return ReadDirEx(pszDirname, 0); }
     char **ReadDirEx( const char *pszDirname, int nMaxFiles ) override;
+    char **SiblingFiles( const char *pszFilename ) override;
 
     int HasOptimizedReadMultiRange( const char* /* pszPath */ )
         override { return true; }

--- a/gdal/port/cpl_vsil_plugin.cpp
+++ b/gdal/port/cpl_vsil_plugin.cpp
@@ -322,6 +322,15 @@ char ** VSIPluginFilesystemHandler::ReadDirEx( const char * pszDirname, int nMax
     return nullptr;
 }
 
+char ** VSIPluginFilesystemHandler::SiblingFiles( const char * pszFilename ) {
+    if( !IsValidFilename(pszFilename) )
+        return nullptr;
+    if (m_cb->sibling_files != nullptr) {
+        return m_cb->sibling_files(m_cb->pUserData, GetCallbackFilename(pszFilename));
+    }
+    return nullptr;
+}
+
 int VSIPluginFilesystemHandler::Unlink(const char *pszFilename) {
     if( m_cb->unlink == nullptr || !IsValidFilename(pszFilename) )
         return -1;

--- a/gdal/port/cpl_vsil_plugin.h
+++ b/gdal/port/cpl_vsil_plugin.h
@@ -86,6 +86,7 @@ public:
     char **ReadDir  ( const char *pszDirname ) override
                         { return ReadDirEx(pszDirname, 0); }
     char **ReadDirEx( const char * pszDirname, int nMaxFiles ) override;
+    char **SiblingFiles( const char * pszFilename ) override;
     int HasOptimizedReadMultiRange(const char* pszPath ) override;
     
 };


### PR DESCRIPTION
This patch allows vsi filesystems to return a list of sibling files. This can be used to explicitely disallow opening/querying for .aux or .ovr files without having to set GDAL_DISABLE_READDIR_ON_OPEN to EMPTY_DIR.
One might argue that this has nothing to do in the VSIFileSystem API, but the current lack of this function has already lead to an hack which has been cleaned up by this commit.