### PR TITLE
Update FindQHULL.cmake

### DIFF
--- a/cmake/modules/packages/FindQHULL.cmake
+++ b/cmake/modules/packages/FindQHULL.cmake
@@ -8,7 +8,7 @@
 # Copyright (c) 2017,2018, Hiroshi Miura <miurahr@linux.com>
 #
 # Input variables:
-#    QHULL_PACKAGE_NAME: name of the pkg-config package, typically qhull_r or qhullstatic_r
+#    QHULL_PACKAGE_NAME: name (or list of names) of the pkg-config package, typically qhull_r or qhullstatic_r
 #
 # If it's found it sets QHULL_FOUND to TRUE
 # and following variables are set:
@@ -16,12 +16,12 @@
 #    QHULL_LIBRARY
 #
 
-set(QHULL_PACKAGE_NAME qhull_r CACHE STRING "Name of the pkg-config package, typically qhull_r or qhullstatic_r")
+set(QHULL_PACKAGE_NAME "qhull_r;qhullstatic_r" CACHE STRING "Names of the pkg-config package, typically qhull_r or qhullstatic_r")
 mark_as_advanced(QHULL_PACKAGE_NAME)
 
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_QHULL QUIET ${QHULL_PACKAGE_NAME})
+    pkg_search_module(PC_QHULL QUIET ${QHULL_PACKAGE_NAME})
 endif()
 
 find_path(QHULL_INCLUDE_DIR libqhull_r/libqhull_r.h


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

This change lets the Find module search for the `qhullstatic_r` pkg-config module in addition to `qhull_r`.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
