### PR TITLE
GTiff: remove limitation to 32,000 bytes when writing the GDAL metadata tag (fixes #4116)

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -1257,55 +1257,24 @@ def test_tiff_write_34():
     gdaltest.tiff_drv.Delete('tmp/tw_34.tif')
 
 ###############################################################################
-# Test fallback from internal storage of Geotiff metadata to PAM storage
-# when metadata is too big to fit into the GDALGeotiff tag
+# Test big metadata (that was used to consider too big to fit into the GDALGeotiff tag
+# before GDAL 3.4.2)
 
 
 def test_tiff_write_35():
 
-    # I've no idea why this works, and why this rolled in a
-    # loop doesn't work... Python gurus please fix that !
-    big_string = 'a'
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-    big_string = big_string + big_string
-
+    big_string = 'a' * 12345678
     ds = gdaltest.tiff_drv.Create('tmp/tw_35.tif', 1, 1, gdal.GDT_Byte)
 
     md = {}
     md['test'] = big_string
     ds.SetMetadata(md)
-
-    md = ds.GetMetadata()
-
-    gdal.PushErrorHandler('CPLQuietErrorHandler')
     ds = None
-    gdal.PopErrorHandler()
 
-    try:
-        os.stat('tmp/tw_35.tif.aux.xml')
-    except OSError:
-        pytest.fail('No .aux.xml file.')
+    assert not os.path.exists('tmp/tw_35.tif.aux.xml')
 
-    gdal.PushErrorHandler('CPLQuietErrorHandler')
     ds = gdal.Open('tmp/tw_35.tif')
-    gdal.PopErrorHandler()
-
-    md = ds.GetMetadata()
-    assert 'test' in md and len(md['test']) == 32768, 'Did not get expected metadata.'
-
+    assert ds.GetMetadataItem('test') == big_string
     ds = None
 
     gdaltest.tiff_drv.Delete('tmp/tw_35.tif')

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -12240,37 +12240,7 @@ bool GTiffDataset::WriteMetadata( GDALDataset *poSrcDS, TIFF *l_hTIFF,
         if( eProfile == GTiffProfile::GDALGEOTIFF )
         {
             char *pszXML_MD = CPLSerializeXMLTree( psRoot );
-            if( strlen(pszXML_MD) > 32000 )
-            {
-                if( bSrcIsGeoTIFF )
-                {
-                    if( cpl::down_cast<GTiffDataset *>(
-                           poSrcDS)->GetPamFlags() & GPF_DISABLED )
-                    {
-                        ReportError(
-                            pszTIFFFilename, CE_Warning, CPLE_AppDefined,
-                            "Metadata exceeding 32000 bytes cannot be written "
-                            "into GeoTIFF." );
-                    }
-                    else
-                    {
-                        cpl::down_cast<GTiffDataset *>(poSrcDS)->
-                            PushMetadataToPam();
-                        ReportError(
-                            pszTIFFFilename, CE_Warning, CPLE_AppDefined,
-                            "Metadata exceeding 32000 bytes cannot be written "
-                            "into GeoTIFF. Transferred to PAM instead." );
-                    }
-                }
-                else
-                {
-                    bRet = false;
-                }
-            }
-            else
-            {
-                TIFFSetField( l_hTIFF, TIFFTAG_GDAL_METADATA, pszXML_MD );
-            }
+            TIFFSetField( l_hTIFF, TIFFTAG_GDAL_METADATA, pszXML_MD );
             CPLFree( pszXML_MD );
         }
         else


### PR DESCRIPTION
This limitation came from the initial revision of metadata writing, in e86e2db8d5ddd5d716384f5dd49ab2b435e3879b,
20 years ago. There's no limitation in the TIFF spec nor in libtiff
itself, to text tag data larger than 32 KB, so just remove it.
