### PR TITLE
remove hidden bidirectional unicode character

### DIFF
--- a/alg/viewshed.cpp
+++ b/alg/viewshed.cpp
@@ -165,7 +165,7 @@ inline static double CalcHeight(double dfZ, double dfZ2, GDALViewshedMode eMode)
  * @param dfCurvCoeff Coefficient to consider the effect of the curvature and refraction.
  * The height of the DEM is corrected according to the following formula:
  * [Height] -= dfCurvCoeff * [Target Distance]^2 / [Earth Diameter]
- * For the effect of the atmospheric refraction we can use 0.85714‬.
+ * For the effect of the atmospheric refraction we can use 0.85714.
  *
  * @param eMode The mode of the viewshed calculation.
  * Possible values GVM_Diagonal = 1, GVM_Edge = 2 (default), GVM_Max = 3, GVM_Min = 4.


### PR DESCRIPTION
The diff here might not show much, but I removed Unicode character 'POP DIRECTIONAL FORMATTING' (U+202C).
It looks like this was added by mistake in 2e9d67f055ad6e2b8343df02030918918fbe9b27.

This pop character only makes sense if there is a bidirectional marker to pop, so that makes the string unbalanced. Interestingly I came across this in the Julia GDAL wrapper, which also copies original docstrings. The Julia parser errored with "unbalanced bidirectional formatting in string literal".

I see that GitHub now also shows a yellow banner above https://github.com/OSGeo/gdal/blob/master/alg/viewshed.cpp that warns about bidirectional Unicode characters.