### PR TITLE
Add CPLHTTP[Push|Pop]FetchCallback() and CPLHTTPSetFetchCallback() callback mechanisms

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -2914,4 +2914,136 @@ namespace tut
 #endif // HAVE_CURL        
     }    
 
+    // Test CPLHTTPPushFetchCallback
+    template<>
+    template<>
+    void object::test<42>()
+    {
+        struct myCbkUserDataStruct
+        {
+            CPLString osURL{};
+            CSLConstList papszOptions = nullptr;
+            GDALProgressFunc pfnProgress = nullptr;
+            void *pProgressArg = nullptr;
+            CPLHTTPFetchWriteFunc pfnWrite = nullptr;
+            void *pWriteArg = nullptr;
+        };
+
+        const auto myCbk = [](const char *pszURL,
+                              CSLConstList papszOptions,
+                              GDALProgressFunc pfnProgress,
+                              void *pProgressArg,
+                              CPLHTTPFetchWriteFunc pfnWrite,
+                              void *pWriteArg,
+                              void* pUserData )
+        {
+            myCbkUserDataStruct* pCbkUserData = static_cast<myCbkUserDataStruct*>(pUserData);
+            pCbkUserData->osURL = pszURL;
+            pCbkUserData->papszOptions = papszOptions;
+            pCbkUserData->pfnProgress = pfnProgress;
+            pCbkUserData->pProgressArg = pProgressArg;
+            pCbkUserData->pfnWrite = pfnWrite;
+            pCbkUserData->pWriteArg = pWriteArg;
+            auto psResult = static_cast<CPLHTTPResult*>(CPLCalloc(sizeof(CPLHTTPResult), 1));
+            psResult->nStatus = 123;
+            return psResult;
+        };
+
+        myCbkUserDataStruct userData;
+        ensure( CPLHTTPPushFetchCallback(myCbk, &userData) );
+
+        int progressArg = 0;
+        const auto myWriteCbk = [](void *, size_t, size_t, void *) -> size_t { return 0; };
+        int writeCbkArg = 00;
+
+        CPLStringList aosOptions;
+        GDALProgressFunc pfnProgress = GDALTermProgress;
+        CPLHTTPFetchWriteFunc pfnWriteCbk = myWriteCbk;
+        CPLHTTPResult* pResult = CPLHTTPFetchEx("http://example.com",
+                                                aosOptions.List(),
+                                                pfnProgress,
+                                                &progressArg,
+                                                pfnWriteCbk,
+                                                &writeCbkArg);
+        ensure(pResult != nullptr);
+        ensure_equals(pResult->nStatus, 123);
+        CPLHTTPDestroyResult(pResult);
+
+        ensure( CPLHTTPPopFetchCallback() );
+        CPLPushErrorHandler(CPLQuietErrorHandler);
+        ensure( !CPLHTTPPopFetchCallback() );
+        CPLPopErrorHandler();
+
+        ensure_equals( userData.osURL, std::string("http://example.com") );
+        ensure_equals( userData.papszOptions, aosOptions.List() );
+        ensure_equals( userData.pfnProgress, pfnProgress );
+        ensure_equals( userData.pProgressArg, &progressArg );
+        ensure_equals( userData.pfnWrite, pfnWriteCbk );
+        ensure_equals( userData.pWriteArg, &writeCbkArg );
+    }
+
+    // Test CPLHTTPSetFetchCallback
+    template<>
+    template<>
+    void object::test<43>()
+    {
+        struct myCbkUserDataStruct
+        {
+            CPLString osURL{};
+            CSLConstList papszOptions = nullptr;
+            GDALProgressFunc pfnProgress = nullptr;
+            void *pProgressArg = nullptr;
+            CPLHTTPFetchWriteFunc pfnWrite = nullptr;
+            void *pWriteArg = nullptr;
+        };
+
+        const auto myCbk2 = [](const char *pszURL,
+                              CSLConstList papszOptions,
+                              GDALProgressFunc pfnProgress,
+                              void *pProgressArg,
+                              CPLHTTPFetchWriteFunc pfnWrite,
+                              void *pWriteArg,
+                              void* pUserData )
+        {
+            myCbkUserDataStruct* pCbkUserData = static_cast<myCbkUserDataStruct*>(pUserData);
+            pCbkUserData->osURL = pszURL;
+            pCbkUserData->papszOptions = papszOptions;
+            pCbkUserData->pfnProgress = pfnProgress;
+            pCbkUserData->pProgressArg = pProgressArg;
+            pCbkUserData->pfnWrite = pfnWrite;
+            pCbkUserData->pWriteArg = pWriteArg;
+            auto psResult = static_cast<CPLHTTPResult*>(CPLCalloc(sizeof(CPLHTTPResult), 1));
+            psResult->nStatus = 124;
+            return psResult;
+        };
+        myCbkUserDataStruct userData2;
+        CPLHTTPSetFetchCallback(myCbk2, &userData2);
+
+        int progressArg = 0;
+        const auto myWriteCbk = [](void *, size_t, size_t, void *) -> size_t { return 0; };
+        int writeCbkArg = 00;
+
+        CPLStringList aosOptions;
+        GDALProgressFunc pfnProgress = GDALTermProgress;
+        CPLHTTPFetchWriteFunc pfnWriteCbk = myWriteCbk;
+        CPLHTTPResult* pResult = CPLHTTPFetchEx("http://example.com",
+                                                aosOptions.List(),
+                                                pfnProgress,
+                                                &progressArg,
+                                                pfnWriteCbk,
+                                                &writeCbkArg);
+        ensure(pResult != nullptr);
+        ensure_equals(pResult->nStatus, 124);
+        CPLHTTPDestroyResult(pResult);
+
+        CPLHTTPSetFetchCallback(nullptr, nullptr);
+
+        ensure_equals( userData2.osURL, std::string("http://example.com") );
+        ensure_equals( userData2.papszOptions, aosOptions.List() );
+        ensure_equals( userData2.pfnProgress, pfnProgress );
+        ensure_equals( userData2.pProgressArg, &progressArg );
+        ensure_equals( userData2.pfnWrite, pfnWriteCbk );
+        ensure_equals( userData2.pWriteArg, &writeCbkArg );
+    }
+
 } // namespace tut

--- a/gdal/port/cpl_http.h
+++ b/gdal/port/cpl_http.h
@@ -114,6 +114,39 @@ void CPL_DLL  CPLHTTPDestroyMultiResult( CPLHTTPResult **papsResults, int nCount
 int  CPL_DLL  CPLHTTPParseMultipartMime( CPLHTTPResult *psResult );
 
 /* -------------------------------------------------------------------- */
+/* To install an alternate network layer to the default Curl one        */
+/* -------------------------------------------------------------------- */
+/** Callback function to process network requests.
+ *
+ * If CLOSE_PERSISTENT is found in papszOptions, no network request should be
+ * issued, but a dummy non-null CPLHTTPResult* should be returned by the callback.
+ *
+ * Its first arguments are the same as CPLHTTPFetchEx()
+ * @param pszURL See CPLHTTPFetchEx()
+ * @param papszOptions See CPLHTTPFetchEx()
+ * @param pfnProgress See CPLHTTPFetchEx()
+ * @param pProgressArg See CPLHTTPFetchEx()
+ * @param pfnWrite See CPLHTTPFetchEx()
+ * @param pWriteArg See CPLHTTPFetchEx()
+ * @param pUserData user data value that was passed during CPLHTTPPushFetchCallback()
+ * @return nullptr if the request cannot be processed, in which case the previous handler will be used.
+ */
+typedef CPLHTTPResult* (*CPLHTTPFetchCallbackFunc)( const char *pszURL,
+                                                    CSLConstList papszOptions,
+                                                    GDALProgressFunc pfnProgress,
+                                                    void *pProgressArg,
+                                                    CPLHTTPFetchWriteFunc pfnWrite,
+                                                    void *pWriteArg,
+                                                    void* pUserData );
+
+void CPL_DLL CPLHTTPSetFetchCallback( CPLHTTPFetchCallbackFunc pFunc,
+                                      void* pUserData );
+
+int CPL_DLL  CPLHTTPPushFetchCallback( CPLHTTPFetchCallbackFunc pFunc,
+                                       void* pUserData );
+int CPL_DLL  CPLHTTPPopFetchCallback(void);
+
+/* -------------------------------------------------------------------- */
 /*      The following is related to OAuth2 authorization around         */
 /*      google services like fusion tables, and potentially others      */
 /*      in the future.  Code in cpl_google_oauth2.cpp.                  */

--- a/gdal/port/cpl_multiproc.h
+++ b/gdal/port/cpl_multiproc.h
@@ -228,6 +228,7 @@ class CPL_DLL CPLLockHolder
 #define CTLS_ERRORHANDLERACTIVEDATA     17         /* cpl_error.cpp */
 #define CTLS_PROJCONTEXTHOLDER          18         /* ogr_proj_p.cpp */
 #define CTLS_GDALDEFAULTOVR_ANTIREC     19         /* gdaldefaultoverviews.cpp */
+#define CTLS_HTTPFETCHCALLBACK          20         /* cpl_http.cpp */
 
 #define CTLS_MAX                        32
 


### PR DESCRIPTION
Those functions are to be used to install callbacks that will take care
of executing network requests submitted to CPLHTTPFetch/CPLHTTPFetchEx().

This is meant to allow QGIS for example to be able to plug its network layer
instead of using the Curl implementation.