### PR TITLE
gdal_edit.py: Correctly handle '-scale' without number

### DIFF
--- a/gdal/swig/python/osgeo/utils/gdal_edit.py
+++ b/gdal/swig/python/osgeo/utils/gdal_edit.py
@@ -134,7 +134,7 @@ def gdal_edit(argv):
         elif argv[i] == '-a_nodata' and i < len(argv) - 1:
             nodata = float(argv[i + 1])
             i = i + 1
-        elif argv[i] == '-scale' and i < len(argv) :
+        elif argv[i] == '-scale' and i < len(argv) -1:
             scale.append(float(argv[i+1]))
             i = i + 1
             while i < len(argv) - 1 and ArgIsNumeric(argv[i+1]):


### PR DESCRIPTION
## What does this PR do?

Fixes `gdal_edit.py my_img.tif -scale` crashing with `IndexError: list index out of range` by making the parameter check the same as for the `-offset` parameter` 6 lines below (`gdal_edit.py my_img.tif -offset` prints `Unrecognized option : -offset`).