### PR TITLE
gdalwarp: fix issue with vertical shift mode when only one of the CRS is 3D, with PROJ 9.1

### DIFF
--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -2149,6 +2149,12 @@ GDALCreateGenImgProjTransformer2( GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
             InsertCenterLong( hSrcDS, &oSrcSRS, aosOptions );
         }
 
+        if( CPLFetchBool(papszOptions, "PROMOTE_TO_3D", false) )
+        {
+            oSrcSRS.PromoteTo3D(nullptr);
+            oDstSRS.PromoteTo3D(nullptr);
+        }
+
         if( !(dfWestLongitudeDeg == 0.0 && dfSouthLatitudeDeg == 0.0 &&
               dfEastLongitudeDeg == 0.0 && dfNorthLatitudeDeg == 0.0) )
         {

--- a/autotest/alg/applyverticalshiftgrid.py
+++ b/autotest/alg/applyverticalshiftgrid.py
@@ -295,7 +295,8 @@ def test_applyverticalshiftgrid_6():
     grid_ds = None
 
     ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM',
-                   dstSRS='+proj=utm +zone=11 +datum=NAD27 +geoidgrids=./tmp/applyverticalshiftgrid_6.gtx +vunits=m +no_defs')
+                   srcSRS='EPSG:32611',
+                   dstSRS='+proj=utm +zone=11 +datum=WGS84 +geoidgrids=./tmp/applyverticalshiftgrid_6.gtx +vunits=m +no_defs')
     cs = ds.GetRasterBand(1).Checksum()
     assert cs == 4783
 
@@ -314,7 +315,8 @@ def test_applyverticalshiftgrid_7():
     grid_ds = None
 
     ds = gdal.Warp('', '../gcore/data/byte.tif', format='MEM',
-                   dstSRS='+proj=utm +zone=11 +datum=NAD27 +geoidgrids=./tmp/applyverticalshiftgrid_7.gtx +vunits=m +no_defs')
+                   srcSRS='EPSG:32611',
+                   dstSRS='+proj=utm +zone=11 +datum=WGS84 +geoidgrids=./tmp/applyverticalshiftgrid_7.gtx +vunits=m +no_defs')
     cs = ds.GetRasterBand(1).Checksum()
     assert cs == 4783
 


### PR DESCRIPTION
Due to change https://github.com/OSGeo/PROJ/pull/3119
