### PR TITLE
/vsis3/: make sure file properties of /vsis3_streaming/foo are invalidated when /vsis3/foo ones are

### DIFF
--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -53,7 +53,12 @@
 #include "cpl_multiproc.h"
 #include "cpl_string.h"
 #include "cpl_vsi_virtual.h"
+#include "cpl_vsil_curl_class.h"
 
+// To avoid aliasing to GetDiskFreeSpace to GetDiskFreeSpaceA on Windows
+#ifdef GetDiskFreeSpace
+#undef GetDiskFreeSpace
+#endif
 
 CPL_CVSID("$Id$")
 
@@ -2814,6 +2819,10 @@ void VSICleanupFileManager()
         CPLDestroyMutex(hVSIFileManagerMutex);
         hVSIFileManagerMutex = nullptr;
     }
+
+#ifdef HAVE_CURL
+    cpl::VSICURLDestroyCacheFileProp();
+#endif
 }
 
 /************************************************************************/

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -191,7 +191,12 @@ class VSICurlFilesystemHandlerBase : public VSIFilesystemHandler
     std::unique_ptr<RegionCacheType> m_poRegionCacheDoNotUseDirectly{}; // do not access directly. Use GetRegionCache();
     RegionCacheType* GetRegionCache();
 
-    lru11::Cache<std::string, FileProp>  oCacheFileProp;
+    // LRU cache that just keeps in memory if this file system handler is
+    // spposed to know the file properties of a file. The actual cache is a
+    // shared one among all network file systems.
+    // The aim of that design is that invalidating /vsis3/foo results in
+    // /vsis3_streaming/foo to be invalidated as well.
+    lru11::Cache<std::string, bool>  oCacheFileProp;
 
     int                                       nCachedFilesInDirList = 0;
     lru11::Cache<std::string, CachedDirList>  oCacheDirList;
@@ -825,6 +830,15 @@ void MultiPerform(CURLM* hCurlMultiHandle,
 void VSICURLResetHeaderAndWriterFunctions(CURL* hCurlHandle);
 
 int VSICurlParseUnixPermissions(const char* pszPermissions);
+
+// Cache of file properties (size, etc.)
+bool VSICURLGetCachedFileProp( const char* pszURL,
+                               FileProp& oFileProp );
+void VSICURLSetCachedFileProp( const char* pszURL,
+                               FileProp& oFileProp );
+void VSICURLInvalidateCachedFileProp( const char* pszURL );
+void VSICURLInvalidateCachedFilePropPrefix( const char* pszURL );
+void VSICURLDestroyCacheFileProp();
 
 } // namespace cpl
 

--- a/port/cpl_vsil_curl_streaming.cpp
+++ b/port/cpl_vsil_curl_streaming.cpp
@@ -172,24 +172,6 @@ void RingBuffer::Read( void* pBuffer, size_t nSize )
 
 namespace {
 
-typedef enum
-{
-    EXIST_UNKNOWN = -1,
-    EXIST_NO,
-    EXIST_YES,
-} ExistStatus;
-
-typedef struct
-{
-    ExistStatus     eExists;
-    int             bHasComputedFileSize;
-    vsi_l_offset    fileSize;
-    int             bIsDirectory;
-#ifdef notdef
-    unsigned int    nChecksumOfFirst1024Bytes;
-#endif
-} CachedFileProp;
-
 typedef struct
 {
     char*           pBuffer;
@@ -198,7 +180,11 @@ typedef struct
     int             bIsInHeader;
     int             nHTTPCode;
     int             bDownloadHeaderOnly;
-} WriteFuncStruct;
+} WriteFuncStructStreaming;
+
+}
+
+namespace cpl {
 
 /************************************************************************/
 /*                       VSICurlStreamingFSHandler                      */
@@ -210,7 +196,12 @@ class VSICurlStreamingFSHandler : public VSIFilesystemHandler
 {
     CPL_DISALLOW_COPY_ASSIGN(VSICurlStreamingFSHandler)
 
-    std::map<CPLString, CachedFileProp*>   cacheFileSize{};
+    // LRU cache that just keeps in memory if this file system handler is
+    // spposed to know the file properties of a file. The actual cache is a
+    // shared one among all network file systems.
+    // The aim of that design is that invalidating /vsis3/foo results in
+    // /vsis3_streaming/foo to be invalidated as well.
+    lru11::Cache<std::string, bool>  oCacheFileProp;
 
 protected:
     CPLMutex           *hMutex = nullptr;
@@ -237,7 +228,10 @@ public:
     void                AcquireMutex();
     void                ReleaseMutex();
 
-    CachedFileProp*     GetCachedFileProp(const char*     pszURL);
+    bool                GetCachedFileProp( const char* pszURL,
+                                           FileProp& oFileProp );
+    void                SetCachedFileProp( const char* pszURL,
+                                           FileProp& oFileProp );
 
     virtual void    ClearCache();
 };
@@ -262,9 +256,9 @@ class VSICurlStreamingHandle : public VSIVirtualHandle
 #endif
     vsi_l_offset    curOffset = 0;
     vsi_l_offset    fileSize = 0;
-    int             bHasComputedFileSize = 0;
+    bool            bHasComputedFileSize = false;
     ExistStatus     eExists = EXIST_UNKNOWN;
-    int             bIsDirectory = 0;
+    bool            bIsDirectory = false;
 
     bool            bCanTrustCandidateFileSize = true;
     bool            bHasCandidateFileSize = false;
@@ -330,11 +324,11 @@ class VSICurlStreamingHandle : public VSIVirtualHandle
     size_t               ReceivedBytesHeader( GByte *buffer, size_t count,
                                               size_t nmemb );
 
-    int                  IsKnownFileSize() const
+    bool                 IsKnownFileSize() const
         { return bHasComputedFileSize; }
     vsi_l_offset         GetFileSize();
     int                  Exists();
-    int                  IsDirectory() const { return bIsDirectory; }
+    bool                 IsDirectory() const { return bIsDirectory; }
 
     const char          *GetURL() const { return m_pszURL; }
 };
@@ -349,14 +343,13 @@ VSICurlStreamingHandle::VSICurlStreamingHandle( VSICurlStreamingFSHandler* poFS,
     m_papszHTTPOptions(CPLHTTPGetOptionsFromEnv()),
     m_pszURL(CPLStrdup(pszURL))
 {
-
-    poFS->AcquireMutex();
-    CachedFileProp* cachedFileProp = poFS->GetCachedFileProp(pszURL);
-    eExists = cachedFileProp->eExists;
-    fileSize = cachedFileProp->fileSize;
-    bHasComputedFileSize = cachedFileProp->bHasComputedFileSize;
-    bIsDirectory = cachedFileProp->bIsDirectory;
-    poFS->ReleaseMutex();
+    FileProp cachedFileProp;
+    poFS->GetCachedFileProp(pszURL, cachedFileProp);
+    eExists = cachedFileProp.eExists;
+    fileSize = cachedFileProp.fileSize;
+    bHasComputedFileSize = cachedFileProp.bHasComputedFileSize;
+    bIsDirectory = cachedFileProp.bIsDirectory;
+    poFS->SetCachedFileProp(pszURL, cachedFileProp);
 
     hRingBufferMutex = CPLCreateMutex();
     ReleaseMutex();
@@ -428,7 +421,7 @@ int VSICurlStreamingHandle::Seek( vsi_l_offset nOffset, int nWhence )
         pCachedData = nullptr;
         nCachedSize = 0;
         AcquireMutex();
-        bHasComputedFileSize = FALSE;
+        bHasComputedFileSize = false;
         fileSize = 0;
         ReleaseMutex();
     }
@@ -450,10 +443,10 @@ int VSICurlStreamingHandle::Seek( vsi_l_offset nOffset, int nWhence )
 }
 
 /************************************************************************/
-/*                  VSICURLStreamingInitWriteFuncStruct()               */
+/*                  VSICURLStreamingInitWriteFuncStructStreaming()               */
 /************************************************************************/
 
-static void VSICURLStreamingInitWriteFuncStruct( WriteFuncStruct *psStruct )
+static void VSICURLStreamingInitWriteFuncStructStreaming( WriteFuncStructStreaming *psStruct )
 {
     psStruct->pBuffer = nullptr;
     psStruct->nSize = 0;
@@ -471,7 +464,7 @@ static size_t
 VSICurlStreamingHandleWriteFuncForHeader( void *buffer, size_t count,
                                           size_t nmemb, void *req )
 {
-    WriteFuncStruct* psStruct = static_cast<WriteFuncStruct *>(req);
+    WriteFuncStructStreaming* psStruct = static_cast<WriteFuncStructStreaming *>(req);
     const size_t nSize = count * nmemb;
 
     char* pNewBuffer = static_cast<char*>(
@@ -523,8 +516,8 @@ VSICurlStreamingHandleWriteFuncForHeader( void *buffer, size_t count,
 
 vsi_l_offset VSICurlStreamingHandle::GetFileSize()
 {
-    WriteFuncStruct sWriteFuncData;
-    WriteFuncStruct sWriteFuncHeaderData;
+    WriteFuncStructStreaming sWriteFuncData;
+    WriteFuncStructStreaming sWriteFuncHeaderData;
 
     AcquireMutex();
     if( bHasComputedFileSize )
@@ -540,7 +533,7 @@ vsi_l_offset VSICurlStreamingHandle::GetFileSize()
     struct curl_slist* headers =
         VSICurlSetOptions(hLocalHandle, m_pszURL, m_papszHTTPOptions);
 
-    VSICURLStreamingInitWriteFuncStruct(&sWriteFuncHeaderData);
+    VSICURLStreamingInitWriteFuncStructStreaming(&sWriteFuncHeaderData);
 
     // HACK for mbtiles driver: Proper fix would be to auto-detect servers that
     // don't accept HEAD http://a.tiles.mapbox.com/v3/ doesn't accept HEAD, so
@@ -574,7 +567,7 @@ vsi_l_offset VSICurlStreamingHandle::GetFileSize()
 
     // Bug with older curl versions (<=7.16.4) and FTP.
     // See http://curl.haxx.se/mail/lib-2007-08/0312.html
-    VSICURLStreamingInitWriteFuncStruct(&sWriteFuncData);
+    VSICURLStreamingInitWriteFuncStructStreaming(&sWriteFuncData);
     curl_easy_setopt(hLocalHandle, CURLOPT_WRITEDATA, &sWriteFuncData);
     curl_easy_setopt(hLocalHandle, CURLOPT_WRITEFUNCTION,
                      VSICurlStreamingHandleWriteFuncForHeader);
@@ -591,7 +584,7 @@ vsi_l_offset VSICurlStreamingHandle::GetFileSize()
     AcquireMutex();
 
     eExists = EXIST_UNKNOWN;
-    bHasComputedFileSize = TRUE;
+    bHasComputedFileSize = true;
 
     if( STARTS_WITH(m_pszURL, "ftp") )
     {
@@ -652,7 +645,7 @@ vsi_l_offset VSICurlStreamingHandle::GetFileSize()
         {
             eExists = EXIST_YES;
             fileSize = 0;
-            bIsDirectory = TRUE;
+            bIsDirectory = true;
         }
 
         if( ENABLE_DEBUG )
@@ -664,17 +657,15 @@ vsi_l_offset VSICurlStreamingHandle::GetFileSize()
     CPLFree(sWriteFuncData.pBuffer);
     CPLFree(sWriteFuncHeaderData.pBuffer);
 
-    m_poFS->AcquireMutex();
-    CachedFileProp* cachedFileProp = m_poFS->GetCachedFileProp(m_pszURL);
-    cachedFileProp->bHasComputedFileSize = TRUE;
-#ifdef notdef
-    cachedFileProp->nChecksumOfFirst1024Bytes =
-        nRecomputedChecksumOfFirst1024Bytes;
-#endif
-    cachedFileProp->fileSize = fileSize;
-    cachedFileProp->eExists = eExists;
-    cachedFileProp->bIsDirectory = bIsDirectory;
-    m_poFS->ReleaseMutex();
+    FileProp cachedFileProp;
+    m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+    cachedFileProp.bHasComputedFileSize = true;
+    cachedFileProp.fileSize = fileSize;
+    cachedFileProp.eExists = eExists;
+    cachedFileProp.bIsDirectory = bIsDirectory;
+    if( cachedFileProp.nMode == 0 )
+        cachedFileProp.nMode = bIsDirectory ? S_IFDIR : S_IFREG;
+    m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
 
     const vsi_l_offset nRet = fileSize;
     ReleaseMutex();
@@ -723,13 +714,15 @@ int VSICurlStreamingHandle::Exists()
                 eExists = EXIST_NO;
                 fileSize = 0;
 
-                m_poFS->AcquireMutex();
-                CachedFileProp* cachedFileProp =
-                    m_poFS->GetCachedFileProp(m_pszURL);
-                cachedFileProp->bHasComputedFileSize = TRUE;
-                cachedFileProp->fileSize = fileSize;
-                cachedFileProp->eExists = eExists;
-                m_poFS->ReleaseMutex();
+
+                FileProp cachedFileProp;
+                m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+                cachedFileProp.bHasComputedFileSize = true;
+                cachedFileProp.fileSize = fileSize;
+                cachedFileProp.eExists = eExists;
+                cachedFileProp.bIsDirectory = false;
+                cachedFileProp.nMode = S_IFREG;
+                m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
 
                 CSLDestroy(papszExtensions);
 
@@ -742,12 +735,10 @@ int VSICurlStreamingHandle::Exists()
         char chFirstByte = '\0';
         int bExists = (Read(&chFirstByte, 1, 1) == 1);
 
-        AcquireMutex();
-        m_poFS->AcquireMutex();
-        CachedFileProp* cachedFileProp = m_poFS->GetCachedFileProp(m_pszURL);
-        cachedFileProp->eExists = eExists = bExists ? EXIST_YES : EXIST_NO;
-        m_poFS->ReleaseMutex();
-        ReleaseMutex();
+        FileProp cachedFileProp;
+        m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+        cachedFileProp.eExists = eExists = bExists ? EXIST_YES : EXIST_NO;
+        m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
 
         Seek(0, SEEK_SET);
     }
@@ -780,22 +771,23 @@ size_t VSICurlStreamingHandle::ReceivedBytes( GByte *buffer, size_t count,
     if( bHasCandidateFileSize && bCanTrustCandidateFileSize &&
         !bHasComputedFileSize )
     {
-        m_poFS->AcquireMutex();
-        CachedFileProp* cachedFileProp = m_poFS->GetCachedFileProp(m_pszURL);
-        cachedFileProp->fileSize = fileSize = nCandidateFileSize;
-        cachedFileProp->bHasComputedFileSize = bHasComputedFileSize = TRUE;
+        FileProp cachedFileProp;
+        m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+        cachedFileProp.fileSize = fileSize = nCandidateFileSize;
+        bHasCandidateFileSize = TRUE;
+        cachedFileProp.bHasComputedFileSize = bHasComputedFileSize;
+        m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
         if( ENABLE_DEBUG )
             CPLDebug("VSICURL", "File size = " CPL_FRMT_GUIB, fileSize);
-        m_poFS->ReleaseMutex();
     }
 
     AcquireMutex();
     if( eExists == EXIST_UNKNOWN )
     {
-        m_poFS->AcquireMutex();
-        CachedFileProp* cachedFileProp = m_poFS->GetCachedFileProp(m_pszURL);
-        cachedFileProp->eExists = eExists = EXIST_YES;
-        m_poFS->ReleaseMutex();
+        FileProp cachedFileProp;
+        m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+        cachedFileProp.eExists = eExists = EXIST_YES;
+        m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
     }
     else if( eExists == EXIST_NO && StopReceivingBytesOnError() )
     {
@@ -924,12 +916,11 @@ size_t VSICurlStreamingHandle::ReceivedBytesHeader( GByte *buffer, size_t count,
             if( !(InterpretRedirect() &&
                   (nHTTPCode == 301 || nHTTPCode == 302)) )
             {
-                m_poFS->AcquireMutex();
-                CachedFileProp* cachedFileProp =
-                    m_poFS->GetCachedFileProp(m_pszURL);
                 eExists = nHTTPCode == 200 ? EXIST_YES : EXIST_NO;
-                cachedFileProp->eExists = eExists;
-                m_poFS->ReleaseMutex();
+                FileProp cachedFileProp;
+                m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+                cachedFileProp.eExists = eExists;
+                m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
             }
         }
 
@@ -1056,13 +1047,15 @@ void VSICurlStreamingHandle::DownloadInThread()
     AcquireMutex();
     if( !bAskDownloadEnd && eRet == 0 && !bHasComputedFileSize )
     {
-        m_poFS->AcquireMutex();
-        CachedFileProp* cachedFileProp = m_poFS->GetCachedFileProp(m_pszURL);
-        cachedFileProp->fileSize = fileSize = nBodySize;
-        cachedFileProp->bHasComputedFileSize = bHasComputedFileSize = TRUE;
+        FileProp cachedFileProp;
+        m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+        fileSize = nBodySize;
+        cachedFileProp.fileSize = fileSize;
+        bHasComputedFileSize = true;
+        cachedFileProp.bHasComputedFileSize = bHasComputedFileSize;
+        m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
         if( ENABLE_DEBUG )
             CPLDebug("VSICURL", "File size = " CPL_FRMT_GUIB, fileSize);
-        m_poFS->ReleaseMutex();
     }
 
     bDownloadInProgress = FALSE;
@@ -1178,7 +1171,7 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
     AcquireMutex();
     // fileSize might be set wrongly to 0, such as
     // /vsicurl_streaming/https://query.data.world/s/jgsghstpphjhicstradhy5kpjwrnfy
-    const int bHasComputedFileSizeLocal = bHasComputedFileSize && fileSize > 0;
+    const bool bHasComputedFileSizeLocal = bHasComputedFileSize && fileSize > 0;
     const vsi_l_offset fileSizeLocal = fileSize;
     ReleaseMutex();
 
@@ -1196,43 +1189,6 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
     if( ENABLE_DEBUG )
         CPLDebug("VSICURL", "Read [" CPL_FRMT_GUIB ", " CPL_FRMT_GUIB "[ in %s",
                  curOffset, curOffset + nBufferRequestSize, m_pszURL);
-
-#ifdef notdef
-    if( pCachedData != nullptr && nCachedSize >= 1024 &&
-        nRecomputedChecksumOfFirst1024Bytes == 0 )
-    {
-        for( size_t i = 0; i < 1024 / sizeof(int); i++ )
-        {
-            int nVal = 0;
-            memcpy(&nVal, pCachedData + i * sizeof(int), sizeof(int));
-            nRecomputedChecksumOfFirst1024Bytes += nVal;
-        }
-
-        if( bHasComputedFileSizeLocal )
-        {
-            poFS->AcquireMutex();
-            CachedFileProp* cachedFileProp = poFS->GetCachedFileProp(pszURL);
-            if( cachedFileProp->nChecksumOfFirst1024Bytes == 0 )
-            {
-                cachedFileProp->nChecksumOfFirst1024Bytes =
-                    nRecomputedChecksumOfFirst1024Bytes;
-            }
-            else if( nRecomputedChecksumOfFirst1024Bytes !=
-                     cachedFileProp->nChecksumOfFirst1024Bytes )
-            {
-                CPLDebug("VSICURL",
-                         "Invalidating previously cached file size. "
-                         "First bytes of file have changed!");
-                AcquireMutex();
-                bHasComputedFileSize = FALSE;
-                cachedFileProp->bHasComputedFileSize = FALSE;
-                cachedFileProp->nChecksumOfFirst1024Bytes = 0;
-                ReleaseMutex();
-            }
-            poFS->ReleaseMutex();
-        }
-    }
-#endif
 
     // Can we use the cache?
     if( pCachedData != nullptr && curOffset < nCachedSize )
@@ -1407,17 +1363,18 @@ size_t VSICurlStreamingHandle::Read( void * const pBuffer, size_t const nSize,
             bEOF = false;
             AcquireMutex();
             eExists = EXIST_UNKNOWN;
-            bHasComputedFileSize = FALSE;
+            bHasComputedFileSize = false;
             fileSize = 0;
             ReleaseMutex();
             nCachedSize = 0;
-            m_poFS->AcquireMutex();
-            CachedFileProp* cachedFileProp =
-                m_poFS->GetCachedFileProp(m_pszURL);
-            cachedFileProp->bHasComputedFileSize = FALSE;
-            cachedFileProp->fileSize = 0;
-            cachedFileProp->eExists = EXIST_UNKNOWN;
-            m_poFS->ReleaseMutex();
+
+            FileProp cachedFileProp;
+            m_poFS->GetCachedFileProp(m_pszURL, cachedFileProp);
+            cachedFileProp.bHasComputedFileSize = false;
+            cachedFileProp.fileSize = 0;
+            cachedFileProp.eExists = EXIST_UNKNOWN;
+            m_poFS->SetCachedFileProp(m_pszURL, cachedFileProp);
+
             nRet = Read(pBuffer, nSize, nMemb);
         }
         else
@@ -1503,7 +1460,8 @@ int       VSICurlStreamingHandle::Close()
 /*                      VSICurlStreamingFSHandler()                     */
 /************************************************************************/
 
-VSICurlStreamingFSHandler::VSICurlStreamingFSHandler()
+VSICurlStreamingFSHandler::VSICurlStreamingFSHandler():
+    oCacheFileProp{100*1024}
 {
     hMutex = CPLCreateMutex();
     CPLReleaseMutex(hMutex);
@@ -1529,11 +1487,15 @@ void VSICurlStreamingFSHandler::ClearCache()
 {
     CPLMutexHolder oHolder( &hMutex );
 
-    for( auto& kv: cacheFileSize )
     {
-        CPLFree(kv.second);
+        const auto lambda = [](
+            const lru11::KeyValuePair<std::string, bool>& kv)
+        {
+            VSICURLInvalidateCachedFileProp(kv.key.c_str());
+        };
+        oCacheFileProp.cwalk(lambda);
+        oCacheFileProp.clear();
     }
-    cacheFileSize.clear();
 }
 
 /************************************************************************/
@@ -1552,33 +1514,6 @@ void VSICurlStreamingFSHandler::AcquireMutex()
 void VSICurlStreamingFSHandler::ReleaseMutex()
 {
     CPLReleaseMutex(hMutex);
-}
-
-/************************************************************************/
-/*                         GetCachedFileProp()                          */
-/************************************************************************/
-
-/* Should be called under the FS Lock */
-
-CachedFileProp *
-VSICurlStreamingFSHandler::GetCachedFileProp( const char* pszURL )
-{
-    CachedFileProp* cachedFileProp = cacheFileSize[pszURL];
-    if( cachedFileProp == nullptr )
-    {
-        cachedFileProp =
-            static_cast<CachedFileProp *>(CPLMalloc(sizeof(CachedFileProp)));
-        cachedFileProp->eExists = EXIST_UNKNOWN;
-        cachedFileProp->bHasComputedFileSize = FALSE;
-        cachedFileProp->fileSize = 0;
-        cachedFileProp->bIsDirectory = FALSE;
-#ifdef notdef
-        cachedFileProp->nChecksumOfFirst1024Bytes = 0;
-#endif
-        cacheFileSize[pszURL] = cachedFileProp;
-    }
-
-    return cachedFileProp;
 }
 
 /************************************************************************/
@@ -1625,6 +1560,40 @@ VSIVirtualHandle* VSICurlStreamingFSHandler::Open( const char *pszFilename,
         return VSICreateCachedFile( poHandle );
 
     return poHandle;
+}
+
+/************************************************************************/
+/*                         GetCachedFileProp()                          */
+/************************************************************************/
+
+bool
+VSICurlStreamingFSHandler::GetCachedFileProp( const char* pszURL,
+                                             FileProp& oFileProp )
+{
+    CPLMutexHolder oHolder( &hMutex );
+    bool inCache;
+    if( oCacheFileProp.tryGet(std::string(pszURL), inCache) )
+    {
+        if( VSICURLGetCachedFileProp(pszURL, oFileProp) )
+        {
+            return true;
+        }
+        oCacheFileProp.remove(std::string(pszURL));
+    }
+    return false;
+}
+
+/************************************************************************/
+/*                         SetCachedFileProp()                          */
+/************************************************************************/
+
+void
+VSICurlStreamingFSHandler::SetCachedFileProp( const char* pszURL,
+                                             FileProp& oFileProp )
+{
+    CPLMutexHolder oHolder( &hMutex );
+    oCacheFileProp.insert(std::string(pszURL), true);
+    VSICURLSetCachedFileProp(pszURL, oFileProp);
 }
 
 /************************************************************************/
@@ -2031,7 +2000,7 @@ VSISwiftStreamingFSHandler::CreateFileHandle( const char* pszURL )
 
 //! @endcond
 
-} /* end of anonymous namespace */
+} /* namespace cpl */
 
 /************************************************************************/
 /*                 VSIInstallCurlStreamingFileHandler()                 */
@@ -2050,7 +2019,7 @@ VSISwiftStreamingFSHandler::CreateFileHandle( const char* pszURL )
 void VSIInstallCurlStreamingFileHandler(void)
 {
     VSIFileManager::InstallHandler( "/vsicurl_streaming/",
-                                    new VSICurlStreamingFSHandler );
+                                    new cpl::VSICurlStreamingFSHandler );
 }
 
 /************************************************************************/
@@ -2070,7 +2039,7 @@ void VSIInstallCurlStreamingFileHandler(void)
 void VSIInstallS3StreamingFileHandler(void)
 {
     VSIFileManager::InstallHandler( "/vsis3_streaming/",
-                                    new VSIS3StreamingFSHandler );
+                                    new cpl::VSIS3StreamingFSHandler );
 }
 
 /************************************************************************/
@@ -2090,7 +2059,7 @@ void VSIInstallS3StreamingFileHandler(void)
 
 void VSIInstallGSStreamingFileHandler( void )
 {
-    VSIFileManager::InstallHandler( "/vsigs_streaming/", new VSIGSStreamingFSHandler );
+    VSIFileManager::InstallHandler( "/vsigs_streaming/", new cpl::VSIGSStreamingFSHandler );
 }
 
 /************************************************************************/
@@ -2111,7 +2080,7 @@ void VSIInstallGSStreamingFileHandler( void )
 void VSIInstallAzureStreamingFileHandler( void )
 {
     VSIFileManager::InstallHandler( "/vsiaz_streaming/",
-                                    new VSIAzureStreamingFSHandler );
+                                    new cpl::VSIAzureStreamingFSHandler );
 }
 
 /************************************************************************/
@@ -2132,7 +2101,7 @@ void VSIInstallAzureStreamingFileHandler( void )
 void VSIInstallOSSStreamingFileHandler( void )
 {
     VSIFileManager::InstallHandler( "/vsioss_streaming/",
-                                    new VSIOSSStreamingFSHandler );
+                                    new cpl::VSIOSSStreamingFSHandler );
 }
 
 /************************************************************************/
@@ -2153,7 +2122,7 @@ void VSIInstallOSSStreamingFileHandler( void )
 void VSIInstallSwiftStreamingFileHandler( void )
 {
     VSIFileManager::InstallHandler( "/vsiswift_streaming/",
-                                    new VSISwiftStreamingFSHandler );
+                                    new cpl::VSISwiftStreamingFSHandler );
 }
 //! @cond Doxygen_Suppress
 
@@ -2164,13 +2133,13 @@ void VSIInstallSwiftStreamingFileHandler( void )
 void VSICurlStreamingClearCache( void )
 {
     // FIXME ? Currently we have different filesystem instances for
-    // vsicurl/, /vsis3/, /vsigs/ . So each one has its own cache of regions,
-    // file size, etc.
+    // vsicurl/, /vsis3/, /vsigs/ . So each one has its own cache of regions.
+    // File properties cache are now shared
     CSLConstList papszPrefix = VSIFileManager::GetPrefixes();
     for( size_t i = 0; papszPrefix && papszPrefix[i]; ++i )
     {
         auto poFSHandler =
-            dynamic_cast<VSICurlStreamingFSHandler*>(
+            dynamic_cast<cpl::VSICurlStreamingFSHandler*>(
                 VSIFileManager::GetHandler( papszPrefix[i] ));
 
         if( poFSHandler )


### PR DESCRIPTION
This fixes scenarios with using repeated VSISync() that may use
/vsis3_streaming/ to download file, and /vsis3/ to upload it.
