### PR TITLE
JP2OpenJPEG: add a TLM=YES creation option

### DIFF
--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -2984,7 +2984,7 @@ def test_jp2openjpeg_tilesize_16():
 
 def test_jp2openjpeg_generate_PLT():
 
-    # Only try the rest with openjpeg > 2.3.1 that supports it
+    # Only try the rest with openjpeg >= 2.4.0 that supports it
     if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('PLT') < 0:
         pytest.skip()
 
@@ -3001,6 +3001,33 @@ def test_jp2openjpeg_generate_PLT():
     # Check presence of a PLT marker
     ret = gdal.GetJPEG2000StructureAsString(filename, ['ALL=YES'])
     assert '<Marker name="PLT"' in ret
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+
+###############################################################################
+# Test generation of TLM marker segments
+
+
+def test_jp2openjpeg_generate_TLM():
+
+    # Only try the rest with openjpeg >= 2.5.0 that supports it
+    if gdaltest.jp2openjpeg_drv.GetMetadataItem('DMD_CREATIONOPTIONLIST').find('TLM') < 0:
+        pytest.skip()
+
+    filename = '/vsimem/temp.jp2'
+    gdaltest.jp2openjpeg_drv.CreateCopy(filename, gdal.Open('data/byte.tif'),
+                                        options=['TLM=YES',
+                                                 'REVERSIBLE=YES',
+                                                 'QUALITY=100'])
+
+    ds = gdal.Open(filename)
+    assert ds.GetRasterBand(1).Checksum() == 4672
+    ds = None
+
+    # Check presence of a TLM marker
+    ret = gdal.GetJPEG2000StructureAsString(filename, ['ALL=YES'])
+    assert '<Marker name="TLM"' in ret
 
     gdaltest.jp2openjpeg_drv.Delete(filename)
 

--- a/gdal/doc/source/drivers/raster/jp2openjpeg.rst
+++ b/gdal/doc/source/drivers/raster/jp2openjpeg.rst
@@ -261,8 +261,11 @@ Creation Options
    increase codestream size, but improve either coding/decoding speed or
    resilience/error detection.
 
--  **PLT=YES/NO**: (GDAL >= 3.1.1 and OpenJPEG > 2.3.1) Whether to write a
-   PLT (Packet Length) marker segments in tile-part headers. Defaults to NO.
+-  **PLT=YES/NO**: (GDAL >= 3.1.1 and OpenJPEG >= 2.4.0) Whether to write a
+   PLT (Packet Length) marker segment in tile-part headers. Defaults to NO.
+
+-  **TLM=YES/NO**: (GDAL >= 3.4.0 and OpenJPEG >= 2.5.0) Whether to write a
+   TLM (Tile-part Length) marker segment in main header. Defaults to NO.
 
 -  **WRITE_METADATA=YES/NO**: Whether metadata should be
    written, in a dedicated JP2 'xml ' box. Defaults to NO. The content


### PR DESCRIPTION
to write Tile-part Length Marker.

Depends on openjpeg >= 2.5.0 / https://github.com/uclouvain/openjpeg/pull/1359