### PR TITLE
[dwg] Make Closed AcDb2dPolyline and AcDb3dPolyline to Closed OGRLineString

### DIFF
--- a/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -725,6 +725,11 @@ OGRFeature *OGRDWGLayer::Translate2DPOLYLINE( OdDbEntityPtr poEntity )
         poIter->step();
     }
 
+    if (poPL->isClosed())
+    {
+        poLS->addPoint(poLS->getX(0), poLS->getY(0), poLS->getZ(0));
+    }
+
     poFeature->SetGeometryDirectly( poLS );
 
     PrepareLineStyle( poFeature );
@@ -756,6 +761,11 @@ OGRFeature *OGRDWGLayer::Translate3DPOLYLINE( OdDbEntityPtr poEntity )
         OdGePoint3d oPoint = poVertex->position();
         poLS->addPoint( oPoint.x, oPoint.y, oPoint.z );
         poIter->step();
+    }
+
+    if (poPL->isClosed())
+    {
+        poLS->addPoint(poLS->getX(0), poLS->getY(0), poLS->getZ(0));
     }
 
     poFeature->SetGeometryDirectly( poLS );

--- a/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -725,7 +725,7 @@ OGRFeature *OGRDWGLayer::Translate2DPOLYLINE( OdDbEntityPtr poEntity )
         poIter->step();
     }
 
-    if (poPL->isClosed())
+    if (poPL->isClosed() && !poLS->IsEmpty())
     {
         poLS->addPoint(poLS->getX(0), poLS->getY(0), poLS->getZ(0));
     }

--- a/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -763,7 +763,7 @@ OGRFeature *OGRDWGLayer::Translate3DPOLYLINE( OdDbEntityPtr poEntity )
         poIter->step();
     }
 
-    if (poPL->isClosed())
+    if (poPL->isClosed() && !poLS->IsEmpty())
     {
         poLS->addPoint(poLS->getX(0), poLS->getY(0), poLS->getZ(0));
     }


### PR DESCRIPTION
When dwg files contain closed AcDb2dPolyline or AcDb3dPolyline, ogr read it to unclosed line because closed AcDb2dPolyline or AcDb3dPolyline end point not equal to start point, only use isClosed function show it was closed.