### PR TITLE
MRF: Padding space logic fix

### DIFF
--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -2110,8 +2110,8 @@ CPLErr MRFDataset::WriteTile(void* buff, GUIntBig infooffset, GUIntBig size)
 
         // Spacing should be 0 in MP safe mode, this doesn't have much of effect
         // Use the existing data, spacing content is not guaranteed
-        for (GUIntBig pending = spacing; pending != 0; pending -= std::max(pending, size))
-            VSIFWriteL(buff, 1, static_cast<size_t>(std::max(pending, size)), l_dfp); // Usually only once
+        for (GUIntBig pending = spacing; pending != 0; pending -= std::min(pending, size))
+            VSIFWriteL(buff, 1, static_cast<size_t>(std::min(pending, size)), l_dfp); // Usually only once
 
         if (static_cast<size_t>(size) != VSIFWriteL(buff, 1, static_cast<size_t>(size), l_dfp))
             ret = CE_Failure;


### PR DESCRIPTION
It got broken a while ago, it is not used often

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fix a logic error in MRF, when padding between tiles is requested

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
