### PR TITLE
VRT: Support named arguments to C++ derived band pixel functions

### DIFF
--- a/autotest/gcore/data/pixfun_pow.vrt
+++ b/autotest/gcore/data/pixfun_pow.vrt
@@ -1,0 +1,14 @@
+<VRTDataset rasterXSize="20" rasterYSize="20">
+  <VRTRasterBand dataType="Float32" band="1" subClass="VRTDerivedRasterBand">
+    <Description>Power</Description>
+    <PixelFunctionType>pow</PixelFunctionType>
+    <PixelFunctionArguments power="3.14" />
+    <SourceTransferType>Float32</SourceTransferType>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">float32.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20"/>
+      <DstRect xOff="0" yOff="0" xSize="20" ySize="20"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -620,3 +620,22 @@ def test_pixfun_dB2pow():
 
 
 ###############################################################################
+# Verify raising values to a power
+
+def test_pixfun_pow():
+
+    filename = 'data/pixfun_pow.vrt'
+    ds = gdal.OpenShared(filename, gdal.GA_ReadOnly)
+    assert ds is not None, ('Unable to open "%s" dataset.' % filename)
+    data = ds.GetRasterBand(1).ReadAsArray()
+
+    reffilename = 'data/float32.tif'
+    refds = gdal.Open(reffilename)
+    assert refds is not None, ('Unable to open "%s" dataset.' % reffilename)
+    refdata = refds.GetRasterBand(1).ReadAsArray()
+    refdata = refdata.astype('float64')
+
+    assert numpy.allclose(data, refdata**3.14)
+
+
+###############################################################################

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -273,7 +273,7 @@ def test_vrtderived_7():
             print(err)
         assert 'Checksum=0' in ret, err
 
-    
+
 ###############################################################################
 # Check that GDAL_VRT_ENABLE_PYTHON=NO or undefined is honored
 
@@ -341,17 +341,6 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
     syntax_error
 ]]>
      </PixelFunctionCode>
-  </VRTRasterBand>
-</VRTDataset>
-""")
-    assert ds is None
-
-    # PixelFunctionArguments can only be used with Python
-    with gdaltest.error_handler():
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
-  <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
-    <PixelFunctionType>identity</PixelFunctionType>
-    <PixelFunctionArguments foo="bar"/>
   </VRTRasterBand>
 </VRTDataset>
 """)
@@ -522,7 +511,7 @@ uncallable_object = True
         print(gdal.GetLastErrorMsg())
         pytest.fail('invalid checksum')
 
-    
+
 
 def vrtderived_code_that_only_makes_sense_with_GDAL_VRT_ENABLE_PYTHON_equal_IF_SAFE_but_that_is_now_disabled():
 
@@ -578,7 +567,7 @@ def my_func(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize,
         print(gdal.GetLastErrorMsg())
         pytest.fail('invalid checksum')
 
-    
+
 ###############################################################################
 # Check Python function in another module
 
@@ -650,7 +639,7 @@ def test_vrtderived_10():
             print(gdal.GetLastErrorMsg())
             pytest.fail('invalid checksum')
 
-    
+
 ###############################################################################
 # Test serializing with python code
 
@@ -736,7 +725,7 @@ def test_vrtderived_12():
             print(gdal.GetLastErrorMsg())
             pytest.fail('invalid checksum')
 
-    
+
 ###############################################################################
 # Test translating a Python derived VRT
 
@@ -849,6 +838,6 @@ def test_vrtderived_cleanup():
         os.remove('tmp/derived.vrt')
     except OSError:
         pass
-    
+
 
 

--- a/gdal/doc/source/drivers/raster/vrt.rst
+++ b/gdal/doc/source/drivers/raster/vrt.rst
@@ -824,7 +824,7 @@ with derived bands that use this function), an application calls
 
 .. code-block:: cpp
 
-    GDALAddDerivedBandPixelFunc("MyFirstFunction", TestFunction);
+    GDALAddDerivedBandPixelFunc("MyFirstFunction", TestFunction, nullptr);
 
 A good time to do this is at the beginning of an application when the
 GDAL drivers are registered.

--- a/gdal/doc/source/drivers/raster/vrt.rst
+++ b/gdal/doc/source/drivers/raster/vrt.rst
@@ -271,9 +271,9 @@ The allowed subelements for VRTRasterBand are :
 
 - **AveragedSource**: The AveragedSource is derived from the SimpleSource and shares the same properties except that it uses an averaging resampling instead of a nearest neighbour algorithm as in SimpleSource, when the size of the destination rectangle is not the same as the size of the source rectangle. Note: a more general mechanism to specify resampling algorithms can be used. See above paragraph about the 'resampling' attribute.
 
-- **ComplexSource**: The ComplexSource_ is derived from the SimpleSource (so it shares the SourceFilename, SourceBand, SrcRect and DestRect elements), but it provides support to rescale and offset the range of the source values. Certain regions of the source can be masked by specifying the NODATA value, or starting with GDAL 3.3, with the <UseMaskBand>true</UseMaskBand> element.
+- **ComplexSource**: The ComplexSource_ is derived from the SimpleSource (so it shares the SourceFilename, SourceBand, SrcRect and DstRect elements), but it provides support to rescale and offset the range of the source values. Certain regions of the source can be masked by specifying the NODATA value, or starting with GDAL 3.3, with the <UseMaskBand>true</UseMaskBand> element.
 
-- **KernelFilteredSource**: The KernelFilteredSource_ is a pixel source derived from the Simple Source (so it shares the SourceFilename, SourceBand, SrcRect and DestRect elements, but it also passes the data through a simple filtering kernel specified with the Kernel element.
+- **KernelFilteredSource**: The KernelFilteredSource_ is a pixel source derived from the Simple Source (so it shares the SourceFilename, SourceBand, SrcRect and DstRect elements, but it also passes the data through a simple filtering kernel specified with the Kernel element.
 
 - **MaskBand**: This element represents a mask band that is specific to the VRTRasterBand it contains. It must contain a single VRTRasterBand child element, that is the description of the mask band itself.
 
@@ -720,11 +720,11 @@ registered with GDAL using a unique key.
 Using derived bands you can create VRT datasets that manipulate bands on
 the fly without having to create new band files on disk.  For example, you
 might want to generate a band using four source bands from a nine band input
-dataset (x0, x3, x4, and x8):
+dataset (x0, x3, x4, and x8) and some constant y:
 
 .. code-block:: c
 
-  band_value = sqrt((x3*x3+x4*x4)/(x0*x8));
+  band_value = sqrt((x3*x3+x4*x4)/(x0*x8)) + y;
 
 You could write the pixel function to compute this value and then register
 it with GDAL with the name "MyFirstFunction".  Then, the following VRT XML
@@ -737,6 +737,7 @@ could be used to display this derived band:
         <VRTRasterBand dataType="Float32" band="1" subClass="VRTDerivedRasterBand">
             <Description>Magnitude</Description>
             <PixelFunctionType>MyFirstFunction</PixelFunctionType>
+            <PixelFunctionArguments y="4" />
             <SimpleSource>
                 <SourceFilename relativeToVRT="1">nine_band.dat</SourceFilename>
                 <SourceBand>1</SourceBand>
@@ -764,6 +765,11 @@ could be used to display this derived band:
         </VRTRasterBand>
     </VRTDataset>
 
+.. note::
+
+    PixelFunctionArguments can only be used with C++ pixel functions in GDAL versions 3.4 and greater.
+
+
 In addition to the subclass specification (VRTDerivedRasterBand) and
 the PixelFunctionType value, there is another new parameter that can come
 in handy: SourceTransferType.  Typically the source rasters are obtained
@@ -788,7 +794,7 @@ calling the pixel function, and the imaginary portion would be lost.
 Default Pixel Functions
 +++++++++++++++++++++++
 
-Starting with GDAL 2.2, GDAL provides a set of default pixel functions that can be used without writing new code:
+GDAL provides a set of default pixel functions that can be used without writing new code:
 
 - **real**: extract real part from a single raster band (just a copy if the input is non-complex)
 - **imag**: extract imaginary part from a single raster band (0 for non-complex)
@@ -803,6 +809,7 @@ Starting with GDAL 2.2, GDAL provides a set of default pixel functions that can 
 - **inv**: inverse (1./x). Note: no check is performed on zero division
 - **intensity**: computes the intensity Re(x*conj(x)) of a single raster band (real or complex)
 - **sqrt**:perform the square root of a single raster band (real only)
+- **pow**: raise a single raster band to a constant power, specified with argument "power" (real only)
 - **log10**: compute the logarithm (base 10) of the abs of a single raster band (real or complex): log10( abs( x ) )
 - **dB**: perform conversion to dB of the abs of a single raster band (real or complex): 20. * log10( abs( x ) )
 - **dB2amp**: perform scale conversion from logarithmic to linear (amplitude) (i.e. 10 ^ ( x / 20 ) ) of a single raster band (real only)
@@ -813,7 +820,7 @@ Writing Pixel Functions
 
 To register this function with GDAL (prior to accessing any VRT datasets
 with derived bands that use this function), an application calls
-GDALAddDerivedBandPixelFunc with a key and a GDALDerivedPixelFunc:
+:cpp:func:`GDALAddDerivedBandPixelFuncWithArgs` with a key and a :cpp:type:`GDALDerivedPixelFuncWithArgs`:
 
 .. code-block:: cpp
 
@@ -822,10 +829,10 @@ GDALAddDerivedBandPixelFunc with a key and a GDALDerivedPixelFunc:
 A good time to do this is at the beginning of an application when the
 GDAL drivers are registered.
 
-A :cpp:type:`GDALDerivedPixelFunc` is defined with a signature similar to :cpp:func:`GDALRasterBand::IRasterIO`:
+A :cpp:type:`GDALDerivedPixelFuncWithArgs` is defined with a signature similar to :cpp:func:`GDALRasterBand::IRasterIO`:
 
 
-.. cpp:function:: CPL_Err TestFunction(void** papoSources, int nSources, void* pData, int nBufXSize, int nBufYSize, GDALDataType eSrcType, GDALDataType eBufType, int nPixelSpace, int nLineSpace)
+.. cpp:function:: CPLErr TestFunction(void** papoSources, int nSources, void* pData, int nBufXSize, int nBufYSize, GDALDataType eSrcType, GDALDataType eBufType, int nPixelSpace, int nLineSpace, CSLConstList papszArgs)
 
    :param papoSources: A pointer to packed rasters; one per source.  The
     datatype of all will be the same, specified in the ``eSrcType`` parameter.
@@ -857,6 +864,11 @@ A :cpp:type:`GDALDerivedPixelFunc` is defined with a signature similar to :cpp:f
    :param nLineSpace: The byte offset from the start of one scanline in
     pData to the start of the next.
 
+   :param papszArgs: An optional string list of named function arguments (e.g. ``y=4``)
+
+
+It is also possible to register a :cpp:type:`GDALDerivedPixelFunc` (which omits the final :cpp:type:`CSLConstList` argument) using :cpp:func:`GDALAddDerivedBandPixelFunc`.
+
 The following is an implementation of the pixel function:
 
 .. code-block:: cpp
@@ -866,7 +878,8 @@ The following is an implementation of the pixel function:
     CPLErr TestFunction(void **papoSources, int nSources, void *pData,
                         int nXSize, int nYSize,
                         GDALDataType eSrcType, GDALDataType eBufType,
-                        int nPixelSpace, int nLineSpace)
+                        int nPixelSpace, int nLineSpace,
+                        CSLConstList papszArgs)
     {
         int ii, iLine, iCol;
         double pix_val;
@@ -874,6 +887,13 @@ The following is an implementation of the pixel function:
 
         // ---- Init ----
         if (nSources != 4) return CE_Failure;
+
+        const char *pszY = CSLFetchNameValue(papszArgs, "y");
+        if (pszY == nullptr) return CE_Failure;
+
+        char *end = nullptr;
+        double y = std::strtod(pszY, &end);
+        if (end == pszY) return CE_Failure; // Could not parse
 
         // ---- Set pixels ----
         for( iLine = 0; iLine < nYSize; iLine++ )
@@ -887,7 +907,7 @@ The following is an implementation of the pixel function:
                 x4 = SRCVAL(papoSources[2], eSrcType, ii);
                 x8 = SRCVAL(papoSources[3], eSrcType, ii);
 
-                pix_val = sqrt((x3*x3+x4*x4)/(x0*x8));
+                pix_val = sqrt((x3*x3+x4*x4)/(x0*x8)) + y;
 
                 GDALCopyWords(&pix_val, GDT_Float64, 0,
                             ((GByte *)pData) + nLineSpace * iLine + iCol * nPixelSpace,
@@ -913,8 +933,6 @@ set to VRTDerivedRasterBand) are :
 - **PixelFunctionType** (required): Must be set to a function name that will be defined as a inline Python module in PixelFunctionCode element or as the form "module_name.function_name" to refer to a function in an external Python module
 
 - **PixelFunctionLanguage** (required): Must be set to Python.
-
-- **PixelFunctionArguments** (optional): It is possible to pass arguments to the Python pixel function by defining attributes in the PixelFunctionArguments element.
 
 - **PixelFunctionCode** (required if PixelFunctionType is of the form "function_name", ignored otherwise). The in-lined code of a Python module, that must be at least have a function whose name is given by PixelFunctionType.
 

--- a/gdal/frmts/vrt/pixelfunctions.cpp
+++ b/gdal/frmts/vrt/pixelfunctions.cpp
@@ -876,7 +876,7 @@ static CPLErr dB2PowPixelFunc( void **papoSources, int nSources, void *pData,
 static CPLErr PowPixelFunc( void **papoSources, int nSources, void *pData,
                                int nXSize, int nYSize,
                                GDALDataType eSrcType, GDALDataType eBufType,
-                               int nPixelSpace, int nLineSpace, char **papszArgs ) {
+                               int nPixelSpace, int nLineSpace, CSLConstList papszArgs ) {
     /* ---- Init ---- */
     if( nSources != 1 ) return CE_Failure;
     if( GDALDataTypeIsComplex( eSrcType ) ) return CE_Failure;

--- a/gdal/frmts/vrt/pixelfunctions.cpp
+++ b/gdal/frmts/vrt/pixelfunctions.cpp
@@ -976,7 +976,7 @@ CPLErr GDALRegisterDefaultPixelFunc()
     GDALAddDerivedBandPixelFunc("dB", DBPixelFunc);
     GDALAddDerivedBandPixelFunc("dB2amp", dB2AmpPixelFunc);
     GDALAddDerivedBandPixelFunc("dB2pow", dB2PowPixelFunc);
-    GDALAddDerivedBandPixelFuncWithArgs("pow", PowPixelFunc);
+    GDALAddDerivedBandPixelFuncWithArgs("pow", PowPixelFunc, nullptr);
 
     return CE_None;
 }

--- a/gdal/frmts/vrt/pixelfunctions.cpp
+++ b/gdal/frmts/vrt/pixelfunctions.cpp
@@ -882,11 +882,19 @@ static CPLErr PowPixelFunc( void **papoSources, int nSources, void *pData,
     if( GDALDataTypeIsComplex( eSrcType ) ) return CE_Failure;
 
     const char *pszPower = CSLFetchNameValue(papszArgs, "power");
-    if ( pszPower == nullptr ) return CE_Failure;
+    if ( pszPower == nullptr )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Missing pixel function argument: power");
+        return CE_Failure;
+    }
 
     char *end = nullptr;
     double power = std::strtod(pszPower, &end);
-    if ( end == pszPower ) return CE_Failure;
+    if ( end == pszPower )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to parse pixel function argument: power");
+        return CE_Failure;
+    }
 
     /* ---- Set pixels ---- */
     for( int iLine = 0, ii = 0; iLine < nYSize; ++iLine ) {

--- a/gdal/frmts/vrt/pixelfunctions.cpp
+++ b/gdal/frmts/vrt/pixelfunctions.cpp
@@ -873,6 +873,40 @@ static CPLErr dB2PowPixelFunc( void **papoSources, int nSources, void *pData,
                               nPixelSpace, nLineSpace, 10.0, 10.0);
 }  // dB2PowPixelFunc
 
+static CPLErr PowPixelFunc( void **papoSources, int nSources, void *pData,
+                               int nXSize, int nYSize,
+                               GDALDataType eSrcType, GDALDataType eBufType,
+                               int nPixelSpace, int nLineSpace, char **papszArgs ) {
+    /* ---- Init ---- */
+    if( nSources != 1 ) return CE_Failure;
+    if( GDALDataTypeIsComplex( eSrcType ) ) return CE_Failure;
+
+    const char *pszPower = CSLFetchNameValue(papszArgs, "power");
+    if ( pszPower == nullptr ) return CE_Failure;
+
+    char *end = nullptr;
+    double power = std::strtod(pszPower, &end);
+    if ( end == pszPower ) return CE_Failure;
+
+    /* ---- Set pixels ---- */
+    for( int iLine = 0, ii = 0; iLine < nYSize; ++iLine ) {
+        for( int iCol = 0; iCol < nXSize; ++iCol, ++ii ) {
+            const double dfPixVal = std::pow(
+                    SRCVAL(papoSources[0], eSrcType, ii),
+                    power);
+
+            GDALCopyWords(
+                    &dfPixVal, GDT_Float64, 0,
+                    static_cast<GByte *>(pData) + nLineSpace * iLine +
+                    iCol * nPixelSpace, eBufType, nPixelSpace, 1);
+        }
+    }
+
+    /* ---- Return success ---- */
+    return CE_None;
+
+}
+
 /************************************************************************/
 /*                     GDALRegisterDefaultPixelFunc()                   */
 /************************************************************************/
@@ -934,6 +968,7 @@ CPLErr GDALRegisterDefaultPixelFunc()
     GDALAddDerivedBandPixelFunc("dB", DBPixelFunc);
     GDALAddDerivedBandPixelFunc("dB2amp", dB2AmpPixelFunc);
     GDALAddDerivedBandPixelFunc("dB2pow", dB2PowPixelFunc);
+    GDALAddDerivedBandPixelFuncWithArgs("pow", PowPixelFunc);
 
     return CE_None;
 }

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -782,7 +782,8 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
     static CPLErr AddPixelFunction( const char *pszFuncName,
                                     GDALDerivedPixelFunc pfnPixelFunc );
     static CPLErr AddPixelFunction( const char *pszFuncName,
-                                    GDALDerivedPixelFuncWithArgs pfnPixelFunc );
+                                    GDALDerivedPixelFuncWithArgs pfnPixelFunc,
+                                    const char *pszMetadata);
 
     static PixelFunc* GetPixelFunction( const char *pszFuncName );
 

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -41,6 +41,7 @@
 #include "gdal_vrt.h"
 #include "gdal_rat.h"
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <vector>
@@ -761,6 +762,8 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
     char *pszFuncName;
     GDALDataType eSourceTransferType;
 
+    using PixelFunc = std::function<CPLErr(void**, int, void*, int, int, GDALDataType, GDALDataType, int, int, char**)>;
+
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand );
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand,
                           GDALDataType eType, int nXSize, int nYSize );
@@ -778,7 +781,10 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
 
     static CPLErr AddPixelFunction( const char *pszFuncName,
                                     GDALDerivedPixelFunc pfnPixelFunc );
-    static GDALDerivedPixelFunc GetPixelFunction( const char *pszFuncName );
+    static CPLErr AddPixelFunction( const char *pszFuncName,
+                                    GDALDerivedPixelFuncWithArgs pfnPixelFunc );
+
+    static PixelFunc* GetPixelFunction( const char *pszFuncName );
 
     void SetPixelFunctionName( const char *pszFuncName );
     void SetSourceTransferType( GDALDataType eDataType );

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -762,7 +762,7 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
     char *pszFuncName;
     GDALDataType eSourceTransferType;
 
-    using PixelFunc = std::function<CPLErr(void**, int, void*, int, int, GDALDataType, GDALDataType, int, int, char**)>;
+    using PixelFunc = std::function<CPLErr(void**, int, void*, int, int, GDALDataType, GDALDataType, int, int, CSLConstList)>;
 
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand );
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand,

--- a/gdal/frmts/vrt/vrtderivedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtderivedrasterband.cpp
@@ -248,7 +248,7 @@ GDALAddDerivedBandPixelFunc( const char *pszFuncName,
     osMapPixelFunction[pszFuncName] = [pfnNewFunction](void **papoSources, int nSources, void *pData,
                                          int nBufXSize, int nBufYSize,
                                          GDALDataType eSrcType, GDALDataType eBufType,
-                                         int nPixelSpace, int nLineSpace, char** papszFunctionArgs) {
+                                         int nPixelSpace, int nLineSpace, CSLConstList papszFunctionArgs) {
         (void) papszFunctionArgs;
         return pfnNewFunction(papoSources, nSources, pData, nBufXSize, nBufYSize,
                               eSrcType, eBufType, nPixelSpace, nLineSpace);
@@ -272,6 +272,7 @@ GDALAddDerivedBandPixelFunc( const char *pszFuncName,
  *  replaced with the new one.
  *
  * @return CE_None, invalid (NULL) parameters are currently ignored.
+ * @since GDAL 3.4
  */
 CPLErr CPL_STDCALL
 GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,

--- a/gdal/frmts/vrt/vrtderivedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtderivedrasterband.cpp
@@ -270,19 +270,23 @@ GDALAddDerivedBandPixelFunc( const char *pszFuncName,
  * @param pfnNewFunction Pixel function associated with name.  An
  *  existing pixel function registered with the same name will be
  *  replaced with the new one.
+ * @param pszMetadata Pixel function metadata (not currently implemented)
  *
  * @return CE_None, invalid (NULL) parameters are currently ignored.
  * @since GDAL 3.4
  */
 CPLErr CPL_STDCALL
 GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,
-                                    GDALDerivedPixelFuncWithArgs pfnNewFunction )
+                                    GDALDerivedPixelFuncWithArgs pfnNewFunction,
+                                    const char *pszMetadata)
 {
     if( pszFuncName == nullptr || pszFuncName[0] == '\0' ||
         pfnNewFunction == nullptr )
     {
         return CE_None;
     }
+
+    (void) pszMetadata;
 
     osMapPixelFunction[pszFuncName] = pfnNewFunction;
 
@@ -313,9 +317,11 @@ VRTDerivedRasterBand::AddPixelFunction(
 
 CPLErr
 VRTDerivedRasterBand::AddPixelFunction(
-        const char *pszFuncName, GDALDerivedPixelFuncWithArgs pfnNewFunction )
+        const char *pszFuncName,
+        GDALDerivedPixelFuncWithArgs pfnNewFunction,
+        const char *pszMetadata)
 {
-    return GDALAddDerivedBandPixelFuncWithArgs(pszFuncName, pfnNewFunction);
+    return GDALAddDerivedBandPixelFuncWithArgs(pszFuncName, pfnNewFunction, pszMetadata);
 }
 
 /************************************************************************/

--- a/gdal/frmts/vrt/vrtderivedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtderivedrasterband.cpp
@@ -52,7 +52,7 @@ using namespace GDALPy;
 #define GDAL_VRT_ENABLE_PYTHON_DEFAULT "TRUSTED_MODULES"
 #endif
 
-static std::map<CPLString, GDALDerivedPixelFunc> osMapPixelFunction;
+static std::map<CPLString, VRTDerivedRasterBand::PixelFunc> osMapPixelFunction;
 
 /* Flags for getting buffers */
 #define PyBUF_WRITABLE 0x0001
@@ -245,6 +245,44 @@ GDALAddDerivedBandPixelFunc( const char *pszFuncName,
       return CE_None;
     }
 
+    osMapPixelFunction[pszFuncName] = [pfnNewFunction](void **papoSources, int nSources, void *pData,
+                                         int nBufXSize, int nBufYSize,
+                                         GDALDataType eSrcType, GDALDataType eBufType,
+                                         int nPixelSpace, int nLineSpace, char** papszFunctionArgs) {
+        (void) papszFunctionArgs;
+        return pfnNewFunction(papoSources, nSources, pData, nBufXSize, nBufYSize,
+                              eSrcType, eBufType, nPixelSpace, nLineSpace);
+    };
+
+    return CE_None;
+}
+
+/**
+ * This adds a pixel function to the global list of available pixel
+ * functions for derived bands.  Pixel functions must be registered
+ * in this way before a derived band tries to access data.
+ *
+ * Derived bands are stored with only the name of the pixel function
+ * that it will apply, and if a pixel function matching the name is not
+ * found the IRasterIO() call will do nothing.
+ *
+ * @param pszFuncName Name used to access pixel function
+ * @param pfnNewFunction Pixel function associated with name.  An
+ *  existing pixel function registered with the same name will be
+ *  replaced with the new one.
+ *
+ * @return CE_None, invalid (NULL) parameters are currently ignored.
+ */
+CPLErr CPL_STDCALL
+GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,
+                                    GDALDerivedPixelFuncWithArgs pfnNewFunction )
+{
+    if( pszFuncName == nullptr || pszFuncName[0] == '\0' ||
+        pfnNewFunction == nullptr )
+    {
+        return CE_None;
+    }
+
     osMapPixelFunction[pszFuncName] = pfnNewFunction;
 
     return CE_None;
@@ -256,7 +294,7 @@ GDALAddDerivedBandPixelFunc( const char *pszFuncName,
  * This adds a pixel function to the global list of available pixel
  * functions for derived bands.
  *
- * This is the same as the c function GDALAddDerivedBandPixelFunc()
+ * This is the same as the C function GDALAddDerivedBandPixelFunc()
  *
  * @param pszFuncName Name used to access pixel function
  * @param pfnNewFunction Pixel function associated with name.  An
@@ -272,6 +310,13 @@ VRTDerivedRasterBand::AddPixelFunction(
     return GDALAddDerivedBandPixelFunc(pszFuncName, pfnNewFunction);
 }
 
+CPLErr
+VRTDerivedRasterBand::AddPixelFunction(
+        const char *pszFuncName, GDALDerivedPixelFuncWithArgs pfnNewFunction )
+{
+    return GDALAddDerivedBandPixelFuncWithArgs(pszFuncName, pfnNewFunction);
+}
+
 /************************************************************************/
 /*                           GetPixelFunction()                         */
 /************************************************************************/
@@ -285,7 +330,7 @@ VRTDerivedRasterBand::AddPixelFunction(
  * @return A derived band pixel function, or NULL if none have been
  * registered for pszFuncName.
  */
-GDALDerivedPixelFunc
+VRTDerivedRasterBand::PixelFunc*
 VRTDerivedRasterBand::GetPixelFunction( const char *pszFuncName )
 {
     if( pszFuncName == nullptr || pszFuncName[0] == '\0' )
@@ -293,13 +338,12 @@ VRTDerivedRasterBand::GetPixelFunction( const char *pszFuncName )
         return nullptr;
     }
 
-    std::map<CPLString, GDALDerivedPixelFunc>::iterator oIter =
-        osMapPixelFunction.find(pszFuncName);
+    auto oIter = osMapPixelFunction.find(pszFuncName);
 
     if( oIter == osMapPixelFunction.end())
         return nullptr;
 
-    return oIter->second;
+    return &(oIter->second);
 }
 
 /************************************************************************/
@@ -812,12 +856,12 @@ CPLErr VRTDerivedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
     }
 
     /* ---- Get pixel function for band ---- */
-    GDALDerivedPixelFunc pfnPixelFunc = nullptr;
+    PixelFunc* poPixelFunc = nullptr;
 
     if( EQUAL(m_poPrivate->m_osLanguage, "C") )
     {
-        pfnPixelFunc = VRTDerivedRasterBand::GetPixelFunction(pszFuncName);
-        if( pfnPixelFunc == nullptr )
+        poPixelFunc = VRTDerivedRasterBand::GetPixelFunction(pszFuncName);
+        if( poPixelFunc == nullptr )
         {
             CPLError( CE_Failure, CPLE_IllegalArg,
                     "VRTDerivedRasterBand::IRasterIO:"
@@ -1153,11 +1197,23 @@ CPLErr VRTDerivedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
             VSIFree(pabyTmpBuffer);
         }
     }
-    else if( eErr == CE_None && pfnPixelFunc != nullptr ) {
-        eErr = pfnPixelFunc( static_cast<void **>( pBuffers ), nSources,
-                             pData, nBufXSize, nBufYSize,
-                             eSrcType, eBufType, static_cast<int>(nPixelSpace),
-                             static_cast<int>(nLineSpace) );
+    else if( eErr == CE_None && poPixelFunc != nullptr )
+    {
+        char **papszArgs = nullptr;
+
+        for (const auto &oArg : m_poPrivate->m_oFunctionArgs) {
+            const char *pszKey = oArg.first.c_str();
+            const char *pszValue = oArg.second.c_str();
+            papszArgs = CSLSetNameValue(papszArgs, pszKey, pszValue);
+        }
+
+        eErr = (*poPixelFunc)(static_cast<void **>( pBuffers ), nSources,
+                              pData, nBufXSize, nBufYSize,
+                              eSrcType, eBufType, static_cast<int>(nPixelSpace),
+                              static_cast<int>(nLineSpace),
+                              papszArgs);
+
+        CSLDestroy(papszArgs);
     }
 end:
     // Release buffers.
@@ -1249,12 +1305,6 @@ CPLErr VRTDerivedRasterBand::XMLInit( CPLXMLNode *psTree,
     CPLXMLNode* psArgs = CPLGetXMLNode( psTree, "PixelFunctionArguments" );
     if( psArgs != nullptr )
     {
-        if( !EQUAL(m_poPrivate->m_osLanguage, "Python") )
-        {
-            CPLError(CE_Failure, CPLE_NotSupported,
-                     "PixelFunctionArguments can only be used with Python");
-            return CE_Failure;
-        }
         for( CPLXMLNode* psIter = psArgs->psChild;
                          psIter != nullptr;
                          psIter = psIter->psNext )

--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -922,7 +922,7 @@ typedef CPLErr
                                 int nBufXSize, int nBufYSize,
                                 GDALDataType eSrcType, GDALDataType eBufType,
                                 int nPixelSpace, int nLineSpace,
-                                char** papszFunctionArgs);
+                                CSLConstList papszFunctionArgs);
 
 GDALDataType CPL_DLL CPL_STDCALL GDALGetRasterDataType( GDALRasterBandH );
 void CPL_DLL CPL_STDCALL

--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -915,6 +915,15 @@ typedef CPLErr
                         GDALDataType eSrcType, GDALDataType eBufType,
                         int nPixelSpace, int nLineSpace);
 
+/** Type of functions to pass to GDALAddDerivedBandPixelFuncWithArgs.
+ * @since GDAL 3.4 */
+typedef CPLErr
+(*GDALDerivedPixelFuncWithArgs)(void **papoSources, int nSources, void *pData,
+                                int nBufXSize, int nBufYSize,
+                                GDALDataType eSrcType, GDALDataType eBufType,
+                                int nPixelSpace, int nLineSpace,
+                                char** papszFunctionArgs);
+
 GDALDataType CPL_DLL CPL_STDCALL GDALGetRasterDataType( GDALRasterBandH );
 void CPL_DLL CPL_STDCALL
 GDALGetBlockSize( GDALRasterBandH, int * pnXSize, int * pnYSize );
@@ -1052,6 +1061,8 @@ CPLErr CPL_DLL CPL_STDCALL GDALSetDefaultRAT( GDALRasterBandH,
                                               GDALRasterAttributeTableH );
 CPLErr CPL_DLL CPL_STDCALL GDALAddDerivedBandPixelFunc( const char *pszName,
                                     GDALDerivedPixelFunc pfnPixelFunc );
+CPLErr CPL_DLL CPL_STDCALL GDALAddDerivedBandPixelFuncWithArgs( const char *pszName,
+                                                                GDALDerivedPixelFuncWithArgs pfnPixelFunc );
 
 GDALRasterBandH CPL_DLL CPL_STDCALL GDALGetMaskBand( GDALRasterBandH hBand );
 int CPL_DLL CPL_STDCALL GDALGetMaskFlags( GDALRasterBandH hBand );

--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -1062,7 +1062,8 @@ CPLErr CPL_DLL CPL_STDCALL GDALSetDefaultRAT( GDALRasterBandH,
 CPLErr CPL_DLL CPL_STDCALL GDALAddDerivedBandPixelFunc( const char *pszName,
                                     GDALDerivedPixelFunc pfnPixelFunc );
 CPLErr CPL_DLL CPL_STDCALL GDALAddDerivedBandPixelFuncWithArgs( const char *pszName,
-                                                                GDALDerivedPixelFuncWithArgs pfnPixelFunc );
+                                                                GDALDerivedPixelFuncWithArgs pfnPixelFunc,
+                                                                const char *pszMetadata);
 
 GDALRasterBandH CPL_DLL CPL_STDCALL GDALGetMaskBand( GDALRasterBandH hBand );
 int CPL_DLL CPL_STDCALL GDALGetMaskFlags( GDALRasterBandH hBand );


### PR DESCRIPTION
## What does this PR do?

This commit introduces a new pixel function signature,
GDALDerivedPixelFuncWithArgs, that extends GDALDerivedPixelFunc with an
additional argument of named string arguments. These arguments can be
specified using the PixelFunctionArguments tag already used for pixel
functions defined in Python. It is the responsibility of the pixel
function to check the validity of its own arguments.

## What are related issues/pull requests?

Not aware of any.

## Tasklist

 - [X] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed
