### PR TITLE
Tolerate "degrees_E"/"degrees_N" as valid axis names

### DIFF
--- a/gdal/doc/source/drivers/raster/netcdf.rst
+++ b/gdal/doc/source/drivers/raster/netcdf.rst
@@ -377,7 +377,7 @@ Configuration Options
    not needed unless a specific dataset is causing problems (which
    should be reported in GDAL trac).
 
--  **GDAL_NETCDF_VERIFY_DIMS=[YES/STRICT] : Try to guess which dimensions
+-  **GDAL_NETCDF_VERIFY_DIMS=[YES/STRICT]** : Try to guess which dimensions
    represent the latitude and longitude only by their attributes (STRICT)
    or also by guessing the name (YES), default is YES.
 

--- a/gdal/doc/source/drivers/raster/netcdf.rst
+++ b/gdal/doc/source/drivers/raster/netcdf.rst
@@ -381,7 +381,7 @@ Configuration Options
    represent the latitude and longitude only by their attributes (STRICT)
    or also by guessing the name (YES), default is YES.
 
--  **GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS=[YES/NO] : When a dimension
+-  **GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS=[YES/NO]** : When a dimension
    has been identified as latitude or longitude by its attributes, check
    if its name also matches the convention, default is YES.
 

--- a/gdal/doc/source/drivers/raster/netcdf.rst
+++ b/gdal/doc/source/drivers/raster/netcdf.rst
@@ -198,7 +198,7 @@ driver first tries to follow the CF-1 Convention from UNIDATA looking
 for the Metadata named "grid_mapping". If "grid_mapping" is not present,
 the driver will try to find an lat/lon grid array to set geotransform
 array. The NetCDF driver verifies that the Lat/Lon array is equally
-space.
+spaced.
 
 If those 2 methods fail, NetCDF driver will try to read the following
 metadata directly and set up georeferencing.
@@ -213,6 +213,10 @@ or,
 -  Southernmost_Northing
 -  Easternmost_Easting
 -  Westernmost_Easting
+
+See also the configuration options **GDAL_NETCDF_VERIFY_DIMS** and
+**GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS** which control this
+behaviour.
 
 Open options
 ------------
@@ -372,6 +376,14 @@ Configuration Options
    overriding the order detected by the driver. This option is usually
    not needed unless a specific dataset is causing problems (which
    should be reported in GDAL trac).
+
+-  **GDAL_NETCDF_VERIFY_DIMS=[YES/STRICT] : Try to guess which dimensions
+   represent the latitude and longitude only by their attributes (STRICT)
+   or also by guessing the name (YES), default is YES.
+
+-  **GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS=[YES/NO] : When a dimension
+   has been identified as latitude or longitude by its attributes, check
+   if its name also matches the convention, default is YES.
 
 VSI Virtual File System API support
 -----------------------------------

--- a/gdal/frmts/netcdf/netcdf_cf_constants.h
+++ b/gdal/frmts/netcdf/netcdf_cf_constants.h
@@ -62,8 +62,10 @@
 #define CF_LATITUDE_LNG_NAME       "latitude"
 #define CF_DEGREES_NORTH           "degrees_north" /* recommended */
 #define CF_DEGREE_NORTH            "degree_north"  /* acceptable */
+#define CF_DEGREES_N               "degrees_N"     /* acceptable */
 #define CF_DEGREES_EAST            "degrees_east"  /* recommended */
 #define CF_DEGREE_EAST             "degree_east"   /* acceptable */
+#define CF_DEGREES_E               "degrees_E"     /* acceptable */
 
 #define CF_AXIS            "axis"
 /* #define CF_BOUNDS          "bounds" */

--- a/gdal/frmts/netcdf/netcdfdataset.h
+++ b/gdal/frmts/netcdf/netcdfdataset.h
@@ -182,11 +182,11 @@ static const int NCDF_DEFLATE_LEVEL    = 1;  /* best time/size ratio */
 /*         CF-1 Coordinate Type Naming (Chapter 4.  Coordinate Types )  */
 /* -------------------------------------------------------------------- */
 static const char* const papszCFLongitudeVarNames[] = { CF_LONGITUDE_VAR_NAME, "longitude", nullptr };
-static const char* const papszCFLongitudeAttribNames[] = { CF_UNITS, CF_UNITS, CF_STD_NAME, CF_AXIS, CF_LNG_NAME, nullptr };
-static const char* const papszCFLongitudeAttribValues[] = { CF_DEGREES_EAST, CF_DEGREE_EAST, CF_LONGITUDE_STD_NAME, "X", CF_LONGITUDE_LNG_NAME, nullptr };
+static const char* const papszCFLongitudeAttribNames[] = { CF_UNITS, CF_UNITS, CF_UNITS, CF_STD_NAME, CF_AXIS, CF_LNG_NAME, nullptr };
+static const char* const papszCFLongitudeAttribValues[] = { CF_DEGREES_EAST, CF_DEGREE_EAST, CF_DEGREES_E, CF_LONGITUDE_STD_NAME, "X", CF_LONGITUDE_LNG_NAME, nullptr };
 static const char* const papszCFLatitudeVarNames[] = { CF_LATITUDE_VAR_NAME, "latitude", nullptr };
-static const char* const papszCFLatitudeAttribNames[] = { CF_UNITS, CF_UNITS, CF_STD_NAME, CF_AXIS, CF_LNG_NAME, nullptr };
-static const char* const papszCFLatitudeAttribValues[] = { CF_DEGREES_NORTH, CF_DEGREE_NORTH, CF_LATITUDE_STD_NAME, "Y", CF_LATITUDE_LNG_NAME, nullptr };
+static const char* const papszCFLatitudeAttribNames[] = { CF_UNITS, CF_UNITS, CF_UNITS, CF_STD_NAME, CF_AXIS, CF_LNG_NAME, nullptr };
+static const char* const papszCFLatitudeAttribValues[] = { CF_DEGREES_NORTH, CF_DEGREE_NORTH, CF_DEGREES_N, CF_LATITUDE_STD_NAME, "Y", CF_LATITUDE_LNG_NAME, nullptr };
 
 static const char* const papszCFProjectionXVarNames[] = { CF_PROJ_X_VAR_NAME, "xc", nullptr };
 static const char* const papszCFProjectionXAttribNames[] = { CF_STD_NAME, CF_AXIS, nullptr };


### PR DESCRIPTION
## What does this PR do?

Tolerate "degrees_E"/"degrees_N" as valid axis names

NOAA seems to use these in their NetCDF files

## What are related issues/pull requests?

Refs: #4581

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

Finding a test file is difficult since the original is 7GB and GDAL corrects the dimension names when writing a NetCDF file