### PR TITLE
Windows: do not define MSVCRT macro on UCRT target

### DIFF
--- a/gdal/frmts/mrsid_lidar/gdal_MG4Lidar.cpp
+++ b/gdal/frmts/mrsid_lidar/gdal_MG4Lidar.cpp
@@ -780,7 +780,7 @@ GDALDataset *MG4LidarDataset::Open( GDALOpenInfo * poOpenInfo )
    MG4PointReader *r = MG4PointReader::create();
    FileIO* io = FileIO::create();
 
-#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601
+#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
    bool bIsUTF8 =
        CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) );
    wchar_t *pwszFilename = nullptr;
@@ -814,7 +814,7 @@ GDALDataset *MG4LidarDataset::Open( GDALOpenInfo * poOpenInfo )
          delete poDS;
          RELEASE(r);
          RELEASE(io);
-#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601
+#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
          if ( pwszFilename )
             CPLFree( pwszFilename );
 #endif
@@ -838,7 +838,7 @@ GDALDataset *MG4LidarDataset::Open( GDALOpenInfo * poOpenInfo )
       CSLDestroy(papszClipExtent);
    }
 
-#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601
+#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
    if (bIsUTF8)
    {
       poDS->fileIO->init(pwszFilename, "r");

--- a/gdal/gcore/gdalpython.cpp
+++ b/gdal/gcore/gdalpython.cpp
@@ -475,7 +475,7 @@ static bool LoadPythonAPI()
         uOldErrorMode = SetErrorMode(SEM_NOOPENFILEERRORBOX |
                                      SEM_FAILCRITICALERRORS);
 
-#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601
+#if (defined(WIN32) && _MSC_VER >= 1310) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
         if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
         {
             wchar_t *pwszFilename =

--- a/gdal/port/cpl_port.h
+++ b/gdal/port/cpl_port.h
@@ -116,7 +116,7 @@
 /* We need __MSVCRT_VERSION__ >= 0x0700 to have "_aligned_malloc" */
 /* Latest versions of mingw32 define it, but with older ones, */
 /* we need to define it manually */
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && !defined(_UCRT)
 #ifndef __MSVCRT_VERSION__
 #define __MSVCRT_VERSION__ 0x0700
 #endif

--- a/gdal/port/cpl_vsil_win32.cpp
+++ b/gdal/port/cpl_vsil_win32.cpp
@@ -722,7 +722,7 @@ int VSIWin32FilesystemHandler::Stat( const char * pszFilename,
 {
     (void) nFlags;
 
-#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601
+#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
     if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         wchar_t *pwszFilename =
@@ -790,7 +790,7 @@ int VSIWin32FilesystemHandler::Stat( const char * pszFilename,
 int VSIWin32FilesystemHandler::Unlink( const char * pszFilename )
 
 {
-#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601
+#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
     if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         wchar_t *pwszFilename =
@@ -815,7 +815,7 @@ int VSIWin32FilesystemHandler::Rename( const char *oldpath,
                                            const char *newpath )
 
 {
-#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601
+#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
     if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         wchar_t *pwszOldPath =
@@ -844,7 +844,7 @@ int VSIWin32FilesystemHandler::Mkdir( const char * pszPathname,
 
 {
     (void) nMode;
-#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601
+#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
     if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         wchar_t *pwszFilename =
@@ -868,7 +868,7 @@ int VSIWin32FilesystemHandler::Mkdir( const char * pszPathname,
 int VSIWin32FilesystemHandler::Rmdir( const char * pszPathname )
 
 {
-#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601
+#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
     if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         wchar_t *pwszFilename =
@@ -893,7 +893,7 @@ char **VSIWin32FilesystemHandler::ReadDirEx( const char *pszPath,
                                              int nMaxFiles )
 
 {
-#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601
+#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
     if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         struct _wfinddata_t c_file;

--- a/gdal/port/cplgetsymbol.cpp
+++ b/gdal/port/cplgetsymbol.cpp
@@ -150,7 +150,7 @@ void *CPLGetSymbol( const char * pszLibrary, const char * pszSymbolName )
     UINT uOldErrorMode =
         SetErrorMode(SEM_NOOPENFILEERRORBOX | SEM_FAILCRITICALERRORS);
 
-#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601
+#if defined(_MSC_VER) || __MSVCRT_VERSION__ >= 0x0601 || defined(_UCRT)
     if( CPLTestBool( CPLGetConfigOption( "GDAL_FILENAME_IS_UTF8", "YES" ) ) )
     {
         wchar_t *pwszFilename =


### PR DESCRIPTION
## What does this PR do?

Currently we set `__MSVCRT_VERSION__` if unset, for backward compatibility. 

https://github.com/OSGeo/gdal/blob/23115297099b9750923b5a54f826733be2378986/gdal/port/cpl_port.h#L116-L123

However setting `__MSVCRT_VERSION__` breaks the new UCRT targets. Instead we should check explicitly for `_UCRT`, which equals MSVCRT runtime version `0xE00`.

This is the same as https://github.com/msys2/MINGW-packages/pull/8284

## Environment

Provide environment details, if relevant:

* OS: WINDOWS
* Compiler: mingw-w64 (for example msys2 with new ucrt64 target)
