### PR TITLE
autotest: Simplify some test skipping

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1685,10 +1685,7 @@ def test_warp_55():
 
 def test_warp_56():
 
-    try:
-        import numpy
-    except (ImportError, AttributeError):
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     pix_ds = gdal.GetDriverByName('MEM').Create('', 1, 1)
     src_ds = gdal.GetDriverByName('MEM').Create('', 3, 3)

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -58,10 +58,8 @@ def test_basic_test_1():
     pytest.fail('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
 
 
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_basic_test_strace_non_existing_file():
-
-    if not sys.platform.startswith('linux'):
-        pytest.skip()
 
     python_exe = sys.executable
     cmd = "strace -f %s -c \"from osgeo import gdal; " % python_exe + (

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -58,7 +58,7 @@ def test_basic_test_1():
     pytest.fail('did not get expected error message, got %s' % gdal.GetLastErrorMsg())
 
 
-@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform != 'linux', reason='Incorrect platform')
 def test_basic_test_strace_non_existing_file():
 
     python_exe = sys.executable

--- a/autotest/gcore/hfa_rfc40.py
+++ b/autotest/gcore/hfa_rfc40.py
@@ -34,28 +34,18 @@ from osgeo import gdal
 
 import pytest
 
-
-try:
-    import numpy
-    array = numpy.array
-except ImportError:
-    numpy = None
-    array = list
-
-pytestmark = pytest.mark.skipif(numpy is None, reason="numpy not available")
+np = pytest.importorskip('numpy')
 
 
-INT_DATA = array([197, 83, 46, 29, 1, 78, 23, 90, 12, 45])
-DOUBLE_DATA = array([0.1, 43.2, 78.1, 9.9, 23.0, 0.92, 82.5, 0.0, 1.0, 99.0])
-STRING_DATA = array(["sddf", "wess", "grbgr", "dewd", "ddww", "qwsqw",
-                     "gbfgbf", "wwqw3", "e", ""])
-STRING_DATA_INTS = array(["197", "83", "46", "29", "1", "78",
-                          "23", "90", "12", "45"])
-STRING_DATA_DOUBLES = array(["0.1", "43.2", "78.1", "9.9", "23.0", "0.92",
-                             "82.5", "0.0", "1.0", "99.0"])
-LONG_STRING_DATA = array(["sdfsdfsdfs", "sdweddw", "sdewdweee", "3423dedd",
-                          "jkejjjdjd", "edcdcdcdc", "fcdkmk4m534m", "edwededdd",
-                          "dedwedew", "wdedefrfrfrf"])
+INT_DATA = np.array([197, 83, 46, 29, 1, 78, 23, 90, 12, 45])
+DOUBLE_DATA = np.array([0.1, 43.2, 78.1, 9.9, 23.0, 0.92, 82.5, 0.0, 1.0, 99.0])
+STRING_DATA = np.array([
+    "sddf", "wess", "grbgr", "dewd", "ddww", "qwsqw", "gbfgbf", "wwqw3", "e", ""])
+STRING_DATA_INTS = np.array(["197", "83", "46", "29", "1", "78", "23", "90", "12", "45"])
+STRING_DATA_DOUBLES = np.array([
+    "0.1", "43.2", "78.1", "9.9", "23.0", "0.92", "82.5", "0.0", "1.0", "99.0"])
+LONG_STRING_DATA = np.array(["sdfsdfsdfs", "sdweddw", "sdewdweee", "3423dedd", "jkejjjdjd",
+                             "edcdcdcdc", "fcdkmk4m534m", "edwededdd", "dedwedew", "wdedefrfrfrf"])
 
 
 class HFATestError(Exception):
@@ -74,7 +64,7 @@ def CreateAndWriteRAT(fname):
 
     # write some image data
     band = ds.GetRasterBand(1)
-    data = numpy.zeros((10, 10), numpy.uint8)
+    data = np.zeros((10, 10), np.uint8)
     data[5, 5] = 20
     band.WriteArray(data)
 
@@ -206,7 +196,7 @@ def ReadAndCheckValues(fname, numrows):
         raise HFATestError("double as int column does not match")
 
     data = rat.ReadAsArray(6, 0, 10)
-    if not (data == STRING_DATA_DOUBLES.astype(numpy.double)).all():
+    if not (data == STRING_DATA_DOUBLES.astype(np.double)).all():
         raise HFATestError("double as string column does not match")
 
     data = rat.ReadAsArray(7, 0, 10)
@@ -214,7 +204,7 @@ def ReadAndCheckValues(fname, numrows):
         raise HFATestError("string as int column does not match")
 
     data = rat.ReadAsArray(8, 0, 10)
-    if not (data.astype(numpy.double) == DOUBLE_DATA).all():
+    if not (data.astype(np.double) == DOUBLE_DATA).all():
         raise HFATestError("string as int column does not match")
 
     # print('succeeded reading')

--- a/autotest/gcore/hfa_rfc40.py
+++ b/autotest/gcore/hfa_rfc40.py
@@ -34,6 +34,7 @@ from osgeo import gdal
 
 import pytest
 
+# All tests will be skipped if numpy is unavailable.
 np = pytest.importorskip('numpy')
 
 

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -34,6 +34,7 @@ from osgeo import gdal
 import pytest
 
 
+# All tests will be skipped if numpy or gdal_array are unavailable.
 numpy = pytest.importorskip('numpy')
 gdal_array = pytest.importorskip('osgeo.gdal_array')
 

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -29,19 +29,13 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-try:
-    import numpy
-    from osgeo import gdal_array
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 import gdaltest
 from osgeo import gdal
 import pytest
 
 
-pytestmark = pytest.mark.skipif(not numpy_available, reason='numpy not available')
+numpy = pytest.importorskip('numpy')
+gdal_array = pytest.importorskip('osgeo.gdal_array')
 
 ###############################################################################
 # verify that we can load the deprecated gdalnumeric module

--- a/autotest/gcore/numpy_rw_multidim.py
+++ b/autotest/gcore/numpy_rw_multidim.py
@@ -42,11 +42,8 @@ import struct
 def test_numpy_rw_multidim_init():
 
     gdaltest.numpy_drv = None
-    try:
-        # importing gdal_array will allow numpy driver registration
-        from osgeo import gdal_array  # noqa
-    except (ImportError, AttributeError):
-        pytest.skip()
+    # importing gdal_array will allow numpy driver registration
+    pytest.importorskip('osgeo.gdal_array')
 
     gdal.AllRegister()
 

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -31,23 +31,15 @@
 import gdaltest
 import pytest
 
-try:
-    import numpy  # noqa
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 from osgeo import gdal
+
+numpy = pytest.importorskip('numpy')
 
 
 ###############################################################################
 # Verify real part extraction from a complex dataset.
 
-
 def test_pixfun_real_c():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_real_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -67,9 +59,6 @@ def test_pixfun_real_c():
 
 def test_pixfun_real_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_real_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -87,9 +76,6 @@ def test_pixfun_real_r():
 # Verify imaginary part extraction from a complex dataset.
 
 def test_pixfun_imag_c():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_imag_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -116,9 +102,6 @@ def test_pixfun_imag_c():
 
 def test_pixfun_imag_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_imag_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -131,9 +114,6 @@ def test_pixfun_imag_r():
 # Verify imaginary part extraction from a real dataset.
 
 def test_pixfun_complex():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_complex.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -152,9 +132,6 @@ def test_pixfun_complex():
 # Verify modulus extraction from a complex (float) dataset.
 
 def test_pixfun_mod_c():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_mod_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -180,9 +157,6 @@ def test_pixfun_mod_c():
 
 def test_pixfun_mod_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_mod_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -207,9 +181,6 @@ def test_pixfun_mod_r():
 
 def test_pixfun_phase_c():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_phase_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -229,9 +200,6 @@ def test_pixfun_phase_c():
 
 def test_pixfun_phase_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_phase_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -249,9 +217,6 @@ def test_pixfun_phase_r():
 # Verify cmplex conjugare computation on a complex dataset.
 
 def test_pixfun_conj_c():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_conj_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -271,9 +236,6 @@ def test_pixfun_conj_c():
 
 def test_pixfun_conj_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_conj_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -292,9 +254,6 @@ def test_pixfun_conj_r():
 
 def test_pixfun_sum_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_sum_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -310,14 +269,10 @@ def test_pixfun_sum_r():
     assert numpy.alltrue(data == refdata)
 
 
-
 ###############################################################################
 # Verify the sum of 3 (two complex and one real) datasets.
 
 def test_pixfun_sum_c():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_sum_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -334,14 +289,10 @@ def test_pixfun_sum_c():
     assert numpy.alltrue(data == refdata)
 
 
-
 ###############################################################################
 # Verify the difference of 2 (real) datasets.
 
 def test_pixfun_diff_r():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_diff_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -366,9 +317,6 @@ def test_pixfun_diff_r():
 
 def test_pixfun_diff_c():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_diff_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -392,9 +340,6 @@ def test_pixfun_diff_c():
 
 def test_pixfun_mul_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_mul_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -410,14 +355,10 @@ def test_pixfun_mul_r():
     assert numpy.alltrue(data == refdata)
 
 
-
 ###############################################################################
 # Verify the product of 2 (complex) datasets.
 
 def test_pixfun_mul_c():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_mul_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -437,9 +378,6 @@ def test_pixfun_mul_c():
 
 def test_pixfun_cmul_c():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_cmul_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -457,9 +395,6 @@ def test_pixfun_cmul_c():
 # Verify the product with complex conjugate of two real datasets.
 
 def test_pixfun_cmul_r():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_cmul_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -486,9 +421,6 @@ def test_pixfun_cmul_r():
 
 def test_pixfun_inv_r():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_inv_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -507,9 +439,6 @@ def test_pixfun_inv_r():
 # Verify computation of the inverse of a complex datasets.
 
 def test_pixfun_inv_c():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_inv_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -532,9 +461,6 @@ def test_pixfun_inv_c():
 
 def test_pixfun_intensity_c():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_intensity_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -552,9 +478,6 @@ def test_pixfun_intensity_c():
 # Verify intensity computation of real dataset.
 
 def test_pixfun_intensity_r():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_intensity_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -574,9 +497,6 @@ def test_pixfun_intensity_r():
 
 def test_pixfun_sqrt():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_sqrt.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -594,9 +514,6 @@ def test_pixfun_sqrt():
 # Verify logarithm computation of real dataset.
 
 def test_pixfun_log10_r():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_log10_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -616,9 +533,6 @@ def test_pixfun_log10_r():
 
 def test_pixfun_log10_c():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_log10_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -635,9 +549,6 @@ def test_pixfun_log10_c():
 # Verify dB computation of real dataset.
 
 def test_pixfun_dB_r():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_dB_r.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -657,9 +568,6 @@ def test_pixfun_dB_r():
 
 def test_pixfun_dB_c():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_dB_c.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -676,9 +584,6 @@ def test_pixfun_dB_c():
 # Verify conversion from dB to amplitude.
 
 def test_pixfun_dB2amp():
-
-    if not numpy_available:
-        pytest.skip()
 
     filename = 'data/pixfun_dB2amp.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
@@ -699,9 +604,6 @@ def test_pixfun_dB2amp():
 
 def test_pixfun_dB2pow():
 
-    if not numpy_available:
-        pytest.skip()
-
     filename = 'data/pixfun_dB2pow.vrt'
     ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
     assert ds is not None, ('Unable to open "%s" dataset.' % filename)
@@ -717,6 +619,3 @@ def test_pixfun_dB2pow():
 
 
 ###############################################################################
-
-
-

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -33,6 +33,7 @@ import pytest
 
 from osgeo import gdal
 
+# All tests will be skipped if numpy is unavailable.
 numpy = pytest.importorskip('numpy')
 
 

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -32,12 +32,6 @@
 import struct
 import sys
 
-try:
-    import numpy
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 from osgeo import gdal
 import gdaltest
 import pytest
@@ -654,9 +648,7 @@ def test_rasterio_10():
 
 
 def test_rasterio_11():
-
-    if not numpy_available:
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     mem_ds = gdal.GetDriverByName('MEM').Create('', 4, 3)
     mem_ds.GetRasterBand(1).WriteArray(numpy.array([[80, 125, 125, 80], [80, 125, 125, 80], [80, 125, 125, 80]]))
@@ -685,9 +677,7 @@ def rasterio_12_progress_callback(pct, message, user_data):
 
 
 def test_rasterio_12():
-
-    if not numpy_available:
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     mem_ds = gdal.GetDriverByName('MEM').Create('', 4, 3, 4)
     for i in range(3):
@@ -722,9 +712,7 @@ def test_rasterio_12():
 
 
 def test_rasterio_13():
-
-    if not numpy_available:
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     for dt in [gdal.GDT_Byte, gdal.GDT_UInt16, gdal.GDT_UInt32]:
 
@@ -866,9 +854,7 @@ cellsize     0
 
 
 def test_rasterio_nodata():
-
-    if not numpy_available:
-        pytest.skip()
+    pytest.importorskip('numpy')
 
     ndv = 123
     btype = [gdal.GDT_Byte, gdal.GDT_Int16, gdal.GDT_Int32, gdal.GDT_Float32, gdal.GDT_Float64]
@@ -976,9 +962,7 @@ nodata_value 0
 
 
 def test_rasterio_dataset_readarray_cint16():
-
-    if not numpy_available:
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     mem_ds = gdal.GetDriverByName('MEM').Create('', 1, 1, 2, gdal.GDT_CInt16)
     mem_ds.GetRasterBand(1).WriteArray(numpy.array([[1 + 2j]]))
@@ -1040,9 +1024,7 @@ def test_rasterio_floating_point_window_no_resampling():
 
 def test_rasterio_floating_point_window_no_resampling_numpy():
     # Same as above but using ReadAsArray() instead of ReadRaster()
-
-    if not numpy_available:
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     ds = gdal.Translate('/vsimem/test.tif', gdal.Open('data/rgbsmall.tif'))
     assert ds.GetMetadataItem('INTERLEAVE', 'IMAGE_STRUCTURE') == 'PIXEL'

--- a/autotest/gcore/testnonboundtoswig.py
+++ b/autotest/gcore/testnonboundtoswig.py
@@ -97,8 +97,7 @@ def setup():
 
         return gdal_handle
     except Exception:
-        print('cannot find gdal shared object')
-        pytest.skip()
+        pytest.skip('cannot find gdal shared object')
 
 ###############################################################################
 # Call GDALDestroyDriverManager()

--- a/autotest/gcore/testnonboundtoswig.py
+++ b/autotest/gcore/testnonboundtoswig.py
@@ -32,13 +32,9 @@
 from osgeo import gdal
 import pytest
 
-
-try:
-    import ctypes
-except ImportError:
-    pass
-
 import gdaltest
+
+ctypes = pytest.importorskip('ctypes')
 
 gdal_handle_init = False
 gdal_handle = None
@@ -96,7 +92,8 @@ def setup():
         if dynamic_version != static_version:
             gdal_handle = None
             gdal_handle_stdcall = None
-            pytest.skip('dynamic version(%s) does not match static version (%s)' % (dynamic_version, static_version))
+            pytest.skip(f'dynamic version({dynamic_version}) does not match '
+                        f'static version ({static_version})')
 
         return gdal_handle
     except Exception:

--- a/autotest/gcore/testnonboundtoswig.py
+++ b/autotest/gcore/testnonboundtoswig.py
@@ -29,12 +29,12 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import ctypes
+
 from osgeo import gdal
 import pytest
 
 import gdaltest
-
-ctypes = pytest.importorskip('ctypes')
 
 gdal_handle_init = False
 gdal_handle = None
@@ -61,11 +61,6 @@ def setup():
         return gdal_handle
 
     gdal_handle_init = True
-
-    try:
-        ctypes.cdll
-    except ImportError:
-        pytest.skip('cannot find ctypes')
 
     name = find_libgdal()
     if name is None:

--- a/autotest/gcore/thread_test.py
+++ b/autotest/gcore/thread_test.py
@@ -31,12 +31,6 @@
 
 import threading
 
-try:
-    import numpy  # noqa
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 from osgeo import gdal
 import pytest
 
@@ -62,8 +56,7 @@ def thread_test_1_worker(args_dict):
 
 def test_thread_test_1():
 
-    if not numpy_available:
-        pytest.skip()
+    pytest.importorskip('numpy')
 
     threads = []
     args_array = []

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -31,7 +31,6 @@
 ###############################################################################
 
 import os
-import sys
 import shutil
 import array
 import stat
@@ -1387,10 +1386,8 @@ def test_tiff_ovr_43(both_endian):
             except:
                 ds = None
 
-    if gdal.GetLastErrorMsg().find(
-            'Unsupported JPEG data precision 12') != -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+    if gdal.GetLastErrorMsg().find('Unsupported JPEG data precision 12') != -1:
+        pytest.skip('12bit jpeg not available')
 
     ds = gdaltest.tiff_drv.Create('tmp/ovr43.tif', 16, 16, 1, gdal.GDT_UInt16)
     ds.GetRasterBand(1).Fill(4000)

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -1982,15 +1982,12 @@ def test_tiff_read_empty_nodata_tag():
     ds = gdal.Open('data/empty_nodata.tif')
     assert ds.GetRasterBand(1).GetNoDataValue() is None
 
+
 ###############################################################################
 # Check that no auxiliary files are read with a simple Open(), reading
 # imagery and getting IMAGE_STRUCTURE metadata
-
-
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_tiff_read_strace_check():
-
-    if not sys.platform.startswith('linux'):
-        pytest.skip()
 
     python_exe = sys.executable
     cmd = "strace -f %s -c \"from osgeo import gdal; " % python_exe + (
@@ -2742,11 +2739,8 @@ def test_tiff_read_huge_implied_number_strips():
 ###############################################################################
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Runs super slow on some Windows configs')
 def test_tiff_read_many_blocks():
-
-    # Runs super slow on some Windows configs
-    if sys.platform == 'win32':
-        pytest.skip()
 
     md = gdal.GetDriverByName('GTiff').GetMetadata()
     if md['LIBTIFF'] != 'INTERNAL':

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -649,10 +649,8 @@ def test_tiff_12bitjpeg():
     gdal.PopErrorHandler()
     gdal.SetConfigOption('CPL_ACCUM_ERROR_MSG', old_accum)
 
-    if gdal.GetLastErrorMsg().find(
-            'Unsupported JPEG data precision 12') != -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+    if gdal.GetLastErrorMsg().find('Unsupported JPEG data precision 12') != -1:
+        pytest.skip('12bit jpeg not available')
     elif ds is None:
         pytest.fail('failed to open 12bit jpeg file with unexpected error')
 

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -2737,7 +2737,6 @@ def test_tiff_read_huge_implied_number_strips():
 ###############################################################################
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='Runs super slow on some Windows configs')
 def test_tiff_read_many_blocks():
 
     md = gdal.GetDriverByName('GTiff').GetMetadata()

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -1984,7 +1984,7 @@ def test_tiff_read_empty_nodata_tag():
 ###############################################################################
 # Check that no auxiliary files are read with a simple Open(), reading
 # imagery and getting IMAGE_STRUCTURE metadata
-@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform != 'linux', reason='Incorrect platform')
 def test_tiff_read_strace_check():
 
     python_exe = sys.executable

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -2278,10 +2278,8 @@ def test_tiff_write_74():
     gdal.PopErrorHandler()
     gdal.SetConfigOption('CPL_ACCUM_ERROR_MSG', old_accum)
 
-    if gdal.GetLastErrorMsg().find(
-            'Unsupported JPEG data precision 12') != -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+    if gdal.GetLastErrorMsg().find('Unsupported JPEG data precision 12') != -1:
+        pytest.skip('12bit jpeg not available')
 
     for photometric in ('YCBCR', 'RGB'):
 

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -124,38 +124,22 @@ def test_tiff_write_3():
 
 def test_tiff_write_4():
 
-    try:
-        import numpy
-    except ImportError:
-        pytest.skip()
+    np = pytest.importorskip('numpy')
 
     options = ['TILED=YES', 'BLOCKXSIZE=32', 'BLOCKYSIZE=32']
 
     new_ds = gdaltest.tiff_drv.Create('tmp/test_4.tif', 40, 50, 3,
                                       gdal.GDT_Byte, options)
 
-    try:
-        data_red = numpy.zeros((50, 40))
-        data_green = numpy.zeros((50, 40))
-        data_blue = numpy.zeros((50, 40))
-    except AttributeError:
-        import numpy
-        data_red = numpy.zeros((50, 40))
-        data_green = numpy.zeros((50, 40))
-        data_blue = numpy.zeros((50, 40))
+    data_red = np.zeros((50, 40), dtype=np.uint8)
+    data_green = np.zeros((50, 40), dtype=np.uint8)
+    data_blue = np.zeros((50, 40), dtype=np.uint8)
 
     for y in range(50):
         for x in range(40):
             data_red[y][x] = x
             data_green[y][x] = y
             data_blue[y][x] = x + y
-
-    try:
-        data_red = data_red.astype(numpy.uint8)
-        data_green = data_green.astype(numpy.uint8)
-        data_blue = data_blue.astype(numpy.uint8)
-    except AttributeError:
-        pass
 
     new_ds.GetRasterBand(1).WriteArray(data_red)
     new_ds.GetRasterBand(2).WriteArray(data_green)

--- a/autotest/gcore/virtualmem.py
+++ b/autotest/gcore/virtualmem.py
@@ -34,6 +34,7 @@ import sys
 from osgeo import gdal
 import pytest
 
+# All tests will be skipped if numpy unavailable or SKIP_VIRTUALMEM is set.
 numpy = pytest.importorskip('numpy')
 pytestmark = pytest.mark.skipif(gdal.GetConfigOption('SKIP_VIRTUALMEM'),
                                 reason='SKIP_VIRTUALMEM is set in config')

--- a/autotest/gcore/virtualmem.py
+++ b/autotest/gcore/virtualmem.py
@@ -104,9 +104,10 @@ def test_virtualmem_1():
 
 ###############################################################################
 # Test write mode
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_virtualmem_2():
 
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not sys.platform.startswith('linux'):
+    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
         pytest.skip()
 
     ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 1)
@@ -123,9 +124,10 @@ def test_virtualmem_2():
 
 ###############################################################################
 # Test virtual mem auto with a raw driver
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_virtualmem_3():
 
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not sys.platform.startswith('linux'):
+    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
         pytest.skip()
 
     for tmpfile in ['tmp/virtualmem_3.img', '/vsimem/virtualmem_3.img']:
@@ -160,9 +162,10 @@ def test_virtualmem_3():
 
 ###############################################################################
 # Test virtual mem auto with GTiff
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_virtualmem_4():
 
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not sys.platform.startswith('linux'):
+    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
         pytest.skip()
 
     tmpfile = 'tmp/virtualmem_4.tif'

--- a/autotest/gcore/virtualmem.py
+++ b/autotest/gcore/virtualmem.py
@@ -35,14 +35,13 @@ from osgeo import gdal
 import pytest
 
 numpy = pytest.importorskip('numpy')
+pytestmark = pytest.mark.skipif(gdal.GetConfigOption('SKIP_VIRTUALMEM'),
+                                reason='SKIP_VIRTUALMEM is set in config')
 
 
 ###############################################################################
 # Test linear and tiled virtual mem interfaces in read-only mode
 def test_virtualmem_1():
-
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
-        pytest.skip()
 
     ds = gdal.Open('../gdrivers/data/small_world.tif')
     bufxsize = 400
@@ -106,10 +105,6 @@ def test_virtualmem_1():
 # Test write mode
 @pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_virtualmem_2():
-
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
-        pytest.skip()
-
     ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 1)
     ar = ds.GetVirtualMemArray(gdal.GF_Write)
     ar.fill(255)
@@ -126,10 +121,6 @@ def test_virtualmem_2():
 # Test virtual mem auto with a raw driver
 @pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_virtualmem_3():
-
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
-        pytest.skip()
-
     for tmpfile in ['tmp/virtualmem_3.img', '/vsimem/virtualmem_3.img']:
         ds = gdal.GetDriverByName('EHdr').Create(tmpfile, 400, 300, 2)
         ar1 = ds.GetRasterBand(1).GetVirtualMemAutoArray(gdal.GF_Write)
@@ -164,10 +155,6 @@ def test_virtualmem_3():
 # Test virtual mem auto with GTiff
 @pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
 def test_virtualmem_4():
-
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
-        pytest.skip()
-
     tmpfile = 'tmp/virtualmem_4.tif'
     for option in ['INTERLEAVE=PIXEL', 'INTERLEAVE=BAND']:
         gdal.Unlink(tmpfile)

--- a/autotest/gcore/virtualmem.py
+++ b/autotest/gcore/virtualmem.py
@@ -31,22 +31,17 @@
 
 import sys
 
-try:
-    import numpy
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 from osgeo import gdal
 import pytest
 
+numpy = pytest.importorskip('numpy')
+
+
 ###############################################################################
 # Test linear and tiled virtual mem interfaces in read-only mode
-
-
 def test_virtualmem_1():
 
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not numpy_available:
+    if gdal.GetConfigOption('SKIP_VIRTUALMEM'):
         pytest.skip()
 
     ds = gdal.Open('../gdrivers/data/small_world.tif')
@@ -106,13 +101,12 @@ def test_virtualmem_1():
     ar_bsq = None
     ds = None
 
+
 ###############################################################################
 # Test write mode
-
-
 def test_virtualmem_2():
 
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not numpy_available or not sys.platform.startswith('linux'):
+    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not sys.platform.startswith('linux'):
         pytest.skip()
 
     ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 1)
@@ -126,13 +120,12 @@ def test_virtualmem_2():
 
     assert cs == 57182
 
+
 ###############################################################################
 # Test virtual mem auto with a raw driver
-
-
 def test_virtualmem_3():
 
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not numpy_available or not sys.platform.startswith('linux'):
+    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not sys.platform.startswith('linux'):
         pytest.skip()
 
     for tmpfile in ['tmp/virtualmem_3.img', '/vsimem/virtualmem_3.img']:
@@ -167,11 +160,9 @@ def test_virtualmem_3():
 
 ###############################################################################
 # Test virtual mem auto with GTiff
-
-
 def test_virtualmem_4():
 
-    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not numpy_available or not sys.platform.startswith('linux'):
+    if gdal.GetConfigOption('SKIP_VIRTUALMEM') or not sys.platform.startswith('linux'):
         pytest.skip()
 
     tmpfile = 'tmp/virtualmem_4.tif'
@@ -223,8 +214,3 @@ def test_virtualmem_4():
         ds = None
 
         gdal.GetDriverByName('GTiff').Delete(tmpfile)
-
-
-
-
-

--- a/autotest/gcore/virtualmem.py
+++ b/autotest/gcore/virtualmem.py
@@ -104,7 +104,7 @@ def test_virtualmem_1():
 
 ###############################################################################
 # Test write mode
-@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform != 'linux', reason='Incorrect platform')
 def test_virtualmem_2():
     ds = gdal.GetDriverByName('MEM').Create('', 100, 100, 1)
     ar = ds.GetVirtualMemArray(gdal.GF_Write)
@@ -120,7 +120,7 @@ def test_virtualmem_2():
 
 ###############################################################################
 # Test virtual mem auto with a raw driver
-@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform != 'linux', reason='Incorrect platform')
 def test_virtualmem_3():
     for tmpfile in ['tmp/virtualmem_3.img', '/vsimem/virtualmem_3.img']:
         ds = gdal.GetDriverByName('EHdr').Create(tmpfile, 400, 300, 2)
@@ -154,7 +154,7 @@ def test_virtualmem_3():
 
 ###############################################################################
 # Test virtual mem auto with GTiff
-@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform != 'linux', reason='Incorrect platform')
 def test_virtualmem_4():
     tmpfile = 'tmp/virtualmem_4.tif'
     for option in ['INTERLEAVE=PIXEL', 'INTERLEAVE=BAND']:

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -146,10 +146,7 @@ def test_vrt_read_3():
 
 def test_vrt_read_4():
 
-    try:
-        import numpy as np
-    except ImportError:
-        pytest.skip()
+    np = pytest.importorskip('numpy')
 
     data = np.zeros((1, 1), np.complex64)
     data[0, 0] = 1. + 3.j
@@ -865,10 +862,7 @@ def test_vrt_read_22():
 
 def test_vrt_read_23():
 
-    try:
-        import numpy
-    except (ImportError, AttributeError):
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     mem_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/vrt_read_23.tif', 2, 1)
     mem_ds.GetRasterBand(1).WriteArray(numpy.array([[0, 10]]))

--- a/autotest/gcore/vsicrypt.py
+++ b/autotest/gcore/vsicrypt.py
@@ -29,9 +29,10 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import ctypes
 import struct
-from osgeo import gdal
 
+from osgeo import gdal
 
 import gdaltest
 import pytest
@@ -465,8 +466,6 @@ def test_vsicrypt_5():
 
 
 def test_vsicrypt_6(testnonboundtoswig_setup):  # noqa
-
-    ctypes = pytest.importorskip('ctypes')
 
     testnonboundtoswig_setup.VSISetCryptKey.argtypes = [ctypes.c_char_p, ctypes.c_int]
     testnonboundtoswig_setup.VSISetCryptKey.restype = None

--- a/autotest/gcore/vsicrypt.py
+++ b/autotest/gcore/vsicrypt.py
@@ -466,10 +466,7 @@ def test_vsicrypt_5():
 
 def test_vsicrypt_6(testnonboundtoswig_setup):  # noqa
 
-    try:
-        import ctypes
-    except ImportError:
-        pytest.skip()
+    ctypes = pytest.importorskip('ctypes')
 
     testnonboundtoswig_setup.VSISetCryptKey.argtypes = [ctypes.c_char_p, ctypes.c_int]
     testnonboundtoswig_setup.VSISetCryptKey.restype = None

--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -1143,11 +1143,6 @@ def test_vsigs_extra_1():
     if not gdaltest.built_against_curl():
         pytest.skip()
 
-    # if gdal.GetConfigOption('GS_SECRET_ACCESS_KEY') is None:
-    #    pytest.skip('Missing GS_SECRET_ACCESS_KEY')
-    # elif gdal.GetConfigOption('GS_ACCESS_KEY_ID') is None:
-    #    pytest.skip('Missing GS_ACCESS_KEY_ID')
-
     gs_resource = gdal.GetConfigOption('GS_RESOURCE')
     if gs_resource is None:
         pytest.skip('Missing GS_RESOURCE')

--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -983,16 +983,13 @@ client_secret = CLIENT_SECRET
     gdal.SetConfigOption('GOA2_AUTH_URL_TOKEN', None)
     gdal.Unlink('/vsimem/.boto')
 
+
 ###############################################################################
 # Read credentials from simulated GCE instance
-
-
+@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
 def test_vsigs_read_credentials_gce():
 
     if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    if sys.platform not in ('linux', 'linux2', 'win32'):
         pytest.skip()
 
     gdal.SetConfigOption('CPL_GS_CREDENTIALS_FILE', '')
@@ -1058,17 +1055,14 @@ def test_vsigs_read_credentials_gce():
     gdal.SetConfigOption('CPL_GCE_CREDENTIALS_URL', '')
     gdal.SetConfigOption('CPL_GCE_CHECK_LOCAL_FILES', None)
 
+
 ###############################################################################
 # Read credentials from simulated GCE instance with expiration of the
 # cached credentials
-
-
+@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
 def test_vsigs_read_credentials_gce_expiration():
 
     if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    if sys.platform not in ('linux', 'linux2', 'win32'):
         pytest.skip()
 
     gdal.SetConfigOption('CPL_GS_CREDENTIALS_FILE', '')

--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -1144,11 +1144,9 @@ def test_vsigs_extra_1():
         pytest.skip()
 
     # if gdal.GetConfigOption('GS_SECRET_ACCESS_KEY') is None:
-    #    print('Missing GS_SECRET_ACCESS_KEY')
-    #    pytest.skip()
+    #    pytest.skip('Missing GS_SECRET_ACCESS_KEY')
     # elif gdal.GetConfigOption('GS_ACCESS_KEY_ID') is None:
-    #    print('Missing GS_ACCESS_KEY_ID')
-    #    pytest.skip()
+    #    pytest.skip('Missing GS_ACCESS_KEY_ID')
 
     gs_resource = gdal.GetConfigOption('GS_RESOURCE')
     if gs_resource is None:

--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -986,7 +986,7 @@ client_secret = CLIENT_SECRET
 
 ###############################################################################
 # Read credentials from simulated GCE instance
-@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform not in ('linux', 'win32'), reason='Incorrect platform')
 def test_vsigs_read_credentials_gce():
 
     if gdaltest.webserver_port == 0:
@@ -1059,7 +1059,7 @@ def test_vsigs_read_credentials_gce():
 ###############################################################################
 # Read credentials from simulated GCE instance with expiration of the
 # cached credentials
-@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform not in ('linux', 'win32'), reason='Incorrect platform')
 def test_vsigs_read_credentials_gce_expiration():
 
     if gdaltest.webserver_port == 0:

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -3132,7 +3132,7 @@ aws_secret_access_key = bar
 
 ###############################################################################
 # Read credentials from simulated EC2 instance
-@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform not in ('linux', 'win32'), reason='Incorrect platform')
 def test_vsis3_read_credentials_ec2_imdsv2():
 
     if gdaltest.webserver_port == 0:
@@ -3191,7 +3191,7 @@ def test_vsis3_read_credentials_ec2_imdsv2():
 
 ###############################################################################
 # Read credentials from simulated EC2 instance that only supports IMDSv1
-@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform not in ('linux', 'win32'), reason='Incorrect platform')
 def test_vsis3_read_credentials_ec2_imdsv1():
 
     if gdaltest.webserver_port == 0:
@@ -3238,7 +3238,7 @@ def test_vsis3_read_credentials_ec2_imdsv1():
 ###############################################################################
 # Read credentials from simulated EC2 instance with expiration of the
 # cached credentials
-@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform not in ('linux', 'win32'), reason='Incorrect platform')
 def test_vsis3_read_credentials_ec2_expiration():
 
     if gdaltest.webserver_port == 0:

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -3129,16 +3129,13 @@ aws_secret_access_key = bar
     gdal.SetConfigOption('AWS_CONFIG_FILE', '')
     gdal.Unlink('/vsimem/aws_config')
 
+
 ###############################################################################
 # Read credentials from simulated EC2 instance
-
-
+@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
 def test_vsis3_read_credentials_ec2_imdsv2():
 
     if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    if sys.platform not in ('linux', 'linux2', 'win32'):
         pytest.skip()
 
     gdal.SetConfigOption('CPL_AWS_CREDENTIALS_FILE', '')
@@ -3191,16 +3188,13 @@ def test_vsis3_read_credentials_ec2_imdsv2():
     gdal.SetConfigOption('CPL_AWS_EC2_API_ROOT_URL', '')
     gdal.SetConfigOption('CPL_AWS_AUTODETECT_EC2', None)
 
+
 ###############################################################################
 # Read credentials from simulated EC2 instance that only supports IMDSv1
-
-
+@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
 def test_vsis3_read_credentials_ec2_imdsv1():
 
     if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    if sys.platform not in ('linux', 'linux2', 'win32'):
         pytest.skip()
 
     gdal.SetConfigOption('CPL_AWS_CREDENTIALS_FILE', '')
@@ -3240,17 +3234,14 @@ def test_vsis3_read_credentials_ec2_imdsv1():
     gdal.SetConfigOption('CPL_AWS_EC2_API_ROOT_URL', '')
     gdal.SetConfigOption('CPL_AWS_AUTODETECT_EC2', None)
 
+
 ###############################################################################
 # Read credentials from simulated EC2 instance with expiration of the
 # cached credentials
-
-
+@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
 def test_vsis3_read_credentials_ec2_expiration():
 
     if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    if sys.platform not in ('linux', 'linux2', 'win32'):
         pytest.skip()
 
     gdal.SetConfigOption('CPL_AWS_CREDENTIALS_FILE', '')

--- a/autotest/gdrivers/eedai.py
+++ b/autotest/gdrivers/eedai.py
@@ -442,7 +442,7 @@ gwE6fxOLyJDxuWRf\n
 # Read credentials from simulated GCE instance
 
 
-@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform not in ('linux', 'win32'), reason='Incorrect platform')
 def test_eedai_gce_credentials():
 
     if gdaltest.eedai_drv is None:

--- a/autotest/gdrivers/eedai.py
+++ b/autotest/gdrivers/eedai.py
@@ -442,12 +442,10 @@ gwE6fxOLyJDxuWRf\n
 # Read credentials from simulated GCE instance
 
 
+@pytest.mark.skipif(sys.platform not in ('linux', 'linux2', 'win32'), reason='Incorrect platform')
 def test_eedai_gce_credentials():
 
     if gdaltest.eedai_drv is None:
-        pytest.skip()
-
-    if sys.platform not in ('linux', 'linux2', 'win32'):
         pytest.skip()
 
     gdaltest.webserver_process = None

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -115,10 +115,7 @@ def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=Non
     path = samples_path
     if path not in sys.path:
         sys.path.append(path)
-    try:
-        import validate_jp2
-    except ImportError:
-        pytest.skip('Cannot run validate_jp2')
+    validate_jp2 = pytest.importorskip('validate_jp2')
 
     try:
         os.stat('tmp/cache/SCHEMAS_OPENGIS_NET')
@@ -550,12 +547,7 @@ def test_jp2lura_19():
 
 def test_jp2lura_20():
 
-    try:
-        import xmlvalidate
-    except ImportError:
-        import traceback
-        traceback.print_exc(file=sys.stdout)
-        pytest.skip('Cannot import xmlvalidate')
+    xmlvalidate = pytest.importorskip('xmlvalidate')
 
     try:
         os.stat('tmp/cache/SCHEMAS_OPENGIS_NET.zip')

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -476,12 +476,7 @@ def test_jp2openjpeg_19():
 
 def test_jp2openjpeg_20():
 
-    try:
-        import xmlvalidate
-    except ImportError:
-        import traceback
-        traceback.print_exc(file=sys.stdout)
-        pytest.skip('Cannot import xmlvalidate')
+    xmlvalidate = pytest.importorskip('xmlvalidate')
 
     try:
         os.stat('tmp/cache/SCHEMAS_OPENGIS_NET.zip')
@@ -745,10 +740,7 @@ def validate(filename, expected_gmljp2=True, return_error_count=False, oidoc=Non
         if path not in sys.path:
             sys.path.append(path)
 
-    try:
-        import validate_jp2
-    except ImportError:
-        pytest.skip('Cannot run validate_jp2')
+    validate_jp2 = pytest.importorskip('validate_jp2')
 
     try:
         os.stat('tmp/cache/SCHEMAS_OPENGIS_NET')

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -886,17 +886,14 @@ def test_jpeg_26():
     assert ds is None
     gdal.Unlink('/vsimem/jpeg_26.jpg')
 
+
 ###############################################################################
 # Test reading a file that contains the 2 denial of service
 # vulnerabilities listed in
 # http://www.libjpeg-jpeg_26.org/pmwiki/uploads/About/TwoIssueswiththeJPEGStandard.pdf
 
-
+@pytest.mark.skipif(sys.platform == 'win32', reason='Fails for some reason on Windows')
 def test_jpeg_27_max_memory():
-
-    # Fails for some reason on Windows.
-    if sys.platform == 'win32':
-        pytest.skip()
 
     # Should error out with 'Reading this image would require
     # libjpeg to allocate at least...'

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -344,8 +344,7 @@ def test_jpeg_10():
     drv = gdal.GetDriverByName('JPEG')
     md = drv.GetMetadata()
     if md[gdal.DMD_CREATIONDATATYPES].find('UInt16') == -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+        pytest.skip('12bit jpeg not available')
 
     try:
         os.remove('data/jpeg/12bit_rose_extract.jpg.aux.xml')
@@ -377,8 +376,7 @@ def test_jpeg_11():
     drv = gdal.GetDriverByName('JPEG')
     md = drv.GetMetadata()
     if md[gdal.DMD_CREATIONDATATYPES].find('UInt16') == -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+        pytest.skip('12bit jpeg not available')
 
     ds = gdal.Open('data/jpeg/12bit_rose_extract.jpg')
     out_ds = gdal.GetDriverByName('JPEG').CreateCopy('tmp/jpeg11.jpg', ds)
@@ -443,8 +441,7 @@ def test_jpeg_14():
     drv = gdal.GetDriverByName('JPEG')
     md = drv.GetMetadata()
     if md[gdal.DMD_CREATIONDATATYPES].find('UInt16') == -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+        pytest.skip('12bit jpeg not available')
 
     src_ds = gdal.Open('data/jpeg/12bit_rose_extract.jpg')
     ds = drv.CreateCopy('/vsistdout_redirect//vsimem/tmp.jpg', src_ds)

--- a/autotest/gdrivers/kmlsuperoverlay.py
+++ b/autotest/gdrivers/kmlsuperoverlay.py
@@ -196,7 +196,7 @@ def test_kmlsuperoverlay_4():
 
 def test_kmlsuperoverlay_5():
 
-    ElementTree = pytest.importorskip('xml.etree.ElementTree')
+    from xml.etree import ElementTree
 
     src_ds = gdal.Open("""<VRTDataset rasterXSize="512" rasterYSize="512">
   <SRS>PROJCS["WGS 84 / Mercator 41",

--- a/autotest/gdrivers/kmlsuperoverlay.py
+++ b/autotest/gdrivers/kmlsuperoverlay.py
@@ -196,10 +196,7 @@ def test_kmlsuperoverlay_4():
 
 def test_kmlsuperoverlay_5():
 
-    try:
-        from xml.etree import ElementTree
-    except ImportError:
-        pytest.skip()
+    ElementTree = pytest.importorskip('xml.etree.ElementTree')
 
     src_ds = gdal.Open("""<VRTDataset rasterXSize="512" rasterYSize="512">
   <SRS>PROJCS["WGS 84 / Mercator 41",

--- a/autotest/gdrivers/lcp.py
+++ b/autotest/gdrivers/lcp.py
@@ -30,6 +30,9 @@
 ###############################################################################
 
 import os
+import random
+import struct
+
 from osgeo import gdal
 
 
@@ -762,11 +765,6 @@ def test_lcp_20():
 
 
 def test_lcp_21():
-    try:
-        import random
-        import struct
-    except ImportError:
-        pytest.skip()
     mem_drv = gdal.GetDriverByName('MEM')
     assert mem_drv is not None
     drv = gdal.GetDriverByName('LCP')
@@ -803,12 +801,8 @@ def test_lcp_21():
 
 
 def test_lcp_22():
-    try:
-        import random
-        import struct
-        import numpy
-    except ImportError:
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
+
     mem_drv = gdal.GetDriverByName('MEM')
     assert mem_drv is not None
     drv = gdal.GetDriverByName('LCP')

--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -108,10 +108,7 @@ def test_mem_2():
     gdal.PopErrorHandler()
     assert ds is None, 'opening MEM dataset should have failed.'
 
-    try:
-        import ctypes
-    except ImportError:
-        pytest.skip()
+    ctypes = pytest.importorskip('ctypes')
 
     for libname in ['msvcrt', 'libc.so.6']:
         try:

--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -29,9 +29,10 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import ctypes
 import struct
-from osgeo import gdal
 
+from osgeo import gdal
 
 import gdaltest
 import pytest
@@ -107,8 +108,6 @@ def test_mem_2():
     ds = gdal.Open('MEM:::')
     gdal.PopErrorHandler()
     assert ds is None, 'opening MEM dataset should have failed.'
-
-    ctypes = pytest.importorskip('ctypes')
 
     for libname in ['msvcrt', 'libc.so.6']:
         try:

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -148,8 +148,9 @@ def netcdf_test_copy_timeout(ifile, band, checksum, ofile, opts=None, driver='NE
             proc.terminate()
             if os.path.exists(ofile):
                 drv.Delete(ofile)
-            print('testCreateCopy() for file %s has reached timeout limit of %d seconds' % (ofile, timeout))
-            pytest.fail()
+            pytest.fail(
+                f'testCreateCopy() for file {ofile} has reached timeout limit of {timeout} seconds')
+
 
 ###############################################################################
 # check support for DEFLATE compression, requires HDF5 and zlib
@@ -1119,9 +1120,10 @@ def test_netcdf_34():
     # valgrind detects memory leaks when this occurs (although it should never happen)
     if proc.is_alive():
         proc.terminate()
-        pytest.fail('testOpen() for file %s has reached timeout limit of %d seconds' % (filename, timeout))
+        pytest.fail(
+            f'testOpen() for file {filename} has reached timeout limit of {timeout} seconds')
 
-    
+
 ###############################################################################
 # test writing a long metadata > 8196 chars (bug #5113)
 

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -32,7 +32,6 @@
 
 import copy
 import os
-import sys
 import array
 import struct
 import shutil
@@ -1058,8 +1057,7 @@ def test_nitf_41(not_jpeg_9b):
     jpg_drv = gdal.GetDriverByName('JPEG')
     md = jpg_drv.GetMetadata()
     if md[gdal.DMD_CREATIONDATATYPES].find('UInt16') == -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+        pytest.skip('12bit jpeg not available')
 
     gdal.Unlink('data/nitf/U_4017A.NTF.aux.xml')
 
@@ -1081,8 +1079,7 @@ def test_nitf_42(not_jpeg_9b):
     jpg_drv = gdal.GetDriverByName('JPEG')
     md = jpg_drv.GetMetadata()
     if md[gdal.DMD_CREATIONDATATYPES].find('UInt16') == -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+        pytest.skip('12bit jpeg not available')
 
     ds = gdal.Open('data/nitf/U_4017A.NTF')
     out_ds = gdal.GetDriverByName('NITF').CreateCopy('tmp/nitf42.ntf', ds, options=['IC=C3', 'FHDR=NITF02.10'])
@@ -4147,8 +4144,7 @@ def test_nitf_online_14(not_jpeg_9b):
     jpg_drv = gdal.GetDriverByName('JPEG')
     md = jpg_drv.GetMetadata()
     if md[gdal.DMD_CREATIONDATATYPES].find('UInt16') == -1:
-        sys.stdout.write('(12bit jpeg not available) ... ')
-        pytest.skip()
+        pytest.skip('12bit jpeg not available')
 
     ds = gdal.Open('tmp/cache/U_4020h.ntf')
     assert ds.GetRasterBand(1).DataType == gdal.GDT_UInt16

--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -643,10 +643,7 @@ def test_rmf_31d():
 
 
 def test_rmf_31e():
-    try:
-        import numpy
-    except ImportError:
-        pytest.skip()
+    numpy = pytest.importorskip('numpy')
 
     drv = gdal.GetDriverByName('Gtiff')
     if drv is None:

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -457,10 +457,8 @@ def test_sentinel2_l1c_5():
 # Windows specific test to test support for long filenames
 
 
+@pytest.mark.skipif(sys.platform != 'win32', reason='Incorrect platform')
 def test_sentinel2_l1c_6():
-
-    if sys.platform != 'win32':
-        pytest.skip()
 
     filename_xml = 'data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/S2A_OPER_MTD_SAFL1C.xml'
     filename_xml = filename_xml.replace('/', '\\')

--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -91,10 +91,7 @@ def test_tiledb_write_custom_blocksize(mode):
     ['BAND', 'PIXEL']
 )
 def test_tiledb_write_update(mode):
-    try:
-        import numpy as np
-    except (ImportError):
-        pytest.skip()
+    np = pytest.importorskip('numpy')
 
     gdaltest.tiledb_drv = gdal.GetDriverByName('TileDB')
 
@@ -268,10 +265,7 @@ def test_tiledb_write_band_meta(mode):
     ['BAND', 'PIXEL']
 )
 def test_tiledb_write_history(mode):
-    try:
-        import numpy as np
-    except (ImportError):
-        pytest.skip()
+    np = pytest.importorskip('numpy')
 
     options = [
         'INTERLEAVE=%s' % (mode),

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -4298,11 +4298,9 @@ def test_abort_sql():
 # Test ST_Transform() with no record in gpkg_spatial_ref_sys and thus we
 # fallback to EPSG
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason='f.GetGeometryRef() returns None on the current Windows CI')
 def test_ogr_gpkg_st_transform_no_record_spatial_ref_sys():
-
-    if sys.platform == 'win32':
-        # For some reason f.GetGeometryRef() returns None on the current Windows CI
-        pytest.skip('Failure on windows')
 
     ds = ogr.GetDriverByName('GPKG').CreateDataSource('/vsimem/test.gpkg')
     lyr = ds.CreateLayer('test')

--- a/autotest/ogr/ogr_odbc.py
+++ b/autotest/ogr/ogr_odbc.py
@@ -39,6 +39,8 @@ import gdaltest
 import ogrtest
 import pytest
 
+pytestmark = pytest.mark.skipif(sys.platform != 'win32', reason='Incorrect platform')
+
 ###############################################################################
 # Basic testing
 
@@ -47,9 +49,6 @@ def test_ogr_odbc_1():
 
     ogrtest.odbc_drv = ogr.GetDriverByName('ODBC')
     if ogrtest.odbc_drv is None:
-        pytest.skip()
-
-    if sys.platform != 'win32':
         pytest.skip()
 
     ds = ogrtest.odbc_drv.Open('data/mdb/empty.mdb')

--- a/autotest/ogr/ogr_odbc.py
+++ b/autotest/ogr/ogr_odbc.py
@@ -39,7 +39,9 @@ import gdaltest
 import ogrtest
 import pytest
 
+# Skip all tests if we aren't on Windows.
 pytestmark = pytest.mark.skipif(sys.platform != 'win32', reason='Incorrect platform')
+
 
 ###############################################################################
 # Basic testing

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -2909,7 +2909,7 @@ def test_ogr_shape_70():
 # Test heterogeneous file permissions on .shp and .dbf.
 
 
-@pytest.mark.skipif(sys.platform.find('linux') != 0, reason='Incorrect platform')
+@pytest.mark.skipif(sys.platform != 'linux', reason='Incorrect platform')
 def test_ogr_shape_71():
 
     if os.getuid() == 0:

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -2771,10 +2771,8 @@ def test_ogr_shape_67():
 # Test opening a shape datasource with files with mixed case and then REPACK
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on MacOSX. Not sure why.')
 def test_ogr_shape_68():
-
-    if sys.platform == 'darwin':
-        pytest.skip("Fails on MacOSX. Not sure why.")
 
     for i in range(2):
         if i == 1 and sys.platform != 'win32':
@@ -2875,10 +2873,8 @@ def test_ogr_shape_69():
 # (shapefile opened twice on Windows)
 
 
+@pytest.mark.skipif(sys.platform != 'win32', reason='Incorrect platform')
 def test_ogr_shape_70():
-
-    if sys.platform != 'win32':
-        pytest.skip()
 
     ds = ogr.GetDriverByName('ESRI Shapefile').CreateDataSource('tmp/ogr_shape_70.shp')
     lyr = ds.CreateLayer('ogr_shape_70')
@@ -2913,10 +2909,8 @@ def test_ogr_shape_70():
 # Test heterogeneous file permissions on .shp and .dbf.
 
 
+@pytest.mark.skipif(sys.platform.find('linux') != 0, reason='Incorrect platform')
 def test_ogr_shape_71():
-
-    if sys.platform.find('linux') != 0:
-        pytest.skip()
 
     if os.getuid() == 0:
         pytest.skip('running as root... skipping')

--- a/autotest/osr/osr_ct_proj.py
+++ b/autotest/osr/osr_ct_proj.py
@@ -176,8 +176,7 @@ def test_proj(src_srs, src_xyz, src_error,
                     found = True
                     break
         if not found:
-            #print( 'Did not find GRID:%s' % grid_name )
-            pytest.skip()
+            pytest.skip(f'Did not find GRID:{grid_name}')
 
     src = osr.SpatialReference()
     assert src.SetFromUserInput(src_srs) == 0, \

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -42,13 +42,13 @@ import pytest
 from collections import defaultdict
 
 # test that numpy is available, if not skip all tests
+np = pytest.importorskip('numpy')
+gdal_calc = pytest.importorskip('osgeo.utils.gdal_calc')
+gdal_array = pytest.importorskip('osgeo.gdal_array')
 try:
-    import numpy as np
-    from osgeo.utils import gdal_calc
-    from osgeo.gdal_array import GDALTypeCodeToNumericTypeCode
-    numpy_available = True
-except (ImportError, AttributeError):
-    numpy_available = False
+    GDALTypeCodeToNumericTypeCode = gdal_array.GDALTypeCodeToNumericTypeCode
+except AttributeError:
+    pytestmark = pytest.mark.skip('osgeo.gdal_array.GDALTypeCodeToNumericTypeCode is unavailable')
 
 # Usage: gdal_calc.py [-A <filename>] [--A_band] [-B...-Z filename] [other_options]
 
@@ -106,8 +106,6 @@ def make_temp_filename_list(test_id, test_count, is_opt=False):
 
 def test_gdal_calc_py_1():
     """ test basic copy """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -127,8 +125,6 @@ def test_gdal_calc_py_1():
 
 def test_gdal_calc_py_2():
     """ test simple formulas """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -148,8 +144,6 @@ def test_gdal_calc_py_2():
 
 def test_gdal_calc_py_3():
     """ test --allBands option (simple copy) """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -168,8 +162,6 @@ def test_gdal_calc_py_3():
 
 def test_gdal_calc_py_4():
     """ test --allBands option (simple calc) """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -197,8 +189,6 @@ def test_gdal_calc_py_4():
 
 def test_gdal_calc_py_5():
     """ test python interface, basic copy """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -223,8 +213,6 @@ def test_gdal_calc_py_5():
 
 def test_gdal_calc_py_6():
     """ test nodata """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -246,8 +234,6 @@ def test_gdal_calc_py_6():
 
 def test_gdal_calc_py_7():
     """ test --optfile """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -285,8 +271,6 @@ def test_gdal_calc_py_7():
 
 def test_gdal_calc_py_8():
     """ test multiple calcs """
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:
@@ -331,9 +315,6 @@ def test_gdal_calc_py_9():
     * single alpha for multiple datasets
     * extent = 'fail'
     """
-
-    if not numpy_available:
-        pytest.skip("numpy is not available, skipping all tests", allow_module_level=True)
 
     script_path = test_py_scripts.get_py_script('gdal_calc')
     if script_path is None:

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -204,11 +204,11 @@ def test_gdal_edit_py_5():
     if script_path is None:
         pytest.skip()
 
+    gdal_array = pytest.importorskip('osgeo.gdal_array')
     try:
-        from osgeo import gdal_array
         gdal_array.BandRasterIONumPy
-    except:
-        pytest.skip()
+    except AttributeError:
+        pytest.skip('osgeo.gdal_array.BandRasterIONumPy is unavailable')
 
     shutil.copy(test_py_scripts.get_data_path('gcore') + 'byte.tif', 'tmp/test_gdal_edit_py.tif')
     ds = gdal.Open('tmp/test_gdal_edit_py.tif', gdal.GA_Update)

--- a/autotest/pyscripts/test_gdal_merge.py
+++ b/autotest/pyscripts/test_gdal_merge.py
@@ -161,10 +161,10 @@ def test_gdal_merge_4():
 
 
 def test_gdal_merge_5():
+    gdal_array = pytest.importorskip('osgeo.gdal_array')
     try:
-        from osgeo import gdal_array
         gdal_array.BandRasterIONumPy
-    except (ImportError, AttributeError):
+    except AttributeError:
         pytest.skip()
 
     script_path = test_py_scripts.get_py_script('gdal_merge')

--- a/autotest/pyscripts/test_gdal_retile.py
+++ b/autotest/pyscripts/test_gdal_retile.py
@@ -247,10 +247,7 @@ def test_gdal_retile_4():
 
 def test_gdal_retile_5():
 
-    try:
-        import numpy as np
-    except (ImportError, AttributeError):
-        pytest.skip()
+    np = pytest.importorskip('numpy')
 
     nodata_value = -3.4028234663852886e+38
     raster_array = np.array(([0.0, 2.0], [-1.0, nodata_value]))

--- a/autotest/pyscripts/test_ogr2ogr_py.py
+++ b/autotest/pyscripts/test_ogr2ogr_py.py
@@ -182,10 +182,7 @@ def test_ogr2ogr_py_5():
 
 def test_ogr2ogr_py_6():
 
-    try:
-        import ogr_pg
-    except:
-        pytest.skip()
+    ogr_pg = pytest.importorskip('ogr_pg')
 
     script_path = test_py_scripts.get_py_script('ogr2ogr')
     if script_path is None:
@@ -215,10 +212,7 @@ def test_ogr2ogr_py_6():
 
 def test_ogr2ogr_py_7():
 
-    try:
-        import ogr_pg
-    except:
-        pytest.skip()
+    ogr_pg = pytest.importorskip('ogr_pg')
 
     script_path = test_py_scripts.get_py_script('ogr2ogr')
     if script_path is None:

--- a/autotest/pyscripts/test_pct.py
+++ b/autotest/pyscripts/test_pct.py
@@ -61,11 +61,11 @@ def test_rgb2pct_1():
 
 
 def test_pct2rgb_1():
+    gdal_array = pytest.importorskip('osgeo.gdal_array')
     try:
-        from osgeo import gdal_array
         gdal_array.BandRasterIONumPy
-    except:
-        pytest.skip()
+    except AttributeError:
+        pytest.skip('osgeo.gdal_array.BandRasterIONumPy is unavailable')
 
     script_path = test_py_scripts.get_py_script('pct2rgb')
     if script_path is None:
@@ -134,11 +134,11 @@ def test_rgb2pct_3():
 
 
 def test_pct2rgb_4():
+    gdal_array = pytest.importorskip('osgeo.gdal_array')
     try:
-        from osgeo import gdal_array
         gdal_array.BandRasterIONumPy
-    except (ImportError, AttributeError):
-        pytest.skip()
+    except AttributeError:
+        pytest.skip('osgeo.gdal_array.BandRasterIONumPy is unavailable')
 
     script_path = test_py_scripts.get_py_script('pct2rgb')
     if script_path is None:

--- a/autotest/utilities/test_gdal_rasterize.py
+++ b/autotest/utilities/test_gdal_rasterize.py
@@ -33,12 +33,6 @@
 import sys
 import os
 
-try:
-    import numpy  # noqa
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 import pytest
 
 sys.path.append('../gcore')
@@ -308,7 +302,8 @@ def test_gdal_rasterize_6():
 
 def test_gdal_rasterize_7():
 
-    if not numpy_available or test_cli_utilities.get_gdal_rasterize_path() is None:
+    pytest.importorskip('numpy')
+    if test_cli_utilities.get_gdal_rasterize_path() is None:
         pytest.skip()
 
     drv = ogr.GetDriverByName('SQLite')


### PR DESCRIPTION
## What does this PR do?

Skips due to import errors can be done using `pytest.importorskip`, which will give a standard message and be a little shorter. It's also a bit nicer to use `pytest.mark.skipif` where possible, and actually pass skip reasons to `pytest.skip` instead of printing them.

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
