### PR TITLE
Internal libtiff: fix when writing a IFD with a single tile that is a…

### DIFF
--- a/gdal/ci/travis/graviton2/install.sh
+++ b/gdal/ci/travis/graviton2/install.sh
@@ -27,7 +27,7 @@ sudo sh -c "apt-get remove -y libproj-dev"
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Configure GDAL
-sh -c "cd $PWD/gdal && CCACHE_CPP2=yes CC='ccache gcc' CXX='ccache g++' LDFLAGS='-lstdc++' ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-mysql --with-liblzma --without-webp --with-epsilon --with-proj=/usr/local --with-poppler --with-hdf5 --with-dods-root=/usr --with-sosi --with-mysql"
+sh -c "cd $PWD/gdal && CCACHE_CPP2=yes CC='ccache gcc' CXX='ccache g++' LDFLAGS='-lstdc++' ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-mysql --with-liblzma --without-webp --with-epsilon --with-proj=/usr/local --with-poppler --with-hdf5 --with-dods-root=/usr --with-sosi --with-mysql --with-libtiff=internal --with-rename-internal-libtiff-symbols"
 
 sh -c "cd $PWD/gdal && CCACHE_CPP2=yes make USER_DEFS=-Werror -j3"
 sh -c "cd $PWD/gdal/apps && make USER_DEFS=-Werror -j3 test_ogrsf"

--- a/gdal/ci/travis/s390x/install.sh
+++ b/gdal/ci/travis/s390x/install.sh
@@ -27,7 +27,7 @@ sudo sh -c "apt-get remove -y libproj-dev"
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Configure GDAL
-sh -c "cd $PWD/gdal && CCACHE_CPP2=yes CC='ccache gcc' CXX='ccache g++' LDFLAGS='-lstdc++' ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-mysql --with-liblzma --without-webp --with-epsilon --with-proj=/usr/local --with-poppler --with-hdf5 --with-dods-root=/usr --with-sosi --with-mysql"
+sh -c "cd $PWD/gdal && CCACHE_CPP2=yes CC='ccache gcc' CXX='ccache g++' LDFLAGS='-lstdc++' ./configure --prefix=/usr --without-libtool --with-jpeg12 --with-python=/usr/bin/python3 --with-poppler --with-mysql --with-liblzma --without-webp --with-epsilon --with-proj=/usr/local --with-poppler --with-hdf5 --with-dods-root=/usr --with-sosi --with-mysql --with-libtiff=internal --with-rename-internal-libtiff-symbols"
 
 sh -c "cd $PWD/gdal && CCACHE_CPP2=yes make USER_DEFS=-Werror -j3"
 sh -c "cd $PWD/gdal/apps && make USER_DEFS=-Werror -j3 test_ogrsf"

--- a/gdal/frmts/gtiff/libtiff/tif_dirwrite.c
+++ b/gdal/frmts/gtiff/libtiff/tif_dirwrite.c
@@ -3675,7 +3675,16 @@ _TIFFRewriteField(TIFF* tif, uint16_t tag, TIFFDataType in_datatype,
     }
     else
     {
-        memcpy( &entry_offset, buf_to_write, count*TIFFDataWidth(datatype));
+        if( count*TIFFDataWidth(datatype) == 4 )
+        {
+            uint32_t value;
+            memcpy( &value, buf_to_write, count*TIFFDataWidth(datatype));
+            entry_offset = value;
+        }
+        else
+        {
+            memcpy( &entry_offset, buf_to_write, count*TIFFDataWidth(datatype));
+        }
     }
 
     _TIFFfree( buf_to_write );


### PR DESCRIPTION
… sparse one, on big endian hosts (fixes failures in cog.py tests)
