### PR TITLE
KEA: print error message when opening of kea file fails

### DIFF
--- a/frmts/kea/keadataset.cpp
+++ b/frmts/kea/keadataset.cpp
@@ -151,9 +151,12 @@ GDALDataset *KEADataset::Open( GDALOpenInfo * poOpenInfo )
 
             return pDataset;
         }
-        catch (const kealib::KEAIOException &)
+        catch (const kealib::KEAIOException &e)
         {
             // was a problem - can't be a valid file
+            CPLError( CE_Failure, CPLE_OpenFailed,
+                  "Attempt to open file `%s' failed. Error: %s\n",
+                  poOpenInfo->pszFilename, e.what() );
             return nullptr;
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a situation when a file is identified as `kea` but can't be opened for any reason. This could be because it is corrupt or locked by `libhdf5` because the file is open elsewhere for update.

Previously, the file would fail to open with no message. Now provides the error from `libkea` (which in turns comes from `libhdf5`) which isn't always that useful but at least the user gets some feedback that the open was attempted but failed. Otherwise the user may think that the `kea` driver hasn't been built etc.

## What are related issues/pull requests?

https://github.com/ubarsc/kealib/pull/14

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed


