### PR TITLE
VRT: preserve source block size

### DIFF
--- a/autotest/gcore/vrtmisc.py
+++ b/autotest/gcore/vrtmisc.py
@@ -540,11 +540,26 @@ def test_vrtmisc_mask_implicit_overviews():
     ds = None
     gdal.Unlink('/vsimem/out.tif')
 
+
 ###############################################################################
-# Cleanup.
+# Test setting block size
 
 
-def test_vrtmisc_cleanup():
-    pass
+def test_vrtmisc_blocksize():
+    filename = '/vsimem/test_vrtmisc_blocksize.vrt'
+    vrt_ds = gdal.GetDriverByName('VRT').Create(filename, 50, 50, 0)
+    options = [
+        'subClass=VRTSourcedRasterBand',
+        'blockXSize=32',
+        'blockYSize=48'
+    ]
+    vrt_ds.AddBand(gdal.GDT_Byte, options)
+    vrt_ds = None
 
+    vrt_ds = gdal.Open(filename)
+    blockxsize, blockysize = vrt_ds.GetRasterBand(1).GetBlockSize()
+    assert blockxsize == 32
+    assert blockysize == 48
+    vrt_ds = None
 
+    gdal.Unlink(filename)

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -600,6 +600,22 @@ def test_gdal_translate_lib_tr_non_nearest_oversampling():
     assert ds.RasterYSize == 3
     assert 0 not in struct.unpack('B' * 13 * 3, ds.ReadRaster())
 
+
+def test_gdal_translate_lib_preserve_block_size():
+
+    src_ds = gdal.GetDriverByName('GTiff').Create(
+        '/vsimem/tmp.tif', 256, 256, 1, options = ['TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=64'])
+
+    # VRT created by CreateCopy() of VRT driver
+    ds = gdal.Translate('', src_ds, format = 'VRT')
+    assert ds.GetRasterBand(1).GetBlockSize() == [32, 64]
+
+    # VRT created by GDALTranslate()
+    ds = gdal.Translate('', src_ds, format = 'VRT', metadataOptions=['FOO=BAR'])
+    assert ds.GetRasterBand(1).GetBlockSize() == [32, 64]
+    src_ds = None
+    gdal.Unlink('/vsimem/tmp.tif')
+
 ###############################################################################
 # Cleanup
 
@@ -614,8 +630,4 @@ def test_gdal_translate_lib_cleanup():
             os.remove('tmp/test' + str(i + 1) + '.tif.aux.xml')
         except OSError:
             pass
-
-    
-
-
 

--- a/gdal/data/gdalvrt.xsd
+++ b/gdal/data/gdalvrt.xsd
@@ -210,10 +210,9 @@
         </xs:sequence>
         <xs:attribute name="dataType" type="DataTypeType"/>
         <xs:attribute name="band" type="xs:unsignedInt"/>
+        <xs:attribute name="blockXSize" type="nonNegativeInteger32"/>
+        <xs:attribute name="blockYSize" type="nonNegativeInteger32"/>
         <xs:attribute name="subClass" type="VRTRasterBandSubClassType"/>
-
-        <xs:attribute name="BlockXSize" type="xs:unsignedInt"/> <!-- ignored -->
-        <xs:attribute name="BlockYSize" type="xs:unsignedInt"/> <!-- ignored -->
     </xs:complexType>
 
     <xs:simpleType name="ZeroOrOne">

--- a/gdal/doc/source/drivers/raster/vrt.rst
+++ b/gdal/doc/source/drivers/raster/vrt.rst
@@ -138,7 +138,21 @@ The **dataAxisToSRSAxisMapping** attribute is allowed since GDAL 3.0 to describe
 VRTRasterBand
 +++++++++++++
 
-It will have a dataType attribute with the type of the pixel data associated with this band (use names Byte, UInt16, Int16, UInt32, Int32, Float32, Float64, CInt16, CInt32, CFloat32 or CFloat64) and the band this element represents (1 based).  This element may have Metadata, ColorInterp, NoDataValue, HideNoDataValue, ColorTable, GDALRasterAttributeTable, Description and MaskBand subelements as well as the various kinds of source elements such as SimpleSource, ComplexSource, etc.  A raster band may have many "sources" indicating where the actual raster data should be fetched from, and how it should be mapped into the raster bands pixel space.
+The attributes for VRTRasterBand are:
+
+- **dataType** (optional): type of the pixel data associated with this band (use
+  names Byte, UInt16, Int16, UInt32, Int32, Float32, Float64, CInt16, CInt32, CFloat32 or CFloat64).
+  If not specified, defaults to 1
+ 
+- **band** (optional): band number this element represents (1 based).
+
+- **blockXSize** (optional, GDAL >= 3.3): block width.
+  If not specified, defaults to the minimum of the raster width and 128.
+
+- **blockYSize** (optional, GDAL >= 3.3): block height.
+  If not specified, defaults to the minimum of the raster height and 128.
+
+This element may have Metadata, ColorInterp, NoDataValue, HideNoDataValue, ColorTable, GDALRasterAttributeTable, Description and MaskBand subelements as well as the various kinds of source elements such as SimpleSource, ComplexSource, etc.  A raster band may have many "sources" indicating where the actual raster data should be fetched from, and how it should be mapped into the raster bands pixel space.
 
 The allowed subelements for VRTRasterBand are :
 

--- a/gdal/frmts/dimap/dimapdataset.cpp
+++ b/gdal/frmts/dimap/dimapdataset.cpp
@@ -1218,8 +1218,19 @@ int DIMAPDataset::ReadImageInformation2()
 
     for( int iBand = 0; iBand < poImageDS->GetRasterCount(); iBand++ )
     {
+        auto poSrcBandFirstImage = poImageDS->GetRasterBand(iBand+1);
+        CPLStringList aosAddBandOptions;
+        int nSrcBlockXSize, nSrcBlockYSize;
+        poSrcBandFirstImage->GetBlockSize(&nSrcBlockXSize, &nSrcBlockYSize);
+        if( oMapRowColumnToName.size() == 1 ||
+            ((nTileWidth % nSrcBlockXSize) == 0 &&
+             (nTileHeight % nSrcBlockYSize) == 0) )
+        {
+            aosAddBandOptions.SetNameValue("BLOCKXSIZE", CPLSPrintf("%d", nSrcBlockXSize));
+            aosAddBandOptions.SetNameValue("BLOCKYSIZE", CPLSPrintf("%d", nSrcBlockYSize));
+        }
         poVRTDS->AddBand(
-            poImageDS->GetRasterBand(iBand+1)->GetRasterDataType(), nullptr );
+            poSrcBandFirstImage->GetRasterDataType(), aosAddBandOptions.List() );
 
         VRTSourcedRasterBand *poVRTBand =
             reinterpret_cast<VRTSourcedRasterBand *>(

--- a/gdal/frmts/vrt/vrtdataset.cpp
+++ b/gdal/frmts/vrt/vrtdataset.cpp
@@ -1280,10 +1280,15 @@ CPLErr VRTDataset::AddBand( GDALDataType eType, char **papszOptions )
             poBand = poDerivedBand;
         }
         else {
+            int nBlockXSizeIn = atoi(
+                CSLFetchNameValueDef(papszOptions, "BLOCKXSIZE", "0"));
+            int nBlockYSizeIn = atoi(
+                CSLFetchNameValueDef(papszOptions, "BLOCKYSIZE", "0"));
             /* ---- Standard sourced band ---- */
             poBand = new VRTSourcedRasterBand(
                 this, GetRasterCount() + 1, eType,
-                GetRasterXSize(), GetRasterYSize());
+                GetRasterXSize(), GetRasterYSize(),
+                nBlockXSizeIn, nBlockYSizeIn);
         }
 
         SetBand( GetRasterCount() + 1, poBand );

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -596,6 +596,10 @@ class CPL_DLL VRTSourcedRasterBand CPL_NON_FINAL: public VRTRasterBand
                    VRTSourcedRasterBand( GDALDataset *poDS, int nBand,
                                          GDALDataType eType,
                                          int nXSize, int nYSize );
+                   VRTSourcedRasterBand( GDALDataset *poDS, int nBand,
+                                         GDALDataType eType,
+                                         int nXSize, int nYSize,
+                                         int nBlockXSizeIn, int nBlockYSizeIn );
     virtual        ~VRTSourcedRasterBand();
 
     virtual CPLErr IRasterIO( GDALRWFlag, int, int, int, int,

--- a/gdal/frmts/vrt/vrtrasterband.cpp
+++ b/gdal/frmts/vrt/vrtrasterband.cpp
@@ -375,6 +375,22 @@ CPLErr VRTRasterBand::XMLInit( CPLXMLNode * psTree,
         }
     }
 
+    const char* pszBlockXSize = CPLGetXMLValue( psTree, "blockXSize", nullptr );
+    if( pszBlockXSize )
+    {
+        int nBlockXSizeIn = atoi(pszBlockXSize);
+        if( nBlockXSizeIn >= 32 && nBlockXSizeIn <= 16384 )
+            nBlockXSize = nBlockXSizeIn;
+    }
+
+    const char* pszBlockYSize = CPLGetXMLValue( psTree, "blockYSize", nullptr );
+    if( pszBlockYSize )
+    {
+        int nBlockYSizeIn = atoi(pszBlockYSize);
+        if( nBlockYSizeIn >= 32 && nBlockYSizeIn <= 16384 )
+            nBlockYSize = nBlockYSizeIn;
+    }
+
 /* -------------------------------------------------------------------- */
 /*      Apply any band level metadata.                                  */
 /* -------------------------------------------------------------------- */
@@ -641,6 +657,12 @@ CPLXMLNode *VRTRasterBand::SerializeToXML( const char *pszVRTPath )
 
     if( nBand > 0 )
         CPLSetXMLValue( psTree, "#band", CPLSPrintf( "%d", GetBand() ) );
+
+    if( nBlockXSize != 128 && nBlockXSize != nRasterXSize )
+        CPLSetXMLValue( psTree, "#blockXSize", CPLSPrintf( "%d", nBlockXSize ) );
+
+    if( nBlockYSize != 128 && nBlockYSize != nRasterYSize )
+        CPLSetXMLValue( psTree, "#blockYSize", CPLSPrintf( "%d", nBlockYSize ) );
 
     CPLXMLNode *psMD = oMDMD.Serialize();
     if( psMD != nullptr )

--- a/gdal/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtsourcedrasterband.cpp
@@ -102,6 +102,18 @@ VRTSourcedRasterBand::VRTSourcedRasterBand( GDALDataType eType,
 VRTSourcedRasterBand::VRTSourcedRasterBand( GDALDataset *poDSIn, int nBandIn,
                                             GDALDataType eType,
                                             int nXSize, int nYSize ) :
+    VRTSourcedRasterBand(poDSIn, nBandIn, eType, nXSize, nYSize, 0, 0)
+{
+}
+
+/************************************************************************/
+/*                        VRTSourcedRasterBand()                        */
+/************************************************************************/
+
+VRTSourcedRasterBand::VRTSourcedRasterBand( GDALDataset *poDSIn, int nBandIn,
+                                            GDALDataType eType,
+                                            int nXSize, int nYSize,
+                                            int nBlockXSizeIn, int nBlockYSizeIn ) :
     m_nRecursionCounter(0),
     m_papszSourceList(nullptr),
     nSources(0),
@@ -114,6 +126,10 @@ VRTSourcedRasterBand::VRTSourcedRasterBand( GDALDataset *poDSIn, int nBandIn,
     nBand = nBandIn;
 
     eDataType = eType;
+    if( nBlockXSizeIn > 0 )
+        nBlockXSize = nBlockXSizeIn;
+    if( nBlockYSizeIn > 0 )
+        nBlockYSize = nBlockYSizeIn;
 }
 
 /************************************************************************/

--- a/gdal/gcore/rasterio.cpp
+++ b/gdal/gcore/rasterio.cpp
@@ -4216,6 +4216,12 @@ static void GDALCopyWholeRasterGetSwathSize(
 
     const char* pszSrcCompression =
         poSrcPrototypeBand->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+    if( pszSrcCompression == nullptr )
+    {
+        auto poSrcDS = poSrcPrototypeBand->GetDataset();
+        if( poSrcDS )
+            pszSrcCompression = poSrcDS->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+    }
 
 /* -------------------------------------------------------------------- */
 /*      What will our swath size be?                                    */


### PR DESCRIPTION
Assorted set of improvements that help for example to gdal_translate a DIMAP JPEG2000 dataset (read by JP2KAK) to tiled GeoTIFF