### PR TITLE
Doc: Mention libpng on PNG page, max dimensions of JPEG

### DIFF
--- a/doc/source/drivers/raster/jpeg.rst
+++ b/doc/source/drivers/raster/jpeg.rst
@@ -41,7 +41,9 @@ JPEG_READ_MASK to NO.
 
 The GDAL JPEG Driver is built using the Independent JPEG Group's jpeg
 library. Also note that the GeoTIFF driver supports tiled TIFF with JPEG
-compressed tiles.
+compressed tiles. This can be used to apply JPEG compression to datasets
+that exceed the maximum dimensions of 65,535x65,535 pixels for a single
+JPEG image.
 
 It is also possible to use the JPEG driver with the libjpeg-turbo, a
 version of libjpeg, API and ABI compatible with IJG libjpeg-6b, which

--- a/doc/source/drivers/raster/png.rst
+++ b/doc/source/drivers/raster/png.rst
@@ -14,7 +14,7 @@ as precisions of eight and sixteen bits per sample.
 
 The GDAL PNG Driver is built using the libpng library. Also note that
 the GeoTIFF driver supports tiled TIFF with DEFLATE compressed tiles,
-which is the same compression algorithm that PNG uses.
+which is the same compression algorithm that PNG at its core uses.
 
 PNG files are linearly compressed, so random reading of large PNG files
 can be very inefficient (resulting in many restarts of decompression
@@ -35,9 +35,6 @@ pixel types other than 16bit unsigned will be written as eight bit.
 
 XMP metadata can be extracted from the file,
 and will be stored as XML raw content in the xml:XMP metadata domain.
-
-The maximum dimension of a PNG file that can be created is set to
-1000000x1000000 pixels by libpng.
 
 Driver capabilities
 -------------------

--- a/doc/source/drivers/raster/png.rst
+++ b/doc/source/drivers/raster/png.rst
@@ -12,9 +12,14 @@ GDAL includes support for reading, and creating .png files. Greyscale,
 pseudo-colored, Paletted, RGB and RGBA PNG files are supported as well
 as precisions of eight and sixteen bits per sample.
 
+The GDAL PNG Driver is built using the libpng library. Also note that
+the GeoTIFF driver supports tiled TIFF with DEFLATE compressed tiles,
+which is the same compression algorithm that PNG uses.
+
 PNG files are linearly compressed, so random reading of large PNG files
 can be very inefficient (resulting in many restarts of decompression
-from the start of the file).
+from the start of the file). The maximum dimension of a PNG file that
+can be created by GDAL is set to 1,000,000x1,000,000 pixels by libpng.
 
 Text chunks are translated into metadata, typically with multiple lines
 per item. :ref:`raster.wld` with the extensions of .pgw, .pngw or


### PR DESCRIPTION
## What does this PR do?
Further improve documentation about maximum dimensions of PNG and JPEG files. Mention libpng being used by the PNG driver similarly to what the JPEG page does.

Sorry could have thought of that in the earlier PR already.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/issues/4870

Thanks to @jratike80 for their input!