### PR TITLE
Improve doc readability of --extent gdal_calc option

### DIFF
--- a/doc/source/programs/gdal_calc.rst
+++ b/doc/source/programs/gdal_calc.rst
@@ -99,19 +99,24 @@ but no projection checking is performed (unless projectionCheck option is used).
 
     .. versionadded:: 3.3
 
-    this option determines how to handle rasters with different extents.
-    this option is mutually exclusive with the `projwin` option, which is used for providing a custom extent.
-    for all the options below the pixel size (resolution) and SRS (Spatial Reference System) of all the input rasters must be the same.
+    This option determines how to handle rasters with different extents.
+    This option is mutually exclusive with the `projwin` option, which is used for providing a custom extent.
+    
+    For all the options below the pixel size (resolution) and SRS (Spatial Reference System) of all the input rasters must be the same.
+    
     ``ignore`` (default) - only the dimensions of the rasters are compared. if the dimensions do not agree the operation will fail.
+    
     ``fail`` - the dimensions and the extent (bounds) of the rasters must agree, otherwise the operation will fail.
+    
     ``union`` - the extent (bounds) of the output will be the minimal rectangle that contains all the input extents.
+    
     ``intersect`` - the extent (bounds) of the output will be the maximal rectangle that is contained in all the input extents.
 
 .. option:: --projwin <ulx> <uly> <lrx> <lry>
 
     .. versionadded:: 3.3
 
-    this option provides a custom extent for the output, it is mutually exclusive with the `extent` option.
+    This option provides a custom extent for the output, it is mutually exclusive with the `extent` option.
 
 .. option:: --projectionCheck
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Improve doc readability of --extent gdal_calc option
(I didn't compile the doc locally to test my changes)


