### PR TITLE
Doc: update gdaltindex output formats

### DIFF
--- a/gdal/doc/source/programs/gdaltindex.rst
+++ b/gdal/doc/source/programs/gdaltindex.rst
@@ -89,14 +89,20 @@ tileindex.
 Examples
 --------
 
-- Produce a GeoPackage (``index.gpkg``) with a record for every
-  image that the utility found in the ``raster_files`` folder. Each record holds
+- Produce a shapefile (``doq_index.shp``) with a record for every
+  image that the utility found in the ``doq`` folder. Each record holds
   information that points to the location of the image and also a bounding rectangle
   shape showing the bounds of the image:
 
 ::
 
-    gdaltindex index.gpkg raster_files/*.tif
+    gdaltindex doq_index.shp doq/*.tif
+
+- Perform the same command as before, but now we create a GeoPacakge instead of a Shapefile. 
+
+::
+
+    gdaltindex -f GPKG doq_index.gpkg doq/*.tif
 
 - The :option:`-t_srs` option can also be used to transform all input rasters
   into the same output projection:

--- a/gdal/doc/source/programs/gdaltindex.rst
+++ b/gdal/doc/source/programs/gdaltindex.rst
@@ -6,7 +6,7 @@ gdaltindex
 
 .. only:: html
 
-    Builds a shapefile as a raster tileindex.
+    Creates an OGR-supported dataset as a raster tileindex.
 
 .. Index:: gdaltindex
 
@@ -23,7 +23,7 @@ Synopsis
 Description
 -----------
 
-This program builds a shapefile with a record for each input raster file,
+This program creates an OGR-supported dataset with a record for each input raster file,
 an attribute containing the filename, and a polygon geometry outlining the
 raster.  This output is suitable for use with `MapServer <http://mapserver.org/>`__ as a raster
 tileindex.
@@ -76,9 +76,9 @@ tileindex.
 
 .. option:: index_file
 
-    The name of the output file to create/append to. The default shapefile will
+    The name of the output file to create/append to. The default dataset will
     be created if it doesn't already exist, otherwise it will append to the
-    existing file.
+    existing dataset.
 
 .. option:: <gdal_file>
 
@@ -89,14 +89,14 @@ tileindex.
 Examples
 --------
 
-- Produce a shapefile (``doq_index.shp``) with a record for every
-  image that the utility found in the ``doq`` folder. Each record holds
+- Produce a GeoPackage (``index.gpkg``) with a record for every
+  image that the utility found in the ``raster_files`` folder. Each record holds
   information that points to the location of the image and also a bounding rectangle
   shape showing the bounds of the image:
 
 ::
 
-    gdaltindex doq_index.shp doq/*.tif
+    gdaltindex index.gpkg raster_files/*.tif
 
 - The :option:`-t_srs` option can also be used to transform all input rasters
   into the same output projection:

--- a/gdal/doc/source/programs/index.rst
+++ b/gdal/doc/source/programs/index.rst
@@ -54,7 +54,7 @@ Raster programs
     - :ref:`gdal_translate`: Converts raster data between different formats.
     - :ref:`gdaladdo`: Builds or rebuilds overview images.
     - :ref:`gdalwarp`: Image reprojection and warping utility.
-    - :ref:`gdaltindex`: Builds a shapefile as a raster tileindex.
+    - :ref:`gdaltindex`: Builds an OGR-supported dataset as a raster tileindex.
     - :ref:`gdalbuildvrt`: Builds a VRT from a list of datasets.
     - :ref:`gdal_contour`: Builds vector contour lines from a raster elevation model.
     - :ref:`gdaldem`: Tools to analyze and visualize DEMs.


### PR DESCRIPTION
## What does this PR do?

- it updates the documentation of [gdaltindex](https://gdal.org/programs/gdaltindex.html#gdaltindex). 
`gdaltindex` meanwhile can create all OGR-supported datasets and is not limited to Shapefile anymore. 
- it also updates the basic example for using GeoPackage instead of Shapefile

Please let me know if `OGR-supported dataset` is the correct wording in this case. Otherwise I am happy to correct.

## What are related issues/pull requests?

- not found

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
