### PR TITLE
Viewranger .VRC driver

### DIFF
--- a/gdal/GDALmake.opt.in
+++ b/gdal/GDALmake.opt.in
@@ -599,6 +599,10 @@ ifeq ($(HAVE_CHARLS),yes)
 GDAL_FORMATS := $(GDAL_FORMATS) jpegls
 endif
 
+#ifneq ($(HAVE_VRC),no)
+#GDAL_FORMATS += vrc
+#endif
+
 
 #
 # CONFIG_LIBS is what local program should link against, and CONFIG_LIBS_INS

--- a/gdal/PROVENANCE.TXT
+++ b/gdal/PROVENANCE.TXT
@@ -254,6 +254,10 @@ Note: all the following are build options, not required.
 
 * Copyright mostly FrankW, but also Mark Phillips, clean.
 
+=== gdal/ogr/ogrsf_frmts/vrc ===
+
+* Copyright Andrew Aitchison, clean.
+
 === gdal/ogr/ogrsf_frmts/vrt ===
 
 * FrankW, clean.

--- a/gdal/configure
+++ b/gdal/configure
@@ -809,6 +809,7 @@ PCIDSK_INCLUDE
 PCIDSK_LIB
 PCIDSK_SETTING
 GTA_SETTING
+VRC_SETTING
 DDS_SETTING
 CRUNCHDIR
 PNG_SETTING
@@ -1073,6 +1074,7 @@ enable_driver_grib
 enable_driver_ozi
 enable_driver_pdf
 enable_driver_rik
+enable_driver_vrc
 enable_driver_arcgen
 enable_driver_avc
 enable_driver_cad
@@ -1143,6 +1145,7 @@ with_cfitsio
 with_pcraster
 with_png
 with_dds
+with_vrc
 with_gta
 with_pcidsk
 with_geotiff
@@ -1983,6 +1986,8 @@ Optional Features:
                           requires dependency)
   --disable-driver-rik    disable rik format support (enabled by default,
                           requires dependency)
+  --disable-driver-vrc    disable vrc format support (enabled by default,
+                          requires dependency)
   --disable-driver-arcgen disable arcgen driver support (enabled by default)
   --disable-driver-avc    disable avc driver support (enabled by default)
   --disable-driver-cad    disable cad driver support (enabled by default)
@@ -2148,6 +2153,7 @@ Optional Packages:
   --with-pcraster=ARG   Include PCRaster (libcsf) support (ARG=internal, no or path)
   --with-png=ARG        Include PNG support (ARG=internal, no or path)
   --with-dds=ARG        Include DDS support (ARG=no, or path)
+  --with-vrc=ARG        Include VRC support (ARG=no, or path)
   --with-gta=ARG        Include GTA support (ARG=no or libgta tree prefix)
   --with-pcidsk=ARG     Path to external PCIDSK SDK or internal (default)
   --with-geotiff=ARG    Libgeotiff library to use (ARG=internal, yes or path)
@@ -28042,6 +28048,33 @@ else
   INTERNAL_FORMAT_rik_ENABLED=no
 fi
 
+# Check whether --enable-driver-vrc was given.
+if test "${enable_driver_vrc+set}" = set; then :
+  enableval=$enable_driver_vrc;
+fi
+cur_driver_enabled=yes
+requested=$enable_driver_vrc
+if test "$all_drivers_disabled" = "yes"; then :
+  if test "x$requested" = "xyes"; then :
+    cur_driver_enabled=yes
+  else
+    cur_driver_enabled=no
+  fi
+else
+  if test "x$requested" != "xno"; then :
+    cur_driver_enabled=yes
+  else
+    cur_driver_enabled=no
+  fi
+fi
+
+if test "$cur_driver_enabled" = "yes"; then :
+  INTERNAL_FORMAT_vrc_ENABLED=yes
+else
+  GDALFORMATS_DISABLED="$GDALFORMATS_DISABLED vrc"
+  INTERNAL_FORMAT_vrc_ENABLED=no
+fi
+
 
 
 
@@ -30873,6 +30906,40 @@ DDS_SETTING=$DDS_SETTING
 
 if test "$DDS_SETTING" != "no" ; then
   OPT_GDAL_FORMATS="dds $OPT_GDAL_FORMATS"
+fi
+
+
+
+# Check whether --with-vrc was given.
+if test "${with_vrc+set}" = set; then :
+  withval=$with_vrc;
+fi
+
+
+if test "$PNG_SETTING" = "no" ; then
+
+  VRC_SETTING="no"
+
+  echo "vrc support disabled as it needs PNG."
+
+elif test "$with_vrc" = "no" ; then
+
+  VRC_SETTING="no"
+
+  echo "vrc support disabled."
+
+else
+
+  VRC_SETTING=yes
+  echo "using VRC from $with_vrc."
+
+fi
+
+VRC_SETTING=$VRC_SETTING
+
+
+if test "$VRC_SETTING" != "no" ; then
+  OPT_GDAL_FORMATS="$OPT_GDAL_FORMATS vrc"
 fi
 
 
@@ -45211,6 +45278,9 @@ echo "  TileDB support:            ${TILEDB_SETTING}"
 
 
 echo "  userfaultfd support:       ${ENABLE_UFFD}"
+
+
+echo "  VRC support:               ${VRC_SETTING}"
 
 
 echo "  WebP support:              ${WEBP_SETTING}"

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -1700,7 +1700,7 @@ OGRFORMATS_ENABLED_CFLAGS=
 OGRFORMATS_DISABLED=
 
 AC_DEFUN([INTERNAL_FORMATS],[aaigrid adrg aigrid airsar arg blx bmp bsb cals ceos ceos2 coasp cosar ctg dimap dted elas envisat ers esric fit gff gsg gxf hf2 idrisi ilwis ingr iris iso8211 jaxapalsar jdem kmlsuperoverlay l1b leveller map mrf msgn ngsgeoid nitf northwood pds prf r raw rmf rs2 safe saga sdts sentinel2 sgi sigdem srtmhgt stacta terragen tga til tsx usgsdem xpm xyz zmap])
-AC_DEFUN([INTERNAL_OPT_FORMATS],[grib ozi pdf rik])
+AC_DEFUN([INTERNAL_OPT_FORMATS],[grib ozi pdf rik vrc])
 AC_DEFUN([INTERNAL_DRIVERS],[arcgen avc cad csv dgn dxf edigeo flatgeobuf geoconcept georss gml gmt gpsbabel gpx gtm jml mapml mvt ntf openfilegdb pgdump rec s57 selafin shape svg sxf tiger vdv wasp])dnl
 AC_DEFUN([CURL_FORMATS],[eeda plmosaic rda wcs wms wmts daas ogcapi])dnl
 AC_DEFUN([CURL_DRIVERS],[amigocloud carto cloudant couchdb csw elastic ngw plscenes wfs])dnl
@@ -2232,6 +2232,37 @@ AC_SUBST([DDS_SETTING], [$DDS_SETTING])
 
 if test "$DDS_SETTING" != "no" ; then
   OPT_GDAL_FORMATS="dds $OPT_GDAL_FORMATS"
+fi
+
+dnl ---------------------------------------------------------------------------
+dnl Enable VRC driver.
+dnl ---------------------------------------------------------------------------
+
+AC_ARG_WITH([vrc], [  --with-vrc[=ARG]        Include VRC support (ARG=no, or path)],,)
+
+if test "$PNG_SETTING" = "no" ; then
+
+  VRC_SETTING="no"
+
+  echo "vrc support disabled as it needs PNG."
+
+elif test "$with_vrc" = "no" ; then
+
+  VRC_SETTING="no"
+
+  echo "vrc support disabled."
+
+else
+
+  VRC_SETTING=yes
+  echo "using VRC from $with_vrc."
+
+fi
+
+AC_SUBST([VRC_SETTING], [$VRC_SETTING])
+
+if test "$VRC_SETTING" != "no" ; then
+  OPT_GDAL_FORMATS="$OPT_GDAL_FORMATS vrc"
 fi
 
 dnl ---------------------------------------------------------------------------
@@ -6156,6 +6187,7 @@ LOC_MSG([  SQLite support:            ${HAVE_SQLITE}])
 LOC_MSG([  Teigha (DWG and DGNv8):    ${HAVE_TEIGHA}])
 LOC_MSG([  TileDB support:            ${TILEDB_SETTING}])
 LOC_MSG([  userfaultfd support:       ${ENABLE_UFFD}])
+LOC_MSG([  VRC support:               ${VRC_SETTING}])
 LOC_MSG([  WebP support:              ${WEBP_SETTING}])
 LOC_MSG([  Xerces-C support:          ${HAVE_XERCES}])
 LOC_MSG([  ZSTD support:              ${ZSTD_SETTING}])

--- a/gdal/frmts/gdalallregister.cpp
+++ b/gdal/frmts/gdalallregister.cpp
@@ -588,6 +588,10 @@ void CPL_STDCALL GDALAllRegister()
     GDALRegister_STACTA();
 #endif
 
+#ifdef FRMT_vrc
+    GDALRegister_VRC();
+#endif
+
     // NOTE: you need to generally your own driver before that line.
 
 /* -------------------------------------------------------------------- */

--- a/gdal/frmts/makefile.vc
+++ b/gdal/frmts/makefile.vc
@@ -16,7 +16,7 @@ EXTRAFLAGS =	-DFRMT_ceos -DFRMT_aigrid -DFRMT_elas -DFRMT_hfa -DFRMT_gtiff\
 		-DFRMT_kmlsuperoverlay -DFRMT_ozi -DFRMT_ctg \
 		-DFRMT_zmap -DFRMT_ngsgeoid -DFRMT_iris -DFRMT_map -DFRMT_cals \
 		-DFRMT_safe -DFRMT_sentinel2 -DFRMT_derived -DFRMT_prf \
-		-DFRMT_sigdem -DFRMT_tga -DFRMT_stacta
+		-DFRMT_sigdem -DFRMT_tga -DFRMT_stacta -DFRMT_vrc
 
 MOREEXTRA 	=	
 
@@ -189,6 +189,10 @@ PLUGINFLAGS	=	$(PLUGINFLAGS) -DFRMT_kea
 
 !IFDEF MRF_SETTING
 EXTRAFLAGS	=	$(EXTRAFLAGS) -DFRMT_mrf
+!ENDIF
+
+!IFDEF VRC_DIR
+EXTRAFLAGS	=	$(EXTRAFLAGS) -DFRMT_vrc
 !ENDIF
 
 !IFDEF CHARLS_LIB

--- a/gdal/frmts/vrc/GNUmakefile
+++ b/gdal/frmts/vrc/GNUmakefile
@@ -1,0 +1,23 @@
+
+include ../../GDALmake.opt
+
+OBJ	=	png_crc.o VRC.o VRCutils.o VRCthirtysix.o VRHV.o
+
+# CPPFLAGS        :=       -I.. $(CPPFLAGS) -DFRMT_vrhv
+CPPFLAGS        :=       -I.. $(CPPFLAGS)
+
+default:	$(OBJ:.o=.$(OBJ_EXT))
+
+clean:
+	rm -f *.o $(O_OBJ) *.so *.lo .libs/*.o
+
+install-obj:	$(O_OBJ:.o=.$(OBJ_EXT))
+
+PLUGIN_SO = gdal_VRC.so
+
+plugin: $(PLUGIN_SO)
+
+# Do we need to add "-Lsomething -lpng" ?
+$(PLUGIN_SO): $(OBJ)
+	$(LD) $(LNK_FLAGS) $(OBJ) $(CONFIG_LIBS_INS) $(LIBS) \
+	-o $(PLUGIN_SO)

--- a/gdal/frmts/vrc/GNUmakefile
+++ b/gdal/frmts/vrc/GNUmakefile
@@ -2,14 +2,17 @@
 include ../../GDALmake.opt
 
 OBJ	=	png_crc.o VRC.o VRCutils.o VRCthirtysix.o VRHV.o
+LO_O_OBJ       =       $(addsuffix .lo,$(basename $(O_OBJ)))
 
 # CPPFLAGS        :=       -I.. $(CPPFLAGS) -DFRMT_vrhv
-CPPFLAGS        :=       -I.. $(CPPFLAGS)
+CPPFLAGS        :=       -I.. $(CPPFLAGS) -Wno-unknown-pragmas
+#LNK_FLAGS		+=		-shared
+LD_SHARED		= $(LD) -shared
 
 default:	$(OBJ:.o=.$(OBJ_EXT))
 
 clean:
-	rm -f *.o $(O_OBJ) *.so *.lo .libs/*.o
+	rm -f $(OBJ) $(O_OBJ) *.so $(LO_O_OBJ) .libs/*.o $(PLUGIN_SO)
 
 install-obj:	$(O_OBJ:.o=.$(OBJ_EXT))
 
@@ -19,5 +22,4 @@ plugin: $(PLUGIN_SO)
 
 # Do we need to add "-Lsomething -lpng" ?
 $(PLUGIN_SO): $(OBJ)
-	$(LD) $(LNK_FLAGS) $(OBJ) $(CONFIG_LIBS_INS) $(LIBS) \
-	-o $(PLUGIN_SO)
+	$(LD_SHARED) $(LNK_FLAGS) $(OBJ) $(CONFIG_LIBS_INS) $(LIBS) -o $(PLUGIN_SO)

--- a/gdal/frmts/vrc/VRC.cpp
+++ b/gdal/frmts/vrc/VRC.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * $Id: VRC.cpp,v 1.279 2021/06/20 08:58:41 werdna Exp $
+ * $Id: VRC.cpp,v 1.281 2021/07/08 11:52:49 werdna Exp $
  *
  * Project:  GDAL
  * Purpose:  Viewranger GDAL Driver
@@ -18,49 +18,17 @@
 // #ifdef FRMT_vrc
 
 #include "VRC.h"
-
 #include "png_crc.h"  // for crc pngcrc_for_VRC, used in:
                     //   PNGCRCcheck
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
-#pragma clang diagnostic ignored "-Wdouble-promotion"
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#pragma clang diagnostic ignored "-Wmicrosoft-enum-value"
-#pragma clang diagnostic ignored "-Wreserved-id-macro"
-#pragma clang diagnostic ignored "-Wswitch-enum"
-#pragma clang diagnostic ignored "-Wundef"
-#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
-#pragma clang diagnostic ignored "-Wpadded"
-#pragma clang diagnostic ignored "-Wweak-vtables"
-#pragma clang diagnostic ignored "-Wsuggest-destructor-override"
-#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
-#pragma clang diagnostic ignored "-Wunused-template"
-// #pragma clang diagnostic ignored ""
-#pragma clang diagnostic ignored "-Wformat-pedantic"
-#pragma clang diagnostic ignored "-Wc++98-compat"
-#pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
-#pragma clang diagnostic ignored "-Wsign-conversion"
-
-#include "cpl_port.h"
-#include "cpl_string.h"
-#include "gdal_pam.h"
-#include "ogr_spatialref.h"
-
-#pragma clang diagnostic pop
-
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winfinite-recursion"
 //#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
-CPL_CVSID("$Id: VRC.cpp,v 1.279 2021/06/20 08:58:41 werdna Exp $")
+CPL_CVSID("$Id: VRC.cpp,v 1.281 2021/07/08 11:52:49 werdna Exp $")
 #pragma clang diagnostic push
-
-#include <cerrno>
-#include <cstdio>
 
 CPL_C_START
 void CPL_DLL GDALRegister_VRC(void);
-
 CPL_C_END
 
 void VRC_file_strerror_r(int nFileErr, char* const buf, size_t buflen)
@@ -2026,11 +1994,11 @@ GDALDataset *VRCDataset::Open( GDALOpenInfo * poOpenInfo )
             // It ignores CPLDebug then deduces that dfheight2 is not used.
             double dfheight2 =
                 (anCorners[3]-anCorners[1]) / poDS->dfPixelMetres;
-#endif
             CPLDebug("Viewranger",
                      "height either %d %g or %g pixels",
                      poDS->nRasterYSize, dfHeightPix, dfheight2
                      );
+#endif
         }
 
         if (nFullHeightPix < dfHeightPix) {

--- a/gdal/frmts/vrc/VRC.cpp
+++ b/gdal/frmts/vrc/VRC.cpp
@@ -1,0 +1,4599 @@
+/******************************************************************************
+ * $Id: VRC.cpp,v 1.279 2021/06/20 08:58:41 werdna Exp $
+ *
+ * Project:  GDAL
+ * Purpose:  Viewranger GDAL Driver
+ * Authors:  Andrew C Aitchison
+ *
+ ******************************************************************************
+ * Copyright (c) 2015-21, Andrew C Aitchison
+ ****************************************************************************
+ * Portions taken from gdal-2.2.3/frmts/png/pngdataset.cpp and other GDAL code
+ * Copyright (c) 2000, Frank Warmerdam
+ * Copyright (c) 2007-2014, Even Rouault <even dot rouault at mines-paris dot org>
+ ****************************************************************************/
+
+/* -*- tab-width: 4 ; indent-tabs-mode: nil ; c-basic-offset 'tab-width -*- */
+
+// #ifdef FRMT_vrc
+
+#include "VRC.h"
+
+#include "png_crc.h"  // for crc pngcrc_for_VRC, used in:
+                    //   PNGCRCcheck
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wmicrosoft-enum-value"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#pragma clang diagnostic ignored "-Wsuggest-destructor-override"
+#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
+#pragma clang diagnostic ignored "-Wunused-template"
+// #pragma clang diagnostic ignored ""
+#pragma clang diagnostic ignored "-Wformat-pedantic"
+#pragma clang diagnostic ignored "-Wc++98-compat"
+#pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+
+#include "cpl_port.h"
+#include "cpl_string.h"
+#include "gdal_pam.h"
+#include "ogr_spatialref.h"
+
+#pragma clang diagnostic pop
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winfinite-recursion"
+//#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+CPL_CVSID("$Id: VRC.cpp,v 1.279 2021/06/20 08:58:41 werdna Exp $")
+#pragma clang diagnostic push
+
+#include <cerrno>
+#include <cstdio>
+
+CPL_C_START
+void CPL_DLL GDALRegister_VRC(void);
+
+CPL_C_END
+
+void VRC_file_strerror_r(int nFileErr, char* const buf, size_t buflen)
+{
+    if (buf==nullptr || buflen<1) {
+        return;
+    }
+#if 0
+#define STRERR_DEBUG(...) CPLDebug(...)
+#else
+#define STRERR_DEBUG(...)
+#endif
+
+#if defined(WIN32)
+    STRERR_DEBUG("Viewranger",
+                 "Windows file error %d",
+                 nFileErr);
+    snprintf(buf, buflen, "Windows file error %d",
+                 nFileErr);
+#else
+#if (_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE
+    /* strerror_r is XSI-compliant */
+    if (int err=strerror_r(nFileErr, buf, buflen)) {
+        int errnum=errno;
+        // error getting error for nFileErr
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "nested errors - %d=x%x  %d=x%x %d=x%x ?\n\tbuf %p buflen %ld",
+                  nFileErr,nFileErr, err,err, errnum,errnum, buf, buflen );
+    } else {
+        STRERR_DEBUG("Viewranger",
+                 "XSI strerror_r(%d,...) returns null and sets buf to %s",
+                 nFileErr, buf);
+    }
+#else
+    /* GNU-specific strerror_r */
+    char *ret=strerror_r(nFileErr, buf, buflen);
+    if (ret) {
+        STRERR_DEBUG("Viewranger",
+                 "GNU strerror_r(%d,...) returns %s and sets buf to %s",
+                  nFileErr, ret, buf);
+        if (buf && buf!=ret) {
+            strncpy(buf,ret,buflen);
+            buf[buflen]=0;
+        }
+    } else {
+        STRERR_DEBUG("Viewranger",
+                 "GNU strerror_r(%d,...) returns null and sets buf to %s",
+                 nFileErr, buf);
+    }
+#endif
+#endif // !defined(WIN32)
+#undef STRERR_DEBUG
+} // VRC_file_strerror_r()
+
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+typedef struct __attribute__((aligned(32))) {
+    png_bytep pData;
+    signed long length;
+    signed long current;
+} VRCpng_data;
+#pragma clang diagnostic pop
+
+static unsigned int PNGGetUInt( void* base, unsigned int byteOffset )
+{
+    unsigned char * buf = static_cast<unsigned char*>(base)+byteOffset;
+    unsigned int vv = buf[3];
+    vv |= static_cast<unsigned int>(buf[2]) << 8;
+    vv |= static_cast<unsigned int>(buf[1]) << 16;
+    vv |= static_cast<unsigned int>(buf[0]) << 24;
+
+    return(vv);
+}
+static signed int PNGGetInt( void* base, unsigned int byteOffset )
+{
+    return(static_cast<signed int>(PNGGetUInt(base, byteOffset)));
+}
+
+
+static
+unsigned int PNGReadUInt(VSILFILE *fp)
+{
+    unsigned char buf[4]={};
+    // int ret =
+    VSIFReadL(buf, 1, 4, fp);
+    return PNGGetUInt(buf, 0);
+}
+#if 0 // Not used
+static
+signed int PNGReadInt(VSILFILE *fp)
+{
+    return(static_cast<signed int>(PNGReadInt(fp)));
+}
+#endif
+
+static
+void PNGAPI
+VRC_png_read_data_fn (png_structp png_read_ptr,
+                      png_bytep data,
+                      png_size_t length)
+{
+    if (png_read_ptr == nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "VRC_png_read_data_fn given null io ptr");
+        //png_warning(png_read_ptr,
+        //            "VRC_png_read_data_fn given null io ptr\n");
+        return;
+    }
+    if (data == nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "VRC_png_read_data_fn cannot write to null ptr");
+        //png_warning(png_read_ptr,
+        //            "VRC_png_read_data_fn cannot write to null ptr\n");
+        return;
+    }
+    if (length <1) {
+        CPLDebug("Viewranger PNG",
+                 "VRC_png_read_data_fn() requested length %ld < 1",
+                 static_cast<long>(length)
+                 );
+        return;
+    }
+
+    auto *pVRCpng_data =
+        static_cast<VRCpng_data*>(png_get_io_ptr(png_read_ptr));
+#if 0
+    CPLDebug("Viewranger PNG",
+             "VRC_png_read_data_fn(%p %p %ld) %p %s %p",
+             png_read_ptr, data, static_cast<long>(length),
+             pVRCpng_data,
+             pVRCpng_data == png_read_ptr->io_ptr ? "==" : "!=",
+             png_read_ptr->io_ptr
+             );
+    CPLDebug("Viewranger PNG",
+            "pVRCpng_data %p cur=%ld len=%ld",
+             pVRCpng_data->pData,
+             pVRCpng_data->current,
+             pVRCpng_data->length
+             );
+#endif
+
+    // Sanity checks on our data pointer
+    if (pVRCpng_data->pData==nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "VRC_png_read_data_fn(%p %p %ld) pVRCpng_data is null",
+                 png_read_ptr, data, length
+                 );
+        return;
+    }
+    if ( pVRCpng_data->current < 0) {
+        CPLDebug("Viewranger PNG",
+                 "VRC_png_read_data_fn() current %ld < 0",
+                 pVRCpng_data->current
+                 );
+        return;
+    }
+    long nSpare =  pVRCpng_data->length - pVRCpng_data->current;
+    if ( nSpare<0) {
+        CPLDebug("Viewranger PNG",
+                 "VRC_png_read_data_fn() current %ld > length %ld - diff %ld",
+                 pVRCpng_data->current, pVRCpng_data->length,
+                 -nSpare
+                 );
+        return;
+    }
+    // Sanity check the function args
+    if ( static_cast<long>(length) > nSpare ) {
+        CPLDebug("Viewranger PNG",
+                 "VRC_png_read_data_fn(%p %p %ld) %ld+%ld reads beyond %ld",
+                 png_read_ptr, data, length,
+                 pVRCpng_data->current, length, pVRCpng_data->length
+                 );
+        // Copy the data we have ...
+        if (nSpare>0) { // pVRCpng_data->current < pVRCpng_data->length) {
+            memcpy(data,
+                   pVRCpng_data->pData + pVRCpng_data->current,
+                   static_cast<size_t>(nSpare));
+        } else {
+            CPLDebug("Viewranger PNG",
+                     "VRC_png_read_data_fn(%p %p %ld) buffer already over full: current %ld >= space %ld",
+                     png_read_ptr, data, length,
+                     pVRCpng_data->current, pVRCpng_data->length
+                     );
+        }
+        pVRCpng_data->current = pVRCpng_data->length;
+        return;
+    }
+
+    memcpy(data,
+           pVRCpng_data->pData + pVRCpng_data->current,
+           length);
+    pVRCpng_data->current += static_cast<long>(length);
+
+}
+
+static
+int PNGCRCcheck(VRCpng_data *oVRCpng_data, unsigned long nGiven)
+{
+    if (oVRCpng_data->current < 8) {
+        CPLDebug("Viewranger PNG", "PNGCRCcheck: current %lu < 8",
+                 oVRCpng_data->current);
+        return -1;
+    }
+    unsigned char *pBuf = &oVRCpng_data->pData[oVRCpng_data->current-4];
+    auto nLen = static_cast<unsigned>
+        (PNGGetInt(&oVRCpng_data->pData[oVRCpng_data->current-8], 0));
+
+    if (nLen > static_cast<unsigned long int> (oVRCpng_data->length)
+        || nLen > static_cast<unsigned long int> (1LLU<<31U)
+        ) {
+        // from PNG spec nLen <= 2^31
+        CPLDebug("Viewranger PNG", "PNGCRCcheck: nLen %u > buffer length %lu",
+                 nLen, oVRCpng_data->length);
+        return -1;
+    } else {
+        CPLDebug("Viewranger PNG", "PNGCRCcheck((%p, %lu) %u, x%08lx)",
+                 pBuf, oVRCpng_data->current, nLen, nGiven);
+    }
+
+    unsigned long nFileCRC = 0xffffffff & static_cast<unsigned long>
+        ( PNGGetInt(oVRCpng_data->pData,
+                    (static_cast<unsigned int>(oVRCpng_data->current)
+                     + nLen)) );
+    if (nGiven == nFileCRC) {
+        CPLDebug("Viewranger PNG",
+                 "PNGCRCcheck(x%08lx) given CRC matches CRC from file",
+                 nFileCRC);
+    } else {
+        CPLDebug("Viewranger PNG",
+                 "PNGCRCcheck(x%08lx) CRC given does not match x%08lx from file",
+                 nGiven, nFileCRC);
+        return -1;
+    }
+
+    unsigned long nComputed = pngcrc_for_VRC(pBuf, nLen+4);
+    nComputed &= 0xffffffff;
+    int ret = (nGiven==nComputed);
+    if (ret==0) {
+        CPLDebug("Viewranger PNG",
+                 "PNG file: CRC given x%08lx, calculated x%08lx",
+                 nGiven, nComputed);
+    }
+
+    return ret;
+}
+
+
+/* -------------------------------------------------------------------------
+ * Returns a (null-terminated) string allocated from VSIMalloc.
+ * The 32 bit length of the string is stored in file fp at byteaddr.
+ * The string itself is stored immediately after its length;
+ * it is *not* null-terminated in the file.
+ * If index pointer is nul then an empty string is returned
+ * (rather than a null pointer).
+ */
+char *VRCDataset::VRCGetString( VSILFILE *fp, unsigned int byteaddr )
+{
+    if (byteaddr==0) return( strdup (""));
+
+    int seekres = VSIFSeekL( fp, byteaddr, SEEK_SET );
+    if ( seekres ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to VRC string" );
+        return nullptr;
+    }
+    int string_length = VRReadInt(fp);
+    if (string_length<=0) {
+        if (string_length<0) {
+            CPLDebug("Viewranger", "odd length for string %08x - length %d",
+                     byteaddr, string_length);
+        }
+        return( strdup (""));
+    }
+    size_t ustring_length = static_cast<unsigned>(string_length);
+
+    char *pszNewString = static_cast<char*>(VSIMalloc(1+ustring_length));
+    if (pszNewString == nullptr) {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate %d bytes for string",
+                 1+string_length);
+        return nullptr;
+    }
+
+
+    size_t bytesread =
+      VSIFReadL( pszNewString, 1, ustring_length, fp);
+
+    if (bytesread < ustring_length) {
+      VSIFree(pszNewString);
+      CPLDebug("Viewranger", "requested x%08x bytes but only got x%8lx",
+               string_length, bytesread);
+      CPLError(CE_Failure, CPLE_AppDefined,
+               "problem reading string\n");
+      return nullptr;
+    }
+
+    pszNewString[string_length] = 0;
+    // CPLDebug("Viewranger", "read string %s at %08x - length %d",
+    //         pszNewString, byteaddr, string_length);
+    return pszNewString;
+} // VRCDataset::VRCGetString( VSILFILE *fp, unsigned int byteaddr )
+
+
+
+/************************************************************************/
+/*                           VRCRasterBand()                            */
+/************************************************************************/
+
+VRCRasterBand::VRCRasterBand(
+                             VRCDataset *poDSIn,
+                             int nBandIn,
+                             int nThisOverviewIn,
+                             int nOverviewCountIn,
+                             VRCRasterBand**papoOverviewBandsIn
+                             )
+    :
+    // nRecordSize(0),
+    eBandInterp(GCI_Undefined),
+    nThisOverview(nThisOverviewIn),
+    nOverviewCount(nOverviewCountIn),
+    papoOverviewBands(papoOverviewBandsIn)
+{
+    VRCDataset *poVRCDS = poDSIn;
+    poDS = static_cast<GDALDataset *>(poVRCDS);
+    nBand = nBandIn;
+    CPLDebug("Viewranger", "%s %p->VRCRasterBand(%p, %d, %d, %d, %p)",
+             poVRCDS->sLongTitle.c_str(), this,
+             poVRCDS, nBand, nThisOverview, nOverviewCount, papoOverviewBands);
+
+    if (nOverviewCount >=32) {
+        // This is unnecessarily big;
+        // the scale factor will not fit in an int, and
+        // a 1cm / pixel map of the world will have a one pixel overview.
+        // nOverviewCount=32;
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "%d overviews is not practical",
+                 nOverviewCount);
+        nOverviewCount=0;
+        return;  // Can I return failure ?
+    }
+    if (nOverviewCount>=0 && nThisOverview >= nOverviewCount) {
+        if (nOverviewCount>0) {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "failed: cannot set overview %d of %d\n",
+                     nThisOverview, nOverviewCount);
+        }
+        return; // CE_Failure; // nullptr; ?
+    }
+
+    auto nOverviewScale =
+        static_cast<signed int>(1U << static_cast<unsigned int>(nThisOverview+1));
+    nRasterXSize = poVRCDS->nRasterXSize / nOverviewScale; // >> nOverviewShift;
+    nRasterYSize = poVRCDS->nRasterYSize / nOverviewScale; // >> nOverviewShift;
+
+    // int tileXcount = poVRCDS->tileXcount;
+    // int tileYcount = poVRCDS->tileYcount;
+
+    CPLDebug("Viewranger", "nRasterXSize %d nRasterYSize %d",
+             nRasterXSize, nRasterYSize);
+
+
+    // Image Structure Metadata:  INTERLEAVE=PIXEL would be good
+    SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
+    
+    if (poVRCDS->nMagic == vrc_magic_metres
+        // || poVRDSIn->nMagic == vrc_magic_thirtysix // temp: merging metre and thirtysix tile code
+        ) {
+        
+        eDataType = GDT_Byte; // GDT_UInt32;
+        // GCI_Undefined; // GCI_GrayIndex; // GCI_PaletteIndex;
+        // GCI_RedBand; // GCI_GreenBand;  // GCI_BlueBand; //GCI_AlphaBand;
+        switch (nBand) {
+        case 1:
+            eBandInterp = GCI_RedBand;
+            CPLDebug("Viewranger", "vrcmetres_pixel_is_pixel Red band");
+            break;
+        case 2:
+            eBandInterp = GCI_GreenBand;
+            CPLDebug("Viewranger", "vrcmetres_pixel_is_pixel Green band");
+            break;
+        case 3:
+            eBandInterp = GCI_BlueBand;
+            CPLDebug("Viewranger", "vrcmetres_pixel_is_pixel Blue band");
+            break;
+        case 4:
+          eBandInterp = GCI_AlphaBand;
+          CPLDebug("Viewranger", "vrcmetres_pixel_is_pixel Alpha band");
+          break;
+        default:
+            CPLDebug("Viewranger", "vrcmetres_pixel_is_pixel band %d unexpected !",
+                     nBand);
+        }
+
+        // These will change with nThisOverview
+
+        CPLDebug("Viewranger",
+                 "vrcmetres_pixel_is_pixel nThisOverview=%d",
+                 nThisOverview);
+        if (nThisOverview<-1) {
+            CPLDebug("Viewranger",
+                     "\toverview %d invalid",
+                     nThisOverview);
+            nThisOverview=-1; //  main view
+        } else if (nThisOverview>7) {
+            CPLDebug("Viewranger",
+                     "\toverview %d unexpected",
+                     nThisOverview);
+        }
+
+#if defined ROUND_UP_OVERVIEWSIZE
+        {
+            unsigned int rounding =
+                (1U<<static_cast<unsigned int>(1+nThisOverview)) -1;
+            nBlockXSize =
+                (static_cast<signed int>(rounding + poVRCDS->tileSizeMax))
+                / nOverviewScale;
+            CPLDebug("Viewranger",
+                     "overview %d tileSizeMax %d nBlockXSize %d rounding %d",
+                     nThisOverview, poVRCDS->tileSizeMax, nBlockXSize, rounding
+                     );
+        }
+#else
+        nBlockXSize =
+            static_cast<signed int>(poVRCDS->tileSizeMax) / nOverviewScale;
+             // was static_cast<int>(poVRCDS->tileSizeMax >> (1+nThisOverview));
+#endif // ROUND_UP_OVERVIEWSIZE
+        nBlockYSize = nBlockXSize;
+        if (nBlockXSize<1) {
+             CPLDebug("Viewranger",
+                      "overview %d block %d x %d too small",
+                      nThisOverview, nBlockXSize, nBlockYSize
+                 );
+             nBlockYSize=nBlockXSize=1;
+        }
+        CPLDebug("Viewranger",
+                 "overview %d block %d x %d",
+                 nThisOverview, nBlockXSize, nBlockYSize
+                 );
+
+#if 0
+        nRecordSize = static_cast<GUIntBig>(nBlockXSize)
+            * static_cast<GUIntBig>(nBlockYSize)
+            * sizeof(GByte); // sizeof(GUInt32);
+#endif
+    } else if (poVRCDS->nMagic == vrc_magic_thirtysix) {
+#if defined VRC36_PIXEL_IS_FILE
+        CPLDebug("Viewranger", "vrcthirtysix_pixel_is_file");
+        // eDataType = GDT_Byte;
+        // eBandInterp = GCI_GrayIndex; // GCI_PaletteIndex;
+        // at this stage data values are probably a pointers
+        // we want to view them to spot duplicates etc.
+        eDataType = GDT_UInt32;
+        eBandInterp = GCI_Undefined; // GCI_GrayIndex; // GCI_PaletteIndex;
+
+        /* We cannot yet interpret the map data.
+         * For now we pretend it is a single pixel.
+         */
+
+        nBlockXSize = 1;
+        nBlockYSize = 1;
+
+        // nRecordSize = sizeof(GUInt32);
+#else
+#if defined VRC36_PIXEL_IS_TILE
+        CPLDebug("Viewranger", "vrcthirtysix_pixel_is_tile");
+        // at this stage data is probably a pointer
+        eDataType = GDT_UInt32;
+        eBandInterp = GCI_Undefined; // GCI_GrayIndex; // GCI_PaletteIndex;
+
+        nBlockXSize = poVRCDS->tileXcount;
+        nBlockYSize = poVRCDS->tileYcount;
+        // nRecordSize = static_cast<GUIntBig>(nBlockXSize) * static_cast<GUIntBig>(nBlockYSize) * sizeof(GUInt32);
+#else
+        CPLDebug("Viewranger", "vrcthirtysix_pixel_is_pixel");
+
+        // VRC36_PIXEL_IS_PIXEL
+        // this will be the default
+        CPLDebug("Viewranger", "vrcthirtysix_pixel_is_pixel not yet tested");
+        eDataType = GDT_Byte; // GDT_UInt32;
+        eBandInterp =  GCI_PaletteIndex; // GCI_GrayIndex; // GCI_Undefined; // GCI_GrayIndex; //
+
+#if defined ROUND_UP_OVERVIEWSIZE
+        {
+            int rounding = (1<<(1+nThisOverview)) -1;
+            nBlockXSize = (rounding + poVRCDS->tileSizeMax) >> (1+nThisOverview);
+            CPLDebug("Viewranger",
+                     "overview %d tileSizeMax %d nBlockXSize %d rounding %d",
+                     nThisOverview, poVRCDS->tileSizeMax, nBlockXSize, rounding
+                     );
+        }
+#else
+        nBlockXSize = static_cast<int>(poVRCDS->tileSizeMax >> (1+nThisOverview));
+#endif // ROUND_UP_OVERVIEWSIZE
+        nBlockYSize = nBlockXSize;
+        if (nBlockXSize<1) {
+             CPLDebug("Viewranger",
+                      "overview %d block %d x %d too small",
+                      nThisOverview, nBlockXSize, nBlockYSize
+                 );
+             nBlockYSize=nBlockXSize=1;
+        }
+        //nBlockXSize = 1;
+        //nBlockYSize = 1;
+#if 0 // nRecordSize
+        nRecordSize = static_cast<GUIntBig>(nBlockXSize)
+            * static_cast<GUIntBig>(nBlockYSize)
+            * sizeof(GByte);
+#endif // nRecordSize
+#endif // not defined VRC36_PIXEL_IS_TILE - so VRC36_PIXEL_IS_PIXEL
+#endif // not defined VRC36_PIXEL_IS_FILE
+    } // else if (poVRCDS->nMagic == vrc_magic_thirtysix) {
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+    switch (eBandInterp) {
+    case GCI_GrayIndex:
+        CPLDebug("Viewranger", "eBandInterp Greyscale (x%08x)",
+             eBandInterp);
+        break;
+    case GCI_PaletteIndex:
+        CPLDebug("Viewranger", "eBandInterp Paletted (x%08x)",
+             eBandInterp);
+        break;
+    case GCI_RedBand:
+        CPLDebug("Viewranger", "eBandInterp Red (x%08x)",
+             eBandInterp);
+        break;
+    case GCI_GreenBand:
+        CPLDebug("Viewranger", "eBandInterp Green (x%08x)",
+             eBandInterp);
+        break;
+    case GCI_BlueBand:
+        CPLDebug("Viewranger", "eBandInterp Blue (x%08x)",
+             eBandInterp);
+        break;
+    case GCI_AlphaBand:
+        CPLDebug("Viewranger", "eBandInterp Alpha (x%08x)",
+             eBandInterp);
+        break;
+    default:
+        CPLDebug("Viewranger", "eBandInterp x%08x, (Red==x%08x)",
+                 eBandInterp, GCI_RedBand);
+        break;
+    }
+#pragma clang diagnostic pop
+    SetColorInterpretation(eBandInterp);
+
+/* -------------------------------------------------------------------- */
+/*      If this is the base layer, create the overview layers.          */
+/* -------------------------------------------------------------------- */
+
+#if defined VRC36_PIXEL_IS_FILE || defined VRC36_PIXEL_IS_TILE
+    if (poVRCDS->nMagic == vrc_magic_thirtysix) {
+        nOverviewCount=0;
+        return ;
+    }
+#endif // VRC36_PIXEL_IS_ not _PIXEL
+
+    if( nOverviewCount>=0 && nThisOverview == -1 ) {
+        if (papoOverviewBands != nullptr) {
+            CPLDebug("Viewranger OVRV",
+                     "%s nThisOverview==-1 but %d papoOverviewBands already set at %p",
+                     poVRCDS->sLongTitle.c_str(),
+                     nOverviewCount+1, papoOverviewBands);
+        } else {
+            if (nOverviewCount!=6) {
+                // Seen Fri 24 Jul 2020
+                CPLDebug("Viewranger OVRV",
+                         "nThisOverview==-1 expected 6 overviews but given %d",
+                         nOverviewCount);
+                // nOverviewCount=6; // Hack. FIXME
+            }
+            if (nOverviewCount>=32) {
+                // This is unnecessarily big;
+                // the scale factor will not fit in an int, and
+                // a 1cm / pixel map of the world will have a one pixel overview.
+                // nOverviewCount=32;
+                CPLDebug("Viewranger OVRV",
+                         "%s Reducing nOverviewCount from %d to 6",
+                         poVRCDS->sLongTitle.c_str(),
+                         nOverviewCount);
+                nOverviewCount=6;
+            }
+            if (nOverviewCount>=0) {
+                papoOverviewBands = static_cast<VRCRasterBand **>
+                    (CPLCalloc(sizeof(void*), 1+static_cast<size_t>(nOverviewCount)));
+                if (papoOverviewBands==nullptr) {
+                    // Seen Fri 24 Jul 2020
+                    CPLError(CE_Failure, CPLE_OutOfMemory,
+                             "Cannot allocate memory for %d overview bands",
+                             nOverviewCount+1
+                             );
+                    return;
+                }
+            }
+            CPLDebug("Viewranger OVRV",
+                     "%s this = %p VRCRasterBand(%p, %d, %d, %d, %p)",
+                     poVRCDS->sLongTitle.c_str(),
+                     this, poVRCDS, nBandIn, nThisOverview,
+                     nOverviewCount, papoOverviewBands);
+            for (int i=0; i<nOverviewCount; i++) {
+                if (papoOverviewBands[i]) {
+                    CPLError( CE_Warning, CPLE_AppDefined,
+                              "\toverview %p[%d] already set to %p",
+                              papoOverviewBands, i, papoOverviewBands[i]
+                              );
+                } else {
+                    papoOverviewBands[i]= new // 8 Feb 2021 leaks memory
+                        VRCRasterBand(poVRCDS, nBand, i,
+                                      // the overview has no overviews, so
+                                      0, nullptr
+                                      // not: nOverviewCount, papoOverviewBands
+                                      );
+                }
+            } // for (int i=0; i<nOverviewCount; i++) {
+        }
+    } else { // !(nOverviewCount>=0 && nThisOverview == -1)
+#if 1 // NOISY
+        // if (getenv("VRC_NOISY"))
+        {
+            if (papoOverviewBands == nullptr) {
+                CPLDebug("Viewranger OVRV",
+                         "nOverviewCount==%d nThisOverview==%d and papoOverviewBands is null - OK",
+                         nOverviewCount, nThisOverview);
+            } else {
+                CPLDebug("Viewranger OVRV",
+                         "nThisOverview==%d but papoOverviewBands is already set to %p",
+                         nThisOverview, papoOverviewBands);
+            }
+        }
+#endif // NOISY
+
+        if (nThisOverview<-1 || nThisOverview>nOverviewCount) { // Off-by-one somewhere ?
+            CPLDebug("ViewrangerOverview",
+                     "%s %p nThisOverview==%d out of range [-1,%d]",
+                     poVRCDS->sLongTitle.c_str(),
+                     this,
+                     nThisOverview, nOverviewCount);
+        }
+    }
+    
+    CPLDebug("Viewranger",
+             "%s %p->VRCRasterBand(%p, %d, %d, %d, %p) finished",
+             poVRCDS->sLongTitle.c_str(),
+             this, poVRCDS, nBand, nThisOverview,
+             nOverviewCount, papoOverviewBands
+             );
+
+} // VRCRasterBand::VRCRasterBand()
+
+/************************************************************************/
+/*                          ~VRCRasterBand()                            */
+/************************************************************************/
+
+VRCRasterBand::~VRCRasterBand()
+{
+    // FlushCache();
+
+    CPLDebug("Viewranger",
+             "deleting %p->VRCRasterBand(%p, %d, %d, %d, %p)",
+             this, poDS, nBand, nThisOverview,
+             nOverviewCount, papoOverviewBands);
+
+    if( nThisOverview<0 && papoOverviewBands) {
+        CPLDebug("Viewranger",
+                 "deleting papoOverviewBands %p",
+                 papoOverviewBands);
+        VRCRasterBand** papo=papoOverviewBands;
+        papoOverviewBands=nullptr;
+        if( nOverviewCount>0 ) {
+            int nC=nOverviewCount;
+            nOverviewCount=0;
+            for( int i = 0; i < nC; i++ ) {
+                if (papo[i]) {
+                    papo[i]->nOverviewCount=0;
+                    CPLDebug("Viewranger",
+                             "deleting papoOverviewBands[%d]=%p",
+                             i, papo[i]);
+                    delete papo[i];
+                    papo[i]=nullptr;
+                }
+            }
+        }
+        CPLFree( papo );
+    }
+}
+
+/************************************************************************/
+/*                             IReadBlock()                             */
+/************************************************************************/
+
+CPLErr VRCRasterBand::IReadBlock( int nBlockXOff, int nBlockYOff,
+                                  void * pImage )
+
+{
+    auto *poGDS = static_cast<VRCDataset *>(poDS);
+    
+    CPLDebug("Viewranger", "IReadBlock(%d,%d,%p) %d",
+             nBlockXOff, nBlockYOff, pImage, nThisOverview);
+    CPLDebug("Viewranger", "Block (%d,%d) %d x %d band %d (%d x %d) overview %d",
+             nBlockXOff, nBlockYOff,
+             nBlockXSize,nBlockYSize,
+             nBand,
+             nRasterXSize, nRasterXSize,
+             nThisOverview);
+    if (nBlockXOff < 0 || nBlockXOff*nBlockXSize >= nRasterXSize)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Block (any,%d) overview %d does not exist %d* %d >?= %d",
+                 nBlockXOff, nThisOverview,
+                 nBlockXOff, nRasterXSize, nBlockXSize );
+            return CE_Failure;
+    }
+    if (nBlockYOff < 0 || nBlockYOff*nBlockYSize >= nRasterYSize)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Block (any,%d)) overview %d does not exist %d* %d >?= %d",
+                 nBlockYOff, nThisOverview, nBlockYOff,
+                 poGDS->nRasterYSize, nBlockYSize );
+            return CE_Failure;
+    }
+
+    if ( poGDS->nMagic == vrc_magic_metres) {
+        read_VRC_Tile_Metres(poGDS->fp, nBlockXOff, nBlockYOff, pImage);
+        // return CE_None; // I cannot yet confirm no errors
+
+    } else  if (poGDS->nMagic == vrc_magic_thirtysix) {
+        // Seeing whether we can do thirtysix files at the (PNG/raw?) block level
+#if 0
+        read_VRC_Tile_Metres(poGDS->fp, nBlockXOff, nBlockYOff, pImage);
+#else
+        read_VRC_Tile_ThirtySix(poGDS->fp, nBlockXOff, nBlockYOff, pImage);
+#endif
+        // return CE_None; // I cannot yet confirm no errors
+    }
+
+    CPLErr eErr = CE_None;
+#if 0
+    // Copied from pngdataset.cpp PNGRasterBand::IReadBlock() lines 311-318
+    // Forcibly load the other bands associated with this scanline.
+    // Is this recursive ?
+    // Does GetRasterBand or GetLockedBlockRef call IReadBlock ?
+    //
+    // Does this need to understand overviews ?
+
+    for(int iBand = 1; iBand < poGDS->GetRasterCount(); iBand++)
+    {
+        CPLDebug("Viewranger",
+                 "Forcing band %d overview %d to be loaded.",
+                 iBand+1, nThisOverview);
+        GDALRasterBand *poBand = poGDS->GetRasterBand(iBand+1);
+        // if( nThisOverview != -1 ) {
+        //     poBand = poBand->GetOverview( nThisOverview );
+        // }
+        if (poBand != nullptr ) {
+            GDALRasterBlock *poBlock =
+                poBand->GetLockedBlockRef(nBlockXOff,nBlockYOff);
+            if( poBlock != nullptr ) {
+                poBlock->DropLock();
+            }
+        } else {
+            CPLDebug("Viewranger",
+                 "GetRasterBand(band %d) is null: overview %d.",
+                 iBand+1, nThisOverview);
+            eErr = CE_Failure;
+        }
+    }
+    CPLDebug("Viewranger",
+             "Forced %d bands to be loaded.",
+             poGDS->GetRasterCount());
+#endif
+    return eErr;
+} // VRCRasterBand::IReadBlock()
+
+/************************************************************************/
+/*                           GetNoDataValue()                           */
+/************************************************************************/
+
+double VRCRasterBand::GetNoDataValue( int *pbSuccess )
+{
+  if (pbSuccess) {
+      *pbSuccess=TRUE;
+  }
+  return nVRCNoData;
+}
+
+/************************************************************************/
+/*                           IGetDataCoverageStatus()                           */
+/************************************************************************/
+
+#if GDAL_VERSION_NUM >= 2020000
+    // See https://trac.osgeo.org/gdal/wiki/rfc63_sparse_datasets_improvements
+    // and https://github.com/rouault/gdal2/blob/sparse_datasets/gdal/frmts/gtiff/geotiff.cpp
+/* Most of this function
+ * Copyright (c) 1998, 2002, Frank Warmerdam <warmerdam@pobox.com>
+ * Copyright (c) 2007-2015, Even Rouault <even dot rouault at spatialys dot com>
+ */
+int VRCRasterBand::IGetDataCoverageStatus( int nXOff, int nYOff,
+                                           int nXSize, int nYSize,
+                                           int nMaskFlagStop,
+                                           double* pdfDataPct)
+{
+    int nStatus = 0;
+    auto *poGDS = static_cast<VRCDataset *>(poDS);
+    if ( poGDS->anTileIndex == nullptr ) {
+        nStatus = GDAL_DATA_COVERAGE_STATUS_UNIMPLEMENTED | GDAL_DATA_COVERAGE_STATUS_DATA;
+        CPLDebug("Viewranger", "IGetDataCoverageStatus(%d, %d, %d, %d, %d, %p) not yet available - Tile Index not yet read",
+                 nXOff, nYOff, nXSize, nYSize, nMaskFlagStop, pdfDataPct);
+        if( pdfDataPct ) {
+            *pdfDataPct = -1.0;
+        }
+        return nStatus;
+    }
+
+    CPLDebug("Viewranger", "IGetDataCoverageStatus(%d, %d, %d, %d, %d, %p) top skip %d right skip %d",
+             nXOff, nYOff, nXSize, nYSize, nMaskFlagStop, pdfDataPct,
+             poGDS->nTopSkipPix, poGDS->nRightSkipPix);
+
+    const int iXBlockStart = nXOff / nBlockXSize;
+    const int iXBlockEnd = (nXOff + nXSize - 1) / nBlockXSize;
+    const int iYBlockStart = nYOff / nBlockYSize;
+    const int iYBlockEnd = (nYOff + nYSize - 1) / nBlockYSize;
+
+    GIntBig nPixelsData = 0;
+    int nTopEdge = MAX( nYOff, poGDS->nTopSkipPix);
+    int nRightEdge = //nXOff + nXSize; //
+        MIN( nXOff + nXSize, poGDS->nRasterXSize - poGDS->nRightSkipPix);
+    for( int iY = iYBlockStart; iY <= iYBlockEnd; ++iY ) {
+        for( int iX = iXBlockStart; iX <= iXBlockEnd; ++iX ) {
+            const int nBlockIdBand0 =
+                iX + iY * nBlocksPerRow;
+            int nBlockId = nBlockIdBand0;
+            bool bHasData = false;
+            if( poGDS->anTileIndex[nBlockId] == 0 ) {
+                nStatus |= GDAL_DATA_COVERAGE_STATUS_EMPTY;
+            } else {
+                bHasData = true;
+            }
+            if( bHasData ) {
+                // We could be more accurate by looking at the png sub-tiles.
+                // We should also discount any strip we added for short (or narrow?) tiles.
+                nPixelsData += (MIN( (iX + 1) * nBlockXSize, nRightEdge ) - MAX( iX * nBlockXSize, nXOff )) *
+                               (MIN( (iY + 1) * nBlockYSize, nYOff+nYSize) - MAX( iY * nBlockYSize, nTopEdge ));
+                nStatus |= GDAL_DATA_COVERAGE_STATUS_DATA;
+            }
+            if( nMaskFlagStop != 0 && (nMaskFlagStop & nStatus) != 0 ) {
+                if( pdfDataPct ) {
+                    *pdfDataPct = -1.0;
+                }
+                return nStatus;
+            }
+        }
+    }
+
+    double dfDataPct =
+        100.0 * static_cast<double>(nPixelsData) /
+        (static_cast<double>(nXSize) * static_cast<double>(nYSize));
+    if (pdfDataPct) {
+        *pdfDataPct = dfDataPct;
+    }
+
+    CPLDebug("Viewranger",
+             "IGetDataCoverageStatus(%d, %d, %d, %d, %d, %p) returns %d with %lf%% coverage",
+             nXOff, nYOff, nXSize, nYSize, nMaskFlagStop,
+             pdfDataPct, nStatus, dfDataPct);
+
+    return nStatus;
+} // VRCRasterBand::IGetDataCoverageStatus()
+#endif
+
+/************************************************************************/
+/*                       GetColorInterpretation()                       */
+/************************************************************************/
+
+GDALColorInterp VRCRasterBand::GetColorInterpretation()
+
+{
+    auto *poGDS = static_cast<VRCDataset*>(poDS);
+    if (poGDS->nMagic == vrc_magic_metres) {
+        CPLDebug("Viewranger",
+                 "VRCRasterBand::GetColorInterpretation vrcmetres GetColorInterpretation %08x %d",
+                 poGDS->nMagic, this->eBandInterp);
+        return this->eBandInterp;
+    } else if (poGDS->nMagic == vrc_magic_thirtysix) {
+        CPLDebug("Viewranger",
+                 "VRCRasterBand::GetColorInterpretation vrcthirtysix GetColorInterpretation %08x %d",
+                 poGDS->nMagic, this->eBandInterp);
+        return this->eBandInterp;
+    } else {
+        CPLDebug("Viewranger",
+                 "VRCRasterBand::GetColorInterpretation unexpected magic %08x - GetColorInterpretation %d -but returning GrayIndex",
+                 poGDS->nMagic, this->eBandInterp);
+        return GCI_GrayIndex;
+    }
+}
+
+
+/************************************************************************/
+/*                           GetColorTable()                            */
+/************************************************************************/
+
+GDALColorTable *VRCRasterBand::GetColorTable()
+
+{
+#if 0
+    VRCDataset  *poGDS = static_cast<VRCDataset *>(poDS);
+
+    if( nBand == 1 )
+        return poGDS->poColorTable;
+    else
+#endif
+        return nullptr;
+}
+
+
+/************************************************************************/
+/* ==================================================================== */
+/*                            VRCDataset                                */
+/* ==================================================================== */
+/************************************************************************/
+
+/************************************************************************/
+/*                            VRCDataset()                              */
+/************************************************************************/
+
+VRCDataset::VRCDataset() :
+    fp(nullptr),
+    poColorTable ( nullptr),
+    anColumnIndex ( nullptr),
+    anTileIndex ( nullptr),
+
+    // These are only here to keep cppcheck happy
+    // They may make the program think things are OK when they are not.
+#ifdef CODE_ANALYSIS
+    nMagic(0),
+    dfPixelMetres(0.0),
+    nMapID(-1),
+
+    nLeft(INT_MAX),
+    nRight(INT_MIN),
+    nTop(INT_MIN),
+    nBottom(INT_MAX),
+    nTopSkipPix(0),
+    nRightSkipPix(0),
+    nScale(0),
+    nMaxOverviewCount(7),
+    nCountry(-1),
+#endif // CODE_ANALYSIS
+
+    poSRS(nullptr)
+
+    // ,sLongTitle("")
+    // ,sCopyright("")
+
+#ifdef CODE_ANALYSIS
+    , tileSizeMax(0),
+    tileSizeMin(INT_MAX),
+    tileXcount(0),
+    tileYcount(0)
+#endif // CODE_ANALYSIS
+{
+
+    // Real "initialization" is done later, in VRCDataset::Open()
+    // but some values need to be set before
+    // IGetDataCoverageStatus() is called.
+    nTopSkipPix=0;
+    nRightSkipPix=0;
+    
+    CPLDebug("Viewranger",
+             "creating VRCDataset %p",
+             this);
+
+} // VRCDataset::VRCDataset()
+
+
+/************************************************************************/
+/*                           ~VRCDataset()                             */
+/************************************************************************/
+
+VRCDataset::~VRCDataset()
+{
+    FlushCache();
+    if( fp != nullptr )
+        VSIFCloseL( fp );
+
+    if( poColorTable != nullptr )
+        delete ( poColorTable );
+
+    if (anColumnIndex != nullptr ) {
+        VSIFree(anColumnIndex);
+        anColumnIndex = nullptr;
+    }
+    if (anTileIndex != nullptr ) {
+        VSIFree(anTileIndex);
+        anTileIndex = nullptr;
+    }
+#if 0
+    if (pszLongTitle != nullptr ) {
+        VSIFree(pszLongTitle);
+        pszLongTitle = nullptr;
+    }
+    if (pszCopyright != nullptr ) {
+        VSIFree(pszCopyright);
+        pszCopyright = nullptr;
+    }
+#elif 0 // These don't compile
+    if (sLongTitle) {
+        VSIFree(sLongTitle);
+        sLongTitle = nullptr;
+    }
+    if (sCopyright) {
+        VSIFree(sCopyright);
+        sCopyright = nullptr;
+    }
+#endif
+#if 0
+    // trying to free strings created in VRCDataset::Open
+    if (paszStrings) {
+        for (int ii=0; ii<nStringCount; ++ii) {
+            if (paszStrings[ii]) {
+                VSIFree(paszStrings[ii]);
+                paszStrings[ii] = nullptr;
+            }
+        }
+        VSIFree(paszStrings);
+        paszStrings = nullptr;
+    }
+#endif
+
+    if (poSRS) {
+        poSRS->Release();
+        poSRS = nullptr;
+    }
+} // VRCDataset::~VRCDataset()
+
+/************************************************************************/
+/*                          GetGeoTransform()                           */
+/************************************************************************/
+CPLErr VRCDataset::GetGeoTransform( double * padfTransform )
+{
+    const double tenMillion = 10.0 * 1000 * 1000;
+
+    double dLeft = nLeft;
+    double dRight = nRight;
+    double dTop = nTop ;
+    double dBottom = nBottom ;
+
+    if (nCountry == 17) {
+        // This may not be correct
+        // USA, Discovery (Spain) and some Belgium (VRH height) maps have coordinate unit of
+        //   1 degree/ten million
+        CPLDebug("Viewranger", "country/srs 17 USA?Belgium?Discovery(Spain) grid is unknown. Current guess is unlikely to be correct.");
+#if 0 // standard until 20 Sept 2020
+        dLeft   /= tenMillion;
+        dRight  /= tenMillion;
+        dTop    /= tenMillion;
+        dBottom /= tenMillion;
+#else
+        const double nineMillion = 9.0 * 1000 * 1000;
+        dLeft   /= nineMillion;
+        dRight  /= nineMillion;
+        dTop    /= nineMillion;
+        dBottom /= nineMillion;
+#endif // standard until 20 Sept 2020
+        CPLDebug("Viewranger", "scaling by 10 million: TL: %g %g BR: %g %g",
+                 dTop,dLeft,dBottom,dRight);
+    } else if (nCountry == 155) {
+        // New South Wales, Australia uses GDA94/MGA55 EPSG:28355
+        // but without the 10million metre false_northing
+        dLeft   = 1.0*nLeft;
+        dRight  = 1.0*nRight;
+        dTop    = 1.0*nTop + tenMillion;
+        dBottom = 1.0*nBottom + tenMillion;
+
+        CPLDebug("Viewranger", "shifting by 10 million: TL: %g %g BR: %g %g",
+                 dTop,dLeft,dBottom,dRight);
+    }
+
+    // Xgeo = padfTransform[0] + pixel*padfTransform[1] + line*padfTransform[2];
+    // Ygeo = padfTransform[3] + pixel*padfTransform[4] + line*padfTransform[5];
+    if (nMagic == vrc_magic_metres) {
+        padfTransform[0] = dLeft;
+        padfTransform[1] = (1.0*dRight - dLeft) / (GetRasterXSize() /* -1.0 */);
+        padfTransform[2] = 0.0;
+        padfTransform[3] = dTop;
+        padfTransform[4] = 0.0;
+        padfTransform[5] = (1.0*dBottom - dTop) / (GetRasterYSize() /* -1.0 */);
+    } else if (nMagic == vrc_magic_thirtysix) {
+        padfTransform[0] = dLeft;
+        padfTransform[1] = (1.0*dRight - dLeft);
+        padfTransform[2] = 0.0;
+        padfTransform[3] = dTop;
+        padfTransform[4] = 0.0;
+        padfTransform[5] = (1.0*dBottom - dTop);
+#if !defined VRC36_PIXEL_IS_FILE
+        padfTransform[1] /= (GetRasterXSize());
+        padfTransform[5] /= (GetRasterYSize());
+#endif
+    } else {
+        CPLDebug("Viewranger", "nMagic x%08x unknown", nMagic);
+        padfTransform[0] = dLeft;
+        padfTransform[1] = (1.0*dRight - dLeft) / (GetRasterXSize() /* -1.0 */);
+        padfTransform[2] = 0.0;
+        padfTransform[3] = dTop;
+        padfTransform[4] = 0.0;
+        padfTransform[5] = (1.0*dBottom - dTop) / (GetRasterYSize() /* -1.0 */);
+    }
+
+    CPLDebug("Viewranger", "padfTransform raster %d x %d", GetRasterXSize(), GetRasterYSize());
+    CPLDebug("Viewranger", "padfTransform %g %g %g", padfTransform[0], padfTransform[1], padfTransform[2]);
+    CPLDebug("Viewranger", "padfTransform %g %g %g", padfTransform[3], padfTransform[4], padfTransform[5]);
+    return CE_None;
+} // GetGeoTransform()
+
+/************************************************************************/
+/*                           CleanOverviews()                           */
+/************************************************************************/
+
+#if 0
+CPLErr VRCRasterBand::CleanOverviews()
+{
+    CPLDebug("Viewranger",
+             "%p->VRCRasterBand::CleanOverviews() band=%d, overview %d of %d, %p\n",
+             poDS, nBand,
+             nThisOverview, nOverviewCount,
+             papoOverviewBands
+             );
+    
+    if( nOverviewCount == 0 )
+        return CE_None;
+
+    // Clear our reference to overviews as bands.
+    for( int iOverview = 0; iOverview < nOverviewCount; iOverview++ ) {
+        delete papoOverviewBands[iOverview];
+    }
+
+    CPLFree(papoOverviewBands);
+    papoOverviewBands = nullptr;
+    nOverviewCount = 0;
+
+#if 0
+    // Search for any RRDNamesList and destroy it.
+    HFABand *poBand = hHFA->papoBand[nBand - 1];
+    HFAEntry *poEntry = poBand->poNode->GetNamedChild("RRDNamesList");
+    if( poEntry != nullptr )
+    {
+        poEntry->RemoveAndDestroy();
+    }
+
+    // Destroy and subsample layers under our band.
+    for( HFAEntry *poChild = poBand->poNode->GetChild();
+         poChild != nullptr; )
+    {
+        HFAEntry *poNext = poChild->GetNext();
+
+        if( EQUAL(poChild->GetType(), "Eimg_Layer_SubSample") )
+            poChild->RemoveAndDestroy();
+
+        poChild = poNext;
+    }
+#endif
+    return CE_None;
+} // VRCRasterBand::CleanOverviews()
+#endif
+
+
+/************************************************************************/
+/*                              Identify()                              */
+/************************************************************************/
+
+int VRCDataset::Identify( GDALOpenInfo * poOpenInfo )
+
+{
+#if 1
+    const char* fileName = CPLGetFilename(poOpenInfo->pszFilename);
+    if( fileName==nullptr ) {
+        return GDAL_IDENTIFY_FALSE;
+    }
+    if( !EQUAL(fileName + strlen(fileName) - strlen(".VRC"), ".VRC")) {
+        return GDAL_IDENTIFY_FALSE;
+    }
+#endif
+
+    if ( poOpenInfo->nHeaderBytes < 12 ) {
+         return GDAL_IDENTIFY_UNKNOWN;
+    }
+
+    unsigned int nMagic = VRGetUInt(poOpenInfo->pabyHeader, 0);
+    // unsigned int version = VRGetUInt(poOpenInfo->pabyHeader, 4);
+
+    bool b64k1=(VRGetUInt(poOpenInfo->pabyHeader, 8) == 0x10001);
+
+    if( nMagic == vrc_magic_metres ) {
+        CPLDebug("Viewranger", "VRCmetres file %s supported",
+                 poOpenInfo->pszFilename);
+        if (!b64k1) {
+            CPLDebug("Viewranger",
+                     "VRC file %s - limited support for unusual third long (not x10001)",
+                     poOpenInfo->pszFilename);
+        }
+        return GDAL_IDENTIFY_TRUE;
+    } else if( nMagic == vrc_magic_thirtysix ) {
+            CPLError( CE_Warning, CPLE_AppDefined,
+                      "%s: image data for .VRC magic 0x3663ce01 files not yet understood",
+                 poOpenInfo->pszFilename);
+        if (!b64k1) {
+            CPLDebug("Viewranger",
+                     "VRC file %s - limited support for unusual third long (not x10001)",
+                     poOpenInfo->pszFilename);
+        }
+        return GDAL_IDENTIFY_TRUE;
+    }
+    return GDAL_IDENTIFY_FALSE;
+} // VRCDataset::Identify()
+
+
+/************************************************************************/
+/*                              VRCGetTileIndex()                       */
+/************************************************************************/
+
+
+unsigned int* VRCDataset::VRCGetTileIndex( unsigned int nTileIndexStart )
+{
+    // We were reading from abyHeader;
+    // the next bit may be too big for that,
+    // so we need to start reading directly from the file.
+
+    //int nTileStart = -1;
+    if ( VSIFSeekL( fp, static_cast<size_t>(nTileIndexStart), SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to VRC tile index" );
+        return nullptr;
+    }
+
+#if 0 // only true for MapId 8. Maybe not even then.
+    int nSeven=VRReadInt(fp);
+    if (nSeven == 7) {
+        // CPLDebug does not support m$ in format strings
+        CPLDebug("Viewranger",
+                 "VRCGetTileIndex(): %d=x%08x points to seven as expected",
+                 startHere, startHere);
+    } else {
+        CPLDebug("Viewranger",
+                 "VRCGetTileIndex(): %d=x%08x arg points to %08x - not seven",
+                 startHere, startHere, nSeven);
+    }
+#endif
+
+    auto *anNewTileIndex = static_cast<unsigned int *>
+        (VSIMalloc3(sizeof (unsigned int),
+                    static_cast<size_t>(tileXcount),
+                    static_cast<size_t>(tileYcount)) );
+    if (anNewTileIndex == nullptr) {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate memory for tile index");
+        return nullptr;
+    }
+
+    // Read Tile Index into memory
+    // rotating it as we read it,
+    // since viewranger files start by going up the left column
+    // whilst gdal expects to go left to right across the top row.
+    for (int i=0; i<tileXcount; i++) {
+        int q = tileXcount*(tileYcount-1) +i;
+        for (int j=0; j<tileYcount; j++) {
+            unsigned int nValue = VRReadUInt(fp);
+            // Ignore the index if it points
+            // outside the limits of the file
+            if (/* nValue <= 0 || */ nValue >= oStatBufL.st_size) {
+                CPLDebug("Viewranger",
+                         "anNewTileIndex[%d] (%d %d) addr x%08x not in file",
+                         q, i, j, nValue);
+                nValue = 0; // nVRCNoData ? ;
+            }
+            CPLDebug("Viewranger",
+                     "setting anNewTileIndex[%d] (%d %d) to %d=x%08x",
+                     q, i, j, nValue, nValue);
+            anNewTileIndex[q] = nValue;
+            q -= tileXcount;
+        }
+    }
+
+    // Separate loop, since the previous loop has sequential reads
+    // and this loop has random reads.
+    for (int q=0; q<tileXcount*tileYcount; q++) {
+        unsigned int nIndex=anNewTileIndex[q];
+        if (nIndex<16) {
+            CPLDebug("Viewranger",
+                     "anNewTileIndex[%d]=x%08x=%d - points into file header",
+                     q, nIndex, nIndex);
+            anNewTileIndex[q] = 0;
+            continue;
+        }
+
+        // This looks promising on DE_50 tiles
+        // see how good it is in general
+        if ( (nIndex %100) == 0 && nIndex < 10000) {
+            CPLDebug("Viewranger",
+                     "anNewTileIndex[%d]=x%08x=%d - ignore small multiples of 100",
+                     q, nIndex, nIndex);
+            anNewTileIndex[q] = 0;
+            continue;
+        }
+        int nValue = VRReadInt(fp, nIndex);
+        if (/*nIndex>0 && */nValue != 7) {
+            CPLDebug("Viewranger",
+                     "anNewTileIndex[%d]=%08x points to %d=x%08x - expected seven.",
+                     q, nIndex, nValue, nValue);
+        }
+    }
+    return anNewTileIndex;
+} // VRCDataset::VRCGetTileIndex()
+
+// MapId==8 files may have more than one tile.
+// If so there is not tile index (that I can find),
+// so we have to wander through the tile overview indices to build it.
+//
+// This may be a bit hacky.
+//
+unsigned int* VRCDataset::VRCBuildTileIndex( unsigned int nTileIndexStart )
+{
+    if (nMapID!=8) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRCBuildTileIndex called for a map with mapID %d",
+                  nMapID);
+    }
+    if ( VSIFSeekL( fp, static_cast<size_t>(nTileIndexStart), SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to VRC tile index start 0x%xu",
+                  nTileIndexStart);
+        return nullptr;
+    }
+    if (tileXcount<=0 || tileYcount<=0) {
+         CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRCBuildTileIndex(x%x) called for empty (%d x %d) image",
+                   nTileIndexStart, tileXcount, tileYcount);
+        return nullptr;
+    }
+
+    auto *anNewTileIndex = static_cast<unsigned int *>
+        (VSIMalloc3(sizeof (unsigned int),
+                    static_cast<size_t>(tileXcount),
+                    static_cast<size_t>(tileYcount)) );
+    if (anNewTileIndex == nullptr) {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate memory for tile index");
+        return nullptr;
+    }
+    int nTileFound=0;
+    for (nTileFound=0; nTileFound < tileXcount * tileYcount; nTileFound++) {
+        anNewTileIndex[nTileFound]=0;
+    }
+    nTileFound=0;
+    unsigned int nLastTileFound = anNewTileIndex[nTileFound++] = nTileIndexStart;
+    while (nTileFound < tileXcount * tileYcount) {
+        // VR tiles start at the bottom left and count up then right;
+        // GDAL tiles start at the top left and count across then down.
+        int nVRow = nTileFound % tileYcount;
+        // int nGRow = tileYcount-1 - nVRow;
+        // int nVCol = (nTileFound-nVRow) / tileYcount;
+        // int nGCol = nVCol;
+        // int nGdalTile = nGCol + nGRow * tileXcount;
+        // int nGdalTile = (nTileFound-nTileFound % tileYcount) / tileYcount
+        //    + (tileYcount-1 - nTileFound % tileYcount) * tileXcount;
+        int nGdalTile = (nTileFound - nVRow) / tileYcount + nVRow * tileXcount;
+
+        // Ignore the index if it points
+        // outside the limits of the file
+        if (/* nLastTileFound <= 0 || */ nLastTileFound >= oStatBufL.st_size) {
+            if (nLastTileFound == oStatBufL.st_size) {
+                CPLDebug("Viewranger",
+                         "Searching for anTileIndex[%d]: nLastTileFound x%08x is end of file",
+                         nTileFound, nLastTileFound);
+            } else {
+                CPLDebug("Viewranger",
+                         "Searching for anTileIndex[%d]: nLastTileFound x%08x beyond end of file",
+                         nTileFound, nLastTileFound);
+            }
+            break;
+        }
+        
+        int nOverviewCount = VRReadInt(fp, nLastTileFound);
+        if (nOverviewCount!=7) {
+            CPLDebug("Viewranger",
+                     "VRCBuildTileIndex(0x%08x) tile %d 0x%08x: expected OverviewIndex with 7 entries - got %d",
+                     nTileIndexStart,
+                     nTileFound, nLastTileFound,
+                     nOverviewCount );
+            //VSIFree(anNewTileIndex);
+            //return nullptr;
+            break;
+        }
+        unsigned int anOverviewIndex[7]={};
+        size_t res=VSIFReadL(anOverviewIndex, 4, 7, fp);
+        if (res!=7) {
+            CPLDebug("Viewranger",
+                     "VRCBuildTileIndex(%d) tile %d 0x%08x: expected OverviewIndex with %d entries - read %zd",
+                     nTileIndexStart,
+                     nTileFound, nLastTileFound,
+                     7 //nOverviewCount,
+                     , res );
+            //VSIFree(anNewTileIndex);
+            //return nullptr;
+            break;
+        }
+        int nLastOI = nOverviewCount;
+        while (nLastOI>0) {
+            nLastOI--;
+            if (anOverviewIndex[nLastOI]) {
+                unsigned int x = VRReadUInt(fp, anOverviewIndex[nLastOI]);
+                unsigned int y = VRReadUInt(fp);
+                anNewTileIndex[nGdalTile] =
+                    VRReadUInt(fp,
+                              anOverviewIndex[nLastOI] +
+                              (
+                               2+2 // tile count and size
+                               +x*y // ignore x by y matrix
+                                    // and read the "pointer to end of last tile"
+                               )*sizeof(int) );
+                nLastTileFound=anNewTileIndex[nGdalTile];
+                nTileFound++;
+                break;
+            }
+        }
+        if (nLastOI<=0) break;
+    } // while (nTileFound < tileXcount * tileYcount)
+    for (int y=0; y<tileYcount; y++) {
+        for (int x=0; x<tileXcount; x++) {
+            CPLDebug("Viewranger",
+                     "anNewTileIndex[%d,%d] = %x",
+                     x,y, anNewTileIndex[x+y*tileXcount] );
+        }
+    }
+    return anNewTileIndex;
+} //VRCDataset::VRCBuildTileIndex()
+
+/************************************************************************/
+/*                                Open()                                */
+/************************************************************************/
+
+GDALDataset *VRCDataset::Open( GDALOpenInfo * poOpenInfo )
+
+{
+    CPLDebug("Viewranger",
+             "VRCDataset::Open( %p )",
+             poOpenInfo);
+    
+    if (!Identify(poOpenInfo))
+        return nullptr;
+
+#if defined(__GNUC__)
+    //    CPLDebug("Viewranger", "__GNUC__ defined as %d", __GNUC__);
+    CPLDebug("Viewranger", "__GNUC__ defined");
+#else
+    CPLDebug("Viewranger", "__GNUC__ not defined");
+#endif
+#if defined(_GNU_SOURCE)
+    CPLDebug("Viewranger", "_GNU_SOURCE defined as %d", _GNU_SOURCE);
+#else
+    CPLDebug("Viewranger", "_GNU_SOURCE not defined");
+#endif
+#if defined(GCC_VERSION)
+    CPLDebug("Viewranger", "GCC_VERSION defined as %d", GCC_VERSION);
+#else
+    CPLDebug("Viewranger", "GCC_VERSION not defined");
+#endif
+#if defined(__clang__)
+    CPLDebug("Viewranger", "__clang__ defined as %d", __clang__);
+#else
+    CPLDebug("Viewranger", "__clang__ not defined");
+#endif
+#if defined(__cplusplus)
+    CPLDebug("Viewranger", "__cplusplus defined as %ld", __cplusplus);
+#else
+    CPLDebug("Viewranger", "__cplusplus not defined");
+#endif
+#if defined(_POSIX_C_SOURCE)
+    CPLDebug("Viewranger", "_POSIX_C_SOURCE defined as %ld", _POSIX_C_SOURCE);
+#else
+    CPLDebug("Viewranger", "_POSIX_C_SOURCE not defined");
+#endif
+#if defined(WIN32)
+    CPLDebug("Viewranger", "WIN32 defined as %s", "WIN32");
+#else
+    CPLDebug("Viewranger", "WIN32 not defined");
+#endif
+#if defined(override)
+    CPLDebug("Viewranger", "override defined as %ld", override+0l);
+#else
+    CPLDebug("Viewranger", "override not defined");
+#endif
+#if defined(nullptr)
+    CPLDebug("Viewranger", "nullptr defined as %d", nullptr);
+#else
+    CPLDebug("Viewranger", "nullptr not defined");
+#endif
+    
+#if GDAL_VERSION_MAJOR >= 2
+    /* Check that the file pointer from GDALOpenInfo* is available */
+    if( poOpenInfo->fpL == nullptr )
+    {
+        return nullptr;
+    }
+#endif
+
+/* -------------------------------------------------------------------- */
+/*      Confirm the requested access is supported.                      */
+/* -------------------------------------------------------------------- */
+    if( poOpenInfo->eAccess == GA_Update )
+    {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "The VRC driver does not support update access to existing"
+                  " datasets.\n" );
+        return nullptr;
+    }
+
+
+/* -------------------------------------------------------------------- */
+/*      Create a corresponding GDALDataset.                             */
+/* -------------------------------------------------------------------- */
+
+    auto*poDS = new VRCDataset();
+
+#if GDAL_VERSION_MAJOR >= 2
+    /* Borrow the file pointer from GDALOpenInfo* */
+    poDS->fp = poOpenInfo->fpL;
+    poOpenInfo->fpL = nullptr;
+#else
+    poDS->fp = VSIFOpenL( poOpenInfo->pszFilename, "rb" );
+    if (poDS->fp == nullptr)
+    {
+        GDALClose(poDS);
+        poDS=nullptr;
+        return nullptr;
+    }
+#endif
+
+/* -------------------------------------------------------------------- */
+/*      Read the header.                                                */
+/* -------------------------------------------------------------------- */
+    VSIFReadL( poDS->abyHeader, 1, 0x5a0, poDS->fp );
+
+    poDS->nMagic = VRGetUInt(poOpenInfo->pabyHeader, 0);
+
+    if (poDS->nMagic != vrc_magic_metres && poDS->nMagic != vrc_magic_thirtysix) {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "File magic 0x%08x unknown to viewranger VRC driver\n",
+                  poDS->nMagic );
+        GDALClose(poDS);
+        poDS=nullptr;
+        return nullptr;
+    }
+
+    {
+        // Verify and/or report some unknown?unused values early in the header
+        auto nVRCdownloadID =
+            static_cast<unsigned int>(VRGetShort(poOpenInfo->pabyHeader, 4));
+        unsigned int sixtyfourKplus1 = VRGetUInt( poDS->abyHeader, 8 );
+        int byte12 = poDS->abyHeader[12];
+        int byte13 = poDS->abyHeader[13];
+
+        if (nVRCdownloadID!=4) {
+            CPLDebug("Viewranger", "VRC file %s unexpected download ID %d",
+                     poOpenInfo->pszFilename, nVRCdownloadID);
+        }
+        if (sixtyfourKplus1!=0x00010001) {
+            CPLDebug("Viewranger", "VRC file %s expected 0x00010001 but got 0x%08x",
+                     poOpenInfo->pszFilename, sixtyfourKplus1);
+        }
+        // No idea what byte12 and byte13 represent;
+        // report them in case I can spot a pattern.
+        if (byte12!=15) {
+            // NSWRoadMap250k.VRC has 0xAA
+            CPLDebug("Viewranger", "VRC file %s byte 0x0000000c is 0x%02x - expected 0x0f",
+                 poOpenInfo->pszFilename, byte12);
+        }
+        if (byte13!=9) {
+            CPLDebug("Viewranger", "VRC file %s byte 0x0000000d is 0x%02x - expected 0x09",
+                     poOpenInfo->pszFilename, byte13);
+        }
+    }  // Verify and/or report some unknown?unused values early in the header
+
+    poDS->nCountry = VRGetShort(poDS->abyHeader, 6);
+    const char* szInCharset = CharsetFromCountry(poDS->nCountry);
+    const char* szOutCharset = "UTF-8";
+
+    CPLDebug("ViewRanger",
+             "Country %d has charset %s",
+             poDS->nCountry, szInCharset
+             );
+
+    poDS->nMapID = VRGetInt( poDS->abyHeader, 14 );
+    if (   poDS->nMapID !=  -10 // Demo_{Hemsedal,Oslo}.VRC IrelandTrial50K.VRC
+        && poDS->nMapID !=    0 // overviews and some demos
+        && poDS->nMapID !=    8 // pay-by-tile
+        && poDS->nMapID !=   16 // GreatBritain-250k-{FarNorth,North,South}.VRC
+        && poDS->nMapID !=   22 // Finland1M.VRC
+        && poDS->nMapID !=  293 // SouthTyrol50k/SouthTyro50k.VRC
+        && poDS->nMapID !=  294 // TrentinoGarda50k.VRC
+        && poDS->nMapID !=  588 // Danmark50k-*.VRC
+        && poDS->nMapID != 3038 // 4LAND200AlpSouth
+         ) {
+#if 1
+        CPLDebug("Viewranger", "VRC file %s unexpected Map ID %d",
+                 poOpenInfo->pszFilename, poDS->nMapID);
+#else
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "VRC file %s unexpected Map ID %d",
+                 poOpenInfo->pszFilename, poDS->nMapID);
+        return nullptr;
+#endif
+    }
+
+    {
+#define VRCpszMapIDlen 11
+        char pszMapID[VRCpszMapIDlen]="";
+        int ret=CPLsnprintf(pszMapID, VRCpszMapIDlen, "0x%08x", poDS->nMapID);
+        pszMapID[VRCpszMapIDlen-1]='\000';
+        if(ret==VRCpszMapIDlen-1) {
+            poDS->SetMetadataItem("VRC ViewRanger MapID", pszMapID, "");
+        } else {
+            CPLDebug("Viewranger",
+                     "Could not set MapID Metadata - CPLsnprintf( , VRCpszMapIDlen, 0x%08x) returned %d", poDS->nMapID, ret);
+        }
+#undef VRCpszMapIDlen
+    }
+
+    unsigned int nStringCount = VRGetUInt( poDS->abyHeader, 18 );
+    unsigned int nNextString = 22;
+    if (nStringCount == 0 && poDS->nMapID == 8) {
+        // seems to be needed for pay-by-tile files
+        CPLDebug("Viewranger", "Pay-by-tile; skipping null int before string count.");
+        nStringCount = VRGetUInt( poDS->abyHeader, 22 );
+        nNextString += 4;
+    }
+    CPLDebug("Viewranger", "VRC Map ID %d with %d strings",
+             poDS->nMapID, nStringCount);
+    if (poDS->nMagic == vrc_magic_metres) {
+        CPLDebug("Viewranger", "vrc_magic_metres driver represents all pixels");
+    } else {
+#if defined VRC36_PIXEL_IS_FILE
+        CPLDebug("Viewranger", "vrc_magic_thirtysix driver represents a whole file in each pixel");
+#else
+#if defined VRC36_PIXEL_IS_TILE
+        CPLDebug("Viewranger", "vrc_magic_thirtysix driver represents a tile in each pixel");
+#else
+        // VRC36_PIXEL_IS_PIXEL is the default
+        CPLDebug("Viewranger", "vrc_magic_thirtysix driver represents all pixels");
+#endif
+#endif
+    }
+    char ** paszStrings =
+        static_cast<char **>(VSIMalloc2(sizeof (char *), nStringCount));
+    if (paszStrings == nullptr) {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate memory for array strings");
+        return nullptr;
+    }
+    for (unsigned int ii=0; ii<nStringCount; ++ii) {
+        paszStrings[ii] = VRCGetString(poDS->fp, nNextString);
+        nNextString += 4 + VRGetUInt( poDS->abyHeader, nNextString );
+        CPLDebug("Viewranger", "string %u %s", ii,
+                 paszStrings[ii] );
+
+        if (*paszStrings[ii]) {
+            // Save the string as a MetadataItem.
+            const int VRCpszTAGlen=18;
+            char pszTag[VRCpszTAGlen+1]="";
+            int ret=CPLsnprintf(pszTag, VRCpszTAGlen, "String%u", ii);
+            pszTag[VRCpszTAGlen] = '\000';
+            if(VRCpszTAGlen>=ret && ret>0) {
+                poDS->SetMetadataItem
+                    ( pszTag,
+                      CPLRecode(paszStrings[ii],
+                                szInCharset, szOutCharset)
+                      );
+            } else {
+                CPLDebug("Viewranger",
+                         "Could not set String%d Metadata - CPLsnprintf(..., VRCpszTAGlen %s) returned %d",
+                         ii, paszStrings[ii], ret);
+            }
+        }
+    }
+    if (nStringCount > 0) {
+        poDS->sLongTitle = CPLRecode(paszStrings[0],
+                                     szInCharset, szOutCharset);
+        poDS->SetMetadataItem("TIFFTAG_IMAGEDESCRIPTION",
+                              poDS->sLongTitle.c_str(), "" );
+    }
+    if (nStringCount > 1) {
+        // poDS->sCopyright = CPLString(paszStrings[1]);
+        poDS->sCopyright = CPLRecode(paszStrings[1],
+                                     szInCharset, szOutCharset);
+        poDS->SetMetadataItem("TIFFTAG_COPYRIGHT",
+                              poDS->sCopyright.c_str(), "" );
+    }
+    if (nStringCount > 5 && *paszStrings[5]) {
+        poDS->SetMetadataItem("VRC ViewRanger Device ID",
+                              CPLString(paszStrings[5]).c_str(), "" );
+    }
+
+    poDS->nLeft   = VRGetInt( poDS->abyHeader, nNextString );
+    poDS->nTop    = VRGetInt( poDS->abyHeader, nNextString +4 );
+    poDS->nRight  = VRGetInt( poDS->abyHeader, nNextString +8 );
+    poDS->nBottom = VRGetInt( poDS->abyHeader, nNextString +12 );
+    poDS->nScale  = VRGetUInt( poDS->abyHeader, nNextString +16 );
+    if (poDS->nScale==0) {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Cannot locate a VRC map with zero scale");
+        return nullptr;        
+    }
+
+    // based on 10 pixels/millimetre (254 dpi)
+    poDS->dfPixelMetres = poDS->nScale / 10000.0;
+    if (static_cast<unsigned long>(lround(10000.0*poDS->dfPixelMetres)) != poDS->nScale )
+    {
+        CPLDebug("Viewranger", "VRC %f metre pixels is not exactly 1:%d",
+                 poDS->dfPixelMetres, poDS->nScale);
+    } else {
+        CPLDebug("Viewranger", "VRC %f metre pixels",
+                 poDS->dfPixelMetres);
+    }
+    if (poDS->dfPixelMetres <0.5) {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Map with %g metre pixels is too large scale (detailed) for the current VRC driver",
+                 poDS->dfPixelMetres);
+        return nullptr;        
+    }
+    
+    {
+        double dfRasterXSize =
+            ((10000.0)*(poDS->nRight - poDS->nLeft)) / poDS->nScale;
+        poDS->nRasterXSize = static_cast<int>(dfRasterXSize);
+        double dfRasterYSize =
+            ((10000.0)*(poDS->nTop - poDS->nBottom)) / poDS->nScale;
+        poDS->nRasterYSize = static_cast<int>(dfRasterYSize);
+
+        // cast to double to avoid overflow and loss of precision
+        // eg  (10000*503316480)/327680000 = 15360
+        //             but                 = 11 with 32bit ints.
+
+        CPLDebug("Viewranger", "%d=%f x %d=%f pixels",
+                 poDS->nRasterXSize, dfRasterXSize,
+                 poDS->nRasterYSize, dfRasterYSize);
+
+        if  (poDS->nRasterXSize <= 0 || poDS->nRasterYSize <= 0 ) {
+            CPLError( CE_Failure, CPLE_NotSupported,
+                      "Invalid dimensions : %d x %d",
+                      poDS->nRasterXSize, poDS->nRasterYSize);
+            GDALClose(poDS);
+            poDS=nullptr;
+            return nullptr;
+        }
+    }
+
+    {
+        poDS->tileSizeMax = VRGetUInt( poDS->abyHeader, nNextString +20 );
+        poDS->tileSizeMin = VRGetUInt( poDS->abyHeader, nNextString +24 );
+        if (poDS->tileSizeMax==0) {
+            CPLError( CE_Failure, CPLE_NotSupported,
+                     "tileSizeMax is zero and invalid"
+                     );
+            GDALClose(poDS);
+            poDS=nullptr;
+            return nullptr;
+        }
+        if (poDS->tileSizeMin==0) {
+            poDS->tileSizeMin=poDS->tileSizeMax;
+            CPLDebug("Viewranger",
+                     "tileSizeMin is zero. Using tileSizeMax %d",
+                     poDS->tileSizeMax
+                     );
+        }
+        int bits = 63 - __builtin_clzll
+            (static_cast<unsigned long long>(
+                           poDS->tileSizeMax/poDS->tileSizeMin) );
+        if (poDS->tileSizeMax == poDS->tileSizeMin << bits) {
+            CPLDebug("Viewranger",
+                     "%d / %d == %f == 2^%d",
+                     poDS->tileSizeMax, poDS->tileSizeMin,
+                     1.0*poDS->tileSizeMax/poDS->tileSizeMin, bits);
+        } else {
+            CPLDebug("Viewranger",
+                     "%d / %d == %f != 2^%d",
+                     poDS->tileSizeMax, poDS->tileSizeMin,
+                     1.0*poDS->tileSizeMax/poDS->tileSizeMin, bits);
+        }
+        poDS->nMaxOverviewCount = 1+static_cast<unsigned int>(bits);
+    
+        // seven is not really used yet
+        unsigned int seven = VRGetUInt( poDS->abyHeader, nNextString +28 );
+
+        // I don't really know what chksum is but am curious about the value
+        unsigned int chksum = VRGetUInt( poDS->abyHeader, nNextString +32 );
+        // Record it in the metadata (TIFF tags or similar) in case it is important.
+        const unsigned int VRCpszSumLen=11;
+        char pszChkSum[VRCpszSumLen]="";
+        int ret=CPLsnprintf(pszChkSum, VRCpszSumLen, "0x%08x", chksum);
+        pszChkSum[VRCpszSumLen-1]='\000';
+        if(ret==VRCpszSumLen-1) {
+            poDS->SetMetadataItem("VRCchecksum", pszChkSum, "");
+        } else {
+            CPLDebug("Viewranger",
+                     "Could not set VRCchecksum to 0x%08x", chksum);
+        }
+
+        poDS->tileXcount   = VRGetInt( poDS->abyHeader, nNextString +36 );
+        poDS->tileYcount   = VRGetInt( poDS->abyHeader, nNextString +40 );
+
+        CPLDebug("Viewranger", "tileSizeMax %d\ttileSizeMin %d",
+                 poDS->tileSizeMax, poDS->tileSizeMin);
+        if (seven != 7) {
+            CPLDebug("Viewranger", "expected seven; got %d", seven);
+        }
+        CPLDebug("Viewranger", "chksum 0x%08x", chksum);
+        CPLDebug("Viewranger", "tile count %d x %d",
+                 poDS->tileXcount, poDS->tileYcount);
+
+        // Sets        VSIStatBufL oStatBufL;
+        // Find out how big the file is.
+        // Used in VRCGetTileIndex to recognize noData values
+        // and several other places.
+        if (VSIStatL(poOpenInfo->pszFilename, &poDS->oStatBufL) ) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "cannot stat file %s\n", poOpenInfo->pszFilename );
+            return nullptr;
+        }
+
+        unsigned int nTileIndexAddr = nNextString + 44;
+
+        if ( poDS->anTileIndex != nullptr ) {
+            CPLDebug("Viewranger",
+                     "poDS->anTileIndex unexpectedly set, to %p",
+                     poDS->anTileIndex);
+            // The address of the index isn't very useful for debugging,
+            // so try to print some of the index. This may crash.
+#undef VRC_DANGEROUS_TILE_INDEX
+#if defined VRC_DANGEROUS_TILE_INDEX
+            for (int ii=0; ii<poDS->tileXcount; ii++) {
+                CPLDebug("Viewranger",
+                         "\tpoDS->anTileIndex[%d] = %d=x%08x",
+                         ii, poDS->anTileIndex[ii], poDS->anTileIndex[ii]);
+            }
+#endif // VRC_DANGEROUS_TILE_INDEX
+            return nullptr; // ?
+        }
+
+        if (poDS->nMapID != 8) {
+            // Read the index of tile addresses
+
+            poDS->anTileIndex = poDS->VRCGetTileIndex( nTileIndexAddr );
+            if ( poDS->anTileIndex == nullptr ) {
+                CPLDebug("Viewranger",
+                         "VRCGetTileIndex(%d=0x%08x) failed",
+                         nTileIndexAddr, nTileIndexAddr);
+            }
+
+        } else { // So poDS->nMapID == 8
+            if ( VSIFSeekL( poDS->fp, nTileIndexAddr, SEEK_SET ) ) {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "cannot seek to nTileIndexAddr %d=x%08x",
+                          nTileIndexAddr, nTileIndexAddr);
+                return nullptr;
+            }
+            CPLDebug("Viewranger",
+                     "Pay-by-tile: skipping %dx%d values after tile count:",
+                     poDS->tileXcount, poDS->tileYcount);
+            for (int jj=0; jj<poDS->tileYcount; jj++) {
+                for (int ii=0; ii<poDS->tileXcount; ii++) {
+                    int nValue=VRReadInt(poDS->fp);
+                    CPLDebug("Viewranger",
+                             "\t(%d,%d) = %d=x%08x",
+                             ii, jj, nValue, nValue);
+                    (void) nValue; // CPLDebug doesn't count as "using" a variable
+                }
+            }
+        }
+
+        // Verify 07 00 00 00 01 00 01 00 01 00 01
+        unsigned int nSecondSevenPtr =
+            nTileIndexAddr + 4 *
+            static_cast<unsigned int>(poDS->tileXcount) * static_cast<unsigned int>(poDS->tileYcount);
+
+        if ( VSIFSeekL( poDS->fp, nSecondSevenPtr, SEEK_SET ) ) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "cannot seek to nSecondSevenPtr %d=x%08x",
+                      nSecondSevenPtr, nSecondSevenPtr);
+            return nullptr;
+        }
+
+        int nSecondSeven=VRReadInt(poDS->fp);
+        int nSignature1=VRReadInt(poDS->fp);
+        int nSignature2=VRReadInt(poDS->fp);
+        if ( nSecondSeven==7 &&
+             nSignature1==0x00010001 &&
+             (nSignature2&0x00ffffff)==0x010001) {
+            CPLDebug("Viewranger",
+                     "x%08x found expected signature 07 00 00 00 01 00 01 00 01 00 01",
+                     nSecondSevenPtr
+                     );
+        } else {
+            CPLDebug("Viewranger",
+                     "x%08x got signature x%08x x%08x x%08x - expected 07 00 00 00 01 00 01 00 01 00 01",
+                     nSecondSevenPtr,
+                     nSecondSeven, nSignature1, nSignature2
+                     );
+        }
+
+        unsigned int nCornerPtr=nSecondSevenPtr+11;  // skip over 07 00 00 00 01 00 01 00 01 00 01
+        if ( // VSIFSeekL( poDS->fp, -1, SEEK_CUR ) // offset is unsigned :-(
+            VSIFSeekL( poDS->fp, nCornerPtr, SEEK_SET )
+             ) {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "cannot seek to VRC tile corners" );
+                return nullptr;
+        }
+
+        // Tile corners here
+        signed int anCorners[4]={};
+        anCorners[0]=VRReadInt(poDS->fp);
+        anCorners[1]=VRReadInt(poDS->fp);
+        anCorners[2]=VRReadInt(poDS->fp);
+        anCorners[3]=VRReadInt(poDS->fp);
+        CPLDebug("Viewranger",
+                 "x%08x LTRB (outer) %d %d %d %d",
+                 nCornerPtr,
+                 poDS->nLeft, poDS->nTop,
+                 poDS->nRight, poDS->nBottom
+                 );
+        CPLDebug("Viewranger",
+                 "x%08x LTRB (inner) %d %d %d %d",
+                 nCornerPtr,
+                 anCorners[0], anCorners[3],
+                 anCorners[2], anCorners[1]
+                 );
+
+        if (poDS->nTop != anCorners[3]) {
+            CPLDebug("Viewranger",
+                     "mismatch original Top %d %d",
+                     poDS->nTop, anCorners[3]
+                     );
+        }
+
+        //   We have some short (underheight) tiles.
+        // GDAL expects these at the top of the bottom tile,
+        // but VRC puts these at the bottom of the top tile.
+        //   We need to add a blank strip at the top of the
+        // file up to compensate.
+        double dfHeightPix = (poDS->nTop - poDS->nBottom) / poDS->dfPixelMetres;
+        int nFullHeightPix = 0;
+        if (poDS->tileSizeMax>0) {
+            nFullHeightPix = static_cast<signed int>(poDS->tileSizeMax)
+                * static_cast<signed int>(dfHeightPix/poDS->tileSizeMax);
+        }
+        if ( (poDS->nTop - poDS->nBottom) != (anCorners[3]- anCorners[1])
+             || (poDS->nTop - poDS->nBottom) != static_cast<signed int>(poDS->nRasterYSize*poDS->dfPixelMetres) ) {
+            // Equivalent to
+            // if (dfHeightPix!=dfheight2 || dfHeightPix!=poDS->nRasterYSize) {
+            // but without the division and floating-point equality test.
+#ifndef CODE_ANALYSIS
+            // Appease cppcheck.
+            // It ignores CPLDebug then deduces that dfheight2 is not used.
+            double dfheight2 =
+                (anCorners[3]-anCorners[1]) / poDS->dfPixelMetres;
+#endif
+            CPLDebug("Viewranger",
+                     "height either %d %g or %g pixels",
+                     poDS->nRasterYSize, dfHeightPix, dfheight2
+                     );
+        }
+
+        if (nFullHeightPix < dfHeightPix) {
+            nFullHeightPix += poDS->tileSizeMax;
+            int nNewTop = poDS->nBottom
+                + static_cast<signed int>(nFullHeightPix*poDS->dfPixelMetres);
+            poDS->nTopSkipPix = nFullHeightPix - static_cast<signed int>(dfHeightPix);
+            CPLDebug("Viewranger",
+                     "Adding %d pixels at top edge - from %d to %d - height was %d now %d",
+                     poDS->nTopSkipPix,
+                     poDS->nTop, nNewTop,
+                     poDS->nRasterYSize, nFullHeightPix
+                     );
+            poDS->nTop = nNewTop;
+            if (poDS->nTop != anCorners[3]) {
+                CPLDebug("Viewranger",
+                         "mismatch new Top %d %d",
+                         poDS->nTop, anCorners[3]
+                         );
+            }
+            poDS->nRasterYSize = nFullHeightPix;
+        }
+
+        if (poDS->nLeft != anCorners[0]) {
+            CPLDebug("Viewranger",
+                     "Unexpected mismatch Left %d %d",
+                     poDS->nLeft, anCorners[0]
+                     );
+        }
+        if (poDS->nBottom != anCorners[1]) {
+            CPLDebug("Viewranger",
+                     "Unexpected mismatch Bottom %d %d",
+                     poDS->nBottom, anCorners[1]
+                     );
+        }
+        if (poDS->nRight != anCorners[2]) {
+            //   Unlike the top edge, GDAL and VRC agree that
+            // narrow tiles are at the left edge of the right-most tile.
+            //   We don't need to adjust anything for this case...
+            CPLDebug("Viewranger",
+                     "mismatch Right %d %d",
+                     poDS->nRight, anCorners[2]
+                     );
+        }
+        unsigned int nThirdSevenPtr=nCornerPtr+16; // Skip the corners
+
+
+        int nThirdSeven=VRReadInt(poDS->fp);
+        if (nThirdSeven == 7) {
+            // CPLDebug does not support m$ in format strings
+            CPLDebug("Viewranger",
+                     "nThirdSevenPtr %d=x%08x points to seven as expected",
+                     nThirdSevenPtr, nThirdSevenPtr);
+        } else {
+            CPLDebug("Viewranger",
+                     "nThirdSevenPtr %d=x%08x points to %08x is not seven",
+                     nThirdSevenPtr, nThirdSevenPtr, nThirdSeven);
+        }
+
+        if (poDS->nMapID == 8) {
+            // Read the index of tile addresses
+            if ( poDS->anTileIndex == nullptr ) {
+#if 0   // Did this break DE...VRC ?
+                poDS->anTileIndex = static_cast<unsigned int *>
+                    (VSIMalloc3(sizeof (unsigned int),
+                                static_cast<size_t>(poDS->tileXcount),
+                                static_cast<size_t>(poDS->tileYcount) ));
+                if (poDS->anTileIndex == nullptr) {
+                    CPLError(CE_Failure, CPLE_OutOfMemory,
+                             "Cannot allocate memory for block index");
+                    return nullptr;
+                }
+                // poDS->anTileIndex[0] = nThirdSevenPtr+4;
+                poDS->anTileIndex[0] = nThirdSevenPtr; // correct; we want the rest of the values too.
+                {
+                    // Dirty hack while testing
+                    //   SE_50_W770010_E839990_S6610010_N6659990.VRC
+                    // 21 Aug, 2020
+                    // poDS->anTileIndex[1] = VRReadInt(poDS->fp);
+                    //poDS->anTileIndex[2] = VRReadInt(poDS->fp);
+                    
+                    if ( // VSIFSeekL( poDS->fp, -4, SEEK_CUR ) // offset is unsigned :-(
+                        VSIFSeekL( poDS->fp, nThirdSevenPtr, SEEK_SET )
+                         ) {
+                        CPLError( CE_Failure, CPLE_AppDefined,
+                                  "cannot seek to VRC tile corners" );
+                        return nullptr;
+                    }
+                    // Read Tile Index into memory
+                    // rotating it as we read it,
+                    // since viewranger files start by going up the left column
+                    // whilst gdal expects to go left to right across the top row.
+                    for (int i=0; i<poDS->tileXcount; i++) {
+                        int q = poDS->tileXcount*(poDS->tileYcount-1) +i;
+                        for (int j=0; j<poDS->tileYcount; j++) {
+                            unsigned int nValue = VRReadUInt(poDS->fp);
+                            // Ignore the index if it points
+                            // outside the limits of the file
+                            if (/* nValue <= 0 || */ nValue >= poDS->oStatBufL.st_size) {
+                                CPLDebug("Viewranger",
+                                         "anTileIndex[%d] (%d %d) addr x%08x not in file",
+                                         q, i, j, nValue);
+                                nValue = 0; // nVRCNoData ? ;
+                            }
+                            CPLDebug("Viewranger",
+                                     "setting anTileIndex[%d] (%d %d) to %d=x%08x",
+                                     q, i, j, nValue, nValue);
+                            poDS->anTileIndex[q] = nValue;
+                            q -= poDS->tileXcount;
+                        }
+                    }
+                }
+#else
+                //poDS->anTileIndex = poDS->VRCGetTileIndex( nThirdSevenPtr+4 );
+                poDS->anTileIndex = poDS->VRCBuildTileIndex( nThirdSevenPtr );
+                //poDS->anTileIndex = poDS->VRCGetTileIndex( nThirdSevenPtr );
+                if ( poDS->anTileIndex == nullptr ) {
+                    CPLDebug("Viewranger", "VRCGetTileIndex(%d=0x%08x) failed",
+                             nThirdSevenPtr, nThirdSevenPtr);
+                    return nullptr;
+                }
+#endif
+            } else {
+                CPLDebug("Viewranger",
+                         "poDS->anTileIndex unexpectedly set, to %p",
+                         poDS->anTileIndex);
+                // The address of the index isn't very useful for debugging,
+                // so try to print some of the index. This may crash.
+#if defined VRC_DANGEROUS_TILE_INDEX
+                for (int ii=0; ii<poDS->tileXcount; ii++) {
+                    CPLDebug("Viewranger",
+                             "\tpoDS->anTileIndex[%d] = %d=x%08x",
+                             ii, poDS->anTileIndex[ii], poDS->anTileIndex[ii]);
+                }
+#endif
+            }
+        }
+
+        if (poDS->nMagic == vrc_magic_metres) {
+            // nRasterXSize,nRasterYSize are fine
+            // (perhaps except for short tiles ?)
+            // but we need to get tileSizeMax/Min and/or tile[XY]count
+            // into the band
+        } else if (poDS->nMagic == vrc_magic_thirtysix) {
+#if defined VRC36_PIXEL_IS_FILE
+            CPLDebug("Viewranger", "each pixel represents a whole thirtysix-based file");
+            // Fake an image with one pixel.
+            poDS->nRasterXSize = 1;
+            poDS->nRasterYSize = 1;
+#else
+#if defined VRC36_PIXEL_IS_TILE
+            // Fake an image with one pixel for each tile.
+            CPLDebug("Viewranger", "each pixel represents a thirtysix-based tile");
+            poDS->nRasterXSize = poDS->tileXcount;
+            poDS->nRasterYSize = poDS->tileYcount;
+#else
+            // VRC36_PIXEL_IS_PIXEL
+            // this will be the default
+            // nRasterXSize,nRasterYSize are fine
+            // but we need to get tileSizeMax/Min and/or tile[XY]count
+            // into the band
+            CPLDebug("Viewranger", "each pixel represents a thirtysix-based pixel");
+#endif
+#endif
+        } else {
+            CPLDebug("Viewranger", "nMagic x%08x unknown", poDS->nMagic);
+        }
+    }
+    if (paszStrings) {
+        for (unsigned int ii=0; ii<nStringCount; ++ii) {
+            if (paszStrings[ii]) {
+                VSIFree(paszStrings[ii]);
+                paszStrings[ii] = nullptr;
+            }
+        }
+        VSIFree(paszStrings);
+        paszStrings= nullptr ;
+    }
+
+    /********************************************************************/
+    /*                              Set CRS                             */
+    /********************************************************************/
+    if(!poDS->poSRS) {
+        poDS->poSRS = CRSfromCountry(poDS->nCountry);
+    }
+
+    
+    /********************************************************************/
+    /*             Report some strings found in the file                */
+    /********************************************************************/
+    CPLDebug("Viewranger", "Long Title: %s",poDS->sLongTitle.c_str());
+    CPLDebug("Viewranger", "Copyright: %s",poDS->sCopyright.c_str());
+    CPLDebug("Viewranger", "%g metre pixels",poDS->dfPixelMetres);
+    if (poDS->nScale > 0) {
+        CPLDebug("Viewranger", "Scale: 1: %d",poDS->nScale);
+    } else {
+        CPLDebug("Viewranger", "Scale not given");
+    }
+
+
+/* -------------------------------------------------------------------- */
+/*      Create band information objects.                                */
+/* -------------------------------------------------------------------- */
+    // Until we support overviews, large files are very slow.
+    // This environment variable allows users to skip them.
+    int fSlowFile=FALSE;
+   if (getenv("VRC_MAX_SIZE")!=nullptr) {
+        long long nMaxSize = strtoll(getenv("VRC_MAX_SIZE"),nullptr,10);
+        // Should support KMGTP... suffixes.
+        if (nMaxSize < static_cast<VRCDataset *>(poDS)->oStatBufL.st_size) {
+            CPLDebug("Viewranger",
+                     "skipping file bigger than VRC_MAX_SIZE %lld",
+                     nMaxSize);
+            fSlowFile=TRUE;
+        }
+    }
+    if (!fSlowFile) {
+        int nMyBandCount=4;
+        if (poDS->nMagic == vrc_magic_thirtysix) {
+            nMyBandCount=1;
+        }
+        for (int i=1; i<=nMyBandCount; i++) {
+            auto *poBand = new VRCRasterBand( poDS, i, -1, 6, nullptr);
+            poDS->SetBand( i, poBand );
+
+            if (i==4) {
+                // Alpha band. Do we need to set a no data value ?
+                poBand->SetNoDataValue( nVRCNoData );
+            }
+        }
+
+        // More metadata.
+        if( poDS->nBands > 1 ) {
+            poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
+        }
+    }
+
+/* -------------------------------------------------------------------- */
+/*      Initialize any PAM information.                                 */
+/* -------------------------------------------------------------------- */
+    poDS->SetDescription( poOpenInfo->pszFilename );
+    poDS->TryLoadXML();
+
+    CPLDebug("Viewranger",
+             "VRCDataset::Open( %p ) returns %p",
+             poOpenInfo, poDS);
+    return( poDS );
+} // VRCDataset::Open()
+
+
+void dumpPPM(unsigned int width,
+             unsigned int height,
+             unsigned char* const data,
+             unsigned int rowlength,
+             CPLString osBaseLabel,
+             VRCinterleave eInterleave,
+             unsigned int nMaxPPM
+             )
+{
+    // Is static the best way to count the PPMs ?
+    static unsigned int nPPMcount = 0;
+
+    CPLDebug("Viewranger PPM",
+             "dumpPPM(%d %d %p %d %s %s-interleaved) count %u",
+             width, height, data, rowlength,
+             osBaseLabel.c_str(),
+             (eInterleave==pixel) ? "pixel" : "band",
+             nPPMcount
+             );
+    if (osBaseLabel==nullptr) {
+        CPLDebug("Viewranger PPM",
+                 "dumpPPM: null osBaseLabel\n");
+        return;
+    }
+    if (rowlength==0) {
+        rowlength=width;
+        CPLDebug("Viewranger PPM",
+                 "dumpPPM(... %d %s) no rowlength, setting to width = %d",
+                 0, osBaseLabel.c_str(), rowlength);
+    }
+
+    CPLString osPPMname =
+        CPLString().Printf("%s.%05d.%s", osBaseLabel.c_str(), nPPMcount,
+                           (eInterleave==pixel) ? "ppm" : "pgm"
+                           );
+    if (osPPMname==nullptr) {
+        CPLDebug("Viewranger PPM",
+                 "osPPMname truncated %s %d",
+                 osBaseLabel.c_str(), nPPMcount);
+    }
+    char const*pszPPMname = osPPMname.c_str();
+
+    if (nPPMcount>10 && nPPMcount>nMaxPPM) {
+         CPLDebug("Viewranger PPM",
+             "... too many PPM files; skipping  %s",
+             pszPPMname
+             );
+         nPPMcount++;
+         return;
+    }
+
+    CPLDebug("Viewranger PPM",
+             "About to dump PPM file %s",
+             pszPPMname
+             );
+
+    char errstr[256]="";
+    VSILFILE *fpPPM = VSIFOpenL(pszPPMname, "w");
+    if (fpPPM == nullptr) {
+        int nFileErr=errno;
+        VRC_file_strerror_r(nFileErr, errstr, 255);
+        CPLDebug("Viewranger PPM",
+                 "PPM data dump file %s failed; errno=%d %s",
+                 pszPPMname, nFileErr, errstr
+                 );
+    } else {
+        const size_t nHeaderBufSize = 40;
+        char acHeaderBuf[nHeaderBufSize]="";
+        size_t nHeaderSize=0;
+        switch (eInterleave) {
+        case pixel:
+            nHeaderSize=static_cast<size_t>
+                (CPLsnprintf(acHeaderBuf, nHeaderBufSize,
+                          "P6\n%u %u\n255\n",
+                          width, height) );
+            break;
+        case band:
+            nHeaderSize=static_cast<size_t>
+                (CPLsnprintf(acHeaderBuf, nHeaderBufSize,
+                          "P5\n%u %u\n255\n",
+                          width, height) );
+            break;
+#if 0
+        default:
+            break;
+#endif
+        }
+        // CPLsnprintf may return negative values;
+        // the cast to size_t converts these to large positive
+        // values, so we only need one test.
+        if (nHeaderSize>=nHeaderBufSize) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "dumpPPM error generating header for %s\n",
+                      pszPPMname);
+            VSIFCloseL(fpPPM);
+            return;
+        }
+        size_t nHeaderWriteResult=VSIFWriteL(acHeaderBuf, 1, nHeaderSize, fpPPM);
+        if (nHeaderSize==nHeaderWriteResult) {
+            const unsigned char* pRow = data;
+            for (unsigned int r=0; r<height; r++) {
+                if (eInterleave==pixel) {
+                    if (width!=VSIFWriteL(pRow, 3, width, fpPPM)) {
+                        int nWriteErr = errno;
+                        VRC_file_strerror_r(nWriteErr, errstr, 255);
+                        CPLError( CE_Failure, CPLE_AppDefined,
+                                  "dumpPPM error writing %s row %d errno=%d %s\n",
+                                  pszPPMname, r, nWriteErr, errstr);
+                        break;
+                    }
+                    pRow += 3*rowlength;
+                } else { // must be band interleaved
+#if 0 // PPM
+                    for (unsigned int c=0; c<width; c++) {
+                        unsigned char acTmpBuf[4]="";
+                        acTmpBuf[0] = pRow[c];
+                        acTmpBuf[1] = pRow[c]; // +rowlength];
+                        acTmpBuf[2] = pRow[c]; // +rowlength+rowlength];
+                        // acTmpBuf[3] = 255; // opposite of nVRCNoData
+                        //if (1!=VSIFWriteL(acTmpBuf, 4, 1, fpPPM)) {
+                        if (1!=VSIFWriteL(acTmpBuf, 3, 1, fpPPM)) {
+                            int nWriteErr = errno;
+                            VRC_file_strerror_r(nWriteErr, errstr, 255);
+                            CPLError( CE_Failure, CPLE_AppDefined,
+                                      "dumpPPM error writing %s row %u col %u;errno=%d %s",
+                                      pszPPMname, r, c, nWriteErr, errstr);
+                            VSIFCloseL(fpPPM);
+                            return; // nested break, goto or throw/catch would be better
+                        }
+                    }
+                    pRow += rowlength; // pRow += 4*rowlength;
+#else // PGM
+                    size_t rowwriteresult=VSIFWriteL(pRow, 1, width, fpPPM);
+#if 1 // Noisy
+                    if (getenv("VRC_NOISY")) {
+                        CPLDebug("Viewranger PGM",
+                                 "dumpPPM: writing(%p, 1, %d, %p) returned %lu",
+                                 pRow, width, fpPPM, rowwriteresult);
+                    }
+#endif // Noisy
+                    if (width!=rowwriteresult) {
+                        int nWriteErr = errno;
+                        VRC_file_strerror_r(nWriteErr, errstr, 255);
+                        CPLError( CE_Failure, CPLE_AppDefined,
+                                  "dumpPPM error writing %s row %u: errno=%d %s",
+                                  pszPPMname, r, nWriteErr, errstr);
+                        break;
+                    }
+                    pRow += rowlength;
+#endif // PPM or PGM
+                } // pixel or band interleaved ?
+            } // for row r
+        } else { // nHeaderSize!=nHeaderWriteResult
+            int nWriteErr=errno;
+            VRC_file_strerror_r(nWriteErr, errstr, 255);
+            // CPLError( CE_Failure, CPLE_AppDefined,
+            CPLDebug("Viewranger PPM",
+                     "dumpPPM error writing header for %s errno=%u %s",
+                     pszPPMname, nWriteErr, errstr);
+        }
+
+        if (0!=VSIFCloseL(fpPPM)) {
+            CPLDebug("Viewranger PPM",
+                     "Failed to close PPM data dump file %s; errno=%d",
+                     pszPPMname, errno
+                     );
+        } else {
+            CPLDebug("Viewranger PPM",
+                     "PPM data dumped to file %s",
+                     pszPPMname
+                     );
+        }
+    }
+
+    nPPMcount++;
+
+    // return;
+
+} // dumpPPM
+
+static
+void dumpPNG(
+        // unsigned int width,
+        // unsigned int height,
+        unsigned char* const data, // pre-prepared PNG data, *not* raw image.
+        int nDataLen,
+        CPLString osBaseLabel,
+        unsigned int nMaxPNG
+        )
+{
+    // Is static the best way to count the PNGs ?
+    static unsigned int nPNGcount = 0;
+
+    CPLDebug("Viewranger PNG",
+             // "dumpPNG(%d %d %p %d %s) count %u)",
+             "dumpPNG(%p %d %s) count %u)",
+             // width, height,
+             data, nDataLen,
+             osBaseLabel.c_str(), nPNGcount
+             );
+    if (osBaseLabel==nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "dumpPNG: null osBaseLabel\n");
+        return;
+    }
+
+    CPLString osPPMname =
+        CPLString().Printf("%s.%05d.png", osBaseLabel.c_str(), nPNGcount);
+    if (osPPMname==nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "osPPMname truncated %s %d",
+                 osBaseLabel.c_str(), nPNGcount );
+    }
+    char const*pszPNGname = osPPMname.c_str();
+
+    if (nPNGcount>10 && nPNGcount>nMaxPNG) {
+         CPLDebug("Viewranger PNG",
+             "... too many PNG files; skipping %s",
+             pszPNGname
+             );
+         nPNGcount++;
+         return;
+    }
+
+    CPLDebug("Viewranger PNG",
+             "About to dump PNG file %s",
+             pszPNGname
+             );
+
+    char pszErrStr[256]="";
+    VSILFILE *fpPNG = VSIFOpenL(pszPNGname, "w");
+    if (fpPNG == nullptr) {
+        int nFileErr=errno;
+        VRC_file_strerror_r(nFileErr, pszErrStr, 255);
+        CPLDebug("Viewranger PNG",
+                 "PNG data dump file %s failed; errno=%d %s",
+                 pszPNGname, nFileErr, pszErrStr
+                 );
+    } else {
+        size_t nWriteResult =
+            VSIFWriteL( data, 1, static_cast<size_t>(nDataLen), fpPNG );
+        if (static_cast<size_t>(nDataLen)!=nWriteResult) {
+            int nFileErr=errno;
+            VRC_file_strerror_r(nFileErr, pszErrStr, 255);
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "dumpPNG error writing %s result=%d errno=%lu\n\t%s",
+                      pszPNGname, nFileErr, nWriteResult, pszErrStr);
+
+            return;
+        }
+        if (0!=VSIFCloseL(fpPNG)) {
+            int nFileErr=errno;
+            VRC_file_strerror_r(nFileErr, pszErrStr, 255);
+            CPLDebug("Viewranger PNG",
+                     "Failed to close PNG data dump file %s; errno=%d %s",
+                     pszPNGname, nFileErr, pszErrStr
+                     );
+        } else {
+            CPLDebug("Viewranger PNG",
+                     "PNG data dumped to file %s",
+                     pszPNGname
+                     );
+        }
+    }
+
+    nPNGcount++;
+} // dumpPNG()
+
+png_byte *
+VRCRasterBand::read_PNG(VSILFILE *fp,
+                        // void *pImage,
+                        unsigned int *pPNGwidth,
+                        unsigned int *pPNGheight,
+                        unsigned int nVRCHeader,
+                        vsi_l_offset nPalette,
+                        unsigned int nVRCDataLen,
+                        // int nPNGXcount, int nPNGYcount,
+                        int nGDtile_xx, int nGDtile_yy,
+                        unsigned int nVRtile_xx, unsigned int nVRtile_yy
+                        )
+{
+    unsigned int nVRCData = nVRCHeader+0x12;
+
+    if (fp==nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "read_PNG given null file pointer");
+        return nullptr;
+    }
+#if 0
+    if (pImage==nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "read_PNG given null image pointer");
+        return nullptr;
+    }
+#endif
+    if (pPNGwidth==nullptr || pPNGheight==nullptr) {
+        CPLDebug("Viewranger PNG",
+                 "read_PNG needs space to return image size");
+        return nullptr;
+    }
+
+    if (nVRCHeader == 0) {
+        CPLDebug("Viewranger PNG",
+                 "block (%d,%d) tile (%d,%d) nVRCHeader is nullptr",
+                 nGDtile_xx, nGDtile_yy, nVRtile_xx, nVRtile_yy);
+        return nullptr;
+    }
+    if (nVRCDataLen < 12) {
+        CPLDebug("Viewranger PNG",
+                 "block (%d,%d) tile (%d,%d) nVRCData is too small %u < 12",
+                 nGDtile_xx, nGDtile_yy, nVRtile_xx, nVRtile_yy,
+                 nVRCDataLen );
+        return nullptr;
+    }
+    if (nVRCDataLen >= static_cast<VRCDataset *>(poDS)->oStatBufL.st_size) {
+        CPLDebug("Viewranger PNG",
+                 "block (%d,%d) tile (%d,%d) nVRCData is bigger %u than file %lu",
+                 nGDtile_xx, nGDtile_yy, nVRtile_xx, nVRtile_yy,
+                 nVRCDataLen, static_cast<VRCDataset *>(poDS)->oStatBufL.st_size);
+        return nullptr;
+    }
+
+    png_voidp user_error_ptr=nullptr;
+    // Initialize PNG structures
+    png_structp png_ptr = png_create_read_struct
+        (PNG_LIBPNG_VER_STRING, static_cast<png_voidp>(user_error_ptr),
+         nullptr, nullptr // user_error_fn, user_warning_fn
+         );
+    if (!png_ptr) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRCRasterBand::read_PNG png_create_read_struct error %p\n",
+                  user_error_ptr);
+        return nullptr;
+    }
+    png_infop info_ptr = png_create_info_struct(png_ptr);
+    if (!info_ptr) {
+        png_destroy_read_struct(&png_ptr,
+                                static_cast<png_infopp>(nullptr), static_cast<png_infopp>(nullptr));
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRCRasterBand::read_PNG png_create_info_struct error %p\n",
+                  user_error_ptr);
+        return nullptr;
+    }
+
+    png_infop end_info = png_create_info_struct(png_ptr);
+    if (!end_info) {
+        png_destroy_read_struct(&png_ptr, &info_ptr,
+                                static_cast<png_infopp>(nullptr));
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRCRasterBand::read_PNG end_info png_create_info_struct error %p\n",
+                  user_error_ptr);
+        return nullptr;
+    }
+
+
+   /*********************************************************************
+    *
+    * This is where we create the PNG file from the VRC data.
+    *
+    * I wish I could find a *simple* way to avoid reading it in to memory
+    * only to pass it to the iterator VRC_png_read_data_fn.
+    *
+    *********************************************************************/
+
+    const unsigned char PNG_sig[]    = {0x89,  'P',  'N',  'G', 0x0d, 0x0a, 0x1a, 0x0a};
+    const unsigned char IHDR_head[]  = {0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R'};
+    const unsigned char IEND_chunk[] = {0x00, 0x00, 0x00, 0x00, 'I', 'E', 'N', 'D',
+                                       0xae, 0x42, 0x60, 0x82};
+
+#if 0
+    // Redundant ?
+    // Find the length of the VRCData
+    if ( VSIFSeekL( fp, nVRCData, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to nVRCData %d=x%08x",
+                  nVRCData, nVRCData);
+        return nullptr;
+    }
+#endif
+
+    // This is missing:
+    // the IHDR data (+CRC),
+    // the PLTE chunk, and
+    // the IDAT data chunk(s).
+    VRCpng_data oVRCpng_data = {nullptr, 0, 0};
+    // C++11 does not let us cast unsigned-ness inside {}
+    oVRCpng_data.length = static_cast<long>
+        (sizeof(PNG_sig)
+         +sizeof(IHDR_head)+13+4
+         + 3*256 + 3*4   // enough for 256x3 entry palette plus length, "PLTE" and checksum.
+         + nVRCDataLen     // IDAT chunks
+         +sizeof(IEND_chunk));
+
+    oVRCpng_data.pData = static_cast<png_byte*>
+        (png_malloc(png_ptr,
+                    static_cast<png_size_t>(oVRCpng_data.length)) );
+    if (oVRCpng_data.pData == nullptr) {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate memory for copy of PNG file");
+        return nullptr;
+    }
+    oVRCpng_data.current = 0;
+    memcpy(static_cast<void*>(oVRCpng_data.pData),
+           PNG_sig, sizeof(PNG_sig) );
+    oVRCpng_data.current += sizeof(PNG_sig);
+
+    // IHDR starts here
+    memcpy(static_cast<void*>(&oVRCpng_data.pData[oVRCpng_data.current]),
+           IHDR_head, sizeof(IHDR_head) );
+    oVRCpng_data.current += sizeof(IHDR_head);
+
+    // IHDR_data here
+
+    char aVRCHeader[17]={};
+    if ( VSIFSeekL( fp, nVRCHeader, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to nVRCHeader %d=x%08x",
+                  nVRCHeader, nVRCHeader);
+        return nullptr;
+    }
+    if (int n=VRReadChar(fp)) {
+        (void)n; // Appease static analysers
+        CPLDebug("Viewranger PNG",
+                 "%d=x%08x: First PNG header byte is x%02x - expected x00",
+                 nVRCHeader, nVRCHeader, n);
+    } else {
+         CPLDebug("Viewranger PNG",
+                  "%d=x%08x: First PNG header byte is x00 as expected",
+                  nVRCHeader, nVRCHeader);
+    }
+    size_t count=VSIFReadL(aVRCHeader, 1, 17, fp);
+    if (17>count) {
+        CPLError( CE_Failure, CPLE_FileIO,
+                  "only read %d of 17 bytes for PNG header\n",
+                  static_cast<int>(count));
+        return nullptr;
+     }
+
+    memcpy(static_cast<void*>(&oVRCpng_data.pData[oVRCpng_data.current]),
+           aVRCHeader, 17 );
+    unsigned int nPNGwidth=PNGGetUInt(aVRCHeader, 0);
+    *pPNGwidth=nPNGwidth;
+    unsigned int nPNGheight=PNGGetUInt(aVRCHeader, 4);
+    *pPNGheight=nPNGheight;
+
+    if (nPNGwidth==0 || nPNGheight==0) {
+        CPLDebug("Viewranger PNG",
+                 "empty PNG tile %d x %d (VRC tile %d,%d)",
+                 nPNGwidth, nRasterXSize,
+                 nVRtile_xx, nVRtile_yy);
+        return nullptr;
+    }
+
+#if 0
+    // We need to make *two* adjustments to the position
+    // of the PNG tile within the GDAL block.
+    // 1. If the last (top or right) VRC block is smaller than the others,
+    //    then there may be fewer tiles in the block, eg:
+    //       nPNGheight*(nPNGYcount+k) == nBlockYSize ?
+    // 2. If nBlockXSizePNG / 2^n is not an integer
+    //    then the total width/height of the PNG overview tiles
+    //    will be slightly bigger than the GDAL block, eg:
+    //       nPNGheight*nPNGYcount > nBlockYSize ?
+    // I don't know whether both can occur in the same block.
+    
+    if (nPNGwidth*nPNGXcount!= nBlockXSize) { // nRasterXSize ?
+        CPLDebug("Viewranger PNG",
+                 "PNG width %d * PNG count %d != block width %d - G=%d V=%d",
+                 nPNGwidth, nPNGXcount, nBlockXSize,
+                 nGDtile_xx, nVRtile_xx);
+    }
+#endif
+
+
+#if defined UseCountFull
+    double dfPNGYcountFull = nBlockYSize/nPNGheight;
+    int nPNGYcountFull = (int)(dfPNGYcountFull+.5);
+    if (nPNGheight*nPNGYcount==nBlockYSize) { // nRasterYSize ? - nBlockYSize probably OK
+        CPLDebug("Viewranger PNG",
+                 "PNG height: %d * PNG count %d == block height %d - G=%d V=%d",
+                 nPNGheight, nPNGYcount, nBlockYSize,
+                 nGDtile_yy, nVRtile_yy);
+    } else {
+        bool bCase1 = false;
+        bool bCase2 = false;
+        if (nPNGYcount<nPNGYcountFull) {
+            bCase1 = true;
+            CPLDebug("Viewranger PNG",
+                     "PNG height %d: %d pixel block G=%d V=%d has fewer PNGS (%d<%d) than other block rows",
+                     nPNGheight, nBlockYSize,
+                     nGDtile_yy, nVRtile_yy,
+                     nPNGYcount, nPNGYcountFull
+                     );
+        }
+
+        if (nPNGheight*nPNGYcountFull != nBlockYSize) {
+            bCase2 = true;
+            CPLDebug("Viewranger PNG",
+                     "PNG height %d does not divide block height %d - counts %d %d - G=%d V=%d",
+                     nPNGheight, nBlockYSize,
+                     nPNGYcount, nPNGYcountFull,
+                     nGDtile_yy, nVRtile_yy);
+        }
+
+        if (bCase1 && bCase2) {
+            CPLDebug("Viewranger PNG", "PNG height: both cases");
+        } else if (!bCase1 && !bCase2) {
+            CPLDebug("Viewranger PNG",
+                     "PNG height %d - PNG counts %d %d - block height %d - G=%d V=%d",
+                     nPNGheight, nPNGYcountFull, nPNGYcount, nBlockYSize,
+                     nGDtile_yy, nVRtile_yy);
+            CPLDebug("Viewranger PNG", "PNG height: neither case");
+        }
+    }
+#endif // defined UseCountFull
+
+#if 0 // defined UsePNGsizeMin
+    signed int nPNGwidthMin = std::min(nPNGwidth,nBlockXSize/nPNGXcount);
+    signed int nPNGheightMin = std::min(nPNGheight,nBlockYSize/nPNGYcount);
+    CPLDebug("Viewranger PNG",
+             "nBlockXSize %d ?= nPNGwidthMin %d * nPNGXcount %d",
+             nBlockXSize, nPNGwidthMin, nPNGXcount);
+    CPLDebug("Viewranger PNG",
+             "nBlockYSize %d ?= nPNGheightMin %d * nPNGYcount %d",
+             nBlockYSize, nPNGheightMin, nPNGYcount);
+#endif // defined UsePNGsizeMin
+
+    // pbyPNGbuffer needs freeing in lots of places, before we return nullptr
+    auto *pbyPNGbuffer = static_cast< png_byte*>
+        (VSIMalloc3(3,
+                    static_cast<size_t>(nPNGwidth), 
+                    static_cast<size_t>(nPNGheight) ));
+    if (pbyPNGbuffer == nullptr) {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate memory for PNG buffer");
+        return nullptr;
+    }
+    // Do we need to zero the buffer ?
+    for (unsigned int ii=0; ii<3*nPNGwidth*nPNGheight; ii++) {
+        // apc_row_pointers[ii][jj] = 0;
+        pbyPNGbuffer[ii] = nVRCNoData; // werdna July 14 2020
+    }
+
+    std::vector<unsigned char*> apc_row_pointers;
+    apc_row_pointers.reserve(static_cast<size_t>(nPNGheight));
+    for (unsigned int ii=0; ii<nPNGheight; ii++) {
+        // clag-tidy readability-simplify-subscript-expr objects to
+        apc_row_pointers.data()[ii] = 
+        // but g++ -Werror,-Wsign-conversion objects to
+        // apc_row_pointers[ii] = static_cast<unsigned char*>
+            (&((static_cast<GByte*>(pbyPNGbuffer))[3*nPNGwidth*ii]));
+    }
+    png_set_rows(png_ptr, info_ptr, apc_row_pointers.data());
+
+    auto nPNGdepth = static_cast<unsigned char>(aVRCHeader[8]);
+    auto nPNGcolour = static_cast<unsigned char>(aVRCHeader[9]);
+    auto nPNGcompress = static_cast<unsigned char>(aVRCHeader[10]);
+    auto nPNGfilter = static_cast<unsigned char>(aVRCHeader[11]);
+    auto nPNGinterlace = static_cast<unsigned char>(aVRCHeader[12]);
+    unsigned int nPNGcrc = PNGGetUInt(aVRCHeader, 13);
+
+    CPLDebug("Viewranger PNG",
+             "PNG file: %d x %d depth %d colour %d, compress=%d, filter=%d, interlace=%d crc=x%08x",
+             nPNGwidth, nPNGheight, nPNGdepth, nPNGcolour,
+             nPNGcompress, nPNGfilter, nPNGinterlace, nPNGcrc
+             );
+
+    switch (nPNGdepth) {
+    case 1:    case 2:    case 4:    case 8:
+        break;
+    // case 16:
+    default:
+        CPLDebug("Viewranger PNG",
+                 "PNG file: Depth %d depth unsupported",
+                 nPNGdepth);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+    switch (nPNGcolour) {
+    case 0: // Gray
+        break;
+    case 2: // RGB
+        if (nPNGdepth==8) {
+            break;
+        }
+        if (nPNGdepth==16) {
+            CPLError( CE_Warning, CPLE_AppDefined,
+                      "16/48bit RGB unexpected");
+            break;
+        }
+        CPL_FALLTHROUGH
+    case 3: // Palette
+        if (nPNGdepth<16 && nPNGcolour==3) {
+            break;
+        }
+        CPLDebug("Viewranger PNG",
+                 "PNG file: colour %d depth %d combination unsupported",
+                 nPNGcolour, nPNGdepth);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    // case 4: // Gray + Alpha
+    // case 6: // RGBA
+    default:
+        CPLDebug("Viewranger PNG",
+                 "PNG file: colour %d unsupported",
+                 nPNGcolour);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+    switch (nPNGcompress) {
+    case 0:
+        break;
+    default:
+        CPLDebug("Viewranger PNG",
+                 "PNG file: compress %d unsupported",
+                 nPNGcompress);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+    switch (nPNGfilter) {
+    case 0:
+        break;
+     default:
+        CPLDebug("Viewranger PNG",
+                 "PNG file: filter %d unsupported",
+                 nPNGfilter);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+    switch (nPNGinterlace) {
+    case 0: // None
+    case 1: // Adam7
+        break;
+    default:
+        CPLDebug("Viewranger PNG",
+                 "PNG file: interlace %d unsupported",
+                 nPNGinterlace);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+
+    int check = PNGCRCcheck(&oVRCpng_data, nPNGcrc);
+    if (1!=check) {
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+
+    oVRCpng_data.current+= 13;
+    oVRCpng_data.current+= 4;
+
+    // PLTE chunk here (no "PLTE" type string in VRC data)
+    if (nPalette!=0) {
+        if ( VSIFSeekL( fp, nPalette, SEEK_SET ) ) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "cannot seek to nPalette %llu=x%012llx",
+                      nPalette, nPalette);
+            VSIFree(pbyPNGbuffer);
+            return nullptr;
+        }
+
+        unsigned int nVRCPlteLen = VRReadUInt(fp);
+        if ( nVRCPlteLen > static_cast<VRCDataset *>(poDS)->oStatBufL.st_size) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "implausible palette length %d=x%08x",
+                      nVRCPlteLen, nVRCPlteLen);
+            VSIFree(pbyPNGbuffer);
+            return nullptr;
+        }
+        char *pVRCPalette = static_cast<char *>(VSIMalloc(nVRCPlteLen));
+        if (pVRCPalette == nullptr) {
+            CPLDebug("Viewranger PNG",
+                     "could not allocate memory for pVRCPalette");
+            VSIFree(pbyPNGbuffer);
+            return nullptr;
+        }
+
+        size_t nBytesRead=VSIFReadL(pVRCPalette,1, nVRCPlteLen, fp);
+        if (nVRCPlteLen!=nBytesRead) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "at x%012llx cannot read %u=x%08x bytes of PNG palette data - read %012zx",
+                      nPalette, nVRCPlteLen, nVRCPlteLen,nBytesRead );
+            VSIFree(pbyPNGbuffer);
+            return nullptr;
+        }
+
+        unsigned int nPNGPlteLen = PNGGetUInt(pVRCPalette,0);
+        if ( nVRCPlteLen != nPNGPlteLen+8) {
+            CPLDebug("Viewranger PNG",
+                     "Palette lengths mismatch: VRC %d != PNG %u +8",
+                     nVRCPlteLen, nPNGPlteLen
+                     );
+            VSIFree(pbyPNGbuffer);
+            return nullptr;
+        }
+        if ( nPNGPlteLen > static_cast<VRCDataset *>(poDS)->oStatBufL.st_size) {
+            CPLDebug("Viewranger PNG",
+                     "PNGPalette length %u=x%08x bigger than file !",
+                     nPNGPlteLen, nPNGPlteLen
+                     );
+            VSIFree(pbyPNGbuffer);
+            return nullptr;
+        }
+        if (nPNGPlteLen %3) {
+            CPLDebug("Viewranger PNG",
+                     "palette size %d=x%08x not a multiple of 3",
+                     nPNGPlteLen, nPNGPlteLen
+                     );
+            VSIFree(pbyPNGbuffer);
+            return nullptr;
+        } else {
+            CPLDebug("Viewranger PNG",
+                     "palette %d=x%08x bytes, %d entries",
+                     nPNGPlteLen, nPNGPlteLen,
+                     nPNGPlteLen/3
+                     );
+        }
+        memcpy(static_cast<void*>(&oVRCpng_data.pData[oVRCpng_data.current]),
+               static_cast<char*>(pVRCPalette),
+               4 );
+        oVRCpng_data.current+= 4;
+        memcpy(static_cast<void*>(&oVRCpng_data.pData[oVRCpng_data.current]),
+               "PLTE",
+               4 );
+        oVRCpng_data.current+= 4;
+
+        memcpy(static_cast<void*>(&oVRCpng_data.pData[oVRCpng_data.current]),
+               static_cast<char*>(pVRCPalette)+4,
+               nPNGPlteLen+4 );
+        oVRCpng_data.current+= nPNGPlteLen+4;
+        VSIFree(pVRCPalette);
+    } else { // if (nVRCpalette!=0)
+        if (nPNGcolour == 3) {
+            CPLDebug("Viewranger PNG",
+                     "Colour type 3 PNG: needs a PLTE. Assuming Greyscale."
+                     );
+            // Next four bytes are 3*256 in PNGendian
+            oVRCpng_data.pData[oVRCpng_data.current++] = 0;
+            oVRCpng_data.pData[oVRCpng_data.current++] = 0;
+            oVRCpng_data.pData[oVRCpng_data.current++] = 3;
+            oVRCpng_data.pData[oVRCpng_data.current++] = 0;
+
+            memcpy(static_cast<void*>(&oVRCpng_data.pData[oVRCpng_data.current]),
+                   "PLTE",
+                   4 );
+            oVRCpng_data.current+= 4;
+
+            for (int i=0; i<256; i++) {
+                // for (unsigned char i=0; i<256; i++) gives
+                //  i<256 is always true.
+                // "& 255" is shorter than "static_cast<char>(i)"
+                oVRCpng_data.pData[oVRCpng_data.current++] = i & 255;
+                oVRCpng_data.pData[oVRCpng_data.current++] = i & 255;
+                oVRCpng_data.pData[oVRCpng_data.current++] = i & 255;
+            }
+
+            // The checksum 0xe2b05d7d (not 0xa5d99fdd) of the greyscale palette.
+            oVRCpng_data.pData[oVRCpng_data.current++] = 0xe2;
+            oVRCpng_data.pData[oVRCpng_data.current++] = 0xb0;
+            oVRCpng_data.pData[oVRCpng_data.current++] = 0x5d;
+            oVRCpng_data.pData[oVRCpng_data.current++] = 0x7d;
+        }
+    }
+
+    // IDAT chunk(s) here
+    // werdna 26 June 2017. This is subject to verification and may well be wrong.
+
+    // Jump to VRCData
+    if ( VSIFSeekL( fp, nVRCData, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to nVRCData %d=x%08x",
+                  nVRCData, nVRCData);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+
+    if (static_cast<size_t>(oVRCpng_data.length) <
+        static_cast<size_t>(oVRCpng_data.current) +
+        static_cast<size_t>(nVRCDataLen) + sizeof(IEND_chunk)
+        ) {
+        // Either we seg-faulted before we got here (if current > length)
+        // or we will do.
+        // Abort now.
+        // FixME: We should either realloc, or use some other memory allocation system ...
+        long long nNeeded=
+            oVRCpng_data.current
+            + static_cast<long long>(nVRCDataLen)
+            + static_cast<long long>(sizeof(IEND_chunk));
+        long long nMore= nNeeded - oVRCpng_data.length;
+        CPLError( CE_Failure, CPLE_OutOfMemory,
+                  "allocated %ld bytes for PNG but need %lld = %lld more",
+                  oVRCpng_data.length,
+                  nNeeded, nMore
+                  );
+        VSIFree(pbyPNGbuffer);
+        // exit(0);
+        return nullptr;
+    }
+
+    auto nBytesRead = static_cast<unsigned>
+        (VSIFReadL(&oVRCpng_data.pData[oVRCpng_data.current],
+                   1 , nVRCDataLen, fp));
+    if (nVRCDataLen != nBytesRead) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "only read %u=x%08x bytes of PNG data out of %u=x%08x",
+                  nBytesRead, nBytesRead, nVRCDataLen, nVRCDataLen);
+        VSIFree(pbyPNGbuffer);
+        return nullptr;
+    }
+
+    oVRCpng_data.current += nVRCDataLen;
+
+    // IEND chunk is fixed and pre-canned.
+    memcpy(static_cast<void*>(&oVRCpng_data.pData[oVRCpng_data.current]),
+           IEND_chunk, sizeof(IEND_chunk) );
+    oVRCpng_data.current+=sizeof(IEND_chunk);
+
+    if (oVRCpng_data.length > oVRCpng_data.current) {
+        int nPNGPlteLen = static_cast<int>
+            (768 + oVRCpng_data.current - oVRCpng_data.length);
+        if (nPNGPlteLen %3 != 0 || nPNGPlteLen<0 || nPNGPlteLen>768) {
+            if (nPNGPlteLen!=780 || (nPNGcolour!=0 && nPNGcolour!=4)) {
+                CPLDebug("Viewranger PNG",
+                         "allocated %ld bytes for PNG but only copied %ld - short %ld bytes",
+                         oVRCpng_data.length, oVRCpng_data.current,
+                         oVRCpng_data.length - oVRCpng_data.current
+                         );
+            } else {
+                // We allowed for a 768byte palette but the tile has none.
+            }
+        }
+    }
+
+    if (getenv("VRC_DUMP_PNG")) {
+        auto nEnvPNGDump = static_cast<unsigned int>
+            (strtol(getenv("VRC_DUMP_PNG"),nullptr,10));
+        CPLString osBaseLabel
+            = CPLString().
+            Printf("/tmp/werdna/vrc2tif/%s.%01d.%03d.%03d.%03d.%03d.%02u.x%012x",
+                   // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                   static_cast<VRCDataset *>(poDS)->sLongTitle.c_str(),
+                   nThisOverview, nGDtile_xx, nGDtile_yy, nVRtile_xx, nVRtile_yy,
+                   nBand, nVRCHeader);
+        dumpPNG(
+                // static_cast<unsigned int>(nPNGwidth), 
+                // static_cast<unsigned int>(nPNGheight),
+                oVRCpng_data.pData,
+                static_cast<int>(oVRCpng_data.current),
+                osBaseLabel,
+                nEnvPNGDump
+            );
+    }
+
+    // return to start of buffer
+    // ... but skip the png magic - see below.
+    oVRCpng_data.current = sizeof(PNG_sig);
+
+    // The first eight, png-identifying, magic, bytes of the PNG file
+    // are not present in the VRC data; we tell libpng to skip them.
+    png_set_sig_bytes(png_ptr, static_cast<int>(oVRCpng_data.current));
+
+    /*******************************************************************/
+
+    // if (color_type == PNG_COLOR_TYPE_PALETTE)
+    //     png_set_palette_to_rgb(png_ptr);
+    //
+    // if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
+    //     png_set_expand_gray_1_2_4_to_8(png_ptr);
+    //
+
+    // png_set_read_fn( png_ptr, info_ptr, VRC_png_read_data_fn );
+    png_set_read_fn( png_ptr, &oVRCpng_data, VRC_png_read_data_fn );
+
+    CPLDebug("Viewranger PNG",
+             "oVRCpng_data %p (%p %ld %ld)",
+             &oVRCpng_data,
+             oVRCpng_data.pData,
+             oVRCpng_data.length, oVRCpng_data.current
+             );
+
+    // May wish to change this so that the result is RGBA (currently RGB)
+    png_read_png( png_ptr, info_ptr,
+#if PNG_LIBPNG_VER > 10504
+                  PNG_TRANSFORM_SCALE_16 |
+#else
+                  PNG_TRANSFORM_STRIP_16 |
+#endif
+                  PNG_TRANSFORM_STRIP_ALPHA |
+                  PNG_TRANSFORM_PACKING |
+                  PNG_TRANSFORM_GRAY_TO_RGB |
+                  PNG_TRANSFORM_EXPAND,
+                  nullptr);
+
+    CPLDebug("Viewranger PNG",
+             "read oVRCpng_data %p (%p %ld %ld) to %p",
+             &oVRCpng_data,
+             oVRCpng_data.pData,
+             oVRCpng_data.length, oVRCpng_data.current,
+             pbyPNGbuffer
+             );
+
+    png_free(png_ptr, oVRCpng_data.pData);
+
+    png_free_data(png_ptr, info_ptr, PNG_FREE_ALL, -1);
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+
+
+    oVRCpng_data.pData = nullptr;
+    oVRCpng_data.current = oVRCpng_data.length = 0;
+
+    return pbyPNGbuffer;
+
+}  // VRCRasterBand::read_PNG
+
+/************************************************************************/
+/*                          GDALRegister_VRC()                          */
+/************************************************************************/
+
+extern "C" void CPL_DLL GDALRegister_VRC()
+
+{
+    if (! GDAL_CHECK_VERSION("ViewrangerVRC"))
+        return;
+
+    if( GDALGetDriverByName( "ViewrangerVRC" ) == nullptr )
+    {
+        auto*poDriver = new GDALDriver();
+        if (poDriver==nullptr) {
+            CPLError( CE_Failure, CPLE_ObjectNull,
+                      "Could not build a driver for VRC"
+                     );
+            return;
+        }
+
+        poDriver->SetDescription( "ViewrangerVRC" );
+
+        // required in gdal version 2, not supported in gdal 1.11
+#if GDAL_VERSION_MAJOR >= 2
+        poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
+#endif
+
+        poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
+                                   "ViewRanger (.VRC)" );
+        poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC,
+                                   "frmt_various.html#VRC" );
+        poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "VRC" );
+
+        // poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "Byte Int16" );
+        poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES, "" );
+        poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
+
+        // See https://gdal.org/development/rfc/rfc34_license_policy.html
+        poDriver->SetMetadataItem( "LICENSE_POLICY", "NONRECIPROCAL" );
+
+        // Which of these is correct ?
+        // poDriver->SetMetadataItem(GDALMD_AREA_OR_POINT, GDALMD_AOP_POINT);
+        poDriver->SetMetadataItem(GDALMD_AREA_OR_POINT, GDALMD_AOP_AREA);
+        // GDALMD_AOP_AREA is the GDAL default.
+
+        // poDriver->SetMetadataItem( "INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE" );
+
+        poDriver->pfnOpen = VRCDataset::Open;
+        poDriver->pfnIdentify = VRCDataset::Identify;
+
+        GetGDALDriverManager()->RegisterDriver( poDriver );
+    }
+}   // GDALRegister_VRC()
+
+// -------------------------------------------------------------------------
+
+/************************************************************************/
+/*                         EstablishOverviews()                         */
+/*                                                                      */
+/*      Delayed population of overview information.                     */
+/************************************************************************/
+#if 0
+void VRCRasterBand::EstablishOverviews()
+{
+    CPLDebug("VRC","EstablishOverviews()");
+    
+    if( nOverviewCount != -1 )
+        return;
+
+#if 0
+    nOverviewCount = GetOverviewCount(hVRC, nBand);
+#else
+    nOverviewCount = 0;
+#endif
+    if( nOverviewCount > 0 )
+    {
+        papoOverviewBands = static_cast<VRCRasterBand **>
+            (CPLMalloc(sizeof(void*) * static_cast<size_t>(nOverviewCount)) );
+
+        for( int iOvIndex = 0; iOvIndex < nOverviewCount; iOvIndex++ )
+        {
+            papoOverviewBands[iOvIndex] =
+                new VRCRasterBand(static_cast<VRCDataset *>(poDS), nBand, iOvIndex);
+            if( papoOverviewBands[iOvIndex]->GetXSize() == 0 )
+            {
+                delete papoOverviewBands[iOvIndex];
+                papoOverviewBands[iOvIndex] = nullptr;
+            }
+        }
+    }
+} // VRCRasterBand::EstablishOverviews
+#endif // 0
+
+int VRCRasterBand::GetOverviewCount()
+{    
+    auto*poVRCDS = static_cast<VRCDataset*>(poDS);
+    if (poVRCDS == nullptr) {
+        CPLDebug("VRC",
+                 "%p->GetOverviewCount() - band has no dataset",
+                 this);
+        return 0;
+    }
+
+#if defined VRC36_PIXEL_IS_FILE || defined VRC36_PIXEL_IS_TILE
+    if (poVRCDS->nMagic == vrc_magic_thirtysix) {
+        return 0;
+    }
+#endif // VRC36_PIXEL_IS_ not _PIXEL
+
+#if 0 // prune overview list
+    int nRet = nOverviewCount;
+    CPLDebug("Viewranger OVRV",
+             "VRCRasterBand::GetOverviewCount(nOverviewCount=%d papoOverviewBands=%p)",
+             nOverviewCount, papoOverviewBands);
+    if (nRet>0 && papoOverviewBands) {
+        while (nRet>0 && papoOverviewBands[nRet]==nullptr) {
+            --nRet;
+        }
+    }
+    if (nRet<=0) return 0;
+    CPLDebug("Viewranger OVRV",
+             "VRCRasterBand::GetOverviewCount(nOverviewCount=%d papoOverviewBands=%p) returns %d",
+             nOverviewCount, papoOverviewBands, nRet-1);
+    return nRet-1;
+#endif // prune overview list
+
+    auto* poFullBand =
+        static_cast<VRCRasterBand*>(poVRCDS->GetRasterBand(nBand));
+    if (nullptr==poFullBand) {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "%s %p->GetOverviewCount() band %d but dataset %p has no such band",
+                 poVRCDS->sLongTitle.c_str(),
+                 this, nBand, poVRCDS
+                 );
+        return 0;
+    }
+    if (this==poFullBand) {
+        CPLDebug("Viewranger OVRV",
+                 "%s band %p is a parent band with %d overviews at %p",
+                 poVRCDS->sLongTitle.c_str(),
+                 this, poFullBand->nOverviewCount,
+                 poFullBand->papoOverviewBands);
+        if (nOverviewCount != poFullBand->nOverviewCount) {
+            // This cannot happen ?
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "%s %p==%p but overview count %d != %d",
+                 poVRCDS->sLongTitle.c_str(),
+                      this, poFullBand,
+                      nOverviewCount, poFullBand->nOverviewCount);
+        }
+    } else {
+        CPLDebug("Viewranger OVRV",
+                 "%s band %p has %d overviews at %p; its parent %p has %d overviews at %p",
+                 poVRCDS->sLongTitle.c_str(),
+                 this, nOverviewCount, papoOverviewBands,
+                 poFullBand, poFullBand->nOverviewCount, poFullBand->papoOverviewBands
+                 );
+    }
+    
+    if (poFullBand->papoOverviewBands) {
+        return poFullBand->nOverviewCount;
+    } else {    
+        return 0;
+    }
+    
+#if 0 // old
+    if (this==poFullBand) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot find overview tables for full band %p",
+                  this);
+        return 0;
+    }
+
+    int nRet = nOverviewCount;
+    
+    if (0==nRet) {
+        nRet = poFullBand -> nOverviewCount;
+        if ( papoOverviewBands != nullptr &&
+             papoOverviewBands != poFullBand->papoOverviewBands ) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "overview tables for band %p and full band %p differ",
+                      this, poFullBand);
+            return 0;
+        }
+
+        // Should we return 0 for any child overview band ?
+        // return 0;
+    }
+    if (nRet>32) {
+        // silly
+        // something has gone wrong
+        CPLError( CE_Failure, CPLE_AppDefined,
+             "%s %p->VRCRasterBand::GetOverviewCount() nOverviewCount=%d is silly. papoOverviewBands=%p Returning 0",
+                  poVRCDS->sLongTitle.c_str(),
+                  this, nOverviewCount, papoOverviewBands);
+        return 0;
+    }
+
+    // This should not be needed
+    // but we get called with "this" equal to one of the overview bands
+    // (this may be our fault)
+    // and we don't want GDALRasterBand::RasterIO() and
+    // GDALRasterBand::IRasterIO() calling each other.
+    for (int i=0; i<nOverviewCount; i++) {
+        if(this==poFullBand->papoOverviewBands[i]) {
+            if (i==nThisOverview) {
+                CPLDebug("VRC",
+                         "Found band %p as overview %d",
+                         this, i );
+            } else {
+                static int nErrCount=0;
+                nErrCount++;
+                nRet=0;
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "%p->VRCRasterBand::GetOverviewCount(nOverviewCount=%d papoOverviewBands=%p) returns band %d - itself ! (%d such errors)",
+                          this, nOverviewCount, papoOverviewBands, i,
+                          nErrCount);
+                break;
+            }
+        }
+    }
+    CPLDebug("Viewranger OVRV",
+             "%p->VRCRasterBand::GetOverviewCount(nOverviewCount=%d papoOverviewBands=%p) returns %d",
+             this, nOverviewCount, poFullBand->papoOverviewBands, nRet);
+    return nRet;
+#endif // 0 // old
+} // VRCRasterBand::GetOverviewCount
+
+/************************************************************************/
+/*                            GetOverview()                             */
+/************************************************************************/
+
+GDALRasterBand *VRCRasterBand::GetOverview( int iOverviewIn )
+{
+    auto* poVRCDS = static_cast<VRCDataset*>(poDS);
+    if (poVRCDS == nullptr) {
+        CPLDebug("VRC",
+                 "%p->GetOverview(%d) - band has no dataset",
+                 this, iOverviewIn);
+        return nullptr;
+    }
+#if defined VRC36_PIXEL_IS_FILE || defined VRC36_PIXEL_IS_TILE
+    if (poVRCDS->nMagic == vrc_magic_thirtysix) {
+        return nullptr;
+    }
+#endif // VRC36_PIXEL_IS_ not _PIXEL
+    
+    auto* poFullBand =
+        static_cast<VRCRasterBand*>(poVRCDS->GetRasterBand(nBand));
+    if (poFullBand == nullptr) {
+        CPLDebug("VRC",
+                 "%p->GetOverview(%d) - dataset %p has no band %d",
+                 this, iOverviewIn,poVRCDS, nBand );
+        return nullptr;
+    }
+
+    // Short circuit the sanity checks in this case.
+    if (iOverviewIn==poFullBand->nThisOverview) {
+        CPLDebug("VRC", "%p->GetOverview(%d) is itself",
+                 poFullBand, iOverviewIn);
+        return poFullBand;
+    }
+  
+    if( nOverviewCount>32) {
+        CPLDebug("Viewranger",
+                 "nBand %d requested overview %d of %d: more than 32 is silly - something has gone wrong",
+                 nBand, iOverviewIn, nOverviewCount);
+        // This *should* cause it to be regenerated if required.
+        nOverviewCount=-1;
+        return nullptr;
+    }
+    if( nOverviewCount<-1) {
+        CPLDebug("Viewranger",
+                 "nBand %d has %d overviews, but overview %d requested - something has gone wrong",
+                 nBand, nOverviewCount, iOverviewIn);
+        nOverviewCount=-1; // This should cause it to be regenerated if required.
+        return nullptr;
+    }
+    if( iOverviewIn < 0 || iOverviewIn >= poFullBand->nOverviewCount) {
+        CPLDebug("Viewranger",
+                 "nBand %d expected 0<= iOverviewIn %d < nOverviewCount %d",
+                 nBand, iOverviewIn, poFullBand->nOverviewCount);
+        return nullptr;
+    }
+    if( iOverviewIn>32) {
+        // We should not get here
+        CPLDebug("Viewranger",
+                 "nBand %d overview %d requested: more than 32 is silly",
+                 nBand, iOverviewIn);
+        return nullptr;
+    }
+    if(poFullBand->papoOverviewBands==nullptr) {
+        // Seen Fri 24 Jul 2020 and Thu 21 Jan 2021
+        // CPLDebug("Viewranger",
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "%p->GetOverview(%d) nBand %d - no overviews but count is %d :-(",
+                  this, iOverviewIn, nBand, nOverviewCount);
+        return nullptr;
+    } else {
+        VRCRasterBand* pThisOverview
+            = poFullBand->papoOverviewBands[iOverviewIn];
+        CPLDebug("Viewranger",
+                 "GetOverview(%d) nBand %d - returns %d x %d overview %p (overview count is %d)",
+                 iOverviewIn, nBand,
+                 pThisOverview->nRasterXSize,
+                 pThisOverview->nRasterYSize,
+                 pThisOverview, nOverviewCount);
+        if (this==pThisOverview) {
+            static int nCount=0;
+            nCount++;
+            CPLDebug("VRC",
+             "%p->VRCRasterBand::GetOverview(%d) returns itself - called %d times",
+                 this, iOverviewIn, nCount);
+#if 0
+            if (nCount>1000) {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "%p->VRCRasterBand::GetOverview(%d) returns itself - aborting",
+                          this,iOverviewIn);
+                exit(0);
+            }
+#endif
+        }
+        return pThisOverview;
+    }
+} // VRCRasterBand::GetOverview
+
+extern void
+dumpTileHeaderData(
+                   VSILFILE *fp,
+                   unsigned int nTileIndex,
+                   unsigned int nOverviewCount,
+                   unsigned int anTileOverviewIndex[],
+                   const int tile_xx, const int tile_yy )
+{
+    if (fp==nullptr || anTileOverviewIndex==nullptr) {return;}
+    vsi_l_offset byteOffset = VSIFTellL(fp);
+    if (nOverviewCount!=7) {
+        CPLDebug("Viewranger",
+                 "tile (%d %d) header at x%x: %d - not seven",
+                 tile_xx, tile_yy, nTileIndex, nOverviewCount);
+        // CPLDebug does not "use" values
+        (void)tile_xx;
+        (void)tile_yy;
+    }
+    if ( VSIFSeekL( fp, nTileIndex, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "dumpTileHeaderData cannot seek to nTileIndex %u=x%08ux",
+                  nTileIndex, nTileIndex);
+    }
+    for (unsigned int i=0; i<nOverviewCount; i++) {
+        unsigned int a=anTileOverviewIndex[i];
+        if (0==a) {
+            CPLDebug("Viewranger",
+                     "\tanTileOverviewIndex[%d] =x%08x",
+                     i, a);
+        } else {
+            int nXcount = VRReadInt(fp, a);
+            int nYcount = VRReadInt(fp, a+4);
+            int nXsize = VRReadInt(fp, a+8);
+            int nYsize = VRReadInt(fp, a+12);
+            CPLDebug("Viewranger",
+                     "\ttile(%d,%d) anTileOverviewIndex[%d]=x%08x %dx%d tiles each %dx%d pixels",
+                     tile_xx, tile_yy,
+                     i, a, nXcount, nYcount, nXsize, nYsize);
+            // CPLDebug does not "use" values
+            (void)nXcount;
+            (void)nYcount;
+            (void)nXsize;
+            (void)nYsize;
+        }
+    }
+    if ( VSIFSeekL( fp, byteOffset, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "dumpTileHeaderData cannot return file pointer to VRC byteOffset %d=x%08x",
+                  static_cast<int>(byteOffset),
+                  static_cast<int>(byteOffset));
+    }
+} // dumpTileHeaderData()
+
+/* -------------------------------------------------------------------------
+ * -------------------------------------------------------------------------
+ *                VRCRasterBand::read_VRC_Tile_Metres()
+ * -------------------------------------------------------------------------
+ * -------------------------------------------------------------------------
+ */
+void
+VRCRasterBand::read_VRC_Tile_Metres(VSILFILE *fp,
+                             int block_xx, int block_yy,
+                             void *pImage)
+{
+
+    if (block_xx < 0 || block_xx >= static_cast<VRCDataset *>(poDS)->nRasterXSize ) {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "read_VRC_Tile_Metres invalid row %d", block_xx );
+        return ;
+    }
+    if (block_yy < 0 || block_yy >= static_cast<VRCDataset *>(poDS)->nRasterYSize ) {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "read_VRC_Tile_Metres invalid column %d", block_yy );
+        return ;
+    }
+    if (pImage == nullptr ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VRC_Tile_Metres passed no image" );
+        return ;
+    }
+    if (static_cast<VRCDataset *>(poDS)->nMagic != vrc_magic_metres) {
+        // Second "if" will be temporary
+        // if we can read "thirtysix" file data at the subtile/block level.
+        if (static_cast<VRCDataset *>(poDS)->nMagic != vrc_magic_thirtysix) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "read_VRC_Tile_Metres called with wrong magic number x%08x",
+                      static_cast<VRCDataset *>(poDS)->nMagic );
+            return ;
+        }
+    }
+
+    CPLDebug("Viewranger", "read_VRC_Tile_Metres(%p, %d, %d, %p) band %d overview %d",
+             fp, block_xx, block_yy, pImage, nBand, nThisOverview
+             );
+
+
+    // int tilenum = static_cast<VRCDataset *>(poDS)->nRasterXSize * block_xx + block_yy;
+    // int tilenum = nBlockYSize * block_xx + block_yy;
+    // int tilenum = static_cast<VRCDataset *>(poDS)->tileYcount * block_xx + block_yy;
+    int tilenum = static_cast<VRCDataset *>(poDS)->tileXcount * block_yy + block_xx;
+
+    unsigned int nTileIndex = static_cast<VRCDataset *>(poDS)->anTileIndex[tilenum];
+    // CPLDebug("Viewranger", "vrcmetres_pixel_is_pixel");
+    CPLDebug("Viewranger", "\tblock %d x %d, (%d, %d) tilenum %d tileIndex x%08x",
+             nBlockXSize,
+             nBlockYSize,
+             block_xx, block_yy,
+             tilenum,
+             nTileIndex
+             );
+
+    // Write nodata to the canvas before we start reading
+    if (eDataType==GDT_Byte) {
+        for (int j=0; j < nBlockYSize ; j++) {
+            for (int i=0; i < nBlockXSize ; i++) {
+                int pixelnum = j * nBlockXSize + i;
+                if (nBand==4) {
+                    static_cast<GByte *>(pImage)[pixelnum] = 255 ; // alpha: opaque
+                } else {
+                    static_cast<GByte *>(pImage)[pixelnum] =
+#if 0
+                        static_cast<GByte>((i+j) % 256);
+#else
+                        nVRCNoData;
+#endif
+                }
+                // ((GByte *) pImage)[pixelnum] = nVRCNoData;
+            }
+        }
+    } else {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRCRasterBand::read_VRC_Tile_Metres eDataType %d unexpected for null tile",
+                  eDataType);
+    }
+    
+    if (nTileIndex==0) {
+        // No data for this tile
+        CPLDebug("Viewranger",
+                 "VRCRasterBand::read_VRC_Tile_Metres(.. %d %d ..) null tile",
+                 block_xx, block_yy );
+
+        return;
+    }  // nTileIndex==0 No data for this tile
+
+    if (nTileIndex >= static_cast<VRCDataset *>(poDS)->oStatBufL.st_size) {
+        // No data for this tile
+        CPLDebug("Viewranger",
+                 "VRCRasterBand::read_VRC_Tile_Metres(.. %d %d ..) tileIndex %d beyond end of file",
+                 block_xx, block_yy, nTileIndex);
+        return;
+    }  // nTileIndex >= oStatBufL.st_size
+
+    if ( VSIFSeekL( fp, nTileIndex, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to tile header x%08x", nTileIndex );
+        return;
+    }
+
+    nOverviewCount = VRReadInt(fp);
+    if (nOverviewCount != 7) {
+        CPLDebug("Viewranger OVRV", "read_VRC_Tile_Metres: nOverviewCount is %d - expected seven - MapID %d",
+                 nOverviewCount,
+                 static_cast<VRCDataset *>(poDS)->nMapID
+                 );
+        return;
+    }
+    if (static_cast<unsigned int>(nOverviewCount) > static_cast<VRCDataset*>(poDS)->nMaxOverviewCount) {
+        CPLDebug("Viewranger OVRV", "read_VRC_Tile_Metres: reducing nOverviewCount %d to %d (from tile sizes %d - %d)",
+                 nOverviewCount,
+                 static_cast<VRCDataset *>(poDS)->nMaxOverviewCount,
+                 static_cast<VRCDataset *>(poDS)->tileSizeMax,
+                 static_cast<VRCDataset *>(poDS)->tileSizeMin
+                 );
+        // nOverviewCount = static_cast<int>(static_cast<VRCDataset *>(poDS)->nMaxOverviewCount);
+    }
+
+    unsigned int anTileOverviewIndex[7]={};
+    for (int ii=0; ii<std::min(7,nOverviewCount); ii++) {
+        anTileOverviewIndex[ii] = VRReadUInt(fp);
+    }
+    CPLDebug("Viewranger OVRV",
+             "x%08x:  x%08x x%08x x%08x x%08x  x%08x x%08x x%08x x%08x",
+             nTileIndex, nOverviewCount,
+             anTileOverviewIndex[0],  anTileOverviewIndex[1],
+             anTileOverviewIndex[2],  anTileOverviewIndex[3],
+             anTileOverviewIndex[4],  anTileOverviewIndex[5],
+             anTileOverviewIndex[6]
+             );
+
+    // VRC counts main image plus 6 overviews.
+    // GDAL just counts the 6 overview images.
+    // anTileOverviewIndex[0] points to the full image
+    // ..[1-6] are the overviews:
+    nOverviewCount--; // equals 6
+
+    // If the smallest overviews do not exist, ignore them.
+    // This saves this driver generating them from larger overviews,
+    // they may need to be generated elsewhere ...
+    while (nOverviewCount>0 && 0==anTileOverviewIndex[nOverviewCount]) {
+        nOverviewCount--;
+    }
+    if (nOverviewCount<6) {
+        CPLDebug("Viewranger OVRV",
+                 "Overviews %d-6 not available",
+                 1+nOverviewCount);
+    }
+
+    if (nOverviewCount<1 || anTileOverviewIndex[0] == 0) {
+        CPLDebug("Viewranger",
+                 "VRCRasterBand::read_VRC_Tile_Metres(.. %d %d ..) empty tile",
+                 block_xx, block_yy );
+        return; 
+    }
+
+    // here 22 Aug, 2020
+    
+    // This is just for the developer's understanding.
+    if (0x20 + nTileIndex == anTileOverviewIndex[0]) {
+        CPLDebug("Viewranger OVRV",
+                 "anTileOverviewIndex[0] %d x%08x - 0x20 = %d x%08x as expected",
+                 anTileOverviewIndex[0], anTileOverviewIndex[0],
+                 nTileIndex, nTileIndex);
+    } else {
+        CPLDebug("Viewranger OVRV",
+                 "anTileOverviewIndex[0] %d x%08x - nTileIndex %d x%08x = %d x%08x - expected 0x20",
+                 anTileOverviewIndex[0], anTileOverviewIndex[0],
+                 nTileIndex,           nTileIndex,
+                 anTileOverviewIndex[0] - nTileIndex,
+                 anTileOverviewIndex[0] - nTileIndex);
+    }
+
+    dumpTileHeaderData(fp, nTileIndex,
+                       1+static_cast<unsigned int>(nOverviewCount),
+                       anTileOverviewIndex, block_xx, block_yy );
+
+    if (nThisOverview < -1 || nThisOverview >= nOverviewCount) {
+        CPLDebug("Viewranger OVRV",
+                 "read_VRC_Tile_Metres: overview %d=x%08x not in range [-1, %d)",
+                 nThisOverview, nThisOverview, nOverviewCount);
+        return;
+    }
+
+    if (anTileOverviewIndex[nThisOverview+1] >= static_cast<VRCDataset *>(poDS)->oStatBufL.st_size) {
+        CPLDebug("Viewranger OVRV",
+                 "\toverview level %d data at x%08x is beyond end of file",
+                 nThisOverview, anTileOverviewIndex[nThisOverview+1] );
+        return ;
+    }
+    CPLDebug("Viewranger OVRV",
+             "\toverview level %d data at x%08x",
+             nThisOverview, anTileOverviewIndex[nThisOverview+1] );
+
+    bool bTileShrink = (anTileOverviewIndex[nThisOverview+1]==0);
+    unsigned int nShrinkFactor=1;
+    if (bTileShrink == false) {
+        nShrinkFactor = 1;
+        if ( VSIFSeekL( fp, anTileOverviewIndex[nThisOverview+1], SEEK_SET ) ) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "cannot seek to overview level %d data at x%08x",
+                      nThisOverview, anTileOverviewIndex[nThisOverview+1] );
+            return;
+        }
+
+        unsigned int nTileMax = static_cast<VRCDataset *>(poDS)->tileSizeMax;
+        unsigned int nTileMin = static_cast<VRCDataset *>(poDS)->tileSizeMin;
+        int bits = 63 - __builtin_clzll
+            (static_cast<unsigned long long>(nTileMax/nTileMin) );
+
+        if (nTileMax == nTileMin << bits) {
+            CPLDebug("Viewranger OVRV",
+                     "%d / %d == %f == 2^%d",
+                     nTileMax, nTileMin,
+                     1.0*nTileMax/nTileMin, bits);
+        } else {
+            CPLDebug("Viewranger OVRV",
+                     "%d / %d == %f != 2^%d",
+                     nTileMax, nTileMin,
+                     1.0*nTileMax/nTileMin, bits);
+        }
+
+        CPLDebug("Viewranger OVRV",
+                 "\tblock %d x %d, max %d min %d overview %d",
+                 nBlockXSize,
+                 nBlockYSize,
+                 nTileMax, nTileMin,
+                 nThisOverview
+                 );
+        
+    } else { // bTileShrink == true;
+        // Data for this block is not available
+        // so we need to rescale another overview.
+        if(anTileOverviewIndex[nThisOverview]==0) {
+            CPLDebug("Viewranger OVRV",
+                     "Band %d block %d,%d overviews %d and %d empty - cannot shrink one to get other\n",
+                     nBand, block_xx, block_yy,
+                     nThisOverview-1, nThisOverview
+                     );
+            return;
+        }
+
+        nShrinkFactor = 2;
+
+        CPLDebug("Viewranger OVRV",
+                 "Band %d block %d,%d empty at overview %d\n",
+                 nBand, block_xx, block_yy, nThisOverview
+                 );
+        CPLDebug("Viewranger OVRV",
+                 "\t overview %d at x%08x\n",
+                 nThisOverview-1, anTileOverviewIndex[nThisOverview]
+                 );
+
+        if ( VSIFSeekL( fp, anTileOverviewIndex[nThisOverview], SEEK_SET ) ) {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "cannot seek to overview level %d data at x%08x",
+                      nThisOverview-1, anTileOverviewIndex[nThisOverview] );
+            return;
+        }
+
+        CPLDebug("Viewranger OVRV",
+                 "Band %d block %d,%d overview %d will be downsampled",
+                 nBand, block_xx, block_yy, nThisOverview
+                 );
+    } // end bTileShrink == true
+
+    // We have reached the start of the tile
+    // ... but it is split into (essentially .png file) subtiles
+    unsigned int nPNGXcount = VRReadUInt(fp);
+    unsigned int nPNGYcount = VRReadUInt(fp);
+    unsigned int pngXsize  = VRReadUInt(fp);
+    unsigned int pngYsize  = VRReadUInt(fp);
+
+    if (nPNGXcount==0 || nPNGYcount==0) {
+        CPLDebug("Viewranger",
+                 "tilenum %d contains no subtiles (%u x %u)",
+                 tilenum, nPNGXcount, nPNGYcount );
+        return;
+    }
+    if (pngXsize==0||pngYsize==0) {
+        CPLDebug("Viewranger",
+                 "empty (%u x %u) subtile in tilenum %d",
+                 pngXsize, pngYsize, tilenum );
+        return;
+    }
+    auto nFullBlockXSize =
+        static_cast<unsigned>(nBlockXSize) * nShrinkFactor;
+    if ( nPNGXcount > nFullBlockXSize
+         || pngXsize > nFullBlockXSize
+         || nPNGXcount * pngXsize > nFullBlockXSize
+         ) {
+        CPLDebug("Viewranger",
+                 "nPNGXcount %d x pngXsize %d too big > nBlockXSize %d * nShrinkFactor %d",
+                 nPNGXcount, pngXsize, nBlockXSize, nShrinkFactor);
+        // return;
+    }
+    auto nFullBlockYSize =
+        static_cast<unsigned>(nBlockYSize) * nShrinkFactor;
+    if ( nPNGYcount > nFullBlockYSize
+         || pngYsize > nFullBlockYSize
+         || nPNGYcount * pngYsize > nFullBlockYSize
+         ) {
+        CPLDebug("Viewranger",
+                 "nPNGYcount %d x pngYsize %d too big > nBlockYSize %d * nShrinkFactor %d",
+                 nPNGYcount, pngYsize, nBlockYSize, nShrinkFactor);
+        // return;
+    }
+
+    CPLDebug("Viewranger",
+             "ovrvw %d nPNGXcount %d nPNGYcount %d pngXsize %d pngYsize %d nShrinkFactor %d",
+             nThisOverview,
+             nPNGXcount, nPNGYcount,
+             pngXsize, pngYsize,
+             nShrinkFactor);
+
+    // Read in this tile's index to png sub-tiles.
+    std::vector<unsigned int> anPngIndex;
+    anPngIndex.reserve(static_cast<size_t>(nPNGXcount)*nPNGYcount +1 );
+    for (unsigned long loop=0;
+         loop <= static_cast<unsigned long>(nPNGXcount)*nPNGYcount;
+         loop++) {
+        // <= because there is an extra entry
+        //    pointing just passed the last png sub-tile.
+        anPngIndex[loop] = VRReadUInt(fp);
+        if (anPngIndex[loop] > static_cast<VRCDataset *>(poDS)->oStatBufL.st_size) {
+            CPLDebug("Viewranger",
+                     "Band %d ovrvw %d block [%d,%d] png image %lu at x%x is beyond EOF - is file truncated ?",
+                     nBand, nThisOverview, block_xx, block_yy, loop, anPngIndex[loop] );
+            anPngIndex[loop] = 0;
+        }
+    }
+
+    // unsigned int nPNGplteIndex = nTileIndex + 0x20 + 0x10 +8
+    //    + 4*(nPNGXcount*nPNGYcount+1);
+    vsi_l_offset nPNGplteIndex = VSIFTellL(fp);
+    CPLDebug("Viewranger",
+             "nPNGplteIndex %llu=x%08llx",
+             nPNGplteIndex, nPNGplteIndex );
+
+    unsigned int VRCplteSize = VRReadUInt(fp);
+    unsigned int PNGplteSize = PNGReadUInt(fp);
+    if (VRCplteSize-PNGplteSize ==8) {
+        if (PNGplteSize %3) {
+            CPLDebug("Viewranger",
+                     "ignoring palette: size %d=x%08x not a multiple of 3",
+                     PNGplteSize, PNGplteSize );
+            nPNGplteIndex = 0;
+        } else {
+            CPLDebug("Viewranger",
+                     "palette %d=x%08x bytes, %d entries at %012llx",
+                     PNGplteSize, PNGplteSize,
+                     PNGplteSize/3, nPNGplteIndex);
+        }
+    } else {
+        CPLDebug("Viewranger",
+                 "ignoring palette at %lld=x%08llx: size mismatch %d=x%08x - %d=x%08x is %d=x%08x not 8",
+                 nPNGplteIndex, nPNGplteIndex,
+                 VRCplteSize,VRCplteSize, PNGplteSize,PNGplteSize,
+                 VRCplteSize-PNGplteSize, VRCplteSize-PNGplteSize
+                 );
+        nPNGplteIndex = 0;
+    }
+
+    int nLeftCol=0;
+    unsigned int nPrevPNGwidth=0;
+    unsigned int nXlimit = MIN(nPNGXcount, nFullBlockXSize);
+    unsigned int nYlimit = MIN(nPNGYcount, nFullBlockYSize);
+    for (unsigned int loopX=0; loopX < nXlimit; loopX++) {
+        int nRightCol=0;
+        unsigned int nPrevPNGheight=0;
+        int nBottomRow=nBlockYSize;
+        // int nTopRow;
+
+        // for (unsigned int loopY=nYlimit; loopY >= 0; loopY--) {
+        // unsigned>=0 always true, so a standard for loop wont work:
+        for (unsigned int loopY=nYlimit; loopY >= 1; /* see comments */ ) {
+            // decrement at *start* of loop
+            //so that we can have the last pass with loopY==0
+            --loopY;
+            
+            unsigned int loop = (nYlimit-1-loopY) + loopX*nPNGYcount;
+
+            unsigned int nHeader =
+                anPngIndex[static_cast<unsigned>(loop)];
+            unsigned int nextPngIndex =
+                anPngIndex[static_cast<unsigned>(loop+1)];
+            signed int nDataLen =
+                static_cast<signed>(nextPngIndex) -
+                static_cast<signed>(nHeader + 0x12);
+            if (nHeader==0) {
+                CPLDebug("Viewranger",
+                         "block (%d,%d) tile (%d,%d) empty",
+                         block_xx, block_yy, loopX, loopY);
+                continue;
+            }
+            if (nDataLen<1) { // There should be a better/higher limit.
+                CPLDebug("Viewranger PNG",
+                         "block (%d,%d) tile (%d,%d) PNG data overflows - length %d",
+                         block_xx, block_yy, loopX, loopY, nDataLen);
+                continue ;
+            }
+            //unsigned int nPalette = nPNGplteIndex;
+
+            if ( static_cast<VRCDataset *>(poDS)->nMagic == vrc_magic_metres) {
+                unsigned int nPNGwidth=0;
+                unsigned int nPNGheight=0;
+                CPLDebug("Viewranger",
+                         "calling read_PNG(%p .. %d %llu %d tile (%d %d) loop (%d %d))",
+                         fp,
+                         nHeader, nPNGplteIndex, nDataLen,
+                         block_xx, block_yy,
+                         loopX, loopY
+                         );
+                png_byte* pbyPNGbuffer =
+                    read_PNG (
+                              fp,
+                              &nPNGwidth, &nPNGheight,
+                              nHeader, nPNGplteIndex,
+                              static_cast<unsigned int>(nDataLen),
+                              block_xx, block_yy,
+                              loopX, loopY
+                              );
+                if (pbyPNGbuffer) {
+                    CPLDebug("Viewranger",
+                             "read_PNG() returned %p: %d x %d tile",
+                             pbyPNGbuffer, nPNGwidth, nPNGheight);
+                    if (getenv("VRC_DUMP_TILE")) {
+                        auto nEnvTile = static_cast<unsigned int>
+                            (strtol(getenv("VRC_DUMP_TILE"),nullptr,10));
+                        // Dump pbyPNGbuffer as .ppm, one for each band, they should be full-colour and the same.
+                        CPLString osBaseLabel = CPLString().Printf
+                            ("/tmp/werdna/vrc2tif/%s.%01d.%03d.%03d.%03d.%03d.%02ua",
+                             // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                             static_cast<VRCDataset *>(poDS)->sLongTitle.c_str(),
+                             nThisOverview, block_xx, block_yy,
+                             loopX, loopY,
+                             nBand);
+                        dumpPPM(
+                                static_cast<unsigned int>(nPNGwidth),
+                                static_cast<unsigned int>(nPNGheight),
+                                pbyPNGbuffer,
+                                static_cast<unsigned int>(nPNGwidth),
+                                osBaseLabel,
+                                pixel,
+                                nEnvTile
+                                );
+                    }
+
+                    if (nPrevPNGwidth==0) {
+                        nPrevPNGwidth=nPNGwidth;
+                    } else if (nPNGwidth!=nPrevPNGwidth) {
+                        CPLDebug("Viewranger",
+                                 "PNG width %d different from previous tile %d in same column",
+                                 nPNGwidth, nPrevPNGwidth);
+                    }
+    
+                    if (nPrevPNGheight==0) {
+                        nPrevPNGheight=nPNGheight;
+                    } else if (nPrevPNGheight!=nPNGheight) {
+                        CPLDebug("Viewranger",
+                                 "PNG height %d different from previous tile %d in same row",
+                                 nPNGheight, nPrevPNGheight);
+                    }
+    
+                    nRightCol=nLeftCol;
+                    int nTopRow=nBottomRow;
+                    nRightCol += nPNGwidth/nShrinkFactor;
+                    nTopRow -= nPNGheight/nShrinkFactor;
+
+                    if (nPNGheight>=nFullBlockYSize) {
+                        // single tile block
+                        if (nTopRow<0) {
+                            CPLDebug("Viewranger",
+                                     "Single PNG high band toprow %d set to 0",
+                                     nTopRow);
+                            nTopRow=0;
+                        }
+                    }
+                    if (nTopRow<0) {
+                        CPLDebug("Viewranger",
+                                 "%d tall PNG tile: top row %d above top of %d tall block",
+                                 nPNGheight, nTopRow, nBlockYSize 
+                                 );
+                    }
+                    
+                    // Blank the top of the top tile if necessary
+                    if (loopY==nYlimit-1) {
+#if 0
+                        int rowStartPixel =
+                            nTopRow * std::max(nPNGwidth, nBlockXSize)
+                            + nLeftCol;
+#endif
+                        auto *pGImage = static_cast<GByte*>(pImage);
+                        for (int ii=nBlockYSize; ii<nTopRow; ii++) {
+                            for (int jj=nLeftCol; jj<nRightCol; jj++) {
+                                pGImage[jj] = // (ii+jj)%255;
+                                    nVRCNoData;
+                            }
+                            pGImage += nBlockXSize;
+                        } 
+                    }
+                    
+                    int nCopyResult=0;
+                    if(!bTileShrink){ // anTileOverviewIndex[nThisOverview+1]) {
+                        CPLDebug("Viewranger",
+                                 "Band %d: Copy_Tile_ (%d %d) into_Block (%d %d) [%d %d)x[%d %d)",
+                                 nBand,
+                                 loopX, loopY,
+                                 block_xx, block_yy,
+                                 nLeftCol, nRightCol,
+                                 nTopRow, nBottomRow
+                                 );
+                        nCopyResult = Copy_Tile_into_Block
+                            (static_cast<GByte*>(pbyPNGbuffer),
+                             static_cast<int>(nPNGwidth),
+                             static_cast<int>(nPNGheight),
+                             nLeftCol,nRightCol,
+                             nTopRow, nBottomRow,
+                             pImage
+                             // , nBlockXSize, nBlockYSize
+                             );
+                    } else {
+                        CPLDebug("Viewranger",
+                                 "Band %d: Shrink_Tile_ (%d %d) into_Block (%d %d) [%d %d)x[%d %d)",
+                                 nBand,
+                                 loopX, loopY,
+                                 block_xx, block_yy,
+                                 nLeftCol, nRightCol,
+                                 nTopRow, nBottomRow
+                                 );
+
+                        nCopyResult = Shrink_Tile_into_Block
+                            (static_cast<GByte*>(pbyPNGbuffer),
+                             static_cast<int>(nPNGwidth),
+                             static_cast<int>(nPNGheight),
+                             nLeftCol,nRightCol,
+                             nTopRow, nBottomRow,
+                             pImage
+                             // , nBlockXSize, nBlockYSize
+                             );
+                        CPLDebug("Viewranger",
+                                 "\tShrink_Tile (%d %d) _into_Block (%d %d) returned %d",
+                                 loopX, loopY,
+                                 block_xx, block_yy,
+                                 nCopyResult
+                                 );
+                    }
+
+                    nBottomRow = nTopRow;
+                    VSIFree(pbyPNGbuffer);
+                    pbyPNGbuffer=nullptr;
+                    if (nCopyResult) {
+                        CPLDebug("Viewranger",
+                                 "failed to copy/shrink tile to block"
+                                 );
+                    }
+                } else {
+                    // read_PNG returned nullptr
+                    CPLDebug("Viewranger", "empty %d x %d tile ... prev was %d x %d",
+                             nPNGwidth, nPNGheight, nPrevPNGwidth, nPrevPNGheight
+                             );
+                } // if (pbyPNGbuffer)
+                CPLDebug("Viewranger",
+                         "... read PNG tile (%d %d) overview %d block (%d %d) completed",
+                         loopX, loopY,
+                         nThisOverview,
+                         block_xx, block_yy
+                         );
+                
+            } else if (static_cast<VRCDataset *>(poDS)->nMagic == vrc_magic_thirtysix) {
+#if 0
+                CPLString osBaseLabel = CPLString().
+                    Printf("/tmp/werdna/vrc2tif/%s.%01d.%03d.%03d.%03d.%03d.%08lu.%02u",
+                           // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                           static_cast<VRCDataset *>(poDS)->sLongTitle.c_str(),
+                           nThisOverview, block_xx, block_yy, loopX, loopY,
+                           static_cast<long unsigned>(nHeader), nBand);
+#endif
+                int ret=
+                    verifySubTileFile(fp,
+                                      nHeader,
+                                      nextPngIndex,
+                                      block_xx, block_yy, loopX, loopY);
+                if (0!=ret) {
+                    CPLDebug("Viewranger RAW",
+                             "verify tile (%d,%d) subtile (%d,%d) returned %d\n",
+                             block_xx, block_yy, loopX, loopY, ret);
+                }
+            } else {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "We should not be here with magic=x%08x",
+                         static_cast<VRCDataset *>(poDS)->nMagic);
+                return;
+            } // if (magic ...)
+        } // for (loopY
+        nLeftCol=nRightCol;
+    } // for (loopX
+
+#if 0
+    // Blank a strip on the right of any under-wide tiles.
+    int nSkipRightCols = nBlockXSize - nPNGXcount * pngXsize;
+    if (nSkipRightCols > 0) {
+        CPLDebug("Viewranger",
+                 "Band %d ovrvw %d block [%d,%d] png image %d pixels (nSkipRightCols) underwide: pngXsize %d",
+                 nBand, nThisOverview, block_xx, block_yy, nSkipRightCols,
+                 pngXsize);
+        //   Unlike the top edge, GDAL and VRC agree that
+        // narrow tiles are at the left edge of the right-most tile.
+        //   We don't need to adjust any sizes for this case...
+        // ... but we may need to blank a strip at the right of the tile.
+        for (int nY=0; nY<nBlockYSize; nY++) {
+            int nPix = nY * nBlockXSize +  nPNGXcount * pngXsize;
+            for (int nX=0; nX<nSkipRightCols; nX++) {
+                // July 8, 2020 - seeing whether this affects Slovenia 25% - no
+                // ((unsigned char*)pImage)[nPix++] = 255; // 63*nBand; // nVRCNoData;
+                ((unsigned char*)pImage)[nPix++] = nVRCNoData;
+            }
+        }
+        CPLDebug("Viewranger",
+                 "Band %d ovrvw %d block [%d,%d] png image %d pixels under-wide",
+                 nBand, nThisOverview, block_xx, block_yy, nSkipRightCols);
+    }
+    // Should we set poDS->nRightSkipPix here ?
+    CPLDebug("Viewranger",
+             "VRCRasterBand::read_VRC_Tile_Metres: nRightSkipPix %d nSkipRightCols %d",
+             poDS->nRightSkipPix, nSkipRightCols );
+#endif
+    
+    if (getenv("VRC_DUMP_TILE")) {
+        auto nPPMcount = static_cast<unsigned int>
+            (strtol(getenv("VRC_DUMP_TILE"),nullptr,10));
+        // Dump VRC tile as .pgm, one for each band, they will be monochrome.
+        CPLString osBaseLabel
+            = CPLString().Printf("/tmp/werdna/vrc2tif/%s.%01d.%03d.%03d.%02u",
+                                 // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                                 static_cast<VRCDataset *>(poDS)->sLongTitle.c_str(),
+                                 nThisOverview, block_xx, block_yy,
+                                 nBand);
+
+        dumpPPM(
+                static_cast<unsigned int>(nBlockXSize),
+                static_cast<unsigned int>(nBlockYSize),
+                static_cast<unsigned char*>(pImage),
+                static_cast<unsigned int>(nBlockXSize),
+                osBaseLabel,
+                band,
+                nPPMcount
+                );
+    }
+
+} // VRCRasterBand::read_VRC_Tile_Metres
+
+int VRCRasterBand::Copy_Tile_into_Block
+(
+   GByte* pbyPNGbuffer,
+   int nPNGwidth,
+   int nPNGheight,
+   int nLeftCol,
+   int nRightCol,
+   int nTopRow,
+   int nBottomRow,
+   void* pImage
+ // , int nBlockXSize,
+ // , int nBlockYSize
+ )
+{
+    // Copy image data from buffer to band
+    
+    CPLDebug("Viewranger PNG",
+             "Copy_Tile_into_Block(%p %d x %d -> [%d %d)x[%d %d) %p) band %d",
+             pbyPNGbuffer,
+             nPNGwidth,   nPNGheight,
+             nLeftCol,    nRightCol,
+             nTopRow,     nBottomRow,
+             pImage,
+             // nBlockXSize, nBlockYSize,
+             nBand
+             );
+
+    int rowStartPixel =
+        nTopRow * std::max(nPNGwidth, nBlockXSize)
+        + nLeftCol;
+    // Need to adjust if we have a short (underheight) tile.
+    // werdna, 2020 July 09 done ? No.
+    // What about underwide tiles/blocks ?
+        
+
+    // GByte *pGImage = &(((GByte *)(pImage))[rowStartPixel]);
+    GByte *pGImage = (static_cast<GByte*>(pImage))+rowStartPixel;
+    CPLDebug("Viewranger PNG",
+             "VRC band %d ovrvw %d nTopRow %d rowStartPixel %d",
+             nBand, nThisOverview,
+             nTopRow, rowStartPixel
+             );
+
+    if (nPNGheight < nBlockYSize) {
+        if (nTopRow+nPNGheight > nBlockYSize) {
+            CPLDebug("Viewranger PNG",
+                     "band %d overview %d nTopRow %d +nPNGheight %d > nRasterYSize %d",
+                     nBand, nThisOverview,
+                     nTopRow, nPNGheight, nRasterYSize);
+            //VSIFree(pbyPNGbuffer);
+            //continue;
+        }
+    }
+                        
+    CPLDebug("Viewranger PNG",
+             "band %d overview %d copying to [%d %d) x [%d %d)",
+             nBand, nThisOverview,
+             nLeftCol, nRightCol, nTopRow, nBottomRow
+             );
+#if 0
+    CPLDebug("Viewranger PNG",
+             "band %d overview %d block %d %d prev %d %d, current %d %d",
+             nBand, nThisOverview, block_xx, block_yy,
+             nPrevPNGwidth, nPrevPNGheight, nPNGwidth, nPNGheight
+             );
+#endif
+    
+    int nCopyStopRow=std::min(nPNGheight,nBlockYSize-nTopRow);
+
+    if (nBottomRow!=nCopyStopRow) {
+        CPLDebug("Viewranger PNG",
+                 "band %d overview %d nTopRow %d - nBottomRow %d != %d nCopyStopRow",
+                 nBand, nThisOverview,
+                 nTopRow, nBottomRow,
+                 nCopyStopRow
+             );
+    }
+    for (int ii=0; ii<nCopyStopRow; ii++) {
+        long long nGImageOffset = pGImage-static_cast<GByte*>(pImage);
+        
+#if 1 // Noisy
+        if (getenv("VRC_NOISY")) {
+            CPLDebug("Viewranger PNG",
+                     "band %d overview %d row %d: copying from %p = pbyPNGbuffer %p + %ld",
+                     nBand, nThisOverview, ii, pbyPNGbuffer+nPNGwidth*ii,
+                     pbyPNGbuffer, static_cast<long>(nPNGwidth)*ii
+                     );
+            CPLDebug("Viewranger PNG",
+                     "band %d overview %d copying 1  to %p = pImage + %lld = pImage + %g*%d",
+                     nBand, nThisOverview, pGImage, nGImageOffset,
+                     static_cast<double>(nGImageOffset)/nRasterXSize, nRasterXSize
+                         
+                     );
+            // Which of these is right (if any) ?
+            CPLDebug("Viewranger PNG",
+                     "band %d overview %d copying 2  to %p = pImage + %lld = pImage + %g*%d",
+                     nBand, nThisOverview, pGImage, nGImageOffset,
+                     static_cast<double>(nGImageOffset)/nBlockXSize, nBlockXSize
+                     );
+            }
+#endif // Noisy
+        if (nGImageOffset+nPNGwidth > nBlockXSize*nBlockYSize) {
+            CPLDebug("Viewranger PNG",
+                     "Bang: %lld+%d ?> %d = %d*%d",
+                     nGImageOffset, nPNGwidth,
+                     nBlockXSize*nBlockYSize,
+                     nBlockXSize,nBlockYSize
+                     );
+        }
+        // If nBlockXSize is not divisible by a sufficiently large power of two
+        // then nPNGwidth*2^k may be slightly bigger than nBlockXSize
+        int nCopyStopCol=std::min(nPNGwidth,nBlockXSize-nLeftCol);
+        if (nRightCol!=nCopyStopCol) {
+            CPLDebug("Viewranger PNG",
+                     "stopping at col %d of %d",
+                     nCopyStopCol, nRightCol
+                     );
+        }
+#if 0 // Grey-scale
+        for (int jj=0; jj<nCopyStopCol; jj++) {
+            pGImage[jj] = (pbyPNGbuffer+nPNGwidth*ii)[jj];
+        }
+#else
+        if (nBand==4) {
+            for (int jj=0; jj<nCopyStopCol; jj++) {
+                // pGImage[jj] = 255; // Opposite of nVRCNoData;
+            }
+        } else {
+            for (int jj=0, jjj=nBand-1; jj<nCopyStopCol; jj++, jjj+=3) {
+                unsigned char temp =
+                    (pbyPNGbuffer+3*nPNGwidth*ii)[jjj];
+#if 1 // Noisy
+                if (getenv("VRC_NOISY")) {
+                    CPLDebug("Viewranger PNG",
+                             "pixel copy %d[%d] (%d) -> %lld[%d]",
+                             3*nPNGwidth*ii, jjj,
+                             temp,
+                             nGImageOffset, jj);
+                }
+#endif // Noisy
+                pGImage[jj] = temp;
+            }
+        }
+#endif // ! Grey-scale
+
+        pGImage += nBlockXSize;
+    } // for ii < nCopyStopRow
+    
+    CPLDebug("Viewranger PNG",
+             "copied PNG buffer %p %d x %d into pImage %p %d x %d",
+             pbyPNGbuffer, nPNGwidth, nPNGheight,
+             pImage, nRasterXSize, nRasterYSize
+             );
+
+#if 1 // defined VRCDUMPTILE
+    if (getenv("VRC_DUMP_TILE")) {
+        auto nPPMcount = static_cast<unsigned int>
+            (strtol(getenv("VRC_DUMP_TILE"),nullptr,10));
+        CPLString osBaseLabel = CPLString().Printf
+            ("/tmp/werdna/vrc2tif/%s.%d.%01d.t%03d.l%03d.w%03d.h%03d",
+             // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+             static_cast<VRCDataset *>(poDS)->sLongTitle.c_str(),
+             nBand, nThisOverview,
+             nTopRow, nLeftCol,
+             nPNGwidth, nPNGheight
+             );
+        
+        dumpPPM(
+                static_cast<unsigned>(nPNGwidth),
+                static_cast<unsigned>(nPNGheight),
+                static_cast<unsigned char*>(pImage)
+                + nBlockXSize*nTopRow
+                + nLeftCol
+                ,
+                static_cast<unsigned>(nBlockXSize), // nRasterXSize,
+                osBaseLabel,
+                band,
+                nPPMcount
+                );
+    }
+#endif // VRCDUMPTILE
+
+    return 0;
+
+} // VRCRasterBand::Copy_Tile_into_Block
+
+int VRCRasterBand::Shrink_Tile_into_Block
+(
+ GByte* pbyPNGbuffer,
+ int nPNGwidth,
+ int nPNGheight,
+ int nLeftCol,
+ int nRightCol,
+ int nTopRow,
+ int nBottomRow,
+ void* pImage
+ // , int nBlockXSize,
+ // int nBlockYSize
+ )
+{
+    CPLDebug("Viewranger PNG",
+             "Shrink_Tile_into_Block(%p %d x %d -> [%d %d)x[%d %d) %p [%d %d) )",
+             pbyPNGbuffer,
+             nPNGwidth,
+             nPNGheight,
+             nLeftCol,
+             nRightCol,
+             nTopRow,
+             nBottomRow,
+             pImage,
+             nBlockXSize,
+             nBlockYSize
+             );
+    
+    if (nTopRow <0 || nTopRow>= nBlockYSize) {
+            CPLDebug("Viewranger PNG",
+                     "Shrink_Tile_into_Block: nTopRow %d not in [0,%d)",
+                     nTopRow, nBlockYSize);
+            //return -1;
+    }
+    if (nBottomRow < nTopRow || nBottomRow > nBlockYSize) {
+            CPLDebug("Viewranger PNG",
+             "Shrink_Tile_into_Block: nBottomRow %d not in [%d,%d)",
+                     nBottomRow, nTopRow, nBlockYSize);
+            //return -1;
+    }
+
+    if (nLeftCol <0 || nLeftCol>= nBlockXSize) {
+            CPLDebug("Viewranger PNG",
+                     "Shrink_Tile_into_Block: nLeftCol %d not in [0,%d)",
+                     nLeftCol, nBlockXSize);
+            //return -1;
+    }
+    if (nRightCol < nLeftCol || nRightCol > nBlockXSize ) {
+            CPLDebug("Viewranger PNG",
+             "Shrink_Tile_into_Block: nRightCol %d not in [%d,%d)",
+                     nRightCol, nLeftCol, nBlockXSize);
+            //return -1;
+    }
+    int nCopyStartCol=std::max(0,nLeftCol);
+    int nCopyStartRow=std::max(0,nTopRow);
+    // If nBlockXYSize is not divisible by a sufficiently large power
+    // of two then nPNGwidthheight*2^k may be slightly bigger than nBlockXYSize
+    int nCopyStopCol=
+        std::min(nLeftCol+(nPNGwidth+1)/2,
+                 std::min(nRightCol, nBlockYSize));
+    int nCopyStopRow=std::min(nTopRow+(nPNGheight+1)/2, nBottomRow);
+
+    // here 10 Feb 2021
+        
+    int nOutRowStartPixel =
+        nCopyStartRow * nBlockXSize; // std::max((1+nPNGwidth)/2, nBlockXSize)
+    // + nCopyStartCol;
+    // Need to adjust if we have a short (underheight) tile.
+    // werdna, 2020 July 09 done ? No.
+    // What about underwide tiles/blocks ?
+    CPLDebug("Viewranger PNG",
+             "nOutRowStartPixel %d == %d * %d + %d",
+             nOutRowStartPixel, nCopyStartRow, nBlockXSize, nCopyStartCol );
+    CPLDebug("Viewranger PNG",
+             "Shrink_Tile_into_Block: nOutRowStartPixel %d ii loops [%d/%d,%d/%d/%d)",
+             nOutRowStartPixel,
+             nTopRow,nCopyStartRow, nCopyStopRow,nBottomRow,nBlockYSize);
+    CPLDebug("Viewranger PNG",
+             "Shrink_Tile_into_Block: loopX-tile-adj missing jj loops [%d/%d,%d/%d/%d)",
+             // need adjustment for loopX'th tile,
+             nLeftCol,nCopyStartCol, nCopyStopCol,nRightCol,nBlockXSize);
+        
+
+    GByte *pGImage = static_cast<GByte *>(pImage)
+        // need + adjust for loopX'th tile
+        + nOutRowStartPixel;
+
+#if 1
+    {
+        int i1=3*nPNGwidth*2*(nBottomRow-1-nCopyStartRow);
+        // int i2=i1+3*nPNGwidth;
+        int jjj=(nBand-1)+(nCopyStopCol-1-nCopyStartCol)*6;
+        if (i1+jjj > 3*nPNGwidth*nPNGheight - 16) {
+            CPLDebug("Viewranger PNG",
+                     "Band %d: i1 %d = 3 * %d * 2 * %d",
+                     nBand,
+                     i1, nPNGwidth, nBottomRow-1-nCopyStartRow
+                     );
+            CPLDebug("Viewranger PNG",
+                     "Band %d: jjj %d = %d + %d * 6",
+                     nBand,
+                     jjj, nBand-1, nCopyStopCol-1-nCopyStartCol
+                     );
+            CPLDebug("Viewranger PNG",
+                     "Band %d: Shrink_Tile_into_Block: (i1+jjj %d+%d=%d) - 6*%d*%d = %d",
+                     nBand,
+                     i1, jjj, i1+jjj,
+                     nPNGwidth,nPNGheight,
+                     (i1+jjj)-(6*nPNGwidth*nPNGheight)
+                     );
+        }
+    }
+#endif
+
+#if 0
+    // ? 4 March, 2021 - found without ii - this is a guess
+    // Do we need/want to blank the top of the block ?
+    // No. one of the Sweden or Finland Overviews has bands which flash on and off with this code. Retire it.
+    for (int ii=0; ii<nCopyStartRow; ii++) {
+        for (int jj=nCopyStartCol; jj<nCopyStopCol; jj++) {
+            pGImage[jj+nPNGwidth*ii] = nVRCNoData; // ? 4 March, 2021 - found without ii - this is a guess
+        } // for jj
+    } // for ii
+#endif
+    
+    for (int ii=nCopyStartRow;
+         ii< nCopyStopRow; // nBottomRow;
+         ii++
+         ) {
+#if 1
+        long long pixelOffset = pGImage-static_cast<GByte*>(pImage);
+        long long nextOffset = pixelOffset - nBlockXSize*nBlockYSize;
+        if (nextOffset+nCopyStopCol >=0) {
+            CPLDebug("Viewranger PNG",
+                     "Shrink_Tile_into_Block: %p pixelOffset %lld nextOffset %lld nCopyStopCol %d nxt+CSCol=%lld>=?0 (row %d<?%d)",
+                     pGImage, pixelOffset,
+                     nextOffset,nCopyStopCol,
+                     nextOffset+nCopyStopCol,
+                     ii, nBottomRow);
+        }
+#endif
+
+#if 0 // Grey-scale
+        for (int jj=nCopyStartCol; jj<nCopyStopCol; jj++) {
+            pGImage[jj] = (pbyPNGbuffer+nPNGwidth*ii)[jj];
+        }
+#else
+        if (nBand==4) {
+            for (int jj=0; jj<nCopyStopCol; jj++) {
+                // pGImage[jj] = 255; // Opposite of nVRCNoData;
+            }
+        } else {
+            int i1=3*nPNGwidth*2*(ii-nCopyStartRow);
+            int i2=i1+3*nPNGwidth;
+            for (int jj=nCopyStartCol, jjj=nBand-1;
+                 jj<nCopyStopCol;
+                 jj++, jjj+=6) {
+                unsigned short temp =
+                    (pbyPNGbuffer+i1)[jjj];
+                    temp += (pbyPNGbuffer+i2)[jjj];
+                    temp += (pbyPNGbuffer+i1)[jjj+3];
+                    temp += (pbyPNGbuffer+i2)[jjj+3];
+
+                    pGImage[jj] = static_cast<GByte>(temp>>2);
+            } // for jj,jjj
+#endif // ! Grey-scale
+        }
+        pGImage += nBlockXSize;
+    } // for ii < nCopyStopRow
+    
+    CPLDebug("Viewranger PNG",
+             "shrunk PNG buffer %p %d x %d into pImage %p %d x %d within %d x %d",
+             pbyPNGbuffer, nPNGwidth, nPNGheight,
+             pImage, nBlockXSize, nBlockYSize, nRasterXSize, nRasterYSize
+             );
+         
+
+    return 0;
+} // VRCRasterBand::Shrink_Tile_into_Block
+
+// #endif // def FRMT_vrc

--- a/gdal/frmts/vrc/VRC.h
+++ b/gdal/frmts/vrc/VRC.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * $Id: VRC.h,v 1.23 2021/06/21 13:03:42 werdna Exp $
+ * $Id: VRC.h,v 1.24 2021/07/08 11:56:03 werdna Exp $
  *
  * Author:  Andrew C Aitchison
  *
@@ -110,28 +110,28 @@ class VRCDataset : public GDALPamDataset
 {
     friend class VRCRasterBand;
     
-    VSILFILE            *fp;
-    GDALColorTable      *poColorTable;
+    VSILFILE            *fp = nullptr;
+    GDALColorTable      *poColorTable = nullptr;
     GByte       abyHeader[0x5a0];
     
-    unsigned int *anColumnIndex;
-    unsigned int *anTileIndex;
-    unsigned int nMagic;
-    double dfPixelMetres;
-    signed int nMapID;
-    signed int nLeft, nRight, nTop, nBottom;
-    signed int nTopSkipPix, nRightSkipPix;
-    unsigned int nScale;
-    unsigned int nMaxOverviewCount;
-    short nCountry;
+    unsigned int *anColumnIndex = nullptr;
+    unsigned int *anTileIndex = nullptr;
+    unsigned int nMagic=0;
+    double dfPixelMetres=0.0;
+    signed int nMapID=-1;
+    signed int nLeft=INT_MAX, nRight=INT_MAX, nTop=INT_MIN, nBottom=INT_MIN;
+    signed int nTopSkipPix=0, nRightSkipPix=0;
+    unsigned int nScale=0;
+    unsigned int nMaxOverviewCount=7;
+    short nCountry=-1;
     OGRSpatialReference* poSRS = nullptr;
 
     std::string sLongTitle;
     std::string sCopyright;
     // std::string sDatum;
 
-    unsigned int tileSizeMax, tileSizeMin;
-    int tileXcount, tileYcount;
+    unsigned int tileSizeMax=0, tileSizeMin=INT_MAX;
+    int tileXcount=0, tileYcount=0;
 
     unsigned int* VRCGetTileIndex( unsigned int nTileIndexStart );
     unsigned int* VRCBuildTileIndex( unsigned int nTileIndexStart );

--- a/gdal/frmts/vrc/VRC.h
+++ b/gdal/frmts/vrc/VRC.h
@@ -1,0 +1,339 @@
+/******************************************************************************
+ * $Id: VRC.h,v 1.23 2021/06/21 13:03:42 werdna Exp $
+ *
+ * Author:  Andrew C Aitchison
+ *
+ ******************************************************************************
+ * Copyright (c) 2019-21, Andrew C Aitchison
+ *****************************************************************************/
+
+#pragma once
+
+#ifndef VRC_H_INCLUDED
+#define VRC_H_INCLUDED
+
+#ifdef FRMT_vrc
+#define FRMT_viewranger
+#endif
+
+#pragma clang diagnostic push
+// #pragma clang diagnostic ignored "-Wformat-pedantic"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wsuggest-destructor-override"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wunused-template"
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#include "gdal_pam.h"
+#pragma clang diagnostic pop
+#include "ogr_spatialref.h"
+//#include "cpl_string.h"
+
+// We have not fully deciphered the data format
+// of VRC files with magic=0x01ce6336.
+// Set *one* of these definitions (to 1)
+// VRC36_PIXEL_IS_PIXEL is to be assumed if none are set.
+// #define VRC36_PIXEL_IS_PIXEL 1
+#define VRC36_PIXEL_IS_TILE 1
+// #define VRC36_PIXEL_IS_FILE 1
+
+#if GDAL_VERSION_NUM < 2010000
+#define GDAL_IDENTIFY_UNKNOWN -1
+#define GDAL_IDENTIFY_FALSE 0
+#define GDAL_IDENTIFY_TRUE 1
+#define CPLsnprintf snprintf
+#else
+// These are defined in gdal/gdal_priv.h
+#endif // GDAL_VERSION_NUM < 2010000
+
+#if 0 // __cplusplus <= 201103L
+#define override
+#define nullptr 0
+#endif
+
+#ifdef CODE_ANALYSIS
+
+// Printing variables with CPLDebug can hide
+// the fact that they are not otherwise used ...
+// ... but this also confuse other checks, such as
+// Found duplicate branches for 'if' and 'else'
+// 
+#define CPLDebug(...)
+
+#endif // CODE_ANALYSIS
+
+
+
+static const unsigned int vrc_magic_metres = 0x002e1f7e; // 0x7e1f2e00; //
+static const unsigned int vrc_magic_thirtysix = 0x01ce6336; // 0x3663ce01; //
+
+// static const unsigned int nVRCNoData = 255;
+// static const unsigned int nVRCNoData = 0xffffffff;
+static const unsigned int nVRCNoData = 0;
+
+class VRCRasterBand;
+
+int VRReadChar(VSILFILE *fp);
+int VRReadInt(VSILFILE *fp);
+void VRC_file_strerror_r(int nFileErr, char *buf, size_t buflen);
+
+enum VRCinterleave {band, pixel};
+
+void dumpPPM(unsigned int width,
+             unsigned int height,
+             unsigned char* const data,
+             unsigned int rowlength,
+             CPLString osBaseLabel,
+             VRCinterleave eInterleave,
+             unsigned int nMaxPPM
+             );
+
+OGRSpatialReference* CRSfromCountry(int nCountry);
+extern const char* CharsetFromCountry(int nCountry);
+
+
+/************************************************************************/
+/* ==================================================================== */
+/*                         VRCDataset                                   */
+/* ==================================================================== */
+/************************************************************************/
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+class VRCDataset : public GDALPamDataset
+{
+    friend class VRCRasterBand;
+    
+    VSILFILE            *fp;
+    GDALColorTable      *poColorTable;
+    GByte       abyHeader[0x5a0];
+    
+    unsigned int *anColumnIndex;
+    unsigned int *anTileIndex;
+    unsigned int nMagic;
+    double dfPixelMetres;
+    signed int nMapID;
+    signed int nLeft, nRight, nTop, nBottom;
+    signed int nTopSkipPix, nRightSkipPix;
+    unsigned int nScale;
+    unsigned int nMaxOverviewCount;
+    short nCountry;
+    OGRSpatialReference* poSRS = nullptr;
+
+    std::string sLongTitle;
+    std::string sCopyright;
+    // std::string sDatum;
+
+    unsigned int tileSizeMax, tileSizeMin;
+    int tileXcount, tileYcount;
+
+    unsigned int* VRCGetTileIndex( unsigned int nTileIndexStart );
+    unsigned int* VRCBuildTileIndex( unsigned int nTileIndexStart );
+
+    VSIStatBufL oStatBufL;
+
+public:
+    VRCDataset();
+    ~VRCDataset() override;
+
+#if 0    
+    virtual CPLErr IBuildOverviews( const char *pszResampling,
+                                    int nOverviewCount, int *panOverviewList,
+                                    int nListBands, int *panBandList,
+                                    GDALProgressFunc pfnProgress,
+                                    void * pProgressData ) override;
+#endif
+
+    static GDALDataset *Open( GDALOpenInfo * );
+    static int Identify( GDALOpenInfo * );
+
+    // Gdal <3 uses proj.4, Gdal>=3 uses proj.6, see eg:
+    // https://trac.osgeo.org/gdal/wiki/rfc73_proj6_wkt2_srsbarn
+    // https://gdal.org/development/rfc/rfc73_proj6_wkt2_srsbarn.html
+#if GDAL_VERSION_MAJOR >= 3
+    const OGRSpatialReference* GetSpatialRef() const override {
+        return poSRS;
+    }
+    // const char *_GetProjectionRef
+#else
+    const char* GetProjectionRef() override {
+        char* pszSRS=nullptr;
+        if(!poSRS) {
+            poSRS = CRSfromCountry(nCountry);
+        }
+        if(poSRS) {
+            poSRS->exportToWkt( &pszSRS );
+            // delete poSRS; ???
+        }
+        CPLDebug("VRC",
+                 "GetProjectionRef() returns %s",
+                 pszSRS);
+        return pszSRS;
+    }
+#endif
+
+#if 1 // GeoLoc
+    CPLErr GetGeoTransform( double * padfTransform ) override;
+#endif
+
+    static char *VRCGetString( VSILFILE *fp, unsigned int byteaddr );
+}; // class VRCDataset
+
+#pragma clang diagnostic pop
+
+
+/************************************************************************/
+/* ==================================================================== */
+/*                            VRCRasterBand                             */
+/* ==================================================================== */
+/************************************************************************/
+
+class VRCRasterBand : public GDALPamRasterBand
+{
+    friend class VRCDataset;
+    
+    // GUIntBig    nRecordSize;
+    
+    GDALColorInterp  eBandInterp;
+    int          nThisOverview;  // -1 for base ?
+    unsigned int nResFactor;
+    int          nOverviewCount;
+    VRCRasterBand**  papoOverviewBands;
+
+    void read_VRC_Tile_ThirtySix( VSILFILE *fp,
+                                int block_xx, int block_yy,
+                                void *pImage);
+    void read_VRC_Tile_Metres( VSILFILE *fp,
+                               int block_xx, int block_yy,
+                               void *pImage);
+    GByte* read_PNG(VSILFILE *fp,
+                    // void *pImage,
+                    unsigned int *pPNGwidth,
+                    unsigned int *pPNGheight,
+                    unsigned int nVRCHeader,
+                    vsi_l_offset nPalette,
+                    unsigned int nVRCDataLen,
+                    // int nPNGXcount,  int nPNGYcount,
+                    int nGDtile_xx, int nGDtile_yy,
+                    unsigned int nVRtile_xx, unsigned int nVRtile_yy
+                    );
+
+    int Copy_Tile_into_Block(
+                           GByte* pbyPNGbuffer,
+                           int nPNGwidth,
+                            int nPNGheight,
+                           int nLeftCol,
+                           int nRightCol,
+                           int nTopRow,
+                           int nBottomRow,
+                           void* pImage
+                           // , int nBlockXSize,
+                           // , int nBlockYSize
+                           );
+
+    int Shrink_Tile_into_Block(
+                           GByte* pbyPNGbuffer,
+                           int nPNGwidth,
+                           int nPNGheight,
+                           int nLeftCol,
+                           int nRightCol,
+                           int nTopRow,
+                           int nBottomRow,
+                           void* pImage
+                           // , int nBlockXSize,
+                           // , int nBlockYSize
+                           );
+
+    int verifySubTileFile(
+                       VSILFILE *fp,
+                       unsigned long start,
+                       unsigned long finish,
+                       int nGDtile_xx,
+                       int nGDtile_yy,
+                       unsigned int nVRtile_xx,
+                       unsigned int nVRtile_yy
+                       );
+    int verifySubTileMem(
+                       GByte abyRawStartData[],
+                       unsigned long start,
+                       unsigned long finish,
+                       int nGDtile_xx,
+                       int nGDtile_yy,
+                       unsigned int nVRtile_xx,
+                       unsigned int nVRtile_yy
+                       );
+
+public:
+
+    VRCRasterBand(VRCDataset *poDSIn,
+                  int nBandIn,
+                  int nThisOverviewIn,
+                  int nOverviewCountIn,
+                  VRCRasterBand**papoOverviewBandsIn);
+
+#if 0
+    VRCRasterBand(VRCDataset *pVRDS,
+                  int nBandIn,
+                  int nThisOverviewIn )
+    {
+         VRCRasterBand( pVRDS, nBandIn, nThisOverviewIn,
+                        6, nullptr);
+    }
+#endif
+    
+    ~VRCRasterBand() override;
+    
+    virtual GDALColorInterp GetColorInterpretation() override;
+    virtual GDALColorTable  *GetColorTable() override;
+
+    // virtual double GetNoDataValue( int *pbSuccess = NULL );
+    virtual double GetNoDataValue( int *) override;
+    // virtual CPLErr SetNoDataValue( double );
+    
+    virtual int GetOverviewCount() override;
+    virtual GDALRasterBand *GetOverview(int) override;
+#if 0
+    void EstablishOverviews();
+    virtual CPLErr CleanOverviews();
+
+    virtual CPLErr BuildOverviews( const char *pszResampling,
+                                   int nReqOverviews, int *panOverviewList,
+                                   GDALProgressFunc pfnProgress,
+                                   void *pProgressData ) override;
+#endif
+    virtual CPLErr IReadBlock( int, int, void * ) override;
+
+#if GDAL_VERSION_NUM >= 2020000
+    virtual int IGetDataCoverageStatus( int nXOff, int nYOff,
+                                        int nXSize, int nYSize,
+                                        int nMaskFlagStop,
+                                        double* pdfDataPct) override;
+#endif
+}; // class VRCRasterBand 
+
+extern void
+dumpTileHeaderData(
+                   VSILFILE *fp,
+                   unsigned int nTileIndex,
+                   unsigned int nOverviewCount,
+                   unsigned int anTileOverviewIndex[],
+                   const int tile_xx, const int tile_yy );
+
+extern short VRGetShort( void* base, int byteOffset );
+extern signed int VRGetInt( void* base, unsigned int byteOffset );
+extern unsigned int VRGetUInt( void* base, unsigned int byteOffset );
+
+extern int VRReadChar(VSILFILE *fp);
+extern int VRReadShort(VSILFILE *fp);
+extern int VRReadInt(VSILFILE *fp);
+extern int VRReadInt(VSILFILE *fp, unsigned int byteOffset );
+extern unsigned int VRReadUInt(VSILFILE *fp);
+extern unsigned int VRReadUInt(VSILFILE *fp, unsigned int byteOffset );
+
+#endif // ndef VRC_H_INCLUDED

--- a/gdal/frmts/vrc/VRCthirtysix.cpp
+++ b/gdal/frmts/vrc/VRCthirtysix.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * $Id: VRCthirtysix.cpp,v 1.19 2021/06/20 08:58:41 werdna Exp werdna $
+ * $Id: VRCthirtysix.cpp,v 1.20 2021/06/26 20:37:41 werdna Exp $
  *
  * Author:  Andrew C Aitchison
  *

--- a/gdal/frmts/vrc/VRCthirtysix.cpp
+++ b/gdal/frmts/vrc/VRCthirtysix.cpp
@@ -1,0 +1,797 @@
+/******************************************************************************
+ * $Id: VRCthirtysix.cpp,v 1.19 2021/06/20 08:58:41 werdna Exp werdna $
+ *
+ * Author:  Andrew C Aitchison
+ *
+ ******************************************************************************
+ * Copyright (c) 2019, Andrew C Aitchison
+ *****************************************************************************/
+
+// #ifdef FRMT_vrc
+
+#include "VRC.h"
+
+#ifdef CODE_ANALYSIS
+
+// Printing variables with CPLDebug can hide
+// the fact that they are not otherwise used ...
+#define CPLDebug(...)
+
+#endif // CODE_ANALYSIS
+
+// Like strncmp but null bytes don't terminate.
+// Used in verifySubTileMem()
+static
+size_t bytesmatch(const unsigned char*data, const unsigned char*pattern, size_t nLen)
+{
+    size_t count=0;
+    for (  ; count<nLen && data[count]==pattern[count]; count++) {
+    }
+    return count;
+}
+
+
+void VRCRasterBand::read_VRC_Tile_ThirtySix( VSILFILE *fp,
+                                int block_xx, int block_yy,
+                                void *pImage)
+{
+    auto *poGDS = dynamic_cast<VRCDataset *>(poDS);
+    if (block_xx < 0 || block_xx >= nRasterXSize ) {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "read_VRC_Tile_ThirtySix invalid row %d", block_xx );
+        return ;
+    }
+    if (block_yy < 0 || block_yy >= nRasterYSize ) {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "read_VRC_Tile_ThirtySix invalid column %d", block_yy );
+        return ;
+    }
+    if (pImage == nullptr ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VRC_Tile_ThirtySix passed no image" );
+        return ;
+    }
+    if (poGDS->nMagic != vrc_magic_thirtysix) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VRC_Tile_ThirtySix called with wrong magic number x%08x",
+                  poGDS->nMagic );
+        return ;
+    }
+        
+    CPLDebug("Viewranger", "read_VRC_Tile_ThirtySix(%p, %d, %d, %p)",
+             static_cast<void*>(fp), block_xx, block_yy, pImage
+             );
+
+#if defined VRC36_PIXEL_IS_FILE
+    // dummy pixel until we can read the real data
+    if (block_xx != 0 || block_yy != 0 ) {
+        CPLDebug("Viewranger",
+                 "vrc36_pixel_is_file only supports one tile: %d %d requested",
+                 block_xx, block_yy);
+    }
+    // static_cast<char*>(pImage)[0] = 1;
+    // GDT_UInt32
+    static_cast<GUInt32*>(pImage)[0] = 0xffbb7744;
+    (void)fp; // We don't actually use the image data for VRC36_PIXEL_IS_FILE
+#else
+
+    int tilenum = poGDS->tileXcount * block_yy + block_xx;
+#if defined VRC36_PIXEL_IS_TILE
+    if (block_xx != 0 || block_yy != 0 ) {
+        CPLDebug("Viewranger",
+                 "vrc36_pixel_is_tile only supports one tile: %d %d requested",
+                 block_xx, block_yy);
+    }
+    // The image is a single tile with one pixel for each VRC tile.
+    // Since the tiles are divided into subtiles,
+    // this is not particularly informative
+    // - one pixel per subtile would be better.
+    CPLDebug("Viewranger", "\traster %d x %d tilenum %d",
+             poGDS->nRasterXSize, poGDS->nRasterYSize, tilenum );
+    if (poGDS->nRasterXSize<=0 || poGDS->nRasterYSize<=0) {
+        // No data to examine
+        return;
+    }
+    auto nXsize = static_cast<unsigned int>(poGDS->nRasterXSize);
+    auto nYsize = static_cast<unsigned int>(poGDS->nRasterYSize);
+    // GDT_UInt32 ((char *) pImage)[0] = 1;
+    // ((GUInt32 *) pImage)[tilenum] = 0xffbb7744; // temporary
+
+    for (unsigned int i=0; i<nXsize * nYsize; i++) {
+        // ((GUInt32 *) pImage)[i] = poGDS->anTileIndex[i];
+
+        unsigned long nStart = poGDS->anTileIndex[i];
+        unsigned long nFinish= poGDS->anTileIndex[i+1];
+        long long nFileSize = poGDS->oStatBufL.st_size;
+        CPLString osBaseLabel
+            = CPLString().Printf("/tmp/werdna/vrc2tif/%s.%03d.%03d.%08lu.%02u",
+                                 // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                                 poGDS->sLongTitle.c_str(),
+                                 i / nYsize, i % nYsize , nStart, // nGDtile_xx, nGDtile_yy, // nVRtile_xx, nVRtile_yy,
+                                 nBand);
+
+        if (/* 0<=nStart && */ nStart<=nFinish
+            && static_cast<long long>(nFinish) <= nFileSize) {
+            int nVerifyResult=
+                verifySubTileFile(fp,
+                                  nStart, nFinish,
+                                  block_xx, block_yy,
+                                  //static_cast<unsigned int>
+                                  (i / nYsize),
+                                  //static_cast<unsigned int>
+                                  (i % nYsize)
+                                  );
+            if (nVerifyResult<0) {
+                static_cast<GUInt32*>(pImage)[tilenum] = nVRCNoData;
+            } else {
+                static_cast<GUInt32*>(pImage)[tilenum] = static_cast<GUInt32>(nVerifyResult);
+                if (0 == (0x0100 & static_cast<GUInt32>(nVerifyResult))) {
+                    CPLDebug("Viewranger",
+                             "raw data for tile %u, %u did not verify\n",
+                             i / nYsize, i % nYsize);
+                }
+            }
+        } else {
+            CPLDebug("Viewranger",
+                     "skipping %s: expected 0 <= x%lx <= x%lx <= x%llx filesize",
+                     osBaseLabel.c_str(),
+                     nStart, nFinish, nFileSize
+                     );
+            static_cast<GUInt32*>(pImage)[i] = nVRCNoData;
+        } // end range check 
+    } // for  i<nXsize * nYsize
+    
+    // CPLDebug("Viewranger", "vrc36_pixel_is_tile set %d pixels", p);
+#else
+    // VRC36_PIXEL_IS_PIXEL
+    // this will be the default
+    CPLDebug("Viewranger", "vrc36_pixel_is_pixel only partially implemented");
+    unsigned int nTileIndex = poGDS->anTileIndex[tilenum];
+    // CPLDebug("Viewranger", "vrcmetres_pixel_is_pixel");
+    CPLDebug("Viewranger", "\tblock %d x %d, (%d, %d) tilenum %d tileIndex x%08x",
+             nBlockXSize,
+             nBlockYSize,
+             block_xx, block_yy,
+             tilenum,
+             nTileIndex
+             );
+
+    if (nTileIndex==0) {
+        // No data for this tile
+        CPLDebug("Viewranger",
+                 "read_VRC_Tile_ThirtySix(.. %d %d ..) null tile",
+                 block_xx, block_yy );
+
+        if (eDataType==GDT_Byte) {
+            for (int j=0; j < nBlockYSize ; j++) {
+                int pixelnum = j * nBlockXSize;
+                for (int i=0; i < nBlockXSize ; i++) {
+                    static_cast<GUInt32*>(pImage)[pixelnum++] = nVRCNoData;
+                }
+            }
+        } else {
+            CPLError( CE_Failure, CPLE_AppDefined,
+                      "read_VRC_Tile_ThirtySix eDataType %d unexpected for null tile",
+                      eDataType);
+        }
+        return;
+    }  // nTileIndex==0 No data for this tile
+
+    if ( VSIFSeekL( fp, nTileIndex, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to tile header x%08x", nTileIndex );
+        return;
+    }
+
+    if (poGDS->nMapID != 8) {
+        nOverviewCount = VRReadInt(fp);
+        if (nOverviewCount != 7) {
+            CPLDebug("Viewranger OVRV", "read_VRC_Tile_Metres: nOverviewCount is %d - expected seven - MapID %d",
+                nOverviewCount,
+                poGDS->nMapID
+            );
+            return;
+        }
+
+        unsigned int anTileOverviewIndex[7]={};
+        for (int ii=0; ii<nOverviewCount; ii++) {
+            anTileOverviewIndex[ii] = VRReadUInt(fp);
+        }
+        CPLDebug("Viewranger OVRV",
+                 "x%08x:  x%08x x%08x x%08x x%08x  x%08x x%08x x%08x x%08x",
+                 nTileIndex, nOverviewCount,
+                 anTileOverviewIndex[0],  anTileOverviewIndex[1],
+                 anTileOverviewIndex[2],  anTileOverviewIndex[3],
+                 anTileOverviewIndex[4],  anTileOverviewIndex[5],
+                 anTileOverviewIndex[6]
+                 );
+
+        // VRC counts main image plus 6 overviews.
+        // GDAL just counts the 6 overview images.
+        // anTileOverviewIndex[0] points to the full image
+        // ..[1-6] are the overviews:
+        nOverviewCount--; // equals 6
+
+        // If the smallest overviews do not exist, ignore them.
+        // This saves this driver generating them from larger overviews,
+        // they may need to be generated elsewhere ...
+        while (nOverviewCount>0 && 0==anTileOverviewIndex[nOverviewCount]) {
+            nOverviewCount--;
+        }
+        if (nOverviewCount<6) {
+            CPLDebug("Viewranger OVRV",
+                     "Overviews %d-6 not available",
+                     1+nOverviewCount);
+        }
+
+        if (nOverviewCount<1 || anTileOverviewIndex[0] == 0) {
+            CPLDebug("Viewranger",
+                     "VRCRasterBand::read_VRC_Tile_Metres(.. %d %d ..) empty tile",
+                     block_xx, block_yy );
+            return; 
+        }
+    
+        // This is just for the developer's understanding.
+        if (0x20 + nTileIndex == anTileOverviewIndex[1]) {
+            CPLDebug("Viewranger",
+                     "anTileOverviewIndex[1] %d x%08x - 0x20 = %d x%08x as expected",
+                     anTileOverviewIndex[1], anTileOverviewIndex[1],
+                     nTileIndex, nTileIndex);
+        } else {
+            CPLDebug("Viewranger",
+                     "anTileOverviewIndex[1] %d x%08x - anTileOverviewIndex[0] %d x%08x = %d x%08x - expected 0x20",
+                     anTileOverviewIndex[1], anTileOverviewIndex[1],  
+                     nTileIndex,           nTileIndex,
+                     anTileOverviewIndex[1] - nTileIndex,
+                     anTileOverviewIndex[1] - nTileIndex);
+        }
+
+        dumpTileHeaderData(fp, nTileIndex,
+                           1+static_cast<unsigned int>(nOverviewCount),
+                           anTileOverviewIndex,
+                           block_xx, block_yy );
+
+        if (nThisOverview < -1 || nThisOverview >= nOverviewCount) {
+            CPLDebug("Viewranger",
+                     "read_VRC_Tile_ThirtySix: overview %d=x%08x not in range [-1, %d]",
+                     nThisOverview, nThisOverview, nOverviewCount);
+            return;
+        }
+
+        if (anTileOverviewIndex[nThisOverview+1] >= poGDS->oStatBufL.st_size) {
+            CPLDebug("Viewranger",
+                     "\toverview level %d data beyond end of file at x%08x",
+                     nThisOverview, anTileOverviewIndex[nThisOverview+1] );
+            return ;
+        }
+        CPLDebug("Viewranger",
+                 "\toverview level %d data at x%08x",
+                 nThisOverview, anTileOverviewIndex[nThisOverview+1] );
+    
+        bool bTileShrink = (anTileOverviewIndex[nThisOverview+1]==0);
+        // int nShrinkFactor=1;
+        if (bTileShrink == false) {
+            // nShrinkFactor = 1;
+            if ( VSIFSeekL( fp, anTileOverviewIndex[nThisOverview+1], SEEK_SET ) ) {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "cannot seek to overview level %d data at x%08x",
+                          nThisOverview, anTileOverviewIndex[nThisOverview+1] );
+                return;
+            }
+
+            unsigned int nTileMax = poGDS->tileSizeMax;
+            unsigned int nTileMin = poGDS->tileSizeMin;
+            if (nTileMax==0) {
+                CPLError( CE_Failure, CPLE_NotSupported,
+                          "tileSizeMax is zero and invalid"
+                          );
+                return;
+            }
+            if (nTileMin==0) {
+                poGDS->tileSizeMin=nTileMax;
+                CPLDebug("Viewranger",
+                         "nTileMin is zero. Using nTileMax %d",
+                         nTileMax
+                         );
+            } else {
+                int bits = 63 - __builtin_clzll
+                    (static_cast<unsigned long long>(nTileMax/nTileMin) );
+                if (nTileMax == nTileMin << bits) {
+                    CPLDebug("Viewranger",
+                             "%d / %d == %f == 2^%d",
+                             nTileMax, nTileMin,
+                             1.0*nTileMax/nTileMin, bits);
+                } else {
+                    CPLDebug("Viewranger",
+                             "%d / %d == %f != 2^%d",
+                             nTileMax, nTileMin,
+                             1.0*nTileMax/nTileMin, bits);
+                }
+            }
+        } else { // if(bTileShrink == false)
+            // If data for this block is not available, we need to rescale another overview
+            // perhaps with GDALRegenerateOverviews from gcore/overview.cpp
+            
+            CPLDebug("Viewranger",
+                     "Band %d block %d,%d empty at overview %d\n",
+                     nBand, block_xx, block_yy, nThisOverview
+                     );
+            GDALRasterBandH hOvrBandSrc =
+                reinterpret_cast<GDALRasterBandH>(GetOverview( nThisOverview+1 ));
+            GDALRasterBandH ahOvrBandTgts[1];
+            ahOvrBandTgts[0] = reinterpret_cast<GDALRasterBandH>(GetOverview( nThisOverview+2 ));
+            if (hOvrBandSrc==nullptr || ahOvrBandTgts[0]==nullptr) {
+                CPLDebug("Viewranger",
+                         "SrcBand %p, TargetBand %p\n",
+                         hOvrBandSrc, ahOvrBandTgts[0]
+                         );
+                return;
+            }
+            CPLErr regErr =
+                GDALRegenerateOverviews
+                (hOvrBandSrc,
+                 1,             // nOverviewCount,
+                 &ahOvrBandTgts[0],   // GDALRasterBandH
+                 "AVERAGE",     // const char * pszResampling,
+                 nullptr,       // GDALProgressFunc
+                 nullptr        // void * pProgressData 
+                 );
+            if (regErr!=CE_None) {
+                CPLDebug("Viewranger",
+                         "Band %d block %d,%d downsampling for overview %d failed: %d\n",
+                         nBand, block_xx, block_yy, nThisOverview, regErr
+                         );
+            } else {
+                CPLDebug("Viewranger",
+                         "Band %d block %d,%d downsampling for overview %d succeeded\n",
+                         nBand, block_xx, block_yy, nThisOverview
+                         );
+            }
+            return;
+        } // end else clause of if(bTileShrink == false) 
+    } // nMapID != 8
+
+    // We have reached the start of the tile
+    // ... but it is split into subtiles (of a format yet to be determined)
+    int nRawXcount = VRReadInt(fp);
+    int nRawYcount = VRReadInt(fp);
+    int nRawXsize  = VRReadInt(fp);
+    int nRawYsize  = VRReadInt(fp);
+
+    if (nRawXcount <=0) {
+        CPLDebug("Viewranger",
+                 "nRawXcount %d zero or negative in tilenum %d",
+                 nRawXcount, tilenum );
+        return;
+    }
+    if (nRawYcount <=0) {
+        CPLDebug("Viewranger",
+                 "nRawYcount %d zero or negative in tilenum %d",
+                 nRawYcount, tilenum );
+        return;
+    }
+    if (nRawXsize <=0) {
+        CPLDebug("Viewranger",
+                 "nRawXsize %d zero or negative in tilenum %d",
+                 nRawXsize, tilenum );
+        return;
+    }
+    if (nRawYsize <=0) {
+        CPLDebug("Viewranger",
+                 "nRawYsize %d zero or negative in tilenum %d",
+                 nRawYsize, tilenum );
+        return;
+    }
+
+    if ( nRawXcount > nBlockXSize
+         || nRawXsize > nBlockXSize
+         || nRawXcount * nRawXsize > nBlockXSize
+         ) {
+        CPLDebug("Viewranger",
+                 "nRawXcount %d x nRawXsize %d too big > nBlockXSize %d\tx%08x x x%08x > x%08x",
+                 nRawXcount, nRawXsize, nBlockXSize,
+                 nRawXcount, nRawXsize, nBlockXSize );
+        // return;
+    }
+    if ( nRawYcount > nBlockYSize
+         || nRawYsize > nBlockYSize
+         || nRawYcount * nRawYsize > nBlockYSize
+         ) {
+        CPLDebug("Viewranger",
+                 "nRawYcount %d x nRawYsize %d too big > nBlockYSize %d\tx%08x x x%08x > x%08x",
+                 nRawYcount, nRawYsize, nBlockYSize,
+                 nRawYcount, nRawYsize, nBlockYSize );
+        // return;
+    }
+
+    CPLDebug("Viewranger",
+             "nRawXcount %d nRawYcount %d nRawXsize %d nRawYsize %d",
+             nRawXcount, nRawYcount, nRawXsize, nRawYsize);
+
+    // Allow for under-height tiles
+    {
+        int nSkipTopRows = nBlockYSize - nRawYcount * nRawYsize;
+        if (nSkipTopRows > 0) {
+            CPLDebug("Viewranger",
+                     "underheight tile nRawYcount %d x nRawYsize %d < blocksize %d",
+                     nRawYcount, nRawYsize, nBlockYSize );
+            //   This is a short (underheight) tile.
+            // GDAL expects these at the top of the bottom tile,
+            // but VRC puts these at the bottom of the top tile.
+            //   We need to add a blank strip at the top of the
+            // tile to compensate.
+
+            for (int nPix=0; nPix<nSkipTopRows*nBlockXSize; nPix++) {
+                static_cast<char*>(pImage)[nPix] = nVRCNoData;
+            }
+        } else if (nSkipTopRows != 0) {
+            // This should not happen
+            CPLDebug("Viewranger",
+                     "OVERheight tile nRawYcount %d x nRawYsize %d > blocksize %d)",
+                     nRawYcount, nRawYsize, nBlockYSize );
+        }
+    }  // Finished allowing for under-height tiles
+
+    CPLDebug("Viewranger",
+             "nRawXcount %d nRawYcount %d nRawXsize %d nRawYsize %d",
+             nRawXcount, nRawYcount, nRawXsize, nRawYsize);
+
+    // Read in this tile's index to ?raw? sub-tiles.
+    std::vector<unsigned int> anSubTileIndex;
+    anSubTileIndex.reserve(static_cast<size_t>(nRawXcount*nRawYcount +1));
+    for (size_t loop=0;
+         loop <= static_cast<size_t>(nRawXcount*nRawYcount);
+         loop++) {
+        anSubTileIndex[loop] = VRReadUInt(fp);
+        if (anSubTileIndex[loop] >= poGDS->oStatBufL.st_size)
+            {
+                CPLDebug("Viewranger",
+                         "Band %d block [%d,%d] raw image %zd at x%x is beyond EOF - is file truncated ?",
+                         nBand, block_xx, block_yy, loop, anSubTileIndex[loop] );
+                anSubTileIndex[loop] = 0;
+            }
+    }
+    
+
+    for (int loopX=0; loopX < nRawXcount; loopX++) {
+        for (int loopY=0; loopY < nRawYcount; loopY++) {
+            auto loop = static_cast<size_t>
+                (nRawYcount-1-loopY + loopX*nRawYcount);
+
+            //((GUInt32 *) pImage)[i] = poGDS->anSubTileIndex[loop];
+
+            unsigned long nStart = anSubTileIndex[loop];
+            unsigned long nFinish= anSubTileIndex[loop+1];
+            unsigned long nFileSize = static_cast<unsigned int>
+                (poGDS->oStatBufL.st_size);
+            CPLString osBaseLabel
+                = CPLString().Printf("/tmp/werdna/vrc2tif/%s.%03d.%03d.%08lu.%02u",
+                                     // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                                     poGDS->sLongTitle.c_str(),
+                                     loopX, loopX, nStart,
+                                     nBand);
+
+            if (/* 0<=nStart && */ nStart<=nFinish && nFinish <= nFileSize) {
+                size_t nRawSubtileSize = static_cast<size_t>
+                    (nRawXsize*nRawYsize);
+                if (nRawSubtileSize>nFinish-nStart) {
+                    nRawSubtileSize = nFinish-nStart;
+                }
+                GByte *abySubTileData = static_cast<GByte *>(VSIMalloc(nRawSubtileSize));
+
+                int seekres = VSIFSeekL( fp, nStart, SEEK_SET );
+                if ( seekres ) {
+                    CPLError( CE_Failure, CPLE_AppDefined,
+                              "cannot seek to x%lx", nStart);
+                    return;
+                }
+                size_t bytesread = VSIFReadL(abySubTileData, sizeof(GByte), nRawSubtileSize, fp);
+                if (bytesread < nRawSubtileSize) {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "problem reading bytes [x%lx, x%lx)\n",
+                             nStart,nFinish);
+                    return;  
+                }
+            
+                int nVerifyResult=verifySubTileMem(abySubTileData,
+                                                   nStart, nFinish,
+                                                   block_xx, block_yy,
+                                                   loopX, loopY
+                                                   );
+                if (0==(nVerifyResult & ~0xff)) {
+                    CPLDebug("Viewranger",
+                             "raw data at x%08lx for tile (%d,%d) sub tile (%d,%d) did not verify\n",
+                             nStart, block_xx, block_yy, loopX, loopY);
+                }
+                if ( VSIFSeekL( fp, nStart, SEEK_SET ) ) {
+                    CPLError( CE_Failure, CPLE_AppDefined,
+                              "cannot seek to start of tile (%d,%d) sub tile (%d,%d)",
+                              block_xx, block_yy, loopX, loopY);
+                    return;
+                }
+
+#if 0
+                {
+                    unsigned int nf0count=0;
+                    unsigned int n47count=0;
+                    for (unsigned int i=0; i < nRawSubtileSize ; i++) {
+                        if (abySubTileData[i] == 0xf0) {
+                            nf0count++;
+                        }
+                        if (abySubTileData[i] == 0x47) {
+                            nf0count++;
+                        }
+                    }
+                    CPLDebug("Viewranger",
+                             "tile (%d,%d) sub tile (%d,%d) contains 0xf0 %d times",
+                             block_xx, block_yy, loopX, loopY, nf0count);
+                    CPLDebug("Viewranger",
+                             "tile (%d,%d) sub tile (%d,%d) contains 0x47 %d times",
+                             block_xx, block_yy, loopX, loopY, n47count);
+                }
+#endif
+
+                // Allow for under-height tiles
+                int nSkipTopRows = nBlockYSize - nRawYcount * nRawYsize;
+                if (nSkipTopRows > 0) {
+                    CPLDebug("Viewranger",
+                             "underheight tile nRawYcount %d x nRawYsize %d < blocksize %d)",
+                             nRawYcount, nRawYsize, nBlockYSize );
+                    //   This is a short (underheight) tile.
+                    // GDAL expects these at the top of the bottom tile,
+                    // but VRC puts these at the bottom of the top tile.
+                    //   We need to add a blank strip at the top of the
+                    // tile to compensate.
+                    
+                    for (int nPix=0; nPix<nSkipTopRows*nBlockXSize; nPix++) {
+                        // This probably blanks all the subtiles in the top row,
+                        // not just subtile loopX
+                        (static_cast<char*>(pImage))[nPix] = nVRCNoData;
+                    }
+                } else if (nSkipTopRows != 0) {
+                    // This should not happen
+                    CPLDebug("Viewranger",
+                             "OVERheight tile nRawYcount %d x nRawYsize %d > blocksize %d)",
+                             nRawYcount, nRawYsize, nBlockYSize );
+                    nSkipTopRows = 0;
+                }
+                
+                // Write the raw data into the subtile of the image,
+                // padding with the result of verifySubTileMem/File.
+                unsigned int nCount= static_cast<unsigned int>(nStart);
+                for (int j=0; j < nRawYsize ; j++) {
+                    int pixelnum = (j+loopY*nRawYsize+nSkipTopRows) * nBlockXSize
+                        + loopX*nRawXsize;
+                    for (int i=0; i < nRawXsize ; i++) {
+                        if (pixelnum >= nBlockXSize*nBlockYSize) {
+                            CPLDebug("Viewranger",
+                                     "pixelnum %d > %x x %d - tile(%x,%d) loop(%x,%d) i=%d j=%d nCount=%d\n",
+                                     pixelnum, nBlockXSize, nBlockYSize,
+                                     block_xx, block_yy, loopX, loopY,
+                                     i, j, nCount);
+                            break;
+                        }
+                        if (nCount<nFinish) {
+                            static_cast<GByte*>(pImage)[pixelnum] =
+                                static_cast<GByte>(VRReadChar(fp));
+                        } else {
+                            static_cast<GByte*>(pImage)[pixelnum] =
+                                static_cast<GByte>(nVerifyResult);
+                            // static_cast<GByte*>(pImage)[pixelnum] =nf0count;
+                        }
+                        nCount++;
+                        pixelnum++;
+                    }
+                }
+                if(abySubTileData) {
+                    VSIFree(abySubTileData);
+                }            
+            } else {
+                CPLDebug("Viewranger",
+                         "skipping %s: expected 0 <= x%lx <= x%lx <= x%lx filesize",
+                         osBaseLabel.c_str(),
+                         nStart, nFinish, nFileSize
+                         );
+            } // end range check 
+        } // for loopY
+    } // for loopX
+#endif
+#endif
+
+    if (getenv("VRC_DUMP_TILE") && 1==nBand) {
+        long nDumpCount = strtol(getenv("VRC_DUMP_TILE"),nullptr,10);
+        // Dump first band of VRC tile as a (monochrome) .pgm.
+        // The bands are currently all the same.
+        CPLString osBaseLabel
+            = CPLString().Printf("/tmp/werdna/vrc2tif/%s.%03d.%03d.%02u",
+                                 // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                                 poGDS->sLongTitle.c_str(),
+                                 block_xx, block_yy,
+                                 nBand);
+        
+        dumpPPM(
+                static_cast<unsigned int>(nBlockXSize),
+                static_cast<unsigned int>(nBlockYSize),
+                static_cast<unsigned char*>(pImage),
+                static_cast<unsigned int>(nBlockXSize),
+                osBaseLabel,
+                band,
+                static_cast<unsigned int>(nDumpCount)
+                );
+    }
+
+} // VRCRasterBand::read_VRC_Tile_ThirtySix
+
+
+int VRCRasterBand::verifySubTileFile(
+        VSILFILE *fp,
+        unsigned long start,
+        unsigned long finish,
+        int nGDtile_xx,
+        int nGDtile_yy,
+        unsigned int nVRtile_xx,
+        unsigned int nVRtile_yy
+)
+{
+    CPLString osBaseLabel;
+    osBaseLabel.Printf("/tmp/werdna/vrc2tif/%s.%03d.%03d.%03d.%03d.%08lu.%02u",
+                       // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                       static_cast<VRCDataset *>(poDS)->sLongTitle.c_str(),
+                       nGDtile_xx, nGDtile_yy,
+                       nVRtile_xx, nVRtile_yy,
+                       start, nBand);
+
+    if (start>finish) {
+        CPLDebug("Viewranger", "Backwards sub-tile: %lu>%lu bytes at %s",
+                 start, finish, osBaseLabel.c_str());
+        return -1;
+    }
+
+    int seekres = VSIFSeekL( fp, start, SEEK_SET );
+    if ( seekres ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to x%lx", start);
+        return -1;
+    }
+
+    auto nLen = static_cast<unsigned int>(finish-start);
+    std::vector<GByte> abyRawSubtileData;
+    abyRawSubtileData.reserve(nLen);
+    size_t bytesread = VSIFReadL(abyRawSubtileData.data(), sizeof(GByte), nLen, fp);
+    if (bytesread < nLen) {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "problem reading bytes [x%lx, x%lx)\n",
+                 start,finish);
+        return -1;  
+    }
+
+    return verifySubTileMem(abyRawSubtileData.data(),
+                          start, finish,
+                          nGDtile_xx, nGDtile_yy,
+                          nVRtile_xx, nVRtile_yy );
+} // VRCRasterBand::verifySubTileFile()
+
+int VRCRasterBand::verifySubTileMem(
+        GByte abyRawStartData[],
+        unsigned long start,
+        unsigned long finish,
+        int nGDtile_xx,
+        int nGDtile_yy,
+        unsigned int nVRtile_xx,
+        unsigned int nVRtile_yy
+)
+{
+    CPLString osBaseLabel;
+    osBaseLabel.Printf("/tmp/werdna/vrc2tif/%s.%03d.%03d.%03d.%03d.%08lu.%02u",
+                       // CPLGetBasename(poOpenInfo->pszFilename) doesn't quite work
+                       static_cast<VRCDataset *>(poDS)->sLongTitle.c_str(),
+                       nGDtile_xx, nGDtile_yy,
+                       nVRtile_xx, nVRtile_yy,
+                       start, nBand);
+
+    const unsigned char kacExpectedValues[144] = 
+        {
+         0x00, 0xbe, 0xe9, 0x42,        0x77, 0x64, 0x30, 0x21,
+         0x3d, 0x5c, 0x2e, 0x34,        0x77, 0x46, 0x5a, 0x59,
+         0x79, 0x24, 0x4b, 0x4b,        0x4e, 0x51, 0x38, 0x48,
+         0x3d, 0x6d, 0x3c, 0x31,        0x36, 0x55, 0x27, 0x20,
+                     
+         0x66, 0x54, 0x47, 0x47,        0x69, 0x37, 0x5b, 0x55,
+         0x5e, 0x5c, 0x17, 0x5d,        0x2e, 0x7f, 0x15, 0x39,
+         0x2e, 0x4c, 0x0b, 0x1c,        0x51, 0x63, 0x79, 0x78,
+         0x57, 0x09, 0x64, 0x5a,        0x5b, 0x6c, 0x02, 0x6f,
+                     
+         0x1c, 0x54, 0x13, 0x0d,        0x11, 0x72, 0xd4, 0xeb,
+         0x71, 0x03, 0x5e, 0x58,        0x79, 0x24, 0x47,
+         // Some USA sub-tiles only match up to here.
+                                                          0x4b,
+         // 80=x50 bytes
+         0x4e, 0x52, 0x38, 0x48,        0x27, 0x4c, 0x2c, 0x33,
+         0x22,
+         // These 20 bytes ...
+               0x72, 0x03, 0x18,        0x59, 0x68, 0x77, 0x77,
+         0x56, 0x0b, 0x65, 0x6b,        0x6c, 0x69, 0x1a, 0x6a,
+         0x1c, 0x4c, 0x1e, 0x0d,        0x10,
+         // .. repeat ...
+               0x72, 0x03, 0x18,        0x59, 0x68, 0x77, 0x77,
+         0x56, 0x0b, 0x65, 0x6b,        0x6c, 0x69, 0x1a, 0x6a,
+         0x1c, 0x4c, 0x1e, 0x0d,        0x10,
+         // ... and 10 bytes again
+               0x72, 0x03, 0x18,        0x59, 0x68, 0x77, 0x77,
+         0x56, 0x0b, 0x65,
+         //
+                           0xbc,        0x84, 0x41, 0x23, 0x4a
+        };
+#if 0
+    const unsigned char kacExpectedValues2[73] =
+        { /*                                           */ 0x4B,
+         0x4E, 0x52, 0x38, 0x48,        0x27, 0x4C, 0x2C, 0x33,
+         0x22, 0x72, 0x59, 0x68,        0x77, 0x77, 0x56, 0x65,
+         0x6B, 0x6C, 0x69,
+        };
+#endif
+
+    if (start>finish) {
+        CPLDebug("Viewranger", "Backwards sub-tile: %lu>%lu bytes at %s",
+                 start, finish, osBaseLabel.c_str());
+        return -1;
+    }
+
+    auto nLen = static_cast<unsigned int>(finish-start);
+    unsigned int nHeadLen = 144;
+    if (nLen < nHeadLen) {
+        CPLDebug("Viewranger", "Short sub-tile: %u<144 bytes at x%lx %s",
+                 nLen, start, osBaseLabel.c_str());       
+        if (nLen>0) {
+            nHeadLen = nLen;
+        } else {
+            nHeadLen=0;
+        }
+    }
+
+    if (abyRawStartData==nullptr) {
+        CPLDebug("Viewranger", "SubTile %s [%lu>%lu) has null ptr",
+                 osBaseLabel.c_str(), start, finish
+                 );
+        return -1;
+    }
+
+    size_t nBytesMatched=bytesmatch(abyRawStartData, kacExpectedValues, nHeadLen);
+    if (nBytesMatched==144) {
+        CPLDebug("Viewranger", "Found all of expected 144-byte header at x%lx %s",
+                 start, osBaseLabel.c_str());
+    } else {
+        CPLDebug("Viewranger", "Found %lu bytes of expected 144-byte header at x%lx %s",
+                 nBytesMatched, start, osBaseLabel.c_str());
+    }
+    for (size_t i=nBytesMatched; i<nHeadLen; i++) {
+        CPLDebug("Viewranger", "then [%lu] = x%02x",
+                 i, static_cast<unsigned char>(abyRawStartData[i]));
+    }
+
+#if 0
+    {
+        // Script to write a "plain" portable graymap ...
+        CPLDebug("Viewranger",
+                 "echo \"P2 1 1 65535\n%lu\" > \"%s.pgm\"",
+                 nBytesMatched, osBaseLabel.c_str() );
+        // ... and a script to write the matching world map:
+        // These values are a work in progress
+        // and are not yet expected to be correct.
+        double dx = static_cast<VRCDataset *>(poDS)->nLeft
+            + nBlockXSize*nGDtile_xx + nVRtile_xx;
+        double dy = static_cast<VRCDataset *>(poDS)->nBottom
+            - nBlockYSize*nGDtile_yy + nVRtile_yy;
+        CPLDebug("Viewranger",
+                 "echo \"%g\n%g\n%g\n%g\n%g\n%g\n\" > \"%s.wld\"",
+                 1.0*static_cast<VRCDataset *>(poDS)->tileXcount, 0.0,
+                 0.0, -1.0*static_cast<VRCDataset *>(poDS)->tileYcount,
+                 dx, dy,
+                 osBaseLabel.c_str() );
+    }
+#endif
+
+    return 0x0100 | static_cast<int>(nBytesMatched);
+} // VRCRasterBand::verifySubTileMem()
+
+// #endif // def FRMT_vrc

--- a/gdal/frmts/vrc/VRCutils.cpp
+++ b/gdal/frmts/vrc/VRCutils.cpp
@@ -1,0 +1,223 @@
+/*
+ */
+
+// #ifdef FRMT_vrc
+
+#include "VRC.h"
+
+extern short VRGetShort( void* base, int byteOffset )
+{
+    unsigned char * buf = static_cast<unsigned char*>(base)+byteOffset;
+    short vv = buf[0];
+    vv |= (buf[1] << 8);
+
+    return(vv);
+}
+
+signed int VRGetInt( void* base, unsigned int byteOffset )
+{
+    unsigned char* buf = static_cast<unsigned char*>(base)+byteOffset;
+    signed int vv = buf[0];
+    vv |= (buf[1] << 8U);
+    vv |= (buf[2] << 16U);
+    vv |= (buf[3] << 24U);
+
+    return(vv);
+}
+unsigned int VRGetUInt( void* base, unsigned int byteOffset )
+{
+    unsigned char* buf = static_cast<unsigned char*>(base)+byteOffset;
+    int vv = buf[0];
+    vv |= (buf[1] << 8U);
+    vv |= (buf[2] << 16U);
+    vv |= (buf[3] << 24U);
+
+    return(static_cast<unsigned int>(vv));
+}
+
+
+///////////////////////////////////////////////////////////////////
+
+
+int VRReadChar(VSILFILE *fp)
+{
+    unsigned char buf[4]="";
+    // size_t ret =
+    VSIFReadL(buf, 1, 1, fp);
+    unsigned char vv = buf[0];
+    // if (ret<1) return(EOF);
+    return(vv);
+}
+
+int VRReadShort(VSILFILE *fp)
+{
+    unsigned char buf[4]="";
+    // size_t ret =
+    VSIFReadL(buf, 1, 2, fp);
+    short vv = buf[0];
+    vv |= (buf[1] << 8);
+    // if (ret<2) return(EOF);
+    return(vv);
+}
+
+int VRReadInt(VSILFILE *fp)
+{
+    unsigned char buf[4]="";
+    // size_t ret =
+    VSIFReadL(buf, 1, 4, fp);
+    signed int vv = buf[0];
+    vv |= (buf[1] << 8);
+    vv |= (buf[2] << 16);
+    vv |= (buf[3] << 24);
+    // if (ret<4) return(EOF);
+    return(vv);
+}
+int VRReadInt(VSILFILE *fp, unsigned int byteOffset )
+{
+    if ( VSIFSeekL( fp, byteOffset, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRReadInt cannot seek to VRC byteOffset %d=x%08x",
+                  byteOffset, byteOffset);
+        return CE_Failure; // dangerous ?
+    }
+    return VRReadInt(fp);
+}
+
+unsigned int VRReadUInt(VSILFILE *fp)
+{
+    // unsigned int vv;
+    unsigned char buf[4]="";
+    // size_t ret =
+    VSIFReadL(buf, 1, 4, fp);
+    // if (ret<4) return(EOF);
+    return(VRGetUInt(buf,0));
+}
+unsigned int VRReadUInt(VSILFILE *fp, unsigned int byteOffset )
+{
+    if ( VSIFSeekL( fp, byteOffset, SEEK_SET ) ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "VRReadInt cannot seek to VRC byteOffset %d=x%08x",
+                  byteOffset, byteOffset);
+        return CE_Failure; // dangerous ?
+    }
+    return VRReadUInt(fp);
+}
+
+
+/*
+ *               CRSfromCountry
+ *
+ * GDAL v1:
+ * const char* CRSfromCountry(int nCountry)
+ * GDAL v2 and v3:
+ * OGRSpatialReference* CRSfromCountry(int nCountry)
+ *
+ */
+
+// Some CRS use the "old" axis convention
+#if GDAL_VERSION_MAJOR >= 3
+#define VRC_SWAP_AXES        poSRS->SetAxisMappingStrategy( OAMS_TRADITIONAL_GIS_ORDER )
+#else
+#define VRC_SWAP_AXES
+#endif
+
+#define VRC_EPSG(A) errImport=poSRS->importFromEPSGA(A)
+
+extern OGRSpatialReference* CRSfromCountry(int nCountry)
+{
+    // OGRSpatialReference* poSRS=nullptr;
+    auto* poSRS=new OGRSpatialReference();
+    if (poSRS==nullptr) {
+        CPLDebug("Viewranger",
+                 "CRSfromCountry(%d) failed to create a spatial reference",
+                 nCountry);
+        return nullptr;
+    }
+
+    OGRErr errImport=OGRERR_NONE;
+
+    switch (nCountry) {
+        // case 0: break; // Online maps
+    case  1: VRC_EPSG(27700);   break; // UK Ordnace Survey
+    case  2: VRC_EPSG(29901);   break; // Ireland
+    case  5: VRC_EPSG(2393); VRC_SWAP_AXES;   break; // Finland
+    case  8: VRC_EPSG(31370);
+        // Other possibilities for Belgium include
+        //   EPSG:21500, EPSG:31300, EPSG:31370, EPSG:6190 and EPSG:3447.
+        // BelgiumOverview.VRC is not EPSG:3812 or EPSG:4171
+        // Some Belgium VRH (height) files are case 17:
+        break;
+    case  9: VRC_EPSG(21781); VRC_SWAP_AXES;  break; // Switzerland
+    case 12: VRC_EPSG(28992);   break; // Nederlands
+    case 13: VRC_EPSG(3907);    break; // tbc, Slovenia
+    case 14: VRC_EPSG(3006); VRC_SWAP_AXES; break; // Sweden SWEREF99
+    case 15: VRC_EPSG(25833);   break; // Norway
+    case 16: VRC_EPSG(32632);   break; // Italy
+    case 17: VRC_EPSG(4267); VRC_SWAP_AXES;
+        // USA, Discovery(Spain/Canaries) and Belgium VRH (height) files
+        break;
+    case 18: VRC_EPSG(2193); VRC_SWAP_AXES; break; // New Zealand
+    case 19: VRC_EPSG(2154);    break; // France
+    case 20: VRC_EPSG(2100);    break; // Greece
+    case 21: VRC_EPSG(3042); VRC_SWAP_AXES;
+        // Spain (Including Discovery Walking Guides)
+        break;
+    case 132: VRC_EPSG(25832);  break; // Austria/Germany/Denmark 
+    case 133: VRC_EPSG(25833);
+        // Czech Republic / Slovakia, EPSG:25833 tbc may be 32633 or 3045
+        break;
+    case 155: VRC_EPSG(28355); // not VRC_EPSG(4283);
+        // Australia
+        // Note that in VRCDataset::GetGeoTransform()
+        // we shift 10million metres north
+        // (which undoes the false_northing).
+        break;
+    default:
+        CPLDebug("Viewranger",
+                 "CRSfromCountry(country %d unknown) assuming WGS 84",
+                 nCountry);
+        VRC_EPSG(4326);   break;
+    }
+
+    if (errImport != OGRERR_NONE) {
+        CPLDebug("Viewranger",
+                 "failed to import EPSG for CRSfromCountry(%d) error %d",
+                 nCountry, errImport);
+        delete poSRS;
+        poSRS = nullptr;
+    }
+    return poSRS;
+} // CRSfromCountry()
+
+extern const char* CharsetFromCountry(int nCountry)
+{
+    // CPLDebug("Viewranger", "CharsetFromCountry(%d)", nCountry);
+    switch (nCountry) {
+        // case 0: return ""; // Online maps
+    case  1: return "LATIN9"; // UK Ordnance Survey
+    case  2: return "LATIN9"; // Ireland
+    case  5: return "LATIN9"; // Finland
+    case  8: return "LATIN9"; // Belgium. Some Belgium .VRH files are case 17:
+    case  9: return "LATIN9"; // Switzerland
+    case 12: return "LATIN9"; // Nederlands
+    case 13: return "LATIN9"; // Slovenia
+    case 14: return "LATIN9"; // Sweden SWEREF99
+    case 15: return "LATIN9"; // Norway
+    case 16: return "LATIN9"; // Italy
+    case 17: return "LATIN9"; // USA, Discovery(Spain/Canaries)
+        // (Belgium .VRH files are also 17, but .VRH files have no strings).
+    case 18: return "LATIN9"; // New Zealand
+    case 19: return "LATIN9"; // France
+    case 20: return "LATIN9"; // Greece
+        // case 21: return "UTF-8"; // Spain, but not Discovery Walking Guides ?
+    case 132: return "LATIN9"; // Austria/Germany/Denmark 
+    case 133: return "LATIN9"; // Czech Republic / Slovakia, EPSG:25833 tbc may be 32633 or 3045
+    case 155: return "LATIN9"; // Australia
+
+    default:
+        return "UTF-8";
+    }
+}
+// CharsetFromCountry(int nCountry)
+
+// #endif // ifdef FRMT_vrc

--- a/gdal/frmts/vrc/VRCutils.h
+++ b/gdal/frmts/vrc/VRCutils.h
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * $Id: VRCutils.h,v 1.4 2021/04/28 15:38:13 werdna Exp werdna $
+ *
+ * Author:  Andrew C Aitchison
+ *
+ ******************************************************************************
+ * Copyright (c) 2020, Andrew C Aitchison
+ *****************************************************************************/
+
+// Everything declared here is also declared in VRC.h
+// #ifndef VRC_H_INCLUDED
+
+#ifndef VRC_UTILS_H_INCLUDED
+#define VRC_UTILS_H_INCLUDED
+
+#pragma clang diagnostic push
+// #pragma clang diagnostic ignored "-Wformat-pedantic"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wunused-template"
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#include "gdal_pam.h"
+#pragma clang diagnostic pop
+#include "ogr_spatialref.h"
+//#include "cpl_string.h"
+
+// We have not fully deciphered the data format
+// of VRC files with magic=0x01ce6336.
+// Set *one* of these definitions (to 1)
+// VRC36_PIXEL_IS_PIXEL is to be assumed if none are set.
+#define VRC36_PIXEL_IS_PIXEL 1
+// #define VRC36_PIXEL_IS_TILE 1
+// #define VRC36_PIXEL_IS_FILE 1
+
+#if GDAL_VERSION_NUM < 2010000
+#define GDAL_IDENTIFY_UNKNOWN -1
+#define GDAL_IDENTIFY_FALSE 0
+#define GDAL_IDENTIFY_TRUE 1
+#else
+// These are defined in gdal/gdal_priv.h
+#endif // GDAL_VERSION_NUM < 2010000
+
+#if 0 // __cplusplus <= 201103L
+#define override
+#define nullptr 0
+#endif
+
+#ifdef CODE_ANALYSIS
+
+// Printing variables with CPLDebug can hide
+// the fact that they are not otherwise used ...
+#define CPLDebug(...)
+
+#endif // CODE_ANALYSIS
+
+int VRReadChar(VSILFILE *fp);
+int VRReadInt(VSILFILE *fp);
+void VRC_file_strerror_r(int nFileErr, char *buf, size_t buflen);
+
+extern OGRSpatialReference* CRSfromCountry(int nCountry);
+extern const char* CharsetFromCountry(int nCountry);
+
+extern void
+dumpTileHeaderData(
+                   VSILFILE *fp,
+                   unsigned int nTileIndex,
+                   unsigned int nOverviewCount,
+                   unsigned int anTileOverviewIndex[],
+                   const int tile_xx, const int tile_yy );
+
+extern short VRGetShort( void* base, int byteOffset );
+extern signed int VRGetInt( void* base, unsigned int byteOffset );
+extern unsigned int VRGetUInt( void* base, unsigned int byteOffset );
+
+extern int VRReadChar(VSILFILE *fp);
+extern int VRReadShort(VSILFILE *fp);
+extern int VRReadInt(VSILFILE *fp);
+extern int VRReadInt(VSILFILE *fp, unsigned int byteOffset );
+extern unsigned int VRReadUInt(VSILFILE *fp);
+extern unsigned int VRReadUInt(VSILFILE *fp, unsigned int byteOffset );
+
+#endif // ndef VRC_UTILS_H_INCLUDED
+
+// #endif // ndef VRC_H_INCLUDED

--- a/gdal/frmts/vrc/VRCutils.h
+++ b/gdal/frmts/vrc/VRCutils.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * $Id: VRCutils.h,v 1.4 2021/04/28 15:38:13 werdna Exp werdna $
+ * $Id: VRCutils.h,v 1.6 2021/06/26 19:10:13 werdna Exp $
  *
  * Author:  Andrew C Aitchison
  *
@@ -16,23 +16,21 @@
 #pragma clang diagnostic push
 // #pragma clang diagnostic ignored "-Wformat-pedantic"
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
 #pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
 #pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wsuggest-destructor-override"
+#pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wunused-template"
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #include "gdal_pam.h"
 #pragma clang diagnostic pop
 #include "ogr_spatialref.h"
 //#include "cpl_string.h"
-
-// We have not fully deciphered the data format
-// of VRC files with magic=0x01ce6336.
-// Set *one* of these definitions (to 1)
-// VRC36_PIXEL_IS_PIXEL is to be assumed if none are set.
-#define VRC36_PIXEL_IS_PIXEL 1
-// #define VRC36_PIXEL_IS_TILE 1
-// #define VRC36_PIXEL_IS_FILE 1
 
 #if GDAL_VERSION_NUM < 2010000
 #define GDAL_IDENTIFY_UNKNOWN -1

--- a/gdal/frmts/vrc/VRHV.cpp
+++ b/gdal/frmts/vrc/VRHV.cpp
@@ -1,0 +1,1434 @@
+/******************************************************************************
+ * $Id: VRHV.cpp,v 1.101 2021/06/18 17:33:29 werdna Exp werdna $
+ *
+ * Project:  GDAL
+ * Purpose:  Viewranger GDAL Driver
+ * Authors:  Andrew C Aitchison
+ *
+ ******************************************************************************
+ * Copyright (c) 2015-9, Andrew C Aitchison
+ ****************************************************************************/
+
+/* -*- tab-width: 4 ; indent-tabs-mode: nil ; c-basic-offset 'tab-width -*- */
+
+//#ifdef FRMT_vrc
+//#ifdef FRMT_vrhv
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command" // 3 errors
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion" // 1 error
+#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override" // 1 error
+#pragma clang diagnostic ignored "-Wpadded"          // 11 errors
+#pragma clang diagnostic ignored "-Wsuggest-destructor-override"
+#pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunused-template" // 1 error
+#pragma clang diagnostic ignored "-Wweak-vtables"    // 1 error
+
+#include "gdal_pam.h"
+#include "ogr_spatialref.h"
+
+#include "cpl_port.h"
+#include "cpl_string.h"
+
+#pragma clang diagnostic pop
+
+#include "VRC.h"
+
+CPL_CVSID("$Id: VRHV.cpp,v 1.101 2021/06/18 17:33:29 werdna Exp werdna $")
+
+CPL_C_START
+void   GDALRegister_VRHV(void);
+CPL_C_END
+
+#ifdef CODE_ANALYSIS
+
+// Printing variables with CPLDebug can hide
+// the fact that they are not otherwise used ...
+#define CPLDebug(...)
+
+#endif // CODE_ANALYSIS
+
+
+static const unsigned int vrh_magic = 0xfac6804f; // 0x4f80c6fa; //
+static const signed int nVRHNoData = -32768;
+
+static const unsigned int vrv_magic = 0x2;
+
+// ViewRanger Map Chooser (.vmc) file
+// viewrangershop can read and write these files
+// which describe the tiles selected from a VRV file 
+static const unsigned int vmc_magic = 0x1;
+static const unsigned int nVMCNoData = 0;
+static const unsigned int nVMCYesData = 255;
+
+static const unsigned int nVRNoData = 255;
+static const unsigned int nVRVNoData = 255;
+
+// typedef struct {double lat; double lon; } latlon;
+
+
+#include "VRCutils.h"
+
+/************************************************************************/
+/* ==================================================================== */
+/*                         VRHVDataset                                   */
+/* ==================================================================== */
+/************************************************************************/
+
+class VRHRasterBand;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+class VRHVDataset : public GDALPamDataset
+{
+    friend class VRHRasterBand;
+    
+    VSILFILE            *fp;
+    GDALColorTable      *poColorTable;
+    GByte       abyHeader[0x5a0];
+    
+    unsigned int nMagic, nPixelMetres;
+    int nVRHVersion;
+    signed int nLeft, nRight, nTop, nBottom;
+    unsigned int nScale;
+    unsigned int *anColumnIndex;
+    unsigned int *anTileIndex;
+    short nCountry;
+    OGRSpatialReference* poSRS = nullptr;
+
+    char *pszLongTitle,
+    // *pszName, *pszIdentifier,
+    // *pszEdition, *pszRevision, *pszKeywords,
+        *pszCopyright
+        ;
+    // *pszDepths, *pszHeights, *pszProjection,
+    // *pszOrigFileName;
+    // latlon TL, TR, BL, BR;
+
+    std::string sDatum;
+    
+#pragma clang diagnostic pop
+
+public:
+    VRHVDataset();
+    ~VRHVDataset() override;
+    
+    static GDALDataset *Open( GDALOpenInfo *poOpenInfo );
+    static int Identify( GDALOpenInfo *poOpenInfo );
+    
+    // Gdal <3 uses proj.4, Gdal>=3 uses proj.6, see eg:
+    // https://trac.osgeo.org/gdal/wiki/rfc73_proj6_wkt2_srsbarn
+    // https://gdal.org/development/rfc/rfc73_proj6_wkt2_srsbarn.html
+#if GDAL_VERSION_MAJOR >= 3
+    const OGRSpatialReference* GetSpatialRef() const override {
+        return GetSpatialRefFromOldGetProjectionRef();
+    }
+    const char *_GetProjectionRef
+#else
+    const char *GetProjectionRef
+#endif
+    () override {
+        return sDatum.c_str();
+    }
+
+#if 1 // GeoLoc
+    CPLErr GetGeoTransform( double * padfTransform ) override;
+#endif
+
+    char       **GetFileList() override;
+
+    static char *VRHGetString( VSILFILE *fp, unsigned long long byteaddr );
+    // static void xy_to_latlon(VRHVDataset *poDS, int pixel_x, int pixel_y, latlon *latlon);
+};
+
+
+/* -------------------------------------------------------------------------
+ * Returns a (null-terminated) string allocated from VSIMalloc.
+ * The 32 bit length of the string is stored in file fp at byteaddr.
+ * The string itself is stored immediately after its length;
+ * it is *not* null-terminated in the file.
+ * If index pointer is nul then an empty string is returned
+ * (rather than a null pointer).
+ */
+char *VRHVDataset::VRHGetString( VSILFILE *fp, unsigned long long byteaddr )
+{
+    if (byteaddr==0) return( strdup (""));
+    
+    int seekres = VSIFSeekL( fp, byteaddr, SEEK_SET );
+    if ( seekres ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to VRH string" );
+        return nullptr;
+    }
+    int string_length = VRReadInt(fp);
+    if (string_length<=0) {
+        if (string_length<0) {
+            CPLDebug("ViewrangerHV", "odd length for string %012llx - length %d",
+                     byteaddr, string_length);
+        }
+        return( strdup (""));
+    }
+    auto ustring_length = static_cast<size_t>(string_length);
+
+    auto *pszNewString = static_cast<char*>(VSIMalloc(1+ustring_length));
+    if (pszNewString == nullptr) {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate %d bytes for string",
+                 1+string_length);
+        return nullptr;
+    }
+    
+
+    size_t bytesread =
+      VSIFReadL( pszNewString, 1, ustring_length, fp);
+
+    if (bytesread < ustring_length) {
+      VSIFree(pszNewString);
+      CPLDebug("ViewrangerHV", "requested x%08x bytes but only got x%8lx",
+               string_length, bytesread);
+      CPLError(CE_Failure, CPLE_AppDefined,
+               "problem reading string\n");
+      return nullptr;     
+    }
+
+    pszNewString[string_length] = 0;
+    // CPLDebug("ViewrangerHV", "read string %s at %08x - length %d",
+    //         pszNewString, byteaddr, string_length);
+    return pszNewString;
+}
+
+
+/************************************************************************/
+/* ==================================================================== */
+/*                            VRHRasterBand                             */
+/* ==================================================================== */
+/************************************************************************/
+
+class VRHRasterBand : public GDALPamRasterBand
+{
+    friend class VRHVDataset;
+    
+    int          nRecordSize;
+    
+    GDALColorInterp  eBandInterp;
+    signed short *pVRHVData;
+
+    void read_VRH_Tile( VSILFILE *fp,
+                                int tile_xx, int tile_yy,
+                                void *pimage);
+    void read_VRV_Tile( VSILFILE *fp,
+                                int tile_xx, int tile_yy,
+                                void *pimage);
+    
+    void read_VMC_Tile( VSILFILE *fp,
+                                int tile_xx, int tile_yy,
+                                void *pimage);
+    
+public:
+
+    VRHRasterBand( VRHVDataset* poDSIn, int nBandIn, int iOverviewIn);
+    ~VRHRasterBand() override;
+
+    // virtual
+    GDALColorInterp GetColorInterpretation() override;
+    // virtual
+    GDALColorTable  *GetColorTable() override;
+    // virtual
+    double GetNoDataValue( int* pbSuccess ) override;    
+    // virtual
+    CPLErr IReadBlock( int nBlockXOff,
+                       int nBlockYOff,
+                       void* pImage ) override;
+
+};
+
+
+/************************************************************************/
+/*                           VRHRasterBand()                            */
+/************************************************************************/
+
+VRHRasterBand::VRHRasterBand(
+                             VRHVDataset *poDSIn,
+                             int nBandIn,
+                             int iOverviewIn )
+{
+    this->poDS = poDSIn;
+    (void)iOverviewIn;
+    this->nBand = nBandIn;
+    CPLDebug("ViewrangerHV", "VRHRasterBand(%p, %d, %d)",
+             static_cast<void*>(poDS), nBand, iOverviewIn);
+    
+    nRasterXSize = poDSIn->nRasterXSize;
+    nRasterYSize = poDSIn->nRasterYSize;
+
+    // int tileXcount = poDS->tileXcount;
+    // int tileYcount = poDS->tileYcount;
+
+    CPLDebug("ViewrangerHV", "nRasterXSize %d nRasterYSize %d",
+             nRasterXSize, nRasterYSize);
+
+    CPLDebug("ViewrangerHV", "eBandInterp x%08x, (Blue=x%08x)",
+             eBandInterp, GCI_BlueBand);
+
+    pVRHVData = nullptr;
+
+    if (poDSIn->nMagic == vrh_magic) {
+        eDataType = GDT_Int16;
+        eBandInterp = GCI_GrayIndex;
+
+        /* Height data has an index of columns, so
+         * we have one block per column.
+         */
+        nBlockXSize = 1;
+        nBlockYSize = poDSIn->nRasterYSize;
+        nRecordSize = /* nBlockXSize* */ nBlockYSize; // * sizeof(short) ?
+    } else if (poDSIn->nMagic == vrv_magic || poDSIn->nMagic == vmc_magic) {
+        eDataType = GDT_Byte;
+        eBandInterp = GCI_GrayIndex;
+        
+        /* We currently make one block that stores the whole image.
+         * We could make the blocks use fewer rows, but
+         * since the data on file is west up we need to rotate it
+         * to put into the block.
+         * Since all known sample images are small, we don't
+         * currently support multiple blocks.
+         */
+        
+        nBlockXSize = nRasterXSize;
+        nBlockYSize = nRasterYSize;
+        
+        /* Cannot overflow as nBlockXSize, nBlockYSize both <= 4096
+         * in VRHVDataset::Open()
+         */
+        nRecordSize = nBlockXSize*nBlockYSize;
+    }
+    CPLDebug("ViewrangerHV", "eBandInterp x%08x, (Red==x%08x)",
+             eBandInterp, GCI_RedBand);
+} // VRHRasterBand()
+
+/************************************************************************/
+/*                          ~VRHRasterBand()                            */
+/************************************************************************/
+
+VRHRasterBand::~VRHRasterBand()
+{
+    if (pVRHVData) {
+        VSIFree(pVRHVData);
+        pVRHVData = nullptr;
+    }
+}
+
+/************************************************************************/
+/*                             IReadBlock()                             */
+/************************************************************************/
+
+CPLErr VRHRasterBand::IReadBlock( int nBlockXOff, int nBlockYOff,
+                                  void * pImage )
+{
+    auto *poGDS = static_cast<VRHVDataset *>(poDS);
+
+    CPLDebug("ViewrangerHV", "Block (%d,%d)", nBlockXOff, nBlockYOff);
+    if (nBlockXOff < 0 || nBlockXOff*nBlockXSize >= poGDS->nRasterXSize)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Block (any,%d) does not exist %d * %d >?= %d",
+                 nBlockXOff, nBlockXOff,
+                 poGDS->nRasterXSize, nBlockXSize );
+            return CE_Failure;
+    }
+    if (nBlockYOff < 0 || nBlockYOff*nBlockYSize >= poGDS->nRasterYSize)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Block (any,%d) does not exist %d * %d >?= %d",
+                 nBlockYOff, nBlockYOff,
+                 poGDS->nRasterYSize, nBlockYSize );
+            return CE_Failure;
+    }
+
+#if 0
+    if (pVRHVData == nullptr) {
+        if (nRecordSize < 0)
+            return CE_Failure;
+
+        pVRHVData = static_cast<signed short*>(VSIMalloc(nRecordSize));
+        if (pVRHVData == nullptr) {
+            CPLError(CE_Failure, CPLE_OutOfMemory,
+                     "Cannot allocate scanline buffer");
+            nRecordSize = -1;
+            return CE_Failure;
+        }
+    }
+#endif
+
+    if ( poGDS->nMagic == vrh_magic ) {
+#if 0
+        // dummy data for now
+        // this draws a box
+        for( int i = 0; i < nBlockXSize *nBlockYSize ; i++ ) {
+            static_cast<signed short*>(pImage)[i] = nVRHNoData;
+        }
+        for( int i = 0; i < nBlockXSize ; i++ ) {
+            static_cast<signed short*>(pImage)[i] = 0;
+            static_cast<signed short*>(pImage)[nBlockXSize *nBlockYSize - i] = 0;
+        }
+        for( int i = 1; i < nBlockYSize-1 ; i++ ) {
+            static_cast<signed short*>(pImage)[i*nBlockXSize] = 0;
+            static_cast<signed short*>(pImage)[(i+1)*nBlockXSize-1] = 0;
+        }
+#endif
+
+        if ( poGDS->anColumnIndex[nBlockXOff] ) {
+            int seekres =
+                VSIFSeekL( poGDS->fp, poGDS->anColumnIndex[nBlockXOff], SEEK_SET );
+            if ( seekres ) {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "cannot seek to VRH column %d", nBlockXOff );
+                return CE_Failure;
+            }
+            read_VRH_Tile(poGDS->fp, nBlockXOff, nBlockYOff, pImage);
+
+        } else {
+            // no data for this column;
+            auto *panColumn = static_cast<short*>(pImage);
+            for (int i=0; i < nBlockYSize; i++) {
+                panColumn[i] = nVRHNoData;
+            }
+            return CE_None; // all OK
+        }        
+    } else  if ( poGDS->nMagic == vrv_magic ) {
+        read_VRV_Tile(poGDS->fp, nBlockXOff, nBlockYOff, pImage);
+#if 0
+        char * charImage = (char *)pImage;
+        CPLDebug("ViewrangerHV", "IReadBlock %p\t%02x %02x %02x %02x %02x %02x %02x %02x\t%02x %02x %02x %02x %02x %02x %02x %02x",
+                 charImage,
+                 charImage[0], charImage[1], charImage[2], charImage[3],
+                 charImage[4], charImage[5], charImage[6], charImage[7],
+                 charImage[8], charImage[9], charImage[10], charImage[11],
+                 charImage[12], charImage[13], charImage[14], charImage[15]
+                 );
+#endif
+        return CE_None; // all OK
+        
+    } else  if ( poGDS->nMagic == vmc_magic ) {
+        read_VMC_Tile(poGDS->fp, nBlockXOff, nBlockYOff, pImage);
+        CPLDebug("ViewrangerHV", "IReadBlock(%d, %d, %p)",
+                 nBlockXOff, nBlockYOff, pImage);
+        return CE_None; // all OK
+        
+    }
+    return CE_None;
+} // VRHRasterBand::IReadBlock
+
+/************************************************************************/
+/*                           GetNoDataValue()                           */
+/************************************************************************/
+
+double VRHRasterBand::GetNoDataValue( int* pbSuccess )
+{
+  if (pbSuccess) {
+      *pbSuccess=TRUE;
+  }
+
+  switch (static_cast<VRHVDataset*>(poDS)->nMagic) {
+  case vmc_magic: return nVMCNoData;
+  case vrh_magic: return nVRHNoData;
+  case vrv_magic: return nVRVNoData;
+  default :
+      if (pbSuccess) {
+          *pbSuccess=FALSE;
+      }
+      return 0.0;
+  }
+}
+
+/************************************************************************/
+/*                       GetColorInterpretation()                       */
+/************************************************************************/
+
+GDALColorInterp VRHRasterBand::GetColorInterpretation()
+
+{
+    return GCI_GrayIndex;
+}
+
+
+/************************************************************************/
+/*                           GetColorTable()                            */
+/************************************************************************/
+
+GDALColorTable *VRHRasterBand::GetColorTable()
+
+{
+#if 0
+    VRHVDataset  *poGDS = (VRHVDataset *) poDS;
+
+    if( nBand == 1 )
+        return poGDS->poColorTable;
+    else
+#endif
+        return nullptr;
+}
+
+
+/************************************************************************/
+/* ==================================================================== */
+/*                            VRHVDataset                                */
+/* ==================================================================== */
+/************************************************************************/
+
+/************************************************************************/
+/*                            VRHVDataset()                              */
+/************************************************************************/
+
+VRHVDataset::VRHVDataset() :
+    fp(nullptr),
+    poColorTable(nullptr),
+    // These are only here to keep cppcheck happy
+    // They may make the program think things are OK when they are not.
+#ifdef CODE_ANALYSIS
+    abyHeader{0},   // Inefficient since we never use the initial value.
+    // iOverview(0),
+    nMagic(0),
+    nPixelMetres(0),
+    nVRHVersion(-1),
+#endif // CODE_ANALYSIS
+    nLeft(INT_MAX),
+    nRight(INT_MIN),
+    nTop(INT_MIN),
+    nBottom(INT_MAX),
+#ifdef CODE_ANALYSIS
+    nScale(0),
+#endif // CODE_ANALYSIS
+    anColumnIndex(nullptr),
+    anTileIndex(nullptr),
+#ifdef CODE_ANALYSIS
+    nCountry(-1),
+#endif // CODE_ANALYSIS
+    poSRS(nullptr),
+
+    pszLongTitle(nullptr),
+    //pszName(nullptr),
+    //pszIdentifier(nullptr),
+    //pszEdition(nullptr),
+    //pszRevision(nullptr),
+    //pszKeywords(nullptr),
+    pszCopyright(nullptr),
+    //pszDepths(nullptr),
+    //pszHeights(nullptr),
+    //pszProjection(nullptr),
+    //pszOrigFileName(nullptr),
+    // These are only here to keep cppcheck happy
+    // They may make the program think things are OK when they are not.
+
+    sDatum(CPLStrdup(""))
+{
+}
+
+/************************************************************************/
+/*                           ~VRHVDataset()                             */
+/************************************************************************/
+
+VRHVDataset::~VRHVDataset()
+
+{
+    FlushCache();
+    if( fp != nullptr )
+        VSIFCloseL( fp );
+
+    if( poColorTable != nullptr )
+        delete ( poColorTable );
+
+    if (anColumnIndex != nullptr ) {
+        VSIFree(anColumnIndex);
+        anColumnIndex = nullptr;
+    }
+    if (anTileIndex != nullptr ) {
+        VSIFree(anTileIndex);
+        anTileIndex = nullptr;
+    }
+    if (pszLongTitle != nullptr ) {
+        VSIFree(pszLongTitle);
+        pszLongTitle = nullptr;
+    }
+    if (pszCopyright != nullptr ) {
+        VSIFree(pszCopyright);
+        pszCopyright = nullptr;
+    }
+    if (poSRS) {
+        poSRS->Release();
+        poSRS = nullptr;
+    }
+#if 0
+    if (sDatum != nullptr ) {
+        VSIFree(sDatum);
+        sDatum = nullptr;
+    }
+
+    // trying to free strings created in VRHVDataset::Open
+    for (int ii=0; ii<nStringCount; ++ii) {
+        if (paszStrings[ii]) {
+            VSIFree(paszStrings[ii]);
+            paszStrings[ii] = 0;
+        }        
+    }
+    VSIFree(paszStrings);
+    paszStrings = 0;
+#endif
+}
+
+/************************************************************************/
+/*                          GetGeoTransform()                           */
+/************************************************************************/
+#if 1 // GeoLoc
+CPLErr VRHVDataset::GetGeoTransform( double * padfTransform )
+
+{
+    double dLeft = nLeft;
+    double dRight = nRight;
+    double dTop = nTop ;
+    double dBottom = nBottom ;
+
+    double tenMillion = 10.0 * 1000 * 1000;
+     if (nCountry == 17) {
+        // This may not be correct
+        // USA, Discovery (Spain) and some Belgium (VRH height) maps have coordinate unit of
+        //   1 degree/ten million
+        CPLDebug("ViewrangerHV", "country/srs 17 USA?Belgium?Discovery(Spain) grid is unknown. Current guess is unlikely to be correct.");
+#if 0 // standard until 20 Sept 2020
+        dLeft   /= tenMillion;
+        dRight  /= tenMillion;
+        dTop    /= tenMillion;
+        dBottom /= tenMillion;
+#else
+        const double nineMillion = 9.0 * 1000 * 1000;
+        dLeft   /= nineMillion;
+        dRight  /= nineMillion;
+        dTop    /= nineMillion;
+        dBottom /= nineMillion;
+#endif
+        CPLDebug("ViewrangerHV", "scaling by 10 million: TL: %g %g BR: %g %g",
+                 dTop,dLeft,dBottom,dRight);
+    } else if (nCountry == 155) {
+        // New South Wales srs is not quite GDA94/MGA55 EPSG:28355
+        dLeft   = 1.0*nLeft;
+        dRight  = 1.0*nRight;
+        dTop    = 1.0*nTop + tenMillion;
+        dBottom = 1.0*nBottom + tenMillion;
+        CPLDebug("ViewrangerHV", "shifting by 10 million: TL: %g %g BR: %g %g",
+                 dTop,dLeft,dBottom,dRight);
+    }
+
+    // Xgeo = padfTransform[0] + pixel*padfTransform[1] + line*padfTransform[2];
+    // Ygeo = padfTransform[3] + pixel*padfTransform[4] + line*padfTransform[5];
+    if (nMagic == vrh_magic || nMagic == vrv_magic || nMagic == vmc_magic) {
+        padfTransform[0] = dLeft;
+        padfTransform[1] = (1.0*dRight - dLeft) / (GetRasterXSize());
+        padfTransform[2] = 0.0;
+        padfTransform[3] = dTop;
+        padfTransform[4] = 0.0;
+        padfTransform[5] = (1.0*dBottom - dTop) / (GetRasterYSize());
+    } else {
+#if 0
+        padfTransform[0] = dLeft;
+        padfTransform[1] = (1.0*dRight - dLeft);
+        padfTransform[2] = 0.0;
+        padfTransform[3] = dTop;
+        padfTransform[4] = 0.0;
+        padfTransform[5] = (1.0*dBottom - dTop);
+#endif
+        CPLError( CE_Failure, CPLE_AppDefined,
+                          "unknown magic %d", nMagic);
+    }
+
+    CPLDebug("ViewrangerHV", "padfTransform raster %d x %d", GetRasterXSize(), GetRasterYSize());
+    CPLDebug("ViewrangerHV", "padfTransform %g %g %g", padfTransform[0], padfTransform[1], padfTransform[2]);
+    CPLDebug("ViewrangerHV", "padfTransform %g %g %g", padfTransform[3], padfTransform[4], padfTransform[5]);
+    return CE_None;
+}
+#endif
+
+/************************************************************************/
+/*                              Identify()                              */
+/************************************************************************/
+
+int VRHVDataset::Identify( GDALOpenInfo * poOpenInfo )
+
+{
+/* -------------------------------------------------------------------- */
+/*  This has to be a file on disk ending in .VRH, .VRV or .vmc          */
+/*  case is probably not important, but this is what we get on linux    */
+/* .VRH (but not all .VRV) files also have an obvious right magic number*/
+/* -------------------------------------------------------------------- */
+
+    // Need to read 
+    // http://trac.osgeo.org/gdal/wiki/rfc11_fastidentify
+    CPLDebug("ViewrangerHV", "VRHVDataset::Identify(%s) %d byte header available",
+             poOpenInfo->pszFilename, poOpenInfo->nHeaderBytes
+             );
+ 
+    if(poOpenInfo->nHeaderBytes < 20 ) {
+         return FALSE;
+    }
+
+    unsigned int magic = VRGetUInt(poOpenInfo->pabyHeader, 0);
+    unsigned int version = VRGetUInt(poOpenInfo->pabyHeader, 4);
+
+    // .VRH files can be very small and may not have a header
+    if(magic != vrv_magic && magic != vmc_magic && magic != vrh_magic
+       && poOpenInfo->nHeaderBytes < 0x60 ) {
+        // http://lists.osgeo.org/pipermail/gdal-dev/2013-February/035530.html
+        // suggests that file extension is a bad way to detect file format
+        // but if the header is not present we don't have a choice
+
+        if( EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"VRH") ||
+            EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"vrh") )  {
+            CPLError( CE_Failure, CPLE_AppDefined, 
+                      "VRH identify given %d byte header - needs 0x60 (file %s)",
+                      poOpenInfo->nHeaderBytes, poOpenInfo->pszFilename );
+        }
+        // Small file that doesn't have any magic and has wrong filename
+        return FALSE;
+    }
+
+    if( magic == vrh_magic ) {
+        CPLDebug("ViewrangerHV", "VRH file %s supported",
+                 poOpenInfo->pszFilename);
+        return TRUE;
+    } else if( magic == vmc_magic ) {
+        // This match could easily be accidental,
+        // so we require the correct extension even though
+        // http://lists.osgeo.org/pipermail/gdal-dev/2013-February/035530.html
+        // suggests that file extension is a bad way to detect file format.
+        if( ! EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"VMC") &&
+            ! EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"vmc") ) {
+            return FALSE;
+        }
+
+        if (version == 1 || version == 2) {
+            CPLDebug("ViewrangerHV", ".vmc file %s support limited",
+                     poOpenInfo->pszFilename);
+            return TRUE;     
+        } else {
+            CPLDebug("ViewrangerHV", "unexpected vmc version %08x", version);
+            return FALSE;
+       }
+    } else if( magic == vrv_magic ) {
+        // should do more checks here; matching this magic could easily be accidental
+
+        // http://lists.osgeo.org/pipermail/gdal-dev/2013-February/035530.html
+        // suggests that file extension is a bad way to detect file format
+        // but .VRV files can be very small so we may not have a choice.
+        if( EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"VRV") ||
+            EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"vrv") ) {
+            CPLDebug("ViewrangerHV", "VRV file %s supported",
+                     poOpenInfo->pszFilename);
+            return TRUE;
+        } else {
+            CPLDebug("ViewrangerHV", "ignoring possible VRV file %s with unexpected extension",
+                     poOpenInfo->pszFilename);
+            return FALSE;
+        }
+    } else if( EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"VRH") ||
+               EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"vrh") ) {
+        // *some* .VRH files have no magic.
+        // http://lists.osgeo.org/pipermail/gdal-dev/2013-February/035530.html
+        // suggests that file extension is a bad way to detect file format
+        // so use that plus some extra checks.
+        // We need to be extra careful in case this is not in fact a VRH file
+
+        CPLDebug("ViewrangerHV", "Doing extra checks for VRH file %s",
+                 poOpenInfo->pszFilename);
+
+        int nLeft = VRGetInt( poOpenInfo->pabyHeader, 0 );
+        int nRight = VRGetInt( poOpenInfo->pabyHeader, 4 );
+        int nBottom = VRGetInt( poOpenInfo->pabyHeader, 8 );
+        int nTop = VRGetInt( poOpenInfo->pabyHeader, 12 );
+        int nWidth = nRight - nLeft;
+        int nHeight = nTop - nBottom;
+        int nPixelMetres = VRGetInt( poOpenInfo->pabyHeader, 16 );
+        const int hundmill = 100 * 1000 * 1000;
+
+        CPLDebug("ViewrangerHV", "nLeft %d nRight %d nBottom %d nTop %d nWidth %d nHeight %d",
+                 nLeft, nRight, nBottom, nTop, nWidth, nHeight);
+
+        if (   nLeft   < -hundmill || nLeft   > hundmill
+            || nRight  < -hundmill || nRight  > hundmill
+            || nWidth  < -hundmill || nWidth  > hundmill 
+            || nTop    < -hundmill || nTop    > hundmill 
+            || nBottom < -hundmill || nBottom > hundmill 
+            || nHeight < -hundmill || nHeight > hundmill
+            || nPixelMetres <= 0   || nPixelMetres > 1000 * 1000 )
+            {
+                CPLDebug("ViewrangerHV", "%s failed extra checks for a .VRH file",
+                 poOpenInfo->pszFilename);
+                return FALSE;
+            }
+        CPLDebug("ViewrangerHV", "%s passes extra checks for a .VRH file",
+                 poOpenInfo->pszFilename);
+        return TRUE;
+    }
+    return FALSE;
+} // VRHVDataset::Identify()
+
+/************************************************************************/
+/*                                Open()                                */
+/************************************************************************/
+
+GDALDataset *VRHVDataset::Open( GDALOpenInfo * poOpenInfo )
+
+{
+    if (!Identify(poOpenInfo))
+        return nullptr;
+
+#if GDAL_VERSION_MAJOR >= 2
+    /* Check that the file pointer from GDALOpenInfo* is available */ 
+    if( poOpenInfo->fpL == nullptr )
+    {
+        return nullptr;
+    }
+#endif
+
+/* -------------------------------------------------------------------- */
+/*      Confirm the requested access is supported.                      */
+/* -------------------------------------------------------------------- */
+    if( poOpenInfo->eAccess == GA_Update )
+    {
+        CPLError( CE_Failure, CPLE_NotSupported, 
+                  "The VRH driver does not support update access to existing"
+                  " datasets.\n" );
+        return nullptr;
+    }
+
+/* -------------------------------------------------------------------- */
+/*      Create a corresponding GDALDataset.                             */
+/* -------------------------------------------------------------------- */
+    // unsigned int nVRHVersion;
+    auto* poDS = new VRHVDataset();
+
+#if GDAL_VERSION_MAJOR >= 2
+    /* Borrow the file pointer from GDALOpenInfo* */
+    poDS->fp = poOpenInfo->fpL;
+    poOpenInfo->fpL = nullptr;
+#else
+    poDS->fp = VSIFOpenL( poOpenInfo->pszFilename, "rb" );
+    if (poDS->fp == nullptr)
+    {
+        delete poDS;
+        return nullptr;
+    }
+#endif
+
+/* -------------------------------------------------------------------- */
+/*      Read the header.                                                */
+/* -------------------------------------------------------------------- */
+    VSIFReadL( poDS->abyHeader, 1, 0x5a0, poDS->fp );
+
+    poDS->nMagic = VRGetUInt(poDS->abyHeader, 0);
+    poDS->nVRHVersion = VRGetInt(poDS->abyHeader, 4);
+    
+    if ( poDS->nMagic!=vrh_magic && poDS->nMagic!=vmc_magic) {
+        if( EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"VRH") ||
+            EQUAL(CPLGetExtension(poOpenInfo->pszFilename),"vrh") )
+            {
+                // early .VRH files have no magic signature
+                poDS->nMagic = vrh_magic;
+                poDS->nVRHVersion = 0;
+            }
+    }
+
+    switch (poDS->nMagic) {
+    case vrh_magic:
+        {
+            // .VRH height file
+            unsigned int vrh_header_offset=0;
+            if (poDS->nVRHVersion < 2) {
+                poDS->nCountry = 1;
+            } else {
+                vrh_header_offset = 10;
+                poDS->nCountry = VRGetShort( poDS->abyHeader, 8 );
+            }
+            
+            poDS->nLeft =
+                VRGetInt( poDS->abyHeader, vrh_header_offset );
+            poDS->nRight =
+                VRGetInt( poDS->abyHeader, vrh_header_offset+4 );
+            poDS->nBottom =
+                VRGetInt( poDS->abyHeader, vrh_header_offset+8 );
+            poDS->nTop =
+                VRGetInt( poDS->abyHeader, vrh_header_offset+12 );
+
+            poDS->nPixelMetres =
+                VRGetUInt( poDS->abyHeader, vrh_header_offset+16 );
+
+            if (poDS->nPixelMetres < 1) {
+                CPLDebug("ViewrangerHV",
+                         "Map with %d metre pixels is too large scale (detailed) for the current VRHV driver",
+                         poDS->nPixelMetres);
+            } else {
+                // Should check that poDS->nRasterXSize and
+                // poDS->nRasterXSize are integers ...
+                auto dfPixelMetres = static_cast<double>(poDS->nPixelMetres);
+                double dfRasterXSize =
+                    static_cast<double>(poDS->nRight - poDS->nLeft) /
+                    dfPixelMetres;
+                poDS->nRasterXSize = static_cast<int>(dfRasterXSize);
+                double dfRasterYSize =
+                    static_cast<double>(poDS->nTop - poDS->nBottom) /
+                    dfPixelMetres;
+                poDS->nRasterYSize = static_cast<int>(dfRasterYSize);
+
+                // cast to double to avoid overflow and loss of precision
+                // eg  (10000*503316480)/327680000 = 15360
+                //             but                 = 11 with 32bit ints.
+                CPLDebug("ViewrangerHV", "Image %d x %d",
+                         poDS->nRasterXSize, poDS->nRasterYSize
+                         );
+            }
+            
+            poDS->pszLongTitle = CPLStrdup("") ; // poOpenInfo->pszFilename might be good
+            poDS->pszCopyright = CPLStrdup("") ;
+            
+            /*************************************************************/
+            /*             Read index data from VRH file                 */
+            /*************************************************************/
+            int seekres =
+                VSIFSeekL( poDS->fp, vrh_header_offset+20, SEEK_SET );
+            if ( seekres ) {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "cannot seek to VRH column index" );
+                return nullptr;
+            }
+            
+            poDS->anColumnIndex = static_cast<unsigned int*>(
+                VSIMalloc2(sizeof (unsigned int),
+                           static_cast<size_t>(poDS->nRasterXSize)) );
+            if (poDS->anColumnIndex == nullptr) {
+                CPLError(CE_Failure, CPLE_OutOfMemory,
+                         "Cannot allocate %d bytes of memory for column index",
+                         poDS->nRasterXSize);
+                return nullptr;
+            }
+            for (int ii=0; ii<poDS->nRasterXSize; ii++) {
+                poDS->anColumnIndex[ii] = VRReadUInt(poDS->fp);
+            }
+        }
+        break; // case vrh_magic
+    case vrv_magic:
+        // .VRV file describes tiles available for purchase
+        poDS->nPixelMetres = VRGetUInt(poDS->abyHeader, 4);
+        poDS->nRasterXSize = VRGetInt(poDS->abyHeader, 8 );
+        poDS->nRasterYSize = VRGetInt(poDS->abyHeader, 0xC );
+        
+        poDS->nLeft = VRGetInt( poDS->abyHeader, 0x10 );
+        poDS->nBottom = VRGetInt( poDS->abyHeader, 0x14 );
+        CPLDebug("ViewrangerHV", "VRV max value %d",
+                 VRGetInt( poDS->abyHeader, 0x18)
+                 );
+        poDS->nCountry = VRGetShort( poDS->abyHeader, 0x1C );
+        poDS->nScale = VRGetUInt( poDS->abyHeader, 0x20 );
+
+        {
+            // based on 10 pixels/millimetre (254 dpi)
+            double scaleFactor = poDS->nPixelMetres; //100000.0/poDS->nScale;
+            poDS->nTop = poDS->nBottom +
+                static_cast<int>(scaleFactor*poDS->nRasterYSize);
+            poDS->nRight = poDS->nLeft + 
+                static_cast<int>(scaleFactor*poDS->nRasterXSize);
+            CPLDebug("ViewrangerHV", "Top %d = %d + %lf * %d",
+                     poDS->nTop, poDS->nBottom, scaleFactor, poDS->nRasterYSize);
+            CPLDebug("ViewrangerHV", "Right %d = %d + %lf * %d",
+                     poDS->nRight, poDS->nLeft, scaleFactor, poDS->nRasterXSize);
+        }
+
+        poDS->nCountry = VRGetShort(poDS->abyHeader, 6);
+        {
+            const char* szInCharset = CharsetFromCountry(poDS->nCountry);
+            const char* szOutCharset = "UTF-8";
+            if (poDS->pszLongTitle != nullptr ) {
+                VSIFree(poDS->pszLongTitle);
+            }
+            char* pszLT = VRHGetString(poDS->fp, 0x24);  // poOpenInfo->pszFilename might be good
+            poDS->pszLongTitle =
+                CPLRecode(pszLT, szInCharset, szOutCharset);
+            VSIFree(pszLT);
+        }
+        poDS->pszCopyright = CPLStrdup("ViewRanger") ;
+        
+        break; // case vrv_magic
+    case vmc_magic:
+        // .vmc viewranger map choice file
+        // generated by viewrangershop to store tiles to be purchased.
+        // poDS->nPixelMetres = VRGetInt(poDS->abyHeader, 8);
+        poDS->nPixelMetres = static_cast<unsigned int>
+            (VRGetInt(poDS->abyHeader, 8) / 10.0);
+        // int l5 = VRGetInt(poDS->abyHeader, 12);
+        poDS->nRasterXSize = VRGetInt(poDS->abyHeader, 16);
+        poDS->nRasterYSize = VRGetInt(poDS->abyHeader, 20);
+        poDS->nScale = VRGetUInt( poDS->abyHeader, 0x20 );
+        {
+            // I am curious about these values
+            unsigned int l5 = VRGetUInt(poDS->abyHeader, 12);
+            unsigned int dc1 = (static_cast<unsigned char*>(poDS->abyHeader))[24];
+            unsigned int p = VRGetUInt(poDS->abyHeader, 25);
+
+            CPLDebug("ViewrangerHV",
+                     "VMC nPixelMetres %d nScale %d l5 x%08x dc1 x%02x p x%08x",
+                     poDS->nPixelMetres, poDS->nScale, l5, dc1, p);
+            // CPLDebug doesn't count as "using" a variable
+            (void) l5;
+            (void) dc1;
+            (void) p;
+        }
+        if (poDS->nVRHVersion == 1) {
+            poDS->nCountry = 1;  // UK
+            poDS->nLeft=0;
+            poDS->nBottom=0;
+        } else if (poDS->nVRHVersion == 2) {
+            poDS->nCountry = VRGetShort(poDS->abyHeader, 29 );
+            poDS->nLeft = VRGetInt(poDS->abyHeader, 33 );
+            poDS->nBottom = VRGetInt(poDS->abyHeader, 37 );
+        } else {
+            CPLDebug("ViewrangerHV", "Unexpected VMC file version %d",
+                     poDS->nVRHVersion);
+        }
+        poDS->nTop = poDS->nBottom + poDS->nRasterYSize*
+            static_cast<int>(poDS->nPixelMetres);
+        poDS->nRight = poDS->nLeft + poDS->nRasterXSize*
+            static_cast<int>(poDS->nPixelMetres);
+        CPLDebug("ViewrangerHV", "VMC Top %d = %d + %d * %d",
+                 poDS->nTop, poDS->nBottom, poDS->nPixelMetres, poDS->nRasterYSize);
+        CPLDebug("ViewrangerHV", "VMC Right %d = %d + %d * %d",
+                 poDS->nRight, poDS->nLeft, poDS->nPixelMetres, poDS->nRasterXSize);
+        poDS->pszCopyright = CPLStrdup("Unknown. Probably ViewRanger") ;
+        break; // case vmc_magic
+    default:
+        // CPLError( CE_Failure, CPLE_NotSupported, 
+        CPLDebug("Viewranger VRH/VRV",
+                 "File magic 0x%08x unknown to viewranger VRH/VRV driver\n",
+                  poDS->nMagic );
+        delete poDS;
+        return nullptr;
+    } // switch poDS->nMagic
+
+
+    if  (poDS->nRasterXSize <= 0 || poDS->nRasterYSize <= 0 )
+    {
+        CPLError( CE_Failure, CPLE_NotSupported, 
+                  "Invalid dimensions : %d x %d", 
+                  poDS->nRasterXSize, poDS->nRasterYSize);
+        delete poDS;
+        return nullptr;
+    }
+#define MAX_X 1024 // 2711
+#define MAX_Y 1024 // 3267
+    if  (poDS->nRasterXSize >MAX_X || poDS->nRasterYSize > MAX_Y )
+    {
+        if ( poDS->nMagic != vrh_magic ) {
+            CPLError( CE_Failure, CPLE_NotSupported, 
+                      "Unsupported dimensions : %d x %d (max %d x %d)", 
+                      poDS->nRasterXSize, poDS->nRasterYSize,
+                      MAX_X, MAX_Y);
+            delete poDS;
+            return nullptr;
+            /* We could handle this case by using more than one
+             * block (perhaps one per row) but that makes the
+             * rotation from the "west up" data on file harder
+             * and is not necessary for any files yet found.
+             */
+        }
+        CPLDebug("ViewrangerHV",
+                 "Unsupported dimensions : %d x %d (max %d x %d)", 
+                 poDS->nRasterXSize, poDS->nRasterYSize,
+                 MAX_X, MAX_Y);
+    }
+ 
+    /********************************************************************/
+    /*                     Set datum - do I mean CRS ?                  */
+    /********************************************************************/
+    {
+        char* pszSRS=nullptr;
+        if(!poDS->poSRS) {
+            poDS->poSRS = CRSfromCountry(poDS->nCountry);
+        }
+        poDS->poSRS->exportToWkt( &pszSRS );
+        if (pszSRS) {
+            poDS->sDatum = CPLString(pszSRS);
+            CPLFree(pszSRS);
+        }
+    }
+
+    /********************************************************************/
+    /*             Report some strings found in the file                */
+    /********************************************************************/
+    CPLDebug("ViewrangerHV", "Long Title: %s",poDS->pszLongTitle);
+    CPLDebug("ViewrangerHV", "Copyright: %s",poDS->pszCopyright);
+    CPLDebug("ViewrangerHV", "%d metre pixels",poDS->nPixelMetres);
+    if ((poDS->nMagic != vrh_magic) && poDS->nScale > 0) {
+        CPLDebug("ViewrangerHV", "Scale: 1: %d",poDS->nScale);
+    }
+    CPLDebug("ViewrangerHV", "Datum: %s",poDS->sDatum.c_str());
+
+
+    /********************************************************************/
+    /*                       Set coordinate model                       */
+    /********************************************************************/
+
+    // calculate corner coordinates
+#if 0
+#if defined VRC_PIXEL_IS_FILE
+    xy_to_latlon(poDS, 0, 0, &poDS->TL);
+    xy_to_latlon(poDS, poDS->nRasterXSize, 0, &poDS->TR);
+    xy_to_latlon(poDS, 0, poDS->nRasterYSize, &poDS->BL);
+    xy_to_latlon(poDS, poDS->nRasterXSize, poDS->nRasterYSize, &poDS->BR);
+#else
+#if defined VRC_PIXEL_IS_TILE
+    xy_to_latlon(poDS, 0, 0, &poDS->TL);
+    xy_to_latlon(poDS, poDS->nRasterXSize, 0, &poDS->TR);
+    xy_to_latlon(poDS, 0, poDS->nRasterYSize, &poDS->BL);
+    xy_to_latlon(poDS, poDS->nRasterXSize, poDS->nRasterYSize, &poDS->BR);
+#else
+    // VRC_PIXEL_IS_PIXEL
+    xy_to_latlon(poDS, 0, 0, &poDS->TL);
+    xy_to_latlon(poDS, poDS->nRasterXSize, 0, &poDS->TR);
+    xy_to_latlon(poDS, 0, poDS->nRasterYSize, &poDS->BL);
+    xy_to_latlon(poDS, poDS->nRasterXSize, poDS->nRasterYSize, &poDS->BR);
+#endif
+#endif
+#endif
+
+
+/* -------------------------------------------------------------------- */
+/*      Create copyright information.                                   */
+/* -------------------------------------------------------------------- */
+    poDS->SetMetadataItem( "TIFFTAG_COPYRIGHT", poDS->pszCopyright, "" );
+
+
+/* -------------------------------------------------------------------- */
+/*      Create band information objects.                                */
+/* -------------------------------------------------------------------- */
+    auto *poBand = new VRHRasterBand( poDS, 1, 01);
+    poDS->SetBand( 1, poBand);
+    if (poDS->nMagic == vrh_magic) {
+        poBand->SetNoDataValue( nVRHNoData );
+    } else if (poDS->nMagic == vrv_magic) {
+        poBand->SetNoDataValue( nVRVNoData );
+    } else {
+        poBand->SetNoDataValue( nVRNoData );
+    }
+
+/* -------------------------------------------------------------------- */
+/*      Initialize any PAM information.                                 */
+/* -------------------------------------------------------------------- */
+    poDS->SetDescription( poOpenInfo->pszFilename );
+    poDS->TryLoadXML();
+
+/* -------------------------------------------------------------------- */
+/*      Check for overviews.                                            */
+/* -------------------------------------------------------------------- */
+    /* Let gdal do this for us.      */
+    poDS->oOvManager.Initialize( poDS, poOpenInfo->pszFilename );
+
+    return( poDS );
+} // VRHVDataset::Open()
+
+/************************************************************************/
+/*                       GDALRegister_VRHV()                      */
+/************************************************************************/
+
+void GDALRegister_VRHV()
+
+{
+    if (! GDAL_CHECK_VERSION("ViewrangerVRHV"))
+        return;
+
+    if( GDALGetDriverByName( "ViewrangerVRH/VRV" ) == nullptr )
+    {
+        auto *poDriver = new GDALDriver();
+        if (poDriver==nullptr) {
+            CPLError( CE_Failure, CPLE_ObjectNull,
+                      "Could not build a driver for ViewrangerHV"
+                     );
+            return;
+        }
+
+        poDriver->SetDescription( "ViewrangerVRH/VRV" );
+
+        // required in gdal version 2, not supported in gdal 1.11
+#if GDAL_VERSION_MAJOR >= 2
+        poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
+#endif
+
+        poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, 
+                                   "ViewRanger Height (.VRH/.VHV)" );
+        poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, 
+                                   "frmt_various.html#VRHV" );
+        poDriver->SetMetadataItem( GDAL_DMD_EXTENSION, "VRH" );
+
+        poDriver->SetMetadataItem( GDAL_DMD_CREATIONDATATYPES,
+                                   "Byte Int16" );
+        poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
+
+        // "NONRECIPROCAL" is the intent of the author
+        // of the code for this driver.
+        // Since they are not the authors, or owners,
+        // of the ViewRanger file formats, further research may be needed.
+        poDriver->SetMetadataItem( "LICENSE_POLICY", "NONRECIPROCAL" );
+
+        poDriver->pfnOpen = VRHVDataset::Open;
+        poDriver->pfnIdentify = VRHVDataset::Identify;
+
+        GetGDALDriverManager()->RegisterDriver( poDriver );
+    }
+}
+
+
+
+/* -------------------------------------------------------------------------
+ */
+void
+VRHRasterBand::read_VRH_Tile(VSILFILE *fp,
+                             int tile_xx, int tile_yy,
+                             void *pimage)
+{
+    if (tile_xx < 0 || tile_xx >= static_cast<VRHVDataset *>(poDS)->nRasterXSize ) {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "read_VRH_Tile invalid row %d", tile_xx );
+        return ;
+    }
+    if (tile_yy < 0 || tile_yy >= static_cast<VRHVDataset *>(poDS)->nRasterYSize ) {
+        CPLError( CE_Failure, CPLE_NotSupported,
+                  "read_VRH_Tile invalid column %d", tile_yy );
+        return ;
+    }
+    if (pimage == nullptr ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VRH_Tile passed no image" );
+        return ;
+    }
+
+    auto* pnBottomPixel = static_cast<signed short*>(pimage);
+    // pnBottomPixel += static_cast<VRHVDataset *>(poDS)->nRasterYSize * tile_xx;
+
+    signed short *pnOutPixel =
+        pnBottomPixel + static_cast<VRHVDataset *>(poDS)->nRasterYSize - 1;
+
+    signed int max = -1 * 0x10000;
+    while (pnOutPixel >= pnBottomPixel) {
+        signed int length = 1;
+        signed int value = VRReadShort(fp) & 0xffff;
+        if (value >= 0xf000) value -= 0x10000;
+        if (value >= 0x8000) {
+            length = VRReadShort(fp);
+            value = VRReadShort(fp);
+            if (static_cast<unsigned short>(value) == 0x8878) {
+                CPLDebug("ViewrangerHV",
+                         "run, length %d, value %d",
+                         length, value);
+            }
+        }
+        if (value > max) {
+            max = value;
+        }
+        while ( length>0 ) {
+            length--;
+            *pnOutPixel-- = static_cast<short>(value);
+            if (pnOutPixel < pnBottomPixel) {
+                break;
+            }
+        }
+    }
+} // end VRHRasterBand::read_VRH_Tile()
+
+
+/* -------------------------------------------------------------------------
+ */
+void
+VRHRasterBand::read_VMC_Tile(VSILFILE *fp,
+                             int tile_xx, int tile_yy,
+                             void *pimage)
+{
+    if (tile_xx != 0 ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VMC_Tile %d %d out of range",
+                  tile_xx, tile_yy );
+        return ;
+    }
+    //if (tile_yy < 0 || tile_yy >= static_cast<VRHVDataset *>(poDS)->nRasterYSize)
+    if (tile_yy != 0)
+    {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VMC_Tile %d %d out of range",
+                  tile_xx, tile_yy );
+        return ;
+    }
+    if (pimage == nullptr ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VMC_Tile passed no image" );
+        return ;
+    }
+
+    int seekres=0;
+    if (static_cast<VRHVDataset *>(poDS)->nVRHVersion==1) {
+        CPLDebug("ViewrangerHV", "Seeking to byte 29 for version 1");
+        seekres = VSIFSeekL( fp, 29, SEEK_SET );
+    } else {
+        CPLDebug("ViewrangerHV", "Seeking to byte 41 for version 2");
+        seekres = VSIFSeekL( fp, 41, SEEK_SET );
+    }
+    if ( seekres!=0 ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to VMC data" );
+        return ;
+    }
+
+    auto* pnBottomPixel = static_cast<unsigned char*>(pimage);
+    // pnBottomPixel += static_cast<VRHVDataset *>(poDS)->nRasterYSize * tile_xx;
+
+    // char *pnOutPixel = pnBottomPixel + static_cast<VRHVDataset *>(poDS)->nRasterYSize - 1;
+
+    auto nCurrentData=static_cast<unsigned int>(VRReadChar(fp));
+    int nBitsLeft=8;
+    int nBytesRead=1;
+    int nMaxPix=0;
+    for (int x=0; x<nBlockXSize; x++) {
+        for (int y=nBlockYSize-1 ; y>=0; y--) {
+            int nPix = x + y*nBlockXSize;
+            if (nPix>nMaxPix) {
+                nMaxPix=nPix;
+            }
+            pnBottomPixel[nPix] =
+                    (nCurrentData & 1) ? nVMCYesData : nVMCNoData ;
+#if 0
+            if (x>nBlockXSize/2) {
+                pnBottomPixel[nPix] |= 128;
+            }
+            if (y>nBlockYSize/3) {
+                pnBottomPixel[nPix] |= 64;
+            }
+#endif
+#if 1
+            CPLDebug("ViewrangerHV", "read_VMC_Tile: %p %3d %3d [%06d] = x%02x x%02x %d/%d",
+                     pimage, x, y, nPix,
+                     pnBottomPixel[nPix],
+                     0xff&nCurrentData, nBytesRead, nBitsLeft);
+#endif
+            nCurrentData >>= 1;  nBitsLeft--;
+            if (nBitsLeft<=0) {
+                nCurrentData=static_cast<unsigned int>(VRReadChar(fp));
+                nBitsLeft=8;
+                nBytesRead++;
+            }
+        }
+    }
+    CPLDebug("ViewrangerHV", "read_VMC_Tile(%p %d %d %p %p)",
+             static_cast<void*>(fp), tile_xx, tile_yy, pimage, pnBottomPixel);
+    CPLDebug("ViewrangerHV", "read_VMC_Tile: x%02x %d/%d - pnBottomPixel %p furthest pix %d",
+             0xff&nCurrentData, nBytesRead, nBitsLeft, pnBottomPixel, nMaxPix);
+} // VRHRasterBand::read_VMC_Tile()
+
+
+/* -------------------------------------------------------------------------
+ */
+void
+VRHRasterBand::read_VRV_Tile(VSILFILE *fp,
+                             int tile_xx, int tile_yy,
+                             void *pimage)
+{
+    if (tile_xx != 0 ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VRV_Tile %d %d out of range",
+                  tile_xx, tile_yy );
+        return ;
+    }
+    if (tile_yy < 0 || tile_yy >= static_cast<VRHVDataset *>(poDS)->nRasterYSize)
+    {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VRV_Tile %d %d out of range",
+                  tile_xx, tile_yy );
+        return ;
+    }
+    if (pimage == nullptr ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "read_VRV_Tile passed no image" );
+        return ;
+    }
+
+    int seekres = VSIFSeekL( fp, 0x24, SEEK_SET );
+    if ( seekres ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to VRV data" );
+        return ;
+    }
+    vsi_l_offset string_length = VRReadUInt(fp);
+    seekres = VSIFSeekL( fp, 0x28+string_length, SEEK_SET );
+    if ( seekres ) {
+        CPLError( CE_Failure, CPLE_AppDefined,
+                  "cannot seek to VRV data" );
+        return ;
+    }
+
+    auto* pnBottomPixel = static_cast<char*>(pimage);
+    // pnBottomPixel += static_cast<VRHVDataset *>(poDS)->nRasterYSize * tile_xx;
+
+    // char *pnOutPixel = pnBottomPixel + static_cast<VRHVDataset *>(poDS)->nRasterYSize - 1;
+
+    int pixelnum = 0;
+    for (int x=0; x<nBlockXSize; x++) {
+        for (int y=nBlockYSize-1 ; y>=0; y--) {
+            int nPixel=VRReadChar(fp);
+            if (nPixel == 0) nPixel=nVRVNoData;
+            pnBottomPixel[y*nBlockXSize + x] = static_cast<char>(nPixel);
+
+#if 0
+            CPLDebug("ViewrangerHV", "read_VRV_Tile: %p %d %d %d [%d] = %d",
+                     pimage, x, y, pixelnum, y*nBlockXSize + x,
+                     (int)pnBottomPixel[y*nBlockXSize + x] );
+#endif
+
+            pixelnum++;
+        }
+    }
+    CPLDebug("ViewrangerHV", "read_VRV_Tile(%p %d %d %p %p)\n\tread %d = %d * %d pixels",
+             static_cast<void*>(fp), tile_xx, tile_yy, pimage, pnBottomPixel,
+             pixelnum, nBlockXSize, nBlockYSize);
+    (void)pixelnum; // cppcheck ignores CPLDebug args. Don't complain that pixelnum is never used.
+#if 0
+    // Could crash with small files (eg Switzerland1M.VRV is 2x2) ?
+    CPLDebug("ViewrangerHV", "read_VRV_Tile %p\t%02x %02x %02x %02x %02x %02x %02x %02x\t%02x %02x %02x %02x %02x %02x %02x %02x",
+             pnBottomPixel,
+             pnBottomPixel[0], pnBottomPixel[1], pnBottomPixel[2], pnBottomPixel[3],
+             pnBottomPixel[4], pnBottomPixel[5], pnBottomPixel[6], pnBottomPixel[7],
+             pnBottomPixel[8], pnBottomPixel[9], pnBottomPixel[10], pnBottomPixel[11],
+             pnBottomPixel[12], pnBottomPixel[13], pnBottomPixel[14], pnBottomPixel[15]
+             );
+#endif
+} // VRHRasterBand::read_VMC_Tile()
+
+
+/************************************************************************/
+/*                            GetFileList()                             */
+/************************************************************************/
+
+char **VRHVDataset::GetFileList()
+{
+    char **papszFileList = GDALPamDataset::GetFileList();
+
+    CPLDebug("ViewrangerHV", "GetDescription %s", GetDescription() );
+
+    // GDALReadWorldFile2 (gdal_misc.cpp) has code we need to copy
+#if 0
+    if (osWldFilename.size() != 0 &&
+        CSLFindString(papszFileList, osWldFilename) == -1)
+    {
+        papszFileList = CSLAddString( papszFileList, osWldFilename );
+    }
+#endif
+    return papszFileList;
+}
+
+//#endif // def FRMT_vrhv
+//#endif // def FRMT_vrc

--- a/gdal/frmts/vrc/VRHV.cpp
+++ b/gdal/frmts/vrc/VRHV.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * $Id: VRHV.cpp,v 1.101 2021/06/18 17:33:29 werdna Exp werdna $
+ * $Id: VRHV.cpp,v 1.102 2021/06/26 20:28:41 werdna Exp werdna $
  *
  * Project:  GDAL
  * Purpose:  Viewranger GDAL Driver
@@ -14,31 +14,9 @@
 //#ifdef FRMT_vrc
 //#ifdef FRMT_vrhv
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation-unknown-command" // 3 errors
-#pragma clang diagnostic ignored "-Wdouble-promotion"
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion" // 1 error
-#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override" // 1 error
-#pragma clang diagnostic ignored "-Wpadded"          // 11 errors
-#pragma clang diagnostic ignored "-Wsuggest-destructor-override"
-#pragma clang diagnostic ignored "-Wundef"
-#pragma clang diagnostic ignored "-Wreserved-id-macro"
-#pragma clang diagnostic ignored "-Wunknown-warning-option"
-#pragma clang diagnostic ignored "-Wunused-template" // 1 error
-#pragma clang diagnostic ignored "-Wweak-vtables"    // 1 error
+#include "VRCutils.h"
 
-#include "gdal_pam.h"
-#include "ogr_spatialref.h"
-
-#include "cpl_port.h"
-#include "cpl_string.h"
-
-#pragma clang diagnostic pop
-
-#include "VRC.h"
-
-CPL_CVSID("$Id: VRHV.cpp,v 1.101 2021/06/18 17:33:29 werdna Exp werdna $")
+CPL_CVSID("$Id: VRHV.cpp,v 1.102 2021/06/26 20:28:41 werdna Exp werdna $")
 
 CPL_C_START
 void   GDALRegister_VRHV(void);
@@ -70,8 +48,6 @@ static const unsigned int nVRVNoData = 255;
 
 // typedef struct {double lat; double lon; } latlon;
 
-
-#include "VRCutils.h"
 
 /************************************************************************/
 /* ==================================================================== */
@@ -598,20 +574,24 @@ CPLErr VRHVDataset::GetGeoTransform( double * padfTransform )
         // USA, Discovery (Spain) and some Belgium (VRH height) maps have coordinate unit of
         //   1 degree/ten million
         CPLDebug("ViewrangerHV", "country/srs 17 USA?Belgium?Discovery(Spain) grid is unknown. Current guess is unlikely to be correct.");
-#if 0 // standard until 20 Sept 2020
+        CPLDebug("ViewrangerHV", "raw position: TL: %d %d BR: %d %d",
+                 nTop,nLeft,nBottom,nRight);
+#if 1 // standard until 20 Sept 2020
         dLeft   /= tenMillion;
         dRight  /= tenMillion;
         dTop    /= tenMillion;
         dBottom /= tenMillion;
+        CPLDebug("ViewrangerHV", "scaling by 10 million: TL: %g %g BR: %g %g",
+                 dTop,dLeft,dBottom,dRight);
 #else
         const double nineMillion = 9.0 * 1000 * 1000;
         dLeft   /= nineMillion;
         dRight  /= nineMillion;
         dTop    /= nineMillion;
         dBottom /= nineMillion;
-#endif
-        CPLDebug("ViewrangerHV", "scaling by 10 million: TL: %g %g BR: %g %g",
+        CPLDebug("ViewrangerHV", "scaling by 9 million: TL: %g %g BR: %g %g",
                  dTop,dLeft,dBottom,dRight);
+#endif
     } else if (nCountry == 155) {
         // New South Wales srs is not quite GDA94/MGA55 EPSG:28355
         dLeft   = 1.0*nLeft;

--- a/gdal/frmts/vrc/makefile.vc
+++ b/gdal/frmts/vrc/makefile.vc
@@ -1,0 +1,30 @@
+
+OBJ	=	png_crc.obj VRC.obj VRCutils.obj VRCthirtysix.obj VRHV.obj
+
+GDAL_ROOT	=	..\..
+
+PLUGIN_DLL = gdal_JP2OpenJPEG.dll
+
+!INCLUDE $(GDAL_ROOT)\nmake.opt
+
+EXTRAFLAGS = -I.. $(VRC_CFLAGS)
+
+default:	$(OBJ)
+	xcopy /D  /Y *.obj ..\o
+
+clean:
+	-del *.obj
+	-del *.dll
+	-del *.exp
+	-del *.lib
+	-del *.manifest
+	
+plugin:	$(PLUGIN_DLL)
+
+$(PLUGIN_DLL): $(OBJ)
+	link /dll $(LDEBUG) /out:$(PLUGIN_DLL) $(OBJ) $(OPENJPEG_LIB) $(GDALLIB)
+	if exist $(PLUGIN_DLL).manifest mt -manifest $(PLUGIN_DLL).manifest -outputresource:$(PLUGIN_DLL);2
+
+plugin-install:
+	-mkdir $(PLUGINDIR)
+	$(INSTALL) $(PLUGIN_DLL) $(PLUGINDIR)

--- a/gdal/frmts/vrc/png_crc.c
+++ b/gdal/frmts/vrc/png_crc.c
@@ -1,0 +1,110 @@
+/*
+ * $Id: png_crc.c,v 1.9 2021/06/20 08:58:41 werdna Exp $
+ *
+ * http://www.libpng.org/pub/png/spec/1.2/PNG-CRCAppendix.html
+ *
+ */
+
+#include "png_crc.h"
+
+// This should be C not C++, so this is not needed ?
+// ... unless compiled with something like $(CC) ... -std=c++11
+CPL_C_START
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+// #include <unistd.h>
+
+// #include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+const unsigned long nBitsPerBytes=8;
+
+/* Table of CRCs of all 8-bit messages. */
+#define ncrc_table_size 256
+// static const
+unsigned long crc_table[ ncrc_table_size ]
+#if 1
+   =
+    {
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0
+    }
+#endif
+    ;
+
+/* Flag: has the table been computed? Initially false. */
+// static
+int crc_table_computed = 0;
+
+/* Make the table for a fast CRC. */
+static void make_crc_table(void)
+{
+    // unsigned int n, k;
+
+    unsigned long const crc_magic = 0xedb88320L;
+
+    for (unsigned int n = 0; n < ncrc_table_size; n++) {
+        unsigned long c = (unsigned long) n;
+        for (unsigned int k = 0; k < nBitsPerBytes; k++) {
+            if (c & 1U) {
+                c = crc_magic ^ (c >> 1U);
+            } else {
+                c = c >> 1U;
+            }
+        }
+        crc_table[n] = c;
+    }
+    crc_table_computed = 1;
+}
+
+/* Update a running CRC with the bytes buf[0..len-1]--the CRC
+   should be initialized to all 1's, and the transmitted value
+   is the 1's complement of the final running CRC (see the
+   crc() routine below)). */
+   
+static unsigned long update_crc(const unsigned long crc,
+                                const unsigned char *buf,
+                                const unsigned int len)
+{
+    unsigned long c = crc;
+    
+    if (!crc_table_computed) {
+        make_crc_table();
+    }
+    const unsigned char fullbyte = 0xff;
+    for (unsigned int n = 0; n < len; n++) {
+        c = crc_table[(c ^ buf[n]) & fullbyte] ^ (c >> nBitsPerBytes);
+    }
+    return c;
+}
+
+/* Return the CRC of the bytes buf[0..len-1]. */
+extern unsigned long pngcrc_for_VRC(const unsigned char *buf,
+                                    const unsigned int len)
+{
+    const unsigned long full32bits = 0xffffffffL;
+    return update_crc(full32bits, buf, len) ^ full32bits;
+}
+
+CPL_C_END
+

--- a/gdal/frmts/vrc/png_crc.h
+++ b/gdal/frmts/vrc/png_crc.h
@@ -1,0 +1,27 @@
+/*
+ * $Id: png_crc.h,v 1.7 2021/06/15 10:05:06 werdna Exp $
+ */
+
+#pragma once
+
+#ifndef PNG_CRC_H_INCLUDED
+#define PNG_CRC_H_INCLUDED
+
+#include <cpl_port.h>
+
+CPL_C_START
+      
+#ifdef INTERNAL_PNG
+#include "../png/libpng/png.h"
+#else
+#include <png.h>
+#endif
+
+/* Return the PNG CRC of the bytes buf[0..len-1]. */
+extern unsigned long pngcrc_for_VRC(
+                                    const unsigned char *buf,
+                                    const unsigned int len);
+
+CPL_C_END
+
+#endif // PNG_CRC_H_INCLUDED

--- a/gdal/gcore/gdal_frmts.h
+++ b/gdal/gcore/gdal_frmts.h
@@ -112,6 +112,7 @@ void CPL_DLL GDALRegister_HDF5Image(void);
 void CPL_DLL GDALRegister_MSGN(void);
 void CPL_DLL GDALRegister_MSG(void);
 void CPL_DLL GDALRegister_RIK(void);
+void CPL_DLL GDALRegister_VRC(void);
 void CPL_DLL GDALRegister_Leveller(void);
 void CPL_DLL GDALRegister_SGI(void);
 void CPL_DLL GDALRegister_SRTMHGT(void);


### PR DESCRIPTION
## What does this PR do?
This is a driver which adds read-only support for the viewranger .VRC raster file format.
Raster maps in this format were formerly available from https://www.viewranger.com/en-gb
Although there is DRM and we attempt to preserve and make available all DRM information,
there is no known encrypted data in the file and no decryption in the driver.
.
## What are related issues/pull requests?

## Tasklist

 - [ ] Write support for ViewRanger .VRC files
 - [ ] Should we also include support for ViewRanger .VRH height files?
 - [ ] Should we also include support for .VRV and .vmc files ? These are more about offline purchases.
 - [ ] Add test case(s)
 - [ ] Build on windows
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] Review
 - [ ] Squash commits in a single one.

## Environment
Provide environment details, if relevant:

* OS:Ubuntu 21.04
* Compiler: GNU v7.3.1, GNU v11, Clang v12
