### PR TITLE
CMake: do not generate gdal.pc and gdal-config on MSVC builds

### DIFF
--- a/gdal.cmake
+++ b/gdal.cmake
@@ -684,25 +684,27 @@ if (NOT GDAL_ENABLE_MACOSX_FRAMEWORK)
                  ${CMAKE_CURRENT_BINARY_DIR}/GDALConfig.cmake @ONLY)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/GDALConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/gdal/)
 
-  # Generate gdal-config utility command and pkg-config module gdal.pc
-  include(GdalGenerateConfig)
-  gdal_generate_config(
-    TARGET
-    "${GDAL_LIB_TARGET_NAME}"
-    GLOBAL_PROPERTY
-    "gdal_private_link_libraries"
-    GDAL_CONFIG
-    "${PROJECT_BINARY_DIR}/apps/gdal-config"
-    PKG_CONFIG
-    "${CMAKE_CURRENT_BINARY_DIR}/gdal.pc")
-  install(
-    PROGRAMS ${PROJECT_BINARY_DIR}/apps/gdal-config
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT applications)
-  install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/gdal.pc
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-    COMPONENT libraries)
+  if (NOT MSVC)
+      # Generate gdal-config utility command and pkg-config module gdal.pc
+      include(GdalGenerateConfig)
+      gdal_generate_config(
+        TARGET
+        "${GDAL_LIB_TARGET_NAME}"
+        GLOBAL_PROPERTY
+        "gdal_private_link_libraries"
+        GDAL_CONFIG
+        "${PROJECT_BINARY_DIR}/apps/gdal-config"
+        PKG_CONFIG
+        "${CMAKE_CURRENT_BINARY_DIR}/gdal.pc")
+      install(
+        PROGRAMS ${PROJECT_BINARY_DIR}/apps/gdal-config
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT applications)
+      install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/gdal.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+        COMPONENT libraries)
+  endif()
 endif ()
 
 configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/uninstall.cmake.in ${PROJECT_BINARY_DIR}/cmake_uninstall.cmake @ONLY)


### PR DESCRIPTION
With CMake 3.21.3 on a Windows MSVC Conda-based build, I get the
following warnings:
```
CMake Warning at cmake/helpers/GdalGenerateConfig.cmake:47 (message):
  Dropping unsupported generator expression: '$<PLATFORM_ID:Windows>'
Call Stack (most recent call first):
  cmake/helpers/GdalGenerateConfig.cmake:27 (gdal_evaluate_link_genex)
  cmake/helpers/GdalGenerateConfig.cmake:7 (gdal_resolve_link_genex)
  cmake/helpers/GdalGenerateConfig.cmake:119 (gdal_flatten_link_libraries)
  cmake/helpers/GdalGenerateConfig.cmake:193 (gdal_get_lflags)
  gdal.cmake:689 (gdal_generate_config)
  CMakeLists.txt:206 (include)

CMake Warning at cmake/helpers/GdalGenerateConfig.cmake:47 (message):
  Dropping unsupported generator expression: '$<NOT:>'
Call Stack (most recent call first):
  cmake/helpers/GdalGenerateConfig.cmake:27 (gdal_evaluate_link_genex)
  cmake/helpers/GdalGenerateConfig.cmake:7 (gdal_resolve_link_genex)
  cmake/helpers/GdalGenerateConfig.cmake:119 (gdal_flatten_link_libraries)
  cmake/helpers/GdalGenerateConfig.cmake:193 (gdal_get_lflags)
  gdal.cmake:689 (gdal_generate_config)
  CMakeLists.txt:206 (include)

CMake Warning at cmake/helpers/GdalGenerateConfig.cmake:47 (message):
  Dropping unsupported generator expression: '$<:>'
Call Stack (most recent call first):
  cmake/helpers/GdalGenerateConfig.cmake:27 (gdal_evaluate_link_genex)
  cmake/helpers/GdalGenerateConfig.cmake:7 (gdal_resolve_link_genex)
  cmake/helpers/GdalGenerateConfig.cmake:119 (gdal_flatten_link_libraries)
  cmake/helpers/GdalGenerateConfig.cmake:193 (gdal_get_lflags)
  gdal.cmake:689 (gdal_generate_config)
  CMakeLists.txt:206 (include)
```

and the resulting gdal.pc is not super helpful:
```
CONFIG_VERSION=3.5.0dev
CONFIG_INST_PREFIX=C:/Program Files/gdal
CONFIG_INST_LIBS=-LIBPATH:C:/Program Files/gdal/lib gdal
CONFIG_INST_CFLAGS=-IC:/Program Files/gdal/include
CONFIG_INST_DATA=C:/Program Files/gdal/share/gdal
prefix=${CONFIG_INST_PREFIX}
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${exec_prefix}/include
datadir=${CONFIG_INST_DATA}

Name: libgdal
Description: Geospatial Data Abstraction Library
Version: ${CONFIG_VERSION}
Libs: ${CONFIG_INST_LIBS}
Libs.private: -LIBPATH:C:/dev/miniconda3/envs/myenv/Library/bin -LIBPATH:C:/dev/miniconda3/envs/myenv/Library/lib iconv charset -LIBPATH:C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/x64 libssl libcrypto crypt32 liblzma libdeflate liblz4 wbemuuid armadillo lapack blis -fortranlibs qhull_r geotiff tiff ws2_32 poppler libpng netcdf blosc cfitsio hdf5 libwebp hdf mfhdf xdr z openjp2 jasper jpeg tiledb IlmImf IlmImfUtil Half Iex kmlbase kmldom kmlengine pcre2-8 spatialite_i sqlite3 libcurl xerces-c_3 mysqlclient zstd zlib libpq -LIBPATH:C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/170/SDK/Lib/x64 msodbcsql17 odbccp32 C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/x64/WS2_32.Lib legacy_stdio_definitions.lib odbccp32.lib freexl_i libexpat xml2 geos_c psapi proj_8_1 json-c
Cflags: ${CONFIG_INST_CFLAGS}
```

So let's drop its generation for MSVC build.

I also get the same CMake warnings on a msys-mingw64 build with cmake
3.22.1 but gdal.pc is correct.

CC @dg0yt 