### PR TITLE
osgeo/__init__.py - update gdal_version_and_min_supported_python_version

### DIFF
--- a/gdal/swig/python/osgeo/__init__.py
+++ b/gdal/swig/python/osgeo/__init__.py
@@ -84,7 +84,9 @@ fail_on_unsupported_version = False
 # when importing osgeo from a Python version which will not be
 # supported in the next version of GDAL.
 gdal_version_and_min_supported_python_version = (
-    ((3, 2), (2, 0)),
+    ((0, 0), (0, 0)),
+    ((1, 0), (2, 0)),
+    ((2, 0), (2, 7)),
     ((3, 3), (3, 6)),
     # ((3, 4), (3, 7)),
     # ((3, 5), (3, 8)),


### PR DESCRIPTION
## What does this PR do?

Update the python - gdal version support.
What was the minimum supported Python version of GDAL 3.2 ? Python 2.7? older?
Did gdal ever drop a python version support before?

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/3165

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
