### PR TITLE
MITAB: allow reading MID/MIF files with lines up to 1 million bytes (fixes #3943)

### DIFF
--- a/ogr/ogrsf_frmts/mitab/mitab_middatafile.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_middatafile.cpp
@@ -53,8 +53,6 @@ MIDDATAFile::MIDDATAFile( const char* pszEncoding ) :
     m_pszDelimiter("\t"),  // Encom 2003 (was NULL).
     m_pszFname(nullptr),
     m_eAccessMode(TABRead),
-    // TODO(schwehr): m_szLastRead({}),
-    // TODO(schwehr): m_szSavedLine({}),
     m_dfXMultiplier(1.0),
     m_dfYMultiplier(1.0),
     m_dfXDisplacement(0.0),
@@ -62,8 +60,6 @@ MIDDATAFile::MIDDATAFile( const char* pszEncoding ) :
     m_bEof(FALSE),
     m_osEncoding(pszEncoding)
 {
-    m_szLastRead[0] = '\0';
-    m_szSavedLine[0] = '\0';
 }
 
 MIDDATAFile::~MIDDATAFile() { Close(); }
@@ -72,15 +68,15 @@ void MIDDATAFile::SaveLine(const char *pszLine)
 {
     if(pszLine == nullptr)
     {
-        m_szSavedLine[0] = '\0';
+        m_osSavedLine.clear();
     }
     else
     {
-        CPLStrlcpy(m_szSavedLine, pszLine, MIDMAXCHAR);
+        m_osSavedLine = pszLine;
     }
 }
 
-const char *MIDDATAFile::GetSavedLine() { return m_szSavedLine; }
+const char *MIDDATAFile::GetSavedLine() { return m_osSavedLine.c_str(); }
 
 int MIDDATAFile::Open(const char *pszFname, const char *pszAccess)
 {
@@ -159,21 +155,30 @@ const char *MIDDATAFile::GetLine()
         return nullptr;
     }
 
-    const char *pszLine = CPLReadLine2L(m_fp, MIDMAXCHAR, nullptr);
+    static const int nMaxLineLength = atoi(
+        CPLGetConfigOption("MITAB_MAX_LINE_LENGTH", "1000000"));
+    const char *pszLine = CPLReadLine2L(m_fp, nMaxLineLength, nullptr);
 
     if(pszLine == nullptr)
     {
+        if( strstr(CPLGetLastErrorMsg(), "Maximum number of characters allowed reached") )
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Maximum number of characters allowed reached. "
+                     "You can set the MITAB_MAX_LINE_LENGTH configuration option "
+                     "to the desired number of bytes (or -1 for unlimited)");
+        }
         SetEof(TRUE);
-        m_szLastRead[0] = '\0';
+        m_osLastRead.clear();
     }
     else
     {
         // Skip leading spaces and tabs except if the delimiter is tab.
-        while(pszLine && (*pszLine == ' ' ||
-                          (*m_pszDelimiter != '\t' && *pszLine == '\t')))
+        while(*pszLine == ' ' ||
+                          (*m_pszDelimiter != '\t' && *pszLine == '\t'))
             pszLine++;
 
-        CPLStrlcpy(m_szLastRead, pszLine, MIDMAXCHAR);
+        m_osLastRead = pszLine;
     }
 
 #if DEBUG_VERBOSE
@@ -194,9 +199,9 @@ const char *MIDDATAFile::GetLastLine()
     if(m_eAccessMode == TABRead)
     {
 #if DEBUG_VERBOSE
-        CPLDebug("MITAB", "m_szLastRead: %s", m_szLastRead);
+        CPLDebug("MITAB", "m_osLastRead: %s", m_osLastRead.c_str());
 #endif
-        return m_szLastRead;
+        return m_osLastRead.c_str();
     }
 
     // We should never get here.  Read/Write mode not implemented.

--- a/ogr/ogrsf_frmts/mitab/mitab_priv.h
+++ b/ogr/ogrsf_frmts/mitab/mitab_priv.h
@@ -1906,10 +1906,8 @@ class MIDDATAFile
        VSILFILE *m_fp;
        const char *m_pszDelimiter;
 
-       // Set limit for the length of a line
-#define MIDMAXCHAR 10000
-       char m_szLastRead[MIDMAXCHAR];
-       char m_szSavedLine[MIDMAXCHAR];
+       std::string m_osLastRead{};
+       std::string m_osSavedLine{};
 
        char        *m_pszFname;
        TABAccess   m_eAccessMode;


### PR DESCRIPTION
The limit can be adjusted at runtime with the MITAB_MAX_LINE_LENGTH
configuration option.