### PR TITLE
Fix for .net core build error fixes #3711

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -228,9 +228,9 @@ jobs:
             cd $env:GITHUB_WORKSPACE\gdal\swig\python
             exec { python setup.py build }
             exec { python setup.py install }
-            # Disabled because of https://github.com/OSGeo/gdal/issues/3711
             cd $env:GITHUB_WORKSPACE\gdal\swig\csharp
             dotnet nuget locals all --clear
+            dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
             exec { nmake /f makefile.vc interface }
             exec { nmake /f makefile.vc all $env:WIN64_ARG }
             cd $env:GITHUB_WORKSPACE\autotest\cpp
@@ -259,6 +259,5 @@ jobs:
             cd $env:GITHUB_WORKSPACE\autotest
             pip install -Ur requirements.txt
             exec { pytest -vv }
-            # Disabled because of https://github.com/OSGeo/gdal/issues/3711
-            #cd $env:GITHUB_WORKSPACE\gdal\swig\csharp
-            #exec { nmake /f makefile.vc test }
+            cd $env:GITHUB_WORKSPACE\gdal\swig\csharp
+            exec { nmake /f makefile.vc test }

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -229,9 +229,10 @@ jobs:
             exec { python setup.py build }
             exec { python setup.py install }
             # Disabled because of https://github.com/OSGeo/gdal/issues/3711
-            #cd $env:GITHUB_WORKSPACE\gdal\swig\csharp
-            #exec { nmake /f makefile.vc interface }
-            #exec { nmake /f makefile.vc all $env:WIN64_ARG }
+            cd $env:GITHUB_WORKSPACE\gdal\swig\csharp
+            dotnet nuget locals all -clear
+            exec { nmake /f makefile.vc interface }
+            exec { nmake /f makefile.vc all $env:WIN64_ARG }
             cd $env:GITHUB_WORKSPACE\autotest\cpp
             exec { nmake /f makefile.vc MSVC_VER=$env:MSVC_VER $env:WIN64_ARG }
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -230,7 +230,7 @@ jobs:
             exec { python setup.py install }
             # Disabled because of https://github.com/OSGeo/gdal/issues/3711
             cd $env:GITHUB_WORKSPACE\gdal\swig\csharp
-            dotnet nuget locals all -clear
+            dotnet nuget locals all --clear
             exec { nmake /f makefile.vc interface }
             exec { nmake /f makefile.vc all $env:WIN64_ARG }
             cd $env:GITHUB_WORKSPACE\autotest\cpp

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -231,6 +231,7 @@ jobs:
             cd $env:GITHUB_WORKSPACE\gdal\swig\csharp
             dotnet nuget locals all --clear
             dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org
+            dotnet restore
             exec { nmake /f makefile.vc interface }
             exec { nmake /f makefile.vc all $env:WIN64_ARG }
             cd $env:GITHUB_WORKSPACE\autotest\cpp

--- a/gdal/swig/csharp/makefile.vc
+++ b/gdal/swig/csharp/makefile.vc
@@ -33,7 +33,7 @@ CSC = mcs
 NETSTANDARD = netstandard2.0
 !ENDIF
 !IFNDEF NETCORE
-NETCORE = netcoreapp3.1
+NETCORE = netcoreapp2.1
 !ENDIF
 !IF $(MSVC_VER) >= 1400
 !IFDEF WIN64

--- a/gdal/swig/csharp/makefile.vc
+++ b/gdal/swig/csharp/makefile.vc
@@ -33,7 +33,7 @@ CSC = mcs
 NETSTANDARD = netstandard2.0
 !ENDIF
 !IFNDEF NETCORE
-NETCORE = netcoreapp2.1
+NETCORE = netcoreapp3.1
 !ENDIF
 !IF $(MSVC_VER) >= 1400
 !IFDEF WIN64


### PR DESCRIPTION
fixes #3711 

This fixes the problem. It is based on a concatenation of the various threads about this across the web.

The effect seems to be widespread. The cause seems to be some as yet unidentified change in the vs2019 environment.
