### PR TITLE
Fits adjustments

### DIFF
--- a/autotest/gdrivers/fits.py
+++ b/autotest/gdrivers/fits.py
@@ -224,6 +224,7 @@ def test_fits_open_raster_only_in_vector_mode():
     assert os.path.exists(filename)
     with gdaltest.error_handler():
         assert ogr.Open(filename) is None
+    assert 'but contains image' in gdal.GetLastErrorMsg()
 
     filename = 'data/fits/image_in_first_and_second_hdu.fits'
     assert os.path.exists(filename)
@@ -241,7 +242,7 @@ def test_fits_open_vector_only_in_raster_mode():
     assert os.path.exists(filename)
     with gdaltest.error_handler():
         assert gdal.Open(filename) is None
-
+    assert 'but contains binary table' in gdal.GetLastErrorMsg()
 
 # Test opening with gdal.OF_RASTER | gdal.OF_VECTOR
 def test_fits_open_mix_mode():

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -28,6 +28,7 @@
 ###############################################################################
 
 import os
+import struct
 import sys
 
 
@@ -714,6 +715,31 @@ def test_ogr_basic_field_alternative_name():
     field_defn.SetAlternativeName('my alias')
     assert field_defn.GetAlternativeName() == 'my alias'
 
+
+def test_ogr_basic_float32_formatting():
+
+    def cast_as_float(x):
+        return struct.unpack('f', struct.pack('f', x))[0]
+
+    feat_defn = ogr.FeatureDefn('test')
+    fldn_defn = ogr.FieldDefn('float32', ogr.OFTReal)
+    fldn_defn.SetSubType(ogr.OFSTFloat32)
+    feat_defn.AddFieldDefn(fldn_defn)
+
+    f = ogr.Feature(feat_defn)
+    for x in ('0.35', '0.15', '123.0', '0.12345678', '1.2345678e-15'):
+        f['float32'] = cast_as_float(float(x))
+        assert f.GetFieldAsString('float32').replace('e+0', 'e+').replace('e-0', 'e-') == x
+
+
+    feat_defn = ogr.FeatureDefn('test')
+    fldn_defn = ogr.FieldDefn('float32_list', ogr.OFTRealList)
+    fldn_defn.SetSubType(ogr.OFSTFloat32)
+    feat_defn.AddFieldDefn(fldn_defn)
+
+    f = ogr.Feature(feat_defn)
+    f['float32_list'] = [ cast_as_float(0.35) ]
+    assert f.GetFieldAsString('float32_list') == '(1:0.35)'
 
 ###############################################################################
 # cleanup

--- a/gdal/ogr/ogr_p.h
+++ b/gdal/ogr/ogr_p.h
@@ -97,6 +97,9 @@ void OGRFormatDouble( char *pszBuffer, int nBufferLen, double dfVal,
                       char chDecimalSep, int nPrecision = 15, char chConversionSpecifier = 'f' );
 std::string OGRFormatDouble(double val, const OGRWktOptions& opts);
 
+int OGRFormatFloat(char *pszBuffer, int nBufferLen, float fVal,
+                   int nPrecision, char chConversionSpecifier);
+
 /* -------------------------------------------------------------------- */
 /*      Date-time parsing and processing functions                      */
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
- FITS: display more informative error message when opening raster dataset in vector mode, or vice-verca
- OGRFeature::GetFieldAsString() and GeoJSON output: do not output Float32 with excessive precision

Funded by CNES