### PR TITLE
gdal_calc.py - add support for color table files and more extent options

### DIFF
--- a/autotest/pyscripts/test_rgb2pct.py
+++ b/autotest/pyscripts/test_rgb2pct.py
@@ -34,6 +34,8 @@ import struct
 
 
 from osgeo import gdal
+from osgeo.utils import attachpct, rgb2pct
+from osgeo.auxiliary.color_table import get_color_table
 import gdaltest
 import test_py_scripts
 import pytest
@@ -162,6 +164,24 @@ def test_pct2rgb_4():
     ori_ds = None
 
 
+def test_attachpct_1():
+    pct_filename = 'tmp/test_rgb2pct_2.tif'
+    src_filename = '../gcore/data/rgbsmall.tif'
+
+    ds1, err = rgb2pct.doit(src_filename=src_filename, pct_filename=pct_filename)
+    ct1 = get_color_table(pct_filename)
+    assert err == 0 and ds1 is not None and ct1 is not None
+
+    ds2, err = rgb2pct.doit(src_filename=src_filename, pct_filename=None)
+    ct2 = get_color_table(pct_filename)
+    # todo check that the palette is empty
+    assert err == 0 and ds2 is not None and ct2 is not None
+
+    ds3, err = attachpct.doit(src_filename=src_filename, pct_filename=ct1)
+    assert err == 0 and ds3 is not None
+    # todo: finish this test
+
+
 ###############################################################################
 # Cleanup
 
@@ -178,8 +198,3 @@ def test_rgb2pct_cleanup():
             os.remove(filename)
         except OSError:
             pass
-
-    
-
-
-

--- a/gdal/doc/source/programs/attachpct.rst
+++ b/gdal/doc/source/programs/attachpct.rst
@@ -1,0 +1,47 @@
+.. _attachpct:
+
+================================================================================
+attachpct
+================================================================================
+
+.. only:: html
+
+    Attach a color table from one file to another file.
+
+.. Index:: attachpct
+
+Synopsis
+--------
+
+.. code-block::
+
+    attachpct.py [-of format] [-pct palette_file] source_file dest_file
+
+Description
+-----------
+
+This utility will attach a color table file from an input raster file or a color table file to another raster.
+
+.. program:: attachpct
+
+.. option:: -of <format>
+
+    Select the output format. Starting with
+    GDAL 2.3, if not specified, the format is guessed from the extension (previously
+    was GTiff). Use the short format name.
+
+.. option:: -pct <palette_file>
+
+    Extract the color table from <palette_file>.
+    The<palette_file> must be either a raster file in a GDAL supported format with a palette
+    or a color file in a supported format (txt, qml, qlr).
+
+.. option:: <source_file>
+
+    The input file.
+
+.. option:: <dest_file>
+
+    The output RGB file that will be created.
+
+NOTE: attachpct.py is a Python script, and will only work if GDAL was built with Python support.

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -95,6 +95,14 @@ but no projection checking is performed (unless projectionCheck option is used).
     this option determinants how to handle rasters with different extents.
     ``ignore`` (default) - only the dimensions of the rasters are compared. if the dimensions do not agree the operation will fail.
     ``fail`` - the dimensions and the extent (bounds) of the rasters must agree, otherwise the operation will fail.
+    ``union`` - the dimensions and the extent (bounds) of the rasters will be a union of the input extents.
+    ``intersect`` - the dimensions and the extent (bounds) of the rasters will be an intersection of the input extents.
+    a specified custom extent is also supported using the Python interface.
+
+.. option:: color_table=<filename>
+
+    Allows to specify a filename of a color table (or a ColorTable object) (with Palette Index interpretation) to be used for the output raster.
+    Supported formats: txt (i.e. like gdaldem, but color names are not supported), qlr, qml (i.e. exported from QGIS)
 
 .. option:: --projectionCheck
 
@@ -148,9 +156,6 @@ they are not available using the command prompt.
 
     If enabled, the output dataset would be returned from the function and not closed.
 
-.. option:: color_table
-
-    Allows to specify a ColorTable object (with Palette Index interpretation) to be used for the output raster.
 
 Example
 -------

--- a/gdal/doc/source/programs/index.rst
+++ b/gdal/doc/source/programs/index.rst
@@ -22,6 +22,7 @@ Raster programs
    gdaldem
    rgb2pct
    pct2rgb
+   attachpct
    gdal_merge
    gdal2tiles
    gdal_rasterize
@@ -58,6 +59,7 @@ Raster programs
     - :ref:`gdaldem`: Tools to analyze and visualize DEMs.
     - :ref:`rgb2pct`: Convert a 24bit RGB image to 8bit paletted.
     - :ref:`pct2rgb`: Convert an 8bit paletted image to 24bit RGB.
+    - :ref:`attachpct`: Attach a color table to a raster file from an input file.
     - :ref:`gdal_merge`: Mosaics a set of images.
     - :ref:`gdal2tiles`: Generates directory with TMS tiles, KMLs and simple web viewers.
     - :ref:`gdal_rasterize`: Burns vector geometries into a raster.

--- a/gdal/doc/source/programs/rgb2pct.rst
+++ b/gdal/doc/source/programs/rgb2pct.rst
@@ -6,7 +6,7 @@ rgb2pct
 
 .. only:: html
 
-    Convert a 24bit RGB image to 8bit paletted. 
+    Convert a 24bit RGB image to 8bit paletted.
 
 .. Index:: rgb2pct
 
@@ -35,10 +35,10 @@ maximize output image visual quality.
 
 .. option:: -pct <palette_file>
 
-    Extract the color table from
-    <palette_file> instead of computing it. Can be used to have a consistent
-    color table for multiple files.  The<palette_file> must be a raster file
-    in a GDAL supported format with a palette.
+    Extract the color table from <palette_file> instead of computing it.
+    Can be used to have a consistent color table for multiple files.
+    The<palette_file> must be either a raster file in a GDAL supported format with a palette
+    or a color file in a supported format (txt, qml, qlr).
 
 .. option:: -of <format>
 
@@ -55,8 +55,7 @@ maximize output image visual quality.
 
     The output pseudo-colored file that will be created.
 
-NOTE: rgb2pct.py is a Python script, and will only work if GDAL was built
-with Python support.
+NOTE: rgb2pct.py is a Python script, and will only work if GDAL was built with Python support.
 
 Example
 -------

--- a/gdal/swig/python/osgeo/auxiliary/color_palette.py
+++ b/gdal/swig/python/osgeo/auxiliary/color_palette.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL
+#  Purpose:  module for handling color palettes
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import os
+import re
+from xml.dom import minidom
+from collections import OrderedDict
+import glob
+import tempfile
+from osgeo.auxiliary import base
+
+
+# from typing import Sequence, Union
+# from pathlib import Path
+# PathOrStrings = Union[Path, str, Sequence[str]]
+# ColorPaletteOrPathOrStrings = Union['ColorPalette', PathOrStrings]
+
+
+class ColorPalette:
+    __slots__ = ['pal', '_all_numeric']
+
+    def __init__(self):
+        self.pal = OrderedDict()
+        self._all_numeric = True
+
+    def __repr__(self):
+        return str(self.pal)
+
+    def replace_absolute_values_with_percent(self, ndv=True):
+        new_pal = ColorPalette()
+        for num, val in self.pal.items():
+            if not isinstance(num, str):
+                if num < 0:
+                    num = 0
+                elif num > 100:
+                    num = 100
+                num = str(num)+'%'
+            new_pal.pal[num] = val
+        new_pal._all_numeric = False
+        if ndv:
+            new_pal.pal['nv'] = 0
+        return new_pal
+
+    def to_serial_values(self, first=0):
+        keys = list(self.pal.keys())
+        i = first
+        for key in keys:
+            if not isinstance(key, str):
+                self.pal[i] = self.pal.pop(key)
+                i += 1
+
+    def has_percents(self):
+        if self._all_numeric:
+            return False
+        for num in self.pal.keys():
+            if not isinstance(num, str):
+                continue
+            is_percent = num.endswith('%')
+            if is_percent:
+                return True
+        return False
+
+    def apply_percent(self, min_val, max_val):
+        if self._all_numeric:
+            # nothing to do
+            return
+        all_numeric = True
+        new_pal = self.pal.copy()
+        for num in self.pal.keys():
+            if not isinstance(num, str):
+                continue
+            is_percent = num.endswith('%')
+            if is_percent:
+                new_num = num.rstrip('%')
+                try:
+                    new_num = base.to_number(new_num)
+                    if is_percent:
+                        new_num = (max_val - min_val) * new_num * 0.01 + min_val
+                    new_pal[new_num] = new_pal.pop(num)
+                except ValueError:
+                    all_numeric = False
+            else:
+                all_numeric = False
+                continue
+        if all_numeric:
+            self._all_numeric = True
+        self.pal = new_pal
+
+    def read(self, filename_or_strings):
+        # def read(self, filename_or_strings: ColorPaletteOrPathOrStrings):
+        if isinstance(filename_or_strings, ColorPalette):
+            self = filename_or_strings.copy()
+        else:
+            filename, temp_filename = get_file_from_strings(filename_or_strings)
+            if base.get_suffix(filename).lower() == '.qlr':
+                self.read_qlr(filename)
+            else:
+                self.read_color_file(filename)
+            if temp_filename:
+                os.remove(temp_filename)
+
+    def read_color_file(self, color_filename_or_lines):
+        if isinstance(color_filename_or_lines, ColorPalette):
+            return self
+        elif color_filename_or_lines is None:
+            self.pal.clear()
+            return self
+        elif base.is_path_like(color_filename_or_lines):
+            color_filename_or_lines = open(str(color_filename_or_lines)).readlines()
+        elif not base.is_sequence(color_filename_or_lines):
+            raise Exception('unknown input {}'.format(color_filename_or_lines))
+
+        self.pal.clear()
+        for line in color_filename_or_lines:
+            split_line = line.strip().split(' ', maxsplit=1)
+            if len(split_line) < 2:
+                continue
+            try:
+                color = self.pal_color_to_rgb(split_line[1])
+                key = split_line[0].strip()
+            except:
+                raise Exception('Error reading palette line: {}'.format(line))
+            try:
+                key = base.to_number(key)
+            except ValueError:
+                # should be percent
+                self._all_numeric = False
+                pass
+            self.pal[key] = color
+
+    def write_color_file(self, color_filename=None):
+        if color_filename is None:
+            color_filename = tempfile.mktemp(suffix='.txt')
+        os.makedirs(os.path.dirname(str(color_filename)), exist_ok=True)
+        with open(str(color_filename), mode='w') as fp:
+            for key, color in self.pal.items():
+                cc = self.color_to_cc(color)
+                cc = ' '.join(str(c) for c in cc)
+                fp.write('{} {}\n'.format(key, cc))
+        return color_filename
+
+    def to_mem_buffer(self):
+        s = ''
+        for key, color in self.pal.items():
+            cc = self.color_to_cc(color)
+            cc = ' '.join(str(c) for c in cc)
+            s = s + '{} {}\n'.format(key, cc)
+        return s
+
+    def read_xml(self, xml_filename, type=None, tag_name=None):
+        if tag_name is None:
+            if type is None:
+                type = base.get_suffix(xml_filename)
+            type = type.lstrip('.').lower()
+            if type == 'qlr':
+                #             <paletteEntry color="#ffffff" alpha="0" label="0" value="0"/>
+                tag_name = "paletteEntry"
+            elif type == 'qml':
+                #           <item label="-373" color="#d7191c" alpha="255" value="-373"/>
+                tag_name = "item"
+            else:
+                raise Exception('Unknown file type {}'.format(xml_filename))
+        self.pal.clear()
+        qlr = minidom.parse(str(xml_filename))
+        #             <paletteEntry color="#ffffff" alpha="0" label="0" value="0"/>
+        color_palette = qlr.getElementsByTagName(tag_name)
+        for palette_entry in color_palette:
+            color = palette_entry.getAttribute("color")
+            if str(color).startswith('#'):
+                color = int(color[1:], 16)
+            alpha = palette_entry.getAttribute("alpha")
+            alpha = int(alpha)
+            color = color + (alpha << 8*3)  # * 256**3
+            key = palette_entry.getAttribute("value")
+            key = base.to_number(key)
+            self.pal[key] = color
+
+    def read_qlr(self, qlr_filename):
+        return self.read_xml(qlr_filename, type='qlr')
+
+    def read_qml(self, qml_filename):
+        return self.read_xml(qml_filename, type='qml')
+
+    @staticmethod
+    def from_string_list(color_palette_strings):
+        res = ColorPalette()
+        res.read_color_file(color_palette_strings)
+        return res
+
+    @staticmethod
+    def format_number(num):
+        return num if isinstance(num, str) else '{:.2f}'.format(num)
+
+    @staticmethod
+    def format_color(col):
+        return col if isinstance(col, str) else '#{:06X}'.format(col)
+
+    @staticmethod
+    def color_to_cc(color):
+        # if color < 256:
+        #     return color
+        # else:
+            b = base.get_byte(color, 0)
+            g = base.get_byte(color, 1)
+            r = base.get_byte(color, 2)
+            a = base.get_byte(color, 3)
+
+            if a < 255:
+                return r, g, b, a
+            else:
+                return r, g, b
+
+    @staticmethod
+    def pal_color_to_rgb(cc):
+        # r g b a -> argb
+        # todo: support color names as implemented in the cpp version of this function...
+        # cc = color components
+        cc = re.findall(r'\d+', cc)
+        try:
+            # if not rgb_colors:
+            #     return (*(int(c) for c in cc),)
+            if len(cc) == 1:
+                return int(cc[0])
+            elif len(cc) == 3:
+                return (((((255 << 8) + int(cc[0])) << 8) + int(cc[1])) << 8) + int(cc[2])
+            elif len(cc) == 4:
+                return (((((int(cc[3]) << 8) + int(cc[0])) << 8) + int(cc[1])) << 8) + int(cc[2])
+            else:
+                return 0
+        except:
+            return 0
+
+    @staticmethod
+    def pas_color_to_rgb(col):
+        # $CC00FF80
+        # $AARRGGBB
+        if isinstance(col, str):
+            col = str(col).strip('$')
+        return int(col, 16)
+
+    @staticmethod
+    def from_color_list(color_list):
+        res = ColorPalette()
+        res.pal.clear()
+        res._all_numeric = True
+        for key, color in enumerate(color_list):
+            res.pal[key] = color
+        return res
+
+    @staticmethod
+    def from_mcd(mcd_color_list):
+        color_list = [int(color.lstrip('#'), 16) for color in mcd_color_list]
+        return ColorPalette.from_color_list(color_list)
+
+    @staticmethod
+    def get_css4_palette():
+        from matplotlib._color_data import CSS4_COLORS as color_dict
+        return ColorPalette.from_mcd(color_dict.values())
+
+    @staticmethod
+    def get_tableau_palette():
+        from matplotlib._color_data import TABLEAU_COLORS as color_dict
+        return ColorPalette.from_mcd(color_dict.values())
+
+    @staticmethod
+    def get_xkcd_palette():
+        from matplotlib._color_data import XKCD_COLORS as color_dict
+        return ColorPalette.from_mcd(color_dict.values())
+
+
+def xml_to_color_file(xml_filename, **kwargs):
+    # def xml_to_color_file(xml_filename: Path, **kwargs) -> ColorPalette, Path:
+    xml_filename = xml_filename
+    pal = ColorPalette()
+    pal.read_xml(xml_filename, **kwargs)
+    color_filename = xml_filename.with_suffix('.txt')
+    pal.write_color_file(color_filename)
+    return pal, color_filename
+
+
+def get_file_from_strings(color_palette):
+    # def get_file_from_strings(color_palette: ColorPaletteOrPathOrStrings):
+    temp_color_filename = None
+    if isinstance(color_palette, ColorPalette):
+        temp_color_filename = tempfile.mktemp(suffix='.txt')
+        color_filename = temp_color_filename
+        color_palette.write_color_file(temp_color_filename)
+    elif base.is_path_like(color_palette):
+        color_filename = color_palette
+    elif base.is_sequence(color_palette):
+        temp_color_filename = tempfile.mktemp(suffix='.txt')
+        color_filename = temp_color_filename
+        with open(temp_color_filename, 'w') as f:
+            for item in color_palette:
+                f.write(item+'\n')
+    else:
+        raise Exception('Unknown color palette type {}'.format(color_palette))
+    return color_filename, temp_color_filename
+
+
+def get_color_palette(color_palette_or_path_or_strings):
+    # def get_color_palette(color_palette_or_path_or_strings: ColorPaletteOrPathOrStrings):
+    if color_palette_or_path_or_strings is None:
+        return None
+    if isinstance(color_palette_or_path_or_strings, ColorPalette):
+        pal = color_palette_or_path_or_strings
+    else:
+        pal = ColorPalette()
+        pal.read(color_palette_or_path_or_strings)
+    return pal
+
+
+def test_xml():
+    dir_path = 'sample/color_files'
+    for ext in ['qlr', 'qml']:
+        for filename in glob.glob(base.path_join(dir_path, '**', '*.' + ext)):
+            pal, filename = xml_to_color_file(filename, type=ext)
+            print(filename, pal)
+
+
+if __name__ == "__main__":
+    test_xml()

--- a/gdal/swig/python/osgeo/auxiliary/color_table.py
+++ b/gdal/swig/python/osgeo/auxiliary/color_table.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL
+#  Purpose:  module for loading gdal.ColorTable from a file using ColorPalette
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+from osgeo import gdal
+from osgeo.auxiliary.color_palette import get_color_palette
+
+
+def get_color_table(color_palette_or_path_or_strings_or_ds, min_key=0, max_key=255, fill_missing_colors=True):
+    # def get_color_table(color_palette_or_path_or_strings: ColorPaletteOrPathOrStrings) -> gdal.ColorTable:
+    if color_palette_or_path_or_strings_or_ds is None or isinstance(color_palette_or_path_or_strings_or_ds, gdal.ColorTable):
+        return color_palette_or_path_or_strings_or_ds
+    ds = gdal.Open(color_palette_or_path_or_strings_or_ds)
+    if ds is not None:
+        ct = ds.GetRasterBand(1).GetRasterColorTable()
+        return ct.Clone()
+
+    pal = get_color_palette(color_palette_or_path_or_strings_or_ds)
+    if pal is None:
+        return None
+    color_table = gdal.ColorTable()
+    if fill_missing_colors:
+        keys = sorted(list(pal.pal.keys()))
+        if min_key is None:
+            min_key = keys[0]
+        if max_key is None:
+            max_key = keys[-1]
+        c = pal.color_to_cc(pal.pal[keys[0]])
+        for key in range(min_key, max_key+1):
+            if key in keys:
+                c = pal.color_to_cc(pal.pal[key])
+            color_table.SetColorEntry(key, c)
+    else:
+        for key, col in pal.pal.items():
+            color_table.SetColorEntry(key, pal.color_to_cc(col))  # set color for each key
+    return color_table

--- a/gdal/swig/python/osgeo/auxiliary/extent.py
+++ b/gdal/swig/python/osgeo/auxiliary/extent.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL
+#  Purpose:  module for handling extents
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import tempfile
+import math
+
+from osgeo import gdal
+
+from osgeo.auxiliary.geo_rectangle import GeoRectangle, get_points_extent
+from osgeo.auxiliary import base
+
+
+def calc_dx_dy(extent, sample_count):
+    # extent: GeoRectangle
+    # sample_count: int
+    (min_x, max_x, min_y, max_y) = extent.min_max
+    w = max_x - min_x
+    h = max_y - min_y
+    pix_area = w * h / sample_count
+    if pix_area <= 0 or w <= 0 or h <= 0:
+        return 0, 0
+    pix_len = math.sqrt(pix_area)
+    return pix_len, pix_len
+
+
+def translate_extent(extent, transform, sample_count=1000):
+    # extent: GeoRectangle
+    if transform is None:
+        return extent
+    maxf = float("inf")
+    (out_min_x, out_max_x, out_min_y, out_max_y) = (maxf, -maxf, maxf, -maxf)
+
+    dx, dy = calc_dx_dy(extent, sample_count)
+    if dx == 0:
+        return GeoRectangle.empty()
+
+    y = float(extent.min_y)
+    while y <= extent.max_y + dy:
+        x = float(extent.min_x)
+        while x <= extent.max_x + dx:
+            tx, ty, tz = transform.TransformPoint(x, y)
+            x += dx
+            if not math.isfinite(tz):
+                continue
+            out_min_x = min(out_min_x, tx)
+            out_max_x = max(out_max_x, tx)
+            out_min_y = min(out_min_y, ty)
+            out_max_y = max(out_max_y, ty)
+        y += dy
+
+    return GeoRectangle.from_min_max(out_min_x, out_max_x, out_min_y, out_max_y)
+
+
+def get_geotransform_and_size(ds):
+    return ds.GetGeoTransform(), (ds.RasterXSize, ds.RasterYSize)
+
+
+def get_points_extent_from_ds(ds):
+    geo_transform, size = get_geotransform_and_size(ds)
+    points_extent = get_points_extent(geo_transform, *size)
+    return points_extent, geo_transform
+
+
+def dist(p1x, p1y, p2x, p2y):
+    return math.sqrt((p2y - p1y) ** 2 + (p2x - p1x) ** 2)
+
+
+def transform_resolution_p(transform, dx, dy, px, py):
+    p1x, p1y, _ = transform.TransformPoint(px, py + dx, 0)
+    p2x, p2y, _ = transform.TransformPoint(px, py + dy, 0)
+    return dist(p1x, p1y, p2x, p2y)
+
+
+def transform_resolution_old(transform, input_res, extent):
+    # extent: GeoRectangle
+    (xmin, xmax, ymin, ymax) = extent.min_max
+    [dx, dy] = input_res
+    out_res_x = min(
+        transform_resolution_p(transform, 0, dy, xmin, ymin),
+        transform_resolution_p(transform, 0, -dy, xmin, ymax),
+        transform_resolution_p(transform, 0, -dy, xmax, ymax),
+        transform_resolution_p(transform, 0, dy, xmax, ymin),
+    )
+    if (ymin > 0) and (ymax < 0):
+        out_res_x = min(
+            out_res_x,
+            transform_resolution_p(transform, 0, dy, xmin, 0),
+            transform_resolution_p(transform, 0, dy, xmax, 0),
+        )
+    out_res_x = round_to_sig(out_res_x, -1)
+    out_res = (out_res_x, -out_res_x)
+    return out_res
+
+
+def transform_resolution(transform, input_res, extent, equal_res_both_axis=True, only_y_axis=True, sample_count=1000):
+    # extent: GeoRectangle
+
+    dx, dy = calc_dx_dy(extent, sample_count)
+    out_x = []
+    out_y = []
+    y = float(extent.min_y)
+    while y <= extent.max_y:
+        x = float(extent.min_x)
+        while x < extent.max_x:
+            out_y.append(transform_resolution_p(transform, 0, input_res[1], x, y))
+            if not only_y_axis:
+                out_x.append(transform_resolution_p(transform, input_res[0], 0, x, y))
+            x += dx
+        y += dy
+
+    if only_y_axis:
+        out_y.sort()
+        out_x = out_y
+    elif equal_res_both_axis:
+        out_y.extend(out_x)
+        out_y.sort()
+        out_x = out_y
+    else:
+        out_x.sort()
+        out_y.sort()
+    out_r = [out_x, out_y]
+
+    # choose the median resolution
+    out_res = [round_to_sig(r[round(len(r) / 2)], -1) for r in out_r]
+    out_res[1] = -out_res[1]
+    return out_res
+
+
+def round_to_sig(d, extra_digits=-5):
+    if (d == 0) or math.isnan(d) or math.isinf(d):
+        return 0
+    if abs(d) > 1e-20:
+        digits = int(math.floor(math.log10(abs(d) + 1e-20)))
+    else:
+        digits = int(math.floor(math.log10(abs(d))))
+    digits = digits + extra_digits
+    return round(d, -digits)
+
+
+def get_vec_extent(lyr):
+    result = None
+    for feature in lyr:
+        geom = feature.GetGeometryRef()
+        envelope = geom.GetEnvelope()
+        r = GeoRectangle.from_min_max(*envelope)
+        if result is None:
+            result = r
+        else:
+            result = result.union(r)
+    return result
+
+
+def open_ds(filename_or_ds):
+    return gdal.Open(str(filename_or_ds)) if base.is_path_like(filename_or_ds) else filename_or_ds
+
+
+def get_extent(filename_or_ds):
+    # returns -> GeoRectangle
+    ds = open_ds(filename_or_ds)
+    gt, size = get_geotransform_and_size(ds)
+    return GeoRectangle.from_geotransform_and_size(gt, size)
+
+
+def calc_geo_offsets(src_gt, src_size, dst_gt, dst_size):
+    src = GeoRectangle.from_geotransform_and_size_to_pix(src_gt, src_size)
+    dst = GeoRectangle.from_geotransform_and_size_to_pix(dst_gt, dst_size)
+    offset = (dst.x - src.x, dst.y - src.y)
+    src_offset = (max(0, offset[0]), max(0, offset[1]))
+    dst_offset = (max(0, -offset[0]), max(0, -offset[1]))
+    return src_offset, dst_offset
+
+
+def calc_geotransform_and_dimensions(geotransforms, dimensions, input_extent=None):
+    # input_extent: GeoRectangle
+    # extents differ, but pixel size and rotation are the same.
+    # we'll make a union or an intersection
+    if geotransforms is None or len(geotransforms) != len(dimensions):
+        raise Exception('Error! GeoTransforms and Dimensions have different lengths!')
+    if isinstance(input_extent, GeoRectangle):
+        gt = geotransforms[0]
+        out_extent = input_extent.align(gt)
+    else:
+        out_extent = None  # : GeoRectangle
+        is_union = input_extent == 2
+        for gt, size in zip(geotransforms, dimensions):
+            extent = GeoRectangle.from_geotransform_and_size(gt, size)
+            out_extent = extent if out_extent is None else \
+                out_extent.union(extent) if is_union else out_extent.intersect(extent)
+
+    if out_extent is None or out_extent.is_empty():
+        return None, None, None
+    else:
+        pixel_size = (gt[1], gt[5])
+        pix_extent = out_extent.to_pixels(pixel_size)
+        gt = (out_extent.left,
+              gt[1], gt[2],
+              out_extent.up,
+              gt[4], gt[5])
+    return gt, (math.ceil(pix_extent.w), math.ceil(pix_extent.h)), out_extent
+
+
+def make_temp_vrt(ds, extent):
+    # extent: GeoRectangle
+    options = gdal.BuildVRTOptions(outputBounds=(extent.min_x, extent.min_y, extent.max_x, extent.max_y))
+    vrt_filename = tempfile.mktemp(suffix='.vrt')
+    vrt_ds = gdal.BuildVRT(vrt_filename, ds, options=options)
+    if vrt_ds is None:
+        raise Exception("Error! cannot create vrt. Cannot proceed")
+    return vrt_filename, vrt_ds
+
+
+def make_temp_vrt_old(filename, ds, data_type, projection, bands_count, gt, dimensions, ref_gt, ref_dimensions):
+    drv = gdal.GetDriverByName("VRT")
+    dt = gdal.GetDataTypeByName(data_type)
+
+    # vrt_filename = filename + ".vrt"
+    vrt_filename = tempfile.mktemp(suffix='.vrt')
+    vrt_ds = drv.Create(vrt_filename, ref_dimensions[0], ref_dimensions[1], bands_count, dt)
+    vrt_ds.SetGeoTransform(ref_gt)
+    vrt_ds.SetProjection(projection)
+
+    src_offset, dst_offset = calc_geo_offsets(gt, dimensions, ref_gt, ref_dimensions)
+    if src_offset is None:
+        raise Exception("Error! The requested extent is empty. Cannot proceed")
+
+    source_size = dimensions
+
+    for j in range(1, bands_count + 1):
+        band = vrt_ds.GetRasterBand(j)
+        inBand = ds.GetRasterBand(j)
+        myBlockSize = inBand.GetBlockSize()
+
+        myOutNDV = inBand.GetNoDataValue()
+        if myOutNDV is not None:
+            band.SetNoDataValue(myOutNDV)
+        ndv_out = '' if myOutNDV is None else '<NODATA>%i</NODATA>' % myOutNDV
+
+        source_xml = '<SourceFilename relativeToVRT="1">%s</SourceFilename>' % filename + \
+                     '<SourceBand>%i</SourceBand>' % j + \
+                     '<SourceProperties RasterXSize="%i" RasterYSize="%i" DataType=%s BlockXSize="%i" BlockYSize="%i"/>' % \
+                     (source_size[0], source_size[1], dt, myBlockSize[0], myBlockSize[1]) + \
+                     '<SrcRect xOff="%i" yOff="%i" xSize="%i" ySize="%i"/>' % \
+                     (src_offset[0], src_offset[1], source_size[0], source_size[1]) + \
+                     '<DstRect xOff="%i" yOff="%i" xSize="%i" ySize="%i"/>' % \
+                     (dst_offset[0], dst_offset[1], source_size[0], source_size[1]) + \
+                     ndv_out
+        source = '<ComplexSource>' + source_xml + '</ComplexSource>'
+        band.SetMetadataItem("source_%i" % j, source, 'new_vrt_sources')
+        band = None  # close band
+    return vrt_filename, vrt_ds
+
+
+# def GetExtent(gt,cols,rows):
+#     ''' Return list of corner coordinates from a gt
+#
+#         @type gt:   C{tuple/list}
+#         @param gt: gt
+#         @type cols:   C{int}
+#         @param cols: number of columns in the dataset
+#         @type rows:   C{int}
+#         @param rows: number of rows in the dataset
+#         @rtype:    C{[float,...,float]}
+#         @return:   coordinates of each corner
+#     '''
+#     ext=[]
+#     xarr=[0, cols]
+#     yarr=[0, rows]
+#
+#     for px in xarr:
+#         for py in yarr:
+#             x=gt[0]+(px*gt[1])+(py*gt[2])
+#             y=gt[3]+(px*gt[4])+(py*gt[5])
+#             ext.append([x, y])
+#         yarr.reverse()
+#     return ext
+

--- a/gdal/swig/python/osgeo/auxiliary/geo_rectangle.py
+++ b/gdal/swig/python/osgeo/auxiliary/geo_rectangle.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL
+#  Purpose:  module for handling a geographic rectangle
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import math
+
+
+class GeoRectangle:
+    __slots__ = ['x', 'y', 'w', 'h']
+
+    def __init__(self, x, y, w, h, allow_negative_size=False):
+        if w <= 0:
+            if allow_negative_size:
+                x = x + w
+                w = -w
+            else:
+                w = 0
+        if h <= 0:
+            if allow_negative_size:
+                y = y + h
+                h = -h
+            else:
+                h = 0
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+
+    def __eq__(self, other):
+        if not isinstance(other, GeoRectangle):
+            # don't attempt to compare against unrelated types
+            return False
+        return self.xywh == other.xywh
+
+    def __round__(self, *args, **kwargs):
+        return self.from_lrdu(*(round(i, *args, **kwargs) for i in self.lrdu))
+
+    def is_empty(self):
+        return self.w <= 0 or self.h <= 0
+
+    def intersect(self, other):
+        # other: "GeoRectangle"
+        return GeoRectangle.from_min_max(
+            max(self.min_x, other.min_x),
+            min(self.max_x, other.max_x),
+            max(self.min_y, other.min_y),
+            min(self.max_y, other.max_y),
+        )
+
+    def union(self, other):
+        # other: "GeoRectangle"
+        return GeoRectangle.from_min_max(
+            min(self.min_x, other.min_x),
+            max(self.max_x, other.max_x),
+            min(self.min_y, other.min_y),
+            max(self.max_y, other.max_y),
+        )
+
+    def round(self, digits):
+        self.x = round(self.x, digits)
+        self.y = round(self.y, digits)
+        self.w = round(self.w, digits)
+        self.h = round(self.h, digits)
+
+    def align(self, geo_transform):
+        # compute the pixel-aligned bounding box (larger than the feature's bbox)
+        left = self.min_x - (self.min_x - geo_transform[0]) % geo_transform[1]
+        right = self.max_x + (geo_transform[1] - ((self.max_x - geo_transform[0]) % geo_transform[1]))
+        bottom = self.min_y + (geo_transform[5] - ((self.min_y - geo_transform[3]) % geo_transform[5]))
+        top = self.max_y - (self.max_y - geo_transform[3]) % geo_transform[5]
+        return self.from_lrud(left, right, top, bottom)
+
+    def get_partition(self, part):
+        # part: "GeoRectangle"
+        # part: x,y - part indexes; w,h - part counts
+        part_width = self.w / part.w
+        part_hight = self.h / part.h
+        return GeoRectangle(
+            self.x + part.x * part_width,
+            self.y + part.y * part_hight,
+            part_width,
+            part_hight,
+        )
+
+    @classmethod
+    def empty(cls):
+        return cls(0, 0, 0, 0)
+
+    @classmethod
+    def from_lrud(cls, l, r, u, d):
+        ret = cls(l, d, r - l, u - d)
+        return ret
+
+    @classmethod
+    # # same as min_max
+    def from_lrdu(cls, l, r, d, u):
+        ret = cls(l, d, r - l, u - d)
+        return ret
+
+    @classmethod
+    # # same as min_max
+    def from_xwyh(cls, x, w, y, h, allow_negative_size=False):
+        ret = cls(x, y, w, h, allow_negative_size)
+        return ret
+
+    @classmethod
+    # # same as cls
+    def from_xywh(cls, x, y, w, h, allow_negative_size=False):
+        ret = cls(x, y, w, h, allow_negative_size)
+        return ret
+
+    @classmethod
+    # # same as cls
+    def from_xywhps(cls, x, y, w, h, px, py):
+        ret = cls(x, y, w*px, h*py, True)
+        return ret
+
+    @classmethod
+    # same as lrdu
+    def from_min_max(cls, min_x, max_x, min_y, max_y):
+        ret = cls(min_x, min_y, max_x - min_x, max_y - min_y)
+        return ret
+
+    @classmethod
+    def from_center_and_radius(cls, cent_x, cent_y, rad_x, rad_y=None):
+        if rad_y is None:
+            rad_y = rad_x
+        x = cent_x - rad_x
+        y = cent_y - rad_y
+        w = rad_x * 2
+        h = rad_y * 2
+        ret = cls(x, y, w, h)
+        return ret
+
+    @classmethod
+    def from_points(cls, points):
+        return cls.from_min_max(
+            min(p[0] for p in points),
+            max(p[0] for p in points),
+            min(p[1] for p in points),
+            max(p[1] for p in points),
+        )
+
+    @classmethod
+    def from_geotransform_and_size(cls, gt, size):
+        if gt[2] or gt[4]:
+            return cls.from_points(get_points_extent(gt, *size))
+        else:
+            # faster method
+            origin = (gt[0], gt[3])
+            pixel_size = (gt[1], gt[5])
+            extent = cls.from_xywhps(origin[0], origin[1], size[0], size[1], pixel_size[0], pixel_size[1])
+            # extent_b = cls.from_points(get_points_extent(gt, *size))
+            # assert extent == extent_b
+            return extent
+
+    def to_pixels(self, pixel_size):
+        return self.from_xwyh(self.x / pixel_size[0], self.w / pixel_size[0],
+                              self.y / pixel_size[1], self.h / pixel_size[1], True)
+
+    @classmethod
+    def from_geotransform_and_size_to_pix(cls, gt, size):
+        origin = (gt[0], gt[3])
+        pixel_size = (gt[1], gt[5])
+        pix_origin = list(origin[i] / pixel_size[i] for i in (0, 1))
+        # pix_bounds = list(origin[i] / pixel_size[i] + size[i] for i in (0, 1))
+        return cls.from_xwyh(pix_origin[0], size[0], pix_origin[1], size[1])
+
+    @property
+    def area(self):
+        return self.w * self.h
+
+    @property
+    def size(self):
+        return self.w, self.h
+
+    @property
+    def left(self):
+        return self.x
+
+    @property
+    def right(self):
+        return self.x + self.w
+
+    @property
+    def down(self):
+        return self.y
+
+    @property
+    def up(self):
+        return self.y + self.h
+
+    @property
+    def min_x(self):
+        return self.x
+
+    @property
+    def max_x(self):
+        return self.x + self.w
+
+    @property
+    def min_y(self):
+        return self.y
+
+    @property
+    def max_y(self):
+        return self.y + self.h
+
+    @property
+    def lurd(self):
+        return self.left, self.up, self.right, self.down
+
+    @property
+    def lrud(self):
+        return self.left, self.right, self.up, self.down
+
+    @property
+    def ldru(self):
+        return self.left, self.down, self.right, self.up
+
+    @property
+    def lrdu(self):
+        return self.left, self.right, self.down, self.up
+
+    @property
+    def xywh(self):
+        return self.x, self.y, self.w, self.h
+
+    @property
+    def xwyh(self):
+        return self.x, self.w, self.y, self.h
+
+    @property
+    def min_max(self):
+        return self.min_x, self.max_x, self.min_y, self.max_y
+
+    def __str__(self):
+        return "Rectangle(x[{},{}], y[{},{}] wh[{},{}])".format(self.min_x, self.max_x, self.min_y, self.max_y, self.w, self.h)
+
+    def __repr__(self):
+        return "Rectangle(x:{}, y:{}, w:{}, h:{})".format(self.x, self.y, self.w, self.h)
+
+    def __hash__(self):
+        return hash(self.xywh)
+
+
+def get_points_extent(gt, cols, rows):
+    """Return list of corner coordinates from a geotransform"""
+
+    def transform_point(px, py):
+        x = gt[0] + (px * gt[1]) + (py * gt[2])
+        y = gt[3] + (px * gt[4]) + (py * gt[5])
+        return x, y
+
+    return [
+        transform_point(0, 0),
+        transform_point(0, rows),
+        transform_point(cols, rows),
+        transform_point(cols, 0),
+    ]
+
+
+def find_two_greatest_devisors(x):
+    # x: int
+    sqrtx = int(math.sqrt(x))
+    for y in range(sqrtx, 1, -1):
+        if x % y == 0:
+            return int(x / y), y
+    return x, 1
+
+
+def make_partitions(x_parts, y_parts=None):
+    if y_parts is None:
+        x_parts, y_parts = find_two_greatest_devisors(x_parts)
+    return list(
+        GeoRectangle(i, j, x_parts, y_parts)
+        for i in range(x_parts)
+        for j in range(y_parts)
+    )
+
+
+def test_find_two_greatest_devisors():
+    for i in range(100):
+        print('{:2d} = {:2d} x {:2d}'.format(i, *find_two_greatest_devisors(i)))
+
+
+if __name__ == '__main__':
+    test_find_two_greatest_devisors()

--- a/gdal/swig/python/osgeo/utils/attachpct.py
+++ b/gdal/swig/python/osgeo/utils/attachpct.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#  $Id$
+#
+#  Project:  GDAL
+#  Purpose:  Simple command line program for copying the color table of a
+#            raster into another raster.
+#  Author:   Frank Warmerdam, warmerda@home.com
+#
+# ******************************************************************************
+#  Copyright (c) 2000, Frank Warmerdam
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import sys
+
+from osgeo import gdal
+from osgeo.auxiliary.base import GetOutputDriverFor
+from osgeo.auxiliary.color_table import get_color_table
+
+
+def Usage():
+    print('Usage: attachpct.py <pctfile> <infile> <outfile>')
+    return 1
+
+
+def main(argv):
+    if len(argv) < 3:
+        return Usage()
+    pct_filename = argv[1]
+    src_filename = argv[2]
+    dst_filename = argv[3]
+    _ds, err = doit(src_filename, pct_filename, dst_filename)
+    return err
+
+
+def doit(src_filename, pct_filename, dst_filename=None, driver=None):
+
+    # =============================================================================
+    # Get the PCT.
+    # =============================================================================
+
+    ct = get_color_table(pct_filename)
+    if pct_filename is not None and ct is None:
+        print('No color table on file ', pct_filename)
+        return None, 1
+
+    # =============================================================================
+    # Create a MEM clone of the source file.
+    # =============================================================================
+
+    src_ds = gdal.Open(src_filename)
+
+    mem_ds = gdal.GetDriverByName('MEM').CreateCopy('mem', src_ds)
+
+    # =============================================================================
+    # Assign the color table in memory.
+    # =============================================================================
+
+    mem_ds.GetRasterBand(1).SetRasterColorTable(ct)
+    mem_ds.GetRasterBand(1).SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
+
+    # =============================================================================
+    # Write the dataset to the output file.
+    # =============================================================================
+
+    if not driver:
+        driver = GetOutputDriverFor(dst_filename)
+
+    dst_driver = gdal.GetDriverByName(driver)
+    if dst_driver is None:
+        print('"%s" driver not registered.' % driver)
+        return None, 1
+
+    if driver.upper() == 'MEM':
+        out_ds = mem_ds
+    else:
+        out_ds = dst_driver.CreateCopy(dst_filename or '', mem_ds)
+
+    mem_ds = None
+    src_ds = None
+
+    return out_ds, 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/gdal/swig/python/osgeo/utils/pct2rgb.py
+++ b/gdal/swig/python/osgeo/utils/pct2rgb.py
@@ -10,6 +10,7 @@
 # ******************************************************************************
 #  Copyright (c) 2001, Frank Warmerdam
 #  Copyright (c) 2009-2010, Even Rouault <even dot rouault at spatialys.com>
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -35,6 +36,8 @@ import sys
 
 from osgeo import gdal
 from osgeo.auxiliary.base import GetOutputDriverFor
+from osgeo.auxiliary.color_palette import get_color_palette
+from osgeo.auxiliary.color_table import get_color_table
 
 progress = gdal.TermProgress_nocb
 
@@ -51,9 +54,10 @@ def Usage():
 
 
 def main(argv):
-    frmt = None
+    driver = None
     src_filename = None
     dst_filename = None
+    pct_filename = None
     out_bands = 3
     band_number = 1
 
@@ -68,7 +72,11 @@ def main(argv):
 
         if arg == '-of' or arg == '-f':
             i = i + 1
-            frmt = argv[i]
+            driver = argv[i]
+
+        if arg == '-ct':
+            i = i + 1
+            pct_filename = argv[i]
 
         elif arg == '-b':
             i = i + 1
@@ -91,11 +99,11 @@ def main(argv):
     if dst_filename is None:
         return Usage()
 
-    _ds, err = doit(src_filename, dst_filename, band_number, out_bands, frmt)
+    _ds, err = doit(src_filename, pct_filename, dst_filename, band_number, out_bands, driver)
     return err
 
 
-def doit(src_filename, dst_filename, band_number=1, out_bands=3, frmt=None):
+def doit(src_filename, pct_filename, dst_filename, band_number=1, out_bands=3, driver=None):
     # Open source file
     src_ds = gdal.Open(src_filename)
     if src_ds is None:
@@ -107,18 +115,26 @@ def doit(src_filename, dst_filename, band_number=1, out_bands=3, frmt=None):
     # ----------------------------------------------------------------------------
     # Ensure we recognise the driver.
 
-    if frmt is None:
-        frmt = GetOutputDriverFor(dst_filename)
+    if driver is None:
+        driver = GetOutputDriverFor(dst_filename)
 
-    dst_driver = gdal.GetDriverByName(frmt)
+    dst_driver = gdal.GetDriverByName(driver)
     if dst_driver is None:
-        print('"%s" driver not registered.' % frmt)
+        print('"%s" driver not registered.' % driver)
         return None, 1
 
     # ----------------------------------------------------------------------------
     # Build color table.
 
-    ct = src_band.GetRasterColorTable()
+    if pct_filename is not None:
+        pal = get_color_palette(pct_filename)
+        if pal.has_percents():
+            min_val = src_band.GetMinimum()
+            max_val = src_band.GetMinimum()
+            pal.apply_percent(min_val, max_val)
+        ct = get_color_table(pal)
+    else:
+        ct = src_band.GetRasterColorTable()
 
     ct_size = ct.GetCount()
     lookup = [Numeric.arrayrange(ct_size),
@@ -135,15 +151,14 @@ def doit(src_filename, dst_filename, band_number=1, out_bands=3, frmt=None):
     # ----------------------------------------------------------------------------
     # Create the working file.
 
-    if frmt == 'GTiff':
+    if driver.lower() == 'gtiff':
         tif_filename = dst_filename
     else:
         tif_filename = 'temp.tif'
 
     gtiff_driver = gdal.GetDriverByName('GTiff')
 
-    tif_ds = gtiff_driver.Create(tif_filename,
-                                 src_ds.RasterXSize, src_ds.RasterYSize, out_bands)
+    tif_ds = gtiff_driver.Create(tif_filename, src_ds.RasterXSize, src_ds.RasterYSize, out_bands)
 
 
     # ----------------------------------------------------------------------------
@@ -175,7 +190,7 @@ def doit(src_filename, dst_filename, band_number=1, out_bands=3, frmt=None):
     if tif_filename == dst_filename:
         dst_ds = tif_ds
     else:
-        dst_ds = dst_driver.CreateCopy(dst_filename, tif_ds)
+        dst_ds = dst_driver.CreateCopy(dst_filename or '', tif_ds)
         tif_ds = None
         gtiff_driver.Delete(tif_filename)
 

--- a/gdal/swig/python/osgeo/utils/rgb2pct.py
+++ b/gdal/swig/python/osgeo/utils/rgb2pct.py
@@ -9,6 +9,7 @@
 #
 # ******************************************************************************
 #  Copyright (c) 2001, Frank Warmerdam
+#  Copyright (c) 2020, Idan Miara <idan@miara.com>
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -34,7 +35,7 @@ import sys
 
 from osgeo import gdal
 from osgeo.auxiliary.base import GetOutputDriverFor
-
+from osgeo.auxiliary.color_table import get_color_table
 
 
 def Usage():
@@ -44,7 +45,7 @@ def Usage():
 
 def main(argv):
     color_count = 256
-    frmt = None
+    driver = None
     src_filename = None
     dst_filename = None
     pct_filename = None
@@ -60,7 +61,7 @@ def main(argv):
 
         if arg == '-of' or arg == '-f':
             i = i + 1
-            frmt = argv[i]
+            driver = argv[i]
 
         elif arg == '-n':
             i = i + 1
@@ -84,11 +85,11 @@ def main(argv):
     if dst_filename is None:
         return Usage()
 
-    _ds, err = doit(pct_filename, src_filename, dst_filename, color_count, frmt)
+    _ds, err = doit(src_filename, pct_filename, dst_filename, color_count, driver)
     return err
 
 
-def doit(pct_filename=None, src_filename=None, dst_filename=None, color_count=256, frmt=None):
+def doit(src_filename, pct_filename=None, dst_filename=None, color_count=256, driver=None):
     # Open source file
     src_ds = gdal.Open(src_filename)
     if src_ds is None:
@@ -101,32 +102,30 @@ def doit(pct_filename=None, src_filename=None, dst_filename=None, color_count=25
         return None, 1
 
     # Ensure we recognise the driver.
+    if not driver:
+        driver = GetOutputDriverFor(dst_filename)
 
-    if frmt is None:
-        frmt = GetOutputDriverFor(dst_filename)
-
-    dst_driver = gdal.GetDriverByName(frmt)
+    dst_driver = gdal.GetDriverByName(driver)
     if dst_driver is None:
-        print('"%s" driver not registered.' % frmt)
+        print('"%s" driver not registered.' % driver)
         return None, 1
 
     # Generate palette
 
-    ct = gdal.ColorTable()
     if pct_filename is None:
+        ct = gdal.ColorTable()
         err = gdal.ComputeMedianCutPCT(src_ds.GetRasterBand(1),
                                        src_ds.GetRasterBand(2),
                                        src_ds.GetRasterBand(3),
                                        color_count, ct,
                                        callback=gdal.TermProgress_nocb)
     else:
-        pct_ds = gdal.Open(pct_filename)
-        ct = pct_ds.GetRasterBand(1).GetRasterColorTable().Clone()
+        ct = get_color_table(pct_filename)
 
     # Create the working file.  We have to use TIFF since there are few formats
     # that allow setting the color table after creation.
 
-    if format == 'GTiff':
+    if driver.lower() == 'gtiff':
         tif_filename = dst_filename
     else:
         import tempfile
@@ -160,7 +159,7 @@ def doit(pct_filename=None, src_filename=None, dst_filename=None, color_count=25
     if tif_filename == dst_filename:
         dst_ds = tif_ds
     else:
-        dst_ds = dst_driver.CreateCopy(dst_filename, tif_ds)
+        dst_ds = dst_driver.CreateCopy(dst_filename or '', tif_ds)
         tif_ds = None
         gtiff_driver.Delete(tif_filename)
         os.close(tif_filedesc)

--- a/gdal/swig/python/samples/README.md
+++ b/gdal/swig/python/samples/README.md
@@ -13,6 +13,7 @@ Python interface may be used in your applications.
 `attachpct.py`
 
     Simple command line program for copying the color table of a raster into another raster.
+    from (GDAL >= 3.3) the input color table can be read from a color file
 
 `fft.py`
 

--- a/gdal/swig/python/samples/attachpct.py
+++ b/gdal/swig/python/samples/attachpct.py
@@ -1,99 +1,11 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# ******************************************************************************
-#  $Id$
-#
-#  Project:  GDAL
-#  Purpose:  Simple command line program for copying the color table of a
-#            raster into another raster.
-#  Author:   Frank Warmerdam, warmerda@home.com
-#
-# ******************************************************************************
-#  Copyright (c) 2000, Frank Warmerdam
-#
-#  Permission is hereby granted, free of charge, to any person obtaining a
-#  copy of this software and associated documentation files (the "Software"),
-#  to deal in the Software without restriction, including without limitation
-#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-#  and/or sell copies of the Software, and to permit persons to whom the
-#  Software is furnished to do so, subject to the following conditions:
-#
-#  The above copyright notice and this permission notice shall be included
-#  in all copies or substantial portions of the Software.
-#
-#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-#  DEALINGS IN THE SOFTWARE.
-# ******************************************************************************
 
 import sys
-
-from osgeo import gdal
-from osgeo.auxiliary.base import GetOutputDriverFor
-
-
-def Usage():
-    print('Usage: attachpct.py <pctfile> <infile> <outfile>')
-    return 1
+# import osgeo.utils.attachpct as a convenience to use as a script
+from osgeo.utils.attachpct import *  # noqa
+from osgeo.utils.attachpct import main
+from osgeo.gdal import deprecation_warn
 
 
-def main(argv):
-    if len(argv) < 3:
-        return Usage()
-    ct_filename = argv[1]
-    src_filename = argv[2]
-    dst_filename = argv[3]
-    _ds, err = doit(ct_filename, src_filename, dst_filename)
-    return err
-
-
-def doit(pct_filename, src_filename, dst_filename, frmt=None):
-
-    # =============================================================================
-    # Get the PCT.
-    # =============================================================================
-    ds = gdal.Open(pct_filename)
-    ct = ds.GetRasterBand(1).GetRasterColorTable()
-
-    if ct is None:
-        print('No color table on file ', pct_filename)
-        return None, 1
-
-    ct = ct.Clone()
-
-    # =============================================================================
-    # Create a MEM clone of the source file.
-    # =============================================================================
-
-    src_ds = gdal.Open(src_filename)
-
-    mem_ds = gdal.GetDriverByName('MEM').CreateCopy('mem', src_ds)
-
-    # =============================================================================
-    # Assign the color table in memory.
-    # =============================================================================
-
-    mem_ds.GetRasterBand(1).SetRasterColorTable(ct)
-    mem_ds.GetRasterBand(1).SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
-
-    # =============================================================================
-    # Write the dataset to the output file.
-    # =============================================================================
-
-    if frmt is None:
-        frmt = GetOutputDriverFor(dst_filename)
-
-    out_ds = frmt.CreateCopy(dst_filename, mem_ds)
-
-    mem_ds = None
-    src_ds = None
-
-    return out_ds, 0
-
-
-if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+deprecation_warn('attachpct', 'utils')
+sys.exit(main(sys.argv))


### PR DESCRIPTION
## What does this PR do?

This PR adds option to attach color table from a supported file and to more extent options (union, intersection, custom).
The related functions were implemented in https://github.com/OSGeo/gdal/pull/3131.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/3131 (prerequisite)
https://github.com/OSGeo/gdal/pull/3016 (merged)
https://github.com/OSGeo/gdal/pull/3117 (merged)

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
