### PR TITLE
COG/GTiff: fix error messages when creating JPEG compressed COGs from RGBA…

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -220,7 +220,8 @@ def test_cog_creation_options():
             assert filesize_lerc_zstd_level_1 > filesize_lerc_zstd
 
     src_ds = None
-    gdal.GetDriverByName('GTiff').Delete(filename)
+    with gdaltest.error_handler():
+        gdal.GetDriverByName('GTiff').Delete(filename)
 
 
 ###############################################################################
@@ -813,6 +814,7 @@ def test_cog_sparse_mask():
         src_ds.GetRasterBand(i+1).WriteRaster(256, 256, 128, 128, '\x00' * 128 * 128)
     src_ds.BuildOverviews('NEAREST', [2])
     gdal.GetDriverByName('COG').CreateCopy(filename, src_ds, options = ['BLOCKSIZE=128', 'SPARSE_OK=YES', 'COMPRESS=JPEG', 'RESAMPLING=NEAREST'])
+    assert gdal.GetLastErrorMsg() == ''
     _check_cog(filename)
     with gdaltest.config_option('GTIFF_HAS_OPTIMIZED_READ_MULTI_RANGE', 'YES'):
         ds = gdal.Open(filename)

--- a/gdal/frmts/gtiff/gt_overview.cpp
+++ b/gdal/frmts/gtiff/gt_overview.cpp
@@ -837,34 +837,36 @@ GTIFFBuildOverviewsEx( const char * pszFilename,
         GTIFFBuildOverviewMetadata( pszResampling, poBaseDS, osMetadata );
     }
 
-    const bool bStandardColorInterp =
-        poBaseDS != nullptr &&
-        GTIFFIsStandardColorInterpretation(GDALDataset::ToHandle(poBaseDS),
-                                           static_cast<uint16_t>(nPhotometric),
-                                           nullptr);
-    if( poBaseDS != nullptr && !bStandardColorInterp )
+    if( poBaseDS != nullptr && poBaseDS->GetRasterCount() == nBands )
     {
-        if( osMetadata.size() >= strlen("</GDALMetadata>") &&
-            osMetadata.substr(osMetadata.size() - strlen("</GDALMetadata>")) == "</GDALMetadata>" )
+        const bool bStandardColorInterp =
+            GTIFFIsStandardColorInterpretation(GDALDataset::ToHandle(poBaseDS),
+                                               static_cast<uint16_t>(nPhotometric),
+                                               nullptr);
+        if( !bStandardColorInterp )
         {
-            osMetadata.resize(osMetadata.size() - strlen("</GDALMetadata>"));
+            if( osMetadata.size() >= strlen("</GDALMetadata>") &&
+                osMetadata.substr(osMetadata.size() - strlen("</GDALMetadata>")) == "</GDALMetadata>" )
+            {
+                osMetadata.resize(osMetadata.size() - strlen("</GDALMetadata>"));
+            }
+            else
+            {
+                CPLAssert(osMetadata.empty());
+                osMetadata = "<GDALMetadata>";
+            }
+            for( int i = 0; i < poBaseDS->GetRasterCount(); ++i )
+            {
+                const GDALColorInterp eInterp =
+                    poBaseDS->GetRasterBand(i + 1)->GetColorInterpretation();
+                osMetadata += CPLSPrintf(
+                    "<Item sample=\"%d\" name=\"COLORINTERP\" role=\"colorinterp\">",
+                    i);
+                osMetadata += GDALGetColorInterpretationName(eInterp);
+                osMetadata += "</Item>";
+            }
+            osMetadata += "</GDALMetadata>";
         }
-        else
-        {
-            CPLAssert(osMetadata.empty());
-            osMetadata = "<GDALMetadata>";
-        }
-        for( int i = 0; i < poBaseDS->GetRasterCount(); ++i )
-        {
-            const GDALColorInterp eInterp =
-                poBaseDS->GetRasterBand(i + 1)->GetColorInterpretation();
-            osMetadata += CPLSPrintf(
-                "<Item sample=\"%d\" name=\"COLORINTERP\" role=\"colorinterp\">",
-                i);
-            osMetadata += GDALGetColorInterpretationName(eInterp);
-            osMetadata += "</Item>";
-        }
-        osMetadata += "</GDALMetadata>";
     }
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
… (fixes regression introduced by 20cb378a1ac46515d1aad87e93dff401feedffa7, refs #3939)
