### PR TITLE
DWG/DGNv8: avoid potential crash with ODA 2022 on Linux

### DIFF
--- a/frmts/ecw/ecwdataset.cpp
+++ b/frmts/ecw/ecwdataset.cpp
@@ -53,8 +53,6 @@ static int    bNCSInitialized = FALSE;
 
 void ECWInitialize( void );
 
-extern "C" int CPL_DLL GDALIsInGlobalDestructor(void);
-
 #define BLOCK_SIZE 256
 
 GDALDataset* ECWDatasetOpenJPEG2000(GDALOpenInfo* poOpenInfo);
@@ -1040,35 +1038,7 @@ ECWDataset::~ECWDataset()
 
     CPLMutexHolder oHolder( &hECWDatasetMutex );
 
-    // bInGDALGlobalDestructor is set to TRUE by gdaldllmain.cpp/GDALDestroy() so as
-    // to avoid an issue with the ECW SDK 3.3 where the destructor of CNCSJP2File::CNCSJP2FileVector CNCSJP2File::sm_Files;
-    // static resource allocated in NCJP2File.cpp can be called before GDALDestroy(), causing
-    // ECW SDK resources ( CNCSJP2File files ) to be closed before we get here.
-    //
-    // We also have an issue with ECW SDK 5.0 and ECW files on Linux when
-    // running a multi-threaded test under Java if there's still an ECW dataset
-    // not explicitly closed at process termination.
-    /*  #0  0x00007fffb26e7a80 in NCSAtomicAdd64 () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #1  0x00007fffb2aa7684 in NCS::SDK::CBuffer2D::Free() () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #2  0x00007fffb2aa7727 in NCS::SDK::CBuffer2D::~CBuffer2D() () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #3  0x00007fffb29aa7be in NCS::ECW::CReader::~CReader() () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #4  0x00007fffb29aa819 in NCS::ECW::CReader::~CReader() () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #5  0x00007fffb291fd3a in NCS::CView::Close(bool) () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #6  0x00007fffb2927529 in NCS::CView::~CView() () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #7  0x00007fffb29277f9 in NCS::CView::~CView() () from /home/even/ecwjp2_sdk/redistributable/x64/libNCSEcw.so
-        #8  0x00007fffb71a9a53 in ECWDataset::~ECWDataset (this=0x7fff942cce10, __in_chrg=<optimized out>) at ecwdataset.cpp:1003
-        #9  0x00007fffb71a9cca in ECWDataset::~ECWDataset (this=0x7fff942cce10, __in_chrg=<optimized out>) at ecwdataset.cpp:1039
-        #10 0x00007fffb7551f98 in GDALDriverManager::~GDALDriverManager (this=0x7ffff01981a0, __in_chrg=<optimized out>) at gdaldrivermanager.cpp:196
-        #11 0x00007fffb7552140 in GDALDriverManager::~GDALDriverManager (this=0x7ffff01981a0, __in_chrg=<optimized out>) at gdaldrivermanager.cpp:288
-        #12 0x00007fffb7552e18 in GDALDestroyDriverManager () at gdaldrivermanager.cpp:824
-        #13 0x00007fffb7551c61 in GDALDestroy () at gdaldllmain.cpp:80
-        #14 0x00007ffff7de990e in _dl_fini () at dl-fini.c:254
-    */
-    // Not reproducible with similar test in C++, but this might be
-    // just a matter of luck related to the order in which the
-    // libraries are unloaded, so just don't try to delete poFileView
-    // from the GDAL destructor.
-    if( poFileView != nullptr && !GDALIsInGlobalDestructor() )
+    if( poFileView != nullptr )
     {
 #if ECWSDK_VERSION >= 55
         delete poFileView;
@@ -3589,10 +3559,7 @@ static void GDALDeregister_ECW( GDALDriver * )
     if( bNCSInitialized )
     {
         bNCSInitialized = FALSE;
-        if( !GDALIsInGlobalDestructor() )
-        {
-            NCSecwShutdown();
-        }
+        NCSecwShutdown();
     }
 #endif
 #endif

--- a/frmts/hdf5/hdf5vfl.h
+++ b/frmts/hdf5/hdf5vfl.h
@@ -25,11 +25,11 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
- 
- // This file contains the Virtual File Layer implementation that calls through 
- // to the VSI functions and should be included by HDF5 based drivers that wish 
+
+ // This file contains the Virtual File Layer implementation that calls through
+ // to the VSI functions and should be included by HDF5 based drivers that wish
  // to use the VFL for /vsi file system support.
- 
+
 #ifndef HDF5VFL_H_INCLUDED_
 #define HDF5VFL_H_INCLUDED_
 
@@ -37,8 +37,6 @@
 
 #include <algorithm>
 #include <mutex>
-
-extern "C" int CPL_DLL GDALIsInGlobalDestructor(void);
 
 #ifdef H5FD_FEAT_SUPPORTS_SWMR_IO
 #define HDF5_1_10_OR_LATER
@@ -189,7 +187,7 @@ static haddr_t HDF5_vsil_get_eof(const H5FD_t *_file
     return fh->eof;
 }
 
-static herr_t HDF5_vsil_read(H5FD_t *_file, H5FD_mem_t /* type */, 
+static herr_t HDF5_vsil_read(H5FD_t *_file, H5FD_mem_t /* type */,
                              hid_t /* dxpl_id */,
                              haddr_t addr, size_t size, void *buf /*out*/)
 {
@@ -236,9 +234,9 @@ static hid_t HDF5VFLGetFileDriver()
     {
         hFileDriver = H5FDregister(&HDF5_vsil_g);
 #if H5E_auto_t_vers == 2
-        // also, don't print error messages from KEA driver. 
+        // also, don't print error messages from KEA driver.
         // (which uses H5E_auto_t_vers=2 - the default, hdf uses 1 for some reason).
-        // These tend to be meaningless - ie no GCP's found etc. 
+        // These tend to be meaningless - ie no GCP's found etc.
         // They didn't seem to be shown when we didn't use the VFL layer
         // - maybe VFL turns them on?
         H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
@@ -253,7 +251,6 @@ static hid_t HDF5VFLGetFileDriver()
 
 static void HDF5VFLUnloadFileDriver()
 {
-    if( !GDALIsInGlobalDestructor() )
     {
         std::lock_guard<std::mutex> oLock(gMutex);
         if( hFileDriver >= 0 )

--- a/ogr/ograpispy.cpp
+++ b/ogr/ograpispy.cpp
@@ -50,7 +50,6 @@ static CPLMutex* hMutex = nullptr;
 static CPLString osSnapshotPath;
 static CPLString osSpyFile;
 static FILE* fpSpyFile = nullptr;
-extern "C" int CPL_DLL GDALIsInGlobalDestructor(void);
 
 // Keep in sync with cpl_conv.cpp
 void OGRAPISPYCPLSetConfigOption(const char*, const char*);
@@ -130,7 +129,6 @@ void FeatureDefnDescription::Free()
 
 DatasetDescription::~DatasetDescription()
 {
-    if( !GDALIsInGlobalDestructor() )
     {
         std::map<OGRLayerH, LayerDescription>::iterator oIter =
             oMapLayer.begin();
@@ -610,7 +608,6 @@ void OGRAPISpyPreClose( GDALDatasetH hDS )
 
 void OGRAPISpyPostClose()
 {
-    if( !GDALIsInGlobalDestructor() )
     {
         if( !OGRAPISpyEnabled() ) return;
         CPLMutexHolderD(&hMutex);

--- a/ogr/ogrsf_frmts/dwg/ogrteigha.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrteigha.cpp
@@ -34,8 +34,6 @@
 
 extern "C" void CPL_DLL RegisterOGRDWG_DGNV8();
 
-extern "C" int CPL_DLL GDALIsInGlobalDestructor();
-
 static CPLMutex* hMutex = nullptr;
 static bool bInitialized = false;
 static bool bInitSuccess = false;
@@ -156,8 +154,6 @@ OGRDGNV8Services* OGRDGNV8GetServices()
 
 void OGRTEIGHADeinitialize()
 {
-    if( GDALIsInGlobalDestructor()   )
-        return;
     if( bInitSuccess )
     {
         odUninitialize();

--- a/ogr/ogrsf_frmts/dwg/ogrteigha.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrteigha.cpp
@@ -39,8 +39,19 @@ extern "C" int CPL_DLL GDALIsInGlobalDestructor();
 static CPLMutex* hMutex = nullptr;
 static bool bInitialized = false;
 static bool bInitSuccess = false;
-static OdStaticRxObject<OGRDWGServices> oDWGServices;
-static OdStaticRxObject<OGRDGNV8Services> oDGNServices;
+
+// We used to define the 2 below objects as static in the global scope
+// However with ODA 2022 on Linux, when OGRTEIGHADeinitialize() is not called,
+// on unloading of the ODA libraries, a crash occured when freeing a singleton
+// inside one of the ODA libraries. It turns out that if the 2 below objects
+// are kept alive, the crash doesn't occur.
+struct OGRODAServicesWrapper
+{
+    OdStaticRxObject<OGRDWGServices> oDWGServices;
+    OdStaticRxObject<OGRDGNV8Services> oDGNServices;
+};
+
+static OGRODAServicesWrapper* poServicesWrapper = nullptr;
 
 /************************************************************************/
 /*                        OGRTEIGHAErrorHandler()                       */
@@ -89,18 +100,20 @@ bool OGRTEIGHAInitialize()
 
     try
     {
-        odInitialize(&oDWGServices);
-        oDWGServices.disableOutput( true );
+        poServicesWrapper = new OGRODAServicesWrapper();
+
+        odInitialize(&poServicesWrapper->oDWGServices);
+        poServicesWrapper->oDWGServices.disableOutput( true );
 
         /********************************************************************/
         /* Find the data file and and initialize the character mapper       */
         /********************************************************************/
-        OdString iniFile = oDWGServices.findFile(OD_T("adinit.dat"));
+        OdString iniFile = poServicesWrapper->oDWGServices.findFile(OD_T("adinit.dat"));
         if (!iniFile.isEmpty())
             OdCharMapper::initialize(iniFile);
 
-        odrxInitialize(&oDGNServices);
-        oDGNServices.disableProgressMeterOutput( true );
+        odrxInitialize(&poServicesWrapper->oDGNServices);
+        poServicesWrapper->oDGNServices.disableProgressMeterOutput( true );
 
         ::odrxDynamicLinker()->loadModule(L"TG_Db", false);
 
@@ -125,7 +138,7 @@ bool OGRTEIGHAInitialize()
 
 OGRDWGServices* OGRDWGGetServices()
 {
-    return &oDWGServices;
+    return poServicesWrapper ? &poServicesWrapper->oDWGServices : nullptr;
 }
 
 /************************************************************************/
@@ -134,7 +147,7 @@ OGRDWGServices* OGRDWGGetServices()
 
 OGRDGNV8Services* OGRDGNV8GetServices()
 {
-    return &oDGNServices;
+    return poServicesWrapper ? &poServicesWrapper->oDGNServices : nullptr;
 }
 
 /************************************************************************/
@@ -150,6 +163,8 @@ void OGRTEIGHADeinitialize()
         odUninitialize();
         odrxUninitialize();
     }
+    delete poServicesWrapper;
+    poServicesWrapper = nullptr;
     bInitialized = false;
     bInitSuccess = false;
     if( hMutex != nullptr )

--- a/ogr/ogrsf_frmts/mongodb/ogrmongodbdriver.cpp
+++ b/ogr/ogrsf_frmts/mongodb/ogrmongodbdriver.cpp
@@ -2730,11 +2730,9 @@ void OGRMongoDBDataSource::ReleaseResultSet( OGRLayer * poLayer )
 /*                          OGRMongoDBDriverUnload()                    */
 /************************************************************************/
 
-extern "C" int GDALIsInGlobalDestructor();
-
 static void OGRMongoDBDriverUnload( CPL_UNUSED GDALDriver* poDriver )
 {
-    if( bMongoInitialized != -1 && !GDALIsInGlobalDestructor() )
+    if( bMongoInitialized != -1 )
     {
         client::shutdown();
     }

--- a/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
+++ b/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
@@ -2619,11 +2619,9 @@ static GDALDataset* OGRMongoDBv3DriverOpen( GDALOpenInfo* poOpenInfo )
 /*                        OGRMongoDBv3DriverUnload()                    */
 /************************************************************************/
 
-extern "C" int GDALIsInGlobalDestructor();
-
 static void OGRMongoDBv3DriverUnload( GDALDriver* )
 {
-    if( g_pInst != nullptr && !GDALIsInGlobalDestructor() )
+    if( g_pInst != nullptr )
     {
         delete g_pInst;
         g_pInst = nullptr;

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -2672,15 +2672,10 @@ void CachedConnection::clear()
 /*                  ~VSICurlFilesystemHandlerBase()                         */
 /************************************************************************/
 
-extern "C" int CPL_DLL GDALIsInGlobalDestructor();
-
 VSICurlFilesystemHandlerBase::~VSICurlFilesystemHandlerBase()
 {
     VSICurlFilesystemHandlerBase::ClearCache();
-    if( !GDALIsInGlobalDestructor() )
-    {
-        GetConnectionCache().erase(this);
-    }
+    GetConnectionCache().erase(this);
 
     if( hMutex != nullptr )
         CPLDestroyMutex( hMutex );
@@ -2919,10 +2914,7 @@ void VSICurlFilesystemHandlerBase::ClearCache()
     oCacheDirList.clear();
     nCachedFilesInDirList = 0;
 
-    if( !GDALIsInGlobalDestructor() )
-    {
-        GetConnectionCache()[this].clear();
-    }
+    GetConnectionCache()[this].clear();
 }
 
 /************************************************************************/


### PR DESCRIPTION
- when driver unloading doesn't occur properly
- Remove most uses of GDALIsInGlobalDestructor() : Previously GDALDestroy() was a __attribute__ ((destructor)) function,
which could cause issues with automatic C++ objects that could get destroyed before it. Now it should be safe to access those C++ objects since they must still be alive at the time GDALDestroy() is called.