### PR TITLE
Zarr: peformance improvements, especially for network access

### DIFF
--- a/autotest/gcore/pam.py
+++ b/autotest/gcore/pam.py
@@ -74,7 +74,7 @@ def test_pam_1():
 def test_pam_2():
 
     driver = gdal.GetDriverByName('PNM')
-    ds = driver.Create('tmp/pam.pnm', 10, 10)
+    ds = driver.Create('tmp/pam.pgm', 10, 10)
     band = ds.GetRasterBand(1)
 
     band.SetMetadata({'other': 'red', 'key': 'value'})
@@ -95,7 +95,7 @@ def test_pam_2():
 
 def test_pam_3():
 
-    ds = gdal.Open("tmp/pam.pnm")
+    ds = gdal.Open("tmp/pam.pgm")
 
     band = ds.GetRasterBand(1)
     base_md = band.GetMetadata()
@@ -117,11 +117,11 @@ def test_pam_3():
     assert band.GetNoDataValue() == 100, 'nodata not saved via pam'
 
     ds = None
-    ds = gdal.Open('tmp/pam.pnm', gdal.GA_Update)
+    ds = gdal.Open('tmp/pam.pgm', gdal.GA_Update)
     assert ds.GetRasterBand(1).DeleteNoDataValue() == 0
     ds = None
 
-    ds = gdal.Open('tmp/pam.pnm')
+    ds = gdal.Open('tmp/pam.pgm')
     assert ds.GetRasterBand(1).GetNoDataValue() is None, \
         'got nodata value whereas none was expected'
 
@@ -336,7 +336,8 @@ def test_pam_11():
     stats = ds.GetRasterBand(1).ComputeStatistics(False)
     assert stats[0] == 74, 'did not get expected minimum'
     gdal.ErrorReset()
-    ds = None
+    with gdaltest.error_handler():
+        ds = None
     error_msg = gdal.GetLastErrorMsg()
     assert error_msg.startswith('Unable to save auxiliary information'), \
         'warning was expected at that point'
@@ -402,7 +403,8 @@ def test_pam_13():
 
     gdal.SetConfigOption('GDAL_PAM_ENABLED', 'NO')
 
-    ds = gdal.GetDriverByName('PNM').Create('/vsimem/tmp.pnm', 1, 1)
+    tmpfilename = '/vsimem/tmp.pgm'
+    ds = gdal.GetDriverByName('PNM').Create(tmpfilename, 1, 1)
     # if ds.GetRasterBand(1).SetColorTable(None) == 0:
     #    gdaltest.post_reason('fail')
     #    return 'fail'
@@ -418,9 +420,9 @@ def test_pam_13():
 
     ds = None
 
-    assert gdal.VSIStatL('/vsimem/tmp.pnm.aux.xml') is None
+    assert gdal.VSIStatL(tmpfilename + '.aux.xml') is None
 
-    gdal.Unlink('/vsimem/tmp.pnm')
+    gdal.Unlink(tmpfilename)
 
     gdal.SetConfigOption('GDAL_PAM_ENABLED', 'YES')
 
@@ -431,7 +433,7 @@ def test_pam_13():
 
 def test_pam_metadata_preserved():
 
-    tmpfilename = '/vsimem/tmp.pnm'
+    tmpfilename = '/vsimem/tmp.pgm'
     ds = gdal.GetDriverByName('PNM').Create(tmpfilename, 1, 1)
     ds.SetMetadataItem('foo', 'bar')
     ds = None
@@ -520,7 +522,7 @@ def test_pam_esri_GeodataXform_gcp():
 
 def test_pam_metadata_coordinate_epoch():
 
-    tmpfilename = '/vsimem/tmp.pnm'
+    tmpfilename = '/vsimem/tmp.pgm'
     ds = gdal.GetDriverByName('PNM').Create(tmpfilename, 1, 1)
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(4326)

--- a/autotest/gcore/pamproxydb.py
+++ b/autotest/gcore/pamproxydb.py
@@ -95,7 +95,9 @@ if len(sys.argv) == 2 and sys.argv[1] == '-test1':
 
     # Check that proxy overviews work
     ds = gdal.Open('tmpdirreadonly/byte.tif')
-    ds.BuildOverviews('NEAR', overviewlist=[2])
+    gdal.PushErrorHandler()
+    assert ds.BuildOverviews('NEAR', overviewlist=[2]) == gdal.CE_None
+    gdal.PopErrorHandler()
     ds = None
 
     filelist = gdal.ReadDir('tmppamproxydir')

--- a/autotest/gdrivers/netcdf_multidim_pamproxydb.py
+++ b/autotest/gdrivers/netcdf_multidim_pamproxydb.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test multidimensional support in netCDF driver
+# Author:   Even Rouault <even.rouault@spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2021, Even Rouault <even.rouault@spatialys.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import sys
+sys.path.append('../pymod')
+
+import gdaltest
+
+from osgeo import gdal
+
+# Must to be launched from netcdf_multidim.py::test_netcdf_multidim_cache_pamproxydb
+if len(sys.argv) == 2 and sys.argv[1] == '-test_netcdf_multidim_cache_pamproxydb':
+
+    gdal.SetConfigOption('GDAL_PAM_PROXY_DIR', 'tmp/tmppamproxydir')
+
+    tmpfilename = 'tmp/tmpdirreadonly/test.nc'
+
+    def get_transposed_and_cache():
+        ds = gdal.OpenEx(tmpfilename, gdal.OF_MULTIDIM_RASTER)
+        ar = ds.GetRootGroup().OpenMDArray('Band1')
+        assert ar
+        transpose = ar.Transpose([1, 0])
+        assert transpose.Cache()
+        with gdaltest.error_handler():
+            # Cannot cache twice the same array
+            assert transpose.Cache() is False
+
+        ar2 = ds.GetRootGroup().OpenMDArray('Band1')
+        assert ar2
+        assert ar2.Cache()
+
+        return transpose.Read()
+
+    transposed_data = get_transposed_and_cache()
+
+    def check_cache_exists():
+        cache_ds = gdal.OpenEx('tmp/tmppamproxydir/000000_tmp_tmpdirreadonly_test.nc.gmac', gdal.OF_MULTIDIM_RASTER)
+        assert cache_ds
+        rg = cache_ds.GetRootGroup()
+        cached_ar = rg.OpenMDArray('Transposed_view_of__Band1_along__1_0_')
+        assert cached_ar
+        assert cached_ar.Read() == transposed_data
+
+        assert rg.OpenMDArray('_Band1') is not None
+
+    check_cache_exists()
+
+    def check_cache_working():
+        ds = gdal.OpenEx(tmpfilename, gdal.OF_MULTIDIM_RASTER)
+        ar = ds.GetRootGroup().OpenMDArray('Band1')
+        transpose = ar.Transpose([1, 0])
+        assert transpose.Read() == transposed_data
+        # Again
+        assert transpose.Read() == transposed_data
+
+    check_cache_working()
+
+    # Now alter the cache directly
+    def alter_cache():
+        cache_ds = gdal.OpenEx('tmp/tmppamproxydir/000000_tmp_tmpdirreadonly_test.nc.gmac',
+                               gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
+        assert cache_ds
+        rg = cache_ds.GetRootGroup()
+        cached_ar = rg.OpenMDArray(rg.GetMDArrayNames()[0])
+        cached_ar.Write(b'\x00' * len(transposed_data))
+
+    alter_cache()
+
+    # And check we get the altered values
+    def check_cache_really_working():
+        ds = gdal.OpenEx(tmpfilename, gdal.OF_MULTIDIM_RASTER)
+        ar = ds.GetRootGroup().OpenMDArray('Band1')
+        transpose = ar.Transpose([1, 0])
+        assert transpose.Read() == b'\x00' * len(transposed_data)
+
+    check_cache_really_working()
+
+    gdal.Unlink(tmpfilename)
+    gdal.Unlink('tmp/tmppamproxydir/000000_tmp_tmpdirreadonly_test.nc.gmac')
+
+    print('success')
+    sys.exit(0)

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -312,6 +312,8 @@ def test_zarr_invalid_json_remove_member(member):
                                          {"shape": [5, 0]},
                                          {"chunks": [1 << 40, 1 << 40],
                                           "shape": [1 << 40, 1 << 40]},
+                                         {"shape": [1 << 30, 1 << 30, 1 << 30],
+                                          "chunks": [1, 1, 1]},
                                          {"dtype": None},
                                          {"dtype": 1},
                                          {"dtype": ""},

--- a/autotest/utilities/test_gdalmdiminfo_lib.py
+++ b/autotest/utilities/test_gdalmdiminfo_lib.py
@@ -146,6 +146,10 @@ def test_gdalmdiminfo_lib_mem_dataset():
         "/dim0",
         "/dim1"
       ],
+      "dimension_size": [
+        2,
+        3
+      ],
       "attributes": {
         "myattr": {
           "datatype": "String",
@@ -183,6 +187,9 @@ def test_gdalmdiminfo_lib_mem_dataset():
       },
       "dimensions": [
         "/dim0"
+      ],
+      "dimension_size": [
+        2
       ],
       "nodata_value": {
         "x": 32767,
@@ -237,6 +244,9 @@ def test_gdalmdiminfo_lib_mem_dataset():
       "type": "my_type",
       "direction": "my_direction"
     }
+  ],
+  "dimension_size": [
+    2
   ],
   "nodata_value": {
     "x": 32767,

--- a/gdal/apps/gdal_utils_priv.h
+++ b/gdal/apps/gdal_utils_priv.h
@@ -163,6 +163,9 @@ struct GDALMultiDimTranslateOptionsForBinary
     char* pszFormat;
     int   bQuiet;
     int   bUpdate;
+
+    /* Open options. */
+    char** papszOpenOptions;
 };
 
 CPL_C_END

--- a/gdal/apps/gdalmdiminfo_lib.cpp
+++ b/gdal/apps/gdalmdiminfo_lib.cpp
@@ -731,6 +731,34 @@ static void DumpArray(std::shared_ptr<GDALMDArray> array,
     {
         serializer.AddObjKey("dimensions");
         DumpDimensions(dims, serializer, psOptions, alreadyDumpedDimensions);
+
+        serializer.AddObjKey("dimension_size");
+        auto arrayContext(serializer.MakeArrayContext());
+        for( const auto& poDim: dims )
+        {
+            serializer.Add(poDim->GetSize());
+        }
+    }
+
+
+    bool hasNonNullBlockSize = false;
+    const auto blockSize = array->GetBlockSize();
+    for( auto v: blockSize )
+    {
+        if( v != 0 )
+        {
+            hasNonNullBlockSize = true;
+            break;
+        }
+    }
+    if( hasNonNullBlockSize )
+    {
+        serializer.AddObjKey("block_size");
+        auto arrayContext(serializer.MakeArrayContext());
+        for( auto v: blockSize )
+        {
+            serializer.Add(v);
+        }
     }
 
     CPLStringList aosOptions;

--- a/gdal/apps/gdalmdimtranslate_bin.cpp
+++ b/gdal/apps/gdalmdimtranslate_bin.cpp
@@ -47,6 +47,7 @@ static void Usage(const char* pszErrorMsg = nullptr)
         "                             [-group <group_spec>]* \n"
         "                             [-subset <subset_spec>]* \n"
         "                             [-scaleaxes <scaleaxes_spec>] \n"
+        "                             [-oo NAME=VALUE]*\n"
         "                             <src_filename> <dst_filename>\n" );
 
     if( pszErrorMsg != nullptr )
@@ -77,6 +78,7 @@ static void GDALMultiDimTranslateOptionsForBinaryFree(
     CPLFree(psOptionsForBinary->pszSource);
     CPLFree(psOptionsForBinary->pszDest);
     CPLFree(psOptionsForBinary->pszFormat);
+    CSLDestroy(psOptionsForBinary->papszOpenOptions);
     CPLFree(psOptionsForBinary);
 }
 
@@ -160,7 +162,9 @@ MAIN_START(argc, argv)
         hDstDS = GDALOpenEx(
             psOptionsForBinary->pszDest,
             GDAL_OF_RASTER | GDAL_OF_MULTIDIM_RASTER | GDAL_OF_VERBOSE_ERROR | GDAL_OF_UPDATE,
-            nullptr, nullptr, nullptr );
+            nullptr,
+            psOptionsForBinary->papszOpenOptions,
+            nullptr );
         CPLPopErrorHandler();
     }
 

--- a/gdal/apps/gdalmdimtranslate_lib.cpp
+++ b/gdal/apps/gdalmdimtranslate_lib.cpp
@@ -1863,6 +1863,13 @@ GDALMultiDimTranslateOptions *GDALMultiDimTranslateOptionsNew(
             psOptions->aosCreateOptions.AddString( papszArgv[i] );
         }
 
+        else if( EQUAL(papszArgv[i], "-oo") && i+1 < argc )
+        {
+            if( psOptionsForBinary )
+                psOptionsForBinary->papszOpenOptions = CSLAddString(
+                                                psOptionsForBinary->papszOpenOptions,
+                                                papszArgv[++i] );
+        }
         else if( papszArgv[i][0] == '-' )
         {
             CPLError(CE_Failure, CPLE_NotSupported,

--- a/gdal/data/gdalmdiminfo_output.schema.json
+++ b/gdal/data/gdalmdiminfo_output.schema.json
@@ -17,6 +17,8 @@
         "type": { "type": "string", "enum": ["array"] },
         "datatype": { "$ref": "#/definitions/datatype" },
         "dimensions": { "$ref": "#/definitions/dimensions" },
+        "dimension_size": { "type": "array", "items": { "type": "number" } },
+        "block_size": { "type": "array", "items": { "type": "number" } },
         "attributes": { "$ref": "#/definitions/attributes" },
         "srs": { "$ref": "#/definitions/srs" },
         "nodata_value": { "$ref": "#/definitions/value" },
@@ -184,7 +186,7 @@
 
     "value": {
       "anyOf": [
-            {"type": "string"}, 
+            {"type": "string"},
             {"type": "number"},
             {"type": "object"},
             {"type": "array"}

--- a/gdal/doc/source/drivers/raster/zarr.rst
+++ b/gdal/doc/source/drivers/raster/zarr.rst
@@ -232,6 +232,26 @@ If the dataset contains more than one such single array, or arrays with 3 or
 more dimensions, the driver will list subdatasets to access each array and/or
 2D slices within arrays with 3 or more dimensions.
 
+Open options
+------------
+
+The following dataset open options are available:
+
+- **USE_ZMETADATA=YES/NO**: (defaults to YES)
+  Whether to use consolidated metadata from .zmetadata (Zarr V2 only).
+
+- **CACHE_TILE_PRESENCE=YES/NO**: (defaults to NO)
+  Whether to establish an initial listing of
+  present tiles. This cached listing will be stored in a .gmac file next to the
+  .zarray / .array.json.gmac file if they can be written. Otherwise the
+  :decl_configoption:`GDAL_PAM_PROXY_DIR` config option should be set to an
+  existing directory where those cached files will be stored. Once the cached
+  listing has been established, the open option no longer needs to be specified.
+  Note: the runtime of this option can be in minutes or more for large datasets
+  stored on remote file systems. And for network file systems, this will rarely
+  work for /vsicurl/ itself, but more cloud-based file systems (such as /vsis3/,
+  /vsigs/, /vsiaz/, etc) which have a dedicated directory listing operation.
+
 Creation options
 ----------------
 

--- a/gdal/doc/source/drivers/raster/zarr.rst
+++ b/gdal/doc/source/drivers/raster/zarr.rst
@@ -252,6 +252,25 @@ The following dataset open options are available:
   work for /vsicurl/ itself, but more cloud-based file systems (such as /vsis3/,
   /vsigs/, /vsiaz/, etc) which have a dedicated directory listing operation.
 
+Multi-threaded caching
+----------------------
+
+The driver implements the :cpp:func:`GDALMDArray::AdviseRead` method. This
+proceed to multi-threaded decoding of the tiles that intersect the area of
+interest specified. A sufficient cache size must be specified. The call is
+blocking.
+
+The options that can be passed to the methods are:
+
+- **CACHE_SIZE=value_in_byte**: Maximum RAM to use, expressed in number of bytes.
+  If not specified, half of the remaining GDAL block cache size will be used.
+  Note: the caching mechanism of Zarr array will not update this remaining block
+  cache size.
+
+- **NUM_THREADS=integer or ALL_CPUS**: Number of threads to use in parallel.
+  If not specified, the :decl_configoption:`GDAL_NUM_THREADS` configuration option
+  will be taken into account.
+
 Creation options
 ----------------
 

--- a/gdal/doc/source/programs/gdalmdimtranslate.rst
+++ b/gdal/doc/source/programs/gdalmdimtranslate.rst
@@ -19,9 +19,10 @@ Synopsis
 
     gdalmdimtranslate [--help-general] [-co "NAME=VALUE"]*
                       [-of format] [-array <array_spec>]*
-                      [-group <group_spec>]* 
-                      [-subset <subset_spec>]* 
-                      [-scaleaxes <scaleaxes_spec>]* 
+                      [-group <group_spec>]*
+                      [-subset <subset_spec>]*
+                      [-scaleaxes <scaleaxes_spec>]*
+                      [-oo NAME=VALUE]*
                       <src_filename> <dst_filename>
 
 
@@ -122,6 +123,12 @@ The following command line parameters can appear in any order.
     That is dim1_name(scale_factor)[,dim2_name(scale_factor)]*
 
     Using -scaleaxes is incompatible of specifying a *view* option in -array.
+
+.. option:: -oo <NAME=VALUE>
+
+    .. versionadded:: 3.4
+
+    Source dataset open option (format specific)
 
 .. option:: <src_dataset>
 

--- a/gdal/frmts/netcdf/netcdfmultidim.cpp
+++ b/gdal/frmts/netcdf/netcdfmultidim.cpp
@@ -416,7 +416,8 @@ protected:
                       const void* pSrcBuffer) override;
 
     bool IAdviseRead(const GUInt64* arrayStartIdx,
-                     const size_t* count) const override;
+                     const size_t* count,
+                     CSLConstList papszOptions) const override;
 
 public:
     static std::shared_ptr<netCDFVariable> Create(
@@ -2825,7 +2826,8 @@ bool netCDFVariable::IRead(const GUInt64* arrayStartIdx,
 /************************************************************************/
 
 bool netCDFVariable::IAdviseRead(const GUInt64* arrayStartIdx,
-                                 const size_t* count) const
+                                 const size_t* count,
+                                 CSLConstList /* papszOptions */) const
 {
     const auto nDims = GetDimensionCount();
     if( nDims == 0 )

--- a/gdal/frmts/zarr/zarr.h
+++ b/gdal/frmts/zarr/zarr.h
@@ -519,8 +519,6 @@ protected:
                       const GDALExtendedDataType& bufferDataType,
                       const void* pSrcBuffer) override;
 
-    bool IsCacheable() const override { return false; }
-
 public:
     ~ZarrArray() override;
 

--- a/gdal/frmts/zarr/zarr.h
+++ b/gdal/frmts/zarr/zarr.h
@@ -464,6 +464,7 @@ class ZarrArray final: public GDALPamMDArray
     bool                                              m_bHasScale = false;
     bool                                              m_bScaleModified = false;
     std::weak_ptr<GDALGroup>                          m_poGroupWeak{};
+    uint64_t                                          m_nTotalTileCount = 0;
 
     ZarrArray(const std::shared_ptr<ZarrSharedResource>& poSharedResource,
               const std::string& osParentName,

--- a/gdal/frmts/zarr/zarr_array.cpp
+++ b/gdal/frmts/zarr/zarr_array.cpp
@@ -28,6 +28,7 @@
 
 #include "cpl_vsi_virtual.h"
 #include "zarr.h"
+#include "gdal_thread_pool.h"
 
 #include "tif_float.h"
 
@@ -63,6 +64,16 @@ ZarrArray::ZarrArray(const std::shared_ptr<ZarrSharedResource>& poSharedResource
 {
     m_oCompressorJSonV2.Deinit();
     m_oCompressorJSonV3.Deinit();
+
+    // Compute individual tile size
+    const size_t nSourceSize = m_aoDtypeElts.back().nativeOffset +
+                               m_aoDtypeElts.back().nativeSize;
+    m_nTileSize = m_oType.GetClass() == GEDTC_STRING ?
+                                m_oType.GetMaxStringLength() : nSourceSize;
+    for( const auto& nBlockSize: m_anBlockSize )
+    {
+        m_nTileSize *= static_cast<size_t>(nBlockSize);
+    }
 }
 
 /************************************************************************/
@@ -656,29 +667,40 @@ bool ZarrArray::AllocateWorkingBuffers() const
     m_bAllocateWorkingBuffersDone = true;
 
     // Reserve a buffer for tile content
-    const size_t nSourceSize = m_aoDtypeElts.back().nativeOffset +
-                               m_aoDtypeElts.back().nativeSize;
-    size_t nTileSize = m_oType.GetClass() == GEDTC_STRING ?
-                                m_oType.GetMaxStringLength() : nSourceSize;
-    for( const auto& nBlockSize: m_anBlockSize )
-    {
-        nTileSize *= static_cast<size_t>(nBlockSize);
-    }
-    if( nTileSize > 1024 * 1024 * 1024 &&
+    if( m_nTileSize > 1024 * 1024 * 1024 &&
         !CPLTestBool(CPLGetConfigOption("ZARR_ALLOW_BIG_TILE_SIZE", "NO")) )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Zarr tile allocation would require " CPL_FRMT_GUIB " bytes. "
                  "By default the driver limits to 1 GB. To allow that memory "
                  "allocation, set the ZARR_ALLOW_BIG_TILE_SIZE configuration "
-                 "option to YES.", static_cast<GUIntBig>(nTileSize));
+                 "option to YES.", static_cast<GUIntBig>(m_nTileSize));
         return false;
     }
+
+    m_bWorkingBuffersOK = AllocateWorkingBuffers(m_abyRawTileData,
+                                                 m_abyTmpRawTileData,
+                                                 m_abyDecodedTileData);
+    return m_bWorkingBuffersOK;
+}
+
+bool ZarrArray::AllocateWorkingBuffers(std::vector<GByte>& abyRawTileData,
+                                       std::vector<GByte>& abyTmpRawTileData,
+                                       std::vector<GByte>& abyDecodedTileData) const
+{
+    // This method should NOT modify any ZarrArray member, as it is going to
+    // be called concurrently from several threads.
+
+    // Set those #define to avoid accidental use of some global variables
+#define m_abyTmpRawTileData cannot_use_here
+#define m_abyRawTileData cannot_use_here
+#define m_abyDecodedTileData cannot_use_here
+
     try
     {
-        m_abyRawTileData.resize( nTileSize );
+        abyRawTileData.resize( m_nTileSize );
         if( m_bFortranOrder || m_oFiltersArray.Size() != 0 )
-            m_abyTmpRawTileData.resize( nTileSize );
+            abyTmpRawTileData.resize( m_nTileSize );
     }
     catch( const std::bad_alloc& e )
     {
@@ -687,6 +709,8 @@ bool ZarrArray::AllocateWorkingBuffers() const
     }
 
     bool bNeedDecodedBuffer = false;
+    const size_t nSourceSize = m_aoDtypeElts.back().nativeOffset +
+                               m_aoDtypeElts.back().nativeSize;
     if( m_oType.GetClass() == GEDTC_COMPOUND && nSourceSize != m_oType.GetSize() )
     {
         bNeedDecodedBuffer = true;
@@ -712,7 +736,7 @@ bool ZarrArray::AllocateWorkingBuffers() const
         }
         try
         {
-            m_abyDecodedTileData.resize( nDecodedBufferSize );
+            abyDecodedTileData.resize( nDecodedBufferSize );
         }
         catch( const std::bad_alloc& e )
         {
@@ -721,8 +745,10 @@ bool ZarrArray::AllocateWorkingBuffers() const
         }
     }
 
-    m_bWorkingBuffersOK = true;
     return true;
+#undef m_abyTmpRawTileData
+#undef m_abyRawTileData
+#undef m_abyDecodedTileData
 }
 
 /************************************************************************/
@@ -1036,21 +1062,49 @@ static void DecodeSourceElt(const std::vector<DtypeElt>& elts,
 /*                        ZarrArray::LoadTileData()                     */
 /************************************************************************/
 
-bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
+bool ZarrArray::LoadTileData(const uint64_t* tileIndices,
                              bool& bMissingTileOut) const
 {
+    return LoadTileData(tileIndices,
+                        false, // use mutex
+                        m_psDecompressor,
+                        m_abyRawTileData,
+                        m_abyTmpRawTileData,
+                        m_abyDecodedTileData,
+                        bMissingTileOut);
+}
+
+bool ZarrArray::LoadTileData(const uint64_t* tileIndices,
+                             bool bUseMutex,
+                             const CPLCompressor* psDecompressor,
+                             std::vector<GByte>& abyRawTileData,
+                             std::vector<GByte>& abyTmpRawTileData,
+                             std::vector<GByte>& abyDecodedTileData,
+                             bool& bMissingTileOut) const
+{
+    // This method should NOT modify any ZarrArray member, as it is going to
+    // be called concurrently from several threads.
+
+    // Set those #define to avoid accidental use of some global variables
+#define m_abyTmpRawTileData cannot_use_here
+#define m_abyRawTileData cannot_use_here
+#define m_abyDecodedTileData cannot_use_here
+#define m_psDecompressor cannot_use_here
+
+    bMissingTileOut = false;
+
     std::string osFilename;
-    if( tileIndices.empty() )
+    if( m_aoDims.empty() )
     {
         osFilename = "0";
     }
     else
     {
-        for( const auto index: tileIndices )
+        for( size_t i = 0; i < m_aoDims.size(); ++i )
         {
             if( !osFilename.empty() )
                 osFilename += m_osDimSeparator;
-            osFilename += std::to_string(index);
+            osFilename += std::to_string(tileIndices[i]);
         }
     }
 
@@ -1072,6 +1126,8 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
     osFilename = VSIFileManager::GetHandler( osFilename.c_str() )->GetStreamingFilename(osFilename);
 
     // First if we have a tile presence cache, check tile presence from it
+    if( bUseMutex )
+        m_oMutex.lock();
     auto poTilePresenceArray = OpenTilePresenceCache(false);
     if( poTilePresenceArray )
     {
@@ -1080,7 +1136,7 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
         const std::vector<GInt64> anArrayStep(m_aoDims.size(), 0);
         const std::vector<GPtrDiff_t> anBufferStride(m_aoDims.size(), 0);
         const auto eByteDT = GDALExtendedDataType::Create(GDT_Byte);
-        for( size_t i = 0; i < tileIndices.size(); ++i )
+        for( size_t i = 0; i < m_aoDims.size(); ++i )
         {
             anTileIdx[i] = static_cast<GUInt64>(tileIndices[i]);
         }
@@ -1093,11 +1149,15 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
                                        &byValue) &&
             byValue == 0 )
         {
+            if( bUseMutex )
+                m_oMutex.unlock();
             CPLDebugOnly("Zarr", "Tile %s missing (=nodata)", osFilename.c_str());
             bMissingTileOut = true;
             return true;
         }
     }
+    if( bUseMutex )
+        m_oMutex.unlock();
 
     VSILFILE* fp = nullptr;
     // This is the number of files returned in a S3 directory listing operation
@@ -1125,10 +1185,10 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
 
     bMissingTileOut = false;
     bool bRet = true;
-    size_t nRawDataSize = m_abyRawTileData.size();
-    if( m_psDecompressor == nullptr )
+    size_t nRawDataSize = abyRawTileData.size();
+    if( psDecompressor == nullptr )
     {
-        nRawDataSize = VSIFReadL(&m_abyRawTileData[0], 1, nRawDataSize, fp);
+        nRawDataSize = VSIFReadL(&abyRawTileData[0], 1, nRawDataSize, fp);
     }
     else
     {
@@ -1168,12 +1228,12 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
             }
             else
             {
-                void* out_buffer = &m_abyRawTileData[0];
-                if( !m_psDecompressor->pfnFunc(abyCompressedData.data(),
-                                               abyCompressedData.size(),
-                                               &out_buffer, &nRawDataSize,
-                                               nullptr,
-                                               m_psDecompressor->user_data ))
+                void* out_buffer = &abyRawTileData[0];
+                if( !psDecompressor->pfnFunc(abyCompressedData.data(),
+                                             abyCompressedData.size(),
+                                             &out_buffer, &nRawDataSize,
+                                             nullptr,
+                                             psDecompressor->user_data ))
                 {
                     CPLError(CE_Failure, CPLE_AppDefined,
                              "Decompression of tile %s failed",
@@ -1199,9 +1259,9 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
             aosOptions.SetNameValue(obj.GetName().c_str(),
                                     obj.ToString().c_str());
         }
-        void* out_buffer = &m_abyTmpRawTileData[0];
-        size_t nOutSize = m_abyTmpRawTileData.size();
-        if( !psFilterDecompressor->pfnFunc(m_abyRawTileData.data(),
+        void* out_buffer = &abyTmpRawTileData[0];
+        size_t nOutSize = abyTmpRawTileData.size();
+        if( !psFilterDecompressor->pfnFunc(abyRawTileData.data(),
                                          nRawDataSize,
                                          &out_buffer,
                                          &nOutSize,
@@ -1215,9 +1275,9 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
         }
 
         nRawDataSize = nOutSize;
-        std::swap(m_abyRawTileData, m_abyTmpRawTileData);
+        std::swap(abyRawTileData, abyTmpRawTileData);
     }
-    if( nRawDataSize != m_abyRawTileData.size() )
+    if( nRawDataSize != abyRawTileData.size() )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Decompressed tile %s has not expected size after filters",
@@ -1227,18 +1287,18 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
 
     if( bRet && !bMissingTileOut && m_bFortranOrder )
     {
-        BlockTranspose(m_abyRawTileData, m_abyTmpRawTileData, true);
-        std::swap(m_abyRawTileData, m_abyTmpRawTileData);
+        BlockTranspose(abyRawTileData, abyTmpRawTileData, true);
+        std::swap(abyRawTileData, abyTmpRawTileData);
     }
 
-    if( bRet && !bMissingTileOut && !m_abyDecodedTileData.empty() )
+    if( bRet && !bMissingTileOut && !abyDecodedTileData.empty() )
     {
         const size_t nSourceSize = m_aoDtypeElts.back().nativeOffset +
                                    m_aoDtypeElts.back().nativeSize;
         const auto nDTSize = m_oType.GetSize();
-        const size_t nValues = m_abyDecodedTileData.size() / nDTSize;
-        const GByte* pSrc = m_abyRawTileData.data();
-        GByte* pDst = &m_abyDecodedTileData[0];
+        const size_t nValues = abyDecodedTileData.size() / nDTSize;
+        const GByte* pSrc = abyRawTileData.data();
+        GByte* pDst = &abyDecodedTileData[0];
         for( size_t i = 0; i < nValues; i++, pSrc += nSourceSize, pDst += nDTSize )
         {
             DecodeSourceElt(m_aoDtypeElts, pSrc, pDst);
@@ -1246,6 +1306,300 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
     }
 
     return bRet;
+
+#undef m_abyTmpRawTileData
+#undef m_abyRawTileData
+#undef m_abyDecodedTileData
+#undef m_psDecompressor
+}
+
+/************************************************************************/
+/*                      ZarrArray::IAdviseRead()                        */
+/************************************************************************/
+
+bool ZarrArray::IAdviseRead(const GUInt64* arrayStartIdx,
+                            const size_t* count,
+                            CSLConstList papszOptions) const
+{
+    const size_t nDims = m_aoDims.size();
+    std::vector<uint64_t> anIndicesCur(nDims);
+    std::vector<uint64_t> anIndicesMin(nDims);
+    std::vector<uint64_t> anIndicesMax(nDims);
+
+    // Compute min and max tile indices in each dimension, and the total
+    // nomber of tiles this represents.
+    uint64_t nReqTiles = 1;
+    for( size_t i = 0; i < nDims; ++i )
+    {
+        anIndicesMin[i] = arrayStartIdx[i] / m_anBlockSize[i];
+        anIndicesMax[i] = (arrayStartIdx[i] + count[i] - 1) / m_anBlockSize[i];
+        // Overflow on number of tiles already checked in Create()
+        nReqTiles *= (anIndicesMax[i] - anIndicesMin[i] + 1);
+    }
+
+    // Find available cache size
+    const size_t nCacheSize = [papszOptions]()
+    {
+        size_t nCacheSizeTmp;
+        const char* pszCacheSize = CSLFetchNameValue(papszOptions, "CACHE_SIZE");
+        if( pszCacheSize )
+        {
+            const auto nCacheSizeBig = CPLAtoGIntBig(pszCacheSize);
+            if( nCacheSizeBig < 0 ||
+                static_cast<uint64_t>(nCacheSizeBig) >
+                        std::numeric_limits<size_t>::max() / 2 )
+            {
+                CPLError(CE_Failure, CPLE_OutOfMemory, "Too big CACHE_SIZE");
+                return std::numeric_limits<size_t>::max();
+            }
+            nCacheSizeTmp = static_cast<size_t>(nCacheSizeBig);
+        }
+        else
+        {
+            // Arbitrarily take half of remaining cache size
+            nCacheSizeTmp = static_cast<size_t>(
+                std::min(static_cast<uint64_t>(
+                            (GDALGetCacheMax64() - GDALGetCacheUsed64())/2),
+                         static_cast<uint64_t>(
+                             std::numeric_limits<size_t>::max() / 2)));
+            CPLDebug("ZARR", "Using implicit CACHE_SIZE=" CPL_FRMT_GUIB,
+                     static_cast<GUIntBig>(nCacheSizeTmp));
+        }
+        return nCacheSizeTmp;
+    }();
+    if( nCacheSize == std::numeric_limits<size_t>::max() )
+        return false;
+
+    // Check that cache size is sufficient to hold all needed tiles.
+    // Also check that anReqTilesIndices size computation won't overflow.
+    if( nReqTiles > nCacheSize / std::max(m_nTileSize, nDims) )
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "CACHE_SIZE=" CPL_FRMT_GUIB " is not big enough to cache "
+                 "all needed tiles. "
+                 "At least " CPL_FRMT_GUIB " bytes would be needed",
+                 static_cast<GUIntBig>(nCacheSize),
+                 static_cast<GUIntBig>(nReqTiles * std::max(m_nTileSize, nDims)));
+        return false;
+    }
+
+    const int nThreads = [papszOptions, nReqTiles]()
+    {
+        int nThreadsTmp;
+        const char* pszNumThreads = CSLFetchNameValueDef(
+            papszOptions, "NUM_THREADS",
+            CPLGetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS"));
+        if( EQUAL(pszNumThreads, "ALL_CPUS") )
+            nThreadsTmp = CPLGetNumCPUs();
+        else
+            nThreadsTmp = std::max(1, atoi(pszNumThreads));
+        nThreadsTmp = static_cast<int>(
+                        std::min(static_cast<uint64_t>(nThreadsTmp), nReqTiles));
+        nThreadsTmp = std::min(nThreadsTmp, 10 * CPLGetNumCPUs());
+        return nThreadsTmp;
+    }();
+    if( nThreads <= 1 )
+        return true;
+    CPLDebug("ZARR", "IAdviseRead(): Using %d threads", nThreads);
+
+    m_oMapTileIndexToCachedTile.clear();
+
+    std::vector<uint64_t> anReqTilesIndices;
+    // Overflow checked above
+    try
+    {
+        anReqTilesIndices.resize( static_cast<size_t>(nDims * nReqTiles) );
+    }
+    catch( const std::bad_alloc& e )
+    {
+         CPLError(CE_Failure, CPLE_OutOfMemory,
+                  "Cannot allocate anReqTilesIndices: %s", e.what());
+         return false;
+    }
+
+    size_t dimIdx = 0;
+    size_t nTileIter = 0;
+lbl_next_depth:
+    if( dimIdx == nDims )
+    {
+        if( nDims == 2 )
+        {
+            // optimize in common case
+            memcpy( &anReqTilesIndices[nTileIter * nDims], anIndicesCur.data(),
+                    sizeof(uint64_t) * 2 );
+        }
+        else if( nDims == 3 )
+        {
+            // optimize in common case
+            memcpy( &anReqTilesIndices[nTileIter * nDims], anIndicesCur.data(),
+                    sizeof(uint64_t) * 3 );
+        }
+        else
+        {
+            memcpy( &anReqTilesIndices[nTileIter * nDims], anIndicesCur.data(),
+                    sizeof(uint64_t) * nDims );
+        }
+        nTileIter ++;
+    }
+    else
+    {
+        // This level of loop loops over blocks
+        anIndicesCur[dimIdx] = anIndicesMin[dimIdx];
+        while(true)
+        {
+            dimIdx ++;
+            goto lbl_next_depth;
+lbl_return_to_caller:
+            dimIdx --;
+            if( anIndicesCur[dimIdx] == anIndicesMax[dimIdx] )
+                break;
+            ++ anIndicesCur[dimIdx];
+        }
+    }
+    if( dimIdx > 0 )
+        goto lbl_return_to_caller;
+    assert( nTileIter == nReqTiles );
+
+    CPLWorkerThreadPool* wtp = GDALGetGlobalThreadPool(nThreads);
+    if( wtp == nullptr )
+        return false;
+
+    struct JobStruct
+    {
+        JobStruct() = default;
+
+        JobStruct(const JobStruct&) = delete;
+        JobStruct& operator= (const JobStruct&) = delete;
+
+        JobStruct(JobStruct&&) = default;
+        JobStruct& operator= (JobStruct&&) = default;
+
+        const ZarrArray* poArray = nullptr;
+        bool* pbGlobalStatus = nullptr;
+        int* pnRemainingThreads = nullptr;
+        const std::vector<uint64_t>* panReqTilesIndices = nullptr;
+        size_t nFirstIdx = 0;
+        size_t nLastIdxNotIncluded = 0;
+    };
+    std::vector<JobStruct> asJobStructs;
+
+    bool bGlobalStatus = true;
+    int nRemainingThreads = nThreads;
+    // Check for very highly overflow in below loop
+    assert( static_cast<size_t>(nThreads) <
+                    std::numeric_limits<size_t>::max() / nReqTiles );
+
+    // Setup jobs
+    for( int i = 0; i < nThreads; i++ )
+    {
+        JobStruct jobStruct;
+        jobStruct.poArray = this;
+        jobStruct.pbGlobalStatus = &bGlobalStatus;
+        jobStruct.pnRemainingThreads = &nRemainingThreads;
+        jobStruct.panReqTilesIndices = &anReqTilesIndices;
+        jobStruct.nFirstIdx = static_cast<size_t>(i * nReqTiles / nThreads);
+        jobStruct.nLastIdxNotIncluded = std::min(
+            static_cast<size_t>((i + 1) * nReqTiles / nThreads), nTileIter);
+        asJobStructs.emplace_back(std::move(jobStruct));
+    }
+
+    const auto JobFunc = [](void* pThreadData)
+    {
+        const JobStruct* jobStruct = static_cast<const JobStruct*>(pThreadData);
+
+        const auto poArray = jobStruct->poArray;
+        const auto& aoDims = poArray->m_aoDims;
+        const size_t l_nDims = poArray->GetDimensionCount();
+        std::vector<GByte> abyRawTileData;
+        std::vector<GByte> abyDecodedTileData;
+        std::vector<GByte> abyTmpRawTileData;
+        const CPLCompressor* psDecompressor =
+            CPLGetDecompressor(poArray->m_osDecompressorId.c_str());
+
+        for( size_t iReq = jobStruct->nFirstIdx; iReq < jobStruct->nLastIdxNotIncluded; ++iReq )
+        {
+            // Check if we must early exit
+            {
+                std::lock_guard<std::mutex> oLock(poArray->m_oMutex);
+                if( !(*jobStruct->pbGlobalStatus) )
+                    return;
+            }
+
+            const uint64_t* tileIndices =
+                jobStruct->panReqTilesIndices->data() + iReq * l_nDims;
+
+            uint64_t nTileIdx = 0;
+            for( size_t j = 0; j < l_nDims; ++j )
+            {
+                if( j > 0 )
+                    nTileIdx *= aoDims[j-1]->GetSize();
+                nTileIdx += tileIndices[j];
+            }
+
+            if( !poArray->AllocateWorkingBuffers(abyRawTileData,
+                                                 abyTmpRawTileData,
+                                                 abyDecodedTileData) )
+            {
+                std::lock_guard<std::mutex> oLock(poArray->m_oMutex);
+                *jobStruct->pbGlobalStatus = false;
+                break;
+            }
+
+            bool bIsEmpty = false;
+            bool success = poArray->LoadTileData(tileIndices,
+                                                 true, // use mutex
+                                                 psDecompressor,
+                                                 abyRawTileData,
+                                                 abyTmpRawTileData,
+                                                 abyDecodedTileData,
+                                                 bIsEmpty);
+
+            std::lock_guard<std::mutex> oLock(poArray->m_oMutex);
+            if( !success )
+            {
+                *jobStruct->pbGlobalStatus = false;
+                break;
+            }
+
+            CachedTile cachedTile;
+            if( !bIsEmpty )
+            {
+                if( !abyDecodedTileData.empty() )
+                    std::swap(cachedTile.abyDecoded, abyDecodedTileData);
+                else
+                    std::swap(cachedTile.abyDecoded, abyRawTileData);
+            }
+            poArray->m_oMapTileIndexToCachedTile[nTileIdx] = std::move(cachedTile);
+        }
+
+        std::lock_guard<std::mutex> oLock(poArray->m_oMutex);
+        (*jobStruct->pnRemainingThreads) --;
+    };
+
+    // Start jobs
+    for( int i = 0; i < nThreads; i++ )
+    {
+        if( !wtp->SubmitJob(JobFunc, &asJobStructs[i]) )
+        {
+            std::lock_guard<std::mutex> oLock(m_oMutex);
+            bGlobalStatus = false;
+            nRemainingThreads = i;
+            break;
+        }
+    }
+
+    // Wait for all jobs to be finished
+    while( true )
+    {
+        {
+            std::lock_guard<std::mutex> oLock(m_oMutex);
+            if( nRemainingThreads == 0 )
+                break;
+        }
+        wtp->WaitEvent();
+    }
+
+    return bGlobalStatus;
 }
 
 /************************************************************************/
@@ -1353,28 +1707,66 @@ lbl_next_depth:
         size_t dimIdxSubLoop = 0;
         dstPtrStackInnerLoop[0] = dstPtrStackOuterLoop[nDims];
         bool bEmptyTile = false;
-        if( !tileIndices.empty() && tileIndices == m_anCachedTiledIndices )
-        {
-            if( !m_bCachedTiledValid )
-                return false;
-            bEmptyTile = m_bCachedTiledEmpty;
-        }
-        else
-        {
-            if( !FlushDirtyTile() )
-                return false;
-
-            m_anCachedTiledIndices = tileIndices;
-            m_bCachedTiledValid = LoadTileData(tileIndices, bEmptyTile);
-            if( !m_bCachedTiledValid )
-            {
-                return false;
-            }
-            m_bCachedTiledEmpty = bEmptyTile;
-        }
 
         const GByte* pabySrcTile = m_abyDecodedTileData.empty() ?
-                        m_abyRawTileData.data(): m_abyDecodedTileData.data();
+                            m_abyRawTileData.data(): m_abyDecodedTileData.data();
+        bool bMatchFoundInMapTileIndexToCachedTile = false;
+
+        // Use cache built by IAdviseRead() if possible
+        if( !m_oMapTileIndexToCachedTile.empty() )
+        {
+            uint64_t nTileIdx = 0;
+            for( size_t j = 0; j < nDims; ++j )
+            {
+                if( j > 0 )
+                    nTileIdx *= m_aoDims[j-1]->GetSize();
+                nTileIdx += tileIndices[j];
+            }
+            const auto oIter = m_oMapTileIndexToCachedTile.find(nTileIdx);
+            if( oIter != m_oMapTileIndexToCachedTile.end() )
+            {
+                bMatchFoundInMapTileIndexToCachedTile = true;
+                if( oIter->second.abyDecoded.empty() )
+                {
+                    bEmptyTile = true;
+                }
+                else
+                {
+                    pabySrcTile = oIter->second.abyDecoded.data();
+                }
+            }
+            else
+            {
+                CPLDebugOnly("ZARR", "Cache miss for tile " CPL_FRMT_GUIB,
+                             static_cast<GUIntBig>(nTileIdx));
+            }
+        }
+
+        if( !bMatchFoundInMapTileIndexToCachedTile )
+        {
+            if( !tileIndices.empty() && tileIndices == m_anCachedTiledIndices )
+            {
+                if( !m_bCachedTiledValid )
+                    return false;
+                bEmptyTile = m_bCachedTiledEmpty;
+            }
+            else
+            {
+                if( !FlushDirtyTile() )
+                    return false;
+
+                m_anCachedTiledIndices = tileIndices;
+                m_bCachedTiledValid = LoadTileData(tileIndices.data(), bEmptyTile);
+                if( !m_bCachedTiledValid )
+                {
+                    return false;
+                }
+                m_bCachedTiledEmpty = bEmptyTile;
+            }
+
+            pabySrcTile = m_abyDecodedTileData.empty() ?
+                            m_abyRawTileData.data(): m_abyDecodedTileData.data();
+        }
         const size_t nSrcDTSize = m_abyDecodedTileData.empty() ? nSourceSize : nDTSize;
 
         for( size_t i = 0; i < nDims; ++i )
@@ -1930,6 +2322,8 @@ bool ZarrArray::IWrite(const GUInt64* arrayStartIdx,
     if( !AllocateWorkingBuffers() )
         return false;
 
+    m_oMapTileIndexToCachedTile.clear();
+
     // Need to be kept in top-level scope
     std::vector<GUInt64> arrayStartIdxMod;
     std::vector<GInt64> arrayStepMod;
@@ -2073,7 +2467,7 @@ lbl_next_depth:
                 // If we don't write the whole tile, we need to fetch a
                 // potentially existing one.
                 bool bEmptyTile = false;
-                m_bCachedTiledValid = LoadTileData(tileIndices, bEmptyTile);
+                m_bCachedTiledValid = LoadTileData(tileIndices.data(), bEmptyTile);
                 if( !m_bCachedTiledValid )
                 {
                     return false;
@@ -3206,6 +3600,7 @@ std::shared_ptr<ZarrArray> ZarrGroupBase::LoadArray(const std::string& osArrayNa
     const CPLCompressor* psCompressor = nullptr;
     const CPLCompressor* psDecompressor = nullptr;
     const auto oCompressor = oRoot["compressor"];
+    std::string osDecompressorId("NONE");
     if( isZarrV2 )
     {
         if( !oCompressor.IsValid() )
@@ -3219,19 +3614,19 @@ std::shared_ptr<ZarrArray> ZarrGroupBase::LoadArray(const std::string& osArrayNa
         }
         else if( oCompressor.GetType() == CPLJSONObject::Type::Object )
         {
-            const auto osCompressorId = oCompressor["id"].ToString();
-            if( osCompressorId.empty() )
+            osDecompressorId = oCompressor["id"].ToString();
+            if( osDecompressorId.empty() )
             {
                 CPLError(CE_Failure, CPLE_AppDefined, "Missing compressor id");
                 return nullptr;
             }
-            psCompressor = CPLGetCompressor( osCompressorId.c_str() );
-            psDecompressor = CPLGetDecompressor( osCompressorId.c_str() );
+            psCompressor = CPLGetCompressor( osDecompressorId.c_str() );
+            psDecompressor = CPLGetDecompressor( osDecompressorId.c_str() );
             if( psCompressor == nullptr || psDecompressor == nullptr )
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Decompressor %s not handled",
-                         osCompressorId.c_str());
+                         osDecompressorId.c_str());
                 return nullptr;
             }
         }
@@ -3258,9 +3653,9 @@ std::shared_ptr<ZarrArray> ZarrGroupBase::LoadArray(const std::string& osArrayNa
                     auto posSlash = osCodecName.find('/');
                     if( posSlash != std::string::npos )
                     {
-                        osCodecName.resize(posSlash);
-                        psCompressor = CPLGetCompressor( osCodecName.c_str() );
-                        psDecompressor = CPLGetDecompressor( osCodecName.c_str() );
+                        osDecompressorId = osCodecName.substr(0, posSlash);
+                        psCompressor = CPLGetCompressor( osDecompressorId.c_str() );
+                        psDecompressor = CPLGetDecompressor( osDecompressorId.c_str() );
                     }
                     break;
                 }
@@ -3333,7 +3728,7 @@ std::shared_ptr<ZarrArray> ZarrGroupBase::LoadArray(const std::string& osArrayNa
     poArray->SetDimSeparator(osDimSeparator);
     if( isZarrV2 )
         poArray->SetCompressorJsonV2(oCompressor);
-    poArray->SetCompressorDecompressor(psCompressor, psDecompressor);
+    poArray->SetCompressorDecompressor(osDecompressorId, psCompressor, psDecompressor);
     poArray->SetFilters(oFiltersArray);
     if( !abyNoData.empty() )
     {

--- a/gdal/frmts/zarr/zarr_array.cpp
+++ b/gdal/frmts/zarr/zarr_array.cpp
@@ -26,6 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#include "cpl_vsi_virtual.h"
 #include "zarr.h"
 
 #include "tif_float.h"
@@ -1065,6 +1066,10 @@ bool ZarrArray::LoadTileData(const std::vector<uint64_t>& tileIndices,
             osTmp += GetFullName();
         osFilename = osTmp + "/c" + osFilename;
     }
+
+    // For network file systems, get the streaming version of the filename,
+    // as we don't need arbitrary seeking in the file
+    osFilename = VSIFileManager::GetHandler( osFilename.c_str() )->GetStreamingFilename(osFilename);
 
     VSILFILE* fp = nullptr;
     // This is the number of files returned in a S3 directory listing operation

--- a/gdal/frmts/zarr/zarr_array.cpp
+++ b/gdal/frmts/zarr/zarr_array.cpp
@@ -2031,7 +2031,7 @@ lbl_next_depth:
             if( bWriteWholeTile )
             {
                 const bool bWholePartialTileThisDim =
-                    arrayStartIdx[i] + countInnerLoopInit[i] == m_aoDims[i]->GetSize();
+                    indicesOuterLoop[i] + countInnerLoopInit[i] == m_aoDims[i]->GetSize();
                 bWriteWholeTile = (countInnerLoopInit[i] == m_anBlockSize[i] ||
                                    bWholePartialTileThisDim);
                 if( bWholePartialTileThisDim )

--- a/gdal/frmts/zarr/zarr_group.cpp
+++ b/gdal/frmts/zarr/zarr_group.cpp
@@ -1255,7 +1255,7 @@ std::shared_ptr<GDALMDArray> ZarrGroupV2::CreateMDArray(
     poArray->SetDimSeparator(pszDimSeparator);
     poArray->SetVersion(2);
     poArray->SetDtype(dtype);
-    poArray->SetCompressorDecompressor(psCompressor, psDecompressor);
+    poArray->SetCompressorDecompressor(pszCompressor, psCompressor, psDecompressor);
     if( oCompressor.IsValid() )
         poArray->SetCompressorJsonV2(oCompressor);
     poArray->SetFilters(oFilters);
@@ -1710,7 +1710,7 @@ std::shared_ptr<GDALMDArray> ZarrGroupV3::CreateMDArray(
     poArray->SetDimSeparator(pszDimSeparator);
     poArray->SetVersion(3);
     poArray->SetDtype(dtype);
-    poArray->SetCompressorDecompressor(psCompressor, psDecompressor);
+    poArray->SetCompressorDecompressor(pszCompressor, psCompressor, psDecompressor);
     if( oCompressor.IsValid() )
         poArray->SetCompressorJsonV3(oCompressor);
     poArray->SetUpdatable(true);

--- a/gdal/frmts/zarr/zarrdriver.cpp
+++ b/gdal/frmts/zarr/zarrdriver.cpp
@@ -98,6 +98,8 @@ GDALDataset* ZarrDataset::OpenMultidim(const char* pszFilename,
         osFilename.resize(osFilename.size() - 1);
 
     auto poSharedResource = std::make_shared<ZarrSharedResource>(osFilename);
+    poSharedResource->SetOpenOptions(papszOpenOptions);
+
     auto poRG = ZarrGroupV2::Create(poSharedResource, std::string(), "/");
     poRG->SetUpdatable(bUpdateMode);
     poRG->SetDirectoryName(osFilename);
@@ -1252,6 +1254,7 @@ void GDALRegister_Zarr()
     poDriver->SetMetadataItem( GDAL_DMD_OPENOPTIONLIST,
 "<OpenOptionList>"
 "   <Option name='USE_ZMETADATA' type='boolean' description='Whether to use consolidated metadata from .zmetadata' default='YES'/>"
+"   <Option name='CACHE_TILE_PRESENCE' type='boolean' description='Whether to establish an initial listing of present tiles' default='NO'/>"
 "</OpenOptionList>" );
 
     poDriver->SetMetadataItem(GDAL_DMD_MULTIDIM_DATASET_CREATIONOPTIONLIST,

--- a/gdal/gcore/gdal.h
+++ b/gdal/gcore/gdal.h
@@ -1623,6 +1623,10 @@ int CPL_DLL GDALMDArrayWrite(GDALMDArrayH hArray,
 int CPL_DLL GDALMDArrayAdviseRead(GDALMDArrayH hArray,
                                   const GUInt64* arrayStartIdx,
                                   const size_t* count);
+int CPL_DLL GDALMDArrayAdviseReadEx(GDALMDArrayH hArray,
+                                    const GUInt64* arrayStartIdx,
+                                    const size_t* count,
+                                    CSLConstList papszOptions);
 GDALAttributeH CPL_DLL GDALMDArrayGetAttribute(GDALMDArrayH hArray, const char* pszName) CPL_WARN_UNUSED_RESULT;
 GDALAttributeH CPL_DLL *GDALMDArrayGetAttributes(GDALMDArrayH hArray, size_t* pnCount, CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
 GDALAttributeH CPL_DLL GDALMDArrayCreateAttribute(GDALMDArrayH hArray,

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -2393,7 +2393,8 @@ protected:
     GDALMDArray(const std::string& osParentName, const std::string& osName);
 
     virtual bool IAdviseRead(const GUInt64* arrayStartIdx,
-                             const size_t* count) const;
+                             const size_t* count,
+                             CSLConstList papszOptions) const;
 
     virtual bool IsCacheable() const { return true; }
 
@@ -2515,7 +2516,8 @@ public:
     virtual std::vector<std::shared_ptr<GDALMDArray>> GetCoordinateVariables() const;
 
     bool AdviseRead(const GUInt64* arrayStartIdx,
-                    const size_t* count) const;
+                    const size_t* count,
+                    CSLConstList papszOptions = nullptr) const;
 
     bool IsRegularlySpaced(double& dfStart, double& dfIncrement) const;
 

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -2402,6 +2402,10 @@ protected:
                                 double dfMean, double dfStdDev,
                                 GUInt64 nValidCount );
 
+    static std::string MassageName(const std::string& inputName);
+
+    std::shared_ptr<GDALGroup> GetCacheRootGroup(bool bCanCreate,
+                                                 std::string& osCacheFilenameOut) const;
 //! @endcond
 
 public:

--- a/gdal/gcore/gdalpamproxydb.cpp
+++ b/gdal/gcore/gdalpamproxydb.cpp
@@ -418,10 +418,13 @@ const char *PamAllocateProxy( const char *pszOriginal )
     for( i = static_cast<int>(osRevProxyFile.size())-1; i >= 0; i-- )
         osProxy += osRevProxyFile[i];
 
-    if( osOriginal.find(":::OVR") != CPLString::npos )
-        osProxy += ".ovr";
-    else
-        osProxy += ".aux.xml";
+    if( !osOriginal.endsWith(".gmac") )
+    {
+        if( osOriginal.find(":::OVR") != CPLString::npos )
+            osProxy += ".ovr";
+        else
+            osProxy += ".aux.xml";
+    }
 
 /* -------------------------------------------------------------------- */
 /*      Add the proxy and the original to the proxy list and resave     */

--- a/gdal/port/cpl_vsi_virtual.h
+++ b/gdal/port/cpl_vsi_virtual.h
@@ -136,6 +136,8 @@ public:
                                     CSLConstList papszOptions );
 
     virtual bool    AbortPendingUploads(const char* /*pszFilename*/) { return true;}
+
+    virtual std::string GetStreamingFilename(const std::string& osFilename) const { return osFilename; }
 };
 #endif /* #ifndef DOXYGEN_SKIP */
 

--- a/gdal/port/cpl_vsil_adls.cpp
+++ b/gdal/port/cpl_vsil_adls.cpp
@@ -275,10 +275,10 @@ class VSIADLSFSHandler final : public IVSIS3LikeFSHandler
                         int /* nMaxRetry */,
                         double /* dfRetryDelay */) override { return true; }
 
-    CPLString GetStreamingPath( const char* pszFilename ) const override;
-
     IVSIS3LikeHandleHelper* CreateHandleHelper(
         const char* pszURI, bool bAllowNoObject) override;
+
+    std::string GetStreamingFilename(const std::string& osFilename) const override;
 };
 
 /************************************************************************/
@@ -763,7 +763,7 @@ int VSIADLSFSHandler::Stat( const char *pszFilename, VSIStatBufL *pStatBuf,
         return 0;
     }
 
-    return VSICurlFilesystemHandler::Stat(osFilenameWithoutSlash, pStatBuf, nFlags);
+    return VSICurlFilesystemHandlerBase::Stat(osFilenameWithoutSlash, pStatBuf, nFlags);
 }
 
 /************************************************************************/
@@ -779,7 +779,7 @@ char** VSIADLSFSHandler::GetFileMetadata( const char* pszFilename,
 
     if( pszDomain == nullptr || (!EQUAL(pszDomain, "STATUS") && !EQUAL(pszDomain, "ACL")) )
     {
-        return VSICurlFilesystemHandler::GetFileMetadata(
+        return VSICurlFilesystemHandlerBase::GetFileMetadata(
                     pszFilename, pszDomain, papszOptions);
     }
 
@@ -1203,7 +1203,7 @@ VSIVirtualHandle* VSIADLSFSHandler::Open( const char *pszFilename,
     }
 
     return
-        VSICurlFilesystemHandler::Open(pszFilename, pszAccess, bSetError, papszOptions);
+        VSICurlFilesystemHandlerBase::Open(pszFilename, pszAccess, bSetError, papszOptions);
 }
 
 /************************************************************************/
@@ -2017,7 +2017,7 @@ const char* VSIADLSFSHandler::GetOptions()
     "  <Option name='VSIAZ_CHUNK_SIZE' type='int' "
         "description='Size in MB for chunks of files that are uploaded' "
         "default='4' min='1' max='4'/>" +
-        VSICurlFilesystemHandler::GetOptionsStatic() +
+        VSICurlFilesystemHandlerBase::GetOptionsStatic() +
         "</Options>");
     return osOptions.c_str();
 }
@@ -2094,18 +2094,14 @@ VSIDIR* VSIADLSFSHandler::OpenDir( const char *pszPath,
 }
 
 /************************************************************************/
-/*                         GetStreamingPath()                           */
+/*                      GetStreamingFilename()                          */
 /************************************************************************/
 
-CPLString VSIADLSFSHandler::GetStreamingPath( const char* pszFilename ) const
+std::string VSIADLSFSHandler::GetStreamingFilename(const std::string& osFilename) const
 {
-    const CPLString osPrefix(GetFSPrefix());
-    if( !STARTS_WITH_CI(pszFilename, osPrefix) )
-        return CPLString();
-
-    // Transform /vsiadls/foo into /vsiaz_streaming/foo
-    const size_t nPrefixLen = osPrefix.size();
-    return CPLString("/vsiaz_streaming/")  + (pszFilename + nPrefixLen);
+    if( STARTS_WITH(osFilename.c_str(), GetFSPrefix().c_str()) )
+        return "/vsiaz_streaming/" + osFilename.substr(GetFSPrefix().size());
+    return osFilename;
 }
 
 /************************************************************************/

--- a/gdal/port/cpl_vsil_az.cpp
+++ b/gdal/port/cpl_vsil_az.cpp
@@ -544,6 +544,8 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
                         IVSIS3LikeHandleHelper * /*poS3HandleHelper */,
                         int /* nMaxRetry */,
                         double /* dfRetryDelay */) override { return true; }
+
+    std::string GetStreamingFilename(const std::string& osFilename) const override;
 };
 
 /************************************************************************/
@@ -622,7 +624,7 @@ int VSIAzureFSHandler::Stat( const char *pszFilename, VSIStatBufL *pStatBuf,
     {
         osFilename += "/";
     }
-    return VSICurlFilesystemHandler::Stat(osFilename, pStatBuf, nFlags);
+    return VSICurlFilesystemHandlerBase::Stat(osFilename, pStatBuf, nFlags);
 }
 
 
@@ -640,7 +642,7 @@ char** VSIAzureFSHandler::GetFileMetadata( const char* pszFilename,
     if( pszDomain == nullptr ||
         (!EQUAL(pszDomain, "TAGS") && !EQUAL(pszDomain, "METADATA")) )
     {
-        return VSICurlFilesystemHandler::GetFileMetadata(
+        return VSICurlFilesystemHandlerBase::GetFileMetadata(
                     pszFilename, pszDomain, papszOptions);
     }
 
@@ -939,6 +941,17 @@ bool VSIAzureFSHandler::SetFileMetadata( const char * pszFilename,
     }
     while( bRetry );
     return bRet;
+}
+
+/************************************************************************/
+/*                      GetStreamingFilename()                          */
+/************************************************************************/
+
+std::string VSIAzureFSHandler::GetStreamingFilename(const std::string& osFilename) const
+{
+    if( STARTS_WITH(osFilename.c_str(), GetFSPrefix().c_str()) )
+        return "/vsiaz_streaming/" + osFilename.substr(GetFSPrefix().size());
+    return osFilename;
 }
 
 /************************************************************************/
@@ -1242,7 +1255,7 @@ VSIVirtualHandle* VSIAzureFSHandler::Open( const char *pszFilename,
     }
 
     return
-        VSICurlFilesystemHandler::Open(pszFilename, pszAccess, bSetError, papszOptions);
+        VSICurlFilesystemHandlerBase::Open(pszFilename, pszAccess, bSetError, papszOptions);
 }
 
 /************************************************************************/
@@ -1822,7 +1835,7 @@ const char* VSIAzureFSHandler::GetOptions()
     "  <Option name='VSIAZ_CHUNK_SIZE' type='int' "
         "description='Size in MB for chunks of files that are uploaded' "
         "default='4' min='1' max='4'/>" +
-        VSICurlFilesystemHandler::GetOptionsStatic() +
+        VSICurlFilesystemHandlerBase::GetOptionsStatic() +
         "</Options>");
     return osOptions.c_str();
 }

--- a/gdal/port/cpl_vsil_curl.cpp
+++ b/gdal/port/cpl_vsil_curl.cpp
@@ -391,7 +391,7 @@ static CPLString VSICurlGetURLFromFilename(const char* pszFilename,
 /*                           VSICurlHandle()                            */
 /************************************************************************/
 
-VSICurlHandle::VSICurlHandle( VSICurlFilesystemHandler* poFSIn,
+VSICurlHandle::VSICurlHandle( VSICurlFilesystemHandlerBase* poFSIn,
                               const char* pszFilename,
                               const char* pszURLIn ) :
     poFS(poFSIn),
@@ -2599,10 +2599,10 @@ int       VSICurlHandle::Close()
 }
 
 /************************************************************************/
-/*                   VSICurlFilesystemHandler()                         */
+/*                   VSICurlFilesystemHandlerBase()                         */
 /************************************************************************/
 
-VSICurlFilesystemHandler::VSICurlFilesystemHandler():
+VSICurlFilesystemHandlerBase::VSICurlFilesystemHandlerBase():
     oCacheFileProp{100 * 1024},
     oCacheDirList{1024, 0}
 {
@@ -2626,13 +2626,13 @@ struct CachedConnection
 // Currently thread_local and C++ objects don't work well with DLL on Windows
 static void FreeCachedConnection( void* pData )
 {
-    delete static_cast<std::map<VSICurlFilesystemHandler*, CachedConnection>*>(pData);
+    delete static_cast<std::map<VSICurlFilesystemHandlerBase*, CachedConnection>*>(pData);
 }
 
 // Per-thread and per-filesystem Curl connection cache.
-static std::map<VSICurlFilesystemHandler*, CachedConnection>& GetConnectionCache()
+static std::map<VSICurlFilesystemHandlerBase*, CachedConnection>& GetConnectionCache()
 {
-    static std::map<VSICurlFilesystemHandler*, CachedConnection> dummyCache;
+    static std::map<VSICurlFilesystemHandlerBase*, CachedConnection> dummyCache;
     int bMemoryErrorOccurred = false;
     void* pData = CPLGetTLSEx(CTLS_VSICURL_CACHEDCONNECTION, &bMemoryErrorOccurred);
     if( bMemoryErrorOccurred )
@@ -2641,7 +2641,7 @@ static std::map<VSICurlFilesystemHandler*, CachedConnection>& GetConnectionCache
     }
     if( pData == nullptr)
     {
-        auto cachedConnection = new std::map<VSICurlFilesystemHandler*, CachedConnection>();
+        auto cachedConnection = new std::map<VSICurlFilesystemHandlerBase*, CachedConnection>();
         CPLSetTLSWithFreeFuncEx( CTLS_VSICURL_CACHEDCONNECTION,
                                  cachedConnection,
                                  FreeCachedConnection, &bMemoryErrorOccurred );
@@ -2652,11 +2652,11 @@ static std::map<VSICurlFilesystemHandler*, CachedConnection>& GetConnectionCache
         }
         return *cachedConnection;
     }
-    return *static_cast<std::map<VSICurlFilesystemHandler*, CachedConnection>*>(pData);
+    return *static_cast<std::map<VSICurlFilesystemHandlerBase*, CachedConnection>*>(pData);
 }
 #else
-static thread_local std::map<VSICurlFilesystemHandler*, CachedConnection> g_tls_connectionCache;
-static std::map<VSICurlFilesystemHandler*, CachedConnection>& GetConnectionCache()
+static thread_local std::map<VSICurlFilesystemHandlerBase*, CachedConnection> g_tls_connectionCache;
+static std::map<VSICurlFilesystemHandlerBase*, CachedConnection>& GetConnectionCache()
 {
     return g_tls_connectionCache;
 }
@@ -2676,14 +2676,14 @@ void CachedConnection::clear()
 }
 
 /************************************************************************/
-/*                  ~VSICurlFilesystemHandler()                         */
+/*                  ~VSICurlFilesystemHandlerBase()                         */
 /************************************************************************/
 
 extern "C" int CPL_DLL GDALIsInGlobalDestructor();
 
-VSICurlFilesystemHandler::~VSICurlFilesystemHandler()
+VSICurlFilesystemHandlerBase::~VSICurlFilesystemHandlerBase()
 {
-    VSICurlFilesystemHandler::ClearCache();
+    VSICurlFilesystemHandlerBase::ClearCache();
     if( !GDALIsInGlobalDestructor() )
     {
         GetConnectionCache().erase(this);
@@ -2698,7 +2698,7 @@ VSICurlFilesystemHandler::~VSICurlFilesystemHandler()
 /*                      AllowCachedDataFor()                            */
 /************************************************************************/
 
-bool VSICurlFilesystemHandler::AllowCachedDataFor(const char* pszFilename)
+bool VSICurlFilesystemHandlerBase::AllowCachedDataFor(const char* pszFilename)
 {
     bool bCachedAllowed = true;
     char** papszTokens = CSLTokenizeString2(
@@ -2719,7 +2719,7 @@ bool VSICurlFilesystemHandler::AllowCachedDataFor(const char* pszFilename)
 /*                     GetCurlMultiHandleFor()                          */
 /************************************************************************/
 
-CURLM* VSICurlFilesystemHandler::GetCurlMultiHandleFor(const CPLString& /*osURL*/)
+CURLM* VSICurlFilesystemHandlerBase::GetCurlMultiHandleFor(const CPLString& /*osURL*/)
 {
     auto& conn = GetConnectionCache()[this];
     if( conn.hCurlMultiHandle == nullptr )
@@ -2733,7 +2733,7 @@ CURLM* VSICurlFilesystemHandler::GetCurlMultiHandleFor(const CPLString& /*osURL*
 /*                          GetRegionCache()                            */
 /************************************************************************/
 
-VSICurlFilesystemHandler::RegionCacheType* VSICurlFilesystemHandler::GetRegionCache()
+VSICurlFilesystemHandlerBase::RegionCacheType* VSICurlFilesystemHandlerBase::GetRegionCache()
 {
     // should be called under hMutex taken
     if( m_poRegionCacheDoNotUseDirectly == nullptr )
@@ -2748,7 +2748,7 @@ VSICurlFilesystemHandler::RegionCacheType* VSICurlFilesystemHandler::GetRegionCa
 /************************************************************************/
 
 std::shared_ptr<std::string>
-VSICurlFilesystemHandler::GetRegion( const char* pszURL,
+VSICurlFilesystemHandlerBase::GetRegion( const char* pszURL,
                                      vsi_l_offset nFileOffsetStart )
 {
     CPLMutexHolder oHolder( &hMutex );
@@ -2771,7 +2771,7 @@ VSICurlFilesystemHandler::GetRegion( const char* pszURL,
 /*                          AddRegion()                                 */
 /************************************************************************/
 
-void VSICurlFilesystemHandler::AddRegion( const char* pszURL,
+void VSICurlFilesystemHandlerBase::AddRegion( const char* pszURL,
                                           vsi_l_offset nFileOffsetStart,
                                           size_t nSize,
                                           const char *pData )
@@ -2790,7 +2790,7 @@ void VSICurlFilesystemHandler::AddRegion( const char* pszURL,
 /************************************************************************/
 
 bool
-VSICurlFilesystemHandler::GetCachedFileProp( const char* pszURL,
+VSICurlFilesystemHandlerBase::GetCachedFileProp( const char* pszURL,
                                              FileProp& oFileProp )
 {
     CPLMutexHolder oHolder( &hMutex );
@@ -2806,7 +2806,7 @@ VSICurlFilesystemHandler::GetCachedFileProp( const char* pszURL,
 /************************************************************************/
 
 void
-VSICurlFilesystemHandler::SetCachedFileProp( const char* pszURL,
+VSICurlFilesystemHandlerBase::SetCachedFileProp( const char* pszURL,
                                              FileProp& oFileProp )
 {
     CPLMutexHolder oHolder( &hMutex );
@@ -2820,7 +2820,7 @@ VSICurlFilesystemHandler::SetCachedFileProp( const char* pszURL,
 /************************************************************************/
 
 bool
-VSICurlFilesystemHandler::GetCachedDirList( const char* pszURL,
+VSICurlFilesystemHandlerBase::GetCachedDirList( const char* pszURL,
                                             CachedDirList& oCachedDirList )
 {
     CPLMutexHolder oHolder( &hMutex );
@@ -2835,7 +2835,7 @@ VSICurlFilesystemHandler::GetCachedDirList( const char* pszURL,
 /************************************************************************/
 
 void
-VSICurlFilesystemHandler::SetCachedDirList( const char* pszURL,
+VSICurlFilesystemHandlerBase::SetCachedDirList( const char* pszURL,
                                             CachedDirList& oCachedDirList )
 {
     CPLMutexHolder oHolder( &hMutex );
@@ -2867,7 +2867,7 @@ VSICurlFilesystemHandler::SetCachedDirList( const char* pszURL,
 /*                        ExistsInCacheDirList()                        */
 /************************************************************************/
 
-bool VSICurlFilesystemHandler::ExistsInCacheDirList(
+bool VSICurlFilesystemHandlerBase::ExistsInCacheDirList(
                             const CPLString& osDirname, bool *pbIsDir )
 {
     CachedDirList cachedDirList;
@@ -2889,7 +2889,7 @@ bool VSICurlFilesystemHandler::ExistsInCacheDirList(
 /*                        InvalidateCachedData()                        */
 /************************************************************************/
 
-void VSICurlFilesystemHandler::InvalidateCachedData( const char* pszURL )
+void VSICurlFilesystemHandlerBase::InvalidateCachedData( const char* pszURL )
 {
     CPLMutexHolder oHolder( &hMutex );
 
@@ -2915,7 +2915,7 @@ void VSICurlFilesystemHandler::InvalidateCachedData( const char* pszURL )
 /*                            ClearCache()                              */
 /************************************************************************/
 
-void VSICurlFilesystemHandler::ClearCache()
+void VSICurlFilesystemHandlerBase::ClearCache()
 {
     CPLMutexHolder oHolder( &hMutex );
 
@@ -2936,7 +2936,7 @@ void VSICurlFilesystemHandler::ClearCache()
 /*                          PartialClearCache()                         */
 /************************************************************************/
 
-void VSICurlFilesystemHandler::PartialClearCache(const char* pszFilenamePrefix)
+void VSICurlFilesystemHandlerBase::PartialClearCache(const char* pszFilenamePrefix)
 {
     CPLMutexHolder oHolder( &hMutex );
 
@@ -2991,7 +2991,7 @@ void VSICurlFilesystemHandler::PartialClearCache(const char* pszFilenamePrefix)
 /*                          CreateFileHandle()                          */
 /************************************************************************/
 
-VSICurlHandle* VSICurlFilesystemHandler::CreateFileHandle(
+VSICurlHandle* VSICurlFilesystemHandlerBase::CreateFileHandle(
                                                 const char* pszFilename )
 {
     return new VSICurlHandle(this, pszFilename);
@@ -3001,7 +3001,7 @@ VSICurlHandle* VSICurlFilesystemHandler::CreateFileHandle(
 /*                          GetActualURL()                              */
 /************************************************************************/
 
-const char* VSICurlFilesystemHandler::GetActualURL(const char* pszFilename)
+const char* VSICurlFilesystemHandlerBase::GetActualURL(const char* pszFilename)
 {
     VSICurlHandle* poHandle = CreateFileHandle(pszFilename);
     if( poHandle == nullptr )
@@ -3065,12 +3065,12 @@ const char* VSICurlFilesystemHandler::GetActualURL(const char* pszFilename)
         "description='Whether to skip files with Glacier storage class in " \
         "directory listing.' default='YES'/>"
 
-const char* VSICurlFilesystemHandler::GetOptionsStatic()
+const char* VSICurlFilesystemHandlerBase::GetOptionsStatic()
 {
     return VSICURL_OPTIONS;
 }
 
-const char* VSICurlFilesystemHandler::GetOptions()
+const char* VSICurlFilesystemHandlerBase::GetOptions()
 {
     static CPLString osOptions(CPLString("<Options>") + GetOptionsStatic() + "</Options>");
     return osOptions.c_str();
@@ -3080,7 +3080,7 @@ const char* VSICurlFilesystemHandler::GetOptions()
 /*                        IsAllowedFilename()                           */
 /************************************************************************/
 
-bool VSICurlFilesystemHandler::IsAllowedFilename( const char* pszFilename )
+bool VSICurlFilesystemHandlerBase::IsAllowedFilename( const char* pszFilename )
 {
     const char* pszAllowedFilename =
         CPLGetConfigOption("CPL_VSIL_CURL_ALLOWED_FILENAME", nullptr);
@@ -3147,7 +3147,7 @@ bool VSICurlFilesystemHandler::IsAllowedFilename( const char* pszFilename )
 /*                                Open()                                */
 /************************************************************************/
 
-VSIVirtualHandle* VSICurlFilesystemHandler::Open( const char *pszFilename,
+VSIVirtualHandle* VSICurlFilesystemHandlerBase::Open( const char *pszFilename,
                                                   const char *pszAccess,
                                                   bool bSetError,
                                                   CSLConstList /* papszOptions */ )
@@ -3417,7 +3417,7 @@ static bool VSICurlParseHTMLDateTimeFileSize( const char* pszStr,
 /*      Parse a file list document and return all the components.       */
 /************************************************************************/
 
-char** VSICurlFilesystemHandler::ParseHTMLFileList( const char* pszFilename,
+char** VSICurlFilesystemHandlerBase::ParseHTMLFileList( const char* pszFilename,
                                                     int nMaxFiles,
                                                     char* pszData,
                                                     bool* pbGotFileList )
@@ -3625,6 +3625,17 @@ char** VSICurlFilesystemHandler::ParseHTMLFileList( const char* pszFilename,
 }
 
 /************************************************************************/
+/*                      GetStreamingFilename()                          */
+/************************************************************************/
+
+std::string VSICurlFilesystemHandler::GetStreamingFilename(const std::string& osFilename) const
+{
+    if( STARTS_WITH(osFilename.c_str(), GetFSPrefix().c_str()) )
+        return "/vsicurl_streaming/" + osFilename.substr(GetFSPrefix().size());
+    return osFilename;
+}
+
+/************************************************************************/
 /*                         VSICurlGetToken()                            */
 /************************************************************************/
 
@@ -3776,7 +3787,7 @@ static bool VSICurlParseFullFTPLine( char* pszLine,
 /************************************************************************/
 
 CPLString
-VSICurlFilesystemHandler::GetURLFromFilename( const CPLString& osFilename )
+VSICurlFilesystemHandlerBase::GetURLFromFilename( const CPLString& osFilename )
 {
     return VSICurlGetURLFromFilename(osFilename, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
@@ -3785,7 +3796,7 @@ VSICurlFilesystemHandler::GetURLFromFilename( const CPLString& osFilename )
 /*                         RegisterEmptyDir()                           */
 /************************************************************************/
 
-void VSICurlFilesystemHandler::RegisterEmptyDir( const CPLString& osDirname )
+void VSICurlFilesystemHandlerBase::RegisterEmptyDir( const CPLString& osDirname )
 {
     CachedDirList cachedDirList;
     cachedDirList.bGotFileList = true;
@@ -3797,7 +3808,7 @@ void VSICurlFilesystemHandler::RegisterEmptyDir( const CPLString& osDirname )
 /*                          GetFileList()                               */
 /************************************************************************/
 
-char** VSICurlFilesystemHandler::GetFileList(const char *pszDirname,
+char** VSICurlFilesystemHandlerBase::GetFileList(const char *pszDirname,
                                              int nMaxFiles,
                                              bool* pbGotFileList)
 {
@@ -4081,7 +4092,7 @@ char** VSICurlFilesystemHandler::GetFileList(const char *pszDirname,
 /*                                Stat()                                */
 /************************************************************************/
 
-int VSICurlFilesystemHandler::Stat( const char *pszFilename,
+int VSICurlFilesystemHandlerBase::Stat( const char *pszFilename,
                                     VSIStatBufL *pStatBuf,
                                     int nFlags )
 {
@@ -4173,7 +4184,7 @@ int VSICurlFilesystemHandler::Stat( const char *pszFilename,
 /*                               Unlink()                               */
 /************************************************************************/
 
-int VSICurlFilesystemHandler::Unlink( const char * /* pszFilename */ )
+int VSICurlFilesystemHandlerBase::Unlink( const char * /* pszFilename */ )
 {
     return -1;
 }
@@ -4182,7 +4193,7 @@ int VSICurlFilesystemHandler::Unlink( const char * /* pszFilename */ )
 /*                               Rename()                               */
 /************************************************************************/
 
-int VSICurlFilesystemHandler::Rename( const char * /* oldpath */,
+int VSICurlFilesystemHandlerBase::Rename( const char * /* oldpath */,
                                       const char * /* newpath */ )
 {
     return -1;
@@ -4192,7 +4203,7 @@ int VSICurlFilesystemHandler::Rename( const char * /* oldpath */,
 /*                               Mkdir()                                */
 /************************************************************************/
 
-int VSICurlFilesystemHandler::Mkdir( const char * /* pszDirname */,
+int VSICurlFilesystemHandlerBase::Mkdir( const char * /* pszDirname */,
                                      long /* nMode */ )
 {
     return -1;
@@ -4202,7 +4213,7 @@ int VSICurlFilesystemHandler::Mkdir( const char * /* pszDirname */,
 /*                               Rmdir()                                */
 /************************************************************************/
 
-int VSICurlFilesystemHandler::Rmdir( const char * /* pszDirname */ )
+int VSICurlFilesystemHandlerBase::Rmdir( const char * /* pszDirname */ )
 {
     return -1;
 }
@@ -4211,7 +4222,7 @@ int VSICurlFilesystemHandler::Rmdir( const char * /* pszDirname */ )
 /*                             ReadDirInternal()                        */
 /************************************************************************/
 
-char** VSICurlFilesystemHandler::ReadDirInternal( const char *pszDirname,
+char** VSICurlFilesystemHandlerBase::ReadDirInternal( const char *pszDirname,
                                                   int nMaxFiles,
                                                   bool* pbGotFileList )
 {
@@ -4304,7 +4315,7 @@ char** VSICurlFilesystemHandler::ReadDirInternal( const char *pszDirname,
 /*                        InvalidateDirContent()                        */
 /************************************************************************/
 
-void VSICurlFilesystemHandler::InvalidateDirContent( const char *pszDirname )
+void VSICurlFilesystemHandlerBase::InvalidateDirContent( const char *pszDirname )
 {
     CPLMutexHolder oHolder( &hMutex );
 
@@ -4320,7 +4331,7 @@ void VSICurlFilesystemHandler::InvalidateDirContent( const char *pszDirname )
 /*                             ReadDirEx()                              */
 /************************************************************************/
 
-char** VSICurlFilesystemHandler::ReadDirEx( const char *pszDirname,
+char** VSICurlFilesystemHandlerBase::ReadDirEx( const char *pszDirname,
                                             int nMaxFiles )
 {
     return ReadDirInternal(pszDirname, nMaxFiles, nullptr);
@@ -4330,7 +4341,7 @@ char** VSICurlFilesystemHandler::ReadDirEx( const char *pszDirname,
 /*                             SiblingFiles()                           */
 /************************************************************************/
 
-char** VSICurlFilesystemHandler::SiblingFiles( const char *pszFilename )
+char** VSICurlFilesystemHandlerBase::SiblingFiles( const char *pszFilename )
 {
     /* Small optimization to avoid unnecessary stat'ing from PAux or ENVI */
     /* drivers. The MBTiles driver needs no companion file. */
@@ -4346,7 +4357,7 @@ char** VSICurlFilesystemHandler::SiblingFiles( const char *pszFilename )
 /*                          GetFileMetadata()                           */
 /************************************************************************/
 
-char** VSICurlFilesystemHandler::GetFileMetadata( const char* pszFilename,
+char** VSICurlFilesystemHandlerBase::GetFileMetadata( const char* pszFilename,
                                                   const char* pszDomain,
                                                   CSLConstList )
 {
@@ -4367,7 +4378,7 @@ char** VSICurlFilesystemHandler::GetFileMetadata( const char* pszFilename,
 /*                       VSIAppendWriteHandle()                         */
 /************************************************************************/
 
-VSIAppendWriteHandle::VSIAppendWriteHandle( VSICurlFilesystemHandler* poFS,
+VSIAppendWriteHandle::VSIAppendWriteHandle( VSICurlFilesystemHandlerBase* poFS,
                                             const char* pszFSPrefix,
                                             const char* pszFilename,
                                             int nChunkSize ) :
@@ -4546,7 +4557,7 @@ CurlRequestHelper::~CurlRequestHelper()
 
 long CurlRequestHelper::perform(CURL* hCurlHandle,
                 struct curl_slist* headers,
-                VSICurlFilesystemHandler *poFS,
+                VSICurlFilesystemHandlerBase *poFS,
                 IVSIS3LikeHandleHelper *poS3HandleHelper)
 {
     curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
@@ -5046,7 +5057,7 @@ void VSICurlClearCache( void )
     for( size_t i = 0; papszPrefix && papszPrefix[i]; ++i )
     {
         auto poFSHandler =
-            dynamic_cast<cpl::VSICurlFilesystemHandler*>(
+            dynamic_cast<cpl::VSICurlFilesystemHandlerBase*>(
                 VSIFileManager::GetHandler( papszPrefix[i] ));
 
         if( poFSHandler )
@@ -5078,7 +5089,7 @@ void VSICurlClearCache( void )
 void VSICurlPartialClearCache(const char* pszFilenamePrefix)
 {
      auto poFSHandler =
-            dynamic_cast<cpl::VSICurlFilesystemHandler*>(
+            dynamic_cast<cpl::VSICurlFilesystemHandlerBase*>(
                 VSIFileManager::GetHandler( pszFilenamePrefix ));
 
     if( poFSHandler )

--- a/gdal/port/cpl_vsil_oss.cpp
+++ b/gdal/port/cpl_vsil_oss.cpp
@@ -99,6 +99,8 @@ public:
             IVSIS3LikeHandleHelper * poHandleHelper ) override;
 
     char* GetSignedURL( const char* pszFilename, CSLConstList papszOptions ) override;
+
+    std::string GetStreamingFilename(const std::string& osFilename) const override { return osFilename; }
 };
 
 /************************************************************************/
@@ -169,7 +171,7 @@ VSIVirtualHandle* VSIOSSFSHandler::Open( const char *pszFilename,
     }
 
     return
-        VSICurlFilesystemHandler::Open(pszFilename, pszAccess, bSetError, papszOptions);
+        VSICurlFilesystemHandlerBase::Open(pszFilename, pszAccess, bSetError, papszOptions);
 }
 
 /************************************************************************/
@@ -187,7 +189,7 @@ VSIOSSFSHandler::~VSIOSSFSHandler()
 
 void VSIOSSFSHandler::ClearCache()
 {
-    VSICurlFilesystemHandler::ClearCache();
+    VSICurlFilesystemHandlerBase::ClearCache();
 
     oMapBucketsToOSSParams.clear();
 }
@@ -210,7 +212,7 @@ const char* VSIOSSFSHandler::GetOptions()
         "description='Size in MB for chunks of files that are uploaded. The"
         "default value of 50 MB allows for files up to 500 GB each' "
         "default='50' min='1' max='1000'/>" +
-        VSICurlFilesystemHandler::GetOptionsStatic() +
+        VSICurlFilesystemHandlerBase::GetOptionsStatic() +
         "</Options>");
     return osOptions.c_str();
 }

--- a/gdal/port/cpl_vsil_swift.cpp
+++ b/gdal/port/cpl_vsil_swift.cpp
@@ -64,7 +64,7 @@ namespace cpl {
 /*                       AnalyseSwiftFileList()                         */
 /************************************************************************/
 
-void VSICurlFilesystemHandler::AnalyseSwiftFileList(
+void VSICurlFilesystemHandlerBase::AnalyseSwiftFileList(
     const CPLString& osBaseURL,
     const CPLString& osPrefix,
     const char* pszJson,
@@ -250,11 +250,13 @@ public:
         VSIDIR* OpenDir( const char *pszPath, int nRecurseDepth,
                                 const char* const *papszOptions) override
         {
-            return VSICurlFilesystemHandler::OpenDir(pszPath, nRecurseDepth,
+            return VSICurlFilesystemHandlerBase::OpenDir(pszPath, nRecurseDepth,
                                                      papszOptions);
         }
 
         const char* GetOptions() override;
+
+        std::string GetStreamingFilename(const std::string& osFilename) const override { return osFilename; }
 };
 
 /************************************************************************/
@@ -325,7 +327,7 @@ VSIVirtualHandle* VSISwiftFSHandler::Open( const char *pszFilename,
     }
 
     return
-        VSICurlFilesystemHandler::Open(pszFilename, pszAccess, bSetError, papszOptions);
+        VSICurlFilesystemHandlerBase::Open(pszFilename, pszAccess, bSetError, papszOptions);
 }
 
 /************************************************************************/
@@ -344,7 +346,7 @@ VSISwiftFSHandler::~VSISwiftFSHandler()
 
 void VSISwiftFSHandler::ClearCache()
 {
-    VSICurlFilesystemHandler::ClearCache();
+    VSICurlFilesystemHandlerBase::ClearCache();
 
     VSISwiftHandleHelper::ClearCache();
 }
@@ -384,7 +386,7 @@ const char* VSISwiftFSHandler::GetOptions()
         "description='Project domain name'/>"
     "  <Option name='OS_REGION_NAME' type='string' "
         "description='Region name'/>"
-    +  VSICurlFilesystemHandler::GetOptionsStatic() +
+    +  VSICurlFilesystemHandlerBase::GetOptionsStatic() +
         "</Options>");
     return osOptions.c_str();
 }
@@ -456,7 +458,7 @@ int VSISwiftFSHandler::Stat( const char *pszFilename, VSIStatBufL *pStatBuf,
 
     memset(pStatBuf, 0, sizeof(VSIStatBufL));
 
-    if( VSICurlFilesystemHandler::Stat(pszFilename, pStatBuf, nFlags) == 0 )
+    if( VSICurlFilesystemHandlerBase::Stat(pszFilename, pStatBuf, nFlags) == 0 )
     {
         // if querying /vsiswift/container_name, the GET will succeed and
         // we would consider this as a file whereas it should be exposed as

--- a/gdal/port/cpl_vsil_webhdfs.cpp
+++ b/gdal/port/cpl_vsil_webhdfs.cpp
@@ -71,7 +71,7 @@ namespace cpl {
 /*                         VSIWebHDFSFSHandler                          */
 /************************************************************************/
 
-class VSIWebHDFSFSHandler final : public VSICurlFilesystemHandler
+class VSIWebHDFSFSHandler final : public VSICurlFilesystemHandlerBase
 {
     CPL_DISALLOW_COPY_ASSIGN(VSIWebHDFSFSHandler)
 
@@ -99,9 +99,13 @@ public:
         int Rmdir( const char *pszFilename ) override;
         int Mkdir( const char *pszDirname, long nMode ) override;
 
+        const char* GetDebugKey() const override { return "VSIWEBHDFS"; }
+
         CPLString GetFSPrefix() const override { return "/vsiwebhdfs/"; }
 
         const char* GetOptions() override;
+
+        std::string GetStreamingFilename(const std::string& osFilename) const override { return osFilename; }
 };
 
 /************************************************************************/
@@ -539,7 +543,7 @@ VSIVirtualHandle* VSIWebHDFSFSHandler::Open( const char *pszFilename,
     }
 
     return
-        VSICurlFilesystemHandler::Open(pszFilename, pszAccess, bSetError, papszOptions);
+        VSICurlFilesystemHandlerBase::Open(pszFilename, pszAccess, bSetError, papszOptions);
 }
 
 /************************************************************************/
@@ -563,7 +567,7 @@ const char* VSIWebHDFSFSHandler::GetOptions()
     "  <Option name='WEBHDFS_PERMISSION' type='integer' "
         "description='Permission mask (to provide as decimal number) when "
         "creating a file or directory'/>" +
-        VSICurlFilesystemHandler::GetOptionsStatic() +
+        VSICurlFilesystemHandlerBase::GetOptionsStatic() +
         "</Options>");
     return osOptions.c_str();
 }

--- a/gdal/swig/include/MultiDimensional.i
+++ b/gdal/swig/include/MultiDimensional.i
@@ -712,7 +712,7 @@ public:
 %apply (int nList, GUIntBig* pList) {(int nDims1, GUIntBig *array_start_idx)};
 %apply (int nList, GUIntBig* pList) {(int nDims2, GUIntBig *count)};
   CPLErr AdviseRead( int nDims1, GUIntBig* array_start_idx,
-                     int nDims2, GUIntBig* count ) {
+                     int nDims2, GUIntBig* count, char** options = 0 ) {
 
     const int nExpectedDims = (int)GDALMDArrayGetDimensionCount(self);
     if( nDims1 != nExpectedDims )
@@ -739,7 +739,7 @@ public:
         }
     }
 
-    if( !(GDALMDArrayAdviseRead( self, array_start_idx, count_internal.data() )) )
+    if( !(GDALMDArrayAdviseReadEx( self, array_start_idx, count_internal.data(), options )) )
     {
         return CE_Failure;
     }

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1060,12 +1060,12 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
       from osgeo import gdal_array
       return gdal_array.MDArrayReadAsArray(self, array_start_idx, count, array_step, buffer_datatype, buf_obj)
 
-  def AdviseRead(self, array_start_idx = None, count = None):
+  def AdviseRead(self, array_start_idx = None, count = None, options = []):
       if not array_start_idx:
         array_start_idx = [0] * self.GetDimensionCount()
       if not count:
         count = [ (self.GetDimensions()[i].GetSize() - array_start_idx[i]) for i in range (self.GetDimensionCount()) ]
-      return _gdal.MDArray_AdviseRead(self, array_start_idx, count)
+      return _gdal.MDArray_AdviseRead(self, array_start_idx, count, options)
 
   def __getitem__(self, item):
 

--- a/gdal/swig/python/extensions/gdal_wrap.cpp
+++ b/gdal/swig/python/extensions/gdal_wrap.cpp
@@ -6009,7 +6009,7 @@ SWIGINTERN CPLErr GDALMDArrayHS_Write(GDALMDArrayHS *self,int nDims1,GUIntBig *a
                                    (size_t)buf_len ) ? CE_None : CE_Failure;
     return eErr;
   }
-SWIGINTERN CPLErr GDALMDArrayHS_AdviseRead(GDALMDArrayHS *self,int nDims1,GUIntBig *array_start_idx,int nDims2,GUIntBig *count){
+SWIGINTERN CPLErr GDALMDArrayHS_AdviseRead(GDALMDArrayHS *self,int nDims1,GUIntBig *array_start_idx,int nDims2,GUIntBig *count,char **options=0){
 
     const int nExpectedDims = (int)GDALMDArrayGetDimensionCount(self);
     if( nDims1 != nExpectedDims )
@@ -6036,7 +6036,7 @@ SWIGINTERN CPLErr GDALMDArrayHS_AdviseRead(GDALMDArrayHS *self,int nDims1,GUIntB
         }
     }
 
-    if( !(GDALMDArrayAdviseRead( self, array_start_idx, count_internal.data() )) )
+    if( !(GDALMDArrayAdviseReadEx( self, array_start_idx, count_internal.data(), options )) )
     {
         return CE_Failure;
     }
@@ -24723,14 +24723,16 @@ SWIGINTERN PyObject *_wrap_MDArray_AdviseRead(PyObject *SWIGUNUSEDPARM(self), Py
   GUIntBig *arg3 = (GUIntBig *) 0 ;
   int arg4 ;
   GUIntBig *arg5 = (GUIntBig *) 0 ;
+  char **arg6 = (char **) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
   CPLErr result;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOO:MDArray_AdviseRead",&obj0,&obj1,&obj2)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOO|O:MDArray_AdviseRead",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_GDALMDArrayHS, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MDArray_AdviseRead" "', argument " "1"" of type '" "GDALMDArrayHS *""'"); 
@@ -24788,13 +24790,24 @@ SWIGINTERN PyObject *_wrap_MDArray_AdviseRead(PyObject *SWIGUNUSEDPARM(self), Py
       Py_DECREF(o);
     }
   }
+  if (obj3) {
+    {
+      /* %typemap(in) char **options */
+      int bErr = FALSE;
+      arg6 = CSLFromPySequence(obj3, &bErr);
+      if( bErr )
+      {
+        SWIG_fail;
+      }
+    }
+  }
   {
     if ( bUseExceptions ) {
       ClearErrorState();
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      CPL_IGNORE_RET_VAL(result = (CPLErr)GDALMDArrayHS_AdviseRead(arg1,arg2,arg3,arg4,arg5));
+      CPL_IGNORE_RET_VAL(result = (CPLErr)GDALMDArrayHS_AdviseRead(arg1,arg2,arg3,arg4,arg5,arg6));
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -24819,6 +24832,10 @@ SWIGINTERN PyObject *_wrap_MDArray_AdviseRead(PyObject *SWIGUNUSEDPARM(self), Py
       free((void*) arg5);
     }
   }
+  {
+    /* %typemap(freearg) char **options */
+    CSLDestroy( arg6 );
+  }
   if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
   return resultobj;
 fail:
@@ -24833,6 +24850,10 @@ fail:
     if (arg5) {
       free((void*) arg5);
     }
+  }
+  {
+    /* %typemap(freearg) char **options */
+    CSLDestroy( arg6 );
   }
   return NULL;
 }
@@ -44041,7 +44062,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"MDArray_Read", _wrap_MDArray_Read, METH_VARARGS, (char *)"MDArray_Read(MDArray self, int nDims1, int nDims2, int nDims3, int nDims4, ExtendedDataType buffer_datatype) -> CPLErr"},
 	 { (char *)"MDArray_WriteStringArray", _wrap_MDArray_WriteStringArray, METH_VARARGS, (char *)"MDArray_WriteStringArray(MDArray self, int nDims1, int nDims2, int nDims3, ExtendedDataType buffer_datatype, char ** options) -> CPLErr"},
 	 { (char *)"MDArray_Write", _wrap_MDArray_Write, METH_VARARGS, (char *)"MDArray_Write(MDArray self, int nDims1, int nDims2, int nDims3, int nDims4, ExtendedDataType buffer_datatype, GIntBig buf_len) -> CPLErr"},
-	 { (char *)"MDArray_AdviseRead", _wrap_MDArray_AdviseRead, METH_VARARGS, (char *)"MDArray_AdviseRead(MDArray self, int nDims1, int nDims2) -> CPLErr"},
+	 { (char *)"MDArray_AdviseRead", _wrap_MDArray_AdviseRead, METH_VARARGS, (char *)"MDArray_AdviseRead(MDArray self, int nDims1, int nDims2, char ** options=None) -> CPLErr"},
 	 { (char *)"MDArray_GetAttribute", _wrap_MDArray_GetAttribute, METH_VARARGS, (char *)"MDArray_GetAttribute(MDArray self, char const * name) -> Attribute"},
 	 { (char *)"MDArray_GetAttributes", _wrap_MDArray_GetAttributes, METH_VARARGS, (char *)"MDArray_GetAttributes(MDArray self, char ** options=None)"},
 	 { (char *)"MDArray_CreateAttribute", _wrap_MDArray_CreateAttribute, METH_VARARGS, (char *)"MDArray_CreateAttribute(MDArray self, char const * name, int nDimensions, ExtendedDataType data_type, char ** options=None) -> Attribute"},

--- a/gdal/swig/python/osgeo/gdal.py
+++ b/gdal/swig/python/osgeo/gdal.py
@@ -2964,7 +2964,7 @@ class MDArray(_object):
 
 
     def AdviseRead(self, *args):
-        """AdviseRead(MDArray self, int nDims1, int nDims2) -> CPLErr"""
+        """AdviseRead(MDArray self, int nDims1, int nDims2, char ** options=None) -> CPLErr"""
         return _gdal.MDArray_AdviseRead(self, *args)
 
 
@@ -3148,12 +3148,12 @@ class MDArray(_object):
         from osgeo import gdal_array
         return gdal_array.MDArrayReadAsArray(self, array_start_idx, count, array_step, buffer_datatype, buf_obj)
 
-    def AdviseRead(self, array_start_idx = None, count = None):
+    def AdviseRead(self, array_start_idx = None, count = None, options = []):
         if not array_start_idx:
           array_start_idx = [0] * self.GetDimensionCount()
         if not count:
           count = [ (self.GetDimensions()[i].GetSize() - array_start_idx[i]) for i in range (self.GetDimensionCount()) ]
-        return _gdal.MDArray_AdviseRead(self, array_start_idx, count)
+        return _gdal.MDArray_AdviseRead(self, array_start_idx, count, options)
 
     def __getitem__(self, item):
 


### PR DESCRIPTION
- gdalmdimtranslate: add -oo switch to specify open option of source dataset
- Zarr: avoid directory listing when reading arrays with big number of chunks
- Zarr: use streaming filename when downloading tiles
- gdalmdiminfo: add dimension_size and block_size in output
- GDALMDArray::Cache(): make it compatible with PAM proxy db mechanism
- Zarr: add a CACHE_TILE_PRESENCE=YES open option to do an initial listing of present tiles and cache it in .gmac file
- Zarr: implement AdviseRead() to do multi-threaded fetching and decoding of tiles
