### PR TITLE
COG: fix potential generation failure when main imagery has overview and mask none

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -1076,3 +1076,22 @@ def test_cog_copy_xmp():
     _check_cog(filename)
 
     gdal.Unlink(filename)
+
+###############################################################################
+# Test creating COG from a source dataset that has overview with 'odd' sizes
+# and a mask without overview
+
+
+def test_cog_odd_overview_size_and_msk():
+
+    filename = '/vsimem/test_cog_odd_overview_size_and_msk.tif'
+    src_ds = gdal.GetDriverByName('MEM').Create('', 511, 511)
+    src_ds.BuildOverviews('NEAR', [2])
+    src_ds.CreateMaskBand(gdal.GMF_PER_DATASET)
+    ds = gdal.GetDriverByName('COG').CreateCopy(filename, src_ds, options=['BLOCKSIZE=256'])
+    assert ds
+    assert ds.GetRasterBand(1).GetOverview(0).XSize == 256
+    assert ds.GetRasterBand(1).GetMaskBand().GetOverview(0).XSize == 256
+    ds = None
+
+    gdal.Unlink(filename)

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -849,13 +849,28 @@ GDALDataset* GDALCOGCreator::Create(const char * pszFilename,
             nCurLevel --;
         }
     }
-    else
+    else if( bGenerateMskOvr || bGenerateOvr )
     {
-        while( nTmpXSize > nOvrThresholdSize || nTmpYSize > nOvrThresholdSize )
+        if( !bGenerateOvr )
         {
-            nTmpXSize /= 2;
-            nTmpYSize /= 2;
-            asOverviewDims.push_back(std::pair<int,int>(nTmpXSize, nTmpYSize));
+            // If generating only .msk.ovr, use the exact overview size as
+            // the overviews of the imagery.
+            for(int i = 0; i < poFirstBand->GetOverviewCount(); i++ )
+            {
+                auto poOvrBand = poFirstBand->GetOverview(i);
+                asOverviewDims.push_back(std::pair<int,int>(
+                    poOvrBand->GetXSize(), poOvrBand->GetYSize()));
+            }
+        }
+        else
+        {
+            while( nTmpXSize > nOvrThresholdSize ||
+                   nTmpYSize > nOvrThresholdSize )
+            {
+                nTmpXSize /= 2;
+                nTmpYSize /= 2;
+                asOverviewDims.push_back(std::pair<int,int>(nTmpXSize, nTmpYSize));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2021-December/055108.html
