### PR TITLE
Update OGR_G_GetX,Y,Z docs

### DIFF
--- a/gdal/ogr/ogr_api.cpp
+++ b/gdal/ogr/ogr_api.cpp
@@ -62,7 +62,7 @@ inline OGRGeometryH ToHandle(OGRGeometry* poGeom)
 /*                        OGR_G_GetPointCount()                         */
 /************************************************************************/
 /**
- * \brief Fetch number of points from a geometry.
+ * \brief Fetch number of points from a Point or a LineString/LinearRing geometry.
  *
  * Only wkbPoint[25D] or wkbLineString[25D] may return a valid value.
  * Other geometry types will silently return 0.
@@ -177,7 +177,7 @@ static double OGR_G_Get_Component( OGRGeometryH hGeom, int i )
 /*                             OGR_G_GetX()                             */
 /************************************************************************/
 /**
- * \brief Fetch the x coordinate of a point from a geometry.
+ * \brief Fetch the x coordinate of a point from a Point or a LineString/LinearRing geometry.
  *
  * @param hGeom handle to the geometry from which to get the x coordinate.
  * @param i point to get the x coordinate.
@@ -200,7 +200,7 @@ double OGR_G_GetX( OGRGeometryH hGeom, int i )
 /*                             OGR_G_GetY()                             */
 /************************************************************************/
 /**
- * \brief Fetch the x coordinate of a point from a geometry.
+ * \brief Fetch the x coordinate of a point from a Point or a LineString/LinearRing geometry.
  *
  * @param hGeom handle to the geometry from which to get the y coordinate.
  * @param i point to get the Y coordinate.
@@ -223,7 +223,7 @@ double OGR_G_GetY( OGRGeometryH hGeom, int i )
 /*                             OGR_G_GetZ()                             */
 /************************************************************************/
 /**
- * \brief Fetch the z coordinate of a point from a geometry.
+ * \brief Fetch the z coordinate of a point from a Point or a LineString/LinearRing geometry.
  *
  * @param hGeom handle to the geometry from which to get the Z coordinate.
  * @param i point to get the Z coordinate.


### PR DESCRIPTION
Add to docs that OGR_G_GetX,Y,Z applies only to Point or a LineString/LinearRing geometries

