### PR TITLE
NITF: Add xml:DES metadata domain and DES creation option

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -3627,6 +3627,73 @@ def test_nitf_RSMECB():
     assert data == expected_data
 
 ###############################################################################
+# Test creation and reading of Data Extension Segments (DES)
+
+def test_nitf_des():
+    des_data = "02U" + " "*166 + r'0004ABCD1234567\0890'
+
+    ds = gdal.GetDriverByName("NITF").Create("/vsimem/nitf_DES.ntf", 1, 1, options=["DES=DES1=" + des_data, "DES=DES2=" + des_data])
+    ds = None
+
+    # DESDATA portion will be Base64 encoded on output
+    # base64.b64encode(bytes("1234567\x00890", "utf-8")) == b'MTIzNDU2NwA4OTA='
+    ds = gdal.Open("/vsimem/nitf_DES.ntf")
+    data = ds.GetMetadata("xml:DES")[0]
+    ds = None
+
+    gdal.GetDriverByName('NITF').Delete('/vsimem/nitf_DES.ntf')
+
+    expected_data = """<des_list>
+  <des name="DES1">
+    <field name="NITF_DESVER" value="02" />
+    <field name="NITF_DECLAS" value="U" />
+    <field name="NITF_DESCLSY" value="" />
+    <field name="NITF_DESCODE" value="" />
+    <field name="NITF_DESCTLH" value="" />
+    <field name="NITF_DESREL" value="" />
+    <field name="NITF_DESDCTP" value="" />
+    <field name="NITF_DESDCDT" value="" />
+    <field name="NITF_DESDCXM" value="" />
+    <field name="NITF_DESDG" value="" />
+    <field name="NITF_DESDGDT" value="" />
+    <field name="NITF_DESCLTX" value="" />
+    <field name="NITF_DESCATP" value="" />
+    <field name="NITF_DESCAUT" value="" />
+    <field name="NITF_DESCRSN" value="" />
+    <field name="NITF_DESSRDT" value="" />
+    <field name="NITF_DESCTLN" value="" />
+    <field name="NITF_DESSHL" value="0004" />
+    <field name="NITF_DESSHF" value="ABCD" />
+    <field name="NITF_DESDATA" value="MTIzNDU2NwA4OTA=" />
+  </des>
+  <des name="DES2">
+    <field name="NITF_DESVER" value="02" />
+    <field name="NITF_DECLAS" value="U" />
+    <field name="NITF_DESCLSY" value="" />
+    <field name="NITF_DESCODE" value="" />
+    <field name="NITF_DESCTLH" value="" />
+    <field name="NITF_DESREL" value="" />
+    <field name="NITF_DESDCTP" value="" />
+    <field name="NITF_DESDCDT" value="" />
+    <field name="NITF_DESDCXM" value="" />
+    <field name="NITF_DESDG" value="" />
+    <field name="NITF_DESDGDT" value="" />
+    <field name="NITF_DESCLTX" value="" />
+    <field name="NITF_DESCATP" value="" />
+    <field name="NITF_DESCAUT" value="" />
+    <field name="NITF_DESCRSN" value="" />
+    <field name="NITF_DESSRDT" value="" />
+    <field name="NITF_DESCTLN" value="" />
+    <field name="NITF_DESSHL" value="0004" />
+    <field name="NITF_DESSHF" value="ABCD" />
+    <field name="NITF_DESDATA" value="MTIzNDU2NwA4OTA=" />
+  </des>
+</des_list>
+"""
+
+    assert data == expected_data
+
+###############################################################################
 # Test reading C4 compressed file
 
 

--- a/gdal/doc/source/drivers/raster/nitf.rst
+++ b/gdal/doc/source/drivers/raster/nitf.rst
@@ -149,6 +149,13 @@ Creation Options:
 -  **FILE_TRE=tre-name=tre-contents**: Similar to above
    options, except that the TREs are written in the file header, instead
    of the image header.
+-  **DES=des-name=des-contents**: One or more DES creation options may
+   be provided to write arbitrary user defined DESs to the NITF file.
+   The des-name should be at most 25 characters, and the des-contents
+   should be "backslash escaped" if it contains backslashes or zero
+   bytes.  The des-contents must contain standard DES fields, starting
+   with DESVER (See MIL-STD-2500C).  DESs are not currently copied in
+   CreateCopy(), but may be explicitly added as with Create().
 -  **SDE_TRE=YES/NO**: Write GEOLOB and GEOPSB TREs to
    get more precise georeferencing. This is limited to geographic SRS,
    and to CreateCopy() for now.

--- a/gdal/doc/source/drivers/raster/nitf.rst
+++ b/gdal/doc/source/drivers/raster/nitf.rst
@@ -153,7 +153,8 @@ Creation Options:
    be provided to write arbitrary user defined DESs to the NITF file.
    The des-name should be at most 25 characters, and the des-contents
    should be "backslash escaped" if it contains backslashes or zero
-   bytes.  The des-contents must contain standard DES fields, starting
+   bytes, as in CPLEscapeString(str, -1, CPLES_BackslashQuotable).
+   The des-contents must contain standard DES fields, starting
    with DESVER (See MIL-STD-2500C).  DESs are not currently copied in
    CreateCopy(), but may be explicitly added as with Create().
 -  **SDE_TRE=YES/NO**: Write GEOLOB and GEOPSB TREs to

--- a/gdal/doc/source/drivers/raster/nitf_advanced.rst
+++ b/gdal/doc/source/drivers/raster/nitf_advanced.rst
@@ -217,13 +217,35 @@ TRE creation from hexadecimal data
 ----------------------------------
 
 TRE data can be added to a newly created NITF file in hexadecimal format to encode binary
-data such as unsigned int or floating point types.  The hexadecimal TRE creation option is 
+data such as unsigned int or floating point types.  The hexadecimal TRE creation option is
 supplied as "TRE=HEX/<tre_name>=<hex_tre_data>" or "FILE_TRE=HEX/<tre_name>=<hex_tre_data>
 
 .. code-block:: python
 
     # Encode "ABC" as 3 bytes of hex data, "414243"
     ds = gdal.GetDriverByName('NITF').Create('/vsimem/file.ntf', 1, 1, options=["TRE=HEX/TSTTRE=414243"])
+
+Data Extension Segments (xml:DES)
+---------------------------------
+Data Extension Segments (DESs) are user-defined metadata extensions to the NITF format.
+The DES metadata is available through the xml\:DES metadata domain.  The xml\:DES domain
+returns an XML string with standard and user-defined DES fields in plain text, and
+the user-defined DES data as Base64 encoded text.  The following is an example XML structure:
+
+::
+
+    <des_list>
+      <des name="TEST">
+        <field name="NITF_DESVER" value="02" />
+        <field name="NITF_DECLAS" value="U" />
+        <field name="NITF_DESCLSY" value="" />
+        [...]
+        <field name="NITF_DESCTLN" value="" />
+        <field name="NITF_DESSHL" value="0004" />
+        <field name="NITF_DESSHF" value="ABCD" />
+        <field name="NITF_DESDATA" value="MTIzNDU2Nzg5MA==" />
+      </des>
+    </des_list>
 
 Raw File / Image Headers
 ------------------------

--- a/gdal/frmts/nitf/nitfdataset.cpp
+++ b/gdal/frmts/nitf/nitfdataset.cpp
@@ -2289,7 +2289,7 @@ CPLErr NITFDataset::_SetProjection(const char* _pszProjection)
 void NITFDataset::InitializeNITFDESMetadata()
 {
     static const char   * const pszDESMetadataDomain       = "NITF_DES_METADATA";
-    static const char   * const pszDESsDomain              = "NITF_DES";
+    static const char   * const pszDESsDomain              = "xml:DES";
     static const char   * const pszMDXmlDataContentDESDATA = "NITF_DES_XML_DATA_CONTENT_DESDATA";
     static const char   * const pszXmlDataContent          = "XML_DATA_CONTENT";
     constexpr int     idxXmlDataContentDESDATA   = 973;
@@ -2349,93 +2349,6 @@ void NITFDataset::InitializeNITFDESMetadata()
         pachNITFDES   = NULL;
         ppszDESsList += 1;
     }
-}
-
-/************************************************************************/
-/*                       InitializeNITFDESs()                           */
-/************************************************************************/
-
-void NITFDataset::InitializeNITFDESs()
-{
-    static const char * const pszDESsDomain = "NITF_DES";
-
-    char **ppszDESsList = oSpecialMD.GetMetadata( pszDESsDomain );
-
-    if( ppszDESsList != NULL ) return;
-
-/* -------------------------------------------------------------------- */
-/*  Go through all the segments and process all DES segments.           */
-/* -------------------------------------------------------------------- */
-
-    char               *pachDESData  = NULL;
-    int                 nDESDataSize = 0;
-    std::string         encodedDESData("");
-    CPLStringList       aosList;
-
-    for( int iSegment = 0; iSegment < psFile->nSegmentCount; iSegment++ )
-    {
-        NITFSegmentInfo *psSegInfo = psFile->pasSegmentInfo + iSegment;
-
-        if( EQUAL(psSegInfo->szSegmentType,"DE") )
-        {
-            nDESDataSize = psSegInfo->nSegmentHeaderSize + psSegInfo->nSegmentSize;
-            pachDESData  = reinterpret_cast<char *>(
-                VSI_MALLOC_VERBOSE( nDESDataSize + 1 ) );
-
-            if (pachDESData == NULL)
-            {
-                return;
-            }
-
-            if( VSIFSeekL( psFile->fp, psSegInfo->nSegmentHeaderStart,
-                          SEEK_SET ) != 0
-                || static_cast<int>( VSIFReadL( pachDESData, 1, nDESDataSize,
-                                                psFile->fp ) ) != nDESDataSize )
-            {
-                CPLError( CE_Failure, CPLE_FileIO,
-                          "Failed to read %d byte DES subheader from " CPL_FRMT_GUIB ".",
-                          nDESDataSize,
-                          psSegInfo->nSegmentHeaderStart );
-                CPLFree( pachDESData );
-                return;
-            }
-
-            pachDESData[nDESDataSize] = '\0';
-
-/* -------------------------------------------------------------------- */
-/*          Accumulate all the DES segments.                            */
-/* -------------------------------------------------------------------- */
-
-            char* pszBase64 = CPLBase64Encode( nDESDataSize, (const GByte *)pachDESData );
-            encodedDESData = pszBase64;
-            CPLFree(pszBase64);
-
-            CPLFree( pachDESData );
-            pachDESData = NULL;
-
-            if( encodedDESData.empty() )
-            {
-                CPLError(CE_Failure, CPLE_AppDefined, "Failed to encode DES subheader data!");
-                return;
-            }
-
-            // The length of the DES subheader data plus a space is append to the beginning of the encoded
-            // string so that we can recover the actual length of the image subheader when we decode it.
-
-            char buffer[20];
-
-            snprintf(buffer, sizeof(buffer), "%d", nDESDataSize);
-
-            std::string desSubheaderStr(buffer);
-            desSubheaderStr.append(" ");
-            desSubheaderStr.append(encodedDESData);
-
-            aosList.AddString(desSubheaderStr.c_str() );
-        }
-    }
-
-    if (!aosList.empty())
-        oSpecialMD.SetMetadata( aosList.List(), pszDESsDomain );
 }
 
 /************************************************************************/
@@ -2549,6 +2462,46 @@ void NITFDataset::InitializeNITFTREs()
     }
 }
 #endif
+
+/************************************************************************/
+/*                       InitializeNITFDESs()                           */
+/************************************************************************/
+
+void NITFDataset::InitializeNITFDESs()
+{
+    char** papszDESsList = oSpecialMD.GetMetadata( "xml:DES" );
+
+    if( papszDESsList != nullptr )
+    {
+        return;
+    }
+
+    CPLXMLNode* psDesListNode = CPLCreateXMLNode(nullptr, CXT_Element, "des_list");
+
+    for( int iSegment = 0; iSegment < psFile->nSegmentCount; iSegment++ )
+    {
+        NITFSegmentInfo *psSegInfo = psFile->pasSegmentInfo + iSegment;
+
+        if (EQUAL(psSegInfo->szSegmentType, "DE"))
+        {
+            CPLXMLNode* psDesNode = NITFDESGetXml(psFile, iSegment);
+
+            if (psDesNode != nullptr)
+            {
+                CPLAddXMLChild(psDesListNode, psDesNode);
+            }
+        }
+    }
+
+    if (psDesListNode->psChild != nullptr)
+    {
+        char* pszXML = CPLSerializeXMLTree(psDesListNode);
+        char* apszMD[2] = { pszXML, nullptr };
+        oSpecialMD.SetMetadata( apszMD, "xml:DES" );
+        CPLFree(pszXML);
+    }
+    CPLDestroyXMLNode(psDesListNode);
+}
 
 /************************************************************************/
 /*                       InitializeNITFMetadata()                        */
@@ -3045,7 +2998,7 @@ char **NITFDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
                                    TRUE,
-                                   "NITF_METADATA", "NITF_DES", "NITF_DES_METADATA",
+                                   "NITF_METADATA", "xml:DES", "NITF_DES_METADATA",
                                    "NITF_FILE_HEADER_TRES", "NITF_IMAGE_SEGMENT_TRES",
                                    "CGM", "TEXT", "TRE", "xml:TRE", "OVERVIEWS", nullptr);
 }
@@ -3065,8 +3018,7 @@ char **NITFDataset::GetMetadata( const char * pszDomain )
         return oSpecialMD.GetMetadata( pszDomain );
     }
 
-#ifdef ESRI_BUILD
-    if( pszDomain != NULL && EQUAL(pszDomain,"NITF_DES") )
+    if( pszDomain != nullptr && EQUAL(pszDomain,"xml:DES") )
     {
         // InitializeNITFDESs retrieves all the DES file headers (NOTE: The returned strings are base64-encoded).
 
@@ -3074,6 +3026,7 @@ char **NITFDataset::GetMetadata( const char * pszDomain )
         return oSpecialMD.GetMetadata( pszDomain );
     }
 
+#ifdef ESRI_BUILD
     if( pszDomain != NULL && EQUAL(pszDomain,"NITF_DES_METADATA") )
     {
         // InitializeNITFDESs retrieves all the DES file headers (NOTE: The returned strings are base64-encoded).
@@ -4290,7 +4243,7 @@ NITFDataset::NITFCreateCopy(
         else if( STARTS_WITH_CI(papszSrcMD[iMD], "NITF_FHDR") )
         {
             bPreserveSrcMDAsCreationOption =
-                CSLFetchNameValue(papszOptions, "FHDR") == nullptr; 
+                CSLFetchNameValue(papszOptions, "FHDR") == nullptr;
         }
         if( bPreserveSrcMDAsCreationOption )
         {
@@ -4336,7 +4289,7 @@ NITFDataset::NITFCreateCopy(
 
         char *pszName = nullptr;
         CPLParseNameValue( papszSrcMD[iMD], &pszName );
-        if( pszName != nullptr && 
+        if( pszName != nullptr &&
             CSLPartialFindString(papszOptions, CPLSPrintf("TRE=%s", pszName)) < 0 )
         {
             papszFullOptions = CSLAddString( papszFullOptions, osTRE );
@@ -6139,7 +6092,8 @@ void GDALRegister_NITF()
     osCreationOptions +=
 "   <Option name='TRE' type='string' description='Under the format TRE=tre-name,tre-contents'/>"
 "   <Option name='FILE_TRE' type='string' description='Under the format FILE_TRE=tre-name,tre-contents'/>"
-"   <Option name='BLOCKA_BLOCK_COUNT' type='int'/>";
+"   <Option name='BLOCKA_BLOCK_COUNT' type='int'/>"
+"   <Option name='DES' type='string' description='Under the format DES=des-name,des-contents'/>";
 
     for( unsigned int i=0; apszFieldsBLOCKA[i] != nullptr; i+=3 )
     {

--- a/gdal/frmts/nitf/nitfdataset.cpp
+++ b/gdal/frmts/nitf/nitfdataset.cpp
@@ -6093,7 +6093,7 @@ void GDALRegister_NITF()
 "   <Option name='TRE' type='string' description='Under the format TRE=tre-name,tre-contents'/>"
 "   <Option name='FILE_TRE' type='string' description='Under the format FILE_TRE=tre-name,tre-contents'/>"
 "   <Option name='BLOCKA_BLOCK_COUNT' type='int'/>"
-"   <Option name='DES' type='string' description='Under the format DES=des-name,des-contents'/>";
+"   <Option name='DES' type='string' description='Under the format DES=des-name=des-contents'/>";
 
     for( unsigned int i=0; apszFieldsBLOCKA[i] != nullptr; i+=3 )
     {

--- a/gdal/frmts/nitf/nitfdataset.h
+++ b/gdal/frmts/nitf/nitfdataset.h
@@ -88,9 +88,9 @@ class NITFDataset final: public GDALPamDataset
 
 #ifdef ESRI_BUILD
     void         InitializeNITFDESMetadata();
-    void         InitializeNITFDESs();
     void         InitializeNITFTREs();
 #endif
+    void         InitializeNITFDESs();
     void         InitializeNITFMetadata();
     void         InitializeCGMMetadata();
     void         InitializeTextMetadata();

--- a/gdal/frmts/nitf/nitfdes.c
+++ b/gdal/frmts/nitf/nitfdes.c
@@ -590,3 +590,98 @@ int NITFDESExtractShapefile(NITFDES* psDES, const char* pszRadixFileName)
 
     return TRUE;
 }
+
+/************************************************************************/
+/*                              NITFDESGetXml()                         */
+/************************************************************************/
+
+CPLXMLNode* NITFDESGetXml(NITFFile* psFile, int iSegment)
+{
+    CPLXMLNode* psDesNode = CPLCreateXMLNode(NULL, CXT_Element, "des");
+    NITFDES* psDes = NITFDESAccess(psFile, iSegment);
+    char** papszTmp = psDes->papszMetadata;
+
+    if (psDes == NULL)
+    {
+        CPLDestroyXMLNode(psDesNode);
+        return NULL;
+    }
+
+    if (papszTmp == NULL)
+    {
+        CPLDestroyXMLNode(psDesNode);
+        NITFDESDeaccess(psDes);
+        return NULL;
+    }
+
+    while (papszTmp != NULL && *papszTmp != NULL)
+    {
+        CPLXMLNode* psFieldNode;
+        CPLXMLNode* psNameNode;
+        CPLXMLNode* psValueNode;
+
+        const char* pszMDval;
+        const char* pszMDsep;
+
+        if ((pszMDsep = strchr(*papszTmp, '=')) == NULL)
+        {
+            NITFDESDeaccess(psDes);
+            CPLDestroyXMLNode(psDesNode);
+            CPLError(CE_Failure, CPLE_AppDefined,
+                "NITF DES metadata item missing separator");
+            return NULL;
+        }
+
+        pszMDval = pszMDsep + 1;
+
+        if (papszTmp == psDes->papszMetadata)
+        {
+            CPLCreateXMLNode(CPLCreateXMLNode(psDesNode, CXT_Attribute, "name"),
+                CXT_Text, pszMDval);
+        }
+        else
+        {
+            char* pszMDname = (char*)CPLMalloc(pszMDsep - *papszTmp + 1);
+            CPLStrlcpy(pszMDname, *papszTmp, pszMDsep - *papszTmp + 1);
+
+            psFieldNode = CPLCreateXMLNode(psDesNode, CXT_Element, "field");
+            psNameNode = CPLCreateXMLNode(psFieldNode, CXT_Attribute, "name");
+            CPLCreateXMLNode(psNameNode, CXT_Text, pszMDname);
+            psValueNode = CPLCreateXMLNode(psFieldNode, CXT_Attribute, "value");
+
+            if (strcmp(pszMDname, "NITF_DESDATA") == 0)
+            {
+                int nLen;
+                char* pszUnescaped = CPLUnescapeString(pszMDval, &nLen, CPLES_BackslashQuotable);
+                char* pszBase64 = CPLBase64Encode(nLen, (const GByte*)pszUnescaped);
+                CPLFree(pszUnescaped);
+
+                if (pszBase64 == NULL)
+                {
+                    NITFDESDeaccess(psDes);
+                    CPLDestroyXMLNode(psDesNode);
+                    CPLFree(pszMDname);
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                        "NITF DES data could not be encoded");
+                    return NULL;
+                }
+
+                CPLCreateXMLNode(psValueNode, CXT_Text, pszBase64);
+
+                CPLFree(pszBase64);
+            }
+            else
+            {
+                CPLCreateXMLNode(psValueNode, CXT_Text, pszMDval);
+            }
+
+            CPLFree(pszMDname);
+        }
+
+        ++papszTmp;
+    }
+
+    NITFDESDeaccess(psDes);
+
+    return psDesNode;
+}

--- a/gdal/frmts/nitf/nitfdes.c
+++ b/gdal/frmts/nitf/nitfdes.c
@@ -597,22 +597,23 @@ int NITFDESExtractShapefile(NITFDES* psDES, const char* pszRadixFileName)
 
 CPLXMLNode* NITFDESGetXml(NITFFile* psFile, int iSegment)
 {
-    CPLXMLNode* psDesNode = CPLCreateXMLNode(NULL, CXT_Element, "des");
+    CPLXMLNode* psDesNode;
+    char** papszTmp;
     NITFDES* psDes = NITFDESAccess(psFile, iSegment);
-    char** papszTmp = psDes->papszMetadata;
 
     if (psDes == NULL)
     {
-        CPLDestroyXMLNode(psDesNode);
         return NULL;
     }
 
-    if (papszTmp == NULL)
+    if (psDes->papszMetadata == NULL)
     {
-        CPLDestroyXMLNode(psDesNode);
         NITFDESDeaccess(psDes);
         return NULL;
     }
+
+    psDesNode = CPLCreateXMLNode(NULL, CXT_Element, "des");
+    papszTmp = psDes->papszMetadata;
 
     while (papszTmp != NULL && *papszTmp != NULL)
     {

--- a/gdal/frmts/nitf/nitflib.h
+++ b/gdal/frmts/nitf/nitflib.h
@@ -263,6 +263,8 @@ void      CPL_DLL  NITFDESFreeTREData( char* pabyTREData );
 
 int       CPL_DLL  NITFDESExtractShapefile(NITFDES* psDES, const char* pszRadixFileName);
 
+CPLXMLNode CPL_DLL *NITFDESGetXml(NITFFile*, int iSegment);
+
 /* -------------------------------------------------------------------- */
 /*      These are really intended to be private helper stuff for the    */
 /*      library.                                                        */


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR adds an xml:DES metadata domain to extract user-defined Data Extension Segments from a NITF file.  A DES creation option was also added to facilitate testing.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
