### PR TITLE
NITF: Add SNIP TREs - SECURA and SNSPSB

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -3271,6 +3271,112 @@ def test_nitf_89():
   </tre>
 </tres>
 """
+
+    assert data == expected_data
+
+###############################################################################
+# Test parsing SECURA TRE (STDI-0002-1-v5.0 App AI)
+
+def test_nitf_90():
+    tre_data = "FILE_TRE=SECURA=20201020142500NITF02.10" + " "*207 + "ARH.XML         00068" + \
+               "<?xml version=\"1.0\" encoding=\"UTF-8\"?> <arh:Security></arh:Security>"
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_90.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_90.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_90.ntf')
+
+    expected_data = """<tres>
+  <tre name="SECURA" location="file">
+    <field name="FDATTIM" value="20201020142500" />
+    <field name="NITFVER" value="NITF02.10" />
+    <field name="NFSECFLDS" value="" />
+    <field name="SECSTD" value="ARH.XML" />
+    <field name="SECCOMP" value="" />
+    <field name="SECLEN" value="00068" />
+    <field name="SECURITY" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt; &lt;arh:Security&gt;&lt;/arh:Security&gt;" />
+  </tre>
+</tres>
+"""
+
+    assert data == expected_data
+
+###############################################################################
+# Test parsing SNSPSB TRE (STDI-0002-1-v5.0 App P)
+
+def test_nitf_91():
+    tre_data = "TRE=SNSPSB=010001111112222233333M  000001000001000001000001GSL         " + \
+               "PLTFM   INS     MOD PRL  SID       ACT               DEG0000001      +111111.11-222222.22" + \
+               "         meters 000000000000000000000011111111111111111111112222222222222222222222001" + \
+               "API                 Imeters 0123456789"
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_91.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_91.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_91.ntf')
+
+    expected_data = """<tres>
+  <tre name="SNSPSB" location="image">
+    <field name="NUM_SNS" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <field name="NUM_BP" value="00" />
+        <field name="NUM_BND" value="01" />
+        <repeated number="1">
+          <group index="0">
+            <field name="BID" value="11111" />
+            <field name="WS1" value="22222" />
+            <field name="WS2" value="33333" />
+          </group>
+        </repeated>
+        <field name="UNIRES" value="M" />
+        <field name="REX" value="000001" />
+        <field name="REY" value="000001" />
+        <field name="GSX" value="000001" />
+        <field name="GSY" value="000001" />
+        <field name="GSL" value="GSL" />
+        <field name="PLTFM" value="PLTFM" />
+        <field name="INS" value="INS" />
+        <field name="MOD" value="MOD" />
+        <field name="PRL" value="PRL" />
+        <field name="SID" value="SID" />
+        <field name="ACT" value="ACT" />
+        <field name="UNINOA" value="DEG" />
+        <field name="NOA" value="0000001" />
+        <field name="UNIANG" value="" />
+        <field name="UNIALT" value="" />
+        <field name="LONSCC" value="+111111.11" />
+        <field name="LATSCC" value="-222222.22" />
+        <field name="UNISAE" value="" />
+        <field name="UNIRPY" value="" />
+        <field name="UNIPXT" value="" />
+        <field name="UNISPE" value="meters" />
+        <field name="ROS" value="0000000000000000000000" />
+        <field name="PIS" value="1111111111111111111111" />
+        <field name="YAS" value="2222222222222222222222" />
+        <field name="NUM_AUX" value="001" />
+        <repeated number="1">
+          <group index="0">
+            <field name="API" value="API" />
+            <field name="APF" value="I" />
+            <field name="UNIAPX" value="meters" />
+            <field name="APN" value="0123456789" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+
     assert data == expected_data
 
 ###############################################################################

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -1717,6 +1717,17 @@
         <field name="CSSIZ" length="21" type="real"/>
     </tre>
 
+    <!-- STDI-0002-1-v5.0 Appendix AI, Section AI.4, Table AI-1 -->
+    <tre name="SECURA" md_prefix="NITF_SECURA_" location="file" minlength="251" maxlength="99988">
+        <field name="FDATTIM" length="14" type="string"/>
+        <field name="NITFVER" length="9" type="string"/>
+        <field name="NFSECFLDS" length="207" type="string"/>
+        <field name="SECSTD" length="8" type="string"/>
+        <field name="SECCOMP" length="8" type="string"/>
+        <field name="SECLEN" length="5" type="integer"/>
+        <field name="SECURITY" length_var="SECLEN" type="string"/>
+    </tre>
+
     <tre name="SENSRB" location="image">
         <field name="GENERAL_DATA" length="1" type="string"/>
         <if cond="GENERAL_DATA=Y">
@@ -2069,6 +2080,89 @@
             <field name="PARAMETER_COUNT_MMM" length="4" type="integer"/>
             <loop counter="PARAMETER_COUNT_MMM" name="ADDITIONAL_PARAMETER_VALUES" md_prefix="PARAMETER_VALUE_%04d">
                 <field name="PARAMETER_VALUE_NNNN" length_var="PARAMETER_SIZE_MMM" type="string"/>
+            </loop>
+        </loop>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix P, Section P.3.2.7.2, Table P-13 -->
+    <tre name="SNSPSB" md_prefix="NITF_SNSPSB_" location="image" minlength="161" maxlength="99985">
+        <field name="NUM_SNS" length="2" type="integer"/>
+        <loop counter="NUM_SNS" md_prefix="SNS_%02d_">
+            <field name="NUM_BP" length="2" type="integer"/>
+            <loop counter="NUM_BP" md_prefix="BP_%02d_">
+                <field name="NUM_PTS" length="3" type="integer"/>
+                <loop counter="NUM_PTS" md_prefix="PT_%03d_">
+                    <field name="LON" length="15" type="real"/>
+                    <field name="LAT" length="15" type="real"/>
+                </loop>
+            </loop>
+            <field name="NUM_BND" length="2" type="integer"/>
+            <loop counter="NUM_BND" md_prefix="BND_%02d_">
+                <field name="BID" length="5" type="string"/>
+                <field name="WS1" length="5" type="integer"/>
+                <field name="WS2" length="5" type="integer"/>
+            </loop>
+            <field name="UNIRES" length="3" type="string"/>
+            <field name="REX" length="6" type="real"/>
+            <field name="REY" length="6" type="real"/>
+            <field name="GSX" length="6" type="real"/>
+            <field name="GSY" length="6" type="real"/>
+            <field name="GSL" length="12" type="string"/>
+            <field name="PLTFM" length="8" type="string"/>
+            <field name="INS" length="8" type="string"/>
+            <field name="MOD" length="4" type="string"/>
+            <field name="PRL" length="5" type="string"/>
+            <field name="SID" length="10" type="string"/>
+            <field name="ACT" length="18" type="string"/>
+            <field name="UNINOA" length="3" type="string"/>
+            <if cond="UNINOA!=">
+                <field name="NOA" length="7" type="real"/>
+            </if>
+            <field name="UNIANG" length="3" type="string"/>
+            <if cond="UNIANG!=">
+                <field name="ANG" length="7" type="real"/>
+            </if>
+            <field name="UNIALT" length="3" type="string"/>
+            <if cond="UNIALT!=">
+                <field name="ALT" length="9" type="real"/>
+            </if>
+            <field name="LONSCC" length="10" type="real"/>
+            <field name="LATSCC" length="10" type="real"/>
+            <field name="UNISAE" length="3" type="string"/>
+            <if cond="UNISAE!=">
+                <field name="SAZ" length="7" type="real"/>
+                <field name="SEL" length="7" type="real"/>
+            </if>
+            <field name="UNIRPY" length="3" type="string"/>
+            <if cond="UNIRPY!=">
+                <field name="ROL" length="7" type="real"/>
+                <field name="PIT" length="7" type="real"/>
+                <field name="YAW" length="7" type="real"/>
+            </if>
+            <field name="UNIPXT" length="3" type="string"/>
+            <if cond="UNIPXT!=">
+                <field name="PXT" length="14" type="real"/>
+            </if>
+            <field name="UNISPE" length="7" type="string"/>
+            <if cond="UNISPE!=">
+                <field name="ROS" length="22" type="real"/>
+                <field name="PIS" length="22" type="real"/>
+                <field name="YAS" length="22" type="real"/>
+            </if>
+            <field name="NUM_AUX" length="3" type="integer"/>
+            <loop counter="NUM_AUX" md_prefix="AUX_%03d_">
+                <field name="API" length="20" type="string"/>
+                <field name="APF" length="1" type="string"/>
+                <field name="UNIAPX" length="7" type="string"/>
+                <if cond="APF=I">
+                    <field name="APN" length="10" type="integer"/>
+                </if>
+                <if cond="APF=R">
+                    <field name="APR" length="20" type="real"/>
+                </if>
+                <if cond="APF=A">
+                    <field name="APA" length="20" type="string"/>
+                </if>
             </loop>
         </loop>
     </tre>


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds the capability to read the SECURA and SNSPSB TREs, defined in the Spectral NITF Implementation Profile
The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
SECURA is defined in STDI-0002-1-v5.0 Appendix AI.
SNSPSB is defined in STDI-0002-1-v5.0 Appendix P.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/3090

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
