### PR TITLE
Flip FITS file in y direction (as expected in coordinate translation).

### DIFF
--- a/gdal/data/pds4_template.xml
+++ b/gdal/data/pds4_template.xml
@@ -56,7 +56,7 @@
                     <disp:horizontal_display_axis>Sample</disp:horizontal_display_axis>
                     <disp:horizontal_display_direction>Left to Right</disp:horizontal_display_direction>
                     <disp:vertical_display_axis>Line</disp:vertical_display_axis>
-                    <disp:vertical_display_direction>Top to Bottom</disp:vertical_display_direction>
+                    <disp:vertical_display_direction>${VERTICAL_DISPLAY_DIRECTION}</disp:vertical_display_direction>
                 </disp:Display_Direction>
             </disp:Display_Settings>
 

--- a/gdal/frmts/fits/fitsdataset.cpp
+++ b/gdal/frmts/fits/fitsdataset.cpp
@@ -1751,9 +1751,9 @@ CPLErr FITSRasterBand::IReadBlock(CPL_UNUSED int nBlockXOff, int nBlockYOff,
   CPLAssert(nBlockYOff < nRasterYSize);
 
   // Calculate offsets and read in the data. Note that FITS array offsets
-  // start at 1...
+  // start at 1 at the bottom left...
   LONGLONG offset = static_cast<LONGLONG>(nBand - 1) * nRasterXSize * nRasterYSize +
-    static_cast<LONGLONG>(nBlockYOff) * nRasterXSize + 1;
+    (static_cast<LONGLONG>(nRasterYSize - 1 - nBlockYOff) * nRasterXSize + 1);
   long nElements = nRasterXSize;
 
   // If we haven't written this block to the file yet, then attempting
@@ -1803,7 +1803,7 @@ CPLErr FITSRasterBand::IWriteBlock( CPL_UNUSED int nBlockXOff, int nBlockYOff,
   // Calculate offsets and read in the data. Note that FITS array offsets
   // start at 1 at the bottom left...
   LONGLONG offset = static_cast<LONGLONG>(nBand - 1) * nRasterXSize * nRasterYSize +
-    static_cast<LONGLONG>(nBlockYOff) * nRasterXSize + 1;
+    (static_cast<LONGLONG>(nRasterYSize - 1 - nBlockYOff) * nRasterXSize + 1);
   long nElements = nRasterXSize;
   fits_write_img(hFITS, dataset->m_fitsDataType, offset, nElements,
                  pImage, &status);

--- a/gdal/frmts/pds/pds4dataset.cpp
+++ b/gdal/frmts/pds/pds4dataset.cpp
@@ -4084,6 +4084,8 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
         if( poSrcDriver)
         {
             auto pszDriverName = poSrcDriver->GetDescription();
+            papszOptions = CSLSetNameValue(
+                papszOptions, "VAR_VERTICAL_DISPLAY_DIRECTION", "Top to Bottom");
             if( EQUAL(pszDriverName, "GTiff") )
             {
                 GByte abySignature[4] = {0};
@@ -4106,6 +4108,8 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
             else if( EQUAL(pszDriverName, "FITS") )
             {
                 osHeaderParsingStandard = "FITS 3.0";
+                papszOptions = CSLSetNameValue(
+                    papszOptions, "VAR_VERTICAL_DISPLAY_DIRECTION", "Bottom to Top");
             }
         }
     }

--- a/gdal/frmts/pds/pds4dataset.cpp
+++ b/gdal/frmts/pds/pds4dataset.cpp
@@ -4084,8 +4084,6 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
         if( poSrcDriver)
         {
             auto pszDriverName = poSrcDriver->GetDescription();
-            papszOptions = CSLSetNameValue(
-                papszOptions, "VAR_VERTICAL_DISPLAY_DIRECTION", "Top to Bottom");
             if( EQUAL(pszDriverName, "GTiff") )
             {
                 GByte abySignature[4] = {0};


### PR DESCRIPTION
## What does this PR do?
This pull request flips FITS rasters in y direction.
This is a feature I should have added from the beginning in #1298 as discussed in the [mailing list exchange](https://lists.osgeo.org/pipermail/gdal-dev/2016-March/043985.html).
I guess my git skills weren't good enough at the time and this feature went lost in synchronizing with upstream at some time.
The FITS World Coordinate System metadata translated via GDAL expect FITS be flipped.

I apologize for the mistake and thank @AzriaChloe for the detailed bug report.
