### PR TITLE
NITF: Add hexadecimal TRE creation

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2696,7 +2696,7 @@ def test_nitf_77():
 # Test parsing BANDSB TRE (STDI-0002 App X)
 
 def test_nitf_78():
-    float_data = struct.pack(">f", 2.1).hex()
+    float_data = "40066666" # == struct.pack(">f", 2.1).hex()
     bit_mask = "80000000" # Set bit 31 only
 
     tre_data = "TRE=HEX/BANDSB=" + hex_string("00001RADIANCE                S") + float_data*2 + \

--- a/gdal/doc/source/drivers/raster/nitf_advanced.rst
+++ b/gdal/doc/source/drivers/raster/nitf_advanced.rst
@@ -213,6 +213,18 @@ metadata domain.
      </tre>
    </tres>
 
+TRE creation from hexadecimal data
+----------------------------------
+
+TRE data can be added to a newly created NITF file in hexadecimal format to encode binary
+data such as unsigned int or floating point types.  The hexadecimal TRE creation option is 
+supplied as "TRE=HEX/<tre_name>=<hex_tre_data>" or "FILE_TRE=HEX/<tre_name>=<hex_tre_data>
+
+::
+
+    # Encode "ABC" as 3 bytes of hex data, "414243"
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/file.ntf', 1, 1, options=["TRE=HEX/TSTTRE=414243"])
+
 Raw File / Image Headers
 ------------------------
 

--- a/gdal/doc/source/drivers/raster/nitf_advanced.rst
+++ b/gdal/doc/source/drivers/raster/nitf_advanced.rst
@@ -220,7 +220,7 @@ TRE data can be added to a newly created NITF file in hexadecimal format to enco
 data such as unsigned int or floating point types.  The hexadecimal TRE creation option is 
 supplied as "TRE=HEX/<tre_name>=<hex_tre_data>" or "FILE_TRE=HEX/<tre_name>=<hex_tre_data>
 
-::
+.. code-block:: python
 
     # Encode "ABC" as 3 bytes of hex data, "414243"
     ds = gdal.GetDriverByName('NITF').Create('/vsimem/file.ntf', 1, 1, options=["TRE=HEX/TSTTRE=414243"])

--- a/gdal/frmts/nitf/nitffile.c
+++ b/gdal/frmts/nitf/nitffile.c
@@ -1342,7 +1342,7 @@ static int NITFWriteTREsFromOptions(
         if (bIsHex)
         {
             int i;
-            char pszSubStr[2];
+            char pszSubStr[3];
 
             if (nContentLength % 2)
             {

--- a/gdal/frmts/nitf/nitffile.c
+++ b/gdal/frmts/nitf/nitffile.c
@@ -1348,6 +1348,8 @@ static int NITFWriteTREsFromOptions(
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                      "Could not parse creation options %s: invalid hex data", papszOptions[iOption]+nTREPrefixLen);
+                CPLFree(pszTREName);
+                CPLFree(pszUnescapedContents);
                 return FALSE;
             }
             


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds a NITF creation option to create TREs from a hexadecimal string.

Several TREs defined in the Spectral NITF Implementation Profile have non-string fields (uint, float32, etc).  This capability will help develop more effective tests of SNIP TREs.

The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/2983
## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
