### PR TITLE
Doc: gdaladdo: mention bilinear resampling

### DIFF
--- a/gdal/doc/source/programs/gdaladdo.rst
+++ b/gdal/doc/source/programs/gdaladdo.rst
@@ -15,7 +15,7 @@ Synopsis
 
 .. code-block::
 
-    gdaladdo [-r {nearest,average,rms,gauss,cubic,cubicspline,lanczos,average_magphase,mode}]
+    gdaladdo [-r {nearest,average,rms,bilinear,gauss,cubic,cubicspline,lanczos,average_magphase,mode}]
             [-b band]* [-minsize val]
             [-ro] [-clean] [-oo NAME=VALUE]* [--help-general] filename [levels]
 


### PR DESCRIPTION
Adds "bilinear" among the resampling algorithm list for "-r" option.

Followup https://github.com/OSGeo/gdal/commit/9d3b8c9a8453beee22a08f67d5a60b84dc634558