### PR TITLE
Build with CMake 3.10

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -22,6 +22,12 @@ jobs:
     steps:
     - name: Checkout GDAL
       uses: actions/checkout@v2
+    - name: Install CMake 3.10.2
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        wget https://github.com/Kitware/CMake/releases/download/v3.10.2/cmake-3.10.2-Linux-x86_64.tar.gz
+        tar xzf cmake-3.10.2-Linux-x86_64.tar.gz
+        echo "$GITHUB_WORKSPACE/cmake-3.10.2-Linux-x86_64/bin" >> $GITHUB_PATH
     - run: |
         cmake --version
     - name: Install dependency
@@ -60,18 +66,18 @@ jobs:
         cmake  ${CMAKE_OPTIONS} -Werror=dev -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} -DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror -DGDAL_USE_PUBLICDECOMPWT:BOOL=ON -DPUBLICDECOMPWT_URL=https://github.com/rouault/PublicDecompWT .. -DWERROR_DEV_FLAG="-Werror=dev"
     - name: Build
       run: |
-        cmake --build $GITHUB_WORKSPACE/superbuild/build -j $(nproc)
+        cmake --build $GITHUB_WORKSPACE/superbuild/build -- -j$(nproc)
       env:
         GIT_LFS_SKIP_SMUDGE: 1 # for PublicDecompWT github repository clone
     - name: test (with command targets)
       run: |
-        cmake --build $GITHUB_WORKSPACE/superbuild/build --target quicktest -j $(nproc)
+        cmake --build $GITHUB_WORKSPACE/superbuild/build --target quicktest -- -j$(nproc)
     - name: test (with ctest)
       run: |
         ctest --test-dir $GITHUB_WORKSPACE/superbuild/build -V
     - name: install
       run: |
-        cmake --build $GITHUB_WORKSPACE/superbuild/build --target install -j $(nproc)
+        cmake --build $GITHUB_WORKSPACE/superbuild/build --target install -- -j$(nproc)
         export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install-gdal/lib
         $GITHUB_WORKSPACE/install-gdal/bin/gdalinfo --version
         PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3/dist-packages python3 -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
@@ -80,7 +86,7 @@ jobs:
         cd $GITHUB_WORKSPACE/superbuild/build
         rm -rf swig/csharp
         cmake  ${CMAKE_OPTIONS} -DCSHARP_MONO=ON -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} -DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror ..
-        cmake --build $GITHUB_WORKSPACE/superbuild/build --target install -j $(nproc)
+        cmake --build $GITHUB_WORKSPACE/superbuild/build --target install -- -j$(nproc)
         ctest --test-dir $GITHUB_WORKSPACE/superbuild/build -V -R "^csharp.*"
     - name: Standalone Python bindings build
       run: |


### PR DESCRIPTION
## What does this PR do?

At least one CI configuration must cover the minimum supported version of CMake. This PR make the GH Actions Ubuntu 20.04 cmake build use version 3.10.2

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed