### PR TITLE
Removed linux commands in makefile.vc

### DIFF
--- a/gdal/makefile.vc
+++ b/gdal/makefile.vc
@@ -187,6 +187,9 @@ third_party_dir:      port_dir
 
 lib_dist:	default
 	if not exist $(DISTDIR) mkdir $(DISTDIR)
+	copy .\port\*.h .\$(DISTDIR)
+	copy .\gcore\*.h .\$(DISTDIR)
+	copy .\ogr\*.h .\$(DISTDIR)
 	copy $(GDAL_LIB_NAME) .\$(DISTDIR)
 	copy $(GDAL_DLL) .\$(DISTDIR)
 	copy $(GDAL_PDB) .\$(DISTDIR)

--- a/gdal/makefile.vc
+++ b/gdal/makefile.vc
@@ -186,10 +186,10 @@ third_party_dir:      port_dir
 	cd ..
 
 lib_dist:	default
-	rm -rf $(DISTDIR)
-	mkdir $(DISTDIR)
-	cp $(GDAL_LIB_NAME) port\*.h gcore\*.h ogr\*.h $(DISTDIR)
-	zip -r $(DISTDIR).zip $(DISTDIR)
+	if not exist $(DISTDIR) mkdir $(DISTDIR)
+	copy $(GDAL_LIB_NAME) .\$(DISTDIR)
+	copy $(GDAL_DLL) .\$(DISTDIR)
+	copy $(GDAL_PDB) .\$(DISTDIR)
 
 $(GDAL_DLL): $(LIB_DEPENDS)
 	call <<clean_main_build_output.bat


### PR DESCRIPTION
makefile.vc was calling linux utilites: "rm", "cp" and "zip" inside of the windows makefile. This was causing an error when I was building the windows build on my local machine. I have updated the section to check if the $(DISTDIR) exists and if not make the directory and then copy the gdal build artefacts into the $(DISTDIR). 
