### PR TITLE
New feature: UUID string subtype

### DIFF
--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -318,6 +318,38 @@ def test_ogr_mssqlspatial_create_feature_in_unregistered_table():
     feature.Destroy()
 
 ###############################################################################
+# Test UUID datatype support
+
+def test_ogr_mssqlspatial_uuid():
+    if gdaltest.mssqlspatial_ds is None:
+        pytest.skip()
+
+    lyr = gdaltest.mssqlspatial_ds.CreateLayer('test_ogr_mssql_uuid')
+
+    fd = ogr.FieldDefn('uid', ogr.OFTString)
+    fd.SetSubType(ogr.OFSTUUID)
+
+    assert lyr.CreateField(fd) == 0
+
+    lyr.StartTransaction()
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f['uid'] = '6F9619FF-8B86-D011-B42D-00C04FC964FF'
+    lyr.CreateFeature(f)
+    lyr.CommitTransaction()
+
+    test_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=0)
+    lyr = test_ds.GetLayer('test_ogr_mssql_uuid')
+    fd = lyr.GetLayerDefn().GetFieldDefn(0)
+    assert fd.GetType() == ogr.OFTString
+    assert fd.GetSubType() == ogr.OFSTUUID
+    f = lyr.GetNextFeature()
+
+    assert f.GetField(0) == '6F9619FF-8B86-D011-B42D-00C04FC964FF'
+
+    test_ds.Destroy()
+
+
+###############################################################################
 #
 
 
@@ -331,6 +363,7 @@ def test_ogr_mssqlspatial_cleanup():
     gdaltest.mssqlspatial_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=1)
     gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE Unregistered')
     gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE tpoly')
+    gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE test_ogr_mssql_uuid')
 
     gdaltest.mssqlspatial_ds = None
 

--- a/gdal/ogr/ogr_core.h
+++ b/gdal/ogr/ogr_core.h
@@ -677,7 +677,11 @@ typedef enum
      * @since GDAL 2.4
      */
                                                         OFSTJSON = 4,
-                                                        OFSTMaxSubType = 4
+    /** UUID string representation. Only valid for OFTString.
+     * @since GDAL 3.3
+     */
+                                                        OFSTUUID = 5,
+                                                        OFSTMaxSubType = 5
 } OGRFieldSubType;
 
 /**

--- a/gdal/ogr/ogrfielddefn.cpp
+++ b/gdal/ogr/ogrfielddefn.cpp
@@ -849,6 +849,9 @@ const char * OGRFieldDefn::GetFieldSubTypeName( OGRFieldSubType eSubType )
       case OFSTJSON:
         return "JSON";
 
+      case OFSTUUID:
+        return "UUID";
+
       default:
         return "(unknown)";
     }
@@ -897,6 +900,8 @@ int OGR_AreTypeSubTypeCompatible( OGRFieldType eType, OGRFieldSubType eSubType )
     if( eSubType == OFSTFloat32 )
         return eType == OFTReal || eType == OFTRealList;
     if( eSubType == OFSTJSON )
+        return eType == OFTString;
+    if( eSubType == OFSTUUID )
         return eType == OFTString;
     return FALSE;
 }

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatiallayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatiallayer.cpp
@@ -241,6 +241,12 @@ CPLErr OGRMSSQLSpatialLayer::BuildFeatureDefn( const char *pszLayerName,
                 oField.SetType( OFTDateTime );
                 break;
 
+            case SQL_C_GUID:
+                oField.SetType( OFTString );
+                oField.SetSubType( OFSTUUID );
+                break;
+
+
             default:
                 /* leave it as OFTString */;
         }

--- a/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -924,7 +924,9 @@ OGRErr OGRMSSQLSpatialTableLayer::CreateField( OGRFieldDefn *poFieldIn,
     }
     else if( oField.GetType() == OFTString )
     {
-        if( oField.GetWidth() == 0 || oField.GetWidth() > 4000 || !bPreservePrecision )
+        if( oField.GetSubType() == OGRFieldSubType::OFSTUUID)
+            strcpy( szFieldType, "uniqueidentifier" );
+        else if( oField.GetWidth() == 0 || oField.GetWidth() > 4000 || !bPreservePrecision )
             strcpy( szFieldType, "nvarchar(MAX)" );
         else
             snprintf( szFieldType, sizeof(szFieldType), "nvarchar(%d)", oField.GetWidth() );
@@ -2405,6 +2407,7 @@ void OGRMSSQLSpatialTableLayer::AppendFieldValue(CPLODBCStatement *poStatement,
                                        OGRFeature* poFeature, int i, int *bind_num, void **bind_buffer)
 {
     int nOGRFieldType = poFeatureDefn->GetFieldDefn(i)->GetType();
+    int nOGRFieldSubType = poFeatureDefn->GetFieldDefn(i)->GetSubType();
 
     // We need special formatting for integer list values.
     if(  nOGRFieldType == OFTIntegerList )
@@ -2495,42 +2498,60 @@ void OGRMSSQLSpatialTableLayer::AppendFieldValue(CPLODBCStatement *poStatement,
     {
         if (nOGRFieldType == OFTString)
         {
-            // bind UTF8 as unicode parameter
-            wchar_t* buffer = CPLRecodeToWChar( pszStrValue, CPL_ENC_UTF8, CPL_ENC_UCS2);
-            size_t nLen = wcslen(buffer) + 1;
-            if (nLen > 4000)
+            if (nOGRFieldSubType == OFSTUUID)
             {
-                /* need to handle nvarchar(max) */
-#ifdef SQL_SS_LENGTH_UNLIMITED
-                nLen = SQL_SS_LENGTH_UNLIMITED;
-#else
-                /* for older drivers truncate the data to 4000 chars */
-                buffer[4000] = 0;
-                nLen = 4000;
-                CPLError( CE_Warning, CPLE_AppDefined,
-                          "String data truncation applied on field: %s. Use a more recent ODBC driver that supports handling large string values.", poFeatureDefn->GetFieldDefn(i)->GetNameRef() );
-#endif
-            }
-#if WCHAR_MAX > 0xFFFFu
-            // Shorten each character to a two-byte value, as expected by
-            // the ODBC driver
-            GUInt16 *panBuffer = reinterpret_cast<GUInt16 *>(buffer);
-            for( unsigned int nIndex = 1; nIndex < nLen; nIndex += 1 )
-                panBuffer[nIndex] = static_cast<GUInt16>(buffer[nIndex]);
-#endif
-            int nRetCode = SQLBindParameter(poStatement->GetStatement(), (SQLUSMALLINT)((*bind_num) + 1),
-                SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR, nLen, 0, (SQLPOINTER)buffer, 0, nullptr);
-            if ( nRetCode == SQL_SUCCESS || nRetCode == SQL_SUCCESS_WITH_INFO )
-            {
-                poStatement->Append( "?" );
-                bind_buffer[*bind_num] = buffer;
-                ++(*bind_num);
-            }
+                int nRetCode = SQLBindParameter(poStatement->GetStatement(), (SQLUSMALLINT)((*bind_num) + 1),
+                    SQL_PARAM_INPUT, SQL_C_CHAR, SQL_GUID, 16, 0, (SQLPOINTER)pszStrValue, 0, nullptr);
+                if ( nRetCode == SQL_SUCCESS || nRetCode == SQL_SUCCESS_WITH_INFO )
+                {
+                    poStatement->Append( "?" );
+                    bind_buffer[*bind_num] = CPLStrdup(pszStrValue);
+                    ++(*bind_num);
+                }
+                else
+                {
+                    OGRMSSQLAppendEscaped(poStatement, pszStrValue);
+                }
+            }   
             else
             {
-                OGRMSSQLAppendEscaped(poStatement, pszStrValue);
-                CPLFree(buffer);
-            }
+                // bind UTF8 as unicode parameter
+                wchar_t* buffer = CPLRecodeToWChar( pszStrValue, CPL_ENC_UTF8, CPL_ENC_UCS2);
+                size_t nLen = wcslen(buffer) + 1;
+                if (nLen > 4000)
+                {
+                    /* need to handle nvarchar(max) */
+    #ifdef SQL_SS_LENGTH_UNLIMITED
+                    nLen = SQL_SS_LENGTH_UNLIMITED;
+    #else
+                    /* for older drivers truncate the data to 4000 chars */
+                    buffer[4000] = 0;
+                    nLen = 4000;
+                    CPLError( CE_Warning, CPLE_AppDefined,
+                            "String data truncation applied on field: %s. Use a more recent ODBC driver that supports handling large string values.", poFeatureDefn->GetFieldDefn(i)->GetNameRef() );
+    #endif
+                }
+    #if WCHAR_MAX > 0xFFFFu
+                // Shorten each character to a two-byte value, as expected by
+                // the ODBC driver
+                GUInt16 *panBuffer = reinterpret_cast<GUInt16 *>(buffer);
+                for( unsigned int nIndex = 1; nIndex < nLen; nIndex += 1 )
+                    panBuffer[nIndex] = static_cast<GUInt16>(buffer[nIndex]);
+    #endif
+                int nRetCode = SQLBindParameter(poStatement->GetStatement(), (SQLUSMALLINT)((*bind_num) + 1),
+                    SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR, nLen, 0, (SQLPOINTER)buffer, 0, nullptr);
+                if ( nRetCode == SQL_SUCCESS || nRetCode == SQL_SUCCESS_WITH_INFO )
+                {
+                    poStatement->Append( "?" );
+                    bind_buffer[*bind_num] = buffer;
+                    ++(*bind_num);
+                }
+                else
+                {
+                    OGRMSSQLAppendEscaped(poStatement, pszStrValue);
+                    CPLFree(buffer);
+                }
+            } 
         }
         else
             OGRMSSQLAppendEscaped(poStatement, pszStrValue);

--- a/gdal/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/gdal/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -78,6 +78,7 @@
 #define TIMESTAMPTZOID          1184
 #define NUMERICOID              1700
 #define NUMERICARRAYOID         1231
+#define UUIDOID                 2950
 #define JSONBOID                3802
 
 CPLString OGRPGEscapeString(void *hPGConn,

--- a/gdal/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
@@ -2192,6 +2192,11 @@ int OGRPGLayer::ReadResultDefinition(PGresult *hInitialResultIn)
             oField.SetType( OFTString );
             oField.SetSubType( OFSTJSON );
         }
+        else if ( nTypeOID == UUIDOID)
+        {
+            oField.SetType( OFTString );
+            oField.SetSubType( OFSTUUID );
+        }
         else /* unknown type */
         {
             CPLDebug("PG", "Unhandled OID (%d) for column %s. Defaulting to String.",

--- a/gdal/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
@@ -1224,6 +1224,8 @@ CPLString OGRPGCommonLayerGetType( OGRFieldDefn& oField,
     {
         if (oField.GetSubType() == OFSTJSON )
             pszFieldType = CPLGetConfigOption("OGR_PG_JSON_TYPE", "JSON");
+        else if (oField.GetSubType() == OFSTUUID )
+            pszFieldType = CPLGetConfigOption("OGR_PG_UUID_TYPE", "UUID");
         else if (oField.GetWidth() > 0 && oField.GetWidth() < 10485760 && bPreservePrecision )
             pszFieldType = CPLSPrintf( "VARCHAR(%d)",  oField.GetWidth() );
         else
@@ -1454,6 +1456,11 @@ bool OGRPGCommonLayerSetType( OGRFieldDefn& oField,
     {
         oField.SetType( OFTString );
         oField.SetSubType( OFSTJSON );
+    }
+    else if( EQUAL(pszType,"uuid") )
+    {
+        oField.SetType( OFTString );
+        oField.SetSubType( OFSTUUID );
     }
     else
     {

--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -1983,7 +1983,7 @@ SQLSMALLINT CPLODBCStatement::GetTypeMapping( SQLSMALLINT nTypeCode )
         case SQL_INTERVAL_HOUR_TO_SECOND:
         case SQL_INTERVAL_MINUTE_TO_SECOND:
         case SQL_GUID:
-            return SQL_C_CHAR;
+            return SQL_C_GUID;
 
         case SQL_DATE:
         case SQL_TYPE_DATE:

--- a/gdal/swig/include/ogr.i
+++ b/gdal/swig/include/ogr.i
@@ -200,6 +200,10 @@ typedef enum
      * @since GDAL 2.4
      */
                                                         OFSTJSON = 4,
+    /** UUID string representation. Only valid for OFTString.
+     * @since GDAL 3.3
+     */
+                                                        OFSTUUID = 5,
 } OGRFieldSubType;
 
 
@@ -376,6 +380,7 @@ typedef void retGetPoints;
 %constant OFSTInt16 = 2;
 %constant OFSTFloat32 = 3;
 %constant OFSTJSON = 4;
+%constant OFSTUUID = 5;
 
 %constant OJUndefined = 0;
 %constant OJLeft = 1;
@@ -2169,6 +2174,7 @@ public:
             case OFSTInt16:
             case OFSTFloat32:
             case OFSTJSON:
+            case OFSTUUID:
                 return TRUE;
             default:
                 CPLError(CE_Failure, CPLE_IllegalArg, "Illegal field subtype value");

--- a/gdal/swig/python/extensions/ogr_wrap.cpp
+++ b/gdal/swig/python/extensions/ogr_wrap.cpp
@@ -4900,6 +4900,7 @@ SWIGINTERN int OGRFeatureDefnShadow_IsSame(OGRFeatureDefnShadow *self,OGRFeature
             case OFSTInt16:
             case OFSTFloat32:
             case OFSTJSON:
+            case OFSTUUID:
                 return TRUE;
             default:
                 CPLError(CE_Failure, CPLE_IllegalArg, "Illegal field subtype value");
@@ -35798,6 +35799,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "OFSTInt16",SWIG_From_int(static_cast< int >(2)));
   SWIG_Python_SetConstant(d, "OFSTFloat32",SWIG_From_int(static_cast< int >(3)));
   SWIG_Python_SetConstant(d, "OFSTJSON",SWIG_From_int(static_cast< int >(4)));
+  SWIG_Python_SetConstant(d, "OFSTUUID",SWIG_From_int(static_cast< int >(5)));
   SWIG_Python_SetConstant(d, "OJUndefined",SWIG_From_int(static_cast< int >(0)));
   SWIG_Python_SetConstant(d, "OJLeft",SWIG_From_int(static_cast< int >(1)));
   SWIG_Python_SetConstant(d, "OJRight",SWIG_From_int(static_cast< int >(2)));

--- a/gdal/swig/python/osgeo/ogr.py
+++ b/gdal/swig/python/osgeo/ogr.py
@@ -187,6 +187,7 @@ OFSTBoolean = _ogr.OFSTBoolean
 OFSTInt16 = _ogr.OFSTInt16
 OFSTFloat32 = _ogr.OFSTFloat32
 OFSTJSON = _ogr.OFSTJSON
+OFSTUUID = _ogr.OFSTUUID
 OJUndefined = _ogr.OJUndefined
 OJLeft = _ogr.OJLeft
 OJRight = _ogr.OJRight


### PR DESCRIPTION
## What does this PR do?

Implements support for UUID as a string subtype and native datatype support for PostgreSQL, MSSQL and FileGDB.

## What are related issues/pull requests?

* https://github.com/OSGeo/gdal/issues/3141 
* https://github.com/OSGeo/gdal/issues/3057

## Tasklist

 - [x] PostgreSQL implementation
 - [x] MSSQL implementation
 - [x] Updated bindings
 - [x] Add test case(s)
 - [ ] (Add documentation)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
