### PR TITLE
OGREnvelope: ignore fp warnings for operator== like IsInit()

### DIFF
--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -155,10 +155,18 @@ class CPL_DLL OGREnvelope
     /** Return whether the current rectangle is equal to the other rectangle */
     bool operator== (const OGREnvelope& other) const
     {
+#ifdef HAVE_GCC_DIAGNOSTIC_PUSH
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
         return MinX == other.MinX &&
                MinY == other.MinY &&
                MaxX == other.MaxX &&
                MaxY == other.MaxY;
+
+#ifdef HAVE_GCC_DIAGNOSTIC_PUSH
+#pragma GCC diagnostic pop
+#endif
     }
 
     /** Return whether the current rectangle is not equal to the other rectangle */


### PR DESCRIPTION
As discussed in https://lists.osgeo.org/pipermail/gdal-dev/2022-February/055504.html
when using clang++ options "-Werror,-Wfloat-equal" compile fails on an internal header:

 /usr/local/gdal.git.llvm/include/ogr_core.h:158:21: error: comparing floating point
 with == or != is unsafe [-Werror,-Wfloat-equal]
         return MinX == other.MinX &&
                ~~~~ ^  ~~~~~~~~~~
 + 3 similar errors.

## What does this PR do?
Turns on same compiler #pragma as used earlier in the same header file.

I did _not_ switch to
 #ifdef __GNUC__
as that does not fix the failure with clang++13.

## What are related issues/pull requests?
This is pull/commit that causes the problem. 
https://github.com/OSGeo/gdal/pull/5122/commits/3d877aa5da8868ed5c3aacf98845c90bc0d36e54
## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment
* OS:  Ubuntu 21.10
* Compiler: clang++ 13.0.0
