### PR TITLE
gdaldem TRI: add a -alg Riley option to use the Riley 1999 formula, for terrestrial use cases

### DIFF
--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -389,13 +389,13 @@ def test_gdaldem_lib_tpi():
     ds = None
 
 ###############################################################################
-# Test gdaldem tri
+# Test gdaldem tri with Wilson formula
 
 
-def test_gdaldem_lib_tri():
+def test_gdaldem_lib_tri_wilson():
 
     src_ds = gdal.Open('../gdrivers/data/n43.dt0')
-    ds = gdal.DEMProcessing('', src_ds, 'tri', format='MEM')
+    ds = gdal.DEMProcessing('', src_ds, 'tri', format='MEM', alg='Wilson')
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -410,7 +410,7 @@ def test_gdaldem_lib_tri():
 def test_gdaldem_lib_tri_riley():
 
     src_ds = gdal.Open('../gdrivers/data/n43.dt0')
-    ds = gdal.DEMProcessing('', src_ds, 'tri', format='MEM', alg='Riley')
+    ds = gdal.DEMProcessing('', src_ds, 'tri', format='MEM')
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -404,6 +404,21 @@ def test_gdaldem_lib_tri():
     ds = None
 
 ###############################################################################
+# Test gdaldem tri with Riley formula
+
+
+def test_gdaldem_lib_tri_riley():
+
+    src_ds = gdal.Open('../gdrivers/data/n43.dt0')
+    ds = gdal.DEMProcessing('', src_ds, 'tri', format='MEM', alg='Riley')
+    assert ds is not None
+
+    cs = ds.GetRasterBand(1).Checksum()
+    assert cs == 41233, 'Bad checksum'
+
+    ds = None
+
+###############################################################################
 # Test gdaldem roughness
 
 

--- a/gdal/apps/gdaldem_bin.cpp
+++ b/gdal/apps/gdaldem_bin.cpp
@@ -75,6 +75,7 @@ static void Usage(const char* pszErrorMsg = nullptr)
             "\n"
             " - To generate a Terrain Ruggedness Index (TRI) map from any GDAL-supported elevation raster\n"
             "     gdaldem TRI input_dem output_TRI_map\n"
+            "                 [-alg Wilson|Riley]\n"
             "                 [-compute_edges] [-b Band (default=1)] [-of format] [-co \"NAME=VALUE\"]* [-q]\n"
             "\n"
             " - To generate a Topographic Position Index (TPI) map from any GDAL-supported elevation raster\n"

--- a/gdal/apps/gdaldem_lib.cpp
+++ b/gdal/apps/gdaldem_lib.cpp
@@ -173,7 +173,7 @@ struct GDALDEMProcessingOptions
     bool bGradientAlgSpecified = false;
     GradientAlg eGradientAlg = GradientAlg::HORN;
     bool bTRIAlgSpecified = false;
-    TRIAlg eTRIAlg = TRIAlg::WILSON;
+    TRIAlg eTRIAlg = TRIAlg::RILEY;
     bool bCombined = false;
     bool bIgor = false;
     bool bMultiDirectional = false;

--- a/gdal/apps/gdaldem_lib.cpp
+++ b/gdal/apps/gdaldem_lib.cpp
@@ -57,8 +57,15 @@
  * Color table of named colors and lookup code derived from src/libes/gis/named_colr.c
  * of GRASS 4.1
  *
- * TRI - Terrain Ruggedness Index is as described in Wilson et al. (2007)
+ * TRI -
+ * For bathymetric use cases, implements
+ * Terrain Ruggedness Index is as described in Wilson et al. (2007)
  * this is based on the method of Valentine et al. (2004)
+ *
+ * For terrestrial use cases, implements
+ * Riley, S.J., De Gloria, S.D., Elliot, R. (1999): A Terrain Ruggedness
+ * that Quantifies Topographic Heterogeneity. Intermountain Journal of Science, Vol.5, No.1-4, pp.23-27
+ * 
  *
  * TPI - Topographic Position Index follows the description in
  * Wilson et al. (2007), following Weiss (2001).  The radius is fixed
@@ -128,33 +135,50 @@ typedef enum
     COLOR_SELECTION_EXACT_ENTRY
 } ColorSelectionMode;
 
+namespace {
+enum class GradientAlg
+{
+    HORN,
+    ZEVENBERGEN_THORNE,
+};
+
+enum class TRIAlg
+{
+    WILSON,
+    RILEY,
+};
+}
+
 struct GDALDEMProcessingOptions
 {
     /*! output format. Use the short format name. */
-    char *pszFormat;
+    char *pszFormat = nullptr;
 
     /*! the progress function to use */
-    GDALProgressFunc pfnProgress;
+    GDALProgressFunc pfnProgress = nullptr;
 
     /*! pointer to the progress data variable */
-    void *pProgressData;
+    void *pProgressData = nullptr;
 
-    double z;
-    double scale;
-    double az;
-    double alt;
-    int slopeFormat;
-    bool bAddAlpha;
-    bool bZeroForFlat;
-    bool bAngleAsAzimuth;
-    ColorSelectionMode eColorSelectionMode;
-    bool bComputeAtEdges;
-    bool bZevenbergenThorne;
-    bool bCombined;
-    bool bIgor;
-    bool bMultiDirectional;
-    char** papszCreateOptions;
-    int nBand;
+    double z = 1.0;
+    double scale = 1.0;
+    double az = 315.0;
+    double alt = 45.0;
+    int slopeFormat = 1; // 0 = 'percent' or 1 = 'degrees'
+    bool bAddAlpha = false;
+    bool bZeroForFlat = false;
+    bool bAngleAsAzimuth = true;
+    ColorSelectionMode eColorSelectionMode = COLOR_SELECTION_INTERPOLATE;
+    bool bComputeAtEdges = false;
+    bool bGradientAlgSpecified = false;
+    GradientAlg eGradientAlg = GradientAlg::HORN;
+    bool bTRIAlgSpecified = false;
+    TRIAlg eTRIAlg = TRIAlg::WILSON;
+    bool bCombined = false;
+    bool bIgor = false;
+    bool bMultiDirectional = false;
+    char** papszCreateOptions = nullptr;
+    int nBand = 1;
 };
 
 /************************************************************************/
@@ -725,19 +749,13 @@ CPLErr GDALGeneric3x3Processing(
 /*                            GradientAlg                               */
 /************************************************************************/
 
-typedef enum
-{
-    HORN,
-    ZEVENBERGEN_THORNE
-} GradientAlg;
-
 template<class T, GradientAlg alg> struct Gradient
 {
     static void inline calc(const T* afWin, double inv_ewres, double inv_nsres,
                             double&x, double&y);
 };
 
-template<class T> struct Gradient<T, HORN>
+template<class T> struct Gradient<T, GradientAlg::HORN>
 {
     static void calc(const T* afWin, double inv_ewres, double inv_nsres,
                      double&x, double&y)
@@ -750,7 +768,7 @@ template<class T> struct Gradient<T, HORN>
     }
 };
 
-template<class T> struct Gradient<T, ZEVENBERGEN_THORNE>
+template<class T> struct Gradient<T, GradientAlg::ZEVENBERGEN_THORNE>
 {
     static void calc(const T* afWin, double inv_ewres, double inv_nsres,
                      double&x, double&y)
@@ -885,7 +903,7 @@ float GDALHillshadeIgorAlg (const T* afWin, float /*fDstNoDataValue*/, void* pDa
     GDALHillshadeAlgData* psData = static_cast<GDALHillshadeAlgData*>(pData);
 
     double slopeDegrees;
-    if (alg == HORN)
+    if (alg == GradientAlg::HORN)
     {
         const double dx = ((afWin[0] + afWin[3] + afWin[3] + afWin[6]) -
             (afWin[2] + afWin[5] + afWin[5] + afWin[8])) * psData->inv_ewres;
@@ -906,7 +924,7 @@ float GDALHillshadeIgorAlg (const T* afWin, float /*fDstNoDataValue*/, void* pDa
     }
 
     double aspect;
-    if (alg == HORN)
+    if (alg == GradientAlg::HORN)
     {
         const double dx = ((afWin[2] + afWin[5] + afWin[5] + afWin[8]) -
             (afWin[0] + afWin[3] + afWin[3] + afWin[6]));
@@ -1148,7 +1166,7 @@ void* GDALCreateHillshadeData( double* adfGeoTransform,
                                double scale,
                                double alt,
                                double az,
-                               bool bZevenbergenThorne )
+                               GradientAlg eAlg )
 {
     GDALHillshadeAlgData* pData = static_cast<GDALHillshadeAlgData *>(
         CPLCalloc(1, sizeof(GDALHillshadeAlgData)));
@@ -1157,7 +1175,7 @@ void* GDALCreateHillshadeData( double* adfGeoTransform,
     pData->inv_ewres = 1.0 / adfGeoTransform[1];
     pData->sin_altRadians = sin(alt * kdfDegreesToRadians);
     pData->azRadians = az * kdfDegreesToRadians;
-    pData->z_scaled = z / ((bZevenbergenThorne ? 2 : 8) * scale);
+    pData->z_scaled = z / ((eAlg == GradientAlg::ZEVENBERGEN_THORNE ? 2 : 8) * scale);
     pData->cos_alt_mul_z =
         cos(alt * kdfDegreesToRadians) * pData->z_scaled;
     pData->cos_az_mul_cos_alt_mul_z =
@@ -1268,7 +1286,7 @@ void* GDALCreateHillshadeMultiDirectionalData( double* adfGeoTransform,
                                                double z,
                                                double scale,
                                                double alt,
-                                               bool bZevenbergenThorne )
+                                               GradientAlg eAlg )
 {
     GDALHillshadeMultiDirectionalAlgData* pData =
       static_cast<GDALHillshadeMultiDirectionalAlgData *>(
@@ -1276,7 +1294,7 @@ void* GDALCreateHillshadeMultiDirectionalData( double* adfGeoTransform,
 
     pData->inv_nsres = 1.0 / adfGeoTransform[5];
     pData->inv_ewres = 1.0 / adfGeoTransform[1];
-    const double z_scaled = z / ((bZevenbergenThorne ? 2 : 8) * scale);
+    const double z_scaled = z / ((eAlg == GradientAlg::ZEVENBERGEN_THORNE ? 2 : 8) * scale);
     const double cos_alt_mul_z =
         cos(alt * kdfDegreesToRadians) * z_scaled;
     pData->square_z = z_scaled * z_scaled;
@@ -2676,11 +2694,12 @@ template<class T> static T MyAbs(T x);
 template<> float MyAbs( float x ) { return fabsf(x); }
 template<> int MyAbs( int x ) { return x >= 0 ? x : -x; }
 
+// Implements Wilson et al. (2007), for bathymetric use cases
 template<class T>
 static
-float GDALTRIAlg( const T* afWin,
-                  float /*fDstNoDataValue*/,
-                  void* /*pData*/ )
+float GDALTRIAlgWilson( const T* afWin,
+                        float /*fDstNoDataValue*/,
+                        void* /*pData*/ )
 {
     // Terrain Ruggedness is average difference in height
     return (MyAbs(afWin[0]-afWin[4]) +
@@ -2691,6 +2710,27 @@ float GDALTRIAlg( const T* afWin,
             MyAbs(afWin[6]-afWin[4]) +
             MyAbs(afWin[7]-afWin[4]) +
             MyAbs(afWin[8]-afWin[4])) * 0.125f;
+}
+
+// Implements Riley, S.J., De Gloria, S.D., Elliot, R. (1999): A Terrain Ruggedness
+// that Quantifies Topographic Heterogeneity. Intermountain Journal of Science, Vol.5, No.1-4, pp.23-27
+// for terrestrial use cases
+template<class T>
+static
+float GDALTRIAlgRiley( const T* afWin,
+                        float /*fDstNoDataValue*/,
+                        void* /*pData*/ )
+{
+    const auto square = [](double x) { return x * x; };
+
+    return static_cast<float>(std::sqrt(square(afWin[0]-afWin[4]) +
+                                        square(afWin[1]-afWin[4]) +
+                                        square(afWin[2]-afWin[4]) +
+                                        square(afWin[3]-afWin[4]) +
+                                        square(afWin[5]-afWin[4]) +
+                                        square(afWin[6]-afWin[4]) +
+                                        square(afWin[7]-afWin[4]) +
+                                        square(afWin[8]-afWin[4])));
 }
 
 /************************************************************************/
@@ -3434,6 +3474,24 @@ GDALDatasetH GDALDEMProcessing( const char *pszDest,
         psOptions = psOptionsToFree;
     }
 
+    if( psOptions->bGradientAlgSpecified &&
+        !(eUtilityMode == HILL_SHADE || eUtilityMode == SLOPE || eUtilityMode == ASPECT) )
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "This value of -alg is only value for hillshade, slope or aspect processing");
+        GDALDEMProcessingOptionsFree(psOptionsToFree);
+        return nullptr;
+    }
+
+    if( psOptions->bTRIAlgSpecified &&
+        !(eUtilityMode == TRI) )
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "This value of -alg is only value for TRI processing");
+        GDALDEMProcessingOptionsFree(psOptionsToFree);
+        return nullptr;
+    }
+
     double adfGeoTransform[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     const int nXSize = GDALGetRasterXSize(hSrcDataset);
@@ -3509,16 +3567,16 @@ GDALDatasetH GDALDEMProcessing( const char *pszDest,
                                                         psOptions->z,
                                                         psOptions->scale,
                                                         psOptions->alt,
-                                                        psOptions->bZevenbergenThorne);
-        if( psOptions->bZevenbergenThorne )
+                                                        psOptions->eGradientAlg);
+        if( psOptions->eGradientAlg == GradientAlg::ZEVENBERGEN_THORNE )
         {
-            pfnAlgFloat = GDALHillshadeMultiDirectionalAlg<float, ZEVENBERGEN_THORNE>;
-            pfnAlgInt32 = GDALHillshadeMultiDirectionalAlg<GInt32, ZEVENBERGEN_THORNE>;
+            pfnAlgFloat = GDALHillshadeMultiDirectionalAlg<float, GradientAlg::ZEVENBERGEN_THORNE>;
+            pfnAlgInt32 = GDALHillshadeMultiDirectionalAlg<GInt32, GradientAlg::ZEVENBERGEN_THORNE>;
         }
         else
         {
-            pfnAlgFloat = GDALHillshadeMultiDirectionalAlg<float, HORN>;
-            pfnAlgInt32 = GDALHillshadeMultiDirectionalAlg<GInt32, HORN>;
+            pfnAlgFloat = GDALHillshadeMultiDirectionalAlg<float, GradientAlg::HORN>;
+            pfnAlgInt32 = GDALHillshadeMultiDirectionalAlg<GInt32, GradientAlg::HORN>;
         }
     }
     else if( eUtilityMode == HILL_SHADE )
@@ -3530,36 +3588,36 @@ GDALDatasetH GDALDEMProcessing( const char *pszDest,
                                         psOptions->scale,
                                         psOptions->alt,
                                         psOptions->az,
-                                        psOptions->bZevenbergenThorne);
-        if( psOptions->bZevenbergenThorne )
+                                        psOptions->eGradientAlg);
+        if( psOptions->eGradientAlg == GradientAlg::ZEVENBERGEN_THORNE )
         {
             if( psOptions->bCombined )
             {
-                pfnAlgFloat = GDALHillshadeCombinedAlg<float, ZEVENBERGEN_THORNE>;
-                pfnAlgInt32 = GDALHillshadeCombinedAlg<GInt32, ZEVENBERGEN_THORNE>;
+                pfnAlgFloat = GDALHillshadeCombinedAlg<float, GradientAlg::ZEVENBERGEN_THORNE>;
+                pfnAlgInt32 = GDALHillshadeCombinedAlg<GInt32, GradientAlg::ZEVENBERGEN_THORNE>;
             }
             else if( psOptions->bIgor )
             {
-                pfnAlgFloat = GDALHillshadeIgorAlg<float, ZEVENBERGEN_THORNE>;
-                pfnAlgInt32 = GDALHillshadeIgorAlg<GInt32, ZEVENBERGEN_THORNE>;
+                pfnAlgFloat = GDALHillshadeIgorAlg<float, GradientAlg::ZEVENBERGEN_THORNE>;
+                pfnAlgInt32 = GDALHillshadeIgorAlg<GInt32, GradientAlg::ZEVENBERGEN_THORNE>;
             }
             else
             {
-                pfnAlgFloat = GDALHillshadeAlg<float, ZEVENBERGEN_THORNE>;
-                pfnAlgInt32 = GDALHillshadeAlg<GInt32, ZEVENBERGEN_THORNE>;
+                pfnAlgFloat = GDALHillshadeAlg<float, GradientAlg::ZEVENBERGEN_THORNE>;
+                pfnAlgInt32 = GDALHillshadeAlg<GInt32, GradientAlg::ZEVENBERGEN_THORNE>;
             }
         }
         else
         {
             if( psOptions->bCombined )
             {
-                pfnAlgFloat = GDALHillshadeCombinedAlg<float, HORN>;
-                pfnAlgInt32 = GDALHillshadeCombinedAlg<GInt32, HORN>;
+                pfnAlgFloat = GDALHillshadeCombinedAlg<float, GradientAlg::HORN>;
+                pfnAlgInt32 = GDALHillshadeCombinedAlg<GInt32, GradientAlg::HORN>;
             }
             else if( psOptions->bIgor )
             {
-                pfnAlgFloat = GDALHillshadeIgorAlg<float, HORN>;
-                pfnAlgInt32 = GDALHillshadeIgorAlg<GInt32, HORN>;
+                pfnAlgFloat = GDALHillshadeIgorAlg<float, GradientAlg::HORN>;
+                pfnAlgInt32 = GDALHillshadeIgorAlg<GInt32, GradientAlg::HORN>;
             }
             else
             {
@@ -3574,8 +3632,8 @@ GDALDatasetH GDALDEMProcessing( const char *pszDest,
                 }
                 else
                 {
-                    pfnAlgFloat = GDALHillshadeAlg<float, HORN>;
-                    pfnAlgInt32 = GDALHillshadeAlg<GInt32, HORN>;
+                    pfnAlgFloat = GDALHillshadeAlg<float, GradientAlg::HORN>;
+                    pfnAlgInt32 = GDALHillshadeAlg<GInt32, GradientAlg::HORN>;
                 }
             }
         }
@@ -3586,7 +3644,7 @@ GDALDatasetH GDALDEMProcessing( const char *pszDest,
         bDstHasNoData = true;
 
         pData = GDALCreateSlopeData(adfGeoTransform, psOptions->scale, psOptions->slopeFormat);
-        if( psOptions->bZevenbergenThorne )
+        if( psOptions->eGradientAlg == GradientAlg::ZEVENBERGEN_THORNE )
         {
             pfnAlgFloat = GDALSlopeZevenbergenThorneAlg<float>;
             pfnAlgInt32 = GDALSlopeZevenbergenThorneAlg<GInt32>;
@@ -3607,7 +3665,7 @@ GDALDatasetH GDALDEMProcessing( const char *pszDest,
         }
 
         pData = GDALCreateAspectData(psOptions->bAngleAsAzimuth);
-        if( psOptions->bZevenbergenThorne )
+        if( psOptions->eGradientAlg == GradientAlg::ZEVENBERGEN_THORNE )
         {
             pfnAlgFloat = GDALAspectZevenbergenThorneAlg<float>;
             pfnAlgInt32 = GDALAspectZevenbergenThorneAlg<GInt32>;
@@ -3622,8 +3680,16 @@ GDALDatasetH GDALDEMProcessing( const char *pszDest,
     {
         dfDstNoDataValue = -9999;
         bDstHasNoData = true;
-        pfnAlgFloat = GDALTRIAlg<float>;
-        pfnAlgInt32 = GDALTRIAlg<GInt32>;
+        if( psOptions->eTRIAlg == TRIAlg::WILSON )
+        {
+            pfnAlgFloat = GDALTRIAlgWilson<float>;
+            pfnAlgInt32 = GDALTRIAlgWilson<GInt32>;
+        }
+        else
+        {
+            pfnAlgFloat = GDALTRIAlgRiley<float>;
+            pfnAlgInt32 = GDALTRIAlgRiley<GInt32>;
+        }
     }
     else if( eUtilityMode == TPI )
     {
@@ -3882,31 +3948,8 @@ GDALDEMProcessingOptions *GDALDEMProcessingOptionsNew(
     char** papszArgv,
     GDALDEMProcessingOptionsForBinary* psOptionsForBinary )
 {
-    GDALDEMProcessingOptions *psOptions =
-        static_cast<GDALDEMProcessingOptions *>(
-            CPLCalloc(1, sizeof(GDALDEMProcessingOptions)));
+    GDALDEMProcessingOptions *psOptions = new GDALDEMProcessingOptions;
     Algorithm eUtilityMode = INVALID;
-
-    psOptions->pszFormat = nullptr;
-    psOptions->pfnProgress = GDALDummyProgress;
-    psOptions->pProgressData = nullptr;
-    psOptions->z = 1.0;
-    psOptions->scale = 1.0;
-    psOptions->az = 315.0;
-    psOptions->alt = 45.0;
-    // 0 = 'percent' or 1 = 'degrees'
-    psOptions->slopeFormat = 1;
-    psOptions->bAddAlpha = false;
-    psOptions->bZeroForFlat = false;
-    psOptions->bAngleAsAzimuth = true;
-    psOptions->eColorSelectionMode = COLOR_SELECTION_INTERPOLATE;
-    psOptions->bComputeAtEdges = false;
-    psOptions->bZevenbergenThorne = false;
-    psOptions->bCombined = false;
-    psOptions->bIgor = false;
-    psOptions->bMultiDirectional = false;
-    psOptions->nBand = 1;
-    psOptions->papszCreateOptions = nullptr;
     bool bAzimuthSpecified = false;
     bool bAltSpecified = false;
 
@@ -3964,12 +4007,28 @@ GDALDEMProcessingOptions *GDALDEMProcessingOptionsNew(
             i++;
             if( EQUAL(papszArgv[i], "ZevenbergenThorne") )
             {
-                psOptions->bZevenbergenThorne = true;
+                psOptions->bGradientAlgSpecified = true;
+                psOptions->eGradientAlg = GradientAlg::ZEVENBERGEN_THORNE;
             }
-            else if( !EQUAL(papszArgv[i], "Horn") )
+            else if( EQUAL(papszArgv[i], "Horn") )
+            {
+                psOptions->bGradientAlgSpecified = true;
+                psOptions->eGradientAlg = GradientAlg::HORN;
+            }
+            else if( EQUAL(papszArgv[i], "Riley") )
+            {
+                psOptions->bTRIAlgSpecified = true;
+                psOptions->eTRIAlg = TRIAlg::RILEY;
+            }
+            else if( EQUAL(papszArgv[i], "Wilson") )
+            {
+                psOptions->bTRIAlgSpecified = true;
+                psOptions->eTRIAlg = TRIAlg::WILSON;
+            }
+            else
             {
                 CPLError(CE_Failure, CPLE_IllegalArg,
-                         "Numeric value expected for %s", papszArgv[i-1]);
+                         "Invalid value for -alg: %s", papszArgv[i-1]);
                 GDALDEMProcessingOptionsFree(psOptions);
                 return nullptr;
             }
@@ -4160,7 +4219,7 @@ void GDALDEMProcessingOptionsFree( GDALDEMProcessingOptions *psOptions )
         CPLFree(psOptions->pszFormat);
         CSLDestroy(psOptions->papszCreateOptions);
 
-        CPLFree(psOptions);
+        delete psOptions;
     }
 }
 

--- a/gdal/doc/source/programs/gdaldem.rst
+++ b/gdal/doc/source/programs/gdaldem.rst
@@ -24,7 +24,7 @@ Generate a shaded relief map from any GDAL-supported elevation raster:
     gdaldem hillshade input_dem output_hillshade
                 [-z ZFactor (default=1)] [-s scale* (default=1)]
                 [-az Azimuth (default=315)] [-alt Altitude (default=45)]
-                [-alg ZevenbergenThorne] [-combined | -multidirectional | -igor]
+                [-alg Horn|ZevenbergenThorne] [-combined | -multidirectional | -igor]
                 [-compute_edges] [-b Band (default=1)] [-of format] [-co "NAME=VALUE"]* [-q]
 
 Generate a slope map from any GDAL-supported elevation raster:
@@ -33,7 +33,7 @@ Generate a slope map from any GDAL-supported elevation raster:
 
     gdaldem slope input_dem output_slope_map
                 [-p use percent slope (default=degrees)] [-s scale* (default=1)]
-                [-alg ZevenbergenThorne]
+                [-alg Horn|ZevenbergenThorne]
                 [-compute_edges] [-b Band (default=1)] [-of format] [-co "NAME=VALUE"]* [-q]
 
 Generate an aspect map from any GDAL-supported elevation raster,
@@ -43,7 +43,7 @@ outputs a 32-bit float raster with pixel values from 0-360 indicating azimuth:
 
     gdaldem aspect input_dem output_aspect_map
                 [-trigonometric] [-zero_for_flat]
-                [-alg ZevenbergenThorne]
+                [-alg Horn|ZevenbergenThorne]
                 [-compute_edges] [-b Band (default=1)] [-of format] [-co "NAME=VALUE"]* [-q]
 
 Generate a color relief map from any GDAL-supported elevation raster:
@@ -60,6 +60,7 @@ Generate a Terrain Ruggedness Index (TRI) map from any GDAL-supported elevation 
 .. code-block::
 
     gdaldem TRI input_dem output_TRI_map
+                [-alg Wilson|Riley]
                 [-compute_edges] [-b Band (default=1)] [-of format] [-q]
 
 Generate a Topographic Position Index (TPI) map from any GDAL-supported elevation raster:
@@ -141,10 +142,6 @@ The following general options are available:
 
     Do the computation at raster edges and near nodata values
 
-.. option:: alg ZevenbergenThorne
-
-    Use Zevenbergen & Thorne formula, instead of Horn's formula, to compute slope & aspect. The literature suggests Zevenbergen & Thorne to be more suited to smooth landscapes, whereas Horn's formula to perform better on rougher terrain.
-
 .. option:: -b <band>
 
     Select an input band to be processed. Bands are numbered from 1.
@@ -175,6 +172,10 @@ This command outputs an 8-bit raster with a nice shaded relief effect. It’s ve
 The value 0 is used as the output nodata value.
 
 The following specific options are available :
+
+.. option:: -alg Horn|ZevenbergenThorne
+
+    The literature suggests Zevenbergen & Thorne to be more suited to smooth landscapes, whereas Horn's formula to perform better on rougher terrain.
 
 .. option:: -z <factor>
 
@@ -221,6 +222,10 @@ The value `-9999` is used as the output nodata value.
 
 The following specific options are available :
 
+.. option:: -alg Horn|ZevenbergenThorne
+
+    The literature suggests Zevenbergen & Thorne to be more suited to smooth landscapes, whereas Horn's formula to perform better on rougher terrain.
+
 .. option:: -p
 
     If specified, the slope will be expressed as percent slope. Otherwise, it is expressed as degrees
@@ -235,6 +240,10 @@ aspect
 This command outputs a 32-bit float raster with values between 0° and 360° representing the azimuth that slopes are facing. The definition of the azimuth is such that : 0° means that the slope is facing the North, 90° it's facing the East, 180° it's facing the South and 270° it's facing the West (provided that the top of your input raster is north oriented). The aspect value -9999 is used as the nodata value to indicate undefined aspect in flat areas with slope=0.
 
 The following specifics options are available :
+
+.. option:: -alg Horn|ZevenbergenThorne
+
+    The literature suggests Zevenbergen & Thorne to be more suited to smooth landscapes, whereas Horn's formula to perform better on rougher terrain.
 
 .. option:: -trigonometric
 
@@ -330,13 +339,24 @@ TRI
 ^^^
 
 This command outputs a single-band raster with values computed from the elevation.
-`TRI` stands for Terrain Ruggedness Index, which is defined as the mean difference
-between a central pixel and its surrounding cells (see Wilson et al 2007,
-Marine Geodesy 30:3-35).
+`TRI` stands for Terrain Ruggedness Index, which measures the difference
+between a central pixel and its surrounding cells.
 
 The value -9999 is used as the output nodata value.
 
-There are no specific options.
+The following option is available:
+
+.. option:: -alg Wilson|Riley
+
+    The default is Wilson (see Wilson et al 2007, Marine Geodesy 30:3-35), which
+    uses the  mean difference between a central pixel and its surrounding cells.
+    This is recommended for bathymetric use cases.
+
+    Starting with GDAL 3.3, the Riley algorithm is available (see Riley, S.J.,
+    De Gloria, S.D., Elliot, R. (1999): A Terrain Ruggedness that Quantifies Topographic Heterogeneity.
+    Intermountain Journal of Science, Vol.5, No.1-4, pp.23-27), which uses the
+    square root of the sum of the square of the difference between a central pixel
+    and its surrounding cells. This is recommended for terrestrial use cases.
 
 TPI
 ^^^

--- a/gdal/doc/source/programs/gdaldem.rst
+++ b/gdal/doc/source/programs/gdaldem.rst
@@ -348,15 +348,16 @@ The following option is available:
 
 .. option:: -alg Wilson|Riley
 
-    The default is Wilson (see Wilson et al 2007, Marine Geodesy 30:3-35), which
-    uses the  mean difference between a central pixel and its surrounding cells.
-    This is recommended for bathymetric use cases.
-
-    Starting with GDAL 3.3, the Riley algorithm is available (see Riley, S.J.,
+    Starting with GDAL 3.3, the Riley algorithm (see Riley, S.J.,
     De Gloria, S.D., Elliot, R. (1999): A Terrain Ruggedness that Quantifies Topographic Heterogeneity.
-    Intermountain Journal of Science, Vol.5, No.1-4, pp.23-27), which uses the
+    Intermountain Journal of Science, Vol.5, No.1-4, pp.23-27) is available and
+    the new default value. This algorithm uses the
     square root of the sum of the square of the difference between a central pixel
     and its surrounding cells. This is recommended for terrestrial use cases.
+
+    The Wilson (see Wilson et al 2007, Marine Geodesy 30:3-35) algorithm
+    uses the mean difference between a central pixel and its surrounding cells.
+    This is recommended for bathymetric use cases.
 
 TPI
 ^^^

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1890,7 +1890,7 @@ def VectorTranslate(destNameOrDestDS, srcDS, **kwargs):
         return wrapper_GDALVectorTranslateDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 def DEMProcessingOptions(options=None, colorFilename=None, format=None,
-              creationOptions=None, computeEdges=False, alg='Horn', band=1,
+              creationOptions=None, computeEdges=False, alg=None, band=1,
               zFactor=None, scale=None, azimuth=None, altitude=None,
               combined=False, multiDirectional=False, igor=False,
               slopeFormat=None, trigonometric=False, zeroForFlat=False,
@@ -1903,7 +1903,7 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
           format --- output format ("GTiff", etc...)
           creationOptions --- list of creation options
           computeEdges --- whether to compute values at raster edges.
-          alg --- 'ZevenbergenThorne' or 'Horn'
+          alg --- 'Horn' (default) or 'ZevenbergenThorne' for hillshade, slope or aspect. 'Wilson' (default) or 'Riley' for TRI
           band --- source band number to use
           zFactor --- (hillshade only) vertical exaggeration used to pre-multiply the elevations.
           scale --- ratio of vertical units to horizontal.
@@ -1933,8 +1933,8 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
                 new_options += ['-co', opt]
         if computeEdges:
             new_options += ['-compute_edges']
-        if alg == 'ZevenbergenThorne':
-            new_options += ['-alg', 'ZevenbergenThorne']
+        if alg:
+            new_options += ['-alg', alg]
         new_options += ['-b', str(band)]
         if zFactor is not None:
             new_options += ['-z', str(zFactor)]

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -855,7 +855,7 @@ def VectorTranslate(destNameOrDestDS, srcDS, **kwargs):
         return wrapper_GDALVectorTranslateDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 def DEMProcessingOptions(options=None, colorFilename=None, format=None,
-              creationOptions=None, computeEdges=False, alg='Horn', band=1,
+              creationOptions=None, computeEdges=False, alg=None, band=1,
               zFactor=None, scale=None, azimuth=None, altitude=None,
               combined=False, multiDirectional=False, igor=False,
               slopeFormat=None, trigonometric=False, zeroForFlat=False,
@@ -868,7 +868,7 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
           format --- output format ("GTiff", etc...)
           creationOptions --- list of creation options
           computeEdges --- whether to compute values at raster edges.
-          alg --- 'ZevenbergenThorne' or 'Horn'
+          alg --- 'Horn' (default) or 'ZevenbergenThorne' for hillshade, slope or aspect. 'Wilson' (default) or 'Riley' for TRI
           band --- source band number to use
           zFactor --- (hillshade only) vertical exaggeration used to pre-multiply the elevations.
           scale --- ratio of vertical units to horizontal.
@@ -898,8 +898,8 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
                 new_options += ['-co', opt]
         if computeEdges:
             new_options += ['-compute_edges']
-        if alg == 'ZevenbergenThorne':
-            new_options += ['-alg', 'ZevenbergenThorne']
+        if alg:
+            new_options += ['-alg', alg]
         new_options += ['-b', str(band)]
         if zFactor is not None:
             new_options += ['-z', str(zFactor)]


### PR DESCRIPTION
 (fixes #3320)