### PR TITLE
Smarter GDALDriver::CreateCopy()

### DIFF
--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -1207,6 +1207,7 @@ namespace tut
             ensure( poSrcDS != nullptr );
             auto tmpFilename = "/vsimem/tmp.tif";
             const char* options [] = { "-srcwin", "0", "0", "48", "32",
+                                       "-co", "INTERLEAVE=PIXEL",
                                        "-co", "TILED=YES",
                                        "-co", "BLOCKXSIZE=48",
                                        "-co", "BLOCKYSIZE=32", nullptr };

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -1010,7 +1010,7 @@ def test_rasterio_dataset_invalid_resample_alg(resample_alg):
 def test_rasterio_floating_point_window_no_resampling():
     """ Test fix for #3101 """
 
-    ds = gdal.Translate('/vsimem/test.tif', gdal.Open('data/rgbsmall.tif'))
+    ds = gdal.Translate('/vsimem/test.tif', gdal.Open('data/rgbsmall.tif'), options = '-co INTERLEAVE=PIXEL')
     assert ds.GetMetadataItem('INTERLEAVE', 'IMAGE_STRUCTURE') == 'PIXEL'
 
     # Check that GDALDataset::IRasterIO() in block-based strategy behaves the
@@ -1027,7 +1027,7 @@ def test_rasterio_floating_point_window_no_resampling_numpy():
     # Same as above but using ReadAsArray() instead of ReadRaster()
     numpy = pytest.importorskip('numpy')
 
-    ds = gdal.Translate('/vsimem/test.tif', gdal.Open('data/rgbsmall.tif'))
+    ds = gdal.Translate('/vsimem/test.tif', gdal.Open('data/rgbsmall.tif'), options = '-co INTERLEAVE=PIXEL')
     assert ds.GetMetadataItem('INTERLEAVE', 'IMAGE_STRUCTURE') == 'PIXEL'
 
     data_per_band = numpy.stack([ds.GetRasterBand(i+1).ReadAsArray(0.1,0.2,10.4,11.4,buf_xsize=10,buf_ysize=11) for i in range(3)])

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -258,6 +258,17 @@ def test_pds4_7():
     return ret
 
 ###############################################################################
+# Test CreateCopy() from BIL to IMAGE_FORMAT=GEOTIFF doesn't result in error
+
+
+def test_pds4_from_bil_to_geotiff():
+
+    tst = gdaltest.GDALTest('PDS4', 'envi/envi_rgbsmall_bil.img', 2, 20669, options=['IMAGE_FORMAT=GEOTIFF'])
+    with hide_substitution_warnings_error_handler():
+        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
+    return ret
+
+###############################################################################
 # Test SRS support
 
 @pytest.mark.parametrize('proj4str', ['+proj=eqc +lat_ts=43.75 +lat_0=10 +lon_0=-112.5 +x_0=0 +y_0=0 +R=2439400 +units=m +no_defs',

--- a/doc/source/drivers/raster/envi.rst
+++ b/doc/source/drivers/raster/envi.rst
@@ -30,6 +30,11 @@ Creation Options:
 -  **INTERLEAVE=BSQ/BIP/BIL**: Force the generation specified type of
    interleaving. **BSQ** -- band sequential (default), **BIP** --- data
    interleaved by pixel, **BIL** -- data interleaved by line.
+   Starting with GDAL 3.5, when copying from a source dataset with multiple bands
+   which advertises a INTERLEAVE metadata item, if the INTERLEAVE creation option
+   is not specified, the source dataset INTERLEAVE will be automatically taken
+   into account.
+
 -  **SUFFIX=REPLACE/ADD**: Force adding ".hdr" suffix to supplied
    filename, e.g. if user selects "file.bin" name for output dataset,
    "file.bin.hdr" header file will be created. By default header file

--- a/doc/source/drivers/raster/georaster.rst
+++ b/doc/source/drivers/raster/georaster.rst
@@ -23,7 +23,7 @@ Where:
 | user   = Oracle server user's name login
 | pwd    = user password
 | db     = Oracle server identification (database name)
-| schema = name of a schema                      
+| schema = name of a schema
 | table  = name of a GeoRaster table (table that contains GeoRaster
   columns)
 | column = name of a column data type MDSYS.SDO_GEORASTER
@@ -114,7 +114,11 @@ Creation Options
 -  SRID: Assign a specific EPSG projection/reference system
    identification to the GeoRaster.
 -  **INTERLEAVE**: Band interleaving mode, BAND, LINE, PIXEL (or BSQ,
-   BIL, BIP) for band sequential, Line or Pixel interleaving. 
+   BIL, BIP) for band sequential, Line or Pixel interleaving.
+   Starting with GDAL 3.5, when copying from a source dataset with multiple bands
+   which advertises a INTERLEAVE metadata item, if the INTERLEAVE creation option
+   is not specified, the source dataset INTERLEAVE will be automatically taken
+   into account, unless the COMPRESS creation option is specified.
 -  **DESCRIPTION**: A simple description of a newly created table in SQL
    syntax. If the table already exist, this create option will be
    ignored, e.g.:

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -358,6 +358,10 @@ Creation Options
    These are slightly less efficient than BAND interleaving for some
    purposes, but some applications only support pixel interleaved TIFF
    files.
+   Starting with GDAL 3.5, when copying from a source dataset with multiple bands
+   which advertises a INTERLEAVE metadata item, if the INTERLEAVE creation option
+   is not specified, the source dataset INTERLEAVE will be automatically taken
+   into account, unless the COMPRESS creation option is specified.
 
 -  **TILED=YES**: By default striped TIFF files are created. This
    option can be used to force creation of tiled TIFF files.

--- a/doc/source/drivers/raster/paux.rst
+++ b/doc/source/drivers/raster/paux.rst
@@ -21,6 +21,10 @@ Creation Options:
 
 -  **INTERLEAVE=PIXEL/LINE/BAND**: Establish output interleaving, the
    default is BAND.
+   Starting with GDAL 3.5, when copying from a source dataset with multiple bands
+   which advertises a INTERLEAVE metadata item, if the INTERLEAVE creation option
+   is not specified, the source dataset INTERLEAVE will be automatically taken
+   into account.
 
 NOTE: Implemented as ``gdal/frmts/raw/pauxdataset.cpp``.
 

--- a/doc/source/drivers/raster/pds4.rst
+++ b/doc/source/drivers/raster/pds4.rst
@@ -98,7 +98,11 @@ The following dataset creation options are available:
    -  **INTERLEAVE**\ =BSQ/BIP/BIL. Pixel organization in the image
       file. BSQ is Band SeQuential, BIP is Band Interleaved per Pixel
       and BIL is Band Interleave Per Line. The default is BSQ. BIL is
-      not valid for IMAGE_FORMAT=GEOTIFF
+      not valid for IMAGE_FORMAT=GEOTIFF.
+      Starting with GDAL 3.5, when copying from a source dataset with multiple bands
+      which advertises a INTERLEAVE metadata item, if the INTERLEAVE creation option
+      is not specified, the source dataset INTERLEAVE will be automatically taken
+      into account.
    -  **USE_SRC_LABEL**\ =YES/NO. Whether to use the source label in
       PDS4 to PDS4 conversions. Defaults to YES.
    -  **ARRAY_TYPE**\ =Array/Array_2D/Array_2D_Image/Array_2D_Map/

--- a/doc/source/drivers/raster/rraster.rst
+++ b/doc/source/drivers/raster/rraster.rst
@@ -29,7 +29,11 @@ attribute of the '[description]' section.
 The following creation options are supported:
 
 -  INTERLEAVE=BIP/BIL/BSQ. Respectively band interleaved by pixel, band
-   interleaved by line, band sequential. Default to BIL
+   interleaved by line, band sequential. Default to BIL.
+   Starting with GDAL 3.5, when copying from a source dataset with multiple bands
+   which advertises a INTERLEAVE metadata item, if the INTERLEAVE creation option
+   is not specified, the source dataset INTERLEAVE will be automatically taken
+   into account.
 -  PIXELTYPE=SIGNEDBYTE. To write Byte bands as signed byte instead of
    unsigned byte.
 

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -4370,11 +4370,18 @@ PDS4Dataset *PDS4Dataset::CreateInternal(const char *pszFilename,
     }
     else if( EQUAL(pszImageFormat, "GEOTIFF") )
     {
-        if( EQUAL(pszInterleave, "BIL") )
+        if( EQUAL(pszInterleave, "BIL"))
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "INTERLEAVE=BIL not supported for GeoTIFF in PDS4" );
-            return nullptr;
+            if( aosOptions.FetchBool("@INTERLEAVE_ADDED_AUTOMATICALLY", false) )
+            {
+                pszInterleave = "BSQ";
+            }
+            else
+            {
+                CPLError( CE_Failure, CPLE_AppDefined,
+                          "INTERLEAVE=BIL not supported for GeoTIFF in PDS4" );
+                return nullptr;
+            }
         }
         GDALDriver* poDrv = static_cast<GDALDriver*>(
                                             GDALGetDriverByName("GTiff"));

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -1011,7 +1011,7 @@ GDALDataset *GDALDriver::CreateCopy( const char * pszFilename,
             (CSLFindString(interleavesCSL, "PIXEL") >= 0) ? "PIXEL" :
             (CSLFindString(interleavesCSL, "BIP") >= 0) ? "BIP" :
             nullptr;
-        const char* dstInterleave = !srcInterleave ? 0 :
+        const char* dstInterleave = !srcInterleave ? nullptr :
             EQUAL(srcInterleave, "BAND") ? dstInterleaveBand :
             EQUAL(srcInterleave, "LINE") ? dstInterleaveLine :
             EQUAL(srcInterleave, "PIXEL") ? dstInterleavePixel :


### PR DESCRIPTION
Aims #4911

Better doc to explain how interleaving is handled by CreateCopy()

Added a system that tries to automatically match the src data interleaving by default, if not specified otherwise.

That might break backward compatibility for people that were relying on the default driver data interleaving when using CreateCopy() with no creation options.

~~The system is "fragile" regarding the different syntaxes for INTERLEAVE (BAND/PIXEL/LINE or BIP/BI/BSQ) and is currently hard coding BIP/BIL/BSQ for ENVI drivers only.~~
UPDATE : an XML parsing is performed to explore the declared INTERLEAVE syntaxes in the current driver creation options

