### PR TITLE
PG: When detecting SRID from table contents, ignore null geometries

### DIFF
--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgresultlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgresultlayer.cpp
@@ -400,9 +400,11 @@ void OGRPGResultLayer::ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn)
             osGetSRID += OGRPGEscapeColumnName(poGFldDefn->GetNameRef());
             if (poDS->sPostGISVersion.nMajor > 2 || (poDS->sPostGISVersion.nMajor == 2 && poDS->sPostGISVersion.nMinor >= 2))
                 osGetSRID += "::geometry";
-            osGetSRID += ") FROM(";
+            osGetSRID += ") FROM (";
             osGetSRID += pszRawStatement;
-            osGetSRID += ") AS ogrpggetsrid LIMIT 1";
+            osGetSRID += ") AS ogrpggetsrid WHERE (";
+            osGetSRID += OGRPGEscapeColumnName(poGFldDefn->GetNameRef());
+            osGetSRID += " IS NOT NULL) LIMIT 1";
 
             PGresult* hSRSIdResult = OGRPG_PQexec(poDS->GetPGConn(), osGetSRID );
 

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -2909,7 +2909,9 @@ void OGRPGTableLayer::ResolveSRID(const OGRPGGeomFieldDefn* poGFldDefn)
         osGetSRID += OGRPGEscapeColumnName(poGFldDefn->GetNameRef());
         osGetSRID += ") FROM ";
         osGetSRID += pszSqlTableName;
-        osGetSRID += " LIMIT 1";
+        osGetSRID += " WHERE (";
+        osGetSRID += OGRPGEscapeColumnName(poGFldDefn->GetNameRef());
+        osGetSRID += " IS NOT NULL) LIMIT 1";
 
         hResult = OGRPG_PQexec(poDS->GetPGConn(), osGetSRID );
         if( hResult


### PR DESCRIPTION
## What does this PR do?

When the PostGIS driver doesn't find any SRID set in `geometry_columns`, it falls back to querying a single row of data using `ST_SRID()`. But if the row it randomly picks happens to have a `NULL` geometry then the result is an undefined SRID.

This change filters out `NULL` geometries from the SRID-detection queries in `OGRPGTableLayer::ResolveSRID()` and `OGRPGResultLayer::ResolveSRID()`.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

Not quite sure how to write a test-case for it, since by definition the result ordering returned by PostgreSQL is undefined without passing an `ORDER BY` clause.