### PR TITLE
Revert "gdallocationinfo.rst: x y mandatory"

### DIFF
--- a/gdal/doc/source/programs/gdallocationinfo.rst
+++ b/gdal/doc/source/programs/gdallocationinfo.rst
@@ -18,7 +18,7 @@ Synopsis
     Usage: gdallocationinfo [--help-general] [-xml] [-lifonly] [-valonly]
                             [-b band]* [-overview overview_level]
                             [-l_srs srs_def] [-geoloc] [-wgs84]
-                            [-oo NAME=VALUE]* srcfile x y
+                            [-oo NAME=VALUE]* srcfile [x y]
 
 Description
 -----------


### PR DESCRIPTION
Reverts OSGeo/gdal#2524

x y can be supplied interactively.