### PR TITLE
NITF: Add support for SNIP TREs, CSRLSB and CSWRPB

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -3175,6 +3175,103 @@ def test_nitf_87():
 """
     assert data == expected_data
 
+###############################################################################
+# Test parsing CSWRPB TRE (STDI-0002-1-v5.0 App AH)
+
+def test_nitf_88():
+    tre_data = "TRE=CSWRPB=1F199.9999999900000010000002000000300000040000005000000600000070000008" \
+               "1111-9.99999999999999E-99+9.99999999999999E+9900000"
+               
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_88.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_88.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_88.ntf')
+
+    expected_data = """<tres>
+  <tre name="CSWRPB" location="image">
+    <field name="NUM_SETS_WARP_DATA" value="1" />
+    <field name="SENSOR_TYPE" value="F" />
+    <field name="WRP_INTERP" value="1" />
+    <repeated number="1">
+      <group index="0">
+        <field name="FL_WARP" value="99.99999999" />
+        <field name="OFFSET_LINE" value="0000001" />
+        <field name="OFFSET_SAMP" value="0000002" />
+        <field name="SCALE_LINE" value="0000003" />
+        <field name="SCALE_SAMP" value="0000004" />
+        <field name="OFFSET_LINE_UNWRP" value="0000005" />
+        <field name="OFFSET_SAMP_UNWRP" value="0000006" />
+        <field name="SCALE_LINE_UNWRP" value="0000007" />
+        <field name="SCALE_SAMP_UNWRP" value="0000008" />
+        <field name="LINE_POLY_ORDER_M1" value="1" />
+        <field name="LINE_POLY_ORDER_M2" value="1" />
+        <field name="SAMP_POLY_ORDER_N1" value="1" />
+        <field name="SAMP_POLY_ORDER_N2" value="1" />
+        <repeated number="1">
+          <group index="0">
+            <repeated number="1">
+              <group index="0">
+                <field name="A" value="-9.99999999999999E-99" />
+              </group>
+            </repeated>
+          </group>
+        </repeated>
+        <repeated number="1">
+          <group index="0">
+            <repeated number="1">
+              <group index="0">
+                <field name="B" value="+9.99999999999999E+99" />
+              </group>
+            </repeated>
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+    <field name="RESERVED_LEN" value="00000" />
+  </tre>
+</tres>
+"""
+    assert data == expected_data
+
+###############################################################################
+# Test parsing CSRLSB TRE (STDI-0002-1-v5.0 App AH)
+
+def test_nitf_89():
+    tre_data = "TRE=CSRLSB=0101+11111111.11-22222222.22+33333333.33-44444444.44"
+               
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_89.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_89.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_89.ntf')
+
+    expected_data = """<tres>
+  <tre name="CSRLSB" location="image">
+    <field name="N_RS_ROW_BLOCKS" value="01" />
+    <field name="M_RS_COLUMN_BLOCKS" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <repeated number="1">
+          <group index="0">
+            <field name="RS_DT_1" value="+11111111.11" />
+            <field name="RS_DT_2" value="-22222222.22" />
+            <field name="RS_DT_3" value="+33333333.33" />
+            <field name="RS_DT_4" value="-44444444.44" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+    assert data == expected_data
 
 ###############################################################################
 # Test reading C4 compressed file

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -517,6 +517,20 @@
         <field name="BWC" length="12"/>
     </tre>
 
+    <!-- STDI-0002-1-v5.0 Appendix AH, Section AH.6.2, Table AH.6-2 -->
+    <tre name="CSRLSB" md_prefix="NITF_CSRLSB_" location="image">
+        <field name="N_RS_ROW_BLOCKS" length="2" type="integer" minval="1" maxval="99"/>
+        <field name="M_RS_COLUMN_BLOCKS" length="2" type="integer" minval="1" maxval="99"/>
+        <loop counter="N_RS_ROW_BLOCKS" md_prefix="ROWBLOCK_%02d_">
+            <loop counter="M_RS_COLUMN_BLOCKS" md_prefix="COLBLOCK_%02d_">
+                <field name="RS_DT_1" length="12" type="real"/>
+                <field name="RS_DT_2" length="12" type="real"/>
+                <field name="RS_DT_3" length="12" type="real"/>
+                <field name="RS_DT_4" length="12" type="real"/>
+            </loop>
+        </loop>
+    </tre>
+
     <tre name="CSSFAA" minlength="107" maxlength="425" location="image">
         <field name="NUM_BANDS" length="1"/>
         <loop counter="NUM_BANDS" md_prefix="BAND_%d_" name="BAND">
@@ -534,6 +548,46 @@
             <field name="FINISH_X" length="11"/>
             <field name="FINISH_Y" length="11"/>
         </loop>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix AH, Section AH.6.3, Table AH.6-3 -->
+    <tre name="CSWRPB" md_prefix="NITF_CSWRPB_" location="image">
+        <field name="NUM_SETS_WARP_DATA" length="1" type="integer" minval="1" maxval="9"/>
+        <field name="SENSOR_TYPE" length="1" type="string"/>
+        <if cond="SENSOR_TYPE=F">
+            <field name="WRP_INTERP" length="1" type="integer" minval="0" maxval="1"/>
+        </if>
+        <loop counter="NUM_SETS_WARP_DATA" md_prefix="WARP_DATA_SET_%01d_">
+            <if cond="SENSOR_TYPE=F">
+                <field name="FL_WARP" length="11" type="real" minval="0" maxval="99.99999999"/>
+            </if>
+            <field name="OFFSET_LINE" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="OFFSET_SAMP" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="SCALE_LINE" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="SCALE_SAMP" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="OFFSET_LINE_UNWRP" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="OFFSET_SAMP_UNWRP" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="SCALE_LINE_UNWRP" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="SCALE_SAMP_UNWRP" length="7" type="integer" minval="1" maxval="9999999"/>
+            <field name="LINE_POLY_ORDER_M1" length="1" type="integer"/>
+            <field name="LINE_POLY_ORDER_M2" length="1" type="integer"/>
+            <field name="SAMP_POLY_ORDER_N1" length="1" type="integer"/>
+            <field name="SAMP_POLY_ORDER_N2" length="1" type="integer"/>
+            <loop counter="LINE_POLY_ORDER_M2" md_prefix="M2_%01d_">
+                <loop counter="LINE_POLY_ORDER_M1" md_prefix="M1_%01d_">
+                    <field name="A" length="21" type="real"/>
+                </loop>
+            </loop>
+            <loop counter="SAMP_POLY_ORDER_N2" md_prefix="N2_%01d_">
+                <loop counter="SAMP_POLY_ORDER_N1" md_prefix="N1_%01d_">
+                    <field name="B" length="21" type="real"/>
+                </loop>
+            </loop>
+        </loop>
+        <field name="RESERVED_LEN" length="5" type="integer"/>
+        <if cond="RESERVED_LEN!=00000">
+            <field name="RESERVED" length_var="RESERVED_LEN" type="string"/>
+        </if>
     </tre>
 
     <!-- STDI-0002 Appendix N -->


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds the capability to read the CSRLSB and CSWRPB TREs, defined in the Spectral NITF Implementation Profile
The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
CSRLSB and CSWRPB are defined in STDI-0002-1-v5.0 Appendix AH.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/3071
https://github.com/OSGeo/gdal/pull/3058

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
