### PR TITLE
vrt.rst:  example code, xml domain for VRT content

### DIFF
--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -602,7 +602,7 @@ metadata domain.
   poVRTDS = poDriver->CreateCopy( "", poSrcDS, FALSE, NULL, NULL, NULL );
 
   // obtain the actual XML text that a VRT file would contain
-  char *xmlvrt poVRTDS->GetMetadata("xml:VRT")[0];
+  const char *xmlvrt = poVRTDS->GetMetadata("xml:VRT")[0];
 
 To create a virtual copy of a dataset with some attributes added or changed
 such as metadata or coordinate system that are often hard to change on other

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -597,14 +597,12 @@ you can modify the above code to open the new dataset with an empty filename and
 metadata domain.
 
 .. code-block:: cpp
-  // ...
+
   // no filename
   poVRTDS = poDriver->CreateCopy( "", poSrcDS, FALSE, NULL, NULL, NULL );
 
   // obtain the actual XML text that a VRT file would contain
   char *xmlvrt poVRTDS->GetMetadata("xml:VRT")[0];
-
-  // ...
 
 To create a virtual copy of a dataset with some attributes added or changed
 such as metadata or coordinate system that are often hard to change on other

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -592,6 +592,20 @@ words, in the previous example, you could also invert the 2 last lines, whereas
 if you open the source dataset with :cpp:func:`GDALOpen`, you'd need to close the VRT dataset
 before closing the source dataset.
 
+To obtain the resulting VRT XML of "wrk.vrt" without having to read the text from an actual file,
+you can modify the above code to open the new dataset with an empty filename and use the "xml:VRT"
+metadata domain.
+
+.. code-block:: cpp
+  // ...
+  // no filename
+  poVRTDS = poDriver->CreateCopy( "", poSrcDS, FALSE, NULL, NULL, NULL );
+
+  // obtain the actual XML text that a VRT file would contain
+  char *xmlvrt poVRTDS->GetMetadata("xml:VRT")[0];
+
+  // ...
+
 To create a virtual copy of a dataset with some attributes added or changed
 such as metadata or coordinate system that are often hard to change on other
 formats, you might do the following.  In this case, the virtual dataset is

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -592,7 +592,7 @@ words, in the previous example, you could also invert the 2 last lines, whereas
 if you open the source dataset with :cpp:func:`GDALOpen`, you'd need to close the VRT dataset
 before closing the source dataset.
 
-To obtain the resulting VRT XML of "wrk.vrt" without having to read the text from an actual file,
+To obtain the resulting VRT XML of :file:`wrk.vrt` without having to read the text from an actual file,
 you can modify the above code to open the new dataset with an empty filename and use the "xml:VRT"
 metadata domain.
 


### PR DESCRIPTION
Small documentation addition, example code for 'xml:VRT' metadata domain from a non-file data source. 

This example shows how to obtain the XML content of a VRT representation of a raster, without instantiating/reading an actual file. 

Prompted by mailing list discussion: https://lists.osgeo.org/pipermail/gdal-dev/2022-March/055544.html

## Tasklist

 - [ ] Add documentation to vrt.rst, possibly other additions
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
