### PR TITLE
test: Catch moved test data in individual directory

### DIFF
--- a/autotest/cpp/testclosedondestroydm.cpp
+++ b/autotest/cpp/testclosedondestroydm.cpp
@@ -97,25 +97,25 @@ int main(int /* argc*/ , char* /* argv */[])
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen(GDRIVERS_DIR "data/rgb_warp.vrt", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/vrt/rgb_warp.vrt", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen(GDRIVERS_DIR "data/A.TOC", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/nitf/A.TOC", GA_ReadOnly);
 
-    hDS = GDALOpen("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:" GDRIVERS_DIR "data/A.TOC", GA_ReadOnly);
+    hDS = GDALOpen("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:" GDRIVERS_DIR "data/nitf/A.TOC", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen(GDRIVERS_DIR "data/testtil.til", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/til/testtil.til", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen(GDRIVERS_DIR "data/product.xml", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/rs2/product.xml", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen(GDRIVERS_DIR "data/METADATA.DIM", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/dimap/METADATA.DIM", GA_ReadOnly);
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
@@ -123,7 +123,7 @@ int main(int /* argc*/ , char* /* argv */[])
     if (hDS)
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
 
-    hDS = GDALOpen(GDRIVERS_DIR "data/bug407.gif", GA_ReadOnly);
+    hDS = GDALOpen(GDRIVERS_DIR "data/gif/bug407.gif", GA_ReadOnly);
     if (hDS)
     {
         GDALChecksumImage(GDALGetRasterBand(hDS, 1), 0, 0, GDALGetRasterXSize(hDS), GDALGetRasterYSize(hDS));
@@ -211,10 +211,10 @@ int main(int /* argc*/ , char* /* argv */[])
     hDS = GDALOpenShared(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
     hDS = GDALOpenShared(GCORE_DATA_DIR "byte.tif", GA_ReadOnly);
 
-    hDS = GDALOpenShared(GDRIVERS_DIR "data/mercator.sid", GA_ReadOnly);
+    hDS = GDALOpenShared(GDRIVERS_DIR "data/sid/mercator.sid", GA_ReadOnly);
 
-    hDS = GDALOpen("RASTERLITE:" GDRIVERS_DIR "data/rasterlite_pyramids.sqlite,table=test", GA_ReadOnly);
-    hDS = GDALOpen("RASTERLITE:" GDRIVERS_DIR "data/rasterlite_pyramids.sqlite,table=test,level=1", GA_ReadOnly);
+    hDS = GDALOpen("RASTERLITE:" GDRIVERS_DIR "data/rasterlite/rasterlite_pyramids.sqlite,table=test", GA_ReadOnly);
+    hDS = GDALOpen("RASTERLITE:" GDRIVERS_DIR "data/rasterlite/rasterlite_pyramids.sqlite,table=test,level=1", GA_ReadOnly);
 
     OpenJPEG2000(GDRIVERS_DIR "data/jpeg2000/rgbwcmyk01_YeGeo_kakadu.jp2");
 


### PR DESCRIPTION
- update testclosedondestroydm to catch up data place changes
- there moved test data to dedicated test subdir

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fix test case to be able to find a test data.

reduce these errors on C++ test.
```
./testclosedondestroydm
ERROR 4: ../gdrivers/data/rgb_warp.vrt: No such file or directory
ERROR 4: ../gdrivers/data/A.TOC: No such file or directory
ERROR 4: Failed to open file ../gdrivers/data/A.TOC.
ERROR 4: ../gdrivers/data/testtil.til: No such file or directory
ERROR 4: ../gdrivers/data/product.xml: No such file or directory
ERROR 4: ../gdrivers/data/METADATA.DIM: No such file or directory
ERROR 4: ../gdrivers/tmp/cache/file9_j2c.ntf: No such file or directory
ERROR 4: ../gdrivers/data/bug407.gif: No such file or directory
ERROR 4: ../gdrivers/data/mercator.sid: No such file or directory
ERROR 4: `RASTERLITE:../gdrivers/data/rasterlite_pyramids.sqlite,table=test' does not exist in the file system, and is not recognized as a supported dataset name.
ERROR 4: `RASTERLITE:../gdrivers/data/rasterlite_pyramids.sqlite,table=test,level=1' does not exist in the file system, and is not recognized as a supported dataset name.
ERROR 4: ../gdrivers/tmp/cache/Europe 2001_OZF.map: No such file or directory
```

to

```
./testclosedondestroydm
ERROR 1: Cannot import NULL due to ALLOW_FILE_ACCESS=NO
ERROR 4: ../gdrivers/data/dimap/rgbsmall.tif: No such file or directory
ERROR 3: Checksum value could not be computed due to I/O read error.
ERROR 4: ../gdrivers/tmp/cache/file9_j2c.ntf: No such file or directory
ERROR 4: ../gdrivers/tmp/cache/Europe 2001_OZF.map: No such file or directory
```

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
