### PR TITLE
GTiff: propage SPARSE_OK to overviews (refs #4932)

### DIFF
--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -1432,6 +1432,118 @@ def test_tiff_ovr_45(both_endian):
     assert cs == 1087, 'did not get expected checksum'
 
 ###############################################################################
+# Test that SPARSE_OK creation option propagates on internal overviews
+
+
+@pytest.mark.parametrize("apply_sparse", [False,True])
+def test_tiff_ovr_propagate_sparse_ok_creation_option(apply_sparse):
+
+    filename = '/vsimem/test_tiff_ovr_propagate_sparse_ok_creation_option.tif'
+    ds = gdaltest.tiff_drv.Create(filename, 100, 100, options=['SPARSE_OK=YES'] if apply_sparse else [])
+    ds.BuildOverviews('NEAREST', overviewlist=[2])
+    ds = None
+    ds = gdal.Open(filename)
+    has_block = ds.GetRasterBand(1).GetOverview(0).GetMetadataItem("BLOCK_OFFSET_0_0", "TIFF") is not None
+    if apply_sparse:
+        assert not has_block
+    else:
+        assert has_block
+    ds = None
+
+    gdaltest.tiff_drv.Delete(filename)
+
+###############################################################################
+# Test that SPARSE_OK open option propagates on internal overviews
+
+
+@pytest.mark.parametrize("apply_sparse", [False,True])
+def test_tiff_ovr_propagate_sparse_ok_open_option_internal(apply_sparse):
+
+    filename = '/vsimem/test_tiff_ovr_propagate_sparse_ok_open_option_internal.tif'
+    gdaltest.tiff_drv.Create(filename, 100, 100)
+    ds = gdal.OpenEx(filename, gdal.OF_UPDATE | gdal.OF_RASTER, open_options=['SPARSE_OK=YES'] if apply_sparse else [])
+    ds.BuildOverviews('NEAREST', overviewlist=[2])
+    ds = None
+    ds = gdal.Open(filename)
+    has_block = ds.GetRasterBand(1).GetOverview(0).GetMetadataItem("BLOCK_OFFSET_0_0", "TIFF") is not None
+    if apply_sparse:
+        assert not has_block
+    else:
+        assert has_block
+    ds = None
+
+    gdaltest.tiff_drv.Delete(filename)
+
+###############################################################################
+# Test that SPARSE_OK open option propagates on internal overviews
+
+
+@pytest.mark.parametrize("apply_sparse", [False,True])
+def test_tiff_ovr_propagate_sparse_ok_open_option_external(apply_sparse):
+
+    filename = '/vsimem/test_tiff_ovr_propagate_sparse_ok_open_option_external.tif'
+    gdaltest.tiff_drv.Create(filename, 100, 100)
+    ds = gdal.OpenEx(filename, open_options = ['SPARSE_OK=YES'] if apply_sparse else [])
+    ds.BuildOverviews('NEAREST', overviewlist=[2])
+    ds = None
+    ds = gdal.Open(filename)
+    has_block = ds.GetRasterBand(1).GetOverview(0).GetMetadataItem("BLOCK_OFFSET_0_0", "TIFF") is not None
+    if apply_sparse:
+        assert not has_block
+    else:
+        assert has_block
+    ds = None
+
+    gdaltest.tiff_drv.Delete(filename)
+
+###############################################################################
+# Test SPARSE_OK_OVERVIEW on internal overview
+
+
+@pytest.mark.parametrize("apply_sparse", [False,True])
+def test_tiff_ovr_sparse_ok_internal_overview(apply_sparse):
+
+    filename = '/vsimem/test_tiff_ovr_sparse_ok_internal_overview.tif'
+    gdaltest.tiff_drv.Create(filename, 100, 100)
+    ds = gdal.Open(filename, gdal.GA_Update)
+    with gdaltest.config_options({'SPARSE_OK_OVERVIEW': 'YES'} if apply_sparse else {}):
+        ds.BuildOverviews('NEAREST', overviewlist=[2])
+    ds = None
+    ds = gdal.Open(filename)
+    has_block = ds.GetRasterBand(1).GetOverview(0).GetMetadataItem("BLOCK_OFFSET_0_0", "TIFF") is not None
+    if apply_sparse:
+        assert not has_block
+    else:
+        assert has_block
+    ds = None
+
+    gdaltest.tiff_drv.Delete(filename)
+
+###############################################################################
+# Test SPARSE_OK_OVERVIEW on external overview
+
+
+@pytest.mark.parametrize("apply_sparse", [False,True])
+def test_tiff_ovr_sparse_ok_external_overview(apply_sparse):
+
+    filename = '/vsimem/test_tiff_ovr_sparse_ok_external_overview.tif'
+    gdaltest.tiff_drv.Create(filename, 100, 100)
+    ds = gdal.Open(filename)
+    with gdaltest.config_options({'SPARSE_OK_OVERVIEW': 'YES'} if apply_sparse else {}):
+        ds.BuildOverviews('NEAREST', overviewlist=[2])
+    ds = None
+    ds = gdal.Open(filename)
+    has_block = ds.GetRasterBand(1).GetOverview(0).GetMetadataItem("BLOCK_OFFSET_0_0", "TIFF") is not None
+    if apply_sparse:
+        assert not has_block
+    else:
+        assert has_block
+    ds = None
+
+    gdaltest.tiff_drv.Delete(filename)
+
+
+###############################################################################
 # Test overview on a dataset where width * height > 2 billion
 
 

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -744,6 +744,9 @@ the default behavior of the GTiff driver.
 -  :decl_configoption:`MAX_Z_ERROR_OVERVIEW` : Floating-point value. Default value: 0 (lossless)
    Maximum error threshold on values for LERC/LERC_DEFLATE/LERC_ZSTD compression of overviews, either internal or external.
    Added in GDAL 3.4.1
+-  :decl_configoption:`SPARSE_OK_OVERVIEW` :Boolean value. Default value: OFF
+   When set to ON, blocks whose pixels are all at nodata (or 0 if no nodata is defined)
+   will not be written. Added in GDAL 3.4.1
 -  :decl_configoption:`GDAL_TIFF_INTERNAL_MASK` : See `Internal nodata
    masks <#internal_mask>`__ section. Default value : FALSE.
 -  :decl_configoption:`GDAL_TIFF_INTERNAL_MASK_TO_8BIT` : See `Internal nodata

--- a/doc/source/programs/gdaladdo.rst
+++ b/doc/source/programs/gdaladdo.rst
@@ -167,6 +167,10 @@ documented in the GeoTIFF driver documentation.
   and overviews larger than 4GB).
 - IF_SAFER will create BigTIFF if the resulting file *might* exceed 4GB.
 
+Sparse GeoTIFF overview files (that is tiles which are omitted if all their pixels are
+at the nodata value, when there's one, or at 0 otherwise) can be obtained with
+``--config SPARSE_OK_OVERVIEW ON``. Added in GDAL 3.4.1
+
 See the documentation of the :ref:`raster.gtiff` driver for further explanations on all those options.
 
 Setting blocksize in Geotiff overviews

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -989,7 +989,8 @@ GTIFFBuildOverviewsEx( const char * pszFilename,
     aosOpenOptions.SetNameValue("NUM_THREADS",
                                 CSLFetchNameValue(papszOptions, "NUM_THREADS"));
     aosOpenOptions.SetNameValue("SPARSE_OK",
-                                CSLFetchNameValue(papszOptions, "SPARSE_OK"));
+                                CSLFetchNameValueDef(papszOptions, "SPARSE_OK",
+                                     CPLGetConfigOption("SPARSE_OK_OVERVIEW", nullptr)));
     aosOpenOptions.SetNameValue("@MASK_OVERVIEW_DATASET",
                                 CSLFetchNameValue(papszOptions, "MASK_OVERVIEW_DATASET"));
     GDALDataset *hODS = GDALDataset::Open( pszFilename,


### PR DESCRIPTION
* Propagate SPARSE_OK creation option to (internal) overviews
  when calling BuildOverviews() on the created dataset
* Propagate SPARSE_OK open option to internal overviews (dataset
  opened in update mode) or external overviews (dataset opened in
  read-only mode)
* Take into account the newly added SPARSE_OK_OVERVIEW configuration
  option to internal overviews (dataset opened in update mode) or
  external overviews (dataset opened in read-only mode)
