### PR TITLE
Small typo fix for sponsor level name

### DIFF
--- a/gdal/doc/source/sponsors/index.rst
+++ b/gdal/doc/source/sponsors/index.rst
@@ -9,7 +9,7 @@ contributing resources to its success. The following organizations take an
 extra step, providing unrestricted funding every year to maintain and improve
 the health of project:
 
-- Platinium level:
+- Platinum level:
 
   .. _platinium-sponsors:
   .. container:: horizontal-logos


### PR DESCRIPTION
On the PDF in the same folder the sponsor level is called `Platinum` so I assume the rst-file has a typo.