### PR TITLE
createFromGeoJson: support non-null terminated #3870

### DIFF
--- a/gdal/ogr/ogr_geometry.h
+++ b/gdal/ogr/ogr_geometry.h
@@ -3253,7 +3253,7 @@ class CPL_DLL OGRGeometryFactory
     static OGRGeometry *createFromGML( const char * );
     static OGRGeometry *createFromGEOS( GEOSContextHandle_t hGEOSCtxt,
                                         GEOSGeom );
-    static OGRGeometry *createFromGeoJson( const char *);
+    static OGRGeometry *createFromGeoJson( const char *, int = -1 );
     static OGRGeometry *createFromGeoJson( const CPLJSONObject &oJSONObject );
 
     static void   destroyGeometry( OGRGeometry * );

--- a/gdal/ogr/ogrgeometryfactory.cpp
+++ b/gdal/ogr/ogrgeometryfactory.cpp
@@ -6087,13 +6087,16 @@ OGRCurve* OGRGeometryFactory::curveFromLineString(
 /**
  * @brief Create geometry from GeoJson fragment.
  * @param pszJsonString The GeoJSON fragment for the geometry.
+ * @param nSize (new in GDAL 3.4) Optional length of the string
+ *              if it is not null-terminated
  * @return a geometry on success, or NULL on error.
  * @since GDAL 2.3
  */
-OGRGeometry* OGRGeometryFactory::createFromGeoJson( const char *pszJsonString )
+OGRGeometry* OGRGeometryFactory::createFromGeoJson(
+    const char *pszJsonString, int nSize )
 {
     CPLJSONDocument oDocument;
-    if( !oDocument.LoadMemory( reinterpret_cast<const GByte*>(pszJsonString)) )
+    if( !oDocument.LoadMemory( reinterpret_cast<const GByte*>(pszJsonString), nSize) )
     {
         return nullptr;
     }


### PR DESCRIPTION

## What does this PR do?

Add an optional size argument to `OGRGeometryFactory::createFromGeojson` for non-null terminated strings

## What are related issues/pull requests?

## Tasklist

 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 20.04
* Compiler: gcc 9
