### PR TITLE
test_py_scripts - simplify get_py_script; add samples_path, get_data_dir

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -37,13 +37,14 @@ from osgeo import gdal
 from osgeo import osr
 
 import gdaltest
+from test_py_scripts import samples_path
 
 ###############################################################################
 
 
 def _check_cog(filename):
 
-    path = '../../gdal/swig/python/samples'
+    path = samples_path
     if path not in sys.path:
         sys.path.append(path)
     import validate_cloud_optimized_geotiff
@@ -1000,7 +1001,7 @@ def test_cog_overview_size():
 
 def test_cog_float32_color_table():
 
-    src_ds = gdal.GetDriverByName('MEM').Create('', 1024, 1024, 1, gdal.GDT_Float32) 
+    src_ds = gdal.GetDriverByName('MEM').Create('', 1024, 1024, 1, gdal.GDT_Float32)
     src_ds.GetRasterBand(1).Fill(1.0)
     ct = gdal.ColorTable()
     src_ds.GetRasterBand(1).SetColorTable(ct)

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -38,13 +38,14 @@ from osgeo import osr
 import pytest
 
 import gdaltest
+from test_py_scripts import samples_path
 
 ###############################################################################
 
 
 def _check_cog(filename, check_tiled=True, full_check=False):
 
-    path = '../../gdal/swig/python/samples'
+    path = samples_path
     if path not in sys.path:
         sys.path.append(path)
     import validate_cloud_optimized_geotiff

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -32,6 +32,7 @@
 import os
 import sys
 import pytest
+from test_py_scripts import samples_path
 
 # Make sure we run from the directory of the script
 if os.path.basename(sys.argv[0]) == os.path.basename(__file__):
@@ -47,7 +48,7 @@ import gdaltest
 
 def validate(filename, quiet=False):
 
-    path = '../../gdal/swig/python/samples'
+    path = samples_path
     if path not in sys.path:
         sys.path.append(path)
     try:
@@ -3191,7 +3192,7 @@ def test_gpkg_GeneralCmdLineProcessor():
            'scope=' not in ret_gdalinfo and \
            'scope=' not in ret_ogrinfo)
 
-    
+
 ###############################################################################
 
 

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -39,6 +39,7 @@ from osgeo import osr
 import pytest
 
 import gdaltest
+from test_py_scripts import samples_path
 
 def jp2lura_available():
 
@@ -111,7 +112,7 @@ def test_jp2lura_invalid_license_num():
 
 def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=None, inspire_tg=True):
 
-    path = '../../gdal/swig/python/samples'
+    path = samples_path
     if path not in sys.path:
         sys.path.append(path)
     try:
@@ -708,7 +709,7 @@ def test_jp2lura_22():
 
         assert maxdiff <= 0, 'Image too different from reference'
 
-    
+
 ###############################################################################
 # Test NBITS support
 
@@ -776,7 +777,7 @@ def test_jp2lura_24():
         ds = None
         gdal.Unlink('/vsimem/jp2lura_24.jp2')
 
-    
+
 ###############################################################################
 # Test multiband support
 
@@ -1114,7 +1115,7 @@ def test_jp2lura_37():
 
         gdal.Unlink('/vsimem/jp2lura_37.jp2')
 
-    
+
 ###############################################################################
 # Test non-EPSG SRS (so written with a GML dictionary)
 
@@ -1147,7 +1148,7 @@ def test_jp2lura_38():
     if do_validate:
         assert xmlvalidate.validate(crsdictionary, ogc_schemas_location='tmp/cache/SCHEMAS_OPENGIS_NET')
 
-    
+
 ###############################################################################
 # Test GMLJP2OVERRIDE configuration option and DGIWG GMLJP2
 
@@ -1695,7 +1696,7 @@ def test_jp2lura_49():
         gdal.OpenEx('data/jpeg2000/inconsitant_geojp2_gmljp2.jp2', open_options=['GEOREF_SOURCES=unhandled'])
         assert gdal.GetLastErrorMsg() != '', 'expected warning'
 
-    
+
 
 ###############################################################################
 # Test reading split IEEE-754 Float32

--- a/autotest/gdrivers/test_validate_jp2.py
+++ b/autotest/gdrivers/test_validate_jp2.py
@@ -35,6 +35,7 @@ from osgeo import gdal
 import pytest
 
 import gdaltest
+from test_py_scripts import samples_path
 
 ###############################################################################
 # Verify we have the JP2OpenJPEG driver.
@@ -48,7 +49,7 @@ def test_validate_jp2_1():
         pytest.skip()
 
 
-    path = '../../gdal/swig/python/samples'
+    path = samples_path
     if path not in sys.path:
         sys.path.append(path)
 
@@ -81,7 +82,7 @@ def validate(filename, inspire_tg=True, expected_gmljp2=True, oidoc=None):
         except (ImportError, AttributeError):
             ogc_schemas_location = 'disabled'
 
-    path = '../../gdal/swig/python/samples'
+    path = samples_path
     if path not in sys.path:
         sys.path.append(path)
 
@@ -153,7 +154,7 @@ def test_validate_jp2_2():
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
 
-    
+
 ###############################################################################
 # Another highly corrupted file
 
@@ -207,7 +208,7 @@ def test_validate_jp2_3():
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
 
-    
+
 ###############################################################################
 # Another highly corrupted file
 
@@ -248,7 +249,7 @@ def test_validate_jp2_4():
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
 
-    
+
 ###############################################################################
 # Slightly less corrupted file. Test mainly issues with JP2boxes and color table
 # Also a RGN marker
@@ -293,7 +294,7 @@ def test_validate_jp2_5():
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
 
-    
+
 ###############################################################################
 # Nominal case with single band data
 
@@ -320,7 +321,7 @@ def test_validate_jp2_6():
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
 
-    
+
 ###############################################################################
 # Nominal case with RGBA data
 
@@ -347,7 +348,7 @@ def test_validate_jp2_7():
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
 
-    
+
 ###############################################################################
 # Nominal case with color table data
 
@@ -374,7 +375,7 @@ def test_validate_jp2_8():
         pp.pprint(error_report.warning_array)
         pytest.fail('did not get expected errors')
 
-    
+
 ###############################################################################
 
 
@@ -383,6 +384,6 @@ def test_validate_jp2_cleanup():
     if gdaltest.has_validate_jp2_and_build_jp2:
         gdaltest.reregister_all_jpeg2000_drivers()
 
-    
+
 
 

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -41,6 +41,7 @@ from osgeo import gdal
 from osgeo import ogr
 from osgeo import osr
 import gdaltest
+from test_py_scripts import samples_path
 
 pytestmark = pytest.mark.require_driver('GPKG')
 
@@ -79,7 +80,7 @@ def startup_and_cleanup():
 
 
 def _validate_check(filename):
-    path = '../../gdal/swig/python/samples'
+    path = samples_path
     if path not in sys.path:
         sys.path.append(path)
     try:
@@ -1652,7 +1653,7 @@ def test_ogr_gpkg_write_srs_undefined_cartesian():
     gpkg_ds.ReleaseResultSet(sql_lyr)
 
     srs= osr.SpatialReference()
-    srs.SetFromUserInput('LOCAL_CS["Undefined cartesian SRS"]') 
+    srs.SetFromUserInput('LOCAL_CS["Undefined cartesian SRS"]')
     lyr = gpkg_ds.CreateLayer('srs_test_cartesian_layer', geom_type=ogr.wkbPoint, srs=srs)
     srs_wkt = lyr.GetSpatialRef().ExportToWkt()
     assert srs_wkt.find('Undefined cartesian SRS') >= 0

--- a/autotest/pymod/test_py_scripts.py
+++ b/autotest/pymod/test_py_scripts.py
@@ -37,25 +37,28 @@ import gdaltest
 # Return the path in which the Python script is found
 #
 
+# path relative to gdal root
+utils_subdir = 'swig/python/osgeo/utils'
+samples_subdir = 'swig/python/samples'
+samples_path = '../../gdal/' + samples_subdir
+
+
+def get_data_path(dir):
+    return f'../{dir}/data/'
+
 
 def get_py_script(script_name):
-
-    for subdir in ['scripts', 'samples']:
+    # how to get to {root_dir}/gdal from {root_dir}/autotest/X
+    base_gdal_path = os.path.join(os.getcwd(), '..', '..', 'gdal')
+    # now we need to look for the script in the utils or samples subdirs...
+    for subdir in [utils_subdir, samples_subdir]:
         try:
-            # Test subversion layout : {root_dir}/gdal, {root_dir}/autotest
-            test_path = os.path.join(os.getcwd(), '..', '..', 'gdal', 'swig', 'python', subdir)
+            test_path = os.path.join(base_gdal_path, subdir)
             test_file_path = os.path.join(test_path, script_name + '.py')
             os.stat(test_file_path)
             return test_path
         except OSError:
-            try:
-                # Test FrankW's directory layout : {root_dir}/gdal, {root_dir}/gdal/autotest
-                test_path = os.path.join(os.getcwd(), '..', '..', 'swig', 'python', subdir)
-                test_file_path = os.path.join(test_path, script_name + '.py')
-                os.stat(test_file_path)
-                return test_path
-            except OSError:
-                pass
+            pass
 
     return None
 

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -42,7 +42,7 @@ def _verify_raster_band_checksums(filename, expected_cs=[]):
     ds = gdal.Open(filename)
     if ds is None:
         pytest.fail('cannot open output file "%s"' % filename)
-    
+
     num_bands = len(expected_cs)
     for i in range(num_bands):
         if ds.GetRasterBand(i + 1).Checksum() != expected_cs[i]:
@@ -57,7 +57,7 @@ def test_gdal2tiles_py_simple():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gdrivers/data/small_world.tif', 'tmp/out_gdal2tiles_smallworld.tif')
+    shutil.copy(test_py_scripts.get_data_path('gdrivers')+'small_world.tif', 'tmp/out_gdal2tiles_smallworld.tif')
 
     os.chdir('tmp')
     test_py_scripts.run_py_script(
@@ -77,7 +77,7 @@ def test_gdal2tiles_py_simple():
         assert os.path.exists('tmp/out_gdal2tiles_smallworld/' + filename), \
             ('%s missing' % filename)
 
-    
+
 
 def test_gdal2tiles_py_zoom_option():
 
@@ -93,7 +93,7 @@ def test_gdal2tiles_py_zoom_option():
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q --force-kml --processes=2 -z 0-1 ../gdrivers/data/small_world.tif tmp/out_gdal2tiles_smallworld')
+        '-q --force-kml --processes=2 -z 0-1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
 
     _verify_raster_band_checksums(
         'tmp/out_gdal2tiles_smallworld/1/0/0.png',
@@ -132,7 +132,7 @@ def test_gdal2tiles_py_resampling_option():
             script_path,
             'gdal2tiles',
             '-q --resampling={0} {1} {2}'.format(
-                resample, '../gdrivers/data/small_world.tif', out_dir))
+                resample, test_py_scripts.get_data_path('gdrivers')+'small_world.tif', out_dir))
 
         # very basic check
         ds = gdal.Open('tmp/out_gdal2tiles_smallworld/0/0/0.png')
@@ -149,7 +149,7 @@ def test_gdal2tiles_py_xyz():
         pytest.skip()
 
     try:
-        shutil.copy('../gdrivers/data/small_world.tif', 'tmp/out_gdal2tiles_smallworld_xyz.tif')
+        shutil.copy(test_py_scripts.get_data_path('gdrivers')+'small_world.tif', 'tmp/out_gdal2tiles_smallworld_xyz.tif')
 
         os.chdir('tmp')
         ret = test_py_scripts.run_py_script(
@@ -187,8 +187,8 @@ def test_gdal2tiles_py_invalid_srs():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gdrivers/data/test_nosrs.vrt', 'tmp/out_gdal2tiles_test_nosrs.vrt')
-    shutil.copy('../gdrivers/data/byte.tif', 'tmp/byte.tif')
+    shutil.copy(test_py_scripts.get_data_path('gdrivers')+'test_nosrs.vrt', 'tmp/out_gdal2tiles_test_nosrs.vrt')
+    shutil.copy(test_py_scripts.get_data_path('gdrivers')+'byte.tif', 'tmp/byte.tif')
 
     os.chdir('tmp')
     # try running on image with missing SRS
@@ -240,7 +240,7 @@ def test_does_not_error_when_source_bounds_close_to_tiles_bound():
             'Case of tile not getting any data not handled properly '
             '(tiles at the border of the image)')
 
-    
+
 
 def test_does_not_error_when_nothing_to_put_in_the_low_zoom_tile():
     """
@@ -268,7 +268,7 @@ def test_does_not_error_when_nothing_to_put_in_the_low_zoom_tile():
             'Case of low level tile not getting any data not handled properly '
             '(tile at a zoom level too low)')
 
-    
+
 
 def test_python2_handles_utf8_by_default():
     if sys.version_info[0] >= 3:
@@ -383,7 +383,7 @@ def test_gdal2tiles_py_cleanup():
         except Exception:
             pass
 
-    
+
 
 def test_exclude_transparent_tiles():
     script_path = test_py_scripts.get_py_script('gdal2tiles')
@@ -431,7 +431,7 @@ def test_gdal2tiles_py_profile_raster():
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q -p raster -z 0-1 ../gdrivers/data/small_world.tif tmp/out_gdal2tiles_smallworld')
+        '-q -p raster -z 0-1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
 
     if sys.platform != 'win32':
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
@@ -462,7 +462,7 @@ def test_gdal2tiles_py_profile_raster_xyz():
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q -p raster --xyz -z 0-1 ../gdrivers/data/small_world.tif tmp/out_gdal2tiles_smallworld')
+        '-q -p raster --xyz -z 0-1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
 
     if sys.platform != 'win32':
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
@@ -493,7 +493,7 @@ def test_gdal2tiles_py_profile_geodetic_tmscompatible_xyz():
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q -p geodetic --tmscompatible --xyz -z 0-1 ../gdrivers/data/small_world.tif tmp/out_gdal2tiles_smallworld')
+        '-q -p geodetic --tmscompatible --xyz -z 0-1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
 
     if sys.platform != 'win32':
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
@@ -521,7 +521,7 @@ def test_gdal2tiles_py_mapml():
 
     shutil.rmtree('tmp/out_gdal2tiles_mapml', ignore_errors=True)
 
-    gdal.Translate('tmp/byte_APS.tif', '../gcore/data/byte.tif',
+    gdal.Translate('tmp/byte_APS.tif', test_py_scripts.get_data_path('gcore') + 'byte.tif',
                    options='-a_srs EPSG:5936 -a_ullr 0 40 40 0')
 
     test_py_scripts.run_py_script_as_external_script(

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -75,7 +75,7 @@ input_checksum = (12603, 58561, 36064, 10807)
 def get_input_file():
     infile = make_temp_filename(0)
     if not os.path.isfile(infile):
-        shutil.copy('../gcore/data/stefan_full_rgba.tif', infile)
+        shutil.copy(test_py_scripts.get_data_path('gcore') + 'stefan_full_rgba.tif', infile)
     return infile
 
 
@@ -233,7 +233,7 @@ def test_gdal_calc_py_6():
     test_id, test_count = 6, 2
     out = make_temp_filename_list(test_id, test_count)
 
-    gdal.Translate(out[0], '../gcore/data/byte.tif', options='-a_nodata 74')
+    gdal.Translate(out[0], test_py_scripts.get_data_path('gcore') + 'byte.tif', options='-a_nodata 74')
     gdal_calc.Calc('A', A=out[0], overwrite=True, quiet=True, outfile=out[1], NoDataValue=1)
 
     for i, checksum in zip(range(test_count), (4672, 4673)):

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -54,7 +54,7 @@ def test_gdal_edit_py_1():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
 
     if sys.platform == 'win32':
         # Passing utf-8 characters doesn't at least please Wine...
@@ -104,7 +104,7 @@ def test_gdal_edit_py_1b():
         pytest.skip()
 
     image = 'tmp/test_gdal_edit_py.tif'
-    shutil.copy('../gcore/data/byte.tif', image)
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', image)
 
     for points, expected in (
         ('2 50 3 50 2 49', (2, 0.05, 0, 50, 0, -0.05)),  # not rotated
@@ -125,7 +125,7 @@ def test_gdal_edit_py_2():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
 
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -unsetgt")
 
@@ -148,7 +148,7 @@ def test_gdal_edit_py_3():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
 
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -a_srs ''")
 
@@ -171,7 +171,7 @@ def test_gdal_edit_py_4():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
     ds = gdal.Open('tmp/test_gdal_edit_py.tif', gdal.GA_Update)
     band = ds.GetRasterBand(1)
     band.ComputeStatistics(False)
@@ -213,7 +213,7 @@ def test_gdal_edit_py_5():
     except:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
     ds = gdal.Open('tmp/test_gdal_edit_py.tif', gdal.GA_Update)
     band = ds.GetRasterBand(1)
     array = band.ReadAsArray()
@@ -261,7 +261,7 @@ def test_gdal_edit_py_6():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
 
     # original values should be min=74, max=255, mean=126.765 StdDev=22.928470838676
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -setstats None None None None")
@@ -300,7 +300,7 @@ def test_gdal_edit_py_7():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
 
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -scale 2 -offset 3")
     ds = gdal.Open('tmp/test_gdal_edit_py.tif')
@@ -308,7 +308,7 @@ def test_gdal_edit_py_7():
     assert ds.GetRasterBand(1).GetOffset() == 3
     ds = None
 
-    shutil.copy('../gcore/data/1bit_2bands.tif', 'tmp/test_gdal_edit_py.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + '1bit_2bands.tif', 'tmp/test_gdal_edit_py.tif')
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -scale 2 4 -offset 10 20")
 
     ds = gdal.Open('tmp/test_gdal_edit_py.tif')
@@ -329,7 +329,7 @@ def test_gdal_edit_py_8():
         pytest.skip()
 
     gdal.Translate('tmp/test_gdal_edit_py.tif',
-                   '../gcore/data/byte.tif',
+                   test_py_scripts.get_data_path('gcore') + 'byte.tif',
                    options='-b 1 -b 1 -b 1 -b 1 -co PHOTOMETRIC=RGB -co ALPHA=NO')
 
     test_py_scripts.run_py_script(script_path, 'gdal_edit', "tmp/test_gdal_edit_py.tif -colorinterp_4 alpha")
@@ -351,7 +351,7 @@ def test_gdal_edit_py_unsetrpc():
     if script_path is None:
         pytest.skip()
 
-    gdal.Translate('tmp/test_gdal_edit_py.tif', '../gcore/data/byte_rpc.tif')
+    gdal.Translate('tmp/test_gdal_edit_py.tif', test_py_scripts.get_data_path('gcore') + 'byte_rpc.tif')
 
     test_py_scripts.run_py_script(script_path, 'gdal_edit',
                                   "tmp/test_gdal_edit_py.tif -unsetrpc")

--- a/autotest/pyscripts/test_gdal_fillnodata.py
+++ b/autotest/pyscripts/test_gdal_fillnodata.py
@@ -46,7 +46,7 @@ def test_gdal_fillnodata_1():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'gdal_fillnodata', '../gcore/data/byte.tif tmp/test_gdal_fillnodata_1.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_fillnodata', test_py_scripts.get_data_path('gcore') + 'byte.tif tmp/test_gdal_fillnodata_1.tif')
 
     ds = gdal.Open('tmp/test_gdal_fillnodata_1.tif')
     assert ds.GetRasterBand(1).Checksum() == 4672
@@ -63,7 +63,7 @@ def test_gdal_fillnodata_2():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'gdal_fillnodata', '../gcore/data/nodata_byte.tif tmp/test_gdal_fillnodata_2.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_fillnodata', test_py_scripts.get_data_path('gcore') + 'nodata_byte.tif tmp/test_gdal_fillnodata_2.tif')
 
     ds = gdal.Open('tmp/test_gdal_fillnodata_2.tif')
     assert ds.GetRasterBand(1).GetNoDataValue() == 0, \
@@ -82,8 +82,5 @@ def test_gdal_fillnodata_cleanup():
             os.remove(filename)
         except OSError:
             pass
-
-    
-
 
 

--- a/autotest/pyscripts/test_gdal_ls_py.py
+++ b/autotest/pyscripts/test_gdal_ls_py.py
@@ -76,7 +76,7 @@ def run_gdal_ls(argv):
 
 def test_gdal_ls_py_1():
     # TODO: Why the '' as the first element of the list here and below?
-    ret_str = run_gdal_ls(['', '-l', '../ogr/data/poly.shp'])
+    ret_str = run_gdal_ls(['', '-l', test_py_scripts.get_data_path('ogr') + 'poly.shp'])
 
     assert ret_str.find('poly.shp') != -1
 
@@ -85,7 +85,7 @@ def test_gdal_ls_py_1():
 
 
 def test_gdal_ls_py_2():
-    ret_str = run_gdal_ls(['', '-l', '../ogr/data'])
+    ret_str = run_gdal_ls(['', '-l', test_py_scripts.get_data_path('ogr')])
 
     assert ret_str.find('poly.shp') != -1
 
@@ -94,7 +94,7 @@ def test_gdal_ls_py_2():
 
 
 def test_gdal_ls_py_3():
-    ret_str = run_gdal_ls(['', '-R', '../ogr/data'])
+    ret_str = run_gdal_ls(['', '-R', test_py_scripts.get_data_path('ogr')])
 
     assert ret_str.find('PROJ_UNITS') != -1
 
@@ -104,9 +104,9 @@ def test_gdal_ls_py_3():
 
 
 def test_gdal_ls_py_4():
-    ret_str = run_gdal_ls(['', '-l', '/vsizip/../ogr/data/shp/poly.zip'])
+    ret_str = run_gdal_ls(['', '-l', '/vsizip/'+test_py_scripts.get_data_path('ogr')+'shp/poly.zip'])
 
-    if ret_str.find('-r--r--r--  1 unknown unknown          415 2008-02-11 21:35 /vsizip/../ogr/data/shp/poly.zip/poly.PRJ') == -1:
+    if ret_str.find('-r--r--r--  1 unknown unknown          415 2008-02-11 21:35 /vsizip/'+test_py_scripts.get_data_path('ogr')+'shp/poly.zip/poly.PRJ') == -1:
         if gdaltest.skip_on_travis():
             # FIXME
             # Fails on Travis with dates at 1970-01-01 00:00

--- a/autotest/pyscripts/test_gdal_merge.py
+++ b/autotest/pyscripts/test_gdal_merge.py
@@ -47,7 +47,7 @@ def test_gdal_merge_1():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'gdal_merge', '-o tmp/test_gdal_merge_1.tif ../gcore/data/byte.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_merge', '-o tmp/test_gdal_merge_1.tif ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
 
     ds = gdal.Open('tmp/test_gdal_merge_1.tif')
     assert ds.GetRasterBand(1).Checksum() == 4672

--- a/autotest/pyscripts/test_gdal_pansharpen.py
+++ b/autotest/pyscripts/test_gdal_pansharpen.py
@@ -45,7 +45,7 @@ def test_gdal_pansharpen_1():
     if script_path is None:
         pytest.skip()
 
-    src_ds = gdal.Open('../gdrivers/data/small_world.tif')
+    src_ds = gdal.Open(test_py_scripts.get_data_path('gdrivers')+'small_world.tif')
     src_data = src_ds.GetRasterBand(1).ReadRaster()
     gt = src_ds.GetGeoTransform()
     wkt = src_ds.GetProjectionRef()
@@ -59,7 +59,7 @@ def test_gdal_pansharpen_1():
     pan_ds.GetRasterBand(1).WriteRaster(0, 0, 800, 400, src_data, 400, 200)
     pan_ds = None
 
-    test_py_scripts.run_py_script(script_path, 'gdal_pansharpen', ' tmp/small_world_pan.tif ../gdrivers/data/small_world.tif tmp/out.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_pansharpen', ' tmp/small_world_pan.tif '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out.tif')
 
     ds = gdal.Open('tmp/out.tif')
     cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
@@ -78,7 +78,7 @@ def test_gdal_pansharpen_2():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'gdal_pansharpen', ' -q -b 3 -b 1 -bitdepth 8 -threads ALL_CPUS -spat_adjust union -w 0.33333333333333333 -w 0.33333333333333333 -w 0.33333333333333333 -of VRT -r cubic tmp/small_world_pan.tif ../gdrivers/data/small_world.tif,band=1 ../gdrivers/data/small_world.tif,band=2 ../gdrivers/data/small_world.tif,band=3 tmp/out.vrt')
+    test_py_scripts.run_py_script(script_path, 'gdal_pansharpen', ' -q -b 3 -b 1 -bitdepth 8 -threads ALL_CPUS -spat_adjust union -w 0.33333333333333333 -w 0.33333333333333333 -w 0.33333333333333333 -of VRT -r cubic tmp/small_world_pan.tif '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif,band=1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif,band=2 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif,band=3 tmp/out.vrt')
 
     ds = gdal.Open('tmp/out.vrt')
     cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]

--- a/autotest/pyscripts/test_gdal_polygonize.py
+++ b/autotest/pyscripts/test_gdal_polygonize.py
@@ -66,7 +66,7 @@ def test_gdal_polygonize_1():
     shp_ds.Destroy()
 
     # run the algorithm.
-    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '../alg/data/polygonize_in.grd tmp poly DN')
+    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', test_py_scripts.get_data_path('alg')+'polygonize_in.grd tmp poly DN')
 
     # Confirm we get the set of expected features in the output layer.
 
@@ -114,7 +114,7 @@ def test_gdal_polygonize_2():
         pass
 
     # run the algorithm.
-    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-b 1 -f "ESRI Shapefile" -q -nomask ../alg/data/polygonize_in.grd tmp')
+    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-b 1 -f "ESRI Shapefile" -q -nomask '+test_py_scripts.get_data_path('alg')+'polygonize_in.grd tmp')
 
     # Confirm we get the set of expected features in the output layer.
     shp_ds = ogr.Open('tmp')
@@ -152,7 +152,7 @@ def test_gdal_polygonize_3():
         pass
 
     # run the algorithm.
-    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-b 1 -f "GPKG" -q -nomask ../alg/data/polygonize_in.grd tmp/out.gpkg')
+    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-b 1 -f "GPKG" -q -nomask '+test_py_scripts.get_data_path('alg')+'polygonize_in.grd tmp/out.gpkg')
 
     # Confirm we get the set of expected features in the output layer.
     gpkg_ds = ogr.Open('tmp/out.gpkg')
@@ -180,7 +180,7 @@ def test_gdal_polygonize_4():
         pytest.skip()
 
     # Test mask syntax
-    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-q -f GML -b mask ../gcore/data/byte.tif tmp/out.gml')
+    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-q -f GML -b mask ' + test_py_scripts.get_data_path('gcore') + 'byte.tif tmp/out.gml')
 
     content = open('tmp/out.gml', 'rt').read()
 
@@ -189,7 +189,7 @@ def test_gdal_polygonize_4():
     assert '<ogr:geometryProperty><gml:Polygon srsName="EPSG:26711"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>440720,3751320 440720,3750120 441920,3750120 441920,3751320 440720,3751320</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>' in content
 
     # Test mask,1 syntax
-    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-q -f GML -b mask,1 ../gcore/data/byte.tif tmp/out.gml')
+    test_py_scripts.run_py_script(script_path, 'gdal_polygonize', '-q -f GML -b mask,1 ' + test_py_scripts.get_data_path('gcore') + 'byte.tif tmp/out.gml')
 
     content = open('tmp/out.gml', 'rt').read()
 

--- a/autotest/pyscripts/test_gdal_proximity.py
+++ b/autotest/pyscripts/test_gdal_proximity.py
@@ -51,7 +51,7 @@ def test_gdal_proximity_1():
     dst_ds = drv.Create('tmp/proximity_1.tif', 25, 25, 1, gdal.GDT_Byte)
     dst_ds = None
 
-    test_py_scripts.run_py_script(script_path, 'gdal_proximity', '../alg/data/pat.tif tmp/proximity_1.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_proximity', test_py_scripts.get_data_path('alg')+'pat.tif tmp/proximity_1.tif')
 
     dst_ds = gdal.Open('tmp/proximity_1.tif')
     dst_band = dst_ds.GetRasterBand(1)
@@ -65,7 +65,7 @@ def test_gdal_proximity_1():
     if cs != cs_expected:
         print('Got: ', cs)
         pytest.fail('got wrong checksum')
-    
+
 ###############################################################################
 # Try several options
 
@@ -76,7 +76,7 @@ def test_gdal_proximity_2():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'gdal_proximity', '-q -values 65,64 -maxdist 12 -nodata -1 -fixed-buf-val 255 ../alg/data/pat.tif tmp/proximity_2.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_proximity', '-q -values 65,64 -maxdist 12 -nodata -1 -fixed-buf-val 255 '+test_py_scripts.get_data_path('alg')+'pat.tif tmp/proximity_2.tif')
 
     dst_ds = gdal.Open('tmp/proximity_2.tif')
     dst_band = dst_ds.GetRasterBand(1)
@@ -90,7 +90,7 @@ def test_gdal_proximity_2():
     if cs != cs_expected:
         print('Got: ', cs)
         pytest.fail('got wrong checksum')
-    
+
 ###############################################################################
 # Try input nodata option
 
@@ -101,7 +101,7 @@ def test_gdal_proximity_3():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'gdal_proximity', '-q -values 65,64 -maxdist 12 -nodata 0 -use_input_nodata yes ../alg/data/pat.tif tmp/proximity_3.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_proximity', '-q -values 65,64 -maxdist 12 -nodata 0 -use_input_nodata yes '+test_py_scripts.get_data_path('alg')+'pat.tif tmp/proximity_3.tif')
 
     dst_ds = gdal.Open('tmp/proximity_3.tif')
     dst_band = dst_ds.GetRasterBand(1)
@@ -115,7 +115,7 @@ def test_gdal_proximity_3():
     if cs != cs_expected:
         print('Got: ', cs)
         pytest.fail('got wrong checksum')
-    
+
 ###############################################################################
 # Cleanup
 
@@ -130,7 +130,4 @@ def test_gdal_proximity_cleanup():
             os.remove(filename)
         except OSError:
             pass
-
-    
-
 

--- a/autotest/pyscripts/test_gdal_retile.py
+++ b/autotest/pyscripts/test_gdal_retile.py
@@ -51,7 +51,7 @@ def test_gdal_retile_1():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -levels 2 -r bilinear -targetDir tmp/outretile ../gcore/data/byte.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -levels 2 -r bilinear -targetDir tmp/outretile ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
 
     ds = gdal.Open('tmp/outretile/byte_1_1.tif')
     assert ds.GetRasterBand(1).Checksum() == 4672
@@ -86,7 +86,7 @@ def test_gdal_retile_2():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -levels 2 -r bilinear -targetDir tmp/outretile2 ../gcore/data/rgba.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -levels 2 -r bilinear -targetDir tmp/outretile2 ' + test_py_scripts.get_data_path('gcore') + 'rgba.tif')
 
     ds = gdal.Open('tmp/outretile2/2/rgba_1_1.tif')
     assert ds.GetRasterBand(1).Checksum() == 35, 'wrong checksum for band 1'
@@ -182,7 +182,7 @@ def test_gdal_retile_4():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -ps 8 7 -overlap 3 -targetDir tmp/outretile4 ../gcore/data/byte.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -ps 8 7 -overlap 3 -targetDir tmp/outretile4 ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
 
     expected_results = [['tmp/outretile4/byte_1_1.tif', 8, 7],
                         ['tmp/outretile4/byte_1_2.tif', 8, 7],
@@ -211,7 +211,7 @@ def test_gdal_retile_4():
         assert ds.RasterYSize == height, filename
         ds = None
 
-    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -levels 1 -ps 8 8 -overlap 4 -targetDir tmp/outretile4 ../gcore/data/byte.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_retile', '-v -levels 1 -ps 8 8 -overlap 4 -targetDir tmp/outretile4 ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
 
     expected_results = [['tmp/outretile4/byte_1_1.tif', 8, 8],
                         ['tmp/outretile4/byte_1_2.tif', 8, 8],

--- a/autotest/pyscripts/test_gdal_sieve.py
+++ b/autotest/pyscripts/test_gdal_sieve.py
@@ -50,7 +50,7 @@ def test_gdal_sieve_1():
     dst_ds = drv.Create('tmp/sieve_1.tif', 5, 7, 1, gdal.GDT_Byte)
     dst_ds = None
 
-    test_py_scripts.run_py_script(script_path, 'gdal_sieve', '-nomask -st 2 -4 ../alg/data/sieve_src.grd tmp/sieve_1.tif')
+    test_py_scripts.run_py_script(script_path, 'gdal_sieve', '-nomask -st 2 -4 '+test_py_scripts.get_data_path('alg')+'sieve_src.grd tmp/sieve_1.tif')
 
     dst_ds = gdal.Open('tmp/sieve_1.tif')
     dst_band = dst_ds.GetRasterBand(1)
@@ -70,6 +70,6 @@ def test_gdal_sieve_1():
     if cs != cs_expected:
         print('Got: ', cs)
         pytest.fail('got wrong checksum')
-    
+
 
 

--- a/autotest/pyscripts/test_gdalinfo_py.py
+++ b/autotest/pyscripts/test_gdalinfo_py.py
@@ -44,7 +44,7 @@ def test_gdalinfo_py_1():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('Driver: GTiff/GeoTIFF') != -1
 
 ###############################################################################
@@ -56,7 +56,7 @@ def test_gdalinfo_py_2():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-checksum ../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-checksum ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('Checksum=4672') != -1
 
 ###############################################################################
@@ -68,10 +68,10 @@ def test_gdalinfo_py_3():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('Metadata') != -1
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-nomd ../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-nomd ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('Metadata') == -1
 
 ###############################################################################
@@ -83,10 +83,10 @@ def test_gdalinfo_py_4():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gdrivers/data/gif/bug407.gif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gdrivers')+'gif/bug407.gif')
     assert ret.find('0: 255,255,255,255') != -1
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-noct ../gdrivers/data/gif/bug407.gif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-noct '+test_py_scripts.get_data_path('gdrivers')+'gif/bug407.gif')
     assert ret.find('0: 255,255,255,255') == -1
 
 ###############################################################################
@@ -99,18 +99,18 @@ def test_gdalinfo_py_5():
         pytest.skip()
 
     try:
-        os.remove('../gcore/data/byte.tif.aux.xml')
+        os.remove(test_py_scripts.get_data_path('gcore') + 'byte.tif.aux.xml')
     except OSError:
         pass
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('STATISTICS_MINIMUM=74') == -1, 'got wrong minimum.'
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-stats ../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-stats ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('STATISTICS_MINIMUM=74') != -1, 'got wrong minimum (2).'
 
     # We will blow an exception if the file does not exist now!
-    os.remove('../gcore/data/byte.tif.aux.xml')
+    os.remove(test_py_scripts.get_data_path('gcore') + 'byte.tif.aux.xml')
 
 ###############################################################################
 # Test a dataset with overviews and RAT
@@ -121,7 +121,7 @@ def test_gdalinfo_py_6():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gdrivers/data/hfa/int.img')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gdrivers')+'hfa/int.img')
     assert ret.find('Overviews') != -1
 
 ###############################################################################
@@ -133,13 +133,13 @@ def test_gdalinfo_py_7():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gcore/data/gcps.vrt')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gcore') + 'gcps.vrt')
     assert ret.find('GCP Projection =') != -1
     assert ret.find('PROJCS["NAD27 / UTM zone 11N"') != -1
     assert ret.find('(100,100) -> (446720,3745320,0)') != -1
 
     # Same but with -nogcps
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-nogcp ../gcore/data/gcps.vrt')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-nogcp ' + test_py_scripts.get_data_path('gcore') + 'gcps.vrt')
     assert ret.find('GCP Projection =') == -1
     assert ret.find('PROJCS["NAD27 / UTM zone 11N"') == -1
     assert ret.find('(100,100) -> (446720,3745320,0)') == -1
@@ -154,20 +154,20 @@ def test_gdalinfo_py_8():
         pytest.skip()
 
     try:
-        os.remove('../gcore/data/byte.tif.aux.xml')
+        os.remove(test_py_scripts.get_data_path('gcore') + 'byte.tif.aux.xml')
     except OSError:
         pass
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 6 0 0 0 0 0 0 0 0 37 0 0 0 0 0 0 0 57 0 0 0 0 0 0 0 62 0 0 0 0 0 0 0 66 0 0 0 0 0 0 0 0 72 0 0 0 0 0 0 0 31 0 0 0 0 0 0 0 24 0 0 0 0 0 0 0 12 0 0 0 0 0 0 0 0 7 0 0 0 0 0 0 0 12 0 0 0 0 0 0 0 5 0 0 0 0 0 0 0 3 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1') == -1, \
         'did not expect histogram.'
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-hist ../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-hist ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 6 0 0 0 0 0 0 0 0 37 0 0 0 0 0 0 0 57 0 0 0 0 0 0 0 62 0 0 0 0 0 0 0 66 0 0 0 0 0 0 0 0 72 0 0 0 0 0 0 0 31 0 0 0 0 0 0 0 24 0 0 0 0 0 0 0 12 0 0 0 0 0 0 0 0 7 0 0 0 0 0 0 0 12 0 0 0 0 0 0 0 5 0 0 0 0 0 0 0 3 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1') != -1, \
         'did not get expected histogram.'
 
     # We will blow an exception if the file does not exist now!
-    os.remove('../gcore/data/byte.tif.aux.xml')
+    os.remove(test_py_scripts.get_data_path('gcore') + 'byte.tif.aux.xml')
 
 ###############################################################################
 # Test -mdd option
@@ -178,10 +178,10 @@ def test_gdalinfo_py_9():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gdrivers/data/nitf/fake_nsif.ntf')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gdrivers')+'nitf/fake_nsif.ntf')
     assert ret.find('BLOCKA=010000001000000000') == -1, 'Got unexpected extra MD.'
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-mdd TRE ../gdrivers/data/nitf/fake_nsif.ntf')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-mdd TRE '+test_py_scripts.get_data_path('gdrivers')+'nitf/fake_nsif.ntf')
     assert ret.find('BLOCKA=010000001000000000') != -1, 'did not get extra MD.'
 
 ###############################################################################
@@ -193,10 +193,10 @@ def test_gdalinfo_py_10():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('Computed Min/Max=74.000,255.000') == -1
 
-    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-mm ../gcore/data/byte.tif')
+    ret = test_py_scripts.run_py_script(script_path, 'gdalinfo', '-mm ' + test_py_scripts.get_data_path('gcore') + 'byte.tif')
     assert ret.find('Computed Min/Max=74.000,255.000') != -1
 
 

--- a/autotest/pyscripts/test_gdalmove.py
+++ b/autotest/pyscripts/test_gdalmove.py
@@ -46,7 +46,7 @@ def test_gdalmove_1():
     if script_path is None:
         pytest.skip()
 
-    shutil.copy('../gcore/data/byte.tif', 'tmp/test_gdalmove_1.tif')
+    shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdalmove_1.tif')
 
     test_py_scripts.run_py_script(script_path, 'gdalmove', '-s_srs "+proj=utm +zone=11 +ellps=clrk66 +towgs84=0,0,0 +no_defs" -t_srs EPSG:32611 tmp/test_gdalmove_1.tif -et 1')
 
@@ -71,8 +71,4 @@ def test_gdalmove_cleanup():
             os.remove(filename)
         except OSError:
             pass
-
-    
-
-
 

--- a/autotest/pyscripts/test_ogr2ogr_py.py
+++ b/autotest/pyscripts/test_ogr2ogr_py.py
@@ -59,7 +59,7 @@ def test_ogr2ogr_py_1():
     except:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
 
@@ -88,7 +88,7 @@ def test_ogr2ogr_py_2():
     except:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp -sql "select * from poly"')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -sql "select * from poly"')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
@@ -111,7 +111,7 @@ def test_ogr2ogr_py_3():
     except:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp -spat 479609 4764629 479764 4764817')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -spat 479609 4764629 479764 4764817')
 
     ds = ogr.Open('tmp/poly.shp')
     if ogrtest.have_geos():
@@ -137,7 +137,7 @@ def test_ogr2ogr_py_4():
     except (OSError, AttributeError):
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp -where "EAS_ID=171"')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -where "EAS_ID=171"')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 1
@@ -160,8 +160,8 @@ def test_ogr2ogr_py_5():
     except (OSError, AttributeError):
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp')
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-update -append tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-update -append tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 20
@@ -200,8 +200,8 @@ def test_ogr2ogr_py_6():
 
     gdaltest.runexternal(test_cli_utilities.get_ogrinfo_path() + ' PG:"' + gdaltest.pg_connection_string + '" -sql "DELLAYER:tpoly"')
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-f PostgreSQL PG:"' + gdaltest.pg_connection_string + '" ../ogr/data/poly.shp -nln tpoly')
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-update -overwrite -f PostgreSQL PG:"' + gdaltest.pg_connection_string + '" ../ogr/data/poly.shp -nln tpoly')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-f PostgreSQL PG:"' + gdaltest.pg_connection_string + '" '+test_py_scripts.get_data_path('ogr')+'poly.shp -nln tpoly')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-update -overwrite -f PostgreSQL PG:"' + gdaltest.pg_connection_string + '" '+test_py_scripts.get_data_path('ogr')+'poly.shp -nln tpoly')
 
     ds = ogr.Open('PG:' + gdaltest.pg_connection_string)
     assert ds is not None and ds.GetLayerByName('tpoly').GetFeatureCount() == 10
@@ -233,7 +233,7 @@ def test_ogr2ogr_py_7():
 
     gdaltest.runexternal(test_cli_utilities.get_ogrinfo_path() + ' PG:"' + gdaltest.pg_connection_string + '" -sql "DELLAYER:tpoly"')
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-f PostgreSQL PG:"' + gdaltest.pg_connection_string + '" ../ogr/data/poly.shp -nln tpoly -gt 1')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-f PostgreSQL PG:"' + gdaltest.pg_connection_string + '" '+test_py_scripts.get_data_path('ogr')+'poly.shp -nln tpoly -gt 1')
 
     ds = ogr.Open('PG:' + gdaltest.pg_connection_string)
     assert ds is not None and ds.GetLayerByName('tpoly').GetFeatureCount() == 10
@@ -256,7 +256,7 @@ def test_ogr2ogr_py_8():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-t_srs EPSG:4326 tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-t_srs EPSG:4326 tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert str(ds.GetLayer(0).GetSpatialRef()).find('1984') != -1
@@ -279,7 +279,7 @@ def test_ogr2ogr_py_9():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-a_srs EPSG:4326 tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-a_srs EPSG:4326 tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert str(ds.GetLayer(0).GetSpatialRef()).find('1984') != -1
@@ -303,7 +303,7 @@ def test_ogr2ogr_py_10():
         pass
 
     # Voluntary don't use the exact case of the source field names (#4502)
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-select eas_id,prfedea tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-select eas_id,prfedea tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     lyr = ds.GetLayer(0)
@@ -341,7 +341,7 @@ def test_ogr2ogr_py_11():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-lco SHPT=POLYGONZ tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-lco SHPT=POLYGONZ tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds.GetLayer(0).GetLayerDefn().GetGeomType() == ogr.wkbPolygon25D
@@ -365,7 +365,7 @@ def test_ogr2ogr_py_12():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-nlt POLYGON25D tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-nlt POLYGON25D tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds.GetLayer(0).GetLayerDefn().GetGeomType() == ogr.wkbPolygon25D
@@ -388,7 +388,7 @@ def test_ogr2ogr_py_13():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp poly')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp poly')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
@@ -412,7 +412,7 @@ def test_ogr2ogr_py_14():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-segmentize 100 tmp/poly.shp ../ogr/data/poly.shp poly')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-segmentize 100 tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp poly')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
@@ -438,14 +438,14 @@ def test_ogr2ogr_py_15():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
     ds.Destroy()
 
     # Overwrite
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-overwrite tmp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-overwrite tmp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
@@ -468,9 +468,9 @@ def test_ogr2ogr_py_16():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-fid 8 tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-fid 8 tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
-    src_ds = ogr.Open('../ogr/data/poly.shp')
+    src_ds = ogr.Open(test_py_scripts.get_data_path('ogr') + 'poly.shp')
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 1
     src_feat = src_ds.GetLayer(0).GetFeature(8)
@@ -496,7 +496,7 @@ def test_ogr2ogr_py_17():
     except OSError:
         pass
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-progress tmp/poly.shp ../ogr/data/poly.shp')
+    ret = test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-progress tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
     assert ret.find('0...10...20...30...40...50...60...70...80...90...100 - done.') != -1
 
     ds = ogr.Open('tmp/poly.shp')
@@ -576,7 +576,7 @@ def test_ogr2ogr_py_19():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp -clipsrc spat_extent -spat 479609 4764629 479764 4764817')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -clipsrc spat_extent -spat 479609 4764629 479764 4764817')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
@@ -635,7 +635,7 @@ def test_ogr2ogr_py_20():
                      '14',
                      '15']
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp ../utilities/data/Fields.csv')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp '+test_py_scripts.get_data_path('utilities')+'Fields.csv')
 
     ds = ogr.Open('tmp/Fields.dbf')
 
@@ -677,7 +677,7 @@ def test_ogr2ogr_py_21():
         pass
 
     test_py_scripts.run_py_script(script_path, 'ogr2ogr',
-                                  '-f GPSTrackMaker tmp/testogr2ogr21.gtm ../utilities/data/dataforogr2ogr21.csv ' +
+                                  '-f GPSTrackMaker tmp/testogr2ogr21.gtm '+test_py_scripts.get_data_path('utilities')+'dataforogr2ogr21.csv ' +
                                   '-sql "SELECT comment, name FROM dataforogr2ogr21" -nlt POINT')
     ds = ogr.Open('tmp/testogr2ogr21.gtm')
 
@@ -705,7 +705,7 @@ def test_ogr2ogr_py_22():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogr2ogr',
-                                  '-f "MapInfo File" tmp/testogr2ogr22.mif ../utilities/data/dataforogr2ogr21.csv ' +
+                                  '-f "MapInfo File" tmp/testogr2ogr22.mif '+test_py_scripts.get_data_path('utilities')+'dataforogr2ogr21.csv ' +
                                   '-sql "SELECT comment, name FROM dataforogr2ogr21" -nlt POINT')
     ds = ogr.Open('tmp/testogr2ogr22.mif')
 
@@ -735,7 +735,7 @@ def test_ogr2ogr_py_23():
         pytest.skip()
 
     gdaltest.runexternal(test_cli_utilities.get_ogr2ogr_path() +
-                         ' -f "MapInfo File" tmp/testogr2ogr23.mif ../utilities/data/dataforogr2ogr21.csv ' +
+                         ' -f "MapInfo File" tmp/testogr2ogr23.mif '+test_py_scripts.get_data_path('utilities')+'dataforogr2ogr21.csv ' +
                          '-sql "SELECT comment, name FROM dataforogr2ogr21" -select comment,name -nlt POINT')
     ds = ogr.Open('tmp/testogr2ogr23.mif')
 
@@ -771,7 +771,7 @@ def test_ogr2ogr_py_24():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp -clipsrc "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -clipsrc "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
@@ -806,7 +806,7 @@ def test_ogr2ogr_py_25():
     f.write('foo,"POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"\n')
     f.close()
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp -clipsrc tmp/clip.csv -clipsrcwhere foo=\'foo\'')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -clipsrc tmp/clip.csv -clipsrcwhere foo=\'foo\'')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
@@ -837,7 +837,7 @@ def test_ogr2ogr_py_26():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp ../ogr/data/poly.shp -clipdst "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', 'tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -clipdst "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
@@ -872,7 +872,7 @@ def test_ogr2ogr_py_27():
     f.write('foo,"POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"\n')
     f.close()
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-nlt MULTIPOLYGON tmp/poly.shp ../ogr/data/poly.shp -clipdst tmp/clip.csv -clipdstsql "SELECT * from clip"')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', '-nlt MULTIPOLYGON tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -clipdst tmp/clip.csv -clipdstsql "SELECT * from clip"')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
@@ -901,7 +901,7 @@ def test_ogr2ogr_py_31():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/poly.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
@@ -925,14 +925,14 @@ def test_ogr2ogr_py_32():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_32.shp ../ogr/data/poly.shp')
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -append tmp/test_ogr2ogr_32.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_32.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -append tmp/test_ogr2ogr_32.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/test_ogr2ogr_32.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 20, '-append failed'
     ds = None
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/test_ogr2ogr_32.shp ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/test_ogr2ogr_32.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/test_ogr2ogr_32.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10, \
@@ -1022,20 +1022,20 @@ def test_ogr2ogr_py_34():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_34_dir ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_34_dir '+test_py_scripts.get_data_path('ogr')+'poly.shp -nln test_ogr2ogr_34_dir')
 
     ds = ogr.Open('tmp/test_ogr2ogr_34_dir/test_ogr2ogr_34_dir.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10, \
         'initial shapefile creation failed'
     ds = None
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -append tmp/test_ogr2ogr_34_dir ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -append tmp/test_ogr2ogr_34_dir '+test_py_scripts.get_data_path('ogr')+'poly.shp -nln test_ogr2ogr_34_dir')
 
     ds = ogr.Open('tmp/test_ogr2ogr_34_dir/test_ogr2ogr_34_dir.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 20, '-append failed'
     ds = None
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/test_ogr2ogr_34_dir ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/test_ogr2ogr_34_dir '+test_py_scripts.get_data_path('ogr')+'poly.shp -nln test_ogr2ogr_34_dir')
 
     ds = ogr.Open('tmp/test_ogr2ogr_34_dir/test_ogr2ogr_34_dir.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10, \
@@ -1060,20 +1060,20 @@ def test_ogr2ogr_py_35():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_35_dir ../ogr/data/poly.shp ')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_35_dir '+test_py_scripts.get_data_path('ogr')+'poly.shp ')
 
     ds = ogr.Open('tmp/test_ogr2ogr_35_dir/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10, \
         'initial shapefile creation failed'
     ds = None
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -append tmp/test_ogr2ogr_35_dir ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -append tmp/test_ogr2ogr_35_dir '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/test_ogr2ogr_35_dir/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 20, '-append failed'
     ds = None
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/test_ogr2ogr_35_dir ../ogr/data/poly.shp')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' -overwrite tmp/test_ogr2ogr_35_dir '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/test_ogr2ogr_35_dir/poly.shp')
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10, \
@@ -1098,7 +1098,7 @@ def test_ogr2ogr_py_36():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_36.shp ../ogr/data/poly.shp -zfield EAS_ID')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_36.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -zfield EAS_ID')
 
     ds = ogr.Open('tmp/test_ogr2ogr_36.shp')
     feat = ds.GetLayer(0).GetNextFeature()
@@ -1129,12 +1129,12 @@ def test_ogr2ogr_py_37():
         os.mkdir('tmp/test_ogr2ogr_37_src')
     except OSError:
         pass
-    shutil.copy('../ogr/data/poly.shp', 'tmp/test_ogr2ogr_37_src')
-    shutil.copy('../ogr/data/poly.shx', 'tmp/test_ogr2ogr_37_src')
-    shutil.copy('../ogr/data/poly.dbf', 'tmp/test_ogr2ogr_37_src')
-    shutil.copy('../ogr/data/shp/testpoly.shp', 'tmp/test_ogr2ogr_37_src')
-    shutil.copy('../ogr/data/shp/testpoly.shx', 'tmp/test_ogr2ogr_37_src')
-    shutil.copy('../ogr/data/shp/testpoly.dbf', 'tmp/test_ogr2ogr_37_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'poly.shp', 'tmp/test_ogr2ogr_37_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'poly.shx', 'tmp/test_ogr2ogr_37_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'poly.dbf', 'tmp/test_ogr2ogr_37_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'shp/testpoly.shp', 'tmp/test_ogr2ogr_37_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'shp/testpoly.shx', 'tmp/test_ogr2ogr_37_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'shp/testpoly.dbf', 'tmp/test_ogr2ogr_37_src')
 
     test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_37_dir.shp tmp/test_ogr2ogr_37_src')
 
@@ -1162,7 +1162,7 @@ def test_ogr2ogr_py_38():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_38.shp ../ogr/data/poly.shp -select AREA -where "EAS_ID = 170"')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_38.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -select AREA -where "EAS_ID = 170"')
 
     ds = ogr.Open('tmp/test_ogr2ogr_38.shp')
     lyr = ds.GetLayer(0)
@@ -1192,12 +1192,12 @@ def test_ogr2ogr_py_39():
         os.mkdir('tmp/test_ogr2ogr_39_src')
     except OSError:
         pass
-    shutil.copy('../ogr/data/poly.shp', 'tmp/test_ogr2ogr_39_src')
-    shutil.copy('../ogr/data/poly.shx', 'tmp/test_ogr2ogr_39_src')
-    shutil.copy('../ogr/data/poly.dbf', 'tmp/test_ogr2ogr_39_src')
-    shutil.copy('../ogr/data/shp/testpoly.shp', 'tmp/test_ogr2ogr_39_src')
-    shutil.copy('../ogr/data/shp/testpoly.shx', 'tmp/test_ogr2ogr_39_src')
-    shutil.copy('../ogr/data/shp/testpoly.dbf', 'tmp/test_ogr2ogr_39_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'poly.shp', 'tmp/test_ogr2ogr_39_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'poly.shx', 'tmp/test_ogr2ogr_39_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'poly.dbf', 'tmp/test_ogr2ogr_39_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'shp/testpoly.shp', 'tmp/test_ogr2ogr_39_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'shp/testpoly.shx', 'tmp/test_ogr2ogr_39_src')
+    shutil.copy(test_py_scripts.get_data_path('ogr') + 'shp/testpoly.dbf', 'tmp/test_ogr2ogr_39_src')
 
     test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_39.shp tmp/test_ogr2ogr_39_src -sql "select * from poly"')
 
@@ -1224,7 +1224,7 @@ def test_ogr2ogr_py_43():
     except OSError:
         pass
 
-    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_43_3d.shp ../ogr/data/poly.shp -dim 3')
+    test_py_scripts.run_py_script(script_path, 'ogr2ogr', ' tmp/test_ogr2ogr_43_3d.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp -dim 3')
 
     ds = ogr.Open('tmp/test_ogr2ogr_43_3d.shp')
     lyr = ds.GetLayerByIndex(0)

--- a/autotest/pyscripts/test_ogrinfo_py.py
+++ b/autotest/pyscripts/test_ogrinfo_py.py
@@ -44,7 +44,7 @@ def test_ogrinfo_py_1():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp')
     assert ret.find('ESRI Shapefile') != -1
 
 ###############################################################################
@@ -56,7 +56,7 @@ def test_ogrinfo_py_2():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '-ro ../ogr/data/poly.shp')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '-ro '+test_py_scripts.get_data_path('ogr')+'poly.shp')
     assert ret.find('ESRI Shapefile') != -1
 
 ###############################################################################
@@ -68,7 +68,7 @@ def test_ogrinfo_py_3():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '-al ../ogr/data/poly.shp')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '-al '+test_py_scripts.get_data_path('ogr')+'poly.shp')
     assert ret.find('Feature Count: 10') != -1
 
 ###############################################################################
@@ -80,7 +80,7 @@ def test_ogrinfo_py_4():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp poly')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp poly')
     assert ret.find('Feature Count: 10') != -1
 
 ###############################################################################
@@ -92,7 +92,7 @@ def test_ogrinfo_py_5():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp -sql "select * from poly"')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp -sql "select * from poly"')
     assert ret.find('Feature Count: 10') != -1
 
 ###############################################################################
@@ -104,7 +104,7 @@ def test_ogrinfo_py_6():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp poly -geom=no')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp poly -geom=no')
     assert ret.find('Feature Count: 10') != -1
     assert ret.find('POLYGON') == -1
 
@@ -117,7 +117,7 @@ def test_ogrinfo_py_7():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp poly -geom=summary')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp poly -geom=summary')
     assert ret.find('Feature Count: 10') != -1
     assert ret.find('POLYGON (') == -1
     assert ret.find('POLYGON :') != -1
@@ -131,7 +131,7 @@ def test_ogrinfo_py_8():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp poly -spat 479609 4764629 479764 4764817')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp poly -spat 479609 4764629 479764 4764817')
     if ogrtest.have_geos():
         assert ret.find('Feature Count: 4') != -1
         return
@@ -148,7 +148,7 @@ def test_ogrinfo_py_9():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp poly -where "EAS_ID=171"')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp poly -where "EAS_ID=171"')
     assert ret.find('Feature Count: 1') != -1
 
 ###############################################################################
@@ -160,7 +160,7 @@ def test_ogrinfo_py_10():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp poly -fid 9')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp poly -fid 9')
     assert ret.find('OGRFeature(poly):9') != -1
 
 ###############################################################################
@@ -172,7 +172,7 @@ def test_ogrinfo_py_11():
     if script_path is None:
         pytest.skip()
 
-    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', '../ogr/data/poly.shp poly -fields=no')
+    ret = test_py_scripts.run_py_script(script_path, 'ogrinfo', test_py_scripts.get_data_path('ogr') + 'poly.shp poly -fields=no')
     assert ret.find('AREA (Real') == -1
     assert ret.find('POLYGON (') != -1
 

--- a/autotest/pyscripts/test_ogrmerge.py
+++ b/autotest/pyscripts/test_ogrmerge.py
@@ -45,7 +45,7 @@ def test_ogrmerge_1():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-single -o tmp/out.shp ../ogr/data/poly.shp ../ogr/data/poly.shp')
+                                  '-single -o tmp/out.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/out.shp')
     lyr = ds.GetLayer(0)
@@ -64,9 +64,9 @@ def test_ogrmerge_2():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-single -o tmp/out.shp ../ogr/data/poly.shp')
+                                  '-single -o tmp/out.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-append -single -o tmp/out.shp "../ogr/data/p*ly.shp"')
+                                  '-append -single -o tmp/out.shp "'+test_py_scripts.get_data_path('ogr')+'p*ly.shp"')
 
     ds = ogr.Open('tmp/out.shp')
     lyr = ds.GetLayer(0)
@@ -85,9 +85,9 @@ def test_ogrmerge_3():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-overwrite_ds -o tmp/out.shp ../ogr/data/poly.shp')
+                                  '-overwrite_ds -o tmp/out.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-overwrite_ds -single -o tmp/out.shp ../ogr/data/poly.shp')
+                                  '-overwrite_ds -single -o tmp/out.shp '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/out.shp')
     lyr = ds.GetLayer(0)
@@ -106,7 +106,7 @@ def test_ogrmerge_4():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-f VRT -o tmp/out.vrt ../ogr/data/poly.shp')
+                                  '-f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp')
 
     ds = ogr.Open('tmp/out.vrt')
     lyr = ds.GetLayer(0)
@@ -126,15 +126,15 @@ def test_ogrmerge_5():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-f VRT -o tmp/out.vrt ../ogr/data/poly.shp ../ogr/data/shp/testpoly.shp -nln '
+                                  '-f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '+test_py_scripts.get_data_path('ogr')+'shp/testpoly.shp -nln '
                                   '"foo_{DS_NAME}_{DS_BASENAME}_{DS_INDEX}_{LAYER_NAME}_{LAYER_INDEX}"')
 
     ds = ogr.Open('tmp/out.vrt')
     lyr = ds.GetLayer(0)
-    assert lyr.GetName() == 'foo_../ogr/data/poly.shp_poly_0_poly_0'
+    assert lyr.GetName() == 'foo_'+test_py_scripts.get_data_path('ogr')+'poly.shp_poly_0_poly_0'
     assert lyr.GetFeatureCount() == 10
     lyr = ds.GetLayer(1)
-    assert lyr.GetName() == 'foo_../ogr/data/shp/testpoly.shp_testpoly_1_testpoly_0'
+    assert lyr.GetName() == 'foo_'+test_py_scripts.get_data_path('ogr')+'shp/testpoly.shp_testpoly_1_testpoly_0'
     assert lyr.GetFeatureCount() == 14
     ds = None
 
@@ -150,14 +150,14 @@ def test_ogrmerge_6():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-single -f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-single -f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-src_layer_field_name source -src_layer_field_content '
                                   '"foo_{DS_NAME}_{DS_BASENAME}_{DS_INDEX}_{LAYER_NAME}_{LAYER_INDEX}"')
 
     ds = ogr.Open('tmp/out.vrt')
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
-    if f['source'] != 'foo_../ogr/data/poly.shp_poly_0_poly_0':
+    if f['source'] != 'foo_'+test_py_scripts.get_data_path('ogr')+'poly.shp_poly_0_poly_0':
         f.DumpReadable()
         pytest.fail()
     ds = None
@@ -175,7 +175,7 @@ def test_ogrmerge_7():
 
     # No match in -single mode
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-single -f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-single -f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-src_geom_type POINT')
 
     ds = ogr.Open('tmp/out.vrt')
@@ -186,7 +186,7 @@ def test_ogrmerge_7():
 
     # Match in single mode
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-single -f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-single -f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-src_geom_type POLYGON')
 
     ds = ogr.Open('tmp/out.vrt')
@@ -197,7 +197,7 @@ def test_ogrmerge_7():
 
     # No match in default mode
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-src_geom_type POINT')
 
     ds = ogr.Open('tmp/out.vrt')
@@ -208,7 +208,7 @@ def test_ogrmerge_7():
 
     # Match in default mode
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-src_geom_type POLYGON')
 
     ds = ogr.Open('tmp/out.vrt')
@@ -227,7 +227,7 @@ def test_ogrmerge_8():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-single -f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-single -f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-s_srs EPSG:32630 -t_srs EPSG:4326')
 
     ds = ogr.Open('tmp/out.vrt')
@@ -255,7 +255,7 @@ def test_ogrmerge_9():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-s_srs EPSG:32630 -t_srs EPSG:4326')
 
     ds = ogr.Open('tmp/out.vrt')
@@ -283,7 +283,7 @@ def test_ogrmerge_10():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-single -f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-single -f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-a_srs EPSG:32630')
 
     ds = ogr.Open('tmp/out.vrt')
@@ -309,7 +309,7 @@ def test_ogrmerge_11():
         pytest.skip()
 
     test_py_scripts.run_py_script(script_path, 'ogrmerge',
-                                  '-f VRT -o tmp/out.vrt ../ogr/data/poly.shp '
+                                  '-f VRT -o tmp/out.vrt '+test_py_scripts.get_data_path('ogr')+'poly.shp '
                                   '-a_srs EPSG:32630')
 
     ds = ogr.Open('tmp/out.vrt')

--- a/autotest/pyscripts/test_pct.py
+++ b/autotest/pyscripts/test_pct.py
@@ -50,7 +50,7 @@ def test_rgb2pct_1():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'rgb2pct', '../gcore/data/rgbsmall.tif tmp/test_rgb2pct_1.tif')
+    test_py_scripts.run_py_script(script_path, 'rgb2pct', test_py_scripts.get_data_path('gcore') + 'rgbsmall.tif tmp/test_rgb2pct_1.tif')
 
     ds = gdal.Open('tmp/test_rgb2pct_1.tif')
     assert ds.GetRasterBand(1).Checksum() == 31231
@@ -76,7 +76,7 @@ def test_pct2rgb_1():
     ds = gdal.Open('tmp/test_pct2rgb_1.tif')
     assert ds.GetRasterBand(1).Checksum() == 20963
 
-    ori_ds = gdal.Open('../gcore/data/rgbsmall.tif')
+    ori_ds = gdal.Open(test_py_scripts.get_data_path('gcore') + 'rgbsmall.tif')
     max_diff = gdaltest.compare_ds(ori_ds, ds)
     assert max_diff <= 18
 
@@ -93,7 +93,7 @@ def test_rgb2pct_2():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'rgb2pct', '-n 16 ../gcore/data/rgbsmall.tif tmp/test_rgb2pct_2.tif')
+    test_py_scripts.run_py_script(script_path, 'rgb2pct', '-n 16 ' + test_py_scripts.get_data_path('gcore') + 'rgbsmall.tif tmp/test_rgb2pct_2.tif')
 
     ds = gdal.Open('tmp/test_rgb2pct_2.tif')
     assert ds.GetRasterBand(1).Checksum() == 16596
@@ -116,7 +116,7 @@ def test_rgb2pct_3():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'rgb2pct', '-pct tmp/test_rgb2pct_2.tif ../gcore/data/rgbsmall.tif tmp/test_rgb2pct_3.tif')
+    test_py_scripts.run_py_script(script_path, 'rgb2pct', '-pct tmp/test_rgb2pct_2.tif ' + test_py_scripts.get_data_path('gcore') + 'rgbsmall.tif tmp/test_rgb2pct_3.tif')
 
     ds = gdal.Open('tmp/test_rgb2pct_3.tif')
     assert ds.GetRasterBand(1).Checksum() == 16596
@@ -144,10 +144,10 @@ def test_pct2rgb_4():
     if script_path is None:
         pytest.skip()
 
-    test_py_scripts.run_py_script(script_path, 'pct2rgb', '-rgba ../gcore/data/rat.img tmp/test_pct2rgb_4.tif')
+    test_py_scripts.run_py_script(script_path, 'pct2rgb', '-rgba ' + test_py_scripts.get_data_path('gcore') + 'rat.img tmp/test_pct2rgb_4.tif')
 
     ds = gdal.Open('tmp/test_pct2rgb_4.tif')
-    ori_ds = gdal.Open('../gcore/data/rat.img')
+    ori_ds = gdal.Open(test_py_scripts.get_data_path('gcore') + 'rat.img')
 
     ori_data = struct.unpack('H', ori_ds.GetRasterBand(1).ReadRaster(1990, 1990, 1, 1, 1, 1))[0]
     data = (struct.unpack('B', ds.GetRasterBand(1).ReadRaster(1990, 1990, 1, 1, 1, 1))[0],
@@ -166,7 +166,7 @@ def test_pct2rgb_4():
 
 def test_gdalattachpct_1():
     pct_filename = 'tmp/test_rgb2pct_2.tif'
-    src_filename = '../gcore/data/rgbsmall.tif'
+    src_filename = test_py_scripts.get_data_path('gcore') + 'rgbsmall.tif'
     pct_filename4 = 'tmp/test_gdalattachpct_1_4.txt'
 
     # pct from raster

--- a/gdal/swig/python/samples/ogr2ogr.py
+++ b/gdal/swig/python/samples/ogr2ogr.py
@@ -68,7 +68,7 @@ def EQUAL(a, b):
     return a.lower() == b.lower()
 
 ###############################################################################
-# Redefinition of GDALTermProgress, so that autotest/pyscripts/test_ogr2ogr_py.py
+# Redefinition of GDALTermProgress, so that test_ogr2ogr_py.py
 # can check that the progress bar is displayed
 
 


### PR DESCRIPTION
## What does this PR do?

test_py_scripts - simplify get_py_script; add samples_path, get_data_dir and use them in tests instead of hardcode paths
This will allow adding/removing/changing Python script/modules paths easily.

This PR also cleanup some redundant spaces and empty lines from the effected files.

I'm not sure if FrankW's folder structure is relevant for anything. if not I'll remove it.
