### PR TITLE
FileGDB: faster CreateLayer() w.r.t SRS identification

### DIFF
--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -574,14 +574,14 @@ def test_ogr_fgdb_10(fgdb_drv):
 
     srs_approx_4326 = srs_exact_4326.Clone()
     srs_approx_4326.MorphToESRI()
-    srs_approx_4326.MorphFromESRI()
+    srs_approx_4326.ImportFromWkt(srs_approx_4326.ExportToWkt())
 
     srs_exact_2193 = osr.SpatialReference()
     srs_exact_2193.ImportFromEPSG(2193)
 
     srs_approx_2193 = srs_exact_2193.Clone()
     srs_approx_2193.MorphToESRI()
-    srs_approx_2193.MorphFromESRI()
+    srs_approx_2193.ImportFromWkt(srs_approx_2193.ExportToWkt())
 
     srs_not_in_db = osr.SpatialReference("""PROJCS["foo",
     GEOGCS["foo",
@@ -601,7 +601,7 @@ def test_ogr_fgdb_10(fgdb_drv):
     srs_exact_4230.ImportFromEPSG(4230)
     srs_approx_4230 = srs_exact_4230.Clone()
     srs_approx_4230.MorphToESRI()
-    srs_approx_4230.MorphFromESRI()
+    srs_approx_4230.ImportFromWkt(srs_approx_4230.ExportToWkt())
 
     srs_approx_intl = osr.SpatialReference()
     srs_approx_intl.ImportFromProj4('+proj=longlat +ellps=intl +no_defs')


### PR DESCRIPTION
When creating a layer, we try to identify to which SRS known by the
FileGDB SDK the passed SRS corresponds to.
The previous logic used an enumerator over the FileGDB known SRS,
instanciated them as OGRSpatialReference object from the ESRI WKT, and
compared the passed SRS to each of the candidate SRS. However instanciating a
OGRSpatialRefrence from ESRI WKT is a rather costly operation, and doing
that repeatedly caused delays of several seconds.
The new strategy relies on PROJ identification logic to find candidates.

This speed up unit tests execution (which was getting a bit slower due to recent refactorings using pytest fixture)