### PR TITLE
S57: enable recoding to UTF-8 by default (RECODE_BY_DSSI=YES open option) (fixes #4751)

### DIFF
--- a/autotest/ogr/ogr_s57.py
+++ b/autotest/ogr/ogr_s57.py
@@ -94,7 +94,7 @@ def test_ogr_s57_check_layers():
         assert lyr.GetLayerDefn().GetGeomType() == lyr_info[1], \
             ('Expected %d layer type in layer %s, but got %d.' % (lyr_info[1], lyr_info[0], lyr.GetLayerDefn().GetGeomType()))
 
-    
+
 ###############################################################################
 # Check the COALNE feature.
 
@@ -383,7 +383,7 @@ def test_ogr_s57_online_4():
         except OSError:
             pytest.skip()
 
-    gdal.SetConfigOption('OGR_S57_OPTIONS', 'RETURN_PRIMITIVES=ON,RETURN_LINKAGES=ON,LNAM_REFS=ON,RECODE_BY_DSSI=ON')
+    gdal.SetConfigOption('OGR_S57_OPTIONS', 'RETURN_PRIMITIVES=ON,RETURN_LINKAGES=ON,LNAM_REFS=ON')
     ds = ogr.Open('tmp/cache/ENC_ROOT/JP34NC94.000')
     gdal.SetConfigOption('OGR_S57_OPTIONS', None)
     lyr = ds.GetLayerByName('LNDMRK')

--- a/doc/source/drivers/vector/s57.rst
+++ b/doc/source/drivers/vector/s57.rst
@@ -158,14 +158,14 @@ They can also be specified independently as open options to the driver.
    useful when translated S-57 to S-57 losslessly. Default is OFF.
 -  **LNAM_REFS**\ =ON/OFF: Should LNAM and LNAM_REFS fields be attached
    to features capturing the feature to feature relationships in the
-   FFPT group of the S-57 file. Default is ON.
+   FFPT group of the S-57 file. Default is OFF.
 -  **RETURN_LINKAGES**\ =ON/OFF: Should additional attributes relating
    features to their underlying geometric primitives be attached. These
    are the values of the FSPT group, and are primarily needed when doing
    S-57 to S-57 translations. Default is OFF.
 -  **RECODE_BY_DSSI**\ =ON/OFF: Should attribute values be
    recoded to UTF-8 from the character encoding specified in the S57
-   DSSI record. Default is OFF.
+   DSSI record. Default is ON starting with GDAL 3.4.1.
 -  **LIST_AS_STRING**\ =ON/OFF: (GDAL >= 3.2) Whether attributes tagged as list in S57
    dictionaries should be reported as a String field, instead of a StringList.
    Default is OFF. Before GDAL 3.2, the behavior was equivalent to setting

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -486,6 +486,8 @@ class OGRPGDataSource final: public OGRDataSource
 
     char               *pszName = nullptr;
 
+    bool                m_bUTF8ClientEncoding = false;
+
     int                 bDSUpdate = false;
     int                 bHavePostGIS = false;
     int                 bHaveGeography = false;
@@ -540,7 +542,8 @@ class OGRPGDataSource final: public OGRDataSource
     bool                m_bHasGeometryColumns = false;
     bool                m_bHasSpatialRefSys = false;
 
-    int                GetUndefinedSRID() const { return nUndefinedSRID; }
+    int                 GetUndefinedSRID() const { return nUndefinedSRID; }
+    bool                IsUTF8ClientEncoding() const { return m_bUTF8ClientEncoding; }
 
   public:
                         OGRPGDataSource();

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -611,13 +611,31 @@ int OGRPGDataSource::Open( const char * pszNewName, int bUpdate,
 /* -------------------------------------------------------------------- */
     if (CPLGetConfigOption("PGCLIENTENCODING", nullptr) == nullptr)
     {
-        const char* encoding = "UNICODE";
+        const char* encoding = "UTF8";
         if (PQsetClientEncoding(hPGConn, encoding) == -1)
         {
             CPLError( CE_Warning, CPLE_AppDefined,
                     "PQsetClientEncoding(%s) failed.\n%s",
                     encoding, PQerrorMessage( hPGConn ) );
         }
+    }
+
+    {
+        PGresult* hResult = OGRPG_PQexec(hPGConn, "SHOW client_encoding" );
+        if( hResult && PQresultStatus(hResult) == PGRES_TUPLES_OK
+            && PQntuples(hResult) == 1 )
+        {
+            const char* pszClientEncoding = PQgetvalue(hResult,0,0);
+            if( pszClientEncoding )
+            {
+                CPLDebug("PG","Client encoding: '%s'", pszClientEncoding);
+                if( EQUAL(pszClientEncoding, "UTF8") )
+                {
+                    m_bUTF8ClientEncoding = true;
+                }
+            }
+        }
+        OGRPGClearResult(hResult);
     }
 
 /* -------------------------------------------------------------------- */

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -1974,6 +1974,20 @@ OGRErr OGRPGTableLayer::CreateFeatureViaCopy( OGRFeature *poFeature )
     /* Add end of line marker */
     osCommand += "\n";
 
+    // PostgreSQL doesn't provide very helpful reporting of invalid UTF-8
+    // content in COPY mode.
+    if( poDS->IsUTF8ClientEncoding() &&
+        !CPLIsUTF8(osCommand.c_str(), static_cast<int>(osCommand.size())) )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Non UTF-8 content found when writing feature " CPL_FRMT_GIB
+                 " of layer %s: %s",
+                 poFeature->GetFID(),
+                 poFeatureDefn->GetName(),
+                 osCommand.c_str());
+        return OGRERR_FAILURE;
+    }
+
     /* ------------------------------------------------------------ */
     /*      Execute the copy.                                       */
     /* ------------------------------------------------------------ */

--- a/ogr/ogrsf_frmts/s57/ogrs57driver.cpp
+++ b/ogr/ogrsf_frmts/s57/ogrs57driver.cpp
@@ -185,9 +185,9 @@ void RegisterOGRS57()
         "  <Option name='" S57O_ADD_SOUNDG_DEPTH "' type='boolean' description='Should a DEPTH attribute be added on SOUNDG features and assign the depth of the sounding' default='NO'/>"
         "  <Option name='" S57O_RETURN_PRIMITIVES "' type='boolean' description='Should all the low level geometry primitives be returned as special IsolatedNode, ConnectedNode, Edge and Face layers' default='NO'/>"
         "  <Option name='" S57O_PRESERVE_EMPTY_NUMBERS "' type='boolean' description='If enabled, numeric attributes assigned an empty string as a value will be preserved as a special numeric value' default='NO'/>"
-        "  <Option name='" S57O_LNAM_REFS "' type='boolean' description='Should LNAM and LNAM_REFS fields be attached to features capturing the feature to feature relationships in the FFPT group of the S-57 file' default='YES'/>"
+        "  <Option name='" S57O_LNAM_REFS "' type='boolean' description='Should LNAM and LNAM_REFS fields be attached to features capturing the feature to feature relationships in the FFPT group of the S-57 file' default='NO'/>"
         "  <Option name='" S57O_RETURN_LINKAGES "' type='boolean' description='Should additional attributes relating features to their underlying geometric primitives be attached' default='NO'/>"
-        "  <Option name='" S57O_RECODE_BY_DSSI "' type='boolean' description='Should attribute values be recoded to UTF-8 from the character encoding specified in the S57 DSSI record.' default='NO'/>"
+        "  <Option name='" S57O_RECODE_BY_DSSI "' type='boolean' description='Should attribute values be recoded to UTF-8 from the character encoding specified in the S57 DSSI record.' default='YES'/>"
         "  <Option name='" S57O_LIST_AS_STRING "' type='boolean' description='Whether attributes tagged as list in S57 dictionaries should be reported as a String field' default='NO'/>"
         "</OpenOptionList>");
     poDriver->SetMetadataItem(

--- a/ogr/ogrsf_frmts/s57/ogrs57layer.cpp
+++ b/ogr/ogrsf_frmts/s57/ogrs57layer.cpp
@@ -217,6 +217,13 @@ int OGRS57Layer::TestCapability( const char * pszCap )
     if( EQUAL(pszCap, OLCFastSpatialFilter) )
         return false;
 
+    if( EQUAL(pszCap, OLCStringsAsUTF8) )
+    {
+        return poDS->GetModule(0) != nullptr &&
+               (poDS->GetModule(0)->GetOptionFlags()
+                    & S57M_RECODE_BY_DSSI);
+    }
+
     return false;
 }
 

--- a/ogr/ogrsf_frmts/s57/s57reader.cpp
+++ b/ogr/ogrsf_frmts/s57/s57reader.cpp
@@ -407,7 +407,7 @@ bool S57Reader::SetOptions( char ** papszOptionsIn )
         nOptionFlags &= ~S57M_RETURN_DSID;
 
     pszOptionValue = CSLFetchNameValue( papszOptions, S57O_RECODE_BY_DSSI );
-    if( pszOptionValue != nullptr && CPLTestBool(pszOptionValue) )
+    if( pszOptionValue == nullptr || CPLTestBool(pszOptionValue) )
         nOptionFlags |= S57M_RECODE_BY_DSSI;
     else
         nOptionFlags &= ~S57M_RECODE_BY_DSSI;


### PR DESCRIPTION
And also PG: error out if non UTF-8 content is transmitted in COPY mode, when client_encoding=UTF8