### PR TITLE
Fix Vertical Units check in GetProjection()

### DIFF
--- a/gdal/frmts/gtiff/gt_wkt_srs.cpp
+++ b/gdal/frmts/gtiff/gt_wkt_srs.cpp
@@ -1366,7 +1366,7 @@ OGRSpatialReferenceH GTIFGetOGISDefnAsOSR( GTIF *hGTIF, GTIFDefn * psDefn )
 /* -------------------------------------------------------------------- */
 /*      Set the vertical units.                                         */
 /* -------------------------------------------------------------------- */
-        if( verticalUnits > 0 && verticalUnits != KvUserDefined
+        if( verticalUnits > 0 && verticalUnits < KvUserDefined
             && verticalUnits != 9001 )
         {
             char szCode[12];


### PR DESCRIPTION
The GetProjection() function should ignore values that are within the Private User Implementations range rather than throwing an exception. In fact, it does ignore values that are set to a user-defined unit (32767)

