### PR TITLE
gdal_fillnodata.py: remove broken -nomask option

### DIFF
--- a/autotest/alg/fillnodata.py
+++ b/autotest/alg/fillnodata.py
@@ -48,33 +48,88 @@ def test_fillnodata_1x1_no_nodata():
 
 
 fillnodata_tests = {
-    # (width, height, input_ar, maxSearchDist, expected):
-    '1x1_nodata_but_pixel_valid': (1, 1, (1,), 1, (1,)),
-    '1x1_nodata_pixel_invalid': (1, 1, (0,), 1, (0,)),
-    '2x1_valid_invalid': (2, 1, (1, 0), 1, (1, 1)),
-    '2x1_invalid_valid': (2, 1, (0, 1), 1, (1, 1)),
-    '3x1_valid_invalid_valid': (3, 1, (2, 0, 4), 1, (2, 3, 4)),
-    '4x1_valid_invalid_invalid_valid': (4, 1, (2, 0, 0, 4), 1, (2, 2, 4, 4)),
-    '1x2_valid_invalid': (1, 2, (1, 0), 1, (1, 1)),
-    '1x2_invalid_valid': (1, 2, (0, 1), 1, (1, 1)),
-    '1x3_valid_invalid_valid': (1, 3, (2, 0, 4), 1, (2, 3, 4)),
-    '1x4_valid_invalid_invalid_valid': (1, 4, (2, 0, 0, 4), 1, (2, 2, 4, 4)),
+    # (width, height, input_ar, maxSearchDist, expected, smoothingIterations):
+    '1x1_nodata_but_pixel_valid': (1, 1, (1,), 1, (1,), 0),
+    '1x1_nodata_pixel_invalid': (1, 1, (0,), 1, (0,), 0),
+    '2x1_valid_invalid': (2, 1, (1, 0), 1, (1, 1), 0),
+    '2x1_invalid_valid': (2, 1, (0, 1), 1, (1, 1), 0),
+    '3x1_valid_invalid_valid': (3, 1, (2, 0, 4), 1, (2, 3, 4), 0),
+    '4x1_valid_invalid_invalid_valid': (4, 1, (2, 0, 0, 4), 1, (2, 2, 4, 4), 0),
+    '1x2_valid_invalid': (1, 2, (1, 0), 1, (1, 1), 0),
+    '1x2_invalid_valid': (1, 2, (0, 1), 1, (1, 1), 0),
+    '1x3_valid_invalid_valid': (1, 3, (2, 0, 4), 1, (2, 3, 4), 0),
+    '1x4_valid_invalid_invalid_valid': (1, 4, (2, 0, 0, 4), 1, (2, 2, 4, 4), 0),
     '3x3_central_column_invalid': (
-        3, 3, (2, 0, 4, 4, 0, 6, 6, 0, 8), 1, (2, 3, 4, 4, 5, 6, 6, 7, 8)),
+        3, 3,
+        (2, 0, 4,
+         4, 0, 6,
+         6, 0, 8),
+        1,
+        (2, 3, 4,
+         4, 5, 6,
+         6, 7, 8), 0),
     '3x3_central_line_invalid': (
-        3, 3, (2, 3, 4, 0, 0, 0, 6, 7, 8), 1, (2, 3, 4, 4, 5, 6, 6, 7, 8)),
+        3, 3,
+        (2, 3, 4,
+         0, 0, 0,
+         6, 7, 8),
+        1,
+        (2, 3, 4,
+         4, 5, 6,
+         6, 7, 8),
+        0),
     '3x3_central_column_and_line_invalid': (
-        3, 3, (2, 0, 4, 0, 0, 0, 6, 0, 8), 1, (2, 3, 4, 4, 0, 6, 6, 7, 8)),
+        3, 3,
+        (2, 0, 4,
+         0, 0, 0,
+         6, 0, 8),
+        1,
+        (2, 3, 4,
+         4, 0, 6,
+         6, 7, 8),
+        0),
     # 1.5 > sqrt(2)
     '3x3_central_column_and_line_invalid_search_dist_1_5': (
-        3, 3, (2, 0, 4, 0, 0, 0, 6, 0, 8), 1.5, (2, 3, 4, 4, 5, 6, 6, 7, 8)),
+        3, 3,
+        (2, 0, 4,
+         0, 0, 0,
+         6, 0, 8),
+        1.5,
+        (2, 3, 4,
+         4, 5, 6,
+         6, 7, 8),
+        0),
+    '4x4': (
+        4, 4,
+        (20, 30, 40, 50,
+         30, 0,  0,  60,
+         40, 0,  0,  70,
+         50, 60, 70, 80),
+        1,
+        (20, 30, 40, 50,
+         30, 30, 50,  60,
+         40, 50, 70,  70,
+         50, 60, 70, 80),
+        0),
+    '4x4_smooth_1': (
+        4, 4,
+        (20, 30, 40, 50,
+         30, 0,  0,  60,
+         40, 0,  0,  70,
+         50, 60, 70, 80),
+        1,
+        (20, 30, 40, 50,
+         30, 40, 50, 60,
+         40, 50, 60, 70,
+         50, 60, 70, 80),
+        1),
 }
 
 
-@pytest.mark.parametrize('width, height, input_ar, maxSearchDist, expected',
+@pytest.mark.parametrize('width, height, input_ar, maxSearchDist, expected, smoothingIterations',
                          fillnodata_tests.values(),
                          ids=fillnodata_tests.keys())
-def test_fillnodata_nodata(width, height, input_ar, maxSearchDist, expected):
+def test_fillnodata_nodata(width, height, input_ar, maxSearchDist, expected, smoothingIterations):
     ds = gdal.GetDriverByName('MEM').Create('', width, height)
     npixels = ds.RasterXSize * ds.RasterYSize
     ds.GetRasterBand(1).SetNoDataValue(0)
@@ -84,6 +139,7 @@ def test_fillnodata_nodata(width, height, input_ar, maxSearchDist, expected):
     ds.WriteRaster(0, 0, ds.RasterXSize, ds.RasterYSize, ar)
     gdal.FillNodata(targetBand = ds.GetRasterBand(1),
                     maxSearchDist = maxSearchDist,
-                    maskBand = None, smoothingIterations = 0)
+                    maskBand = None,
+                    smoothingIterations = smoothingIterations)
     ar = ds.ReadRaster()
     assert struct.unpack('B' * npixels, ar) == expected

--- a/autotest/pyscripts/test_gdal_fillnodata.py
+++ b/autotest/pyscripts/test_gdal_fillnodata.py
@@ -28,9 +28,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-
-import os
-
+import struct
 
 from osgeo import gdal
 import test_py_scripts
@@ -48,9 +46,12 @@ def test_gdal_fillnodata_1():
 
     test_py_scripts.run_py_script(script_path, 'gdal_fillnodata', test_py_scripts.get_data_path('gcore') + 'byte.tif tmp/test_gdal_fillnodata_1.tif')
 
-    ds = gdal.Open('tmp/test_gdal_fillnodata_1.tif')
-    assert ds.GetRasterBand(1).Checksum() == 4672
-    ds = None
+    try:
+        ds = gdal.Open('tmp/test_gdal_fillnodata_1.tif')
+        assert ds.GetRasterBand(1).Checksum() == 4672
+        ds = None
+    finally:
+        gdal.GetDriverByName('GTiff').Delete('tmp/test_gdal_fillnodata_1.tif')
 
 ###############################################################################
 # Make sure we copy the no data value to the dst when created
@@ -65,22 +66,47 @@ def test_gdal_fillnodata_2():
 
     test_py_scripts.run_py_script(script_path, 'gdal_fillnodata', '-si 0 ' + test_py_scripts.get_data_path('gcore') + 'nodata_byte.tif tmp/test_gdal_fillnodata_2.tif')
 
-    ds = gdal.Open('tmp/test_gdal_fillnodata_2.tif')
-    assert ds.GetRasterBand(1).GetNoDataValue() == 0, \
-        'Failed to copy No Data Value to dst dataset.'
-    ds = None
+
+    try:
+        ds = gdal.Open('tmp/test_gdal_fillnodata_2.tif')
+        assert ds.GetRasterBand(1).GetNoDataValue() == 0, \
+            'Failed to copy No Data Value to dst dataset.'
+        ds = None
+    finally:
+        gdal.GetDriverByName('GTiff').Delete('tmp/test_gdal_fillnodata_2.tif')
 
 
 ###############################################################################
-# Cleanup
+# Test -si 1 and -md
 
-def test_gdal_fillnodata_cleanup():
+def test_gdal_fillnodata_smoothing():
 
-    lst = ['tmp/test_gdal_fillnodata_1.tif', 'tmp/test_gdal_fillnodata_2.tif']
-    for filename in lst:
-        try:
-            os.remove(filename)
-        except OSError:
-            pass
+    script_path = test_py_scripts.get_py_script('gdal_fillnodata')
+    if script_path is None:
+        pytest.skip()
 
+    ds = gdal.GetDriverByName('GTiff').Create('tmp/test_gdal_fillnodata_smoothing_in.tif', 4, 4)
+    ds.GetRasterBand(1).SetNoDataValue(0)
+    input_data = (
+        20, 30, 40, 50,
+        30, 0,  0,  60,
+        40, 0,  0,  70,
+        50, 60, 70, 80)
+    ds.GetRasterBand(1).WriteRaster(0, 0, 4, 4, b''.join([struct.pack('B', x) for x in input_data]))
+    ds = None
+
+    test_py_scripts.run_py_script(script_path, 'gdal_fillnodata', '-md 1 -si 1 tmp/test_gdal_fillnodata_smoothing_in.tif tmp/test_gdal_fillnodata_smoothing.tif')
+
+    expected_data = (
+        20, 30, 40, 50,
+        30, 40, 50, 60,
+        40, 50, 60, 70,
+        50, 60, 70, 80)
+    try:
+        ds = gdal.Open('tmp/test_gdal_fillnodata_smoothing.tif')
+        assert struct.unpack('B' * 16, ds.GetRasterBand(1).ReadRaster()) == expected_data
+        ds = None
+    finally:
+        gdal.GetDriverByName('GTiff').Delete('tmp/test_gdal_fillnodata_smoothing_in.tif')
+        gdal.GetDriverByName('GTiff').Delete('tmp/test_gdal_fillnodata_smoothing.tif')
 

--- a/gdal/alg/rasterfill.cpp
+++ b/gdal/alg/rasterfill.cpp
@@ -804,11 +804,10 @@ GDALFillNodata( GDALRasterBandH hTargetBand,
             {
                 if( adfQuadDist[iQuad] <= dfMaxSearchDist )
                 {
-                    const double dfWeight = 1.0 / adfQuadDist[iQuad];
-
-                    bHasSrcValues = dfWeight != 0;
+                    bHasSrcValues = true;
                     if( !bHasNoData || fQuadValue[iQuad] != fNoData )
                     {
+                        const double dfWeight = 1.0 / adfQuadDist[iQuad];
                         dfWeightSum += dfWeight;
                         dfValueSum += fQuadValue[iQuad] * dfWeight;
                     }
@@ -817,7 +816,6 @@ GDALFillNodata( GDALRasterBandH hTargetBand,
 
             if( bHasSrcValues )
             {
-                pabyMask[iX] = 255;
                 pabyFiltMask[iX] = 255;
                 if( dfWeightSum > 0.0 )
                     pafScanline[iX] = static_cast<float>(dfValueSum / dfWeightSum);

--- a/gdal/doc/source/programs/gdal_fillnodata.rst
+++ b/gdal/doc/source/programs/gdal_fillnodata.rst
@@ -56,11 +56,6 @@ Additional details on the algorithm are available in the
     The source raster file used to identify target pixels.
     Only one band is used.
 
-.. option:: -nomask
-
-    Do not use the default validity mask for the input band (such as nodata,
-    or alpha masks).
-
 .. option:: -mask filename
 
     Use the first band of the specified file as a validity mask (zero is

--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
@@ -106,7 +106,6 @@ def gdal_fillnodata(src_filename: Optional[str] = None, band_number: int = 1,
             dst_ds.SetGeoTransform(gt)
 
         dstband = dst_ds.GetRasterBand(1)
-        CopyBand(srcband, dstband)
         ndv = srcband.GetNoDataValue()
         if ndv is not None:
             dstband.SetNoDataValue(ndv)
@@ -116,6 +115,8 @@ def gdal_fillnodata(src_filename: Optional[str] = None, band_number: int = 1,
         if color_interp == gdal.GCI_PaletteIndex:
             color_table = srcband.GetColorTable()
             dstband.SetColorTable(color_table)
+
+        CopyBand(srcband, dstband)
 
     else:
         dstband = srcband

--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
@@ -81,14 +81,6 @@ def gdal_fillnodata(src_filename: Optional[str] = None, band_number: int = 1,
 
     srcband = src_ds.GetRasterBand(band_number)
 
-    if mask == 'default':
-        maskband = srcband.GetMaskBand()
-    elif mask == 'none':
-        maskband = None
-    else:
-        mask_ds = gdal.Open(mask)
-        maskband = mask_ds.GetRasterBand(1)
-
     # =============================================================================
     #       Create output file if one is specified.
     # =============================================================================
@@ -129,6 +121,14 @@ def gdal_fillnodata(src_filename: Optional[str] = None, band_number: int = 1,
         prog_func = None
     else:
         prog_func = gdal.TermProgress_nocb
+
+    if mask == 'default':
+        maskband = dstband.GetMaskBand()
+    elif mask == 'none':
+        maskband = None
+    else:
+        mask_ds = gdal.Open(mask)
+        maskband = mask_ds.GetRasterBand(1)
 
     result = gdal.FillNodata(dstband, maskband,
                              max_distance, smoothing_iterations, options,

--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
@@ -124,8 +124,6 @@ def gdal_fillnodata(src_filename: Optional[str] = None, band_number: int = 1,
 
     if mask == 'default':
         maskband = dstband.GetMaskBand()
-    elif mask == 'none':
-        maskband = None
     else:
         mask_ds = gdal.Open(mask)
         maskband = mask_ds.GetRasterBand(1)
@@ -172,10 +170,6 @@ class GDALFillNoData(GDALScript):
         parser.add_argument("-mask", dest="mask", type=str, metavar='filename', default='default',
                             help="Use the first band of the specified file as a validity mask "
                                  "(zero is invalid, non-zero is valid).")
-
-        parser.add_argument("-nomask", dest="mask", action="store_const", const='none', default='default',
-                            help="Do not use the default validity mask for the input band "
-                                 "(such as nodata, or alpha masks).")
 
         parser.add_argument("-b", "-band", dest="band_number", metavar="band", type=int, default=1,
                             help="The band to operate on, defaults to 1.")


### PR DESCRIPTION
It has likely never worked, and was equivalent to the default mode

(on top of PR #4200)