### PR TITLE
Fix RAT SetDefaultRAT for GTiff driver

### DIFF
--- a/autotest/gcore/rat.py
+++ b/autotest/gcore/rat.py
@@ -137,7 +137,7 @@ def test_rat_3():
     gdal.GetDriverByName('GTiff').Delete('/vsimem/rat_3.tif')
 
 ###############################################################################
-# Edit an existing RAT (#5451)
+# Edit an existing RAT (#3783)
 
 
 def test_rat_4():
@@ -174,5 +174,4 @@ def test_rat_4():
 gdal.GetDriverByName('GTiff').Delete('/tmp/rat_4.tif')
 
 ##############################################################################
-
 

--- a/autotest/gcore/rat.py
+++ b/autotest/gcore/rat.py
@@ -171,8 +171,8 @@ def test_rat_4():
     assert rat.GetValueAsInt(0, 0) == 222
     ds = None
 
+gdal.GetDriverByName('GTiff').Delete('/tmp/rat_4.tif')
 
 ##############################################################################
-
 
 

--- a/autotest/gcore/rat.py
+++ b/autotest/gcore/rat.py
@@ -135,6 +135,43 @@ def test_rat_3():
     ds = None
 
     gdal.GetDriverByName('GTiff').Delete('/vsimem/rat_3.tif')
+
+###############################################################################
+# Edit an existing RAT (#5451)
+
+
+def test_rat_4():
+
+    ds = gdal.GetDriverByName('GTiff').Create('/tmp/rat_4.tif', 1, 1)
+    rat = gdal.RasterAttributeTable()
+    rat.CreateColumn('VALUE', gdal.GFT_Integer, gdal.GFU_MinMax)
+    rat.CreateColumn('CLASS', gdal.GFT_String, gdal.GFU_Name)
+    rat.SetValueAsInt(0, 0, 111)
+    rat.SetValueAsString(0, 1, 'Class1')
+    ds.GetRasterBand(1).SetDefaultRAT(rat)
+    ds = None
+
+    # Replace existing RAT
+    rat = gdal.RasterAttributeTable()
+    rat.CreateColumn('VALUE', gdal.GFT_Integer, gdal.GFU_MinMax)
+    rat.CreateColumn('CLASS', gdal.GFT_String, gdal.GFU_Name)
+    rat.SetValueAsInt(0, 0, 222)
+    rat.SetValueAsString(0, 1, 'Class1')
+
+    ds = gdal.OpenEx('/tmp/rat_4.tif', gdal.OF_RASTER | gdal.OF_UPDATE)
+    gdal_band = ds.GetRasterBand(1)
+    gdal_band.SetDefaultRAT(rat)
+    ds.FlushCache()
+    ds = None
+
+    ds = gdal.OpenEx('/tmp/rat_4.tif')
+    gdal_band = ds.GetRasterBand(1)
+    rat = gdal_band.GetDefaultRAT()
+    assert rat is not None
+    assert rat.GetValueAsInt(0, 0) == 222
+    ds = None
+
+
 ##############################################################################
 
 

--- a/autotest/gcore/rat.py
+++ b/autotest/gcore/rat.py
@@ -31,7 +31,6 @@
 ###############################################################################
 
 
-
 import gdaltest
 from osgeo import gdal
 import pytest
@@ -171,7 +170,7 @@ def test_rat_4():
     assert rat.GetValueAsInt(0, 0) == 222
     ds = None
 
+
 gdal.GetDriverByName('GTiff').Delete('/tmp/rat_4.tif')
 
 ##############################################################################
-

--- a/autotest/gcore/rat.py
+++ b/autotest/gcore/rat.py
@@ -141,7 +141,8 @@ def test_rat_3():
 
 def test_rat_4():
 
-    ds = gdal.GetDriverByName('GTiff').Create('/tmp/rat_4.tif', 1, 1)
+    # Create test RAT
+    ds = gdal.GetDriverByName('GTiff').Create('/vsimem/rat_4.tif', 1, 1)
     rat = gdal.RasterAttributeTable()
     rat.CreateColumn('VALUE', gdal.GFT_Integer, gdal.GFU_MinMax)
     rat.CreateColumn('CLASS', gdal.GFT_String, gdal.GFU_Name)
@@ -150,27 +151,32 @@ def test_rat_4():
     ds.GetRasterBand(1).SetDefaultRAT(rat)
     ds = None
 
+    # Verify
+    ds = gdal.OpenEx('/vsimem/rat_4.tif')
+    gdal_band = ds.GetRasterBand(1)
+    rat = gdal_band.GetDefaultRAT()
+    assert rat.GetValueAsInt(0, 0) == 111
+    ds = None
+
     # Replace existing RAT
     rat = gdal.RasterAttributeTable()
     rat.CreateColumn('VALUE', gdal.GFT_Integer, gdal.GFU_MinMax)
     rat.CreateColumn('CLASS', gdal.GFT_String, gdal.GFU_Name)
     rat.SetValueAsInt(0, 0, 222)
     rat.SetValueAsString(0, 1, 'Class1')
-
-    ds = gdal.OpenEx('/tmp/rat_4.tif', gdal.OF_RASTER | gdal.OF_UPDATE)
+    ds = gdal.OpenEx('/vsimem/rat_4.tif', gdal.OF_RASTER | gdal.OF_UPDATE)
     gdal_band = ds.GetRasterBand(1)
     gdal_band.SetDefaultRAT(rat)
-    ds.FlushCache()
     ds = None
 
-    ds = gdal.OpenEx('/tmp/rat_4.tif')
+    # Verify
+    ds = gdal.OpenEx('/vsimem/rat_4.tif')
     gdal_band = ds.GetRasterBand(1)
     rat = gdal_band.GetDefaultRAT()
     assert rat is not None
     assert rat.GetValueAsInt(0, 0) == 222
     ds = None
 
-
-gdal.GetDriverByName('GTiff').Delete('/tmp/rat_4.tif')
+    gdal.GetDriverByName('GTiff').Delete('/vsimem/rat_4.tif')
 
 ##############################################################################

--- a/gdal/frmts/gtiff/geotiff.cpp
+++ b/gdal/frmts/gtiff/geotiff.cpp
@@ -1271,6 +1271,7 @@ public:
                                                char **papszOptions )  override final;
 
     GDALRasterAttributeTable* GetDefaultRAT() override final;
+    virtual CPLErr SetDefaultRAT(const GDALRasterAttributeTable *) override final;
     virtual CPLErr  GetHistogram(
         double dfMin, double dfMax,
         int nBuckets, GUIntBig * panHistogram,
@@ -1842,6 +1843,12 @@ GDALRasterAttributeTable *GTiffRasterBand::GetDefaultRAT()
 {
     m_poGDS->LoadGeoreferencingAndPamIfNeeded();
     return GDALPamRasterBand::GetDefaultRAT();
+}
+
+CPLErr GTiffRasterBand::SetDefaultRAT(const GDALRasterAttributeTable *poRAT )
+{
+    m_poGDS->LoadGeoreferencingAndPamIfNeeded();
+    return GDALPamRasterBand::SetDefaultRAT( poRAT );
 }
 
 /************************************************************************/


### PR DESCRIPTION
Fixes #3783 by making sure that the PAM is
read before setting the RAT.

Without that, when serializing the PAM,
`GTiffDataset::LoadGeoreferencingAndPamIfNeeded()`
is called, but if it wasn't called before it will
reload the RAT from the old `xml` that at this
point contains the old RAT effectively overwriting
any change made by `SetDefaultRat()` call.
