### PR TITLE
gdalcompare: fix floor division in Python 3

### DIFF
--- a/gdal/swig/python/scripts/gdalcompare.py
+++ b/gdal/swig/python/scripts/gdalcompare.py
@@ -243,7 +243,7 @@ def compare_sds(golden_db, new_db, options=None):
     golden_sds = golden_db.GetMetadata('SUBDATASETS')
     new_sds = new_db.GetMetadata('SUBDATASETS')
 
-    count = len(list(golden_sds.keys())) / 2
+    count = len(list(golden_sds.keys())) // 2
     for i in range(count):
         key = 'SUBDATASET_%d_NAME' % (i + 1)
 


### PR DESCRIPTION
## What does this PR do?
With the standard division operator, the parameter passed to the range function can be a float. This assure to always use floor division for Python 2 and 3.

