### PR TITLE
doc: Fix faulty sphinx rst versionadded directive

### DIFF
--- a/gdal/doc/source/programs/gdal_calc.rst
+++ b/gdal/doc/source/programs/gdal_calc.rst
@@ -68,7 +68,7 @@ but no projection checking is performed (unless projectionCheck option is used).
 
 .. option:: --hideNoData
 
-    ..versionadded:: 3.3
+    .. versionadded:: 3.3
 
     Ignores the input bands NoDataValue.
     By default, the input bands NoDataValue are not participating in the calculation.
@@ -95,7 +95,7 @@ but no projection checking is performed (unless projectionCheck option is used).
 
 .. option:: --extent=<option>
 
-    ..versionadded:: 3.3
+    .. versionadded:: 3.3
 
     this option determines how to handle rasters with different extents.
     this option is mutually exclusive with the `projwin` option, which is used for providing a custom extent.
@@ -107,13 +107,13 @@ but no projection checking is performed (unless projectionCheck option is used).
 
 .. option:: --projwin <ulx> <uly> <lrx> <lry>
 
-    ..versionadded:: 3.3
+    .. versionadded:: 3.3
 
     this option provides a custom extent for the output, it is mutually exclusive with the `extent` option.
 
 .. option:: --projectionCheck
 
-    ..versionadded:: 3.3
+    .. versionadded:: 3.3
 
     By default, no projection checking will be performed.
     By setting this option, if the projection is not the same for all bands then the operation will fail.
@@ -197,7 +197,7 @@ Add three files together (two options with the same result):
 
     gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="A+B+C"
 
-..versionadded:: 3.3
+.. versionadded:: 3.3
 
 .. code-block::
 
@@ -209,7 +209,7 @@ Average of three layers (two options with the same result):
 
     gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="(A+B+C)/3"
 
-..versionadded:: 3.3
+.. versionadded:: 3.3
 
 .. code-block::
 
@@ -221,7 +221,7 @@ Maximum of three layers  (two options with the same result):
 
     gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="numpy.max((A,B,C),axis=0)"
 
-..versionadded:: 3.3
+.. versionadded:: 3.3
 
 .. code-block::
 


### PR DESCRIPTION


<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes rendering of "versionadded" on doc page of gdal_calc. 
