### PR TITLE
WEBP: Support 'exact' option

### DIFF
--- a/autotest/gdrivers/webp.py
+++ b/autotest/gdrivers/webp.py
@@ -136,4 +136,27 @@ def test_webp_5():
     assert cs4 == 10807, 'did not get expected checksum on band 4'
 
 
+###############################################################################
+# CreateCopy() on RGBA with lossless compression and exact rgb values
 
+
+def test_webp_6():
+
+    if gdaltest.webp_drv is None:
+        pytest.skip()
+
+    md = gdaltest.webp_drv.GetMetadata()
+    if md['DMD_CREATIONOPTIONLIST'].find('LOSSLESS') == -1 or md['DMD_CREATIONOPTIONLIST'].find('EXACT') == -1:
+        pytest.skip()
+
+    src_ds = gdal.Open('../gcore/data/stefan_full_rgba.tif')
+    out_ds = gdaltest.webp_drv.CreateCopy('/vsimem/webp_6.webp', src_ds, options=['LOSSLESS=YES', 'EXACT=1'])
+    src_ds = None
+    cs1 = out_ds.GetRasterBand(1).Checksum()
+    cs4 = out_ds.GetRasterBand(4).Checksum()
+    out_ds = None
+    gdal.Unlink('/vsimem/webp_6.webp')
+
+    assert cs1 == 12603, 'did not get expected checksum on band 1'
+
+    assert cs4 == 10807, 'did not get expected checksum on band 4'

--- a/gdal/frmts/webp/webpdataset.cpp
+++ b/gdal/frmts/webp/webpdataset.cpp
@@ -695,6 +695,9 @@ WEBPDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     if (sConfig.lossless)
         sPicture.use_argb = 1;
 #endif
+#if WEBP_ENCODER_ABI_VERSION >= 0x0209
+    FETCH_AND_SET_OPTION_INT("EXACT", exact, 0, 1);
+#endif
 
     if (!WebPValidateConfig(&sConfig))
     {
@@ -907,6 +910,9 @@ void GDALRegister_WEBP()
 "   <Option name='PARTITIONS' type='int' description='log2(number of token partitions) in [0..3]' default='0'/>\n"
 #if WEBP_ENCODER_ABI_VERSION >= 0x0002
 "   <Option name='PARTITION_LIMIT' type='int' description='quality degradation allowed to fit the 512k limit on prediction modes coding (0=no degradation, 100=full)' default='0'/>\n"
+#endif
+#if WEBP_ENCODER_ABI_VERSION >= 0x0209
+"   <Option name='EXACT' type='int' description='preserve the exact RGB values under transparent area. off=0, on=1' default='0'/>\n"
 #endif
 "</CreationOptionList>\n" );
 


### PR DESCRIPTION
## What does this PR do?

Supports the 'exact' option, which preserves the RGB values under transparent areas.

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed