### PR TITLE
DIMAP: expose virtual overviews

### DIFF
--- a/gdal/frmts/dimap/dimapdataset.cpp
+++ b/gdal/frmts/dimap/dimapdataset.cpp
@@ -1341,10 +1341,10 @@ int DIMAPDataset::ReadImageInformation2()
     const int nSrcOverviews = std::min(30, poSrcBandFirstImage->GetOverviewCount());
     if(nSrcOverviews>0) {
         std::unique_ptr<int[]> ovrLevels(new int[nSrcOverviews]);
-        int iLvl=2;
+        int iLvl=1;
         for(int i=0; i<nSrcOverviews; i++) {
-            ovrLevels[i]=iLvl;
             iLvl*=2;
+            ovrLevels[i]=iLvl;
         }
         poVRTDS->IBuildOverviews("average",nSrcOverviews,ovrLevels.get(),0,nullptr,nullptr,nullptr);
     }

--- a/gdal/frmts/dimap/dimapdataset.cpp
+++ b/gdal/frmts/dimap/dimapdataset.cpp
@@ -1333,6 +1333,20 @@ int DIMAPDataset::ReadImageInformation2()
         }
     }
 
+    if(CPLTestBool(CPLGetConfigOption("VRT_VIRTUAL_OVERVIEWS","NO"))) {
+        auto poSrcBandFirstImage = poImageDS->GetRasterBand(1);
+        int nSrcOverviews = poSrcBandFirstImage->GetOverviewCount();
+        if(nSrcOverviews>0) {
+            std::unique_ptr<int[]> ovrLevels(new int[nSrcOverviews]);
+            int iLvl=2;
+            for(int i=0; i<nSrcOverviews; i++) {
+                ovrLevels[i]=iLvl;
+                iLvl*=2;
+            }
+            poVRTDS->IBuildOverviews("average",nSrcOverviews,ovrLevels.get(),0,nullptr,nullptr,nullptr);
+        }
+    }
+
 #ifdef DEBUG_VERBOSE
     CPLDebug("DIMAP", "VRT XML: %s", poVRTDS->GetMetadata("xml:VRT")[0]);
 #endif


### PR DESCRIPTION
The dynamically created VRT that wraps the underlying datasets does not expose any overviews.
This PR adds this capability, although I'm not sure wether this is a hack or the correct way
to do so.

Before (cancelled):
```
time /opt/bin/gdalwarp  -ts 1248 4835 DIM_PHR1B_PMS_201911041624143_SEN_5886713101.XML og.tif
Creating output file that is 1248P x 4835L.
Processing DIM_PHR1B_PMS_201911041624143_SEN_5886713101.XML [1/1] : 0^C
real	0m20,575s
user	2m36,811s
sys	0m0,748s
```

After:
```
time /opt/bin/gdalwarp  -ts 1248 4835 DIM_PHR1B_PMS_201911041624143_SEN_5886713101.XML ng.tif --config VRT_VIRTUAL_OVERVIEWS YES
Creating output file that is 1248P x 4835L.
Processing DIM_PHR1B_PMS_201911041624143_SEN_5886713101.XML [1/1] : 0...10...20...30...40...50...60...70...80...90...100 - done.

real	0m2,342s
user	0m13,045s
sys	0m0,226s
```
