### PR TITLE
Add STACIT (Spatio-Temporal Asset Catalog Items) raster driver 

### DIFF
--- a/autotest/gdrivers/data/stacit/overlapping_sources.json
+++ b/autotest/gdrivers/data/stacit/overlapping_sources.json
@@ -1,0 +1,151 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0-beta.2",
+  "stac_extensions": [],
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "byte",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-25T00:00:00Z",
+        "proj:epsg": 26711,
+      },
+      "collection": "my_collection",
+      "assets": {
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.4439,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "href": "data/byte.tif",
+          "proj:bbox": [
+            440720.000, 3750120.000,
+            441920.000, 3751320.000
+          ],
+          "proj:transform": [
+            60,
+            0,
+            440720,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "under",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-19T10:57:30Z",
+        "proj:epsg": 26711,
+      },
+      "collection": "my_collection",
+      "assets": {
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.4439,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "href": "data/under.tif",
+          "proj:bbox": [
+            440720.000, 3750120.000,
+            441920.000, 3751320.000
+          ],
+          "proj:transform": [
+            60,
+            0,
+            440720,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "anotherunder",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-22T00:00:00Z",
+        "proj:epsg": 26711,
+      },
+      "collection": "my_collection",
+      "assets": {
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.4439,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "href": "data/anotherunder.tif",
+          "proj:bbox": [
+            440720.000, 3750120.000,
+            441920.000, 3751320.000
+          ],
+          "proj:transform": [
+            60,
+            0,
+            440720,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/autotest/gdrivers/data/stacit/test.json
+++ b/autotest/gdrivers/data/stacit/test.json
@@ -1,0 +1,66 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0-beta.2",
+  "stac_extensions": [],
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "byte",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-19T10:57:30Z",
+        "proj:epsg": 26711,
+      },
+      "collection": "my_collection",
+      "assets": {
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://example.com/metadata.xml"
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.4439,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "href": "data/byte.tif",
+          "proj:bbox": [
+            440720.000, 3750120.000,
+            441920.000, 3751320.000
+          ],
+          "proj:transform": [
+            60,
+            0,
+            440720,
+            0,
+            -60,
+            3751320
+          ]
+        }
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": "next",
+      "href": "data/stacit/test_page2.json"
+    }
+  ]
+}

--- a/autotest/gdrivers/data/stacit/test_multiple_assets.json
+++ b/autotest/gdrivers/data/stacit/test_multiple_assets.json
@@ -1,0 +1,166 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0-beta.2",
+  "stac_extensions": [],
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "byte",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-19T10:57:30Z",
+        "proj:epsg": 26711,
+      },
+      "collection": "my_collection",
+      "assets": {
+        "B01": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01"
+            }
+          ],
+          "href": "data/byte.tif",
+          "proj:shape": [
+            20,
+            20
+          ],
+          "proj:transform": [
+            60,
+            0,
+            440720,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        },
+        "B02": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B02"
+            }
+          ],
+          "href": "data/byte.tif",
+          "proj:shape": [
+            20,
+            20
+          ],
+          "proj:transform": [
+            60,
+            0,
+            -440720,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "int16",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-19T10:57:30Z",
+        "proj:epsg": 26712,
+      },
+      "collection": "my_collection",
+      "assets": {
+        "B01": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01"
+            }
+          ],
+          "href": "data/int16.tif",
+          "proj:shape": [
+            20,
+            20
+          ],
+          "proj:transform": [
+            60,
+            0,
+            440720,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "int16",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-19T10:57:30Z",
+        "proj:epsg": 26713,
+      },
+      "collection": "my_collection2",
+      "assets": {
+        "B01": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01"
+            }
+          ],
+          "href": "data/int16.tif",
+          "proj:shape": [
+            20,
+            20
+          ],
+          "proj:transform": [
+            60,
+            0,
+            440720,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/autotest/gdrivers/data/stacit/test_page2.json
+++ b/autotest/gdrivers/data/stacit/test_page2.json
@@ -1,0 +1,55 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0-beta.2",
+  "stac_extensions": [],
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": [
+        "eo",
+        "proj"
+      ],
+      "id": "int16",
+      "geometry": null,
+      "properties": {
+        "datetime": "2021-07-19T10:57:30Z",
+      },
+      "collection": "my_collection",
+      "assets": {
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.4439,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "href": "data/int16.tif",
+          "proj:epsg": 26711,
+          "proj:shape": [
+            20,
+            20
+          ],
+          "proj:transform": [
+            60,
+            0,
+            441920,
+            0,
+            -60,
+            3751320,
+            0,
+            0,
+            1
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -125,7 +125,21 @@ def test_sentinel2_l1c_1():
             ds = gdal.Open(name)
         assert ds is None, name
 
-    
+###############################################################################
+
+
+def strip_source_properties(xml):
+    pos = 0
+    while True:
+        pos = xml.find('      <SourceProperties', pos)
+        if pos == -1:
+            break
+        pos2 = xml.find('>\n', pos)
+        assert pos2 != -1
+        xml = xml[0:pos] + xml[pos2+2:]
+
+    return xml
+
 ###############################################################################
 # Test opening a L1C subdataset on the 10m bands
 
@@ -179,18 +193,16 @@ def test_sentinel2_l1c_2():
 
     assert ds.RasterCount == 4
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/IMG_DATA/S2A_OPER_MSI_L1C_T32TQR_B08.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="10980" RasterYSize="10980" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
       <DstRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
     </SimpleSource>
     <SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TRQ_N01.03/IMG_DATA/S2A_OPER_MSI_L1C_T32TRQ_B08.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="10980" RasterYSize="10980" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
       <DstRect xOff="10004" yOff="10000" xSize="10980" ySize="10980" />
     </SimpleSource>"""
@@ -235,7 +247,7 @@ def test_sentinel2_l1c_2():
         pprint.pprint(got_md)
         pytest.fail()
 
-    
+
 ###############################################################################
 # Test opening a L1C subdataset on the 60m bands and enabling alpha band
 
@@ -620,7 +632,7 @@ def test_sentinel2_l1c_tile_1():
             ds = gdal.Open(name)
         assert ds is None, name
 
-    
+
 ###############################################################################
 # Test opening a L1C tile without main MTD file
 
@@ -660,7 +672,7 @@ def test_sentinel2_l1c_tile_2():
         pprint.pprint(got_md)
         pytest.fail()
 
-    
+
 ###############################################################################
 # Test opening a L1C tile subdataset on the 10m bands
 
@@ -718,11 +730,10 @@ def test_sentinel2_l1c_tile_3():
 
     assert ds.RasterCount == 4
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/IMG_DATA/S2A_OPER_MSI_L1C_T32TQR_B08.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="10980" RasterYSize="10980" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
       <DstRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
     </SimpleSource>"""
@@ -767,7 +778,7 @@ def test_sentinel2_l1c_tile_3():
         pprint.pprint(got_md)
         pytest.fail()
 
-    
+
 ###############################################################################
 # Test opening a L1C tile subdataset on the 10m bands without main MTD file
 
@@ -802,11 +813,10 @@ def test_sentinel2_l1c_tile_4():
 
     assert ds.RasterCount == 5
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/IMG_DATA/S2A_OPER_MSI_L1C_T32TQR_B08.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="10980" RasterYSize="10980" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
       <DstRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
     </SimpleSource>"""
@@ -856,11 +866,10 @@ def test_sentinel2_l1c_tile_5():
 
     assert ds.RasterCount == 3
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/QI_DATA/S2A_OPER_PVI_L1C_T32TQR.jp2</SourceFilename>
       <SourceBand>3</SourceBand>
-      <SourceProperties RasterXSize="343" RasterYSize="343" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="343" ySize="343" />
       <DstRect xOff="0" yOff="0" xSize="343" ySize="343" />
     </SimpleSource>"""
@@ -991,7 +1000,7 @@ def test_sentinel2_l1b_1():
             ds = gdal.Open(name)
         assert ds is None, name
 
-    
+
 ###############################################################################
 # Test opening a L1B granule
 
@@ -1069,7 +1078,7 @@ def test_sentinel2_l1b_2():
         pprint.pprint(got_md)
         pytest.fail()
 
-    
+
 ###############################################################################
 # Test opening a L1B subdataset
 
@@ -1159,11 +1168,10 @@ def test_sentinel2_l1b_3():
 
     assert ds.RasterCount == 3
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1b/S2B_OPER_PRD_MSIL1B.SAFE/GRANULE/S2B_OPER_MSI_L1B_N01.03/IMG_DATA/S2B_OPER_MSI_L1B_B01.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="1276" RasterYSize="384" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="1276" ySize="384" />
       <DstRect xOff="0" yOff="0" xSize="1276" ySize="384" />
     </SimpleSource>"""
@@ -1557,7 +1565,7 @@ def test_sentinel2_l2a_1():
             ds = gdal.Open(name)
         assert ds is None, name
 
-    
+
 ###############################################################################
 # Test opening a L21 subdataset on the 60m bands
 
@@ -1633,11 +1641,10 @@ def test_sentinel2_l2a_2():
 
     assert ds.RasterCount == 17
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l2a/S2A_USER_PRD_MSIL2A.SAFE/GRANULE/S2A_USER_MSI_L2A_T32TQR_N01.03/IMG_DATA/R60m/S2A_USER_MSI_L2A_T32TQR_B01_60m.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="1830" RasterYSize="1830" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="1830" ySize="1830" />
       <DstRect xOff="0" yOff="0" xSize="1830" ySize="1830" />
     </SimpleSource>"""
@@ -1696,7 +1703,7 @@ def test_sentinel2_l2a_2():
         pprint.pprint(got_categories)
         pytest.fail()
 
-    
+
 ###############################################################################
 # Test opening invalid XML files
 
@@ -1877,7 +1884,7 @@ def test_sentinel2_l2a_4():
             ds = gdal.Open(name)
         assert ds is None, name
 
-    
+
 
 ###############################################################################
 # Test opening a L2A MSIL2A subdataset on the 60m bands
@@ -1953,11 +1960,10 @@ def test_sentinel2_l2a_5():
 
     assert ds.RasterCount == 7
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/GRANULE/L2A_T34VFJ_A016478_20180818T094030/IMG_DATA/R60m/T34VFJ_20180818T094031_B01_60m.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="1830" RasterYSize="1830" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="1830" ySize="1830" />
       <DstRect xOff="0" yOff="0" xSize="1830" ySize="1830" />
     </SimpleSource>"""
@@ -2096,7 +2102,7 @@ def test_sentinel2_l2a_6():
             ds = gdal.Open(name)
         assert ds is None, name
 
-    
+
 
 ###############################################################################
 # Test opening a L2A MSIL2Ap subdataset on the 60m bands
@@ -2177,11 +2183,10 @@ def test_sentinel2_l2a_7():
 
     assert ds.RasterCount == 7
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l2a_MSIL2Ap/S2A_MSIL2A_20170823T094031_N0205_R036_T34VFJ_20170823T094252.SAFE/GRANULE/L2A_T34VFJ_A011330_20170823T094252/IMG_DATA/R60m/L2A_T34VFJ_20170823T094031_B01_60m.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="1830" RasterYSize="1830" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="1830" ySize="1830" />
       <DstRect xOff="0" yOff="0" xSize="1830" ySize="1830" />
     </SimpleSource>"""
@@ -2294,7 +2299,7 @@ def test_sentinel2_l1c_safe_compact_1():
             assert ds is not None
             os.unlink('tmp/S2A_MSIL1C_test.zip')
 
-    
+
 ###############################################################################
 # Test opening a L1C Safe Compact subdataset on the 10m bands
 
@@ -2348,11 +2353,10 @@ def test_sentinel2_l1c_safe_compact_2():
 
     assert ds.RasterCount == 4
 
-    vrt = ds.GetMetadata('xml:VRT')[0]
+    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c_safecompact/S2A_MSIL1C_test.SAFE/GRANULE/FOO/IMG_DATA/BAR_B04.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="10980" RasterYSize="10980" DataType="UInt16" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
       <DstRect xOff="0" yOff="0" xSize="10980" ySize="10980" />
     </SimpleSource>
@@ -2398,7 +2402,7 @@ def test_sentinel2_l1c_safe_compact_2():
         pprint.pprint(got_md)
         pytest.fail()
 
-    
+
 ###############################################################################
 # Test opening a L1C subdataset on the TCI bands
 

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -126,21 +126,6 @@ def test_sentinel2_l1c_1():
         assert ds is None, name
 
 ###############################################################################
-
-
-def strip_source_properties(xml):
-    pos = 0
-    while True:
-        pos = xml.find('      <SourceProperties', pos)
-        if pos == -1:
-            break
-        pos2 = xml.find('>\n', pos)
-        assert pos2 != -1
-        xml = xml[0:pos] + xml[pos2+2:]
-
-    return xml
-
-###############################################################################
 # Test opening a L1C subdataset on the 10m bands
 
 
@@ -193,7 +178,7 @@ def test_sentinel2_l1c_2():
 
     assert ds.RasterCount == 4
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/IMG_DATA/S2A_OPER_MSI_L1C_T32TQR_B08.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
@@ -730,7 +715,7 @@ def test_sentinel2_l1c_tile_3():
 
     assert ds.RasterCount == 4
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/IMG_DATA/S2A_OPER_MSI_L1C_T32TQR_B08.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
@@ -813,7 +798,7 @@ def test_sentinel2_l1c_tile_4():
 
     assert ds.RasterCount == 5
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/IMG_DATA/S2A_OPER_MSI_L1C_T32TQR_B08.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
@@ -866,7 +851,7 @@ def test_sentinel2_l1c_tile_5():
 
     assert ds.RasterCount == 3
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/QI_DATA/S2A_OPER_PVI_L1C_T32TQR.jp2</SourceFilename>
       <SourceBand>3</SourceBand>
@@ -1168,7 +1153,7 @@ def test_sentinel2_l1b_3():
 
     assert ds.RasterCount == 3
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1b/S2B_OPER_PRD_MSIL1B.SAFE/GRANULE/S2B_OPER_MSI_L1B_N01.03/IMG_DATA/S2B_OPER_MSI_L1B_B01.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
@@ -1641,7 +1626,7 @@ def test_sentinel2_l2a_2():
 
     assert ds.RasterCount == 17
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l2a/S2A_USER_PRD_MSIL2A.SAFE/GRANULE/S2A_USER_MSI_L2A_T32TQR_N01.03/IMG_DATA/R60m/S2A_USER_MSI_L2A_T32TQR_B01_60m.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
@@ -1960,7 +1945,7 @@ def test_sentinel2_l2a_5():
 
     assert ds.RasterCount == 7
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/GRANULE/L2A_T34VFJ_A016478_20180818T094030/IMG_DATA/R60m/T34VFJ_20180818T094031_B01_60m.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
@@ -2183,7 +2168,7 @@ def test_sentinel2_l2a_7():
 
     assert ds.RasterCount == 7
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l2a_MSIL2Ap/S2A_MSIL2A_20170823T094031_N0205_R036_T34VFJ_20170823T094252.SAFE/GRANULE/L2A_T34VFJ_A011330_20170823T094252/IMG_DATA/R60m/L2A_T34VFJ_20170823T094031_B01_60m.jp2</SourceFilename>
       <SourceBand>1</SourceBand>
@@ -2353,7 +2338,7 @@ def test_sentinel2_l1c_safe_compact_2():
 
     assert ds.RasterCount == 4
 
-    vrt = strip_source_properties(ds.GetMetadata('xml:VRT')[0])
+    vrt = ds.GetMetadata('xml:VRT')[0]
     placement_vrt = """<SimpleSource>
       <SourceFilename relativeToVRT="0">data/sentinel2/fake_l1c_safecompact/S2A_MSIL1C_test.SAFE/GRANULE/FOO/IMG_DATA/BAR_B04.jp2</SourceFilename>
       <SourceBand>1</SourceBand>

--- a/autotest/gdrivers/stacit.py
+++ b/autotest/gdrivers/stacit.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env pytest
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test STACIT driver
+# Author:   Even Rouault <even.rouault@spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2021, Even Rouault <even.rouault@spatialys.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import gdaltest
+import pytest
+
+from osgeo import gdal
+
+pytestmark = pytest.mark.require_driver('STACIT')
+
+
+def test_stacit_basic():
+
+    ds = gdal.Open('data/stacit/test.json')
+    assert ds is not None
+    assert ds.RasterCount == 1
+    assert ds.RasterXSize == 40
+    assert ds.RasterYSize == 20
+    assert ds.GetSpatialRef().GetName() == 'NAD27 / UTM zone 11N'
+    assert ds.GetGeoTransform() == pytest.approx([440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0], rel=1e-8)
+    assert ds.GetRasterBand(1).GetNoDataValue() is None
+
+    vrt = ds.GetMetadata('xml:VRT')[0]
+    placement_vrt = """<SimpleSource>
+      <SourceFilename relativeToVRT="0">data/byte.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
+      <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/int16.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
+      <DstRect xOff="20" yOff="0" xSize="20" ySize="20" />
+    </SimpleSource>"""
+    assert placement_vrt in vrt
+
+    assert ds.GetRasterBand(1).Checksum() == 9239
+
+
+def test_stacit_max_items():
+
+    ds = gdal.OpenEx('data/stacit/test.json', open_options=['MAX_ITEMS=1'])
+    assert ds is not None
+    assert ds.RasterXSize == 20
+    assert ds.GetRasterBand(1).Checksum() == 4672
+
+
+def test_stacit_multiple_assets():
+
+    ds = gdal.Open('data/stacit/test_multiple_assets.json')
+    assert ds is not None
+    assert ds.RasterCount == 0
+    subds = ds.GetSubDatasets()
+    assert subds == [
+        ('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection,asset=B01,crs=EPSG_26711',
+         'Collection my_collection, Asset B01 of data/stacit/test_multiple_assets.json in CRS EPSG:26711'),
+        ('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection,asset=B01,crs=EPSG_26712',
+         'Collection my_collection, Asset B01 of data/stacit/test_multiple_assets.json in CRS EPSG:26712'),
+        ('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection,asset=B02',
+         'Collection my_collection, Asset B02 of data/stacit/test_multiple_assets.json'),
+        ('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection2,asset=B01',
+         'Collection my_collection2, Asset B01 of data/stacit/test_multiple_assets.json'),
+    ]
+
+    ds = gdal.Open('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection,asset=B01,crs=EPSG_26711')
+    assert ds.RasterXSize == 20
+    assert ds.RasterYSize == 20
+    assert ds.GetSpatialRef().GetName() == 'NAD27 / UTM zone 11N'
+    assert ds.GetGeoTransform() == pytest.approx([440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0], rel=1e-8)
+
+    ds = gdal.Open('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection,asset=B01,crs=EPSG_26712')
+    assert ds.RasterXSize == 20
+    assert ds.RasterYSize == 20
+    assert ds.GetSpatialRef().GetName() == 'NAD27 / UTM zone 12N'
+    assert ds.GetGeoTransform() == pytest.approx([440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0], rel=1e-8)
+
+    ds = gdal.Open('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection,asset=B02')
+    assert ds.RasterXSize == 20
+    assert ds.RasterYSize == 20
+    assert ds.GetSpatialRef().GetName() == 'NAD27 / UTM zone 11N'
+    assert ds.GetGeoTransform() == pytest.approx([-440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0], rel=1e-8)
+
+    ds = gdal.Open('STACIT:"data/stacit/test_multiple_assets.json":collection=my_collection2,asset=B01')
+    assert ds.RasterXSize == 20
+    assert ds.RasterYSize == 20
+    assert ds.GetSpatialRef().GetName() == 'NAD27 / UTM zone 13N'
+    assert ds.GetGeoTransform() == pytest.approx([440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0], rel=1e-8)
+
+    with gdaltest.error_handler():
+        ds = gdal.Open('STACIT:"data/stacit/test_multiple_assets.json":collection=i_dont_exist')
+    assert ds is None
+
+    with gdaltest.error_handler():
+        ds = gdal.Open('STACIT:"data/stacit/test_multiple_assets.json":asset=i_dont_exist')
+    assert ds is None

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -71,11 +71,8 @@ def test_vrtderived_1():
     expected_md_read = (
         '<SimpleSource>\n'
         '  <SourceFilename relativeToVRT="0">data/byte.tif</SourceFilename>\n'
-        '  <SourceBand>1</SourceBand>\n'
-        '  <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" '
-        'BlockXSize="20" BlockYSize="20" />\n'
-        '</SimpleSource>\n')
-    assert md_read['source_0'] == expected_md_read
+        '  <SourceBand>1</SourceBand>\n')
+    assert expected_md_read in md_read['source_0']
 
     xmlstring = open(filename).read()
     gdal.Unlink(filename)

--- a/gdal/configure
+++ b/gdal/configure
@@ -1064,6 +1064,7 @@ enable_driver_sentinel2
 enable_driver_sgi
 enable_driver_sigdem
 enable_driver_srtmhgt
+enable_driver_stacit
 enable_driver_stacta
 enable_driver_terragen
 enable_driver_tga
@@ -1969,6 +1970,7 @@ Optional Features:
   --disable-driver-sigdem disable sigdem driver support (enabled by default)
   --disable-driver-srtmhgt
                           disable srtmhgt driver support (enabled by default)
+  --disable-driver-stacit disable stacit driver support (enabled by default)
   --disable-driver-stacta disable stacta driver support (enabled by default)
   --disable-driver-terragen
                           disable terragen driver support (enabled by default)
@@ -27927,6 +27929,34 @@ if test "$cur_driver_enabled" = "yes"; then :
 else
   GDALFORMATS_DISABLED="$GDALFORMATS_DISABLED srtmhgt"
   INTERNAL_FORMAT_srtmhgt_ENABLED=no
+fi
+
+# Check whether --enable-driver-stacit was given.
+if test "${enable_driver_stacit+set}" = set; then :
+  enableval=$enable_driver_stacit;
+fi
+cur_driver_enabled=yes
+requested=$enable_driver_stacit
+if test "$all_drivers_disabled" = "yes"; then :
+  if test "x$requested" = "xyes"; then :
+    cur_driver_enabled=yes
+  else
+    cur_driver_enabled=no
+  fi
+else
+  if test "x$requested" != "xno"; then :
+    cur_driver_enabled=yes
+  else
+    cur_driver_enabled=no
+  fi
+fi
+
+if test "$cur_driver_enabled" = "yes"; then :
+  GDALFORMATS_ENABLED="$GDALFORMATS_ENABLED stacit"
+  INTERNAL_FORMAT_stacit_ENABLED=yes
+else
+  GDALFORMATS_DISABLED="$GDALFORMATS_DISABLED stacit"
+  INTERNAL_FORMAT_stacit_ENABLED=no
 fi
 
 # Check whether --enable-driver-stacta was given.

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -1770,7 +1770,7 @@ OGRFORMATS_ENABLED=
 OGRFORMATS_ENABLED_CFLAGS=
 OGRFORMATS_DISABLED=
 
-AC_DEFUN([INTERNAL_FORMATS],[aaigrid adrg aigrid airsar arg blx bmp bsb cals ceos ceos2 coasp cosar ctg dimap dted elas envisat ers esric fit gff gsg gxf hf2 idrisi ilwis ingr iris iso8211 jaxapalsar jdem kmlsuperoverlay l1b leveller map mrf msgn ngsgeoid nitf northwood pds prf r raw rmf rs2 safe saga sdts sentinel2 sgi sigdem srtmhgt stacta terragen tga til tsx usgsdem xpm xyz zarr zmap])
+AC_DEFUN([INTERNAL_FORMATS],[aaigrid adrg aigrid airsar arg blx bmp bsb cals ceos ceos2 coasp cosar ctg dimap dted elas envisat ers esric fit gff gsg gxf hf2 idrisi ilwis ingr iris iso8211 jaxapalsar jdem kmlsuperoverlay l1b leveller map mrf msgn ngsgeoid nitf northwood pds prf r raw rmf rs2 safe saga sdts sentinel2 sgi sigdem srtmhgt stacit stacta terragen tga til tsx usgsdem xpm xyz zarr zmap])
 AC_DEFUN([INTERNAL_OPT_FORMATS],[grib ozi pdf rik])
 AC_DEFUN([INTERNAL_DRIVERS],[arcgen avc cad csv dgn dxf edigeo flatgeobuf geoconcept georss gml gmt gpsbabel gpx gtm jml mapml mvt ntf openfilegdb pgdump rec s57 selafin shape svg sxf tiger vdv wasp])dnl
 AC_DEFUN([CURL_FORMATS],[eeda plmosaic rda wcs wms wmts daas ogcapi])dnl
@@ -5679,7 +5679,7 @@ if test "$with_brunsli" != "" -a "$with_brunsli" != "no" ; then
   AC_SUBST(BRUNSLI_ENABLED, $BRUNSLI_ENABLED)
   AC_SUBST(BRUNSLI_INCLUDE, -I$prefix/include)
   AC_SUBST(BRUNSLI_LIB, "-lbrunslicommon -lbrunslienc -lbrunslidec -lbrotlicommon -lbrotlienc -lbrotlidec")
-fi 
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl RDB support

--- a/gdal/doc/source/drivers/raster/index.rst
+++ b/gdal/doc/source/drivers/raster/index.rst
@@ -172,6 +172,7 @@ Raster drivers
    snodas
    srp
    srtmhgt
+   stacit
    stacta
    terragen
    tga

--- a/gdal/doc/source/drivers/raster/stacit.rst
+++ b/gdal/doc/source/drivers/raster/stacit.rst
@@ -1,0 +1,86 @@
+.. _raster.stacit:
+
+================================================================================
+STACIT - Spatio-Temporal Asset Catalog Items
+================================================================================
+
+.. versionadded:: 3.4
+
+.. shortname:: STACIT
+
+.. built_in_by_default::
+
+This driver supports opening JSON files, or usually the result of a remote query,
+that are the ``items`` link of a
+`STAC Collection <https://github.com/radiantearth/stac-api-spec/blob/master/stac-spec/collection-spec/collection-spec.md>`_,
+and whose items also implement the
+`Projection Extension Specification <https://github.com/stac-extensions/projection/>`_.
+It builds a virtual mosaic from the items.
+
+A STACIT dataset which has no subdatasets is actually a :ref:`raster.vrt` dataset.
+Thus, translating it into VRT will result in a VRT file that directly references the items.
+
+Open syntax
+-----------
+
+STACIT datasets/subdatasets can be accessed with one of the following syntaxes:
+
+* ``filename.json``: local file
+
+* ``STACIT:"https://example.com/filename.json"``: remote file
+
+* ``STACIT:"filename.json":asset=my_asset``: specify an asset of a local/remote file
+
+* ``STACIT:"filename.json":collection=my_collect,asset=my_asset``: specify a collection + asset of a local/remote file
+
+* ``STACIT:"filename.json":collection=my_collect,asset=my_asset,crs=my_crs``: specify a collection + asset + CRS of a local/remote file
+
+Open options
+------------
+
+The following open options are supported:
+
+* ``MAX_ITEMS`` = number. Maximum number of items fetched. 0=unlimited. Default is 1000.
+
+* ``COLLECTION`` = string. Name of collection to filter items.
+
+* ``ASSET`` = string. Name of asset to filter items.
+
+* ``CRS`` = string. Name of CRS to filter items.
+
+* ``RESOLUTION`` = AVERAGE/HIGHEST/LOWEST. Strategy to use to determine dataset resolution. Default is AVERAGE.
+
+Subdatasets
+-----------
+
+If a STACIT JSON file contains several collections, assets or CRS,
+the driver will return a list of subdataset names to open each of the possible
+subdatasets.
+
+Driver capabilities
+-------------------
+
+.. supports_virtualio::
+
+Examples
+--------
+
+List the subdatasets associated to a `STAC search <https://github.com/radiantearth/stac-api-spec/tree/master/item-search>`_
+on a given collection, bbox and starting from a datetime:
+
+::
+
+    gdalinfo "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\""
+
+
+Open a subdataset returned by the above request:
+
+::
+
+    gdalinfo "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image"
+
+
+See Also
+--------
+
+-  :ref:`raster.stacta` documentation page.

--- a/gdal/doc/source/drivers/raster/stacta.rst
+++ b/gdal/doc/source/drivers/raster/stacta.rst
@@ -56,3 +56,8 @@ Driver capabilities
 -------------------
 
 .. supports_virtualio::
+
+See Also
+--------
+
+-  :ref:`raster.stacit` documentation page.

--- a/gdal/doc/source/drivers/raster/vrt.rst
+++ b/gdal/doc/source/drivers/raster/vrt.rst
@@ -293,11 +293,16 @@ filename should be interpreted as relative to the .vrt file (value is 1)
 or not relative to the .vrt file (value is 0).  The default is 0.
 
 Some characteristics of the source band can be specified in the optional
-SourceProperties tag to enable the VRT driver to defer the opening of the source
+``SourceProperties`` element to enable the VRT driver to defer the opening of the source
 dataset until it really needs to read data from it. This is particularly useful
 when building VRTs with a big number of source datasets. The needed parameters are the
 raster dimensions, the size of the blocks and the data type. If the SourceProperties
 tag is not present, the source dataset will be opened at the same time as the VRT itself.
+
+.. note::
+
+    Starting with GDAL 3.4, the ``SourceProperties`` element is no longer necessary
+    for defered opening of the source datasets.
 
 The content of the SourceBand subelement can refer to
 a mask band. For example mask,1 means the mask band of the first band of the source.

--- a/gdal/frmts/derived/deriveddataset.cpp
+++ b/gdal/frmts/derived/deriveddataset.cpp
@@ -27,7 +27,6 @@
  *****************************************************************************/
 #include "../vrt/vrtdataset.h"
 #include "gdal_pam.h"
-#include "gdal_proxy.h"
 #include "derivedlist.h"
 
 CPL_CVSID("$Id$")
@@ -172,23 +171,7 @@ GDALDataset * DerivedDataset::Open( GDALOpenInfo * poOpenInfo )
         poBand->SetPixelFunctionName(pixelFunctionName);
         poBand->SetSourceTransferType(poTmpDS->GetRasterBand(nBand)->GetRasterDataType());
 
-        GDALProxyPoolDataset* proxyDS =
-            new GDALProxyPoolDataset(
-                odFilename,
-                poDS->nRasterXSize,
-                poDS->nRasterYSize,
-                GA_ReadOnly,
-                TRUE);
-        for(int j=0;j<nbBands;++j)
-        {
-            int blockXSize, blockYSize;
-            poTmpDS->GetRasterBand(nBand)->GetBlockSize(&blockXSize,&blockYSize);
-            proxyDS->AddSrcBandDescription(poTmpDS->GetRasterBand(nBand)->GetRasterDataType(), blockXSize, blockYSize);
-        }
-
-        poBand->AddComplexSource(proxyDS->GetRasterBand(nBand),0,0,nCols,nRows,0,0,nCols,nRows);
-
-        proxyDS->Dereference();
+        poBand->AddComplexSource(odFilename,nBand,0,0,nCols,nRows,0,0,nCols,nRows);
     }
 
     GDALClose(poTmpDS);

--- a/gdal/frmts/gdalallregister.cpp
+++ b/gdal/frmts/gdalallregister.cpp
@@ -588,6 +588,10 @@ void CPL_STDCALL GDALAllRegister()
     GDALRegister_STACTA();
 #endif
 
+#ifdef FRMT_stacit
+    GDALRegister_STACIT();
+#endif
+
     // NOTE: you need to generally your own driver before that line.
 
 /* -------------------------------------------------------------------- */

--- a/gdal/frmts/makefile.vc
+++ b/gdal/frmts/makefile.vc
@@ -16,7 +16,7 @@ EXTRAFLAGS =	-DFRMT_ceos -DFRMT_aigrid -DFRMT_elas -DFRMT_hfa -DFRMT_gtiff\
 		-DFRMT_kmlsuperoverlay -DFRMT_ozi -DFRMT_ctg \
 		-DFRMT_zmap -DFRMT_ngsgeoid -DFRMT_iris -DFRMT_map -DFRMT_cals \
 		-DFRMT_safe -DFRMT_sentinel2 -DFRMT_derived -DFRMT_prf \
-		-DFRMT_sigdem -DFRMT_tga -DFRMT_stacta -DFRMT_zarr
+		-DFRMT_sigdem -DFRMT_tga -DFRMT_stacit -DFRMT_stacta -DFRMT_zarr
 
 MOREEXTRA 	=
 

--- a/gdal/frmts/stacit/GNUmakefile
+++ b/gdal/frmts/stacit/GNUmakefile
@@ -1,0 +1,14 @@
+include ../../GDALmake.opt
+
+OBJ	=	stacitdataset.o
+
+CXXFLAGS        :=      $(WARN_EFFCPLUSPLUS) $(CXXFLAGS) -iquote ../vrt
+
+default:	$(OBJ:.o=.$(OBJ_EXT))
+
+clean:
+	rm -f *.o $(O_OBJ)
+
+install-obj:	$(O_OBJ:.o=.$(OBJ_EXT))
+
+install:

--- a/gdal/frmts/stacit/makefile.vc
+++ b/gdal/frmts/stacit/makefile.vc
@@ -1,0 +1,15 @@
+
+OBJ	=	stacitdataset.obj
+
+GDAL_ROOT	=	..\..
+
+EXTRAFLAGS	= 	-I..\vrt
+
+!INCLUDE $(GDAL_ROOT)\nmake.opt
+
+default:	$(OBJ)
+	xcopy /D  /Y *.obj ..\o
+
+clean:
+	-del *.obj
+

--- a/gdal/frmts/stacit/stacitdataset.cpp
+++ b/gdal/frmts/stacit/stacitdataset.cpp
@@ -1,0 +1,924 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  STACIT (Spatio-Temporal Asset Catalog ITems) driver
+ * Author:   Even Rouault, <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2021, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_json.h"
+#include "vrtdataset.h"
+#include "ogr_spatialref.h"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <string>
+
+CPL_CVSID("$Id$")
+
+namespace {
+
+struct AssetItem
+{
+    std::string osFilename{};
+    std::string osDateTime{};
+    int nXSize = 0;
+    int nYSize = 0;
+    double dfXMin = 0;
+    double dfYMin = 0;
+    double dfXMax = 0;
+    double dfYMax = 0;
+};
+
+struct AssetSetByProjection
+{
+    std::string osProjUserString{};
+    std::vector<AssetItem> assets{};
+};
+
+struct Asset
+{
+    std::string osName{};
+    CPLJSONArray eoBands{};
+    std::map<std::string, AssetSetByProjection> assets{};
+};
+
+struct Collection
+{
+    std::string osName{};
+    std::map<std::string, Asset> assets{};
+};
+} // namespace
+
+/************************************************************************/
+/*                            STACITDataset                             */
+/************************************************************************/
+
+class STACITDataset final: public VRTDataset
+{
+        STACITDataset();
+
+        bool Open(GDALOpenInfo* poOpenInfo);
+        bool SetupDataset(GDALOpenInfo* poOpenInfo,
+                          std::map<std::string, Collection>& oMapCollection);
+        bool SetSubdatasets(
+                    const std::string& osFilename,
+                    const std::map<std::string, Collection>& oMapCollection);
+public:
+        static int Identify(GDALOpenInfo* poOpenInfo);
+        static GDALDataset* OpenStatic(GDALOpenInfo* poOpenInfo);
+};
+
+/************************************************************************/
+/*                          STACITDataset()                             */
+/************************************************************************/
+
+STACITDataset::STACITDataset():
+    VRTDataset(0,0)
+{
+    SetWritable(false);
+}
+
+/************************************************************************/
+/*                             Identify()                               */
+/************************************************************************/
+
+int STACITDataset::Identify(GDALOpenInfo* poOpenInfo)
+{
+    if( STARTS_WITH(poOpenInfo->pszFilename, "STACIT:") )
+    {
+        return true;
+    }
+
+    if( poOpenInfo->nHeaderBytes == 0 )
+    {
+        return false;
+    }
+
+    for( int i = 0; i < 2; i++ )
+    {
+        // TryToIngest() may reallocate pabyHeader, so do not move this
+        // before the loop.
+        const char* pszHeader =
+            reinterpret_cast<const char*>(poOpenInfo->pabyHeader);
+        if( strstr(pszHeader, "\"stac_version\"") != nullptr &&
+            strstr(pszHeader, "\"proj:transform\"") != nullptr )
+        {
+            return true;
+        }
+
+        if( i == 0 )
+        {
+            // Should be enough for a STACIT .json file
+            poOpenInfo->TryToIngest(32768);
+        }
+    }
+
+    return false;
+}
+
+/************************************************************************/
+/*                        SanitizeCRSValue()                            */
+/************************************************************************/
+
+static std::string SanitizeCRSValue(const std::string& v)
+{
+    std::string ret;
+    bool lastWasAlphaNum = true;
+    for( char ch: v )
+    {
+        if( !isalnum(static_cast<int>(ch)) )
+        {
+            if( lastWasAlphaNum )
+                ret += '_';
+            lastWasAlphaNum = false;
+        }
+        else
+        {
+            ret += ch;
+            lastWasAlphaNum = true;
+        }
+    }
+    if( !ret.empty() && ret.back() == '_' )
+        ret.resize(ret.size() - 1);
+    return ret;
+}
+
+/************************************************************************/
+/*                            ParseAsset()                              */
+/************************************************************************/
+
+static void ParseAsset(const CPLJSONObject& jAsset,
+                       const CPLJSONObject& oProperties,
+                       const std::string& osCollection,
+                       const std::string& osFilteredCRS,
+                       std::map<std::string, Collection>& oMapCollection)
+{
+    // Skip assets that are obviously not images
+    const auto osType = jAsset["type"].ToString();
+    if( osType == "application/json" ||
+        osType == "application/xml" ||
+        osType == "text/plain" )
+    {
+        return;
+    }
+
+    // Skip assets whose role is obviously non georeferenced
+    const auto oRoles = jAsset.GetArray("roles");
+    if( oRoles.IsValid() )
+    {
+        for( const auto& oRole: oRoles )
+        {
+            const auto osRole = oRole.ToString();
+            if( osRole == "thumbnail" || osRole == "info" ||
+                osRole == "metadata" )
+            {
+                return;
+            }
+        }
+    }
+
+    const auto osAssetName = jAsset.GetName();
+
+    const auto osHref = jAsset["href"].ToString();
+    if( osHref.empty() )
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Missing href on asset %s", osAssetName.c_str());
+        return;
+    }
+
+    const auto GetAssetOrFeatureProperty = [&oProperties, &jAsset](const char* pszName)
+    {
+        auto obj = jAsset[pszName];
+        if( obj.IsValid() )
+            return obj;
+        return oProperties[pszName];
+    };
+
+    auto oProjEPSG = GetAssetOrFeatureProperty("proj:epsg");
+    if( !oProjEPSG.IsValid() )
+    {
+        CPLDebug("STACIT",
+                 "Skipping asset %s that lacks the 'proj:epsg' member",
+                 osAssetName.c_str());
+        return;
+    }
+    std::string osProjUserString;
+    if( oProjEPSG.GetType() != CPLJSONObject::Type::Null )
+    {
+        osProjUserString = "EPSG:" + oProjEPSG.ToString();
+    }
+    else
+    {
+        auto oProjWKT2 = GetAssetOrFeatureProperty("proj:wkt2");
+        if( oProjWKT2.IsValid() &&
+            oProjWKT2.GetType() == CPLJSONObject::Type::String )
+        {
+            osProjUserString = oProjWKT2.ToString();
+        }
+        else
+        {
+            auto oProjPROJJSON = GetAssetOrFeatureProperty("proj:projjson");
+            if( oProjPROJJSON.IsValid() &&
+                oProjPROJJSON.GetType() == CPLJSONObject::Type::Object )
+            {
+                osProjUserString = oProjPROJJSON.ToString();
+            }
+            else
+            {
+                CPLDebug("STACIT",
+                         "Skipping asset %s that lacks a valid CRS member",
+                         osAssetName.c_str());
+                return;
+            }
+        }
+    }
+
+    if( !osFilteredCRS.empty() &&
+        osFilteredCRS != SanitizeCRSValue(osProjUserString) )
+    {
+        return;
+    }
+
+    AssetItem item;
+    item.osFilename = osHref;
+    item.osDateTime = oProperties["datetime"].ToString();
+
+    // Figure out item bounds and width/height
+    auto oProjBBOX = GetAssetOrFeatureProperty("proj:bbox").ToArray();
+    auto oProjShape = GetAssetOrFeatureProperty("proj:shape").ToArray();
+    auto oProjTransform = GetAssetOrFeatureProperty("proj:transform").ToArray();
+    const bool bIsBBOXValid = oProjBBOX.IsValid() && oProjBBOX.Size() == 4;
+    const bool bIsShapeValid = oProjShape.IsValid() && oProjShape.Size() == 2;
+    const bool bIsTransformValid = oProjTransform.IsValid() && (oProjTransform.Size() == 6 || oProjTransform.Size() == 9);
+    std::vector<double> bbox;
+    if( bIsBBOXValid )
+    {
+        for( const auto& oItem: oProjBBOX )
+            bbox.push_back(oItem.ToDouble());
+        CPLAssert(bbox.size() == 4);
+    }
+    std::vector<int> shape;
+    if( bIsShapeValid )
+    {
+        for( const auto& oItem: oProjShape )
+            shape.push_back(oItem.ToInteger());
+        CPLAssert(shape.size() == 2);
+    }
+    std::vector<double> transform;
+    if( bIsTransformValid )
+    {
+        for( const auto& oItem: oProjTransform )
+            transform.push_back(oItem.ToDouble());
+        CPLAssert(transform.size() == 6 || transform.size() == 9);
+        if( transform[0] <= 0 ||
+            transform[1] != 0 ||
+            transform[3] != 0 ||
+            transform[4] >= 0 ||
+            (transform.size() == 9 &&
+             (transform[6] != 0 ||
+             transform[7] != 0 ||
+             transform[8] != 1)) )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Skipping asset %s because its proj:transform is "
+                     "not of the form [xres,0,xoffset,0,yres<0,yoffset[,0,0,1]]",
+                     osAssetName.c_str());
+            return;
+        }
+    }
+
+    if( bIsBBOXValid && bIsShapeValid )
+    {
+        item.nXSize = shape[1];
+        item.nYSize = shape[0];
+        item.dfXMin = bbox[0];
+        item.dfYMin = bbox[1];
+        item.dfXMax = bbox[2];
+        item.dfYMax = bbox[3];
+    }
+    else if( bIsBBOXValid && bIsTransformValid )
+    {
+        item.dfXMin = bbox[0];
+        item.dfYMin = bbox[1];
+        item.dfXMax = bbox[2];
+        item.dfYMax = bbox[3];
+        if( item.dfXMin != transform[2] ||
+            item.dfYMax != transform[5] )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Skipping asset %s because the origin of "
+                     "proj:transform and proj:bbox are not consistent",
+                     osAssetName.c_str());
+            return;
+        }
+        double dfXSize = (item.dfXMax - item.dfXMin) / transform[0];
+        double dfYSize = (item.dfYMax - item.dfYMin) / -transform[4];
+        if( !(dfXSize < INT_MAX && dfYSize < INT_MAX) )
+            return;
+        item.nXSize = static_cast<int>(dfXSize);
+        item.nYSize = static_cast<int>(dfYSize);
+    }
+    else if( bIsShapeValid && bIsTransformValid )
+    {
+        item.nXSize = shape[1];
+        item.nYSize = shape[0];
+        item.dfXMin = transform[2];
+        item.dfYMax = transform[5];
+        item.dfXMax = item.dfXMin + item.nXSize * transform[0];
+        item.dfYMin = item.dfYMax + item.nYSize * transform[4];
+    }
+    else
+    {
+        CPLDebug("STACIT",
+                 "Skipping asset %s that lacks at least 2 members among "
+                 "proj:bbox, proj:shape and proj:transform",
+                 osAssetName.c_str());
+        return;
+    }
+
+    if( item.nXSize <= 0 || item.nYSize <= 0 )
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Skipping asset %s because the size is invalid",
+                 osAssetName.c_str());
+        return;
+    }
+
+    // Create/fetch collection
+    if( oMapCollection.find(osCollection) == oMapCollection.end() )
+    {
+        Collection collection;
+        collection.osName = osCollection;
+        oMapCollection[osCollection] = collection;
+    }
+    auto& collection = oMapCollection[osCollection];
+
+    // Create/fetch asset in collection
+    if( collection.assets.find(osAssetName) == collection.assets.end() )
+    {
+        Asset asset;
+        asset.osName = osAssetName;
+        asset.eoBands = jAsset.GetArray("eo:bands");
+
+        collection.assets[osAssetName] = asset;
+    }
+    auto& asset = collection.assets[osAssetName];
+
+    // Create/fetch projection in asset
+    if( asset.assets.find(osProjUserString) == asset.assets.end() )
+    {
+        AssetSetByProjection assetByProj;
+        assetByProj.osProjUserString = osProjUserString;
+        asset.assets[osProjUserString] = assetByProj;
+    }
+    auto& assets = asset.assets[osProjUserString];
+
+    // Add item
+    assets.assets.emplace_back(item);
+}
+
+/************************************************************************/
+/*                           SetupDataset()                             */
+/************************************************************************/
+
+bool STACITDataset::SetupDataset(GDALOpenInfo* poOpenInfo,
+                                 std::map<std::string, Collection>& oMapCollection)
+{
+    auto& collection = oMapCollection.begin()->second;
+    auto& asset = collection.assets.begin()->second;
+    auto& assetByProj = asset.assets.begin()->second;
+    auto& items = assetByProj.assets;
+
+    // Compute global bounds and resolution
+    double dfXMin = std::numeric_limits<double>::max();
+    double dfYMin = std::numeric_limits<double>::max();
+    double dfXMax = -std::numeric_limits<double>::max();
+    double dfYMax = -std::numeric_limits<double>::max();
+    double dfXRes = 0;
+    double dfYRes = 0;
+    const char* pszResolution = CSLFetchNameValueDef(
+        poOpenInfo->papszOpenOptions, "RESOLUTION", "AVERAGE");
+    for( const auto& assetItem: items )
+    {
+        dfXMin = std::min(dfXMin, assetItem.dfXMin);
+        dfYMin = std::min(dfYMin, assetItem.dfYMin);
+        dfXMax = std::max(dfXMax, assetItem.dfXMax);
+        dfYMax = std::max(dfYMax, assetItem.dfYMax);
+        const double dfThisXRes =
+            (assetItem.dfXMax - assetItem.dfXMin) / assetItem.nXSize;
+        const double dfThisYRes =
+            (assetItem.dfYMax - assetItem.dfYMin) / assetItem.nYSize;
+#ifdef DEBUG_VERBOSE
+        CPLDebug("STACIT", "%s -> resx=%f resy=%f",
+                 assetItem.osFilename.c_str(), dfThisXRes, dfThisYRes);
+#endif
+        if( dfXRes != 0 && EQUAL(pszResolution, "HIGHEST") )
+        {
+            dfXRes = std::min(dfXRes, dfThisXRes);
+            dfYRes = std::min(dfYRes, dfThisYRes);
+        }
+        else if( dfXRes != 0 && EQUAL(pszResolution, "LOWEST") )
+        {
+            dfXRes = std::max(dfXRes, dfThisXRes);
+            dfYRes = std::max(dfYRes, dfThisYRes);
+        }
+        else
+        {
+            dfXRes += dfThisXRes;
+            dfYRes += dfThisYRes;
+        }
+    }
+    if( EQUAL(pszResolution, "AVERAGE") )
+    {
+        dfXRes /= static_cast<int>(items.size());
+        dfYRes /= static_cast<int>(items.size());
+    }
+
+    // Set raster size
+    double dfXSize = std::round((dfXMax - dfXMin) / dfXRes);
+    double dfYSize = std::round((dfYMax - dfYMin) / dfYRes);
+    if( dfXSize <= 0 ||
+        dfYSize <= 0 ||
+        dfXSize > INT_MAX ||
+        dfYSize > INT_MAX )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Invalid computed dataset dimensions");
+        return false;
+    }
+    nRasterXSize = static_cast<int>(dfXSize);
+    nRasterYSize = static_cast<int>(dfYSize);
+
+    // Set geotransform
+    double adfGeoTransform[6];
+    adfGeoTransform[0] = dfXMin;
+    adfGeoTransform[1] = dfXRes;
+    adfGeoTransform[2] = 0;
+    adfGeoTransform[3] = dfYMax;
+    adfGeoTransform[4] = 0;
+    adfGeoTransform[5] = -dfYRes;
+    SetGeoTransform(adfGeoTransform);
+
+    // Set SRS
+    OGRSpatialReference oSRS;
+    if( oSRS.SetFromUserInput(assetByProj.osProjUserString.c_str()) == OGRERR_NONE )
+    {
+        oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        SetSpatialRef(&oSRS);
+    }
+
+    // Open of the items to find the number of bands, their data type
+    // and nodata.
+    CPLString osFirstItemName(items.front().osFilename);
+    if( osFirstItemName.find("http") == 0 )
+        osFirstItemName = "/vsicurl/" + osFirstItemName;
+    auto poItemDS = std::unique_ptr<GDALDataset>(GDALDataset::Open(osFirstItemName));
+    if( !poItemDS )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Cannot open %s to retrieve band characteristics",
+                 osFirstItemName.c_str());
+        return false;
+    }
+
+    // Sort by ascending datetime
+    std::sort(items.begin(), items.end(),
+              [](const AssetItem& a, const AssetItem& b)
+        {
+            if( !a.osDateTime.empty() && !b.osDateTime.empty() )
+                return a.osDateTime < b.osDateTime;
+            return &a < &b;
+        }
+    );
+
+    // Create VRT bands and add sources
+    for(int i = 0; i < poItemDS->GetRasterCount(); i++ )
+    {
+        auto poItemBand = poItemDS->GetRasterBand(i+1);
+        AddBand( poItemBand->GetRasterDataType(), nullptr );
+        auto poVRTBand = cpl::down_cast<VRTSourcedRasterBand *>(GetRasterBand(i+1));
+        int bHasNoData = FALSE;
+        const double dfNoData = poItemBand->GetNoDataValue(&bHasNoData);
+        if( bHasNoData )
+            poVRTBand->SetNoDataValue(dfNoData);
+
+        const auto eInterp = poItemBand->GetColorInterpretation();
+        if( eInterp != GCI_Undefined )
+            poVRTBand->SetColorInterpretation(eInterp);
+
+        // Set band properties
+        if( asset.eoBands.IsValid() &&
+            asset.eoBands.Size() == poItemDS->GetRasterCount() )
+        {
+            const auto& eoBand = asset.eoBands[i];
+            const auto osBandName = eoBand["name"].ToString();
+            if( !osBandName.empty() )
+                poVRTBand->SetDescription(osBandName.c_str());
+
+            if( eInterp != GCI_Undefined )
+            {
+                const auto osCommonName = eoBand["common_name"].ToString();
+                if( osCommonName == "red" )
+                    poVRTBand->SetColorInterpretation(GCI_RedBand);
+                else if( osCommonName == "green" )
+                    poVRTBand->SetColorInterpretation(GCI_GreenBand);
+                else if( osCommonName == "blue" )
+                    poVRTBand->SetColorInterpretation(GCI_BlueBand);
+                else if( osCommonName == "alpha" )
+                    poVRTBand->SetColorInterpretation(GCI_AlphaBand);
+            }
+
+            for( const auto& eoBandChild: eoBand.GetChildren() )
+            {
+                const auto osChildName = eoBandChild.GetName();
+                if( osChildName != "name" && osChildName != "common_name" )
+                {
+                    poVRTBand->SetMetadataItem(osChildName.c_str(),
+                                               eoBandChild.ToString().c_str());
+                }
+            }
+        }
+
+        // Add items as VRT sources
+        for( const auto& assetItem: items )
+        {
+            CPLString osItemName(assetItem.osFilename);
+            if( osItemName.find("http") == 0 )
+                osItemName = "/vsicurl/" + osItemName;
+            const double dfDstXOff = (assetItem.dfXMin - dfXMin) / dfXRes;
+            const double dfDstXSize = (assetItem.dfXMax - assetItem.dfXMin ) / dfXRes;
+            const double dfDstYOff = (dfYMax - assetItem.dfYMax) / dfYRes;
+            const double dfDstYSize = (assetItem.dfYMax - assetItem.dfYMin ) / dfYRes;
+            if( !bHasNoData )
+            {
+                poVRTBand->AddSimpleSource( osItemName.c_str(), i+1,
+                                            0,
+                                            0,
+                                            assetItem.nXSize,
+                                            assetItem.nYSize,
+                                            dfDstXOff,
+                                            dfDstYOff,
+                                            dfDstXSize,
+                                            dfDstYSize );
+            }
+            else
+            {
+                poVRTBand->AddComplexSource( osItemName.c_str(), i+1,
+                                            0,
+                                            0,
+                                            assetItem.nXSize,
+                                            assetItem.nYSize,
+                                            dfDstXOff,
+                                            dfDstYOff,
+                                            dfDstXSize,
+                                            dfDstYSize,
+                                            0.0, // offset
+                                            1.0, // scale
+                                            dfNoData );
+            }
+        }
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                         SetSubdatasets()                             */
+/************************************************************************/
+
+bool STACITDataset::SetSubdatasets(
+                        const std::string& osFilename,
+                        const std::map<std::string, Collection>& oMapCollection)
+{
+    CPLStringList aosSubdatasets;
+    int nCount = 1;
+    for( const auto& collectionKV: oMapCollection )
+    {
+        for( const auto& assetKV: collectionKV.second.assets )
+        {
+            std::string osCollectionAssetArg;
+            if( oMapCollection.size() > 1 )
+                osCollectionAssetArg += "collection=" + collectionKV.first + ",";
+            osCollectionAssetArg += "asset=" + assetKV.first;
+
+            std::string osCollectionAssetText;
+            if( oMapCollection.size() > 1 )
+                osCollectionAssetText += "Collection " + collectionKV.first + ", ";
+            osCollectionAssetText += "Asset " + assetKV.first;
+
+            if( assetKV.second.assets.size() == 1 )
+            {
+                aosSubdatasets.AddString(
+                    CPLSPrintf("SUBDATASET_%d_NAME=STACIT:\"%s\":%s",
+                               nCount,
+                               osFilename.c_str(),
+                               osCollectionAssetArg.c_str()));
+                aosSubdatasets.AddString(
+                    CPLSPrintf("SUBDATASET_%d_DESC=%s of %s",
+                               nCount,
+                               osCollectionAssetText.c_str(),
+                               osFilename.c_str()));
+                nCount ++;
+            }
+            else
+            {
+                for( const auto& assetsByProjKV: assetKV.second.assets )
+                {
+                    aosSubdatasets.AddString(
+                        CPLSPrintf("SUBDATASET_%d_NAME=STACIT:\"%s\":%s,crs=%s",
+                                   nCount,
+                                   osFilename.c_str(),
+                                   osCollectionAssetArg.c_str(),
+                                   SanitizeCRSValue(assetsByProjKV.first).c_str()));
+                    aosSubdatasets.AddString(
+                        CPLSPrintf("SUBDATASET_%d_DESC=%s of %s in CRS %s",
+                                   nCount,
+                                   osCollectionAssetText.c_str(),
+                                   osFilename.c_str(),
+                                   assetsByProjKV.first.c_str()));
+                    nCount ++;
+                }
+            }
+        }
+    }
+    GDALDataset::SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+    return true;
+}
+
+/************************************************************************/
+/*                               Open()                                 */
+/************************************************************************/
+
+bool STACITDataset::Open(GDALOpenInfo* poOpenInfo)
+{
+    CPLString osFilename(poOpenInfo->pszFilename);
+    std::string osFilteredCollection =
+        CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "COLLECTION", "");
+    std::string osFilteredAsset =
+        CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "ASSET", "");
+    std::string osFilteredCRS =
+        SanitizeCRSValue(CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "CRS", ""));
+    if( STARTS_WITH(poOpenInfo->pszFilename, "STACIT:") )
+    {
+        const CPLStringList aosTokens(
+            CSLTokenizeString2(poOpenInfo->pszFilename, ":", CSLT_HONOURSTRINGS ));
+        if( aosTokens.size() != 2 && aosTokens.size() != 3 )
+            return false;
+        osFilename = aosTokens[1];
+        if( aosTokens.size() >= 3 )
+        {
+            const CPLStringList aosFilters(
+                CSLTokenizeString2(aosTokens[2], ",", 0));
+            osFilteredCollection = aosFilters.FetchNameValueDef("collection",
+                                                osFilteredCollection.c_str());
+            osFilteredAsset = aosFilters.FetchNameValueDef("asset",
+                                                osFilteredAsset.c_str());
+            osFilteredCRS = aosFilters.FetchNameValueDef("crs",
+                                                osFilteredCRS.c_str());
+        }
+    }
+
+    std::map<std::string, Collection> oMapCollection;
+    GIntBig nItemIter = 0;
+    GIntBig nMaxItems = CPLAtoGIntBig(CSLFetchNameValueDef(
+        poOpenInfo->papszOpenOptions, "MAX_ITEMS", "1000"));
+
+    if( CSLFetchNameValue(poOpenInfo->papszOpenOptions, "MAX_ITEMS") == nullptr )
+    {
+        // If the URL includes a limit parameter, and it's larger than our
+        // default MAX_ITEMS value, then increase the later to the former.
+        const auto nPos = osFilename.ifind("&limit=");
+        if( nPos != std::string::npos )
+        {
+            const auto nLimit = CPLAtoGIntBig(
+                osFilename.substr(nPos + strlen("&limit=")).c_str());
+            nMaxItems = std::max(nMaxItems, nLimit);
+        }
+    }
+
+    auto osCurFilename = osFilename;
+    do
+    {
+        CPLJSONDocument oDoc;
+        if( STARTS_WITH(osCurFilename, "http://") ||
+            STARTS_WITH(osCurFilename, "https://") )
+        {
+            if( !oDoc.LoadUrl(osCurFilename, nullptr) )
+                return false;
+        }
+        else
+        {
+            if( !oDoc.Load(osCurFilename) )
+                return false;
+        }
+        const auto oRoot = oDoc.GetRoot();
+        const auto oFeatures = oRoot.GetArray("features");
+        if( !oFeatures.IsValid() )
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Missing features");
+            return false;
+        }
+        for( const auto& oFeature: oFeatures )
+        {
+            nItemIter ++;
+            if( nItemIter > nMaxItems )
+            {
+                break;
+            }
+
+            auto oStacExtensions = oFeature.GetArray("stac_extensions");
+            if( !oStacExtensions.IsValid() )
+            {
+                CPLDebug("STACIT", "Skipping Feature that lacks stac_extensions");
+                continue;
+            }
+            bool bProjExtensionFound = false;
+            for( const auto& oStacExtension: oStacExtensions )
+            {
+                if( oStacExtension.ToString() == "proj" ||
+                    oStacExtension.ToString().find(
+                        "https://stac-extensions.github.io/projection/") == 0 )
+                {
+                    bProjExtensionFound = true;
+                    break;
+                }
+            }
+            if( !bProjExtensionFound )
+            {
+                CPLDebug("STACIT",
+                         "Skipping Feature that lacks the 'proj' STAC extension");
+                continue;
+            }
+
+            auto jAssets = oFeature["assets"];
+            if( !jAssets.IsValid() ||
+                jAssets.GetType() != CPLJSONObject::Type::Object )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Missing assets on a Feature");
+                continue;
+            }
+
+            auto oProperties = oFeature["properties"];
+            if( !oProperties.IsValid() ||
+                oProperties.GetType() != CPLJSONObject::Type::Object )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Missing properties on a Feature");
+                continue;
+            }
+
+            const auto osCollection = oFeature["collection"].ToString();
+            if( !osFilteredCollection.empty() && osFilteredCollection != osCollection )
+                continue;
+
+            for( const auto& jAsset: jAssets.GetChildren() )
+            {
+                const auto osAssetName = jAsset.GetName();
+                if( !osFilteredAsset.empty() && osFilteredAsset != osAssetName )
+                    continue;
+
+                ParseAsset(jAsset, oProperties, osCollection,
+                           osFilteredCRS,
+                           oMapCollection);
+            }
+        }
+        if( nItemIter >= nMaxItems )
+        {
+            if( CSLFetchNameValue(poOpenInfo->papszOpenOptions,
+                                  "MAX_ITEMS") == nullptr )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Maximum number of items (" CPL_FRMT_GIB
+                         ") allowed to be retrieved has been hit",
+                         nMaxItems);
+            }
+            else
+            {
+                CPLDebug("STACIT",
+                         "Maximum number of items (" CPL_FRMT_GIB
+                         ") allowed to be retrieved has been hit",
+                         nMaxItems);
+            }
+            break;
+        }
+
+        // Follow next link
+        const auto oLinks = oRoot.GetArray("links");
+        if( !oLinks.IsValid() )
+            break;
+        std::string osNewFilename;
+        for( const auto& oLink: oLinks )
+        {
+            if( oLink["rel"].ToString() == "next" )
+            {
+                osNewFilename = oLink["href"].ToString();
+                break;
+            }
+        }
+        if( !osNewFilename.empty() && osNewFilename != osCurFilename )
+            osCurFilename = osNewFilename;
+        else
+            osCurFilename.clear();
+    }
+    while( !osCurFilename.empty() );
+
+    if( oMapCollection.empty() )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "No compatible asset found");
+        return false;
+    }
+
+    if( oMapCollection.size() > 1 ||
+        oMapCollection.begin()->second.assets.size() > 1 ||
+        oMapCollection.begin()->second.assets.begin()->second.assets.size() > 1 )
+    {
+        // If there's more than one asset type or more than one SRS, expose
+        // subdatasets.
+        return SetSubdatasets(osFilename, oMapCollection);
+    }
+    else
+    {
+        return SetupDataset(poOpenInfo, oMapCollection);
+    }
+}
+
+/************************************************************************/
+/*                            OpenStatic()                              */
+/************************************************************************/
+
+GDALDataset* STACITDataset::OpenStatic(GDALOpenInfo* poOpenInfo)
+{
+    if( !Identify(poOpenInfo) )
+        return nullptr;
+    auto poDS = std::unique_ptr<STACITDataset>(new STACITDataset());
+    if( !poDS->Open(poOpenInfo) )
+        return nullptr;
+    return poDS.release();
+}
+
+/************************************************************************/
+/*                       GDALRegister_STACIT()                          */
+/************************************************************************/
+
+void GDALRegister_STACIT()
+
+{
+    if( GDALGetDriverByName( "STACIT" ) != nullptr )
+      return;
+
+    GDALDriver *poDriver = new GDALDriver();
+
+    poDriver->SetDescription( "STACIT" );
+    poDriver->SetMetadataItem( GDAL_DCAP_RASTER, "YES" );
+    poDriver->SetMetadataItem( GDAL_DMD_LONGNAME,
+                               "Spatio-Temporal Asset Catalog Items" );
+    poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/raster/stacit.html" );
+    poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
+    poDriver->SetMetadataItem( GDAL_DMD_SUBDATASETS, "YES" );
+    poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
+"<OpenOptionList>"
+"   <Option name='MAX_ITEMS' type='int' default='1000' "
+                        "description='Maximum number of items fetched. 0=unlimited'/>"
+"   <Option name='COLLECTION' type='string' "
+                        "description='Name of collection to filter items'/>"
+"   <Option name='ASSET' type='string' "
+                        "description='Name of asset to filter items'/>"
+"   <Option name='CRS' type='string' "
+                        "description='Name of CRS to filter items'/>"
+"   <Option name='RESOLUTION' type='string-select' default='AVERAGE' "
+            "description='Strategy to use to determine dataset resolution'>"
+"       <Value>AVERAGE</Value>"
+"       <Value>HIGHEST</Value>"
+"       <Value>LOWEST</Value>"
+"   </Option>"
+"</OpenOptionList>" );
+
+    poDriver->pfnOpen = STACITDataset::OpenStatic;
+    poDriver->pfnIdentify = STACITDataset::Identify;
+
+    GetGDALDriverManager()->RegisterDriver( poDriver );
+}

--- a/gdal/frmts/stacit/stacitdataset.cpp
+++ b/gdal/frmts/stacit/stacitdataset.cpp
@@ -600,6 +600,10 @@ bool STACITDataset::SetupDataset(GDALOpenInfo* poOpenInfo,
                                             dfNoData );
             }
         }
+
+        const char* apszOptions[] = { "EMIT_ERROR_IF_GEOS_NOT_AVAILABLE=NO",
+                                      nullptr };
+        poVRTBand->RemoveCoveredSources(apszOptions);
     }
     return true;
 }

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -896,37 +896,47 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL: public VRTSource
 {
     CPL_DISALLOW_COPY_ASSIGN(VRTSimpleSource)
 
+private:
+    // Owned by the VRTDataset
+    std::map<CPLString, GDALDataset*>* m_poMapSharedSources = nullptr;
+
+    GDALRasterBand      *m_poRasterBand = nullptr;
+
+    // When poRasterBand is a mask band, poMaskBandMainBand is the band
+    // from which the mask band is taken.
+    GDALRasterBand      *m_poMaskBandMainBand = nullptr;
+
+    CPLStringList        m_aosOpenOptions{};
+
 protected:
     friend class VRTSourcedRasterBand;
     friend class VRTDataset;
 
-    GDALRasterBand      *m_poRasterBand;
+    int                 m_nBand = 0;
+    bool                m_bGetMaskBand = false;
 
-    // When poRasterBand is a mask band, poMaskBandMainBand is the band
-    // from which the mask band is taken.
-    GDALRasterBand      *m_poMaskBandMainBand;
+    double              m_dfSrcXOff = 0;
+    double              m_dfSrcYOff = 0;
+    double              m_dfSrcXSize = 0;
+    double              m_dfSrcYSize = 0;
 
-    double              m_dfSrcXOff;
-    double              m_dfSrcYOff;
-    double              m_dfSrcXSize;
-    double              m_dfSrcYSize;
+    double              m_dfDstXOff = 0;
+    double              m_dfDstYOff = 0;
+    double              m_dfDstXSize = 0;
+    double              m_dfDstYSize = 0;
 
-    double              m_dfDstXOff;
-    double              m_dfDstYOff;
-    double              m_dfDstXSize;
-    double              m_dfDstYSize;
-
-    int                 m_bNoDataSet;       // should really be a member of VRTComplexSource as only taken into account by it
-    double              m_dfNoDataValue;    // same as above
+    int                 m_bNoDataSet = false;       // should really be a member of VRTComplexSource as only taken into account by it
+    double              m_dfNoDataValue = VRT_NODATA_UNSET;    // same as above
     CPLString           m_osResampling{};
 
-    int                 m_nMaxValue;
+    int                 m_nMaxValue = 0;
 
-    int                 m_bRelativeToVRTOri;
+    int                 m_bRelativeToVRTOri = -1;
     CPLString           m_osSourceFileNameOri{};
-    int                 m_nExplicitSharedStatus; // -1 unknown, 0 = unshared, 1 = shared
+    int                 m_nExplicitSharedStatus = -1; // -1 unknown, 0 = unshared, 1 = shared
+    CPLString           m_osSrcDSName{};
 
-    bool                m_bDropRefOnSrcBand;
+    bool                m_bDropRefOnSrcBand = true;
 
     int                 NeedMaxValAdjustment() const;
 
@@ -953,7 +963,8 @@ public:
                                     double *pdfReqXOff, double *pdfReqYOff,
                                     double *pdfReqXSize, double *pdfReqYSize,
                                     int *, int *, int *, int *,
-                                    int *, int *, int *, int * );
+                                    int *, int *, int *, int *,
+                                    bool& bErrorOut );
 
     virtual CPLErr  RasterIO( GDALDataType eBandDataType,
                               int nXOff, int nYOff, int nXSize, int nYSize,
@@ -991,8 +1002,8 @@ public:
     virtual const char* GetType() { return "SimpleSource"; }
     virtual CPLErr FlushCache() override;
 
-    GDALRasterBand* GetBand();
-    GDALRasterBand* GetMaskBandMainBand() { return m_poMaskBandMainBand; }
+    GDALRasterBand* GetRasterBand() const;
+    GDALRasterBand* GetMaskBandMainBand();
     int             IsSameExceptBandNumber( VRTSimpleSource* poOtherSource );
     CPLErr          DatasetRasterIO(
                                GDALDataType eBandDataType,

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -577,19 +577,21 @@ class VRTSimpleSource;
 class CPL_DLL VRTSourcedRasterBand CPL_NON_FINAL: public VRTRasterBand
 {
   private:
-    int            m_nRecursionCounter;
+    int            m_nRecursionCounter = 0;
     CPLString      m_osLastLocationInfo{};
-    char         **m_papszSourceList;
+    char         **m_papszSourceList = nullptr;
+    int            m_nSkipBufferInitialization = -1;
 
     bool           CanUseSourcesMinMaxImplementations();
-    void           CheckSource( VRTSimpleSource *poSS );
 
     CPL_DISALLOW_COPY_ASSIGN(VRTSourcedRasterBand)
 
+  protected:
+    bool           SkipBufferInitialization();
+
   public:
-    int            nSources;
-    VRTSource    **papoSources;
-    int            bSkipBufferInitialization;
+    int            nSources = 0;
+    VRTSource    **papoSources = nullptr;
 
                    VRTSourcedRasterBand( GDALDataset *poDS, int nBand );
                    VRTSourcedRasterBand( GDALDataType eType,

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -701,6 +701,8 @@ class CPL_DLL VRTSourcedRasterBand CPL_NON_FINAL: public VRTRasterBand
                                    double dfDstXOff, double dfDstYOff,
                                    double dfDstXSize, double dfDstYSize );
 
+    void RemoveCoveredSources(CSLConstList papszOptions = nullptr);
+
     virtual CPLErr IReadBlock( int, int, void * ) override;
 
     virtual void   GetFileList(char*** ppapszFileList, int *pnSize,

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -643,6 +643,16 @@ class CPL_DLL VRTSourcedRasterBand CPL_NON_FINAL: public VRTRasterBand
                                   void *pProgressData ) override;
 
     CPLErr         AddSource( VRTSource * );
+
+    CPLErr         AddSimpleSource( const char* pszFilename,
+                                    int nBand,
+                                    double dfSrcXOff=-1, double dfSrcYOff=-1,
+                                    double dfSrcXSize=-1, double dfSrcYSize=-1,
+                                    double dfDstXOff=-1, double dfDstYOff=-1,
+                                    double dfDstXSize=-1, double dfDstYSize=-1,
+                                    const char *pszResampling = "near",
+                                    double dfNoDataValue = VRT_NODATA_UNSET);
+
     CPLErr         AddSimpleSource( GDALRasterBand *poSrcBand,
                                     double dfSrcXOff=-1, double dfSrcYOff=-1,
                                     double dfSrcXSize=-1, double dfSrcYSize=-1,
@@ -650,6 +660,18 @@ class CPL_DLL VRTSourcedRasterBand CPL_NON_FINAL: public VRTRasterBand
                                     double dfDstXSize=-1, double dfDstYSize=-1,
                                     const char *pszResampling = "near",
                                     double dfNoDataValue = VRT_NODATA_UNSET);
+
+    CPLErr         AddComplexSource( const char* pszFilename,
+                                     int nBand,
+                                     double dfSrcXOff=-1, double dfSrcYOff=-1,
+                                     double dfSrcXSize=-1, double dfSrcYSize=-1,
+                                     double dfDstXOff=-1, double dfDstYOff=-1,
+                                     double dfDstXSize=-1, double dfDstYSize=-1,
+                                     double dfScaleOff=0.0,
+                                     double dfScaleRatio=1.0,
+                                     double dfNoDataValue = VRT_NODATA_UNSET,
+                                     int nColorTableComponent = 0);
+
     CPLErr         AddComplexSource( GDALRasterBand *poSrcBand,
                                      double dfSrcXOff=-1, double dfSrcYOff=-1,
                                      double dfSrcXSize=-1, double dfSrcYSize=-1,
@@ -952,6 +974,7 @@ public:
                              std::map<CPLString, GDALDataset*>& ) override;
     virtual CPLXMLNode *SerializeToXML( const char *pszVRTPath ) override;
 
+    void           SetSrcBand( const char* pszFilename, int nBand );
     void           SetSrcBand( GDALRasterBand * );
     void           SetSrcMaskBand( GDALRasterBand * );
     void           SetSrcWindow( double, double, double, double );

--- a/gdal/frmts/vrt/vrtderivedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtderivedrasterband.cpp
@@ -1254,12 +1254,10 @@ int  VRTDerivedRasterBand::IGetDataCoverageStatus( int /* nXOff */,
 
 CPLErr VRTDerivedRasterBand::XMLInit( CPLXMLNode *psTree,
                                       const char *pszVRTPath,
-                                      void* pUniqueHandle,
                                       std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
     const CPLErr eErr = VRTSourcedRasterBand::XMLInit( psTree, pszVRTPath,
-                                                       pUniqueHandle,
                                                        oMapSharedSources );
     if( eErr != CE_None )
         return eErr;

--- a/gdal/frmts/vrt/vrtderivedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtderivedrasterband.cpp
@@ -826,7 +826,7 @@ CPLErr VRTDerivedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
 /*      Initialize the buffer to some background value. Use the         */
 /*      nodata value if available.                                      */
 /* -------------------------------------------------------------------- */
-    if( bSkipBufferInitialization )
+    if( SkipBufferInitialization() )
     {
         // Do nothing
     }

--- a/gdal/frmts/vrt/vrtdriver.cpp
+++ b/gdal/frmts/vrt/vrtdriver.cpp
@@ -137,7 +137,6 @@ void VRTDriver::AddSourceParser( const char *pszElementName,
 /************************************************************************/
 
 VRTSource *VRTDriver::ParseSource( CPLXMLNode *psSrc, const char *pszVRTPath,
-                                   void* pUniqueHandle,
                                    std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
@@ -163,7 +162,7 @@ VRTSource *VRTDriver::ParseSource( CPLXMLNode *psSrc, const char *pszVRTPath,
     if( pfnParser == nullptr )
         return nullptr;
 
-    return pfnParser( psSrc, pszVRTPath, pUniqueHandle, oMapSharedSources );
+    return pfnParser( psSrc, pszVRTPath, oMapSharedSources );
 }
 
 /************************************************************************/

--- a/gdal/frmts/vrt/vrtfilters.cpp
+++ b/gdal/frmts/vrt/vrtfilters.cpp
@@ -174,11 +174,15 @@ VRTFilteredSource::RasterIO( GDALDataType eBandDataType,
     int nOutXSize = 0;
     int nOutYSize = 0;
 
+    bool bError = false;
     if( !GetSrcDstWindow( dfXOff, dfYOff, dfXSize, dfYSize, nBufXSize, nBufYSize,
                         &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                         &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                        &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) )
-        return CE_None;
+                        &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                        bError ) )
+    {
+        return bError ? CE_Failure : CE_None;
+    }
 
     pData = reinterpret_cast<GByte *>( pData )
         + nPixelSpace * nOutXOff
@@ -195,9 +199,13 @@ VRTFilteredSource::RasterIO( GDALDataType eBandDataType,
     if( IsTypeSupported( eBufType ) )
         eOperDataType = eBufType;
 
+    auto l_band = GetRasterBand();
+    if( !l_band )
+        return CE_Failure;
+
     if( eOperDataType == GDT_Unknown
-        && IsTypeSupported( m_poRasterBand->GetRasterDataType() ) )
-        eOperDataType = m_poRasterBand->GetRasterDataType();
+        && IsTypeSupported( l_band->GetRasterDataType() ) )
+        eOperDataType = l_band->GetRasterDataType();
 
     if( eOperDataType == GDT_Unknown )
     {
@@ -294,15 +302,15 @@ VRTFilteredSource::RasterIO( GDALDataType eBandDataType,
         nFileYSize -= nTopFill;
     }
 
-    if( nFileXOff + nFileXSize > m_poRasterBand->GetXSize() )
+    if( nFileXOff + nFileXSize > l_band->GetXSize() )
     {
-        nRightFill = nFileXOff + nFileXSize - m_poRasterBand->GetXSize();
+        nRightFill = nFileXOff + nFileXSize - l_band->GetXSize();
         nFileXSize -= nRightFill;
     }
 
-    if( nFileYOff + nFileYSize > m_poRasterBand->GetYSize() )
+    if( nFileYOff + nFileYSize > l_band->GetYSize() )
     {
-        nBottomFill = nFileYOff + nFileYSize - m_poRasterBand->GetYSize();
+        nBottomFill = nFileYOff + nFileYSize - l_band->GetYSize();
         nFileYSize -= nBottomFill;
     }
 
@@ -514,8 +522,11 @@ CPLErr VRTKernelFilteredSource::FilterData( int nXSize, int nYSize,
         float *pafDstData = reinterpret_cast<float *>( pabyDstData );
 
         int bHasNoData = FALSE;
+        auto l_poBand = GetRasterBand();
+        if( !l_poBand )
+            return CE_Failure;
         const float fNoData =
-            static_cast<float>( m_poRasterBand->GetNoDataValue(&bHasNoData) );
+            static_cast<float>( l_poBand->GetNoDataValue(&bHasNoData) );
 
         const int nAxisCount = m_bSeparable ? 2 : 1;
 

--- a/gdal/frmts/vrt/vrtfilters.cpp
+++ b/gdal/frmts/vrt/vrtfilters.cpp
@@ -600,13 +600,11 @@ CPLErr VRTKernelFilteredSource::FilterData( int nXSize, int nYSize,
 
 CPLErr VRTKernelFilteredSource::XMLInit( CPLXMLNode *psTree,
                                          const char *pszVRTPath,
-                                         void* pUniqueHandle,
                                          std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
     {
         const CPLErr eErr = VRTFilteredSource::XMLInit( psTree, pszVRTPath,
-                                                        pUniqueHandle,
                                                         oMapSharedSources );
         if( eErr != CE_None )
             return eErr;
@@ -704,14 +702,13 @@ CPLXMLNode *VRTKernelFilteredSource::SerializeToXML( const char *pszVRTPath )
 /************************************************************************/
 
 VRTSource *VRTParseFilterSources( CPLXMLNode *psChild, const char *pszVRTPath,
-                                  void* pUniqueHandle,
                                   std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
     if( EQUAL(psChild->pszValue, "KernelFilteredSource") )
     {
         VRTSource *poSrc = new VRTKernelFilteredSource();
-        if( poSrc->XMLInit( psChild, pszVRTPath, pUniqueHandle, oMapSharedSources ) == CE_None )
+        if( poSrc->XMLInit( psChild, pszVRTPath, oMapSharedSources ) == CE_None )
             return poSrc;
 
         delete poSrc;

--- a/gdal/frmts/vrt/vrtrasterband.cpp
+++ b/gdal/frmts/vrt/vrtrasterband.cpp
@@ -329,7 +329,6 @@ CPLErr VRTRasterBand::SetCategoryNames( char ** papszNewNames )
 
 CPLErr VRTRasterBand::XMLInit( CPLXMLNode * psTree,
                                const char *pszVRTPath,
-                               void* pUniqueHandle,
                                std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
@@ -593,7 +592,7 @@ CPLErr VRTRasterBand::XMLInit( CPLXMLNode * psTree,
             break;
         }
 
-        if( poBand->XMLInit( psNode, pszVRTPath, pUniqueHandle,
+        if( poBand->XMLInit( psNode, pszVRTPath,
                              oMapSharedSources ) == CE_None )
         {
             SetMaskBand(poBand);

--- a/gdal/frmts/vrt/vrtrawrasterband.cpp
+++ b/gdal/frmts/vrt/vrtrawrasterband.cpp
@@ -349,11 +349,10 @@ CPLVirtualMem * VRTRawRasterBand::GetVirtualMemAuto( GDALRWFlag eRWFlag,
 
 CPLErr VRTRawRasterBand::XMLInit( CPLXMLNode * psTree,
                                   const char *pszVRTPath,
-                                  void* pUniqueHandle,
                                   std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
-    const CPLErr eErr = VRTRasterBand::XMLInit( psTree, pszVRTPath, pUniqueHandle,
+    const CPLErr eErr = VRTRasterBand::XMLInit( psTree, pszVRTPath,
                                                 oMapSharedSources );
     if( eErr != CE_None )
         return eErr;

--- a/gdal/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtsourcedrasterband.cpp
@@ -988,13 +988,11 @@ CPLErr CPL_STDCALL VRTAddSource( VRTSourcedRasterBandH hVRTBand,
 
 CPLErr VRTSourcedRasterBand::XMLInit( CPLXMLNode * psTree,
                                       const char *pszVRTPath,
-                                      void* pUniqueHandle,
                                       std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
     {
         const CPLErr eErr = VRTRasterBand::XMLInit( psTree, pszVRTPath,
-                                                    pUniqueHandle,
                                                     oMapSharedSources );
         if( eErr != CE_None )
             return eErr;
@@ -1015,7 +1013,7 @@ CPLErr VRTSourcedRasterBand::XMLInit( CPLXMLNode * psTree,
 
         CPLErrorReset();
         VRTSource * const poSource =
-            poDriver->ParseSource( psChild, pszVRTPath, pUniqueHandle,
+            poDriver->ParseSource( psChild, pszVRTPath,
                                    oMapSharedSources );
         if( poSource != nullptr )
             AddSource( poSource );
@@ -1640,7 +1638,6 @@ CPLErr VRTSourcedRasterBand::SetMetadataItem( const char *pszName,
 
         auto l_poDS = cpl::down_cast<VRTDataset*>(GetDataset());
         VRTSource * const poSource = poDriver->ParseSource( psTree, nullptr,
-                                                            l_poDS,
                                                             l_poDS->m_oMapSharedSources );
         CPLDestroyXMLNode( psTree );
 
@@ -1673,7 +1670,6 @@ CPLErr VRTSourcedRasterBand::SetMetadataItem( const char *pszName,
 
         auto l_poDS = cpl::down_cast<VRTDataset*>(GetDataset());
         VRTSource * const poSource = poDriver->ParseSource( psTree, nullptr,
-                                                            l_poDS,
                                                             l_poDS->m_oMapSharedSources );
         CPLDestroyXMLNode( psTree );
 
@@ -1725,7 +1721,6 @@ CPLErr VRTSourcedRasterBand::SetMetadata( char **papszNewMD, const char *pszDoma
 
             auto l_poDS = cpl::down_cast<VRTDataset*>(GetDataset());
             VRTSource * const poSource = poDriver->ParseSource( psTree, nullptr,
-                                                                l_poDS,
                                                                 l_poDS->m_oMapSharedSources );
             CPLDestroyXMLNode( psTree );
 

--- a/gdal/frmts/vrt/vrtsources.cpp
+++ b/gdal/frmts/vrt/vrtsources.cpp
@@ -829,11 +829,9 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
 void VRTSimpleSource::GetFileList( char*** ppapszFileList, int *pnSize,
                                    int *pnMaxSize, CPLHashSet* hSetFiles )
 {
-    const char* pszFilename = nullptr;
-    auto l_band = GetRasterBand();
-    if( l_band != nullptr && l_band->GetDataset() != nullptr &&
-        (pszFilename = l_band->GetDataset()->GetDescription()) != nullptr )
+    if( !m_osSrcDSName.empty() )
     {
+        const char* pszFilename = m_osSrcDSName.c_str();
 /* -------------------------------------------------------------------- */
 /*      Is the filename even a real filesystem object?                  */
 /* -------------------------------------------------------------------- */

--- a/gdal/frmts/vrt/vrtsources.cpp
+++ b/gdal/frmts/vrt/vrtsources.cpp
@@ -182,6 +182,17 @@ void VRTSimpleSource::UnsetPreservedRelativeFilenames()
 /*                             SetSrcBand()                             */
 /************************************************************************/
 
+void VRTSimpleSource::SetSrcBand( const char* pszFilename, int nBand )
+
+{
+    m_nBand = nBand;
+    m_osSrcDSName = pszFilename;
+}
+
+/************************************************************************/
+/*                             SetSrcBand()                             */
+/************************************************************************/
+
 void VRTSimpleSource::SetSrcBand( GDALRasterBand *poNewSrcBand )
 
 {

--- a/gdal/frmts/vrt/vrtsources.cpp
+++ b/gdal/frmts/vrt/vrtsources.cpp
@@ -96,24 +96,7 @@ void VRTSource::GetFileList(char*** /* ppapszFileList */,
 /*                          VRTSimpleSource()                           */
 /************************************************************************/
 
-VRTSimpleSource::VRTSimpleSource() :
-    m_poRasterBand(nullptr),
-    m_poMaskBandMainBand(nullptr),
-    m_dfSrcXOff(0.0),
-    m_dfSrcYOff(0.0),
-    m_dfSrcXSize(0.0),
-    m_dfSrcYSize(0.0),
-    m_dfDstXOff(0.0),
-    m_dfDstYOff(0.0),
-    m_dfDstXSize(0.0),
-    m_dfDstYSize(0.0),
-    m_bNoDataSet(FALSE),
-    m_dfNoDataValue(VRT_NODATA_UNSET),
-    m_nMaxValue(0),
-    m_bRelativeToVRTOri(-1),
-    m_nExplicitSharedStatus(-1),
-    m_bDropRefOnSrcBand(true)
-{}
+VRTSimpleSource::VRTSimpleSource() = default;
 
 /************************************************************************/
 /*                          VRTSimpleSource()                           */
@@ -121,8 +104,12 @@ VRTSimpleSource::VRTSimpleSource() :
 
 VRTSimpleSource::VRTSimpleSource( const VRTSimpleSource* poSrcSource,
                                   double dfXDstRatio, double dfYDstRatio ) :
+    m_poMapSharedSources(poSrcSource->m_poMapSharedSources),
     m_poRasterBand(poSrcSource->m_poRasterBand),
     m_poMaskBandMainBand(poSrcSource->m_poMaskBandMainBand),
+    m_aosOpenOptions(poSrcSource->m_aosOpenOptions),
+    m_nBand(poSrcSource->m_nBand),
+    m_bGetMaskBand(poSrcSource->m_bGetMaskBand),
     m_dfSrcXOff(poSrcSource->m_dfSrcXOff),
     m_dfSrcYOff(poSrcSource->m_dfSrcYOff),
     m_dfSrcXSize(poSrcSource->m_dfSrcXSize),
@@ -136,6 +123,7 @@ VRTSimpleSource::VRTSimpleSource( const VRTSimpleSource* poSrcSource,
     m_nMaxValue(poSrcSource->m_nMaxValue),
     m_bRelativeToVRTOri(-1),
     m_nExplicitSharedStatus(poSrcSource->m_nExplicitSharedStatus),
+    m_osSrcDSName(poSrcSource->m_osSrcDSName),
     m_bDropRefOnSrcBand(poSrcSource->m_bDropRefOnSrcBand)
 {}
 
@@ -198,6 +186,10 @@ void VRTSimpleSource::SetSrcBand( GDALRasterBand *poNewSrcBand )
 
 {
     m_poRasterBand = poNewSrcBand;
+    m_nBand = m_poRasterBand->GetBand();
+    auto poDS = poNewSrcBand->GetDataset();
+    if( poDS != nullptr )
+        m_osSrcDSName = poDS->GetDescription();
 }
 
 /************************************************************************/
@@ -211,6 +203,11 @@ void VRTSimpleSource::SetSrcMaskBand( GDALRasterBand *poNewSrcBand )
 {
     m_poRasterBand = poNewSrcBand->GetMaskBand();
     m_poMaskBandMainBand = poNewSrcBand;
+    m_nBand = poNewSrcBand->GetBand();
+    auto poDS = poNewSrcBand->GetDataset();
+    if( poDS != nullptr )
+        m_osSrcDSName = poDS->GetDescription();
+    m_bGetMaskBand = true;
 }
 
 /************************************************************************/
@@ -288,21 +285,23 @@ static const char* const apszSpecialSyntax[] = {
 CPLXMLNode *VRTSimpleSource::SerializeToXML( const char *pszVRTPath )
 
 {
-    if( m_poRasterBand == nullptr )
+    auto l_band = GetRasterBand();
+    if( l_band == nullptr )
         return nullptr;
 
     GDALDataset *poDS = nullptr;
 
-    if( m_poMaskBandMainBand )
+    auto l_maskband = GetMaskBandMainBand();
+    if( l_maskband )
     {
-        poDS = m_poMaskBandMainBand->GetDataset();
-        if( poDS == nullptr || m_poMaskBandMainBand->GetBand() < 1 )
+        poDS = l_maskband->GetDataset();
+        if( poDS == nullptr || l_maskband->GetBand() < 1 )
             return nullptr;
     }
     else
     {
-        poDS = m_poRasterBand->GetDataset();
-        if( poDS == nullptr || m_poRasterBand->GetBand() < 1 )
+        poDS = l_band->GetDataset();
+        if( poDS == nullptr || l_band->GetBand() < 1 )
             return nullptr;
     }
 
@@ -427,26 +426,26 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML( const char *pszVRTPath )
     char** papszOpenOptions = poDS->GetOpenOptions();
     GDALSerializeOpenOptionsToXML(psSrc, papszOpenOptions);
 
-    if( m_poMaskBandMainBand )
+    if( l_maskband )
         CPLSetXMLValue( psSrc, "SourceBand",
-                        CPLSPrintf("mask,%d",m_poMaskBandMainBand->GetBand()) );
+                        CPLSPrintf("mask,%d",l_maskband->GetBand()) );
     else
         CPLSetXMLValue( psSrc, "SourceBand",
-                        CPLSPrintf("%d",m_poRasterBand->GetBand()) );
+                        CPLSPrintf("%d",l_band->GetBand()) );
 
     /* Write a few additional useful properties of the dataset */
     /* so that we can use a proxy dataset when re-opening. See XMLInit() */
     /* below */
     CPLSetXMLValue( psSrc, "SourceProperties.#RasterXSize",
-                    CPLSPrintf("%d",m_poRasterBand->GetXSize()) );
+                    CPLSPrintf("%d",l_band->GetXSize()) );
     CPLSetXMLValue( psSrc, "SourceProperties.#RasterYSize",
-                    CPLSPrintf("%d",m_poRasterBand->GetYSize()) );
+                    CPLSPrintf("%d",l_band->GetYSize()) );
     CPLSetXMLValue( psSrc, "SourceProperties.#DataType",
-                GDALGetDataTypeName( m_poRasterBand->GetRasterDataType() ) );
+                GDALGetDataTypeName( l_band->GetRasterDataType() ) );
 
     int nBlockXSize = 0;
     int nBlockYSize = 0;
-    m_poRasterBand->GetBlockSize(&nBlockXSize, &nBlockYSize);
+    l_band->GetBlockSize(&nBlockXSize, &nBlockYSize);
 
     CPLSetXMLValue( psSrc, "SourceProperties.#BlockXSize",
                     CPLSPrintf("%d",nBlockXSize) );
@@ -491,6 +490,8 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
                                  std::map<CPLString, GDALDataset*>& oMapSharedSources )
 
 {
+    m_poMapSharedSources = &oMapSharedSources;
+
     m_osResampling = CPLGetXMLValue( psSrc, "resampling", "");
 
 /* -------------------------------------------------------------------- */
@@ -530,7 +531,6 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
         bShared = true;
     }
 
-    CPLString osSrcDSName;
     if( pszVRTPath != nullptr && m_bRelativeToVRTOri )
     {
         bool bDone = false;
@@ -558,7 +558,7 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
                     }
                     CPLString osPrefixFilename = pszFilename;
                     osPrefixFilename.resize(pszLastPart - pszFilename);
-                    osSrcDSName = osPrefixFilename +
+                    m_osSrcDSName = osPrefixFilename +
                         CPLProjectRelativeFilename( pszVRTPath, pszLastPart );
                     bDone = true;
                 }
@@ -576,7 +576,7 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
                     {
                         const CPLString osSuffix = osFilename.substr(nPos);
                         osFilename.resize(nPos);
-                        osSrcDSName =
+                        m_osSrcDSName =
                             osPrefix + CPLProjectRelativeFilename(
                                 pszVRTPath, osFilename ) + osSuffix;
                         bDone = true;
@@ -587,30 +587,29 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
         }
         if( !bDone )
         {
-            osSrcDSName = CPLProjectRelativeFilename( pszVRTPath, pszFilename );
+            m_osSrcDSName = CPLProjectRelativeFilename( pszVRTPath, pszFilename );
         }
     }
     else
     {
-        osSrcDSName = pszFilename;
+        m_osSrcDSName = pszFilename;
     }
 
     const char* pszSourceBand = CPLGetXMLValue(psSrc,"SourceBand","1");
-    int nSrcBand = 0;
-    bool bGetMaskBand = false;
+    m_bGetMaskBand = false;
     if( STARTS_WITH_CI(pszSourceBand, "mask") )
     {
-        bGetMaskBand = true;
+        m_bGetMaskBand = true;
         if( pszSourceBand[4] == ',' )
-            nSrcBand = atoi(pszSourceBand + 5);
+            m_nBand = atoi(pszSourceBand + 5);
         else
-            nSrcBand = 1;
+            m_nBand = 1;
     }
     else
     {
-        nSrcBand = atoi(pszSourceBand);
+        m_nBand = atoi(pszSourceBand);
     }
-    if( !GDALCheckBandCount(nSrcBand, 0) )
+    if( !GDALCheckBandCount(m_nBand, 0) )
     {
         CPLError( CE_Warning, CPLE_AppDefined,
                   "Invalid <SourceBand> element in VRTRasterBand." );
@@ -661,10 +660,9 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
         }
     }
 
-    char** papszOpenOptions = GDALDeserializeOpenOptionsFromXML(psSrc);
-    if( strstr(osSrcDSName.c_str(),"<VRTDataset") != nullptr )
-        papszOpenOptions =
-            CSLSetNameValue(papszOpenOptions, "ROOT_PATH", pszVRTPath);
+    m_aosOpenOptions = GDALDeserializeOpenOptionsFromXML(psSrc);
+    if( strstr(m_osSrcDSName.c_str(),"<VRTDataset") != nullptr )
+        m_aosOpenOptions.SetNameValue("ROOT_PATH", pszVRTPath);
 
     bool bAddToMapIfOk = false;
     GDALDataset *poSrcDS = nullptr;
@@ -682,7 +680,7 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
             // annoying reference cycles in situations like you have
             // foo.tif and foo.tif.ovr, the later being actually a VRT file
             // that points to foo.tif
-            auto oIter = oMapSharedSources.find(osSrcDSName);
+            auto oIter = oMapSharedSources.find(m_osSrcDSName);
             if( oIter != oMapSharedSources.end() )
             {
                 poSrcDS = oIter->second;
@@ -691,8 +689,8 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
             else
             {
                 poSrcDS = static_cast<GDALDataset *>( GDALOpenEx(
-                        osSrcDSName, nOpenFlags, nullptr,
-                        papszOpenOptions, nullptr ) );
+                        m_osSrcDSName, nOpenFlags, nullptr,
+                        m_aosOpenOptions.List(), nullptr ) );
                 if( poSrcDS )
                 {
                     bAddToMapIfOk = true;
@@ -702,8 +700,8 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
         else
         {
             poSrcDS = static_cast<GDALDataset *>( GDALOpenEx(
-                        osSrcDSName, nOpenFlags, nullptr,
-                        papszOpenOptions, nullptr ) );
+                        m_osSrcDSName, nOpenFlags, nullptr,
+                        m_aosOpenOptions.List(), nullptr ) );
         }
     }
     else
@@ -713,34 +711,32 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
         /* ----------------------------------------------------------------- */
         CPLString osUniqueHandle( CPLSPrintf("%p", pUniqueHandle) );
         GDALProxyPoolDataset * const proxyDS =
-            new GDALProxyPoolDataset( osSrcDSName, nRasterXSize, nRasterYSize,
+            new GDALProxyPoolDataset( m_osSrcDSName, nRasterXSize, nRasterYSize,
                                       GA_ReadOnly, bShared, nullptr, nullptr,
                                       osUniqueHandle.c_str() );
-        proxyDS->SetOpenOptions(papszOpenOptions);
+        proxyDS->SetOpenOptions(m_aosOpenOptions.List());
         poSrcDS = proxyDS;
 
-        // Only the information of rasterBand nSrcBand will be accurate
+        // Only the information of rasterBand m_nBand will be accurate
         // but that's OK since we only use that band afterwards.
         //
-        // Previously this added a src band for every band <= nSrcBand, but this becomes
+        // Previously this added a src band for every band <= m_nBand, but this becomes
         // prohibitely expensive for files with a large number of bands. This optimization
         // only adds the desired band and the rest of the bands will simply be initialized with a nullptr.
         // This assumes no other code here accesses any of the lower bands in the GDALProxyPoolDataset.
         // It has been suggested that in addition, we should to try share GDALProxyPoolDataset between multiple
         // Simple Sources, which would save on memory for papoBands. For now, that's not implemented.
-        proxyDS->AddSrcBand(nSrcBand, eDataType, nBlockXSize, nBlockYSize);
+        proxyDS->AddSrcBand(m_nBand, eDataType, nBlockXSize, nBlockYSize);
 
-        if( bGetMaskBand )
+        if( m_bGetMaskBand )
         {
           GDALProxyPoolRasterBand *poMaskBand =
               cpl::down_cast<GDALProxyPoolRasterBand *>(
-              proxyDS->GetRasterBand(nSrcBand) );
+              proxyDS->GetRasterBand(m_nBand) );
           poMaskBand->AddSrcMaskBandDescription(
               eDataType, nBlockXSize, nBlockYSize );
         }
     }
-
-    CSLDestroy(papszOpenOptions);
 
     if( poSrcDS == nullptr )
         return CE_Failure;
@@ -749,7 +745,7 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
 /*      Get the raster band.                                            */
 /* -------------------------------------------------------------------- */
 
-    m_poRasterBand = poSrcDS->GetRasterBand(nSrcBand);
+    m_poRasterBand = poSrcDS->GetRasterBand(m_nBand);
     if( m_poRasterBand == nullptr )
     {
         poSrcDS->ReleaseRef();
@@ -757,10 +753,10 @@ CPLErr VRTSimpleSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
     }
     else if( bAddToMapIfOk )
     {
-        oMapSharedSources[osSrcDSName] = poSrcDS;
+        oMapSharedSources[m_osSrcDSName] = poSrcDS;
     }
 
-    if( bGetMaskBand )
+    if( m_bGetMaskBand )
     {
         m_poMaskBandMainBand = m_poRasterBand;
         m_poRasterBand = m_poRasterBand->GetMaskBand();
@@ -834,8 +830,9 @@ void VRTSimpleSource::GetFileList( char*** ppapszFileList, int *pnSize,
                                    int *pnMaxSize, CPLHashSet* hSetFiles )
 {
     const char* pszFilename = nullptr;
-    if( m_poRasterBand != nullptr && m_poRasterBand->GetDataset() != nullptr &&
-        (pszFilename = m_poRasterBand->GetDataset()->GetDescription()) != nullptr )
+    auto l_band = GetRasterBand();
+    if( l_band != nullptr && l_band->GetDataset() != nullptr &&
+        (pszFilename = l_band->GetDataset()->GetDescription()) != nullptr )
     {
 /* -------------------------------------------------------------------- */
 /*      Is the filename even a real filesystem object?                  */
@@ -881,12 +878,21 @@ void VRTSimpleSource::GetFileList( char*** ppapszFileList, int *pnSize,
 }
 
 /************************************************************************/
-/*                             GetBand()                                */
+/*                         GetRasterBand()                              */
 /************************************************************************/
 
-GDALRasterBand* VRTSimpleSource::GetBand()
+GDALRasterBand* VRTSimpleSource::GetRasterBand() const
 {
-    return m_poMaskBandMainBand ? nullptr : m_poRasterBand;
+    return m_poRasterBand;
+}
+
+/************************************************************************/
+/*                        GetMaskBandMainBand()                         */
+/************************************************************************/
+
+GDALRasterBand* VRTSimpleSource::GetMaskBandMainBand()
+{
+    return m_poMaskBandMainBand;
 }
 
 /************************************************************************/
@@ -905,11 +911,8 @@ int VRTSimpleSource::IsSameExceptBandNumber( VRTSimpleSource* poOtherSource )
            m_dfDstYSize == poOtherSource->m_dfDstYSize &&
            m_bNoDataSet == poOtherSource->m_bNoDataSet &&
            m_dfNoDataValue == poOtherSource->m_dfNoDataValue &&
-           GetBand() != nullptr && poOtherSource->GetBand() != nullptr &&
-           GetBand()->GetDataset() != nullptr &&
-           poOtherSource->GetBand()->GetDataset() != nullptr &&
-           EQUAL(GetBand()->GetDataset()->GetDescription(),
-                 poOtherSource->GetBand()->GetDataset()->GetDescription());
+           !m_osSrcDSName.empty() &&
+           m_osSrcDSName == poOtherSource->m_osSrcDSName;
 }
 
 /************************************************************************/
@@ -953,9 +956,12 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
                                   int *pnReqXOff, int *pnReqYOff,
                                   int *pnReqXSize, int *pnReqYSize,
                                   int *pnOutXOff, int *pnOutYOff,
-                                  int *pnOutXSize, int *pnOutYSize )
+                                  int *pnOutXSize, int *pnOutYSize,
+                                  bool& bErrorOut )
 
 {
+    bErrorOut = false;
+
     if( m_dfSrcXSize == 0.0 || m_dfSrcYSize == 0.0 ||
         m_dfDstXSize == 0.0 || m_dfDstYSize == 0.0 )
     {
@@ -1099,27 +1105,33 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
     if( *pnReqYSize == 0 )
         *pnReqYSize = 1;
 
-    if( *pnReqXSize > INT_MAX - *pnReqXOff ||
-        *pnReqXOff + *pnReqXSize > m_poRasterBand->GetXSize() )
+    auto l_band = GetRasterBand();
+    if( !l_band )
     {
-        *pnReqXSize = m_poRasterBand->GetXSize() - *pnReqXOff;
+        bErrorOut = true;
+        return FALSE;
+    }
+    if( *pnReqXSize > INT_MAX - *pnReqXOff ||
+        *pnReqXOff + *pnReqXSize > l_band->GetXSize() )
+    {
+        *pnReqXSize = l_band->GetXSize() - *pnReqXOff;
         bModifiedX = true;
     }
-    if( *pdfReqXOff + *pdfReqXSize > m_poRasterBand->GetXSize() )
+    if( *pdfReqXOff + *pdfReqXSize > l_band->GetXSize() )
     {
-        *pdfReqXSize = m_poRasterBand->GetXSize() - *pdfReqXOff;
+        *pdfReqXSize = l_band->GetXSize() - *pdfReqXOff;
         bModifiedX = true;
     }
 
     if( *pnReqYSize > INT_MAX - *pnReqYOff ||
-        *pnReqYOff + *pnReqYSize > m_poRasterBand->GetYSize() )
+        *pnReqYOff + *pnReqYSize > l_band->GetYSize() )
     {
-        *pnReqYSize = m_poRasterBand->GetYSize() - *pnReqYOff;
+        *pnReqYSize = l_band->GetYSize() - *pnReqYOff;
         bModifiedY = true;
     }
-    if( *pdfReqYOff + *pdfReqYSize > m_poRasterBand->GetYSize() )
+    if( *pdfReqYOff + *pdfReqYSize > l_band->GetYSize() )
     {
-        *pdfReqYSize = m_poRasterBand->GetYSize() - *pdfReqYOff;
+        *pdfReqYSize = l_band->GetYSize() - *pdfReqYOff;
         bModifiedY = true;
     }
 
@@ -1127,8 +1139,8 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
 /*      Don't do anything if the requesting region is completely off    */
 /*      the source image.                                               */
 /* -------------------------------------------------------------------- */
-    if( *pnReqXOff >= m_poRasterBand->GetXSize()
-        || *pnReqYOff >= m_poRasterBand->GetYSize()
+    if( *pnReqXOff >= l_band->GetXSize()
+        || *pnReqYOff >= l_band->GetYSize()
         || *pnReqXSize <= 0 || *pnReqYSize <= 0 )
     {
         return FALSE;
@@ -1256,8 +1268,11 @@ int VRTSimpleSource::NeedMaxValAdjustment() const
     if( !m_nMaxValue )
         return FALSE;
 
+    auto l_band = GetRasterBand();
+    if( !l_band )
+        return FALSE;
     const char* pszNBITS =
-        m_poRasterBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+        l_band->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
     const int nBits = (pszNBITS) ? atoi(pszNBITS) : 0;
     if( nBits >= 1 && nBits <= 31 )
     {
@@ -1313,13 +1328,15 @@ VRTSimpleSource::RasterIO( GDALDataType eBandDataType,
     int nOutXSize = 0;
     int nOutYSize = 0;
 
+    bool bError = false;
     if( !GetSrcDstWindow( dfXOff, dfYOff, dfXSize, dfYSize,
                           nBufXSize, nBufYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) )
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) )
     {
-        return CE_None;
+        return bError ? CE_Failure : CE_None;
     }
 #if DEBUG_VERBOSE
     CPLDebug(
@@ -1357,9 +1374,12 @@ VRTSimpleSource::RasterIO( GDALDataType eBandDataType,
         + nOutXOff * nPixelSpace
         + static_cast<GPtrDiff_t>(nOutYOff) * nLineSpace;
 
-    CPLErr eErr = CE_Failure;
+    auto l_band = GetRasterBand();
+    if( !l_band )
+        return CE_Failure;
 
-    if( GDALDataTypeIsConversionLossy(m_poRasterBand->GetRasterDataType(),
+    CPLErr eErr = CE_Failure;
+    if( GDALDataTypeIsConversionLossy(l_band->GetRasterDataType(),
                                       eBandDataType) )
     {
         const int nBandDTSize = GDALGetDataTypeSizeBytes(eBandDataType);
@@ -1367,7 +1387,7 @@ VRTSimpleSource::RasterIO( GDALDataType eBandDataType,
         if( pTemp )
         {
             eErr =
-                m_poRasterBand->RasterIO(
+                l_band->RasterIO(
                     GF_Read,
                     nReqXOff, nReqYOff, nReqXSize, nReqYSize,
                     pTemp,
@@ -1394,7 +1414,7 @@ VRTSimpleSource::RasterIO( GDALDataType eBandDataType,
     else
     {
         eErr =
-            m_poRasterBand->RasterIO(
+            l_band->RasterIO(
                 GF_Read,
                 nReqXOff, nReqYOff, nReqXSize, nReqYSize,
                 pabyOut,
@@ -1448,20 +1468,24 @@ double VRTSimpleSource::GetMinimum( int nXSize, int nYSize, int *pbSuccess )
     int nOutXSize = 0;
     int nOutYSize = 0;
 
-    if( !GetSrcDstWindow( 0, 0, nXSize, nYSize,
+    bool bError = false;
+    auto l_band = GetRasterBand();
+    if( !l_band ||
+        !GetSrcDstWindow( 0, 0, nXSize, nYSize,
                           nXSize, nYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) ||
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) ||
         nReqXOff != 0 || nReqYOff != 0 ||
-        nReqXSize != m_poRasterBand->GetXSize() ||
-        nReqYSize != m_poRasterBand->GetYSize())
+        nReqXSize != l_band->GetXSize() ||
+        nReqYSize != l_band->GetYSize())
     {
         *pbSuccess = FALSE;
         return 0;
     }
 
-    const double dfVal = m_poRasterBand->GetMinimum(pbSuccess);
+    const double dfVal = l_band->GetMinimum(pbSuccess);
     if( NeedMaxValAdjustment() && dfVal > m_nMaxValue )
         return m_nMaxValue;
     return dfVal;
@@ -1489,20 +1513,24 @@ double VRTSimpleSource::GetMaximum( int nXSize, int nYSize, int *pbSuccess )
     int nOutXSize = 0;
     int nOutYSize = 0;
 
-    if( !GetSrcDstWindow( 0, 0, nXSize, nYSize,
+    bool bError = false;
+    auto l_band = GetRasterBand();
+    if( !l_band ||
+        !GetSrcDstWindow( 0, 0, nXSize, nYSize,
                           nXSize, nYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) ||
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) ||
         nReqXOff != 0 || nReqYOff != 0 ||
-        nReqXSize != m_poRasterBand->GetXSize() ||
-        nReqYSize != m_poRasterBand->GetYSize())
+        nReqXSize != l_band->GetXSize() ||
+        nReqYSize != l_band->GetYSize())
     {
         *pbSuccess = FALSE;
         return 0;
     }
 
-    const double dfVal = m_poRasterBand->GetMaximum(pbSuccess);
+    const double dfVal = l_band->GetMaximum(pbSuccess);
     if( NeedMaxValAdjustment() && dfVal > m_nMaxValue )
         return m_nMaxValue;
     return dfVal;
@@ -1531,20 +1559,24 @@ CPLErr VRTSimpleSource::ComputeRasterMinMax( int nXSize, int nYSize,
     int nOutXSize = 0;
     int nOutYSize = 0;
 
-    if( !GetSrcDstWindow( 0, 0, nXSize, nYSize,
+    bool bError = false;
+    auto l_band = GetRasterBand();
+    if( !l_band ||
+        !GetSrcDstWindow( 0, 0, nXSize, nYSize,
                           nXSize, nYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) ||
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) ||
         nReqXOff != 0 || nReqYOff != 0 ||
-        nReqXSize != m_poRasterBand->GetXSize() ||
-        nReqYSize != m_poRasterBand->GetYSize())
+        nReqXSize != l_band->GetXSize() ||
+        nReqYSize != l_band->GetYSize())
     {
         return CE_Failure;
     }
 
     const CPLErr eErr =
-        m_poRasterBand->ComputeRasterMinMax( bApproxOK, adfMinMax );
+        l_band->ComputeRasterMinMax( bApproxOK, adfMinMax );
     if( NeedMaxValAdjustment() )
     {
         if( adfMinMax[0] > m_nMaxValue )
@@ -1582,22 +1614,26 @@ CPLErr VRTSimpleSource::ComputeStatistics(
     int nOutXSize = 0;
     int nOutYSize = 0;
 
-    if( NeedMaxValAdjustment() ||
+    bool bError = false;
+    auto l_band = GetRasterBand();
+    if( !l_band ||
+        NeedMaxValAdjustment() ||
         !GetSrcDstWindow( 0, 0, nXSize, nYSize,
                           nXSize, nYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) ||
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) ||
         nReqXOff != 0 || nReqYOff != 0 ||
-        nReqXSize != m_poRasterBand->GetXSize() ||
-        nReqYSize != m_poRasterBand->GetYSize())
+        nReqXSize != l_band->GetXSize() ||
+        nReqYSize != l_band->GetYSize())
     {
         return CE_Failure;
     }
 
-    return m_poRasterBand->ComputeStatistics( bApproxOK, pdfMin, pdfMax,
-                                              pdfMean, pdfStdDev,
-                                              pfnProgress, pProgressData );
+    return l_band->ComputeStatistics( bApproxOK, pdfMin, pdfMax,
+                                      pdfMean, pdfStdDev,
+                                      pfnProgress, pProgressData );
 }
 
 /************************************************************************/
@@ -1627,23 +1663,27 @@ CPLErr VRTSimpleSource::GetHistogram(
     int nOutXSize = 0;
     int nOutYSize = 0;
 
-    if( NeedMaxValAdjustment() ||
+    bool bError = false;
+    auto l_band = GetRasterBand();
+    if( !l_band ||
+        NeedMaxValAdjustment() ||
         !GetSrcDstWindow( 0, 0, nXSize, nYSize,
                           nXSize, nYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) ||
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) ||
         nReqXOff != 0 || nReqYOff != 0 ||
-        nReqXSize != m_poRasterBand->GetXSize() ||
-        nReqYSize != m_poRasterBand->GetYSize())
+        nReqXSize != l_band->GetXSize() ||
+        nReqYSize != l_band->GetYSize())
     {
         return CE_Failure;
     }
 
-    return m_poRasterBand->GetHistogram( dfMin, dfMax, nBuckets,
-                                         panHistogram,
-                                         bIncludeOutOfRange, bApproxOK,
-                                         pfnProgress, pProgressData );
+    return l_band->GetHistogram( dfMin, dfMax, nBuckets,
+                                 panHistogram,
+                                 bIncludeOutOfRange, bApproxOK,
+                                 pfnProgress, pProgressData );
 }
 
 /************************************************************************/
@@ -1699,16 +1739,22 @@ CPLErr VRTSimpleSource::DatasetRasterIO(
     int nOutXSize = 0;
     int nOutYSize = 0;
 
+    bool bError = false;
     if( !GetSrcDstWindow( dfXOff, dfYOff, dfXSize, dfYSize,
                           nBufXSize, nBufYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) )
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) )
     {
-        return CE_None;
+        return bError ? CE_Failure : CE_None;
     }
 
-    GDALDataset* poDS = m_poRasterBand->GetDataset();
+    auto l_band = GetRasterBand();
+    if( !l_band )
+        return CE_Failure;
+
+    GDALDataset* poDS = l_band->GetDataset();
     if( poDS == nullptr )
         return CE_Failure;
 
@@ -1733,7 +1779,7 @@ CPLErr VRTSimpleSource::DatasetRasterIO(
 
     CPLErr eErr = CE_Failure;
 
-    if( GDALDataTypeIsConversionLossy(m_poRasterBand->GetRasterDataType(),
+    if( GDALDataTypeIsConversionLossy(l_band->GetRasterDataType(),
                                       eBandDataType) )
     {
         const int nBandDTSize = GDALGetDataTypeSizeBytes(eBandDataType);
@@ -1900,12 +1946,21 @@ VRTAveragedSource::RasterIO( GDALDataType /*eBandDataType*/,
     int nOutXSize = 0;
     int nOutYSize = 0;
 
+    bool bError = false;
     if( !GetSrcDstWindow( dfXOff, dfYOff, dfXSize, dfYSize,
                           nBufXSize, nBufYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) )
-        return CE_None;
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError
+                        ) )
+    {
+        return bError ? CE_Failure : CE_None;
+    }
+
+    auto l_band = GetRasterBand();
+    if( !l_band )
+        return CE_Failure;
 
 /* -------------------------------------------------------------------- */
 /*      Allocate a temporary buffer to whole the full resolution        */
@@ -1937,7 +1992,7 @@ VRTAveragedSource::RasterIO( GDALDataType /*eBandDataType*/,
     psExtraArg->dfYSize = dfReqYSize;
 
     const CPLErr eErr =
-        m_poRasterBand->RasterIO( GF_Read,
+        l_band->RasterIO( GF_Read,
                                   nReqXOff, nReqYOff, nReqXSize, nReqYSize,
                                   pafSrc, nReqXSize, nReqYSize, GDT_Float32,
                                   0, 0, psExtraArg );
@@ -2213,8 +2268,12 @@ CPLXMLNode *VRTComplexSource::SerializeToXML( const char *pszVRTPath )
 
     if( m_bNoDataSet )
     {
-        CPLSetXMLValue( psSrc, "NODATA", VRTSerializeNoData(
-            m_dfNoDataValue, m_poRasterBand->GetRasterDataType(), 16).c_str());
+        auto l_band = GetRasterBand();
+        if( l_band )
+        {
+            CPLSetXMLValue( psSrc, "NODATA", VRTSerializeNoData(
+                m_dfNoDataValue, l_band->GetRasterDataType(), 16).c_str());
+        }
     }
 
     switch( m_eScalingType )
@@ -2352,7 +2411,8 @@ CPLErr VRTComplexSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
     {
         m_bNoDataSet = TRUE;
         m_dfNoDataValue = CPLAtofM( CPLGetXMLValue(psSrc, "NODATA", "0") );
-        if( m_poRasterBand->GetRasterDataType() == GDT_Float32 )
+        auto l_band = GetRasterBand();
+        if( l_band != nullptr && l_band->GetRasterDataType() == GDT_Float32 )
         {
             m_dfNoDataValue = GDALAdjustNoDataCloseToFloatMax(m_dfNoDataValue);
         }
@@ -2557,12 +2617,16 @@ VRTComplexSource::RasterIO( GDALDataType /*eBandDataType*/,
     int nOutXSize = 0;
     int nOutYSize = 0;
 
+    bool bError = false;
     if( !GetSrcDstWindow( dfXOff, dfYOff, dfXSize, dfYSize,
                           nBufXSize, nBufYSize,
                           &dfReqXOff, &dfReqYOff, &dfReqXSize, &dfReqYSize,
                           &nReqXOff, &nReqYOff, &nReqXSize, &nReqYSize,
-                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize ) )
-        return CE_None;
+                          &nOutXOff, &nOutYOff, &nOutXSize, &nOutYSize,
+                          bError ) )
+    {
+        return bError ? CE_Failure : CE_None;
+    }
 #if DEBUG_VERBOSE
     CPLDebug(
         "VRT",
@@ -2576,6 +2640,10 @@ VRTComplexSource::RasterIO( GDALDataType /*eBandDataType*/,
         nReqXOff, nReqYOff, nReqXSize, nReqYSize,
         nOutXOff, nOutYOff, nOutXSize, nOutYSize );
 #endif
+
+    auto l_poBand = GetRasterBand();
+    if( !l_poBand )
+        return CE_Failure;
 
     if( !m_osResampling.empty() )
     {
@@ -2650,10 +2718,13 @@ CPLErr VRTComplexSource::RasterIOInternal( int nReqXOff, int nReqYOff,
     // has a nodata value, then use it as if it was set as <NODATA>
     int bNoDataSet = m_bNoDataSet;
     double dfNoDataValue = m_dfNoDataValue;
+    auto l_band = GetRasterBand();
+    if( !l_band )
+        return CE_Failure;
     if( !m_bNoDataSet && m_bUseMaskBand &&
-        m_poRasterBand->GetMaskFlags() == GMF_NODATA )
+        l_band->GetMaskFlags() == GMF_NODATA )
     {
-        dfNoDataValue = m_poRasterBand->GetNoDataValue(&bNoDataSet);
+        dfNoDataValue = l_band->GetNoDataValue(&bNoDataSet);
     }
 
     const bool bNoDataSetIsNan = bNoDataSet && CPLIsNan(dfNoDataValue);
@@ -2692,7 +2763,7 @@ CPLErr VRTComplexSource::RasterIOInternal( int nReqXOff, int nReqYOff,
         }
 
         const CPLErr eErr =
-            m_poRasterBand->RasterIO( GF_Read,
+            l_band->RasterIO( GF_Read,
                                       nReqXOff, nReqYOff,
                                       nReqXSize, nReqYSize,
                                       pafData,
@@ -2713,9 +2784,9 @@ CPLErr VRTComplexSource::RasterIOInternal( int nReqXOff, int nReqYOff,
 
         // Allocate and read mask band if needed
         if( !bNoDataSet && m_bUseMaskBand &&
-            (m_poRasterBand->GetMaskFlags() != GMF_ALL_VALID ||
-             m_poRasterBand->GetColorInterpretation() == GCI_AlphaBand ||
-             m_poMaskBandMainBand != nullptr) )
+            (l_band->GetMaskFlags() != GMF_ALL_VALID ||
+             l_band->GetColorInterpretation() == GCI_AlphaBand ||
+             GetMaskBandMainBand() != nullptr) )
         {
             try
             {
@@ -2728,9 +2799,9 @@ CPLErr VRTComplexSource::RasterIOInternal( int nReqXOff, int nReqYOff,
                 CPLFree( pafData );
                 return CE_Failure;
             }
-            auto poMaskBand = (m_poRasterBand->GetColorInterpretation() == GCI_AlphaBand ||
-                               m_poMaskBandMainBand != nullptr) ?
-                m_poRasterBand : m_poRasterBand->GetMaskBand();
+            auto poMaskBand = (l_band->GetColorInterpretation() == GCI_AlphaBand ||
+                               GetMaskBandMainBand() != nullptr) ?
+                l_band : l_band->GetMaskBand();
             if( poMaskBand->RasterIO( GF_Read,
                                       nReqXOff, nReqYOff,
                                       nReqXSize, nReqYSize,
@@ -2748,7 +2819,7 @@ CPLErr VRTComplexSource::RasterIOInternal( int nReqXOff, int nReqYOff,
 
         if( m_nColorTableComponent != 0 )
         {
-            poColorTable = m_poRasterBand->GetColorTable();
+            poColorTable = l_band->GetColorTable();
             if( poColorTable == nullptr )
             {
                 CPLError( CE_Failure, CPLE_AppDefined,
@@ -2824,10 +2895,10 @@ CPLErr VRTComplexSource::RasterIOInternal( int nReqXOff, int nReqYOff,
                         int bSuccessMin = FALSE;
                         int bSuccessMax = FALSE;
                         double adfMinMax[2] = {
-                            m_poRasterBand->GetMinimum(&bSuccessMin),
-                            m_poRasterBand->GetMaximum(&bSuccessMax) };
+                            l_band->GetMinimum(&bSuccessMin),
+                            l_band->GetMaximum(&bSuccessMax) };
                         if( (bSuccessMin && bSuccessMax) ||
-                            m_poRasterBand->ComputeRasterMinMax( TRUE,
+                            l_band->ComputeRasterMinMax( TRUE,
                                                                  adfMinMax )
                             == CE_None )
                         {

--- a/gdal/frmts/vrt/vrtsources.cpp
+++ b/gdal/frmts/vrt/vrtsources.cpp
@@ -200,7 +200,10 @@ void VRTSimpleSource::SetSrcBand( GDALRasterBand *poNewSrcBand )
     m_nBand = m_poRasterBand->GetBand();
     auto poDS = poNewSrcBand->GetDataset();
     if( poDS != nullptr )
+    {
         m_osSrcDSName = poDS->GetDescription();
+        m_aosOpenOptions = CSLDuplicate(poDS->GetOpenOptions());
+    }
 }
 
 /************************************************************************/
@@ -217,7 +220,10 @@ void VRTSimpleSource::SetSrcMaskBand( GDALRasterBand *poNewSrcBand )
     m_nBand = poNewSrcBand->GetBand();
     auto poDS = poNewSrcBand->GetDataset();
     if( poDS != nullptr )
+    {
         m_osSrcDSName = poDS->GetDescription();
+        m_aosOpenOptions = CSLDuplicate(poDS->GetOpenOptions());
+    }
     m_bGetMaskBand = true;
 }
 
@@ -296,26 +302,6 @@ static const char* const apszSpecialSyntax[] = {
 CPLXMLNode *VRTSimpleSource::SerializeToXML( const char *pszVRTPath )
 
 {
-    auto l_band = GetRasterBand();
-    if( l_band == nullptr )
-        return nullptr;
-
-    GDALDataset *poDS = nullptr;
-
-    auto l_maskband = GetMaskBandMainBand();
-    if( l_maskband )
-    {
-        poDS = l_maskband->GetDataset();
-        if( poDS == nullptr || l_maskband->GetBand() < 1 )
-            return nullptr;
-    }
-    else
-    {
-        poDS = l_band->GetDataset();
-        if( poDS == nullptr || l_band->GetBand() < 1 )
-            return nullptr;
-    }
-
     CPLXMLNode * const psSrc =
         CPLCreateXMLNode( nullptr, CXT_Element, "SimpleSource" );
 
@@ -336,12 +322,12 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML( const char *pszVRTPath )
         pszRelativePath = m_osSourceFileNameOri;
         bRelativeToVRT = m_bRelativeToVRTOri;
     }
-    else if( strstr(poDS->GetDescription(), "/vsicurl/http") != nullptr ||
-             strstr(poDS->GetDescription(), "/vsicurl/ftp") != nullptr )
+    else if( strstr(m_osSrcDSName, "/vsicurl/http") != nullptr ||
+             strstr(m_osSrcDSName, "/vsicurl/ftp") != nullptr )
     {
         // Testing the existence of remote resources can be excruciating
         // slow, so let's just suppose they exist.
-        pszRelativePath = poDS->GetDescription();
+        pszRelativePath = m_osSrcDSName;
         bRelativeToVRT = FALSE;
     }
     // If this isn't actually a file, don't even try to know if it is a
@@ -349,10 +335,10 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML( const char *pszVRTPath )
     // can only work with strings that are filenames To be clear
     // NITF_TOC_ENTRY:CADRG_JOG-A_250K_1_0:some_path isn't a relative file
     // path.
-    else if( VSIStatExL( poDS->GetDescription(), &sStat,
+    else if( VSIStatExL( m_osSrcDSName, &sStat,
                          VSI_STAT_EXISTS_FLAG ) != 0 )
     {
-        pszRelativePath = poDS->GetDescription();
+        pszRelativePath = m_osSrcDSName;
         bRelativeToVRT = FALSE;
         for( size_t i = 0;
              i < sizeof(apszSpecialSyntax) / sizeof(apszSpecialSyntax[0]);
@@ -411,7 +397,7 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML( const char *pszVRTPath )
     else
     {
         pszRelativePath =
-            CPLExtractRelativePath( pszVRTPath, poDS->GetDescription(),
+            CPLExtractRelativePath( pszVRTPath, m_osSrcDSName,
                                     &bRelativeToVRT );
     }
 
@@ -434,34 +420,38 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML( const char *pszVRTPath )
                               CXT_Text, "0" );
     }
 
-    char** papszOpenOptions = poDS->GetOpenOptions();
-    GDALSerializeOpenOptionsToXML(psSrc, papszOpenOptions);
+    GDALSerializeOpenOptionsToXML(psSrc, m_aosOpenOptions.List());
 
-    if( l_maskband )
+    if( m_bGetMaskBand )
         CPLSetXMLValue( psSrc, "SourceBand",
-                        CPLSPrintf("mask,%d",l_maskband->GetBand()) );
+                        CPLSPrintf("mask,%d",m_nBand) );
     else
         CPLSetXMLValue( psSrc, "SourceBand",
-                        CPLSPrintf("%d",l_band->GetBand()) );
+                        CPLSPrintf("%d",m_nBand) );
 
-    /* Write a few additional useful properties of the dataset */
-    /* so that we can use a proxy dataset when re-opening. See XMLInit() */
-    /* below */
-    CPLSetXMLValue( psSrc, "SourceProperties.#RasterXSize",
-                    CPLSPrintf("%d",l_band->GetXSize()) );
-    CPLSetXMLValue( psSrc, "SourceProperties.#RasterYSize",
-                    CPLSPrintf("%d",l_band->GetYSize()) );
-    CPLSetXMLValue( psSrc, "SourceProperties.#DataType",
-                GDALGetDataTypeName( l_band->GetRasterDataType() ) );
+    // TODO: in a later version, no longer emit SourceProperties, which
+    // is no longer used by GDAL 3.4
+    if( m_poRasterBand )
+    {
+        /* Write a few additional useful properties of the dataset */
+        /* so that we can use a proxy dataset when re-opening. See XMLInit() */
+        /* below */
+        CPLSetXMLValue( psSrc, "SourceProperties.#RasterXSize",
+                        CPLSPrintf("%d",m_poRasterBand->GetXSize()) );
+        CPLSetXMLValue( psSrc, "SourceProperties.#RasterYSize",
+                        CPLSPrintf("%d",m_poRasterBand->GetYSize()) );
+        CPLSetXMLValue( psSrc, "SourceProperties.#DataType",
+                    GDALGetDataTypeName( m_poRasterBand->GetRasterDataType() ) );
 
-    int nBlockXSize = 0;
-    int nBlockYSize = 0;
-    l_band->GetBlockSize(&nBlockXSize, &nBlockYSize);
+        int nBlockXSize = 0;
+        int nBlockYSize = 0;
+        m_poRasterBand->GetBlockSize(&nBlockXSize, &nBlockYSize);
 
-    CPLSetXMLValue( psSrc, "SourceProperties.#BlockXSize",
-                    CPLSPrintf("%d",nBlockXSize) );
-    CPLSetXMLValue( psSrc, "SourceProperties.#BlockYSize",
-                    CPLSPrintf("%d",nBlockYSize) );
+        CPLSetXMLValue( psSrc, "SourceProperties.#BlockXSize",
+                        CPLSPrintf("%d",nBlockXSize) );
+        CPLSetXMLValue( psSrc, "SourceProperties.#BlockYSize",
+                        CPLSPrintf("%d",nBlockYSize) );
+    }
 
     if( m_dfSrcXOff != -1
         || m_dfSrcYOff != -1

--- a/gdal/gcore/gdal_frmts.h
+++ b/gdal/gcore/gdal_frmts.h
@@ -205,6 +205,7 @@ void CPL_DLL GDALRegister_TGA(void);
 void CPL_DLL GDALRegister_OGCAPI(void);
 void CPL_DLL GDALRegister_STACTA(void);
 void CPL_DLL GDALRegister_Zarr(void);
+void CPL_DLL GDALRegister_STACIT(void);
 CPL_C_END
 
 #endif /* ndef GDAL_FRMTS_H_INCLUDED */

--- a/gdal/gcore/gdal_proxy.h
+++ b/gdal/gcore/gdal_proxy.h
@@ -235,6 +235,11 @@ class CPL_DLL GDALProxyPoolDataset : public GDALProxyDataset
 
         GDALDataset *RefUnderlyingDataset(bool bForceOpen) const;
 
+        GDALProxyPoolDataset( const char* pszSourceDatasetDescription,
+                              GDALAccess eAccess,
+                              int bShared,
+                              const char* pszOwner );
+
   protected:
     GDALDataset *RefUnderlyingDataset() const override;
     void UnrefUnderlyingDataset(GDALDataset* poUnderlyingDataset) const override;
@@ -249,9 +254,17 @@ class CPL_DLL GDALProxyPoolDataset : public GDALProxyDataset
                           const char * pszProjectionRef = nullptr,
                           double * padfGeoTransform = nullptr,
                           const char* pszOwner = nullptr );
+
+
+    static GDALProxyPoolDataset* Create( const char* pszSourceDatasetDescription,
+                                         CSLConstList papszOpenOptions = nullptr,
+                                         GDALAccess eAccess = GA_ReadOnly,
+                                         int bShared = FALSE,
+                                         const char* pszOwner = nullptr );
+
     ~GDALProxyPoolDataset() override;
 
-    void SetOpenOptions( char** papszOpenOptions );
+    void SetOpenOptions( CSLConstList papszOpenOptions );
 
     // If size (nBlockXSize&nBlockYSize) parameters is zero
     // they will be loaded when RefUnderlyingRasterBand function is called.
@@ -333,6 +346,8 @@ class CPL_DLL GDALProxyPoolRasterBand : public GDALProxyRasterBand
 
     void AddSrcMaskBandDescription( GDALDataType eDataType, int nBlockXSize,
                                     int nBlockYSize );
+
+    void AddSrcMaskBandDescriptionFromUnderlying();
 
     // Special behavior for the following methods : they return a pointer
     // data type, that must be cached by the proxy, so it doesn't become invalid

--- a/gdal/port/cpl_json.cpp
+++ b/gdal/port/cpl_json.cpp
@@ -170,7 +170,7 @@ bool CPLJSONDocument::Load(const std::string &osPath)
 {
     GByte *pabyOut = nullptr;
     vsi_l_offset nSize = 0;
-    if( !VSIIngestFile( nullptr, osPath.c_str(), &pabyOut, &nSize, 8 * 1024 * 1024) ) // Maximum 8 Mb allowed
+    if( !VSIIngestFile( nullptr, osPath.c_str(), &pabyOut, &nSize, 100 * 1024 * 1024) ) // Maximum 100 Mb allowed
     {
         CPLError( CE_Failure, CPLE_FileIO, "Load json file %s failed", osPath.c_str() );
         return false;

--- a/gdal/port/cpl_quad_tree.h
+++ b/gdal/port/cpl_quad_tree.h
@@ -86,6 +86,10 @@ void        CPL_DLL   CPLQuadTreeInsertWithBounds(CPLQuadTree *hQuadtree,
                                                   void* hFeature,
                                                   const CPLRectObj* psBounds);
 
+void        CPL_DLL   CPLQuadTreeRemove(CPLQuadTree *hQuadtree,
+                                        void* hFeature,
+                                        const CPLRectObj* psBounds);
+
 void        CPL_DLL **CPLQuadTreeSearch(const CPLQuadTree *hQuadtree,
                                         const CPLRectObj* pAoi,
                                         int* pnFeatureCount);


### PR DESCRIPTION
This driver supports opening JSON files, or usually the result of a remote query, that are the ``items`` link of a
[STAC Collection](https://github.com/radiantearth/stac-api-spec/blob/master/stac-spec/collection-spec/collection-spec.md), and whose items also implement the [Projection Extension Specification](https://github.com/stac-extensions/projection/). It builds a virtual mosaic from the items.

On top of https://github.com/OSGeo/gdal/pull/4130