### PR TITLE
Docs and help strings: add missing -pct option description in pct2rgb and fix some typos in pct2rgb and rgb2pct

### DIFF
--- a/doc/source/programs/pct2rgb.rst
+++ b/doc/source/programs/pct2rgb.rst
@@ -15,7 +15,7 @@ Synopsis
 
 .. code-block::
 
-    pct2rgb.py [-of format] [-b band] [-rgba] source_file dest_file
+    pct2rgb.py [-of format] [-b band] [-rgba] [-pct palette_file] source_file dest_file
 
 Description
 -----------
@@ -38,6 +38,13 @@ RGB file of the desired format.
 .. option:: -rgba
 
     Generate a RGBA file (instead of a RGB file by default).
+
+.. option:: -pct <palette_file>
+
+    Extract the color table from <palette_file> instead of computing it.
+    Can be used to have a consistent color table for multiple files.
+    The <palette_file> must be either a raster file in a GDAL supported format with a palette
+    or a color file in a supported format (txt, qml, qlr).
 
 .. option:: <source_file>
 

--- a/doc/source/programs/pct2rgb.rst
+++ b/doc/source/programs/pct2rgb.rst
@@ -41,7 +41,7 @@ RGB file of the desired format.
 
 .. option:: -pct <palette_file>
 
-    Extract the color table from <palette_file> instead of getting it from <source_file>
+    Extract the color table from <palette_file> instead of getting it from <source_file>.
     Can be used to have a consistent color table for multiple files.
     The <palette_file> must be either a raster file in a GDAL supported format with a palette
     or a color file in a supported format (txt, qml, qlr).

--- a/doc/source/programs/pct2rgb.rst
+++ b/doc/source/programs/pct2rgb.rst
@@ -41,7 +41,7 @@ RGB file of the desired format.
 
 .. option:: -pct <palette_file>
 
-    Extract the color table from <palette_file> instead of computing it.
+    Extract the color table from <palette_file> instead of getting it from <source_file>
     Can be used to have a consistent color table for multiple files.
     The <palette_file> must be either a raster file in a GDAL supported format with a palette
     or a color file in a supported format (txt, qml, qlr).

--- a/doc/source/programs/rgb2pct.rst
+++ b/doc/source/programs/rgb2pct.rst
@@ -37,7 +37,7 @@ maximize output image visual quality.
 
     Extract the color table from <palette_file> instead of computing it.
     Can be used to have a consistent color table for multiple files.
-    The<palette_file> must be either a raster file in a GDAL supported format with a palette
+    The <palette_file> must be either a raster file in a GDAL supported format with a palette
     or a color file in a supported format (txt, qml, qlr).
 
 .. option:: -of <format>

--- a/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
+++ b/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
@@ -172,7 +172,7 @@ class PCT2RGB(GDALScript):
 
         parser.add_argument("-pct", dest='pct_filename', type=str,
                             help="Extract the color table from <palette_file> instead of computing it. "
-                                 "can be used to have a consistent color table for multiple files. "
+                                 "Can be used to have a consistent color table for multiple files. "
                                  "The palette file must be either a raster file in a GDAL supported format with a "
                                  "palette or a color file in a supported format (txt, qml, qlr).")
 

--- a/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
+++ b/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
@@ -171,7 +171,7 @@ class PCT2RGB(GDALScript):
                             help="Band to convert to RGB, defaults to 1.")
 
         parser.add_argument("-pct", dest='pct_filename', type=str,
-                            help="Extract the color table from <palette_file> instead of computing it. "
+                            help="Extract the color table from <palette_file> instead of getting it from <source_file>. "
                                  "Can be used to have a consistent color table for multiple files. "
                                  "The palette file must be either a raster file in a GDAL supported format with a "
                                  "palette or a color file in a supported format (txt, qml, qlr).")

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -155,7 +155,7 @@ class RGB2PCT(GDALScript):
 
         group.add_argument("-pct", dest='pct_filename', type=str,
                            help="Extract the color table from <palette_file> instead of computing it. "
-                                "can be used to have a consistent color table for multiple files. "
+                                "Can be used to have a consistent color table for multiple files. "
                                 "The palette file must be either a raster file in a GDAL supported format with a "
                                 "palette or a color file in a supported format (txt, qml, qlr).")
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

- adds the `-pct` option description in the [`pct2rgb.py`](https://gdal.org/programs/pct2rgb.html) docs (fixes https://github.com/OSGeo/gdal/pull/4587#issuecomment-932778801)
- fixes a typo in the `-pct` option description of [`rgb2pct.py`](https://gdal.org/programs/rgb2pct.html)  docs
- fixes some typos in the `-pct` option help string of `pct2rgb.py` and `rgb2pct.py`