### PR TITLE
XLS: Set OLCStringsAsUTF8 capability to TRUE

### DIFF
--- a/gdal/ogr/ogrsf_frmts/xls/ogrxlslayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/xls/ogrxlslayer.cpp
@@ -340,6 +340,8 @@ int OGRXLSLayer::TestCapability( const char * pszCap )
 {
     if( EQUAL(pszCap, OLCFastFeatureCount) )
         return m_poAttrQuery == nullptr /* && m_poFilterGeom == NULL */;
+    else if( EQUAL(pszCap, OLCStringsAsUTF8) )
+        return TRUE;
 
     return FALSE;
 }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Sets the OLCStringsAsUTF8 capability to TRUE for XLS layers.

## What are related issues/pull requests?

See https://lists.osgeo.org/pipermail/qgis-developer/2021-July/063855.html

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

