### PR TITLE
Lets copy XMP metadata

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -1013,3 +1013,23 @@ def test_cog_float32_color_table():
     assert struct.unpack('f', ds.ReadRaster(0,0,1,1))[0] == 1.0
     assert struct.unpack('f', ds.GetRasterBand(1).GetOverview(0).ReadRaster(0,0,1,1))[0] == 1.0
     gdal.Unlink(filename)
+
+###############################################################################
+# Test copy XMP
+
+
+def test_cog_copy_xmp():
+
+    filename = '/vsimem/cog_xmp.tif'
+    src_ds = gdal.Open('../gdrivers/data/gtiff/byte_with_xmp.tif')
+    ds = gdal.GetDriverByName('COG').CreateCopy(filename, src_ds)
+    assert ds
+    ds = None
+
+    ds = gdal.Open(filename)
+    xmp = ds.GetMetadata('xml:XMP')
+    ds = None
+    assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong input file without XMP'
+    _check_cog(filename)
+
+    gdal.Unlink(filename)

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -6975,6 +6975,20 @@ def test_tiff_write_181_xmp():
 
     gdaltest.tiff_drv.Delete('tmp/test_181.tif')
 
+
+def test_tiff_write_181_xmp_copy():
+
+    src_ds = gdal.Open('../gdrivers/data/gtiff/byte_with_xmp.tif')
+
+    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_181_copy.tif', src_ds)
+    src_ds = None
+
+    xmp = new_ds.GetMetadata('xml:XMP')
+    new_ds = None
+    assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong input file without XMP'
+
+    gdaltest.tiff_drv.Delete('tmp/test_181_copy.tif')
+
 ###############################################################################
 # Test delete XMP from a dataset
 

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -6980,14 +6980,22 @@ def test_tiff_write_181_xmp_copy():
 
     src_ds = gdal.Open('../gdrivers/data/gtiff/byte_with_xmp.tif')
 
-    new_ds = gdaltest.tiff_drv.CreateCopy('tmp/test_181_copy.tif', src_ds)
+    filename = 'tmp/test_181_copy.tif'
+    new_ds = gdaltest.tiff_drv.CreateCopy(filename, src_ds)
+    assert new_ds is not None
     src_ds = None
+
+    new_ds = None
+    new_ds = gdal.Open(filename)
+
+    assert int(new_ds.GetRasterBand(1).GetMetadataItem('IFD_OFFSET', 'TIFF')) == 8, 'TIFF directory not at the beginning'
 
     xmp = new_ds.GetMetadata('xml:XMP')
     new_ds = None
     assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong input file without XMP'
 
-    gdaltest.tiff_drv.Delete('tmp/test_181_copy.tif')
+    gdaltest.tiff_drv.Delete(filename)
+
 
 ###############################################################################
 # Test delete XMP from a dataset

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -481,6 +481,8 @@ def test_gdal_translate_lib_111():
     # codepath if some other options are set is different, creating a VRTdataset
     new_ds = gdal.Translate('tmp/test111notcopied.tif', ds, nogcp='True')
     assert new_ds is not None
+    new_ds = None
+    new_ds = gdal.Open('tmp/test111notcopied.tif')
     xmp = new_ds.GetMetadata('xml:XMP')
     new_ds = None
     assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong output file without XMP'
@@ -488,6 +490,8 @@ def test_gdal_translate_lib_111():
     # normal codepath calling CreateCopy directly
     new_ds = gdal.Translate('tmp/test111.tif', ds)
     assert new_ds is not None
+    new_ds = None
+    new_ds = gdal.Open('tmp/test111.tif')
     xmp = new_ds.GetMetadata('xml:XMP')
     new_ds = None
     assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong output file without XMP'
@@ -498,7 +502,7 @@ def test_gdal_translate_lib_111():
 def test_gdal_translate_lib_112():
 
     ds = gdal.Open('../gdrivers/data/gtiff/byte_with_xmp.tif')
-    new_ds = gdal.Translate('tmp/test112noxmp.tif', ds, options='-noxmp', format='COG')
+    new_ds = gdal.Translate('tmp/test112noxmp.tif', ds, options='-of COG -noxmp')
     assert new_ds is not None
     xmp = new_ds.GetMetadata('xml:XMP')
     new_ds = None
@@ -506,6 +510,8 @@ def test_gdal_translate_lib_112():
 
     new_ds = gdal.Translate('tmp/test112.tif', ds, format='COG')
     assert new_ds is not None
+    new_ds = None
+    new_ds = gdal.Open('tmp/test112.tif')
     xmp = new_ds.GetMetadata('xml:XMP')
     new_ds = None
     assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong output file without XMP'

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -464,6 +464,55 @@ def test_gdal_translate_lib_110():
 
     ds = None
 
+
+###############################################################################
+# Test noxmp options
+
+
+def test_gdal_translate_lib_111():
+
+    ds = gdal.Open('../gdrivers/data/gtiff/byte_with_xmp.tif')
+    new_ds = gdal.Translate('tmp/test111noxmp.tif', ds, options='-noxmp')
+    assert new_ds is not None
+    xmp = new_ds.GetMetadata('xml:XMP')
+    new_ds = None
+    assert xmp is None
+
+    # codepath if some other options are set is different, creating a VRTdataset
+    new_ds = gdal.Translate('tmp/test111notcopied.tif', ds, nogcp='True')
+    assert new_ds is not None
+    xmp = new_ds.GetMetadata('xml:XMP')
+    new_ds = None
+    assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong output file without XMP'
+
+    # normal codepath calling CreateCopy directly
+    new_ds = gdal.Translate('tmp/test111.tif', ds)
+    assert new_ds is not None
+    xmp = new_ds.GetMetadata('xml:XMP')
+    new_ds = None
+    assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong output file without XMP'
+
+    ds = None
+
+
+def test_gdal_translate_lib_112():
+
+    ds = gdal.Open('../gdrivers/data/gtiff/byte_with_xmp.tif')
+    new_ds = gdal.Translate('tmp/test112noxmp.tif', ds, options='-noxmp', format='COG')
+    assert new_ds is not None
+    xmp = new_ds.GetMetadata('xml:XMP')
+    new_ds = None
+    assert xmp is None
+
+    new_ds = gdal.Translate('tmp/test112.tif', ds, format='COG')
+    assert new_ds is not None
+    xmp = new_ds.GetMetadata('xml:XMP')
+    new_ds = None
+    assert 'W5M0MpCehiHzreSzNTczkc9d' in xmp[0], 'Wrong output file without XMP'
+
+    ds = None
+
+
 ###############################################################################
 # Test gdal_translate foo.tif foo.tif.ovr
 

--- a/gdal/apps/gdal_translate_bin.cpp
+++ b/gdal/apps/gdal_translate_bin.cpp
@@ -62,7 +62,7 @@ static void Usage(const char* pszErrorMsg, int bShort)
             "       |-colorinterp {red|green|blue|alpha|gray|undefined},...]\n"
             "       [-mo \"META-TAG=VALUE\"]* [-q] [-sds]\n"
             "       [-co \"NAME=VALUE\"]* [-stats] [-norat]\n"
-            "       [-oo NAME=VALUE]*\n"
+            "       [-oo NAME=VALUE]* [-noxmp]\n"
             "       src_dataset dst_dataset\n" );
 
     if( !bShort )

--- a/gdal/apps/gdal_translate_lib.cpp
+++ b/gdal/apps/gdal_translate_lib.cpp
@@ -1546,7 +1546,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
     if( !psOptions->bNoXMP )
     {
         char** papszXMP = poSrcDS->GetMetadata("xml:XMP");
-        if (papszXMP != nullptr && papszXMP[0] != nullptr)
+        if (papszXMP != nullptr && *papszXMP != nullptr)
         {
             poVDS->SetMetadata(papszXMP, "xml:XMP");
         }

--- a/gdal/apps/gdal_translate_lib.cpp
+++ b/gdal/apps/gdal_translate_lib.cpp
@@ -281,6 +281,9 @@ struct GDALTranslateOptions
     // value, or -1 if no override.
     int nColorInterpSize;
     int* panColorInterp;
+
+    /*! does not copy source XMP into destination dataset (when TRUE) */
+    bool bNoXMP;
 };
 
 /************************************************************************/
@@ -1117,7 +1120,8 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         && psOptions->nGCPCount == 0 && !bGotBounds
         && psOptions->pszOutputSRS == nullptr && !psOptions->bSetNoData && !psOptions->bUnsetNoData
         && psOptions->nRGBExpand == 0 && !psOptions->bNoRAT
-        && psOptions->panColorInterp == nullptr )
+        && psOptions->panColorInterp == nullptr
+        && !psOptions->bNoXMP )
     {
 
         // For gdal_translate_fuzzer
@@ -1537,6 +1541,17 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         if( papszMD_VICAR != nullptr)
             poVDS->SetMetadata( papszMD_VICAR, "json:VICAR" );
     }
+
+    // Copy XMP metadata
+    if( !psOptions->bNoXMP )
+    {
+        char** papszXMP = poSrcDS->GetMetadata("xml:XMP");
+        if (papszXMP != nullptr && papszXMP[0] != nullptr)
+        {
+            poVDS->SetMetadata(papszXMP, "xml:XMP");
+        }
+    }
+
 
 /* -------------------------------------------------------------------- */
 /*      Transfer metadata that remains valid if the spatial             */
@@ -2304,6 +2319,7 @@ GDALTranslateOptions *GDALTranslateOptionsNew(char** papszArgv, GDALTranslateOpt
     psOptions->dfYRes = 0.0;
     psOptions->pszProjSRS = nullptr;
     psOptions->nLimitOutSize = 0;
+    psOptions->bNoXMP = false;
 
     bool bParsedMaskArgument = false;
     bool bOutsideExplicitlySet = false;
@@ -2816,6 +2832,12 @@ GDALTranslateOptions *GDALTranslateOptionsNew(char** papszArgv, GDALTranslateOpt
                     psOptionsForBinary->papszAllowInputDrivers, papszArgv[i] );
             }
         }
+
+        else if (EQUAL(papszArgv[i], "-noxmp"))
+        {
+            psOptions->bNoXMP = true;
+        }
+
 
         else if( papszArgv[i][0] == '-' )
         {

--- a/gdal/doc/source/programs/gdal_translate.rst
+++ b/gdal/doc/source/programs/gdal_translate.rst
@@ -33,7 +33,7 @@ Synopsis
         |-colorinterp {red|green|blue|alpha|gray|undefined},...]
         [-mo "META-TAG=VALUE"]* [-q] [-sds]
         [-co "NAME=VALUE"]* [-stats] [-norat]
-        [-oo NAME=VALUE]*
+        [-oo NAME=VALUE]* [-noxmp]
         src_dataset dst_dataset
 
 Description
@@ -249,6 +249,10 @@ resampling, and rescaling pixels in the process.
 .. option:: -oo NAME=VALUE
 
     Dataset open option (format specific)
+
+.. option:: -noxmp
+
+    Do not copy the XMP metadata in the source dataset to the output dataset when driver is able to copy it.
 
 .. option:: <src_dataset>
 

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -17742,6 +17742,16 @@ GTiffDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     }
 
 /* -------------------------------------------------------------------- */
+/*      Copy xml:XMP data                                               */
+/* -------------------------------------------------------------------- */
+    char **papszXMP = poSrcDS->GetMetadata("xml:XMP");
+    if( papszXMP != nullptr && *papszXMP != nullptr )
+    {
+        int nTagSize = static_cast<int>(strlen(*papszXMP));
+        TIFFSetField( l_hTIFF, TIFFTAG_XMLPACKET, nTagSize, *papszXMP );
+    }
+
+/* -------------------------------------------------------------------- */
 /*      Write the projection information, if possible.                  */
 /* -------------------------------------------------------------------- */
     const bool bHasProjection = l_poSRS != nullptr;
@@ -18008,15 +18018,6 @@ GTiffDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
         {
             poDS->SetMetadata( papszESRIMD, "xml:ESRI");
         }
-    }
-
-/* -------------------------------------------------------------------- */
-/*      Copy xml:XMP data                                               */
-/* -------------------------------------------------------------------- */
-    char **papszXMP = poSrcDS->GetMetadata("xml:XMP");
-    if( papszXMP != nullptr && papszXMP[0] != nullptr )
-    {
-        poDS->SetMetadata( papszXMP, "xml:XMP");
     }
 
 /* -------------------------------------------------------------------- */

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -18011,6 +18011,15 @@ GTiffDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     }
 
 /* -------------------------------------------------------------------- */
+/*      Copy xml:XMP data                                               */
+/* -------------------------------------------------------------------- */
+    char **papszXMP = poSrcDS->GetMetadata("xml:XMP");
+    if( papszXMP != nullptr && papszXMP[0] != nullptr )
+    {
+        poDS->SetMetadata( papszXMP, "xml:XMP");
+    }
+
+/* -------------------------------------------------------------------- */
 /*      Second chance: now that we have a PAM dataset, it is possible   */
 /*      to write metadata that we could not write as a TIFF tag.        */
 /* -------------------------------------------------------------------- */

--- a/gdal/gcore/gdaldriver.cpp
+++ b/gdal/gcore/gdaldriver.cpp
@@ -745,7 +745,7 @@ GDALDataset *GDALDriver::DefaultCreateCopy( const char * pszFilename,
 /*      Copy XMPmetadata.                                               */
 /* -------------------------------------------------------------------- */
     char** papszXMP = poSrcDS->GetMetadata("xml:XMP");
-    if (papszXMP != nullptr && papszXMP[0] != nullptr)
+    if (papszXMP != nullptr && *papszXMP != nullptr)
     {
         poDstDS->SetMetadata(papszXMP, "xml:XMP");
     }

--- a/gdal/gcore/gdaldriver.cpp
+++ b/gdal/gcore/gdaldriver.cpp
@@ -742,6 +742,15 @@ GDALDataset *GDALDriver::DefaultCreateCopy( const char * pszFilename,
         poDstDS->SetMetadata( papszMD, "RPC" );
 
 /* -------------------------------------------------------------------- */
+/*      Copy XMPmetadata.                                               */
+/* -------------------------------------------------------------------- */
+    char** papszXMP = poSrcDS->GetMetadata("xml:XMP");
+    if (papszXMP != nullptr && papszXMP[0] != nullptr)
+    {
+        poDstDS->SetMetadata(papszXMP, "xml:XMP");
+    }
+    
+/* -------------------------------------------------------------------- */
 /*      Loop copying bands.                                             */
 /* -------------------------------------------------------------------- */
     for( int iBand = 0;


### PR DESCRIPTION
Add feature to copy XMP metadata in `CreateCopy`, in particular for `GTiff` driver (`COG` indirectly), and all drivers that use `DefaultCreateCopy` method.

`gdal_translate` adds the option `-noxmp` to not copy this data when desired

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
