### PR TITLE
`gdallocationinfo` fixes + more tests

### DIFF
--- a/autotest/pyscripts/test_gdallocationinfo_py.py
+++ b/autotest/pyscripts/test_gdallocationinfo_py.py
@@ -29,15 +29,26 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
-
-
-from osgeo import gdal
-import test_py_scripts
 import pytest
 
 # test that numpy is available, if not skip all tests
 np = pytest.importorskip('numpy')
-gdallocationinfo = pytest.importorskip('osgeo_utils.samples.gdallocationinfo')
+pytest.importorskip('osgeo_utils.samples.gdallocationinfo')
+
+import os
+from itertools import product
+from numpy.testing import assert_allclose
+
+from osgeo import gdal, osr
+import test_py_scripts
+
+from osgeo_utils.auxiliary.osr_util import get_transform, transform_points, get_srs
+from osgeo_utils.auxiliary.util import open_ds
+from osgeo_utils.auxiliary.raster_creation import copy_raster_and_add_overviews
+from osgeo_utils.samples.gdallocationinfo import LocationInfoSRS
+from osgeo_utils.samples import gdallocationinfo
+
+temp_files = []
 
 
 def test_gdallocationinfo_py_1():
@@ -104,3 +115,75 @@ def test_gdallocationinfo_py_wgs84():
 
     expected_ret = """115"""
     assert expected_ret in ret
+
+
+def test_gdallocationinfo_py_7():
+    filename_template = 'tmp/byte{}.tif'
+    overview_list = [2]
+    overview_list, file_list = copy_raster_and_add_overviews(
+        filename_src='../gcore/data/byte.tif', output_filename_template=filename_template,
+        overview_list=overview_list)
+    temp_files.extend(file_list)
+
+    ds = open_ds(filename_template.format(''))
+    ds_srs = ds.GetSpatialRef()
+    gt = ds.GetGeoTransform()
+    ovr_fact = 1
+    pix_offset = 0
+    p0 = list(i*ovr_fact+pix_offset for i in range(0, 3))
+    l0 = list(i*ovr_fact+pix_offset for i in range(0, 3))
+    p0, l0 = zip(*product(p0, l0))
+    x0 = list(gt[0] + pixel * gt[1] for pixel in p0)
+    y0 = list(gt[3] + line * gt[5] for line in l0)
+
+    dtype = np.float64
+    p0 = np.array(p0, dtype=dtype)
+    l0 = np.array(l0, dtype=dtype)
+    x0 = np.array(x0, dtype=dtype)
+    y0 = np.array(y0, dtype=dtype)
+
+    expected_results = [
+        [(0.0, 0.0, 107), (0.0, 1.0, 115), (0.0, 2.0, 115), (1.0, 0.0, 123), (1.0, 1.0, 132), (1.0, 2.0, 132),
+         (2.0, 0.0, 132), (2.0, 1.0, 107), (2.0, 2.0, 140)],
+        [(0.0, 0.0, 120), (0.0, 0.5, 120), (0.0, 1.0, 132), (0.5, 0.0, 120), (0.5, 0.5, 120),
+         (0.5, 1.0, 132), (1.0, 0.0, 124), (1.0, 0.5, 124), (1.0, 1.0, 129)]
+    ]
+    expected_results = np.array(expected_results, dtype=dtype)
+
+    do_print = False
+    for ovr_idx, f in enumerate(overview_list):
+        for srs in [LocationInfoSRS.PixelLine, LocationInfoSRS.SameAsDS_SRS, 4326]:
+            if srs == LocationInfoSRS.PixelLine:
+                x = p0
+                y = l0
+            elif srs == LocationInfoSRS.SameAsDS_SRS:
+                x = x0
+                y = y0
+            else:
+                points_srs = get_srs(srs, axis_order=osr.OAMS_TRADITIONAL_GIS_ORDER)
+                ct = get_transform(ds_srs, points_srs)
+                x = x0.copy()
+                y = y0.copy()
+                transform_points(ct, x, y)
+            pixels, lines, results = gdallocationinfo.gdallocationinfo(
+                filename_or_ds=ds, ovr_idx=ovr_idx, x=x, y=y,
+                transform_round_digits=2, return_ovr_pixel_line=True,
+                srs=srs, axis_order=osr.OAMS_TRADITIONAL_GIS_ORDER)
+
+            actual = list(zip(pixels, lines, *results))
+            actual = np.array(actual, dtype=dtype)
+            expected = expected_results[ovr_idx]
+            if do_print:
+                print(actual)
+                print(expected)
+                outputs = list(zip(x, y, pixels, lines, *results))
+                print(f'ovr: {ovr_idx}, srs: {srs}, x/y/pixel/line/result: {outputs}')
+            assert_allclose(expected, actual, rtol=1e-4, atol=1e-3)
+
+
+def test_gdallocationinfo_py_cleanup():
+    for filename in temp_files:
+        try:
+            os.remove(filename)
+        except OSError:
+            pass

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/osr_util.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/osr_util.py
@@ -125,8 +125,7 @@ def get_transform(src_srs: AnySRS, tgt_srs: AnySRS) -> Optional[osr.CoordinateTr
 
 
 def transform_points(ct: Optional[osr.CoordinateTransformation],
-                     x: ArrayLike, y: ArrayLike, z: Optional[ArrayLike] = None) -> \
-                     Tuple[ArrayLike, ArrayLike, Optional[ArrayLike]]:
+                     x: ArrayLike, y: ArrayLike, z: Optional[ArrayLike] = None) -> None:
     if ct is not None:
         if z is None:
             for idx, (x0, y0) in enumerate(zip(x, y)):
@@ -134,4 +133,3 @@ def transform_points(ct: Optional[osr.CoordinateTransformation],
         else:
             for idx, (x0, y0, z0) in enumerate(zip(x, y, z)):
                 x[idx], y[idx], z[idx] = ct.TransformPoint(x0, y0, z0)
-    return x, y, z


### PR DESCRIPTION
## What does this PR do?

* gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py - add `ovr_only: bool = False` parameter to `_open_ds`
* gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/osr_util.py - change `transform_points()` to return None as it makes an inline replacement
* gdal/swig/python/gdal-utils/osgeo_utils/samples/gdallocationinfo.py - fix inline_xy_replacement; fix unscaling; fix formatting; use faster `BandRasterIONumPy` instead of `band.ReadAsArray`; add optional parameters `return_ovr_pixel_line`, `transform_round_digits`
* autotest/pyscripts/test_gdallocationinfo_py.py - add another test
