### PR TITLE
Fix MinGW Debug builds with CMake

### DIFF
--- a/gdal.cmake
+++ b/gdal.cmake
@@ -296,7 +296,7 @@ if (MINGW)
   # excluding any optimizations that take up extra space. Given that the issue is a string table overflowing, -Os seemed
   # appropriate.
   if (CMAKE_BUILD_TYPE MATCHES Debug)
-    set_compile_options(-Os)
+    add_compile_options(-Os)
   endif ()
 endif ()
 


### PR DESCRIPTION
## What does this PR do?

Fixes a cmake error with `MINGW` and `CMAKE_BUILD_TYPE` `Debug`

## Tasklist
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

mingw triplets with vcpkg, CMake 3.21
