### PR TITLE
Fix build without atlbase.h

### DIFF
--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -43,7 +43,7 @@ CPL_CVSID("$Id$")
 // #define DEBUG_VERBOSE 1
 
 #ifdef WIN32
-#if defined(_MSC_VER)
+#if defined(HAVE_ATLBASE_H)
 bool CPLFetchWindowsProductUUID(CPLString &osStr); // defined in cpl_aws_win32.cpp
 #endif
 const char* CPLGetWineVersion(); // defined in cpl_vsil_win32.cpp
@@ -701,7 +701,7 @@ static bool IsMachinePotentiallyEC2Instance()
     }
     else
     {
-#if defined(_MSC_VER)
+#if defined(HAVE_ATLBASE_H)
         CPLString osMachineUUID;
         if( CPLFetchWindowsProductUUID(osMachineUUID) )
         {

--- a/port/cpl_aws_win32.cpp
+++ b/port/cpl_aws_win32.cpp
@@ -28,7 +28,7 @@
 
 #include "cpl_port.h"
 
-#if defined(WIN32) && defined(_MSC_VER) && HAVE_ATLBASE_H
+#if defined(HAVE_ATLBASE_H)
 
 #define _WIN32_DCOM
 #include <iostream>
@@ -140,4 +140,4 @@ bool CPLFetchWindowsProductUUID(CPLString &osStr)
     return !osWindowsProductUUID.empty();
 }
 
-#endif /* defined(WIN32) && defined(_MSC_VER) */
+#endif /* defined(HAVE_ATLBASE_H) */


### PR DESCRIPTION
## What does this PR do?

Fixes undefined symbols when building without atlbase.h on windows.

## What are related issues/pull requests?

Amends #5436.

---

Wish list:
For packaging, I would prefer to control "AWS EC2 host detection" as a feature, at least with CMake.
(This is possible with nmake now via `HAVE_ATLBASE_H`.)