### PR TITLE
WKT: prevent putting quotes around spatial CS type

### DIFF
--- a/gdal/ogr/ogr_srsnode.cpp
+++ b/gdal/ogr/ogr_srsnode.cpp
@@ -443,6 +443,10 @@ int OGR_SRSNode::NeedsQuoting() const
         && this != poParent->GetChild(0) )
         return FALSE;
 
+    if( poParent != nullptr && EQUAL(poParent->GetValue(), "CS")
+        && this == poParent->GetChild(0) )
+        return FALSE;
+
     // Strings starting with e or E are not valid numeric values, so they
     // need quoting, like in AXIS["E",EAST]
     if( (pszValue[0] == 'e' || pszValue[0] == 'E') )


### PR DESCRIPTION
## What does this PR do?
This PR prevents putting quotes around the spatial CS type, such as `Cartesian`, inside the CS node of the WKT.

WKT reference: http://docs.opengeospatial.org/is/18-010r7/18-010r7.html#45

Before this PR, the following code fails to generate a WKT because it puts quotes around `Cartesian` and fails this check in proj: https://github.com/OSGeo/PROJ/blob/29f849485bf2ea9caa7ca3da7d93ece1daf4d7d5/src/iso19111/io.cpp#L2727. This problem was triggered by a fairly exotic WKT that preserved the `CS` node after being imported and after manipulating the nodes. A minimal repro is below:

```
#include <gdal.h>
#include <ogr_spatialref.h>
#include <stdio.h>

int main() {
    const char* wkt = "DERIVEDPROJCRS[\"unnamed\",BASEPROJCRS[\"unnamed\",BASEGEOGCRS[\"WGS 84\",DATUM[\"World Geodetic System 1984\", ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"Oblique Stereographic\",METHOD[\"Oblique Stereographic\",ID[\"EPSG\",9809]],PARAMETER[\"Latitude of natural origin\",35.91600629551671,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",-84.21682058830596,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9999411285026271,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",760932.0392583184,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",177060.0539497079, LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]]],DERIVINGCONVERSION[\"unnamed\",METHOD[\"PROJ affine\"],PARAMETER[\"xoff\",10992.286002854082],PARAMETER[\"yoff\",-45365.00735334917],PARAMETER[\"zoff\",31.80827133745305],PARAMETER[\"s11\",3.280289313911039],PARAMETER[\"s12\",-0.059744272965456834],PARAMETER[\"s13\",0],PARAMETER[\"s21\",0.059744272965456834],PARAMETER[\"s22\",3.280289313911039],PARAMETER[\"s23\",0],PARAMETER[\"s31\",0.000144198502849885],PARAMETER[\"s32\",-0.00016681800457995442],PARAMETER[\"s33\",3.2808333333333355]],CS[Cartesian,3],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"ellipsoidal height (h)\",up,ORDER[3],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]";

    OGRSpatialReference srs;
    srs.importFromWkt(wkt);

    // trigger OGRSpatialReference::Private::refreshProjObj
    srs.GetRoot()->DestroyChild(0);
    srs.GetRoot()->InsertChild(new OGR_SRSNode("whatever"), 0);

    char* outWkt = nullptr;
    const char* options[] = {"FORMAT=WKT2_2018", 0};
    OGRErr error = srs.exportToWkt(&outWkt, options);

    // Before patch:
    // WKT: ""
    // Error: 6 (OGRERR_FAILURE)
    
    // After patch:
    // WKT: DERIVEDPROJCRS["whatever",BASEPROJCRS["unnamed",BASEGEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]]],CONVERSION["Oblique Stereographic",METHOD["Oblique Stereographic",ID["EPSG",9809]],PARAMETER["Latitude of natural origin",35.9160062955167,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",-84.216820588306,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["Scale factor at natural origin",0.999941128502627,SCALEUNIT["unity",1],ID["EPSG",8805]],PARAMETER["False easting",760932.039258318,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",177060.053949708,LENGTHUNIT["metre",1],ID["EPSG",8807]]]],DERIVINGCONVERSION["unnamed",METHOD["PROJ affine"],PARAMETER["xoff",10992.2860028541],PARAMETER["yoff",-45365.0073533492],PARAMETER["zoff",31.808271337453],PARAMETER["s11",3.28028931391104],PARAMETER["s12",-0.0597442729654568],PARAMETER["s13",0],PARAMETER["s21",0.0597442729654568],PARAMETER["s22",3.28028931391104],PARAMETER["s23",0],PARAMETER["s31",0.000144198502849885],PARAMETER["s32",-0.000166818004579954],PARAMETER["s33",3.28083333333334]],CS[Cartesian,3],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1,ID["EPSG",9001]]],AXIS["ellipsoidal height (h)",up,ORDER[3],LENGTHUNIT["metre",1,ID["EPSG",9001]]]]
    // Error: 0
    
    printf("WKT: %s\n", outWkt);
    printf("Error: %d\n", error);
}
``` 

This code was compiled on Ubuntu 20.04 with:
```
g++ test.cpp -I ~/Code/gdal/gdal/gcore/ -I ~/Code/gdal/gdal/port/ -I ~/Code/gdal/gdal/ogr/ -L ~/Code/gdal/gdal/.libs/ -Wl,-rpath ~/Code/gdal/gdal/.libs/ -l gdal -o test && ./test
```

And for easier reading, here is the WKT I'm using:
```
DERIVEDPROJCRS["unnamed",
    BASEPROJCRS["unnamed",
        BASEGEOGCRS["WGS 84",
            DATUM["World Geodetic System 1984", 
                ELLIPSOID["WGS 84",6378137,298.257223563,
                    LENGTHUNIT["metre",1]]],
            PRIMEM["Greenwich",0,
                ANGLEUNIT["degree",0.0174532925199433]],
            ID["EPSG",4326]],
        CONVERSION["Oblique Stereographic",
            METHOD["Oblique Stereographic",
                ID["EPSG",9809]],
            PARAMETER["Latitude of natural origin",35.91600629551671,
                ANGLEUNIT["degree",0.0174532925199433],
                ID["EPSG",8801]],
            PARAMETER["Longitude of natural origin",-84.21682058830596,
                ANGLEUNIT["degree",0.0174532925199433],
                ID["EPSG",8802]],
            PARAMETER["Scale factor at natural origin",0.9999411285026271,
                SCALEUNIT["unity",1],
                ID["EPSG",8805]],
            PARAMETER["False easting",760932.0392583184,
                LENGTHUNIT["metre",1],
                ID["EPSG",8806]],
            PARAMETER["False northing",177060.0539497079, 
                LENGTHUNIT["metre",1],
                ID["EPSG",8807]]]],
    DERIVINGCONVERSION["unnamed",
        METHOD["PROJ affine"],
        PARAMETER["xoff",10992.286002854082],
        PARAMETER["yoff",-45365.00735334917],
        PARAMETER["zoff",31.80827133745305],
        PARAMETER["s11",3.280289313911039],
        PARAMETER["s12",-0.059744272965456834],
        PARAMETER["s13",0],
        PARAMETER["s21",0.059744272965456834],
        PARAMETER["s22",3.280289313911039],
        PARAMETER["s23",0],
        PARAMETER["s31",0.000144198502849885],
        PARAMETER["s32",-0.00016681800457995442],
        PARAMETER["s33",3.2808333333333355]],
    CS[Cartesian,3],
    AXIS["(E)",east,
        ORDER[1],
        LENGTHUNIT["metre",1,
            ID["EPSG",9001]]],
    AXIS["(N)",north,
        ORDER[2],
        LENGTHUNIT["metre",1,
            ID["EPSG",9001]]],
    AXIS["ellipsoidal height (h)",up,
        ORDER[3],
        LENGTHUNIT["metre",1,
            ID["EPSG",9001]]]]
```

## What are related issues/pull requests?

There is a similar comment right above about the AXIS keyword.
```
// As per bugzilla bug 294, the OGC spec says the direction
// values for the AXIS keywords should *not* be quoted.
```

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 20.04
* Compiler: gcc 9.3.0
