### PR TITLE
util.py - fix get_raster_min_max() default approx_ok value

### DIFF
--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -134,7 +134,7 @@ def test_utils_py_1():
 def test_min_max(data, name, min, max, approx_ok):
     ds = util.open_ds(test_py_scripts.get_data_path(data) + name)
     min_max = util.get_raster_min_max(ds, approx_ok=approx_ok)
-    assert min_max == min, max
+    assert min_max == (min, max)
 
 
 def test_utils_arrays():

--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -129,10 +129,12 @@ def test_utils_py_1():
     ds_list = None
 
 
-def test_min_max():
-    ds = util.open_ds(test_py_scripts.get_data_path('gcore') + 'byte.tif')
-    min_max = util.get_raster_min_max(ds)
-    assert min_max == (74, 255)
+@pytest.mark.parametrize("data,name,min,max,approx_ok",
+                         [('gcore', 'byte.tif', 74, 255, False)])
+def test_min_max(data, name, min, max, approx_ok):
+    ds = util.open_ds(test_py_scripts.get_data_path(data) + name)
+    min_max = util.get_raster_min_max(ds, approx_ok=approx_ok)
+    assert min_max == min, max
 
 
 def test_utils_arrays():

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
@@ -309,7 +309,7 @@ def get_raster_minimum(filename_or_ds: PathOrDS, bnd_index: Optional[int] = 1):
             return get_band_minimum(bnd)
 
 
-def get_raster_min_max(filename_or_ds: PathOrDS, bnd_index: int = 1, approx_ok: Union[bool, int] = True):
+def get_raster_min_max(filename_or_ds: PathOrDS, bnd_index: int = 1, approx_ok: Union[bool, int] = False):
     with OpenDS(filename_or_ds) as ds:
         bnd = ds.GetRasterBand(bnd_index)
         min_max = bnd.ComputeRasterMinMax(int(approx_ok))


### PR DESCRIPTION
## What does this PR do?

Fix previous PR, which I mistakenly set the approx_ok default to be True (https://github.com/OSGeo/gdal/pull/4151), which breaks backwards compatibility and also inconsistent with the default in `ComputeRasterMinMax`. 

I couldn't find a small test file that yields different min, max values for approx_ok True/False.

* gdal-utils/osgeo_utils/auxiliary/util.py - change default parameter get_raster_min_max(...,approx_ok = True)

* autotest/pyscripts/test_gdal_utils.py - parameterize the test_min_max test so that more cases would be added easily (i.e. approx_ok=False)

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/4167
https://github.com/OSGeo/gdal/pull/4151

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
