### PR TITLE
OGR/shape/shpopen.c: Communicate why the file size cannot be reached …

### DIFF
--- a/gdal/ogr/ogrsf_frmts/shape/shpopen.c
+++ b/gdal/ogr/ogrsf_frmts/shape/shpopen.c
@@ -1572,7 +1572,7 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
     {
         if( psSHP->nFileSize > UINT_MAX - nRecordSize)
         {
-            char str[150];
+            char str[255];
             snprintf( str, sizeof(str), "Failed to write shape object. "
                      "The maximum file size of %u has been reached. "
                      "The current record of size %u cannot be added.",

--- a/gdal/ogr/ogrsf_frmts/shape/shpopen.c
+++ b/gdal/ogr/ogrsf_frmts/shape/shpopen.c
@@ -1572,9 +1572,10 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject ) {
     {
         if( psSHP->nFileSize > UINT_MAX - nRecordSize)
         {
-            char str[128];
+            char str[150];
             snprintf( str, sizeof(str), "Failed to write shape object. "
-                     "File size cannot reach %u + %u.",
+                     "The maximum file size of %u has been reached. "
+                     "The current record of size %u cannot be added.",
                      psSHP->nFileSize, nRecordSize );
             str[sizeof(str)-1] = '\0';
             psSHP->sHooks.Error( str );


### PR DESCRIPTION
…when appending features

Clearly state why the file size cannot be reached. This is important in order to correctly inform the user and prevent him/her from looking for other reasons

This PR suggestion has been motivated by the follwing issue:
https://github.com/qgis/QGIS/issues/44202

## Tasklist

 - [ ] Review

