### PR TITLE
WMS: Use noDataValue on empty blocks

### DIFF
--- a/gdal/frmts/wms/gdalwmsrasterband.cpp
+++ b/gdal/frmts/wms/gdalwmsrasterband.cpp
@@ -910,7 +910,7 @@ CPLErr GDALWMSRasterBand::EmptyBlock(int x, int y, int to_buffer_band, void *buf
                 if (!hasNDV)
                     valNDV = 0;
                 GDALCopyWords(&valNDV, GDT_Float64, 0, p, eDataType,
-                    GDALGetDataTypeSizeBytes(eDataType), static_cast<size_t>(nBlockXSize) * nBlockYSize);
+                    GDALGetDataTypeSizeBytes(eDataType), nBlockXSize * nBlockYSize);
             }
             if (b != nullptr) {
                 b->DropLock();

--- a/gdal/frmts/wms/gdalwmsrasterband.cpp
+++ b/gdal/frmts/wms/gdalwmsrasterband.cpp
@@ -883,7 +883,6 @@ CPLErr GDALWMSRasterBand::ReadBlockFromCache(const char* pszKey, int x, int y,
 
 CPLErr GDALWMSRasterBand::EmptyBlock(int x, int y, int to_buffer_band, void *buffer) {
     CPLErr ret = CE_None;
-    size_t block_size = static_cast<size_t>(nBlockXSize) * nBlockYSize;
 
     for (int ib = 1; ib <= m_parent_dataset->nBands; ++ib) {
         if (ret == CE_None) {
@@ -910,7 +909,8 @@ CPLErr GDALWMSRasterBand::EmptyBlock(int x, int y, int to_buffer_band, void *buf
                 double valNDV = band->GetNoDataValue(&hasNDV);
                 if (!hasNDV)
                     valNDV = 0;
-                GDALCopyWords(&hasNDV, GDT_Float64, 0, p, eDataType, GDALGetDataTypeSizeBytes(eDataType), block_size);
+                GDALCopyWords(&valNDV, GDT_Float64, 0, p, eDataType,
+                    GDALGetDataTypeSizeBytes(eDataType), static_cast<size_t>(nBlockXSize) * nBlockYSize);
             }
             if (b != nullptr) {
                 b->DropLock();

--- a/gdal/frmts/wms/gdalwmsrasterband.cpp
+++ b/gdal/frmts/wms/gdalwmsrasterband.cpp
@@ -123,8 +123,8 @@ CPLErr GDALWMSRasterBand::ReadBlocks(int x, int y, void *buffer, int bx0, int by
                 // A missing tile is signaled by setting a range of "none"
                 if (EQUAL(request.Range, "none")) {
                     if (!advise_read) {
-                        if (ZeroBlock(ix, iy, nBand, p) != CE_None) {
-                            CPLError(CE_Failure, CPLE_AppDefined, "GDALWMS: ZeroBlock failed.");
+                        if (EmptyBlock(ix, iy, nBand, p) != CE_None) {
+                            CPLError(CE_Failure, CPLE_AppDefined, "GDALWMS: EmptyBlock failed.");
                             ret = CE_Failure;
                         }
                     }
@@ -153,8 +153,8 @@ CPLErr GDALWMSRasterBand::ReadBlocks(int x, int y, void *buffer, int bx0, int by
             if (need_this_block) {
                 if (offline) {
                     if (!advise_read) {
-                        if (ZeroBlock(ix, iy, nBand, p) != CE_None) {
-                            CPLError(CE_Failure, CPLE_AppDefined, "GDALWMS: ZeroBlock failed.");
+                        if (EmptyBlock(ix, iy, nBand, p) != CE_None) {
+                            CPLError(CE_Failure, CPLE_AppDefined, "GDALWMS: EmptyBlock failed.");
                             ret = CE_Failure;
                         }
                     }
@@ -214,9 +214,9 @@ CPLErr GDALWMSRasterBand::ReadBlocks(int x, int y, void *buffer, int bx0, int by
                         }
                     }
                     else if (wms_exception && m_parent_dataset->m_zeroblock_on_serverexceptions) {
-                        ret = ZeroBlock(request.x, request.y, nBand, p);
+                        ret = EmptyBlock(request.x, request.y, nBand, p);
                         if (ret != CE_None)
-                            CPLError(ret, CPLE_AppDefined, "GDALWMS: ZeroBlock failed.");
+                            CPLError(ret, CPLE_AppDefined, "GDALWMS: EmptyBlock failed.");
                     }
                     VSIUnlink(file_name);
                 }
@@ -238,9 +238,9 @@ CPLErr GDALWMSRasterBand::ReadBlocks(int x, int y, void *buffer, int bx0, int by
                         != m_parent_dataset->m_http_zeroblock_codes.end())
                     {
                         if (!advise_read) {
-                            ret = ZeroBlock(request.x, request.y, nBand, p);
+                            ret = EmptyBlock(request.x, request.y, nBand, p);
                             if (ret != CE_None)
-                                CPLError(ret, CPLE_AppDefined, "GDALWMS: ZeroBlock failed.");
+                                CPLError(ret, CPLE_AppDefined, "GDALWMS: EmptyBlock failed.");
                         }
                     } else {
                         ret = CE_Failure;
@@ -746,7 +746,7 @@ CPLErr GDALWMSRasterBand::ReadBlockFromDataset(GDALDataset *ds, int x,
 
                 if (p != nullptr)
                 {
-                    int pixel_space = GDALGetDataTypeSize(eDataType) / 8;
+                    int pixel_space = GDALGetDataTypeSizeBytes(eDataType);
                     int line_space = pixel_space * nBlockXSize;
                     if (color_table == nullptr)
                     {
@@ -881,18 +881,24 @@ CPLErr GDALWMSRasterBand::ReadBlockFromCache(const char* pszKey, int x, int y,
     return ReadBlockFromDataset(ds, x, y, to_buffer_band, buffer, advise_read);
 }
 
-CPLErr GDALWMSRasterBand::ZeroBlock(int x, int y, int to_buffer_band, void *buffer) {
+template <typename T> static void valset(T* dst, T val, size_t count) {
+    for (; count; count--)
+        *dst++ = val;
+}
+
+CPLErr GDALWMSRasterBand::EmptyBlock(int x, int y, int to_buffer_band, void *buffer) {
     CPLErr ret = CE_None;
+    size_t block_size = static_cast<size_t>(nBlockXSize) * nBlockYSize;
 
     for (int ib = 1; ib <= m_parent_dataset->nBands; ++ib) {
         if (ret == CE_None) {
             void *p = nullptr;
             GDALRasterBlock *b = nullptr;
+            GDALWMSRasterBand* band = static_cast<GDALWMSRasterBand*>(m_parent_dataset->GetRasterBand(ib));
+            if (m_overview >= 0) band = static_cast<GDALWMSRasterBand*>(band->GetOverview(m_overview));
             if ((buffer != nullptr) && (ib == to_buffer_band)) {
                 p = buffer;
             } else {
-                GDALWMSRasterBand *band = static_cast<GDALWMSRasterBand *>(m_parent_dataset->GetRasterBand(ib));
-                if (m_overview >= 0) band = static_cast<GDALWMSRasterBand *>(band->GetOverview(m_overview));
                 if (!band->IsBlockInCache(x, y)) {
                     b = band->GetLockedBlockRef(x, y, true);
                     if (b != nullptr) {
@@ -903,11 +909,26 @@ CPLErr GDALWMSRasterBand::ZeroBlock(int x, int y, int to_buffer_band, void *buff
                         }
                     }
                 }
-            }
+            } 
             if (p != nullptr) {
-                unsigned char *paby = reinterpret_cast<unsigned char *>(p);
-                int block_size = nBlockXSize * nBlockYSize * (GDALGetDataTypeSize(eDataType) / 8);
-                for (int i = 0; i < block_size; ++i) paby[i] = 0;
+                int hasNDV;
+                double valNDV = band->GetNoDataValue(&hasNDV);
+                if (!hasNDV)
+                    valNDV = 0;
+#define NDVSET(T) valset(reinterpret_cast<T *>(p), static_cast<T>(valNDV), block_size)
+                    switch (eDataType) {
+                    case GDT_Byte: NDVSET(GByte); break;
+                    case GDT_UInt16: NDVSET(GUInt16); break;
+                    case GDT_Int16: NDVSET(GInt16); break;
+                    case GDT_UInt32: NDVSET(GUInt32); break;
+                    case GDT_Int32: NDVSET(GInt32); break;
+                    case GDT_Float32: NDVSET(float); break;
+                    case GDT_Float64: NDVSET(double); break;
+                    default:
+                        CPLError(CE_Failure, CPLE_NotSupported, "GDALWMS: Type not supported.");
+                        ret = CE_Failure;
+                    }
+#undef NDVSET
             }
             if (b != nullptr) {
                 b->DropLock();

--- a/gdal/frmts/wms/wmsdriver.h
+++ b/gdal/frmts/wms/wmsdriver.h
@@ -505,7 +505,7 @@ protected:
                               int to_buffer_band, void *buffer, int advise_read);
     CPLErr ReadBlockFromDataset(GDALDataset *ds, int x, int y, int to_buffer_band,
                                                    void *buffer, int advise_read);
-    CPLErr ZeroBlock(int x, int y, int to_buffer_band, void *buffer);
+    CPLErr EmptyBlock(int x, int y, int to_buffer_band, void *buffer);
     static CPLErr ReportWMSException(const char *file_name);
 
 protected:


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Missing tiles are filled with NoDataValue when NoDataValue is defined instead of always being zero.
To keep it backwards compatible with existing WMS driver use, the name of the ZeroBlock tag in the WMS definition file is not changed.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
