### PR TITLE
Unix builds: move generated headers to a generated_headers subdirectory

### DIFF
--- a/GDALmake.opt.in
+++ b/GDALmake.opt.in
@@ -73,7 +73,7 @@ INST_DOCS	=	@htmldir@
 INST_MAN	=	@mandir@
 INST_WEB	=	$(HOME)/www/gdal
 
-CPPFLAGS	:= @CPPFLAGS@ -iquote $(GDAL_ROOT)/port @EXTRA_INCLUDES@ -DGDAL_COMPILATION
+CPPFLAGS	:= @CPPFLAGS@ -iquote $(GDAL_ROOT)/port -iquote $(GDAL_ROOT)/generated_headers @EXTRA_INCLUDES@ -DGDAL_COMPILATION
 CFLAGS		= @CFLAGS@ @C_WFLAGS@ $(USER_DEFS)
 CXXFLAGS	= @CXXFLAGS@ @CXX_WFLAGS@ $(USER_DEFS)
 CFLAGS_NOFTRAPV          = @CFLAGS_NOFTRAPV@ @C_WFLAGS@ $(USER_DEFS)
@@ -120,7 +120,7 @@ else
 HAVE_LD_SHARED  =	yes
 endif
 
-GDAL_INCLUDE	=	-iquote $(GDAL_ROOT)/port -iquote $(GDAL_ROOT)/gcore \
+GDAL_INCLUDE	=	-iquote $(GDAL_ROOT)/port -iquote $(GDAL_ROOT)/generated_headers -iquote $(GDAL_ROOT)/gcore \
 			-iquote $(GDAL_ROOT)/alg \
                         -iquote $(GDAL_ROOT)/ogr -iquote $(GDAL_ROOT)/ogr/ogrsf_frmts \
                         -iquote $(GDAL_ROOT)/gnm -iquote $(GDAL_ROOT)/apps

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -134,6 +134,7 @@ swig-modules:	apps-target
 
 clean:	lclean
 	(cd port; $(MAKE) clean)
+	(cd generated_headers; $(MAKE) clean)
 	(cd ogr; $(MAKE) clean)
 	(cd gnm; $(MAKE) clean)
 	(cd gcore; $(MAKE) clean)
@@ -156,7 +157,7 @@ lclean:
 distclean:	dist-clean
 
 dist-clean:	clean
-	rm -f GDALmake.opt port/cpl_config.h config.cache config.status
+	rm -f GDALmake.opt generated_headers/cpl_config.h config.cache config.status
 	rm -f libtool
 	rm -rf autom4te.cache
 
@@ -200,6 +201,7 @@ install-static-lib: static-lib gdal.pc
 	$(INSTALL_DIR) $(DESTDIR)$(INST_INCLUDE)
 	(cd port; $(MAKE) install)
 	(cd gcore; $(MAKE) install)
+	(cd generated_headers; $(MAKE) install)
 	(cd frmts; $(MAKE) install)
 	(cd alg; $(MAKE) install)
 	(cd ogr; $(MAKE) install)
@@ -228,6 +230,7 @@ ifeq ($(MACOSX_FRAMEWORK),yes)
 endif
 	(cd port; $(MAKE) install)
 	(cd gcore; $(MAKE) install)
+	(cd generated_headers; $(MAKE) install)
 	(cd frmts; $(MAKE) install)
 	(cd alg; $(MAKE) install)
 	(cd ogr; $(MAKE) install)

--- a/apps/GNUmakefile
+++ b/apps/GNUmakefile
@@ -205,7 +205,7 @@ gdal-config:	gdal-config.in ../GDALmake.opt ./GNUmakefile ../VERSION
 	echo 'CONFIG_LIBS="$(CONFIG_LIBS)"' >> gdal-config
 	echo 'CONFIG_DEP_LIBS="$(LIBS)"' >> gdal-config
 	echo 'CONFIG_PREFIX="$(GDAL_ROOT)"' >> gdal-config
-	echo 'CONFIG_CFLAGS="-I$(GDAL_ROOT)/port -I$(GDAL_ROOT)/gcore -I$(GDAL_ROOT)/alg -I$(GDAL_ROOT)/gnm -I$(GDAL_ROOT)/ogr -I$(GDAL_ROOT)/ogr/ogrsf_frmts -I$(GDAL_ROOT)/frmts/vrt -I$(GDAL_ROOT)/apps"' >> gdal-config
+	echo 'CONFIG_CFLAGS="-I$(GDAL_ROOT)/port -I$(GDAL_ROOT)/generated_headers -I$(GDAL_ROOT)/gcore -I$(GDAL_ROOT)/alg -I$(GDAL_ROOT)/gnm -I$(GDAL_ROOT)/ogr -I$(GDAL_ROOT)/ogr/ogrsf_frmts -I$(GDAL_ROOT)/frmts/vrt -I$(GDAL_ROOT)/apps"' >> gdal-config
 	echo 'CONFIG_DATA="$(GDAL_ROOT)/data"' >> gdal-config
 	echo 'CONFIG_VERSION="'`cat ../VERSION`'"' >> gdal-config
 	echo 'CONFIG_OGR_ENABLED=yes' >> gdal-config  # Deprecated.  Always true.

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AC_INIT
 AC_CONFIG_SRCDIR([GDALmake.opt.in])
 AC_SUBST(PACKAGE, gdal)
 AC_CONFIG_MACRO_DIR(m4)
-AC_CONFIG_HEADERS([port/cpl_config.h:port/cpl_config.h.in])
+AC_CONFIG_HEADERS([generated_headers/cpl_config.h:port/cpl_config.h.in])
 AH_TOP([#ifndef CPL_CONFIG_H])
 AH_TOP([#define CPL_CONFIG_H])
 AH_BOTTOM([#include "cpl_config_extras.h"])

--- a/gcore/GNUmakefile
+++ b/gcore/GNUmakefile
@@ -60,12 +60,11 @@ $(OBJ):	gdal_priv.h gdal_proxy.h
 
 clean: mdreader-clean
 	$(RM) *.o $(O_OBJ)
-	$(RM) -f gdal_version.h
 
 docs:
 	(cd ..; $(MAKE) docs)
 
-gdal_misc.$(OBJ_EXT):	gdal_misc.cpp gdal_version.h
+gdal_misc.$(OBJ_EXT):	gdal_misc.cpp ../generated_headers/gdal_version.h
 
 gdaldrivermanager.$(OBJ_EXT):	gdaldrivermanager.cpp ../GDALmake.opt
 	$(CXX) -c $(GDAL_INCLUDE) $(CPPFLAGS) $(CXXFLAGS) -DINST_DATA=\"$(INST_DATA)\" \
@@ -82,8 +81,7 @@ INST_H_FILES = \
 	gdal_priv.h \
 	gdal_proxy.h \
 	gdal_rat.h \
-	rawdataset.h \
-	gdal_version.h
+	rawdataset.h
 
 install:
 	for f in $(INST_H_FILES) ; do $(INSTALL_DATA) $$f $(DESTDIR)$(INST_INCLUDE) ; done

--- a/gcore/generate_gdal_version_h.sh
+++ b/gcore/generate_gdal_version_h.sh
@@ -2,8 +2,8 @@
 set -e
 
 if test "x$GDAL_SHA1SUM" != "x"; then
-        if test -f gdal_version.h; then
-                cp gdal_version.h gdal_version.h.bak
+        if test -f ../generated_headers/gdal_version.h; then
+                cp ../generated_headers/gdal_version.h gdal_version.h.bak
         else
                 touch gdal_version.h.bak
         fi
@@ -20,15 +20,15 @@ if test "x$GDAL_SHA1SUM" != "x"; then
         fi
         diff -u gdal_version.h.new gdal_version.h.bak >/dev/null || \
             (echo "Update gdal_version.h"; \
-             cp gdal_version.h.new gdal_version.h)
+             cp gdal_version.h.new ../generated_headers/gdal_version.h)
         rm -f gdal_version.h.bak
         rm -f gdal_version.h.new
 elif git log -1 >/dev/null 2>/dev/null && grep dev gdal_version.h.in >/dev/null; then
         REV=$(git log -1 --format="%h")
         DATE=$(git log -1 --date=format:'%Y%m%d' --format="%ad" 2>/dev/null) || DATE=""
         if git status --porcelain -uno | grep . >/dev/null; then REV="$REV-dirty"; fi
-        if test -f gdal_version.h; then
-                cp gdal_version.h gdal_version.h.bak
+        if test -f ../generated_headers/gdal_version.h; then
+                cp ../generated_headers/gdal_version.h gdal_version.h.bak
         else
                 touch gdal_version.h.bak
         fi
@@ -41,7 +41,7 @@ elif git log -1 >/dev/null 2>/dev/null && grep dev gdal_version.h.in >/dev/null;
         fi
         diff -u gdal_version.h.new gdal_version.h.bak >/dev/null || \
             (echo "Update gdal_version.h"; \
-             cp gdal_version.h.new gdal_version.h)
+             cp gdal_version.h.new ../generated_headers/gdal_version.h)
         rm -f gdal_version.h.bak
         rm -f gdal_version.h.new
 else
@@ -50,6 +50,6 @@ else
         cat gdal_version.h.in >> gdal_version.h.new
         diff -u gdal_version.h.new gdal_version.h 2>/dev/null >/dev/null || \
             (echo "Update gdal_version.h"; \
-             cp gdal_version.h.new gdal_version.h)
+             cp gdal_version.h.new ../generated_headers/gdal_version.h)
         rm -f gdal_version.h.new
 fi

--- a/generated_headers/.gitignore
+++ b/generated_headers/.gitignore
@@ -1,0 +1,2 @@
+cpl_config.h
+gdal_version.h

--- a/generated_headers/GNUmakefile
+++ b/generated_headers/GNUmakefile
@@ -1,0 +1,11 @@
+include ../GDALmake.opt
+
+INST_H_FILES = \
+	cpl_config.h \
+	gdal_version.h
+
+clean:
+	$(RM) -f gdal_version.h
+
+install:
+	for f in $(INST_H_FILES) ; do $(INSTALL_DATA) $$f $(DESTDIR)$(INST_INCLUDE) ; done

--- a/port/GNUmakefile
+++ b/port/GNUmakefile
@@ -117,7 +117,6 @@ clean:
 INST_H_FILES = \
 	cpl_atomic_ops.h \
 	cpl_config_extras.h \
-	cpl_config.h \
 	cpl_conv.h \
 	cpl_csv.h \
 	cpl_error.h \

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -19,6 +19,8 @@ GDAL_ROOT=$SCRIPT_DIR/..
 
 if test -f port/cpl_config.h; then
   CPL_CONFIG_H=$PWD/port/cpl_config.h
+elif test -f generated_headers/cpl_config.h; then
+  CPL_CONFIG_H=$PWD/generated_headers/cpl_config.h
 else
   echo "No cpl_config.h file found"
   exit 1
@@ -91,7 +93,7 @@ for dirname in alg port gcore ogr frmts gnm apps fuzzers; do
         --include="${CPL_CONFIG_H}" \
         --include=port/cpl_port.h \
         -I "${CPL_CONFIG_H_DIR}" \
-        -I port -I gcore -I ogr -I ogr/ogrsf_frmts -I ogr/ogrsf_frmts/geojson \
+        -I port -I generated_headers -I gcore -I ogr -I ogr/ogrsf_frmts -I ogr/ogrsf_frmts/geojson \
         -I ogr/ogrsf_frmts/geojson/libjson \
         -i cpl_mem_cache.h \
         -i ogrdissolve.cpp \

--- a/swig/python/fallback_build_mingw32_under_unix.sh
+++ b/swig/python/fallback_build_mingw32_under_unix.sh
@@ -20,7 +20,7 @@ else
     HAS_NUMPY=no
 fi
 
-INCFLAGS="-I${PYTHONHOME}/include -I../../port -I../../gcore -I../../alg -I../../ogr/ -I../../apps/"
+INCFLAGS="-I${PYTHONHOME}/include -I../../port -I../../generated_headers -I../../gcore -I../../alg -I../../ogr/ -I../../apps/"
 LINKFLAGS="-L../../.libs -lgdal -L${PYTHONHOME}/libs -l${PYTHONLIB}"
 CFLAGS="-O2 -D__MSVCRT_VERSION__=0x0601"
 

--- a/swig/python/fallback_build_mingw32_under_unix_py37.sh
+++ b/swig/python/fallback_build_mingw32_under_unix_py37.sh
@@ -17,7 +17,7 @@ else
     HAS_NUMPY=no
 fi
 
-INCFLAGS="-I${PYTHONHOME}/include -I../../port -I../../gcore -I../../alg -I../../ogr/ -I../../gnm -I../../apps/"
+INCFLAGS="-I${PYTHONHOME}/include -I../../port -I../../generated_headers -I../../gcore -I../../alg -I../../ogr/ -I../../gnm -I../../apps/"
 LINKFLAGS="-L../../.libs -lgdal -L${PYTHONHOME}/libs -l${PYTHONLIB}"
 CFLAGS="-O2 -D__MSVCRT_VERSION__=0x0601"
 


### PR DESCRIPTION
This moves port/cpl_config.h and gcore/gdal_version.h to
generated_headers/. This should not be visible from outside users, since
the header will still be installed in ${prefix}/include.

The motivation behind this is to be able, in a same git checkout, to
continue to do autoconf in-source-tree builds as well as cmake
out-of-source-tree builds. The cmake builds would be confused by the
existing autoconf generateds files in port/ and gcore/ if there were
present (a check in the cmake build has been already put in place to avoid
doing builds that would use such stale files)

Something similar could probably be done for makefile.vc builds, but
this is more pressing for my own needs.