### PR TITLE
Fix -Wunused-but-set-variable warning.

### DIFF
--- a/gdal/frmts/msgn/msg_reader_core.cpp
+++ b/gdal/frmts/msgn/msg_reader_core.cpp
@@ -236,13 +236,15 @@ void Msg_reader_core::read_metadata_block(VSILFILE* fin) {
 
 #ifdef DEBUG
     printf("lines = %u, cols = %u\n", _lines, _columns);/*ok*/
+    int records_per_line = 0;
 #endif // DEBUG
 
-    int records_per_line = 0;
     for (i=0; i < MSG_NUM_CHANNELS; i++) {
         if (_sec_header.selectedBandIds.value[i] == 'X') {
             _bands[i] = 1;
+#ifdef DEBUG
             records_per_line += (i == (MSG_NUM_CHANNELS-1)) ? 3 : 1;
+#endif // DEBUG
         } else {
             _bands[i] = 0;
         }


### PR DESCRIPTION
Mask the records_per_line variable when compiling with -DNDEBUG.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

It fixes compilation with `-Werror` on newer Clang versions. More specifically, it fixes the `-Wunused-but-set-variable` warning. This one is a bit more annoying than other warnings as it cannot be easily disabled by setting `CXXFLAGS=-Wno-error=unused-but-set-variable` because the configure script appends a `-Wall` *after* the `CXXFLAGS` so it re-activates the warning, which then breaks the compilation when `-Werror` is also set.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: `unknown`
* Compiler: Clang 13 cross-compiling using Emscripten.
