### PR TITLE
swig/python/GNUmakefile and swig/makefile.vc: remove useless command to install scripts in bin directory

### DIFF
--- a/gdal/swig/makefile.vc
+++ b/gdal/swig/makefile.vc
@@ -29,7 +29,6 @@ python_install: python
 	if not exist $(GDAL_HOME)\python\script  mkdir $(GDAL_HOME)\python\script
 	set PYTHONPATH=$(GDAL_HOME)\python\Lib\site-packages
 	$(PYDIR)\$(PYEXEC) setup.py install --prefix $(GDAL_HOME)\python
-	$(INSTALL) scripts\*.py $(GDAL_HOME)\python\script
 	cd ..
 
 #d:\Python\debug\Python-2.4\PCbuild\python_d.exe setup.py build   --debug

--- a/gdal/swig/python/GNUmakefile
+++ b/gdal/swig/python/GNUmakefile
@@ -14,7 +14,6 @@ SWIGOUTPUTDIR=extensions/
 
 include ../SWIGmake.base
 
-SCRIPTS			= `ls ./scripts/*.py`
 PY_COMMANDS     =       epsg_tr.py gdalchksum.py gdal2xyz.py gcps2wld.py \
                         gdalimport.py gdal_merge.py pct2rgb.py rgb2pct.py \
                         gcps2vec.py
@@ -149,7 +148,6 @@ install:
 	fi
 	env PYTHONPATH=$(site_package_dir)$${PYTHONPATH:+:$$PYTHONPATH} \
 		$(PYTHON) setup.py install ${setup_opts}
-	for f in $(SCRIPTS) ; do $(INSTALL) $$f $(DESTDIR)$(INST_BIN) ; done
 
 # see swig/include/python/docs/README to refresh the  ../include/python/docs/ files
 docs:


### PR DESCRIPTION
CC @idanmiara 
I noticed this during the build of one of the Docker image that threw the following warning:
```
for f in `ls ./scripts/*.py` ; do  /gdal/gdal/install-sh -c $f /build/usr/bin ; done
ls: ./scripts/*.py: No such file or directory
make[2]: Leaving directory '/gdal/gdal/swig/python'
make[1]: Leaving directory '/gdal/gdal/swig'
```