### PR TITLE
/vsiaz/: avoid appending same chunk several times

### DIFF
--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -178,7 +178,7 @@ def test_vsiaz_fake_basic():
                 print(stat_res)
             pytest.fail()
 
-    
+
 ###############################################################################
 # Test ReadDir() with a fake Azure Blob server
 
@@ -486,7 +486,8 @@ def test_vsiaz_fake_write():
         h = request.headers
         if 'Content-Length' not in h or h['Content-Length'] != '10' or \
            'x-ms-date' not in h or h['x-ms-date'] != 'my_timestamp' or \
-           'x-ms-blob-type' not in h or h['x-ms-blob-type'] != 'AppendBlob':
+           'x-ms-blob-type' not in h or h['x-ms-blob-type'] != 'AppendBlob' or \
+           'x-ms-blob-condition-appendpos' not in h or h['x-ms-blob-condition-appendpos'] != '0':
             sys.stderr.write('Bad headers: %s\n' % str(h))
             request.send_response(403)
             return
@@ -509,7 +510,8 @@ def test_vsiaz_fake_write():
         h = request.headers
         if 'Content-Length' not in h or h['Content-Length'] != '6' or \
            'x-ms-date' not in h or h['x-ms-date'] != 'my_timestamp' or \
-           'x-ms-blob-type' not in h or h['x-ms-blob-type'] != 'AppendBlob':
+           'x-ms-blob-type' not in h or h['x-ms-blob-type'] != 'AppendBlob' or \
+           'x-ms-blob-condition-appendpos' not in h or h['x-ms-blob-condition-appendpos'] != '10':
             sys.stderr.write('Bad headers: %s\n' % str(h))
             request.send_response(403)
             return

--- a/gdal/port/cpl_vsil_az.cpp
+++ b/gdal/port/cpl_vsil_az.cpp
@@ -1116,6 +1116,10 @@ bool VSIAzureWriteHandle::SendInternal(bool bInitOnly, bool bIsLastBlock)
             osContentLength.Printf("Content-Length: %d", m_nBufferOff);
             headers = curl_slist_append(headers, osContentLength.c_str());
             headers = curl_slist_append(headers, "x-ms-blob-type: AppendBlob");
+            CPLString osAppendPos;
+            vsi_l_offset nStartOffset = m_nCurOffset - m_nBufferOff;
+            osAppendPos.Printf("x-ms-blob-condition-appendpos: " CPL_FRMT_GUIB, nStartOffset);
+            headers = curl_slist_append(headers, osAppendPos.c_str());
         }
 
         headers = VSICurlMergeHeaders(headers,


### PR DESCRIPTION
Should avoid an issue occuring sometimes with appending blocks to Azure
AppendBlob. It appears that the uploaded size is different, and we may be
appending blocks multiple times due to timeouts/failures. Not sure if the
operation succeeds on the server-side, but the client does not get a
response and retries, but we see server timeouts in these cases.

Based on patch by Robin Princeley