### PR TITLE
TileDB: do not try to identify /vsis3/ files ending with .tif

### DIFF
--- a/gdal/frmts/tiledb/tiledbdataset.cpp
+++ b/gdal/frmts/tiledb/tiledbdataset.cpp
@@ -1171,7 +1171,8 @@ int TileDBDataset::Identify( GDALOpenInfo * poOpenInfo )
         }
 
         if( poOpenInfo->bIsDirectory ||
-                STARTS_WITH_CI( poOpenInfo->pszFilename, "/VSIS3/" ) )
+            (STARTS_WITH_CI( poOpenInfo->pszFilename, "/VSIS3/" ) &&
+                !EQUAL(CPLGetExtension(poOpenInfo->pszFilename), "tif")) )
         {
             tiledb::Context ctx;
             CPLString osArrayPath = vsi_to_s3( poOpenInfo->pszFilename );


### PR DESCRIPTION
If trying to open a /vsis3/ TIFF file without appropriate /vsis3/
credentials, it takes a few seconds to the TileDB driver to realize
t can't open it. So avoid it trying when the extension if tif.
A bit of a hack...

CC @normanb : this is more a workaround than a proper fix. There's probably something to improve on the tiledb lib side. GDAL's /vsis3/ is much faster to realize that it can't do the connection to S3.