### PR TITLE
Fix the issue 4460 by adding sessionUser to oci_wrapper.h as the actual us…

### DIFF
--- a/gdal/frmts/georaster/georaster_wrapper.cpp
+++ b/gdal/frmts/georaster/georaster_wrapper.cpp
@@ -323,7 +323,7 @@ GeoRasterWrapper* GeoRasterWrapper::Open( const char* pszStringId, bool bUpdate 
         else
         {
             poGRW->sSchema = "";
-            poGRW->sOwner  = poGRW->poConnection->GetUser();
+            poGRW->sOwner  = poGRW->poConnection->GetSessionUser();
         }
 
         CSLDestroy( papszSchema );

--- a/gdal/frmts/georaster/oci_wrapper.cpp
+++ b/gdal/frmts/georaster/oci_wrapper.cpp
@@ -246,11 +246,11 @@ OWConnection::OWConnection( const char* pszUserIn,
             "select sys_context('userenv','session_user')\n"
             "from dual\n" );
 
-      pszUser = static_cast<char*>(CPLRealloc(pszUser, OWNAME)); 
-      poStmt->Define(pszUser);
+      pszSessionUser = static_cast<char*>(CPLMalloc(OWNAME)); 
+      poStmt->Define(pszSessionUser);
       CPL_IGNORE_RET_VAL(poStmt->Execute());
       delete poStmt;
-      CPLDebug("OCI: ", "Implicit User: %s\n", pszUser);
+      CPLDebug("OCI: ", "Implicit User: %s\n", pszSessionUser);
     }
 
     // ------------------------------------------------------
@@ -304,6 +304,7 @@ void OWConnection::QueryVersion()
 OWConnection::~OWConnection()
 {
     CPLFree( pszUser );
+    CPLFree( pszSessionUser );
     CPLFree( pszPassword );
     CPLFree( pszServer );
 

--- a/gdal/frmts/georaster/oci_wrapper.h
+++ b/gdal/frmts/georaster/oci_wrapper.h
@@ -290,6 +290,8 @@ private:
     bool                bExtProc = false;
 
     char*               pszUser = nullptr;
+                        //session is only used when user is not provided. 
+    char*               pszSessionUser = nullptr;
     char*               pszPassword = nullptr;
     char*               pszServer = nullptr;
 
@@ -329,6 +331,9 @@ public:
     bool                Succeeded() const { return bSuceeeded; }
 
     const char*         GetUser() const { return pszUser; }
+    const char*         GetSessionUser() const { 
+                         return (pszSessionUser == nullptr)? 
+                                   pszUser : pszSessionUser; } 
     const char*         GetPassword() const { return pszPassword; }
     const char*         GetServer() const{ return pszServer; }
     int                 GetVersion () const{ return nVersion; }


### PR DESCRIPTION
…er and

keeping the original pszUser variable value. pszUser is to be used to
construct the connect string later.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
