### PR TITLE
rdb: enable building rdb driver via CMake

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -362,6 +362,7 @@ gdal_check_package(IDB "enable ogr_IDB driver")
 # TODO: implement FindRASDAMAN
 # libs: -lrasodmg -lclientcomm -lcompression -lnetwork -lraslib
 gdal_check_package(RASDAMAN "enable rasdaman driver")
+gdal_check_package(rdb "enable RIEGL RDB library" CAN_DISABLE)
 gdal_check_package(TileDB "enable TileDB driver" CAN_DISABLE)
 gdal_check_package(OpenEXR "OpenEXR >=2.2" CAN_DISABLE)
 

--- a/cmake/modules/packages/FindRDB.cmake
+++ b/cmake/modules/packages/FindRDB.cmake
@@ -1,0 +1,2 @@
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(rdb CONFIG_MODE)

--- a/doc/source/drivers/raster/rdb.rst
+++ b/doc/source/drivers/raster/rdb.rst
@@ -12,7 +12,7 @@ RDB - *RIEGL* Database
 
 GDAL can read \*.mpx files in the RDB format, the in-house format used by `RIEGL Laser Measurement Systems GmbH <http://www.riegl.com>`__ through the RDB library.
 
-The driver relies on the RDB library, which can be downloaded `here <http://riegl.com/members-area/>`__. The minimum version required of the rdblib is 2.2.0.
+The driver relies on the RDB library, which can be downloaded `here <https://repository.riegl.com/software/libraries/rdblib>`__ . The minimum version required of the rdblib is 2.2.0.
 
 Driver capabilities
 -------------------
@@ -22,7 +22,7 @@ Driver capabilities
 Provided Bands
 -------------------
 
-All attributes stored in the RDB, but the coordinates, are provided in bands. Vector attributes are split up into multiple bands. 
+All attributes stored in the RDB, but the coordinates, are provided in bands. Vector attributes are split up into multiple bands.
 The attributes are currently mapped as follows:
 
 +----------------------------+-------------------------+
@@ -33,48 +33,34 @@ The attributes are currently mapped as follows:
 | riegl.surface_normal[1],   | Band 2                  |
 |                            |                         |
 | riegl.surface_normal[2]    | Band 3                  |
-+----------------------------+-------------------------+ 
-| riegl.reflectance          | Band 4                  |
 +----------------------------+-------------------------+
-| riegl.amplitude            | Band 5                  |
+| riegl.timestamp_min        | Band 4                  |
 +----------------------------+-------------------------+
-| riegl.deviation            | Band 6                  |
+| riegl.timestamp_max        | Band 5                  |
 +----------------------------+-------------------------+
-| riegl.point_count          | Band 7                  |
+| riegl.reflectance          | Band 6                  |
 +----------------------------+-------------------------+
-| riegl.pca_thickness        | Band 8                  |
+| riegl.amplitude            | Band 7                  |
 +----------------------------+-------------------------+
-| riegl.std_dev              | Band 9                  |
+| riegl.deviation            | Band 8                  |
 +----------------------------+-------------------------+
-| riegl.height_center        | Band 10                 |
+| riegl.height_center        | Band 9                  |
 +----------------------------+-------------------------+
-| riegl.height_mean          | Band 11                 |
+| riegl.height_mean          | Band 10                 |
 +----------------------------+-------------------------+
-| riegl.height_min           | Band 12                 |
+| riegl.height_min           | Band 11                 |
 +----------------------------+-------------------------+
-| riegl.height_max           | Band 13                 |
+| riegl.height_max           | Band 12                 |
 +----------------------------+-------------------------+
-| pixel_linear_sums[0]       | Band 14                 |
-|                            |                         |
-| pixel_linear_sums[1]       | Band 15                 |
-|                            |                         |
-| pixel_linear_sums[2]       | Band 16                 |
+| riegl.point_count          | Band 13                 |
 +----------------------------+-------------------------+
-| pixel_square_sums[0]       | Band 17                 |
-|                            |                         |
-| pixel_square_sums[1]       | Band 18                 |
-|                            |                         |
-| pixel_square_sums[2]       | Band 19                 |
-|                            |                         |
-| pixel_square_sums[3]       | Band 20                 |
-|                            |                         |
-| pixel_square_sums[4]       | Band 21                 |
-|                            |                         |
-| pixel_square_sums[5]       | Band 22                 |
+| riegl.point_count_grid_cell| Band 14                 |
 +----------------------------+-------------------------+
-| riegl.voxel_count          | Band 23                 |
+| riegl.pca_thickness        | Band 15                 |
 +----------------------------+-------------------------+
-| riegl.id                   | Band 24                 |
+| riegl.std_dev              | Band 16                 |
 +----------------------------+-------------------------+
-| riegl.point_count_grid_cell| Band 25                 |
+| riegl.voxel_count          | Band 17                 |
++----------------------------+-------------------------+
+| riegl.id                   | Band 18                 |
 +----------------------------+-------------------------+

--- a/frmts/CMakeLists.txt
+++ b/frmts/CMakeLists.txt
@@ -132,6 +132,7 @@ gdal_dependent_format(jpeg2000 "JPEG2000 --- Implementation of the JPEG-2000 par
 gdal_dependent_format(tiledb "TileDB tiledb.io" "GDAL_USE_TILEDB")
 gdal_dependent_format(exr "EXR support via OpenEXR library" "GDAL_USE_OPENEXR")
 gdal_dependent_format(pcraster "PCRaster CSF 2.0 raster file driver" "GDAL_USE_LIBCSF OR GDAL_USE_LIBCSF_INTERNAL")
+gdal_dependent_format(rdb "RIEGL RDB Map Pixel (.mpx) driver" "rdb_FOUND")
 
 # for circulate dependency, grass is NOT always compiled in.
 gdal_dependent_format(grass "GRASS" "HAVE_GRASS")

--- a/frmts/rdb/CMakeLists.txt
+++ b/frmts/rdb/CMakeLists.txt
@@ -5,6 +5,6 @@ gdal_target_link_libraries(TARGET gdal_RDB PRIVATE LIBRARIES rdbcpp)
 
 if (GDAL_USE_LIBJSONC_INTERNAL)
   target_include_directories(gdal_RDB PRIVATE $<TARGET_PROPERTY:libjson,SOURCE_DIR>)
-else()
+else ()
   gdal_target_link_libraries(TARGET gdal_RDB LIBRARIES JSONC::JSONC)
-endif()
+endif ()

--- a/frmts/rdb/CMakeLists.txt
+++ b/frmts/rdb/CMakeLists.txt
@@ -1,3 +1,10 @@
-add_gdal_driver(TARGET gdal_RDB SOURCES rdbdataset.cpp)
+add_gdal_driver(TARGET gdal_RDB SOURCES rdbdataset.cpp PLUGIN_CAPABLE_IF "NOT GDAL_USE_LIBJSONC_INTERNAL")
 gdal_standard_includes(gdal_RDB)
 target_include_directories(gdal_RDB PRIVATE ${GDAL_VECTOR_FORMAT_SOURCE_DIR}/geojson)
+gdal_target_link_libraries(TARGET gdal_RDB PRIVATE LIBRARIES rdbcpp)
+
+if (GDAL_USE_LIBJSONC_INTERNAL)
+  target_include_directories(gdal_RDB PRIVATE $<TARGET_PROPERTY:libjson,SOURCE_DIR>)
+else()
+  gdal_target_link_libraries(TARGET gdal_RDB LIBRARIES JSONC::JSONC)
+endif()


### PR DESCRIPTION
## What does this PR do?

Updates CMake files in order to enable building the rdb driver.

I did not add anything to `doc/source/build_hints.rst` because the only build requirement is, that the rdb can be found by CMake.
Instead I have updated the information in `doc/source/drivers/raster/rdb.rst`.

## Tasklist

 - [x] Update CMake files in order to build rdb driver
 - [x] Updated documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

I currently only compiled the update on Ubuntu focal. I could add downloading and building with the rdblib in the CI steps, because the rdblib can be downloaded from a server.