### PR TITLE
refactor python scripts and add osgeo.auxilary package

### DIFF
--- a/autotest/pymod/xmlvalidate.py
+++ b/autotest/pymod/xmlvalidate.py
@@ -458,18 +458,22 @@ def has_local_inspire_schemas(path):
     except OSError:
         return False
 
-###############################################################################
-# Usage function
-
 
 def Usage():
-    print('Usage: validate.py [-target_dir dir] [-download_ogc_schemas] [-ogc_schemas_location path]')
-    print('                   [-download_inspire_schemas] [-inspire_schemas_location path]')
-    print('                   [-app_schema_ns ns] [-schema some.xsd]')
-    print('                   some.xml')
-    sys.exit(255)
-
-###############################################################################
-# Main
+    print('Usage: xmlvalidate.py [-target_dir dir] [-download_ogc_schemas] [-ogc_schemas_location path]')
+    print('                      [-download_inspire_schemas] [-inspire_schemas_location path]')
+    print('                      [-app_schema_ns ns] [-schema some.xsd]')
+    print('                      some.xml')
+    return 255
 
 
+def main(argv):
+    if len(argv) < 2:
+        return Usage()
+    else:
+        print('command line usage is not implemented yet')
+        return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/gdal/swig/python/osgeo/auxiliary/base.py
+++ b/gdal/swig/python/osgeo/auxiliary/base.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL sctipts
+#  Purpose:  useful utility functions for this package
+#  Author:   Even Rouault <even.rouault at spatialys.com>
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2015, Even Rouault <even.rouault at spatialys.com>
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+from osgeo import gdal
+import os.path
+# from pathlib import Path
+# from typing import Sequence, Union
+
+
+def is_path_like(s):
+    # when GDAL drops Python2 support we can support from pathlib import Path, for now it's just str.
+    # return isinstance(s, (str, Path))
+    return isinstance(s, str)
+
+
+def get_suffix(filename):
+    # return Path(filename).suffix
+    return os.path.splitext(filename)[1]
+
+
+def is_sequence(f):
+    # return isinstance(f, Sequence):
+    return isinstance(f, (list, tuple))
+
+
+def to_number(s):
+    try:
+        return int(s)
+    except ValueError:
+        return float(s)
+
+
+def get_byte(number, i):
+    return (number & (0xff << (i * 8))) >> (i * 8)
+
+
+def path_join(*args):
+    return os.path.join(*(str(arg) for arg in args))
+
+
+def DoesDriverHandleExtension(drv, ext):
+    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
+    return exts is not None and exts.lower().find(ext.lower()) >= 0
+
+
+def GetExtension(filename):
+    if filename.lower().endswith('.shp.zip'):
+        return 'shp.zip'
+    ext = os.path.splitext(filename)[1]
+    if ext.startswith('.'):
+        ext = ext[1:]
+    return ext
+
+
+def GetOutputDriversFor(filename, is_raster=True):
+    drv_list = []
+    ext = GetExtension(filename)
+    if ext.lower() == 'vrt':
+        return ['VRT']
+    for i in range(gdal.GetDriverCount()):
+        drv = gdal.GetDriver(i)
+        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
+            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
+           drv.GetMetadataItem(gdal.DCAP_RASTER if is_raster else gdal.DCAP_VECTOR) is not None:
+            if ext and DoesDriverHandleExtension(drv, ext):
+                drv_list.append(drv.ShortName)
+            else:
+                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
+                if prefix is not None and filename.lower().startswith(prefix.lower()):
+                    drv_list.append(drv.ShortName)
+
+    # GMT is registered before netCDF for opening reasons, but we want
+    # netCDF to be used by default for output.
+    if ext.lower() == 'nc' and not drv_list and \
+       drv_list[0].upper() == 'GMT' and drv_list[1].upper() == 'NETCDF':
+        drv_list = ['NETCDF', 'GMT']
+
+    return drv_list
+
+
+def GetOutputDriverFor(filename, is_raster=True, default_raster_format='GTiff', default_vector_format='ESRI Shapefile'):
+    if not filename:
+        return 'MEM'
+    drv_list = GetOutputDriversFor(filename, is_raster)
+    ext = GetExtension(filename)
+    if not drv_list:
+        if not ext:
+            return default_raster_format if is_raster else default_vector_format
+        else:
+            raise Exception("Cannot guess driver for %s" % filename)
+    elif len(drv_list) > 1:
+        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
+    return drv_list[0]

--- a/gdal/swig/python/osgeo/utils/epsg_tr.py
+++ b/gdal/swig/python/osgeo/utils/epsg_tr.py
@@ -40,10 +40,9 @@ from osgeo import gdal
 
 
 def Usage():
-
     print('Usage: epsg_tr.py [-wkt] [-pretty_wkt] [-proj4] [-xml] [-postgis]')
     print('                  [-authority name]')
-    sys.exit(1)
+    return 1
 
 # =============================================================================
 
@@ -122,7 +121,7 @@ def main(argv):
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
 
@@ -139,10 +138,10 @@ def main(argv):
             authority = argv[i]
 
         elif arg[0] == '-':
-            Usage()
+            return Usage()
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 

--- a/gdal/swig/python/osgeo/utils/esri2wkt.py
+++ b/gdal/swig/python/osgeo/utils/esri2wkt.py
@@ -36,7 +36,7 @@ from osgeo import osr
 def main(argv):
     if len(argv) < 2:
         print('Usage: esri2wkt.py <esri .prj file>')
-        sys.exit(1)
+        return 1
 
     prj_fd = open(argv[1])
     prj_lines = prj_fd.readlines()

--- a/gdal/swig/python/osgeo/utils/gcps2vec.py
+++ b/gdal/swig/python/osgeo/utils/gcps2vec.py
@@ -37,7 +37,7 @@ from osgeo import osr
 
 def Usage():
     print('Usage: gcps2vec.py [-of <ogr_drivername>] [-p] <raster_file> <vector_file>')
-    sys.exit(1)
+    return 1
 
 
 def main(argv):
@@ -46,10 +46,9 @@ def main(argv):
     out_file = None
     pixel_out = 0
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -70,12 +69,12 @@ def main(argv):
             out_file = argv[i]
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if out_file is None:
-        Usage()
+        return Usage()
 
     # ----------------------------------------------------------------------------
     # Open input file, and fetch GCPs.
@@ -83,7 +82,7 @@ def main(argv):
     ds = gdal.Open(in_file)
     if ds is None:
         print('Unable to open %s' % in_file)
-        sys.exit(1)
+        return 1
 
     gcp_srs = ds.GetGCPProjection()
     gcps = ds.GetGCPs()
@@ -92,7 +91,7 @@ def main(argv):
 
     if gcps is None or not gcps:
         print('No GCPs on file %s!' % in_file)
-        sys.exit(1)
+        return 1
 
     # ----------------------------------------------------------------------------
     # Create output file, and layer.
@@ -101,7 +100,7 @@ def main(argv):
     drv = ogr.GetDriverByName(out_format)
     if drv is None:
         print('No driver named %s available.' % out_format)
-        sys.exit(1)
+        return 1
 
     ds = drv.CreateDataSource(out_file)
 

--- a/gdal/swig/python/osgeo/utils/gcps2wld.py
+++ b/gdal/swig/python/osgeo/utils/gcps2wld.py
@@ -39,25 +39,25 @@ from osgeo import gdal
 def main(argv):
     if len(argv) < 2:
         print("Usage: gcps2wld.py source_file")
-        sys.exit(1)
+        return 1
 
     filename = argv[1]
     dataset = gdal.Open(filename)
     if dataset is None:
         print('Unable to open %s' % filename)
-        sys.exit(1)
+        return 1
 
     gcps = dataset.GetGCPs()
 
     if gcps is None or not gcps:
         print('No GCPs found on file ' + filename)
-        sys.exit(1)
+        return 1
 
     geotransform = gdal.GCPsToGeoTransform(gcps)
 
     if geotransform is None:
         print('Unable to extract a geotransform.')
-        sys.exit(1)
+        return 1
 
     print(geotransform[1])
     print(geotransform[4])

--- a/gdal/swig/python/osgeo/utils/gdal2xyz.py
+++ b/gdal/swig/python/osgeo/utils/gdal2xyz.py
@@ -45,7 +45,7 @@ def Usage():
     print('Usage: gdal2xyz.py [-skip factor] [-srcwin xoff yoff width height]')
     print('                   [-band b] [-csv] srcfile [dstfile]')
     print('')
-    sys.exit(1)
+    return 1
 
 
 def main(argv):
@@ -56,10 +56,9 @@ def main(argv):
     band_nums = []
     delim = ' '
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -83,7 +82,7 @@ def main(argv):
             delim = ','
 
         elif arg[0] == '-':
-            Usage()
+            return Usage()
 
         elif srcfile is None:
             srcfile = arg
@@ -92,12 +91,12 @@ def main(argv):
             dstfile = arg
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if srcfile is None:
-        Usage()
+        return Usage()
 
     if band_nums == []:
         band_nums = [1]
@@ -105,14 +104,14 @@ def main(argv):
     srcds = gdal.Open(srcfile)
     if srcds is None:
         print('Could not open %s.' % srcfile)
-        sys.exit(1)
+        return 1
 
     bands = []
     for band_num in band_nums:
         band = srcds.GetRasterBand(band_num)
         if band is None:
             print('Could not get band %d' % band_num)
-            sys.exit(1)
+            return 1
         bands.append(band)
 
     gt = srcds.GetGeoTransform()

--- a/gdal/swig/python/osgeo/utils/gdal_auth.py
+++ b/gdal/swig/python/osgeo/utils/gdal_auth.py
@@ -42,10 +42,6 @@ SCOPES = {
     'storage-rw': 'https://www.googleapis.com/auth/devstorage.read_write'
 }
 
-# =============================================================================
-# 	Usage()
-# =============================================================================
-
 
 def Usage():
     print('')
@@ -59,7 +55,7 @@ def Usage():
     print('')
     print('scopes: ft/storage/storage-rw/full_url')
     print('')
-    sys.exit(1)
+    return 1
 
 
 def main(argv):
@@ -69,7 +65,7 @@ def main(argv):
 
     argv = gdal.GeneralCmdLineProcessor(sys.argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -83,12 +79,11 @@ def main(argv):
                 scope = argv[i + 1]
             else:
                 print('Scope %s not recognised.' % argv[i + 1])
-                Usage()
-                sys.exit(1)
+                return Usage()
             i = i + 1
 
         elif arg[0] == '-':
-            Usage()
+            return Usage()
 
         elif command is None:
             command = arg
@@ -97,7 +92,7 @@ def main(argv):
             token_in = arg
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
@@ -111,7 +106,7 @@ def main(argv):
     elif command == 'refresh2access':
         print(gdal.GOA2GetAccessToken(token_in, scope))
     elif command != 'interactive':
-        Usage()
+        return Usage()
     else:
         # Interactive case
         print('Authorization requested for scope:')

--- a/gdal/swig/python/osgeo/utils/gdal_fillnodata.py
+++ b/gdal/swig/python/osgeo/utils/gdal_fillnodata.py
@@ -42,12 +42,10 @@ def CopyBand(srcband, dstband):
 
 
 def Usage():
-    print("""
-gdal_fillnodata [-q] [-md max_distance] [-si smooth_iterations]
+    print("""gdal_fillnodata [-q] [-md max_distance] [-si smooth_iterations]
                 [-o name=value] [-b band]
-                srcfile [-nomask] [-mask filename] [-of format] [-co name=value]* [dstfile]
-""")
-    sys.exit(1)
+                srcfile [-nomask] [-mask filename] [-of format] [-co name=value]* [dstfile]""")
+    return 1
 
 
 def main(argv):
@@ -64,10 +62,9 @@ def main(argv):
 
     mask = 'default'
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -109,7 +106,7 @@ def main(argv):
             mask = argv[i]
 
         elif arg[:2] == '-h':
-            Usage()
+            return Usage()
 
         elif src_filename is None:
             src_filename = argv[i]
@@ -118,12 +115,12 @@ def main(argv):
             dst_filename = argv[i]
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if src_filename is None:
-        Usage()
+        return Usage()
 
     # =============================================================================
     # 	Verify we have next gen bindings with the sievefilter method.
@@ -135,7 +132,7 @@ def main(argv):
         print('gdal.FillNodata() not available.  You are likely using "old gen"')
         print('bindings or an older version of the next gen bindings.')
         print('')
-        sys.exit(1)
+        return 1
 
     # =============================================================================
     # Open source file
@@ -148,7 +145,7 @@ def main(argv):
 
     if src_ds is None:
         print('Unable to open %s' % src_filename)
-        sys.exit(1)
+        return 1
 
     srcband = src_ds.GetRasterBand(src_band)
 

--- a/gdal/swig/python/osgeo/utils/gdal_merge.py
+++ b/gdal/swig/python/osgeo/utils/gdal_merge.py
@@ -36,59 +36,11 @@ import sys
 import time
 
 from osgeo import gdal
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 progress = gdal.TermProgress_nocb
 
 __version__ = '$id$'[5:-1]
-
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_RASTER) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    # GMT is registered before netCDF for opening reasons, but we want
-    # netCDF to be used by default for output.
-    if ext.lower() == 'nc' and not drv_list and \
-       drv_list[0].upper() == 'GMT' and drv_list[1].upper() == 'NETCDF':
-        drv_list = ['NETCDF', 'GMT']
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'GTiff'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
 
 
 # =============================================================================
@@ -350,6 +302,7 @@ def Usage():
     print('                     [-ot datatype] [-createonly] input_files')
     print('                     [--help-general]')
     print('')
+    return 1
 
 
 def main(argv=None):
@@ -372,12 +325,11 @@ def main(argv=None):
     bTargetAlignedPixels = False
     start_time = time.time()
 
-    gdal.AllRegister()
     if argv is None:
         argv = argv
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -411,7 +363,7 @@ def main(argv=None):
             band_type = gdal.GetDataTypeByName(argv[i])
             if band_type == gdal.GDT_Unknown:
                 print('Unknown GDAL data type: %s' % argv[i])
-                sys.exit(1)
+                return 1
 
         elif arg == '-init':
             i = i + 1
@@ -452,8 +404,7 @@ def main(argv=None):
 
         elif arg[:1] == '-':
             print('Unrecognized command option: %s' % arg)
-            Usage()
-            sys.exit(1)
+            return Usage()
 
         else:
             names.append(arg)
@@ -462,8 +413,7 @@ def main(argv=None):
 
     if not names:
         print('No input files selected.')
-        Usage()
-        sys.exit(1)
+        return Usage()
 
     if frmt is None:
         frmt = GetOutputDriverFor(out_file)
@@ -471,12 +421,12 @@ def main(argv=None):
     Driver = gdal.GetDriverByName(frmt)
     if Driver is None:
         print('Format driver %s not found, pick a supported driver.' % frmt)
-        sys.exit(1)
+        return 1
 
     DriverMD = Driver.GetMetadata()
     if 'DCAP_CREATE' not in DriverMD:
         print('Format driver %s does not support creation and piecewise writing.\nPlease select a format that does, such as GTiff (the default) or HFA (Erdas Imagine).' % frmt)
-        sys.exit(1)
+        return 1
 
     # Collect information on all the source files.
     file_infos = names_to_fileinfos(names)
@@ -531,7 +481,7 @@ def main(argv=None):
                              band_type, create_options)
         if t_fh is None:
             print('Creation failed, terminating gdal_merge.')
-            sys.exit(1)
+            return 1
 
         t_fh.SetGeoTransform(geotransform)
         t_fh.SetProjection(file_infos[0].projection)
@@ -545,7 +495,7 @@ def main(argv=None):
                 bands = bands + fi.bands
             if t_fh.RasterCount < bands:
                 print('Existing output file has less bands than the input files. You should delete it before. Terminating gdal_merge.')
-                sys.exit(1)
+                return 1
         else:
             bands = min(file_infos[0].bands, t_fh.RasterCount)
 

--- a/gdal/swig/python/osgeo/utils/gdal_pansharpen.py
+++ b/gdal/swig/python/osgeo/utils/gdal_pansharpen.py
@@ -33,55 +33,7 @@ import os
 import os.path
 import sys
 from osgeo import gdal
-
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_RASTER) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    # GMT is registered before netCDF for opening reasons, but we want
-    # netCDF to be used by default for output.
-    if ext.lower() == 'nc' and not drv_list and \
-       drv_list[0].upper() == 'GMT' and drv_list[1].upper() == 'NETCDF':
-        drv_list = ['NETCDF', 'GMT']
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'GTiff'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 
 def Usage():

--- a/gdal/swig/python/osgeo/utils/gdal_polygonize.py
+++ b/gdal/swig/python/osgeo/utils/gdal_polygonize.py
@@ -35,57 +35,13 @@ import sys
 
 from osgeo import gdal
 from osgeo import ogr
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 
 def Usage():
-    print("""
-gdal_polygonize [-8] [-nomask] [-mask filename] raster_file [-b band|mask]
-                [-q] [-f ogr_format] out_file [layer] [fieldname]
-""")
-    sys.exit(1)
-
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_VECTOR) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'ESRI Shapefile'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
+    print("""gdal_polygonize [-8] [-nomask] [-mask filename] raster_file [-b band|mask]
+                [-q] [-f ogr_format] out_file [layer] [fieldname]""")
+    return 1
 
 
 def main(argv):
@@ -102,10 +58,9 @@ def main(argv):
 
     mask = 'default'
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -149,15 +104,15 @@ def main(argv):
             dst_fieldname = argv[i]
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if src_filename is None or dst_filename is None:
-        Usage()
+        return Usage()
 
     if frmt is None:
-        frmt = GetOutputDriverFor(dst_filename)
+        frmt = GetOutputDriverFor(dst_filename, is_raster=False)
 
     if dst_layername is None:
         dst_layername = 'out'
@@ -172,7 +127,7 @@ def main(argv):
         print('gdal.Polygonize() not available.  You are likely using "old gen"')
         print('bindings or an older version of the next gen bindings.')
         print('')
-        sys.exit(1)
+        return 1
 
     # =============================================================================
     # Open source file
@@ -182,7 +137,7 @@ def main(argv):
 
     if src_ds is None:
         print('Unable to open %s' % src_filename)
-        sys.exit(1)
+        return 1
 
     if src_band_n == 'mask':
         srcband = src_ds.GetRasterBand(1).GetMaskBand()

--- a/gdal/swig/python/osgeo/utils/gdal_proximity.py
+++ b/gdal/swig/python/osgeo/utils/gdal_proximity.py
@@ -34,6 +34,7 @@ import os.path
 import sys
 
 from osgeo import gdal
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 
 def Usage():
@@ -44,56 +45,7 @@ gdal_proximity.py srcfile dstfile [-srcband n] [-dstband n]
                   [-values n,n,n] [-distunits PIXEL/GEO]
                   [-maxdist n] [-nodata n] [-use_input_nodata YES/NO]
                   [-fixed-buf-val n] [-q] """)
-    sys.exit(1)
-
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_RASTER) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    # GMT is registered before netCDF for opening reasons, but we want
-    # netCDF to be used by default for output.
-    if ext.lower() == 'nc' and not drv_list and \
-       drv_list[0].upper() == 'GMT' and drv_list[1].upper() == 'NETCDF':
-        drv_list = ['NETCDF', 'GMT']
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'GTiff'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
+    return 1
 
 
 def main(argv):
@@ -107,10 +59,9 @@ def main(argv):
     creation_type = 'Float32'
     quiet_flag = 0
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -171,12 +122,12 @@ def main(argv):
             dst_filename = argv[i]
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if src_filename is None or dst_filename is None:
-        Usage()
+        return Usage()
 
     # =============================================================================
     #    Open source file
@@ -186,7 +137,7 @@ def main(argv):
 
     if src_ds is None:
         print('Unable to open %s' % src_filename)
-        sys.exit(1)
+        return 1
 
     srcband = src_ds.GetRasterBand(src_band_n)
 

--- a/gdal/swig/python/osgeo/utils/gdal_sieve.py
+++ b/gdal/swig/python/osgeo/utils/gdal_sieve.py
@@ -33,63 +33,13 @@ import os.path
 import sys
 
 from osgeo import gdal
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 
 def Usage():
-    print("""
-gdal_sieve [-q] [-st threshold] [-4] [-8] [-o name=value]
-           srcfile [-nomask] [-mask filename] [-of format] [dstfile]
-""")
-    sys.exit(1)
-
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_RASTER) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    # GMT is registered before netCDF for opening reasons, but we want
-    # netCDF to be used by default for output.
-    if ext.lower() == 'nc' and not drv_list and \
-       drv_list[0].upper() == 'GMT' and drv_list[1].upper() == 'NETCDF':
-        drv_list = ['NETCDF', 'GMT']
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'GTiff'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
+    print("""gdal_sieve [-q] [-st threshold] [-4] [-8] [-o name=value]
+           srcfile [-nomask] [-mask filename] [-of format] [dstfile]""")
+    return 1
 
 
 def main(argv):
@@ -103,10 +53,9 @@ def main(argv):
 
     mask = 'default'
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -142,7 +91,7 @@ def main(argv):
             mask = argv[i]
 
         elif arg[:2] == '-h':
-            Usage()
+            return Usage()
 
         elif src_filename is None:
             src_filename = argv[i]
@@ -151,12 +100,12 @@ def main(argv):
             dst_filename = argv[i]
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if src_filename is None:
-        Usage()
+        return Usage()
 
     # =============================================================================
     # 	Verify we have next gen bindings with the sievefilter method.
@@ -168,7 +117,7 @@ def main(argv):
         print('gdal.SieveFilter() not available.  You are likely using "old gen"')
         print('bindings or an older version of the next gen bindings.')
         print('')
-        sys.exit(1)
+        return 1
 
     # =============================================================================
     # Open source file
@@ -181,7 +130,7 @@ def main(argv):
 
     if src_ds is None:
         print('Unable to open %s ' % src_filename)
-        sys.exit(1)
+        return 1
 
     srcband = src_ds.GetRasterBand(1)
 

--- a/gdal/swig/python/osgeo/utils/gdalchksum.py
+++ b/gdal/swig/python/osgeo/utils/gdalchksum.py
@@ -35,7 +35,7 @@ from osgeo import gdal
 
 def Usage():
     print('Usage: gdalchksum.py [-b band] [-srcwin xoff yoff xsize ysize] file')
-    sys.exit(1)
+    return 1
 
 
 def main(argv):
@@ -44,10 +44,9 @@ def main(argv):
 
     filename = None
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -67,19 +66,19 @@ def main(argv):
             filename = argv[i]
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if filename is None:
-        Usage()
+        return Usage()
 
     # Open source file
 
     ds = gdal.Open(filename)
     if ds is None:
         print('Unable to open %s' % filename)
-        sys.exit(1)
+        return 1
 
     # Default values
 

--- a/gdal/swig/python/osgeo/utils/gdalcompare.py
+++ b/gdal/swig/python/osgeo/utils/gdalcompare.py
@@ -290,7 +290,7 @@ def find_diff(golden_file, new_file, check_sds=False):
 
 def Usage():
     print('Usage: gdalcompare.py [-sds] <golden_file> <new_file>')
-    sys.exit(1)
+    return 1
 
 #######################################################
 #
@@ -302,10 +302,10 @@ def main(argv):
     # Default GDAL argument parsing.
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     if len(argv) == 1:
-        Usage()
+        return Usage()
 
     # Script argument parsing.
     golden_file = None
@@ -326,7 +326,7 @@ def main(argv):
 
         else:
             print('Unrecognised argument: ' + argv[i])
-            Usage()
+            return Usage()
 
         i = i + 1
         # next argument

--- a/gdal/swig/python/osgeo/utils/gdalident.py
+++ b/gdal/swig/python/osgeo/utils/gdalident.py
@@ -36,20 +36,12 @@ import sys
 from osgeo import gdal
 
 
-# =============================================================================
-# 	Usage()
-# =============================================================================
 def Usage():
     print('Usage: gdalident.py [-r] file(s)')
-    sys.exit(1)
-
-# =============================================================================
-# 	ProcessTarget()
-# =============================================================================
+    return 1
 
 
 def ProcessTarget(target, recursive, report_failure, filelist=None):
-
     if filelist is not None:
         driver = gdal.IdentifyDriver(target, filelist)
     else:
@@ -78,10 +70,9 @@ def main(argv):
     report_failure = 0
     files = []
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -100,7 +91,7 @@ def main(argv):
         i = i + 1
 
     if not files:
-        Usage()
+        return Usage()
 
     for f in files:
         ProcessTarget(f, recursive, report_failure)

--- a/gdal/swig/python/osgeo/utils/gdalimport.py
+++ b/gdal/swig/python/osgeo/utils/gdalimport.py
@@ -40,25 +40,24 @@ def progress_cb(complete, message, cb_data):
 
 
 def main(argv):
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     if len(argv) < 2:
         print("Usage: gdalimport.py [--help-general] source_file [newfile]")
-        sys.exit(1)
+        return 1
 
     filename = argv[1]
     dataset = gdal.Open(filename)
     if dataset is None:
         print('Unable to open %s' % filename)
-        sys.exit(1)
+        return 1
 
     geotiff = gdal.GetDriverByName("GTiff")
     if geotiff is None:
         print('GeoTIFF driver not registered.')
-        sys.exit(1)
+        return 1
 
     if len(argv) < 3:
         newbase, ext = os.path.splitext(os.path.basename(filename))

--- a/gdal/swig/python/osgeo/utils/gdalmove.py
+++ b/gdal/swig/python/osgeo/utils/gdalmove.py
@@ -203,11 +203,9 @@ error threshold so the file has not been updated.""" % max_error)
 
 
 def Usage():
-    print("""
-gdalmove.py [-s_srs <srs_defn>] -t_srs <srs_defn>
-            [-et <max_pixel_err>] target_file
-""")
-    sys.exit(1)
+    print("""gdalmove.py [-s_srs <srs_defn>] -t_srs <srs_defn>
+            [-et <max_pixel_err>] target_file""")
+    return 1
 
 
 def main(argv):
@@ -215,10 +213,10 @@ def main(argv):
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     if len(argv) == 1:
-        Usage()
+        return Usage()
 
     # Script argument defaults
     s_srs = None
@@ -248,18 +246,18 @@ def main(argv):
 
         else:
             print('Urecognised argument: ' + argv[i])
-            Usage()
+            return Usage()
 
         i = i + 1
         # next argument
 
     if filename is None:
         print('Missing name of file to operate on, but required.')
-        Usage()
+        return Usage()
 
     if t_srs is None:
         print('Target SRS (-t_srs) missing, but required.')
-        Usage()
+        return Usage()
 
     move(filename, t_srs, s_srs, pixel_threshold)
 

--- a/gdal/swig/python/osgeo/utils/mkgraticule.py
+++ b/gdal/swig/python/osgeo/utils/mkgraticule.py
@@ -62,9 +62,8 @@ def Usage():
     print('Usage: mkgraticule [-connected] [-s stepsize] [-substep substepsize]')
     print('         [-t_srs srs] [-range xmin ymin xmax ymax] outfile')
     print('')
-    sys.exit(1)
+    return 1
 
-#############################################################################
 
 def main(argv):
     # Argument processing.
@@ -99,11 +98,11 @@ def main(argv):
             ymax = float(argv[i + 4])
             i = i + 4
         elif argv[i][0] == '-':
-            Usage()
+            return Usage()
         elif outfile is None:
             outfile = argv[i]
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
@@ -238,6 +237,8 @@ def main(argv):
 
     ds.Destroy()
     ds = None
+
+    return 0
 
 
 if __name__ == '__main__':

--- a/gdal/swig/python/osgeo/utils/ogrmerge.py
+++ b/gdal/swig/python/osgeo/utils/ogrmerge.py
@@ -36,9 +36,7 @@ import sys
 
 from osgeo import gdal
 from osgeo import ogr
-
-###############################################################
-# Usage()
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 
 def Usage():
@@ -68,52 +66,6 @@ def Usage():
 
     return 1
 
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    if filename.lower().endswith('.shp.zip'):
-        return 'shp.zip'
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    if ext.lower() == 'vrt':
-        return ['VRT']
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_VECTOR) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'ESRI Shapefile'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
 
 #############################################################################
 
@@ -312,7 +264,7 @@ def process(argv, progress=None, progress_arg=None):
         output_format = ''
     else:
         if output_format is None:
-            output_format = GetOutputDriverFor(dst_filename)
+            output_format = GetOutputDriverFor(dst_filename, is_raster=False)
 
     if src_layer_field_content is None:
         src_layer_field_content = '{AUTO_NAME}'
@@ -604,9 +556,6 @@ def process(argv, progress=None, progress_arg=None):
         gdal.Unlink(vrt_filename)
 
     return ret
-
-###############################################################
-# Entry point
 
 
 def main(argv):

--- a/gdal/swig/python/osgeo/utils/pct2rgb.py
+++ b/gdal/swig/python/osgeo/utils/pct2rgb.py
@@ -34,6 +34,7 @@ import os.path
 import sys
 
 from osgeo import gdal
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 progress = gdal.TermProgress_nocb
 
@@ -46,56 +47,7 @@ except ImportError:
 
 def Usage():
     print('Usage: pct2rgb.py [-of format] [-b <band>] [-rgba] source_file dest_file')
-    sys.exit(1)
-
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_RASTER) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    # GMT is registered before netCDF for opening reasons, but we want
-    # netCDF to be used by default for output.
-    if ext.lower() == 'nc' and not drv_list and \
-       drv_list[0].upper() == 'GMT' and drv_list[1].upper() == 'NETCDF':
-        drv_list = ['NETCDF', 'GMT']
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'GTiff'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
+    return 1
 
 
 def main(argv):
@@ -105,10 +57,9 @@ def main(argv):
     out_bands = 3
     band_number = 1
 
-    gdal.AllRegister()
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
-        sys.exit(0)
+        return 0
 
     # Parse command line arguments.
     i = 1
@@ -133,20 +84,23 @@ def main(argv):
             dst_filename = argv[i]
 
         else:
-            Usage()
+            return Usage()
 
         i = i + 1
 
     if dst_filename is None:
-        Usage()
+        return Usage()
 
-    # ----------------------------------------------------------------------------
+    _ds, err = doit(src_filename, dst_filename, band_number, out_bands, frmt)
+    return err
+
+
+def doit(src_filename, dst_filename, band_number=1, out_bands=3, frmt=None):
     # Open source file
-
     src_ds = gdal.Open(src_filename)
     if src_ds is None:
         print('Unable to open %s ' % src_filename)
-        sys.exit(1)
+        return None, 1
 
     src_band = src_ds.GetRasterBand(band_number)
 
@@ -159,7 +113,7 @@ def main(argv):
     dst_driver = gdal.GetDriverByName(frmt)
     if dst_driver is None:
         print('"%s" driver not registered.' % frmt)
-        sys.exit(1)
+        return None, 1
 
     # ----------------------------------------------------------------------------
     # Build color table.
@@ -215,18 +169,17 @@ def main(argv):
 
         progress((iY + 1.0) / src_ds.RasterYSize)
 
-
-    tif_ds = None
-
     # ----------------------------------------------------------------------------
     # Translate intermediate file to output format if desired format is not TIFF.
 
-    if tif_filename != dst_filename:
-        tif_ds = gdal.Open(tif_filename)
-        dst_driver.CreateCopy(dst_filename, tif_ds)
+    if tif_filename == dst_filename:
+        dst_ds = tif_ds
+    else:
+        dst_ds = dst_driver.CreateCopy(dst_filename, tif_ds)
         tif_ds = None
-
         gtiff_driver.Delete(tif_filename)
+
+    return dst_ds, 0
 
 
 if __name__ == '__main__':

--- a/gdal/swig/python/samples/attachpct.py
+++ b/gdal/swig/python/samples/attachpct.py
@@ -33,6 +33,7 @@
 import sys
 
 from osgeo import gdal
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 
 def Usage():
@@ -50,7 +51,7 @@ def main(argv):
     return err
 
 
-def doit(pct_filename, src_filename, dst_filename, frmt='GTiff'):
+def doit(pct_filename, src_filename, dst_filename, frmt=None):
 
     # =============================================================================
     # Get the PCT.
@@ -82,6 +83,9 @@ def doit(pct_filename, src_filename, dst_filename, frmt='GTiff'):
     # =============================================================================
     # Write the dataset to the output file.
     # =============================================================================
+
+    if frmt is None:
+        frmt = GetOutputDriverFor(dst_filename)
 
     out_ds = frmt.CreateCopy(dst_filename, mem_ds)
 

--- a/gdal/swig/python/samples/tile_extent_from_raster.py
+++ b/gdal/swig/python/samples/tile_extent_from_raster.py
@@ -29,61 +29,14 @@
 #  DEALINGS IN THE SOFTWARE.
 # ******************************************************************************
 
-import os
 import sys
 from osgeo import gdal, ogr
+from osgeo.auxiliary.base import GetOutputDriverFor
 
 
 def Usage():
     print('Usage:  tile_extent_from_raster.py [-f format] [-ovr level] in.tif out.shp')
     return 1
-
-
-def DoesDriverHandleExtension(drv, ext):
-    exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
-
-
-def GetExtension(filename):
-    if filename.lower().endswith('.shp.zip'):
-        return 'shp.zip'
-    ext = os.path.splitext(filename)[1]
-    if ext.startswith('.'):
-        ext = ext[1:]
-    return ext
-
-
-def GetOutputDriversFor(filename):
-    drv_list = []
-    ext = GetExtension(filename)
-    if ext.lower() == 'vrt':
-        return ['VRT']
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        if (drv.GetMetadataItem(gdal.DCAP_CREATE) is not None or
-            drv.GetMetadataItem(gdal.DCAP_CREATECOPY) is not None) and \
-           drv.GetMetadataItem(gdal.DCAP_VECTOR) is not None:
-            if ext and DoesDriverHandleExtension(drv, ext):
-                drv_list.append(drv.ShortName)
-            else:
-                prefix = drv.GetMetadataItem(gdal.DMD_CONNECTION_PREFIX)
-                if prefix is not None and filename.lower().startswith(prefix.lower()):
-                    drv_list.append(drv.ShortName)
-
-    return drv_list
-
-
-def GetOutputDriverFor(filename):
-    drv_list = GetOutputDriversFor(filename)
-    ext = GetExtension(filename)
-    if not drv_list:
-        if not ext:
-            return 'ESRI Shapefile'
-        else:
-            raise Exception("Cannot guess driver for %s" % filename)
-    elif len(drv_list) > 1:
-        print("Several drivers matching %s extension. Using %s" % (ext if ext else '', drv_list[0]))
-    return drv_list[0]
 
 
 def main(argv):

--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -402,7 +402,7 @@ if GNM_ENABLED:
 if HAVE_NUMPY:
     ext_modules.append(array_module)
 
-packages = ["osgeo", "osgeo.utils"]
+packages = ["osgeo", "osgeo.utils", "osgeo.auxiliary"]
 
 readme = str(open('README.rst', 'rb').read())
 


### PR DESCRIPTION
## What does this PR do?

osgeo.auxiliary package added. to be home for auxilary functions for GDAL python scripting. more stuff should arrive here soon :)
auxiliary/base.py - combined all versions of GetOutputDriverFor, GetOutputDriversFor. removed duplicated versions from other source files. added some other useful functions.
setup.py - added osgeo.auxiliary

pct2rgb.py, rgb2pct.py - added a doit function and return ds

ogr/ogr_as_sqlite_extension.py - added main function
xmlvalidate.py - added main stub

attachpct.py - use GetOutputDriverFor

replace sys.exit(x) by return x for the osgeo.utils functions

## What are related issues/pull requests?

prerequisite:
https://github.com/OSGeo/gdal/pull/3115

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
