### PR TITLE
Remove remains of the DEBUG_BOOL mechanism

### DIFF
--- a/alg/gdallinearsystem.cpp
+++ b/alg/gdallinearsystem.cpp
@@ -33,10 +33,6 @@
 
 /*! @cond Doxygen_Suppress */
 
-#if defined(HAVE_ARMADILLO) && !defined(DO_NOT_USE_DEBUG_BOOL)
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include "cpl_port.h"
 #include "cpl_conv.h"
 #include "gdallinearsystem.h"

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -30,8 +30,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#define DO_NOT_USE_DEBUG_BOOL  // See TODO for bGCPUseOK.
-
 #include "cpl_port.h"
 #include "gdal_alg.h"
 #include "gdal_alg_priv.h"
@@ -1697,7 +1695,6 @@ GDALCreateGenImgProjTransformer2( GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
     const int nOrder = pszValue ? atoi(pszValue) : 0;
 
     pszValue = CSLFetchNameValue( papszOptions, "GCPS_OK" );
-    // TODO(schwehr): Why does this upset DEBUG_BOOL?
     const bool bGCPUseOK = pszValue ? CPLTestBool(pszValue) : true;
 
     pszValue = CSLFetchNameValue( papszOptions, "REFINE_MINIMUM_GCPS" );

--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -1395,7 +1395,7 @@ static void GWKOverlayDensity( const GDALWarpKernel *poWK, GPtrDiff_t iDstOffset
 /*                          GWKRoundValueT()                            */
 /************************************************************************/
 
-template<class T, EMULATED_BOOL is_signed> struct sGWKRoundValueT
+template<class T, bool is_signed> struct sGWKRoundValueT
 {
     static T eval(double);
 };

--- a/frmts/dods/dodsdataset2.cpp
+++ b/frmts/dods/dodsdataset2.cpp
@@ -28,8 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#define DO_NOT_USE_DEBUG_BOOL
-
 #include <string>
 #include <sstream>
 #include <algorithm>

--- a/frmts/ecw/CMakeLists.txt
+++ b/frmts/ecw/CMakeLists.txt
@@ -4,7 +4,7 @@ add_gdal_driver(
   SOURCES ${SOURCE} DRIVER_NAME_OPTION ECW
   DEF FRMT_ecw PLUGIN_CAPABLE)
 gdal_standard_includes(gdal_ECW_JP2ECW)
-target_compile_definitions(gdal_ECW_JP2ECW PRIVATE -DFRMT_ecw -DDO_NOT_USE_DEBUG_BOOL)
+target_compile_definitions(gdal_ECW_JP2ECW PRIVATE -DFRMT_ecw)
 gdal_target_link_libraries(gdal_ECW_JP2ECW PRIVATE ECW::ECW_ALL)
 foreach (d IN LISTS ECW_INCLUDE_DIRS)
   if (EXISTS "${d}/ECWJP2BuildNumber.h")

--- a/frmts/ecw/GNUmakefile
+++ b/frmts/ecw/GNUmakefile
@@ -4,7 +4,7 @@ include ../../GDALmake.opt
 OBJ	=	ecwdataset.o ecwcreatecopy.o jp2userbox.o ecwasyncreader.o
 
 CPPFLAGS	:=	 -DFRMT_ecw $(CPPFLAGS) \
-	$(ECW_FLAGS) $(ECW_INCLUDE) $(EXTRA_CFLAGS) -DDO_NOT_USE_DEBUG_BOOL
+	$(ECW_FLAGS) $(ECW_INCLUDE) $(EXTRA_CFLAGS)
 PLUGIN_SO =	gdal_ECW_JP2ECW.so
 
 default:	$(OBJ:.o=.$(OBJ_EXT))

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -1643,7 +1643,7 @@ public:
         return true;
     }
 
-    static const EMULATED_BOOL bMinimizeIO = true;
+    static const bool bMinimizeIO = true;
 };
 
 /************************************************************************/
@@ -2415,7 +2415,7 @@ public:
         return true;
     }
 
-    static const EMULATED_BOOL bMinimizeIO = false;
+    static const bool bMinimizeIO = false;
 };
 
 /************************************************************************/

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -27,10 +27,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#ifdef DEBUG_BOOL
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include "cpl_port.h"
 #include "jp2kakdataset.h"
 

--- a/frmts/jp2kak/jp2kakdataset.h
+++ b/frmts/jp2kak/jp2kakdataset.h
@@ -29,10 +29,6 @@
 
 // $Id$
 
-#ifdef DEBUG_BOOL
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include <cstring>
 #include <algorithm>
 #include <cmath>

--- a/frmts/jpipkak/jpipkakdataset.cpp
+++ b/frmts/jpipkak/jpipkakdataset.cpp
@@ -28,10 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
 **/
 
-#ifdef DEBUG_BOOL
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include "gdal_frmts.h"
 #include "jpipkakdataset.h"
 

--- a/frmts/kea/CMakeLists.txt
+++ b/frmts/kea/CMakeLists.txt
@@ -16,7 +16,6 @@ add_gdal_driver(
           libkea_headers.h
           PLUGIN_CAPABLE)
 gdal_standard_includes(gdal_KEA)
-target_compile_definitions(gdal_KEA PRIVATE -DDO_NOT_USE_DEBUG_BOOL)
 target_include_directories(gdal_KEA PRIVATE ${HDF5_INCLUDE_DIRS})
 gdal_target_link_libraries(gdal_KEA PRIVATE KEA::KEA ${HDF5_CXX_LIBRARIES})
 if (HDF5_BUILD_SHARED_LIBS)

--- a/frmts/kea/GNUmakefile
+++ b/frmts/kea/GNUmakefile
@@ -3,7 +3,7 @@ include ../../GDALmake.opt
 
 OBJ	=	keaband.o keacopy.o keadataset.o keadriver.o keamaskband.o keaoverview.o kearat.o
 
-CPPFLAGS	:=	 $(KEA_INC) $(CPPFLAGS) -DDO_NOT_USE_DEBUG_BOOL
+CPPFLAGS	:=	 $(KEA_INC) $(CPPFLAGS)
 
 default:	$(OBJ:.o=.$(OBJ_EXT))
 

--- a/frmts/mrsid/mrsiddataset.cpp
+++ b/frmts/mrsid/mrsiddataset.cpp
@@ -27,10 +27,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#ifdef DEBUG_BOOL
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #define NO_DELETE
 
 #include "cpl_string.h"

--- a/frmts/mrsid/mrsidstream.cpp
+++ b/frmts/mrsid/mrsidstream.cpp
@@ -28,10 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#ifdef DEBUG_BOOL
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include "cpl_error.h"
 #include "mrsidstream.h"
 

--- a/frmts/msg/CMakeLists.txt
+++ b/frmts/msg/CMakeLists.txt
@@ -14,7 +14,6 @@ add_gdal_driver(
           xritheaderparser.h
           PLUGIN_CAPABLE)
 gdal_standard_includes(gdal_MSG)
-target_compile_definitions(gdal_MSG PRIVATE -DDO_NOT_USE_DEBUG_BOOL)
 
 set(PUBLICDECOMPWT_URL
     "https://gitlab.eumetsat.int/open-source/PublicDecompWT.git"

--- a/frmts/msg/GNUmakefile
+++ b/frmts/msg/GNUmakefile
@@ -2,7 +2,7 @@ include ../../GDALmake.opt
 
 OBJ	=	msgdataset.o xritheaderparser.o prologue.o msgcommand.o reflectancecalculator.o PublicDecompWT_all.o
 
-CPPFLAGS	:=	 -DDO_NOT_USE_DEBUG_BOOL -I PublicDecompWT/DISE -I PublicDecompWT/COMP/WT/Inc -I PublicDecompWT/COMP/Inc -iquote . $(CPPFLAGS)
+CPPFLAGS	:=	 -I PublicDecompWT/DISE -I PublicDecompWT/COMP/WT/Inc -I PublicDecompWT/COMP/Inc -iquote . $(CPPFLAGS)
 
 default:	$(OBJ:.o=.$(OBJ_EXT))
 

--- a/frmts/openjpeg/openjpegdataset.cpp
+++ b/frmts/openjpeg/openjpegdataset.cpp
@@ -515,7 +515,7 @@ public:
     volatile int        nCurPair;
     int                 nBandCount;
     int                *panBandMap;
-    VOLATILE_BOOL       bSuccess;
+    volatile bool       bSuccess;
 };
 
 void JP2OpenJPEGDataset::JP2OpenJPEGReadBlockInThread(void* userdata)

--- a/frmts/pdf/GNUmakefile
+++ b/frmts/pdf/GNUmakefile
@@ -37,7 +37,7 @@ endif
 
 $(O_OBJ):       pdfobject.h pdfio.h pdfcreatecopy.h pdfcreatefromcomposition.h gdal_pdf.h ../../ogr/ogrsf_frmts/mem/ogr_mem.h
 
-CPPFLAGS	:=	 -iquote ../vrt -iquote ../mem -iquote ../../ogr/ogrsf_frmts/mem $(CPPFLAGS) $(POPPLER_INC) $(PODOFO_INC) $(PDFIUM_INC) -DDO_NOT_USE_DEBUG_BOOL
+CPPFLAGS	:=	 -iquote ../vrt -iquote ../mem -iquote ../../ogr/ogrsf_frmts/mem $(CPPFLAGS) $(POPPLER_INC) $(PODOFO_INC) $(PDFIUM_INC)
 
 default:	$(OBJ:.o=.$(OBJ_EXT))
 

--- a/ogr/ogr_xerces.cpp
+++ b/ogr/ogr_xerces.cpp
@@ -32,7 +32,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_xerces.h"
 
 #include "cpl_port.h"

--- a/ogr/ogr_xerces.h
+++ b/ogr/ogr_xerces.h
@@ -28,7 +28,6 @@
 #ifndef OGR_XERCES_INCLUDED
 #define OGR_XERCES_INCLUDED
 
-// Must be first for DEBUG_BOOL case
 #ifdef HAVE_XERCES
 #include "ogr_xerces_headers.h"
 #endif

--- a/ogr/ogrpgeogeometry.cpp
+++ b/ogr/ogrpgeogeometry.cpp
@@ -92,7 +92,7 @@ struct CurveSegment
         {
             double dfX;
             double dfY;
-            EMULATED_BOOL bIsCCW;
+            bool bIsCCW;
         } ArcByCenterPoint;
 
         struct
@@ -110,8 +110,8 @@ struct CurveSegment
             double dfRotationDeg;
             double dfSemiMajor;
             double dfRatioSemiMinor;
-            EMULATED_BOOL bIsMinor;
-            EMULATED_BOOL bIsComplete;
+            bool bIsMinor;
+            bool bIsComplete;
         } EllipseByCenter;
     } u;
 };

--- a/ogr/ogrsf_frmts/dods/GNUmakefile
+++ b/ogr/ogrsf_frmts/dods/GNUmakefile
@@ -5,7 +5,7 @@ include ../../../GDALmake.opt
 OBJ	=	ogrdodsdriver.o ogrdodsdatasource.o ogrdodslayer.o \
 		ogrdodssequencelayer.o ogrdodsfielddefn.o ogrdodsgrid.o
 
-CPPFLAGS	:=	-iquote ..  $(CPPFLAGS) $(DODS_INC) $(LIBXML2_INC) -DDO_NOT_USE_DEBUG_BOOL
+CPPFLAGS	:=	-iquote ..  $(CPPFLAGS) $(DODS_INC) $(LIBXML2_INC)
 
 default:	$(O_OBJ:.o=.$(OBJ_EXT))
 

--- a/ogr/ogrsf_frmts/dwg/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/dwg/CMakeLists.txt
@@ -23,7 +23,6 @@ else ()
 endif ()
 
 gdal_standard_includes(ogr_DWG_DGNV8)
-target_compile_definitions(ogr_DWG_DGNV8 PRIVATE -DDO_NOT_USE_DEBUG_BOOL)
 target_include_directories(ogr_DWG_DGNV8 PRIVATE $<TARGET_PROPERTY:ogr_DXF,SOURCE_DIR>)
 gdal_target_link_libraries(ogr_DWG_DGNV8 PRIVATE TEIGHA::TEIGHA)
 if (Threads_FOUND)

--- a/ogr/ogrsf_frmts/dwg/GNUmakefile
+++ b/ogr/ogrsf_frmts/dwg/GNUmakefile
@@ -20,7 +20,7 @@ OBJ	=	ogrdwgdriver.o ogrdwgdatasource.o ogrdwglayer.o \
 		ogrdgnv8driver.o ogrdgnv8datasource.o ogrdgnv8layer.o \
 		ogrteigha.o
 
-CPPFLAGS	:=	 -iquote ../dxf $(TDXXFLAGS) $(CPPFLAGS) $(TEIGHA_CPPFLAGS) -DDO_NOT_USE_DEBUG_BOOL
+CPPFLAGS	:=	 -iquote ../dxf $(TDXXFLAGS) $(CPPFLAGS) $(TEIGHA_CPPFLAGS)
 
 default:	$(O_OBJ:.o=.$(OBJ_EXT))
 

--- a/ogr/ogrsf_frmts/dxf/intronurbs.cpp
+++ b/ogr/ogrsf_frmts/dxf/intronurbs.cpp
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 #include <vector>
-#include "cpl_port.h" // in case of -DDEBUG_BOOL
+#include "cpl_port.h"
 
 CPL_CVSID("$Id$")
 
@@ -339,7 +339,7 @@ void rbspline2( int npts,int k,int p1,double b[],double h[],
                   b[1] contains the x-component of the vertex
                   b[2] contains the y-component of the vertex
                   b[3] contains the z-component of the vertex
-    h[]         = array containing the homogeneous weighting factors 
+    h[]         = array containing the homogeneous weighting factors
     k           = order of the B-spline basis function
     nbasis      = array containing the basis functions for a single value of t
     nplusc      = number of knot values
@@ -379,7 +379,7 @@ void rbspline(int npts,int k,int p1,double b[],double h[], double p[])
                   b[1] contains the x-component of the vertex
                   b[2] contains the y-component of the vertex
                   b[3] contains the z-component of the vertex
-    h[]         = array containing the homogeneous weighting factors 
+    h[]         = array containing the homogeneous weighting factors
     k           = order of the B-spline basis function
     nbasis      = array containing the basis functions for a single value of t
     nplusc      = number of knot values

--- a/ogr/ogrsf_frmts/filegdb/ogr_fgdb.h
+++ b/ogr/ogrsf_frmts/filegdb/ogr_fgdb.h
@@ -31,10 +31,6 @@
 #ifndef OGR_FGDB_H_INCLUDED
 #define OGR_FGDB_H_INCLUDED
 
-#ifdef DEBUG_BOOL
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include <vector>
 #include <set>
 #include "ogrsf_frmts.h"

--- a/ogr/ogrsf_frmts/gml/gmlreaderp.h
+++ b/ogr/ogrsf_frmts/gml/gmlreaderp.h
@@ -33,7 +33,6 @@
 
 #if defined(HAVE_XERCES)
 
-// Must be first for DEBUG_BOOL case
 #include "xercesc_headers.h"
 #include "ogr_xerces.h"
 

--- a/ogr/ogrsf_frmts/gmlas/ogr_gmlas.h
+++ b/ogr/ogrsf_frmts/gmlas/ogr_gmlas.h
@@ -31,7 +31,6 @@
 #ifndef OGR_GMLAS_INCLUDED
 #define OGR_GMLAS_INCLUDED
 
-// Must be first for DEBUG_BOOL case
 #include "xercesc_headers.h"
 #include "ogr_xerces.h"
 

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 #define CONSTANT_DEFINITION

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasdatasource.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasdatasource.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 #include "ogr_mem.h"

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasdriver.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasdriver.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 // g++ -I/usr/include/json -DxDEBUG_VERBOSE -DDEBUG   -g -DDEBUG -ftrapv  -Wall -Wextra -Winit-self -Wunused-parameter -Wformat -Werror=format-security -Wno-format-nonliteral -Wlogical-op -Wshadow -Werror=vla -Wmissing-declarations -Wnon-virtual-dtor -Woverloaded-virtual -fno-operator-names ogr/ogrsf_frmts/gmlas/*.cpp -fPIC -shared -o ogr_GMLAS.so -Iport -Igcore -Iogr -Iogr/ogrsf_frmts -Iogr/ogrsf_frmts/mem  -L. -lgdal   -I/home/even/spatialys/eea/inspire_gml/install-xerces-c-3.1.3/include

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasfeatureclass.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasfeatureclass.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 CPL_CVSID("$Id$")

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlaslayer.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlaslayer.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 #include "ogr_pgdump.h"
 #include "cpl_minixml.h"

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasreader.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasreader.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 #include "ogr_p.h"

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasschemaanalyzer.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasschemaanalyzer.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "xercesc_headers.h"
 
 // Hack to avoid bool, possibly redefined to pedantic bool class, being later used

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlaswriter.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlaswriter.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 #include "ogr_p.h"
 #include "ogrgeojsonreader.h"

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasxlinkresolver.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasxlinkresolver.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 #include "cpl_http.h"

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasxpatchmatcher.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasxpatchmatcher.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 CPL_CVSID("$Id$")

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
@@ -28,7 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Must be first for DEBUG_BOOL case
 #include "ogr_gmlas.h"
 
 #include "cpl_sha256.h"

--- a/ogr/ogrsf_frmts/nas/nasreaderp.h
+++ b/ogr/ogrsf_frmts/nas/nasreaderp.h
@@ -31,7 +31,6 @@
 #ifndef CPL_NASREADERP_H_INCLUDED
 #define CPL_NASREADERP_H_INCLUDED
 
-// Must be first for DEBUG_BOOL case
 #include "xercesc_headers.h"
 #include "ogr_xerces.h"
 

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
@@ -275,25 +275,25 @@ static int ReadVarUInt(GByte*& pabyIter, GByte* pabyEnd, OutType& nOutVal)
 struct ControlTypeVerboseErrorTrue
 {
     // cppcheck-suppress unusedStructMember
-    static const EMULATED_BOOL check_bounds = true;
+    static const bool check_bounds = true;
     // cppcheck-suppress unusedStructMember
-    static const EMULATED_BOOL verbose_error = true;
+    static const bool verbose_error = true;
 };
 
 struct ControlTypeVerboseErrorFalse
 {
     // cppcheck-suppress unusedStructMember
-    static const EMULATED_BOOL check_bounds = true;
+    static const bool check_bounds = true;
     // cppcheck-suppress unusedStructMember
-    static const EMULATED_BOOL verbose_error = false;
+    static const bool verbose_error = false;
 };
 
 struct ControlTypeNone
 {
     // cppcheck-suppress unusedStructMember
-    static const EMULATED_BOOL check_bounds = false;
+    static const bool check_bounds = false;
     // cppcheck-suppress unusedStructMember
-    static const EMULATED_BOOL verbose_error = false;
+    static const bool verbose_error = false;
 };
 
 static int ReadVarUInt32(GByte*& pabyIter, GByte* pabyEnd, GUInt32& nOutVal)

--- a/ogr/ogrsf_frmts/osm/ogr_osm.h
+++ b/ogr/ogrsf_frmts/osm/ogr_osm.h
@@ -270,8 +270,8 @@ typedef struct
     IndexedKVP*         pasTags; /*  point to a sub-array of OGROSMDataSource.pasAccumulatedTags */
     OSMInfo             sInfo;
     OGRFeature         *poFeature;
-    EMULATED_BOOL       bIsArea : 1;
-    EMULATED_BOOL       bAttrFilterAlreadyEvaluated : 1;
+    bool       bIsArea : 1;
+    bool       bAttrFilterAlreadyEvaluated : 1;
 } WayFeaturePair;
 
 #ifdef ENABLE_NODE_LOOKUP_BY_HASHING

--- a/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -1675,7 +1675,7 @@ void OGROSMDataSource::ProcessWaysBatch()
     {
         WayFeaturePair* psWayFeaturePairs = &pasWayFeaturePairs[iPair];
 
-        const EMULATED_BOOL bIsArea = psWayFeaturePairs->bIsArea;
+        const bool bIsArea = psWayFeaturePairs->bIsArea;
         m_asLonLatCache.clear();
 
 #ifdef ENABLE_NODE_LOOKUP_BY_HASHING

--- a/port/cpl_multiproc.cpp
+++ b/port/cpl_multiproc.cpp
@@ -41,9 +41,7 @@
 #  include <cassert>
 #endif
 #include <cerrno>
-#ifndef DEBUG_BOOL
 #include <cmath>
-#endif
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>

--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -1005,86 +1005,6 @@ inline static bool CPL_TO_BOOL(int x) { return x != 0; }
 #endif
 
 /*! @cond Doxygen_Suppress */
-// Define DEBUG_BOOL to compile in "MSVC mode", ie error out when
-// a integer is assigned to a bool
-// WARNING: use only at compilation time, since it is know to not work
-//  at runtime for unknown reasons (crash in MongoDB driver for example)
-#if defined(__cplusplus) && defined(DEBUG_BOOL) && !defined(DO_NOT_USE_DEBUG_BOOL) && !defined(CPL_SUPRESS_CPLUSPLUS)
-extern "C++" {
-class MSVCPedanticBool
-{
-
-        friend bool operator== (const bool& one, const MSVCPedanticBool& other);
-        friend bool operator!= (const bool& one, const MSVCPedanticBool& other);
-
-        bool b;
-        MSVCPedanticBool(int bIn);
-
-    public:
-        /* b not initialized on purpose in default ctor to flag use. */
-        /* cppcheck-suppress uninitMemberVar */
-        MSVCPedanticBool() {}
-        MSVCPedanticBool(bool bIn) : b(bIn) {}
-        MSVCPedanticBool(const MSVCPedanticBool& other) : b(other.b) {}
-
-        MSVCPedanticBool& operator= (const MSVCPedanticBool& other) { b = other.b; return *this; }
-        MSVCPedanticBool& operator&= (const MSVCPedanticBool& other) { b &= other.b; return *this; }
-        MSVCPedanticBool& operator|= (const MSVCPedanticBool& other) { b |= other.b; return *this; }
-
-        bool operator== (const bool& other) const { return b == other; }
-        bool operator!= (const bool& other) const { return b != other; }
-        bool operator< (const bool& other) const { return b < other; }
-        bool operator== (const MSVCPedanticBool& other) const { return b == other.b; }
-        bool operator!= (const MSVCPedanticBool& other) const { return b != other.b; }
-        bool operator< (const MSVCPedanticBool& other) const { return b < other.b; }
-
-        bool operator! () const { return !b; }
-        operator bool() const { return b; }
-        operator int() const { return b; }
-        operator GIntBig() const { return b; }
-};
-
-inline bool operator== (const bool& one, const MSVCPedanticBool& other) { return one == other.b; }
-inline bool operator!= (const bool& one, const MSVCPedanticBool& other) { return one != other.b; }
-
-/* We must include all C++ stuff before to avoid issues with templates that use bool */
-#include <vector>
-#include <map>
-#include <set>
-#include <string>
-#include <cstddef>
-#include <limits>
-#include <sstream>
-#include <fstream>
-#include <algorithm>
-#include <functional>
-#include <memory>
-#include <queue>
-#include <mutex>
-#include <unordered_map>
-#include <thread>
-#include <unordered_set>
-#include <complex>
-#include <iomanip>
-
-} /* extern C++ */
-
-#undef FALSE
-#define FALSE false
-#undef TRUE
-#define TRUE true
-
-/* In the very few cases we really need a "simple" type, fallback to bool */
-#define EMULATED_BOOL int
-
-/* Use our class instead of bool */
-#define bool MSVCPedanticBool
-
-/* "volatile bool" with the below substitution doesn't really work. */
-/* Just for the sake of the debug, we don't really need volatile */
-#define VOLATILE_BOOL bool
-
-#else /* defined(__cplusplus) && defined(DEBUG_BOOL) */
 
 #ifndef FALSE
 #  define FALSE 0
@@ -1093,11 +1013,6 @@ inline bool operator!= (const bool& one, const MSVCPedanticBool& other) { return
 #ifndef TRUE
 #  define TRUE 1
 #endif
-
-#define EMULATED_BOOL bool
-#define VOLATILE_BOOL volatile bool
-
-#endif /* defined(__cplusplus) && defined(DEBUG_BOOL) */
 
 #if __clang_major__ >= 4 || (__clang_major__ == 3 && __clang_minor__ >= 8)
 #define CPL_NOSANITIZE_UNSIGNED_INT_OVERFLOW __attribute__((no_sanitize("unsigned-integer-overflow")))
@@ -1116,9 +1031,6 @@ inline C CPLUnsanitizedAdd(A a, B b)
 }
 #endif
 
-/*! @endcond */
-
-/*! @cond Doxygen_Suppress */
 #if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)
 #define CPL_NULLPTR nullptr
 #else

--- a/port/cpl_sha256.cpp
+++ b/port/cpl_sha256.cpp
@@ -31,10 +31,6 @@
  *  Allan Saddi
  */
 
-#ifdef HAVE_CRYPTOPP
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include <string.h>
 #include "cpl_conv.h"
 #include "cpl_error.h"

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -36,6 +36,8 @@
 #include "cpl_conv.h"
 #include "cpl_vsi.h"
 
+#include <stdbool.h>
+
 /**
  * \file cpl_string.h
  *
@@ -120,24 +122,9 @@ int CPL_DLL CSLTestBoolean( const char *pszValue );
 /* Do not use CPLTestBoolean in C++ code.  Use CPLTestBool. */
 int CPL_DLL CPLTestBoolean( const char *pszValue );
 
-#if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)
-#ifdef DO_NOT_USE_DEBUG_BOOL
-#define CPLTestBool(x) CPL_TO_BOOL(CPLTestBoolean(x))
-#define CPLFetchBool(list,key,default) \
-    CPL_TO_BOOL(CSLFetchBoolean(list,key,default))
-#else /* DO_NOT_USE_DEBUG_BOOL */
-/* Prefer these for C++ code. */
-#ifdef DEBUG_BOOL
-extern "C++" {
-#endif
 bool CPL_DLL CPLTestBool( const char *pszValue );
 bool CPL_DLL CPLFetchBool( CSLConstList papszStrList, const char *pszKey,
                            bool bDefault );
-#ifdef DEBUG_BOOL
-}
-#endif
-#endif
-#endif  /* __cplusplus */
 
 const char CPL_DLL *
       CPLParseNameValue( const char *pszNameValue, char **ppszKey );

--- a/port/cpl_vsil_crypt.cpp
+++ b/port/cpl_vsil_crypt.cpp
@@ -26,10 +26,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#ifdef DEBUG_BOOL
-#define DO_NOT_USE_DEBUG_BOOL
-#endif
-
 #include "cpl_port.h"
 #include "cpl_vsi_virtual.h"
 


### PR DESCRIPTION
This was somewhat useful at a time to try to emulate MSVC 2015 warnings
related to int->bool implicit conversion on other compilers, but this was
quite horrible.
And later versions of MSVC have backed that warning, so let's get rid of
that.
