### PR TITLE
Add support for comments in ERS files

### DIFF
--- a/autotest/gdrivers/data/ers/srtm.ers
+++ b/autotest/gdrivers/data/ers/srtm.ers
@@ -1,3 +1,4 @@
+# This is an ERS file with a comment at the start
 DatasetHeader Begin
   Version = "5.2"
   DataSetType = ERStorage
@@ -5,6 +6,9 @@ DatasetHeader Begin
   ByteOrder = MSBFirst
   Foo = { "x\\\"
 y" }
+  Bar = "# not a comment"
+  Baz = { "x\\\"
+#also not a comment" }
 
   CoordinateSpace Begin
     Datum = "WGS84"
@@ -13,8 +17,9 @@ y" }
     Rotation = 0:0:0.0
   CoordinateSpace End
 
+# Comment in the middle
   RasterInfo Begin
-    CellType = Signed16BitInteger
+    CellType = Signed16BitInteger   # Comment at the end of a line
     NullCellValue = +9999
     CellInfo Begin
       Xdimension = 0.00833333
@@ -37,7 +42,8 @@ y" }
     RegionInfo Begin
       RegionName = "All"
       Stats Begin
-        MinimumValue = { -4315 }
+        MinimumValue = { -4315 # comment in brackets
+        }
         MaximumValue = { -3744 }
         MeanValue = { -4020.25 }
         MedianValue = { -4000 }

--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -829,14 +829,7 @@ int ERSDataset::Identify( GDALOpenInfo * poOpenInfo )
 /*      We assume the user selects the .ers file.                       */
 /* -------------------------------------------------------------------- */
     if( poOpenInfo->nHeaderBytes >= 15
-        && STARTS_WITH_CI((const char *) poOpenInfo->pabyHeader, "DatasetHeader ") )
-        return TRUE;
-
-/* -------------------------------------------------------------------- */
-/*      We assume the user selects the .ers file.                       */
-/* -------------------------------------------------------------------- */
-    if( poOpenInfo->nHeaderBytes >= 1
-        && STARTS_WITH_CI((const char *) poOpenInfo->pabyHeader, "#") )
+        && strstr((const char *) poOpenInfo->pabyHeader, "DatasetHeader ") != nullptr )
         return TRUE;
 
     return FALSE;

--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -818,7 +818,7 @@ int ERSDataset::Identify( GDALOpenInfo * poOpenInfo )
 /* -------------------------------------------------------------------- */
     CPLString osHeader((const char *)poOpenInfo->pabyHeader, poOpenInfo->nHeaderBytes);
 
-    if( osHeader.ifind( "Algorithm " ) != std::string::npos )
+    if( osHeader.ifind( "Algorithm Begin" ) != std::string::npos )
     {
         CPLError( CE_Failure, CPLE_OpenFailed,
                   "%s appears to be an algorithm ERS file, which is not currently supported.",

--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -816,8 +816,9 @@ int ERSDataset::Identify( GDALOpenInfo * poOpenInfo )
 /* -------------------------------------------------------------------- */
 /*      We assume the user selects the .ers file.                       */
 /* -------------------------------------------------------------------- */
-    if( poOpenInfo->nHeaderBytes > 15
-        && STARTS_WITH_CI((const char *) poOpenInfo->pabyHeader, "Algorithm Begin") )
+    CPLString osHeader((const char *)poOpenInfo->pabyHeader, poOpenInfo->nHeaderBytes);
+
+    if( osHeader.ifind( "Algorithm " ) != std::string::npos )
     {
         CPLError( CE_Failure, CPLE_OpenFailed,
                   "%s appears to be an algorithm ERS file, which is not currently supported.",
@@ -825,11 +826,7 @@ int ERSDataset::Identify( GDALOpenInfo * poOpenInfo )
         return FALSE;
     }
 
-/* -------------------------------------------------------------------- */
-/*      We assume the user selects the .ers file.                       */
-/* -------------------------------------------------------------------- */
-    if( poOpenInfo->nHeaderBytes >= 15
-        && strstr((const char *) poOpenInfo->pabyHeader, "DatasetHeader ") != nullptr )
+    if( osHeader.ifind( "DatasetHeader " ) != std::string::npos )
         return TRUE;
 
     return FALSE;

--- a/frmts/ers/ershdrnode.cpp
+++ b/frmts/ers/ershdrnode.cpp
@@ -130,10 +130,53 @@ int ERSHdrNode::ReadLine( VSILFILE * fp, CPLString &osLine )
             {
                 bLastCharWasSlashInQuote = true;
             }
+            // A comment is a '#' up to the end of the line.
+            else if( ch == '#' && !bInQuote )
+            {
+                osLine = osLine.substr(0, i) + "\n";
+            }
         }
     } while( nBracketLevel > 0 );
 
     return TRUE;
+}
+
+/************************************************************************/
+/*                            ParseHeader()                             */
+/*                                                                      */
+/*      We receive the FILE * positioned at the start of the file       */
+/*      and read all children.  This allows reading comment lines       */
+/*      at the start of the file.                                       */
+/************************************************************************/
+
+int ERSHdrNode::ParseHeader( VSILFILE * fp )
+
+{
+    while( true )
+    {
+/* -------------------------------------------------------------------- */
+/*      Read the next line                                              */
+/* -------------------------------------------------------------------- */
+        CPLString osLine;
+        size_t iOff;
+
+        if( !ReadLine( fp, osLine ) )
+            return FALSE;
+
+/* -------------------------------------------------------------------- */
+/*      Got a DatasetHeader Begin                                       */
+/* -------------------------------------------------------------------- */
+        else if( (iOff = osLine.ifind( " Begin" )) != std::string::npos )
+        {
+            CPLString osName = osLine.substr(0,iOff);
+            osName.Trim();
+
+            if ( osName.tolower() == CPLString("DatasetHeader").tolower() )
+            {
+                return ParseChildren( fp );
+            }
+        }
+    }
 }
 
 /************************************************************************/
@@ -155,7 +198,7 @@ int ERSHdrNode::ParseChildren( VSILFILE * fp, int nRecLevel )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Too many recursion level while parsing .ers header");
-        return false;
+        return FALSE;
     }
 
     while( true )

--- a/frmts/ers/ershdrnode.h
+++ b/frmts/ers/ershdrnode.h
@@ -17,6 +17,7 @@ public:
     ERSHdrNode();
     ~ERSHdrNode();
 
+    int    ParseHeader( VSILFILE *fp );
     int    ParseChildren( VSILFILE *fp, int nRecLevel = 0 );
     int    WriteSelf( VSILFILE *fp, int nIndent );
 


### PR DESCRIPTION
## What does this PR do?

This PR adds support for comments in ERS file headers.  A comment starts with a `#` character and continues to the end of the line.  ER Mapper documentation describes comments in this fashion and we've recently encountered files in the wild that contain comments.  Since comments may appear at the start of the file, ERS file identification logic is modified to accommodate presence of such comments.

The `srtm.ers` test case is modified to exercise comment logic and all ERS test cases are still passing.