### PR TITLE
docs: fix broken "Edit on Github" link

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,7 +55,7 @@ html_context = {
   'theme_vcs_pageview_mode': 'edit',
   'github_user': 'OSGeo',
   'github_repo': 'gdal',
-  'github_version': '/master/gdal/doc/source/'
+  'github_version': 'master/doc/source/'
 }
 
 html_theme_options = {


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

I haven't tested the changes, but I think this should fix it.

Currently, on the documentation website <https://gdal.org/>, clicking on the link "Edit on Github" on the top right leads to <https://github.com/OSGeo/gdal/edit//master/gdal/doc/source/index.rst> which is a 404 page. The correct link should be <https://github.com/OSGeo/gdal/edit/master/doc/source/index.rst>.

This seems to be caused by commit 9e9f8b2.

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
