### PR TITLE
HFA: enable to read GCPs from PAM .aux.xml (fixes #4591)

### DIFF
--- a/gdal/frmts/hfa/GNUmakefile
+++ b/gdal/frmts/hfa/GNUmakefile
@@ -16,6 +16,6 @@ clean:
 $(O_OBJ): hfa.h hfa_p.h
 
 hfatest: hfatest.$(OBJ_EXT) $(HFAOBJ:.o=.$(OBJ_EXT))
-	$(LD) hfatest.$(OBJ_EXT) $(HFAOBJ:.o=.$(OBJ_EXT)) ../../port/*.$(OBJ_EXT)  ../../ogr/ogrsf_frmts/o/json_*.o  ../../ogr/ogrsf_frmts/o/printbuf.o  ../../ogr/ogrsf_frmts/o/arraylist.o  ../../ogr/ogrsf_frmts/o/linkhash.o ../../ogr/ograpispy.o  -L../.. -lgdal $(LIBS) -o hfatest
+	$(LD) hfatest.$(OBJ_EXT) $(HFAOBJ:.o=.$(OBJ_EXT)) ../../port/*.$(OBJ_EXT)  ../../ogr/ogrsf_frmts/o/json_*.o  ../../ogr/ogrsf_frmts/o/printbuf.o  ../../ogr/ogrsf_frmts/o/arraylist.o  ../../ogr/ogrsf_frmts/o/linkhash.o ../../ogr/ograpispy.o ../../ogr/ogr_proj_p.o  -L../.. -lgdal $(LIBS) -o hfatest
 
 install-obj: $(O_OBJ:.o=.$(OBJ_EXT))

--- a/gdal/frmts/hfa/hfa_p.h
+++ b/gdal/frmts/hfa/hfa_p.h
@@ -42,6 +42,7 @@
 
 #include "cpl_error.h"
 #include "cpl_vsi.h"
+#include "ogr_spatialref.h"
 
 #ifdef CPL_LSB
 #  define HFAStandard(n,p) {}
@@ -135,11 +136,14 @@ HFACreateLayer( HFAHandle psInfo, HFAEntry *poParent,
                 GIntBig nStackDataOffset,
                 int nStackCount, int nStackIndex );
 
-char *
-HFAPCSStructToWKT( const Eprj_Datum *psDatum,
+std::unique_ptr<OGRSpatialReference>
+HFAPCSStructToOSR( const Eprj_Datum *psDatum,
                    const Eprj_ProParameters *psPro,
                    const Eprj_MapInfo *psMapInfo,
                    HFAEntry *poMapInformation );
+
+const char *const* HFAGetDatumMap();
+const char *const* HFAGetUnitMap();
 
 /************************************************************************/
 /*                               HFABand                                */

--- a/gdal/frmts/hfa/hfadataset.h
+++ b/gdal/frmts/hfa/hfadataset.h
@@ -59,7 +59,7 @@ class HFADataset final : public GDALPamDataset
 
     bool        bGeoDirty;
     double      adfGeoTransform[6];
-    char        *pszProjection;
+    OGRSpatialReference m_oSRS{};
 
     bool        bIgnoreUTM;
 
@@ -104,23 +104,14 @@ class HFADataset final : public GDALPamDataset
 
     virtual char **GetFileList() override;
 
-    virtual const char *_GetProjectionRef() override;
-    virtual CPLErr _SetProjection( const char * ) override;
-    const OGRSpatialReference* GetSpatialRef() const override {
-        return GetSpatialRefFromOldGetProjectionRef();
-    }
-    CPLErr SetSpatialRef(const OGRSpatialReference* poSRS) override {
-        return OldSetProjectionFromSetSpatialRef(poSRS);
-    }
+    const OGRSpatialReference* GetSpatialRef() const override;
+    CPLErr SetSpatialRef(const OGRSpatialReference* poSRS) override;
 
     virtual CPLErr GetGeoTransform( double * ) override;
     virtual CPLErr SetGeoTransform( double * ) override;
 
     virtual int    GetGCPCount() override;
-    virtual const char *_GetGCPProjection() override;
-    const OGRSpatialReference* GetGCPSpatialRef() const override {
-        return GetGCPSpatialRefFromOldGetGCPProjection();
-    }
+    const OGRSpatialReference* GetGCPSpatialRef() const override;
     virtual const GDAL_GCP *GetGCPs() override;
 
     virtual CPLErr SetMetadata( char **, const char * = "" ) override;

--- a/gdal/frmts/hfa/hfatest.cpp
+++ b/gdal/frmts/hfa/hfatest.cpp
@@ -43,21 +43,6 @@ static void Usage()
 }
 
 /************************************************************************/
-/* Stub for HFAPCSStructToWKT, defined in hfadataset.cpp but used by    */
-/* hfaopen.cpp                                                          */
-/************************************************************************/
-#ifndef WIN32
-char *
-HFAPCSStructToWKT( const Eprj_Datum *,
-                   const Eprj_ProParameters *,
-                   const Eprj_MapInfo *,
-                   HFAEntry * )
-{
-    return nullptr;
-}
-#endif
-
-/************************************************************************/
 /*                                main()                                */
 /************************************************************************/
 


### PR DESCRIPTION
The writing side is unchanged, that is GCPs are written to PAM, not as
internal GCPs.

In the process, use the more modern API for SRS, and move some code from
hfadataset.cpp to hfaopen.cpp, to avoid a hack in hfatest.cpp