### PR TITLE
Add domain management functions

### DIFF
--- a/autotest/ogr/ogr_fielddomain.py
+++ b/autotest/ogr/ogr_fielddomain.py
@@ -203,3 +203,41 @@ def test_delete_domain_assigned_to_field():
     assert not lyr.GetLayerDefn().GetFieldDefn(0).GetDomainName()
     assert not lyr.GetLayerDefn().GetFieldDefn(1).GetDomainName()
     assert not lyr2.GetLayerDefn().GetFieldDefn(0).GetDomainName()
+
+
+def test_update_field_domain():
+    ds = gdal.GetDriverByName('Memory').Create('', 0, 0, 0, gdal.GDT_Unknown)
+    assert ds.AddFieldDomain(ogr.CreateGlobFieldDomain('name', 'desc', ogr.OFTString, ogr.OFSTNone, '*'))
+    assert ds.AddFieldDomain(ogr.CreateGlobFieldDomain('name2', 'desc2', ogr.OFTString, ogr.OFSTNone, '*a'))
+
+    assert ds.GetFieldDomain('name').GetName() == 'name'
+    assert ds.GetFieldDomain('name').GetDescription() == 'desc'
+    assert ds.GetFieldDomain('name').GetGlob() == '*'
+
+    assert ds.GetFieldDomain('name2').GetName() == 'name2'
+    assert ds.GetFieldDomain('name2').GetDescription() == 'desc2'
+    assert ds.GetFieldDomain('name2').GetGlob() == '*a'
+
+    # try updating domain which doesn't exist
+    no_matching_domain = ogr.CreateGlobFieldDomain('nomatch', 'desc', ogr.OFTString, ogr.OFSTNone, '*')
+    assert not ds.UpdateFieldDomain(no_matching_domain)
+
+    new_domain1 = ogr.CreateGlobFieldDomain('name', 'different desc', ogr.OFTString, ogr.OFSTNone, '*b')
+    assert ds.UpdateFieldDomain(new_domain1)
+    assert ds.GetFieldDomain('name').GetName() == 'name'
+    assert ds.GetFieldDomain('name').GetDescription() == 'different desc'
+    assert ds.GetFieldDomain('name').GetGlob() == '*b'
+
+    assert ds.GetFieldDomain('name2').GetName() == 'name2'
+    assert ds.GetFieldDomain('name2').GetDescription() == 'desc2'
+    assert ds.GetFieldDomain('name2').GetGlob() == '*a'
+
+    new_domain2 = ogr.CreateGlobFieldDomain('name2', 'different desc 2', ogr.OFTString, ogr.OFSTNone, '*c')
+    assert ds.UpdateFieldDomain(new_domain2)
+    assert ds.GetFieldDomain('name').GetName() == 'name'
+    assert ds.GetFieldDomain('name').GetDescription() == 'different desc'
+    assert ds.GetFieldDomain('name').GetGlob() == '*b'
+
+    assert ds.GetFieldDomain('name2').GetName() == 'name2'
+    assert ds.GetFieldDomain('name2').GetDescription() == 'different desc 2'
+    assert ds.GetFieldDomain('name2').GetGlob() == '*c'

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -892,6 +892,9 @@ OGRFieldDomainH CPL_DLL GDALDatasetGetFieldDomain(GDALDatasetH hDS,
 bool CPL_DLL GDALDatasetAddFieldDomain(GDALDatasetH hDS,
                                        OGRFieldDomainH hFieldDomain,
                                        char** ppszFailureReason);
+bool CPL_DLL GDALDatasetDeleteFieldDomain(GDALDatasetH hDS,
+                                          const char* pszName,
+                                          char** ppszFailureReason);
 
 /* ==================================================================== */
 /*      GDALRasterBand ... one band/channel in a dataset.               */

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -895,6 +895,9 @@ bool CPL_DLL GDALDatasetAddFieldDomain(GDALDatasetH hDS,
 bool CPL_DLL GDALDatasetDeleteFieldDomain(GDALDatasetH hDS,
                                           const char* pszName,
                                           char** ppszFailureReason);
+bool CPL_DLL GDALDatasetUpdateFieldDomain(GDALDatasetH hDS,
+                                          OGRFieldDomainH hFieldDomain,
+                                          char** ppszFailureReason);
 
 /* ==================================================================== */
 /*      GDALRasterBand ... one band/channel in a dataset.               */

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -805,6 +805,9 @@ private:
     virtual bool        AddFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
                                        std::string& failureReason);
 
+    virtual bool        DeleteFieldDomain(const std::string& name,
+                                          std::string& failureReason);
+
     virtual OGRLayer   *CreateLayer( const char *pszName,
                                      OGRSpatialReference *poSpatialRef = nullptr,
                                      OGRwkbGeometryType eGType = wkbUnknown,

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -808,6 +808,9 @@ private:
     virtual bool        DeleteFieldDomain(const std::string& name,
                                           std::string& failureReason);
 
+    virtual bool        UpdateFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
+                                          std::string& failureReason);
+
     virtual OGRLayer   *CreateLayer( const char *pszName,
                                      OGRSpatialReference *poSpatialRef = nullptr,
                                      OGRwkbGeometryType eGType = wkbUnknown,

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -8611,6 +8611,81 @@ bool GDALDatasetAddFieldDomain(GDALDatasetH hDS,
     return bRet;
 }
 
+
+/************************************************************************/
+/*                        DeleteFieldDomain()                           */
+/************************************************************************/
+
+/** Removes a field domain from the dataset.
+ *
+ * Only a few drivers will support this operation.
+ *
+ * At the time of writing (GDAL 3.5), only the Memory and GeoPackage drivers
+ * support this operation. A dataset having at least some support for this
+ * operation should report the ODsCDeleteFieldDomain dataset capability.
+ *
+ * Anticipated failures will not be emitted through the CPLError()
+ * infrastructure, but will be reported in the failureReason output parameter.
+ *
+ * @note Drivers should make sure to update m_oMapFieldDomains in order for the
+ * default implementation of GetFieldDomainNames() to work correctly, or alternatively
+ * a specialized implementation of GetFieldDomainNames() should be implemented.
+ *
+ * @param name The domain name.
+ * @param failureReason      Output parameter. Will contain an error message if
+ *                           an error occurs.
+ * @return true in case of success.
+ * @since GDAL 3.5
+ */
+bool GDALDataset::DeleteFieldDomain(CPL_UNUSED const std::string& name,
+                                    std::string& failureReason)
+{
+    failureReason = "DeleteFieldDomain not supported by this driver";
+    return false;
+}
+
+/************************************************************************/
+/*                  GDALDatasetDeleteFieldDomain()                      */
+/************************************************************************/
+
+/** Removes a field domain from the dataset.
+ *
+ * Only a few drivers will support this operation.
+ *
+ * At the time of writing (GDAL 3.5), only the Memory and GeoPackage drivers
+ * support this operation. A dataset having at least some support for this
+ * operation should report the ODsCDeleteFieldDomain dataset capability.
+ *
+ * Anticipated failures will not be emitted through the CPLError()
+ * infrastructure, but will be reported in the ppszFailureReason output parameter.
+ *
+ * @param hDS                Dataset handle.
+ * @param pszName            The domain name.
+ * @param ppszFailureReason  Output parameter. Will contain an error message if
+ *                           an error occurs (*ppszFailureReason to be freed
+ *                           with CPLFree). May be NULL.
+ * @return true in case of success.
+ * @since GDAL 3.3
+ */
+bool GDALDatasetDeleteFieldDomain(GDALDatasetH hDS,
+                                  const char* pszName,
+                                  char** ppszFailureReason)
+{
+    VALIDATE_POINTER1(hDS, __func__, false);
+    VALIDATE_POINTER1(pszName, __func__, false);
+    std::string failureReason;
+    const bool bRet =
+        GDALDataset::FromHandle(hDS)->DeleteFieldDomain(
+             pszName, failureReason);
+    if( ppszFailureReason )
+    {
+        *ppszFailureReason = failureReason.empty() ?
+                                nullptr : CPLStrdup(failureReason.c_str());
+    }
+    return bRet;
+}
+
+
 //! @cond Doxygen_Suppress
 
 /************************************************************************/

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -8686,6 +8686,85 @@ bool GDALDatasetDeleteFieldDomain(GDALDatasetH hDS,
 }
 
 
+/************************************************************************/
+/*                       UpdateFieldDomain()                            */
+/************************************************************************/
+
+
+/** Updates an existing field domain by replacing its definition.
+ *
+ * The existing field domain with matching name will be replaced.
+ *
+ * Only a few drivers will support this operation, and some of them might only
+ * support it only for some types of field domains.
+ * At the time of writing (GDAL 3.5), only the Memory driver
+ * supports this operation. A dataset having at least some support for this
+ * operation should report the ODsCUpdateFieldDomain dataset capability.
+ *
+ * Anticipated failures will not be emitted through the CPLError()
+ * infrastructure, but will be reported in the failureReason output parameter.
+ *
+ * @param domain The domain definition.
+ * @param failureReason      Output parameter. Will contain an error message if
+ *                           an error occurs.
+ * @return true in case of success.
+ * @since GDAL 3.5
+ */
+bool GDALDataset::UpdateFieldDomain(CPL_UNUSED std::unique_ptr<OGRFieldDomain> &&domain, std::string &failureReason)
+{
+    failureReason = "UpdateFieldDomain not supported by this driver";
+    return false;
+}
+
+
+/************************************************************************/
+/*                  GDALDatasetUpdateFieldDomain()                      */
+/************************************************************************/
+
+/** Updates an existing field domain by replacing its definition.
+ *
+ * The existing field domain with matching name will be replaced.
+ *
+ * Only a few drivers will support this operation, and some of them might only
+ * support it only for some types of field domains.
+ * At the time of writing (GDAL 3.5), only the Memory driver
+ * supports this operation. A dataset having at least some support for this
+ * operation should report the ODsCUpdateFieldDomain dataset capability.
+ *
+ * Anticipated failures will not be emitted through the CPLError()
+ * infrastructure, but will be reported in the failureReason output parameter.
+ *
+ * @param hDS                Dataset handle.
+ * @param hFieldDomain       The domain definition. Contrary to the C++ version,
+ *                           the passed object is copied.
+ * @param ppszFailureReason  Output parameter. Will contain an error message if
+ *                           an error occurs (*ppszFailureReason to be freed
+ *                           with CPLFree). May be NULL.
+ * @return true in case of success.
+ * @since GDAL 3.5
+ */
+bool GDALDatasetUpdateFieldDomain(GDALDatasetH hDS,
+                                  OGRFieldDomainH hFieldDomain,
+                                  char** ppszFailureReason)
+{
+    VALIDATE_POINTER1(hDS, __func__, false);
+    VALIDATE_POINTER1(hFieldDomain, __func__, false);
+    auto poDomain = std::unique_ptr<OGRFieldDomain>(
+                 OGRFieldDomain::FromHandle(hFieldDomain)->Clone());
+    if( poDomain == nullptr )
+        return false;
+    std::string failureReason;
+    const bool bRet =
+        GDALDataset::FromHandle(hDS)->UpdateFieldDomain(
+             std::move(poDomain), failureReason);
+    if( ppszFailureReason )
+    {
+        *ppszFailureReason = failureReason.empty() ?
+                                nullptr : CPLStrdup(failureReason.c_str());
+    }
+    return bRet;
+}
+
 //! @cond Doxygen_Suppress
 
 /************************************************************************/

--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -848,7 +848,8 @@ int CPL_DLL OGRParseDate( const char *pszInput, OGRField *psOutput,
 #define ODsCRandomLayerRead     "RandomLayerRead"   /**< Dataset capability for GetNextFeature() returning features from random layers */
 /* Note the unfortunate trailing space at the end of the string */
 #define ODsCRandomLayerWrite    "RandomLayerWrite " /**< Dataset capability for supporting CreateFeature on layer in random order */
-#define ODsCAddFieldDomain     "AddFieldDomain"    /**< Dataset capability for supporting AddFieldDomain() (at least partially) */
+#define ODsCAddFieldDomain     "AddFieldDomain"     /**< Dataset capability for supporting AddFieldDomain() (at least partially) */
+#define ODsCDeleteFieldDomain  "DeleteFieldDomain"  /**< Dataset capability for supporting DeleteFieldDomain()*/
 
 #define ODrCCreateDataSource   "CreateDataSource"   /**< Driver capability for datasource creation */
 #define ODrCDeleteDataSource   "DeleteDataSource"   /**< Driver capability for datasource deletion */

--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -850,6 +850,7 @@ int CPL_DLL OGRParseDate( const char *pszInput, OGRField *psOutput,
 #define ODsCRandomLayerWrite    "RandomLayerWrite " /**< Dataset capability for supporting CreateFeature on layer in random order */
 #define ODsCAddFieldDomain     "AddFieldDomain"     /**< Dataset capability for supporting AddFieldDomain() (at least partially) */
 #define ODsCDeleteFieldDomain  "DeleteFieldDomain"  /**< Dataset capability for supporting DeleteFieldDomain()*/
+#define ODsCUpdateFieldDomain  "UpdateFieldDomain"  /**< Dataset capability for supporting UpdateFieldDomain()*/
 
 #define ODrCCreateDataSource   "CreateDataSource"   /**< Driver capability for datasource creation */
 #define ODrCDeleteDataSource   "DeleteDataSource"   /**< Driver capability for datasource deletion */

--- a/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
+++ b/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
@@ -136,6 +136,8 @@ class OGRDataSourceWithTransaction final: public OGRDataSource
     virtual const OGRFieldDomain* GetFieldDomain(const std::string& name) const override;
     virtual bool        AddFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
                                        std::string& failureReason) override;
+    virtual bool        DeleteFieldDomain(const std::string& name,
+                                          std::string& failureReason) override;
 
     virtual std::shared_ptr<GDALGroup> GetRootGroup() const override;
 
@@ -455,6 +457,12 @@ bool OGRDataSourceWithTransaction::AddFieldDomain(std::unique_ptr<OGRFieldDomain
 {
     if( !m_poBaseDataSource ) return false;
     return m_poBaseDataSource->AddFieldDomain(std::move(domain), failureReason);
+}
+
+bool OGRDataSourceWithTransaction::DeleteFieldDomain(const std::string &name, std::string &failureReason)
+{
+    if( !m_poBaseDataSource ) return false;
+    return m_poBaseDataSource->DeleteFieldDomain(name, failureReason);
 }
 
 std::shared_ptr<GDALGroup> OGRDataSourceWithTransaction::GetRootGroup() const

--- a/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
+++ b/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
@@ -138,6 +138,8 @@ class OGRDataSourceWithTransaction final: public OGRDataSource
                                        std::string& failureReason) override;
     virtual bool        DeleteFieldDomain(const std::string& name,
                                           std::string& failureReason) override;
+    virtual bool        UpdateFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
+                                          std::string& failureReason) override;
 
     virtual std::shared_ptr<GDALGroup> GetRootGroup() const override;
 
@@ -463,6 +465,12 @@ bool OGRDataSourceWithTransaction::DeleteFieldDomain(const std::string &name, st
 {
     if( !m_poBaseDataSource ) return false;
     return m_poBaseDataSource->DeleteFieldDomain(name, failureReason);
+}
+
+bool OGRDataSourceWithTransaction::UpdateFieldDomain(std::unique_ptr<OGRFieldDomain> &&domain, std::string &failureReason)
+{
+    if( !m_poBaseDataSource ) return false;
+    return m_poBaseDataSource->UpdateFieldDomain(std::move(domain), failureReason);
 }
 
 std::shared_ptr<GDALGroup> OGRDataSourceWithTransaction::GetRootGroup() const

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
@@ -258,6 +258,12 @@ bool OGRMutexedDataSource::AddFieldDomain(std::unique_ptr<OGRFieldDomain>&& doma
     return m_poBaseDataSource->AddFieldDomain(std::move(domain), failureReason);
 }
 
+bool OGRMutexedDataSource::DeleteFieldDomain(const std::string &name, std::string &failureReason)
+{
+    CPLMutexHolderOptionalLockD(m_hGlobalMutex);
+    return m_poBaseDataSource->DeleteFieldDomain(name, failureReason);
+}
+
 std::shared_ptr<GDALGroup> OGRMutexedDataSource::GetRootGroup() const
 {
     CPLMutexHolderOptionalLockD(m_hGlobalMutex);

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
@@ -264,6 +264,12 @@ bool OGRMutexedDataSource::DeleteFieldDomain(const std::string &name, std::strin
     return m_poBaseDataSource->DeleteFieldDomain(name, failureReason);
 }
 
+bool OGRMutexedDataSource::UpdateFieldDomain(std::unique_ptr<OGRFieldDomain> &&domain, std::string &failureReason)
+{
+    CPLMutexHolderOptionalLockD(m_hGlobalMutex);
+    return m_poBaseDataSource->UpdateFieldDomain(std::move(domain), failureReason);
+}
+
 std::shared_ptr<GDALGroup> OGRMutexedDataSource::GetRootGroup() const
 {
     CPLMutexHolderOptionalLockD(m_hGlobalMutex);

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
@@ -119,6 +119,8 @@ class CPL_DLL OGRMutexedDataSource : public OGRDataSource
 
     virtual bool        AddFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
                                        std::string& failureReason) override;
+    virtual bool        DeleteFieldDomain(const std::string& name,
+                                          std::string& failureReason) override;
 
     virtual std::shared_ptr<GDALGroup> GetRootGroup() const override;
 

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
@@ -121,6 +121,9 @@ class CPL_DLL OGRMutexedDataSource : public OGRDataSource
                                        std::string& failureReason) override;
     virtual bool        DeleteFieldDomain(const std::string& name,
                                           std::string& failureReason) override;
+    virtual bool        UpdateFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
+                                          std::string& failureReason) override;
+
 
     virtual std::shared_ptr<GDALGroup> GetRootGroup() const override;
 

--- a/ogr/ogrsf_frmts/mem/ogr_mem.h
+++ b/ogr/ogrsf_frmts/mem/ogr_mem.h
@@ -146,6 +146,9 @@ class OGRMemDataSource CPL_NON_FINAL: public OGRDataSource
 
     bool                AddFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
                                        std::string& failureReason) override;
+
+    bool                DeleteFieldDomain(const std::string& name,
+                                          std::string& failureReason) override;
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/mem/ogr_mem.h
+++ b/ogr/ogrsf_frmts/mem/ogr_mem.h
@@ -149,6 +149,10 @@ class OGRMemDataSource CPL_NON_FINAL: public OGRDataSource
 
     bool                DeleteFieldDomain(const std::string& name,
                                           std::string& failureReason) override;
+
+    bool                UpdateFieldDomain(std::unique_ptr<OGRFieldDomain>&& domain,
+                                          std::string& failureReason) override;
+
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/mem/ogrmemdatasource.cpp
+++ b/ogr/ogrsf_frmts/mem/ogrmemdatasource.cpp
@@ -143,6 +143,8 @@ int OGRMemDataSource::TestCapability( const char *pszCap )
         return TRUE;
     else if( EQUAL(pszCap, ODsCDeleteFieldDomain) )
         return TRUE;
+    else if( EQUAL(pszCap, ODsCUpdateFieldDomain) )
+        return TRUE;
 
     return FALSE;
 }
@@ -205,5 +207,23 @@ bool OGRMemDataSource::DeleteFieldDomain(const std::string &name, std::string &f
         }
     }
 
+    return true;
+}
+
+
+/************************************************************************/
+/*                           UpdateFieldDomain()                        */
+/************************************************************************/
+
+bool OGRMemDataSource::UpdateFieldDomain(std::unique_ptr<OGRFieldDomain> &&domain, std::string &failureReason)
+{
+    const auto domainName = domain->GetName();
+    const auto iter = m_oMapFieldDomains.find(domainName);
+    if( iter == m_oMapFieldDomains.end() )
+    {
+        failureReason = "No matching domain found";
+        return false;
+    }
+    m_oMapFieldDomains[domainName] = std::move(domain);
     return true;
 }

--- a/swig/include/Dataset.i
+++ b/swig/include/Dataset.i
@@ -1032,6 +1032,13 @@ OGRErr AbortSQL() {
   }
   %clear OGRFieldDomainShadow* fieldDomain;
 
+  %apply Pointer NONNULL {const char* name};
+  bool DeleteFieldDomain(const char* name)
+  {
+      return GDALDatasetDeleteFieldDomain(self, name, NULL);
+  }
+  %clear const char* name;
+
 } /* extend */
 }; /* GDALDatasetShadow */
 

--- a/swig/include/Dataset.i
+++ b/swig/include/Dataset.i
@@ -1039,6 +1039,13 @@ OGRErr AbortSQL() {
   }
   %clear const char* name;
 
+  %apply Pointer NONNULL {OGRFieldDomainShadow* fieldDomain};
+  bool UpdateFieldDomain(OGRFieldDomainShadow* fieldDomain)
+  {
+      return GDALDatasetUpdateFieldDomain(self, (OGRFieldDomainH)fieldDomain, NULL);
+  }
+  %clear OGRFieldDomainShadow* fieldDomain;
+
 } /* extend */
 }; /* GDALDatasetShadow */
 

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -490,6 +490,7 @@ typedef void retGetPoints;
 /* Note the unfortunate trailing space at the end of the string */
 %constant char *ODsCRandomLayerWrite   = "RandomLayerWrite ";
 %constant char *ODsCAddFieldDomain     = "AddFieldDomain";
+%constant char *ODsCDeleteFieldDomain  = "DeleteFieldDomain";
 
 %constant char *ODrCCreateDataSource   = "CreateDataSource";
 %constant char *ODrCDeleteDataSource   = "DeleteDataSource";

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -491,6 +491,7 @@ typedef void retGetPoints;
 %constant char *ODsCRandomLayerWrite   = "RandomLayerWrite ";
 %constant char *ODsCAddFieldDomain     = "AddFieldDomain";
 %constant char *ODsCDeleteFieldDomain  = "DeleteFieldDomain";
+%constant char *ODsCUpdateFieldDomain  = "UpdateFieldDomain";
 
 %constant char *ODrCCreateDataSource   = "CreateDataSource";
 %constant char *ODrCDeleteDataSource   = "DeleteDataSource";

--- a/swig/python/extensions/gdal_wrap.cpp
+++ b/swig/python/extensions/gdal_wrap.cpp
@@ -5071,6 +5071,9 @@ SWIGINTERN OGRFieldDomainShadow *GDALDatasetShadow_GetFieldDomain(GDALDatasetSha
 SWIGINTERN bool GDALDatasetShadow_AddFieldDomain(GDALDatasetShadow *self,OGRFieldDomainShadow *fieldDomain){
       return GDALDatasetAddFieldDomain(self, (OGRFieldDomainH)fieldDomain, NULL);
   }
+SWIGINTERN bool GDALDatasetShadow_DeleteFieldDomain(GDALDatasetShadow *self,char const *name){
+      return GDALDatasetDeleteFieldDomain(self, name, NULL);
+  }
 SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double xoff,double yoff,double xsize,double ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,GDALDataType *buf_type=0,int band_list=0,int *pband_list=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GIntBig *buf_band_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL,void *inputOutputBuf=NULL){
     *buf = NULL;
 
@@ -21207,6 +21210,61 @@ SWIGINTERN PyObject *_wrap_Dataset_AddFieldDomain(PyObject *SWIGUNUSEDPARM(self)
   if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
   return resultobj;
 fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Dataset_DeleteFieldDomain(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  GDALDatasetShadow *arg1 = (GDALDatasetShadow *) 0 ;
+  char *arg2 = (char *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject *swig_obj[2] ;
+  bool result;
+
+  if (!SWIG_Python_UnpackTuple(args, "Dataset_DeleteFieldDomain", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_GDALDatasetShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Dataset_DeleteFieldDomain" "', argument " "1"" of type '" "GDALDatasetShadow *""'");
+  }
+  arg1 = reinterpret_cast< GDALDatasetShadow * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Dataset_DeleteFieldDomain" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (bool)GDALDatasetShadow_DeleteFieldDomain(arg1,(char const *)arg2);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
   return NULL;
 }
 
@@ -43882,6 +43940,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "Dataset_GetFieldDomainNames", _wrap_Dataset_GetFieldDomainNames, METH_VARARGS, "Dataset_GetFieldDomainNames(Dataset self, char ** options=None) -> char **"},
 	 { "Dataset_GetFieldDomain", _wrap_Dataset_GetFieldDomain, METH_VARARGS, "Dataset_GetFieldDomain(Dataset self, char const * name) -> FieldDomain"},
 	 { "Dataset_AddFieldDomain", _wrap_Dataset_AddFieldDomain, METH_VARARGS, "Dataset_AddFieldDomain(Dataset self, FieldDomain fieldDomain) -> bool"},
+	 { "Dataset_DeleteFieldDomain", _wrap_Dataset_DeleteFieldDomain, METH_VARARGS, "Dataset_DeleteFieldDomain(Dataset self, char const * name) -> bool"},
 	 { "Dataset_ReadRaster1", (PyCFunction)(void(*)(void))_wrap_Dataset_ReadRaster1, METH_VARARGS|METH_KEYWORDS, "Dataset_ReadRaster1(Dataset self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, int band_list=0, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GIntBig * buf_band_space=None, GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"},
 	 { "Dataset_swigregister", Dataset_swigregister, METH_O, NULL},
 	 { "delete_Group", _wrap_delete_Group, METH_O, "delete_Group(Group self)"},

--- a/swig/python/extensions/gdal_wrap.cpp
+++ b/swig/python/extensions/gdal_wrap.cpp
@@ -5074,6 +5074,9 @@ SWIGINTERN bool GDALDatasetShadow_AddFieldDomain(GDALDatasetShadow *self,OGRFiel
 SWIGINTERN bool GDALDatasetShadow_DeleteFieldDomain(GDALDatasetShadow *self,char const *name){
       return GDALDatasetDeleteFieldDomain(self, name, NULL);
   }
+SWIGINTERN bool GDALDatasetShadow_UpdateFieldDomain(GDALDatasetShadow *self,OGRFieldDomainShadow *fieldDomain){
+      return GDALDatasetUpdateFieldDomain(self, (OGRFieldDomainH)fieldDomain, NULL);
+  }
 SWIGINTERN CPLErr GDALDatasetShadow_ReadRaster1(GDALDatasetShadow *self,double xoff,double yoff,double xsize,double ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,GDALDataType *buf_type=0,int band_list=0,int *pband_list=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GIntBig *buf_band_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL,void *inputOutputBuf=NULL){
     *buf = NULL;
 
@@ -21265,6 +21268,58 @@ SWIGINTERN PyObject *_wrap_Dataset_DeleteFieldDomain(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Dataset_UpdateFieldDomain(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  GDALDatasetShadow *arg1 = (GDALDatasetShadow *) 0 ;
+  OGRFieldDomainShadow *arg2 = (OGRFieldDomainShadow *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject *swig_obj[2] ;
+  bool result;
+  
+  if (!SWIG_Python_UnpackTuple(args, "Dataset_UpdateFieldDomain", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_GDALDatasetShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Dataset_UpdateFieldDomain" "', argument " "1"" of type '" "GDALDatasetShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< GDALDatasetShadow * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_OGRFieldDomainShadow, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Dataset_UpdateFieldDomain" "', argument " "2"" of type '" "OGRFieldDomainShadow *""'"); 
+  }
+  arg2 = reinterpret_cast< OGRFieldDomainShadow * >(argp2);
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (bool)GDALDatasetShadow_UpdateFieldDomain(arg1,arg2);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
   return NULL;
 }
 
@@ -43941,6 +43996,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "Dataset_GetFieldDomain", _wrap_Dataset_GetFieldDomain, METH_VARARGS, "Dataset_GetFieldDomain(Dataset self, char const * name) -> FieldDomain"},
 	 { "Dataset_AddFieldDomain", _wrap_Dataset_AddFieldDomain, METH_VARARGS, "Dataset_AddFieldDomain(Dataset self, FieldDomain fieldDomain) -> bool"},
 	 { "Dataset_DeleteFieldDomain", _wrap_Dataset_DeleteFieldDomain, METH_VARARGS, "Dataset_DeleteFieldDomain(Dataset self, char const * name) -> bool"},
+	 { "Dataset_UpdateFieldDomain", _wrap_Dataset_UpdateFieldDomain, METH_VARARGS, "Dataset_UpdateFieldDomain(Dataset self, FieldDomain fieldDomain) -> bool"},
 	 { "Dataset_ReadRaster1", (PyCFunction)(void(*)(void))_wrap_Dataset_ReadRaster1, METH_VARARGS|METH_KEYWORDS, "Dataset_ReadRaster1(Dataset self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, int band_list=0, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GIntBig * buf_band_space=None, GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"},
 	 { "Dataset_swigregister", Dataset_swigregister, METH_O, NULL},
 	 { "delete_Group", _wrap_delete_Group, METH_O, "delete_Group(Group self)"},

--- a/swig/python/extensions/ogr_wrap.cpp
+++ b/swig/python/extensions/ogr_wrap.cpp
@@ -36900,6 +36900,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "ODsCRandomLayerRead",SWIG_FromCharPtr("RandomLayerRead"));
   SWIG_Python_SetConstant(d, "ODsCRandomLayerWrite",SWIG_FromCharPtr("RandomLayerWrite "));
   SWIG_Python_SetConstant(d, "ODsCAddFieldDomain",SWIG_FromCharPtr("AddFieldDomain"));
+  SWIG_Python_SetConstant(d, "ODsCDeleteFieldDomain",SWIG_FromCharPtr("DeleteFieldDomain"));
   SWIG_Python_SetConstant(d, "ODrCCreateDataSource",SWIG_FromCharPtr("CreateDataSource"));
   SWIG_Python_SetConstant(d, "ODrCDeleteDataSource",SWIG_FromCharPtr("DeleteDataSource"));
   SWIG_Python_SetConstant(d, "OLMD_FID64",SWIG_FromCharPtr("OLMD_FID64"));

--- a/swig/python/extensions/ogr_wrap.cpp
+++ b/swig/python/extensions/ogr_wrap.cpp
@@ -36901,6 +36901,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "ODsCRandomLayerWrite",SWIG_FromCharPtr("RandomLayerWrite "));
   SWIG_Python_SetConstant(d, "ODsCAddFieldDomain",SWIG_FromCharPtr("AddFieldDomain"));
   SWIG_Python_SetConstant(d, "ODsCDeleteFieldDomain",SWIG_FromCharPtr("DeleteFieldDomain"));
+  SWIG_Python_SetConstant(d, "ODsCUpdateFieldDomain",SWIG_FromCharPtr("UpdateFieldDomain"));
   SWIG_Python_SetConstant(d, "ODrCCreateDataSource",SWIG_FromCharPtr("CreateDataSource"));
   SWIG_Python_SetConstant(d, "ODrCDeleteDataSource",SWIG_FromCharPtr("DeleteDataSource"));
   SWIG_Python_SetConstant(d, "OLMD_FID64",SWIG_FromCharPtr("OLMD_FID64"));

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -2330,6 +2330,10 @@ class Dataset(MajorObject):
         r"""DeleteFieldDomain(Dataset self, char const * name) -> bool"""
         return _gdal.Dataset_DeleteFieldDomain(self, *args)
 
+    def UpdateFieldDomain(self, *args) -> "bool":
+        r"""UpdateFieldDomain(Dataset self, FieldDomain fieldDomain) -> bool"""
+        return _gdal.Dataset_UpdateFieldDomain(self, *args)
+
     def ReadRaster1(self, *args, **kwargs):
         r"""ReadRaster1(Dataset self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, int band_list=0, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GIntBig * buf_band_space=None, GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"""
         return _gdal.Dataset_ReadRaster1(self, *args, **kwargs)

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -2326,6 +2326,10 @@ class Dataset(MajorObject):
         r"""AddFieldDomain(Dataset self, FieldDomain fieldDomain) -> bool"""
         return _gdal.Dataset_AddFieldDomain(self, *args)
 
+    def DeleteFieldDomain(self, *args) -> "bool":
+        r"""DeleteFieldDomain(Dataset self, char const * name) -> bool"""
+        return _gdal.Dataset_DeleteFieldDomain(self, *args)
+
     def ReadRaster1(self, *args, **kwargs):
         r"""ReadRaster1(Dataset self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, int band_list=0, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GIntBig * buf_band_space=None, GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"""
         return _gdal.Dataset_ReadRaster1(self, *args, **kwargs)

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -363,6 +363,8 @@ ODsCAddFieldDomain = _ogr.ODsCAddFieldDomain
 
 ODsCDeleteFieldDomain = _ogr.ODsCDeleteFieldDomain
 
+ODsCUpdateFieldDomain = _ogr.ODsCUpdateFieldDomain
+
 ODrCCreateDataSource = _ogr.ODrCCreateDataSource
 
 ODrCDeleteDataSource = _ogr.ODrCDeleteDataSource

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -361,6 +361,8 @@ ODsCRandomLayerWrite = _ogr.ODsCRandomLayerWrite
 
 ODsCAddFieldDomain = _ogr.ODsCAddFieldDomain
 
+ODsCDeleteFieldDomain = _ogr.ODsCDeleteFieldDomain
+
 ODrCCreateDataSource = _ogr.ODrCCreateDataSource
 
 ODrCDeleteDataSource = _ogr.ODrCDeleteDataSource


### PR DESCRIPTION
This PR builds off https://github.com/OSGeo/gdal/pull/5152 (~~temporarily included in this branch~~) and adds two functions for management of field domains -- DeleteFieldDomain and UpdateFieldDomain. Both are implemented for the memory driver only for now, with GPKG driver implementations to follow (in a separate PR)