### PR TITLE
 GPKG: perf improvement: when inserting more than 100 features in a transaction in an existing layer, switch to a deferred insertion strategy for spatial index entries

### DIFF
--- a/gdal/apps/ogr2ogr_lib.cpp
+++ b/gdal/apps/ogr2ogr_lib.cpp
@@ -5039,7 +5039,7 @@ GDALVectorTranslateOptions *GDALVectorTranslateOptionsNew(char** papszArgv,
     psOptions->bSkipFailures = false;
     psOptions->nLayerTransaction = -1;
     psOptions->bForceTransaction = false;
-    psOptions->nGroupTransactions = 20000;
+    psOptions->nGroupTransactions = 100 * 1000;
     psOptions->nFIDToFetch = OGRNullFID;
     psOptions->bQuiet = false;
     psOptions->pszFormat = nullptr;

--- a/gdal/doc/source/programs/ogr2ogr.rst
+++ b/gdal/doc/source/programs/ogr2ogr.rst
@@ -233,7 +233,7 @@ output coordinate system or even reprojecting the features during translation.
 
 .. option:: -gt n
 
-    Group n features per transaction (default 20000). Increase the value for
+    Group n features per transaction (default 100 000). Increase the value for
     better performance when writing into DBMS drivers that have transaction
     support. ``n`` can be set to unlimited to load the data into a single
     transaction.

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -284,7 +284,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         virtual OGRErr      CommitTransaction() override;
         virtual OGRErr      RollbackTransaction() override;
 
-        bool                IsInTransaction() const;
+        inline bool         IsInTransaction() const { return nSoftTransactionLevel > 0; }
 
         int                 GetSrsId( const OGRSpatialReference& oSRS );
         const char*         GetSrsName( const OGRSpatialReference& oSRS );
@@ -452,6 +452,20 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     GPKGASpatialVariant         m_eASPatialVariant;
     std::set<OGRwkbGeometryType> m_eSetBadGeomTypeWarned;
 
+    int                         m_nCountInsertInTransactionThreshold = -1;
+    GIntBig                     m_nCountInsertInTransaction = 0;
+    std::vector<CPLString >     m_aoRTreeTriggersSQL{};
+    typedef struct
+    {
+        GIntBig nId;
+        float   fMinX;
+        float   fMinY;
+        float   fMaxX;
+        float   fMaxY;
+    } GPKGRTreeEntry;
+    std::vector<GPKGRTreeEntry>  m_aoRTreeEntries{};
+
+
     virtual OGRErr      ResetStatement() override;
 
     void                BuildWhere();
@@ -472,6 +486,9 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     void                InitView();
 
     bool                DoSpecialProcessingForColumnCreation(OGRFieldDefn* poField);
+
+    bool                StartDeferredSpatialIndexUpdate();
+    bool                FlushPendingSpatialIndexUpdate();
 
     public:
                         OGRGeoPackageTableLayer( GDALGeoPackageDataset *poDS,
@@ -563,6 +580,9 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
                                 { m_bTruncateFields = CPL_TO_BOOL( bFlag ); }
     OGRErr              RunDeferredCreationIfNecessary();
     bool                RunDeferredDropRTreeTableIfNecessary();
+    bool                DoJobAtTransactionCommit();
+    bool                DoJobAtTransactionRollback();
+    bool                RunDeferredSpatialIndexUpdate();
 
 #ifdef ENABLE_GPKG_OGR_CONTENTS
     bool                GetAddOGRFeatureCountTriggers() const


### PR DESCRIPTION
And: ogr2ogr: bump default value of -gt to 100 000 