### PR TITLE
Change GetFieldAsBinary to use VSIMalloc.

### DIFF
--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -1654,7 +1654,7 @@ public:
 %apply (GByte* outBytes) {GByte*};
   GByte* GetFieldAsBinary(int id, int *nLen, char **pBuf) {
     GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
-    *pBuf = (char*)malloc(*nLen);
+    *pBuf = (char*)VSIMalloc(*nLen);
     memcpy(*pBuf, pabyBlob, *nLen);
     return (GByte*)*pBuf;
   }
@@ -1669,7 +1669,7 @@ public:
       else
       {
         GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
-        *pBuf = (char*)malloc(*nLen);
+        *pBuf = (char*)VSIMalloc(*nLen);
         memcpy(*pBuf, pabyBlob, *nLen);
         return (GByte*)*pBuf;
       }
@@ -1678,7 +1678,7 @@ public:
 #else
   OGRErr GetFieldAsBinary( int id, int *nLen, char **pBuf) {
     GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
-    *pBuf = (char*)malloc(*nLen);
+    *pBuf = (char*)VSIMalloc(*nLen);
     memcpy(*pBuf, pabyBlob, *nLen);
     return OGRERR_NONE;
   }
@@ -1694,7 +1694,7 @@ public:
       else
       {
         GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
-        *pBuf = (char*)malloc(*nLen);
+        *pBuf = (char*)VSIMalloc(*nLen);
         memcpy(*pBuf, pabyBlob, *nLen);
         return OGRERR_NONE;
       }

--- a/swig/python/extensions/ogr_wrap.cpp
+++ b/swig/python/extensions/ogr_wrap.cpp
@@ -4479,7 +4479,7 @@ SWIGINTERN char **OGRFeatureShadow_GetFieldAsStringList(OGRFeatureShadow *self,i
   }
 SWIGINTERN OGRErr OGRFeatureShadow_GetFieldAsBinary__SWIG_0(OGRFeatureShadow *self,int id,int *nLen,char **pBuf){
     GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
-    *pBuf = (char*)malloc(*nLen);
+    *pBuf = (char*)VSIMalloc(*nLen);
     memcpy(*pBuf, pabyBlob, *nLen);
     return 0;
   }
@@ -4493,7 +4493,7 @@ SWIGINTERN OGRErr OGRFeatureShadow_GetFieldAsBinary__SWIG_1(OGRFeatureShadow *se
       else
       {
         GByte* pabyBlob = OGR_F_GetFieldAsBinary(self, id, nLen);
-        *pBuf = (char*)malloc(*nLen);
+        *pBuf = (char*)VSIMalloc(*nLen);
         memcpy(*pBuf, pabyBlob, *nLen);
         return 0;
       }


### PR DESCRIPTION
Running the tests with a custom allocator caused crashes as GetFieldAsBinary was using malloc for allocation but in the swig generated python/extensions/ogr_wrap.cpp file at line 15401 you can see that the memory is freed using VSIFree which does not match the allocation.

This change fixes the ogr.i file however I am not sure of the process to regenerate the *_wrap.cpp files using swig as using the makefile.vc in gdal/swig creates quite a different file from what is checked in. However I can add these to the pull request if required. 

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
