### PR TITLE
change the default urllib user-agent to avoid being blocked

### DIFF
--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1703,7 +1703,14 @@ def gdalurlopen(url, timeout=10):
         urllib.request.install_opener(opener)
 
     try:
-        handle = urllib.request.urlopen(url)
+        req = urllib.request.Request(
+            url,
+            data = None,
+            headers = {
+                'User-Agent': 'GDAL pytest'
+            }
+        )
+        handle = urllib.request.urlopen(req)
         socket.setdefaulttimeout(old_timeout)
         return handle
     except urllib.error.HTTPError as e:


### PR DESCRIPTION
## What does this PR do?

Changes the default User-Agent to avoid being blocked by some CDN providers (bad reputation?)

## What are related issues/pull requests?

#4095 

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

