### PR TITLE
gdalsrsinfo: failed to load SRS exitcode

### DIFF
--- a/apps/gdalsrsinfo.cpp
+++ b/apps/gdalsrsinfo.cpp
@@ -181,6 +181,7 @@ MAIN_START(argc, argv)
         CPLError( CE_Failure, CPLE_AppDefined,
                   "ERROR - failed to load SRS definition from %s",
                   pszInput );
+        exit(1)
     }
 
     else {


### PR DESCRIPTION
## What does this PR do?
Adds an exit code for gdalsrsinfo when it can't find a SRS definition.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
