### PR TITLE
gdal_calc: support multiple calc arguments to produce a multiband file

### DIFF
--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -200,24 +200,30 @@ def test_gdal_calc_py_5():
     gdal_calc.Calc('A', A='tmp/test_gdal_calc_py.tif', overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_1.tif')
     gdal_calc.Calc('A', A='tmp/test_gdal_calc_py.tif', A_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_2.tif')
     gdal_calc.Calc('Z', Z='tmp/test_gdal_calc_py.tif', Z_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_3.tif')
+    gdal_calc.Calc(['A', 'Z'], A='tmp/test_gdal_calc_py.tif', Z='tmp/test_gdal_calc_py.tif', Z_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_4.tif')
 
     sys.path = backup_sys_path
 
     ds1 = gdal.Open('tmp/test_gdal_calc_py_5_1.tif')
     ds2 = gdal.Open('tmp/test_gdal_calc_py_5_2.tif')
     ds3 = gdal.Open('tmp/test_gdal_calc_py_5_3.tif')
+    ds4 = gdal.Open('tmp/test_gdal_calc_py_5_4.tif')
 
     assert ds1 is not None, 'ds1 not found'
     assert ds2 is not None, 'ds2 not found'
     assert ds3 is not None, 'ds3 not found'
+    assert ds4 is not None, 'ds4 not found'
 
     assert ds1.GetRasterBand(1).Checksum() == 12603, 'ds1 wrong checksum'
     assert ds2.GetRasterBand(1).Checksum() == 58561, 'ds2 wrong checksum'
     assert ds3.GetRasterBand(1).Checksum() == 58561, 'ds3 wrong checksum'
+    assert ds4.GetRasterBand(1).Checksum() == 12603, 'ds4#1 wrong checksum'
+    assert ds4.GetRasterBand(2).Checksum() == 58561, 'ds4#2 wrong checksum'
 
     ds1 = None
     ds2 = None
     ds3 = None
+    ds4 = None
 
 ###############################################################################
 # test nodata
@@ -306,6 +312,32 @@ def test_gdal_calc_py_7():
     ds3 = None
     ds4 = None
 
+
+###############################################################################
+# test multiple calcs
+
+def test_gdal_calc_py_8():
+
+    if gdalnumeric_not_available:
+        pytest.skip()
+
+    script_path = test_py_scripts.get_py_script('gdal_calc')
+    if script_path is None:
+        pytest.skip()
+
+    test_py_scripts.run_py_script(
+        script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band=1 -B tmp/test_gdal_calc_py.tif --B_band=2 -Z tmp/test_gdal_calc_py.tif --Z_band=2 --calc=A --calc=B --calc=Z --overwrite --outfile tmp/test_gdal_calc_py_8_1.tif')
+
+    ds1 = gdal.Open('tmp/test_gdal_calc_py_8_1.tif')
+
+    assert ds1 is not None, 'ds1 not found'
+
+    assert ds1.GetRasterBand(1).Checksum() == 12603, 'ds1#1 wrong checksum'
+    assert ds1.GetRasterBand(2).Checksum() == 58561, 'ds1#2 wrong checksum'
+    assert ds1.GetRasterBand(3).Checksum() == 58561, 'ds1#3 wrong checksum'
+
+    ds1 = None
+
 def test_gdal_calc_py_cleanup():
 
     lst = ['tmp/test_gdal_calc_py.tif',
@@ -322,11 +354,13 @@ def test_gdal_calc_py_cleanup():
            'tmp/test_gdal_calc_py_5_1.tif',
            'tmp/test_gdal_calc_py_5_2.tif',
            'tmp/test_gdal_calc_py_5_3.tif',
+           'tmp/test_gdal_calc_py_5_4.tif',
            'tmp/test_gdal_calc_py_6.tif',
            'tmp/test_gdal_calc_py_7_1.tif',
            'tmp/test_gdal_calc_py_7_2.tif',
            'tmp/test_gdal_calc_py_7_3.tif',
            'tmp/test_gdal_calc_py_7_4.tif',
+           'tmp/test_gdal_calc_py_8_1.tif',
            'tmp/opt1',
            'tmp/opt2',
            'tmp/opt3',

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -38,7 +38,7 @@ performed.
 .. option:: --calc=expression
 
     Calculation in gdalnumeric syntax using ``+``, ``-``, ``/``, ``*``, or any numpy array functions (i.e. ``log10()``).
-    Multiple calc options can be listed to produce a multiband file.
+    Multiple ``--calc`` options can be listed to produce a multiband file (GDAL >= 3.2).
 
 .. option:: -A <filename>
 

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -38,6 +38,7 @@ performed.
 .. option:: --calc=expression
 
     Calculation in gdalnumeric syntax using ``+``, ``-``, ``/``, ``*``, or any numpy array functions (i.e. ``log10()``).
+    Multiple calc options can be listed to produce a multiband file.
 
 .. option:: -A <filename>
 
@@ -83,7 +84,7 @@ performed.
 
 .. option:: --allBands=[A-Z]
 
-    Process all bands of given raster (A-Z).
+    Process all bands of given raster (A-Z). Requires a single calc for all bands.
 
 .. option:: --overwrite
 
@@ -132,3 +133,9 @@ Using logical operator to keep a range of values from input:
 .. code-block::
 
     gdal_calc.py -A input.tif --outfile=result.tif --calc="A*logical_and(A>100,A<150)"
+
+Work with multiple bands:
+
+.. code-block::
+
+    gdal_calc.py -A input.tif --A_band=1 -B input.tif --B_band=2 --outfile=result.tif --calc="(A+B)/2" --calc="B*logical_and(A>100,A<150)"

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -44,8 +44,12 @@
 
 # example 4 - using logical operator to keep a range of values from input:
 # gdal_calc.py -A input.tif --outfile=result.tif --calc="A*logical_and(A>100,A<150)"
+
+# example 5 - work with multiple bands:
+# gdal_calc.py -A input.tif --A_band=1 -B input.tif --B_band=2 --outfile=result.tif --calc="(A+B)/2" --calc="A*logical_and(A>100,A<150)"
 ################################################################
 
+import builtins
 from optparse import OptionParser, OptionConflictError, Values
 import os
 import os.path
@@ -182,6 +186,8 @@ def doit(opts, args):
     allBandsIndex = None
     allBandsCount = 1
     if opts.allBands:
+        if len(opts.calc) > 1:
+            raise Exception("Error! --allBands implies a single --calc")
         try:
             allBandsIndex = myAlphaList.index(opts.allBands)
         except ValueError:
@@ -189,6 +195,8 @@ def doit(opts, args):
         allBandsCount = myFiles[allBandsIndex].RasterCount
         if allBandsCount <= 1:
             allBandsIndex = None
+    else:
+        allBandsCount = len(opts.calc)
 
     ################################################################
     # set up output file
@@ -198,6 +206,8 @@ def doit(opts, args):
     if os.path.isfile(opts.outF) and not opts.overwrite:
         if allBandsIndex is not None:
             raise Exception("Error! allBands option was given but Output file exists, must use --overwrite option!")
+        if len(opts.calc) > 1:
+            raise Exception("Error! multiple calc options were given but Output file exists, must use --overwrite option!")
         if opts.debug:
             print("Output file %s exists - filling in results into file" % (opts.outF))
         myOut = gdal.Open(opts.outF, gdal.GA_Update)
@@ -345,10 +355,11 @@ def doit(opts, args):
                     myval = None
 
                 # try the calculation on the array blocks
+                calc = opts.calc[bandNo-1 if len(opts.calc) > 1 else 0]
                 try:
-                    myResult = eval(opts.calc, global_namespace, local_namespace)
+                    myResult = eval(calc, global_namespace, local_namespace)
                 except:
-                    print("evaluation of calculation %s failed" % (opts.calc))
+                    print("evaluation of calculation %s failed" % (calc))
                     raise
 
                 # Propagate nodata values (set nodata cells to zero
@@ -393,10 +404,18 @@ def Calc(calc, outfile, NoDataValue=None, type=None, format=None, creation_optio
 
     set values of zero and below to null:
         Calc(calc="A*(A>0)", A="input.tif", A_band=2, outfile="result.tif", NoDataValue=0)
+
+    work with two bands:
+        Calc(["(A+B)/2", "A*(A>0)"], A="input.tif", A_band=1, B="input.tif", B_band=2, outfile="result.tif", NoDataValue=0)
     """
     opts = Values()
     opts.input_files = input_files
-    opts.calc = calc
+    # Single calc value compatiblity
+    # (type is overriden in the parameter list)
+    if builtins.type(calc) is not list:
+        opts.calc = [ calc ]
+    else:
+        opts.calc = calc
     opts.outF = outfile
     opts.NoDataValue = NoDataValue
     opts.type = type
@@ -434,7 +453,7 @@ def main():
     parser = OptionParser(usage)
 
     # define options
-    parser.add_option("--calc", dest="calc", help="calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. log10())", metavar="expression")
+    parser.add_option("--calc", dest="calc", action="append", help="calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. log10()), may appear multiple times to produce a multi-band file", metavar="expression")
     add_alpha_args(parser, sys.argv)
 
     parser.add_option("--outfile", dest="outF", help="output file to generate or fill", metavar="filename")

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -49,7 +49,6 @@
 # gdal_calc.py -A input.tif --A_band=1 -B input.tif --B_band=2 --outfile=result.tif --calc="(A+B)/2" --calc="A*logical_and(A>100,A<150)"
 ################################################################
 
-import builtins
 from optparse import OptionParser, OptionConflictError, Values
 import os
 import os.path
@@ -412,10 +411,10 @@ def Calc(calc, outfile, NoDataValue=None, type=None, format=None, creation_optio
     opts.input_files = input_files
     # Single calc value compatiblity
     # (type is overriden in the parameter list)
-    if builtins.type(calc) is not list:
-        opts.calc = [ calc ]
-    else:
+    if isinstance(calc, list):
         opts.calc = calc
+    else:
+        opts.calc = [calc]
     opts.outF = outfile
     opts.NoDataValue = NoDataValue
     opts.type = type

--- a/gdal/swig/python/scripts/gdal_calc.py
+++ b/gdal/swig/python/scripts/gdal_calc.py
@@ -452,7 +452,7 @@ def main():
     parser = OptionParser(usage)
 
     # define options
-    parser.add_option("--calc", dest="calc", action="append", help="calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. log10()), may appear multiple times to produce a multi-band file", metavar="expression")
+    parser.add_option("--calc", dest="calc", action="append", help="calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. log10()). May appear multiple times to produce a multi-band file", metavar="expression")
     add_alpha_args(parser, sys.argv)
 
     parser.add_option("--outfile", dest="outF", help="output file to generate or fill", metavar="filename")


### PR DESCRIPTION
Support mulitple calc arguments to produce a multiband file
Currently, producing a multiband file requires producing separate files, then merging them either by constructing a VRT file, either by using gdal_merge
It stays compatible with the old way of calling gdal_calc from other python scripts by supporting both single calc values and lists of calc values

Example:
gdal_calc.py -A A.tif --A_band=1 -B.tif --B_band=2 -Z Z.tif --calc="(A+B)" --calc="(B+Z)" --calc="(Z/2)" --overwrite --outfile tmp/test_gdal_calc_py_8_1.tif

It is not compatible with --allBands - ie you have to either specify allBands, either have multiple calcs but not both