### PR TITLE
VSICurl: Print response code for failed range requests

### DIFF
--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -2118,7 +2118,7 @@ int VSICurlHandle::ReadMultiRange( int const nRanges, void ** const ppData,
                     asWriteFuncHeaderData[iReq].nEndOffset);
 
             CPLError(CE_Failure, CPLE_AppDefined,
-                     "Request for %s failed", rangeStr);
+                     "Request for %s failed with response_code=%ld", rangeStr, response_code);
             nRet = -1;
         }
         else if( nRet == 0 )


### PR DESCRIPTION
## What does this PR do?
Improves the error message when a VSI request fails. This is to simplify debugging such issues as knowing the response code can help understand what's the underlying cause.

Example output with the fix:

```
$ gdal_translate -srcwin 10 10 2000 2000 /vsigs/foobar/raster.tif out.tif
Input file size is 170239, 79702
ERROR 1: Request for 1859354131-1859361062 failed with response_code=42
ERROR 1: Request for 1861843881-1861850812 failed with response_code=42
ERROR 1: Request for 1865380401-1865387332 failed with response_code=42
ERROR 1: Request for 1869606905-1869613836 failed with response_code=42
```
