### PR TITLE
Fix typo in csv.rst

### DIFF
--- a/gdal/doc/source/drivers/vector/csv.rst
+++ b/gdal/doc/source/drivers/vector/csv.rst
@@ -160,8 +160,8 @@ Y_POSSIBLE_NAMES=Lat\* -oo KEEP_GEOM_COLUMNS=NO* will return :
      Name (String) = Third point
      POINT (0.75 47.5)
      
-If CSV file does not have a header line the dummy "field_n" names can be
-used as possible names for coordinate fieds. For example plain XYZ point 
+If CSV file does not have a header line, the dummy "field_n" names can be
+used as possible names for coordinate fields. For example plain XYZ point 
 data can be opened as
 
 *ogrinfo -ro -al elevation.xyz -oo X_POSSIBLE_NAMES=field_1 -oo


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fix a typo in the docs