### PR TITLE
stacta manual: new tiled-assets URL

### DIFF
--- a/gdal/doc/source/drivers/raster/stacta.rst
+++ b/gdal/doc/source/drivers/raster/stacta.rst
@@ -11,7 +11,7 @@ STACTA - Spatio-Temporal Asset Catalog Tiled Assets
 .. built_in_by_default::
 
 This driver supports opening JSON files following the
-`Spatio-Temporal Asset Catalog Tiled Assets <https://github.com/radiantearth/stac-spec/tree/master/extensions/tiled-assets>`_
+`Spatio-Temporal Asset Catalog Tiled Assets <https://github.com/stac-extensions/tiled-assets>`_
 specification. Such JSON file references tiles (also called metatiles), split
 from a potentially big dataset according to a tiling scheme, with several zoom
 levels. The driver provides a single raster view, with overviews, of the dataset


### PR DESCRIPTION
## What does this PR do?

Fix broken URL to:

- https://github.com/stac-extensions/tiled-assets
