### PR TITLE
NITF: Add support for ISO8859-1 fields in NITF TREs

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -3107,8 +3107,10 @@ def test_nitf_86():
 # Test parsing ILLUMB TRE (STDI-0002-1-v5.0 App AL)
 
 def test_nitf_87():
+    mu = "B5"   # \mu per ISO-8859-1
     bit_mask = "7A0000"
-    tre_data = "TRE=HEX/ILLUMB=" + hex_string("0001mm                                      8.5192000000E-01") + \
+    tre_data = "TRE=HEX/ILLUMB=" + hex_string("0001") + \
+        mu + hex_string("m                                      8.5192000000E-01") + \
         hex_string("2.5770800000E+00001NUM_BANDS=1 because ILLUMB has no band-dependent content                        ") + \
         hex_string("World Geodetic System 1984                                                      ") + \
         hex_string("WGE World Geodetic System 1984                                                      ") + \
@@ -3129,7 +3131,7 @@ def test_nitf_87():
     expected_data = """<tres>
   <tre name="ILLUMB" location="image">
     <field name="NUM_BANDS" value="0001" />
-    <field name="BAND_UNIT" value="mm" />
+    <field name="BAND_UNIT" value="µm" />
     <repeated number="1">
       <group index="0">
         <field name="LBOUND" value="8.5192000000E-01" />

--- a/gdal/data/nitf_spec.xml
+++ b/gdal/data/nitf_spec.xml
@@ -750,18 +750,18 @@
     <!-- STDI-0002-1-v5.0 Appendix AL, Section AL.6.2.4, Table AL.6-3 -->
     <tre name="ILLUMB" minlength="381" maxlength="99985" md_prefix="NITF_ILLUMB_" location="image">
         <field name="NUM_BANDS" length="4" type="integer"/>
-        <field name="BAND_UNIT" length="40" type="string"/>
+        <field name="BAND_UNIT" length="40" type="ISO8859-1"/>
         <loop counter="NUM_BANDS" md_prefix="BAND_%04d_">
             <field name="LBOUND" length="16" type="real"/>
             <field name="UBOUND" length="16" type="real"/>
         </loop>
         <field name="NUM_OTHERS" length="2" type="integer"/>
         <loop counter="NUM_OTHERS" md_prefix="OTHER_%02d_">
-            <field name="OTHER_NAME" length="40" type="string"/>
+            <field name="OTHER_NAME" length="40" type="ISO8859-1"/>
         </loop>
         <field name="NUM_COMS" length="1" type="integer"/>
         <loop counter="NUM_COMS" md_prefix="COMS_%01d_">
-            <field name="COMMENT" length="80" type="string"/>
+            <field name="COMMENT" length="80" type="ISO8859-1"/>
         </loop>
         <field name="GEO_DATUM" length="80" type="string"/>
         <field name="GEO_DATUM_CODE" length="4" type="string"/>
@@ -771,8 +771,8 @@
         <field name="VERTICAL_REF_CODE" length="4" type="string"/>
         <field name="EXISTENCE_MASK" length="3" type="bitmask"/>
         <if cond="EXISTENCE_MASK:23">
-            <field name="RAD_QUANTITY" length="40" type="string"/>
-            <field name="RADQ_UNIT" length="40" type="string"/>
+            <field name="RAD_QUANTITY" length="40" type="ISO8859-1"/>
+            <field name="RADQ_UNIT" length="40" type="ISO8859-1"/>
         </if>
         <field name="NUM_ILLUM_SETS" length="3" type="integer"/>
         <loop counter="NUM_ILLUM_SETS" md_prefix="ILLUM_SET_%03d_">
@@ -874,19 +874,19 @@
 
     <!-- STDI-0002-1 Appendix AK: Table AK.6-5: MATESA -->
     <tre name="MATESA" location="file">
-        <field name="CUR_SOURCE" length="42" type="string"/>
-        <field name="CUR_MATE_TYPE" length="16" type="string"/>
+        <field name="CUR_SOURCE" length="42" type="ISO8859-1"/>
+        <field name="CUR_MATE_TYPE" length="16" type="ISO8859-1"/>
         <field name="CUR_FILE_ID_LEN" length="4" type="integer" minval="1" maxval="9999"/>
-        <field name="CUR_FILE_ID" length_var="CUR_FILE_ID_LEN" type="string"/>
+        <field name="CUR_FILE_ID" length_var="CUR_FILE_ID_LEN" type="ISO8859-1"/>
         <field name="NUM_GROUPS" length="4" type="integer" minval="1" maxval="9999"/>
         <loop counter="NUM_GROUPS" md_prefix="GROUP_%d" name="GROUPS">
-            <field name="RELATIONSHIP" length="24" type="string"/>
+            <field name="RELATIONSHIP" length="24" type="ISO8859-1"/>
             <field name="NUM_MATES" length="4" type="integer" minval="1" maxval="9999"/>
             <loop counter="NUM_MATES" md_prefix="MATE_%d" name="MATES">
-                 <field name="SOURCE" length="42" type="string"/>
-                 <field name="MATE_TYPE" length="16" type="string"/>
+                 <field name="SOURCE" length="42" type="ISO8859-1"/>
+                 <field name="MATE_TYPE" length="16" type="ISO8859-1"/>
                  <field name="MATE_ID_LEN" length="4" type="integer" minval="1" maxval="9999"/>
-                 <field name="MATE_ID" length_var="MATE_ID_LEN" type="string"/>
+                 <field name="MATE_ID" length_var="MATE_ID_LEN" type="ISO8859-1"/>
             </loop>
         </loop>
     </tre>
@@ -1145,7 +1145,7 @@
         <field name="PERBAND" length="1" type="string"/>
         <loop counter="NUMMETRICS" md_prefix="METRIC_%05d_">
             <field name="DESCRIPTION" length="40" type="string"/>
-            <field name="UNIT" length="40" type="string"/>
+            <field name="UNIT" length="40" type="ISO8859-1"/>
             <field name="FITTYPE" length="1" type="string"/>
             <if cond="FITTYPE=P">
                 <field name="NUMCOEF" length="1" type="integer"/>
@@ -1985,7 +1985,7 @@
     <tre name="SECURA" md_prefix="NITF_SECURA_" location="file" minlength="251" maxlength="99988">
         <field name="FDATTIM" length="14" type="string"/>
         <field name="NITFVER" length="9" type="string"/>
-        <field name="NFSECFLDS" length="207" type="string"/>
+        <field name="NFSECFLDS" length="207" type="ISO8859-1"/>
         <field name="SECSTD" length="8" type="string"/>
         <field name="SECCOMP" length="8" type="string"/>
         <field name="SECLEN" length="5" type="integer"/>
@@ -2425,7 +2425,7 @@
                     <field name="APR" length="20" type="real"/>
                 </if>
                 <if cond="APF=A">
-                    <field name="APA" length="20" type="string"/>
+                    <field name="APA" length="20" type="ISO8859-1"/>
                 </if>
             </loop>
         </loop>

--- a/gdal/data/nitf_spec.xsd
+++ b/gdal/data/nitf_spec.xsd
@@ -132,6 +132,7 @@
                     <xs:enumeration value="real"/>
                     <xs:enumeration value="IEEE754_Float32_BigEndian"/>
                     <xs:enumeration value="UnsignedInt_BigEndian"/>
+                    <xs:enumeration value="ISO8859-1"/>
                     <xs:enumeration value="bitmask"/>
                 </xs:restriction>
             </xs:simpleType>

--- a/gdal/frmts/nitf/nitffile.c
+++ b/gdal/frmts/nitf/nitffile.c
@@ -2484,6 +2484,15 @@ static char** NITFGenericMetadataReadTREInternal(char **papszMD,
                         break;
                     }
                 }
+                else if (strcmp(pszType, "ISO8859-1") == 0)
+                {
+                    NITFExtractMetadata( &papszTmp, pachTRE, *pnTreOffset,
+                                        nLength, pszMDItemName );
+
+                    pszValue = CPLRecode(strchr(papszTmp[0], '=') + 1, CPL_ENC_ISO8859_1, CPL_ENC_UTF8);
+                    papszTmp = CSLSetNameValue(papszTmp, pszMDItemName, pszValue);
+
+                }
                 else
                 {
                     NITFExtractMetadata( &papszTmp, pachTRE, *pnTreOffset,


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR introduces a new field type to nitf_spec.xml to handle NITF Extended Character Set (ECS).  ECS consists of 1-byte characters that align to the ISO-8859-1 extended ASCII standard.

ECS is defined in MIL-STD-2500C
ECS character \mu (0xB5) is used for several TREs including ILLUMB (STDI-0002 Appendix AL) and PIXMTA (STDI-0002 Appendix AJ).

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/3071
https://github.com/OSGeo/gdal/pull/3023

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
