### PR TITLE
gdal2tiles.rst - Add missing -x, --exclude option

### DIFF
--- a/gdal/doc/source/programs/gdal2tiles.rst
+++ b/gdal/doc/source/programs/gdal2tiles.rst
@@ -93,6 +93,10 @@ can publish a picture without proper georeferencing too.
 
   Generate verbose output of tile generation.
 
+.. option:: -x, --exclude
+
+  Exclude transparent tiles from result tileset.
+
 .. option:: -q, --quiet
 
   Disable messages and status to stdout


### PR DESCRIPTION
There is a missing command line option (-x, --exclude) for gdal2tiles.py.

Reference: https://github.com/OSGeo/gdal/blob/5d233d423a4be9e4c75fd611da841f66f8c50065/gdal/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py#L1362

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/osgeo/gdal/3699)
<!-- Reviewable:end -->
