### PR TITLE
CI: force code_quality_checks and doxygen to ubuntu 18.04

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -73,7 +73,7 @@ jobs:
         run: ./gdal/scripts/cppcheck.sh
 
   code_quality_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -115,7 +115,7 @@ jobs:
             $FLAKE8 gdal/swig/python/osgeo/utils/auxiliary
 
   doxygen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu-latest is now at 20.04 and causes warnings/errors:
https://github.com/OSGeo/gdal/pull/3424/checks?check_run_id=1810156472