### PR TITLE
CMake: avoid warning messages for rdb and TileDB

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -22,14 +22,16 @@ include(CheckSymbolExists)
 # GDAL_USE_ is OFF.
 # Accept a RECOMMENDED option
 macro(gdal_check_package name purpose)
-    set(_options CAN_DISABLE RECOMMENDED DISABLED_BY_DEFAULT)
+    set(_options CONFIG CAN_DISABLE RECOMMENDED DISABLED_BY_DEFAULT)
     set(_oneValueArgs )
     set(_multiValueArgs COMPONENTS)
     cmake_parse_arguments(_GCP "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
     string(TOUPPER ${name} key)
     find_package2(${name} QUIET)
     if(NOT DEFINED ${key}_FOUND)
-        if(_GCP_COMPONENTS)
+        if(_GCP_CONFIG)
+            find_package(${name} CONFIG)
+        elseif(_GCP_COMPONENTS)
             find_package(${name} COMPONENTS ${_GCP_COMPONENTS})
         else()
             find_package(${name})
@@ -367,8 +369,8 @@ gdal_check_package(IDB "enable ogr_IDB driver")
 # TODO: implement FindRASDAMAN
 # libs: -lrasodmg -lclientcomm -lcompression -lnetwork -lraslib
 gdal_check_package(RASDAMAN "enable rasdaman driver")
-gdal_check_package(rdb "enable RIEGL RDB library" CAN_DISABLE)
-gdal_check_package(TileDB "enable TileDB driver" CAN_DISABLE)
+gdal_check_package(rdb "enable RIEGL RDB library" CONFIG CAN_DISABLE)
+gdal_check_package(TileDB "enable TileDB driver" CONFIG CAN_DISABLE)
 gdal_check_package(OpenEXR "OpenEXR >=2.2" CAN_DISABLE)
 
 # OpenJPEG's cmake-CONFIG is broken, so call module explicitly

--- a/cmake/modules/packages/FindRDB.cmake
+++ b/cmake/modules/packages/FindRDB.cmake
@@ -1,2 +1,0 @@
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(rdb CONFIG_MODE)


### PR DESCRIPTION
Fixes warnings like
```
CMake Warning at cmake/helpers/CheckDependentLibraries.cmake:35 (find_package):
  By not providing "Findrdb.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "rdb", but
  CMake did not find one.

  Could not find a package configuration file provided by "rdb" with any of
  the following names:

    rdbConfig.cmake
    rdb-config.cmake

  Add the installation prefix of "rdb" to CMAKE_PREFIX_PATH or set "rdb_DIR"
  to a directory containing one of the above files.  If "rdb" provides a
  separate development package or SDK, be sure it has been installed.
```

@tnixeu Could you check that this pull request still work with the rdb driver ? On Linux, I got the above warning due to different of case FindRDB.cmake vs 'rdb' in find_package() call. Renaming the file to Findrdb.cmake seemed to solve it, but there's no need to create a wrapper file if calling ``find_package(rdb CONFIG)``