### PR TITLE
Zarr: handle _ARRAY_DIMENSIONS variables being in a upper-directory of the variable of interest

### DIFF
--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/.zgroup
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/.zgroup
@@ -1,0 +1,3 @@
+{
+    "zarr_format": 2
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/.zmetadata
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/.zmetadata
@@ -1,0 +1,66 @@
+{
+    "metadata": {
+        ".zgroup": {
+            "zarr_format": 2
+        },
+        "subgroup/.zgroup": {
+            "zarr_format": 2
+        },
+        "subgroup/var/.zarray": {
+            "chunks": [
+                20, 40
+            ],
+            "compressor": null,
+            "dtype": "<f8",
+            "fill_value": null,
+            "filters": null,
+            "order": "C",
+            "shape": [
+                20, 40
+            ],
+            "zarr_format": 2
+        },
+        "subgroup/var/.zattrs": {
+            "_ARRAY_DIMENSIONS": [ "lat", "lon" ]
+        },
+        "lat/.zarray": {
+            "chunks": [
+                20
+            ],
+            "compressor": null,
+            "dtype": "<f8",
+            "fill_value": null,
+            "filters": null,
+            "order": "C",
+            "shape": [
+                20
+            ],
+            "zarr_format": 2
+        },
+        "lat/.zattrs": {
+            "_ARRAY_DIMENSIONS": [ "lat" ],
+            "standard_name": "latitude",
+            "units": "degrees_north"
+        },
+        "lon/.zarray": {
+            "chunks": [
+                40
+            ],
+            "compressor": null,
+            "dtype": "<f8",
+            "fill_value": null,
+            "filters": null,
+            "order": "C",
+            "shape": [
+                40
+            ],
+            "zarr_format": 2
+        },
+        "lon/.zattrs": {
+            "_ARRAY_DIMENSIONS": [ "lon" ],
+            "standard_name": "longitude",
+            "units": "degrees_east"
+        }
+    },
+    "zarr_consolidated_format": 1
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lat/.zarray
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lat/.zarray
@@ -1,0 +1,14 @@
+{
+    "chunks": [
+        20
+    ],
+    "compressor": null,
+    "dtype": "<f8",
+    "fill_value": null,
+    "filters": null,
+    "order": "C",
+    "shape": [
+        20
+    ],
+    "zarr_format": 2
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lat/.zattrs
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lat/.zattrs
@@ -1,0 +1,5 @@
+{
+    "_ARRAY_DIMENSIONS": [ "lat" ],
+    "standard_name": "latitude",
+    "units": "degrees_north"
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lon/.zarray
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lon/.zarray
@@ -1,0 +1,14 @@
+{
+    "chunks": [
+        40
+    ],
+    "compressor": null,
+    "dtype": "<f8",
+    "fill_value": null,
+    "filters": null,
+    "order": "C",
+    "shape": [
+        40
+    ],
+    "zarr_format": 2
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lon/.zattrs
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/lon/.zattrs
@@ -1,0 +1,5 @@
+{
+    "_ARRAY_DIMENSIONS": [ "lon" ],
+    "standard_name": "longitude",
+    "units": "degrees_east"
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/subgroup/.zgroup
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/subgroup/.zgroup
@@ -1,0 +1,3 @@
+{
+    "zarr_format": 2
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/subgroup/var/.zarray
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/subgroup/var/.zarray
@@ -1,0 +1,14 @@
+{
+    "chunks": [
+        20, 40
+    ],
+    "compressor": null,
+    "dtype": "<f8",
+    "fill_value": null,
+    "filters": null,
+    "order": "C",
+    "shape": [
+        20, 40
+    ],
+    "zarr_format": 2
+}

--- a/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/subgroup/var/.zattrs
+++ b/autotest/gdrivers/data/zarr/array_dimensions_upper_level.zarr/subgroup/var/.zattrs
@@ -1,0 +1,3 @@
+{
+    "_ARRAY_DIMENSIONS": [ "lat", "lon" ]
+}

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -262,7 +262,7 @@ def test_zarr_string(fill_value, expected_read_data):
 # Check that all required elements are present in .zarray
 @pytest.mark.parametrize("member",
                          [None, 'zarr_format', 'chunks', 'compressor', 'dtype',
-                          'filters', 'order', 'shape'])
+                          'filters', 'order', 'shape', 'fill_value'])
 def test_zarr_invalid_json_remove_member(member):
 
     j = {
@@ -290,7 +290,10 @@ def test_zarr_invalid_json_remove_member(member):
         gdal.FileFromMemBuffer('/vsimem/test.zarr/.zarray', json.dumps(j))
         with gdaltest.error_handler():
             ds = gdal.OpenEx('/vsimem/test.zarr', gdal.OF_MULTIDIM_RASTER)
-        if member is None:
+        if member == 'fill_value':
+            assert ds is not None
+            assert gdal.GetLastErrorMsg() != ''
+        elif member is None:
             assert ds
         else:
             assert ds is None

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -765,16 +765,22 @@ def test_zarr_read_group_with_zmetadata():
     assert subsubgroup.OpenMDArray('not_existing') is None
 
 
-@pytest.mark.parametrize("use_zmetadata", [True, False])
-def test_zarr_read_ARRAY_DIMENSIONS(use_zmetadata):
-
-    filename = 'data/zarr/array_dimensions.zarr'
+@pytest.mark.parametrize("use_zmetadata, filename",
+                         [(True, 'data/zarr/array_dimensions.zarr'),
+                          (False, 'data/zarr/array_dimensions.zarr'),
+                          (True, 'data/zarr/array_dimensions_upper_level.zarr'),
+                          (False, 'data/zarr/array_dimensions_upper_level.zarr'),
+                          (False, 'data/zarr/array_dimensions_upper_level.zarr/subgroup/var')])
+def test_zarr_read_ARRAY_DIMENSIONS(use_zmetadata, filename):
 
     ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER, open_options=[
                      'USE_ZMETADATA=' + str(use_zmetadata)])
     assert ds is not None
     rg = ds.GetRootGroup()
-    ar = rg.OpenMDArray('var')
+    if filename != 'data/zarr/array_dimensions_upper_level.zarr':
+        ar = rg.OpenMDArray('var')
+    else:
+        ar = rg.OpenGroup('subgroup').OpenMDArray('var')
     assert ar
     dims = ar.GetDimensions()
     assert len(dims) == 2

--- a/gdal/frmts/zarr/zarr.h
+++ b/gdal/frmts/zarr/zarr.h
@@ -227,6 +227,7 @@ protected:
     // For ZarrV3, this is the root directory of the dataset
     std::shared_ptr<ZarrSharedResource> m_poSharedResource;
     std::string m_osDirectoryName{};
+    std::weak_ptr<ZarrGroupBase> m_poParent{};
     mutable std::map<CPLString, std::shared_ptr<GDALGroup>> m_oMapGroups{};
     mutable std::map<CPLString, std::shared_ptr<ZarrArray>> m_oMapMDArrays{};
     mutable std::map<CPLString, std::shared_ptr<GDALDimensionWeakIndexingVar>> m_oMapDimensions{};
@@ -238,7 +239,7 @@ protected:
     bool                                              m_bReadFromZMetadata = false;
     mutable bool                                      m_bDimensionsInstantiated = false;
     bool                                              m_bUpdatable = false;
-    std::weak_ptr<GDALGroup> m_pSelf{};
+    std::weak_ptr<ZarrGroupBase> m_pSelf{};
 
     virtual void ExploreDirectory() const = 0;
     virtual void LoadAttributes() const = 0;
@@ -253,7 +254,7 @@ public:
 
     ~ZarrGroupBase() override;
 
-    void SetSelf(std::weak_ptr<GDALGroup> self) { m_pSelf = self; }
+    void SetSelf(std::weak_ptr<ZarrGroupBase> self) { m_pSelf = self; }
 
     std::shared_ptr<GDALAttribute> GetAttribute(const std::string& osName) const override
         { LoadAttributes(); return m_oAttrGroup.GetAttribute(osName); }

--- a/gdal/frmts/zarr/zarr_array.cpp
+++ b/gdal/frmts/zarr/zarr_array.cpp
@@ -2623,6 +2623,173 @@ std::shared_ptr<ZarrArray> ZarrGroupBase::LoadArray(const std::string& osArrayNa
 
     // XArray extension
     const auto arrayDimensionsObj = oAttributes["_ARRAY_DIMENSIONS"];
+
+    const auto FindDimension = [this, &aoDims, &oAttributes, &osUnit,
+                                bLoadedFromZMetadata, &osArrayName,
+                                &osZarrayFilename,
+                                isZarrV2](
+                                        const std::string& osDimName,
+                                        std::shared_ptr<GDALDimension>& poDim,
+                                        int i)
+    {
+        auto oIter = m_oMapDimensions.find(osDimName);
+        if( oIter != m_oMapDimensions.end() )
+        {
+            if( oIter->second->GetSize() == poDim->GetSize() )
+            {
+                poDim = oIter->second;
+                return true;
+            }
+            else
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                     "Size of _ARRAY_DIMENSIONS[%d] different "
+                     "from the one of shape", i);
+                return false;
+            }
+        }
+
+        // Try to load the indexing variable.
+
+        // If loading from zmetadata, we should have normally
+        // already loaded the dimension variables, unless they
+        // are in a upper level.
+        if( bLoadedFromZMetadata && osArrayName != osDimName &&
+            m_oMapMDArrays.find(osDimName) == m_oMapMDArrays.end() )
+        {
+            auto poParent = m_poParent.lock();
+            while( poParent != nullptr )
+            {
+                oIter = poParent->m_oMapDimensions.find(osDimName);
+                if( oIter != poParent->m_oMapDimensions.end() &&
+                    oIter->second->GetSize() == poDim->GetSize() )
+                {
+                    poDim = oIter->second;
+                    return true;
+                }
+                poParent = poParent->m_poParent.lock();
+            }
+        }
+
+        // Not loading from zmetadata, and not in m_oMapMDArrays,
+        // then stat() the indexing variable.
+        else if( !bLoadedFromZMetadata &&
+                 osArrayName != osDimName &&
+                 m_oMapMDArrays.find(osDimName) == m_oMapMDArrays.end() )
+        {
+            std::string osDirName = m_osDirectoryName;
+            while( true )
+            {
+                const std::string osArrayFilenameDim =
+                    isZarrV2 ?
+                        CPLFormFilename(
+                            CPLFormFilename(osDirName.c_str(),
+                                            osDimName.c_str(),
+                                            nullptr),
+                            ".zarray", nullptr) :
+                        CPLFormFilename(
+                            CPLGetDirname(osZarrayFilename.c_str()),
+                            (osDimName + ".array.json").c_str(),
+                            nullptr);
+                VSIStatBufL sStat;
+                if( VSIStatL(osArrayFilenameDim.c_str(), &sStat) == 0 )
+                {
+                    CPLJSONDocument oDoc;
+                    if( oDoc.Load(osArrayFilenameDim) )
+                    {
+                        LoadArray(
+                            osDimName,
+                            osArrayFilenameDim,
+                            oDoc.GetRoot(),
+                            false,
+                            CPLJSONObject());
+                    }
+                }
+                else
+                {
+                    // Recurse to upper level for datasets such as
+                    // /vsis3/hrrrzarr/sfc/20210809/20210809_00z_anl.zarr/0.1_sigma_level/HAIL_max_fcst/0.1_sigma_level/HAIL_max_fcst
+                    const std::string osDirNameNew = CPLGetPath(osDirName.c_str());
+                    if( !osDirNameNew.empty() && osDirNameNew != osDirName )
+                    {
+                        osDirName = osDirNameNew;
+                        continue;
+                    }
+                }
+                break;
+            }
+        }
+
+        oIter = m_oMapDimensions.find(osDimName);
+        if( oIter != m_oMapDimensions.end() &&
+            oIter->second->GetSize() == poDim->GetSize() )
+        {
+            poDim = oIter->second;
+            return true;
+        }
+
+        std::string osType;
+        std::string osDirection;
+        if( aoDims.size() == 1 && osArrayName == osDimName )
+        {
+            const auto oStdName = oAttributes[CF_STD_NAME];
+            if( oStdName.GetType() == CPLJSONObject::Type::String )
+            {
+                const auto osStdName = oStdName.ToString();
+                if( osStdName == CF_PROJ_X_COORD ||
+                    osStdName == CF_LONGITUDE_STD_NAME )
+                {
+                    osType = GDAL_DIM_TYPE_HORIZONTAL_X;
+                    oAttributes.Delete(CF_STD_NAME);
+                    if( osUnit == CF_DEGREES_EAST )
+                    {
+                        osDirection = "EAST";
+                    }
+                }
+                else if( osStdName == CF_PROJ_Y_COORD ||
+                    osStdName == CF_LATITUDE_STD_NAME )
+                {
+                    osType = GDAL_DIM_TYPE_HORIZONTAL_Y;
+                    oAttributes.Delete(CF_STD_NAME);
+                    if( osUnit == CF_DEGREES_NORTH )
+                    {
+                        osDirection = "NORTH";
+                    }
+                }
+                else if( osStdName == "time" )
+                {
+                    osType = GDAL_DIM_TYPE_TEMPORAL;
+                    oAttributes.Delete(CF_STD_NAME);
+                }
+            }
+
+            const auto osAxis = oAttributes[CF_AXIS].ToString();
+            if( osAxis == "Z" )
+            {
+                osType = GDAL_DIM_TYPE_VERTICAL;
+                const auto osPositive = oAttributes["positive"].ToString();
+                if( osPositive == "up" )
+                {
+                    osDirection = "UP";
+                    oAttributes.Delete("positive");
+                }
+                else if( osPositive == "down" )
+                {
+                    osDirection = "DOWN";
+                    oAttributes.Delete("positive");
+                }
+                oAttributes.Delete(CF_AXIS);
+            }
+        }
+
+        auto poDimLocal = std::make_shared<GDALDimensionWeakIndexingVar>(
+            GetFullName(), osDimName,
+            osType, osDirection, poDim->GetSize());
+        m_oMapDimensions[osDimName] = poDimLocal;
+        poDim = poDimLocal;
+        return true;
+    };
+
     if( arrayDimensionsObj.GetType() == CPLJSONObject::Type::Array )
     {
         const auto arrayDims = arrayDimensionsObj.ToArray();
@@ -2634,127 +2801,7 @@ std::shared_ptr<ZarrArray> ZarrGroupBase::LoadArray(const std::string& osArrayNa
                 if( arrayDims[i].GetType() == CPLJSONObject::Type::String )
                 {
                     const auto osDimName = arrayDims[i].ToString();
-                    auto oIter = m_oMapDimensions.find(osDimName);
-                    if( oIter != m_oMapDimensions.end() )
-                    {
-                        if( oIter->second->GetSize() == aoDims[i]->GetSize() )
-                        {
-                            aoDims[i] = oIter->second;
-                        }
-                        else
-                        {
-                            ok = false;
-                            CPLError(CE_Warning, CPLE_AppDefined,
-                                 "Size of _ARRAY_DIMENSIONS[%d] different "
-                                 "from the one of shape", i);
-                        }
-                    }
-                    else
-                    {
-                        // Try to load the indexing variable
-                        // If loading from zmetadata, we should have normally
-                        // already loaded the dimension variables, so if they
-                        // are not in m_oMapMDArrays, they are supposed to be missing,
-                        // and thus the stat() is useless.
-                        if( !bLoadedFromZMetadata &&
-                            osArrayName != osDimName &&
-                            m_oMapMDArrays.find(osDimName) == m_oMapMDArrays.end() )
-                        {
-                            const std::string osArrayFilenameDim =
-                                isZarrV2 ?
-                                    CPLFormFilename(
-                                        CPLFormFilename(m_osDirectoryName.c_str(),
-                                                        osDimName.c_str(),
-                                                        nullptr),
-                                        ".zarray", nullptr) :
-                                    CPLFormFilename(
-                                        CPLGetDirname(osZarrayFilename.c_str()),
-                                        (osDimName + ".array.json").c_str(),
-                                        nullptr);
-                            VSIStatBufL sStat;
-                            if( VSIStatL(osArrayFilenameDim.c_str(), &sStat) == 0 )
-                            {
-                                CPLJSONDocument oDoc;
-                                if( oDoc.Load(osArrayFilenameDim) )
-                                {
-                                    LoadArray(
-                                        osDimName,
-                                        osArrayFilenameDim,
-                                        oDoc.GetRoot(),
-                                        false,
-                                        CPLJSONObject());
-                                }
-                            }
-                        }
-
-                        oIter = m_oMapDimensions.find(osDimName);
-                        if( oIter != m_oMapDimensions.end() &&
-                            oIter->second->GetSize() == aoDims[i]->GetSize() )
-                        {
-                            aoDims[i] = oIter->second;
-                        }
-                        else
-                        {
-                            std::string osType;
-                            std::string osDirection;
-                            if( aoDims.size() == 1 && osArrayName == osDimName )
-                            {
-                                const auto oStdName = oAttributes[CF_STD_NAME];
-                                if( oStdName.GetType() == CPLJSONObject::Type::String )
-                                {
-                                    const auto osStdName = oStdName.ToString();
-                                    if( osStdName == CF_PROJ_X_COORD ||
-                                        osStdName == CF_LONGITUDE_STD_NAME )
-                                    {
-                                        osType = GDAL_DIM_TYPE_HORIZONTAL_X;
-                                        oAttributes.Delete(CF_STD_NAME);
-                                        if( osUnit == CF_DEGREES_EAST )
-                                        {
-                                            osDirection = "EAST";
-                                        }
-                                    }
-                                    else if( osStdName == CF_PROJ_Y_COORD ||
-                                        osStdName == CF_LATITUDE_STD_NAME )
-                                    {
-                                        osType = GDAL_DIM_TYPE_HORIZONTAL_Y;
-                                        oAttributes.Delete(CF_STD_NAME);
-                                        if( osUnit == CF_DEGREES_NORTH )
-                                        {
-                                            osDirection = "NORTH";
-                                        }
-                                    }
-                                    else if( osStdName == "time" )
-                                    {
-                                        osType = GDAL_DIM_TYPE_TEMPORAL;
-                                        oAttributes.Delete(CF_STD_NAME);
-                                    }
-                                }
-
-                                const auto osAxis = oAttributes[CF_AXIS].ToString();
-                                if( osAxis == "Z" )
-                                {
-                                    osType = GDAL_DIM_TYPE_VERTICAL;
-                                    const auto osPositive = oAttributes["positive"].ToString();
-                                    if( osPositive == "up" )
-                                    {
-                                        osDirection = "UP";
-                                        oAttributes.Delete("positive");
-                                    }
-                                    else if( osPositive == "down" )
-                                    {
-                                        osDirection = "DOWN";
-                                        oAttributes.Delete("positive");
-                                    }
-                                    oAttributes.Delete(CF_AXIS);
-                                }
-                            }
-                            auto poDim = std::make_shared<GDALDimensionWeakIndexingVar>(
-                                GetFullName(), osDimName,
-                                osType, osDirection, aoDims[i]->GetSize());
-                            m_oMapDimensions[osDimName] = poDim;
-                            aoDims[i] = poDim;
-                        }
-                    }
+                    ok &= FindDimension(osDimName, aoDims[i], i);
                 }
             }
             if( ok )

--- a/gdal/frmts/zarr/zarrdriver.cpp
+++ b/gdal/frmts/zarr/zarrdriver.cpp
@@ -93,6 +93,7 @@ GDALDataset* ZarrDataset::OpenMultidim(const char* pszFilename,
     auto poRG = ZarrGroupV2::Create(poSharedResource, std::string(), "/");
     poRG->SetUpdatable(bUpdateMode);
     poDS->m_poRootGroup = poRG;
+    poRG->SetDirectoryName(osFilename);
 
     const std::string osZarrayFilename(
                 CPLFormFilename(pszFilename, ".zarray", nullptr));
@@ -110,8 +111,6 @@ GDALDataset* ZarrDataset::OpenMultidim(const char* pszFilename,
 
         return poDS.release();
     }
-
-    poRG->SetDirectoryName(osFilename);
 
     const std::string osZmetadataFilename(
             CPLFormFilename(pszFilename, ".zmetadata", nullptr));


### PR DESCRIPTION
helps for datasets such as /vsis3/hrrrzarr/sfc/20210809/20210809_00z_anl.zarr/0.1_sigma_level/HAIL_max_fcst/0.1_sigma_level/HAIL_max_fcst
