### PR TITLE
VRT: fix issue with sources with nodata and OverviewList resampling='average' that triggers a 'recursion error' message

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1640,3 +1640,25 @@ def test_vrt_check_dont_open_unneeded_source():
         assert ds is None
     finally:
         gdal.Unlink(tmpfilename)
+
+
+def test_vrt_nodata_and_implicit_ovr_recursion_issue():
+
+    """ Tests scenario https://github.com/OSGeo/gdal/issues/4620#issuecomment-938636360 """
+
+    vrt = """<VRTDataset rasterXSize="20" rasterYSize="20">
+  <VRTRasterBand dataType="Byte" band="1">
+    <NoDataValue>0</NoDataValue>
+    <ComplexSource>
+      <NODATA>0</NODATA>
+      <SourceFilename>data/byte.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+    </ComplexSource>
+  </VRTRasterBand>
+  <OverviewList resampling="average">2</OverviewList>
+</VRTDataset>"""
+
+    tmpfilename = '/vsimem/tmp.vrt'
+    with gdaltest.tempfile(tmpfilename, vrt):
+        ds = gdal.Open(tmpfilename)
+        assert ds.GetRasterBand(1).GetOverview(0).Checksum() == 1152

--- a/gdal/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/gdal/frmts/vrt/vrtsourcedrasterband.cpp
@@ -257,13 +257,23 @@ CPLErr VRTSourcedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
             }
             if( bFallbackToBase )
             {
-                return GDALRasterBand::IRasterIO( eRWFlag,
+                const bool bBackupEnabledOverviews = l_poDS->AreOverviewsEnabled();
+                if( !l_poDS->m_apoOverviews.empty() &&
+                    l_poDS->AreOverviewsEnabled() )
+                {
+                    // Disable use of implicit overviews to avoid infinite
+                    // recursion
+                    l_poDS->SetEnableOverviews(false);
+                }
+                const auto eErr = GDALRasterBand::IRasterIO( eRWFlag,
                                                   nXOff, nYOff, nXSize, nYSize,
                                                   pData, nBufXSize, nBufYSize,
                                                   eBufType,
                                                   nPixelSpace,
                                                   nLineSpace,
                                                   psExtraArg );
+                l_poDS->SetEnableOverviews(bBackupEnabledOverviews);
+                return eErr;
             }
         }
     }


### PR DESCRIPTION
refs https://github.com/OSGeo/gdal/issues/4620#issuecomment-938636360
