### PR TITLE
ECW: Register VSIL functions as IO callbacks for ECW=3.3

### DIFF
--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -1716,9 +1716,6 @@ def test_ecw_46():
 
 def test_ecw_47():
 
-    if gdaltest.ecw_drv.major_version == 3:
-        pytest.skip()
-
     data = open('data/ecw/jrc.ecw', 'rb').read()
     gdal.FileFromMemBuffer('/vsimem/ecw_47.ecw', data)
 
@@ -1729,8 +1726,10 @@ def test_ecw_47():
 
     if gdaltest.ecw_drv.major_version == 5:
         (exp_mean, exp_stddev) = (141.606, 67.2919)
-    else:
+    elif gdaltest.ecw_drv.major_version == 4:
         (exp_mean, exp_stddev) = (140.332, 67.611)
+    elif gdaltest.ecw_drv.major_version == 3:
+        (exp_mean, exp_stddev) = (141.172, 67.3636)
 
     (mean, stddev) = ds.GetRasterBand(1).ComputeBandStats()
 

--- a/gdal/frmts/ecw/ecwsdk_headers.h
+++ b/gdal/frmts/ecw/ecwsdk_headers.h
@@ -66,6 +66,7 @@
 
 #if ECWSDK_VERSION < 40
 
+#include <NCSJPCFileIOStream.h>
 #if !defined(NO_COMPRESS) && !defined(HAVE_COMPRESS)
 #  define HAVE_COMPRESS
 #endif


### PR DESCRIPTION
Enabled reading ECW files from virtual file systems.

I'm inspect `libecwj2-3.3` source code, [ `CNCSJPCFileIOStream::SetIOCallbacks`](https://github.com/sasgis/libecwj2/blob/93d7869826c36df85f45fc23d767d52dee9e529b/Source/C/NCSEcw/NCSJP2/NCSJPCFileIOStream.cpp#L302) affects only on ECW [decompress](https://github.com/sasgis/libecwj2/blob/93d7869826c36df85f45fc23d767d52dee9e529b/Source/C/NCSEcw/shared_src/fileio_decompress.c#L83) path and we can't `GDAL_DCAP_VIRTUALIO` flag to `YES`.

See: https://trac.osgeo.org/gdal/ticket/6482