### PR TITLE
gdal_calc.py - improvements

### DIFF
--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -10,6 +10,7 @@
 ###############################################################################
 # Copyright (c) 2013, Even Rouault <even dot rouault @ spatialys.com>
 # Copyright (c) 2014, Etienne Tourigny <etourigny dot dev @ gmail dot com>
+# Copyright (c) 2020, Idan Miara <idan@miara.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,326 +33,351 @@
 
 import os
 import shutil
+from copy import copy
 
 
 from osgeo import gdal
 import test_py_scripts
 import pytest
+from collections import defaultdict
 
 # test that gdalnumeric is available, if not skip all tests
 gdalnumeric_not_available = False
 try:
     from osgeo import gdalnumeric
     from osgeo.utils import gdal_calc
+    import numpy as np
     gdalnumeric.BandRasterIONumPy
 except (ImportError, AttributeError):
     gdalnumeric_not_available = True
 
+if gdalnumeric_not_available:
+    pytest.skip("gdalnumeric is not available, skipping all tests", allow_module_level=True)
+script_path = test_py_scripts.get_py_script('gdal_calc')
+if script_path is None:
+    pytest.skip("gdal_calc script not found, skipping all tests", allow_module_level=True)
+
 # Usage: gdal_calc.py [-A <filename>] [--A_band] [-B...-Z filename] [other_options]
 
 
-###############################################################################
-# test basic copy
+def check_file(filename_or_ds, checksum, i=None, bnd_idx=1):
+    if gdal_calc.is_path_like(filename_or_ds):
+        ds = gdal.Open(filename_or_ds)
+    else:
+        ds = filename_or_ds
+    assert ds is not None, 'ds{} not found'.format(i if i is not None else '')
+    ds_checksum = ds.GetRasterBand(bnd_idx).Checksum()
+    if checksum is None:
+        print('ds{} bnd{} checksum is {}'.format(i, bnd_idx, ds_checksum))
+    else:
+        assert ds_checksum == checksum, 'ds{} bnd{} wrong checksum, expected {}, got {}'.format(i, bnd_idx, checksum, ds_checksum)
+    return ds
+
+
+temp_counter_dict = defaultdict(int)
+opts_counter_counter = 0
+input_checksum = (12603, 58561, 36064, 10807)
+
+
+def get_input_file():
+    infile = make_temp_filename(0)
+    if not os.path.isfile(infile):
+        shutil.copy('../gcore/data/stefan_full_rgba.tif', infile)
+    return infile
+
+
+def format_temp_filename(test_id, idx, is_opt=False):
+    if not is_opt:
+        out_template = 'tmp/test_gdal_calc_py{}.tif'
+        return out_template.format('' if test_id == 0 else '_{}_{}'.format(test_id, idx))
+    else:
+        opts_template = 'tmp/opt{}'
+        return opts_template.format(idx)
+
+
+def make_temp_filename(test_id, is_opt=False):
+    if not is_opt:
+        global temp_counter_dict
+        temp_counter_dict[test_id] = 1 + (temp_counter_dict[test_id] if test_id else 0)
+        idx = temp_counter_dict[test_id]
+    else:
+        global opts_counter_counter
+        opts_counter_counter = opts_counter_counter + 1
+        idx = opts_counter_counter
+    return format_temp_filename(test_id, idx, is_opt)
+
+
+def make_temp_filename_list(test_id, test_count, is_opt=False):
+    return list(make_temp_filename(test_id, is_opt) for _ in range(test_count))
+
 
 def test_gdal_calc_py_1():
+    """ test basic copy """
+    infile = get_input_file()
+    test_id, test_count = 1, 3
+    out = make_temp_filename_list(test_id, test_count)
 
-    if gdalnumeric_not_available:
-        pytest.skip('gdalnumeric is not available, skipping all tests')
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --calc=A --overwrite --outfile {}'.format(infile, out[0]))
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --A_band=2 --calc=A --overwrite --outfile {}'.format(infile, out[1]))
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-Z {} --Z_band=2 --calc=Z --overwrite --outfile {}'.format(infile, out[2]))
 
-    script_path = test_py_scripts.get_py_script('gdal_calc')
-    if script_path is None:
-        pytest.skip()
-
-    shutil.copy('../gcore/data/stefan_full_rgba.tif', 'tmp/test_gdal_calc_py.tif')
-
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --calc=A --overwrite --outfile tmp/test_gdal_calc_py_1_1.tif')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band=2 --calc=A --overwrite --outfile tmp/test_gdal_calc_py_1_2.tif')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-Z tmp/test_gdal_calc_py.tif --Z_band=2 --calc=Z --overwrite --outfile tmp/test_gdal_calc_py_1_3.tif')
-
-    ds1 = gdal.Open('tmp/test_gdal_calc_py_1_1.tif')
-    ds2 = gdal.Open('tmp/test_gdal_calc_py_1_2.tif')
-    ds3 = gdal.Open('tmp/test_gdal_calc_py_1_3.tif')
-
-    assert ds1 is not None, 'ds1 not found'
-    assert ds2 is not None, 'ds2 not found'
-    assert ds3 is not None, 'ds3 not found'
-
-    assert ds1.GetRasterBand(1).Checksum() == 12603, 'ds1 wrong checksum'
-    assert ds2.GetRasterBand(1).Checksum() == 58561, 'ds2 wrong checksum'
-    assert ds3.GetRasterBand(1).Checksum() == 58561, 'ds3 wrong checksum'
-
-    ds1 = None
-    ds2 = None
-    ds3 = None
-
-###############################################################################
-# test simple formulas
+    for i, checksum in zip(range(test_count), (input_checksum[0], input_checksum[1], input_checksum[1])):
+        check_file(out[i], checksum, i+1)
 
 
 def test_gdal_calc_py_2():
+    """ test simple formulas """
+    infile = get_input_file()
+    test_id, test_count = 2, 3
+    out = make_temp_filename_list(test_id, test_count)
 
-    if gdalnumeric_not_available:
-        pytest.skip()
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --A_band 1 -B {} --B_band 2 --calc=A+B --overwrite --outfile {}'.format(infile, infile, out[0]))
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --A_band 1 -B {} --B_band 2 --calc=A*B --overwrite --outfile {}'.format(infile, infile, out[1]))
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --A_band 1 --calc="sqrt(A)" --type=Float32 --overwrite --outfile {}'.format(infile, out[2]))
 
-    script_path = test_py_scripts.get_py_script('gdal_calc')
-    if script_path is None:
-        pytest.skip()
-
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band 1 -B tmp/test_gdal_calc_py.tif --B_band 2 --calc=A+B --overwrite --outfile tmp/test_gdal_calc_py_2_1.tif')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band 1 -B tmp/test_gdal_calc_py.tif --B_band 2 --calc=A*B --overwrite --outfile tmp/test_gdal_calc_py_2_2.tif')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band 1 --calc="sqrt(A)" --type=Float32 --overwrite --outfile tmp/test_gdal_calc_py_2_3.tif')
-
-    ds1 = gdal.Open('tmp/test_gdal_calc_py_2_1.tif')
-    ds2 = gdal.Open('tmp/test_gdal_calc_py_2_2.tif')
-    ds3 = gdal.Open('tmp/test_gdal_calc_py_2_3.tif')
-
-    assert ds1 is not None, 'ds1 not found'
-    assert ds2 is not None, 'ds2 not found'
-    assert ds3 is not None, 'ds3 not found'
-    assert ds1.GetRasterBand(1).Checksum() == 12368, 'ds1 wrong checksum'
-    assert ds2.GetRasterBand(1).Checksum() == 62785, 'ds2 wrong checksum'
-    assert ds3.GetRasterBand(1).Checksum() == 47132, 'ds3 wrong checksum'
-    ds1 = None
-    ds2 = None
-    ds3 = None
-
-
-###############################################################################
-# test --allBands option (simple copy)
+    for i, checksum in zip(range(test_count), (12368, 62785, 47132)):
+        check_file(out[i], checksum, i+1)
+#
 
 def test_gdal_calc_py_3():
+    """ test --allBands option (simple copy) """
+    infile = get_input_file()
+    test_id, test_count = 3, 1
+    out = make_temp_filename_list(test_id, test_count)
 
-    if gdalnumeric_not_available:
-        pytest.skip()
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --allBands A --calc=A --overwrite --outfile {}'.format(infile, out[0]))
 
-    script_path = test_py_scripts.get_py_script('gdal_calc')
-    if script_path is None:
-        pytest.skip()
-
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --allBands A --calc=A --overwrite --outfile tmp/test_gdal_calc_py_3.tif')
-
-    ds = gdal.Open('tmp/test_gdal_calc_py_3.tif')
-
-    assert ds is not None, 'ds not found'
-    assert ds.GetRasterBand(1).Checksum() == 12603, 'band 1 wrong checksum'
-    assert ds.GetRasterBand(2).Checksum() == 58561, 'band 2 wrong checksum'
-    assert ds.GetRasterBand(3).Checksum() == 36064, 'band 3 wrong checksum'
-    assert ds.GetRasterBand(4).Checksum() == 10807, 'band 4 wrong checksum'
-
-    ds = None
-
-###############################################################################
-# test --allBands option (simple calc)
+    bnd_count = 4
+    for i, checksum in zip(range(bnd_count), input_checksum[0:bnd_count]):
+        check_file(out[0], checksum, 1, bnd_idx=i+1)
 
 
 def test_gdal_calc_py_4():
-
-    if gdalnumeric_not_available:
-        pytest.skip()
-
-    script_path = test_py_scripts.get_py_script('gdal_calc')
-    if script_path is None:
-        pytest.skip()
+    """ test --allBands option (simple calc) """
+    infile = get_input_file()
+    test_id, test_count = 4, 3
+    out = make_temp_filename_list(test_id, test_count)
 
     # some values are clipped to 255, but this doesn't matter... small values were visually checked
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --calc=1 --overwrite --outfile tmp/test_gdal_calc_py_4_1.tif')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif -B tmp/test_gdal_calc_py_4_1.tif --B_band 1 --allBands A --calc=A+B --NoDataValue=999 --overwrite --outfile tmp/test_gdal_calc_py_4_2.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --calc=1 --overwrite --outfile {}'.format(infile, out[0]))
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} -B {} --B_band 1 --allBands A --calc=A+B --NoDataValue=999 --overwrite --outfile {}'.format(infile, out[0], out[1]))
 
-    ds1 = gdal.Open('tmp/test_gdal_calc_py_4_2.tif')
-
-    assert ds1 is not None, 'ds1 not found'
-    assert ds1.GetRasterBand(1).Checksum() == 29935, 'ds1 band 1 wrong checksum'
-    assert ds1.GetRasterBand(2).Checksum() == 13128, 'ds1 band 2 wrong checksum'
-    assert ds1.GetRasterBand(3).Checksum() == 59092, 'ds1 band 3 wrong checksum'
-
-    ds1 = None
+    bnd_count = 3
+    for i, checksum in zip(range(bnd_count), (29935, 13128, 59092)):
+        check_file(out[1], checksum, 2, bnd_idx=i+1)
 
     # these values were not tested
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif -B tmp/test_gdal_calc_py.tif --B_band 1 --allBands A --calc=A*B --NoDataValue=999 --overwrite --outfile tmp/test_gdal_calc_py_4_3.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} -B {} --B_band 1 --allBands A --calc=A*B --NoDataValue=999 --overwrite --outfile {}'.format(infile, infile, out[2]))
 
-    ds2 = gdal.Open('tmp/test_gdal_calc_py_4_3.tif')
-
-    assert ds2 is not None, 'ds2 not found'
-    assert ds2.GetRasterBand(1).Checksum() == 10025, 'ds2 band 1 wrong checksum'
-    assert ds2.GetRasterBand(2).Checksum() == 62785, 'ds2 band 2 wrong checksum'
-    assert ds2.GetRasterBand(3).Checksum() == 10621, 'ds2 band 3 wrong checksum'
-
-    ds2 = None
-
-###############################################################################
-# test python interface, basic copy
+    bnd_count = 3
+    for i, checksum in zip(range(bnd_count), (10025, 62785, 10621)):
+        check_file(out[2], checksum, 3, bnd_idx=i+1)
 
 
 def test_gdal_calc_py_5():
+    """ test python interface, basic copy """
+    infile = get_input_file()
+    test_id, test_count = 5, 4
+    out = make_temp_filename_list(test_id, test_count)
 
-    if gdalnumeric_not_available:
-        pytest.skip('gdalnumeric is not available, skipping all tests')
+    gdal_calc.Calc('A', A=infile, overwrite=True, quiet=True, outfile=out[0])
+    gdal_calc.Calc('A', A=infile, A_band=2, overwrite=True, quiet=True, outfile=out[1])
+    gdal_calc.Calc('Z', Z=infile, Z_band=2, overwrite=True, quiet=True, outfile=out[2])
+    gdal_calc.Calc(['A', 'Z'], A=infile, Z=infile, Z_band=2, overwrite=True, quiet=True, outfile=out[3])
 
-    shutil.copy('../gcore/data/stefan_full_rgba.tif', 'tmp/test_gdal_calc_py.tif')
+    for i, checksum in zip(range(test_count), (input_checksum[0], input_checksum[1], input_checksum[1])):
+        check_file(out[i], checksum, i+1)
 
-    gdal_calc.Calc('A', A='tmp/test_gdal_calc_py.tif', overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_1.tif')
-    gdal_calc.Calc('A', A='tmp/test_gdal_calc_py.tif', A_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_2.tif')
-    gdal_calc.Calc('Z', Z='tmp/test_gdal_calc_py.tif', Z_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_3.tif')
-    gdal_calc.Calc(['A', 'Z'], A='tmp/test_gdal_calc_py.tif', Z='tmp/test_gdal_calc_py.tif', Z_band=2, overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_5_4.tif')
-
-    ds1 = gdal.Open('tmp/test_gdal_calc_py_5_1.tif')
-    ds2 = gdal.Open('tmp/test_gdal_calc_py_5_2.tif')
-    ds3 = gdal.Open('tmp/test_gdal_calc_py_5_3.tif')
-    ds4 = gdal.Open('tmp/test_gdal_calc_py_5_4.tif')
-
-    assert ds1 is not None, 'ds1 not found'
-    assert ds2 is not None, 'ds2 not found'
-    assert ds3 is not None, 'ds3 not found'
-    assert ds4 is not None, 'ds4 not found'
-
-    assert ds1.GetRasterBand(1).Checksum() == 12603, 'ds1 wrong checksum'
-    assert ds2.GetRasterBand(1).Checksum() == 58561, 'ds2 wrong checksum'
-    assert ds3.GetRasterBand(1).Checksum() == 58561, 'ds3 wrong checksum'
-    assert ds4.GetRasterBand(1).Checksum() == 12603, 'ds4#1 wrong checksum'
-    assert ds4.GetRasterBand(2).Checksum() == 58561, 'ds4#2 wrong checksum'
-
-    ds1 = None
-    ds2 = None
-    ds3 = None
-    ds4 = None
-
-###############################################################################
-# test nodata
+    bnd_count = 2
+    for i, checksum in zip(range(bnd_count), (input_checksum[0], input_checksum[1])):
+        check_file(out[3], checksum, 4, bnd_idx=i+1)
 
 
 def test_gdal_calc_py_6():
+    """ test nodata """
+    test_id, test_count = 6, 2
+    out = make_temp_filename_list(test_id, test_count)
 
-    if gdalnumeric_not_available:
-        pytest.skip('gdalnumeric is not available, skipping all tests')
+    gdal.Translate(out[0], '../gcore/data/byte.tif', options='-a_nodata 74')
+    gdal_calc.Calc('A', A=out[0], overwrite=True, quiet=True, outfile=out[1], NoDataValue=1)
 
-    gdal.Translate('tmp/test_gdal_calc_py.tif', '../gcore/data/byte.tif', options='-a_nodata 74')
+    for i, checksum in zip(range(test_count), (4672, 4673)):
+        ds = check_file(out[i], checksum, i+1)
+        if i == 1:
+            result = ds.GetRasterBand(1).ComputeRasterMinMax()
+            assert result == (90, 255), 'Error! min/max not correct!'
+        ds = None
 
-    gdal_calc.Calc('A', A='tmp/test_gdal_calc_py.tif', overwrite=True, quiet=True, outfile='tmp/test_gdal_calc_py_6.tif', NoDataValue=1)
-
-    ds = gdal.Open('tmp/test_gdal_calc_py_6.tif')
-    cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 4673
-    result = ds.GetRasterBand(1).ComputeRasterMinMax()
-    assert result == (90, 255)
-
-###############################################################################
-# test --optfile
 
 def test_gdal_calc_py_7():
-    if gdalnumeric_not_available:
-        pytest.skip('gdalnumeric is not available, skipping all tests')
+    """ test --optfile """
+    infile = get_input_file()
+    test_id, test_count = 7, 4
+    out = make_temp_filename_list(test_id, test_count)
+    opt_files = make_temp_filename_list(test_id, test_count, is_opt=True)
 
-    script_path = test_py_scripts.get_py_script('gdal_calc')
-    if script_path is None:
-        pytest.skip()
-
-    shutil.copy('../gcore/data/stefan_full_rgba.tif', 'tmp/test_gdal_calc_py.tif')
-
-    with open('tmp/opt1', 'w') as f:
-        f.write('-A tmp/test_gdal_calc_py.tif --calc=A --overwrite --outfile tmp/test_gdal_calc_py_7_1.tif')
+    with open(opt_files[0], 'w') as f:
+        f.write('-A {} --calc=A --overwrite --outfile {}'.format(infile, out[0]))
 
     # Lines in optfiles beginning with '#' should be ignored
-    with open('tmp/opt2', 'w') as f:
-        f.write('-A tmp/test_gdal_calc_py.tif --A_band=2 --calc=A --overwrite --outfile tmp/test_gdal_calc_py_7_2.tif')
+    with open(opt_files[1], 'w') as f:
+        f.write('-A {} --A_band=2 --calc=A --overwrite --outfile {}'.format(infile, out[1]))
         f.write('\n# -A_band=1')
 
     # options on separate lines should work, too
-    opts = '-Z tmp/test_gdal_calc_py.tif', '--Z_band=2', '--calc=Z', '--overwrite', '--outfile tmp/test_gdal_calc_py_7_3.tif'
-    with open('tmp/opt3', 'w') as f:
+    opts = '-Z {}'.format(infile), '--Z_band=2', '--calc=Z', '--overwrite', '--outfile  {}'.format(out[2])
+    with open(opt_files[2], 'w') as f:
         for i in opts:
             f.write(i + '\n')
 
     # double-quoted options should be read as single arguments. Mixed numbers of arguments per line should work.
-    opts = '-Z tmp/test_gdal_calc_py.tif --Z_band=2', '--calc "Z + 0"', '--overwrite --outfile tmp/test_gdal_calc_py_7_4.tif'
-    with open('tmp/opt4', 'w') as f:
+    opts = '-Z {} --Z_band=2'.format(infile), '--calc "Z + 0"', '--overwrite --outfile {}'.format(out[3])
+    with open(opt_files[3], 'w') as f:
         for i in opts:
             f.write(i + '\n')
 
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '--optfile tmp/opt1')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '--optfile tmp/opt2')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '--optfile tmp/opt3')
-    test_py_scripts.run_py_script(script_path, 'gdal_calc', '--optfile tmp/opt4')
+    for i, checksum in zip(range(test_count), (input_checksum[0], input_checksum[1], input_checksum[1], input_checksum[1])):
+        test_py_scripts.run_py_script(script_path, 'gdal_calc', '--optfile {}'.format(opt_files[i]))
+        check_file(out[i], checksum, i+1)
 
-    ds1 = gdal.Open('tmp/test_gdal_calc_py_7_1.tif')
-    ds2 = gdal.Open('tmp/test_gdal_calc_py_7_2.tif')
-    ds3 = gdal.Open('tmp/test_gdal_calc_py_7_3.tif')
-    ds4 = gdal.Open('tmp/test_gdal_calc_py_7_4.tif')
-
-    assert ds1 is not None, 'ds1 not found'
-    assert ds2 is not None, 'ds2 not found'
-    assert ds3 is not None, 'ds3 not found'
-    assert ds4 is not None, 'ds4 not found'
-
-    assert ds1.GetRasterBand(1).Checksum() == 12603, 'ds1 wrong checksum'
-    assert ds2.GetRasterBand(1).Checksum() == 58561, 'ds2 wrong checksum'
-    assert ds3.GetRasterBand(1).Checksum() == 58561, 'ds3 wrong checksum'
-    assert ds4.GetRasterBand(1).Checksum() == 58561, 'ds4 wrong checksum'
-
-    ds1 = None
-    ds2 = None
-    ds3 = None
-    ds4 = None
-
-
-###############################################################################
-# test multiple calcs
 
 def test_gdal_calc_py_8():
-
-    if gdalnumeric_not_available:
-        pytest.skip()
-
-    script_path = test_py_scripts.get_py_script('gdal_calc')
-    if script_path is None:
-        pytest.skip()
+    """ test multiple calcs """
+    infile = get_input_file()
+    test_id, test_count = 8, 1
+    out = make_temp_filename_list(test_id, test_count)
 
     test_py_scripts.run_py_script(
-        script_path, 'gdal_calc', '-A tmp/test_gdal_calc_py.tif --A_band=1 -B tmp/test_gdal_calc_py.tif --B_band=2 -Z tmp/test_gdal_calc_py.tif --Z_band=2 --calc=A --calc=B --calc=Z --overwrite --outfile tmp/test_gdal_calc_py_8_1.tif')
+        script_path, 'gdal_calc',
+        '-A {} --A_band=1 -B {} --B_band=2 -Z {} --Z_band=2 --calc=A --calc=B --calc=Z --overwrite --outfile {}'.
+            format(infile, infile, infile, out[0]))
 
-    ds1 = gdal.Open('tmp/test_gdal_calc_py_8_1.tif')
+    bnd_count = 3
+    for i, checksum in zip(range(bnd_count), (input_checksum[0], input_checksum[1], input_checksum[1])):
+        check_file(out[0], checksum, 1, bnd_idx=i+1)
 
-    assert ds1 is not None, 'ds1 not found'
 
-    assert ds1.GetRasterBand(1).Checksum() == 12603, 'ds1#1 wrong checksum'
-    assert ds1.GetRasterBand(2).Checksum() == 58561, 'ds1#2 wrong checksum'
-    assert ds1.GetRasterBand(3).Checksum() == 58561, 'ds1#3 wrong checksum'
+def my_sum(a, gdal_dt=None):
+    """ sum using numpy """
+    np_dt = None if gdal_dt is None else gdal_calc.gdal_dt_to_np_dt[gdal_dt]
+    concatenate = np.stack(a)
+    ret = concatenate.sum(axis=0, dtype=np_dt)
+    return ret
 
-    ds1 = None
+
+def my_max(a):
+    """ max using numpy """
+    concatenate = np.stack(a)
+    ret = concatenate.max(axis=0)
+    return ret
+
+
+def test_gdal_calc_py_9():
+    """
+    test calculating sum in different ways. testing the following features:
+    * noDataValue
+    * user_namespace
+    * using output ds
+    * mem driver (no output file)
+    * single alpha for multiple datasets
+    * extent = 'fail'
+    """
+    infile = get_input_file()
+    test_id, test_count = 9, 9
+    out = make_temp_filename_list(test_id, test_count)
+
+    common_kwargs = {
+        'hideNoData': True,
+        'overwrite': True,
+        'extent': 'fail',
+    }
+    inputs0 = dict()
+    inputs0['a'] = infile
+
+    total_bands = 3
+    checksums = [input_checksum[0], input_checksum[1], input_checksum[2]]
+    inputs = []
+    keep_ds = [True, False, False]
+    for i in range(total_bands):
+        bnd_idx = i + 1
+        inputs0['a_band'] = bnd_idx
+        outfile = out[i]
+        return_ds = keep_ds[i]
+        kwargs = copy(common_kwargs)
+        kwargs.update(inputs0)
+        ds = gdal_calc.Calc(calc='a', outfile=outfile, **kwargs)
+        input_file = ds if return_ds else outfile
+        inputs.append(input_file)
+        check_file(input_file, checksums[i], i+1)
+
+    inputs1 = dict()
+    inputs1['a'] = inputs[0]
+    inputs1['b'] = inputs[1]
+    inputs1['c'] = inputs[2]
+
+    inputs2 = {'a': inputs}
+
+    write_output = True
+    outfile = [out[i] if write_output else None for i in range(test_count)]
+
+    i = total_bands
+
+    checksum = 13256
+    kwargs = copy(common_kwargs)
+    kwargs.update(inputs1)
+    check_file(gdal_calc.Calc(calc='numpy.max((a,b,c),axis=0)', outfile=outfile[i], **kwargs), checksum, i)
+    i += 1
+    kwargs = copy(common_kwargs)
+    kwargs.update(inputs2)
+    check_file(gdal_calc.Calc(calc='numpy.max(a,axis=0)', outfile=outfile[i], **kwargs), checksum, i)
+    i += 1
+    kwargs = copy(common_kwargs)
+    kwargs.update(inputs2)
+    check_file(gdal_calc.Calc(calc='my_neat_max(a)', outfile=outfile[i], user_namespace={'my_neat_max': my_max}, **kwargs), checksum, i)
+    i += 1
+
+    # for summing 3 bytes we'll use GDT_UInt16
+    gdal_dt = gdal.GDT_UInt16
+    np_dt = None if gdal_dt is None else gdal_calc.gdal_dt_to_np_dt[gdal_dt]
+
+    # sum with overflow
+    checksum = 12261
+    kwargs = copy(common_kwargs)
+    kwargs.update(inputs1)
+    check_file(gdal_calc.Calc(calc='a+b+c', type=gdal_dt, outfile=outfile[i], **kwargs), checksum, i)
+    i += 1
+
+    # sum with numpy function, no overflow
+    checksum = 12789
+    kwargs = copy(common_kwargs)
+    kwargs.update(inputs2)
+    check_file(gdal_calc.Calc(calc='numpy.sum(a,axis=0,dtype=np_dt)', type=gdal_dt, outfile=outfile[i], user_namespace={'np_dt': np_dt}, **kwargs), checksum, i)
+    i += 1
+    # sum with my custom numpy function
+    kwargs = copy(common_kwargs)
+    kwargs.update(inputs2)
+    check_file(gdal_calc.Calc(calc='my_neat_sum(a, out_dt)', type=gdal_dt, outfile=outfile[i], user_namespace={'my_neat_sum': my_sum, 'out_dt': gdal_dt}, **kwargs), checksum, i)
+    i += 1
+
 
 def test_gdal_calc_py_cleanup():
+    """ cleanup all temporary files that were created in this pytest """
+    global temp_counter_dict
+    global opts_counter_counter
+    temp_files = []
+    for test_id, count in temp_counter_dict.items():
+        for i in range(count):
+            name = format_temp_filename(test_id, i+1)
+            temp_files.append(name)
 
-    lst = ['tmp/test_gdal_calc_py.tif',
-           'tmp/test_gdal_calc_py_1_1.tif',
-           'tmp/test_gdal_calc_py_1_2.tif',
-           'tmp/test_gdal_calc_py_1_3.tif',
-           'tmp/test_gdal_calc_py_2_1.tif',
-           'tmp/test_gdal_calc_py_2_2.tif',
-           'tmp/test_gdal_calc_py_2_3.tif',
-           'tmp/test_gdal_calc_py_3.tif',
-           'tmp/test_gdal_calc_py_4_1.tif',
-           'tmp/test_gdal_calc_py_4_2.tif',
-           'tmp/test_gdal_calc_py_4_3.tif',
-           'tmp/test_gdal_calc_py_5_1.tif',
-           'tmp/test_gdal_calc_py_5_2.tif',
-           'tmp/test_gdal_calc_py_5_3.tif',
-           'tmp/test_gdal_calc_py_5_4.tif',
-           'tmp/test_gdal_calc_py_6.tif',
-           'tmp/test_gdal_calc_py_7_1.tif',
-           'tmp/test_gdal_calc_py_7_2.tif',
-           'tmp/test_gdal_calc_py_7_3.tif',
-           'tmp/test_gdal_calc_py_7_4.tif',
-           'tmp/test_gdal_calc_py_8_1.tif',
-           'tmp/opt1',
-           'tmp/opt2',
-           'tmp/opt3',
-          ]
-    for filename in lst:
+    for i in range(opts_counter_counter):
+        name = format_temp_filename(test_id, i+1, True)
+        temp_files.append(name)
+
+    for filename in temp_files:
         try:
             os.remove(filename)
         except OSError:
             pass
-
-
-
 
 

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -23,9 +23,9 @@ Synopsis
 
 Command line raster calculator with numpy syntax. Use any basic
 arithmetic supported by numpy arrays such as ``+``, ``-``, ``*``, and
-``\`` along with logical operators such as ``>``. Note that all files
-must have the same dimensions, but no projection checking is
-performed.
+``\`` along with logical operators such as ``>``.
+Note that all files must have the same dimensions (unless extent option is used),
+but no projection checking is performed (unless projectionCheck option is used).
 
 .. option:: --help
 
@@ -42,7 +42,11 @@ performed.
 
 .. option:: -A <filename>
 
-    Input gdal raster file, you can use any letter (A-Z).
+    Input gdal raster file, you can use any letter (a-z, A-Z).  (lower case supported since GDAL 3.3)
+
+    A letter may be repeated (GDAL >= 3.3). The effect will be to create a 3-dim numpy array.
+    In such a case, the calculation formula must use this input as a 3-dim array and must return a 2D array (see examples below).
+    In case the calculation does not return a 2D array an error would be generated.
 
 .. option:: --A_band=<n>
 
@@ -54,21 +58,50 @@ performed.
 
 .. option:: --NoDataValue=<value>
 
-    Output nodata value (default datatype specific value).
+    Output NoDataValue (default datatype specific value).
+    To indicate not setting a NoDataValue use --NoDataValue=none (GDAL >= 3.3)
+
+    .. note::
+        Using the Python API:
+        ``None`` value will indicate default datatype specific value.
+        ``'none'`` value will indicate not setting a NoDataValue.
+
+.. option:: --hideNoData
+
+    ..versionadded:: 3.3
+
+    Ignores the input bands NoDataValue.
+    By default, the input bands NoDataValue are not participating in the calculation.
+    By setting this setting - no special treatment will be performed on the input NoDataValue. and they will be participating in the calculation as any other value.
+    The output will not have a set NoDataValue, unless you explicitly specified a specific value by setting --NoDataValue=<value>.
 
 .. option:: --type=<datatype>
 
     Output datatype, must be one of [``Int32``, ``Int16``, ``Float64``, ``UInt16``, ``Byte``, ``UInt32``, ``Float32``].
- 
+
     .. note::
-    
+
        Despite the datatype set using ``--type``, when doing intermediate aritmethic operations using operands of the
        same type, the operation result will honor the original datatype. This may lead into unexpected results in the final result.
-    
+
 .. option:: --format=<gdal_format>
 
     GDAL format for output file.
 
+.. option:: --extent=<option>
+
+    ..versionadded:: 3.3
+
+    this option determinants how to handle rasters with different extents.
+    ``ignore`` (default) - only the dimensions of the rasters are compared. if the dimensions do not agree the operation will fail.
+    ``fail`` - the dimensions and the extent (bounds) of the rasters must agree, otherwise the operation will fail.
+
+.. option:: --projectionCheck
+
+    ..versionadded:: 3.3
+
+    By default, no projection checking will be performed.
+    By setting this option, if the projection is not the same for all bands then the operation will fail.
 
 .. _creation-option:
 
@@ -82,9 +115,9 @@ performed.
 
         The same as creation-option_.
 
-.. option:: --allBands=[A-Z]
+.. option:: --allBands=[a-z, A-Z]
 
-    Process all bands of given raster (A-Z). Requires a single calc for all bands.
+    Process all bands of given raster (a-z, A-Z). Requires a single calc for all bands.
 
 .. option:: --overwrite
 
@@ -97,6 +130,27 @@ performed.
 .. option:: --quiet
 
     Suppress progress messages.
+
+
+Python options
+--------------
+
+..versionadded:: 3.3
+
+The following options are available by using function the python interface of gdal_calc.
+they are not available using the command prompt.
+
+.. option:: user_namespace
+
+    A dictionary of custom functions or other names to be available for use in the Calc expression.
+
+.. option:: return_ds
+
+    If enabled, the output dataset would be returned from the function and not closed.
+
+.. option:: color_table
+
+    Allows to specify a ColorTable object (with Palette Index interpretation) to be used for the output raster.
 
 Example
 -------
@@ -111,23 +165,59 @@ Average of two layers:
 
 .. code-block::
 
-    gdal_calc.py -A input.tif -B input2.tif --outfile=result.tif --calc="(A+B)/2"
-    
+    gdal_calc.py -A input1.tif -B input2.tif --outfile=result.tif --calc="(A+B)/2"
+
 .. note::
 
    In the previous example, beware that if A and B inputs are of the same datatype, for example integers, you
    may need to force the conversion of one of the operands before the division operation.
-   
+
    .. code-block::
 
       gdal_calc.py -A input.tif -B input2.tif --outfile=result.tif --calc="(A.astype(numpy.float64) + B) / 2"
+
+Add three files together (two options with the same result):
+
+.. code-block::
+
+    gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="A+B+C"
+
+..versionadded:: 3.3
+
+.. code-block::
+
+    gdal_calc.py -A input1.tif -A input2.tif -A input3.tif --outfile=result.tif --calc="numpy.sum(A,axis=0)".
+
+Average of three layers (two options with the same result):
+
+.. code-block::
+
+    gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="(A+B+C)/3"
+
+..versionadded:: 3.3
+
+.. code-block::
+
+    gdal_calc.py -A input1.tif -A input2.tif -A input3.tif --outfile=result.tif --calc="numpy.average(a,axis=0)".
+
+Maximum of three layers  (two options with the same result):
+
+.. code-block::
+
+    gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="numpy.max((A,B,C),axis=0)"
+
+..versionadded:: 3.3
+
+.. code-block::
+
+    gdal_calc.py -A input1.tif -A input2.tif -A input3.tif --outfile=result.tif --calc="numpy.max(A,axis=0)"
 
 Set values of zero and below to null:
 
 .. code-block::
 
     gdal_calc.py -A input.tif --outfile=result.tif --calc="A*(A>0)" --NoDataValue=0
-    
+
 Using logical operator to keep a range of values from input:
 
 .. code-block::

--- a/gdal/swig/python/osgeo/utils/gdal_calc.py
+++ b/gdal/swig/python/osgeo/utils/gdal_calc.py
@@ -10,6 +10,7 @@
 #  Copyright (c) 2010, Chris Yesson <chris.yesson@ioz.ac.uk>
 #  Copyright (c) 2010-2011, Even Rouault <even dot rouault at spatialys.com>
 #  Copyright (c) 2016, Piers Titus van der Torren <pierstitus@gmail.com>
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -54,19 +55,61 @@ import os
 import os.path
 import sys
 import shlex
+import string
+import numbers
+from collections import defaultdict
 
 import numpy
 
 from osgeo import gdal
 from osgeo import gdalnumeric
 
-
-# create alphabetic list for storing input layers
-AlphaList =  ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
-              "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+# create alphabetic list (lowercase + uppercase) for storing input layers
+AlphaList = list(string.ascii_letters)
 
 # set up some default nodatavalues for each datatype
-DefaultNDVLookup = {'Byte': 255, 'UInt16': 65535, 'Int16': -32767, 'UInt32': 4294967293, 'Int32': -2147483647, 'Float32': 3.402823466E+38, 'Float64': 1.7976931348623158E+308}
+DefaultNDVLookup = {gdal.GDT_Byte: 255, gdal.GDT_UInt16: 65535, gdal.GDT_Int16: -32768,
+                    gdal.GDT_UInt32: 4294967293, gdal.GDT_Int32: -2147483647,
+                    gdal.GDT_Float32: 3.402823466E+38, gdal.GDT_Float64: 1.7976931348623158E+308}
+
+# tuple of available output datatypes names
+GDALDataTypeNames = tuple(gdal.GetDataTypeName(dt) for dt in DefaultNDVLookup.keys())
+
+gdal_dt_to_np_dt = {gdal.GDT_Byte: numpy.uint8,
+                    gdal.GDT_UInt16: numpy.uint16,
+                    gdal.GDT_Int16: numpy.int16,
+                    gdal.GDT_UInt32: numpy.uint32,
+                    gdal.GDT_Int32: numpy.int32,
+                    gdal.GDT_Float32: numpy.float32,
+                    gdal.GDT_Float64: numpy.float64}
+
+EXTENT = int
+EXTENT_IGNORE = 0
+EXTENT_FAIL = 1
+EXTENT_UNION = 2
+EXTENT_INTERSECT = 3
+
+
+def parse_extent(extent):
+    if isinstance(extent, str):
+        extent = extent.lower()
+        if extent == 'ignore':
+            return EXTENT_IGNORE
+        elif extent == 'fail':
+            return EXTENT_FAIL
+        elif extent == 'union':
+            return EXTENT_UNION
+        elif extent == 'intersect':
+            return EXTENT_INTERSECT
+    elif isinstance(extent, EXTENT):
+        return extent
+    raise Exception('Error: Unknown extent %s' % extent)
+
+
+def is_path_like(s):
+    # when GDAL drops Python2 support we can support from pathlib import Path, for now it's just str.
+    # return isinstance(s, (str, Path))
+    return isinstance(s, str)
 
 
 def DoesDriverHandleExtension(drv, ext):
@@ -106,6 +149,8 @@ def GetOutputDriversFor(filename):
 
 
 def GetOutputDriverFor(filename):
+    if not filename:
+        return 'MEM'
     drv_list = GetOutputDriversFor(filename)
     ext = GetExtension(filename)
     if not drv_list:
@@ -117,7 +162,32 @@ def GetOutputDriverFor(filename):
         print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
     return drv_list[0]
 
-################################################################
+
+GT_SAME = -1
+GT_ALMOST_SAME = -2
+GT_COMPATIBLE_DIFF = -3
+GT_INCOMPATIBLE_OFFSET = 0
+GT_INCOMPATIBLE_PIXEL_SIZE = 1
+GT_INCOMPATIBLE_ROTATION = 2
+GT_NON_ZERO_ROTATION = 3
+
+
+def gt_diff(gt0, gt1, diff_support, eps=0.0):
+    if gt0 == gt1:
+        return GT_SAME
+    if isinstance(eps, numbers.Number):
+        eps = {GT_INCOMPATIBLE_OFFSET: eps, GT_INCOMPATIBLE_PIXEL_SIZE: eps, GT_INCOMPATIBLE_ROTATION: eps}
+    same = {
+        GT_INCOMPATIBLE_OFFSET:     eps[GT_INCOMPATIBLE_OFFSET]     >= (abs(gt0[0] - gt1[0]) + abs(gt0[3] - gt1[3])),
+        GT_INCOMPATIBLE_PIXEL_SIZE: eps[GT_INCOMPATIBLE_PIXEL_SIZE] >= (abs(gt0[1] - gt1[1]) + abs(gt0[5] - gt1[5])),
+        GT_INCOMPATIBLE_ROTATION:   eps[GT_INCOMPATIBLE_ROTATION]   >= (abs(gt0[2] - gt1[2]) + abs(gt0[4] - gt1[4])),
+        GT_NON_ZERO_ROTATION:       gt0[2] == gt0[4] == gt1[2] == gt1[4] == 0}
+    if same[GT_INCOMPATIBLE_OFFSET] and same[GT_INCOMPATIBLE_PIXEL_SIZE] and same[GT_INCOMPATIBLE_ROTATION]:
+        return GT_ALMOST_SAME
+    for reason in same.keys():
+        if not same[reason] or diff_support[reason]:
+            return reason  # incompatible gt, returns the reason
+    return GT_COMPATIBLE_DIFF
 
 
 def doit(opts, args):
@@ -129,57 +199,141 @@ def doit(opts, args):
     # set up global namespace for eval with all functions of gdalnumeric
     global_namespace = dict([(key, getattr(gdalnumeric, key))
                              for key in dir(gdalnumeric) if not key.startswith('__')])
+    if opts.user_namespace:
+        global_namespace.update(opts.user_namespace)
 
     if not opts.calc:
         raise Exception("No calculation provided.")
-    elif not opts.outF:
+    elif not opts.outF and opts.format.upper() != 'MEM':
         raise Exception("No output file provided.")
 
     if opts.format is None:
         opts.format = GetOutputDriverFor(opts.outF)
+
+    if not hasattr(opts, "color_table"):
+        opts.color_table = None
+    if not opts.extent:
+        opts.extent = EXTENT_IGNORE
+    else:
+        opts.extent = parse_extent(opts.extent)
+
+    compatible_gt_eps = 0.000001
+    gt_diff_support = {
+        GT_INCOMPATIBLE_OFFSET: opts.extent != EXTENT_FAIL,
+        GT_INCOMPATIBLE_PIXEL_SIZE: False,
+        GT_INCOMPATIBLE_ROTATION: False,
+        GT_NON_ZERO_ROTATION: False,
+    }
+    gt_diff_error = {
+        GT_INCOMPATIBLE_OFFSET: 'different offset',
+        GT_INCOMPATIBLE_PIXEL_SIZE: 'different pixel size',
+        GT_INCOMPATIBLE_ROTATION: 'different rotation',
+        GT_NON_ZERO_ROTATION: 'non zero rotation',
+    }
 
     ################################################################
     # fetch details of input layers
     ################################################################
 
     # set up some lists to store data for each band
-    myFiles = []
-    myBands = []
-    myAlphaList = []
-    myDataType = []
-    myDataTypeNum = []
-    myNDV = []
-    DimensionsCheck = None
+    myFileNames = []  # input filenames
+    myFiles = []  # input DataSets
+    myBands = []  # input bands
+    myAlphaList = []  # input alpha letter that represents each input file
+    myDataType = []  # string representation of the datatype of each input file
+    myDataTypeNum = []  # datatype of each input file
+    myNDV = []  # nodatavalue for each input file
+    DimensionsCheck = None  # dimensions of the output
+    Dimensions = []  # Dimensions of input files
+    ProjectionCheck = None  # projection of the output
+    GeoTransformCheck = None  # GeoTransform of the output
+    GeoTransforms = []  # GeoTransform of each input file
+    GeoTransformDiffer = False  # True if we have inputs with different GeoTransforms
+    myTempFileNames = []  # vrt filename from each input file
+    myAlphaFileLists = []  # list of the Alphas which holds a list of inputs
 
     # loop through input files - checking dimensions
-    for myI, myF in opts.input_files.items():
-        if not myI.endswith("_band"):
-            # check if we have asked for a specific band...
-            if "%s_band" % myI in opts.input_files:
-                myBand = opts.input_files["%s_band" % myI]
-            else:
-                myBand = 1
+    for alphas, filenames in opts.input_files.items():
+        if isinstance(filenames, (list, tuple)):
+            # alpha is a list of files
+            myAlphaFileLists.append(alphas)
+        elif is_path_like(filenames) or isinstance(filenames, gdal.Dataset):
+            # alpha is a single filename or a Dataset
+            filenames = [filenames]
+            alphas = [alphas]
+        else:
+            # I guess this alphas should be in the global_namespace,
+            # It would have been better to pass it as user_namepsace, but I'll accept it anyway
+            global_namespace[alphas] = filenames
+            continue
+        for alpha, filename in zip(alphas*len(filenames), filenames):
+            if not alpha.endswith("_band"):
+                # check if we have asked for a specific band...
+                if "%s_band" % alpha in opts.input_files:
+                    myBand = opts.input_files["%s_band" % alpha]
+                else:
+                    myBand = 1
 
-            myFile = gdal.Open(myF, gdal.GA_ReadOnly)
-            if not myFile:
-                raise IOError("No such file or directory: '%s'" % myF)
+                myF_is_ds = not is_path_like(filename)
+                if myF_is_ds:
+                    myFile = filename
+                    filename = None
+                else:
+                    filename = str(filename)
+                    myFile = gdal.Open(filename, gdal.GA_ReadOnly)
+                if not myFile:
+                    raise IOError("No such file or directory: '%s'" % filename)
 
-            myFiles.append(myFile)
-            myBands.append(myBand)
-            myAlphaList.append(myI)
-            myDataType.append(gdal.GetDataTypeName(myFile.GetRasterBand(myBand).DataType))
-            myDataTypeNum.append(myFile.GetRasterBand(myBand).DataType)
-            myNDV.append(myFile.GetRasterBand(myBand).GetNoDataValue())
-            # check that the dimensions of each layer are the same
-            if DimensionsCheck:
-                if DimensionsCheck != [myFile.RasterXSize, myFile.RasterYSize]:
-                    raise Exception("Error! Dimensions of file %s (%i, %i) are different from other files (%i, %i).  Cannot proceed" %
-                                    (myF, myFile.RasterXSize, myFile.RasterYSize, DimensionsCheck[0], DimensionsCheck[1]))
-            else:
-                DimensionsCheck = [myFile.RasterXSize, myFile.RasterYSize]
+                myFileNames.append(filename)
+                myFiles.append(myFile)
+                myBands.append(myBand)
+                myAlphaList.append(alpha)
+                dt = myFile.GetRasterBand(myBand).DataType
+                myDataType.append(gdal.GetDataTypeName(dt))
+                myDataTypeNum.append(dt)
+                myNDV.append(None if opts.hideNoData else myFile.GetRasterBand(myBand).GetNoDataValue())
 
-            if opts.debug:
-                print("file %s: %s, dimensions: %s, %s, type: %s" % (myI, myF, DimensionsCheck[0], DimensionsCheck[1], myDataType[-1]))
+                # check that the dimensions of each layer are the same
+                myFileDimensions = [myFile.RasterXSize, myFile.RasterYSize]
+                if DimensionsCheck:
+                    if DimensionsCheck != myFileDimensions:
+                        GeoTransformDiffer = True
+                        if opts.extent in [EXTENT_IGNORE, EXTENT_FAIL]:
+                            raise Exception("Error! Dimensions of file %s (%i, %i) are different from other files (%i, %i).  Cannot proceed" %
+                                            (filename, myFileDimensions[0], myFileDimensions[1], DimensionsCheck[0], DimensionsCheck[1]))
+                else:
+                    DimensionsCheck = myFileDimensions
+
+                # check that the Projection of each layer are the same
+                myProjection = myFile.GetProjection()
+                if ProjectionCheck:
+                    if opts.projectionCheck and ProjectionCheck != myProjection:
+                        raise Exception(
+                            "Error! Projection of file %s %s are different from other files %s.  Cannot proceed" %
+                            (filename, myProjection, ProjectionCheck))
+                else:
+                    ProjectionCheck = myProjection
+
+                # check that the GeoTransforms of each layer are the same
+                myFileGeoTransform = myFile.GetGeoTransform(can_return_null=True)
+                if opts.extent == EXTENT_IGNORE:
+                    GeoTransformCheck = myFileGeoTransform
+                else:
+                    Dimensions.append(myFileDimensions)
+                    GeoTransforms.append(myFileGeoTransform)
+                    if not GeoTransformCheck:
+                        GeoTransformCheck = myFileGeoTransform
+                    else:
+                        my_gt_diff = gt_diff(GeoTransformCheck, myFileGeoTransform, eps=compatible_gt_eps, diff_support=gt_diff_support)
+                        if my_gt_diff not in [GT_SAME, GT_ALMOST_SAME]:
+                            GeoTransformDiffer = True
+                            if my_gt_diff not in [GT_COMPATIBLE_DIFF]:
+                                raise Exception(
+                                    "Error! GeoTransform of file {} {} is incompatible ({}), first file GeoTransform is {}. Cannot proceed".
+                                        format(filename, myFileGeoTransform, gt_diff_error[my_gt_diff], GeoTransformCheck))
+                if opts.debug:
+                    print("file %s: %s, dimensions: %s, %s, type: %s" % (
+                        alpha, filename, DimensionsCheck[0], DimensionsCheck[1], myDataType[-1]))
 
     # process allBands option
     allBandsIndex = None
@@ -197,63 +351,100 @@ def doit(opts, args):
     else:
         allBandsCount = len(opts.calc)
 
+    if opts.extent not in [EXTENT_IGNORE, EXTENT_FAIL] and (GeoTransformDiffer or not isinstance(opts.extent, EXTENT)):
+        raise Exception('Error! mixing different GeoTransforms/Extents is not supported yet.')
+
     ################################################################
     # set up output file
     ################################################################
 
     # open output file exists
-    if os.path.isfile(opts.outF) and not opts.overwrite:
+    if opts.outF and os.path.isfile(opts.outF) and not opts.overwrite:
         if allBandsIndex is not None:
             raise Exception("Error! allBands option was given but Output file exists, must use --overwrite option!")
         if len(opts.calc) > 1:
             raise Exception("Error! multiple calc options were given but Output file exists, must use --overwrite option!")
         if opts.debug:
             print("Output file %s exists - filling in results into file" % (opts.outF))
+
         myOut = gdal.Open(opts.outF, gdal.GA_Update)
-        if [myOut.RasterXSize, myOut.RasterYSize] != DimensionsCheck:
-            raise Exception("Error! Output exists, but is the wrong size.  Use the --overwrite option to automatically overwrite the existing file")
+        if myOut is None:
+            error = 'but cannot be opened for update'
+        elif [myOut.RasterXSize, myOut.RasterYSize] != DimensionsCheck:
+            error = 'but is the wrong size'
+        elif ProjectionCheck and ProjectionCheck != myOut.GetProjection():
+            error = 'but is the wrong projection'
+        elif GeoTransformCheck and GeoTransformCheck != myOut.GetGeoTransform(can_return_null=True):
+            error = 'but is the wrong geotransform'
+        else:
+            error = None
+        if error:
+            raise Exception("Error! Output exists, %s.  Use the --overwrite option to automatically overwrite the existing file" % error)
+
         myOutB = myOut.GetRasterBand(1)
         myOutNDV = myOutB.GetNoDataValue()
-        myOutType = gdal.GetDataTypeName(myOutB.DataType)
+        myOutType = myOutB.DataType
 
     else:
-        # remove existing file and regenerate
-        if os.path.isfile(opts.outF):
-            os.remove(opts.outF)
-        # create a new file
-        if opts.debug:
-            print("Generating output file %s" % (opts.outF))
+        if opts.outF:
+            # remove existing file and regenerate
+            if os.path.isfile(opts.outF):
+                os.remove(opts.outF)
+            # create a new file
+            if opts.debug:
+                print("Generating output file %s" % (opts.outF))
+        else:
+            opts.outF = ''
 
         # find data type to use
         if not opts.type:
             # use the largest type of the input files
-            myOutType = gdal.GetDataTypeName(max(myDataTypeNum))
+            myOutType = max(myDataTypeNum)
         else:
             myOutType = opts.type
+            if isinstance(myOutType, str):
+                myOutType = gdal.GetDataTypeByName(myOutType)
 
         # create file
         myOutDrv = gdal.GetDriverByName(opts.format)
         myOut = myOutDrv.Create(
             opts.outF, DimensionsCheck[0], DimensionsCheck[1], allBandsCount,
-            gdal.GetDataTypeByName(myOutType), opts.creation_options)
+            myOutType, opts.creation_options)
 
         # set output geo info based on first input layer
-        myOut.SetGeoTransform(myFiles[0].GetGeoTransform())
-        myOut.SetProjection(myFiles[0].GetProjection())
+        if not GeoTransformCheck:
+            GeoTransformCheck = myFiles[0].GetGeoTransform(can_return_null=True)
+        if GeoTransformCheck:
+            myOut.SetGeoTransform(GeoTransformCheck)
 
-        if opts.NoDataValue is not None:
-            myOutNDV = opts.NoDataValue
+        if not ProjectionCheck:
+            ProjectionCheck = myFiles[0].GetProjection()
+        if ProjectionCheck:
+            myOut.SetProjection(ProjectionCheck)
+
+        if opts.NoDataValue is None:
+            myOutNDV = None if opts.hideNoData else DefaultNDVLookup[myOutType]  # use the default noDataValue for this datatype
+        elif isinstance(opts.NoDataValue, str) and opts.NoDataValue.lower() == 'none':
+            myOutNDV = None  # not to set any noDataValue
         else:
-            myOutNDV = DefaultNDVLookup[myOutType]
+            myOutNDV = opts.NoDataValue  # use the given noDataValue
 
         for i in range(1, allBandsCount + 1):
             myOutB = myOut.GetRasterBand(i)
-            myOutB.SetNoDataValue(myOutNDV)
-            # write to band
-            myOutB = None
+            if myOutNDV is not None:
+                myOutB.SetNoDataValue(myOutNDV)
+            if opts.color_table:
+                # set color table and color interpretation
+                if is_path_like(opts.color_table):
+                    raise Exception('Error! reading a color table from a file is not supported yet')
+                myOutB.SetRasterColorTable(opts.color_table)
+                myOutB.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
 
+            myOutB = None  # write to band
+
+    myOutTypeName = gdal.GetDataTypeName(myOutType)
     if opts.debug:
-        print("output file: %s, dimensions: %s, %s, type: %s" % (opts.outF, myOut.RasterXSize, myOut.RasterYSize, myOutType))
+        print("output file: %s, dimensions: %s, %s, type: %s" % (opts.outF, myOut.RasterXSize, myOut.RasterYSize, myOutTypeName))
 
     ################################################################
     # find block size to chop grids into bite-sized chunks
@@ -328,6 +519,8 @@ def doit(opts, args):
                 # make local namespace for calculation
                 local_namespace = {}
 
+                val_lists = defaultdict(list)
+
                 # fetch data for each input layer
                 for i, Alpha in enumerate(myAlphaList):
 
@@ -340,18 +533,28 @@ def doit(opts, args):
                                                         xoff=myX, yoff=myY,
                                                         win_xsize=nXValid, win_ysize=nYValid)
                     if myval is None:
-                        raise Exception('Input block reading failed')
+                        raise Exception('Input block reading failed from filename %s' % filename[i])
 
                     # fill in nodata values
                     if myNDV[i] is not None:
+                        # myNDVs is a boolean buffer.
+                        # a cell equals to 1 if there is NDV in any of the corresponsing cells in input raster bands.
                         if myNDVs is None:
+                            # this is the first band that has NDV set. we initializes myNDVs to a zero buffer
+                            # as we didn't see any NDV value yet.
                             myNDVs = numpy.zeros(myBufSize)
                             myNDVs.shape = (nYValid, nXValid)
                         myNDVs = 1 * numpy.logical_or(myNDVs == 1, myval == myNDV[i])
 
                     # add an array of values for this block to the eval namespace
-                    local_namespace[Alpha] = myval
+                    if Alpha in myAlphaFileLists:
+                        val_lists[Alpha].append(myval)
+                    else:
+                        local_namespace[Alpha] = myval
                     myval = None
+
+                for lst in myAlphaFileLists:
+                    local_namespace[lst] = val_lists[lst]
 
                 # try the calculation on the array blocks
                 calc = opts.calc[bandNo-1 if len(opts.calc) > 1 else 0]
@@ -363,7 +566,7 @@ def doit(opts, args):
 
                 # Propagate nodata values (set nodata cells to zero
                 # then add nodata value to these cells).
-                if myNDVs is not None:
+                if myNDVs is not None and myOutNDV is not None:
                     myResult = ((1 * (myNDVs == 0)) * myResult) + (myOutNDV * myNDVs)
                 elif not isinstance(myResult, numpy.ndarray):
                     myResult = numpy.ones((nYValid, nXValid)) * myResult
@@ -372,20 +575,30 @@ def doit(opts, args):
                 myOutB = myOut.GetRasterBand(bandNo)
                 if gdalnumeric.BandWriteArray(myOutB, myResult, xoff=myX, yoff=myY) != 0:
                     raise Exception('Block writing failed')
+                myOutB = None  # write to band
+
+    # remove temp files
+    for idx, tempFile in enumerate(myTempFileNames):
+        myFiles[idx] = None
+        os.remove(tempFile)
 
     gdal.ErrorReset()
     myOut.FlushCache()
-    myOut = None
     if gdal.GetLastErrorMsg() != '':
         raise Exception('Dataset writing failed')
 
     if not opts.quiet:
         print("100 - Done")
 
+    return myOut
+
 ################################################################
 
 
-def Calc(calc, outfile, NoDataValue=None, type=None, format=None, creation_options=None, allBands='', overwrite=False, debug=False, quiet=False, **input_files):
+def Calc(calc, outfile=None, NoDataValue=None, type=None, format=None, creation_options=None, allBands='', overwrite=False,
+         hideNoData=False, projectionCheck=False, color_table=None, extent=None, user_namespace=None,
+         debug=False, quiet=False, **input_files):
+
     """ Perform raster calculations with numpy syntax.
     Use any basic arithmetic supported by numpy arrays such as +-* along with logical
     operators such as >. Note that all files must have the same dimensions, but no projection checking is performed.
@@ -406,6 +619,9 @@ def Calc(calc, outfile, NoDataValue=None, type=None, format=None, creation_optio
 
     work with two bands:
         Calc(["(A+B)/2", "A*(A>0)"], A="input.tif", A_band=1, B="input.tif", B_band=2, outfile="result.tif", NoDataValue=0)
+
+    sum all files with hidden noDataValue
+        Calc(calc="sum(a,axis=0)", a=['0.tif','1.tif','2.tif'], outfile="sum.tif", hideNoData=True)
     """
     opts = Values()
     opts.input_files = input_files
@@ -422,17 +638,29 @@ def Calc(calc, outfile, NoDataValue=None, type=None, format=None, creation_optio
     opts.creation_options = [] if creation_options is None else creation_options
     opts.allBands = allBands
     opts.overwrite = overwrite
+    opts.hideNoData = hideNoData
+    opts.projectionCheck = projectionCheck
+    opts.color_table = color_table
+    opts.extent = extent
+    opts.user_namespace = user_namespace
     opts.debug = debug
     opts.quiet = quiet
 
-    doit(opts, None)
+    return doit(opts, None)
 
 
 def store_input_file(option, opt_str, value, parser):
     # pylint: disable=unused-argument
     if not hasattr(parser.values, 'input_files'):
         parser.values.input_files = {}
-    parser.values.input_files[opt_str.lstrip('-')] = value
+    key = opt_str.lstrip('-')
+    if key in parser.values.input_files:
+        value_list = parser.values.input_files[key]
+        if not isinstance(value_list, list):
+            value_list = [value_list]
+        value_list.append(value)
+        value = value_list
+    parser.values.input_files[key] = value
 
 
 def add_alpha_args(parser, argv):
@@ -457,23 +685,33 @@ def main(argv):
 
     parser.add_option("--outfile", dest="outF", help="output file to generate or fill", metavar="filename")
     parser.add_option("--NoDataValue", dest="NoDataValue", type=float, help="output nodata value (default datatype specific value)", metavar="value")
-    parser.add_option("--type", dest="type", help="output datatype, must be one of %s" % list(DefaultNDVLookup.keys()), metavar="datatype")
+    parser.add_option("--hideNoData", dest="hideNoData", action="store_true", help="ignores the NoDataValues of the input rasters")
+    parser.add_option("--type", dest="type", help="output datatype", choices=GDALDataTypeNames, metavar="datatype")
     parser.add_option("--format", dest="format", help="GDAL format for output file", metavar="gdal_format")
     parser.add_option(
         "--creation-option", "--co", dest="creation_options", default=[], action="append",
         help="Passes a creation option to the output format driver. Multiple "
         "options may be listed. See format specific documentation for legal "
         "creation options for each format.", metavar="option")
-    parser.add_option("--allBands", dest="allBands", default="", help="process all bands of given raster (A-Z)", metavar="[A-Z]")
+    parser.add_option("--allBands", dest="allBands", default="", help="process all bands of given raster (a-z, A-Z)", metavar="[a-z, A-Z]")
     parser.add_option("--overwrite", dest="overwrite", action="store_true", help="overwrite output file if it already exists")
     parser.add_option("--debug", dest="debug", action="store_true", help="print debugging information")
     parser.add_option("--quiet", dest="quiet", action="store_true", help="suppress progress messages")
     parser.add_option("--optfile", dest="optfile", metavar="optfile", help="Read the named file and substitute the contents into the command line options list.")
 
+    # parser.add_option("--color_table", dest="color_table", help="color table file name")
+    parser.add_option("--extent", dest="extent",
+                      choices=['ignore', 'fail'],
+                      help="how to treat mixed geotrasnforms")
+    parser.add_option("--projectionCheck", dest="projectionCheck", action="store_true",
+                      help="check that all rasters share the same projection")
+
     (opts, args) = parser.parse_args(argv[1:])
 
     if not hasattr(opts, "input_files"):
         opts.input_files = {}
+    if not hasattr(opts, "user_namespace"):
+        opts.user_namespace = {}
 
     if opts.optfile:
         with open(opts.optfile, 'r') as f:
@@ -482,12 +720,16 @@ def main(argv):
         parser.remove_option('--optfile')
         add_alpha_args(parser, ofargv)
         ofopts, ofargs = parser.parse_args(ofargv)
+
         # Let options given directly override the optfile.
         input_files = getattr(ofopts, 'input_files', {})
         input_files.update(opts.input_files)
+        user_namespace = getattr(ofopts, 'user_namespace', {})
+        user_namespace.update(opts.user_namespace)
         ofopts.__dict__.update({k: v for k, v in vars(opts).items() if v})
         opts = ofopts
         opts.input_files = input_files
+        opts.user_namespace = user_namespace
         args = args + ofargs
 
     if len(argv) == 1:


### PR DESCRIPTION
## What does this PR do?

Multiple improvements for gdal_calc.py

general additions:
* AlphaList - now includes lowercase + uppercase alphabet
* GDALDataTypeNames - tuple of available output datatypes names
* DefaultNDVLookup - dictionary.keys() changed from string to GDALDataType; DefaultNDVLookup[GDT_Int16] = -32768 (changed to min int16, was -32767)
* Support Alpha inputs as a Sequence of inputs
* store_input_file - extended to support multiple inputs with the same alpha (which will make a list)
* accept dataset inputs in additions of filename inputs

* Support input files with different GeoTransforms and Dimensions - Implementation of this feature will be in another PR

new options:
* opts.NoDataValue=... - use opts.NoDataValue to indicate None datatype (opts.NoDataValue=None already indicates default value)
* opts.color_table - allow use input color_table
* opts.hideNodata - allows hiding nodatavalue
* opts.projectionCheck - should we check that all inputs have the same projection
* opts.extent - set custom output extent
* opts.user_namespace - add option for user_namespace, which can hold custom functions (default=None)
* opts.return_ds - option to keep the dataset open and return it (default=False)

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

