### PR TITLE
ECW: fix build with original ECW SDK 5.4 (fixes #2776)

### DIFF
--- a/gdal/frmts/ecw/gdal_ecw.h
+++ b/gdal/frmts/ecw/gdal_ecw.h
@@ -125,9 +125,11 @@ public:
 
 class VSIIOStream final: public CNCSJPCIOStream
 {
-#if ECWSDK_VERSION >= 54
-    NCS_DELETE_ALL_COPY_AND_MOVE(VSIIOStream)
-#endif
+    VSIIOStream(const VSIIOStream &) = delete;
+    VSIIOStream& operator= (const VSIIOStream&) = delete;
+    VSIIOStream(VSIIOStream &&) = delete;
+    VSIIOStream& operator= (VSIIOStream &&) = delete;
+
     char     *m_Filename;
   public:
 
@@ -186,7 +188,7 @@ class VSIIOStream final: public CNCSJPCIOStream
         {
             return nullptr;
         }
-        
+
         VSIIOStream *pDst = new VSIIOStream();
         pDst->Access(fpNewVSIL, bWritable, bSeekable, m_Filename, startOfJPData, lengthOfJPData);
         return pDst;


### PR DESCRIPTION
This is only for original 5.4 version. ECW SDK 5.4 update 1 or 5.5 build fine.