### PR TITLE
Docs: fix a typo in color-table option for gdal_calc

### DIFF
--- a/doc/source/programs/gdal_calc.rst
+++ b/doc/source/programs/gdal_calc.rst
@@ -90,7 +90,7 @@ but no projection checking is performed (unless projectionCheck option is used).
 
     GDAL format for output file.
 
-.. option:: color-table=<filename>
+.. option:: --color-table=<filename>
 
     Allows specifying a filename of a color table (or a ColorTable object) (with Palette Index interpretation) to be used for the output raster.
     Supported formats: txt (i.e. like gdaldem, but color names are not supported), qlr, qml (i.e. exported from QGIS)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes a typo in color-table option string for gdal_calc.py docs: modify option string from `color-table` to `--color-table`.
See https://github.com/OSGeo/gdal/blob/1c5bc766513c4407f702bd8cd8bfa958ed61cfea/swig/python/gdal-utils/osgeo_utils/gdal_calc.py#L673