### PR TITLE
OCI: Don't try to create new layer with TRUNCATE option (fixes #4027)

### DIFF
--- a/gdal/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
@@ -507,11 +507,13 @@ OGROCIDataSource::ICreateLayer( const char * pszLayerName,
 /*      away?                                                           */
 /* -------------------------------------------------------------------- */
     int iLayer;
+    bool bIsNewLayer = TRUE;
 
     if( CPLFetchBool( papszOptions, "TRUNCATE", false ) )
     {
         CPLDebug( "OCI", "Calling TruncateLayer for %s", pszLayerName );
         TruncateLayer( pszSafeLayerName );
+        bIsNewLayer = false;  // Oracle table already exists
     }
     else
     {
@@ -621,7 +623,7 @@ OGROCIDataSource::ICreateLayer( const char * pszLayerName,
     if( pszLoaderFile == nullptr )
         poLayer = new OGROCITableLayer( this, pszSafeLayerName, eType,
                                         EQUAL(szSRSId,"NULL") ? -1 : atoi(szSRSId),
-                                        TRUE, TRUE );
+                                        TRUE, bIsNewLayer);
     else
         poLayer =
             new OGROCILoaderLayer( this, pszSafeLayerName,


### PR DESCRIPTION
With TRUNCATE the Oracle table already exists and there should be a row in USERS_SDO_GEOM_METADATA, for which the extent will be updated.
Don't try to create a new row in USERS_SDO_GEOM_METADATA (otherwise fails with ORA-13223).

## What does this PR do?
OCI TRUNCATE option now works correctly (doesn't give exception).

## What are related issues/pull requests?
Fixes issue #4027 

## Tasklist

Test case - Create a table in Oracle from a source layer, and then try to reload the data into the same table:
```
ogr2ogr -progress -f OCI -nln OGR_TEST -lco GEOMETRY_NAME=geom -lco SRID=27700 -lco LAUNDER=YES OCI:/@mydb: test.gdb test_layer
ogr2ogr -progress -f OCI -nln OGR_TEST -lco TRUNCATE=YES -lco GEOMETRY_NAME=geom -lco SRID=27700 -lco LAUNDER=YES OCI:/@mydb: test.gdb test_layer
```

## Environment
* OS: Windows 10 x64
* Compiler: MSCV 2015
