### PR TITLE
Delay destroying VSIMemFile on bUnlinkAndSeize

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -3486,4 +3486,21 @@ namespace tut
 
         CPLQuadTreeDestroy(hTree);
     }
+    // Test bUnlinkAndSize on VSIGetMemFileBuffer
+    template<>
+    template<>
+    void object::test<50>()
+    {
+        VSILFILE *fp = VSIFOpenL("/vsimem/test_unlink_and_seize.tif", "wb");
+        VSIFWriteL("test", 5, 1, fp);
+        GByte *pRawData = VSIGetMemFileBuffer("/vsimem/test_unlink_and_seize.tif", nullptr, true);
+        ensure(EQUAL(reinterpret_cast<const char *>(pRawData), "test"));
+        ensure(VSIGetMemFileBuffer("/vsimem/test_unlink_and_seize.tif", nullptr, false) == nullptr);
+        ensure(VSIFOpenL("/vsimem/test_unlink_and_seize.tif", "r") == nullptr);
+        ensure(VSIFReadL(pRawData, 5, 1, fp) == 0);
+        ensure(VSIFWriteL(pRawData, 5, 1, fp) == 0);
+        ensure(VSIFSeekL(fp, 0, SEEK_END) == 0);
+        CPLFree(pRawData);
+        VSIFCloseL(fp);
+    }
 } // namespace tut

--- a/gdal/port/cpl_vsi_mem.cpp
+++ b/gdal/port/cpl_vsi_mem.cpp
@@ -1034,8 +1034,11 @@ GByte *VSIGetMemFileBuffer( const char *pszFilename,
         CPLDebug("VSIMEM", "VSIGetMemFileBuffer() %s: ref_count=%d (before)",
                  poFile->osFilename.c_str(), poFile->nRefCount);
 #endif
-        CPLAtomicDec(&(poFile->nRefCount));
-        delete poFile;
+        poFile->pabyData = nullptr;
+        poFile->nLength = 0;
+        poFile->nAllocLength = 0;
+        if (CPLAtomicDec(&(poFile->nRefCount)) == 0)
+            delete poFile;
     }
 
     return pabyData;


### PR DESCRIPTION
## What does this PR do?

It delays destroying the `VSIMemFile` object on `bUnlinkAndSeize` by reusing the same mechanism as `VSIMemFile::Unlink`

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/4158

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

Creating an unit test requires that the undocumented Python API `gdal.VSIGetMemFileBuffer_unsafe` is replaced by a public `gdal.VSIGetMemFileBuffer` that will use this
