### PR TITLE
CMake: disable capability of building GRASS

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -638,6 +638,13 @@ if (GDAL_USE_OPENJPEG)
   string(APPEND GDAL_IMPORT_DEPENDENCIES "find_dependency(OpenJPEG MODULE)\n")
 endif ()
 
+# FIXME: we should probably ultimately move the GRASS driver to an
+# external repository, due to GRASS depending on GDAL, hence the GRASS driver
+# can only be built as a plugin. Or at the very least we should only allow building
+# it as a plugin, and have a GDAL_USE_GRASS variable to control if libgrass should
+# be used (and change frmts/CMakeLists.txt and ogr/ogrsf_frmts/CMakeLists.txt
+# to use it instead of HAVE_GRASS)
+if( ALLOW_GRASS_DRIVER )
 # Only GRASS 7 is currently supported but we keep dual version support in cmake for possible future switch to GRASS 8.
 set(TMP_GRASS OFF)
 foreach (GRASS_SEARCH_VERSION 7)
@@ -664,6 +671,7 @@ else ()
       CACHE INTERNAL "HAVE_GRASS")
 endif ()
 unset(TMP_GRASS)
+endif ()
 
 gdal_check_package(HDFS "Enable Hadoop File System through native library" CAN_DISABLE)
 


### PR DESCRIPTION
We should probably ultimately move the GRASS driver to an
external repository, due to GRASS depending on GDAL, hence the GRASS driver
can only be built as a plugin. Or at the very least we should only allow building
it as a plugin, and have a GDAL_USE_GRASS variable to control if libgrass should
be used (and change frmts/CMakeLists.txt and ogr/ogrsf_frmts/CMakeLists.txt
to use it instead of HAVE_GRASS)

CC @sebastic 