### PR TITLE
[kmlsuperoverlay] Allow reading kml documents with a GroundOverlay element directly inside a Document element

### DIFF
--- a/autotest/gdrivers/data/kml/small_world_in_document_pct.kml
+++ b/autotest/gdrivers/data/kml/small_world_in_document_pct.kml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+<GroundOverlay>
+<name>small_world</name>
+<color>ffffffff</color>
+<Icon>
+<href>../small_world_pct.tif</href>
+<viewBoundScale>1</viewBoundScale>
+</Icon>
+<LatLonBox>
+<north>90</north>
+<south>-90</south>
+<east>180</east>
+<west>-180</west>
+</LatLonBox>
+</GroundOverlay>
+</Document>
+</kml>

--- a/autotest/gdrivers/kmlsuperoverlay.py
+++ b/autotest/gdrivers/kmlsuperoverlay.py
@@ -307,6 +307,22 @@ def test_kmlsuperoverlay_single_overlay_document_folder_pct():
     assert ds.GetRasterBand(1).GetColorTable()
 
 ###############################################################################
+# Test raster KML with single Overlay, with no Folder element
+
+
+def test_kmlsuperoverlay_single_overlay_document_pct():
+
+    ds = gdal.Open('data/kml/small_world_in_document_pct.kml')
+    assert ds.GetProjectionRef().find('WGS_1984') >= 0
+    got_gt = ds.GetGeoTransform()
+    ref_gt = [-180.0, 0.9, 0.0, 90.0, 0.0, -0.9]
+    for i in range(6):
+        assert got_gt[i] == pytest.approx(ref_gt[i], abs=1e-6)
+
+    assert ds.GetRasterBand(1).GetRasterColorInterpretation() == gdal.GCI_PaletteIndex
+    assert ds.GetRasterBand(1).GetColorTable()
+
+###############################################################################
 # Test that a raster with lots of blank space doesn't have unnecessary child
 # KML/PNG files in transparent areas
 

--- a/gdal/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/gdal/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -2469,11 +2469,10 @@ GDALDataset* KmlSingleOverlayRasterDataset::Open(const char* pszFilename,
                     return nullptr;
             }
         }
-        if( psFolder == nullptr )
-        {
-            return nullptr;
-        }
-        for( auto psIter = psFolder->psChild; psIter; psIter = psIter->psNext )
+
+        // folder is not mandatory -- some kml have a structure kml.Document.GroundOverlay
+        CPLXMLNode* psParent = psFolder != nullptr ? psFolder : psDoc;
+        for( auto psIter = psParent->psChild; psIter; psIter = psIter->psNext )
         {
             if( psIter->eType == CXT_Element &&
                 strcmp(psIter->pszValue, "GroundOverlay") == 0 )


### PR DESCRIPTION
Previously only GroundElements which were placed inside a Document > Folder element were supported, but this Folder element is not mandatory.