### PR TITLE
GDAL GRASS driver: add rpath to Makefile.in

### DIFF
--- a/frmts/grass/pkg/Makefile.in
+++ b/frmts/grass/pkg/Makefile.in
@@ -34,10 +34,10 @@ distclean: clean
 
 
 $(GLIBNAME):	grass.o
-	$(LD_SHARED) $(LDFLAGS) grass.o $(LIBS) -o $(GLIBNAME)
+	$(LD_SHARED) $(LDFLAGS) grass.o $(LIBS) -o $(GLIBNAME) -Wl,-rpath,"@GRASS_GISBASE@/lib"
 
 $(OLIBNAME):	ogrgrassdriver.o ogrgrassdatasource.o ogrgrasslayer.o
-	$(LD_SHARED) $(LDFLAGS) ogrgrassdriver.o ogrgrassdatasource.o ogrgrasslayer.o $(LIBS) -o $(OLIBNAME)
+	$(LD_SHARED) $(LDFLAGS) ogrgrassdriver.o ogrgrassdatasource.o ogrgrasslayer.o $(LIBS) -o $(OLIBNAME) -Wl,-rpath,"@GRASS_GISBASE@/lib"
 
 %.o:	%.cpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
## What does this PR do?
Add `-Wl,-rpath,<path>` to Makefile.in of the GDAL GRASS driver. This is supposed to be a generic solution replacing the [Debian patch](https://salsa.debian.org/debian-gis-team/gdal-grass/-/commit/0192b0418e04d79678bdd5c4c377b8cece5e0939).

The reason for this PR, as well as the Debian patch, is that GRASS shared libraries are in a non-standard location that is usually not in the common list of directories with shared libraries, also not in `/etc/ld.so.conf.d/*` and not in `LD_LIBRARY_PATH`.