### PR TITLE
Changed setting of LIBS to append $saved_LIBS instead of $LIBS in configure

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -24765,7 +24765,7 @@ if ${ac_cv_lib_sqlite3_sqlite3_open+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lsqlite3 -L$ac_sqlite3_path/lib $LIBS"
+LIBS="-lsqlite3 -L$ac_sqlite3_path/lib $saved_LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -24822,7 +24822,7 @@ if ${ac_cv_lib_sqlite3_sqlite3_open+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lsqlite3  $LIBS"
+LIBS="-lsqlite3  $saved_LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -24871,7 +24871,7 @@ if ${ac_cv_lib_sqlite3_sqlite3_open+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lsqlite3 -L$ac_sqlite3_path_tmp/lib $LIBS"
+LIBS="-lsqlite3 -L$ac_sqlite3_path_tmp/lib $saved_LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 


### PR DESCRIPTION
In the configure script for sqlite it seems that when setting LIBS after checking for SQLITE, in some paths the variable $LIBS get set to "". Subsequently when setting LIBS up it then appends this empty variable, which causes SQLITE to fail durng configuration.

