### PR TITLE
gdalwarp: slightly change default behaviour of unified src band masking…

### DIFF
--- a/gdal/alg/gdalwarper.cpp
+++ b/gdal/alg/gdalwarper.cpp
@@ -1112,12 +1112,50 @@ GDALWarpDstAlphaMasker( void *pMaskFuncArg, int nBandCount,
  * situations. Starting with GDAL 2.4, gdalwarp will automatically enable this
  * option when it is assumed to be safe to do so.</li>
  *
- * <li>UNIFIED_SRC_NODATA=YES/NO: By default nodata masking values considered
- * independently for each band.  However, sometimes it is desired to treat all
- * bands as nodata if and only if, all bands match the corresponding nodata
- * values. To get this behavior set this option to YES.
- * Note: UNIFIED_SRC_NODATA=YES is set by default, when called from gdalwarp /
- * GDALWarp()</li>
+ * <li>UNIFIED_SRC_NODATA=YES/NO/PARTIAL: This setting determines
+ * how to take into account nodata values when there are several input bands.
+ * <ul>
+ * <li>When YES, all bands are considered as nodata if and only if, all bands
+ *     match the corresponding nodata values.
+ *     Note: UNIFIED_SRC_NODATA=YES is set by default, when called from gdalwarp /
+ *     GDALWarp() with an explicit -srcnodata setting.
+ *
+ *     Example with nodata values at (1, 2, 3) and target alpha band requested.
+ *     <ul>
+ *     <li>input pixel = (1, 2, 3) ==> output pixel = (0, 0, 0, 0)</li>
+ *     <li>input pixel = (1, 2, 127) ==> output pixel = (1, 2, 127, 255)</li>
+ *     </ul>
+ * </li>
+ * <li>When NO, nodata masking values is considered independently for each band.
+ *     A potential target alpha band will always be valid if there are multiple
+ *     bands.
+ *
+ *     Example with nodata values at (1, 2, 3) and target alpha band requested.
+ *     <ul>
+ *     <li>input pixel = (1, 2, 3) ==> output pixel = (0, 0, 0, 255)</li>
+ *     <li>input pixel = (1, 2, 127) ==> output pixel = (0, 0, 127, 255)</li>
+ *     </ul>
+ *
+ *     Note: NO was the default behaviour before GDAL 3.3.2
+ * </li>
+ * <li>When PARTIAL, or not specified at all (default behavior),
+ *     nodata masking values is considered independently for each band.
+ *     But, and this is the difference with NO, if for a given pixel, it
+ *     evaluates to the nodata value of each band, the target pixel is
+ *     considered as globally invalid, which impacts the value of a potential
+ *     target alpha band.
+ *
+ *     Note: PARTIAL is new to GDAL 3.3.2 and should not be used with
+ *     earlier versions. The default behavior of GDAL < 3.3.2 was NO.
+ *
+ *     Example with nodata values at (1, 2, 3) and target alpha band requested.
+ *     <ul>
+ *     <li>input pixel = (1, 2, 3) ==> output pixel = (0, 0, 0, 0)</li>
+ *     <li>input pixel = (1, 2, 127) ==> output pixel = (0, 0, 127, 255)</li>
+ *     </ul>
+ * </li>
+ * </ul>
+ * </li>
  *
  * <li>CUTLINE: This may contain the WKT geometry for a cutline.  It will
  * be converted into a geometry by GDALWarpOperation::Initialize() and assigned

--- a/gdal/alg/gdalwarpoperation.cpp
+++ b/gdal/alg/gdalwarpoperation.cpp
@@ -1916,11 +1916,10 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
     oWK.papabyDstImage = reinterpret_cast<GByte **>(
         CPLCalloc(sizeof(GByte*), psOptions->nBandCount));
 
-    int i1 = 0;  // Used after for.
-    for( ; i1 < psOptions->nBandCount && eErr == CE_None; i1++ )
+    for( int i = 0; i < psOptions->nBandCount && eErr == CE_None; i++ )
     {
-        oWK.papabyDstImage[i1] = static_cast<GByte *>(pDataBuf)
-            + i1 * static_cast<GPtrDiff_t>(nDstXSize) * nDstYSize * nWordSize;
+        oWK.papabyDstImage[i] = static_cast<GByte *>(pDataBuf)
+            + i * static_cast<GPtrDiff_t>(nDstXSize) * nDstYSize * nWordSize;
     }
 
 /* -------------------------------------------------------------------- */
@@ -1938,7 +1937,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
     {
         CPLAssert( oWK.pafUnifiedSrcDensity == nullptr );
 
-        eErr = CreateKernelMask( &oWK, 0, "UnifiedSrcDensity" );
+        eErr = CreateKernelMask( &oWK, -1, "UnifiedSrcDensity" );
 
         if( eErr == CE_None )
         {
@@ -1973,7 +1972,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
     {
         if( oWK.pafUnifiedSrcDensity == nullptr )
         {
-            eErr = CreateKernelMask( &oWK, 0, "UnifiedSrcDensity" );
+            eErr = CreateKernelMask( &oWK, -1, "UnifiedSrcDensity" );
 
             if( eErr == CE_None )
             {
@@ -2001,7 +2000,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
     {
         CPLAssert( oWK.pafDstDensity == nullptr );
 
-        eErr = CreateKernelMask( &oWK, i1, "DstDensity" );
+        eErr = CreateKernelMask( &oWK, -1, "DstDensity" );
 
         if( eErr == CE_None )
             eErr =
@@ -2023,16 +2022,15 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
         CPLAssert( oWK.papanBandSrcValid == nullptr );
 
         bool bAllBandsAllValid = true;
-        int i2 = 0;  // Used after for.
-        for( ; i2 < psOptions->nBandCount && eErr == CE_None; i2++ )
+        for( int i = 0; i < psOptions->nBandCount && eErr == CE_None; i++ )
         {
-            eErr = CreateKernelMask( &oWK, i2, "BandSrcValid" );
+            eErr = CreateKernelMask( &oWK, i, "BandSrcValid" );
             if( eErr == CE_None )
             {
                 double adfNoData[2] =
                 {
-                    psOptions->padfSrcNoDataReal[i2],
-                    psOptions->padfSrcNoDataImag != nullptr ? psOptions->padfSrcNoDataImag[i2] : 0.0
+                    psOptions->padfSrcNoDataReal[i],
+                    psOptions->padfSrcNoDataImag != nullptr ? psOptions->padfSrcNoDataImag[i] : 0.0
                 };
 
                 int bAllValid = FALSE;
@@ -2041,8 +2039,8 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
                                           psOptions->eWorkingDataType,
                                           oWK.nSrcXOff, oWK.nSrcYOff,
                                           oWK.nSrcXSize, oWK.nSrcYSize,
-                                          &(oWK.papabySrcImage[i2]),
-                                          FALSE, oWK.papanBandSrcValid[i2],
+                                          &(oWK.papabySrcImage[i]),
+                                          FALSE, oWK.papanBandSrcValid[i],
                                           &bAllValid );
                 if( !bAllValid )
                     bAllBandsAllValid = false;
@@ -2058,7 +2056,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
                 "WARP",
                 "No need for a source nodata mask as all values are valid");
 #endif
-            for( int k = 0; k < oWK.nBands; k++ )
+            for( int k = 0; k < psOptions->nBandCount; k++ )
                 CPLFree( oWK.papanBandSrcValid[k] );
             CPLFree( oWK.papanBandSrcValid );
             oWK.papanBandSrcValid = nullptr;
@@ -2077,35 +2075,63 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
         }
 
 /* -------------------------------------------------------------------- */
-/*      If UNIFIED_SRC_NODATA is set, then compute a unified input      */
-/*      pixel mask if and only if all bands nodata is true.  That       */
-/*      is, we only treat a pixel as nodata if all bands match their    */
-/*      respective nodata values.                                       */
+/*      Compute a unified input pixel mask if and only if all bands     */
+/*      nodata is true.  That is, we only treat a pixel as nodata if    */
+/*      all bands match their respective nodata values.                 */
 /* -------------------------------------------------------------------- */
-        else if( oWK.papanBandSrcValid != nullptr &&
-            CPLFetchBool( psOptions->papszWarpOptions, "UNIFIED_SRC_NODATA",
-                          false )
-            && eErr == CE_None )
+        else if( oWK.papanBandSrcValid != nullptr && eErr == CE_None )
         {
-            const GPtrDiff_t nBytesInMask = (static_cast<GPtrDiff_t>(oWK.nSrcXSize) * oWK.nSrcYSize + 31) / 8;
-
-            eErr = CreateKernelMask( &oWK, i2, "UnifiedSrcValid" );
-
-            if( eErr == CE_None )
+            bool bAtLeastOneBandAllValid = false;
+            for( int k = 0; k < psOptions->nBandCount; k++ )
             {
-                memset( oWK.panUnifiedSrcValid, 0, nBytesInMask );
-
-                for( int k = 0; k < psOptions->nBandCount; k++ )
+                if( oWK.papanBandSrcValid[k] == nullptr )
                 {
-                    for( GPtrDiff_t iWord = nBytesInMask/4 - 1; iWord >= 0; iWord-- )
-                        oWK.panUnifiedSrcValid[iWord] |=
-                            oWK.papanBandSrcValid[k][iWord];
-                    CPLFree( oWK.papanBandSrcValid[k] );
-                    oWK.papanBandSrcValid[k] = nullptr;
+                    bAtLeastOneBandAllValid = true;
+                    break;
                 }
+            }
 
-                CPLFree( oWK.papanBandSrcValid );
-                oWK.papanBandSrcValid = nullptr;
+            const char* pszUnifiedSrcNoData = CSLFetchNameValue(
+                            psOptions->papszWarpOptions, "UNIFIED_SRC_NODATA");
+            if( !bAtLeastOneBandAllValid &&
+                (pszUnifiedSrcNoData == nullptr || CPLTestBool(pszUnifiedSrcNoData)) )
+            {
+                const GPtrDiff_t nBytesInMask = (
+                    static_cast<GPtrDiff_t>(oWK.nSrcXSize) * oWK.nSrcYSize + 31) / 8;
+                const GPtrDiff_t nIters = nBytesInMask / 4;
+
+                eErr = CreateKernelMask( &oWK, -1, "UnifiedSrcValid" );
+
+                if( eErr == CE_None )
+                {
+                    memset( oWK.panUnifiedSrcValid, 0, nBytesInMask );
+
+                    for( int k = 0; k < psOptions->nBandCount; k++ )
+                    {
+                        for( GPtrDiff_t iWord = 0; iWord < nIters; iWord++ )
+                        {
+                            oWK.panUnifiedSrcValid[iWord] |=
+                                oWK.papanBandSrcValid[k][iWord];
+                        }
+                    }
+
+                    // If UNIFIED_SRC_NODATA is set, then we will ignore the individual
+                    // nodata status of each band.
+                    // If it is not set, both mechanism apply:
+                    // - if panUnifiedSrcValid[] indicates a pixel is invalid
+                    //   (that is all its bands are at nodata), then the output
+                    //   pixel will be invalid
+                    // - otherwise, the status band per band will be check with
+                    //   papanBandSrcValid[iBand][], and the output pixel will be valid
+                    if( pszUnifiedSrcNoData != nullptr
+                            && !EQUAL(pszUnifiedSrcNoData, "PARTIAL") )
+                    {
+                        for( int k = 0; k < psOptions->nBandCount; k++ )
+                            CPLFree( oWK.papanBandSrcValid[k] );
+                        CPLFree( oWK.papanBandSrcValid );
+                        oWK.papanBandSrcValid = nullptr;
+                    }
+                }
             }
         }
     }
@@ -2130,7 +2156,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
         && nSrcXSize > 0 && nSrcYSize > 0 )
 
     {
-        eErr = CreateKernelMask( &oWK, 0, "UnifiedSrcValid" );
+        eErr = CreateKernelMask( &oWK, -1, "UnifiedSrcValid" );
 
         if( eErr == CE_None )
             eErr =
@@ -2158,7 +2184,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
 
         const GPtrDiff_t nMaskWords = (static_cast<GPtrDiff_t>(oWK.nDstXSize) * oWK.nDstYSize + 31)/32;
 
-        eErr = CreateKernelMask( &oWK, 0, "DstValid" );
+        eErr = CreateKernelMask( &oWK, -1, "DstValid" );
         GUInt32 *panBandMask =
             eErr == CE_None
             ? static_cast<GUInt32 *>(CPLMalloc(nMaskWords * 4))

--- a/gdal/doc/source/programs/gdalwarp.rst
+++ b/gdal/doc/source/programs/gdalwarp.rst
@@ -229,11 +229,19 @@ with control information.
 
 .. option:: -srcnodata <value [value...]>
 
-    Set nodata masking
-    values for input bands (different values can be supplied for each band).  If
-    more than one value is supplied all values should be quoted to keep them
-    together as a single operating system argument.  Masked values will not be
-    used in interpolation.  Use a value of ``None`` to ignore intrinsic nodata settings on the source dataset.
+    Set nodata masking values for input bands (different values can be supplied
+    for each band). If more than one value is supplied all values should be quoted
+    to keep them together as a single operating system argument.
+    Masked values will not be used in interpolation.
+    Use a value of ``None`` to ignore intrinsic nodata settings on the source dataset.
+
+    When this option is set to a non-``None`` value, it causes the ``UNIFIED_SRC_NODATA``
+    warping option (see :cpp:member:`GDALWarpOptions::papszWarpOptions`) to be
+    set to ``YES``, if it is not explicitly set.
+
+    If ``-srcnodata`` is not explicitly set, but the source dataset has nodata values,
+    they will be taken into account, with ``UNIFIED_SRC_NODATA`` at ``PARTIAL``
+    by default.
 
 .. option:: -dstnodata <value [value...]>
 


### PR DESCRIPTION
…when a pixel is evaluate to the nodata value on all bands (fixes #4253)
