### PR TITLE
OGRSpatialReference: Support GetLinearUnits for ellipsoidal and spherical coordinate systems that have a height axis

### DIFF
--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -1331,6 +1331,20 @@ def test_osr_basic_25():
     assert sr2 is None
 
 ###############################################################################
+# EPSG 4979, but overridden to be in Feet.
+
+
+def test_osr_basic_26():
+
+    srs = osr.SpatialReference()
+
+    srs.ImportFromEPSG(4979)
+
+    srs.SetLinearUnits('Foot', 0.3048)
+
+    assert srs.GetLinearUnits() == 0.3048
+
+###############################################################################
 # Test corner cases of osr.SetGeocCS()
 
 

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -2748,16 +2748,39 @@ double OGRSpatialReference::GetTargetLinearUnits( const char *pszTargetKey,
                 break;
             }
             auto csType = proj_cs_get_type(d->getPROJContext(), coordSys);
-            if(csType != PJ_CS_TYPE_CARTESIAN && csType != PJ_CS_TYPE_VERTICAL )
+
+            if( csType != PJ_CS_TYPE_CARTESIAN
+                && csType != PJ_CS_TYPE_VERTICAL
+                && csType != PJ_CS_TYPE_ELLIPSOIDAL
+                && csType != PJ_CS_TYPE_SPHERICAL )
             {
                 proj_destroy(coordSys);
                 break;
             }
 
+            int axis = 0;
+
+            if ( csType == PJ_CS_TYPE_ELLIPSOIDAL
+                 || csType == PJ_CS_TYPE_SPHERICAL )
+            {
+                const int axisCount = proj_cs_get_axis_count(
+                    d->getPROJContext(), coordSys);
+
+                if( axisCount == 3 )
+                {
+                    axis = 2;
+                }
+                else
+                {
+                    proj_destroy(coordSys);
+                    break;
+                }
+            }
+
             double dfConvFactor = 0.0;
             const char* pszUnitName = nullptr;
             if( !proj_cs_get_axis_info(
-                d->getPROJContext(), coordSys, 0, nullptr, nullptr, nullptr,
+                d->getPROJContext(), coordSys, axis, nullptr, nullptr, nullptr,
                 &dfConvFactor, &pszUnitName, nullptr, nullptr) )
             {
                 proj_destroy(coordSys);

--- a/gdal/ogr/ogrspatialreference.cpp
+++ b/gdal/ogr/ogrspatialreference.cpp
@@ -2422,7 +2422,8 @@ OGRErr OSRSetLinearUnitsAndUpdateParameters( OGRSpatialReferenceH hSRS,
  * \brief Set the linear units for the projection.
  *
  * This method creates a UNIT subnode with the specified values as a
- * child of the PROJCS, GEOCCS or LOCAL_CS node.
+ * child of the PROJCS, GEOCCS, GEOGCS or LOCAL_CS node. When called on a
+ * Geographic 3D CRS the vertical axis units will be set.
  *
  * This method does the same as the C function OSRSetLinearUnits().
  *
@@ -2597,8 +2598,9 @@ OGRErr OSRSetTargetLinearUnits( OGRSpatialReferenceH hSRS,
  * \brief Fetch linear projection units.
  *
  * If no units are available, a value of "Meters" and 1.0 will be assumed.
- * This method only checks directly under the PROJCS, GEOCCS or LOCAL_CS node
- * for units.
+ * This method only checks directly under the PROJCS, GEOCCS, GEOGCS or
+ * LOCAL_CS node for units. When called on a Geographic 3D CRS the vertical
+ * axis units will be returned.
  *
  * This method does the same thing as the C function OSRGetLinearUnits()
  *
@@ -2673,7 +2675,7 @@ double OSRGetLinearUnits( OGRSpatialReferenceH hSRS, char ** ppszName )
  *
  * @param pszTargetKey the key to look on. i.e. "PROJCS" or "VERT_CS". Might be
  * NULL, in which case PROJCS will be implied (and if not found, LOCAL_CS,
- * GEOCCS and VERT_CS are looked up)
+ * GEOCCS, GEOGCS and VERT_CS are looked up)
  * @param ppszName a pointer to be updated with the pointer to the units name.
  * The returned value remains internal to the OGRSpatialReference and should not
  * be freed, or modified.  It may be invalidated on the next


### PR DESCRIPTION
## What does this PR do?
This PR adds ellipsoidal and spherical coordinate system support for `OGRSpatialReference::GetLinearUnits`, as long as they have a third axis for height.

Before this PR, if you called `SetLinearUnits` on an ellipsoidal/spherical coordinate system with a non-`1.0` value it would store the units correctly, but if you followed that with a call to `GetLinearUnits` it would return `1.0`. However, this wasn't a problem with `GetTargetLinearUnits` because it would return the cached result.

I tested with the following code:

```
#include <gdal.h>
#include <ogr_spatialref.h>
#include <stdio.h>

int main() {
    {
        OGRSpatialReference srs;
        OGRErr err0 = srs.SetFromUserInput("EPSG:4979");
        OGRErr err1 = srs.SetLinearUnits("unnamed", 0.5);
        const double units = srs.GetLinearUnits();
        printf("Value: %f\n", units);
    }

    {
        OGRSpatialReference srs;
        OGRErr err0 = srs.SetFromUserInput("EPSG:4979");
        OGRErr err1 = srs.SetLinearUnits("unnamed", 0.5);
        const double units = srs.GetTargetLinearUnits("GEOGCS");
        printf("Value: %f\n", units);
    }
}
```

Before this PR: the first code block prints `1.0`. The second prints `0.5`.
After this PR: they both print `0.5`.

There's no mention of `GEOGCS` in the `GetLinearUnits` or `SetLinearUnits` docs, so I'm not sure if this omission is intentional. Thanks for reviewing and let me know if there is anything I should change.

## What are related issues/pull requests?
None

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
