### PR TITLE
Revert "CI: pin specific poppler version on ubuntu 16.04 and 18.04 du…

### DIFF
--- a/.github/workflows/asan/start.sh
+++ b/.github/workflows/asan/start.sh
@@ -35,13 +35,7 @@ sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
 sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo apt-get update
 sudo apt-get install -y python3.6 python3.6-dev
-sudo apt-get install -y --allow-unauthenticated libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libpoppler-glib8 poppler-utils libsqlite3-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libpodofo-dev libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libmysqlclient-dev libogdi3.2-dev libcfitsio-dev openjdk-8-jdk couchdb libzstd1-dev ccache curl autoconf automake sqlite3 libspatialite-dev make g++ libssl-dev libsfcgal-dev libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler58_0.41.0-0ubuntu1.14_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-glib8_0.41.0-0ubuntu1.14_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-dev_0.41.0-0ubuntu1.14_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-private-dev_0.41.0-0ubuntu1.14_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/poppler-utils_0.41.0-0ubuntu1.14_amd64.deb
-dpkg -i libpoppler58_0.41.0-0ubuntu1.14_amd64.deb libpoppler-glib8_0.41.0-0ubuntu1.14_amd64.deb libpoppler-dev_0.41.0-0ubuntu1.14_amd64.deb libpoppler-private-dev_0.41.0-0ubuntu1.14_amd64.deb poppler-utils_0.41.0-0ubuntu1.14_amd64.deb
+sudo apt-get install -y --allow-unauthenticated libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libsqlite3-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libpodofo-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libmysqlclient-dev libogdi3.2-dev libcfitsio-dev openjdk-8-jdk couchdb libzstd1-dev ccache curl autoconf automake sqlite3 libspatialite-dev make g++ libssl-dev libsfcgal-dev libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev
 
 wget https://github.com/Esri/file-geodatabase-api/raw/master/FileGDB_API_1.5/FileGDB_API_1_5_64gcc51.tar.gz
 tar xzf FileGDB_API_1_5_64gcc51.tar.gz

--- a/.github/workflows/ubuntu_18.04/before_install.sh
+++ b/.github/workflows/ubuntu_18.04/before_install.sh
@@ -19,13 +19,7 @@ docker run --name mariadb -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -
 # PostGIS
 docker run -v /home:/home --name "postgis" -p 25432:5432 -e ALLOW_IP_RANGE=0.0.0.0/0 -d -t kartoza/postgis:13.0
 
-sudo apt-get install -y --allow-unauthenticated python3-dev python3-pip python3-numpy libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler73 libpoppler-dev libpoppler-private-dev poppler-utils libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libkml-dev libmysqlclient-dev mysql-client-core-5.7 libogdi3.2-dev libcfitsio-dev openjdk-8-jdk libzstd1-dev ccache bash zip curl libpq-dev postgresql-client postgis cmake libssl-dev libboost-dev autoconf automake sqlite3 libopenexr-dev g++ fossil libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev doxygen wget
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler73_0.62.0-2ubuntu2.10_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-dev_0.62.0-2ubuntu2.10_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-private-dev_0.62.0-2ubuntu2.10_amd64.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/poppler-utils_0.62.0-2ubuntu2.10_amd64.deb
-dpkg -i libpoppler73_0.62.0-2ubuntu2.10_amd64.deb libpoppler-dev_0.62.0-2ubuntu2.10_amd64.deb libpoppler-private-dev_0.62.0-2ubuntu2.10_amd64.deb poppler-utils_0.62.0-2ubuntu2.10_amd64.deb
-
+sudo apt-get install -y --allow-unauthenticated python3-dev python3-pip python3-numpy libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libkml-dev libmysqlclient-dev mysql-client-core-5.7 libogdi3.2-dev libcfitsio-dev openjdk-8-jdk libzstd1-dev ccache bash zip curl libpq-dev postgresql-client postgis cmake libssl-dev libboost-dev autoconf automake sqlite3 libopenexr-dev g++ fossil libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev doxygen
 # libheif-dev: strane linking errors (__cxa_init_primary_exception, std::thread::_State::~_State()) related to also linking to FileGDB API
 # libpodofo-dev : FIXME incompatibilities at runtime with that version
 #sudo apt-get install -y --allow-unauthenticated libsfcgal-dev

--- a/.github/workflows/ubuntu_18.04_32bit/start.sh
+++ b/.github/workflows/ubuntu_18.04_32bit/start.sh
@@ -29,12 +29,7 @@ if test -f "$WORK_DIR/ccache.tar.gz"; then
 fi
 
 
-sudo apt-get install -y --allow-unauthenticated python3-dev python3-pip python3-numpy libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler73 libpoppler-dev libpoppler-private-dev poppler-utils libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libkml-dev libmysqlclient-dev mysql-client-core-5.7 libogdi3.2-dev libcfitsio-dev openjdk-8-jdk libzstd1-dev ccache bash zip curl libpq-dev postgresql-client postgis cmake libssl-dev libboost-dev autoconf automake sqlite3 libopenexr-dev g++ fossil libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev wget
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler73_0.62.0-2ubuntu2.10_i386.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-dev_0.62.0-2ubuntu2.10_i386.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-private-dev_0.62.0-2ubuntu2.10_i386.deb
-wget http://security.ubuntu.com/ubuntu/pool/main/p/poppler/poppler-utils_0.62.0-2ubuntu2.10_i386.deb
-dpkg -i libpoppler73_0.62.0-2ubuntu2.10_i386.deb libpoppler-dev_0.62.0-2ubuntu2.10_i386.deb libpoppler-private-dev_0.62.0-2ubuntu2.10_i386.deb poppler-utils_0.62.0-2ubuntu2.10_i386.deb
+sudo apt-get install -y --allow-unauthenticated python3-dev python3-pip python3-numpy libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libkml-dev libmysqlclient-dev mysql-client-core-5.7 libogdi3.2-dev libcfitsio-dev openjdk-8-jdk libzstd1-dev ccache bash zip curl libpq-dev postgresql-client postgis cmake libssl-dev libboost-dev autoconf automake sqlite3 libopenexr-dev g++ fossil libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev
 
 
 SCRIPT_DIR=$(dirname "$0")

--- a/gdal/ci/travis/s390x/before_install.sh
+++ b/gdal/ci/travis/s390x/before_install.sh
@@ -5,12 +5,6 @@ set -e
 sudo apt-get update
 sudo apt-get install -y software-properties-common
 sudo apt-get update
-sudo apt-get install -y --allow-unauthenticated python3-numpy libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler73 libpoppler-dev libpoppler-private-dev poppler-utils libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libkml-dev libmysqlclient-dev mysql-client-core-5.7 libogdi3.2-dev libcfitsio-dev openjdk-8-jdk libzstd1-dev ccache bash zip curl libpq-dev postgresql-client postgis cmake libssl-dev libboost-dev autoconf automake sqlite3 libopenexr-dev wget
-wget http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler73_0.62.0-2ubuntu2.10_s390x.deb
-wget http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler-dev_0.62.0-2ubuntu2.10_s390x.deb
-wget http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler-private-dev_0.62.0-2ubuntu2.10_s390x.deb
-wget http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/poppler-utils_0.62.0-2ubuntu2.10_s390x.deb
-sudo dpkg -i libpoppler73_0.62.0-2ubuntu2.10_s390x.deb libpoppler-dev_0.62.0-2ubuntu2.10_s390x.deb libpoppler-private-dev_0.62.0-2ubuntu2.10_s390x.deb poppler-utils_0.62.0-2ubuntu2.10_s390x.deb
-
+sudo apt-get install -y --allow-unauthenticated python3-numpy libpng-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev liblcms2-2 libpcre3-dev libcrypto++-dev libdap-dev libfyba-dev libkml-dev libmysqlclient-dev mysql-client-core-5.7 libogdi3.2-dev libcfitsio-dev openjdk-8-jdk libzstd1-dev ccache bash zip curl libpq-dev postgresql-client postgis cmake libssl-dev libboost-dev autoconf automake sqlite3 libopenexr-dev
 sudo apt-get install -y doxygen texlive-latex-base make python3-dev g++
 sudo apt-get install -y --allow-unauthenticated fossil libgeotiff-dev libcharls-dev libopenjp2-7-dev libcairo2-dev


### PR DESCRIPTION
…e to broken security patch"

This reverts commit ef015c5c182168ad24f1a0b3b4106dd256a5c19c.

The broken packages have been fixed
