### PR TITLE
NITF: Add SNIP TREs - RSMAPB, RSMDCB, RSMECB

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -3380,6 +3380,253 @@ def test_nitf_91():
     assert data == expected_data
 
 ###############################################################################
+# Test parsing RSMAPB TRE (STDI-0002-1-v5.0 App U)
+
+def test_nitf_RSMAPB():
+
+    tre_data = "TRE=RSMAPB=iid                                                                             " + \
+        "edition                                 tid                                     01IG+9.99999999999999E+99" + \
+        "+9.99999999999999E+99+9.99999999999999E+99+9.99999999999999E+99+9.99999999999999E+99+9.99999999999999E+99" + \
+        "Y01011230001+9.99999999999999E+99+9.99999999999999E+99"
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_RSMAPB.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_RSMAPB.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_RSMAPB.ntf')
+
+    expected_data = """<tres>
+  <tre name="RSMAPB" location="image">
+    <field name="IID" value="iid" />
+    <field name="EDITION" value="edition" />
+    <field name="TID" value="tid" />
+    <field name="NPAR" value="01" />
+    <field name="APTYP" value="I" />
+    <field name="LOCTYP" value="G" />
+    <field name="NSFX" value="+9.99999999999999E+99" />
+    <field name="NSFY" value="+9.99999999999999E+99" />
+    <field name="NSFZ" value="+9.99999999999999E+99" />
+    <field name="NOFFX" value="+9.99999999999999E+99" />
+    <field name="NOFFY" value="+9.99999999999999E+99" />
+    <field name="NOFFZ" value="+9.99999999999999E+99" />
+    <field name="APBASE" value="Y" />
+    <field name="NISAP" value="01" />
+    <field name="NISAPR" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <field name="XPWRR" value="1" />
+        <field name="YPWRR" value="2" />
+        <field name="ZPWRR" value="3" />
+      </group>
+    </repeated>
+    <field name="NISAPC" value="00" />
+    <field name="NBASIS" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <repeated number="1">
+          <group index="0">
+            <field name="AEL" value="+9.99999999999999E+99" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+    <repeated number="1">
+      <group index="0">
+        <field name="PARVAL" value="+9.99999999999999E+99" />
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+
+    assert data == expected_data
+
+###############################################################################
+# Test parsing RSMDCB TRE (STDI-0002-1-v5.0 App U)
+
+def test_nitf_RSMDCB():
+
+    tre_data = "TRE=RSMDCB=iid                                                                             " + \
+        "edition                                 tid                                     01001iidi" + " "*76 + \
+        "01Y01GN" + "+9.99999999999999E+99"*6 + "N01ABCD+9.99999999999999E+99"
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_RSMDCB.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_RSMDCB.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_RSMDCB.ntf')
+
+    expected_data = """<tres>
+  <tre name="RSMDCB" location="image">
+    <field name="IID" value="iid" />
+    <field name="EDITION" value="edition" />
+    <field name="TID" value="tid" />
+    <field name="NROWCB" value="01" />
+    <field name="NIMGE" value="001" />
+    <repeated number="1">
+      <group index="0">
+        <field name="IIDI" value="iidi" />
+        <field name="NCOLCB" value="01" />
+      </group>
+    </repeated>
+    <field name="INCAPD" value="Y" />
+    <field name="NPAR" value="01" />
+    <field name="APTYP" value="G" />
+    <field name="LOCTYP" value="N" />
+    <field name="NSFX" value="+9.99999999999999E+99" />
+    <field name="NSFY" value="+9.99999999999999E+99" />
+    <field name="NSFZ" value="+9.99999999999999E+99" />
+    <field name="NOFFX" value="+9.99999999999999E+99" />
+    <field name="NOFFY" value="+9.99999999999999E+99" />
+    <field name="NOFFZ" value="+9.99999999999999E+99" />
+    <field name="APBASE" value="N" />
+    <field name="NGSAP" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <field name="GSAPID" value="ABCD" />
+      </group>
+    </repeated>
+    <repeated number="1">
+      <group index="0">
+        <repeated number="1">
+          <group index="0">
+            <repeated number="1">
+              <group index="0">
+                <field name="CRSCOV" value="+9.99999999999999E+99" />
+              </group>
+            </repeated>
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+
+    assert data == expected_data
+
+###############################################################################
+# Test parsing RSMECB TRE (STDI-0002-1-v5.0 App U)
+
+def test_nitf_RSMECB():
+
+    tre_data = "TRE=RSMECB=iid                                                                             " + \
+        "edition                                 tid                                     " + \
+        "YY01012020110201GN" + "+9.99999999999999E+99"*6 + "N01ABCD02" + "+9.99999999999999E+99"*3 + \
+        "1N2" + "+9.99999999999999E+99"*8 + "N2" + "+9.99999999999999E+99"*4 + "2" + "+9.99999999999999E+99"*4
+
+    ds = gdal.GetDriverByName('NITF').Create('/vsimem/nitf_RSMECB.ntf', 1, 1, options=[tre_data])
+    ds = None
+
+    ds = gdal.Open('/vsimem/nitf_RSMECB.ntf')
+    data = ds.GetMetadata('xml:TRE')[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_RSMECB.ntf')
+
+    expected_data = """<tres>
+  <tre name="RSMECB" location="image">
+    <field name="IID" value="iid" />
+    <field name="EDITION" value="edition" />
+    <field name="TID" value="tid" />
+    <field name="INCLIC" value="Y" />
+    <field name="INCLUC" value="Y" />
+    <field name="NPARO" value="01" />
+    <field name="IGN" value="01" />
+    <field name="CVDATE" value="20201102" />
+    <field name="NPAR" value="01" />
+    <field name="APTYP" value="G" />
+    <field name="LOCTYP" value="N" />
+    <field name="NSFX" value="+9.99999999999999E+99" />
+    <field name="NSFY" value="+9.99999999999999E+99" />
+    <field name="NSFZ" value="+9.99999999999999E+99" />
+    <field name="NOFFX" value="+9.99999999999999E+99" />
+    <field name="NOFFY" value="+9.99999999999999E+99" />
+    <field name="NOFFZ" value="+9.99999999999999E+99" />
+    <field name="APBASE" value="N" />
+    <field name="NGSAP" value="01" />
+    <repeated number="1">
+      <group index="0">
+        <field name="GSAPID" value="ABCD" />
+      </group>
+    </repeated>
+    <repeated number="1">
+      <group index="0">
+        <field name="NUMOPG" value="02" />
+        <repeated number="3">
+          <group index="0">
+            <field name="ERRCVG" value="+9.99999999999999E+99" />
+          </group>
+          <group index="1">
+            <field name="ERRCVG" value="+9.99999999999999E+99" />
+          </group>
+          <group index="2">
+            <field name="ERRCVG" value="+9.99999999999999E+99" />
+          </group>
+        </repeated>
+        <field name="TCDF" value="1" />
+        <field name="ACSMC" value="N" />
+        <field name="NCSEG" value="2" />
+        <repeated number="2">
+          <group index="0">
+            <field name="CORSEG" value="+9.99999999999999E+99" />
+            <field name="TAUSEG" value="+9.99999999999999E+99" />
+          </group>
+          <group index="1">
+            <field name="CORSEG" value="+9.99999999999999E+99" />
+            <field name="TAUSEG" value="+9.99999999999999E+99" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+    <repeated number="1">
+      <group index="0">
+        <repeated number="1">
+          <group index="0">
+            <field name="MAP" value="+9.99999999999999E+99" />
+          </group>
+        </repeated>
+      </group>
+    </repeated>
+    <field name="URR" value="+9.99999999999999E+99" />
+    <field name="URC" value="+9.99999999999999E+99" />
+    <field name="UCC" value="+9.99999999999999E+99" />
+    <field name="UACSMC" value="N" />
+    <field name="UNCSR" value="2" />
+    <repeated number="2">
+      <group index="0">
+        <field name="UCORSR" value="+9.99999999999999E+99" />
+        <field name="UTAUSR" value="+9.99999999999999E+99" />
+      </group>
+      <group index="1">
+        <field name="UCORSR" value="+9.99999999999999E+99" />
+        <field name="UTAUSR" value="+9.99999999999999E+99" />
+      </group>
+    </repeated>
+    <field name="UNCSC" value="2" />
+    <repeated number="2">
+      <group index="0">
+        <field name="UCORSC" value="+9.99999999999999E+99" />
+        <field name="UTAUSC" value="+9.99999999999999E+99" />
+      </group>
+      <group index="1">
+        <field name="UCORSC" value="+9.99999999999999E+99" />
+        <field name="UTAUSC" value="+9.99999999999999E+99" />
+      </group>
+    </repeated>
+  </tre>
+</tres>
+"""
+
+    assert data == expected_data
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -1334,6 +1334,70 @@
         </loop>
     </tre>
 
+    <!-- STDI-0002-1-v5.0 Appendix U, Section 11.4, Table 8 -->
+    <tre name="RSMAPB" md_prefix="NITF_RSMAPB_" minlength="321" maxlength="28411" location="image">
+        <field name="IID" length="80" type="string"/>
+        <field name="EDITION" length="40" type="string"/>
+        <field name="TID" length="40" type="string"/>
+        <field name="NPAR" length="2" type="integer" minval="1" maxval="36"/>
+        <field name="APTYP" length="1" type="string"/>
+        <field name="LOCTYP" length="1" type="string"/>
+        <field name="NSFX" length="21" type="real"/>
+        <field name="NSFY" length="21" type="real"/>
+        <field name="NSFZ" length="21" type="real"/>
+        <field name="NOFFX" length="21" type="real"/>
+        <field name="NOFFY" length="21" type="real"/>
+        <field name="NOFFZ" length="21" type="real"/>
+        <if cond="LOCTYP=R">
+            <field name="XUOL" length="21" type="real"/>
+            <field name="YUOL" length="21" type="real"/>
+            <field name="ZUOL" length="21" type="real"/>
+            <field name="XUXL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="XUYL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="XUZL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="YUXL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="YUYL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="YUZL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="ZUXL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="ZUYL" length="21" type="real" minval="-1" maxval="1"/>
+            <field name="ZUZL" length="21" type="real" minval="-1" maxval="1"/>
+        </if>
+        <field name="APBASE" length="1" type="string"/>
+        <if cond="APTYP=I">
+            <field name="NISAP" length="2" type="integer" minval="1" maxval="99"/>
+            <field name="NISAPR" length="2" type="integer" minval="0" maxval="99"/>
+            <loop counter="NISAPR" md_prefix="ISAPR_%02d_">
+                <field name="XPWRR" length="1" type="integer" minval="0" maxval="5"/>
+                <field name="YPWRR" length="1" type="integer" minval="0" maxval="5"/>
+                <field name="ZPWRR" length="1" type="integer" minval="0" maxval="5"/>
+            </loop>
+            <field name="NISAPC" length="2" type="integer" minval="0" maxval="99"/>
+            <loop counter="NISAPC" md_prefix="ISAPC_%02d_">
+                <field name="XPWRC" length="1" type="integer" minval="0" maxval="5"/>
+                <field name="YPWRC" length="1" type="integer" minval="0" maxval="5"/>
+                <field name="ZPWRC" length="1" type="integer" minval="0" maxval="5"/>
+            </loop>
+        </if>
+        <if cond="APTYP=G">
+            <field name="NGSAP" length="2" type="integer" minval="1" maxval="16"/>
+            <loop counter="NGSAP" md_prefix="GSAP_%02d_">
+                <field name="GSAPID" length="4" type="string"/>
+            </loop>
+        </if>
+        <if cond="APBASE=Y">
+            <field name="NBASIS" length="2" type="integer" minval="1" maxval="99"/>
+            <!-- AEL stored in row-major order for NPAR rows and NBASIS columns -->
+            <loop counter="NPAR" md_prefix="PAR_%02d_">
+                <loop counter="NBASIS" md_prefix="BASIS_%02d_">
+                    <field name="AEL" length="21" type="real"/>
+                </loop>
+            </loop>
+        </if>
+        <loop counter="NPAR" md_prefix="PAR_%02d_">
+            <field name="PARVAL" length="21" type="real"/>
+        </loop>
+    </tre>
+
     <tre name="RSMDCA" minlength="597" maxlength="99988" location="image">
         <field name="IID" length="80" type="string"/>
         <field name="EDITION" length="40" type="string"/>
@@ -1395,6 +1459,83 @@
         <field name="GZZ" length="2" type="integer" minval="1" maxval="36"/>
         <loop formula="(NPART+1)*(NPART)/2" name="DERCOV" md_prefix="DERCOV_%05d"> <!--Warning: this condition is currently hardcoded in the interpreter -->
             <field name="" longname="DERCOV" length="21" type="real"/>
+        </loop>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix U, Section 9.6, Table 6 -->
+    <tre name="RSMDCB" md_prefix="NITF_RSMDCB_" minlength="269" maxlength="99985" location="image">
+        <field name="IID" length="80" type="string"/>
+        <field name="EDITION" length="40" type="string"/>
+        <field name="TID" length="40" type="string"/>
+        <field name="NROWCB" length="2" type="integer"/>
+        <field name="NIMGE" length="3" type="integer"/>
+        <loop counter="NIMGE" md_prefix="IMGE_%03d_">
+            <field name="IIDI" length="80" type="string"/>
+            <field name="NCOLCB" length="2" type="integer" minval="1" maxval="36"/>
+        </loop>
+        <field name="INCAPD" length="1" type="string"/>
+        <if cond="INCAPD=Y">
+            <field name="NPAR" length="2" type="integer" minval="1" maxval="36"/>
+            <field name="APTYP" length="1" type="string"/>
+            <field name="LOCTYP" length="1" type="string"/>
+            <field name="NSFX" length="21" type="real"/>
+            <field name="NSFY" length="21" type="real"/>
+            <field name="NSFZ" length="21" type="real"/>
+            <field name="NOFFX" length="21" type="real"/>
+            <field name="NOFFY" length="21" type="real"/>
+            <field name="NOFFZ" length="21" type="real"/>
+            <if cond="LOCTYP=R">
+                <field name="XUOL" length="21" type="real"/>
+                <field name="YUOL" length="21" type="real"/>
+                <field name="ZUOL" length="21" type="real"/>
+                <field name="XUXL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="XUYL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="XUZL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="YUXL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="YUYL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="YUZL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="ZUXL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="ZUYL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="ZUZL" length="21" type="real" minval="-1" maxval="1"/>
+            </if>
+            <field name="APBASE" length="1" type="string"/>
+            <if cond="APTYP=I">
+                <field name="NISAP" length="2" type="integer" minval="1" maxval="99"/>
+                <field name="NISAPR" length="2" type="integer" minval="0" maxval="99"/>
+                <loop counter="NISAPR" md_prefix="ISAPR_%02d_">
+                    <field name="XPWRR" length="1" type="integer" minval="0" maxval="5"/>
+                    <field name="YPWRR" length="1" type="integer" minval="0" maxval="5"/>
+                    <field name="ZPWRR" length="1" type="integer" minval="0" maxval="5"/>
+                </loop>
+                <field name="NISAPC" length="2" type="integer" minval="0" maxval="99"/>
+                <loop counter="NISAPC" md_prefix="ISAPC_%02d_">
+                    <field name="XPWRC" length="1" type="integer" minval="0" maxval="5"/>
+                    <field name="YPWRC" length="1" type="integer" minval="0" maxval="5"/>
+                    <field name="ZPWRC" length="1" type="integer" minval="0" maxval="5"/>
+                </loop>
+            </if>
+            <if cond="APTYP=G">
+                <field name="NGSAP" length="2" type="integer" minval="1" maxval="16"/>
+                <loop counter="NGSAP" md_prefix="GSAP_%02d_">
+                    <field name="GSAPID" length="4" type="string"/>
+                </loop>
+            </if>
+            <if cond="APBASE=Y">
+                <field name="NBASIS" length="2" type="integer" minval="1" maxval="99"/>
+                <!-- AEL stored in row-major order for NPAR rows and NBASIS columns -->
+                <loop counter="NPAR" md_prefix="PAR_%02d_">
+                    <loop counter="NBASIS" md_prefix="BASIS_%02d_">
+                        <field name="AEL" length="21" type="real"/>
+                    </loop>
+                </loop>
+            </if>
+        </if>
+        <loop counter="NIMGE" md_prefix="IMGE_%03d_">
+            <loop counter="NROWCB" md_prefix="ROW_%02d_">
+                <loop counter="NCOLCB" md_prefix="COL_%02d_">
+                    <field name="CRSCOV" length="21" type="real"/>
+                </loop>
+            </loop>
         </loop>
     </tre>
 
@@ -1487,6 +1628,129 @@
                 <field name="UCORSC" length="21" type="real"/>
                 <field name="UTAUSC" length="21" type="real" unit="pixels"/>
             </loop>
+        </if>
+    </tre>
+
+    <!-- STDI-0002-1-v5.0 Appendix U, Section 13.7, Table 10 -->
+    <tre name="RSMECB" md_prefix="NITF_RSMECB_" minlength="371" maxlength="98487" location="image">
+        <field name="IID" length="80" type="string"/>
+        <field name="EDITION" length="40" type="string"/>
+        <field name="TID" length="40" type="string"/>
+        <field name="INCLIC" length="1" type="string"/>
+        <field name="INCLUC" length="1" type="string"/>
+        <if cond="INCLIC=Y">
+            <field name="NPARO" length="2" type="integer" minval="1" maxval="53"/>
+            <field name="IGN" length="2" type="integer" minval="1" maxval="36"/>
+            <field name="CVDATE" length="8" type="string"/>
+            <field name="NPAR" length="2" type="integer" minval="1" maxval="36"/>
+            <field name="APTYP" length="1" type="string"/>
+            <field name="LOCTYP" length="1" type="string"/>
+            <field name="NSFX" length="21" type="real"/>
+            <field name="NSFY" length="21" type="real"/>
+            <field name="NSFZ" length="21" type="real"/>
+            <field name="NOFFX" length="21" type="real"/>
+            <field name="NOFFY" length="21" type="real"/>
+            <field name="NOFFZ" length="21" type="real"/>
+            <if cond="LOCTYP=R">
+                <field name="XUOL" length="21" type="real"/>
+                <field name="YUOL" length="21" type="real"/>
+                <field name="ZUOL" length="21" type="real"/>
+                <field name="XUXL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="XUYL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="XUZL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="YUXL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="YUYL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="YUZL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="ZUXL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="ZUYL" length="21" type="real" minval="-1" maxval="1"/>
+                <field name="ZUZL" length="21" type="real" minval="-1" maxval="1"/>
+            </if>
+            <field name="APBASE" length="1" type="string"/>
+            <if cond="APTYP=I">
+                <field name="NISAP" length="2" type="integer"/>
+                <field name="NISAPR" length="2" type="integer"/>
+                <loop counter="NISAPR" md_prefix="ISAPR_%02d_">
+                    <field name="XPWRR" length="1" type="integer"/>
+                    <field name="YPWRR" length="1" type="integer"/>
+                    <field name="ZPWRR" length="1" type="integer"/>
+                </loop>
+                <field name="NISAPC" length="2" type="integer"/>
+                <loop counter="NISAPC" md_prefix="ISAPC_%02d_">
+                    <field name="XPWRC" length="1" type="integer"/>
+                    <field name="YPWRC" length="1" type="integer"/>
+                    <field name="ZPWRC" length="1" type="integer"/>
+                </loop>
+            </if>
+            <if cond="APTYP=G">
+                <field name="NGSAP" length="2" type="integer"/>
+                <loop counter="NGSAP" md_prefix="GSAP_%02d_">
+                    <field name="GSAPID" length="4" type="string"/>
+                </loop>
+            </if>
+            <if cond="APBASE=Y">
+                <field name="NBASIS" length="2" type="integer"/>
+                <!-- AEL stored in row-major order for NPAR rows and NBASIS columns -->
+                <loop counter="NPAR" md_prefix="PAR_%02d_">
+                    <loop counter="NBASIS" md_prefix="BASIS_%02d_">
+                        <field name="AEL" length="21" type="real"/>
+                    </loop>
+                </loop>
+            </if>
+            <loop counter="IGN" md_prefix="IGN_%02d_">
+                <field name="NUMOPG" length="2" type="integer"/>
+                <loop formula="(NUMOPG+1)*(NUMOPG)/2" md_prefix="EG_%04d_"> <!--Warning: this condition is currently hardcoded in the interpreter -->
+                    <field name="ERRCVG" length="21" type="real"/>
+                </loop>
+                <field name="TCDF" length="1" type="integer" minval="0" maxval="2"/>
+                <field name="ACSMC" length="1" type="string"/>
+                <if cond="ACSMC=N">
+                    <field name="NCSEG" length="1" type="integer" minval="2" maxval="9"/>
+                    <loop counter="NCSEG" md_prefix="CSEG_%01d_">
+                        <field name="CORSEG" length="21" type="real" minval="0" maxval="1"/>
+                        <field name="TAUSEG" length="21" type="real" minval="0"/>
+                    </loop>
+                </if>
+                <if cond="ACSMC=Y">
+                    <field name="AC" length="21" type="real" minval="0" maxval="1"/>
+                    <field name="ALPC" length="21" type="real" minval="0" maxval="1"/>
+                    <field name="BETC" length="21" type="real" minval="0" maxval="10"/>
+                    <field name="TC" length="21" type="real" minval="0"/>
+                </if>
+            </loop>
+            <!-- MAP stored in row-major order for NPAR rows and NPARO columns -->
+            <loop counter="NPAR" md_prefix="PAR_%02d_">
+                <loop counter="NPARO" md_prefix="PARO_%02d_">
+                    <field name="MAP" length="21" type="real"/>
+                </loop>
+            </loop>
+        </if>
+        <if cond="INCLUC=Y">
+            <field name="URR" length="21" type="real"/>
+            <field name="URC" length="21" type="real"/>
+            <field name="UCC" length="21" type="real"/>
+            <field name="UACSMC" length="1" type="string"/>
+            <if cond="UACSMC=N">
+                <field name="UNCSR" length="1" type="integer" minval="2" maxval="9"/>
+                <loop counter="UNCSR" md_prefix="CSR_%01d_">
+                    <field name="UCORSR" length="21" type="real" minval="0" maxval="1"/>
+                    <field name="UTAUSR" length="21" type="real" minval="0"/>
+                </loop>
+                <field name="UNCSC" length="1" type="integer" minval="2" maxval="9"/>
+                <loop counter="UNCSC" md_prefix="CSC_%01d_">
+                    <field name="UCORSC" length="21" type="real" minval="0" maxval="1"/>
+                    <field name="UTAUSC" length="21" type="real" minval="0"/>
+                </loop>
+            </if>
+            <if cond="UACSMC=Y">
+                <field name="UACR" length="21" type="real" minval="0" maxval="1"/>
+                <field name="UALPCR" length="21" type="real" minval="0" maxval="1"/>
+                <field name="UBETCR" length="21" type="real" minval="0" maxval="10"/>
+                <field name="UTCR" length="21" type="real" minval="0"/>
+                <field name="UACC" length="21" type="real" minval="0" maxval="1"/>
+                <field name="UALPCC" length="21" type="real" minval="0" maxval="1"/>
+                <field name="UBETCC" length="21" type="real" minval="0" maxval="10"/>
+                <field name="UTCC" length="21" type="real" minval="0"/>
+            </if>
         </if>
     </tre>
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds the capability to read the RSMAPB, RSMDCB, and RSMECB TREs, defined in the Spectral NITF Implementation Profile.  The SNIP is in NGA.STND.0072_1.0_SNIP 7 June 2019. It out references to the relevant TREs in Table 6-2.
The RSM* TREs are defined in STDI-0002-1-v5.0 Appendix U.

These are the last three SNIP related TREs!

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/3113
https://github.com/OSGeo/gdal/pull/3090

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
