### PR TITLE
GDALDataset::GetFileList(): avoid cyclic calls on odd/corrupted datasets...

### DIFF
--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -2961,6 +2961,13 @@ char **GDALDataset::GetFileList()
     CPLString osMainFilename = GetDescription();
     VSIStatBufL sStat;
 
+    AntiRecursionStruct& sAntiRecursion = GetAntiRecursion();
+    const AntiRecursionStruct::DatasetContext datasetCtxt(
+        osMainFilename, 0, 0);
+    auto& aosDatasetList = sAntiRecursion.aosDatasetNamesWithFlags;
+    if( aosDatasetList.find(datasetCtxt) != aosDatasetList.end() )
+        return nullptr;
+
 /* -------------------------------------------------------------------- */
 /*      Is the main filename even a real filesystem object?             */
 /* -------------------------------------------------------------------- */
@@ -2975,7 +2982,6 @@ char **GDALDataset::GetFileList()
     if( bMainFileReal )
         papszList = CSLAddString(papszList, osMainFilename);
 
-    AntiRecursionStruct& sAntiRecursion = GetAntiRecursion();
     if( sAntiRecursion.nRecLevel == 100 )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
@@ -2989,9 +2995,11 @@ char **GDALDataset::GetFileList()
 /* -------------------------------------------------------------------- */
     if(oOvManager.IsInitialized() && oOvManager.poODS != nullptr)
     {
+        auto iter = aosDatasetList.insert(datasetCtxt).first;
         char **papszOvrList = oOvManager.poODS->GetFileList();
         papszList = CSLInsertStrings(papszList, -1, papszOvrList);
         CSLDestroy(papszOvrList);
+        aosDatasetList.erase(iter);
     }
 
 /* -------------------------------------------------------------------- */
@@ -2999,6 +3007,7 @@ char **GDALDataset::GetFileList()
 /* -------------------------------------------------------------------- */
     if( oOvManager.HaveMaskFile() )
     {
+        auto iter = aosDatasetList.insert(datasetCtxt).first;
         char **papszMskList = oOvManager.poMaskDS->GetFileList();
         char **papszIter = papszMskList;
         while( papszIter && *papszIter )
@@ -3008,6 +3017,7 @@ char **GDALDataset::GetFileList()
             ++papszIter;
         }
         CSLDestroy(papszMskList);
+        aosDatasetList.erase(iter);
     }
 
     --sAntiRecursion.nRecLevel;


### PR DESCRIPTION
... Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37460
