### PR TITLE
CPLLoadConfigOptionsFromFile(): add an argument to define if env vars…

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -3051,7 +3051,7 @@ namespace tut
     template<>
     void object::test<44>()
     {
-        CPLLoadConfigOptionsFromFile("/i/do/not/exist");
+        CPLLoadConfigOptionsFromFile("/i/do/not/exist", false);
 
         VSILFILE* fp = VSIFOpenL("/vsimem/.gdal/gdalrc", "wb");
         VSIFPrintfL(fp, "[configoptions]\n");
@@ -3060,7 +3060,7 @@ namespace tut
         VSIFCloseL(fp);
 
         // Try CPLLoadConfigOptionsFromFile()
-        CPLLoadConfigOptionsFromFile("/vsimem/.gdal/gdalrc");
+        CPLLoadConfigOptionsFromFile("/vsimem/.gdal/gdalrc", false);
         ensure( EQUAL(CPLGetConfigOption("FOO_CONFIGOPTION", ""), "BAR") );
         CPLSetConfigOption("FOO_CONFIGOPTION", nullptr);
 

--- a/gdal/doc/source/user/configoptions.rst
+++ b/gdal/doc/source/user/configoptions.rst
@@ -104,6 +104,9 @@ Configuration options set in the configuration file can later be overridden
 by calls to :cpp:func:`CPLSetConfigOption` or  :cpp:func:`CPLSetThreadLocalConfigOption`,
 or through the ``--config`` command line switch.
 
+The value of environment variables set before GDAL starts will be used instead
+of the value set in the configuration files.
+
 .. _list_config_options:
 
 List of configuration options and where they apply

--- a/gdal/port/cpl_conv.h
+++ b/gdal/port/cpl_conv.h
@@ -66,7 +66,7 @@ char CPL_DLL** CPLGetConfigOptions(void);
 void CPL_DLL   CPLSetConfigOptions(const char* const * papszConfigOptions);
 char CPL_DLL** CPLGetThreadLocalConfigOptions(void);
 void CPL_DLL   CPLSetThreadLocalConfigOptions(const char* const * papszConfigOptions);
-void CPL_DLL   CPLLoadConfigOptionsFromFile(const char* pszFilename);
+void CPL_DLL   CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars);
 void CPL_DLL   CPLLoadConfigOptionsFromPredefinedFiles();
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
… should have precedence, and make CPLLoadConfigOptionsFromPredefinedFiles() call it such that env vars have precedence over values of the config file

Addresses https://github.com/OSGeo/gdal/pull/3384#issuecomment-763836526