### PR TITLE
gdal/doc/source/programs/gdalcompare.rst - update the docs to reference `osgeo_utils`

### DIFF
--- a/gdal/doc/source/programs/gdalcompare.rst
+++ b/gdal/doc/source/programs/gdalcompare.rst
@@ -46,8 +46,8 @@ count of 1 (the binary difference) should be considered acceptable.
     The file being compared to the golden file, referred to as the new
     file.
 
-Note that the :program:`gdalcompare.py` script can also be called as a library from
-python code though it is not typically in the python path for including.
+Note that the :program:`gdalcompare.py` script (like all the other scripts)
+can also be called as a library from python code: `from osgeo_utils import gdalcompare`.
 The primary entry point is `gdalcompare.compare()` which takes a golden
 `gdal.Dataset` and a new `gdal.Dataset` as arguments and returns a
 difference count (excluding the binary comparison). The


### PR DESCRIPTION
## What does this PR do?

gdalcompare.rst - update the docs to reference `osgeo_utils`

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/4128
