### PR TITLE
improve color palette support: gdal_calc, gdalattachpct, rgb2pct, pct2rgb

### DIFF
--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -88,6 +88,11 @@ but no projection checking is performed (unless projectionCheck option is used).
 
     GDAL format for output file.
 
+.. option:: color-table=<filename>
+
+    Allows to specify a filename of a color table (or a ColorTable object) (with Palette Index interpretation) to be used for the output raster.
+    Supported formats: txt (i.e. like gdaldem, but color names are not supported), qlr, qml (i.e. exported from QGIS)
+
 .. option:: --extent=<option>
 
     ..versionadded:: 3.3

--- a/gdal/doc/source/programs/gdalattachpct.rst
+++ b/gdal/doc/source/programs/gdalattachpct.rst
@@ -1,0 +1,47 @@
+.. _gdalattachpct:
+
+================================================================================
+gdalattachpct
+================================================================================
+
+.. only:: html
+
+    Attach a color table from one file to another file.
+
+.. Index:: gdalattachpct
+
+Synopsis
+--------
+
+.. code-block::
+
+    gdalattachpct.py [-of format] palette_file source_file dest_file
+
+Description
+-----------
+
+This utility will attach a color table file from an input raster file or a color table file to another raster.
+
+.. program:: gdalattachpct
+
+.. option:: -of <format>
+
+    Select the output format. Starting with
+    GDAL 2.3, if not specified, the format is guessed from the extension (previously
+    was GTiff). Use the short format name.
+
+.. option:: <palette_file>
+
+    Extract the color table from <palette_file>.
+    The<palette_file> must be either a raster file in a GDAL supported format with a palette
+    or a color file in a supported format (txt, qml, qlr).
+
+.. option:: <source_file>
+
+    The input file.
+
+.. option:: <dest_file>
+
+    The output RGB file that will be created.
+
+NOTE: gdalattachpct.py is a Python script, and will only work if GDAL was built with Python support.

--- a/gdal/doc/source/programs/index.rst
+++ b/gdal/doc/source/programs/index.rst
@@ -22,6 +22,7 @@ Raster programs
    gdaldem
    rgb2pct
    pct2rgb
+   gdalattachpct
    gdal_merge
    gdal2tiles
    gdal_rasterize
@@ -58,6 +59,7 @@ Raster programs
     - :ref:`gdaldem`: Tools to analyze and visualize DEMs.
     - :ref:`rgb2pct`: Convert a 24bit RGB image to 8bit paletted.
     - :ref:`pct2rgb`: Convert an 8bit paletted image to 24bit RGB.
+    - :ref:`gdalattachpct`: Attach a color table to a raster file from an input file.
     - :ref:`gdal_merge`: Mosaics a set of images.
     - :ref:`gdal2tiles`: Generates directory with TMS tiles, KMLs and simple web viewers.
     - :ref:`gdal_rasterize`: Burns vector geometries into a raster.

--- a/gdal/doc/source/programs/rgb2pct.rst
+++ b/gdal/doc/source/programs/rgb2pct.rst
@@ -35,10 +35,10 @@ maximize output image visual quality.
 
 .. option:: -pct <palette_file>
 
-    Extract the color table from
-    <palette_file> instead of computing it. Can be used to have a consistent
-    color table for multiple files.  The<palette_file> must be a raster file
-    in a GDAL supported format with a palette.
+    Extract the color table from <palette_file> instead of computing it.
+    Can be used to have a consistent color table for multiple files.
+    The<palette_file> must be either a raster file in a GDAL supported format with a palette
+    or a color file in a supported format (txt, qml, qlr).
 
 .. option:: -of <format>
 
@@ -55,8 +55,7 @@ maximize output image visual quality.
 
     The output pseudo-colored file that will be created.
 
-NOTE: rgb2pct.py is a Python script, and will only work if GDAL was built
-with Python support.
+NOTE: rgb2pct.py is a Python script, and will only work if GDAL was built with Python support.
 
 Example
 -------

--- a/gdal/swig/python/osgeo/utils/auxiliary/color_palette.py
+++ b/gdal/swig/python/osgeo/utils/auxiliary/color_palette.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL
+#  Purpose:  module for handling color palettes
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import os
+import re
+from xml.dom import minidom
+from collections import OrderedDict
+import glob
+import tempfile
+from typing import Sequence, Union
+
+from osgeo.utils.auxiliary import base
+
+PathOrStrings = Union[base.PathLike, Sequence[str]]
+ColorPaletteOrPathOrStrings = Union['ColorPalette', PathOrStrings]
+
+
+class ColorPalette:
+    __slots__ = ['pal', '_all_numeric']
+
+    def __init__(self):
+        self.pal = OrderedDict()
+        self._all_numeric = True
+
+    def __repr__(self):
+        return str(self.pal)
+
+    def replace_absolute_values_with_percent(self, ndv=True):
+        new_pal = ColorPalette()
+        for num, val in self.pal.items():
+            if not isinstance(num, str):
+                if num < 0:
+                    num = 0
+                elif num > 100:
+                    num = 100
+                num = str(num)+'%'
+            new_pal.pal[num] = val
+        new_pal._all_numeric = False
+        if ndv:
+            new_pal.pal['nv'] = 0
+        return new_pal
+
+    def to_serial_values(self, first=0):
+        keys = list(self.pal.keys())
+        i = first
+        for key in keys:
+            if not isinstance(key, str):
+                self.pal[i] = self.pal.pop(key)
+                i += 1
+
+    def has_percents(self):
+        if self._all_numeric:
+            return False
+        for num in self.pal.keys():
+            if not isinstance(num, str):
+                continue
+            is_percent = num.endswith('%')
+            if is_percent:
+                return True
+        return False
+
+    def apply_percent(self, min_val, max_val):
+        if self._all_numeric:
+            # nothing to do
+            return
+        all_numeric = True
+        new_pal = self.pal.copy()
+        for num in self.pal.keys():
+            if not isinstance(num, str):
+                continue
+            is_percent = num.endswith('%')
+            if is_percent:
+                new_num = num.rstrip('%')
+                try:
+                    new_num = base.num(new_num)
+                    if is_percent:
+                        new_num = (max_val - min_val) * new_num * 0.01 + min_val
+                    new_pal[new_num] = new_pal.pop(num)
+                except ValueError:
+                    all_numeric = False
+            else:
+                all_numeric = False
+                continue
+        if all_numeric:
+            self._all_numeric = True
+        self.pal = new_pal
+
+    def assign(self, other: 'ColorPalette'):
+        self.pal = other.pal.copy()
+        self._all_numeric = other._all_numeric
+
+    @staticmethod
+    def get_supported_extenstions():
+        return ['txt', 'qlr']
+
+    def is_supported_format(self, filename):
+        if base.is_path_like(filename):
+            ext = base.get_extension().lower()
+            return ext in self.get_supported_extenstions()
+        return False
+
+    def read(self, filename_or_strings: ColorPaletteOrPathOrStrings):
+        if isinstance(filename_or_strings, ColorPalette):
+            self.assign(filename_or_strings)
+        else:
+            filename, temp_filename = get_file_from_strings(filename_or_strings)
+            ext = base.get_extension(filename).lower()
+            if ext == 'qlr':
+                self.read_qlr(filename)
+            elif ext == 'txt':
+                self.read_color_file(filename)
+            else:
+                return False
+            if temp_filename:
+                os.remove(temp_filename)
+        return True
+
+    def read_color_file(self, color_filename_or_lines):
+        if isinstance(color_filename_or_lines, ColorPalette):
+            return self
+        elif color_filename_or_lines is None:
+            self.pal.clear()
+            return self
+        elif base.is_path_like(color_filename_or_lines):
+            color_filename_or_lines = open(str(color_filename_or_lines)).readlines()
+        elif not base.is_sequence(color_filename_or_lines):
+            raise Exception('unknown input {}'.format(color_filename_or_lines))
+
+        self.pal.clear()
+        for line in color_filename_or_lines:
+            split_line = line.strip().split(' ', 1)
+            if len(split_line) < 2:
+                continue
+            try:
+                color = self.pal_color_to_rgb(split_line[1])
+                key = split_line[0].strip()
+            except:
+                raise Exception('Error reading palette line: {}'.format(line))
+            try:
+                key = base.num(key)
+            except ValueError:
+                # should be percent
+                self._all_numeric = False
+                pass
+            self.pal[key] = color
+
+    def write_color_file(self, color_filename=None):
+        if color_filename is None:
+            color_filename = tempfile.mktemp(suffix='.txt')
+        os.makedirs(os.path.dirname(str(color_filename)), exist_ok=True)
+        with open(str(color_filename), mode='w') as fp:
+            for key, color in self.pal.items():
+                color_entry = self.color_to_color_entry(color)
+                color_entry = ' '.join(str(c) for c in color_entry)
+                fp.write('{} {}\n'.format(key, color_entry))
+        return color_filename
+
+    def to_mem_buffer(self):
+        s = ''
+        for key, color in self.pal.items():
+            cc = self.color_to_color_entry(color)
+            cc = ' '.join(str(c) for c in cc)
+            s = s + '{} {}\n'.format(key, cc)
+        return s
+
+    def read_xml(self, xml_filename, type=None, tag_name=None):
+        if tag_name is None:
+            if type is None:
+                type = base.get_suffix(xml_filename)
+            type = type.lstrip('.').lower()
+            if type == 'qlr':
+                #             <paletteEntry color="#ffffff" alpha="0" label="0" value="0"/>
+                tag_name = "paletteEntry"
+            elif type == 'qml':
+                #           <item label="-373" color="#d7191c" alpha="255" value="-373"/>
+                tag_name = "item"
+            else:
+                raise Exception('Unknown file type {}'.format(xml_filename))
+        self.pal.clear()
+        qlr = minidom.parse(str(xml_filename))
+        #             <paletteEntry color="#ffffff" alpha="0" label="0" value="0"/>
+        color_palette = qlr.getElementsByTagName(tag_name)
+        for palette_entry in color_palette:
+            color = palette_entry.getAttribute("color")
+            if str(color).startswith('#'):
+                color = int(color[1:], 16)
+            alpha = palette_entry.getAttribute("alpha")
+            alpha = int(alpha)
+            color = color + (alpha << 8*3)  # * 256**3
+            key = palette_entry.getAttribute("value")
+            key = base.num(key)
+            self.pal[key] = color
+
+    def read_qlr(self, qlr_filename):
+        return self.read_xml(qlr_filename, type='qlr')
+
+    def read_qml(self, qml_filename):
+        return self.read_xml(qml_filename, type='qml')
+
+    @staticmethod
+    def from_string_list(color_palette_strings):
+        res = ColorPalette()
+        res.read_color_file(color_palette_strings)
+        return res
+
+    @staticmethod
+    def format_number(num):
+        return num if isinstance(num, str) else '{:.2f}'.format(num)
+
+    @staticmethod
+    def format_color(col):
+        return col if isinstance(col, str) else '#{:06X}'.format(col)
+
+    @staticmethod
+    def color_to_color_entry(color):
+        # if color < 256:
+        #     return color
+        # else:
+            b = base.get_byte(color, 0)
+            g = base.get_byte(color, 1)
+            r = base.get_byte(color, 2)
+            a = base.get_byte(color, 3)
+
+            if a < 255:
+                return r, g, b, a
+            else:
+                return r, g, b
+
+    @staticmethod
+    def pal_color_to_rgb(cc):
+        # r g b a -> argb
+        # todo: support color names as implemented in the cpp version of this function...
+        # cc = color components
+        cc = re.findall(r'\d+', cc)
+        try:
+            # if not rgb_colors:
+            #     return (*(int(c) for c in cc),)
+            if len(cc) == 1:
+                return int(cc[0])
+            elif len(cc) == 3:
+                return (((((255 << 8) + int(cc[0])) << 8) + int(cc[1])) << 8) + int(cc[2])
+            elif len(cc) == 4:
+                return (((((int(cc[3]) << 8) + int(cc[0])) << 8) + int(cc[1])) << 8) + int(cc[2])
+            else:
+                return 0
+        except:
+            return 0
+
+    @staticmethod
+    def pas_color_to_rgb(col):
+        # $CC00FF80
+        # $AARRGGBB
+        if isinstance(col, str):
+            col = str(col).strip('$')
+        return int(col, 16)
+
+    @staticmethod
+    def from_color_list(color_list):
+        res = ColorPalette()
+        res.pal.clear()
+        res._all_numeric = True
+        for key, color in enumerate(color_list):
+            res.pal[key] = color
+        return res
+
+    @staticmethod
+    def from_mcd(mcd_color_list):
+        color_list = [int(color.lstrip('#'), 16) for color in mcd_color_list]
+        return ColorPalette.from_color_list(color_list)
+
+    @staticmethod
+    def get_css4_palette():
+        from matplotlib._color_data import CSS4_COLORS as color_dict
+        return ColorPalette.from_mcd(color_dict.values())
+
+    @staticmethod
+    def get_tableau_palette():
+        from matplotlib._color_data import TABLEAU_COLORS as color_dict
+        return ColorPalette.from_mcd(color_dict.values())
+
+    @staticmethod
+    def get_xkcd_palette():
+        from matplotlib._color_data import XKCD_COLORS as color_dict
+        return ColorPalette.from_mcd(color_dict.values())
+
+
+def xml_to_color_file(xml_filename, **kwargs):
+    # def xml_to_color_file(xml_filename: Path, **kwargs) -> ColorPalette, Path:
+    xml_filename = xml_filename
+    pal = ColorPalette()
+    pal.read_xml(xml_filename, **kwargs)
+    color_filename = xml_filename.with_suffix('.txt')
+    pal.write_color_file(color_filename)
+    return pal, color_filename
+
+
+def get_file_from_strings(color_palette: ColorPaletteOrPathOrStrings):
+    temp_color_filename = None
+    if isinstance(color_palette, ColorPalette):
+        temp_color_filename = tempfile.mktemp(suffix='.txt')
+        color_filename = temp_color_filename
+        color_palette.write_color_file(temp_color_filename)
+    elif base.is_path_like(color_palette):
+        color_filename = color_palette
+    elif base.is_sequence(color_palette):
+        temp_color_filename = tempfile.mktemp(suffix='.txt')
+        color_filename = temp_color_filename
+        with open(temp_color_filename, 'w') as f:
+            for item in color_palette:
+                f.write(item+'\n')
+    else:
+        raise Exception('Unknown color palette type {}'.format(color_palette))
+    return color_filename, temp_color_filename
+
+
+def get_color_palette(color_palette_or_path_or_strings: ColorPaletteOrPathOrStrings):
+    if color_palette_or_path_or_strings is None:
+        return None
+    if isinstance(color_palette_or_path_or_strings, ColorPalette):
+        pal = color_palette_or_path_or_strings
+    else:
+        pal = ColorPalette()
+        if not pal.read(color_palette_or_path_or_strings):
+            return None
+    return pal
+
+
+def test_xml():
+    dir_path = 'sample/color_files'
+    for ext in ['qlr', 'qml']:
+        for filename in glob.glob(base.path_join(dir_path, '**', '*.' + ext)):
+            pal, filename = xml_to_color_file(filename, type=ext)
+            print(filename, pal)
+
+
+if __name__ == "__main__":
+    test_xml()

--- a/gdal/swig/python/osgeo/utils/auxiliary/color_table.py
+++ b/gdal/swig/python/osgeo/utils/auxiliary/color_table.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL
+#  Purpose:  module for loading gdal.ColorTable from a file using ColorPalette
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import os
+import tempfile
+from typing import Optional
+
+from osgeo import gdal
+from osgeo.utils.auxiliary.base import PathLike
+from osgeo.utils.auxiliary.util import open_ds, path_or_ds
+from osgeo.utils.auxiliary.color_palette import get_color_palette, ColorPaletteOrPathOrStrings
+
+
+def get_color_table_from_raster(path_or_ds: path_or_ds) -> Optional[gdal.ColorTable]:
+    ds = open_ds(path_or_ds, silent_fail=True)
+    if ds is not None:
+        ct = ds.GetRasterBand(1).GetRasterColorTable()
+        return ct.Clone()
+    return None
+
+
+def get_color_table(color_palette_or_path_or_strings_or_ds: ColorPaletteOrPathOrStrings, min_key=0, max_key=255,
+                    fill_missing_colors=True) -> Optional[gdal.ColorTable]:
+    if (color_palette_or_path_or_strings_or_ds is None or
+       isinstance(color_palette_or_path_or_strings_or_ds, gdal.ColorTable)):
+        return color_palette_or_path_or_strings_or_ds
+
+    if isinstance(color_palette_or_path_or_strings_or_ds, gdal.Dataset):
+        return get_color_table_from_raster(color_palette_or_path_or_strings_or_ds)
+
+    pal = get_color_palette(color_palette_or_path_or_strings_or_ds)
+    if pal is None:
+        return get_color_table_from_raster(color_palette_or_path_or_strings_or_ds)
+    color_table = gdal.ColorTable()
+    if fill_missing_colors:
+        keys = sorted(list(pal.pal.keys()))
+        if min_key is None:
+            min_key = keys[0]
+        if max_key is None:
+            max_key = keys[-1]
+        c = pal.color_to_color_entry(pal.pal[keys[0]])
+        for key in range(min_key, max_key + 1):
+            if key in keys:
+                c = pal.color_to_color_entry(pal.pal[key])
+            color_table.SetColorEntry(key, c)
+    else:
+        for key, col in pal.pal.items():
+            color_table.SetColorEntry(key, pal.color_to_color_entry(col))  # set color for each key
+    return color_table
+
+
+def is_fixed_color_table(color_table: gdal.ColorTable, c=(0, 0, 0, 0)) -> bool:
+    for i in range(color_table.GetCount()):
+        color_entry: gdal.ColorEntry = color_table.GetColorEntry(i)
+        if color_entry != c:
+            return False
+    return True
+
+
+def get_fixed_color_table(c=(0, 0, 0, 0), count=1):
+    color_table = gdal.ColorTable()
+    for i in range(count):
+        color_table.SetColorEntry(i, c)
+    return color_table
+
+
+def are_equal_color_table(color_table1: gdal.ColorTable, color_table2: gdal.ColorTable) -> bool:
+    if color_table1.GetCount() != color_table2.GetCount():
+        return False
+    for i in range(color_table1.GetCount()):
+        color_entry1: gdal.ColorEntry = color_table1.GetColorEntry(i)
+        color_entry2: gdal.ColorEntry = color_table2.GetColorEntry(i)
+        if color_entry1 != color_entry2:
+            return False
+    return True
+
+
+def write_color_table_to_file(color_table: gdal.ColorTable, color_filename: Optional[PathLike]):
+    if color_filename is None:
+        color_filename = tempfile.mktemp(suffix='.txt')
+    os.makedirs(os.path.dirname(str(color_filename)), exist_ok=True)
+    with open(str(color_filename), mode='w') as fp:
+        for i in range(color_table.GetCount()):
+            color_entry = color_table.GetColorEntry(i)
+            color_entry = ' '.join(str(c) for c in color_entry)
+            fp.write('{} {}\n'.format(i, color_entry))
+    return color_filename

--- a/gdal/swig/python/osgeo/utils/auxiliary/util.py
+++ b/gdal/swig/python/osgeo/utils/auxiliary/util.py
@@ -151,7 +151,6 @@ class OpenDS:
             if open_options:
                 s = s + " with options: {}".format(str(open_options))
             logger.debug(s)
-        if open_options:
-            open_options = ["{}={}".format(k, v) for k, v in open_options.items()]
+        open_options = ["{}={}".format(k, v) for k, v in open_options.items()]
 
         return gdal.OpenEx(str(filename), access_mode, open_options=open_options)

--- a/gdal/swig/python/osgeo/utils/gdal_calc.py
+++ b/gdal/swig/python/osgeo/utils/gdal_calc.py
@@ -69,6 +69,7 @@ from osgeo.utils.auxiliary.util import GetOutputDriverFor
 from osgeo.utils.auxiliary.extent_util import Extent, GT
 from osgeo.utils.auxiliary import extent_util
 from osgeo.utils.auxiliary.rectangle import GeoRectangle
+from osgeo.utils.auxiliary.color_table import get_color_table
 
 GDALDataType = int
 
@@ -353,7 +354,7 @@ def doit(opts, args):
             if opts.color_table:
                 # set color table and color interpretation
                 if is_path_like(opts.color_table):
-                    raise Exception('Error! reading a color table from a file is not supported yet')
+                    opts.color_table = get_color_table(opts.color_table)
                 myOutB.SetRasterColorTable(opts.color_table)
                 myOutB.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
 
@@ -515,7 +516,8 @@ def doit(opts, args):
 def Calc(calc: Union[str, Sequence[str]], outfile: Optional[PathLike] = None, NoDataValue: Optional[Number] = None,
          type: Optional[Union[GDALDataType, str]] = None, format: Optional[str] = None,
          creation_options: Optional[Sequence[str]] = None, allBands: str = '', overwrite: bool = False,
-         hideNoData: bool = False, projectionCheck: bool = False, color_table: Optional[gdal.ColorTable] = None,
+         hideNoData: bool = False, projectionCheck: bool = False,
+         color_table: Optional[Union[PathLike, gdal.ColorTable]] = None,
          extent: Optional[Extent] = None, projwin: Optional[Union[Tuple, GeoRectangle]] = None, user_namespace=None,
          debug: bool=False, quiet: bool = False, **input_files):
 
@@ -620,7 +622,7 @@ def main(argv):
     parser.add_option("--quiet", dest="quiet", action="store_true", help="suppress progress messages")
     parser.add_option("--optfile", dest="optfile", metavar="optfile", help="Read the named file and substitute the contents into the command line options list.")
 
-    # parser.add_option("--color_table", dest="color_table", help="color table file name")
+    parser.add_option("--color-table", dest="color_table", help="color table file name")
     parser.add_option("--extent", dest="extent",
                       choices=[e.name.lower() for e in Extent],
                       help="how to treat mixed geotrasnforms")

--- a/gdal/swig/python/osgeo/utils/gdalattachpct.py
+++ b/gdal/swig/python/osgeo/utils/gdalattachpct.py
@@ -10,6 +10,7 @@
 #
 # ******************************************************************************
 #  Copyright (c) 2000, Frank Warmerdam
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -33,43 +34,69 @@
 import sys
 
 from osgeo import gdal
-from osgeo.auxiliary.base import GetOutputDriverFor
+from osgeo.utils.auxiliary.util import GetOutputDriverFor, open_ds
+from osgeo.utils.auxiliary.color_table import get_color_table
 
 
 def Usage():
-    print('Usage: attachpct.py <pctfile> <infile> <outfile>')
+    print('Usage: gdalattachpct.py <pctfile> <infile> <outfile>')
     return 1
 
 
 def main(argv):
     if len(argv) < 3:
         return Usage()
-    ct_filename = argv[1]
-    src_filename = argv[2]
-    dst_filename = argv[3]
-    _ds, err = doit(ct_filename, src_filename, dst_filename)
+    pct_filename = None
+    src_filename = None
+    dst_filename = None
+
+    argv = gdal.GeneralCmdLineProcessor(argv)
+    if argv is None:
+        return 0
+
+    # Parse command line arguments.
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+
+        if arg == '-of' or arg == '-f':
+            i = i + 1
+            driver = argv[i]
+
+        elif pct_filename is None:
+            pct_filename = argv[i]
+
+        elif src_filename is None:
+            src_filename = argv[i]
+
+        elif dst_filename is None:
+            dst_filename = argv[i]
+
+        else:
+            return Usage()
+
+        i = i + 1
+
+    _ds, err = doit(src_filename=src_filename, pct_filename=pct_filename, dst_filename=dst_filename, driver=driver)
     return err
 
 
-def doit(pct_filename, src_filename, dst_filename, frmt=None):
+def doit(src_filename, pct_filename, dst_filename=None, driver=None):
 
     # =============================================================================
     # Get the PCT.
     # =============================================================================
-    ds = gdal.Open(pct_filename)
-    ct = ds.GetRasterBand(1).GetRasterColorTable()
 
-    if ct is None:
+    ct = get_color_table(pct_filename)
+    if pct_filename is not None and ct is None:
         print('No color table on file ', pct_filename)
         return None, 1
-
-    ct = ct.Clone()
 
     # =============================================================================
     # Create a MEM clone of the source file.
     # =============================================================================
 
-    src_ds = gdal.Open(src_filename)
+    src_ds = open_ds(src_filename)
 
     mem_ds = gdal.GetDriverByName('MEM').CreateCopy('mem', src_ds)
 
@@ -84,10 +111,18 @@ def doit(pct_filename, src_filename, dst_filename, frmt=None):
     # Write the dataset to the output file.
     # =============================================================================
 
-    if frmt is None:
-        frmt = GetOutputDriverFor(dst_filename)
+    if not driver:
+        driver = GetOutputDriverFor(dst_filename)
 
-    out_ds = frmt.CreateCopy(dst_filename, mem_ds)
+    dst_driver = gdal.GetDriverByName(driver)
+    if dst_driver is None:
+        print('"%s" driver not registered.' % driver)
+        return None, 1
+
+    if driver.upper() == 'MEM':
+        out_ds = mem_ds
+    else:
+        out_ds = dst_driver.CreateCopy(dst_filename or '', mem_ds)
 
     mem_ds = None
     src_ds = None

--- a/gdal/swig/python/samples/README.md
+++ b/gdal/swig/python/samples/README.md
@@ -10,10 +10,6 @@ Python interface may be used in your applications.
     Script demonstrates how to assemble polygons from arcs.
     Demonstrates various aspects of OGR Python API.
 
-`attachpct.py`
-
-    Simple command line program for copying the color table of a raster into another raster.
-
 `fft.py`
 
     Script to perform forward and inverse two-dimensional fast Fourier transform.

--- a/gdal/swig/python/scripts/gdalattachpct.py
+++ b/gdal/swig/python/scripts/gdalattachpct.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+# import osgeo.utils.gdalattachpct as a convenience to use as a script
+from osgeo.utils.gdalattachpct import *  # noqa
+from osgeo.utils.gdalattachpct import main
+from osgeo.gdal import deprecation_warn
+
+
+deprecation_warn('gdalattachpct', 'utils')
+sys.exit(main(sys.argv))


### PR DESCRIPTION
color palette python modules improvements
- gdalattachpct.py - upgraded attachpct.py into a module, added support for color table files and format
- gdal/swig/python/samples/attachpct.py - upgraded into a module
- gdal/swig/python/samples/README.md - remove attachpct.py
- gdal/swig/python/osgeo/utils/gdalattachpct.py - use GetOutputDriverFor (to support other drivers), get_color_table (to allow loading color palette from a ds or a txt file), open_ds (allow a ds input in addition of a filename)
- gdal/doc/source/programs/gdalattachpct.rst - document gdalattachpct.py
- gdal/doc/source/programs/index.rst - reference gdalattachpct.py
- autotest/pyscripts/test_pct.py - rename and add tests for gdalattachpct.py
- gdal/swig/python/osgeo/utils/[rgb2pct.py, pct2rgb.py] - use get_color_table to allow loading color palette from a ds or a txt file; use open_ds to allow input a ds in addition to filename
- added osgeo/utils/auxiliary/[color_palette.py, color_table.py] added to handle color palettes (the former number -> color, the latter index -> color)
- added `color_palette` option to gdal_calc

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/3341 (prerequisite) - Please review it first
https://github.com/OSGeo/gdal/pull/3117 (merged)
https://github.com/OSGeo/gdal/pull/3095 (closed)

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed