### PR TITLE
OGRGeometry: Handle WKB > 2 GB

### DIFF
--- a/gdal/frmts/netcdf/netcdflayersg.cpp
+++ b/gdal/frmts/netcdf/netcdflayersg.cpp
@@ -272,19 +272,19 @@ void netCDFDataset::SGCommitPendingTransaction()
                     if(err_code != NC_NOERR)
                     {
                         std::string frmt = std::string("attribute: ") + std::string(CF_SG_INTERIOR_RING);
-                        throw nccfdriver::SGWriter_Exception_NCDelFailure(layerMD.get_containerName().c_str(), frmt.c_str()); 
+                        throw nccfdriver::SGWriter_Exception_NCDelFailure(layerMD.get_containerName().c_str(), frmt.c_str());
                     }
 
                     // Invalidate variable writes as well - Interior Ring
                     vcdf.nc_del_vvar(layerMD.get_intring_varID());
 
-                    if(geometry_type == nccfdriver::POLYGON) 
+                    if(geometry_type == nccfdriver::POLYGON)
                     {
                         err_code = nc_del_att(cdfid, layerMD.get_containerRealID(), CF_SG_PART_NODE_COUNT);
                         NCDF_ERR(err_code);
                         if(err_code != NC_NOERR)
                         {
-                            std::string frmt = std::string("attribute: ") + std::string(CF_SG_PART_NODE_COUNT); 
+                            std::string frmt = std::string("attribute: ") + std::string(CF_SG_PART_NODE_COUNT);
                             throw nccfdriver::SGWriter_Exception_NCDelFailure(layerMD.get_containerName().c_str(), frmt.c_str());
                         }
 
@@ -314,7 +314,7 @@ void netCDFDataset::SGCommitPendingTransaction()
 void netCDFDataset::SGLogPendingTransaction()
 {
     GeometryScribe.log_transaction();
-    FieldScribe.log_transaction(); 
+    FieldScribe.log_transaction();
 }
 
 /* Takes an index and using the layer geometry builds the equivalent
@@ -350,7 +350,7 @@ OGRFeature* netCDFLayer::buildSGeometryFeature(size_t featureInd)
     }
 
     const auto wkb = m_simpleGeometryReader->serializeToWKB(featureInd);
-    geometry->importFromWkb(wkb.data(), static_cast<int>(wkb.size()), wkbVariantIso);
+    geometry->importFromWkb(wkb.data(), wkb.size(), wkbVariantIso);
     geometry->assignSpatialReference(this->GetSpatialRef());
 
     OGRFeatureDefn* defn = this->GetLayerDefn();
@@ -367,5 +367,5 @@ OGRFeature* netCDFLayer::buildSGeometryFeature(size_t featureInd)
 
 std::string netCDFDataset::generateLogName()
 {
-    return std::string(CPLGenerateTempFilename(nullptr)); 
+    return std::string(CPLGenerateTempFilename(nullptr));
 }

--- a/gdal/ogr/ogr_api.h
+++ b/gdal/ogr/ogr_api.h
@@ -45,6 +45,7 @@
 #include "ogr_core.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 
 CPL_C_START
 
@@ -88,6 +89,8 @@ struct _CPLXMLNode;
 
 OGRErr CPL_DLL OGR_G_CreateFromWkb( const void*, OGRSpatialReferenceH,
                                     OGRGeometryH *, int );
+OGRErr CPL_DLL OGR_G_CreateFromWkbEx( const void*, OGRSpatialReferenceH,
+                                      OGRGeometryH *, size_t );
 OGRErr CPL_DLL OGR_G_CreateFromWkt( char **, OGRSpatialReferenceH,
                                     OGRGeometryH * );
 OGRErr CPL_DLL OGR_G_CreateFromFgf( const void*, OGRSpatialReferenceH,
@@ -126,6 +129,7 @@ OGRErr CPL_DLL OGR_G_ImportFromWkb( OGRGeometryH, const void*, int );
 OGRErr CPL_DLL OGR_G_ExportToWkb( OGRGeometryH, OGRwkbByteOrder, unsigned char*);
 OGRErr CPL_DLL OGR_G_ExportToIsoWkb( OGRGeometryH, OGRwkbByteOrder, unsigned char*);
 int    CPL_DLL OGR_G_WkbSize( OGRGeometryH hGeom );
+size_t CPL_DLL OGR_G_WkbSizeEx( OGRGeometryH hGeom );
 OGRErr CPL_DLL OGR_G_ImportFromWkt( OGRGeometryH, char ** );
 OGRErr CPL_DLL OGR_G_ExportToWkt( OGRGeometryH, char ** );
 OGRErr CPL_DLL OGR_G_ExportToIsoWkt( OGRGeometryH, char ** );

--- a/gdal/ogr/ogr_geometry.h
+++ b/gdal/ogr/ogr_geometry.h
@@ -346,15 +346,15 @@ class CPL_DLL OGRGeometry
                      OGRErr (*pfnAddCurveDirectly)(OGRGeometry* poSelf,
                                                    OGRCurve* poCurve) );
     OGRErr       importPreambleFromWkb( const unsigned char * pabyData,
-                                         int nSize,
+                                         size_t nSize,
                                          OGRwkbByteOrder& eByteOrder,
                                          OGRwkbVariant eWkbVariant );
     OGRErr       importPreambleOfCollectionFromWkb(
                      const unsigned char * pabyData,
-                     int& nSize,
-                     int& nDataOffset,
+                     size_t& nSize,
+                     size_t& nDataOffset,
                      OGRwkbByteOrder& eByteOrder,
-                     int nMinSubGeomSize,
+                     size_t nMinSubGeomSize,
                      int& nGeomCount,
                      OGRwkbVariant eWkbVariant );
     OGRErr       PointOnSurfaceInternal( OGRPoint * poPoint ) const;
@@ -412,13 +412,13 @@ class CPL_DLL OGRGeometry
     virtual void getEnvelope( OGREnvelope3D * psEnvelope ) const = 0;
 
     // IWks Interface.
-    virtual int WkbSize() const = 0;
-    OGRErr importFromWkb( const GByte*, int=-1,
+    virtual size_t WkbSize() const = 0;
+    OGRErr importFromWkb( const GByte*, size_t=-1,
                                   OGRwkbVariant=wkbVariantOldOgc );
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) = 0;
+                                  size_t& nBytesConsumedOut ) = 0;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc ) const = 0;
     virtual OGRErr importFromWkt( const char ** ppszInput ) = 0;
@@ -951,11 +951,11 @@ class CPL_DLL OGRPoint : public OGRGeometry
     OGRPoint& operator=( const OGRPoint& other );
 
     // IWks Interface
-    int WkbSize() const override;
+    size_t WkbSize() const override;
     OGRErr importFromWkb( const unsigned char *,
-                          int,
+                          size_t,
                           OGRwkbVariant,
-                          int& nBytesConsumedOut ) override;
+                          size_t& nBytesConsumedOut ) override;
     OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                         OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -1276,11 +1276,11 @@ class CPL_DLL OGRSimpleCurve: public OGRCurve
     ConstIterator end() const;
 
     // IWks Interface.
-    virtual int WkbSize() const override;
+    virtual size_t WkbSize() const override;
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -1481,16 +1481,28 @@ class CPL_DLL OGRLinearRing : public OGRLineString
 {
     static OGRLineString*       CasterToLineString( OGRCurve* poCurve );
 
+    // IWks Interface - Note this isn't really a first class object
+    // for the purposes of WKB form.  These methods always fail since this
+    // object can't be serialized on its own.
+    virtual size_t WkbSize() const override;
+    virtual OGRErr importFromWkb( const unsigned char *,
+                                  size_t,
+                                  OGRwkbVariant,
+                                  size_t& nBytesConsumedOut ) override;
+    virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
+                                OGRwkbVariant=wkbVariantOldOgc )
+        const override;
+
   protected:
 //! @cond Doxygen_Suppress
     friend class OGRPolygon;
     friend class OGRTriangle;
 
     // These are not IWks compatible ... just a convenience for OGRPolygon.
-    virtual int _WkbSize( int _flags ) const;
+    virtual size_t _WkbSize( int _flags ) const;
     virtual OGRErr _importFromWkb( OGRwkbByteOrder, int _flags,
-                                   const unsigned char *, int,
-                                   int& nBytesConsumedOut );
+                                   const unsigned char *, size_t,
+                                   size_t& nBytesConsumedOut );
     virtual OGRErr _exportToWkb( OGRwkbByteOrder, int _flags,
                                  unsigned char * ) const;
 
@@ -1529,18 +1541,6 @@ class CPL_DLL OGRLinearRing : public OGRLineString
 
     virtual void accept(IOGRGeometryVisitor* visitor) override { visitor->visit(this); }
     virtual void accept(IOGRConstGeometryVisitor* visitor) const override { visitor->visit(this); }
-
-    // IWks Interface - Note this isn't really a first class object
-    // for the purposes of WKB form.  These methods always fail since this
-    // object can't be serialized on its own.
-    virtual int WkbSize() const override;
-    virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
-                                  OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
-    virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
-                                OGRwkbVariant=wkbVariantOldOgc )
-        const override;
 
     OGR_ALLOW_UPCAST_TO(LineString)
     OGR_ALLOW_CAST_TO_THIS(LinearRing)
@@ -1589,9 +1589,9 @@ class CPL_DLL OGRCircularString : public OGRSimpleCurve
 
     // IWks Interface.
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -1705,23 +1705,23 @@ class CPL_DLL OGRCurveCollection
 
     OGRErr          addCurveDirectly( OGRGeometry* poGeom, OGRCurve* poCurve,
                                       int bNeedRealloc );
-    int             WkbSize() const;
+    size_t          WkbSize() const;
     OGRErr          importPreambleFromWkb( OGRGeometry* poGeom,
                                             const unsigned char * pabyData,
-                                            int& nSize,
-                                            int& nDataOffset,
+                                            size_t& nSize,
+                                            size_t& nDataOffset,
                                             OGRwkbByteOrder& eByteOrder,
-                                            int nMinSubGeomSize,
+                                            size_t nMinSubGeomSize,
                                             OGRwkbVariant eWkbVariant );
     OGRErr      importBodyFromWkb(
                     OGRGeometry* poGeom,
                     const unsigned char * pabyData,
-                    int nSize,
-                    int bAcceptCompoundCurve,
+                    size_t nSize,
+                    bool bAcceptCompoundCurve,
                     OGRErr (*pfnAddCurveDirectlyFromWkb)( OGRGeometry* poGeom,
                                                           OGRCurve* poCurve ),
                     OGRwkbVariant eWkbVariant,
-                    int& nBytesConsumedOut );
+                    size_t& nBytesConsumedOut );
     std::string     exportToWkt(const OGRGeometry *geom, const OGRWktOptions& opts,
                                 OGRErr *err) const;
     OGRErr          exportToWkb( const OGRGeometry* poGeom, OGRwkbByteOrder,
@@ -1818,11 +1818,11 @@ class CPL_DLL OGRCompoundCurve : public OGRCurve
     const ChildType* const * end() const { return oCC.end(); }
 
     // IWks Interface
-    virtual int WkbSize() const override;
+    virtual size_t WkbSize() const override;
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -2039,11 +2039,11 @@ class CPL_DLL OGRCurvePolygon : public OGRSurface
     virtual double      get_Area() const override;
 
     // IWks Interface
-    virtual int WkbSize() const override;
+    virtual size_t WkbSize() const override;
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -2194,11 +2194,11 @@ class CPL_DLL OGRPolygon : public OGRCurvePolygon
         const char* const* papszOptions = nullptr) const override;
 
     // IWks Interface.
-    virtual int WkbSize() const override;
+    virtual size_t WkbSize() const override;
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -2301,9 +2301,9 @@ class CPL_DLL OGRTriangle : public OGRPolygon
 
     // IWks Interface.
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
 
     // New methods rewritten from OGRPolygon/OGRCurvePolygon/OGRGeometry.
     virtual OGRErr addRingDirectly( OGRCurve * poNewRing ) override;
@@ -2338,9 +2338,9 @@ class CPL_DLL OGRTriangle : public OGRPolygon
 class CPL_DLL OGRGeometryCollection : public OGRGeometry
 {
     OGRErr      importFromWkbInternal( const unsigned char * pabyData,
-                                       int nSize,
+                                       size_t nSize,
                                        int nRecLevel,
-                                       OGRwkbVariant, int& nBytesConsumedOut );
+                                       OGRwkbVariant, size_t& nBytesConsumedOut );
     OGRErr      importFromWktInternal( const char **ppszInput, int nRecLevel );
 
   protected:
@@ -2397,11 +2397,11 @@ class CPL_DLL OGRGeometryCollection : public OGRGeometry
         const char* const* papszOptions = nullptr ) const override;
 
     // IWks Interface
-    virtual int WkbSize() const override;
+    virtual size_t WkbSize() const override;
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -2738,13 +2738,13 @@ class CPL_DLL OGRPolyhedralSurface : public OGRSurface
     const ChildType* const* end() const { return oMP.end(); }
 
     // IWks Interface.
-    virtual int WkbSize() const override;
+    virtual size_t WkbSize() const override;
     virtual const char *getGeometryName() const override;
     virtual OGRwkbGeometryType getGeometryType() const  override;
     virtual OGRErr importFromWkb( const unsigned char *,
-                                  int,
+                                  size_t,
                                   OGRwkbVariant,
-                                  int& nBytesConsumedOut ) override;
+                                  size_t& nBytesConsumedOut ) override;
     virtual OGRErr exportToWkb( OGRwkbByteOrder, unsigned char *,
                                 OGRwkbVariant=wkbVariantOldOgc )
         const override;
@@ -3224,14 +3224,14 @@ class CPL_DLL OGRGeometryFactory
                                          int nRecLevel );
   public:
     static OGRErr createFromWkb( const void *, OGRSpatialReference *,
-                                 OGRGeometry **, int = -1,
+                                 OGRGeometry **, size_t = -1,
                                  OGRwkbVariant=wkbVariantOldOgc );
     static OGRErr createFromWkb( const void * pabyData,
                                  OGRSpatialReference *,
                                  OGRGeometry **,
-                                 int nSize,
+                                 size_t nSize,
                                  OGRwkbVariant eVariant,
-                                 int& nBytesConsumedOut );
+                                 size_t& nBytesConsumedOut );
     static OGRErr createFromWkt( const char* , OGRSpatialReference *,
                                  OGRGeometry ** );
     static OGRErr createFromWkt( const char **, OGRSpatialReference *,

--- a/gdal/ogr/ogrcircularstring.cpp
+++ b/gdal/ogr/ogrcircularstring.cpp
@@ -146,9 +146,9 @@ OGRCircularString *OGRCircularString::clone() const
 /************************************************************************/
 
 OGRErr OGRCircularString::importFromWkb( const unsigned char * pabyData,
-                                         int nSize,
+                                         size_t nSize,
                                          OGRwkbVariant eWkbVariant,
-                                         int& nBytesConsumedOut )
+                                         size_t& nBytesConsumedOut )
 
 {
     OGRErr eErr = OGRSimpleCurve::importFromWkb(pabyData, nSize,

--- a/gdal/ogr/ogrcompoundcurve.cpp
+++ b/gdal/ogr/ogrcompoundcurve.cpp
@@ -135,7 +135,7 @@ const char * OGRCompoundCurve::getGeometryName() const
 /************************************************************************/
 /*                              WkbSize()                               */
 /************************************************************************/
-int OGRCompoundCurve::WkbSize() const
+size_t OGRCompoundCurve::WkbSize() const
 {
     return oCC.WkbSize();
 }
@@ -156,12 +156,12 @@ OGRErr OGRCompoundCurve::addCurveDirectlyFromWkb( OGRGeometry* poSelf,
 /************************************************************************/
 
 OGRErr OGRCompoundCurve::importFromWkb( const unsigned char * pabyData,
-                                        int nSize,
+                                        size_t nSize,
                                         OGRwkbVariant eWkbVariant,
-                                       int& nBytesConsumedOut )
+                                        size_t& nBytesConsumedOut )
 {
     OGRwkbByteOrder eByteOrder = wkbNDR;
-    int nDataOffset = 0;
+    size_t nDataOffset = 0;
     // coverity[tainted_data]
     OGRErr eErr = oCC.importPreambleFromWkb(this, pabyData, nSize, nDataOffset,
                                              eByteOrder, 9, eWkbVariant);
@@ -169,7 +169,7 @@ OGRErr OGRCompoundCurve::importFromWkb( const unsigned char * pabyData,
         return eErr;
 
     eErr =  oCC.importBodyFromWkb(this, pabyData + nDataOffset, nSize,
-                                 FALSE,  // bAcceptCompoundCurve
+                                 false,  // bAcceptCompoundCurve
                                  addCurveDirectlyFromWkb,
                                  eWkbVariant,
                                  nBytesConsumedOut);

--- a/gdal/ogr/ogrcurvecollection.cpp
+++ b/gdal/ogr/ogrcurvecollection.cpp
@@ -134,9 +134,9 @@ OGRCurveCollection::operator=( const OGRCurveCollection& other )
 /*                              WkbSize()                               */
 /************************************************************************/
 
-int OGRCurveCollection::WkbSize() const
+size_t OGRCurveCollection::WkbSize() const
 {
-    int nSize = 9;
+    size_t nSize = 9;
 
     for( auto&& poSubGeom: *this )
     {
@@ -179,10 +179,10 @@ OGRErr OGRCurveCollection::addCurveDirectly( OGRGeometry* poGeom,
 
 OGRErr OGRCurveCollection::importPreambleFromWkb( OGRGeometry* poGeom,
                                                    const unsigned char * pabyData,
-                                                   int& nSize,
-                                                   int& nDataOffset,
+                                                   size_t& nSize,
+                                                   size_t& nDataOffset,
                                                    OGRwkbByteOrder& eByteOrder,
-                                                   int nMinSubGeomSize,
+                                                   size_t nMinSubGeomSize,
                                                    OGRwkbVariant eWkbVariant )
 {
     OGRErr eErr = poGeom->importPreambleOfCollectionFromWkb(
@@ -215,27 +215,27 @@ OGRErr OGRCurveCollection::importPreambleFromWkb( OGRGeometry* poGeom,
 OGRErr OGRCurveCollection::importBodyFromWkb(
     OGRGeometry* poGeom,
     const unsigned char * pabyData,
-    int nSize,
-    int bAcceptCompoundCurve,
+    size_t nSize,
+    bool bAcceptCompoundCurve,
     OGRErr (*pfnAddCurveDirectlyFromWkb)(OGRGeometry* poGeom,
                                          OGRCurve* poCurve),
     OGRwkbVariant eWkbVariant,
-    int& nBytesConsumedOut )
+    size_t& nBytesConsumedOut )
 {
-    nBytesConsumedOut = -1;
+    nBytesConsumedOut = 0;
 /* -------------------------------------------------------------------- */
 /*      Get the Geoms.                                                  */
 /* -------------------------------------------------------------------- */
     const int nIter = nCurveCount;
     nCurveCount = 0;
-    int nDataOffset = 0;
+    size_t nDataOffset = 0;
     for( int iGeom = 0; iGeom < nIter; iGeom++ )
     {
         OGRGeometry* poSubGeom = nullptr;
 
         // Parses sub-geometry.
         const unsigned char* pabySubData = pabyData + nDataOffset;
-        if( nSize < 9 && nSize != -1 )
+        if( nSize < 9 && nSize != static_cast<size_t>(-1) )
             return OGRERR_NOT_ENOUGH_DATA;
 
         OGRwkbGeometryType eFlattenSubGeomType = wkbUnknown;
@@ -245,7 +245,7 @@ OGRErr OGRCurveCollection::importBodyFromWkb(
         eFlattenSubGeomType = wkbFlatten(eFlattenSubGeomType);
 
         OGRErr eErr = OGRERR_NONE;
-        int nSubGeomBytesConsumedOut = -1;
+        size_t nSubGeomBytesConsumedOut = 0;
         if( (eFlattenSubGeomType != wkbCompoundCurve &&
              OGR_GT_IsCurve(eFlattenSubGeomType)) ||
             (bAcceptCompoundCurve && eFlattenSubGeomType == wkbCompoundCurve) )
@@ -267,7 +267,7 @@ OGRErr OGRCurveCollection::importBodyFromWkb(
         if( eErr == OGRERR_NONE )
         {
             CPLAssert( nSubGeomBytesConsumedOut > 0 );
-            if( nSize != -1 )
+            if( nSize != static_cast<size_t>(-1) )
             {
                 CPLAssert( nSize >= nSubGeomBytesConsumedOut );
                 nSize -= nSubGeomBytesConsumedOut;
@@ -409,7 +409,7 @@ OGRErr OGRCurveCollection::exportToWkb( const OGRGeometry* poGeom,
     }
 
     // TODO(schwehr): Where do these 9 values come from?
-    int nOffset = 9;
+    size_t nOffset = 9;
 
 /* ==================================================================== */
 /*      Serialize each of the Geoms.                                    */

--- a/gdal/ogr/ogrcurvepolygon.cpp
+++ b/gdal/ogr/ogrcurvepolygon.cpp
@@ -422,7 +422,7 @@ OGRErr OGRCurvePolygon::addRingDirectlyInternal( OGRCurve* poNewRing,
 /*      representation including the byte order, and type information.  */
 /************************************************************************/
 
-int OGRCurvePolygon::WkbSize() const
+size_t OGRCurvePolygon::WkbSize() const
 
 {
     return oCC.WkbSize();
@@ -447,14 +447,14 @@ OGRErr OGRCurvePolygon::addCurveDirectlyFromWkb( OGRGeometry* poSelf,
 /************************************************************************/
 
 OGRErr OGRCurvePolygon::importFromWkb( const unsigned char * pabyData,
-                                       int nSize,
+                                       size_t nSize,
                                        OGRwkbVariant eWkbVariant,
-                                       int& nBytesConsumedOut )
+                                       size_t& nBytesConsumedOut )
 
 {
-    nBytesConsumedOut = -1;
+    nBytesConsumedOut = 0;
     OGRwkbByteOrder eByteOrder;
-    int nDataOffset = 0;
+    size_t nDataOffset = 0;
     // coverity[tainted_data]
     OGRErr eErr = oCC.importPreambleFromWkb(this, pabyData, nSize, nDataOffset,
                                              eByteOrder, 9, eWkbVariant);
@@ -462,7 +462,7 @@ OGRErr OGRCurvePolygon::importFromWkb( const unsigned char * pabyData,
         return eErr;
 
     eErr = oCC.importBodyFromWkb(this, pabyData + nDataOffset, nSize,
-                                 TRUE,  // bAcceptCompoundCurve
+                                 true,  // bAcceptCompoundCurve
                                  addCurveDirectlyFromWkb,
                                  eWkbVariant,
                                  nBytesConsumedOut );

--- a/gdal/ogr/ogrgeometryfactory.cpp
+++ b/gdal/ogr/ogrgeometryfactory.cpp
@@ -95,7 +95,7 @@ CPL_CVSID("$Id$")
  *                  of failure. If not NULL, *ppoReturn should be freed with
  *                  OGRGeometryFactory::destroyGeometry() after use.
  * @param nBytes the number of bytes available in pabyData, or -1 if it isn't
- *               known.
+ *               known
  * @param eWkbVariant WKB variant.
  *
  * @return OGRERR_NONE if all goes well, otherwise any of
@@ -106,11 +106,11 @@ CPL_CVSID("$Id$")
 OGRErr OGRGeometryFactory::createFromWkb( const void *pabyData,
                                           OGRSpatialReference * poSR,
                                           OGRGeometry **ppoReturn,
-                                          int nBytes,
+                                          size_t nBytes,
                                           OGRwkbVariant eWkbVariant )
 
 {
-    int nBytesConsumedOutIgnored = -1;
+    size_t nBytesConsumedOutIgnored = 0;
     return createFromWkb( pabyData,
                           poSR,
                           ppoReturn,
@@ -143,7 +143,7 @@ OGRErr OGRGeometryFactory::createFromWkb( const void *pabyData,
  *                  of failure. If not NULL, *ppoReturn should be freed with
  *                  OGRGeometryFactory::destroyGeometry() after use.
  * @param nBytes the number of bytes available in pabyData, or -1 if it isn't
- *               known.
+ *               known
  * @param eWkbVariant WKB variant.
  * @param nBytesConsumedOut output parameter. Number of bytes consumed.
  *
@@ -156,16 +156,16 @@ OGRErr OGRGeometryFactory::createFromWkb( const void *pabyData,
 OGRErr OGRGeometryFactory::createFromWkb( const void *pabyData,
                                           OGRSpatialReference * poSR,
                                           OGRGeometry **ppoReturn,
-                                          int nBytes,
+                                          size_t nBytes,
                                           OGRwkbVariant eWkbVariant,
-                                          int& nBytesConsumedOut )
+                                          size_t& nBytesConsumedOut )
 
 {
     const GByte* l_pabyData = static_cast<const GByte*>(pabyData);
-    nBytesConsumedOut = -1;
+    nBytesConsumedOut = 0;
     *ppoReturn = nullptr;
 
-    if( nBytes < 9 && nBytes != -1 )
+    if( nBytes < 9 && nBytes != static_cast<size_t>(-1) )
         return OGRERR_NOT_ENOUGH_DATA;
 
 /* -------------------------------------------------------------------- */
@@ -276,6 +276,52 @@ OGRErr CPL_DLL OGR_G_CreateFromWkb( const void *pabyData,
                                     OGRSpatialReferenceH hSRS,
                                     OGRGeometryH *phGeometry,
                                     int nBytes )
+
+{
+    return OGRGeometryFactory::createFromWkb(
+        pabyData,
+        OGRSpatialReference::FromHandle(hSRS),
+        reinterpret_cast<OGRGeometry **>(phGeometry),
+        nBytes );
+}
+
+/************************************************************************/
+/*                      OGR_G_CreateFromWkbEx()                         */
+/************************************************************************/
+/**
+ * \brief Create a geometry object of the appropriate type from its
+ * well known binary representation.
+ *
+ * Note that if nBytes is passed as zero, no checking can be done on whether
+ * the pabyData is sufficient.  This can result in a crash if the input
+ * data is corrupt.  This function returns no indication of the number of
+ * bytes from the data source actually used to represent the returned
+ * geometry object.  Use OGR_G_WkbSizeEx() on the returned geometry to
+ * establish the number of bytes it required in WKB format.
+ *
+ * The OGRGeometryFactory::createFromWkb() CPP method is the same as this
+ * function.
+ *
+ * @param pabyData pointer to the input BLOB data.
+ * @param hSRS handle to the spatial reference to be assigned to the
+ *             created geometry object.  This may be NULL.
+ * @param phGeometry the newly created geometry object will
+ * be assigned to the indicated handle on return.  This will be NULL in case
+ * of failure. If not NULL, *phGeometry should be freed with
+ * OGR_G_DestroyGeometry() after use.
+ * @param nBytes the number of bytes of data available in pabyData, or -1
+ * if it is not known, but assumed to be sufficient.
+ *
+ * @return OGRERR_NONE if all goes well, otherwise any of
+ * OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or
+ * OGRERR_CORRUPT_DATA may be returned.
+ * @since GDAL 3.3
+ */
+
+OGRErr CPL_DLL OGR_G_CreateFromWkbEx( const void *pabyData,
+                                      OGRSpatialReferenceH hSRS,
+                                      OGRGeometryH *phGeometry,
+                                      size_t nBytes )
 
 {
     return OGRGeometryFactory::createFromWkb(

--- a/gdal/ogr/ogrlinearring.cpp
+++ b/gdal/ogr/ogrlinearring.cpp
@@ -137,7 +137,7 @@ const char * OGRLinearRing::getGeometryName() const
 /*      Disable this method.                                            */
 /************************************************************************/
 
-int OGRLinearRing::WkbSize() const
+size_t OGRLinearRing::WkbSize() const
 
 {
     return 0;
@@ -150,9 +150,9 @@ int OGRLinearRing::WkbSize() const
 /************************************************************************/
 
 OGRErr OGRLinearRing::importFromWkb( const unsigned char * /*pabyData*/,
-                                     int /*nSize*/,
+                                     size_t /*nSize*/,
                                      OGRwkbVariant /*eWkbVariant*/,
-                                     int& /* nBytesConsumedOut */ )
+                                     size_t& /* nBytesConsumedOut */ )
 
 {
     return OGRERR_UNSUPPORTED_OPERATION;
@@ -182,12 +182,12 @@ OGRErr OGRLinearRing::exportToWkb( CPL_UNUSED OGRwkbByteOrder eByteOrder,
 //! @cond Doxygen_Suppress
 OGRErr OGRLinearRing::_importFromWkb( OGRwkbByteOrder eByteOrder, int _flags,
                                       const unsigned char * pabyData,
-                                      int nBytesAvailable,
-                                      int& nBytesConsumedOut )
+                                      size_t nBytesAvailable,
+                                      size_t& nBytesConsumedOut )
 
 {
-    nBytesConsumedOut = -1;
-    if( nBytesAvailable < 4 && nBytesAvailable != -1 )
+    nBytesConsumedOut = 0;
+    if( nBytesAvailable < 4 && nBytesAvailable != static_cast<size_t>(-1) )
         return OGRERR_NOT_ENOUGH_DATA;
 
 /* -------------------------------------------------------------------- */
@@ -203,18 +203,21 @@ OGRErr OGRLinearRing::_importFromWkb( OGRwkbByteOrder eByteOrder, int _flags,
     // Check if the wkb stream buffer is big enough to store
     // fetched number of points.
     // 16, 24, or 32 - size of point structure.
-    int nPointSize = 0;
+    size_t nPointSize = 0;
     if( (_flags & OGR_G_3D) && (_flags & OGR_G_MEASURED) )
         nPointSize = 32;
     else if( (_flags & OGR_G_3D) || (_flags & OGR_G_MEASURED) )
         nPointSize = 24;
     else
         nPointSize = 16;
-    if( nNewNumPoints < 0 || nNewNumPoints > INT_MAX / nPointSize )
-        return OGRERR_CORRUPT_DATA;
-    int nBufferMinSize = nPointSize * nNewNumPoints;
 
-    if( nBytesAvailable != -1 && nBufferMinSize > nBytesAvailable - 4 )
+    if( nNewNumPoints < 0 ||
+        static_cast<size_t>(nNewNumPoints) > std::numeric_limits<size_t>::max() / nPointSize )
+    {
+        return OGRERR_CORRUPT_DATA;
+    }
+    const size_t nBufferMinSize = nPointSize * nNewNumPoints;
+    if( nBytesAvailable != static_cast<size_t>(-1) && nBufferMinSize > nBytesAvailable - 4 )
     {
         CPLError( CE_Failure, CPLE_AppDefined,
                   "Length of input WKB is too small" );
@@ -242,7 +245,7 @@ OGRErr OGRLinearRing::_importFromWkb( OGRwkbByteOrder eByteOrder, int _flags,
 /* -------------------------------------------------------------------- */
     if( (flags & OGR_G_3D) && (flags & OGR_G_MEASURED) )
     {
-        for( int i = 0; i < nPointCount; i++ )
+        for( size_t i = 0; i < static_cast<size_t>(nPointCount); i++ )
         {
             memcpy( &(paoPoints[i].x), pabyData + 4 + 32 * i, 8 );
             memcpy( &(paoPoints[i].y), pabyData + 4 + 32 * i + 8, 8 );
@@ -252,7 +255,7 @@ OGRErr OGRLinearRing::_importFromWkb( OGRwkbByteOrder eByteOrder, int _flags,
     }
     else if( flags & OGR_G_MEASURED )
     {
-        for( int i = 0; i < nPointCount; i++ )
+        for( size_t i = 0; i < static_cast<size_t>(nPointCount); i++ )
         {
             memcpy( &(paoPoints[i].x), pabyData + 4 + 24 * i, 8 );
             memcpy( &(paoPoints[i].y), pabyData + 4 + 24 * i + 8, 8 );
@@ -261,7 +264,7 @@ OGRErr OGRLinearRing::_importFromWkb( OGRwkbByteOrder eByteOrder, int _flags,
     }
     else if( flags & OGR_G_3D )
     {
-        for( int i = 0; i < nPointCount; i++ )
+        for( size_t i = 0; i < static_cast<size_t>(nPointCount); i++ )
         {
             memcpy( &(paoPoints[i].x), pabyData + 4 + 24 * i, 8 );
             memcpy( &(paoPoints[i].y), pabyData + 4 + 24 * i + 8, 8 );
@@ -270,7 +273,7 @@ OGRErr OGRLinearRing::_importFromWkb( OGRwkbByteOrder eByteOrder, int _flags,
     }
     else
     {
-        memcpy( paoPoints, pabyData + 4, 16 * nPointCount );
+        memcpy( paoPoints, pabyData + 4, 16 * static_cast<size_t>(nPointCount) );
     }
 
 /* -------------------------------------------------------------------- */
@@ -278,7 +281,7 @@ OGRErr OGRLinearRing::_importFromWkb( OGRwkbByteOrder eByteOrder, int _flags,
 /* -------------------------------------------------------------------- */
     if( OGR_SWAP( eByteOrder ) )
     {
-        for( int i = 0; i < nPointCount; i++ )
+        for( size_t i = 0; i < static_cast<size_t>(nPointCount); i++ )
         {
             CPL_SWAPDOUBLE( &(paoPoints[i].x) );
             CPL_SWAPDOUBLE( &(paoPoints[i].y) );
@@ -317,11 +320,11 @@ OGRErr OGRLinearRing::_exportToWkb( OGRwkbByteOrder eByteOrder, int _flags,
 /* -------------------------------------------------------------------- */
 /*      Copy in the raw data.                                           */
 /* -------------------------------------------------------------------- */
-    int nWords = 0;
+    size_t nWords = 0;
     if( (_flags & OGR_G_3D) && (_flags & OGR_G_MEASURED) )
     {
-        nWords = 4 * nPointCount;
-        for( int i = 0; i < nPointCount; i++ )
+        nWords = 4 * static_cast<size_t>(nPointCount);
+        for( size_t i = 0; i < static_cast<size_t>(nPointCount); i++ )
         {
             memcpy( pabyData+4+i*32, &(paoPoints[i].x), 8 );
             memcpy( pabyData+4+i*32+8, &(paoPoints[i].y), 8 );
@@ -337,8 +340,8 @@ OGRErr OGRLinearRing::_exportToWkb( OGRwkbByteOrder eByteOrder, int _flags,
     }
     else if( _flags & OGR_G_MEASURED )
     {
-        nWords = 3 * nPointCount;
-        for( int i = 0; i < nPointCount; i++ )
+        nWords = 3 * static_cast<size_t>(nPointCount);
+        for( size_t i = 0; i < static_cast<size_t>(nPointCount); i++ )
         {
             memcpy( pabyData+4+i*24, &(paoPoints[i].x), 8 );
             memcpy( pabyData+4+i*24+8, &(paoPoints[i].y), 8 );
@@ -350,8 +353,8 @@ OGRErr OGRLinearRing::_exportToWkb( OGRwkbByteOrder eByteOrder, int _flags,
     }
     else if( _flags & OGR_G_3D )
     {
-        nWords = 3 * nPointCount;
-        for( int i = 0; i < nPointCount; i++ )
+        nWords = 3 * static_cast<size_t>(nPointCount);
+        for( size_t i = 0; i < static_cast<size_t>(nPointCount); i++ )
         {
             memcpy( pabyData+4+i*24, &(paoPoints[i].x), 8 );
             memcpy( pabyData+4+i*24+8, &(paoPoints[i].y), 8 );
@@ -363,8 +366,8 @@ OGRErr OGRLinearRing::_exportToWkb( OGRwkbByteOrder eByteOrder, int _flags,
     }
     else
     {
-        nWords = 2 * nPointCount;
-        memcpy( pabyData+4, paoPoints, 16 * nPointCount );
+        nWords = 2 * static_cast<size_t>(nPointCount);
+        memcpy( pabyData+4, paoPoints, 16 * static_cast<size_t>(nPointCount) );
     }
 
 /* -------------------------------------------------------------------- */
@@ -372,10 +375,10 @@ OGRErr OGRLinearRing::_exportToWkb( OGRwkbByteOrder eByteOrder, int _flags,
 /* -------------------------------------------------------------------- */
     if( OGR_SWAP( eByteOrder ) )
     {
-        int nCount = CPL_SWAP32( nPointCount );
+        const int nCount = CPL_SWAP32( nPointCount );
         memcpy( pabyData, &nCount, 4 );
 
-        for( int i = 0; i < nWords; i++ )
+        for( size_t i = 0; i < nWords; i++ )
         {
             CPL_SWAPDOUBLE( pabyData + 4 + 8 * i );
         }
@@ -390,15 +393,15 @@ OGRErr OGRLinearRing::_exportToWkb( OGRwkbByteOrder eByteOrder, int _flags,
 /*      Helper method for OGRPolygon.  NOT THE NORMAL WkbSize() METHOD. */
 /************************************************************************/
 
-int OGRLinearRing::_WkbSize( int _flags ) const
+size_t OGRLinearRing::_WkbSize( int _flags ) const
 
 {
     if( (_flags & OGR_G_3D) && (_flags & OGR_G_MEASURED) )
-        return 4 + 32 * nPointCount;
+        return 4 + 32 * static_cast<size_t>(nPointCount);
     else if( (_flags & OGR_G_3D) || (_flags & OGR_G_MEASURED) )
-        return 4 + 24 * nPointCount;
+        return 4 + 24 * static_cast<size_t>(nPointCount);
     else
-        return 4 + 16 * nPointCount;
+        return 4 + 16 * static_cast<size_t>(nPointCount);
 }
 //! @endcond
 

--- a/gdal/ogr/ogrpoint.cpp
+++ b/gdal/ogr/ogrpoint.cpp
@@ -293,7 +293,7 @@ void OGRPoint::setCoordinateDimension( int nNewDimension )
 /*      representation including the byte order, and type information.  */
 /************************************************************************/
 
-int OGRPoint::WkbSize() const
+size_t OGRPoint::WkbSize() const
 
 {
     if( (flags & OGR_G_3D) && (flags & OGR_G_MEASURED) )
@@ -312,12 +312,12 @@ int OGRPoint::WkbSize() const
 /************************************************************************/
 
 OGRErr OGRPoint::importFromWkb( const unsigned char *pabyData,
-                                int nSize,
+                                size_t nSize,
                                 OGRwkbVariant eWkbVariant,
-                                int& nBytesConsumedOut )
+                                size_t& nBytesConsumedOut )
 
 {
-    nBytesConsumedOut = -1;
+    nBytesConsumedOut = 0;
     OGRwkbByteOrder eByteOrder = wkbNDR;
 
     flags = 0;
@@ -327,7 +327,7 @@ OGRErr OGRPoint::importFromWkb( const unsigned char *pabyData,
     if( eErr != OGRERR_NONE )
         return eErr;
 
-    if( nSize != -1 )
+    if( nSize != static_cast<size_t>(-1) )
     {
         if( (nSize < 37) && ((flags & OGR_G_3D) && (flags & OGR_G_MEASURED)) )
             return OGRERR_NOT_ENOUGH_DATA;

--- a/gdal/ogr/ogrpolygon.cpp
+++ b/gdal/ogr/ogrpolygon.cpp
@@ -306,10 +306,10 @@ int OGRPolygon::checkRing( OGRCurve * poNewRing ) const
 /*      representation including the byte order, and type information.  */
 /************************************************************************/
 
-int OGRPolygon::WkbSize() const
+size_t OGRPolygon::WkbSize() const
 
 {
-    int nSize = 9;
+    size_t nSize = 9;
 
     for( auto&& poRing: *this )
     {
@@ -327,14 +327,14 @@ int OGRPolygon::WkbSize() const
 /************************************************************************/
 
 OGRErr OGRPolygon::importFromWkb( const unsigned char * pabyData,
-                                  int nSize,
+                                  size_t nSize,
                                   OGRwkbVariant eWkbVariant,
-                                  int& nBytesConsumedOut )
+                                  size_t& nBytesConsumedOut )
 
 {
-    nBytesConsumedOut = -1;
+    nBytesConsumedOut = 0;
     OGRwkbByteOrder eByteOrder = wkbNDR;
-    int nDataOffset = 0;
+    size_t nDataOffset = 0;
     // coverity[tainted_data]
     OGRErr eErr = oCC.importPreambleFromWkb(this, pabyData, nSize, nDataOffset,
                                              eByteOrder, 4, eWkbVariant);
@@ -348,7 +348,7 @@ OGRErr OGRPolygon::importFromWkb( const unsigned char * pabyData,
     {
         OGRLinearRing* poLR = new OGRLinearRing();
         oCC.papoCurves[iRing] = poLR;
-        int nBytesConsumedRing = -1;
+        size_t nBytesConsumedRing = 0;
         eErr = poLR->_importFromWkb( eByteOrder, flags,
                                      pabyData + nDataOffset,
                                      nSize,
@@ -361,7 +361,7 @@ OGRErr OGRPolygon::importFromWkb( const unsigned char * pabyData,
         }
 
         CPLAssert( nBytesConsumedRing > 0 );
-        if( nSize != -1 )
+        if( nSize != static_cast<size_t>(-1) )
         {
             CPLAssert( nSize >= nBytesConsumedRing );
             nSize -= nBytesConsumedRing;
@@ -433,7 +433,7 @@ OGRErr OGRPolygon::exportToWkb( OGRwkbByteOrder eByteOrder,
 /* ==================================================================== */
 /*      Serialize each of the rings.                                    */
 /* ==================================================================== */
-    int nOffset = 9;
+    size_t nOffset = 9;
 
     for( auto&& poRing: *this )
     {

--- a/gdal/ogr/ogrpolyhedralsurface.cpp
+++ b/gdal/ogr/ogrpolyhedralsurface.cpp
@@ -134,9 +134,9 @@ OGRwkbGeometryType OGRPolyhedralSurface::getGeometryType() const
 /*                              WkbSize()                               */
 /************************************************************************/
 
-int OGRPolyhedralSurface::WkbSize() const
+size_t OGRPolyhedralSurface::WkbSize() const
 {
-    int nSize = 9;
+    size_t nSize = 9;
     for( auto&& poSubGeom: *this )
     {
         nSize += poSubGeom->WkbSize();
@@ -195,14 +195,14 @@ void OGRPolyhedralSurface::getEnvelope( OGREnvelope3D * psEnvelope ) const
 /************************************************************************/
 
 OGRErr OGRPolyhedralSurface::importFromWkb ( const unsigned char * pabyData,
-                                             int nSize,
+                                             size_t nSize,
                                              OGRwkbVariant eWkbVariant,
-                                             int& nBytesConsumedOut )
+                                             size_t& nBytesConsumedOut )
 {
-    nBytesConsumedOut = -1;
+    nBytesConsumedOut = 0;
     oMP.nGeomCount = 0;
     OGRwkbByteOrder eByteOrder = wkbXDR;
-    int nDataOffset = 0;
+    size_t nDataOffset = 0;
     OGRErr eErr = importPreambleOfCollectionFromWkb( pabyData,
                                                       nSize,
                                                       nDataOffset,
@@ -230,7 +230,7 @@ OGRErr OGRPolyhedralSurface::importFromWkb ( const unsigned char * pabyData,
     {
         // Parse the polygons
         const unsigned char* pabySubData = pabyData + nDataOffset;
-        if( nSize < 9 && nSize != -1 )
+        if( nSize < 9 && nSize != static_cast<size_t>(-1) )
             return OGRERR_NOT_ENOUGH_DATA;
 
         OGRwkbGeometryType eSubGeomType;
@@ -248,7 +248,7 @@ OGRErr OGRPolyhedralSurface::importFromWkb ( const unsigned char * pabyData,
         }
 
         OGRGeometry* poSubGeom = nullptr;
-        int nSubGeomBytesConsumed = -1;
+        size_t nSubGeomBytesConsumed = 0;
         eErr = OGRGeometryFactory::createFromWkb( pabySubData, nullptr,
                                                   &poSubGeom, nSize,
                                                   eWkbVariant,
@@ -269,7 +269,7 @@ OGRErr OGRPolyhedralSurface::importFromWkb ( const unsigned char * pabyData,
             flags |= OGR_G_MEASURED;
 
         CPLAssert( nSubGeomBytesConsumed > 0 );
-        if( nSize != -1 )
+        if( nSize != static_cast<size_t>(-1) )
         {
             CPLAssert( nSize >= nSubGeomBytesConsumed );
             nSize -= nSubGeomBytesConsumed;
@@ -318,7 +318,7 @@ OGRErr  OGRPolyhedralSurface::exportToWkb ( OGRwkbByteOrder eByteOrder,
     else
         memcpy( pabyData+5, &oMP.nGeomCount, 4 );
 
-    int nOffset = 9;
+    size_t nOffset = 9;
 
     // serialize each of the geometries
     for( auto&& poSubGeom: *this )

--- a/gdal/ogr/ogrsf_frmts/arcobjects/aoutils.cpp
+++ b/gdal/ogr/ogrsf_frmts/arcobjects/aoutils.cpp
@@ -333,7 +333,7 @@ bool OGRGeometryToAOGeometry(OGRGeometry* pOGRGeom, esriGeometry::IGeometry** pp
 
   *ppGeometry = NULL;
 
-  long wkbSize = pOGRGeom->WkbSize();
+  long wkbSize = static_cast<long>(pOGRGeom->WkbSize());
   GByte* pWKB = (GByte *) CPLMalloc(wkbSize);
 
   if( pOGRGeom->exportToWkb( wkbNDR, pWKB ) != OGRERR_NONE )

--- a/gdal/ogr/ogrsf_frmts/ingres/ogringrestablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/ingres/ogringrestablelayer.cpp
@@ -990,13 +990,15 @@ OGRErr OGRIngresTableLayer::ICreateFeature( OGRFeature *poFeature )
     if( !osGeomText.empty() && poDS->IsNewIngres() == TRUE )
     {
         GByte * pabyWKB;
-        int nSize = poFeature->GetGeometryRef()->WkbSize();
-        pabyWKB = (GByte *) CPLMalloc(nSize);
+        const auto nSize = poFeature->GetGeometryRef()->WkbSize();
+        pabyWKB = (GByte *) VSI_MALLOC_VERBOSE(nSize);
+        if( pabyWKB )
+        {
+            poFeature->GetGeometryRef()->exportToWkb(wkbNDR, pabyWKB);
 
-        poFeature->GetGeometryRef()->exportToWkb(wkbNDR, pabyWKB);
-
-        oStmt.addInputParameter( IIAPI_LBYTE_TYPE, nSize, pabyWKB );
-        CPLFree(pabyWKB);
+            oStmt.addInputParameter( IIAPI_LBYTE_TYPE, nSize, pabyWKB );
+            CPLFree(pabyWKB);
+        }
 /*
  * Test code
         char * pszWKT;

--- a/gdal/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/gdal/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -184,7 +184,7 @@ class OGRPGLayer CPL_NON_FINAL: public OGRLayer
     int                 nCursorPage = 0;
     GIntBig             iNextShapeId = 0;
 
-    static char        *GByteArrayToBYTEA( const GByte* pabyData, int nLen);
+    static char        *GByteArrayToBYTEA( const GByte* pabyData, size_t nLen);
     static char        *GeometryToBYTEA( const OGRGeometry *, int nPostGISMajor, int nPostGISMinor );
     static GByte       *BYTEAToGByteArray( const char *pszBytea, int* pnLength );
     static OGRGeometry *BYTEAToGeometry( const char *, int bIsPostGIS1 );

--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -33,6 +33,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <set>
 #include <string>
@@ -1263,14 +1264,21 @@ static void OGR2SQLITE_ExportGeometry(OGRGeometry* poGeom, int nSRSId,
     /* the spatialite blob */
     else if( poGeom->hasCurveGeometry() )
     {
-        int nWkbSize = poGeom->WkbSize();
+        const size_t nWkbSize = poGeom->WkbSize();
+        if( nWkbSize + 1 >
+                static_cast<size_t>(std::numeric_limits<int>::max()) - nGeomBLOBLen )
+        {
+            CPLError(CE_Failure, CPLE_NotSupported, "Too large geometry");
+            nGeomBLOBLen = 0;
+            return;
+        }
 
         pabyGeomBLOB = (GByte*) CPLRealloc(pabyGeomBLOB,
                                 nGeomBLOBLen + nWkbSize + 1);
         poGeom->exportToWkb(wkbNDR, pabyGeomBLOB + nGeomBLOBLen, wkbVariantIso);
         /* Cheat a bit and add a end-of-blob spatialite marker */
         pabyGeomBLOB[nGeomBLOBLen + nWkbSize] = 0xFE;
-        nGeomBLOBLen += nWkbSize + 1;
+        nGeomBLOBLen += static_cast<int>(nWkbSize) + 1;
     }
 }
 

--- a/gdal/ogr/ogrsf_frmts/vfk/vfkdatablocksqlite.cpp
+++ b/gdal/ogr/ogrsf_frmts/vfk/vfkdatablocksqlite.cpp
@@ -30,6 +30,7 @@
  ****************************************************************************/
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <utility>
 
@@ -978,7 +979,7 @@ VFKFeatureSQLiteList VFKDataBlockSQLite::GetFeatures(const char **column, GUIntB
 */
 OGRErr VFKDataBlockSQLite::SaveGeometryToDB(const OGRGeometry *poGeom, int iRowId)
 {
-    int        rc, nWKBLen;
+    int        rc;
     CPLString  osSQL;
 
     sqlite3_stmt *hStmt = nullptr;
@@ -991,20 +992,29 @@ OGRErr VFKDataBlockSQLite::SaveGeometryToDB(const OGRGeometry *poGeom, int iRowI
         return OGRERR_FAILURE;
 
     if (poGeom) {
-        nWKBLen = poGeom->WkbSize();
-        GByte *pabyWKB = (GByte *) CPLMalloc(nWKBLen + 1);
-        poGeom->exportToWkb(wkbNDR, pabyWKB);
-
-        osSQL.Printf("UPDATE %s SET %s = ? WHERE rowid = %d",
-                     m_pszName, GEOM_COLUMN, iRowId);
-        hStmt = poReader->PrepareStatement(osSQL.c_str());
-
-        rc = sqlite3_bind_blob(hStmt, 1, pabyWKB, nWKBLen, CPLFree);
-        if (rc != SQLITE_OK) {
-            sqlite3_finalize(hStmt);
+        const size_t nWKBLen = poGeom->WkbSize();
+        if( nWKBLen > static_cast<size_t>(std::numeric_limits<int>::max()) )
+        {
             CPLError(CE_Failure, CPLE_AppDefined,
-                     "Storing geometry in DB failed");
+                     "Too large geometry");
             return OGRERR_FAILURE;
+        }
+        GByte *pabyWKB = (GByte *) VSI_MALLOC_VERBOSE(nWKBLen);
+        if( pabyWKB )
+        {
+            poGeom->exportToWkb(wkbNDR, pabyWKB);
+
+            osSQL.Printf("UPDATE %s SET %s = ? WHERE rowid = %d",
+                         m_pszName, GEOM_COLUMN, iRowId);
+            hStmt = poReader->PrepareStatement(osSQL.c_str());
+
+            rc = sqlite3_bind_blob(hStmt, 1, pabyWKB, static_cast<int>(nWKBLen), CPLFree);
+            if (rc != SQLITE_OK) {
+                sqlite3_finalize(hStmt);
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Storing geometry in DB failed");
+                return OGRERR_FAILURE;
+            }
         }
     }
     else { /* invalid */

--- a/gdal/ogr/ogrsf_frmts/wfs/ogrwfsjoinlayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/wfs/ogrwfsjoinlayer.cpp
@@ -602,22 +602,22 @@ OGRFeature* OGRWFSJoinLayer::GetNextFeature()
                     if( eType == OFTInteger )
                     {
                         int nVal = poNewFeature->GetFieldAsInteger(i);
-                        CPLMD5Update( &sMD5Context, (const GByte*)&nVal, sizeof(nVal));
+                        CPLMD5Update( &sMD5Context, &nVal, sizeof(nVal));
                     }
                     else if( eType == OFTInteger64 )
                     {
                         GIntBig nVal = poNewFeature->GetFieldAsInteger64(i);
-                        CPLMD5Update( &sMD5Context, (const GByte*)&nVal, sizeof(nVal));
+                        CPLMD5Update( &sMD5Context, &nVal, sizeof(nVal));
                     }
                     else if( eType == OFTReal )
                     {
                         double dfVal = poNewFeature->GetFieldAsDouble(i);
-                        CPLMD5Update( &sMD5Context, (const GByte*)&dfVal, sizeof(dfVal));
+                        CPLMD5Update( &sMD5Context, &dfVal, sizeof(dfVal));
                     }
                     else
                     {
                         const char* pszStr = poNewFeature->GetFieldAsString(i);
-                        CPLMD5Update( &sMD5Context, (const GByte*)pszStr, static_cast<int>(strlen(pszStr)));
+                        CPLMD5Update( &sMD5Context, pszStr, strlen(pszStr));
                     }
                 }
             }
@@ -634,11 +634,14 @@ OGRFeature* OGRWFSJoinLayer::GetNextFeature()
 
                     if( bDistinct )
                     {
-                        int nSize = poGeom->WkbSize();
-                        GByte* pabyGeom = (GByte*)CPLMalloc(nSize);
-                        poGeom->exportToWkb(wkbNDR, pabyGeom);
-                        CPLMD5Update( &sMD5Context, (const GByte*)pabyGeom, nSize);
-                        CPLFree(pabyGeom);
+                        const size_t nSize = poGeom->WkbSize();
+                        GByte* pabyGeom = (GByte*)VSI_MALLOC_VERBOSE(nSize);
+                        if( pabyGeom )
+                        {
+                            poGeom->exportToWkb(wkbNDR, pabyGeom);
+                            CPLMD5Update( &sMD5Context, pabyGeom, nSize);
+                            CPLFree(pabyGeom);
+                        }
                     }
 
                     poNewFeature->SetGeomFieldDirectly(i, poGeom);

--- a/gdal/ogr/ogrtriangle.cpp
+++ b/gdal/ogr/ogrtriangle.cpp
@@ -196,9 +196,9 @@ bool OGRTriangle::quickValidityCheck() const
 /************************************************************************/
 
 OGRErr OGRTriangle::importFromWkb( const unsigned char *pabyData,
-                                   int nSize,
+                                   size_t nSize,
                                    OGRwkbVariant eWkbVariant,
-                                   int& nBytesConsumedOut )
+                                   size_t& nBytesConsumedOut )
 {
     OGRErr eErr = OGRPolygon::importFromWkb( pabyData, nSize, eWkbVariant,
                                              nBytesConsumedOut );

--- a/gdal/port/cpl_md5.cpp
+++ b/gdal/port/cpl_md5.cpp
@@ -73,14 +73,22 @@ void CPLMD5Init( struct CPLMD5Context *context )
 * Update context to reflect the concatenation of another buffer full
 * of bytes.
 */
-void CPLMD5Update( struct CPLMD5Context *context, unsigned char const *buf,
-                   unsigned len )
+void CPLMD5Update( struct CPLMD5Context *context, const void *buf,
+                   size_t len )
 {
+    const GByte* pabyBuf = static_cast<const GByte*>(buf);
+    while( len > 0xffffffffU )
+    {
+        CPLMD5Update(context, pabyBuf, 0xffffffffU);
+        pabyBuf += 0xffffffffU;
+        len -= 0xffffffffU;
+    }
+
     // Update bitcount
     GUInt32 t = context->bits[0];
     if ((context->bits[0] = (t + (static_cast<GUInt32>(len) << 3)) & 0xffffffff) < t)
         context->bits[1]++;  /* Carry from low to high */
-    context->bits[1] += len >> 29;
+    context->bits[1] += static_cast<GUInt32>(len >> 29);
 
     t = (t >> 3) & 0x3f;  /* Bytes already in shsInfo->data */
 
@@ -93,28 +101,28 @@ void CPLMD5Update( struct CPLMD5Context *context, unsigned char const *buf,
         t = 64 - t;
         if( len < t )
         {
-            memcpy(p, buf, len);
+            memcpy(p, pabyBuf, len);
             return;
         }
-        memcpy(p, buf, t);
+        memcpy(p, pabyBuf, t);
         CPLMD5Transform(context->buf, context->in);
-        buf += t;
-        len -= static_cast<unsigned>(t);
+        pabyBuf += t;
+        len -= t;
     }
 
     /* Process data in 64-byte chunks */
 
     while( len >= 64 )
     {
-        memcpy(context->in, buf, 64);
+        memcpy(context->in, pabyBuf, 64);
         CPLMD5Transform(context->buf, context->in);
-        buf += 64;
+        pabyBuf += 64;
         len -= 64;
     }
 
     /* Handle any remaining bytes of data. */
 
-    memcpy(context->in, buf, len);
+    memcpy(context->in, pabyBuf, len);
 }
 
 /*
@@ -274,8 +282,7 @@ const char *CPLMD5String( const char *pszText )
 {
     struct CPLMD5Context context;
     CPLMD5Init(&context);
-    CPLMD5Update(&context, reinterpret_cast<unsigned char const *>(pszText),
-                  static_cast<int>(strlen(pszText)));
+    CPLMD5Update(&context, pszText, strlen(pszText));
     unsigned char hash[16];
     CPLMD5Final(hash, &context);
 

--- a/gdal/port/cpl_md5.h
+++ b/gdal/port/cpl_md5.h
@@ -18,8 +18,8 @@ struct CPLMD5Context {
 };
 
 void CPLMD5Init( struct CPLMD5Context *context );
-void CPLMD5Update( struct CPLMD5Context *context, unsigned char const *buf,
-                   unsigned len );
+void CPLMD5Update( struct CPLMD5Context *context, const void *buf,
+                   size_t len );
 void CPLMD5Final( unsigned char digest[16], struct CPLMD5Context *context );
 void CPLMD5Transform( GUInt32 buf[4], const unsigned char inraw[64] );
 

--- a/gdal/port/cpl_vsil_s3.cpp
+++ b/gdal/port/cpl_vsil_s3.cpp
@@ -2058,8 +2058,7 @@ std::set<CPLString> VSIS3FSHandler::DeleteObjects(const char* pszBucket,
     CPLString osContentMD5;
     struct CPLMD5Context context;
     CPLMD5Init(&context);
-    CPLMD5Update(&context, reinterpret_cast<unsigned char const *>(pszXML),
-                  static_cast<int>(strlen(pszXML)));
+    CPLMD5Update(&context, pszXML, strlen(pszXML));
     unsigned char hash[16];
     CPLMD5Final(hash, &context);
     char* pszBase64 = CPLBase64Encode(16, hash);
@@ -2368,8 +2367,7 @@ bool VSIS3FSHandler::SetFileMetadata( const char * pszFilename,
     {
         struct CPLMD5Context context;
         CPLMD5Init(&context);
-        CPLMD5Update(&context, reinterpret_cast<unsigned char const *>(osXML.c_str()),
-                    static_cast<int>(osXML.size()));
+        CPLMD5Update(&context, osXML.data(), osXML.size());
         unsigned char hash[16];
         CPLMD5Final(hash, &context);
         char* pszBase64 = CPLBase64Encode(16, hash);
@@ -3170,7 +3168,7 @@ static CPLString ComputeMD5OfLocalFile(VSILFILE* fp)
     while( true )
     {
         size_t nRead = VSIFReadL(&abyBuffer[0], 1, nBufferSize, fp);
-        CPLMD5Update(&context, &abyBuffer[0], static_cast<int>(nRead));
+        CPLMD5Update(&context, &abyBuffer[0], nRead);
         if( nRead < nBufferSize )
         {
             break;

--- a/gdal/swig/csharp/apps/WKT2WKB.cs
+++ b/gdal/swig/csharp/apps/WKT2WKB.cs
@@ -67,7 +67,7 @@ class WKT2WKB {
 
         Geometry geom = Geometry.CreateFromWkt(args[0]);
 
-		int wkbSize = geom.WkbSize();
+		long wkbSize = geom.WkbSize();
         if (wkbSize > 0)
         {
             byte[] wkb = new byte[wkbSize];

--- a/gdal/swig/include/csharp/ogr_csharp.i
+++ b/gdal/swig/include/csharp/ogr_csharp.i
@@ -46,14 +46,16 @@ DEFINE_EXTERNAL_CLASS(GDALMajorObjectShadow, OSGeo.GDAL.MajorObject)
 %typemap(cscode, noblock="1") OGRGeometryShadow {
   public int ExportToWkb( byte[] buffer, wkbByteOrder byte_order ) {
       int retval;
-      int size = WkbSize();
+      long size = WkbSize();
+      if (size > Int32.MaxValue)
+        throw new ArgumentException("Too big geometry (ExportToWkb)");
       if (buffer.Length < size)
         throw new ArgumentException("Buffer size is small (ExportToWkb)");
 
-      IntPtr ptr = Marshal.AllocHGlobal(size * Marshal.SizeOf(buffer[0]));
+      IntPtr ptr = Marshal.AllocHGlobal((int)size * Marshal.SizeOf(buffer[0]));
       try {
-          retval = ExportToWkb(size, ptr, byte_order);
-          Marshal.Copy(ptr, buffer, 0, size);
+          retval = ExportToWkb((int)size, ptr, byte_order);
+          Marshal.Copy(ptr, buffer, 0, (int)size);
       } finally {
           Marshal.FreeHGlobal(ptr);
       }

--- a/gdal/swig/include/java/typemaps_java.i
+++ b/gdal/swig/include/java/typemaps_java.i
@@ -495,7 +495,7 @@
 {
   /* %typemap(freearg) (int *nLen, char **pBuf ) */
   if( nLen$argnum ) {
-    free( pBuf$argnum );
+    VSIFree( pBuf$argnum );
   }
 }
 
@@ -504,6 +504,41 @@
 %typemap(jstype) (int *nLen, char **pBuf ) "byte[]"
 %typemap(javain) (int *nLen, char **pBuf ) "$javainput"
 %typemap(javaout) (int *nLen, char **pBuf ) {
+    return $jnicall;
+  }
+
+/***************************************************
+ * Typemaps for  (size_t *nLen, char **pBuf)
+ ***************************************************/
+
+%typemap(in,numinputs=0) (size_t *nLen, char **pBuf ) ( size_t nLen, char *pBuf )
+{
+  /* %typemap(in) (size_t *nLen, char **pBuf ) */
+  $1 = &nLen;
+  $2 = &pBuf;
+}
+
+%typemap(argout) (size_t *nLen, char **pBuf )
+{
+  /* %typemap(argout) (size_t *nLen, char **pBuf ) */
+  jbyteArray byteArray = jenv->NewByteArray(nLen$argnum);
+  jenv->SetByteArrayRegion(byteArray, (jsize)0, (jsize)nLen$argnum, (jbyte*)pBuf$argnum);
+  $result = byteArray;
+}
+
+%typemap(freearg) (size_t *nLen, char **pBuf )
+{
+  /* %typemap(freearg) (size_t *nLen, char **pBuf ) */
+  if( nLen$argnum ) {
+    VSIFree( pBuf$argnum );
+  }
+}
+
+%typemap(jni) (size_t *nLen, char **pBuf ) "jbyteArray"
+%typemap(jtype) (size_t *nLen, char **pBuf ) "byte[]"
+%typemap(jstype) (size_t *nLen, char **pBuf ) "byte[]"
+%typemap(javain) (size_t *nLen, char **pBuf ) "$javainput"
+%typemap(javaout) (size_t *nLen, char **pBuf ) {
     return $jnicall;
   }
 

--- a/gdal/swig/include/perl/typemaps_perl.i
+++ b/gdal/swig/include/perl/typemaps_perl.i
@@ -663,9 +663,30 @@
 {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */
     if( *$1 ) {
-        free( *$2 );
+        VSIFree( *$2 );
     }
 }
+
+%typemap(in,numinputs=0) (size_t *nLen, char **pBuf ) ( size_t nLen = 0, char *pBuf = 0 )
+{
+    /* %typemap(in,numinputs=0) (size_t *nLen, char **pBuf ) */
+    $1 = &nLen;
+    $2 = &pBuf;
+}
+%typemap(argout) (size_t *nLen, char **pBuf )
+{
+    /* %typemap(argout) (size_t *nLen, char **pBuf ) */
+    $result = sv_2mortal(newSVpv( *$2, *$1 ));
+    argvi++;
+}
+%typemap(freearg) (size_t *nLen, char **pBuf )
+{
+    /* %typemap(freearg) (size_t *nLen, char **pBuf ) */
+    if( *$1 ) {
+        VSIFree( *$2 );
+    }
+}
+
 %typemap(in,numinputs=0) (GIntBig *nLen, char **pBuf ) ( GIntBig nLen = 0, char *pBuf = 0 )
 {
     /* %typemap(in,numinputs=0) (GIntBig *nLen, char **pBuf ) */
@@ -685,6 +706,7 @@
         free( *$2 );
     }
 }
+
 %typemap(in,numinputs=1) (int nLen, char *pBuf )
 {
     /* %typemap(in,numinputs=1) (int nLen, char *pBuf ) */
@@ -719,6 +741,42 @@
         $1 = 0;
     }
 }
+
+%typemap(in,numinputs=1) (size_t nLen, char *pBuf )
+{
+    /* %typemap(in,numinputs=1) (size_t nLen, char *pBuf ) */
+    if (SvOK($input)) {
+        SV *sv = $input;
+        if (SvROK(sv) && SvTYPE(SvRV(sv)) < SVt_PVAV)
+            sv = SvRV(sv);
+        if (!SvPOK(sv))
+            do_confess(NEED_BINARY_DATA, 1);
+        STRLEN len = SvCUR(sv);
+        $2 = SvPV_nolen(sv);
+        $1 = len;
+    } else {
+        $2 = NULL;
+        $1 = 0;
+    }
+}
+%typemap(in,numinputs=1) (size_t nLen, unsigned char *pBuf )
+{
+    /* %typemap(in,numinputs=1) (size_t nLen, unsigned char *pBuf ) */
+    if (SvOK($input)) {
+        SV *sv = $input;
+        if (SvROK(sv) && SvTYPE(SvRV(sv)) < SVt_PVAV)
+            sv = SvRV(sv);
+        if (!SvPOK(sv))
+            do_confess(NEED_BINARY_DATA, 1);
+        STRLEN len = SvCUR(sv);
+        $2 = (unsigned char *)SvPV_nolen(sv);
+        $1 = len;
+    } else {
+        $2 = NULL;
+        $1 = 0;
+    }
+}
+
 %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf )
 {
     /* %typemap(in,numinputs=1) (GIntBig nLen, char *pBuf ) */

--- a/gdal/swig/java/apps/WKT2WKB.java
+++ b/gdal/swig/java/apps/WKT2WKB.java
@@ -62,7 +62,7 @@ public class WKT2WKB {
 
             Geometry geom = Geometry.CreateFromWkt(args[0]);
 
-            int wkbSize = geom.WkbSize();
+            long wkbSize = geom.WkbSize();
             byte[] wkb = geom.ExportToWkb();
             if (wkb.length != wkbSize)
             {

--- a/gdal/swig/python/extensions/ogr_wrap.cpp
+++ b/gdal/swig/python/extensions/ogr_wrap.cpp
@@ -3035,8 +3035,9 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_p_char swig_types[24]
 #define SWIGTYPE_p_p_double swig_types[25]
 #define SWIGTYPE_p_p_int swig_types[26]
-static swig_type_info *swig_types[28];
-static swig_module_info swig_module = {swig_types, 27, 0, 0, 0, 0};
+#define SWIGTYPE_p_size_t swig_types[27]
+static swig_type_info *swig_types[29];
+static swig_module_info swig_module = {swig_types, 28, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -5035,7 +5036,7 @@ SWIGINTERN void OGRGeomFieldDefnShadow_SetNullable(OGRGeomFieldDefnShadow *self,
     return OGR_GFld_SetNullable( self, bNullable );
   }
 
-  OGRGeometryShadow* CreateGeometryFromWkb( int len, char *bin_string,
+  OGRGeometryShadow* CreateGeometryFromWkb( size_t len, char *bin_string,
                                             OSRSpatialReferenceShadow *reference=NULL ) {
     OGRGeometryH geom = NULL;
     OGRErr err = OGR_G_CreateFromWkb( (unsigned char *) bin_string,
@@ -5049,6 +5050,121 @@ SWIGINTERN void OGRGeomFieldDefnShadow_SetNullable(OGRGeomFieldDefnShadow *self,
     return (OGRGeometryShadow*) geom;
   }
 
+
+
+SWIGINTERN int
+SWIG_AsVal_unsigned_SS_long (PyObject *obj, unsigned long *val) 
+{
+#if PY_VERSION_HEX < 0x03000000
+  if (PyInt_Check(obj)) {
+    long v = PyInt_AsLong(obj);
+    if (v >= 0) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      return SWIG_OverflowError;
+    }
+  } else
+#endif
+  if (PyLong_Check(obj)) {
+    unsigned long v = PyLong_AsUnsignedLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+      return SWIG_OverflowError;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    int dispatch = 0;
+    unsigned long v = PyLong_AsUnsignedLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_AddCast(SWIG_OK);
+    } else {
+      PyErr_Clear();
+    }
+    if (!dispatch) {
+      double d;
+      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
+      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, 0, ULONG_MAX)) {
+	if (val) *val = (unsigned long)(d);
+	return res;
+      }
+    }
+  }
+#endif
+  return SWIG_TypeError;
+}
+
+
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+SWIGINTERN int
+SWIG_AsVal_unsigned_SS_long_SS_long (PyObject *obj, unsigned long long *val)
+{
+  int res = SWIG_TypeError;
+  if (PyLong_Check(obj)) {
+    unsigned long long v = PyLong_AsUnsignedLongLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+      res = SWIG_OverflowError;
+    }
+  } else {
+    unsigned long v;
+    res = SWIG_AsVal_unsigned_SS_long (obj,&v);
+    if (SWIG_IsOK(res)) {
+      if (val) *val = v;
+      return res;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    const double mant_max = 1LL << DBL_MANT_DIG;
+    double d;
+    res = SWIG_AsVal_double (obj,&d);
+    if (SWIG_IsOK(res) && !SWIG_CanCastAsInteger(&d, 0, mant_max))
+      return SWIG_OverflowError;
+    if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, 0, mant_max)) {
+      if (val) *val = (unsigned long long)(d);
+      return SWIG_AddCast(res);
+    }
+    res = SWIG_TypeError;
+  }
+#endif
+  return res;
+}
+#endif
+
+
+SWIGINTERNINLINE int
+SWIG_AsVal_size_t (PyObject * obj, size_t *val)
+{
+  int res = SWIG_TypeError;
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+#endif
+    unsigned long v;
+    res = SWIG_AsVal_unsigned_SS_long (obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = static_cast< size_t >(v);
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else if (sizeof(size_t) <= sizeof(unsigned long long)) {
+    unsigned long long v;
+    res = SWIG_AsVal_unsigned_SS_long_SS_long (obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = static_cast< size_t >(v);
+  }
+#endif
+  return res;
+}
 
 
   OGRGeometryShadow* CreateGeometryFromWkt( char **val,
@@ -5193,14 +5309,18 @@ SWIGINTERN OGRErr OGRGeometryShadow_ExportToWkt(OGRGeometryShadow *self,char **a
 SWIGINTERN OGRErr OGRGeometryShadow_ExportToIsoWkt(OGRGeometryShadow *self,char **argout){
     return OGR_G_ExportToIsoWkt(self, argout);
   }
-SWIGINTERN OGRErr OGRGeometryShadow_ExportToWkb(OGRGeometryShadow *self,int *nLen,char **pBuf,OGRwkbByteOrder byte_order=wkbXDR){
-    *nLen = OGR_G_WkbSize( self );
-    *pBuf = (char *) malloc( *nLen );
+SWIGINTERN OGRErr OGRGeometryShadow_ExportToWkb(OGRGeometryShadow *self,size_t *nLen,char **pBuf,OGRwkbByteOrder byte_order=wkbXDR){
+    *nLen = OGR_G_WkbSizeEx( self );
+    *pBuf = (char *) VSI_MALLOC_VERBOSE( *nLen );
+    if( *pBuf == NULL )
+        return 6;
     return OGR_G_ExportToWkb(self, byte_order, (unsigned char*) *pBuf );
   }
-SWIGINTERN OGRErr OGRGeometryShadow_ExportToIsoWkb(OGRGeometryShadow *self,int *nLen,char **pBuf,OGRwkbByteOrder byte_order=wkbXDR){
-    *nLen = OGR_G_WkbSize( self );
-    *pBuf = (char *) malloc( *nLen );
+SWIGINTERN OGRErr OGRGeometryShadow_ExportToIsoWkb(OGRGeometryShadow *self,size_t *nLen,char **pBuf,OGRwkbByteOrder byte_order=wkbXDR){
+    *nLen = OGR_G_WkbSizeEx( self );
+    *pBuf = (char *) VSI_MALLOC_VERBOSE( *nLen );
+    if( *pBuf == NULL )
+        return 6;
     return OGR_G_ExportToIsoWkb(self, byte_order, (unsigned char*) *pBuf );
   }
 SWIGINTERN retStringAndCPLFree *OGRGeometryShadow_ExportToGML(OGRGeometryShadow *self,char **options=0){
@@ -5474,9 +5594,46 @@ SWIGINTERN OGRGeometryShadow *OGRGeometryShadow_Centroid(OGRGeometryShadow *self
 SWIGINTERN OGRGeometryShadow *OGRGeometryShadow_PointOnSurface(OGRGeometryShadow *self){
     return (OGRGeometryShadow*) OGR_G_PointOnSurface( self );
   }
-SWIGINTERN int OGRGeometryShadow_WkbSize(OGRGeometryShadow *self){
-    return OGR_G_WkbSize(self);
+SWIGINTERN size_t OGRGeometryShadow_WkbSize(OGRGeometryShadow *self){
+    return OGR_G_WkbSizeEx(self);
   }
+
+  #define SWIG_From_long   PyInt_FromLong 
+
+
+SWIGINTERNINLINE PyObject* 
+SWIG_From_unsigned_SS_long  (unsigned long value)
+{
+  return (value > LONG_MAX) ?
+    PyLong_FromUnsignedLong(value) : PyInt_FromLong(static_cast< long >(value));
+}
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+SWIGINTERNINLINE PyObject* 
+SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
+{
+  return (value > LONG_MAX) ?
+    PyLong_FromUnsignedLongLong(value) : PyInt_FromLong(static_cast< long >(value));
+}
+#endif
+
+
+SWIGINTERNINLINE PyObject *
+SWIG_From_size_t  (size_t value)
+{    
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+#endif
+    return SWIG_From_unsigned_SS_long  (static_cast< unsigned long >(value));
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else {
+    /* assume sizeof(size_t) <= sizeof(unsigned long long) */
+    return SWIG_From_unsigned_SS_long_SS_long  (static_cast< unsigned long long >(value));
+  }
+#endif
+}
+
 SWIGINTERN int OGRGeometryShadow_GetCoordinateDimension(OGRGeometryShadow *self){
     return OGR_G_GetCoordinateDimension(self);
   }
@@ -15238,7 +15395,7 @@ SWIGINTERN PyObject *_wrap_Feature_GetFieldAsBinary__SWIG_0(PyObject *SWIGUNUSED
   {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */
     if( *arg3 ) {
-      free( *arg4 );
+      VSIFree( *arg4 );
     }
   }
   {
@@ -15253,7 +15410,7 @@ fail:
   {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */
     if( *arg3 ) {
-      free( *arg4 );
+      VSIFree( *arg4 );
     }
   }
   return NULL;
@@ -15336,7 +15493,7 @@ SWIGINTERN PyObject *_wrap_Feature_GetFieldAsBinary__SWIG_1(PyObject *SWIGUNUSED
   {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */
     if( *arg3 ) {
-      free( *arg4 );
+      VSIFree( *arg4 );
     }
   }
   {
@@ -15355,7 +15512,7 @@ fail:
   {
     /* %typemap(freearg) (int *nLen, char **pBuf ) */
     if( *arg3 ) {
-      free( *arg4 );
+      VSIFree( *arg4 );
     }
   }
   return NULL;
@@ -21532,7 +21689,7 @@ SWIGINTERN PyObject *GeomFieldDefn_swigregister(PyObject *SWIGUNUSEDPARM(self), 
 
 SWIGINTERN PyObject *_wrap_CreateGeometryFromWkb(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
-  int arg1 ;
+  size_t arg1 ;
   char *arg2 = (char *) 0 ;
   OSRSpatialReferenceShadow *arg3 = (OSRSpatialReferenceShadow *) NULL ;
   int alloc1 = 0 ;
@@ -21549,16 +21706,12 @@ SWIGINTERN PyObject *_wrap_CreateGeometryFromWkb(PyObject *SWIGUNUSEDPARM(self),
   
   if (!PyArg_ParseTupleAndKeywords(args,kwargs,(char *)"O|O:CreateGeometryFromWkb",kwnames,&obj0,&obj1)) SWIG_fail;
   {
-    /* %typemap(in,numinputs=1) (int nLen, char *pBuf ) */
+    /* %typemap(in,numinputs=1) (size_t nLen, char *pBuf ) */
     {
       if (PyObject_GetBuffer(obj0, &view1, PyBUF_SIMPLE) == 0)
       {
-        if( view1.len > INT_MAX ) {
-          PyBuffer_Release(&view1);
-          SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-        }
         viewIsValid1 = true;
-        arg1 = (int) view1.len;
+        arg1 = view1.len;
         arg2 = (char *) view1.buf;
         goto ok;
       }
@@ -21576,10 +21729,7 @@ SWIGINTERN PyObject *_wrap_CreateGeometryFromWkb(PyObject *SWIGUNUSEDPARM(self),
       }
       
       if (safeLen) safeLen--;
-      if( safeLen > INT_MAX ) {
-        SWIG_exception( SWIG_RuntimeError, "too large buffer (>2GB)" );
-      }
-      arg1 = (int) safeLen;
+      arg1 = safeLen;
     }
     else
     {
@@ -21615,7 +21765,7 @@ SWIGINTERN PyObject *_wrap_CreateGeometryFromWkb(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_OGRGeometryShadow, SWIG_POINTER_OWN |  0 );
   {
-    /* %typemap(freearg) (int *nLen, char *pBuf ) */
+    /* %typemap(freearg) (size_t *nLen, char *pBuf ) */
     if( viewIsValid1 ) {
       PyBuffer_Release(&view1);
     }
@@ -21627,7 +21777,7 @@ SWIGINTERN PyObject *_wrap_CreateGeometryFromWkb(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    /* %typemap(freearg) (int *nLen, char *pBuf ) */
+    /* %typemap(freearg) (size_t *nLen, char *pBuf ) */
     if( viewIsValid1 ) {
       PyBuffer_Release(&view1);
     }
@@ -22634,12 +22784,12 @@ fail:
 SWIGINTERN PyObject *_wrap_Geometry_ExportToWkb(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   OGRGeometryShadow *arg1 = (OGRGeometryShadow *) 0 ;
-  int *arg2 = (int *) 0 ;
+  size_t *arg2 = (size_t *) 0 ;
   char **arg3 = (char **) 0 ;
   OGRwkbByteOrder arg4 = (OGRwkbByteOrder) wkbXDR ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  int nLen2 = 0 ;
+  size_t nLen2 = 0 ;
   char *pBuf2 = 0 ;
   int val4 ;
   int ecode4 = 0 ;
@@ -22651,7 +22801,7 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToWkb(PyObject *SWIGUNUSEDPARM(self), 
   OGRErr result;
   
   {
-    /* %typemap(in,numinputs=0) (int *nLen2, char **pBuf2 ) */
+    /* %typemap(in,numinputs=0) (size_t *nLen2, char **pBuf2 ) */
     arg2 = &nLen2;
     arg3 = &pBuf2;
   }
@@ -22698,14 +22848,14 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToWkb(PyObject *SWIGUNUSEDPARM(self), 
     }
   }
   {
-    /* %typemap(argout) (int *nLen, char **pBuf ) */
+    /* %typemap(argout) (size_t *nLen, char **pBuf ) */
     Py_XDECREF(resultobj);
     resultobj = PyByteArray_FromStringAndSize( *arg3, *arg2 );
   }
   {
-    /* %typemap(freearg) (int *nLen, char **pBuf ) */
+    /* %typemap(freearg) (size_t *nLen, char **pBuf ) */
     if( *arg2 ) {
-      free( *arg3 );
+      VSIFree( *arg3 );
     }
   }
   {
@@ -22718,9 +22868,9 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToWkb(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    /* %typemap(freearg) (int *nLen, char **pBuf ) */
+    /* %typemap(freearg) (size_t *nLen, char **pBuf ) */
     if( *arg2 ) {
-      free( *arg3 );
+      VSIFree( *arg3 );
     }
   }
   return NULL;
@@ -22730,12 +22880,12 @@ fail:
 SWIGINTERN PyObject *_wrap_Geometry_ExportToIsoWkb(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   OGRGeometryShadow *arg1 = (OGRGeometryShadow *) 0 ;
-  int *arg2 = (int *) 0 ;
+  size_t *arg2 = (size_t *) 0 ;
   char **arg3 = (char **) 0 ;
   OGRwkbByteOrder arg4 = (OGRwkbByteOrder) wkbXDR ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  int nLen2 = 0 ;
+  size_t nLen2 = 0 ;
   char *pBuf2 = 0 ;
   int val4 ;
   int ecode4 = 0 ;
@@ -22747,7 +22897,7 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToIsoWkb(PyObject *SWIGUNUSEDPARM(self
   OGRErr result;
   
   {
-    /* %typemap(in,numinputs=0) (int *nLen2, char **pBuf2 ) */
+    /* %typemap(in,numinputs=0) (size_t *nLen2, char **pBuf2 ) */
     arg2 = &nLen2;
     arg3 = &pBuf2;
   }
@@ -22794,14 +22944,14 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToIsoWkb(PyObject *SWIGUNUSEDPARM(self
     }
   }
   {
-    /* %typemap(argout) (int *nLen, char **pBuf ) */
+    /* %typemap(argout) (size_t *nLen, char **pBuf ) */
     Py_XDECREF(resultobj);
     resultobj = PyByteArray_FromStringAndSize( *arg3, *arg2 );
   }
   {
-    /* %typemap(freearg) (int *nLen, char **pBuf ) */
+    /* %typemap(freearg) (size_t *nLen, char **pBuf ) */
     if( *arg2 ) {
-      free( *arg3 );
+      VSIFree( *arg3 );
     }
   }
   {
@@ -22814,9 +22964,9 @@ SWIGINTERN PyObject *_wrap_Geometry_ExportToIsoWkb(PyObject *SWIGUNUSEDPARM(self
   return resultobj;
 fail:
   {
-    /* %typemap(freearg) (int *nLen, char **pBuf ) */
+    /* %typemap(freearg) (size_t *nLen, char **pBuf ) */
     if( *arg2 ) {
-      free( *arg3 );
+      VSIFree( *arg3 );
     }
   }
   return NULL;
@@ -26949,7 +27099,7 @@ SWIGINTERN PyObject *_wrap_Geometry_WkbSize(PyObject *SWIGUNUSEDPARM(self), PyOb
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  int result;
+  size_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:Geometry_WkbSize",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_OGRGeometryShadow, 0 |  0 );
@@ -26963,7 +27113,7 @@ SWIGINTERN PyObject *_wrap_Geometry_WkbSize(PyObject *SWIGUNUSEDPARM(self), PyOb
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      result = (int)OGRGeometryShadow_WkbSize(arg1);
+      result = OGRGeometryShadow_WkbSize(arg1);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -26975,7 +27125,7 @@ SWIGINTERN PyObject *_wrap_Geometry_WkbSize(PyObject *SWIGUNUSEDPARM(self), PyOb
     }
 #endif
   }
-  resultobj = SWIG_From_int(static_cast< int >(result));
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
   if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
   return resultobj;
 fail:
@@ -34607,7 +34757,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"GeomFieldDefn_IsNullable", _wrap_GeomFieldDefn_IsNullable, METH_VARARGS, (char *)"GeomFieldDefn_IsNullable(GeomFieldDefn self) -> int"},
 	 { (char *)"GeomFieldDefn_SetNullable", _wrap_GeomFieldDefn_SetNullable, METH_VARARGS, (char *)"GeomFieldDefn_SetNullable(GeomFieldDefn self, int bNullable)"},
 	 { (char *)"GeomFieldDefn_swigregister", GeomFieldDefn_swigregister, METH_VARARGS, NULL},
-	 { (char *)"CreateGeometryFromWkb", (PyCFunction) _wrap_CreateGeometryFromWkb, METH_VARARGS | METH_KEYWORDS, (char *)"CreateGeometryFromWkb(int len, SpatialReference reference=None) -> Geometry"},
+	 { (char *)"CreateGeometryFromWkb", (PyCFunction) _wrap_CreateGeometryFromWkb, METH_VARARGS | METH_KEYWORDS, (char *)"CreateGeometryFromWkb(size_t len, SpatialReference reference=None) -> Geometry"},
 	 { (char *)"CreateGeometryFromWkt", (PyCFunction) _wrap_CreateGeometryFromWkt, METH_VARARGS | METH_KEYWORDS, (char *)"CreateGeometryFromWkt(char ** val, SpatialReference reference=None) -> Geometry"},
 	 { (char *)"CreateGeometryFromGML", _wrap_CreateGeometryFromGML, METH_VARARGS, (char *)"CreateGeometryFromGML(char const * input_string) -> Geometry"},
 	 { (char *)"CreateGeometryFromJson", _wrap_CreateGeometryFromJson, METH_VARARGS, (char *)"CreateGeometryFromJson(char const * input_string) -> Geometry"},
@@ -35905,7 +36055,7 @@ static PyMethodDef SwigMethods[] = {
 		"OGR 1.10 \n"
 		""},
 	 { (char *)"Geometry_WkbSize", _wrap_Geometry_WkbSize, METH_VARARGS, (char *)"\n"
-		"Geometry_WkbSize(Geometry self) -> int\n"
+		"Geometry_WkbSize(Geometry self) -> size_t\n"
 		"\n"
 		"int OGR_G_WkbSize(OGRGeometryH hGeom)\n"
 		"\n"
@@ -36236,6 +36386,7 @@ static swig_type_info _swigt__p_p_GIntBig = {"_p_p_GIntBig", "GIntBig **", 0, 0,
 static swig_type_info _swigt__p_p_char = {"_p_p_char", "char **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_double = {"_p_p_double", "double **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_int = {"_p_p_int", "int **", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_size_t = {"_p_size_t", "size_t *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_GDALMajorObjectShadow,
@@ -36265,6 +36416,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_p_char,
   &_swigt__p_p_double,
   &_swigt__p_p_int,
+  &_swigt__p_size_t,
 };
 
 static swig_cast_info _swigc__p_GDALMajorObjectShadow[] = {  {&_swigt__p_GDALMajorObjectShadow, 0, 0, 0},  {&_swigt__p_OGRDriverShadow, _p_OGRDriverShadowTo_p_GDALMajorObjectShadow, 0, 0},  {&_swigt__p_OGRLayerShadow, _p_OGRLayerShadowTo_p_GDALMajorObjectShadow, 0, 0},  {&_swigt__p_OGRDataSourceShadow, _p_OGRDataSourceShadowTo_p_GDALMajorObjectShadow, 0, 0},{0, 0, 0, 0}};
@@ -36294,6 +36446,7 @@ static swig_cast_info _swigc__p_p_GIntBig[] = {  {&_swigt__p_p_GIntBig, 0, 0, 0}
 static swig_cast_info _swigc__p_p_char[] = {  {&_swigt__p_p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_double[] = {  {&_swigt__p_p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_int[] = {  {&_swigt__p_p_int, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_size_t[] = {  {&_swigt__p_size_t, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_GDALMajorObjectShadow,
@@ -36323,6 +36476,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_p_char,
   _swigc__p_p_double,
   _swigc__p_p_int,
+  _swigc__p_size_t,
 };
 
 

--- a/gdal/swig/python/osgeo/ogr.py
+++ b/gdal/swig/python/osgeo/ogr.py
@@ -5870,7 +5870,7 @@ GeomFieldDefn_swigregister(GeomFieldDefn)
 
 
 def CreateGeometryFromWkb(*args, **kwargs):
-    """CreateGeometryFromWkb(int len, SpatialReference reference=None) -> Geometry"""
+    """CreateGeometryFromWkb(size_t len, SpatialReference reference=None) -> Geometry"""
     return _ogr.CreateGeometryFromWkb(*args, **kwargs)
 
 def CreateGeometryFromWkt(*args, **kwargs):
@@ -7543,7 +7543,7 @@ class Geometry(_object):
 
     def WkbSize(self, *args):
         """
-        WkbSize(Geometry self) -> int
+        WkbSize(Geometry self) -> size_t
 
         int OGR_G_WkbSize(OGRGeometryH hGeom)
 


### PR DESCRIPTION
- Avoid potential int overflow in OGRGeometry::WkbSize() method by
  returning now a size_t. Make OGR_G_WkbSize() returns an error if
  the value doesn't fit on it, and add OGR_G_WkbSizeEx() returning
  size_t
- Make OGRGeometry::importFromWkb() work on wkb > 2 GB (C++ signature
  change), and add OGR_G_CreateFromWkbEx()
- Make OGRGeometry::exportToWkb() work on wkb > 2 GB
- Changes in drivers that call WkbSize()
