### PR TITLE
GDALmake.opt.in: in non-libtool LD_SHARED builds, do not link applications against libgdal dependencies, but only against libgdal itself

### DIFF
--- a/.github/workflows/asan/start.sh
+++ b/.github/workflows/asan/start.sh
@@ -71,7 +71,10 @@ ccache -s
 
 # Build proj
 (cd proj;  ./autogen.sh && CFLAGS='-DPROJ_RENAME_SYMBOLS' CXXFLAGS='-DPROJ_RENAME_SYMBOLS' ./configure --disable-static --prefix=/usr/local && make -j3)
-(cd proj; sudo make -j3 install && sudo mv /usr/local/lib/libproj.so.15.0.0 /usr/local/lib/libinternalproj.so.15.0.0 && sudo rm /usr/local/lib/libproj.so*  && sudo rm /usr/local/lib/libproj.la && sudo ln -f -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so.15 && sudo ln -f -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so)
+(cd proj; sudo make -j3 install)
+sudo sh -c "apt-get remove -y libproj-dev"
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 CURRENT_DIR=$PWD
 cd gdal

--- a/.github/workflows/ubuntu_18.04/install.sh
+++ b/.github/workflows/ubuntu_18.04/install.sh
@@ -31,7 +31,10 @@ fossil clone https://www.gaia-gis.it/fossil/librasterlite2 librasterlite2.fossil
 
 # Build proj
 (cd proj && ./autogen.sh && CC='ccache gcc' CXX='ccache g++' CFLAGS='-DPROJ_RENAME_SYMBOLS' CXXFLAGS='-DPROJ_RENAME_SYMBOLS' ./configure  --disable-static --prefix=/usr/local || cat config.log && make -j3)
-sudo sh -c "cd $PWD/proj && make -j3 install && mv /usr/local/lib/libproj.so.15.0.0 /usr/local/lib/libinternalproj.so.15.0.0 && rm /usr/local/lib/libproj.so*  && rm /usr/local/lib/libproj.la && ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so.15 && ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so"
+sudo sh -c "cd $PWD/proj && make -j3 install"
+sudo sh -c "apt-get remove -y libproj-dev"
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Configure GDAL
 CURRENT_DIR=$PWD

--- a/.github/workflows/ubuntu_18.04_32bit/start.sh
+++ b/.github/workflows/ubuntu_18.04_32bit/start.sh
@@ -56,7 +56,10 @@ fossil clone https://www.gaia-gis.it/fossil/librasterlite2 librasterlite2.fossil
 # Build proj
 
 (git clone --depth 1 https://github.com/OSGeo/PROJ && cd PROJ && (cd data && curl http://download.osgeo.org/proj/proj-datumgrid-1.8.tar.gz > proj-datumgrid-1.8.tar.gz && tar xvzf proj-datumgrid-1.8.tar.gz) && ./autogen.sh && CC='ccache gcc' CXX='ccache g++' CFLAGS='-DPROJ_RENAME_SYMBOLS' CXXFLAGS='-DPROJ_RENAME_SYMBOLS' ./configure  --disable-static --prefix=/usr/local || cat config.log && make -j3)
-sudo sh -c "cd $PWD/PROJ && make -j3 install && mv /usr/local/lib/libproj.so.22.0.0 /usr/local/lib/libinternalproj.so.22.0.0 && rm /usr/local/lib/libproj.so*  && rm /usr/local/lib/libproj.la && ln -s libinternalproj.so.22.0.0  /usr/local/lib/libinternalproj.so.19 && ln -s libinternalproj.so.22.0.0  /usr/local/lib/libinternalproj.so"
+sudo sh -c "cd $PWD/PROJ && make -j3 install"
+sudo sh -c "apt-get remove -y libproj-dev"
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Configure GDAL
 CURRENT_DIR=$PWD

--- a/gdal/GDALmake.opt.in
+++ b/gdal/GDALmake.opt.in
@@ -613,7 +613,7 @@ SO_EXT		=	la
 else # HAVE_LIBTOOL
 
 ifeq ($(HAVE_LD_SHARED),yes)
-CONFIG_LIBS	=	$(GDAL_SLIB_LINK) $(LIBS)
+CONFIG_LIBS	=	$(GDAL_SLIB_LINK)
 ifeq ($(MACOSX_FRAMEWORK),yes)
 CONFIG_LIBS_INS	=	-L$(INST_LIB)/unix/lib -lgdal
 else

--- a/gdal/ci/travis/graviton2/install.sh
+++ b/gdal/ci/travis/graviton2/install.sh
@@ -21,7 +21,10 @@ ccache -s
 # Build proj
 sh -c "cd $PWD/proj && ./autogen.sh && CC='ccache gcc' CXX='ccache g++' CFLAGS='-DPROJ_RENAME_SYMBOLS' CXXFLAGS='-DPROJ_RENAME_SYMBOLS' ./configure  --disable-static --prefix=/usr/local || cat config.log"
 sh -c "cd $PWD/proj && CCACHE_CPP2=yes make -j3"
-sudo sh -c "cd $PWD/proj && make -j3 install && mv /usr/local/lib/libproj.so.15.0.0 /usr/local/lib/libinternalproj.so.15.0.0 && rm /usr/local/lib/libproj.so*  && rm /usr/local/lib/libproj.la && ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so.15 && ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so"
+sudo sh -c "cd $PWD/proj && make -j3 install"
+sudo sh -c "apt-get remove -y libproj-dev"
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Configure GDAL
 sh -c "cd $PWD/gdal && CCACHE_CPP2=yes CC='ccache gcc' CXX='ccache g++' LDFLAGS='-lstdc++' ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-mysql --with-liblzma --without-webp --with-epsilon --with-proj=/usr/local --with-poppler --with-hdf5 --with-dods-root=/usr --with-sosi --with-mysql"

--- a/gdal/ci/travis/s390x/install.sh
+++ b/gdal/ci/travis/s390x/install.sh
@@ -21,7 +21,10 @@ ccache -s
 # Build proj
 sh -c "cd $PWD/proj && ./autogen.sh && CC='ccache gcc' CXX='ccache g++' CFLAGS='-DPROJ_RENAME_SYMBOLS' CXXFLAGS='-DPROJ_RENAME_SYMBOLS' ./configure  --disable-static --prefix=/usr/local || cat config.log"
 sh -c "cd $PWD/proj && CCACHE_CPP2=yes make -j3"
-sudo sh -c "cd $PWD/proj && make -j3 install && mv /usr/local/lib/libproj.so.15.0.0 /usr/local/lib/libinternalproj.so.15.0.0 && rm /usr/local/lib/libproj.so*  && rm /usr/local/lib/libproj.la && ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so.15 && ln -s libinternalproj.so.15.0.0  /usr/local/lib/libinternalproj.so"
+sudo sh -c "cd $PWD/proj && make -j3 install"
+sudo sh -c "apt-get remove -y libproj-dev"
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Configure GDAL
 sh -c "cd $PWD/gdal && CCACHE_CPP2=yes CC='ccache gcc' CXX='ccache g++' LDFLAGS='-lstdc++' ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-mysql --with-liblzma --without-webp --with-epsilon --with-proj=/usr/local --with-poppler --with-hdf5 --with-dods-root=/usr --with-sosi --with-mysql"


### PR DESCRIPTION
Besides being useless, it was found to cause a hang in the OpenCL's call
clGetPlatformIDs() of gdalwarp when linking against ECW SDK...
