### PR TITLE
ERS: Fix off-by-one error when reading ERS header

### DIFF
--- a/gdal/frmts/ers/ershdrnode.cpp
+++ b/gdal/frmts/ers/ershdrnode.cpp
@@ -175,7 +175,7 @@ int ERSHdrNode::ParseChildren( VSILFILE * fp, int nRecLevel )
 
         if( (iOff = osLine.find_first_of( '=' )) != std::string::npos )
         {
-            CPLString osName = iOff == 0 ? std::string() : osLine.substr(0,iOff-1);
+            CPLString osName = iOff == 0 ? std::string() : osLine.substr(0,iOff);
             osName.Trim();
 
             CPLString osValue = osLine.c_str() + iOff + 1;


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue when reading ERS headers that lack spaces between keys and values.  Line parsing was performed by the following code snippet:

```C++
        if( (iOff = osLine.find_first_of( '=' )) != std::string::npos )
        {
            CPLString osName = iOff == 0 ? std::string() : osLine.substr(0,iOff-1);
            osName.Trim();

            CPLString osValue = osLine.c_str() + iOff + 1;
            osValue.Trim();
```
When parsing the line `DataSetType = ERStorage`, the snippet would populate `osName` with `DataSetType` and `osValue` with `ERStorage`.  However, when parsing the line `DataSetType=ERStorage`, the snippet would populate osName with `DataSetTyp`.  Prior to trimming, `osType` was `"DataSetType"` and `"DataSetTyp"` in each respective case when it should have been `"DataSetType "` (note the trailing space to be trimmed) and `"DataSetType"`.

This PR corrects the off-by-one error by changing `iOff-1` to `iOff`.