### PR TITLE
Mkgdaldist portability

### DIFF
--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -92,17 +92,41 @@ Perl module maintainer to make a CPAN release.
 
 8) Prepare archives
 
+8.0) Ensure you have the following prerequisites (beyond normal build deps):
+
+   If make is not GNU make, e.g., export MAKE=gmake
+
+   doxygen
+
+   python available as "python", or e.g. export PYTHON=python3.9
+
+   python3 available as "python3" in path (export PYTHON=python3.9
+   partially works, but some scripts under doc have hardcoded python3)
+
+   sphinx-build in path, or e.g. export SPHINXBUILD=sphinx-build-3.9
+
+   breathe extension for sphinx
+
+   swig 4 in path as "swig"
+
+   md5sum (GNU version) in path (not a POSIX requirement)
+
 8.1) Create the source distributions using the mkgdaldist.sh script.
    The argument should be the version number (i.e. 1.4.2). As our process involves
    doing betas or RCs, use the -rc option so that the filenames include this
    information (after promotion to official release, filename renaming will have
    to be done)
 
-   % mkgdaldist.sh 3.1.0 -tag v3.1.0RC1 -rc rc1
+   % ./mkgdaldist.sh 3.1.0 -tag v3.1.0RC1 -rc rc1
 
    For a beta version:
 
-   % mkgdaldist.sh 3.1.0beta1 -tag v3.1.0beta1
+   % ./mkgdaldist.sh 3.1.0beta1 -tag v3.1.0beta1
+
+   For a version intended for testing packaging (and not for
+   distribution):
+
+   % ./mkgdaldist.sh 3.4.80 -tag master
 
    It might be useful to compare the content of the generated tarball, with
    a previous release (diff -Nur gdal-3.0.1 gdal-3.0.2).

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,8 +2,9 @@
 #
 
 # You can set these variables from the command line.
+PYTHON        ?= python3
 SPHINXOPTS    ?= --keep-going -j auto -W
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
@@ -26,9 +27,9 @@ help:
 	touch .doxygen_up_to_date
 
 generated_rst_files: .doxygen_up_to_date
-	python3 "$(SOURCEDIR)/build_driver_summary.py" "$(SOURCEDIR)/drivers/raster" raster_driver_summary "$(SOURCEDIR)/drivers/raster/driver_summary.rst"
-	python3 "$(SOURCEDIR)/build_driver_summary.py" "$(SOURCEDIR)/drivers/vector" vector_driver_summary "$(SOURCEDIR)/drivers/vector/driver_summary.rst"
-	python3 "$(SOURCEDIR)/build_configoptions_index.py"  "$(SOURCEDIR)" "$(SOURCEDIR)/user/configoptions_index_generated.rst"
+	$(PYTHON) "$(SOURCEDIR)/build_driver_summary.py" "$(SOURCEDIR)/drivers/raster" raster_driver_summary "$(SOURCEDIR)/drivers/raster/driver_summary.rst"
+	$(PYTHON) "$(SOURCEDIR)/build_driver_summary.py" "$(SOURCEDIR)/drivers/vector" vector_driver_summary "$(SOURCEDIR)/drivers/vector/driver_summary.rst"
+	$(PYTHON) "$(SOURCEDIR)/build_configoptions_index.py"  "$(SOURCEDIR)" "$(SOURCEDIR)/user/configoptions_index_generated.rst"
 
 .PHONY: html latexpdf
 html: generated_rst_files

--- a/mkgdaldist.sh
+++ b/mkgdaldist.sh
@@ -6,8 +6,16 @@
 
 set -eu
 
+if [ "$MAKE" = "" ]; then
+    MAKE="make"
+fi
+
+if [ "$PYTHON" = "" ]; then
+    PYTHON="python3"
+fi
+
 # Doxygen 1.7.1 has a bug related to man pages. See https://trac.osgeo.org/gdal/ticket/6048
-doxygen --version | xargs python -c "import sys; v = sys.argv[1].split('.'); v=int(v[0])*10000+int(v[1])*100+int(v[2]); sys.exit(v < 10704)"
+doxygen --version | xargs ${PYTHON} -c "import sys; v = sys.argv[1].split('.'); v=int(v[0])*10000+int(v[1])*100+int(v[2]); sys.exit(v < 10704)"
 rc=$?
 if test $rc != 0; then
     echo "Wrong Doxygen version. 1.7.4 or later required"
@@ -191,7 +199,7 @@ CWD=${PWD}
 
 rm -f swig/perl/*wrap*
 touch GDALmake.opt
-(cd swig/perl && make generate)
+(cd swig/perl && ${MAKE} generate)
 rm GDALmake.opt
 
 #
@@ -220,7 +228,7 @@ zip -qr "../gdalautotest-${GDAL_VERSION}${RC}.zip" "gdalautotest-${GDAL_VERSION}
 cd "gdal-${GDAL_VERSION}"
 echo "GDAL_VER=${GDAL_VERSION}" > GDALmake.opt
 cd frmts/grass
-make dist
+${MAKE} dist
 mv ./*.tar.gz ../../../..
 cd ../../..
 


### PR DESCRIPTION
## What does this PR do?

This PR adds documentation to mkgdaldist.sh and makes minor, low-risk, portability improvements to enable it to run on NetBSD.

## What are related issues/pull requests?

None - was discussed on gdal-dev@ and mkgdaldist was the suggestion for preparing releases to test cmake with in packaging.

## Tasklist

 - [ ] Add test case(s):
 - [ x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

There aren't any mkgdaldist tests, but ithis branch builds a tarball on NetBSD, and then I can build a gdal-3.5.0.dev package from that under pkgsrc, and that passes all but a handful of tests.

Happy to edit/rebase as requested - this is my first gdal PR.

## Environment

Provide environment details, if relevant:

* OS: NetBSD 9 amd64
* python 3.9, swig4
