### PR TITLE
CI: Disable CMake Lint job, not task

### DIFF
--- a/.github/workflows/cmake-lint.yml
+++ b/.github/workflows/cmake-lint.yml
@@ -8,6 +8,8 @@ concurrency:
 
 jobs:
   cmake-lint:
+    # Disabled because of https://github.com/OSGeo/gdal/pull/5326#issuecomment-1042617407
+    if: false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -20,6 +22,5 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install cmake-format pyyaml
-    # Disabled because of https://github.com/OSGeo/gdal/pull/5326#issuecomment-1042617407
-    #- name: Check cmakelist
-    #  run: find . -name CMakeLists.txt |xargs cmake-format --check
+    - name: Check cmakelist
+      run: find . -name CMakeLists.txt |xargs cmake-format --check


### PR DESCRIPTION
## What does this PR do?

Another small cleanup. Unless you want to remove this workflow entirely.
