### PR TITLE
netCDF multidim: add a GROUP_BY=SAME_DIMENSION option to GetGroupNames()

### DIFF
--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -1557,3 +1557,23 @@ def test_netcdf_multidim_createcopy_array_options_if_name_fullname(netcdf_setup)
     check()
 
     gdal.Unlink(tmpfilename)
+
+
+def test_netcdf_multidim_group_by_same_dimension(netcdf_setup):  # noqa
+
+    if not gdaltest.netcdf_drv_has_nc4:
+        pytest.skip()
+
+    ds = gdal.OpenEx('data/netcdf/sen3_sral_mwr_fake_standard_measurement.nc', gdal.OF_MULTIDIM_RASTER)
+    rg = ds.GetRootGroup()
+    assert rg.GetMDArrayNames(['GROUP_BY=SAME_DIMENSION']) is None
+    groups = rg.GetGroupNames(['GROUP_BY=SAME_DIMENSION'])
+    assert set(groups) == set(['time_01', 'time_20_c', 'time_20_ku'])
+    g = rg.OpenGroup('time_01', ['GROUP_BY=SAME_DIMENSION'])
+    assert g is not None
+    arrays = g.GetMDArrayNames()
+    for arrayName in arrays:
+        ar = g.OpenMDArray(arrayName)
+        dims = ar.GetDimensions()
+        assert len(dims) == 1
+        assert dims[0].GetName() == 'time_01'

--- a/gdal/doc/source/drivers/raster/netcdf.rst
+++ b/gdal/doc/source/drivers/raster/netcdf.rst
@@ -427,6 +427,18 @@ Multidimensional API support
 The netCDF driver supports the :ref:`multidim_raster_data_model` for reading and
 creation operations.
 
+The :cpp:func:`GDALGroup::GetGroupNames` method supports the following options:
+
+- GROUP_BY=SAME_DIMENSION. If set, single-dimensional variables will be exposed
+  as a "virtual" subgroup. This enables the user to get a clearer organization of
+  variables, for example in datasets where variables belonging to different
+  trajectories are indexed by different dimensions but mixed in the same netCDF
+  group.
+
+The :cpp:func:`GDALGroup::OpenGroup` method supports the following options:
+
+- GROUP_BY=SAME_DIMENSION. See above description
+
 The :cpp:func:`GDALGroup::GetMDArrayNames` method supports the following options:
 
 - SHOW_ALL=YES/NO. Defaults to NO. If set to YES, all variables will be listed.
@@ -442,6 +454,7 @@ The :cpp:func:`GDALGroup::GetMDArrayNames` method supports the following options
 - SHOW_TIME=YES/NO. Defaults to YES. If set to NO,
   single-dimensional variables whose ``standard_name`` attribute is "time"
   will not be listed.
+- GROUP_BY=SAME_DIMENSION. If set, single-dimensional variables will not be listed
 
 The :cpp:func:`GDALGroup::CreateMDArray` method supports the following options:
 


### PR DESCRIPTION
If set, single-dimensional variables will be exposed
as a "virtual" subgroup. This enables the user to get a clearer organization of
variables, for example in datasets where variables belonging to different
trajectories are indexed by different dimensions but mixed in the same netCDF
group.

Useful in particular for datasets such as Sentinel-3 altimetry products, L2 SRAL/MWR
