### PR TITLE
python: Remove deprecated NumPy aliases for standard types.

### DIFF
--- a/autotest/gcore/hfa_rfc40.py
+++ b/autotest/gcore/hfa_rfc40.py
@@ -190,7 +190,7 @@ def ReadAndCheckValues(fname, numrows):
         raise HFATestError("double column does not match")
 
     data = rat.ReadAsArray(2, 0, 10)
-    if not (data == STRING_DATA.astype(numpy.character)).all():
+    if not (data == STRING_DATA.astype(bytes)).all():
         raise HFATestError("string column does not match")
 
     data = rat.ReadAsArray(3, 0, 10)
@@ -198,7 +198,7 @@ def ReadAndCheckValues(fname, numrows):
         raise HFATestError("int as double column does not match")
 
     data = rat.ReadAsArray(4, 0, 10)
-    if not (data == STRING_DATA_INTS.astype(numpy.int)).all():
+    if not (data == STRING_DATA_INTS.astype(int)).all():
         raise HFATestError("int as string column does not match")
 
     data = rat.ReadAsArray(5, 0, 10)
@@ -210,7 +210,7 @@ def ReadAndCheckValues(fname, numrows):
         raise HFATestError("double as string column does not match")
 
     data = rat.ReadAsArray(7, 0, 10)
-    if not (data.astype(numpy.int) == INT_DATA).all():
+    if not (data.astype(int) == INT_DATA).all():
         raise HFATestError("string as int column does not match")
 
     data = rat.ReadAsArray(8, 0, 10)
@@ -301,7 +301,7 @@ def CheckExtension(fname):
         raise HFATestError("Double column does not match")
 
     data = rat.ReadAsArray(2, 10, 10)
-    if not (data == STRING_DATA.astype(numpy.character)).all():
+    if not (data == STRING_DATA.astype(bytes)).all():
         raise HFATestError("String column does not match")
 
     # print('extension data ok')
@@ -329,7 +329,7 @@ def CheckLongStrings(fname):
     rat = band.GetDefaultRAT()
 
     data = rat.ReadAsArray(2, 10, 10)
-    if not (data == LONG_STRING_DATA.astype(numpy.character)).all():
+    if not (data == LONG_STRING_DATA.astype(bytes)).all():
         raise HFATestError("String column does not match")
 
     # print("checked long strings ok")

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1715,7 +1715,7 @@ def RATWriteArray(rat, array, field, start=0):
         array = array.astype(numpy.double)
     elif numpy.issubdtype(array.dtype, numpy.character):
         # cast away any kind of Unicode etc
-        array = array.astype(numpy.character)
+        array = array.astype(bytes)
     else:
         raise ValueError("Array not of a supported type (integer, double or string)")
 

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1167,7 +1167,7 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
       if mask is not None:
           array = self.ReadAsArray(array_start_idx, count, array_step)
           mask_array = mask.ReadAsArray(array_start_idx, count, array_step)
-          bool_array = ~mask_array.astype(numpy.bool)
+          bool_array = ~mask_array.astype(bool)
           return numpy.ma.array(array, mask=bool_array)
       else:
           return numpy.ma.array(self.ReadAsArray(array_start_idx, count, array_step), mask=None)

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -3141,7 +3141,7 @@ class MDArray(_object):
         if mask is not None:
             array = self.ReadAsArray(array_start_idx, count, array_step)
             mask_array = mask.ReadAsArray(array_start_idx, count, array_step)
-            bool_array = ~mask_array.astype(numpy.bool)
+            bool_array = ~mask_array.astype(bool)
             return numpy.ma.array(array, mask=bool_array)
         else:
             return numpy.ma.array(self.ReadAsArray(array_start_idx, count, array_step), mask=None)

--- a/gdal/swig/python/osgeo/gdal_array.py
+++ b/gdal/swig/python/osgeo/gdal_array.py
@@ -552,7 +552,7 @@ def RATWriteArray(rat, array, field, start=0):
         array = array.astype(numpy.double)
     elif numpy.issubdtype(array.dtype, numpy.character):
 # cast away any kind of Unicode etc
-        array = array.astype(numpy.character)
+        array = array.astype(bytes)
     else:
         raise ValueError("Array not of a supported type (integer, double or string)")
 


### PR DESCRIPTION
## What does this PR do?

Removes usage of the deprecated aliases in NumPy for types that are standard in Python. 

## What are related issues/pull requests?

Fixes #3444.

## Tasklist

 - [n/a] Add test case(s)
 - [n/a] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
