### PR TITLE
Fix broken link for the news page

### DIFF
--- a/doc/source/about_no_title.rst
+++ b/doc/source/about_no_title.rst
@@ -7,6 +7,6 @@ GDAL is a translator library for raster and vector geospatial data formats that 
    :target:  `Open Source Geospatial Foundation`_
 
 .. _`Open Source Geospatial Foundation`: http://www.osgeo.org/
-.. _`NEWS`: https://github.com/OSGeo/gdal/blob/v3.4.0/gdal/NEWS
+.. _`NEWS`: https://github.com/OSGeo/gdal/blob/v3.4.0/gdal/NEWS.md
 
 See :ref:`software_using_gdal`


### PR DESCRIPTION
The link on the [main documentation page](https://gdal.org/) to the news file is broken for release 3.4.0, because the file has been renamed from NEWS to NEWS.md in https://github.com/OSGeo/gdal/commit/631010291ba98717fa3a6e880b5a964494c336f4
