### PR TITLE
fixed windows build error where variables declared in switch must be …

### DIFF
--- a/gdal/frmts/sdts/sdts2shp.cpp
+++ b/gdal/frmts/sdts/sdts2shp.cpp
@@ -788,36 +788,41 @@ WriteAttrRecordToDBF( DBFHandle hDBF, int iRecord,
 /* -------------------------------------------------------------------- */
 /*      Handle each of the types.                                       */
 /* -------------------------------------------------------------------- */
-        switch( poSFDefn->GetType() )
+        switch (poSFDefn->GetType())
         {
-          case DDFString:
-            const char *pszValue
-                = poSFDefn->ExtractStringData(pachData, nMaxBytes, NULL);
+            case DDFString:
+            {
+                const char *pszValue = poSFDefn->ExtractStringData(pachData, nMaxBytes, NULL);
 
-            if( iField != -1 )
-                DBFWriteStringAttribute(hDBF, iRecord, iField, pszValue );
+                if (iField != -1)
+                    DBFWriteStringAttribute(hDBF, iRecord, iField, pszValue);
+            }
+        break;
+
+        case DDFFloat:
+            {
+                double dfValue;
+
+                dfValue = poSFDefn->ExtractFloatData(pachData, nMaxBytes,
+                                                     NULL);
+
+                if (iField != -1)
+                    DBFWriteDoubleAttribute(hDBF, iRecord, iField, dfValue);
+            }
             break;
 
-          case DDFFloat:
-            double      dfValue;
+        case DDFInt:
+            {
+                int nValue;
 
-            dfValue = poSFDefn->ExtractFloatData(pachData, nMaxBytes,
-                                                 NULL);
+                nValue = poSFDefn->ExtractIntData(pachData, nMaxBytes, NULL);
 
-            if( iField != -1 )
-                DBFWriteDoubleAttribute( hDBF, iRecord, iField, dfValue );
+                if (iField != -1)
+                    DBFWriteIntegerAttribute(hDBF, iRecord, iField, nValue);
+            }
             break;
 
-          case DDFInt:
-            int         nValue;
-
-            nValue = poSFDefn->ExtractIntData(pachData, nMaxBytes, NULL);
-
-            if( iField != -1 )
-                DBFWriteIntegerAttribute( hDBF, iRecord, iField, nValue );
-            break;
-
-          default:
+        default:
             break;
         }
     } /* next subfield */


### PR DESCRIPTION
frmts/sdts/sdts2shp.cpp

PR to fix Windows build errors: C2360 & C23261 which are caused by uninitialized variables which are declared inside of switch case statements.

* OS: Windows 10
* Compiler: VS 2019 MSVC  v142
