### PR TITLE
Pixelfn metadata

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   test_gdal_aaigrid.cpp
   test_gdal_dted.cpp
   test_gdal_gtiff.cpp
+  test_gdal_pixelfn.cpp
   test_ogr.cpp
   test_ogr_geometry_stealing.cpp
   test_ogr_lgpl.cpp

--- a/autotest/cpp/Makefile
+++ b/autotest/cpp/Makefile
@@ -58,6 +58,7 @@ OBJ = \
     test_gdal_aaigrid.o \
     test_gdal_dted.o \
     test_gdal_gtiff.o \
+    test_gdal_pixelfn.o \
     test_triangulation.o \
     test_ogr.o \
 	  test_ogr_geometry_stealing.o \

--- a/autotest/cpp/data/pixelfn.vrt
+++ b/autotest/cpp/data/pixelfn.vrt
@@ -4,7 +4,7 @@
     <PixelFunctionType>custom</PixelFunctionType>
     <SourceTransferType>Float64</SourceTransferType>
     <SimpleSource>
-      <SourceFilename relativeToVRT="0">data/float32.tif</SourceFilename>
+      <SourceFilename relativeToVRT="1">float32.tif</SourceFilename>
     </SimpleSource>
   </VRTRasterBand>
 </VRTDataset>

--- a/autotest/cpp/data/pixelfn.vrt
+++ b/autotest/cpp/data/pixelfn.vrt
@@ -1,0 +1,10 @@
+<VRTDataset rasterXSize="20" rasterYSize="20">
+  <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
+    <Description>CustomPixelFn</Description>
+    <PixelFunctionType>custom</PixelFunctionType>
+    <SourceTransferType>Float64</SourceTransferType>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/float32.tif</SourceFilename>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/cpp/makefile.vc
+++ b/autotest/cpp/makefile.vc
@@ -51,6 +51,7 @@ OBJ = \
     test_gdal_aaigrid.obj \
     test_gdal_dted.obj \
     test_gdal_gtiff.obj \
+    test_gdal_pixelfn.obj \
     test_triangulation.obj \
     test_ogr.obj \
 	  test_ogr_geometry_stealing.obj \

--- a/autotest/cpp/test_gdal_pixelfn.cpp
+++ b/autotest/cpp/test_gdal_pixelfn.cpp
@@ -106,7 +106,7 @@ CPLErr CustomPixelFuncWithMetadata( void **papoSources, int nSources, void *pDat
     {
         for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
         {
-            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii);
+            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii) * 2;
             GDALCopyWords(
                     &dfPixVal, GDT_Float64, 0,
                     static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
@@ -134,7 +134,7 @@ CPLErr CustomPixelFunc( void **papoSources, int nSources, void *pData,
     {
         for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
         {
-            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii);
+            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii) * 3;
             GDALCopyWords(
                     &dfPixVal, GDT_Float64, 0,
                     static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
@@ -160,7 +160,7 @@ CPLErr CustomPixelFuncNoArgs( void **papoSources, int nSources, void *pData,
     {
         for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
         {
-            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii);
+            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii) * 4;
             GDALCopyWords(
                     &dfPixVal, GDT_Float64, 0,
                     static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
@@ -204,7 +204,7 @@ namespace tut
         float buf[20 * 20];
         CPL_IGNORE_RET_VAL(GDALRasterIO(band, GF_Read, 0, 0, 20, 20, buf, 20, 20, GDT_Float32, 0, 0));
 
-        ensure_equals("Read wrong data", buf[0], 107);
+        ensure_equals("Read wrong data", buf[0], 107 * 2);
 
         GDALClose(ds);
     }
@@ -229,7 +229,7 @@ namespace tut
         CPL_IGNORE_RET_VAL(GDALRasterIO(
           band, GF_Read, 0, 0, 20, 20, buf, 20, 20, GDT_Float32, 0, 0));
 
-        ensure_equals("Read wrong data", buf[0], 107);
+        ensure_equals("Read wrong data", buf[0], 107 * 3);
 
         GDALClose(ds);
     }
@@ -254,7 +254,7 @@ namespace tut
         CPL_IGNORE_RET_VAL(GDALRasterIO(
           band, GF_Read, 0, 0, 20, 20, buf, 20, 20, GDT_Float32, 0, 0));
 
-        ensure_equals("Read wrong data", buf[0], 107);
+        ensure_equals("Read wrong data", buf[0], 107 * 4);
 
         GDALClose(ds);
     }

--- a/autotest/cpp/test_gdal_pixelfn.cpp
+++ b/autotest/cpp/test_gdal_pixelfn.cpp
@@ -1,0 +1,149 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Project:  C++ Test Suite for GDAL/OGR
+// Purpose:  Test constant and builtin arguments for C++ pixel functions
+// Author:   Momtchil Momtchev <momtchil@momtchev.com>
+//
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2022, Momtchil Momtchev <momtchil@momtchev.com>
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_unit_test.h"
+
+#include "cpl_string.h"
+#include "gdal_alg.h"
+#include "gdal_priv.h"
+#include "gdal.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+CPLErr CustomPixelFunc( void **papoSources, int nSources, void *pData,
+                            int nXSize, int nYSize,
+                            GDALDataType eSrcType, GDALDataType eBufType,
+                            int nPixelSpace, int nLineSpace, CSLConstList papszArgs );
+
+template<typename T>
+inline double
+GetSrcVal(const void* pSource, GDALDataType eSrcType, T ii)
+{
+    switch (eSrcType)
+    {
+        case GDT_Unknown:
+            return 0;
+        case GDT_Byte:
+            return static_cast<const GByte*>(pSource)[ii];
+        case GDT_UInt16:
+            return static_cast<const GUInt16*>(pSource)[ii];
+        case GDT_Int16:
+            return static_cast<const GInt16*>(pSource)[ii];
+        case GDT_UInt32:
+            return static_cast<const GUInt32*>(pSource)[ii];
+        case GDT_Int32:
+            return static_cast<const GInt32*>(pSource)[ii];
+        case GDT_Float32:
+            return static_cast<const float*>(pSource)[ii];
+        case GDT_Float64:
+            return static_cast<const double*>(pSource)[ii];
+        case GDT_CInt16:
+            return static_cast<const GInt16*>(pSource)[2 * ii];
+        case GDT_CInt32:
+            return static_cast<const GInt32*>(pSource)[2 * ii];
+        case GDT_CFloat32:
+            return static_cast<const float*>(pSource)[2 * ii];
+        case GDT_CFloat64:
+            return static_cast<const double*>(pSource)[2 * ii];
+        case GDT_TypeCount:
+            break;
+    }
+    return 0;
+}
+
+CPLErr CustomPixelFunc( void **papoSources, int nSources, void *pData,
+                            int nXSize, int nYSize,
+                            GDALDataType eSrcType, GDALDataType eBufType,
+                            int nPixelSpace, int nLineSpace, CSLConstList papszArgs ) {
+
+    /* ---- Init ---- */
+    if( nSources != 1 ) return CE_Failure;
+    const char* pszConstant = CSLFetchNameValue(papszArgs, "customConstant");
+    if (pszConstant == nullptr) return CE_Failure;
+    if (strncmp(pszConstant, "something", strlen("something"))) return CE_Failure;
+    const char* pszScale = CSLFetchNameValue(papszArgs, "scale");
+    if (pszScale == nullptr) return CE_Failure;
+
+    /* ---- Set pixels ---- */
+    size_t ii = 0;
+    for( int iLine = 0; iLine < nYSize; ++iLine )
+    {
+        for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
+        {
+            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii);
+            GDALCopyWords(
+                    &dfPixVal, GDT_Float64, 0,
+                    static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
+                    iCol * nPixelSpace, eBufType, nPixelSpace, 1);
+        }
+    }
+
+    /* ---- Return success ---- */
+    return CE_None;
+}
+
+namespace tut
+{
+    const char pszFuncMetadata[] =
+        "<PixelFunctionArgumentsList>"
+        "   <Argument name='customConstant' type='constant' value='something'>"
+        "   </Argument>"
+        "   <Argument type='builtin' value='scale'>"
+        "   </Argument>"
+        "</PixelFunctionArgumentsList>";
+    const char src[] = "data/pixelfn.vrt";
+    struct test_pixelfn_data {};
+
+    // Register test group
+    typedef test_group<test_pixelfn_data> group;
+    typedef group::object object;
+    group test_pixelfn_group("GDAL::PixelFunc");
+
+    // Test constant parameters in a custom pixel function
+    template<>
+    template<>
+    void object::test<1>()
+    {
+        GDALAddDerivedBandPixelFuncWithArgs("custom", CustomPixelFunc, pszFuncMetadata);
+        GDALDatasetH ds = GDALOpen(src, GA_ReadOnly);
+        ensure("Can't open dataset", nullptr != ds);
+
+        GDALRasterBandH band = GDALGetRasterBand(ds, 1);
+        ensure("Can't get raster band", nullptr != band);
+
+        float buf[20 * 20];
+        CPL_IGNORE_RET_VAL(GDALRasterIO(band, GF_Read, 0, 0, 20, 20, buf, 20, 20, GDT_Float32, 0, 0));
+
+        ensure_equals("Read wrong data", buf[0], 107);
+
+        GDALClose(ds);
+    }
+
+ } // namespace tut

--- a/autotest/cpp/test_gdal_pixelfn.cpp
+++ b/autotest/cpp/test_gdal_pixelfn.cpp
@@ -32,7 +32,7 @@
 #include "gdal_alg.h"
 #include "gdal_priv.h"
 #include "gdal.h"
-#include "../frmts/vrt/vrtdataset.h"
+#include "../../frmts/vrt/vrtdataset.h"
 
 #include <sstream>
 #include <string>
@@ -50,42 +50,6 @@ CPLErr CustomPixelFuncNoArgs( void **papoSources, int nSources, void *pData,
                             int nXSize, int nYSize,
                             GDALDataType eSrcType, GDALDataType eBufType,
                             int nPixelSpace, int nLineSpace);
-
-template<typename T>
-inline double
-GetSrcVal(const void* pSource, GDALDataType eSrcType, T ii)
-{
-    switch (eSrcType)
-    {
-        case GDT_Unknown:
-            return 0;
-        case GDT_Byte:
-            return static_cast<const GByte*>(pSource)[ii];
-        case GDT_UInt16:
-            return static_cast<const GUInt16*>(pSource)[ii];
-        case GDT_Int16:
-            return static_cast<const GInt16*>(pSource)[ii];
-        case GDT_UInt32:
-            return static_cast<const GUInt32*>(pSource)[ii];
-        case GDT_Int32:
-            return static_cast<const GInt32*>(pSource)[ii];
-        case GDT_Float32:
-            return static_cast<const float*>(pSource)[ii];
-        case GDT_Float64:
-            return static_cast<const double*>(pSource)[ii];
-        case GDT_CInt16:
-            return static_cast<const GInt16*>(pSource)[2 * ii];
-        case GDT_CInt32:
-            return static_cast<const GInt32*>(pSource)[2 * ii];
-        case GDT_CFloat32:
-            return static_cast<const float*>(pSource)[2 * ii];
-        case GDT_CFloat64:
-            return static_cast<const double*>(pSource)[2 * ii];
-        case GDT_TypeCount:
-            break;
-    }
-    return 0;
-}
 
 CPLErr CustomPixelFuncWithMetadata( void **papoSources, int nSources, void *pData,
                             int nXSize, int nYSize,
@@ -106,7 +70,7 @@ CPLErr CustomPixelFuncWithMetadata( void **papoSources, int nSources, void *pDat
     {
         for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
         {
-            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii) * 2;
+            const double dfPixVal = SRCVAL(papoSources[0], eSrcType, ii) * 2;
             GDALCopyWords(
                     &dfPixVal, GDT_Float64, 0,
                     static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
@@ -134,7 +98,7 @@ CPLErr CustomPixelFunc( void **papoSources, int nSources, void *pData,
     {
         for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
         {
-            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii) * 3;
+            const double dfPixVal = SRCVAL(papoSources[0], eSrcType, ii) * 3;
             GDALCopyWords(
                     &dfPixVal, GDT_Float64, 0,
                     static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
@@ -160,7 +124,7 @@ CPLErr CustomPixelFuncNoArgs( void **papoSources, int nSources, void *pData,
     {
         for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
         {
-            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii) * 4;
+            const double dfPixVal = SRCVAL(papoSources[0], eSrcType, ii) * 4;
             GDALCopyWords(
                     &dfPixVal, GDT_Float64, 0,
                     static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -1086,7 +1086,7 @@ def test_pixfun_nan():
   <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
     <Description>Nan</Description>
     <NoDataValue>0.0</NoDataValue>
-    <PixelFunctionType>nan</PixelFunctionType>
+    <PixelFunctionType>replace_nodata</PixelFunctionType>
     <SourceTransferType>Float64</SourceTransferType>
     <SimpleSource>
       <SourceFilename relativeToVRT="0">data/test_nodatavalues.tif</SourceFilename>
@@ -1102,6 +1102,34 @@ def test_pixfun_nan():
         for j in range(data_src.shape[1]):
             if (data_src[i][j] == NoData):
                 assert math.isnan(data_vrt[i][j])
+            else:
+                assert data_vrt[i][j] == data_src[i][j]
+
+
+def test_pixfun_replacenodata():
+
+    src_ds = gdal.Open('data/test_nodatavalues.tif')
+    vrt_ds = gdal.Open("""<VRTDataset rasterXSize="50" rasterYSize="50">
+  <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
+    <Description>Nan</Description>
+    <NoDataValue>0.0</NoDataValue>
+    <PixelFunctionType>replace_nodata</PixelFunctionType>
+    <PixelFunctionArguments to="42" />
+    <SourceTransferType>Float64</SourceTransferType>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/test_nodatavalues.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>""")
+    data_src = src_ds.GetRasterBand(1).ReadAsArray(buf_type=gdal.GDT_Float32)
+    data_vrt = vrt_ds.GetRasterBand(1).ReadAsArray(buf_type=gdal.GDT_Float32)
+    NoData = src_ds.GetRasterBand(1).GetNoDataValue()
+
+    for i in range(data_src.shape[0]):
+        for j in range(data_src.shape[1]):
+            if (data_src[i][j] == NoData):
+                assert data_vrt[i][j] == 42
             else:
                 assert data_vrt[i][j] == data_src[i][j]
 

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -1173,7 +1173,6 @@ def test_pixfun_missing_builtin():
   </VRTRasterBand>
 </VRTDataset>""")
 
-    last_error = gdal.GetLastErrorMsg()
     band_vrt = vrt_ds.GetRasterBand(1)
     assert band_vrt.GetOffset() == 0
     assert band_vrt.GetScale() == 1

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -1164,7 +1164,7 @@ def test_pixfun_missing_builtin():
     vrt_ds = gdal.Open("""<VRTDataset rasterXSize="20" rasterYSize="20">
   <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
     <Description>Scaling</Description>
-    <PixelFunctionType>reaplace_nodata</PixelFunctionType>
+    <PixelFunctionType>replace_nodata</PixelFunctionType>
     <SourceTransferType>Float64</SourceTransferType>
     <SimpleSource>
       <SourceFilename relativeToVRT="0">data/float32.tif</SourceFilename>

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -1078,4 +1078,59 @@ def test_pixfun_interpolate_linear():
     interpolated = ds.GetRasterBand(1).ReadAsArray()
     assert np.allclose(interpolated, layers[0]*np.exp(np.log(layers[1]/layers[0])/1 * (-22.7 - -10)))
 
+
+def test_pixfun_nan():
+
+    src_ds = gdal.Open('data/test_nodatavalues.tif')
+    vrt_ds = gdal.Open("""<VRTDataset rasterXSize="50" rasterYSize="50">
+  <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
+    <Description>Nan</Description>
+    <NoDataValue>0.0</NoDataValue>
+    <PixelFunctionType>nan</PixelFunctionType>
+    <SourceTransferType>Float64</SourceTransferType>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/test_nodatavalues.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>""")
+    data_src = src_ds.GetRasterBand(1).ReadAsArray(buf_type=gdal.GDT_Float32)
+    data_vrt = vrt_ds.GetRasterBand(1).ReadAsArray(buf_type=gdal.GDT_Float32)
+    NoData = src_ds.GetRasterBand(1).GetNoDataValue()
+
+    for i in range(data_src.shape[0]):
+        for j in range(data_src.shape[1]):
+            if (data_src[i][j] == NoData):
+                assert math.isnan(data_vrt[i][j])
+            else:
+                assert data_vrt[i][j] == data_src[i][j]
+
+
+def test_pixfun_scale():
+    src_ds = gdal.Open('data/float32.tif')
+    vrt_ds = gdal.Open("""<VRTDataset rasterXSize="20" rasterYSize="20">
+  <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
+    <Description>Scaling</Description>
+    <PixelFunctionType>scale</PixelFunctionType>
+    <SourceTransferType>Float64</SourceTransferType>
+    <Scale>2.0</Scale>
+    <Offset>1.0</Offset>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/float32.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>""")
+
+    band_src = src_ds.GetRasterBand(1)
+    band_vrt = vrt_ds.GetRasterBand(1)
+    assert band_vrt.GetOffset() == 1
+    assert band_vrt.GetScale() == 2
+
+    data_src = band_src.ReadAsArray(buf_type=gdal.GDT_Float32)
+    data_vrt = band_vrt.ReadAsArray(buf_type=gdal.GDT_Float32)
+
+    print(data_src, data_vrt)
+    assert numpy.allclose(data_src * 2 + 1, data_vrt)
+
 ###############################################################################

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -904,9 +904,11 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - sum 2 or more raster bands. If the optional ``k`` parameter is provided then it is added to each element of the result.
    * - **nan**
      - = 1
+     - -
      - convert incoming ``NoData`` values to IEEE 754 ``Nan``. Works only when writing IEEE 754 floating point data types.
    * - **scale**
      - = 1
+     - -
      - perform scaling according to the ``offset`` and ``scale`` values of the raster band.
 
 Writing Pixel Functions

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -884,7 +884,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - extract phase from a single raster band [-PI,PI] (0 or PI for non-complex)
    * - **polar**
      - 2
-     - ``amplitude_type`` (optinal)
+     - ``amplitude_type`` (optional)
      - make a complex band using input bands for amplitude and phase values ``b1 * exp( j * b2 )``. The optional (string) parameter ``amplitude_type`` can be ``AMPLITUDE`` (default) ``INTENSITY`` or ``dB``. Note: if ``amplitude_type`` is set to ``INTENSITY`` then negative values are clipped to zero.
    * - **pow**
      - 1
@@ -901,15 +901,15 @@ GDAL provides a set of default pixel functions that can be used without writing 
    * - **sum**
      - >= 2
      - ``k`` (optional)
-     - sum 2 or more raster bands. If the optional ``k`` parameter is provided then it is added to each element of the result.
-   * - **nan**
+     - sum 2 or more raster bands. If the optional ``k`` parameter is provided then it is added to each element of the result
+   * - **replace_nodata**
      - = 1
-     - -
-     - convert incoming ``NoData`` values to IEEE 754 ``Nan``. Works only when writing IEEE 754 floating point data types.
+     - ``to`` (optional)
+     - convert incoming ``NoData`` values to a new value, IEEE 754 `nan` by default
    * - **scale**
      - = 1
      - -
-     - perform scaling according to the ``offset`` and ``scale`` values of the raster band.
+     - perform scaling according to the ``offset`` and ``scale`` values of the raster band
 
 Writing Pixel Functions
 +++++++++++++++++++++++

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -902,6 +902,12 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - >= 2
      - ``k`` (optional)
      - sum 2 or more raster bands. If the optional ``k`` parameter is provided then it is added to each element of the result.
+   * - **nan**
+     - = 1
+     - convert incoming ``NoData`` values to IEEE 754 ``Nan``. Works only when writing IEEE 754 floating point data types.
+   * - **scale**
+     - = 1
+     - perform scaling according to the ``offset`` and ``scale`` values of the raster band.
 
 Writing Pixel Functions
 +++++++++++++++++++++++

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -193,6 +193,15 @@ typedef enum {
     GAT_dB
 } PolarAmplitudeType;
 
+static const char pszPolarPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='amplitude_type' description='Amplitude Type' type='string-select' default='AMPLITUDE'>"
+"       <Value>INTENSITY</Value>"
+"       <Value>dB</Value>"
+"       <Value>AMPLITUDE</Value>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
+
 static CPLErr PolarPixelFunc( void **papoSources, int nSources, void *pData,
                               int nXSize, int nYSize,
                               GDALDataType eSrcType, GDALDataType eBufType,
@@ -422,6 +431,12 @@ static CPLErr ConjPixelFunc( void **papoSources, int nSources, void *pData,
     return CE_None;
 }  // ConjPixelFunc
 
+static const char pszSumPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='k' description='Optional constant term' type='double' default='0.0'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
+
 static CPLErr SumPixelFunc(void **papoSources, int nSources, void *pData,
                     int nXSize, int nYSize,
                     GDALDataType eSrcType, GDALDataType eBufType,
@@ -546,6 +561,12 @@ static CPLErr DiffPixelFunc( void **papoSources, int nSources, void *pData,
     /* ---- Return success ---- */
     return CE_None;
 }  // DiffPixelFunc
+
+static const char pszMulPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='k' description='Optional constant factor' type='double' default='1.0'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
 
 static CPLErr MulPixelFunc( void **papoSources, int nSources, void *pData,
                             int nXSize, int nYSize,
@@ -749,6 +770,12 @@ static CPLErr CMulPixelFunc( void **papoSources, int nSources, void *pData,
     /* ---- Return success ---- */
     return CE_None;
 }  // CMulPixelFunc
+
+static const char pszInvPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='k' description='Optional constant factor' type='double' default='1.0'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
 
 static CPLErr InvPixelFunc( void **papoSources, int nSources, void *pData,
                             int nXSize, int nYSize,
@@ -971,6 +998,12 @@ static CPLErr Log10PixelFunc( void **papoSources, int nSources, void *pData,
                                 nPixelSpace, nLineSpace, 1.0);
 } // Log10PixelFunc
 
+static const char pszDBPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='fact' description='Factor' type='double' default='20.0'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
+
 static CPLErr DBPixelFunc( void **papoSources, int nSources, void *pData,
                            int nXSize, int nYSize,
                            GDALDataType eSrcType, GDALDataType eBufType,
@@ -1015,6 +1048,14 @@ static CPLErr ExpPixelFuncHelper( void **papoSources, int nSources, void *pData,
     return CE_None;
 }  // ExpPixelFuncHelper
 
+static const char pszExpPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='base' description='Base' type='double' default='2.7182818284590452353602874713526624'>"
+"   </Argument>"
+"   <Argument name='fact' description='Factor' type='double' default='1'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
+
 static CPLErr ExpPixelFunc( void **papoSources, int nSources, void *pData,
                             int nXSize, int nYSize,
                             GDALDataType eSrcType, GDALDataType eBufType,
@@ -1054,6 +1095,12 @@ static CPLErr dB2PowPixelFunc( void **papoSources, int nSources, void *pData,
                               nXSize, nYSize, eSrcType, eBufType,
                               nPixelSpace, nLineSpace, 10.0, 1./10);
 }  // dB2PowPixelFunc
+
+static const char pszPowPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='power' description='Exponent' type='double' mandatory='1'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
 
 static CPLErr PowPixelFunc( void **papoSources, int nSources, void *pData,
                                int nXSize, int nYSize,
@@ -1113,6 +1160,16 @@ static double InterpolateExponential(double dfX0, double dfX1, double dfY0, doub
     return dfY0*std::exp(r * (dfX - dfX0));
 }
 
+static const char pszInterpolatePixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument name='t0' description='t0' type='double' mandatory='1'>"
+"   </Argument>"
+"   <Argument name='dt' description='dt' type='double' mandatory='1'>"
+"   </Argument>"
+"   <Argument name='t' description='t' type='double' mandatory='1'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
+
 template<decltype(InterpolateLinear) InterpolationFunction>
 CPLErr InterpolatePixelFunc( void **papoSources, int nSources, void *pData,
                              int nXSize, int nYSize,
@@ -1164,6 +1221,99 @@ CPLErr InterpolatePixelFunc( void **papoSources, int nSources, void *pData,
     /* ---- Return success ---- */
     return CE_None;
 }
+
+static const char pszNanPixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument type='builtin' value='NoData'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
+
+static CPLErr NanPixelFunc( void **papoSources, int nSources, void *pData,
+                               int nXSize, int nYSize,
+                               GDALDataType eSrcType, GDALDataType eBufType,
+                               int nPixelSpace, int nLineSpace, CSLConstList papszArgs ) {
+    /* ---- Init ---- */
+    if( nSources != 1 ) return CE_Failure;
+    if (GDALDataTypeIsComplex(eSrcType))
+    {
+        CPLError(
+          CE_Failure, CPLE_AppDefined, "nan cannot convert complex data types");
+        return CE_Failure;
+    }
+    if (!GDALDataTypeIsFloating(eBufType))
+    {
+        CPLError(
+          CE_Failure, CPLE_AppDefined, "nan requires a floating point type output buffer");
+        return CE_Failure;
+    }
+
+    double dfNoData;
+    if ( FetchDoubleArg(papszArgs, "NoData", &dfNoData) != CE_None ) return CE_Failure;
+
+    /* ---- Set pixels ---- */
+    size_t ii = 0;
+    for( int iLine = 0; iLine < nYSize; ++iLine )
+    {
+        for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
+        {
+            double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii);
+            if (dfPixVal == dfNoData) dfPixVal = NAN;
+
+            GDALCopyWords(
+                    &dfPixVal, GDT_Float64, 0,
+                    static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
+                    iCol * nPixelSpace, eBufType, nPixelSpace, 1);
+        }
+    }
+
+    /* ---- Return success ---- */
+    return CE_None;
+}
+
+static const char pszScalePixelFuncMetadata[] =
+"<PixelFunctionArgumentsList>"
+"   <Argument type='builtin' value='offset'>"
+"   </Argument>"
+"   <Argument type='builtin' value='scale'>"
+"   </Argument>"
+"</PixelFunctionArgumentsList>";
+
+static CPLErr ScalePixelFunc( void **papoSources, int nSources, void *pData,
+                               int nXSize, int nYSize,
+                               GDALDataType eSrcType, GDALDataType eBufType,
+                               int nPixelSpace, int nLineSpace, CSLConstList papszArgs ) {
+    /* ---- Init ---- */
+    if( nSources != 1 ) return CE_Failure;
+    if (GDALDataTypeIsComplex(eSrcType))
+    {
+        CPLError(
+          CE_Failure, CPLE_AppDefined, "scale cannot by applied to complex data types");
+        return CE_Failure;
+    }
+
+    double dfScale, dfOffset;
+    if ( FetchDoubleArg(papszArgs, "scale", &dfScale) != CE_None ) return CE_Failure;
+    if ( FetchDoubleArg(papszArgs, "offset", &dfOffset) != CE_None ) return CE_Failure;
+
+    /* ---- Set pixels ---- */
+    size_t ii = 0;
+    for( int iLine = 0; iLine < nYSize; ++iLine )
+    {
+        for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
+        {
+            const double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii) * dfScale + dfOffset;
+
+            GDALCopyWords(
+                    &dfPixVal, GDT_Float64, 0,
+                    static_cast<GByte *>(pData) + static_cast<GSpacing>(nLineSpace) * iLine +
+                    iCol * nPixelSpace, eBufType, nPixelSpace, 1);
+        }
+    }
+
+    /* ---- Return success ---- */
+    return CE_None;
+}
+
 
 /************************************************************************/
 /*                     GDALRegisterDefaultPixelFunc()                   */
@@ -1224,6 +1374,8 @@ CPLErr InterpolatePixelFunc( void **papoSources, int nSources, void *pData,
  *                         using linear interpolation
  * - "interpolate_exp": interpolate values between two raster bands using
  *                      exponential interpolation
+ * - "scale": Apply the RasterBand metadata values of "offset" and "scale"
+ * - "nan": Convert incoming NoData values to IEEE 754 nan
  *
  * @see GDALAddDerivedBandPixelFunc
  *
@@ -1234,26 +1386,30 @@ CPLErr GDALRegisterDefaultPixelFunc()
     GDALAddDerivedBandPixelFunc("real", RealPixelFunc);
     GDALAddDerivedBandPixelFunc("imag", ImagPixelFunc);
     GDALAddDerivedBandPixelFunc("complex", ComplexPixelFunc);
-    GDALAddDerivedBandPixelFuncWithArgs("polar", PolarPixelFunc, nullptr);
+    GDALAddDerivedBandPixelFuncWithArgs("polar", PolarPixelFunc, pszPolarPixelFuncMetadata);
     GDALAddDerivedBandPixelFunc("mod", ModulePixelFunc);
     GDALAddDerivedBandPixelFunc("phase", PhasePixelFunc);
     GDALAddDerivedBandPixelFunc("conj", ConjPixelFunc);
-    GDALAddDerivedBandPixelFuncWithArgs("sum", SumPixelFunc, nullptr);
+    GDALAddDerivedBandPixelFuncWithArgs("sum", SumPixelFunc, pszSumPixelFuncMetadata);
     GDALAddDerivedBandPixelFunc("diff", DiffPixelFunc);
-    GDALAddDerivedBandPixelFuncWithArgs("mul", MulPixelFunc, nullptr);
+    GDALAddDerivedBandPixelFuncWithArgs("mul", MulPixelFunc, pszMulPixelFuncMetadata);
     GDALAddDerivedBandPixelFunc("div", DivPixelFunc);
     GDALAddDerivedBandPixelFunc("cmul", CMulPixelFunc);
-    GDALAddDerivedBandPixelFuncWithArgs("inv", InvPixelFunc, nullptr);
+    GDALAddDerivedBandPixelFuncWithArgs("inv", InvPixelFunc, pszInvPixelFuncMetadata);
     GDALAddDerivedBandPixelFunc("intensity", IntensityPixelFunc);
     GDALAddDerivedBandPixelFunc("sqrt", SqrtPixelFunc);
     GDALAddDerivedBandPixelFunc("log10", Log10PixelFunc);
-    GDALAddDerivedBandPixelFuncWithArgs("dB", DBPixelFunc, nullptr);
-    GDALAddDerivedBandPixelFuncWithArgs("exp", ExpPixelFunc, nullptr);
+    GDALAddDerivedBandPixelFuncWithArgs("dB", DBPixelFunc, pszDBPixelFuncMetadata);
+    GDALAddDerivedBandPixelFuncWithArgs("exp", ExpPixelFunc, pszExpPixelFuncMetadata);
     GDALAddDerivedBandPixelFunc("dB2amp", dB2AmpPixelFunc);  // deprecated in v3.5
     GDALAddDerivedBandPixelFunc("dB2pow", dB2PowPixelFunc);  // deprecated in v3.5
-    GDALAddDerivedBandPixelFuncWithArgs("pow", PowPixelFunc, nullptr);
-    GDALAddDerivedBandPixelFuncWithArgs("interpolate_linear", InterpolatePixelFunc<InterpolateLinear>, nullptr);
-    GDALAddDerivedBandPixelFuncWithArgs("interpolate_exp", InterpolatePixelFunc<InterpolateExponential>, nullptr);
+    GDALAddDerivedBandPixelFuncWithArgs("pow", PowPixelFunc, pszPowPixelFuncMetadata);
+    GDALAddDerivedBandPixelFuncWithArgs("interpolate_linear",
+        InterpolatePixelFunc<InterpolateLinear>, pszInterpolatePixelFuncMetadata);
+    GDALAddDerivedBandPixelFuncWithArgs("interpolate_exp",
+        InterpolatePixelFunc<InterpolateExponential>, pszInterpolatePixelFuncMetadata);
+    GDALAddDerivedBandPixelFuncWithArgs("nan", NanPixelFunc, pszNanPixelFuncMetadata);
+    GDALAddDerivedBandPixelFuncWithArgs("scale", ScalePixelFunc, pszScalePixelFuncMetadata);
 
     return CE_None;
 }

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -433,8 +433,7 @@ static CPLErr ConjPixelFunc( void **papoSources, int nSources, void *pData,
 
 static const char pszSumPixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument name='k' description='Optional constant term' type='double' default='0.0'>"
-"   </Argument>"
+"   <Argument name='k' description='Optional constant term' type='double' default='0.0' />"
 "</PixelFunctionArgumentsList>";
 
 static CPLErr SumPixelFunc(void **papoSources, int nSources, void *pData,
@@ -564,8 +563,7 @@ static CPLErr DiffPixelFunc( void **papoSources, int nSources, void *pData,
 
 static const char pszMulPixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument name='k' description='Optional constant factor' type='double' default='1.0'>"
-"   </Argument>"
+"   <Argument name='k' description='Optional constant factor' type='double' default='1.0' />"
 "</PixelFunctionArgumentsList>";
 
 static CPLErr MulPixelFunc( void **papoSources, int nSources, void *pData,
@@ -773,8 +771,7 @@ static CPLErr CMulPixelFunc( void **papoSources, int nSources, void *pData,
 
 static const char pszInvPixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument name='k' description='Optional constant factor' type='double' default='1.0'>"
-"   </Argument>"
+"   <Argument name='k' description='Optional constant factor' type='double' default='1.0' />"
 "</PixelFunctionArgumentsList>";
 
 static CPLErr InvPixelFunc( void **papoSources, int nSources, void *pData,
@@ -1000,8 +997,7 @@ static CPLErr Log10PixelFunc( void **papoSources, int nSources, void *pData,
 
 static const char pszDBPixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument name='fact' description='Factor' type='double' default='20.0'>"
-"   </Argument>"
+"   <Argument name='fact' description='Factor' type='double' default='20.0' />"
 "</PixelFunctionArgumentsList>";
 
 static CPLErr DBPixelFunc( void **papoSources, int nSources, void *pData,
@@ -1050,10 +1046,8 @@ static CPLErr ExpPixelFuncHelper( void **papoSources, int nSources, void *pData,
 
 static const char pszExpPixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument name='base' description='Base' type='double' default='2.7182818284590452353602874713526624'>"
-"   </Argument>"
-"   <Argument name='fact' description='Factor' type='double' default='1'>"
-"   </Argument>"
+"   <Argument name='base' description='Base' type='double' default='2.7182818284590452353602874713526624' />"
+"   <Argument name='fact' description='Factor' type='double' default='1' />"
 "</PixelFunctionArgumentsList>";
 
 static CPLErr ExpPixelFunc( void **papoSources, int nSources, void *pData,
@@ -1098,8 +1092,7 @@ static CPLErr dB2PowPixelFunc( void **papoSources, int nSources, void *pData,
 
 static const char pszPowPixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument name='power' description='Exponent' type='double' mandatory='1'>"
-"   </Argument>"
+"   <Argument name='power' description='Exponent' type='double' mandatory='1' />"
 "</PixelFunctionArgumentsList>";
 
 static CPLErr PowPixelFunc( void **papoSources, int nSources, void *pData,
@@ -1162,12 +1155,9 @@ static double InterpolateExponential(double dfX0, double dfX1, double dfY0, doub
 
 static const char pszInterpolatePixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument name='t0' description='t0' type='double' mandatory='1'>"
-"   </Argument>"
-"   <Argument name='dt' description='dt' type='double' mandatory='1'>"
-"   </Argument>"
-"   <Argument name='t' description='t' type='double' mandatory='1'>"
-"   </Argument>"
+"   <Argument name='t0' description='t0' type='double' mandatory='1' />"
+"   <Argument name='dt' description='dt' type='double' mandatory='1' />"
+"   <Argument name='t' description='t' type='double' mandatory='1' />"
 "</PixelFunctionArgumentsList>";
 
 template<decltype(InterpolateLinear) InterpolationFunction>
@@ -1222,13 +1212,13 @@ CPLErr InterpolatePixelFunc( void **papoSources, int nSources, void *pData,
     return CE_None;
 }
 
-static const char pszNanPixelFuncMetadata[] =
+static const char pszReplaceNoDataPixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument type='builtin' value='NoData'>"
-"   </Argument>"
+"   <Argument type='builtin' value='NoData' />"
+"   <Argument name='to' type='double' description='New NoData value to be replaced' default='nan' />"
 "</PixelFunctionArgumentsList>";
 
-static CPLErr NanPixelFunc( void **papoSources, int nSources, void *pData,
+static CPLErr ReplaceNoDataPixelFunc( void **papoSources, int nSources, void *pData,
                                int nXSize, int nYSize,
                                GDALDataType eSrcType, GDALDataType eBufType,
                                int nPixelSpace, int nLineSpace, CSLConstList papszArgs ) {
@@ -1237,18 +1227,20 @@ static CPLErr NanPixelFunc( void **papoSources, int nSources, void *pData,
     if (GDALDataTypeIsComplex(eSrcType))
     {
         CPLError(
-          CE_Failure, CPLE_AppDefined, "nan cannot convert complex data types");
-        return CE_Failure;
-    }
-    if (!GDALDataTypeIsFloating(eBufType))
-    {
-        CPLError(
-          CE_Failure, CPLE_AppDefined, "nan requires a floating point type output buffer");
+          CE_Failure, CPLE_AppDefined, "replace_nodata cannot convert complex data types");
         return CE_Failure;
     }
 
-    double dfNoData;
-    if ( FetchDoubleArg(papszArgs, "NoData", &dfNoData) != CE_None ) return CE_Failure;
+    double dfOldNoData, dfNewNoData = NAN;
+    if ( FetchDoubleArg(papszArgs, "NoData", &dfOldNoData) != CE_None ) return CE_Failure;
+    if ( FetchDoubleArg(papszArgs, "to", &dfNewNoData, &dfNewNoData) != CE_None ) return CE_Failure;
+
+    if (!GDALDataTypeIsFloating(eBufType) && std::isnan(dfNewNoData))
+    {
+        CPLError(
+          CE_Failure, CPLE_AppDefined, "Using nan requires a floating point type output buffer");
+        return CE_Failure;
+    }
 
     /* ---- Set pixels ---- */
     size_t ii = 0;
@@ -1257,7 +1249,7 @@ static CPLErr NanPixelFunc( void **papoSources, int nSources, void *pData,
         for( int iCol = 0; iCol < nXSize; ++iCol, ++ii )
         {
             double dfPixVal = GetSrcVal(papoSources[0], eSrcType, ii);
-            if (dfPixVal == dfNoData) dfPixVal = NAN;
+            if (dfPixVal == dfOldNoData || std::isnan(dfPixVal)) dfPixVal = dfNewNoData;
 
             GDALCopyWords(
                     &dfPixVal, GDT_Float64, 0,
@@ -1272,10 +1264,8 @@ static CPLErr NanPixelFunc( void **papoSources, int nSources, void *pData,
 
 static const char pszScalePixelFuncMetadata[] =
 "<PixelFunctionArgumentsList>"
-"   <Argument type='builtin' value='offset'>"
-"   </Argument>"
-"   <Argument type='builtin' value='scale'>"
-"   </Argument>"
+"   <Argument type='builtin' value='offset' />"
+"   <Argument type='builtin' value='scale' />"
 "</PixelFunctionArgumentsList>";
 
 static CPLErr ScalePixelFunc( void **papoSources, int nSources, void *pData,
@@ -1408,7 +1398,8 @@ CPLErr GDALRegisterDefaultPixelFunc()
         InterpolatePixelFunc<InterpolateLinear>, pszInterpolatePixelFuncMetadata);
     GDALAddDerivedBandPixelFuncWithArgs("interpolate_exp",
         InterpolatePixelFunc<InterpolateExponential>, pszInterpolatePixelFuncMetadata);
-    GDALAddDerivedBandPixelFuncWithArgs("nan", NanPixelFunc, pszNanPixelFuncMetadata);
+    GDALAddDerivedBandPixelFuncWithArgs("replace_nodata",
+        ReplaceNoDataPixelFunc, pszReplaceNoDataPixelFuncMetadata);
     GDALAddDerivedBandPixelFuncWithArgs("scale", ScalePixelFunc, pszScalePixelFuncMetadata);
 
     return CE_None;

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -788,13 +788,13 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
                                         int nMaskFlagStop,
                                         double* pdfDataPct) override;
 
-    static CPLErr AddPixelFunction( const char *pszFuncName,
+    static CPLErr AddPixelFunction( const char *pszFuncNameIn,
                                     GDALDerivedPixelFunc pfnPixelFunc );
-    static CPLErr AddPixelFunction( const char *pszFuncName,
+    static CPLErr AddPixelFunction( const char *pszFuncNameIn,
                                     GDALDerivedPixelFuncWithArgs pfnPixelFunc,
                                     const char *pszMetadata);
 
-    static std::pair<PixelFunc, CPLString>* GetPixelFunction( const char *pszFuncName );
+    static std::pair<PixelFunc, CPLString>* GetPixelFunction( const char *pszFuncNameIn );
 
     void SetPixelFunctionName( const char *pszFuncNameIn );
     void SetSourceTransferType( GDALDataType eDataType );

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -796,7 +796,7 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
 
     static std::pair<PixelFunc, CPLString>* GetPixelFunction( const char *pszFuncName );
 
-    void SetPixelFunctionName( const char *pszFuncName );
+    void SetPixelFunctionName( const char *pszFuncNameIn );
     void SetSourceTransferType( GDALDataType eDataType );
     void SetPixelFunctionLanguage( const char* pszLanguage );
 

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -771,12 +771,7 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
     char *pszFuncName;
     GDALDataType eSourceTransferType;
 
-    using PixelFuncSignature = std::function<CPLErr(void**, int, void*, int, int, GDALDataType, GDALDataType, int, int, CSLConstList)>;
-    struct PixelFunc
-    {
-        PixelFuncSignature oFunction = {};
-        CPLString osMetadata = "";
-    };
+    using PixelFunc = std::function<CPLErr(void**, int, void*, int, int, GDALDataType, GDALDataType, int, int, CSLConstList)>;
 
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand );
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand,
@@ -799,7 +794,7 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
                                     GDALDerivedPixelFuncWithArgs pfnPixelFunc,
                                     const char *pszMetadata);
 
-    static PixelFunc* GetPixelFunction( const char *pszFuncName );
+    static std::pair<PixelFunc, CPLString>* GetPixelFunction( const char *pszFuncName );
 
     void SetPixelFunctionName( const char *pszFuncName );
     void SetSourceTransferType( GDALDataType eDataType );

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -761,6 +761,9 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
 {
     VRTDerivedRasterBandPrivateData* m_poPrivate;
     bool InitializePython();
+    CPLErr GetPixelFunctionArguments(
+      const CPLString&,
+      std::vector<std::pair<CPLString, CPLString>> &);
 
     CPL_DISALLOW_COPY_ASSIGN(VRTDerivedRasterBand)
 
@@ -768,7 +771,12 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL: public VRTSourcedRasterBand
     char *pszFuncName;
     GDALDataType eSourceTransferType;
 
-    using PixelFunc = std::function<CPLErr(void**, int, void*, int, int, GDALDataType, GDALDataType, int, int, CSLConstList)>;
+    using PixelFuncSignature = std::function<CPLErr(void**, int, void*, int, int, GDALDataType, GDALDataType, int, int, CSLConstList)>;
+    struct PixelFunc
+    {
+        PixelFuncSignature oFunction = {};
+        CPLString osMetadata = "";
+    };
 
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand );
     VRTDerivedRasterBand( GDALDataset *poDS, int nBand,

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -289,7 +289,7 @@ GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,
         return CE_None;
     }
 
-    osMapPixelFunction[pszFuncName] = { pfnNewFunction, pszMetadata };
+    osMapPixelFunction[pszFuncName] = { pfnNewFunction, pszMetadata != nullptr ? pszMetadata : "" };
 
     return CE_None;
 }

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -289,7 +289,10 @@ GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,
         return CE_None;
     }
 
-    osMapPixelFunction[pszFuncName] = { pfnNewFunction, pszMetadata != nullptr ? pszMetadata : "" };
+    osMapPixelFunction[pszFuncName] = {
+        pfnNewFunction,
+        pszMetadata != nullptr ? pszMetadata : ""
+    };
 
     return CE_None;
 }

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -753,12 +753,12 @@ VRTDerivedRasterBand::GetPixelFunctionArguments(
   std::vector<std::pair<CPLString, CPLString>>& oAdditionalArgs)
 {
 
-    CPLXMLNode* oArgs = CPLParseXMLString(osMetadata);
-    if (oArgs != nullptr && oArgs->eType == CXT_Element &&
-        !strcmp(oArgs->pszValue,
+    auto poArgs = CPLXMLTreeCloser(CPLParseXMLString(osMetadata));
+    if (poArgs != nullptr && poArgs->eType == CXT_Element &&
+        !strcmp(poArgs->pszValue,
                  "PixelFunctionArgumentsList"))
     {
-        for (CPLXMLNode* psIter = oArgs->psChild; psIter != nullptr;
+        for (CPLXMLNode* psIter = poArgs->psChild; psIter != nullptr;
              psIter = psIter->psNext)
         {
             if (psIter->eType == CXT_Element &&

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -755,45 +755,44 @@ VRTDerivedRasterBand::GetPixelFunctionArguments(
 
     CPLXMLNode* oArgs = CPLParseXMLString(osMetadata);
     if (oArgs != nullptr && oArgs->eType == CXT_Element &&
-        !strncmp(oArgs->pszValue,
-                 "PixelFunctionArgumentsList",
-                 strlen("PixelFunctionArgumentsList")))
+        !strcmp(oArgs->pszValue,
+                 "PixelFunctionArgumentsList"))
     {
         for (CPLXMLNode* psIter = oArgs->psChild; psIter != nullptr;
              psIter = psIter->psNext)
         {
             if (psIter->eType == CXT_Element &&
-                !strncmp(psIter->pszValue, "Argument", strlen("Argument")))
+                !strcmp(psIter->pszValue, "Argument"))
             {
-                CPLString szName, szType, szValue;
+                CPLString osName, osType, osValue;
                 auto pszName = CPLGetXMLValue(psIter, "name", nullptr);
                 if (pszName != nullptr)
-                    szName = pszName;
+                    osName = pszName;
                 auto pszType = CPLGetXMLValue(psIter, "type", nullptr);
                 if (pszType != nullptr)
-                    szType = pszType;
+                    osType = pszType;
                 auto pszValue = CPLGetXMLValue(psIter, "value", nullptr);
                 if (pszValue != nullptr)
-                    szValue = pszValue;
-                if (szType == "constant" && szValue != "" && szName != "")
+                    osValue = pszValue;
+                if (osType == "constant" && osValue != "" && osName != "")
                     oAdditionalArgs.push_back(
-                      std::pair<CPLString, CPLString>(szName, szValue));
-                if (szType == "builtin")
+                      std::pair<CPLString, CPLString>(osName, osValue));
+                if (osType == "builtin")
                 {
                     double dfVal;
                     int success;
-                    if (szValue == "NoData")
+                    if (osValue == "NoData")
                         dfVal = this->GetNoDataValue(&success);
-                    else if (szValue == "scale")
+                    else if (osValue == "scale")
                         dfVal = this->GetScale(&success);
-                    else if (szValue == "offset")
+                    else if (osValue == "offset")
                         dfVal = this->GetOffset(&success);
                     else
                     {
                         CPLError(CE_Failure,
                                  CPLE_NotSupported,
                                  "PixelFunction builtin %s not supported",
-                                 szValue.c_str());
+                                 osValue.c_str());
                         return CE_Failure;
                     }
                     // Should we signal the user that he is using a builtin
@@ -801,9 +800,9 @@ VRTDerivedRasterBand::GetPixelFunctionArguments(
                     // Maybe we should allow generalized use of scale/offset
                     // even if they are left with their default 1/0 values
                     oAdditionalArgs.push_back(std::pair<CPLString, CPLString>(
-                      szValue, CPLSPrintf("%lf", dfVal)));
+                      osValue, CPLSPrintf("%.18g", dfVal)));
                     CPLDebug("VRT", "Added builtin pixel function argument %s = %s (%s)",
-                           szValue.c_str(),
+                           osValue.c_str(),
                            CPLSPrintf("%lf", dfVal),
                            success ? "value set" : "value undefined");
                 }
@@ -951,8 +950,8 @@ CPLErr VRTDerivedRasterBand::IRasterIO( GDALRWFlag eRWFlag,
 
         if (poPixelFunc->second != "")
         {
-            if ((GetPixelFunctionArguments(poPixelFunc->second,
-                                        oAdditionalArgs)) != CE_None)
+            if (GetPixelFunctionArguments(poPixelFunc->second,
+                                        oAdditionalArgs) != CE_None)
             {
                 return CE_Failure;
             }

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -228,7 +228,7 @@ void VRTDerivedRasterBand::Cleanup()
  * that it will apply, and if a pixel function matching the name is not
  * found the IRasterIO() call will do nothing.
  *
- * @param pszFuncName Name used to access pixel function
+ * @param pszName Name used to access pixel function
  * @param pfnNewFunction Pixel function associated with name.  An
  *  existing pixel function registered with the same name will be
  *  replaced with the new one.
@@ -236,16 +236,16 @@ void VRTDerivedRasterBand::Cleanup()
  * @return CE_None, invalid (NULL) parameters are currently ignored.
  */
 CPLErr CPL_STDCALL
-GDALAddDerivedBandPixelFunc( const char *pszFuncName,
+GDALAddDerivedBandPixelFunc( const char *pszName,
                              GDALDerivedPixelFunc pfnNewFunction )
 {
-    if( pszFuncName == nullptr || pszFuncName[0] == '\0' ||
+    if( pszName == nullptr || pszName[0] == '\0' ||
         pfnNewFunction == nullptr )
     {
       return CE_None;
     }
 
-    osMapPixelFunction[pszFuncName] = {
+    osMapPixelFunction[pszName] = {
         [pfnNewFunction](void **papoSources, int nSources, void *pData,
                                          int nBufXSize, int nBufYSize,
                                          GDALDataType eSrcType, GDALDataType eBufType,
@@ -269,7 +269,7 @@ GDALAddDerivedBandPixelFunc( const char *pszFuncName,
  * that it will apply, and if a pixel function matching the name is not
  * found the IRasterIO() call will do nothing.
  *
- * @param pszFuncName Name used to access pixel function
+ * @param pszName Name used to access pixel function
  * @param pfnNewFunction Pixel function associated with name.  An
  *  existing pixel function registered with the same name will be
  *  replaced with the new one.
@@ -279,17 +279,17 @@ GDALAddDerivedBandPixelFunc( const char *pszFuncName,
  * @since GDAL 3.4
  */
 CPLErr CPL_STDCALL
-GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,
+GDALAddDerivedBandPixelFuncWithArgs(const char *pszName,
                                     GDALDerivedPixelFuncWithArgs pfnNewFunction,
                                     const char *pszMetadata)
 {
-    if( pszFuncName == nullptr || pszFuncName[0] == '\0' ||
+    if( pszName == nullptr || pszName[0] == '\0' ||
         pfnNewFunction == nullptr )
     {
         return CE_None;
     }
 
-    osMapPixelFunction[pszFuncName] = {
+    osMapPixelFunction[pszName] = {
         pfnNewFunction,
         pszMetadata != nullptr ? pszMetadata : ""
     };
@@ -305,7 +305,7 @@ GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,
  *
  * This is the same as the C function GDALAddDerivedBandPixelFunc()
  *
- * @param pszFuncName Name used to access pixel function
+ * @param pszFuncNameIn Name used to access pixel function
  * @param pfnNewFunction Pixel function associated with name.  An
  *  existing pixel function registered with the same name will be
  *  replaced with the new one.
@@ -314,18 +314,18 @@ GDALAddDerivedBandPixelFuncWithArgs(const char *pszFuncName,
  */
 CPLErr
 VRTDerivedRasterBand::AddPixelFunction(
-    const char *pszFuncName, GDALDerivedPixelFunc pfnNewFunction )
+    const char *pszFuncNameIn, GDALDerivedPixelFunc pfnNewFunction )
 {
-    return GDALAddDerivedBandPixelFunc(pszFuncName, pfnNewFunction);
+    return GDALAddDerivedBandPixelFunc(pszFuncNameIn, pfnNewFunction);
 }
 
 CPLErr
 VRTDerivedRasterBand::AddPixelFunction(
-        const char *pszFuncName,
+        const char *pszFuncNameIn,
         GDALDerivedPixelFuncWithArgs pfnNewFunction,
         const char *pszMetadata)
 {
-    return GDALAddDerivedBandPixelFuncWithArgs(pszFuncName, pfnNewFunction, pszMetadata);
+    return GDALAddDerivedBandPixelFuncWithArgs(pszFuncNameIn, pfnNewFunction, pszMetadata);
 }
 
 /************************************************************************/
@@ -336,20 +336,20 @@ VRTDerivedRasterBand::AddPixelFunction(
  * Get a pixel function previously registered using the global
  * AddPixelFunction.
  *
- * @param pszFuncName The name associated with the pixel function.
+ * @param pszFuncNameIn The name associated with the pixel function.
  *
  * @return A derived band pixel function, or NULL if none have been
  * registered for pszFuncName.
  */
 std::pair<VRTDerivedRasterBand::PixelFunc, CPLString>*
-VRTDerivedRasterBand::GetPixelFunction( const char *pszFuncName )
+VRTDerivedRasterBand::GetPixelFunction( const char *pszFuncNameIn )
 {
-    if( pszFuncName == nullptr || pszFuncName[0] == '\0' )
+    if( pszFuncNameIn == nullptr || pszFuncNameIn[0] == '\0' )
     {
         return nullptr;
     }
 
-    auto oIter = osMapPixelFunction.find(pszFuncName);
+    auto oIter = osMapPixelFunction.find(pszFuncNameIn);
 
     if( oIter == osMapPixelFunction.end())
         return nullptr;

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -795,16 +795,20 @@ VRTDerivedRasterBand::GetPixelFunctionArguments(
                                  osValue.c_str());
                         return CE_Failure;
                     }
-                    // Should we signal the user that he is using a builtin
-                    // that depends on a value that is not set on the raster?
-                    // Maybe we should allow generalized use of scale/offset
-                    // even if they are left with their default 1/0 values
+                    if (!success)
+                    {
+                        CPLError(CE_Failure,
+                                 CPLE_AppDefined,
+                                 "Raster has no %s",
+                                 osValue.c_str());
+                        return CE_Failure;
+                    }
+
                     oAdditionalArgs.push_back(std::pair<CPLString, CPLString>(
                       osValue, CPLSPrintf("%.18g", dfVal)));
-                    CPLDebug("VRT", "Added builtin pixel function argument %s = %s (%s)",
+                    CPLDebug("VRT", "Added builtin pixel function argument %s = %s",
                            osValue.c_str(),
-                           CPLSPrintf("%lf", dfVal),
-                           success ? "value set" : "value undefined");
+                           CPLSPrintf("%.18g", dfVal));
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?

  * Implements metadata for C++ pixel functions
  * Adds two new types of arguments, to be specified in the metadata: builtins (currently `NoData`, `scale` and `offset`) and constants
  * Adds two new builtin functions: `replace_nodata` and `scale`

## What are related issues/pull requests?

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

