### PR TITLE
GetFilename does not exit before GDAL 3.4

### DIFF
--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -2412,7 +2412,7 @@ public:
      *
      * Might be empty if the array is not linked to a file.
      * 
-     * Since GDAL 3.4
+     * @since GDAL 3.4
      */
     virtual const std::string& GetFilename() const = 0;
 

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -2410,7 +2410,10 @@ public:
      *
      * This is used in particular for caching.
      *
-     * Might be empty if the array is not linked to a file. */
+     * Might be empty if the array is not linked to a file.
+     * 
+     * Since GDAL 3.4
+     */
     virtual const std::string& GetFilename() const = 0;
 
     virtual CSLConstList GetStructuralInfo() const;


### PR DESCRIPTION
Update doxygen
`GDALMDArray::GetFilename` does not exist before GDAL 3.4