### PR TITLE
VRT: more potential flt parameters for GetSrcDstWindow for consistency (fixes #4098)

### DIFF
--- a/gdal/frmts/vrt/vrtfilters.cpp
+++ b/gdal/frmts/vrt/vrtfilters.cpp
@@ -146,6 +146,18 @@ VRTFilteredSource::RasterIO( GDALDataType eBandDataType,
                                            psExtraArg );
     }
 
+    double dfXOff = nXOff;
+    double dfYOff = nYOff;
+    double dfXSize = nXSize;
+    double dfYSize = nYSize;
+    if( psExtraArg != nullptr && psExtraArg->bFloatingPointWindowValidity )
+    {
+        dfXOff = psExtraArg->dfXOff;
+        dfYOff = psExtraArg->dfYOff;
+        dfXSize = psExtraArg->dfXSize;
+        dfYSize = psExtraArg->dfYSize;
+    }
+
     // The window we will actually request from the source raster band.
     double dfReqXOff = 0.0;
     double dfReqYOff = 0.0;
@@ -162,7 +174,7 @@ VRTFilteredSource::RasterIO( GDALDataType eBandDataType,
     int nOutXSize = 0;
     int nOutYSize = 0;
 
-    if( !GetSrcDstWindow( nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize,
+    if( !GetSrcDstWindow( dfXOff, dfYOff, dfXSize, dfYSize, nBufXSize, nBufYSize,
                         &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                         &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
                         &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) )

--- a/gdal/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtsourcedrasterband.cpp
@@ -218,7 +218,7 @@ CPLErr VRTSourcedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
                 double dfYOff = nYOff;
                 double dfXSize = nXSize;
                 double dfYSize = nYSize;
-                if( psExtraArg != nullptr && psExtraArg->bFloatingPointWindowValidity )
+                if( psExtraArg->bFloatingPointWindowValidity )
                 {
                     dfXOff = psExtraArg->dfXOff;
                     dfYOff = psExtraArg->dfYOff;

--- a/gdal/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtsourcedrasterband.cpp
@@ -213,6 +213,19 @@ CPLErr VRTSourcedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
             {
                 VRTSimpleSource* const poSource
                     = static_cast<VRTSimpleSource *>( papoSources[i] );
+
+                double dfXOff = nXOff;
+                double dfYOff = nYOff;
+                double dfXSize = nXSize;
+                double dfYSize = nYSize;
+                if( psExtraArg != nullptr && psExtraArg->bFloatingPointWindowValidity )
+                {
+                    dfXOff = psExtraArg->dfXOff;
+                    dfYOff = psExtraArg->dfYOff;
+                    dfXSize = psExtraArg->dfXSize;
+                    dfYSize = psExtraArg->dfYSize;
+                }
+
                 // The window we will actually request from the source raster band.
                 double dfReqXOff = 0.0;
                 double dfReqYOff = 0.0;
@@ -229,7 +242,7 @@ CPLErr VRTSourcedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
                 int nOutXSize = 0;
                 int nOutYSize = 0;
 
-                if( !poSource->GetSrcDstWindow( nXOff, nYOff, nXSize, nYSize,
+                if( !poSource->GetSrcDstWindow( dfXOff, dfYOff, dfXSize, dfYSize,
                                       nBufXSize, nBufYSize,
                                       &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                                       &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,


### PR DESCRIPTION
A follow up on #4099 to include a few extra cases where we could pass psExtraArgs to GetSrcDstWindow.