### PR TITLE
NITF: Add support for SNIP TREs, PIXQLA and PIXMTA

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2699,7 +2699,7 @@ def test_nitf_78():
     float_data = r"\0\0\0\0"
     bit_mask = r"\0\0\0\0"
 
-    tre_data = "FILE_TRE=BANDSB=00001RADIANCE                S" + float_data*2 + \
+    tre_data = "TRE=BANDSB=00001RADIANCE                S" + float_data*2 + \
                 "0030.00M0030.00M-------M-------M                                                " + \
                 bit_mask + "DETECTOR                " + float_data
 
@@ -2713,7 +2713,7 @@ def test_nitf_78():
     gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_78.ntf')
 
     expected_data = """<tres>
-  <tre name="BANDSB" location="file">
+  <tre name="BANDSB" location="image">
     <field name="COUNT" value="00001" />
     <field name="RADIOMETRIC_QUANTITY" value="RADIANCE" />
     <field name="RADIOMETRIC_QUANTITY_UNIT" value="S" />
@@ -2741,7 +2741,7 @@ def test_nitf_78():
 # Test parsing ACCHZB TRE (STDI-0002-1-v5.0 Appendix P)
 
 def test_nitf_79():
-    tre_data = "FILE_TRE=ACCHZB=01M  00129M  00129004+044.4130499724+33.69234401034+044.4945572008" \
+    tre_data = "TRE=ACCHZB=01M  00129M  00129004+044.4130499724+33.69234401034+044.4945572008" \
                "+33.67855217830+044.1731373448+32.79106350687+044.2538103407+32.77733592314"
 
     ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_79.ntf', 1, 1, options=[tre_data])
@@ -2754,7 +2754,7 @@ def test_nitf_79():
     gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_79.ntf')
 
     expected_data = """<tres>
-  <tre name="ACCHZB" location="file">
+  <tre name="ACCHZB" location="image">
     <field name="NUM_ACHZ" value="01" />
     <repeated number="1">
       <group index="0">
@@ -2843,7 +2843,7 @@ def test_nitf_80():
 # Test parsing MSTGTA TRE (STDI-0002-1-v5.0 App E)
 
 def test_nitf_81():
-    tre_data = "FILE_TRE=MSTGTA=012340123456789AB0123456789ABCDE0120123456789AB0123456789AB000123401234560123450TGT_LOC=             "
+    tre_data = "TRE=MSTGTA=012340123456789AB0123456789ABCDE0120123456789AB0123456789AB000123401234560123450TGT_LOC=             "
     ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_81.ntf', 1, 1, options=[tre_data])
     ds = None
 
@@ -2854,7 +2854,7 @@ def test_nitf_81():
     gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_81.ntf')
 
     expected_data = """<tres>
-  <tre name="MSTGTA" location="file">
+  <tre name="MSTGTA" location="image">
     <field name="TGT_NUM" value="01234" />
     <field name="TGT_ID" value="0123456789AB" />
     <field name="TGT_BE" value="0123456789ABCDE" />
@@ -2877,7 +2877,7 @@ def test_nitf_81():
 # Test parsing PIATGB TRE (STDI-0002-1-v5.0 App C)
 
 def test_nitf_82():
-    tre_data = "FILE_TRE=PIATGB=0123456789ABCDE0123456789ABCDE01012340123456789ABCDE012" \
+    tre_data = "TRE=PIATGB=0123456789ABCDE0123456789ABCDE01012340123456789ABCDE012" \
                "TGTNAME=                              012+01.234567-012.345678"
     ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_82.ntf', 1, 1, options=[tre_data])
     ds = None
@@ -2889,7 +2889,7 @@ def test_nitf_82():
     gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_82.ntf')
 
     expected_data = """<tres>
-  <tre name="PIATGB" location="file">
+  <tre name="PIATGB" location="image">
     <field name="TGTUTM" value="0123456789ABCDE" />
     <field name="PIATGAID" value="0123456789ABCDE" />
     <field name="PIACTRY" value="01" />
@@ -2900,6 +2900,92 @@ def test_nitf_82():
     <field name="PERCOVER" value="012" />
     <field name="TGTLAT" value="+01.234567" />
     <field name="TGTLON" value="-012.345678" />
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
+# Test parsing PIXQLA TRE (STDI-0002-1-v5.0 App AA)
+
+def test_nitf_83():
+    tre_data = "TRE=PIXQLA=00100200031Dead                                    " \
+               "Saturated                               Bad                                     "
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_83.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_83.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_83.ntf')
+
+    expected_data = """<tres>
+  <tre name="PIXQLA" location="image">
+    <field name="NUMAIS" value="001" />
+    <repeated number="1">
+      <group index="0">
+        <field name="AISDLVL" value="002" />
+      </group>
+    </repeated>
+    <field name="NPIXQUAL" value="0003" />
+    <field name="PQ_BIT_VALUE" value="1" />
+    <repeated number="3">
+      <group index="0">
+        <field name="PQ_CONDITION" value="Dead" />
+      </group>
+      <group index="1">
+        <field name="PQ_CONDITION" value="Saturated" />
+      </group>
+      <group index="2">
+        <field name="PQ_CONDITION" value="Bad" />
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
+# Test parsing PIXMTA TRE (STDI-0002-1-v5.0 App AJ)
+
+def test_nitf_84():
+    tre_data = "TRE=PIXMTA=0010020.00000000E+000.00000000E+001.00000000E+003.35200000E+03F00001P" \
+               "BAND_WAVELENGTH                         micron                                  D00000"
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_84.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_84.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_84.ntf')
+
+    expected_data = """<tres>
+  <tre name="PIXMTA" location="image">
+    <field name="NUMAIS" value="001" />
+    <repeated number="1">
+      <group index="0">
+        <field name="AISDLVL" value="002" />
+      </group>
+    </repeated>
+    <field name="ORIGIN_X" value="0.00000000E+00" />
+    <field name="ORIGIN_Y" value="0.00000000E+00" />
+    <field name="SCALE_X" value="1.00000000E+00" />
+    <field name="SCALE_Y" value="3.35200000E+03" />
+    <field name="SAMPLE_MODE" value="F" />
+    <field name="NUMMETRICS" value="00001" />
+    <field name="PERBAND" value="P" />
+    <repeated number="1">
+      <group index="0">
+        <field name="DESCRIPTION" value="BAND_WAVELENGTH" />
+        <field name="UNIT" value="micron" />
+        <field name="FITTYPE" value="D" />
+      </group>
+    </repeated>
+    <field name="RESERVED_LEN" value="00000" />
   </tre>
 </tres>
 """

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -34,7 +34,7 @@
 
 <tres>
     <!-- STDI-0002-1-v5.0 Appendix P, Section P.3.2.6.2, Table P-11 -->
-    <tre name="ACCHZB" md_prefix="NITF_ACCHZB_" minlength="11" maxlength="99985">
+    <tre name="ACCHZB" md_prefix="NITF_ACCHZB_" minlength="11" maxlength="99985" location="image">
         <field name="NUM_ACHZ" length="2" type="integer" minval="1" maxval="99"/>
         <loop counter="NUM_ACHZ" md_prefix="ACHZ_%02d_">
             <field name="UNIAAH" length="3" type="string"/>
@@ -81,7 +81,7 @@
     </tre>
 
     <!-- STDI-0002-1-v5.0 Appendix P, Section P.3.2.6.3, Table P-12 -->
-    <tre name="ACCVTB" md_prefix="NITF_ACCVTB_" minlength="11" maxlength="99985">
+    <tre name="ACCVTB" md_prefix="NITF_ACCVTB_" minlength="11" maxlength="99985" location="image">
         <field name="NUM_ACVT" length="2" type="integer" minval="1" maxval="99"/>
         <loop counter="NUM_ACVT" md_prefix="ACVT_%02d_">
             <field name="UNIAAV" length="3" type="string"/>
@@ -697,7 +697,7 @@
     </tre>
 
     <!-- STDI-0002-1-v5.0 Appendix E, Section E.3.9, Table E-16-->
-    <tre name="MSTGTA" md_prefix="NITF_MSTGTA_" length="101">
+    <tre name="MSTGTA" md_prefix="NITF_MSTGTA_" length="101" location="image">
         <field name="TGT_NUM" length="5" type="integer" minval="0" maxval="99999"/>
         <field name="TGT_ID" length="12" type="string"/>
         <field name="TGT_BE" length="15" type="string"/>
@@ -891,7 +891,7 @@
     </tre>
 
     <!-- STDI-0002-1-v5.0 Appendix C, Section C.3, Tables C-7,C-8,C-9 -->
-    <tre name="PIATGB" md_prefix="NITF_PIATGB_" length="117">
+    <tre name="PIATGB" md_prefix="NITF_PIATGB_" length="117" location="image">
       <field name="TGTUTM" length="15" type="string"/>
       <field name="PIATGAID" length="15" type="string"/>
       <field name="PIACTRY" length="2" type="string"/>
@@ -902,6 +902,57 @@
       <field name="PERCOVER" length="3" type="integer" minval="0" maxval="100"/>
       <field name="TGTLAT" length="10" type="string"/>
       <field name="TGTLON" length="11" type="string"/>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix AJ, Section AJ.6.3, Table AJ.6-8 -->
+    <tre name="PIXMTA" md_prefix="NITF_PIXMTA_" minlength="152" maxlength="99985" location="image">
+        <field name="NUMAIS" length="3" type="integer"/>
+        <if cond="NUMAIS!=ALL">
+            <if cond="NUMAIS!=000">
+                <loop counter="NUMAIS" md_prefix = "AIS_%03d_">
+                    <field name="AISDLVL" length="3" type="integer"/>
+                </loop>
+            </if>
+        </if>
+        <field name="ORIGIN_X" length="14" type="real"/>
+        <field name="ORIGIN_Y" length="14" type="real"/>
+        <field name="SCALE_X" length="14" type="real"/>
+        <field name="SCALE_Y" length="14" type="real"/>
+        <field name="SAMPLE_MODE" length="1" type="string"/>
+        <field name="NUMMETRICS" length="5" type="integer"/>
+        <field name="PERBAND" length="1" type="string"/>
+        <loop counter="NUMMETRICS" md_prefix="METRIC_%05d_">
+            <field name="DESCRIPTION" length="40" type="string"/>
+            <field name="UNIT" length="40" type="string"/>
+            <field name="FITTYPE" length="1" type="string"/>
+            <if cond="FITTYPE=P">
+                <field name="NUMCOEF" length="1" type="integer"/>
+                <loop counter="NUMCOEF" md_prefix="COEF_%01d_">
+                    <field name="COEF" length="15" type="real"/>
+                </loop>
+            </if>
+        </loop>
+        <field name="RESERVED_LEN" length="5" type="integer"/>
+        <if cond="RESERVED_LEN!=00000">
+            <field name="RESERVED" length_var="RESERVED_LEN"/>
+        </if>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix AA, Section AA.4.1, Table AA-1 -->
+    <tre name="PIXQLA" md_prefix="NITF_PIXQLA_" location="image">
+        <field name="NUMAIS" length="3" type="integer"/>
+        <if cond="NUMAIS!=ALL">
+            <if cond="NUMAIS!=000">
+                <loop counter="NUMAIS" md_prefix = "AIS_%03d_">
+                    <field name="AISDLVL" length="3" type="integer"/>
+                </loop>
+            </if>
+        </if>
+        <field name="NPIXQUAL" length="4" type="integer"/>
+        <field name="PQ_BIT_VALUE" length="1" type="integer"/>
+        <loop counter="NPIXQUAL" md_prefix="PIXQUAL_%04d_">
+            <field name="PQ_CONDITION" length="40" type="string"/>
+        </loop>
     </tre>
 
     <tre name="PRJPSB" minlength="113" maxlength="248" location="file">


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds the capability to read the PIXQLA and PIXMTA TREs, defined in the Spectral NITF Implementation Profile
The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
PIXQLA is defined in STDI-0002-1-v5.0 Appendix AA.
PIXMTA is defined in STDI-0002-1-v5.0 Appendix AJ.

This PR also adds correct TRE locations for other recent SNIP TREs.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/3015
https://github.com/OSGeo/gdal/pull/3001
https://github.com/OSGeo/gdal/pull/2983

## Tasklist

 - [x] Validate nitf_spec.xml against nitf_spec.xsd
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
