### PR TITLE
GPKG: remove creation support for data_type='aspatial' legacy tables

### DIFF
--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -215,12 +215,6 @@ def test_gpkg_1():
 
     out_ds = gdal.Open('/vsimem/tmp.gpkg')
 
-    # Check there's no ogr_empty_table
-    sql_lyr = out_ds.ExecuteSQL("SELECT COUNT(*) FROM sqlite_master WHERE name = 'ogr_empty_table'")
-    f = sql_lyr.GetNextFeature()
-    assert f.GetField(0) == 0
-    out_ds.ReleaseResultSet(sql_lyr)
-
     got_gt = out_ds.GetGeoTransform()
     for i in range(6):
         assert expected_gt[i] == pytest.approx(got_gt[i], abs=1e-8)
@@ -2489,12 +2483,6 @@ def test_gpkg_39():
     assert validate('/vsimem/gpkg_39.gpkg'), 'validation failed'
 
     ds = gdal.Open('/vsimem/gpkg_39.gpkg')
-
-    # Check there a ogr_empty_table
-    sql_lyr = ds.ExecuteSQL("SELECT COUNT(*) FROM sqlite_master WHERE name = 'ogr_empty_table'")
-    f = sql_lyr.GetNextFeature()
-    assert f.GetField(0) == 1
-    ds.ReleaseResultSet(sql_lyr)
 
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Int16
     assert ds.GetRasterBand(1).Checksum() == 4672

--- a/gdal/doc/source/drivers/vector/gpkg.rst
+++ b/gdal/doc/source/drivers/vector/gpkg.rst
@@ -238,19 +238,22 @@ Layer Creation Options
    in the contents table.
 -  **DESCRIPTION**\ =string: Description of the layer, as
    put in the contents table.
--  **ASPATIAL_VARIANT**\ =GPKG_ATTRIBUTES/OGR_ASPATIAL/NOT_REGISTERED:
+-  **ASPATIAL_VARIANT**\ =GPKG_ATTRIBUTES/NOT_REGISTERED:
    (GDAL >=2.2) How to register non spatial tables. Defaults to
    GPKG_ATTRIBUTES in GDAL 2.2 or later (behavior in previous version
    was equivalent to OGR_ASPATIAL). Starting with GeoPackage 1.2, non
    spatial tables are part of the specification. They are recorded with
    data_type="attributes" in the gpkg_contents table. This is only
-   compatible of GDAL 2.2 or later. Priorly, in OGR 2.0 and 2.1, the
-   "aspatial" extension had been developed for similar purposes, so if
-   selecting OGR_ASPATIAL, non spatial tables will be recorded with
-   data_type="aspatial" and the "aspatial" extension was declared in the
-   gpkg_extensions table. It is also possible to use the NOT_REGISTERED
+   compatible of GDAL 2.2 or later.
+   It is also possible to use the NOT_REGISTERED
    option, in which case the non spatial table is not registered at all
    in any GeoPackage system tables.
+   Priorly, in OGR 2.0 and 2.1, the "aspatial" extension had been developed for
+   similar purposes, so if selecting OGR_ASPATIAL, non spatial tables will be
+   recorded with data_type="aspatial" and the "aspatial" extension was declared in the
+   gpkg_extensions table. Starting with GDAL 3.3, OGR_ASPATIAL is no longer
+   available on creation.
+
 
 Metadata
 --------

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -52,7 +52,6 @@
 typedef enum
 {
     GPKG_ATTRIBUTES,
-    OGR_ASPATIAL,
     NOT_REGISTERED,
 } GPKGASpatialVariant;
 
@@ -129,8 +128,6 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
 
     bool                m_bInFlushCache;
 
-    bool                m_bTableCreated;
-
     bool                m_bDateTimeWithTZ = true;
 
     CPLString           m_osTilingScheme;
@@ -199,7 +196,6 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         bool                    HasGriddedCoverageAncillaryTable();
         bool                    CreateTileGriddedTable(char** papszOptions);
 
-        void                    CreateOGREmptyTableIfNeeded();
         void                    RemoveOGREmptyTable();
 
         std::map<CPLString, CPLString> m_oMapNameToType;
@@ -296,7 +292,6 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         OGRSpatialReference* GetSpatialRef( int iSrsId, bool bFallbackToEPSG = false );
         OGRErr              CreateExtensionsTableIfNecessary();
         bool                HasExtensionsTable();
-        OGRErr              CreateGDALAspatialExtension();
         void                SetMetadataDirty() { m_bMetadataDirty = true; }
 
         bool                    HasDataColumnsTable() const;

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -892,7 +892,6 @@ GDALGeoPackageDataset::GDALGeoPackageDataset() :
     m_papoOverviewDS(nullptr),
     m_bZoomOther(false),
     m_bInFlushCache(false),
-    m_bTableCreated(false),
     m_osTilingScheme("CUSTOM"),
     m_bMapTableToExtensionsBuilt(false),
     m_bMapTableToContentsBuilt(false)
@@ -925,11 +924,6 @@ GDALGeoPackageDataset::~GDALGeoPackageDataset()
 
     GDALGeoPackageDataset::FlushCache();
     FlushMetadata();
-
-    if( eAccess == GA_Update )
-    {
-        CreateOGREmptyTableIfNeeded();
-    }
 
     // Destroy bands now since we don't want
     // GDALGPKGMBTilesLikeRasterBand::FlushCache() to run after dataset
@@ -4580,37 +4574,7 @@ int GDALGeoPackageDataset::Create( const char * pszFilename,
         SQLCommand( hDB, "PRAGMA synchronous = OFF" );
     }
 
-    m_bTableCreated = true;
-
     return TRUE;
-}
-
-/************************************************************************/
-/*                     CreateOGREmptyTableIfNeeded()                    */
-/************************************************************************/
-
-void GDALGeoPackageDataset::CreateOGREmptyTableIfNeeded()
-{
-    // The specification makes it compulsory (Req 17) to have at least a
-    // features or tiles table, so create a dummy one.
-    if( m_bTableCreated &&
-        !SQLGetInteger(hDB,
-        "SELECT 1 FROM gpkg_contents WHERE data_type IN "
-        "('features', 'tiles')", nullptr) &&
-        CPLTestBool(CPLGetConfigOption("OGR_GPKG_CREATE_EMPTY_TABLE", "YES")) )
-    {
-        CPLDebug("GPKG", "Creating a dummy ogr_empty_table features table, "
-                "since there is no features or tiles table.");
-        const char* const apszLayerOptions[] = {
-            "SPATIAL_INDEX=NO",
-            "DESCRIPTION=Technical table needed to be conformant with "
-                        "Requirement 17 of the GeoPackage specification",
-            nullptr };
-        CreateLayer("ogr_empty_table", nullptr, wkbUnknown,
-                    const_cast<char**>(apszLayerOptions));
-        // Effectively create the table
-        FlushCache();
-    }
 }
 
 /************************************************************************/
@@ -5332,10 +5296,6 @@ OGRLayer* GDALGeoPackageDataset::GetLayer( int iLayer )
 
 /************************************************************************/
 /*                          ICreateLayer()                              */
-/* Options:                                                             */
-/*   FID = primary key name                                             */
-/*   OVERWRITE = YES|NO, overwrite existing layer?                      */
-/*   SPATIAL_INDEX = YES|NO, TBD                                        */
 /************************************************************************/
 
 OGRLayer* GDALGeoPackageDataset::ICreateLayer( const char * pszLayerName,
@@ -5475,7 +5435,8 @@ OGRLayer* GDALGeoPackageDataset::ICreateLayer( const char * pszLayerName,
     }
 
     /* Create a blank layer. */
-    OGRGeoPackageTableLayer *poLayer = new OGRGeoPackageTableLayer(this, pszLayerName);
+    auto poLayer = std::unique_ptr<OGRGeoPackageTableLayer>(
+        new OGRGeoPackageTableLayer(this, pszLayerName));
 
     OGRSpatialReference* poSRS = nullptr;
     if( poSpatialRef )
@@ -5514,30 +5475,31 @@ OGRLayer* GDALGeoPackageDataset::ICreateLayer( const char * pszLayerName,
         if( EQUAL(pszASpatialVariant, "GPKG_ATTRIBUTES") )
             eASpatialVariant = GPKG_ATTRIBUTES;
         else if( EQUAL(pszASpatialVariant, "OGR_ASPATIAL") )
-            eASpatialVariant = OGR_ASPATIAL;
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "ASPATIAL_VARIANT=OGR_ASPATIAL is no longer supported");
+            return nullptr;
+        }
         else if( EQUAL(pszASpatialVariant, "NOT_REGISTERED") )
             eASpatialVariant = NOT_REGISTERED;
         else
         {
-            CPLError(CE_Warning, CPLE_NotSupported,
+            CPLError(CE_Failure, CPLE_NotSupported,
                      "Unsupported value for ASPATIAL_VARIANT: %s",
                      pszASpatialVariant);
+            return nullptr;
         }
         poLayer->SetASpatialVariant( eASpatialVariant );
     }
 
     // If there was an ogr_empty_table table, we can remove it
-    if( strcmp(pszLayerName, "ogr_empty_table") != 0 &&
-        eGType != wkbNone )
-    {
-        RemoveOGREmptyTable();
-    }
-
-    m_bTableCreated = true;
+    RemoveOGREmptyTable();
 
     m_papoLayers = (OGRGeoPackageTableLayer**)CPLRealloc(m_papoLayers,  sizeof(OGRGeoPackageTableLayer*) * (m_nLayers+1));
-    m_papoLayers[m_nLayers++] = poLayer;
-    return poLayer;
+    auto poRet = poLayer.release();
+    m_papoLayers[m_nLayers] = poRet;
+    m_nLayers++;
+    return poRet;
 }
 
 /************************************************************************/
@@ -6301,27 +6263,6 @@ bool GDALGeoPackageDataset::HasGDALAspatialExtension()
     bool bHasExtension = ( err == OGRERR_NONE && oResultTable.nRowCount == 1 );
     SQLResultFree(&oResultTable);
     return bHasExtension;
-}
-
-/************************************************************************/
-/*                  CreateGDALAspatialExtension()                       */
-/************************************************************************/
-
-OGRErr GDALGeoPackageDataset::CreateGDALAspatialExtension()
-{
-    if( CreateExtensionsTableIfNecessary() != OGRERR_NONE )
-        return OGRERR_FAILURE;
-
-    if( HasGDALAspatialExtension() )
-        return OGRERR_NONE;
-
-    const char* pszCreateAspatialExtension =
-        "INSERT INTO gpkg_extensions "
-        "(table_name, column_name, extension_name, definition, scope) "
-        "VALUES "
-        "(NULL, NULL, 'gdal_aspatial', 'http://gdal.org/geopackage_aspatial.html', 'read-write')";
-
-    return SQLCommand(hDB, pszCreateAspatialExtension);
 }
 
 /************************************************************************/

--- a/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -465,7 +465,6 @@ COMPRESSION_OPTIONS
 "  <Option name='DESCRIPTION' type='string' description='Description of the layer, as put in the contents table'/>"
 "  <Option name='ASPATIAL_VARIANT' type='string-select' description='How to register non spatial tables' default='GPKG_ATTRIBUTES'>"
 "     <Value>GPKG_ATTRIBUTES</Value>"
-"     <Value>OGR_ASPATIAL</Value>"
 "     <Value>NOT_REGISTERED</Value>"
 "  </Option>"
 "</LayerCreationOptionList>");

--- a/gdal/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
@@ -301,17 +301,11 @@ class GPKGChecker(object):
         ]
         self._check_structure(columns, expected_columns, 13, 'gpkg_contents')
 
-        c.execute("SELECT 1 FROM gpkg_contents "
-                  "WHERE data_type IN ('features', 'tiles')")
-        self._assert(c.fetchone() is not None, 17,
-                     'gpkg_contents should at least have one table with '
-                     'data_type = features and/or tiles')
-
         c.execute("SELECT table_name, data_type FROM gpkg_contents "
                   "WHERE data_type NOT IN "
                   "('features', 'tiles', 'attributes', '2d-gridded-coverage')")
         ret = c.fetchall()
-        self._assert(len(ret) == 0, 17,
+        self._assert(len(ret) == 0, 17, # no longer required actually...
                      'Unexpected data types in gpkg_contents: %s' % str(ret))
 
         c.execute('SELECT table_name, last_change, srs_id FROM gpkg_contents')


### PR DESCRIPTION
This option has now long lived and is superseded by the
data_type='attributes' supported since GeoPackage 1.2 / GDAL 2.2.
Only keep read support for it.

Also remove the creation of the dummy ogr_empty_table special table that
was made to be compliant with Requirement 17 that has now been retired.