### PR TITLE
restore py_modules in setup.py

### DIFF
--- a/gdal/swig/python/setup.py
+++ b/gdal/swig/python/setup.py
@@ -390,6 +390,11 @@ ext_modules = [gdal_module,
                osr_module,
                ogr_module]
 
+py_modules = ['gdal',
+              'ogr',
+              'osr',
+              'gdalconst']
+
 if os.path.exists('setup_vars.ini'):
     with open('setup_vars.ini') as f:
         lines = f.readlines()
@@ -401,6 +406,7 @@ if GNM_ENABLED:
 
 if HAVE_NUMPY:
     ext_modules.append(array_module)
+    py_modules.append('gdalnumeric')
 
 packages = ["osgeo", "osgeo.utils", "osgeo.auxiliary"]
 
@@ -452,6 +458,7 @@ setup_kwargs = dict(
     description=description,
     license=license_type,
     classifiers=classifiers,
+    py_modules=py_modules,
     packages=packages,
     url=url,
     data_files=data_files,


### PR DESCRIPTION
## What does this PR do?

This PR restores the py_modules in setup.py as in GDAL 3.1

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/3149

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

