### PR TITLE
Improve Postgis raster support for libpq services (fixes #3820)

### DIFF
--- a/gdal/frmts/postgisraster/postgisraster.h
+++ b/gdal/frmts/postgisraster/postgisraster.h
@@ -182,8 +182,7 @@ private:
 public:
     PostGISRasterDriver();
     virtual ~PostGISRasterDriver();
-    PGconn* GetConnection(const char* pszConnectionString,
-        const char * pszDbnameIn, const char * pszHostIn, const char * pszPortIn, const char * pszUserIn);
+    PGconn* GetConnection(const char* pszConnectionString);
 };
 
 /***********************************************************************

--- a/gdal/frmts/postgisraster/postgisraster.h
+++ b/gdal/frmts/postgisraster/postgisraster.h
@@ -182,7 +182,10 @@ private:
 public:
     PostGISRasterDriver();
     virtual ~PostGISRasterDriver();
-    PGconn* GetConnection(const char* pszConnectionString);
+  PGconn *GetConnection(const char *pszConnectionString,
+                        const char *pszServiceIn, const char *pszDbnameIn,
+                        const char *pszHostIn, const char *pszPortIn,
+                        const char *pszUserIn);
 };
 
 /***********************************************************************

--- a/gdal/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/gdal/frmts/postgisraster/postgisrasterdataset.cpp
@@ -2800,8 +2800,8 @@ GetConnectionInfo(const char *pszFilename, char **ppszConnectionString,
         CSLDestroy(papszParams);
 
         return false;
-    } 
-    
+    }
+
     *ppszDbname = (nPos != -1) ? CPLStrdup(CPLParseNameValue(papszParams[nPos], nullptr)) : nullptr;
     *ppszService = (sPos != -1) ? CPLStrdup(CPLParseNameValue(papszParams[sPos], nullptr)) : nullptr;
 
@@ -2999,7 +2999,7 @@ GetConnectionInfo(const char *pszFilename, char **ppszConnectionString,
         "Mode: %d\nDbname: %s\nSchema: %s\nTable: %s\nColumn: %s\nWhere: %s\n"
         "Host: %s\nPort: %s\nUser: %s\nPassword: %s\n"
         "Connection String: %s\n",
-        *nMode, 
+        *nMode,
         *ppszService ? *ppszService : "(null)",
         *ppszDbname ? *ppszDbname : "(null)",
         *ppszSchema ? *ppszSchema : "(null)",
@@ -3052,6 +3052,7 @@ GetConnection(const char * pszFilename, char ** ppszConnectionString,
         }
     }
 
+    CPLFree(pszService);
     CPLFree(pszDbname);
     CPLFree(pszHost);
     CPLFree(pszPort);

--- a/gdal/frmts/postgisraster/postgisrasterdriver.cpp
+++ b/gdal/frmts/postgisraster/postgisrasterdriver.cpp
@@ -68,21 +68,11 @@ PostGISRasterDriver::~PostGISRasterDriver() {
  * All connection will be destroyed when the PostGISRasterDriver is destroyed.
  *
  ***************************************************************************/
-PGconn* PostGISRasterDriver::GetConnection(const char* pszConnectionString,
-        const char * pszDbnameIn, const char * pszHostIn, const char * pszPortIn, const char * pszUserIn)
+PGconn* PostGISRasterDriver::GetConnection(const char* pszConnectionString)
 {
     PGconn * poConn = nullptr;
 
-    if( pszHostIn == nullptr ) pszHostIn = "(null)";
-    if( pszPortIn == nullptr ) pszPortIn = "(null)";
-    if( pszUserIn == nullptr ) pszUserIn = "(null)";
-    CPLString osKey = pszDbnameIn;
-    osKey += "-";
-    osKey += pszHostIn;
-    osKey += "-";
-    osKey += pszPortIn;
-    osKey += "-";
-    osKey += pszUserIn;
+    CPLString osKey = pszConnectionString;
     osKey += "-";
     osKey += CPLSPrintf(CPL_FRMT_GIB, CPLGetPID());
 

--- a/gdal/frmts/postgisraster/postgisrasterdriver.cpp
+++ b/gdal/frmts/postgisraster/postgisrasterdriver.cpp
@@ -68,11 +68,25 @@ PostGISRasterDriver::~PostGISRasterDriver() {
  * All connection will be destroyed when the PostGISRasterDriver is destroyed.
  *
  ***************************************************************************/
-PGconn* PostGISRasterDriver::GetConnection(const char* pszConnectionString)
+PGconn *PostGISRasterDriver::GetConnection(const char *pszConnectionString,
+                                           const char *pszServiceIn,
+                                           const char *pszDbnameIn,
+                                           const char *pszHostIn,
+                                           const char *pszPortIn,
+                                           const char *pszUserIn)
 {
     PGconn * poConn = nullptr;
 
-    CPLString osKey = pszConnectionString;
+    if( pszHostIn == nullptr ) pszHostIn = "(null)";
+    if( pszPortIn == nullptr ) pszPortIn = "(null)";
+    if( pszUserIn == nullptr ) pszUserIn = "(null)";
+    CPLString osKey = ( pszServiceIn == nullptr ) ? pszDbnameIn : pszServiceIn;
+    osKey += "-";
+    osKey += pszHostIn;
+    osKey += "-";
+    osKey += pszPortIn;
+    osKey += "-";
+    osKey += pszUserIn;
     osKey += "-";
     osKey += CPLSPrintf(CPL_FRMT_GIB, CPLGetPID());
 


### PR DESCRIPTION
## What does this PR do?

This PR allow users to use just the service name in Postgis raster driver connection strings.

All the support was already there. The condition to check if there is a dbname was changed, to check if we have a database or a service name. We only report failure if both are not present.

## Examples

```bash
$ gdalinfo "PG:service=ortos schema=ortos table=ortos_2018_2k_desertas column=rast mode=2"
Driver: PostGISRaster/PostGIS Raster driver
Files: none associated
Size is 96000, 220000
Coordinate System is:
BOUNDCRS[
    SOURCECRS[
        PROJCRS["PTRA08 / UTM zone 28N",
(...)
Data axis to CRS axis mapping: 1,2
Origin = (354000.000000000000000,3607300.000000000000000)
Pixel Size = (0.100000000000000,-0.100000000000000)
Corner Coordinates:
Upper Left  (  354000.000, 3607300.000) ( 16d33'20.63"W, 32d35'36.87"N)
Lower Left  (  354000.000, 3585300.000) ( 16d33' 8.34"W, 32d23'42.66"N)
Upper Right (  363600.000, 3607300.000) ( 16d27'12.47"W, 32d35'41.28"N)
Lower Right (  363600.000, 3585300.000) ( 16d27' 1.00"W, 32d23'47.04"N)
Center      (  358800.000, 3596300.000) ( 16d30'10.60"W, 32d29'42.00"N)
Band 1 Block=2048x2048 Type=Byte, ColorInterp=Undefined
  Overviews: 12000x27500, 6000x13750, 3000x6875, 1500x3438, 750x1719, 375x859, 188x430
Band 2 Block=2048x2048 Type=Byte, ColorInterp=Undefined
  Overviews: 12000x27500, 6000x13750, 3000x6875, 1500x3438, 750x1719, 375x859, 188x430
Band 3 Block=2048x2048 Type=Byte, ColorInterp=Undefined
  Overviews: 12000x27500, 6000x13750, 3000x6875, 1500x3438, 750x1719, 375x859, 188x430
Band 4 Block=2048x2048 Type=Byte, ColorInterp=Undefined
  Overviews: 12000x27500, 6000x13750, 3000x6875, 1500x3438, 750x1719, 375x859, 188x430
```

```bash
$ gdalinfo "PG:schema=ortos table=ortos_2018_2k_desertas column=rast mode=2"
ERROR 1: You must specify at least a db name or a service name
gdalinfo failed - unable to open 'PG:schema=ortos table=ortos_2018_2k_desertas column=rast mode=2'.
```
## Environment

* OS: Ubuntu 20.04
