### PR TITLE
netCDF: add a IGNORE_XY_AXIS_NAME_CHECKS=YES open option (refs qgis/QGIS#47158)

### DIFF
--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -274,6 +274,10 @@ The following open options are available:
    nodata pixel values outside of the validity range indicated by
    valid_min, valid_max or valid_range attributes. Default is YES.
 
+-  **IGNORE_XY_AXIS_NAME_CHECKS**\ =YES/NO: (GDAL >= 3.4.2) Whether X/Y dimensions
+   should be always considered as geospatial axis, even if the lack
+   conventional attributes confirming it. Default is NO.
+
 -  **VARIABLES_AS_BANDS**\ =YES/NO: (GDAL >= 3.5) If set to YES, and if the
    netCDF file only contains 2D variables of the same type and indexed by the
    same dimensions, then they should be reported as multiple bands of a same dataset.
@@ -500,9 +504,9 @@ Configuration Options
    represent the latitude and longitude only by their attributes (STRICT)
    or also by guessing the name (YES), default is YES.
 
--  **GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS=[YES/NO]** : When a dimension
-   has been identified as latitude or longitude by its attributes, check
-   if its name also matches the convention, default is NO.
+-  **GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS=[YES/NO]** : Whether X/Y dimensions
+   should be always considered as geospatial axis, even if the lack
+   conventional attributes confirming it. Default is NO.
 
 VSI Virtual File System API support
 -----------------------------------

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -3574,7 +3574,9 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
         // logic. This should handle for example NASA Ocean Color L2 products.
 
         const bool bIgnoreXYAxisNameChecks =
-            CPLTestBool(CPLGetConfigOption("GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS", "NO")) ||
+            CPLTestBool(
+                CSLFetchNameValueDef(papszOpenOptions, "IGNORE_XY_AXIS_NAME_CHECKS",
+                    CPLGetConfigOption("GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS", "NO"))) ||
             // Dataset from https://github.com/OSGeo/gdal/issues/4075 has a res and transform attributes
             (FetchAttr(nGroupId, nVarId, "res") != nullptr &&
              FetchAttr(nGroupId, nVarId, "transform") != nullptr);
@@ -9815,6 +9817,10 @@ void GDALRegister_netCDF()
 "   <Option name='HONOUR_VALID_RANGE' type='boolean' scope='raster' "
     "description='Whether to set to nodata pixel values outside of the "
     "validity range' default='YES'/>"
+"   <Option name='IGNORE_XY_AXIS_NAME_CHECKS' type='boolean' scope='raster' "
+    "description='Whether X/Y dimensions should be always considered as "
+    "geospatial axis, even if the lack conventional attributes confirming it.'"
+    " default='NO'/>"
 "   <Option name='VARIABLES_AS_BANDS' type='boolean' scope='raster' "
     "description='Whether 2D variables that share the same indexing dimensions "
     "should be exposed as several bands of a same dataset instead of several "


### PR DESCRIPTION
Perhaps more convenient for usage in GUI like QGIS than the existing
GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS environment variable
