### PR TITLE
Error msg when geometry is not supported in GeoJSON

### DIFF
--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
@@ -1079,9 +1079,9 @@ json_object* OGRGeoJSONWriteGeometry( const OGRGeometry* poGeometry,
                                             oOptions );
         else
         {
-            CPLDebug( "GeoJSON",
-                      "Unsupported geometry type detected. "
-                      "Feature gets NULL geometry assigned." );
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Unsupported GeoJSON geometry type detected. "
+                     "Feature gets NULL geometry assigned.");
         }
 
         if( poObjGeom != nullptr )

--- a/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+++ b/gdal/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
@@ -1080,7 +1080,7 @@ json_object* OGRGeoJSONWriteGeometry( const OGRGeometry* poGeometry,
         else
         {
             CPLError(CE_Failure, CPLE_NotSupported,
-                     "Unsupported GeoJSON geometry type detected. "
+                     "OGR geometry type unsupported as a GeoJSON geometry detected. "
                      "Feature gets NULL geometry assigned.");
         }
 


### PR DESCRIPTION
Transform CPLDebug into CPLError

Rationale:
This is a serious error condition that causes the function to fail and to set a null geometry for the feature
Without it, a NULL geometry is returned and there is no `LastErrorMsg`

It doesn't break any unit tests

Refs: #4004 
