### PR TITLE
gdal_calc: map GDAL NoData to numpy.nan

### DIFF
--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -181,10 +181,7 @@ def test_gdal_calc_py_4():
     out = make_temp_filename_list(test_id, test_count)
 
     # some values are clipped to 255, but this doesn't matter... small values were visually checked
-    print('gdal_calc', '-A {} --calc=1 --overwrite --outfile {}'.format(infile, out[0]))
     test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} --calc=1 --overwrite --outfile {}'.format(infile, out[0]))
-    print(script_path, 'gdal_calc', '-A {} -B {} --B_band 1 --allBands A --calc=A+B --NoDataValue=999 --overwrite --outfile {}'.format(
-        infile, out[0], out[1]))
     test_py_scripts.run_py_script(script_path, 'gdal_calc', '-A {} -B {} --B_band 1 --allBands A --calc=A+B --NoDataValue=999 --overwrite --outfile {}'.format(infile, out[0], out[1]))
 
     bnd_count = 3

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -451,7 +451,6 @@ def test_gdal_calc_py_10():
 
 
 def test_gdal_calc_py_cleanup():
-    return
     """ cleanup all temporary files that were created in this pytest """
     global temp_counter_dict
     global opts_counter_counter

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -424,6 +424,27 @@ def test_gdal_calc_py_9():
     i += 1
 
 
+def test_gdal_calc_py_10():
+    """ test working with numpy.nan """
+    if gdalnumeric_not_available:
+        pytest.skip("gdalnumeric is not available, skipping all tests", allow_module_level=True)
+
+    script_path = test_py_scripts.get_py_script('gdal_calc')
+    if script_path is None:
+        pytest.skip("gdal_calc script not found, skipping all tests", allow_module_level=True)
+
+    infile = get_input_file()
+    test_id, test_count = 10, 1
+    out = make_temp_filename_list(test_id, test_count)
+
+    test_py_scripts.run_py_script(
+        script_path, 'gdal_calc',
+        '-A {} --A_band=1 -B {} --B_band=2 -Z {} --Z_band=3 --calc="numpy.nanmean([A, B, C], axis=2)" --overwrite --outfile {}'.
+        format(infile, infile, infile, out[0]))
+
+    check_file(out[0], 36074, 1, 1)
+
+
 def test_gdal_calc_py_cleanup():
     """ cleanup all temporary files that were created in this pytest """
     global temp_counter_dict

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -39,6 +39,7 @@ but no projection checking is performed (unless projectionCheck option is used).
 
     Calculation in gdalnumeric syntax using ``+``, ``-``, ``/``, ``*``, or any numpy array functions (i.e. ``log10()``).
     Multiple ``--calc`` options can be listed to produce a multiband file (GDAL >= 3.2).
+    NoDataValue will be mapped to numpy.nan when reading and numpy.nan will be written as NoDataValue in the output file (GDAL >= 3.3).
 
 .. option:: -A <filename>
 

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -39,7 +39,6 @@ but no projection checking is performed (unless projectionCheck option is used).
 
     Calculation in gdalnumeric syntax using ``+``, ``-``, ``/``, ``*``, or any numpy array functions (i.e. ``log10()``).
     Multiple ``--calc`` options can be listed to produce a multiband file (GDAL >= 3.2).
-    NoDataValue will be mapped to ``numpy.nan`` when reading and ``numpy.nan`` will be written as NoDataValue in the output file (GDAL >= 3.3).
 
 .. option:: -A <filename>
 
@@ -75,6 +74,13 @@ but no projection checking is performed (unless projectionCheck option is used).
     By default, the input bands NoDataValue are not participating in the calculation.
     By setting this setting - no special treatment will be performed on the input NoDataValue. and they will be participating in the calculation as any other value.
     The output will not have a set NoDataValue, unless you explicitly specified a specific value by setting --NoDataValue=<value>.
+
+.. option:: --nanNoData
+
+    ..versionadded:: 3.3
+
+    Input NoDataValue will be mapped to ``numpy.nan`` and ``numpy.nan`` results will be transformed to NoDataValue in the output file.
+    Works best with floating point types. Allows explicit calculation with NoDataValue according to ``numpy.nan`` rules.
 
 .. option:: --type=<datatype>
 
@@ -230,3 +236,9 @@ Work with multiple bands:
 .. code-block::
 
     gdal_calc.py -A input.tif --A_band=1 -B input.tif --B_band=2 --outfile=result.tif --calc="(A+B)/2" --calc="B*logical_and(A>100,A<150)"
+
+Mean of three input bands, ignoring NoDataValue:
+
+.. code-block::
+
+    gdal_calc.py -A input.tif --A_band=1 -B input.tif --B_band=2 -C input.tif --C_band=3 --outfile=result.tif --nanNoData --calc="numpy.nanmean([A, B, C], axis=0)"

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -39,7 +39,7 @@ but no projection checking is performed (unless projectionCheck option is used).
 
     Calculation in gdalnumeric syntax using ``+``, ``-``, ``/``, ``*``, or any numpy array functions (i.e. ``log10()``).
     Multiple ``--calc`` options can be listed to produce a multiband file (GDAL >= 3.2).
-    NoDataValue will be mapped to numpy.nan when reading and numpy.nan will be written as NoDataValue in the output file (GDAL >= 3.3).
+    NoDataValue will be mapped to ``numpy.nan`` when reading and ``numpy.nan`` will be written as NoDataValue in the output file (GDAL >= 3.3).
 
 .. option:: -A <filename>
 

--- a/gdal/swig/python/osgeo/utils/gdal_calc.py
+++ b/gdal/swig/python/osgeo/utils/gdal_calc.py
@@ -479,7 +479,7 @@ def doit(opts, args):
 
                     # convert nodata values to numpy.nan
                     if myNDV[i] is not None:
-                        numpy.where(myval == myNDV[i], numpy.nan, myval)
+                        myval = numpy.where(myval == myNDV[i], numpy.nan, myval)
 
                     # add an array of values for this block to the eval namespace
                     if Alpha in myAlphaFileLists:
@@ -501,7 +501,7 @@ def doit(opts, args):
 
                 # convert numpy.nan to output NDV
                 if myOutNDV is not None:
-                    numpy.where(numpy.isnan(myResult), myOutNDV, myResult)
+                    myResult = numpy.where(numpy.isnan(myResult), myOutNDV, myResult)
 
                 # write data block to the output file
                 myOutB = myOut.GetRasterBand(bandNo)

--- a/gdal/swig/python/osgeo/utils/gdal_calc.py
+++ b/gdal/swig/python/osgeo/utils/gdal_calc.py
@@ -400,7 +400,6 @@ def doit(opts, args):
     # find total x and y blocks to be read
     nXBlocks = (int)((DimensionsCheck[0] + myBlockSize[0] - 1) / myBlockSize[0])
     nYBlocks = (int)((DimensionsCheck[1] + myBlockSize[1] - 1) / myBlockSize[1])
-    myBufSize = myBlockSize[0] * myBlockSize[1]
 
     if opts.debug:
         print("using blocksize %s x %s" % (myBlockSize[0], myBlockSize[1]))
@@ -437,7 +436,6 @@ def doit(opts, args):
 
             # reset buffer size for start of Y loop
             nYValid = myBlockSize[1]
-            myBufSize = nXValid * nYValid
 
             # loop through Y lines
             for Y in range(0, nYBlocks):
@@ -453,7 +451,6 @@ def doit(opts, args):
                 # change the block size of the final piece
                 if Y == nYBlocks - 1:
                     nYValid = DimensionsCheck[1] - Y * myBlockSize[1]
-                    myBufSize = nXValid * nYValid
 
                 # find Y offset
                 myY = Y * myBlockSize[1]


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->


## What does this PR do?

map GDAL's NoData to numpy's nan so one could write `--calc="numpy.nanmean([A, B, C], axis=2)"` to get an average without taking into account the NoData's

## What are related issues/pull requests?

#1893 

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 19.10
* Compiler: g++ 9 / Python 3.7
