### PR TITLE
swig/python/osgeo/__init__.py: catch OSError exception

### DIFF
--- a/gdal/swig/python/osgeo/__init__.py
+++ b/gdal/swig/python/osgeo/__init__.py
@@ -9,7 +9,7 @@ if version_info >= (3, 8, 0) and platform == 'win32':
             if p:
                 try:
                     os.add_dll_directory(p)
-                except FileNotFoundError:
+                except (FileNotFoundError, OSError):
                     continue
 
 


### PR DESCRIPTION
See https://lists.osgeo.org/pipermail/gdal-dev/2021-October/054834.html
