### PR TITLE
Make creation of global hCOAMutex thread-safer on Windows

### DIFF
--- a/gdal/port/cpl_multiproc.cpp
+++ b/gdal/port/cpl_multiproc.cpp
@@ -299,7 +299,7 @@ CPLMutex*& CPLCreateOrAcquireMasterMutexInternal(double dfWaitInSeconds = 1000.0
     {
         // In case of unexpected call to CPLCleanupMasterMutex,
         // attempt this NOT thread-safe re-construction of the master mutex.
-        hCOAMutex = CPLCreateMutex();
+        hCOAMutex = CPLCreateUnacquiredMutex();
     }
 
     if( hCOAMutex )

--- a/gdal/port/cpl_multiproc.cpp
+++ b/gdal/port/cpl_multiproc.cpp
@@ -143,6 +143,9 @@ static int     CPLCreateOrAcquireSpinLockInternal( CPLLock** );
 static int     CPLAcquireSpinLock( CPLSpinLock* );
 static void    CPLReleaseSpinLock( CPLSpinLock* );
 static void    CPLDestroySpinLock( CPLSpinLock* );
+static CPLMutex*    CPLCreateOrAcquireMasterMutex( double );
+static CPLMutex*&   CPLCreateOrAcquireMasterMutexInternal( double );
+static CPLMutex*    CPLCreateUnacquiredMutex();
 
 // We don't want it to be publicly used since it solves rather tricky issues
 // that are better to remain hidden.

--- a/gdal/port/cpl_multiproc.cpp
+++ b/gdal/port/cpl_multiproc.cpp
@@ -379,10 +379,6 @@ int CPLCreateOrAcquireMutexInternal( CPLLock **phLock, double dfWaitInSeconds,
         *phLock = nullptr;
         return FALSE;
     }
-    else
-    {
-        CPLAcquireMutex( hCOAMutex, dfWaitInSeconds );
-    }
 
     if( *phLock == nullptr )
     {

--- a/gdal/port/cpl_multiproc.cpp
+++ b/gdal/port/cpl_multiproc.cpp
@@ -143,9 +143,14 @@ static int     CPLCreateOrAcquireSpinLockInternal( CPLLock** );
 static int     CPLAcquireSpinLock( CPLSpinLock* );
 static void    CPLReleaseSpinLock( CPLSpinLock* );
 static void    CPLDestroySpinLock( CPLSpinLock* );
+
+#ifndef CPL_MULTIPROC_PTHREAD
+#ifndef MUTEX_NONE
 static CPLMutex*    CPLCreateOrAcquireMasterMutex( double );
 static CPLMutex*&   CPLCreateOrAcquireMasterMutexInternal( double );
 static CPLMutex*    CPLCreateUnacquiredMutex();
+#endif
+#endif
 
 // We don't want it to be publicly used since it solves rather tricky issues
 // that are better to remain hidden.
@@ -606,7 +611,7 @@ void CPLCondWait( CPLCond * /* hCond */ , CPLMutex* /* hMutex */ ) {}
 /*                         CPLCondTimedWait()                           */
 /************************************************************************/
 
-CPLCondTimedWaitReason CPLCondTimedWait( CPLCond * /* hCond */ , 
+CPLCondTimedWaitReason CPLCondTimedWait( CPLCond * /* hCond */ ,
                                          CPLMutex* /* hMutex */, double )
 {
     return COND_TIMED_WAIT_OTHER;


### PR DESCRIPTION
## What does this PR do?

This is an attempt to improve the "Ironically, creation of this initial mutex is not threadsafe" on Windows with implementation based on the `CRITICAL_SECTION`.

C++11 guarantees:
> Dynamic initialization of a block variable with static storage duration
>  is performed the first time control passes through its declaration (...)
> If control enters the declaration concurrently while the variable is
> being initialized, the concurrent execution shall wait for completion of the initialization.
~ http://eel.is/c++draft/stmt.dcl#4

MSVC guarantees:
> This behaviour is also available starting in Visual Studio 2015
> By default, Visual Studio enables this option.
~ https://docs.microsoft.com/en-us/cpp/build/reference/zc-threadsafeinit-thread-safe-local-static-initialization


## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Windows
* Compiler: MSVC
