### PR TITLE
CI: Skip GitLab CI for documentation-only commits

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,12 @@
 name: Android build
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
 
 jobs:
 

--- a/.github/workflows/asan_build.yml
+++ b/.github/workflows/asan_build.yml
@@ -1,6 +1,12 @@
 name: ASAN build
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
 
 jobs:
 

--- a/.github/workflows/clang_static_analyzer.yml
+++ b/.github/workflows/clang_static_analyzer.yml
@@ -1,6 +1,13 @@
 name: CLang Static Analyzer
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,6 +1,12 @@
 name: Code Checks
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
 
 jobs:
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,6 +1,13 @@
 name: Conda
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,13 @@
 name: MacOS build
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
 

--- a/.github/workflows/mingw_w64.yml
+++ b/.github/workflows/mingw_w64.yml
@@ -1,6 +1,13 @@
 name: mingw_w64 build
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
 

--- a/.github/workflows/ubuntu_18.04.yml
+++ b/.github/workflows/ubuntu_18.04.yml
@@ -1,6 +1,13 @@
 name: Ubuntu 18.04 build
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
 

--- a/.github/workflows/ubuntu_18.04_32bit.yml
+++ b/.github/workflows/ubuntu_18.04_32bit.yml
@@ -1,6 +1,13 @@
 name: Ubuntu 18.04 32bit build
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
 

--- a/.github/workflows/ubuntu_20.04.yml
+++ b/.github/workflows/ubuntu_20.04.yml
@@ -1,6 +1,13 @@
 name: Ubuntu 20.04 build
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
 

--- a/.github/workflows/validate_xml.yml
+++ b/.github/workflows/validate_xml.yml
@@ -1,6 +1,13 @@
 name: Validate XML
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
   validate_xml:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,6 +1,13 @@
 name: Windows builds
 
-on: [push, pull_request]
+on:
+    push:
+        paths-ignore:
+            - 'gdal/doc/**'
+    pull_request:
+        paths-ignore:
+            - 'gdal/doc/**'
+
 
 jobs:
 

--- a/gdal/doc/source/contributing/developer.rst
+++ b/gdal/doc/source/contributing/developer.rst
@@ -106,7 +106,7 @@ Working with a feature branch
    git push my_user_name my_new_feature_branch
    From GitHub UI, issue a pull request
 
-If the pull request discussion or Travis-CI/AppVeyor checks require
+If the pull request discussion or CI checks require
 changes, commit locally and push. To get a reasonable history, you may
 need to ``git rebase -i master``, in which case you will have to
 force-push your branch with

--- a/gdal/ogr/ogrlinestring.cpp
+++ b/gdal/ogr/ogrlinestring.cpp
@@ -396,8 +396,7 @@ double OGRSimpleCurve::getZ( int iVertex ) const
  * \brief Get measure at vertex.
  *
  * Returns the M (measure) value at the indicated vertex.  If no M
- * value is available, 0.0 is returned.  If iVertex is out of range a
- * crash may occur, no internal range checking is performed.
+ * value is available, 0.0 is returned.
  *
  * @param iVertex the vertex to return, between 0 and getNumPoints()-1.
  *


### PR DESCRIPTION
This should save time and electrons for the many documentation-only PRs.