### PR TITLE
gdal2tiles: move workaround out of wrapper script

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -3232,6 +3232,11 @@ def multi_threaded_tiling(input_file: str, output_folder: str, options: Options,
             self.shutdown()
         pool.join = pool_join.__get__(pool)
     else:
+        # Trick inspired from https://stackoverflow.com/questions/45720153/python-multiprocessing-error-attributeerror-module-main-has-no-attribute
+        # and https://bugs.python.org/issue42949
+        import __main__
+        if not hasattr(__main__, '__spec__'):
+            __main__.__spec__ = None
         from multiprocessing import Pool
         # Make sure that all processes do not consume more than `gdal.GetCacheMax()`
         gdal_cache_max_per_process = max(1024 * 1024, math.floor(gdal_cache_max / nb_processes))

--- a/swig/python/gdal-utils/scripts/gdal2tiles.py
+++ b/swig/python/gdal-utils/scripts/gdal2tiles.py
@@ -9,8 +9,5 @@ from osgeo.gdal import deprecation_warn
 # Running main() must be protected that way due to use of multiprocessing on Windows:
 # https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
 if __name__ == '__main__':
-    # Trick inspired from https://stackoverflow.com/questions/45720153/python-multiprocessing-error-attributeerror-module-main-has-no-attribute
-    # and https://bugs.python.org/issue42949
-    __spec__ = None
     deprecation_warn('gdal2tiles')
     sys.exit(main(sys.argv))


### PR DESCRIPTION
An incompatibility between pdb and multiprocessing using the
'spawn' start method was being worked around by setting
__spec__ = None in the gdal2tiles wrapper script.

Moved workaround into the gdal2tiles module and made more general by
fixing __spec__ regardless of where the __main__ module is defined.