### PR TITLE
HFA: Fix "Pulkovo 1942" datum write to IMG files

### DIFF
--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -3238,6 +3238,8 @@ CPLErr HFADataset::WriteProjection()
             sDatum.datumname = const_cast<char *>("NAD83");
         if( nGCS == 4283 )
             sDatum.datumname = const_cast<char *>("GDA94");
+        if( nGCS == 6284 )
+            sDatum.datumname = const_cast<char *>("Pulkovo 1942");
 
         if( poGeogSRS->GetTOWGS84(sDatum.params) == OGRERR_NONE )
         {

--- a/frmts/hfa/hfaopen.cpp
+++ b/frmts/hfa/hfaopen.cpp
@@ -3964,6 +3964,7 @@ static const char *const apszDatumMap[] = {
     "WGS 84", "WGS_1984",
     "WGS 1972", "WGS_1972",
     "GDA94", "Geocentric_Datum_of_Australia_1994",
+    "Pulkovo 1942", "Pulkovo_1942",
     nullptr, nullptr
 };
 


### PR DESCRIPTION
Default `spheroid.tab` from `Erdas imagine` defines "Pulkovo_1942" datum as "Pulkovo 1942" (without "_" symbol), so we need to translate these names on read/write for correct interaction with `Erdas`.