### PR TITLE
fix the function name to match the text

### DIFF
--- a/gdal/doc/source/drivers/raster/vrt.rst
+++ b/gdal/doc/source/drivers/raster/vrt.rst
@@ -895,7 +895,7 @@ with derived bands that use this function), an application calls
 
 .. code-block:: cpp
 
-    GDALAddDerivedBandPixelFunc("MyFirstFunction", TestFunction, nullptr);
+    GDALAddDerivedBandPixelFuncWithArgs("MyFirstFunction", TestFunction, nullptr);
 
 A good time to do this is at the beginning of an application when the
 GDAL drivers are registered.


### PR DESCRIPTION
Small documentation fix to the Raster VRT "Writing Pixel Functions" block.