### PR TITLE
Docs: add missing decl_configoption in gdal_grid, jp2openjpeg and sentinel2

### DIFF
--- a/doc/source/drivers/raster/jp2openjpeg.rst
+++ b/doc/source/drivers/raster/jp2openjpeg.rst
@@ -46,7 +46,7 @@ information is fetched in following order (first listed is the most
 prioritary): PAM, GeoJP2, GMLJP2, WORLDFILE.
 
 Starting with GDAL 2.2, the allowed sources and their priority order can
-be changed with the GDAL_GEOREF_SOURCES configuration option (or
+be changed with the :decl_configoption:`GDAL_GEOREF_SOURCES` configuration option (or
 GEOREF_SOURCES open option) whose value is a comma-separated list of the
 following keywords : PAM, GEOJP2, GMLJP2, INTERNAL (shortcut for
 GEOJP2,GMLJP2), WORLDFILE, NONE. First mentioned sources are the most
@@ -63,7 +63,7 @@ Thread support
 By default, if the JPEG2000 file has internal tiling, GDAL will try to
 decode several tiles in multiple threads if the RasterIO() request it
 receives intersect several tiles. This behavior can be controlled with
-the GDAL_NUM_THREADS configuration option that defaults to ALL_CPUS in
+the :decl_configoption:`GDAL_NUM_THREADS` configuration option that defaults to ALL_CPUS in
 that context. In case RAM is limited, it can be needed to set this
 configuration option to 1 to disable multi-threading
 

--- a/doc/source/drivers/raster/sentinel2.rst
+++ b/doc/source/drivers/raster/sentinel2.rst
@@ -161,12 +161,12 @@ NONE resampling method ('-r none' as gdaladdo switch).
 
 When converting a subdataset to another format like tiled GeoTIFF, if
 using the JP2OpenJPEG driver, the recommended minimum value for the
-GDAL_CACHEMAX configuration option is (subdataset_width \* 2048 \* 2 ) /
+:decl_configoption:`GDAL_CACHEMAX` configuration option is (subdataset_width \* 2048 \* 2 ) /
 10000000 if generating a INTERLEAVE=BAND GeoTIFF, or that value
 multiplied by the number of bands for the default INTERLEAVE=PIXEL
 configuration. The current versions of the OpenJPEG libraries can also
 consume a lot of memory to decode a JPEG2000 tile (up to 600MB), so you
-might want to specify the GDAL_NUM_THREADS configuration option to a
+might want to specify the :decl_configoption:`GDAL_NUM_THREADS` configuration option to a
 reasonable number of threads if you are short of memory (the default
 value is the total number of virtual CPUs).
 

--- a/doc/source/programs/gdal_grid.rst
+++ b/doc/source/programs/gdal_grid.rst
@@ -35,7 +35,7 @@ This program creates regular grid (raster) from the scattered data read from
 the OGR datasource. Input data will be interpolated to fill grid nodes with
 values, you can choose from various interpolation methods.
 
-It is possible to set the ``GDAL_NUM_THREADS``
+It is possible to set the :decl_configoption:`GDAL_NUM_THREADS`
 configuration option to parallelize the processing. The value to specify is
 the number of worker threads, or ``ALL_CPUS`` to use all the cores/CPUs of the
 computer.


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Adds missing decl_configoption reference tag in [gdal_grid](https://gdal.org/programs/gdal_grid.html) (GDAL_NUM_THREADS), [jp2openjpeg](https://gdal.org/drivers/raster/jp2openjpeg.html) (GDAL_NUM_THREADS and GDAL_GEOREF_SOURCES) and [sentinel2](https://gdal.org/drivers/raster/sentinel2.html) (GDAL_NUM_THREADS and GDAL_CACHEMAX) docs.
