### PR TITLE
shapelib: update from upstream: general cleanup; no functional changes

### DIFF
--- a/gdal/ogr/ogrsf_frmts/shape/dbfopen.c
+++ b/gdal/ogr/ogrsf_frmts/shape/dbfopen.c
@@ -37,6 +37,8 @@
 #include "shapefil.h"
 
 #include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
@@ -106,9 +108,7 @@ CPL_INLINE static void CPL_IGNORE_RET_VAL_INT(CPL_UNUSED int unused) {}
 /*      a valid input.                                                  */
 /************************************************************************/
 
-static void * SfRealloc( void * pMem, int nNewSize )
-
-{
+static void * SfRealloc( void * pMem, int nNewSize ) {
     if( pMem == SHPLIB_NULLPTR )
         return malloc(nNewSize);
     else
@@ -124,10 +124,8 @@ static void * SfRealloc( void * pMem, int nNewSize )
 /*      and so forth values.                                            */
 /************************************************************************/
 
-static void DBFWriteHeader(DBFHandle psDBF)
-
-{
-    unsigned char	abyHeader[XBASE_FILEHDR_SZ] = { 0 };
+static void DBFWriteHeader(DBFHandle psDBF) {
+    unsigned char abyHeader[XBASE_FILEHDR_SZ] = { 0 };
 
     if( !psDBF->bNoHeader )
         return;
@@ -169,9 +167,7 @@ static void DBFWriteHeader(DBFHandle psDBF)
     if( psDBF->nHeaderLength > XBASE_FLDHDR_SZ*psDBF->nFields +
                                XBASE_FLDHDR_SZ )
     {
-        char	cNewline;
-
-        cNewline = HEADER_RECORD_TERMINATOR;
+        char cNewline = HEADER_RECORD_TERMINATOR;
         psDBF->sHooks.FWrite( &cNewline, 1, 1, psDBF->fp );
     }
 
@@ -192,16 +188,12 @@ static void DBFWriteHeader(DBFHandle psDBF)
 /*      Write out the current record if there is one.                   */
 /************************************************************************/
 
-static int DBFFlushRecord( DBFHandle psDBF )
-
-{
-    SAOffset	nRecordOffset;
-
+static bool DBFFlushRecord( DBFHandle psDBF ) {
     if( psDBF->bCurrentRecordModified && psDBF->nCurrentRecord > -1 )
     {
 	psDBF->bCurrentRecordModified = FALSE;
 
-	nRecordOffset =
+        const SAOffset nRecordOffset =
             psDBF->nRecordLength * STATIC_CAST(SAOffset, psDBF->nCurrentRecord)
             + psDBF->nHeaderLength;
 
@@ -217,7 +209,7 @@ static int DBFFlushRecord( DBFHandle psDBF )
                           "Failure seeking to position before writing DBF record %d.",
                           psDBF->nCurrentRecord );
                 psDBF->sHooks.Error( szMessage );
-                return FALSE;
+                return false;
             }
         }
 
@@ -229,7 +221,7 @@ static int DBFFlushRecord( DBFHandle psDBF )
             snprintf( szMessage, sizeof(szMessage), "Failure writing DBF record %d.",
                      psDBF->nCurrentRecord );
             psDBF->sHooks.Error( szMessage );
-            return FALSE;
+            return false;
         }
 
 /* -------------------------------------------------------------------- */
@@ -247,24 +239,20 @@ static int DBFFlushRecord( DBFHandle psDBF )
         }
     }
 
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/
 /*                           DBFLoadRecord()                            */
 /************************************************************************/
 
-static int DBFLoadRecord( DBFHandle psDBF, int iRecord )
-
-{
+static bool DBFLoadRecord( DBFHandle psDBF, int iRecord ) {
     if( psDBF->nCurrentRecord != iRecord )
     {
-        SAOffset nRecordOffset;
-
 	if( !DBFFlushRecord( psDBF ) )
-            return FALSE;
+            return false;
 
-	nRecordOffset =
+        const SAOffset nRecordOffset =
             psDBF->nRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
 
 	if( psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, SEEK_SET ) != 0 )
@@ -273,7 +261,7 @@ static int DBFLoadRecord( DBFHandle psDBF, int iRecord )
             snprintf( szMessage, sizeof(szMessage), "fseek(%ld) failed on DBF file.",
                       STATIC_CAST(long, nRecordOffset) );
             psDBF->sHooks.Error( szMessage );
-            return FALSE;
+            return false;
         }
 
 	if( psDBF->sHooks.FRead( psDBF->pszCurrentRecord,
@@ -283,7 +271,7 @@ static int DBFLoadRecord( DBFHandle psDBF, int iRecord )
             snprintf( szMessage, sizeof(szMessage), "fread(%d) failed on DBF file.",
                      psDBF->nRecordLength );
             psDBF->sHooks.Error( szMessage );
-            return FALSE;
+            return false;
         }
 
 	psDBF->nCurrentRecord = iRecord;
@@ -293,7 +281,7 @@ static int DBFLoadRecord( DBFHandle psDBF, int iRecord )
 	psDBF->bRequireNextWriteSeek = TRUE;
     }
 
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/
@@ -301,11 +289,7 @@ static int DBFLoadRecord( DBFHandle psDBF, int iRecord )
 /************************************************************************/
 
 void SHPAPI_CALL
-DBFUpdateHeader( DBFHandle psDBF )
-
-{
-    unsigned char abyFileHeader[XBASE_FILEHDR_SZ] = {0}; 
-
+DBFUpdateHeader( DBFHandle psDBF ) {
     if( psDBF->bNoHeader )
         DBFWriteHeader( psDBF );
 
@@ -313,6 +297,8 @@ DBFUpdateHeader( DBFHandle psDBF )
         return;
 
     psDBF->sHooks.FSeek( psDBF->fp, 0, 0 );
+
+    unsigned char abyFileHeader[XBASE_FILEHDR_SZ] = {0};
     psDBF->sHooks.FRead( abyFileHeader, 1, sizeof(abyFileHeader), psDBF->fp );
 
     abyFileHeader[1] = STATIC_CAST(unsigned char, psDBF->nUpdateYearSince1900);
@@ -362,11 +348,9 @@ DBFOpen( const char * pszFilename, const char * pszAccess )
 /*                      DBFGetLenWithoutExtension()                     */
 /************************************************************************/
 
-static int DBFGetLenWithoutExtension(const char* pszBasename)
-{
-    int i;
-    int nLen = STATIC_CAST(int, strlen(pszBasename));
-    for( i = nLen-1;
+static int DBFGetLenWithoutExtension(const char* pszBasename) {
+    const int nLen = STATIC_CAST(int, strlen(pszBasename));
+    for( int i = nLen-1;
          i > 0 && pszBasename[i] != '/' && pszBasename[i] != '\\';
          i-- )
     {
@@ -385,17 +369,7 @@ static int DBFGetLenWithoutExtension(const char* pszBasename)
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL
-DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
-
-{
-    DBFHandle		psDBF;
-    SAFile		pfCPG;
-    unsigned char	*pabyBuf;
-    int			nFields, nHeadLen, iField;
-    char		*pszFullname;
-    int                 nBufSize = 500;
-    int                 nLenWithoutExtension;
-
+DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks ) {
 /* -------------------------------------------------------------------- */
 /*      We only allow the access strings "rb" and "r+".                  */
 /* -------------------------------------------------------------------- */
@@ -414,12 +388,12 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
 /*	Compute the base (layer) name.  If there is any extension	*/
 /*	on the passed in filename we will strip it off.			*/
 /* -------------------------------------------------------------------- */
-    nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
-    pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    const int nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
+    char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszFilename, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
-    psDBF = STATIC_CAST(DBFHandle, calloc( 1, sizeof(DBFInfo) ));
+    DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc( 1, sizeof(DBFInfo) ));
     psDBF->fp = psHooks->FOpen( pszFullname, pszAccess );
     memcpy( &(psDBF->sHooks), psHooks, sizeof(SAHooks) );
 
@@ -430,7 +404,7 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".cpg", 5);
-    pfCPG = psHooks->FOpen( pszFullname, "r" );
+    SAFile pfCPG = psHooks->FOpen( pszFullname, "r" );
     if( pfCPG == SHPLIB_NULLPTR )
     {
         memcpy(pszFullname + nLenWithoutExtension, ".CPG", 5);
@@ -453,7 +427,8 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
 /*  Read Table Header info                                              */
 /* -------------------------------------------------------------------- */
-    pabyBuf = STATIC_CAST(unsigned char *, malloc(nBufSize));
+    const int nBufSize = 500;
+    unsigned char *pabyBuf = STATIC_CAST(unsigned char *, malloc(nBufSize));
     if( psDBF->sHooks.FRead( pabyBuf, XBASE_FILEHDR_SZ, 1, psDBF->fp ) != 1 )
     {
         psDBF->sHooks.FClose( psDBF->fp );
@@ -468,7 +443,8 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
     psDBF->nRecords =
      pabyBuf[4]|(pabyBuf[5]<<8)|(pabyBuf[6]<<16)|((pabyBuf[7]&0x7f)<<24);
 
-    psDBF->nHeaderLength = nHeadLen = pabyBuf[8]|(pabyBuf[9]<<8);
+    const int nHeadLen = pabyBuf[8]|(pabyBuf[9]<<8);
+    psDBF->nHeaderLength = nHeadLen;
     psDBF->nRecordLength = pabyBuf[10]|(pabyBuf[11]<<8);
     psDBF->iLanguageDriver = pabyBuf[29];
 
@@ -481,7 +457,8 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
         return SHPLIB_NULLPTR;
     }
 
-    psDBF->nFields = nFields = (nHeadLen - XBASE_FILEHDR_SZ) / XBASE_FLDHDR_SZ;
+    const int nFields = (nHeadLen - XBASE_FILEHDR_SZ) / XBASE_FLDHDR_SZ;
+    psDBF->nFields = nFields;
 
     /* coverity[tainted_data] */
     psDBF->pszCurrentRecord = STATIC_CAST(char *, malloc(psDBF->nRecordLength));
@@ -489,14 +466,12 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
 /*  Figure out the code page from the LDID and CPG                      */
 /* -------------------------------------------------------------------- */
-
     psDBF->pszCodePage = SHPLIB_NULLPTR;
     if( pfCPG )
     {
-        size_t n;
         memset( pabyBuf, 0, nBufSize);
         psDBF->sHooks.FRead(pabyBuf, 1, nBufSize - 1, pfCPG);
-        n = strcspn( REINTERPRET_CAST(char *, pabyBuf), "\n\r" );
+        const size_t n = strcspn( REINTERPRET_CAST(char *, pabyBuf), "\n\r" );
         if( n > 0 )
         {
             pabyBuf[n] = '\0';
@@ -515,7 +490,6 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
 /*  Read in Field Definitions                                           */
 /* -------------------------------------------------------------------- */
-
     pabyBuf = STATIC_CAST(unsigned char *, SfRealloc(pabyBuf,nHeadLen));
     psDBF->pszHeader = REINTERPRET_CAST(char *, pabyBuf);
 
@@ -536,11 +510,9 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
     psDBF->panFieldDecimals = STATIC_CAST(int *, malloc(sizeof(int) * nFields));
     psDBF->pachFieldType = STATIC_CAST(char *, malloc(sizeof(char) * nFields));
 
-    for( iField = 0; iField < nFields; iField++ )
+    for( int iField = 0; iField < nFields; iField++ )
     {
-	unsigned char		*pabyFInfo;
-
-	pabyFInfo = pabyBuf+iField*XBASE_FLDHDR_SZ;
+	unsigned char *pabyFInfo = pabyBuf+iField*XBASE_FLDHDR_SZ;
         if( pabyFInfo[0] == HEADER_RECORD_TERMINATOR )
         {
             psDBF->nFields = iField;
@@ -646,9 +618,7 @@ DBFClose(DBFHandle psDBF)
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL
-DBFCreate( const char * pszFilename )
-
-{
+DBFCreate( const char * pszFilename ) {
     return DBFCreateEx( pszFilename, "LDID/87" ); // 0x57
 }
 
@@ -659,9 +629,7 @@ DBFCreate( const char * pszFilename )
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL
-DBFCreateEx( const char * pszFilename, const char* pszCodePage )
-
-{
+DBFCreateEx( const char * pszFilename, const char* pszCodePage ) {
     SAHooks sHooks;
 
     SASetupDefaultHooks( &sHooks );
@@ -676,35 +644,27 @@ DBFCreateEx( const char * pszFilename, const char* pszCodePage )
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL
-DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHooks )
-
-{
-    DBFHandle	psDBF;
-    SAFile	fp;
-    char	*pszFullname;
-    int		ldid = -1;
-    char chZero = '\0';
-    int         nLenWithoutExtension;
-
+DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHooks ) {
 /* -------------------------------------------------------------------- */
 /*	Compute the base (layer) name.  If there is any extension	*/
 /*	on the passed in filename we will strip it off.			*/
 /* -------------------------------------------------------------------- */
-    nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
-    pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    const int nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
+    char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszFilename, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
 /* -------------------------------------------------------------------- */
 /*      Create the file.                                                */
 /* -------------------------------------------------------------------- */
-    fp = psHooks->FOpen( pszFullname, "wb" );
+    SAFile fp = psHooks->FOpen( pszFullname, "wb" );
     if( fp == SHPLIB_NULLPTR )
     {
         free( pszFullname );
         return SHPLIB_NULLPTR;
     }
 
+    char chZero = '\0';
     psHooks->FWrite( &chZero, 1, 1, fp );
     psHooks->FClose( fp );
 
@@ -716,6 +676,7 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".cpg", 5);
+    int ldid = -1;
     if( pszCodePage != SHPLIB_NULLPTR )
     {
         if( strncmp( pszCodePage, "LDID/", 5 ) == 0 )
@@ -741,7 +702,7 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
 /* -------------------------------------------------------------------- */
 /*	Create the info structure.					*/
 /* -------------------------------------------------------------------- */
-    psDBF = STATIC_CAST(DBFHandle, calloc(1,sizeof(DBFInfo)));
+    DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc(1,sizeof(DBFInfo)));
 
     memcpy( &(psDBF->sHooks), psHooks, sizeof(SAHooks) );
     psDBF->fp = fp;
@@ -786,10 +747,8 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
 
 int SHPAPI_CALL
 DBFAddField(DBFHandle psDBF, const char * pszFieldName,
-            DBFFieldType eType, int nWidth, int nDecimals )
-
-{
-    char chNativeType = 'C';
+            DBFFieldType eType, int nWidth, int nDecimals ) {
+    char chNativeType;
 
     if( eType == FTLogical )
         chNativeType = 'L';
@@ -808,8 +767,7 @@ DBFAddField(DBFHandle psDBF, const char * pszFieldName,
 /*                        DBFGetNullCharacter()                         */
 /************************************************************************/
 
-static char DBFGetNullCharacter(char chType)
-{
+static char DBFGetNullCharacter(char chType) {
     switch (chType)
     {
       case 'N':
@@ -833,16 +791,7 @@ static char DBFGetNullCharacter(char chType)
 
 int SHPAPI_CALL
 DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
-                      char chType, int nWidth, int nDecimals )
-
-{
-    char	*pszFInfo;
-    int		i;
-    int         nOldRecordLength, nOldHeaderLength;
-    char        *pszRecord;
-    char        chFieldFill;
-    SAOffset    nRecordOffset;
-
+                      char chType, int nWidth, int nDecimals ) {
     /* make sure that everything is written in .dbf */
     if( !DBFFlushRecord( psDBF ) )
         return -1;
@@ -878,8 +827,8 @@ DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
         return -1;
     }
 
-    nOldRecordLength = psDBF->nRecordLength;
-    nOldHeaderLength = psDBF->nHeaderLength;
+    const int nOldRecordLength = psDBF->nRecordLength;
+    const int nOldHeaderLength = psDBF->nHeaderLength;
 
 /* -------------------------------------------------------------------- */
 /*      SfRealloc all the arrays larger to hold the additional field      */
@@ -917,9 +866,9 @@ DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
     psDBF->pszHeader = STATIC_CAST(char *, SfRealloc(psDBF->pszHeader,
                                           psDBF->nFields*XBASE_FLDHDR_SZ));
 
-    pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * (psDBF->nFields-1);
+    char *pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * (psDBF->nFields-1);
 
-    for( i = 0; i < XBASE_FLDHDR_SZ; i++ )
+    for( int i = 0; i < XBASE_FLDHDR_SZ; i++ )
         pszFInfo[i] = '\0';
 
     strncpy( pszFInfo, pszFieldName, XBASE_FLDNAME_LEN_WRITE );
@@ -952,17 +901,18 @@ DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
 /* -------------------------------------------------------------------- */
 
     /* alloc record */
-    pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
+    char *pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
 
-    chFieldFill = DBFGetNullCharacter(chType);
+    const char chFieldFill = DBFGetNullCharacter(chType);
 
-    for (i = psDBF->nRecords-1; i >= 0; --i)
+    SAOffset nRecordOffset;
+    for (int i = psDBF->nRecords-1; i >= 0; --i)
     {
         nRecordOffset = nOldRecordLength * STATIC_CAST(SAOffset, i) + nOldHeaderLength;
 
         /* load record */
         psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
-        if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1, psDBF->fp) != 1) { 
+        if (psDBF->sHooks.FRead(pszRecord, nOldRecordLength, 1, psDBF->fp) != 1) {
           free(pszRecord);
           return -1;
         }
@@ -1009,12 +959,7 @@ DBFAddNativeFieldType(DBFHandle psDBF, const char * pszFieldName,
 /************************************************************************/
 
 static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
-                              char chReqType )
-
-{
-    unsigned char	*pabyRec;
-    void	*pReturnField = SHPLIB_NULLPTR;
-
+                              char chReqType ) {
 /* -------------------------------------------------------------------- */
 /*      Verify selection.                                               */
 /* -------------------------------------------------------------------- */
@@ -1030,7 +975,7 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
     if( !DBFLoadRecord( psDBF, hEntity ) )
         return SHPLIB_NULLPTR;
 
-    pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
 /* -------------------------------------------------------------------- */
 /*      Ensure we have room to extract the target field.                */
@@ -1053,7 +998,7 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
 	     psDBF->panFieldSize[iField] );
     psDBF->pszWorkField[psDBF->panFieldSize[iField]] = '\0';
 
-    pReturnField = psDBF->pszWorkField;
+    void *pReturnField = psDBF->pszWorkField;
 
 /* -------------------------------------------------------------------- */
 /*      Decode the field.                                               */
@@ -1077,9 +1022,9 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
 #ifdef TRIM_DBF_WHITESPACE
     else
     {
-        char	*pchSrc, *pchDst;
+        char *pchSrc = psDBF->pszWorkField;
+        char *pchDst = pchSrc;
 
-        pchDst = pchSrc = psDBF->pszWorkField;
         while( *pchSrc == ' ' )
             pchSrc++;
 
@@ -1102,12 +1047,8 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
 /************************************************************************/
 
 int SHPAPI_CALL
-DBFReadIntegerAttribute( DBFHandle psDBF, int iRecord, int iField )
-
-{
-    int	*pnValue;
-
-    pnValue = STATIC_CAST(int *, DBFReadAttribute( psDBF, iRecord, iField, 'I' ));
+DBFReadIntegerAttribute( DBFHandle psDBF, int iRecord, int iField ) {
+    int	*pnValue = STATIC_CAST(int *, DBFReadAttribute( psDBF, iRecord, iField, 'I' ));
 
     if( pnValue == SHPLIB_NULLPTR )
         return 0;
@@ -1122,12 +1063,8 @@ DBFReadIntegerAttribute( DBFHandle psDBF, int iRecord, int iField )
 /************************************************************************/
 
 double SHPAPI_CALL
-DBFReadDoubleAttribute( DBFHandle psDBF, int iRecord, int iField )
-
-{
-    double	*pdValue;
-
-    pdValue = STATIC_CAST(double *, DBFReadAttribute( psDBF, iRecord, iField, 'N' ));
+DBFReadDoubleAttribute( DBFHandle psDBF, int iRecord, int iField ) {
+    double *pdValue = STATIC_CAST(double *, DBFReadAttribute( psDBF, iRecord, iField, 'N' ));
 
     if( pdValue == SHPLIB_NULLPTR )
         return 0.0;
@@ -1168,12 +1105,9 @@ DBFReadLogicalAttribute( DBFHandle psDBF, int iRecord, int iField )
 /*      Return TRUE if the passed string is NULL.                       */
 /************************************************************************/
 
-static int DBFIsValueNULL( char chType, const char* pszValue )
-{
-    int i;
-
+static bool DBFIsValueNULL( char chType, const char* pszValue ) {
     if( pszValue == SHPLIB_NULLPTR )
-        return TRUE;
+        return true;
 
     switch(chType)
     {
@@ -1185,14 +1119,14 @@ static int DBFIsValueNULL( char chType, const char* pszValue )
         ** asterisks.
         */
         if( pszValue[0] == '*' )
-            return TRUE;
+            return true;
 
-        for( i = 0; pszValue[i] != '\0'; i++ )
+        for( int i = 0; pszValue[i] != '\0'; i++ )
         {
             if( pszValue[i] != ' ' )
-                return FALSE;
+                return false;
         }
-        return TRUE;
+        return true;
 
       case 'D':
         /* NULL date fields have value "00000000" */
@@ -1217,12 +1151,8 @@ static int DBFIsValueNULL( char chType, const char* pszValue )
 /************************************************************************/
 
 int SHPAPI_CALL
-DBFIsAttributeNULL( DBFHandle psDBF, int iRecord, int iField )
-
-{
-    const char	*pszValue;
-
-    pszValue = DBFReadStringAttribute( psDBF, iRecord, iField );
+DBFIsAttributeNULL( DBFHandle psDBF, int iRecord, int iField ) {
+    const char *pszValue = DBFReadStringAttribute( psDBF, iRecord, iField );
 
     if( pszValue == SHPLIB_NULLPTR )
         return TRUE;
@@ -1280,12 +1210,10 @@ DBFGetFieldInfo( DBFHandle psDBF, int iField, char * pszFieldName,
 
     if( pszFieldName != SHPLIB_NULLPTR )
     {
-	int	i;
-
 	strncpy( pszFieldName, STATIC_CAST(char *,psDBF->pszHeader)+iField*XBASE_FLDHDR_SZ,
                  XBASE_FLDNAME_LEN_READ );
 	pszFieldName[XBASE_FLDNAME_LEN_READ] = '\0';
-	for( i = XBASE_FLDNAME_LEN_READ - 1; i > 0 && pszFieldName[i] == ' '; i-- )
+	for( int i = XBASE_FLDNAME_LEN_READ - 1; i > 0 && pszFieldName[i] == ' '; i-- )
 	    pszFieldName[i] = '\0';
     }
 
@@ -1316,19 +1244,13 @@ DBFGetFieldInfo( DBFHandle psDBF, int iField, char * pszFieldName,
 /*	Write an attribute record to the file.				*/
 /************************************************************************/
 
-static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
-			     void * pValue )
-
-{
-    int	       	i, j, nRetResult = TRUE;
-    unsigned char	*pabyRec;
-    char	szSField[XBASE_FLD_MAX_WIDTH+1], szFormat[20];
-
+static bool DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
+			     void * pValue ) {
 /* -------------------------------------------------------------------- */
 /*	Is this a valid record?						*/
 /* -------------------------------------------------------------------- */
     if( hEntity < 0 || hEntity > psDBF->nRecords )
-        return( FALSE );
+        return false;
 
     if( psDBF->bNoHeader )
         DBFWriteHeader(psDBF);
@@ -1339,10 +1261,10 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
     if( hEntity == psDBF->nRecords )
     {
 	if( !DBFFlushRecord( psDBF ) )
-            return FALSE;
+            return false;
 
 	psDBF->nRecords++;
-	for( i = 0; i < psDBF->nRecordLength; i++ )
+	for( int i = 0; i < psDBF->nRecordLength; i++ )
 	    psDBF->pszCurrentRecord[i] = ' ';
 
 	psDBF->nCurrentRecord = hEntity;
@@ -1353,9 +1275,9 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
 /*      we accessed?                                                    */
 /* -------------------------------------------------------------------- */
     if( !DBFLoadRecord( psDBF, hEntity ) )
-        return FALSE;
+        return false;
 
-    pabyRec = REINTERPRET_CAST(unsigned char *,psDBF->pszCurrentRecord);
+    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
     psDBF->bCurrentRecordModified = TRUE;
     psDBF->bUpdated = TRUE;
@@ -1370,23 +1292,27 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
         memset( pabyRec+psDBF->panFieldOffset[iField],
                 DBFGetNullCharacter(psDBF->pachFieldType[iField]),
                 psDBF->panFieldSize[iField] );
-        return TRUE;
+        return true;
     }
 
 /* -------------------------------------------------------------------- */
 /*      Assign all the record fields.                                   */
 /* -------------------------------------------------------------------- */
+    bool nRetResult = true;
+
     switch( psDBF->pachFieldType[iField] )
     {
       case 'D':
       case 'N':
       case 'F':
       {
-        int		nWidth = psDBF->panFieldSize[iField];
+        int nWidth = psDBF->panFieldSize[iField];
 
+        char szSField[XBASE_FLD_MAX_WIDTH+1];
         if( STATIC_CAST(int,sizeof(szSField))-2 < nWidth )
             nWidth = sizeof(szSField)-2;
 
+        char szFormat[20];
         snprintf( szFormat, sizeof(szFormat), "%%%d.%df",
                     nWidth, psDBF->panFieldDecimals[iField] );
         CPLsnprintf(szSField, sizeof(szSField), szFormat, *STATIC_CAST(double *, pValue) );
@@ -1394,7 +1320,7 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
         if( STATIC_CAST(int,strlen(szSField)) > psDBF->panFieldSize[iField] )
         {
             szSField[psDBF->panFieldSize[iField]] = '\0';
-            nRetResult = FALSE;
+            nRetResult = false;
         }
         memcpy(REINTERPRET_CAST(char *, pabyRec+psDBF->panFieldOffset[iField]),
             szSField, strlen(szSField) );
@@ -1408,10 +1334,12 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
         break;
 
       default:
+      {
+        int j;
 	if( STATIC_CAST(int, strlen(STATIC_CAST(char *,pValue))) > psDBF->panFieldSize[iField] )
         {
 	    j = psDBF->panFieldSize[iField];
-            nRetResult = FALSE;
+            nRetResult = false;
         }
 	else
         {
@@ -1423,9 +1351,10 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
 	strncpy(REINTERPRET_CAST(char *, pabyRec+psDBF->panFieldOffset[iField]),
 		STATIC_CAST(const char *, pValue), j );
 	break;
+      }
     }
 
-    return( nRetResult );
+    return nRetResult;
 }
 
 /************************************************************************/
@@ -1438,12 +1367,7 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
 
 int SHPAPI_CALL
 DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity, int iField,
-                              void * pValue )
-
-{
-    int	       		i, j;
-    unsigned char	*pabyRec;
-
+                              void * pValue ) {
 /* -------------------------------------------------------------------- */
 /*	Is this a valid record?						*/
 /* -------------------------------------------------------------------- */
@@ -1462,7 +1386,7 @@ DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity, int iField,
             return FALSE;
 
 	psDBF->nRecords++;
-	for( i = 0; i < psDBF->nRecordLength; i++ )
+	for( int i = 0; i < psDBF->nRecordLength; i++ )
 	    psDBF->pszCurrentRecord[i] = ' ';
 
 	psDBF->nCurrentRecord = hEntity;
@@ -1475,11 +1399,12 @@ DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity, int iField,
     if( !DBFLoadRecord( psDBF, hEntity ) )
         return FALSE;
 
-    pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
 /* -------------------------------------------------------------------- */
 /*      Assign all the record fields.                                   */
 /* -------------------------------------------------------------------- */
+    int j;
     if( STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue))) > psDBF->panFieldSize[iField] )
         j = psDBF->panFieldSize[iField];
     else
@@ -1506,9 +1431,7 @@ DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity, int iField,
 
 int SHPAPI_CALL
 DBFWriteDoubleAttribute( DBFHandle psDBF, int iRecord, int iField,
-                         double dValue )
-
-{
+                         double dValue ) {
     return( DBFWriteAttribute( psDBF, iRecord, iField, STATIC_CAST(void *, &dValue) ) );
 }
 
@@ -1520,10 +1443,8 @@ DBFWriteDoubleAttribute( DBFHandle psDBF, int iRecord, int iField,
 
 int SHPAPI_CALL
 DBFWriteIntegerAttribute( DBFHandle psDBF, int iRecord, int iField,
-                          int nValue )
-
-{
-    double	dValue = nValue;
+                          int nValue ) {
+    double dValue = nValue;
 
     return( DBFWriteAttribute( psDBF, iRecord, iField, STATIC_CAST(void *, &dValue) ) );
 }
@@ -1576,12 +1497,7 @@ DBFWriteLogicalAttribute( DBFHandle psDBF, int iRecord, int iField,
 /************************************************************************/
 
 int SHPAPI_CALL
-DBFWriteTuple(DBFHandle psDBF, int hEntity, void * pRawTuple )
-
-{
-    int	       		i;
-    unsigned char	*pabyRec;
-
+DBFWriteTuple(DBFHandle psDBF, int hEntity, void * pRawTuple ) {
 /* -------------------------------------------------------------------- */
 /*	Is this a valid record?						*/
 /* -------------------------------------------------------------------- */
@@ -1600,7 +1516,7 @@ DBFWriteTuple(DBFHandle psDBF, int hEntity, void * pRawTuple )
             return FALSE;
 
 	psDBF->nRecords++;
-	for( i = 0; i < psDBF->nRecordLength; i++ )
+	for( int i = 0; i < psDBF->nRecordLength; i++ )
 	    psDBF->pszCurrentRecord[i] = ' ';
 
 	psDBF->nCurrentRecord = hEntity;
@@ -1613,7 +1529,7 @@ DBFWriteTuple(DBFHandle psDBF, int hEntity, void * pRawTuple )
     if( !DBFLoadRecord( psDBF, hEntity ) )
         return FALSE;
 
-    pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    unsigned char *pabyRec = REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
     memcpy ( pabyRec, pRawTuple,  psDBF->nRecordLength );
 
@@ -1650,11 +1566,8 @@ DBFReadTuple(DBFHandle psDBF, int hEntity )
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL
-DBFCloneEmpty(DBFHandle psDBF, const char * pszFilename )
-{
-    DBFHandle	newDBF;
-
-   newDBF = DBFCreateEx ( pszFilename, psDBF->pszCodePage );
+DBFCloneEmpty(DBFHandle psDBF, const char * pszFilename ) {
+   DBFHandle newDBF = DBFCreateEx ( pszFilename, psDBF->pszCodePage );
    if ( newDBF == SHPLIB_NULLPTR ) return SHPLIB_NULLPTR;
 
    newDBF->nFields = psDBF->nFields;
@@ -1719,13 +1632,10 @@ DBFGetNativeFieldType( DBFHandle psDBF, int iField )
 /************************************************************************/
 
 int SHPAPI_CALL
-DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName)
+DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName) {
+    char name[XBASE_FLDNAME_LEN_READ+1];
 
-{
-    char          name[XBASE_FLDNAME_LEN_READ+1];
-    int           i;
-
-    for( i = 0; i < DBFGetFieldCount(psDBF); i++ )
+    for( int i = 0; i < DBFGetFieldCount(psDBF); i++ )
     {
         DBFGetFieldInfo( psDBF, i, name, SHPLIB_NULLPTR, SHPLIB_NULLPTR );
         if(!STRCASECMP(pszFieldName,name))
@@ -1741,9 +1651,7 @@ DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName)
 /*      it returns FALSE.                                               */
 /************************************************************************/
 
-int SHPAPI_CALL DBFIsRecordDeleted( DBFHandle psDBF, int iShape )
-
-{
+int SHPAPI_CALL DBFIsRecordDeleted( DBFHandle psDBF, int iShape ) {
 /* -------------------------------------------------------------------- */
 /*      Verify selection.                                               */
 /* -------------------------------------------------------------------- */
@@ -1767,11 +1675,7 @@ int SHPAPI_CALL DBFIsRecordDeleted( DBFHandle psDBF, int iShape )
 /************************************************************************/
 
 int SHPAPI_CALL DBFMarkRecordDeleted( DBFHandle psDBF, int iShape,
-                                      int bIsDeleted )
-
-{
-    char chNewFlag;
-
+                                      int bIsDeleted ) {
 /* -------------------------------------------------------------------- */
 /*      Verify selection.                                               */
 /* -------------------------------------------------------------------- */
@@ -1788,6 +1692,7 @@ int SHPAPI_CALL DBFMarkRecordDeleted( DBFHandle psDBF, int iShape,
 /* -------------------------------------------------------------------- */
 /*      Assign value, marking record as dirty if it changes.            */
 /* -------------------------------------------------------------------- */
+    char chNewFlag;
     if( bIsDeleted )
         chNewFlag = '*';
     else
@@ -1822,14 +1727,7 @@ DBFGetCodePage(DBFHandle psDBF )
 /************************************************************************/
 
 int SHPAPI_CALL
-DBFDeleteField(DBFHandle psDBF, int iField)
-{
-    int nOldRecordLength, nOldHeaderLength;
-    int nDeletedFieldOffset, nDeletedFieldSize;
-    SAOffset nRecordOffset;
-    char* pszRecord;
-    int i, iRecord;
-
+DBFDeleteField(DBFHandle psDBF, int iField) {
     if (iField < 0 || iField >= psDBF->nFields)
         return FALSE;
 
@@ -1838,13 +1736,13 @@ DBFDeleteField(DBFHandle psDBF, int iField)
         return FALSE;
 
     /* get information about field to be deleted */
-    nOldRecordLength = psDBF->nRecordLength;
-    nOldHeaderLength = psDBF->nHeaderLength;
-    nDeletedFieldOffset = psDBF->panFieldOffset[iField];
-    nDeletedFieldSize = psDBF->panFieldSize[iField];
+    int nOldRecordLength = psDBF->nRecordLength;
+    int nOldHeaderLength = psDBF->nHeaderLength;
+    int nDeletedFieldOffset = psDBF->panFieldOffset[iField];
+    int nDeletedFieldSize = psDBF->panFieldSize[iField];
 
     /* update fields info */
-    for (i = iField + 1; i < psDBF->nFields; i++)
+    for (int i = iField + 1; i < psDBF->nFields; i++)
     {
         psDBF->panFieldOffset[i-1] = psDBF->panFieldOffset[i] - nDeletedFieldSize;
         psDBF->panFieldSize[i-1] = psDBF->panFieldSize[i];
@@ -1892,12 +1790,12 @@ DBFDeleteField(DBFHandle psDBF, int iField)
     DBFUpdateHeader( psDBF );
 
     /* alloc record */
-    pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * nOldRecordLength));
+    char *pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * nOldRecordLength));
 
     /* shift records to their new positions */
-    for (iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
+    for (int iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
     {
-        nRecordOffset =
+        SAOffset nRecordOffset =
             nOldRecordLength * STATIC_CAST(SAOffset,iRecord) + nOldHeaderLength;
 
         /* load record */
@@ -1952,19 +1850,7 @@ DBFDeleteField(DBFHandle psDBF, int iField)
 /************************************************************************/
 
 int SHPAPI_CALL
-DBFReorderFields( DBFHandle psDBF, int* panMap )
-{
-    SAOffset nRecordOffset;
-    int      i, iRecord;
-    int     *panFieldOffsetNew;
-    int     *panFieldSizeNew;
-    int     *panFieldDecimalsNew;
-    char    *pachFieldTypeNew;
-    char    *pszHeaderNew;
-    char    *pszRecord;
-    char    *pszRecordNew;
-    int errorAbort = FALSE;
-
+DBFReorderFields( DBFHandle psDBF, int* panMap ) {
     if ( psDBF->nFields == 0 )
         return TRUE;
 
@@ -1973,15 +1859,15 @@ DBFReorderFields( DBFHandle psDBF, int* panMap )
         return FALSE;
 
     /* a simple malloc() would be enough, but calloc() helps clang static analyzer */
-    panFieldOffsetNew = STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
-    panFieldSizeNew = STATIC_CAST(int *, calloc(sizeof(int),  psDBF->nFields));
-    panFieldDecimalsNew = STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
-    pachFieldTypeNew = STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
-    pszHeaderNew = STATIC_CAST(char*, malloc(sizeof(char) * XBASE_FLDHDR_SZ * 
+    int *panFieldOffsetNew = STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+    int *panFieldSizeNew = STATIC_CAST(int *, calloc(sizeof(int),  psDBF->nFields));
+    int *panFieldDecimalsNew = STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+    char *pachFieldTypeNew = STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
+    char *pszHeaderNew = STATIC_CAST(char*, malloc(sizeof(char) * XBASE_FLDHDR_SZ *
                                   psDBF->nFields));
 
     /* shuffle fields definitions */
-    for(i=0; i < psDBF->nFields; i++)
+    for(int i = 0; i < psDBF->nFields; i++)
     {
         panFieldSizeNew[i] = psDBF->panFieldSize[panMap[i]];
         panFieldDecimalsNew[i] = psDBF->panFieldDecimals[panMap[i]];
@@ -1990,13 +1876,15 @@ DBFReorderFields( DBFHandle psDBF, int* panMap )
                psDBF->pszHeader + panMap[i] * XBASE_FLDHDR_SZ, XBASE_FLDHDR_SZ);
     }
     panFieldOffsetNew[0] = 1;
-    for(i=1; i < psDBF->nFields; i++)
+    for(int i = 1; i < psDBF->nFields; i++)
     {
         panFieldOffsetNew[i] = panFieldOffsetNew[i - 1] + panFieldSizeNew[i - 1];
     }
 
     free(psDBF->pszHeader);
     psDBF->pszHeader = pszHeaderNew;
+
+    bool errorAbort = false;
 
     /* we're done if we're dealing with not yet created .dbf */
     if ( !(psDBF->bNoHeader && psDBF->nRecords == 0) )
@@ -2006,25 +1894,25 @@ DBFReorderFields( DBFHandle psDBF, int* panMap )
         DBFUpdateHeader( psDBF );
 
         /* alloc record */
-        pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
-        pszRecordNew = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
+        char *pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
+        char *pszRecordNew = STATIC_CAST(char *, malloc(sizeof(char) * psDBF->nRecordLength));
 
         /* shuffle fields in records */
-        for (iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
+        for (int iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
         {
-            nRecordOffset =
+            const SAOffset nRecordOffset =
                 psDBF->nRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
 
             /* load record */
             psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
             if (psDBF->sHooks.FRead(pszRecord, psDBF->nRecordLength, 1, psDBF->fp) != 1) {
-              errorAbort = TRUE;
-              break; 
+              errorAbort = true;
+              break;
             }
 
             pszRecordNew[0] = pszRecord[0];
 
-            for(i=0; i < psDBF->nFields; i++)
+            for(int i = 0; i < psDBF->nFields; i++)
             {
                 memcpy(pszRecordNew + panFieldOffsetNew[i],
                        pszRecord + psDBF->panFieldOffset[panMap[i]],
@@ -2042,16 +1930,16 @@ DBFReorderFields( DBFHandle psDBF, int* panMap )
     }
 
     if (errorAbort) {
-      free(panFieldOffsetNew); 
+      free(panFieldOffsetNew);
       free(panFieldSizeNew);
-      free(panFieldDecimalsNew); 
+      free(panFieldDecimalsNew);
       free(pachFieldTypeNew);
       psDBF->nCurrentRecord = -1;
       psDBF->bCurrentRecordModified = FALSE;
-      psDBF->bUpdated = FALSE; 
-      return FALSE; 
+      psDBF->bUpdated = FALSE;
+      return FALSE;
     }
-    
+
     free(psDBF->panFieldOffset);
     free(psDBF->panFieldSize);
     free(psDBF->panFieldDecimals);
@@ -2078,20 +1966,7 @@ DBFReorderFields( DBFHandle psDBF, int* panMap )
 
 int SHPAPI_CALL
 DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
-                    char chType, int nWidth, int nDecimals )
-{
-    int   i;
-    int   iRecord;
-    int   nOffset;
-    int   nOldWidth;
-    int   nOldRecordLength;
-    SAOffset  nRecordOffset;
-    char* pszFInfo;
-    char  chOldType;
-    int   bIsNULL;
-    char chFieldFill;
-    int errorAbort = FALSE;
-
+                    char chType, int nWidth, int nDecimals ) {
     if (iField < 0 || iField >= psDBF->nFields)
         return FALSE;
 
@@ -2099,12 +1974,12 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
     if( !DBFFlushRecord( psDBF ) )
         return FALSE;
 
-    chFieldFill = DBFGetNullCharacter(chType);
+    const char chFieldFill = DBFGetNullCharacter(chType);
 
-    chOldType = psDBF->pachFieldType[iField];
-    nOffset = psDBF->panFieldOffset[iField];
-    nOldWidth = psDBF->panFieldSize[iField];
-    nOldRecordLength = psDBF->nRecordLength;
+    const char chOldType = psDBF->pachFieldType[iField];
+    const int nOffset = psDBF->panFieldOffset[iField];
+    const int nOldWidth = psDBF->panFieldSize[iField];
+    const int nOldRecordLength = psDBF->nRecordLength;
 
 /* -------------------------------------------------------------------- */
 /*      Do some checking to ensure we can add records to this file.     */
@@ -2125,9 +2000,9 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
 /* -------------------------------------------------------------------- */
 /*      Update the header information.                                  */
 /* -------------------------------------------------------------------- */
-    pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * iField;
+    char* pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * iField;
 
-    for( i = 0; i < XBASE_FLDHDR_SZ; i++ )
+    for( int i = 0; i < XBASE_FLDHDR_SZ; i++ )
         pszFInfo[i] = '\0';
 
     strncpy( pszFInfo, pszFieldName, XBASE_FLDNAME_LEN_WRITE );
@@ -2150,7 +2025,7 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
 /* -------------------------------------------------------------------- */
     if (nWidth != nOldWidth)
     {
-        for (i = iField + 1; i < psDBF->nFields; i++)
+        for (int i = iField + 1; i < psDBF->nFields; i++)
              psDBF->panFieldOffset[i] += nWidth - nOldWidth;
         psDBF->nRecordLength += nWidth - nOldWidth;
 
@@ -2166,6 +2041,8 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
     psDBF->bNoHeader = TRUE;
     DBFUpdateHeader( psDBF );
 
+    bool errorAbort = false;
+
     if (nWidth < nOldWidth || (nWidth == nOldWidth && chType != chOldType))
     {
         char* pszRecord = STATIC_CAST(char *, malloc(sizeof(char) * nOldRecordLength));
@@ -2175,20 +2052,20 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
         pszOldField[nOldWidth] = 0;
 
         /* move records to their new positions */
-        for (iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
+        for (int iRecord = 0; iRecord < psDBF->nRecords; iRecord++)
         {
-            nRecordOffset =
+            SAOffset nRecordOffset =
                 nOldRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
 
             /* load record */
             psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
             if (psDBF->sHooks.FRead( pszRecord, nOldRecordLength, 1, psDBF->fp ) != 1) {
-              errorAbort = TRUE;
-              break; 
+              errorAbort = true;
+              break;
             }
 
             memcpy(pszOldField, pszRecord + nOffset, nOldWidth);
-            bIsNULL = DBFIsValueNULL( chOldType, pszOldField );
+            const bool bIsNULL = DBFIsValueNULL( chOldType, pszOldField );
 
             if (nWidth != nOldWidth)
             {
@@ -2225,7 +2102,7 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
         {
             char ch = END_OF_FILE_CHARACTER;
 
-            nRecordOffset =
+            SAOffset nRecordOffset =
                 psDBF->nRecordLength * STATIC_CAST(SAOffset,psDBF->nRecords) + psDBF->nHeaderLength;
 
             psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
@@ -2245,20 +2122,20 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
         pszOldField[nOldWidth] = 0;
 
         /* move records to their new positions */
-        for (iRecord = psDBF->nRecords - 1; iRecord >= 0; iRecord--)
+        for (int iRecord = psDBF->nRecords - 1; iRecord >= 0; iRecord--)
         {
-            nRecordOffset =
+            SAOffset nRecordOffset =
                 nOldRecordLength * STATIC_CAST(SAOffset,iRecord) + psDBF->nHeaderLength;
 
             /* load record */
             psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
             if (psDBF->sHooks.FRead( pszRecord, nOldRecordLength, 1, psDBF->fp )!= 1) {
-              errorAbort = TRUE;
-              break; 
+              errorAbort = true;
+              break;
             }
 
             memcpy(pszOldField, pszRecord + nOffset, nOldWidth);
-            bIsNULL = DBFIsValueNULL( chOldType, pszOldField );
+            const bool bIsNULL = DBFIsValueNULL( chOldType, pszOldField );
 
             if (nOffset + nOldWidth < nOldRecordLength)
             {
@@ -2300,7 +2177,7 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
         {
             char ch = END_OF_FILE_CHARACTER;
 
-            nRecordOffset =
+            SAOffset nRecordOffset =
                 psDBF->nRecordLength * STATIC_CAST(SAOffset,psDBF->nRecords) + psDBF->nHeaderLength;
 
             psDBF->sHooks.FSeek( psDBF->fp, nRecordOffset, 0 );
@@ -2313,11 +2190,11 @@ DBFAlterFieldDefn( DBFHandle psDBF, int iField, const char * pszFieldName,
 
     if (errorAbort) {
       psDBF->nCurrentRecord = -1;
-      psDBF->bCurrentRecordModified = TRUE; 
-      psDBF->bUpdated = FALSE; 
+      psDBF->bCurrentRecordModified = TRUE;
+      psDBF->bUpdated = FALSE;
 
-      return FALSE; 
-    } 
+      return FALSE;
+    }
     psDBF->nCurrentRecord = -1;
     psDBF->bCurrentRecordModified = FALSE;
     psDBF->bUpdated = TRUE;

--- a/gdal/ogr/ogrsf_frmts/shape/sbnsearch.c
+++ b/gdal/ogr/ogrsf_frmts/shape/sbnsearch.c
@@ -1,13 +1,11 @@
-#define sanity_checks 1
-#define DEBUG_IO 1
 /******************************************************************************
  *
  * Project:  Shapelib
  * Purpose:  Implementation of search in ESRI SBN spatial index.
- * Author:   Even Rouault, even dot rouault at mines dash paris dot org
+ * Author:   Even Rouault, even dot rouault at spatialys.com
  *
  ******************************************************************************
- * Copyright (c) 2012-2014, Even Rouault <even dot rouault at mines-paris dot org>
+ * Copyright (c) 2012-2014, Even Rouault <even dot rouault at spatialys.com>
  *
  * This software is available under the following "MIT Style" license,
  * or at the option of the licensee under the LGPL (see COPYING).  This

--- a/gdal/ogr/ogrsf_frmts/shape/sbnsearch.c
+++ b/gdal/ogr/ogrsf_frmts/shape/sbnsearch.c
@@ -1,12 +1,13 @@
+#define sanity_checks 1
+#define DEBUG_IO 1
 /******************************************************************************
- * $Id$
  *
  * Project:  Shapelib
  * Purpose:  Implementation of search in ESRI SBN spatial index.
- * Author:   Even Rouault, even dot rouault at spatialys.com
+ * Author:   Even Rouault, even dot rouault at mines dash paris dot org
  *
  ******************************************************************************
- * Copyright (c) 2012-2014, Even Rouault <even dot rouault at spatialys.com>
+ * Copyright (c) 2012-2014, Even Rouault <even dot rouault at mines-paris dot org>
  *
  * This software is available under the following "MIT Style" license,
  * or at the option of the licensee under the LGPL (see COPYING).  This
@@ -35,17 +36,14 @@
 
 #include "shapefil.h"
 
-#include <math.h>
 #include <assert.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 SHP_CVSID("$Id$")
-
-#ifndef TRUE
-#  define TRUE 1
-#  define FALSE 0
-#endif
 
 #ifndef USE_CPL
 #if defined(_MSC_VER)
@@ -89,7 +87,7 @@ typedef struct
     int     nBinCount;      /* Number of bins for this node. May be 0 if node is empty. */
     int     nBinOffset;     /* Offset in file of the start of the first bin. May be 0 if node is empty. */
 
-    int     bBBoxInit;      /* TRUE if the following bounding box has been computed. */
+    bool    bBBoxInit;      /* true if the following bounding box has been computed. */
     coord   bMinX;          /* Bounding box of the shapes directly attached to this node. */
     coord   bMinY;          /* This is *not* the theoretical footprint of the node. */
     coord   bMaxX;
@@ -139,15 +137,10 @@ typedef struct
 /*      Swap a 2, 4 or 8 byte word.                                     */
 /************************************************************************/
 
-static void SwapWord( int length, void * wordP )
-
-{
-    int i;
-    uchar temp;
-
-    for( i=0; i < length/2; i++ )
+static void SwapWord( int length, void * wordP ) {
+    for( int i=0; i < length/2; i++ )
     {
-        temp = STATIC_CAST(uchar*, wordP)[i];
+        const uchar temp = STATIC_CAST(uchar*, wordP)[i];
         STATIC_CAST(uchar*, wordP)[i] = STATIC_CAST(uchar*, wordP)[length-i-1];
         STATIC_CAST(uchar*, wordP)[length-i-1] = temp;
     }
@@ -158,38 +151,24 @@ static void SwapWord( int length, void * wordP )
 /************************************************************************/
 
 SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
-                                 SAHooks *psHooks )
-{
-    int i;
-    SBNSearchHandle hSBN;
-    uchar abyHeader[108];
-    int nShapeCount;
-    int nMaxDepth;
-    int nMaxNodes;
-    int nNodeDescSize;
-    int nNodeDescCount;
-    uchar* pabyData = SHPLIB_NULLPTR;
-    SBNNodeDescriptor* pasNodeDescriptor = SHPLIB_NULLPTR;
-    uchar abyBinHeader[8];
-    int nCurNode;
-    int nNextNonEmptyNode;
-    int nExpectedBinId;
-    int bBigEndian;
-
+                                 SAHooks *psHooks ) {
 /* -------------------------------------------------------------------- */
 /*  Establish the byte order on this machine.                           */
 /* -------------------------------------------------------------------- */
-    i = 1;
+    bool bBigEndian;
+    {
+    int i = 1;
     if( *REINTERPRET_CAST(unsigned char *, &i) == 1 )
-        bBigEndian = FALSE;
+        bBigEndian = false;
     else
-        bBigEndian = TRUE;
+        bBigEndian = true;
+    }
 
 /* -------------------------------------------------------------------- */
 /*      Initialize the handle structure.                                */
 /* -------------------------------------------------------------------- */
-    hSBN = STATIC_CAST(SBNSearchHandle,
-                        calloc(sizeof(struct SBNSearchInfo),1));
+    SBNSearchHandle hSBN =
+        STATIC_CAST(SBNSearchHandle, calloc(sizeof(struct SBNSearchInfo), 1));
 
     if (psHooks == SHPLIB_NULLPTR)
         SASetupDefaultHooks( &(hSBN->sHooks) );
@@ -206,6 +185,7 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 /* -------------------------------------------------------------------- */
 /*      Check file header signature.                                    */
 /* -------------------------------------------------------------------- */
+    uchar abyHeader[108];
     if (hSBN->sHooks.FRead(abyHeader, 108, 1, hSBN->fpSBN) != 1 ||
         abyHeader[0] != 0 ||
         abyHeader[1] != 0 ||
@@ -249,7 +229,7 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 /* -------------------------------------------------------------------- */
 /*      Read and check number of shapes.                                */
 /* -------------------------------------------------------------------- */
-    nShapeCount = READ_MSB_INT(abyHeader + 28);
+    const int nShapeCount = READ_MSB_INT(abyHeader + 28);
     hSBN->nShapeCount = nShapeCount;
     if (nShapeCount < 0 || nShapeCount > 256000000 )
     {
@@ -272,11 +252,11 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 /*      It is computed such as in average there are not more than 8     */
 /*      shapes per node. With a minimum depth of 2, and a maximum of 24 */
 /* -------------------------------------------------------------------- */
-    nMaxDepth = 2;
+    int nMaxDepth = 2;
     while( nMaxDepth < 24 && nShapeCount > ((1 << nMaxDepth) - 1) * 8 )
         nMaxDepth ++;
     hSBN->nMaxDepth = nMaxDepth;
-    nMaxNodes = (1 << nMaxDepth) - 1;
+    const int nMaxNodes = (1 << nMaxDepth) - 1;
 
 /* -------------------------------------------------------------------- */
 /*      Check that the first bin id is 1.                               */
@@ -294,11 +274,11 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 /*      There are at most (2^nMaxDepth) - 1, but all are not necessary  */
 /*      described. Non described nodes are empty.                       */
 /* -------------------------------------------------------------------- */
-    nNodeDescSize = READ_MSB_INT(abyHeader + 104);
+    int nNodeDescSize = READ_MSB_INT(abyHeader + 104);
     nNodeDescSize *= 2; /* 16-bit words */
 
     /* each bin descriptor is made of 2 ints */
-    nNodeDescCount = nNodeDescSize / 8;
+    const int nNodeDescCount = nNodeDescSize / 8;
 
     if ((nNodeDescSize % 8) != 0 ||
         nNodeDescCount < 0 || nNodeDescCount > nMaxNodes )
@@ -312,8 +292,8 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
     }
 
     /* coverity[tainted_data] */
-    pabyData = STATIC_CAST(uchar*, malloc( nNodeDescSize ));
-    pasNodeDescriptor = STATIC_CAST(SBNNodeDescriptor*,
+    uchar *pabyData = STATIC_CAST(uchar*, malloc( nNodeDescSize ));
+    SBNNodeDescriptor *pasNodeDescriptor = STATIC_CAST(SBNNodeDescriptor*,
                 calloc ( nMaxNodes, sizeof(SBNNodeDescriptor) ));
     if (pabyData == SHPLIB_NULLPTR || pasNodeDescriptor == SHPLIB_NULLPTR)
     {
@@ -339,7 +319,7 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 
     hSBN->pasNodeDescriptor = pasNodeDescriptor;
 
-    for(i = 0; i < nNodeDescCount; i++)
+    for(int i = 0; i < nNodeDescCount; i++)
     {
 /* -------------------------------------------------------------------- */
 /*      Each node descriptor contains the index of the first bin that   */
@@ -364,7 +344,7 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
     /* pabyData = SHPLIB_NULLPTR; */
 
     /* Locate first non-empty node */
-    nCurNode = 0;
+    int nCurNode = 0;
     while(nCurNode < nMaxNodes && pasNodeDescriptor[nCurNode].nBinStart <= 0)
         nCurNode ++;
 
@@ -379,28 +359,27 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
         STATIC_CAST(int, hSBN->sHooks.FTell(hSBN->fpSBN));
 
     /* Compute the index of the next non empty node. */
-    nNextNonEmptyNode = nCurNode + 1;
+    int nNextNonEmptyNode = nCurNode + 1;
     while(nNextNonEmptyNode < nMaxNodes &&
         pasNodeDescriptor[nNextNonEmptyNode].nBinStart <= 0)
         nNextNonEmptyNode ++;
 
-    nExpectedBinId = 1;
+    int nExpectedBinId = 1;
 
 /* -------------------------------------------------------------------- */
 /*      Traverse bins to compute the offset of the first bin of each    */
 /*      node.                                                           */
 /*      Note: we could use the .sbx file to compute the offsets instead.*/
 /* -------------------------------------------------------------------- */
+    uchar abyBinHeader[8];
+
     while( hSBN->sHooks.FRead(abyBinHeader, 8, 1,
                                      hSBN->fpSBN) == 1 )
     {
-        int nBinId;
-        int nBinSize;
+        nExpectedBinId++;
 
-        nExpectedBinId ++;
-
-        nBinId = READ_MSB_INT(abyBinHeader);
-        nBinSize = READ_MSB_INT(abyBinHeader + 4);
+        const int nBinId = READ_MSB_INT(abyBinHeader);
+        int nBinSize = READ_MSB_INT(abyBinHeader + 4);
         nBinSize *= 2; /* 16-bit words */
 
         if( nBinId != nExpectedBinId )
@@ -446,18 +425,14 @@ SBNSearchHandle SBNOpenDiskTree( const char* pszSBNFilename,
 /*                          SBNCloseDiskTree()                         */
 /************************************************************************/
 
-void SBNCloseDiskTree( SBNSearchHandle hSBN )
-{
-    int i;
-    int nMaxNodes;
-
+void SBNCloseDiskTree( SBNSearchHandle hSBN ) {
     if (hSBN == SHPLIB_NULLPTR)
         return;
 
     if( hSBN->pasNodeDescriptor != SHPLIB_NULLPTR )
     {
-        nMaxNodes = (1 << hSBN->nMaxDepth) - 1;
-        for(i = 0; i < nMaxNodes; i++)
+        const int nMaxNodes = (1 << hSBN->nMaxDepth) - 1;
+        for(int i = 0; i < nMaxNodes; i++)
         {
             if( hSBN->pasNodeDescriptor[i].pabyShapeDesc != SHPLIB_NULLPTR )
                 free(hSBN->pasNodeDescriptor[i].pabyShapeDesc);
@@ -479,9 +454,7 @@ void SBNCloseDiskTree( SBNSearchHandle hSBN )
 /*      a valid input.                                                  */
 /************************************************************************/
 
-static void * SfRealloc( void * pMem, int nNewSize )
-
-{
+static void * SfRealloc( void * pMem, int nNewSize ) {
     if( pMem == SHPLIB_NULLPTR )
         return malloc(nNewSize);
     else
@@ -492,29 +465,26 @@ static void * SfRealloc( void * pMem, int nNewSize )
 /*                         SBNAddShapeId()                              */
 /************************************************************************/
 
-static int SBNAddShapeId( SearchStruct* psSearch,
-                          int nShapeId )
-{
+static bool SBNAddShapeId( SearchStruct* psSearch,
+                          int nShapeId ) {
     if (psSearch->nShapeCount == psSearch->nShapeAlloc)
     {
-        int* pNewPtr;
-
         psSearch->nShapeAlloc =
             STATIC_CAST(int, ((psSearch->nShapeCount + 100) * 5) / 4);
-        pNewPtr =
+        int *pNewPtr =
             STATIC_CAST(int *, SfRealloc( psSearch->panShapeId,
                                psSearch->nShapeAlloc * sizeof(int) ));
         if( pNewPtr == SHPLIB_NULLPTR )
         {
             psSearch->hSBN->sHooks.Error( "Out of memory error" );
-            return FALSE;
+            return false;
         }
         psSearch->panShapeId = pNewPtr;
     }
 
     psSearch->panShapeId[psSearch->nShapeCount] = nShapeId;
     psSearch->nShapeCount ++;
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/
@@ -533,7 +503,7 @@ static int SBNAddShapeId( SearchStruct* psSearch,
      bSearchMinY <= _bMaxY && bSearchMaxY >= _bMinY)))
 
 
-static int SBNSearchDiskInternal( SearchStruct* psSearch,
+static bool SBNSearchDiskInternal( SearchStruct* psSearch,
                                   int nDepth,
                                   int nNodeId,
                                   coord bNodeMinX,
@@ -541,16 +511,14 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                                   coord bNodeMaxX,
                                   coord bNodeMaxY )
 {
-    SBNSearchHandle hSBN;
-    SBNNodeDescriptor* psNode;
-    coord bSearchMinX = psSearch->bMinX;
-    coord bSearchMinY = psSearch->bMinY;
-    coord bSearchMaxX = psSearch->bMaxX;
-    coord bSearchMaxY = psSearch->bMaxY;
+    const coord bSearchMinX = psSearch->bMinX;
+    const coord bSearchMinY = psSearch->bMinY;
+    const coord bSearchMaxX = psSearch->bMaxX;
+    const coord bSearchMaxY = psSearch->bMaxY;
 
-    hSBN = psSearch->hSBN;
+    SBNSearchHandle hSBN = psSearch->hSBN;
 
-    psNode = &(hSBN->pasNodeDescriptor[nNodeId]);
+    SBNNodeDescriptor* psNode = &(hSBN->pasNodeDescriptor[nNodeId]);
 
 /* -------------------------------------------------------------------- */
 /*      Check if this node contains shapes that intersect the search    */
@@ -570,23 +538,20 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
 /* -------------------------------------------------------------------- */
     else if (psNode->pabyShapeDesc != SHPLIB_NULLPTR)
     {
-        int j;
         uchar* pabyShapeDesc = psNode->pabyShapeDesc;
 
         /* printf("nNodeId = %d, nDepth = %d\n", nNodeId, nDepth); */
 
-        for(j = 0; j < psNode->nShapeCount; j++)
+        for(int j = 0; j < psNode->nShapeCount; j++)
         {
-            coord bMinX = pabyShapeDesc[0];
-            coord bMinY = pabyShapeDesc[1];
-            coord bMaxX = pabyShapeDesc[2];
-            coord bMaxY = pabyShapeDesc[3];
+            const coord bMinX = pabyShapeDesc[0];
+            const coord bMinY = pabyShapeDesc[1];
+            const coord bMaxX = pabyShapeDesc[2];
+            const coord bMaxY = pabyShapeDesc[3];
 
             if( SEARCH_BB_INTERSECTS(bMinX, bMinY, bMaxX, bMaxY) )
             {
-                int nShapeId;
-
-                nShapeId = READ_MSB_INT(pabyShapeDesc + 4);
+                int nShapeId = READ_MSB_INT(pabyShapeDesc + 4);
 
                 /* Caution : we count shape id starting from 0, and not 1 */
                 nShapeId --;
@@ -595,7 +560,7 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                        nShapeId, bMinX, bMinY, bMaxX, bMaxY);*/
 
                 if( !SBNAddShapeId( psSearch, nShapeId ) )
-                    return FALSE;
+                    return false;
             }
 
             pabyShapeDesc += 8;
@@ -609,22 +574,16 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
 
     else if (psNode->nBinCount > 0)
     {
-        uchar abyBinHeader[8];
-        int   nBinSize, nShapes;
-        int   nShapeCountAcc = 0;
-        int   i, j;
-
-        /* printf("nNodeId = %d, nDepth = %d\n", nNodeId, nDepth); */
-
         hSBN->sHooks.FSeek(hSBN->fpSBN, psNode->nBinOffset, SEEK_SET);
 
         if (nDepth < CACHED_DEPTH_LIMIT)
             psNode->pabyShapeDesc = STATIC_CAST(uchar*, malloc(psNode->nShapeCount * 8));
 
-        for(i = 0; i < psNode->nBinCount; i++)
-        {
-            uchar* pabyBinShape;
+        uchar abyBinHeader[8];
+        int nShapeCountAcc = 0;
 
+        for(int i = 0; i < psNode->nBinCount; i++)
+        {
 #ifdef DEBUG_IO
             psSearch->nBytesRead += 8;
 #endif
@@ -634,7 +593,7 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                 hSBN->sHooks.Error( "I/O error" );
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
-                return FALSE;
+                return false;
             }
 
             if ( READ_MSB_INT(abyBinHeader + 0) != psNode->nBinStart + i )
@@ -642,13 +601,13 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                 hSBN->sHooks.Error( "Unexpected bin id" );
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
-                return FALSE;
+                return false;
             }
 
-            nBinSize = READ_MSB_INT(abyBinHeader + 4);
+            int nBinSize = READ_MSB_INT(abyBinHeader + 4);
             nBinSize *= 2; /* 16-bit words */
 
-            nShapes = nBinSize / 8;
+            int nShapes = nBinSize / 8;
 
             /* Bins are always limited to 100 features */
             if( (nBinSize % 8) != 0 || nShapes <= 0 || nShapes > 100)
@@ -656,7 +615,7 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                 hSBN->sHooks.Error( "Unexpected bin size" );
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
-                return FALSE;
+                return false;
             }
 
             if( nShapeCountAcc + nShapes > psNode->nShapeCount)
@@ -664,9 +623,10 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
                 hSBN->sHooks.Error( "Inconsistent shape count for bin" );
-                return FALSE;
+                return false;
             }
 
+            uchar* pabyBinShape;
             if (nDepth < CACHED_DEPTH_LIMIT && psNode->pabyShapeDesc != SHPLIB_NULLPTR)
             {
                 pabyBinShape = psNode->pabyShapeDesc + nShapeCountAcc * 8;
@@ -685,7 +645,7 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                 hSBN->sHooks.Error( "I/O error" );
                 free(psNode->pabyShapeDesc);
                 psNode->pabyShapeDesc = SHPLIB_NULLPTR;
-                return FALSE;
+                return false;
             }
 
             nShapeCountAcc += nShapes;
@@ -698,12 +658,12 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                 psNode->bMaxY = pabyBinShape[3];
             }
 
-            for(j = 0; j < nShapes; j++)
+            for(int j = 0; j < nShapes; j++)
             {
-                coord bMinX = pabyBinShape[0];
-                coord bMinY = pabyBinShape[1];
-                coord bMaxX = pabyBinShape[2];
-                coord bMaxY = pabyBinShape[3];
+                const coord bMinX = pabyBinShape[0];
+                const coord bMinY = pabyBinShape[1];
+                const coord bMaxX = pabyBinShape[2];
+                const coord bMaxY = pabyBinShape[3];
 
                 if( !psNode->bBBoxInit )
                 {
@@ -730,7 +690,7 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                             "Invalid shape bounding box in bin" );
                         free(psNode->pabyShapeDesc);
                         psNode->pabyShapeDesc = SHPLIB_NULLPTR;
-                        return FALSE;
+                        return false;
                     }
 #endif
                     if (bMinX < psNode->bMinX) psNode->bMinX = bMinX;
@@ -741,9 +701,7 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
 
                 if( SEARCH_BB_INTERSECTS(bMinX, bMinY, bMaxX, bMaxY) )
                 {
-                    int nShapeId;
-
-                    nShapeId = READ_MSB_INT(pabyBinShape + 4);
+                    int nShapeId = READ_MSB_INT(pabyBinShape + 4);
 
                     /* Caution : we count shape id starting from 0, and not 1 */
                     nShapeId --;
@@ -752,7 +710,7 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
                         nShapeId, bMinX, bMinY, bMaxX, bMaxY);*/
 
                     if( !SBNAddShapeId( psSearch, nShapeId ) )
-                        return FALSE;
+                        return false;
                 }
 
                 pabyBinShape += 8;
@@ -764,10 +722,10 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
             free(psNode->pabyShapeDesc);
             psNode->pabyShapeDesc = SHPLIB_NULLPTR;
             hSBN->sHooks.Error( "Inconsistent shape count for bin" );
-            return FALSE;
+            return false;
         }
 
-        psNode->bBBoxInit = TRUE;
+        psNode->bBBoxInit = true;
     }
 
 /* -------------------------------------------------------------------- */
@@ -779,43 +737,43 @@ static int SBNSearchDiskInternal( SearchStruct* psSearch,
 
         if( (nDepth % 2) == 0 ) /* x split */
         {
-            coord bMid = STATIC_CAST(coord, 1 + (STATIC_CAST(int, bNodeMinX) + bNodeMaxX) / 2);
+            const coord bMid = STATIC_CAST(coord, 1 + (STATIC_CAST(int, bNodeMinX) + bNodeMaxX) / 2);
             if( bSearchMinX <= bMid - 1 &&
                 !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId + 1,
                                         bNodeMinX, bNodeMinY,
                                         bMid - 1, bNodeMaxY ) )
             {
-                return FALSE;
+                return false;
             }
             if( bSearchMaxX >= bMid &&
                 !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId,
                                         bMid, bNodeMinY,
                                         bNodeMaxX, bNodeMaxY ) )
             {
-                return FALSE;
+                return false;
             }
         }
         else /* y split */
         {
-            coord bMid = STATIC_CAST(coord, 1 + (STATIC_CAST(int, bNodeMinY) + bNodeMaxY) / 2);
+            const coord bMid = STATIC_CAST(coord, 1 + (STATIC_CAST(int, bNodeMinY) + bNodeMaxY) / 2);
             if( bSearchMinY <= bMid - 1 &&
                 !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId + 1,
                                         bNodeMinX, bNodeMinY,
                                         bNodeMaxX, bMid - 1 ) )
             {
-                return FALSE;
+                return false;
             }
             if( bSearchMaxY >= bMid &&
                 !SBNSearchDiskInternal( psSearch, nDepth + 1, nNodeId,
                                         bNodeMinX, bMid,
                                         bNodeMaxX, bNodeMaxY ) )
             {
-                return FALSE;
+                return false;
             }
         }
     }
 
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/
@@ -835,18 +793,13 @@ compare_ints( const void * a, const void * b)
 
 int* SBNSearchDiskTree( SBNSearchHandle hSBN,
                         double *padfBoundsMin, double *padfBoundsMax,
-                        int *pnShapeCount )
-{
-    double dfMinX, dfMinY, dfMaxX, dfMaxY;
-    double dfDiskXExtent, dfDiskYExtent;
-    int bMinX, bMinY, bMaxX, bMaxY;
-
+                        int *pnShapeCount ) {
     *pnShapeCount = 0;
 
-    dfMinX = padfBoundsMin[0];
-    dfMinY = padfBoundsMin[1];
-    dfMaxX = padfBoundsMax[0];
-    dfMaxY = padfBoundsMax[1];
+    const double dfMinX = padfBoundsMin[0];
+    const double dfMinY = padfBoundsMin[1];
+    const double dfMaxX = padfBoundsMax[0];
+    const double dfMaxY = padfBoundsMax[1];
 
     if( dfMinX > dfMaxX || dfMinY > dfMaxY )
         return SHPLIB_NULLPTR;
@@ -858,9 +811,13 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
 /* -------------------------------------------------------------------- */
 /*      Compute the search coordinates in [0,255]x[0,255] coord. space  */
 /* -------------------------------------------------------------------- */
-    dfDiskXExtent = hSBN->dfMaxX - hSBN->dfMinX;
-    dfDiskYExtent = hSBN->dfMaxY - hSBN->dfMinY;
+    const double dfDiskXExtent = hSBN->dfMaxX - hSBN->dfMinX;
+    const double dfDiskYExtent = hSBN->dfMaxY - hSBN->dfMinY;
 
+    int bMinX;
+    int bMaxX;
+    int bMinY;
+    int bMaxY;
     if ( dfDiskXExtent == 0.0 )
     {
         bMinX = 0;
@@ -872,7 +829,7 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
             bMinX = 0;
         else
         {
-            double dfMinX_255 = (dfMinX - hSBN->dfMinX)
+            const double dfMinX_255 = (dfMinX - hSBN->dfMinX)
                                                     / dfDiskXExtent * 255.0;
             bMinX = STATIC_CAST(int, floor(dfMinX_255 - 0.005));
             if( bMinX < 0 ) bMinX = 0;
@@ -882,7 +839,7 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
             bMaxX = 255;
         else
         {
-            double dfMaxX_255 = (dfMaxX - hSBN->dfMinX)
+            const double dfMaxX_255 = (dfMaxX - hSBN->dfMinX)
                                                     / dfDiskXExtent * 255.0;
             bMaxX = STATIC_CAST(int, ceil(dfMaxX_255 + 0.005));
             if( bMaxX > 255 ) bMaxX = 255;
@@ -900,7 +857,7 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
             bMinY = 0;
         else
         {
-            double dfMinY_255 = (dfMinY - hSBN->dfMinY)
+            const double dfMinY_255 = (dfMinY - hSBN->dfMinY)
                                                     / dfDiskYExtent * 255.0;
             bMinY = STATIC_CAST(int, floor(dfMinY_255 - 0.005));
             if( bMinY < 0 ) bMinY = 0;
@@ -910,7 +867,7 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
             bMaxY = 255;
         else
         {
-            double dfMaxY_255 = (dfMaxY - hSBN->dfMinY)
+            const double dfMaxY_255 = (dfMaxY - hSBN->dfMinY)
                                                     / dfDiskYExtent * 255.0;
             bMaxY = STATIC_CAST(int, ceil(dfMaxY_255 + 0.005));
             if( bMaxY > 255 ) bMaxY = 255;
@@ -932,11 +889,7 @@ int* SBNSearchDiskTree( SBNSearchHandle hSBN,
 
 int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
                                int bMinX, int bMinY, int bMaxX, int bMaxY,
-                               int *pnShapeCount )
-{
-    SearchStruct sSearch;
-    int bRet;
-
+                               int *pnShapeCount ) {
     *pnShapeCount = 0;
 
     if( bMinX > bMaxX || bMinY > bMaxY )
@@ -950,6 +903,7 @@ int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
 /* -------------------------------------------------------------------- */
 /*      Run the search.                                                 */
 /* -------------------------------------------------------------------- */
+    SearchStruct sSearch;
     memset( &sSearch, 0, sizeof(sSearch) );
     sSearch.hSBN = hSBN;
     sSearch.bMinX = STATIC_CAST(coord, bMinX >= 0 ? bMinX : 0);
@@ -963,7 +917,7 @@ int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
     sSearch.nBytesRead = 0;
 #endif
 
-    bRet = SBNSearchDiskInternal(&sSearch, 0, 0, 0, 0, 255, 255);
+    const bool bRet = SBNSearchDiskInternal(&sSearch, 0, 0, 0, 0, 255, 255);
 
 #ifdef DEBUG_IO
     hSBN->nTotalBytesRead += sSearch.nBytesRead;
@@ -991,7 +945,6 @@ int* SBNSearchDiskTreeInteger( SBNSearchHandle hSBN,
 /*                         SBNSearchFreeIds()                           */
 /************************************************************************/
 
-void SBNSearchFreeIds( int* panShapeId )
-{
+void SBNSearchFreeIds( int* panShapeId ) {
     free( panShapeId );
 }

--- a/gdal/ogr/ogrsf_frmts/shape/shapefil.h
+++ b/gdal/ogr/ogrsf_frmts/shape/shapefil.h
@@ -10,7 +10,7 @@
  *
  ******************************************************************************
  * Copyright (c) 1999, Frank Warmerdam
- * Copyright (c) 2012-2016, Even Rouault <even dot rouault at mines-paris dot org>
+ * Copyright (c) 2012-2016, Even Rouault <even dot rouault at spatialys.com>
  *
  * This software is available under the following "MIT Style" license,
  * or at the option of the licensee under the LGPL (see COPYING).  This

--- a/gdal/ogr/ogrsf_frmts/shape/shapefil.h
+++ b/gdal/ogr/ogrsf_frmts/shape/shapefil.h
@@ -10,7 +10,7 @@
  *
  ******************************************************************************
  * Copyright (c) 1999, Frank Warmerdam
- * Copyright (c) 2012-2016, Even Rouault <even dot rouault at spatialys.com>
+ * Copyright (c) 2012-2016, Even Rouault <even dot rouault at mines-paris dot org>
  *
  * This software is available under the following "MIT Style" license,
  * or at the option of the licensee under the LGPL (see COPYING).  This
@@ -36,6 +36,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  ******************************************************************************
+ *
  */
 
 #include <stdio.h>

--- a/gdal/ogr/ogrsf_frmts/shape/shpopen.c
+++ b/gdal/ogr/ogrsf_frmts/shape/shpopen.c
@@ -978,7 +978,8 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
                   pszFullname, strerror(errno) );
         psHooks->Error( szErrorMsg );
 
-        goto error;
+        free(pszFullname);
+        return NULL;
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
@@ -990,7 +991,10 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
                  "Failed to create file %s: %s",
                   pszFullname, strerror(errno) );
         psHooks->Error( szErrorMsg );
-        goto error;
+
+        free(pszFullname);
+        psHooks->FClose(fpSHP);
+        return NULL;
     }
 
     free( pszFullname );
@@ -1035,7 +1039,10 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
         szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
         psHooks->Error( szErrorMsg );
 
-        goto error;
+        free(pszFullname);
+        psHooks->FClose(fpSHP);
+        psHooks->FClose(fpSHX);
+        return NULL;
     }
 
 /* -------------------------------------------------------------------- */
@@ -1054,7 +1061,10 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
         szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
         psHooks->Error( szErrorMsg );
 
-        goto error;
+        free(pszFullname);
+        psHooks->FClose(fpSHP);
+        psHooks->FClose(fpSHX);
+        return NULL;
     }
 
 /* -------------------------------------------------------------------- */
@@ -1064,12 +1074,6 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
     psHooks->FClose( fpSHX );
 
     return( SHPOpenLL( pszLayer, "r+b", psHooks ) );
-
-error:
-    if (pszFullname) free(pszFullname);
-    if (fpSHP) psHooks->FClose( fpSHP );
-    if (fpSHX) psHooks->FClose( fpSHX );
-    return SHPLIB_NULLPTR;
 }
 
 /************************************************************************/

--- a/gdal/ogr/ogrsf_frmts/shape/shpopen.c
+++ b/gdal/ogr/ogrsf_frmts/shape/shpopen.c
@@ -1,5 +1,4 @@
 /******************************************************************************
- * $Id$
  *
  * Project:  Shapelib
  * Purpose:  Implementation of core Shapefile read/write functions.
@@ -36,13 +35,14 @@
 
 #include "shapefil.h"
 
-#include <math.h>
-#include <limits.h>
 #include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <errno.h>
 
 SHP_CVSID("$Id$")
 
@@ -83,14 +83,14 @@ typedef unsigned int	      int32;
 #else
 #  define CPL_UNUSED
 #endif
-#endif  
+#endif
 
 #if defined(CPL_LSB)
-#define bBigEndian FALSE
+#define bBigEndian false
 #elif defined(CPL_MSB)
-#define bBigEndian TRUE
+#define bBigEndian true
 #else
-static int 	bBigEndian;
+static bool bBigEndian;
 #endif
 
 #ifdef __cplusplus
@@ -107,15 +107,10 @@ static int 	bBigEndian;
 /*      Swap a 2, 4 or 8 byte word.                                     */
 /************************************************************************/
 
-static void	SwapWord( int length, void * wordP )
-
-{
-    int		i;
-    uchar	temp;
-
-    for( i=0; i < length/2; i++ )
+static void SwapWord( int length, void * wordP ) {
+    for( int i = 0; i < length/2; i++ )
     {
-	temp = STATIC_CAST(uchar*, wordP)[i];
+	const uchar temp = STATIC_CAST(uchar*, wordP)[i];
 	STATIC_CAST(uchar*, wordP)[i] = STATIC_CAST(uchar*, wordP)[length-i-1];
 	STATIC_CAST(uchar*, wordP)[length-i-1] = temp;
     }
@@ -128,9 +123,7 @@ static void	SwapWord( int length, void * wordP )
 /*      a valid input.                                                  */
 /************************************************************************/
 
-static void * SfRealloc( void * pMem, int nNewSize )
-
-{
+static void * SfRealloc( void * pMem, int nNewSize ) {
     if( pMem == SHPLIB_NULLPTR )
         return malloc(nNewSize);
     else
@@ -144,15 +137,7 @@ static void * SfRealloc( void * pMem, int nNewSize )
 /*	contents of the index (.shx) file.				*/
 /************************************************************************/
 
-void SHPAPI_CALL SHPWriteHeader( SHPHandle psSHP )
-
-{
-    uchar     	abyHeader[100] = { 0 };
-    int		i;
-    int32	i32;
-    double	dValue;
-    int32	*panSHX;
-
+void SHPAPI_CALL SHPWriteHeader( SHPHandle psSHP ) {
     if (psSHP->fpSHX == SHPLIB_NULLPTR)
     {
         psSHP->sHooks.Error( "SHPWriteHeader failed : SHX file is closed");
@@ -163,10 +148,11 @@ void SHPAPI_CALL SHPWriteHeader( SHPHandle psSHP )
 /*      Prepare header block for .shp file.                             */
 /* -------------------------------------------------------------------- */
 
+    uchar abyHeader[100] = { 0 };
     abyHeader[2] = 0x27;				/* magic cookie */
     abyHeader[3] = 0x0a;
 
-    i32 = psSHP->nFileSize/2;				/* file size */
+    int32 i32 = psSHP->nFileSize/2;				/* file size */
     ByteCopy( &i32, abyHeader+24, 4 );
     if( !bBigEndian ) SwapWord( 4, abyHeader+24 );
 
@@ -178,7 +164,7 @@ void SHPAPI_CALL SHPWriteHeader( SHPHandle psSHP )
     ByteCopy( &i32, abyHeader+32, 4 );
     if( bBigEndian ) SwapWord( 4, abyHeader+32 );
 
-    dValue = psSHP->adBoundsMin[0];			/* set bounds */
+    double dValue = psSHP->adBoundsMin[0];			/* set bounds */
     ByteCopy( &dValue, abyHeader+36, 8 );
     if( bBigEndian ) SwapWord( 8, abyHeader+36 );
 
@@ -248,14 +234,14 @@ void SHPAPI_CALL SHPWriteHeader( SHPHandle psSHP )
 /* -------------------------------------------------------------------- */
 /*      Write out the .shx contents.                                    */
 /* -------------------------------------------------------------------- */
-    panSHX = STATIC_CAST(int32 *, malloc(sizeof(int32) * 2 * psSHP->nRecords));
+    int32 *panSHX = STATIC_CAST(int32 *, malloc(sizeof(int32) * 2 * psSHP->nRecords));
     if( panSHX == SHPLIB_NULLPTR )
     {
         psSHP->sHooks.Error( "Failure allocatin panSHX" );
         return;
     }
 
-    for( i = 0; i < psSHP->nRecords; i++ )
+    for( int i = 0; i < psSHP->nRecords; i++ )
     {
         panSHX[i*2  ] = psSHP->panRecOffset[i]/2;
         panSHX[i*2+1] = psSHP->panRecSize[i]/2;
@@ -288,9 +274,7 @@ void SHPAPI_CALL SHPWriteHeader( SHPHandle psSHP )
 /************************************************************************/
 
 SHPHandle SHPAPI_CALL
-SHPOpen( const char * pszLayer, const char * pszAccess )
-
-{
+SHPOpen( const char * pszLayer, const char * pszAccess ){
     SAHooks sHooks;
 
     SASetupDefaultHooks( &sHooks );
@@ -304,9 +288,8 @@ SHPOpen( const char * pszLayer, const char * pszAccess )
 
 static int SHPGetLenWithoutExtension(const char* pszBasename)
 {
-    int i;
-    int nLen = STATIC_CAST(int, strlen(pszBasename));
-    for( i = nLen-1;
+    const int nLen = STATIC_CAST(int, strlen(pszBasename));
+    for( int i = nLen-1;
          i > 0 && pszBasename[i] != '/' && pszBasename[i] != '\\';
          i-- )
     {
@@ -326,28 +309,17 @@ static int SHPGetLenWithoutExtension(const char* pszBasename)
 /************************************************************************/
 
 SHPHandle SHPAPI_CALL
-SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
-
-{
-    char        *pszFullname;
-    SHPHandle       psSHP;
-
-    uchar       *pabyBuf;
-    int         i;
-    double      dValue;
-    int         bLazySHXLoading = FALSE;
-    int         nLenWithoutExtension;
-
+SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
 /* -------------------------------------------------------------------- */
 /*      Ensure the access string is one of the legal ones.  We          */
 /*      ensure the result string indicates binary to avoid common       */
 /*      problems on Windows.                                            */
 /* -------------------------------------------------------------------- */
+    bool bLazySHXLoading = false;
     if( strcmp(pszAccess,"rb+") == 0 || strcmp(pszAccess,"r+b") == 0
-        || strcmp(pszAccess,"r+") == 0 )
+        || strcmp(pszAccess,"r+") == 0 ) {
         pszAccess = "r+b";
-    else
-    {
+    } else {
         bLazySHXLoading = strchr(pszAccess, 'l') != SHPLIB_NULLPTR;
         pszAccess = "rb";
     }
@@ -356,17 +328,19 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 /*  Establish the byte order on this machine.           */
 /* -------------------------------------------------------------------- */
 #if !defined(bBigEndian)
-    i = 1;
+    {
+    int i = 1;
     if( *((uchar *) &i) == 1 )
-        bBigEndian = FALSE;
+        bBigEndian = false;
     else
-        bBigEndian = TRUE;
+        bBigEndian = true;
+    }
 #endif
 
 /* -------------------------------------------------------------------- */
 /*  Initialize the info structure.                  */
 /* -------------------------------------------------------------------- */
-    psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo),1));
+    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo),1));
 
     psSHP->bUpdated = FALSE;
     memcpy( &(psSHP->sHooks), psHooks, sizeof(SAHooks) );
@@ -375,8 +349,8 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 /*  Open the .shp and .shx files.  Note that files pulled from  */
 /*  a PC to Unix with upper case filenames won't work!      */
 /* -------------------------------------------------------------------- */
-    nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
-    pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    const int nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
+    char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
     psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess );
@@ -388,7 +362,7 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 
     if( psSHP->fpSHP == SHPLIB_NULLPTR )
     {
-        size_t nMessageLen = strlen(pszFullname)*2+256;
+        const size_t nMessageLen = strlen(pszFullname)*2+256;
         char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
         pszFullname[nLenWithoutExtension] = 0;
         snprintf( pszMessage, nMessageLen, "Unable to open %s.shp or %s.SHP.",
@@ -412,7 +386,7 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 
     if( psSHP->fpSHX == SHPLIB_NULLPTR )
     {
-        size_t nMessageLen = strlen(pszFullname)*2+256;
+        const size_t nMessageLen = strlen(pszFullname)*2+256;
         char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
         pszFullname[nLenWithoutExtension] = 0;
         snprintf( pszMessage, nMessageLen, "Unable to open %s.shx or %s.SHX. "
@@ -432,7 +406,7 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
 /*  Read the file size from the SHP file.               */
 /* -------------------------------------------------------------------- */
-    pabyBuf = STATIC_CAST(uchar *, malloc(100));
+    uchar *pabyBuf = STATIC_CAST(uchar *, malloc(100));
     if( psSHP->sHooks.FRead( pabyBuf, 100, 1, psSHP->fpSHP ) != 1 )
     {
         psSHP->sHooks.Error( ".shp file is unreadable, or corrupt." );
@@ -497,9 +471,8 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
     /* to hold them */
     if( psSHP->nRecords >= 1024 * 1024 )
     {
-        SAOffset nFileSize;
         psSHP->sHooks.FSeek( psSHP->fpSHX, 0, 2 );
-        nFileSize = psSHP->sHooks.FTell( psSHP->fpSHX );
+        const SAOffset nFileSize = psSHP->sHooks.FTell( psSHP->fpSHX );
         if( nFileSize > 100 &&
             nFileSize/2 < STATIC_CAST(SAOffset, psSHP->nRecords * 4 + 50) )
         {
@@ -511,6 +484,8 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
 /*      Read the bounds.                                                */
 /* -------------------------------------------------------------------- */
+    double dValue;
+
     if( bBigEndian ) SwapWord( 8, pabyBuf+36 );
     memcpy( &dValue, pabyBuf+36, 8 );
     psSHP->adBoundsMin[0] = dValue;
@@ -618,13 +593,13 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
         psSHP->fpSHX = SHPLIB_NULLPTR;
     }
 
-    for( i = 0; i < psSHP->nRecords; i++ )
+    for( int i = 0; i < psSHP->nRecords; i++ )
     {
-        unsigned int        nOffset, nLength;
-
+        unsigned int nOffset;
         memcpy( &nOffset, pabyBuf + i * 8, 4 );
         if( !bBigEndian ) SwapWord( 4, &nOffset );
 
+        unsigned int nLength;
         memcpy( &nLength, pabyBuf + i * 8 + 4, 4 );
         if( !bBigEndian ) SwapWord( 4, &nLength );
 
@@ -670,9 +645,7 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 
 SHPHandle SHPAPI_CALL
 SHPOpenLLEx( const char * pszLayer, const char * pszAccess, SAHooks *psHooks,
-            int bRestoreSHX )
-
-{
+            int bRestoreSHX ) {
     if ( !bRestoreSHX ) return SHPOpenLL ( pszLayer, pszAccess, psHooks );
     else
     {
@@ -692,38 +665,17 @@ SHPOpenLLEx( const char * pszLayer, const char * pszAccess, SAHooks *psHooks,
 /*                                                                      */
 /************************************************************************/
 
-int       SHPAPI_CALL
-SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
-
-{
-    char            *pszFullname;
-    SAFile          fpSHP, fpSHX;
-
-
-    uchar           *pabyBuf;
-    int             nLenWithoutExtension;
-    unsigned int    nSHPFilesize;
-
-    unsigned int    nCurrentSHPOffset = 100;
-    unsigned int    nRealSHXContentSize = 100;
-
-    const char      pszSHXAccess[] = "w+b";
-    char            *pabySHXHeader;
-    char            abyReadedRecord[8];
-    unsigned int    niRecord = 0;
-    unsigned int    nRecordLength = 0;
-    unsigned int    nRecordOffset = 50;
-
+int SHPAPI_CALL
+SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks ) {
 /* -------------------------------------------------------------------- */
 /*      Ensure the access string is one of the legal ones.  We          */
 /*      ensure the result string indicates binary to avoid common       */
 /*      problems on Windows.                                            */
 /* -------------------------------------------------------------------- */
     if( strcmp(pszAccess,"rb+") == 0 || strcmp(pszAccess,"r+b") == 0
-        || strcmp(pszAccess,"r+") == 0 )
+        || strcmp(pszAccess,"r+") == 0 ) {
         pszAccess = "r+b";
-    else
-    {
+    } else {
         pszAccess = "rb";
     }
 
@@ -734,9 +686,9 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
     {
         int i = 1;
         if( *((uchar *) &i) == 1 )
-            bBigEndian = FALSE;
+            bBigEndian = false;
         else
-            bBigEndian = TRUE;
+            bBigEndian = true;
     }
 #endif
 
@@ -744,11 +696,11 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 /*  Open the .shp file.  Note that files pulled from                    */
 /*  a PC to Unix with upper case filenames won't work!                  */
 /* -------------------------------------------------------------------- */
-    nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
-    pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    const int nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
+    char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    fpSHP = psHooks->FOpen(pszFullname, pszAccess );
+    SAFile fpSHP = psHooks->FOpen(pszFullname, pszAccess );
     if( fpSHP == SHPLIB_NULLPTR )
     {
         memcpy(pszFullname + nLenWithoutExtension, ".SHP", 5);
@@ -757,7 +709,7 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 
     if( fpSHP == SHPLIB_NULLPTR )
     {
-        size_t nMessageLen = strlen( pszFullname ) * 2 + 256;
+        const size_t nMessageLen = strlen( pszFullname ) * 2 + 256;
         char* pszMessage = STATIC_CAST(char *, malloc( nMessageLen ));
 
         pszFullname[nLenWithoutExtension] = 0;
@@ -774,7 +726,7 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 /* -------------------------------------------------------------------- */
 /*  Read the file size from the SHP file.                               */
 /* -------------------------------------------------------------------- */
-    pabyBuf = STATIC_CAST(uchar *, malloc(100));
+    uchar *pabyBuf = STATIC_CAST(uchar *, malloc(100));
     if( psHooks->FRead( pabyBuf, 100, 1, fpSHP ) != 1 )
     {
         psHooks->Error( ".shp file is unreadable, or corrupt." );
@@ -786,7 +738,7 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
         return( 0 );
     }
 
-    nSHPFilesize = (STATIC_CAST(unsigned int, pabyBuf[24])<<24)|(pabyBuf[25]<<16)|
+    unsigned int nSHPFilesize = (STATIC_CAST(unsigned int, pabyBuf[24])<<24)|(pabyBuf[25]<<16)|
                    (pabyBuf[26]<<8)|pabyBuf[27];
     if( nSHPFilesize < UINT_MAX / 2 )
         nSHPFilesize *= 2;
@@ -794,7 +746,8 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
         nSHPFilesize = (UINT_MAX / 2) * 2;
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
-    fpSHX = psHooks->FOpen( pszFullname, pszSHXAccess );
+    const char pszSHXAccess[] = "w+b";
+    SAFile fpSHX = psHooks->FOpen( pszFullname, pszSHXAccess );
     if( fpSHX == SHPLIB_NULLPTR )
     {
         size_t nMessageLen = strlen( pszFullname ) * 2 + 256;
@@ -817,10 +770,18 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 /*  Open SHX and create it using SHP file content.                      */
 /* -------------------------------------------------------------------- */
     psHooks->FSeek( fpSHP, 100, 0 );
-    pabySHXHeader = STATIC_CAST(char *, malloc ( 100 ));
+    char *pabySHXHeader = STATIC_CAST(char *, malloc ( 100 ));
     memcpy( pabySHXHeader, pabyBuf, 100 );
     psHooks->FWrite( pabySHXHeader, 100, 1, fpSHX );
     free ( pabyBuf );
+
+    // unsigned int nCurrentRecordOffset = 0;
+    unsigned int nCurrentSHPOffset = 100;
+    unsigned int nRealSHXContentSize = 100;
+    unsigned int niRecord = 0;
+    unsigned int nRecordLength = 0;
+    unsigned int nRecordOffset = 50;
+    char abyReadedRecord[8];
 
     while( nCurrentSHPOffset < nSHPFilesize )
     {
@@ -836,6 +797,7 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
             if ( !bBigEndian ) SwapWord( 4, &nRecordOffset );
             if ( !bBigEndian ) SwapWord( 4, &nRecordLength );
             nRecordOffset += nRecordLength + 4;
+            // nCurrentRecordOffset += 8;
             nCurrentSHPOffset += 8 + nRecordLength * 2;
 
             psHooks->FSeek( fpSHP, nCurrentSHPOffset, 0 );
@@ -876,9 +838,7 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 /************************************************************************/
 
 void SHPAPI_CALL
-SHPClose(SHPHandle psSHP )
-
-{
+SHPClose(SHPHandle psSHP ) {
     if( psSHP == SHPLIB_NULLPTR )
         return;
 
@@ -945,11 +905,7 @@ void SHPAPI_CALL SHPSetFastModeReadObject( SHPHandle hSHP, int bFastMode )
 
 void SHPAPI_CALL
 SHPGetInfo(SHPHandle psSHP, int * pnEntities, int * pnShapeType,
-           double * padfMinBound, double * padfMaxBound )
-
-{
-    int		i;
-
+           double * padfMinBound, double * padfMaxBound ) {
     if( psSHP == SHPLIB_NULLPTR )
         return;
 
@@ -959,7 +915,7 @@ SHPGetInfo(SHPHandle psSHP, int * pnEntities, int * pnShapeType,
     if( pnShapeType != SHPLIB_NULLPTR )
         *pnShapeType = psSHP->nShapeType;
 
-    for( i = 0; i < 4; i++ )
+    for( int i = 0; i < 4; i++ )
     {
         if( padfMinBound != SHPLIB_NULLPTR )
             padfMinBound[i] = psSHP->adBoundsMin[i];
@@ -976,9 +932,7 @@ SHPGetInfo(SHPHandle psSHP, int * pnEntities, int * pnShapeType,
 /************************************************************************/
 
 SHPHandle SHPAPI_CALL
-SHPCreate( const char * pszLayer, int nShapeType )
-
-{
+SHPCreate( const char * pszLayer, int nShapeType ) {
     SAHooks sHooks;
 
     SASetupDefaultHooks( &sHooks );
@@ -994,17 +948,7 @@ SHPCreate( const char * pszLayer, int nShapeType )
 /************************************************************************/
 
 SHPHandle SHPAPI_CALL
-SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks )
-
-{
-    char	*pszFullname;
-    SAFile	fpSHP;
-    SAFile      fpSHX = SHPLIB_NULLPTR;
-    uchar     	abyHeader[100];
-    int32	i32;
-    double	dValue;
-    int         nLenWithoutExtension;
-
+SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks ) {
 /* -------------------------------------------------------------------- */
 /*      Establish the byte order on this system.                        */
 /* -------------------------------------------------------------------- */
@@ -1012,20 +956,20 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks )
     {
         int i = 1;
         if( *((uchar *) &i) == 1 )
-            bBigEndian = FALSE;
+            bBigEndian = false;
         else
-            bBigEndian = TRUE;
+            bBigEndian = true;
     }
 #endif
 
 /* -------------------------------------------------------------------- */
 /*      Open the two files so we can write their headers.               */
 /* -------------------------------------------------------------------- */
-    nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
-    pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    const int nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
+    char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
-    fpSHP = psHooks->FOpen(pszFullname, "wb" );
+    SAFile fpSHP = psHooks->FOpen(pszFullname, "wb" );
     if( fpSHP == SHPLIB_NULLPTR )
     {
         char szErrorMsg[200];
@@ -1038,7 +982,7 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks )
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".shx", 5);
-    fpSHX = psHooks->FOpen(pszFullname, "wb" );
+    SAFile fpSHX = psHooks->FOpen(pszFullname, "wb" );
     if( fpSHX == SHPLIB_NULLPTR )
     {
         char szErrorMsg[200];
@@ -1049,17 +993,19 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks )
         goto error;
     }
 
-    free( pszFullname ); pszFullname = SHPLIB_NULLPTR;
+    free( pszFullname );
+    pszFullname = SHPLIB_NULLPTR;
 
 /* -------------------------------------------------------------------- */
 /*      Prepare header block for .shp file.                             */
 /* -------------------------------------------------------------------- */
+    uchar abyHeader[100];
     memset( abyHeader, 0, sizeof(abyHeader) );
 
     abyHeader[2] = 0x27;				/* magic cookie */
     abyHeader[3] = 0x0a;
 
-    i32 = 50;						/* file size */
+    int32 i32 = 50;						/* file size */
     ByteCopy( &i32, abyHeader+24, 4 );
     if( !bBigEndian ) SwapWord( 4, abyHeader+24 );
 
@@ -1071,7 +1017,7 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks )
     ByteCopy( &i32, abyHeader+32, 4 );
     if( bBigEndian ) SwapWord( 4, abyHeader+32 );
 
-    dValue = 0.0;					/* set bounds */
+    double dValue = 0.0;				/* set bounds */
     ByteCopy( &dValue, abyHeader+36, 8 );
     ByteCopy( &dValue, abyHeader+44, 8 );
     ByteCopy( &dValue, abyHeader+52, 8 );
@@ -1133,9 +1079,7 @@ error:
 /*      indicated location in the record.                               */
 /************************************************************************/
 
-static void	_SHPSetBounds( uchar * pabyRec, SHPObject * psShape )
-
-{
+static void _SHPSetBounds( uchar * pabyRec, SHPObject * psShape ) {
     ByteCopy( &(psShape->dfXMin), pabyRec +  0, 8 );
     ByteCopy( &(psShape->dfYMin), pabyRec +  8, 8 );
     ByteCopy( &(psShape->dfXMax), pabyRec + 16, 8 );
@@ -1158,11 +1102,7 @@ static void	_SHPSetBounds( uchar * pabyRec, SHPObject * psShape )
 /************************************************************************/
 
 void SHPAPI_CALL
-SHPComputeExtents( SHPObject * psObject )
-
-{
-    int		i;
-
+SHPComputeExtents( SHPObject * psObject ) {
 /* -------------------------------------------------------------------- */
 /*      Build extents for this object.                                  */
 /* -------------------------------------------------------------------- */
@@ -1174,7 +1114,7 @@ SHPComputeExtents( SHPObject * psObject )
         psObject->dfMMin = psObject->dfMMax = psObject->padfM[0];
     }
 
-    for( i = 0; i < psObject->nVertices; i++ )
+    for( int i = 0; i < psObject->nVertices; i++ )
     {
         psObject->dfXMin = MIN(psObject->dfXMin, psObject->padfX[i]);
         psObject->dfYMin = MIN(psObject->dfYMin, psObject->padfY[i]);
@@ -1199,13 +1139,8 @@ SHPObject SHPAPI_CALL1(*)
 SHPCreateObject( int nSHPType, int nShapeId, int nParts,
                  const int * panPartStart, const int * panPartType,
                  int nVertices, const double *padfX, const double *padfY,
-                 const double * padfZ, const double * padfM )
-
-{
-    SHPObject	*psObject;
-    int		i, bHasM, bHasZ;
-
-    psObject = STATIC_CAST(SHPObject *, calloc(1,sizeof(SHPObject)));
+                 const double * padfZ, const double * padfM ) {
+    SHPObject *psObject = STATIC_CAST(SHPObject *, calloc(1,sizeof(SHPObject)));
     psObject->nSHPType = nSHPType;
     psObject->nShapeId = nShapeId;
     psObject->bMeasureIsUsed = FALSE;
@@ -1213,13 +1148,16 @@ SHPCreateObject( int nSHPType, int nShapeId, int nParts,
 /* -------------------------------------------------------------------- */
 /*	Establish whether this shape type has M, and Z values.		*/
 /* -------------------------------------------------------------------- */
+    bool bHasM;
+    bool bHasZ;
+
     if( nSHPType == SHPT_ARCM
         || nSHPType == SHPT_POINTM
         || nSHPType == SHPT_POLYGONM
         || nSHPType == SHPT_MULTIPOINTM )
     {
-        bHasM = TRUE;
-        bHasZ = FALSE;
+        bHasM = true;
+        bHasZ = false;
     }
     else if( nSHPType == SHPT_ARCZ
              || nSHPType == SHPT_POINTZ
@@ -1227,13 +1165,13 @@ SHPCreateObject( int nSHPType, int nShapeId, int nParts,
              || nSHPType == SHPT_MULTIPOINTZ
              || nSHPType == SHPT_MULTIPATCH )
     {
-        bHasM = TRUE;
-        bHasZ = TRUE;
+        bHasM = true;
+        bHasZ = true;
     }
     else
     {
-        bHasM = FALSE;
-        bHasZ = FALSE;
+        bHasM = false;
+        bHasZ = false;
     }
 
 /* -------------------------------------------------------------------- */
@@ -1255,7 +1193,7 @@ SHPCreateObject( int nSHPType, int nShapeId, int nParts,
         psObject->panPartStart[0] = 0;
         psObject->panPartType[0] = SHPP_RING;
 
-        for( i = 0; i < nParts; i++ )
+        for( int i = 0; i < nParts; i++ )
         {
             if( panPartStart != SHPLIB_NULLPTR )
                 psObject->panPartStart[i] = panPartStart[i];
@@ -1275,7 +1213,7 @@ SHPCreateObject( int nSHPType, int nShapeId, int nParts,
 /* -------------------------------------------------------------------- */
     if( nVertices > 0 )
     {
-        size_t nSize = sizeof(double) * nVertices;
+        const size_t nSize = sizeof(double) * nVertices;
         psObject->padfX = STATIC_CAST(double *, padfX ? malloc(nSize) :
                                              calloc(sizeof(double),nVertices));
         psObject->padfY = STATIC_CAST(double *, padfY ? malloc(nSize) :
@@ -1316,9 +1254,7 @@ SHPCreateObject( int nSHPType, int nShapeId, int nParts,
 SHPObject SHPAPI_CALL1(*)
 SHPCreateSimpleObject( int nSHPType, int nVertices,
                        const double * padfX, const double * padfY,
-                       const double * padfZ )
-
-{
+                       const double * padfZ ) {
     return( SHPCreateObject( nSHPType, -1, 0, SHPLIB_NULLPTR, SHPLIB_NULLPTR,
                              nVertices, padfX, padfY, padfZ, SHPLIB_NULLPTR ) );
 }
@@ -1331,18 +1267,7 @@ SHPCreateSimpleObject( int nSHPType, int nVertices,
 /************************************************************************/
 
 int SHPAPI_CALL
-SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
-
-{
-    SAOffset nRecordOffset;
-    unsigned int nRecordSize=0;
-    int i;
-    uchar	*pabyRec;
-    int32	i32;
-    int     bAppendToLastRecord = FALSE;
-    int     bAppendToFile = FALSE;
-    int     bFirstFeature = (psSHP->nRecords == 0);
-
+SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
     psSHP->bUpdated = TRUE;
 
 /* -------------------------------------------------------------------- */
@@ -1390,7 +1315,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 /* -------------------------------------------------------------------- */
 /*      Initialize record.                                              */
 /* -------------------------------------------------------------------- */
-    pabyRec = STATIC_CAST(uchar *, malloc(psObject->nVertices * 4 * sizeof(double)
+    uchar *pabyRec = STATIC_CAST(uchar *, malloc(psObject->nVertices * 4 * sizeof(double)
                                + psObject->nParts * 8 + 128));
     if( pabyRec == SHPLIB_NULLPTR )
         return -1;
@@ -1398,6 +1323,9 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 /* -------------------------------------------------------------------- */
 /*  Extract vertices for a Polygon or Arc.				*/
 /* -------------------------------------------------------------------- */
+    unsigned int nRecordSize = 0;
+    const bool bFirstFeature = psSHP->nRecords == 0;
+
     if( psObject->nSHPType == SHPT_POLYGON
         || psObject->nSHPType == SHPT_POLYGONZ
         || psObject->nSHPType == SHPT_POLYGONM
@@ -1406,10 +1334,8 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
         || psObject->nSHPType == SHPT_ARCM
         || psObject->nSHPType == SHPT_MULTIPATCH )
     {
-        int32		nPoints, nParts;
-
-        nPoints = psObject->nVertices;
-        nParts = psObject->nParts;
+        int32 nPoints = psObject->nVertices;
+        int32 nParts = psObject->nParts;
 
         _SHPSetBounds( pabyRec + 12, psObject );
 
@@ -1426,7 +1352,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
          */
         ByteCopy( psObject->panPartStart, pabyRec + 44 + 8,
                   4 * psObject->nParts );
-        for( i = 0; i < psObject->nParts; i++ )
+        for( int i = 0; i < psObject->nParts; i++ )
         {
             if( bBigEndian ) SwapWord( 4, pabyRec + 44 + 8 + 4*i );
             nRecordSize += 4;
@@ -1439,7 +1365,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
         {
             memcpy( pabyRec + nRecordSize, psObject->panPartType,
                     4*psObject->nParts );
-            for( i = 0; i < psObject->nParts; i++ )
+            for( int i = 0; i < psObject->nParts; i++ )
             {
                 if( bBigEndian ) SwapWord( 4, pabyRec + nRecordSize );
                 nRecordSize += 4;
@@ -1449,7 +1375,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
         /*
          * Write the (x,y) vertex values.
          */
-        for( i = 0; i < psObject->nVertices; i++ )
+        for( int i = 0; i < psObject->nVertices; i++ )
         {
             ByteCopy( psObject->padfX + i, pabyRec + nRecordSize, 8 );
             ByteCopy( psObject->padfY + i, pabyRec + nRecordSize + 8, 8 );
@@ -1478,7 +1404,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
             if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
             nRecordSize += 8;
 
-            for( i = 0; i < psObject->nVertices; i++ )
+            for( int i = 0; i < psObject->nVertices; i++ )
             {
                 ByteCopy( psObject->padfZ + i, pabyRec + nRecordSize, 8 );
                 if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
@@ -1506,7 +1432,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
             if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
             nRecordSize += 8;
 
-            for( i = 0; i < psObject->nVertices; i++ )
+            for( int i = 0; i < psObject->nVertices; i++ )
             {
                 ByteCopy( psObject->padfM + i, pabyRec + nRecordSize, 8 );
                 if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
@@ -1522,16 +1448,14 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
              || psObject->nSHPType == SHPT_MULTIPOINTZ
              || psObject->nSHPType == SHPT_MULTIPOINTM )
     {
-        int32		nPoints;
-
-        nPoints = psObject->nVertices;
+        int32 nPoints = psObject->nVertices;
 
         _SHPSetBounds( pabyRec + 12, psObject );
 
         if( bBigEndian ) SwapWord( 4, &nPoints );
         ByteCopy( &nPoints, pabyRec + 44, 4 );
 
-        for( i = 0; i < psObject->nVertices; i++ )
+        for( int i = 0; i < psObject->nVertices; i++ )
         {
             ByteCopy( psObject->padfX + i, pabyRec + 48 + i*16, 8 );
             ByteCopy( psObject->padfY + i, pabyRec + 48 + i*16 + 8, 8 );
@@ -1552,7 +1476,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
             if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
             nRecordSize += 8;
 
-            for( i = 0; i < psObject->nVertices; i++ )
+            for( int i = 0; i < psObject->nVertices; i++ )
             {
                 ByteCopy( psObject->padfZ + i, pabyRec + nRecordSize, 8 );
                 if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
@@ -1572,7 +1496,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
             if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
             nRecordSize += 8;
 
-            for( i = 0; i < psObject->nVertices; i++ )
+            for( int i = 0; i < psObject->nVertices; i++ )
             {
                 ByteCopy( psObject->padfM + i, pabyRec + nRecordSize, 8 );
                 if( bBigEndian ) SwapWord( 8, pabyRec + nRecordSize );
@@ -1619,12 +1543,9 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
     else if( psObject->nSHPType == SHPT_NULL )
     {
         nRecordSize = 12;
-    }
-
-    else
-    {
+    } else {
         /* unknown type */
-        assert( FALSE );
+        assert( false );
     }
 
 /* -------------------------------------------------------------------- */
@@ -1634,11 +1555,14 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 /*      fit, then put it  back where the original came from.  Otherwise */
 /*      write at the end.                                               */
 /* -------------------------------------------------------------------- */
+    SAOffset nRecordOffset;
+    bool bAppendToLastRecord = false;
+    bool bAppendToFile = false;
     if( nShapeId != -1 && psSHP->panRecOffset[nShapeId] +
                         psSHP->panRecSize[nShapeId] + 8 == psSHP->nFileSize )
     {
         nRecordOffset = psSHP->panRecOffset[nShapeId];
-        bAppendToLastRecord = TRUE;
+        bAppendToLastRecord = true;
     }
     else if( nShapeId == -1 || psSHP->panRecSize[nShapeId] < nRecordSize-8 )
     {
@@ -1654,7 +1578,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
             return -1;
         }
 
-        bAppendToFile = TRUE;
+        bAppendToFile = true;
         nRecordOffset = psSHP->nFileSize;
     }
     else
@@ -1665,7 +1589,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 /* -------------------------------------------------------------------- */
 /*      Set the shape type, record number, and record size.             */
 /* -------------------------------------------------------------------- */
-    i32 = (nShapeId < 0) ? psSHP->nRecords+1 : nShapeId+1;					/* record # */
+    int32 i32 = (nShapeId < 0) ? psSHP->nRecords+1 : nShapeId+1;  /* record # */
     if( !bBigEndian ) SwapWord( 4, &i32 );
     ByteCopy( &i32, pabyRec, 4 );
 
@@ -1718,7 +1642,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 
     if( bAppendToLastRecord )
     {
-        psSHP->nFileSize = psSHP->panRecOffset[nShapeId] + nRecordSize; 
+        psSHP->nFileSize = psSHP->panRecOffset[nShapeId] + nRecordSize;
     }
     else if( bAppendToFile )
     {
@@ -1751,7 +1675,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
         }
     }
 
-    for( i = 0; i < psObject->nVertices; i++ )
+    for( int i = 0; i < psObject->nVertices; i++ )
     {
         psSHP->adBoundsMin[0] = MIN(psSHP->adBoundsMin[0],psObject->padfX[i]);
         psSHP->adBoundsMin[1] = MIN(psSHP->adBoundsMin[1],psObject->padfY[i]);
@@ -1776,14 +1700,11 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject )
 /*                         SHPAllocBuffer()                             */
 /************************************************************************/
 
-static void* SHPAllocBuffer(unsigned char** pBuffer, int nSize)
-{
-    unsigned char* pRet;
-
+static void* SHPAllocBuffer(unsigned char** pBuffer, int nSize) {
     if( pBuffer == SHPLIB_NULLPTR )
         return calloc(1, nSize);
 
-    pRet = *pBuffer;
+    unsigned char* pRet = *pBuffer;
     if( pRet == SHPLIB_NULLPTR )
         return SHPLIB_NULLPTR;
 
@@ -1796,13 +1717,13 @@ static void* SHPAllocBuffer(unsigned char** pBuffer, int nSize)
 /************************************************************************/
 
 static unsigned char* SHPReallocObjectBufIfNecessary ( SHPHandle psSHP,
-                                                       int nObjectBufSize )
-{
-    unsigned char* pBuffer;
+                                                       int nObjectBufSize ) {
     if( nObjectBufSize == 0 )
     {
         nObjectBufSize = 4 * sizeof(double);
     }
+
+    unsigned char* pBuffer;
     if( nObjectBufSize > psSHP->nObjectBufSize )
     {
         pBuffer = STATIC_CAST(unsigned char*, realloc( psSHP->pabyObjectBuf, nObjectBufSize ));
@@ -1811,9 +1732,10 @@ static unsigned char* SHPReallocObjectBufIfNecessary ( SHPHandle psSHP,
             psSHP->pabyObjectBuf = pBuffer;
             psSHP->nObjectBufSize = nObjectBufSize;
         }
-    }
-    else
+    } else {
         pBuffer = psSHP->pabyObjectBuf;
+    }
+
     return pBuffer;
 }
 
@@ -1825,15 +1747,7 @@ static unsigned char* SHPReallocObjectBufIfNecessary ( SHPHandle psSHP,
 /************************************************************************/
 
 SHPObject SHPAPI_CALL1(*)
-SHPReadObject( SHPHandle psSHP, int hEntity )
-
-{
-    int                  nEntitySize, nRequiredSize;
-    SHPObject           *psShape;
-    char                 szErrorMsg[160];
-    int                  nSHPType;
-    int                  nBytesRead;
-
+SHPReadObject( SHPHandle psSHP, int hEntity ) {
 /* -------------------------------------------------------------------- */
 /*      Validate the record/entity number.                              */
 /* -------------------------------------------------------------------- */
@@ -1845,7 +1759,8 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 /* -------------------------------------------------------------------- */
     if( psSHP->panRecOffset[hEntity] == 0 && psSHP->fpSHX != SHPLIB_NULLPTR )
     {
-        unsigned int       nOffset, nLength;
+        unsigned int nOffset;
+        unsigned int nLength;
 
         if( psSHP->sHooks.FSeek( psSHP->fpSHX, 100 + 8 * hEntity, 0 ) != 0 ||
             psSHP->sHooks.FRead( &nOffset, 1, 4, psSHP->fpSHX ) != 4 ||
@@ -1891,10 +1806,9 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 /* -------------------------------------------------------------------- */
 /*      Ensure our record buffer is large enough.                       */
 /* -------------------------------------------------------------------- */
-    nEntitySize = psSHP->panRecSize[hEntity]+8;
+    const int nEntitySize = psSHP->panRecSize[hEntity]+8;
     if( nEntitySize > psSHP->nBufSize )
     {
-        uchar* pabyRecNew;
         int nNewBufSize = nEntitySize;
         if( nNewBufSize < INT_MAX - nNewBufSize / 3 )
             nNewBufSize += nNewBufSize / 3;
@@ -1935,9 +1849,10 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             }
         }
 
-        pabyRecNew = STATIC_CAST(uchar *, SfRealloc(psSHP->pabyRec,nNewBufSize));
+        uchar* pabyRecNew = STATIC_CAST(uchar *, SfRealloc(psSHP->pabyRec,nNewBufSize));
         if (pabyRecNew == SHPLIB_NULLPTR)
         {
+            char szErrorMsg[160];
             snprintf( szErrorMsg, sizeof(szErrorMsg),
                      "Not enough memory to allocate requested memory (nNewBufSize=%d). "
                      "Probably broken SHP file", nNewBufSize);
@@ -1976,7 +1891,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         return SHPLIB_NULLPTR;
     }
 
-    nBytesRead = STATIC_CAST(int, psSHP->sHooks.FRead( psSHP->pabyRec, 1, nEntitySize, psSHP->fpSHP ));
+    const int nBytesRead = STATIC_CAST(int, psSHP->sHooks.FRead( psSHP->pabyRec, 1, nEntitySize, psSHP->fpSHP ));
 
     /* Special case for a shapefile whose .shx content length field is not equal */
     /* to the content length field of the .shp, which is a violation of "The */
@@ -2022,6 +1937,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 
     if ( 8 + 4 > nEntitySize )
     {
+        char szErrorMsg[160];
         snprintf(szErrorMsg, sizeof(szErrorMsg),
                  "Corrupted .shp file : shape %d : nEntitySize = %d",
                  hEntity, nEntitySize);
@@ -2029,6 +1945,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         psSHP->sHooks.Error( szErrorMsg );
         return SHPLIB_NULLPTR;
     }
+    int nSHPType;
     memcpy( &nSHPType, psSHP->pabyRec + 8, 4 );
 
     if( bBigEndian ) SwapWord( 4, &(nSHPType) );
@@ -2036,6 +1953,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 /* -------------------------------------------------------------------- */
 /*	Allocate and minimally initialize the object.			*/
 /* -------------------------------------------------------------------- */
+    SHPObject *psShape;
     if( psSHP->bFastModeReadObject )
     {
         if( psSHP->psCachedObject->bFastModeReadObject )
@@ -2047,9 +1965,9 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 
         psShape = psSHP->psCachedObject;
         memset(psShape, 0, sizeof(SHPObject));
-    }
-    else
+    } else {
         psShape = STATIC_CAST(SHPObject *, calloc(1,sizeof(SHPObject)));
+    }
     psShape->nShapeId = hEntity;
     psShape->nSHPType = nSHPType;
     psShape->bMeasureIsUsed = FALSE;
@@ -2065,13 +1983,9 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         || psShape->nSHPType == SHPT_ARCM
         || psShape->nSHPType == SHPT_MULTIPATCH )
     {
-        int32		nPoints, nParts;
-        int    		i, nOffset;
-        unsigned char* pBuffer = SHPLIB_NULLPTR;
-        unsigned char** ppBuffer = SHPLIB_NULLPTR;
-
         if ( 40 + 8 + 4 > nEntitySize )
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nEntitySize = %d",
                      hEntity, nEntitySize);
@@ -2097,7 +2011,9 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 /*      Extract part/point count, and build vertex and part arrays      */
 /*      to proper size.                                                 */
 /* -------------------------------------------------------------------- */
+        int32 nPoints;
         memcpy( &nPoints, psSHP->pabyRec + 40 + 8, 4 );
+        int32 nParts;
         memcpy( &nParts, psSHP->pabyRec + 36 + 8, 4 );
 
         if( bBigEndian ) SwapWord( 4, &nPoints );
@@ -2107,6 +2023,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         if (/* nPoints < 0 || nParts < 0 || */
             nPoints > 50 * 1000 * 1000 || nParts > 10 * 1000 * 1000)
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d, nPoints=%u, nParts=%u.",
                      hEntity, nPoints, nParts);
@@ -2119,7 +2036,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         /* With the previous checks on nPoints and nParts, */
         /* we should not overflow here and after */
         /* since 50 M * (16 + 8 + 8) = 1 600 MB */
-        nRequiredSize = 44 + 8 + 4 * nParts + 16 * nPoints;
+        int nRequiredSize = 44 + 8 + 4 * nParts + 16 * nPoints;
         if ( psShape->nSHPType == SHPT_POLYGONZ
              || psShape->nSHPType == SHPT_ARCZ
              || psShape->nSHPType == SHPT_MULTIPATCH )
@@ -2132,6 +2049,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         }
         if (nRequiredSize > nEntitySize)
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d, nPoints=%u, nParts=%u, nEntitySize=%d.",
                      hEntity, nPoints, nParts, nEntitySize);
@@ -2141,9 +2059,12 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             return SHPLIB_NULLPTR;
         }
 
+        unsigned char* pBuffer = SHPLIB_NULLPTR;
+        unsigned char** ppBuffer = SHPLIB_NULLPTR;
+
         if( psShape->bFastModeReadObject )
         {
-            int nObjectBufSize = 4 * sizeof(double) * nPoints + 2 * sizeof(int) * nParts;
+            const int nObjectBufSize = 4 * sizeof(double) * nPoints + 2 * sizeof(int) * nParts;
             pBuffer = SHPReallocObjectBufIfNecessary(psSHP, nObjectBufSize);
             ppBuffer = &pBuffer;
         }
@@ -2165,6 +2086,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             psShape->panPartStart == SHPLIB_NULLPTR ||
             psShape->panPartType == SHPLIB_NULLPTR)
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                     "Not enough memory to allocate requested memory (nPoints=%u, nParts=%u) for shape %d. "
                     "Probably broken SHP file", nPoints, nParts, hEntity );
@@ -2174,14 +2096,14 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             return SHPLIB_NULLPTR;
         }
 
-        for( i = 0; STATIC_CAST(int32, i) < nParts; i++ )
+        for( int i = 0; STATIC_CAST(int32, i) < nParts; i++ )
             psShape->panPartType[i] = SHPP_RING;
 
 /* -------------------------------------------------------------------- */
 /*      Copy out the part array from the record.                        */
 /* -------------------------------------------------------------------- */
         memcpy( psShape->panPartStart, psSHP->pabyRec + 44 + 8, 4 * nParts );
-        for( i = 0; STATIC_CAST(int32, i) < nParts; i++ )
+        for( int i = 0; STATIC_CAST(int32, i) < nParts; i++ )
         {
             if( bBigEndian ) SwapWord( 4, psShape->panPartStart+i );
 
@@ -2191,6 +2113,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
                     && psShape->nVertices > 0)
                 || (psShape->panPartStart[i] > 0 && psShape->nVertices == 0) )
             {
+                char szErrorMsg[160];
                 snprintf(szErrorMsg, sizeof(szErrorMsg),
                          "Corrupted .shp file : shape %d : panPartStart[%d] = %d, nVertices = %d",
                          hEntity, i, psShape->panPartStart[i], psShape->nVertices);
@@ -2201,6 +2124,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             }
             if (i > 0 && psShape->panPartStart[i] <= psShape->panPartStart[i-1])
             {
+                char szErrorMsg[160];
                 snprintf(szErrorMsg, sizeof(szErrorMsg),
                          "Corrupted .shp file : shape %d : panPartStart[%d] = %d, panPartStart[%d] = %d",
                          hEntity, i, psShape->panPartStart[i], i - 1, psShape->panPartStart[i - 1]);
@@ -2211,7 +2135,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             }
         }
 
-        nOffset = 44 + 8 + 4*nParts;
+        int nOffset = 44 + 8 + 4*nParts;
 
 /* -------------------------------------------------------------------- */
 /*      If this is a multipatch, we will also have parts types.         */
@@ -2219,7 +2143,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         if( psShape->nSHPType == SHPT_MULTIPATCH )
         {
             memcpy( psShape->panPartType, psSHP->pabyRec + nOffset, 4*nParts );
-            for( i = 0; STATIC_CAST(int32, i) < nParts; i++ )
+            for( int i = 0; STATIC_CAST(int32, i) < nParts; i++ )
             {
                 if( bBigEndian ) SwapWord( 4, psShape->panPartType+i );
             }
@@ -2230,7 +2154,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 /* -------------------------------------------------------------------- */
 /*      Copy out the vertices from the record.                          */
 /* -------------------------------------------------------------------- */
-        for( i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+        for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
         {
             memcpy(psShape->padfX + i,
                    psSHP->pabyRec + nOffset + i * 16,
@@ -2259,7 +2183,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             if( bBigEndian ) SwapWord( 8, &(psShape->dfZMin) );
             if( bBigEndian ) SwapWord( 8, &(psShape->dfZMax) );
 
-            for( i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
             {
                 memcpy( psShape->padfZ + i,
                         psSHP->pabyRec + nOffset + 16 + i*8, 8 );
@@ -2287,7 +2211,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             if( bBigEndian ) SwapWord( 8, &(psShape->dfMMin) );
             if( bBigEndian ) SwapWord( 8, &(psShape->dfMMax) );
 
-            for( i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
             {
                 memcpy( psShape->padfM + i,
                         psSHP->pabyRec + nOffset + 16 + i*8, 8 );
@@ -2308,13 +2232,9 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
              || psShape->nSHPType == SHPT_MULTIPOINTM
              || psShape->nSHPType == SHPT_MULTIPOINTZ )
     {
-        int32		nPoints;
-        int    		i, nOffset;
-        unsigned char* pBuffer = SHPLIB_NULLPTR;
-        unsigned char** ppBuffer = SHPLIB_NULLPTR;
-
         if ( 44 + 4 > nEntitySize )
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nEntitySize = %d",
                      hEntity, nEntitySize);
@@ -2323,6 +2243,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             SHPDestroyObject(psShape);
             return SHPLIB_NULLPTR;
         }
+        int32 nPoints;
         memcpy( &nPoints, psSHP->pabyRec + 44, 4 );
 
         if( bBigEndian ) SwapWord( 4, &nPoints );
@@ -2330,6 +2251,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         /* nPoints is unsigned */
         if (/* nPoints < 0 || */ nPoints > 50 * 1000 * 1000)
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nPoints = %u",
                      hEntity, nPoints);
@@ -2339,13 +2261,14 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             return SHPLIB_NULLPTR;
         }
 
-        nRequiredSize = 48 + nPoints * 16;
+        int nRequiredSize = 48 + nPoints * 16;
         if( psShape->nSHPType == SHPT_MULTIPOINTZ )
         {
             nRequiredSize += 16 + nPoints * 8;
         }
         if (nRequiredSize > nEntitySize)
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nPoints = %u, nEntitySize = %d",
                      hEntity, nPoints, nEntitySize);
@@ -2355,9 +2278,12 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             return SHPLIB_NULLPTR;
         }
 
+        unsigned char* pBuffer = SHPLIB_NULLPTR;
+        unsigned char** ppBuffer = SHPLIB_NULLPTR;
+
         if( psShape->bFastModeReadObject )
         {
-            int nObjectBufSize = 4 * sizeof(double) * nPoints;
+            const int nObjectBufSize = 4 * sizeof(double) * nPoints;
             pBuffer = SHPReallocObjectBufIfNecessary(psSHP, nObjectBufSize);
             ppBuffer = &pBuffer;
         }
@@ -2374,6 +2300,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             psShape->padfZ == SHPLIB_NULLPTR ||
             psShape->padfM == SHPLIB_NULLPTR)
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Not enough memory to allocate requested memory (nPoints=%u) for shape %d. "
                      "Probably broken SHP file", nPoints, hEntity );
@@ -2383,7 +2310,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             return SHPLIB_NULLPTR;
         }
 
-        for( i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+        for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
         {
             memcpy(psShape->padfX+i, psSHP->pabyRec + 48 + 16 * i, 8 );
             memcpy(psShape->padfY+i, psSHP->pabyRec + 48 + 16 * i + 8, 8 );
@@ -2392,7 +2319,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             if( bBigEndian ) SwapWord( 8, psShape->padfY + i );
         }
 
-        nOffset = 48 + 16*nPoints;
+        int nOffset = 48 + 16*nPoints;
 
 /* -------------------------------------------------------------------- */
 /*	Get the X/Y bounds.						*/
@@ -2418,7 +2345,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             if( bBigEndian ) SwapWord( 8, &(psShape->dfZMin) );
             if( bBigEndian ) SwapWord( 8, &(psShape->dfZMax) );
 
-            for( i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
             {
                 memcpy( psShape->padfZ + i,
                         psSHP->pabyRec + nOffset + 16 + i*8, 8 );
@@ -2444,7 +2371,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             if( bBigEndian ) SwapWord( 8, &(psShape->dfMMin) );
             if( bBigEndian ) SwapWord( 8, &(psShape->dfMMax) );
 
-            for( i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
+            for( int i = 0; STATIC_CAST(int32, i) < nPoints; i++ )
             {
                 memcpy( psShape->padfM + i,
                         psSHP->pabyRec + nOffset + 16 + i*8, 8 );
@@ -2463,8 +2390,6 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
              || psShape->nSHPType == SHPT_POINTM
              || psShape->nSHPType == SHPT_POINTZ )
     {
-        int	nOffset;
-
         psShape->nVertices = 1;
         if( psShape->bFastModeReadObject )
         {
@@ -2485,6 +2410,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 
         if (20 + 8 + (( psShape->nSHPType == SHPT_POINTZ ) ? 8 : 0)> nEntitySize)
         {
+            char szErrorMsg[160];
             snprintf(szErrorMsg, sizeof(szErrorMsg),
                      "Corrupted .shp file : shape %d : nEntitySize = %d",
                      hEntity, nEntitySize);
@@ -2499,7 +2425,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
         if( bBigEndian ) SwapWord( 8, psShape->padfX );
         if( bBigEndian ) SwapWord( 8, psShape->padfY );
 
-        nOffset = 20 + 8;
+        int nOffset = 20 + 8;
 
 /* -------------------------------------------------------------------- */
 /*      If we have a Z coordinate, collect that now.                    */
@@ -2545,9 +2471,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
 /************************************************************************/
 
 const char SHPAPI_CALL1(*)
-SHPTypeName( int nSHPType )
-
-{
+SHPTypeName( int nSHPType ) {
     switch( nSHPType )
     {
       case SHPT_NULL:
@@ -2602,9 +2526,7 @@ SHPTypeName( int nSHPType )
 /************************************************************************/
 
 const char SHPAPI_CALL1(*)
-SHPPartTypeName( int nPartType )
-
-{
+SHPPartTypeName( int nPartType ) {
     switch( nPartType )
     {
       case SHPP_TRISTRIP:
@@ -2635,9 +2557,7 @@ SHPPartTypeName( int nPartType )
 /************************************************************************/
 
 void SHPAPI_CALL
-SHPDestroyObject( SHPObject * psShape )
-
-{
+SHPDestroyObject( SHPObject * psShape ) {
     if( psShape == SHPLIB_NULLPTR )
         return;
 
@@ -2683,8 +2603,7 @@ static int SHPGetPartVertexCount( const SHPObject * psObject, int iPart )
 /* Return -1 in case of ambiguity */
 static int SHPRewindIsInnerRing( const SHPObject * psObject,
                                  int iOpRing,
-                                 double dfTestX, double dfTestY )
-{
+                                 double dfTestX, double dfTestY ) {
 /* -------------------------------------------------------------------- */
 /*      Determine if this ring is an inner ring or an outer ring        */
 /*      relative to all the other rings.  For now we assume the         */
@@ -2694,23 +2613,18 @@ static int SHPRewindIsInnerRing( const SHPObject * psObject,
 /*                                                                      */
 /* -------------------------------------------------------------------- */
 
-    int bInner = FALSE;
-    int iCheckRing;
-    for( iCheckRing = 0; iCheckRing < psObject->nParts; iCheckRing++ )
+    bool bInner = false;
+    for( int iCheckRing = 0; iCheckRing < psObject->nParts; iCheckRing++ )
     {
-        int nVertStartCheck, nVertCountCheck;
-        int iEdge;
-
         if( iCheckRing == iOpRing )
             continue;
 
-        nVertStartCheck = psObject->panPartStart[iCheckRing];
-        nVertCountCheck = SHPGetPartVertexCount(psObject, iCheckRing);
+        const int nVertStartCheck = psObject->panPartStart[iCheckRing];
+        const int nVertCountCheck = SHPGetPartVertexCount(psObject, iCheckRing);
 
-        for( iEdge = 0; iEdge < nVertCountCheck; iEdge++ )
+        for( int iEdge = 0; iEdge < nVertCountCheck; iEdge++ )
         {
             int iNext;
-
             if( iEdge < nVertCountCheck-1 )
                 iNext = iEdge+1;
             else
@@ -2730,7 +2644,7 @@ static int SHPRewindIsInnerRing( const SHPObject * psObject,
                  * Test if edge-ray intersection is on the right from the
                  * test point (dfTestY,dfTestY)
                  */
-                double const intersect =
+                const double intersect =
                     ( psObject->padfX[iEdge+nVertStartCheck]
                         + ( dfTestY - psObject->padfY[iEdge+nVertStartCheck] )
                         / ( psObject->padfY[iNext+nVertStartCheck] -
@@ -2764,8 +2678,6 @@ int SHPAPI_CALL
 SHPRewindObject( CPL_UNUSED SHPHandle hSHP,
                  SHPObject * psObject )
 {
-    int  iOpRing, bAltered = 0;
-
 /* -------------------------------------------------------------------- */
 /*      Do nothing if this is not a polygon object.                     */
 /* -------------------------------------------------------------------- */
@@ -2780,19 +2692,17 @@ SHPRewindObject( CPL_UNUSED SHPHandle hSHP,
 /* -------------------------------------------------------------------- */
 /*      Process each of the rings.                                      */
 /* -------------------------------------------------------------------- */
-    for( iOpRing = 0; iOpRing < psObject->nParts; iOpRing++ )
+    int  bAltered = 0;
+    for( int iOpRing = 0; iOpRing < psObject->nParts; iOpRing++ )
     {
-        int      bInner = FALSE;
-        int      iVert;
-        double   dfSum;
-
         const int nVertStart = psObject->panPartStart[iOpRing];
         const int nVertCount = SHPGetPartVertexCount(psObject, iOpRing);
 
         if (nVertCount < 2)
             continue;
 
-        for( iVert = nVertStart; iVert + 1 < nVertStart + nVertCount; ++iVert )
+        int bInner = FALSE;
+        for( int iVert = nVertStart; iVert + 1 < nVertStart + nVertCount; ++iVert )
         {
             /* Use point in the middle of segment to avoid testing
             * common points of rings.
@@ -2817,10 +2727,11 @@ SHPRewindObject( CPL_UNUSED SHPHandle hSHP,
 /*      it has to be reversed.                                          */
 /* -------------------------------------------------------------------- */
 
-        dfSum = psObject->padfX[nVertStart] *
+        double dfSum = psObject->padfX[nVertStart] *
                         (psObject->padfY[nVertStart+1] -
                          psObject->padfY[nVertStart+nVertCount-1]);
-        for( iVert = nVertStart + 1; iVert < nVertStart+nVertCount-1; iVert++ )
+        int iVert = nVertStart + 1;
+        for( ; iVert < nVertStart+nVertCount-1; iVert++ )
         {
             dfSum += psObject->padfX[iVert] * (psObject->padfY[iVert+1] -
                                                psObject->padfY[iVert-1]);
@@ -2834,15 +2745,11 @@ SHPRewindObject( CPL_UNUSED SHPHandle hSHP,
 /* -------------------------------------------------------------------- */
         if( (dfSum < 0.0 && bInner) || (dfSum > 0.0 && !bInner) )
         {
-            int   i;
-
             bAltered++;
-            for( i = 0; i < nVertCount/2; i++ )
+            for( int i = 0; i < nVertCount/2; i++ )
             {
-                double dfSaved;
-
                 /* Swap X */
-                dfSaved = psObject->padfX[nVertStart+i];
+                double dfSaved = psObject->padfX[nVertStart+i];
                 psObject->padfX[nVertStart+i] =
                     psObject->padfX[nVertStart+nVertCount-i-1];
                 psObject->padfX[nVertStart+nVertCount-i-1] = dfSaved;

--- a/gdal/ogr/ogrsf_frmts/shape/shptree.c
+++ b/gdal/ogr/ogrsf_frmts/shape/shptree.c
@@ -7,7 +7,7 @@
  *
  ******************************************************************************
  * Copyright (c) 1999, Frank Warmerdam
- * Copyright (c) 2012, Even Rouault <even dot rouault at mines-paris dot org>
+ * Copyright (c) 2012, Even Rouault <even dot rouault at spatialys.com>
  *
  * This software is available under the following "MIT Style" license,
  * or at the option of the licensee under the LGPL (see COPYING).  This

--- a/gdal/ogr/ogrsf_frmts/shape/shptree.c
+++ b/gdal/ogr/ogrsf_frmts/shape/shptree.c
@@ -7,7 +7,7 @@
  *
  ******************************************************************************
  * Copyright (c) 1999, Frank Warmerdam
- * Copyright (c) 2012, Even Rouault <even dot rouault at spatialys.com>
+ * Copyright (c) 2012, Even Rouault <even dot rouault at mines-paris dot org>
  *
  * This software is available under the following "MIT Style" license,
  * or at the option of the licensee under the LGPL (see COPYING).  This
@@ -32,12 +32,15 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- *******************************************************************************/
+ ******************************************************************************
+ *
+ */
 
 #include "shapefil.h"
 
 #include <math.h>
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
@@ -53,8 +56,7 @@ SHP_CVSID("$Id$")
 #  define FALSE 0
 #endif
 
-static int bBigEndian = 0;
-
+static bool bBigEndian = false;
 
 /* -------------------------------------------------------------------- */
 /*      If the following is 0.5, nodes will be split in half.  If it    */
@@ -294,12 +296,8 @@ SHPDestroyTree( SHPTree * psTree )
 int SHPAPI_CALL
 SHPCheckBoundsOverlap( double * padfBox1Min, double * padfBox1Max,
                        double * padfBox2Min, double * padfBox2Max,
-                       int nDimension )
-
-{
-    int		iDim;
-
-    for( iDim = 0; iDim < nDimension; iDim++ )
+                       int nDimension ) {
+    for( int iDim = 0; iDim < nDimension; iDim++ )
     {
         if( padfBox2Max[iDim] < padfBox1Min[iDim] )
             return FALSE;
@@ -317,33 +315,33 @@ SHPCheckBoundsOverlap( double * padfBox1Min, double * padfBox1Max,
 /*      Does the given shape fit within the indicated extents?          */
 /************************************************************************/
 
-static int SHPCheckObjectContained( SHPObject * psObject, int nDimension,
+static bool SHPCheckObjectContained( SHPObject * psObject, int nDimension,
                            double * padfBoundsMin, double * padfBoundsMax )
 
 {
     if( psObject->dfXMin < padfBoundsMin[0]
         || psObject->dfXMax > padfBoundsMax[0] )
-        return FALSE;
+        return false;
 
     if( psObject->dfYMin < padfBoundsMin[1]
         || psObject->dfYMax > padfBoundsMax[1] )
-        return FALSE;
+        return false;
 
     if( nDimension == 2 )
-        return TRUE;
+        return true;
 
     if( psObject->dfZMin < padfBoundsMin[2]
         || psObject->dfZMax > padfBoundsMax[2] )
-        return FALSE;
+        return false;
 
     if( nDimension == 3 )
-        return TRUE;
+        return true;
 
     if( psObject->dfMMin < padfBoundsMin[3]
         || psObject->dfMMax > padfBoundsMax[3] )
-        return FALSE;
+        return false;
 
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/
@@ -396,7 +394,7 @@ SHPTreeSplitBounds( double *padfBoundsMinIn, double *padfBoundsMaxIn,
 /*                       SHPTreeNodeAddShapeId()                        */
 /************************************************************************/
 
-static int
+static bool
 SHPTreeNodeAddShapeId( SHPTreeNode * psTreeNode, SHPObject * psObject,
                        int nMaxDepth, int nDimension )
 
@@ -534,7 +532,7 @@ SHPTreeNodeAddShapeId( SHPTreeNode * psTreeNode, SHPObject * psObject,
         psTreeNode->papsShapeObj[psTreeNode->nShapeCount-1] = SHPLIB_NULLPTR;
     }
 
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/
@@ -800,7 +798,7 @@ void SHPCloseDiskTree( SHPTreeDiskHandle hDiskTree )
 /*                       SHPSearchDiskTreeNode()                        */
 /************************************************************************/
 
-static int
+static bool
 SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, double *padfBoundsMax,
                        int **ppanResultBuffer, int *pnBufferMax,
                        int *pnResultCount, int bNeedSwap, int nRecLevel )
@@ -835,21 +833,21 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
     if( nFReadAcc != 1 + 2 + 2 + 1 )
     {
         hDiskTree->sHooks.Error("I/O error");
-        return FALSE;
+        return false;
     }
 
     /* Sanity checks to avoid int overflows in later computation */
     if( offset > INT_MAX - sizeof(int) )
     {
         hDiskTree->sHooks.Error("Invalid value for offset");
-        return FALSE;
+        return false;
     }
 
     if( numshapes > (INT_MAX - offset - sizeof(int)) / sizeof(int) ||
         numshapes > INT_MAX / sizeof(int) - *pnResultCount )
     {
         hDiskTree->sHooks.Error("Invalid value for numshapes");
-        return FALSE;
+        return false;
     }
 
 /* -------------------------------------------------------------------- */
@@ -861,7 +859,7 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
     {
         offset += numshapes*sizeof(int) + sizeof(int);
         hDiskTree->sHooks.FSeek(hDiskTree->fpQIX, offset, SEEK_CUR);
-        return TRUE;
+        return true;
     }
 
 /* -------------------------------------------------------------------- */
@@ -884,7 +882,7 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
             if( pNewBuffer == SHPLIB_NULLPTR )
             {
                 hDiskTree->sHooks.Error("Out of memory error");
-                return FALSE;
+                return false;
             }
 
             *ppanResultBuffer = pNewBuffer;
@@ -894,7 +892,7 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
                     sizeof(int), numshapes, hDiskTree->fpQIX ) != numshapes )
         {
             hDiskTree->sHooks.Error("I/O error");
-            return FALSE;
+            return false;
         }
 
         if (bNeedSwap )
@@ -912,13 +910,13 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
     if( hDiskTree->sHooks.FRead( &numsubnodes, 4, 1, hDiskTree->fpQIX ) != 1 )
     {
         hDiskTree->sHooks.Error("I/O error");
-        return FALSE;
+        return false;
     }
     if ( bNeedSwap  ) SwapWord ( 4, &numsubnodes );
     if( numsubnodes > 0 && nRecLevel == 32 )
     {
         hDiskTree->sHooks.Error("Shape tree is too deep");
-        return FALSE;
+        return false;
     }
 
     for(i=0; i<numsubnodes; i++)
@@ -926,10 +924,10 @@ SHPSearchDiskTreeNode( SHPTreeDiskHandle hDiskTree, double *padfBoundsMin, doubl
         if( !SHPSearchDiskTreeNode( hDiskTree, padfBoundsMin, padfBoundsMax,
                                     ppanResultBuffer, pnBufferMax,
                                     pnResultCount, bNeedSwap, nRecLevel + 1 ) )
-            return FALSE;
+            return false;
     }
 
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/
@@ -989,7 +987,8 @@ int* SHPSearchDiskTreeEx( SHPTreeDiskHandle hDiskTree,
                           int *pnShapeCount )
 
 {
-    int i, bNeedSwap, nBufferMax = 0;
+    int i;
+    int nBufferMax = 0;
     unsigned char abyBuf[16];
     int *panResultBuffer = SHPLIB_NULLPTR;
 
@@ -1000,9 +999,9 @@ int* SHPSearchDiskTreeEx( SHPTreeDiskHandle hDiskTree,
 /* -------------------------------------------------------------------- */
     i = 1;
     if( *REINTERPRET_CAST(unsigned char *, &i) == 1 )
-        bBigEndian = FALSE;
+        bBigEndian = false;
     else
-        bBigEndian = TRUE;
+        bBigEndian = true;
 
 /* -------------------------------------------------------------------- */
 /*      Read the header.                                                */
@@ -1013,11 +1012,12 @@ int* SHPSearchDiskTreeEx( SHPTreeDiskHandle hDiskTree,
     if( memcmp( abyBuf, "SQT", 3 ) != 0 )
         return SHPLIB_NULLPTR;
 
+    bool bNeedSwap;
     if( (abyBuf[3] == 2 && bBigEndian)
         || (abyBuf[3] == 1 && !bBigEndian) )
-        bNeedSwap = FALSE;
+        bNeedSwap = false;
     else
-        bNeedSwap = TRUE;
+        bNeedSwap = true;
 
 /* -------------------------------------------------------------------- */
 /*      Search through root node and its descendants.                   */
@@ -1165,9 +1165,9 @@ int SHPWriteTreeLL(SHPTree *tree, const char *filename, SAHooks* psHooks )
 /* -------------------------------------------------------------------- */
     i = 1;
     if( *REINTERPRET_CAST(unsigned char *, &i) == 1 )
-        bBigEndian = FALSE;
+        bBigEndian = false;
     else
-        bBigEndian = TRUE;
+        bBigEndian = true;
 
 /* -------------------------------------------------------------------- */
 /*      Write the header.                                               */


### PR DESCRIPTION
Upstream at https://github.com/OSGeo/shapelib/tree/2025ce22196f100a773e2d0bbdc86cfd2ad0ad18

General cleanup.  No functional changes.

- Use stdbool true/false for internal variables
- Localize variables
- Combine variable definition and initialization when possible
- Add const when possible
- Remove or comment out most unused variables
- Remove some extra empty space
- Add some missing headers
- Sort standard headers
- Move static variable to after includes
- Remove RCS/CVS/SVN Id/Revision tags except for SHP_CVSID
- Remove some "goto error;" from shpopen.c
