### PR TITLE
Warped VRT opening: do not open the source dataset with GDAL_OF_SHARED

### DIFF
--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -1954,7 +1954,7 @@ GDALWarpOptions * CPL_STDCALL GDALDeserializeWarpOptions( CPLXMLNode *psTree )
 
         char** papszOpenOptions = GDALDeserializeOpenOptionsFromXML(psTree);
         psWO->hSrcDS = GDALOpenEx(
-            pszValue, GDAL_OF_SHARED | GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR,
+            pszValue, GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR,
             nullptr,
             papszOpenOptions, nullptr );
         CSLDestroy(papszOpenOptions);


### PR DESCRIPTION
This makes it easier to possible to open multiple times the same warped
VRT and then distribute each warped VRT handle to different threads.
