### PR TITLE
replace FILE with VSILFILE on Win32

### DIFF
--- a/gdal/ogr/ogrsf_frmts/avc/avc_binwr.cpp
+++ b/gdal/ogr/ogrsf_frmts/avc/avc_binwr.cpp
@@ -1516,7 +1516,7 @@ int _AVCBinWriteCreateArcDirEntry(const char *pszArcDirFile,
      * fixed by forcing a VSIFSeek() before the first fwrite()... we've
      * added it below.
      *----------------------------------------------------------------*/
-    FILE *fp;
+    VSILFILE *fp;
     if ((fp = VSIFOpenL(pszArcDirFile, "r")) != nullptr)
     {
         char buf[380];


### PR DESCRIPTION
Replace FILE with VSILFILE

#3034 

* OS: Win32
* Compiler: MSVC 140
