### PR TITLE
gdal2tiles: Allow automatic max zoom when min zoom is specified

### DIFF
--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -44,7 +44,7 @@ can publish a picture without proper georeferencing too.
     Inputs with non-Byte data type (i.e. ``Int16``, ``UInt16``,...) will be clamped to
     the ``Byte`` data type, causing wrong results. To avoid this it is necessary to
     rescale input to the ``Byte`` data type using `gdal_translate` utility.
-    
+
 .. note::
 
     Config options of the input drivers may have an effect on the output of gdal2tiles. An example driver config option is GDAL_PDF_DPI, which can be found at :ref:`configoptions`
@@ -78,7 +78,7 @@ can publish a picture without proper georeferencing too.
 
 .. option:: -z <ZOOM>, --zoom=<ZOOM>
 
-  Zoom levels to render (format:'2-5' or '10').
+  Zoom levels to render (format:'2-5', '10-' or '10').
 
 .. option:: -e, --resume
 

--- a/gdal/swig/python/scripts/tests/gdal2tiles/test_option_parser.py
+++ b/gdal/swig/python/scripts/tests/gdal2tiles/test_option_parser.py
@@ -142,3 +142,31 @@ class OptionParserPostProcessingTest(TestCase):
 
         with self.assertRaises(SystemExit):
             gdal2tiles.options_post_processing(self.DEFAULT_ATTRDICT_OPTIONS, "foo.tiff", "/bar/")
+
+    def test_zoom_option_not_specified(self):
+        self.DEFAULT_ATTRDICT_OPTIONS["zoom"] = None
+
+        options = gdal2tiles.options_post_processing(self.DEFAULT_ATTRDICT_OPTIONS, "foo.tiff", "baz")
+
+        self.assertEqual(options.zoom, [None, None])
+
+    def test_zoom_option_single_level(self):
+        self.DEFAULT_ATTRDICT_OPTIONS["zoom"] = "10"
+
+        options = gdal2tiles.options_post_processing(self.DEFAULT_ATTRDICT_OPTIONS, "foo.tiff", "baz")
+
+        self.assertEqual(options.zoom, [10, 10])
+
+    def test_zoom_option_two_levels(self):
+        self.DEFAULT_ATTRDICT_OPTIONS["zoom"] = '14-24'
+
+        options = gdal2tiles.options_post_processing(self.DEFAULT_ATTRDICT_OPTIONS, "foo.tiff", "baz")
+
+        self.assertEqual(options.zoom, [14, 24])
+
+    def test_zoom_option_two_levels_automatic_max(self):
+        self.DEFAULT_ATTRDICT_OPTIONS["zoom"] = '14-'
+
+        options = gdal2tiles.options_post_processing(self.DEFAULT_ATTRDICT_OPTIONS, "foo.tiff", "baz")
+
+        self.assertEqual(options.zoom, [14, None])


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Allow the max zoom for gdal2tiles to be automatically calculated, even when min zoom is specified using the '10-' syntax.
This is a minor improvement I thought could prove useful, let me know what your opinions are.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
