### PR TITLE
gdal2tiles: fix tile grid origin of openlayers with xyz and geodetic profile as arguments (fixes #4425)

### DIFF
--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -2872,7 +2872,10 @@ class GDAL2Tiles(object):
             args['resolutions'] = '[' + ','.join('%.18g' % res for res in resolutions) + ']'
 
             if self.options.xyz:
-                args['origin'] = '[-180,90]'
+                if self.options.tmscompatible:
+                    args['origin'] = '[-180,90]'
+                else:
+                    args['origin'] = '[-180,270]'
                 args['y_formula'] = 'tileCoord[2]'
             else:
                 args['origin'] = '[-180,-90]'


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->
fixes #4425