### PR TITLE
gpkg.rst: improve wording of GEOMETRY_NAME description

### DIFF
--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -217,8 +217,8 @@ Layer Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  **GEOMETRY_NAME**: Column to use for the geometry column. Default to
-   "geom". Note: This option was called GEOMETRY_COLUMN in releases before
-   GDAL 2
+   "geom" if it is not named in the source data.
+   Note: This option was called GEOMETRY_COLUMN in releases before GDAL 2
 -  **GEOMETRY_NULLABLE**: Whether the values of the
    geometry column can be NULL. Can be set to NO so that geometry is
    required. Default to "YES"


### PR DESCRIPTION
Reading the description of *Layer creation options* and *GEOMETRY_NAME*, it seems that the default name given to the geometry column is *geom*. This is the case *if it is not named in the data source*. If it is named, the geometry name in the new data source is inherited from the source data.

See also #5153.