### PR TITLE
autotest/cpp: relicence LGPL licensed files to MIT except one exception

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   test_gdal_dted.cpp
   test_gdal_gtiff.cpp
   test_ogr.cpp
+  test_ogr_lgpl.cpp
   test_ogr_geos.cpp
   test_ogr_shape.cpp
   test_osr.cpp

--- a/autotest/cpp/Makefile
+++ b/autotest/cpp/Makefile
@@ -60,6 +60,7 @@ OBJ = \
     test_gdal_gtiff.o \
     test_triangulation.o \
     test_ogr.o \
+    test_ogr_lgpl.o \
     test_ogr_geos.o \
     test_ogr_shape.o \
     test_osr.o \

--- a/autotest/cpp/gdal_unit_test.cpp
+++ b/autotest/cpp/gdal_unit_test.cpp
@@ -6,22 +6,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #ifdef _MSC_VER
 #define WIN32_LEAN_AND_MEAN
@@ -82,7 +85,7 @@ int main(int argc, char* argv[])
         return EXIT_SUCCESS;
     }
 
-        
+
 
     // Initialize TUT framework
     int nRetCode = EXIT_FAILURE;

--- a/autotest/cpp/gdal_unit_test.h
+++ b/autotest/cpp/gdal_unit_test.h
@@ -6,22 +6,26 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
 #ifndef GDAL_COMMON_H_INCLUDED
 #define GDAL_COMMON_H_INCLUDED
 

--- a/autotest/cpp/makefile.vc
+++ b/autotest/cpp/makefile.vc
@@ -53,6 +53,7 @@ OBJ = \
     test_gdal_gtiff.obj \
     test_triangulation.obj \
     test_ogr.obj \
+    test_ogr_lgpl.obj \
     test_ogr_geos.obj \
     test_ogr_shape.obj \
     test_osr.obj \

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -9,22 +9,25 @@
 // Copyright (c) 2008-2012, Even Rouault <even dot rouault at spatialys.com>
 // Copyright (c) 2017, Dmitry Baryshnikov <polimax@mail.ru>
 // Copyright (c) 2017, NextGIS <info@nextgis.com>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #ifndef GDAL_COMPILATION
 #define GDAL_COMPILATION

--- a/autotest/cpp/test_data.h
+++ b/autotest/cpp/test_data.h
@@ -6,22 +6,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2017, Hiroshi Miura
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #ifndef GDAL_TEST_DATA_H
 #define GDAL_TEST_DATA_H

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -6,22 +6,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_gdal_aaigrid.cpp
+++ b/autotest/cpp/test_gdal_aaigrid.cpp
@@ -7,22 +7,25 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
 // Copyright (c) 2010, Even Rouault <even dot rouault at spatialys.com>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_gdal_dted.cpp
+++ b/autotest/cpp/test_gdal_dted.cpp
@@ -7,22 +7,25 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
 // Copyright (c) 2010, Even Rouault <even dot rouault at spatialys.com>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_gdal_gtiff.cpp
+++ b/autotest/cpp/test_gdal_gtiff.cpp
@@ -7,22 +7,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -6,22 +6,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 
@@ -1571,121 +1574,6 @@ namespace tut
 
         }
         poFeatureDefn->Release();
-    }
-
-    // Test OGRGetXMLDateTime()
-    template<>
-    template<>
-    void object::test<15>()
-    {
-        OGRField sField;
-        char *pszDateTime;
-
-        sField.Date.Year = 2001;
-        sField.Date.Month = 2;
-        sField.Date.Day = 3;
-        sField.Date.Hour = 4;
-        sField.Date.Minute = 5;
-
-        // Unknown time zone (TZFlag = 0), no millisecond count
-        sField.Date.TZFlag = 0;
-        sField.Date.Second = 6.0f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "unknown time zone, no millisecond count",
-               strcmp("2001-02-03T04:05:06", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // Unknown time zone (TZFlag = 0), millisecond count
-        sField.Date.TZFlag = 0;
-        sField.Date.Second = 6.789f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "unknown time zone, millisecond count",
-               strcmp("2001-02-03T04:05:06.789", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // Local time zone (TZFlag = 1), no millisecond count
-        sField.Date.TZFlag = 1;
-        sField.Date.Second = 6.0f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "local time zone, no millisecond count",
-               strcmp("2001-02-03T04:05:06", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // Local time zone (TZFlag = 1), millisecond count
-        sField.Date.TZFlag = 1;
-        sField.Date.Second = 6.789f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "local time zone, millisecond count",
-               strcmp("2001-02-03T04:05:06.789", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // GMT time zone (TZFlag = 100), no millisecond count
-        sField.Date.TZFlag = 100;
-        sField.Date.Second = 6.0f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "GMT time zone, no millisecond count",
-               strcmp("2001-02-03T04:05:06Z", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // GMT time zone (TZFlag = 100), millisecond count
-        sField.Date.TZFlag = 100;
-        sField.Date.Second = 6.789f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "GMT time zone, millisecond count",
-               strcmp("2001-02-03T04:05:06.789Z", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // Positive time-zone offset, no millisecond count
-        sField.Date.TZFlag = 111;
-        sField.Date.Second = 6.0f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "positive time-zone offset, no millisecond count",
-               strcmp("2001-02-03T04:05:06+02:45", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // Positive time-zone offset, millisecond count
-        sField.Date.TZFlag = 111;
-        sField.Date.Second = 6.789f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "positive time-zone offset, millisecond count",
-               strcmp("2001-02-03T04:05:06.789+02:45", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // Negative time-zone offset, no millisecond count
-        sField.Date.TZFlag = 88;
-        sField.Date.Second = 6.0f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "negative time-zone offset, no millisecond count",
-               strcmp("2001-02-03T04:05:06-03:00", pszDateTime) == 0);
-        CPLFree(pszDateTime);
-
-        // Negative time-zone offset, millisecond count
-        sField.Date.TZFlag = 88;
-        sField.Date.Second = 6.789f;
-        pszDateTime = OGRGetXMLDateTime(&sField);
-        ensure(nullptr != pszDateTime);
-        ensure("OGRGetXMLDateTime formats date/time field with "
-               "negative time-zone offset, millisecond count",
-               strcmp("2001-02-03T04:05:06.789-03:00", pszDateTime) == 0);
-        CPLFree(pszDateTime);
     }
 
     // Test OGRLinearRing::isPointOnRingBoundary()

--- a/autotest/cpp/test_ogr_geos.cpp
+++ b/autotest/cpp/test_ogr_geos.cpp
@@ -7,22 +7,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_ogr_lgpl.cpp
+++ b/autotest/cpp/test_ogr_lgpl.cpp
@@ -1,0 +1,160 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Project:  C++ Test Suite for GDAL/OGR
+// Purpose:  Test general OGR features.
+// Author:   Simon South
+//
+// Note the LGPL license of that file. See https://github.com/OSGeo/gdal/issues/5198
+//
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2019, Simon South
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Library General Public
+// License as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Library General Public License for more details.
+//
+// You should have received a copy of the GNU Library General Public
+// License along with this library; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "gdal_unit_test.h"
+
+#include "ogr_p.h"
+#include "ogrsf_frmts.h"
+
+#include <string>
+
+namespace tut
+{
+    struct test_ogr_lgpl_data
+    {
+    };
+    // Register test group
+    typedef test_group<test_ogr_lgpl_data> group;
+    typedef group::object object;
+    group test_ogr_lgpl_group("OGR_LGPL");
+
+    // Test OGRGetXMLDateTime()
+    template<>
+    template<>
+    void object::test<15>()
+    {
+        OGRField sField;
+        char *pszDateTime;
+
+        sField.Date.Year = 2001;
+        sField.Date.Month = 2;
+        sField.Date.Day = 3;
+        sField.Date.Hour = 4;
+        sField.Date.Minute = 5;
+
+        // Unknown time zone (TZFlag = 0), no millisecond count
+        sField.Date.TZFlag = 0;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "unknown time zone, no millisecond count",
+               strcmp("2001-02-03T04:05:06", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Unknown time zone (TZFlag = 0), millisecond count
+        sField.Date.TZFlag = 0;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "unknown time zone, millisecond count",
+               strcmp("2001-02-03T04:05:06.789", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Local time zone (TZFlag = 1), no millisecond count
+        sField.Date.TZFlag = 1;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "local time zone, no millisecond count",
+               strcmp("2001-02-03T04:05:06", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Local time zone (TZFlag = 1), millisecond count
+        sField.Date.TZFlag = 1;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "local time zone, millisecond count",
+               strcmp("2001-02-03T04:05:06.789", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // GMT time zone (TZFlag = 100), no millisecond count
+        sField.Date.TZFlag = 100;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "GMT time zone, no millisecond count",
+               strcmp("2001-02-03T04:05:06Z", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // GMT time zone (TZFlag = 100), millisecond count
+        sField.Date.TZFlag = 100;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "GMT time zone, millisecond count",
+               strcmp("2001-02-03T04:05:06.789Z", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Positive time-zone offset, no millisecond count
+        sField.Date.TZFlag = 111;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "positive time-zone offset, no millisecond count",
+               strcmp("2001-02-03T04:05:06+02:45", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Positive time-zone offset, millisecond count
+        sField.Date.TZFlag = 111;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "positive time-zone offset, millisecond count",
+               strcmp("2001-02-03T04:05:06.789+02:45", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Negative time-zone offset, no millisecond count
+        sField.Date.TZFlag = 88;
+        sField.Date.Second = 6.0f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "negative time-zone offset, no millisecond count",
+               strcmp("2001-02-03T04:05:06-03:00", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+
+        // Negative time-zone offset, millisecond count
+        sField.Date.TZFlag = 88;
+        sField.Date.Second = 6.789f;
+        pszDateTime = OGRGetXMLDateTime(&sField);
+        ensure(nullptr != pszDateTime);
+        ensure("OGRGetXMLDateTime formats date/time field with "
+               "negative time-zone offset, millisecond count",
+               strcmp("2001-02-03T04:05:06.789-03:00", pszDateTime) == 0);
+        CPLFree(pszDateTime);
+    }
+
+} // namespace tut

--- a/autotest/cpp/test_ogr_shape.cpp
+++ b/autotest/cpp/test_ogr_shape.cpp
@@ -7,22 +7,25 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
 // Copyright (c) 2010, Even Rouault <even dot rouault at spatialys.com>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_osr.cpp
+++ b/autotest/cpp/test_osr.cpp
@@ -6,22 +6,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_osr_ct.cpp
+++ b/autotest/cpp/test_osr_ct.cpp
@@ -6,22 +6,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_osr_pci.cpp
+++ b/autotest/cpp/test_osr_pci.cpp
@@ -7,22 +7,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 

--- a/autotest/cpp/test_osr_proj4.cpp
+++ b/autotest/cpp/test_osr_proj4.cpp
@@ -7,22 +7,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2006, Mateusz Loskot <mateusz@loskot.net>
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Library General Public
-// License as published by the Free Software Foundation; either
-// version 2 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Library General Public License for more details.
-//
-// You should have received a copy of the GNU Library General Public
-// License along with this library; if not, write to the
-// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-// Boston, MA 02111-1307, USA.
-///////////////////////////////////////////////////////////////////////////////
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
 
 #include "gdal_unit_test.h"
 


### PR DESCRIPTION
with the content of commit 81c82782567ed5b57930efd3ff8d67ac8f58bf45
where we couldn't reach the author, which is moved to a dedicated file.

Agreement of authors has been noted in https://github.com/OSGeo/gdal/issues/5198

Fixes #5198
