### PR TITLE
OGRCoordinateTransformation / gdalwarp performance improvements

### DIFF
--- a/.github/workflows/fedora_rawhide/start.sh
+++ b/.github/workflows/fedora_rawhide/start.sh
@@ -67,13 +67,14 @@ rm -f "$WORK_DIR/ccache.tar.gz"
 
 export PYTEST="python3 -m pytest -vv -p no:sugar --color=no"
 
+projsync --system-directory --file us_noaa_conus.tif
+projsync --system-directory --file us_nga_egm96
+projsync --system-directory --file ca_nrc_ntv1_can.tif
+
 (cd autotest/cpp && make quick_test)
 
 # install pip and use it to install test dependencies
 pip3 install -U -r autotest/requirements.txt
-
-projsync --system-directory --file us_noaa_conus.tif
-projsync --system-directory --file us_nga_egm96
 
 (cd autotest && $PYTEST)
 

--- a/gdal/alg/gdaltransformer.cpp
+++ b/gdal/alg/gdaltransformer.cpp
@@ -2825,7 +2825,6 @@ void *GDALCreateReprojectionTransformerEx(
     const char* pszCO = CSLFetchNameValue(papszOptions, "COORDINATE_OPERATION");
 
     OGRCoordinateTransformationOptions optionsFwd;
-    OGRCoordinateTransformationOptions optionsInv;
     if( !(dfWestLongitudeDeg == 0.0 && dfSouthLatitudeDeg == 0.0 &&
           dfEastLongitudeDeg == 0.0 && dfNorthLatitudeDeg == 0.0) )
     {
@@ -2833,22 +2832,16 @@ void *GDALCreateReprojectionTransformerEx(
                                   dfSouthLatitudeDeg,
                                   dfEastLongitudeDeg,
                                   dfNorthLatitudeDeg);
-        optionsInv.SetAreaOfInterest(dfWestLongitudeDeg,
-                                  dfSouthLatitudeDeg,
-                                  dfEastLongitudeDeg,
-                                  dfNorthLatitudeDeg);
     }
     if( pszCO )
     {
         optionsFwd.SetCoordinateOperation(pszCO, false);
-        optionsInv.SetCoordinateOperation(pszCO, true);
     }
 
     const char* pszCENTER_LONG = CSLFetchNameValue(papszOptions, "CENTER_LONG");
     if( pszCENTER_LONG )
     {
         optionsFwd.SetSourceCenterLong(CPLAtof(pszCENTER_LONG));
-        optionsInv.SetTargetCenterLong(CPLAtof(pszCENTER_LONG));
     }
 
     OGRCoordinateTransformation *poForwardTransform =
@@ -2871,10 +2864,7 @@ void *GDALCreateReprojectionTransformerEx(
     psInfo->poForwardTransform = poForwardTransform;
     psInfo->dfTime = CPLAtof(CSLFetchNameValueDef(papszOptions,
                                                   "COORDINATE_EPOCH", "0"));
-    CPLPushErrorHandler(CPLQuietErrorHandler);
-    psInfo->poReverseTransform =
-        OGRCreateCoordinateTransformation(poDstSRS, poSrcSRS, optionsInv);
-    CPLPopErrorHandler();
+    psInfo->poReverseTransform = poForwardTransform->GetInverse();
 
     if( psInfo->poReverseTransform )
         psInfo->poReverseTransform->SetEmitErrors(false);

--- a/gdal/alg/gdaltransformer.cpp
+++ b/gdal/alg/gdaltransformer.cpp
@@ -1284,7 +1284,7 @@ bool GDALComputeAreaOfInterest(OGRSpatialReference* poSRS,
                 dfEastLongitudeDeg = 0;
                 dfNorthLatitudeDeg = 0;
             }
-            delete poCT;
+            OGRCoordinateTransformation::DestroyCT(poCT);
         }
 
         delete poGeog;
@@ -2923,10 +2923,10 @@ void GDALDestroyReprojectionTransformer( void *pTransformArg )
         static_cast<GDALReprojectionTransformInfo *>(pTransformArg);
 
     if( psInfo->poForwardTransform )
-        delete psInfo->poForwardTransform;
+        OGRCoordinateTransformation::DestroyCT(psInfo->poForwardTransform);
 
     if( psInfo->poReverseTransform )
-        delete psInfo->poReverseTransform;
+        OGRCoordinateTransformation::DestroyCT(psInfo->poReverseTransform);
 
     CSLDestroy( psInfo->papszOptions );
 

--- a/gdal/apps/gdalwarp_bin.cpp
+++ b/gdal/apps/gdalwarp_bin.cpp
@@ -156,6 +156,7 @@ MAIN_START(argc, argv)
     int nSrcCount = 0;
 
     EarlySetConfigOptions(argc, argv);
+    CPLDebugOnly("GDAL", "Start");
 
 /* -------------------------------------------------------------------- */
 /*      Register standard GDAL drivers, and process generic GDAL        */

--- a/gdal/apps/gdalwarp_lib.cpp
+++ b/gdal/apps/gdalwarp_lib.cpp
@@ -3680,6 +3680,8 @@ public:
         return new CutlineTransformer(
             GDALCloneTransformer(hSrcImageTransformer));
     }
+
+    virtual OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
 };
 
 static

--- a/gdal/apps/ogr2ogr_lib.cpp
+++ b/gdal/apps/ogr2ogr_lib.cpp
@@ -1007,6 +1007,8 @@ public:
             return GDALGCPTransform( hTransformArg, FALSE,
                                  nCount, x, y, z, pabSuccess );
     }
+
+    virtual OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
 };
 
 /************************************************************************/
@@ -1074,6 +1076,8 @@ public:
             nResult = poCT2->Transform(nCount, x, y, z, t, pabSuccess);
         return nResult;
     }
+
+    virtual OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
 };
 
 /************************************************************************/
@@ -1140,6 +1144,8 @@ public:
         }
         return true;
     }
+
+    virtual OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
 };
 
 /************************************************************************/

--- a/gdal/frmts/vrt/vrtwarped.cpp
+++ b/gdal/frmts/vrt/vrtwarped.cpp
@@ -327,7 +327,7 @@ GDALCreateWarpedVRT( GDALDatasetH hSrcDS,
     {
         int nDstBand = psOptions->panDstBands[i];
         while( poDS->GetRasterCount() < nDstBand )
-        {   
+        {
             poDS->AddBand( psOptions->eWorkingDataType, nullptr );
         }
 
@@ -592,6 +592,7 @@ public:
     virtual OGRCoordinateTransformation* Clone() const override {
         return new GDALWarpCoordRescaler(*this); }
 
+    virtual OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
 };
 
 /************************************************************************/
@@ -1534,7 +1535,7 @@ CPLXMLNode *VRTWarpedDataset::SerializeToXML( const char *pszVRTPathIn )
 /* -------------------------------------------------------------------- */
     for(size_t i = 0; i < m_aoVerticalShiftGrids.size(); ++i )
     {
-        CPLXMLNode* psVertShiftGridNode = 
+        CPLXMLNode* psVertShiftGridNode =
             CPLCreateXMLNode( psTree, CXT_Element, "VerticalShiftGrids" );
         CPLCreateXMLElementAndValue(psVertShiftGridNode,
                                     "Grids",
@@ -1658,7 +1659,7 @@ CPLErr VRTWarpedDataset::ProcessBlock( int iBlockX, int iBlockY )
 /* -------------------------------------------------------------------- */
 /*      Warp into this buffer.                                          */
 /* -------------------------------------------------------------------- */
-    
+
     const GDALWarpOptions *psWO = m_poWarper->GetOptions();
     const CPLErr eErr =
         m_poWarper->WarpRegionToBuffer(
@@ -1685,7 +1686,7 @@ CPLErr VRTWarpedDataset::ProcessBlock( int iBlockX, int iBlockY )
         GDALRasterBlock *poBlock
             = poBand->GetLockedBlockRef( iBlockX, iBlockY, TRUE );
 
-        const GByte* pabyDstBandBuffer = 
+        const GByte* pabyDstBandBuffer =
             pabyDstBuffer + static_cast<GPtrDiff_t>(i)*nReqXSize*nReqYSize*nWordSize;
 
         if( poBlock != nullptr )

--- a/gdal/gcore/gdaldrivermanager.cpp
+++ b/gdal/gcore/gdaldrivermanager.cpp
@@ -238,6 +238,12 @@ GDALDriverManager::~GDALDriverManager()
     PamCleanProxyDB();
 
 /* -------------------------------------------------------------------- */
+/*      Cleanup any memory allocated by the OGRSpatialReference         */
+/*      related subsystem.                                              */
+/* -------------------------------------------------------------------- */
+    OSRCleanup();
+
+/* -------------------------------------------------------------------- */
 /*      Blow away all the finder hints paths.  We really should not     */
 /*      be doing all of them, but it is currently hard to keep track    */
 /*      of those that actually belong to us.                            */
@@ -245,12 +251,6 @@ GDALDriverManager::~GDALDriverManager()
     CPLFinderClean();
     CPLFreeConfig();
     CPLCleanupSharedFileMutex();
-
-/* -------------------------------------------------------------------- */
-/*      Cleanup any memory allocated by the OGRSpatialReference         */
-/*      related subsystem.                                              */
-/* -------------------------------------------------------------------- */
-    OSRCleanup();
 
 #ifdef HAVE_XERCES
     OGRCleanupXercesMutex();

--- a/gdal/ogr/ogr_proj_p.h
+++ b/gdal/ogr/ogr_proj_p.h
@@ -95,6 +95,8 @@ OSRProjTLSCache* OSRGetProjTLSCache();
 
 void OGRCTDumpStatistics();
 
+void OSRCTCleanCache();
+
 /*! @endcond Doxygen_Suppress */
 
 #endif

--- a/gdal/ogr/ogr_proj_p.h
+++ b/gdal/ogr/ogr_proj_p.h
@@ -93,6 +93,8 @@ class OSRProjTLSCache
 
 OSRProjTLSCache* OSRGetProjTLSCache();
 
+void OGRCTDumpStatistics();
+
 /*! @endcond Doxygen_Suppress */
 
 #endif

--- a/gdal/ogr/ogr_spatialref.h
+++ b/gdal/ogr/ogr_spatialref.h
@@ -830,6 +830,17 @@ public:
      * @since GDAL 3.1
      */
     virtual OGRCoordinateTransformation* Clone() const = 0;
+
+    /** Return a coordinate transformation that performs the inverse transformation
+     * of the current one.
+     *
+     * In some cases, this is not possible, and this method might return nullptr,
+     * or fail to perform the transformations.
+     *
+     * @return the new coordinate transformation, or nullptr in case of error.
+     * @since GDAL 3.3
+     */
+    virtual OGRCoordinateTransformation* GetInverse() const = 0;
 };
 
 OGRCoordinateTransformation CPL_DLL *

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -36,9 +36,11 @@
 #include <cstring>
 #include <limits>
 #include <list>
+#include <mutex>
 
 #include "cpl_conv.h"
 #include "cpl_error.h"
+#include "cpl_mem_cache.h"
 #include "cpl_string.h"
 #include "ogr_core.h"
 #include "ogr_srs_api.h"
@@ -84,6 +86,21 @@ static void CPLGettimeofday(struct CPLTimeVal* tp, void* /* timezonep*/ )
 
 #endif // DEBUG_PERF
 
+// Cache of OGRProjCT objects
+static std::mutex g_oCTCacheMutex;
+class OGRProjCT;
+// We wrap a OGRProjCT in a shared_ptr<unique_ptr>, because we need a copyable
+// type to be inserted in the cache (shared_ptr), and we need to be able to
+// alter the content of the value to release() the unique_ptr value when we
+// find a value in it.
+// In a future improvement (notably to help for the multi-threaded warping),
+// we could let the cached value in the cache and clone it, but for now clone,
+// just instanciates a new OGRProjCT from scrach. The clone method should be
+// improved to do things similar to GetInverse().
+typedef std::string CTCacheKey;
+typedef std::shared_ptr<std::unique_ptr<OGRProjCT>> CTCacheValue;
+static lru11::Cache<CTCacheKey, CTCacheValue>* g_poCTCache = nullptr;
+
 /************************************************************************/
 /*             OGRCoordinateTransformationOptions::Private              */
 /************************************************************************/
@@ -107,7 +124,88 @@ struct OGRCoordinateTransformationOptions::Private
 
     bool bHasTargetCenterLong = false;
     double dfTargetCenterLong = 0.0;
+
+    bool bCheckWithInvertProj = false;
+
+    Private();
+    Private(const Private&) = default;
+    Private(Private&&) = default;
+    Private& operator=(const Private&) = default;
+    Private& operator=(Private&&) = default;
+
+    std::string GetKey() const;
+    void RefreshCheckWithInvertProj();
 };
+
+/************************************************************************/
+/*                              Private()                               */
+/************************************************************************/
+
+OGRCoordinateTransformationOptions::Private::Private()
+{
+    RefreshCheckWithInvertProj();
+}
+
+/************************************************************************/
+/*                              GetKey()                                */
+/************************************************************************/
+
+std::string OGRCoordinateTransformationOptions::Private::GetKey() const
+{
+    std::string ret;
+    ret += std::to_string(static_cast<int>(bHasAreaOfInterest));
+    ret += std::to_string(dfWestLongitudeDeg);
+    ret += std::to_string(dfSouthLatitudeDeg);
+    ret += std::to_string(dfEastLongitudeDeg);
+    ret += std::to_string(dfNorthLatitudeDeg);
+    ret += osCoordOperation;
+    ret += std::to_string(static_cast<int>(bReverseCO));
+    ret += std::to_string(static_cast<int>(bAllowBallpark));
+    ret += std::to_string(dfAccuracy);
+    ret += std::to_string(static_cast<int>(bHasSourceCenterLong));
+    ret += std::to_string(dfSourceCenterLong);
+    ret += std::to_string(static_cast<int>(bHasTargetCenterLong));
+    ret += std::to_string(dfTargetCenterLong);
+    ret += std::to_string(static_cast<int>(bCheckWithInvertProj));
+    return ret;
+}
+
+/************************************************************************/
+/*                       RefreshCheckWithInvertProj()                   */
+/************************************************************************/
+
+void OGRCoordinateTransformationOptions::Private::RefreshCheckWithInvertProj()
+{
+    bCheckWithInvertProj =
+        CPLTestBool(CPLGetConfigOption( "CHECK_WITH_INVERT_PROJ", "NO" ));
+}
+
+/************************************************************************/
+/*                          GetWktOrProjString()                        */
+/************************************************************************/
+
+static char* GetWktOrProjString(const OGRSpatialReference* poSRS)
+{
+    CPLErrorStateBackuper oErrorStateBackuper;
+    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+    const char* const apszOptionsWKT2_2018[] = { "FORMAT=WKT2_2018", nullptr };
+    // If there's a PROJ4 EXTENSION node in WKT1, then use
+    // it. For example when dealing with "+proj=longlat +lon_wrap=180"
+    char* pszText = nullptr;
+    if( poSRS->GetExtension(nullptr, "PROJ4", nullptr) )
+    {
+        poSRS->exportToProj4(&pszText);
+        if (strstr(pszText, " +type=crs") == nullptr )
+        {
+            auto tmpText = std::string(pszText) + " +type=crs";
+            CPLFree(pszText);
+            pszText = CPLStrdup(tmpText.c_str());
+        }
+    }
+    else
+        poSRS->exportToWkt(&pszText, apszOptionsWKT2_2018);
+    return pszText;
+}
 
 /************************************************************************/
 /*                  OGRCoordinateTransformationOptions()                */
@@ -444,7 +542,6 @@ class OGRProjCT : public OGRCoordinateTransformation
 
     int         nErrorCount = 0;
 
-    bool        bCheckWithInvertProj = false;
     double      dfThreshold = 0.0;
 
     PJ*         m_pj = nullptr;
@@ -522,6 +619,10 @@ class OGRProjCT : public OGRCoordinateTransformation
     }
     OGRProjCT& operator= (const OGRProjCT& ) = delete;
 
+    static CTCacheKey MakeCacheKey(const OGRSpatialReference* poSRS1,
+                           const OGRSpatialReference* poSRS2,
+                           const OGRCoordinateTransformationOptions& options);
+
 public:
     OGRProjCT();
     ~OGRProjCT() override;
@@ -550,6 +651,12 @@ public:
     }
 
     OGRCoordinateTransformation* GetInverse() const override;
+
+    static void InsertIntoCache( OGRProjCT* poCT );
+
+    static OGRProjCT* FindFromCache( const OGRSpatialReference *poSource,
+                                     const OGRSpatialReference *poTarget,
+                                     const OGRCoordinateTransformationOptions& options );
 };
 //! @endcond
 
@@ -569,7 +676,8 @@ void CPL_STDCALL
 OCTDestroyCoordinateTransformation( OGRCoordinateTransformationH hCT )
 
 {
-    delete OGRCoordinateTransformation::FromHandle(hCT);
+    OGRCoordinateTransformation::DestroyCT(
+        OGRCoordinateTransformation::FromHandle(hCT));
 }
 
 /************************************************************************/
@@ -595,7 +703,15 @@ OCTDestroyCoordinateTransformation( OGRCoordinateTransformationH hCT )
 
 void OGRCoordinateTransformation::DestroyCT( OGRCoordinateTransformation* poCT )
 {
-    delete poCT;
+    auto poProjCT = dynamic_cast<OGRProjCT*>(poCT);
+    if( poProjCT )
+    {
+        OGRProjCT::InsertIntoCache(poProjCT);
+    }
+    else
+    {
+        delete poCT;
+    }
 }
 
 /************************************************************************/
@@ -696,6 +812,11 @@ OGRCreateCoordinateTransformation( const OGRSpatialReference *poSource,
                                    const OGRCoordinateTransformationOptions& options )
 
 {
+    // Try to find if we have a match in the case
+    auto poCTFromCache = OGRProjCT::FindFromCache(poSource, poTarget, options);
+    if( poCTFromCache )
+        return poCTFromCache;
+
     OGRProjCT *poCT = new OGRProjCT();
 
     if( !poCT->Initialize( poSource, poTarget, options ) )
@@ -953,9 +1074,6 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
         CPLDebug( "OGRCT", "Wrap target at %g.", dfTargetWrapLong );
     }
 
-    bCheckWithInvertProj =
-        CPLTestBool(CPLGetConfigOption( "CHECK_WITH_INVERT_PROJ", "NO" ));
-
     ComputeThreshold();
 
     // Detect webmercator to WGS84
@@ -1142,23 +1260,7 @@ int OGRProjCT::Initialize( const OGRSpatialReference * poSourceIn,
             }
             if( pszText == nullptr )
             {
-                CPLErrorStateBackuper oErrorStateBackuper;
-                CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-                const char* const apszOptionsWKT2_2018[] = { "FORMAT=WKT2_2018", nullptr };
-                // If there's a PROJ4 EXTENSION node in WKT1, then use
-                // it. For example when dealing with "+proj=longlat +lon_wrap=180"
-                if( poSRS->GetExtension(nullptr, "PROJ4", nullptr) )
-                {
-                    poSRS->exportToProj4(&pszText);
-                    if (strstr(pszText, " +type=crs") == nullptr )
-                    {
-                        auto tmpText = std::string(pszText) + " +type=crs";
-                        CPLFree(pszText);
-                        pszText = CPLStrdup(tmpText.c_str());
-                    }
-                }
-                else
-                    poSRS->exportToWkt(&pszText, apszOptionsWKT2_2018);
+                pszText = GetWktOrProjString(poSRS);
             }
             return pszText;
         };
@@ -1877,7 +1979,7 @@ int OGRProjCT::TransformWithErrorCodes(
                     {
                         x[i] = M_PI;
                     }
-                    else if( bCheckWithInvertProj )
+                    else if( m_options.d->bCheckWithInvertProj )
                     {
                         x[i] = HUGE_VAL;
                         y[i] = HUGE_VAL;
@@ -1897,7 +1999,7 @@ int OGRProjCT::TransformWithErrorCodes(
                     {
                         x[i] = -M_PI;
                     }
-                    else if( bCheckWithInvertProj )
+                    else if( m_options.d->bCheckWithInvertProj )
                     {
                         x[i] = HUGE_VAL;
                         y[i] = HUGE_VAL;
@@ -2144,7 +2246,7 @@ int OGRProjCT::TransformWithErrorCodes(
                 if( err == 0 )
                     err = PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN;
             }
-            else if( bCheckWithInvertProj )
+            else if( m_options.d->bCheckWithInvertProj )
             {
                 // For some projections, we cannot detect if we are trying to reproject
                 // coordinates outside the validity area of the projection. So let's do
@@ -2317,6 +2419,7 @@ OGRCoordinateTransformation* OGRProjCT::GetInverse() const
     std::swap(newOptions.d->bHasSourceCenterLong, newOptions.d->bHasTargetCenterLong);
     std::swap(newOptions.d->dfSourceCenterLong, newOptions.d->dfTargetCenterLong);
     newOptions.d->bReverseCO = !newOptions.d->bReverseCO;
+    newOptions.d->RefreshCheckWithInvertProj();
 
     if( new_pj == nullptr && !bNoTransform )
     {
@@ -2338,9 +2441,6 @@ OGRCoordinateTransformation* OGRProjCT::GetInverse() const
     poNewCT->bTargetWrap = bSourceWrap;
     poNewCT->dfTargetWrapLong = dfSourceWrapLong;
 
-    poNewCT->bCheckWithInvertProj =
-        CPLTestBool(CPLGetConfigOption( "CHECK_WITH_INVERT_PROJ", "NO" ));
-
     poNewCT->ComputeThreshold();
 
     poNewCT->m_pj = new_pj;
@@ -2350,6 +2450,98 @@ OGRCoordinateTransformation* OGRProjCT::GetInverse() const
     poNewCT->m_options = newOptions;
     return poNewCT;
 }
+
+/************************************************************************/
+/*                            OSRCTCleanCache()                         */
+/************************************************************************/
+
+void OSRCTCleanCache()
+{
+    std::lock_guard<std::mutex> oGuard(g_oCTCacheMutex);
+    delete g_poCTCache;
+    g_poCTCache = nullptr;
+}
+
+/************************************************************************/
+/*                          MakeCacheKey()                              */
+/************************************************************************/
+
+CTCacheKey OGRProjCT::MakeCacheKey(const OGRSpatialReference* poSRS1,
+                                    const OGRSpatialReference* poSRS2,
+                                    const OGRCoordinateTransformationOptions& options)
+{
+    const auto GetKeyForSRS = [](const OGRSpatialReference* poSRS)
+    {
+        if (poSRS)
+        {
+            char* pszText = GetWktOrProjString(poSRS);
+            std::string ret(pszText);
+            CPLFree(pszText);
+            const auto& mapping = poSRS->GetDataAxisToSRSAxisMapping();
+            for(const auto& axis: mapping)
+            {
+                ret += std::to_string(axis);
+            }
+            return ret;
+        }
+        else
+        {
+            return std::string("null");
+        }
+    };
+
+    std::string ret( GetKeyForSRS(poSRS1) );
+    ret += GetKeyForSRS(poSRS2);
+    ret += options.d->GetKey();
+    return ret;
+}
+
+/************************************************************************/
+/*                           InsertIntoCache()                          */
+/************************************************************************/
+
+void OGRProjCT::InsertIntoCache( OGRProjCT* poCT )
+{
+    std::lock_guard<std::mutex> oGuard(g_oCTCacheMutex);
+    if( g_poCTCache == nullptr )
+    {
+        g_poCTCache = new lru11::Cache<CTCacheKey, CTCacheValue>();
+    }
+    const auto key = MakeCacheKey(poCT->poSRSSource, poCT->poSRSTarget,
+                                  poCT->m_options);
+    if( g_poCTCache->contains(key) )
+    {
+        delete poCT;
+        return;
+    }
+    g_poCTCache->insert(key, std::make_shared<std::unique_ptr<OGRProjCT>>(
+                                            std::unique_ptr<OGRProjCT>(poCT)));
+}
+
+/************************************************************************/
+/*                            FindFromCache()                           */
+/************************************************************************/
+
+OGRProjCT* OGRProjCT::FindFromCache( const OGRSpatialReference *poSource,
+                                     const OGRSpatialReference *poTarget,
+                                     const OGRCoordinateTransformationOptions& options )
+{
+    std::lock_guard<std::mutex> oGuard(g_oCTCacheMutex);
+    if( g_poCTCache == nullptr || g_poCTCache->empty() )
+        return nullptr;
+
+    const auto key = MakeCacheKey(poSource, poTarget, options);
+    // Get value from cache and remove it
+    CTCacheValue holder;
+    if( g_poCTCache->tryGet(key, holder) )
+    {
+        auto poCT = holder->release();
+        g_poCTCache->remove(key);
+        return poCT;
+    }
+    return nullptr;
+}
+
 //! @endcond
 
 /************************************************************************/

--- a/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -1083,6 +1083,8 @@ public:
 
     OGRCoordinateTransformation* Clone() const override { return new GeometryInsertTransformer(*this); }
 
+    virtual OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
+
     int Transform( int nCount,
                      double *x, double *y, double *z = nullptr,
                      double * /*t*/ = nullptr,

--- a/gdal/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/gdal/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -183,6 +183,8 @@ public:
         }
         return TRUE;
     }
+
+    OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
 };
 
 /************************************************************************/
@@ -273,6 +275,8 @@ public:
     OGRCoordinateTransformation* Clone() const override {
         return new OGRDXFOCSTransformer(*this);
     }
+
+    OGRCoordinateTransformation* GetInverse() const override { return nullptr; }
 };
 
 /************************************************************************/

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -9479,6 +9479,7 @@ void OSRCleanup( void )
     OGRCTDumpStatistics();
     CSVDeaccess( nullptr );
     CleanupSRSWGS84Mutex();
+    OSRCTCleanCache();
     OSRCleanupTLSContext();
 }
 

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -9476,6 +9476,7 @@ static void CleanupSRSWGS84Mutex();
 void OSRCleanup( void )
 
 {
+    OGRCTDumpStatistics();
     CSVDeaccess( nullptr );
     CleanupSRSWGS84Mutex();
     OSRCleanupTLSContext();


### PR DESCRIPTION
Series of performance enhancements to fix the performance regression of gdalwarp in the use case of https://github.com/OSGeo/gdal/issues/3470.

With GDAL 2.4 / PROJ 5.2 : ~ 80 ms
Before with GDAL 3.2 / PROJ 8:  ~ 280 ms
With this PR + https://github.com/OSGeo/gdal/pull/3587 + https://github.com/OSGeo/PROJ/pull/2583: ~ 105 ms