### PR TITLE
FlatGeoBuf: fix crash in GetFileList() on a dataset opened in update mode

### DIFF
--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
@@ -304,7 +304,7 @@ GDALDataset *OGRFlatGeobufDataset::Create( const char *pszName,
 OGRLayer *OGRFlatGeobufDataset::GetLayer( int iLayer ) {
     if( iLayer < 0 || iLayer >= GetLayerCount() )
         return nullptr;
-    return m_apoLayers[iLayer].get();
+    return m_apoLayers[iLayer]->GetLayer();
 }
 
 int OGRFlatGeobufDataset::TestCapability(const char *pszCap)
@@ -389,29 +389,19 @@ OGRLayer* OGRFlatGeobufDataset::ICreateLayer( const char *pszLayerName,
 
     m_apoLayers.push_back(std::move(poLayer));
 
-    return m_apoLayers.back().get();
+    return m_apoLayers.back()->GetLayer();
 }
 
 /************************************************************************/
 //                            GetFileList()                             */
 /************************************************************************/
 
-template<typename Base, typename T>
-inline bool instanceof(const T*) {
-   return std::is_base_of<Base, T>::value;
-}
-
 char** OGRFlatGeobufDataset::GetFileList()
 {
     CPLStringList oFileList;
     for( const auto& poLayer: m_apoLayers )
     {
-        std::string filename;
-        if (instanceof<OGRFlatGeobufEditableLayer>(poLayer.get()))
-            filename = dynamic_cast<OGRFlatGeobufEditableLayer *>(poLayer.get())->GetFilename();
-        else
-            filename = dynamic_cast<OGRFlatGeobufLayer *>(poLayer.get())->GetFilename();
-        oFileList.AddString( filename.c_str() );
+        oFileList.AddString( poLayer->GetFilename().c_str() );
     }
     return oFileList.StealList();
 }

--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -1456,3 +1456,5 @@ OGRFlatGeobufLayer *OGRFlatGeobufLayer::Open(const char* pszFilename, VSILFILE* 
 
     return poLayer;
 }
+
+OGRFlatGeobufBaseLayerInterface::~OGRFlatGeobufBaseLayerInterface() = default;


### PR DESCRIPTION
Issue hinted by clang static analyzer.
Note to @bjornharrtell : you can't use std::is_base_of<> as a way of determining at run-time if an object can be dynamically cast to some type. std::is_base_of<> is a mechanism operating only on types (at compilation time), and not instances.