### PR TITLE
`gdal-utils` version: add `gdal_utils_version` and bump `__version__`; fix typo

### DIFF
--- a/gdal/swig/python/gdal-utils/osgeo_utils/__init__.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/__init__.py
@@ -1,4 +1,4 @@
-__pacakge_name__ = 'gdal-utils'
+__package_name__ = 'gdal-utils'
 gdal_utils_version = (3, 3, 0, 7)
 __version__ = '.'.join(str(i) for i in gdal_utils_version)
 __author__ = "Frank Warmerdam"

--- a/gdal/swig/python/gdal-utils/osgeo_utils/__init__.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/__init__.py
@@ -1,5 +1,6 @@
 __pacakge_name__ = 'gdal-utils'
-__version__ = '3.3.0.6'
+gdal_utils_version = (3, 3, 0, 7)
+__version__ = '.'.join(str(i) for i in gdal_utils_version)
 __author__ = "Frank Warmerdam"
 __author_email__ = "warmerdam@pobox.com"
 __maintainer__ = "Idan Miara"

--- a/gdal/swig/python/gdal-utils/setup.py
+++ b/gdal/swig/python/gdal-utils/setup.py
@@ -6,7 +6,7 @@ from glob import glob
 from setuptools import setup, find_packages
 
 from osgeo_utils import (
-    __pacakge_name__,
+    __package_name__,
     __version__,
     __author__,
     __author_email__,
@@ -36,7 +36,7 @@ packages = find_packages(package_root)  # include all packages under package_roo
 package_dir = {'': package_root}  # packages sources are under package_root
 
 setup(
-    name=__pacakge_name__,
+    name=__package_name__,
     version=__version__,
     author=__author__,
     author_email=__author_email__,


### PR DESCRIPTION
## What does this PR do?

`gdal/swig/python/gdal-utils/osgeo_utils/__init__.py` - `gdal-utils` version: add `gdal_utils_version` and bump `__version__`
`gdal/swig/python/gdal-utils/[setup|osgeo_utils/__init__].py` - fix typo `__pacakge_name__ ` ->  `__package_name__`