### PR TITLE
Update gdalbuildvrt.rst

### DIFF
--- a/gdal/doc/source/programs/gdalbuildvrt.rst
+++ b/gdal/doc/source/programs/gdalbuildvrt.rst
@@ -53,10 +53,7 @@ interpretation... If not, files that do not match the common characteristics wil
 If there is some amount of spatial overlapping between files, the order of files
 appearing in the list of source matter: files that are listed at the end are the ones
 from which the content will be fetched. Note that nodata will be taken into account
-to potentially fetch data from less priority datasets, but currently, alpha channel
-is not taken into account to do alpha compositing (so a source with alpha=0
-appearing on top of another source will override is content). This might be
-changed in later versions.
+to potentially fetch data from less priority datasets.
 
 .. program:: gdalbuildvrt
 


### PR DESCRIPTION
With the new parameter (i.e., -ignore_srcmaskband) in the new version of GDAL, there is no issue with merging images that have alpha channel and so the introduction should be revised.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
