### PR TITLE
Remove too strict CPLAssert checking global hCOAMutex

### DIFF
--- a/gdal/port/cpl_multiproc.cpp
+++ b/gdal/port/cpl_multiproc.cpp
@@ -301,7 +301,7 @@ CPLMutex*& CPLCreateOrAcquireMasterMutexInternal(double dfWaitInSeconds = 1000.0
     {
         // Fall back to this, ironically, NOT thread-safe re-initialisation of
         // hCOAMutex in case of a memory error or call to CPLCleanupMasterMutex
-        // sequenced in an unusual, unexected or erroneous way.
+        // sequenced in an unusual, unexpected or erroneous way.
         // For example, an unusual sequence could be:
         //   GDALDriverManager has been instantiated,
         //   then OGRCleanupAll is called which calls CPLCleanupMasterMutex,


### PR DESCRIPTION
## What does this PR do?

Although adding an `CPLAssert(hCOAMutex);` might seem logical
here, do not enable it (see comment below). It calls CPLError that
uses the hCOAMutex itself leading to recursive mutex acquisition
and likely a stack overflow.

Fall back to this, ironically, NOT thread-safe re-initialisation of
hCOAMutex in case of a memory error or call to CPLCleanupMasterMutex
sequenced in an unusual, unexected or erroneous way.

For example, an unusual sequence could be:
  - GDALDriverManager has been instantiated,
  - then OGRCleanupAll is called which calls CPLCleanupMasterMutex,
  - then CPLFreeConfig is called which acquires the hCOAMutex
  - that has already been released and destroyed.

## What are related issues/pull requests?

Refines #3399

## Tasklist

 - [x] Add test case(s) - already available MT tests do cover the unusual execution paths
 - [ ] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Windows
* Compiler: MSVC
