### PR TITLE
Do not copy final DXF when MarkSuppressOnClose was called

### DIFF
--- a/ogr/ogrsf_frmts/dxf/ogrdxfwriterds.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfwriterds.cpp
@@ -69,6 +69,14 @@ OGRDXFWriterDS::~OGRDXFWriterDS()
 /* -------------------------------------------------------------------- */
         CPLDebug( "DXF", "Compose final DXF file from components." );
 
+        if (bSuppressOnClose && fpTemp != nullptr)
+        {
+            CPLDebug( "DXF", "Do not copy final DXF when 'suppress on close'." );
+            VSIFCloseL( fpTemp );
+            VSIUnlink( osTempFilename );
+            fpTemp = nullptr;
+        }
+
         TransferUpdateHeader( fp );
 
         if (fpTemp != nullptr)


### PR DESCRIPTION
## What does this PR do?
When MarkSuppressOnClose is called on a DXF, the final copy from the `tmp` to the DXF file is not done. 
This improves performance when the creation of a big file is cancelled.

## Tasklist

 - [x] Add test case

Added test checks that `MarkSuppressOnClose` works... that is not modified by this PR. I checked that the added code in `ogrdxfwriterds.cpp` to avoid the unneeded copy is used debugging the execution.
The test just adds a bunch of points in a dxf to be able to easily debug it and see how it behaves.