### PR TITLE
Python bindings: improvements in [Read|Write][Raster|Array] methods

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -407,29 +407,29 @@ def test_basic_test_14():
 
     with pytest.raises(Exception):
         ds.SetMetadata(5)
-    
+
 
     ds.SetMetadata(['foo=bar'])
     assert ds.GetMetadata_List() == ['foo=bar']
 
     with pytest.raises(Exception):
         ds.SetMetadata([5])
-    
+
 
     ds.SetMetadata({'foo': 'baz'})
     assert ds.GetMetadata_List() == ['foo=baz']
 
     with pytest.raises(Exception):
         ds.SetMetadata({'foo': 5})
-    
+
 
     with pytest.raises(Exception):
         ds.SetMetadata({5: 'baz'})
-    
+
 
     with pytest.raises(Exception):
         ds.SetMetadata({5: 6})
-    
+
 
     val = '\u00e9ven'
 
@@ -441,13 +441,13 @@ def test_basic_test_14():
 
     with pytest.raises(Exception):
         ds.SetMetadata({val: 5})
-    
+
 
     with pytest.raises(Exception):
         ds.SetMetadata({5: val})
-    
 
-    
+
+
 ###############################################################################
 # Test errors with progress callback
 
@@ -587,3 +587,13 @@ def test_gdal_setgcpspatialref():
     assert sr_got
     assert sr_got.IsSame(sr)
 
+
+def test_gdal_getdatatypename():
+
+    assert gdal.GetDataTypeName(gdal.GDT_Byte) == 'Byte'
+    with pytest.raises(Exception):
+        gdal.GetDataTypeName(-1)
+    with pytest.raises(Exception):
+        gdal.GetDataTypeName(100)
+    with pytest.raises(Exception):
+        gdal.GetDataTypeName('invalid')

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -720,6 +720,11 @@ def test_numpy_rw_dataset_writearray():
     assert ds.WriteArray(ar) == 0
     assert numpy.array_equal(ds.ReadAsArray(), ar)
 
+    # Use WriteRaster interface
+    ds = gdal.GetDriverByName('MEM').Create('', 3, 2)
+    assert ds.WriteRaster(0, 0, ds.RasterXSize, ds.RasterYSize, ar.astype(numpy.uint32)) == 0
+    assert numpy.array_equal(ds.ReadAsArray(), ar)
+
     with pytest.raises(Exception):
         ds.WriteArray(None)
 
@@ -763,6 +768,11 @@ def test_numpy_rw_dataset_writearray():
     # band_list
     ds = gdal.GetDriverByName('MEM').Create('', 3, 2, 2)
     assert ds.WriteArray(ar[::-1,...], band_list=[2,1]) == 0
+    assert numpy.array_equal(ds.ReadAsArray(), ar)
+
+    # Use WriteRaster interface
+    ds = gdal.GetDriverByName('MEM').Create('', 3, 2, 2)
+    assert ds.WriteRaster(0, 0, ds.RasterXSize, ds.RasterYSize, ar.astype(numpy.uint32)) == 0
     assert numpy.array_equal(ds.ReadAsArray(), ar)
 
     # 2D array

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -670,10 +670,6 @@ def test_numpy_rw_gdal_array_openarray_permissions():
         assert ds.GetRasterBand(1).ReadAsArray(buf_obj = ar) is None
 
 
-def test_numpy_rw_cleanup():
-    gdaltest.numpy_drv = None
-
-
 ###############################################################################
 # Test ReadAsArray RMS subsampling.
 

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -689,3 +689,19 @@ def test_numpy_rw_rms_resemple_alg():
     assert cs == exp_cs, 'got wrong rms sum'
 
 
+
+###############################################################################
+# Test Dataset.ReadAsArray() with band_list
+
+def test_numpy_rw_dataset_read_as_array():
+
+    wrk_ds = gdal.Open('../gdrivers/data/rgbsmall.tif')
+
+    assert numpy.array_equal(wrk_ds.ReadAsArray(band_list=[2]),
+                             wrk_ds.GetRasterBand(2).ReadAsArray())
+
+    assert numpy.array_equal(wrk_ds.ReadAsArray(band_list=[2,1]),
+                             numpy.stack(
+                                 [wrk_ds.GetRasterBand(2).ReadAsArray(),
+                                  wrk_ds.GetRasterBand(1).ReadAsArray()]))
+

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -790,3 +790,23 @@ def test_numpy_rw_dataset_writearray():
     # Too big 3D array in band dimension
     with pytest.raises(Exception):
         ds.WriteArray(numpy.array([[[0,1,2],[3,4,5]],[[10,11,12],[13,14,15]],[[10,11,12],[13,14,15]]]))
+
+
+###############################################################################
+# Test Band.ReadAsArray() error cases
+
+
+def test_numpy_rw_band_read_as_array_error_cases():
+
+    ds = gdal.GetDriverByName('MEM').Create('', 3, 2)
+    band = ds.GetRasterBand(1)
+    assert band.ReadAsArray(buf_obj = numpy.empty((3,2), dtype=numpy.uint8)) is not None
+    assert band.ReadAsArray(buf_obj = numpy.empty((1, 3,2), dtype=numpy.uint8)) is not None
+
+    # 1D
+    with pytest.raises(Exception, match='expected array of dimension 2 or 3'):
+        band.ReadAsArray(buf_obj = numpy.empty((3,), dtype=numpy.uint8))
+
+    # 3D of wrong size in first dimension
+    with pytest.raises(Exception, match='expected size of first dimension should be 0'):
+        band.ReadAsArray(buf_obj = numpy.empty((2, 3,2), dtype=numpy.uint8))

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -664,6 +664,11 @@ def test_numpy_rw_gdal_array_openarray_permissions():
         assert ds.GetRasterBand(1).Fill(1) != 0
     assert ds.GetRasterBand(1).Checksum()  == 0
 
+    # Cannot read in non-writeable array
+    with gdaltest.error_handler():
+        assert ds.ReadAsArray(buf_obj = ar) is None
+        assert ds.GetRasterBand(1).ReadAsArray(buf_obj = ar) is None
+
 
 def test_numpy_rw_cleanup():
     gdaltest.numpy_drv = None

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -1307,3 +1307,14 @@ def test_rasterio_writeraster_from_bytearray():
     ar = bytearray([1, 2])
     ds.WriteRaster(0, 0, 1, 2, ar)
     assert ds.ReadRaster() == ar
+
+###############################################################################
+# Test WriteRaster() on a memoryview
+
+
+def test_rasterio_writeraster_from_memoryview():
+
+    ds = gdal.GetDriverByName('MEM').Create('', 1, 2)
+    ar = memoryview(bytearray([1, 2, 3]))[1:]
+    ds.WriteRaster(0, 0, 1, 2, ar)
+    assert ds.ReadRaster() == ar

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -1296,3 +1296,14 @@ def test_rasterio_rms_halfsize_downsampling_cfloat32():
     ds.BuildOverviews('RMS', [2])
     ovr_data = ds.GetRasterBand(1).GetOverview(0).ReadRaster()
     assert ovr_data == data
+
+###############################################################################
+# Test WriteRaster() on a bytearray
+
+
+def test_rasterio_writeraster_from_bytearray():
+
+    ds = gdal.GetDriverByName('MEM').Create('', 1, 2)
+    ar = bytearray([1, 2])
+    ds.WriteRaster(0, 0, 1, 2, ar)
+    assert ds.ReadRaster() == ar

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -991,7 +991,7 @@ def test_rasterio_dataset_write_on_readonly():
     assert err != 0
 
 
-@pytest.mark.parametrize('resample_alg', [-1, 8])
+@pytest.mark.parametrize('resample_alg', [-1, 8, "foo"])
 def test_rasterio_dataset_invalid_resample_alg(resample_alg):
 
     mem_ds = gdal.GetDriverByName('MEM').Create('', 2, 2)

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -1318,3 +1318,108 @@ def test_rasterio_writeraster_from_memoryview():
     ar = memoryview(bytearray([1, 2, 3]))[1:]
     ds.WriteRaster(0, 0, 1, 2, ar)
     assert ds.ReadRaster() == ar
+
+###############################################################################
+# Test ReadRaster() in an existing buffer
+
+
+def test_rasterio_readraster_in_existing_buffer():
+
+    ds = gdal.GetDriverByName('MEM').Create('', 2, 1)
+    ar = bytearray([1, 2])
+    ds.WriteRaster(0, 0, 2, 1, ar)
+    band = ds.GetRasterBand(1)
+
+    # buf_obj is of expected size
+    assert ds.ReadRaster(buf_obj = bytearray([0, 0])) == ar
+    # buf_obj is larger than expected
+    assert ds.ReadRaster(buf_obj = bytearray([0, 0, 10])) == bytearray([1, 2, 10])
+    with gdaltest.error_handler():
+        # buf_obj is a wrong object type
+        assert ds.ReadRaster(buf_obj = 123) is None
+        # buf_obj is not large enough
+        assert ds.ReadRaster(buf_obj = bytearray([0])) is None
+        # buf_obj is read-only
+        assert ds.ReadRaster(buf_obj = bytes(bytearray([0, 0]))) is None
+
+
+    # buf_obj is of expected size
+    assert band.ReadRaster(buf_obj = bytearray([0, 0])) == ar
+    # buf_obj is larger than expected
+    assert band.ReadRaster(buf_obj = bytearray([0, 0, 10])) == bytearray([1, 2, 10])
+    with gdaltest.error_handler():
+        # buf_obj is a wrong object type
+        assert band.ReadRaster(buf_obj = 123) is None
+        # buf_obj is not large enough
+        assert band.ReadRaster(buf_obj = bytearray([0])) is None
+        # buf_obj is read-only
+        assert band.ReadRaster(buf_obj = bytes(bytearray([0, 0]))) is None
+
+###############################################################################
+# Test ReadBlock() in an existing buffer
+
+
+def test_rasterio_readblock_in_existing_buffer():
+
+    ds = gdal.GetDriverByName('MEM').Create('', 2, 1)
+    ar = bytearray([1, 2])
+    ds.WriteRaster(0, 0, 2, 1, ar)
+    band = ds.GetRasterBand(1)
+
+    assert band.ReadBlock(0, 0) == ar
+
+    # buf_obj is of expected size
+    assert band.ReadBlock(0, 0, buf_obj = bytearray([0, 0])) == ar
+    # buf_obj is larger than expected
+    assert band.ReadBlock(0, 0, buf_obj = bytearray([0, 0, 10])) == bytearray([1, 2, 10])
+    with gdaltest.error_handler():
+        # buf_obj is a wrong object type
+        assert band.ReadBlock(0, 0, buf_obj = 123) is None
+        # buf_obj is not large enough
+        assert band.ReadBlock(0, 0, buf_obj = bytearray([0])) is None
+        # buf_obj is read-only
+        assert band.ReadBlock(0, 0, buf_obj = bytes(bytearray([0, 0]))) is None
+
+###############################################################################
+# Test ReadRaster() in an existing buffer and alignment issues
+
+
+@pytest.mark.parametrize('datatype', [gdal.GDT_Int16,
+                                      gdal.GDT_UInt16,
+                                      gdal.GDT_Int32,
+                                      gdal.GDT_UInt32,
+                                      gdal.GDT_Float32,
+                                      gdal.GDT_Float64,
+                                      gdal.GDT_CInt16,
+                                      gdal.GDT_CInt32,
+                                      gdal.GDT_CFloat32,
+                                      gdal.GDT_CFloat64],
+                          ids=gdal.GetDataTypeName)
+def test_rasterio_readraster_in_existing_buffer_alignment_issues(datatype):
+
+    ds = gdal.GetDriverByName('MEM').Create('', 2, 1, 1, datatype)
+    band = ds.GetRasterBand(1)
+    band.Fill(1)
+    ar = band.ReadRaster()
+    buffer_size = 2 * 1 * (gdal.GetDataTypeSize(datatype) // 8)
+
+    # buf_obj has appropriate alignment
+    assert ds.ReadRaster(buf_obj = bytearray([0] * buffer_size)) == ar
+
+    with gdaltest.error_handler():
+        # buf_obj has not appropriate alignment
+        assert ds.ReadRaster(buf_obj = memoryview(bytearray([0] * (buffer_size + 1)))[1:]) is None
+
+    # buf_obj has appropriate alignment
+    assert band.ReadRaster(buf_obj = bytearray([0] * buffer_size)) == ar
+
+    with gdaltest.error_handler():
+        # buf_obj has not appropriate alignment
+        assert band.ReadRaster(buf_obj = memoryview(bytearray([0] * (buffer_size + 1)))[1:]) is None
+
+    # buf_obj has appropriate alignment
+    assert band.ReadBlock(0, 0, buf_obj = bytearray([0] * buffer_size)) == ar
+
+    with gdaltest.error_handler():
+        # buf_obj has not appropriate alignment
+        assert band.ReadBlock(0, 0, buf_obj = memoryview(bytearray([0] * (2 * 8 + 1)))[1:]) is None

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -78,7 +78,7 @@ def tiff_ovr_check(src_ds):
         if ovr_band.Checksum() != 328:
             msg = 'overview wrong checksum: band %d, overview 1, checksum = %d,' % (i, ovr_band.Checksum())
             pytest.fail(msg)
-    
+
 ###############################################################################
 # Create a 3 band floating point GeoTIFF file so we can build overviews on it
 # later.  Build overviews on it.
@@ -183,17 +183,7 @@ def test_tiff_ovr_4(both_endian):
     ovimage = ovband.ReadRaster(0, 0, ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    total = 0.0
-    is_bytes = False
-    if (isinstance(ovimage, bytes) and not isinstance(ovimage, str)):
-        is_bytes = True
-
-    if is_bytes is True:
-        for i in range(pix_count):
-            total += ovimage[i]
-    else:
-        for i in range(pix_count):
-            total += ord(ovimage[i])
+    total = float(sum(ovimage))
 
     average = total / pix_count
     exp_average = 154.0992
@@ -207,13 +197,7 @@ def test_tiff_ovr_4(both_endian):
                                 ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    total = 0.0
-    if is_bytes is True:
-        for i in range(pix_count):
-            total += ovimage[i]
-    else:
-        for i in range(pix_count):
-            total += ord(ovimage[i])
+    total = float(sum(ovimage))
     average = total / pix_count
     exp_average = 0.6096
 
@@ -1247,7 +1231,7 @@ def test_tiff_ovr_39(both_endian):
         assert cs == expected_cs, \
             ('did not get expected checksum for datatype %s' % gdal.GetDataTypeName(datatype))
 
-    
+
 ###############################################################################
 # Test external overviews on 1 bit datasets with AVERAGE_BIT2GRAYSCALE (similar to tiff_ovr_4)
 
@@ -1274,18 +1258,7 @@ def test_tiff_ovr_40(both_endian):
     ovimage = ovband.ReadRaster(0, 0, ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    total = 0.0
-    is_bytes = False
-    if (isinstance(ovimage, bytes) and not isinstance(ovimage, str)):
-        is_bytes = True
-
-    if is_bytes is True:
-        for i in range(pix_count):
-            total += ovimage[i]
-    else:
-        for i in range(pix_count):
-            total += ord(ovimage[i])
-
+    total = float(sum(ovimage))
     average = total / pix_count
     exp_average = 154.0992
     assert average == pytest.approx(exp_average, abs=0.1), 'got wrong average for overview image'
@@ -1298,13 +1271,7 @@ def test_tiff_ovr_40(both_endian):
                                 ovband.XSize, ovband.YSize)
 
     pix_count = ovband.XSize * ovband.YSize
-    total = 0.0
-    if is_bytes is True:
-        for i in range(pix_count):
-            total += ovimage[i]
-    else:
-        for i in range(pix_count):
-            total += ord(ovimage[i])
+    total = float(sum(ovimage))
     average = total / pix_count
     exp_average = 0.6096
 
@@ -1601,7 +1568,7 @@ def test_tiff_ovr_48(both_endian):
         cs = ds.GetRasterBand(i + 1).Checksum()
         assert cs == 0, i
 
-    
+
 ###############################################################################
 # Test possible stride computation issue in GDALRegenerateOverviewsMultiBand (#5653)
 

--- a/autotest/gdrivers/mrsid.py
+++ b/autotest/gdrivers/mrsid.py
@@ -144,7 +144,7 @@ def test_mrsid_1():
     if got_prj != prj:
         print('Warning: did not get exactly expected projection. Got %s' % got_prj)
 
-    
+
 ###############################################################################
 # Do a direct IO to read the image at a resolution for which there is no
 # builtin overview.  Checks for the bug Steve L found in the optimized
@@ -162,16 +162,7 @@ def test_mrsid_2():
 
     ds = None
 
-    is_bytes = False
-    if (isinstance(data, bytes) and not isinstance(data, str)):
-        is_bytes = True
-
-    # check that we got roughly the right values by checking mean.
-    if is_bytes is True:
-        total = sum(data)
-    else:
-        total = sum([ord(c) for c in data])
-
+    total = sum(data)
     mean = float(total) / len(data)
 
     assert mean >= 95 and mean <= 105, 'image mean out of range.'
@@ -199,7 +190,7 @@ def test_mrsid_3():
             print('new = ', new_stat)
             pytest.fail('Statistics differ.')
 
-    
+
 ###############################################################################
 # Check a new (V3) file which uses a different form for coordinate sys.
 
@@ -478,7 +469,7 @@ def test_mrsid_online_3():
         gdaltest.compare_ds(ds, ds_ref, verbose=1)
         pytest.fail('Image too different from reference')
 
-    
+
 ###############################################################################
 
 

--- a/gdal/swig/include/Band.i
+++ b/gdal/swig/include/Band.i
@@ -391,18 +391,23 @@ public:
 %apply (GIntBig nLen, char *pBuf) { (GIntBig buf_len, char *buf_string) };
 %apply (GIntBig *optional_GIntBig) { (GIntBig*) };
 %apply ( int *optional_int ) {(int*)};
+#if defined(SWIGPYTHON)
+%apply (GDALDataType *optional_GDALDataType) { (GDALDataType *buf_type) };
+#else
+%apply (int *optional_int) { (GDALDataType *buf_type) };
+#endif
 %feature( "kwargs" ) WriteRaster;
   CPLErr WriteRaster( int xoff, int yoff, int xsize, int ysize,
                       GIntBig buf_len, char *buf_string,
                       int *buf_xsize = 0,
                       int *buf_ysize = 0,
-                      int *buf_type = 0,
+                      GDALDataType *buf_type = 0,
                       GIntBig *buf_pixel_space = 0,
                       GIntBig *buf_line_space = 0) {
     int nxsize = (buf_xsize==0) ? xsize : *buf_xsize;
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
-                                        : (GDALDataType)*buf_type;
+                                        : *buf_type;
     GIntBig pixel_space = (buf_pixel_space == 0) ? 0 : *buf_pixel_space;
     GIntBig line_space = (buf_line_space == 0) ? 0 : *buf_line_space;
     GDALRasterIOExtraArg* psExtraArg = NULL;
@@ -410,6 +415,7 @@ public:
                                  nxsize, nysize, ntype, buf_len, buf_string, pixel_space, line_space, psExtraArg );
   }
 %clear (GIntBig buf_len, char *buf_string);
+%clear (GDALDataType *buf_type);
 %clear (int*);
 %clear (GIntBig*);
 #endif

--- a/gdal/swig/include/Dataset.i
+++ b/gdal/swig/include/Dataset.i
@@ -513,7 +513,11 @@ public:
 %apply (GIntBig nLen, char *pBuf) { (GIntBig buf_len, char *buf_string) };
 %apply (GIntBig *optional_GIntBig) { (GIntBig*) };
 %apply (int *optional_int) { (int*) };
+#if defined(SWIGPYTHON)
+%apply (GDALDataType *optional_GDALDataType) { (GDALDataType *buf_type) };
+#else
 %apply (int *optional_int) { (GDALDataType *buf_type) };
+#endif
 %apply (int nList, int *pList ) { (int band_list, int *pband_list ) };
   CPLErr WriteRaster( int xoff, int yoff, int xsize, int ysize,
                       GIntBig buf_len, char *buf_string,

--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -487,12 +487,12 @@ GByte *CPLHexToBinary( const char *pszHex, int *pnBytes );
 
 #if defined(SWIGPYTHON)
 
-%apply (GIntBig nLen, char *pBuf) {( GIntBig nBytes, const GByte *pabyData )};
+%apply (GIntBig nLen, char *pBuf) {( GIntBig nBytes, const char *pabyData )};
 %inline {
-void wrapper_VSIFileFromMemBuffer( const char* utf8_path, GIntBig nBytes, const GByte *pabyData)
+void wrapper_VSIFileFromMemBuffer( const char* utf8_path, GIntBig nBytes, const char *pabyData)
 {
     const size_t nSize = static_cast<size_t>(nBytes);
-    GByte* pabyDataDup = (GByte*)VSIMalloc(nSize);
+    void* pabyDataDup = VSIMalloc(nSize);
     if (pabyDataDup == NULL)
             return;
     memcpy(pabyDataDup, pabyData, nSize);

--- a/gdal/swig/include/gdal.i
+++ b/gdal/swig/include/gdal.i
@@ -258,21 +258,6 @@ typedef enum {
 %include "gdal_typemaps.i"
 #endif
 
-%typemap(check) GDALRIOResampleAlg
-{
-    // %typemap(check) GDALRIOResampleAlg
-    // This check is a bit too late, since $1 has already been cast
-    // to GDALRIOResampleAlg, so we are a bit in undefined behavior land,
-    // but compilers should hopefully do the right thing
-    if( static_cast<int>($1) < 0 ||
-        ( static_cast<int>($1) >= static_cast<int>(GRIORA_RESERVED_START) &&
-          static_cast<int>($1) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-        static_cast<int>($1) > static_cast<int>(GRIORA_LAST) )
-    {
-        SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
-    }
-}
-
 /* Default memberin typemaps required to support SWIG 1.3.39 and above */
 %typemap(memberin) char *Info %{
 /* char* Info memberin typemap */

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1625,10 +1625,15 @@ def BandReadAsArray(band, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
         buf_obj = numpy.empty([buf_ysize, buf_xsize], dtype=typecode)
 
     else:
+        if len(buf_obj.shape) not in (2, 3):
+            raise ValueError("expected array of dimension 2 or 3")
+
         if len(buf_obj.shape) == 2:
             shape_buf_xsize = buf_obj.shape[1]
             shape_buf_ysize = buf_obj.shape[0]
         else:
+            if buf_obj.shape[0] != 1:
+                raise ValueError("expected size of first dimension should be 0")
             shape_buf_xsize = buf_obj.shape[2]
             shape_buf_ysize = buf_obj.shape[1]
         if buf_xsize is not None and buf_xsize != shape_buf_xsize:

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -736,6 +736,13 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
         return CE_Failure;
     }
 
+    if( !bWrite && !(PyArray_FLAGS(psArray) & NPY_ARRAY_WRITEABLE) )
+    {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "Cannot read in a non-writeable array." );
+        return CE_Failure;
+    }
+
     int xdim = ( PyArray_NDIM(psArray) == 2) ? 1 : 2;
     int ydim = ( PyArray_NDIM(psArray) == 2) ? 0 : 1;
 
@@ -795,6 +802,13 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
         CPLError( CE_Failure, CPLE_AppDefined,
                   "Illegal numpy array rank %d.",
                   PyArray_NDIM(psArray) );
+        return CE_Failure;
+    }
+
+    if( !bWrite && !(PyArray_FLAGS(psArray) & NPY_ARRAY_WRITEABLE) )
+    {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "Cannot read in a non-writeable array." );
         return CE_Failure;
     }
 

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -63,21 +63,6 @@
 typedef int CPLErr;
 typedef int GDALRIOResampleAlg;
 
-%typemap(check) GDALRIOResampleAlg
-{
-    // %typemap(check) GDALRIOResampleAlg
-    // This check is a bit too late, since $1 has already been cast
-    // to GDALRIOResampleAlg, so we are a bit in undefined behavior land,
-    // but compilers should hopefully do the right thing
-    if( static_cast<int>($1) < 0 ||
-        ( static_cast<int>($1) >= static_cast<int>(GRIORA_RESERVED_START) &&
-          static_cast<int>($1) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-        static_cast<int>($1) > static_cast<int>(GRIORA_LAST) )
-    {
-        SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
-    }
-}
-
 %include "python_strings.i"
 
 %{

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -723,12 +723,11 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 %inline %{
   CPLErr BandRasterIONumPy( GDALRasterBandShadow* band, int bWrite, double xoff, double yoff, double xsize, double ysize,
                             PyArrayObject *psArray,
-                            int buf_type,
+                            GDALDataType buf_type,
                             GDALRIOResampleAlg resample_alg,
                             GDALProgressFunc callback = NULL,
                             void* callback_data = NULL) {
 
-    GDALDataType ntype  = (GDALDataType)buf_type;
     if( PyArray_NDIM(psArray) < 2 || PyArray_NDIM(psArray) > 3 )
     {
         CPLError( CE_Failure, CPLE_AppDefined,
@@ -775,7 +774,7 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 
     return  GDALRasterIOEx( band, (bWrite) ? GF_Write : GF_Read, nXOff, nYOff, nXSize, nYSize,
                           PyArray_DATA(psArray), nxsize, nysize,
-                          ntype, pixel_space, line_space, &sExtraArg );
+                          buf_type, pixel_space, line_space, &sExtraArg );
   }
 %}
 
@@ -784,14 +783,13 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 %inline %{
   CPLErr DatasetIONumPy( GDALDatasetShadow* ds, int bWrite, double xoff, double yoff, double xsize, double ysize,
                          PyArrayObject *psArray,
-                         int buf_type,
+                         GDALDataType buf_type,
                          GDALRIOResampleAlg resample_alg,
                          GDALProgressFunc callback = NULL,
                          void* callback_data = NULL,
                          bool binterleave = true,
                          int band_list = 0, int *pband_list = 0 )
 {
-    GDALDataType ntype  = (GDALDataType)buf_type;
     if( PyArray_NDIM(psArray) != 3 )
     {
         CPLError( CE_Failure, CPLE_AppDefined,
@@ -850,7 +848,7 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 
     return  GDALDatasetRasterIOEx( ds, (bWrite) ? GF_Write : GF_Read, nXOff, nYOff, nXSize, nYSize,
                                    PyArray_DATA(psArray), nxsize, nysize,
-                                   ntype,
+                                   buf_type,
                                    bandcount, pband_list,
                                    pixel_space, line_space, band_space, &sExtraArg );
   }

--- a/gdal/swig/include/gdal_array.i
+++ b/gdal/swig/include/gdal_array.i
@@ -1523,6 +1523,76 @@ def DatasetReadAsArray(ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_o
 
     return buf_obj
 
+
+def DatasetWriteArray(ds, array, xoff=0, yoff=0,
+                      band_list=None,
+                      interleave='band',
+                      resample_alg=gdal.GRIORA_NearestNeighbour,
+                      callback=None, callback_data=None):
+    """Pure python implementation of writing a chunk of a GDAL file
+    from a numpy array.  Used by the gdal.Dataset.WriteArray method."""
+
+    if band_list is None:
+        band_list = list(range(1, ds.RasterCount + 1))
+
+    interleave = interleave.lower()
+    if interleave == 'band':
+        interleave = True
+        xdim = 2
+        ydim = 1
+        banddim = 0
+    elif interleave == 'pixel':
+        interleave = False
+        xdim = 1
+        ydim = 0
+        banddim = 2
+    else:
+        raise ValueError('Interleave should be band or pixel')
+
+    if len(band_list) == 1:
+        if array is None or (len(array.shape) != 2 and len(array.shape) != 3):
+            raise ValueError("expected array of dim 2 or 3")
+        if len(array.shape) == 3:
+            if array.shape[banddim] != 1:
+                raise ValueError("expected size of dimension %d should be 1" % banddim)
+            array = array[banddim]
+
+        return BandWriteArray(ds.GetRasterBand(band_list[0]),
+                              array,
+                              xoff=xoff, yoff=yoff, resample_alg=resample_alg,
+                              callback=callback, callback_data=callback_data)
+
+    if array is None or len(array.shape) != 3:
+        raise ValueError("expected array of dim 3")
+
+    xsize = array.shape[xdim]
+    ysize = array.shape[ydim]
+
+    if xsize + xoff > ds.RasterXSize or ysize + yoff > ds.RasterYSize:
+        raise ValueError("array larger than output file, or offset off edge")
+    if array.shape[banddim] != len(band_list):
+        raise ValueError('Dimension %d of array should have size %d to store bands)' % (banddim, len(band_list)))
+
+    datatype = NumericTypeCodeToGDALTypeCode(array.dtype.type)
+
+    # if we receive some odd type, like int64, try casting to a very
+    # generic type we do support (#2285)
+    if not datatype:
+        gdal.Debug('gdal_array', 'force array to float64')
+        array = array.astype(numpy.float64)
+        datatype = NumericTypeCodeToGDALTypeCode(array.dtype.type)
+
+    if not datatype:
+        raise ValueError("array does not have corresponding GDAL data type")
+
+    ret = DatasetIONumPy(ds, 1, xoff, yoff, xsize, ysize,
+                         array, datatype, resample_alg, callback, callback_data,
+                         interleave, band_list)
+    if ret != 0:
+        _RaiseException()
+    return ret
+
+
 def BandReadAsArray(band, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
                     buf_xsize=None, buf_ysize=None, buf_type=None, buf_obj=None,
                     resample_alg=gdal.GRIORA_NearestNeighbour,

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -392,17 +392,6 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
 
     *buf = NULL;
 
-    // This check is a bit too late. resample_alg should already have been
-    // validated, so we are a bit in undefined behavior land, but compilers
-    // should hopefully do the right thing
-    if( static_cast<int>(resample_alg) < 0 ||
-        ( static_cast<int>(resample_alg) >= static_cast<int>(GRIORA_RESERVED_START) &&
-          static_cast<int>(resample_alg) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
-    {
-        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
-        return CE_Failure;
-    }
     int nxsize = (buf_xsize==0) ? static_cast<int>(xsize) : *buf_xsize;
     int nysize = (buf_ysize==0) ? static_cast<int>(ysize) : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
@@ -651,17 +640,6 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
 {
     *buf = NULL;
 
-    // This check is a bit too late. resample_alg should already have been
-    // validated, so we are a bit in undefined behavior land, but compilers
-    // should hopefully do the right thing
-    if( static_cast<int>(resample_alg) < 0 ||
-        ( static_cast<int>(resample_alg) >= static_cast<int>(GRIORA_RESERVED_START) &&
-          static_cast<int>(resample_alg) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
-    {
-        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
-        return CE_Failure;
-    }
     int nxsize = (buf_xsize==0) ? xsize : *buf_xsize;
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype;

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -653,7 +653,8 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
                     resample_alg=gdalconst.GRIORA_NearestNeighbour,
                     callback=None,
                     callback_data=None,
-                    interleave='band'):
+                    interleave='band',
+                    band_list=None):
         """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
         parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
@@ -663,7 +664,8 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
                                               resample_alg=resample_alg,
                                               callback=callback,
                                               callback_data=callback_data,
-                                              interleave=interleave )
+                                              interleave=interleave,
+                                              band_list=band_list)
 
     def WriteRaster(self, xoff, yoff, xsize, ysize,
                     buf_string,

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -757,6 +757,21 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
                                               interleave=interleave,
                                               band_list=band_list)
 
+    def WriteArray(self, array, xoff=0, yoff=0,
+                   band_list=None,
+                   interleave='band',
+                   resample_alg=gdalconst.GRIORA_NearestNeighbour,
+                   callback=None,
+                   callback_data=None):
+        from osgeo import gdal_array
+
+        return gdal_array.DatasetWriteArray(self, array, xoff, yoff,
+                                            band_list=band_list,
+                                            interleave=interleave,
+                                            resample_alg=resample_alg,
+                                            callback=callback,
+                                            callback_data=callback_data)
+
     def WriteRaster(self, xoff, yoff, xsize, ysize,
                     buf_string,
                     buf_xsize=None, buf_ysize=None, buf_type=None,

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -376,13 +376,14 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
 %apply ( void *inPythonObject ) { (void* inputOutputBuf) };
 %apply ( void **outPythonObject ) { (void **buf ) };
 %apply ( int *optional_int ) {(int*)};
+%apply ( GDALDataType *optional_GDALDataType ) {(GDALDataType*)};
 %apply ( GIntBig *optional_GIntBig ) {(GIntBig*)};
 %feature( "kwargs" ) ReadRaster1;
   CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
                      void **buf,
                      int *buf_xsize = 0,
                      int *buf_ysize = 0,
-                     int *buf_type = 0,
+                     GDALDataType *buf_type = 0,
                      GIntBig *buf_pixel_space = 0,
                      GIntBig *buf_line_space = 0,
                      GDALRIOResampleAlg resample_alg = GRIORA_NearestNeighbour,
@@ -395,7 +396,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
     int nxsize = (buf_xsize==0) ? static_cast<int>(xsize) : *buf_xsize;
     int nysize = (buf_ysize==0) ? static_cast<int>(ysize) : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
-                                        : (GDALDataType)*buf_type;
+                                        : *buf_type;
     GIntBig pixel_space = (buf_pixel_space == 0) ? 0 : *buf_pixel_space;
     GIntBig line_space = (buf_line_space == 0) ? 0 : *buf_line_space;
 
@@ -454,6 +455,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
 %clean (void* inputOutputBuf);
 %clear (int*);
 %clear (GIntBig*);
+%clear (GDALDataType *);
 
 %apply ( void *inPythonObject ) { (void* buf_obj) };
 %apply ( void **outPythonObject ) { (void **buf ) };
@@ -622,7 +624,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
 %extend GDALDatasetShadow {
 %feature("kwargs") ReadRaster1;
 %apply ( void *inPythonObject ) { (void* inputOutputBuf) };
-%apply (int *optional_int) { (GDALDataType *buf_type) };
+%apply ( GDALDataType *optional_GDALDataType ) {(GDALDataType*)};
 %apply (int nList, int *pList ) { (int band_list, int *pband_list ) };
 %apply ( void **outPythonObject ) { (void **buf ) };
 %apply ( int *optional_int ) {(int*)};
@@ -644,7 +646,7 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype;
     if ( buf_type != 0 ) {
-      ntype = (GDALDataType) *buf_type;
+      ntype = *buf_type;
     } else {
       int lastband = GDALGetRasterCount( self ) - 1;
       if (lastband < 0)
@@ -727,7 +729,7 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
     return eErr;
 }
 
-%clear (GDALDataType *buf_type);
+%clear (GDALDataType *);
 %clear (int band_list, int *pband_list );
 %clear (void **buf );
 %clear (void *inputOutputBuf);

--- a/gdal/swig/include/python/typemaps_python.i
+++ b/gdal/swig/include/python/typemaps_python.i
@@ -523,18 +523,9 @@ CreateTupleFromDoubleArray( int *first, unsigned int size ) {
     }
     $1 = (int) safeLen;
   }
-  else if (PyBytes_Check($input))
-  {
-    Py_ssize_t safeLen = 0;
-    PyBytes_AsStringAndSize($input, (char**) &$2, &safeLen);
-    if( safeLen > INT_MAX ) {
-      SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-    }
-    $1 = (int) safeLen;
-  }
   else
   {
-    PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+    PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
     SWIG_fail;
   }
   ok: ;

--- a/gdal/swig/include/python/typemaps_python.i
+++ b/gdal/swig/include/python/typemaps_python.i
@@ -461,6 +461,12 @@ CreateTupleFromDoubleArray( int *first, unsigned int size ) {
   }
 }
 
+%typemap(in) ( void *inPythonObject )
+{
+  /* %typemap(in) ( void *inPythonObject ) */
+  $1 = $input;
+}
+
 /*
  * Typemap for methods such as GetFieldAsBinary()
  */

--- a/gdal/swig/include/python/typemaps_python.i
+++ b/gdal/swig/include/python/typemaps_python.i
@@ -2405,3 +2405,22 @@ OBJECT_LIST_INPUT(GDALEDTComponentHS)
   PyTuple_SetItem( r, 4, PyLong_FromLong($2[0]));
   $result = t_output_helper($result,r);
 }
+
+
+%typemap(in) GDALRIOResampleAlg
+{
+    // %typemap(in) GDALRIOResampleAlg
+    int val = 0;
+    int ecode = SWIG_AsVal_int($input, &val);
+    if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALRIOResampleAlg");
+    }
+    if( val < 0 ||
+        ( val >= static_cast<int>(GRIORA_RESERVED_START) &&
+          val <= static_cast<int>(GRIORA_RESERVED_END) ) ||
+        val > static_cast<int>(GRIORA_LAST) )
+    {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for resample_alg");
+    }
+    $1 = static_cast< GDALRIOResampleAlg >(val);
+}

--- a/gdal/swig/include/python/typemaps_python.i
+++ b/gdal/swig/include/python/typemaps_python.i
@@ -462,11 +462,7 @@ CreateTupleFromDoubleArray( int *first, unsigned int size ) {
 }
 
 /*
- * Typemap for buffers with length <-> PyStrings
- * Used in Band::WriteRaster()
- *
- * This typemap has a typecheck also since the WriteRaster()
- * methods are overloaded.
+ * Typemap for methods such as GetFieldAsBinary()
  */
 %typemap(in,numinputs=0) (int *nLen, char **pBuf ) ( int nLen = 0, char *pBuf = 0 )
 {
@@ -478,7 +474,7 @@ CreateTupleFromDoubleArray( int *first, unsigned int size ) {
 {
   /* %typemap(argout) (int *nLen, char **pBuf ) */
   Py_XDECREF($result);
-  $result = PyBytes_FromStringAndSize( *$2, *$1 );
+  $result = PyByteArray_FromStringAndSize( *$2, *$1 );
 }
 %typemap(freearg) (int *nLen, char **pBuf )
 {

--- a/gdal/swig/include/python/typemaps_python.i
+++ b/gdal/swig/include/python/typemaps_python.i
@@ -572,9 +572,15 @@ CreateTupleFromDoubleArray( int *first, unsigned int size ) {
     PyBytes_AsStringAndSize($input, (char**) &$2, &safeLen);
     $1 = (GIntBig) safeLen;
   }
+  else if (PyByteArray_Check($input))
+  {
+    Py_ssize_t safeLen = PyByteArray_Size($input);
+    $2 = PyByteArray_AsString($input);
+    $1 = (GIntBig) safeLen;
+  }
   else
   {
-    PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+    PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
     SWIG_fail;
   }
 }
@@ -1809,7 +1815,7 @@ DecomposeSequenceOf4DCoordinates( PyObject *seq, int nCount, double *x, double *
 }
 %}
 
-%typemap(in,numinputs=1,fragment="DecomposeSequenceOf4DCoordinates") (int nCount, double *x, double *y, double *z, double *t) (int foundTime = FALSE) 
+%typemap(in,numinputs=1,fragment="DecomposeSequenceOf4DCoordinates") (int nCount, double *x, double *y, double *z, double *t) (int foundTime = FALSE)
 {
   if ( !PySequence_Check($input) ) {
     PyErr_SetString(PyExc_TypeError, "not a sequence");

--- a/gdal/swig/include/python/typemaps_python.i
+++ b/gdal/swig/include/python/typemaps_python.i
@@ -2424,3 +2424,46 @@ OBJECT_LIST_INPUT(GDALEDTComponentHS)
     }
     $1 = static_cast< GDALRIOResampleAlg >(val);
 }
+
+
+%typemap(in) GDALDataType
+{
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int($input, &val);
+    if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    $1 = static_cast<GDALDataType>(val);
+}
+
+%typemap(in) (GDALDataType *optional_GDALDataType) ( GDALDataType val )
+{
+  /* %typemap(in) (GDALDataType *optional_GDALDataType) */
+  int intval = 0;
+  if ( $input == Py_None ) {
+    $1 = NULL;
+  }
+  else if ( SWIG_IsOK(SWIG_AsVal_int($input, &intval)) ) {
+    if( intval < GDT_Unknown || intval >= GDT_TypeCount )
+    {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    val = static_cast<GDALDataType>(intval);
+    $1 = &val;
+  }
+  else {
+    PyErr_SetString( PyExc_TypeError, "Invalid Parameter" );
+    SWIG_fail;
+  }
+}
+
+%typemap(typecheck,precedence=0) (GDALDataType *optional_GDALDataType)
+{
+  /* %typemap(typecheck,precedence=0) (GDALDataType *optional_GDALDataType) */
+  $1 = (($input==Py_None) || my_PyCheck_int($input)) ? 1 : 0;
+}

--- a/gdal/swig/python/extensions/gdal_array_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_array_wrap.cpp
@@ -4352,6 +4352,13 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
         return CE_Failure;
     }
 
+    if( !bWrite && !(PyArray_FLAGS(psArray) & NPY_ARRAY_WRITEABLE) )
+    {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "Cannot read in a non-writeable array." );
+        return CE_Failure;
+    }
+
     int xdim = ( PyArray_NDIM(psArray) == 2) ? 1 : 2;
     int ydim = ( PyArray_NDIM(psArray) == 2) ? 0 : 1;
 
@@ -4408,6 +4415,13 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
         CPLError( CE_Failure, CPLE_AppDefined,
                   "Illegal numpy array rank %d.",
                   PyArray_NDIM(psArray) );
+        return CE_Failure;
+    }
+
+    if( !bWrite && !(PyArray_FLAGS(psArray) & NPY_ARRAY_WRITEABLE) )
+    {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "Cannot read in a non-writeable array." );
         return CE_Failure;
     }
 

--- a/gdal/swig/python/extensions/gdal_array_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_array_wrap.cpp
@@ -5335,8 +5335,6 @@ SWIGINTERN PyObject *_wrap_BandRasterIONumPy(PyObject *SWIGUNUSEDPARM(self), PyO
   int ecode6 = 0 ;
   int val8 ;
   int ecode8 = 0 ;
-  int val9 ;
-  int ecode9 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -5408,11 +5406,22 @@ SWIGINTERN PyObject *_wrap_BandRasterIONumPy(PyObject *SWIGUNUSEDPARM(self), PyO
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "BandRasterIONumPy" "', argument " "8"" of type '" "int""'");
   } 
   arg8 = static_cast< int >(val8);
-  ecode9 = SWIG_AsVal_int(obj8, &val9);
-  if (!SWIG_IsOK(ecode9)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "BandRasterIONumPy" "', argument " "9"" of type '" "GDALRIOResampleAlg""'");
-  } 
-  arg9 = static_cast< GDALRIOResampleAlg >(val9);
+  {
+    // %typemap(in) GDALRIOResampleAlg
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj8, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALRIOResampleAlg");
+    }
+    if( val < 0 ||
+      ( val >= static_cast<int>(GRIORA_RESERVED_START) &&
+        val <= static_cast<int>(GRIORA_RESERVED_END) ) ||
+      val > static_cast<int>(GRIORA_LAST) )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for resample_alg");
+    }
+    arg9 = static_cast< GDALRIOResampleAlg >(val);
+  }
   if (obj9) {
     {
       /* %typemap(in) (GDALProgressFunc callback = NULL) */
@@ -5455,19 +5464,6 @@ SWIGINTERN PyObject *_wrap_BandRasterIONumPy(PyObject *SWIGUNUSEDPARM(self), PyO
     {
       /* %typemap(in) ( void* callback_data=NULL)  */
       psProgressInfo->psPyCallbackData = obj10 ;
-    }
-  }
-  {
-    // %typemap(check) GDALRIOResampleAlg
-    // This check is a bit too late, since arg9 has already been cast
-    // to GDALRIOResampleAlg, so we are a bit in undefined behavior land,
-    // but compilers should hopefully do the right thing
-    if( static_cast<int>(arg9) < 0 ||
-      ( static_cast<int>(arg9) >= static_cast<int>(GRIORA_RESERVED_START) &&
-        static_cast<int>(arg9) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-      static_cast<int>(arg9) > static_cast<int>(GRIORA_LAST) )
-    {
-      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
     }
   }
   {
@@ -5524,8 +5520,6 @@ SWIGINTERN PyObject *_wrap_DatasetIONumPy(PyObject *SWIGUNUSEDPARM(self), PyObje
   int ecode6 = 0 ;
   int val8 ;
   int ecode8 = 0 ;
-  int val9 ;
-  int ecode9 = 0 ;
   bool val12 ;
   int ecode12 = 0 ;
   PyObject * obj0 = 0 ;
@@ -5601,11 +5595,22 @@ SWIGINTERN PyObject *_wrap_DatasetIONumPy(PyObject *SWIGUNUSEDPARM(self), PyObje
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "DatasetIONumPy" "', argument " "8"" of type '" "int""'");
   } 
   arg8 = static_cast< int >(val8);
-  ecode9 = SWIG_AsVal_int(obj8, &val9);
-  if (!SWIG_IsOK(ecode9)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "DatasetIONumPy" "', argument " "9"" of type '" "GDALRIOResampleAlg""'");
-  } 
-  arg9 = static_cast< GDALRIOResampleAlg >(val9);
+  {
+    // %typemap(in) GDALRIOResampleAlg
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj8, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALRIOResampleAlg");
+    }
+    if( val < 0 ||
+      ( val >= static_cast<int>(GRIORA_RESERVED_START) &&
+        val <= static_cast<int>(GRIORA_RESERVED_END) ) ||
+      val > static_cast<int>(GRIORA_LAST) )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for resample_alg");
+    }
+    arg9 = static_cast< GDALRIOResampleAlg >(val);
+  }
   if (obj9) {
     {
       /* %typemap(in) (GDALProgressFunc callback = NULL) */
@@ -5664,19 +5669,6 @@ SWIGINTERN PyObject *_wrap_DatasetIONumPy(PyObject *SWIGUNUSEDPARM(self), PyObje
       if( arg13 < 0 ) {
         SWIG_fail;
       }
-    }
-  }
-  {
-    // %typemap(check) GDALRIOResampleAlg
-    // This check is a bit too late, since arg9 has already been cast
-    // to GDALRIOResampleAlg, so we are a bit in undefined behavior land,
-    // but compilers should hopefully do the right thing
-    if( static_cast<int>(arg9) < 0 ||
-      ( static_cast<int>(arg9) >= static_cast<int>(GRIORA_RESERVED_START) &&
-        static_cast<int>(arg9) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-      static_cast<int>(arg9) > static_cast<int>(GRIORA_LAST) )
-    {
-      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
     }
   }
   {

--- a/gdal/swig/python/extensions/gdal_array_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_array_wrap.cpp
@@ -4339,12 +4339,11 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 
   CPLErr BandRasterIONumPy( GDALRasterBandShadow* band, int bWrite, double xoff, double yoff, double xsize, double ysize,
                             PyArrayObject *psArray,
-                            int buf_type,
+                            GDALDataType buf_type,
                             GDALRIOResampleAlg resample_alg,
                             GDALProgressFunc callback = NULL,
                             void* callback_data = NULL) {
 
-    GDALDataType ntype  = (GDALDataType)buf_type;
     if( PyArray_NDIM(psArray) < 2 || PyArray_NDIM(psArray) > 3 )
     {
         CPLError( CE_Failure, CPLE_AppDefined,
@@ -4391,20 +4390,19 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 
     return  GDALRasterIOEx( band, (bWrite) ? GF_Write : GF_Read, nXOff, nYOff, nXSize, nYSize,
                           PyArray_DATA(psArray), nxsize, nysize,
-                          ntype, pixel_space, line_space, &sExtraArg );
+                          buf_type, pixel_space, line_space, &sExtraArg );
   }
 
 
   CPLErr DatasetIONumPy( GDALDatasetShadow* ds, int bWrite, double xoff, double yoff, double xsize, double ysize,
                          PyArrayObject *psArray,
-                         int buf_type,
+                         GDALDataType buf_type,
                          GDALRIOResampleAlg resample_alg,
                          GDALProgressFunc callback = NULL,
                          void* callback_data = NULL,
                          bool binterleave = true,
                          int band_list = 0, int *pband_list = 0 )
 {
-    GDALDataType ntype  = (GDALDataType)buf_type;
     if( PyArray_NDIM(psArray) != 3 )
     {
         CPLError( CE_Failure, CPLE_AppDefined,
@@ -4463,7 +4461,7 @@ retStringAndCPLFree* GetArrayFilename(PyArrayObject *psArray)
 
     return  GDALDatasetRasterIOEx( ds, (bWrite) ? GF_Write : GF_Read, nXOff, nYOff, nXSize, nYSize,
                                    PyArray_DATA(psArray), nxsize, nysize,
-                                   ntype,
+                                   buf_type,
                                    bandcount, pband_list,
                                    pixel_space, line_space, band_space, &sExtraArg );
   }
@@ -5317,7 +5315,7 @@ SWIGINTERN PyObject *_wrap_BandRasterIONumPy(PyObject *SWIGUNUSEDPARM(self), PyO
   double arg5 ;
   double arg6 ;
   PyArrayObject *arg7 = (PyArrayObject *) 0 ;
-  int arg8 ;
+  GDALDataType arg8 ;
   GDALRIOResampleAlg arg9 ;
   GDALProgressFunc arg10 = (GDALProgressFunc) NULL ;
   void *arg11 = (void *) NULL ;
@@ -5333,8 +5331,6 @@ SWIGINTERN PyObject *_wrap_BandRasterIONumPy(PyObject *SWIGUNUSEDPARM(self), PyO
   int ecode5 = 0 ;
   double val6 ;
   int ecode6 = 0 ;
-  int val8 ;
-  int ecode8 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -5401,11 +5397,19 @@ SWIGINTERN PyObject *_wrap_BandRasterIONumPy(PyObject *SWIGUNUSEDPARM(self), PyO
       SWIG_fail;
     }
   }
-  ecode8 = SWIG_AsVal_int(obj7, &val8);
-  if (!SWIG_IsOK(ecode8)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "BandRasterIONumPy" "', argument " "8"" of type '" "int""'");
-  } 
-  arg8 = static_cast< int >(val8);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj7, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg8 = static_cast<GDALDataType>(val);
+  }
   {
     // %typemap(in) GDALRIOResampleAlg
     int val = 0;
@@ -5499,7 +5503,7 @@ SWIGINTERN PyObject *_wrap_DatasetIONumPy(PyObject *SWIGUNUSEDPARM(self), PyObje
   double arg5 ;
   double arg6 ;
   PyArrayObject *arg7 = (PyArrayObject *) 0 ;
-  int arg8 ;
+  GDALDataType arg8 ;
   GDALRIOResampleAlg arg9 ;
   GDALProgressFunc arg10 = (GDALProgressFunc) NULL ;
   void *arg11 = (void *) NULL ;
@@ -5518,8 +5522,6 @@ SWIGINTERN PyObject *_wrap_DatasetIONumPy(PyObject *SWIGUNUSEDPARM(self), PyObje
   int ecode5 = 0 ;
   double val6 ;
   int ecode6 = 0 ;
-  int val8 ;
-  int ecode8 = 0 ;
   bool val12 ;
   int ecode12 = 0 ;
   PyObject * obj0 = 0 ;
@@ -5590,11 +5592,19 @@ SWIGINTERN PyObject *_wrap_DatasetIONumPy(PyObject *SWIGUNUSEDPARM(self), PyObje
       SWIG_fail;
     }
   }
-  ecode8 = SWIG_AsVal_int(obj7, &val8);
-  if (!SWIG_IsOK(ecode8)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "DatasetIONumPy" "', argument " "8"" of type '" "int""'");
-  } 
-  arg8 = static_cast< int >(val8);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj7, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg8 = static_cast<GDALDataType>(val);
+  }
   {
     // %typemap(in) GDALRIOResampleAlg
     int val = 0;
@@ -6173,8 +6183,8 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"OpenNumPyArray", _wrap_OpenNumPyArray, METH_VARARGS, (char *)"OpenNumPyArray(PyArrayObject * psArray, bool binterleave) -> Dataset"},
 	 { (char *)"OpenMultiDimensionalNumPyArray", _wrap_OpenMultiDimensionalNumPyArray, METH_VARARGS, (char *)"OpenMultiDimensionalNumPyArray(PyArrayObject * psArray) -> Dataset"},
 	 { (char *)"GetArrayFilename", _wrap_GetArrayFilename, METH_VARARGS, (char *)"GetArrayFilename(PyArrayObject * psArray) -> retStringAndCPLFree *"},
-	 { (char *)"BandRasterIONumPy", (PyCFunction) _wrap_BandRasterIONumPy, METH_VARARGS | METH_KEYWORDS, (char *)"BandRasterIONumPy(Band band, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, int buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None) -> CPLErr"},
-	 { (char *)"DatasetIONumPy", (PyCFunction) _wrap_DatasetIONumPy, METH_VARARGS | METH_KEYWORDS, (char *)"DatasetIONumPy(Dataset ds, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, int buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, bool binterleave=True, int band_list=0) -> CPLErr"},
+	 { (char *)"BandRasterIONumPy", (PyCFunction) _wrap_BandRasterIONumPy, METH_VARARGS | METH_KEYWORDS, (char *)"BandRasterIONumPy(Band band, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, GDALDataType buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None) -> CPLErr"},
+	 { (char *)"DatasetIONumPy", (PyCFunction) _wrap_DatasetIONumPy, METH_VARARGS | METH_KEYWORDS, (char *)"DatasetIONumPy(Dataset ds, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, GDALDataType buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, bool binterleave=True, int band_list=0) -> CPLErr"},
 	 { (char *)"MDArrayIONumPy", _wrap_MDArrayIONumPy, METH_VARARGS, (char *)"MDArrayIONumPy(bool bWrite, GDALMDArrayHS * mdarray, PyArrayObject * psArray, int nDims1, int nDims3, GDALExtendedDataTypeHS * buffer_datatype) -> CPLErr"},
 	 { (char *)"VirtualMemGetArray", _wrap_VirtualMemGetArray, METH_VARARGS, (char *)"VirtualMemGetArray(VirtualMem virtualmem)"},
 	 { (char *)"RATValuesIONumPyWrite", (PyCFunction) _wrap_RATValuesIONumPyWrite, METH_VARARGS | METH_KEYWORDS, (char *)"RATValuesIONumPyWrite(RasterAttributeTable poRAT, int nField, int nStart, PyArrayObject * psArray) -> CPLErr"},

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -5338,7 +5338,7 @@ SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double x
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype;
     if ( buf_type != 0 ) {
-      ntype = (GDALDataType) *buf_type;
+      ntype = *buf_type;
     } else {
       int lastband = GDALGetRasterCount( self ) - 1;
       if (lastband < 0)
@@ -6481,11 +6481,11 @@ SWIGINTERN void GDALRasterBandShadow_ComputeBandStats(GDALRasterBandShadow *self
 SWIGINTERN CPLErr GDALRasterBandShadow_Fill(GDALRasterBandShadow *self,double real_fill,double imag_fill=0.0){
     return GDALFillRaster( self, real_fill, imag_fill );
   }
-SWIGINTERN CPLErr GDALRasterBandShadow_WriteRaster(GDALRasterBandShadow *self,int xoff,int yoff,int xsize,int ysize,GIntBig buf_len,char *buf_string,int *buf_xsize=0,int *buf_ysize=0,int *buf_type=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0){
+SWIGINTERN CPLErr GDALRasterBandShadow_WriteRaster(GDALRasterBandShadow *self,int xoff,int yoff,int xsize,int ysize,GIntBig buf_len,char *buf_string,int *buf_xsize=0,int *buf_ysize=0,GDALDataType *buf_type=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0){
     int nxsize = (buf_xsize==0) ? xsize : *buf_xsize;
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
-                                        : (GDALDataType)*buf_type;
+                                        : *buf_type;
     GIntBig pixel_space = (buf_pixel_space == 0) ? 0 : *buf_pixel_space;
     GIntBig line_space = (buf_line_space == 0) ? 0 : *buf_line_space;
     GDALRasterIOExtraArg* psExtraArg = NULL;
@@ -6640,14 +6640,14 @@ SWIGINTERN CPLErr GDALRasterBandShadow_AdviseRead(GDALRasterBandShadow *self,int
 SWIGINTERN GDALMDArrayHS *GDALRasterBandShadow_AsMDArray(GDALRasterBandShadow *self){
     return GDALRasterBandAsMDArray(self);
   }
-SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,double xoff,double yoff,double xsize,double ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,int *buf_type=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL,void *inputOutputBuf=NULL){
+SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,double xoff,double yoff,double xsize,double ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,GDALDataType *buf_type=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL,void *inputOutputBuf=NULL){
 
     *buf = NULL;
 
     int nxsize = (buf_xsize==0) ? static_cast<int>(xsize) : *buf_xsize;
     int nysize = (buf_ysize==0) ? static_cast<int>(ysize) : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
-                                        : (GDALDataType)*buf_type;
+                                        : *buf_type;
     GIntBig pixel_space = (buf_pixel_space == 0) ? 0 : *buf_pixel_space;
     GIntBig line_space = (buf_line_space == 0) ? 0 : *buf_line_space;
 
@@ -13977,8 +13977,6 @@ SWIGINTERN PyObject *_wrap_Driver_Create(PyObject *SWIGUNUSEDPARM(self), PyObjec
   int ecode4 = 0 ;
   int val5 ;
   int ecode5 = 0 ;
-  int val6 ;
-  int ecode6 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -14024,11 +14022,19 @@ SWIGINTERN PyObject *_wrap_Driver_Create(PyObject *SWIGUNUSEDPARM(self), PyObjec
     arg5 = static_cast< int >(val5);
   }
   if (obj5) {
-    ecode6 = SWIG_AsVal_int(obj5, &val6);
-    if (!SWIG_IsOK(ecode6)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "Driver_Create" "', argument " "6"" of type '" "GDALDataType""'");
-    } 
-    arg6 = static_cast< GDALDataType >(val6);
+    {
+      // %typemap(in) GDALDataType
+      int val = 0;
+      int ecode = SWIG_AsVal_int(obj5, &val);
+      if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+      }
+      if( val < GDT_Unknown || val >= GDT_TypeCount )
+      {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+      }
+      arg6 = static_cast<GDALDataType>(val);
+    }
   }
   if (obj6) {
     {
@@ -18375,8 +18381,6 @@ SWIGINTERN PyObject *_wrap_Dataset_AddBand(PyObject *SWIGUNUSEDPARM(self), PyObj
   char **arg3 = (char **) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -18392,11 +18396,19 @@ SWIGINTERN PyObject *_wrap_Dataset_AddBand(PyObject *SWIGUNUSEDPARM(self), PyObj
   }
   arg1 = reinterpret_cast< GDALDatasetShadow * >(argp1);
   if (obj1) {
-    ecode2 = SWIG_AsVal_int(obj1, &val2);
-    if (!SWIG_IsOK(ecode2)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Dataset_AddBand" "', argument " "2"" of type '" "GDALDataType""'");
-    } 
-    arg2 = static_cast< GDALDataType >(val2);
+    {
+      // %typemap(in) GDALDataType
+      int val = 0;
+      int ecode = SWIG_AsVal_int(obj1, &val);
+      if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+      }
+      if( val < GDT_Unknown || val >= GDT_TypeCount )
+      {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+      }
+      arg2 = static_cast<GDALDataType>(val);
+    }
   }
   if (obj2) {
     {
@@ -18580,7 +18592,7 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
   Py_buffer view6 ;
   int val8 ;
   int val9 ;
-  int val10 ;
+  GDALDataType val10 ;
   GIntBig val13 ;
   GIntBig val14 ;
   GIntBig val15 ;
@@ -18693,12 +18705,18 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
   }
   if (obj8) {
     {
-      /* %typemap(in) (int *optional_##int) */
+      /* %typemap(in) (GDALDataType *optional_GDALDataType) */
+      int intval = 0;
       if ( obj8 == Py_None ) {
-        arg10 = 0;
+        arg10 = NULL;
       }
-      else if ( PyArg_Parse( obj8,"i" ,&val10 ) ) {
-        arg10 = (GDALDataType *) &val10;
+      else if ( SWIG_IsOK(SWIG_AsVal_int(obj8, &intval)) ) {
+        if( intval < GDT_Unknown || intval >= GDT_TypeCount )
+        {
+          SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+        }
+        val10 = static_cast<GDALDataType>(intval);
+        arg10 = &val10;
       }
       else {
         PyErr_SetString( PyExc_TypeError, "Invalid Parameter" );
@@ -19002,8 +19020,6 @@ SWIGINTERN PyObject *_wrap_Dataset_BeginAsyncReader(PyObject *SWIGUNUSEDPARM(sel
   int ecode9 = 0 ;
   int val10 ;
   int ecode10 = 0 ;
-  int val11 ;
-  int ecode11 = 0 ;
   int val14 ;
   int ecode14 = 0 ;
   int val15 ;
@@ -19081,11 +19097,19 @@ SWIGINTERN PyObject *_wrap_Dataset_BeginAsyncReader(PyObject *SWIGUNUSEDPARM(sel
   } 
   arg10 = static_cast< int >(val10);
   if (obj8) {
-    ecode11 = SWIG_AsVal_int(obj8, &val11);
-    if (!SWIG_IsOK(ecode11)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode11), "in method '" "Dataset_BeginAsyncReader" "', argument " "11"" of type '" "GDALDataType""'");
-    } 
-    arg11 = static_cast< GDALDataType >(val11);
+    {
+      // %typemap(in) GDALDataType
+      int val = 0;
+      int ecode = SWIG_AsVal_int(obj8, &val);
+      if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+      }
+      if( val < GDT_Unknown || val >= GDT_TypeCount )
+      {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+      }
+      arg11 = static_cast<GDALDataType>(val);
+    }
   }
   if (obj9) {
     {
@@ -19251,8 +19275,6 @@ SWIGINTERN PyObject *_wrap_Dataset_GetVirtualMem(PyObject *SWIGUNUSEDPARM(self),
   int ecode7 = 0 ;
   int val8 ;
   int ecode8 = 0 ;
-  int val9 ;
-  int ecode9 = 0 ;
   int val12 ;
   int ecode12 = 0 ;
   size_t val13 ;
@@ -19319,11 +19341,19 @@ SWIGINTERN PyObject *_wrap_Dataset_GetVirtualMem(PyObject *SWIGUNUSEDPARM(self),
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "Dataset_GetVirtualMem" "', argument " "8"" of type '" "int""'");
   } 
   arg8 = static_cast< int >(val8);
-  ecode9 = SWIG_AsVal_int(obj8, &val9);
-  if (!SWIG_IsOK(ecode9)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "Dataset_GetVirtualMem" "', argument " "9"" of type '" "GDALDataType""'");
-  } 
-  arg9 = static_cast< GDALDataType >(val9);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj8, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg9 = static_cast<GDALDataType>(val);
+  }
   {
     /* %typemap(in,numinputs=1) (int nList, int* pList)*/
     arg11 = CreateCIntListFromSequence(obj9, &arg10);
@@ -19431,8 +19461,6 @@ SWIGINTERN PyObject *_wrap_Dataset_GetTiledVirtualMem(PyObject *SWIGUNUSEDPARM(s
   int ecode7 = 0 ;
   int val8 ;
   int ecode8 = 0 ;
-  int val9 ;
-  int ecode9 = 0 ;
   int val12 ;
   int ecode12 = 0 ;
   size_t val13 ;
@@ -19496,11 +19524,19 @@ SWIGINTERN PyObject *_wrap_Dataset_GetTiledVirtualMem(PyObject *SWIGUNUSEDPARM(s
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "Dataset_GetTiledVirtualMem" "', argument " "8"" of type '" "int""'");
   } 
   arg8 = static_cast< int >(val8);
-  ecode9 = SWIG_AsVal_int(obj8, &val9);
-  if (!SWIG_IsOK(ecode9)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "Dataset_GetTiledVirtualMem" "', argument " "9"" of type '" "GDALDataType""'");
-  } 
-  arg9 = static_cast< GDALDataType >(val9);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj8, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg9 = static_cast<GDALDataType>(val);
+  }
   {
     /* %typemap(in,numinputs=1) (int nList, int* pList)*/
     arg11 = CreateCIntListFromSequence(obj9, &arg10);
@@ -20770,7 +20806,7 @@ SWIGINTERN PyObject *_wrap_Dataset_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), P
   void *pyObject6 = NULL ;
   int val7 ;
   int val8 ;
-  int val9 ;
+  GDALDataType val9 ;
   GIntBig val12 ;
   GIntBig val13 ;
   GIntBig val14 ;
@@ -20864,12 +20900,18 @@ SWIGINTERN PyObject *_wrap_Dataset_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), P
   }
   if (obj7) {
     {
-      /* %typemap(in) (int *optional_##int) */
+      /* %typemap(in) (GDALDataType *optional_GDALDataType) */
+      int intval = 0;
       if ( obj7 == Py_None ) {
-        arg9 = 0;
+        arg9 = NULL;
       }
-      else if ( PyArg_Parse( obj7,"i" ,&val9 ) ) {
-        arg9 = (GDALDataType *) &val9;
+      else if ( SWIG_IsOK(SWIG_AsVal_int(obj7, &intval)) ) {
+        if( intval < GDT_Unknown || intval >= GDT_TypeCount )
+        {
+          SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+        }
+        val9 = static_cast<GDALDataType>(intval);
+        arg9 = &val9;
       }
       else {
         PyErr_SetString( PyExc_TypeError, "Invalid Parameter" );
@@ -24847,8 +24889,6 @@ SWIGINTERN PyObject *_wrap_MDArray_SetOffset(PyObject *SWIGUNUSEDPARM(self), PyO
   int res1 = 0 ;
   double val2 ;
   int ecode2 = 0 ;
-  int val3 ;
-  int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -24869,11 +24909,19 @@ SWIGINTERN PyObject *_wrap_MDArray_SetOffset(PyObject *SWIGUNUSEDPARM(self), PyO
   } 
   arg2 = static_cast< double >(val2);
   if (obj2) {
-    ecode3 = SWIG_AsVal_int(obj2, &val3);
-    if (!SWIG_IsOK(ecode3)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "MDArray_SetOffset" "', argument " "3"" of type '" "GDALDataType""'");
-    } 
-    arg3 = static_cast< GDALDataType >(val3);
+    {
+      // %typemap(in) GDALDataType
+      int val = 0;
+      int ecode = SWIG_AsVal_int(obj2, &val);
+      if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+      }
+      if( val < GDT_Unknown || val >= GDT_TypeCount )
+      {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+      }
+      arg3 = static_cast<GDALDataType>(val);
+    }
   }
   {
     if ( bUseExceptions ) {
@@ -24910,8 +24958,6 @@ SWIGINTERN PyObject *_wrap_MDArray_SetScale(PyObject *SWIGUNUSEDPARM(self), PyOb
   int res1 = 0 ;
   double val2 ;
   int ecode2 = 0 ;
-  int val3 ;
-  int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -24932,11 +24978,19 @@ SWIGINTERN PyObject *_wrap_MDArray_SetScale(PyObject *SWIGUNUSEDPARM(self), PyOb
   } 
   arg2 = static_cast< double >(val2);
   if (obj2) {
-    ecode3 = SWIG_AsVal_int(obj2, &val3);
-    if (!SWIG_IsOK(ecode3)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "MDArray_SetScale" "', argument " "3"" of type '" "GDALDataType""'");
-    } 
-    arg3 = static_cast< GDALDataType >(val3);
+    {
+      // %typemap(in) GDALDataType
+      int val = 0;
+      int ecode = SWIG_AsVal_int(obj2, &val);
+      if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+      }
+      if( val < GDT_Unknown || val >= GDT_TypeCount )
+      {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+      }
+      arg3 = static_cast<GDALDataType>(val);
+    }
   }
   {
     if ( bUseExceptions ) {
@@ -27156,17 +27210,23 @@ fail:
 SWIGINTERN PyObject *_wrap_ExtendedDataType_Create(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   GDALDataType arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
   PyObject * obj0 = 0 ;
   GDALExtendedDataTypeHS *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)"O:ExtendedDataType_Create",&obj0)) SWIG_fail;
-  ecode1 = SWIG_AsVal_int(obj0, &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "ExtendedDataType_Create" "', argument " "1"" of type '" "GDALDataType""'");
-  } 
-  arg1 = static_cast< GDALDataType >(val1);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj0, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg1 = static_cast<GDALDataType>(val);
+  }
   {
     if ( bUseExceptions ) {
       ClearErrorState();
@@ -29886,7 +29946,7 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
   char *arg7 = (char *) 0 ;
   int *arg8 = (int *) 0 ;
   int *arg9 = (int *) 0 ;
-  int *arg10 = (int *) 0 ;
+  GDALDataType *arg10 = (GDALDataType *) 0 ;
   GIntBig *arg11 = (GIntBig *) 0 ;
   GIntBig *arg12 = (GIntBig *) 0 ;
   void *argp1 = 0 ;
@@ -29904,7 +29964,7 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
   Py_buffer view6 ;
   int val8 ;
   int val9 ;
-  int val10 ;
+  GDALDataType val10 ;
   GIntBig val11 ;
   GIntBig val12 ;
   PyObject * obj0 = 0 ;
@@ -30014,12 +30074,18 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
   }
   if (obj8) {
     {
-      /* %typemap(in) (int *optional_##int) */
+      /* %typemap(in) (GDALDataType *optional_GDALDataType) */
+      int intval = 0;
       if ( obj8 == Py_None ) {
-        arg10 = 0;
+        arg10 = NULL;
       }
-      else if ( PyArg_Parse( obj8,"i" ,&val10 ) ) {
-        arg10 = (int *) &val10;
+      else if ( SWIG_IsOK(SWIG_AsVal_int(obj8, &intval)) ) {
+        if( intval < GDT_Unknown || intval >= GDT_TypeCount )
+        {
+          SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+        }
+        val10 = static_cast<GDALDataType>(intval);
+        arg10 = &val10;
       }
       else {
         PyErr_SetString( PyExc_TypeError, "Invalid Parameter" );
@@ -31228,8 +31294,6 @@ SWIGINTERN PyObject *_wrap_Band_GetVirtualMem(PyObject *SWIGUNUSEDPARM(self), Py
   int ecode7 = 0 ;
   int val8 ;
   int ecode8 = 0 ;
-  int val9 ;
-  int ecode9 = 0 ;
   size_t val10 ;
   int ecode10 = 0 ;
   size_t val11 ;
@@ -31292,11 +31356,19 @@ SWIGINTERN PyObject *_wrap_Band_GetVirtualMem(PyObject *SWIGUNUSEDPARM(self), Py
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "Band_GetVirtualMem" "', argument " "8"" of type '" "int""'");
   } 
   arg8 = static_cast< int >(val8);
-  ecode9 = SWIG_AsVal_int(obj8, &val9);
-  if (!SWIG_IsOK(ecode9)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "Band_GetVirtualMem" "', argument " "9"" of type '" "GDALDataType""'");
-  } 
-  arg9 = static_cast< GDALDataType >(val9);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj8, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg9 = static_cast<GDALDataType>(val);
+  }
   ecode10 = SWIG_AsVal_size_t(obj9, &val10);
   if (!SWIG_IsOK(ecode10)) {
     SWIG_exception_fail(SWIG_ArgError(ecode10), "in method '" "Band_GetVirtualMem" "', argument " "10"" of type '" "size_t""'");
@@ -31454,8 +31526,6 @@ SWIGINTERN PyObject *_wrap_Band_GetTiledVirtualMem(PyObject *SWIGUNUSEDPARM(self
   int ecode7 = 0 ;
   int val8 ;
   int ecode8 = 0 ;
-  int val9 ;
-  int ecode9 = 0 ;
   size_t val10 ;
   int ecode10 = 0 ;
   PyObject * obj0 = 0 ;
@@ -31515,11 +31585,19 @@ SWIGINTERN PyObject *_wrap_Band_GetTiledVirtualMem(PyObject *SWIGUNUSEDPARM(self
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "Band_GetTiledVirtualMem" "', argument " "8"" of type '" "int""'");
   } 
   arg8 = static_cast< int >(val8);
-  ecode9 = SWIG_AsVal_int(obj8, &val9);
-  if (!SWIG_IsOK(ecode9)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "Band_GetTiledVirtualMem" "', argument " "9"" of type '" "GDALDataType""'");
-  } 
-  arg9 = static_cast< GDALDataType >(val9);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj8, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg9 = static_cast<GDALDataType>(val);
+  }
   ecode10 = SWIG_AsVal_size_t(obj9, &val10);
   if (!SWIG_IsOK(ecode10)) {
     SWIG_exception_fail(SWIG_ArgError(ecode10), "in method '" "Band_GetTiledVirtualMem" "', argument " "10"" of type '" "size_t""'");
@@ -31854,7 +31932,7 @@ SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyOb
   void **arg6 = (void **) 0 ;
   int *arg7 = (int *) 0 ;
   int *arg8 = (int *) 0 ;
-  int *arg9 = (int *) 0 ;
+  GDALDataType *arg9 = (GDALDataType *) 0 ;
   GIntBig *arg10 = (GIntBig *) 0 ;
   GIntBig *arg11 = (GIntBig *) 0 ;
   GDALRIOResampleAlg arg12 = (GDALRIOResampleAlg) GRIORA_NearestNeighbour ;
@@ -31874,7 +31952,7 @@ SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyOb
   void *pyObject6 = NULL ;
   int val7 ;
   int val8 ;
-  int val9 ;
+  GDALDataType val9 ;
   GIntBig val10 ;
   GIntBig val11 ;
   PyObject * obj0 = 0 ;
@@ -31965,12 +32043,18 @@ SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyOb
   }
   if (obj7) {
     {
-      /* %typemap(in) (int *optional_##int) */
+      /* %typemap(in) (GDALDataType *optional_GDALDataType) */
+      int intval = 0;
       if ( obj7 == Py_None ) {
-        arg9 = 0;
+        arg9 = NULL;
       }
-      else if ( PyArg_Parse( obj7,"i" ,&val9 ) ) {
-        arg9 = (int *) &val9;
+      else if ( SWIG_IsOK(SWIG_AsVal_int(obj7, &intval)) ) {
+        if( intval < GDT_Unknown || intval >= GDT_TypeCount )
+        {
+          SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+        }
+        val9 = static_cast<GDALDataType>(intval);
+        arg9 = &val9;
       }
       else {
         PyErr_SetString( PyExc_TypeError, "Invalid Parameter" );
@@ -37953,17 +38037,23 @@ fail:
 SWIGINTERN PyObject *_wrap_GetDataTypeSize(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   GDALDataType arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
   PyObject * obj0 = 0 ;
   int result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:GetDataTypeSize",&obj0)) SWIG_fail;
-  ecode1 = SWIG_AsVal_int(obj0, &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "GetDataTypeSize" "', argument " "1"" of type '" "GDALDataType""'");
-  } 
-  arg1 = static_cast< GDALDataType >(val1);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj0, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg1 = static_cast<GDALDataType>(val);
+  }
   {
     if ( bUseExceptions ) {
       ClearErrorState();
@@ -37993,17 +38083,23 @@ fail:
 SWIGINTERN PyObject *_wrap_DataTypeIsComplex(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   GDALDataType arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
   PyObject * obj0 = 0 ;
   int result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:DataTypeIsComplex",&obj0)) SWIG_fail;
-  ecode1 = SWIG_AsVal_int(obj0, &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "DataTypeIsComplex" "', argument " "1"" of type '" "GDALDataType""'");
-  } 
-  arg1 = static_cast< GDALDataType >(val1);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj0, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg1 = static_cast<GDALDataType>(val);
+  }
   {
     if ( bUseExceptions ) {
       ClearErrorState();
@@ -38033,17 +38129,23 @@ fail:
 SWIGINTERN PyObject *_wrap_GetDataTypeName(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   GDALDataType arg1 ;
-  int val1 ;
-  int ecode1 = 0 ;
   PyObject * obj0 = 0 ;
   char *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)"O:GetDataTypeName",&obj0)) SWIG_fail;
-  ecode1 = SWIG_AsVal_int(obj0, &val1);
-  if (!SWIG_IsOK(ecode1)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "GetDataTypeName" "', argument " "1"" of type '" "GDALDataType""'");
-  } 
-  arg1 = static_cast< GDALDataType >(val1);
+  {
+    // %typemap(in) GDALDataType
+    int val = 0;
+    int ecode = SWIG_AsVal_int(obj0, &val);
+    if (!SWIG_IsOK(ecode)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALDataType");
+    }
+    if( val < GDT_Unknown || val >= GDT_TypeCount )
+    {
+      SWIG_exception_fail(SWIG_ValueError, "Invalid value for GDALDataType");
+    }
+    arg1 = static_cast<GDALDataType>(val);
+  }
   {
     if ( bUseExceptions ) {
       ClearErrorState();
@@ -42943,7 +43045,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Band_ComputeRasterMinMax", _wrap_Band_ComputeRasterMinMax, METH_VARARGS, (char *)"Band_ComputeRasterMinMax(Band self, int approx_ok=0)"},
 	 { (char *)"Band_ComputeBandStats", _wrap_Band_ComputeBandStats, METH_VARARGS, (char *)"Band_ComputeBandStats(Band self, int samplestep=1)"},
 	 { (char *)"Band_Fill", _wrap_Band_Fill, METH_VARARGS, (char *)"Band_Fill(Band self, double real_fill, double imag_fill=0.0) -> CPLErr"},
-	 { (char *)"Band_WriteRaster", (PyCFunction) _wrap_Band_WriteRaster, METH_VARARGS | METH_KEYWORDS, (char *)"Band_WriteRaster(Band self, int xoff, int yoff, int xsize, int ysize, GIntBig buf_len, int * buf_xsize=None, int * buf_ysize=None, int * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None) -> CPLErr"},
+	 { (char *)"Band_WriteRaster", (PyCFunction) _wrap_Band_WriteRaster, METH_VARARGS | METH_KEYWORDS, (char *)"Band_WriteRaster(Band self, int xoff, int yoff, int xsize, int ysize, GIntBig buf_len, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None) -> CPLErr"},
 	 { (char *)"Band_FlushCache", _wrap_Band_FlushCache, METH_VARARGS, (char *)"Band_FlushCache(Band self)"},
 	 { (char *)"Band_GetRasterColorTable", _wrap_Band_GetRasterColorTable, METH_VARARGS, (char *)"Band_GetRasterColorTable(Band self) -> ColorTable"},
 	 { (char *)"Band_GetColorTable", _wrap_Band_GetColorTable, METH_VARARGS, (char *)"Band_GetColorTable(Band self) -> ColorTable"},
@@ -42966,7 +43068,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Band_GetDataCoverageStatus", _wrap_Band_GetDataCoverageStatus, METH_VARARGS, (char *)"Band_GetDataCoverageStatus(Band self, int nXOff, int nYOff, int nXSize, int nYSize, int nMaskFlagStop=0) -> int"},
 	 { (char *)"Band_AdviseRead", _wrap_Band_AdviseRead, METH_VARARGS, (char *)"Band_AdviseRead(Band self, int xoff, int yoff, int xsize, int ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, char ** options=None) -> CPLErr"},
 	 { (char *)"Band_AsMDArray", _wrap_Band_AsMDArray, METH_VARARGS, (char *)"Band_AsMDArray(Band self) -> MDArray"},
-	 { (char *)"Band_ReadRaster1", (PyCFunction) _wrap_Band_ReadRaster1, METH_VARARGS | METH_KEYWORDS, (char *)"Band_ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, int * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"},
+	 { (char *)"Band_ReadRaster1", (PyCFunction) _wrap_Band_ReadRaster1, METH_VARARGS | METH_KEYWORDS, (char *)"Band_ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"},
 	 { (char *)"Band_ReadBlock", (PyCFunction) _wrap_Band_ReadBlock, METH_VARARGS | METH_KEYWORDS, (char *)"Band_ReadBlock(Band self, int xoff, int yoff, void * buf_obj=None) -> CPLErr"},
 	 { (char *)"Band_swigregister", Band_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_ColorTable", (PyCFunction) _wrap_new_ColorTable, METH_VARARGS | METH_KEYWORDS, (char *)"new_ColorTable(GDALPaletteInterp palette) -> ColorTable"},

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -5334,17 +5334,6 @@ SWIGINTERN void GDALDatasetShadow_ClearStatistics(GDALDatasetShadow *self){
 SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double xoff,double yoff,double xsize,double ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,GDALDataType *buf_type=0,int band_list=0,int *pband_list=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GIntBig *buf_band_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL,void *inputOutputBuf=NULL){
     *buf = NULL;
 
-    // This check is a bit too late. resample_alg should already have been
-    // validated, so we are a bit in undefined behavior land, but compilers
-    // should hopefully do the right thing
-    if( static_cast<int>(resample_alg) < 0 ||
-        ( static_cast<int>(resample_alg) >= static_cast<int>(GRIORA_RESERVED_START) &&
-          static_cast<int>(resample_alg) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
-    {
-        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
-        return CE_Failure;
-    }
     int nxsize = (buf_xsize==0) ? xsize : *buf_xsize;
     int nysize = (buf_ysize==0) ? ysize : *buf_ysize;
     GDALDataType ntype;
@@ -6655,17 +6644,6 @@ SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,do
 
     *buf = NULL;
 
-    // This check is a bit too late. resample_alg should already have been
-    // validated, so we are a bit in undefined behavior land, but compilers
-    // should hopefully do the right thing
-    if( static_cast<int>(resample_alg) < 0 ||
-        ( static_cast<int>(resample_alg) >= static_cast<int>(GRIORA_RESERVED_START) &&
-          static_cast<int>(resample_alg) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-        static_cast<int>(resample_alg) > static_cast<int>(GRIORA_LAST) )
-    {
-        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for resample_alg");
-        return CE_Failure;
-    }
     int nxsize = (buf_xsize==0) ? static_cast<int>(xsize) : *buf_xsize;
     int nysize = (buf_ysize==0) ? static_cast<int>(ysize) : *buf_ysize;
     GDALDataType ntype  = (buf_type==0) ? GDALGetRasterDataType(self)
@@ -20796,8 +20774,6 @@ SWIGINTERN PyObject *_wrap_Dataset_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), P
   GIntBig val12 ;
   GIntBig val13 ;
   GIntBig val14 ;
-  int val15 ;
-  int ecode15 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -20956,11 +20932,22 @@ SWIGINTERN PyObject *_wrap_Dataset_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), P
     }
   }
   if (obj12) {
-    ecode15 = SWIG_AsVal_int(obj12, &val15);
-    if (!SWIG_IsOK(ecode15)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode15), "in method '" "Dataset_ReadRaster1" "', argument " "15"" of type '" "GDALRIOResampleAlg""'");
-    } 
-    arg15 = static_cast< GDALRIOResampleAlg >(val15);
+    {
+      // %typemap(in) GDALRIOResampleAlg
+      int val = 0;
+      int ecode = SWIG_AsVal_int(obj12, &val);
+      if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALRIOResampleAlg");
+      }
+      if( val < 0 ||
+        ( val >= static_cast<int>(GRIORA_RESERVED_START) &&
+          val <= static_cast<int>(GRIORA_RESERVED_END) ) ||
+        val > static_cast<int>(GRIORA_LAST) )
+      {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for resample_alg");
+      }
+      arg15 = static_cast< GDALRIOResampleAlg >(val);
+    }
   }
   if (obj13) {
     {
@@ -21010,19 +20997,6 @@ SWIGINTERN PyObject *_wrap_Dataset_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), P
     {
       /* %typemap(in) ( void *inPythonObject ) */
       arg18 = obj15;
-    }
-  }
-  {
-    // %typemap(check) GDALRIOResampleAlg
-    // This check is a bit too late, since arg15 has already been cast
-    // to GDALRIOResampleAlg, so we are a bit in undefined behavior land,
-    // but compilers should hopefully do the right thing
-    if( static_cast<int>(arg15) < 0 ||
-      ( static_cast<int>(arg15) >= static_cast<int>(GRIORA_RESERVED_START) &&
-        static_cast<int>(arg15) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-      static_cast<int>(arg15) > static_cast<int>(GRIORA_LAST) )
-    {
-      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
     }
   }
   {
@@ -31903,8 +31877,6 @@ SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyOb
   int val9 ;
   GIntBig val10 ;
   GIntBig val11 ;
-  int val12 ;
-  int ecode12 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -32037,11 +32009,22 @@ SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyOb
     }
   }
   if (obj10) {
-    ecode12 = SWIG_AsVal_int(obj10, &val12);
-    if (!SWIG_IsOK(ecode12)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode12), "in method '" "Band_ReadRaster1" "', argument " "12"" of type '" "GDALRIOResampleAlg""'");
-    } 
-    arg12 = static_cast< GDALRIOResampleAlg >(val12);
+    {
+      // %typemap(in) GDALRIOResampleAlg
+      int val = 0;
+      int ecode = SWIG_AsVal_int(obj10, &val);
+      if (!SWIG_IsOK(ecode)) {
+        SWIG_exception_fail(SWIG_ArgError(ecode), "invalid value for GDALRIOResampleAlg");
+      }
+      if( val < 0 ||
+        ( val >= static_cast<int>(GRIORA_RESERVED_START) &&
+          val <= static_cast<int>(GRIORA_RESERVED_END) ) ||
+        val > static_cast<int>(GRIORA_LAST) )
+      {
+        SWIG_exception_fail(SWIG_ValueError, "Invalid value for resample_alg");
+      }
+      arg12 = static_cast< GDALRIOResampleAlg >(val);
+    }
   }
   if (obj11) {
     {
@@ -32091,19 +32074,6 @@ SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyOb
     {
       /* %typemap(in) ( void *inPythonObject ) */
       arg15 = obj13;
-    }
-  }
-  {
-    // %typemap(check) GDALRIOResampleAlg
-    // This check is a bit too late, since arg12 has already been cast
-    // to GDALRIOResampleAlg, so we are a bit in undefined behavior land,
-    // but compilers should hopefully do the right thing
-    if( static_cast<int>(arg12) < 0 ||
-      ( static_cast<int>(arg12) >= static_cast<int>(GRIORA_RESERVED_START) &&
-        static_cast<int>(arg12) <= static_cast<int>(GRIORA_RESERVED_END) ) ||
-      static_cast<int>(arg12) > static_cast<int>(GRIORA_LAST) )
-    {
-      SWIG_exception(SWIG_ValueError, "Invalid value for resample_alg");
     }
   }
   {

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -8989,18 +8989,9 @@ SWIGINTERN PyObject *_wrap_EscapeString(PyObject *SWIGUNUSEDPARM(self), PyObject
       }
       arg1 = (int) safeLen;
     }
-    else if (PyBytes_Check(obj0))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj0, (char**) &arg2, &safeLen);
-      if( safeLen > INT_MAX ) {
-        SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-      }
-      arg1 = (int) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
     ok: ;
@@ -10294,18 +10285,9 @@ SWIGINTERN PyObject *_wrap_CPLBinaryToHex(PyObject *SWIGUNUSEDPARM(self), PyObje
       }
       arg1 = (int) safeLen;
     }
-    else if (PyBytes_Check(obj0))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj0, (char**) &arg2, &safeLen);
-      if( safeLen > INT_MAX ) {
-        SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-      }
-      arg1 = (int) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
     ok: ;
@@ -12738,18 +12720,9 @@ SWIGINTERN PyObject *_wrap_VSIFWriteL(PyObject *SWIGUNUSEDPARM(self), PyObject *
       }
       arg1 = (int) safeLen;
     }
-    else if (PyBytes_Check(obj0))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj0, (char**) &arg2, &safeLen);
-      if( safeLen > INT_MAX ) {
-        SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-      }
-      arg1 = (int) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
     ok: ;

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -3236,49 +3236,6 @@ typedef int RETURN_NONE;
 typedef int VSI_RETVAL;
 
 
-
-/* This is quite annoying but the data member of a string/buffer object */
-/* is sometimes not 8-byte aligned (Linux 64bit at least) given that it is */
-/* part of the object structure, and so has an offset. So we will allocate */
-/* a bit more, do the RasterIO() on a properly aligned buffer, and then move */
-/* back if necessary to the original buffer */
-
-#define ALIGNMENT_EXTRA 63
-#define ALIGNMENT_SHIFT 32
-
-static
-char* get_aligned_buffer(char* data, GDALDataType ntype)
-{
-    int alignment_needed = ntype == GDT_Byte ? 1:
-                           ntype == GDT_Int16 ? 2:
-                           ntype == GDT_UInt16 ? 2:
-                           ntype == GDT_Int32 ? 4:
-                           ntype == GDT_UInt32 ? 4:
-                           ntype == GDT_Float32 ? 4:
-                           ntype == GDT_Float64 ? 8:
-                           ntype == GDT_CInt16 ? 2:
-                           ntype == GDT_CInt32 ? 4:
-                           ntype == GDT_CFloat32 ? 4:
-                           ntype == GDT_CFloat64 ? 8: 8;
-    char* data_aligned = data + (alignment_needed - (size_t)data % alignment_needed) % alignment_needed;
-    if( data_aligned != data )
-        data_aligned += ALIGNMENT_SHIFT;
-    return data_aligned;
-}
-
-static void update_buffer_size(void* obj, char* data, char* data_aligned, size_t buf_size)
-{
-    if( data != data_aligned )
-        memmove(data, data_aligned, buf_size);
-
-    PyBytesObject* stringobj = (PyBytesObject *) obj;
-    Py_SIZE(stringobj) = buf_size;
-    stringobj->ob_sval[buf_size] = '\0';
-    stringobj->ob_shash = -1;          /* invalidate cached hash value */
-}
-
-
-
 #define MODULE_NAME           "gdal"
 
 
@@ -3487,7 +3444,7 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
     }
 
     SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-    *buf = (void *)PyBytes_FromStringAndSize( NULL, buf_size );
+    *buf = (void *)PyByteArray_FromStringAndSize( NULL, buf_size );
     if (*buf == NULL)
     {
         *buf = Py_None;
@@ -3500,13 +3457,13 @@ unsigned int wrapper_VSIFReadL( void **buf, unsigned int nMembSize, unsigned int
         return 0;
     }
     PyObject* o = (PyObject*) *buf;
-    char *data = PyBytes_AsString(o);
+    char *data = PyByteArray_AsString(o);
     SWIG_PYTHON_THREAD_END_BLOCK;
     size_t nRet = (size_t)VSIFReadL( data, nMembSize, nMembCount, fp );
     if (nRet * (size_t)nMembSize < buf_size)
     {
         SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        _PyBytes_Resize(&o, nRet * nMembSize);
+        PyByteArray_Resize(o, nRet * nMembSize);
         SWIG_PYTHON_THREAD_END_BLOCK;
         *buf = o;
     }
@@ -5286,14 +5243,14 @@ SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double x
                                     pband_list, band_list,
                                     pixel_space, line_space, band_space,
                                     FALSE));
-    if (buf_size == 0 || buf_size + ALIGNMENT_EXTRA < buf_size)
+    if (buf_size == 0)
     {
         *buf = NULL;
         return CE_Failure;
     }
 
     SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-    *buf = (void *)PyBytes_FromStringAndSize( NULL, buf_size + ALIGNMENT_EXTRA );
+    *buf = (void *)PyByteArray_FromStringAndSize( NULL, buf_size );
     if (*buf == NULL)
     {
         if( !bUseExceptions )
@@ -5304,23 +5261,21 @@ SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double x
         CPLError(CE_Failure, CPLE_OutOfMemory, "Cannot allocate result buffer");
         return CE_Failure;
     }
-    char *data = PyBytes_AsString( (PyObject *)*buf );
+    char *data = PyByteArray_AsString( (PyObject *)*buf );
     SWIG_PYTHON_THREAD_END_BLOCK;
-
-    char* data_aligned = get_aligned_buffer(data, ntype);
 
     /* Should we clear the buffer in case there are hole in it ? */
     if( line_space != 0 && pixel_space != 0 && line_space > pixel_space * nxsize )
     {
-        memset(data_aligned, 0, buf_size);
+        memset(data, 0, buf_size);
     }
     else if( band_list > 1 && band_space != 0 )
     {
         if( line_space != 0 && band_space > line_space * nysize )
-            memset(data_aligned, 0, buf_size);
+            memset(data, 0, buf_size);
         else if( pixel_space != 0 && band_space < pixel_space &&
                  pixel_space != GDALGetRasterCount(self) * ntypesize )
-            memset(data_aligned, 0, buf_size);
+            memset(data, 0, buf_size);
     }
 
     GDALRasterIOExtraArg sExtraArg;
@@ -5344,7 +5299,7 @@ SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double x
     }
 
     CPLErr eErr = GDALDatasetRasterIOEx(self, GF_Read, nXOff, nYOff, nXSize, nYSize,
-                               (void*) data_aligned, nxsize, nysize, ntype,
+                               data, nxsize, nysize, ntype,
                                band_list, pband_list, pixel_space, line_space, band_space,
                                &sExtraArg );
     if (eErr == CE_Failure)
@@ -5354,10 +5309,7 @@ SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double x
         SWIG_PYTHON_THREAD_END_BLOCK;
         *buf = NULL;
     }
-    else
-    {
-        update_buffer_size(*buf, data, data_aligned, buf_size);
-    }
+
     return eErr;
 }
 
@@ -5746,13 +5698,10 @@ SWIGINTERN CPLErr GDALMDArrayHS_Read(GDALMDArrayHS *self,int nDims1,GUIntBig *ar
     {
         return CE_None;
     }
-    if (buf_size + ALIGNMENT_EXTRA < buf_size)
-    {
-        return CE_Failure;
-    }
+
 
     SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-    *buf = (void *)PyBytes_FromStringAndSize( NULL, buf_size + ALIGNMENT_EXTRA );
+    *buf = (void *)PyByteArray_FromStringAndSize( NULL, buf_size );
     if (*buf == NULL)
     {
         *buf = Py_None;
@@ -5764,12 +5713,10 @@ SWIGINTERN CPLErr GDALMDArrayHS_Read(GDALMDArrayHS *self,int nDims1,GUIntBig *ar
         CPLError(CE_Failure, CPLE_OutOfMemory, "Cannot allocate result buffer");
         return CE_Failure;
     }
-    char *data = PyBytes_AsString( (PyObject *)*buf );
+    char *data = PyByteArray_AsString( (PyObject *)*buf );
     SWIG_PYTHON_THREAD_END_BLOCK;
 
-    GDALDataType ntype  = GDALExtendedDataTypeGetNumericDataType(buffer_datatype);
-    char* data_aligned = get_aligned_buffer(data, ntype);
-    memset(data_aligned, 0, buf_size);
+    memset(data, 0, buf_size);
 
     CPLErr eErr = GDALMDArrayRead( self,
                                    array_start_idx,
@@ -5777,8 +5724,8 @@ SWIGINTERN CPLErr GDALMDArrayHS_Read(GDALMDArrayHS *self,int nDims1,GUIntBig *ar
                                    array_step,
                                    &buffer_stride_internal[0],
                                    buffer_datatype,
-                                   data_aligned,
-                                   data_aligned,
+                                   data,
+                                   data,
                                    buf_size ) ? CE_None : CE_Failure;
     if (eErr == CE_Failure)
     {
@@ -5786,10 +5733,6 @@ SWIGINTERN CPLErr GDALMDArrayHS_Read(GDALMDArrayHS *self,int nDims1,GUIntBig *ar
         Py_DECREF((PyObject*)*buf);
         SWIG_PYTHON_THREAD_END_BLOCK;
         *buf = NULL;
-    }
-    else
-    {
-        update_buffer_size(*buf, data, data_aligned, buf_size);
     }
 
     return eErr;
@@ -5949,7 +5892,7 @@ SWIGINTERN CPLErr GDALMDArrayHS_GetNoDataValueAsRaw(GDALMDArrayHS *self,void **b
     GDALExtendedDataTypeRelease(selfType);
 
     SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-    *buf = (void *)PyBytes_FromStringAndSize( NULL, buf_size );
+    *buf = (void *)PyByteArray_FromStringAndSize( NULL, buf_size );
     if (*buf == NULL)
     {
         *buf = Py_None;
@@ -5961,7 +5904,7 @@ SWIGINTERN CPLErr GDALMDArrayHS_GetNoDataValueAsRaw(GDALMDArrayHS *self,void **b
         CPLError(CE_Failure, CPLE_OutOfMemory, "Cannot allocate result buffer");
         return CE_Failure;
     }
-    char *data = PyBytes_AsString( (PyObject *)*buf );
+    char *data = PyByteArray_AsString( (PyObject *)*buf );
     SWIG_PYTHON_THREAD_END_BLOCK;
 
     memcpy(data, pabyBuf, buf_size);
@@ -6612,14 +6555,14 @@ SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,do
         ComputeBandRasterIOSize( nxsize, nysize,
                                  GDALGetDataTypeSize( ntype ) / 8,
                                  pixel_space, line_space, FALSE ) );
-    if (buf_size == 0 || buf_size + ALIGNMENT_EXTRA < buf_size)
+    if (buf_size == 0)
     {
         *buf = NULL;
         return CE_Failure;
     }
 
     SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-    *buf = (void *)PyBytes_FromStringAndSize( NULL, buf_size + ALIGNMENT_EXTRA );
+    *buf = (void *)PyByteArray_FromStringAndSize( NULL, buf_size );
     if (*buf == NULL)
     {
         *buf = Py_None;
@@ -6631,15 +6574,13 @@ SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,do
         CPLError(CE_Failure, CPLE_OutOfMemory, "Cannot allocate result buffer");
         return CE_Failure;
     }
-    char *data = PyBytes_AsString( (PyObject *)*buf );
+    char *data = PyByteArray_AsString( (PyObject *)*buf );
     SWIG_PYTHON_THREAD_END_BLOCK;
-
-    char* data_aligned = get_aligned_buffer(data, ntype);
 
     /* Should we clear the buffer in case there are hole in it ? */
     if( line_space != 0 && pixel_space != 0 && line_space > pixel_space * nxsize )
     {
-        memset(data_aligned, 0, buf_size);
+        memset(data, 0, buf_size);
     }
 
     GDALRasterIOExtraArg sExtraArg;
@@ -6662,7 +6603,7 @@ SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,do
     }
 
     CPLErr eErr = GDALRasterIOEx( self, GF_Read, nXOff, nYOff, nXSize, nYSize,
-                         (void *) data_aligned, nxsize, nysize, ntype,
+                         data, nxsize, nysize, ntype,
                          pixel_space, line_space, &sExtraArg );
     if (eErr == CE_Failure)
     {
@@ -6670,10 +6611,6 @@ SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,do
         Py_DECREF((PyObject*)*buf);
         SWIG_PYTHON_THREAD_END_BLOCK;
         *buf = NULL;
-    }
-    else
-    {
-        update_buffer_size(*buf, data, data_aligned, buf_size);
     }
 
     return eErr;
@@ -6686,14 +6623,9 @@ SWIGINTERN CPLErr GDALRasterBandShadow_ReadBlock(GDALRasterBandShadow *self,int 
     int nDataTypeSize = (GDALGetDataTypeSize(ntype) / 8);
     size_t buf_size = static_cast<size_t>(nBlockXSize) *
                                                 nBlockYSize * nDataTypeSize;
-    if( buf_size + ALIGNMENT_EXTRA < buf_size)
-    {
-        *buf = NULL;
-        return CE_Failure;
-    }
 
     SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-    *buf = (void *)PyBytes_FromStringAndSize( NULL, buf_size + ALIGNMENT_EXTRA );
+    *buf = (void *)PyByteArray_FromStringAndSize( NULL, buf_size );
     if (*buf == NULL)
     {
         *buf = Py_None;
@@ -6705,22 +6637,16 @@ SWIGINTERN CPLErr GDALRasterBandShadow_ReadBlock(GDALRasterBandShadow *self,int 
         CPLError(CE_Failure, CPLE_OutOfMemory, "Cannot allocate result buffer");
         return CE_Failure;
     }
-    char *data = PyBytes_AsString( (PyObject *)*buf );
+    char *data = PyByteArray_AsString( (PyObject *)*buf );
     SWIG_PYTHON_THREAD_END_BLOCK;
 
-    char* data_aligned = get_aligned_buffer(data, ntype);
-
-    CPLErr eErr = GDALReadBlock( self, xoff, yoff, (void *) data_aligned);
+    CPLErr eErr = GDALReadBlock( self, xoff, yoff, data);
     if (eErr == CE_Failure)
     {
         SWIG_PYTHON_THREAD_BEGIN_BLOCK;
         Py_DECREF((PyObject*)*buf);
         SWIG_PYTHON_THREAD_END_BLOCK;
         *buf = NULL;
-    }
-    else
-    {
-        update_buffer_size(*buf, data, data_aligned, buf_size);
     }
 
     return eErr;

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -10426,6 +10426,8 @@ SWIGINTERN PyObject *_wrap_FileFromMemBuffer(PyObject *SWIGUNUSEDPARM(self), PyO
   char *arg3 = (char *) 0 ;
   int bToFree1 = 0 ;
   int alloc2 = 0 ;
+  bool viewIsValid2 = false ;
+  Py_buffer view2 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   
@@ -10441,6 +10443,19 @@ SWIGINTERN PyObject *_wrap_FileFromMemBuffer(PyObject *SWIGUNUSEDPARM(self), PyO
   }
   {
     /* %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf ) */
+    {
+      if (PyObject_GetBuffer(obj1, &view2, PyBUF_SIMPLE) == 0)
+      {
+        viewIsValid2 = true;
+        arg2 = view2.len;
+        arg3 = (char *) view2.buf;
+        goto ok;
+      }
+      else
+      {
+        PyErr_Clear();
+      }
+    }
     if (PyUnicode_Check(obj1))
     {
       size_t safeLen = 0;
@@ -10452,23 +10467,12 @@ SWIGINTERN PyObject *_wrap_FileFromMemBuffer(PyObject *SWIGUNUSEDPARM(self), PyO
       if (safeLen) safeLen--;
       arg2 = (GIntBig) safeLen;
     }
-    else if (PyBytes_Check(obj1))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj1, (char**) &arg3, &safeLen);
-      arg2 = (GIntBig) safeLen;
-    }
-    else if (PyByteArray_Check(obj1))
-    {
-      Py_ssize_t safeLen = PyByteArray_Size(obj1);
-      arg3 = PyByteArray_AsString(obj1);
-      arg2 = (GIntBig) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
+    ok: ;
   }
   {
     if (!arg1) {
@@ -10500,7 +10504,10 @@ SWIGINTERN PyObject *_wrap_FileFromMemBuffer(PyObject *SWIGUNUSEDPARM(self), PyO
   }
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
+    if( viewIsValid2 ) {
+      PyBuffer_Release(&view2);
+    }
+    else if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
       delete[] arg3;
     }
   }
@@ -10513,7 +10520,10 @@ fail:
   }
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
+    if( viewIsValid2 ) {
+      PyBuffer_Release(&view2);
+    }
+    else if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
       delete[] arg3;
     }
   }
@@ -18516,6 +18526,8 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
   int val5 ;
   int ecode5 = 0 ;
   int alloc6 = 0 ;
+  bool viewIsValid6 = false ;
+  Py_buffer view6 ;
   int val8 ;
   int val9 ;
   int val10 ;
@@ -18568,6 +18580,19 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
   arg5 = static_cast< int >(val5);
   {
     /* %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf ) */
+    {
+      if (PyObject_GetBuffer(obj5, &view6, PyBUF_SIMPLE) == 0)
+      {
+        viewIsValid6 = true;
+        arg6 = view6.len;
+        arg7 = (char *) view6.buf;
+        goto ok;
+      }
+      else
+      {
+        PyErr_Clear();
+      }
+    }
     if (PyUnicode_Check(obj5))
     {
       size_t safeLen = 0;
@@ -18579,23 +18604,12 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
       if (safeLen) safeLen--;
       arg6 = (GIntBig) safeLen;
     }
-    else if (PyBytes_Check(obj5))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj5, (char**) &arg7, &safeLen);
-      arg6 = (GIntBig) safeLen;
-    }
-    else if (PyByteArray_Check(obj5))
-    {
-      Py_ssize_t safeLen = PyByteArray_Size(obj5);
-      arg7 = PyByteArray_AsString(obj5);
-      arg6 = (GIntBig) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
+    ok: ;
   }
   if (obj6) {
     {
@@ -18717,7 +18731,10 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
   resultobj = SWIG_From_int(static_cast< int >(result));
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
+    if( viewIsValid6 ) {
+      PyBuffer_Release(&view6);
+    }
+    else if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
       delete[] arg7;
     }
   }
@@ -18730,7 +18747,10 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
 fail:
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
+    if( viewIsValid6 ) {
+      PyBuffer_Release(&view6);
+    }
+    else if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
       delete[] arg7;
     }
   }
@@ -23601,6 +23621,8 @@ SWIGINTERN PyObject *_wrap_MDArray_Write(PyObject *SWIGUNUSEDPARM(self), PyObjec
   void *argp10 = 0 ;
   int res10 = 0 ;
   int alloc11 = 0 ;
+  bool viewIsValid11 = false ;
+  Py_buffer view11 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -23727,6 +23749,19 @@ SWIGINTERN PyObject *_wrap_MDArray_Write(PyObject *SWIGUNUSEDPARM(self), PyObjec
   arg10 = reinterpret_cast< GDALExtendedDataTypeHS * >(argp10);
   {
     /* %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf ) */
+    {
+      if (PyObject_GetBuffer(obj6, &view11, PyBUF_SIMPLE) == 0)
+      {
+        viewIsValid11 = true;
+        arg11 = view11.len;
+        arg12 = (char *) view11.buf;
+        goto ok;
+      }
+      else
+      {
+        PyErr_Clear();
+      }
+    }
     if (PyUnicode_Check(obj6))
     {
       size_t safeLen = 0;
@@ -23738,23 +23773,12 @@ SWIGINTERN PyObject *_wrap_MDArray_Write(PyObject *SWIGUNUSEDPARM(self), PyObjec
       if (safeLen) safeLen--;
       arg11 = (GIntBig) safeLen;
     }
-    else if (PyBytes_Check(obj6))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj6, (char**) &arg12, &safeLen);
-      arg11 = (GIntBig) safeLen;
-    }
-    else if (PyByteArray_Check(obj6))
-    {
-      Py_ssize_t safeLen = PyByteArray_Size(obj6);
-      arg12 = PyByteArray_AsString(obj6);
-      arg11 = (GIntBig) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
+    ok: ;
   }
   {
     if (!arg10) {
@@ -23806,7 +23830,10 @@ SWIGINTERN PyObject *_wrap_MDArray_Write(PyObject *SWIGUNUSEDPARM(self), PyObjec
   }
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if( alloc11 == SWIG_NEWOBJ ) {
+    if( viewIsValid11 ) {
+      PyBuffer_Release(&view11);
+    }
+    else if( alloc11 == SWIG_NEWOBJ ) {
       delete[] arg12;
     }
   }
@@ -23839,7 +23866,10 @@ fail:
   }
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if( alloc11 == SWIG_NEWOBJ ) {
+    if( viewIsValid11 ) {
+      PyBuffer_Release(&view11);
+    }
+    else if( alloc11 == SWIG_NEWOBJ ) {
       delete[] arg12;
     }
   }
@@ -24423,6 +24453,8 @@ SWIGINTERN PyObject *_wrap_MDArray_SetNoDataValueRaw(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   int alloc2 = 0 ;
+  bool viewIsValid2 = false ;
+  Py_buffer view2 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   CPLErr result;
@@ -24435,6 +24467,19 @@ SWIGINTERN PyObject *_wrap_MDArray_SetNoDataValueRaw(PyObject *SWIGUNUSEDPARM(se
   arg1 = reinterpret_cast< GDALMDArrayHS * >(argp1);
   {
     /* %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf ) */
+    {
+      if (PyObject_GetBuffer(obj1, &view2, PyBUF_SIMPLE) == 0)
+      {
+        viewIsValid2 = true;
+        arg2 = view2.len;
+        arg3 = (char *) view2.buf;
+        goto ok;
+      }
+      else
+      {
+        PyErr_Clear();
+      }
+    }
     if (PyUnicode_Check(obj1))
     {
       size_t safeLen = 0;
@@ -24446,23 +24491,12 @@ SWIGINTERN PyObject *_wrap_MDArray_SetNoDataValueRaw(PyObject *SWIGUNUSEDPARM(se
       if (safeLen) safeLen--;
       arg2 = (GIntBig) safeLen;
     }
-    else if (PyBytes_Check(obj1))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj1, (char**) &arg3, &safeLen);
-      arg2 = (GIntBig) safeLen;
-    }
-    else if (PyByteArray_Check(obj1))
-    {
-      Py_ssize_t safeLen = PyByteArray_Size(obj1);
-      arg3 = PyByteArray_AsString(obj1);
-      arg2 = (GIntBig) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
+    ok: ;
   }
   {
     if ( bUseExceptions ) {
@@ -24485,7 +24519,10 @@ SWIGINTERN PyObject *_wrap_MDArray_SetNoDataValueRaw(PyObject *SWIGUNUSEDPARM(se
   resultobj = SWIG_From_int(static_cast< int >(result));
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
+    if( viewIsValid2 ) {
+      PyBuffer_Release(&view2);
+    }
+    else if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
       delete[] arg3;
     }
   }
@@ -24494,7 +24531,10 @@ SWIGINTERN PyObject *_wrap_MDArray_SetNoDataValueRaw(PyObject *SWIGUNUSEDPARM(se
 fail:
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
+    if( viewIsValid2 ) {
+      PyBuffer_Release(&view2);
+    }
+    else if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
       delete[] arg3;
     }
   }
@@ -26301,6 +26341,8 @@ SWIGINTERN PyObject *_wrap_Attribute_WriteRaw(PyObject *SWIGUNUSEDPARM(self), Py
   void *argp1 = 0 ;
   int res1 = 0 ;
   int alloc2 = 0 ;
+  bool viewIsValid2 = false ;
+  Py_buffer view2 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   CPLErr result;
@@ -26313,6 +26355,19 @@ SWIGINTERN PyObject *_wrap_Attribute_WriteRaw(PyObject *SWIGUNUSEDPARM(self), Py
   arg1 = reinterpret_cast< GDALAttributeHS * >(argp1);
   {
     /* %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf ) */
+    {
+      if (PyObject_GetBuffer(obj1, &view2, PyBUF_SIMPLE) == 0)
+      {
+        viewIsValid2 = true;
+        arg2 = view2.len;
+        arg3 = (char *) view2.buf;
+        goto ok;
+      }
+      else
+      {
+        PyErr_Clear();
+      }
+    }
     if (PyUnicode_Check(obj1))
     {
       size_t safeLen = 0;
@@ -26324,23 +26379,12 @@ SWIGINTERN PyObject *_wrap_Attribute_WriteRaw(PyObject *SWIGUNUSEDPARM(self), Py
       if (safeLen) safeLen--;
       arg2 = (GIntBig) safeLen;
     }
-    else if (PyBytes_Check(obj1))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj1, (char**) &arg3, &safeLen);
-      arg2 = (GIntBig) safeLen;
-    }
-    else if (PyByteArray_Check(obj1))
-    {
-      Py_ssize_t safeLen = PyByteArray_Size(obj1);
-      arg3 = PyByteArray_AsString(obj1);
-      arg2 = (GIntBig) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
+    ok: ;
   }
   {
     if ( bUseExceptions ) {
@@ -26363,7 +26407,10 @@ SWIGINTERN PyObject *_wrap_Attribute_WriteRaw(PyObject *SWIGUNUSEDPARM(self), Py
   resultobj = SWIG_From_int(static_cast< int >(result));
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
+    if( viewIsValid2 ) {
+      PyBuffer_Release(&view2);
+    }
+    else if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
       delete[] arg3;
     }
   }
@@ -26372,7 +26419,10 @@ SWIGINTERN PyObject *_wrap_Attribute_WriteRaw(PyObject *SWIGUNUSEDPARM(self), Py
 fail:
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
+    if( viewIsValid2 ) {
+      PyBuffer_Release(&view2);
+    }
+    else if (ReturnSame(alloc2) == SWIG_NEWOBJ ) {
       delete[] arg3;
     }
   }
@@ -29796,6 +29846,8 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
   int val5 ;
   int ecode5 = 0 ;
   int alloc6 = 0 ;
+  bool viewIsValid6 = false ;
+  Py_buffer view6 ;
   int val8 ;
   int val9 ;
   int val10 ;
@@ -29845,6 +29897,19 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
   arg5 = static_cast< int >(val5);
   {
     /* %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf ) */
+    {
+      if (PyObject_GetBuffer(obj5, &view6, PyBUF_SIMPLE) == 0)
+      {
+        viewIsValid6 = true;
+        arg6 = view6.len;
+        arg7 = (char *) view6.buf;
+        goto ok;
+      }
+      else
+      {
+        PyErr_Clear();
+      }
+    }
     if (PyUnicode_Check(obj5))
     {
       size_t safeLen = 0;
@@ -29856,23 +29921,12 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
       if (safeLen) safeLen--;
       arg6 = (GIntBig) safeLen;
     }
-    else if (PyBytes_Check(obj5))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj5, (char**) &arg7, &safeLen);
-      arg6 = (GIntBig) safeLen;
-    }
-    else if (PyByteArray_Check(obj5))
-    {
-      Py_ssize_t safeLen = PyByteArray_Size(obj5);
-      arg7 = PyByteArray_AsString(obj5);
-      arg6 = (GIntBig) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
+    ok: ;
   }
   if (obj6) {
     {
@@ -29970,7 +30024,10 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
   resultobj = SWIG_From_int(static_cast< int >(result));
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
+    if( viewIsValid6 ) {
+      PyBuffer_Release(&view6);
+    }
+    else if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
       delete[] arg7;
     }
   }
@@ -29979,7 +30036,10 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
 fail:
   {
     /* %typemap(freearg) (GIntBig *nLen, char *pBuf ) */
-    if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
+    if( viewIsValid6 ) {
+      PyBuffer_Release(&view6);
+    }
+    else if (ReturnSame(alloc6) == SWIG_NEWOBJ ) {
       delete[] arg7;
     }
   }

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -4200,10 +4200,10 @@ const char *wrapper_CPLGetConfigOption( const char * pszKey, const char * pszDef
 }
 
 
-void wrapper_VSIFileFromMemBuffer( const char* utf8_path, GIntBig nBytes, const GByte *pabyData)
+void wrapper_VSIFileFromMemBuffer( const char* utf8_path, GIntBig nBytes, const char *pabyData)
 {
     const size_t nSize = static_cast<size_t>(nBytes);
-    GByte* pabyDataDup = (GByte*)VSIMalloc(nSize);
+    void* pabyDataDup = VSIMalloc(nSize);
     if (pabyDataDup == NULL)
             return;
     memcpy(pabyDataDup, pabyData, nSize);
@@ -10497,7 +10497,7 @@ SWIGINTERN PyObject *_wrap_FileFromMemBuffer(PyObject *SWIGUNUSEDPARM(self), PyO
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   char *arg1 = (char *) 0 ;
   GIntBig arg2 ;
-  GByte *arg3 = (GByte *) 0 ;
+  char *arg3 = (char *) 0 ;
   int bToFree1 = 0 ;
   int alloc2 = 0 ;
   PyObject * obj0 = 0 ;
@@ -10532,9 +10532,15 @@ SWIGINTERN PyObject *_wrap_FileFromMemBuffer(PyObject *SWIGUNUSEDPARM(self), PyO
       PyBytes_AsStringAndSize(obj1, (char**) &arg3, &safeLen);
       arg2 = (GIntBig) safeLen;
     }
+    else if (PyByteArray_Check(obj1))
+    {
+      Py_ssize_t safeLen = PyByteArray_Size(obj1);
+      arg3 = PyByteArray_AsString(obj1);
+      arg2 = (GIntBig) safeLen;
+    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
       SWIG_fail;
     }
   }
@@ -10549,7 +10555,7 @@ SWIGINTERN PyObject *_wrap_FileFromMemBuffer(PyObject *SWIGUNUSEDPARM(self), PyO
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      wrapper_VSIFileFromMemBuffer((char const *)arg1,arg2,(GByte const *)arg3);
+      wrapper_VSIFileFromMemBuffer((char const *)arg1,arg2,(char const *)arg3);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -18653,9 +18659,15 @@ SWIGINTERN PyObject *_wrap_Dataset_WriteRaster(PyObject *SWIGUNUSEDPARM(self), P
       PyBytes_AsStringAndSize(obj5, (char**) &arg7, &safeLen);
       arg6 = (GIntBig) safeLen;
     }
+    else if (PyByteArray_Check(obj5))
+    {
+      Py_ssize_t safeLen = PyByteArray_Size(obj5);
+      arg7 = PyByteArray_AsString(obj5);
+      arg6 = (GIntBig) safeLen;
+    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
       SWIG_fail;
     }
   }
@@ -23806,9 +23818,15 @@ SWIGINTERN PyObject *_wrap_MDArray_Write(PyObject *SWIGUNUSEDPARM(self), PyObjec
       PyBytes_AsStringAndSize(obj6, (char**) &arg12, &safeLen);
       arg11 = (GIntBig) safeLen;
     }
+    else if (PyByteArray_Check(obj6))
+    {
+      Py_ssize_t safeLen = PyByteArray_Size(obj6);
+      arg12 = PyByteArray_AsString(obj6);
+      arg11 = (GIntBig) safeLen;
+    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
       SWIG_fail;
     }
   }
@@ -24508,9 +24526,15 @@ SWIGINTERN PyObject *_wrap_MDArray_SetNoDataValueRaw(PyObject *SWIGUNUSEDPARM(se
       PyBytes_AsStringAndSize(obj1, (char**) &arg3, &safeLen);
       arg2 = (GIntBig) safeLen;
     }
+    else if (PyByteArray_Check(obj1))
+    {
+      Py_ssize_t safeLen = PyByteArray_Size(obj1);
+      arg3 = PyByteArray_AsString(obj1);
+      arg2 = (GIntBig) safeLen;
+    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
       SWIG_fail;
     }
   }
@@ -26380,9 +26404,15 @@ SWIGINTERN PyObject *_wrap_Attribute_WriteRaw(PyObject *SWIGUNUSEDPARM(self), Py
       PyBytes_AsStringAndSize(obj1, (char**) &arg3, &safeLen);
       arg2 = (GIntBig) safeLen;
     }
+    else if (PyByteArray_Check(obj1))
+    {
+      Py_ssize_t safeLen = PyByteArray_Size(obj1);
+      arg3 = PyByteArray_AsString(obj1);
+      arg2 = (GIntBig) safeLen;
+    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
       SWIG_fail;
     }
   }
@@ -29906,9 +29936,15 @@ SWIGINTERN PyObject *_wrap_Band_WriteRaster(PyObject *SWIGUNUSEDPARM(self), PyOb
       PyBytes_AsStringAndSize(obj5, (char**) &arg7, &safeLen);
       arg6 = (GIntBig) safeLen;
     }
+    else if (PyByteArray_Check(obj5))
+    {
+      Py_ssize_t safeLen = PyByteArray_Size(obj5);
+      arg7 = PyByteArray_AsString(obj5);
+      arg6 = (GIntBig) safeLen;
+    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes or bytearray");
       SWIG_fail;
     }
   }

--- a/gdal/swig/python/extensions/ogr_wrap.cpp
+++ b/gdal/swig/python/extensions/ogr_wrap.cpp
@@ -21293,18 +21293,9 @@ SWIGINTERN PyObject *_wrap_CreateGeometryFromWkb(PyObject *SWIGUNUSEDPARM(self),
       }
       arg1 = (int) safeLen;
     }
-    else if (PyBytes_Check(obj0))
-    {
-      Py_ssize_t safeLen = 0;
-      PyBytes_AsStringAndSize(obj0, (char**) &arg2, &safeLen);
-      if( safeLen > INT_MAX ) {
-        SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-      }
-      arg1 = (int) safeLen;
-    }
     else
     {
-      PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+      PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
       SWIG_fail;
     }
     ok: ;
@@ -22121,18 +22112,9 @@ SWIGINTERN PyObject *_wrap_new_Geometry(PyObject *SWIGUNUSEDPARM(self), PyObject
         }
         arg3 = (int) safeLen;
       }
-      else if (PyBytes_Check(obj2))
-      {
-        Py_ssize_t safeLen = 0;
-        PyBytes_AsStringAndSize(obj2, (char**) &arg4, &safeLen);
-        if( safeLen > INT_MAX ) {
-          SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-        }
-        arg3 = (int) safeLen;
-      }
       else
       {
-        PyErr_SetString(PyExc_TypeError, "not a unicode string or a bytes");
+        PyErr_SetString(PyExc_TypeError, "not a unicode string, bytes, bytearray or memoryview");
         SWIG_fail;
       }
       ok: ;

--- a/gdal/swig/python/extensions/ogr_wrap.cpp
+++ b/gdal/swig/python/extensions/ogr_wrap.cpp
@@ -15041,7 +15041,7 @@ SWIGINTERN PyObject *_wrap_Feature_GetFieldAsBinary__SWIG_0(PyObject *SWIGUNUSED
   {
     /* %typemap(argout) (int *nLen, char **pBuf ) */
     Py_XDECREF(resultobj);
-    resultobj = PyBytes_FromStringAndSize( *arg4, *arg3 );
+    resultobj = PyByteArray_FromStringAndSize( *arg4, *arg3 );
   }
   {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */
@@ -15135,7 +15135,7 @@ SWIGINTERN PyObject *_wrap_Feature_GetFieldAsBinary__SWIG_1(PyObject *SWIGUNUSED
   {
     /* %typemap(argout) (int *nLen, char **pBuf ) */
     Py_XDECREF(resultobj);
-    resultobj = PyBytes_FromStringAndSize( *arg4, *arg3 );
+    resultobj = PyByteArray_FromStringAndSize( *arg4, *arg3 );
   }
   {
     /* %typemap(freearg) (const char *utf8_path) */
@@ -22412,7 +22412,7 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToWkb(PyObject *SWIGUNUSEDPARM(self), 
   {
     /* %typemap(argout) (int *nLen, char **pBuf ) */
     Py_XDECREF(resultobj);
-    resultobj = PyBytes_FromStringAndSize( *arg3, *arg2 );
+    resultobj = PyByteArray_FromStringAndSize( *arg3, *arg2 );
   }
   {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */
@@ -22508,7 +22508,7 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToIsoWkb(PyObject *SWIGUNUSEDPARM(self
   {
     /* %typemap(argout) (int *nLen, char **pBuf ) */
     Py_XDECREF(resultobj);
-    resultobj = PyBytes_FromStringAndSize( *arg3, *arg2 );
+    resultobj = PyByteArray_FromStringAndSize( *arg3, *arg2 );
   }
   {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -2473,7 +2473,7 @@ class Dataset(MajorObject):
 
 
     def ReadRaster1(self, *args, **kwargs):
-        """ReadRaster1(Dataset self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, int band_list=0, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GIntBig * buf_band_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None) -> CPLErr"""
+        """ReadRaster1(Dataset self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, int band_list=0, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GIntBig * buf_band_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"""
         return _gdal.Dataset_ReadRaster1(self, *args, **kwargs)
 
 
@@ -2523,7 +2523,8 @@ class Dataset(MajorObject):
                    buf_pixel_space=None, buf_line_space=None, buf_band_space=None,
                    resample_alg=gdalconst.GRIORA_NearestNeighbour,
                    callback=None,
-                   callback_data=None):
+                   callback_data=None,
+                   buf_obj=None):
 
         if xsize is None:
             xsize = self.RasterXSize
@@ -2542,7 +2543,7 @@ class Dataset(MajorObject):
         return _gdal.Dataset_ReadRaster1(self, xoff, yoff, xsize, ysize,
                                             buf_xsize, buf_ysize, buf_type,
                                             band_list, buf_pixel_space, buf_line_space, buf_band_space,
-                                          resample_alg, callback, callback_data )
+                                          resample_alg, callback, callback_data, buf_obj )
 
     def GetVirtualMemArray(self, eAccess=gdalconst.GF_Read, xoff=0, yoff=0,
                            xsize=None, ysize=None, bufxsize=None, bufysize=None,
@@ -3806,12 +3807,12 @@ class Band(MajorObject):
 
 
     def ReadRaster1(self, *args, **kwargs):
-        """ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, int * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None) -> CPLErr"""
+        """ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, int * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"""
         return _gdal.Band_ReadRaster1(self, *args, **kwargs)
 
 
     def ReadBlock(self, *args, **kwargs):
-        """ReadBlock(Band self, int xoff, int yoff) -> CPLErr"""
+        """ReadBlock(Band self, int xoff, int yoff, void * buf_obj=None) -> CPLErr"""
         return _gdal.Band_ReadBlock(self, *args, **kwargs)
 
 
@@ -3838,7 +3839,8 @@ class Band(MajorObject):
                    buf_pixel_space=None, buf_line_space=None,
                    resample_alg=gdalconst.GRIORA_NearestNeighbour,
                    callback=None,
-                   callback_data=None):
+                   callback_data=None,
+                   buf_obj=None):
 
         if xsize is None:
             xsize = self.XSize
@@ -3848,7 +3850,8 @@ class Band(MajorObject):
         return _gdal.Band_ReadRaster1(self, xoff, yoff, xsize, ysize,
                                       buf_xsize, buf_ysize, buf_type,
                                       buf_pixel_space, buf_line_space,
-                                      resample_alg, callback, callback_data)
+                                      resample_alg, callback, callback_data,
+                                      buf_obj)
 
     def ReadAsArray(self, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
                     buf_xsize=None, buf_ysize=None, buf_type=None, buf_obj=None,

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -2497,6 +2497,21 @@ class Dataset(MajorObject):
                                               interleave=interleave,
                                               band_list=band_list)
 
+    def WriteArray(self, array, xoff=0, yoff=0,
+                   band_list=None,
+                   interleave='band',
+                   resample_alg=gdalconst.GRIORA_NearestNeighbour,
+                   callback=None,
+                   callback_data=None):
+        from osgeo import gdal_array
+
+        return gdal_array.DatasetWriteArray(self, array, xoff, yoff,
+                                            band_list=band_list,
+                                            interleave=interleave,
+                                            resample_alg=resample_alg,
+                                            callback=callback,
+                                            callback_data=callback_data)
+
     def WriteRaster(self, xoff, yoff, xsize, ysize,
                     buf_string,
                     buf_xsize=None, buf_ysize=None, buf_type=None,

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -2483,7 +2483,8 @@ class Dataset(MajorObject):
                     resample_alg=gdalconst.GRIORA_NearestNeighbour,
                     callback=None,
                     callback_data=None,
-                    interleave='band'):
+                    interleave='band',
+                    band_list=None):
         """ Reading a chunk of a GDAL band into a numpy array. The optional (buf_xsize,buf_ysize,buf_type)
         parameters should generally not be specified if buf_obj is specified. The array is returned"""
 
@@ -2493,7 +2494,8 @@ class Dataset(MajorObject):
                                               resample_alg=resample_alg,
                                               callback=callback,
                                               callback_data=callback_data,
-                                              interleave=interleave )
+                                              interleave=interleave,
+                                              band_list=band_list)
 
     def WriteRaster(self, xoff, yoff, xsize, ysize,
                     buf_string,

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -2524,6 +2524,14 @@ class Dataset(MajorObject):
             buf_ysize = ysize
         if band_list is None:
             band_list = list(range(1, self.RasterCount + 1))
+
+    # Redirect to numpy-friendly WriteArray() if buf_string is a numpy array
+    # and other arguments are compatible
+        if type(buf_string).__name__ == 'ndarray' and \
+           buf_xsize == xsize and buf_ysize == ysize and buf_type is None and \
+           buf_pixel_space is None and buf_line_space is None and buf_band_space is None:
+            return self.WriteArray(buf_string, xoff=xoff, yoff=yoff,
+                                   band_list=band_list)
         if buf_type is None:
             buf_type = self.GetRasterBand(1).DataType
 
@@ -3867,6 +3875,31 @@ class Band(MajorObject):
                                       buf_pixel_space, buf_line_space,
                                       resample_alg, callback, callback_data,
                                       buf_obj)
+
+    def WriteRaster(self, xoff, yoff, xsize, ysize,
+                    buf_string,
+                    buf_xsize=None, buf_ysize=None, buf_type=None,
+                    buf_pixel_space=None, buf_line_space=None ):
+
+        if buf_xsize is None:
+            buf_xsize = xsize
+        if buf_ysize is None:
+            buf_ysize = ysize
+
+    # Redirect to numpy-friendly WriteArray() if buf_string is a numpy array
+    # and other arguments are compatible
+        if type(buf_string).__name__ == 'ndarray' and \
+           buf_xsize == xsize and buf_ysize == ysize and buf_type is None and \
+           buf_pixel_space is None and buf_line_space is None:
+            return self.WriteArray(buf_string, xoff=xoff, yoff=yoff)
+
+        if buf_type is None:
+            buf_type = self.DataType
+
+        return _gdal.Band_WriteRaster(self,
+                 xoff, yoff, xsize, ysize,
+                buf_string, buf_xsize, buf_ysize, buf_type,
+                buf_pixel_space, buf_line_space )
 
     def ReadAsArray(self, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
                     buf_xsize=None, buf_ysize=None, buf_type=None, buf_obj=None,

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -3692,7 +3692,7 @@ class Band(MajorObject):
 
 
     def WriteRaster(self, *args, **kwargs):
-        """WriteRaster(Band self, int xoff, int yoff, int xsize, int ysize, GIntBig buf_len, int * buf_xsize=None, int * buf_ysize=None, int * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None) -> CPLErr"""
+        """WriteRaster(Band self, int xoff, int yoff, int xsize, int ysize, GIntBig buf_len, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None) -> CPLErr"""
         return _gdal.Band_WriteRaster(self, *args, **kwargs)
 
 
@@ -3807,7 +3807,7 @@ class Band(MajorObject):
 
 
     def ReadRaster1(self, *args, **kwargs):
-        """ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, int * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"""
+        """ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"""
         return _gdal.Band_ReadRaster1(self, *args, **kwargs)
 
 

--- a/gdal/swig/python/osgeo/gdal_array.py
+++ b/gdal/swig/python/osgeo/gdal_array.py
@@ -470,10 +470,15 @@ def BandReadAsArray(band, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
         buf_obj = numpy.empty([buf_ysize, buf_xsize], dtype=typecode)
 
     else:
+        if len(buf_obj.shape) not in (2, 3):
+            raise ValueError("expected array of dimension 2 or 3")
+
         if len(buf_obj.shape) == 2:
             shape_buf_xsize = buf_obj.shape[1]
             shape_buf_ysize = buf_obj.shape[0]
         else:
+            if buf_obj.shape[0] != 1:
+                raise ValueError("expected size of first dimension should be 0")
             shape_buf_xsize = buf_obj.shape[2]
             shape_buf_ysize = buf_obj.shape[1]
         if buf_xsize is not None and buf_xsize != shape_buf_xsize:

--- a/gdal/swig/python/osgeo/gdal_array.py
+++ b/gdal/swig/python/osgeo/gdal_array.py
@@ -155,11 +155,11 @@ def GetArrayFilename(psArray):
     return _gdal_array.GetArrayFilename(psArray)
 
 def BandRasterIONumPy(band, bWrite, xoff, yoff, xsize, ysize, psArray, buf_type, resample_alg, callback=0, callback_data=None):
-    """BandRasterIONumPy(Band band, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, int buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None) -> CPLErr"""
+    """BandRasterIONumPy(Band band, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, GDALDataType buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None) -> CPLErr"""
     return _gdal_array.BandRasterIONumPy(band, bWrite, xoff, yoff, xsize, ysize, psArray, buf_type, resample_alg, callback, callback_data)
 
 def DatasetIONumPy(ds, bWrite, xoff, yoff, xsize, ysize, psArray, buf_type, resample_alg, callback=0, callback_data=None, binterleave=True, band_list=0):
-    """DatasetIONumPy(Dataset ds, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, int buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, bool binterleave=True, int band_list=0) -> CPLErr"""
+    """DatasetIONumPy(Dataset ds, int bWrite, double xoff, double yoff, double xsize, double ysize, PyArrayObject * psArray, GDALDataType buf_type, GDALRIOResampleAlg resample_alg, GDALProgressFunc callback=0, void * callback_data=None, bool binterleave=True, int band_list=0) -> CPLErr"""
     return _gdal_array.DatasetIONumPy(ds, bWrite, xoff, yoff, xsize, ysize, psArray, buf_type, resample_alg, callback, callback_data, binterleave, band_list)
 
 def MDArrayIONumPy(bWrite, mdarray, psArray, nDims1, nDims3, buffer_datatype):


### PR DESCRIPTION
Several improvements:
- accept any memoryview (includes bytes, bytearray objects) as input of WriteRaster()
- return a bytearray object as output of ReadRaster() (and if passing buf_obj, accept a writeable memoryview)
- add buf_obj argument to ReadRaster()
- add band_list argument to Dataset.ReadAsArray()
- add Dataset.WriteArray()
- improve input value validation in typemaps for GDALRioResampleAlg and GDALDataType