### PR TITLE
SWIG: fix expansion of ODsCRandomLayerWrite

### DIFF
--- a/gdal/ogr/ogr_core.h
+++ b/gdal/ogr/ogr_core.h
@@ -825,6 +825,7 @@ int CPL_DLL OGRParseDate( const char *pszInput, OGRField *psOutput,
 #define ODsCEmulatedTransactions "EmulatedTransactions" /**< Dataset capability for emulated dataset transactions */
 #define ODsCMeasuredGeometries "MeasuredGeometries"     /**< Dataset capability for measured geometries support */
 #define ODsCRandomLayerRead     "RandomLayerRead"   /**< Dataset capability for GetNextFeature() returning features from random layers */
+/* Note the unfortunate trailing space at the end of the string */
 #define ODsCRandomLayerWrite    "RandomLayerWrite " /**< Dataset capability for supporting CreateFeature on layer in random order */
 
 #define ODrCCreateDataSource   "CreateDataSource"   /**< Driver capability for datasource creation */

--- a/gdal/swig/include/ogr.i
+++ b/gdal/swig/include/ogr.i
@@ -475,7 +475,8 @@ typedef int OGRErr;
 #define ODsCEmulatedTransactions "EmulatedTransactions"
 #define ODsCMeasuredGeometries  "MeasuredGeometries";
 #define ODsCRandomLayerRead    "RandomLayerRead";
-#define ODsCRandomLayerWrite   "RandomLayerWrite";
+/* Note the unfortunate trailing space at the end of the string */
+#define ODsCRandomLayerWrite   "RandomLayerWrite ";
 
 #define ODrCCreateDataSource   "CreateDataSource"
 #define ODrCDeleteDataSource   "DeleteDataSource"


### PR DESCRIPTION
The C #define has a unfortunate trailing space at the end of the
string. We must also replicate that in SWIG.