### PR TITLE
FITS: apply vertical mirroring on reading/writing

### DIFF
--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -587,7 +587,7 @@ def test_pds4_10():
         gdal.GetDriverByName('PDS4').Delete(filename)
         gdal.GetDriverByName('PDS4').Delete(filename2)
 
-    
+
 ###############################################################################
 # Test various data types
 
@@ -1276,7 +1276,10 @@ def test_pds4_append_subdataset_not_same_srs():
 ###############################################################################
 
 
-def _test_createlabelonly(src_ds, expected_standard_id = None, filename = '/vsimem/out.xml', validate = False):
+def _test_createlabelonly(src_ds,
+                          expected_content = None,
+                          filename = '/vsimem/out.xml',
+                          validate = False):
 
     src_ds_name = src_ds.GetDescription()
     src_driver_name = src_ds.GetDriver().GetDescription()
@@ -1305,8 +1308,12 @@ def _test_createlabelonly(src_ds, expected_standard_id = None, filename = '/vsim
         data = gdal.VSIFReadL(1, 10000, f).decode('ascii')
         gdal.VSIFCloseL(f)
     assert 'Binary file pre-existing PDS4 label' in data, data
-    if expected_standard_id:
-        assert expected_standard_id in data, data
+    if expected_content:
+        if isinstance(expected_content, list):
+            for expected_content_item in expected_content:
+                assert expected_content_item in data, data
+        else:
+            assert expected_content in data, data
 
     gdal.GetDriverByName('PDS4').Delete(filename)
     assert gdal.VSIStatL(src_ds_name)
@@ -1334,7 +1341,7 @@ def test_pds4_createlabelonly_gtiff():
     gdal.GetDriverByName('GTiff').CreateCopy('/vsimem/byte.tif', gdal.Open('data/byte.tif'))
 
     src_ds = gdal.Open('/vsimem/byte.tif')
-    return _test_createlabelonly(src_ds, expected_standard_id = '<parsing_standard_id>TIFF 6.0</parsing_standard_id>', validate = True)
+    return _test_createlabelonly(src_ds, expected_content = '<parsing_standard_id>TIFF 6.0</parsing_standard_id>', validate = True)
 
 
 ###############################################################################
@@ -1360,7 +1367,7 @@ def test_pds4_createlabelonly_bigtiff():
     gdal.GetDriverByName('GTiff').CreateCopy('/vsimem/byte.tif', gdal.Open('data/byte.tif'), options=['BIGTIFF=YES'])
 
     src_ds = gdal.Open('/vsimem/byte.tif')
-    return _test_createlabelonly(src_ds, expected_standard_id = '<parsing_standard_id>TIFF 6.0</parsing_standard_id>')
+    return _test_createlabelonly(src_ds, expected_content = '<parsing_standard_id>TIFF 6.0</parsing_standard_id>')
 
 
 ###############################################################################
@@ -1372,7 +1379,7 @@ def test_pds4_createlabelonly_isis3():
     gdal.GetDriverByName('ISIS3').CreateCopy('/vsimem/input.cub', gdal.Open('../gcore/data/uint16.tif'))
 
     src_ds = gdal.Open('/vsimem/input.cub')
-    return _test_createlabelonly(src_ds, expected_standard_id = '<parsing_standard_id>ISIS3</parsing_standard_id>')
+    return _test_createlabelonly(src_ds, expected_content = '<parsing_standard_id>ISIS3</parsing_standard_id>')
 
 
 ###############################################################################
@@ -1384,7 +1391,7 @@ def test_pds4_createlabelonly_vicar():
     gdal.FileFromMemBuffer('/vsimem/test_vicar_truncated.bin', open('data/vicar/test_vicar_truncated.bin', 'rb').read())
 
     src_ds = gdal.Open('/vsimem/test_vicar_truncated.bin')
-    return _test_createlabelonly(src_ds, expected_standard_id = '<parsing_standard_id>VICAR2</parsing_standard_id>')
+    return _test_createlabelonly(src_ds, expected_content = '<parsing_standard_id>VICAR2</parsing_standard_id>')
 
 
 ###############################################################################
@@ -1400,7 +1407,10 @@ def test_pds4_createlabelonly_fits():
     fits_drv.CreateCopy('tmp/input.fits', gdal.Open('../gcore/data/int16.tif'))
 
     src_ds = gdal.Open('tmp/input.fits')
-    return _test_createlabelonly(src_ds, expected_standard_id = '<parsing_standard_id>FITS 3.0</parsing_standard_id>', filename = 'tmp/out.xml')
+    return _test_createlabelonly(src_ds,
+                                 expected_content = ['<parsing_standard_id>FITS 3.0</parsing_standard_id>',
+                                                     '<disp:vertical_display_direction>Bottom to Top</disp:vertical_display_direction>'],
+                                 filename = 'tmp/out.xml')
 
 
 ###############################################################################
@@ -1412,6 +1422,6 @@ def test_pds4_createlabelonly_pds3():
     gdal.FileFromMemBuffer('/vsimem/mc02_truncated.img', open('data/pds/mc02_truncated.img', 'rb').read())
 
     src_ds = gdal.Open('/vsimem/mc02_truncated.img')
-    return _test_createlabelonly(src_ds, expected_standard_id = '<parsing_standard_id>PDS3</parsing_standard_id>')
+    return _test_createlabelonly(src_ds, expected_content = '<parsing_standard_id>PDS3</parsing_standard_id>')
 
 

--- a/gdal/data/pds4_template.xml
+++ b/gdal/data/pds4_template.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?> 
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://pds.nasa.gov/datastandards/schema/released/pds/v1/PDS4_PDS_1D00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="https://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1D00_1933.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>

--- a/gdal/frmts/fits/fitsdataset.cpp
+++ b/gdal/frmts/fits/fitsdataset.cpp
@@ -1751,9 +1751,9 @@ CPLErr FITSRasterBand::IReadBlock(CPL_UNUSED int nBlockXOff, int nBlockYOff,
   CPLAssert(nBlockYOff < nRasterYSize);
 
   // Calculate offsets and read in the data. Note that FITS array offsets
-  // start at 1...
+  // start at 1 at the bottom left...
   LONGLONG offset = static_cast<LONGLONG>(nBand - 1) * nRasterXSize * nRasterYSize +
-    static_cast<LONGLONG>(nBlockYOff) * nRasterXSize + 1;
+    (static_cast<LONGLONG>(nRasterYSize - 1 - nBlockYOff) * nRasterXSize + 1);
   long nElements = nRasterXSize;
 
   // If we haven't written this block to the file yet, then attempting
@@ -1803,7 +1803,7 @@ CPLErr FITSRasterBand::IWriteBlock( CPL_UNUSED int nBlockXOff, int nBlockYOff,
   // Calculate offsets and read in the data. Note that FITS array offsets
   // start at 1 at the bottom left...
   LONGLONG offset = static_cast<LONGLONG>(nBand - 1) * nRasterXSize * nRasterYSize +
-    static_cast<LONGLONG>(nBlockYOff) * nRasterXSize + 1;
+    (static_cast<LONGLONG>(nRasterYSize - 1 - nBlockYOff) * nRasterXSize + 1);
   long nElements = nRasterXSize;
   fits_write_img(hFITS, dataset->m_fitsDataType, offset, nElements,
                  pImage, &status);

--- a/gdal/frmts/pds/pds4dataset.cpp
+++ b/gdal/frmts/pds/pds4dataset.cpp
@@ -951,7 +951,7 @@ void PDS4Dataset::ReadGeoreferencing(CPLXMLNode* psProduct)
                           CPLString(osProjName).replaceAll(' ','_').c_str());
             if( psProjParamNode == nullptr &&
                 // typo in https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1700.sch
-                EQUAL(osProjName, "Orothographic") ) 
+                EQUAL(osProjName, "Orothographic") )
             {
                 psProjParamNode = CPLGetXMLNode(psMapProjection, "Orthographic");
             }
@@ -967,7 +967,7 @@ void PDS4Dataset::ReadGeoreferencing(CPLXMLNode* psProduct)
                 if( !bGotCenterLon )
                 {
                     dfCenterLon = GetAngularValue(psProjParamNode,
-                                    "straight_vertical_longitude_from_pole", 
+                                    "straight_vertical_longitude_from_pole",
                                     &bGotCenterLon);
                 }
                 dfCenterLat = GetAngularValue(psProjParamNode,
@@ -2186,7 +2186,7 @@ void PDS4Dataset::WriteGeoreferencing(CPLXMLNode* psCart,
         m_papszCreationOptions, "BOUNDING_DEGREES");
     double dfWest = std::min(std::min(adfX[0], adfX[1]),
                              std::min(adfX[2], adfX[3]));
-    double dfEast = std::max(std::max(adfX[0], adfX[1]), 
+    double dfEast = std::max(std::max(adfX[0], adfX[1]),
                              std::max(adfX[2], adfX[3]));
     double dfNorth = std::max(std::max(adfY[0], adfY[1]),
                               std::max(adfY[2], adfY[3]));
@@ -2427,13 +2427,13 @@ void PDS4Dataset::WriteGeoreferencing(CPLXMLNode* psCart,
         {
             CPLXMLNode* psOLA = CPLCreateXMLNode(nullptr, CXT_Element,
                                     (osPrefix + "Oblique_Line_Azimuth").c_str());
-            CPLAddXMLAttributeAndValue( 
+            CPLAddXMLAttributeAndValue(
                 CPLCreateXMLElementAndValue(psOLA,
                     (osPrefix + "azimuthal_angle").c_str(),
                     CPLSPrintf("%.18g", oSRS.GetNormProjParm(SRS_PP_AZIMUTH, 0.0))),
                 "unit", "deg");;
             // Not completely sure of this
-            CPLAddXMLAttributeAndValue( 
+            CPLAddXMLAttributeAndValue(
                 CPLCreateXMLElementAndValue(psOLA,
                     (osPrefix + "azimuth_measure_point_longitude").c_str(),
                     CPLSPrintf("%.18g", oSRS.GetNormProjParm(SRS_PP_CENTRAL_MERIDIAN, 0.0))),
@@ -2498,24 +2498,24 @@ void PDS4Dataset::WriteGeoreferencing(CPLXMLNode* psCart,
                                     (osPrefix + "Oblique_Line_Point").c_str());
             CPLXMLNode* psOLPG1 = CPLCreateXMLNode(psOLP, CXT_Element,
                                     (osPrefix + "Oblique_Line_Point_Group").c_str());
-            CPLAddXMLAttributeAndValue( 
+            CPLAddXMLAttributeAndValue(
                 CPLCreateXMLElementAndValue(psOLPG1,
                     (osPrefix + "oblique_line_latitude").c_str(),
                     CPLSPrintf("%.18g", oSRS.GetNormProjParm(SRS_PP_LATITUDE_OF_POINT_1, 0.0))),
                 "unit", "deg");
-            CPLAddXMLAttributeAndValue( 
+            CPLAddXMLAttributeAndValue(
                 CPLCreateXMLElementAndValue(psOLPG1,
                     (osPrefix + "oblique_line_longitude").c_str(),
                     CPLSPrintf("%.18g", oSRS.GetNormProjParm(SRS_PP_LONGITUDE_OF_POINT_1, 0.0))),
                 "unit", "deg");
             CPLXMLNode* psOLPG2 = CPLCreateXMLNode(psOLP, CXT_Element,
                                     (osPrefix + "Oblique_Line_Point_Group").c_str());
-            CPLAddXMLAttributeAndValue( 
+            CPLAddXMLAttributeAndValue(
                 CPLCreateXMLElementAndValue(psOLPG2,
                     (osPrefix + "oblique_line_latitude").c_str(),
                     CPLSPrintf("%.18g", oSRS.GetNormProjParm(SRS_PP_LATITUDE_OF_POINT_2, 0.0))),
                 "unit", "deg");
-            CPLAddXMLAttributeAndValue( 
+            CPLAddXMLAttributeAndValue(
                 CPLCreateXMLElementAndValue(psOLPG2,
                     (osPrefix + "oblique_line_longitude").c_str(),
                     CPLSPrintf("%.18g", oSRS.GetNormProjParm(SRS_PP_LONGITUDE_OF_POINT_2, 0.0))),
@@ -2770,7 +2770,7 @@ void PDS4Dataset::SubstituteVariables(CPLXMLNode* psNode, char** papszDict)
     {
         CPLString osVal(psNode->pszValue);
 
-        if( strstr(psNode->pszValue, "${TITLE}") != nullptr && 
+        if( strstr(psNode->pszValue, "${TITLE}") != nullptr &&
             CSLFetchNameValue(papszDict, "VAR_TITLE") == nullptr )
         {
             const CPLString osTitle(CPLGetFilename(GetDescription()));
@@ -3514,6 +3514,26 @@ void PDS4Dataset::CreateHeader(CPLXMLNode* psProduct,
 
             WriteGeoreferencing(psCart, osWKT, pszCARTVersion);
         }
+
+        const char* pszVertDir = CSLFetchNameValue(m_papszCreationOptions,
+                                                   "VAR_VERTICAL_DISPLAY_DIRECTION");
+        if( pszVertDir )
+        {
+            CPLXMLNode* psVertDirNode = CPLGetXMLNode(psDisciplineArea,
+              "disp:Display_Settings.disp:Display_Direction."
+              "disp:vertical_display_direction");
+            if( psVertDirNode == nullptr )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "PDS4 template lacks a disp:vertical_display_direction element where to write %s",
+                         pszVertDir);
+            }
+            else
+            {
+                CPLDestroyXMLNode(psVertDirNode->psChild);
+                psVertDirNode->psChild = CPLCreateXMLNode(nullptr, CXT_Text, pszVertDir);
+            }
+        }
     }
     else
     {
@@ -3901,8 +3921,11 @@ GDALDataset *PDS4Dataset::Create(const char *pszFilename,
 PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
                                          GDALDataset* poSrcDS,
                                          int nXSize, int nYSize, int nBands,
-                                         GDALDataType eType, char **papszOptions)
+                                         GDALDataType eType,
+                                         const char * const * papszOptionsIn)
 {
+    CPLStringList aosOptions(papszOptionsIn);
+
     if( nXSize == 0 && nYSize == 0 && nBands == 0 && eType == GDT_Unknown )
     {
         // Vector file creation
@@ -3914,8 +3937,8 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
         poDS->m_osXMLFilename = pszFilename;
         poDS->m_bCreateHeader = true;
         poDS->m_bStripFileAreaObservationalFromTemplate = true;
-        poDS->m_papszCreationOptions = CSLDuplicate(papszOptions);
-        poDS->m_bUseSrcLabel = CPLFetchBool(papszOptions, "USE_SRC_LABEL", true);
+        poDS->m_papszCreationOptions = CSLDuplicate(aosOptions.List());
+        poDS->m_bUseSrcLabel = aosOptions.FetchBool("USE_SRC_LABEL", true);
         return poDS;
     }
 
@@ -3940,7 +3963,7 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
         return nullptr;
     }
 
-    const char* pszArrayType = CSLFetchNameValueDef(papszOptions,
+    const char* pszArrayType = aosOptions.FetchNameValueDef(
                                     "ARRAY_TYPE", "Array_3D_Image");
     const bool bIsArray2D = STARTS_WITH(pszArrayType, "Array_2D");
     if( nBands > 1 && bIsArray2D )
@@ -3958,8 +3981,7 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
     int nLineOffset, nPixelOffset;
     vsi_l_offset nBandOffset;
 
-    const char* pszInterleave = CSLFetchNameValueDef(
-        papszOptions, "INTERLEAVE", "BSQ");
+    const char* pszInterleave = aosOptions.FetchNameValueDef("INTERLEAVE", "BSQ");
     if( bIsArray2D )
         pszInterleave = "BIP";
 
@@ -4001,15 +4023,14 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
         return nullptr;
     }
 
-    const char* pszImageFormat = CSLFetchNameValueDef(papszOptions,
-                                                       "IMAGE_FORMAT",
+    const char* pszImageFormat = aosOptions.FetchNameValueDef("IMAGE_FORMAT",
                                                        "RAW");
-    const char* pszImageExtension = CSLFetchNameValueDef(papszOptions,
+    const char* pszImageExtension = aosOptions.FetchNameValueDef(
         "IMAGE_EXTENSION", EQUAL(pszImageFormat, "RAW") ? "img" : "tif");
-    CPLString osImageFilename(CSLFetchNameValueDef(papszOptions,
+    CPLString osImageFilename(aosOptions.FetchNameValueDef(
         "IMAGE_FILENAME", CPLResetExtension(pszFilename, pszImageExtension)));
 
-    const bool bAppend = CPLFetchBool(papszOptions, "APPEND_SUBDATASET", false);
+    const bool bAppend = aosOptions.FetchBool("APPEND_SUBDATASET", false);
     if( bAppend )
     {
         GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
@@ -4037,7 +4058,7 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
     vsi_l_offset nBaseOffset = 0;
     bool bIsLSB = true;
     CPLString osHeaderParsingStandard;
-    const bool bCreateLabelOnly = CPLFetchBool(papszOptions, "CREATE_LABEL_ONLY", false);
+    const bool bCreateLabelOnly = aosOptions.FetchBool("CREATE_LABEL_ONLY", false);
     if( bCreateLabelOnly )
     {
         if( poSrcDS == nullptr )
@@ -4106,6 +4127,7 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
             else if( EQUAL(pszDriverName, "FITS") )
             {
                 osHeaderParsingStandard = "FITS 3.0";
+                aosOptions.SetNameValue("VAR_VERTICAL_DISPLAY_DIRECTION", "Bottom to Top");
             }
         }
     }
@@ -4214,8 +4236,8 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
     poDS->m_bCreateHeader = true;
     poDS->m_bStripFileAreaObservationalFromTemplate = true;
     poDS->m_osInterleave = pszInterleave;
-    poDS->m_papszCreationOptions = CSLDuplicate(papszOptions);
-    poDS->m_bUseSrcLabel = CPLFetchBool(papszOptions, "USE_SRC_LABEL", true);
+    poDS->m_papszCreationOptions = CSLDuplicate(aosOptions.List());
+    poDS->m_bUseSrcLabel = aosOptions.FetchBool("USE_SRC_LABEL", true);
     poDS->m_bIsLSB = bIsLSB;
     poDS->m_osHeaderParsingStandard = osHeaderParsingStandard;
     poDS->m_bCreatedFromExistingBinaryFile = bCreateLabelOnly;

--- a/gdal/frmts/pds/pds4dataset.h
+++ b/gdal/frmts/pds/pds4dataset.h
@@ -365,7 +365,8 @@ class PDS4Dataset final: public RawDataset
     static PDS4Dataset *CreateInternal(const char *pszFilename,
                                        GDALDataset* poSrcDS,
                                        int nXSize, int nYSize, int nBands,
-                                       GDALDataType eType, char **papszOptions);
+                                       GDALDataType eType,
+                                       const char * const * papszOptions);
 
 public:
     PDS4Dataset();


### PR DESCRIPTION
as expected by WCS translation.

Also adapt the PDS4 driver in CREATE_LABEL_ONLY=YES mode to alter
the <disp:vertical_display_direction> element (and warn if it is
missing)

Co-authored-by: Even Rouault <even.rouault@spatialys.com>
