### PR TITLE
Selafin: fix time step count when none dataset in the file

### DIFF
--- a/ogr/ogrsf_frmts/selafin/io_selafin.cpp
+++ b/ogr/ogrsf_frmts/selafin/io_selafin.cpp
@@ -634,7 +634,7 @@ namespace Selafin {
             delete poHeader;
             return nullptr;
         }
-        vsi_l_offset nStepsBig = (poHeader->nFileSize-nPos)/(poHeader->getPosition(1)-nPos);
+        vsi_l_offset nStepsBig = poHeader->nVar != 0 ? (poHeader->nFileSize-nPos)/(poHeader->getPosition(1)-nPos) : 0;
         if( nStepsBig > INT_MAX )
             poHeader->nSteps=INT_MAX;
         else

--- a/ogr/ogrsf_frmts/selafin/ogrselafindatasource.cpp
+++ b/ogr/ogrsf_frmts/selafin/ogrselafindatasource.cpp
@@ -414,7 +414,13 @@ int OGRSelafinDataSource::OpenTable(const char * pszFilename) {
 
     // Create two layers for each selected time step: one for points, the other for elements
     poRange.setMaxValue(poHeader->nSteps);
-    const int nNewLayers = static_cast<int>(poRange.getSize());
+    size_t size=poRange.getSize();
+    if (size > INT32_MAX)
+    {
+        CPLError( CE_Failure, CPLE_OpenFailed, "Invalid size" );
+        return FALSE;
+    }
+    const int nNewLayers = static_cast<int>(size);
     if (EQUAL(pszFilename, "/vsistdin/")) osBaseLayerName = "layer";
     CPLString osLayerName;
     papoLayers = (OGRSelafinLayer **) CPLRealloc(papoLayers, sizeof(void*) * (nLayers+nNewLayers));


### PR DESCRIPTION
SELAFIN files, without dataset but only with the mesh frame, can exist, especially coming from editors as  Bluekenue, Basemesh SalomeHydro, or more recently QGIS.

When opening such file by drag/drop such files in QGIS, opening the file is tested with OGR driver, which returns a very big (and bad) layer count. That make QGIS crashes or being freeze.

This little PR fixes this issue. In such case, the file can't be opened by OGR, but it doesn't consider anymore bad layer count.

