### PR TITLE
Create FindOpenEXR.cmake

### DIFF
--- a/cmake/modules/packages/FindOpenEXR.cmake
+++ b/cmake/modules/packages/FindOpenEXR.cmake
@@ -46,7 +46,7 @@ find_path(Imath_INCLUDE_DIR
           HINTS ${Imath_INC_HINTS} ${OpenEXR_INCLUDE_DIR}
           PATH_SUFFIXES Imath)
 
-if(NOT OpenEXR_VERSION_STRING)
+if(OpenEXR_INCLUDE_DIR AND NOT OpenEXR_VERSION_STRING)
   # Fallback for PkgConfig not finding anything
   file(READ ${OpenEXR_INCLUDE_DIR}/OpenEXRConfig.h txt)
   string(REGEX MATCH "define[ \t]+OPENEXR_VERSION_STRING[ \t]+\"([0-9]+(.[0-9]+)?(.[0-9]+)?)\".*$" _ ${txt})


### PR DESCRIPTION
## What does this PR do?

It is now possible to just specify OpenEXR_ROOT for Versions < 3. Versions >= 3 need an additional Imath_ROOT as Imath is separate now. This should work without an explicitly user supplied PKG_CONFIG_PATH. Tested on openexr-2.5 and openexr-3.1.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

CMake 3.16, Ninja, openexr-2.5 and openexr-3.1

Provide environment details, if relevant:

* OS: Linux
* Compiler: GCC 9.3
