### PR TITLE
autotest: fixes strange issues when importing files of autotest 

### DIFF
--- a/.github/workflows/fedora_rawhide.yml
+++ b/.github/workflows/fedora_rawhide.yml
@@ -28,4 +28,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-fedora-rawhide-
 
       - name: Build
-        run: docker run --privileged=true -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD -v /var/run/docker.sock:/var/run/docker.sock fedora:34 $PWD/.github/workflows/fedora_rawhide/start.sh
+        run: docker run --privileged=true -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD -v /var/run/docker.sock:/var/run/docker.sock fedora:rawhide $PWD/.github/workflows/fedora_rawhide/start.sh

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -44,10 +44,11 @@ def chdir_to_test_file(request):
     """
     old = os.getcwd()
 
-    os.chdir(os.path.dirname(request.module.__file__))
-    sys.path.insert(0, ".")
+    new_cwd = os.path.dirname(request.module.__file__)
+    os.chdir(new_cwd)
+    sys.path.insert(0, new_cwd)
     yield
-    if sys.path and sys.path[0] == ".":
+    if sys.path and sys.path[0] == new_cwd:
         sys.path.pop(0)
     os.chdir(old)
 


### PR DESCRIPTION
Should fix the recent MacOSX failures
(https://github.com/OSGeo/gdal/runs/2554610301)
and the ones on Fedora Rawhide (fixes #3814)