### PR TITLE
sqlite/ogrsqlitelayer.cpp: Add missing SQL data types to sqlite driver

### DIFF
--- a/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
+++ b/gdal/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
@@ -342,7 +342,7 @@ void OGRSQLiteLayer::BuildFeatureDefn( const char *pszLayerName,
         OGRFieldType eFieldType = OFTString;
         if (pszDeclType != nullptr)
         {
-            if (EQUAL(pszDeclType, "INTEGER_BOOLEAN"))
+            if (EQUAL(pszDeclType, "INTEGER_BOOLEAN") || EQUAL(pszDeclType, "BOOLEAN"))
             {
                 oField.SetType(OFTInteger);
                 oField.SetSubType(OFSTBoolean);
@@ -373,11 +373,17 @@ void OGRSQLiteLayer::BuildFeatureDefn( const char *pszLayerName,
             {
                 oField.SetType(OFTStringList);
             }
-            else if (EQUAL(pszDeclType, "BIGINT") || EQUAL(pszDeclType, "INT8"))
+            else if (EQUAL(pszDeclType, "BIGINT") || EQUAL(pszDeclType, "INT8") || 
+                     EQUAL(pszDeclType, "UNSIGNED BIG INT"))
             {
                 oField.SetType(OFTInteger64);
             }
-            else if (STARTS_WITH_CI(pszDeclType, "INTEGER"))
+            else if (STARTS_WITH_CI(pszDeclType, "INTEGER") ||
+                     EQUAL(pszDeclType, "INT") ||
+                     EQUAL(pszDeclType, "TINYINT") ||
+                     EQUAL(pszDeclType, "SMALLINT") ||
+                     EQUAL(pszDeclType, "MEDIUMINT") ||
+                     EQUAL(pszDeclType, "INT2"))
             {
                 oField.SetType(OFTInteger);
             }
@@ -387,7 +393,11 @@ void OGRSQLiteLayer::BuildFeatureDefn( const char *pszLayerName,
                 oField.SetSubType(OFSTFloat32);
             }
             else if (EQUAL(pszDeclType, "FLOAT") ||
-                     EQUAL(pszDeclType, "DECIMAL"))
+                     EQUAL(pszDeclType, "DECIMAL") ||
+                     EQUAL(pszDeclType, "REAL") ||
+                     EQUAL(pszDeclType, "DOUBLE") ||
+                     EQUAL(pszDeclType, "DOUBLE PRECISION") ||
+                     EQUAL(pszDeclType, "NUMERIC"))
             {
                 oField.SetType(OFTReal);
             }
@@ -438,7 +448,13 @@ void OGRSQLiteLayer::BuildFeatureDefn( const char *pszLayerName,
                 }
             }
             else if (EQUAL(pszDeclType, "TEXT") ||
-                     STARTS_WITH_CI(pszDeclType, "VARCHAR"))
+                     STARTS_WITH_CI(pszDeclType, "VARCHAR") || 
+                     STARTS_WITH_CI(pszDeclType, "CHARACTER") || 
+                     STARTS_WITH_CI(pszDeclType, "VARYING CHARACTER") || 
+                     STARTS_WITH_CI(pszDeclType, "NCHAR") || 
+                     STARTS_WITH_CI(pszDeclType, "NATIVE CHARACTER") || 
+                     STARTS_WITH_CI(pszDeclType, "NVARCHAR") || 
+                     EQUAL(pszDeclType, "CLOB"))
             {
                 oField.SetType( OFTString );
                 if( strstr(pszDeclType, "_deflate") != nullptr )


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Add missing SQL datatypes (from https://www.sqlite.org/datatype3.html) to sqlite driver field type detection algorithm (BuildFeatureDefn). Now all types from sqlite docs can be recognised by gdal

## What are related issues/pull requests?

Main problem was with floating-point fields. Only FLOAT and DECIMAL field types was supported.
If first row contains null in floating-point field and field type (in sqlite metadata) REAL, DOUBLE, DOUBLE PRECISION, NUMERIC data in field is processed as string
As a result floating-point fields occasionally may have string output type in ogr2ogr and data in them is rounded to 15 characters (for string fields gdal uses sqlite3_column_text which calls sqlite printf('%!.15g') for REAL storage class)

To reproduce this behaviour create sqlite database with commands bellow and convert it to another format with ogr2ogr:
create table test(col1 double);
insert into test(col1) values (null);
insert into test(col1) values (1.0000000000000002);


