### PR TITLE
gdaldem.rst: fixed formatting in documentation (aspect mode)

### DIFF
--- a/gdal/doc/source/programs/gdaldem.rst
+++ b/gdal/doc/source/programs/gdaldem.rst
@@ -96,12 +96,15 @@ grid using gdalwarp before using gdaldem.
 
     * ``hillshade``
 
-        Generate a shaded relief map from any GDAL-supported elevation raster
+        Generate a shaded relief map from any GDAL-supported elevation raster.
 
     * ``slope``
 
-        Generate a slope map from any GDAL-supported elevation raster aspect to
-        generate an aspect map from any GDAL-supported elevation raster
+        Generate a slope map from any GDAL-supported elevation raster.
+
+    * ``aspect``
+
+        Generate an aspect map from any GDAL-supported elevation raster.
 
     * ``color-relief``
 


### PR DESCRIPTION
Aspect was in the slope text. Also added a dot at the end of hillshade, slope and aspect texts. Now all sentences have a dot at the end (in the mode part of the file).

