### PR TITLE
Docs: fix link to GDAL Data Model (fixes #4527)

### DIFF
--- a/gdal/frmts/grib/gribdataset.cpp
+++ b/gdal/frmts/grib/gribdataset.cpp
@@ -2299,7 +2299,7 @@ void GRIBDataset::SetGribMetaData(grib_MetaData *meta)
         }
     }
 
-    // http://gdal.org/gdal_datamodel.html :
+    // https://gdal.org/user/raster_data_model.html :
     //   we need the top left corner of the top left pixel.
     //   At the moment we have the center of the pixel.
     rMinX -= rPixelSizeX / 2;

--- a/gdal/gcore/gdaldataset.cpp
+++ b/gdal/gcore/gdaldataset.cpp
@@ -224,9 +224,9 @@ GIntBig GDALGetResponsiblePIDForCurrentThread()
 /**
  * \class GDALDataset "gdal_priv.h"
  *
- * A dataset encapsulating one or more raster bands.  Details are
- * further discussed in the <a href="gdal_datamodel.html#GDALDataset">GDAL
- * Data Model</a>.
+ * A dataset encapsulating one or more raster bands.  Details are further
+ * discussed in the <a href="https://gdal.org/user/raster_data_model.html">GDAL
+ * Raster Data Model</a>.
  *
  * Use GDALOpen() or GDALOpenShared() to create a GDALDataset for a named file,
  * or GDALDriver::Create() or GDALDriver::CreateCopy() to create a new


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Substitutes the links https://gdal.org/doxygen/gdal_datamodel.html#GDALDataset and http://gdal.org/gdal_datamodel.html to the no longer existing GDAL Data Model page with the the link to the Raster Data Model page at https://gdal.org/user/raster_data_model.html

## What are related issues/pull requests?

Fixes https://github.com/OSGeo/gdal/issues/4527
