### PR TITLE
[backport #4136] gdal_calc.py - fix hideNoData for input: NoDataValue!='none', hideNoData=True

### DIFF
--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -351,7 +351,7 @@ def doit(opts):
             myOut.SetProjection(ProjectionCheck)
 
         if opts.NoDataValue is None:
-            myOutNDV = None if opts.hideNoData else DefaultNDVLookup[
+            myOutNDV = DefaultNDVLookup[
                 myOutType]  # use the default noDataValue for this datatype
         elif isinstance(opts.NoDataValue, str) and opts.NoDataValue.lower() == 'none':
             myOutNDV = None  # not to set any noDataValue
@@ -370,6 +370,9 @@ def doit(opts):
                 myOutB.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
 
             myOutB = None  # write to band
+
+        if opts.hideNoData:
+            myOutNDV = None
 
     myOutTypeName = gdal.GetDataTypeName(myOutType)
     if opts.debug:


### PR DESCRIPTION
backport https://github.com/OSGeo/gdal/pull/4136