### PR TITLE
gdal-utils/osgeo_utils/auxiliary/base.py - fix `num()`

### DIFF
--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -69,10 +69,15 @@ def test_utils_py_0():
 
     assert base.num(42) == 42
     assert base.num('42') == 42
+    assert isinstance(base.num('42'), int)
 
     assert base.num(42.0) == 42.0
     assert base.num('42.0') == 42.0
+    assert isinstance(base.num('42.0'), float)
     assert base.num('42.') == 42.0
+    assert isinstance(base.num('42.'), float)
+    assert base.num(42.5) == 42.5
+    assert base.num('42.5') == 42.5
 
     assert base.num_or_none('') is None
     assert base.num_or_none(None) is None

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/base.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/base.py
@@ -31,7 +31,7 @@
 # ******************************************************************************
 
 import os.path
-from numbers import Real
+from numbers import Real, Number
 from pathlib import Path
 from typing import Sequence, Union, List, Tuple, TypeVar, Optional
 from enum import Enum
@@ -78,14 +78,17 @@ def path_join(*args) -> str:
     return os.path.join(*(str(arg) for arg in args))
 
 
-def num(s: Union[int, float, str]) -> Real:
-    try:
-        return int(s)
-    except ValueError:
-        return float(s)
+def num(s: Union[Number, str]) -> Number:
+    if isinstance(s, Number):
+        return s
+    else:
+        try:
+            return int(s)
+        except ValueError:
+            return float(s)
 
 
-def num_or_none(s: Optional[Union[int, float, str]]) -> Optional[Real]:
+def num_or_none(s: Optional[Union[Number, str]]) -> Optional[Number]:
     try:
         return num(s)
     except Exception:


### PR DESCRIPTION
This PR fixes the `num` auxiliary function. 
Before this PR `num(f: float)` returned `int(f)`
i.e. num(42.5)` returned 42 (instead of 42.5)

Tests added for this case.