### PR TITLE
CPLHTTP: Allow to set GSSAPI credential delegation type

### DIFF
--- a/gdal/frmts/wms/gdalhttp.cpp
+++ b/gdal/frmts/wms/gdalhttp.cpp
@@ -32,7 +32,7 @@
 #include "wmsdriver.h"
 #include <algorithm>
 
-#if LIBCURL_VERSION_NUM < 0x071c00
+#if !CURL_AT_LEAST_VERSION(7,28,0)
 // Needed for curl_multi_wait()
 #error Need libcurl version 7.28.0 or newer
 // 7.28 was released in Oct 2012

--- a/gdal/frmts/wms/wmsdriver.h
+++ b/gdal/frmts/wms/wmsdriver.h
@@ -41,9 +41,8 @@
 #include <vector>
 #include <utility>
 
-#include <curl/curl.h>
-
 #include "cpl_conv.h"
+#include "cpl_curl_priv.h"
 #include "cpl_http.h"
 #include "gdal_alg.h"
 #include "gdal_pam.h"

--- a/gdal/port/cpl_curl_priv.h
+++ b/gdal/port/cpl_curl_priv.h
@@ -1,0 +1,40 @@
+/******************************************************************************
+ * $Id$
+ *
+ * Project:  CPL - Common Portability Library
+ * Author:   Andrew Sudorgin (drons [a] list dot ru)
+ *
+ ******************************************************************************
+ * Copyright (c) 2021, Andrew Sudorgin (drons [a] list dot ru)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef CPL_CURL_PRIV_H_INCLUDED
+#define CPL_CURL_PRIV_H_INCLUDED
+
+#include <curl/curl.h>
+
+#ifndef CURL_AT_LEAST_VERSION
+#define CURL_VERSION_BITS(x,y,z) ((x)<<16|(y)<<8|z)
+#define CURL_AT_LEAST_VERSION(x,y,z) \
+  (LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(x, y, z))
+#endif //#ifndef CURL_AT_LEAST_VERSION
+
+#endif // CPL_CURL_PRIV_H_INCLUDED

--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -52,6 +52,13 @@
 
 #ifdef HAVE_CURL
 #  include <curl/curl.h>
+
+#ifndef CURL_AT_LEAST_VERSION
+#define CURL_VERSION_BITS(x,y,z) ((x)<<16|(y)<<8|z)
+#define CURL_AT_LEAST_VERSION(x,y,z) \
+  (LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(x, y, z))
+#endif //#ifndef CURL_AT_LEAST_VERSION
+
 // CURLINFO_RESPONSE_CODE was known as CURLINFO_HTTP_CODE in libcurl 7.10.7 and
 // earlier.
 #if LIBCURL_VERSION_NUM < 0x070a07

--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -1965,6 +1965,36 @@ void *CPLHTTPSetOptions(void *pcurl, const char* pszURL,
     }
 #endif
 
+#if CURL_AT_LEAST_VERSION(7,22,0)
+    const char *pszGssDelegation = CSLFetchNameValue(papszOptions, "GSSAPI_DELEGATION");
+    if( pszGssDelegation == nullptr )
+            pszGssDelegation = CPLGetConfigOption("GDAL_GSSAPI_DELEGATION", nullptr);
+    if(pszGssDelegation == nullptr)
+    {
+    }
+    else if(EQUAL(pszGssDelegation, "NONE"))
+    {
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_GSSAPI_DELEGATION,
+                                   CURLGSSAPI_DELEGATION_NONE);
+    }
+    else if(EQUAL(pszGssDelegation, "POLICY"))
+    {
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_GSSAPI_DELEGATION,
+                                   CURLGSSAPI_DELEGATION_POLICY_FLAG);
+    }
+    else if(EQUAL(pszGssDelegation, "ALWAYS"))
+    {
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_GSSAPI_DELEGATION,
+                                   CURLGSSAPI_DELEGATION_FLAG);
+    }
+    else
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Unsupported GSSAPI_DELEGATION value '%s', ignored.",
+                 pszGssDelegation);
+    }
+#endif //#if CURL_AT_LEAST_VERSION(7,22,0)
+
     // Support use of .netrc - default enabled.
     const char *pszHttpNetrc = CSLFetchNameValue( papszOptions, "NETRC" );
     if( pszHttpNetrc == nullptr )

--- a/gdal/port/cpl_http.cpp
+++ b/gdal/port/cpl_http.cpp
@@ -914,6 +914,8 @@ int CPLHTTPPopFetchCallback(void)
  *     (GDAL >= 2.2)</li>
  * <li>HTTPAUTH=[BASIC/NTLM/GSSNEGOTIATE/ANY] to specify an authentication scheme to use.</li>
  * <li>USERPWD=userid:password to specify a user and password for authentication</li>
+ * <li>GSSAPI_DELEGATION=[NONE/POLICY/ALWAYS] set allowed GSS-API delegation.
+ *     Relevant only with HTTPAUTH=GSSNEGOTIATE (GDAL >= 3.3).</li>
  * <li>POSTFIELDS=val, where val is a nul-terminated string to be passed to the server
  *                     with a POST request.</li>
  * <li>PROXY=val, to make requests go through a proxy server, where val is of the
@@ -964,14 +966,15 @@ int CPLHTTPPopFetchCallback(void)
  * Alternatively, if not defined in the papszOptions arguments, the
  * CONNECTTIMEOUT, TIMEOUT,
  * LOW_SPEED_TIME, LOW_SPEED_LIMIT, USERPWD, PROXY, HTTPS_PROXY, PROXYUSERPWD, PROXYAUTH, NETRC,
- * MAX_RETRY and RETRY_DELAY, HEADER_FILE, HTTP_VERSION, SSL_VERIFYSTATUS, USE_CAPI_STORE
+ * MAX_RETRY and RETRY_DELAY, HEADER_FILE, HTTP_VERSION, SSL_VERIFYSTATUS, USE_CAPI_STORE,
+ * GSSAPI_DELEGATION
  * values are searched in the configuration
  * options respectively named GDAL_HTTP_CONNECTTIMEOUT, GDAL_HTTP_TIMEOUT,
  * GDAL_HTTP_LOW_SPEED_TIME, GDAL_HTTP_LOW_SPEED_LIMIT, GDAL_HTTP_USERPWD,
  * GDAL_HTTP_PROXY, GDAL_HTTPS_PROXY, GDAL_HTTP_PROXYUSERPWD, GDAL_PROXY_AUTH,
  * GDAL_HTTP_NETRC, GDAL_HTTP_MAX_RETRY, GDAL_HTTP_RETRY_DELAY,
  * GDAL_HTTP_HEADER_FILE, GDAL_HTTP_VERSION, GDAL_HTTP_SSL_VERIFYSTATUS,
- * GDAL_HTTP_USE_CAPI_STORE
+ * GDAL_HTTP_USE_CAPI_STORE, GDAL_GSSAPI_DELEGATION
  *
  * @return a CPLHTTPResult* structure that must be freed by
  * CPLHTTPDestroyResult(), or NULL if libcurl support is disabled

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -574,9 +574,9 @@ void VSICURLInitWriteFuncStruct( WriteFuncStruct   *psStruct,
     psStruct->pReadCbkUserData = pReadCbkUserData;
     psStruct->bInterrupted = false;
 
-#if LIBCURL_VERSION_NUM < 0x073600
+#if !CURL_AT_LEAST_VERSION(7,54,0)
     psStruct->bIsProxyConnectHeader = false;
-#endif
+#endif //!CURL_AT_LEAST_VERSION(7,54,0)
 }
 
 /************************************************************************/
@@ -606,7 +606,7 @@ size_t VSICurlHandleWriteFunc( void *buffer, size_t count,
                 {
                     psStruct->nHTTPCode = atoi(pszSpace + 1);
 
-#if LIBCURL_VERSION_NUM < 0x073600
+#if !CURL_AT_LEAST_VERSION(7,54,0)
                     // Workaround to ignore extra HTTP response headers from
                     // proxies in older versions of curl.
                     // CURLOPT_SUPPRESS_CONNECT_HEADERS fixes this
@@ -624,7 +624,7 @@ size_t VSICurlHandleWriteFunc( void *buffer, size_t count,
                             psStruct->bIsProxyConnectHeader = true;
                         }
                     }
-#endif
+#endif //!CURL_AT_LEAST_VERSION(7,54,0)
                 }
             }
             else if( STARTS_WITH_CI(pszLine, "Content-Length: ") )
@@ -676,12 +676,12 @@ size_t VSICurlHandleWriteFunc( void *buffer, size_t count,
                           psStruct->nHTTPCode == 302) )
                         return 0;
                 }
-#if LIBCURL_VERSION_NUM < 0x073600
+#if !CURL_AT_LEAST_VERSION(7,54,0)
                 else if( psStruct->bIsProxyConnectHeader )
                 {
                     psStruct->bIsProxyConnectHeader = false;
                 }
-#endif
+#endif //!CURL_AT_LEAST_VERSION(7,54,0)
                 else
                 {
                     psStruct->bIsInHeader = false;
@@ -3795,12 +3795,7 @@ char** VSICurlFilesystemHandler::GetFileList(const char *pszDirname,
             // work, then try again with CURLOPT_DIRLISTONLY set.
             if( iTry == 1 )
             {
-// 7.16.4
-#if LIBCURL_VERSION_NUM <= 0x071004
-                curl_easy_setopt(hCurlHandle, CURLOPT_FTPLISTONLY, 1);
-#elif LIBCURL_VERSION_NUM > 0x071004
                 curl_easy_setopt(hCurlHandle, CURLOPT_DIRLISTONLY, 1);
-#endif
             }
 
             VSICURLInitWriteFuncStruct(&sWriteFuncData, nullptr, nullptr, nullptr);
@@ -4836,18 +4831,12 @@ struct curl_slist* VSICurlSetOptions(
     struct curl_slist* headers = static_cast<struct curl_slist*>(
         CPLHTTPSetOptions(hCurlHandle, pszURL, papszOptions));
 
-// 7.16
-#if LIBCURL_VERSION_NUM >= 0x071000
     long option = CURLFTPMETHOD_SINGLECWD;
     curl_easy_setopt(hCurlHandle, CURLOPT_FTP_FILEMETHOD, option);
-#endif
 
-// 7.12.3
-#if LIBCURL_VERSION_NUM > 0x070C03
     // ftp://ftp2.cits.rncan.gc.ca/pub/cantopo/250k_tif/
     // doesn't like EPSV command,
     curl_easy_setopt(hCurlHandle, CURLOPT_FTP_USE_EPSV, 0);
-#endif
 
     return headers;
 }

--- a/gdal/port/cpl_vsil_curl_class.h
+++ b/gdal/port/cpl_vsil_curl_class.h
@@ -39,7 +39,7 @@
 #include "cpl_vsil_curl_priv.h"
 #include "cpl_mem_cache.h"
 
-#include <curl/curl.h>
+#include "cpl_curl_priv.h"
 
 #include <set>
 #include <map>
@@ -48,10 +48,8 @@
 
 //! @cond Doxygen_Suppress
 
-// 7.18.1
-#if LIBCURL_VERSION_NUM >= 0x071201
+// Leave it for backward compatibility, but deprecate.
 #define HAVE_CURLINFO_REDIRECT_URL
-#endif
 
 void VSICurlStreamingClearCache( void ); // from cpl_vsil_curl_streaming.cpp
 
@@ -121,12 +119,12 @@ struct WriteFuncStruct
     void               *pReadCbkUserData = nullptr;
     bool                bInterrupted = false;
 
-#if LIBCURL_VERSION_NUM < 0x073600
+#if !CURL_AT_LEAST_VERSION(7,54,0)
     // Workaround to ignore extra HTTP response headers from
     // proxies in older versions of curl.
     // CURLOPT_SUPPRESS_CONNECT_HEADERS fixes this
     bool            bIsProxyConnectHeader = false;
-#endif
+#endif //!CURL_AT_LEAST_VERSION(7,54,0)
 };
 
 struct PutData


### PR DESCRIPTION
Delegation type can be set using CPLHTTPSetOptions option 'GSSAPI_DELEGATION'
or CPLGetConfigOption option 'GDAL_GSSAPI_DELEGATION'

See: https://curl.se/libcurl/c/CURLOPT_GSSAPI_DELEGATION.html