### PR TITLE
doc: Recommended default mode for VSIMkdir is 0755

### DIFF
--- a/gdal/port/cpl_vsil.cpp
+++ b/gdal/port/cpl_vsil.cpp
@@ -436,10 +436,10 @@ void VSICloseDir(VSIDIR* dir)
 /**
  * \brief Create a directory.
  *
- * Create a new directory with the indicated mode.  The mode is ignored
- * on some platforms.  A reasonable default mode value would be 0666.
- * This method goes through the VSIFileHandler virtualization and may
- * work on unusual filesystems such as in memory.
+ * Create a new directory with the indicated mode. For POSIX-style systems,
+ * the mode is modified by the file creation mask (umask). However, some
+ * file systems and platforms may not use umask, or they may ignore the mode
+ * completely. So a reasonable cross-platform default mode value is 0755.
  *
  * Analog of the POSIX mkdir() function.
  *


### PR DESCRIPTION
## What does this PR do?

This PR fixes a documentation error. 

Following the previous instructions (mode 0666), the directory was created without execute permissions, rendering it unusable. E.g. after creating a `../Test/KMZ/123/files` directory:

~~~
$ LANG=C ls -la ../Test/KMZ/123/files
ls: cannot access '../Test/KMZ/123/files/.': Permission denied
ls: cannot access '../Test/KMZ/123/files/..': Permission denied
total 0
d????????? ? ? ? ?             ? .
d????????? ? ? ? ?             ? ..
~~~

Note that looking for `VSIMkdir` in GDAL reveals a number of suboptimal (`0755`) and broken (`0744`) code:
https://github.com/OSGeo/gdal/search?q=vsimkdir
However, I don't know if VSI and OS implementation would properly apply umask in all cases.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
