### PR TITLE
making --no-kml option takes effect (fixes #4936)

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -1412,7 +1412,7 @@ def optparse_init() -> optparse.OptionParser:
     p.add_option_group(g)
 
 
-    p.set_defaults(verbose=False, profile="mercator", kml=False, url='',
+    p.set_defaults(verbose=False, profile="mercator", kml=None, url='',
                    webviewer='all', copyright='', resampling='average', resume=False,
                    googlekey='INSERT_YOUR_KEY_HERE', bingkey='INSERT_YOUR_KEY_HERE',
                    processes=1)
@@ -1775,10 +1775,14 @@ class GDAL2Tiles(object):
         srs4326.ImportFromEPSG(4326)
         srs4326.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         if self.out_srs and srs4326.ExportToProj4() == self.out_srs.ExportToProj4():
-            self.kml = True
             self.isepsg4326 = True
-            if self.options.verbose:
+            if self.kml is None:
+                self.kml = True
+            if self.kml and self.options.verbose:
                 print("KML autotest OK!")
+
+        if self.kml is None:
+            self.kml = False
 
         # Read the georeference
         self.out_gt = self.warped_input_dataset.GetGeoTransform()


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

If no kml related options are specific,  the generation of kml file will be enabled if  the SRS is EPSG:4326 and disabled for another SRS. This change also make sure that the original meaning of --force-kml and --no-kml will not be changed regardless of what SRS. More details can be found in this PR: https://github.com/OSGeo/gdal/pull/4937
