### PR TITLE
NITF: Add ACCHZB and ACCVTB TREs

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2738,6 +2738,108 @@ def test_nitf_78():
     assert data == expected_data
 
 ###############################################################################
+# Test parsing ACCHZB TRE (STDI-0002-1-v5.0 Appendix P)
+
+def test_nitf_79():
+    tre_data = "FILE_TRE=ACCHZB=01M  00129M  00129004+044.4130499724+33.69234401034+044.4945572008" \
+               "+33.67855217830+044.1731373448+32.79106350687+044.2538103407+32.77733592314"
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_79.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_79.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_79.ntf')
+
+    expected_data = """<tres>
+  <tre name="ACCHZB" location="file">
+    <field name="NUM_ACHZ" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <field name="UNIAAH" value="M" />
+        <field name="AAH" value="00129" />
+        <field name="UNIAPH" value="M" />
+        <field name="APH" value="00129" />
+        <field name="NUM_PTS" value="004" />
+        <repeated number="4">
+          <group index="0">
+            <field name="LON" value="+044.4130499724" />
+            <field name="LAT" value="+33.69234401034" />
+          </group>
+          <group index="1">
+            <field name="LON" value="+044.4945572008" />
+            <field name="LAT" value="+33.67855217830" />
+          </group>
+          <group index="2">
+            <field name="LON" value="+044.1731373448" />
+            <field name="LAT" value="+32.79106350687" />
+          </group>
+          <group index="3">
+            <field name="LON" value="+044.2538103407" />
+            <field name="LAT" value="+32.77733592314" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
+# Test parsing ACCVTB TRE (STDI-0002-1-v5.0 Appendix P)
+
+def test_nitf_80():
+    tre_data = "TRE=ACCVTB=01M  00095M  00095004+044.4130499724+33.69234401034+044.4945572008" \
+               "+33.67855217830+044.1731373448+32.79106350687+044.2538103407+32.77733592314"
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_80.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_80.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_80.ntf')
+
+    expected_data = """<tres>
+  <tre name="ACCVTB" location="image">
+    <field name="NUM_ACVT" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <field name="UNIAAV" value="M" />
+        <field name="AAV" value="00095" />
+        <field name="UNIAPV" value="M" />
+        <field name="APV" value="00095" />
+        <field name="NUM_PTS" value="004" />
+        <repeated number="4">
+          <group index="0">
+            <field name="LON" value="+044.4130499724" />
+            <field name="LAT" value="+33.69234401034" />
+          </group>
+          <group index="1">
+            <field name="LON" value="+044.4945572008" />
+            <field name="LAT" value="+33.67855217830" />
+          </group>
+          <group index="2">
+            <field name="LON" value="+044.1731373448" />
+            <field name="LAT" value="+32.79106350687" />
+          </group>
+          <group index="3">
+            <field name="LON" value="+044.2538103407" />
+            <field name="LAT" value="+32.77733592314" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -33,6 +33,25 @@
 <!-- This file should validate against nitf_spec.xsd -->
 
 <tres>
+    <!-- STDI-0002-1-v5.0 Appendix P, Section P.3.2.6.2, Table P-11 -->
+    <tre name="ACCHZB" md_prefix="NITF_ACCHZB_" minlength="11" maxlength="99985">
+        <field name="NUM_ACHZ" length="2" type="integer" minval="1" maxval="99"/>
+        <loop counter="NUM_ACHZ" md_prefix="ACHZ_%02d_">
+            <field name="UNIAAH" length="3" type="string"/>
+            <if cond="UNIAAH!=   ">
+                <field name="AAH" length="5" type="integer"/>
+            </if>
+            <field name="UNIAPH" length="3" type="string"/>
+            <if cond="UNIAPH!=   ">
+                <field name="APH" length="5" type="integer"/>
+            </if>
+            <field name="NUM_PTS" length="3" type="integer" minval="0" maxval="999"/>
+            <loop counter="NUM_PTS" md_prefix="POINT_%03d_">
+                <field name="LON" length="15" type="string"/>
+                <field name="LAT" length="15" type="string"/>
+            </loop>
+        </loop>
+    </tre>
 
     <tre name="ACCPOB" minlength="17" maxlength="99985" location="image">
         <field name="NUM_ACPO" length="2" type="integer" minval="1" maxval="99"/>
@@ -59,6 +78,26 @@
                 <field name="LAT" length="15" type="real"/>
             </loop>
         </loop>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix P, Section P.3.2.6.3, Table P-12 -->
+    <tre name="ACCVTB" md_prefix="NITF_ACCVTB_" minlength="11" maxlength="99985">
+        <field name="NUM_ACVT" length="2" type="integer" minval="1" maxval="99"/>
+        <loop counter="NUM_ACVT" md_prefix="ACVT_%02d_">
+            <field name="UNIAAV" length="3" type="string"/>
+            <if cond="UNIAAV!=   ">
+                <field name="AAV" length="5" type="integer"/>
+            </if>
+            <field name="UNIAPV" length="3" type="string"/>
+            <if cond="UNIAPV!=   ">
+                <field name="APV" length="5" type="integer"/>
+            </if>
+            <field name="NUM_PTS" length="3" type="integer" minval="0" maxval="999"/>
+            <loop counter="NUM_PTS" md_prefix="POINT_%03d_">
+                <field name="LON" length="15" type="string"/>
+                <field name="LAT" length="15" type="string"/>
+            </loop>
+         </loop>
     </tre>
 
     <tre name="ACFTB" length="207" location="image">


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

This PR adds the capability to read the ACCHZB and ACCVTB TREs, defined in the Spectral NITF Implementation Profile
The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
These TREs are defined in STDI-0002-1-v5.0 Appendix P.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/2983
https://github.com/OSGeo/gdal/pull/2973

## Tasklist

 - [x] Validate nitf_spec.xml against nitf_spec.xsd
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
