### PR TITLE
[pgeo] Add support for retrieving layer definition and metadata

### DIFF
--- a/autotest/ogr/ogr_pgeo.py
+++ b/autotest/ogr/ogr_pgeo.py
@@ -409,3 +409,46 @@ def test_ogr_pgeo_read_domains():
     assert domain.GetMaxAsDouble() == 50.0
 
 
+###############################################################################
+# Test retrieving layer definition
+
+def test_ogr_pgeo_read_definition():
+    ds = gdal.OpenEx('data/pgeo/metadata.mdb', gdal.OF_VECTOR)
+    if ds is None:
+        pytest.skip('could not open DB. Driver probably misconfigured')
+
+    sql_lyr = ds.ExecuteSQL('GetLayerDefinition not a table')
+    assert sql_lyr is None
+
+    sql_lyr = ds.ExecuteSQL('GetLayerDefinition metadata')
+    feat_count = sql_lyr.GetFeatureCount()
+    assert feat_count == 1, 'did not get expected feature count'
+
+    feat = sql_lyr.GetNextFeature()
+    assert feat is not None
+    assert feat.GetField(0).startswith('<DEFeatureClassInfo')
+
+    ds.ReleaseResultSet(sql_lyr)
+
+
+###############################################################################
+# Test retrieving layer metadata
+
+def test_ogr_pgeo_read_metadata():
+    ds = gdal.OpenEx('data/pgeo/metadata.mdb', gdal.OF_VECTOR)
+    if ds is None:
+        pytest.skip('could not open DB. Driver probably misconfigured')
+
+    sql_lyr = ds.ExecuteSQL('GetLayerMetadata not a table')
+    assert sql_lyr is None
+
+    sql_lyr = ds.ExecuteSQL('GetLayerMetadata metadata')
+    feat_count = sql_lyr.GetFeatureCount()
+    assert feat_count == 1, 'did not get expected feature count'
+
+    feat = sql_lyr.GetNextFeature()
+    assert feat is not None
+    assert feat.GetField(0).startswith('<metadata xml:lang="en"><Esri>')
+
+    ds.ReleaseResultSet(sql_lyr)
+

--- a/gdal/doc/source/drivers/vector/pgeo.rst
+++ b/gdal/doc/source/drivers/vector/pgeo.rst
@@ -47,6 +47,13 @@ engine. It's also possible to request the driver to handle SQL commands
 with :ref:`OGR SQL <ogr_sql_dialect>` engine, by passing **"OGRSQL"**
 string to the ExecuteSQL() method, as name of the SQL dialect.
 
+Special SQL requests
+--------------------
+
+"GetLayerDefinition a_layer_name" and "GetLayerMetadata a_layer_name"
+can be used as special SQL requests to get respectively the definition
+and metadata of a Personal GeoDatabase table as XML content.
+
 Driver capabilities
 -------------------
 

--- a/gdal/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
+++ b/gdal/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
@@ -213,4 +213,26 @@ public:
 
 int OGROpenFileGDBIsComparisonOp(int op);
 
+/************************************************************************/
+/*                   OGROpenFileGDBSingleFeatureLayer                   */
+/************************************************************************/
+
+class OGROpenFileGDBSingleFeatureLayer final: public OGRLayer
+{
+  private:
+    char               *pszVal;
+    OGRFeatureDefn     *poFeatureDefn;
+    int                 iNextShapeId;
+
+  public:
+                        OGROpenFileGDBSingleFeatureLayer( const char* pszLayerName,
+                                                          const char *pszVal );
+               virtual ~OGROpenFileGDBSingleFeatureLayer();
+
+    virtual void        ResetReading() override { iNextShapeId = 0; }
+    virtual OGRFeature *GetNextFeature() override;
+    virtual OGRFeatureDefn *GetLayerDefn() override { return poFeatureDefn; }
+    virtual int         TestCapability( const char * ) override { return FALSE; }
+};
+
 #endif /* ndef OGR_OPENFILEGDB_H_INCLUDED */

--- a/gdal/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -768,27 +768,6 @@ OGRLayer* OGROpenFileGDBDataSource::GetLayerByName( const char* pszName )
     return nullptr;
 }
 
-/************************************************************************/
-/*                   OGROpenFileGDBSingleFeatureLayer                   */
-/************************************************************************/
-
-class OGROpenFileGDBSingleFeatureLayer final: public OGRLayer
-{
-  private:
-    char               *pszVal;
-    OGRFeatureDefn     *poFeatureDefn;
-    int                 iNextShapeId;
-
-  public:
-                        OGROpenFileGDBSingleFeatureLayer( const char* pszLayerName,
-                                                          const char *pszVal );
-               virtual ~OGROpenFileGDBSingleFeatureLayer();
-
-    virtual void        ResetReading() override { iNextShapeId = 0; }
-    virtual OGRFeature *GetNextFeature() override;
-    virtual OGRFeatureDefn *GetLayerDefn() override { return poFeatureDefn; }
-    virtual int         TestCapability( const char * ) override { return FALSE; }
-};
 
 /************************************************************************/
 /*                 OGROpenFileGDBSingleFeatureLayer()                   */

--- a/gdal/ogr/ogrsf_frmts/pgeo/ogr_pgeo.h
+++ b/gdal/ogr/ogrsf_frmts/pgeo/ogr_pgeo.h
@@ -102,6 +102,8 @@ class OGRPGeoTableLayer final: public OGRPGeoLayer
     virtual CPLODBCStatement *  GetStatement() override;
 
     OGREnvelope         sExtent;
+    std::string         m_osDefinition;
+    std::string         m_osDocumentation;
 
   public:
     explicit            OGRPGeoTableLayer( OGRPGeoDataSource * );
@@ -129,6 +131,8 @@ class OGRPGeoTableLayer final: public OGRPGeoLayer
     virtual OGRErr      GetExtent(OGREnvelope *psExtent, int bForce = TRUE) override;
     virtual OGRErr      GetExtent(int iGeomField, OGREnvelope *psExtent, int bForce) override
                 { return OGRLayer::GetExtent(iGeomField, psExtent, bForce); }
+    const std::string&  GetXMLDefinition() { return m_osDefinition; }
+    const std::string&  GetXMLDocumentation() { return m_osDocumentation; }
 };
 
 /************************************************************************/

--- a/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
@@ -33,6 +33,7 @@
 #include <vector>
 #include <unordered_set>
 #include "filegdb_fielddomain.h"
+#include "ogr_openfilegdb.h"
 
 #ifdef __linux
 #include <sys/types.h>
@@ -331,6 +332,41 @@ OGRLayer * OGRPGeoDataSource::ExecuteSQL( const char *pszSQLCommand,
                                           const char *pszDialect )
 
 {
+
+/* -------------------------------------------------------------------- */
+/*      Special case GetLayerDefinition                                 */
+/* -------------------------------------------------------------------- */
+    if (STARTS_WITH_CI(pszSQLCommand, "GetLayerDefinition "))
+    {
+        OGRPGeoTableLayer* poLayer = cpl::down_cast<OGRPGeoTableLayer *>(
+            GetLayerByName(pszSQLCommand + strlen("GetLayerDefinition ")) );
+        if (poLayer)
+        {
+            OGRLayer* poRet = new OGROpenFileGDBSingleFeatureLayer(
+                "LayerDefinition", poLayer->GetXMLDefinition().c_str() );
+            return poRet;
+        }
+
+        return nullptr;
+    }
+
+/* -------------------------------------------------------------------- */
+/*      Special case GetLayerMetadata                                   */
+/* -------------------------------------------------------------------- */
+    if (STARTS_WITH_CI(pszSQLCommand, "GetLayerMetadata "))
+    {
+        OGRPGeoTableLayer* poLayer = cpl::down_cast<OGRPGeoTableLayer *>(
+            GetLayerByName(pszSQLCommand + strlen("GetLayerMetadata ")) );
+        if (poLayer)
+        {
+            OGRLayer* poRet = new OGROpenFileGDBSingleFeatureLayer(
+                "LayerMetadata", poLayer->GetXMLDocumentation().c_str() );
+            return poRet;
+        }
+
+        return nullptr;
+    }
+
 /* -------------------------------------------------------------------- */
 /*      Use generic implementation for recognized dialects              */
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Add support for retrieving layer definition and metadata special "GetLayerDefinition table_name" and "GetLayerMetadata
table_name" SQL queries

Exposes the same functionality as the fgdb/openfilegdb drivers offer for retrieving these properties

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
