### PR TITLE
CPLLoadConfigOptionsFromFile(): add a [credentials] section to load VSI credentials

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -3084,6 +3084,9 @@ namespace tut
         CPLLoadConfigOptionsFromFile("/i/do/not/exist", false);
 
         VSILFILE* fp = VSIFOpenL("/vsimem/.gdal/gdalrc", "wb");
+        VSIFPrintfL(fp, "# some comment\n");
+        VSIFPrintfL(fp, "\n"); // blank line
+        VSIFPrintfL(fp, "  \n"); // blank line
         VSIFPrintfL(fp, "[configoptions]\n");
         VSIFPrintfL(fp, "# some comment\n");
         VSIFPrintfL(fp, "FOO_CONFIGOPTION=BAR\n");
@@ -3530,4 +3533,140 @@ namespace tut
         CPLFree(pRawData);
         VSIFCloseL(fp);
     }
+
+    // Test CPLLoadConfigOptionsFromFile() for VSI credentials
+    template<>
+    template<>
+    void object::test<51>()
+    {
+        VSILFILE* fp = VSIFOpenL("/vsimem/credentials.txt", "wb");
+        VSIFPrintfL(fp, "[credentials]\n");
+        VSIFPrintfL(fp, "\n");
+        VSIFPrintfL(fp, "[.my_subsection]\n");
+        VSIFPrintfL(fp, "path=/vsi_test/foo/bar\n");
+        VSIFPrintfL(fp, "FOO=BAR\n");
+        VSIFPrintfL(fp, "FOO2=BAR2\n");
+        VSIFPrintfL(fp, "\n");
+        VSIFPrintfL(fp, "[.my_subsection2]\n");
+        VSIFPrintfL(fp, "path=/vsi_test/bar/baz\n");
+        VSIFPrintfL(fp, "BAR=BAZ\n");
+        VSIFPrintfL(fp, "[configoptions]\n");
+        VSIFPrintfL(fp, "configoptions_FOO=BAR\n");
+        VSIFCloseL(fp);
+
+        CPLErrorReset();
+        CPLLoadConfigOptionsFromFile("/vsimem/credentials.txt", false);
+        ensure_equals(CPLGetLastErrorType(), CE_None);
+
+        {
+            const char* pszVal = VSIGetCredential("/vsi_test/foo/bar", "FOO", nullptr);
+            ensure(pszVal != nullptr);
+            ensure_equals(std::string(pszVal), std::string("BAR"));
+        }
+
+        {
+            const char* pszVal = VSIGetCredential("/vsi_test/foo/bar", "FOO2", nullptr);
+            ensure(pszVal != nullptr);
+            ensure_equals(std::string(pszVal), std::string("BAR2"));
+        }
+
+        {
+            const char* pszVal = VSIGetCredential("/vsi_test/bar/baz", "BAR", nullptr);
+            ensure(pszVal != nullptr);
+            ensure_equals(std::string(pszVal), std::string("BAZ"));
+        }
+
+        {
+            const char* pszVal = CPLGetConfigOption("configoptions_FOO", nullptr);
+            ensure(pszVal != nullptr);
+            ensure_equals(std::string(pszVal), std::string("BAR"));
+        }
+
+        VSIClearCredentials("/vsi_test");
+        CPLSetConfigOption("configoptions_FOO", nullptr);
+
+        {
+            const char* pszVal = VSIGetCredential("/vsi_test/bar/baz", "BAR", nullptr);
+            ensure(pszVal == nullptr);
+        }
+
+        VSIUnlink("/vsimem/credentials.txt");
+    }
+
+    // Test CPLLoadConfigOptionsFromFile() for VSI credentials, warning case
+    template<>
+    template<>
+    void object::test<52>()
+    {
+        VSILFILE* fp = VSIFOpenL("/vsimem/credentials.txt", "wb");
+        VSIFPrintfL(fp, "[credentials]\n");
+        VSIFPrintfL(fp, "\n");
+        VSIFPrintfL(fp, "FOO=BAR\n"); // content outside of subsection
+        VSIFCloseL(fp);
+
+        CPLErrorReset();
+        CPLPushErrorHandler(CPLQuietErrorHandler);
+        CPLLoadConfigOptionsFromFile("/vsimem/credentials.txt", false);
+        CPLPopErrorHandler();
+        ensure_equals(CPLGetLastErrorType(), CE_Warning);
+
+
+        VSIUnlink("/vsimem/credentials.txt");
+    }
+
+    // Test CPLLoadConfigOptionsFromFile() for VSI credentials, warning case
+    template<>
+    template<>
+    void object::test<53>()
+    {
+        VSILFILE* fp = VSIFOpenL("/vsimem/credentials.txt", "wb");
+        VSIFPrintfL(fp, "[credentials]\n");
+        VSIFPrintfL(fp, "[.subsection]");
+        VSIFPrintfL(fp, "FOO=BAR\n"); // first key is not 'path'
+        VSIFCloseL(fp);
+
+        CPLErrorReset();
+        CPLPushErrorHandler(CPLQuietErrorHandler);
+        CPLLoadConfigOptionsFromFile("/vsimem/credentials.txt", false);
+        CPLPopErrorHandler();
+        ensure_equals(CPLGetLastErrorType(), CE_Warning);
+
+
+        VSIUnlink("/vsimem/credentials.txt");
+    }
+
+    // Test CPLLoadConfigOptionsFromFile() for VSI credentials, warning case
+    template<>
+    template<>
+    void object::test<54>()
+    {
+        VSILFILE* fp = VSIFOpenL("/vsimem/credentials.txt", "wb");
+        VSIFPrintfL(fp, "[credentials]\n");
+        VSIFPrintfL(fp, "[.subsection]");
+        VSIFPrintfL(fp, "path=/vsi_test/foo\n");
+        VSIFPrintfL(fp, "path=/vsi_test/bar\n"); // duplicated path
+        VSIFPrintfL(fp, "FOO=BAR\n"); // first key is not 'path'
+        VSIFPrintfL(fp, "[unrelated_section]");
+        VSIFPrintfL(fp, "BAR=BAZ\n"); // first key is not 'path'
+        VSIFCloseL(fp);
+
+        CPLErrorReset();
+        CPLPushErrorHandler(CPLQuietErrorHandler);
+        CPLLoadConfigOptionsFromFile("/vsimem/credentials.txt", false);
+        CPLPopErrorHandler();
+        ensure_equals(CPLGetLastErrorType(), CE_Warning);
+
+        {
+            const char* pszVal = VSIGetCredential("/vsi_test/foo", "FOO", nullptr);
+            ensure(pszVal != nullptr);
+        }
+
+        {
+            const char* pszVal = VSIGetCredential("/vsi_test/foo", "BAR", nullptr);
+            ensure(pszVal == nullptr);
+        }
+
+        VSIUnlink("/vsimem/credentials.txt");
+    }
+
 } // namespace tut

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -66,6 +66,8 @@ For boolean options, the values YES, TRUE or ON can be used to turn the option o
 NO, FALSE or OFF to turn it off.
 
 
+.. _gdal_configuration_file:
+
 GDAL configuration file
 -----------------------
 

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -152,10 +152,33 @@ Cloud storage services require setting credentials. For some of them, they can
 be provided through configuration files (~/.aws/config, ~/.boto, ..) or through
 environment variables / configuration options.
 
-Starting with GDAL 3.5, :cpp:func:`VSISetCredential` can also be used to set configuration
+Starting with GDAL 3.5, :cpp:func:`VSISetCredential` can be used to set configuration
 options with a granularity at the level of a file path, which makes it easier if using
 the same virtual file system but with different credentials (e.g. different
 credentials for bucket "/vsis3/foo" and "/vsis3/bar")
+
+Starting with GDAL 3.5, credentials can be specified in a
+:ref:`GDAL configuration file <gdal_configuration_file>`, either in a specific one
+explicitly loaded with :cpp:func:`CPLLoadConfigOptionsFromFile`, or
+one of the default automatically loaded by :cpp:func:`CPLLoadConfigOptionsFromPredefinedFiles`.
+
+They should be put under a ``[credentials]`` section, and for each path prefix,
+under a relative subsection whose name starts with ``[.`` (e.g. ``[.some_arbitrary_name]``),
+and whose first key is ``path``.
+`
+.. code-block::
+
+    [credentials]
+
+    [.private_bucket]
+    path=/vsis3/my_private_bucket
+    AWS_SECRET_ACCESS_KEY=...
+    AWS_ACCESS_KEY_ID=...
+
+    [.sentinel_s2_l1c]
+    path=/vsis3/sentinel-s2-l1c
+    AWS_REQUEST_PAYER=requester
+
 
 .. _vsicurl:
 

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -1995,24 +1995,45 @@ void CPL_STDCALL CPLFreeConfig()
 /************************************************************************/
 
 /** Load configuration from a given configuration file.
- *
- * A configuration file is a text file in a .ini style format, that lists
- * configuration options and their values.
- * Lines starting with # are comment lines.
- *
- * Example:
- * <pre>
- * [configoptions]
- * # set BAR as the value of configuration option FOO
- * FOO=BAR
- * </pre>
- *
- * This function is typically called by CPLLoadConfigOptionsFromPredefinedFiles()
- *
- * @param pszFilename File where to load configuration from.
- * @param bOverrideEnvVars Whether configuration options from the configuration
- *                         file should override environment variables.
- * @since GDAL 3.3
+
+A configuration file is a text file in a .ini style format, that lists
+configuration options and their values.
+Lines starting with # are comment lines.
+
+Example:
+\verbatim
+[configoptions]
+# set BAR as the value of configuration option FOO
+FOO=BAR
+\endverbatim
+
+Starting with GDAL 3.5, a configuration file can also contain credentials
+(or more generally options related to a virtual file system) for a given path prefix,
+that can also be set with VSISetCredential(). Credentials should be put under
+a [credentials] section, and for each path prefix, under a relative subsection
+whose name starts with "[." (e.g. "[.some_arbitrary_name]"), and whose first
+key is "path".
+
+Example:
+\verbatim
+[credentials]
+
+[.private_bucket]
+path=/vsis3/my_private_bucket
+AWS_SECRET_ACCESS_KEY=...
+AWS_ACCESS_KEY_ID=...
+
+[.sentinel_s2_l1c]
+path=/vsis3/sentinel-s2-l1c
+AWS_REQUEST_PAYER=requester
+\endverbatim
+
+This function is typically called by CPLLoadConfigOptionsFromPredefinedFiles()
+
+@param pszFilename File where to load configuration from.
+@param bOverrideEnvVars Whether configuration options from the configuration
+                        file should override environment variables.
+@since GDAL 3.3
  */
 void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
 {
@@ -2022,19 +2043,98 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
     CPLDebug("CPL", "Loading configuration from %s", pszFilename);
     const char* pszLine;
     bool bInConfigOptions = false;
+    bool bInCredentials = false;
+    bool bInSubsection = false;
+    std::string osPath;
+
+    const auto IsSpaceOnly = [](const char* pszStr)
+    {
+        for(; *pszStr; ++pszStr)
+        {
+            if( !isspace(*pszStr) )
+                return false;
+        }
+        return true;
+    };
+
     while( (pszLine = CPLReadLine2L(fp, -1, nullptr)) != nullptr )
     {
-        if( pszLine[0] == '#' )
+        if( IsSpaceOnly(pszLine) )
+        {
+            // Blank line
+        }
+        else if( pszLine[0] == '#' )
         {
             // Comment line
         }
         else if( strcmp(pszLine, "[configoptions]") == 0 )
         {
             bInConfigOptions = true;
+            bInCredentials = false;
+        }
+        else if( strcmp(pszLine, "[credentials]") == 0 )
+        {
+            bInConfigOptions = false;
+            bInCredentials = true;
+            bInSubsection = false;
+            osPath.clear();
+        }
+        else if( bInCredentials )
+        {
+            if( strncmp(pszLine, "[.", 2) == 0 )
+            {
+                bInSubsection = true;
+                osPath.clear();
+            }
+            else if( bInSubsection )
+            {
+                char* pszKey = nullptr;
+                const char* pszValue = CPLParseNameValue(pszLine, &pszKey);
+                if( pszKey && pszValue )
+                {
+                    if( strcmp(pszKey, "path") == 0 )
+                    {
+                        if( !osPath.empty() )
+                        {
+                            CPLError(CE_Warning, CPLE_AppDefined,
+                                     "Duplicated 'path' key in the same subsection. "
+                                     "Ignoring %s=%s",
+                                     pszKey, pszValue);
+                        }
+                        else
+                        {
+                            osPath = pszValue;
+                        }
+                    }
+                    else if( osPath.empty() )
+                    {
+                        CPLError(CE_Warning, CPLE_AppDefined,
+                                 "First entry in a credentials subsection "
+                                 "should be 'path'.");
+                    }
+                    else
+                    {
+                        VSISetCredential(osPath.c_str(), pszKey, pszValue);
+                    }
+                }
+                CPLFree(pszKey);
+            }
+            else if( pszLine[0] == '[' )
+            {
+                bInConfigOptions = false;
+                bInCredentials = false;
+            }
+            else
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Ignoring content in [credential] section that is not "
+                         "in a [.xxxxx] subsection");
+            }
         }
         else if( pszLine[0] == '[' )
         {
             bInConfigOptions = false;
+            bInCredentials = false;
         }
         else if( bInConfigOptions )
         {


### PR DESCRIPTION
Extract from doc
```
Starting with GDAL 3.5, credentials can be specified in a
:ref:`GDAL configuration file <gdal_configuration_file>`, either in a specific one
explicitly loaded with :cpp:func:`CPLLoadConfigOptionsFromFile`, or
one of the default automatically loaded by :cpp:func:`CPLLoadConfigOptionsFromPredefinedFiles`.

They should be put under a ``[credentials]`` section, and for each path prefix,
under a relative subsection whose name starts with ``[.`` (e.g. ``[.some_arbitrary_name]``),
and whose first key is ``path``.
`
.. code-block::

    [credentials]

    [.private_bucket]
    path=/vsis3/my_private_bucket
    AWS_SECRET_ACCESS_KEY=...
    AWS_ACCESS_KEY_ID=...

    [.sentinel_s2_l1c]
    path=/vsis3/sentinel-s2-l1c
    AWS_REQUEST_PAYER=requester
```