### PR TITLE
MRF: Restore raw Lerc1 detection

### DIFF
--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -362,6 +362,27 @@ def test_mrf_lerc_with_huffman():
     gdal.Unlink('/vsimem/out.lrc')
     gdal.Unlink('/vsimem/out.til')
 
+def test_raw_lerc():
+    if 'LERC' not in gdal.GetDriverByName('MRF').GetMetadataItem('DMD_CREATIONOPTIONLIST'):
+        pytest.skip()
+
+    # Defaults to LERC2
+    for opt in 'OPTIONS=V1:1', None:
+        co = ['COMPRESS=LERC']
+        if opt:
+            co.append(opt)
+        gdal.Translate('/vsimem/out.mrf', 'data/byte.tif', format='MRF',
+                        creationOptions = co)
+        ds = gdal.Open('/vsimem/out.lrc')
+        with gdaltest.error_handler():
+            cs = ds.GetRasterBand(1).Checksum()
+        expected_cs = 4819
+        assert cs == expected_cs
+        ds = None
+        gdal.Unlink('/vsimem/out.mrf')
+        gdal.Unlink('/vsimem/out.mrf.aux.xml')
+        gdal.Unlink('/vsimem/out.idx')
+        gdal.Unlink('/vsimem/out.lrc')
 
 def test_mrf_cached_source():
 

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
@@ -402,6 +402,9 @@ bool Lerc1Image::write(Byte** ppByte, double maxZError, bool zPart) const
 #undef WRVAR
 }
 
+// To avoid excessive memory allocation attempts, this is still 1.8GB!!
+static size_t TOO_LARGE = 1800 * 1000 * 1000 / static_cast<int>(sizeof(float));
+
 bool Lerc1Image::read(Byte** ppByte, size_t& nRemainingBytes,
     double maxZError, bool ZPart)
 {
@@ -434,8 +437,7 @@ bool Lerc1Image::read(Byte** ppByte, size_t& nRemainingBytes,
         return false;
     if (width <= 0 || width > 20000 || height <= 0 || height > 20000 || maxZErrorInFile > maxZError)
         return false;
-    // To avoid excessive memory allocation attempts, this is still 1.8GB!!
-    if (width * height > 1800 * 1000 * 1000 / static_cast<int>(sizeof(float)))
+    if (static_cast<size_t>(width) * height > TOO_LARGE)
         return false;
 
     if (ZPart) {
@@ -482,6 +484,42 @@ bool Lerc1Image::read(Byte** ppByte, size_t& nRemainingBytes,
         nRemainingBytes -= numBytes;
         ZPart = !ZPart;
     } while (ZPart); // Stop after writing Z
+    return true;
+}
+
+// Initialize from the given header, return true if it worked
+// It could read more info from the header, if needed
+bool Lerc1Image::getwh(const Byte* pByte, size_t nBytes, int &width, int &height)
+{
+    size_t len = sCntZImage.length();
+    if (nBytes < len)
+        return false;
+
+    std::string typeStr(reinterpret_cast<const char*>(pByte), len);
+    if (typeStr != sCntZImage)
+        return false;
+    pByte += len;
+    nBytes -= len;
+
+    int version = 0, type = 0;
+    double maxZErrorInFile = 0;
+
+    if (nBytes < (4 * sizeof(int) + sizeof(double)))
+        return false;
+    RDVAR(pByte, version);
+    RDVAR(pByte, type);
+    RDVAR(pByte, height);
+    RDVAR(pByte, width);
+    RDVAR(pByte, maxZErrorInFile);
+    nBytes -= 4 * sizeof(int) + sizeof(double);
+
+    if (version != CNT_Z_VER || type != CNT_Z)
+        return false;
+    if (width <= 0 || width > 20000 || height <= 0 || height > 20000)
+        return false;
+    if (static_cast<size_t>(width) * height > TOO_LARGE)
+        return false;
+
     return true;
 #undef RDVAR
 }

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp
@@ -511,7 +511,6 @@ bool Lerc1Image::getwh(const Byte* pByte, size_t nBytes, int &width, int &height
     RDVAR(pByte, height);
     RDVAR(pByte, width);
     RDVAR(pByte, maxZErrorInFile);
-    nBytes -= 4 * sizeof(int) + sizeof(double);
 
     if (version != CNT_Z_VER || type != CNT_Z)
         return false;

--- a/gdal/frmts/mrf/LERCV1/Lerc1Image.h
+++ b/gdal/frmts/mrf/LERCV1/Lerc1Image.h
@@ -148,6 +148,9 @@ public:
 
     static unsigned int computeNumBytesNeededToWriteVoidImage();
 
+    // Only initialize the size from the header, if LERC1
+    static bool getwh(const Byte* ppByte, size_t nBytes, int& w, int& h);
+
     bool resize(int width, int height) {
         setsize(width, height);
         mask.resize(getWidth(), getHeight());
@@ -161,6 +164,7 @@ public:
     // Read and write into a memory buffer
     bool write(Byte** ppByte, double maxZError = 0, bool onlyZPart = false) const;
     bool read(Byte** ppByte, size_t& nRemainingBytes, double maxZError, bool onlyZPart = false);
+
 
     BitMaskV1 mask;
 };

--- a/gdal/frmts/mrf/LERCV1/makefile.vc
+++ b/gdal/frmts/mrf/LERCV1/makefile.vc
@@ -7,8 +7,6 @@ HEADERS = Lerc1Image.h
 
 LERCV1 = LERCV1.obj
 
-GDAL_ROOT	=	..\..\..
-
 EXTRAFLAGS      = -DLERC
 
 default:    $(LERCV1)


### PR DESCRIPTION
Add function to read size from tile

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes raw LERC1 detection/read via MRF, it was broken by previous commits

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
