### PR TITLE
DatasetPool:  expose the current size in private C interface

### DIFF
--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -2809,6 +2809,7 @@ void GDALNullifyOpenDatasetsList();
 CPLMutex** GDALGetphDMMutex();
 CPLMutex** GDALGetphDLMutex();
 void GDALNullifyProxyPoolSingleton();
+int GDALDatasetPoolGetCurrentSize();
 void GDALSetResponsiblePIDForCurrentThread(GIntBig responsiblePID);
 GIntBig GDALGetResponsiblePIDForCurrentThread();
 

--- a/gdal/gcore/gdalproxypool.cpp
+++ b/gdal/gcore/gdalproxypool.cpp
@@ -139,6 +139,7 @@ class GDALDatasetPool
 
         static void PreventDestroy();
         static void ForceDestroy();
+        static int GetCurrentSize();
 };
 
 /************************************************************************/
@@ -518,6 +519,20 @@ void GDALDatasetPool::CloseDatasetIfZeroRefCount(
 {
     CPLMutexHolderD( GDALGetphDLMutex() );
     singleton->_CloseDatasetIfZeroRefCount(pszFileName, eAccess, pszOwner);
+}
+
+/************************************************************************/
+/*                  GetCurrentSize()                                    */
+/************************************************************************/
+
+int GDALDatasetPool::GetCurrentSize()
+{
+    return singleton != nullptr ? singleton->currentSize : 0;
+}
+
+int GDALDatasetPoolGetCurrentSize()
+{
+    return GDALDatasetPool::GetCurrentSize();
 }
 
 struct GetMetadataElt


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This exposes the current size of the dataset pool as part of the private C interface. This enables a use case that estimates the current memory usage of a VRT given the number of open datasets in the pool.

It may not seem like much, but this lets me track ~500MiB of otherwise unaccountable heap allocations (for my specific use case, it's related to the zstd decompression context within an open TIFF dataset).

## What are related issues/pull requests?
None.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 20.04
* Compiler: GCC 9.3
