### PR TITLE
configure: change default of RENAME_INTERNAL_LIBTIFF/LIBGEOTIFF/SHAPELIB_SYMBOLS to yes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -877,19 +877,12 @@ dnl ---------------------------------------------------------------------------
 
 AC_ARG_WITH(rename_internal_libtiff_symbols,[  --with-rename-internal-libtiff-symbols[=ARG] Prefix internal libtiff symbols with gdal_ (ARG=yes/no)],,)
 
-if test "$HAVE_HIDE_INTERNAL_SYMBOLS" = "yes" ; then
-    with_rename_internal_libtiff_symbols=yes
-    if test "x$with_rename_internal_libtiff_symbols" = "x$no"; then
-        with_rename_internal_libtiff_symbols=no
-    fi
-else
-    with_rename_internal_libtiff_symbols=no
-    if test "x$with_rename_internal_libtiff_symbols" = "x$yes" -o "x$with_rename_internal_libtiff_symbols" = "x"; then
-        with_rename_internal_libtiff_symbols=yes
-    fi
+RENAME_INTERNAL_LIBTIFF_SYMBOLS=no
+if test "x$with_rename_internal_libtiff_symbols" = "xyes" -o "x$with_rename_internal_libtiff_symbols" = "x"; then
+  RENAME_INTERNAL_LIBTIFF_SYMBOLS=yes
 fi
 
-AC_SUBST(RENAME_INTERNAL_LIBTIFF_SYMBOLS,$with_rename_internal_libtiff_symbols)
+AC_SUBST(RENAME_INTERNAL_LIBTIFF_SYMBOLS,$RENAME_INTERNAL_LIBTIFF_SYMBOLS)
 
 dnl ---------------------------------------------------------------------------
 dnl Check if user requests renaming internal libgeotiff symbols
@@ -897,19 +890,12 @@ dnl ---------------------------------------------------------------------------
 
 AC_ARG_WITH(rename_internal_libgeotiff_symbols,[  --with-rename-internal-libgeotiff-symbols[=ARG] Prefix internal libgeotiff symbols with gdal_ (ARG=yes/no)],,)
 
-if test "$HAVE_HIDE_INTERNAL_SYMBOLS" = "yes" ; then
-    with_rename_internal_libgeotiff_symbols=yes
-    if test "x$with_rename_internal_libgeotiff_symbols" = "x$no"; then
-        with_rename_internal_libgeotiff_symbols=no
-    fi
-else
-    with_rename_internal_libgeotiff_symbols=no
-    if test "x$with_rename_internal_libgeotiff_symbols" = "x$yes" -o "x$with_rename_internal_libgeotiff_symbols" = "x"; then
-        with_rename_internal_libgeotiff_symbols=yes
-    fi
+RENAME_INTERNAL_LIBGEOTIFF_SYMBOLS=no
+if test "x$with_rename_internal_libgeotiff_symbols" = "xyes" -o "x$with_rename_internal_libgeotiff_symbols" = "x"; then
+   RENAME_INTERNAL_LIBGEOTIFF_SYMBOLS=yes
 fi
 
-AC_SUBST(RENAME_INTERNAL_LIBGEOTIFF_SYMBOLS,$with_rename_internal_libgeotiff_symbols)
+AC_SUBST(RENAME_INTERNAL_LIBGEOTIFF_SYMBOLS,$RENAME_INTERNAL_LIBGEOTIFF_SYMBOLS)
 
 dnl ---------------------------------------------------------------------------
 dnl Check if user requests renaming internal shapelib symbols
@@ -917,18 +903,11 @@ dnl ---------------------------------------------------------------------------
 
 AC_ARG_WITH(rename_internal_shapelib_symbols,[  --with-rename-internal-shapelib-symbols[=ARG] Prefix internal shapelib symbols with gdal_ (ARG=yes/no)],,)
 
-if test "$HAVE_HIDE_INTERNAL_SYMBOLS" = "yes" ; then
-    with_rename_internal_shapelib_symbols=yes
-    if test "x$with_rename_internal_shapelib_symbols" = "x$no"; then
-        with_rename_internal_shapelib_symbols=no
-    fi
-else
-    with_rename_internal_shapelib_symbols=no
-    if test "x$with_rename_internal_shapelib_symbols" = "x$yes" -o "x$with_rename_internal_shapelib_symbols" = "x"; then
-        with_rename_internal_shapelib_symbols=yes
-    fi
+RENAME_INTERNAL_SHAPELIB_SYMBOLS=no
+if test "x$with_rename_internal_shapelib_symbols" = "xyes" -o "x$with_rename_internal_shapelib_symbols" = "x"; then
+    RENAME_INTERNAL_SHAPELIB_SYMBOLS=yes
 fi
-AC_SUBST(RENAME_INTERNAL_SHAPELIB_SYMBOLS,$with_rename_internal_shapelib_symbols)
+AC_SUBST(RENAME_INTERNAL_SHAPELIB_SYMBOLS,$RENAME_INTERNAL_SHAPELIB_SYMBOLS)
 
 
 dnl ---------------------------------------------------------------------------


### PR DESCRIPTION
This will align with the default of the CMake builds.

And actually fix the taking account of the --with-rename... options that
was was broken in the non --with-hide-internal-symbols case.
