### PR TITLE
COG driver: output exactly square pixels when using -co TILING_SCHEME…

### DIFF
--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -177,6 +177,9 @@ int GDALTransformLonLatToDestApproxTransformer(void* hTransformArg,
                                                     double* pdfX,
                                                     double* pdfY);
 
+bool GDALTransformIsTranslationOnPixelBoundaries(GDALTransformerFunc pfnTransformer,
+                                                 void                *pTransformerArg);
+
 typedef struct {
     GDALTransformerInfo sTI;
 

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -4584,3 +4584,46 @@ void GDALGetTransformerDstGeoTransform( void *pTransformArg,
                 sizeof(double) * 6 );
     }
 }
+
+/************************************************************************/
+/*            GDALTransformIsTranslationOnPixelBoundaries()             */
+/************************************************************************/
+
+bool GDALTransformIsTranslationOnPixelBoundaries(
+                                GDALTransformerFunc pfnTransformer,
+                                void                *pTransformerArg)
+{
+    if( pfnTransformer == GDALApproxTransform )
+    {
+        const auto* pApproxInfo = static_cast<const ApproxTransformInfo*>(pTransformerArg);
+        pfnTransformer = pApproxInfo->pfnBaseTransformer;
+        pTransformerArg = pApproxInfo->pBaseCBData;
+    }
+    if( pfnTransformer == GDALGenImgProjTransform )
+    {
+        const auto* pGenImgpProjInfo = static_cast<GDALGenImgProjTransformInfo*>(pTransformerArg);
+        const auto IsCloseToInteger = [](double dfVal) {
+            return std::fabs(dfVal - std::round(dfVal)) <= 1e-6;
+        };
+        return pGenImgpProjInfo->pSrcTransformArg == nullptr &&
+               pGenImgpProjInfo->pDstTransformer == nullptr &&
+               pGenImgpProjInfo->pReproject == nullptr &&
+               pGenImgpProjInfo->adfSrcGeoTransform[1] == pGenImgpProjInfo->adfDstGeoTransform[1] &&
+               pGenImgpProjInfo->adfSrcGeoTransform[5] == pGenImgpProjInfo->adfDstGeoTransform[5] &&
+               pGenImgpProjInfo->adfSrcGeoTransform[2] == pGenImgpProjInfo->adfDstGeoTransform[2] &&
+               pGenImgpProjInfo->adfSrcGeoTransform[4] == pGenImgpProjInfo->adfDstGeoTransform[4] &&
+               // Check that the georeferenced origin of the destination geotransform is close
+               // to be an integer value when transformed to source image coordinates
+               IsCloseToInteger(pGenImgpProjInfo->adfSrcInvGeoTransform[0] +
+                        pGenImgpProjInfo->adfDstGeoTransform[0] *
+                        pGenImgpProjInfo->adfSrcInvGeoTransform[1]  +
+                        pGenImgpProjInfo->adfDstGeoTransform[3] *
+                        pGenImgpProjInfo->adfSrcInvGeoTransform[2]) &&
+               IsCloseToInteger(pGenImgpProjInfo->adfSrcInvGeoTransform[3] +
+                        pGenImgpProjInfo->adfDstGeoTransform[0] *
+                        pGenImgpProjInfo->adfSrcInvGeoTransform[4]  +
+                        pGenImgpProjInfo->adfDstGeoTransform[3] *
+                        pGenImgpProjInfo->adfSrcInvGeoTransform[5]);
+    }
+    return false;
+}

--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -502,6 +502,8 @@ private:
     // if ComputeSourceWindow() must use a grid based sampling.
     std::vector<std::pair<double, double>> aDstXYSpecialPoints{};
 
+    bool m_bIsTranslationOnPixelBoundaries = false;
+
     void            WipeChunkList();
     CPLErr          CollectChunkListInternal( int nDstXOff, int nDstYOff,
                                       int nDstXSize, int nDstYSize );

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -2923,6 +2923,21 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
         return CE_None;
     }
 
+    // For scenarios where warping is used as a "decoration", try to clamp
+    // source pixel coordinates to integer when very close.
+    const auto roundIfCloseEnough = [](double dfVal)
+    {
+        const double dfRounded = std::round(dfVal);
+        if( std::fabs(dfRounded - dfVal) < 1e-6 )
+            return dfRounded;
+        return dfVal;
+    };
+
+    dfMinXOut = roundIfCloseEnough(dfMinXOut);
+    dfMinYOut = roundIfCloseEnough(dfMinYOut);
+    dfMaxXOut = roundIfCloseEnough(dfMaxXOut);
+    dfMaxYOut = roundIfCloseEnough(dfMaxYOut);
+
 /* -------------------------------------------------------------------- */
 /*      How much of a window around our source pixel might we need      */
 /*      to collect data from based on the resampling kernel?  Even      */
@@ -2970,7 +2985,7 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
 #if DEBUG_VERBOSE
     CPLDebug(
         "WARP",
-        "dst=(%d,%d,%d,%d) raw src=(minx=%.8g,miny=%.8g,maxx=%.8g,maxy=%.8g)",
+        "dst=(%d,%d,%d,%d) raw src=(minx=%.18g,miny=%.18g,maxx=%.18g,maxy=%.18g)",
         nDstXOff, nDstYOff, nDstXSize, nDstYSize,
         dfMinXOut, dfMinYOut, dfMaxXOut, dfMaxYOut);
 #endif

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -1277,6 +1277,29 @@ GDALDatasetH GDALWarp( const char *pszDest, GDALDatasetH hDstDS,
 }
 
 /************************************************************************/
+/*                    UseTEAndTSAndTRConsistently()                     */
+/************************************************************************/
+
+static bool UseTEAndTSAndTRConsistently(const GDALWarpAppOptions *psOptions)
+{
+    // We normally don't allow -te, -ts and -tr together, unless they are all
+    // consistent. The interest of this is to use the -tr values to produce
+    // exact pixel size, rather than infering it from -te and -ts
+
+    // Constant and logic to be kept in sync with cogdriver.cpp
+    constexpr double RELATIVE_ERROR_RES_SHARED_BY_COG_AND_GDALWARP = 1e-8;
+    return psOptions->nForcePixels != 0 &&
+            psOptions->nForceLines != 0 &&
+            psOptions->dfXRes != 0 &&
+            psOptions->dfYRes != 0 &&
+            !(psOptions->dfMinX == 0.0 && psOptions->dfMinY == 0.0 && psOptions->dfMaxX == 0.0 && psOptions->dfMaxY == 0.0) &&
+            fabs((psOptions->dfMaxX - psOptions->dfMinX) / psOptions->dfXRes - psOptions->nForcePixels) <=
+                 RELATIVE_ERROR_RES_SHARED_BY_COG_AND_GDALWARP &&
+            fabs((psOptions->dfMaxY - psOptions->dfMinY) / psOptions->dfYRes - psOptions->nForceLines) <=
+                 RELATIVE_ERROR_RES_SHARED_BY_COG_AND_GDALWARP;
+}
+
+/************************************************************************/
 /*                            CheckOptions()                            */
 /************************************************************************/
 
@@ -1326,7 +1349,8 @@ static bool CheckOptions(const char *pszDest,
 /* -------------------------------------------------------------------- */
 
     if ((psOptions->nForcePixels != 0 || psOptions->nForceLines != 0) &&
-        (psOptions->dfXRes != 0 && psOptions->dfYRes != 0))
+        (psOptions->dfXRes != 0 && psOptions->dfYRes != 0) &&
+        !UseTEAndTSAndTRConsistently(psOptions) )
     {
         CPLError(CE_Failure, CPLE_IllegalArg, "-tr and -ts options cannot be used at the same time.");
         if(pbUsageError)
@@ -3488,7 +3512,17 @@ GDALWarpCreateOutput( int nSrcCount, GDALDatasetH *pahSrcDS, const char *pszFile
 /* -------------------------------------------------------------------- */
 /*      Did the user override some parameters?                          */
 /* -------------------------------------------------------------------- */
-    if( psOptions->dfXRes != 0.0 && psOptions->dfYRes != 0.0 )
+    if( UseTEAndTSAndTRConsistently(psOptions) )
+    {
+        adfDstGeoTransform[0] = psOptions->dfMinX;
+        adfDstGeoTransform[3] = psOptions->dfMaxY;
+        adfDstGeoTransform[1] = psOptions->dfXRes;
+        adfDstGeoTransform[5] = -psOptions->dfYRes;
+
+        nPixels = psOptions->nForcePixels;
+        nLines = psOptions->nForceLines;
+    }
+    else if( psOptions->dfXRes != 0.0 && psOptions->dfYRes != 0.0 )
     {
         if( psOptions->dfMinX == 0.0 && psOptions->dfMinY == 0.0 && psOptions->dfMaxX == 0.0 && psOptions->dfMaxY == 0.0 )
         {

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1628,12 +1628,14 @@ def test_warp_53(typestr, option, alg_name, expected_cs):
 # Test Alpha on UInt16/Int16
 
 
-def test_warp_54():
+@pytest.mark.parametrize('use_optim', ['YES', 'NO'])
+def test_warp_54(use_optim):
 
     # UInt16
     src_ds = gdal.Translate('', '../gcore/data/stefan_full_rgba.tif',
                                 options='-of MEM -scale 0 255 0 65535 -ot UInt16 -a_ullr -162 150 0 0')
-    dst_ds = gdal.Warp('', src_ds, format='MEM')
+    with gdaltest.config_option('GDAL_WARP_USE_TRANSLATION_OPTIM', use_optim):
+        dst_ds = gdal.Warp('', src_ds, format='MEM')
     for i in range(4):
         expected_cs = src_ds.GetRasterBand(i + 1).Checksum()
         got_cs = dst_ds.GetRasterBand(i + 1).Checksum()
@@ -1642,7 +1644,8 @@ def test_warp_54():
     # Int16
     src_ds = gdal.Translate('', '../gcore/data/stefan_full_rgba.tif',
                                 options='-of MEM -scale 0 255 0 32767 -ot Int16 -a_ullr -162 150 0 0')
-    dst_ds = gdal.Warp('', src_ds, format='MEM')
+    with gdaltest.config_option('GDAL_WARP_USE_TRANSLATION_OPTIM', use_optim):
+        dst_ds = gdal.Warp('', src_ds, format='MEM')
     for i in range(4):
         expected_cs = src_ds.GetRasterBand(i + 1).Checksum()
         got_cs = dst_ds.GetRasterBand(i + 1).Checksum()
@@ -1653,7 +1656,8 @@ def test_warp_54():
                                 options='-of MEM -scale 0 255 0 32767 -ot UInt16 -a_ullr -162 150 0 0')
     for i in range(4):
         src_ds.GetRasterBand(i + 1).SetMetadataItem('NBITS', '15', 'IMAGE_STRUCTURE')
-    dst_ds = gdal.Warp('/vsimem/warp_54.tif', src_ds, options='-co NBITS=15')
+    with gdaltest.config_option('GDAL_WARP_USE_TRANSLATION_OPTIM', use_optim):
+        dst_ds = gdal.Warp('/vsimem/warp_54.tif', src_ds, options='-co NBITS=15')
     for i in range(4):
         expected_cs = src_ds.GetRasterBand(i + 1).Checksum()
         got_cs = dst_ds.GetRasterBand(i + 1).Checksum()
@@ -1679,7 +1683,8 @@ def test_warp_55():
 # same size). This test crops a single pixel out of a 3-by-3 image.
 
 
-def test_warp_56():
+@pytest.mark.parametrize('use_optim', ['YES', 'NO'])
+def test_warp_56(use_optim):
 
     numpy = pytest.importorskip('numpy')
 
@@ -1694,7 +1699,8 @@ def test_warp_56():
     for off in numpy.linspace(0, 2, 21):
         pix_ds.SetGeoTransform([off + 1, 1, 0,
                                 off + 1, 0, 1])
-        gdal.Warp(pix_ds, src_ds, resampleAlg='bilinear')
+        with gdaltest.config_option('GDAL_WARP_USE_TRANSLATION_OPTIM', use_optim):
+            gdal.Warp(pix_ds, src_ds, resampleAlg='bilinear')
 
         exp = 0 if off < 1 else 100 * (off - 1)**2
         warped = pix_ds.GetRasterBand(1).ReadAsArray()[0, 0]

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -389,6 +389,7 @@ def test_cog_small_world_to_web_mercator():
     assert ds.GetRasterBand(1).GetMaskFlags() == gdal.GMF_PER_DATASET
     assert ds.GetRasterBand(1).GetBlockSize() == [256, 256]
     gt = ds.GetGeoTransform()
+    assert gt[1] == -gt[5] # yes, checking for strict equality
     expected_gt = [-20037508.342789248, 156543.033928041, 0.0,
                    20037508.342789248, 0.0, -156543.033928041]
     for i in range(6):
@@ -442,6 +443,7 @@ def test_cog_byte_to_web_mercator():
     assert ds.GetRasterBand(1).GetMaskFlags() == gdal.GMF_ALPHA + gdal.GMF_PER_DATASET
     assert ds.GetRasterBand(1).GetBlockSize() == [256,256]
     gt = ds.GetGeoTransform()
+    assert gt[1] == -gt[5] # yes, checking for strict equality
     expected_gt = [-13149614.849955443, 76.43702828517598, 0.0,
                    4070118.8821290657, 0.0, -76.43702828517598]
     for i in range(6):
@@ -735,6 +737,8 @@ def test_cog_northing_easting_and_non_power_of_two_ratios():
     assert [(b.GetOverview(i).XSize, b.GetOverview(i).YSize) for i in range(b.GetOverviewCount())] == [(512, 512), (256, 256)]
 
     gt = ds.GetGeoTransform()
+    assert gt[1] == -gt[5] # yes, checking for strict equality
+
     res_zoom_level_14 = scale_denom_zoom_level_14 * 0.28e-3 # According to OGC Tile Matrix Set formula
     assert gt == pytest.approx((999872, res_zoom_level_14, 0, 5000320, 0, -res_zoom_level_14), abs=1e-8)
 

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -137,6 +137,7 @@ bool COGGetWarpingCharacteristics(GDALDataset* poSrcDS,
                                   double& dfMinY,
                                   double& dfMaxX,
                                   double& dfMaxY,
+                                  double& dfRes,
                                   std::unique_ptr<gdal::TileMatrixSet>& poTM,
                                   int& nZoomLevel,
                                   int& nAlignedLevels)
@@ -147,8 +148,8 @@ bool COGGetWarpingCharacteristics(GDALDataset* poSrcDS,
     if( EQUAL(osTargetSRS, "") && EQUAL(osTilingScheme, "CUSTOM") )
         return false;
 
-    CPLString osExtent(CSLFetchNameValueDef(papszOptions, "EXTENT", ""));
-    CPLString osRes(CSLFetchNameValueDef(papszOptions, "RES", ""));
+    const CPLString osExtent(CSLFetchNameValueDef(papszOptions, "EXTENT", ""));
+    const CPLString osRes(CSLFetchNameValueDef(papszOptions, "RES", ""));
     if( !EQUAL(osTilingScheme, "CUSTOM") )
     {
         poTM = gdal::TileMatrixSet::parse(osTilingScheme);
@@ -171,6 +172,10 @@ bool COGGetWarpingCharacteristics(GDALDataset* poSrcDS,
             CPLError(CE_Failure, CPLE_NotSupported,
                     "Unsupported tiling scheme: some levels have variable matrix width");
             return false;
+        }
+        if( !osTargetSRS.empty() )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined, "Ignoring TARGET_SRS option");
         }
         osTargetSRS = poTM->crs();
 
@@ -285,10 +290,18 @@ bool COGGetWarpingCharacteristics(GDALDataset* poSrcDS,
     dfMinY = adfExtent[1];
     dfMaxX = adfExtent[2];
     dfMaxY = adfExtent[3];
-    double dfRes = adfGeoTransform[1];
+    dfRes = adfGeoTransform[1];
 
     if( poTM )
     {
+        if( !osExtent.empty() )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined, "Ignoring EXTENT option");
+        }
+        if( !osRes.empty() )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined, "Ignoring RES option");
+        }
         const bool bInvertAxis =
             oTargetSRS.EPSGTreatsAsLatLong() != FALSE ||
             oTargetSRS.EPSGTreatsAsNorthingEasting() != FALSE;
@@ -428,8 +441,6 @@ bool COGGetWarpingCharacteristics(GDALDataset* poSrcDS,
         dfMinY = dfOriY - nBRTileY * dfTileExtent;
         dfMaxX = dfOriX + nBRTileX * dfTileExtent;
         dfMaxY = dfOriY - nTLTileY * dfTileExtent;
-        nXSize = static_cast<int>(std::round((dfMaxX - dfMinX) / dfRes));
-        nYSize = static_cast<int>(std::round((dfMaxY - dfMinY) / dfRes));
     }
     else if( !osExtent.empty() || !osRes.empty() )
     {
@@ -474,12 +485,13 @@ bool COGGetWarpingCharacteristics(GDALDataset* poSrcDS,
     std::unique_ptr<gdal::TileMatrixSet> poTM;
     int nZoomLevel = 0;
     int nAlignedLevels = 0;
+    double dfRes;
     return COGGetWarpingCharacteristics(poSrcDS,
                                         papszOptions,
                                         osResampling,
                                         osTargetSRS,
                                         nXSize, nYSize,
-                                        dfMinX, dfMinY, dfMaxX, dfMaxY,
+                                        dfMinX, dfMinY, dfMaxX, dfMaxY, dfRes,
                                         poTM, nZoomLevel, nAlignedLevels);
 }
 
@@ -524,6 +536,7 @@ static std::unique_ptr<GDALDataset> CreateReprojectedDS(
                                 const double dfMinY,
                                 const double dfMaxX,
                                 const double dfMaxY,
+                                const double dfRes,
                                 GDALProgressFunc pfnProgress,
                                 void * pProgressData,
                                 double& dfCurPixels,
@@ -550,13 +563,30 @@ static std::unique_ptr<GDALDataset> CreateReprojectedDS(
     papszArg = CSLAddString(papszArg, "-t_srs");
     papszArg = CSLAddString(papszArg, osTargetSRS);
     papszArg = CSLAddString(papszArg, "-te");
-    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g,", dfMinX));
-    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g,", dfMinY));
-    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g,", dfMaxX));
-    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g,", dfMaxY));
+    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g", dfMinX));
+    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g", dfMinY));
+    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g", dfMaxX));
+    papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g", dfMaxY));
     papszArg = CSLAddString(papszArg, "-ts");
     papszArg = CSLAddString(papszArg, CPLSPrintf("%d", nXSize));
     papszArg = CSLAddString(papszArg, CPLSPrintf("%d", nYSize));
+
+    // to be kept in sync with gdalwarp_lib.cpp
+    constexpr double RELATIVE_ERROR_RES_SHARED_BY_COG_AND_GDALWARP = 1e-8;
+    if (fabs((dfMaxX - dfMinX) / dfRes - nXSize) <= RELATIVE_ERROR_RES_SHARED_BY_COG_AND_GDALWARP &&
+        fabs((dfMaxY - dfMinY) / dfRes - nYSize) <= RELATIVE_ERROR_RES_SHARED_BY_COG_AND_GDALWARP )
+    {
+        // Try to produce exactly square pixels
+        papszArg = CSLAddString(papszArg, "-tr");
+        papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g", dfRes));
+        papszArg = CSLAddString(papszArg, CPLSPrintf("%.18g", dfRes));
+    }
+    else
+    {
+        CPLDebug("COG", "Cannot pass -tr option to GDALWarp() due to extent, "
+                 "size and resolution not consistent enough");
+    }
+
     int bHasNoData = FALSE;
     poSrcDS->GetRasterBand(1)->GetNoDataValue(&bHasNoData);
     if( !bHasNoData && CPLTestBool(CSLFetchNameValueDef(
@@ -702,12 +732,14 @@ GDALDataset* GDALCOGCreator::Create(const char * pszFilename,
         double dfTargetMinY = 0;
         double dfTargetMaxX = 0;
         double dfTargetMaxY = 0;
+        double dfRes = 0;
         if( !COGGetWarpingCharacteristics(poCurDS, papszOptions,
                                           osTargetResampling,
                                           osTargetSRS,
                                           nTargetXSize, nTargetYSize,
                                           dfTargetMinX, dfTargetMinY,
                                           dfTargetMaxX, dfTargetMaxY,
+                                          dfRes,
                                           poTM, nZoomLevel, nAlignedLevels) )
         {
             return nullptr;
@@ -764,6 +796,7 @@ GDALDataset* GDALCOGCreator::Create(const char * pszFilename,
                                     nTargetXSize, nTargetYSize,
                                     dfTargetMinX, dfTargetMinY,
                                     dfTargetMaxX, dfTargetMaxY,
+                                    dfRes,
                                     pfnProgress, pProgressData,
                                     dfCurPixels, dfTotalPixelsToProcess);
             if( !m_poReprojectedDS )


### PR DESCRIPTION
… (fixes #5343)

and emit warning messages when using RES or EXTENT options in that mode.
