### PR TITLE
Fix OVERVIEW_LEVEL=NONE open option

### DIFF
--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -5955,6 +5955,9 @@ void GTiffRasterBand::NullBlock( void *pData )
 int GTiffRasterBand::GetOverviewCount()
 
 {
+    if( !m_poGDS->AreOverviewsEnabled() )
+        return 0;
+
     m_poGDS->ScanDirectories();
 
     if( m_poGDS->m_nOverviewCount > 0 )

--- a/gdal/frmts/jp2kak/jp2kakdataset.cpp
+++ b/gdal/frmts/jp2kak/jp2kakdataset.cpp
@@ -324,6 +324,9 @@ JP2KAKRasterBand::~JP2KAKRasterBand()
 int JP2KAKRasterBand::GetOverviewCount()
 
 {
+    if( !poBaseDS->AreOverviewsEnabled() )
+        return 0;
+
     if( GDALPamRasterBand::GetOverviewCount() > 0 )
         return GDALPamRasterBand::GetOverviewCount();
 
@@ -1328,12 +1331,15 @@ JP2KAKDataset::DirectRasterIO( GDALRWFlag /* eRWFlag */,
     int nDiscardLevels = 0;
     int nResMult = 1;
 
-    while( nDiscardLevels < nResCount - 1 &&
-           nBufXSize * nResMult * 2 < nXSize * 1.01 &&
-           nBufYSize * nResMult * 2 < nYSize * 1.01 )
+    if( AreOverviewsEnabled() )
     {
-        nDiscardLevels++;
-        nResMult *= 2;
+        while( nDiscardLevels < nResCount - 1 &&
+               nBufXSize * nResMult * 2 < nXSize * 1.01 &&
+               nBufYSize * nResMult * 2 < nYSize * 1.01 )
+        {
+            nDiscardLevels++;
+            nResMult *= 2;
+        }
     }
 
     // Prepare component indices list.

--- a/gdal/frmts/jpeg/jpgdataset.cpp
+++ b/gdal/frmts/jpeg/jpgdataset.cpp
@@ -1416,13 +1416,11 @@ int JPGRasterBand::GetMaskFlags()
 
 GDALRasterBand *JPGRasterBand::GetOverview(int i)
 {
-    poGDS->InitInternalOverviews();
+    if( i < 0 || i >= GetOverviewCount() )
+        return nullptr;
 
     if( poGDS->nInternalOverviewsCurrent == 0 )
         return GDALPamRasterBand::GetOverview(i);
-
-    if( i < 0 || i >= poGDS->nInternalOverviewsCurrent )
-        return nullptr;
 
     return poGDS->papoInternalOverviews[i]->GetRasterBand(nBand);
 }
@@ -1433,6 +1431,9 @@ GDALRasterBand *JPGRasterBand::GetOverview(int i)
 
 int JPGRasterBand::GetOverviewCount()
 {
+    if( !poGDS->AreOverviewsEnabled() )
+        return 0;
+
     poGDS->InitInternalOverviews();
 
     if( poGDS->nInternalOverviewsCurrent == 0 )

--- a/gdal/frmts/openjpeg/openjpegdataset.cpp
+++ b/gdal/frmts/openjpeg/openjpegdataset.cpp
@@ -1150,10 +1150,13 @@ end:
 
 int JP2OpenJPEGRasterBand::GetOverviewCount()
 {
+    JP2OpenJPEGDataset *poGDS = cpl::down_cast<JP2OpenJPEGDataset*>(poDS);
+    if( !poGDS->AreOverviewsEnabled() )
+        return 0;
+
     if( GDALPamRasterBand::GetOverviewCount() > 0 )
         return GDALPamRasterBand::GetOverviewCount();
 
-    JP2OpenJPEGDataset *poGDS = (JP2OpenJPEGDataset *) poDS;
     return poGDS->nOverviewCount;
 }
 

--- a/gdal/frmts/vrt/vrtrasterband.cpp
+++ b/gdal/frmts/vrt/vrtrasterband.cpp
@@ -1152,6 +1152,10 @@ void VRTRasterBand::GetFileList(char*** ppapszFileList, int *pnSize,
 int VRTRasterBand::GetOverviewCount()
 
 {
+    VRTDataset* poVRTDS = static_cast<VRTDataset *>( poDS );
+    if( !poVRTDS->AreOverviewsEnabled() )
+        return 0;
+
     // First: overviews declared in <Overview> element
     if( !m_aoOverviewInfos.empty() )
         return static_cast<int>(m_aoOverviewInfos.size());
@@ -1162,7 +1166,6 @@ int VRTRasterBand::GetOverviewCount()
         return nOverviewCount;
 
     // If not found, implicit virtual overviews
-    VRTDataset* poVRTDS = static_cast<VRTDataset *>( poDS );
     poVRTDS->BuildVirtualOverviews();
     if( !poVRTDS->m_apoOverviews.empty() && poVRTDS->m_apoOverviews[0] )
         return static_cast<int>( poVRTDS->m_apoOverviews.size() );

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -672,6 +672,14 @@ class CPL_DLL GDALDataset : public GDALMajorObject
         OGRLayer* layer = nullptr;
     };
 
+//! @cond Doxygen_Suppress
+    // SetEnableOverviews() only to be used by GDALOverviewDataset
+    void SetEnableOverviews(bool bEnable);
+
+    // Only to be used by driver's GetOverviewCount() method.
+    bool AreOverviewsEnabled() const;
+//! @endcond
+
 private:
     class Private;
     Private *m_poPrivate;

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -123,6 +123,8 @@ class GDALDataset::Private
 
     GDALDataset* poParentDataset = nullptr;
 
+    bool m_bOverviewsEnabled = true;
+
     Private() = default;
 };
 
@@ -2065,7 +2067,7 @@ CPLErr GDALDataset::IRasterIO( GDALRWFlag eRWFlag,
          psExtraArg->eResampleAlg == GRIORA_Lanczos) &&
         !(nXSize == nBufXSize && nYSize == nBufYSize) && nBandCount > 1 )
     {
-        if( nBufXSize < nXSize && nBufYSize < nYSize )
+        if( nBufXSize < nXSize && nBufYSize < nYSize && AreOverviewsEnabled() )
         {
             int bTried = FALSE;
             const CPLErr eErr =
@@ -8405,3 +8407,28 @@ bool GDALDatasetAddFieldDomain(GDALDatasetH hDS,
     }
     return bRet;
 }
+
+//! @cond Doxygen_Suppress
+
+/************************************************************************/
+/*                       SetEnableOverviews()                           */
+/************************************************************************/
+
+void GDALDataset::SetEnableOverviews(bool bEnable)
+{
+    if( m_poPrivate )
+    {
+        m_poPrivate->m_bOverviewsEnabled = bEnable;
+    }
+}
+
+/************************************************************************/
+/*                      AreOverviewsEnabled()                           */
+/************************************************************************/
+
+bool GDALDataset::AreOverviewsEnabled() const
+{
+    return m_poPrivate ? m_poPrivate->m_bOverviewsEnabled : true;
+}
+
+//! @endcond

--- a/gdal/gcore/gdalrasterband.cpp
+++ b/gdal/gcore/gdalrasterband.cpp
@@ -2184,7 +2184,7 @@ int CPL_STDCALL GDALHasArbitraryOverviews( GDALRasterBandH hBand )
 int GDALRasterBand::GetOverviewCount()
 
 {
-    if( poDS != nullptr && poDS->oOvManager.IsInitialized() )
+    if( poDS != nullptr && poDS->oOvManager.IsInitialized() && poDS->AreOverviewsEnabled() )
         return poDS->oOvManager.GetOverviewCount( nBand );
 
     return 0;
@@ -2226,7 +2226,7 @@ int CPL_STDCALL GDALGetOverviewCount( GDALRasterBandH hBand )
 GDALRasterBand * GDALRasterBand::GetOverview( int i )
 
 {
-    if( poDS != nullptr && poDS->oOvManager.IsInitialized() )
+    if( poDS != nullptr && poDS->oOvManager.IsInitialized() && poDS->AreOverviewsEnabled() )
         return poDS->oOvManager.GetOverview( nBand, i );
 
     return nullptr;


### PR DESCRIPTION
and also "{x}only". This however needs cooperation from drivers.
I've just updated the GTiff, JP2KAK, JPEG, OpenJPEG and VRT ones. Others
would need similar changes in their specific GetOverviewCount() / IRasterIO()
implementation.

Fixes https://github.com/OSGeo/gdal/pull/3181#issuecomment-822868290
