### PR TITLE
CI: Fix AppVeyor skip for doc-only commits

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 # the file patterns below
 skip_commits:
     files:
-        - gdal/doc/**
+        - gdal/doc/**/*
 
 environment:
   matrix:

--- a/gdal/doc/source/contributing/rst_style.rst
+++ b/gdal/doc/source/contributing/rst_style.rst
@@ -196,7 +196,7 @@ To include link to sample file, use the ``download`` directive::
 
 The result of this code will generate a standard link to an :download:`external file <example.txt>`
 
-To include a the contents of a file, use ``literalinclude`` directive::
+To include the contents of a file, use ``literalinclude`` directive::
 
    Example of :command:`gdalinfo` use:
    

--- a/gdal/doc/source/faq.rst
+++ b/gdal/doc/source/faq.rst
@@ -54,7 +54,7 @@ See :ref:`license`
 What operating systems does GDAL-OGR run on?
 ++++++++++++++++++++++++++++++++++++++++++++
 
-You can use GDAL/OGR on all modern flavors of Unix: Linux, FreeBSD, Mac OS X; all supported versions of Microsoft Windows; mobile environements (Android and iOS). Both, 32-bit and 64-bit architectures are supported.
+You can use GDAL/OGR on all modern flavors of Unix: Linux, FreeBSD, Mac OS X; all supported versions of Microsoft Windows; mobile environments (Android and iOS). Both 32-bit and 64-bit architectures are supported.
 
 Is there a graphical user interface to GDAL/OGR?
 ++++++++++++++++++++++++++++++++++++++++++++++++

--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -191,7 +191,7 @@ Available options are:
     template_tiles.mapml file from GDAL data resources
     will be used
 
-The --url option is also used to substitue ``${URL}`` in the template MapML file.
+The --url option is also used to substitute ``${URL}`` in the template MapML file.
 
 Examples
 --------

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -97,7 +97,7 @@ but no projection checking is performed (unless projectionCheck option is used).
 
     ..versionadded:: 3.3
 
-    this option determinants how to handle rasters with different extents.
+    this option determines how to handle rasters with different extents.
     this option is mutually exclusive with the `projwin` option, which is used for providing a custom extent.
     for all the options below the pixel size (resolution) and SRS (Spatial Reference System) of all the input rasters must be the same.
     ``ignore`` (default) - only the dimensions of the rasters are compared. if the dimensions do not agree the operation will fail.
@@ -153,7 +153,7 @@ Python options
 ..versionadded:: 3.3
 
 The following options are available by using function the python interface of gdal_calc.
-they are not available using the command prompt.
+They are not available using the command prompt.
 
 .. option:: user_namespace
 

--- a/gdal/doc/source/software_using_gdal.rst
+++ b/gdal/doc/source/software_using_gdal.rst
@@ -44,7 +44,7 @@ Software using GDAL
 - `gstat  <http://www.gstat.org>`_  a geostatistical modelling package.
 - `GuidosToolbox  <https://forest.jrc.ec.europa.eu/en/activities/lpa/gtb/>`_  A multi-platform desktop application for generic image object analysis.
 - `gvSIG  <http://www.gvsig.com>`_  Desktop GIS Client.
-- `HydroDaVE Explorer  <http://www.hydrodave.com>`_  A web-enabled client that provides users an easy to use, secure, and reliable data management platform to efficienctly manage, access, and analyze environmental data.
+- `HydroDaVE Explorer  <http://www.hydrodave.com>`_  A web-enabled client that provides users an easy to use, secure, and reliable data management platform to efficiently manage, access, and analyze environmental data.
 - `IDRISI  <http://www.idrisi.com>`_  A GIS and Image Processing Windows Desktop application. Uses GDAL to import/export/warp raster data.
 - `ILWIS  <http://www.itc.nl/ilwis>`_  Remote Sensing and GIS Desktop Package.
 - `Image I/O-Ext  <https://github.com/geosolutions-it/imageio-ext>`_  includes gdalframework, a framework leveraging on GDAL via SWIG's generated JAVA bindings to provide support for a broad set of data formats.

--- a/gdal/doc/source/tutorials/wktproblems.rst
+++ b/gdal/doc/source/tutorials/wktproblems.rst
@@ -4,7 +4,7 @@
 OGC WKT Coordinate System Issues
 ================================================================================
 
-This document is intended to discuss some issues that arrise in
+This document is intended to discuss some issues that arise in
 attempting to use OpenGIS Well Known Text descriptions of coordinate
 systems. It discusses various vendor implementations and issues between
 the original `"Simple Features" specification (ie. SF-SQL
@@ -135,7 +135,7 @@ instance the BNF for the PROJCS item in the CT spec is
 
 This clearly states that the PROJECTION keyword follows the GEOGCS,
 followed by the UNIT, AXIS and AUTHORITY items. Providing them out of
-order is technially a violation of the spec. On the other hand, WKT
+order is technically a violation of the spec. On the other hand, WKT
 consumers are encouraged to be flexible on ordering.
 
 Units of PARAMETERs
@@ -266,7 +266,7 @@ EPSG 9607. Furthermore, I would like to see any future rev of the spec
 clarify this, referencing the EPSG method definitions.
 
 Martin wrote back that he was uncertain on the correct signage and that
-the Adam had programmed the Cadcorp implementation imperically,
+the Adam had programmed the Cadcorp implementation empirically,
 according to what seemed to work for the test data available.
 
 I am prepared to adhere to the Cadorp sign usage (as per EPSG 9607) if
@@ -335,7 +335,7 @@ The specification does not address the precision to which values in WKT
 should be stored. Some implementations, such as Oracles apparently, use
 rather limited precision for parameters such as Scale Factor making it
 difficult to compare coordinate system descriptions or even to get
-comparible numerical results.
+comparable numerical results.
 
 The best practice is to preserve the original precision as specified in
 the source database, such as EPSG where possible. Given that many


### PR DESCRIPTION
Attempt to fix AppVeyor skip config set in #3533. I will push a doc-only commit shortly to check that this is working.