### PR TITLE
Fix various source comment typos throughout the codebase

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -84,10 +84,10 @@ jobs:
       - name: Detect printf
         run: ./gdal/scripts/detect_printf.sh
 
-      - name: Detect self assigments
+      - name: Detect self assignments
         run: ./gdal/scripts/detect_self_assignment.sh
 
-      - name: Detect suspicous char digit zero
+      - name: Detect suspicious char digit zero
         run: ./gdal/scripts/detect_suspicious_char_digit_zero.sh
 
       - name: Shellcheck

--- a/.github/workflows/mingw_w64/install-python.sh
+++ b/.github/workflows/mingw_w64/install-python.sh
@@ -39,7 +39,7 @@ apt install -y  --no-install-recommends \
     wine-devel-i386=5.21~bionic \
     wine-devel-amd64=5.21~bionic \
     winetricks \
-    xvfb        # This is for making a dummy X server disply 
+    xvfb        # This is for making a dummy X server display
 
 echo "------ Download python ------"
 wget https://www.python.org/ftp/python/3.7.6/python-3.7.6-amd64.exe

--- a/autotest/gcore/test_driver_metadata.py
+++ b/autotest/gcore/test_driver_metadata.py
@@ -3,7 +3,7 @@
 # $Id$
 #
 # Project:  GDAL/OGR Test Suite
-# Purpose:  Test driver matadata
+# Purpose:  Test driver metadata
 # Author:   Rene Buffat <buffat at gmail dot com>
 #
 ###############################################################################

--- a/autotest/gdrivers/data/isce/isce.slc.xml
+++ b/autotest/gdrivers/data/isce/isce.slc.xml
@@ -24,7 +24,7 @@
     <component name="Coordinate1">
         <factorymodule>isceobj.Image</factorymodule>
         <factoryname>createCoordinate</factoryname>
-        <doc>First coordinate of a 2D image (witdh).</doc>
+        <doc>First coordinate of a 2D image (width).</doc>
         <property name="startingValue">
             <value>14.259166666666667</value>
         </property>

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -2240,7 +2240,7 @@ def test_ogr_geojson_57():
     assert ogrtest.check_feature_geometry(ogr.CreateGeometryFromJson(json.dumps(j_got["features"][1]["geometry"])), ogr.CreateGeometryFromJson(json.dumps(j_expected["features"][1]["geometry"]))) == 0
     assert ogrtest.check_feature_geometry(ogr.CreateGeometryFromJson(json.dumps(j_got["features"][2]["geometry"])), ogr.CreateGeometryFromJson(json.dumps(j_expected["features"][2]["geometry"]))) == 0
 
-    # Antimeridian case: EPSG:32660: WGS 84 / UTM zone 60N wit polygon on west of antimeridian
+    # Antimeridian case: EPSG:32660: WGS 84 / UTM zone 60N with polygon on west of antimeridian
     src_ds = gdal.GetDriverByName('Memory').Create('', 0, 0, 0)
     sr = osr.SpatialReference()
     sr.SetFromUserInput('+proj=utm +zone=60 +datum=WGS84 +units=m +no_defs')

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -1991,7 +1991,7 @@ def test_gdalwarp_lib_no_crs():
 
 ###############################################################################
 # Test that the warp kernel properly computes the resampling kernel xsize
-# when wraping along the antimeridian (related to #2754)
+# when wrapping along the antimeridian (related to #2754)
 
 def test_gdalwarp_lib_xscale_antimeridian():
 

--- a/gdal/apps/gdal_translate_lib.cpp
+++ b/gdal/apps/gdal_translate_lib.cpp
@@ -2210,7 +2210,7 @@ static void CopyBandInfo( GDALRasterBand * poSrcBand, GDALRasterBand * poDstBand
         {
             GDALRasterAttributeTable *poNewRAT = poSrcBand->GetDefaultRAT()->Clone();
 
-            // strip histogram data (as definied by the source RAT)
+            // strip histogram data (as defined by the source RAT)
             poNewRAT->RemoveStatistics();
             if( poNewRAT->GetColumnCount() )
             {

--- a/gdal/data/gdalvrt.xsd
+++ b/gdal/data/gdalvrt.xsd
@@ -44,7 +44,7 @@
                     <xs:element name="MaskBand" type="MaskBandType"/>
                     <xs:element name="GDALWarpOptions" type="GDALWarpOptionsType"/> <!-- only if subClass="VRTWarpedDataset" -->
                     <xs:element name="PansharpeningOptions" type="PansharpeningOptionsType"/> <!-- only if subClass="VRTPansharpenedDataset" -->
-                    <xs:element name="Group" type="GroupType"/> <!-- only for multidimensionnal dataset -->
+                    <xs:element name="Group" type="GroupType"/> <!-- only for multidimensional dataset -->
                     <xs:element name="OverviewList" type="OverviewListType"/>
                 </xs:choice>
             </xs:sequence>

--- a/gdal/data/netcdf_config.xsd
+++ b/gdal/data/netcdf_config.xsd
@@ -97,7 +97,7 @@
             <xs:annotation><xs:documentation>netCDF variable name. When both name
             and netcdf_name are set, the OGR field {name} will be written as the
             netCDF {netcdf_name} variable. When netcdf_name is set, but name is none,
-            then the Field definition will match an implictly created netCDF variable,
+            then the Field definition will match an implicitly created netCDF variable,
             such as x/lon, y/lat, z, ...
             </xs:documentation></xs:annotation>
         </xs:attribute>

--- a/gdal/data/ogrvrt.xsd
+++ b/gdal/data/ogrvrt.xsd
@@ -496,7 +496,7 @@
                 </xs:element>
                 <xs:element name="FieldStrategy" type="FieldStrategyType">
                     <xs:annotation>
-                        <xs:documentation>Defaults to Union if no Field or GeometryField element is speicified.</xs:documentation>
+                        <xs:documentation>Defaults to Union if no Field or GeometryField element is specified.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="Field" type="FieldTypeWithoutSrc">

--- a/gdal/data/pdfcomposition.xsd
+++ b/gdal/data/pdfcomposition.xsd
@@ -32,7 +32,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="1.0">
     <xs:element name="PDFComposition">
         <xs:annotation><xs:documentation>
-            Root element definining a composition of one or several pages.
+            Root element defining a composition of one or several pages.
         </xs:documentation></xs:annotation>
         <xs:complexType>
             <xs:sequence>
@@ -325,7 +325,7 @@
         </xs:sequence>
         <xs:attribute name="id" type="xs:string">
                 <xs:annotation><xs:documentation>
-                    ID that can be refered to to automatically place content.
+                    ID that can be referred to to automatically place content.
                     The georeferencing area ca be referenced to, only if the
                     control points define an affine geotransform, without rotation
                     or shearing, from PDF coordinate space to georeferenced
@@ -394,8 +394,8 @@
         <xs:annotation><xs:documentation>
             Sequence of raster, vector, labels, content from other PDF document,
             or conditionalized content of any of the above types.
-            The content is drawn in the order it is mentionned, that is the
-            first mentionned item is drawn first, and the last mentionned item
+            The content is drawn in the order it is mentioned, that is the
+            first mentioned item is drawn first, and the last mentioned item
             is drawn last.
         </xs:documentation></xs:annotation>
         <xs:sequence>
@@ -602,7 +602,7 @@
         <xs:attribute name="displayLayerName" type="xs:string">
             <xs:annotation><xs:documentation>
                 Name of the layer that will appear in the PDF reader.
-                If not specified, this wil be the OGR layer name.
+                If not specified, this will be the OGR layer name.
             </xs:documentation></xs:annotation>
         </xs:attribute>
         <xs:attribute name="fieldToDisplay" type="xs:string">

--- a/gdal/doc/source/development/rfc/rfc31_ogr_64.rst
+++ b/gdal/doc/source/development/rfc/rfc31_ogr_64.rst
@@ -181,7 +181,7 @@ A new option is added to ogr2ogr : -mapFieldType. Can be used like this
 -mapFieldType Integer64=Integer,Date=String to mean that Integer64 field
 in the source layer should be created as Integer, and Date as String.
 ogr2ogr will also warn if attempting to create a field in an output
-driver that advertizes a GDAL_DMD_CREATIONFIELDDATATYPES metadata item
+driver that advertises a GDAL_DMD_CREATIONFIELDDATATYPES metadata item
 that does not mention the required field type. For Integer64 fields, if
 it is not advertized in GDAL_DMD_CREATIONFIELDDATATYPES metadata item or
 GDAL_DMD_CREATIONFIELDDATATYPES is missing, conversion to Real is done
@@ -279,7 +279,7 @@ list of changes is :
 -  WFS: Integer64, Integer64List and 64 bit FID supported in read/write.
    GetFeatureCount() modified to return 64 bit values.
 -  CartoDB: Integer64 supported on creation. On read returned as Real
-   (CartoDB only advertizes a 'Number' type). GetFeatureCount() modified
+   (CartoDB only advertises a 'Number' type). GetFeatureCount() modified
    to return 64 bit values.
 -  XLSX: Integer64 supported in read/write.
 -  ODS: Integer64 supported in read/write.

--- a/gdal/doc/source/development/rfc/rfc49_curve_geometries.rst
+++ b/gdal/doc/source/development/rfc/rfc49_curve_geometries.rst
@@ -342,7 +342,7 @@ New methods
     * their corresponding linear geometry type (see OGR_GT_GetLinear()), by
     * possibly approximating circular arcs they may contain.
     * Regarding conversion from linear geometry types to curve geometry types, only
-    * "wraping" will be done. No attempt to retrieve potential circular arcs by
+    * "wrapping" will be done. No attempt to retrieve potential circular arcs by
     * de-approximating stroking will be done. For that, OGRGeometry::getCurveGeometry()
     * can be used.
     *

--- a/gdal/doc/source/development/rfc/rfc66_randomlayerreadwrite.rst
+++ b/gdal/doc/source/development/rfc/rfc66_randomlayerreadwrite.rst
@@ -236,7 +236,7 @@ Utilities
 ogr2ogr / GDALVectorTranslate() is changed internally to remove the hack
 that was used for the OSM driver to use the new API, when
 ODsCRandomLayerRead is advertized. It checks if the output driver
-advertizes ODsCRandomLayerWrite, and if it does not, emit a warning, but
+advertises ODsCRandomLayerWrite, and if it does not, emit a warning, but
 still goes on proceeding with the conversion using random layer
 reading/writing.
 

--- a/gdal/doc/source/development/rfc/rfc6_sqlgeom.rst
+++ b/gdal/doc/source/development/rfc/rfc6_sqlgeom.rst
@@ -30,7 +30,7 @@ Main concepts
 
 The most reasonable way to support this feature is to extend the
 currently existing 'special field' approach to allow specifying more
-than one fields. Along with the already definied 'FID' field we will add
+than one fields. Along with the already defined 'FID' field we will add
 the following ones:
 
 -  'OGR_GEOMETRY' containing the geometry type like 'POINT' or

--- a/gdal/doc/source/drivers/raster/gsbg.rst
+++ b/gdal/doc/source/drivers/raster/gsbg.rst
@@ -15,7 +15,7 @@ writing (including create, delete, and copy). Currently the associated
 formats for color, metadata, and shapes are not supported.
 
 Surfer 8 uses a fixed nodata value at 1.701410009187828e+38. When writing a
-GSBG dataset, GDAL remaps the user-specfied input nodata value to 1.701410009187828e+38.
+GSBG dataset, GDAL remaps the user-specified input nodata value to 1.701410009187828e+38.
 
 NOTE: Implemented as ``gdal/frmts/gsg/gsbgdataset.cpp``.
 

--- a/gdal/doc/source/drivers/raster/sentinel2.rst
+++ b/gdal/doc/source/drivers/raster/sentinel2.rst
@@ -56,7 +56,7 @@ Level-1B
 Level-1B products are composed of several "granules" of ~ 25 km
 across-track x ~ 23km along-track, in sensor geometry (i.e. non
 ortho-rectified). Each granule correspond to the imagery captured by one
-of the 12 detectors accros-track (for a total 290 km swath width). The
+of the 12 detectors across-track (for a total 290 km swath width). The
 imagery of each band is put in a separate JPEG2000 file.
 
 Level-1B products are aimed at advanced users.

--- a/gdal/doc/source/drivers/vector/netcdf.rst
+++ b/gdal/doc/source/drivers/vector/netcdf.rst
@@ -375,7 +375,7 @@ direct children of the root <Configuration> node, or specifically to a
 given layer, when defined as children of a <Layer> node.
 
 The filename is specified with the CONFIG_FILE dataset creation option.
-Alternatively, the content of the file can be specifid inline as the
+Alternatively, the content of the file can be specified inline as the
 value of the option (it must then begin strictly with the
 "<Configuration" characters)
 

--- a/gdal/doc/source/tutorials/vector_python_driver.rst
+++ b/gdal/doc/source/tutorials/vector_python_driver.rst
@@ -434,7 +434,7 @@ The following methods may be optionally implemented:
     :noindex:
 
     This method is called whenever self.attribute_filter has been changed.
-    It is the opportunity for the driver to potentially chane the value of
+    It is the opportunity for the driver to potentially change the value of
     self.iterator_honour_attribute_filter or feature_count_honour_attribute_filter
     attributes.
 
@@ -443,7 +443,7 @@ The following methods may be optionally implemented:
 
     This method is called whenever self.spatial_filter has been changed (its value
     is a geometry encoded in WKT)
-    It is the opportunity for the driver to potentially chane the value of
+    It is the opportunity for the driver to potentially change the value of
     self.iterator_honour_spatial_filter or feature_count_honour_spatial_filter
     attributes.
 


### PR DESCRIPTION
## What does this PR do?

Typos found via`codespell -q 3 -L als,ang,ans,dum,geometrie,hist,iff,inout,lod,merget,nd,objext,oder,oposition,parm,parms,pres,poiter,posession,repid,ressource,sinc,som,sur,te,templat,thare,titel,tre`

## What are related issues/pull requests?

Not relevant

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [x] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Not relevant
