### PR TITLE
 GTiff: add WEBP_LEVEL_OVERVIEW config option to set WebP compression level on overviews

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -6952,6 +6952,15 @@ def test_tiff_write_185_lerc_create_and_overview():
     gdal.Unlink(filename)
     assert (cs, cs_ovr) == (4672, 1087)
 
+    filename2 = '/vsimem/test_tiff_write_185_lerc_create_and_overview_copy.tif'
+    gdaltest.tiff_drv.CreateCopy(filename2, ds, options=['COMPRESS=LERC_DEFLATE', 'COPY_SRC_OVERVIEWS=YES'])
+    assert gdal.GetLastErrorMsg() == ''
+    ds = gdal.Open(filename2)
+    cs = ds.GetRasterBand(1).Checksum()
+    cs_ovr = ds.GetRasterBand(1).GetOverview(0).Checksum()
+    gdal.Unlink(filename2)
+    assert (cs, cs_ovr) == (4672, 1087)
+
 
 ###############################################################################
 

--- a/gdal/doc/source/drivers/raster/gtiff.rst
+++ b/gdal/doc/source/drivers/raster/gtiff.rst
@@ -657,6 +657,8 @@ the default behavior of the GTiff driver.
    domain to be written to PAM.
 -  :decl_configoption:`JPEG_QUALITY_OVERVIEW` : Integer between 0 and 100. Default value : 75.
    Quality of JPEG compressed overviews, either internal or external.
+-  :decl_configoption:`WEBP_LEVEL_OVERVIEW` : Integer between 1 and 100. Default value : 75.
+   WEBP quality level of overviews, either internal or external.
 -  :decl_configoption:`GDAL_TIFF_INTERNAL_MASK` : See `Internal nodata
    masks <#internal_mask>`__ section. Default value : FALSE.
 -  :decl_configoption:`GDAL_TIFF_INTERNAL_MASK_TO_8BIT` : See `Internal nodata

--- a/gdal/doc/source/programs/gdaladdo.rst
+++ b/gdal/doc/source/programs/gdaladdo.rst
@@ -130,6 +130,9 @@ and the interleaving with the :decl_configoption:`INTERLEAVE_OVERVIEW` =PIXEL/BA
 For JPEG compressed external overviews, the JPEG quality can be set with
 ``--config JPEG_QUALITY_OVERVIEW value``.
 
+For WEBP compressed external and internal overviews, the WEBP quality level can be set with
+``--config WEBP_LEVEL_OVERVIEW value``. If not set, will default to 75.
+
 For LZW or DEFLATE compressed external overviews, the predictor value can be set
 with ``--config PREDICTOR_OVERVIEW 1|2|3``.
 

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -10098,6 +10098,9 @@ CPLErr GTiffDataset::RegisterNewOverviewDataset(toff_t nOverviewOffset,
         return CE_Failure;
     }
 
+    // Do that now that m_nCompression is set
+    poODS->RestoreVolatileParameters( poODS->m_hTIFF );
+
     ++m_nOverviewCount;
     m_papoOverviewDS = static_cast<GTiffDataset **>(
         CPLRealloc( m_papoOverviewDS,

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -8915,6 +8915,13 @@ void GTiffDataset::ThreadCompressionFunc( void* pData )
     TIFFSetField(hTIFFTmp, TIFFTAG_PLANARCONFIG, poDS->m_nPlanarConfig);
     if( psJob->nPredictor != PREDICTOR_NONE )
         TIFFSetField(hTIFFTmp, TIFFTAG_PREDICTOR, psJob->nPredictor);
+#if HAVE_LERC
+    if( poDS->m_nCompression == COMPRESSION_LERC )
+    {
+        TIFFSetField(hTIFFTmp, TIFFTAG_LERC_PARAMETERS, 2,
+                    poDS->m_anLercAddCompressionAndVersion);
+    }
+#endif
 
     TIFFSetField(hTIFFTmp, TIFFTAG_PHOTOMETRIC, poDS->m_nPhotometric);
     TIFFSetField(hTIFFTmp, TIFFTAG_SAMPLEFORMAT, poDS->m_nSampleFormat);
@@ -12099,8 +12106,6 @@ void GTiffDataset::RestoreVolatileParameters(TIFF* hTIFF)
         if( m_nCompression == COMPRESSION_LERC )
         {
             TIFFSetField(hTIFF, TIFFTAG_LERC_MAXZERROR, m_dfMaxZError);
-            TIFFSetField(hTIFF, TIFFTAG_LERC_PARAMETERS, 2,
-                         m_anLercAddCompressionAndVersion);
         }
 #endif
         if( m_nWebPLevel > 0 && m_nCompression == COMPRESSION_WEBP)

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -286,6 +286,7 @@ private:
 
     friend void  GTIFFSetJpegQuality( GDALDatasetH hGTIFFDS, int nJpegQuality );
     friend void  GTIFFSetJpegTablesMode( GDALDatasetH hGTIFFDS, int nJpegTablesMode );
+    friend void  GTIFFSetWebPLevel( GDALDatasetH hGTIFFDS, int nWebPLevel );
 
     TIFF                 *m_hTIFF = nullptr;
     VSILFILE             *m_fpL = nullptr;
@@ -489,7 +490,8 @@ private:
     void          LoadEXIFMetadata();
     void          LoadICCProfile();
 
-    CPLErr        RegisterNewOverviewDataset( toff_t nOverviewOffset, int l_nJpegQuality );
+    CPLErr        RegisterNewOverviewDataset( toff_t nOverviewOffset, int l_nJpegQuality,
+                                              int l_nWebPLevel );
     CPLErr        CreateOverviewsFromSrcOverviews( GDALDataset* poSrcDS,
                                                    GDALDataset* poOvrDS );
     CPLErr        CreateInternalMaskOverviews( int nOvrBlockXSize,
@@ -1112,6 +1114,26 @@ void GTIFFSetJpegQuality( GDALDatasetH hGTIFFDS, int nJpegQuality )
 
     for( int i = 0; i < poDS->m_nOverviewCount; ++i )
         poDS->m_papoOverviewDS[i]->m_nJpegQuality = poDS->m_nJpegQuality;
+}
+
+/************************************************************************/
+/*                        GTIFFSetWebPLevel()                         */
+/* Called by GTIFFBuildOverviews() to set the jpeg quality on the IFD   */
+/* of the .ovr file.                                                    */
+/************************************************************************/
+
+void GTIFFSetWebPLevel( GDALDatasetH hGTIFFDS, int nWebpLevel )
+{
+    CPLAssert(
+        EQUAL(GDALGetDriverShortName(GDALGetDatasetDriver(hGTIFFDS)), "GTIFF"));
+
+    GTiffDataset* const poDS = static_cast<GTiffDataset *>(hGTIFFDS);
+    poDS->m_nWebPLevel = static_cast<signed char>(nWebpLevel);
+
+    poDS->ScanDirectories();
+
+    for( int i = 0; i < poDS->m_nOverviewCount; ++i )
+        poDS->m_papoOverviewDS[i]->m_nWebPLevel = poDS->m_nWebPLevel;
 }
 
 /************************************************************************/
@@ -10070,7 +10092,8 @@ CPLErr GTiffDataset::CleanOverviews()
 /************************************************************************/
 
 CPLErr GTiffDataset::RegisterNewOverviewDataset(toff_t nOverviewOffset,
-                                                int l_nJpegQuality)
+                                                int l_nJpegQuality,
+                                                int l_nWebPLevel)
 {
     if( m_nOverviewCount == 127 )
         return CE_Failure;
@@ -10079,10 +10102,10 @@ CPLErr GTiffDataset::RegisterNewOverviewDataset(toff_t nOverviewOffset,
     poODS->ShareLockWithParentDataset(this);
     poODS->m_pszFilename = CPLStrdup(m_pszFilename);
     poODS->m_nJpegQuality = static_cast<signed char>(l_nJpegQuality);
+    poODS->m_nWebPLevel = static_cast<signed char>(l_nWebPLevel);
     poODS->m_nZLevel = m_nZLevel;
     poODS->m_nLZMAPreset = m_nLZMAPreset;
     poODS->m_nZSTDLevel = m_nZSTDLevel;
-    poODS->m_nWebPLevel = m_nWebPLevel;
     poODS->m_bWebPLossless = m_bWebPLossless;
     poODS->m_nJpegTablesMode = m_nJpegTablesMode;
 #if HAVE_LERC
@@ -10261,6 +10284,13 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS,
             nOvrJpegQuality =
                 atoi(CPLGetConfigOption("JPEG_QUALITY_OVERVIEW","75"));
         }
+        int nOvrWebpLevel = m_nWebPLevel;
+        if( m_nCompression == COMPRESSION_WEBP &&
+            CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr ) != nullptr )
+        {
+            nOvrWebpLevel =
+                atoi(CPLGetConfigOption("WEBP_LEVEL_OVERVIEW","75"));
+        }
 
         CPLString osNoData; // don't move this in inner scope
         const char* pszNoData = nullptr;
@@ -10292,13 +10322,15 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS,
 #else
                                     nullptr,
 #endif
-                                    m_bWriteCOGLayout
+                                    m_bWriteCOGLayout,
+                                    nOvrWebpLevel >= 0 ?
+                                        CPLSPrintf("%d", nOvrWebpLevel) : nullptr
                                    );
 
         if( nOverviewOffset == 0 )
             eErr = CE_Failure;
         else
-            eErr = RegisterNewOverviewDataset(nOverviewOffset, nOvrJpegQuality);
+            eErr = RegisterNewOverviewDataset(nOverviewOffset, nOvrJpegQuality, nOvrWebpLevel);
     }
 
     // For directory reloading, so that the chaining to the next directory is
@@ -10365,7 +10397,8 @@ CPLErr GTiffDataset::CreateInternalMaskOverviews(int nOvrBlockXSize,
                         nullptr, nullptr, nullptr, 0, nullptr,
                         "",
                         nullptr, nullptr, nullptr, nullptr,
-                        m_bWriteCOGLayout );
+                        m_bWriteCOGLayout,
+                        nullptr );
 
                 if( nOverviewOffset == 0 )
                 {
@@ -10651,6 +10684,13 @@ CPLErr GTiffDataset::IBuildOverviews(
                 nOvrJpegQuality =
                     atoi(CPLGetConfigOption("JPEG_QUALITY_OVERVIEW","75"));
             }
+            int nOvrWebpLevel = m_nWebPLevel;
+            if( m_nCompression == COMPRESSION_WEBP &&
+                CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr ) != nullptr )
+            {
+                nOvrWebpLevel =
+                    atoi(CPLGetConfigOption("WEBP_LEVEL_OVERVIEW","75"));
+            }
 
             CPLString osNoData; // don't move this in inner scope
             const char* pszNoData = nullptr;
@@ -10680,14 +10720,17 @@ CPLErr GTiffDataset::IBuildOverviews(
 #else
                     nullptr,
 #endif
-                    false
+                    false,
+                    nOvrWebpLevel >= 0 ?
+                                CPLSPrintf("%d", nOvrWebpLevel) : nullptr
             );
 
             if( nOverviewOffset == 0 )
                 eErr = CE_Failure;
             else
                 eErr = RegisterNewOverviewDataset(nOverviewOffset,
-                                                  nOvrJpegQuality);
+                                                  nOvrJpegQuality,
+                                                  nOvrWebpLevel);
         }
     }
 
@@ -19378,7 +19421,7 @@ CPLErr GTiffDataset::CreateMaskBand(int nFlagsIn)
                 bIsTiled, l_nCompression,
                 PHOTOMETRIC_MASK, PREDICTOR_NONE,
                 SAMPLEFORMAT_UINT, nullptr, nullptr, nullptr, 0, nullptr, "", nullptr, nullptr,
-                nullptr, nullptr, m_bWriteCOGLayout );
+                nullptr, nullptr, m_bWriteCOGLayout, nullptr );
 
         ReloadDirectory();
 

--- a/gdal/frmts/gtiff/gt_overview.cpp
+++ b/gdal/frmts/gtiff/gt_overview.cpp
@@ -86,7 +86,8 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
                             const char* pszJPEGTablesMode,
                             const char* pszNoData,
                             CPL_UNUSED const uint32* panLercAddCompressionAndVersion,
-                            bool bDeferStrileArrayWriting )
+                            bool bDeferStrileArrayWriting,
+                            const char *pszWebpLevel)
 
 {
     const toff_t nBaseDirOffset = TIFFCurrentDirOffset( hTIFF );
@@ -170,6 +171,13 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
             // is a no-op (helps for cloud optimized geotiffs)
             TIFFSetField( hTIFF, TIFFTAG_YCBCRSUBSAMPLING, 2, 2 );
         }
+    }
+
+    if (nCompressFlag == COMPRESSION_WEBP  && pszWebpLevel != nullptr)
+    {
+        const int nWebpLevel = atoi(pszWebpLevel);
+        if ( nWebpLevel >= 1 )
+            TIFFSetField( hTIFF, TIFFTAG_WEBP_LEVEL, nWebpLevel );
     }
 
 #ifdef HAVE_LERC
@@ -912,7 +920,10 @@ GTIFFBuildOverviewsEx( const char * pszFilename,
                                 CPLGetConfigOption( "JPEG_TABLESMODE_OVERVIEW", nullptr ),
                              pszNoData,
                              nullptr,
-                             false
+                             false,
+                             papszOptions ?
+                                CSLFetchNameValue(papszOptions, "WEBP_LEVEL") :
+                                CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr )
                            ) == 0 )
         {
             XTIFFClose( hOTIFF );
@@ -969,6 +980,19 @@ GTIFFBuildOverviewsEx( const char * pszFilename,
         TIFFSetField( hTIFF, TIFFTAG_JPEGQUALITY,
                       nJpegQuality );
         GTIFFSetJpegQuality(GDALDataset::ToHandle(hODS), nJpegQuality);
+    }
+    const char* pszWebpLevel =
+        papszOptions ?
+            CSLFetchNameValue(papszOptions, "WEBP_LEVEL") :
+            CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr );
+    if( nCompression == COMPRESSION_WEBP && pszWebpLevel != nullptr )
+    {
+        const int nWebpLevel = atoi(pszWebpLevel);
+        if ( nWebpLevel >= 1 )
+        {
+            TIFFSetField( hTIFF, TIFFTAG_WEBP_LEVEL, nWebpLevel );
+            GTIFFSetWebPLevel(GDALDataset::ToHandle(hODS), nWebpLevel);
+        }
     }
 
     const char* pszJPEGTablesMode =

--- a/gdal/frmts/gtiff/gt_overview.h
+++ b/gdal/frmts/gtiff/gt_overview.h
@@ -54,7 +54,8 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
                             const char* pszJPEGTablesMode,
                             const char* pszNoData,
                             const uint32* panLercAddCompressionAndVersion,
-                            bool DeferStrileArrayWriting );
+                            bool DeferStrileArrayWriting,
+                            const char * pszWebpLevel );
 
 void GTIFFBuildOverviewMetadata( const char *pszResampling,
                                  GDALDataset *poBaseDS,

--- a/gdal/frmts/gtiff/gtiff.h
+++ b/gdal/frmts/gtiff/gtiff.h
@@ -45,6 +45,7 @@ CPL_C_END
 void    GTIFFSetInExternalOvr( bool b );
 void    GTIFFGetOverviewBlockSize( GDALRasterBandH hBand, int* pnBlockXSize, int* pnBlockYSize );
 void    GTIFFSetJpegQuality( GDALDatasetH hGTIFFDS, int nJpegQuality );
+void    GTIFFSetWebPLevel( GDALDatasetH hGTIFFDS, int nWebPLevel );
 void    GTIFFSetJpegTablesMode( GDALDatasetH hGTIFFDS, int nJpegTablesMode );
 int     GTIFFGetCompressionMethod( const char* pszValue,
                                    const char* pszVariableName );


### PR DESCRIPTION
Supersedes #3014

@tbonfort I kept your first 3 commits, but I put before https://github.com/OSGeo/gdal/commit/bed9da378be158a56dad0956068c91598624cd4f which was the fix for the issue you saw. Basically the issue is that RestoreVolatileParameters() called by SetDirectory() from OpenOffset() was mostly a no-op because nCompression wasn't set at that point... Using libtiff in a multi-directory context is a mess beyond imagination!
And this fix actually underlined a unrelated issue with LERC... fixed by the first commit in the series (actually moved in its own PR https://github.com/OSGeo/gdal/pull/3038)

I let you confirm that things work as expected for you