### PR TITLE
CMake: add/fix CSharp support

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -115,8 +115,9 @@ jobs:
       #  libxml2 disabled because currently causes a 'Imported target "LibXml2::LibXml2" includes non-existent path "/mingw64/include/libxml2" in its INTERFACE_INCLUDE_DIRECTORIES'
       # Disable mySQL since C:/mysql/lib/mysqlclient.lib (unrelated to msys) is found, which causes linking issues
       # Disable Python bindings because of 'ValueError: filename D:/a/gdal/gdal/swig/python/osgeo/__init__.py does not start with the input_base_dir D:/a/gdal/gdal/swig/python/osgeo/\' when running lib2to3
+      # BUILD_CSHARP_BINDINGS=OFF because we get "AssemblyInfo.cs(98,12): error CS0246: The type or namespace name 'SecurityRules' could not be found (are you missing a using directive or an assembly reference?)" with Microsoft (R) Visual C# 2005 Compiler version 8.00.50727.9031 for Microsoft (R) Windows (R) 2005 Framework version 2.0.50727
       - name: Configure
-        run: cmake -DCMAKE_BUILD_TYPE=release -G "${env:generator}" "-DCMAKE_C_COMPILER_LAUNCHER=c:\tools\msys64\mingw64\bin\ccache.exe" "-DCMAKE_CXX_COMPILER_LAUNCHER=c:\tools\msys64\mingw64\bin\ccache.exe" "-DCMAKE_PREFIX_PATH=C:\tools\msys64\mingw64" "-DCMAKE_UNITY_BUILD=${env:CMAKE_UNITY_BUILD}" -S . -B "build" -DLIBXML2_INCLUDE_DIR=C:/tools/msys64/mingw64/include -DGDAL_USE_LIBXML2:BOOL=OFF -DGDAL_USE_MYSQL:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=OFF
+        run: cmake -DCMAKE_BUILD_TYPE=release -G "${env:generator}" "-DCMAKE_C_COMPILER_LAUNCHER=c:\tools\msys64\mingw64\bin\ccache.exe" "-DCMAKE_CXX_COMPILER_LAUNCHER=c:\tools\msys64\mingw64\bin\ccache.exe" "-DCMAKE_PREFIX_PATH=C:\tools\msys64\mingw64" "-DCMAKE_UNITY_BUILD=${env:CMAKE_UNITY_BUILD}" -S . -B "build" -DLIBXML2_INCLUDE_DIR=C:/tools/msys64/mingw64/include -DGDAL_USE_LIBXML2:BOOL=OFF -DGDAL_USE_MYSQL:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=OFF -DBUILD_CSHARP_BINDINGS=OFF
         working-directory: ${{ github.workspace }}
       - name: Build
         run: cmake --build build -j 3
@@ -170,9 +171,10 @@ jobs:
       # Note that the leading space in CMAKE_C/CXX_FLAGS=" /WX" is due to using Bash on Windows that would
       # otherwise interpret /bla has a file relative to the Bash root directory and would replace it by a path like c:\Program Files\git\WX
       # BUILD_JAVA_BINDINGS=OFF because we get "Error occurred during initialization of VM.   Corrupted ZIP library: C:\Miniconda\envs\gdalenv\Library\bin\zip.dll" when running java. Not reproducible on a standard VM
+      # BUILD_CSHARP_BINDINGS=OFF because we get "AssemblyInfo.cs(98,12): error CS0246: The type or namespace name 'SecurityRules' could not be found (are you missing a using directive or an assembly reference?)" with Microsoft (R) Visual C# 2005 Compiler version 8.00.50727.9031 for Microsoft (R) Windows (R) 2005 Framework version 2.0.50727
       run: |
         mkdir -p $GITHUB_WORKSPACE/build
-        cmake -A ${architecture} -G "${generator}" "-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal" "-DCMAKE_C_COMPILER_LAUNCHER=clcache" "-DCMAKE_CXX_COMPILER_LAUNCHER=clcache" "-DCMAKE_PREFIX_PATH=${CONDA_PREFIX}" -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} -S "$GITHUB_WORKSPACE" -B "$GITHUB_WORKSPACE/build" -DSPATIALITE_LIBRARY:FILEPATH= -DJASPER_LIBRARY_RELEASE:FILEPATH= -DMYSQL_LIBRARY:FILEPATH= -DLIBKML_BASE_LIBRARY:FILEPATH= -DGDAL_ENABLE_PLUGINS:BOOL=ON -DGDAL_ENABLE_PLUGINS_NO_DEPS:BOOL=ON -DGDAL_USE_PUBLICDECOMPWT:BOOL=ON -DBUILD_JAVA_BINDINGS=OFF -DCMAKE_C_FLAGS=" /WX" -DCMAKE_CXX_FLAGS=" /WX"
+        cmake -A ${architecture} -G "${generator}" "-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal" "-DCMAKE_C_COMPILER_LAUNCHER=clcache" "-DCMAKE_CXX_COMPILER_LAUNCHER=clcache" "-DCMAKE_PREFIX_PATH=${CONDA_PREFIX}" -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} -S "$GITHUB_WORKSPACE" -B "$GITHUB_WORKSPACE/build" -DSPATIALITE_LIBRARY:FILEPATH= -DJASPER_LIBRARY_RELEASE:FILEPATH= -DMYSQL_LIBRARY:FILEPATH= -DLIBKML_BASE_LIBRARY:FILEPATH= -DGDAL_ENABLE_PLUGINS:BOOL=ON -DGDAL_ENABLE_PLUGINS_NO_DEPS:BOOL=ON -DGDAL_USE_PUBLICDECOMPWT:BOOL=ON -DBUILD_JAVA_BINDINGS=OFF -DBUILD_CSHARP_BINDINGS=OFF -DCMAKE_C_FLAGS=" /WX" -DCMAKE_CXX_FLAGS=" /WX"
     - name: Build
       shell: bash -l {0}
       run: cmake --build $GITHUB_WORKSPACE/build --config Release -j 2

--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -48,46 +48,23 @@ target_include_directories(
                          $<TARGET_PROPERTY:appslib,SOURCE_DIR> $<TARGET_PROPERTY:gdal_vrt,SOURCE_DIR>)
 target_compile_definitions(gdal_unit_test PRIVATE -DGDAL_TEST_ROOT_DIR="${GDAL_ROOT_TEST_DIR}")
 
-set(TEST_ENV)
+include(GdalSetTestEnv)
+gdal_set_test_env(TEST_ENV)
+
 if (MINGW)
   list(APPEND TEST_ENV SKIP_MEM_INTENSIVE_TEST=YES)
 endif ()
 
-# Set PATH / LD_LIBRARY_PATH
-set(GDAL_OUTPUT_DIR "$<SHELL_PATH:$<TARGET_FILE_DIR:${GDAL_LIB_TARGET_NAME}>>")
 if (WIN32)
   # If running GDAL as a CustomBuild Command os MSBuild, "ERROR bla:" is considered as failing the job. This is rarely
   # the intended behavior
   list(APPEND TEST_ENV "CPL_ERROR_SEPARATOR=\\;")
-
-  string(REPLACE ";" "\\;" PATH_ESCAPED "$ENV{PATH}")
-  list(APPEND TEST_ENV "PATH=${GDAL_OUTPUT_DIR}\\;${PATH_ESCAPED}")
-else ()
-  list(APPEND TEST_ENV "LD_LIBRARY_PATH=${GDAL_OUTPUT_DIR}:$ENV{LD_LIBRARY_PATH}")
 endif ()
 
 if (WIN32 OR APPLE)
   # Recoding tests in test_cpl.cpp fail on Windows and Mac
   list(APPEND TEST_ENV DO_NOT_FAIL_ON_RECODE_ERRORS=YES)
 endif ()
-
-# Set GDAL_DRIVER_PATH We request the TARGET_FILE_DIR of one of the plugins, since the PLUGIN_OUTPUT_DIR will not
-# contain the \Release suffix with MSVC generator
-get_property(PLUGIN_MODULES GLOBAL PROPERTY PLUGIN_MODULES)
-list(LENGTH PLUGIN_MODULES PLUGIN_MODULES_LENGTH)
-if (PLUGIN_MODULES_LENGTH GREATER_EQUAL 1)
-  list(GET PLUGIN_MODULES 0 FIRST_TARGET)
-  set(PLUGIN_OUTPUT_DIR "$<SHELL_PATH:$<TARGET_FILE_DIR:${FIRST_TARGET}>>")
-  list(APPEND TEST_ENV "GDAL_DRIVER_PATH=${PLUGIN_OUTPUT_DIR}")
-else ()
-  # if no plugins are configured, set up a dummy path, to avoid loading installed plugins (from a previous install
-  # execution) that could have a different ABI
-  list(APPEND TEST_ENV "GDAL_DRIVER_PATH=dummy")
-endif ()
-
-# Set GDAL_DATA
-file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/data" GDAL_DATA)
-list(APPEND TEST_ENV "GDAL_DATA=${GDAL_DATA}")
 
 macro (register_test_as_custom_target _test_name _binary_name)
   if (NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)

--- a/cmake/helpers/GdalSetTestEnv.cmake
+++ b/cmake/helpers/GdalSetTestEnv.cmake
@@ -1,0 +1,30 @@
+function(gdal_set_test_env res)
+  # Set PATH / LD_LIBRARY_PATH
+  set(GDAL_OUTPUT_DIR "$<SHELL_PATH:$<TARGET_FILE_DIR:${GDAL_LIB_TARGET_NAME}>>")
+  if (WIN32)
+    string(REPLACE ";" "\\;" PATH_ESCAPED "$ENV{PATH}")
+    list(APPEND TEST_ENV "PATH=${GDAL_OUTPUT_DIR}\\;${PATH_ESCAPED}")
+  else ()
+    list(APPEND TEST_ENV "LD_LIBRARY_PATH=${GDAL_OUTPUT_DIR}:$ENV{LD_LIBRARY_PATH}")
+  endif ()
+
+  # Set GDAL_DRIVER_PATH We request the TARGET_FILE_DIR of one of the plugins, since the PLUGIN_OUTPUT_DIR will not
+  # contain the \Release suffix with MSVC generator
+  get_property(PLUGIN_MODULES GLOBAL PROPERTY PLUGIN_MODULES)
+  list(LENGTH PLUGIN_MODULES PLUGIN_MODULES_LENGTH)
+  if (PLUGIN_MODULES_LENGTH GREATER_EQUAL 1)
+    list(GET PLUGIN_MODULES 0 FIRST_TARGET)
+    set(PLUGIN_OUTPUT_DIR "$<SHELL_PATH:$<TARGET_FILE_DIR:${FIRST_TARGET}>>")
+    list(APPEND TEST_ENV "GDAL_DRIVER_PATH=${PLUGIN_OUTPUT_DIR}")
+  else ()
+    # if no plugins are configured, set up a dummy path, to avoid loading installed plugins (from a previous install
+    # execution) that could have a different ABI
+    list(APPEND TEST_ENV "GDAL_DRIVER_PATH=dummy")
+  endif ()
+
+  # Set GDAL_DATA
+  file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/data" GDAL_DATA)
+  list(APPEND TEST_ENV "GDAL_DATA=${GDAL_DATA}")
+
+  set(${res} "${TEST_ENV}" PARENT_SCOPE)
+endfunction()

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -598,10 +598,13 @@ system_summary(DESCRIPTION "GDAL is now configured on;")
 
 # Do not warn about Shapelib being an optional package not found, as we
 # don't recommend using it
+# Mono/DotNetFrameworkSdk is also an internal detail of CSharp that we don't want to report
 get_property(_packages_not_found GLOBAL PROPERTY PACKAGES_NOT_FOUND)
 set(_new_packages_not_found)
 foreach(_package IN LISTS _packages_not_found)
-    if(NOT ${_package} STREQUAL "Shapelib")
+    if(NOT ${_package} STREQUAL "Shapelib" AND
+       NOT ${_package} STREQUAL "Mono" AND
+       NOT ${_package} STREQUAL "DotNetFrameworkSdk")
         set(_new_packages_not_found ${_new_packages_not_found} "${_package}")
     endif()
 endforeach()

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -24,6 +24,7 @@ set(GDAL_SWIG_COMMON_INTERFACE_FILES
 
 option(BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
 option(BUILD_JAVA_BINDINGS "Build Java bindings" ON)
+option(BUILD_CSHARP_BINDINGS "Build CSharp bindings" ON)
 
 if (BUILD_PYTHON_BINDINGS)
   add_subdirectory(python)
@@ -37,12 +38,9 @@ if (SWIG_EXECUTABLE
     AND BUILD_JAVA_BINDINGS)
   add_subdirectory(java)
 endif ()
-if (UNIX)
-  if (PERL_FOUND)
-    # add_subdirectory(perl)
-  endif ()
-else ()
-  if (CSHARP_FOUND)
-    # add_subdirectory(csharp)
-  endif ()
+
+if (BUILD_CSHARP_BINDINGS
+    AND SWIG_EXECUTABLE
+    AND CSHARP_FOUND)
+  add_subdirectory(csharp)
 endif ()

--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -5,6 +5,10 @@ if (CMAKE_CXX_FLAGS)
   string(REPLACE "/WX" " " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif ()
 
+set(GDAL_CSHARP_INSTALL_DIR
+    "${CMAKE_INSTALL_DATADIR}/csharp"
+    CACHE PATH "Installation sub-directory for CSharp bindings")
+
 # function for csharp build
 function (gdal_csharp_dll)
   set(_options)
@@ -46,6 +50,17 @@ function (gdal_csharp_dll)
     VERBATIM
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_WRAPPER}.cpp ${_depends} ${CMAKE_CURRENT_BINARY_DIR}/gdal.snk
             ${CMAKE_CURRENT_SOURCE_DIR}/AssemblyInfo.cs)
+
+  install(
+    TARGETS ${_CSHARP_WRAPPER}
+    COMPONENT csharp
+    DESTINATION ${GDAL_CSHARP_INSTALL_DIR})
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET}
+    COMPONENT csharp
+    DESTINATION ${GDAL_CSHARP_INSTALL_DIR})
+
 endfunction ()
 
 # ######################################################################################################################
@@ -201,7 +216,17 @@ add_custom_target(
           ${CMAKE_CURRENT_BINARY_DIR}/GDALOverviews.exe
           ${CMAKE_CURRENT_BINARY_DIR}/GDALCreateCopy.exe
           ${CMAKE_CURRENT_BINARY_DIR}/GDALGetHistogram.exe)
-add_custom_target(csharp_binding ALL DEPENDS gdalconst_wrap osr_wrap ogr_wrap gdal_wrap csharp_samples)
+add_custom_target(
+  csharp_binding ALL
+  DEPENDS gdalconst_csharp.dll
+          osr_csharp.dll
+          ogr_csharp.dll
+          gdal_csharp.dll
+          gdalconst_wrap
+          osr_wrap
+          ogr_wrap
+          gdal_wrap
+          csharp_samples)
 
 if (CSHARP_INTERPRETER OR WIN32)
   include(GdalSetTestEnv)

--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -24,18 +24,9 @@ function (gdal_csharp_dll)
             ${_CSHARP_SWIG_INTERFACE})
   set_source_files_properties(${_CSHARP_WRAPPER} PROPERTIES GENERATED 1)
 
-  set(_wrapper_name "${_CSHARP_WRAPPER}_csharp")
-  add_library(${_wrapper_name} SHARED ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_WRAPPER}.cpp)
-  if (WIN32)
-    set_target_properties(${_wrapper_name} PROPERTIES OUTPUT_NAME "${_CSHARP_WRAPPER}")
-  endif ()
-  gdal_standard_includes(${_wrapper_name})
-  target_link_libraries(${_wrapper_name} PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
-
-  if (NOT WIN32)
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET}.config
-         "<configuration>\n<dllmap dll=\"${_CSHARP_WRAPPER}\" target=\"${_wrapper_name}\"/>\n</configuration>\n")
-  endif ()
+  add_library(${_CSHARP_WRAPPER} SHARED ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_WRAPPER}.cpp)
+  gdal_standard_includes(${_CSHARP_WRAPPER})
+  target_link_libraries(${_CSHARP_WRAPPER} PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
 
   set(_depends)
   if (_CSHARP_DEPENDS)
@@ -86,10 +77,7 @@ gdal_csharp_dll(
   SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/gdal.i TARGET_SUBDIR gdal
   DEPENDS ogr_csharp.dll osr_csharp.dll)
 
-set_directory_properties(
-  PROPERTIES
-    ADDITIONAL_MAKE_CLEAN_FILES
-    "gdal;ogr;osr;const;gdal_csharp.dll.config;ogr_csharp.dll.config;osr_csharp.dll.config;gdalconst_csharp.dll.config")
+set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "gdal;ogr;osr;const")
 
 # ######################################################################################################################
 # sample commands
@@ -213,8 +201,7 @@ add_custom_target(
           ${CMAKE_CURRENT_BINARY_DIR}/GDALOverviews.exe
           ${CMAKE_CURRENT_BINARY_DIR}/GDALCreateCopy.exe
           ${CMAKE_CURRENT_BINARY_DIR}/GDALGetHistogram.exe)
-add_custom_target(csharp_binding ALL DEPENDS gdalconst_wrap_csharp osr_wrap_csharp ogr_wrap_csharp gdal_wrap_csharp
-                                             csharp_samples)
+add_custom_target(csharp_binding ALL DEPENDS gdalconst_wrap osr_wrap ogr_wrap gdal_wrap csharp_samples)
 
 if (CSHARP_INTERPRETER OR WIN32)
   include(GdalSetTestEnv)

--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -1,225 +1,271 @@
 include(GdalStandardIncludes)
+
+if (CMAKE_CXX_FLAGS)
+  string(REPLACE "-Werror" " " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  string(REPLACE "/WX" " " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif ()
+
 # function for csharp build
 function (gdal_csharp_dll)
   set(_options)
-  set(_oneValueArgs WRAPPER WORKING_DIRECTORY SWIG_INTERFACE NAMESPACE TARGET DEPENDS)
-  set(_multiValueArgs CS_SOURCES)
+  set(_oneValueArgs WRAPPER SWIG_INTERFACE NAMESPACE TARGET TARGET_SUBDIR)
+  set(_multiValueArgs DEPENDS)
   cmake_parse_arguments(_CSHARP "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
-  file(MAKE_DIRECTORY ${_CSHARP_WORKING_DIRECTORY})
+  set(_CSHARP_WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET_SUBDIR})
   add_custom_command(
-    OUTPUT ${_CSHARP_WORKING_DIRECTORY}/${_CSHARP_WRAPPER}.cpp ${_CSHARP_CS_SOURCES}
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_WRAPPER}.cpp
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${_CSHARP_WORKING_DIRECTORY}
     COMMAND
       ${SWIG_EXECUTABLE} -namespace ${_CSHARP_NAMESPACE} -outdir ${_CSHARP_WORKING_DIRECTORY} -DSWIG2_CSHARP -dllimport
       ${_CSHARP_WRAPPER} -Wall -I${PROJECT_SOURCE_DIR}/swig/include -I${PROJECT_SOURCE_DIR}/swig/include/csharp
       -I${PROJECT_SOURCE_DIR}/gdal -c++ -csharp -o ${_CSHARP_WRAPPER}.cpp ${_CSHARP_SWIG_INTERFACE}
-    WORKING_DIRECTORY ${_CSHARP_WORKING_DIRECTORY}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${GDAL_SWIG_COMMON_INCLUDE} ${PROJECT_SOURCE_DIR}/swig/include/csharp/typemaps_csharp.i
             ${_CSHARP_SWIG_INTERFACE})
   set_source_files_properties(${_CSHARP_WRAPPER} PROPERTIES GENERATED 1)
-  add_library(${_CSHARP_WRAPPER} OBJECT ${_CSHARP_WORKING_DIRECTORY}/${_CSHARP_WRAPPER}.cpp)
-  gdal_standard_includes(${_CSHARP_WRAPPER})
+
+  set(_wrapper_name "${_CSHARP_WRAPPER}_csharp")
+  add_library(${_wrapper_name} SHARED ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_WRAPPER}.cpp)
+  if (WIN32)
+    set_target_properties(${_wrapper_name} PROPERTIES OUTPUT_NAME "${_CSHARP_WRAPPER}")
+  endif ()
+  gdal_standard_includes(${_wrapper_name})
+  target_link_libraries(${_wrapper_name} PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
+
+  if (NOT WIN32)
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET}.config
+         "<configuration>\n<dllmap dll=\"${_CSHARP_WRAPPER}\" target=\"${_wrapper_name}\"/>\n</configuration>\n")
+  endif ()
+
+  set(_depends)
   if (_CSHARP_DEPENDS)
-    set(CSC_OPTIONS /debug:full /target:library /out:${_CSHARP_TARGET} /r:${_CSHARP_DEPENDS})
-  else ()
-    set(CSC_OPTIONS /debug:full /target:library /out:${_CSHARP_TARGET})
+    set(_CSHARP_DEPENDS_ARGS "-DCSHARP_DEPENDS=${_CSHARP_DEPENDS}")
+    string(REPLACE ";" "\\;" _CSHARP_DEPENDS_ARGS "${_CSHARP_DEPENDS_ARGS}")
+    foreach (_dep IN LISTS _CSHARP_DEPENDS)
+      list(APPEND _depends ${CMAKE_CURRENT_BINARY_DIR}/${_dep})
+    endforeach ()
   endif ()
   add_custom_command(
-    OUTPUT ${_CSHARP_TARGET}
-    COMMAND ${CSHARP_COMPILER} ${CSC_OPTIONS} ${_CSHARP_CS_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/AssemblyInfo.cs
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET}
+    COMMAND
+      ${CMAKE_COMMAND} "-DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}" "-DBUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+      "-DCSHARP_COMPILER=${CSHARP_COMPILER}" "-DCSHARP_TARGET=${_CSHARP_TARGET}" ${_CSHARP_DEPENDS_ARGS}
+      "-DTARGET_SUBDIR=${_CSHARP_TARGET_SUBDIR}" -P "${CMAKE_CURRENT_SOURCE_DIR}/build_dll.cmake"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${_CSHARP_WRAPPER} ${_CSHARP_DEPENDS} ${CMAKE_CURRENT_BINARY_DIR}/gdal.snk AssemblyInfo.cs
-            ${_CSHARP_CS_SOURCES})
+    VERBATIM
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_WRAPPER}.cpp ${_depends} ${CMAKE_CURRENT_BINARY_DIR}/gdal.snk
+            ${CMAKE_CURRENT_SOURCE_DIR}/AssemblyInfo.cs)
 endfunction ()
 
 # ######################################################################################################################
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gdal.snk
-                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gdal.snk ${CMAKE_CURRENT_BINARY_DIR})
-gdal_csharp_dll(
-  TARGET gdal_csharp.dll
-  NAMESPACE OSGeo.GDAL
-  WRAPPER gdal_wrap
-  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/gdal.i
-  CS_SOURCES gdal/Access.cs
-             gdal/GDALWarpAppOptions.cs
-             gdal/AsyncReader.cs
-             gdal/Gdal.cs
-             gdal/AsyncStatusType.cs
-             gdal/GdalPINVOKE.cs
-             gdal/Band.cs
-             gdal/MajorObject.cs
-             gdal/CPLErr.cs
-             gdal/PaletteInterp.cs
-             gdal/ColorEntry.cs
-             gdal/RATFieldType.cs
-             gdal/ColorInterp.cs
-             gdal/RATFieldUsage.cs
-             gdal/RATTableType.cs
-             gdal/ColorTable.cs
-             gdal/RIOResampleAlg.cs
-             gdal/DataType.cs
-             gdal/RWFlag.cs
-             gdal/Dataset.cs
-             gdal/RasterAttributeTable.cs
-             gdal/Driver.cs
-             gdal/RasterIOExtraArg.cs
-             gdal/GCP.cs
-             gdal/ResampleAlg.cs
-             gdal/GDALBuildVRTOptions.cs
-             gdal/SWIGTYPE_p_GDALProgressFunc.cs
-             gdal/GDALDEMProcessingOptions.cs
-             gdal/SWIGTYPE_p_int.cs
-             gdal/GDALGridOptions.cs
-             gdal/SWIGTYPE_p_p_GDALDatasetShadow.cs
-             gdal/GDALInfoOptions.cs
-             gdal/SWIGTYPE_p_p_GDALRasterBandShadow.cs
-             gdal/GDALNearblackOptions.cs
-             gdal/Transformer.cs
-             gdal/GDALRasterizeOptions.cs
-             gdal/XMLNode.cs
-             gdal/GDALTranslateOptions.cs
-             gdal/XMLNodeType.cs
-             gdal/GDALVectorTranslateOptions.cs
-             gdal/SWIGTYPE_p_void.cs
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gdal
-  DEPENDS ogr_csharp.dll)
-gdal_csharp_dll(
-  TARGET ogr_csharp.dll
-  NAMESPACE OSGeo.OGR
-  WRAPPER ogr_wrap
-  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/ogr.i
-  CS_SOURCES ogr/DataSource.cs
-             ogr/FieldDefn.cs
-             ogr/Layer.cs
-             ogr/Driver.cs
-             ogr/FieldSubType.cs
-             ogr/Ogr.cs
-             ogr/Envelope.cs
-             ogr/FieldType.cs
-             ogr/OgrPINVOKE.cs
-             ogr/Envelope3D.cs
-             ogr/GeomFieldDefn.cs
-             ogr/StyleTable.cs
-             ogr/Feature.cs
-             ogr/Geometry.cs
-             ogr/wkbByteOrder.cs
-             ogr/FeatureDefn.cs
-             ogr/Justification.cs
-             ogr/wkbGeometryType.cs
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ogr
-  DEPENDS osr_csharp.dll)
-gdal_csharp_dll(
-  TARGET osr_csharp.dll
-  NAMESPACE OSGeo.OSR
-  WRAPPER osr_wrap
-  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/osr.i
-  CS_SOURCES osr/AxisOrientation.cs osr/Osr.cs osr/SpatialReference.cs osr/CoordinateTransformation.cs osr/OsrPINVOKE.cs
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/osr)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gdal.snk ${CMAKE_CURRENT_BINARY_DIR}/gdal.snk COPYONLY)
+
 gdal_csharp_dll(
   TARGET gdalconst_csharp.dll
   NAMESPACE OSGeo.GDAL
   WRAPPER gdalconst_wrap
-  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/gdalconst.i
-  CS_SOURCES const/GdalConst.cs const/GdalConstPINVOKE.cs
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/const)
+  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/gdalconst.i TARGET_SUBDIR const)
+
+gdal_csharp_dll(
+  TARGET osr_csharp.dll
+  NAMESPACE OSGeo.OSR
+  WRAPPER osr_wrap
+  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/osr.i TARGET_SUBDIR osr)
+
+gdal_csharp_dll(
+  TARGET ogr_csharp.dll
+  NAMESPACE OSGeo.OGR
+  WRAPPER ogr_wrap
+  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/ogr.i TARGET_SUBDIR ogr
+  DEPENDS osr_csharp.dll)
+
+gdal_csharp_dll(
+  TARGET gdal_csharp.dll
+  NAMESPACE OSGeo.GDAL
+  WRAPPER gdal_wrap
+  SWIG_INTERFACE ${PROJECT_SOURCE_DIR}/swig/include/gdal.i TARGET_SUBDIR gdal
+  DEPENDS ogr_csharp.dll osr_csharp.dll)
+
+set_directory_properties(
+  PROPERTIES
+    ADDITIONAL_MAKE_CLEAN_FILES
+    "gdal;ogr;osr;const;gdal_csharp.dll.config;ogr_csharp.dll.config;osr_csharp.dll.config;gdalconst_csharp.dll.config")
+
 # ######################################################################################################################
 # sample commands
-add_custom_command(
-  OUTPUT ogrinfo.exe
-  COMMAND ${CSHARP_COMPILER} /r:ogr_csharp.dll /r:osr_csharp.dll /out:ogrinfo.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/ogrinfo.cs
-  DEPENDS ogr_csharp.dll osr_csharp.dll)
-add_custom_command(
-  OUTPUT createdata.exe
-  COMMAND ${CSHARP_COMPILER} /r:ogr_csharp.dll /r:osr_csharp.dll /out:createdata.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/createdata.cs
-  DEPENDS ogr_csharp.dll osr_csharp.dll)
-add_custom_command(
-  OUTPUT OSRTransform.exe
-  COMMAND ${CSHARP_COMPILER} /r:osr_csharp.dll /out:OSRTransform.exe ${CMAKE_CURRENT_SOURCE_DIR}/apps/OSRTransform.cs
-  DEPENDS osr_csharp.dll)
-add_custom_command(
-  OUTPUT GDALRead.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /r:System.Drawing.dll /out:GDALRead.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALRead.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALReadDirect.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /r:System.Drawing.dll /out:GDALReadDirect.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALReadDirect.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALAdjustContrast.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /r:System.Drawing.dll /out:GDALAdjustContrast.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALAdjustContrast.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALDatasetRasterIO.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /r:System.Drawing.dll /out:GDALDatasetRasterIO.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALDatasetRasterIO.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALWrite.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /out:GDALWrite.exe ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALWrite.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALDatasetWrite.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /out:GDALDatasetWrite.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALDatasetWrite.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALColorTable.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /out:GDALColorTable.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALColorTable.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT WKT2WKB.exe
-  COMMAND ${CSHARP_COMPILER} /r:ogr_csharp.dll /out:WKT2WKB.exe ${CMAKE_CURRENT_SOURCE_DIR}/apps/WKT2WKB.cs
-  DEPENDS ogr_csharp.dll)
-add_custom_command(
-  OUTPUT OGRGEOS.exe
-  COMMAND ${CSHARP_COMPILER} /r:ogr_csharp.dll /out:OGRGEOS.exe ${CMAKE_CURRENT_SOURCE_DIR}/apps/OGRGEOS.cs
-  DEPENDS ogr_csharp.dll)
-add_custom_command(
-  OUTPUT ReadXML.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /out:ReadXML.exe ${CMAKE_CURRENT_SOURCE_DIR}/apps/ReadXML.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALInfo.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /r:osr_csharp.dll /out:GDALInfo.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALInfo.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALOverviews.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /out:GDALOverviews.exe ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALOverviews.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALCreateCopy.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /out:GDALCreateCopy.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALCreateCopy.cs
-  DEPENDS gdal_csharp.dll)
-add_custom_command(
-  OUTPUT GDALGetHistogram.exe
-  COMMAND ${CSHARP_COMPILER} /r:gdal_csharp.dll /out:GDALGetHistogram.exe
-          ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALGetHistogram.cs
-  DEPENDS gdal_csharp.dll)
+
+function (gdal_build_csharp_sample)
+  set(_options)
+  set(_oneValueArgs SOURCE OUTPUT)
+  set(_multiValueArgs DEPENDS SYSTEM_DEPENDS)
+  cmake_parse_arguments(_GBCS "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
+  set(CSC_OPTIONS)
+  set(_depends)
+  foreach (_dep IN LISTS _GBCS_DEPENDS)
+    list(APPEND CSC_OPTIONS /r:${_dep})
+    list(APPEND _depends "${CMAKE_CURRENT_BINARY_DIR}/${_dep}")
+  endforeach ()
+  foreach (_dep IN LISTS _GBCS_SYSTEM_DEPENDS)
+    list(APPEND CSC_OPTIONS /r:${_dep})
+  endforeach ()
+  file(TO_NATIVE_PATH "${_GBCS_SOURCE}" SOURCE_NATIVE)
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_GBCS_OUTPUT}
+    COMMAND ${CSHARP_COMPILER} ${CSC_OPTIONS} /out:${_GBCS_OUTPUT} ${SOURCE_NATIVE}
+    DEPENDS ${_depends} ${_GBCS_SOURCE})
+endfunction ()
+
+gdal_build_csharp_sample(
+  OUTPUT
+  ogrinfo.exe
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/apps/ogrinfo.cs
+  DEPENDS
+  ogr_csharp.dll
+  osr_csharp.dll)
+gdal_build_csharp_sample(
+  OUTPUT
+  createdata.exe
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/apps/createdata.cs
+  DEPENDS
+  ogr_csharp.dll
+  osr_csharp.dll)
+gdal_build_csharp_sample(OUTPUT OSRTransform.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/OSRTransform.cs DEPENDS
+                         osr_csharp.dll)
+gdal_build_csharp_sample(
+  OUTPUT
+  GDALRead.exe
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALRead.cs
+  DEPENDS
+  gdal_csharp.dll
+  SYSTEM_DEPENDS
+  System.Drawing.dll)
+gdal_build_csharp_sample(
+  OUTPUT
+  GDALReadDirect.exe
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALReadDirect.cs
+  DEPENDS
+  gdal_csharp.dll
+  SYSTEM_DEPENDS
+  System.Drawing.dll)
+gdal_build_csharp_sample(
+  OUTPUT
+  GDALAdjustContrast.exe
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALAdjustContrast.cs
+  DEPENDS
+  gdal_csharp.dll
+  SYSTEM_DEPENDS
+  System.Drawing.dll)
+gdal_build_csharp_sample(
+  OUTPUT
+  GDALDatasetRasterIO.exe
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALDatasetRasterIO.cs
+  DEPENDS
+  gdal_csharp.dll
+  SYSTEM_DEPENDS
+  System.Drawing.dll)
+gdal_build_csharp_sample(OUTPUT GDALWrite.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALWrite.cs DEPENDS
+                         gdal_csharp.dll)
+gdal_build_csharp_sample(OUTPUT GDALDatasetWrite.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALDatasetWrite.cs
+                         DEPENDS gdal_csharp.dll)
+gdal_build_csharp_sample(OUTPUT GDALColorTable.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALColorTable.cs DEPENDS
+                         gdal_csharp.dll)
+gdal_build_csharp_sample(OUTPUT WKT2WKB.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/WKT2WKB.cs DEPENDS ogr_csharp.dll)
+gdal_build_csharp_sample(OUTPUT OGRGEOS.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/OGRGEOS.cs DEPENDS ogr_csharp.dll)
+gdal_build_csharp_sample(OUTPUT ReadXML.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/ReadXML.cs DEPENDS gdal_csharp.dll)
+gdal_build_csharp_sample(
+  OUTPUT
+  GDALInfo.exe
+  SOURCE
+  ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALInfo.cs
+  DEPENDS
+  gdal_csharp.dll
+  osr_csharp.dll)
+gdal_build_csharp_sample(OUTPUT GDALOverviews.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALOverviews.cs DEPENDS
+                         gdal_csharp.dll)
+gdal_build_csharp_sample(OUTPUT GDALCreateCopy.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALCreateCopy.cs DEPENDS
+                         gdal_csharp.dll)
+gdal_build_csharp_sample(OUTPUT GDALGetHistogram.exe SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/GDALGetHistogram.cs
+                         DEPENDS gdal_csharp.dll)
+
 add_custom_target(
   csharp_samples
-  DEPENDS ogrinfo.exe
-          createdata.exe
-          OSRTransform.exe
-          GDALRead.exe
-          GDALReadDirect.exe
-          GDALAdjustContrast.exe
-          GDALDatasetRasterIO.exe
-          GDALWrite.exe
-          GDALDatasetWrite.exe
-          GDALColorTable.exe
-          WKT2WKB.exe
-          OGRGEOS.exe
-          ReadXML.exe
-          GDALInfo.exe
-          GDALOverviews.exe
-          GDALCreateCopy.exe
-          GDALGetHistogram.exe)
-add_custom_target(csharp_binding ALL DEPENDS csharp_samples gdalconst_csharp.dll gdal_csharp.dll ogr_csharp.dll
-                                             osr_csharp.dll)
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ogrinfo.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/createdata.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/OSRTransform.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALRead.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALReadDirect.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALAdjustContrast.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALDatasetRasterIO.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALWrite.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALDatasetWrite.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALColorTable.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/WKT2WKB.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/OGRGEOS.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/ReadXML.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALInfo.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALOverviews.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALCreateCopy.exe
+          ${CMAKE_CURRENT_BINARY_DIR}/GDALGetHistogram.exe)
+add_custom_target(csharp_binding ALL DEPENDS gdalconst_wrap_csharp osr_wrap_csharp ogr_wrap_csharp gdal_wrap_csharp
+                                             csharp_samples)
+
+if (CSHARP_INTERPRETER OR WIN32)
+  include(GdalSetTestEnv)
+  gdal_set_test_env(TEST_ENV)
+
+  file(TO_NATIVE_PATH "/" _separator)
+
+  if (WIN32)
+    set(NEW_TEST_ENV)
+    foreach (_env IN LISTS TEST_ENV)
+      if (_env MATCHES "^PATH=.*$")
+        string(REPLACE ";" "\\;" _env "${_env}")
+        list(APPEND NEW_TEST_ENV "${_env}\\;$<SHELL_PATH:$<TARGET_FILE_DIR:gdal_wrap_csharp>>")
+      else ()
+        list(APPEND NEW_TEST_ENV "${_env}")
+      endif ()
+    endforeach ()
+    set(TEST_ENV "${NEW_TEST_ENV}")
+  endif ()
+
+  add_test(NAME csharp_createdata COMMAND ${CSHARP_INTERPRETER} createdata.exe
+                                          ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data pointlayer)
+  add_test(NAME csharp_ogrinfo COMMAND ${CSHARP_INTERPRETER} ogrinfo.exe
+                                       ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data${_separator}pointlayer.shp)
+  add_test(NAME csharp_GDALWrite COMMAND ${CSHARP_INTERPRETER} GDALWrite.exe
+                                         ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data${_separator}sample.tif)
+  add_test(NAME csharp_GDALDatasetWrite COMMAND ${CSHARP_INTERPRETER} GDALDatasetWrite.exe
+                                                ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data${_separator}sample.tif)
+  add_test(
+    NAME csharp_GDALCreateCopy
+    COMMAND
+      ${CSHARP_INTERPRETER} GDALCreateCopy.exe ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data${_separator}sample.tif
+      ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data${_separator}sample2.tif)
+  add_test(NAME csharp_GDALOverviews
+           COMMAND ${CSHARP_INTERPRETER} GDALOverviews.exe
+                   ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data${_separator}sample.tif NEAREST 2 4)
+  add_test(NAME csharp_GDALInfo COMMAND ${CSHARP_INTERPRETER} GDALInfo.exe
+                                        ${CMAKE_CURRENT_SOURCE_DIR}${_separator}Data${_separator}sample.tif)
+  add_test(NAME csharp_OSRTransform COMMAND ${CSHARP_INTERPRETER} OSRTransform.exe)
+
+  foreach (
+    test_name IN
+    ITEMS csharp_createdata
+          csharp_ogrinfo
+          csharp_GDALWrite
+          csharp_GDALDatasetWrite
+          csharp_GDALCreateCopy
+          csharp_GDALOverviews
+          csharp_GDALInfo
+          csharp_OSRTransform)
+    set_property(TEST ${test_name} PROPERTY ENVIRONMENT "${TEST_ENV}")
+  endforeach ()
+
+endif ()

--- a/swig/csharp/build_dll.cmake
+++ b/swig/csharp/build_dll.cmake
@@ -1,0 +1,20 @@
+set(CSC_OPTIONS /unsafe /debug:full /target:library /out:${CSHARP_TARGET})
+if(CSHARP_DEPENDS)
+    foreach(_depends IN LISTS CSHARP_DEPENDS)
+        list(APPEND CSC_OPTIONS /r:${_depends})
+    endforeach ()
+endif()
+if(WIN32)
+    list(APPEND CSC_OPTIONS /define:CLR4)
+endif()
+file(GLOB SOURCES "${BUILD_DIR}/${TARGET_SUBDIR}/*.cs")
+list(APPEND SOURCES ${SOURCE_DIR}/AssemblyInfo.cs)
+set(NATIVE_SOURCES)
+foreach(_src IN LISTS SOURCES)
+    file(TO_NATIVE_PATH "${_src}" _src)
+    list(APPEND NATIVE_SOURCES "${_src}")
+endforeach()
+execute_process(
+    COMMAND ${CSHARP_COMPILER} ${CSC_OPTIONS} ${NATIVE_SOURCES}
+    # COMMAND_ECHO STDOUT
+    WORKING_DIRECTORY ${BUILD_DIR})

--- a/swig/java/CMakeLists.txt
+++ b/swig/java/CMakeLists.txt
@@ -170,32 +170,8 @@ if (Java_Runtime_FOUND)
     set(CLASSPATH_SEPARATOR ":")
   endif ()
 
-  # Set PATH / LD_LIBRARY_PATH
-  set(GDAL_OUTPUT_DIR "$<SHELL_PATH:$<TARGET_FILE_DIR:${GDAL_LIB_TARGET_NAME}>>")
-  if (WIN32)
-    string(REPLACE ";" "\\;" PATH_ESCAPED "$ENV{PATH}")
-    list(APPEND TEST_ENV "PATH=${GDAL_OUTPUT_DIR}\\;${PATH_ESCAPED}")
-  else ()
-    list(APPEND TEST_ENV "LD_LIBRARY_PATH=${GDAL_OUTPUT_DIR}:$ENV{LD_LIBRARY_PATH}")
-  endif ()
-
-  # Set GDAL_DRIVER_PATH We request the TARGET_FILE_DIR of one of the plugins, since the PLUGIN_OUTPUT_DIR will not
-  # contain the \Release suffix with MSVC generator
-  get_property(PLUGIN_MODULES GLOBAL PROPERTY PLUGIN_MODULES)
-  list(LENGTH PLUGIN_MODULES PLUGIN_MODULES_LENGTH)
-  if (PLUGIN_MODULES_LENGTH GREATER_EQUAL 1)
-    list(GET PLUGIN_MODULES 0 FIRST_TARGET)
-    set(PLUGIN_OUTPUT_DIR "$<SHELL_PATH:$<TARGET_FILE_DIR:${FIRST_TARGET}>>")
-    list(APPEND TEST_ENV "GDAL_DRIVER_PATH=${PLUGIN_OUTPUT_DIR}")
-  else ()
-    # if no plugins are configured, set up a dummy path, to avoid loading installed plugins (from a previous install
-    # execution) that could have a different ABI
-    list(APPEND TEST_ENV "GDAL_DRIVER_PATH=dummy")
-  endif ()
-
-  # Set GDAL_DATA
-  file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/data" GDAL_DATA)
-  list(APPEND TEST_ENV "GDAL_DATA=${GDAL_DATA}")
+  include(GdalSetTestEnv)
+  gdal_set_test_env(TEST_ENV)
 
   set(JAVA_RUN ${Java_JAVA_EXECUTABLE} "-Djava.library.path=$<SHELL_PATH:$<TARGET_FILE_DIR:gdalalljni>>" -cp
                "gdal.jar${CLASSPATH_SEPARATOR}build/apps")


### PR DESCRIPTION
Note that it is currently disabled on the CMake Windows CI because we
get the following error:
```
Microsoft (R) Visual C# 2005 Compiler version 8.00.50727.9031
for Microsoft (R) Windows (R) 2005 Framework version 2.0.50727
Copyright (C) Microsoft Corporation 2001-2005. All rights reserved.
d:\a\gdal\gdal\swig\csharp\AssemblyInfo.cs(98,12): error CS0246: The type or namespace name 'SecurityRules' could not be found (are you missing a using directive or an assembly reference?) [D:\a\gdal\gdal\build\swig\csharp\csharp_samples.vcxproj]
```

Things works fine locally for me with Microsoft (R) Visual C# Compiler version 3.9.0-6.21124.20 (db94f4cc)

CC @szekerest  / @bjornharrtell  w.r.t above issue. I haven't also ported swig/csharp/makefile.vc logic related to using dotnet rather than mono. I hope any of will be able to pursue on this.
