### PR TITLE
GRIB: fix writing negative longitude of natural origin for Transverse Mercator

### DIFF
--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -440,7 +440,7 @@ def test_grib_grib2_read_laea():
     ds = gdal.Open('data/grib/lambert_azimuthal_equal_area.grb2')
 
     projection = ds.GetProjectionRef()
-    expected_projection = """PROJCS["unnamed",GEOGCS["Coordinate System imported from GRIB file",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Lambert_Azimuthal_Equal_Area"],PARAMETER["latitude_of_center",33.5],PARAMETER["longitude_of_center",243],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Metre",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]"""
+    expected_projection = """PROJCS["unnamed",GEOGCS["Coordinate System imported from GRIB file",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Lambert_Azimuthal_Equal_Area"],PARAMETER["latitude_of_center",33.5],PARAMETER["longitude_of_center",-117],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Metre",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]"""
     assert projection == expected_projection, 'Did not get expected projection'
 
     gt = ds.GetGeoTransform()

--- a/frmts/grib/gribcreatecopy.cpp
+++ b/frmts/grib/gribcreatecopy.cpp
@@ -456,7 +456,7 @@ bool GRIB2Section3Writer::WriteTransverseMercator()
     const double dfAngUnit = 1e-6;
     WriteScaled(
         oSRS.GetNormProjParm(SRS_PP_LATITUDE_OF_ORIGIN, 0.0), dfAngUnit);
-    WriteScaled(oSRS.GetNormProjParm(SRS_PP_CENTRAL_MERIDIAN, 0.0), dfAngUnit);
+    WriteScaled(Lon180to360(oSRS.GetNormProjParm(SRS_PP_CENTRAL_MERIDIAN, 0.0)), dfAngUnit);
     WriteByte(fp, GRIB2BIT_3 | GRIB2BIT_4); // Resolution and component flags
     float fScale = static_cast<float>(oSRS.GetNormProjParm(
         SRS_PP_SCALE_FACTOR, 0.0));
@@ -496,8 +496,8 @@ bool GRIB2Section3Writer::WritePolarSteregraphic()
     const double dfLatOrigin = oSRS.GetNormProjParm(
                                     SRS_PP_LATITUDE_OF_ORIGIN, 0.0);
     WriteScaled(dfLatOrigin, dfAngUnit);
-    WriteScaled(fmod(oSRS.GetNormProjParm(
-                     SRS_PP_CENTRAL_MERIDIAN, 0.0) + 360.0, 360.0), dfAngUnit);
+    WriteScaled(Lon180to360(oSRS.GetNormProjParm(
+                     SRS_PP_CENTRAL_MERIDIAN, 0.0)), dfAngUnit);
     const double dfLinearUnit = 1e-3;
     WriteScaled(adfGeoTransform[1], dfLinearUnit);
     WriteScaled(fabs(adfGeoTransform[5]), dfLinearUnit);
@@ -554,8 +554,8 @@ bool GRIB2Section3Writer::WriteLCC2SPOrAEA(OGRSpatialReference* poSRS)
     WriteByte( fp, 0);
     WriteScaled(
         poSRS->GetNormProjParm(SRS_PP_LATITUDE_OF_ORIGIN, 0.0), dfAngUnit);
-    WriteScaled(fmod(oSRS.GetNormProjParm(
-                     SRS_PP_CENTRAL_MERIDIAN, 0.0) + 360.0, 360.0), dfAngUnit);
+    WriteScaled(Lon180to360(oSRS.GetNormProjParm(
+                     SRS_PP_CENTRAL_MERIDIAN, 0.0)), dfAngUnit);
     const double dfLinearUnit = 1e-3;
     WriteScaled(adfGeoTransform[1], dfLinearUnit);
     WriteScaled(fabs(adfGeoTransform[5]), dfLinearUnit);
@@ -590,8 +590,8 @@ bool GRIB2Section3Writer::WriteLAEA()
     WriteScaled(dfLLX, dfAngUnit);
     WriteScaled(
         oSRS.GetNormProjParm(SRS_PP_LATITUDE_OF_CENTER, 0.0), dfAngUnit);
-    WriteScaled(fmod(oSRS.GetNormProjParm(
-                SRS_PP_LONGITUDE_OF_CENTER, 0.0) + 360.0, 360.0), dfAngUnit);
+    WriteScaled(Lon180to360(oSRS.GetNormProjParm(
+                SRS_PP_LONGITUDE_OF_CENTER, 0.0)), dfAngUnit);
     WriteByte( fp, GRIB2BIT_3 | GRIB2BIT_4); // Resolution and component flags
     const double dfLinearUnit = 1e-3;
     WriteScaled(adfGeoTransform[1], dfLinearUnit);

--- a/frmts/grib/gribdataset.cpp
+++ b/frmts/grib/gribdataset.cpp
@@ -2378,7 +2378,7 @@ void GRIBDataset::SetGribMetaData(grib_MetaData *meta)
         break;
     case GS3_TRANSVERSE_MERCATOR:
         oSRS.SetTM(meta->gds.latitude_of_origin,
-                   meta->gds.central_meridian,
+                   Lon360to180(meta->gds.central_meridian),
                    std::abs(meta->gds.scaleLat1 - 0.9996) < 1e8 ?
                         0.9996 : meta->gds.scaleLat1,
                    meta->gds.x0,
@@ -2390,11 +2390,11 @@ void GRIBDataset::SetGribMetaData(grib_MetaData *meta)
         break;
     case GS3_LAMBERT:
         oSRS.SetLCC(meta->gds.scaleLat1, meta->gds.scaleLat2, meta->gds.meshLat,
-                    meta->gds.orientLon, 0.0, 0.0);
+                    Lon360to180(meta->gds.orientLon), 0.0, 0.0);
         break;
     case GS3_ALBERS_EQUAL_AREA:
         oSRS.SetACEA(meta->gds.scaleLat1, meta->gds.scaleLat2, meta->gds.meshLat,
-                    meta->gds.orientLon, 0.0, 0.0);
+                     Lon360to180(meta->gds.orientLon), 0.0, 0.0);
         break;
 
     case GS3_ORTHOGRAPHIC:
@@ -2409,7 +2409,9 @@ void GRIBDataset::SetGribMetaData(grib_MetaData *meta)
         oSRS.SetGEOS(0, 35785831, 0, 0);
         break;
     case GS3_LAMBERT_AZIMUTHAL:
-        oSRS.SetLAEA(meta->gds.meshLat, meta->gds.orientLon, 0.0, 0.0);
+        oSRS.SetLAEA(meta->gds.meshLat,
+                     Lon360to180(meta->gds.orientLon),
+                     0.0, 0.0);
         break;
 
     case GS3_EQUATOR_EQUIDIST:
@@ -2467,8 +2469,7 @@ void GRIBDataset::SetGribMetaData(grib_MetaData *meta)
         oSRS.SetDerivedGeogCRSWithPoleRotationGRIBConvention(
             oSRS.GetName(),
             meta->gds.southLat,
-            meta->gds.southLon > 180 ?
-                meta->gds.southLon - 360 : meta->gds.southLon,
+            Lon360to180(meta->gds.southLon),
             meta->gds.angleRotate);
     }
 


### PR DESCRIPTION
and fix reading it for TMerc, LCC, ACEA and LAEA
