### PR TITLE
netCDF: add WRITE_GDAL_VERSION and WRITE_GDAL_HISTORY creation option

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -4914,6 +4914,51 @@ def test_netcdf__crs_wkt():
     assert ds.GetSpatialRef().IsGeographic()
 
 
+def test_netcdf_default_metadata():
+
+    src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1)
+
+    tmpfilename = 'tmp/test_netcdf_default_metadata.nc'
+    gdal.GetDriverByName('netCDF').CreateCopy(tmpfilename, src_ds)
+    ds = gdal.Open(tmpfilename)
+    assert ds.GetMetadataItem("NC_GLOBAL#GDAL") == gdal.VersionInfo("")
+    assert 'GDAL CreateCopy' in ds.GetMetadataItem("NC_GLOBAL#history")
+    assert ds.GetMetadataItem("NC_GLOBAL#conventions").startswith('CF')
+    ds = None
+    gdal.Unlink(tmpfilename)
+
+
+def test_netcdf_default_metadata_with_existing_history_and_conventions():
+
+    src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1)
+    src_ds.SetMetadataItem("NC_GLOBAL#history", "past history")
+    src_ds.SetMetadataItem("NC_GLOBAL#Conventions", "my conventions")
+
+    tmpfilename = 'tmp/test_netcdf_default_metadata_with_existing_history_and_conventions.nc'
+    gdal.GetDriverByName('netCDF').CreateCopy(tmpfilename, src_ds)
+    ds = gdal.Open(tmpfilename)
+    assert 'GDAL CreateCopy' in ds.GetMetadataItem("NC_GLOBAL#history")
+    assert 'past history' in ds.GetMetadataItem("NC_GLOBAL#history")
+    assert ds.GetMetadataItem("NC_GLOBAL#conventions") == "my conventions"
+    ds = None
+    gdal.Unlink(tmpfilename)
+
+
+def test_netcdf_default_metadata_disabled():
+
+    src_ds = gdal.GetDriverByName('MEM').Create('', 1, 1)
+
+    tmpfilename = 'tmp/test_netcdf_default_metadata_disabled.nc'
+    gdal.GetDriverByName('netCDF').CreateCopy(tmpfilename, src_ds,
+                  options = ['WRITE_GDAL_VERSION=NO', 'WRITE_GDAL_HISTORY=NO'])
+    ds = gdal.Open(tmpfilename)
+    assert ds.GetMetadataItem("NC_GLOBAL#GDAL") is None
+    assert ds.GetMetadataItem("NC_GLOBAL#history") is None
+    ds = None
+    gdal.Unlink(tmpfilename)
+
+
+
 def test_clean_tmp():
     # [KEEP THIS AS THE LAST TEST]
     # i.e. please do not add any tests after this one. Put new ones above.

--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -302,6 +302,11 @@ Variables attributes for: tos, lon, lat and time
      time#bounds=time_bnds
      time#original_units=seconds since 2001-1-1
 
+On writing, when using the CreateCopy() interface or gdal_translate, dataset
+level metadata that follows the naming convention NC_GLOBAL#key=value will be
+used to write the netCDF attributes. Metadata set at the band level using
+key=value will also be used to write variable attributes.
+
 Product specific behavior
 --------------------------
 
@@ -371,6 +376,14 @@ Creation Options
 
 -  **PIXELTYPE=[DEFAULT/SIGNEDBYTE]**: By setting this to SIGNEDBYTE, a
    new Byte file can be forced to be written as signed byte.
+
+-  **WRITE_GDAL_VERSION=[YES/NO]**: (GDAL >= 3.5.0)
+   Define if a "GDAL" text global attribute should be added on file creation
+   with the GDAL version. Defaults to YES
+
+-  **WRITE_GDAL_HISTORY=[YES/NO]**: (GDAL >= 3.5.0)
+   Define if the "history" global attribute should be prepended with a date/time
+   and GDAL information. Defaults to YES.
 
 Creation of multidimensional files with CreateCopy() 2D raster API
 ------------------------------------------------------------------

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -99,6 +99,7 @@
 static const size_t NCDF_MAX_STR_LEN = 8192;
 #define NCDF_CONVENTIONS     "Conventions"
 #define NCDF_CONVENTIONS_CF_V1_5  "CF-1.5"
+#define GDAL_DEFAULT_NCDF_CONVENTIONS NCDF_CONVENTIONS_CF_V1_5
 #define NCDF_CONVENTIONS_CF_V1_6  "CF-1.6"
 #define NCDF_CONVENTIONS_CF_V1_8  "CF-1.8"
 #define NCDF_CRS_WKT         "crs_wkt"
@@ -738,6 +739,9 @@ class netCDFDataset final: public GDALPamDataset
     nccfdriver::OGR_NCScribe GeometryScribe;
     nccfdriver::OGR_NCScribe FieldScribe;
     nccfdriver::WBufferManager bufManager;
+
+    bool         bWriteGDALVersion = true;
+    bool         bWriteGDALHistory = true;
 
     /* projection/GT */
     double       adfGeoTransform[6];


### PR DESCRIPTION
and in CreateCopy() use NC_GLOBAL#Conventions metadata item from source
dataset if present.

-  **WRITE_GDAL_VERSION=[YES/NO]**: (GDAL >= 3.5.0)
   Define if a "GDAL" text global attribute should be added on file creation
   with the GDAL version. Defaults to YES

-  **WRITE_GDAL_HISTORY=[YES/NO]**: (GDAL >= 3.5.0)
   Define if the "history" global attribute should be prepended with a date/time
   and GDAL information. Defaults to YES.
