### PR TITLE
NITF: Add nested variable support in xml:TRE

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -2697,11 +2697,11 @@ def test_nitf_77():
 
 def test_nitf_78():
     float_data = "40066666" # == struct.pack(">f", 2.1).hex()
-    bit_mask = "80000000" # Set bit 31 only
+    bit_mask = "89800000" # Set bits 31, 27, 24, 23
 
     tre_data = "TRE=HEX/BANDSB=" + hex_string("00001RADIANCE                S") + float_data*2 + \
                 hex_string("0030.00M0030.00M-------M-------M                                                ") + \
-                bit_mask + hex_string("DETECTOR                ") + float_data
+                bit_mask + hex_string("DETECTOR                ") + float_data + hex_string("U00.851920.01105")
 
     ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_78.ntf', 1, 1, options=[tre_data])
     ds = None
@@ -2728,11 +2728,16 @@ def test_nitf_78():
     <field name="SPT_RESP_COL" value="-------" />
     <field name="SPT_RESP_UNIT_COL" value="M" />
     <field name="DATA_FLD_1" value="" />
-    <field name="EXISTENCE_MASK" value="2147483648" />
+    <field name="EXISTENCE_MASK" value="2306867200" />
     <field name="RADIOMETRIC_ADJUSTMENT_SURFACE" value="DETECTOR" />
     <field name="ATMOSPHERIC_ADJUSTMENT_ALTITUDE" value="2.100000" />
+    <field name="WAVE_LENGTH_UNIT" value="U" />
     <repeated name="BANDS" number="1">
-      <group index="0" />
+      <group index="0">
+        <field name="BAD_BAND" value="0" />
+        <field name="CWAVE" value="0.85192" />
+        <field name="FWHM" value="0.01105" />
+      </group>
     </repeated>
   </tre>
 </tres>

--- a/gdal/frmts/nitf/nitffile.c
+++ b/gdal/frmts/nitf/nitffile.c
@@ -2915,6 +2915,7 @@ CPLXMLNode* NITFCreateXMLTre(NITFFile* psFile,
     CPLXMLNode* psTreNode;
     CPLXMLNode* psOutXMLNode = NULL;
     int nMDSize = 0, nMDAlloc = 0;
+    const char* pszMDPrefix;
 
     psTreNode = NITFFindTREXMLDescFromName(psFile, pszTREName);
     if (psTreNode == NULL)
@@ -2943,6 +2944,7 @@ CPLXMLNode* NITFCreateXMLTre(NITFFile* psFile,
     CPLCreateXMLNode(CPLCreateXMLNode(psOutXMLNode, CXT_Attribute, "name"),
                      CXT_Text, pszTREName);
 
+    pszMDPrefix = CPLGetXMLValue(psTreNode, "md_prefix", "");
     CSLDestroy(NITFGenericMetadataReadTREInternal(NULL,
                                                   &nMDSize,
                                                   &nMDAlloc,
@@ -2952,7 +2954,7 @@ CPLXMLNode* NITFCreateXMLTre(NITFFile* psFile,
                                                   nTRESize,
                                                   psTreNode,
                                                   &nTreOffset,
-                                                  "",
+                                                  pszMDPrefix,
                                                   &bError));
 
     if (bError == FALSE && nTreLength > 0 && nTreOffset != nTreLength)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds missing fields to the XML output of the "xml:TRE" metadata domain.  The fields that were not previously included were contained within \<loop\> or \<if\> blocks that accessed variables outside the immediate block scope.  These variables need md_prefix to be provided in order to recursively find the variable.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/2983

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
