### PR TITLE
Add a per-thread mechanism to count call depth and use it in VRT driver to avoid infinite recursive calls on corrupted datasets

### DIFF
--- a/gdal/frmts/vrt/vrtdataset.cpp
+++ b/gdal/frmts/vrt/vrtdataset.cpp
@@ -1778,18 +1778,6 @@ CPLErr VRTDataset::IRasterIO( GDALRWFlag eRWFlag,
                               GSpacing nBandSpace,
                               GDALRasterIOExtraArg* psExtraArg )
 {
-    // It may be valid to recurse one when dealing with a subsampled request
-    if( m_nRecursionCounter > 1 )
-    {
-        CPLError(
-            CE_Failure, CPLE_AppDefined,
-            "VRTDataset::IRasterIO() called recursively on the "
-            "same dataset. It looks like the VRT is referencing itself." );
-        return CE_Failure;
-    }
-
-    m_nRecursionCounter ++;
-
     bool bLocalCompatibleForDatasetIO = CPL_TO_BOOL(CheckCompatibleForDatasetIO());
     if( bLocalCompatibleForDatasetIO && eRWFlag == GF_Read &&
         (nBufXSize < nXSize || nBufYSize < nYSize) && m_apoOverviews.empty() )
@@ -1807,7 +1795,6 @@ CPLErr VRTDataset::IRasterIO( GDALRWFlag eRWFlag,
 
         if( bTried )
         {
-            m_nRecursionCounter --;
             return eErr;
         }
 
@@ -1929,7 +1916,6 @@ CPLErr VRTDataset::IRasterIO( GDALRWFlag eRWFlag,
         psExtraArg->pfnProgress = pfnProgressGlobal;
         psExtraArg->pProgressData = pProgressDataGlobal;
 
-        m_nRecursionCounter --;
         return eErr;
     }
 
@@ -1958,7 +1944,6 @@ CPLErr VRTDataset::IRasterIO( GDALRWFlag eRWFlag,
                                     nPixelSpace, nLineSpace, nBandSpace,
                                     psExtraArg );
     }
-    m_nRecursionCounter --;
     return eErr;
 }
 

--- a/gdal/frmts/vrt/vrtdataset.h
+++ b/gdal/frmts/vrt/vrtdataset.h
@@ -210,8 +210,6 @@ class CPL_DLL VRTDataset CPL_NON_FINAL: public GDALDataset
     std::map<CPLString, GDALDataset*> m_oMapSharedSources{};
     std::shared_ptr<VRTGroup> m_poRootGroup{};
 
-    int            m_nRecursionCounter = 0;
-
     VRTRasterBand*      InitBand(const char* pszSubclass, int nBand,
                                  bool bAllowPansharpened);
     static GDALDataset *OpenVRTProtocol( const char* pszSpec );
@@ -576,7 +574,6 @@ class VRTSimpleSource;
 class CPL_DLL VRTSourcedRasterBand CPL_NON_FINAL: public VRTRasterBand
 {
   private:
-    int            m_nRecursionCounter = 0;
     CPLString      m_osLastLocationInfo{};
     char         **m_papszSourceList = nullptr;
     int            m_nSkipBufferInitialization = -1;

--- a/gdal/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtsourcedrasterband.cpp
@@ -152,6 +152,22 @@ CPLErr VRTSourcedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
         return CE_Failure;
     }
 
+    const std::string osFctId("VRTSourcedRasterBand::IRasterIO");
+    GDALAntiRecursionGuard oGuard(osFctId);
+    if( oGuard.GetCallDepth() >= 32 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
+    }
+
+    GDALAntiRecursionGuard oGuard2(oGuard, poDS->GetDescription());
+    // Allow 2 recursion depths on the same dataset for non-nearest resampling
+    if( oGuard2.GetCallDepth() > 2 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
+    }
+
     // When using GDALProxyPoolDataset for sources, the recursion will not be
     // detected at VRT opening but when doing RasterIO. As the proxy pool will
     // return the already opened dataset, we can just test a member variable.
@@ -579,6 +595,25 @@ double VRTSourcedRasterBand::GetMinimum( int *pbSuccess )
         return CPLAtofM(pszValue);
     }
 
+    const std::string osFctId("VRTSourcedRasterBand::GetMinimum");
+    GDALAntiRecursionGuard oGuard(osFctId);
+    if( oGuard.GetCallDepth() >= 32 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        if( pbSuccess != nullptr )
+            *pbSuccess = FALSE;
+        return 0;
+    }
+
+    GDALAntiRecursionGuard oGuard2(oGuard, poDS->GetDescription());
+    if( oGuard2.GetCallDepth() >= 2 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        if( pbSuccess != nullptr )
+            *pbSuccess = FALSE;
+        return 0;
+    }
+
     if( m_nRecursionCounter > 0 )
     {
         CPLError(
@@ -634,6 +669,25 @@ double VRTSourcedRasterBand::GetMaximum( int *pbSuccess )
             *pbSuccess = TRUE;
 
         return CPLAtofM(pszValue);
+    }
+
+    const std::string osFctId("VRTSourcedRasterBand::GetMaximum");
+    GDALAntiRecursionGuard oGuard(osFctId);
+    if( oGuard.GetCallDepth() >= 32 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        if( pbSuccess != nullptr )
+            *pbSuccess = FALSE;
+        return 0;
+    }
+
+    GDALAntiRecursionGuard oGuard2(oGuard, poDS->GetDescription());
+    if( oGuard2.GetCallDepth() >= 2 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        if( pbSuccess != nullptr )
+            *pbSuccess = FALSE;
+        return 0;
     }
 
     if( m_nRecursionCounter > 0 )
@@ -709,6 +763,21 @@ CPLErr VRTSourcedRasterBand::ComputeRasterMinMax( int bApproxOK, double* adfMinM
 
         if( poBand != this )
             return poBand->ComputeRasterMinMax( TRUE, adfMinMax );
+    }
+
+    const std::string osFctId("VRTSourcedRasterBand::ComputeRasterMinMax");
+    GDALAntiRecursionGuard oGuard(osFctId);
+    if( oGuard.GetCallDepth() >= 32 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
+    }
+
+    GDALAntiRecursionGuard oGuard2(oGuard, poDS->GetDescription());
+    if( oGuard2.GetCallDepth() >= 2 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
     }
 
 /* -------------------------------------------------------------------- */
@@ -808,6 +877,21 @@ VRTSourcedRasterBand::ComputeStatistics( int bApproxOK,
                                               pfnProgress, pProgressData );
     }
 
+    const std::string osFctId("VRTSourcedRasterBand::ComputeStatistics");
+    GDALAntiRecursionGuard oGuard(osFctId);
+    if( oGuard.GetCallDepth() >= 32 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
+    }
+
+    GDALAntiRecursionGuard oGuard2(oGuard, poDS->GetDescription());
+    if( oGuard2.GetCallDepth() >= 2 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
+    }
+
 /* -------------------------------------------------------------------- */
 /*      Try with source bands.                                          */
 /* -------------------------------------------------------------------- */
@@ -901,6 +985,21 @@ CPLErr VRTSourcedRasterBand::GetHistogram( double dfMin, double dfMax,
                                                  bIncludeOutOfRange, bApproxOK,
                                                  pfnProgress, pProgressData );
         }
+    }
+
+    const std::string osFctId("VRTSourcedRasterBand::GetHistogram");
+    GDALAntiRecursionGuard oGuard(osFctId);
+    if( oGuard.GetCallDepth() >= 32 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
+    }
+
+    GDALAntiRecursionGuard oGuard2(oGuard, poDS->GetDescription());
+    if( oGuard2.GetCallDepth() >= 2 )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Recursion detected");
+        return CE_Failure;
     }
 
 /* -------------------------------------------------------------------- */

--- a/gdal/gcore/gdal_priv.h
+++ b/gdal/gcore/gdal_priv.h
@@ -2732,6 +2732,30 @@ public:
 };
 //! @endcond
 
+/************************************************************************/
+/*                       GDALAntiRecursionGuard                         */
+/************************************************************************/
+
+//! @cond Doxygen_Suppress
+struct GDALAntiRecursionStruct;
+class GDALAntiRecursionGuard
+{
+    GDALAntiRecursionStruct* m_psAntiRecursionStruct;
+    std::string m_osIdentifier;
+    int m_nDepth;
+
+    GDALAntiRecursionGuard(const GDALAntiRecursionGuard&) = delete;
+    GDALAntiRecursionGuard& operator= (const GDALAntiRecursionGuard&) = delete;
+
+public:
+    explicit GDALAntiRecursionGuard(const std::string& osIdentifier);
+             GDALAntiRecursionGuard(const GDALAntiRecursionGuard& other, const std::string& osIdentifier);
+    ~GDALAntiRecursionGuard();
+    int GetCallDepth() const { return m_nDepth; }
+};
+//! @endcond
+
+
 /* ==================================================================== */
 /*      An assortment of overview related stuff.                        */
 /* ==================================================================== */


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37717