### PR TITLE
CMake: iconv on OSX

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -13,6 +13,7 @@ include(CheckFunctionExists)
 include(CMakeDependentOption)
 include(FeatureSummary)
 include(DefineFindPackage2)
+include(CheckSymbolExists)
 
 # Macro to declare a package
 # Accept a CAN_DISABLE option to specify that the package can be disabled

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -178,16 +178,15 @@ if (GDAL_USE_ICONV)
   if (Iconv_IS_BUILT_IN)
     target_sources(cpl PRIVATE cpl_recode_iconv.cpp)
   else ()
-      if (APPLE)
-          # linkage against OSX's system iconv is going to require
-          # LIBICONV_PLUG to be defined, but other self-built situations
-          # like CondaForge or Homebrew might not need this
-          set(CMAKE_REQUIRED_LIBRARIES ${Iconv_LIBRARY})
-          check_symbol_exists(_iconv_close "iconv.h" HAVE_ICONV_CLOSE)
-          if (HAVE_ICONV_CLOSE)
-              target_compile_definitions(cpl PRIVATE -DLIBICONV_PLUG)
-          endif (HAVE_ICONV_CLOSE)
-      endif (APPLE)
+    if (APPLE)
+      # linkage against OSX's system iconv is going to require LIBICONV_PLUG to be defined, but other self-built
+      # situations like CondaForge or Homebrew might not need this
+      set(CMAKE_REQUIRED_LIBRARIES ${Iconv_LIBRARY})
+      check_symbol_exists(_iconv_close "iconv.h" HAVE_ICONV_CLOSE)
+      if (HAVE_ICONV_CLOSE)
+        target_compile_definitions(cpl PRIVATE -DLIBICONV_PLUG)
+      endif (HAVE_ICONV_CLOSE)
+    endif (APPLE)
     target_sources(cpl PRIVATE cpl_recode_iconv.cpp)
     target_include_directories(cpl PRIVATE $<TARGET_PROPERTY:Iconv::Iconv,INTERFACE_INCLUDE_DIRECTORIES>)
     gdal_add_private_link_libraries(Iconv::Iconv)

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -182,6 +182,7 @@ if (GDAL_USE_ICONV)
           # linkage against OSX's system iconv is going to require
           # LIBICONV_PLUG to be defined, but other self-built situations
           # like CondaForge or Homebrew might not need this
+          set(CMAKE_REQUIRED_LIBRARIES ${Iconv_LIBRARY})
           check_symbol_exists(_iconv_close "iconv.h" HAVE_ICONV_CLOSE)
           if (HAVE_ICONV_CLOSE)
               target_compile_definitions(cpl PRIVATE -DLIBICONV_PLUG)

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -178,9 +178,15 @@ if (GDAL_USE_ICONV)
   if (Iconv_IS_BUILT_IN)
     target_sources(cpl PRIVATE cpl_recode_iconv.cpp)
   else ()
-    if (APPLE)
-      target_compile_definitions(cpl PRIVATE -DLIBICONV_PLUG)
-    endif ()
+      if (APPLE)
+          # linkage against OSX's system iconv is going to require
+          # LIBICONV_PLUG to be defined, but other self-built situations
+          # like CondaForge or Homebrew might not need this
+          check_symbol_exists(_iconv_close "iconv.h" HAVE_ICONV_CLOSE)
+          if (HAVE_ICONV_CLOSE)
+              target_compile_definitions(cpl PRIVATE -DLIBICONV_PLUG)
+          endif (HAVE_ICONV_CLOSE)
+      endif (APPLE)
     target_sources(cpl PRIVATE cpl_recode_iconv.cpp)
     target_include_directories(cpl PRIVATE $<TARGET_PROPERTY:Iconv::Iconv,INTERFACE_INCLUDE_DIRECTORIES>)
     gdal_add_private_link_libraries(Iconv::Iconv)


### PR DESCRIPTION
Check for iconv_open availability in libiconv on OSX due to how things could be built on that platform in regard to `LIBICONV_PLUG`