### PR TITLE
util.py - get_ovr_idx to support selecting by resolution + some utility functions + testing

### DIFF
--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  osgeo_utils.auxiliary (gdal-utils) testing
+# Author:   Idan Miara <idan@miara.com>
+#
+###############################################################################
+# Copyright (c) 2021, Idan Miara <idan@miara.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import os
+from pathlib import Path
+
+import pytest
+
+# test that osgeo_utils is available, if not skip all tests
+from osgeo_utils.auxiliary.extent_util import Extent
+
+pytest.importorskip('osgeo_utils')
+
+from osgeo_utils.auxiliary import util, raster_creation, base
+
+temp_files = []
+
+
+def test_utils_py_0():
+    for b in (False, 'False', 'OfF', 'no'):
+        assert not base.is_true(b)
+    for b in (True, 'TruE', 'ON', 'yes'):
+        assert base.is_true(b)
+
+    assert base.enum_to_str(Extent.UNION) == 'UNION'
+    assert base.enum_to_str('UNION') == 'UNION'
+
+    filename = Path('abc') / Path('def') / Path('a.txt')
+    assert base.is_path_like(Path(filename))
+    assert base.is_path_like(str(filename))
+    assert not base.is_path_like(None)
+    assert not base.is_path_like([filename])
+
+    assert base.get_suffix(filename) == '.txt'
+    assert base.get_extension(filename) == 'txt'
+
+    for idx, b in enumerate((0x23, 0xc1, 0xab, 0x00)):
+        byte = base.get_byte(0xab_c1_23, idx)
+        assert byte == b
+
+    assert base.path_join(filename, 'a', 'b') == str(filename / 'a' / 'b')
+
+    assert base.num(42) == 42
+    assert base.num('42') == 42
+
+    assert base.num(42.0) == 42.0
+    assert base.num('42.0') == 42.0
+    assert base.num('42.') == 42.0
+
+    assert base.num_or_none('') is None
+    assert base.num_or_none(None) is None
+    assert base.num_or_none('1a') is None
+    assert base.num_or_none('42') == 42
+    assert base.num_or_none('42.0') == 42.0
+
+
+def test_utils_py_1():
+    """ test get_ovr_idx, create_flat_raster """
+    filename = 'tmp/raster.tif'
+    temp_files.append(filename)
+    raster_creation.create_flat_raster(filename, overview_list=[2, 4])
+    ds = util.open_ds(filename)
+    compression = util.get_image_structure_metadata(filename, 'COMPRESSION')
+    assert compression == 'DEFLATE'
+    ras_count = util.get_ovr_count(ds)+1
+    assert ras_count == 3
+    pixel_size = util.get_pixel_size(ds)
+    assert pixel_size == (10, -10)
+
+    for i in range(-ras_count, ras_count):
+        assert util.get_ovr_idx(filename, ovr_idx=i) == (i if i >= 0 else ras_count+i)
+
+    for res, ovr in [(5, 0), (10, 0), (11, 0), (19.99, 0), (20, 1), (20.1, 1), (39, 1), (40, 2), (41, 2), (400, 2)]:
+        assert util.get_ovr_idx(filename, ovr_res=res) == ovr
+        assert util.get_ovr_idx(filename, ovr_idx=float(res)) == ovr  # noqa secret functionality
+
+
+def test_utils_py_cleanup():
+    for filename in temp_files:
+        try:
+            os.remove(filename)
+        except OSError:
+            pass

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_palette.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_palette.py
@@ -149,7 +149,7 @@ class ColorPalette:
             return self
         elif base.is_path_like(color_filename_or_lines):
             color_filename_or_lines = open(str(color_filename_or_lines)).readlines()
-        elif not base.is_sequence(color_filename_or_lines):
+        elif not isinstance(color_filename_or_lines, Sequence):
             raise Exception('unknown input {}'.format(color_filename_or_lines))
 
         self.pal.clear()
@@ -328,7 +328,7 @@ def get_file_from_strings(color_palette: ColorPaletteOrPathOrStrings):
         color_palette.write_color_file(temp_color_filename)
     elif base.is_path_like(color_palette):
         color_filename = color_palette
-    elif base.is_sequence(color_palette):
+    elif isinstance(color_palette, Sequence):
         temp_color_filename = tempfile.mktemp(suffix='.txt')
         color_filename = temp_color_filename
         with open(temp_color_filename, 'w') as f:

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/raster_creation.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/raster_creation.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL utils.auxiliary
+#  Purpose:  raster creation utility functions
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2021, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import tempfile
+from numbers import Real
+from typing import Sequence, Optional
+
+from osgeo import gdal, osr
+from osgeo_utils.auxiliary.base import PathLike, MaybeSequence, is_true
+from osgeo_utils.auxiliary.util import get_bigtiff_creation_option_value, get_data_type, DataTypeOrStr, CreationOptions
+
+
+def create_flat_raster(filename: Optional[PathLike],
+                       driver: Optional[str] = None, dt: DataTypeOrStr = gdal.GDT_Byte,
+                       size: MaybeSequence[int] = 128, band_count: int = 1, creation_options: CreationOptions = None,
+                       fill_value: Optional[Real] = None, nodata_value: Optional[Real] = None,
+                       origin: Optional[Sequence[int]] = (500_000, 0), pixel_size: MaybeSequence[int] = 10,
+                       epsg: Optional[int] = 32636,
+                       overview_alg: Optional[str] = 'NEAR', overview_list: Optional[Sequence[int]] = None):
+    if filename is None:
+        filename = tempfile.mktemp()
+    elif not filename:
+        filename = ''
+    if driver is None:
+        driver = 'GTiff' if filename else 'MEM'
+    if not isinstance(size, Sequence):
+        size = (size, size)
+
+    drv = gdal.GetDriverByName(driver)
+    dt = get_data_type(dt)
+    creation_options_list = get_creation_options(creation_options, driver=driver)
+    ds = drv.Create(str(filename), *size, band_count, dt, creation_options_list)
+
+    if pixel_size and origin:
+        if not isinstance(pixel_size, Sequence):
+            pixel_size = (pixel_size, -pixel_size)
+        ds.SetGeoTransform([origin[0], pixel_size[0], 0, origin[1], 0, pixel_size[1]])
+    if epsg is not None:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(epsg)
+        ds.SetSpatialRef(srs)
+    for bnd_idx in range(band_count):
+        bnd: gdal.Band = ds.GetRasterBand(bnd_idx+1)
+        if fill_value is not None:
+            bnd.Fill(fill_value)
+        if nodata_value is not None:
+            bnd.SetNoDataValue(nodata_value)
+    if overview_alg and overview_list:
+        ds.BuildOverviews(overview_alg, overviewlist=overview_list)
+    return ds
+
+
+def get_creation_options(creation_options: CreationOptions = None,
+                         driver: str = 'GTiff',
+                         sparse_ok: bool = None,
+                         tiled: bool = None,
+                         block_size: Optional[int] = None,
+                         big_tiff: Optional[str] = None,
+                         comp: str = None):
+    creation_options = dict(creation_options or dict())
+    if sparse_ok is None:
+        sparse_ok = creation_options.get("SPARSE_OK", True)
+    creation_options["SPARSE_OK"] = str(bool(sparse_ok))
+
+    driver = driver.lower()
+    if comp is None:
+        comp = creation_options.get("COMPRESS", "DEFLATE")
+    if driver in ['gtiff', 'cog']:
+        creation_options["BIGTIFF"] = get_bigtiff_creation_option_value(big_tiff)
+        creation_options["COMPRESS"] = comp
+
+    if tiled is None:
+        tiled = creation_options.get("TILED", True)
+    tiled = is_true(tiled)
+    creation_options["TILED"] = str(tiled)
+    if tiled and block_size is not None:
+        if driver == 'gtiff':
+            creation_options["BLOCKXSIZE"] = block_size
+            creation_options["BLOCKYSIZE"] = block_size
+        elif driver == 'cog':
+            creation_options["BLOCKSIZE"] = block_size
+
+    creation_options_list = []
+    for k, v in creation_options.items():
+        creation_options_list.append("{}={}".format(k, v))
+
+    return creation_options_list


### PR DESCRIPTION
improve get_ovr_idx:
def get_ovr_idx(filename_or_ds: PathOrDS, ovr_idx: Optional[Union[int, float]]):
    """
    returns a non-negative ovr_idx, from a given ovr_idx number
    for ovr_idx = None => returns 0
    for ovr_idx: int >= 0 => returns the given ovr_idx
    for ovr_idx: int < 0 => -1 is the last overview; -2 is the one before the last and so on
    for ovr_idx: float => returns the best overview by the given resolution (ovr_idx represents the resolution in this case)
    """

This PR also adds some other basic utility functions and testing