### PR TITLE
OSM: extended attributes of line by railway

### DIFF
--- a/data/osmconf.ini
+++ b/data/osmconf.ini
@@ -50,7 +50,7 @@ osm_user=no
 osm_changeset=no
 
 # keys to report as OGR fields
-attributes=name,highway,waterway,aerialway,barrier,man_made
+attributes=name,highway,waterway,aerialway,barrier,man_made,railway
 
 # type of attribute 'foo' can be changed with something like
 #foo_type=Integer/Real/String/DateTime


### PR DESCRIPTION
Railway is very common OSM line, 58th of mostly used attribute incluing polygon.
https://taginfo.openstreetmap.org/keys/railway

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
