### PR TITLE
util.py - fix get_raster_min_max() and add a test

### DIFF
--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -129,6 +129,12 @@ def test_utils_py_1():
     ds_list = None
 
 
+def test_min_max():
+    ds = util.open_ds(test_py_scripts.get_data_path('gcore') + 'byte.tif')
+    min_max = util.get_raster_min_max(ds)
+    assert min_max == (74, 255)
+
+
 def test_utils_arrays():
     scalars = [7, 5.2]
 

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
@@ -309,10 +309,10 @@ def get_raster_minimum(filename_or_ds: PathOrDS, bnd_index: Optional[int] = 1):
             return get_band_minimum(bnd)
 
 
-def get_raster_min_max(filename_or_ds: PathOrDS, bnd_index: int = 1, approx_ok: bool = True):
+def get_raster_min_max(filename_or_ds: PathOrDS, bnd_index: int = 1, approx_ok: Union[bool, int] = True):
     with OpenDS(filename_or_ds) as ds:
         bnd = ds.GetRasterBand(bnd_index)
-        min_max = bnd.ComputeRasterMinMax(approx_ok=int(approx_ok))
+        min_max = bnd.ComputeRasterMinMax(int(approx_ok))
         return min_max
 
 


### PR DESCRIPTION
## What does this PR do?

util.py - fix get_raster_min_max() and add a test.

On a side note... the docstring `"""ComputeRasterMinMax(Band self, int approx_ok=0)"""` is somewhat misleading as it suggests that `approx_ok` is the name of the argument, but apparently it does not accept it as a named argument but only as a positional argument. 

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/4151 (I should have added the test there... :)