### PR TITLE
Conda package building for GDAL based on Conda Forge recipe

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -31,7 +31,7 @@ jobs:
             CC="ccache gcc" CXX="ccache g++" CFLAGS=-O0 CXXFLAGS=-O0 ./configure --without-static --prefix=/tmp/projinstall
             make -j$(nproc)
             make install -j$(nproc)
- 
+
       - name: Run configure
         run: (cd gdal && ./configure --with-proj=/tmp/projinstall)
 
@@ -65,7 +65,7 @@ jobs:
             CC="ccache gcc" CXX="ccache g++" CFLAGS=-O0 CXXFLAGS=-O0 ./configure --without-static --prefix=/tmp/projinstall
             make -j$(nproc)
             make install -j$(nproc)
- 
+
       - name: Run configure
         run: (cd gdal && ./configure --with-proj=/tmp/projinstall)
 
@@ -91,7 +91,7 @@ jobs:
         run: ./gdal/scripts/detect_suspicious_char_digit_zero.sh
 
       - name: Shellcheck
-        run: shellcheck -e SC2086,SC2046 $(find gdal -name '*.sh' -a -not -name ltmain.sh)
+        run: shellcheck -e SC2086,SC2046,SC2164 $(find gdal -name '*.sh' -a -not -name ltmain.sh)
 
   flake8:
     runs-on: ubuntu-latest

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,0 +1,50 @@
+name: Conda
+
+on:
+  push:
+    branches: '*'
+
+jobs:
+  build:
+    name: Conda ${{ matrix.platform }}
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: ['ubuntu-latest','windows-latest','macos-latest']
+
+    env:
+      PLATFORM: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        channels: conda-forge
+        auto-update-conda: true
+
+    - name: Setup
+      shell: bash -l {0}
+      run: |
+          source ./gdal/ci/travis/conda/setup.sh
+
+    - name: Support longpaths
+      run: git config --system core.longpaths true
+      if: matrix.platform == 'windows-latest'
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+          source ../gdal/ci/travis/conda/compile.sh
+      working-directory: ./gdal-feedstock
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: matrix.platform == 'windows-latest'
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.platform }}-conda-package
+        path: ./gdal-feedstock/packages/

--- a/gdal/ci/travis/conda/compile.sh
+++ b/gdal/ci/travis/conda/compile.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+mkdir -p packages
+
+CI_SUPPORT=""
+if [ "$PLATFORM" == "windows-latest" ]; then
+    CI_SUPPORT="win_64_.yaml"
+fi
+
+if [ "$PLATFORM" == "ubuntu-latest" ]; then
+    CI_SUPPORT="linux_64_.yaml"
+fi
+
+if [ "$PLATFORM" == "macos-latest" ]; then
+    CI_SUPPORT="osx_64_.yaml"
+fi
+
+conda build recipe --clobber-file recipe/recipe_clobber.yaml --output-folder packages -m .ci_support/$CI_SUPPORT
+conda install -c ./packages libgdal gdal
+
+gdalinfo --version

--- a/gdal/ci/travis/conda/setup.sh
+++ b/gdal/ci/travis/conda/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+conda install -c conda-forge conda-build ninja compilers make python=3.8 -y
+
+git clone  https://github.com/conda-forge/gdal-feedstock.git
+
+cd gdal-feedstock
+cat > recipe/recipe_clobber.yaml <<EOL
+source:
+  path: ../../../gdal/gdal
+  url:
+  sha256:
+  patches:
+
+build:
+  number: 2112
+EOL
+
+
+ls recipe


### PR DESCRIPTION
Implements a GHA builder to build Conda packages for the current SHA and adds them as artifacts to the build.