### PR TITLE
WMS and MRF: Let WMS pass expected NoDataValue to MRF for reading data

### DIFF
--- a/gdal/frmts/mrf/LERC_band.cpp
+++ b/gdal/frmts/mrf/LERC_band.cpp
@@ -531,7 +531,12 @@ CPLXMLNode *LERC_Band::GetMRFConfig(GDALOpenInfo *poOpenInfo)
     CPLCreateXMLElementAndValue(raster, "DataFile", poOpenInfo->pszFilename);
     // Set a magic index file name to prevent the driver from attempting to open it
     CPLCreateXMLElementAndValue(raster, "IndexFile", "(null)");
-
+    // The NDV could be passed as an open option
+    const char* pszNDV = CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "NDV", "");
+    if (strlen(pszNDV) > 0) {
+        CPLXMLNode* values = CPLCreateXMLNode(raster, CXT_Element, "DataValues");
+        XMLSetAttributeVal(values, "NoData", pszNDV);
+    }
     return config;
 }
 

--- a/gdal/frmts/mrf/marfa.h
+++ b/gdal/frmts/mrf/marfa.h
@@ -245,6 +245,7 @@ double logbase(double val, double base);
 int IsPower(double value, double base);
 CPLXMLNode *SearchXMLSiblings(CPLXMLNode *psRoot, const char *pszElement);
 CPLString PrintDouble(double d, const char *frmt = "%12.8f");
+void XMLSetAttributeVal(CPLXMLNode* parent, const char* pszName, const char* pszValue);
 void XMLSetAttributeVal(CPLXMLNode *parent, const char* pszName,
     const double val, const char *frmt = "%12.8f");
 CPLXMLNode *XMLSetAttributeVal(CPLXMLNode *parent,

--- a/gdal/frmts/mrf/mrf_util.cpp
+++ b/gdal/frmts/mrf/mrf_util.cpp
@@ -415,21 +415,16 @@ CPLString PrintDouble(double d, const char *frmt)
     return CPLString().FormatC(d, frmt);
 }
 
-static void XMLSetAttributeVal(CPLXMLNode *parent, const char* pszName,
-    const char *val)
+void XMLSetAttributeVal(CPLXMLNode *parent, const char* pszName, const char *pszVal)
 {
     CPLCreateXMLNode(parent, CXT_Attribute, pszName);
-    CPLSetXMLValue(parent, pszName, val);
+    CPLSetXMLValue(parent, pszName, pszVal);
 }
 
 void XMLSetAttributeVal(CPLXMLNode *parent, const char* pszName,
     const double val, const char *frmt)
 {
-    XMLSetAttributeVal(parent, pszName, CPLString().FormatC(val, frmt));
-
-    //  Unfortunately the %a doesn't work in VisualStudio scanf or strtod
-    //    if (strtod(sVal.c_str(),0) != val)
-    //  sVal.Printf("%a",val);
+    XMLSetAttributeVal(parent, pszName, PrintDouble(val, frmt));
 }
 
 CPLXMLNode *XMLSetAttributeVal(CPLXMLNode *parent,

--- a/gdal/frmts/wms/gdalwmsdataset.cpp
+++ b/gdal/frmts/wms/gdalwmsdataset.cpp
@@ -500,15 +500,14 @@ CPLErr GDALWMSDataset::Initialize(CPLXMLNode *config, char **l_papszOpenOptions)
         if (ret == CE_None)
         {
             const char *data_type = CPLGetXMLValue(config, "DataType", "Byte");
+            if (!STARTS_WITH(data_type, "Byte"))
+                SetTileOO("@DATATYPE", data_type);
             m_data_type = GDALGetDataTypeByName(data_type);
             if (m_data_type == GDT_Unknown || m_data_type >= GDT_TypeCount)
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                     "GDALWMS: Invalid value in DataType. Data type \"%s\" is not supported.", data_type);
                 ret = CE_Failure;
-            }
-            else if (!STARTS_WITH(data_type, "Byte")) { // Valid, non-byte
-                m_tileOO = CSLSetNameValue(m_tileOO, "@DATATYPE", data_type);
             }
         }
 
@@ -565,12 +564,15 @@ CPLErr GDALWMSDataset::Initialize(CPLXMLNode *config, char **l_papszOpenOptions)
     if (ret == CE_None) {
         // Data values are attributes, they include NoData Min and Max
         if (nullptr!=CPLGetXMLNode(config,"DataValues")) {
-            const char *nodata=CPLGetXMLValue(config,"DataValues.NoData",nullptr);
-            if (nodata!=nullptr) WMSSetNoDataValue(nodata);
-            const char *min=CPLGetXMLValue(config,"DataValues.min",nullptr);
-            if (min!=nullptr) WMSSetMinValue(min);
-            const char *max=CPLGetXMLValue(config,"DataValues.max",nullptr);
-            if (max!=nullptr) WMSSetMaxValue(max);
+            const char *nodata = CPLGetXMLValue(config, "DataValues.NoData", "");
+            if (strlen(nodata) > 0) {
+                SetTileOO("@NDV", nodata);
+                WMSSetNoDataValue(nodata);
+            }
+            const char *min = CPLGetXMLValue(config, "DataValues.min", nullptr);
+            if (min != nullptr) WMSSetMinValue(min);
+            const char *max = CPLGetXMLValue(config, "DataValues.max", nullptr);
+            if (max != nullptr) WMSSetMaxValue(max);
         }
     }
 
@@ -740,4 +742,14 @@ const char * const * GDALWMSDataset::GetHTTPRequestOpts()
 
     m_http_options = opts;
     return m_http_options;
+}
+
+void GDALWMSDataset::SetTileOO(const char* pszName, const char* pszValue) {
+    if (pszName == nullptr || strlen(pszName) == 0)
+        return;
+    int oldidx = CSLFindName(m_tileOO, pszName);
+    if (oldidx >= 0)
+        m_tileOO = CSLRemoveStrings(m_tileOO, oldidx, 1, nullptr);
+    if (pszValue != nullptr && strlen(pszValue))
+        m_tileOO = CSLAddNameValue(m_tileOO, pszName, pszValue);
 }

--- a/gdal/frmts/wms/minidriver_tiled_wms.cpp
+++ b/gdal/frmts/wms/minidriver_tiled_wms.cpp
@@ -402,7 +402,10 @@ CPLErr WMSMiniDriver_TiledWMS::Initialize(CPLXMLNode *config, CPL_UNUSED char **
         // Data values are attributes, they include NoData Min and Max
         if (nullptr != CPLGetXMLNode(TG, "DataValues")) {
             const char *nodata = CPLGetXMLValue(TG, "DataValues.NoData", nullptr);
-            if (nodata != nullptr) m_parent_dataset->WMSSetNoDataValue(nodata);
+            if (nodata != nullptr) {
+                m_parent_dataset->WMSSetNoDataValue(nodata);
+                m_parent_dataset->SetTileOO("@NDV", nodata);
+            }
             const char *min = CPLGetXMLValue(TG, "DataValues.min", nullptr);
             if (min != nullptr) m_parent_dataset->WMSSetMinValue(min);
             const char *max = CPLGetXMLValue(TG, "DataValues.max", nullptr);
@@ -410,7 +413,10 @@ CPLErr WMSMiniDriver_TiledWMS::Initialize(CPLXMLNode *config, CPL_UNUSED char **
         }
 
         m_parent_dataset->WMSSetBandsCount(band_count);
-        m_parent_dataset->WMSSetDataType(GDALGetDataTypeByName(CPLGetXMLValue(TG, "DataType", "Byte")));
+        GDALDataType dt = GDALGetDataTypeByName(CPLGetXMLValue(TG, "DataType", "Byte"));
+        m_parent_dataset->WMSSetDataType(dt);
+        if (dt != GDT_Byte)
+            m_parent_dataset->SetTileOO("@DATATYPE", GDALGetDataTypeName(dt));
         m_projection_wkt = CPLGetXMLValue(TG, "Projection", "");
 
         m_base_url = CPLGetXMLValue(TG, "OnlineResource.xlink:href", global_base_url);

--- a/gdal/frmts/wms/wmsdriver.h
+++ b/gdal/frmts/wms/wmsdriver.h
@@ -383,6 +383,11 @@ public:
         list2vec(vMax,pszMax);
     }
 
+    // Set open options for tiles
+    // Works like a <set>, only one entry with a give name can exist, last one set wins
+    // If the value is null, the entry is deleted
+    void SetTileOO(const char* pszName, const char* pszValue);
+
     void SetXML(const char *psz) {
         m_osXML.clear();
         if (psz)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

MRF driver can read tiles with LERC encoded data for the WMS driver, but it needs to know the expected NoDataValue.
When combined with the previously existing capability of the WMS driver to pass the expected DataType, this allows a LERC encoded tiled data service to be read correctly via the WMS driver.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
