### PR TITLE
Fix spelling errors.

### DIFF
--- a/gdal/doc/source/drivers/raster/derived.rst
+++ b/gdal/doc/source/drivers/raster/derived.rst
@@ -8,7 +8,7 @@ DERIVED -- Derived subdatasets driver
 
 .. built_in_by_default::
 
-This driver allows to access to subdatasets derived from a given
+This driver allows accessing subdatasets derived from a given
 dataset. Those derived datasets have the same projection reference,
 geo-transform and metadata than the original dataset, but derives new
 pixel values using gdal pixel functions.

--- a/gdal/doc/source/drivers/raster/ngw.rst
+++ b/gdal/doc/source/drivers/raster/ngw.rst
@@ -9,7 +9,7 @@ NGW -- NextGIS Web
 
 .. build_dependencies:: libcurl
 
-NextGIS Web - is a server GIS, which allows to store and edit geodata
+NextGIS Web - is a server GIS, which allows storing and editing geodata
 and to display maps in web browser. Also NextGIS Web can share geodata
 with other NextGIS software.
 

--- a/gdal/doc/source/drivers/vector/nas.rst
+++ b/gdal/doc/source/drivers/vector/nas.rst
@@ -38,8 +38,8 @@ generated using `xmi2db <https://github.com/norBIT/xmi2db/>`__ (fork of
 `xmi2db <https://github.com/pkorduan/xmi2db>`__) from the official
 application schema.
 
-New in 2.3 is also the option **NAS_NO_RELATION_LAYER** that allows to
-disable populating the table *alkis_beziehungen*. The information found
+New in 2.3 is also the option **NAS_NO_RELATION_LAYER** that allows
+disabling populating the table *alkis_beziehungen*. The information found
 there is redundant to the relation fields also contained in original
 elements/tables. Enabling the option also makes progress reporting
 available.

--- a/gdal/doc/source/drivers/vector/ngw.rst
+++ b/gdal/doc/source/drivers/vector/ngw.rst
@@ -9,7 +9,7 @@ NGW -- NextGIS Web
 
 .. build_dependencies:: libcurl
 
-NextGIS Web - is a server GIS, which allows to store and edit geodata
+NextGIS Web - is a server GIS, which allows storing and editing geodata
 and to display maps in web browser. Also NextGIS Web can share geodata
 with other NextGIS software.
 

--- a/gdal/doc/source/drivers/vector/wfs.rst
+++ b/gdal/doc/source/drivers/vector/wfs.rst
@@ -96,7 +96,7 @@ The WFS driver will automatically detect if server supports paging, when
 requesting a WFS 2.0 server.
 
 Some servers (such as MapServer >= 6.0) support the use of STARTINDEX
-that allows to do the requests per "page", and thus to avoid
+that allows doing the requests per "page", and thus to avoid
 downloading the whole content of the layer in a single request. Paging
 was introduced in WFS 2.0.0 but servers may support it as an vendor
 specific option also with WFS 1.0.0 and 1.1.0. The OGR WFS client will

--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -90,7 +90,7 @@ but no projection checking is performed (unless projectionCheck option is used).
 
 .. option:: color-table=<filename>
 
-    Allows to specify a filename of a color table (or a ColorTable object) (with Palette Index interpretation) to be used for the output raster.
+    Allows specifying a filename of a color table (or a ColorTable object) (with Palette Index interpretation) to be used for the output raster.
     Supported formats: txt (i.e. like gdaldem, but color names are not supported), qlr, qml (i.e. exported from QGIS)
 
 .. option:: --extent=<option>
@@ -165,7 +165,7 @@ They are not available using the command prompt.
 
 .. option:: color_table
 
-    Allows to specify a ColorTable object (with Palette Index interpretation) to be used for the output raster.
+    Allows specifying a ColorTable object (with Palette Index interpretation) to be used for the output raster.
 
 Example
 -------

--- a/gdal/frmts/ecw/ecwdataset.cpp
+++ b/gdal/frmts/ecw/ecwdataset.cpp
@@ -3117,7 +3117,7 @@ void ECWDataset::ECW2WKTProjection()
         /* have "Upward" orientation (Y coordinates increase "Upward"). */
         /* Setting ECW_ALWAYS_UPWARD=FALSE option relexes that policy   */
         /* and makes the driver rely on the actual Y-resolution         */
-        /* value (sign) of an image. This allows to correctly process   */
+        /* value (sign) of an image. This allows correctly processing   */
         /* rare images with "Downward" orientation, where Y coordinates */
         /* increase "Downward" and Y-resolution is positive.            */
         if( CPLTestBool( CPLGetConfigOption("ECW_ALWAYS_UPWARD","TRUE") ) )

--- a/gdal/swig/python/extensions/gdal_array_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_array_wrap.cpp
@@ -290,7 +290,7 @@ template <typename T> T SwigValueInit() {
    SWIG errors code.
 
    Finally, if the SWIG_CASTRANK_MODE is enabled, the result code
-   allows to return the 'cast rank', for example, if you have this
+   allows returning the 'cast rank', for example, if you have this
 
        int food(double)
        int fooi(int);

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -291,7 +291,7 @@ template <typename T> T SwigValueInit() {
    SWIG errors code.
 
    Finally, if the SWIG_CASTRANK_MODE is enabled, the result code
-   allows to return the 'cast rank', for example, if you have this
+   allows returning the 'cast rank', for example, if you have this
 
        int food(double)
        int fooi(int);

--- a/gdal/swig/python/extensions/gdalconst_wrap.c
+++ b/gdal/swig/python/extensions/gdalconst_wrap.c
@@ -267,7 +267,7 @@
    SWIG errors code.
 
    Finally, if the SWIG_CASTRANK_MODE is enabled, the result code
-   allows to return the 'cast rank', for example, if you have this
+   allows returning the 'cast rank', for example, if you have this
 
        int food(double)
        int fooi(int);

--- a/gdal/swig/python/extensions/gnm_wrap.cpp
+++ b/gdal/swig/python/extensions/gnm_wrap.cpp
@@ -291,7 +291,7 @@ template <typename T> T SwigValueInit() {
    SWIG errors code.
 
    Finally, if the SWIG_CASTRANK_MODE is enabled, the result code
-   allows to return the 'cast rank', for example, if you have this
+   allows returning the 'cast rank', for example, if you have this
 
        int food(double)
        int fooi(int);

--- a/gdal/swig/python/extensions/ogr_wrap.cpp
+++ b/gdal/swig/python/extensions/ogr_wrap.cpp
@@ -291,7 +291,7 @@ template <typename T> T SwigValueInit() {
    SWIG errors code.
 
    Finally, if the SWIG_CASTRANK_MODE is enabled, the result code
-   allows to return the 'cast rank', for example, if you have this
+   allows returning the 'cast rank', for example, if you have this
 
        int food(double)
        int fooi(int);

--- a/gdal/swig/python/extensions/osr_wrap.cpp
+++ b/gdal/swig/python/extensions/osr_wrap.cpp
@@ -291,7 +291,7 @@ template <typename T> T SwigValueInit() {
    SWIG errors code.
 
    Finally, if the SWIG_CASTRANK_MODE is enabled, the result code
-   allows to return the 'cast rank', for example, if you have this
+   allows returning the 'cast rank', for example, if you have this
 
        int food(double)
        int fooi(int);

--- a/gdal/third_party/LercLib/Lerc2.h
+++ b/gdal/third_party/LercLib/Lerc2.h
@@ -57,7 +57,7 @@ NAMESPACE_LERC_START
  *
  *    -- add checksum for the entire byte blob, for more rigorous detection of compressed data corruption
  *    -- for the main bit stuffing routine, use an extra uint buffer for guaranteed memory alignment
- *    -- this also allows to drop the NumExtraBytesToAllocate functions
+ *    -- this also allows dropping the NumExtraBytesToAllocate functions
  *
  *    Lerc2 v4
  *


### PR DESCRIPTION
The lintian QA tool reported spelling errors for the Debian package build:

 * Allows to VERB -> Allows VERBing
