### PR TITLE
JAVA: Expose two new methods for GDAL's JNI Bridge

### DIFF
--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -186,6 +186,7 @@ void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* psz
 %rename (CPLBinaryToHex) CPLBinaryToHex;
 %rename (CPLHexToBinary) CPLHexToBinary;
 %rename (FileFromMemBuffer) wrapper_VSIFileFromMemBuffer;
+%rename (GetMemFileBuffer) wrapper_VSIGetMemFileBuffer;
 %rename (Unlink) VSIUnlink;
 %rename (HasThreadSupport) wrapper_HasThreadSupport;
 %rename (NetworkStatsReset) VSINetworkStatsReset;
@@ -519,6 +520,27 @@ void wrapper_VSIFileFromMemBuffer( const char* utf8_path, int nBytes, const GByt
 %clear ( int nBytes, const GByte *pabyData );
 #endif
 #endif
+
+#if defined(SWIGJAVA)
+%inline %{
+void wrapper_VSIFileFromMemBuffer( const char* utf8_path, void* nioBuffer, long nioBufferSize) {
+    VSIFCloseL(VSIFileFromMemBuffer(utf8_path, (GByte*) nioBuffer, nioBufferSize, FALSE));
+}
+%}
+#endif
+
+#if defined(SWIGJAVA)
+%apply (jobject outBuffer) {jobject};
+%inline %{
+jobject wrapper_VSIGetMemFileBuffer(JNIEnv *jenv, const char* utf8_path) {
+    vsi_l_offset outBufferLen = 0;
+    GByte* result = VSIGetMemFileBuffer(utf8_path, &outBufferLen, FALSE);
+    return jenv->NewDirectByteBuffer((void*) result, outBufferLen);
+}
+%}
+%clear (jobject outBuffer);
+#endif
+
 
 /* Added in GDAL 1.7.0 */
 VSI_RETVAL VSIUnlink(const char * utf8_path );

--- a/gdal/swig/include/cpl.i
+++ b/gdal/swig/include/cpl.i
@@ -186,7 +186,6 @@ void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* psz
 %rename (CPLBinaryToHex) CPLBinaryToHex;
 %rename (CPLHexToBinary) CPLHexToBinary;
 %rename (FileFromMemBuffer) wrapper_VSIFileFromMemBuffer;
-%rename (GetMemFileBuffer) wrapper_VSIGetMemFileBuffer;
 %rename (Unlink) VSIUnlink;
 %rename (HasThreadSupport) wrapper_HasThreadSupport;
 %rename (NetworkStatsReset) VSINetworkStatsReset;
@@ -487,6 +486,7 @@ GByte *CPLHexToBinary( const char *pszHex, int *pnBytes );
 /* Added in GDAL 1.7.0 */
 
 #if defined(SWIGPYTHON)
+%rename (GetMemFileBuffer) wrapper_VSIGetMemFileBuffer
 
 %apply (GIntBig nLen, char *pBuf) {( GIntBig nBytes, const char *pabyData )};
 %inline {
@@ -530,16 +530,21 @@ void wrapper_VSIFileFromMemBuffer( const char* utf8_path, void* nioBuffer, long 
 #endif
 
 #if defined(SWIGJAVA)
-%apply (jobject outBuffer) {jobject};
+
+%rename (GetMemFileBuffer) wrapper_VSIGetMemFileBuffer;
+
+%apply (GByte* outBytes) {GByte*};
+%apply (GByte **out, vsi_l_offset *length) {(GByte* out, vsi_l_offset length)};
 %inline %{
-jobject wrapper_VSIGetMemFileBuffer(JNIEnv *jenv, const char* utf8_path) {
-    vsi_l_offset outBufferLen = 0;
-    GByte* result = VSIGetMemFileBuffer(utf8_path, &outBufferLen, FALSE);
-    return jenv->NewDirectByteBuffer((void*) result, outBufferLen);
+GByte* wrapper_VSIGetMemFileBuffer(const char* utf8_path, GByte **out, vsi_l_offset *length) {
+    *out = VSIGetMemFileBuffer(utf8_path, length, FALSE);
+    return *out;
 }
 %}
-%clear (jobject outBuffer);
+%clear (GByte **out, vsi_l_offset *length);
+%clear (GByte* outBytes);
 #endif
+
 
 
 /* Added in GDAL 1.7.0 */

--- a/gdal/swig/include/java/gdal_java.i
+++ b/gdal/swig/include/java/gdal_java.i
@@ -105,7 +105,9 @@ import org.gdal.osr.SpatialReference;
       else
         return null;
     }
+
 %}
+
 
 %typemap(javacode) GDAL_GCP %{
   public GCP(double x, double y, double z, double pixel, double line)

--- a/gdal/swig/include/java/typemaps_java.i
+++ b/gdal/swig/include/java/typemaps_java.i
@@ -62,11 +62,6 @@
 
 %typemap(javain) SWIGTYPE *DISOWN "$javaclassname.getCPtrAndDisown($javainput)"
 
-%typemap(in, numinputs=0) JNIEnv *jenv %{
-   $1 = jenv;
-%}
-
-
 /* JAVA TYPEMAPS */
 
 /***************************************************
@@ -377,14 +372,27 @@
   }
 
 /***************************************************
- * Typemaps for  (jobject outBuffer)
+ * Typemaps for  (GByte **outBuffer)
  ***************************************************/
 
-%typemap(jni) (jobject outBuffer) "jobject"
-%typemap(jtype) (jobject outBuffer)  "java.nio.ByteBuffer"
-%typemap(jstype) (jobject outBuffer)  "java.nio.ByteBuffer"
-%typemap(javain) (jobject outBuffer)  "$javainput"
-%typemap(javaout) (jobject outBuffer) {
+%typemap(in, numinputs=0) (GByte **out, vsi_l_offset *length) (GByte *out, vsi_l_offset length) {
+  /* GByte** out, vsi_l_offset *length */
+  $1 = &out;
+  $2 = &length;
+}
+
+%typemap(argout) (GByte **out, vsi_l_offset *length) {
+  /* GByte** out, vsi_l_offset *length */
+  $result = jenv->NewByteArray(length$argnum);
+  jenv->SetByteArrayRegion($result, (jsize)0, (jsize)length$argnum, (jbyte*)result);
+  CPLFree(result);
+}
+
+%typemap(jni) (GByte **out, vsi_l_offset *length) "jbyteArray"
+%typemap(jtype) (GByte **out, vsi_l_offset *length) "byte[]"
+%typemap(jstype) (GByte **out, vsi_l_offset *length) "byte[]"
+%typemap(javain) (GByte **out, vsi_l_offset *length) "$javainput"
+%typemap(javaout) (GByte** out, vsi_l_offset *length) {
     return $jnicall;
   }
 

--- a/gdal/swig/include/java/typemaps_java.i
+++ b/gdal/swig/include/java/typemaps_java.i
@@ -62,6 +62,10 @@
 
 %typemap(javain) SWIGTYPE *DISOWN "$javaclassname.getCPtrAndDisown($javainput)"
 
+%typemap(in, numinputs=0) JNIEnv *jenv %{
+   $1 = jenv;
+%}
+
 
 /* JAVA TYPEMAPS */
 
@@ -371,6 +375,19 @@
 %typemap(javaout) (GByte* outBytes ) {
     return $jnicall;
   }
+
+/***************************************************
+ * Typemaps for  (jobject outBuffer)
+ ***************************************************/
+
+%typemap(jni) (jobject outBuffer) "jobject"
+%typemap(jtype) (jobject outBuffer)  "java.nio.ByteBuffer"
+%typemap(jstype) (jobject outBuffer)  "java.nio.ByteBuffer"
+%typemap(javain) (jobject outBuffer)  "$javainput"
+%typemap(javaout) (jobject outBuffer) {
+    return $jnicall;
+  }
+
 
 /***************************************************
  * Typemaps for  (const char* stringWithDefaultValue)

--- a/gdal/swig/java/GNUmakefile
+++ b/gdal/swig/java/GNUmakefile
@@ -100,6 +100,7 @@ test:
 	${JAVA_RUN} OSRTransform
 	${JAVA_RUN} gdalmajorobject
 	${JAVA_RUN} GDALTestIO
+	${JAVA_RUN} GDALTestIO -membuffer tmp_test/byte.tif
 	${JAVA_RUN} GDALContour -i 1 tmp_test/byte.tif tmp_test/contour.shp
 	${JAVA_RUN} testgetpoints
 	${JAVA_RUN} ogrtindex tmp_test/contour_index.shp tmp_test/contour.shp


### PR DESCRIPTION


<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Exposes two new JNI methods. Specifically:

* VSIFileFromMemBuffer - Augments to support taking a ByteBuffer as an
  argument
* VSIGetMemFileFromBuffer - Exposes this method and returns a ByteBuffer
  pointer to the underlying memory.

## What are related issues/pull requests?

n/a, just exposing what could have been exposed from the start. This is my first gdal contribution as well as some of the first swig code I've written so apologies if I did anything incorrectly.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
