### PR TITLE
Build: no longer build testepsg utility by default, …

### DIFF
--- a/gdal/apps/GNUmakefile
+++ b/gdal/apps/GNUmakefile
@@ -26,7 +26,6 @@ BIN_LIST += 	gdal_contour$(EXE) \
 		ogr2ogr$(EXE) \
 		ogrtindex$(EXE) \
 		ogrlineref$(EXE) \
-		testepsg$(EXE) \
 		gdalbuildvrt$(EXE)
 
 ifeq ($(GNM_ENABLED),yes)

--- a/gdal/apps/makefile.vc
+++ b/gdal/apps/makefile.vc
@@ -12,7 +12,7 @@ LIBS	=	$(GDALLIB)
 !IFDEF INCLUDE_OGR_FRMTS
 OGR_PROGRAMS =	gdal_contour.exe gdaltindex.exe gdal_rasterize.exe \
 		gdal_grid.exe ogrinfo.exe ogr2ogr.exe ogrtindex.exe ogrlineref.exe\
-		gdalbuildvrt.exe testepsg.exe
+		gdalbuildvrt.exe
 !ENDIF
 
 !IFDEF INCLUDE_GNM_FRMTS


### PR DESCRIPTION
which has been superseded by gdalsrsinfo for many years. It will be finally removed in GDAL 3.5
