### PR TITLE
`osgeo_utils/auxiliary/arrays.py` - add `ArrayLike`, `ScalarLike`, `ArrayOrScalarLike` types

### DIFF
--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -27,7 +27,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
-
+import array
 import os
 from pathlib import Path
 
@@ -38,7 +38,7 @@ from osgeo_utils.auxiliary.extent_util import Extent
 
 pytest.importorskip('osgeo_utils')
 
-from osgeo_utils.auxiliary import util, raster_creation, base
+from osgeo_utils.auxiliary import util, raster_creation, base, arrays
 
 temp_files = []
 
@@ -89,13 +89,13 @@ def test_utils_py_1():
     ds = util.open_ds(filename)
     compression = util.get_image_structure_metadata(filename, 'COMPRESSION')
     assert compression == 'DEFLATE'
-    ovr_count = util.get_ovr_count(ds)+1
+    ovr_count = util.get_ovr_count(ds) + 1
     assert ovr_count == 3
     pixel_size = util.get_pixel_size(ds)
     assert pixel_size == (10, -10)
 
     for i in range(-ovr_count, ovr_count):
-        assert util.get_ovr_idx(filename, ovr_idx=i) == (i if i >= 0 else ovr_count+i)
+        assert util.get_ovr_idx(filename, ovr_idx=i) == (i if i >= 0 else ovr_count + i)
 
     for res, ovr in [(5, 0), (10, 0), (11, 0), (19.99, 0), (20, 1), (20.1, 1), (39, 1), (40, 2), (41, 2), (400, 2)]:
         assert util.get_ovr_idx(filename, ovr_res=res) == ovr
@@ -108,6 +108,32 @@ def test_utils_py_1():
     ds_list = util.open_ds([ds, filename2])
     assert tuple(util.get_ovr_count(ds) for ds in ds_list) == (2, 0)
     ds_list = None
+
+
+def test_utils_arrays():
+    scalars = [7, 5.2]
+
+    for scalar in scalars:
+        assert isinstance(scalar, arrays.ScalarLike.__args__)
+        assert isinstance(scalar, arrays.ArrayOrScalarLike.__args__)
+
+    for vec in (scalars, tuple(scalars), array.array('d', scalars), array.array('i', [2, 3])):
+        assert isinstance(vec, arrays.ArrayLike.__args__)
+        assert isinstance(vec, arrays.ArrayOrScalarLike.__args__)
+
+    for not_vec in (None, {1: 2}):
+        assert not isinstance(not_vec, arrays.ArrayLike.__args__)
+        assert not isinstance(not_vec, arrays.ArrayOrScalarLike.__args__)
+
+
+def test_utils_np_arrays():
+    np = pytest.importorskip('numpy')
+    vec_2d = [[1, 2, 3], [4, 5, 6]]
+
+    for dtype in (np.int8, np.int32, np.float64):
+        for vec in (vec_2d[0], vec_2d):
+            arr = np.array(vec, dtype=dtype)
+            assert isinstance(arr, arrays.ArrayLike.__args__)
 
 
 def test_utils_py_cleanup():

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/arrays.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/arrays.py
@@ -3,11 +3,11 @@
 # ******************************************************************************
 #
 #  Project:  GDAL utils.auxiliary
-#  Purpose:  utility functions for gdal-numpy integration
+#  Purpose:  array and scalar related types functions
 #  Author:   Idan Miara <idan@miara.com>
 #
 # ******************************************************************************
-#  Copyright (c) 2020, Idan Miara <idan@miara.com>
+#  Copyright (c) 2021, Idan Miara <idan@miara.com>
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -28,29 +28,31 @@
 #  DEALINGS IN THE SOFTWARE.
 # ******************************************************************************
 import array
-from numbers import Real
-from typing import Union, Sequence
+from typing import Union, Sequence, TYPE_CHECKING
 
-from osgeo import gdal, gdal_array
-import numpy as np
+ScalarLike = Union[
+    int,
+    float,
+]
 
-from osgeo_utils.auxiliary.arrays import \
-    ArrayLike as NumpyCompatibleArray, \
-    ArrayOrScalarLike as NumpyCompatibleArrayOrReal  # noqa backwards compatibility
+if TYPE_CHECKING:
+    # avoid "TypeError: Subscripted generics cannot be used with class and instance checks" while using isinstance()
+    ArrayLike = Union[
+        ScalarLike,
+        Sequence[ScalarLike],
+        array.array,
+    ]
+else:
+    ArrayLike = Union[
+        ScalarLike,
+        Sequence,
+        array.array,
+    ]
 
+try:
+    from numpy import ndarray
+    ArrayLike = Union[ArrayLike, ndarray]
+except ImportError:
+    pass
 
-def GDALTypeCodeToNumericTypeCodeEx(buf_type, signed_byte, default=None):
-    typecode = gdal_array.GDALTypeCodeToNumericTypeCode(buf_type)
-    if typecode is None:
-        typecode = default
-
-    if buf_type == gdal.GDT_Byte and signed_byte:
-        typecode = np.int8
-    return typecode
-
-
-def GDALTypeCodeAndNumericTypeCodeFromDataSet(ds):
-    buf_type = ds.GetRasterBand(1).DataType
-    signed_byte = ds.GetRasterBand(1).GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE'
-    np_typecode = GDALTypeCodeToNumericTypeCodeEx(buf_type, signed_byte=signed_byte, default=np.float32)
-    return buf_type, np_typecode
+ArrayOrScalarLike = Union[ArrayLike, ScalarLike]

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/osr_util.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/osr_util.py
@@ -32,7 +32,7 @@ from typing import Union, Tuple, Optional
 import osgeo
 from osgeo import osr, ogr, gdal
 
-from osgeo_utils.auxiliary.numpy_util import NumpyCompatibleArray
+from osgeo_utils.auxiliary.arrays import ArrayLike
 
 AnySRS = Union[str, int, osr.SpatialReference, gdal.Dataset]
 
@@ -78,8 +78,8 @@ def get_transform(src_srs: AnySRS, tgt_srs: AnySRS) -> Optional[osr.CoordinateTr
 
 
 def transform_points(ct: Optional[osr.CoordinateTransformation],
-                     x: NumpyCompatibleArray, y: NumpyCompatibleArray, z: Optional[NumpyCompatibleArray] = None) -> \
-                     Tuple[NumpyCompatibleArray, NumpyCompatibleArray, Optional[NumpyCompatibleArray]]:
+                     x: ArrayLike, y: ArrayLike, z: Optional[ArrayLike] = None) -> \
+                     Tuple[ArrayLike, ArrayLike, Optional[ArrayLike]]:
     if ct is not None:
         if z is None:
             for idx, (x0, y0) in enumerate(zip(x, y)):

--- a/gdal/swig/python/gdal-utils/osgeo_utils/samples/gdallocationinfo.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/samples/gdallocationinfo.py
@@ -40,8 +40,8 @@ import numpy as np
 from osgeo import gdalconst, osr, gdal
 
 from osgeo_utils.auxiliary.base import is_path_like
-from osgeo_utils.auxiliary.numpy_util import GDALTypeCodeAndNumericTypeCodeFromDataSet, NumpyCompatibleArrayOrReal, \
-    NumpyCompatibleArray
+from osgeo_utils.auxiliary.arrays import ArrayLike, ArrayOrScalarLike
+from osgeo_utils.auxiliary.numpy_util import GDALTypeCodeAndNumericTypeCodeFromDataSet
 from osgeo_utils.auxiliary.osr_util import transform_points, AnySRS, get_transform, get_srs
 from osgeo_utils.auxiliary.util import PathOrDS, open_ds, get_bands, get_scales_and_offsets, get_band_nums
 from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser, GDALScript
@@ -67,7 +67,7 @@ CoordinateTransformationOrSRS = Optional[
 
 
 def gdallocationinfo(filename_or_ds: PathOrDS,
-                     x: NumpyCompatibleArrayOrReal, y: NumpyCompatibleArrayOrReal,
+                     x: ArrayOrScalarLike, y: ArrayOrScalarLike,
                      gis_order: bool = False,
                      open_options: Optional[dict] = None,
                      ovr_idx: Optional[int] = None,
@@ -82,9 +82,9 @@ def gdallocationinfo(filename_or_ds: PathOrDS,
     filename = filename_or_ds if is_path_like(filename_or_ds) else ''
     if ds is None:
         raise Exception(f'Could not open {filename}.')
-    if not isinstance(x, NumpyCompatibleArray.__args__):
+    if not isinstance(x, ArrayLike.__args__):
         x = [x]
-    if not isinstance(y, NumpyCompatibleArray.__args__):
+    if not isinstance(y, ArrayLike.__args__):
         y = [y]
     if len(x) != len(y):
         raise Exception(f'len(x)={len(x)} should be the same as len(y)={len(y)}')
@@ -161,7 +161,7 @@ def gdallocationinfo(filename_or_ds: PathOrDS,
 
 
 def gdallocationinfo_util(filename_or_ds: PathOrDS,
-                     x: NumpyCompatibleArrayOrReal, y: NumpyCompatibleArrayOrReal,
+                     x: ArrayOrScalarLike, y: ArrayOrScalarLike,
                      open_options: Optional[dict] = None,
                      band_nums: Optional[Sequence[int]] = None,
                      resample_alg=gdalconst.GRIORA_NearestNeighbour,


### PR DESCRIPTION
## What does this PR do?

`osr_util.py` depends on numpy. this PR remove this dependency.

`osgeo_utils/auxiliary/arrays.py` - add `ArrayLike`, `ScalarLike`, `ArrayOrScalarLike` types (to be used instead of `NumpyCompatibleArray`, `NumpyCompatibleArrayOrReal`)

osr_util.py, gdallocationinfo.py, numpy_util.py - use new types
autotest/pyscripts/test_gdal_utils.py - test new types

## Related PR

https://github.com/python/typing/issues/593
