### PR TITLE
tms_MapML_CBMTILE.json: fix it to use correct resolution / scaleDenominator

### DIFF
--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -521,21 +521,21 @@ def test_gdal2tiles_py_mapml():
 
     shutil.rmtree('tmp/out_gdal2tiles_mapml', ignore_errors=True)
 
-    gdal.Translate('tmp/byte_CBM.tif', '../gcore/data/byte.tif',
-                   options='-a_srs EPSG:3978 -a_ullr 0 7928380 40 7928300')
+    gdal.Translate('tmp/byte_APS.tif', '../gcore/data/byte.tif',
+                   options='-a_srs EPSG:5936 -a_ullr 0 40 40 0')
 
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q -p CBMTILE -w mapml -z 16-18 --url "https://foo" tmp/byte_CBM.tif tmp/out_gdal2tiles_mapml')
+        '-q -p APSTILE -w mapml -z 16-18 --url "https://foo" tmp/byte_APS.tif tmp/out_gdal2tiles_mapml')
 
     mapml = open('tmp/out_gdal2tiles_mapml/mapml.mapml', 'rb').read().decode('utf-8')
-    print(mapml)
-    assert '<extent units="CBMTILE">' in mapml
+    #print(mapml)
+    assert '<extent units="APSTILE">' in mapml
     assert '<input name="z" type="zoom" value="18" min="16" max="18" />' in mapml
-    assert '<input name="x" type="location" axis="column" units="tilematrix" min="925005" max="925007" />' in mapml
-    assert '<input name="y" type="location" axis="row" units="tilematrix" min="837614" max="837615" />' in mapml
+    assert '<input name="x" type="location" axis="column" units="tilematrix" min="122496" max="122496" />' in mapml
+    assert '<input name="y" type="location" axis="row" units="tilematrix" min="139647" max="139647" />' in mapml
     assert '<link tref="https://foo/out_gdal2tiles_mapml/{z}/{x}/{y}.png" rel="tile" />' in mapml
 
     shutil.rmtree('tmp/out_gdal2tiles_mapml', ignore_errors=True)
-    gdal.Unlink('tmp/byte_CBM.tif')
+    gdal.Unlink('tmp/byte_APS.tif')

--- a/gdal/data/tms_MapML_CBMTILE.json
+++ b/gdal/data/tms_MapML_CBMTILE.json
@@ -18,329 +18,329 @@
       "scaleDenominator": 137016643.08090523
     },
     {
-      "matrixHeight": 10,
+      "matrixHeight": 9,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 10,
-      "identifier": "0",
+      "matrixWidth": 9,
+      "identifier": "1",
       "type": "TileMatrixType",
-      "scaleDenominator": 68508321.54045261
+      "scaleDenominator": 80320101.1163927317
     },
     {
-      "matrixHeight": 20,
+      "matrixHeight": 15,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 20,
-      "identifier": "0",
+      "matrixWidth": 15,
+      "identifier": "2",
       "type": "TileMatrixType",
-      "scaleDenominator": 34254160.77022631
+      "scaleDenominator": 47247118.3037604243
     },
     {
-      "matrixHeight": 40,
+      "matrixHeight": 25,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 40,
-      "identifier": "0",
+      "matrixWidth": 25,
+      "identifier": "3",
       "type": "TileMatrixType",
-      "scaleDenominator": 17127080.385113154
+      "scaleDenominator": 28348270.982256256
     },
     {
-      "matrixHeight": 80,
+      "matrixHeight": 42,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 80,
-      "identifier": "0",
+      "matrixWidth": 42,
+      "identifier": "4",
       "type": "TileMatrixType",
-      "scaleDenominator": 8563540.192556577
+      "scaleDenominator": 16536491.40631615
     },
     {
-      "matrixHeight": 160,
+      "matrixHeight": 73,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 160,
-      "identifier": "0",
+      "matrixWidth": 73,
+      "identifier": "5",
       "type": "TileMatrixType",
-      "scaleDenominator": 4281770.096278288
+      "scaleDenominator": 9449423.66075208597
     },
     {
-      "matrixHeight": 320,
+      "matrixHeight": 121,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 320,
-      "identifier": "0",
+      "matrixWidth": 121,
+      "identifier": "6",
       "type": "TileMatrixType",
-      "scaleDenominator": 2140885.048139144
+      "scaleDenominator": 5669654.1964512514
     },
     {
-      "matrixHeight": 640,
+      "matrixHeight": 208,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 640,
-      "identifier": "0",
+      "matrixWidth": 208,
+      "identifier": "7",
       "type": "TileMatrixType",
-      "scaleDenominator": 1070442.524069572
+      "scaleDenominator": 3307298.2812632299
     },
     {
-      "matrixHeight": 1280,
+      "matrixHeight": 363,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 1280,
-      "identifier": "0",
+      "matrixWidth": 363,
+      "identifier": "8",
       "type": "TileMatrixType",
-      "scaleDenominator": 535221.262034786
+      "scaleDenominator": 1889884.73215041705
     },
     {
-      "matrixHeight": 2560,
+      "matrixHeight": 605,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 2560,
-      "identifier": "0",
+      "matrixWidth": 605,
+      "identifier": "9",
       "type": "TileMatrixType",
-      "scaleDenominator": 267610.631017393
+      "scaleDenominator": 1133930.83929025033
     },
     {
-      "matrixHeight": 5120,
+      "matrixHeight": 1036,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 5120,
-      "identifier": "0",
+      "matrixWidth": 1036,
+      "identifier": "10",
       "type": "TileMatrixType",
-      "scaleDenominator": 133805.3155086965
+      "scaleDenominator": 661459.656252646004
     },
     {
-      "matrixHeight": 10240,
+      "matrixHeight": 1727,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 10240,
-      "identifier": "0",
+      "matrixWidth": 1727,
+      "identifier": "11",
       "type": "TileMatrixType",
-      "scaleDenominator": 66902.65775434826
+      "scaleDenominator": 396875.793751587567
     },
     {
-      "matrixHeight": 20480,
+      "matrixHeight": 2900,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 20480,
-      "identifier": "0",
+      "matrixWidth": 2900,
+      "identifier": "12",
       "type": "TileMatrixType",
-      "scaleDenominator": 33451.32887717413
+      "scaleDenominator": 236235.591518802132
     },
     {
-      "matrixHeight": 40960,
+      "matrixHeight": 5000,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 40960,
-      "identifier": "0",
+      "matrixWidth": 5000,
+      "identifier": "13",
       "type": "TileMatrixType",
-      "scaleDenominator": 16725.664438587064
+      "scaleDenominator": 137016.643080905225
     },
     {
-      "matrixHeight": 81920,
+      "matrixHeight": 8530,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 81920,
-      "identifier": "0",
+      "matrixWidth": 818530920,
+      "identifier": "14",
       "type": "TileMatrixType",
-      "scaleDenominator": 8362.832219293532
+      "scaleDenominator": 80320.1011163927178
     },
     {
-      "matrixHeight": 163840,
+      "matrixHeight": 14501,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 163840,
-      "identifier": "0",
+      "matrixWidth": 14501,
+      "identifier": "15",
       "type": "TileMatrixType",
-      "scaleDenominator": 4181.416109646766
+      "scaleDenominator": 47247.1183037604278
     },
     {
-      "matrixHeight": 327680,
+      "matrixHeight": 24167,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 327680,
-      "identifier": "0",
+      "matrixWidth": 24167,
+      "identifier": "16",
       "type": "TileMatrixType",
-      "scaleDenominator": 2090.708054823383
+      "scaleDenominator": 28348.2709822562538
     },
     {
-      "matrixHeight": 655360,
+      "matrixHeight": 41429,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 655360,
-      "identifier": "0",
+      "matrixWidth": 41429,
+      "identifier": "17",
       "type": "TileMatrixType",
-      "scaleDenominator": 1045.3540274116915
+      "scaleDenominator": 16536.4914063161486
     },
     {
-      "matrixHeight": 1310720,
+      "matrixHeight": 72500,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 1310720,
-      "identifier": "0",
+      "matrixWidth": 72500,
+      "identifier": "18",
       "type": "TileMatrixType",
-      "scaleDenominator": 522.6770137058458
+      "scaleDenominator": 9449.4236607520852
     },
     {
-      "matrixHeight": 2621440,
+      "matrixHeight": 120834,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 2621440,
-      "identifier": "0",
+      "matrixWidth": 120834,
+      "identifier": "19",
       "type": "TileMatrixType",
-      "scaleDenominator": 261.3385068529229
+      "scaleDenominator": 5669.65419645125075
     },
     {
-      "matrixHeight": 5242880,
+      "matrixHeight": 207143,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 5242880,
-      "identifier": "0",
+      "matrixWidth": 207143,
+      "identifier": "20",
       "type": "TileMatrixType",
-      "scaleDenominator": 130.66925342646144
+      "scaleDenominator": 3307.29828126322991
     },
     {
-      "matrixHeight": 10485760,
+      "matrixHeight": 362501,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 10485760,
-      "identifier": "0",
+      "matrixWidth": 362501,
+      "identifier": "21",
       "type": "TileMatrixType",
-      "scaleDenominator": 65.33462671323072
+      "scaleDenominator": 1889.88473215041699
     },
     {
-      "matrixHeight": 20971520,
+      "matrixHeight": 604167,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 20971520,
-      "identifier": "0",
+      "matrixWidth": 604167,
+      "identifier": "22",
       "type": "TileMatrixType",
-      "scaleDenominator": 32.66731335661536
+      "scaleDenominator": 1133.93083929025011
     },
     {
-      "matrixHeight": 41943040,
+      "matrixHeight": 1035715,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 41943040,
-      "identifier": "0",
+      "matrixWidth": 1035715,
+      "identifier": "23",
       "type": "TileMatrixType",
-      "scaleDenominator": 16.33365667830768
+      "scaleDenominator": 661.459656252645914
     },
     {
-      "matrixHeight": 83886080,
+      "matrixHeight": 1726191,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 83886080,
-      "identifier": "0",
+      "matrixWidth": 1726191,
+      "identifier": "24",
       "type": "TileMatrixType",
-      "scaleDenominator": 8.16682833915384
+      "scaleDenominator": 396.875793751587537
     },
     {
-      "matrixHeight": 167772160,
+      "matrixHeight": 2900001,
       "tileHeight": 256,
       "tileWidth": 256,
       "topLeftCorner": [
         -34655800,
         39310000
       ],
-      "matrixWidth": 167772160,
-      "identifier": "0",
+      "matrixWidth": 2900001,
+      "identifier": "25",
       "type": "TileMatrixType",
-      "scaleDenominator": 4.08341416957692
+      "scaleDenominator": 236.235591518802124
     }
   ]
 }

--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -175,7 +175,6 @@ The following profiles are supported:
 - mercator: mapped to OSMTILE MapML tiling scheme
 - geodetic: mapped to WGS84 MapML tiling scheme
 - APSTILE: from the tms_MapML_APSTILE.json data file
-- CBMTILE: from the tms_MapML_CBMTILE.json data file
 
 The generated MapML file in the output directory is ``mapml.mapl``
 


### PR DESCRIPTION
Unfortunately this makes it non-usable by gdal2tiles, but still by the COG driver