### PR TITLE
Migrate doc building to github action workflows

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -23,6 +23,10 @@ jobs:
       shell: bash -l {0}
       run: |
         if find . -name '*.rst' | xargs grep -P '\t'; then echo 'Tabs are bad, please use four spaces in .rst files.'; false; fi
+        if find . -name '*.rst' | xargs grep "\.\.versionadded"; then echo 'Wrong annotation. Should be .. versionadded'; false; fi
+        if find . -name '*.rst' | xargs grep "\.\.note"; then echo 'Wrong annotation. Should be .. note'; false; fi
+        if find . -name '*.rst' | xargs grep "\.\.warning"; then echo 'Wrong annotation. Should be .. warning'; false; fi
+        if find . -name '*.rst' | xargs grep "\.\.codeblock"; then echo 'Wrong annotation. Should be .. codeblock'; false; fi
       working-directory: ./doc
     - name: Doxygen
       shell: bash -l {0}

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -1,0 +1,58 @@
+name: Docs
+
+on: [push, pull_request]
+
+jobs:
+  docs:
+    name: Docs
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    container: osgeo/proj-docs
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Print versions
+      shell: bash -l {0}
+      run: |
+          python3 --version
+          sphinx-build --version
+          python3 -m pip list --not-required --format=columns
+    - name: Lint .rst files
+      shell: bash -l {0}
+      run: |
+        if find . -name '*.rst' | xargs grep -P '\t'; then echo 'Tabs are bad, please use four spaces in .rst files.'; false; fi
+      working-directory: ./doc
+    - name: Doxygen
+      shell: bash -l {0}
+      run: |
+        mkdir -p doc/build
+        doxygen Doxyfile
+    - name: HTML
+      shell: bash -l {0}
+      run: |
+        make html
+      working-directory: ./doc
+    - name: PDF
+      shell: bash -l {0}
+      run: |
+        make latexpdf
+      working-directory: ./doc
+    #- name: Spelling
+    #  shell: bash -l {0}
+    #  run: |
+    #    make spelling
+    #  working-directory: ./doc
+    - uses: actions/upload-artifact@v2
+      with:
+        name: PDF
+        path: doc/build/latex/gdal.pdf
+    - uses: actions/upload-artifact@v2
+      with:
+        name: HTML
+        path: doc/build/html/*
+    #- uses: actions/upload-artifact@v2
+    #  with:
+    #    name: Misspelled
+    #    path: doc/build/spelling/output.txt

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -61,17 +61,16 @@ jobs:
     #    name: Misspelled
     #    path: doc/build/spelling/output.txt
     - name: Deploy ssh key
-      if: ${{ github.ref_name == 'master' }}
+      if: ${{ github.ref_name == 'master' && github.repository == 'OSGeo/gdal' }} 
       shell: bash -l {0}
       run: |
         mkdir /root/.ssh && echo "${{ secrets.SSH_KEY_DOCS }}" > /root/.ssh/id_rsa
-        wc /root/.ssh/id_rsa
         chmod 700 /root/.ssh && chmod 600 /root/.ssh/id_rsa
         ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
         eval `ssh-agent -s`
         ssh-add /root/.ssh/id_rsa
     - name: Deploy to gdal.org
-      if: ${{ github.ref_name == 'master' }}
+      if: ${{ github.ref_name == 'master' && github.repository == 'OSGeo/gdal' }}
       shell: bash -l {0}
       run: |
         set -x

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -60,3 +60,32 @@ jobs:
     #  with:
     #    name: Misspelled
     #    path: doc/build/spelling/output.txt
+    - name: Deploy ssh key
+      if: ${{ github.ref_name == 'master' }}
+      shell: bash -l {0}
+      run: |
+        mkdir /root/.ssh && echo "${{ secrets.SSH_KEY_DOCS }}" > /root/.ssh/id_rsa
+        wc /root/.ssh/id_rsa
+        chmod 700 /root/.ssh && chmod 600 /root/.ssh/id_rsa
+        ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
+        eval `ssh-agent -s`
+        ssh-add /root/.ssh/id_rsa
+    - name: Deploy to gdal.org
+      if: ${{ github.ref_name == 'master' }}
+      shell: bash -l {0}
+      run: |
+        set -x
+        set -e
+        mkdir /__w/html
+        cd /__w/html
+        cp -r /__w/gdal/gdal/doc/build/html/* .
+        git init
+        git config user.email "proj4bot@proj4.bot"
+        git config user.name "GDAL Bot"
+        git remote add origin git@github.com:OSGeo/gdal-docs.git
+        git remote -v
+        echo "gdal.org" > CNAME
+        touch .nojekyll
+        git add -A
+        git commit -m "Update with OSGeo/gdal commit $GITHUB_SHA"
+        git push -f origin master


### PR DESCRIPTION
## What does this PR do?
This pull request migrates the documentation building process to github actions.
Thanks for considering it.

## What are related issues/pull requests?
It fixes #4367.

## Notes
Should the azure pipeline be removed in this pull request too?
The 'spelling' step implemented in https://github.com/OSGeo/PROJ/blob/c80c4ededbad6a11e9731ae5e118f7cfd9138f67/.github/workflows/doc_build.yml#L92 fails due to some spelling warnings. I have commented it out for now. It wasn´t implemented in azure. Should it be removed?