### PR TITLE
WMS: use correct default bbox according to the SRS

### DIFF
--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -634,6 +634,11 @@ def test_wms_16():
     ds = gdal.Open(name)
     assert ds is not None, ('open of %s failed.' % name)
 
+    # check that the default bbox works for srs != EPSG:4326
+    name = 'http://demo.opengeo.org/geoserver/wms?SERVICE=WMS&request=GetMap&version=1.1.1&layers=og:bugsites&styles=&srs=EPSG:26713'
+    ds = gdal.Open(name)
+    assert ds is not None, ('open of %s failed.' % name)
+
     # Matches feature of "WFS:http://demo.opengeo.org/geoserver/wfs?SRSNAME=EPSG:900913" og:bugsites
     # OGRFeature(og:bugsites):68846
     #   gml_id (String) = bugsites.68846

--- a/gdal/frmts/wms/wmsdriver.cpp
+++ b/gdal/frmts/wms/wmsdriver.cpp
@@ -48,6 +48,7 @@
 
 #include <limits>
 #include <utility>
+#include <algorithm>
 
 CPL_CVSID("$Id$")
 
@@ -206,6 +207,7 @@ CPLXMLNode * GDALWMSDatasetGetConfigFromURL(GDALOpenInfo *poOpenInfo)
     const char* pszMinY = papszTokens[1];
     const char* pszMaxX = papszTokens[2];
     const char* pszMaxY = papszTokens[3];
+
 
     if (osBBOXOrder.compare("yxYX") == 0)
     {

--- a/gdal/frmts/wms/wmsdriver.cpp
+++ b/gdal/frmts/wms/wmsdriver.cpp
@@ -167,8 +167,13 @@ CPLXMLNode * GDALWMSDatasetGetConfigFromURL(GDALOpenInfo *poOpenInfo)
 
             double dfWestLongitudeDeg, dfSouthLatitudeDeg,
                     dfEastLongitudeDeg, dfNorthLatitudeDeg;
-            oSRS.GetAreaOfUse(&dfWestLongitudeDeg, &dfSouthLatitudeDeg,
-                    &dfEastLongitudeDeg, &dfNorthLatitudeDeg, nullptr);
+            if (!oSRS.GetAreaOfUse(&dfWestLongitudeDeg, &dfSouthLatitudeDeg,
+                    &dfEastLongitudeDeg, &dfNorthLatitudeDeg, nullptr))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                    "Failed retrieving a default bounding box for the requested SRS");
+                return nullptr;
+            }
             auto poCT = std::unique_ptr<OGRCoordinateTransformation>(
                     OGRCreateCoordinateTransformation(OGRSpatialReference::GetWGS84SRS(),
                                                         &oSRS));

--- a/gdal/frmts/wms/wmsdriver.cpp
+++ b/gdal/frmts/wms/wmsdriver.cpp
@@ -164,9 +164,13 @@ CPLXMLNode * GDALWMSDatasetGetConfigFromURL(GDALOpenInfo *poOpenInfo)
             oSRS.SetFromUserInput(osSRSValue);
             oSRS.AutoIdentifyEPSG();
 
-            double dfWestLongitudeDeg, dfSouthLatitudeDeg, dfEastLongitudeDeg, dfNorthLatitudeDeg;
-            oSRS.GetAreaOfUse(&dfWestLongitudeDeg, &dfSouthLatitudeDeg, &dfEastLongitudeDeg, &dfNorthLatitudeDeg, nullptr);
-            OGRCoordinateTransformation *poCT = OGRCreateCoordinateTransformation(OGRSpatialReference::GetWGS84SRS(), &oSRS);
+            double dfWestLongitudeDeg, dfSouthLatitudeDeg,
+                    dfEastLongitudeDeg, dfNorthLatitudeDeg;
+            oSRS.GetAreaOfUse(&dfWestLongitudeDeg, &dfSouthLatitudeDeg,
+                    &dfEastLongitudeDeg, &dfNorthLatitudeDeg, nullptr);
+            OGRCoordinateTransformation *poCT = 
+                    OGRCreateCoordinateTransformation(OGRSpatialReference::GetWGS84SRS(),
+                                                        &oSRS);
             poCT->Transform(1, &dfWestLongitudeDeg, &dfNorthLatitudeDeg);
             poCT->Transform(1, &dfEastLongitudeDeg, &dfSouthLatitudeDeg);
             const double dfMaxX = std::max(dfWestLongitudeDeg, dfEastLongitudeDeg);


### PR DESCRIPTION

## What does this PR do?

It sets the default `bbox` in the WMS driver according to the CRS (instead of a hard-coded WGS84 world extent)

## What are related issues/pull requests?

#4093 

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

