### PR TITLE
added necessary '-' to option

### DIFF
--- a/gdal/doc/source/programs/gdal_edit.rst
+++ b/gdal/doc/source/programs/gdal_edit.rst
@@ -156,7 +156,7 @@ It works only with raster formats that support update access to existing dataset
 
     .. versionadded:: 3.1
 
-.. option:: colorinterp_X red|green|blue|alpha|gray|undefined
+.. option:: -colorinterp_X red|green|blue|alpha|gray|undefined
 
     Change the color interpretation of band X (where X is a valid band
     number, starting at 1).


### PR DESCRIPTION
colorinterp_X fails with, for example: "Unrecognized option : colorinterp_1=gray" if '-' flag isn't used.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
