### PR TITLE
frmts/pdf: Use correct POPPLER_INCLUDE_DIR

### DIFF
--- a/frmts/pdf/CMakeLists.txt
+++ b/frmts/pdf/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(gdal_PDF PRIVATE ${GDAL_RASTER_FORMAT_SOURCE_DIR}/vrt
                                             ${GDAL_VECTOR_FORMAT_SOURCE_DIR}/mem)
 
 if (GDAL_USE_POPPLER)
-  target_include_directories(gdal_PDF PRIVATE ${POPPLER_INCLUDE_DIRS} ${POPPLER_INCLUDE_DIRS}/../)
+  target_include_directories(gdal_PDF PRIVATE ${POPPLER_INCLUDE_DIR} ${POPPLER_INCLUDE_DIR}/../)
   gdal_target_link_libraries(TARGET gdal_PDF LIBRARIES POPPLER::Poppler)
   string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" POPPLER_VERSION_MAJOR ${POPPLER_VERSION_STRING})
   string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" POPPLER_VERSION_MINOR ${POPPLER_VERSION_STRING})


### PR DESCRIPTION
rather than the not-set POPPLER_INCLUDE_DIRS.  Resolves failure to
build with poppler on NetBSD.

## What does this PR do?

This PR fixesan  incorrect use of cmake variables that resulted in not using the poppler include directory.   Before, the build failed on NetBSD (where poppler is in /usr/pkg, which is not in the default include path).

## What are related issues/pull requests?

There are no related issues.

## Tasklist

 - [ ] It would be nice to have a test case, if we add them for the build system, but github does not support CI runners for other than a few systems.  (One could place poppler in a different prefix to test, removing it from /usr.)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Failure observed and fix verified on NetBSD 9 amd64 with prerequisites from pkgsrc.  However, the problem can be seen by inspection as the variable used is never set.

* OS:
NetBSD 9

* Compiler:
gcc 7.4.0

