### PR TITLE
PG: skip all leading whitespace in SQL statements.

### DIFF
--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -2925,8 +2925,8 @@ OGRLayer * OGRPGDataSource::ExecuteSQL( const char *pszSQLCommand,
                                         const char *pszDialect )
 
 {
-    /* Skip leading spaces */
-    while(*pszSQLCommand == ' ')
+    /* Skip leading whitespace characters */
+    while(std::isspace(static_cast<unsigned char>(*pszSQLCommand)))
         pszSQLCommand ++;
 
     FlushCache(false);

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -32,6 +32,7 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 #include "cpl_hash_set.h"
+#include <cctype>
 #include <set>
 
 #define PQexec this_is_an_error


### PR DESCRIPTION
Previously the logic to skip leading whitespace only skipped over the
space character (0x20), but for SQL all leading whitespace characters
can be skipped.  Use the built-in std::isspace function to test for
this, rather than testing for the space character specifically.

The previous logic led to differences in the behaviour of queries,
because the logic to detect a 'SELECT' statement failed to detect valid
SELECT queries that began with whitespace other than 0x20.

Refs #4301

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Skip all leading whitespace, instead of just spaces, in SQL statements for the PostgreSQL driver.

## What are related issues/pull requests?

Related to #4301.

## Tasklist

 - [x] Build and test locally
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: MacOS 11.6
* Compiler: Xcode
