### PR TITLE
Mention maximum dimension of PNG files (#4870)

### DIFF
--- a/doc/source/drivers/raster/png.rst
+++ b/doc/source/drivers/raster/png.rst
@@ -31,6 +31,9 @@ pixel types other than 16bit unsigned will be written as eight bit.
 XMP metadata can be extracted from the file,
 and will be stored as XML raw content in the xml:XMP metadata domain.
 
+The maximum dimension of a PNG file that can be created is set to
+1000000x1000000 pixels by libpng.
+
 Driver capabilities
 -------------------
 


### PR DESCRIPTION
## What does this PR do?
Adds a sentences to the docs about the libpng imposed maximum dimensions of PNG files.

## What are related issues/pull requests?
#4870 