### PR TITLE
OGR: Avoid SWIG generating exception on OGRGeometry::isValid

### DIFF
--- a/autotest/ogr/ogr_geos.py
+++ b/autotest/ogr/ogr_geos.py
@@ -457,6 +457,20 @@ def test_ogr_geos_isvalid_false():
 
     assert isring == 0
 
+
+###############################################################################
+
+
+def test_ogr_geos_isvalid_false_too_few_points():
+    g1 = ogr.CreateGeometryFromWkt('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 3 2, 2 2))')
+
+    with ogrtest.enable_exceptions():  # fail test if exception is thrown
+        with gdaltest.error_handler():
+            isvalid = g1.IsValid()
+
+    assert isvalid == 0
+
+
 ###############################################################################
 
 

--- a/autotest/pymod/ogrtest.py
+++ b/autotest/pymod/ogrtest.py
@@ -24,6 +24,7 @@
 # Boston, MA 02111-1307, USA.
 ###############################################################################
 
+import contextlib
 import sys
 import pytest
 
@@ -189,7 +190,25 @@ def compare_layers(lyr, lyr_ref, excluded_fields=None):
         pytest.fail()
 
 ###############################################################################
+# Temporarily enable exceptions
 
+
+@contextlib.contextmanager
+def enable_exceptions():
+    if ogr.GetUseExceptions():
+        try:
+            yield
+        finally:
+            pass
+        return
+
+    ogr.UseExceptions()
+    try:
+        yield
+    finally:
+        ogr.DontUseExceptions()
+
+###############################################################################
 
 def get_wkt_data_series(with_z, with_m, with_gc, with_circular, with_surface):
     basic_wkts = [

--- a/gdal/ogr/ogrgeometry.cpp
+++ b/gdal/ogr/ogrgeometry.cpp
@@ -2149,7 +2149,13 @@ OGRGeometry::IsValid() const
 #else
         OGRBoolean bResult = FALSE;
 
-        GEOSContextHandle_t hGEOSCtxt = createGEOSContext();
+        // Some invalid geometries, such as lines with one point, or
+        // rings that do not close, cannot be converted to GEOS.
+        // For validity checking we initialize the GEOS context with
+        // the warning handler as the error handler to avoid emitting
+        // CE_Failure when a geometry cannot be converted to GEOS.
+        GEOSContextHandle_t hGEOSCtxt = initGEOS_r( OGRGEOSWarningHandler, OGRGEOSWarningHandler );
+
         GEOSGeom hThisGeosGeom = exportToGEOS(hGEOSCtxt);
 
         if( hThisGeosGeom != nullptr  )


### PR DESCRIPTION
## What does this PR do?

Avoid throwing an exception for certain invalid geometries when calling `OGRGeometry::IsValid` from SWIG bindings.

## What are related issues/pull requests?

#3578

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed


