### PR TITLE
GPKG: fix doc redirection

### DIFF
--- a/doc/source/_extensions/redirects.py
+++ b/doc/source/_extensions/redirects.py
@@ -44,7 +44,7 @@ def gather_redirects(src_dir):
     output.update({ 'ogr_apitut.html' : os.path.join('./tutorials', 'vector_api_tut') + '.html' })
     output.update({ 'ogr/ogr_arch.html' : os.path.join('../user', 'vector_data_model') + '.html' })
     output.update({ 'ogr_arch.html' : os.path.join('./user', 'vector_data_model') + '.html' })
-    output.update({ 'drivers/vector/geopackage.html' : os.path.join('./drivers/vector', 'gpkg') + '.html' })
+    output.update({ 'drivers/vector/geopackage.html' : os.path.join('../../drivers/vector', 'gpkg') + '.html' })
 
     # Legacy WFS3 renamed as OAPIF
     output.update({ 'drv_wfs3.html' : os.path.join('./drivers/vector', 'oapif') + '.html' })


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

(Hopefully) Fixes doc redirection from https://gdal.org/drivers/vector/geopackage.html to https://gdal.org/drivers/vector/gpkg.html incorrectly introduced by me with https://github.com/OSGeo/gdal/commit/6aa16e0eb980cc57d9e4b79579706b9a60398aee (https://github.com/OSGeo/gdal/pull/4768)

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/4768