### PR TITLE
type hints fix and variable init

### DIFF
--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_table.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_table.py
@@ -30,12 +30,14 @@
 
 import os
 import tempfile
-from typing import Optional
+from typing import Optional, Union
 
 from osgeo import gdal
 from osgeo_utils.auxiliary.base import PathLikeOrStr
 from osgeo_utils.auxiliary.util import open_ds, PathOrDS
 from osgeo_utils.auxiliary.color_palette import get_color_palette, ColorPaletteOrPathOrStrings
+
+ColorTableLike = Union[gdal.ColorTable, ColorPaletteOrPathOrStrings]
 
 
 def get_color_table_from_raster(path_or_ds: PathOrDS) -> Optional[gdal.ColorTable]:
@@ -46,8 +48,8 @@ def get_color_table_from_raster(path_or_ds: PathOrDS) -> Optional[gdal.ColorTabl
     return None
 
 
-def get_color_table(color_palette_or_path_or_strings_or_ds: ColorPaletteOrPathOrStrings, min_key=0, max_key=255,
-                    fill_missing_colors=True) -> Optional[gdal.ColorTable]:
+def get_color_table(color_palette_or_path_or_strings_or_ds: Optional[ColorTableLike],
+                    min_key=0, max_key=255, fill_missing_colors=True) -> Optional[gdal.ColorTable]:
     if (color_palette_or_path_or_strings_or_ds is None or
        isinstance(color_palette_or_path_or_strings_or_ds, gdal.ColorTable)):
         return color_palette_or_path_or_strings_or_ds

--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
@@ -39,7 +39,7 @@ from osgeo import gdal
 from osgeo_utils.auxiliary.base import PathLikeOrStr
 from osgeo_utils.auxiliary.color_palette import ColorPaletteOrPathOrStrings
 from osgeo_utils.auxiliary.util import GetOutputDriverFor, open_ds
-from osgeo_utils.auxiliary.color_table import get_color_table
+from osgeo_utils.auxiliary.color_table import get_color_table, ColorTableLike
 
 
 def Usage():
@@ -53,6 +53,7 @@ def main(argv):
     pct_filename = None
     src_filename = None
     dst_filename = None
+    driver_name = None
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
@@ -86,7 +87,7 @@ def main(argv):
     return err
 
 
-def doit(src_filename, pct_filename: ColorPaletteOrPathOrStrings,
+def doit(src_filename, pct_filename: Optional[ColorTableLike],
          dst_filename: Optional[PathLikeOrStr] = None, driver_name: Optional[str] = None):
 
     # =============================================================================


### PR DESCRIPTION
## What does this PR do?

fix some minor bugs for GDAL 3.3
`color_table.py` - fix some inaccurate type hints
`gdalattachpct.py` -  `driver_name` was not initialized so it might crash if no `-of` is provided.