### PR TITLE
gdal_calc.py - fix `hideNoData` for input: `NoDataValue!='none'`, `hideNoData=True`

### DIFF
--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -368,8 +368,7 @@ def Calc(calc: MaybeSequence[str], outfile: Optional[PathLikeOrStr] = None, NoDa
             myOut.SetProjection(ProjectionCheck)
 
         if NoDataValue is None:
-            myOutNDV = None if hideNoData else DefaultNDVLookup[
-                myOutType]  # use the default noDataValue for this datatype
+            myOutNDV = DefaultNDVLookup[myOutType]  # use the default noDataValue for this datatype
         elif isinstance(NoDataValue, str) and NoDataValue.lower() == 'none':
             myOutNDV = None  # not to set any noDataValue
         else:
@@ -387,6 +386,9 @@ def Calc(calc: MaybeSequence[str], outfile: Optional[PathLikeOrStr] = None, NoDa
                 myOutB.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
 
             myOutB = None  # write to band
+
+        if hideNoData:
+            myOutNDV = None
 
     myOutTypeName = gdal.GetDataTypeName(myOutType)
     if debug:


### PR DESCRIPTION
## What does this PR do?

gdal_calc.py - fix `hideNoData` for input: `NoDataValue!='none'`, `hideNoData=True`

This fix is for the case that the user wants to set ndv to the output ds and also wants the calc operation to ignore the input ndv while performing the calculation itself.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
