### PR TITLE
Add support for GeoPackage 1.3

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -3476,7 +3476,7 @@ def test_ogr_gpkg_47():
     # Set user_version
     fp = gdal.VSIFOpenL('/vsimem/ogr_gpkg_47.gpkg', 'rb+')
     gdal.VSIFSeekL(fp, 60, 0)
-    gdal.VSIFWriteL(struct.pack('B' * 4, 0, 0, 0x27, 0xD9), 4, 1, fp)
+    gdal.VSIFWriteL(struct.pack('>I', 10201), 4, 1, fp)
     gdal.VSIFCloseL(fp)
 
     ds = ogr.Open('/vsimem/ogr_gpkg_47.gpkg', update=1)
@@ -3490,11 +3490,29 @@ def test_ogr_gpkg_47():
     assert gdal.GetLastErrorMsg() == ''
 
     # Set GPKG 1.3.0
+    gdaltest.gpkg_dr.CreateDataSource('/vsimem/ogr_gpkg_47.gpkg')
+    # Set user_version
+    fp = gdal.VSIFOpenL('/vsimem/ogr_gpkg_47.gpkg', 'rb+')
+    gdal.VSIFSeekL(fp, 60, 0)
+    gdal.VSIFWriteL(struct.pack('>I', 10300), 4, 1, fp)
+    gdal.VSIFCloseL(fp)
+
+    ds = ogr.Open('/vsimem/ogr_gpkg_47.gpkg', update=1)
+    assert ds is not None
+    assert gdal.GetLastErrorMsg() == ''
+    ds = None
+
+    gdal.SetConfigOption('GPKG_WARN_UNRECOGNIZED_APPLICATION_ID', 'NO')
+    ogr.Open('/vsimem/ogr_gpkg_47.gpkg')
+    gdal.SetConfigOption('GPKG_WARN_UNRECOGNIZED_APPLICATION_ID', None)
+    assert gdal.GetLastErrorMsg() == ''
+
+    # Set GPKG 1.99.0
     gdaltest.gpkg_dr.CreateDataSource('/vsimem/ogr_gpkg_47.gpkg', options=['VERSION=1.2'])
     # Set user_version
     fp = gdal.VSIFOpenL('/vsimem/ogr_gpkg_47.gpkg', 'rb+')
     gdal.VSIFSeekL(fp, 60, 0)
-    gdal.VSIFWriteL(struct.pack('B' * 4, 0, 0, 0x28, 0x3C), 4, 1, fp)
+    gdal.VSIFWriteL(struct.pack('>I', 19900), 4, 1, fp)
     gdal.VSIFCloseL(fp)
 
     with gdaltest.error_handler():

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -3476,6 +3476,8 @@ def test_ogr_gpkg_47():
     # Set user_version
     fp = gdal.VSIFOpenL('/vsimem/ogr_gpkg_47.gpkg', 'rb+')
     gdal.VSIFSeekL(fp, 60, 0)
+    assert struct.unpack('>I', gdal.VSIFReadL(4, 1, fp))[0] == 10200
+    gdal.VSIFSeekL(fp, 60, 0)
     gdal.VSIFWriteL(struct.pack('>I', 10201), 4, 1, fp)
     gdal.VSIFCloseL(fp)
 
@@ -3490,11 +3492,11 @@ def test_ogr_gpkg_47():
     assert gdal.GetLastErrorMsg() == ''
 
     # Set GPKG 1.3.0
-    gdaltest.gpkg_dr.CreateDataSource('/vsimem/ogr_gpkg_47.gpkg')
-    # Set user_version
-    fp = gdal.VSIFOpenL('/vsimem/ogr_gpkg_47.gpkg', 'rb+')
+    gdaltest.gpkg_dr.CreateDataSource('/vsimem/ogr_gpkg_47.gpkg', options=['VERSION=1.3'])
+    # Check user_version
+    fp = gdal.VSIFOpenL('/vsimem/ogr_gpkg_47.gpkg', 'rb')
     gdal.VSIFSeekL(fp, 60, 0)
-    gdal.VSIFWriteL(struct.pack('>I', 10300), 4, 1, fp)
+    assert struct.unpack('>I', gdal.VSIFReadL(4, 1, fp))[0] == 10300
     gdal.VSIFCloseL(fp)
 
     ds = ogr.Open('/vsimem/ogr_gpkg_47.gpkg', update=1)

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -1333,6 +1333,13 @@ def test_ogr_gpkg_19():
     ds = None
 
     ds = ogr.Open('/vsimem/ogr_gpkg_19.gpkg')
+
+    # Check that we don't create triggers
+    sql_lyr = ds.ExecuteSQL(
+        "SELECT * FROM sqlite_master WHERE type = 'trigger' AND tbl_name IN ('gpkg_metadata', 'gpkg_metadata_reference')")
+    assert sql_lyr.GetFeatureCount() == 0
+    ds.ReleaseResultSet(sql_lyr)
+
     lyr = ds.GetLayer('test_with_md')
     assert lyr.GetMetadataItem('IDENTIFIER') == 'ident'
     assert lyr.GetMetadataItem('DESCRIPTION') == 'desc'

--- a/gdal/doc/source/drivers/raster/gpkg.rst
+++ b/gdal/doc/source/drivers/raster/gpkg.rst
@@ -160,7 +160,7 @@ created or modified. If consistent binary output is required for
 reproducibility, the timestamp can be forced to a specific value by setting the
 :decl_configoption:`OGR_CURRENT_DATE` global configuration option.
 When setting the option, take care to meet the specific time format
-requirement of the GeoPackage standard, 
+requirement of the GeoPackage standard,
 e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
 
 
@@ -425,9 +425,10 @@ The following creation options are available:
    grid-value-is-corner: (GDAL >= 2.3) Grid cell encoding. Only used for
    tiled gridded coverage datasets. Defaults to grid-value-is-center,
    when AREA_OR_POINT metadata item is not set.
--  **VERSION**\ =AUTO/1.0/1.1/1.2: (GDAL >= 2.2) Set GeoPackage version
+-  **VERSION**\ =AUTO/1.0/1.1/1.2/1.3: (GDAL >= 2.2) Set GeoPackage version
    (for application_id and user_version fields). In AUTO mode, this will
    be equivalent to 1.2 starting with GDAL 2.3.
+   1.3 is available starting with GDAL 3.3
 -  **ADD_GPKG_OGR_CONTENTS**\ =YES/NO: (GDAL >= 2.2) Defines whether to
    add a gpkg_ogr_contents table to keep feature count for vector
    layers, and associated triggers. Defaults to YES.

--- a/gdal/doc/source/drivers/vector/gpkg.rst
+++ b/gdal/doc/source/drivers/vector/gpkg.rst
@@ -192,9 +192,10 @@ Dataset Creation Options
 The following creation options (specific to vector, or common with
 raster) are available:
 
--  **VERSION**\ =AUTO/1.0/1.1/1.2: (GDAL >= 2.2) Set GeoPackage version
+-  **VERSION**\ =AUTO/1.0/1.1/1.2/1.3: (GDAL >= 2.2) Set GeoPackage version
    (for application_id and user_version fields). In AUTO mode, this will
    be equivalent to 1.2 starting with GDAL 2.3.
+   1.3 is available starting with GDAL 3.3
 -  **ADD_GPKG_OGR_CONTENTS**\ =YES/NO: (GDAL >= 2.2) Defines whether to
    add a gpkg_ogr_contents table to keep feature count, and associated
    triggers. Defaults to YES.

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -60,7 +60,8 @@ typedef enum
 static const GUInt32 GP10_APPLICATION_ID = 0x47503130U;
 static const GUInt32 GP11_APPLICATION_ID = 0x47503131U;
 static const GUInt32 GPKG_APPLICATION_ID = 0x47504B47U;
-static const GUInt32 GPKG_1_2_VERSION = 0x000027D8U; // 10200
+static const GUInt32 GPKG_1_2_VERSION = 10200U;
+static const GUInt32 GPKG_1_3_VERSION = 10300U;
 
 static const size_t knApplicationIdPos = 68;
 static const size_t knUserVersionPos = 60;

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -4087,6 +4087,11 @@ int GDALGeoPackageDataset::Create( const char * pszFilename,
             m_nApplicationId = GPKG_APPLICATION_ID;
             m_nUserVersion = GPKG_1_2_VERSION;
         }
+        else if( EQUAL(pszVersion, "1.3") )
+        {
+            m_nApplicationId = GPKG_APPLICATION_ID;
+            m_nUserVersion = GPKG_1_3_VERSION;
+        }
     }
 
     SoftStartTransaction();

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -3531,7 +3531,7 @@ void GDALGeoPackageDataset::WriteMetadata(CPLXMLNode* psXMLNode, /* will be dest
 bool GDALGeoPackageDataset::CreateMetadataTables()
 {
     const bool bCreateTriggers =
-        CPLTestBool(CPLGetConfigOption("CREATE_TRIGGERS", "YES"));
+        CPLTestBool(CPLGetConfigOption("CREATE_TRIGGERS", "NO"));
 
     /* From C.10. gpkg_metadata Table 35. gpkg_metadata Table Definition SQL  */
     CPLString osSQL =

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -116,8 +116,12 @@ static int OGRGeoPackageDriverIdentify( GDALOpenInfo* poOpenInfo, bool bEmitWarn
     }
     else if(nApplicationId == GPKG_APPLICATION_ID &&
             // Accept any 102XX version
-            !(nUserVersion >= GPKG_1_2_VERSION &&
-              nUserVersion < GPKG_1_2_VERSION + 99))
+            !((nUserVersion >= GPKG_1_2_VERSION &&
+               nUserVersion < GPKG_1_2_VERSION + 99) ||
+            // Accept any 103XX version
+              (nUserVersion >= GPKG_1_3_VERSION &&
+               nUserVersion < GPKG_1_3_VERSION + 99)
+              ))
     {
 #ifdef DEBUG
         if( EQUAL(CPLGetFilename(poOpenInfo->pszFilename), ".cur_input")  )
@@ -138,7 +142,7 @@ static int OGRGeoPackageDriverIdentify( GDALOpenInfo* poOpenInfo, bool bEmitWarn
                             "GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "YES"));
             if( bWarn )
             {
-                if( nUserVersion > GPKG_1_2_VERSION )
+                if( nUserVersion > GPKG_1_3_VERSION )
                 {
                     CPLError( CE_Warning, CPLE_AppDefined,
                               "This version of GeoPackage "
@@ -166,7 +170,7 @@ static int OGRGeoPackageDriverIdentify( GDALOpenInfo* poOpenInfo, bool bEmitWarn
             }
             else
             {
-                if( nUserVersion > GPKG_1_2_VERSION )
+                if( nUserVersion > GPKG_1_3_VERSION )
                 {
                     CPLDebug( "GPKG",
                               "This version of GeoPackage "

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -383,6 +383,7 @@ COMPRESSION_OPTIONS
 "     <Value>1.0</Value>"
 "     <Value>1.1</Value>"
 "     <Value>1.2</Value>"
+"     <Value>1.3</Value>"
 "  </Option>"
 "  <Option name='DATETIME_FORMAT' type='string-select' description='How to encode DateTime not in UTC' default='WITH_TZ'>"
 "     <Value>WITH_TZ</Value>"

--- a/gdal/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
@@ -39,6 +39,7 @@ import sys
 # If not available, those tests will be skipped
 try:
     from osgeo import gdal
+    from osgeo import ogr
     has_gdal = True
 except ImportError:
     has_gdal = False
@@ -409,6 +410,7 @@ class GPKGChecker(object):
         for (blob,) in c.fetchall():
             if blob is None:
                 continue
+
             self._assert(len(blob) >= 8, 19, 'Invalid geometry')
             max_size_needed = min(len(blob), 8 + 4 * 2 * 8 + 5)
             blob_ar = struct.unpack('B' * max_size_needed,
@@ -417,6 +419,7 @@ class GPKGChecker(object):
             self._assert(blob_ar[1] == ord('P'), 19, 'Invalid geometry')
             self._assert(blob_ar[2] == 0, 19, 'Invalid geometry')
             flags = blob_ar[3]
+            empty_flag = ((flags >> 3) & 1) == 1
             big_endian = (flags & 1) == 0
             env_ind = (flags >> 1) & 7
             self._assert(((flags >> 5) & 1) == 0, 19,
@@ -424,14 +427,16 @@ class GPKGChecker(object):
                          'allowed')
             self._assert(env_ind <= 4, 19,
                          'Invalid geometry: invalid envelope indicator code')
-            if big_endian:
-                geom_srs_id = struct.unpack('>I' * 1, blob[4:8])[0]
-            else:
-                geom_srs_id = struct.unpack('<I' * 1, blob[4:8])[0]
+            endian_prefix = '>' if big_endian else '<'
+            geom_srs_id = struct.unpack((endian_prefix + 'I') * 1, blob[4:8])[0]
             self._assert(srs_id == geom_srs_id, 33,
                          ('table %s has geometries with SRID %d, ' +
                           'whereas only %d is expected') %
                          (table_name, geom_srs_id, srs_id))
+
+            self._assert(not (empty_flag and env_ind != 0), 152,
+                         "Invalid empty geometry")
+
             if env_ind == 0:
                 coord_dim = 0
             elif env_ind == 1:
@@ -452,12 +457,9 @@ class GPKGChecker(object):
             self._assert(len(blob) >= header_len, 19, 'Invalid geometry')
             wkb_endianness = blob_ar[header_len]
             wkb_big_endian = (wkb_endianness == 0)
-            if wkb_big_endian:
-                wkb_geom_type = struct.unpack(
-                    '>I' * 1, blob[header_len + 1:header_len + 5])[0]
-            else:
-                wkb_geom_type = struct.unpack(
-                    '<I' * 1, blob[header_len + 1:header_len + 5])[0]
+            wkb_endian_prefix = '>' if wkb_big_endian else '<'
+            wkb_geom_type = struct.unpack(
+                (wkb_endian_prefix + 'I') * 1, blob[header_len + 1:header_len + 5])[0]
             self._assert(wkb_geom_type >= 0 and
                          (wkb_geom_type % 1000) < len(wkb_geometries),
                          19, 'Invalid WKB geometry type')
@@ -479,6 +481,14 @@ class GPKGChecker(object):
                              'gpkg_geometry_columns')
 
             found_geom_types.add(wkb_geometries[wkb_geom_type % 1000])
+
+            if has_gdal:
+                geom = ogr.CreateGeometryFromWkb(blob[header_len:])
+                self._assert(geom is not None, 19, 'Invalid geometry')
+
+                self._assert((geom.IsEmpty() and empty_flag) or
+                             (not geom.IsEmpty() and not empty_flag), 152,
+                             'Inconsistent empty_flag vs geometry content')
 
         if geometry_type_name in ('POINT', 'LINESTRING', 'POLYGON',
                                   'MULTIPOINT', 'MULTILINESTRING',
@@ -633,8 +643,8 @@ class GPKGChecker(object):
         for (table_name, a_srs_id, b_srs_id) in rows:
             self._assert(False, 146,
                          "Table %s is declared with srs_id %d in "
-                         "gpkg_geometry_columns and %d in gpkg_contents" % \
-                             (table_name, a_srs_id, b_srs_id))
+                         "gpkg_geometry_columns and %d in gpkg_contents" %
+                         (table_name, a_srs_id, b_srs_id))
 
     def _check_attribute_user_table(self, c, table_name):
         self._log('Checking attributes table ' + table_name)

--- a/gdal/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
@@ -380,7 +380,7 @@ class GPKGChecker(object):
             self._assert(len(cols) > 0 and cols[0][2] == 'INTEGER',
                          150, 'view %s has no INTEGER first column' % table_name)
 
-            c.execute("SELECT COUNT(*) - COUNT(DISTINCT %s) FROM %s" % \
+            c.execute("SELECT COUNT(*) - COUNT(DISTINCT %s) FROM %s" %
                       (_esc_id(cols[0][1]), _esc_id(table_name)))
             self._assert(c.fetchone()[0] == 0, 150,
                          'First column of view %s should contain '
@@ -626,6 +626,16 @@ class GPKGChecker(object):
                           "gpkg_geometry_columns which isn't found in " +
                           "gpkg_spatial_ref_sys") % (table_name, srs_id))
 
+        c.execute("SELECT a.table_name, a.srs_id, b.srs_id FROM " +
+                  "gpkg_geometry_columns a, gpkg_contents b " +
+                  "WHERE a.table_name = b.table_name AND a.srs_id != b.srs_id")
+        rows = c.fetchall()
+        for (table_name, a_srs_id, b_srs_id) in rows:
+            self._assert(False, 146,
+                         "Table %s is declared with srs_id %d in "
+                         "gpkg_geometry_columns and %d in gpkg_contents" % \
+                             (table_name, a_srs_id, b_srs_id))
+
     def _check_attribute_user_table(self, c, table_name):
         self._log('Checking attributes table ' + table_name)
 
@@ -653,7 +663,7 @@ class GPKGChecker(object):
             self._assert(len(cols) > 0 and cols[0][2] == 'INTEGER',
                          151, 'view %s has no INTEGER first column' % table_name)
 
-            c.execute("SELECT COUNT(*) - COUNT(DISTINCT %s) FROM %s" % \
+            c.execute("SELECT COUNT(*) - COUNT(DISTINCT %s) FROM %s" %
                       (_esc_id(cols[0][1]), _esc_id(table_name)))
             self._assert(c.fetchone()[0] == 0, 151,
                          'First column of view %s should contain '


### PR DESCRIPTION
Fixes #2479

Nothing particularly exciting. GeoPackage 1.3 is very compatible with 1.2. The only changes done in the driver are:
- accept user_version 103XX (raised a warning before). To be backported in 3.2 branch
- no longer create triggers on gpkg_metadata and gpkg_metadata_reference tables. This change is also mostly backward compatible with 1.2 and will be done in it unconditionally.
- add a VERSION=1.3 creation option. Default remains at 1.2

The rest of changes are enhancements in validate_gpkg.py script