### PR TITLE
PCIDSK: Fixed remaining address and undefined sanitizer fuzzer errors.

### DIFF
--- a/gdal/frmts/pcidsk/sdk/blockdir/blocktilelayer.cpp
+++ b/gdal/frmts/pcidsk/sdk/blockdir/blocktilelayer.cpp
@@ -155,6 +155,10 @@ bool BlockTileLayer::IsCorrupted(void) const
     if (GetLayerType() == BLTDead)
         return false;
 
+    // The tile layer is corrupted when the image size is 0.
+    if (GetXSize() == 0 || GetYSize() == 0)
+        return true;
+
     uint64 nTileSize =
         static_cast<uint64>(GetTileXSize()) * GetTileYSize() * GetDataTypeSize();
 
@@ -655,6 +659,12 @@ void BlockTileLayer::SetTileLayerInfo(uint32 nXSize, uint32 nYSize,
     {
         return ThrowPCIDSKException("Invalid tile dimensions: %d x %d",
                                     nTileXSize, nTileYSize);
+    }
+
+    if (nXSize == 0 || nYSize == 0)
+    {
+        return ThrowPCIDSKException("Invalid tile layer dimensions: %d x %d",
+                                    nXSize, nYSize);
     }
 
     mpsTileLayer->nXSize = nXSize;

--- a/gdal/frmts/pcidsk/sdk/channel/cbandinterleavedchannel.cpp
+++ b/gdal/frmts/pcidsk/sdk/channel/cbandinterleavedchannel.cpp
@@ -125,12 +125,6 @@ int CBandInterleavedChannel::ReadBlock( int block_index, void *buffer,
                                     line_offset);
     }
 
-    if (pixel_offset > line_offset)
-    {
-        return ThrowPCIDSKException(0, "Invalid pixel_offset: " PCIDSK_FRMT_UINT64,
-                                    pixel_offset);
-    }
-
     if (start_byte > std::numeric_limits<uint64>::max() - line_offset * height)
     {
         return ThrowPCIDSKException(0, "Invalid start_byte: " PCIDSK_FRMT_UINT64,
@@ -163,6 +157,11 @@ int CBandInterleavedChannel::ReadBlock( int block_index, void *buffer,
 /*      Establish region to read.                                       */
 /* -------------------------------------------------------------------- */
     int    pixel_size = DataTypeSize( pixel_type );
+
+    if (pixel_offset == 0 || pixel_size == 0)
+    {
+        return ThrowPCIDSKException( 0, "Invalid data type." );
+    }
     if( xsize > 1 && pixel_offset > static_cast<uint64>(INT_MAX / (xsize - 1)) )
     {
         return ThrowPCIDSKException( 0, "Int overfow in ReadBlock() ");
@@ -268,6 +267,10 @@ int CBandInterleavedChannel::WriteBlock( int block_index, void *buffer )
 /*      Establish region to read.                                       */
 /* -------------------------------------------------------------------- */
     int    pixel_size = DataTypeSize( pixel_type );
+
+    if (pixel_offset == 0 || pixel_size == 0)
+        return ThrowPCIDSKException( 0, "Invalid data type." );
+
     uint64 offset = start_byte + line_offset * block_index;
     int    window_size = (int) (pixel_offset*(width-1) + pixel_size);
 

--- a/gdal/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
+++ b/gdal/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
@@ -234,6 +234,9 @@ int CTiledChannel::ReadBlock( int iBlock, void *buffer,
 
     uint32 nTilePerRow = mpoTileLayer->GetTilePerRow();
 
+    if (nTilePerRow == 0)
+        return ThrowPCIDSKException(0, "Invalid number of tiles per row.");
+
     uint32 nCol = iBlock % nTilePerRow;
     uint32 nRow = iBlock / nTilePerRow;
 
@@ -352,6 +355,9 @@ int CTiledChannel::WriteBlock( int iBlock, void *buffer )
     int nPixelCount = nTileXSize * nTileYSize;
 
     uint32 nTilePerRow = mpoTileLayer->GetTilePerRow();
+
+    if (nTilePerRow == 0)
+        return ThrowPCIDSKException(0, "Invalid number of tiles per row.");
 
     uint32 nCol = iBlock % nTilePerRow;
     uint32 nRow = iBlock / nTilePerRow;

--- a/gdal/frmts/pcidsk/sdk/core/cpcidskfile.cpp
+++ b/gdal/frmts/pcidsk/sdk/core/cpcidskfile.cpp
@@ -798,6 +798,13 @@ void CPCIDSKFile::InitializeFromHeader()
 
         pixel_type = GetDataTypeFromName(pixel_type_string);
 
+        // For file interleaved channels, we expect a valid channel type.
+        if (interleaving == "FILE" && pixel_type == CHN_UNKNOWN)
+        {
+            return ThrowPCIDSKException("Invalid or unsupported channel type: %s",
+                                        pixel_type_string);
+        }
+
         // if we didn't get channel type in header, work out from counts (old).
         // Check this only if we don't have complex channels:
 

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -1832,12 +1832,23 @@ size_t VSICurlHandle::Read( void * const pBufferIn, size_t const nSize,
                 return 0;
             }
         }
+
+        const vsi_l_offset nRegionOffset = iterOffset - nOffsetToDownload;
+        if (osRegion.size() < nRegionOffset)
+        {
+            if( iterOffset == curOffset )
+            {
+                CPLDebug(poFS->GetDebugKey(), "Request at offset " CPL_FRMT_GUIB
+                         ", after end of file", iterOffset);
+            }
+            break;
+        }
+
         const int nToCopy = static_cast<int>(
             std::min(static_cast<vsi_l_offset>(nBufferRequestSize),
-                     osRegion.size() -
-                     (iterOffset - nOffsetToDownload)));
+                     osRegion.size() - nRegionOffset));
         memcpy(pBuffer,
-               osRegion.data() + iterOffset - nOffsetToDownload,
+               osRegion.data() + nRegionOffset,
                nToCopy);
         pBuffer = static_cast<char *>(pBuffer) + nToCopy;
         iterOffset += nToCopy;


### PR DESCRIPTION
The pcidsk_fuzzer exposed a bug in VSICurlHandle::Read(). The values were: iterOffset=280, nOffsetToDownload=0, osRegion.size()=272. I didn't try to understand why the file offset seems to be past the end of file. But this change can do no harm and it removes a vunerability. I ran the gtiff_fuzzer for a day and there were no errors.

I ran the pcidsk_fuzzer for 2 days using -timeout=60 and the only errors left are slow-unit errors which I'm not sure how to fix.