### PR TITLE
CI: Revise mingw cmake build

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -134,6 +134,7 @@ jobs:
     runs-on: windows-2022
     env:
       generator: MinGW Makefiles
+      cache-name: cmake-mingw64
     defaults:
       run:
         shell: msys2 {0}
@@ -157,6 +158,22 @@ jobs:
           git config --global core.autocrlf false
       - name: Checkout GDAL
         uses: actions/checkout@v2
+      - name: Setup cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ github.workspace }}\.ccache
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.base_ref }}${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ github.base_ref }}
+            ${{ runner.os }}-${{ env.cache-name }}
+      - name: Configure ccache
+        run: |
+          echo CCACHE_BASEDIR=$PWD >> ${GITHUB_ENV}
+          echo CCACHE_DIR=$PWD/.ccache >> ${GITHUB_ENV}
+          echo CCACHE_MAXSIZE=250M >> ${GITHUB_ENV}
+          ccache -z
+        working-directory: ${{ github.workspace }}
       - name: populate JAVA_HOME
         run: |
           echo "JAVA_HOME=$JAVA_HOME_11_X64" >> ${GITHUB_ENV}
@@ -197,6 +214,8 @@ jobs:
       #  working-directory: ${{ github.workspace }}
       #  env:
       #    PROJ_LIB: "C:\\tools\\msys64\\mingw64\\share\\proj"
+      - name: ccache statistics
+        run: ccache -s
 
   build-windows-conda:
     runs-on: windows-2022

--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -134,7 +134,22 @@ jobs:
     runs-on: windows-2022
     env:
       generator: MinGW Makefiles
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
+      - name: Install development packages
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: |
+            base-devel git mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache
+            mingw-w64-x86_64-crypto++ mingw-w64-x86_64-pcre mingw-w64-x86_64-xerces-c mingw-w64-x86_64-zstd
+            mingw-w64-x86_64-geos mingw-w64-x86_64-libspatialite mingw-w64-x86_64-proj
+            mingw-w64-x86_64-cgal mingw-w64-x86_64-libfreexl mingw-w64-x86_64-hdf5 mingw-w64-x86_64-netcdf mingw-w64-x86_64-poppler mingw-w64-x86_64-postgresql
+            mingw-w64-x86_64-libgeotiff mingw-w64-x86_64-jasper mingw-w64-x86_64-libpng mingw-w64-x86_64-libtiff mingw-w64-x86_64-openjpeg
+            mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-numpy mingw-w64-x86_64-python-pytest mingw-w64-x86_64-python-setuptools
       # To avoid git clone to mess with the line endings of GDAL autotest data
       # files that look like text, but should be handled as binary content
       - name: Set git core.autocrlf to false
@@ -143,40 +158,35 @@ jobs:
       - name: Checkout GDAL
         uses: actions/checkout@v2
       - name: populate JAVA_HOME
-        shell: pwsh
         run: |
-            echo "JAVA_HOME=$env:JAVA_HOME_11_X64" >> %GITHUB_ENV%
-      - name: Install MSYS2
-        run: choco install --yes msys2
-      - name: Install development packages
+          echo "JAVA_HOME=$JAVA_HOME_11_X64" >> ${GITHUB_ENV}
+      - name: Install PROJ data
         run: |
-          $script = @'
-          pacman -S --noconfirm base-devel
-          pacman -S --noconfirm mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache
-          pacman -S --noconfirm mingw-w64-x86_64-proj mingw-w64-x86_64-geos mingw-w64-x86_64-hdf5 mingw-w64-x86_64-netcdf mingw-w64-x86_64-openjpeg mingw-w64-x86_64-poppler mingw-w64-x86_64-libtiff mingw-w64-x86_64-libpng mingw-w64-x86_64-xerces-c mingw-w64-x86_64-libfreexl mingw-w64-x86_64-libgeotiff mingw-w64-x86_64-libspatialite mingw-w64-x86_64-libtiff mingw-w64-x86_64-pcre mingw-w64-x86_64-postgresql mingw-w64-x86_64-zstd mingw-w64-x86_64-crypto++ mingw-w64-x86_64-cgal mingw-w64-x86_64-jasper mingw-w64-x86_64-python-numpy mingw-w64-x86_64-python-pytest mingw-w64-x86_64-python-setuptools
-          cd /C/tools/msys64/mingw64/share/proj
+          cd /mingw64/share/proj
           wget http://download.osgeo.org/proj/proj-datumgrid-1.8.tar.gz
           tar xvzf proj-datumgrid-1.8.tar.gz
-          '@
-          & c:\tools\msys64\usr\bin\bash.exe -lc $script
-        env:
-          MSYSTEM: MSYS
       - name: Install python dependencies for autotest
         run: |
-          $script = @'
-          python -m ensurepip --upgrade
-          python -m pip install -U wheel setuptools numpy
-          python -m pip install pytest pytest-env
-          '@
-          & c:\tools\msys64\usr\bin\bash.exe -lc $script
-        env:
-          MSYSTEM: MINGW64
+          python -m pip install pytest-env
       #  libxml2 disabled because currently causes a 'Imported target "LibXml2::LibXml2" includes non-existent path "/mingw64/include/libxml2" in its INTERFACE_INCLUDE_DIRECTORIES'
       # Disable mySQL since C:/mysql/lib/mysqlclient.lib (unrelated to msys) is found, which causes linking issues
       # Disable Python bindings because of 'ValueError: filename D:/a/gdal/gdal/swig/python/osgeo/__init__.py does not start with the input_base_dir D:/a/gdal/gdal/swig/python/osgeo/\' when running lib2to3
       # Set explicitly CMAKE_C|CXX_COMPILER otherwise C:/ProgramData/chocolatey/bin/gcc.exe would be used
       - name: Configure
-        run: cmake -DCMAKE_BUILD_TYPE=release -G "${env:generator}" -Werror=dev "-DCMAKE_C_COMPILER=c:/tools/msys64/mingw64/bin/gcc.exe" "-DCMAKE_CXX_COMPILER=c:/tools/msys64/mingw64/bin/g++.exe" "-DCMAKE_C_COMPILER_LAUNCHER=c:\tools\msys64\mingw64\bin\ccache.exe" "-DCMAKE_CXX_COMPILER_LAUNCHER=c:\tools\msys64\mingw64\bin\ccache.exe" "-DCMAKE_PREFIX_PATH=C:\tools\msys64\mingw64" "-DCMAKE_UNITY_BUILD=${env:CMAKE_UNITY_BUILD}" -S . -B "build" -DLIBXML2_INCLUDE_DIR=C:/tools/msys64/mingw64/include -DGDAL_USE_LIBXML2:BOOL=OFF -DGDAL_USE_MYSQL:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=OFF -DBUILD_CSHARP_BINDINGS=ON -DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror -DWERROR_DEV_FLAG="-Werror=dev"
+        run: |
+          cmake -S . -B build -G "${generator}" -Werror=dev \
+            -DCMAKE_BUILD_TYPE=release \
+            -DCMAKE_C_FLAGS=-Werror \
+            -DCMAKE_CXX_FLAGS=-Werror \
+            -DWERROR_DEV_FLAG=-Werror=dev \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_PREFIX_PATH=/mingw64 \
+            "-DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD}" \
+            -DLIBXML2_INCLUDE_DIR=/mingw64/include -DGDAL_USE_LIBXML2:BOOL=OFF \
+            -DGDAL_USE_MYSQL:BOOL=OFF \
+            -DBUILD_PYTHON_BINDINGS:BOOL=OFF \
+            -DBUILD_CSHARP_BINDINGS=ON
         working-directory: ${{ github.workspace }}
       - name: Build
         run: cmake --build build -j 3

--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -199,6 +199,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_PREFIX_PATH=/mingw64 \
+            -DCMAKE_INSTALL_PREFIX=$PWD/install-gdal \
             "-DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD}" \
             -DLIBXML2_INCLUDE_DIR=/mingw64/include -DGDAL_USE_LIBXML2:BOOL=OFF \
             -DGDAL_USE_MYSQL:BOOL=OFF \
@@ -214,6 +215,12 @@ jobs:
       #  working-directory: ${{ github.workspace }}
       #  env:
       #    PROJ_LIB: "C:\\tools\\msys64\\mingw64\\share\\proj"
+      - name: Install
+        run: cmake --build build --target install -j 3
+        working-directory: ${{ github.workspace }}
+      - name: Test post-install usage (with pkg-config)
+        run: ./autotest/postinstall/test_pkg-config.sh $PWD/install-gdal
+        working-directory: ${{ github.workspace }}
       - name: ccache statistics
         run: ccache -s
 

--- a/autotest/postinstall/test_pkg-config.sh
+++ b/autotest/postinstall/test_pkg-config.sh
@@ -22,13 +22,20 @@ ERRORS=0
 NTESTS=0
 
 UNAME=$(uname)
-case $UNAME in
+case "$UNAME,$2" in
   Darwin*)
     alias ldd="otool -L"
     export DYLD_LIBRARY_PATH=$prefix/lib
     ;;
   Linux*)
     export LD_LIBRARY_PATH=$prefix/lib
+    ;;
+  MINGW*,)
+    alias ldd="sh -c 'objdump -x \$1.exe' --"
+    LDD_SUBSTR="DLL Name: libgdal.dll"
+    export PATH="$prefix/bin:$PATH"
+    ;;
+  *,--static)
     ;;
   *)
     echo "no ldd equivalent found for UNAME=$UNAME"
@@ -39,7 +46,7 @@ check_ldd(){
   printf "Testing expected ldd output ... "
   NTESTS=$(($NTESTS + 1))
   LDD_OUTPUT=$(ldd ./$1 | grep libgdal)
-  LDD_SUBSTR=$LD_LIBRARY_PATH/libgdal.
+  LDD_SUBSTR=${LDD_SUBSTR:-$LD_LIBRARY_PATH/libgdal.}
   case "$LDD_OUTPUT" in
     *$LDD_SUBSTR*)
       echo "passed" ;;


### PR DESCRIPTION
## What does this PR do?

- Uses msys2/setup-msys2@v2 to setup the Mingw64 CMake CI environment, including numpy.
  Mingw + python setup time: 4 min instead of 15 min
- Configures GH Actions cache to actually enable `ccache` effects. 
  Build step with empty cache: 26 min 
  Build step with full cache: 1 min 
  Cache size: 0.03 GB
- Adds post-install test with `pkg-config` for Mingw64.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
