### PR TITLE
OGR SOSI driver: catch segfault with invalid point geometries

### DIFF
--- a/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
@@ -315,6 +315,12 @@ OGRFeature *OGRSOSILayer::GetNextFeature() {
         case L_PUNKT: {  /* point */
             oGType = wkbPoint;
             OGRPoint *poPoint = poParent->papoBuiltGeometries[oNextSerial.lNr]->toPoint();
+            if (poPoint == nullptr) {
+                // This should not happen under normal operation but may occur with invalid geometries.
+                CPLError( CE_Warning, CPLE_AppDefined, "Point %li may have a broken geometry", oNextSerial.lNr);
+                //return NULL;
+                break;
+            }
             poGeom = poPoint->clone();
             break;
         }

--- a/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
@@ -297,7 +297,7 @@ OGRFeature *OGRSOSILayer::GetNextFeature() {
         case L_BUEP:  {  /* curve, interpolated from circular arc */
             oGType = wkbLineString;
             if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr ||
-                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbLineString )) {
+                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbLineString ) {
                 // This should not happen under normal operation.
                 CPLError( CE_Warning, CPLE_AppDefined, "Curve or line %li may have a broken geometry", oNextSerial.lNr);
                 //return NULL;

--- a/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
@@ -314,13 +314,13 @@ OGRFeature *OGRSOSILayer::GetNextFeature() {
         }
         case L_PUNKT: {  /* point */
             oGType = wkbPoint;
-            OGRPoint *poPoint = poParent->papoBuiltGeometries[oNextSerial.lNr]->toPoint();
-            if (poPoint == nullptr) {
-                // This should not happen under normal operation but may occur with invalid geometries.
+            if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr) {
+                // This should not happen under normal operation.
                 CPLError( CE_Warning, CPLE_AppDefined, "Point %li may have a broken geometry", oNextSerial.lNr);
                 //return NULL;
                 break;
             }
+            OGRPoint *poPoint = poParent->papoBuiltGeometries[oNextSerial.lNr]->toPoint();
             poGeom = poPoint->clone();
             break;
         }

--- a/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
@@ -327,7 +327,7 @@ OGRFeature *OGRSOSILayer::GetNextFeature() {
         case L_PUNKT: {  /* point */
             oGType = wkbPoint;
             if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr ||
-                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbPoint )) {
+                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbPoint ) {
                 // This should not happen under normal operation.
                 CPLError( CE_Warning, CPLE_AppDefined, "Point or symbol %li may have a broken geometry", oNextSerial.lNr);
                 //return NULL;

--- a/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
@@ -296,14 +296,26 @@ OGRFeature *OGRSOSILayer::GetNextFeature() {
         case L_LINJE:    /* curve, not simplifyable */
         case L_BUEP:  {  /* curve, interpolated from circular arc */
             oGType = wkbLineString;
-
+            if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr ||
+                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbLineString )) {
+                // This should not happen under normal operation.
+                CPLError( CE_Warning, CPLE_AppDefined, "Curve or line %li may have a broken geometry", oNextSerial.lNr);
+                //return NULL;
+                break;
+            }
             OGRLineString *poCurve = poParent->papoBuiltGeometries[oNextSerial.lNr]->toLineString();
             poGeom = poCurve->clone();
             break;
         }
         case L_TEKST: {  /* text */
             oGType = wkbMultiPoint;
-
+            if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr ||
+                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbMultiPoint )) {
+                // This should not happen under normal operation.
+                CPLError( CE_Warning, CPLE_AppDefined, "Text point %li may have a broken geometry", oNextSerial.lNr);
+                //return NULL;
+                break;
+            }
             OGRMultiPoint *poMP = poParent->papoBuiltGeometries[oNextSerial.lNr]->toMultiPoint();
             poGeom = poMP->clone();
             break;
@@ -314,9 +326,10 @@ OGRFeature *OGRSOSILayer::GetNextFeature() {
         }
         case L_PUNKT: {  /* point */
             oGType = wkbPoint;
-            if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr) {
+            if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr ||
+                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbPoint )) {
                 // This should not happen under normal operation.
-                CPLError( CE_Warning, CPLE_AppDefined, "Point %li may have a broken geometry", oNextSerial.lNr);
+                CPLError( CE_Warning, CPLE_AppDefined, "Point or symbol %li may have a broken geometry", oNextSerial.lNr);
                 //return NULL;
                 break;
             }

--- a/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosilayer.cpp
@@ -310,7 +310,7 @@ OGRFeature *OGRSOSILayer::GetNextFeature() {
         case L_TEKST: {  /* text */
             oGType = wkbMultiPoint;
             if (poParent->papoBuiltGeometries[oNextSerial.lNr] == nullptr ||
-                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbMultiPoint )) {
+                poParent->papoBuiltGeometries[oNextSerial.lNr]->getGeometryType() != wkbMultiPoint ) {
                 // This should not happen under normal operation.
                 CPLError( CE_Warning, CPLE_AppDefined, "Text point %li may have a broken geometry", oNextSerial.lNr);
                 //return NULL;


### PR DESCRIPTION
The OGR SOSI driver segfaults if a SOSI file contains an invalid point geometry definition (i.e. two rows with identical coordinate pairs).

This PR adds a warning for those cases and skips the duplicated point.
