### PR TITLE
Disable the libpng NEON optimization when using internal libpng

### DIFF
--- a/gdal/frmts/png/GNUmakefile
+++ b/gdal/frmts/png/GNUmakefile
@@ -6,7 +6,7 @@
 include ../../GDALmake.opt
 
 ifeq ($(PNG_SETTING),internal)
-XTRA_OPT =	-DPNG_IMPEXP= -Ilibpng
+XTRA_OPT =	-DPNG_IMPEXP= -DPNG_ARM_NEON_OPT=0 -Ilibpng
 OBJ = \
 	png.o \
 	pngerror.o \


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

On ARM, the gdal internal libpng source does not contain the NEON specific source code. The easy fix is to disable the optimization, as described in the pngpriv.h

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: AWS Linux 2, ARM
* Compiler: gcc 7.3.1
