### PR TITLE
Fix method name in migration guide

### DIFF
--- a/gdal/MIGRATION_GUIDE.TXT
+++ b/gdal/MIGRATION_GUIDE.TXT
@@ -54,7 +54,7 @@ Out-of-tree drivers:
 * GDALDataset::SetProjection() made non-virtual.
   Replaced by SetSpatialRef() virtual method.
   Compatibility emulation possible by defining:
-    CPLErr SetProjection(const char*) override; // note leading underscore
+    CPLErr _SetProjection(const char*) override; // note leading underscore
     CPLErr SetSpatialRef(const OGRSpatialReference* poSRS) override {
         return OldSetProjectionFromSetSpatialRef(poSRS);
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the docs.
