### PR TITLE
CMake: fix handling of geotiff-config.cmake

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -33,6 +33,15 @@ function (gdal_check_target_is_valid target res_var)
         return()
       endif()
     endforeach()
+  elseif("${target}" STREQUAL "geotiff_library" AND DEFINED GeoTIFF_INCLUDE_DIRS)
+    # geotiff-config.cmake of GeoTIFF 1.7.0 doesn't define a INTERFACE_INCLUDE_DIRECTORIES
+    # property, but a GeoTIFF_INCLUDE_DIRS variable.
+    set_target_properties(${target} PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${GeoTIFF_INCLUDE_DIRS})
+  else()
+     message(WARNING "Target ${target} has no INTERFACE_INCLUDE_DIRECTORIES property. Ignoring that target.")
+     set(${res_var} FALSE PARENT_SCOPE)
+     return()
   endif()
   set(${res_var} TRUE PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Windows Conda builds with the MrSID drivers failed because it couldn't
find the geotiff headers. Other drivers need it but must include the
Conda include directories because of other packages, hence it was
unnoticed.

geotiff-config.cmake doesn't define an explicit CMake target but only
CMake variables.

CC @dg0yt 