### PR TITLE
Fix compilation without NETCDF_HAS_NC4

### DIFF
--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -694,8 +694,8 @@ netCDFRasterBand::netCDFRasterBand( const netCDFRasterBand::CONSTRUCTOR_OPEN&,
             }
         }
         else
-        {
 #endif
+        {
 #ifdef NCDF_DEBUG
             CPLDebug("GDAL_netCDF", "SetNoDataValue(%f) read", dfNoData);
 #endif
@@ -1542,8 +1542,8 @@ CPLErr netCDFRasterBand::SetNoDataValueAsInt64( int64_t nNoData )
             status = nc_put_att_longlong (cdfid, nZId, _FillValue,
                                           nc_datatype, 1, &tmp);
         }
-#endif
         else
+#endif
         {
             double dfNoData = static_cast<double>(nNoData);
             status = nc_put_att_double(cdfid, nZId, _FillValue,
@@ -1626,8 +1626,8 @@ CPLErr netCDFRasterBand::SetNoDataValueAsUInt64( uint64_t nNoData )
             status = nc_put_att_ulonglong (cdfid, nZId, _FillValue,
                                            nc_datatype, 1, &tmp);
         }
-#endif
         else
+#endif
         {
             double dfNoData = static_cast<double>(nNoData);
             status = nc_put_att_double(cdfid, nZId, _FillValue,


### PR DESCRIPTION
## What does this PR do?

Fixes an error when building netcdf without NETCDF_HAS_NC4.

Linux gcc:
~~~
/mnt/vcpkg-ci/buildtrees/gdal/src/58ed61cfea-138d7f5529.clean/frmts/netcdf/netcdfdataset.cpp: At global scope:
/mnt/vcpkg-ci/buildtrees/gdal/src/58ed61cfea-138d7f5529.clean/frmts/netcdf/netcdfdataset.cpp:724:23: error: expected constructor, destructor, or type conversion before ‘(’ token
  724 |     CreateBandMetadata(paDimIds, panExtraDimGroupIds, panExtraDimVarIds);
      |                       ^
~~~

Windows cl:
~~~
D:\buildtrees\gdal\src\58ed61cfea-138d7f5529.clean\frmts\netcdf\netcdfdataset.cpp(724): error C2065: 'paDimIds': undeclared identifier
D:\buildtrees\gdal\src\58ed61cfea-138d7f5529.clean\frmts\netcdf\netcdfdataset.cpp(724): error C2065: 'panExtraDimGroupIds': undeclared identifier
D:\buildtrees\gdal\src\58ed61cfea-138d7f5529.clean\frmts\netcdf\netcdfdataset.cpp(724): error C2065: 'panExtraDimVarIds': undeclared identifier
D:\buildtrees\gdal\src\58ed61cfea-138d7f5529.clean\frmts\netcdf\netcdfdataset.cpp(724): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
D:\buildtrees\gdal\src\58ed61cfea-138d7f5529.clean\frmts\netcdf\netcdfdataset.cpp(724): error C2440: 'initializing': cannot convert from 'initializer list' to 'int'
D:\buildtrees\gdal\src\58ed61cfea-138d7f5529.clean\frmts\netcdf\netcdfdataset.cpp(724): note: The initializer contains too many elements
~~~

## What are related issues/pull requests?

Amends https://github.com/OSGeo/gdal/pull/5257.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant: 
https://dev.azure.com/vcpkg/public/_build/results?buildId=68756&view=results