### PR TITLE
CI: Cancel PR and branch workflows on new push

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,6 +8,10 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   android_build:

--- a/.github/workflows/android_cmake.yml
+++ b/.github/workflows/android_cmake.yml
@@ -8,6 +8,10 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   android_cmake_build:

--- a/.github/workflows/asan_build.yml
+++ b/.github/workflows/asan_build.yml
@@ -8,6 +8,10 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   asan_build:

--- a/.github/workflows/clang_static_analyzer.yml
+++ b/.github/workflows/clang_static_analyzer.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/cmake-lint.yml
+++ b/.github/workflows/cmake-lint.yml
@@ -2,6 +2,10 @@ name: Lint CMakeLists.txt
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cmake-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -10,6 +10,10 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   CMAKE_UNITY_BUILD: OFF
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -8,6 +8,10 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   cppcheck_2004:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -2,6 +2,10 @@ name: Docs
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     name: Docs

--- a/.github/workflows/fedora_rawhide.yml
+++ b/.github/workflows/fedora_rawhide.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/mingw_w64.yml
+++ b/.github/workflows/mingw_w64.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/ubuntu_18.04.yml
+++ b/.github/workflows/ubuntu_18.04.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/ubuntu_18.04_32bit.yml
+++ b/.github/workflows/ubuntu_18.04_32bit.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/ubuntu_20.04.yml
+++ b/.github/workflows/ubuntu_20.04.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/validate_xml.yml
+++ b/.github/workflows/validate_xml.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate_xml:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -8,6 +8,9 @@ on:
         paths-ignore:
             - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
## What does this PR do?

This change to the workflows cancel CI runs for a branch or PR when a new push is made to the same target. Typically, this happens when a contributor notices a defect after one push, locally or by a fast CI jobs (e.g. CMake Lint) and pushes a fix while the long-running workflows are still in progress.

This a common behaviour in other CIs, but needs extra activation in GH Actions. It frees runners from obsolete workload, making them available for running new jobs.

Upsides: This also affects the additional workflows in forks.

Downsides: A notification is sent for each canceled workflow. GDAL has many of them...

References: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Disclaimer: I'm not an expert on GH Actions.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

![Unbenannt](https://user-images.githubusercontent.com/13567791/158765059-daad32f5-ddb5-4a07-802a-0a8c0b4eaaef.png)
