### PR TITLE
OGR: Support multiline WKT input

### DIFF
--- a/autotest/ogr/ogr_wkbwkt_geom.py
+++ b/autotest/ogr/ogr_wkbwkt_geom.py
@@ -360,7 +360,7 @@ def test_ogr_wkbwkt_test_broken_geom():
         gdal.PopErrorHandler()
         assert geom is None, ('geom %s instantiated but not expected' % wkt)
 
-    
+
 ###############################################################################
 # Test importing WKT SF1.2
 
@@ -484,7 +484,7 @@ def test_ogr_wkbwkt_test_import_wkt_sf12():
             ('in=%s, out=%s, expected=%s.' % (wkt_tuple[0], out_wkt,
                                                  wkt_tuple[1]))
 
-    
+
 ###############################################################################
 # Test that importing the wkb that would be equivalent to MULTIPOINT(POLYGON((0 0))
 # doesn't work
@@ -525,7 +525,7 @@ def test_ogr_wkbwkt_test_geometrycollection_wktwkb():
         wkt2 = g.ExportToWkt()
         assert wkt == wkt2, ('fail for %s' % wkt)
 
-    
+
 ###############################################################################
 # Test that importing too nested WKT doesn't cause stack overflows
 
@@ -607,6 +607,17 @@ def test_ogr_wkt_multipolygon_corrupted():
     with gdaltest.error_handler():
         g = ogr.CreateGeometryFromWkt('MULTIPOLYGON(POLYGON((N')
     assert g is None
+
+###############################################################################
+# Test multiline WKT
+
+
+def test_ogr_wkt_multiline():
+    g = ogr.CreateGeometryFromWkt("""GEOMETRYCOLLECTION(
+    POINT (1 2),
+    LINESTRING (3 3, 4 4))
+    """)
+    assert g is not None
 
 ###############################################################################
 # When imported build a list of units based on the files available.

--- a/gdal/ogr/ogrutils.cpp
+++ b/gdal/ogr/ogrutils.cpp
@@ -409,7 +409,7 @@ const char *OGRWktReadToken( const char * pszInput, char * pszToken )
 /* -------------------------------------------------------------------- */
 /*      Swallow pre-white space.                                        */
 /* -------------------------------------------------------------------- */
-    while( *pszInput == ' ' || *pszInput == '\t' )
+    while( *pszInput == ' ' || *pszInput == '\t' || *pszInput == '\n' || *pszInput == '\r' )
         ++pszInput;
 
 /* -------------------------------------------------------------------- */
@@ -448,7 +448,7 @@ const char *OGRWktReadToken( const char * pszInput, char * pszToken )
 /* -------------------------------------------------------------------- */
 /*      Eat any trailing white space.                                   */
 /* -------------------------------------------------------------------- */
-    while( *pszInput == ' ' || *pszInput == '\t' )
+    while( *pszInput == ' ' || *pszInput == '\t' || *pszInput == '\n' || *pszInput == '\r' )
         ++pszInput;
 
     return pszInput;


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Allow input WKT strings to span multiple lines.

## What are related issues/pull requests?

https://github.com/r-spatial/sf/issues/1674

## Tasklist

 - [X] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed