### PR TITLE
NITF: Add BANDSB TRE from Spectral NITF Implementation Profile

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2727,7 +2727,7 @@ def test_nitf_78():
     <field name="SPT_RESP_UNIT_ROW" value="M" />
     <field name="SPT_RESP_COL" value="-------" />
     <field name="SPT_RESP_UNIT_COL" value="M" />
-    <field name="DATA_FIELD_1" value="" />
+    <field name="DATA_FLD_1" value="" />
     <field name="EXISTENCE_MASK" value="0" />
     <repeated name="BANDS" number="1">
       <group index="0" />

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2692,6 +2692,52 @@ def test_nitf_77():
     assert data == expected_data
 
 ###############################################################################
+# Test parsing BANDSB TRE (STDI-0002 App X)
+
+def test_nitf_78():
+    # Fill non-character fields with zero
+    float_data = r"\0\0\0\0"
+    bit_mask = r"\0\0\0\0"
+
+    tre_data = "FILE_TRE=BANDSB=00001RADIANCE                S" + float_data*2 + \
+                "0030.00M0030.00M-------M-------M                                                " + \
+                bit_mask + "DETECTOR                " + float_data
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_78.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_78.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_78.ntf')
+
+    expected_data = """<tres>
+  <tre name="BANDSB" location="file">
+    <field name="COUNT" value="00001" />
+    <field name="RADIOMETRIC_QUANTITY" value="RADIANCE" />
+    <field name="RADIOMETRIC_QUANTITY_UNIT" value="S" />
+    <field name="SCALE_FACTOR" value="0.000000" />
+    <field name="ADDITIVE_FACTOR" value="0.000000" />
+    <field name="ROW_GSD" value="0030.00" />
+    <field name="ROW_GSD_UNIT" value="M" />
+    <field name="COL_GSD" value="0030.00" />
+    <field name="COL_GSD_UNIT" value="M" />
+    <field name="SPT_RESP_ROW" value="-------" />
+    <field name="SPT_RESP_UNIT_ROW" value="M" />
+    <field name="SPT_RESP_COL" value="-------" />
+    <field name="SPT_RESP_UNIT_COL" value="M" />
+    <field name="DATA_FIELD_1" value="" />
+    <field name="EXISTENCE_MASK" value="0" />
+    <repeated name="BANDS" number="1">
+      <group index="0" />
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -118,8 +118,8 @@
         <field name="COUNT" length="5" type="integer"/>
         <field name="RADIOMETRIC_QUANTITY" length="24" type="string"/>
         <field name="RADIOMETRIC_QUANTITY_UNIT" length="1" type="string"/>
-        <field name="SCALE_FACTOR" length="4" type="float_raw"/>
-        <field name="ADDITIVE_FACTOR" length="4" type="float_raw"/>
+        <field name="SCALE_FACTOR" length="4" type="IEEE754_Float32_BigEndian"/>
+        <field name="ADDITIVE_FACTOR" length="4" type="IEEE754_Float32_BigEndian"/>
         <field name="ROW_GSD" length="7" type="real"/>
         <field name="ROW_GSD_UNIT" length="1" type="string"/>
         <field name="COL_GSD" length="7" type="real"/>
@@ -132,7 +132,7 @@
         <field name="EXISTENCE_MASK" length="4" type="bitmask"/>
         <if cond="EXISTENCE_MASK:31">
             <field name="RADIOMETRIC_ADJUSTMENT_SURFACE" length="24" type="string"/>
-            <field name="ATMOSPHERIC_ADJUSTMENT_ALTITUDE" length="4" type="float_raw"/>
+            <field name="ATMOSPHERIC_ADJUSTMENT_ALTITUDE" length="4" type="IEEE754_Float32_BigEndian"/>
         </if>
         <if cond="EXISTENCE_MASK:30">
             <field name="DIAMETER" length="7" type="real"/>
@@ -176,8 +176,8 @@
                 <field name="UBOUND" length="7" type="real"/>
             </if>
             <if cond="EXISTENCE_MASK:18">
-                <field name="SCALE_FACTOR" length="4" type="float_raw"/>
-                <field name="ADDITIVE_FACTOR" length="4" type="float_raw"/>
+                <field name="SCALE_FACTOR" length="4" type="IEEE754_Float32_BigEndian"/>
+                <field name="ADDITIVE_FACTOR" length="4" type="IEEE754_Float32_BigEndian"/>
             </if>
             <if cond="EXISTENCE_MASK:17">
                 <field name="START_TIME" length="16" type="string"/>
@@ -249,7 +249,7 @@
                         <field name="APN" length="10" type="integer"/>
                     </if>
                     <if cond="BAPF=R">
-                        <field name="APR" length="4" type="float_raw"/>
+                        <field name="APR" length="4" type="IEEE754_Float32_BigEndian"/>
                     </if>
                     <if cond="BAPF=A">
                         <field name="APA" length="20" type="string"/>
@@ -263,7 +263,7 @@
                     <field name="APN" length="10" type="integer"/>
                 </if>
                 <if cond="CAPF=R">
-                    <field name="APR" length="4" type="float_raw"/>
+                    <field name="APR" length="4" type="IEEE754_Float32_BigEndian"/>
                 </if>
                 <if cond="CAPF=A">
                     <field name="APA" length="20" type="string"/>

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -113,6 +113,165 @@
         <field name="RESERVED_3" length="13"/>
     </tre>
 
+    <!-- STDI-0002-1 Appendix X: BANDSB -->
+    <tre name="BANDSB" md_prefix="NITF_BANDSB_" location="image">
+        <field name="COUNT" length="5" type="integer"/>
+        <field name="RADIOMETRIC_QUANTITY" length="24" type="string"/>
+        <field name="RADIOMETRIC_QUANTITY_UNIT" length="1" type="string"/>
+        <field name="SCALE_FACTOR" length="4" type="float_raw"/>
+        <field name="ADDITIVE_FACTOR" length="4" type="float_raw"/>
+        <field name="ROW_GSD" length="7" type="real"/>
+        <field name="ROW_GSD_UNIT" length="1" type="string"/>
+        <field name="COL_GSD" length="7" type="real"/>
+        <field name="COL_GSD_UNIT" length="1" type="string"/>
+        <field name="SPT_RESP_ROW" length="7" type="real"/>
+        <field name="SPT_RESP_UNIT_ROW" length="1" type="string"/>
+        <field name="SPT_RESP_COL" length="7" type="real"/>
+        <field name="SPT_RESP_UNIT_COL" length="1" type="string"/>
+        <field name="DATA_FLD_1" length="48" type="string"/>
+        <field name="EXISTENCE_MASK" length="4" type="bitmask"/>
+        <if cond="EXISTENCE_MASK:31">
+            <field name="RADIOMETRIC_ADJUSTMENT_SURFACE" length="24" type="string"/>
+            <field name="ATMOSPHERIC_ADJUSTMENT_ALTITUDE" length="4" type="float_raw"/>
+        </if>
+        <if cond="EXISTENCE_MASK:30">
+            <field name="DIAMETER" length="7" type="real"/>
+        </if>
+        <if cond="EXISTENCE_MASK:29">
+            <field name="DATA_FLD_2" length="32" type="string"/>
+        </if>
+        <if cond="EXISTENCE_MASK:24">
+            <field name="WAVE_LENGTH_UNIT" length="1" type="string"/>
+        </if>
+        <loop counter="COUNT" name="BANDS" md_prefix="BAND_%05d_">
+            <if cond="EXISTENCE_MASK:28">
+                <field name="BANDID" length="50" type="string"/>
+            </if>
+            <if cond="EXISTENCE_MASK:27">
+                <field name="BAD_BAND" length="1" type="integer"/>
+            </if>
+            <if cond="EXISTENCE_MASK:26">
+                <field name="NIIRS" length="3" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:25">
+                <field name="FOCAL_LEN" length="5" type="integer"/>
+            </if>
+            <if cond="EXISTENCE_MASK:24">
+                <field name="CWAVE" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:23">
+                <field name="FWHM" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:22">
+                <field name="FWHM_UNC" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:21">
+                <field name="NOM_WAVE" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:20">
+                <field name="NOM_WAVE_UNC" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:19">
+                <field name="LBOUND" length="7" type="real"/>
+                <field name="UBOUND" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:18">
+                <field name="SCALE_FACTOR" length="4" type="float_raw"/>
+                <field name="ADDITIVE_FACTOR" length="4" type="float_raw"/>
+            </if>
+            <if cond="EXISTENCE_MASK:17">
+                <field name="START_TIME" length="16" type="string"/>
+            </if>
+            <if cond="EXISTENCE_MASK:16">
+                <field name="INT_TIME" length="6" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:15">
+                <field name="CALDRK" length="6" type="real"/>
+                <field name="CALIBRATION_SENSITIVITY" length="5" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:14">
+                <field name="ROW_GSD" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:13">
+                <field name="ROW_GSD_UNC" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:14">
+                <field name="ROW_GSD_UNIT" length="1" type="string"/>
+                <field name="COL_GSD" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:13">
+                <field name="COL_GSD_UNC" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:14">
+                <field name="COL_GSD_UNIT" length="1" type="string"/>
+            </if>
+            <if cond="EXISTENCE_MASK:12">
+                <field name="BKNOISE" length="5" type="real"/>
+                <field name="SCNNOISE" length="5" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:11">
+                <field name="SPT_RESP_FUNCTION_ROW" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:10">
+                <field name="SPT_RESP_UNC_ROW" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:11">
+                <field name="SPT_RESP_UNIT_ROW" length="1" type="string"/>
+                <field name="SPT_RESP_FUNCTION_COL" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:10">
+                <field name="SPT_RESP_UNC_COL" length="7" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:11">
+                <field name="SPT_RESP_UNIT_COL" length="1" type="string"/>
+            </if>
+            <if cond="EXISTENCE_MASK:9">
+                <field name="DATA_FLD_3" length="16" type="string"/>
+            </if>
+            <if cond="EXISTENCE_MASK:8">
+                <field name="DATA_FLD_4" length="24" type="string"/>
+            </if>
+            <if cond="EXISTENCE_MASK:7">
+                <field name="DATA_FLD_5" length="32" type="string"/>
+            </if>
+            <if cond="EXISTENCE_MASK:6">
+                <field name="DATA_FLD_6" length="48" type="string"/>
+            </if>
+        </loop>
+        <if cond="EXISTENCE_MASK:0">
+            <field name="NUM_AUX_B" length="2" type="integer"/>
+            <field name="NUM_AUX_C" length="2" type="integer"/>
+            <loop counter="NUM_AUX_B" name="BAND_AUX" md_prefix="BAND_AUX_%02d_">
+                <field name="BAPF" length="1" type="string"/>
+                <field name="UBAP" length="7" type="string"/>
+                <loop counter="COUNT" name="BAND" md_prefix="BAND_%05d">
+                    <if cond="BAPF=I">
+                        <field name="APN" length="10" type="integer"/>
+                    </if>
+                    <if cond="BAPF=R">
+                        <field name="APR" length="4" type="float_raw"/>
+                    </if>
+                    <if cond="BAPF=A">
+                        <field name="APA" length="20" type="string"/>
+                    </if>
+                </loop>
+            </loop>
+            <loop counter="NUM_AUX_C" name="CUBE_AUX" md_prefix="CUBE_AUX_%02d_">
+                <field name="CAPF" length="1" type="string"/>
+                <field name="UCAP" length="7" type="string"/>
+                <if cond="CAPF=I">
+                    <field name="APN" length="10" type="integer"/>
+                </if>
+                <if cond="CAPF=R">
+                    <field name="APR" length="4" type="float_raw"/>
+                </if>
+                <if cond="CAPF=A">
+                    <field name="APA" length="20" type="string"/>
+                </if>
+            </loop>
+        </if>
+    </tre>
+
     <tre name="BLOCKA" length="123" location="image">
         <field name="BLOCK_INSTANCE" length="2" type="integer" minval="1" maxval="99"/>
         <field name="N_GRAY" length="5" type="integer" minval="0" maxval="99999"/>

--- a/gdal/data/nitf_spec.xsd
+++ b/gdal/data/nitf_spec.xsd
@@ -130,7 +130,7 @@
                     <xs:enumeration value="string"/>
                     <xs:enumeration value="integer"/>
                     <xs:enumeration value="real"/>
-                    <xs:enumeration value="float_raw"/>
+                    <xs:enumeration value="IEEE754_Float32_BigEndian"/>
                     <xs:enumeration value="bitmask"/>
                 </xs:restriction>
             </xs:simpleType>

--- a/gdal/data/nitf_spec.xsd
+++ b/gdal/data/nitf_spec.xsd
@@ -107,7 +107,7 @@
         <xs:attribute name="cond">
             <xs:simpleType>
                 <xs:restriction base="xs:string">
-                    <xs:pattern value=".+[!]?=.*"/>
+                    <xs:pattern value=".+([!]?=|:).*"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
@@ -130,6 +130,8 @@
                     <xs:enumeration value="string"/>
                     <xs:enumeration value="integer"/>
                     <xs:enumeration value="real"/>
+                    <xs:enumeration value="float_raw"/>
+                    <xs:enumeration value="bitmask"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>

--- a/gdal/frmts/nitf/nitffile.c
+++ b/gdal/frmts/nitf/nitffile.c
@@ -2123,6 +2123,51 @@ static const char* NITFFindValFromEnd(char** papszMD,
 }
 
 /************************************************************************/
+/*                  NITFFindValRecursive()                              */
+/************************************************************************/
+
+static const char* NITFFindValRecursive(char** papszMD,
+                                        int nMDSize,
+                                        const char* pszMDPrefix,
+                                        const char* pszVar)
+{
+    char* pszMDItemName = CPLStrdup(CPLSPrintf("%s%s", pszMDPrefix, pszVar));
+    const char* pszCondVal = NITFFindValFromEnd(papszMD, nMDSize, pszMDItemName, NULL);
+
+    if (pszCondVal == NULL)
+    {
+        /* Needed for SENSRB */
+        /* See https://github.com/OSGeo/gdal/issues/1520 */
+        /* If the condition variable is not found at this level, */
+        /* try to research it at upper levels by shortening on _ */
+        /* separators */
+        char* pszMDPrefixShortened = CPLStrdup(pszMDPrefix);
+        char* pszLastUnderscore = strrchr(pszMDPrefixShortened, '_');
+        if( pszLastUnderscore )
+        {
+            *pszLastUnderscore = 0;
+            pszLastUnderscore = strrchr(pszMDPrefixShortened, '_');
+        }
+        while( pszLastUnderscore )
+        {
+            pszLastUnderscore[1] = 0;
+            CPLFree(pszMDItemName);
+            pszMDItemName = CPLStrdup(
+                CPLSPrintf("%s%s", pszMDPrefixShortened, pszVar));
+            pszCondVal = NITFFindValFromEnd(papszMD, nMDSize, pszMDItemName, NULL);
+            if( pszCondVal )
+                break;
+            *pszLastUnderscore = 0;
+            pszLastUnderscore = strrchr(pszMDPrefixShortened, '_');
+        }
+        CPLFree(pszMDPrefixShortened);
+    }
+    CPLFree(pszMDItemName);
+
+    return pszCondVal;
+}
+
+/************************************************************************/
 /*                  NITFGenericMetadataReadTREInternal()                */
 /************************************************************************/
 
@@ -2150,6 +2195,7 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
             const char* pszName = CPLGetXMLValue(psIter, "name", NULL);
             const char* pszLongName = CPLGetXMLValue(psIter, "longname", NULL);
             const char* pszLength = CPLGetXMLValue(psIter, "length", NULL);
+            const char* pszType = CPLGetXMLValue(psIter, "type", "string");
             int nLength = -1;
             if (pszLength != NULL)
                 nLength = atoi(pszLength);
@@ -2190,6 +2236,7 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
             {
                 char* pszMDItemName;
                 char** papszTmp = NULL;
+                char* pszValue = NULL;
 
                 if (*pnTreOffset + nLength > nTRESize)
                 {
@@ -2204,27 +2251,75 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                 pszMDItemName = CPLStrdup(
                             CPLSPrintf("%s%s", pszMDPrefix, pszName));
 
-                NITFExtractMetadata( &papszTmp, pachTRE, *pnTreOffset,
-                                     nLength, pszMDItemName );
-                if (*pnMDSize + 1 >= *pnMDAlloc)
+                if (strcmp(pszType, "float_raw") == 0)
                 {
-                    *pnMDAlloc = (*pnMDAlloc * 4 / 3) + 32;
-                    papszMD = (char**)CPLRealloc(papszMD, *pnMDAlloc * sizeof(char*));
+                    if( nLength == 4 )
+                    {
+                        const size_t nBufferSize = 128;
+                        float f;
+                        memcpy(&f, pachTRE + *pnTreOffset, 4);
+                        CPL_MSBPTR32(&f);
+                        pszValue = (char*)CPLMalloc(nBufferSize);
+                        CPLsnprintf(pszValue, nBufferSize, "%f", f);
+                        papszTmp = CSLSetNameValue(papszTmp, pszMDItemName, pszValue);
+                    }
+                    else
+                    {
+                        *pbError = TRUE;
+                        CPLError( CE_Warning, CPLE_AppDefined,
+                                  "Raw float field must be 4 bytes in %s TRE ", pszTREName);
+                        break;
+                    }
                 }
-                papszMD[*pnMDSize] = papszTmp[0];
-                papszMD[(*pnMDSize) + 1] = NULL;
-                (*pnMDSize) ++;
-                papszTmp[0] = NULL;
-                CPLFree(papszTmp);
-
-                if (psOutXMLNode != NULL)
+                else if (strcmp(pszType, "bitmask") == 0)
                 {
-                    const char* pszVal = strchr(papszMD[(*pnMDSize) - 1], '=') + 1;
+                    if( nLength <= 4 )
+                    {
+                        const size_t nBufferSize = 11;
+                        unsigned int nVal = 0;
+                        memcpy(&nVal, pachTRE + *pnTreOffset, nLength);
+                        CPL_MSBPTR32(&nVal);
+                        nVal >>= 8 * (4 - nLength);
+                        pszValue = (char*)CPLMalloc(nBufferSize);
+                        CPLsnprintf(pszValue, nBufferSize, "%u", nVal);
+                        papszTmp = CSLSetNameValue(papszTmp, pszMDItemName, pszValue);
+                    }
+                    else
+                    {
+                        *pbError = TRUE;
+                        CPLError( CE_Warning, CPLE_AppDefined,
+                                  "bitmask field must be <= 4 bytes in %s TRE ", pszTREName);
+                        break;
+                    }
+                }
+                else
+                {
+                    NITFExtractMetadata( &papszTmp, pachTRE, *pnTreOffset,
+                                        nLength, pszMDItemName );
+
+                    pszValue = CPLStrdup(strchr(papszTmp[0], '=') + 1);
+                }
+
+                if( papszTmp )
+                {
+                    if (*pnMDSize + 1 >= *pnMDAlloc)
+                    {
+                        *pnMDAlloc = (*pnMDAlloc * 4 / 3) + 32;
+                        papszMD = (char**)CPLRealloc(papszMD, *pnMDAlloc * sizeof(char*));
+                    }
+                    papszMD[*pnMDSize] = papszTmp[0];
+                    papszMD[(*pnMDSize) + 1] = NULL;
+                    (*pnMDSize) ++;
+                    papszTmp[0] = NULL;
+                    CSLDestroy(papszTmp);
+                }
+
+                if (pszValue != NULL && psOutXMLNode != NULL)
+                {
                     CPLXMLNode* psFieldNode;
                     CPLXMLNode* psNameNode;
                     CPLXMLNode* psValueNode;
 
-                    CPLAssert(pszVal != NULL);
                     psFieldNode =
                         CPLCreateXMLNode(psOutXMLNode, CXT_Element, "field");
                     psNameNode =
@@ -2233,10 +2328,11 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                         CPLCreateXMLNode(psFieldNode, CXT_Attribute, "value");
                     CPLCreateXMLNode(psNameNode, CXT_Text,
                        (pszName[0] || pszLongName == NULL) ? pszName : pszLongName);
-                    CPLCreateXMLNode(psValueNode, CXT_Text, pszVal);
+                    CPLCreateXMLNode(psValueNode, CXT_Text, pszValue);
                 }
 
                 CPLFree(pszMDItemName);
+                CPLFree(pszValue);
 
                 *pnTreOffset += nLength;
             }
@@ -2265,11 +2361,8 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
 
             if (pszCounter != NULL)
             {
-                char* pszMDItemName = CPLStrdup(
-                            CPLSPrintf("%s%s", pszMDPrefix, pszCounter));
-                nIterations = atoi(NITFFindValFromEnd(papszMD, *pnMDSize, pszMDItemName, "-1"));
-                CPLFree(pszMDItemName);
-                if (nIterations < 0)
+                const char* pszIterationsVal = NITFFindValRecursive(papszMD, *pnMDSize, pszMDPrefix, pszCounter);
+                if (pszIterationsVal == NULL || (nIterations = atoi(pszIterationsVal)) < 0)
                 {
                     CPLError( CE_Warning, CPLE_AppDefined,
                             "Invalid loop construct in %s TRE in XML resource : "
@@ -2510,7 +2603,7 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                  strcmp(psIter->pszValue, "if") == 0)
         {
             const char* pszCond = CPLGetXMLValue(psIter, "cond", NULL);
-            const char* pszEqual = NULL;
+            const char* pszOperator = NULL;
             if (pszCond != NULL && strcmp(pszCond, "QSS!=U AND QOD!=Y") == 0)
             {
                 char* pszQSSName = CPLStrdup(
@@ -2544,51 +2637,20 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                 CPLFree(pszQSSName);
                 CPLFree(pszQODName);
             }
-            else if (pszCond != NULL && (pszEqual = strchr(pszCond, '=')) != NULL)
+            else if (pszCond != NULL && (pszOperator = strchr(pszCond, '=')) != NULL)
             {
-                char* pszCondVar = (char*)CPLMalloc(pszEqual - pszCond + 1);
-                const char* pszCondExpectedVal = pszEqual + 1;
-                char* pszMDItemName;
+                char* pszCondVar = (char*)CPLMalloc(pszOperator - pszCond + 1);
+                const char* pszCondExpectedVal = pszOperator + 1;
                 const char* pszCondVal;
                 int bTestEqual = TRUE;
-                memcpy(pszCondVar, pszCond, pszEqual - pszCond);
-                if (pszEqual - pszCond > 1 && pszCondVar[pszEqual - pszCond - 1] == '!')
+                memcpy(pszCondVar, pszCond, pszOperator - pszCond);
+                if (pszOperator - pszCond > 1 && pszCondVar[pszOperator - pszCond - 1] == '!')
                 {
                     bTestEqual = FALSE;
-                    pszCondVar[pszEqual - pszCond - 1] = '\0';
+                    pszCondVar[pszOperator - pszCond - 1] = '\0';
                 }
-                pszCondVar[pszEqual - pszCond] = '\0';
-                pszMDItemName = CPLStrdup(
-                            CPLSPrintf("%s%s", pszMDPrefix, pszCondVar));
-                pszCondVal = NITFFindValFromEnd(papszMD, *pnMDSize, pszMDItemName, NULL);
-                if (pszCondVal == NULL)
-                {
-                    /* Needed for SENSRB */
-                    /* See https://github.com/OSGeo/gdal/issues/1520 */
-                    /* If the condition variable is not found at this level, */
-                    /* try to research it at upper levels by shortening on _ */
-                    /* separators */
-                    char* pszMDPrefixShortened = CPLStrdup(pszMDPrefix);
-                    char* pszLastUnderscore = strrchr(pszMDPrefixShortened, '_');
-                    if( pszLastUnderscore )
-                    {
-                        *pszLastUnderscore = 0;
-                        pszLastUnderscore = strrchr(pszMDPrefixShortened, '_');
-                    }
-                    while( pszLastUnderscore )
-                    {
-                        pszLastUnderscore[1] = 0;
-                        CPLFree(pszMDItemName);
-                        pszMDItemName = CPLStrdup(
-                            CPLSPrintf("%s%s", pszMDPrefixShortened, pszCondVar));
-                        pszCondVal = NITFFindValFromEnd(papszMD, *pnMDSize, pszMDItemName, NULL);
-                        if( pszCondVal )
-                            break;
-                        *pszLastUnderscore = 0;
-                        pszLastUnderscore = strrchr(pszMDPrefixShortened, '_');
-                    }
-                    CPLFree(pszMDPrefixShortened);
-                }
+                pszCondVar[pszOperator - pszCond] = '\0';
+                pszCondVal = NITFFindValRecursive(papszMD, *pnMDSize, pszMDPrefix, pszCondVar);
                 if( pszCondVal == NULL )
                 {
                     CPLDebug("NITF", "Cannot find if cond variable %s",
@@ -2609,7 +2671,35 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                                                                  pszMDPrefix,
                                                                  pbError);
                 }
-                CPLFree(pszMDItemName);
+                CPLFree(pszCondVar);
+            }
+            else if (pszCond != NULL && (pszOperator = strchr(pszCond, ':')) != NULL)
+            {
+                char* pszCondVar = (char*)CPLMalloc(pszOperator - pszCond + 1);
+                const char* pszCondTestBit = pszOperator + 1;
+                const char* pszCondVal;
+                memcpy(pszCondVar, pszCond, pszOperator - pszCond);
+                pszCondVar[pszOperator - pszCond] = '\0';
+                pszCondVal = NITFFindValRecursive(papszMD, *pnMDSize, pszMDPrefix, pszCondVar);
+                if( pszCondVal == NULL )
+                {
+                    CPLDebug("NITF", "Cannot find if cond variable %s",
+                            pszCondVar);
+                }
+                else if (strtoul(pszCondVal, CPL_NULLPTR, 10) & (1 << atoi(pszCondTestBit)))
+                {
+                    papszMD = NITFGenericMetadataReadTREInternal(papszMD,
+                                                                 pnMDSize,
+                                                                 pnMDAlloc,
+                                                                 psOutXMLNode,
+                                                                 pszTREName,
+                                                                 pachTRE,
+                                                                 nTRESize,
+                                                                 psIter,
+                                                                 pnTreOffset,
+                                                                 pszMDPrefix,
+                                                                 pbError);
+                }
                 CPLFree(pszCondVar);
             }
             else

--- a/gdal/frmts/nitf/nitffile.c
+++ b/gdal/frmts/nitf/nitffile.c
@@ -2251,7 +2251,7 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                 pszMDItemName = CPLStrdup(
                             CPLSPrintf("%s%s", pszMDPrefix, pszName));
 
-                if (strcmp(pszType, "float_raw") == 0)
+                if (strcmp(pszType, "IEEE754_Float32_BigEndian") == 0)
                 {
                     if( nLength == 4 )
                     {
@@ -2267,19 +2267,18 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                     {
                         *pbError = TRUE;
                         CPLError( CE_Warning, CPLE_AppDefined,
-                                  "Raw float field must be 4 bytes in %s TRE ", pszTREName);
+                                  "IEEE754_Float32_BigEndian field must be 4 bytes in %s TRE ", pszTREName);
                         break;
                     }
                 }
                 else if (strcmp(pszType, "bitmask") == 0)
                 {
-                    if( nLength <= 4 )
+                    if( nLength == 4 )
                     {
                         const size_t nBufferSize = 11;
-                        unsigned int nVal = 0;
-                        memcpy(&nVal, pachTRE + *pnTreOffset, nLength);
+                        unsigned int nVal;
+                        memcpy(&nVal, pachTRE + *pnTreOffset, 4);
                         CPL_MSBPTR32(&nVal);
-                        nVal >>= 8 * (4 - nLength);
                         pszValue = (char*)CPLMalloc(nBufferSize);
                         CPLsnprintf(pszValue, nBufferSize, "%u", nVal);
                         papszTmp = CSLSetNameValue(papszTmp, pszMDItemName, pszValue);
@@ -2288,7 +2287,7 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                     {
                         *pbError = TRUE;
                         CPLError( CE_Warning, CPLE_AppDefined,
-                                  "bitmask field must be <= 4 bytes in %s TRE ", pszTREName);
+                                  "bitmask field must be 4 bytes in %s TRE ", pszTREName);
                         break;
                     }
                 }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds the capability to read the BANDSB TRE, defined in the Spectral NITF Implementation Profile
The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
STDI-0002-1 Appendix X.

In nitf_spec.xml, this TRE requires recursive variable search in <loop> blocks, and requires raw bits to be read and used as conditionals in <if> blocks.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/2414
https://github.com/OSGeo/gdal/pull/2973

## Tasklist

 - [X] nitf_spec.xml validates against nitf_spec.xsd
 - [X] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
