### PR TITLE
Add read-only support for the CRAP format

### DIFF
--- a/gdal/frmts/gdalallregister.cpp
+++ b/gdal/frmts/gdalallregister.cpp
@@ -444,6 +444,7 @@ void CPL_STDCALL GDALAllRegister()
     GDALRegister_ROIPAC();
     GDALRegister_RRASTER();
     GDALRegister_BYN();
+    GDALRegister_CRAP();
 #endif
 
 #ifdef FRMT_arg

--- a/gdal/frmts/raw/GNUmakefile
+++ b/gdal/frmts/raw/GNUmakefile
@@ -8,7 +8,7 @@ OBJ	=	ehdrdataset.o pauxdataset.o doq1dataset.o \
 		lcpdataset.o eirdataset.o gtxdataset.o loslasdataset.o \
 		ntv2dataset.o ace2dataset.o snodasdataset.o ctable2dataset.o \
 		krodataset.o roipacdataset.o iscedataset.o rrasterdataset.o \
-		byndataset.o ntv1dataset.o
+		byndataset.o ntv1dataset.o crapdataset.o
 
 CXXFLAGS        :=      $(WARN_EFFCPLUSPLUS)  $(CXXFLAGS)
 

--- a/gdal/frmts/raw/crapdataset.cpp
+++ b/gdal/frmts/raw/crapdataset.cpp
@@ -1,0 +1,103 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  CRAP format converter
+ * Author:   crap-designer
+ *
+ ******************************************************************************
+ * Copyright (c) 2021, crap-designer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_priv.h"
+
+extern "C" void GDALRegister_CRAP();
+
+class CRAPDataset: public GDALDataset
+{
+public:
+    CRAPDataset() = default;
+
+    static GDALDataset* Open(GDALOpenInfo* poOpenInfo);
+};
+
+class CRAPRasterBand: public GDALRasterBand
+{
+public:
+    CRAPRasterBand();
+
+    CPLErr IReadBlock(int, int, void* ) override;
+};
+
+CRAPRasterBand::CRAPRasterBand()
+{
+    nRasterXSize = static_cast<int>(strlen("CRAP data"));
+    nRasterYSize = 1;
+    eDataType = GDT_Byte;
+    nBlockXSize = nRasterXSize;
+    nBlockYSize = 1;
+}
+
+CPLErr CRAPRasterBand::IReadBlock(int, int, void* pData )
+{
+    memcpy(pData, "CRAP data", strlen("CRAP data"));
+    return CE_None;
+}
+
+GDALDataset* CRAPDataset::Open(GDALOpenInfo* poOpenInfo)
+{
+    constexpr const char* magic = "This is a crappy format";
+    if( poOpenInfo->nHeaderBytes < static_cast<int>(strlen(magic)) ||
+        !STARTS_WITH(reinterpret_cast<const char*>(poOpenInfo->pabyHeader),
+                     magic) )
+    {
+        return nullptr;
+    }
+
+    auto poDS = new CRAPDataset();
+    auto poBand = new CRAPRasterBand();
+    poDS->nRasterXSize = poBand->GetXSize();
+    poDS->nRasterYSize = poBand->GetYSize();
+    poDS->SetBand(1, poBand);
+    return poDS;
+}
+
+/************************************************************************/
+/*                         GDALRegister_CRAP()                          */
+/************************************************************************/
+
+void GDALRegister_CRAP()
+
+{
+    if( GDALGetDriverByName( "CRAP" ) != nullptr )
+      return;
+
+    GDALDriver *poDriver = new GDALDriver();
+
+    poDriver->SetDescription( "CRAP" );
+    poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
+    poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
+                               "Some crappy format someone may perhaps invent someday" );
+    poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
+
+    poDriver->pfnOpen = CRAPDataset::Open;
+
+    GetGDALDriverManager()->RegisterDriver( poDriver );
+}

--- a/gdal/frmts/raw/makefile.vc
+++ b/gdal/frmts/raw/makefile.vc
@@ -8,7 +8,7 @@ OBJ	=	ehdrdataset.obj pauxdataset.obj doq1dataset.obj\
 		lcpdataset.obj eirdataset.obj gtxdataset.obj loslasdataset.obj \
 		ntv2dataset.obj ace2dataset.obj snodasdataset.obj \
 		ctable2dataset.obj krodataset.obj roipacdataset.obj iscedataset.obj \
-		rrasterdataset.obj byndataset.obj ntv1dataset.obj
+		rrasterdataset.obj byndataset.obj ntv1dataset.obj crapdataset.obj
 
 GDAL_ROOT	=	..\..
 

--- a/gdal/gcore/gdal_frmts.h
+++ b/gdal/gcore/gdal_frmts.h
@@ -208,6 +208,7 @@ void CPL_DLL GDALRegister_HEIF(void);
 void CPL_DLL GDALRegister_TGA(void);
 void CPL_DLL GDALRegister_OGCAPI(void);
 void CPL_DLL GDALRegister_STACTA(void);
+void CPL_DLL GDALRegister_CRAP(void);
 CPL_C_END
 
 #endif /* ndef GDAL_FRMTS_H_INCLUDED */


### PR DESCRIPTION
After many years of intensive work, Spatialys R&D is pleased to offer
to the GDAL community the support for its new innovative raster format.
We're hoping that the community will appreciate its simplistic and powerful
design. We commit to support this format for the next 100 years.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
