### PR TITLE
AUTOTEST: switch back to libjxl main branch (#4716)

### DIFF
--- a/.github/workflows/ubuntu_20.04/build-deps.sh
+++ b/.github/workflows/ubuntu_20.04/build-deps.sh
@@ -59,11 +59,12 @@ mkdir tiledb \
 ln -s /usr/lib/ogdi/libvrf.so /usr/lib
 
 # Build libjxl
-# Checkout this commit because of https://github.com/libjxl/libjxl/issues/771
-JXL_SHA1=f34a2667fe3195bfa06b4dae2e6ea598ad9e3d9f
+# libjxl being still unstable, if the main branch fails to compile/test
+# you can replace JXL_TREEISH=main by JXL_TREEISH=sha1_of_known_working_commit
+JXL_TREEISH=main
 git clone https://github.com/libjxl/libjxl.git --recursive \
     && cd libjxl \
-    && git checkout ${JXL_SHA1} \
+    && git checkout ${JXL_TREEISH} \
     && mkdir build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -7342,7 +7342,7 @@ def test_tiff_write_compression_create_and_createcopy():
 
     if 'JXL' in md['DMD_CREATIONOPTIONLIST']:
         tests.append((['COMPRESS=JXL', 'JXL_LOSSLESS=YES'],['COMPRESS=JXL', 'JXL_LOSSLESS=NO']))
-        tests.append((['COMPRESS=JXL', 'JXL_LOSSLESS=NO', 'JXL_EFFORT=3'],['COMPRESS=JXL', 'JXL_LOSSLESS=NO', 'JXL_EFFORT=9']))
+        tests.append((['COMPRESS=JXL', 'JXL_LOSSLESS=YES', 'JXL_EFFORT=3'],['COMPRESS=JXL', 'JXL_LOSSLESS=YES', 'JXL_EFFORT=9']))
         tests.append((['COMPRESS=JXL', 'JXL_LOSSLESS=NO', 'JXL_DISTANCE=0.1'],['COMPRESS=JXL', 'JXL_LOSSLESS=NO', 'JXL_DISTANCE=3']))
 
     new_tests = []


### PR DESCRIPTION
Fixes #4716

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
