### PR TITLE
Fix dispaly of two dashes instead of a single en-dash in SQLite and FileGDB doc pages

### DIFF
--- a/gdal/doc/source/drivers/vector/filegdb.rst
+++ b/gdal/doc/source/drivers/vector/filegdb.rst
@@ -174,7 +174,7 @@ Known Issues
 -  The SDK is known to be unable to open layers with particular spatial
    reference systems. This might be the case if messages "FGDB: Error
    opening XXXXXXX. Skipping it (Invalid function arguments.)" when
-   running "ogrinfo --debug on the.gdb" (reported as warning in GDAL
+   running ``ogrinfo --debug on the.gdb`` (reported as warning in GDAL
    2.0). Using the OpenFileGDB driver will generally solve that issue.
 -  FGDB coordinate snapping will cause geometries to be altered during
    writing. Use the origin and scale layer creation options to control

--- a/gdal/doc/source/drivers/vector/sqlite.rst
+++ b/gdal/doc/source/drivers/vector/sqlite.rst
@@ -15,7 +15,7 @@ The driver can handle "regular" SQLite databases, as well as Spatialite
 databases (spatial enabled SQLite databases). The type of an existing
 database can be checked from the SQLITE debug info value "OGR style
 SQLite DB found/ SpatiaLite DB found/SpatiaLite v4 DB found" obtained by
-running **"ogrinfo db.sqlite --debug on"**
+running ``ogrinfo db.sqlite --debug on``
 
 Starting with GDAL 2.2, the SQLite driver can also read databases with
 :ref:`RasterLite2 raster coverages <raster.rasterlite2>`.


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes the incorrect display of a single en-dash where two dashes should be displayed in 
SQLite / Spatialite RDBMS doc page https://gdal.org/drivers/vector/sqlite.html
![image](https://user-images.githubusercontent.com/16253859/109391921-cc14f180-7919-11eb-8a87-27ffff28af65.png)
and in ESRI File Geodatabase (FileGDB) doc page https://gdal.org/drivers/vector/filegdb.html
![image](https://user-images.githubusercontent.com/16253859/109392011-10a08d00-791a-11eb-8d6d-23aa852678ba.png)

