### PR TITLE
gdal2tiles: making --no-kml option takes effect fixes (fixes #4936)

### DIFF
--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -356,7 +356,7 @@ def test_gdal2tiles_py_profile_raster():
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q -p raster -z 0-1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
+        '-q -p raster -z 0-1 --force-kml '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
 
     if sys.platform != 'win32':
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
@@ -387,7 +387,7 @@ def test_gdal2tiles_py_profile_raster_xyz():
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q -p raster --xyz -z 0-1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
+        '-q -p raster --xyz -z 0-1 --force-kml ' +test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
 
     if sys.platform != 'win32':
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
@@ -418,7 +418,7 @@ def test_gdal2tiles_py_profile_geodetic_tmscompatible_xyz():
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         'gdal2tiles',
-        '-q -p geodetic --tmscompatible --xyz -z 0-1 '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
+        '-q -p geodetic --tmscompatible --xyz -z 0-1 --force-kml '+test_py_scripts.get_data_path('gdrivers')+'small_world.tif tmp/out_gdal2tiles_smallworld')
 
     if sys.platform != 'win32':
         # For some reason, the checksums on the kml file on Windows are the ones of the below png

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -1775,9 +1775,8 @@ class GDAL2Tiles(object):
         srs4326.ImportFromEPSG(4326)
         srs4326.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         if self.out_srs and srs4326.ExportToProj4() == self.out_srs.ExportToProj4():
-            self.kml = True
             self.isepsg4326 = True
-            if self.options.verbose:
+            if self.kml and self.options.verbose:
                 print("KML autotest OK!")
 
         # Read the georeference


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
The user setting of generating kml file or not should not be modified, and the current behavior is generating kml file for each tile even though --no-kml option is set. 
https://github.com/OSGeo/gdal/blob/59591e36d7939b1712e08e16cff3b5679700342a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py#L1777-L1781

Automatic generation of kml file is disabled by default, but some tests rely on the incorrect behavior which is described above, so modification to the tests is required.
https://github.com/OSGeo/gdal/blob/59591e36d7939b1712e08e16cff3b5679700342a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py#L1415-L1418

