### PR TITLE
MRF: Adjust PNG limits

### DIFF
--- a/frmts/mrf/PNG_band.cpp
+++ b/frmts/mrf/PNG_band.cpp
@@ -237,8 +237,8 @@ CPLErr PNG_Codec::CompressPNG(buf_mgr &dst, buf_mgr &src)
 #endif
 
     // Let the quality control the compression level
-    // Supposedly low numbers work well too while being fast
-    png_set_compression_level(pngp, img.quality / 10);
+    // Start at level 1, level 0 means uncompressed
+    png_set_compression_level(pngp, std::min(1, img.quality / 10));
 
     // Custom strategy for zlib, set using the band option Z_STRATEGY
     if (deflate_flags & ZFLAG_SMASK)
@@ -359,7 +359,8 @@ PNG_Band::PNG_Band( MRFDataset *pDS, const ILImage &image,
         return;
     }
     // PNGs can be larger than the source, especially for small page size
-    poDS->SetPBufferSize( image.pageSizeBytes + 100);
+    // If PPNG is used, the palette can take up to 2100 bytes
+    poDS->SetPBufferSize(static_cast<unsigned int>(1.1 * image.pageSizeBytes + 4000));
 }
 
 NAMESPACE_MRF_END

--- a/frmts/mrf/PNG_band.cpp
+++ b/frmts/mrf/PNG_band.cpp
@@ -241,7 +241,7 @@ CPLErr PNG_Codec::CompressPNG(buf_mgr &dst, buf_mgr &src)
     int zlvl = img.quality / 10;
     if (0 == zlvl)
         zlvl = 1;
-        png_set_compression_level(pngp, zlvl);
+    png_set_compression_level(pngp, zlvl);
 
     // Custom strategy for zlib, set using the band option Z_STRATEGY
     if (deflate_flags & ZFLAG_SMASK)

--- a/frmts/mrf/PNG_band.cpp
+++ b/frmts/mrf/PNG_band.cpp
@@ -238,7 +238,10 @@ CPLErr PNG_Codec::CompressPNG(buf_mgr &dst, buf_mgr &src)
 
     // Let the quality control the compression level
     // Start at level 1, level 0 means uncompressed
-    png_set_compression_level(pngp, std::min(1, img.quality / 10));
+    int zlvl = img.quality / 10;
+    if (0 == zlvl)
+        zlvl = 1;
+        png_set_compression_level(pngp, zlvl);
 
     // Custom strategy for zlib, set using the band option Z_STRATEGY
     if (deflate_flags & ZFLAG_SMASK)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

PNGs can be considerable larger than the input, especially if zlib level zero is used, which means store uncompressed.
This change makes the output buffer larger and enforces a minimum zlib level of 1.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
