### PR TITLE
Fix DGN driver Text property type

### DIFF
--- a/gdal/doc/source/drivers/vector/dgnv8.rst
+++ b/gdal/doc/source/drivers/vector/dgnv8.rst
@@ -14,7 +14,7 @@ reading and writing. Each model of the file is represented by a OGR
 layer.
 
 This driver requires to be built against the (non open source) Open
-Design Alliance Teiga library.
+Design Alliance Teigha library.
 
 DGN files are considered to have no georeferencing information through
 OGR. Features will all have the following generic attributes:
@@ -53,7 +53,7 @@ The following element types are supported in reading:
 -  Arc (16): Approximated as a line geometry or a circular string.
 -  Text (17): Treated as a point geometry.
 -  B-Spline (21): Treated as a line geometry.
--  PointString (22): Treatead as multi point.
+-  PointString (22): Treated as multi point.
 -  Shared cell reference (35): Treated as point.
 
 Generally speaking any concept of complex objects, and cells as

--- a/gdal/doc/source/drivers/vector/dwg.rst
+++ b/gdal/doc/source/drivers/vector/dwg.rst
@@ -8,7 +8,7 @@ AutoCAD DWG
 .. build_dependencies:: Open Design Alliance Teigha library
 
 OGR supports reading most versions of AutoCAD DWG when built with the
-Open Design Alliance Teiga library. DWG is an binary working format used
+Open Design Alliance Teigha library. DWG is an binary working format used
 for AutoCAD drawings. A reasonable effort has been made to make the OGR
 DWG driver work similarly to the OGR DXF driver which shares a common
 data model. The entire contents of the .dwg file is represented as a

--- a/gdal/ogr/ogrsf_frmts/dgn/ogrdgnlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dgn/ogrdgnlayer.cpp
@@ -155,20 +155,20 @@ OGRDGNLayer::OGRDGNLayer( const char * pszName, DGNHandle hDGNIn,
     poFeatureDefn->AddFieldDefn( &oField );
 
 /* -------------------------------------------------------------------- */
-/*      ULink                                                           */
+/*      Text                                                            */
 /* -------------------------------------------------------------------- */
-    oField.SetName( "ULink" );
+    oField.SetName( "Text" );
     oField.SetType( OFTString );
-    oField.SetSubType( OFSTJSON );
     oField.SetWidth( 0 );
     oField.SetPrecision( 0 );
     poFeatureDefn->AddFieldDefn( &oField );
 
 /* -------------------------------------------------------------------- */
-/*      Text                                                            */
+/*      ULink                                                           */
 /* -------------------------------------------------------------------- */
-    oField.SetName( "Text" );
+    oField.SetName( "ULink" );
     oField.SetType( OFTString );
+    oField.SetSubType( OFSTJSON );
     oField.SetWidth( 0 );
     oField.SetPrecision( 0 );
     poFeatureDefn->AddFieldDefn( &oField );
@@ -383,11 +383,11 @@ OGRFeature *OGRDGNLayer::ElementToFeature( DGNElemCore *psElement, int nRecLevel
             break;
             case 6549: // 0x1995 Application ID by IPCC/Portugal
             {
-                theNewObject.Add( "domain", CPLSPrintf("0x%02x", pabyData[1] ) );
-                theNewObject.Add( "subdomain", CPLSPrintf("0x%02x", pabyData[0] ) );
-                theNewObject.Add( "family", CPLSPrintf("0x%02x", pabyData[3] ) );
-                theNewObject.Add( "object", CPLSPrintf("0x%02x", pabyData[2] ) );
-                theNewObject.Add( "key", CPLSPrintf("%02x%02x%02x%02x", pabyData[1], pabyData[0], pabyData[3], pabyData[2] ) );
+                theNewObject.Add( "domain", CPLSPrintf("0x%02x", pabyData[5] ) );
+                theNewObject.Add( "subdomain", CPLSPrintf("0x%02x", pabyData[4] ) );
+                theNewObject.Add( "family", CPLSPrintf("0x%02x", pabyData[7] ) );
+                theNewObject.Add( "object", CPLSPrintf("0x%02x", pabyData[6] ) );
+                theNewObject.Add( "key", CPLSPrintf("%02x%02x%02x%02x", pabyData[5], pabyData[4], pabyData[7], pabyData[6] ) );
                 theNewObject.Add( "type", "IPCC/Portugal" );
             }
             break;

--- a/gdal/ogr/ogrsf_frmts/dwg/ogrdgnv8layer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dwg/ogrdgnv8layer.cpp
@@ -855,11 +855,11 @@ std::vector<tPairFeatureHoleFlag> OGRDGNV8Layer::ProcessElement(
                     break;
                     case 0x1995: // 0x1995 (6549) IPCC/Portugal
                     {
-                        theNewObject.Add( "domain", CPLSPrintf("0x%02x", pData[1] ) );
-                        theNewObject.Add( "subdomain", CPLSPrintf("0x%02x", pData[0] ) );
-                        theNewObject.Add( "family", CPLSPrintf("0x%02x", pData[3] ) );
-                        theNewObject.Add( "object", CPLSPrintf("0x%02x", pData[2] ) );
-                        theNewObject.Add( "key", CPLSPrintf("%02x%02x%02x%02x", pData[1], pData[0], pData[3], pData[2] ) );
+                        theNewObject.Add( "domain", CPLSPrintf("0x%02x", pData[5] ) );
+                        theNewObject.Add( "subdomain", CPLSPrintf("0x%02x", pData[4] ) );
+                        theNewObject.Add( "family", CPLSPrintf("0x%02x", pData[7] ) );
+                        theNewObject.Add( "object", CPLSPrintf("0x%02x", pData[6] ) );
+                        theNewObject.Add( "key", CPLSPrintf("%02x%02x%02x%02x", pData[5], pData[4], pData[7], pData[6] ) );
                         theNewObject.Add( "type", "IPCC/Portugal" );
                     }
                     break;


### PR DESCRIPTION
## What does this PR do?

This small PR does three things:
* Fix #3496 
* Fix DGN/DWG Ulink output for a specific Application ID (by IPCC/Portugal)
* Fix minor typo in DGN and DWG docs

### Fix #3496 

The current pattern code in both `gdal/ogr/ogrsf_frmts/dgn/ogrdgnlayer.cpp` and `gdal/ogr/ogrsf_frmts/dwg/ogrdgnv8layer.cpp` uses the same `oField` do create all feature fields. I had to reverse the order to prevent the side effect of assigning a `SetSubType` to the previous `oField`.

### Fix DGN/DWG Ulink output for a specific Application ID (by IPCC/Portugal)

The current code outputs the first 4 bytes, witch are always the same.
```
OGRFeature(elements):141784
  Type (Integer) = 17
  Level (Integer) = 3
  GraphicGroup (Integer) = 0
  ColorIndex (Integer) = 31
  Weight (Integer) = 0
  Style (Integer) = 0
  Text (String) = Quinta das Urzes
  ULink (String(JSON)) = { "6549": [ { "size": 8, "domain": "0x10", "subdomain": "0x03", "family": "0x19", "object": "0x95", "key": "10031995", "type": "IPCC\/Portugal" } ] }
  Style = LABEL(t:"Quinta das Urzes",c:#000000,s:18g,f:MICROS)
  POINT Z (-75772.7 -124152.56 0)
```
This has been fixed to output the other last 4 of the eight bytes, which contains the information.
```
OGRFeature(elements):141784
  Type (Integer) = 17
  Level (Integer) = 3
  GraphicGroup (Integer) = 0
  ColorIndex (Integer) = 31
  Weight (Integer) = 0
  Style (Integer) = 0
  Text (String) = Quinta das Urzes
  ULink (String(JSON)) = { "6549": [ { "size": 8, "domain": "0x04", "subdomain": "0x01", "family": "0x03", "object": "0x02", "key": "04010302", "type": "IPCC\/Portugal" } ] }
  Style = LABEL(t:"Quinta das Urzes",c:#000000,s:18g,f:MICROS)
  POINT Z (-75772.7 -124152.56 0)
```
## What are related issues/pull requests?

The issue #3496 was introduced by myself. Change the order of the field declaration solves the problem.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 20.04
* Compiler: gcc 8.4.0
