### PR TITLE
Docker: Rename BASE_IMAGE_NAME to TARGET_IMAGE . Add new parameter BASE_IMAGE

### DIFF
--- a/gdal/docker/README.md
+++ b/gdal/docker/README.md
@@ -126,10 +126,18 @@ Use the two script flags in order to leverage BuildKit:
 
 `alpine-small/build.sh --with-multi-arch --release --gdal v3.2.0 --proj master --platform linux/arm64,linux/amd64`
 
-## Custom Image Names
+## Custom Base Image
 
-Override the image and repository by setting the environment variable: `BASE_IMAGE_NAME`
+Override the base image, used to build and run gdal, by setting the environment variable: `BASE_IMAGE`
 
 **Example**
 
-`BASE_IMAGE_NAME="YOU_DOCKER_USERNAME/gdal" alpine-small/build.sh --release --gdal v3.2.0 --proj master`
+`BASE_IMAGE="debian:stable" ubuntu-small/build.sh --release --gdal v3.2.0 --proj master`
+
+## Custom Image Names
+
+Override the image and repository of the final image by setting the environment variable: `TARGET_IMAGE`
+
+**Example**
+
+`TARGET_IMAGE="YOU_DOCKER_USERNAME/gdal" alpine-small/build.sh --release --gdal v3.2.0 --proj master`

--- a/gdal/docker/alpine-normal/build.sh
+++ b/gdal/docker/alpine-normal/build.sh
@@ -19,6 +19,6 @@ esac
 
 export SCRIPT_DIR
 TAG_NAME=$(basename "${SCRIPT_DIR}")
-export BASE_IMAGE_NAME=${BASE_IMAGE_NAME:-osgeo/gdal:${TAG_NAME}}
+export TARGET_IMAGE=${TARGET_IMAGE:-osgeo/gdal:${TAG_NAME}}
 
 "${SCRIPT_DIR}/../util.sh" "$@" --test-python

--- a/gdal/docker/alpine-small/build.sh
+++ b/gdal/docker/alpine-small/build.sh
@@ -19,6 +19,6 @@ esac
 
 export SCRIPT_DIR
 TAG_NAME=$(basename "${SCRIPT_DIR}")
-export BASE_IMAGE_NAME=${BASE_IMAGE_NAME:-osgeo/gdal:${TAG_NAME}}
+export TARGET_IMAGE=${TARGET_IMAGE:-osgeo/gdal:${TAG_NAME}}
 
 "${SCRIPT_DIR}/../util.sh" "$@"

--- a/gdal/docker/alpine-ultrasmall/build.sh
+++ b/gdal/docker/alpine-ultrasmall/build.sh
@@ -19,6 +19,6 @@ esac
 
 export SCRIPT_DIR
 TAG_NAME=$(basename "${SCRIPT_DIR}")
-export BASE_IMAGE_NAME=${BASE_IMAGE_NAME:-osgeo/gdal:${TAG_NAME}}
+export TARGET_IMAGE=${TARGET_IMAGE:-osgeo/gdal:${TAG_NAME}}
 
 "${SCRIPT_DIR}/../util.sh" "$@"

--- a/gdal/docker/ubuntu-full/Dockerfile
+++ b/gdal/docker/ubuntu-full/Dockerfile
@@ -13,6 +13,7 @@ FROM $BASE_IMAGE as builder
 LABEL maintainer="Even Rouault <even.rouault@spatialys.com>"
 
 # Setup build env for PROJ
+USER root
 RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
             software-properties-common build-essential ca-certificates \
@@ -180,6 +181,7 @@ RUN /buildscripts/bh-gdal.sh
 # Build final image
 FROM $BASE_IMAGE as runner
 
+USER root
 RUN date
 ARG JAVA_VERSION=11
 

--- a/gdal/docker/ubuntu-full/build.sh
+++ b/gdal/docker/ubuntu-full/build.sh
@@ -19,6 +19,6 @@ esac
 
 export SCRIPT_DIR
 TAG_NAME=$(basename "${SCRIPT_DIR}")
-export BASE_IMAGE_NAME=${BASE_IMAGE_NAME:-osgeo/gdal:${TAG_NAME}}
+export TARGET_IMAGE=${TARGET_IMAGE:-osgeo/gdal:${TAG_NAME}}
 
 "${SCRIPT_DIR}/../util.sh" "$@" --test-python

--- a/gdal/docker/ubuntu-small/Dockerfile
+++ b/gdal/docker/ubuntu-small/Dockerfile
@@ -14,6 +14,7 @@ FROM $BASE_IMAGE as builder
 LABEL maintainer="Even Rouault <even.rouault@spatialys.com>"
 
 # Setup build env for PROJ
+USER root
 RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
             software-properties-common build-essential ca-certificates \
@@ -154,7 +155,7 @@ RUN if test "${GDAL_VERSION}" = "master"; then \
     && mkdir -p /build_gdal_python/usr/lib \
     && mkdir -p /build_gdal_python/usr/bin \
     && mkdir -p /build_gdal_version_changing/usr/include \
-    && mv /build/usr/lib/python3            /build_gdal_python/usr/lib \
+    && mv /build/usr/lib/python*            /build_gdal_python/usr/lib \
     && mv /build/usr/lib                    /build_gdal_version_changing/usr \
     && mv /build/usr/include/gdal_version.h /build_gdal_version_changing/usr/include \
     && mv /build/usr/bin/*.py               /build_gdal_python/usr/bin \
@@ -166,6 +167,7 @@ RUN if test "${GDAL_VERSION}" = "master"; then \
 # Build final image
 FROM $BASE_IMAGE as runner
 
+USER root
 RUN date
 
 # PROJ dependencies

--- a/gdal/docker/ubuntu-small/build.sh
+++ b/gdal/docker/ubuntu-small/build.sh
@@ -19,6 +19,6 @@ esac
 
 export SCRIPT_DIR
 TAG_NAME=$(basename "${SCRIPT_DIR}")
-export BASE_IMAGE_NAME=${BASE_IMAGE_NAME:-osgeo/gdal:${TAG_NAME}}
+export TARGET_IMAGE=${TARGET_IMAGE:-osgeo/gdal:${TAG_NAME}}
 
 "${SCRIPT_DIR}/../util.sh" "$@" --test-python


### PR DESCRIPTION
## What does this PR do?

The `BASE_IMAGE` argument is never passed to the dockerfile. This makes `ubuntu` the default base image, even if we specify `BASE_IMAGE_NAME` as specified in the readme.

The following code currently succeeds on master (even if the image doesn't exist). After this change the `docker build` process errors as expected.
```
BASE_IMAGE_NAME="nonexistingimage" ./ubuntu-small/build.sh --gdal v3.2.1 --proj 7.2.1 --platform linux/amd64
```

I also added explicitely the `USER root` in the dockerfile since some of these base images might not use it by default. For the current defaults, this is a noop.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
