### PR TITLE
Python import: fix FileNotFoundError when PATH has nonexistent paths (fixes #3898)

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -249,7 +249,11 @@ jobs:
             }
             $env:SDK_PREFIX="$env:GITHUB_WORKSPACE\sdk\$env:SDK"
             $env:SDK_BIN="$env:SDK_PREFIX\bin"
-            $env:PATH="$env:GITHUB_WORKSPACE\gdal;$env:GITHUB_WORKSPACE\gdal\apps;$env:SDK_PREFIX\dll;$env:SDK_PREFIX;$env:SDK_BIN;$env:PATH"
+            # Set USE_PATH_FOR_GDAL_PYTHON=YES and include a fake path in the PATH
+            # to test robustness to nonexistent paths (only relevant for python>=3.8)
+            # See https://github.com/OSGeo/gdal/issues/3898
+            $env:USE_PATH_FOR_GDAL_PYTHON="YES"
+            $env:PATH="$env:GITHUB_WORKSPACE\gdal;$env:GITHUB_WORKSPACE\gdal\apps;$env:SDK_PREFIX\dll;$env:SDK_PREFIX;$env:SDK_BIN;$env:GITHUB_WORKSPACE\not_a_real_path;$env:PATH"
             $env:GDAL_DATA="$env:GITHUB_WORKSPACE\gdal\data"
             $env:DO_NOT_FAIL_ON_RECODE_ERRORS="YES"
             # The ca-bundle.crt file which we could point to is invalid in the current SDK

--- a/gdal/swig/python/osgeo/__init__.py
+++ b/gdal/swig/python/osgeo/__init__.py
@@ -7,7 +7,10 @@ if version_info >= (3, 8, 0) and platform == 'win32':
     if 'USE_PATH_FOR_GDAL_PYTHON' in os.environ and 'PATH' in os.environ:
         for p in os.environ['PATH'].split(';'):
             if p:
-                os.add_dll_directory(p)
+                try:
+                    os.add_dll_directory(p)
+                except FileNotFoundError:
+                    continue
 
 
 def swig_import_helper():


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Prevent FileNotFoundError that can happen when importing from osgeo on Windows, python>=3.8.

I didn't see anywhere obvious to put a test case for this specific import behavior, let me know if that should go somewhere.

## What are related issues/pull requests?
Fixes #3898 

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
