### PR TITLE
Add initial support for Emoji as driver names

### DIFF
--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -327,6 +327,9 @@ typedef struct GDALDimensionHS* GDALDimensionH;
 /** Long name of the driver */
 #define GDAL_DMD_LONGNAME "DMD_LONGNAME"
 
+/** Emoji of the driver */
+#define GDAL_DMD_EMOJI "DMD_EMOJI"
+
 /** URL (relative to http://gdal.org/) to the help page of the driver */
 #define GDAL_DMD_HELPTOPIC "DMD_HELPTOPIC"
 

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -3206,6 +3206,11 @@ GDALGeneralCmdLineProcessor( int nArgc, char ***ppapszArgv, int nOptions )
             printf( "  Long Name: %s\n", GDALGetDriverLongName( hDriver ) );/*ok*/
 
             papszMD = GDALGetMetadata( hDriver, nullptr );
+
+            const char* pszEmoji = CSLFetchNameValue( papszMD, GDAL_DMD_EMOJI );
+            if( pszEmoji )
+                printf( "  Emoji: %s\n", pszEmoji );/*ok*/
+
             if( CPLFetchBool( papszMD, GDAL_DCAP_RASTER, false ) )
                 printf( "  Supports: Raster\n" );/*ok*/
             if( CPLFetchBool( papszMD, GDAL_DCAP_MULTIDIM_RASTER, false ) )

--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -507,6 +507,19 @@ int GDALDriverManager::RegisterDriver( GDALDriver * poDriver )
 
     oMapNameToDrivers[CPLString(poDriver->GetDescription()).toupper()] =
         poDriver;
+    const char* pszEmoji = poDriver->GetMetadataItem( GDAL_DMD_EMOJI );
+    if( pszEmoji )
+    {
+        if( oMapNameToDrivers.find(pszEmoji) == oMapNameToDrivers.end() )
+        {
+            oMapNameToDrivers[pszEmoji] = poDriver;
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Another driver has set %s has emoji", pszEmoji);
+        }
+    }
 
     int iResult = nDrivers - 1;
 
@@ -562,6 +575,13 @@ void GDALDriverManager::DeregisterDriver( GDALDriver * poDriver )
         return;
 
     oMapNameToDrivers.erase(CPLString(poDriver->GetDescription()).toupper());
+
+    const char* pszEmoji = poDriver->GetMetadataItem( GDAL_DMD_EMOJI );
+    if( pszEmoji )
+    {
+        oMapNameToDrivers.erase(pszEmoji);
+    }
+
     --nDrivers;
     // Move all following drivers down by one to pack the list.
     while( i < nDrivers )

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -321,12 +321,13 @@ int OGRPGDataSource::Open( const char * pszNewName, int bUpdate,
     }
     else
     if( !STARTS_WITH_CI(pszNewName, "PG:") &&
+        !STARTS_WITH_CI(pszNewName, "🐘") &&
         !STARTS_WITH(pszNewName, "postgresql://") )
     {
         if( !bTestOpen )
             CPLError( CE_Failure, CPLE_AppDefined,
                       "%s does not conform to PostgreSQL naming convention,"
-                      " PG:* or postgresql://\n", pszNewName );
+                      " PG:*, 🐘:* or postgresql://\n", pszNewName );
         return FALSE;
     }
 
@@ -524,7 +525,8 @@ int OGRPGDataSource::Open( const char * pszNewName, int bUpdate,
     char* pszConnectionName = CPLStrdup(osConnectionName);
     char* pszConnectionNameNoPrefix = pszConnectionName +
         (STARTS_WITH_CI(pszConnectionName, "PGB:") ? 4 :
-         STARTS_WITH_CI(pszConnectionName, "PG:") ? 3 : 0);
+         STARTS_WITH_CI(pszConnectionName, "PG:") ? 3 :
+         STARTS_WITH_CI(pszConnectionName, "🐘:") ? strlen("🐘:") : 0);
 
 /* -------------------------------------------------------------------- */
 /*      Determine if the connection string contains an optional         */

--- a/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
@@ -39,6 +39,7 @@ static int OGRPGDriverIdentify( GDALOpenInfo* poOpenInfo )
 {
     if( !STARTS_WITH_CI(poOpenInfo->pszFilename, "PGB:") &&
         !STARTS_WITH_CI(poOpenInfo->pszFilename, "PG:")&&
+        !STARTS_WITH_CI(poOpenInfo->pszFilename, "🐘")&&
         !STARTS_WITH(poOpenInfo->pszFilename, "postgresql://")  )
         return FALSE;
     return TRUE;
@@ -110,6 +111,7 @@ void RegisterOGRPG()
 
     poDriver->SetDescription( "PostgreSQL" );
     poDriver->SetMetadataItem( GDAL_DMD_LONGNAME, "PostgreSQL/PostGIS" );
+    poDriver->SetMetadataItem( GDAL_DMD_EMOJI, "🐘");
     poDriver->SetMetadataItem( GDAL_DCAP_VECTOR, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_HELPTOPIC, "drivers/vector/pg.html" );
     poDriver->SetMetadataItem( GDAL_DMD_CONNECTION_PREFIX, "PG:" );


### PR DESCRIPTION
Due to popular demand
(https://twitter.com/sgillies/status/1463587111605473282), support Emoji
as an alias for driver name.

Prototyped with PostgreSQL

$ ogrinfo --format postgresql
Format Details:
  Short Name: PostgreSQL
  Long Name: PostgreSQL/PostGIS
  Emoji: 🐘
  Supports: Vector

$ ogrinfo --format 🐘
Format Details:
  Short Name: PostgreSQL
  Long Name: PostgreSQL/PostGIS
  Emoji: 🐘
  Supports: Vector

$ ogrinfo 🐘:dbname=autotest
INFO: Open of `🐘:dbname=autotest'
      using driver `PostgreSQL' successful.
1: poly (Polygon)

$ ogr2ogr -f 🐘 🐘:dbname=autotest autotest/ogr/data/poly.shp
