### PR TITLE
ESRIC: Fix bundle file name

### DIFF
--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -363,7 +363,7 @@ CPLErr ECBand::IReadBlock(int nBlockXOff, int nBlockYOff, void* pData) {
     int lxx = static_cast<int>(parent->resolutions.size() - lvl - 1);
     int bx, by;
     bx = (nBlockXOff / BSZ) * BSZ;
-    by = (nBlockXOff / BSZ) * BSZ;
+    by = (nBlockYOff / BSZ) * BSZ;
     CPLString fname;
     fname = CPLString().Printf("%s/L%02d/R%04xC%04x.bundle", parent->dname.c_str(), lxx, by, bx);
     Bundle& bundle = parent->GetBundle(fname);


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fix a file naming bug in the Esri bundled cache driver. The bug did not affect the lower resolution levels, where a single file is present.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
