### PR TITLE
Python bindings: fix resampleAlg=gdal.GRA_Sum/Med/Min/Max/Q1/Q3 in gdal.Warp()

### DIFF
--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import pytest
 import struct
 
 from osgeo import gdal
@@ -317,3 +318,21 @@ def test_gdalbuildvrt_lib_usemaskband_on_alpha_band():
     ds = gdal.BuildVRT('', [src1_ds, src2_ds])
     assert struct.unpack('B' * 3, ds.GetRasterBand(1).ReadRaster()) == (255, 127, 0)
     assert struct.unpack('B' * 3, ds.GetRasterBand(2).ReadRaster()) == (255, 255, 0)
+
+###############################################################################
+# Test parsing all resampling methods
+
+@pytest.mark.parametrize("resampleAlg,resampleAlgStr",
+                         [ (gdal.GRIORA_NearestNeighbour, "near"),
+                           (gdal.GRIORA_Cubic, "cubic"),
+                           (gdal.GRIORA_CubicSpline, "cubicspline"),
+                           (gdal.GRIORA_Lanczos, "lanczos"),
+                           (gdal.GRIORA_Average, "average"),
+                           (gdal.GRIORA_RMS, "rms"),
+                           (gdal.GRIORA_Mode, "mode"),
+                           (gdal.GRIORA_Gauss, "gauss") ])
+def test_gdalbuildvrt_lib_resampling_methods(resampleAlg, resampleAlgStr):
+
+    option_list = gdal.BuildVRTOptions(resampleAlg=resampleAlg, options='__RETURN_OPTION_LIST__')
+    assert option_list == ['-r', resampleAlgStr]
+    assert gdal.BuildVRT('', '../gcore/data/byte.tif', resampleAlg=resampleAlg) is not None

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -178,7 +178,7 @@ def test_gdalwarp_lib_9():
 
 def test_gdalwarp_lib_10():
 
-    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRIORA_NearestNeighbour)
+    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRA_NearestNeighbour)
 
     assert ds.GetRasterBand(1).Checksum() == 18784, 'Bad checksum'
 
@@ -190,7 +190,7 @@ def test_gdalwarp_lib_10():
 
 def test_gdalwarp_lib_11():
 
-    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRIORA_Bilinear)
+    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRA_Bilinear)
 
     ref_ds = gdal.Open('ref_data/testgdalwarp11.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds, verbose=0)
@@ -208,7 +208,7 @@ def test_gdalwarp_lib_11():
 
 def test_gdalwarp_lib_12():
 
-    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRIORA_Cubic)
+    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRA_Cubic)
 
     ref_ds = gdal.Open('ref_data/testgdalwarp12.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds, verbose=0)
@@ -226,7 +226,7 @@ def test_gdalwarp_lib_12():
 
 def test_gdalwarp_lib_13():
 
-    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRIORA_CubicSpline)
+    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRA_CubicSpline)
 
     ref_ds = gdal.Open('ref_data/testgdalwarp13.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds, verbose=0)
@@ -244,7 +244,7 @@ def test_gdalwarp_lib_13():
 
 def test_gdalwarp_lib_14():
 
-    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRIORA_Lanczos)
+    ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM', width=40, height=40, resampleAlg=gdal.GRA_Lanczos)
 
     ref_ds = gdal.Open('ref_data/testgdalwarp14.tif')
     maxdiff = gdaltest.compare_ds(ds, ref_ds, verbose=0)
@@ -255,6 +255,31 @@ def test_gdalwarp_lib_14():
         pytest.fail('Image too different from reference')
 
     ds = None
+
+###############################################################################
+# Test parsing all resampling methods
+
+@pytest.mark.parametrize("resampleAlg,resampleAlgStr",
+                         [ (gdal.GRA_NearestNeighbour, "near"),
+                           (gdal.GRA_Cubic, "cubic"),
+                           (gdal.GRA_CubicSpline, "cubicspline"),
+                           (gdal.GRA_Lanczos, "lanczos"),
+                           (gdal.GRA_Average, "average"),
+                           (gdal.GRA_RMS, "rms"),
+                           (gdal.GRA_Mode, "mode"),
+                           (gdal.GRA_Max, "max"),
+                           (gdal.GRA_Min, "min"),
+                           (gdal.GRA_Med, "med"),
+                           (gdal.GRA_Q1, "q1"),
+                           (gdal.GRA_Q3, "q3"),
+                           (gdal.GRA_Sum, "sum") ])
+def test_gdalwarp_lib_resampling_methods(resampleAlg, resampleAlgStr):
+
+    option_list = gdal.WarpOptions(resampleAlg=resampleAlg, options='__RETURN_OPTION_LIST__')
+    assert option_list == ['-r', resampleAlgStr]
+    assert gdal.Warp('', '../gcore/data/byte.tif',
+                     format='MEM', width=2, height=2, resampleAlg=resampleAlg) is not None
+
 
 ###############################################################################
 # Test -dstnodata
@@ -1797,7 +1822,7 @@ def test_gdalwarp_lib_ct_wkt():
         BBOX[-90,-180,90,180]]]"""
 
     dstDS = gdal.Warp('', '../gcore/data/byte.tif',
-                      resampleAlg=gdal.GRIORA_Cubic, format='MEM',
+                      resampleAlg=gdal.GRA_Cubic, format='MEM',
                       dstSRS='EPSG:4326',
                       coordinateOperation=wkt)
 

--- a/gdal/swig/include/python/gdal_python.i
+++ b/gdal/swig/include/python/gdal_python.i
@@ -1406,6 +1406,18 @@ def MultiDimInfo(ds, **kwargs):
 def _strHighPrec(x):
     return x if isinstance(x, str) else '%.18g' % x
 
+mapGRIORAMethodToString = {
+    gdalconst.GRIORA_NearestNeighbour: 'near',
+    gdalconst.GRIORA_Bilinear: 'bilinear',
+    gdalconst.GRIORA_Cubic: 'cubic',
+    gdalconst.GRIORA_CubicSpline: 'cubicspline',
+    gdalconst.GRIORA_Lanczos: 'lanczos',
+    gdalconst.GRIORA_Average: 'average',
+    gdalconst.GRIORA_RMS: 'rms',
+    gdalconst.GRIORA_Mode: 'mode',
+    gdalconst.GRIORA_Gauss: 'gauss',
+}
+
 def TranslateOptions(options=None, format=None,
               outputType = gdalconst.GDT_Unknown, bandList=None, maskBand=None,
               width = 0, height = 0, widthPct = 0.0, heightPct = 0.0,
@@ -1451,7 +1463,13 @@ def TranslateOptions(options=None, format=None,
           callback --- callback method
           callback_data --- user data for callback
     """
-    options = [] if options is None else options
+
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -1518,26 +1536,15 @@ def TranslateOptions(options=None, format=None,
         if not rat:
             new_options += ['-norat']
         if resampleAlg is not None:
-            if resampleAlg == gdalconst.GRA_NearestNeighbour:
-                new_options += ['-r', 'near']
-            elif resampleAlg == gdalconst.GRA_Bilinear:
-                new_options += ['-r', 'bilinear']
-            elif resampleAlg == gdalconst.GRA_Cubic:
-                new_options += ['-r', 'cubic']
-            elif resampleAlg == gdalconst.GRA_CubicSpline:
-                new_options += ['-r', 'cubicspline']
-            elif resampleAlg == gdalconst.GRA_Lanczos:
-                new_options += ['-r', 'lanczos']
-            elif resampleAlg == gdalconst.GRA_Average:
-                new_options += ['-r', 'average']
-            elif resampleAlg == gdalconst.GRA_RMS:
-                new_options += ['-r', 'rms']
-            elif resampleAlg == gdalconst.GRA_Mode:
-                new_options += ['-r', 'mode']
+            if resampleAlg in mapGRIORAMethodToString:
+                new_options += ['-r', mapGRIORAMethodToString[resampleAlg]]
             else:
                 new_options += ['-r', str(resampleAlg)]
         if xRes != 0 and yRes != 0:
             new_options += ['-tr', _strHighPrec(xRes), _strHighPrec(yRes)]
+
+    if return_option_list:
+        return new_options
 
     return (GDALTranslateOptions(new_options), callback, callback_data)
 
@@ -1622,7 +1629,13 @@ def WarpOptions(options=None, format=None,
           callback --- callback method
           callback_data --- user data for callback
     """
-    options = [] if options is None else options
+
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -1660,24 +1673,26 @@ def WarpOptions(options=None, format=None,
         if errorThreshold is not None:
             new_options += ['-et', _strHighPrec(errorThreshold)]
         if resampleAlg is not None:
-            if resampleAlg == gdalconst.GRIORA_NearestNeighbour:
-                new_options += ['-r', 'near']
-            elif resampleAlg == gdalconst.GRIORA_Bilinear:
-                new_options += ['-rb']
-            elif resampleAlg == gdalconst.GRIORA_Cubic:
-                new_options += ['-rc']
-            elif resampleAlg == gdalconst.GRIORA_CubicSpline:
-                new_options += ['-rcs']
-            elif resampleAlg == gdalconst.GRIORA_Lanczos:
-                new_options += ['-r', 'lanczos']
-            elif resampleAlg == gdalconst.GRIORA_Average:
-                new_options += ['-r', 'average']
-            elif resampleAlg == gdalconst.GRIORA_RMS:
-                new_options += ['-r', 'rms']
-            elif resampleAlg == gdalconst.GRIORA_Mode:
-                new_options += ['-r', 'mode']
-            elif resampleAlg == gdalconst.GRIORA_Gauss:
-                new_options += ['-r', 'gauss']
+
+            mapMethodToString = {
+                gdalconst.GRA_NearestNeighbour: 'near',
+                gdalconst.GRA_Bilinear: 'bilinear',
+                gdalconst.GRA_Cubic: 'cubic',
+                gdalconst.GRA_CubicSpline: 'cubicspline',
+                gdalconst.GRA_Lanczos: 'lanczos',
+                gdalconst.GRA_Average: 'average',
+                gdalconst.GRA_RMS: 'rms',
+                gdalconst.GRA_Mode: 'mode',
+                gdalconst.GRA_Max: 'max',
+                gdalconst.GRA_Min: 'min',
+                gdalconst.GRA_Med: 'med',
+                gdalconst.GRA_Q1: 'q1',
+                gdalconst.GRA_Q3: 'q3',
+                gdalconst.GRA_Sum: 'sum',
+            }
+
+            if resampleAlg in mapMethodToString:
+                new_options += ['-r', mapMethodToString[resampleAlg]]
             else:
                 new_options += ['-r', str(resampleAlg)]
         if warpMemoryLimit is not None:
@@ -1731,8 +1746,11 @@ def WarpOptions(options=None, format=None,
         else:
             overviewLevel = None
 
-        if overviewLevel:
+        if overviewLevel is not None and overviewLevel != 'AUTO':
             new_options += ['-ovr', overviewLevel]
+
+    if return_option_list:
+        return new_options
 
     return (GDALWarpAppOptions(new_options), callback, callback_data)
 
@@ -2378,7 +2396,13 @@ def BuildVRTOptions(options=None,
           callback --- callback method.
           callback_data --- user data for callback.
     """
-    options = [] if options is None else options
+
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -2400,24 +2424,8 @@ def BuildVRTOptions(options=None,
         if addAlpha:
             new_options += ['-addalpha']
         if resampleAlg is not None:
-            if resampleAlg == gdalconst.GRIORA_NearestNeighbour:
-                new_options += ['-r', 'near']
-            elif resampleAlg == gdalconst.GRIORA_Bilinear:
-                new_options += ['-rb']
-            elif resampleAlg == gdalconst.GRIORA_Cubic:
-                new_options += ['-rc']
-            elif resampleAlg == gdalconst.GRIORA_CubicSpline:
-                new_options += ['-rcs']
-            elif resampleAlg == gdalconst.GRIORA_Lanczos:
-                new_options += ['-r', 'lanczos']
-            elif resampleAlg == gdalconst.GRIORA_Average:
-                new_options += ['-r', 'average']
-            elif resampleAlg == gdalconst.GRIORA_RMS:
-                new_options += ['-r', 'rms']
-            elif resampleAlg == gdalconst.GRIORA_Mode:
-                new_options += ['-r', 'mode']
-            elif resampleAlg == gdalconst.GRIORA_Gauss:
-                new_options += ['-r', 'gauss']
+            if resampleAlg in mapGRIORAMethodToString:
+                new_options += ['-r', mapGRIORAMethodToString[resampleAlg]]
             else:
                 new_options += ['-r', str(resampleAlg)]
         if outputSRS is not None:
@@ -2430,6 +2438,9 @@ def BuildVRTOptions(options=None,
             new_options += ['-vrtnodata', str(VRTNodata)]
         if hideNodata:
             new_options += ['-hidenodata']
+
+    if return_option_list:
+        return new_options
 
     return (GDALBuildVRTOptions(new_options), callback, callback_data)
 


### PR DESCRIPTION
- Fix inversion between GRA_ and GRIORA_ enums in
gdal.Warp()/Translate()/BuildVRT() and their tests
- Also fix bilinear, cubic, cubicspline resampling for gdal.BuildVRT()

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2021-October/054769.html
