### PR TITLE
Support for font and custom symbols in mitab

### DIFF
--- a/autotest/ogr/data/mitab/all_geoms.mif.golden.csv
+++ b/autotest/ogr/data/mitab/all_geoms.mif.golden.csv
@@ -1,6 +1,6 @@
 WKT,ogr_style
 "POINT (0 1)","SYMBOL(a:0,c:#000000,s:12pt,id:""mapinfo-sym-35,ogr-sym-10"")"
-"POINT (2 3)","SYMBOL(a:0,c:#000000,s:1pt,id:""mapinfo-sym-35,ogr-sym-10"")"
+"POINT (2 3)","SYMBOL(a:0,c:#000000,s:1pt,id:""mapinfo-custom-sym-2-bla,-bla,ogr-sym-9"")"
 "POINT (4 5)","SYMBOL(a:30,c:#000001,s:2pt,id:""font-sym-99,ogr-sym-9"",f:""foo"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"
 "LINESTRING (0 1,2 3)","PEN(w:1px,c:#000000,id:""mapinfo-pen-2,ogr-pen-0"")"

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -1846,7 +1846,7 @@ def test_ogr_mitab_43():
     src_ds = None
 
     size = gdal.VSIStatL('/vsimem/all_geoms_block_512.map').size
-    assert size == 6144
+    assert size == 6656
 
     size = gdal.VSIStatL('/vsimem/all_geoms_block_32256.map').size
     assert size == 161280

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab.h
@@ -957,6 +957,7 @@ class ITABFeatureSymbol
     void        SetSymbolSize(GInt16 val)   { m_sSymbolDef.nPointSize = val;}
     void        SetSymbolColor(GInt32 clr)  { m_sSymbolDef.rgbColor = clr;}
 
+	static TABFeatureClass GetSymbolFeatureClass(const char *pszStyleString);
     virtual const char *GetSymbolStyleString(double dfAngle = 0.0) const;
     void        SetSymbolFromStyleString(const char *pszStyleString);
     virtual void SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle);
@@ -1217,9 +1218,11 @@ class TABCustomPoint final : public TABPoint,
     virtual int ReadGeometryFromMIFFile(MIDDATAFile *fp) override;
     virtual int WriteGeometryToMIFFile(MIDDATAFile *fp) override;
 
+    virtual const char *GetSymbolStyleString(double dfAngle = 0.0) const override;
     virtual const char *GetStyleString() const override;
+    virtual void SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle) override;
 
-    const char *GetSymbolNameRef()      { return GetFontNameRef(); }
+    const char *GetSymbolNameRef() const { return GetFontNameRef(); }
     void        SetSymbolName(const char *pszName) {SetFontName(pszName);}
 
     GByte       GetCustomSymbolStyle()              {return m_nCustomStyle;}

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab.h
@@ -957,7 +957,7 @@ class ITABFeatureSymbol
     void        SetSymbolSize(GInt16 val)   { m_sSymbolDef.nPointSize = val;}
     void        SetSymbolColor(GInt32 clr)  { m_sSymbolDef.rgbColor = clr;}
 
-	static TABFeatureClass GetSymbolFeatureClass(const char *pszStyleString);
+    static TABFeatureClass GetSymbolFeatureClass(const char *pszStyleString);
     virtual const char *GetSymbolStyleString(double dfAngle = 0.0) const;
     void        SetSymbolFromStyleString(const char *pszStyleString);
     virtual void SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle);

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1795,24 +1795,24 @@ const char* TABCustomPoint::GetSymbolStyleString(double dfAngle) const
 
     int         nAngle = static_cast<int>(dfAngle);
     const char* pszStyle;
-	const char* pszExt = CPLGetExtension(GetSymbolNameRef());
-	char 		szLowerExt[8] = "";
-	const char*	pszPtr = pszExt;
-	int			i;
+    const char* pszExt = CPLGetExtension(GetSymbolNameRef());
+    char        szLowerExt[8] = "";
+    const char* pszPtr = pszExt;
+    int         i;
 
-	for(i=0; i < 7 && *pszPtr != '\0' && *pszPtr != ' '; i++, pszPtr++)
-	{
-		szLowerExt[i] = (char)tolower(*pszPtr);
-	}
-	szLowerExt[i] = '\0';
+    for(i=0; i < 7 && *pszPtr != '\0' && *pszPtr != ' '; i++, pszPtr++)
+    {
+        szLowerExt[i] = (char)tolower(*pszPtr);
+    }
+    szLowerExt[i] = '\0';
 
     pszStyle=CPLSPrintf("SYMBOL(a:%d%s,s:%dpt,id:\"mapinfo-custom-sym-%d-%s,%s-%s,ogr-sym-9\")",
                         nAngle,
-						color,
+                        color,
                         m_sSymbolDef.nPointSize,
-						m_nCustomStyle,
-						GetSymbolNameRef(),
-						szLowerExt,
+                        m_nCustomStyle,
+                        GetSymbolNameRef(),
+                        szLowerExt,
                         GetSymbolNameRef());
     return pszStyle;
 }
@@ -1834,22 +1834,22 @@ void TABCustomPoint::SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle)
     {
         const int nSymbolStyle = atoi(pszSymbolId+19);
         SetCustomSymbolStyle(static_cast<GByte>(nSymbolStyle));
-		
-		const char* pszPtr = pszSymbolId+19;
-		while (*pszPtr != '-') 
-		{
-			pszPtr++;
-		}
-		pszPtr++;
-		
-		char 		szSymbolName[256] = "";
-		int			i;
-		for(i=0; i < 255 && *pszPtr != '\0' && *pszPtr != ',' && *pszPtr != '"'; i++, pszPtr++)
-		{
-			szSymbolName[i] = *pszPtr;
-		}
-		szSymbolName[i] = '\0';		
-		SetSymbolName(szSymbolName);
+        
+        const char* pszPtr = pszSymbolId+19;
+        while (*pszPtr != '-') 
+        {
+            pszPtr++;
+        }
+        pszPtr++;
+        
+        char szSymbolName[256] = "";
+        int  i;
+        for(i=0; i < 255 && *pszPtr != '\0' && *pszPtr != ',' && *pszPtr != '"'; i++, pszPtr++)
+        {
+            szSymbolName[i] = *pszPtr;
+        }
+        szSymbolName[i] = '\0';
+        SetSymbolName(szSymbolName);
     }
 }
 
@@ -9144,9 +9144,9 @@ TABFeatureClass ITABFeatureSymbol::GetSymbolFeatureClass(const char *pszStyleStr
     {
         poStylePart = poStyleMgr->GetPart(i);
         if( poStylePart == nullptr )
-		{
+        {
             continue;
-		}
+        }
 
         if(poStylePart->GetType() == OGRSTCSymbol)
         {
@@ -9158,8 +9158,8 @@ TABFeatureClass ITABFeatureSymbol::GetSymbolFeatureClass(const char *pszStyleStr
             poStylePart = nullptr;
         }
     }
-	
-	TABFeatureClass result = TABFCPoint;
+    
+    TABFeatureClass result = TABFCPoint;
 
     // If the no Symbol found, do nothing.
     if(poStylePart == nullptr)
@@ -9181,12 +9181,12 @@ TABFeatureClass ITABFeatureSymbol::GetSymbolFeatureClass(const char *pszStyleStr
         if(STARTS_WITH(pszSymbolId, "font-sym-"))
         {
             result = TABFCFontPoint;
-		}
+        }
         else if(STARTS_WITH(pszSymbolId, "mapinfo-custom-sym-"))
         {
             result = TABFCCustomPoint;
-		}
-	}
+        }
+    }
 
     delete poStyleMgr;
     delete poStylePart;

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1802,7 +1802,7 @@ const char* TABCustomPoint::GetSymbolStyleString(double dfAngle) const
 
     for(i=0; i < 7 && *pszPtr != '\0' && *pszPtr != ' '; i++, pszPtr++)
     {
-        szLowerExt[i] = (char)tolower(*pszPtr);
+        szLowerExt[i] = static_cast<char>(tolower(*pszPtr));
     }
     szLowerExt[i] = '\0';
 

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1563,6 +1563,11 @@ const char *TABFontPoint::GetStyleString() const
     return m_pszStyleString;
 }
 
+/**********************************************************************
+ *                   TABFontPoint::SetSymbolFromStyle()
+ *
+ *  Set all Symbol var from a OGRStyleSymbol.
+ **********************************************************************/
 void TABFontPoint::SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle)
 {
     ITABFeatureSymbol::SetSymbolFromStyle(poSymbolStyle);
@@ -1772,6 +1777,80 @@ int TABCustomPoint::WriteGeometryToMAPFile(TABMAPFile *poMapFile,
         return -1;
 
     return 0;
+}
+
+/**********************************************************************
+ *                   TABCustomPoint::GetSymbolStyleString()
+ *
+ *  Return a Symbol() string. All representations info for the Symbol are here.
+ **********************************************************************/
+const char* TABCustomPoint::GetSymbolStyleString(double dfAngle) const
+{
+    /* Get the SymbolStyleString, and add the color if m_nCustomStyle contains "apply color". */
+    const char *color = nullptr;
+    if (m_nCustomStyle & 0x02)
+        color = CPLSPrintf(",c:#%6.6x", m_sSymbolDef.rgbColor);
+    else
+        color = "";
+
+    int         nAngle = static_cast<int>(dfAngle);
+    const char* pszStyle;
+	const char* pszExt = CPLGetExtension(GetSymbolNameRef());
+	char 		szLowerExt[8] = "";
+	const char*	pszPtr = pszExt;
+	int			i;
+
+	for(i=0; i < 7 && *pszPtr != '\0' && *pszPtr != ' '; i++, pszPtr++)
+	{
+		szLowerExt[i] = (char)tolower(*pszPtr);
+	}
+	szLowerExt[i] = '\0';
+
+    pszStyle=CPLSPrintf("SYMBOL(a:%d%s,s:%dpt,id:\"mapinfo-custom-sym-%d-%s,%s-%s,ogr-sym-9\")",
+                        nAngle,
+						color,
+                        m_sSymbolDef.nPointSize,
+						m_nCustomStyle,
+						GetSymbolNameRef(),
+						szLowerExt,
+                        GetSymbolNameRef());
+    return pszStyle;
+}
+
+/**********************************************************************
+ *                   TABCustomPoint::SetSymbolFromStyle()
+ *
+ *  Set all Symbol var from a OGRStyleSymbol.
+ **********************************************************************/
+void TABCustomPoint::SetSymbolFromStyle(OGRStyleSymbol* poSymbolStyle)
+{
+   ITABFeatureSymbol::SetSymbolFromStyle(poSymbolStyle);
+
+    GBool bIsNull = 0;
+
+    // Try to set font glyph number
+    const char* pszSymbolId = poSymbolStyle->Id(bIsNull);
+    if((!bIsNull) && pszSymbolId && STARTS_WITH(pszSymbolId, "mapinfo-custom-sym-"))
+    {
+        const int nSymbolStyle = atoi(pszSymbolId+19);
+        SetCustomSymbolStyle(static_cast<GByte>(nSymbolStyle));
+		
+		const char* pszPtr = pszSymbolId+19;
+		while (*pszPtr != '-') 
+		{
+			pszPtr++;
+		}
+		pszPtr++;
+		
+		char 		szSymbolName[256] = "";
+		int			i;
+		for(i=0; i < 255 && *pszPtr != '\0' && *pszPtr != ',' && *pszPtr != '"'; i++, pszPtr++)
+		{
+			szSymbolName[i] = *pszPtr;
+		}
+		szSymbolName[i] = '\0';		
+		SetSymbolName(szSymbolName);
+    }
 }
 
 /**********************************************************************
@@ -9043,6 +9122,76 @@ void ITABFeatureSymbol::SetSymbolFromStyleString(const char *pszStyleString)
     delete poStylePart;
 
     return;
+}
+
+/**********************************************************************
+ *                   ITABFeatureSymbol::GetSymbolFeatureClass()
+ *
+ *  Return the feature class needed to represent the style string.
+ **********************************************************************/
+TABFeatureClass ITABFeatureSymbol::GetSymbolFeatureClass(const char *pszStyleString)
+{
+    // Use the Style Manager to retrieve all the information we need.
+    OGRStyleMgr *poStyleMgr = new OGRStyleMgr(nullptr);
+    OGRStyleTool *poStylePart = nullptr;
+
+    // Init the StyleMgr with the StyleString.
+    poStyleMgr->InitStyleString(pszStyleString);
+
+    // Retrieve the Symbol info.
+    const int numParts = poStyleMgr->GetPartCount();
+    for( int i = 0; i < numParts; i++ )
+    {
+        poStylePart = poStyleMgr->GetPart(i);
+        if( poStylePart == nullptr )
+		{
+            continue;
+		}
+
+        if(poStylePart->GetType() == OGRSTCSymbol)
+        {
+            break;
+        }
+        else
+        {
+            delete poStylePart;
+            poStylePart = nullptr;
+        }
+    }
+	
+	TABFeatureClass result = TABFCPoint;
+
+    // If the no Symbol found, do nothing.
+    if(poStylePart == nullptr)
+    {
+        delete poStyleMgr;
+        return result;
+    }
+
+    OGRStyleSymbol *poSymbolStyle = cpl::down_cast<OGRStyleSymbol*>(poStylePart);
+
+    GBool bIsNull = 0;
+
+    // Set the Symbol Id (SymbolNo)
+    const char *pszSymbolId = poSymbolStyle->Id(bIsNull);
+    if(bIsNull) pszSymbolId = nullptr;
+
+    if(pszSymbolId)
+    {
+        if(STARTS_WITH(pszSymbolId, "font-sym-"))
+        {
+            result = TABFCFontPoint;
+		}
+        else if(STARTS_WITH(pszSymbolId, "mapinfo-custom-sym-"))
+        {
+            result = TABFCCustomPoint;
+		}
+	}
+
+    delete poStyleMgr;
+    delete poStylePart;
+
+    return result;
 }
 
 /**********************************************************************

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -259,27 +259,27 @@ TABFeature* IMapInfoFile::CreateTABFeature(OGRFeature *poFeature)
       case wkbPoint:
         if(poFeature->GetStyleString())
         {
-			TABFeatureClass featureClass = ITABFeatureSymbol::GetSymbolFeatureClass(poFeature->GetStyleString());
-			if (featureClass == TABFCFontPoint) 
-			{
-				poTABFeature = new TABFontPoint(poFeature->GetDefnRef());
-			}
-			else if (featureClass == TABFCCustomPoint) 
-			{
-				poTABFeature = new TABCustomPoint(poFeature->GetDefnRef());
-			}
-			else 
-			{
-				poTABFeature = new TABPoint(poFeature->GetDefnRef());
-			}
+            TABFeatureClass featureClass = ITABFeatureSymbol::GetSymbolFeatureClass(poFeature->GetStyleString());
+            if (featureClass == TABFCFontPoint) 
+            {
+                poTABFeature = new TABFontPoint(poFeature->GetDefnRef());
+            }
+            else if (featureClass == TABFCCustomPoint) 
+            {
+                poTABFeature = new TABCustomPoint(poFeature->GetDefnRef());
+            }
+            else 
+            {
+                poTABFeature = new TABPoint(poFeature->GetDefnRef());
+            }
             poTABPointFeature = cpl::down_cast<TABPoint*>(poTABFeature);
             poTABPointFeature->SetSymbolFromStyleString(
                 poFeature->GetStyleString());
         }
         else 
-		{
-			poTABFeature = new TABPoint(poFeature->GetDefnRef());	
-		}        
+        {
+            poTABFeature = new TABPoint(poFeature->GetDefnRef());
+        }        
         break;
       /*-------------------------------------------------------------
        * REGION

--- a/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/gdal/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -257,13 +257,29 @@ TABFeature* IMapInfoFile::CreateTABFeature(OGRFeature *poFeature)
        * POINT
        *------------------------------------------------------------*/
       case wkbPoint:
-        poTABFeature = new TABPoint(poFeature->GetDefnRef());
         if(poFeature->GetStyleString())
         {
+			TABFeatureClass featureClass = ITABFeatureSymbol::GetSymbolFeatureClass(poFeature->GetStyleString());
+			if (featureClass == TABFCFontPoint) 
+			{
+				poTABFeature = new TABFontPoint(poFeature->GetDefnRef());
+			}
+			else if (featureClass == TABFCCustomPoint) 
+			{
+				poTABFeature = new TABCustomPoint(poFeature->GetDefnRef());
+			}
+			else 
+			{
+				poTABFeature = new TABPoint(poFeature->GetDefnRef());
+			}
             poTABPointFeature = cpl::down_cast<TABPoint*>(poTABFeature);
             poTABPointFeature->SetSymbolFromStyleString(
                 poFeature->GetStyleString());
         }
+        else 
+		{
+			poTABFeature = new TABPoint(poFeature->GetDefnRef());	
+		}        
         break;
       /*-------------------------------------------------------------
        * REGION


### PR DESCRIPTION
Make sure the correct type of point object is created depending on the type of symbol used. Also map MapInfo's custom symbol styles to OGR symbol styles. The symbol id is set to "mapinfo-custom-sym-[CUSTOM_STYLE]-[FILENAME]" with a fallback id on the form "[FILE_EXTENSION]-[FILENAME]" and finally "ogr-sym-9".