### PR TITLE
Build: Build windows python wrappers with -threads argument

### DIFF
--- a/gdal/swig/makefile.vc
+++ b/gdal/swig/makefile.vc
@@ -14,12 +14,12 @@ python: gdalvars
         cd python
         -del setup_vars.ini
         echo 'GNM_ENABLED=$(INCLUDE_GNM_FRMTS)' > setup_vars.ini
-        $(SWIG) -python -o extensions/gdalconst_wrap.c -outdir osgeo ..\include\gdalconst.i
-        $(SWIG) -c++ -python -I../include/python -I../include/python/docs -o extensions/gdal_wrap.cpp -outdir osgeo ..\include\gdal.i
-        $(SWIG) -c++ -python -I../include/python -I../include/python/docs -o extensions/osr_wrap.cpp -outdir osgeo ..\include\osr.i
-        $(SWIG) -c++ -python -I../include/python -I../include/python/docs -o extensions/ogr_wrap.cpp -outdir osgeo ..\include\ogr.i
-        $(SWIG) -c++ -python -I../include/python -I../include/python/docs -o extensions/gnm_wrap.cpp -outdir osgeo ..\include\gnm.i
-        $(SWIG) -c++ -python -I../include/python -I../include/python/docs -o extensions/gdal_array_wrap.cpp -outdir osgeo ..\include\gdal_array.i
+        $(SWIG) -python -threads -o extensions/gdalconst_wrap.c -outdir osgeo ..\include\gdalconst.i
+        $(SWIG) -c++ -python -threads -I../include/python -I../include/python/docs -o extensions/gdal_wrap.cpp -outdir osgeo ..\include\gdal.i
+        $(SWIG) -c++ -python -threads -I../include/python -I../include/python/docs -o extensions/osr_wrap.cpp -outdir osgeo ..\include\osr.i
+        $(SWIG) -c++ -python -threads -I../include/python -I../include/python/docs -o extensions/ogr_wrap.cpp -outdir osgeo ..\include\ogr.i
+        $(SWIG) -c++ -python -threads -I../include/python -I../include/python/docs -o extensions/gnm_wrap.cpp -outdir osgeo ..\include\gnm.i
+        $(SWIG) -c++ -python -threads -I../include/python -I../include/python/docs -o extensions/gdal_array_wrap.cpp -outdir osgeo ..\include\gdal_array.i
         $(PYDIR)\$(PYEXEC) setup.py build
 	cd ..
 


### PR DESCRIPTION
## What does this PR do?

Passes -threads to SWIG when building python wrappers for windows. This enables releasing the GIL during long-running operations. The GNUmakefile's are already passing this flag.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed