### PR TITLE
Add ASAN symbolizer so stack traces are useful

### DIFF
--- a/.github/workflows/asan/start.sh
+++ b/.github/workflows/asan/start.sh
@@ -64,7 +64,7 @@ case $SCRIPT_DIR in
 esac
 $SCRIPT_DIR/../common_install.sh
 
-export ASAN_OPTIONS=allocator_may_return_null=1
+export ASAN_OPTIONS=allocator_may_return_null=1:symbolize=1
 
 export CCACHE_CPP2=yes
 export CC="ccache $PWD/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang"
@@ -116,6 +116,7 @@ rm -f "$WORK_DIR/ccache.tar.gz"
 
 
 export PRELOAD=$PWD/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04/lib/clang/9.0.0/lib/linux/libclang_rt.asan-x86_64.so
+export ASAN_SYMBOLIZER_PATH=$PWD/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/llvm-symbolizer
 
 cd autotest
 


### PR DESCRIPTION
Otherwise the output is not very useful as it just shows us libgdal and offset in the stack dump whereas with the symbolizer we are able to see the functions.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
