### PR TITLE
Document OGR_CURRENT_DATE config option: update for vector and add to raster

### DIFF
--- a/gdal/doc/source/drivers/raster/gpkg.rst
+++ b/gdal/doc/source/drivers/raster/gpkg.rst
@@ -155,6 +155,15 @@ with FlushCache()), those uncompressed tiles are definitely transferred
 to the GeoPackage file with the appropriate compression. All of this is
 transparent to the user of GDAL API/utilities
 
+The driver updates the GeoPackage ``last_change`` timestamp when the file is
+created or modified. If consistent binary output is required for
+reproducibility, the timestamp can be forced to a specific value by setting the
+:decl_configoption:`OGR_CURRENT_DATE` global configuration option.
+When setting the option, take care to meet the specific time format
+requirement of the GeoPackage standard, 
+e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
+
+
 .. _raster.gpkg.tile_formats:
 
 Tile formats

--- a/gdal/doc/source/drivers/vector/gpkg.rst
+++ b/gdal/doc/source/drivers/vector/gpkg.rst
@@ -182,6 +182,9 @@ The driver updates the GeoPackage ``last_change`` timestamp when the file is
 created or modified. If consistent binary output is required for
 reproducibility, the timestamp can be forced to a specific value by setting the
 :decl_configoption:`OGR_CURRENT_DATE` global configuration option.
+When setting the option, take care to meet the specific time format
+requirement of the GeoPackage standard, 
+e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
 
 Dataset Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
A follow-up to PR #3519, as [suggested](https://github.com/r-spatial/sf/issues/1618#issuecomment-790633693) by @dbaston.

- referral to the specific time format required by GeoPackage standard
- copy into the documentation of the raster driver, where it has its effect as well

However in relation to binary reproducibility, should the `gpkg_metadata_reference` table not be taken into account as well? It also has a `timestamp` column using the same format (a specific format of ISO 8601) - see [Requirement 100](https://www.geopackage.org/spec120/#r100).

It appears that `gpkg_metadata_reference` is _not_ created [when running](https://github.com/r-spatial/sf/issues/1618#issuecomment-790769027) functions of the R packages `sf` and `stars`, which use GDAL, resulting in reproducible files indeed, but it _is_ created when running `ogr2ogr` or `gdal_translate`, applying the GPKG default (current time) regardless of `OGR_CURRENT_DATE`. In the case of `ogr2ogr` and `gdal_translate`, setting `OGR_CURRENT_DATE` does not result in binary identical files, (at least) for that reason.

So for the documentation I'm unsure about the referral to "binary identical output"; see also https://trac.osgeo.org/gdal/wiki/Release/2.2.0-News.

```bash
$ gdal-config --version
3.1.3
$ ogr2ogr --version
GDAL 3.2.1, released 2020/12/29
```