### PR TITLE
Docs: add missing decl_configoption in XLS and XLSX drivers

### DIFF
--- a/doc/source/drivers/vector/xls.rst
+++ b/doc/source/drivers/vector/xls.rst
@@ -19,13 +19,13 @@ directly (but you may use the OGR VRT capabilities for that).
 Configuration options
 ---------------------
 
--  OGR_XLS_HEADERS = FORCE / DISABLE / AUTO : By default, the driver
+-  :decl_configoption:`OGR_XLS_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver
    will read the first lines of each sheet to detect if the first line
    might be the name of columns. If set to FORCE, the driver will
    consider the first line will be taken as the header line. If set to
    DISABLE, it will be considered as the first feature. Otherwise
    auto-detection will occur.
--  OGR_XLS_FIELD_TYPES = STRING / AUTO : By default, the driver will try
+-  :decl_configoption:`OGR_XLS_FIELD_TYPES` = STRING / AUTO : By default, the driver will try
    to detect the data type of fields. If set to STRING, all fields will
    be of String type.
 

--- a/doc/source/drivers/vector/xlsx.rst
+++ b/doc/source/drivers/vector/xlsx.rst
@@ -42,13 +42,13 @@ Driver capabilities
 Configuration options
 ---------------------
 
--  OGR_XLSX_HEADERS = FORCE / DISABLE / AUTO : By default, the driver
+-  :decl_configoption:`OGR_XLSX_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver
    will read the first lines of each sheet to detect if the first line
    might be the name of columns. If set to FORCE, the driver will
    consider the first line will be taken as the header line. If set to
    DISABLE, it will be considered as the first feature. Otherwise
    auto-detection will occur.
--  OGR_XLSX_FIELD_TYPES = STRING / AUTO : By default, the driver will
+-  :decl_configoption:`OGR_XLSX_FIELD_TYPES` = STRING / AUTO : By default, the driver will
    try to detect the data type of fields. If set to STRING, all fields
    will be of String type.
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Adds missing decl_configoption reference tag in [XLS](https://gdal.org/drivers/vector/xls.html) (OGR_XLS_HEADERS and OGR_XLS_FIELD_TYPES) and [XLSX](https://gdal.org/drivers/vector/xlsx.html) (OGR_XLSX_HEADERS and OGR_XLSX_FIELD_TYPES) drivers docs.
