### PR TITLE
fix:fix symbol conflicts with python libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@
 .idea
 .vscode
 .vs
+.vim
+
+# clangd lsp
+.clangd
+compile_commands.json
 
 # Python
 __pycache__/
@@ -28,3 +33,5 @@ CMakeLists.txt
 # NuGet package manager storage
 gdal/packages*
 gdal/share
+
+

--- a/gdal/gcore/gdalpython.cpp
+++ b/gdal/gcore/gdalpython.cpp
@@ -51,8 +51,8 @@ static std::mutex gMutex;
 static bool gbHasInitializedPython = false;
 static PyThreadState* gphThreadState = nullptr;
 
-static PyGILState_STATE (*PyGILState_Ensure)(void) = nullptr;
-static void (*PyGILState_Release)(PyGILState_STATE) = nullptr;
+static PyGILState_STATE (*PyLibGILState_Ensure)(void) = nullptr;
+static void (*PyLibGILState_Release)(PyGILState_STATE) = nullptr;
 
 // Emulate Py_CompileString with Py_CompileStringExFlags
 // Probably just a temporary measure for a bug of Python 3.8.0 on Windows
@@ -735,8 +735,8 @@ static bool LoadPythonAPI()
     LOAD(libHandle, PySequence_Size);
     LOAD(libHandle, PySequence_GetItem);
     LOAD(libHandle, PyArg_ParseTuple);
-    LOAD(libHandle, PyGILState_Ensure);
-    LOAD(libHandle, PyGILState_Release);
+    LOAD_WITH_NAME(libHandle, PyLibGILState_Ensure, "PyGILState_Ensure");
+    LOAD_WITH_NAME(libHandle, PyLibGILState_Release, "PyGILState_Release");
     LOAD(libHandle, PyErr_Fetch);
     LOAD(libHandle, PyErr_Clear);
     LOAD(libHandle, Py_GetVersion);
@@ -815,7 +815,7 @@ GIL_Holder::GIL_Holder(bool bExclusiveLock):
     {
         gMutex.lock();
     }
-    m_eState = PyGILState_Ensure();
+    m_eState = PyLibGILState_Ensure();
 }
 
 /************************************************************************/
@@ -824,7 +824,7 @@ GIL_Holder::GIL_Holder(bool bExclusiveLock):
 
 GIL_Holder::~GIL_Holder()
 {
-    PyGILState_Release(m_eState);
+    PyLibGILState_Release(m_eState);
     if( m_bExclusiveLock )
     {
         gMutex.unlock();


### PR DESCRIPTION
there is a project called pystack . which used to print the python
process's stack info . pystack will use gdb to attach the python process
and call some function defined in python's executable file or python
library
such as
call (void *) PyGILState_Ensure()
call (void) PyRun_SimpleString("exec(r\"f = open('/tmp/pystack', 'w'); \
itervalues = lambda d:getattr(d,'itervalues',d.values)();import gc,traceback,itertools,sys; \
f.write('Dumping Threads\\n\\n\\n');f.write('\\n---------------\\n'.join(str(traceback.format_stack(o)
) for o in itervalues(sys._current_frames())));f.close()\")")
...

but the symbol PyGILState_Ensure also defined in gdal .so if a python
script use gdal , we can't use pystack to debug this .

so i changed the symbol of gdal by add Lib infix

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
