### PR TITLE
ArgumentParser: gdal_calc + others

### DIFF
--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -245,28 +245,28 @@ def test_gdal_calc_py_7():
     opt_files = make_temp_filename_list(test_id, test_count, is_opt=True)
 
     with open(opt_files[0], 'w') as f:
-        f.write('-A {} --calc=A --overwrite --outfile {}'.format(infile, out[0]))
+        f.write(f'-A {infile} --calc=A --overwrite --outfile {out[0]}')
 
     # Lines in optfiles beginning with '#' should be ignored
     with open(opt_files[1], 'w') as f:
-        f.write('-A {} --A_band=2 --calc=A --overwrite --outfile {}'.format(infile, out[1]))
+        f.write(f'-A {infile} --A_band=2 --calc=A --overwrite --outfile {out[1]}')
         f.write('\n# -A_band=1')
 
     # options on separate lines should work, too
-    opts = '-Z {}'.format(infile), '--Z_band=2', '--calc=Z', '--overwrite', '--outfile  {}'.format(out[2])
+    opts = f'-Z {infile}', '--Z_band=2', '--calc=Z', '--overwrite', f'--outfile  {out[2]}'
     with open(opt_files[2], 'w') as f:
         for i in opts:
             f.write(i + '\n')
 
     # double-quoted options should be read as single arguments. Mixed numbers of arguments per line should work.
-    opts = '-Z {} --Z_band=2'.format(infile), '--calc "Z + 0"', '--overwrite --outfile {}'.format(out[3])
+    opts = f'-Z {infile} --Z_band=2', '--calc "Z + 0"', f'--overwrite --outfile {out[3]}'
     with open(opt_files[3], 'w') as f:
         for i in opts:
             f.write(i + '\n')
-
-    for i, checksum in zip(range(test_count), (input_checksum[0], input_checksum[1], input_checksum[1], input_checksum[1])):
-        test_py_scripts.run_py_script(script_path, 'gdal_calc', '--optfile {}'.format(opt_files[i]))
-        check_file(out[i], checksum, i+1)
+    for opt_prefix in ['--optfile ', '@']:
+        for i, checksum in zip(range(test_count), (input_checksum[0], input_checksum[1], input_checksum[1], input_checksum[1])):
+            test_py_scripts.run_py_script(script_path, 'gdal_calc', f'{opt_prefix}{opt_files[i]}')
+            check_file(out[i], checksum, i+1)
 
 
 def test_gdal_calc_py_8():

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/gdal_argparse.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/gdal_argparse.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ******************************************************************************
+#
+#  Project:  GDAL utils.auxiliary
+#  Purpose:  an extended argparse.ArgumentParser to be used with all gdal-utils
+#  Author:   Idan Miara <idan@miara.com>
+#
+# ******************************************************************************
+#  Copyright (c) 2021, Idan Miara <idan@miara.com>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+# ******************************************************************************
+
+import sys
+import argparse
+import shlex
+from gettext import gettext
+from typing import Union
+from warnings import warn
+
+
+class ExtendAction(argparse.Action):
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest) or []
+        items.extend(values)
+        setattr(namespace, self.dest, items)
+
+
+class GDALArgumentParser(argparse.ArgumentParser):
+
+    def __init__(self, fromfile_prefix_chars='@', add_help: Union[str, bool] = True, **kwargs):
+        custom_help = isinstance(add_help, str)
+        super().__init__(fromfile_prefix_chars=fromfile_prefix_chars,
+                         add_help=add_help and not custom_help, **kwargs)
+        if custom_help:
+            self.add_argument(add_help, action='help', default=argparse.SUPPRESS,
+                              help=gettext('show this help message and exit'))
+        if sys.version_info < (3, 8):
+            # extend was introduced to the stdlib in Python 3.8
+            self.register('action', 'extend', ExtendAction)
+
+    def parse_args(self, args=None, optfile_arg=None, **kwargs):
+        if (args is not None
+           and optfile_arg in args
+           and self.fromfile_prefix_chars is not None
+           and optfile_arg is not None):
+
+            # Replace '--optfile x' with the standard '@x'
+            prefix = self.fromfile_prefix_chars[0]
+            count = len(args)
+            new_args = []
+            i = 0
+            while i < count:
+                arg = args[i]
+                if arg == optfile_arg:
+                    if i == count - 1:
+                        raise Exception(f'Missing filename argument following {optfile_arg}: ')
+                    arg = prefix + args[i + 1]
+                    warn(f'"{optfile_arg} {args[i + 1]}" is deprecated. '
+                         f'Please use "{arg}" instead.', DeprecationWarning)
+                    i += 1
+                i += 1
+                new_args.append(arg)
+            args = new_args
+        return super().parse_args(args=args, **kwargs)
+
+    def convert_arg_line_to_args(self, arg_line):
+        return shlex.split(arg_line, comments=True)

--- a/gdal/swig/python/gdal-utils/osgeo_utils/epsg_tr.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/epsg_tr.py
@@ -33,11 +33,12 @@
 # ******************************************************************************
 
 import sys
-from argparse import ArgumentParser
 from typing import Optional
 
 from osgeo import osr
 from osgeo import gdal
+
+from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser
 
 
 def trHandleCode(set_srid, srs, auth_name, code, deprecated, output_format):
@@ -184,18 +185,19 @@ def epsg_tr(output_format: str = '-pretty_wkt', authority: Optional[str] = None)
 
 
 def main(argv):
-    parser = ArgumentParser()
+    parser = GDALArgumentParser()
 
     parser.add_argument("-authority", dest="authority", metavar='name', type=str,
                         help="Authority name")
 
-    parser.add_argument("-wkt", const='wkt', dest="output_format", action='store_const', help='Well Known Text')
-    parser.add_argument("-pretty_wkt", const='pretty_wkt', dest="output_format", action='store_const',
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-wkt", const='wkt', dest="output_format", action='store_const', help='Well Known Text')
+    group.add_argument("-pretty_wkt", const='pretty_wkt', dest="output_format", action='store_const',
                         help='Pretty Well Known Text')
-    parser.add_argument("-proj4", const='proj4', dest="output_format", action='store_const', help='proj string')
-    parser.add_argument("-postgis", const='postgis', dest="output_format", action='store_const', help='postgis')
-    parser.add_argument("-xml", const='xml', dest="output_format", action='store_const', help='XML')
-    parser.add_argument("-copy", const='copy', dest="output_format", action='store_const', help='Table')
+    group.add_argument("-proj4", const='proj4', dest="output_format", action='store_const', help='proj string')
+    group.add_argument("-postgis", const='postgis', dest="output_format", action='store_const', help='postgis')
+    group.add_argument("-xml", const='xml', dest="output_format", action='store_const', help='XML')
+    group.add_argument("-copy", const='copy', dest="output_format", action='store_const', help='Table')
 
     args = parser.parse_args(argv[1:])
 

--- a/gdal/swig/python/gdal-utils/osgeo_utils/esri2wkt.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/esri2wkt.py
@@ -30,15 +30,16 @@
 # ******************************************************************************
 
 import sys
-from argparse import ArgumentParser
 from pathlib import Path
 from typing import Union
 
 from osgeo import osr
 
+from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser
+
 
 def main(argv):
-    parser = ArgumentParser(description='Transforms files from ESRI prj format into WKT format')
+    parser = GDALArgumentParser(description='Transforms files from ESRI prj format into WKT format')
 
     parser.add_argument("filenames", metavar='filename', type=str, nargs='*', help="esri .prj file")
 

--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
@@ -31,7 +31,7 @@
 ###############################################################################
 import sys
 import textwrap
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from argparse import RawDescriptionHelpFormatter
 from numbers import Number, Real
 from pathlib import Path
 from typing import Optional, Union, Sequence, Tuple
@@ -42,6 +42,7 @@ from osgeo_utils.auxiliary.base import num, PathLike
 from osgeo_utils.auxiliary.progress import get_progress_callback, OptionalProgressCallback
 from osgeo_utils.auxiliary.util import PathOrDS, get_bands
 from osgeo_utils.auxiliary.numpy_util import GDALTypeCodeAndNumericTypeCodeFromDataSet
+from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser
 
 
 def gdal2xyz(srcfile: PathOrDS, dstfile: PathLike = None,
@@ -313,7 +314,7 @@ def main_old(argv):
 
 
 def main(argv):
-    parser = ArgumentParser(
+    parser = GDALArgumentParser(
         formatter_class=RawDescriptionHelpFormatter,
         description=textwrap.dedent('''\
             The gdal2xyz utility can be used to translate a raster file into xyz format.

--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -32,7 +32,10 @@
 # ******************************************************************************
 
 ################################################################
-# Command line raster calculator with numpy syntax. Use any basic arithmetic supported by numpy arrays such as +-*\ along with logical operators such as >.  Note that all files must have the same dimensions, but no projection checking is performed.  Use gdal_calc.py --help for list of options.
+# Command line raster calculator with numpy syntax.
+# Use any basic arithmetic supported by numpy arrays such as +-*\ along with logical operators such as >.
+# Note that all files must have the same dimensions, but no projection checking is performed.
+# Use gdal_calc.py --help for list of options.
 
 # example 1 - add two files together
 # gdal_calc.py -A input1.tif -B input2.tif --outfile=result.tif --calc="A+B"
@@ -49,14 +52,13 @@
 # example 5 - work with multiple bands:
 # gdal_calc.py -A input.tif --A_band=1 -B input.tif --B_band=2 --outfile=result.tif --calc="(A+B)/2" --calc="A*logical_and(A>100,A<150)"
 ################################################################
-
+import textwrap
 from numbers import Number
 from typing import Union, Tuple, Optional, Sequence
-from optparse import OptionParser, OptionConflictError, Values
+import argparse
 import os
 import os.path
 import sys
-import shlex
 import string
 from collections import defaultdict
 
@@ -70,6 +72,7 @@ from osgeo_utils.auxiliary.extent_util import Extent, GT
 from osgeo_utils.auxiliary import extent_util
 from osgeo_utils.auxiliary.rectangle import GeoRectangle
 from osgeo_utils.auxiliary.color_table import get_color_table
+from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser
 
 GDALDataType = int
 
@@ -85,7 +88,7 @@ DefaultNDVLookup = {gdal.GDT_Byte: 255, gdal.GDT_UInt16: 65535, gdal.GDT_Int16: 
 GDALDataTypeNames = tuple(gdal.GetDataTypeName(dt) for dt in DefaultNDVLookup.keys())
 
 
-def doit(opts, args):
+def doit(opts):
     # pylint: disable=unused-argument
 
     if opts.debug:
@@ -170,7 +173,7 @@ def doit(opts, args):
             # It would have been better to pass it as user_namepsace, but I'll accept it anyway
             global_namespace[alphas] = filenames
             continue
-        for alpha, filename in zip(alphas*len(filenames), filenames):
+        for alpha, filename in zip(alphas * len(filenames), filenames):
             if not alpha.endswith("_band"):
                 # check if we have asked for a specific band...
                 if "%s_band" % alpha in opts.input_files:
@@ -203,8 +206,10 @@ def doit(opts, args):
                     if DimensionsCheck != myFileDimensions:
                         GeoTransformDiffer = True
                         if opts.extent in [Extent.IGNORE, Extent.FAIL]:
-                            raise Exception("Error! Dimensions of file %s (%i, %i) are different from other files (%i, %i).  Cannot proceed" %
-                                            (filename, myFileDimensions[0], myFileDimensions[1], DimensionsCheck[0], DimensionsCheck[1]))
+                            raise Exception(
+                                "Error! Dimensions of file %s (%i, %i) are different from other files (%i, %i).  Cannot proceed" %
+                                (filename, myFileDimensions[0], myFileDimensions[1], DimensionsCheck[0],
+                                 DimensionsCheck[1]))
                 else:
                     DimensionsCheck = myFileDimensions
 
@@ -228,13 +233,15 @@ def doit(opts, args):
                     if not GeoTransformCheck:
                         GeoTransformCheck = myFileGeoTransform
                     else:
-                        my_gt_diff = extent_util.gt_diff(GeoTransformCheck, myFileGeoTransform, eps=compatible_gt_eps, diff_support=gt_diff_support)
+                        my_gt_diff = extent_util.gt_diff(GeoTransformCheck, myFileGeoTransform, eps=compatible_gt_eps,
+                                                         diff_support=gt_diff_support)
                         if my_gt_diff not in [GT.SAME, GT.ALMOST_SAME]:
                             GeoTransformDiffer = True
                             if my_gt_diff != GT.COMPATIBLE_DIFF:
                                 raise Exception(
                                     "Error! GeoTransform of file {} {} is incompatible ({}), first file GeoTransform is {}. Cannot proceed".
-                                        format(filename, myFileGeoTransform, gt_diff_error[my_gt_diff], GeoTransformCheck))
+                                        format(filename, myFileGeoTransform, gt_diff_error[my_gt_diff],
+                                               GeoTransformCheck))
                 if opts.debug:
                     print("file %s: %s, dimensions: %s, %s, type: %s" % (
                         alpha, filename, DimensionsCheck[0], DimensionsCheck[1], myDataType[-1]))
@@ -255,7 +262,8 @@ def doit(opts, args):
     else:
         allBandsCount = len(opts.calc)
 
-    if opts.extent not in [Extent.IGNORE, Extent.FAIL] and (GeoTransformDiffer or isinstance(opts.extent, GeoRectangle)):
+    if opts.extent not in [Extent.IGNORE, Extent.FAIL] and (
+        GeoTransformDiffer or isinstance(opts.extent, GeoRectangle)):
         # mixing different GeoTransforms/Extents
         GeoTransformCheck, DimensionsCheck, ExtentCheck = extent_util.calc_geotransform_and_dimensions(
             GeoTransforms, Dimensions, opts.extent)
@@ -281,7 +289,8 @@ def doit(opts, args):
         if allBandsIndex is not None:
             raise Exception("Error! allBands option was given but Output file exists, must use --overwrite option!")
         if len(opts.calc) > 1:
-            raise Exception("Error! multiple calc options were given but Output file exists, must use --overwrite option!")
+            raise Exception(
+                "Error! multiple calc options were given but Output file exists, must use --overwrite option!")
         if opts.debug:
             print("Output file %s exists - filling in results into file" % (opts.outF))
 
@@ -297,7 +306,8 @@ def doit(opts, args):
         else:
             error = None
         if error:
-            raise Exception("Error! Output exists, %s.  Use the --overwrite option to automatically overwrite the existing file" % error)
+            raise Exception(
+                "Error! Output exists, %s.  Use the --overwrite option to automatically overwrite the existing file" % error)
 
         myOutB = myOut.GetRasterBand(1)
         myOutNDV = myOutB.GetNoDataValue()
@@ -341,7 +351,8 @@ def doit(opts, args):
             myOut.SetProjection(ProjectionCheck)
 
         if opts.NoDataValue is None:
-            myOutNDV = None if opts.hideNoData else DefaultNDVLookup[myOutType]  # use the default noDataValue for this datatype
+            myOutNDV = None if opts.hideNoData else DefaultNDVLookup[
+                myOutType]  # use the default noDataValue for this datatype
         elif isinstance(opts.NoDataValue, str) and opts.NoDataValue.lower() == 'none':
             myOutNDV = None  # not to set any noDataValue
         else:
@@ -362,7 +373,8 @@ def doit(opts, args):
 
     myOutTypeName = gdal.GetDataTypeName(myOutType)
     if opts.debug:
-        print("output file: %s, dimensions: %s, %s, type: %s" % (opts.outF, myOut.RasterXSize, myOut.RasterYSize, myOutTypeName))
+        print("output file: %s, dimensions: %s, %s, type: %s" % (
+            opts.outF, myOut.RasterXSize, myOut.RasterYSize, myOutTypeName))
 
     ################################################################
     # find block size to chop grids into bite-sized chunks
@@ -448,8 +460,8 @@ def doit(opts, args):
                     else:
                         myBandNo = myBands[i]
                     myval = gdal_array.BandReadAsArray(myFiles[i].GetRasterBand(myBandNo),
-                                                        xoff=myX, yoff=myY,
-                                                        win_xsize=nXValid, win_ysize=nYValid)
+                                                       xoff=myX, yoff=myY,
+                                                       win_xsize=nXValid, win_ysize=nYValid)
                     if myval is None:
                         raise Exception('Input block reading failed from filename %s' % filename[i])
 
@@ -475,7 +487,7 @@ def doit(opts, args):
                     local_namespace[lst] = val_lists[lst]
 
                 # try the calculation on the array blocks
-                calc = opts.calc[bandNo-1 if len(opts.calc) > 1 else 0]
+                calc = opts.calc[bandNo - 1 if len(opts.calc) > 1 else 0]
                 try:
                     myResult = eval(calc, global_namespace, local_namespace)
                 except:
@@ -510,6 +522,7 @@ def doit(opts, args):
 
     return myOut
 
+
 ################################################################
 
 
@@ -519,8 +532,7 @@ def Calc(calc: Union[str, Sequence[str]], outfile: Optional[PathLike] = None, No
          hideNoData: bool = False, projectionCheck: bool = False,
          color_table: Optional[Union[PathLike, gdal.ColorTable]] = None,
          extent: Optional[Extent] = None, projwin: Optional[Union[Tuple, GeoRectangle]] = None, user_namespace=None,
-         debug: bool=False, quiet: bool = False, **input_files):
-
+         debug: bool = False, quiet: bool = False, **input_files):
     """ Perform raster calculations with numpy syntax.
     Use any basic arithmetic supported by numpy arrays such as +-* along with logical
     operators such as >. Note that all files must have the same dimensions, but no projection checking is performed.
@@ -545,7 +557,7 @@ def Calc(calc: Union[str, Sequence[str]], outfile: Optional[PathLike] = None, No
     sum all files with hidden noDataValue
         Calc(calc="sum(a,axis=0)", a=['0.tif','1.tif','2.tif'], outfile="sum.tif", hideNoData=True)
     """
-    opts = Values()
+    opts = argparse.Namespace()
     opts.input_files = input_files
     # Single calc value compatibility
     # (type is overridden in the parameter list)
@@ -569,112 +581,103 @@ def Calc(calc: Union[str, Sequence[str]], outfile: Optional[PathLike] = None, No
     opts.debug = debug
     opts.quiet = quiet
 
-    return doit(opts, None)
-
-
-def store_input_file(option, opt_str, value, parser):
-    # pylint: disable=unused-argument
-    if not hasattr(parser.values, 'input_files'):
-        parser.values.input_files = {}
-    key = opt_str.lstrip('-')
-    if key in parser.values.input_files:
-        value_list = parser.values.input_files[key]
-        if not isinstance(value_list, list):
-            value_list = [value_list]
-        value_list.append(value)
-        value = value_list
-    parser.values.input_files[key] = value
+    return doit(opts)
 
 
 def add_alpha_args(parser, argv):
-    # limit the input file options to the ones in the argument list
-    given_args = set([a[1] for a in argv if a[1:2] in AlphaList] + ['A'])
-    for myAlpha in given_args:
+    if '--help' in argv:
+        alpha_list = ['A']  # we don't want to make help with all the full alpha list, as it's too long...
+    else:
+        alpha_list = AlphaList
+    for alpha in alpha_list:
         try:
-            parser.add_option("-%s" % myAlpha, action="callback", callback=store_input_file, type=str, help="input gdal raster file, you can use any letter (A-Z)", metavar='filename')
-            parser.add_option("--%s_band" % myAlpha, action="callback", callback=store_input_file, type=int, help="number of raster band for file %s (default 1)" % myAlpha, metavar='n')
-        except OptionConflictError:
+            band = alpha + '_band'
+            alpha_arg = '-' + alpha
+            band_arg = '--' + band
+            parser.add_argument(alpha_arg, action="extend", nargs='*', type=str,
+                                help="input gdal raster file, you can use any letter [a-z, A-Z]", metavar='filename')
+            parser.add_argument(band_arg, action="extend", nargs='*', type=int,
+                                help="number of raster band for file %s (default 1)" % alpha, metavar='n')
+        except argparse.ArgumentError:
             pass
 
 
 def main(argv):
-    usage = """usage: %prog --calc=expression --outfile=out_filename [-A filename]
-                    [--A_band=n] [-B...-Z filename] [other_options]"""
-    parser = OptionParser(usage)
+    parser = GDALArgumentParser(
+        # add an explicit --help option because the standard -h/--help option is not valid as -h is an alpha option
+        add_help='--help',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent('''\
+                    Command line raster calculator with numpy syntax.
+                    Use any basic arithmetic supported by numpy arrays such as +, -, *, and
+                    along with logical operators such as >.
+                    Note that all files must have the same dimensions (unless extent option is used),
+                    but no projection checking is performed (unless projectionCheck option is used).'''))
 
-    # define options
-    parser.add_option("--calc", dest="calc", action="append", help="calculation in numpy syntax using +-/* or any numpy array functions (i.e. log10()). May appear multiple times to produce a multi-band file", metavar="expression")
+    parser.add_argument("--calc", dest="calc", type=str, required=True, nargs='*', action="extend",
+                        help="calculation in numpy syntax using +-/* or any numpy array functions (i.e. log10()). "
+                             "May appear multiple times to produce a multi-band file", metavar="expression")
     add_alpha_args(parser, argv)
 
-    parser.add_option("--outfile", dest="outF", help="output file to generate or fill", metavar="filename")
-    parser.add_option("--NoDataValue", dest="NoDataValue", type=float, help="output nodata value (default datatype specific value)", metavar="value")
-    parser.add_option("--hideNoData", dest="hideNoData", action="store_true", help="ignores the NoDataValues of the input rasters")
-    parser.add_option("--type", dest="type", help="output datatype", choices=GDALDataTypeNames, metavar="datatype")
-    parser.add_option("--format", dest="format", help="GDAL format for output file", metavar="gdal_format")
-    parser.add_option(
-        "--creation-option", "--co", dest="creation_options", default=[], action="append",
+    parser.add_argument("--outfile", dest="outF", required=True, metavar="filename",
+                        help="output file to generate or fill")
+    parser.add_argument("--NoDataValue", dest="NoDataValue", type=float, metavar="value",
+                        help="output nodata value (default datatype specific value)")
+    parser.add_argument("--hideNoData", dest="hideNoData", action="store_true",
+                        help="ignores the NoDataValues of the input rasters")
+    parser.add_argument("--type", dest="type", type=str, metavar="datatype", choices=GDALDataTypeNames,
+                        help="output datatype")
+    parser.add_argument("--format", dest="format", type=str, metavar="gdal_format",
+                        help="GDAL format for output file")
+    parser.add_argument(
+        "--creation-option", "--co", dest="creation_options", default=[], action="append", metavar="option",
         help="Passes a creation option to the output format driver. Multiple "
-        "options may be listed. See format specific documentation for legal "
-        "creation options for each format.", metavar="option")
-    parser.add_option("--allBands", dest="allBands", default="", help="process all bands of given raster (a-z, A-Z)", metavar="[a-z, A-Z]")
-    parser.add_option("--overwrite", dest="overwrite", action="store_true", help="overwrite output file if it already exists")
-    parser.add_option("--debug", dest="debug", action="store_true", help="print debugging information")
-    parser.add_option("--quiet", dest="quiet", action="store_true", help="suppress progress messages")
-    parser.add_option("--optfile", dest="optfile", metavar="optfile", help="Read the named file and substitute the contents into the command line options list.")
+             "options may be listed. See format specific documentation for legal "
+             "creation options for each format.")
+    parser.add_argument("--allBands", dest="allBands", type=str, default="", metavar="[a-z, A-Z]",
+                        help="process all bands of given raster [a-z, A-Z]")
+    parser.add_argument("--overwrite", dest="overwrite", action="store_true",
+                        help="overwrite output file if it already exists")
+    parser.add_argument("--debug", dest="debug", action="store_true", help="print debugging information")
+    parser.add_argument("--quiet", dest="quiet", action="store_true", help="suppress progress messages")
 
-    parser.add_option("--color-table", dest="color_table", help="color table file name")
-    parser.add_option("--extent", dest="extent",
-                      choices=[e.name.lower() for e in Extent],
-                      help="how to treat mixed geotrasnforms")
-    parser.add_option("--projwin", dest="projwin", type=float, nargs=4,
-                      help="extent corners <ulx> <uly> <lrx> <lry> given in georeferenced coordinates")
+    parser.add_argument("--color-table", type=str, dest="color_table", help="color table file name")
 
-    parser.add_option("--projectionCheck", dest="projectionCheck", action="store_true",
-                      help="check that all rasters share the same projection")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--extent", dest="extent",
+                       choices=[e.name.lower() for e in Extent],
+                       help="how to treat mixed geotrasnforms")
+    group.add_argument("--projwin", dest="projwin", type=float, nargs=4, metavar=('ulx', 'uly', 'lrx', 'lry'),
+                       help="extent corners given in georeferenced coordinates")
 
-    (opts, args) = parser.parse_args(argv[1:])
+    parser.add_argument("--projectionCheck", dest="projectionCheck", action="store_true",
+                        help="check that all rasters share the same projection")
 
-    if not hasattr(opts, "input_files"):
-        opts.input_files = {}
-    if not hasattr(opts, "user_namespace"):
-        opts.user_namespace = {}
+    opts = parser.parse_args(argv[1:], optfile_arg="--optfile")
 
-    if opts.optfile:
-        with open(opts.optfile, 'r') as f:
-            ofargv = [x for line in f for x in shlex.split(line, comments=True)]
-        # Avoid potential recursion.
-        parser.remove_option('--optfile')
-        add_alpha_args(parser, ofargv)
-        ofopts, ofargs = parser.parse_args(ofargv)
-
-        # Let options given directly override the optfile.
-        input_files = getattr(ofopts, 'input_files', {})
-        input_files.update(opts.input_files)
-        user_namespace = getattr(ofopts, 'user_namespace', {})
-        user_namespace.update(opts.user_namespace)
-        ofopts.__dict__.update({k: v for k, v in vars(opts).items() if v})
-        opts = ofopts
+    try:
+        # create the input_files dict from the alpha arguments ('-a' and '--a_band')
+        input_files = {}
+        for alpha in AlphaList:
+            alpha_val = getattr(opts, alpha, None)
+            if alpha_val is not None:
+                delattr(opts, alpha)
+                alpha_val = [s.strip('"') for s in alpha_val]
+                input_files[alpha] = alpha_val if len(alpha_val) > 1 else alpha_val[0]
+                band_key = alpha + '_band'
+                band_val = getattr(opts, band_key, None)
+                if band_val is not None:
+                    delattr(opts, band_key)
+                    input_files[band_key] = band_val if len(band_val) > 1 else band_val[0]
         opts.input_files = input_files
-        opts.user_namespace = user_namespace
-        args = args + ofargs
-
-    if len(argv) == 1:
-        parser.print_help()
+        opts.calc = [s.strip('"') for s in opts.calc]
+        if not hasattr(opts, "user_namespace"):
+            opts.user_namespace = {}
+        # opts.calc = str(opts.calc).strip()
+        doit(opts)
+    except Exception as e:
+        print(e)
         return 1
-    elif not opts.calc:
-        print("No calculation provided. Nothing to do!")
-        parser.print_help()
-        return 1
-    elif not opts.outF:
-        print("No output file provided. Cannot proceed.")
-        parser.print_help()
-        return 1
-    else:
-        try:
-            doit(opts, args)
-        except IOError as e:
-            print(e)
-            return 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What does this PR do?

gdal_argparse.py - GDALArgumentParser an extended `argparse.ArgumentParser` to be used with all `gdal-utils`
gdal_calc.py - use `GDALArgumentParser ` instead of the old `optparse.OptionParser` 
use minor improvements to `ArgumentParser` uses in other utils
