### PR TITLE
Add GDAL_CURL_CA_BUNDLE environment variable

### DIFF
--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -931,10 +931,12 @@ int CPLHTTPPopFetchCallback(void)
  *                 Default is 30. (GDAL >= 2.0)</li>
  * <li>MAX_FILE_SIZE=val, where val is a number of bytes (GDAL >= 2.2)</li>
  * <li>CAINFO=/path/to/bundle.crt. This is path to Certificate Authority (CA)
- *     bundle file. By default, it will be looked in a system location. If
- *     the CAINFO options is not defined, GDAL will also look if the CURL_CA_BUNDLE
- *     environment variable is defined to use it as the CAINFO value, and as a
- *     fallback to the SSL_CERT_FILE environment variable. (GDAL >= 2.1.3)</li>
+ *     bundle file. By default, it will be looked for in a system location. If
+ *     the CAINFO option is not defined, GDAL will also look in the the
+ *     CURL_CA_BUNDLE and SSL_CERT_FILE environment variables respectively
+ *     and use the first one found as the CAINFO value (GDAL >= 2.1.3). The
+ *     GDAL_CURL_CA_BUNDLE environment variable may also be used to set the
+ *     CAINFO value in GDAL >= 3.2.</li>
  * <li>HTTP_VERSION=1.0/1.1/2/2TLS (GDAL >= 2.3). Specify HTTP version to use.
  *     Will default to 1.1 generally (except on some controlled environments,
  *     like Google Compute Engine VMs, where 2TLS will be the default).

--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -514,6 +514,7 @@ constexpr TupleEnvVarOptionName asAssocEnvVarOptionName[] =
     { "GDAL_HTTP_NETRC", "NETRC" },
     { "GDAL_HTTP_MAX_RETRY", "MAX_RETRY" },
     { "GDAL_HTTP_RETRY_DELAY", "RETRY_DELAY" },
+    { "GDAL_CURL_CA_BUNDLE", "CAINFO" },
     { "CURL_CA_BUNDLE", "CAINFO" },
     { "SSL_CERT_FILE", "CAINFO" },
     { "GDAL_HTTP_HEADER_FILE", "HEADER_FILE" },
@@ -2122,6 +2123,9 @@ void *CPLHTTPSetOptions(void *pcurl, const char* pszURL,
 
     // Custom path to SSL certificates.
     const char* pszCAInfo = CSLFetchNameValue( papszOptions, "CAINFO" );
+    if( pszCAInfo == nullptr )
+        // Name of GDAL environment variable for the CA Bundle path
+        pszCAInfo = CPLGetConfigOption("GDAL_CURL_CA_BUNDLE", nullptr);
     if( pszCAInfo == nullptr )
         // Name of environment variable used by the curl binary
         pszCAInfo = CPLGetConfigOption("CURL_CA_BUNDLE", nullptr);


### PR DESCRIPTION
## What does this PR do?

This adds the `GDAL_CURL_CA_BUNDLE` environment variable for the use case where users want to set the path for the GDAL curl CA Bundle without worrying about modifying/impacting the main one used by other tools.

## What are related issues/pull requests?
Part 1 of #3024

## Tasklist

 - [ ] Add test case(s)
 - [x] Add documentation
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed