### PR TITLE
WKT: Add `DERIVEDPROJCRS` to WKT keywords for `OGRSpatialReference::SetFromUserInput`

### DIFF
--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -3417,7 +3417,7 @@ OGRErr OGRSpatialReference::SetFromUserInput( const char * pszDefinition )
         // WKT2"
         "GEODCRS", "GEOGCRS", "GEODETICCRS", "GEOGRAPHICCRS", "PROJCRS",
         "PROJECTEDCRS", "VERTCRS", "VERTICALCRS", "COMPOUNDCRS",
-        "ENGCRS", "ENGINEERINGCRS", "BOUNDCRS"
+        "ENGCRS", "ENGINEERINGCRS", "BOUNDCRS", "DERIVEDPROJCRS"
     };
     for( const char* keyword: wktKeywords )
     {


### PR DESCRIPTION
## What does this PR do?

This PR adds `DERIVEDPROJCRS` to the list of WKT keywords when using `OGRSpatialReference::SetFromUserInput`. After this PR, `OGRSpatialReference::SetFromUserInput` works identically to `OGRSpatialReference::importFromWkt` with a WKT containing `DERIVEDPROJCRS`.

Minimal repro:
```
#include <gdal.h>
#include <ogr_spatialref.h>
#include <stdio.h>

int main() {
    const char* wkt = "DERIVEDPROJCRS[\"unnamed\",BASEPROJCRS[\"unnamed\",BASEGEOGCRS[\"WGS 84\",DATUM[\"World Geodetic System 1984\", ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4326]],CONVERSION[\"Oblique Stereographic\",METHOD[\"Oblique Stereographic\",ID[\"EPSG\",9809]],PARAMETER[\"Latitude of natural origin\",35.91600629551671,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",-84.21682058830596,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9999411285026271,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",760932.0392583184,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",177060.0539497079, LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]]],DERIVINGCONVERSION[\"affine\",METHOD[\"PROJ affine\"],PARAMETER[\"xoff\",-25.365221999119967,SCALEUNIT[\"unity\",1]],PARAMETER[\"yoff\",-30.51036324049346,SCALEUNIT[\"unity\",1]],PARAMETER[\"zoff\",31.80827133745305,SCALEUNIT[\"unity\",1]],PARAMETER[\"s11\",3.280833333333336,SCALEUNIT[\"unity\",1]],PARAMETER[\"s12\",6.938893903907228e-18,SCALEUNIT[\"unity\",1]],PARAMETER[\"s13\",0,SCALEUNIT[\"unity\",1]],PARAMETER[\"s21\",-6.938893903907228e-18,SCALEUNIT[\"unity\",1]],PARAMETER[\"s22\",3.280833333333336,SCALEUNIT[\"unity\",1]],PARAMETER[\"s23\",0,SCALEUNIT[\"unity\",1]],PARAMETER[\"s31\",0.000144198502849885,SCALEUNIT[\"unity\",1]],PARAMETER[\"s32\",-0.00016681800457995442,SCALEUNIT[\"unity\",1]],PARAMETER[\"s33\",3.2808333333333355,SCALEUNIT[\"unity\",1]]],CS[Cartesian,3],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"ellipsoidal height (h)\",up,ORDER[3],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]";

    OGRSpatialReference srs;
    OGRErr error = srs.SetFromUserInput(wkt);

    // Before patch:
    // Error: 5 (OGRERR_CORRUPT_DATA)
    
    // After patch:
    // Error: 0
    
    printf("Error: %d\n", error);
}
```

This code was compiled on Ubuntu 20.04 with:

```
g++ test.cpp -I ~/Code/gdal/gdal/gcore/ -I ~/Code/gdal/gdal/port/ -I ~/Code/gdal/gdal/ogr/ -L ~/Code/gdal/gdal/.libs/ -Wl,-rpath ~/Code/gdal/gdal/.libs/ -l gdal -o test && ./test
```

Full WKT:
```
DERIVEDPROJCRS["unnamed",
    BASEPROJCRS["unnamed",
        BASEGEOGCRS["WGS 84",
            DATUM["World Geodetic System 1984", 
                ELLIPSOID["WGS 84",6378137,298.257223563,
                    LENGTHUNIT["metre",1]]],
            PRIMEM["Greenwich",0,
                ANGLEUNIT["degree",0.0174532925199433]],
            ID["EPSG",4326]],
        CONVERSION["Oblique Stereographic",
            METHOD["Oblique Stereographic",
                ID["EPSG",9809]],
            PARAMETER["Latitude of natural origin",35.91600629551671,
                ANGLEUNIT["degree",0.0174532925199433],
                ID["EPSG",8801]],
            PARAMETER["Longitude of natural origin",-84.21682058830596,
                ANGLEUNIT["degree",0.0174532925199433],
                ID["EPSG",8802]],
            PARAMETER["Scale factor at natural origin",0.9999411285026271,
                SCALEUNIT["unity",1],
                ID["EPSG",8805]],
            PARAMETER["False easting",760932.0392583184,
                LENGTHUNIT["metre",1],
                ID["EPSG",8806]],
            PARAMETER["False northing",177060.0539497079, 
                LENGTHUNIT["metre",1],
                ID["EPSG",8807]]]],
    DERIVINGCONVERSION["unnamed",
        METHOD["PROJ affine"],
        PARAMETER["xoff",-25.365221999119967,
            SCALEUNIT["unity",1]],
        PARAMETER["yoff",-30.51036324049346,
            SCALEUNIT["unity",1]],
        PARAMETER["zoff",31.80827133745305,
            SCALEUNIT["unity",1]],
        PARAMETER["s11",3.280833333333336,
            SCALEUNIT["unity",1]],
        PARAMETER["s12",6.938893903907228e-18,
            SCALEUNIT["unity",1]],
        PARAMETER["s13",0,
            SCALEUNIT["unity",1]],
        PARAMETER["s21",-6.938893903907228e-18,
            SCALEUNIT["unity",1]],
        PARAMETER["s22",3.280833333333336,
            SCALEUNIT["unity",1]],
        PARAMETER["s23",0,
            SCALEUNIT["unity",1]],
        PARAMETER["s31",0.000144198502849885,
            SCALEUNIT["unity",1]],
        PARAMETER["s32",-0.00016681800457995442,
            SCALEUNIT["unity",1]],
        PARAMETER["s33",3.2808333333333355,
            SCALEUNIT["unity",1]]],
        CS[Cartesian,3],
        AXIS["(E)",east,
            ORDER[1],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        AXIS["(N)",north,
            ORDER[2],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        AXIS["ellipsoidal height (h)",up,
            ORDER[3],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]]]
```

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/issues/3926

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 20.04
* Compiler: gcc 9.3.0
