### PR TITLE
Python installation: try to make Debian layout detection more robust (fixes #4516)

### DIFF
--- a/gdal/swig/python/trimmedsysconfig.py
+++ b/gdal/swig/python/trimmedsysconfig.py
@@ -23,10 +23,8 @@ BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
 
 # Added by GDAL
 def _is_debian():
-    import setuptools.command.easy_install
-    ei = setuptools.command.easy_install.easy_install
-    for opt, _, _ in ei.user_options:
-        if opt == 'install-layout=':
+    for p in sys.path:
+        if 'dist-packages' in p:
             return True
     return False
 


### PR DESCRIPTION
For a unknown and unreproducible reason, we've still observed a failure
on Fedora in https://github.com/OSGeo/gdal/pull/4520/checks?check_run_id=3655557289
where Debian layout was wrongly detected.
