### PR TITLE
MSSQL: do not set field width when reading smallint/int/bigint/float/…

### DIFF
--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -321,33 +321,190 @@ def test_ogr_mssqlspatial_create_feature_in_unregistered_table():
     feature.Destroy()
 
 ###############################################################################
-# Test UUID datatype support
+# Test all datatype support
 
-def test_ogr_mssqlspatial_uuid():
+def test_ogr_mssqlspatial_datatypes():
     if gdaltest.mssqlspatial_ds is None:
         pytest.skip()
 
-    lyr = gdaltest.mssqlspatial_ds.CreateLayer('test_ogr_mssql_uuid')
+    lyr = gdaltest.mssqlspatial_ds.CreateLayer('test_ogr_mssql_datatypes')
+
+    fd = ogr.FieldDefn('int32', ogr.OFTInteger)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('int16', ogr.OFTInteger)
+    fd.SetSubType(ogr.OFSTInt16)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('int64', ogr.OFTInteger64)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('float32', ogr.OFTReal)
+    fd.SetSubType(ogr.OFSTFloat32)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('float64', ogr.OFTReal)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('numeric', ogr.OFTReal)
+    fd.SetWidth(12)
+    fd.SetPrecision(6)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('numeric_width_9_prec_0_from_int', ogr.OFTInteger)
+    fd.SetWidth(9)
+    fd.SetPrecision(0)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('numeric_width_9_prec_0_from_real', ogr.OFTReal)
+    fd.SetWidth(9)
+    fd.SetPrecision(0)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('numeric_width_18_prec_0', ogr.OFTInteger64)
+    fd.SetWidth(18)
+    fd.SetPrecision(0)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('string', ogr.OFTString)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('string_limited', ogr.OFTString)
+    fd.SetWidth(5)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('date', ogr.OFTDate)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('time', ogr.OFTTime)
+    assert lyr.CreateField(fd) == 0
+
+    fd = ogr.FieldDefn('datetime', ogr.OFTDateTime)
+    assert lyr.CreateField(fd) == 0
 
     fd = ogr.FieldDefn('uid', ogr.OFTString)
     fd.SetSubType(ogr.OFSTUUID)
+    assert lyr.CreateField(fd) == 0
 
+    fd = ogr.FieldDefn('binary', ogr.OFTBinary)
     assert lyr.CreateField(fd) == 0
 
     lyr.StartTransaction()
     f = ogr.Feature(lyr.GetLayerDefn())
+    f['int32'] = (1 << 31) - 1
+    f['int16'] = (1 << 15) - 1
+    f['int64'] = (1 << 63) - 1
+    f['float32'] = 1.25
+    f['float64'] = 1.25123456789
+    f['numeric'] = 123456.789012
+    f['numeric_width_9_prec_0_from_int'] = 123456789
+    f['numeric_width_9_prec_0_from_real'] = 123456789
+    f['numeric_width_18_prec_0'] = 12345678912345678
+    f['string'] = 'unlimited string'
+    f['string_limited'] = 'abcd\u00e9'
+    f['date'] = '2021/12/11'
+    f['time'] = '12:34:56'
+    f['datetime'] = '2021/12/11 12:34:56'
     f['uid'] = '6F9619FF-8B86-D011-B42D-00C04FC964FF'
+    f.SetFieldBinaryFromHexString('binary', '0123465789ABCDEF')
     lyr.CreateFeature(f)
     lyr.CommitTransaction()
 
     test_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=0)
-    lyr = test_ds.GetLayer('test_ogr_mssql_uuid')
-    fd = lyr.GetLayerDefn().GetFieldDefn(0)
+    lyr = test_ds.GetLayer('test_ogr_mssql_datatypes')
+    lyr_defn = lyr.GetLayerDefn()
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('int32'))
+    assert fd.GetType() == ogr.OFTInteger
+    assert fd.GetSubType() == ogr.OFSTNone
+    assert fd.GetWidth() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('int16'))
+    assert fd.GetType() == ogr.OFTInteger
+    assert fd.GetSubType() == ogr.OFSTInt16
+    assert fd.GetWidth() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('int64'))
+    assert fd.GetType() == ogr.OFTInteger64
+    assert fd.GetSubType() == ogr.OFSTNone
+    assert fd.GetWidth() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('float32'))
+    assert fd.GetType() == ogr.OFTReal
+    assert fd.GetSubType() == ogr.OFSTFloat32
+    assert fd.GetWidth() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('float64'))
+    assert fd.GetType() == ogr.OFTReal
+    assert fd.GetSubType() == ogr.OFSTNone
+    assert fd.GetWidth() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('numeric'))
+    assert fd.GetType() == ogr.OFTReal
+    assert fd.GetSubType() == ogr.OFSTNone
+    assert fd.GetWidth() == 12
+    assert fd.GetPrecision() == 6
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('numeric_width_9_prec_0_from_int'))
+    assert fd.GetType() == ogr.OFTInteger
+    assert fd.GetSubType() == ogr.OFSTNone
+    assert fd.GetWidth() == 9
+    assert fd.GetPrecision() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('numeric_width_9_prec_0_from_real'))
+    assert fd.GetType() == ogr.OFTInteger
+    assert fd.GetSubType() == ogr.OFSTNone
+    assert fd.GetWidth() == 9
+    assert fd.GetPrecision() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('numeric_width_18_prec_0'))
+    assert fd.GetType() == ogr.OFTInteger64
+    assert fd.GetSubType() == ogr.OFSTNone
+    assert fd.GetWidth() == 18
+    assert fd.GetPrecision() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('string'))
+    assert fd.GetType() == ogr.OFTString
+    assert fd.GetWidth() == 0
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('string_limited'))
+    assert fd.GetType() == ogr.OFTString
+    assert fd.GetWidth() == 5
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('date'))
+    assert fd.GetType() == ogr.OFTDate
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('time'))
+    # We get a string currently
+    # assert fd.GetType() == ogr.OFTTime
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('datetime'))
+    assert fd.GetType() == ogr.OFTDateTime
+
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('uid'))
     assert fd.GetType() == ogr.OFTString
     assert fd.GetSubType() == ogr.OFSTUUID
-    f = lyr.GetNextFeature()
 
-    assert f.GetField(0) == '6F9619FF-8B86-D011-B42D-00C04FC964FF'
+    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('binary'))
+    assert fd.GetType() == ogr.OFTBinary
+
+    f = lyr.GetNextFeature()
+    assert f['int32'] == (1 << 31) - 1
+    assert f['int16'] == (1 << 15) - 1
+    assert f['int64'] == (1 << 63) - 1
+    assert f['float32'] == 1.25
+    assert f['float64'] == 1.25123456789
+    assert f['numeric'] == 123456.789012
+    assert f['numeric_width_9_prec_0_from_int'] == 123456789
+    assert f['numeric_width_9_prec_0_from_real'] == 123456789
+    assert f['numeric_width_18_prec_0'] == 12345678912345678
+    assert f['string'] == 'unlimited string'
+    assert f['string_limited'] == 'abcd\u00e9'
+    assert f['date'] == '2021/12/11'
+    assert f['time'] == '12:34:56' or f['time'].startswith('12:34:56.0')
+    assert f['datetime'] == '2021/12/11 12:34:56'
+    assert f['uid'] == '6F9619FF-8B86-D011-B42D-00C04FC964FF'
+    assert f['binary'] == '0123465789ABCDEF'
 
     test_ds.Destroy()
 
@@ -366,7 +523,7 @@ def test_ogr_mssqlspatial_cleanup():
     gdaltest.mssqlspatial_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=1)
     gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE Unregistered')
     gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE tpoly')
-    gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE test_ogr_mssql_uuid')
+    gdaltest.mssqlspatial_ds.ExecuteSQL('DROP TABLE test_ogr_mssql_datatypes')
 
     gdaltest.mssqlspatial_ds = None
 

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatiallayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatiallayer.cpp
@@ -198,11 +198,14 @@ void OGRMSSQLSpatialLayer::BuildFeatureDefn( const char *pszLayerName,
         }
 
         OGRFieldDefn    oField( poStmtIn->GetColName(iCol), OFTString );
-        oField.SetWidth( MAX(0,poStmtIn->GetColSize( iCol )) );
 
         switch( CPLODBCStatement::GetTypeMapping(poStmtIn->GetColType(iCol)) )
         {
             case SQL_C_SSHORT:
+                oField.SetType( OFTInteger );
+                oField.SetSubType( OFSTInt16 );
+                break;
+
             case SQL_C_USHORT:
             case SQL_C_SLONG:
             case SQL_C_ULONG:
@@ -216,17 +219,26 @@ void OGRMSSQLSpatialLayer::BuildFeatureDefn( const char *pszLayerName,
 
             case SQL_C_BINARY:
                 oField.SetType( OFTBinary );
+                oField.SetWidth( MAX(0,poStmtIn->GetColSize( iCol )) );
                 break;
 
             case SQL_C_NUMERIC:
                 oField.SetType( OFTReal );
                 oField.SetPrecision( poStmtIn->GetColPrecision(iCol) );
+                oField.SetWidth( MAX(0,poStmtIn->GetColSize( iCol )) );
+                if( oField.GetPrecision() == 0 && oField.GetWidth() <= 9 )
+                    oField.SetType( OFTInteger );
+                else if( oField.GetPrecision() == 0 && oField.GetWidth() <= 18 )
+                    oField.SetType( OFTInteger64 );
                 break;
 
             case SQL_C_FLOAT:
+                oField.SetType( OFTReal );
+                oField.SetSubType( OFSTFloat32 );
+                break;
+
             case SQL_C_DOUBLE:
                 oField.SetType( OFTReal );
-                oField.SetWidth( 0 );
                 break;
 
             case SQL_C_DATE:
@@ -249,6 +261,7 @@ void OGRMSSQLSpatialLayer::BuildFeatureDefn( const char *pszLayerName,
 
 
             default:
+                oField.SetWidth( MAX(0,poStmtIn->GetColSize( iCol )) );
                 /* leave it as OFTString */;
         }
 

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -917,6 +917,8 @@ OGRErr OGRMSSQLSpatialTableLayer::CreateField( OGRFieldDefn *poFieldIn,
     {
         if( oField.GetWidth() > 0 && bPreservePrecision )
             snprintf( szFieldType, sizeof(szFieldType), "numeric(%d,0)", oField.GetWidth() );
+        else if( oField.GetSubType() == OFSTInt16 )
+            strcpy( szFieldType, "smallint" );
         else
             strcpy( szFieldType, "int" );
     }
@@ -929,12 +931,14 @@ OGRErr OGRMSSQLSpatialTableLayer::CreateField( OGRFieldDefn *poFieldIn,
     }
     else if( oField.GetType() == OFTReal )
     {
-        if( oField.GetWidth() > 0 && oField.GetPrecision() > 0
+        if( oField.GetWidth() > 0 && oField.GetPrecision() >= 0
             && bPreservePrecision )
             snprintf( szFieldType, sizeof(szFieldType), "numeric(%d,%d)",
                      oField.GetWidth(), oField.GetPrecision() );
+        else if( oField.GetSubType() == OFSTFloat32 )
+            strcpy( szFieldType, "float(23)" );
         else
-            strcpy( szFieldType, "float" );
+            strcpy( szFieldType, "float(53)" );
     }
     else if( oField.GetType() == OFTString )
     {


### PR DESCRIPTION
…real columns, and correctly roundtrip smallint/Int16 (fixes #3345)
