### PR TITLE
NITF: Add ISO-8859-1 decoding for file and image header metadata

### DIFF
--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -6358,7 +6358,7 @@ static const NITFFieldDescription asFieldDescription [] =
     {  8, "ICAT", "Image Category" } ,
     {  2, "ABPP", "Actual Bits-Per-Pixel Per Band" } ,
     {  1, "PJUST", "Pixel Justification" } ,
-    {780, "ICOM", "Image Comments (up to 9x80 characters)" } ,
+    {720, "ICOM", "Image Comments (up to 9x80 characters)" } ,
     {  3, "IDLVL", "Image Display Level" },
     {  3, "IALVL", "Image Attachment Level" },
     {  5, "ILOCROW", "Image Location Row" },

--- a/frmts/nitf/nitfimage.c
+++ b/frmts/nitf/nitfimage.c
@@ -361,9 +361,11 @@ NITFImage *NITFImageAccess( NITFFile *psFile, int iSegment )
         if ( (int)psSegInfo->nSegmentHeaderSize < nOffset + 80 * nNICOM )
             GOTO_header_too_small();
 
-        psImage->pszComments = (char *) CPLMalloc(nNICOM*80+1);
-        NITFGetField( psImage->pszComments, pachHeader,
-                      nOffset, 80 * nNICOM );
+        char *pszICOM = (char *) CPLMalloc(nNICOM*80+1);
+        psImage->pszComments = CPLRecode(
+            NITFGetField( pszICOM, pachHeader, nOffset, 80 * nNICOM ),
+            CPL_ENC_ISO8859_1, CPL_ENC_UTF8 );
+        CPLFree(pszICOM);
         nOffset += nNICOM * 80;
     }
 


### PR DESCRIPTION
## What does this PR do?
Updates the NITF driver metadata readers/writers to use ISO-8859-1 encoding per the NITF specification:
https://gwg.nga.mil/ntb/baseline/docs/2500c/index.html
- ECS-A definition on page 6, item 3
- Character set definition in Appendix D, Table D-1
- Example ECS-A fields are FTITLE, IID2, ICOM

Some file header and image header fields in the NITF specification allow extended ASCII characters encoded as ISO-8859-1.  Current GDAL behavior is to encode/decode those extended characters as UTF-8 resulting in invalid UTF-8 strings on read and incorrect NITF files on write.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
