### PR TITLE
GTIFF SRS reading: avoid warnings due to previous fix for #5399 and other fixes

### DIFF
--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -88,7 +88,9 @@ def test_srs_write_compd_cs():
 
     gdal.SetConfigOption('GTIFF_REPORT_COMPD_CS', 'YES')
     ds = gdal.Open('/vsimem/tiff_srs_compd_cs.tif')
+    gdal.ErrorReset()
     wkt = ds.GetProjectionRef()
+    assert gdal.GetLastErrorMsg() == ''
     gdal.SetConfigOption('GTIFF_REPORT_COMPD_CS', None)
     sr2 = osr.SpatialReference()
     sr2.SetFromUserInput(wkt)
@@ -939,3 +941,58 @@ def test_tiff_srs_read_inconsistent_invflattening():
     assert srs.GetAuthorityCode(None) == '28992'
     assert srs.GetAuthorityCode('GEOGCS') == '4289'
     assert srs.GetInvFlattening() == pytest.approx(299.1528128, abs=1e-7) #  Bessel 1841 official definition
+
+
+def test_tiff_srs_dynamic_geodetic_crs():
+
+    if osr.GetPROJVersionMajor() < 8:
+        pytest.skip()
+
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(8999) # ITRF2008
+    ds = gdal.GetDriverByName('GTiff').Create(
+        '/vsimem/test_tiff_srs_dynamic_geodetic_crs.tif', 1, 1)
+    ds.SetSpatialRef(srs)
+    ds = None
+    ds = gdal.Open('/vsimem/test_tiff_srs_dynamic_geodetic_crs.tif')
+    gdal.ErrorReset()
+    srs = ds.GetSpatialRef()
+    assert gdal.GetLastErrorMsg() == '', srs.ExportToWkt(['FORMAT=WKT2_2019'])
+    assert srs.GetAuthorityCode(None) == '8999'
+    ds = None
+    gdal.Unlink('/vsimem/test_tiff_srs_dynamic_geodetic_crs.tif')
+
+
+@pytest.mark.parametrize('geotiff_version', ['1.0', '1.1'])
+def test_tiff_srs_geographic_crs_3D(geotiff_version):
+
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4959) # NZGD2000 3D
+    ds = gdal.GetDriverByName('GTiff').Create('/vsimem/test_tiff_srs_geographic_crs_3D.tif', 1, 1,
+        options = ['GEOTIFF_VERSION=' + geotiff_version])
+    ds.SetSpatialRef(srs)
+    ds = None
+    ds = gdal.Open('/vsimem/test_tiff_srs_geographic_crs_3D.tif')
+    gdal.ErrorReset()
+    srs = ds.GetSpatialRef()
+    assert gdal.GetLastErrorMsg() == '', srs.ExportToWkt(['FORMAT=WKT2_2019'])
+    if geotiff_version == '1.1':
+        assert srs.GetAuthorityCode(None) == '4959'
+    ds = None
+    gdal.Unlink('/vsimem/test_tiff_srs_geographic_crs_3D.tif')
+
+
+def test_tiff_srs_datum_name_with_space():
+
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4312) # MGI with datum name = 'Militar-Geographische Institut""
+    ds = gdal.GetDriverByName('GTiff').Create('/vsimem/test_tiff_srs_datum_name_with_space.tif', 1, 1)
+    ds.SetSpatialRef(srs)
+    ds = None
+    ds = gdal.Open('/vsimem/test_tiff_srs_datum_name_with_space.tif')
+    gdal.ErrorReset()
+    srs = ds.GetSpatialRef()
+    assert gdal.GetLastErrorMsg() == '', srs.ExportToWkt(['FORMAT=WKT2_2019'])
+    assert srs.GetAuthorityCode(None) == '4312'
+    ds = None
+    gdal.Unlink('/vsimem/test_tiff_srs_datum_name_with_space.tif')

--- a/frmts/gtiff/libgeotiff/geo_normalize.c
+++ b/frmts/gtiff/libgeotiff/geo_normalize.c
@@ -845,6 +845,7 @@ int GTIFGetDatumInfoEx( void* ctxIn,
     {
         char szCode[12];
         PJ* datum;
+        PJ_TYPE pjType;
 
         sprintf(szCode, "%d", nDatumCode);
         datum = proj_create_from_database(
@@ -854,7 +855,9 @@ int GTIFGetDatumInfoEx( void* ctxIn,
             return FALSE;
         }
 
-        if( proj_get_type(datum) != PJ_TYPE_GEODETIC_REFERENCE_FRAME )
+        pjType = proj_get_type(datum);
+        if( pjType != PJ_TYPE_GEODETIC_REFERENCE_FRAME &&
+            pjType != PJ_TYPE_DYNAMIC_GEODETIC_REFERENCE_FRAME )
         {
             proj_destroy(datum);
             return FALSE;


### PR DESCRIPTION
Avoid erroneous new warnings
"The definition of geographic CRS EPSG:%d got from GeoTIFF keys "
"is not the same as the one from the EPSG registry, "
"which may cause issues during reprojection operations. "

- do not massage datum name to WKT1 (avoid warnings with datum names
  that have spaces)
- do not try to compare when the datum is dynamic
- do not try to compare when the code is of a geographic 3D CRS.

Other issues fixed during investigation:
- Fix handling of prime meridian with units != degree
- Internal libgeotiff: fix import of dynamic datum.
