### PR TITLE
Python sphinx docs reorganize

### DIFF
--- a/gdal/doc/source/api/index.rst
+++ b/gdal/doc/source/api/index.rst
@@ -83,6 +83,7 @@ API
    .. toctree::
        :maxdepth: 1
 
+       python
        python_api_ref
        python_gotchas
        python_samples
@@ -102,7 +103,6 @@ API
 
        csharp
        java
-       python
 
    There are also other bindings that are developed outside of the GDAL source tree (**note**: those offer APIs not strictly coupled the GDAL/OGR C/C++ API). These include bindings for
 

--- a/gdal/doc/source/api/python.rst
+++ b/gdal/doc/source/api/python.rst
@@ -26,10 +26,22 @@ A cookbook full of recipes for using the Python GDAL/OGR bindings : `http://pcje
 Examples
 --------
 
-* One example of GDAL/numpy integration is found in the val_repl.py script.
-* An assortment of other samples are available in the Python github samples directory at `https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/gdal-utils/osgeo_utils/samples <https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/gdal-utils/osgeo_utils/samples>`__ with some description in the `samples README <https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/gdal-utils/samples>`__.
-* Several `GDAL utilities <https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/gdal-utils/scripts/>`__ are implemented in Python and can be useful examples.
-* The majority of GDAL regression tests are written in Python. They are available at `https://github.com/OSGeo/gdal/tree/master/autotest <https://github.com/OSGeo/gdal/tree/master/autotest>`__
+* An assortment of other samples are available in the Python github samples directory at
+  `https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/gdal-utils/osgeo_utils/samples
+  <https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/gdal-utils/osgeo_utils/samples>`__
+  with some description in the :ref:`python_samples`.
+* Several `GDAL utilities <https://github.com/OSGeo/gdal/tree/master/gdal/swig/python/gdal-utils/osgeo_utils/>`__
+  are implemented in Python and can be useful examples.
+* The majority of GDAL regression tests are written in Python. They are available at
+  `https://github.com/OSGeo/gdal/tree/master/autotest <https://github.com/OSGeo/gdal/tree/master/autotest>`__
+* Some examples of GDAL/numpy integration can be found is found in the following scripts:
+  - `gdal_calc.py`
+  - `val_repl.py`
+  - `gdal_merge.py`
+  - `gdal2tiles.py`
+  - `gdal2xyz.py`
+  - `pct2rgb.py`
+  - `gdallocationinfo.py`
 
 Gotchas
 -------


### PR DESCRIPTION
## What does this PR do?

gdal/doc/source/api/[python.rst, index.rst] - rewrite the Python Examples section and move the Python API link with the rest of the Python stuff links

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/3678

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
