### PR TITLE
Doc: Add clarifying note about gdal_translate scale ranges

### DIFF
--- a/gdal/doc/source/programs/gdal_translate.rst
+++ b/gdal/doc/source/programs/gdal_translate.rst
@@ -118,9 +118,12 @@ resampling, and rescaling pixels in the process.
 .. option:: -scale [src_min src_max [dst_min dst_max]]
 
     Rescale the input pixels values from the range **src_min** to **src_max**
-    to the range **dst_min** to **dst_max**.  If omitted the output range is 0
+    to the range **dst_min** to **dst_max**. If omitted the output range is 0
     to 255.  If omitted the input range is automatically computed from the
-    source data. -scale can be repeated several times (if specified only once,
+    source data. Note that these values are only used to compute a scale and
+    offset to apply to the input raster values. In particular, src_min and
+    src_max are not used to clip input values.
+    -scale can be repeated several times (if specified only once,
     it also applies to all bands of the output dataset), so as to specify per
     band parameters. It is also possible to use the "-scale_bn" syntax where bn
     is a band number (e.g. "-scale_2" for the 2nd band of the output dataset)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Add clarifying note about gdal_translate scale ranges

## What are related issues/pull requests?

https://lists.osgeo.org/pipermail/gdal-dev/2021-March/053694.html

 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
