### PR TITLE
MSG: fix race condition in satellite number lookup

### DIFF
--- a/gdal/frmts/msg/msgdataset.cpp
+++ b/gdal/frmts/msg/msgdataset.cpp
@@ -53,7 +53,7 @@ const double MSGDataset::rA[12] = {-1, -1, -1, 0.9959, 0.9963, 0.9991, 0.9996, 0
 const double MSGDataset::rB[12] = {-1, -1, -1, 3.471, 2.219, 0.485, 0.181, 0.060, 0.627, 0.397, 0.576, -1};
 const int MSGDataset::iCentralPixelVIS_IR = 1856; // center pixel VIS and IR
 const int MSGDataset::iCentralPixelHRV = 5566; // center pixel HRV
-int MSGDataset::iCurrentSatellite = 1; // satellite number 1,2,3,4 for MSG1, MSG2, MSG3 and MSG4
+int MSGDataset::iCurrentSatelliteHint = 1;     // satellite number hint 1,2,3,4 for MSG1, MSG2, MSG3 and MSG4
 const char *MSGDataset::metadataDomain = "msg"; // the metadata domain
 
 #define MAX_SATELLITES 4

--- a/gdal/frmts/msg/msgdataset.h
+++ b/gdal/frmts/msg/msgdataset.h
@@ -94,7 +94,8 @@ class MSGDataset final: public GDALDataset
     OGRCoordinateTransformation *poTransform;
     double rCalibrationOffset[12];
     double rCalibrationSlope[12];
-    static int iCurrentSatellite; // satellite number 1,2,3,4 for MSG1, MSG2, MSG3 and MSG4
+    int iCurrentSatellite;            // satellite number 1,2,3,4 for MSG1, MSG2, MSG3 and MSG4
+    static int iCurrentSatelliteHint; // hint for satellite number 1,2,3,4 for MSG1, MSG2, MSG3 and MSG4
     static const double rCentralWvl[12];
     static const double rVc[12];
     static const double rA[12];


### PR DESCRIPTION
## What does this PR do?
This PR fixes a race condition in the MSG driver.

The MSG driver looks for a matching "prologue"-file when calling `MSGDataset::Open`. The filename depends on the satellite number. There are only 4 satellites and all of them are tried until an existing prologue is found. The satellite number is stored as a static variable `iCurrentSatellite` and each call to `Open` triggers a loop that modifies this variable. If multiple threads try to open a MSG dataset, the state of `iCurrentSatellite` is modified in all threads.

This PR changes `iCurrentSatellite` to be a class variable and adds a static hint `iCurrentSatelliteHint` which provides a start value for the lookup. Additionally, the lookup logic (loop) was simplified.

## Environment
To use the MSG driver the _PublicDecompWT_  code from EUMETSAT is required. It is available at: https://gitlab.eumetsat.int/open-source/PublicDecompWT
