### PR TITLE
[pgeo] Correctly reflect that non-spatial tables have no geometry, not unknown geometry (3.3)

### DIFF
--- a/autotest/ogr/ogr_pgeo.py
+++ b/autotest/ogr/ogr_pgeo.py
@@ -218,7 +218,7 @@ def test_ogr_pgeo_5():
         feat.DumpReadable()
         pytest.fail('did not get expected attributes')
 
-    
+
 ###############################################################################
 # Run test_ogrsf
 
@@ -273,6 +273,7 @@ def test_ogr_pgeo_8():
     assert set(layer_names) == {'lines', 'polys', 'points', 'non_spatial'}, 'did not get expected layer names'
 
     non_spatial_layer = ogrtest.pgeo_ds.GetLayerByName('non_spatial')
+    assert non_spatial_layer.GetGeomType() == ogr.wkbNone
     feat = non_spatial_layer.GetNextFeature()
     if feat.GetField('text_field') != 'Record 1' or \
        feat.GetField('int_field') != 13 or \

--- a/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeotablelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeotablelayer.cpp
@@ -187,13 +187,18 @@ CPLErr OGRPGeoTableLayer::Initialize( const char *pszTableName,
 /*      NOTE: per reports from Craig Miller, it seems we cannot really  */
 /*      trust the ShapeType value.  At the very least "line" tables     */
 /*      sometimes have multilinestrings.  So for now we just always     */
-/*      return wkbUnknown.                                              */
+/*      return wkbUnknown (unless it's a non-spatial table!)            */
 /*                                                                      */
 /*      TODO - mloskot: Similar issue has been reported in Ticket #1484 */
 /* -------------------------------------------------------------------- */
+    if( eOGRType == wkbNone )
+        poFeatureDefn->SetGeomType( eOGRType );
+    else
+    {
 #ifdef notdef
-    poFeatureDefn->SetGeomType( eOGRType );
+        poFeatureDefn->SetGeomType( eOGRType );
 #endif
+    }
 
     return CE_None;
 }


### PR DESCRIPTION
This is a non-intrusive subset of https://github.com/OSGeo/gdal/pull/4255