### PR TITLE
Fixing some raw.githubusercontent url's in documentation

### DIFF
--- a/doc/source/drivers/raster/bag.rst
+++ b/doc/source/drivers/raster/bag.rst
@@ -216,7 +216,7 @@ missing, the uncertainty will be set to nodata.
 
 The driver will instantiate the BAG XML metadata by using a template
 file, which is by default,
-`bag_template.xml <https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/data/bag_template.xml>`__,
+`bag_template.xml <https://raw.githubusercontent.com/OSGeo/gdal/master/data/bag_template.xml>`__,
 found in the GDAL data definition files. This template contains
 variables, present as ${KEYNAME} or ${KEYNAME:default_value} in the XML
 file, that can be substituted by providing a creation option whose name

--- a/doc/source/drivers/raster/pdf.rst
+++ b/doc/source/drivers/raster/pdf.rst
@@ -380,7 +380,7 @@ datatype = GDT_Unknown and COMPOSITION_FILE must be the single creation
 option.
 
 The XML schema against which the composition file must validate is
-`pdfcomposition.xsd <https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/data/pdfcomposition.xsd>`__
+`pdfcomposition.xsd <https://raw.githubusercontent.com/OSGeo/gdal/master/data/pdfcomposition.xsd>`__
 
 Example on how to use the API:
 
@@ -393,7 +393,7 @@ Example on how to use the API:
    CSLDestroy(papszOptions);
 
 A sample Python script
-`gdal_create_pdf.py <https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/swig/python/gdal-utils/osgeo_utils/samples/gdal_create_pdf.py>`__
+`gdal_create_pdf.py <https://raw.githubusercontent.com/OSGeo/gdal/master/swig/python/gdal-utils/osgeo_utils/samples/gdal_create_pdf.py>`__
 is also available. Starting with GDAL 3.2, the :ref:`gdal_create` utility can
 also be used.
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -53,7 +53,7 @@ for developers.
 .vrt Format
 -----------
 
-A `XML schema of the GDAL VRT format <https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/data/gdalvrt.xsd>`_
+A `XML schema of the GDAL VRT format <https://raw.githubusercontent.com/OSGeo/gdal/master/data/gdalvrt.xsd>`_
 is available.
 
 Virtual files stored on disk are kept in an XML format with the following

--- a/doc/source/drivers/raster/vrt_multidimensional.rst
+++ b/doc/source/drivers/raster/vrt_multidimensional.rst
@@ -36,7 +36,7 @@ Here's an example of such a file:
 .vrt Format
 -----------
 
-A `XML schema of the GDAL VRT format <https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/data/gdalvrt.xsd>`_
+A `XML schema of the GDAL VRT format <https://raw.githubusercontent.com/OSGeo/gdal/master/data/gdalvrt.xsd>`_
 is available.
 
 Virtual files stored on disk are kept in an XML format with the following

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -32,4 +32,4 @@ DEALINGS IN THE SOFTWARE.
 
 The full licensing terms are available in the `LICENSE.TXT`_ file.
 
-.. _`LICENSE.TXT`: https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/LICENSE.TXT
+.. _`LICENSE.TXT`: https://raw.githubusercontent.com/OSGeo/gdal/master/LICENSE.TXT


### PR DESCRIPTION
## What does this PR do?

Hitting a 404 on https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/data/gdalvrt.xsd

I thought to fix it, and tried to find all failing raw.githubusercontent url's in the doc sources