### PR TITLE
Preserve NoData value in gdal_sieve.py when output to a new file

### DIFF
--- a/gdal/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
@@ -172,6 +172,7 @@ def gdal_sieve(src_filename: Optional[str] = None,
             dst_ds.SetGeoTransform(gt)
 
         dstband = dst_ds.GetRasterBand(1)
+        dstband.SetNoDataValue(srcband.GetNoDataValue())
     else:
         dstband = srcband
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Set NoData value from input raster to the newly created output raster in gdal_sieve.py

## What are related issues/pull requests?
fix #4519 
