### PR TITLE
Fix typos in multidimensional raster docs

### DIFF
--- a/gdal/doc/source/user/multidim_raster_data_model.rst
+++ b/gdal/doc/source/user/multidim_raster_data_model.rst
@@ -17,7 +17,7 @@ level utilities.
 It is strongly inspired from the netCDF and HDF5 API and data models.
 See `HDF5 format and data model <https://portal.opengeospatial.org/files/81716>`_.
 
-A :cpp:class:`GDALDataset` with mulidimensional content contains a root
+A :cpp:class:`GDALDataset` with multidimensional content contains a root
 :cpp:class:`GDALGroup`.
 
 Group
@@ -76,7 +76,7 @@ It has the following properties:
   - a size, that is the number of values that can be indexed along
     the dimension
   - a type, which is a string giving the nature of the dimension.
-    Predeined values are: HORIZONTAL_X, HORIZONTAL_Y, VERTICAL, TEMPORAL, PARAMETRIC
+    Predefined values are: HORIZONTAL_X, HORIZONTAL_Y, VERTICAL, TEMPORAL, PARAMETRIC
     Other values might be used. Empty value means unknown.
   - a direction. Predefined values are:
     EAST, WEST, SOUTH, NORTH, UP, DOWN, FUTURE, PAST


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fix typos in multidimensional raster documentation. Thanks!

## What are related issues/pull requests?

None.

## Tasklist

 - [x] Fix typos in documentation
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
