### PR TITLE
[geomedia, walk] Check sql tables for required tables before trying to query them when trying to open a .mdb dataset

### DIFF
--- a/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomediadatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/geomedia/ogrgeomediadatasource.cpp
@@ -140,6 +140,27 @@ int OGRGeomediaDataSource::Open( const char * pszNewName, int bUpdate,
         }
     }
 
+    // check for GAliasTable table
+    {
+        bool bFoundGAliasTable = false;
+        CPLODBCStatement oTableList( &oSession );
+        if( oTableList.GetTables() )
+        {
+            while( oTableList.Fetch() )
+            {
+                const CPLString osTableName = CPLString( oTableList.GetColData(2, "") );
+                const CPLString osLCTableName(CPLString(osTableName).tolower());
+                if( osLCTableName == "galiastable" )
+                {
+                    bFoundGAliasTable = true;
+                    break;
+                }
+            }
+        }
+        if (!bFoundGAliasTable )
+            return FALSE;
+    }
+
     pszName = CPLStrdup( pszNewName );
 
     bDSUpdate = bUpdate;

--- a/gdal/ogr/ogrsf_frmts/walk/ogrwalkdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/walk/ogrwalkdatasource.cpp
@@ -91,6 +91,27 @@ int OGRWalkDataSource::Open( const char * pszNewName, int /* bUpdate */ )
         }
     }
 
+    // check for WalkLayers table
+    {
+        bool bFoundWalkLayersTable = false;
+        CPLODBCStatement oTableList( &oSession );
+        if( oTableList.GetTables() )
+        {
+            while( oTableList.Fetch() )
+            {
+                const CPLString osTableName = CPLString( oTableList.GetColData(2, "") );
+                const CPLString osLCTableName(CPLString(osTableName).tolower());
+                if( osLCTableName == "walklayers" )
+                {
+                    bFoundWalkLayersTable = true;
+                    break;
+                }
+            }
+        }
+        if (!bFoundWalkLayersTable )
+            return FALSE;
+    }
+
     pszName = CPLStrdup( pszNewName );
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
This avoids noisy warnings raised by mdbtools odbc driver when trying to open an mdb files which isn't a geomedia/walk database,
as mdbtools dumps a lot of debug warnings when a query is attempted against a table which doesn't exist
