### PR TITLE
GTiff: allow customising overview compression type (fixes #3453) 

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -268,16 +268,18 @@ def test_cog_creation_of_overviews_with_compression():
                             options='-of MEM -outsize 2048 300')
 
     ds = gdal.GetDriverByName('COG').CreateCopy(filename, src_ds,
-                                            options = ['COMPRESS=LZW', 'OVERVIEW_COMPRESS=JPEG'])
+                                            options = ['COMPRESS=LZW', 'OVERVIEW_COMPRESS=JPEG', 'OVERVIEW_QUALITY=50'])
 
     assert ds.GetRasterBand(1).GetOverviewCount() == 2
     assert ds.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'LZW'
 
     ds_overview_a = gdal.Open('GTIFF_DIR:2:' + filename)
     assert ds_overview_a.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
+    assert ds_overview_a.GetMetadata('IMAGE_STRUCTURE')['JPEG_QUALITY'] == '50'
 
     ds_overview_b = gdal.Open('GTIFF_DIR:3:' + filename)
     assert ds_overview_b.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
+    assert ds_overview_a.GetMetadata('IMAGE_STRUCTURE')['JPEG_QUALITY'] == '50'
 
     ds_overview_a = None
     ds_overview_b = None

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -273,6 +273,15 @@ def test_cog_creation_of_overviews_with_compression():
 
         assert ds.GetRasterBand(1).GetOverviewCount() == 2
         assert ds.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'LZW'
+
+        ds_overview_a = gdal.Open('GTIFF_DIR:2:' + filename)
+        assert ds_overview_a.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
+
+        ds_overview_b = gdal.Open('GTIFF_DIR:3:' + filename)
+        assert ds_overview_b.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
+
+        ds_overview_a = None
+        ds_overview_b = None
         ds = None
 
     src_ds = None

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -267,22 +267,21 @@ def test_cog_creation_of_overviews_with_compression():
     src_ds = gdal.Translate('', 'data/byte.tif',
                             options='-of MEM -outsize 2048 300')
 
-    with gdaltest.config_option('COMPRESS_OVERVIEW', 'JPEG'):
-        ds = gdal.GetDriverByName('COG').CreateCopy(filename, src_ds,
-                                                options = ['COMPRESS=LZW'])
+    ds = gdal.GetDriverByName('COG').CreateCopy(filename, src_ds,
+                                            options = ['COMPRESS=LZW', 'OVERVIEW_COMPRESS=JPEG'])
 
-        assert ds.GetRasterBand(1).GetOverviewCount() == 2
-        assert ds.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'LZW'
+    assert ds.GetRasterBand(1).GetOverviewCount() == 2
+    assert ds.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'LZW'
 
-        ds_overview_a = gdal.Open('GTIFF_DIR:2:' + filename)
-        assert ds_overview_a.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
+    ds_overview_a = gdal.Open('GTIFF_DIR:2:' + filename)
+    assert ds_overview_a.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
 
-        ds_overview_b = gdal.Open('GTIFF_DIR:3:' + filename)
-        assert ds_overview_b.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
+    ds_overview_b = gdal.Open('GTIFF_DIR:3:' + filename)
+    assert ds_overview_b.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'JPEG'
 
-        ds_overview_a = None
-        ds_overview_b = None
-        ds = None
+    ds_overview_a = None
+    ds_overview_b = None
+    ds = None
 
     src_ds = None
     gdal.GetDriverByName('GTiff').Delete(filename)

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -258,6 +258,27 @@ def test_cog_creation_of_overviews():
     gdal.GetDriverByName('GTiff').Delete(filename)
     gdal.Unlink(directory)
 
+###############################################################################
+# Test creation of overviews with a different compression method
+
+def test_cog_creation_of_overviews_with_compression():
+    directory = '/vsimem/test_cog_creation_of_overviews_with_compression'
+    filename = directory + '/cog.tif'
+    src_ds = gdal.Translate('', 'data/byte.tif',
+                            options='-of MEM -outsize 2048 300')
+
+    with gdaltest.config_option('COMPRESS_OVERVIEW', 'JPEG'):
+        ds = gdal.GetDriverByName('COG').CreateCopy(filename, src_ds,
+                                                options = ['COMPRESS=LZW'])
+
+        assert ds.GetRasterBand(1).GetOverviewCount() == 2
+        assert ds.GetMetadata('IMAGE_STRUCTURE')['COMPRESSION'] == 'LZW'
+        ds = None
+
+    src_ds = None
+    gdal.GetDriverByName('GTiff').Delete(filename)
+    gdal.Unlink(directory)
+
 
 ###############################################################################
 # Test creation of overviews with a dataset with a mask

--- a/gdal/doc/source/drivers/raster/cog.rst
+++ b/gdal/doc/source/drivers/raster/cog.rst
@@ -234,6 +234,26 @@ Reprojection related creation options
 - **ADD_ALPHA=YES/NO**: Whether an alpha band is added in case of reprojection.
   Defaults to YES.
 
+Configuration options
+---------------------
+
+COG Overview creation can be configured with the :ref:`raster.gtiff` driver creation options
+
+-  **`COMPRESS_OVERVIEW`**:  See `Creation Options COMPRESS <#creation-options>`__ section.
+   Set the compression type to use for overviews
+-  **`PREDICTOR_OVERVIEW`**: Integer 1,2 or 3.
+   Set the predictor to use for overviews with LZW, DEFLATE and ZSTD compression
+-  **`JPEG_QUALITY_OVERVIEW`**: Integer between 0 and 100. Default value : 75.
+   Quality of JPEG compressed overviews, either internal or external.
+-  **`WEBP_LEVEL_OVERVIEW`**: Integer between 1 and 100. Default value : 75.
+   WEBP quality level of overviews, either internal or external.
+
+Example create a COG with the source data compressed as LZW and overviews compressed with WEBP with a WEBP quality of 90
+
+::
+
+    gdal_translate world.tif world_webmerc_cog.tif -of COG -co COMPRESS=LZW --config COMPRESS_OVERVIEW WEBP --config WEBP_LEVEL_OVERVIEW 90
+
 File format details
 -------------------
 

--- a/gdal/doc/source/drivers/raster/cog.rst
+++ b/gdal/doc/source/drivers/raster/cog.rst
@@ -237,7 +237,7 @@ Reprojection related creation options
 Configuration options
 ---------------------
 
-COG Overview creation can be configured with the :ref:`raster.gtiff` driver creation options
+COG Overview creation can be configured with the :ref:`raster.gtiff` driver configuration options (typically specified with ``--config NAME VALUE`` syntax)
 
 -  **`COMPRESS_OVERVIEW`**:  See `Creation Options COMPRESS <#creation-options>`__ section.
    Set the compression type to use for overviews

--- a/gdal/doc/source/drivers/raster/cog.rst
+++ b/gdal/doc/source/drivers/raster/cog.rst
@@ -164,14 +164,14 @@ General creation options
   Set the compression method to use when storing the overviews in the COG.
 
 - **OVERVIEW_QUALITY=integer_value**: JPEG/WEBP quality setting. A value of 100 is best
-   quality (least compression), and 1 is worst quality (best compression).
-   By default the overviews will be created with the same quality as the COG, unless 
-   the compression type is different then the default is 75.  
+  quality (least compression), and 1 is worst quality (best compression).
+  By default the overviews will be created with the same quality as the COG, unless
+  the compression type is different then the default is 75.
 
 - **OVERVIEW_PREDICTOR=[YES/NO/STANDARD/FLOATING_POINT]**: Set the predictor for LZW,
-   DEFLATE and ZSTD overview compression. By default the overviews will be created with the
-   same predictor as the COG, unless the compression type of the overview is different,
-   then the default is NO.  
+  DEFLATE and ZSTD overview compression. By default the overviews will be created with the
+  same predictor as the COG, unless the compression type of the overview is different,
+  then the default is NO.
 
 - **GEOTIFF_VERSION=[AUTO/1.0/1.1]**: Select the version of
   the GeoTIFF standard used to encode georeferencing information. ``1.0``

--- a/gdal/doc/source/drivers/raster/cog.rst
+++ b/gdal/doc/source/drivers/raster/cog.rst
@@ -237,7 +237,7 @@ Reprojection related creation options
 Configuration options
 ---------------------
 
-COG Overview creation can be configured with the :ref:`raster.gtiff` driver configuration options (typically specified with ``--config NAME VALUE`` syntax)
+By default the COG driver creates overviews with the same compression method than the full resolution image. The default behavior can be changed with the :ref:raster.gtiff driver configuration options (typically specified with --config NAME VALUE syntax).
 
 -  **`COMPRESS_OVERVIEW`**:  See `Creation Options COMPRESS <#creation-options>`__ section.
    Set the compression type to use for overviews

--- a/gdal/doc/source/drivers/raster/cog.rst
+++ b/gdal/doc/source/drivers/raster/cog.rst
@@ -160,6 +160,19 @@ General creation options
         available if general options (i.e. options which are not creation options,
         like subsetting, etc.) are used.
 
+- **OVERVIEW_COMPRESS**=[AUTO/NONE/LZW/JPEG/DEFLATE/ZSTD/WEBP/LERC/LERC_DEFLATE/LERC_ZSTD]**:
+  Set the compression method to use when storing the overviews in the COG.
+
+- **OVERVIEW_QUALITY=integer_value**: JPEG/WEBP quality setting. A value of 100 is best
+   quality (least compression), and 1 is worst quality (best compression).
+   By default the overviews will be created with the same quality as the COG, unless 
+   the compression type is different then the default is 75.  
+
+- **OVERVIEW_PREDICTOR=[YES/NO/STANDARD/FLOATING_POINT]**: Set the predictor for LZW,
+   DEFLATE and ZSTD overview compression. By default the overviews will be created with the
+   same predictor as the COG, unless the compression type of the overview is different,
+   then the default is NO.  
+
 - **GEOTIFF_VERSION=[AUTO/1.0/1.1]**: Select the version of
   the GeoTIFF standard used to encode georeferencing information. ``1.0``
   corresponds to the original
@@ -234,25 +247,6 @@ Reprojection related creation options
 - **ADD_ALPHA=YES/NO**: Whether an alpha band is added in case of reprojection.
   Defaults to YES.
 
-Configuration options
----------------------
-
-By default the COG driver creates overviews with the same compression method than the full resolution image. The default behavior can be changed with the :ref:raster.gtiff driver configuration options (typically specified with --config NAME VALUE syntax).
-
--  **`COMPRESS_OVERVIEW`**:  See `Creation Options COMPRESS <#creation-options>`__ section.
-   Set the compression type to use for overviews
--  **`PREDICTOR_OVERVIEW`**: Integer 1,2 or 3.
-   Set the predictor to use for overviews with LZW, DEFLATE and ZSTD compression
--  **`JPEG_QUALITY_OVERVIEW`**: Integer between 0 and 100. Default value : 75.
-   Quality of JPEG compressed overviews, either internal or external.
--  **`WEBP_LEVEL_OVERVIEW`**: Integer between 1 and 100. Default value : 75.
-   WEBP quality level of overviews, either internal or external.
-
-Example create a COG with the source data compressed as LZW and overviews compressed with WEBP with a WEBP quality of 90
-
-::
-
-    gdal_translate world.tif world_webmerc_cog.tif -of COG -co COMPRESS=LZW --config COMPRESS_OVERVIEW WEBP --config WEBP_LEVEL_OVERVIEW 90
 
 File format details
 -------------------

--- a/gdal/doc/source/drivers/raster/cog.rst
+++ b/gdal/doc/source/drivers/raster/cog.rst
@@ -160,7 +160,7 @@ General creation options
         available if general options (i.e. options which are not creation options,
         like subsetting, etc.) are used.
 
-- **OVERVIEW_COMPRESS**=[AUTO/NONE/LZW/JPEG/DEFLATE/ZSTD/WEBP/LERC/LERC_DEFLATE/LERC_ZSTD]**:
+- **OVERVIEW_COMPRESS=[AUTO/NONE/LZW/JPEG/DEFLATE/ZSTD/WEBP/LERC/LERC_DEFLATE/LERC_ZSTD]**:
   Set the compression method to use when storing the overviews in the COG.
 
 - **OVERVIEW_QUALITY=integer_value**: JPEG/WEBP quality setting. A value of 100 is best

--- a/gdal/doc/source/drivers/raster/gtiff.rst
+++ b/gdal/doc/source/drivers/raster/gtiff.rst
@@ -666,6 +666,10 @@ the default behavior of the GTiff driver.
    partially corrupted TIFF files
 -  :decl_configoption:`ESRI_XML_PAM` : Can be set to TRUE to force metadata in the xml:ESRI
    domain to be written to PAM.
+-  :decl_configoption:`COMPRESS_OVERVIEW` :  See `Creation Options COMPRESS <#creation-options>`__ section.
+   Set the compression type to use for overviews
+-  :decl_configoption:`PREDICTOR_OVERVIEW` : Integer 1,2 or 3.
+   Set the predictor to use for overviews with LZW, DEFLATE and ZSTD compression
 -  :decl_configoption:`JPEG_QUALITY_OVERVIEW` : Integer between 0 and 100. Default value : 75.
    Quality of JPEG compressed overviews, either internal or external.
 -  :decl_configoption:`WEBP_LEVEL_OVERVIEW` : Integer between 1 and 100. Default value : 75.

--- a/gdal/doc/source/drivers/raster/gtiff.rst
+++ b/gdal/doc/source/drivers/raster/gtiff.rst
@@ -668,6 +668,8 @@ the default behavior of the GTiff driver.
    domain to be written to PAM.
 -  :decl_configoption:`COMPRESS_OVERVIEW` :  See `Creation Options COMPRESS <#creation-options>`__ section.
    Set the compression type to use for overviews
+-  :decl_configoption:`PHOTOMETRIC_OVERVIEW` :  YCBCR
+   Set the photometric color space for overview creation
 -  :decl_configoption:`PREDICTOR_OVERVIEW` : Integer 1,2 or 3.
    Set the predictor to use for overviews with LZW, DEFLATE and ZSTD compression
 -  :decl_configoption:`JPEG_QUALITY_OVERVIEW` : Integer between 0 and 100. Default value : 75.

--- a/gdal/frmts/gtiff/cogdriver.cpp
+++ b/gdal/frmts/gtiff/cogdriver.cpp
@@ -90,6 +90,8 @@ static const char* GetResampling(GDALDataset* poSrcDS)
 static const char* GetPredictor(GDALDataset* poSrcDS, 
                                 const char* pszPredictor) 
 {
+    if (pszPredictor == nullptr) return nullptr;
+
     if( EQUAL(pszPredictor, "YES") || EQUAL(pszPredictor, "ON") || EQUAL(pszPredictor, "TRUE") )
     {
         if( GDALDataTypeIsFloating(poSrcDS->GetRasterBand(1)->GetRasterDataType()) )

--- a/gdal/frmts/gtiff/cogdriver.cpp
+++ b/gdal/frmts/gtiff/cogdriver.cpp
@@ -1141,21 +1141,34 @@ void GDALCOGDriver::InitializeCreationOptionList()
                 "   <Option name='COMPRESS' type='string-select'>";
     osOptions += osCompressValues;
     osOptions += "   </Option>";
+
+    osOptions += "   <Option name='OVERVIEW_COMPRESS' type='string-select'>";
+    osOptions += osCompressValues;
+    osOptions += "   </Option>";
+
     if( bHasLZW || bHasDEFLATE || bHasZSTD )
     {
-        osOptions += "   <Option name='LEVEL' type='int' "
-            "description='DEFLATE/ZSTD compression level: 1 (fastest)'/>";
-        osOptions += "   <Option name='PREDICTOR' type='string-select' default='FALSE'>"
-                     "     <Value>YES</Value>"
+        const char* osPredictorOptions =  "     <Value>YES</Value>"
                      "     <Value>NO</Value>"
                      "     <Value alias='2'>STANDARD</Value>"
-                     "     <Value alias='3'>FLOATING_POINT</Value>"
-                     "   </Option>";
+                     "     <Value alias='3'>FLOATING_POINT</Value>";
+
+        osOptions += "   <Option name='LEVEL' type='int' "
+            "description='DEFLATE/ZSTD compression level: 1 (fastest)'/>";
+
+        osOptions += "   <Option name='PREDICTOR' type='string-select' default='FALSE'>";
+        osOptions += osPredictorOptions;
+        osOptions += "   </Option>"
+                "   <Option name='OVERVIEW_PREDICTOR' type='string-select' default='FALSE'>";
+        osOptions += osPredictorOptions;
+        osOptions += "   </Option>";
     }
     if( bHasJPEG || bHasWebP )
     {
         osOptions += "   <Option name='QUALITY' type='int' "
-                     "description='JPEG/WEBP quality 1-100' default='75'/>";
+                     "description='JPEG/WEBP quality 1-100' default='75'/>"
+                     "   <Option name='OVERVIEW_QUALITY' type='int'"
+                     "description='Overview JPEG/WEBP quality 1-100' default='75'/>";
     }
 #ifdef HAVE_LERC
     osOptions += ""

--- a/gdal/frmts/gtiff/cogdriver.cpp
+++ b/gdal/frmts/gtiff/cogdriver.cpp
@@ -1011,6 +1011,36 @@ GDALDataset* GDALCOGCreator::Create(const char * pszFilename,
          }
     }
 
+    const char* osOvrCompress = CSLFetchNameValueDef(papszOptions, "OVERVIEW_COMPRESS", "AUTO");
+    if ( !EQUAL(osOvrCompress, "AUTO") ) 
+    {
+        CPLSetConfigOption("COMPRESS_OVERVIEW", osOvrCompress);
+    }
+
+    const char* osOvrQuality = CSLFetchNameValueDef(papszOptions, "OVERVIEW_QUALITY", "AUTO");
+    if ( !EQUAL(osOvrQuality, "AUTO") ) 
+    {
+        CPLSetConfigOption("JPEG_QUALITY_OVERVIEW", osOvrCompress);
+        CPLSetConfigOption("WEBP_LEVEL_OVERVIEW", osOvrCompress);
+    }
+
+    const char* osOvrPredictor = CSLFetchNameValueDef(papszOptions, "OVERVIEW_PREDICTOR", "FALSE");
+    if( EQUAL(osOvrPredictor, "YES") || EQUAL(osOvrPredictor, "ON") || EQUAL(osOvrPredictor, "TRUE") )
+    {
+        if( GDALDataTypeIsFloating(poSrcDS->GetRasterBand(1)->GetRasterDataType()) )
+            CPLSetConfigOption("PREDICTOR_OVERVIEW", "3");
+        else
+            CPLSetConfigOption("PREDICTOR_OVERVIEW", "2");
+    }
+    else if( EQUAL(osOvrPredictor, "STANDARD") || EQUAL(osOvrPredictor, "2") )
+    {
+        CPLSetConfigOption("PREDICTOR_OVERVIEW", "2");
+    }
+    else if( EQUAL(osOvrPredictor, "FLOATING_POINT") || EQUAL(osOvrPredictor, "3") )
+    {
+        CPLSetConfigOption("PREDICTOR_OVERVIEW", "3");
+    }
+
     GDALDriver* poGTiffDrv = GDALDriver::FromHandle(GDALGetDriverByName("GTiff"));
     if( !poGTiffDrv )
         return nullptr;

--- a/gdal/frmts/gtiff/cogdriver.cpp
+++ b/gdal/frmts/gtiff/cogdriver.cpp
@@ -1159,7 +1159,7 @@ void GDALCOGDriver::InitializeCreationOptionList()
         osOptions += "   <Option name='PREDICTOR' type='string-select' default='FALSE'>";
         osOptions += osPredictorOptions;
         osOptions += "   </Option>"
-                "   <Option name='OVERVIEW_PREDICTOR' type='string-select' default='FALSE'>";
+                     "   <Option name='OVERVIEW_PREDICTOR' type='string-select' default='FALSE'>";
         osOptions += osPredictorOptions;
         osOptions += "   </Option>";
     }
@@ -1167,7 +1167,7 @@ void GDALCOGDriver::InitializeCreationOptionList()
     {
         osOptions += "   <Option name='QUALITY' type='int' "
                      "description='JPEG/WEBP quality 1-100' default='75'/>"
-                     "   <Option name='OVERVIEW_QUALITY' type='int'"
+                     "   <Option name='OVERVIEW_QUALITY' type='int' "
                      "description='Overview JPEG/WEBP quality 1-100' default='75'/>";
     }
 #ifdef HAVE_LERC

--- a/gdal/frmts/gtiff/cogdriver.cpp
+++ b/gdal/frmts/gtiff/cogdriver.cpp
@@ -1027,10 +1027,17 @@ GDALDataset* GDALCOGCreator::Create(const char * pszFilename,
                                      CPLSPrintf("%d", nAlignedLevels));
          }
     }
+    const char* pszOverviewCompress = CSLFetchNameValue(papszOptions, "OVERVIEW_COMPRESS");
 
-    CPLConfigOptionSetter ovrCompressSetter("COMPRESS_OVERVIEW", CSLFetchNameValue(papszOptions, "OVERVIEW_COMPRESS"), true);
+    CPLConfigOptionSetter ovrCompressSetter("COMPRESS_OVERVIEW", pszOverviewCompress, true);
     CPLConfigOptionSetter ovrQualityJpegSetter("JPEG_QUALITY_OVERVIEW", CSLFetchNameValue(papszOptions, "OVERVIEW_QUALITY"), true);
     CPLConfigOptionSetter ovrQualityWebpSetter("WEBP_LEVEL_OVERVIEW", CSLFetchNameValue(papszOptions, "OVERVIEW_QUALITY"), true);
+
+    std::unique_ptr<CPLConfigOptionSetter> poPhotometricSetter;
+    if (pszOverviewCompress != nullptr && nBands == 3 && EQUAL(pszOverviewCompress, "JPEG") ) 
+    {
+        poPhotometricSetter.reset(new CPLConfigOptionSetter("PHOTOMETRIC_OVERVIEW", "YCBCR", true));
+    }
 
     const char* osOvrPredictor = CSLFetchNameValueDef(papszOptions, "OVERVIEW_PREDICTOR", "FALSE");
     const char* pszOvrPredictorValue = GetPredictor(poSrcDS, osOvrPredictor);

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -10268,7 +10268,7 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS,
     {
         if ( CPLGetConfigOption( "PREDICTOR_OVERVIEW", nullptr ) != nullptr ) 
         {
-            nPredictor = atoi(CPLGetConfigOption("PREDICTOR_OVERVIEW","1"));
+            nPredictor = static_cast<uint16>(atoi(CPLGetConfigOption("PREDICTOR_OVERVIEW","1")));
         } 
         else 
         {

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -10268,7 +10268,7 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS,
     {
         if ( CPLGetConfigOption( "PREDICTOR_OVERVIEW", nullptr ) != nullptr ) 
         {
-            nPredictor = atoi(CPLGetConfigOption("PREDICTOR_OVERVIEW","1"))
+            nPredictor = atoi(CPLGetConfigOption("PREDICTOR_OVERVIEW","1"));
         } 
         else 
         {


### PR DESCRIPTION
## What does this PR do?

Adds `COMPRESS_OVERVIEW` as a configuration option for GTiff overview creation

## What are related issues/pull requests?

#3453

## Tasklist

 - [x] Allow compression selection for overview creation
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
