### PR TITLE
GeoPackage: Fix handling of invalid SRS ID

### DIFF
--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -1206,7 +1206,8 @@ def test_gpkg_15():
 
     # Repeated SetProjection()
     out_ds = gdal.Open('/vsimem/tmp.gpkg', gdal.GA_Update)
-    assert out_ds.GetProjectionRef().startswith('LOCAL_CS["Undefined cartesian SRS"]')
+    assert out_ds.GetSpatialRef().IsLocal()
+    assert out_ds.GetProjectionRef().find('Undefined cartesian SRS') >= 0
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(4326)
     ret = out_ds.SetProjection(srs.ExportToWkt())
@@ -1220,7 +1221,8 @@ def test_gpkg_15():
     out_ds = None
 
     out_ds = gdal.Open('/vsimem/tmp.gpkg')
-    assert out_ds.GetProjectionRef().startswith('LOCAL_CS["Undefined cartesian SRS"]')
+    assert out_ds.GetSpatialRef().IsLocal()
+    assert out_ds.GetProjectionRef().find('Undefined cartesian SRS') >= 0
     # Test setting on read-only dataset
     gdal.PushErrorHandler()
     ret = out_ds.SetProjection('')

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -1206,7 +1206,7 @@ def test_gpkg_15():
 
     # Repeated SetProjection()
     out_ds = gdal.Open('/vsimem/tmp.gpkg', gdal.GA_Update)
-    assert out_ds.GetProjectionRef() == ''
+    assert out_ds.GetProjectionRef().startswith('LOCAL_CS["Undefined cartesian SRS"]')
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(4326)
     ret = out_ds.SetProjection(srs.ExportToWkt())
@@ -1220,7 +1220,7 @@ def test_gpkg_15():
     out_ds = None
 
     out_ds = gdal.Open('/vsimem/tmp.gpkg')
-    assert out_ds.GetProjectionRef() == ''
+    assert out_ds.GetProjectionRef().startswith('LOCAL_CS["Undefined cartesian SRS"]')
     # Test setting on read-only dataset
     gdal.PushErrorHandler()
     ret = out_ds.SetProjection('')

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -349,6 +349,7 @@ OGRSpatialReference* GDALGeoPackageDataset::GetSpatialRef(int iSrsId,
     if( iSrsId == 0 || iSrsId == -1 )
     {
         OGRSpatialReference *poSpatialRef = new OGRSpatialReference();
+        poSpatialRef->SetAxisMappingStrategy( OAMS_TRADITIONAL_GIS_ORDER );
 
         if( iSrsId == 0)
         {

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -336,12 +336,6 @@ static OGRErr GDALGPKGImportFromEPSG(OGRSpatialReference *poSpatialRef,
 OGRSpatialReference* GDALGeoPackageDataset::GetSpatialRef(int iSrsId,
                                                           bool bFallbackToEPSG)
 {
-    /* Should we do something special with undefined SRS ? */
-    if( iSrsId == 0 || iSrsId == -1 )
-    {
-        return nullptr;
-    }
-
     std::map<int, OGRSpatialReference*>::const_iterator oIter =
                                                 m_oMapSrsIdToSrs.find(iSrsId);
     if( oIter != m_oMapSrsIdToSrs.end() )
@@ -350,6 +344,29 @@ OGRSpatialReference* GDALGeoPackageDataset::GetSpatialRef(int iSrsId,
             return nullptr;
         oIter->second->Reference();
         return oIter->second;
+    }
+
+    if( iSrsId == 0 || iSrsId == -1 )
+    {
+        OGRSpatialReference *poSpatialRef = new OGRSpatialReference();
+
+        if( iSrsId == 0)
+        {
+            poSpatialRef->SetGeogCS("Undefined geographic SRS",
+                                    "unknown",
+                                    "unknown",
+                                    SRS_WGS84_SEMIMAJOR,
+                                    SRS_WGS84_INVFLATTENING);
+        }
+        else if( iSrsId == -1)
+        {
+            poSpatialRef->SetLocalCS("Undefined cartesian SRS");
+            poSpatialRef->SetLinearUnits( SRS_UL_METER, 1.0 );
+        }
+
+        m_oMapSrsIdToSrs[iSrsId] = poSpatialRef;
+        poSpatialRef->Reference();
+        return poSpatialRef;
     }
 
     CPLString oSQL;


### PR DESCRIPTION
## What does this PR do?

Addresses the previous inline comment saying

```
    /* Should we do something special with undefined SRS ? */
```

and distinguishes between SRS ID of `0` and `-1` according to https://www.geopackage.org/spec121/#r11

> GeoPackage 1.2.1
>  1.1.1.1.1. File Format
>   Requirement 11
>    The record with an srs_id of -1 SHALL be used for undefined Cartesian coordinate reference systems.
>    The record with an srs_id of 0 SHALL be used for undefined geographic coordinate reference systems.
> 



## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: any
* Compiler: any
