### PR TITLE
GTiff: LERC overview related improvements

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -7006,6 +7006,136 @@ def test_tiff_write_180_lerc_separate():
     gdal.Unlink(filename)
     assert cs == [30111, 32302, 40026]
 
+
+###############################################################################
+# Test MAX_Z_ERROR_OVERVIEW effect while creating overviews
+# on a newly created dataset
+
+@pytest.mark.parametrize("external_ovr,compression", [(True, 'LERC_ZSTD'),
+                                                      (False, 'LERC_ZSTD'),
+                                                      (True, 'LERC_DEFLATE'),
+                                                      (False, 'LERC_DEFLATE')])
+def test_tiff_write_lerc_overview(external_ovr, compression):
+    md = gdaltest.tiff_drv.GetMetadata()
+    if compression not in md['DMD_CREATIONOPTIONLIST']:
+        pytest.skip()
+
+    checksums = {}
+    errors = [0,10,10]
+    src_ds = gdal.Open('../gdrivers/data/utm.tif')
+    for i, error in enumerate(errors):
+        fname = '/vsimem/test_tiff_write_lerc_overview_%d' % i
+
+        ds = gdal.GetDriverByName('GTiff').Create(fname, 256, 256, 1,
+                                                  options=['COMPRESS=' + compression,
+                                                           'MAX_Z_ERROR=%f' % error])
+        data = src_ds.GetRasterBand(1).ReadRaster(0, 0, 512, 512, 256, 256)
+        ds.GetRasterBand(1).WriteRaster(0, 0, 256, 256, data)
+        if i == 2:
+            error = 30
+        options = {}
+        if external_ovr:
+            ds = None
+            ds = gdal.Open(fname)
+            options['COMPRESS_OVERVIEW'] = compression
+        options['MAX_Z_ERROR_OVERVIEW'] = '%d' % error
+        with gdaltest.config_options(options):
+            ds.BuildOverviews('AVERAGE', overviewlist=[2, 4])
+
+        ds = None
+
+        ds = gdal.Open(fname)
+        assert ds.GetRasterBand(1).GetOverview(0).GetDataset().GetMetadataItem('COMPRESSION', 'IMAGE_STRUCTURE') == compression
+        checksums[i] = [ ds.GetRasterBand(1).Checksum(),
+                               ds.GetRasterBand(1).GetOverview(0).Checksum(),
+                               ds.GetRasterBand(1).GetOverview(1).Checksum() ]
+        ds = None
+        gdaltest.tiff_drv.Delete(fname)
+
+    assert checksums[0][0] != checksums[1][0]
+    assert checksums[0][1] != checksums[1][1]
+    assert checksums[0][2] != checksums[1][2]
+
+    assert checksums[0][0] != checksums[2][0]
+    assert checksums[0][1] != checksums[2][1]
+    assert checksums[0][2] != checksums[2][2]
+
+    assert checksums[1][0] == checksums[2][0]
+    assert checksums[1][1] != checksums[2][1]
+    assert checksums[1][2] != checksums[2][2]
+
+###############################################################################
+# Test ZLEVEL_OVERVIEW effect while creating overviews
+# on a newly created dataset
+
+@pytest.mark.parametrize("external_ovr", [True, False])
+def test_tiff_write_lerc_zlevel(external_ovr):
+    md = gdaltest.tiff_drv.GetMetadata()
+    if 'LERC_DEFLATE' not in md['DMD_CREATIONOPTIONLIST']:
+        pytest.skip()
+
+    filesize = {}
+    src_ds = gdal.Open('../gdrivers/data/utm.tif')
+    for level in (1,9):
+        fname = '/vsimem/test_tiff_write_lerc_zlevel_%d' % level
+        ds = gdal.GetDriverByName('GTiff').Create(fname, 256, 256, 1,
+                                                  options=['COMPRESS=LERC_DEFLATE'])
+        data = src_ds.GetRasterBand(1).ReadRaster(0, 0, 512, 512, 256, 256)
+        ds.GetRasterBand(1).WriteRaster(0, 0, 256, 256, data)
+        options = { 'MAX_Z_ERROR_OVERVIEW' : '10' }
+        if external_ovr:
+            ds = None
+            ds = gdal.Open(fname)
+            options['COMPRESS_OVERVIEW'] = 'LERC_DEFLATE'
+        options['ZLEVEL_OVERVIEW'] = '%d' % level
+        with gdaltest.config_options(options):
+            ds.BuildOverviews('AVERAGE', overviewlist=[2, 4])
+        ds = None
+
+        if external_ovr:
+            filesize[level] = gdal.VSIStatL(fname + '.ovr').size
+        else:
+            filesize[level] = gdal.VSIStatL(fname).size
+        gdaltest.tiff_drv.Delete(fname)
+
+    assert filesize[1] > filesize[9]
+
+###############################################################################
+# Test ZSTD_LEVEL_OVERVIEW effect while creating overviews
+# on a newly created dataset
+
+@pytest.mark.parametrize("external_ovr", [True, False])
+def test_tiff_write_lerc_zstd_level(external_ovr):
+    md = gdaltest.tiff_drv.GetMetadata()
+    if 'LERC_ZSTD' not in md['DMD_CREATIONOPTIONLIST']:
+        pytest.skip()
+
+    filesize = {}
+    src_ds = gdal.Open('../gdrivers/data/utm.tif')
+    for level in (1,22):
+        fname = '/vsimem/test_tiff_write_lerc_zstd_level_%d' % level
+        ds = gdal.GetDriverByName('GTiff').Create(fname, 256, 256, 1,
+                                                  options=['COMPRESS=LERC_ZSTD'])
+        data = src_ds.GetRasterBand(1).ReadRaster(0, 0, 512, 512, 256, 256)
+        ds.GetRasterBand(1).WriteRaster(0, 0, 256, 256, data)
+        options = { 'MAX_Z_ERROR_OVERVIEW' : '10' }
+        if external_ovr:
+            ds = None
+            ds = gdal.Open(fname)
+            options['COMPRESS_OVERVIEW'] = 'LERC_ZSTD'
+        options['ZSTD_LEVEL_OVERVIEW'] = '%d' % level
+        with gdaltest.config_options(options):
+            ds.BuildOverviews('AVERAGE', overviewlist=[2, 4])
+        ds = None
+
+        if external_ovr:
+            filesize[level] = gdal.VSIStatL(fname + '.ovr').size
+        else:
+            filesize[level] = gdal.VSIStatL(fname).size
+        gdaltest.tiff_drv.Delete(fname)
+
+    assert filesize[1] > filesize[22]
+
 ###############################################################################
 # Test set XMP metadata
 

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -3147,10 +3147,11 @@ def test_tiff_write_90():
     assert checksums[1][2] != checksums[2][2]
 
 ###############################################################################
-# Test WEBP_LEVEL propagation and overriding while creating (internal) overviews
+# Test WEBP_LEVEL propagation and overriding while creating overviews
 # on a newly created dataset
 
-def test_tiff_write_90_webp():
+@pytest.mark.parametrize("external_ovr", [True, False])
+def test_tiff_write_90_webp(external_ovr):
     md = gdaltest.tiff_drv.GetMetadata()
     if md['DMD_CREATIONOPTIONLIST'].find('WEBP') == -1:
         pytest.skip()
@@ -3161,16 +3162,22 @@ def test_tiff_write_90_webp():
         src_ds = gdal.Open('../gdrivers/data/utm.tif')
         fname = 'tmp/tiff_write_90_webp_%d' % i
 
-        ds = gdal.GetDriverByName('GTiff').Create(fname, 1024, 1024, 3,
+        ds = gdal.GetDriverByName('GTiff').Create(fname, 512, 512, 3,
                                                   options=['COMPRESS=WEBP', 'WEBP_LEVEL=%d' % quality])
 
-        data = src_ds.GetRasterBand(1).ReadRaster(0, 0, 512, 512, 1024, 1024)
-        ds.GetRasterBand(1).WriteRaster(0, 0, 1024, 1024, data)
-        ds.GetRasterBand(2).WriteRaster(0, 0, 1024, 1024, data)
-        ds.GetRasterBand(3).WriteRaster(0, 0, 1024, 1024, data)
+        data = src_ds.GetRasterBand(1).ReadRaster()
+        ds.GetRasterBand(1).WriteRaster(0, 0, 512, 512, data)
+        ds.GetRasterBand(2).WriteRaster(0, 0, 512, 512, data)
+        ds.GetRasterBand(3).WriteRaster(0, 0, 512, 512, data)
         if i == 2:
             quality = 30
-        with gdaltest.config_option('WEBP_LEVEL_OVERVIEW', '%d'%quality):
+        options = {}
+        if external_ovr:
+            ds = None
+            ds = gdal.Open(fname)
+            options['COMPRESS_OVERVIEW'] = 'WEBP'
+        options['WEBP_LEVEL_OVERVIEW'] = '%d' % quality
+        with gdaltest.config_options(options):
             ds.BuildOverviews('AVERAGE', overviewlist=[2, 4])
 
         src_ds = None
@@ -3194,7 +3201,6 @@ def test_tiff_write_90_webp():
     assert checksums[1][0] == checksums[2][0]
     assert checksums[1][1] != checksums[2][1]
     assert checksums[1][2] != checksums[2][2]
-
 
 
 ###############################################################################

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -403,7 +403,7 @@ Creation Options
    * ``LERC_ZSTD`` is available when ``LERC`` and ``ZSTD`` are available.
 
    * ``JXL`` is for JPEG-XL, and is only available when using internal libtiff and building GDAL against
-     https://github.com/libjxl/libjxl . JXL compression may only be used alongside ``INTERLEAVE=PIXEL`` 
+     https://github.com/libjxl/libjxl . JXL compression may only be used alongside ``INTERLEAVE=PIXEL``
      (the default) on datasets with 4 bands or less.
 
    * ``NONE`` is the default.
@@ -731,10 +731,19 @@ the default behavior of the GTiff driver.
    Set the photometric color space for overview creation
 -  :decl_configoption:`PREDICTOR_OVERVIEW` : Integer 1,2 or 3.
    Set the predictor to use for overviews with LZW, DEFLATE and ZSTD compression
--  :decl_configoption:`JPEG_QUALITY_OVERVIEW` : Integer between 0 and 100. Default value : 75.
+-  :decl_configoption:`JPEG_QUALITY_OVERVIEW` : Integer between 0 and 100. Default value: 75.
    Quality of JPEG compressed overviews, either internal or external.
--  :decl_configoption:`WEBP_LEVEL_OVERVIEW` : Integer between 1 and 100. Default value : 75.
+-  :decl_configoption:`WEBP_LEVEL_OVERVIEW` : Integer between 1 and 100. Default value: 75.
    WEBP quality level of overviews, either internal or external.
+-  :decl_configoption:`ZLEVEL_OVERVIEW` : Integer between 1 and 9 (or 12 when libdeflate is used). Default value: 6.
+   Deflate compression level of overviews, for COMPRESS_OVERVIEW=DEFLATE or LERC_DEFLATE, either internal or external.
+   Added in GDAL 3.4.1
+-  :decl_configoption:`ZSTD_LEVEL_OVERVIEW` : Integer between 1 and 22. Default value: 9.
+   ZSTD compression level of overviews, for COMPRESS_OVERVIEW=DEFLATE or LERC_ZSTD, either internal or external.
+   Added in GDAL 3.4.1
+-  :decl_configoption:`MAX_Z_ERROR_OVERVIEW` : Floating-point value. Default value: 0 (lossless)
+   Maximum error threshold on values for LERC/LERC_DEFLATE/LERC_ZSTD compression of overviews, either internal or external.
+   Added in GDAL 3.4.1
 -  :decl_configoption:`GDAL_TIFF_INTERNAL_MASK` : See `Internal nodata
    masks <#internal_mask>`__ section. Default value : FALSE.
 -  :decl_configoption:`GDAL_TIFF_INTERNAL_MASK_TO_8BIT` : See `Internal nodata

--- a/doc/source/programs/gdaladdo.rst
+++ b/doc/source/programs/gdaladdo.rst
@@ -63,11 +63,11 @@ most supported file formats with one of several downsampling algorithms.
 .. option:: -ro
 
     open the dataset in read-only mode, in order to generate external overview
-    (for GeoTIFF especially). 
+    (for GeoTIFF especially).
 
 .. option:: -clean
 
-    remove all overviews. 
+    remove all overviews.
 
 .. option:: -oo NAME=VALUE
 
@@ -76,13 +76,13 @@ most supported file formats with one of several downsampling algorithms.
 .. option:: -minsize <val>
 
     Maximum width or height of the smallest overview level. Only taken into
-    account if explicit levels are not specified. Defaults to 256. 
+    account if explicit levels are not specified. Defaults to 256.
 
     .. versionadded:: 2.3
 
 .. option:: <filename>
 
-    The file to build overviews for (or whose overviews must be removed). 
+    The file to build overviews for (or whose overviews must be removed).
 
 .. option:: <levels>
 
@@ -129,13 +129,22 @@ The photometric interpretation can be set with the :decl_configoption:`PHOTOMETR
 =RGB/YCBCR/... configuration option,
 and the interleaving with the :decl_configoption:`INTERLEAVE_OVERVIEW` =PIXEL/BAND configuration option.
 
-For JPEG compressed external overviews, the JPEG quality can be set with
+For JPEG compressed external and internal overviews, the JPEG quality can be set with
 ``--config JPEG_QUALITY_OVERVIEW value``.
 
 For WEBP compressed external and internal overviews, the WEBP quality level can be set with
 ``--config WEBP_LEVEL_OVERVIEW value``. If not set, will default to 75.
 
-For LZW or DEFLATE compressed external overviews, the predictor value can be set
+For LERC compressed external and internal overviews, the max error threshold can be set with
+``--config MAX_Z_ERROR_OVERVIEW value``. If not set, will default to 0 (lossless). Added in GDAL 3.4.1
+
+For DEFLATE or LERC_DEFLATE compressed external and internal overviews, the compression level can be set with
+``--config ZLEVEL_OVERVIEW value``. If not set, will default to 6. Added in GDAL 3.4.1
+
+For ZSTD or LERC_ZSTD compressed external and internal overviews, the compression level can be set with
+``--config ZSTD_LEVEL_OVERVIEW value``. If not set, will default to 9. Added in GDAL 3.4.1
+
+For LZW, ZSTD or DEFLATE compressed external overviews, the predictor value can be set
 with ``--config PREDICTOR_OVERVIEW 1|2|3``.
 
 To produce the smallest possible JPEG-In-TIFF overviews, you should use:

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -289,6 +289,9 @@ private:
     friend void  GTIFFSetJpegQuality( GDALDatasetH hGTIFFDS, int nJpegQuality );
     friend void  GTIFFSetJpegTablesMode( GDALDatasetH hGTIFFDS, int nJpegTablesMode );
     friend void  GTIFFSetWebPLevel( GDALDatasetH hGTIFFDS, int nWebPLevel );
+    friend void  GTIFFSetZLevel( GDALDatasetH hGTIFFDS, int nZLevel );
+    friend void  GTIFFSetZSTDLevel( GDALDatasetH hGTIFFDS, int nZSTDLevel );
+    friend void  GTIFFSetMaxZError( GDALDatasetH hGTIFFDS, double dfMaxZError );
 
     TIFF                 *m_hTIFF = nullptr;
     VSILFILE             *m_fpL = nullptr;
@@ -490,8 +493,8 @@ private:
     void          LoadEXIFMetadata();
     void          LoadICCProfile();
 
-    CPLErr        RegisterNewOverviewDataset( toff_t nOverviewOffset, int l_nJpegQuality,
-                                              int l_nWebPLevel );
+    CPLErr        RegisterNewOverviewDataset( toff_t nOverviewOffset,
+                                              int l_nJpegQuality );
     CPLErr        CreateOverviewsFromSrcOverviews( GDALDataset* poSrcDS,
                                                    GDALDataset* poOvrDS );
     CPLErr        CreateInternalMaskOverviews( int nOvrBlockXSize,
@@ -1137,6 +1140,66 @@ void GTIFFSetJpegTablesMode( GDALDatasetH hGTIFFDS, int nJpegTablesMode )
 
     for( int i = 0; i < poDS->m_nOverviewCount; ++i )
         poDS->m_papoOverviewDS[i]->m_nJpegTablesMode = poDS->m_nJpegTablesMode;
+}
+
+/************************************************************************/
+/*                        GTIFFSetZLevel()                              */
+/* Called by GTIFFBuildOverviews() to set the deflate level on the IFD  */
+/* of the .ovr file.                                                    */
+/************************************************************************/
+
+void GTIFFSetZLevel( GDALDatasetH hGTIFFDS, int nZLevel )
+{
+    CPLAssert(
+        EQUAL(GDALGetDriverShortName(GDALGetDatasetDriver(hGTIFFDS)), "GTIFF"));
+
+    GTiffDataset* const poDS = static_cast<GTiffDataset *>(hGTIFFDS);
+    poDS->m_nZLevel = static_cast<signed char>(nZLevel);
+
+    poDS->ScanDirectories();
+
+    for( int i = 0; i < poDS->m_nOverviewCount; ++i )
+        poDS->m_papoOverviewDS[i]->m_nZLevel = poDS->m_nZLevel;
+}
+
+/************************************************************************/
+/*                        GTIFFSetZSTDLevel()                           */
+/* Called by GTIFFBuildOverviews() to set the ZSTD level on the IFD     */
+/* of the .ovr file.                                                    */
+/************************************************************************/
+
+void GTIFFSetZSTDLevel( GDALDatasetH hGTIFFDS, int nZSTDLevel )
+{
+    CPLAssert(
+        EQUAL(GDALGetDriverShortName(GDALGetDatasetDriver(hGTIFFDS)), "GTIFF"));
+
+    GTiffDataset* const poDS = static_cast<GTiffDataset *>(hGTIFFDS);
+    poDS->m_nZSTDLevel = static_cast<signed char>(nZSTDLevel);
+
+    poDS->ScanDirectories();
+
+    for( int i = 0; i < poDS->m_nOverviewCount; ++i )
+        poDS->m_papoOverviewDS[i]->m_nZSTDLevel = poDS->m_nZSTDLevel;
+}
+
+/************************************************************************/
+/*                        GTIFFSetMaxZError()                           */
+/* Called by GTIFFBuildOverviews() to set the Lerc max error on the IFD */
+/* of the .ovr file.                                                    */
+/************************************************************************/
+
+void GTIFFSetMaxZError( GDALDatasetH hGTIFFDS, double dfMaxZError )
+{
+    CPLAssert(
+        EQUAL(GDALGetDriverShortName(GDALGetDatasetDriver(hGTIFFDS)), "GTIFF"));
+
+    GTiffDataset* const poDS = static_cast<GTiffDataset *>(hGTIFFDS);
+    poDS->m_dfMaxZError = dfMaxZError;
+
+    poDS->ScanDirectories();
+
+    for( int i = 0; i < poDS->m_nOverviewCount; ++i )
+        poDS->m_papoOverviewDS[i]->m_dfMaxZError = poDS->m_dfMaxZError;
 }
 
 /************************************************************************/
@@ -9954,23 +10017,46 @@ CPLErr GTiffDataset::CleanOverviews()
 /************************************************************************/
 
 CPLErr GTiffDataset::RegisterNewOverviewDataset(toff_t nOverviewOffset,
-                                                int l_nJpegQuality,
-                                                int l_nWebPLevel)
+                                                int l_nJpegQuality)
 {
     if( m_nOverviewCount == 127 )
         return CE_Failure;
+
+    int nZLevel = m_nZLevel;
+    if( const char* opt = CPLGetConfigOption( "ZLEVEL_OVERVIEW", nullptr ) )
+    {
+        nZLevel = atoi(opt);
+    }
+
+    int nZSTDLevel = m_nZSTDLevel;
+    if( const char* opt = CPLGetConfigOption( "ZSTD_LEVEL_OVERVIEW", nullptr ) )
+    {
+        nZSTDLevel = atoi(opt);
+    }
+
+    int nWebpLevel = m_nWebPLevel;
+    if( const char* opt = CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr ) )
+    {
+        nWebpLevel = atoi(opt);
+    }
+
+    double dfMaxZError = m_dfMaxZError;
+    if( const char* opt = CPLGetConfigOption( "MAX_Z_ERROR_OVERVIEW", nullptr ) )
+    {
+        dfMaxZError = CPLAtof(opt);
+    }
 
     GTiffDataset* poODS = new GTiffDataset();
     poODS->ShareLockWithParentDataset(this);
     poODS->m_pszFilename = CPLStrdup(m_pszFilename);
     poODS->m_nJpegQuality = static_cast<signed char>(l_nJpegQuality);
-    poODS->m_nWebPLevel = static_cast<signed char>(l_nWebPLevel);
-    poODS->m_nZLevel = m_nZLevel;
+    poODS->m_nWebPLevel = static_cast<signed char>(nWebpLevel);
+    poODS->m_nZLevel = static_cast<signed char>(nZLevel);
     poODS->m_nLZMAPreset = m_nLZMAPreset;
-    poODS->m_nZSTDLevel = m_nZSTDLevel;
+    poODS->m_nZSTDLevel = static_cast<signed char>(nZSTDLevel);
     poODS->m_bWebPLossless = m_bWebPLossless;
     poODS->m_nJpegTablesMode = m_nJpegTablesMode;
-    poODS->m_dfMaxZError = m_dfMaxZError;
+    poODS->m_dfMaxZError = dfMaxZError;
     memcpy(poODS->m_anLercAddCompressionAndVersion, m_anLercAddCompressionAndVersion,
            sizeof(m_anLercAddCompressionAndVersion));
 #ifdef HAVE_JXL
@@ -10196,13 +10282,6 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS,
             nOvrJpegQuality =
                 atoi(CPLGetConfigOption("JPEG_QUALITY_OVERVIEW","75"));
         }
-        int nOvrWebpLevel = m_nWebPLevel;
-        if( l_nCompression == COMPRESSION_WEBP &&
-            CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr ) != nullptr )
-        {
-            nOvrWebpLevel =
-                atoi(CPLGetConfigOption("WEBP_LEVEL_OVERVIEW","75"));
-        }
 
         CPLString osNoData; // don't move this in inner scope
         const char* pszNoData = nullptr;
@@ -10235,7 +10314,8 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS,
         if( nOverviewOffset == 0 )
             eErr = CE_Failure;
         else
-            eErr = RegisterNewOverviewDataset(nOverviewOffset, nOvrJpegQuality, nOvrWebpLevel);
+            eErr = RegisterNewOverviewDataset(nOverviewOffset,
+                                              nOvrJpegQuality);
     }
 
     // For directory reloading, so that the chaining to the next directory is
@@ -10610,13 +10690,6 @@ CPLErr GTiffDataset::IBuildOverviews(
                 nOvrJpegQuality =
                     atoi(CPLGetConfigOption("JPEG_QUALITY_OVERVIEW","75"));
             }
-            int nOvrWebpLevel = m_nWebPLevel;
-            if( m_nCompression == COMPRESSION_WEBP &&
-                CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr ) != nullptr )
-            {
-                nOvrWebpLevel =
-                    atoi(CPLGetConfigOption("WEBP_LEVEL_OVERVIEW","75"));
-            }
 
             CPLString osNoData; // don't move this in inner scope
             const char* pszNoData = nullptr;
@@ -10649,8 +10722,7 @@ CPLErr GTiffDataset::IBuildOverviews(
                 eErr = CE_Failure;
             else
                 eErr = RegisterNewOverviewDataset(nOverviewOffset,
-                                                  nOvrJpegQuality,
-                                                  nOvrWebpLevel);
+                                                  nOvrJpegQuality);
         }
     }
 

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -10230,10 +10230,7 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset* poSrcDS,
                                     CPLSPrintf("%d", m_nJpegTablesMode),
                                     pszNoData,
                                     m_anLercAddCompressionAndVersion,
-                                    m_bWriteCOGLayout,
-                                    nOvrWebpLevel >= 0 ?
-                                        CPLSPrintf("%d", nOvrWebpLevel) : nullptr
-                                   );
+                                    m_bWriteCOGLayout);
 
         if( nOverviewOffset == 0 )
             eErr = CE_Failure;
@@ -10329,8 +10326,7 @@ CPLErr GTiffDataset::CreateInternalMaskOverviews(int nOvrBlockXSize,
                         nullptr, nullptr, nullptr, 0, nullptr,
                         "",
                         nullptr, nullptr, nullptr, nullptr,
-                        m_bWriteCOGLayout,
-                        nullptr );
+                        m_bWriteCOGLayout);
 
                 if( nOverviewOffset == 0 )
                 {
@@ -10646,9 +10642,7 @@ CPLErr GTiffDataset::IBuildOverviews(
                     CPLSPrintf("%d", m_nJpegTablesMode),
                     pszNoData,
                     m_anLercAddCompressionAndVersion,
-                    false,
-                    nOvrWebpLevel >= 0 ?
-                                CPLSPrintf("%d", nOvrWebpLevel) : nullptr
+                    false
             );
 
             if( nOverviewOffset == 0 )
@@ -19555,7 +19549,7 @@ CPLErr GTiffDataset::CreateMaskBand(int nFlagsIn)
                 bIsTiled, l_nCompression,
                 PHOTOMETRIC_MASK, PREDICTOR_NONE,
                 SAMPLEFORMAT_UINT, nullptr, nullptr, nullptr, 0, nullptr, "", nullptr, nullptr,
-                nullptr, nullptr, m_bWriteCOGLayout, nullptr );
+                nullptr, nullptr, m_bWriteCOGLayout );
 
         ReloadDirectory();
 

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -85,9 +85,8 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
                             const char* pszJPEGQuality,
                             const char* pszJPEGTablesMode,
                             const char* pszNoData,
-                            CPL_UNUSED const uint32_t* panLercAddCompressionAndVersion,
-                            bool bDeferStrileArrayWriting,
-                            const char *pszWebpLevel)
+                            const uint32_t* panLercAddCompressionAndVersion,
+                            bool bDeferStrileArrayWriting)
 
 {
     const toff_t nBaseDirOffset = TIFFCurrentDirOffset( hTIFF );
@@ -169,13 +168,6 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
             // is a no-op (helps for cloud optimized geotiffs)
             TIFFSetField( hTIFF, TIFFTAG_YCBCRSUBSAMPLING, 2, 2 );
         }
-    }
-
-    if (nCompressFlag == COMPRESSION_WEBP  && pszWebpLevel != nullptr)
-    {
-        const int nWebpLevel = atoi(pszWebpLevel);
-        if ( nWebpLevel >= 1 )
-            TIFFSetField( hTIFF, TIFFTAG_WEBP_LEVEL, nWebpLevel );
     }
 
     if( nCompressFlag == COMPRESSION_LERC && panLercAddCompressionAndVersion )
@@ -947,10 +939,7 @@ GTIFFBuildOverviewsEx( const char * pszFilename,
                                 CPLGetConfigOption( "JPEG_TABLESMODE_OVERVIEW", nullptr ),
                              pszNoData,
                              nullptr,
-                             false,
-                             papszOptions ?
-                                CSLFetchNameValue(papszOptions, "WEBP_LEVEL") :
-                                CPLGetConfigOption( "WEBP_LEVEL_OVERVIEW", nullptr )
+                             false
                            ) == 0 )
         {
             XTIFFClose( hOTIFF );

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -515,6 +515,10 @@ GTIFFBuildOverviewsEx( const char * pszFilename,
         {
             nPlanarConfig = PLANARCONFIG_CONTIG;
         }
+        else if( nCompression == COMPRESSION_WEBP )
+        {
+            nPlanarConfig = PLANARCONFIG_CONTIG;
+        }
     }
 
     const char* pszInterleave = papszOptions ?

--- a/frmts/gtiff/gt_overview.h
+++ b/frmts/gtiff/gt_overview.h
@@ -56,8 +56,7 @@ toff_t GTIFFWriteDirectory( TIFF *hTIFF, int nSubfileType,
                             const char* pszJPEGTablesMode,
                             const char* pszNoData,
                             const uint32_t* panLercAddCompressionAndVersion,
-                            bool DeferStrileArrayWriting,
-                            const char * pszWebpLevel );
+                            bool bDeferStrileArrayWriting );
 
 void GTIFFBuildOverviewMetadata( const char *pszResampling,
                                  GDALDataset *poBaseDS,

--- a/frmts/gtiff/gtiff.h
+++ b/frmts/gtiff/gtiff.h
@@ -48,6 +48,9 @@ void    GTIFFGetOverviewBlockSize( GDALRasterBandH hBand, int* pnBlockXSize, int
 void    GTIFFSetJpegQuality( GDALDatasetH hGTIFFDS, int nJpegQuality );
 void    GTIFFSetWebPLevel( GDALDatasetH hGTIFFDS, int nWebPLevel );
 void    GTIFFSetJpegTablesMode( GDALDatasetH hGTIFFDS, int nJpegTablesMode );
+void    GTIFFSetZLevel( GDALDatasetH hGTIFFDS, int nZLevel );
+void    GTIFFSetZSTDLevel( GDALDatasetH hGTIFFDS, int nZSTDLevel );
+void    GTIFFSetMaxZError( GDALDatasetH hGTIFFDS, double dfMaxZError );
 int     GTIFFGetCompressionMethod( const char* pszValue,
                                    const char* pszVariableName );
 bool    GTIFFSupportsPredictor(int nCompression);


### PR DESCRIPTION
Fixes #4848

- COMPRESS_OVERVIEW configuration option now honours LERC_DEFLATE
  and LERC_ZSTD for external overviews
- MAX_Z_ERROR_OVERVIEW configuration option is added for LERC
  compressed internal and external overviews.
- ZLEVEL_OVERVIEW configuration option is added for DEFLATE/LERC_DEFLATE
  compressed internal and external overviews.
- ZSTD_LEVEL_OVERVIEW configuration option is added for ZSTD/LERC_ZSTD
  compressed internal and external overviews.