### PR TITLE
Fix configure issues finding dependencies

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -38776,7 +38776,9 @@ $as_echo "no" >&6; }
 fi
 
 
-    ac_geos_config_auto=yes
+    if test x"$with_geos" = x"" ; then
+      ac_geos_config_auto=yes
+    fi
 
   else
 
@@ -38968,13 +38970,27 @@ fi
 
 
       if test x"$HAVE_GEOS" = "xno"; then
-          GEOS_CFLAGS=""
+        if test $ac_geos_config_auto = "yes" ; then
+          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: GEOS was found on your system, but the library could not be linked. GEOS support disabled." >&5
+$as_echo "$as_me: WARNING: GEOS was found on your system, but the library could not be linked. GEOS support disabled." >&2;}
+        else
+          as_fn_error $? "GEOS library could not be linked" "$LINENO" 5
+        fi
+
+        GEOS_CFLAGS=""
+
       fi
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
       LDFLAGS="${ax_save_LDFLAGS}"
 
+    fi
+
+  else
+
+    if test $ac_geos_config_auto = "no" ; then
+      as_fn_error $? "GEOS support explicitly enabled, but geos-config could not be found" "$LINENO" 5
     fi
 
   fi
@@ -39063,7 +39079,9 @@ $as_echo "no" >&6; }
 fi
 
 
-    ac_sfcgal_config_auto=yes
+    if test x"$with_sfcgal" = x"" ; then
+      ac_sfcgal_config_auto=yes
+    fi
 
   else
 
@@ -39256,13 +39274,26 @@ fi
 
 
       if test x"$HAVE_SFCGAL" = "xno"; then
-          SFCGAL_CFLAGS=""
+        if test $ac_sfcgal_config_auto = "yes" ; then
+          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: SFCGAL was found on your system, but the library could not be linked. SFCGAL support disabled." >&5
+$as_echo "$as_me: WARNING: SFCGAL was found on your system, but the library could not be linked. SFCGAL support disabled." >&2;}
+        else
+          as_fn_error $? "SFCGAL library could not be linked" "$LINENO" 5
+        fi
+
+        SFCGAL_CFLAGS=""
       fi
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
       LDFLAGS="${ax_save_LDFLAGS}"
 
+    fi
+
+  else
+
+    if test $ac_sfcgal_config_auto = "no" ; then
+      as_fn_error $? "SFCGAL support explicitly enabled, but sfcgal-config could not be found" "$LINENO" 5
     fi
 
   fi

--- a/gdal/configure
+++ b/gdal/configure
@@ -38920,6 +38920,8 @@ $as_echo "$as_me: WARNING: GEOS was found on your system, but geos-config report
       LIBS=${GEOS_LIBS}
       ax_save_CFLAGS="${CFLAGS}"
       CFLAGS="${GEOS_CFLAGS}"
+      ax_save_LDFLAGS="${LDFLAGS}"
+      LDFLAGS=""
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GEOSversion in -lgeos_c" >&5
 $as_echo_n "checking for GEOSversion in -lgeos_c... " >&6; }
@@ -38971,6 +38973,7 @@ fi
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
+      LDFLAGS="${ax_save_LDFLAGS}"
 
     fi
 
@@ -39204,6 +39207,8 @@ $as_echo "$as_me: WARNING: SFCGAL was found on your system, but sfcgal-config re
       LIBS=${SFCGAL_LIBS}
       ax_save_CFLAGS="${CFLAGS}"
       CFLAGS="${SFCGAL_CFLAGS}"
+      ax_save_LDFLAGS="${LDFLAGS}"
+      LDFLAGS=""
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sfcgal_version in -lSFCGAL" >&5
 $as_echo_n "checking for sfcgal_version in -lSFCGAL... " >&6; }
@@ -39256,6 +39261,7 @@ fi
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
+      LDFLAGS="${ax_save_LDFLAGS}"
 
     fi
 

--- a/gdal/m4/geos.m4
+++ b/gdal/m4/geos.m4
@@ -59,7 +59,9 @@ AC_DEFUN([GEOS_INIT],[
   elif test x"$with_geos" = x"yes" -o x"$with_geos" = x"" ; then
 
     AC_PATH_PROG(GEOS_CONFIG, geos-config, no)
-    ac_geos_config_auto=yes
+    if test x"$with_geos" = x"" ; then
+      ac_geos_config_auto=yes
+    fi
 
   else
 
@@ -140,13 +142,26 @@ AC_DEFUN([GEOS_INIT],[
       )
 
       if test x"$HAVE_GEOS" = "xno"; then
-          GEOS_CFLAGS=""
+        if test $ac_geos_config_auto = "yes" ; then
+          AC_MSG_WARN([GEOS was found on your system, but the library could not be linked. GEOS support disabled.])
+        else
+          AC_MSG_ERROR([GEOS library could not be linked])
+        fi
+
+        GEOS_CFLAGS=""
+
       fi
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
       LDFLAGS="${ax_save_LDFLAGS}"
 
+    fi
+
+  else
+
+    if test $ac_geos_config_auto = "no" ; then
+      AC_MSG_ERROR([GEOS support explicitly enabled, but geos-config could not be found])
     fi
 
   fi

--- a/gdal/m4/geos.m4
+++ b/gdal/m4/geos.m4
@@ -129,6 +129,8 @@ AC_DEFUN([GEOS_INIT],[
       LIBS=${GEOS_LIBS}
       ax_save_CFLAGS="${CFLAGS}"
       CFLAGS="${GEOS_CFLAGS}"
+      ax_save_LDFLAGS="${LDFLAGS}"
+      LDFLAGS=""
 
       AC_CHECK_LIB([geos_c],
         [GEOSversion],
@@ -143,6 +145,7 @@ AC_DEFUN([GEOS_INIT],[
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
+      LDFLAGS="${ax_save_LDFLAGS}"
 
     fi
 

--- a/gdal/m4/sfcgal.m4
+++ b/gdal/m4/sfcgal.m4
@@ -58,7 +58,9 @@ AC_DEFUN([SFCGAL_INIT],[
   elif test x"$with_sfcgal" = x"yes" -o x"$with_sfcgal" = x"" ; then
 
     AC_PATH_PROG(SFCGAL_CONFIG, sfcgal-config, no)
-    ac_sfcgal_config_auto=yes
+    if test x"$with_sfcgal" = x"" ; then
+      ac_sfcgal_config_auto=yes
+    fi
 
   else
 
@@ -140,13 +142,25 @@ AC_DEFUN([SFCGAL_INIT],[
 
 
       if test x"$HAVE_SFCGAL" = "xno"; then
-          SFCGAL_CFLAGS=""
+        if test $ac_sfcgal_config_auto = "yes" ; then
+          AC_MSG_WARN([SFCGAL was found on your system, but the library could not be linked. SFCGAL support disabled.])
+        else
+          AC_MSG_ERROR([SFCGAL library could not be linked])
+        fi
+
+        SFCGAL_CFLAGS=""
       fi
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
       LDFLAGS="${ax_save_LDFLAGS}"
 
+    fi
+
+  else
+
+    if test $ac_sfcgal_config_auto = "no" ; then
+      AC_MSG_ERROR([SFCGAL support explicitly enabled, but sfcgal-config could not be found])
     fi
 
   fi

--- a/gdal/m4/sfcgal.m4
+++ b/gdal/m4/sfcgal.m4
@@ -128,6 +128,8 @@ AC_DEFUN([SFCGAL_INIT],[
       LIBS=${SFCGAL_LIBS}
       ax_save_CFLAGS="${CFLAGS}"
       CFLAGS="${SFCGAL_CFLAGS}"
+      ax_save_LDFLAGS="${LDFLAGS}"
+      LDFLAGS=""
 
       AC_CHECK_LIB([SFCGAL],
         [sfcgal_version],
@@ -143,6 +145,7 @@ AC_DEFUN([SFCGAL_INIT],[
 
       CFLAGS="${ax_save_CFLAGS}"
       LIBS="${ax_save_LIBS}"
+      LDFLAGS="${ax_save_LDFLAGS}"
 
     fi
 


### PR DESCRIPTION
## What does this PR do?

This fixes a couple of bugs with finding GEOS and SFCGAL. Firstly, if `--with-geos` or `--with-sfcgal` are passed, but failed to be found, this was silently ignored. This should only happen if the option is 'auto', or people might think things were correctly found when they weren't. Secondly, it also saves `LDFLAGS` when testing compilability, as sometimes flags in `CFLAGS` and `LDFLAGS` go together. 

## What are related issues/pull requests?

## Tasklist

 - [n/a] Add test case(s)
 - [n/a] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler: