### PR TITLE
GTiff: avoid hang when trying to create a larger than 4GB classic TIFF, and switch to BigTIFF before that happens

### DIFF
--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -16908,8 +16908,12 @@ TIFF *GTiffDataset::CreateLL( const char * pszFilename,
 /* -------------------------------------------------------------------- */
 /*      Compute the uncompressed size.                                  */
 /* -------------------------------------------------------------------- */
+    const unsigned nTileXCount = bTiled ? DIV_ROUND_UP(nXSize, l_nBlockXSize) : 0;
+    const unsigned nTileYCount = bTiled ? DIV_ROUND_UP(nYSize, l_nBlockYSize) : 0;
     const double dfUncompressedImageSize =
-        nXSize * static_cast<double>(nYSize) * l_nBands *
+        (bTiled ? (static_cast<double>(nTileXCount) * nTileYCount * l_nBlockXSize * l_nBlockYSize) :
+                  (nXSize * static_cast<double>(nYSize))) *
+        l_nBands *
         GDALGetDataTypeSizeBytes(eType)
         + dfExtraSpaceForOverviews;
 
@@ -16954,8 +16958,6 @@ TIFF *GTiffDataset::CreateLL( const char * pszFilename,
 /* -------------------------------------------------------------------- */
     if( bTiled )
     {
-        unsigned nTileXCount = DIV_ROUND_UP(nXSize, l_nBlockXSize);
-        unsigned nTileYCount = DIV_ROUND_UP(nYSize, l_nBlockYSize);
         // libtiff implementation limitation
         if( nTileXCount > 0x80000000U / (bCreateBigTIFF ? 8 : 4) / nTileYCount )
         {

--- a/frmts/gtiff/libtiff/tif_dirwrite.c
+++ b/frmts/gtiff/libtiff/tif_dirwrite.c
@@ -300,6 +300,12 @@ TIFFRewriteDirectory( TIFF *tif )
 				return (0);
 			}
 		}
+		else if( tif->tif_diroff > 0xFFFFFFFFU )
+		{
+			TIFFErrorExt(tif->tif_clientdata, module,
+			     "tif->tif_diroff exceeds 32 bit range allowed for Classic TIFF");
+			return (0);
+		}
 		else
 		{
 			uint32_t nextdir;


### PR DESCRIPTION
Fixes #5479