### PR TITLE
SENTINEL2: identify zipped S2 datasets from file content

### DIFF
--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -2417,57 +2417,52 @@ def test_sentinel2_l1c_safe_compact_3():
 
 def test_sentinel2_zipped():
     # S2 L1C
-    if not sys.platform.startswith("win"):
-        zipname = str(uuid.uuid4()) + ".zip"
-        with tempfile.TemporaryDirectory() as tmpdir:
-            zipwpath = os.path.join(tmpdir, zipname)
-            _zip_a_dir(zipwpath, "data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/")
-            assert os.path.exists(zipwpath)
-            ds = gdal.Open(zipwpath)
-            assert ds is not None
+    zipname = str(uuid.uuid4()) + ".zip"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zipwpath = os.path.join(tmpdir, zipname)
+        _zip_a_dir(zipwpath, "data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/")
+        assert os.path.exists(zipwpath)
+        ds = gdal.Open(zipwpath)
+        assert ds is not None
 
    # S2 L1B
-    if not sys.platform.startswith("win"):
-        zipname = str(uuid.uuid4()) + ".zip"
-        with tempfile.TemporaryDirectory() as tmpdir:
-            zipwpath = os.path.join(tmpdir, zipname)
-            _zip_a_dir(zipwpath, "data/sentinel2/fake_l1b/S2B_OPER_PRD_MSIL1B.SAFE/")
-            assert os.path.exists(zipwpath)
-            ds = gdal.Open(zipwpath)
-            assert ds is not None
+    zipname = str(uuid.uuid4()) + ".zip"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zipwpath = os.path.join(tmpdir, zipname)
+        _zip_a_dir(zipwpath, "data/sentinel2/fake_l1b/S2B_OPER_PRD_MSIL1B.SAFE/")
+        assert os.path.exists(zipwpath)
+        ds = gdal.Open(zipwpath)
+        assert ds is not None
 
     # S2 L1A
-    if not sys.platform.startswith("win"):
-        zipname = str(uuid.uuid4()) + ".zip"
-        with tempfile.TemporaryDirectory() as tmpdir:
-            zipwpath = os.path.join(tmpdir, zipname)
-            _zip_a_dir(zipwpath, "data/sentinel2/fake_l2a/S2A_USER_PRD_MSIL2A.SAFE/")
-            assert os.path.exists(zipwpath)
-            ds = gdal.Open(zipwpath)
-            assert ds is not None
+    zipname = str(uuid.uuid4()) + ".zip"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zipwpath = os.path.join(tmpdir, zipname)
+        _zip_a_dir(zipwpath, "data/sentinel2/fake_l2a/S2A_USER_PRD_MSIL2A.SAFE/")
+        assert os.path.exists(zipwpath)
+        ds = gdal.Open(zipwpath)
+        assert ds is not None
 
     # S2 L2A
-    if not sys.platform.startswith("win"):
-        zipname = str(uuid.uuid4()) + ".zip"
-        with tempfile.TemporaryDirectory() as tmpdir:
-            zipwpath = os.path.join(tmpdir, zipname)
-            _zip_a_dir(
-                zipwpath,
-                "data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/",
-            )
-            assert os.path.exists(zipwpath)
-            ds = gdal.Open(zipwpath)
-            assert ds is not None
+    zipname = str(uuid.uuid4()) + ".zip"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zipwpath = os.path.join(tmpdir, zipname)
+        _zip_a_dir(
+            zipwpath,
+            "data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/",
+        )
+        assert os.path.exists(zipwpath)
+        ds = gdal.Open(zipwpath)
+        assert ds is not None
 
    # S2 L1c SAFE compact
-    if not sys.platform.startswith("win"):
-        zipname = str(uuid.uuid4()) + ".zip"
-        with tempfile.TemporaryDirectory() as tmpdir:
-            zipwpath = os.path.join(tmpdir, zipname)
-            _zip_a_dir(
-                zipwpath, "data/sentinel2/fake_l1c_safecompact/S2A_MSIL1C_test.SAFE/"
-            )
-            assert os.path.exists(zipwpath)
-            ds = gdal.Open(zipwpath)
-            assert ds is not None
+    zipname = str(uuid.uuid4()) + ".zip"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zipwpath = os.path.join(tmpdir, zipname)
+        _zip_a_dir(
+            zipwpath, "data/sentinel2/fake_l1c_safecompact/S2A_MSIL1C_test.SAFE/"
+        )
+        assert os.path.exists(zipwpath)
+        ds = gdal.Open(zipwpath)
+        assert ds is not None
 

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -2425,7 +2425,7 @@ def test_sentinel2_zipped():
         ds = gdal.Open(zipwpath)
         assert ds is not None
 
-   # S2 L1B
+    # S2 L1B
     zipname = str(uuid.uuid4()) + ".zip"
     with tempfile.TemporaryDirectory() as tmpdir:
         zipwpath = os.path.join(tmpdir, zipname)
@@ -2455,7 +2455,7 @@ def test_sentinel2_zipped():
         ds = gdal.Open(zipwpath)
         assert ds is not None
 
-   # S2 L1c SAFE compact
+    # S2 L1c SAFE compact
     zipname = str(uuid.uuid4()) + ".zip"
     with tempfile.TemporaryDirectory() as tmpdir:
         zipwpath = os.path.join(tmpdir, zipname)

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -31,11 +31,26 @@
 
 import os
 import sys
+import tempfile
+import uuid
+import zipfile
 from osgeo import gdal
 
 
 import gdaltest
 import pytest
+
+
+def _zip_a_dir(tfile, sdir):
+    zf = zipfile.ZipFile(tfile, "w", zipfile.ZIP_DEFLATED)
+    for root, dirs, files in os.walk(sdir):
+        for file in files:
+            zf.write(
+                os.path.join(root, file),
+                os.path.relpath(os.path.join(root, file), os.path.join(sdir, "..")),
+            )
+    zf.close()
+
 
 ###############################################################################
 # Test opening a L1C product
@@ -95,14 +110,6 @@ def test_sentinel2_l1c_1():
         import pprint
         pprint.pprint(got_md)
         pytest.fail()
-
-    # Try opening a zip file as distributed from https://scihub.esa.int/
-    if not sys.platform.startswith('win'):
-        os.system('sh -c "cd data/sentinel2/fake_l1c && zip -r ../../tmp/S2A_OPER_PRD_MSIL1C.zip S2A_OPER_PRD_MSIL1C.SAFE >/dev/null" && cd ../..')
-        if os.path.exists('tmp/S2A_OPER_PRD_MSIL1C.zip'):
-            ds = gdal.Open('tmp/S2A_OPER_PRD_MSIL1C.zip')
-            assert ds is not None
-            os.unlink('tmp/S2A_OPER_PRD_MSIL1C.zip')
 
     # Try opening the 4 subdatasets
     for i in range(4):
@@ -2276,14 +2283,6 @@ def test_sentinel2_l1c_safe_compact_1():
             ds = gdal.Open(name)
         assert ds is None, name
 
-    # Try opening a zip file as distributed from https://scihub.esa.int/
-    if not sys.platform.startswith('win'):
-        os.system('sh -c "cd data/sentinel2/fake_l1c_safecompact && zip -r ../../tmp/S2A_MSIL1C_test.zip S2A_OPER_PRD_MSIL1C.SAFE >/dev/null" && cd ../..')
-        if os.path.exists('tmp/S2A_MSIL1C_test.zip'):
-            ds = gdal.Open('tmp/S2A_MSIL1C_test.zip')
-            assert ds is not None
-            os.unlink('tmp/S2A_MSIL1C_test.zip')
-
 
 ###############################################################################
 # Test opening a L1C Safe Compact subdataset on the 10m bands
@@ -2413,4 +2412,62 @@ def test_sentinel2_l1c_safe_compact_3():
     assert band.DataType == gdal.GDT_Byte
 
 
+###############################################################################
+# Test opening zipped versions of S2 datasets
+
+def test_sentinel2_zipped():
+    # S2 L1C
+    if not sys.platform.startswith("win"):
+        zipname = str(uuid.uuid4()) + ".zip"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zipwpath = os.path.join(tmpdir, zipname)
+            _zip_a_dir(zipwpath, "data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/")
+            assert os.path.exists(zipwpath)
+            ds = gdal.Open(zipwpath)
+            assert ds is not None
+
+   # S2 L1B
+    if not sys.platform.startswith("win"):
+        zipname = str(uuid.uuid4()) + ".zip"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zipwpath = os.path.join(tmpdir, zipname)
+            _zip_a_dir(zipwpath, "data/sentinel2/fake_l1b/S2B_OPER_PRD_MSIL1B.SAFE/")
+            assert os.path.exists(zipwpath)
+            ds = gdal.Open(zipwpath)
+            assert ds is not None
+
+    # S2 L1A
+    if not sys.platform.startswith("win"):
+        zipname = str(uuid.uuid4()) + ".zip"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zipwpath = os.path.join(tmpdir, zipname)
+            _zip_a_dir(zipwpath, "data/sentinel2/fake_l2a/S2A_USER_PRD_MSIL2A.SAFE/")
+            assert os.path.exists(zipwpath)
+            ds = gdal.Open(zipwpath)
+            assert ds is not None
+
+    # S2 L2A
+    if not sys.platform.startswith("win"):
+        zipname = str(uuid.uuid4()) + ".zip"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zipwpath = os.path.join(tmpdir, zipname)
+            _zip_a_dir(
+                zipwpath,
+                "data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/",
+            )
+            assert os.path.exists(zipwpath)
+            ds = gdal.Open(zipwpath)
+            assert ds is not None
+
+   # S2 L1c SAFE compact
+    if not sys.platform.startswith("win"):
+        zipname = str(uuid.uuid4()) + ".zip"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zipwpath = os.path.join(tmpdir, zipname)
+            _zip_a_dir(
+                zipwpath, "data/sentinel2/fake_l1c_safecompact/S2A_MSIL1C_test.SAFE/"
+            )
+            assert os.path.exists(zipwpath)
+            ds = gdal.Open(zipwpath)
+            assert ds is not None
 

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -143,7 +143,7 @@ static const SENTINEL2_L2A_BandDescription asL2ABandDesc[] =
 
 #define NB_L2A_BANDS (sizeof(asL2ABandDesc)/sizeof(asL2ABandDesc[0]))
 
-bool SENTINEL2isZipped(const char* pszHeader);
+static bool SENTINEL2isZipped(const char* pszHeader);
 static
 const char* SENTINEL2GetOption( GDALOpenInfo* poOpenInfo,
                                 const char* pszName,
@@ -642,7 +642,7 @@ GDALDataset *SENTINEL2Dataset::Open( GDALOpenInfo * poOpenInfo )
 /*                        SENTINEL2isZipped()                           */
 /************************************************************************/
 
-bool SENTINEL2isZipped(const char* pszHeader)
+static bool SENTINEL2isZipped(const char* pszHeader)
 {
     /* According to Sentinel-2 Products Specification Document,
      * all files are located inside a folder with a specific name pattern

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -462,9 +462,11 @@ int SENTINEL2Dataset::Identify( GDALOpenInfo *poOpenInfo )
                 STARTS_WITH_CI(pszInsideFilename, "S2A_USER_MTD_SAFL2A") ||
                 STARTS_WITH_CI(pszInsideFilename, "S2B_USER_MTD_SAFL2A")
             )) {
+                VSICloseDir(psDir);
                 return TRUE;
             }
         }
+        VSICloseDir(psDir);
     }
 
     return FALSE;
@@ -648,9 +650,11 @@ GDALDataset *SENTINEL2Dataset::Open( GDALOpenInfo * poOpenInfo )
                 osFilename = osFilename + "/" + psEntry->pszName;
                 CPLDebug("SENTINEL2", "Trying %s", osFilename.c_str());
                 GDALOpenInfo oOpenInfo(osFilename, GA_ReadOnly);
+                VSICloseDir(psDir);
                 return Open(&oOpenInfo);
             }
         }
+        VSICloseDir(psDir);
     }
 
     return nullptr;

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -143,6 +143,7 @@ static const SENTINEL2_L2A_BandDescription asL2ABandDesc[] =
 
 #define NB_L2A_BANDS (sizeof(asL2ABandDesc)/sizeof(asL2ABandDesc[0]))
 
+bool SENTINEL2isMetadataFile(const char* pszInsideFilename);
 static
 const char* SENTINEL2GetOption( GDALOpenInfo* poOpenInfo,
                                 const char* pszName,
@@ -452,16 +453,8 @@ int SENTINEL2Dataset::Identify( GDALOpenInfo *poOpenInfo )
         while ( const VSIDIREntry* psEntry = VSIGetNextDirEntry(psDir) )
         {
             const char* pszInsideFilename = CPLGetFilename(psEntry->pszName);
-            if ( VSI_ISREG(psEntry->nMode) && (
-                STARTS_WITH_CI(pszInsideFilename, "MTD_MSIL1C") ||
-                STARTS_WITH_CI(pszInsideFilename, "MTD_MSIL2A") ||
-                STARTS_WITH_CI(pszInsideFilename, "S2A_OPER_MTD_SAFL1B") ||
-                STARTS_WITH_CI(pszInsideFilename, "S2B_OPER_MTD_SAFL1B") ||
-                STARTS_WITH_CI(pszInsideFilename, "S2A_OPER_MTD_SAFL1C") ||
-                STARTS_WITH_CI(pszInsideFilename, "S2B_OPER_MTD_SAFL1C") ||
-                STARTS_WITH_CI(pszInsideFilename, "S2A_USER_MTD_SAFL2A") ||
-                STARTS_WITH_CI(pszInsideFilename, "S2B_USER_MTD_SAFL2A")
-            )) {
+            if ( VSI_ISREG(psEntry->nMode) && SENTINEL2isMetadataFile(pszInsideFilename) )
+            {
                 VSICloseDir(psDir);
                 return TRUE;
             }
@@ -637,16 +630,8 @@ GDALDataset *SENTINEL2Dataset::Open( GDALOpenInfo * poOpenInfo )
         while ( const VSIDIREntry* psEntry = VSIGetNextDirEntry(psDir) )
         {
             const char* pszInsideFilename = CPLGetFilename(psEntry->pszName);
-            if ( VSI_ISREG(psEntry->nMode) && (
-                    STARTS_WITH_CI(pszInsideFilename, "MTD_MSIL2A") ||
-                    STARTS_WITH_CI(pszInsideFilename, "MTD_MSIL1C") ||
-                    STARTS_WITH_CI(pszInsideFilename, "S2A_OPER_MTD_SAFL1B") ||
-                    STARTS_WITH_CI(pszInsideFilename, "S2B_OPER_MTD_SAFL1B") ||
-                    STARTS_WITH_CI(pszInsideFilename, "S2A_OPER_MTD_SAFL1C") ||
-                    STARTS_WITH_CI(pszInsideFilename, "S2B_OPER_MTD_SAFL1C") ||
-                    STARTS_WITH_CI(pszInsideFilename, "S2A_USER_MTD_SAFL2A") ||
-                    STARTS_WITH_CI(pszInsideFilename, "S2B_USER_MTD_SAFL2A")
-            )) {
+            if ( VSI_ISREG(psEntry->nMode) && SENTINEL2isMetadataFile(pszInsideFilename) )
+            {
                 osFilename = osFilename + "/" + psEntry->pszName;
                 CPLDebug("SENTINEL2", "Trying %s", osFilename.c_str());
                 GDALOpenInfo oOpenInfo(osFilename, GA_ReadOnly);
@@ -658,6 +643,24 @@ GDALDataset *SENTINEL2Dataset::Open( GDALOpenInfo * poOpenInfo )
     }
 
     return nullptr;
+}
+
+/************************************************************************/
+/*                        SENTINEL2isMetadataFile()                     */
+/************************************************************************/
+
+bool SENTINEL2isMetadataFile(const char* pszInsideFilename)
+{
+    return (
+        STARTS_WITH_CI(pszInsideFilename, "MTD_MSIL2A") ||
+        STARTS_WITH_CI(pszInsideFilename, "MTD_MSIL1C") ||
+        STARTS_WITH_CI(pszInsideFilename, "S2A_OPER_MTD_SAFL1B") ||
+        STARTS_WITH_CI(pszInsideFilename, "S2B_OPER_MTD_SAFL1B") ||
+        STARTS_WITH_CI(pszInsideFilename, "S2A_OPER_MTD_SAFL1C") ||
+        STARTS_WITH_CI(pszInsideFilename, "S2B_OPER_MTD_SAFL1C") ||
+        STARTS_WITH_CI(pszInsideFilename, "S2A_USER_MTD_SAFL2A") ||
+        STARTS_WITH_CI(pszInsideFilename, "S2B_USER_MTD_SAFL2A")
+    );
 }
 
 /************************************************************************/


### PR DESCRIPTION
Previous code was identifying zipped S2 datasets based only on their file names. Thus renaming a S2 dataset containing zip file would make it invisible to glda. This commit introduces extra check for presence of format specific metadata files inside a zip to determine if it is a S2 containing zip file. Primary detection is still done by file name thus speeding up the most common case when file name indicates on its content.

I was not able to run black on Python code and clang-format on C++ code as existing code base has not been reformatted.