### PR TITLE
MEMDataset::Open functions adds support for the 'GEOTRANSFORM' options

### DIFF
--- a/gdal/doc/source/drivers/raster/mem.rst
+++ b/gdal/doc/source/drivers/raster/mem.rst
@@ -32,14 +32,16 @@ For example:
 ::
 
      MEM:::DATAPOINTER=342343408,PIXELS=100,LINES=100,BANDS=3,DATATYPE=Byte,
-          PIXELOFFSET=3,LINEOFFSET=300,BANDOFFSET=1
+          PIXELOFFSET=3,LINEOFFSET=300,BANDOFFSET=1,
+          GEOTRANSFORM=1.166396e+02/1.861068e-05/0.000000e+00/3.627969e+01/0.000000e+00/-1.861068e-05
 
 or
 
 ::
 
      MEM:::DATAPOINTER=0x1467BEF0,PIXELS=100,LINES=100,BANDS=3,DATATYPE=Byte,
-          PIXELOFFSET=3,LINEOFFSET=300,BANDOFFSET=1
+          PIXELOFFSET=3,LINEOFFSET=300,BANDOFFSET=1,
+          GEOTRANSFORM=1.166396e+02/1.861068e-05/0.000000e+00/3.627969e+01/0.000000e+00/-1.861068e-05
 
 -  DATAPOINTER: address of the first pixel of the first band. The
    address can be represented as a hexadecimal or decimal value.
@@ -59,6 +61,8 @@ or
    next. (optional)
 -  BANDOFFSET: Offset in bytes between the start of one bands data and
    the next.
+-  GEOTRANSFORM: Set the affine transformation coefficients. 6 real
+   numbers with '/' as separator (optional)
 
 Creation Options
 ----------------

--- a/gdal/frmts/mem/memdataset.cpp
+++ b/gdal/frmts/mem/memdataset.cpp
@@ -1429,6 +1429,24 @@ GDALDataset *MEMDataset::Open( GDALOpenInfo * poOpenInfo )
     }
 
 /* -------------------------------------------------------------------- */
+/*      Set GeoTransform information.                                   */
+/* -------------------------------------------------------------------- */
+
+    pszOption = CSLFetchNameValue(papszOptions, "GEOTRANSFORM");
+    if( pszOption != nullptr ) {
+        char **values = CSLTokenizeStringComplex(pszOption, "/", TRUE, FALSE );
+        if ( CSLCount( values ) == 6 ) {
+            double adfGeoTransform[6] = {0,0,0,0,0,0};
+            for ( size_t i = 0; i < 6; ++i ) {
+                adfGeoTransform[i] =
+                    CPLScanDouble( values[i], static_cast<int>(strlen(values[i])) );
+            }
+            poDS->SetGeoTransform(adfGeoTransform);
+        }
+        CSLDestroy( values );
+    }
+
+/* -------------------------------------------------------------------- */
 /*      Try to return a regular handle on the file.                     */
 /* -------------------------------------------------------------------- */
     CSLDestroy( papszOptions );


### PR DESCRIPTION
MEM: Open functions adds support for the 'GEOTRANSFORM' options

When using `"MEM:::DATAPOINTER=342343408,PIXELS=100,LINES=100,BANDS=3,DATATYPE=Byte,PIXELOFFSET=3,LINEOFFSET=300,BANDOFFSET=1"` to create a memory data When creating a memory data set, it supports passing in spatial coordinate information.

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: linux / windows 7 later
* Compiler: gcc 8.3 / msvc 14
