### PR TITLE
Fix openstack swift endpoint detection, add application_credential authentication support

### DIFF
--- a/autotest/gcore/vsiswift.py
+++ b/autotest/gcore/vsiswift.py
@@ -324,7 +324,7 @@ def test_vsiswift_fake_auth_v3_application_credential_url():
     gdal.VSICurlClearCache()
     gdal.SetConfigOption('SWIFT_STORAGE_URL', '')
     gdal.SetConfigOption('SWIFT_AUTH_TOKEN', '')
-    with gdaltest.set_config_options( {
+    with gdaltest.config_options( {
             'OS_IDENTITY_API_VERSION': '3',
             'OS_AUTH_URL': 'http://127.0.0.1:%d/v3' % gdaltest.webserver_port,
             'OS_AUTH_TYPE': 'v3applicationcredential',

--- a/autotest/gcore/vsiswift.py
+++ b/autotest/gcore/vsiswift.py
@@ -254,9 +254,21 @@ def test_vsiswift_fake_auth_v3_url():
                   "endpoints" : [
                      {
                         "region" : "Test",
+                        "interface" : "admin",
+                        "url" : "http://127.0.0.1:%d/v1/admin/AUTH_something"
+                     },
+                     {
+                        "region" : "Test",
+                        "interface" : "internal",
+                        "url" : "http://127.0.0.1:%d/v1/internal/AUTH_something"
+                     },
+                     {
+                        "region" : "Test",
+                        "interface" : "public",
                         "url" : "http://127.0.0.1:%d/v1/AUTH_something"
                      }
                   ],
+                  "type": "object-store",
                   "name" : "swift"
                  }
                ]

--- a/autotest/gcore/vsiswift.py
+++ b/autotest/gcore/vsiswift.py
@@ -244,6 +244,8 @@ def test_vsiswift_fake_auth_v3_url():
         request_len = int(h['Content-Length'])
         request_body = request.rfile.read(request_len).decode()
         request_json = json.loads(request_body)
+        methods = request_json['auth']['identity']["methods"]
+        assert "password" in methods
         password = request_json['auth']['identity']['password']['user']['password']
         assert password == 'pwd'
 
@@ -255,12 +257,12 @@ def test_vsiswift_fake_auth_v3_url():
                      {
                         "region" : "Test",
                         "interface" : "admin",
-                        "url" : "http://127.0.0.1:%d/v1/admin/AUTH_something"
+                        "url" : "http://127.0.0.1:8080/v1/admin/AUTH_something"
                      },
                      {
                         "region" : "Test",
                         "interface" : "internal",
-                        "url" : "http://127.0.0.1:%d/v1/internal/AUTH_something"
+                        "url" : "http://127.0.0.1:8081/v1/internal/AUTH_something"
                      },
                      {
                         "region" : "Test",
@@ -290,6 +292,114 @@ def test_vsiswift_fake_auth_v3_url():
         h = request.headers
         if 'x-auth-token' not in h or \
            h['x-auth-token'] != 'my_auth_token':
+            sys.stderr.write('Bad headers: %s\n' % str(h))
+            request.send_response(403)
+            return
+        request.send_response(200)
+        request.send_header('Content-type', 'text/plain')
+        request.send_header('Content-Length', 3)
+        request.send_header('Connection', 'close')
+        request.end_headers()
+        request.wfile.write('foo'.encode('ascii'))
+
+    handler.add('GET', '/v1/AUTH_something/foo/bar', custom_method=method)
+    with webserver.install_http_handler(handler):
+        f = open_for_read('/vsiswift/foo/bar')
+        assert f is not None
+        data = gdal.VSIFReadL(1, 4, f).decode('ascii')
+        assert data == 'foo'
+        gdal.VSIFCloseL(f)
+
+
+###############################################################################
+# Test authentication with OS_IDENTITY_API_VERSION=3 OS_AUTH_TYPE="v3applicationcredential"
+# + OS_APPLICATION_CREDENTIAL_ID + OS_APPLICATION_CREDENTIAL_SECRET
+
+
+def test_vsiswift_fake_auth_v3_application_credential_url():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+    gdal.SetConfigOption('OS_IDENTITY_API_VERSION', '3')
+    gdal.SetConfigOption('OS_AUTH_URL', 'http://127.0.0.1:%d/v3' % gdaltest.webserver_port)
+    gdal.SetConfigOption('OS_AUTH_TYPE', 'v3applicationcredential')
+    gdal.SetConfigOption('OS_APPLICATION_CREDENTIAL_ID', 'xxxyyycredential-idyyyxxx==')
+    gdal.SetConfigOption('OS_APPLICATION_CREDENTIAL_SECRET', 'xxxyyycredential-secretyyyxxx==')
+    gdal.SetConfigOption('OS_USER_DOMAIN_NAME', 'test_user_domain')
+    gdal.SetConfigOption('OS_PROJECT_NAME', 'test_proj')
+    gdal.SetConfigOption('OS_PROJECT_DOMAIN_NAME', 'test_project_domain')
+    gdal.SetConfigOption('OS_REGION_NAME', 'Test')
+    gdal.SetConfigOption('SWIFT_STORAGE_URL', '')
+    gdal.SetConfigOption('SWIFT_AUTH_TOKEN', '')
+
+    handler = webserver.SequentialHandler()
+
+    def method(request):
+
+        request.protocol_version = 'HTTP/1.1'
+        h = request.headers
+
+        if 'Content-Type' not in h or h['Content-Type'] != 'application/json':
+            sys.stderr.write('Bad headers: %s\n' % str(h))
+            request.send_response(403)
+            return
+
+        request_len = int(h['Content-Length'])
+        request_body = request.rfile.read(request_len).decode()
+        request_json = json.loads(request_body)
+        methods = request_json['auth']['identity']["methods"]
+        assert "application_credential" in methods
+        cred_id = request_json['auth']['identity']['application_credential']['id']
+        cred_secret = request_json['auth']['identity']['application_credential']['secret']
+
+        assert cred_id == 'xxxyyycredential-idyyyxxx=='
+        assert cred_secret == 'xxxyyycredential-secretyyyxxx=='
+
+        content = """{
+             "token" : {
+               "catalog" : [
+                 {
+                  "endpoints" : [
+                     {
+                        "region" : "Test",
+                        "interface" : "admin",
+                        "url" : "http://127.0.0.1:8080/v1/admin/AUTH_something"
+                     },
+                     {
+                        "region" : "Test",
+                        "interface" : "internal",
+                        "url" : "http://127.0.0.1:8081/v1/internal/AUTH_something"
+                     },
+                     {
+                        "region" : "Test",
+                        "interface" : "public",
+                        "url" : "http://127.0.0.1:%d/v1/AUTH_something"
+                     }
+                  ],
+                  "type": "object-store",
+                  "name" : "swift"
+                 }
+               ]
+             }
+          }""" % gdaltest.webserver_port
+        content = content.encode('ascii')
+        request.send_response(200)
+        request.send_header('Content-Length', len(content))
+        request.send_header('Content-Type', 'application/json')
+        request.send_header('X-Subject-Token', 'my_auth_token')
+        request.end_headers()
+        request.wfile.write(content)
+
+    handler.add('POST', '/v3/auth/tokens', custom_method=method)
+
+    def method(request):
+
+        request.protocol_version = 'HTTP/1.1'
+        h = request.headers
+        if 'x-auth-token' not in h or \
+                h['x-auth-token'] != 'my_auth_token':
             sys.stderr.write('Bad headers: %s\n' % str(h))
             request.send_response(403)
             return

--- a/autotest/gcore/vsiswift.py
+++ b/autotest/gcore/vsiswift.py
@@ -322,101 +322,101 @@ def test_vsiswift_fake_auth_v3_application_credential_url():
         pytest.skip()
 
     gdal.VSICurlClearCache()
-    gdal.SetConfigOption('OS_IDENTITY_API_VERSION', '3')
-    gdal.SetConfigOption('OS_AUTH_URL', 'http://127.0.0.1:%d/v3' % gdaltest.webserver_port)
-    gdal.SetConfigOption('OS_AUTH_TYPE', 'v3applicationcredential')
-    gdal.SetConfigOption('OS_APPLICATION_CREDENTIAL_ID', 'xxxyyycredential-idyyyxxx==')
-    gdal.SetConfigOption('OS_APPLICATION_CREDENTIAL_SECRET', 'xxxyyycredential-secretyyyxxx==')
-    gdal.SetConfigOption('OS_USER_DOMAIN_NAME', 'test_user_domain')
-    gdal.SetConfigOption('OS_PROJECT_NAME', 'test_proj')
-    gdal.SetConfigOption('OS_PROJECT_DOMAIN_NAME', 'test_project_domain')
-    gdal.SetConfigOption('OS_REGION_NAME', 'Test')
     gdal.SetConfigOption('SWIFT_STORAGE_URL', '')
     gdal.SetConfigOption('SWIFT_AUTH_TOKEN', '')
+    with gdaltest.set_config_options( {
+            'OS_IDENTITY_API_VERSION': '3',
+            'OS_AUTH_URL': 'http://127.0.0.1:%d/v3' % gdaltest.webserver_port,
+            'OS_AUTH_TYPE': 'v3applicationcredential',
+            'OS_APPLICATION_CREDENTIAL_ID': 'xxxyyycredential-idyyyxxx==',
+            'OS_APPLICATION_CREDENTIAL_SECRET': 'xxxyyycredential-secretyyyxxx==',
+            'OS_USER_DOMAIN_NAME': 'test_user_domain',
+            'OS_REGION_NAME': 'Test'
+        } ):
 
-    handler = webserver.SequentialHandler()
+        handler = webserver.SequentialHandler()
 
-    def method(request):
+        def method(request):
 
-        request.protocol_version = 'HTTP/1.1'
-        h = request.headers
+            request.protocol_version = 'HTTP/1.1'
+            h = request.headers
 
-        if 'Content-Type' not in h or h['Content-Type'] != 'application/json':
-            sys.stderr.write('Bad headers: %s\n' % str(h))
-            request.send_response(403)
-            return
+            if 'Content-Type' not in h or h['Content-Type'] != 'application/json':
+                sys.stderr.write('Bad headers: %s\n' % str(h))
+                request.send_response(403)
+                return
 
-        request_len = int(h['Content-Length'])
-        request_body = request.rfile.read(request_len).decode()
-        request_json = json.loads(request_body)
-        methods = request_json['auth']['identity']["methods"]
-        assert "application_credential" in methods
-        cred_id = request_json['auth']['identity']['application_credential']['id']
-        cred_secret = request_json['auth']['identity']['application_credential']['secret']
+            request_len = int(h['Content-Length'])
+            request_body = request.rfile.read(request_len).decode()
+            request_json = json.loads(request_body)
+            methods = request_json['auth']['identity']["methods"]
+            assert "application_credential" in methods
+            cred_id = request_json['auth']['identity']['application_credential']['id']
+            cred_secret = request_json['auth']['identity']['application_credential']['secret']
 
-        assert cred_id == 'xxxyyycredential-idyyyxxx=='
-        assert cred_secret == 'xxxyyycredential-secretyyyxxx=='
+            assert cred_id == 'xxxyyycredential-idyyyxxx=='
+            assert cred_secret == 'xxxyyycredential-secretyyyxxx=='
 
-        content = """{
-             "token" : {
-               "catalog" : [
-                 {
-                  "endpoints" : [
+            content = """{
+                 "token" : {
+                   "catalog" : [
                      {
-                        "region" : "Test",
-                        "interface" : "admin",
-                        "url" : "http://127.0.0.1:8080/v1/admin/AUTH_something"
-                     },
-                     {
-                        "region" : "Test",
-                        "interface" : "internal",
-                        "url" : "http://127.0.0.1:8081/v1/internal/AUTH_something"
-                     },
-                     {
-                        "region" : "Test",
-                        "interface" : "public",
-                        "url" : "http://127.0.0.1:%d/v1/AUTH_something"
+                      "endpoints" : [
+                         {
+                            "region" : "Test",
+                            "interface" : "admin",
+                            "url" : "http://127.0.0.1:8080/v1/admin/AUTH_something"
+                         },
+                         {
+                            "region" : "Test",
+                            "interface" : "internal",
+                            "url" : "http://127.0.0.1:8081/v1/internal/AUTH_something"
+                         },
+                         {
+                            "region" : "Test",
+                            "interface" : "public",
+                            "url" : "http://127.0.0.1:%d/v1/AUTH_something"
+                         }
+                      ],
+                      "type": "object-store",
+                      "name" : "swift"
                      }
-                  ],
-                  "type": "object-store",
-                  "name" : "swift"
+                   ]
                  }
-               ]
-             }
-          }""" % gdaltest.webserver_port
-        content = content.encode('ascii')
-        request.send_response(200)
-        request.send_header('Content-Length', len(content))
-        request.send_header('Content-Type', 'application/json')
-        request.send_header('X-Subject-Token', 'my_auth_token')
-        request.end_headers()
-        request.wfile.write(content)
+              }""" % gdaltest.webserver_port
+            content = content.encode('ascii')
+            request.send_response(200)
+            request.send_header('Content-Length', len(content))
+            request.send_header('Content-Type', 'application/json')
+            request.send_header('X-Subject-Token', 'my_auth_token')
+            request.end_headers()
+            request.wfile.write(content)
 
-    handler.add('POST', '/v3/auth/tokens', custom_method=method)
+        handler.add('POST', '/v3/auth/tokens', custom_method=method)
 
-    def method(request):
+        def method(request):
 
-        request.protocol_version = 'HTTP/1.1'
-        h = request.headers
-        if 'x-auth-token' not in h or \
-                h['x-auth-token'] != 'my_auth_token':
-            sys.stderr.write('Bad headers: %s\n' % str(h))
-            request.send_response(403)
-            return
-        request.send_response(200)
-        request.send_header('Content-type', 'text/plain')
-        request.send_header('Content-Length', 3)
-        request.send_header('Connection', 'close')
-        request.end_headers()
-        request.wfile.write('foo'.encode('ascii'))
+            request.protocol_version = 'HTTP/1.1'
+            h = request.headers
+            if 'x-auth-token' not in h or \
+                    h['x-auth-token'] != 'my_auth_token':
+                sys.stderr.write('Bad headers: %s\n' % str(h))
+                request.send_response(403)
+                return
+            request.send_response(200)
+            request.send_header('Content-type', 'text/plain')
+            request.send_header('Content-Length', 3)
+            request.send_header('Connection', 'close')
+            request.end_headers()
+            request.wfile.write('foo'.encode('ascii'))
 
-    handler.add('GET', '/v1/AUTH_something/foo/bar', custom_method=method)
-    with webserver.install_http_handler(handler):
-        f = open_for_read('/vsiswift/foo/bar')
-        assert f is not None
-        data = gdal.VSIFReadL(1, 4, f).decode('ascii')
-        assert data == 'foo'
-        gdal.VSIFCloseL(f)
+        handler.add('GET', '/v1/AUTH_something/foo/bar', custom_method=method)
+        with webserver.install_http_handler(handler):
+            f = open_for_read('/vsiswift/foo/bar')
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode('ascii')
+            assert data == 'foo'
+            gdal.VSIFCloseL(f)
 
 
 ###############################################################################

--- a/gdal/doc/source/user/virtual_file_systems.rst
+++ b/gdal/doc/source/user/virtual_file_systems.rst
@@ -443,6 +443,15 @@ Three authentication methods are possible, and are attempted in the following or
    - `OS_PROJECT_DOMAIN_NAME`
    - `OS_REGION_NAME`
 
+4. Application Credential Authentication via Keystone v3, GDAL (>= 3.3.1) supports application-credential authentication with the following options:
+
+   - `OS_IDENTITY_API_VERSION=3`
+   - `OS_AUTH_TYPE=v3applicationcredential`
+   - `OS_AUTH_URL`
+   - `OS_APPLICATION_CREDENTIAL_ID`
+   - `OS_APPLICATION_CREDENTIAL_SECRET`
+   - `OS_REGION_NAME`
+
 This file system handler also allows sequential writing of files (no seeks or read operations are then allowed).
 
 In some versions of OpenStack Swift, the access to large (segmented) files fails unless they are explicitly marked as static large objects, instead of being dynamic large objects which is the default. Using the python-swiftclient this can be achieved when uploading the file by passing the ``--use-slo`` flag (see https://docs.openstack.org/python-swiftclient/latest/cli/index.html#swift-upload for all options). For more information about large objects see https://docs.openstack.org/swift/latest/api/large_objects.html.

--- a/gdal/port/cpl_swift.h
+++ b/gdal/port/cpl_swift.h
@@ -46,8 +46,8 @@ class VSISwiftHandleHelper final: public IVSIS3LikeHandleHelper
         CPLString m_osBucket;
         CPLString m_osObjectKey;
 
-        static bool     GetConfiguration(CPLString& osStorageURL,
-                                         CPLString& osAuthToken);
+        static bool GetConfiguration(CPLString& osStorageURL,
+                                     CPLString& osAuthToken);
 
         static bool GetCached(const char* pszURLKey,
                               const char* pszUserKey,
@@ -67,10 +67,11 @@ class VSISwiftHandleHelper final: public IVSIS3LikeHandleHelper
                            CPLString& osAuthToken);
 
         // V3 Authentication
-        static bool CheckCredentialsV3();
-        static bool AuthV3(CPLString& osStorageURL,
+        static bool CheckCredentialsV3(const CPLString& osAuthType);
+        static bool AuthV3(const CPLString& osAuthType,
+                           CPLString& osStorageURL,
                            CPLString& osAuthToken);
-        static CPLJSONObject CreateAuthV3RequestObject();
+        static CPLJSONObject CreateAuthV3RequestObject(const CPLString& osAuthType);
         static bool GetAuthV3StorageURL(const CPLHTTPResult *psResult,
                                         CPLString& storageURL);
 


### PR DESCRIPTION
Two fixes for OpenStack Swift Objectstore endpoint URL detection:
1. When parsing an openstack list of endpoints, the swift endpoint may not necessarily be named "swift". However it will always have the `"type": "object-store"`. Change logic to look for `"type"`, rather than `"name"`.
2. OpenStack endpoint URLs can come in threes, eg: three different "interfaces" each with their own URL, for "public", "admin", or "internal". Add logic to check for interface type, look for "public" (or choose the first URL if "interface" not present).

OpenStack Swift feature addition: When using `OS_IDENTITY_API_VERSION=3`, in authVersion3 mode, allow the use of application_credential authentication if:
* OS_IDENTITY_API_VERSION == "3"
* OS_AUTH_TYPE == "v3applicationcredential"
* OS_APPLICATION_CREDENTIAL_ID is set
* OS_APPLICATION_CREDENTIAL_SECRET is set

This feature is useful in the case where it is not appropriate to store a user's Username and Password in the environment, an application credential should be used instead. See the [Keystone documentation page on Application Credentials](https://docs.openstack.org/keystone/queens/user/application_credentials.html) for more details.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

I'll need assistance to add test cases and documentation, if this is deemed appropriate.