### PR TITLE
color_table.py - fix get_color_table_from_raster for ds w/o color table + tests

### DIFF
--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -44,7 +44,9 @@ pytest.importorskip('osgeo_utils')
 
 from osgeo_utils.auxiliary import util, raster_creation, base, array_util, color_table
 from osgeo_utils.auxiliary.color_palette import ColorPalette
+from osgeo_utils.auxiliary.color_table import get_color_table
 from osgeo_utils.auxiliary.extent_util import Extent
+import gdaltest
 
 temp_files = []
 
@@ -229,6 +231,37 @@ def test_utils_color_table_and_palette():
     max_k = max(color_entries.keys())
     for i in range(max_k, 256):
         assert color_entries[max_k] == ct256.GetColorEntry(i), 'fill remaining entries'
+
+
+def test_read_write_color_table_from_raster():
+    """ test color palettes with and without nv """
+    gdaltest.tiff_drv = gdal.GetDriverByName('GTiff')
+    ds = gdaltest.tiff_drv.Create('tmp/ct8.tif', 1, 1, 1, gdal.GDT_Byte)
+    ct = get_color_table(ds)
+    assert ct is None
+
+    name = 'color_paletted_red_green_0-255.txt'
+    root = Path(test_py_scripts.get_data_path('utilities'))
+    path = root / name
+    cp1 = ColorPalette()
+    cp1.read_file(path)
+    ct = get_color_table(cp1)
+    assert ct is not None
+    ds.GetRasterBand(1).SetRasterColorTable(ct)
+
+    ct2 = get_color_table(ds)
+    assert ct2 is not None
+    assert ct.GetCount() == ct2.GetCount()
+    for k,v in cp1.pal.items():
+        assert ColorPalette.color_to_color_entry(v, with_alpha=True) == \
+               ct.GetColorEntry(k) == ct2.GetColorEntry(k)
+    # assert ct.GetColorEntry(0) == ct2.GetColorEntry(0)
+
+    ct = None
+    ct2 = None
+    ds = None
+
+    gdaltest.tiff_drv.Delete('tmp/ct8.tif')
 
 
 def test_utils_py_cleanup():

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_palette.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_palette.py
@@ -287,13 +287,13 @@ class ColorPalette:
         return col if isinstance(col, str) else '#{:06X}'.format(col)
 
     @staticmethod
-    def color_to_color_entry(color):
+    def color_to_color_entry(color, with_alpha: Optional[bool]=None):
         b = base.get_byte(color, 0)
         g = base.get_byte(color, 1)
         r = base.get_byte(color, 2)
         a = base.get_byte(color, 3)
 
-        if a < 255:
+        if with_alpha or (with_alpha is None and (a < 255)):
             return r, g, b, a
         else:
             return r, g, b

--- a/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_table.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/auxiliary/color_table.py
@@ -42,10 +42,12 @@ ColorTableLike = Union[gdal.ColorTable, ColorPaletteOrPathOrStrings]
 
 def get_color_table_from_raster(path_or_ds: PathOrDS) -> Optional[gdal.ColorTable]:
     ds = open_ds(path_or_ds, silent_fail=True)
-    if ds is not None:
-        ct = ds.GetRasterBand(1).GetRasterColorTable()
-        return ct.Clone()
-    return None
+    if ds is None:
+        return None
+    ct = ds.GetRasterBand(1).GetRasterColorTable()
+    if ct is None:
+        return None
+    return ct.Clone()
 
 
 def color_table_from_color_palette(pal: ColorPalette, color_table: gdal.ColorTable,


### PR DESCRIPTION
## What does this PR do?

* `get_color_table_from_raster` was failing if the ds did not have a color table. now fixed.
* autotest/pyscripts/test_gdal_utils.py - add `test_read_write_color_table_from_raster()`

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
