### PR TITLE
pct2rgb: fix parsing arguments (release/3.3)

### DIFF
--- a/gdal/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
+++ b/gdal/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
@@ -68,7 +68,7 @@ def main(argv):
             i = i + 1
             driver = argv[i]
 
-        if arg == '-ct':
+        elif arg == '-ct':
             i = i + 1
             pct_filename = argv[i]
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes an oversight in the pct2rgb.py arguments parsing logic, introduced with https://github.com/OSGeo/gdal/commit/33374e4545101c36baa50d1434d095c964d53817 (https://github.com/OSGeo/gdal/pull/3131), which prevents pct2rgb.py provided by GDAL 3.3.x to properly work.

It seems the logic in master branch is totally different, and I'm not sure if the issue is also present in master.

## What are related issues/pull requests?

Issue https://github.com/qgis/QGIS/issues/45344 reported for QGIS 3.20.3 on Windows (GDAL 3.3.1).