### PR TITLE
OGRSpatialReference::exportToWKT(): add a option to allow export of Geographic/Projected 3D CRS in WKT1_GDAL

### DIFF
--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -1436,6 +1436,11 @@ static PJ* GDAL_proj_crs_create_bound_crs_to_WGS84(PJ_CONTEXT* ctx, PJ* pj,
  *     WKT1 is an alias of WKT1_GDAL.
  *     WKT2 will default to the latest revision implemented (currently WKT2_2018)
  *     WKT2_2019 can be used as an alias of WKT2_2018 since GDAL 3.2
+ * <li>ALLOW_ELLIPSOIDAL_HEIGHT_AS_VERTICAL_CRS=YES/NO. Default is NO. If set
+ * to YES and FORMAT=WKT1_GDAL, a Geographic 3D CRS or a Projected 3D CRS will
+ * be exported as a compound CRS whose vertical part represents an ellipsoidal
+ * height (for example for use with LAS 1.4 WKT1).
+ * Requires PROJ 7.2.1 and GDAL 3.2.1.</li>
  * </li>
  * </ul>
  *
@@ -1520,6 +1525,13 @@ OGRErr OGRSpatialReference::exportToWkt( char ** ppszResult,
     aosOptions.SetNameValue("MULTILINE",
                     CSLFetchNameValueDef(papszOptions, "MULTILINE", "NO"));
 
+    const char* pszAllowEllpsHeightAsVertCS =
+        CSLFetchNameValue(papszOptions, "ALLOW_ELLIPSOIDAL_HEIGHT_AS_VERTICAL_CRS");
+    if( pszAllowEllpsHeightAsVertCS )
+    {
+        aosOptions.SetNameValue("ALLOW_ELLIPSOIDAL_HEIGHT_AS_VERTICAL_CRS",
+                                pszAllowEllpsHeightAsVertCS);
+    }
 
     PJ* boundCRS = nullptr;
     if( wktFormat == PJ_WKT1_GDAL &&


### PR DESCRIPTION
as CompoundCRS with a VerticalCRS being an ellipsoidal height, which is
not conformant. But needed for LAS 1.4 that only supports WKT1

Requires PROJ 7.2.1 / https://github.com/OSGeo/PROJ/pull/2470

```python:
from osgeo import osr
srs = osr.SpatialReference()
srs.ImportFromEPSG(32631)
srs.PromoteTo3D()
print(srs.ExportToWkt(['FORMAT=WKT1', 'ALLOW_ELLIPSOIDAL_HEIGHT_AS_VERTICAL_CRS=YES']))
```

outputs:

'COMPD_CS["WGS 84 / UTM zone 31N + Ellipsoid (metre)",PROJCS["WGS 84 / UTM zone 31N",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",3],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","32631"]],VERT_CS["Ellipsoid (metre)",VERT_DATUM["Ellipsoid",2002],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Ellipsoidal height",UP]]]'
