### PR TITLE
/vsis3/ sync: improve upload performance by setting the default number of threads and increase the chunk size

### DIFF
--- a/gdal/port/cpl_vsil.cpp
+++ b/gdal/port/cpl_vsil.cpp
@@ -662,15 +662,15 @@ int VSIRename( const char * oldpath, const char * newpath )
  *     The OVERWRITE strategy (GDAL >= 3.2) will always overwrite the target file
  *     with the source one.
  * </li>
- * <li>NUM_THREADS=integer. Number of threads to use for parallel file copying.
+ * <li>NUM_THREADS=integer. (GDAL >= 3.1) Number of threads to use for parallel file copying.
  *     Only use for when /vsis3/, /vsigs/, /vsiaz/ or /vsiadls/ is in source or target.
- *     Since GDAL 3.1</li>
- * <li>CHUNK_SIZE=integer. Maximum size of chunk (in bytes) to use to split
+ *     The default is 10 since GDAL 3.3</li>
+ * <li>CHUNK_SIZE=integer. (GDAL >= 3.1) Maximum size of chunk (in bytes) to use to split
  *     large objects when downloading them from /vsis3/, /vsigs/, /vsiaz/ or /vsiadls/ to
  *     local file system, or for upload to /vsis3/, /vsiaz/ or /vsiadls/ from local file system.
  *     Only used if NUM_THREADS > 1.
  *     For upload to /vsis3/, this chunk size must be set at least to 5 MB.
- *     Since GDAL 3.1</li>
+ *     The default is 8 MB since GDAL 3.3</li>
  * </ul>
  * @param pProgressFunc Progress callback, or NULL.
  * @param pProgressData User data of progress callback, or NULL.

--- a/gdal/port/cpl_vsil_s3.cpp
+++ b/gdal/port/cpl_vsil_s3.cpp
@@ -3552,14 +3552,19 @@ bool IVSIS3LikeFSHandler::Sync( const char* pszSource, const char* pszTarget,
     std::vector<ChunkToCopy> aoChunksToCopy;
     std::set<CPLString> aoSetDirsToCreate;
     const char* pszChunkSize = CSLFetchNameValue(papszOptions, "CHUNK_SIZE");
+#if !defined(CPL_MULTIPROC_STUB)
+    // 10 threads used by default by the Python s3transfer library
+    const int nRequestedThreads = atoi(CSLFetchNameValueDef(papszOptions, "NUM_THREADS", "10"));
+#else
     const int nRequestedThreads = atoi(CSLFetchNameValueDef(papszOptions, "NUM_THREADS", "1"));
+#endif
     auto poTargetFSHandler = dynamic_cast<IVSIS3LikeFSHandler*>(
                                     VSIFileManager::GetHandler( pszTarget ));
     const bool bSupportsParallelMultipartUpload =
         bUploadFromLocalToNetwork && poTargetFSHandler != nullptr &&
         poTargetFSHandler->SupportsParallelMultipartUpload();
     const bool bSimulateThreading = CPLTestBool(CPLGetConfigOption("VSIS3_SIMULATE_THREADING", "NO"));
-    const int nMinSizeChunk = bSupportsParallelMultipartUpload && !bSimulateThreading ? 5242880 : 1; // 5242880 defines by S3 API
+    const int nMinSizeChunk = bSupportsParallelMultipartUpload && !bSimulateThreading ? 8 * 1024 * 1024 : 1; // 5242880 defined by S3 API as the minimum, but 8 MB used by default by the Python s3transfer library
     const int nMinThreads = bSimulateThreading ? 0 : 1;
     const size_t nMaxChunkSize =
         pszChunkSize && nRequestedThreads > nMinThreads &&


### PR DESCRIPTION
Was tested by uploading a set of "small files" and "big files" from local storage to S3

Test files were generated with:

```
import shutil
import os

dirname = 'small_files'
if not os.path.exists(dirname):
    os.mkdir(dirname, 0o755)

    for z in range(10):
        zdirname = dirname + ('/%02d' %z)
        os.mkdir(zdirname, 0o755)
        for y in range(10):
            ydirname = zdirname + ('/%02d' %y)
            os.mkdir(ydirname, 0o755)
            for x in range(10):
                newfile = open(ydirname + ("/testfile.%02d" % x), "wb")
                newfile.write (os.urandom(100 * 1024))
                newfile.close ()

dirname = 'large_files'
if not os.path.exists(dirname):
    os.mkdir(dirname, 0o755)

    for x in range(10):
        newfile = open(dirname + ("/testfile.%02d" % x), "wb")
        newfile.write (os.urandom(100 * 1024 * 1024))
        newfile.close ()
```

And then comparing timing of:
```
time aws s3 cp --quiet --recursive small_files/ s3://bucket/small_files
```
with
```
time python3 -c "from osgeo import gdal; gdal.Sync('small_files','/vsis3/bucket/small_files', options=['NUM_THREADS=10', 'CHUNCK_SIZE=8388608'])"
```

After the changes, on a t2.xlarge EC2 instance (4 CPUs, moderate network bandwidth):

```
$ time aws s3 cp --quiet --recursive small_files/ s3://bucket/small_files

real	0m9.188s
user	0m8.973s
sys	0m3.861s
```

```
$ time python3 -c "from osgeo import gdal; gdal.Sync('small_files','/vsis3/bucket/small_files')"

real	0m10.310s
user	0m1.279s
sys	0m0.344s
```

```
$ time aws s3 cp --quiet --recursive large_files/ s3://bucket/large_files

real	0m11.455s
user	0m9.664s
sys	0m3.600s
```

```
$ time python3 -c "from osgeo import gdal; gdal.Sync('large_files','/vsis3/bucket/large_files')"

real	0m11.677s
user	0m8.561s
sys	0m0.927s
```
