### PR TITLE
NITF: Add ILLUMB TRE from SNIP specification

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -3104,6 +3104,79 @@ def test_nitf_86():
     assert data == expected_data
 
 ###############################################################################
+# Test parsing ILLUMB TRE (STDI-0002-1-v5.0 App AL)
+
+def test_nitf_87():
+    bit_mask = "7A0000"
+    tre_data = "TRE=HEX/ILLUMB=" + hex_string("0001mm                                      8.5192000000E-01") + \
+        hex_string("2.5770800000E+00001NUM_BANDS=1 because ILLUMB has no band-dependent content                        ") + \
+        hex_string("World Geodetic System 1984                                                      ") + \
+        hex_string("WGE World Geodetic System 1984                                                      ") + \
+        hex_string("WE Geodetic                                                                        ") + \
+        hex_string("GEOD") + \
+        bit_mask + hex_string("00120050407072410+33.234974+044.333405+27.8100000E+0132.8+54.9167.5+52.5") + \
+        hex_string("-163.4004099.2+84.0")
+               
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_87.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_87.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_87.ntf')
+
+    expected_data = """<tres>
+  <tre name="ILLUMB" location="image">
+    <field name="NUM_BANDS" value="0001" />
+    <field name="BAND_UNIT" value="mm" />
+    <repeated number="1">
+      <group index="0">
+        <field name="LBOUND" value="8.5192000000E-01" />
+        <field name="UBOUND" value="2.5770800000E+00" />
+      </group>
+    </repeated>
+    <field name="NUM_OTHERS" value="00" />
+    <field name="NUM_COMS" value="1" />
+    <repeated number="1">
+      <group index="0">
+        <field name="COMMENT" value="NUM_BANDS=1 because ILLUMB has no band-dependent content" />
+      </group>
+    </repeated>
+    <field name="GEO_DATUM" value="World Geodetic System 1984" />
+    <field name="GEO_DATUM_CODE" value="WGE" />
+    <field name="ELLIPSOID_NAME" value="World Geodetic System 1984" />
+    <field name="ELLIPSOID_CODE" value="WE" />
+    <field name="VERTICAL_DATUM_REF" value="Geodetic" />
+    <field name="VERTICAL_REF_CODE" value="GEOD" />
+    <field name="EXISTENCE_MASK" value="7995392" />
+    <field name="NUM_ILLUM_SETS" value="001" />
+    <repeated number="1">
+      <group index="0">
+        <field name="DATETIME" value="20050407072410" />
+        <field name="TARGET_LAT" value="+33.234974" />
+        <field name="TARGET_LON" value="+044.333405" />
+        <field name="TARGET_HGT" value="+27.8100000E+0" />
+        <field name="SUN_AZIMUTH" value="132.8" />
+        <field name="SUN_ELEV" value="+54.9" />
+        <field name="MOON_AZIMUTH" value="167.5" />
+        <field name="MOON_ELEV" value="+52.5" />
+        <field name="MOON_PHASE_ANGLE" value="-163.4" />
+        <field name="MOON_ILLUM_PERCENT" value="004" />
+        <field name="SENSOR_AZIMUTH" value="099.2" />
+        <field name="SENSOR_ELEV" value="+84.0" />
+        <repeated number="1">
+          <group index="0" />
+        </repeated>
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -693,6 +693,107 @@
         <field name="FI_COL" length="8" type="integer"/>
     </tre>
 
+    <!-- STDI-0002-1-v5.0 Appendix AL, Section AL.6.2.4, Table AL.6-3 -->
+    <tre name="ILLUMB" minlength="381" maxlength="99985" md_prefix="NITF_ILLUMB_" location="image">
+        <field name="NUM_BANDS" length="4" type="integer"/>
+        <field name="BAND_UNIT" length="40" type="string"/>
+        <loop counter="NUM_BANDS" md_prefix="BAND_%04d_">
+            <field name="LBOUND" length="16" type="real"/>
+            <field name="UBOUND" length="16" type="real"/>
+        </loop>
+        <field name="NUM_OTHERS" length="2" type="integer"/>
+        <loop counter="NUM_OTHERS" md_prefix="OTHER_%02d_">
+            <field name="OTHER_NAME" length="40" type="string"/>
+        </loop>
+        <field name="NUM_COMS" length="1" type="integer"/>
+        <loop counter="NUM_COMS" md_prefix="COMS_%01d_">
+            <field name="COMMENT" length="80" type="string"/>
+        </loop>
+        <field name="GEO_DATUM" length="80" type="string"/>
+        <field name="GEO_DATUM_CODE" length="4" type="string"/>
+        <field name="ELLIPSOID_NAME" length="80" type="string"/>
+        <field name="ELLIPSOID_CODE" length="3" type="string"/>
+        <field name="VERTICAL_DATUM_REF" length="80" type="string"/>
+        <field name="VERTICAL_REF_CODE" length="4" type="string"/>
+        <field name="EXISTENCE_MASK" length="3" type="bitmask"/>
+        <if cond="EXISTENCE_MASK:23">
+            <field name="RAD_QUANTITY" length="40" type="string"/>
+            <field name="RADQ_UNIT" length="40" type="string"/>
+        </if>
+        <field name="NUM_ILLUM_SETS" length="3" type="integer"/>
+        <loop counter="NUM_ILLUM_SETS" md_prefix="ILLUM_SET_%03d_">
+            <field name="DATETIME" length="14" type="string"/>
+            <field name="TARGET_LAT" length="10" type="real"/>
+            <field name="TARGET_LON" length="11" type="real"/>
+            <field name="TARGET_HGT" length="14" type="real"/>
+            <if cond="EXISTENCE_MASK:22">
+                <field name="SUN_AZIMUTH" length="5" type="real"/>
+                <field name="SUN_ELEV" length="5" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:21">
+                <field name="MOON_AZIMUTH" length="5" type="real"/>
+                <field name="MOON_ELEV" length="5" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:20">
+                <field name="MOON_PHASE_ANGLE" length="6" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:19">
+                <field name="MOON_ILLUM_PERCENT" length="3" type="integer"/>
+            </if>
+            <if cond="EXISTENCE_MASK:18">
+                <loop counter="NUM_OTHERS" md_prefix="OTHERS_%02d_">
+                    <field name="OTHER_AZIMUTH" length="5" type="real"/>
+                    <field name="OTHER_ELEV" length="5" type="real"/>
+                </loop>
+            </if>
+            <if cond="EXISTENCE_MASK:17">
+                <field name="SENSOR_AZIMUTH" length="5" type="real"/>
+                <field name="SENSOR_ELEV" length="5" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:16">
+                <field name="CATS_ANGLE" length="5" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:15">
+                <field name="SUN_GLINT_LAT" length="10" type="real"/>
+                <field name="SUN_GLINT_LON" length="11" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:14">
+                <field name="CATM_ANGLE" length="5" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:13">
+                <field name="MOON_GLINT_LAT" length="10" type="real"/>
+                <field name="MOON_GLINT_LON" length="11" type="real"/>
+            </if>
+            <if cond="EXISTENCE_MASK:10">
+                <field name="SOL_LUN_DIST_ADJUST" length="7" type="real"/>
+            </if>
+            <loop counter="NUM_BANDS" md_prefix="BAND_%04d_">
+                <if cond="EXISTENCE_MASK:12">
+                    <field name="SUN_ILLUM_METHOD" length="1" type="string"/>
+                    <field name="SUN_ILLUM" length="16" type="real"/>
+                </if>
+                <if cond="EXISTENCE_MASK:11">
+                    <field name="MOON_ILLUM_METHOD" length="1" type="string"/>
+                    <field name="MOON_ILLUM" length="16" type="real"/>
+                </if>
+                <if cond="EXISTENCE_MASK:10">
+                    <field name="TOT_SUNMOON_ILLUM" length="16" type="real"/>
+                </if>
+                <loop counter="NUM_OTHERS" md_prefix="OTHER_%02d_">
+                    <if cond="EXISTENCE_MASK:9">
+                        <field name="OTHER_ILLUM_METHOD" length="1" type="string"/>
+                        <field name="OTHER_ILLUM" length="16" type="real"/>
+                    </if>
+                </loop>
+                <if cond="EXISTENCE_MASK:8">
+                    <field name="ART_ILLUM_METHOD" length="1" type="string"/>
+                    <field name="ART_ILLUM_MIN" length="16" type="real"/>
+                    <field name="ART_ILLUM_MAX" length="16" type="real"/>
+                </if>
+            </loop>
+        </loop>
+    </tre>
+
     <tre name="J2KLRA" location="image">
         <field name="ORIG" length="1"/>
         <field name="NLEVELS_O" length="2"/>


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds the capability to read the ILLUMB TRE, defined in the Spectral NITF Implementation Profile
The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
ILLUMB is defined in STDI-0002-1-v5.0 Appendix AL.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/3058
https://github.com/OSGeo/gdal/pull/3023

## Tasklist

 - [x] Validate nitf_spec.xml against nitf_spec.xsd
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
