### PR TITLE
Update FindPCRE2.cmake

### DIFF
--- a/cmake/modules/packages/FindPCRE2.cmake
+++ b/cmake/modules/packages/FindPCRE2.cmake
@@ -9,7 +9,7 @@
 # Find the native PCRE2 headers and libraries.
 
 find_path(PCRE2_INCLUDE_DIR NAMES pcre2.h)
-find_library(PCRE2_LIBRARY NAMES pcre2-8)
+find_library(PCRE2_LIBRARY NAMES pcre2-8 pcre2-8d pcre2-8-static pcre2-8-staticd NAMES_PER_DIR)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PCRE2
                                   FOUND_VAR PCRE2_FOUND


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes pcre2 lib for static and debug configurations on windows.
When building pcre2 with CMake and MSVC, the static archives are suffixed `-static`, and for WIN32, there is a debug postfix `d`.
https://github.com/PhilipHazel/pcre2/blob/111cd470b55d0c06bfb157c8f4521907d3d95fdb/CMakeLists.txt#L692-L694
https://github.com/PhilipHazel/pcre2/blob/111cd470b55d0c06bfb157c8f4521907d3d95fdb/CMakeLists.txt#L515-L517

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
