### PR TITLE
Add /vsiadls/ virtual file system for Azure Data Lake Storage Gen2

### DIFF
--- a/autotest/gcore/vsiadls.py
+++ b/autotest/gcore/vsiadls.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env pytest
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test /vsiadls
+# Author:   Even Rouault <even dot rouault at spatialys dot com>
+#
+###############################################################################
+# Copyright (c) 2020 Even Rouault <even dot rouault at spatialys dot com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import sys
+from osgeo import gdal
+
+
+import gdaltest
+import webserver
+import pytest
+
+pytestmark = pytest.mark.skipif(not gdaltest.built_against_curl(), reason="GDAL not built against curl")
+
+
+def open_for_read(uri):
+    """
+    Opens a test file for reading.
+    """
+    return gdal.VSIFOpenExL(uri, 'rb', 1)
+
+
+###############################################################################
+@pytest.fixture(autouse=True, scope='module')
+def startup_and_cleanup():
+
+    # Unset all env vars that could influence the tests
+    az_vars = {}
+    for var in ('AZURE_STORAGE_CONNECTION_STRING', 'AZURE_STORAGE_ACCOUNT',
+                'AZURE_STORAGE_ACCESS_KEY', 'AZURE_SAS', 'AZURE_NO_SIGN_REQUEST'):
+        az_vars[var] = gdal.GetConfigOption(var)
+        if az_vars[var] is not None:
+            gdal.SetConfigOption(var, "")
+
+    assert gdal.GetSignedURL('/vsiadls/foo/bar') is None
+
+    gdaltest.webserver_process = None
+    gdaltest.webserver_port = 0
+
+    if not gdaltest.built_against_curl():
+        pytest.skip()
+
+    (gdaltest.webserver_process, gdaltest.webserver_port) = webserver.launch(handler=webserver.DispatcherHttpHandler)
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.SetConfigOption('AZURE_STORAGE_CONNECTION_STRING',
+                         'DefaultEndpointsProtocol=http;AccountName=myaccount;AccountKey=MY_ACCOUNT_KEY;EndpointSuffix=127.0.0.1:%d' % gdaltest.webserver_port)
+    gdal.SetConfigOption('AZURE_STORAGE_ACCOUNT', '')
+    gdal.SetConfigOption('AZURE_STORAGE_ACCESS_KEY', '')
+    gdal.SetConfigOption('CPL_AZURE_TIMESTAMP', 'my_timestamp')
+
+    yield
+
+    # Clearcache needed to close all connections, since the Python server
+    # can only handle one connection at a time
+    gdal.VSICurlClearCache()
+
+    webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)
+
+    for var in az_vars:
+        gdal.SetConfigOption(var, az_vars[var])
+
+
+###############################################################################
+# Basic authentication tests
+
+def test_vsiadls_fake_basic():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    signed_url = gdal.GetSignedURL('/vsiadls/az_fake_bucket/resource', ['START_DATE=20180213T123456'])
+    assert (signed_url in ('http://127.0.0.1:8080/azure/blob/myaccount/az_fake_bucket/resource?se=2018-02-13T13%3A34%3A56Z&sig=9Jc4yBFlSRZSSxf059OohN6pYRrjuHWJWSEuryczN%2FM%3D&sp=r&sr=c&st=2018-02-13T12%3A34%3A56Z&sv=2012-02-12',
+                          'http://127.0.0.1:8081/azure/blob/myaccount/az_fake_bucket/resource?se=2018-02-13T13%3A34%3A56Z&sig=9Jc4yBFlSRZSSxf059OohN6pYRrjuHWJWSEuryczN%2FM%3D&sp=r&sr=c&st=2018-02-13T12%3A34%3A56Z&sv=2012-02-12'))
+
+    def method(request):
+
+        request.protocol_version = 'HTTP/1.1'
+        h = request.headers
+        if 'Authorization' not in h or \
+           h['Authorization'] != 'SharedKey myaccount:C0sSaBzGbvadfuuMMjQiHCXCUzsGWj3uuE+UO8dDl0U=' or \
+           'x-ms-date' not in h or h['x-ms-date'] != 'my_timestamp':
+            sys.stderr.write('Bad headers: %s\n' % str(h))
+            request.send_response(403)
+            return
+        request.send_response(200)
+        request.send_header('Content-type', 'text/plain')
+        request.send_header('Content-Length', 3)
+        request.send_header('Connection', 'close')
+        request.end_headers()
+        request.wfile.write("""foo""".encode('ascii'))
+
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/az_fake_bucket/resource', custom_method=method)
+    with webserver.install_http_handler(handler):
+        f = open_for_read('/vsiadls/az_fake_bucket/resource')
+        assert f is not None
+        data = gdal.VSIFReadL(1, 4, f).decode('ascii')
+        gdal.VSIFCloseL(f)
+
+    assert data == 'foo'
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_fake_bucket/resource2.bin', 200,
+                {'Content-Length': '1000000'})
+    with webserver.install_http_handler(handler):
+        stat_res = gdal.VSIStatL('/vsiadls/az_fake_bucket/resource2.bin')
+        if stat_res is None or stat_res.size != 1000000:
+            if stat_res is not None:
+                print(stat_res.size)
+            else:
+                print(stat_res)
+            pytest.fail()
+
+
+###############################################################################
+# Test ReadDir()
+
+
+def test_vsiadls_fake_readdir():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/az_fake_bucket2?directory=a_dir%20with_space&recursive=false&resource=filesystem', 200,
+                {'Content-type': 'application/json;charset=utf-8', 'x-ms-continuation': 'contmarker'},
+                """
+                {"paths":[{"name":"a_dir with_space/resource3 with_space.bin","contentLength":"123456","lastModified": "Mon, 01 Jan 1970 00:00:01"}]}
+                """)
+    handler.add('GET', '/azure/blob/myaccount/az_fake_bucket2?continuation=contmarker&directory=a_dir%20with_space&recursive=false&resource=filesystem', 200,
+                {'Content-type': 'application/json;charset=utf-8'},
+                """
+                {"paths":[{"name":"a_dir with_space/resource4.bin","contentLength":"456789","lastModified": "16 Oct 2016 12:34:56"},
+                          {"name":"a_dir with_space/subdir","isDirectory":"true"}]}
+                """
+                )
+
+    with webserver.install_http_handler(handler):
+        f = open_for_read('/vsiadls/az_fake_bucket2/a_dir with_space/resource3 with_space.bin')
+    if f is None:
+        pytest.fail()
+    gdal.VSIFCloseL(f)
+
+    dir_contents = gdal.ReadDir('/vsiadls/az_fake_bucket2/a_dir with_space')
+    assert dir_contents == ['resource3 with_space.bin', 'resource4.bin', 'subdir']
+    assert gdal.VSIStatL('/vsiadls/az_fake_bucket2/a_dir with_space/resource3 with_space.bin').size == 123456
+    assert gdal.VSIStatL('/vsiadls/az_fake_bucket2/a_dir with_space/resource3 with_space.bin').mtime == 1
+
+    # ReadDir on something known to be a file shouldn't cause network access
+    dir_contents = gdal.ReadDir('/vsiadls/az_fake_bucket2/a_dir with_space/resource3 with_space.bin')
+    assert dir_contents is None
+
+    # Test error on ReadDir()
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/az_fake_bucket2?directory=error_test&recursive=false&resource=filesystem', 500)
+    with webserver.install_http_handler(handler):
+        dir_contents = gdal.ReadDir('/vsiadls/az_fake_bucket2/error_test/')
+    assert dir_contents is None
+
+    # List containers (empty result)
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/?resource=account', 200, {'Content-type': 'application/json'},
+                """{ "filesystems": [] }""")
+    with webserver.install_http_handler(handler):
+        dir_contents = gdal.ReadDir('/vsiadls/')
+    assert dir_contents == ['.']
+
+    gdal.VSICurlClearCache()
+
+    # List containers
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/?resource=account', 200, {'Content-type': 'application/json', 'x-ms-continuation': 'contmarker'},
+                """{ "filesystems": [{ "name": "mycontainer1"}] }""")
+    handler.add('GET', '/azure/blob/myaccount/?continuation=contmarker&resource=account', 200, {'Content-type': 'application/json'},
+                """{ "filesystems": [{ "name": "mycontainer2"}] }""")
+    with webserver.install_http_handler(handler):
+        dir_contents = gdal.ReadDir('/vsiadls/')
+    assert dir_contents == ['mycontainer1', 'mycontainer2']
+
+###############################################################################
+# Test OpenDir() with a fake server
+
+
+def test_vsiaz_opendir():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    # Unlimited depth from root
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/?resource=account', 200, {'Content-type': 'application/json', 'x-ms-continuation': 'contmarker_root'},
+                """{ "filesystems": [{ "name": "fs1"}, { "name": "fs2"} ]}""")
+    with webserver.install_http_handler(handler):
+        d = gdal.OpenDir('/vsiadls/')
+    assert d is not None
+
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/fs1?recursive=true&resource=filesystem', 200,
+                {'Content-type': 'application/json;charset=utf-8', 'x-ms-continuation': 'contmarker_within_fs'},
+                """
+                {"paths":[{"name":"foo.txt","contentLength":"123456","lastModified": "Mon, 01 Jan 1970 00:00:01"}]}
+                """)
+    with webserver.install_http_handler(handler):
+        entry = gdal.GetNextDirEntry(d)
+    assert entry.name == 'fs1'
+    assert entry.mode == 16384
+
+    handler = webserver.SequentialHandler()
+    with webserver.install_http_handler(handler):
+        entry = gdal.GetNextDirEntry(d)
+    assert entry.name == 'fs1/foo.txt'
+
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/fs1?continuation=contmarker_within_fs&recursive=true&resource=filesystem', 200,
+                {'Content-type': 'application/json;charset=utf-8', 'x-ms-continuation': ''},
+                """
+                {"paths":[{"name":"bar.txt","contentLength":"123456","lastModified": "Mon, 01 Jan 1970 00:00:01"}]}
+                """)
+    with webserver.install_http_handler(handler):
+        entry = gdal.GetNextDirEntry(d)
+    assert entry.name == 'fs1/bar.txt'
+
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/fs2?recursive=true&resource=filesystem', 200,
+                {'Content-type': 'application/json;charset=utf-8', 'x-ms-continuation': ''},
+                """
+                {"paths":[]}
+                """)
+    with webserver.install_http_handler(handler):
+        entry = gdal.GetNextDirEntry(d)
+    assert entry.name == 'fs2'
+
+    handler = webserver.SequentialHandler()
+    handler.add('GET', '/azure/blob/myaccount/?continuation=contmarker_root&resource=account', 200, {'Content-type': 'application/json'},
+                """{ "filesystems": [{ "name": "fs3"}] }""")
+    handler.add('GET', '/azure/blob/myaccount/fs3?recursive=true&resource=filesystem', 200,
+                {'Content-type': 'application/json;charset=utf-8', 'x-ms-continuation': ''},
+                """
+                {"paths":[{"name":"baz.txt","contentLength":"123456","lastModified": "Mon, 01 Jan 1970 00:00:01"}]}
+                """)
+    with webserver.install_http_handler(handler):
+        entry = gdal.GetNextDirEntry(d)
+    assert entry.name == 'fs3'
+
+    handler = webserver.SequentialHandler()
+    with webserver.install_http_handler(handler):
+        entry = gdal.GetNextDirEntry(d)
+    assert entry.name == 'fs3/baz.txt'
+
+    entry = gdal.GetNextDirEntry(d)
+    assert entry is None
+
+    gdal.CloseDir(d)
+
+###############################################################################
+# Test write
+
+
+def test_vsiadls_fake_write():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    # Error case in initial PUT
+    handler = webserver.SequentialHandler()
+    handler.add('PUT', '/azure/blob/myaccount/test_copy/file.bin?resource=file', 400)
+    with webserver.install_http_handler(handler):
+        f = gdal.VSIFOpenL('/vsiadls/test_copy/file.bin', 'wb')
+        assert f is None
+
+    # Empty file
+    handler = webserver.SequentialHandler()
+    handler.add('PUT', '/azure/blob/myaccount/test_copy/file.bin?resource=file', 201)
+    handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=flush&close=true&position=0', 200)
+    with webserver.install_http_handler(handler):
+        f = gdal.VSIFOpenL('/vsiadls/test_copy/file.bin', 'wb')
+        assert f is not None
+        assert gdal.VSIFCloseL(f) == 0
+
+    # Small file
+    handler = webserver.SequentialHandler()
+    handler.add('PUT', '/azure/blob/myaccount/test_copy/file.bin?resource=file', 201)
+    handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=append&position=0', 202, expected_body = b'foo')
+    handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=flush&close=true&position=3', 200)
+    with webserver.install_http_handler(handler):
+        f = gdal.VSIFOpenL('/vsiadls/test_copy/file.bin', 'wb')
+        assert f is not None
+        assert gdal.VSIFWriteL('foo', 1, 3, f) == 3
+        assert gdal.VSIFCloseL(f) == 0
+
+    # Error case in PATCH append
+    handler = webserver.SequentialHandler()
+    handler.add('PUT', '/azure/blob/myaccount/test_copy/file.bin?resource=file', 201)
+    handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=append&position=0', 400, expected_body = b'foo')
+    with webserver.install_http_handler(handler):
+        f = gdal.VSIFOpenL('/vsiadls/test_copy/file.bin', 'wb')
+        assert f is not None
+        assert gdal.VSIFWriteL('foo', 1, 3, f) == 3
+        assert gdal.VSIFCloseL(f) != 0
+
+    # Error case in PATCH close
+    handler = webserver.SequentialHandler()
+    handler.add('PUT', '/azure/blob/myaccount/test_copy/file.bin?resource=file', 201)
+    handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=append&position=0', 202, expected_body = b'foo')
+    handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=flush&close=true&position=3', 400)
+    with webserver.install_http_handler(handler):
+        f = gdal.VSIFOpenL('/vsiadls/test_copy/file.bin', 'wb')
+        assert f is not None
+        assert gdal.VSIFWriteL('foo', 1, 3, f) == 3
+        assert gdal.VSIFCloseL(f) != 0
+
+    # Chunked output
+    with gdaltest.config_option('VSIAZ_CHUNK_SIZE_BYTES', '10'):
+        handler = webserver.SequentialHandler()
+        handler.add('PUT', '/azure/blob/myaccount/test_copy/file.bin?resource=file', 201)
+        handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=append&position=0', 202, expected_body = b'0123456789')
+        handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=append&position=10', 202, expected_body = b'abcd')
+        handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=flush&close=true&position=14', 200)
+        with webserver.install_http_handler(handler):
+            f = gdal.VSIFOpenL('/vsiadls/test_copy/file.bin', 'wb')
+            assert f is not None
+            assert gdal.VSIFWriteL('0123456789abcd', 1, 14, f) == 14
+            assert gdal.VSIFCloseL(f) == 0
+
+    # Chunked output with last chunk being the chunk size
+    with gdaltest.config_option('VSIAZ_CHUNK_SIZE_BYTES', '5'):
+        handler = webserver.SequentialHandler()
+        handler.add('PUT', '/azure/blob/myaccount/test_copy/file.bin?resource=file', 201)
+        handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=append&position=0', 202, expected_body = b'01234')
+        handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=append&position=5', 202, expected_body = b'56789')
+        handler.add('PATCH', '/azure/blob/myaccount/test_copy/file.bin?action=flush&close=true&position=10', 200)
+        with webserver.install_http_handler(handler):
+            f = gdal.VSIFOpenL('/vsiadls/test_copy/file.bin', 'wb')
+            assert f is not None
+            assert gdal.VSIFWriteL('0123456789', 1, 10, f) == 10
+            assert gdal.VSIFCloseL(f) == 0
+
+###############################################################################
+# Test Unlink()
+
+
+def test_vsiadls_fake_unlink():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    # Success
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_bucket_test_unlink/myfile', 200, {'Content-Length': '1'})
+    handler.add('DELETE', '/azure/blob/myaccount/az_bucket_test_unlink/myfile', 200, {'Connection': 'close'})
+    with webserver.install_http_handler(handler):
+        ret = gdal.Unlink('/vsiadls/az_bucket_test_unlink/myfile')
+    assert ret == 0
+
+    # Failure
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_bucket_test_unlink/myfile', 200, {'Content-Length': '1'})
+    handler.add('DELETE', '/azure/blob/myaccount/az_bucket_test_unlink/myfile', 400, {'Connection': 'close'})
+    with webserver.install_http_handler(handler):
+        with gdaltest.error_handler():
+            ret = gdal.Unlink('/vsiadls/az_bucket_test_unlink/myfile')
+    assert ret == -1
+
+###############################################################################
+# Test Mkdir() / Rmdir() / RmdirRecursive()
+
+
+def test_vsiadls_fake_mkdir_rmdir():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    # Invalid name
+    ret = gdal.Mkdir('/vsiadls', 0)
+    assert ret != 0
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_bucket_test_mkdir/dir', 404, {'Connection': 'close'})
+    handler.add('PUT', '/azure/blob/myaccount/az_bucket_test_mkdir/dir?resource=directory',  201)
+    with webserver.install_http_handler(handler):
+        ret = gdal.Mkdir('/vsiadls/az_bucket_test_mkdir/dir', 0)
+    assert ret == 0
+
+    # Try creating already existing directory
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_bucket_test_mkdir/dir', 200, {'x-ms-permissions': 'rwxrwxrwx', 'x-ms-resource-type': 'directory' } )
+    with webserver.install_http_handler(handler):
+        ret = gdal.Mkdir('/vsiadls/az_bucket_test_mkdir/dir', 0)
+    assert ret != 0
+
+    # Invalid name
+    ret = gdal.Rmdir('/vsiadls')
+    assert ret != 0
+
+    # Not a directory
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_bucket_test_mkdir/it_is_a_file', 200, {'x-ms-permissions': 'rwxrwxrwx', 'x-ms-resource-type': 'file' } )
+    with webserver.install_http_handler(handler):
+        ret = gdal.Rmdir('/vsiadls/az_bucket_test_mkdir/it_is_a_file')
+    assert ret != 0
+
+    # Valid
+    handler = webserver.SequentialHandler()
+    handler.add('DELETE', '/azure/blob/myaccount/az_bucket_test_mkdir/dir?recursive=false', 200)
+    with webserver.install_http_handler(handler):
+        ret = gdal.Rmdir('/vsiadls/az_bucket_test_mkdir/dir')
+    assert ret == 0
+
+    # Try deleting already deleted directory
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_bucket_test_mkdir/dir', 404 )
+    with webserver.install_http_handler(handler):
+        ret = gdal.Rmdir('/vsiadls/az_bucket_test_mkdir/dir')
+    assert ret != 0
+
+    # RmdirRecursive
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/az_bucket_test_mkdir/dir_rec', 200, {'x-ms-permissions': 'rwxrwxrwx', 'x-ms-resource-type': 'directory' } )
+    handler.add('DELETE', '/azure/blob/myaccount/az_bucket_test_mkdir/dir_rec?recursive=true', 200)
+    with webserver.install_http_handler(handler):
+        ret = gdal.RmdirRecursive('/vsiadls/az_bucket_test_mkdir/dir_rec')
+    assert ret == 0
+
+###############################################################################
+# Test rename
+
+def test_vsiadls_fake_rename():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test/source.txt', 200, {'Content-Length': '3', 'x-ms-permissions': 'rwxrwxrwx', 'x-ms-resource-type': 'file'})
+    handler.add('PUT', '/azure/blob/myaccount/test/target.txt', 201, expected_headers = {'x-ms-rename-source' : '/test/source.txt'})
+    handler.add('HEAD', '/azure/blob/myaccount/test/source.txt', 404)
+    with webserver.install_http_handler(handler):
+        assert gdal.Rename( '/vsiadls/test/source.txt', '/vsiadls/test/target.txt') == 0
+        assert gdal.VSIStatL('/vsiadls/test/source.txt') is None
+
+
+###############################################################################
+# Test Sync() with source and target on /vsiadls/
+# Note: this is using Azure blob object copying since ADLS has no equivalent
+
+def test_vsiadls_fake_sync_copyobject():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test_bucket/src.txt', 200, {'Content-Length': '3', 'x-ms-permissions': 'rwxrwxrwx', 'x-ms-resource-type': 'file'})
+    handler.add('HEAD', '/azure/blob/myaccount/test_bucket/dst.txt', 404)
+    handler.add('PUT', '/azure/blob/myaccount/test_bucket/dst.txt', 202,
+                expected_headers={'x-ms-copy-source': 'http://127.0.0.1:%d/azure/blob/myaccount/test_bucket/src.txt' % gdaltest.webserver_port})
+    with webserver.install_http_handler(handler):
+        assert gdal.Sync('/vsiadls/test_bucket/src.txt',
+                         '/vsiadls/test_bucket/dst.txt')
+
+    gdal.VSICurlClearCache()
+
+    # Error case
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test_bucket/src.txt', 200, {'Content-Length': '3', 'x-ms-permissions': 'rwxrwxrwx', 'x-ms-resource-type': 'file'})
+    handler.add('HEAD', '/azure/blob/myaccount/test_bucket/dst.txt', 404)
+    handler.add('PUT', '/azure/blob/myaccount/test_bucket/dst.txt', 400)
+    with webserver.install_http_handler(handler):
+        with gdaltest.error_handler():
+            assert not gdal.Sync('/vsiadls/test_bucket/src.txt',
+                                 '/vsiadls/test_bucket/dst.txt')
+
+
+###############################################################################
+# Test Sync() and multithreaded download of a single file
+
+
+def test_vsiadls_fake_sync_multithreaded_upload_single_file():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    gdal.Mkdir('/vsimem/test', 0)
+    gdal.FileFromMemBuffer('/vsimem/test/foo', 'foo\n')
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test_bucket?resource=filesystem', 200)
+    handler.add('HEAD', '/azure/blob/myaccount/test_bucket/foo', 404)
+    handler.add('PUT', '/azure/blob/myaccount/test_bucket/foo?resource=file', 201)
+    handler.add('PATCH', '/azure/blob/myaccount/test_bucket/foo?action=append&position=0', 202, expected_body = b'foo')
+    handler.add('PATCH', '/azure/blob/myaccount/test_bucket/foo?action=append&position=3', 202, expected_body = b'\n')
+    handler.add('PATCH', '/azure/blob/myaccount/test_bucket/foo?action=flush&close=true&position=4', 200)
+
+    with gdaltest.config_option('VSIS3_SIMULATE_THREADING', 'YES'):
+        with webserver.install_http_handler(handler):
+            assert gdal.Sync('/vsimem/test/foo',
+                             '/vsiadls/test_bucket',
+                             options=['NUM_THREADS=1', 'CHUNK_SIZE=3'])
+
+    gdal.RmdirRecursive('/vsimem/test')
+
+
+###############################################################################
+# Test GetFileMetadata () / SetFileMetadata()
+
+
+def test_vsiadls_fake_metadata():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test/foo.bin', 200, {'Content-Length': '3', 'x-ms-permissions': 'rwxrwxrwx', 'x-ms-resource-type': 'file'})
+    with webserver.install_http_handler(handler):
+        md = gdal.GetFileMetadata('/vsiadls/test/foo.bin', 'HEADERS')
+        assert 'x-ms-permissions' in md
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test/foo.bin?action=getStatus', 200, {'foo': 'bar'})
+    with webserver.install_http_handler(handler):
+        md = gdal.GetFileMetadata('/vsiadls/test/foo.bin', 'STATUS')
+        assert 'foo' in md
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test/foo.bin?action=getAccessControl', 200, {'x-ms-acl': 'some_acl'})
+    with webserver.install_http_handler(handler):
+        md = gdal.GetFileMetadata('/vsiadls/test/foo.bin', 'ACL')
+        assert 'x-ms-acl' in md
+
+    # Error case
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/azure/blob/myaccount/test/foo.bin?action=getStatus', 404)
+    with webserver.install_http_handler(handler):
+        assert gdal.GetFileMetadata('/vsiadls/test/foo.bin', 'STATUS') == {}
+
+    # SetMetadata()
+    handler = webserver.SequentialHandler()
+    handler.add('PATCH', '/azure/blob/myaccount/test/foo.bin?action=setProperties', 200, expected_headers={'x-ms-properties': 'foo=bar'})
+    with webserver.install_http_handler(handler):
+        assert gdal.SetFileMetadata('/vsiadls/test/foo.bin', {'x-ms-properties': 'foo=bar'}, 'PROPERTIES')
+
+    handler = webserver.SequentialHandler()
+    handler.add('PATCH', '/azure/blob/myaccount/test/foo.bin?action=setAccessControl', 200, expected_headers={'x-ms-acl': 'foo'})
+    with webserver.install_http_handler(handler):
+        assert gdal.SetFileMetadata('/vsiadls/test/foo.bin', {'x-ms-acl': 'foo'}, 'ACL')
+
+    handler = webserver.SequentialHandler()
+    handler.add('PATCH', '/azure/blob/myaccount/test/foo.bin?action=setAccessControlRecursive&mode=set', 200, expected_headers={'x-ms-acl': 'foo'})
+    with webserver.install_http_handler(handler):
+        assert gdal.SetFileMetadata('/vsiadls/test/foo.bin', {'x-ms-acl': 'foo'}, 'ACL', ['RECURSIVE=TRUE', 'MODE=set'])
+
+    # Error case
+    handler = webserver.SequentialHandler()
+    handler.add('PATCH', '/azure/blob/myaccount/test/foo.bin?action=setProperties', 404)
+    with webserver.install_http_handler(handler):
+        assert not gdal.SetFileMetadata('/vsiadls/test/foo.bin', {'x-ms-properties': 'foo=bar'}, 'PROPERTIES')

--- a/autotest/gcore/vsiadls_real_instance.py
+++ b/autotest/gcore/vsiadls_real_instance.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env pytest
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test /vsiadls
+# Author:   Even Rouault <even dot rouault at spatialys dot com>
+#
+###############################################################################
+# Copyright (c) 2020 Even Rouault <even dot rouault at spatialys dot com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import base64
+import stat
+from osgeo import gdal
+
+
+import gdaltest
+import pytest
+
+pytestmark = pytest.mark.skipif(not gdaltest.built_against_curl(), reason="GDAL not built against curl")
+
+
+def open_for_read(uri):
+    """
+    Opens a test file for reading.
+    """
+    return gdal.VSIFOpenExL(uri, 'rb', 1)
+
+
+###############################################################################
+# Nominal cases (require valid credentials)
+
+
+def test_vsiadls_real_instance_tests():
+
+    adls_resource = gdal.GetConfigOption('ADLS_RESOURCE')
+    if adls_resource is None:
+        pytest.skip('Missing ADLS_RESOURCE')
+
+    if '/' not in adls_resource:
+        path = '/vsiadls/' + adls_resource
+
+        try:
+            statres = gdal.VSIStatL(path)
+            assert statres is not None and stat.S_ISDIR(statres.mode), \
+                ('%s is not a valid bucket' % path)
+
+            readdir = gdal.ReadDir(path)
+            assert readdir is not None, 'ReadDir() should not return empty list'
+            for filename in readdir:
+                if filename != '.':
+                    subpath = path + '/' + filename
+                    assert gdal.VSIStatL(subpath) is not None, \
+                        ('Stat(%s) should not return an error' % subpath)
+
+            unique_id = 'vsiadls_test'
+            subpath = path + '/' + unique_id
+            ret = gdal.Mkdir(subpath, 0)
+            assert ret >= 0, ('Mkdir(%s) should not return an error' % subpath)
+
+            readdir = gdal.ReadDir(path)
+            assert unique_id in readdir, \
+                ('ReadDir(%s) should contain %s' % (path, unique_id))
+
+            ret = gdal.Mkdir(subpath, 0)
+            assert ret != 0, ('Mkdir(%s) repeated should return an error' % subpath)
+
+            ret = gdal.Rmdir(subpath)
+            assert ret >= 0, ('Rmdir(%s) should not return an error' % subpath)
+
+            readdir = gdal.ReadDir(path)
+            assert unique_id not in readdir, \
+                ('ReadDir(%s) should not contain %s' % (path, unique_id))
+
+            ret = gdal.Rmdir(subpath)
+            assert ret != 0, ('Rmdir(%s) repeated should return an error' % subpath)
+
+            ret = gdal.Mkdir(subpath, 0)
+            assert ret >= 0, ('Mkdir(%s) should not return an error' % subpath)
+
+            f = gdal.VSIFOpenL(subpath + '/test.txt', 'wb')
+            assert f is not None
+            gdal.VSIFWriteL('hello', 1, 5, f)
+            gdal.VSIFCloseL(f)
+
+            ret = gdal.Rmdir(subpath)
+            assert ret != 0, \
+                ('Rmdir(%s) on non empty directory should return an error' % subpath)
+
+            f = gdal.VSIFOpenL(subpath + '/test.txt', 'rb')
+            assert f is not None
+            data = gdal.VSIFReadL(1, 5, f).decode('utf-8')
+            assert data == 'hello'
+            gdal.VSIFCloseL(f)
+
+            assert gdal.VSIStatL(subpath + '/test.txt') is not None
+
+            md = gdal.GetFileMetadata(subpath + '/test.txt', 'HEADERS')
+            assert 'x-ms-properties' in md
+
+            md = gdal.GetFileMetadata(subpath + '/test.txt', 'STATUS')
+            assert 'x-ms-resource-type' in md
+            assert 'x-ms-properties' not in md
+
+            md = gdal.GetFileMetadata(subpath + '/test.txt', 'ACL')
+            assert 'x-ms-acl' in md
+            assert 'x-ms-permissions' in md
+
+            # Change properties
+            properties_foo_bar = 'foo=' + base64.b64encode('bar')
+            assert gdal.SetFileMetadata(subpath + '/test.txt', {'x-ms-properties': properties_foo_bar}, 'PROPERTIES')
+
+            md = gdal.GetFileMetadata(subpath + '/test.txt', 'HEADERS')
+            assert 'x-ms-properties' in md
+            assert md['x-ms-properties'] == properties_foo_bar
+
+            # Change ACL
+            assert gdal.SetFileMetadata(subpath + '/test.txt', {'x-ms-permissions': '0777'}, 'ACL')
+
+            md = gdal.GetFileMetadata(subpath + '/test.txt', 'ACL')
+            assert 'x-ms-permissions' in md
+            assert md['x-ms-permissions'] == 'rwxrwxrwx'
+
+            # Change ACL recursively
+            md = gdal.GetFileMetadata(subpath, 'ACL')
+            assert 'x-ms-acl' in md
+            assert gdal.SetFileMetadata(subpath + '/test.txt', {'x-ms-acl': md['x-ms-acl']}, 'ACL', ['RECURSIVE=YES', 'MODE=set'])
+
+
+            assert gdal.Rename(subpath + '/test.txt', subpath + '/test2.txt') == 0
+
+            assert gdal.VSIStatL(subpath + '/test.txt') is None
+
+            assert gdal.VSIStatL(subpath + '/test2.txt') is not None
+
+            f = gdal.VSIFOpenL(subpath + '/test2.txt', 'rb')
+            assert f is not None
+            data = gdal.VSIFReadL(1, 5, f).decode('utf-8')
+            assert data == 'hello'
+            gdal.VSIFCloseL(f)
+
+            ret = gdal.Unlink(subpath + '/test2.txt')
+            assert ret >= 0, \
+                ('Unlink(%s) should not return an error' % (subpath + '/test2.txt'))
+
+            assert gdal.VSIStatL(subpath + '/test2.txt') is None
+
+            assert gdal.Unlink(subpath + '/test2.txt') != 0, "Unlink on a deleted file should return an error"
+
+            f = gdal.VSIFOpenL(subpath + '/test2.txt', 'wb')
+            assert f is not None
+            gdal.VSIFCloseL(f)
+
+            assert gdal.VSIStatL(subpath + '/test2.txt') is not None
+
+        finally:
+            assert gdal.RmdirRecursive(subpath) == 0
+
+        return
+
+    f = open_for_read('/vsiadls/' + adls_resource)
+    assert f is not None
+    ret = gdal.VSIFReadL(1, 1, f)
+    gdal.VSIFCloseL(f)
+
+    assert len(ret) == 1
+
+    # Test GetSignedURL()
+    signed_url = gdal.GetSignedURL('/vsiadls/' + adls_resource)
+    f = open_for_read('/vsicurl_streaming/' + signed_url)
+    assert f is not None
+    ret = gdal.VSIFReadL(1, 1, f)
+    gdal.VSIFCloseL(f)
+
+    assert len(ret) == 1
+
+###############################################################################
+# Nominal cases (require valid credentials)
+# Note: that test must be run with a delay > 30 seconds due to such a delay
+# for re-creating a filesystem of the same name of one that has been destroyed
+
+def test_vsiadls_real_instance_filesystem_tests():
+
+    if gdal.GetConfigOption('ADLS_ALLOW_FILESYSTEM_TESTS') is None:
+        pytest.skip('Missing ADLS_ALLOW_FILESYSTEM_TESTS')
+
+    fspath = '/vsiadls/test-vsiadls-filesystem-tests'
+
+    try:
+        assert gdal.VSIStatL(fspath) is None
+
+        assert gdal.Mkdir(fspath, 0) == 0
+
+        statres = gdal.VSIStatL(fspath)
+        assert statres is not None and stat.S_ISDIR(statres.mode)
+
+        assert gdal.ReadDir(fspath) == [ "." ]
+
+        assert gdal.Mkdir(fspath, 0) != 0
+
+        assert gdal.Mkdir(fspath + '/subdir', 0) == 0
+
+        statres = gdal.VSIStatL(fspath + '/subdir')
+        assert statres is not None and stat.S_ISDIR(statres.mode)
+
+        assert gdal.Rmdir(fspath) != 0
+
+    finally:
+        assert gdal.RmdirRecursive(fspath) == 0
+
+        assert gdal.VSIStatL(fspath) is None

--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -113,7 +113,7 @@ def test_vsiaz_real_server_errors():
 
     for var in ('AZURE_STORAGE_CONNECTION_STRING', 'AZURE_STORAGE_ACCOUNT',
                 'AZURE_STORAGE_ACCESS_KEY'):
-        gdal.SetConfigOption(var, None)
+        gdal.SetConfigOption(var, '')
 
 ###############################################################################
 # Test AZURE_NO_SIGN_REQUEST=YES

--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -194,6 +194,8 @@ def test_vsiaz_fake_basic():
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
+    gdal.VSICurlClearCache()
+
     signed_url = gdal.GetSignedURL('/vsiaz/az_fake_bucket/resource', ['START_DATE=20180213T123456'])
     assert (signed_url in ('http://127.0.0.1:8080/azure/blob/myaccount/az_fake_bucket/resource?se=2018-02-13T13%3A34%3A56Z&sig=9Jc4yBFlSRZSSxf059OohN6pYRrjuHWJWSEuryczN%2FM%3D&sp=r&sr=c&st=2018-02-13T12%3A34%3A56Z&sv=2012-02-12',
                           'http://127.0.0.1:8081/azure/blob/myaccount/az_fake_bucket/resource?se=2018-02-13T13%3A34%3A56Z&sig=9Jc4yBFlSRZSSxf059OohN6pYRrjuHWJWSEuryczN%2FM%3D&sp=r&sr=c&st=2018-02-13T12%3A34%3A56Z&sv=2012-02-12'))

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -200,6 +200,9 @@ class SequentialHandler(object):
     def do_GET(self, request):
         self.process('GET', request)
 
+    def do_PATCH(self, request):
+        self.process('PATCH', request)
+
     def do_POST(self, request):
         self.process('POST', request)
 
@@ -235,6 +238,14 @@ class DispatcherHttpHandler(BaseHTTPRequestHandler):
             f.close()
 
         custom_handler.do_DELETE(self)
+
+    def do_PATCH(self):
+        if do_log:
+            f = open('/tmp/log.txt', 'a')
+            f.write('PATCH %s\n' % self.path)
+            f.close()
+
+        custom_handler.do_PATCH(self)
 
     def do_POST(self):
 
@@ -281,6 +292,14 @@ class GDAL_Handler(BaseHTTPRequestHandler):
         if do_log:
             f = open('/tmp/log.txt', 'a')
             f.write('DELETE %s\n' % self.path)
+            f.close()
+
+        self.send_error(404, 'File Not Found: %s' % self.path)
+
+    def do_PATCH(self):
+        if do_log:
+            f = open('/tmp/log.txt', 'a')
+            f.write('PATCH %s\n' % self.path)
             f.close()
 
         self.send_error(404, 'File Not Found: %s' % self.path)

--- a/gdal/doc/source/user/virtual_file_systems.rst
+++ b/gdal/doc/source/user/virtual_file_systems.rst
@@ -311,6 +311,8 @@ Authentication options, and read-only features, are identical to :ref:`/vsigs/ <
 
 /vsiaz/ is a file system handler that allows on-the-fly random reading of (primarily non-public) files available in Microsoft Azure Blob containers, without prior download of the entire file. It requires GDAL to be built against libcurl.
 
+See :ref:`/vsiadls/ </vsiadls/>` for a related filesystem for Azure Data Lake Storage Gen2.
+
 It also allows sequential writing of files. No seeks or read operations are then allowed, so in particular direct writing of GeoTIFF files with the GTiff driver is not supported, unless, if, starting with GDAL 3.2, the :decl_configoption:`CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE` configuration option is set to ``YES``, in which case random-write access is possible (involves the creation of a temporary local file, whose location is controlled by the :decl_configoption:`CPL_TMPDIR` configuration option).
 A block blob will be created if the file size is below 4 MB. Beyond, an append blob will be created (with a maximum file size of 195 GB).
 
@@ -345,6 +347,33 @@ Recognized filenames are of the form :file:`/vsiaz_streaming/container/key` wher
 Authentication options, and read-only features, are identical to :ref:`/vsiaz/ </vsiaz/>`
 
 .. versionadded:: 2.3
+
+.. _`/vsiadls/`:
+
+/vsiadls/ (Microsoft Azure Data Lake Storage Gen2)
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+/vsiadls/ is a file system handler that allows on-the-fly random reading of
+(primarily non-public) files available in Microsoft Azure Data Lake Storage file
+systems, without prior download of the entire file.
+It requires GDAL to be built against libcurl.
+
+It has similar capabilities as :ref:`/vsiaz/ </vsiaz/>`, and in particular uses the same
+configuration options for authentication. Its advantages over /vsiaz/ are a real
+management of directory and Unix-style ACL support. Some features require the Azure
+storage to have hierarchical support turned on. Consult its
+`documentation <https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction>`__
+
+The main enhancements over /vsiaz/ are:
+
+  * True directory support (no need for the artificial :file:`.gdal_marker_for_dir`
+    empty file that is used for /vsiaz/ to have empty directories)
+  * One-call recursive directory deletion with :cpp:func:`VSIRmdirRecursive`
+  * Atomic renaming with :cpp:func:`VSIRename`
+  * :cpp:func:`VSIGetFileMetadata` support for the "STATUS" and "ACL" metadata domains
+  * :cpp:func:`VSISetFileMetadata` support for the "PROPERTIES" and "ACL" metadata domains
+
+.. versionadded:: 3.3
 
 .. _`/vsioss/`:
 

--- a/gdal/port/GNUmakefile
+++ b/gdal/port/GNUmakefile
@@ -27,7 +27,7 @@ OBJ =	cpl_conv.o cpl_error.o cpl_string.o cplgetsymbol.o cplstringlist.o \
 	cpl_vsil_stdout.o cpl_vsil_sparsefile.o cpl_vsil_abstract_archive.o \
 	cpl_vsil_tar.o cpl_vsil_stdin.o cpl_vsil_buffered_reader.o \
 	cpl_base64.o cpl_vsil_curl.o cpl_vsil_curl_streaming.o \
-	cpl_vsil_s3.o cpl_vsil_gs.o cpl_vsil_az.o cpl_vsil_oss.o \
+	cpl_vsil_s3.o cpl_vsil_gs.o cpl_vsil_az.o cpl_vsil_adls.o cpl_vsil_oss.o \
 	cpl_vsil_swift.o cpl_vsil_webhdfs.o \
 	cpl_vsil_cache.o cpl_xml_validate.o cpl_spawn.o \
 	cpl_google_oauth2.o cpl_progress.o cpl_virtualmem.o cpl_worker_thread_pool.o \

--- a/gdal/port/cpl_azure.h
+++ b/gdal/port/cpl_azure.h
@@ -41,7 +41,6 @@ class VSIAzureBlobHandleHelper final: public IVSIS3LikeHandleHelper
 {
         CPLString m_osURL;
         CPLString m_osEndpoint;
-        CPLString m_osBlobEndpoint;
         CPLString m_osBucket;
         CPLString m_osObjectKey;
         CPLString m_osStorageAccount;
@@ -49,16 +48,21 @@ class VSIAzureBlobHandleHelper final: public IVSIS3LikeHandleHelper
         CPLString m_osSAS;
         bool      m_bUseHTTPS;
 
+        enum class Service
+        {
+            BLOB,
+            ADLS,
+        };
+
         static bool     GetConfiguration(CSLConstList papszOptions,
+                                         Service eService,
                                          bool& bUseHTTPS,
                                          CPLString& osEndpoint,
-                                         CPLString& osBlobEndpoint,
                                          CPLString& osStorageAccount,
                                          CPLString& osStorageKey,
                                          CPLString& osSAS);
 
         static CPLString BuildURL(const CPLString& osEndpoint,
-                                  const CPLString& osBlobEndpoint,
                                   const CPLString& osStorageAccount,
                                   const CPLString& osBucket,
                                   const CPLString& osObjectKey,
@@ -69,7 +73,6 @@ class VSIAzureBlobHandleHelper final: public IVSIS3LikeHandleHelper
 
     public:
         VSIAzureBlobHandleHelper(const CPLString& osEndpoint,
-                                 const CPLString& osBlobEndpoint,
                                  const CPLString& osBucket,
                                  const CPLString& osObjectKey,
                                  const CPLString& osStorageAccount,
@@ -92,6 +95,10 @@ class VSIAzureBlobHandleHelper final: public IVSIS3LikeHandleHelper
         CPLString GetSignedURL(CSLConstList papszOptions);
 };
 
+namespace cpl
+{
+int GetAzureBufferSize();
+}
 
 #endif /* HAVE_CURL */
 

--- a/gdal/port/cpl_path.cpp
+++ b/gdal/port/cpl_path.cpp
@@ -494,6 +494,7 @@ static bool RequiresUnixPathSeparator(const char* pszPath)
             STARTS_WITH(pszPath, "/vsigs_streaming/") ||
             STARTS_WITH(pszPath, "/vsiaz/") ||
             STARTS_WITH(pszPath, "/vsiaz_streaming/") ||
+            STARTS_WITH(pszPath, "/vsiadls/") ||
             STARTS_WITH(pszPath, "/vsioss/") ||
             STARTS_WITH(pszPath, "/vsioss_streaming/") ||
             STARTS_WITH(pszPath, "/vsiswift/") ||

--- a/gdal/port/cpl_vsi.h
+++ b/gdal/port/cpl_vsi.h
@@ -395,6 +395,7 @@ void VSIInstallGSFileHandler(void);
 void VSIInstallGSStreamingFileHandler(void);
 void VSIInstallAzureFileHandler(void);
 void VSIInstallAzureStreamingFileHandler(void);
+void VSIInstallADLSFileHandler(void);
 void VSIInstallOSSFileHandler(void);
 void VSIInstallOSSStreamingFileHandler(void);
 void VSIInstallSwiftFileHandler(void);

--- a/gdal/port/cpl_vsil.cpp
+++ b/gdal/port/cpl_vsil.cpp
@@ -348,7 +348,7 @@ char **CPLReadDir( const char *pszPath )
  *
  * This function is close to the POSIX opendir() function.
  *
- * For /vsis3/, /vsigs/, /vsioss/ and /vsiaz/, this function has an efficient
+ * For /vsis3/, /vsigs/, /vsioss/, /vsiaz/ and /vsiadls/, this function has an efficient
  * implementation, minimizing the number of network requests, when invoked with
  * nRecurseDepth <= 0.
  *
@@ -877,6 +877,8 @@ int VSIStatExL( const char * pszFilename, VSIStatBufL *psStatBuf, int nFlags )
  * <ul>
  * <li>HEADERS: to get HTTP headers for network-like filesystems (/vsicurl/, /vsis3/, etc)</li>
  * <li>TAGS: specific to /vsis3/: to get S3 Object tagging information</li>
+ * <li>STATUS: specific to /vsiadls/: returns all system defined properties for a path (seems in practice to be a subset of HEADERS)</li>
+ * <li>ACL: specific to /vsiadls/: returns the access control list for a path.</li>
  * </ul>
  * @param papszOptions Unused. Should be set to NULL.
  *
@@ -903,7 +905,7 @@ char** VSIGetFileMetadata( const char * pszFilename, const char* pszDomain,
  *
  * Implemented currently only for /vsis3/
  *
- * @param pszFilename the path of the filesystem object to be queried.
+ * @param pszFilename the path of the filesystem object to be set.
  * UTF-8 encoded.
  * @param papszMetadata NULL-terminated list of key=value strings.
  * @param pszDomain Metadata domain to set. Depends on the file system.
@@ -911,8 +913,14 @@ char** VSIGetFileMetadata( const char * pszFilename, const char* pszDomain,
  * <ul>
  * <li>HEADERS: to set HTTP header</li>
  * <li>TAGS: to set S3 Object tagging information</li>
+ * <li>PROPERTIES: specific to /vsiadls/: to set properties. Refer to https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update for headers valid for action=setProperties.</li>
+ * <li>ACL: specific to /vsiadls/: to set access control list. Refer to https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update for headers valid for action=setAccessControl or setAccessControlRecursive. In setAccessControlRecursive, x-ms-acl must be specified in papszMetadata</li>
  * </ul>
- * @param papszOptions Unused. Should be set to NULL.
+ * @param papszOptions NULL or NULL terminated list of options.
+ *                     For /vsiadls/ and pszDomain=ACL, "RECURSIVE=TRUE" can be
+ *                     set to set the access control list recursively. When
+ *                     RECURSIVE=TRUE is set, MODE should also be set to one of
+ *                     "set", "modify" or "remove".
  *
  * @return TRUE in case of success.
  *

--- a/gdal/port/cpl_vsil.cpp
+++ b/gdal/port/cpl_vsil.cpp
@@ -663,11 +663,11 @@ int VSIRename( const char * oldpath, const char * newpath )
  *     with the source one.
  * </li>
  * <li>NUM_THREADS=integer. Number of threads to use for parallel file copying.
- *     Only use for when /vsis3/, /vsigs/ or /vsiaz/ is in source or target.
+ *     Only use for when /vsis3/, /vsigs/, /vsiaz/ or /vsiadls/ is in source or target.
  *     Since GDAL 3.1</li>
  * <li>CHUNK_SIZE=integer. Maximum size of chunk (in bytes) to use to split
- *     large objects when downloading them from /vsis3/, /vsigs/ or /vsiaz/ to
- *     local file system, or for upload to /vsis3/ or /vsiaz/ from local file system.
+ *     large objects when downloading them from /vsis3/, /vsigs/, /vsiaz/ or /vsiadls/ to
+ *     local file system, or for upload to /vsis3/, /vsiaz/ or /vsiadls/ from local file system.
  *     Only used if NUM_THREADS > 1.
  *     For upload to /vsis3/, this chunk size must be set at least to 5 MB.
  *     Since GDAL 3.1</li>
@@ -2674,6 +2674,7 @@ VSIFileManager *VSIFileManager::Get()
       VSIInstallGSStreamingFileHandler();
       VSIInstallAzureFileHandler();
       VSIInstallAzureStreamingFileHandler();
+      VSIInstallADLSFileHandler();
       VSIInstallOSSFileHandler();
       VSIInstallOSSStreamingFileHandler();
       VSIInstallSwiftFileHandler();

--- a/gdal/port/cpl_vsil_adls.cpp
+++ b/gdal/port/cpl_vsil_adls.cpp
@@ -1,0 +1,2139 @@
+/******************************************************************************
+ *
+ * Project:  CPL - Common Portability Library
+ * Purpose:  Implement VSI large file api for Microsoft Azure Data Lake Storage Gen2
+ * Author:   Even Rouault, even.rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2020, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_port.h"
+#include "cpl_http.h"
+#include "cpl_json.h"
+#include "cpl_time.h"
+#include "cpl_vsil_curl_priv.h"
+#include "cpl_vsil_curl_class.h"
+
+#include <errno.h>
+
+#include <algorithm>
+#include <set>
+#include <map>
+#include <memory>
+
+#include "cpl_azure.h"
+
+CPL_CVSID("$Id$")
+
+#ifndef HAVE_CURL
+
+void VSIInstallADLSFileHandler( void )
+{
+    // Not supported
+}
+
+#else
+
+//! @cond Doxygen_Suppress
+#ifndef DOXYGEN_SKIP
+
+#define ENABLE_DEBUG 0
+
+namespace cpl {
+
+/************************************************************************/
+/*                         GetContinuationToken()                       */
+/************************************************************************/
+
+static CPLString GetContinuationToken(const char* pszHeaders)
+{
+    CPLString osContinuation;
+    if( pszHeaders )
+    {
+        const char* pszContinuation = strstr(pszHeaders, "x-ms-continuation: ");
+        if( pszContinuation )
+        {
+            pszContinuation += strlen("x-ms-continuation: ");
+            const char* pszEOL = strstr(pszContinuation, "\r\n");
+            if( pszEOL )
+            {
+                osContinuation.assign(pszContinuation,
+                                    pszEOL - pszContinuation);
+            }
+        }
+    }
+    return osContinuation;
+}
+
+/************************************************************************/
+/*                        RemoveTrailingSlash()                        */
+/************************************************************************/
+
+static CPLString RemoveTrailingSlash(const CPLString& osFilename)
+{
+    CPLString osWithoutSlash(osFilename);
+    if( !osWithoutSlash.empty() && osWithoutSlash.back() == '/' )
+        osWithoutSlash.resize( osWithoutSlash.size() - 1 );
+    return osWithoutSlash;
+}
+
+/************************************************************************/
+/*                             VSIDIRADLS                               */
+/************************************************************************/
+
+class VSIADLSFSHandler;
+
+struct VSIDIRADLS: public VSIDIR
+{
+    CPLString m_osRootPath{};
+    int m_nRecurseDepth = 0;
+
+    struct Iterator
+    {
+        CPLString m_osNextMarker{};
+        std::vector<std::unique_ptr<VSIDIREntry>> m_aoEntries{};
+        int m_nPos = 0;
+
+        void clear()
+        {
+            m_osNextMarker.clear();
+            m_nPos = 0;
+            m_aoEntries.clear();
+        }
+    };
+
+    Iterator m_oIterWithinFilesystem{};
+    Iterator m_oIterFromRoot{};
+
+    // Backup file system listing when doing a recursive OpenDir() from
+    // the account root
+    bool m_bRecursiveRequestFromAccountRoot = false;
+
+    CPLString m_osFilesystem{};
+    CPLString m_osObjectKey{};
+    VSIADLSFSHandler* m_poFS = nullptr;
+    int m_nMaxFiles = 0;
+    bool m_bCacheEntries = true;
+
+    explicit VSIDIRADLS(VSIADLSFSHandler *poFSIn): m_poFS(poFSIn) {}
+
+    VSIDIRADLS(const VSIDIRADLS&) = delete;
+    VSIDIRADLS& operator=(const VSIDIRADLS&) = delete;
+
+    const VSIDIREntry* NextDirEntry() override;
+
+    bool IssueListDir();
+    bool AnalysePathList( const CPLString& osBaseURL, const char* pszJSON );
+    bool AnalyseFilesystemList( const CPLString& osBaseURL, const char* pszJSON );
+    void clear();
+};
+
+/************************************************************************/
+/*                       VSIADLSFSHandler                              */
+/************************************************************************/
+
+class VSIADLSFSHandler final : public IVSIS3LikeFSHandler
+{
+    CPL_DISALLOW_COPY_ASSIGN(VSIADLSFSHandler)
+
+  protected:
+    VSICurlHandle* CreateFileHandle( const char* pszFilename ) override;
+    CPLString GetURLFromFilename( const CPLString& osFilename ) override;
+
+    char** GetFileList( const char *pszFilename,
+                        int nMaxFiles,
+                        bool* pbGotFileList ) override;
+
+    int      CopyObject( const char *oldpath, const char *newpath,
+                         CSLConstList papszMetadata ) override;
+    int MkdirInternal( const char *pszDirname, long nMode, bool bDoStatCheck ) override;
+    int RmdirInternal( const char * pszDirname, bool bRecursive );
+
+  public:
+    VSIADLSFSHandler() = default;
+    ~VSIADLSFSHandler() override = default;
+
+    CPLString GetFSPrefix() const override { return "/vsiadls/"; }
+    const char* GetDebugKey() const override { return "ADLS"; }
+
+    VSIVirtualHandle *Open( const char *pszFilename,
+                            const char *pszAccess,
+                            bool bSetError ) override;
+
+    int Rename( const char *oldpath, const char *newpath ) override;
+    int Unlink( const char *pszFilename ) override;
+    int Mkdir( const char *, long  ) override;
+    int Rmdir( const char * ) override;
+    int RmdirRecursive( const char *pszDirname ) override;
+    int Stat( const char *pszFilename, VSIStatBufL *pStatBuf,
+              int nFlags ) override;
+
+    char** GetFileMetadata( const char * pszFilename, const char* pszDomain,
+                            CSLConstList papszOptions ) override;
+
+    bool   SetFileMetadata( const char * pszFilename,
+                            CSLConstList papszMetadata,
+                            const char* pszDomain,
+                            CSLConstList papszOptions ) override;
+
+    const char* GetOptions() override;
+
+    char* GetSignedURL( const char* pszFilename, CSLConstList papszOptions ) override;
+
+    char** GetFileList( const char *pszFilename,
+                        int nMaxFiles,
+                        bool bCacheEntries,
+                        bool* pbGotFileList );
+
+    VSIDIR* OpenDir( const char *pszPath, int nRecurseDepth,
+                            const char* const *papszOptions) override;
+
+    enum class Event
+    {
+        CREATE_FILE,
+        APPEND_DATA,
+        FLUSH
+    };
+
+    // Block list upload
+    bool UploadFile(const CPLString& osFilename,
+                         Event event,
+                         vsi_l_offset nPosition,
+                         const void* pabyBuffer,
+                         size_t nBufferSize,
+                         IVSIS3LikeHandleHelper *poS3HandleHelper,
+                         int nMaxRetry,
+                         double dfRetryDelay);
+
+    // Multipart upload (mapping of S3 interface)
+    bool SupportsParallelMultipartUpload() const override { return true; }
+
+    CPLString InitiateMultipartUpload(
+                                const std::string& osFilename,
+                                IVSIS3LikeHandleHelper * poS3HandleHelper,
+                                int nMaxRetry,
+                                double dfRetryDelay) override {
+        return UploadFile(osFilename, Event::CREATE_FILE, 0, nullptr, 0,
+                          poS3HandleHelper, nMaxRetry, dfRetryDelay) ?
+            std::string("dummy") : std::string();
+    }
+
+    CPLString UploadPart(const CPLString& osFilename,
+                         int /* nPartNumber */,
+                         const std::string& /* osUploadID */,
+                         vsi_l_offset nPosition,
+                         const void* pabyBuffer,
+                         size_t nBufferSize,
+                         IVSIS3LikeHandleHelper *poS3HandleHelper,
+                         int nMaxRetry,
+                         double dfRetryDelay) override
+    {
+        return UploadFile(osFilename, Event::APPEND_DATA,
+                          nPosition, pabyBuffer, nBufferSize,
+                          poS3HandleHelper, nMaxRetry, dfRetryDelay) ?
+            std::string("dummy") : std::string();
+    }
+
+    bool CompleteMultipart(const CPLString& osFilename,
+                           const CPLString& /* osUploadID */,
+                           const std::vector<CPLString>& /* aosEtags */,
+                           vsi_l_offset nTotalSize,
+                           IVSIS3LikeHandleHelper *poS3HandleHelper,
+                           int nMaxRetry,
+                           double dfRetryDelay) override
+    {
+        return UploadFile(osFilename, Event::FLUSH, nTotalSize, nullptr, 0,
+                          poS3HandleHelper, nMaxRetry, dfRetryDelay);
+    }
+
+    bool AbortMultipart(const CPLString& /* osFilename */,
+                        const CPLString& /* osUploadID */,
+                        IVSIS3LikeHandleHelper * /*poS3HandleHelper */,
+                        int /* nMaxRetry */,
+                        double /* dfRetryDelay */) override { return true; }
+
+    CPLString GetStreamingPath( const char* pszFilename ) const override;
+
+    IVSIS3LikeHandleHelper* CreateHandleHelper(
+        const char* pszURI, bool bAllowNoObject) override;
+};
+
+/************************************************************************/
+/*                                clear()                               */
+/************************************************************************/
+
+void VSIDIRADLS::clear()
+{
+    if( !m_osFilesystem.empty() )
+        m_oIterWithinFilesystem.clear();
+    else
+        m_oIterFromRoot.clear();
+}
+
+/************************************************************************/
+/*                        GetUnixTimeFromRFC822()                       */
+/************************************************************************/
+
+static GIntBig GetUnixTimeFromRFC822(const char* pszRFC822DateTime)
+{
+    int nYear, nMonth, nDay, nHour, nMinute, nSecond;
+    if( CPLParseRFC822DateTime(pszRFC822DateTime,
+                                    &nYear,
+                                    &nMonth,
+                                    &nDay,
+                                    &nHour,
+                                    &nMinute,
+                                    &nSecond,
+                                    nullptr,
+                                    nullptr ) )
+    {
+        struct tm brokendowntime;
+        brokendowntime.tm_year = nYear - 1900;
+        brokendowntime.tm_mon = nMonth - 1;
+        brokendowntime.tm_mday = nDay;
+        brokendowntime.tm_hour = nHour;
+        brokendowntime.tm_min = nMinute;
+        brokendowntime.tm_sec = nSecond < 0 ? 0 : nSecond;
+        return CPLYMDHMSToUnixTime(&brokendowntime);
+    }
+    return GINTBIG_MIN;
+}
+
+/************************************************************************/
+/*                           AnalysePathList()                          */
+/************************************************************************/
+
+bool VSIDIRADLS::AnalysePathList(
+    const CPLString& osBaseURL,
+    const char* pszJSON)
+{
+#if DEBUG_VERBOSE
+    CPLDebug(m_poFS->GetDebugKey(), "%s", pszJSON);
+#endif
+
+    CPLJSONDocument oDoc;
+    if( !oDoc.LoadMemory(pszJSON) )
+        return false;
+
+    auto oPaths = oDoc.GetRoot().GetArray("paths");
+    if( !oPaths.IsValid() )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot find paths[]");
+        return false;
+    }
+
+    for( const auto& oPath: oPaths )
+    {
+        m_oIterWithinFilesystem.m_aoEntries.push_back(
+            std::unique_ptr<VSIDIREntry>(new VSIDIREntry()));
+        auto& entry = m_oIterWithinFilesystem.m_aoEntries.back();
+
+        // Returns relative path to the filesystem, so for example "mydir/foo.bin"
+        // for https://{account}.dfs.core.windows.net/{filesystem}/mydir/foo.bin
+        const CPLString osName(oPath.GetString("name"));
+        if( !m_osObjectKey.empty() && STARTS_WITH(osName, (m_osObjectKey + "/").c_str()) )
+            entry->pszName = CPLStrdup(osName.substr(m_osObjectKey.size() + 1).c_str());
+        else if (m_bRecursiveRequestFromAccountRoot && !m_osFilesystem.empty() )
+            entry->pszName = CPLStrdup((m_osFilesystem + '/' + osName).c_str());
+        else
+            entry->pszName = CPLStrdup(osName.c_str());
+        entry->nSize = static_cast<GUIntBig>(oPath.GetLong("contentLength"));
+        entry->bSizeKnown = true;
+        entry->nMode = oPath.GetString("isDirectory") == "true" ? S_IFDIR : S_IFREG;
+        entry->nMode |= VSICurlParseUnixPermissions(oPath.GetString("permissions").c_str());
+        entry->bModeKnown = true;
+
+        CPLString ETag = oPath.GetString("etag");
+        if( !ETag.empty() )
+        {
+            entry->papszExtra = CSLSetNameValue(
+                entry->papszExtra, "ETag", ETag.c_str());
+        }
+
+        const GIntBig nMTime = GetUnixTimeFromRFC822(oPath.GetString("lastModified").c_str());
+        if( nMTime != GINTBIG_MIN )
+        {
+            entry->nMTime = nMTime;
+            entry->bMTimeKnown = true;
+        }
+
+        if( m_bCacheEntries )
+        {
+            FileProp prop;
+            prop.eExists = EXIST_YES;
+            prop.bHasComputedFileSize = true;
+            prop.fileSize = entry->nSize;
+            prop.bIsDirectory = CPL_TO_BOOL(VSI_ISDIR(entry->nMode));
+            prop.nMode = entry->nMode;
+            prop.mTime = static_cast<time_t>(entry->nMTime);
+            prop.ETag = ETag;
+
+            CPLString osCachedFilename =
+                osBaseURL + "/" +
+                CPLAWSURLEncode(osName, false);
+#if DEBUG_VERBOSE
+            CPLDebug(m_poFS->GetDebugKey(), "Cache %s", osCachedFilename.c_str());
+#endif
+            m_poFS->SetCachedFileProp(osCachedFilename, prop);
+        }
+
+        if( m_nMaxFiles > 0 && m_oIterWithinFilesystem.m_aoEntries.size() >
+                                            static_cast<unsigned>(m_nMaxFiles) )
+        {
+            break;
+        }
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                         AnalysePathList()                            */
+/************************************************************************/
+
+bool VSIDIRADLS::AnalyseFilesystemList (
+    const CPLString& osBaseURL,
+    const char* pszJSON)
+{
+#if DEBUG_VERBOSE
+    CPLDebug(m_poFS->GetDebugKey(), "%s", pszJSON);
+#endif
+
+    CPLJSONDocument oDoc;
+    if( !oDoc.LoadMemory(pszJSON) )
+        return false;
+
+    auto oPaths = oDoc.GetRoot().GetArray("filesystems");
+    if( !oPaths.IsValid() )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot find filesystems[]");
+        return false;
+    }
+
+    for( const auto& oPath: oPaths )
+    {
+        m_oIterFromRoot.m_aoEntries.push_back(
+            std::unique_ptr<VSIDIREntry>(new VSIDIREntry()));
+        auto& entry = m_oIterFromRoot.m_aoEntries.back();
+
+        const CPLString osName(oPath.GetString("name"));
+        entry->pszName = CPLStrdup(osName.c_str());
+        entry->nSize = 0;
+        entry->bSizeKnown = true;
+        entry->nMode = S_IFDIR;
+        entry->bModeKnown = true;
+
+        CPLString ETag = oPath.GetString("etag");
+        if( !ETag.empty() )
+        {
+            entry->papszExtra = CSLSetNameValue(
+                entry->papszExtra, "ETag", ETag.c_str());
+        }
+
+        const GIntBig nMTime = GetUnixTimeFromRFC822(oPath.GetString("lastModified").c_str());
+        if( nMTime != GINTBIG_MIN )
+        {
+            entry->nMTime = nMTime;
+            entry->bMTimeKnown = true;
+        }
+
+        if( m_bCacheEntries )
+        {
+            FileProp prop;
+            prop.eExists = EXIST_YES;
+            prop.bHasComputedFileSize = true;
+            prop.fileSize = 0;
+            prop.bIsDirectory = true;
+            prop.mTime = static_cast<time_t>(entry->nMTime);
+            prop.ETag = ETag;
+
+            CPLString osCachedFilename =
+                osBaseURL + CPLAWSURLEncode(osName, false);
+#if DEBUG_VERBOSE
+            CPLDebug(m_poFS->GetDebugKey(), "Cache %s", osCachedFilename.c_str());
+#endif
+            m_poFS->SetCachedFileProp(osCachedFilename, prop);
+        }
+
+        if( m_nMaxFiles > 0 && m_oIterFromRoot.m_aoEntries.size() >
+                                        static_cast<unsigned>(m_nMaxFiles) )
+        {
+            break;
+        }
+
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                          IssueListDir()                              */
+/************************************************************************/
+
+bool VSIDIRADLS::IssueListDir()
+{
+    WriteFuncStruct sWriteFuncData;
+
+    auto& oIter = !m_osFilesystem.empty() ? m_oIterWithinFilesystem : m_oIterFromRoot;
+    const CPLString l_osNextMarker(oIter.m_osNextMarker);
+    clear();
+
+    NetworkStatisticsFileSystem oContextFS(m_poFS->GetFSPrefix());
+    NetworkStatisticsAction oContextAction("ListBucket");
+
+    CPLString osMaxKeys = CPLGetConfigOption("AZURE_MAX_RESULTS", "");
+    const int AZURE_SERVER_LIMIT_SINGLE_REQUEST = 5000;
+    if( m_nMaxFiles > 0 && m_nMaxFiles < AZURE_SERVER_LIMIT_SINGLE_REQUEST &&
+        (osMaxKeys.empty() || m_nMaxFiles < atoi(osMaxKeys)) )
+    {
+        osMaxKeys.Printf("%d", m_nMaxFiles);
+    }
+
+
+    auto poHandleHelper = std::unique_ptr<IVSIS3LikeHandleHelper>(
+        m_poFS->CreateHandleHelper(m_osFilesystem, true));
+    if( poHandleHelper == nullptr )
+    {
+        return false;
+    }
+
+    const CPLString osBaseURL(poHandleHelper->GetURLNoKVP());
+
+    CURL* hCurlHandle = curl_easy_init();
+
+    if( !l_osNextMarker.empty() )
+        poHandleHelper->AddQueryParameter("continuation", l_osNextMarker);
+    if( !osMaxKeys.empty() )
+        poHandleHelper->AddQueryParameter("maxresults", osMaxKeys);
+    if( !m_osFilesystem.empty() )
+    {
+        poHandleHelper->AddQueryParameter("resource", "filesystem");
+        poHandleHelper->AddQueryParameter("recursive",
+                                      m_nRecurseDepth == 0 ? "false" : "true");
+        if( !m_osObjectKey.empty() )
+            poHandleHelper->AddQueryParameter("directory", m_osObjectKey);
+    }
+    else
+    {
+        poHandleHelper->AddQueryParameter("resource", "account");
+    }
+
+    struct curl_slist* headers =
+        VSICurlSetOptions(hCurlHandle, poHandleHelper->GetURL(), nullptr);
+    headers = VSICurlMergeHeaders(headers,
+                            poHandleHelper->GetCurlHeaders("GET", headers));
+    curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+    CurlRequestHelper requestHelper;
+    const long response_code =
+        requestHelper.perform(hCurlHandle, headers, m_poFS, poHandleHelper.get());
+
+    NetworkStatisticsLogger::LogGET(sWriteFuncData.nSize);
+
+    bool ret = false;
+    if( response_code != 200 )
+    {
+        CPLDebug(m_poFS->GetDebugKey(), "%s",
+                    requestHelper.sWriteFuncData.pBuffer
+                    ? requestHelper.sWriteFuncData.pBuffer : "(null)");
+    }
+    else
+    {
+        if( !m_osFilesystem.empty() )
+        {
+            // https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/list
+            ret = AnalysePathList( osBaseURL, requestHelper.sWriteFuncData.pBuffer );
+        }
+        else
+        {
+            // https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/filesystem/list
+            ret = AnalyseFilesystemList( osBaseURL, requestHelper.sWriteFuncData.pBuffer );
+        }
+
+        // Get continuation token for response headers
+        oIter.m_osNextMarker = GetContinuationToken(requestHelper.sWriteFuncHeaderData.pBuffer);
+    }
+
+    curl_easy_cleanup(hCurlHandle);
+    return ret;
+}
+
+/************************************************************************/
+/*                           NextDirEntry()                             */
+/************************************************************************/
+
+const VSIDIREntry* VSIDIRADLS::NextDirEntry()
+{
+    while( true )
+    {
+        auto& oIter = !m_osFilesystem.empty() ? m_oIterWithinFilesystem : m_oIterFromRoot;
+        if( oIter.m_nPos < static_cast<int>(oIter.m_aoEntries.size()) )
+        {
+            auto& entry = oIter.m_aoEntries[oIter.m_nPos];
+            oIter.m_nPos ++;
+            if( m_bRecursiveRequestFromAccountRoot )
+            {
+                // If we just read an entry from the account root, it is a
+                // filesystem name, and we want the next iteration to read
+                // into it.
+                if( m_osFilesystem.empty() )
+                {
+                    m_osFilesystem = entry->pszName;
+                    if( !IssueListDir() )
+                    {
+                        return nullptr;
+                    }
+                }
+            }
+            return entry.get();
+        }
+        if( oIter.m_osNextMarker.empty() )
+        {
+            if( m_bRecursiveRequestFromAccountRoot )
+            {
+                // If we have no more entries at the filesystem level, go back
+                // to the root level.
+                if( !m_osFilesystem.empty() )
+                {
+                    m_osFilesystem.clear();
+                    continue;
+                }
+            }
+            return nullptr;
+        }
+        if( !IssueListDir() )
+        {
+            return nullptr;
+        }
+    }
+}
+
+/************************************************************************/
+/*                          VSIADLSHandle                              */
+/************************************************************************/
+
+class VSIADLSHandle final : public VSICurlHandle
+{
+    CPL_DISALLOW_COPY_ASSIGN(VSIADLSHandle)
+
+    std::unique_ptr<VSIAzureBlobHandleHelper> m_poHandleHelper{};
+
+  protected:
+        virtual struct curl_slist* GetCurlHeaders( const CPLString& osVerb,
+                    const struct curl_slist* psExistingHeaders ) override;
+
+    public:
+        VSIADLSHandle( VSIADLSFSHandler* poFS, const char* pszFilename,
+                     VSIAzureBlobHandleHelper* poHandleHelper);
+};
+
+/************************************************************************/
+/*                          CreateFileHandle()                          */
+/************************************************************************/
+
+VSICurlHandle* VSIADLSFSHandler::CreateFileHandle(const char* pszFilename)
+{
+    VSIAzureBlobHandleHelper* poHandleHelper =
+        VSIAzureBlobHandleHelper::BuildFromURI( pszFilename + GetFSPrefix().size(),
+                                         GetFSPrefix() );
+    if( poHandleHelper == nullptr )
+        return nullptr;
+    return new VSIADLSHandle(this, pszFilename, poHandleHelper);
+}
+
+/************************************************************************/
+/*                                Stat()                                */
+/************************************************************************/
+
+int VSIADLSFSHandler::Stat( const char *pszFilename, VSIStatBufL *pStatBuf,
+                          int nFlags )
+{
+    if( !STARTS_WITH_CI(pszFilename, GetFSPrefix()) )
+        return -1;
+
+    const CPLString osFilenameWithoutSlash(RemoveTrailingSlash(pszFilename));
+
+    // Stat("/vsiadls/") ?
+    if( osFilenameWithoutSlash + "/" == GetFSPrefix() )
+    {
+        // List file systems (stop at the first one), to confirm that the
+        // account is correct
+        bool bGotFileList = false;
+        CSLDestroy(GetFileList(GetFSPrefix(), 1, false, &bGotFileList));
+        if( bGotFileList )
+        {
+            memset(pStatBuf, 0, sizeof(VSIStatBufL));
+            pStatBuf->st_mode = S_IFDIR;
+            return 0;
+        }
+        return -1;
+    }
+
+    // Stat("/vsiadls/filesystem") ?
+    if( osFilenameWithoutSlash.size() > GetFSPrefix().size() &&
+        osFilenameWithoutSlash.substr(GetFSPrefix().size()).find('/') == std::string::npos )
+    {
+        // Use https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/filesystem/getproperties
+
+        NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+        NetworkStatisticsAction oContextAction("GetProperties");
+
+        const CPLString osFilesystem(
+            osFilenameWithoutSlash.substr(GetFSPrefix().size()));
+        auto poHandleHelper =
+            std::unique_ptr<IVSIS3LikeHandleHelper>(CreateHandleHelper(osFilesystem, true));
+        if( poHandleHelper == nullptr )
+        {
+            return -1;
+        }
+
+        CURL* hCurlHandle = curl_easy_init();
+
+        poHandleHelper->AddQueryParameter("resource", "filesystem");
+
+        struct curl_slist* headers =
+            VSICurlSetOptions(hCurlHandle, poHandleHelper->GetURL(), nullptr);
+
+        headers = VSICurlMergeHeaders(headers,
+                                poHandleHelper->GetCurlHeaders("HEAD", headers));
+        curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+        curl_easy_setopt(hCurlHandle, CURLOPT_NOBODY, 1);
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poHandleHelper.get());
+
+        NetworkStatisticsLogger::LogHEAD();
+
+        if( response_code != 200 || requestHelper.sWriteFuncHeaderData.pBuffer == nullptr )
+        {
+            curl_easy_cleanup(hCurlHandle);
+            return -1;
+        }
+
+        memset(pStatBuf, 0, sizeof(VSIStatBufL));
+        pStatBuf->st_mode = S_IFDIR;
+
+        const char* pszLastModified =
+            strstr(requestHelper.sWriteFuncHeaderData.pBuffer, "Last-Modified: ");
+        if( pszLastModified )
+        {
+            pszLastModified += strlen("Last-Modified: ");
+            const char* pszEOL = strstr(pszLastModified, "\r\n");
+            if( pszEOL )
+            {
+                CPLString osLastModified;
+                osLastModified.assign(pszLastModified,
+                                    pszEOL - pszLastModified);
+
+                const GIntBig nMTime = GetUnixTimeFromRFC822(osLastModified.c_str());
+                if( nMTime != GINTBIG_MIN )
+                {
+                    pStatBuf->st_mtime = static_cast<time_t>(nMTime);
+                }
+            }
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+
+        return 0;
+    }
+
+    return VSICurlFilesystemHandler::Stat(osFilenameWithoutSlash, pStatBuf, nFlags);
+}
+
+/************************************************************************/
+/*                          GetFileMetadata()                           */
+/************************************************************************/
+
+char** VSIADLSFSHandler::GetFileMetadata( const char* pszFilename,
+                                        const char* pszDomain,
+                                        CSLConstList papszOptions )
+{
+    if( !STARTS_WITH_CI(pszFilename, GetFSPrefix()) )
+        return nullptr;
+
+    if( pszDomain == nullptr || (!EQUAL(pszDomain, "STATUS") && !EQUAL(pszDomain, "ACL")) )
+    {
+        return VSICurlFilesystemHandler::GetFileMetadata(
+                    pszFilename, pszDomain, papszOptions);
+    }
+
+    auto poHandleHelper = std::unique_ptr<IVSIS3LikeHandleHelper>(
+        CreateHandleHelper(pszFilename + GetFSPrefix().size(), false));
+    if( poHandleHelper == nullptr )
+    {
+        return nullptr;
+    }
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("GetFileMetadata");
+
+    bool bRetry;
+    // coverity[tainted_data]
+    double dfRetryDelay = CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
+                                CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+    const int nMaxRetry = atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
+                                   CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)));
+    int nRetryCount = 0;
+    bool bError = true;
+
+    CPLStringList aosMetadata;
+    do
+    {
+        bRetry = false;
+        CURL* hCurlHandle = curl_easy_init();
+        poHandleHelper->AddQueryParameter("action",
+            EQUAL(pszDomain, "STATUS") ? "getStatus" : "getAccessControl");
+
+        struct curl_slist* headers =
+            VSICurlSetOptions(hCurlHandle, poHandleHelper->GetURL(), nullptr);
+
+        headers = VSICurlMergeHeaders(headers,
+                                poHandleHelper->GetCurlHeaders("HEAD", headers));
+        curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+        curl_easy_setopt(hCurlHandle, CURLOPT_NOBODY, 1);
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poHandleHelper.get());
+
+        NetworkStatisticsLogger::LogHEAD();
+
+        if( response_code != 200 || requestHelper.sWriteFuncHeaderData.pBuffer == nullptr )
+        {
+            // Look if we should attempt a retry
+            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
+                static_cast<int>(response_code), dfRetryDelay,
+                requestHelper.sWriteFuncHeaderData.pBuffer, requestHelper.szCurlErrBuf);
+            if( dfNewRetryDelay > 0 &&
+                nRetryCount < nMaxRetry )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                            "HTTP error code: %d - %s. "
+                            "Retrying again in %.1f secs",
+                            static_cast<int>(response_code),
+                            poHandleHelper->GetURL().c_str(),
+                            dfRetryDelay);
+                CPLSleep(dfRetryDelay);
+                dfRetryDelay = dfNewRetryDelay;
+                nRetryCount++;
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug(GetDebugKey(), "GetFileMetadata failed on %s: %s",
+                         pszFilename,
+                         requestHelper.sWriteFuncData.pBuffer
+                         ? requestHelper.sWriteFuncData.pBuffer
+                         : "(null)");
+            }
+        }
+        else
+        {
+            char** papszHeaders = CSLTokenizeString2(requestHelper.sWriteFuncHeaderData.pBuffer, "\r\n", 0);
+            for( int i = 0; papszHeaders[i]; ++i )
+            {
+                char* pszKey = nullptr;
+                const char* pszValue = CPLParseNameValue(papszHeaders[i], &pszKey);
+                if( pszKey && pszValue && !EQUAL(pszKey, "Server") && !EQUAL(pszKey, "Date") )
+                {
+                    aosMetadata.SetNameValue(pszKey, pszValue);
+                }
+                CPLFree(pszKey);
+            }
+            CSLDestroy(papszHeaders);
+            bError = false;
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    }
+    while( bRetry );
+    return bError ? nullptr : CSLDuplicate(aosMetadata.List());
+}
+
+/************************************************************************/
+/*                          SetFileMetadata()                           */
+/************************************************************************/
+
+bool VSIADLSFSHandler::SetFileMetadata( const char * pszFilename,
+                                        CSLConstList papszMetadata,
+                                        const char* pszDomain,
+                                        CSLConstList papszOptions )
+{
+    if( !STARTS_WITH_CI(pszFilename, GetFSPrefix()) )
+        return false;
+
+    if( pszDomain == nullptr ||
+        !(EQUAL(pszDomain, "PROPERTIES") || EQUAL(pszDomain, "ACL")) )
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Only PROPERTIES and ACL domain are supported");
+        return false;
+    }
+
+    auto poHandleHelper = std::unique_ptr<IVSIS3LikeHandleHelper>(
+        CreateHandleHelper(pszFilename + GetFSPrefix().size(), false));
+    if( poHandleHelper == nullptr )
+    {
+        return false;
+    }
+
+    const bool bRecursive = CPLTestBool(
+        CSLFetchNameValueDef(papszOptions, "RECURSIVE", "FALSE"));
+    const char* pszMode = CSLFetchNameValue(papszOptions, "MODE");
+    if( !EQUAL(pszDomain, "PROPERTIES") && bRecursive && pszMode == nullptr )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "For setAccessControlRecursive, the MODE option should be set "
+                 "to: 'set', 'modify' or 'remove'");
+        return false;
+    }
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("SetFileMetadata");
+
+    bool bRetry;
+    // coverity[tainted_data]
+    double dfRetryDelay = CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
+                                CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+    const int nMaxRetry = atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
+                                   CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)));
+    int nRetryCount = 0;
+
+    bool bRet = false;
+
+    do
+    {
+        bRetry = false;
+        CURL* hCurlHandle = curl_easy_init();
+        poHandleHelper->AddQueryParameter("action",
+            EQUAL(pszDomain, "PROPERTIES") ? "setProperties" :
+            bRecursive ? "setAccessControlRecursive" : "setAccessControl");
+        if( pszMode )
+        {
+            poHandleHelper->AddQueryParameter("mode", CPLString(pszMode).tolower());
+        }
+        curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "PATCH");
+
+        struct curl_slist* headers = static_cast<struct curl_slist*>(
+            CPLHTTPSetOptions(hCurlHandle,
+                              poHandleHelper->GetURL().c_str(),
+                              nullptr));
+
+        CPLStringList aosList;
+        for( CSLConstList papszIter = papszMetadata; papszIter && *papszIter; ++papszIter )
+        {
+            char* pszKey = nullptr;
+            const char* pszValue = CPLParseNameValue(*papszIter, &pszKey);
+            if( pszKey && pszValue )
+            {
+                if( (EQUAL(pszDomain, "PROPERTIES") &&
+                        (EQUAL(pszKey, "x-ms-lease-id") ||
+                        EQUAL(pszKey, "x-ms-cache-control") ||
+                        EQUAL(pszKey, "x-ms-content-type") ||
+                        EQUAL(pszKey, "x-ms-content-disposition") ||
+                        EQUAL(pszKey, "x-ms-content-encoding") ||
+                        EQUAL(pszKey, "x-ms-content-language") ||
+                        EQUAL(pszKey, "x-ms-content-md5") ||
+                        EQUAL(pszKey, "x-ms-properties") ||
+                        EQUAL(pszKey, "x-ms-client-request-id") ||
+                        STARTS_WITH_CI(pszKey, "If-"))) ||
+                    (!EQUAL(pszDomain, "PROPERTIES") && !bRecursive &&
+                        (EQUAL(pszKey, "x-ms-lease-id") ||
+                        EQUAL(pszKey, "x-ms-owner") ||
+                        EQUAL(pszKey, "x-ms-group") ||
+                        EQUAL(pszKey, "x-ms-permissions") ||
+                        EQUAL(pszKey, "x-ms-acl") ||
+                        EQUAL(pszKey, "x-ms-client-request-id") ||
+                        STARTS_WITH_CI(pszKey, "If-"))) ||
+                    (!EQUAL(pszDomain, "PROPERTIES") && bRecursive &&
+                        (EQUAL(pszKey, "x-ms-lease-id") ||
+                        EQUAL(pszKey, "x-ms-acl") ||
+                        EQUAL(pszKey, "x-ms-client-request-id") ||
+                        STARTS_WITH_CI(pszKey, "If-"))) )
+                {
+                    char* pszHeader = CPLStrdup(CPLSPrintf("%s: %s", pszKey, pszValue));
+                    aosList.AddStringDirectly(pszHeader);
+                    headers = curl_slist_append(headers, pszHeader);
+                }
+                else
+                {
+                    CPLDebug(GetDebugKey(), "Ignorizing metadata item %s", *papszIter);
+                }
+            }
+            CPLFree(pszKey);
+        }
+
+        headers = VSICurlMergeHeaders(headers,
+                                poHandleHelper->GetCurlHeaders("PATCH", headers));
+        curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+        NetworkStatisticsLogger::LogPUT(0);
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poHandleHelper.get());
+
+        if( response_code != 200 && response_code != 202 )
+        {
+            // Look if we should attempt a retry
+            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
+                static_cast<int>(response_code), dfRetryDelay,
+                requestHelper.sWriteFuncHeaderData.pBuffer, requestHelper.szCurlErrBuf);
+            if( dfNewRetryDelay > 0 &&
+                nRetryCount < nMaxRetry )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                            "HTTP error code: %d - %s. "
+                            "Retrying again in %.1f secs",
+                            static_cast<int>(response_code),
+                            poHandleHelper->GetURL().c_str(),
+                            dfRetryDelay);
+                CPLSleep(dfRetryDelay);
+                dfRetryDelay = dfNewRetryDelay;
+                nRetryCount++;
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug(GetDebugKey(), "SetFileMetadata on %s failed: %s",
+                         pszFilename,
+                         requestHelper.sWriteFuncData.pBuffer
+                         ? requestHelper.sWriteFuncData.pBuffer
+                         : "(null)");
+            }
+        }
+        else
+        {
+            bRet = true;
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    }
+    while( bRetry );
+    return bRet;
+}
+
+/************************************************************************/
+/*                          VSIADLSWriteHandle                         */
+/************************************************************************/
+
+class VSIADLSWriteHandle final : public VSIAppendWriteHandle
+{
+    CPL_DISALLOW_COPY_ASSIGN(VSIADLSWriteHandle)
+
+    std::unique_ptr<VSIAzureBlobHandleHelper>  m_poHandleHelper{};
+    bool                       m_bCreated = false;
+
+    bool                Send(bool bIsLastBlock) override;
+
+    bool                SendInternal(VSIADLSFSHandler::Event event);
+
+    void                InvalidateParentDirectory();
+
+    public:
+        VSIADLSWriteHandle( VSIADLSFSHandler* poFS,
+                          const char* pszFilename,
+                          VSIAzureBlobHandleHelper* poHandleHelper );
+        virtual ~VSIADLSWriteHandle();
+
+        bool CreateFile();
+};
+
+/************************************************************************/
+/*                       VSIADLSWriteHandle()                          */
+/************************************************************************/
+
+VSIADLSWriteHandle::VSIADLSWriteHandle( VSIADLSFSHandler* poFS,
+                                    const char* pszFilename,
+                                    VSIAzureBlobHandleHelper* poHandleHelper) :
+        VSIAppendWriteHandle(poFS, poFS->GetFSPrefix(), pszFilename, GetAzureBufferSize()),
+        m_poHandleHelper(poHandleHelper)
+{
+}
+
+/************************************************************************/
+/*                      ~VSIADLSWriteHandle()                          */
+/************************************************************************/
+
+VSIADLSWriteHandle::~VSIADLSWriteHandle()
+{
+    Close();
+}
+
+/************************************************************************/
+/*                    InvalidateParentDirectory()                       */
+/************************************************************************/
+
+void VSIADLSWriteHandle::InvalidateParentDirectory()
+{
+    m_poFS->InvalidateCachedData(
+        m_poHandleHelper->GetURLNoKVP().c_str() );
+
+    const CPLString osFilenameWithoutSlash(RemoveTrailingSlash(m_osFilename));
+    m_poFS->InvalidateDirContent( CPLGetDirname(osFilenameWithoutSlash) );
+}
+
+/************************************************************************/
+/*                          CreateFile()                                */
+/************************************************************************/
+
+bool VSIADLSWriteHandle::CreateFile()
+{
+    m_bCreated = SendInternal(VSIADLSFSHandler::Event::CREATE_FILE);
+    return m_bCreated;
+}
+
+/************************************************************************/
+/*                             Send()                                   */
+/************************************************************************/
+
+bool VSIADLSWriteHandle::Send(bool bIsLastBlock)
+{
+    if( !m_bCreated )
+        return false;
+    // If we have a non-empty buffer, append it
+    if( m_nBufferOff != 0 && !SendInternal(VSIADLSFSHandler::Event::APPEND_DATA) )
+        return false;
+    // If we are the last block, send the flush event
+    if( bIsLastBlock && !SendInternal(VSIADLSFSHandler::Event::FLUSH) )
+        return false;
+    return true;
+}
+
+/************************************************************************/
+/*                          SendInternal()                              */
+/************************************************************************/
+
+bool VSIADLSWriteHandle::SendInternal(VSIADLSFSHandler::Event event)
+{
+    // coverity[tainted_data]
+    const int nMaxRetry = atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
+                                   CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)));
+    // coverity[tainted_data]
+    double dfRetryDelay = CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
+                                CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+
+    return cpl::down_cast<VSIADLSFSHandler*>(m_poFS)->UploadFile(
+        m_osFilename, event,
+        event == VSIADLSFSHandler::Event::CREATE_FILE ? 0 :
+        event == VSIADLSFSHandler::Event::APPEND_DATA ? m_nCurOffset - m_nBufferOff :
+                                                        m_nCurOffset,
+        m_pabyBuffer, m_nBufferOff, m_poHandleHelper.get(),
+        nMaxRetry, dfRetryDelay);
+}
+
+/************************************************************************/
+/*                                Open()                                */
+/************************************************************************/
+
+VSIVirtualHandle* VSIADLSFSHandler::Open( const char *pszFilename,
+                                        const char *pszAccess,
+                                        bool bSetError)
+{
+    if( !STARTS_WITH_CI(pszFilename, GetFSPrefix()) )
+        return nullptr;
+
+    if( strchr(pszAccess, 'w') != nullptr || strchr(pszAccess, 'a') != nullptr )
+    {
+        if( strchr(pszAccess, '+') != nullptr &&
+            !CPLTestBool(CPLGetConfigOption("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "NO")) )
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                        "w+ not supported for /vsiadls, unless "
+                        "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE is set to YES");
+            errno = EACCES;
+            return nullptr;
+        }
+
+        VSIAzureBlobHandleHelper* poHandleHelper =
+            VSIAzureBlobHandleHelper::BuildFromURI(pszFilename + GetFSPrefix().size(),
+                                            GetFSPrefix().c_str());
+        if( poHandleHelper == nullptr )
+            return nullptr;
+        auto poHandle = std::unique_ptr<VSIADLSWriteHandle>(
+            new VSIADLSWriteHandle(this, pszFilename, poHandleHelper));
+        if( !poHandle->CreateFile() )
+        {
+            return nullptr;
+        }
+        if( strchr(pszAccess, '+') != nullptr)
+        {
+            return VSICreateUploadOnCloseFile(poHandle.release());
+        }
+        return poHandle.release();
+    }
+
+    return
+        VSICurlFilesystemHandler::Open(pszFilename, pszAccess, bSetError);
+}
+
+/************************************************************************/
+/*                          GetURLFromFilename()                        */
+/************************************************************************/
+
+CPLString VSIADLSFSHandler::GetURLFromFilename( const CPLString& osFilename )
+{
+    CPLString osFilenameWithoutPrefix = osFilename.substr(GetFSPrefix().size());
+    VSIAzureBlobHandleHelper* poHandleHelper =
+        VSIAzureBlobHandleHelper::BuildFromURI( osFilenameWithoutPrefix, GetFSPrefix() );
+    if( poHandleHelper == nullptr )
+        return CPLString();
+    CPLString osURL( poHandleHelper->GetURLNoKVP() );
+    delete poHandleHelper;
+    return osURL;
+}
+
+/************************************************************************/
+/*                          CreateHandleHelper()                        */
+/************************************************************************/
+
+IVSIS3LikeHandleHelper* VSIADLSFSHandler::CreateHandleHelper(const char* pszURI,
+                                                           bool)
+{
+    return VSIAzureBlobHandleHelper::BuildFromURI(pszURI, GetFSPrefix().c_str());
+}
+
+/************************************************************************/
+/*                               Rename()                               */
+/************************************************************************/
+
+int VSIADLSFSHandler::Rename( const char *oldpath, const char *newpath )
+{
+    if( !STARTS_WITH_CI(oldpath, GetFSPrefix()) )
+        return -1;
+    if( !STARTS_WITH_CI(newpath, GetFSPrefix()) )
+        return -1;
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("Rename");
+
+    VSIStatBufL sStat;
+    if( VSIStatL(oldpath, &sStat) != 0 )
+    {
+        CPLDebug(GetDebugKey(), "%s is not a object", oldpath);
+        errno = ENOENT;
+        return -1;
+    }
+
+    // POSIX says renaming on the same file is OK
+    if( strcmp(oldpath, newpath) == 0 )
+        return 0;
+
+    auto poHandleHelper =
+        std::unique_ptr<IVSIS3LikeHandleHelper>(
+            CreateHandleHelper(newpath + GetFSPrefix().size(), false));
+    if( poHandleHelper == nullptr )
+    {
+        return -1;
+    }
+
+
+    CPLString osContinuation;
+    int nRet = 0;
+    bool bRetry;
+
+    const int nMaxRetry = atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
+                                   CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)));
+    // coverity[tainted_data]
+    double dfRetryDelay = CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
+                                CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+    int nRetryCount = 0;
+
+    InvalidateCachedData( GetURLFromFilename(oldpath) );
+    InvalidateCachedData( GetURLFromFilename(newpath) );
+    InvalidateDirContent( CPLGetDirname(oldpath) );
+
+    do
+    {
+        bRetry = false;
+
+        CURL* hCurlHandle = curl_easy_init();
+        curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "PUT");
+
+        poHandleHelper->ResetQueryParameters();
+        if( !osContinuation.empty() )
+            poHandleHelper->AddQueryParameter("continuation", osContinuation);
+
+        struct curl_slist* headers = static_cast<struct curl_slist*>(
+            CPLHTTPSetOptions(hCurlHandle,
+                              poHandleHelper->GetURL().c_str(),
+                              nullptr));
+        headers = curl_slist_append(headers, "Content-Length: 0");
+        CPLString osRenameSource("x-ms-rename-source: /");
+        osRenameSource += CPLAWSURLEncode(oldpath + GetFSPrefix().size(), false);
+        headers = curl_slist_append(headers, osRenameSource.c_str());
+        headers = VSICurlMergeHeaders(headers,
+                        poHandleHelper->GetCurlHeaders("PUT", headers));
+        curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poHandleHelper.get());
+
+        NetworkStatisticsLogger::LogPUT(0);
+
+        if( response_code != 201)
+        {
+            // Look if we should attempt a retry
+            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
+                static_cast<int>(response_code), dfRetryDelay,
+                requestHelper.sWriteFuncHeaderData.pBuffer,
+                requestHelper.szCurlErrBuf);
+            if( dfNewRetryDelay > 0 &&
+                nRetryCount < nMaxRetry )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                            "HTTP error code: %d - %s. "
+                            "Retrying again in %.1f secs",
+                            static_cast<int>(response_code),
+                            poHandleHelper->GetURL().c_str(),
+                            dfRetryDelay);
+                CPLSleep(dfRetryDelay);
+                dfRetryDelay = dfNewRetryDelay;
+                nRetryCount++;
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug(GetDebugKey(), "Renaming of %s failed: %s",
+                         oldpath,
+                         requestHelper.sWriteFuncData.pBuffer
+                         ? requestHelper.sWriteFuncData.pBuffer
+                         : "(null)");
+                nRet = -1;
+            }
+        }
+        else
+        {
+            // Get continuation token for response headers
+            osContinuation = GetContinuationToken(requestHelper.sWriteFuncHeaderData.pBuffer);
+            if( !osContinuation.empty() )
+            {
+                nRetryCount = 0;
+                bRetry = true;
+            }
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    }
+    while( bRetry );
+
+    return nRet;
+}
+
+/************************************************************************/
+/*                               Unlink()                               */
+/************************************************************************/
+
+int VSIADLSFSHandler::Unlink( const char *pszFilename )
+{
+    return IVSIS3LikeFSHandler::Unlink(pszFilename);
+}
+
+/************************************************************************/
+/*                               Mkdir()                                */
+/************************************************************************/
+
+int VSIADLSFSHandler::MkdirInternal( const char *pszDirname, long nMode, bool bDoStatCheck )
+{
+    if( !STARTS_WITH_CI(pszDirname, GetFSPrefix()) )
+        return -1;
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("Mkdir");
+
+    const CPLString osDirname(pszDirname);
+
+    if( bDoStatCheck )
+    {
+        VSIStatBufL sStat;
+        if( VSIStatL(osDirname, &sStat) == 0 )
+        {
+            CPLDebug(GetDebugKey(), "Directory or file %s already exists", osDirname.c_str());
+            errno = EEXIST;
+            return -1;
+        }
+    }
+
+    const CPLString osDirnameWithoutEndSlash(RemoveTrailingSlash(osDirname));
+    auto poHandleHelper =
+        std::unique_ptr<IVSIS3LikeHandleHelper>(
+            CreateHandleHelper(osDirnameWithoutEndSlash.c_str() + GetFSPrefix().size(), false));
+    if( poHandleHelper == nullptr )
+    {
+        return -1;
+    }
+
+    InvalidateCachedData( GetURLFromFilename(osDirname) );
+    InvalidateCachedData( GetURLFromFilename(osDirnameWithoutEndSlash) );
+    InvalidateDirContent( CPLGetDirname(osDirnameWithoutEndSlash) );
+
+    int nRet = 0;
+
+    bool bRetry;
+
+    const int nMaxRetry = atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
+                                   CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)));
+    // coverity[tainted_data]
+    double dfRetryDelay = CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
+                                CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+    int nRetryCount = 0;
+
+    do
+    {
+        bRetry = false;
+        CURL* hCurlHandle = curl_easy_init();
+        curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "PUT");
+
+        poHandleHelper->ResetQueryParameters();
+        poHandleHelper->AddQueryParameter("resource",
+            osDirnameWithoutEndSlash.find('/', GetFSPrefix().size())
+                == std::string::npos ? "filesystem" : "directory");
+
+        struct curl_slist* headers = static_cast<struct curl_slist*>(
+            CPLHTTPSetOptions(hCurlHandle,
+                              poHandleHelper->GetURL().c_str(),
+                              nullptr));
+        headers = curl_slist_append(headers, "Content-Length: 0");
+        CPLString osPermissions; // keep in this scope
+        if( (nMode & 0777) != 0 )
+        {
+            osPermissions.Printf("x-ms-permissions: 0%03o", static_cast<int>(nMode));
+            headers = curl_slist_append(headers, osPermissions.c_str());
+        }
+        if( bDoStatCheck )
+        {
+            headers = curl_slist_append(headers, "If-None-Match: \"*\"");
+        }
+
+        headers = VSICurlMergeHeaders(headers,
+                        poHandleHelper->GetCurlHeaders("PUT", headers));
+        curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poHandleHelper.get());
+
+        NetworkStatisticsLogger::LogPUT(0);
+
+        if( response_code != 201 )
+        {
+            // Look if we should attempt a retry
+            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
+                static_cast<int>(response_code), dfRetryDelay,
+                requestHelper.sWriteFuncHeaderData.pBuffer,
+                requestHelper.szCurlErrBuf);
+            if( dfNewRetryDelay > 0 &&
+                nRetryCount < nMaxRetry )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                            "HTTP error code: %d - %s. "
+                            "Retrying again in %.1f secs",
+                            static_cast<int>(response_code),
+                            poHandleHelper->GetURL().c_str(),
+                            dfRetryDelay);
+                CPLSleep(dfRetryDelay);
+                dfRetryDelay = dfNewRetryDelay;
+                nRetryCount++;
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug(GetDebugKey(), "Creation of %s failed: %s",
+                         osDirname.c_str(),
+                         requestHelper.sWriteFuncData.pBuffer
+                         ? requestHelper.sWriteFuncData.pBuffer
+                         : "(null)");
+                nRet = -1;
+            }
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    }
+    while( bRetry );
+
+    return nRet;
+}
+
+int VSIADLSFSHandler::Mkdir( const char * pszDirname, long nMode )
+{
+    return MkdirInternal(pszDirname, nMode, true);
+}
+
+/************************************************************************/
+/*                          RmdirInternal()                             */
+/************************************************************************/
+
+int VSIADLSFSHandler::RmdirInternal( const char * pszDirname, bool bRecursive )
+{
+    const CPLString osDirname(pszDirname);
+    const CPLString osDirnameWithoutEndSlash(RemoveTrailingSlash(osDirname));
+
+    const bool bIsFileSystem =
+        osDirnameWithoutEndSlash.find('/', GetFSPrefix().size()) == std::string::npos;
+
+    if( !bRecursive && bIsFileSystem )
+    {
+        // List content, to confirm it is empty first, as filesystem deletion
+        // is recursive by default.
+        bool bGotFileList = false;
+        CSLDestroy(GetFileList(osDirnameWithoutEndSlash, 1, false, &bGotFileList));
+        if( bGotFileList )
+        {
+            CPLDebug(GetDebugKey(),
+                     "Cannot delete filesystem with non-recursive method as it is not empty");
+            errno = ENOTEMPTY;
+            return -1;
+        }
+    }
+
+    if( !bIsFileSystem )
+    {
+        VSIStatBufL sStat;
+        if( VSIStatL(osDirname, &sStat) != 0  )
+        {
+            CPLDebug(GetDebugKey(), "Object %s does not exist", osDirname.c_str());
+            errno = ENOENT;
+            return -1;
+        }
+        if( !VSI_ISDIR(sStat.st_mode) )
+        {
+            CPLDebug(GetDebugKey(), "Object %s is not a directory", osDirname.c_str());
+            errno = ENOTDIR;
+            return -1;
+        }
+    }
+
+    auto poHandleHelper =
+        std::unique_ptr<IVSIS3LikeHandleHelper>(
+            CreateHandleHelper(osDirnameWithoutEndSlash.c_str() + GetFSPrefix().size(), false));
+    if( poHandleHelper == nullptr )
+    {
+        return -1;
+    }
+
+    InvalidateCachedData( GetURLFromFilename(osDirname) );
+    InvalidateCachedData( GetURLFromFilename(osDirnameWithoutEndSlash) );
+    InvalidateDirContent( CPLGetDirname(osDirnameWithoutEndSlash) );
+    if( bRecursive )
+    {
+        PartialClearCache(osDirnameWithoutEndSlash);
+    }
+
+    CPLString osContinuation;
+    int nRet = 0;
+    bool bRetry;
+
+    const int nMaxRetry = atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
+                                   CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)));
+    // coverity[tainted_data]
+    double dfRetryDelay = CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
+                                CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+    int nRetryCount = 0;
+    do
+    {
+        bRetry = false;
+        CURL* hCurlHandle = curl_easy_init();
+        curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "DELETE");
+
+        poHandleHelper->ResetQueryParameters();
+        if( bIsFileSystem )
+        {
+            poHandleHelper->AddQueryParameter("resource", "filesystem");
+        }
+        else
+        {
+            poHandleHelper->AddQueryParameter("recursive", bRecursive ? "true" : "false");
+            if( !osContinuation.empty() )
+                poHandleHelper->AddQueryParameter("continuation", osContinuation);
+        }
+
+        struct curl_slist* headers = static_cast<struct curl_slist*>(
+            CPLHTTPSetOptions(hCurlHandle,
+                              poHandleHelper->GetURL().c_str(),
+                              nullptr));
+        headers = VSICurlMergeHeaders(headers,
+                        poHandleHelper->GetCurlHeaders("DELETE", headers));
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poHandleHelper.get());
+
+        NetworkStatisticsLogger::LogDELETE();
+
+        // 200 for path deletion
+        // 202 for filesystem deletion
+        if( response_code != 200 && response_code != 202 )
+        {
+            // Look if we should attempt a retry
+            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
+                static_cast<int>(response_code), dfRetryDelay,
+                requestHelper.sWriteFuncHeaderData.pBuffer, requestHelper.szCurlErrBuf);
+            if( dfNewRetryDelay > 0 &&
+                nRetryCount < nMaxRetry )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                            "HTTP error code: %d - %s. "
+                            "Retrying again in %.1f secs",
+                            static_cast<int>(response_code),
+                            poHandleHelper->GetURL().c_str(),
+                            dfRetryDelay);
+                CPLSleep(dfRetryDelay);
+                dfRetryDelay = dfNewRetryDelay;
+                nRetryCount++;
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug(GetDebugKey(), "Delete of %s failed: %s",
+                         osDirname.c_str(),
+                         requestHelper.sWriteFuncData.pBuffer
+                         ? requestHelper.sWriteFuncData.pBuffer
+                         : "(null)");
+                if( requestHelper.sWriteFuncData.pBuffer != nullptr )
+                {
+                    VSIError(VSIE_AWSError, "%s", requestHelper.sWriteFuncData.pBuffer);
+                    if( strstr(requestHelper.sWriteFuncData.pBuffer, "PathNotFound") )
+                    {
+                        errno = ENOENT;
+                    }
+                    else if( strstr(requestHelper.sWriteFuncData.pBuffer, "DirectoryNotEmpty") )
+                    {
+                        errno = ENOTEMPTY;
+                    }
+                }
+                nRet = -1;
+            }
+        }
+        else
+        {
+            // Get continuation token for response headers
+            osContinuation = GetContinuationToken(requestHelper.sWriteFuncHeaderData.pBuffer);
+            if( !osContinuation.empty() )
+            {
+                nRetryCount = 0;
+                bRetry = true;
+            }
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    }
+    while( bRetry );
+
+    return nRet;
+}
+
+/************************************************************************/
+/*                               Rmdir()                                */
+/************************************************************************/
+
+int VSIADLSFSHandler::Rmdir( const char * pszDirname )
+{
+    if( !STARTS_WITH_CI(pszDirname, GetFSPrefix()) )
+        return -1;
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("Rmdir");
+
+    return RmdirInternal(pszDirname, false);
+}
+
+/************************************************************************/
+/*                          RmdirRecursive()                            */
+/************************************************************************/
+
+int VSIADLSFSHandler::RmdirRecursive( const char * pszDirname )
+{
+    if( !STARTS_WITH_CI(pszDirname, GetFSPrefix()) )
+        return -1;
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("RmdirRecursive");
+
+    return RmdirInternal(pszDirname, true);
+}
+
+/************************************************************************/
+/*                            CopyObject()                              */
+/************************************************************************/
+
+int VSIADLSFSHandler::CopyObject( const char *oldpath, const char *newpath,
+                                   CSLConstList /* papszMetadata */ )
+{
+    // There is no CopyObject in ADLS... So use the base Azure blob one...
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("CopyObject");
+
+    CPLString osTargetNameWithoutPrefix = newpath + GetFSPrefix().size();
+    auto poAzHandleHelper =
+        std::unique_ptr<IVSIS3LikeHandleHelper>(
+            VSIAzureBlobHandleHelper::BuildFromURI(osTargetNameWithoutPrefix, "/vsiaz/"));
+    if( poAzHandleHelper == nullptr )
+    {
+        return -1;
+    }
+
+    CPLString osSourceNameWithoutPrefix = oldpath + GetFSPrefix().size();
+    auto poAzHandleHelperSource =
+        std::unique_ptr<IVSIS3LikeHandleHelper>(
+            VSIAzureBlobHandleHelper::BuildFromURI(osSourceNameWithoutPrefix, "/vsiaz/"));
+    if( poAzHandleHelperSource == nullptr )
+    {
+        return -1;
+    }
+
+    CPLString osSourceHeader("x-ms-copy-source: ");
+    osSourceHeader += poAzHandleHelperSource->GetURLNoKVP();
+
+    int nRet = 0;
+
+    bool bRetry;
+
+    const int nMaxRetry = atoi(CPLGetConfigOption("GDAL_HTTP_MAX_RETRY",
+                                   CPLSPrintf("%d",CPL_HTTP_MAX_RETRY)));
+    // coverity[tainted_data]
+    double dfRetryDelay = CPLAtof(CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
+                                CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+    int nRetryCount = 0;
+
+    do
+    {
+        bRetry = false;
+        CURL* hCurlHandle = curl_easy_init();
+        curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, "PUT");
+
+        struct curl_slist* headers = static_cast<struct curl_slist*>(
+            CPLHTTPSetOptions(hCurlHandle,
+                              poAzHandleHelper->GetURL().c_str(),
+                              nullptr));
+        headers = curl_slist_append(headers, osSourceHeader.c_str());
+        headers = curl_slist_append(headers, "Content-Length: 0");
+        headers = VSICurlMergeHeaders(headers,
+                        poAzHandleHelper->GetCurlHeaders("PUT", headers));
+        curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poAzHandleHelper.get());
+
+        NetworkStatisticsLogger::LogPUT(0);
+
+        if( response_code != 202)
+        {
+            // Look if we should attempt a retry
+            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
+                static_cast<int>(response_code), dfRetryDelay,
+                requestHelper.sWriteFuncHeaderData.pBuffer, requestHelper.szCurlErrBuf);
+            if( dfNewRetryDelay > 0 &&
+                nRetryCount < nMaxRetry )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                            "HTTP error code: %d - %s. "
+                            "Retrying again in %.1f secs",
+                            static_cast<int>(response_code),
+                            poAzHandleHelper->GetURL().c_str(),
+                            dfRetryDelay);
+                CPLSleep(dfRetryDelay);
+                dfRetryDelay = dfNewRetryDelay;
+                nRetryCount++;
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug(GetDebugKey(), "%s",
+                         requestHelper.sWriteFuncData.pBuffer
+                         ? requestHelper.sWriteFuncData.pBuffer
+                         : "(null)");
+                CPLError(CE_Failure, CPLE_AppDefined, "Copy of %s to %s failed",
+                         oldpath, newpath);
+                nRet = -1;
+            }
+        }
+        else
+        {
+            auto poADLSHandleHelper =
+                std::unique_ptr<IVSIS3LikeHandleHelper>(
+                    VSIAzureBlobHandleHelper::BuildFromURI(osTargetNameWithoutPrefix, GetFSPrefix()));
+            if( poADLSHandleHelper == nullptr )
+                InvalidateCachedData(poADLSHandleHelper->GetURLNoKVP().c_str());
+
+            const CPLString osFilenameWithoutSlash(RemoveTrailingSlash(newpath));
+            InvalidateDirContent( CPLGetDirname(osFilenameWithoutSlash) );
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    }
+    while( bRetry );
+
+    return nRet;
+}
+
+/************************************************************************/
+/*                          UploadFile()                                */
+/************************************************************************/
+
+bool VSIADLSFSHandler::UploadFile(const CPLString& osFilename,
+                                  Event event,
+                                  vsi_l_offset nPosition,
+                                  const void* pabyBuffer,
+                                  size_t nBufferSize,
+                                  IVSIS3LikeHandleHelper *poHandleHelper,
+                                  int nMaxRetry,
+                                  double dfRetryDelay)
+{
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsFile oContextFile(osFilename);
+    NetworkStatisticsAction oContextAction("UploadFile");
+
+    if( event == Event::CREATE_FILE )
+    {
+        InvalidateCachedData(poHandleHelper->GetURLNoKVP().c_str());
+        InvalidateDirContent( CPLGetDirname(osFilename) );
+    }
+
+    bool bSuccess = true;
+    int nRetryCount = 0;
+    bool bRetry;
+    do
+    {
+        bRetry = false;
+
+        CURL* hCurlHandle = curl_easy_init();
+
+        poHandleHelper->ResetQueryParameters();
+        if( event == Event::CREATE_FILE )
+        {
+            poHandleHelper->AddQueryParameter("resource", "file");
+        }
+        else if( event == Event::APPEND_DATA )
+        {
+            poHandleHelper->AddQueryParameter("action", "append");
+            poHandleHelper->AddQueryParameter("position",
+                CPLSPrintf(CPL_FRMT_GUIB, static_cast<GUIntBig>(nPosition)));
+        }
+        else
+        {
+            poHandleHelper->AddQueryParameter("action", "flush");
+            poHandleHelper->AddQueryParameter("close", "true");
+            poHandleHelper->AddQueryParameter("position",
+                CPLSPrintf(CPL_FRMT_GUIB, static_cast<GUIntBig>(nPosition)));
+        }
+
+        curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
+        curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION,
+                         PutData::ReadCallBackBuffer);
+        PutData putData;
+        putData.pabyData = static_cast<const GByte*>(pabyBuffer);
+        putData.nOff = 0;
+        putData.nTotalSize = nBufferSize;
+        curl_easy_setopt(hCurlHandle, CURLOPT_READDATA, &putData);
+
+        struct curl_slist* headers = static_cast<struct curl_slist*>(
+            CPLHTTPSetOptions(hCurlHandle,
+                              poHandleHelper->GetURL().c_str(),
+                              nullptr));
+
+        CPLString osContentLength; // leave it in this scope
+
+        if( event == Event::APPEND_DATA )
+        {
+            curl_easy_setopt(hCurlHandle, CURLOPT_INFILESIZE,
+                             static_cast<int>(nBufferSize));
+            // Disable "Expect: 100-continue" which doesn't hurt, but is not
+            // needed
+            headers = curl_slist_append(headers, "Expect:");
+            osContentLength.Printf("Content-Length: %d",
+                                   static_cast<int>(nBufferSize));
+            headers = curl_slist_append(headers, osContentLength.c_str());
+        }
+        else 
+        {
+            curl_easy_setopt(hCurlHandle, CURLOPT_INFILESIZE, 0);
+            headers = curl_slist_append(headers, "Content-Length: 0");
+        }
+
+        const char* pszVerb = (event == Event::CREATE_FILE) ? "PUT" : "PATCH";
+        curl_easy_setopt(hCurlHandle, CURLOPT_CUSTOMREQUEST, pszVerb);
+        headers = VSICurlMergeHeaders(headers,
+                        poHandleHelper->GetCurlHeaders(pszVerb, headers));
+        curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
+
+        CurlRequestHelper requestHelper;
+        const long response_code =
+            requestHelper.perform(hCurlHandle, headers, this, poHandleHelper);
+
+        NetworkStatisticsLogger::LogPUT( event == Event::APPEND_DATA ? nBufferSize : 0 );
+
+        // 200 for PATCH flush
+        // 201 for PUT create
+        // 202 for PATCH append
+        if( response_code != 200 && response_code != 201 && response_code != 202 )
+        {
+            // Look if we should attempt a retry
+            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
+                static_cast<int>(response_code), dfRetryDelay,
+                requestHelper.sWriteFuncHeaderData.pBuffer, requestHelper.szCurlErrBuf);
+            if( dfNewRetryDelay > 0 &&
+                nRetryCount < nMaxRetry )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                            "HTTP error code: %d - %s. "
+                            "Retrying again in %.1f secs",
+                            static_cast<int>(response_code),
+                            poHandleHelper->GetURL().c_str(),
+                            dfRetryDelay);
+                CPLSleep(dfRetryDelay);
+                dfRetryDelay = dfNewRetryDelay;
+                nRetryCount++;
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug(GetDebugKey(),
+                        "%s of %s failed: %s",
+                         pszVerb,
+                         osFilename.c_str(),
+                        requestHelper.sWriteFuncData.pBuffer
+                        ? requestHelper.sWriteFuncData.pBuffer
+                        : "(null)");
+                bSuccess = false;
+            }
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    } while( bRetry );
+
+    return bSuccess;
+}
+
+/************************************************************************/
+/*                           GetFileList()                              */
+/************************************************************************/
+
+char** VSIADLSFSHandler::GetFileList( const char *pszDirname,
+                                    int nMaxFiles,
+                                    bool* pbGotFileList )
+{
+    return GetFileList(pszDirname, nMaxFiles, true, pbGotFileList);
+}
+
+
+char** VSIADLSFSHandler::GetFileList( const char *pszDirname,
+                                       int nMaxFiles,
+                                       bool bCacheEntries,
+                                       bool* pbGotFileList )
+{
+    if( ENABLE_DEBUG )
+        CPLDebug(GetDebugKey(), "GetFileList(%s)" , pszDirname);
+
+    *pbGotFileList = false;
+
+    char** papszOptions = CSLSetNameValue(nullptr,
+                                "MAXFILES", CPLSPrintf("%d", nMaxFiles));
+    papszOptions = CSLSetNameValue(papszOptions,
+                            "CACHE_ENTRIES", bCacheEntries ? "YES" : "NO");
+    auto dir = OpenDir(pszDirname, 0, papszOptions);
+    CSLDestroy(papszOptions);
+    if( !dir )
+    {
+        return nullptr;
+    }
+    CPLStringList aosFileList;
+    while( true )
+    {
+        auto entry = dir->NextDirEntry();
+        if( !entry )
+        {
+            break;
+        }
+        aosFileList.AddString(entry->pszName);
+
+        if( nMaxFiles > 0 && aosFileList.size() >= nMaxFiles )
+            break;
+    }
+    delete dir;
+    *pbGotFileList = true;
+    return aosFileList.StealList();
+}
+
+
+/************************************************************************/
+/*                           GetOptions()                               */
+/************************************************************************/
+
+const char* VSIADLSFSHandler::GetOptions()
+{
+    static CPLString osOptions(
+        CPLString("<Options>") +
+    "  <Option name='AZURE_STORAGE_CONNECTION_STRING' type='string' "
+        "description='Connection string that contains account name and "
+        "secret key'/>"
+    "  <Option name='AZURE_STORAGE_ACCOUNT' type='string' "
+        "description='Storage account. To use with AZURE_STORAGE_ACCESS_KEY'/>"
+    "  <Option name='AZURE_STORAGE_ACCESS_KEY' type='string' "
+        "description='Secret key'/>"
+    "  <Option name='VSIAZ_CHUNK_SIZE' type='int' "
+        "description='Size in MB for chunks of files that are uploaded' "
+        "default='4' min='1' max='4'/>" +
+        VSICurlFilesystemHandler::GetOptionsStatic() +
+        "</Options>");
+    return osOptions.c_str();
+}
+
+/************************************************************************/
+/*                           GetSignedURL()                             */
+/************************************************************************/
+
+char* VSIADLSFSHandler::GetSignedURL(const char* pszFilename, CSLConstList papszOptions )
+{
+    if( !STARTS_WITH_CI(pszFilename, GetFSPrefix()) )
+        return nullptr;
+
+    auto poHandleHelper = std::unique_ptr<VSIAzureBlobHandleHelper>(
+        VSIAzureBlobHandleHelper::BuildFromURI(pszFilename + GetFSPrefix().size(),
+                                               "/vsiaz/", // use Azure blob
+                                               papszOptions));
+    if( poHandleHelper == nullptr )
+    {
+        return nullptr;
+    }
+
+    CPLString osRet(poHandleHelper->GetSignedURL(papszOptions));
+
+    return CPLStrdup(osRet);
+}
+
+/************************************************************************/
+/*                            OpenDir()                                 */
+/************************************************************************/
+
+VSIDIR* VSIADLSFSHandler::OpenDir( const char *pszPath,
+                                      int nRecurseDepth,
+                                      const char* const *papszOptions)
+{
+    if( nRecurseDepth > 0)
+    {
+        return VSIFilesystemHandler::OpenDir(pszPath, nRecurseDepth, papszOptions);
+    }
+
+    if( !STARTS_WITH_CI(pszPath, GetFSPrefix()) )
+        return nullptr;
+
+    NetworkStatisticsFileSystem oContextFS(GetFSPrefix());
+    NetworkStatisticsAction oContextAction("OpenDir");
+
+    const CPLString osDirnameWithoutPrefix =
+        RemoveTrailingSlash(pszPath + GetFSPrefix().size());
+    CPLString osFilesystem(osDirnameWithoutPrefix);
+    CPLString osObjectKey;
+    size_t nSlashPos = osDirnameWithoutPrefix.find('/');
+    if( nSlashPos != std::string::npos )
+    {
+        osFilesystem = osDirnameWithoutPrefix.substr(0, nSlashPos);
+        osObjectKey = osDirnameWithoutPrefix.substr(nSlashPos+1);
+    }
+
+    VSIDIRADLS* dir = new VSIDIRADLS(this);
+    dir->m_nRecurseDepth = nRecurseDepth;
+    dir->m_poFS = this;
+    dir->m_bRecursiveRequestFromAccountRoot = osFilesystem.empty() && nRecurseDepth < 0;
+    dir->m_osFilesystem = osFilesystem;
+    dir->m_osObjectKey = osObjectKey;
+    dir->m_nMaxFiles = atoi(CSLFetchNameValueDef(papszOptions, "MAXFILES", "0"));
+    dir->m_bCacheEntries = CPLTestBool(
+        CSLFetchNameValueDef(papszOptions, "CACHE_ENTRIES", "YES"));
+    if( !dir->IssueListDir() )
+    {
+        delete dir;
+        return nullptr;
+    }
+
+    return dir;
+}
+
+/************************************************************************/
+/*                         GetStreamingPath()                           */
+/************************************************************************/
+
+CPLString VSIADLSFSHandler::GetStreamingPath( const char* pszFilename ) const
+{
+    const CPLString osPrefix(GetFSPrefix());
+    if( !STARTS_WITH_CI(pszFilename, osPrefix) )
+        return CPLString();
+
+    // Transform /vsiadls/foo into /vsiaz_streaming/foo
+    const size_t nPrefixLen = osPrefix.size();
+    return CPLString("/vsiaz_streaming/")  + (pszFilename + nPrefixLen);
+}
+
+/************************************************************************/
+/*                           VSIADLSHandle()                           */
+/************************************************************************/
+
+VSIADLSHandle::VSIADLSHandle( VSIADLSFSHandler* poFSIn,
+                          const char* pszFilename,
+                          VSIAzureBlobHandleHelper* poHandleHelper ) :
+        VSICurlHandle(poFSIn, pszFilename, poHandleHelper->GetURLNoKVP()),
+        m_poHandleHelper(poHandleHelper)
+{
+}
+
+/************************************************************************/
+/*                          GetCurlHeaders()                            */
+/************************************************************************/
+
+struct curl_slist* VSIADLSHandle::GetCurlHeaders( const CPLString& osVerb,
+                                const struct curl_slist* psExistingHeaders )
+{
+    return m_poHandleHelper->GetCurlHeaders( osVerb, psExistingHeaders );
+}
+
+} /* end of namespace cpl */
+
+
+#endif // DOXYGEN_SKIP
+//! @endcond
+
+/************************************************************************/
+/*                      VSIInstallADLSFileHandler()                    */
+/************************************************************************/
+
+/**
+ * \brief Install /vsiadls/ Microsoft Azure Data Lake Storage Gen2 file system handler
+ * (requires libcurl)
+ *
+ * @see <a href="gdal_virtual_file_systems.html#gdal_virtual_file_systems_vsiadls">/vsiadls/ documentation</a>
+ *
+ * @since GDAL 3.3
+ */
+
+void VSIInstallADLSFileHandler( void )
+{
+    VSIFileManager::InstallHandler( "/vsiadls/", new cpl::VSIADLSFSHandler );
+}
+
+#endif /* HAVE_CURL */

--- a/gdal/port/cpl_vsil_curl_streaming.cpp
+++ b/gdal/port/cpl_vsil_curl_streaming.cpp
@@ -2151,14 +2151,12 @@ void VSICurlStreamingClearCache( void )
     // FIXME ? Currently we have different filesystem instances for
     // vsicurl/, /vsis3/, /vsigs/ . So each one has its own cache of regions,
     // file size, etc.
-    const char* const apszFS[] = { "/vsicurl_streaming/", "/vsis3_streaming/",
-                                   "/vsigs_streaming/", "/vsiaz_streaming/",
-                                   "/vsioss_streaming/", "/vsiswift_streaming/" };
-    for( size_t i = 0; i < CPL_ARRAYSIZE(apszFS); ++i )
+    CSLConstList papszPrefix = VSIFileManager::GetPrefixes();
+    for( size_t i = 0; papszPrefix && papszPrefix[i]; ++i )
     {
-        VSICurlStreamingFSHandler *poFSHandler =
+        auto poFSHandler =
             dynamic_cast<VSICurlStreamingFSHandler*>(
-                VSIFileManager::GetHandler( apszFS[i] ));
+                VSIFileManager::GetHandler( papszPrefix[i] ));
 
         if( poFSHandler )
             poFSHandler->ClearCache();

--- a/gdal/port/cpl_vsil_gs.cpp
+++ b/gdal/port/cpl_vsil_gs.cpp
@@ -71,7 +71,7 @@ class VSIGSFSHandler final : public IVSIS3LikeFSHandler
     VSICurlHandle* CreateFileHandle( const char* pszFilename ) override;
     const char* GetDebugKey() const override { return "GS"; }
 
-    CPLString GetFSPrefix() override { return "/vsigs/"; }
+    CPLString GetFSPrefix() const override { return "/vsigs/"; }
     CPLString GetURLFromFilename( const CPLString& osFilename ) override;
 
     IVSIS3LikeHandleHelper* CreateHandleHelper(

--- a/gdal/port/cpl_vsil_oss.cpp
+++ b/gdal/port/cpl_vsil_oss.cpp
@@ -78,7 +78,7 @@ protected:
         IVSIS3LikeHandleHelper* CreateHandleHelper(
             const char* pszURI, bool bAllowNoObject) override;
 
-        CPLString GetFSPrefix() override { return "/vsioss/"; }
+        CPLString GetFSPrefix() const override { return "/vsioss/"; }
 
         void ClearCache() override;
 

--- a/gdal/port/cpl_vsil_swift.cpp
+++ b/gdal/port/cpl_vsil_swift.cpp
@@ -227,7 +227,7 @@ protected:
         IVSIS3LikeHandleHelper* CreateHandleHelper(
             const char* pszURI, bool bAllowNoObject) override;
 
-        CPLString GetFSPrefix() override { return "/vsiswift/"; }
+        CPLString GetFSPrefix() const override { return "/vsiswift/"; }
 
         char** GetFileList( const char *pszFilename,
                             int nMaxFiles,

--- a/gdal/port/cpl_vsil_webhdfs.cpp
+++ b/gdal/port/cpl_vsil_webhdfs.cpp
@@ -93,7 +93,7 @@ public:
         int Rmdir( const char *pszFilename ) override;
         int Mkdir( const char *pszDirname, long nMode ) override;
 
-        CPLString GetFSPrefix() override { return "/vsiwebhdfs/"; }
+        CPLString GetFSPrefix() const override { return "/vsiwebhdfs/"; }
 
         const char* GetOptions() override;
 };

--- a/gdal/port/makefile.vc
+++ b/gdal/port/makefile.vc
@@ -42,6 +42,7 @@ OBJ	=	cpl_conv.obj \
 		cpl_vsil_s3.obj \
 		cpl_vsil_gs.obj \
 		cpl_vsil_az.obj \
+		cpl_vsil_adls.obj \
 		cpl_vsil_oss.obj \
 		cpl_vsil_plugin.obj \
 		cpl_vsil_swift.obj \

--- a/gdal/swig/python/samples/gdal_ls.py
+++ b/gdal/swig/python/samples/gdal_ls.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import os
+import stat
 import sys
 
 from osgeo import gdal
@@ -82,7 +83,9 @@ def display_file(fout, dirname, prefix, filename, longformat, check_open=False):
     if longformat and statBuf is not None:
         import time
         bdt = time.gmtime(statBuf.mtime)
-        if statBuf.IsDirectory():
+        if stat.S_IMODE(statBuf.mode) != 0:
+            permissions = stat.filemode(statBuf.mode)
+        elif statBuf.IsDirectory():
             permissions = "dr-xr-xr-x"
         else:
             permissions = "-r--r--r--"


### PR DESCRIPTION
It has similar capabilities as /vsiaz/ and in particular uses the same
configuration options for authentication. Its advantages over /vsiaz/ are a real
management of directory and Unix-style ACL support. Some features require the Azure
storage to have hierarchical support turned on. Consult
https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction

The main enhancements over /vsiaz/ are:

  * True directory support (no need for the artificial :file:`.gdal_marker_for_dir`
    empty file that is used for /vsiaz/ to have empty directories)
  * One-call recursive directory deletion with VSIRmdirRecursive()
  * Atomic renaming with VSIRename()
  * VSIGetFileMetadata() support for the "STATUS" and "ACL" metadata domains
  * VSISetFileMetadata() support for the "PROPERTIES" and "ACL" metadata domains

