### PR TITLE
gdal_rasterize: fix single/double quotes for '-where' parameter in docs

### DIFF
--- a/doc/source/programs/gdal_rasterize.rst
+++ b/doc/source/programs/gdal_rasterize.rst
@@ -216,7 +216,7 @@ file, pulling the top elevation from the ROOF_H attribute.
 
 ::
 
-    gdal_rasterize -a ROOF_H -where 'class="A"' -l footprints footprints.shp city_dem.tif
+    gdal_rasterize -a ROOF_H -where "class='A'" -l footprints footprints.shp city_dem.tif
 
 The following would burn all polygons from footprint.shp into a new 1000x1000
 rgb TIFF as the color red.  Note that :option:`-b` is not used; the order of the :option:`-burn`


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes single/double quotes for '-where' parameter in [gdal_rasterize docs](https://gdal.org/programs/gdal_rasterize.html).

On Windows (OSGeo4W), the example command `gdal_rasterize -a ROOF_H -where 'class="A"' -l footprints footprints.shp city_dem.tif` doesn't work, while `gdal_rasterize -a ROOF_H -where "class='A'" -l footprints footprints.shp city_dem.tif` does work.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
