### PR TITLE
Csharp : Add GetFieldAsBinary methods  - fixes #3041

### DIFF
--- a/gdal/swig/csharp/apps/createdata.cs
+++ b/gdal/swig/csharp/apps/createdata.cs
@@ -249,7 +249,8 @@ class CreateData {
 			if (feat.IsFieldSet(iField))
 			{
 				Console.WriteLine(feat.GetFieldAsString(iField));
-				if (ft == FieldType.OFTString && feat.GetFieldAsBinary( iField ).Length <= 0)
+				if (ft == FieldType.OFTString 
+						&& Encoding.ASCII.GetString(feat.GetFieldAsBinary( iField )) != feat.GetFieldAsString(iField))
 				{
 					Environment.Exit(-1);
 				}

--- a/gdal/swig/csharp/apps/createdata.cs
+++ b/gdal/swig/csharp/apps/createdata.cs
@@ -247,7 +247,7 @@ class CreateData {
 
 			if( feat.IsFieldSet( iField ) )
 				Console.WriteLine( feat.GetFieldAsString( iField ) );
-				if ( Encoding.ASCII.GetString(feat.GetFieldAsBinary( iField )) != feat.GetFieldAsString( iField ) ) {
+				if ( feat.GetFieldAsBinary( iField ).Length <= 0 ) {
 					Environment.Exit(-1);
 				}
 			else

--- a/gdal/swig/csharp/apps/createdata.cs
+++ b/gdal/swig/csharp/apps/createdata.cs
@@ -248,7 +248,7 @@ class CreateData {
 			if( feat.IsFieldSet( iField ) )
 				Console.WriteLine( feat.GetFieldAsString( iField ) );
 				if ( Encoding.ASCII.GetString(feat.GetFieldAsBinary( iField )) != feat.GetFieldAsString( iField ) ) {
-					En.Exit(-1);
+					Environment.Exit(-1);
 				}
 			else
 				Console.WriteLine( "(null)" );

--- a/gdal/swig/csharp/apps/createdata.cs
+++ b/gdal/swig/csharp/apps/createdata.cs
@@ -34,7 +34,7 @@ using System;
 
 using OSGeo.OGR;
 using OSGeo.OSR;
-
+using System.Text;
 
 /**
 
@@ -247,6 +247,9 @@ class CreateData {
 
 			if( feat.IsFieldSet( iField ) )
 				Console.WriteLine( feat.GetFieldAsString( iField ) );
+				if ( Encoding.ASCII.GetString(feat.GetFieldAsBinary( iField )) != feat.GetFieldAsString( iField ) ) {
+					En.Exit(-1);
+				}
 			else
 				Console.WriteLine( "(null)" );
 

--- a/gdal/swig/csharp/apps/createdata.cs
+++ b/gdal/swig/csharp/apps/createdata.cs
@@ -242,16 +242,20 @@ class CreateData {
 		{
 			FieldDefn fdef = def.GetFieldDefn( iField );
 
-			Console.Write( fdef.GetNameRef() + " (" +
+			Console.Write(fdef.GetNameRef() + " (" +
 				fdef.GetFieldTypeName(fdef.GetFieldType()) + ") = ");
+				FieldType ft = fdef.GetFieldType();
 
-			if( feat.IsFieldSet( iField ) )
-				Console.WriteLine( feat.GetFieldAsString( iField ) );
-				if ( feat.GetFieldAsBinary( iField ).Length <= 0 ) {
+			if (feat.IsFieldSet(iField))
+			{
+				Console.WriteLine(feat.GetFieldAsString(iField));
+				if (ft == FieldType.OFTString && feat.GetFieldAsBinary( iField ).Length <= 0)
+				{
 					Environment.Exit(-1);
 				}
+			}
 			else
-				Console.WriteLine( "(null)" );
+				Console.WriteLine("(null)");
 
 		}
 

--- a/gdal/swig/include/csharp/ogr_csharp.i
+++ b/gdal/swig/include/csharp/ogr_csharp.i
@@ -92,3 +92,23 @@ DEFINE_EXTERNAL_CLASS(GDALMajorObjectShadow, OSGeo.GDAL.MajorObject)
     if (OgrPINVOKE.SWIGPendingException.Pending) throw OgrPINVOKE.SWIGPendingException.Retrieve();
   }
 }
+
+%typemap(cscode, noblock="1") OGRFeatureShadow {
+  public byte[] GetFieldAsBinary(int id) {
+    IntPtr[] nPtr = new IntPtr[1];
+    GCHandle pinnedArray = GCHandle.Alloc(nPtr, GCHandleType.Pinned);
+    IntPtr pointer = pinnedArray.AddrOfPinnedObject();
+
+    int length;
+
+    GetFieldAsBinary(id, out length, pointer);
+
+    byte[] buffer = new byte[length];
+
+    if (nPtr[0] != IntPtr.Zero) Marshal.Copy(nPtr[0], buffer, 0, length);
+
+    pinnedArray.Free();
+
+    return buffer;
+  }
+}

--- a/gdal/swig/include/ogr.i
+++ b/gdal/swig/include/ogr.i
@@ -1626,7 +1626,6 @@ public:
 #endif
 #endif
 
-#ifndef SWIGCSHARP
 #ifdef SWIGJAVA
 %apply (GByte* outBytes) {GByte*};
   GByte* GetFieldAsBinary(int id, int *nLen, char **pBuf) {
@@ -1652,6 +1651,15 @@ public:
       }
   }
 %clear GByte*;
+#elif defined(SWIGCSHARP)
+%apply (void *buffer_ptr) {char **};
+  OGRErr GetFieldAsBinary( int id, int *nLen, char **pBuf) {
+    GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
+    *pBuf = (char*)malloc(*nLen);
+    memcpy(*pBuf, pabyBlob, *nLen);
+    return OGRERR_NONE;
+  }
+%clear (char **);
 #else
   OGRErr GetFieldAsBinary( int id, int *nLen, char **pBuf) {
     GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
@@ -1679,7 +1687,6 @@ public:
 #endif
 #endif /* SWIGJAVA */
 
-#endif /* SWIGCSHARP */
 
   /* ---- IsFieldSet --------------------------- */
   bool IsFieldSet(int id) {


### PR DESCRIPTION
## What does this PR do?

fixes #3041

- Opens up to C# the SWIG method `OGRErr GetFieldAsBinary( int id, int *nLen, char **pBuf)` on `Feature`
- Adds the overload `public byte[] GetFieldAsBinary(int id)`
- Add tests to `createdata.cs` to test the new method.

NOTE - this is the first time I have created a PR based on SWIG - so probably @szekerest or @bjornharrtell should take a close look. However, @srweal has been using the prototype of this change in a real environment with success.

## What are related issues/pull requests?

This is related to #3041 

## Tasklist

 - [x] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
