### PR TITLE
doc/source/api/python_gotchas.rst Fixed and expanded example in Python Gotcha docs (Fixes #4718)

### DIFF
--- a/doc/source/api/python_gotchas.rst
+++ b/doc/source/api/python_gotchas.rst
@@ -263,11 +263,7 @@ But you can do something like this instead:
 
     if __name__ == '__main__':
         err = GdalErrorHandler()
-        handler = err.handler  # Note don't pass class method directly or python segfaults
-        # due to a reference counting bug
-        # http://trac.osgeo.org/gdal/ticket/5186#comment:4
-
-        gdal.PushErrorHandler(handler)
+        gdal.PushErrorHandler(err.handler)
         gdal.UseExceptions()  # Exceptions will get raised on anything >= gdal.CE_Failure
 
         assert err.err_level == gdal.CE_None, 'the error level starts at 0'


### PR DESCRIPTION
Fixes #4718

The error handling example had an indentation error in the Python docs.

## What does this PR do?

I fixed the indentation.

While I was fixing it, I also: 

* Made white-space and operator usage within the section
* Added an extra part to the example to show the difference between warnings and errors.
