### PR TITLE
check ovr blocksize can be overriden at creation time

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -7335,8 +7335,6 @@ def test_tiff_write_jpeg_incompatible_of_paletted():
 # on a newly created dataset
 
 def test_tiff_write_186_blocksize():
-    md = gdaltest.tiff_drv.GetMetadata()
-
     blockSizes = [64,256]
     for blockSize in blockSizes:
         src_ds = gdal.Open('../gdrivers/data/utm.tif')

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -7336,26 +7336,22 @@ def test_tiff_write_jpeg_incompatible_of_paletted():
 
 def test_tiff_write_186_blocksize():
     md = gdaltest.tiff_drv.GetMetadata()
-    if md['DMD_CREATIONOPTIONLIST'].find('WEBP') == -1:
-        pytest.skip()
 
-    blockSizes = [128,256]
+    blockSizes = [64,256]
     for blockSize in blockSizes:
         src_ds = gdal.Open('../gdrivers/data/utm.tif')
         fname = 'tmp/tiff_write_186_bs%d.tif' % blockSize
 
-        ds = gdal.GetDriverByName('GTiff').Create(fname, 1024, 1024, 3,
-                                                  options=['COMPRESS=WEBP', 'TILED=YES',
+        ds = gdal.GetDriverByName('GTiff').Create(fname, 1024, 1024, 1,
+                                                  options=['TILED=YES',
                                                       'BLOCKXSIZE=512', 'BLOCKYSIZE=512'])
 
         data = src_ds.GetRasterBand(1).ReadRaster(0, 0, 512, 512, 1024, 1024)
         ds.GetRasterBand(1).WriteRaster(0, 0, 1024, 1024, data)
-        ds.GetRasterBand(2).WriteRaster(0, 0, 1024, 1024, data)
-        ds.GetRasterBand(3).WriteRaster(0, 0, 1024, 1024, data)
-        with gdaltest.config_options({
-            'GDAL_TIFF_OVR_BLOCKSIZE':'%d'%blockSize,
-            'WEBP_LEVEL_OVERVIEW':'30',
-            'GDAL_NUM_THREADS':'8'}):
+        opts = {'GDAL_TIFF_OVR_BLOCKSIZE':'%d'%blockSize}
+        if blockSizes == 256:
+            opts['GDAL_NUM_THREADS']='8'
+        with gdaltest.config_options(opts):
             ds.BuildOverviews('AVERAGE', overviewlist=[2])
 
         src_ds = None

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -7341,7 +7341,7 @@ def test_tiff_write_186_blocksize():
         fname = 'tmp/tiff_write_186_bs%d.tif' % blockSize
 
         ds = gdal.GetDriverByName('GTiff').Create(fname, 1024, 1024, 1,
-                                                  options=['TILED=YES',
+                                                  options=['TILED=YES','COMPRESS=LZW',
                                                       'BLOCKXSIZE=512', 'BLOCKYSIZE=512'])
 
         data = src_ds.GetRasterBand(1).ReadRaster(0, 0, 512, 512, 1024, 1024)


### PR DESCRIPTION
Check that blocksize can be overidden when BuildOverviews is called at creation time (i.e. witout reopening the dataset). Written when hunting down an issue that was on my end after all, but doesn't hurt to have this in the master test suite.