### PR TITLE
Maintenance: Setup flake8 config file, update code_checks paths

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -62,13 +62,10 @@ jobs:
 
       - name: Run flake8
         run: |
-            # flake8 codes to just emulate pyflakes (http://flake8.pycqa.org/en/latest/user/error-codes.html)
-            export FLAKE8="flake8 --select=F401,F402,F403,F404,F405,F406,F407,F601,F602,F621,F622,F631,F701,F702,F703,F704,F705,F706,F707,F721,F722,F811,F812,F821,F822,F823,F831,F841,F901,E999"
+            export FLAKE8="flake8 --config autotest/setup.cfg"
             $FLAKE8 autotest
-            $FLAKE8 gdal/swig/python/gdal-utils/scripts
-            $FLAKE8 gdal/swig/python/gdal-utils/osgeo_utils/samples
-            $FLAKE8 gdal/swig/python/osgeo/utils
-            $FLAKE8 gdal/swig/python/osgeo/utils/auxiliary
+            $FLAKE8 gdal/swig/python/gdal-utils/
+            $FLAKE8 gdal/swig/python/osgeo/
 
   doxygen:
     runs-on: ubuntu-18.04

--- a/autotest/setup.cfg
+++ b/autotest/setup.cfg
@@ -1,0 +1,65 @@
+[flake8]
+ignore = 
+    E101  # Indentation contains mised spaces and tabs
+    E111  # Indentation is not a multiple of 4
+    E114  # Indentation is not a multiple of 4 (comment)
+    E115  # Expected an indented block (comment)
+    E117  # Over-indented comment
+    E121  # Continuation line under-indented for hanging indent
+    E122  # Continuation line missing indentation or outdented
+    E123  # Closing bracket does not match indentation of opening bracket
+    E124  # Closing bracket does not match visual indentation
+    E125  # Continuation line with same indent as next logical line
+    E126  # Continuation line over-indented for hanging indent
+    E127  # Continuation line over-indented
+    E128  # Continuation line under-indented
+    E131  # Continuation line unaligned for handing indent
+    E201  # Whitespace after bracket
+    E202  # Whitespace before bracket
+    E203  # Whitespace before ','
+    E211  # Whitespace before bracket
+    E221  # Multiple spaces before operator
+    E222  # Multiple spaces after operator
+    E225  # Missing whitespace around operator
+    E226  # Missing whitespace around arithmetic operator
+    E227  # Missing whitespace around bitwise or shift operator
+    E228  # Missing whitespace around modulo operator
+    E231  # Missing whitespace after ','
+    E241  # Multiple spaces after ','
+    E251  # Unexpected spaces around keyword equals
+    E252  # Missing whitespace around parameter equals
+    E261  # At least two spaces before inline comment
+    E262  # Inline comment should start with '# '
+    E265  # Block comment should start with '# '
+    E266  # Too many leading '#' for block comment
+    E271  # Multiple spaces after keyword
+    E301  # Expected 1 blank line, found 0
+    E302  # Expected 2 blank lines, found 1
+    E303  # too many blank lines
+    E305  # Expected 2 blank lines after class or function definition
+    E306  # Expected 1 blank line before a nested definition
+    E402  # Module level import not at top of file
+    E501  # Line too long
+    E502  # Backslash is redundant between brackets
+    E703  # Statement ends with a semicolon
+    E711  # Comparison to None should be 'if cond is None'
+    E712  # Comparison to False should be 'if cond is False' or 'if not cond'
+    E713  # Test for membership should be 'not in'
+    E721  # Do not compare types, use isinstance()
+    E722  # Do not use bare 'except'
+    E731  # Do not assign a lambda expression, use a def
+    E741  # Ambiguous variable name 'l'
+    E291  # Trailing whitespace
+    F401  # Module imported but unused
+    F403  # Star import used, unable to detect undefined names
+    F405  # Variable may be undefined, or defined from star imports
+    F811  # Redefinition of unused variable
+    F841  # Local variable is assigned to but never used
+    W191  # Indentation contains tabs
+    W291  # Trailing whitespace
+    W292  # No newline at end of file
+    W293  # Blank line contains whitespace
+    W391  # Blank line at end of file
+    W503  # Line break before binary operator
+    W504  # Line break after binary operator
+    W605  # Invalid escape sequence


### PR DESCRIPTION
## What does this PR do?
The new autotest/setup.cfg defines the Flake8 checks to skip,
and allowing further configuration in future. This makes it easier
for contributors to run the same Flake8 check as the code-checks
CI run, which is much less stringent than unconfigured Flake8.

Update the code_checks.yml file to use this configuration, and
update some of the paths inspected to match the current repo
layout.

