### PR TITLE
SAGA: allow setting nodata

### DIFF
--- a/autotest/gdrivers/saga.py
+++ b/autotest/gdrivers/saga.py
@@ -201,7 +201,8 @@ def test_saga_9():
     ds = None
 
     ds = gdal.Open('tmp/test9.sdat')
-    ret = ds.GetRasterBand(1).SetNoDataValue(56)
+    with gdaltest.error_handler():
+        ret = ds.GetRasterBand(1).SetNoDataValue(56)
     assert ret == gdalconst.CE_Failure
     # make sure nodata value is not changed
     assert ds.GetRasterBand(1).GetNoDataValue() == -99999

--- a/autotest/gdrivers/saga.py
+++ b/autotest/gdrivers/saga.py
@@ -96,7 +96,7 @@ def test_saga_4():
             check_minmax = 1
         tst.testCreateCopy(new_filename='tmp/test4.sdat', check_minmax=check_minmax)
 
-    
+
 ###############################################################################
 # Test Create() for various data types
 
@@ -119,7 +119,7 @@ def test_saga_5():
             check_minmax = 1
         tst.testCreate(new_filename='tmp/test5.sdat', out_bands=1, check_minmax=check_minmax)
 
-    
+
 ###############################################################################
 # Test creating empty datasets and check that nodata values are properly written
 
@@ -161,7 +161,7 @@ def test_saga_6():
     except OSError:
         pass
 
-    
+
 ###############################################################################
 # Test /vsimem
 
@@ -191,5 +191,31 @@ def test_saga_8():
     PARAMETER["false_northing",0],
     UNIT["Meter",1]]""")
 
+##############################################################################
+# Test setnodata
+def test_saga_9():
+
+    gdal_type = gdal.GDT_Float64
+
+    ds = gdal.GetDriverByName('SAGA').Create('tmp/test9.sdat', 2, 2, 1, gdal_type)
+    ds = None
+
+    ds = gdal.Open('tmp/test9.sdat', gdal.GA_Update)
+
+    ds.GetRasterBand(1).SetNoDataValue(56)
+    nd = ds.GetRasterBand(1).GetNoDataValue()
+    # ds.SetGeoTransform(ds.GetGeoTransform())
+    assert nd == 56
+
+    ds = None
+
+    with open('tmp/test9.sgrd', 'r') as f:
+        header_string = f.read()
+        assert "NODATA_VALUE\t= 56.000000" in header_string
+    try:
+        os.remove('tmp/test9.sgrd')
+        os.remove('tmp/test9.sdat')
+    except OSError:
+        pass
 
 

--- a/autotest/gdrivers/saga.py
+++ b/autotest/gdrivers/saga.py
@@ -31,7 +31,7 @@
 
 import os
 from osgeo import gdal
-
+from osgeo import gdalconst
 
 import gdaltest
 
@@ -200,11 +200,18 @@ def test_saga_9():
     ds = gdal.GetDriverByName('SAGA').Create('tmp/test9.sdat', 2, 2, 1, gdal_type)
     ds = None
 
+    ds = gdal.Open('tmp/test9.sdat')
+    ret = ds.GetRasterBand(1).SetNoDataValue(56)
+    assert ret == gdalconst.CE_Failure
+    # make sure nodata value is not changed
+    assert ds.GetRasterBand(1).GetNoDataValue() == -99999
+
+    ds = None
     ds = gdal.Open('tmp/test9.sdat', gdal.GA_Update)
 
-    ds.GetRasterBand(1).SetNoDataValue(56)
+    ret = ds.GetRasterBand(1).SetNoDataValue(56)
+    assert ret == gdalconst.CE_None
     nd = ds.GetRasterBand(1).GetNoDataValue()
-    # ds.SetGeoTransform(ds.GetGeoTransform())
     assert nd == 56
 
     ds = None
@@ -217,5 +224,4 @@ def test_saga_9():
         os.remove('tmp/test9.sdat')
     except OSError:
         pass
-
 

--- a/frmts/saga/sagadataset.cpp
+++ b/frmts/saga/sagadataset.cpp
@@ -317,7 +317,7 @@ CPLErr SAGARasterBand::SetNoDataValue(double dfNoData)
 
     m_NoData = dfNoData;
     SAGADataset * poSAGADS = static_cast<SAGADataset *>(poDS);
-    poSAGADS->headerDirty=1;
+    poSAGADS->headerDirty = true;
     return CE_None;
 }
 

--- a/frmts/saga/sagadataset.cpp
+++ b/frmts/saga/sagadataset.cpp
@@ -132,6 +132,7 @@ public:
     CPLErr          IWriteBlock( int, int, void * ) override;
 
     double          GetNoDataValue( int *pbSuccess = nullptr ) override;
+    CPLErr          SetNoDataValue(double dfNoData) override;
 };
 
 /************************************************************************/
@@ -302,6 +303,16 @@ double SAGARasterBand::GetNoDataValue( int * pbSuccess )
         *pbSuccess = TRUE;
 
     return m_NoData;
+}
+
+/************************************************************************/
+/*                           SetNoDataValue()                           */
+/************************************************************************/
+
+CPLErr SAGARasterBand::SetNoDataValue(double dfNoData)
+{
+    m_NoData = dfNoData;
+    return CE_None;
 }
 
 /************************************************************************/

--- a/frmts/saga/sagadataset.cpp
+++ b/frmts/saga/sagadataset.cpp
@@ -331,14 +331,17 @@ SAGADataset::SAGADataset() :
 
 SAGADataset::~SAGADataset()
 {
-    SAGARasterBand *poGRB = static_cast<SAGARasterBand *>(GetRasterBand( 1 ));
-    const CPLString osPath = CPLGetPath( GetDescription() );
-    const CPLString osName = CPLGetBasename( GetDescription() );
-    const CPLString osFilename = CPLFormCIFilename( osPath, osName, ".sgrd" );
-    WriteHeader( osFilename, poGRB->GetRasterDataType(),
-                 poGRB->nRasterXSize, poGRB->nRasterYSize,
-                 poGRB->m_Xmin, poGRB->m_Ymin, poGRB->m_Cellsize,
-                 poGRB->m_NoData, 1.0, false );
+    if (headerDirty)
+    {
+        SAGARasterBand *poGRB = static_cast<SAGARasterBand *>(GetRasterBand( 1 ));
+        const CPLString osPath = CPLGetPath( GetDescription() );
+        const CPLString osName = CPLGetBasename( GetDescription() );
+        const CPLString osFilename = CPLFormCIFilename( osPath, osName, ".sgrd" );
+        WriteHeader( osFilename, poGRB->GetRasterDataType(),
+                     poGRB->nRasterXSize, poGRB->nRasterYSize,
+                     poGRB->m_Xmin, poGRB->m_Ymin, poGRB->m_Cellsize,
+                     poGRB->m_NoData, 1.0, false );
+    }
     CPLFree( pszProjection );
     FlushCache(true);
     if( fp != nullptr )


### PR DESCRIPTION
Quite a straighforward change.

I tested locally using
```
import rasterio

rst = '/home/johan/git/saga-gis/saga-gis/src/accessories/python/test_data/test.sdat'
rst_out = '/tmp/test.sdat'

with rasterio.open(rst) as src:
    arr = src.read()[0]
    profile = src.profile

profile["nodata"] = 56
print(profile)
arr = np.where(arr == 256, 0, arr).astype("int16")

with rasterio.open(rst_out, "w", **profile) as dst:
    dst.write(arr, 1)
```
and asserted that /tmp/test.sgrd contains 

NODATA_VALUE	= 56.000000

I tried adding a test to the gdal test suite, but I'm missing how to save the file correctly:

 ```
##############################################################################
 # Test setnodata
 def test_saga_9():
 
     gdal_type = gdal.GDT_Float64
 
     ds = gdal.GetDriverByName('SAGA').Create('tmp/test9.sdat', 2, 2, 1, gdal_type)
     ds = None
 
     ds = gdal.Open('tmp/test9.sdat', gdal.GA_Update)
 
     ds.GetRasterBand(1).SetNoDataValue(56)
     nd = ds.GetRasterBand(1).GetNoDataValue()
     assert nd == 56 # ok
 
     ds = None
 
     with open('tmp/test9.sgrd', 'r') as f:
         print(f.read()) # will still contain -99999 as nodata value
         assert 0==1
     try:
         os.remove('tmp/test9.sgrd')
         os.remove('tmp/test9.sdat')
     except OSError:
         pass
```




