### PR TITLE
Remove ODBC text trimming behaviour

### DIFF
--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -365,7 +365,7 @@ int CPLODBCSession::Failed( int nRetCode, HSTMT hStmt )
                     achSQLState, &nNativeError,
                     reinterpret_cast<SQLCHAR *>(pachCurErrMsg),
                     nTextLength, &nTextLength2);
-            }               
+            }
             pachCurErrMsg[nTextLength] = '\0';
             m_osLastError += CPLString().Printf("%s[%5s]%s(" CPL_FRMT_GIB ")",
                     (m_osLastError.empty() ? "" : ", "), achSQLState,
@@ -1030,14 +1030,14 @@ int CPLODBCStatement::Fetch( int nOrientation, int nOffset )
         }
 
         // Trim white space off end, if there is any.
-        if( nFetchType == SQL_C_CHAR && m_papszColValues[iCol] != nullptr )
-        {
-            char *pszTarget = m_papszColValues[iCol];
-            size_t iEnd = strlen(pszTarget);
+        // if( nFetchType == SQL_C_CHAR && m_papszColValues[iCol] != nullptr )
+        // {
+        //     char *pszTarget = m_papszColValues[iCol];
+        //     size_t iEnd = strlen(pszTarget);
 
-            while( iEnd > 0 && pszTarget[iEnd - 1] == ' ' )
-                pszTarget[--iEnd] = '\0';
-        }
+        //     while( iEnd > 0 && pszTarget[iEnd - 1] == ' ' )
+        //         pszTarget[--iEnd] = '\0';
+        // }
 
         // Convert WCHAR to UTF-8, assuming the WCHAR is UCS-2.
         if( nFetchType == SQL_C_WCHAR && m_papszColValues[iCol] != nullptr

--- a/gdal/port/cpl_odbc.cpp
+++ b/gdal/port/cpl_odbc.cpp
@@ -1029,16 +1029,6 @@ int CPLODBCStatement::Fetch( int nOrientation, int nOffset )
             m_papszColValues[iCol][cbDataLen+1] = '\0';
         }
 
-        // Trim white space off end, if there is any.
-        // if( nFetchType == SQL_C_CHAR && m_papszColValues[iCol] != nullptr )
-        // {
-        //     char *pszTarget = m_papszColValues[iCol];
-        //     size_t iEnd = strlen(pszTarget);
-
-        //     while( iEnd > 0 && pszTarget[iEnd - 1] == ' ' )
-        //         pszTarget[--iEnd] = '\0';
-        // }
-
         // Convert WCHAR to UTF-8, assuming the WCHAR is UCS-2.
         if( nFetchType == SQL_C_WCHAR && m_papszColValues[iCol] != nullptr
             && m_panColValueLengths[iCol] > 0 )


### PR DESCRIPTION
Removes the white space trimming from the ODBC fetching code which removes spaces from ODBC text field on retrieval.

The behaviour makes it difficult to use ODBC results for some use cases that consider white space important, and was discovered here https://github.com/pramsey/pgsql-ogr-fdw/issues/208

Either the behaviour should be removed, or made conditional on a run-time option. A compile-time option seems not worth the effort. Initial PR for CI tests, and then can use this PR for final commit or run-time option implementation.