### PR TITLE
Microsoft have deprecated str{n,}casecmp and str{n,}icmp

### DIFF
--- a/gdal/port/cpl_port.h
+++ b/gdal/port/cpl_port.h
@@ -562,8 +562,8 @@ static inline char* CPL_afl_friendly_strstr(const char* haystack, const char* ne
 #endif /* defined(AFL_FRIENDLY) && defined(__GNUC__) */
 
 #  if defined(WIN32)
-#    define STRCASECMP(a,b)         (stricmp(a,b))
-#    define STRNCASECMP(a,b,n)      (strnicmp(a,b,n))
+#    define STRCASECMP(a,b)         (_stricmp(a,b))
+#    define STRNCASECMP(a,b,n)      (_strnicmp(a,b,n))
 #  else
 /** Alias for strcasecmp() */
 #    define STRCASECMP(a,b)         (strcasecmp(a,b))


### PR DESCRIPTION
## What does this PR do?
Microsoft have deprecated str{n,}casecmp and str{n,}icmp
Before this change I get a deprecation warning from cpl_port.h when I use the EQUAL and EQUALN macros when building a stand-alone/plugin driver on Windows with the conda gdal, WIN10 SDK and the mingw-m64 clang11 compiler

## What are related issues/pull requests?
None recorded, but the issue was discussed in
https://lists.osgeo.org/pipermail/gdal-dev/2021-April/053856.html

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment
Windows with the conda gdal, WIN10 SDK and the mingw-m64 clang11 compiler
