### PR TITLE
CMake: Use netcdf config

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -582,7 +582,7 @@ gdal_check_package(KEA "Enable KEA driver" CAN_DISABLE)
 
 gdal_check_package(ECW "Enable ECW driver" CAN_DISABLE)
 gdal_check_package(NetCDF "Enable netCDF driver" CAN_DISABLE
-  # NAMES netCDF # Cf. https://github.com/OSGeo/gdal/pull/5453
+  NAMES netCDF
   TARGETS netCDF::netcdf NETCDF::netCDF)
 gdal_check_package(OGDI "Enable ogr_OGDI driver" CAN_DISABLE)
 # OpenCL warping gives different results than the ones expected by autotest, so disable it by default even if found.


### PR DESCRIPTION
## What does this PR do?

This PR enables using netcdf's exported CMake config.
This allows to handle transitive usage requirements, and it saves expensive tests for feature detection.
Fixes #5452.

## What are related issues/pull requests?

Depends on #5450.
~Blocked by https://github.com/msys2/MINGW-packages/issues/10993~

## Tasklist

 - [x] Wait for fix to msys2 netcdf package.
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed
