### PR TITLE
rasterio.cpp: fixed progress calculation

### DIFF
--- a/gdal/gcore/rasterio.cpp
+++ b/gdal/gcore/rasterio.cpp
@@ -4142,7 +4142,7 @@ GDALDataset::BlockBasedRasterIO( GDALRWFlag eRWFlag,
 
             if( psExtraArg->pfnProgress != nullptr &&
                 !psExtraArg->pfnProgress(
-                    1.0 * std::max(nBufYSize,
+                    1.0 * std::min(nBufYSize,
                                    iBufYOff + nChunkYSize) /
                     nBufYSize, "", psExtraArg->pProgressData) )
             {


### PR DESCRIPTION


<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixed progress calculation in GDALDataset::BlockBasedRasterIO()

https://github.com/OSGeo/gdal/blob/1d77534d0a1ee1efcda7d9f3d0bf1f7b91348e34/gdal/gcore/rasterio.cpp#L4145

Instead std::max, we must use std::min, otherwise progress will always return 1.0.

## What are related issues/pull requests?
#4067
