### PR TITLE
OGR GMT: allow writing to /vsistdout/ (fixes #4993)

### DIFF
--- a/autotest/ogr/ogr_gmt.py
+++ b/autotest/ogr/ogr_gmt.py
@@ -213,3 +213,18 @@ def test_ogr_gmt_coord_only():
         lyr = ds.GetLayer(0)
         f = lyr.GetNextFeature()
         assert not ogrtest.check_feature_geometry(f, 'POINT Z (1 2 3)'), f.GetGeometryRef().ExportToIsoWkt()
+
+
+###############################################################################
+# Test writing to stdout
+
+
+def test_ogr_gmt_write_stdout():
+
+    gdal.VectorTranslate("/vsistdout_redirect//vsimem/test.gmt", "data/poly.shp", format="GMT")
+    ds = ogr.Open("/vsimem/test.gmt")
+    lyr = ds.GetLayer(0)
+    assert lyr.GetGeomType() == ogr.wkbPolygon
+    assert lyr.GetFeatureCount() == 10
+    ds = None
+    gdal.Unlink("/vsimem/test.gmt")

--- a/doc/source/drivers/vector/gmt.rst
+++ b/doc/source/drivers/vector/gmt.rst
@@ -35,3 +35,6 @@ features to existing files, but update of existing features is not
 supported. Each layer is created as a separate .gmt file. If a name that
 ends with .gmt is not given, then the GMT driver will take the layer
 name and add the ".gmt" extension.
+
+Writing to /dev/stdout or /vsistdout/ is supported since GDAL 3.5.0 (note
+that the file will then lack the optional region/bounding box header item)

--- a/ogr/ogrsf_frmts/gmt/ogr_gmt.h
+++ b/ogr/ogrsf_frmts/gmt/ogr_gmt.h
@@ -40,7 +40,7 @@
 
 class OGRGmtLayer final: public OGRLayer, public OGRGetNextFeatureThroughRaw<OGRGmtLayer>
 {
-    OGRSpatialReference *poSRS;
+    OGRSpatialReference *m_poSRS = nullptr;
     OGRFeatureDefn     *poFeatureDefn;
 
     int                 iNextFID;
@@ -52,7 +52,7 @@ class OGRGmtLayer final: public OGRLayer, public OGRGetNextFeatureThroughRaw<OGR
     OGREnvelope         sRegion;
     vsi_l_offset        nRegionOffset;
 
-    VSILFILE           *fp;
+    VSILFILE           *m_fp = nullptr;
 
     bool                ReadLine();
     CPLString           osLine;
@@ -69,7 +69,10 @@ class OGRGmtLayer final: public OGRLayer, public OGRGetNextFeatureThroughRaw<OGR
   public:
     bool                bValidFile;
 
-                        OGRGmtLayer( const char *pszFilename, int bUpdate );
+                        OGRGmtLayer( const char *pszFilename,
+                                     VSILFILE* fp,
+                                     const OGRSpatialReference* poSRS,
+                                     int bUpdate );
                         virtual ~OGRGmtLayer();
 
     void                ResetReading() override;
@@ -106,7 +109,10 @@ class OGRGmtDataSource final: public OGRDataSource
                         OGRGmtDataSource();
                         virtual ~OGRGmtDataSource();
 
-    int                 Open( const char *pszFilename, int bUpdate );
+    int                 Open( const char *pszFilename,
+                              VSILFILE* fp,
+                              const OGRSpatialReference* poSRS,
+                              int bUpdate );
     int                 Create( const char *pszFilename, char **papszOptions );
 
     const char          *GetName() override { return pszName; }

--- a/ogr/ogrsf_frmts/gmt/ogrgmtdriver.cpp
+++ b/ogr/ogrsf_frmts/gmt/ogrgmtdriver.cpp
@@ -61,7 +61,8 @@ static GDALDataset *OGRGMTDriverOpen( GDALOpenInfo* poOpenInfo )
 
     OGRGmtDataSource *poDS = new OGRGmtDataSource();
 
-    if( !poDS->Open( poOpenInfo->pszFilename, poOpenInfo->eAccess == GA_Update ) )
+    if( !poDS->Open( poOpenInfo->pszFilename, nullptr, nullptr,
+                     poOpenInfo->eAccess == GA_Update ) )
     {
         delete poDS;
         return nullptr;


### PR DESCRIPTION
CC @joa-quim Can you confirm that a OGR GMT file that lacks the "# @R" region header will work properly ? (see https://github.com/OSGeo/gdal/issues/4993#issuecomment-993450875)