### PR TITLE
Coordinate transformation: use time neutral value for time-dependant …

### DIFF
--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -143,7 +143,7 @@ def test_osr_ct_4():
         assert result[i][0] == pytest.approx(452772.06, abs=0.01) and result[i][1] == pytest.approx(3540544.89, abs=0.01) and result[i][2] == pytest.approx(0.0, abs=0.01), \
             'Wrong LL to UTM result'
 
-    
+
 ###############################################################################
 # Same test, but with any sequence of tuples instead of a tuple of tuple
 # New in NG bindings (#3020)
@@ -167,7 +167,7 @@ def test_osr_ct_5():
         assert result[i][0] == pytest.approx(452772.06, abs=0.01) and result[i][1] == pytest.approx(3540544.89, abs=0.01) and result[i][2] == pytest.approx(0.0, abs=0.01), \
             'Wrong LL to UTM result'
 
-    
+
 ###############################################################################
 # Test osr.CreateCoordinateTransformation() method
 
@@ -195,7 +195,7 @@ def test_osr_ct_6():
         assert result[i][0] == pytest.approx(452772.06, abs=0.01) and result[i][1] == pytest.approx(3540544.89, abs=0.01) and result[i][2] == pytest.approx(0.0, abs=0.01), \
             'Wrong LL to UTM result'
 
-    
+
 ###############################################################################
 # Actually perform a simple Pseudo Mercator to LL conversion.
 
@@ -233,7 +233,7 @@ def test_osr_ct_7():
         print('Expected: %s' % expected_pnt.ExportToWkt())
         pytest.fail('Failed to transform from Pseudo Mercator to LL')
 
-    
+
 ###############################################################################
 # Test WebMercator -> WGS84 optimized transform
 
@@ -517,3 +517,17 @@ def test_osr_ct_options_ballpark_disallowed():
     except:
         pass
 
+
+###############################################################################
+# Test that we pass a neutral time when not explicitly specified
+
+
+def test_osr_ct_non_specified_time_with_time_dependent_transformation():
+
+    options = osr.CoordinateTransformationOptions()
+    options.SetOperation('+proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +z_in=m +xy_out=rad +z_out=m +step +proj=cart +ellps=GRS80 +step +inv +proj=helmert +dx=0.0008 +dy=-0.0006 +dz=-0.0014 +drx=6.67e-05 +dry=-0.0007574 +drz=-5.13e-05 +ds=-7e-05 +t_epoch=2010 +convention=coordinate_frame +step +inv +proj=cart +ellps=GRS80 +step +proj=unitconvert +xy_in=rad +z_in=m +xy_out=deg +z_out=m +step +proj=axisswap +order=2,1')
+    ct = osr.CoordinateTransformation(None, None, options)
+    assert ct
+    x, y, _ = ct.TransformPoint(50, -40, 0)
+    assert x == pytest.approx(50, abs=1e-10)
+    assert y == pytest.approx(-40, abs=1e-10)

--- a/gdal/ogr/ogrct.cpp
+++ b/gdal/ogr/ogrct.cpp
@@ -2228,7 +2228,7 @@ int OGRProjCT::TransformWithErrorCodes(
             coord.xyzt.x = x[i];
             coord.xyzt.y = y[i];
             coord.xyzt.z = z ? z[i] : 0;
-            coord.xyzt.t = t ? t[i] : 0;
+            coord.xyzt.t = t ? t[i] : HUGE_VAL;
             proj_errno_reset(pj);
             coord = proj_trans(pj, m_bReversePj ? PJ_INV : PJ_FWD, coord);
             x[i] = coord.xyzt.x;


### PR DESCRIPTION
…transformations when no explicit time is specified (fix master bug only)
