### PR TITLE
#4286 OGR LVBAG: add Field verkorteNaam to OpenbareRuimte FT with tests

### DIFF
--- a/autotest/ogr/data/lvbag/opr.xml
+++ b/autotest/ogr/data/lvbag/opr.xml
@@ -107,5 +107,36 @@
                 </Objecten:OpenbareRuimte>
             </sl-bag-extract:bagObject>
         </sl:stand>
+        <sl:stand>
+            <sl-bag-extract:bagObject>
+                <Objecten:OpenbareRuimte>
+                    <Objecten:identificatie domein="NL.IMBAG.Openbareruimte">0221300000311195</Objecten:identificatie>
+                    <Objecten:naam>Schout bij Nacht Doormansingel</Objecten:naam>
+                    <Objecten:type>Weg</Objecten:type>
+                    <Objecten:status>Naamgeving uitgegeven</Objecten:status>
+                    <Objecten:geconstateerd>N</Objecten:geconstateerd>
+                    <Objecten:documentdatum>2009-01-20</Objecten:documentdatum>
+                    <Objecten:documentnummer>BAG/OBR20080001</Objecten:documentnummer>
+                    <Objecten:ligtIn>
+                        <Objecten-ref:WoonplaatsRef domein="NL.IMBAG.Woonplaats">2142</Objecten-ref:WoonplaatsRef>
+                    </Objecten:ligtIn>
+                    <Objecten:voorkomen>
+                        <Historie:Voorkomen>
+                            <Historie:voorkomenidentificatie>1</Historie:voorkomenidentificatie>
+                            <Historie:beginGeldigheid>2009-01-20</Historie:beginGeldigheid>
+                            <Historie:tijdstipRegistratie>2010-12-15T10:57:31.000</Historie:tijdstipRegistratie>
+                            <Historie:BeschikbaarLV>
+                                <Historie:tijdstipRegistratieLV>2010-12-15T11:02:21.484</Historie:tijdstipRegistratieLV>
+                            </Historie:BeschikbaarLV>
+                        </Historie:Voorkomen>
+                    </Objecten:voorkomen>
+                    <Objecten:verkorteNaam>
+                        <nen5825:VerkorteNaamOpenbareRuimte>
+                            <nen5825:verkorteNaam>Sbn Doormansingel</nen5825:verkorteNaam>
+                        </nen5825:VerkorteNaamOpenbareRuimte>
+                    </Objecten:verkorteNaam>
+                </Objecten:OpenbareRuimte>
+            </sl-bag-extract:bagObject>
+        </sl:stand>
     </sl:standBestand>
 </sl-bag-extract:bagStand>

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -153,14 +153,14 @@ def test_ogr_lvbag_dataset_num():
        feat.GetFieldAsInteger('geconstateerd') != 0 or \
        feat.GetFieldAsString('documentdatum') != '2009/09/14' or \
        feat.GetFieldAsString('documentnummer') != '2009-BB01570' or \
-       feat.GetField('woonplaatsRef') != None or \
+       feat.GetField('woonplaatsRef') is not None or \
        feat.GetFieldAsInteger('voorkomenidentificatie') != 1 or \
        feat.GetField('beginGeldigheid') != '2009/09/24' or \
        feat.GetField('tijdstipRegistratie') != '2009/11/06 12:21:37' or \
        feat.GetField('tijdstipRegistratieLV') != '2009/11/06 12:38:46.603':
         feat.DumpReadable()
         pytest.fail()
-        
+
     # Test for 'woonplaatsRef'
     feat = lyr.GetNextFeature()
     if feat.GetField('identificatie') != 'NL.IMBAG.Nummeraanduiding.0106200000002799' or \
@@ -195,8 +195,29 @@ def test_ogr_lvbag_dataset_opr():
 
     assert lyr.GetGeomType() == ogr.wkbUnknown, 'bad layer geometry type'
     assert lyr.GetSpatialRef() is None, 'bad spatial ref'
-    assert lyr.GetFeatureCount() == 3
-    assert lyr.GetLayerDefn().GetFieldCount() == 18
+    assert lyr.GetFeatureCount() == 4
+    assert lyr.GetLayerDefn().GetFieldCount() == 19
+
+    feat = lyr.GetNextFeature()
+    if feat.GetField('naam') != 'Twaalfsuurlaan' or \
+        feat.GetField('verkorteNaam') is not None:
+        feat.DumpReadable()
+        pytest.fail()
+
+    # Skip Feat 2 and 3
+    lyr.GetNextFeature()
+    lyr.GetNextFeature()
+
+    # Last: contains abbreviated name ('verkorteNaam'), see issue 4286
+    feat = lyr.GetNextFeature()
+    if feat.GetField('naam') != 'Schout bij Nacht Doormansingel' or \
+        feat.GetField('verkorteNaam') != 'Sbn Doormansingel':
+        feat.DumpReadable()
+        pytest.fail()
+
+    # No more Features
+    feat = lyr.GetNextFeature()
+    assert feat is None
 
 def test_ogr_lvbag_dataset_pnd():
 

--- a/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -291,10 +291,12 @@ void OGRLVBAGLayer::CreateFeatureDefn( const char *pszDataset )
         OGRFieldDefn oField0("naam", OFTString);
         OGRFieldDefn oField1("type", OFTString);
         OGRFieldDefn oField2("woonplaatsRef", OFTString);
+        OGRFieldDefn oField3("verkorteNaam", OFTString);
 
         poFeatureDefn->AddFieldDefn(&oField0);
         poFeatureDefn->AddFieldDefn(&oField1);
         poFeatureDefn->AddFieldDefn(&oField2);
+        poFeatureDefn->AddFieldDefn(&oField3);
 
         AddIdentifierFieldDefn();
         AddDocumentFieldDefn();


### PR DESCRIPTION
## What does this PR do?
Field `verkorteNaam` was missing in  OpenbareRuimte (OPR) FType. This PR adds that Field with tests.

## What are related issues/pull requests?
Issue  #4286

## Tasklist

 - [x] Add new Field definition in LVBAG OGR Driver
 - [x] Add test case(s)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment
Not relevant, any environment/OS.
