### PR TITLE
CMake: use Poppler_ for variable names

### DIFF
--- a/cmake/modules/packages/FindPoppler.cmake
+++ b/cmake/modules/packages/FindPoppler.cmake
@@ -19,7 +19,7 @@ Copyright (c) 2015, Alex Richardson <arichardson.kde@gmail.com>
 IMPORTED Targets
 ^^^^^^^^^^^^^^^^
 
-This module defines :prop_tgt:`IMPORTED` target ``POPPLER::Poppler``, if
+This module defines :prop_tgt:`IMPORTED` target ``Poppler::Poppler``, if
 curl has been found.
 
 Result Variables
@@ -27,16 +27,16 @@ Result Variables
 
 This module defines the following variables:
 
-``POPPLER_FOUND``
+``Poppler_FOUND``
   True if Poppler found.
 
-``POPPLER_INCLUDE_DIRS``
+``Poppler_INCLUDE_DIRS``
   where to find poppler/poppler-config.h, etc.
 
-``POPPLER_LIBRARIES``
+``Poppler_LIBRARIES``
   List of libraries when using Poppler.
 
-``POPPLER_VERSION_STRING``
+``Poppler_VERSION_STRING``
   The version of Poppler found.
 #]=======================================================================]
 
@@ -44,15 +44,15 @@ find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(PC_Poppler QUIET poppler)
   if(PC_Poppler_VERSION)
-    set(POPPLER_VERSION_STRING ${PC_Poppler_VERSION})
+    set(Poppler_VERSION_STRING ${PC_Poppler_VERSION})
   endif()
 endif()
-find_path(POPPLER_INCLUDE_DIR NAMES "poppler-config.h" "cpp/poppler-version.h" "qt5/poppler-qt5.h" "qt4/poppler-qt4.h"
+find_path(Poppler_INCLUDE_DIR NAMES "poppler-config.h" "cpp/poppler-version.h" "qt5/poppler-qt5.h" "qt4/poppler-qt4.h"
           "glib/poppler.h"
           HINTS ${PC_Poppler_INCLUDE_DIRS}
           PATH_SUFFIXES poppler)
 
-find_library(POPPLER_LIBRARY NAMES poppler HINTS ${PC_Poppler_LIBRARY_DIRS})
+find_library(Poppler_LIBRARY NAMES poppler HINTS ${PC_Poppler_LIBRARY_DIRS})
 
 set(Poppler_known_components Cpp Qt4 Qt5 Glib )
 foreach(_comp IN LISTS Poppler_known_components)
@@ -71,56 +71,56 @@ set(Poppler_Qt4_header "poppler-qt4.h")
 set(Poppler_Glib_header "poppler.h")
 
 foreach(_comp IN LISTS Poppler_FIND_COMPONENTS)
-  set(POPPLER_${_comp}_FOUND FALSE)
+  set(Poppler_${_comp}_FOUND FALSE)
 endforeach()
 
 foreach(_comp IN LISTS Poppler_known_components)
   list(FIND Poppler_FIND_COMPONENTS "${_comp}" _nextcomp)
   if(_nextcomp GREATER -1)
-    find_path(POPPLER_${_comp}_INCLUDE_DIR
+    find_path(Poppler_${_comp}_INCLUDE_DIR
               NAMES ${Poppler_${_comp}_header}
               PATH_SUFFIXES poppler
               HINTS ${PC_Poppler_${_comp}_INCLUDE_DIRS})
-    find_library(POPPLER_${_comp}_LIBRARY
+    find_library(Poppler_${_comp}_LIBRARY
             NAMES ${Poppler_${_comp}_lib}
             HINTS ${PC_Poppler_${_comp}_LIBRARY_DIRS})
   endif()
 endforeach()
 
-if(NOT POPPLER_VERSION_STRING)
-  find_file(POPPLER_VERSION_HEADER
+if(NOT Poppler_VERSION_STRING)
+  find_file(Poppler_VERSION_HEADER
             NAMES "poppler-config.h" "cpp/poppler-version.h"
-            HINTS ${POPPLER_INCLUDE_DIR}
+            HINTS ${Poppler_INCLUDE_DIR}
             PATH_SUFFIXES poppler
             )
-  #if(POPPLER_VERSION_HEADER)
-  #  file(READ ${POPPLER_VERSION_HEADER} _poppler_version_header_contents)
+  #if(Poppler_VERSION_HEADER)
+  #  file(READ ${Poppler_VERSION_HEADER} _poppler_version_header_contents)
   #  string(REGEX REPLACE
   #         "^.*[ \t]+POPPLER_VERSION_MAJOR[ \t]+([0-9]+).*$"
   #         "\\1"
-  #         POPPLER_VERSION_MAJOR
+  #         Poppler_VERSION_MAJOR
   #         "${_poppler_version_header_contents}"
   #         )
   #  string(REGEX REPLACE
   #         "^.*[ \t]+POPPLER_VERSION_MINOR[ \t]+([0-9]+).*$"
   #         "\\1"
-  #         POPPLER_VERSION_MINOR
+  #         Poppler_VERSION_MINOR
   #         "${_poppler_version_header_contents}"
   #         )
   #  string(REGEX REPLACE
   #         "^.*[ \t]+POPPLER_VERSION_MICRO[ \t]+([0-9]+).*$"
   #         "\\1"
-  #         POPPLER_VERSION_MICRO
+  #         Poppler_VERSION_MICRO
   #         "${_poppler_version_header_contents}"
   #         )
   #  unset(_poppler_version_header_contents)
-  #  set(POPPLER_VERSION_STRING "${POPPLER_VERSION_MAJOR}.${POPPLER_VERSION_MINOR}.${POPPLER_VERSION_MICRO}")
+  #  set(Poppler_VERSION_STRING "${Poppler_VERSION_MAJOR}.${Poppler_VERSION_MINOR}.${Poppler_VERSION_MICRO}")
   #endif()
-  if(POPPLER_VERSION_HEADER)
-    file(STRINGS "${POPPLER_VERSION_HEADER}" _poppler_version_str REGEX "^#define[\t ]+POPPLER_VERSION[\t ]+\".*\"")
-    string(REGEX REPLACE "^#define[\t ]+POPPLER_VERSION[\t ]+\"([^\"]*)\".*" "\\1" POPPLER_VERSION_STRING "${_poppler_version_str}")
-    if(NOT ${POPPLER_VERSION_STRING} MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+")
-      message(WARNING "POPPLER_VERSION (${POPPLER_VERSION_STRING}) doesn't match *.*.* form")
+  if(Poppler_VERSION_HEADER)
+    file(STRINGS "${Poppler_VERSION_HEADER}" _poppler_version_str REGEX "^#define[\t ]+POPPLER_VERSION[\t ]+\".*\"")
+    string(REGEX REPLACE "^#define[\t ]+POPPLER_VERSION[\t ]+\"([^\"]*)\".*" "\\1" Poppler_VERSION_STRING "${_poppler_version_str}")
+    if(NOT ${Poppler_VERSION_STRING} MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+")
+      message(WARNING "POPPLER_VERSION (${Poppler_VERSION_STRING}) doesn't match *.*.* form")
     endif()
     unset(_poppler_version_str)
   endif()
@@ -128,25 +128,25 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Poppler
-                                  FOUND_VAR POPPLER_FOUND
-                                  REQUIRED_VARS POPPLER_LIBRARY POPPLER_INCLUDE_DIR
-                                  VERSION_VAR  POPPLER_VERSION_STRING
+                                  FOUND_VAR Poppler_FOUND
+                                  REQUIRED_VARS Poppler_LIBRARY Poppler_INCLUDE_DIR
+                                  VERSION_VAR  Poppler_VERSION_STRING
                                   HANDLE_COMPONENTS)
-mark_as_advanced(POPPLER_INCLUDE_DIR POPPLER_LIBRARY)
+mark_as_advanced(Poppler_INCLUDE_DIR Poppler_LIBRARY)
 
-if(POPPLER_FOUND)
-  set(POPPLER_INCLUDE_DIRS ${POPPLER_INCLUDE_DIR})
-  set(POPPLER_LIBRARIES ${POPPLER_LIBRARY})
-  if(NOT TARGET POPPLER::Poppler)
-    add_library(POPPLER::Poppler UNKNOWN IMPORTED)
-    set_target_properties(POPPLER::Poppler PROPERTIES
-                          INTERFACE_INCLUDE_DIRECTORIES ${POPPLER_INCLUDE_DIR}
+if(Poppler_FOUND)
+  set(Poppler_INCLUDE_DIRS ${Poppler_INCLUDE_DIR})
+  set(Poppler_LIBRARIES ${Poppler_LIBRARY})
+  if(NOT TARGET Poppler::Poppler)
+    add_library(Poppler::Poppler UNKNOWN IMPORTED)
+    set_target_properties(Poppler::Poppler PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${Poppler_INCLUDE_DIR}
                           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-                          IMPORTED_LOCATION "${POPPLER_LIBRARY}")
+                          IMPORTED_LOCATION "${Poppler_LIBRARY}")
     foreach(tgt IN LISTS Poppler_known_components)
-      add_library(POPPLER::${tgt} UNKNOWN IMPORTED)
-      set_target_properties(POPPLER::${tgt} PROPERTIES
-                            INTERFACE_INCLUDE_DIRECTORIES ${POPPLER_${tgt}_INCLUDE_DIR}
+      add_library(Poppler::${tgt} UNKNOWN IMPORTED)
+      set_target_properties(Poppler::${tgt} PROPERTIES
+                            INTERFACE_INCLUDE_DIRECTORIES ${Poppler_${tgt}_INCLUDE_DIR}
                             IMPORTED_LINK_INTERFACE_LANGUAGES "C"
                             IMPORTED_LOCATION ${POPPLER_${tgt}_LIBRARY})
     endforeach()

--- a/doc/source/build_hints.rst
+++ b/doc/source/build_hints.rst
@@ -1270,15 +1270,15 @@ Poppler
 The `Poppler <https://poppler.freedesktop.org/>`_ library is one
 of the possible backends for the :ref:`raster.pdf` driver.
 
-.. option:: POPPLER_INCLUDE_DIR
+.. option:: Poppler_INCLUDE_DIR
 
     Path to an include directory with the ``poppler-config.h`` header file.
 
-.. option:: POPPLER_LIBRARY
+.. option:: Poppler_LIBRARY
 
     Path to a shared or static library file.
 
-.. option:: GDAL_USE_PDFIUM=ON/OFF
+.. option:: GDAL_USE_POPPLER=ON/OFF
 
     Control whether to use Poppler. Defaults to ON when Poppler is found.
 

--- a/frmts/pdf/CMakeLists.txt
+++ b/frmts/pdf/CMakeLists.txt
@@ -21,19 +21,19 @@ target_include_directories(gdal_PDF PRIVATE ${GDAL_RASTER_FORMAT_SOURCE_DIR}/vrt
                                             ${GDAL_VECTOR_FORMAT_SOURCE_DIR}/mem)
 
 if (GDAL_USE_POPPLER)
-  target_include_directories(gdal_PDF PRIVATE ${POPPLER_INCLUDE_DIRS} ${POPPLER_INCLUDE_DIRS}/../)
-  gdal_target_link_libraries(TARGET gdal_PDF LIBRARIES POPPLER::Poppler)
-  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" POPPLER_VERSION_MAJOR ${POPPLER_VERSION_STRING})
-  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" POPPLER_VERSION_MINOR ${POPPLER_VERSION_STRING})
+  target_include_directories(gdal_PDF PRIVATE ${Poppler_INCLUDE_DIRS} ${Poppler_INCLUDE_DIRS}/../)
+  gdal_target_link_libraries(TARGET gdal_PDF LIBRARIES Poppler::Poppler)
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" Poppler_VERSION_MAJOR ${Poppler_VERSION_STRING})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" Poppler_VERSION_MINOR ${Poppler_VERSION_STRING})
   # Strip leading zero
   if ("${POPPLER_VERSION_MINOR}" MATCHES "0?[0-9]+")
-    string(REGEX REPLACE "0?([0-9]+)" "\\1" POPPLER_VERSION_MINOR ${POPPLER_VERSION_MINOR})
+    string(REGEX REPLACE "0?([0-9]+)" "\\1" Poppler_VERSION_MINOR ${Poppler_VERSION_MINOR})
   endif ()
-  if (POPPLER_VERSION_MAJOR GREATER 21)
+  if (Poppler_VERSION_MAJOR GREATER 21)
     target_compile_features(gdal_PDF PRIVATE cxx_std_17)
   endif ()
-  target_compile_definitions(gdal_PDF PRIVATE -DHAVE_POPPLER -DPOPPLER_MAJOR_VERSION=${POPPLER_VERSION_MAJOR}
-                                              -DPOPPLER_MINOR_VERSION=${POPPLER_VERSION_MINOR})
+  target_compile_definitions(gdal_PDF PRIVATE -DHAVE_POPPLER -DPOPPLER_MAJOR_VERSION=${Poppler_VERSION_MAJOR}
+                                              -DPOPPLER_MINOR_VERSION=${Poppler_VERSION_MINOR})
 endif ()
 if (GDAL_USE_PODOFO)
   target_compile_definitions(gdal_PDF PRIVATE -DHAVE_PODOFO)


### PR DESCRIPTION
to be consistent with other FindPoppler.cmake modules like https://github.com/pfultz2/extra-cmake-modules/blob/master/find-modules/FindPoppler.cmake or https://api.kde.org/ecm/find-module/FindPoppler.html