### PR TITLE
NITF: Add SNIP TREs MSTGTA and PIATGB

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2840,6 +2840,72 @@ def test_nitf_80():
     assert data == expected_data
 
 ###############################################################################
+# Test parsing MSTGTA TRE (STDI-0002-1-v5.0 App E)
+
+def test_nitf_81():
+    tre_data = "FILE_TRE=MSTGTA=012340123456789AB0123456789ABCDE0120123456789AB0123456789AB000123401234560123450TGT_LOC=             "
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_81.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_81.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_81.ntf')
+
+    expected_data = """<tres>
+  <tre name="MSTGTA" location="file">
+    <field name="TGT_NUM" value="01234" />
+    <field name="TGT_ID" value="0123456789AB" />
+    <field name="TGT_BE" value="0123456789ABCDE" />
+    <field name="TGT_PRI" value="012" />
+    <field name="TGT_REQ" value="0123456789AB" />
+    <field name="TGT_LTIOV" value="0123456789AB" />
+    <field name="TGT_TYPE" value="0" />
+    <field name="TGT_COLL" value="0" />
+    <field name="TGT_CAT" value="01234" />
+    <field name="TGT_UTC" value="0123456" />
+    <field name="TGT_ELEV" value="012345" />
+    <field name="TGT_ELEV_UNIT" value="0" />
+    <field name="TGT_LOC" value="TGT_LOC=" />
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
+# Test parsing PIATGB TRE (STDI-0002-1-v5.0 App C)
+
+def test_nitf_82():
+    tre_data = "FILE_TRE=PIATGB=0123456789ABCDE0123456789ABCDE01012340123456789ABCDE012" \
+               "TGTNAME=                              012+01.234567-012.345678"
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_82.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_82.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_82.ntf')
+
+    expected_data = """<tres>
+  <tre name="PIATGB" location="file">
+    <field name="TGTUTM" value="0123456789ABCDE" />
+    <field name="PIATGAID" value="0123456789ABCDE" />
+    <field name="PIACTRY" value="01" />
+    <field name="PIACAT" value="01234" />
+    <field name="TGTGEO" value="0123456789ABCDE" />
+    <field name="DATUM" value="012" />
+    <field name="TGTNAME" value="TGTNAME=" />
+    <field name="PERCOVER" value="012" />
+    <field name="TGTLAT" value="+01.234567" />
+    <field name="TGTLON" value="-012.345678" />
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -696,6 +696,23 @@
         <field name="TOTAL_TILES_ROWS" length="5" type="integer" minval="1" maxval="99999"/>
     </tre>
 
+    <!-- STDI-0002-1-v5.0 Appendix E, Section E.3.9, Table E-16-->
+    <tre name="MSTGTA" md_prefix="NITF_MSTGTA_" length="101">
+        <field name="TGT_NUM" length="5" type="integer" minval="0" maxval="99999"/>
+        <field name="TGT_ID" length="12" type="string"/>
+        <field name="TGT_BE" length="15" type="string"/>
+        <field name="TGT_PRI" length="3" type="integer" minval="1" maxval="999"/>
+        <field name="TGT_REQ" length="12" type="string"/>
+        <field name="TGT_LTIOV" length="12" type="string"/>
+        <field name="TGT_TYPE" length="1" type="integer"/>
+        <field name="TGT_COLL" length="1" type="integer"/>
+        <field name="TGT_CAT" length="5" type="integer" minval="10000" maxval="99999"/>
+        <field name="TGT_UTC" length="7" type="string"/>
+        <field name="TGT_ELEV" length="6" type="integer" minval="-1000" maxval="30000"/>
+        <field name="TGT_ELEV_UNIT" length="1" type="string"/>
+        <field name="TGT_LOC" length="21" type="string"/>
+    </tre>
+
     <!-- STDI-0002 Appendix E (ASDE 2.1/CN1), Section 3.10 and Table E-19 -->
     <tre name="MTIRPB" minlength="119" maxlength="42035">
         <field name="MTI_DP" length="2" type="string"/>
@@ -871,6 +888,20 @@
         <loop counter="ATEXTREP" md_prefix="ATEXT_%02d" name="ATEXT">
             <field name="" longname="ATEXT" length="255" type="string"/>
         </loop>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix C, Section C.3, Tables C-7,C-8,C-9 -->
+    <tre name="PIATGB" md_prefix="NITF_PIATGB_" length="117">
+      <field name="TGTUTM" length="15" type="string"/>
+      <field name="PIATGAID" length="15" type="string"/>
+      <field name="PIACTRY" length="2" type="string"/>
+      <field name="PIACAT" length="5" type="string"/>
+      <field name="TGTGEO" length="15" type="string"/>
+      <field name="DATUM" length="3" type="string"/>
+      <field name="TGTNAME" length="38" type="string"/>
+      <field name="PERCOVER" length="3" type="integer" minval="0" maxval="100"/>
+      <field name="TGTLAT" length="10" type="string"/>
+      <field name="TGTLON" length="11" type="string"/>
     </tre>
 
     <tre name="PRJPSB" minlength="113" maxlength="248" location="file">


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds the capability to read the MSTGTA and PIATGB TREs, defined in the Spectral NITF Implementation Profile
The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
MSTGTA is defined in STDI-0002-1-v5.0 Appendix E.
PIATGB is defined in STDI-0002-1-v5.0 Appendix C.

These TREs are not populated in the SNIP reference implementation product 1B, so arbitrary data was used to populate the TREs in the unit tests.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/3001

## Tasklist

 - [x] Validate nitf_spec.xml against nitf_spec.xsd
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
