### PR TITLE
DIMAP: register metadata on all 6 PNEO bands

### DIFF
--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1587,25 +1587,34 @@ int DIMAPDataset::ReadImageInformation2()
                     {
                         if( EQUAL(psTag->pszValue, "BAND_ID") )
                         {
-                            // BAND_ID is: B0, B1, .... P
-                            if( strlen(psTag->psChild->pszValue) == 2 && 
-                                psTag->psChild->pszValue[0]=='B')
+                            nBandIndex = 0;
+                            if (EQUAL(psTag->psChild->pszValue, "P") ||
+                                EQUAL(psTag->psChild->pszValue, "PAN") ||
+                                EQUAL(psTag->psChild->pszValue, "B0") ||
+                                EQUAL(psTag->psChild->pszValue, "R"))
+                                nBandIndex = 1;
+                            else if (EQUAL(psTag->psChild->pszValue, "B1") ||
+                                EQUAL(psTag->psChild->pszValue, "G"))
+                                nBandIndex = 2;
+                            else if (EQUAL(psTag->psChild->pszValue, "B2") ||
+                                EQUAL(psTag->psChild->pszValue, "B"))
+                                nBandIndex = 3;
+                            else if (EQUAL(psTag->psChild->pszValue, "B3") ||
+                                EQUAL(psTag->psChild->pszValue, "NIR"))
+                                nBandIndex = 4;
+                            else if (EQUAL(psTag->psChild->pszValue, "RE"))
+                                nBandIndex = 5;
+                            else if (EQUAL(psTag->psChild->pszValue, "DB"))
+                                nBandIndex = 6;
+                            
+                            if (nBandIndex <= 0 ||
+                                nBandIndex > GetRasterCount())
                             {
-                                nBandIndex =
-                                    atoi(&psTag->psChild->pszValue[1]);
-                                if( nBandIndex < 0 ||
-                                    nBandIndex >= poImageDS->GetRasterCount() )
-                                {
-                                    CPLError(
-                                        CE_Warning, CPLE_AppDefined,
-                                        "Bad BAND_INDEX value : %s",
-                                        psTag->psChild->pszValue);
-                                    nBandIndex = 0;
-                                }
-                                else
-                                {
-                                    nBandIndex++;
-                                }
+                                CPLError(
+                                    CE_Warning, CPLE_AppDefined,
+                                    "Bad BAND_ID value : %s",
+                                    psTag->psChild->pszValue);
+                                nBandIndex = 0;
                             }
                         }
                         else if( nBandIndex >= 1 )


### PR DESCRIPTION
As a followup to #5419, this patch assigns metadata to all 6 PNEO bands. Should also correctly handle the B0,B1,B2,B3 cases and adds band metadata to "P"/"PAN".

Tested on 18 combinations of P,PMS,PMS-FS etc..., band metadata is registered correctly except in the PMS-X case (where the 3 bands are ordered NIR,R,G), but handling that specific case would require a more significant refactoring.