### PR TITLE
Update gdal2tiles.rst - fix typo

### DIFF
--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -42,7 +42,7 @@ can publish a picture without proper georeferencing too.
 .. note::
 
     Inputs with non-Byte data type (i.e. ``Int16``, ``UInt16``,...) will be clamped to
-    the ``Byte`` data type, causing wrong results. To awoid this it is necessary to
+    the ``Byte`` data type, causing wrong results. To avoid this it is necessary to
     rescale input to the ``Byte`` data type using `gdal_translate` utility.
     
 .. note::


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fix a typo in the gdal2tiles documentation page

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] All CI builds and checks have passed

