### PR TITLE
/vsiaz/: read credentials from ~/.azure/config as an additional fallback method

### DIFF
--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -49,11 +49,15 @@ def open_for_read(uri):
 def startup_and_cleanup():
 
     az_vars = {}
-    for var in ('AZURE_STORAGE_CONNECTION_STRING', 'AZURE_STORAGE_ACCOUNT',
-                'AZURE_STORAGE_ACCESS_KEY', 'AZURE_SAS', 'AZURE_NO_SIGN_REQUEST'):
+    for var, reset_val in (
+                ('AZURE_STORAGE_CONNECTION_STRING', None),
+                ('AZURE_STORAGE_ACCOUNT', None),
+                ('AZURE_STORAGE_ACCESS_KEY', None),
+                ('AZURE_STORAGE_SAS_TOKEN', None),
+                ('AZURE_NO_SIGN_REQUEST', None),
+                ('AZURE_CONFIG_DIR', '')):
         az_vars[var] = gdal.GetConfigOption(var)
-        if az_vars[var] is not None:
-            gdal.SetConfigOption(var, "")
+        gdal.SetConfigOption(var, reset_val)
 
     assert gdal.GetSignedURL('/vsiaz/foo/bar') is None
 
@@ -69,8 +73,6 @@ def startup_and_cleanup():
 
     gdal.SetConfigOption('AZURE_STORAGE_CONNECTION_STRING',
                          'DefaultEndpointsProtocol=http;AccountName=myaccount;AccountKey=MY_ACCOUNT_KEY;EndpointSuffix=127.0.0.1:%d' % gdaltest.webserver_port)
-    gdal.SetConfigOption('AZURE_STORAGE_ACCOUNT', '')
-    gdal.SetConfigOption('AZURE_STORAGE_ACCESS_KEY', '')
     gdal.SetConfigOption('CPL_AZURE_TIMESTAMP', 'my_timestamp')
 
     yield
@@ -294,7 +296,7 @@ def test_vsiaz_fake_readdir():
     assert dir_contents == ['mycontainer1', 'mycontainer2']
 
 ###############################################################################
-# Test AZURE_SAS option with fake server
+# Test AZURE_STORAGE_SAS_TOKEN option with fake server
 
 
 def test_vsiaz_sas_fake():
@@ -304,7 +306,11 @@ def test_vsiaz_sas_fake():
 
     gdal.VSICurlClearCache()
 
-    with gdaltest.config_options({ 'AZURE_STORAGE_ACCOUNT': 'test', 'AZURE_SAS': 'sig=sas', 'CPL_AZURE_ENDPOINT' : '127.0.0.1:%d' % gdaltest.webserver_port, 'CPL_AZURE_USE_HTTPS': 'NO', 'AZURE_STORAGE_CONNECTION_STRING': ''}):
+    with gdaltest.config_options({'AZURE_STORAGE_ACCOUNT': 'test',
+                                  'AZURE_STORAGE_SAS_TOKEN': 'sig=sas',
+                                  'CPL_AZURE_ENDPOINT' : '127.0.0.1:%d' % gdaltest.webserver_port,
+                                  'CPL_AZURE_USE_HTTPS': 'NO',
+                                  'AZURE_STORAGE_CONNECTION_STRING': ''}):
 
         handler = webserver.SequentialHandler()
 
@@ -1390,3 +1396,141 @@ def test_vsiaz_fake_metadata():
     handler.add('PUT', '/azure/blob/myaccount/test/foo.bin?comp=metadata', 404)
     with webserver.install_http_handler(handler):
         assert not gdal.SetFileMetadata('/vsiaz/test/foo.bin', {'x-ms-meta-foo': 'bar'}, 'METADATA')
+
+
+###############################################################################
+# Read credentials from configuration file
+
+
+def test_vsiaz_read_credentials_config_file_connection_string():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    config_content = """
+[unrelated]
+account=foo
+[storage]
+connection_string = DefaultEndpointsProtocol=http;AccountName=myaccount2;AccountKey=MY_ACCOUNT_KEY;EndpointSuffix=127.0.0.1:%d
+""" % gdaltest.webserver_port
+
+    with gdaltest.tempfile('/vsimem/azure_config_dir/config', config_content), \
+         gdaltest.config_options({'AZURE_STORAGE_CONNECTION_STRING': None,
+                                  'AZURE_CONFIG_DIR': '/vsimem/azure_config_dir'}):
+        handler = webserver.SequentialHandler()
+        handler.add('GET', '/azure/blob/myaccount2/az_fake_bucket/resource', 200,
+                    {'Content-Length': 3},
+                    'foo',
+                    expected_headers={'Authorization': 'SharedKey myaccount2:LCgZcIfQT/du4Xsdv8ZHT1yi+Qrmaw0IxNdI1Cldy+w='})
+        with webserver.install_http_handler(handler):
+            f = open_for_read('/vsiaz/az_fake_bucket/resource')
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode('ascii')
+            gdal.VSIFCloseL(f)
+
+        assert data == 'foo'
+
+
+###############################################################################
+# Read credentials from configuration file
+
+
+def test_vsiaz_read_credentials_config_file_account_and_key():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    config_content = """
+[unrelated]
+account=foo
+[storage]
+account = myaccount2
+key = MY_ACCOUNT_KEY
+"""
+
+    with gdaltest.tempfile('/vsimem/azure_config_dir/config', config_content), \
+         gdaltest.config_options({'AZURE_STORAGE_CONNECTION_STRING': None,
+                                  'CPL_AZURE_ENDPOINT': '127.0.0.1:%d' % gdaltest.webserver_port,
+                                  'CPL_AZURE_USE_HTTPS': 'NO',
+                                  'AZURE_CONFIG_DIR': '/vsimem/azure_config_dir'}):
+        handler = webserver.SequentialHandler()
+        handler.add('GET', '/azure/blob/myaccount2/az_fake_bucket/resource', 200,
+                    {'Content-Length': 3},
+                    'foo',
+                    expected_headers={'Authorization': 'SharedKey myaccount2:LCgZcIfQT/du4Xsdv8ZHT1yi+Qrmaw0IxNdI1Cldy+w='})
+        with webserver.install_http_handler(handler):
+            f = open_for_read('/vsiaz/az_fake_bucket/resource')
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode('ascii')
+            gdal.VSIFCloseL(f)
+
+        assert data == 'foo'
+
+
+###############################################################################
+# Read credentials from configuration file
+
+
+def test_vsiaz_read_credentials_config_file_account_and_sas_token():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    config_content = """
+[unrelated]
+account=foo
+[storage]
+account = myaccount2
+sas_token = sig=sas
+"""
+
+    with gdaltest.tempfile('/vsimem/azure_config_dir/config', config_content), \
+         gdaltest.config_options({'AZURE_STORAGE_CONNECTION_STRING': None,
+                                  'CPL_AZURE_ENDPOINT': '127.0.0.1:%d' % gdaltest.webserver_port,
+                                  'CPL_AZURE_USE_HTTPS': 'NO',
+                                  'AZURE_CONFIG_DIR': '/vsimem/azure_config_dir'}):
+        handler = webserver.SequentialHandler()
+        handler.add('GET', '/azure/blob/myaccount2/az_fake_bucket/resource?sig=sas', 200,
+                    {'Content-Length': 3},
+                    'foo')
+        with webserver.install_http_handler(handler):
+            f = open_for_read('/vsiaz/az_fake_bucket/resource')
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode('ascii')
+            gdal.VSIFCloseL(f)
+
+        assert data == 'foo'
+
+
+###############################################################################
+# Read credentials from configuration file
+
+
+def test_vsiaz_read_credentials_config_file_missing_account():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    config_content = """
+[unrelated]
+account=foo
+[storage]
+"""
+
+    with gdaltest.tempfile('/vsimem/azure_config_dir/config', config_content), \
+         gdaltest.config_options({'AZURE_STORAGE_CONNECTION_STRING': None,
+                                  'CPL_AZURE_ENDPOINT': '127.0.0.1:%d' % gdaltest.webserver_port,
+                                  'CPL_AZURE_USE_HTTPS': 'NO',
+                                  'AZURE_CONFIG_DIR': '/vsimem/azure_config_dir'}):
+        handler = webserver.SequentialHandler()
+        with webserver.install_http_handler(handler):
+            f = open_for_read('/vsiaz/az_fake_bucket/resource')
+            assert f is None

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -223,7 +223,7 @@ Several authentication methods are possible, and are attempted in the following 
 
 1. If :decl_configoption:`AWS_NO_SIGN_REQUEST=YES` configuration option is set, request signing is disabled. This option might be used for buckets with public access rights. Available since GDAL 2.3
 2. The :decl_configoption:`AWS_SECRET_ACCESS_KEY` and :decl_configoption:`AWS_ACCESS_KEY_ID` configuration options can be set. The :decl_configoption:`AWS_SESSION_TOKEN` configuration option must be set when temporary credentials are used.
-3. Starting with GDAL 2.3, alternate ways of providing credentials similar to what the "aws" command line utility or Boto3 support can be used. If the above mentioned environment variables are not provided, the ``~/.aws/credentials`` or ``UserProfile%/.aws/credentials`` file will be read (or the file pointed by :decl_configoption:`CPL_AWS_CREDENTIALS_FILE`). The profile may be specified with the :decl_configoption:`AWS_DEFAULT_PROFILE` environment variable, or starting with GDAL 3.2 with the :decl_configoption:`AWS_PROFILE` environment variable (the default profile is "default").
+3. Starting with GDAL 2.3, alternate ways of providing credentials similar to what the "aws" command line utility or Boto3 support can be used. If the above mentioned environment variables are not provided, the ``~/.aws/credentials`` or ``%UserProfile%/.aws/credentials`` file will be read (or the file pointed by :decl_configoption:`CPL_AWS_CREDENTIALS_FILE`). The profile may be specified with the :decl_configoption:`AWS_DEFAULT_PROFILE` environment variable, or starting with GDAL 3.2 with the :decl_configoption:`AWS_PROFILE` environment variable (the default profile is "default").
 4. The ``~/.aws/config`` or ``%UserProfile%/.aws/config`` file may also be used (or the file pointer by :decl_configoption:`AWS_CONFIG_FILE`) to retrieve credentials and the AWS region.
 5. If none of the above method succeeds, instance profile credentials will be retrieved when GDAL is used on EC2 instances.
 
@@ -329,12 +329,15 @@ The generalities of :ref:`/vsicurl/ </vsicurl/>` apply.
 Several authentication methods are possible, and are attempted in the following order:
 
 1. The :decl_configoption:`AZURE_STORAGE_CONNECTION_STRING` configuration option, given in the access key section of the administration interface. It contains both the account name and a secret key.
+
 2. The :decl_configoption:`AZURE_STORAGE_ACCOUNT` configuration option is set to specify the account name AND
 
     a) The :decl_configoption:`AZURE_STORAGE_ACCESS_KEY` configuration option is set to specify the secret key.
     b) The :decl_configoption:`AZURE_NO_SIGN_REQUEST=YES` configuration option is set, so as to disable any request signing. This option might be used for accounts with public access rights. Available since GDAL 3.2
-    c) The :decl_configoption:`AZURE_SAS` configuration option is set to specify a Shared Access Signature. This SAS is appended to URLs built by the /vsiaz/ file system handler. Its value should already be URL-encoded and should not contain any leading '?' or '&' character (e.g. a valid one may look like "st=2019-07-18T03%3A53%3A22Z&se=2035-07-19T03%3A53%3A00Z&sp=rl&sv=2018-03-28&sr=c&sig=2RIXmLbLbiagYnUd49rgx2kOXKyILrJOgafmkODhRAQ%3D"). Available since GDAL 3.2
+    c) The :decl_configoption:`AZURE_STORAGE_SAS_TOKEN` configuration option (``AZURE_SAS`` if GDAL < 3.5) is set to specify a Shared Access Signature. This SAS is appended to URLs built by the /vsiaz/ file system handler. Its value should already be URL-encoded and should not contain any leading '?' or '&' character (e.g. a valid one may look like "st=2019-07-18T03%3A53%3A22Z&se=2035-07-19T03%3A53%3A00Z&sp=rl&sv=2018-03-28&sr=c&sig=2RIXmLbLbiagYnUd49rgx2kOXKyILrJOgafmkODhRAQ%3D"). Available since GDAL 3.2
     d) The current machine is a Azure Virtual Machine with Azure Active Directory permissions assigned to it (see https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm). Available since GDAL 3.3
+
+3. Starting with GDAL 3.5, the `configuration file <https://github.com/MicrosoftDocs/azure-docs-cli/blob/main/docs-ref-conceptual/azure-cli-configuration.md>` of the "az" command line utility can be used. The following keys of the ``[storage]`` section will be used in the following priority: ``connection_string``, ``account`` + ``key`` or ``account`` + ``sas_token``
 
 Since GDAL 3.1, the :cpp:func:`VSIRename` operation is supported (first doing a copy of the original file and then deleting it)
 

--- a/port/cpl_azure.h
+++ b/port/cpl_azure.h
@@ -47,7 +47,7 @@ class VSIAzureBlobHandleHelper final: public IVSIS3LikeHandleHelper
         CPLString m_osStorageKey;
         CPLString m_osSAS;
         bool      m_bUseHTTPS;
-        bool      m_bFromManagedIdendities;
+        bool      m_bFromManagedIdentities;
 
         enum class Service
         {
@@ -63,9 +63,6 @@ class VSIAzureBlobHandleHelper final: public IVSIS3LikeHandleHelper
                                          CPLString& osStorageKey,
                                          CPLString& osSAS,
                                          bool& bFromManagedIdentities);
-
-        static bool     GetConfigurationFromManagedIdentities(
-                                                    CPLString& osAccessToken);
 
         static CPLString BuildURL(const CPLString& osEndpoint,
                                   const CPLString& osStorageAccount,


### PR DESCRIPTION
Also taken into account the AZURE_STORAGE_SAS_TOKEN configuration
option, instead of the now deprecated AZURE_SAS one, to be consistent
with the convention used by the az CLI.
