### PR TITLE
Enable JPEG-in-TIFF for 12 bit samples (for internal libtiff), whatever libjpeg is used for 8 bit sample support

### DIFF
--- a/gdal/configure
+++ b/gdal/configure
@@ -31787,38 +31787,22 @@ if test "$with_jpeg12" =  no ; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled by user" >&5
 $as_echo "disabled by user" >&6; }
 
-elif test "$JPEG_SETTING" = "internal" -a "$TIFF_SETTING" = "internal" ; then
+elif test "$JPEG_SETTING" = "no" -a "$with_jpeg12" = ""; then
+    JPEG12_ENABLED=no
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled, JPEG disabled" >&5
+$as_echo "disabled, JPEG disabled" >&6; }
+
+elif test "$TIFF_SETTING" = "internal" ; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: enabled" >&5
 $as_echo "enabled" >&6; }
     JPEG12_ENABLED=yes
     TIFF_JPEG12_ENABLED=yes
 
-elif test "$with_jpeg12" = yes ; then
+else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: enabled" >&5
 $as_echo "enabled" >&6; }
     JPEG12_ENABLED=yes
 
-    echo '#include <stdlib.h>' > check_jpeg_abi.c
-    echo '#include <stdio.h>' >> check_jpeg_abi.c
-    echo '#include "jpeglib.h"' >> check_jpeg_abi.c
-    echo '#if JPEG_LIB_VERSION == 62' >> check_jpeg_abi.c
-    echo 'int main() { return 0; }' >> check_jpeg_abi.c
-    echo '#else' >> check_jpeg_abi.c
-    echo '#error "ABI difference"' >> check_jpeg_abi.c
-    echo '#endif' >> check_jpeg_abi.c
-    if test -z "`${CC} ${CFLAGS} ${EXTRA_INCLUDES} check_jpeg_abi.c -c -o check_jpeg_abi.o 2>&1`" ; then
-      TIFF_JPEG12_ENABLED=yes
-    else
-      TIFF_JPEG12_ENABLED=no
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Internal libjpeg12 has not the same ABI as libjpeg 8 bit. Disabling JPEG-in-TIFF 12 bit" >&5
-$as_echo "$as_me: WARNING: Internal libjpeg12 has not the same ABI as libjpeg 8 bit. Disabling JPEG-in-TIFF 12 bit" >&2;}
-    fi
-    rm -f check_jpeg_abi.*
-
-else
-    JPEG12_ENABLED=no
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled, libjpeg or libtiff not internal" >&5
-$as_echo "disabled, libjpeg or libtiff not internal" >&6; }
 fi
 
 JPEG12_ENABLED=$JPEG12_ENABLED

--- a/gdal/configure.ac
+++ b/gdal/configure.ac
@@ -2525,7 +2525,7 @@ AC_SUBST(HAVE_CHARLS,$HAVE_CHARLS)
 AC_SUBST(CHARLS_INC,$CHARLS_INC)
 
 dnl ---------------------------------------------------------------------------
-dnl Check for BSB in the local tree.
+dnl Check for JPEG 12 bit
 dnl ---------------------------------------------------------------------------
 
 AC_ARG_WITH([jpeg12],
@@ -2538,34 +2538,19 @@ if test "$with_jpeg12" =  no ; then
     JPEG12_ENABLED=no
     AC_MSG_RESULT([disabled by user])
 
-elif test "$JPEG_SETTING" = "internal" -a "$TIFF_SETTING" = "internal" ; then
+elif test "$JPEG_SETTING" = "no" -a "$with_jpeg12" = ""; then
+    JPEG12_ENABLED=no
+    AC_MSG_RESULT([disabled, JPEG disabled])
+
+elif test "$TIFF_SETTING" = "internal" ; then
     AC_MSG_RESULT([enabled])
     JPEG12_ENABLED=yes
     TIFF_JPEG12_ENABLED=yes
 
-elif test "$with_jpeg12" = yes ; then
+else
     AC_MSG_RESULT([enabled])
     JPEG12_ENABLED=yes
 
-    echo '#include <stdlib.h>' > check_jpeg_abi.c
-    echo '#include <stdio.h>' >> check_jpeg_abi.c
-    echo '#include "jpeglib.h"' >> check_jpeg_abi.c
-    echo '#if JPEG_LIB_VERSION == 62' >> check_jpeg_abi.c
-    echo 'int main() { return 0; }' >> check_jpeg_abi.c
-    echo '#else' >> check_jpeg_abi.c
-    echo '#error "ABI difference"' >> check_jpeg_abi.c
-    echo '#endif' >> check_jpeg_abi.c
-    if test -z "`${CC} ${CFLAGS} ${EXTRA_INCLUDES} check_jpeg_abi.c -c -o check_jpeg_abi.o 2>&1`" ; then
-      TIFF_JPEG12_ENABLED=yes
-    else
-      TIFF_JPEG12_ENABLED=no
-      AC_MSG_WARN([Internal libjpeg12 has not the same ABI as libjpeg 8 bit. Disabling JPEG-in-TIFF 12 bit])
-    fi
-    rm -f check_jpeg_abi.*
-
-else
-    JPEG12_ENABLED=no
-    AC_MSG_RESULT([disabled, libjpeg or libtiff not internal])
 fi
 
 AC_SUBST(JPEG12_ENABLED,$JPEG12_ENABLED)
@@ -5679,7 +5664,7 @@ if test "$with_brunsli" != "" -a "$with_brunsli" != "no" ; then
   AC_SUBST(BRUNSLI_ENABLED, $BRUNSLI_ENABLED)
   AC_SUBST(BRUNSLI_INCLUDE, -I$prefix/include)
   AC_SUBST(BRUNSLI_LIB, "-lbrunslicommon -lbrunslienc -lbrunslidec -lbrotlicommon -lbrotlienc -lbrotlidec")
-fi 
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl RDB support

--- a/gdal/doc/source/drivers/raster/gtiff.rst
+++ b/gdal/doc/source/drivers/raster/gtiff.rst
@@ -377,14 +377,17 @@ Creation Options
 -  **COMPRESS=[JPEG/LZW/PACKBITS/DEFLATE/CCITTRLE/CCITTFAX3/CCITTFAX4/LZMA/ZSTD/LERC/LERC_DEFLATE/LERC_ZSTD/WEBP/NONE]**:
    Set the compression to use.
 
-   * ``JPEG`` should generally only be used with
-     Byte data (8 bit per channel). But if GDAL is built with internal libtiff and
-     libjpeg, it is    possible to read and write TIFF files with 12bit JPEG compressed TIFF
-     files (seen as UInt16 bands with NBITS=12). See the `"8 and 12 bit
-     JPEG in TIFF" <http://trac.osgeo.org/gdal/wiki/TIFF12BitJPEG>`__ wiki
-     page for more details.
+   * ``JPEG`` should generally only be used with Byte data (8 bit per channel).
      Better compression for RGB images can be obtained by using the PHOTOMETRIC=YCBCR
      colorspace with a 4:2:2 subsampling of the Y,Cb,Cr components.
+
+     Starting with GDAL 3.4, if GDAL is built with its internal libtiff,
+     read and write support for JPEG-in-TIFF compressed images with 12-bit sample
+     is enabled by default (if JPEG support is also enabled), using GDAL internal libjpeg
+     (based on IJG libjpeg-6b, with additional changes for 12-bit sample support).
+     Support for JPEG with 12-bit sample is independent of whether
+     8-bit JPEG support is enabled through internal IJG libjpeg-6b or external libjpeg
+     (like libjpeg-turbo)
 
    * ``CCITTFAX3``, ``CCITTFAX4`` or ``CCITRLE`` compression should only be used with 1bit (NBITS=1) data
 

--- a/gdal/doc/source/drivers/raster/jpeg.rst
+++ b/gdal/doc/source/drivers/raster/jpeg.rst
@@ -43,18 +43,17 @@ The GDAL JPEG Driver is built using the Independent JPEG Group's jpeg
 library. Also note that the GeoTIFF driver supports tiled TIFF with JPEG
 compressed tiles.
 
-To be able to read and write JPEG images with 12-bit sample, you can
-build GDAL with its internal libjpeg (based on IJG libjpeg-6b, with
-additional changes for 12-bit sample support), or explicitly pass
---with-jpeg12=yes to configure script when building with external
-libjpeg. See `"8 and 12 bit JPEG in
-TIFF" <http://trac.osgeo.org/gdal/wiki/TIFF12BitJPEG>`__ wiki page for
-more details.
-
 It is also possible to use the JPEG driver with the libjpeg-turbo, a
 version of libjpeg, API and ABI compatible with IJG libjpeg-6b, which
 uses MMX, SSE, and SSE2 SIMD instructions to accelerate baseline JPEG
 compression/decompression.
+
+Starting with GDAL 3.4, read and write support for JPEG images with 12-bit sample
+is enabled by default (if JPEG support is also enabled), using GDAL internal libjpeg
+(based on IJG libjpeg-6b, with additional changes for 12-bit sample support).
+Support for JPEG with 12-bit sample is independent of whether
+8-bit JPEG support is enabled through internal IJG libjpeg-6b or external libjpeg
+(like libjpeg-turbo)
 
 XMP metadata can be extracted from the file,
 and will be stored as XML raw content in the xml:XMP metadata domain.

--- a/gdal/nmake.opt
+++ b/gdal/nmake.opt
@@ -304,12 +304,15 @@ ODBC_SUPPORTED = 1
 JPEG_SUPPORTED = 1
 !ENDIF
 
-# This will enable 12bit libjpeg - use only with internal jpeg builds.
+# This will enable 12bit libjpeg, using internal IJG libjpeg-6b in 12-bit mode
+# Note: it is possible to have 12bit JPEG support with this internal IJG libjpeg-6b
+# and 8bit JPEG support through an external libjpeg, such as libjpeg-turbo
 !IFNDEF JPEG12_SUPPORTED
 JPEG12_SUPPORTED = 1
 !ENDIF
 
 #if using an external jpeg library uncomment the following lines
+# libjpeg-turbo is also supported (and recommended for better performance)
 #JPEG_EXTERNAL_LIB = 1
 #JPEGDIR = c:/projects/jpeg-6b
 #JPEG_LIB = $(JPEGDIR)/libjpeg.lib


### PR DESCRIPTION
Previously we required that the libjpeg used for 8 bit sample support
had the libjpeg-6b ABI. The changes done in libtiff/tif_jpeg.c
and tif_jpeg_12.c now remove this constraint, and it is thus now
possible to have JPEG 12 bit support in a build that uses libjpeg-turbo
with IJG v8 ABI for 8-bit.