### PR TITLE
OGRSpatialReference::SetFromUserInput() allow https:// when loading CRS from opengis.net

### DIFF
--- a/autotest/osr/osr_url.py
+++ b/autotest/osr/osr_url.py
@@ -86,7 +86,6 @@ def test_osr_opengis_http_4326():
     assert srs.SetFromUserInput("http://opengis.net/def/crs/EPSG/0/4326") == 0
     assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
 
-
 def test_osr_opengis_https_4326():
     srs = osr.SpatialReference()
     assert srs.SetFromUserInput("https://www.opengis.net/def/crs/EPSG/0/4326") == 0
@@ -94,5 +93,3 @@ def test_osr_opengis_https_4326():
 
     assert srs.SetFromUserInput("https://opengis.net/def/crs/EPSG/0/4326") == 0
     assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
-
-

--- a/autotest/osr/osr_url.py
+++ b/autotest/osr/osr_url.py
@@ -70,11 +70,29 @@ def osr_url_test(url, expected_wkt):
 
 
 def test_osr_url_1():
-    return osr_url_test('http://spatialreference.org/ref/epsg/4326/', expected_wkt)
-
+    osr_url_test('http://spatialreference.org/ref/epsg/4326/', expected_wkt)
 
 def test_osr_url_2():
-    return osr_url_test('http://spatialreference.org/ref/epsg/4326/ogcwkt/', expected_wkt)
+    osr_url_test('http://spatialreference.org/ref/epsg/4326/ogcwkt/', expected_wkt)
 
+def test_osr_spatialreference_https_4326():
+    osr_url_test('https://spatialreference.org/ref/epsg/4326/', expected_wkt)
+
+def test_osr_opengis_http_4326():
+    srs = osr.SpatialReference()
+    assert srs.SetFromUserInput("http://www.opengis.net/def/crs/EPSG/0/4326") == 0
+    assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
+
+    assert srs.SetFromUserInput("http://opengis.net/def/crs/EPSG/0/4326") == 0
+    assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
+
+
+def test_osr_opengis_https_4326():
+    srs = osr.SpatialReference()
+    assert srs.SetFromUserInput("https://www.opengis.net/def/crs/EPSG/0/4326") == 0
+    assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
+
+    assert srs.SetFromUserInput("https://opengis.net/def/crs/EPSG/0/4326") == 0
+    assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
 
 

--- a/autotest/osr/osr_url.py
+++ b/autotest/osr/osr_url.py
@@ -78,18 +78,22 @@ def test_osr_url_2():
 def test_osr_spatialreference_https_4326():
     osr_url_test('https://spatialreference.org/ref/epsg/4326/', expected_wkt)
 
-def test_osr_opengis_http_4326():
+def test_osr_www_opengis_http_4326():
     srs = osr.SpatialReference()
     assert srs.SetFromUserInput("http://www.opengis.net/def/crs/EPSG/0/4326") == 0
     assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
 
+def test_osr_opengis_http_4326():
+    srs = osr.SpatialReference()
     assert srs.SetFromUserInput("http://opengis.net/def/crs/EPSG/0/4326") == 0
     assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
 
-def test_osr_opengis_https_4326():
+def test_osr_www_opengis_https_4326():
     srs = osr.SpatialReference()
     assert srs.SetFromUserInput("https://www.opengis.net/def/crs/EPSG/0/4326") == 0
     assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())
 
+def test_osr_opengis_https_4326():
+    srs = osr.SpatialReference()
     assert srs.SetFromUserInput("https://opengis.net/def/crs/EPSG/0/4326") == 0
     assert gdaltest.equal_srs_from_wkt(expected_wkt, srs.ExportToWkt())

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -3664,7 +3664,7 @@ OGRErr CPL_STDCALL OSRSetFromUserInput( OGRSpatialReferenceH hSRS,
 OGRErr OGRSpatialReference::importFromUrl( const char * pszUrl )
 
 {
-    if( !STARTS_WITH_CI(pszUrl, "http://") )
+    if( !STARTS_WITH_CI(pszUrl, "http://") && !STARTS_WITH_CI(pszUrl, "https://") )
     {
         CPLError( CE_Failure, CPLE_AppDefined,
                   "The given string is not recognized as a URL"
@@ -3715,7 +3715,7 @@ OGRErr OGRSpatialReference::importFromUrl( const char * pszUrl )
     }
 
     const char* pszData = reinterpret_cast<const char*>(psResult->pabyData);
-    if( STARTS_WITH_CI(pszData, "http://") )
+    if( STARTS_WITH_CI(pszData, "http://") || STARTS_WITH_CI(pszData, "https://") )
     {
         CPLError( CE_Failure, CPLE_AppDefined,
                   "The data that was downloaded also starts with 'http://' "

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -3470,7 +3470,9 @@ OGRErr OGRSpatialReference::SetFromUserInput( const char * pszDefinition )
         return importFromURN( pszDefinition );
 
     if( STARTS_WITH_CI(pszDefinition, "http://opengis.net/def/crs")
+        || STARTS_WITH_CI(pszDefinition, "https://opengis.net/def/crs")
         || STARTS_WITH_CI(pszDefinition, "http://www.opengis.net/def/crs")
+        || STARTS_WITH_CI(pszDefinition, "https://opengis.net/def/crs")
         || STARTS_WITH_CI(pszDefinition, "www.opengis.net/def/crs"))
         return importFromCRSURL( pszDefinition );
 
@@ -3530,7 +3532,7 @@ OGRErr OGRSpatialReference::SetFromUserInput( const char * pszDefinition )
              || strstr(pszDefinition, "+init") != nullptr )
         return importFromProj4( pszDefinition );
 
-    if( STARTS_WITH_CI(pszDefinition, "http://") )
+    if( STARTS_WITH_CI(pszDefinition, "http://") || STARTS_WITH_CI(pszDefinition, "https://") )
     {
         return importFromUrl (pszDefinition);
     }
@@ -4001,8 +4003,12 @@ OGRErr OGRSpatialReference::importFromCRSURL( const char *pszURL )
 
     if( STARTS_WITH_CI(pszURL, "http://opengis.net/def/crs") )
         pszCur = pszURL + 26;
+    else if( STARTS_WITH_CI(pszURL, "https://opengis.net/def/crs") )
+        pszCur = pszURL + 27;
     else if( STARTS_WITH_CI(pszURL, "http://www.opengis.net/def/crs") )
         pszCur = pszURL + 30;
+    else if( STARTS_WITH_CI(pszURL, "https://www.opengis.net/def/crs") )
+        pszCur = pszURL + 32;
     else if( STARTS_WITH_CI(pszURL, "www.opengis.net/def/crs") )
         pszCur = pszURL + 23;
     else

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -3472,7 +3472,7 @@ OGRErr OGRSpatialReference::SetFromUserInput( const char * pszDefinition )
     if( STARTS_WITH_CI(pszDefinition, "http://opengis.net/def/crs")
         || STARTS_WITH_CI(pszDefinition, "https://opengis.net/def/crs")
         || STARTS_WITH_CI(pszDefinition, "http://www.opengis.net/def/crs")
-        || STARTS_WITH_CI(pszDefinition, "https://opengis.net/def/crs")
+        || STARTS_WITH_CI(pszDefinition, "https://www.opengis.net/def/crs")
         || STARTS_WITH_CI(pszDefinition, "www.opengis.net/def/crs"))
         return importFromCRSURL( pszDefinition );
 

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -4008,7 +4008,7 @@ OGRErr OGRSpatialReference::importFromCRSURL( const char *pszURL )
     else if( STARTS_WITH_CI(pszURL, "http://www.opengis.net/def/crs") )
         pszCur = pszURL + 30;
     else if( STARTS_WITH_CI(pszURL, "https://www.opengis.net/def/crs") )
-        pszCur = pszURL + 32;
+        pszCur = pszURL + 31;
     else if( STARTS_WITH_CI(pszURL, "www.opengis.net/def/crs") )
         pszCur = pszURL + 23;
     else


### PR DESCRIPTION
## What does this PR do?
This allows https:// to be used when looking up CRS 

## What are related issues/pull requests?

fixes #3548

## Tasklist

 - [x] Support https://opengis.net
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
