### PR TITLE
fix mrf 'make clean' when lercv1 not defined

### DIFF
--- a/gdal/frmts/mrf/GNUmakefile
+++ b/gdal/frmts/mrf/GNUmakefile
@@ -62,7 +62,9 @@ default:  $(PREDEPEND)	$(OBJ:.o=.$(OBJ_EXT)) $(SUBLIBS)
 
 clean:
 	rm -rf *.o *.lo .libs/$(OBJ) .libs $(O_OBJ) $(LO_O_OBJ) gdal_mrf.so.1
+ifdef $(LERCV1)
 	(cd $(LERCV1); $(MAKE) clean)
+endif
 
 install-obj:	$(PREDEPEND) $(SUBLIBS) $(O_OBJ:.o=.$(OBJ_EXT))
 


### PR DESCRIPTION
Without this fix, when LERCV1 is not defined, make clean fails as it will try to run "make clean" in $HOME.
