### PR TITLE
Docs: Add a descriptive Main Page to the Doxygen site.

### DIFF
--- a/gdal/Doxyfile
+++ b/gdal/Doxyfile
@@ -390,7 +390,8 @@ INPUT                  = port \
                          ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp \
                          ogr/ogrsf_frmts/kml/ogr2kmlgeometry.cpp \
                          swig/python/gdal-utils/scripts \
-                         gnm
+                         gnm \
+                         doxygen_index.md
 
 # If the value of the INPUT tag contains directories, you can use the
 # FILE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp
@@ -472,6 +473,13 @@ INPUT_FILTER           =
 # files to browse (i.e. when SOURCE_BROWSER is set to YES).
 
 FILTER_SOURCE_FILES    = NO
+
+# If the USE_MDFILE_AS_MAINPAGE tag refers to the name of a markdown file that
+# is part of the input, its contents will be placed on the main page
+# (index.html). This can be useful if you have a project on for instance GitHub
+# and want to reuse the introduction page also for the doxygen output.
+
+USE_MDFILE_AS_MAINPAGE = doxygen_index.md
 
 #---------------------------------------------------------------------------
 # configuration options related to source browsing

--- a/gdal/doxygen_index.md
+++ b/gdal/doxygen_index.md
@@ -1,0 +1,24 @@
+GDAL
+====
+
+Introduction
+----
+
+[GDAL](https://gdal.org) is a translator library for raster and
+vector geospatial data formats that is released under an X/MIT style Open
+Source license by the
+[Open Source Geospatial Foundation](http://www.osgeo.org/).  As a library, it
+presents a single raster abstract data model and a single vector abstract data
+model to the calling application for all supported formats.  It also comes with
+a variety of useful command line utilities for data translation and processing.
+
+This site contains the complete documentation of the GDAL source code, as
+generated automatically by Doxygen.  For general information about GDAL,
+including user-oriented documentation, please see the
+[GDAL main website](https://gdal.org).
+
+How to use this documentation
+---
+
+You can navigate through this documentation using the "Classes" and "Files"
+menus at the top of the page.


### PR DESCRIPTION
Add a new doxygen_index.md file, and use the Doxygen setting
USE_MDFILE_AS_MAINPAGE to include it as the contents of the Main Page.

Fixes #3689.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Adds some descriptive content to the "Main Page" of the raw Doxygen output at https://gdal.org/doxygen/index.html so it's not just mysteriously blank.

I've copied the intro paragraph about GDAL from the main website verbatim, and added some words of my own about the Doxygen site and how to use it.

## What are related issues/pull requests?

Issue raised in #3689 

## Tasklist

 - [x] Modify Doxygen build and test locally
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: MacOS 11.5.2
* Compiler: Doxygen 1.9.2
