### PR TITLE
Geoloc transformer: fix inverse transform to be exact

### DIFF
--- a/alg/CMakeLists.txt
+++ b/alg/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
   gdalcutline.cpp
   gdaldither.cpp
   gdalgeoloc.cpp
+  gdalgeolocquadtree.cpp
   gdalgrid.cpp
   gdallinearsystem.cpp
   gdalmatching.cpp

--- a/alg/GNUmakefile
+++ b/alg/GNUmakefile
@@ -5,6 +5,7 @@ OBJ	=	gdalmediancut.o gdaldither.o gdal_crs.o gdaltransformer.o \
 		gdalsimplewarp.o gdalwarper.o gdalwarpkernel.o \
 		gdalwarpoperation.o gdalchecksum.o gdal_rpc.o gdal_tps.o \
 		thinplatespline.o llrasterize.o gdalrasterize.o gdalgeoloc.o \
+		gdalgeolocquadtree.o \
 		gdalgrid.o gdalcutline.o gdalproximity.o rasterfill.o \
 		gdalrasterpolygonenumerator.o \
 		gdalsievefilter.o gdalwarpkernel_opencl.o polygonize.o \

--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -187,10 +187,13 @@ int GDALTransformLonLatToDestApproxTransformer(void* hTransformArg,
 bool GDALTransformIsTranslationOnPixelBoundaries(GDALTransformerFunc pfnTransformer,
                                                  void                *pTransformerArg);
 
+typedef struct _CPLQuadTree CPLQuadTree;
+
 typedef struct {
     GDALTransformerInfo sTI;
 
     bool        bReversed;
+    double      dfOversampleFactor;
 
     // Map from target georef coordinates back to geolocation array
     // pixel line coordinates.  Built only if needed.
@@ -229,6 +232,10 @@ typedef struct {
     double           dfPIXEL_STEP;
     double           dfLINE_OFFSET;
     double           dfLINE_STEP;
+
+    bool             bOriginIsTopLeftCorner;
+    bool             bGeographicSRSWithMinus180Plus180LongRange;
+    CPLQuadTree     *hQuadTree;
 
     char **          papszGeolocationInfo;
 
@@ -311,6 +318,11 @@ bool GDALComputeAreaOfInterest(OGRSpatialReference* poSRS,
                                double& dfEastLongitudeDeg,
                                double& dfNorthLatitudeDeg );
 
+void *GDALCreateGeoLocTransformerEx( GDALDatasetH hBaseDS,
+                                     char **papszGeolocationInfo,
+                                     int bReversed,
+                                     const char* pszSourceDataset,
+                                     CSLConstList papszTransformOptions );
 
 #endif /* #ifndef DOXYGEN_SKIP */
 

--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -197,11 +197,12 @@ typedef struct {
 
     // Map from target georef coordinates back to geolocation array
     // pixel line coordinates.  Built only if needed.
-    size_t      nBackMapWidth;
-    size_t      nBackMapHeight;
+    int         nBackMapWidth;
+    int         nBackMapHeight;
     double      adfBackMapGeoTransform[6];  // Maps georef to pixel/line.
-    float       *pafBackMapX;
-    float       *pafBackMapY;
+
+    bool        bUseArray;
+    void       *pAccessors;
 
     // Geolocation bands.
     GDALDatasetH     hDS_X;
@@ -211,10 +212,8 @@ typedef struct {
     int              bSwapXY;
 
     // Located geolocation data.
-    size_t           nGeoLocXSize;
-    size_t           nGeoLocYSize;
-    double           *padfGeoLocX;
-    double           *padfGeoLocY;
+    int              nGeoLocXSize;
+    int              nGeoLocYSize;
     double           dfMinX;
     double           dfYAtMinX;
     double           dfMinY;

--- a/alg/gdalgeoloc.cpp
+++ b/alg/gdalgeoloc.cpp
@@ -8,6 +8,7 @@
  * Copyright (c) 2006, Frank Warmerdam <warmerdam@pobox.com>
  * Copyright (c) 2007-2013, Even Rouault <even dot rouault at spatialys.com>
  * Copyright (c) 2021, CLS
+ * Copyright (c) 2022, Planet Labs
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -31,6 +32,8 @@
 #include "cpl_port.h"
 #include "gdal_alg.h"
 #include "gdal_alg_priv.h"
+#include "gdalgeoloc.h"
+#include "gdalgeolocquadtree.h"
 
 #include <climits>
 #include <cmath>
@@ -44,11 +47,22 @@
 #include "cpl_conv.h"
 #include "cpl_error.h"
 #include "cpl_minixml.h"
+#include "cpl_quad_tree.h"
 #include "cpl_string.h"
 #include "cpl_vsi.h"
 #include "gdal.h"
 #include "gdal_priv.h"
 #include "memdataset.h"
+
+//#define DEBUG_GEOLOC
+
+#ifdef DEBUG_GEOLOC
+#include "ogrsf_frmts.h"
+#endif
+
+#ifdef DEBUG_GEOLOC
+#warning "Remove me before committing"
+#endif
 
 CPL_CVSID("$Id$")
 
@@ -63,17 +77,70 @@ CPL_C_END
 /* ==================================================================== */
 /************************************************************************/
 
+constexpr float INVALID_BMXY = -10.0f;
 
-//Constants to track down systematic shifts
-const double FSHIFT = 0.5;
-const double ISHIFT = 0.5;
-const double OVERSAMPLE_FACTOR=1.3;
+/************************************************************************/
+/*                           UnshiftGeoX()                              */
+/************************************************************************/
+
+// Renormalize longitudes to [-180,180] range
+static double UnshiftGeoX(const GDALGeoLocTransformInfo *psTransform,
+                          double dfX)
+{
+    if( !psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+        return dfX;
+    if( dfX > 180 )
+        return dfX - 360;
+    if( dfX < -180 )
+        return dfX + 360;
+    return dfX;
+}
+
+/************************************************************************/
+/*                           UpdateMinMax()                             */
+/************************************************************************/
+
+inline void UpdateMinMax(GDALGeoLocTransformInfo *psTransform,
+                         double dfGeoLocX,
+                         double dfGeoLocY)
+{
+    if( dfGeoLocX < psTransform->dfMinX )
+    {
+        psTransform->dfMinX = dfGeoLocX;
+        psTransform->dfYAtMinX = dfGeoLocY;
+    }
+    if( dfGeoLocX > psTransform->dfMaxX )
+    {
+        psTransform->dfMaxX = dfGeoLocX;
+        psTransform->dfYAtMaxX = dfGeoLocY;
+    }
+    if( dfGeoLocY < psTransform->dfMinY )
+    {
+        psTransform->dfMinY = dfGeoLocY;
+        psTransform->dfXAtMinY = dfGeoLocX;
+    }
+    if( dfGeoLocY > psTransform->dfMaxY )
+    {
+        psTransform->dfMaxY = dfGeoLocY;
+        psTransform->dfXAtMaxY = dfGeoLocX;
+    }
+}
+
+/************************************************************************/
+/*                                Clamp()                               */
+/************************************************************************/
+
+inline double Clamp(double v, double minV, double maxV)
+{
+    return std::min(std::max(v, minV), maxV);
+}
 
 /************************************************************************/
 /*                         GeoLocLoadFullData()                         */
 /************************************************************************/
 
-static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform )
+static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
+                                CSLConstList papszGeolocationInfo )
 
 {
     const int nXSize_XBand = GDALGetRasterXSize( psTransform->hDS_X );
@@ -194,31 +261,231 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform )
         if( !psTransform->bHasNoData ||
             psTransform->padfGeoLocX[i] != psTransform->dfNoDataX )
         {
-            if( psTransform->padfGeoLocX[i] < psTransform->dfMinX )
-            {
-                psTransform->dfMinX = psTransform->padfGeoLocX[i];
-                psTransform->dfYAtMinX = psTransform->padfGeoLocY[i];
-            }
-            if( psTransform->padfGeoLocX[i] > psTransform->dfMaxX )
-            {
-                psTransform->dfMaxX = psTransform->padfGeoLocX[i];
-                psTransform->dfYAtMaxX = psTransform->padfGeoLocY[i];
-            }
-            if( psTransform->padfGeoLocY[i] < psTransform->dfMinY )
-            {
-                psTransform->dfMinY = psTransform->padfGeoLocY[i];
-                psTransform->dfXAtMinY = psTransform->padfGeoLocX[i];
-            }
-            if( psTransform->padfGeoLocY[i] > psTransform->dfMaxY )
-            {
-                psTransform->dfMaxY = psTransform->padfGeoLocY[i];
-                psTransform->dfXAtMaxY = psTransform->padfGeoLocX[i];
-            }
+            UpdateMinMax(psTransform,
+                         psTransform->padfGeoLocX[i],
+                         psTransform->padfGeoLocY[i]);
         }
     }
 
+    // Check if the SRS is geographic and the geoloc longitudes are in [-180,180]
+    psTransform->bGeographicSRSWithMinus180Plus180LongRange = false;
+    const char* pszSRS = CSLFetchNameValue( papszGeolocationInfo, "SRS" );
+    if( pszSRS && psTransform->dfMinX >= -180.0 && psTransform->dfMaxX <= 180.0 &&
+        !psTransform->bSwapXY )
+    {
+        OGRSpatialReference oSRS;
+        psTransform->bGeographicSRSWithMinus180Plus180LongRange =
+            oSRS.importFromWkt(pszSRS) == OGRERR_NONE &&
+            CPL_TO_BOOL(oSRS.IsGeographic());
+    }
+
+
+#ifdef DEBUG_GEOLOC
+    if( CPLTestBool(CPLGetConfigOption("GEOLOC_DUMP", "NO")) )
+    {
+        auto poDS = std::unique_ptr<GDALDataset>(GDALDriver::FromHandle(
+            GDALGetDriverByName("ESRI Shapefile"))->
+                Create("/tmp/geoloc_poly.shp", 0, 0, 0, GDT_Unknown, nullptr));
+        auto poLayer = poDS->CreateLayer("geoloc_poly", nullptr, wkbPolygon, nullptr);
+        auto poLayerDefn = poLayer->GetLayerDefn();
+        OGRFieldDefn fieldX("x", OFTInteger);
+        poLayer->CreateField(&fieldX);
+        OGRFieldDefn fieldY("y", OFTInteger);
+        poLayer->CreateField(&fieldY);
+        for( size_t iY = 0; iY + 1 < psTransform->nGeoLocYSize; iY++ )
+        {
+            for( size_t iX = 0; iX + 1 < psTransform->nGeoLocXSize; iX++ )
+            {
+                double x0, y0, x1, y1, x2, y2, x3, y3;
+                if( !GDALGeoLocPosPixelLineToXY(psTransform, iX, iY, x0, y0) ||
+                    !GDALGeoLocPosPixelLineToXY(psTransform, iX+1, iY, x2, y2) ||
+                    !GDALGeoLocPosPixelLineToXY(psTransform, iX, iY+1, x1, y1) ||
+                    !GDALGeoLocPosPixelLineToXY(psTransform, iX+1, iY+1, x3, y3) )
+                {
+                    break;
+                }
+                if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+                    std::fabs(x0) > 170 &&
+                    std::fabs(x1) > 170 &&
+                    std::fabs(x2) > 170 &&
+                    std::fabs(x3) > 170 &&
+                    (std::fabs(x1-x0) > 180 ||
+                     std::fabs(x2-x0) > 180 ||
+                     std::fabs(x3-x0) > 180) )
+                {
+                    OGRPolygon* poPoly = new OGRPolygon();
+                    OGRLinearRing* poRing = new OGRLinearRing();
+                    poRing->addPoint(x0 > 0 ? x0 : x0+360, y0);
+                    poRing->addPoint(x2 > 0 ? x2 : x2+360, y2);
+                    poRing->addPoint(x3 > 0 ? x3 : x3+360, y3);
+                    poRing->addPoint(x1 > 0 ? x1 : x1+360, y1);
+                    poRing->addPoint(x0 > 0 ? x0 : x0+360, y0);
+                    poPoly->addRingDirectly(poRing);
+                    auto poFeature = cpl::make_unique<OGRFeature>(poLayerDefn);
+                    poFeature->SetField(0, static_cast<int>(iX));
+                    poFeature->SetField(1, static_cast<int>(iY));
+                    poFeature->SetGeometryDirectly(poPoly);
+                    CPL_IGNORE_RET_VAL(poLayer->CreateFeature(poFeature.get()));
+                    if( x0 > 0 ) x0 -= 360;
+                    if( x1 > 0 ) x1 -= 360;
+                    if( x2 > 0 ) x2 -= 360;
+                    if( x3 > 0 ) x3 -= 360;
+                }
+
+                OGRPolygon* poPoly = new OGRPolygon();
+                OGRLinearRing* poRing = new OGRLinearRing();
+                poRing->addPoint(x0, y0);
+                poRing->addPoint(x2, y2);
+                poRing->addPoint(x3, y3);
+                poRing->addPoint(x1, y1);
+                poRing->addPoint(x0, y0);
+                poPoly->addRingDirectly(poRing);
+                auto poFeature = cpl::make_unique<OGRFeature>(poLayerDefn);
+                poFeature->SetField(0, static_cast<int>(iX));
+                poFeature->SetField(1, static_cast<int>(iY));
+                poFeature->SetGeometryDirectly(poPoly);
+                CPL_IGNORE_RET_VAL(poLayer->CreateFeature(poFeature.get()));
+            }
+        }
+    }
+#endif
+
+    if( psTransform->bOriginIsTopLeftCorner )
+    {
+        // Add "virtual" edge at Y=nGeoLocYSize
+        for( size_t iX = 0; iX <= psTransform->nGeoLocXSize; iX++ )
+        {
+            double dfGeoLocX;
+            double dfGeoLocY;
+            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(iX),
+                    static_cast<double>(psTransform->nGeoLocYSize),
+                    dfGeoLocX, dfGeoLocY) )
+                continue;
+            if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+                dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
+            UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+        }
+
+        // Add "virtual" edge at X=nGeoLocXSize
+        for( size_t iY = 0; iY <= psTransform->nGeoLocYSize; iY++ )
+        {
+            double dfGeoLocX;
+            double dfGeoLocY;
+            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(psTransform->nGeoLocXSize),
+                    static_cast<double>(iY),
+                    dfGeoLocX, dfGeoLocY) )
+                continue;
+            if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+                dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
+            UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+        }
+    }
+    else
+    {
+        // Extend by half-pixel on 4 edges for pixel-center convention
+
+        for( size_t iX = 0; iX <= psTransform->nGeoLocXSize; iX ++ )
+        {
+            double dfGeoLocX;
+            double dfGeoLocY;
+            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(iX),
+                    -0.5,
+                    dfGeoLocX, dfGeoLocY) )
+                continue;
+            if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+                dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
+            UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+
+            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(iX),
+                    static_cast<double>(psTransform->nGeoLocYSize-1 + 0.5),
+                    dfGeoLocX, dfGeoLocY) )
+                continue;
+            if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+                dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
+            UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+        }
+
+        for( size_t iY = 0; iY <= psTransform->nGeoLocYSize; iY++ )
+        {
+            double dfGeoLocX;
+            double dfGeoLocY;
+            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                    -0.5,
+                    static_cast<double>(iY),
+                    dfGeoLocX, dfGeoLocY) )
+                continue;
+            if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+                dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
+            UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+
+            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                    psTransform->nGeoLocXSize-1+0.5,
+                    static_cast<double>(iY),
+                    dfGeoLocX, dfGeoLocY) )
+                continue;
+            if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+                dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
+            UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+        }
+    }
 
     return true;
+}
+
+/************************************************************************/
+/*                  GDALInverseBilinearInterpolation()                  */
+/************************************************************************/
+
+// (i,j) before the call should correspond to the input coordinates that give
+// (x0,y0) as output of the forward interpolation
+// After the call it will be updated to the input coordinates that give (x,y)
+// This assumes that (x,y) is within the polygon formed by
+// (x0, y0), (x2, y2), (x3, y3), (x1, y1), (x0, y0)
+void GDALInverseBilinearInterpolation(const double x,
+                                      const double y,
+                                      const double x0,
+                                      const double y0,
+                                      const double x1,
+                                      const double y1,
+                                      const double x2,
+                                      const double y2,
+                                      const double x3,
+                                      const double y3,
+                                      double& i,
+                                      double& j)
+{
+    // Exact inverse bilinear interpolation method.
+    // Maths from https://stackoverflow.com/a/812077
+
+    const double A = (x0 - x) * (y0 - y2) - (y0 - y) * (x0 - x2);
+    const double B = ( ((x0 - x) * (y1 - y3) - (y0 - y) * (x1 - x3)) +
+                       ((x1 - x) * (y0 - y2) - (y1 - y) * (x0 - x2)) ) / 2;
+    const double C = (x1 - x) * (y1 - y3) - (y1 - y) * (x1 - x3);
+    const double denom = A - 2 * B + C;
+    double s;
+    if( fabs(denom) < 1e-12 )
+    {
+        // Happens typically when the x_i,y_i points form a rectangle
+        s = A / (A-C);
+    }
+    else
+    {
+        const double sqrtTerm = sqrt(B * B - A * C);
+        const double s1 = ((A-B) + sqrtTerm) / denom;
+        const double s2 = ((A-B) - sqrtTerm) / denom;
+        if( s1 < 0 || s1 > 1 )
+            s = s2;
+        else
+            s = s1;
+    }
+    const double t = ( (1-s)*(x0-x) + s*(x1-x) ) / ( (1-s)*(x0-x2) + s*(x1-x3) );
+
+    i += t;
+    j += s;
 }
 
 /************************************************************************/
@@ -228,6 +495,7 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform )
 static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 
 {
+    CPLDebug("GEOLOC", "Starting backmap generation");
     const size_t nXSize = psTransform->nGeoLocXSize;
     const size_t nYSize = psTransform->nGeoLocYSize;
 
@@ -237,52 +505,61 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 /*      establish how much dead space there is in the backmap, so it    */
 /*      is approximate.                                                 */
 /* -------------------------------------------------------------------- */
-    const double dfTargetPixels = (static_cast<double>(nXSize) * nYSize * OVERSAMPLE_FACTOR);
-    const double dfPixelSize = sqrt(
+    const double dfTargetPixels =
+        static_cast<double>(nXSize) * nYSize * psTransform->dfOversampleFactor;
+    const double dfPixelSizeSquare = sqrt(
         (psTransform->dfMaxX - psTransform->dfMinX) *
         (psTransform->dfMaxY - psTransform->dfMinY) / dfTargetPixels);
-    if( dfPixelSize == 0.0 )
+    if( dfPixelSizeSquare == 0.0 )
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Invalid pixel size for backmap");
         return false;
     }
 
-    const double dfBMXSize = (psTransform->dfMaxX - psTransform->dfMinX) / dfPixelSize + 1;
-    const double dfBMYSize = (psTransform->dfMaxY - psTransform->dfMinY) / dfPixelSize + 1;
+    const double dfMinX = psTransform->dfMinX - dfPixelSizeSquare / 2.0;
+    const double dfMaxX = psTransform->dfMaxX + dfPixelSizeSquare / 2.0;
+    const double dfMaxY = psTransform->dfMaxY + dfPixelSizeSquare / 2.0;
+    const double dfMinY = psTransform->dfMinY - dfPixelSizeSquare / 2.0;
+    const double dfBMXSize = std::ceil((dfMaxX - dfMinX) / dfPixelSizeSquare);
+    const double dfBMYSize = std::ceil((dfMaxY - dfMinY) / dfPixelSizeSquare);
 
-    if( !(dfBMXSize > 0 && dfBMXSize < INT_MAX) ||
-        !(dfBMYSize > 0 && dfBMYSize < INT_MAX) )
+    if( !(dfBMXSize > 0 && dfBMXSize + 1 < INT_MAX) ||
+        !(dfBMYSize > 0 && dfBMYSize + 1 < INT_MAX) )
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Int overflow : %f x %f",
                  dfBMXSize, dfBMYSize);
         return false;
     }
 
-    const size_t nBMXSize = static_cast<size_t>(dfBMXSize);
-    const size_t nBMYSize = static_cast<size_t>(dfBMYSize);
+    size_t nBMXSize = static_cast<size_t>(dfBMXSize);
+    size_t nBMYSize = static_cast<size_t>(dfBMYSize);
 
-    if( nBMYSize > std::numeric_limits<size_t>::max() / nBMXSize )
+    if( 1 + nBMYSize > std::numeric_limits<size_t>::max() / (1 + nBMXSize) )
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Int overflow : %f x %f",
                  dfBMXSize, dfBMYSize);
         return false;
     }
 
+    const double dfPixelXSize = (dfMaxX - dfMinX) / nBMXSize;
+    const double dfPixelYSize = (dfMaxY - dfMinY) / nBMYSize;
+
+    // Extra pixel for right-edge and bottom-edge extensions in TOP_LEFT_CORNER
+    // convention.
+    nBMXSize ++;
+    nBMYSize ++;
     psTransform->nBackMapWidth = nBMXSize;
     psTransform->nBackMapHeight = nBMYSize;
 
-    const double dfMinX = psTransform->dfMinX - dfPixelSize / 2.0;
-    const double dfMaxY = psTransform->dfMaxY + dfPixelSize / 2.0;
-
     psTransform->adfBackMapGeoTransform[0] = dfMinX;
-    psTransform->adfBackMapGeoTransform[1] = dfPixelSize;
+    psTransform->adfBackMapGeoTransform[1] = dfPixelXSize;
     psTransform->adfBackMapGeoTransform[2] = 0.0;
     psTransform->adfBackMapGeoTransform[3] = dfMaxY;
     psTransform->adfBackMapGeoTransform[4] = 0.0;
-    psTransform->adfBackMapGeoTransform[5] = -dfPixelSize;
+    psTransform->adfBackMapGeoTransform[5] = -dfPixelYSize;
 
 /* -------------------------------------------------------------------- */
-/*      Allocate backmap, and initialize to nodata value (-1.0).        */
+/*      Allocate backmap.                                               */
 /* -------------------------------------------------------------------- */
     psTransform->pafBackMapX = static_cast<float *>(
         VSI_MALLOC3_VERBOSE(nBMXSize, nBMYSize, sizeof(float)));
@@ -308,22 +585,19 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
         wgtsBackMap[i] = 0.0;
     }
 
-/* -------------------------------------------------------------------- */
-/*      Run through the whole geoloc array forward projecting and       */
-/*      pushing into the backmap.                                       */
-/* -------------------------------------------------------------------- */
+    const double dfGeorefConventionOffset = psTransform->bOriginIsTopLeftCorner ? 0 : 0.5;
 
     const auto UpdateBackmap = [&](std::ptrdiff_t iBMX, std::ptrdiff_t iBMY,
-                                   size_t iX, size_t iY,
+                                   double dfX, double dfY,
                                    double tempwt)
     {
         const float fUpdatedBMX = psTransform->pafBackMapX[iBMX + iBMY * nBMXSize] +
             static_cast<float>( tempwt * (
-                (iX + FSHIFT) * psTransform->dfPIXEL_STEP +
+                (dfX + dfGeorefConventionOffset) * psTransform->dfPIXEL_STEP +
                 psTransform->dfPIXEL_OFFSET));
         const float fUpdatedBMY = psTransform->pafBackMapY[iBMX + iBMY * nBMXSize] +
             static_cast<float>( tempwt * (
-                (iY + FSHIFT) * psTransform->dfLINE_STEP +
+                (dfY + dfGeorefConventionOffset) * psTransform->dfLINE_STEP +
                 psTransform->dfLINE_OFFSET));
         const float fUpdatedWeight = wgtsBackMap[iBMX + iBMY * nBMXSize] +
                                static_cast<float>(tempwt);
@@ -336,8 +610,10 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
         {
             const float fX = fUpdatedBMX / fUpdatedWeight;
             const float fY = fUpdatedBMY / fUpdatedWeight;
-            const double dfGeoLocPixel = (fX - psTransform->dfPIXEL_OFFSET) / psTransform->dfPIXEL_STEP;
-            const double dfGeoLocLine = (fY - psTransform->dfLINE_OFFSET) / psTransform->dfLINE_STEP;
+            const double dfGeoLocPixel = (fX - psTransform->dfPIXEL_OFFSET) / psTransform->dfPIXEL_STEP -
+                dfGeorefConventionOffset;
+            const double dfGeoLocLine = (fY - psTransform->dfLINE_OFFSET) / psTransform->dfLINE_STEP -
+                dfGeorefConventionOffset;
             size_t iXAvg = static_cast<size_t>(std::max(0.0, dfGeoLocPixel));
             iXAvg = std::min(iXAvg, psTransform->nGeoLocXSize-1);
             size_t iYAvg = static_cast<size_t>(std::max(0.0, dfGeoLocLine));
@@ -345,10 +621,13 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
             const double dfGLX = psTransform->padfGeoLocX[iXAvg + iYAvg * nXSize];
             const double dfGLY = psTransform->padfGeoLocY[iXAvg + iYAvg * nXSize];
 
+            const size_t iX = static_cast<size_t>(dfX);
+            const size_t iY = static_cast<size_t>(dfY);
             if( !(psTransform->bHasNoData &&
                   dfGLX == psTransform->dfNoDataX ) &&
-                fabs(dfGLX - psTransform->padfGeoLocX[iX + iY * nXSize]) <= 2 * dfPixelSize &&
-                fabs(dfGLY - psTransform->padfGeoLocY[iX + iY * nXSize]) <= 2 * dfPixelSize )
+                ((iX >= nXSize - 1 || iY >= nYSize - 1) ||
+                 (fabs(dfGLX - psTransform->padfGeoLocX[iX + iY * nXSize]) <= 2 * dfPixelXSize &&
+                  fabs(dfGLY - psTransform->padfGeoLocY[iX + iY * nXSize]) <= 2 * dfPixelYSize)) )
             {
                 psTransform->pafBackMapX[iBMX + iBMY * nBMXSize] = fUpdatedBMX;
                 psTransform->pafBackMapY[iBMX + iBMY * nBMXSize] = fUpdatedBMY;
@@ -357,29 +636,144 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
         }
     };
 
-    for( size_t iY = 0; iY < nYSize; iY++ )
+    // Keep those objects in this outer scope, so they are re-used, to
+    // save memory allocations.
+    OGRPoint oPoint;
+    OGRLinearRing oRing;
+    oRing.setNumPoints(5);
+
+/* -------------------------------------------------------------------- */
+/*      Run through the whole geoloc array forward projecting and       */
+/*      pushing into the backmap.                                       */
+/* -------------------------------------------------------------------- */
+
+    // Iterate over the (i,j) pixel space of the geolocation array, in a sufficiently
+    // dense way that if the geolocation array expressed an affine transformation,
+    // we would hit every node of the backmap.
+    const double dfStep = 1. / psTransform->dfOversampleFactor;
+    for( double dfY = -dfStep; dfY <= static_cast<double>(nYSize) + 2 * dfStep; dfY += dfStep )
     {
-        for( size_t iX = 0; iX < nXSize; iX++ )
+        for( double dfX = -dfStep; dfX <= static_cast<double>(nXSize) + 2 * dfStep; dfX += dfStep )
         {
-            if( psTransform->bHasNoData &&
-                psTransform->padfGeoLocX[iX + iY * nXSize]
-                == psTransform->dfNoDataX )
+            // Use forward geolocation array interpolation to compute the
+            // georeferenced position corresponding to (dfX, dfY)
+            double dfGeoLocX;
+            double dfGeoLocY;
+            if( !GDALGeoLocPosPixelLineToXY(psTransform, dfX, dfY, dfGeoLocX, dfGeoLocY) )
                 continue;
 
-            const size_t i = iX + iY * nXSize;
-
+            // Compute the floating point coordinates in the pixel space of the backmap
             const double dBMX = static_cast<double>(
-                    (psTransform->padfGeoLocX[i] - dfMinX) / dfPixelSize) - FSHIFT;
+                    (dfGeoLocX - dfMinX) / dfPixelXSize);
 
             const double dBMY = static_cast<double>(
-                (dfMaxY - psTransform->padfGeoLocY[i]) / dfPixelSize) - FSHIFT;
-
+                (dfMaxY - dfGeoLocY) / dfPixelYSize);
 
             //Get top left index by truncation
-            const std::ptrdiff_t iBMX = static_cast<std::ptrdiff_t>(dBMX);
-            const std::ptrdiff_t iBMY = static_cast<std::ptrdiff_t>(dBMY);
-            const double fracBMX = dBMX - iBMX;
-            const double fracBMY = dBMY - iBMY;
+            const std::ptrdiff_t iBMX = static_cast<std::ptrdiff_t>(std::floor(dBMX));
+            const std::ptrdiff_t iBMY = static_cast<std::ptrdiff_t>(std::floor(dBMY));
+
+            if( iBMX >= 0 && static_cast<size_t>(iBMX) < nBMXSize &&
+                iBMY >= 0 && static_cast<size_t>(iBMY) < nBMYSize )
+            {
+                // Compute the georeferenced position of the top-left index of
+                // the backmap
+                double dfGeoX = dfMinX + iBMX * dfPixelXSize;
+                const double dfGeoY = dfMaxY - iBMY * dfPixelYSize;
+
+                bool bMatchingGeoLocCellFound = false;
+
+                const int nOuterIters = psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoX) >= 180 ? 2 : 1;
+
+                for( int iOuterIter = 0; iOuterIter < nOuterIters; ++iOuterIter)
+                {
+                    if( iOuterIter == 1 && dfGeoX >= 180 )
+                        dfGeoX -= 360;
+                    else if( iOuterIter == 1 && dfGeoX <= -180 )
+                        dfGeoX += 360;
+
+                    // Identify a cell (quadrilateral in georeferenced space) in
+                    // the geolocation array in which dfGeoX, dfGeoY falls into.
+                    oPoint.setX(dfGeoX);
+                    oPoint.setY(dfGeoY);
+                    for( int sx = -1; !bMatchingGeoLocCellFound && sx <= 0; sx++ )
+                    {
+                        for(int sy = -1; !bMatchingGeoLocCellFound && sy <= 0; sy++)
+                        {
+                            const double pixel = std::floor(dfX) + sx;
+                            const double line = std::floor(dfY) + sy;
+                            double x0, y0, x1, y1, x2, y2, x3, y3;
+                            if( !GDALGeoLocPosPixelLineToXY(psTransform, pixel, line, x0, y0) ||
+                                !GDALGeoLocPosPixelLineToXY(psTransform, pixel+1, line, x2, y2) ||
+                                !GDALGeoLocPosPixelLineToXY(psTransform, pixel, line+1, x1, y1) ||
+                                !GDALGeoLocPosPixelLineToXY(psTransform, pixel+1, line+1, x3, y3) )
+                            {
+                                break;
+                            }
+
+                            int nIters = 1;
+                            if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+                                std::fabs(x0) > 170 &&
+                                std::fabs(x1) > 170 &&
+                                std::fabs(x2) > 170 &&
+                                std::fabs(x3) > 170 &&
+                                (std::fabs(x1-x0) > 180 ||
+                                 std::fabs(x2-x0) > 180 ||
+                                 std::fabs(x3-x0) > 180) )
+                            {
+                                nIters = 2;
+                                if( x0 > 0 ) x0 -= 360;
+                                if( x1 > 0 ) x1 -= 360;
+                                if( x2 > 0 ) x2 -= 360;
+                                if( x3 > 0 ) x3 -= 360;
+                            }
+                            for( int iIter = 0; iIter < nIters; ++iIter )
+                            {
+                                if( iIter == 1 )
+                                {
+                                    x0 += 360;
+                                    x1 += 360;
+                                    x2 += 360;
+                                    x3 += 360;
+                                }
+
+                                oRing.setPoint(0, x0, y0);
+                                oRing.setPoint(1, x2, y2);
+                                oRing.setPoint(2, x3, y3);
+                                oRing.setPoint(3, x1, y1);
+                                oRing.setPoint(4, x0, y0);
+                                if( oRing.isPointInRing( &oPoint ) ||
+                                    oRing.isPointOnRingBoundary( &oPoint ) )
+                                {
+                                    bMatchingGeoLocCellFound = true;
+                                    double dfBMXValue = pixel;
+                                    double dfBMYValue = line;
+                                    GDALInverseBilinearInterpolation(dfGeoX, dfGeoY,
+                                                                 x0, y0,
+                                                                 x1, y1,
+                                                                 x2, y2,
+                                                                 x3, y3,
+                                                                 dfBMXValue, dfBMYValue);
+
+                                    dfBMXValue = (dfBMXValue + dfGeorefConventionOffset) *
+                                        psTransform->dfPIXEL_STEP + psTransform->dfPIXEL_OFFSET ;
+                                    dfBMYValue = (dfBMYValue + dfGeorefConventionOffset) *
+                                        psTransform->dfLINE_STEP + psTransform->dfLINE_OFFSET ;
+
+                                    psTransform->pafBackMapX[iBMX + iBMY * nBMXSize] = static_cast<float>(dfBMXValue);
+                                    psTransform->pafBackMapY[iBMX + iBMY * nBMXSize] = static_cast<float>(dfBMYValue);
+                                    wgtsBackMap[iBMX + iBMY * nBMXSize] = 1.0f;
+                                }
+                            }
+                        }
+                    }
+                }
+                if( bMatchingGeoLocCellFound )
+                    continue;
+            }
+
+            // We will end up here in non-nominal cases, with nodata, holes,
+            // etc.
 
             //Check if the center is in range
             if( iBMX < -1 || iBMY < -1 ||
@@ -387,39 +781,46 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                 (iBMY > 0 && static_cast<size_t>(iBMY) > nBMYSize) )
                 continue;
 
+            const double fracBMX = dBMX - iBMX;
+            const double fracBMY = dBMY - iBMY;
+
             //Check logic for top left pixel
             if ((iBMX >= 0) && (iBMY >= 0) &&
                 (static_cast<size_t>(iBMX) < nBMXSize) &&
-                (static_cast<size_t>(iBMY) < nBMYSize))
+                (static_cast<size_t>(iBMY) < nBMYSize) &&
+                wgtsBackMap[iBMX + iBMY * nBMXSize] != 1.0f )
             {
                 const double tempwt = (1.0 - fracBMX) * (1.0 - fracBMY);
-                UpdateBackmap(iBMX, iBMY, iX, iY, tempwt);
+                UpdateBackmap(iBMX, iBMY, dfX, dfY, tempwt);
             }
 
             //Check logic for top right pixel
             if ((iBMY >= 0) &&
                 (static_cast<size_t>(iBMX+1) < nBMXSize) &&
-                (static_cast<size_t>(iBMY) < nBMYSize))
+                (static_cast<size_t>(iBMY) < nBMYSize) &&
+                wgtsBackMap[iBMX + 1 + iBMY * nBMXSize] != 1.0f )
             {
                 const double tempwt = fracBMX * (1.0 - fracBMY);
-                UpdateBackmap(iBMX + 1, iBMY, iX, iY, tempwt);
+                UpdateBackmap(iBMX + 1, iBMY, dfX, dfY, tempwt);
             }
 
             //Check logic for bottom right pixel
             if ((static_cast<size_t>(iBMX+1) < nBMXSize) &&
-                (static_cast<size_t>(iBMY+1) < nBMYSize))
+                (static_cast<size_t>(iBMY+1) < nBMYSize) &&
+                wgtsBackMap[(iBMX + 1) + (iBMY + 1) * nBMXSize] != 1.0f )
             {
                 const double tempwt = fracBMX * fracBMY;
-                UpdateBackmap(iBMX + 1, iBMY + 1, iX, iY, tempwt);
+                UpdateBackmap(iBMX + 1, iBMY + 1, dfX, dfY, tempwt);
             }
 
             //Check logic for bottom left pixel
             if ((iBMX >= 0) &&
                 (static_cast<size_t>(iBMX) < nBMXSize) &&
-                (static_cast<size_t>(iBMY+1) < nBMYSize))
+                (static_cast<size_t>(iBMY+1) < nBMYSize) &&
+                wgtsBackMap[iBMX + (iBMY + 1) * nBMXSize] != 1.0f )
             {
                 const double tempwt = (1.0 - fracBMX) * fracBMY;
-                UpdateBackmap(iBMX, iBMY + 1, iX, iY, tempwt);
+                UpdateBackmap(iBMX, iBMY + 1, dfX, dfY, tempwt);
             }
 
         }
@@ -440,8 +841,8 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
         }
         else
         {
-            psTransform->pafBackMapX[i] = -1.0f;
-            psTransform->pafBackMapY[i] = -1.0f;
+            psTransform->pafBackMapX[i] = INVALID_BMXY;
+            psTransform->pafBackMapY[i] = INVALID_BMXY;
         }
     }
 
@@ -462,12 +863,13 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
         szBuffer[CPLPrintPointer(szBuffer, ptr, sizeof(szBuffer))] = '\0';
         snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
         poMEMDS->AddBand(GDT_Float32, apszOptions);
-        poMEMDS->GetRasterBand(i)->SetNoDataValue(-1);
+        poMEMDS->GetRasterBand(i)->SetNoDataValue(INVALID_BMXY);
     }
 
 #ifdef DEBUG_GEOLOC
     if( CPLTestBool(CPLGetConfigOption("GEOLOC_DUMP", "NO")) )
     {
+        poMEMDS->SetGeoTransform(psTransform->adfBackMapGeoTransform);
         GDALClose(GDALCreateCopy(GDALGetDriverByName("GTiff"),
                               "/tmp/geoloc_before_fill.tif",
                               poMEMDS.get(),
@@ -507,7 +909,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
         for( size_t iBMX = 0; iBMX < nBMXSize; iBMX++ )
         {
             const size_t iBM = iBMX + iBMY * nBMXSize;
-            if( psTransform->pafBackMapX[iBM] < 0 )
+            if( psTransform->pafBackMapX[iBM] == INVALID_BMXY )
                 continue;
             if( iLastValidIX != static_cast<size_t>(-1) &&
                 iBMX > iLastValidIX + 1 &&
@@ -542,6 +944,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 #endif
 
     CPLFree( wgtsBackMap );
+    CPLDebug("GEOLOC", "Ending backmap generation");
 
     return true;
 }
@@ -588,23 +991,25 @@ void* GDALCreateSimilarGeoLocTransformer( void *hTransformArg,
             "LINE_STEP", 1.0 / dfRatioY, 1.0);
     }
 
-    psInfo = static_cast<GDALGeoLocTransformInfo*>(
+    auto psInfoNew = static_cast<GDALGeoLocTransformInfo*>(
         GDALCreateGeoLocTransformer(
             nullptr, papszGeolocationInfo, psInfo->bReversed));
+    psInfoNew->dfOversampleFactor = psInfo->dfOversampleFactor;
 
     CSLDestroy(papszGeolocationInfo);
 
-    return psInfo;
+    return psInfoNew;
 }
 
 /************************************************************************/
 /*                    GDALCreateGeoLocTransformer()                     */
 /************************************************************************/
 
-/** Create GeoLocation transformer */
-void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
-                                   char **papszGeolocationInfo,
-                                   int bReversed )
+void *GDALCreateGeoLocTransformerEx( GDALDatasetH hBaseDS,
+                                     char **papszGeolocationInfo,
+                                     int bReversed,
+                                     const char* pszSourceDataset,
+                                     CSLConstList papszTransformOptions )
 
 {
 
@@ -629,6 +1034,9 @@ void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
             CPLCalloc(sizeof(GDALGeoLocTransformInfo), 1));
 
     psTransform->bReversed = CPL_TO_BOOL(bReversed);
+    psTransform->dfOversampleFactor = std::max(0.1, std::min(2.0, CPLAtof(
+        CSLFetchNameValueDef(papszTransformOptions, "GEOLOC_BACKMAP_OVERSAMPLE_FACTOR",
+                             CPLGetConfigOption("GDAL_GEOLOC_BACKMAP_OVERSAMPLE_FACTOR", "1.3")))));
 
     memcpy( psTransform->sTI.abySignature,
             GDAL_GTI2_SIGNATURE,
@@ -653,6 +1061,11 @@ void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
     psTransform->dfLINE_STEP =
         CPLAtof(CSLFetchNameValue( papszGeolocationInfo, "LINE_STEP" ));
 
+    psTransform->bOriginIsTopLeftCorner =
+        EQUAL( CSLFetchNameValueDef(papszGeolocationInfo,
+                                    "GEOREFERENCING_CONVENTION",
+                                    "TOP_LEFT_CORNER"), "TOP_LEFT_CORNER" );
+
 /* -------------------------------------------------------------------- */
 /*      Establish access to geolocation dataset(s).                     */
 /* -------------------------------------------------------------------- */
@@ -661,7 +1074,19 @@ void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
     if( pszDSName != nullptr )
     {
         CPLConfigOptionSetter oSetter("CPL_ALLOW_VSISTDIN", "NO", true);
-        psTransform->hDS_X = GDALOpenShared( pszDSName, GA_ReadOnly );
+        if( CPLTestBool(CSLFetchNameValueDef(papszGeolocationInfo,
+                            "X_DATASET_RELATIVE_TO_SOURCE", "NO")) &&
+            (hBaseDS != nullptr || pszSourceDataset) )
+        {
+            CPLString osFilename = CPLProjectRelativeFilename(
+                CPLGetDirname(pszSourceDataset ? pszSourceDataset : GDALGetDescription(hBaseDS)),
+                   pszDSName);
+            psTransform->hDS_X = GDALOpenShared( osFilename.c_str(), GA_ReadOnly );
+        }
+        else
+        {
+            psTransform->hDS_X = GDALOpenShared( pszDSName, GA_ReadOnly );
+        }
     }
     else
     {
@@ -680,7 +1105,19 @@ void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
     if( pszDSName != nullptr )
     {
         CPLConfigOptionSetter oSetter("CPL_ALLOW_VSISTDIN", "NO", true);
-        psTransform->hDS_Y = GDALOpenShared( pszDSName, GA_ReadOnly );
+        if( CPLTestBool(CSLFetchNameValueDef(papszGeolocationInfo,
+                            "Y_DATASET_RELATIVE_TO_SOURCE", "NO")) &&
+            (hBaseDS != nullptr || pszSourceDataset) )
+        {
+            CPLString osFilename = CPLProjectRelativeFilename(
+                CPLGetDirname(pszSourceDataset ? pszSourceDataset : GDALGetDescription(hBaseDS)),
+                   pszDSName);
+            psTransform->hDS_Y = GDALOpenShared( osFilename.c_str(), GA_ReadOnly );
+        }
+        else
+        {
+            psTransform->hDS_Y = GDALOpenShared( pszDSName, GA_ReadOnly );
+        }
     }
     else
     {
@@ -761,14 +1198,30 @@ void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
 /* -------------------------------------------------------------------- */
 /*      Load the geolocation array.                                     */
 /* -------------------------------------------------------------------- */
-    if( !GeoLocLoadFullData( psTransform )
-        || !GeoLocGenerateBackMap( psTransform ) )
+
+    // The quadtree method is experimental. It simplifies the code significantly,
+    // but unfortunately burns more RAM and is slower.
+    const bool bUseQuadtree =
+        EQUAL(CPLGetConfigOption("GDAL_GEOLOC_INVERSE_METHOD", "BACKMAP"), "QUADTREE");
+    if( !GeoLocLoadFullData( psTransform, papszGeolocationInfo )
+        || (bUseQuadtree && !GDALGeoLocBuildQuadTree( psTransform ))
+        || (!bUseQuadtree && !GeoLocGenerateBackMap( psTransform )) )
     {
         GDALDestroyGeoLocTransformer( psTransform );
         return nullptr;
     }
 
     return psTransform;
+}
+
+/** Create GeoLocation transformer */
+void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
+                                   char **papszGeolocationInfo,
+                                   int bReversed )
+
+{
+    return GDALCreateGeoLocTransformerEx( hBaseDS, papszGeolocationInfo,
+                                          bReversed, nullptr, nullptr );
 }
 
 /************************************************************************/
@@ -799,19 +1252,148 @@ void GDALDestroyGeoLocTransformer( void *pTransformAlg )
         && GDALDereferenceDataset( psTransform->hDS_Y ) == 0 )
             GDALClose( psTransform->hDS_Y );
 
+    if( psTransform->hQuadTree != nullptr )
+        CPLQuadTreeDestroy( psTransform->hQuadTree );
+
     CPLFree( pTransformAlg );
+}
+
+/************************************************************************/
+/*                      GDALGeoLocPosPixelLineToXY()                    */
+/************************************************************************/
+
+/** Interpolate a position expessed as (floating point) pixel/line in the
+ * geolocation array to the corresponding bilinearly-interpolated georeferenced
+ * position.
+ *
+ * The interpolation assumes infinite extension beyond borders of available
+ * data based on closest grid square.
+ *
+ * @param psTransform Transformation info
+ * @param dfGeoLocPixel Position along the column/pixel axis of the geolocation array
+ * @param dfGeoLocLine  Position along the row/line axis of the geolocation array
+ * @param[out] dfX      Output X of georeferenced position.
+ * @param[out] dfY      Output Y of georeferenced position.
+ * @return true if success
+ */
+bool GDALGeoLocPosPixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
+                                const double dfGeoLocPixel,
+                                const double dfGeoLocLine,
+                                double& dfX,
+                                double& dfY)
+{
+    const size_t nXSize = psTransform->nGeoLocXSize;
+    size_t iX = static_cast<size_t>(std::max(0.0, dfGeoLocPixel));
+    iX = std::min(iX, psTransform->nGeoLocXSize-1);
+    size_t iY = static_cast<size_t>(std::max(0.0, dfGeoLocLine));
+    iY = std::min(iY, psTransform->nGeoLocYSize-1);
+
+    for( int iAttempt = 0; iAttempt < 2; ++iAttempt )
+    {
+        const double *padfGLX = psTransform->padfGeoLocX + iX + iY * nXSize;
+        const double *padfGLY = psTransform->padfGeoLocY + iX + iY * nXSize;
+
+        if( psTransform->bHasNoData &&
+            padfGLX[0] == psTransform->dfNoDataX )
+        {
+            return false;
+        }
+
+        // This assumes infinite extension beyond borders of available
+        // data based on closest grid square.
+        const double dfRefX = padfGLX[0];
+        if( iX + 1 < psTransform->nGeoLocXSize &&
+            iY + 1 < psTransform->nGeoLocYSize &&
+            (!psTransform->bHasNoData ||
+                (padfGLX[1] != psTransform->dfNoDataX &&
+                 padfGLX[nXSize] != psTransform->dfNoDataX &&
+                 padfGLX[nXSize + 1] != psTransform->dfNoDataX) ))
+        {
+            dfX =
+                (1 - (dfGeoLocLine -iY))
+                * (padfGLX[0] +
+                   (dfGeoLocPixel-iX) * (ShiftGeoX(psTransform, dfRefX, padfGLX[1]) - padfGLX[0]))
+                + (dfGeoLocLine -iY)
+                * (ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize]) + (dfGeoLocPixel-iX) *
+                   (ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize+1]) -
+                       ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize])));
+            dfX = UnshiftGeoX(psTransform, dfX);
+
+            dfY =
+                (1 - (dfGeoLocLine -iY))
+                * (padfGLY[0] +
+                   (dfGeoLocPixel-iX) * (padfGLY[1] - padfGLY[0]))
+                + (dfGeoLocLine -iY)
+                * (padfGLY[nXSize] + (dfGeoLocPixel-iX) *
+                   (padfGLY[nXSize+1] - padfGLY[nXSize]));
+        }
+        else if( iX == psTransform->nGeoLocXSize -1 &&
+                 iX >= 1 && iY + 1 < psTransform->nGeoLocYSize )
+        {
+            // If we are after the right edge, then go one pixel left
+            // and retry
+            iX --;
+            continue;
+        }
+        else if( iY == psTransform->nGeoLocYSize - 1 &&
+                 iY >= 1 && iX + 1 < psTransform->nGeoLocXSize )
+        {
+            // If we are after the bottom edge, then go one pixel up
+            // and retry
+            iY --;
+            continue;
+        }
+        else if( iX == psTransform->nGeoLocXSize -1 &&
+                 iY == psTransform->nGeoLocYSize - 1 &&
+                 iX >= 1 && iY >= 1 )
+        {
+            // If we are after the right and bottom edge, then go one pixel left and up
+            // and retry
+            iX --;
+            iY --;
+            continue;
+        }
+        else if( iX + 1 < psTransform->nGeoLocXSize &&
+                 (!psTransform->bHasNoData ||
+                    padfGLX[1] != psTransform->dfNoDataX) )
+        {
+            dfX =
+                padfGLX[0] + (dfGeoLocPixel-iX) * (ShiftGeoX(psTransform, dfRefX, padfGLX[1]) - padfGLX[0]);
+            dfX = UnshiftGeoX(psTransform, dfX);
+            dfY =
+                padfGLY[0] + (dfGeoLocPixel-iX) * (padfGLY[1] - padfGLY[0]);
+        }
+        else if( iY + 1 < psTransform->nGeoLocYSize &&
+                 (!psTransform->bHasNoData ||
+                    padfGLX[nXSize] != psTransform->dfNoDataX) )
+        {
+            dfX = padfGLX[0]
+                + (dfGeoLocLine -iY) * (ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize]) - padfGLX[0]);
+            dfX = UnshiftGeoX(psTransform, dfX);
+            dfY = padfGLY[0]
+                + (dfGeoLocLine -iY) * (padfGLY[nXSize] - padfGLY[0]);
+        }
+        else
+        {
+            dfX = padfGLX[0];
+            dfY = padfGLY[0];
+        }
+        break;
+    }
+    return true;
 }
 
 /************************************************************************/
 /*                        GDALGeoLocTransform()                         */
 /************************************************************************/
 
+
 /** Use GeoLocation transformer */
 int GDALGeoLocTransform( void *pTransformArg,
                          int bDstToSrc,
                          int nPointCount,
                          double *padfX, double *padfY,
-                         CPL_UNUSED double *padfZ,
+                         double * /* padfZ */,
                          int *panSuccess )
 {
     GDALGeoLocTransformInfo *psTransform =
@@ -820,13 +1402,13 @@ int GDALGeoLocTransform( void *pTransformArg,
     if( psTransform->bReversed )
         bDstToSrc = !bDstToSrc;
 
+    const double dfGeorefConventionOffset = psTransform->bOriginIsTopLeftCorner ? 0 : 0.5;
+
 /* -------------------------------------------------------------------- */
 /*      Do original pixel line to target geox/geoy.                     */
 /* -------------------------------------------------------------------- */
     if( !bDstToSrc )
     {
-        const size_t nXSize = psTransform->nGeoLocXSize;
-
         for( int i = 0; i < nPointCount; i++ )
         {
             if( padfX[i] == HUGE_VAL || padfY[i] == HUGE_VAL )
@@ -837,75 +1419,21 @@ int GDALGeoLocTransform( void *pTransformArg,
 
             const double dfGeoLocPixel =
                 (padfX[i] - psTransform->dfPIXEL_OFFSET)
-                / psTransform->dfPIXEL_STEP;
+                / psTransform->dfPIXEL_STEP - dfGeorefConventionOffset;
             const double dfGeoLocLine =
                 (padfY[i] - psTransform->dfLINE_OFFSET)
-                / psTransform->dfLINE_STEP;
+                / psTransform->dfLINE_STEP - dfGeorefConventionOffset;
 
-            size_t iX = static_cast<size_t>(std::max(0.0, dfGeoLocPixel));
-            iX = std::min(iX, psTransform->nGeoLocXSize-1);
-            size_t iY = static_cast<size_t>(std::max(0.0, dfGeoLocLine));
-            iY = std::min(iY, psTransform->nGeoLocYSize-1);
-
-            const double *padfGLX = psTransform->padfGeoLocX + iX + iY * nXSize;
-            const double *padfGLY = psTransform->padfGeoLocY + iX + iY * nXSize;
-
-            if( psTransform->bHasNoData &&
-                padfGLX[0] == psTransform->dfNoDataX )
+            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                                         dfGeoLocPixel,
+                                         dfGeoLocLine,
+                                         padfX[i],
+                                         padfY[i]) )
             {
                 panSuccess[i] = FALSE;
                 padfX[i] = HUGE_VAL;
                 padfY[i] = HUGE_VAL;
                 continue;
-            }
-
-            // This assumes infinite extension beyond borders of available
-            // data based on closest grid square.
-
-            if( iX + 1 < psTransform->nGeoLocXSize &&
-                iY + 1 < psTransform->nGeoLocYSize &&
-                (!psTransform->bHasNoData ||
-                    (padfGLX[1] != psTransform->dfNoDataX &&
-                     padfGLX[nXSize] != psTransform->dfNoDataX &&
-                     padfGLX[nXSize + 1] != psTransform->dfNoDataX) ))
-            {
-                padfX[i] =
-                    (1 - (dfGeoLocLine -iY))
-                    * (padfGLX[0] +
-                       (dfGeoLocPixel-iX) * (padfGLX[1] - padfGLX[0]))
-                    + (dfGeoLocLine -iY)
-                    * (padfGLX[nXSize] + (dfGeoLocPixel-iX) *
-                       (padfGLX[nXSize+1] - padfGLX[nXSize]));
-                padfY[i] =
-                    (1 - (dfGeoLocLine -iY))
-                    * (padfGLY[0] +
-                       (dfGeoLocPixel-iX) * (padfGLY[1] - padfGLY[0]))
-                    + (dfGeoLocLine -iY)
-                    * (padfGLY[nXSize] + (dfGeoLocPixel-iX) *
-                       (padfGLY[nXSize+1] - padfGLY[nXSize]));
-            }
-            else if( iX + 1 < psTransform->nGeoLocXSize &&
-                     (!psTransform->bHasNoData ||
-                        padfGLX[1] != psTransform->dfNoDataX) )
-            {
-                padfX[i] =
-                    padfGLX[0] + (dfGeoLocPixel-iX) * (padfGLX[1] - padfGLX[0]);
-                padfY[i] =
-                    padfGLY[0] + (dfGeoLocPixel-iX) * (padfGLY[1] - padfGLY[0]);
-            }
-            else if( iY + 1 < psTransform->nGeoLocYSize &&
-                     (!psTransform->bHasNoData ||
-                        padfGLX[nXSize] != psTransform->dfNoDataX) )
-            {
-                padfX[i] = padfGLX[0]
-                    + (dfGeoLocLine -iY) * (padfGLX[nXSize] - padfGLX[0]);
-                padfY[i] = padfGLY[0]
-                    + (dfGeoLocLine -iY) * (padfGLY[nXSize] - padfGLY[0]);
-            }
-            else
-            {
-                padfX[i] = padfGLX[0];
-                padfY[i] = padfGLY[0];
             }
 
             if( psTransform->bSwapXY )
@@ -922,6 +1450,25 @@ int GDALGeoLocTransform( void *pTransformArg,
 /* -------------------------------------------------------------------- */
     else
     {
+        if( psTransform->hQuadTree )
+        {
+            GDALGeoLocInverseTransformQuadtree(psTransform,
+                                               nPointCount,
+                                               padfX,
+                                               padfY,
+                                               panSuccess);
+            return TRUE;
+        }
+
+        const bool bGeolocMaxAccuracy = CPLTestBool(
+            CPLGetConfigOption("GDAL_GEOLOC_USE_MAX_ACCURACY", "YES"));
+
+        // Keep those objects in this outer scope, so they are re-used, to
+        // save memory allocations.
+        OGRPoint oPoint;
+        OGRLinearRing oRing;
+        oRing.setNumPoints(5);
+
         for( int i = 0; i < nPointCount; i++ )
         {
             if( padfX[i] == HUGE_VAL || padfY[i] == HUGE_VAL )
@@ -935,19 +1482,19 @@ int GDALGeoLocTransform( void *pTransformArg,
                 std::swap(padfX[i], padfY[i]);
             }
 
+            const double dfGeoX = padfX[i];
+            const double dfGeoY = padfY[i];
+
             const double dfBMX =
                 ((padfX[i] - psTransform->adfBackMapGeoTransform[0])
-                 / psTransform->adfBackMapGeoTransform[1]) - ISHIFT;
+                 / psTransform->adfBackMapGeoTransform[1]);
             const double dfBMY =
                 ((padfY[i] - psTransform->adfBackMapGeoTransform[3])
-                 / psTransform->adfBackMapGeoTransform[5]) - ISHIFT;
+                 / psTransform->adfBackMapGeoTransform[5]);
 
-            // FIXME: in the case of ]-1,0[, dfBMX-iBMX will be wrong
-            // We should likely error out if values are < 0 ==> affects a few
-            // autotest results
-            if( !(dfBMX > -1 && dfBMY > -1 &&
-                  dfBMX < psTransform->nBackMapWidth &&
-                  dfBMY < psTransform->nBackMapHeight) )
+            if( !(dfBMX >= 0 && dfBMY >= 0 &&
+                  dfBMX + 1 < psTransform->nBackMapWidth &&
+                  dfBMY + 1 < psTransform->nBackMapHeight) )
             {
                 panSuccess[i] = FALSE;
                 padfX[i] = HUGE_VAL;
@@ -959,7 +1506,7 @@ int GDALGeoLocTransform( void *pTransformArg,
             const std::ptrdiff_t iBMY = static_cast<std::ptrdiff_t>(dfBMY);
 
             const size_t iBM = iBMX + iBMY * psTransform->nBackMapWidth;
-            if( psTransform->pafBackMapX[iBM] < 0 )
+            if( psTransform->pafBackMapX[iBM] == INVALID_BMXY )
             {
                 panSuccess[i] = FALSE;
                 padfX[i] = HUGE_VAL;
@@ -969,11 +1516,9 @@ int GDALGeoLocTransform( void *pTransformArg,
 
             const float* pafBMX = psTransform->pafBackMapX + iBM;
             const float* pafBMY = psTransform->pafBackMapY + iBM;
-
-            if( static_cast<size_t>(iBMX + 1) < psTransform->nBackMapWidth &&
-                static_cast<size_t>(iBMY + 1) < psTransform->nBackMapHeight &&
-                pafBMX[1] >=0 && pafBMX[psTransform->nBackMapWidth] >= 0 &&
-                pafBMX[psTransform->nBackMapWidth+1] >= 0)
+            if( pafBMX[1] != INVALID_BMXY &&
+                pafBMX[psTransform->nBackMapWidth] != INVALID_BMXY &&
+                pafBMX[psTransform->nBackMapWidth+1] != INVALID_BMXY)
             {
                 padfX[i] =
                     (1-(dfBMY - iBMY))
@@ -990,16 +1535,14 @@ int GDALGeoLocTransform( void *pTransformArg,
                        (dfBMX - iBMX) * (pafBMY[psTransform->nBackMapWidth+1] -
                                          pafBMY[psTransform->nBackMapWidth]));
             }
-            else if( static_cast<size_t>(iBMX + 1) < psTransform->nBackMapWidth &&
-                     pafBMX[1] >=0)
+            else if( pafBMX[1] != INVALID_BMXY)
             {
                 padfX[i] = pafBMX[0] +
                             (dfBMX - iBMX) * (pafBMX[1] - pafBMX[0]);
                 padfY[i] = pafBMY[0] +
                             (dfBMX - iBMX) * (pafBMY[1] - pafBMY[0]);
             }
-            else if( static_cast<size_t>(iBMY + 1) < psTransform->nBackMapHeight &&
-                     pafBMX[psTransform->nBackMapWidth] >= 0 )
+            else if( pafBMX[psTransform->nBackMapWidth] != INVALID_BMXY)
             {
                 padfX[i] =
                     pafBMX[0] +
@@ -1015,6 +1558,169 @@ int GDALGeoLocTransform( void *pTransformArg,
                 padfX[i] = pafBMX[0];
                 padfY[i] = pafBMY[0];
             }
+
+            const double dfGeoLocPixel =
+                (padfX[i] - psTransform->dfPIXEL_OFFSET)
+                / psTransform->dfPIXEL_STEP - dfGeorefConventionOffset;
+            const double dfGeoLocLine =
+                (padfY[i] - psTransform->dfLINE_OFFSET)
+                / psTransform->dfLINE_STEP - dfGeorefConventionOffset;
+#if 0
+            CPLDebug("GEOLOC", "%f %f %f %f", padfX[i], padfY[i], dfGeoLocPixel, dfGeoLocLine);
+            if( !psTransform->bOriginIsTopLeftCorner )
+            {
+                if( dfGeoLocPixel + dfGeorefConventionOffset > psTransform->nGeoLocXSize-1 ||
+                    dfGeoLocLine + dfGeorefConventionOffset > psTransform->nGeoLocYSize-1 )
+                {
+                    panSuccess[i] = FALSE;
+                    padfX[i] = HUGE_VAL;
+                    padfY[i] = HUGE_VAL;
+                    continue;
+                }
+            }
+#endif
+            if( !bGeolocMaxAccuracy )
+            {
+                panSuccess[i] = TRUE;
+                continue;
+            }
+
+            // Now that we have an approximate solution, identify a matching
+            // cell in the geolocation array, where we can use inverse bilinear
+            // interpolation to find the exact solution.
+
+            // NOTE: if the geolocation array is an affine transformation,
+            // the approximate solution should match the exact one, if the
+            // backmap has correctly been built.
+
+            oPoint.setX(dfGeoX);
+            oPoint.setY(dfGeoY);
+            // The thresholds and radius are rather empirical and have been tuned
+            // on the product S5P_TEST_L2__NO2____20190509T220707_20190509T234837_08137_01_010400_20200220T091343.nc
+            // that includes the north pole.
+            const int nSearchRadius =
+                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 85 ? 5 :
+                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 75 ? 3 :
+                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 65 ? 2 : 1;
+            const ptrdiff_t nGeoLocPixel = static_cast<ptrdiff_t>(std::floor(dfGeoLocPixel));
+            const ptrdiff_t nGeoLocLine = static_cast<ptrdiff_t>(std::floor(dfGeoLocLine));
+
+            bool bDone = false;
+            // Using the above approximate nGeoLocPixel, nGeoLocLine, try to
+            // find a forward cell that includes (dfGeoX, dfGeoY), with an increasing
+            // search radius, up to nSearchRadius.
+            for( int r = 0; !bDone && r <= nSearchRadius; r++ )
+            {
+                for( int iter = 0; !bDone && iter < (r == 0 ? 1 : 8 * r); ++iter)
+                {
+                    // For r=1, the below formulas will give the following offsets:
+                    // (-1,1), (0,1), (1,1), (1,0), (1,-1), (0,-1), (1,-1)
+                    const int sx = (r == 0) ? 0 :
+                             (iter < 2 *r) ? -r + iter :
+                             (iter < 4 * r) ? r :
+                             (iter < 6 * r) ? r - (iter - 4 * r):
+                             -r;
+                    const int sy = (r == 0) ? 0 :
+                             (iter < 2 *r) ? r :
+                             (iter < 4 * r) ? r - (iter - 2 * r) :
+                             (iter < 6 * r) ? -r:
+                             -r + (iter - 6 * r);
+                    const ptrdiff_t iX = nGeoLocPixel + sx;
+                    const ptrdiff_t iY = nGeoLocLine + sy;
+                    if( (iX == -1 || (iX >= 0 && static_cast<size_t>(iX) < psTransform->nGeoLocXSize)) &&
+                        (iY == -1 || (iY >= 0 && static_cast<size_t>(iY) < psTransform->nGeoLocYSize)) )
+                    {
+                        double x0, y0, x1, y1, x2, y2, x3, y3;
+
+                        if( !GDALGeoLocPosPixelLineToXY(psTransform,
+                                static_cast<double>(iX), static_cast<double>(iY),
+                                x0, y0) ||
+                            !GDALGeoLocPosPixelLineToXY(psTransform,
+                                static_cast<double>(iX+1), static_cast<double>(iY),
+                                x2, y2) ||
+                            !GDALGeoLocPosPixelLineToXY(psTransform,
+                                static_cast<double>(iX), static_cast<double>(iY+1),
+                                x1, y1) ||
+                            !GDALGeoLocPosPixelLineToXY(psTransform,
+                                static_cast<double>(iX+1), static_cast<double>(iY+1),
+                                x3, y3) )
+                        {
+                            continue;
+                        }
+
+                        int nIters = 1;
+                        // For a bounding box crossing the anti-meridian, check
+                        // both around -180 and +180 deg.
+                        if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+                            std::fabs(x0) > 170 &&
+                            std::fabs(x1) > 170 &&
+                            std::fabs(x2) > 170 &&
+                            std::fabs(x3) > 170 &&
+                            (std::fabs(x1-x0) > 180 ||
+                             std::fabs(x2-x0) > 180 ||
+                             std::fabs(x3-x0) > 180) )
+                        {
+                            nIters = 2;
+                            if( x0 > 0 ) x0 -= 360;
+                            if( x1 > 0 ) x1 -= 360;
+                            if( x2 > 0 ) x2 -= 360;
+                            if( x3 > 0 ) x3 -= 360;
+                        }
+                        for( int iIter = 0; !bDone && iIter < nIters; ++iIter )
+                        {
+                            if( iIter == 1 )
+                            {
+                                x0 += 360;
+                                x1 += 360;
+                                x2 += 360;
+                                x3 += 360;
+                            }
+                            oRing.setPoint(0, x0, y0);
+                            oRing.setPoint(1, x2, y2);
+                            oRing.setPoint(2, x3, y3);
+                            oRing.setPoint(3, x1, y1);
+                            oRing.setPoint(4, x0, y0);
+                            if( oRing.isPointInRing( &oPoint ) ||
+                                oRing.isPointOnRingBoundary( &oPoint ) )
+                            {
+                                double dfX = static_cast<double>(iX);
+                                double dfY = static_cast<double>(iY);
+                                GDALInverseBilinearInterpolation(dfGeoX, dfGeoY,
+                                                             x0, y0,
+                                                             x1, y1,
+                                                             x2, y2,
+                                                             x3, y3,
+                                                             dfX, dfY);
+
+                                dfX = (dfX + dfGeorefConventionOffset) *
+                                    psTransform->dfPIXEL_STEP + psTransform->dfPIXEL_OFFSET;
+                                dfY = (dfY + dfGeorefConventionOffset) *
+                                    psTransform->dfLINE_STEP + psTransform->dfLINE_OFFSET;
+
+#ifdef DEBUG_GEOLOC_REALLY_VERBOSE
+                                CPLDebug("GEOLOC",
+                                         "value before adjustment: %f %f, "
+                                         "after adjustment: %f %f",
+                                         padfX[i], padfY[i], dfX, dfY);
+#endif
+
+                                padfX[i] = dfX;
+                                padfY[i] = dfY;
+
+                                bDone = true;
+                            }
+                        }
+                    }
+                }
+            }
+            if( !bDone )
+            {
+                panSuccess[i] = FALSE;
+                padfX[i] = HUGE_VAL;
+                padfY[i] = HUGE_VAL;
+                continue;
+            }
+
             panSuccess[i] = TRUE;
         }
     }
@@ -1110,7 +1816,10 @@ void *GDALDeserializeGeoLocTransformer( CPLXMLNode *psTree )
 /* -------------------------------------------------------------------- */
 /*      Generate transformation.                                        */
 /* -------------------------------------------------------------------- */
-    void *pResult = GDALCreateGeoLocTransformer( nullptr, papszMD, bReversed );
+
+    const char* pszSourceDataset = CPLGetXMLValue(psTree,"SourceDataset",nullptr);
+
+    void *pResult = GDALCreateGeoLocTransformerEx( nullptr, papszMD, bReversed, pszSourceDataset, nullptr );
 
 /* -------------------------------------------------------------------- */
 /*      Cleanup GCP copy.                                               */

--- a/alg/gdalgeoloc.cpp
+++ b/alg/gdalgeoloc.cpp
@@ -54,6 +54,11 @@
 #include "gdal_priv.h"
 #include "memdataset.h"
 
+constexpr float INVALID_BMXY = -10.0f;
+
+#include "gdalgeoloc_carray_accessor.h"
+#include "gdalgeoloc_dataset_accessor.h"
+
 //#define DEBUG_GEOLOC
 
 #ifdef DEBUG_GEOLOC
@@ -76,8 +81,6 @@ CPL_C_END
 /*                         GDALGeoLocTransformer                        */
 /* ==================================================================== */
 /************************************************************************/
-
-constexpr float INVALID_BMXY = -10.0f;
 
 /************************************************************************/
 /*                           UnshiftGeoX()                              */
@@ -136,116 +139,16 @@ inline double Clamp(double v, double minV, double maxV)
 }
 
 /************************************************************************/
-/*                         GeoLocLoadFullData()                         */
+/*                    GDALGeoLoc::LoadGeolocFinish()                    */
 /************************************************************************/
 
-static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
-                                CSLConstList papszGeolocationInfo )
+/*! @cond Doxygen_Suppress */
 
+template<class Accessors>
+bool GDALGeoLoc<Accessors>::LoadGeolocFinish( GDALGeoLocTransformInfo *psTransform )
 {
-    const int nXSize_XBand = GDALGetRasterXSize( psTransform->hDS_X );
-    const int nYSize_XBand = GDALGetRasterYSize( psTransform->hDS_X );
-    const int nXSize_YBand = GDALGetRasterXSize( psTransform->hDS_Y );
-    const int nYSize_YBand = GDALGetRasterYSize( psTransform->hDS_Y );
-
-    // Is it a regular grid ? That is:
-    // The XBAND contains the x coordinates for all lines.
-    // The YBAND contains the y coordinates for all columns.
-    const bool bIsRegularGrid = ( nYSize_XBand == 1 && nYSize_YBand == 1 );
-
-    const int nXSize = nXSize_XBand;
-    int nYSize = 0;
-    if( bIsRegularGrid )
-    {
-        nYSize = nXSize_YBand;
-    }
-    else
-    {
-        nYSize = nYSize_XBand;
-    }
-
-    psTransform->nGeoLocXSize = static_cast<size_t>(nXSize);
-    psTransform->nGeoLocYSize = static_cast<size_t>(nYSize);
-
-    psTransform->padfGeoLocY = static_cast<double *>(
-        VSI_MALLOC3_VERBOSE(sizeof(double), nXSize, nYSize));
-    psTransform->padfGeoLocX = static_cast<double *>(
-        VSI_MALLOC3_VERBOSE(sizeof(double), nXSize, nYSize));
-
-    if( psTransform->padfGeoLocX == nullptr ||
-        psTransform->padfGeoLocY == nullptr )
-    {
-        return false;
-    }
-
-    if( bIsRegularGrid )
-    {
-        // Case of regular grid.
-        // The XBAND contains the x coordinates for all lines.
-        // The YBAND contains the y coordinates for all columns.
-
-        double* padfTempX = static_cast<double *>(
-            VSI_MALLOC2_VERBOSE(nXSize, sizeof(double)));
-        double* padfTempY = static_cast<double *>(
-            VSI_MALLOC2_VERBOSE(nYSize, sizeof(double)));
-        if( padfTempX == nullptr || padfTempY == nullptr )
-        {
-            CPLFree(padfTempX);
-            CPLFree(padfTempY);
-            return false;
-        }
-
-        CPLErr eErr =
-            GDALRasterIO( psTransform->hBand_X, GF_Read,
-                          0, 0, nXSize, 1,
-                          padfTempX, nXSize, 1,
-                          GDT_Float64, 0, 0 );
-
-        for( size_t j = 0; j < static_cast<size_t>(nYSize); j++ )
-        {
-            memcpy( psTransform->padfGeoLocX + j * nXSize,
-                    padfTempX,
-                    nXSize * sizeof(double) );
-        }
-
-        if( eErr == CE_None )
-        {
-            eErr = GDALRasterIO( psTransform->hBand_Y, GF_Read,
-                                 0, 0, nYSize, 1,
-                                 padfTempY, nYSize, 1,
-                                 GDT_Float64, 0, 0 );
-
-            for( size_t j = 0; j < static_cast<size_t>(nYSize); j++ )
-            {
-                for( size_t i = 0; i < static_cast<size_t>(nXSize); i++ )
-                {
-                    psTransform->padfGeoLocY[j * nXSize + i] = padfTempY[j];
-                }
-            }
-        }
-
-        CPLFree(padfTempX);
-        CPLFree(padfTempY);
-
-        if( eErr != CE_None )
-            return false;
-    }
-    else
-    {
-        if( GDALRasterIO( psTransform->hBand_X, GF_Read,
-                          0, 0, nXSize, nYSize,
-                          psTransform->padfGeoLocX, nXSize, nYSize,
-                          GDT_Float64, 0, 0 ) != CE_None
-            || GDALRasterIO( psTransform->hBand_Y, GF_Read,
-                             0, 0, nXSize, nYSize,
-                             psTransform->padfGeoLocY, nXSize, nYSize,
-                             GDT_Float64, 0, 0 ) != CE_None )
-            return false;
-    }
-
-    psTransform->dfNoDataX =
-        GDALGetRasterNoDataValue( psTransform->hBand_X,
-                                  &(psTransform->bHasNoData) );
+    auto pAccessors = static_cast<Accessors*>(psTransform->pAccessors);
+    CSLConstList papszGeolocationInfo = psTransform->papszGeolocationInfo;
 
 /* -------------------------------------------------------------------- */
 /*      Scan forward map for lat/long extents.                          */
@@ -255,15 +158,18 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
     psTransform->dfMinY = std::numeric_limits<double>::max();
     psTransform->dfMaxY = -std::numeric_limits<double>::max();
 
-    const size_t nXYCount = psTransform->nGeoLocXSize * psTransform->nGeoLocYSize;
-    for( size_t i = 0; i < nXYCount; i++ )
+    for( int iY = 0; iY < psTransform->nGeoLocYSize; iY++ )
     {
-        if( !psTransform->bHasNoData ||
-            psTransform->padfGeoLocX[i] != psTransform->dfNoDataX )
+        for( int iX = 0; iX < psTransform->nGeoLocXSize; iX++ )
         {
-            UpdateMinMax(psTransform,
-                         psTransform->padfGeoLocX[i],
-                         psTransform->padfGeoLocY[i]);
+            const auto dfX = pAccessors->geolocXAccessor.Get(iX, iY);
+            if( !psTransform->bHasNoData ||
+                 dfX!= psTransform->dfNoDataX )
+            {
+                UpdateMinMax(psTransform,
+                             dfX,
+                             pAccessors->geolocYAccessor.Get(iX, iY));
+            }
         }
     }
 
@@ -292,15 +198,15 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
         poLayer->CreateField(&fieldX);
         OGRFieldDefn fieldY("y", OFTInteger);
         poLayer->CreateField(&fieldY);
-        for( size_t iY = 0; iY + 1 < psTransform->nGeoLocYSize; iY++ )
+        for( int iY = 0; iY < psTransform->nGeoLocYSize - 1; iY++ )
         {
-            for( size_t iX = 0; iX + 1 < psTransform->nGeoLocXSize; iX++ )
+            for( int iX = 0; iX < psTransform->nGeoLocXSize - 1; iX++ )
             {
                 double x0, y0, x1, y1, x2, y2, x3, y3;
-                if( !GDALGeoLocPosPixelLineToXY(psTransform, iX, iY, x0, y0) ||
-                    !GDALGeoLocPosPixelLineToXY(psTransform, iX+1, iY, x2, y2) ||
-                    !GDALGeoLocPosPixelLineToXY(psTransform, iX, iY+1, x1, y1) ||
-                    !GDALGeoLocPosPixelLineToXY(psTransform, iX+1, iY+1, x3, y3) )
+                if( !PixelLineToXY(psTransform, iX, iY, x0, y0) ||
+                    !PixelLineToXY(psTransform, iX+1, iY, x2, y2) ||
+                    !PixelLineToXY(psTransform, iX, iY+1, x1, y1) ||
+                    !PixelLineToXY(psTransform, iX+1, iY+1, x3, y3) )
                 {
                     break;
                 }
@@ -353,11 +259,11 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
     if( psTransform->bOriginIsTopLeftCorner )
     {
         // Add "virtual" edge at Y=nGeoLocYSize
-        for( size_t iX = 0; iX <= psTransform->nGeoLocXSize; iX++ )
+        for( int iX = 0; iX <= psTransform->nGeoLocXSize; iX++ )
         {
             double dfGeoLocX;
             double dfGeoLocY;
-            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+            if( !PixelLineToXY(psTransform,
                     static_cast<double>(iX),
                     static_cast<double>(psTransform->nGeoLocYSize),
                     dfGeoLocX, dfGeoLocY) )
@@ -368,11 +274,11 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
         }
 
         // Add "virtual" edge at X=nGeoLocXSize
-        for( size_t iY = 0; iY <= psTransform->nGeoLocYSize; iY++ )
+        for( int iY = 0; iY <= psTransform->nGeoLocYSize; iY++ )
         {
             double dfGeoLocX;
             double dfGeoLocY;
-            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+            if( !PixelLineToXY(psTransform,
                     static_cast<double>(psTransform->nGeoLocXSize),
                     static_cast<double>(iY),
                     dfGeoLocX, dfGeoLocY) )
@@ -386,11 +292,11 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
     {
         // Extend by half-pixel on 4 edges for pixel-center convention
 
-        for( size_t iX = 0; iX <= psTransform->nGeoLocXSize; iX ++ )
+        for( int iX = 0; iX <= psTransform->nGeoLocXSize; iX ++ )
         {
             double dfGeoLocX;
             double dfGeoLocY;
-            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+            if( !PixelLineToXY(psTransform,
                     static_cast<double>(iX),
                     -0.5,
                     dfGeoLocX, dfGeoLocY) )
@@ -398,8 +304,13 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
             if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
                 dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
             UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+        }
 
-            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+        for( int iX = 0; iX <= psTransform->nGeoLocXSize; iX ++ )
+        {
+            double dfGeoLocX;
+            double dfGeoLocY;
+            if( !PixelLineToXY(psTransform,
                     static_cast<double>(iX),
                     static_cast<double>(psTransform->nGeoLocYSize-1 + 0.5),
                     dfGeoLocX, dfGeoLocY) )
@@ -409,11 +320,11 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
             UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
         }
 
-        for( size_t iY = 0; iY <= psTransform->nGeoLocYSize; iY++ )
+        for( int iY = 0; iY <= psTransform->nGeoLocYSize; iY++ )
         {
             double dfGeoLocX;
             double dfGeoLocY;
-            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+            if( !PixelLineToXY(psTransform,
                     -0.5,
                     static_cast<double>(iY),
                     dfGeoLocX, dfGeoLocY) )
@@ -421,8 +332,13 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
             if( psTransform->bGeographicSRSWithMinus180Plus180LongRange )
                 dfGeoLocX = Clamp(dfGeoLocX, -180.0, 180.0);
             UpdateMinMax(psTransform, dfGeoLocX, dfGeoLocY);
+        }
 
-            if( !GDALGeoLocPosPixelLineToXY(psTransform,
+        for( int iY = 0; iY <= psTransform->nGeoLocYSize; iY++ )
+        {
+            double dfGeoLocX;
+            double dfGeoLocY;
+            if( !PixelLineToXY(psTransform,
                     psTransform->nGeoLocXSize-1+0.5,
                     static_cast<double>(iY),
                     dfGeoLocX, dfGeoLocY) )
@@ -435,6 +351,552 @@ static bool GeoLocLoadFullData( GDALGeoLocTransformInfo *psTransform,
 
     return true;
 }
+
+/************************************************************************/
+/*                     GDALGeoLoc::PixelLineToXY()                      */
+/************************************************************************/
+
+/** Interpolate a position expressed as (floating point) pixel/line in the
+ * geolocation array to the corresponding bilinearly-interpolated georeferenced
+ * position.
+ *
+ * The interpolation assumes infinite extension beyond borders of available
+ * data based on closest grid square.
+ *
+ * @param psTransform Transformation info
+ * @param dfGeoLocPixel Position along the column/pixel axis of the geolocation array
+ * @param dfGeoLocLine  Position along the row/line axis of the geolocation array
+ * @param[out] dfX      Output X of georeferenced position.
+ * @param[out] dfY      Output Y of georeferenced position.
+ * @return true if success
+ */
+
+template<class Accessors>
+bool GDALGeoLoc<Accessors>::PixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
+                                const double dfGeoLocPixel,
+                                const double dfGeoLocLine,
+                                double& dfX,
+                                double& dfY)
+{
+    int iX = static_cast<int>(std::min(std::max(0.0, dfGeoLocPixel),
+                              static_cast<double>(psTransform->nGeoLocXSize-1)));
+    int iY = static_cast<int>(std::min(std::max(0.0, dfGeoLocLine),
+                              static_cast<double>(psTransform->nGeoLocYSize-1)));
+
+    auto pAccessors = static_cast<Accessors*>(psTransform->pAccessors);
+
+    for( int iAttempt = 0; iAttempt < 2; ++iAttempt )
+    {
+        const double dfGLX_0_0 = pAccessors->geolocXAccessor.Get(iX, iY);
+        const double dfGLY_0_0 = pAccessors->geolocYAccessor.Get(iX, iY);
+        if( psTransform->bHasNoData &&
+            dfGLX_0_0 == psTransform->dfNoDataX )
+        {
+            return false;
+        }
+
+        // This assumes infinite extension beyond borders of available
+        // data based on closest grid square.
+        if( iX + 1 < psTransform->nGeoLocXSize &&
+            iY + 1 < psTransform->nGeoLocYSize )
+        {
+            const double dfGLX_1_0 = pAccessors->geolocXAccessor.Get(iX+1, iY);
+            const double dfGLY_1_0 = pAccessors->geolocYAccessor.Get(iX+1, iY);
+            const double dfGLX_0_1 = pAccessors->geolocXAccessor.Get(iX, iY+1);
+            const double dfGLY_0_1 = pAccessors->geolocYAccessor.Get(iX, iY+1);
+            const double dfGLX_1_1 = pAccessors->geolocXAccessor.Get(iX+1, iY+1);
+            const double dfGLY_1_1 = pAccessors->geolocYAccessor.Get(iX+1, iY+1);
+            if( !psTransform->bHasNoData ||
+                (dfGLX_1_0 != psTransform->dfNoDataX &&
+                 dfGLX_0_1 != psTransform->dfNoDataX &&
+                 dfGLX_1_1 != psTransform->dfNoDataX) )
+            {
+                const double dfGLX_1_0_adjusted = ShiftGeoX(psTransform, dfGLX_0_0, dfGLX_1_0);
+                const double dfGLX_0_1_adjusted = ShiftGeoX(psTransform, dfGLX_0_0, dfGLX_0_1);
+                const double dfGLX_1_1_adjusted = ShiftGeoX(psTransform, dfGLX_0_0, dfGLX_1_1);
+                dfX =
+                    (1 - (dfGeoLocLine -iY))
+                    * (dfGLX_0_0 + (dfGeoLocPixel-iX) * (dfGLX_1_0_adjusted - dfGLX_0_0))
+                    + (dfGeoLocLine -iY)
+                    * (dfGLX_0_1_adjusted + (dfGeoLocPixel-iX) * (dfGLX_1_1_adjusted - dfGLX_0_1_adjusted));
+                dfX = UnshiftGeoX(psTransform, dfX);
+
+                dfY = (1 - (dfGeoLocLine -iY)) * (
+                        dfGLY_0_0 + (dfGeoLocPixel-iX) * (dfGLY_1_0 - dfGLY_0_0)) +
+                      (dfGeoLocLine -iY) * (
+                        dfGLY_0_1 + (dfGeoLocPixel-iX) * (dfGLY_1_1 - dfGLY_0_1));
+                break;
+            }
+        }
+
+        if( iX == psTransform->nGeoLocXSize -1 &&
+                 iX >= 1 && iY + 1 < psTransform->nGeoLocYSize )
+        {
+            // If we are after the right edge, then go one pixel left
+            // and retry
+            iX --;
+            continue;
+        }
+        else if( iY == psTransform->nGeoLocYSize - 1 &&
+                 iY >= 1 && iX + 1 < psTransform->nGeoLocXSize )
+        {
+            // If we are after the bottom edge, then go one pixel up
+            // and retry
+            iY --;
+            continue;
+        }
+        else if( iX == psTransform->nGeoLocXSize -1 &&
+                 iY == psTransform->nGeoLocYSize - 1 &&
+                 iX >= 1 && iY >= 1 )
+        {
+            // If we are after the right and bottom edge, then go one pixel left and up
+            // and retry
+            iX --;
+            iY --;
+            continue;
+        }
+        else if( iX + 1 < psTransform->nGeoLocXSize &&
+                 (!psTransform->bHasNoData ||
+                    pAccessors->geolocXAccessor.Get(iX+1, iY) != psTransform->dfNoDataX) )
+        {
+            const double dfGLX_1_0 = pAccessors->geolocXAccessor.Get(iX+1, iY);
+            const double dfGLY_1_0 = pAccessors->geolocYAccessor.Get(iX+1, iY);
+            dfX =
+                dfGLX_0_0 + (dfGeoLocPixel-iX) * (ShiftGeoX(psTransform, dfGLX_0_0, dfGLX_1_0) - dfGLX_0_0);
+            dfX = UnshiftGeoX(psTransform, dfX);
+            dfY = dfGLY_0_0 + (dfGeoLocPixel-iX) * (dfGLY_1_0 - dfGLY_0_0);
+        }
+        else if( iY + 1 < psTransform->nGeoLocYSize &&
+                 (!psTransform->bHasNoData ||
+                    pAccessors->geolocXAccessor.Get(iX, iY+1) != psTransform->dfNoDataX) )
+        {
+            const double dfGLX_0_1 = pAccessors->geolocXAccessor.Get(iX, iY+1);
+            const double dfGLY_0_1 = pAccessors->geolocYAccessor.Get(iX, iY+1);
+            dfX = dfGLX_0_0
+                + (dfGeoLocLine -iY) * (ShiftGeoX(psTransform, dfGLX_0_0, dfGLX_0_1) - dfGLX_0_0);
+            dfX = UnshiftGeoX(psTransform, dfX);
+            dfY = dfGLY_0_0 + (dfGeoLocLine -iY) * (dfGLY_0_1 - dfGLY_0_0);
+        }
+        else
+        {
+            dfX = dfGLX_0_0;
+            dfY = dfGLY_0_0;
+        }
+        break;
+    }
+    return true;
+}
+
+template<class Accessors>
+bool GDALGeoLoc<Accessors>::PixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
+                                          const int nGeoLocPixel,
+                                          const int nGeoLocLine,
+                                          double& dfX,
+                                          double& dfY)
+{
+    if( nGeoLocPixel >= 0 && nGeoLocPixel < psTransform->nGeoLocXSize &&
+        nGeoLocLine >= 0  && nGeoLocLine  < psTransform->nGeoLocYSize )
+    {
+        auto pAccessors = static_cast<Accessors*>(psTransform->pAccessors);
+        const double dfGLX = pAccessors->geolocXAccessor.Get(nGeoLocPixel, nGeoLocLine);
+        const double dfGLY = pAccessors->geolocYAccessor.Get(nGeoLocPixel, nGeoLocLine);
+        if( psTransform->bHasNoData &&
+            dfGLX == psTransform->dfNoDataX )
+        {
+            return false;
+        }
+        dfX = dfGLX;
+        dfY = dfGLY;
+        return true;
+    }
+    return PixelLineToXY(psTransform,
+                         static_cast<double>(nGeoLocPixel),
+                         static_cast<double>(nGeoLocLine),
+                         dfX, dfY);
+}
+
+/************************************************************************/
+/*                     GDALGeoLoc::ExtractSquare()                      */
+/************************************************************************/
+
+template<class Accessors>
+bool GDALGeoLoc<Accessors>::ExtractSquare(const GDALGeoLocTransformInfo *psTransform,
+                                          int nX, int nY,
+                                          double& dfX_0_0, double& dfY_0_0,
+                                          double& dfX_1_0, double& dfY_1_0,
+                                          double& dfX_0_1, double& dfY_0_1,
+                                          double& dfX_1_1, double& dfY_1_1)
+{
+        return PixelLineToXY(psTransform, nX, nY, dfX_0_0, dfY_0_0) &&
+               PixelLineToXY(psTransform, nX+1, nY, dfX_1_0, dfY_1_0) &&
+               PixelLineToXY(psTransform, nX, nY+1, dfX_0_1, dfY_0_1) &&
+               PixelLineToXY(psTransform, nX+1, nY+1, dfX_1_1, dfY_1_1);
+}
+
+bool GDALGeoLocExtractSquare(const GDALGeoLocTransformInfo *psTransform,
+                             int nX, int nY,
+                             double& dfX_0_0, double& dfY_0_0,
+                             double& dfX_1_0, double& dfY_1_0,
+                             double& dfX_0_1, double& dfY_0_1,
+                             double& dfX_1_1, double& dfY_1_1)
+{
+    if( psTransform->bUseArray )
+    {
+        return GDALGeoLoc<GDALGeoLocCArrayAccessors>::ExtractSquare(
+                psTransform, nX, nY,
+                dfX_0_0, dfY_0_0, dfX_1_0, dfY_1_0, dfX_0_1, dfY_0_1, dfX_1_1, dfY_1_1);
+    }
+    else
+    {
+        return GDALGeoLoc<GDALGeoLocDatasetAccessors>::ExtractSquare(
+                psTransform, nX, nY,
+                dfX_0_0, dfY_0_0, dfX_1_0, dfY_1_0, dfX_0_1, dfY_0_1, dfX_1_1, dfY_1_1);
+    }
+}
+
+/************************************************************************/
+/*                        GDALGeoLocTransform()                         */
+/************************************************************************/
+
+template<class Accessors>
+int GDALGeoLoc<Accessors>::Transform( void *pTransformArg,
+                         int bDstToSrc,
+                         int nPointCount,
+                         double *padfX, double *padfY,
+                         double * /* padfZ */,
+                         int *panSuccess )
+{
+    GDALGeoLocTransformInfo *psTransform =
+        static_cast<GDALGeoLocTransformInfo *>(pTransformArg);
+
+    if( psTransform->bReversed )
+        bDstToSrc = !bDstToSrc;
+
+    const double dfGeorefConventionOffset = psTransform->bOriginIsTopLeftCorner ? 0 : 0.5;
+
+/* -------------------------------------------------------------------- */
+/*      Do original pixel line to target geox/geoy.                     */
+/* -------------------------------------------------------------------- */
+    if( !bDstToSrc )
+    {
+        for( int i = 0; i < nPointCount; i++ )
+        {
+            if( padfX[i] == HUGE_VAL || padfY[i] == HUGE_VAL )
+            {
+                panSuccess[i] = FALSE;
+                continue;
+            }
+
+            const double dfGeoLocPixel =
+                (padfX[i] - psTransform->dfPIXEL_OFFSET)
+                / psTransform->dfPIXEL_STEP - dfGeorefConventionOffset;
+            const double dfGeoLocLine =
+                (padfY[i] - psTransform->dfLINE_OFFSET)
+                / psTransform->dfLINE_STEP - dfGeorefConventionOffset;
+
+            if( !PixelLineToXY(psTransform,
+                               dfGeoLocPixel,
+                               dfGeoLocLine,
+                               padfX[i],
+                               padfY[i]) )
+            {
+                panSuccess[i] = FALSE;
+                padfX[i] = HUGE_VAL;
+                padfY[i] = HUGE_VAL;
+                continue;
+            }
+
+            if( psTransform->bSwapXY )
+            {
+                std::swap(padfX[i], padfY[i]);
+            }
+
+            panSuccess[i] = TRUE;
+        }
+    }
+
+/* -------------------------------------------------------------------- */
+/*      geox/geoy to pixel/line using backmap.                          */
+/* -------------------------------------------------------------------- */
+    else
+    {
+        if( psTransform->hQuadTree )
+        {
+            GDALGeoLocInverseTransformQuadtree(psTransform,
+                                               nPointCount,
+                                               padfX,
+                                               padfY,
+                                               panSuccess);
+            return TRUE;
+        }
+
+        const bool bGeolocMaxAccuracy = CPLTestBool(
+            CPLGetConfigOption("GDAL_GEOLOC_USE_MAX_ACCURACY", "YES"));
+
+        // Keep those objects in this outer scope, so they are re-used, to
+        // save memory allocations.
+        OGRPoint oPoint;
+        OGRLinearRing oRing;
+        oRing.setNumPoints(5);
+
+        auto pAccessors = static_cast<Accessors*>(psTransform->pAccessors);
+
+        for( int i = 0; i < nPointCount; i++ )
+        {
+            if( padfX[i] == HUGE_VAL || padfY[i] == HUGE_VAL )
+            {
+                panSuccess[i] = FALSE;
+                continue;
+            }
+
+            if( psTransform->bSwapXY )
+            {
+                std::swap(padfX[i], padfY[i]);
+            }
+
+            const double dfGeoX = padfX[i];
+            const double dfGeoY = padfY[i];
+
+            const double dfBMX =
+                ((padfX[i] - psTransform->adfBackMapGeoTransform[0])
+                 / psTransform->adfBackMapGeoTransform[1]);
+            const double dfBMY =
+                ((padfY[i] - psTransform->adfBackMapGeoTransform[3])
+                 / psTransform->adfBackMapGeoTransform[5]);
+
+            if( !(dfBMX >= 0 && dfBMY >= 0 &&
+                  dfBMX + 1 < psTransform->nBackMapWidth &&
+                  dfBMY + 1 < psTransform->nBackMapHeight) )
+            {
+                panSuccess[i] = FALSE;
+                padfX[i] = HUGE_VAL;
+                padfY[i] = HUGE_VAL;
+                continue;
+            }
+
+            const int iBMX = static_cast<int>(dfBMX);
+            const int iBMY = static_cast<int>(dfBMY);
+
+            const auto fBMX_0_0 = pAccessors->backMapXAccessor.Get(iBMX, iBMY);
+            const auto fBMY_0_0 = pAccessors->backMapYAccessor.Get(iBMX, iBMY);
+            if( fBMX_0_0 == INVALID_BMXY )
+            {
+                panSuccess[i] = FALSE;
+                padfX[i] = HUGE_VAL;
+                padfY[i] = HUGE_VAL;
+                continue;
+            }
+
+            const auto fBMX_1_0 = pAccessors->backMapXAccessor.Get(iBMX+1, iBMY);
+            const auto fBMY_1_0 = pAccessors->backMapYAccessor.Get(iBMX+1, iBMY);
+            const auto fBMX_0_1 = pAccessors->backMapXAccessor.Get(iBMX, iBMY+1);
+            const auto fBMY_0_1 = pAccessors->backMapYAccessor.Get(iBMX, iBMY+1);
+            const auto fBMX_1_1 = pAccessors->backMapXAccessor.Get(iBMX+1, iBMY+1);
+            const auto fBMY_1_1 = pAccessors->backMapYAccessor.Get(iBMX+1, iBMY+1);
+            if( fBMX_1_0 != INVALID_BMXY &&
+                fBMX_0_1 != INVALID_BMXY &&
+                fBMX_1_1 != INVALID_BMXY)
+            {
+                padfX[i] =
+                    (1-(dfBMY - iBMY))
+                    * (fBMX_0_0 + (dfBMX - iBMX) * (fBMX_1_0 - fBMX_0_0))
+                    + (dfBMY - iBMY)
+                    * (fBMX_0_1 + (dfBMX - iBMX) * (fBMX_1_1 - fBMX_0_1));
+                padfY[i] =
+                    (1-(dfBMY - iBMY))
+                    * (fBMY_0_0 + (dfBMX - iBMX) * (fBMY_1_0 - fBMY_0_0))
+                    + (dfBMY - iBMY)
+                    * (fBMY_0_1 + (dfBMX - iBMX) * (fBMY_1_1 - fBMY_0_1));
+            }
+            else if( fBMX_1_0 != INVALID_BMXY)
+            {
+                padfX[i] = fBMX_0_0 + (dfBMX - iBMX) * (fBMX_1_0 - fBMX_0_0);
+                padfY[i] = fBMY_0_0 + (dfBMX - iBMX) * (fBMY_1_0 - fBMY_0_0);
+            }
+            else if( fBMX_0_1 != INVALID_BMXY)
+            {
+                padfX[i] = fBMX_0_0 + (dfBMY - iBMY) * (fBMX_0_1 - fBMX_0_0);
+                padfY[i] = fBMY_0_0 + (dfBMY - iBMY) * (fBMY_0_1 - fBMY_0_0);
+            }
+            else
+            {
+                padfX[i] = fBMX_0_0;
+                padfY[i] = fBMY_0_0;
+            }
+
+            const double dfGeoLocPixel =
+                (padfX[i] - psTransform->dfPIXEL_OFFSET)
+                / psTransform->dfPIXEL_STEP - dfGeorefConventionOffset;
+            const double dfGeoLocLine =
+                (padfY[i] - psTransform->dfLINE_OFFSET)
+                / psTransform->dfLINE_STEP - dfGeorefConventionOffset;
+#if 0
+            CPLDebug("GEOLOC", "%f %f %f %f", padfX[i], padfY[i], dfGeoLocPixel, dfGeoLocLine);
+            if( !psTransform->bOriginIsTopLeftCorner )
+            {
+                if( dfGeoLocPixel + dfGeorefConventionOffset > psTransform->nGeoLocXSize-1 ||
+                    dfGeoLocLine + dfGeorefConventionOffset > psTransform->nGeoLocYSize-1 )
+                {
+                    panSuccess[i] = FALSE;
+                    padfX[i] = HUGE_VAL;
+                    padfY[i] = HUGE_VAL;
+                    continue;
+                }
+            }
+#endif
+            if( !bGeolocMaxAccuracy )
+            {
+                panSuccess[i] = TRUE;
+                continue;
+            }
+
+            // Now that we have an approximate solution, identify a matching
+            // cell in the geolocation array, where we can use inverse bilinear
+            // interpolation to find the exact solution.
+
+            // NOTE: if the geolocation array is an affine transformation,
+            // the approximate solution should match the exact one, if the
+            // backmap has correctly been built.
+
+            oPoint.setX(dfGeoX);
+            oPoint.setY(dfGeoY);
+            // The thresholds and radius are rather empirical and have been tuned
+            // on the product S5P_TEST_L2__NO2____20190509T220707_20190509T234837_08137_01_010400_20200220T091343.nc
+            // that includes the north pole.
+            const int nSearchRadius =
+                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 85 ? 5 :
+                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 75 ? 3 :
+                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 65 ? 2 : 1;
+            const int nGeoLocPixel = static_cast<int>(std::floor(dfGeoLocPixel));
+            const int nGeoLocLine = static_cast<int>(std::floor(dfGeoLocLine));
+
+            bool bDone = false;
+            // Using the above approximate nGeoLocPixel, nGeoLocLine, try to
+            // find a forward cell that includes (dfGeoX, dfGeoY), with an increasing
+            // search radius, up to nSearchRadius.
+            for( int r = 0; !bDone && r <= nSearchRadius; r++ )
+            {
+                for( int iter = 0; !bDone && iter < (r == 0 ? 1 : 8 * r); ++iter)
+                {
+                    // For r=1, the below formulas will give the following offsets:
+                    // (-1,1), (0,1), (1,1), (1,0), (1,-1), (0,-1), (1,-1)
+                    const int sx = (r == 0) ? 0 :
+                             (iter < 2 *r) ? -r + iter :
+                             (iter < 4 * r) ? r :
+                             (iter < 6 * r) ? r - (iter - 4 * r):
+                             -r;
+                    const int sy = (r == 0) ? 0 :
+                             (iter < 2 *r) ? r :
+                             (iter < 4 * r) ? r - (iter - 2 * r) :
+                             (iter < 6 * r) ? -r:
+                             -r + (iter - 6 * r);
+                    if( nGeoLocPixel >= static_cast<int>(psTransform->nGeoLocXSize) - sx ||
+                        nGeoLocLine  >= static_cast<int>(psTransform->nGeoLocYSize) - sy )
+                    {
+                        continue;
+                    }
+                    const int iX = nGeoLocPixel + sx;
+                    const int iY = nGeoLocLine + sy;
+                    if( iX >= -1 || iY >= -1 )
+                    {
+                        double x0, y0, x1, y1, x2, y2, x3, y3;
+
+                        if( !PixelLineToXY(psTransform,
+                                iX, iY,
+                                x0, y0) ||
+                            !PixelLineToXY(psTransform,
+                                iX+1, iY,
+                                x2, y2) ||
+                            !PixelLineToXY(psTransform,
+                                iX, iY+1,
+                                x1, y1) ||
+                            !PixelLineToXY(psTransform,
+                                iX+1, iY+1,
+                                x3, y3) )
+                        {
+                            continue;
+                        }
+
+                        int nIters = 1;
+                        // For a bounding box crossing the anti-meridian, check
+                        // both around -180 and +180 deg.
+                        if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+                            std::fabs(x0) > 170 &&
+                            std::fabs(x1) > 170 &&
+                            std::fabs(x2) > 170 &&
+                            std::fabs(x3) > 170 &&
+                            (std::fabs(x1-x0) > 180 ||
+                             std::fabs(x2-x0) > 180 ||
+                             std::fabs(x3-x0) > 180) )
+                        {
+                            nIters = 2;
+                            if( x0 > 0 ) x0 -= 360;
+                            if( x1 > 0 ) x1 -= 360;
+                            if( x2 > 0 ) x2 -= 360;
+                            if( x3 > 0 ) x3 -= 360;
+                        }
+                        for( int iIter = 0; !bDone && iIter < nIters; ++iIter )
+                        {
+                            if( iIter == 1 )
+                            {
+                                x0 += 360;
+                                x1 += 360;
+                                x2 += 360;
+                                x3 += 360;
+                            }
+                            oRing.setPoint(0, x0, y0);
+                            oRing.setPoint(1, x2, y2);
+                            oRing.setPoint(2, x3, y3);
+                            oRing.setPoint(3, x1, y1);
+                            oRing.setPoint(4, x0, y0);
+                            if( oRing.isPointInRing( &oPoint ) ||
+                                oRing.isPointOnRingBoundary( &oPoint ) )
+                            {
+                                double dfX = static_cast<double>(iX);
+                                double dfY = static_cast<double>(iY);
+                                GDALInverseBilinearInterpolation(dfGeoX, dfGeoY,
+                                                             x0, y0,
+                                                             x1, y1,
+                                                             x2, y2,
+                                                             x3, y3,
+                                                             dfX, dfY);
+
+                                dfX = (dfX + dfGeorefConventionOffset) *
+                                    psTransform->dfPIXEL_STEP + psTransform->dfPIXEL_OFFSET;
+                                dfY = (dfY + dfGeorefConventionOffset) *
+                                    psTransform->dfLINE_STEP + psTransform->dfLINE_OFFSET;
+
+#ifdef DEBUG_GEOLOC_REALLY_VERBOSE
+                                CPLDebug("GEOLOC",
+                                         "value before adjustment: %f %f, "
+                                         "after adjustment: %f %f",
+                                         padfX[i], padfY[i], dfX, dfY);
+#endif
+
+                                padfX[i] = dfX;
+                                padfY[i] = dfY;
+
+                                bDone = true;
+                            }
+                        }
+                    }
+                }
+            }
+            if( !bDone )
+            {
+                panSuccess[i] = FALSE;
+                padfX[i] = HUGE_VAL;
+                padfY[i] = HUGE_VAL;
+                continue;
+            }
+
+            panSuccess[i] = TRUE;
+        }
+    }
+
+    return TRUE;
+}
+/*! @endcond */
 
 /************************************************************************/
 /*                  GDALInverseBilinearInterpolation()                  */
@@ -492,12 +954,15 @@ void GDALInverseBilinearInterpolation(const double x,
 /*                       GeoLocGenerateBackMap()                        */
 /************************************************************************/
 
-static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
+/*! @cond Doxygen_Suppress */
+
+template<class Accessors>
+bool GDALGeoLoc<Accessors>::GenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 
 {
     CPLDebug("GEOLOC", "Starting backmap generation");
-    const size_t nXSize = psTransform->nGeoLocXSize;
-    const size_t nYSize = psTransform->nGeoLocYSize;
+    const int nXSize = psTransform->nGeoLocXSize;
+    const int nYSize = psTransform->nGeoLocYSize;
 
 /* -------------------------------------------------------------------- */
 /*      Decide on resolution for backmap.  We aim for slightly          */
@@ -523,18 +988,21 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
     const double dfBMXSize = std::ceil((dfMaxX - dfMinX) / dfPixelSizeSquare);
     const double dfBMYSize = std::ceil((dfMaxY - dfMinY) / dfPixelSizeSquare);
 
-    if( !(dfBMXSize > 0 && dfBMXSize + 1 < INT_MAX) ||
-        !(dfBMYSize > 0 && dfBMYSize + 1 < INT_MAX) )
+    // +2 : +1 due to afterwards nBMXSize++, and another +1 as security margin
+    // for other computations.
+    if( !(dfBMXSize > 0 && dfBMXSize + 2 < INT_MAX) ||
+        !(dfBMYSize > 0 && dfBMYSize + 2 < INT_MAX) )
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Int overflow : %f x %f",
                  dfBMXSize, dfBMYSize);
         return false;
     }
 
-    size_t nBMXSize = static_cast<size_t>(dfBMXSize);
-    size_t nBMYSize = static_cast<size_t>(dfBMYSize);
+    int nBMXSize = static_cast<int>(dfBMXSize);
+    int nBMYSize = static_cast<int>(dfBMYSize);
 
-    if( 1 + nBMYSize > std::numeric_limits<size_t>::max() / (1 + nBMXSize) )
+    if( static_cast<size_t>(1 + nBMYSize) >
+            std::numeric_limits<size_t>::max() / static_cast<size_t>(1 + nBMXSize) )
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Int overflow : %f x %f",
                  dfBMXSize, dfBMYSize);
@@ -561,45 +1029,27 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 /* -------------------------------------------------------------------- */
 /*      Allocate backmap.                                               */
 /* -------------------------------------------------------------------- */
-    psTransform->pafBackMapX = static_cast<float *>(
-        VSI_MALLOC3_VERBOSE(nBMXSize, nBMYSize, sizeof(float)));
-    psTransform->pafBackMapY = static_cast<float *>(
-        VSI_MALLOC3_VERBOSE(nBMXSize, nBMYSize, sizeof(float)));
-
-    float *wgtsBackMap = static_cast<float *>(
-        VSI_MALLOC3_VERBOSE(nBMXSize, nBMYSize, sizeof(float)));
-
-    if( psTransform->pafBackMapX == nullptr ||
-        psTransform->pafBackMapY == nullptr ||
-        wgtsBackMap == nullptr)
-    {
-        CPLFree( wgtsBackMap );
+    auto pAccessors = static_cast<Accessors*>(psTransform->pAccessors);
+    if( !pAccessors->AllocateBackMap())
         return false;
-    }
-
-    const size_t nBMXYCount = nBMXSize * nBMYSize;
-    for( size_t i = 0; i < nBMXYCount; i++ )
-    {
-        psTransform->pafBackMapX[i] = 0;
-        psTransform->pafBackMapY[i] = 0;
-        wgtsBackMap[i] = 0.0;
-    }
 
     const double dfGeorefConventionOffset = psTransform->bOriginIsTopLeftCorner ? 0 : 0.5;
 
-    const auto UpdateBackmap = [&](std::ptrdiff_t iBMX, std::ptrdiff_t iBMY,
+    const auto UpdateBackmap = [&](int iBMX, int iBMY,
                                    double dfX, double dfY,
                                    double tempwt)
     {
-        const float fUpdatedBMX = psTransform->pafBackMapX[iBMX + iBMY * nBMXSize] +
+        const auto fBMX = pAccessors->backMapXAccessor.Get(iBMX, iBMY);
+        const auto fBMY = pAccessors->backMapYAccessor.Get(iBMX, iBMY);
+        const float fUpdatedBMX = fBMX +
             static_cast<float>( tempwt * (
                 (dfX + dfGeorefConventionOffset) * psTransform->dfPIXEL_STEP +
                 psTransform->dfPIXEL_OFFSET));
-        const float fUpdatedBMY = psTransform->pafBackMapY[iBMX + iBMY * nBMXSize] +
+        const float fUpdatedBMY = fBMY +
             static_cast<float>( tempwt * (
                 (dfY + dfGeorefConventionOffset) * psTransform->dfLINE_STEP +
                 psTransform->dfLINE_OFFSET));
-        const float fUpdatedWeight = wgtsBackMap[iBMX + iBMY * nBMXSize] +
+        const float fUpdatedWeight = pAccessors->backMapWeightAccessor.Get(iBMX, iBMY) +
                                static_cast<float>(tempwt);
 
         // Only update the backmap if the updated averaged value results in a
@@ -614,24 +1064,24 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                 dfGeorefConventionOffset;
             const double dfGeoLocLine = (fY - psTransform->dfLINE_OFFSET) / psTransform->dfLINE_STEP -
                 dfGeorefConventionOffset;
-            size_t iXAvg = static_cast<size_t>(std::max(0.0, dfGeoLocPixel));
+            int iXAvg = static_cast<int>(std::max(0.0, dfGeoLocPixel));
             iXAvg = std::min(iXAvg, psTransform->nGeoLocXSize-1);
-            size_t iYAvg = static_cast<size_t>(std::max(0.0, dfGeoLocLine));
+            int iYAvg = static_cast<int>(std::max(0.0, dfGeoLocLine));
             iYAvg = std::min(iYAvg, psTransform->nGeoLocYSize-1);
-            const double dfGLX = psTransform->padfGeoLocX[iXAvg + iYAvg * nXSize];
-            const double dfGLY = psTransform->padfGeoLocY[iXAvg + iYAvg * nXSize];
+            const double dfGLX = pAccessors->geolocXAccessor.Get(iXAvg, iYAvg);
+            const double dfGLY = pAccessors->geolocYAccessor.Get(iXAvg, iYAvg);
 
-            const size_t iX = static_cast<size_t>(dfX);
-            const size_t iY = static_cast<size_t>(dfY);
+            const unsigned iX = static_cast<unsigned>(dfX);
+            const unsigned iY = static_cast<unsigned>(dfY);
             if( !(psTransform->bHasNoData &&
                   dfGLX == psTransform->dfNoDataX ) &&
-                ((iX >= nXSize - 1 || iY >= nYSize - 1) ||
-                 (fabs(dfGLX - psTransform->padfGeoLocX[iX + iY * nXSize]) <= 2 * dfPixelXSize &&
-                  fabs(dfGLY - psTransform->padfGeoLocY[iX + iY * nXSize]) <= 2 * dfPixelYSize)) )
+                ((iX >= static_cast<unsigned>(nXSize - 1) || iY >= static_cast<unsigned>(nYSize - 1)) ||
+                 (fabs(dfGLX - pAccessors->geolocXAccessor.Get(iX, iY)) <= 2 * dfPixelXSize &&
+                  fabs(dfGLY - pAccessors->geolocYAccessor.Get(iX, iY)) <= 2 * dfPixelYSize)) )
             {
-                psTransform->pafBackMapX[iBMX + iBMY * nBMXSize] = fUpdatedBMX;
-                psTransform->pafBackMapY[iBMX + iBMY * nBMXSize] = fUpdatedBMY;
-                wgtsBackMap[iBMX + iBMY * nBMXSize] = fUpdatedWeight;
+                pAccessors->backMapXAccessor.Set(iBMX, iBMY, fUpdatedBMX);
+                pAccessors->backMapYAccessor.Set(iBMX, iBMY, fUpdatedBMY);
+                pAccessors->backMapWeightAccessor.Set(iBMX, iBMY, fUpdatedWeight);
             }
         }
     };
@@ -659,7 +1109,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
             // georeferenced position corresponding to (dfX, dfY)
             double dfGeoLocX;
             double dfGeoLocY;
-            if( !GDALGeoLocPosPixelLineToXY(psTransform, dfX, dfY, dfGeoLocX, dfGeoLocY) )
+            if( !PixelLineToXY(psTransform, dfX, dfY, dfGeoLocX, dfGeoLocY) )
                 continue;
 
             // Compute the floating point coordinates in the pixel space of the backmap
@@ -670,11 +1120,11 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                 (dfMaxY - dfGeoLocY) / dfPixelYSize);
 
             //Get top left index by truncation
-            const std::ptrdiff_t iBMX = static_cast<std::ptrdiff_t>(std::floor(dBMX));
-            const std::ptrdiff_t iBMY = static_cast<std::ptrdiff_t>(std::floor(dBMY));
+            const int iBMX = static_cast<int>(std::floor(dBMX));
+            const int iBMY = static_cast<int>(std::floor(dBMY));
 
-            if( iBMX >= 0 && static_cast<size_t>(iBMX) < nBMXSize &&
-                iBMY >= 0 && static_cast<size_t>(iBMY) < nBMYSize )
+            if( iBMX >= 0 && iBMX < nBMXSize &&
+                iBMY >= 0 && iBMY < nBMYSize )
             {
                 // Compute the georeferenced position of the top-left index of
                 // the backmap
@@ -696,17 +1146,19 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                     // the geolocation array in which dfGeoX, dfGeoY falls into.
                     oPoint.setX(dfGeoX);
                     oPoint.setY(dfGeoY);
+                    const int nX = static_cast<int>(std::floor(dfX));
+                    const int nY = static_cast<int>(std::floor(dfY));
                     for( int sx = -1; !bMatchingGeoLocCellFound && sx <= 0; sx++ )
                     {
                         for(int sy = -1; !bMatchingGeoLocCellFound && sy <= 0; sy++)
                         {
-                            const double pixel = std::floor(dfX) + sx;
-                            const double line = std::floor(dfY) + sy;
+                            const int pixel = nX + sx;
+                            const int line = nY + sy;
                             double x0, y0, x1, y1, x2, y2, x3, y3;
-                            if( !GDALGeoLocPosPixelLineToXY(psTransform, pixel, line, x0, y0) ||
-                                !GDALGeoLocPosPixelLineToXY(psTransform, pixel+1, line, x2, y2) ||
-                                !GDALGeoLocPosPixelLineToXY(psTransform, pixel, line+1, x1, y1) ||
-                                !GDALGeoLocPosPixelLineToXY(psTransform, pixel+1, line+1, x3, y3) )
+                            if( !PixelLineToXY(psTransform, pixel, line, x0, y0) ||
+                                !PixelLineToXY(psTransform, pixel+1, line, x2, y2) ||
+                                !PixelLineToXY(psTransform, pixel, line+1, x1, y1) ||
+                                !PixelLineToXY(psTransform, pixel+1, line+1, x3, y3) )
                             {
                                 break;
                             }
@@ -760,9 +1212,9 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
                                     dfBMYValue = (dfBMYValue + dfGeorefConventionOffset) *
                                         psTransform->dfLINE_STEP + psTransform->dfLINE_OFFSET ;
 
-                                    psTransform->pafBackMapX[iBMX + iBMY * nBMXSize] = static_cast<float>(dfBMXValue);
-                                    psTransform->pafBackMapY[iBMX + iBMY * nBMXSize] = static_cast<float>(dfBMYValue);
-                                    wgtsBackMap[iBMX + iBMY * nBMXSize] = 1.0f;
+                                    pAccessors->backMapXAccessor.Set(iBMX, iBMY, static_cast<float>(dfBMXValue));
+                                    pAccessors->backMapYAccessor.Set(iBMX, iBMY, static_cast<float>(dfBMYValue));
+                                    pAccessors->backMapWeightAccessor.Set(iBMX, iBMY, 1.0f);
                                 }
                             }
                         }
@@ -776,9 +1228,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
             // etc.
 
             //Check if the center is in range
-            if( iBMX < -1 || iBMY < -1 ||
-                (iBMX > 0 && static_cast<size_t>(iBMX) > nBMXSize) ||
-                (iBMY > 0 && static_cast<size_t>(iBMY) > nBMYSize) )
+            if( iBMX < -1 || iBMY < -1 || iBMX > nBMXSize || iBMY > nBMYSize )
                 continue;
 
             const double fracBMX = dBMX - iBMX;
@@ -786,9 +1236,9 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 
             //Check logic for top left pixel
             if ((iBMX >= 0) && (iBMY >= 0) &&
-                (static_cast<size_t>(iBMX) < nBMXSize) &&
-                (static_cast<size_t>(iBMY) < nBMYSize) &&
-                wgtsBackMap[iBMX + iBMY * nBMXSize] != 1.0f )
+                (iBMX < nBMXSize) &&
+                (iBMY < nBMYSize) &&
+                pAccessors->backMapWeightAccessor.Get(iBMX, iBMY) != 1.0f )
             {
                 const double tempwt = (1.0 - fracBMX) * (1.0 - fracBMY);
                 UpdateBackmap(iBMX, iBMY, dfX, dfY, tempwt);
@@ -796,18 +1246,18 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 
             //Check logic for top right pixel
             if ((iBMY >= 0) &&
-                (static_cast<size_t>(iBMX+1) < nBMXSize) &&
-                (static_cast<size_t>(iBMY) < nBMYSize) &&
-                wgtsBackMap[iBMX + 1 + iBMY * nBMXSize] != 1.0f )
+                (iBMX+1 < nBMXSize) &&
+                (iBMY < nBMYSize) &&
+                pAccessors->backMapWeightAccessor.Get(iBMX + 1, iBMY) != 1.0f )
             {
                 const double tempwt = fracBMX * (1.0 - fracBMY);
                 UpdateBackmap(iBMX + 1, iBMY, dfX, dfY, tempwt);
             }
 
             //Check logic for bottom right pixel
-            if ((static_cast<size_t>(iBMX+1) < nBMXSize) &&
-                (static_cast<size_t>(iBMY+1) < nBMYSize) &&
-                wgtsBackMap[(iBMX + 1) + (iBMY + 1) * nBMXSize] != 1.0f )
+            if ((iBMX+1 < nBMXSize) &&
+                (iBMY+1 < nBMYSize) &&
+                pAccessors->backMapWeightAccessor.Get(iBMX + 1, iBMY + 1) != 1.0f )
             {
                 const double tempwt = fracBMX * fracBMY;
                 UpdateBackmap(iBMX + 1, iBMY + 1, dfX, dfY, tempwt);
@@ -815,9 +1265,9 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 
             //Check logic for bottom left pixel
             if ((iBMX >= 0) &&
-                (static_cast<size_t>(iBMX) < nBMXSize) &&
-                (static_cast<size_t>(iBMY+1) < nBMYSize) &&
-                wgtsBackMap[iBMX + (iBMY + 1) * nBMXSize] != 1.0f )
+                (iBMX < nBMXSize) &&
+                (iBMY+1 < nBMYSize) &&
+                pAccessors->backMapWeightAccessor.Get(iBMX, iBMY + 1) != 1.0f )
             {
                 const double tempwt = (1.0 - fracBMX) * fracBMY;
                 UpdateBackmap(iBMX, iBMY + 1, dfX, dfY, tempwt);
@@ -829,50 +1279,43 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 
     //Each pixel in the backmap may have multiple entries.
     //We now go in average it out using the weights
-    for( size_t i = 0; i < nBMXYCount; i++ )
+    for( int iY = 0; iY < nBMYSize; iY++ )
     {
-        //Check if pixel was only touch during neighbor scan
-        //But no real weight was added as source point matched
-        //backmap grid node
-        if (wgtsBackMap[i] > 0)
+        for( int iX = 0; iX < nBMXSize; iX++ )
         {
-            psTransform->pafBackMapX[i] /= wgtsBackMap[i];
-            psTransform->pafBackMapY[i] /= wgtsBackMap[i];
-        }
-        else
-        {
-            psTransform->pafBackMapX[i] = INVALID_BMXY;
-            psTransform->pafBackMapY[i] = INVALID_BMXY;
+            //Check if pixel was only touch during neighbor scan
+            //But no real weight was added as source point matched
+            //backmap grid node
+            const auto weight = pAccessors->backMapWeightAccessor.Get(iX, iY);
+            if (weight > 0)
+            {
+                pAccessors->backMapXAccessor.Set(iX, iY,
+                    pAccessors->backMapXAccessor.Get(iX, iY) / weight);
+                pAccessors->backMapYAccessor.Set(iX, iY,
+                    pAccessors->backMapYAccessor.Get(iX, iY) / weight);
+            }
+            else
+            {
+                pAccessors->backMapXAccessor.Set(iX, iY, INVALID_BMXY);
+                pAccessors->backMapYAccessor.Set(iX, iY, INVALID_BMXY);
+            }
         }
     }
+
+    pAccessors->FreeWghtsBackMap();
 
     // Fill holes in backmap
-    auto poMEMDS = std::unique_ptr<GDALDataset>(
-          MEMDataset::Create( "",
-                              static_cast<int>(nBMXSize),
-                              static_cast<int>(nBMYSize),
-                              0, GDT_Float32, nullptr ));
+    auto poBackmapDS = pAccessors->GetBackmapDataset();
 
-    for( int i = 1; i <= 2; i++ )
-    {
-        char szBuffer[32] = { '\0' };
-        char szBuffer0[64] = { '\0' };
-        char* apszOptions[] = { szBuffer0, nullptr };
-
-        void* ptr = (i == 1) ? psTransform->pafBackMapX : psTransform->pafBackMapY;
-        szBuffer[CPLPrintPointer(szBuffer, ptr, sizeof(szBuffer))] = '\0';
-        snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
-        poMEMDS->AddBand(GDT_Float32, apszOptions);
-        poMEMDS->GetRasterBand(i)->SetNoDataValue(INVALID_BMXY);
-    }
+    pAccessors->FlushBackmapCaches();
 
 #ifdef DEBUG_GEOLOC
     if( CPLTestBool(CPLGetConfigOption("GEOLOC_DUMP", "NO")) )
     {
-        poMEMDS->SetGeoTransform(psTransform->adfBackMapGeoTransform);
+        poBackmapDS->SetGeoTransform(psTransform->adfBackMapGeoTransform);
         GDALClose(GDALCreateCopy(GDALGetDriverByName("GTiff"),
                               "/tmp/geoloc_before_fill.tif",
-                              poMEMDS.get(),
+                              poBackmapDS,
                               false, nullptr, nullptr, nullptr));
     }
 #endif
@@ -881,7 +1324,7 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
     constexpr int nSmoothingIterations = 1;
     for( int i = 1; i <= 2; i++ )
     {
-        GDALFillNodata( GDALRasterBand::ToHandle(poMEMDS->GetRasterBand(i)),
+        GDALFillNodata( GDALRasterBand::ToHandle(poBackmapDS->GetRasterBand(i)),
                         nullptr,
                         dfMaxSearchDist,
                         0, // unused parameter
@@ -896,37 +1339,36 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
     {
         GDALClose(GDALCreateCopy(GDALGetDriverByName("GTiff"),
                               "/tmp/geoloc_after_fill.tif",
-                              poMEMDS.get(),
+                              poBackmapDS,
                               false, nullptr, nullptr, nullptr));
     }
 #endif
 
     // A final hole filling logic, proceeding line by line, and feeling
     // holes when the backmap values surrounding the hole are close enough.
-    for( size_t iBMY = 0; iBMY < nBMYSize; iBMY++ )
+    for( int iBMY = 0; iBMY < nBMYSize; iBMY++ )
     {
-        size_t iLastValidIX = static_cast<size_t>(-1);
-        for( size_t iBMX = 0; iBMX < nBMXSize; iBMX++ )
+        int iLastValidIX = -1;
+        for( int iBMX = 0; iBMX < nBMXSize; iBMX++ )
         {
-            const size_t iBM = iBMX + iBMY * nBMXSize;
-            if( psTransform->pafBackMapX[iBM] == INVALID_BMXY )
+            if( pAccessors->backMapXAccessor.Get(iBMX, iBMY) == INVALID_BMXY )
                 continue;
-            if( iLastValidIX != static_cast<size_t>(-1) &&
+            if( iLastValidIX != -1 &&
                 iBMX > iLastValidIX + 1 &&
-                fabs( psTransform->pafBackMapX[iBM] -
-                    psTransform->pafBackMapX[iLastValidIX + iBMY * nBMXSize]) <= 2 &&
-                fabs( psTransform->pafBackMapY[iBM] -
-                    psTransform->pafBackMapY[iLastValidIX + iBMY * nBMXSize]) <= 2 )
+                fabs( pAccessors->backMapXAccessor.Get(iBMX, iBMY) -
+                      pAccessors->backMapXAccessor.Get(iLastValidIX, iBMY)) <= 2 &&
+                fabs( pAccessors->backMapYAccessor.Get(iBMX, iBMY) -
+                      pAccessors->backMapYAccessor.Get(iLastValidIX, iBMY)) <= 2 )
             {
-                for( size_t iBMXInner = iLastValidIX + 1; iBMXInner < iBMX; ++iBMXInner )
+                for( int iBMXInner = iLastValidIX + 1; iBMXInner < iBMX; ++iBMXInner )
                 {
                     const float alpha = static_cast<float>(iBMXInner - iLastValidIX) / (iBMX - iLastValidIX);
-                    psTransform->pafBackMapX[iBMXInner + iBMY * nBMXSize] =
-                        (1.0f - alpha) * psTransform->pafBackMapX[iLastValidIX + iBMY * nBMXSize] +
-                        alpha * psTransform->pafBackMapX[iBM];
-                    psTransform->pafBackMapY[iBMXInner + iBMY * nBMXSize] =
-                        (1.0f - alpha) * psTransform->pafBackMapY[iLastValidIX + iBMY * nBMXSize] +
-                        alpha * psTransform->pafBackMapY[iBM];
+                    pAccessors->backMapXAccessor.Set(iBMXInner, iBMY,
+                        (1.0f - alpha) * pAccessors->backMapXAccessor.Get(iLastValidIX, iBMY) +
+                        alpha * pAccessors->backMapXAccessor.Get(iBMX, iBMY));
+                    pAccessors->backMapYAccessor.Set(iBMXInner, iBMY,
+                        (1.0f - alpha) * pAccessors->backMapYAccessor.Get(iLastValidIX, iBMY) +
+                        alpha * pAccessors->backMapYAccessor.Get(iBMX, iBMY));
                 }
             }
             iLastValidIX = iBMX;
@@ -936,18 +1378,22 @@ static bool GeoLocGenerateBackMap( GDALGeoLocTransformInfo *psTransform )
 #ifdef DEBUG_GEOLOC
     if( CPLTestBool(CPLGetConfigOption("GEOLOC_DUMP", "NO")) )
     {
+        pAccessors->FlushBackmapCaches();
+
         GDALClose(GDALCreateCopy(GDALGetDriverByName("GTiff"),
                               "/tmp/geoloc_after_line_fill.tif",
-                              poMEMDS.get(),
+                              poBackmapDS,
                               false, nullptr, nullptr, nullptr));
     }
 #endif
 
-    CPLFree( wgtsBackMap );
+    pAccessors->ReleaseBackmapDataset(poBackmapDS);
     CPLDebug("GEOLOC", "Ending backmap generation");
 
     return true;
 }
+
+/*! @endcond */
 
 /************************************************************************/
 /*                       GDALGeoLocRescale()                            */
@@ -1146,6 +1592,10 @@ void *GDALCreateGeoLocTransformerEx( GDALDatasetH hBaseDS,
         std::max(1, atoi(CSLFetchNameValue( papszGeolocationInfo, "X_BAND" )));
     psTransform->hBand_X = GDALGetRasterBand( psTransform->hDS_X, nXBand );
 
+    psTransform->dfNoDataX =
+        GDALGetRasterNoDataValue( psTransform->hBand_X,
+                                  &(psTransform->bHasNoData) );
+
     const int nYBand =
         std::max(1, atoi(CSLFetchNameValue( papszGeolocationInfo, "Y_BAND" )));
     psTransform->hBand_Y = GDALGetRasterBand( psTransform->hDS_Y, nYBand );
@@ -1186,14 +1636,34 @@ void *GDALCreateGeoLocTransformerEx( GDALDatasetH hBaseDS,
         return nullptr;
     }
 
-    if( static_cast<size_t>(nXSize_XBand) >
-            std::numeric_limits<size_t>::max() / nYSize_XBand )
+    if( nXSize_XBand <= 0 || nYSize_XBand <= 0 ||
+        nXSize_YBand <= 0 || nYSize_YBand <= 0 )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Int overflow : %d x %d",
-                 nXSize_XBand, nYSize_XBand);
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Invalid X_BAND / Y_BAND size");
         GDALDestroyGeoLocTransformer( psTransform );
         return nullptr;
     }
+
+    // Is it a regular grid ? That is:
+    // The XBAND contains the x coordinates for all lines.
+    // The YBAND contains the y coordinates for all columns.
+    const bool bIsRegularGrid = ( nYSize_XBand == 1 && nYSize_YBand == 1 );
+
+    const int nXSize = nXSize_XBand;
+    const int nYSize = bIsRegularGrid ? nXSize_YBand : nYSize_XBand;
+
+    if( static_cast<size_t>(nXSize) >
+            std::numeric_limits<size_t>::max() / static_cast<size_t>(nYSize) )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Int overflow : %d x %d",
+                 nXSize, nYSize);
+        GDALDestroyGeoLocTransformer( psTransform );
+        return nullptr;
+    }
+
+    psTransform->nGeoLocXSize = nXSize;
+    psTransform->nGeoLocYSize = nYSize;
 
 /* -------------------------------------------------------------------- */
 /*      Load the geolocation array.                                     */
@@ -1203,12 +1673,36 @@ void *GDALCreateGeoLocTransformerEx( GDALDatasetH hBaseDS,
     // but unfortunately burns more RAM and is slower.
     const bool bUseQuadtree =
         EQUAL(CPLGetConfigOption("GDAL_GEOLOC_INVERSE_METHOD", "BACKMAP"), "QUADTREE");
-    if( !GeoLocLoadFullData( psTransform, papszGeolocationInfo )
-        || (bUseQuadtree && !GDALGeoLocBuildQuadTree( psTransform ))
-        || (!bUseQuadtree && !GeoLocGenerateBackMap( psTransform )) )
+
+    // Decide if we should C-arrays for geoloc and backmap, or on-disk
+    // temporary datasets.
+    const char* pszUseTempDatasets = CSLFetchNameValueDef(papszTransformOptions,
+        "GEOLOC_USE_TEMP_DATASETS",
+        CPLGetConfigOption("GDAL_GEOLOC_USE_TEMP_DATASETS", nullptr));
+    if( pszUseTempDatasets )
+        psTransform->bUseArray = !CPLTestBool(pszUseTempDatasets);
+    else
+        psTransform->bUseArray = nXSize < 16 * 1000 * 1000 / nYSize;
+
+    if( psTransform->bUseArray )
     {
-        GDALDestroyGeoLocTransformer( psTransform );
-        return nullptr;
+        auto pAccessors = new GDALGeoLocCArrayAccessors(psTransform);
+        psTransform->pAccessors = pAccessors;
+        if( !pAccessors->Load(bIsRegularGrid, bUseQuadtree) )
+        {
+            GDALDestroyGeoLocTransformer( psTransform );
+            return nullptr;
+        }
+    }
+    else
+    {
+        auto pAccessors = new GDALGeoLocDatasetAccessors(psTransform);
+        psTransform->pAccessors = pAccessors;
+        if( !pAccessors->Load(bIsRegularGrid, bUseQuadtree) )
+        {
+            GDALDestroyGeoLocTransformer( psTransform );
+            return nullptr;
+        }
     }
 
     return psTransform;
@@ -1238,11 +1732,12 @@ void GDALDestroyGeoLocTransformer( void *pTransformAlg )
     GDALGeoLocTransformInfo *psTransform =
         static_cast<GDALGeoLocTransformInfo *>(pTransformAlg);
 
-    CPLFree( psTransform->pafBackMapX );
-    CPLFree( psTransform->pafBackMapY );
     CSLDestroy( psTransform->papszGeolocationInfo );
-    CPLFree( psTransform->padfGeoLocX );
-    CPLFree( psTransform->padfGeoLocY );
+
+    if( psTransform->bUseArray )
+        delete static_cast<GDALGeoLocCArrayAccessors*>(psTransform->pAccessors);
+    else
+        delete static_cast<GDALGeoLocDatasetAccessors*>(psTransform->pAccessors);
 
     if( psTransform->hDS_X != nullptr
         && GDALDereferenceDataset( psTransform->hDS_X ) == 0 )
@@ -1258,474 +1753,36 @@ void GDALDestroyGeoLocTransformer( void *pTransformAlg )
     CPLFree( pTransformAlg );
 }
 
-/************************************************************************/
-/*                      GDALGeoLocPosPixelLineToXY()                    */
-/************************************************************************/
-
-/** Interpolate a position expessed as (floating point) pixel/line in the
- * geolocation array to the corresponding bilinearly-interpolated georeferenced
- * position.
- *
- * The interpolation assumes infinite extension beyond borders of available
- * data based on closest grid square.
- *
- * @param psTransform Transformation info
- * @param dfGeoLocPixel Position along the column/pixel axis of the geolocation array
- * @param dfGeoLocLine  Position along the row/line axis of the geolocation array
- * @param[out] dfX      Output X of georeferenced position.
- * @param[out] dfY      Output Y of georeferenced position.
- * @return true if success
- */
-bool GDALGeoLocPosPixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
-                                const double dfGeoLocPixel,
-                                const double dfGeoLocLine,
-                                double& dfX,
-                                double& dfY)
-{
-    const size_t nXSize = psTransform->nGeoLocXSize;
-    size_t iX = static_cast<size_t>(std::max(0.0, dfGeoLocPixel));
-    iX = std::min(iX, psTransform->nGeoLocXSize-1);
-    size_t iY = static_cast<size_t>(std::max(0.0, dfGeoLocLine));
-    iY = std::min(iY, psTransform->nGeoLocYSize-1);
-
-    for( int iAttempt = 0; iAttempt < 2; ++iAttempt )
-    {
-        const double *padfGLX = psTransform->padfGeoLocX + iX + iY * nXSize;
-        const double *padfGLY = psTransform->padfGeoLocY + iX + iY * nXSize;
-
-        if( psTransform->bHasNoData &&
-            padfGLX[0] == psTransform->dfNoDataX )
-        {
-            return false;
-        }
-
-        // This assumes infinite extension beyond borders of available
-        // data based on closest grid square.
-        const double dfRefX = padfGLX[0];
-        if( iX + 1 < psTransform->nGeoLocXSize &&
-            iY + 1 < psTransform->nGeoLocYSize &&
-            (!psTransform->bHasNoData ||
-                (padfGLX[1] != psTransform->dfNoDataX &&
-                 padfGLX[nXSize] != psTransform->dfNoDataX &&
-                 padfGLX[nXSize + 1] != psTransform->dfNoDataX) ))
-        {
-            dfX =
-                (1 - (dfGeoLocLine -iY))
-                * (padfGLX[0] +
-                   (dfGeoLocPixel-iX) * (ShiftGeoX(psTransform, dfRefX, padfGLX[1]) - padfGLX[0]))
-                + (dfGeoLocLine -iY)
-                * (ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize]) + (dfGeoLocPixel-iX) *
-                   (ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize+1]) -
-                       ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize])));
-            dfX = UnshiftGeoX(psTransform, dfX);
-
-            dfY =
-                (1 - (dfGeoLocLine -iY))
-                * (padfGLY[0] +
-                   (dfGeoLocPixel-iX) * (padfGLY[1] - padfGLY[0]))
-                + (dfGeoLocLine -iY)
-                * (padfGLY[nXSize] + (dfGeoLocPixel-iX) *
-                   (padfGLY[nXSize+1] - padfGLY[nXSize]));
-        }
-        else if( iX == psTransform->nGeoLocXSize -1 &&
-                 iX >= 1 && iY + 1 < psTransform->nGeoLocYSize )
-        {
-            // If we are after the right edge, then go one pixel left
-            // and retry
-            iX --;
-            continue;
-        }
-        else if( iY == psTransform->nGeoLocYSize - 1 &&
-                 iY >= 1 && iX + 1 < psTransform->nGeoLocXSize )
-        {
-            // If we are after the bottom edge, then go one pixel up
-            // and retry
-            iY --;
-            continue;
-        }
-        else if( iX == psTransform->nGeoLocXSize -1 &&
-                 iY == psTransform->nGeoLocYSize - 1 &&
-                 iX >= 1 && iY >= 1 )
-        {
-            // If we are after the right and bottom edge, then go one pixel left and up
-            // and retry
-            iX --;
-            iY --;
-            continue;
-        }
-        else if( iX + 1 < psTransform->nGeoLocXSize &&
-                 (!psTransform->bHasNoData ||
-                    padfGLX[1] != psTransform->dfNoDataX) )
-        {
-            dfX =
-                padfGLX[0] + (dfGeoLocPixel-iX) * (ShiftGeoX(psTransform, dfRefX, padfGLX[1]) - padfGLX[0]);
-            dfX = UnshiftGeoX(psTransform, dfX);
-            dfY =
-                padfGLY[0] + (dfGeoLocPixel-iX) * (padfGLY[1] - padfGLY[0]);
-        }
-        else if( iY + 1 < psTransform->nGeoLocYSize &&
-                 (!psTransform->bHasNoData ||
-                    padfGLX[nXSize] != psTransform->dfNoDataX) )
-        {
-            dfX = padfGLX[0]
-                + (dfGeoLocLine -iY) * (ShiftGeoX(psTransform, dfRefX, padfGLX[nXSize]) - padfGLX[0]);
-            dfX = UnshiftGeoX(psTransform, dfX);
-            dfY = padfGLY[0]
-                + (dfGeoLocLine -iY) * (padfGLY[nXSize] - padfGLY[0]);
-        }
-        else
-        {
-            dfX = padfGLX[0];
-            dfY = padfGLY[0];
-        }
-        break;
-    }
-    return true;
-}
-
-/************************************************************************/
-/*                        GDALGeoLocTransform()                         */
-/************************************************************************/
-
-
 /** Use GeoLocation transformer */
 int GDALGeoLocTransform( void *pTransformArg,
                          int bDstToSrc,
                          int nPointCount,
                          double *padfX, double *padfY,
-                         double * /* padfZ */,
+                         double *padfZ,
                          int *panSuccess )
 {
     GDALGeoLocTransformInfo *psTransform =
         static_cast<GDALGeoLocTransformInfo *>(pTransformArg);
-
-    if( psTransform->bReversed )
-        bDstToSrc = !bDstToSrc;
-
-    const double dfGeorefConventionOffset = psTransform->bOriginIsTopLeftCorner ? 0 : 0.5;
-
-/* -------------------------------------------------------------------- */
-/*      Do original pixel line to target geox/geoy.                     */
-/* -------------------------------------------------------------------- */
-    if( !bDstToSrc )
+    if( psTransform->bUseArray )
     {
-        for( int i = 0; i < nPointCount; i++ )
-        {
-            if( padfX[i] == HUGE_VAL || padfY[i] == HUGE_VAL )
-            {
-                panSuccess[i] = FALSE;
-                continue;
-            }
-
-            const double dfGeoLocPixel =
-                (padfX[i] - psTransform->dfPIXEL_OFFSET)
-                / psTransform->dfPIXEL_STEP - dfGeorefConventionOffset;
-            const double dfGeoLocLine =
-                (padfY[i] - psTransform->dfLINE_OFFSET)
-                / psTransform->dfLINE_STEP - dfGeorefConventionOffset;
-
-            if( !GDALGeoLocPosPixelLineToXY(psTransform,
-                                         dfGeoLocPixel,
-                                         dfGeoLocLine,
-                                         padfX[i],
-                                         padfY[i]) )
-            {
-                panSuccess[i] = FALSE;
-                padfX[i] = HUGE_VAL;
-                padfY[i] = HUGE_VAL;
-                continue;
-            }
-
-            if( psTransform->bSwapXY )
-            {
-                std::swap(padfX[i], padfY[i]);
-            }
-
-            panSuccess[i] = TRUE;
-        }
+        return GDALGeoLoc<GDALGeoLocCArrayAccessors>::Transform(pTransformArg,
+                                                               bDstToSrc,
+                                                               nPointCount,
+                                                               padfX,
+                                                               padfY,
+                                                               padfZ,
+                                                               panSuccess);
     }
-
-/* -------------------------------------------------------------------- */
-/*      geox/geoy to pixel/line using backmap.                          */
-/* -------------------------------------------------------------------- */
     else
     {
-        if( psTransform->hQuadTree )
-        {
-            GDALGeoLocInverseTransformQuadtree(psTransform,
-                                               nPointCount,
-                                               padfX,
-                                               padfY,
-                                               panSuccess);
-            return TRUE;
-        }
-
-        const bool bGeolocMaxAccuracy = CPLTestBool(
-            CPLGetConfigOption("GDAL_GEOLOC_USE_MAX_ACCURACY", "YES"));
-
-        // Keep those objects in this outer scope, so they are re-used, to
-        // save memory allocations.
-        OGRPoint oPoint;
-        OGRLinearRing oRing;
-        oRing.setNumPoints(5);
-
-        for( int i = 0; i < nPointCount; i++ )
-        {
-            if( padfX[i] == HUGE_VAL || padfY[i] == HUGE_VAL )
-            {
-                panSuccess[i] = FALSE;
-                continue;
-            }
-
-            if( psTransform->bSwapXY )
-            {
-                std::swap(padfX[i], padfY[i]);
-            }
-
-            const double dfGeoX = padfX[i];
-            const double dfGeoY = padfY[i];
-
-            const double dfBMX =
-                ((padfX[i] - psTransform->adfBackMapGeoTransform[0])
-                 / psTransform->adfBackMapGeoTransform[1]);
-            const double dfBMY =
-                ((padfY[i] - psTransform->adfBackMapGeoTransform[3])
-                 / psTransform->adfBackMapGeoTransform[5]);
-
-            if( !(dfBMX >= 0 && dfBMY >= 0 &&
-                  dfBMX + 1 < psTransform->nBackMapWidth &&
-                  dfBMY + 1 < psTransform->nBackMapHeight) )
-            {
-                panSuccess[i] = FALSE;
-                padfX[i] = HUGE_VAL;
-                padfY[i] = HUGE_VAL;
-                continue;
-            }
-
-            const std::ptrdiff_t iBMX = static_cast<std::ptrdiff_t>(dfBMX);
-            const std::ptrdiff_t iBMY = static_cast<std::ptrdiff_t>(dfBMY);
-
-            const size_t iBM = iBMX + iBMY * psTransform->nBackMapWidth;
-            if( psTransform->pafBackMapX[iBM] == INVALID_BMXY )
-            {
-                panSuccess[i] = FALSE;
-                padfX[i] = HUGE_VAL;
-                padfY[i] = HUGE_VAL;
-                continue;
-            }
-
-            const float* pafBMX = psTransform->pafBackMapX + iBM;
-            const float* pafBMY = psTransform->pafBackMapY + iBM;
-            if( pafBMX[1] != INVALID_BMXY &&
-                pafBMX[psTransform->nBackMapWidth] != INVALID_BMXY &&
-                pafBMX[psTransform->nBackMapWidth+1] != INVALID_BMXY)
-            {
-                padfX[i] =
-                    (1-(dfBMY - iBMY))
-                    * (pafBMX[0] + (dfBMX - iBMX) * (pafBMX[1] - pafBMX[0]))
-                    + (dfBMY - iBMY)
-                    * (pafBMX[psTransform->nBackMapWidth] +
-                       (dfBMX - iBMX) * (pafBMX[psTransform->nBackMapWidth+1] -
-                                         pafBMX[psTransform->nBackMapWidth]));
-                padfY[i] =
-                    (1-(dfBMY - iBMY))
-                    * (pafBMY[0] + (dfBMX - iBMX) * (pafBMY[1] - pafBMY[0]))
-                    + (dfBMY - iBMY)
-                    * (pafBMY[psTransform->nBackMapWidth] +
-                       (dfBMX - iBMX) * (pafBMY[psTransform->nBackMapWidth+1] -
-                                         pafBMY[psTransform->nBackMapWidth]));
-            }
-            else if( pafBMX[1] != INVALID_BMXY)
-            {
-                padfX[i] = pafBMX[0] +
-                            (dfBMX - iBMX) * (pafBMX[1] - pafBMX[0]);
-                padfY[i] = pafBMY[0] +
-                            (dfBMX - iBMX) * (pafBMY[1] - pafBMY[0]);
-            }
-            else if( pafBMX[psTransform->nBackMapWidth] != INVALID_BMXY)
-            {
-                padfX[i] =
-                    pafBMX[0] +
-                    (dfBMY - iBMY) * (pafBMX[psTransform->nBackMapWidth] -
-                                      pafBMX[0]);
-                padfY[i] =
-                    pafBMY[0] +
-                    (dfBMY - iBMY) * (pafBMY[psTransform->nBackMapWidth] -
-                                      pafBMY[0]);
-            }
-            else
-            {
-                padfX[i] = pafBMX[0];
-                padfY[i] = pafBMY[0];
-            }
-
-            const double dfGeoLocPixel =
-                (padfX[i] - psTransform->dfPIXEL_OFFSET)
-                / psTransform->dfPIXEL_STEP - dfGeorefConventionOffset;
-            const double dfGeoLocLine =
-                (padfY[i] - psTransform->dfLINE_OFFSET)
-                / psTransform->dfLINE_STEP - dfGeorefConventionOffset;
-#if 0
-            CPLDebug("GEOLOC", "%f %f %f %f", padfX[i], padfY[i], dfGeoLocPixel, dfGeoLocLine);
-            if( !psTransform->bOriginIsTopLeftCorner )
-            {
-                if( dfGeoLocPixel + dfGeorefConventionOffset > psTransform->nGeoLocXSize-1 ||
-                    dfGeoLocLine + dfGeorefConventionOffset > psTransform->nGeoLocYSize-1 )
-                {
-                    panSuccess[i] = FALSE;
-                    padfX[i] = HUGE_VAL;
-                    padfY[i] = HUGE_VAL;
-                    continue;
-                }
-            }
-#endif
-            if( !bGeolocMaxAccuracy )
-            {
-                panSuccess[i] = TRUE;
-                continue;
-            }
-
-            // Now that we have an approximate solution, identify a matching
-            // cell in the geolocation array, where we can use inverse bilinear
-            // interpolation to find the exact solution.
-
-            // NOTE: if the geolocation array is an affine transformation,
-            // the approximate solution should match the exact one, if the
-            // backmap has correctly been built.
-
-            oPoint.setX(dfGeoX);
-            oPoint.setY(dfGeoY);
-            // The thresholds and radius are rather empirical and have been tuned
-            // on the product S5P_TEST_L2__NO2____20190509T220707_20190509T234837_08137_01_010400_20200220T091343.nc
-            // that includes the north pole.
-            const int nSearchRadius =
-                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 85 ? 5 :
-                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 75 ? 3 :
-                psTransform->bGeographicSRSWithMinus180Plus180LongRange && fabs(dfGeoY) >= 65 ? 2 : 1;
-            const ptrdiff_t nGeoLocPixel = static_cast<ptrdiff_t>(std::floor(dfGeoLocPixel));
-            const ptrdiff_t nGeoLocLine = static_cast<ptrdiff_t>(std::floor(dfGeoLocLine));
-
-            bool bDone = false;
-            // Using the above approximate nGeoLocPixel, nGeoLocLine, try to
-            // find a forward cell that includes (dfGeoX, dfGeoY), with an increasing
-            // search radius, up to nSearchRadius.
-            for( int r = 0; !bDone && r <= nSearchRadius; r++ )
-            {
-                for( int iter = 0; !bDone && iter < (r == 0 ? 1 : 8 * r); ++iter)
-                {
-                    // For r=1, the below formulas will give the following offsets:
-                    // (-1,1), (0,1), (1,1), (1,0), (1,-1), (0,-1), (1,-1)
-                    const int sx = (r == 0) ? 0 :
-                             (iter < 2 *r) ? -r + iter :
-                             (iter < 4 * r) ? r :
-                             (iter < 6 * r) ? r - (iter - 4 * r):
-                             -r;
-                    const int sy = (r == 0) ? 0 :
-                             (iter < 2 *r) ? r :
-                             (iter < 4 * r) ? r - (iter - 2 * r) :
-                             (iter < 6 * r) ? -r:
-                             -r + (iter - 6 * r);
-                    const ptrdiff_t iX = nGeoLocPixel + sx;
-                    const ptrdiff_t iY = nGeoLocLine + sy;
-                    if( (iX == -1 || (iX >= 0 && static_cast<size_t>(iX) < psTransform->nGeoLocXSize)) &&
-                        (iY == -1 || (iY >= 0 && static_cast<size_t>(iY) < psTransform->nGeoLocYSize)) )
-                    {
-                        double x0, y0, x1, y1, x2, y2, x3, y3;
-
-                        if( !GDALGeoLocPosPixelLineToXY(psTransform,
-                                static_cast<double>(iX), static_cast<double>(iY),
-                                x0, y0) ||
-                            !GDALGeoLocPosPixelLineToXY(psTransform,
-                                static_cast<double>(iX+1), static_cast<double>(iY),
-                                x2, y2) ||
-                            !GDALGeoLocPosPixelLineToXY(psTransform,
-                                static_cast<double>(iX), static_cast<double>(iY+1),
-                                x1, y1) ||
-                            !GDALGeoLocPosPixelLineToXY(psTransform,
-                                static_cast<double>(iX+1), static_cast<double>(iY+1),
-                                x3, y3) )
-                        {
-                            continue;
-                        }
-
-                        int nIters = 1;
-                        // For a bounding box crossing the anti-meridian, check
-                        // both around -180 and +180 deg.
-                        if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
-                            std::fabs(x0) > 170 &&
-                            std::fabs(x1) > 170 &&
-                            std::fabs(x2) > 170 &&
-                            std::fabs(x3) > 170 &&
-                            (std::fabs(x1-x0) > 180 ||
-                             std::fabs(x2-x0) > 180 ||
-                             std::fabs(x3-x0) > 180) )
-                        {
-                            nIters = 2;
-                            if( x0 > 0 ) x0 -= 360;
-                            if( x1 > 0 ) x1 -= 360;
-                            if( x2 > 0 ) x2 -= 360;
-                            if( x3 > 0 ) x3 -= 360;
-                        }
-                        for( int iIter = 0; !bDone && iIter < nIters; ++iIter )
-                        {
-                            if( iIter == 1 )
-                            {
-                                x0 += 360;
-                                x1 += 360;
-                                x2 += 360;
-                                x3 += 360;
-                            }
-                            oRing.setPoint(0, x0, y0);
-                            oRing.setPoint(1, x2, y2);
-                            oRing.setPoint(2, x3, y3);
-                            oRing.setPoint(3, x1, y1);
-                            oRing.setPoint(4, x0, y0);
-                            if( oRing.isPointInRing( &oPoint ) ||
-                                oRing.isPointOnRingBoundary( &oPoint ) )
-                            {
-                                double dfX = static_cast<double>(iX);
-                                double dfY = static_cast<double>(iY);
-                                GDALInverseBilinearInterpolation(dfGeoX, dfGeoY,
-                                                             x0, y0,
-                                                             x1, y1,
-                                                             x2, y2,
-                                                             x3, y3,
-                                                             dfX, dfY);
-
-                                dfX = (dfX + dfGeorefConventionOffset) *
-                                    psTransform->dfPIXEL_STEP + psTransform->dfPIXEL_OFFSET;
-                                dfY = (dfY + dfGeorefConventionOffset) *
-                                    psTransform->dfLINE_STEP + psTransform->dfLINE_OFFSET;
-
-#ifdef DEBUG_GEOLOC_REALLY_VERBOSE
-                                CPLDebug("GEOLOC",
-                                         "value before adjustment: %f %f, "
-                                         "after adjustment: %f %f",
-                                         padfX[i], padfY[i], dfX, dfY);
-#endif
-
-                                padfX[i] = dfX;
-                                padfY[i] = dfY;
-
-                                bDone = true;
-                            }
-                        }
-                    }
-                }
-            }
-            if( !bDone )
-            {
-                panSuccess[i] = FALSE;
-                padfX[i] = HUGE_VAL;
-                padfY[i] = HUGE_VAL;
-                continue;
-            }
-
-            panSuccess[i] = TRUE;
-        }
+        return GDALGeoLoc<GDALGeoLocDatasetAccessors>::Transform(pTransformArg,
+                                                               bDstToSrc,
+                                                               nPointCount,
+                                                               padfX,
+                                                               padfY,
+                                                               padfZ,
+                                                               panSuccess);
     }
-
-    return TRUE;
 }
 
 /************************************************************************/

--- a/alg/gdalgeoloc.h
+++ b/alg/gdalgeoloc.h
@@ -1,0 +1,79 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  Implements Geolocation array based transformer.
+ * Author:   Even Rouault, <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Planet Labs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef GDALGEOLOC_H
+#define GDALGEOLOC_H
+
+#include "gdal_alg_priv.h"
+
+bool GDALGeoLocPosPixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
+                            const double dfGeoLocPixel,
+                            const double dfGeoLocLine,
+                            double& dfX,
+                            double& dfY);
+
+
+
+void GDALInverseBilinearInterpolation(const double x,
+                                      const double y,
+                                      const double x0,
+                                      const double y0,
+                                      const double x1,
+                                      const double y1,
+                                      const double x2,
+                                      const double y2,
+                                      const double x3,
+                                      const double y3,
+                                      double& i,
+                                      double& j);
+
+/************************************************************************/
+/*                           ShiftGeoX()                                */
+/************************************************************************/
+
+// Avoid discontinuity at anti-meridian when interpolating longitude
+// dfXRef is a "reference" longitude, typically the one of 4 points to
+// interpolate), towards which we apply a potential +/- 360 deg shift.
+// This may result in a value slightly outside [-180,180]
+static double ShiftGeoX(const GDALGeoLocTransformInfo *psTransform,
+                        double dfXRef,
+                        double dfX)
+{
+    if( !psTransform->bGeographicSRSWithMinus180Plus180LongRange )
+        return dfX;
+    // The threshold at 170 deg is a bit arbitary. A smarter approach
+    // would try to guess the "average" longitude step between 2 grid values
+    // and use 180 - average_step * some_factor as the threshold.
+    if( dfXRef < -170 && dfX > 170 )
+        return dfX - 360;
+    if( dfXRef > 170 && dfX < -170 )
+        return dfX + 360;
+    return dfX;
+}
+
+#endif

--- a/alg/gdalgeoloc.h
+++ b/alg/gdalgeoloc.h
@@ -31,13 +31,53 @@
 
 #include "gdal_alg_priv.h"
 
-bool GDALGeoLocPosPixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
-                            const double dfGeoLocPixel,
-                            const double dfGeoLocLine,
-                            double& dfX,
-                            double& dfY);
+/************************************************************************/
+/*                           GDALGeoLoc                                 */
+/************************************************************************/
+
+/*! @cond Doxygen_Suppress */
+
+template<class Accessors> struct GDALGeoLoc
+{
+    static bool LoadGeolocFinish( GDALGeoLocTransformInfo *psTransform );
+
+    static bool GenerateBackMap( GDALGeoLocTransformInfo *psTransform );
+
+    static bool PixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
+                                const int nGeoLocPixel,
+                                const int nGeoLocLine,
+                                double& dfX,
+                                double& dfY);
+
+    static bool PixelLineToXY(const GDALGeoLocTransformInfo *psTransform,
+                                const double dfGeoLocPixel,
+                                const double dfGeoLocLine,
+                                double& dfX,
+                                double& dfY);
+
+    static bool ExtractSquare(const GDALGeoLocTransformInfo *psTransform,
+                              int nX, int nY,
+                              double& dfX_0_0, double& dfY_0_0,
+                              double& dfX_1_0, double& dfY_1_0,
+                              double& dfX_0_1, double& dfY_0_1,
+                              double& dfX_1_1, double& dfY_1_1);
+
+    static int Transform( void *pTransformArg,
+                         int bDstToSrc,
+                         int nPointCount,
+                         double *padfX, double *padfY,
+                         double * /* padfZ */,
+                         int *panSuccess );
+};
+/*! @endcond */
 
 
+bool GDALGeoLocExtractSquare(const GDALGeoLocTransformInfo *psTransform,
+                             int nX, int nY,
+                             double& dfX_0_0, double& dfY_0_0,
+                             double& dfX_1_0, double& dfY_1_0,
+                             double& dfX_0_1, double& dfY_0_1,
+                             double& dfX_1_1, double& dfY_1_1);
 
 void GDALInverseBilinearInterpolation(const double x,
                                       const double y,

--- a/alg/gdalgeoloc_carray_accessor.h
+++ b/alg/gdalgeoloc_carray_accessor.h
@@ -1,0 +1,299 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  C-Array storage of geolocation array and backmap
+ * Author:   Even Rouault, <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Planet Labs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+/*! @cond Doxygen_Suppress */
+
+/************************************************************************/
+/*                        GDALGeoLocCArrayAccessors                     */
+/************************************************************************/
+
+class GDALGeoLocCArrayAccessors
+{
+    typedef class GDALGeoLocCArrayAccessors AccessorType;
+
+    GDALGeoLocTransformInfo*  m_psTransform;
+    double                   *m_padfGeoLocX = nullptr;
+    double                   *m_padfGeoLocY = nullptr;
+    float                    *m_pafBackMapX = nullptr;
+    float                    *m_pafBackMapY = nullptr;
+    float                    *m_wgtsBackMap = nullptr;
+
+    bool                      LoadGeoloc(bool bIsRegularGrid);
+
+public:
+
+    template<class Type> struct CArrayAccessor
+    {
+        Type*  m_array;
+        size_t m_nXSize;
+
+        CArrayAccessor(Type* array, size_t nXSize): m_array(array), m_nXSize(nXSize) {}
+
+        inline Type Get(int nX, int nY, bool* pbSuccess = nullptr)
+        {
+            if( pbSuccess )
+                *pbSuccess = true;
+            return m_array[nY * m_nXSize + nX];
+        }
+
+        inline bool Set(int nX, int nY, Type val)
+        {
+            m_array[nY * m_nXSize + nX] = val;
+            return true;
+        }
+    };
+
+    CArrayAccessor<double> geolocXAccessor;
+    CArrayAccessor<double> geolocYAccessor;
+    CArrayAccessor<float>  backMapXAccessor;
+    CArrayAccessor<float>  backMapYAccessor;
+    CArrayAccessor<float>  backMapWeightAccessor;
+
+    explicit GDALGeoLocCArrayAccessors(GDALGeoLocTransformInfo* psTransform):
+        m_psTransform(psTransform),
+        geolocXAccessor(nullptr, 0),
+        geolocYAccessor(nullptr, 0),
+        backMapXAccessor(nullptr, 0),
+        backMapYAccessor(nullptr, 0),
+        backMapWeightAccessor(nullptr, 0)
+    {
+    }
+
+    ~GDALGeoLocCArrayAccessors()
+    {
+        VSIFree(m_pafBackMapX);
+        VSIFree(m_pafBackMapY);
+        VSIFree(m_padfGeoLocX);
+        VSIFree(m_padfGeoLocY);
+        VSIFree(m_wgtsBackMap);
+    }
+
+    GDALGeoLocCArrayAccessors(const GDALGeoLocCArrayAccessors&) = delete;
+    GDALGeoLocCArrayAccessors& operator= (const GDALGeoLocCArrayAccessors&) = delete;
+
+    bool         Load(bool bIsRegularGrid, bool bUseQuadtree);
+
+    bool         AllocateBackMap();
+
+    GDALDataset* GetBackmapDataset();
+    static void  FlushBackmapCaches() {}
+    static void  ReleaseBackmapDataset(GDALDataset* poDS) { delete poDS; }
+
+    void         FreeWghtsBackMap();
+};
+
+/************************************************************************/
+/*                         AllocateBackMap()                            */
+/************************************************************************/
+
+bool GDALGeoLocCArrayAccessors::AllocateBackMap()
+{
+    m_pafBackMapX = static_cast<float *>(
+        VSI_MALLOC3_VERBOSE(m_psTransform->nBackMapWidth,
+                            m_psTransform->nBackMapHeight, sizeof(float)));
+    m_pafBackMapY = static_cast<float *>(
+        VSI_MALLOC3_VERBOSE(m_psTransform->nBackMapWidth,
+                            m_psTransform->nBackMapHeight, sizeof(float)));
+
+    m_wgtsBackMap = static_cast<float *>(
+        VSI_MALLOC3_VERBOSE(m_psTransform->nBackMapWidth,
+                            m_psTransform->nBackMapHeight, sizeof(float)));
+
+    if( m_pafBackMapX == nullptr ||
+        m_pafBackMapY == nullptr ||
+        m_wgtsBackMap == nullptr)
+    {
+        return false;
+    }
+
+    const size_t nBMXYCount = static_cast<size_t>(m_psTransform->nBackMapWidth) *
+                                m_psTransform->nBackMapHeight;
+    for( size_t i = 0; i < nBMXYCount; i++ )
+    {
+        m_pafBackMapX[i] = 0;
+        m_pafBackMapY[i] = 0;
+        m_wgtsBackMap[i] = 0.0;
+    }
+
+    backMapXAccessor.m_array = m_pafBackMapX;
+    backMapXAccessor.m_nXSize = m_psTransform->nBackMapWidth;
+
+    backMapYAccessor.m_array = m_pafBackMapY;
+    backMapYAccessor.m_nXSize = m_psTransform->nBackMapWidth;
+
+    backMapWeightAccessor.m_array = m_wgtsBackMap;
+    backMapWeightAccessor.m_nXSize = m_psTransform->nBackMapWidth;
+
+    return true;
+}
+
+/************************************************************************/
+/*                         FreeWghtsBackMap()                           */
+/************************************************************************/
+
+void GDALGeoLocCArrayAccessors::FreeWghtsBackMap()
+{
+    VSIFree(m_wgtsBackMap);
+    m_wgtsBackMap = nullptr;
+    backMapWeightAccessor.m_array = nullptr;
+    backMapWeightAccessor.m_nXSize = 0;
+}
+
+/************************************************************************/
+/*                        GetBackmapDataset()                           */
+/************************************************************************/
+
+GDALDataset* GDALGeoLocCArrayAccessors::GetBackmapDataset()
+{
+    auto poMEMDS = MEMDataset::Create( "",
+                              m_psTransform->nBackMapWidth,
+                              m_psTransform->nBackMapHeight,
+                              0, GDT_Float32, nullptr );
+
+    for( int i = 1; i <= 2; i++ )
+    {
+        char szBuffer[32] = { '\0' };
+        char szBuffer0[64] = { '\0' };
+        char* apszOptions[] = { szBuffer0, nullptr };
+
+        void* ptr = (i == 1) ? m_pafBackMapX : m_pafBackMapY;
+        szBuffer[CPLPrintPointer(szBuffer, ptr, sizeof(szBuffer))] = '\0';
+        snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
+        poMEMDS->AddBand(GDT_Float32, apszOptions);
+        poMEMDS->GetRasterBand(i)->SetNoDataValue(INVALID_BMXY);
+    }
+    return poMEMDS;
+}
+
+/************************************************************************/
+/*                             Load()                                   */
+/************************************************************************/
+
+bool GDALGeoLocCArrayAccessors::Load(bool bIsRegularGrid, bool bUseQuadtree)
+{
+    return LoadGeoloc(bIsRegularGrid) &&
+           ((bUseQuadtree && GDALGeoLocBuildQuadTree(m_psTransform)) ||
+            (!bUseQuadtree && GDALGeoLoc<AccessorType>::GenerateBackMap(m_psTransform)));
+}
+
+/************************************************************************/
+/*                          LoadGeoloc()                                */
+/************************************************************************/
+
+bool GDALGeoLocCArrayAccessors::LoadGeoloc(bool bIsRegularGrid)
+
+{
+    const int nXSize = m_psTransform->nGeoLocXSize;
+    const int nYSize = m_psTransform->nGeoLocYSize;
+
+    m_padfGeoLocY = static_cast<double *>(
+        VSI_MALLOC3_VERBOSE(sizeof(double), nXSize, nYSize));
+    m_padfGeoLocX = static_cast<double *>(
+        VSI_MALLOC3_VERBOSE(sizeof(double), nXSize, nYSize));
+
+    if( m_padfGeoLocX == nullptr ||
+        m_padfGeoLocY == nullptr )
+    {
+        return false;
+    }
+
+    if( bIsRegularGrid )
+    {
+        // Case of regular grid.
+        // The XBAND contains the x coordinates for all lines.
+        // The YBAND contains the y coordinates for all columns.
+
+        double* padfTempX = static_cast<double *>(
+            VSI_MALLOC2_VERBOSE(nXSize, sizeof(double)));
+        double* padfTempY = static_cast<double *>(
+            VSI_MALLOC2_VERBOSE(nYSize, sizeof(double)));
+        if( padfTempX == nullptr || padfTempY == nullptr )
+        {
+            CPLFree(padfTempX);
+            CPLFree(padfTempY);
+            return false;
+        }
+
+        CPLErr eErr =
+            GDALRasterIO( m_psTransform->hBand_X, GF_Read,
+                          0, 0, nXSize, 1,
+                          padfTempX, nXSize, 1,
+                          GDT_Float64, 0, 0 );
+
+        for( size_t j = 0; j < static_cast<size_t>(nYSize); j++ )
+        {
+            memcpy( m_padfGeoLocX + j * nXSize,
+                    padfTempX,
+                    nXSize * sizeof(double) );
+        }
+
+        if( eErr == CE_None )
+        {
+            eErr = GDALRasterIO( m_psTransform->hBand_Y, GF_Read,
+                                 0, 0, nYSize, 1,
+                                 padfTempY, nYSize, 1,
+                                 GDT_Float64, 0, 0 );
+
+            for( size_t j = 0; j < static_cast<size_t>(nYSize); j++ )
+            {
+                for( size_t i = 0; i < static_cast<size_t>(nXSize); i++ )
+                {
+                    m_padfGeoLocY[j * nXSize + i] = padfTempY[j];
+                }
+            }
+        }
+
+        CPLFree(padfTempX);
+        CPLFree(padfTempY);
+
+        if( eErr != CE_None )
+            return false;
+    }
+    else
+    {
+        if( GDALRasterIO( m_psTransform->hBand_X, GF_Read,
+                          0, 0, nXSize, nYSize,
+                          m_padfGeoLocX, nXSize, nYSize,
+                          GDT_Float64, 0, 0 ) != CE_None
+            || GDALRasterIO( m_psTransform->hBand_Y, GF_Read,
+                             0, 0, nXSize, nYSize,
+                             m_padfGeoLocY, nXSize, nYSize,
+                             GDT_Float64, 0, 0 ) != CE_None )
+            return false;
+    }
+
+    geolocXAccessor.m_array = m_padfGeoLocX;
+    geolocXAccessor.m_nXSize = m_psTransform->nGeoLocXSize;
+
+    geolocYAccessor.m_array = m_padfGeoLocY;
+    geolocYAccessor.m_nXSize = m_psTransform->nGeoLocXSize;
+
+    return GDALGeoLoc<GDALGeoLocCArrayAccessors>::LoadGeolocFinish(m_psTransform);
+}
+
+/*! @endcond */

--- a/alg/gdalgeoloc_dataset_accessor.h
+++ b/alg/gdalgeoloc_dataset_accessor.h
@@ -1,0 +1,311 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  Dataset storage of geolocation array and backmap
+ * Author:   Even Rouault, <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Planet Labs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdalcachedpixelaccessor.h"
+
+/*! @cond Doxygen_Suppress */
+
+/************************************************************************/
+/*                        GDALGeoLocDatasetAccessors                    */
+/************************************************************************/
+
+class GDALGeoLocDatasetAccessors
+{
+    typedef class GDALGeoLocDatasetAccessors AccessorType;
+
+    static constexpr int TILE_SIZE = 1024;
+
+    GDALGeoLocTransformInfo*  m_psTransform;
+
+    CPLStringList    m_aosGTiffCreationOptions{};
+
+    GDALDataset*     m_poGeolocTmpDataset = nullptr;
+    GDALDataset*     m_poBackmapTmpDataset = nullptr;
+    GDALDataset*     m_poBackmapWeightsTmpDataset = nullptr;
+
+    GDALGeoLocDatasetAccessors(const GDALGeoLocDatasetAccessors&) = delete;
+    GDALGeoLocDatasetAccessors& operator= (const GDALGeoLocDatasetAccessors&) = delete;
+
+    bool         LoadGeoloc(bool bIsRegularGrid);
+
+public:
+    GDALCachedPixelAccessor<double, TILE_SIZE> geolocXAccessor;
+    GDALCachedPixelAccessor<double, TILE_SIZE> geolocYAccessor;
+    GDALCachedPixelAccessor<float, TILE_SIZE>  backMapXAccessor;
+    GDALCachedPixelAccessor<float, TILE_SIZE>  backMapYAccessor;
+    GDALCachedPixelAccessor<float, TILE_SIZE>  backMapWeightAccessor;
+
+    explicit GDALGeoLocDatasetAccessors(GDALGeoLocTransformInfo* psTransform):
+        m_psTransform(psTransform),
+        geolocXAccessor(nullptr),
+        geolocYAccessor(nullptr),
+        backMapXAccessor(nullptr),
+        backMapYAccessor(nullptr),
+        backMapWeightAccessor(nullptr)
+    {
+        m_aosGTiffCreationOptions.SetNameValue("TILED", "YES");
+        m_aosGTiffCreationOptions.SetNameValue("INTERLEAVE", "BAND");
+        m_aosGTiffCreationOptions.SetNameValue("BLOCKXSIZE", CPLSPrintf("%d", TILE_SIZE));
+        m_aosGTiffCreationOptions.SetNameValue("BLOCKYSIZE", CPLSPrintf("%d", TILE_SIZE));
+    }
+
+               ~GDALGeoLocDatasetAccessors();
+
+    bool         Load(bool bIsRegularGrid, bool bUseQuadtree);
+
+    bool         AllocateBackMap();
+
+    GDALDataset* GetBackmapDataset();
+    void         FlushBackmapCaches();
+    static void  ReleaseBackmapDataset(GDALDataset*) {}
+
+    void         FreeWghtsBackMap();
+};
+
+/************************************************************************/
+/*                    ~GDALGeoLocDatasetAccessors()                     */
+/************************************************************************/
+
+GDALGeoLocDatasetAccessors::~GDALGeoLocDatasetAccessors()
+{
+    geolocXAccessor.ResetModifiedFlag();
+    geolocYAccessor.ResetModifiedFlag();
+    backMapXAccessor.ResetModifiedFlag();
+    backMapYAccessor.ResetModifiedFlag();
+
+    FreeWghtsBackMap();
+
+    delete m_poGeolocTmpDataset;
+    delete m_poBackmapTmpDataset;
+}
+
+/************************************************************************/
+/*                         AllocateBackMap()                            */
+/************************************************************************/
+
+bool GDALGeoLocDatasetAccessors::AllocateBackMap()
+{
+    auto poDriver = GDALDriver::FromHandle(GDALGetDriverByName("GTiff"));
+    if( poDriver == nullptr )
+        return false;
+
+    m_poBackmapTmpDataset = poDriver->Create(
+        CPLResetExtension(CPLGenerateTempFilename(nullptr), "tif"),
+        m_psTransform->nBackMapWidth,
+        m_psTransform->nBackMapHeight,
+        2,
+        GDT_Float32,
+        m_aosGTiffCreationOptions.List());
+    if( m_poBackmapTmpDataset == nullptr )
+    {
+        return false;
+    }
+    m_poBackmapTmpDataset->MarkSuppressOnClose();
+    VSIUnlink(m_poBackmapTmpDataset->GetDescription());
+    auto poBandX = m_poBackmapTmpDataset->GetRasterBand(1);
+    auto poBandY = m_poBackmapTmpDataset->GetRasterBand(2);
+
+    backMapXAccessor.SetBand(poBandX);
+    backMapYAccessor.SetBand(poBandY);
+
+    m_poBackmapWeightsTmpDataset = poDriver->Create(
+        CPLResetExtension(CPLGenerateTempFilename(nullptr), "tif"),
+        m_psTransform->nBackMapWidth,
+        m_psTransform->nBackMapHeight,
+        1,
+        GDT_Float32,
+        m_aosGTiffCreationOptions.List());
+    if( m_poBackmapWeightsTmpDataset == nullptr )
+    {
+        return false;
+    }
+    m_poBackmapWeightsTmpDataset->MarkSuppressOnClose();
+    VSIUnlink(m_poBackmapWeightsTmpDataset->GetDescription());
+    backMapWeightAccessor.SetBand(m_poBackmapWeightsTmpDataset->GetRasterBand(1));
+
+    return true;
+}
+
+/************************************************************************/
+/*                         FreeWghtsBackMap()                           */
+/************************************************************************/
+
+void GDALGeoLocDatasetAccessors::FreeWghtsBackMap()
+{
+    if( m_poBackmapWeightsTmpDataset )
+    {
+        backMapWeightAccessor.ResetModifiedFlag();
+        delete m_poBackmapWeightsTmpDataset;
+        m_poBackmapWeightsTmpDataset = nullptr;
+    }
+}
+
+/************************************************************************/
+/*                        GetBackmapDataset()                           */
+/************************************************************************/
+
+GDALDataset* GDALGeoLocDatasetAccessors::GetBackmapDataset()
+{
+    auto poBandX = m_poBackmapTmpDataset->GetRasterBand(1);
+    auto poBandY = m_poBackmapTmpDataset->GetRasterBand(2);
+    poBandX->SetNoDataValue(INVALID_BMXY);
+    poBandY->SetNoDataValue(INVALID_BMXY);
+    return m_poBackmapTmpDataset;
+}
+
+/************************************************************************/
+/*                       FlushBackmapCaches()                           */
+/************************************************************************/
+
+void GDALGeoLocDatasetAccessors::FlushBackmapCaches()
+{
+    backMapXAccessor.FlushCache();
+    backMapYAccessor.FlushCache();
+}
+
+/************************************************************************/
+/*                             Load()                                   */
+/************************************************************************/
+
+bool GDALGeoLocDatasetAccessors::Load(bool bIsRegularGrid, bool bUseQuadtree)
+{
+    return LoadGeoloc(bIsRegularGrid) &&
+           ((bUseQuadtree && GDALGeoLocBuildQuadTree(m_psTransform)) ||
+            (!bUseQuadtree && GDALGeoLoc<AccessorType>::GenerateBackMap(m_psTransform)));
+}
+
+/************************************************************************/
+/*                          LoadGeoloc()                                */
+/************************************************************************/
+
+bool GDALGeoLocDatasetAccessors::LoadGeoloc(bool bIsRegularGrid)
+
+{
+    if( bIsRegularGrid )
+    {
+        const int nXSize = m_psTransform->nGeoLocXSize;
+        const int nYSize = m_psTransform->nGeoLocYSize;
+
+        auto poDriver = GDALDriver::FromHandle(GDALGetDriverByName("GTiff"));
+        if( poDriver == nullptr )
+            return false;
+
+        m_poGeolocTmpDataset = poDriver->Create(
+            CPLResetExtension(CPLGenerateTempFilename(nullptr), "tif"),
+            nXSize,
+            nYSize,
+            2,
+            GDT_Float64,
+            m_aosGTiffCreationOptions.List());
+        if( m_poGeolocTmpDataset == nullptr )
+        {
+            return false;
+        }
+        m_poGeolocTmpDataset->MarkSuppressOnClose();
+        VSIUnlink(m_poGeolocTmpDataset->GetDescription());
+
+        auto poXBand = m_poGeolocTmpDataset->GetRasterBand(1);
+        auto poYBand = m_poGeolocTmpDataset->GetRasterBand(2);
+
+        // Case of regular grid.
+        // The XBAND contains the x coordinates for all lines.
+        // The YBAND contains the y coordinates for all columns.
+
+        double* padfTempX = static_cast<double *>(
+            VSI_MALLOC2_VERBOSE(nXSize, sizeof(double)));
+        double* padfTempY = static_cast<double *>(
+            VSI_MALLOC2_VERBOSE(nYSize, sizeof(double)));
+        if( padfTempX == nullptr || padfTempY == nullptr )
+        {
+            CPLFree(padfTempX);
+            CPLFree(padfTempY);
+            return false;
+        }
+
+        CPLErr eErr =
+            GDALRasterIO( m_psTransform->hBand_X, GF_Read,
+                          0, 0, nXSize, 1,
+                          padfTempX, nXSize, 1,
+                          GDT_Float64, 0, 0 );
+
+        for( int j = 0; j < nYSize; j++ )
+        {
+             if( poXBand->RasterIO(GF_Write,
+                              0, j, nXSize, 1,
+                              padfTempX,
+                              nXSize, 1,
+                              GDT_Float64,
+                              0, 0, nullptr) != CE_None )
+             {
+                 eErr = CE_Failure;
+                 break;
+             }
+        }
+
+        if( eErr == CE_None )
+        {
+            eErr = GDALRasterIO( m_psTransform->hBand_Y, GF_Read,
+                                 0, 0, nYSize, 1,
+                                 padfTempY, nYSize, 1,
+                                 GDT_Float64, 0, 0 );
+
+            for( int i = 0; i < nXSize; i++ )
+            {
+                 if( poYBand->RasterIO(GF_Write,
+                                  i, 0, 1, nYSize,
+                                  padfTempY,
+                                  1, nYSize,
+                                  GDT_Float64,
+                                  0, 0, nullptr) != CE_None )
+                 {
+                     eErr = CE_Failure;
+                     break;
+                 }
+            }
+        }
+
+        CPLFree(padfTempX);
+        CPLFree(padfTempY);
+
+        if( eErr != CE_None )
+            return false;
+
+        geolocXAccessor.SetBand( poXBand );
+        geolocYAccessor.SetBand( poYBand );
+
+    }
+    else
+    {
+        geolocXAccessor.SetBand( GDALRasterBand::FromHandle(m_psTransform->hBand_X) );
+        geolocYAccessor.SetBand( GDALRasterBand::FromHandle(m_psTransform->hBand_Y) );
+    }
+
+    return GDALGeoLoc<GDALGeoLocDatasetAccessors>::LoadGeolocFinish(m_psTransform);
+}
+
+/*! @endcond */

--- a/alg/gdalgeolocquadtree.cpp
+++ b/alg/gdalgeolocquadtree.cpp
@@ -1,0 +1,406 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  Implements Geolocation array based transformer, using a quadtree
+ *           for inverse
+ * Author:   Even Rouault, <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Planet Labs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdalgeoloc.h"
+#include "gdalgeolocquadtree.h"
+
+#include "cpl_quad_tree.h"
+
+#include "ogr_geometry.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+
+/************************************************************************/
+/*               GDALGeoLocQuadTreeGetFeatureCorners()                  */
+/************************************************************************/
+
+static bool GDALGeoLocQuadTreeGetFeatureCorners(const GDALGeoLocTransformInfo *psTransform,
+                                                size_t nIdx,
+                                                double& x0,
+                                                double& y0,
+                                                double& x1,
+                                                double& y1,
+                                                double& x2,
+                                                double& y2,
+                                                double& x3,
+                                                double& y3)
+{
+    const size_t nExtendedWidth = psTransform->nGeoLocXSize +
+                        ( psTransform->bOriginIsTopLeftCorner ? 0 : 1 );
+    size_t nX = nIdx % nExtendedWidth;
+    size_t nY = nIdx / nExtendedWidth;
+
+    if( !psTransform->bOriginIsTopLeftCorner )
+    {
+        if( nX == 0 || nY == 0 )
+        {
+            return
+                GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(nX) - 1.0,
+                    static_cast<double>(nY) - 1.0,
+                    x0, y0)  &&
+                GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(nX),
+                    static_cast<double>(nY) - 1.0,
+                    x1, y1) &&
+                GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(nX) - 1.0,
+                    static_cast<double>(nY),
+                    x2, y2) &&
+                GDALGeoLocPosPixelLineToXY(psTransform,
+                    static_cast<double>(nX),
+                    static_cast<double>(nY),
+                    x3, y3);
+        }
+        nX --;
+        nY --;
+        nIdx = nY * psTransform->nGeoLocXSize + nX;
+    }
+
+    x0 = psTransform->padfGeoLocX[nIdx];
+    y0 = psTransform->padfGeoLocY[nIdx];
+    if( nX == psTransform->nGeoLocXSize - 1 ||
+        nY == psTransform->nGeoLocYSize - 1 )
+    {
+        if( (psTransform->bHasNoData &&
+              x0 == psTransform->dfNoDataX) ||
+            !GDALGeoLocPosPixelLineToXY(psTransform,
+                static_cast<double>(nX + 1),
+                static_cast<double>(nY),
+                x1, y1) ||
+            !GDALGeoLocPosPixelLineToXY(psTransform,
+                static_cast<double>(nX),
+                static_cast<double>(nY + 1),
+                x2, y2) ||
+            !GDALGeoLocPosPixelLineToXY(psTransform,
+                static_cast<double>(nX + 1),
+                static_cast<double>(nY + 1),
+                x3, y3) )
+        {
+            return false;
+        }
+    }
+    else
+    {
+        x1 = psTransform->padfGeoLocX[nIdx+1];
+        y1 = psTransform->padfGeoLocY[nIdx+1];
+        x2 = psTransform->padfGeoLocX[nIdx+psTransform->nGeoLocXSize];
+        y2 = psTransform->padfGeoLocY[nIdx+psTransform->nGeoLocXSize];
+        x3 = psTransform->padfGeoLocX[nIdx+psTransform->nGeoLocXSize+1];
+        y3 = psTransform->padfGeoLocY[nIdx+psTransform->nGeoLocXSize+1];
+        if( psTransform->bHasNoData &&
+            (x0 == psTransform->dfNoDataX ||
+             x1 == psTransform->dfNoDataX ||
+             x2 == psTransform->dfNoDataX ||
+             x3 == psTransform->dfNoDataX) )
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/************************************************************************/
+/*               GDALGeoLocQuadTreeGetFeatureBounds()                   */
+/************************************************************************/
+
+constexpr size_t BIT_IDX_RANGE_180 = 8 * sizeof(size_t) - 1;
+constexpr size_t BIT_IDX_RANGE_180_SET = static_cast<size_t>(1) << BIT_IDX_RANGE_180;
+
+// Callback used by quadtree to retrieve the bounding box, in georeferenced space,
+// of a cell of the geolocation array.
+static void GDALGeoLocQuadTreeGetFeatureBounds(const void* hFeature, void* pUserData, CPLRectObj* pBounds)
+{
+    const GDALGeoLocTransformInfo *psTransform =
+        static_cast<const GDALGeoLocTransformInfo *>(pUserData);
+    size_t nIdx = reinterpret_cast<size_t>(hFeature);
+    // Most significant bit set means that geometries crossing the antimeridian
+    // should have their longitudes lower or greater than 180 deg.
+    const bool bXRefAt180 = (nIdx >> BIT_IDX_RANGE_180) != 0;
+    // Clear that bit.
+    nIdx &= ~BIT_IDX_RANGE_180_SET;
+
+    double x0 = 0, y0 = 0, x1 = 0, y1 = 0, x2 = 0, y2 = 0, x3 = 0, y3 = 0;
+    GDALGeoLocQuadTreeGetFeatureCorners(psTransform, nIdx,
+                                        x0, y0, x1, y1, x2, y2, x3, y3);
+
+    if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+        std::fabs(x0) > 170 &&
+        std::fabs(x1) > 170 &&
+        std::fabs(x2) > 170 &&
+        std::fabs(x3) > 170 &&
+        (std::fabs(x1-x0) > 180 ||
+         std::fabs(x2-x0) > 180 ||
+         std::fabs(x3-x0) > 180) )
+    {
+        const double dfXRef = bXRefAt180 ? 180 : -180;
+        x0 = ShiftGeoX(psTransform, dfXRef, x0);
+        x1 = ShiftGeoX(psTransform, dfXRef, x1);
+        x2 = ShiftGeoX(psTransform, dfXRef, x2);
+        x3 = ShiftGeoX(psTransform, dfXRef, x3);
+    }
+    pBounds->minx = std::min(std::min(x0, x1), std::min(x2, x3));
+    pBounds->miny = std::min(std::min(y0, y1), std::min(y2, y3));
+    pBounds->maxx = std::max(std::max(x0, x1), std::max(x2, x3));
+    pBounds->maxy = std::max(std::max(y0, y1), std::max(y2, y3));
+}
+
+/************************************************************************/
+/*                      GDALGeoLocBuildQuadTree()                       */
+/************************************************************************/
+
+bool GDALGeoLocBuildQuadTree( GDALGeoLocTransformInfo *psTransform )
+{
+    // For the pixel-center convention, insert a "virtual" row and column
+    // at top and left of the geoloc array.
+    const size_t nExtraPixel = psTransform->bOriginIsTopLeftCorner ? 0 : 1;
+
+    if( psTransform->nGeoLocXSize > static_cast<size_t>(INT_MAX) - nExtraPixel ||
+        psTransform->nGeoLocYSize > static_cast<size_t>(INT_MAX) - nExtraPixel ||
+        // The >> 1 shift is because we need to reserve the most-significant-bit
+        // for the second 'version' of anti-meridian crossing quadrilaterals.
+        // See below
+        (psTransform->nGeoLocXSize + nExtraPixel) > (std::numeric_limits<size_t>::max() >> 1) /
+            (psTransform->nGeoLocYSize + nExtraPixel) )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Too big geolocation array");
+        return false;
+    }
+
+    const size_t nExtendedWidth = psTransform->nGeoLocXSize + nExtraPixel;
+    const size_t nExtendedHeight = psTransform->nGeoLocYSize + nExtraPixel;
+    const size_t nExtendedXYCount = nExtendedWidth * nExtendedHeight;
+
+    CPLDebug("GEOLOC", "Start quadtree construction");
+
+    CPLRectObj globalBounds;
+    globalBounds.minx = psTransform->dfMinX;
+    globalBounds.miny = psTransform->dfMinY;
+    globalBounds.maxx = psTransform->dfMaxX;
+    globalBounds.maxy = psTransform->dfMaxY;
+    psTransform->hQuadTree = CPLQuadTreeCreateEx(&globalBounds,
+                                                 GDALGeoLocQuadTreeGetFeatureBounds,
+                                                 psTransform);
+
+    CPLQuadTreeForceUseOfSubNodes(psTransform->hQuadTree);
+
+    for( size_t i = 0; i < nExtendedXYCount; i++ )
+    {
+        double x0, y0, x1, y1, x2, y2, x3, y3;
+        if (!GDALGeoLocQuadTreeGetFeatureCorners(psTransform, i,
+                                            x0, y0, x1, y1, x2, y2, x3, y3) )
+        {
+            continue;
+        }
+
+        // Skip too large geometries (typically at very high latitudes)
+        // that would fill too many nodes in the quadtree
+        if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+            (std::fabs(x0) > 170 ||
+             std::fabs(x1) > 170 ||
+             std::fabs(x2) > 170 ||
+             std::fabs(x3) > 170) &&
+            (std::fabs(x1-x0) > 180 ||
+             std::fabs(x2-x0) > 180 ||
+             std::fabs(x3-x0) > 180) &&
+            !(std::fabs(x0) > 170 &&
+              std::fabs(x1) > 170 &&
+              std::fabs(x2) > 170 &&
+              std::fabs(x3) > 170) )
+        {
+            continue;
+        }
+
+        CPLQuadTreeInsert(psTransform->hQuadTree,
+                          reinterpret_cast<void*>(i));
+
+        // For a geometry crossing the antimeridian, we've insert before
+        // the "version" around -180 deg. Insert its corresponding version around
+        // +180 deg.
+        if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+                    std::fabs(x0) > 170 &&
+                    std::fabs(x1) > 170 &&
+                    std::fabs(x2) > 170 &&
+                    std::fabs(x3) > 170 &&
+                    (std::fabs(x1-x0) > 180 ||
+                     std::fabs(x2-x0) > 180 ||
+                     std::fabs(x3-x0) > 180) )
+        {
+            CPLQuadTreeInsert(psTransform->hQuadTree,
+                              reinterpret_cast<void*>(i | BIT_IDX_RANGE_180_SET));
+        }
+    }
+
+    CPLDebug("GEOLOC", "End of quadtree construction");
+
+#ifdef DEBUG_GEOLOC
+    int nFeatureCount = 0;
+    int nNodeCount = 0;
+    int nMaxDepth = 0;
+    int nMaxBucketCapacity = 0;
+    CPLQuadTreeGetStats(psTransform->hQuadTree,
+                        &nFeatureCount, &nNodeCount, &nMaxDepth, &nMaxBucketCapacity);
+    CPLDebug("GEOLOC", "Quadtree stats:");
+    CPLDebug("GEOLOC", "  nFeatureCount = %d", nFeatureCount);
+    CPLDebug("GEOLOC", "  nNodeCount = %d", nNodeCount);
+    CPLDebug("GEOLOC", "  nMaxDepth = %d", nMaxDepth);
+    CPLDebug("GEOLOC", "  nMaxBucketCapacity = %d", nMaxBucketCapacity);
+#endif
+
+    return true;
+}
+
+/************************************************************************/
+/*                  GDALGeoLocInverseTransformQuadtree()                */
+/************************************************************************/
+
+void GDALGeoLocInverseTransformQuadtree(
+                    const GDALGeoLocTransformInfo *psTransform,
+                    int nPointCount,
+                    double *padfX,
+                    double *padfY,
+                    int *panSuccess )
+{
+    // Keep those objects in this outer scope, so they are re-used, to
+    // save memory allocations.
+    OGRPoint oPoint;
+    OGRLinearRing oRing;
+    oRing.setNumPoints(5);
+
+    const double dfGeorefConventionOffset = psTransform->bOriginIsTopLeftCorner ? 0 : 0.5;
+
+    for( int i = 0; i < nPointCount; i++ )
+    {
+        if( padfX[i] == HUGE_VAL || padfY[i] == HUGE_VAL )
+        {
+            panSuccess[i] = FALSE;
+            continue;
+        }
+
+        if( psTransform->bSwapXY )
+        {
+            std::swap(padfX[i], padfY[i]);
+        }
+
+        const double dfGeoX = padfX[i];
+        const double dfGeoY = padfY[i];
+
+        bool bDone = false;
+
+        CPLRectObj aoi;
+        aoi.minx = dfGeoX;
+        aoi.maxx = dfGeoX;
+        aoi.miny = dfGeoY;
+        aoi.maxy = dfGeoY;
+        int nFeatureCount = 0;
+        void** pahFeatures = CPLQuadTreeSearch(psTransform->hQuadTree,
+                                               &aoi,
+                                               &nFeatureCount);
+        if( nFeatureCount != 0 )
+        {
+            oPoint.setX(dfGeoX);
+            oPoint.setY(dfGeoY);
+            for( int iFeat = 0; iFeat < nFeatureCount; iFeat++ )
+            {
+                size_t nIdx = reinterpret_cast<size_t>(pahFeatures[iFeat]);
+                const bool bXRefAt180 = (nIdx >> BIT_IDX_RANGE_180) != 0;
+                // Clear that bit.
+                nIdx &= ~BIT_IDX_RANGE_180_SET;
+
+                double x0 = 0, y0 = 0, x1 = 0, y1 = 0, x2 = 0, y2 = 0, x3 = 0, y3 = 0;
+                GDALGeoLocQuadTreeGetFeatureCorners(psTransform, nIdx,
+                                                    x0, y0, x2, y2, x1, y1, x3, y3);
+
+                if( psTransform->bGeographicSRSWithMinus180Plus180LongRange &&
+                    std::fabs(x0) > 170 &&
+                    std::fabs(x1) > 170 &&
+                    std::fabs(x2) > 170 &&
+                    std::fabs(x3) > 170 &&
+                    (std::fabs(x1-x0) > 180 ||
+                     std::fabs(x2-x0) > 180 ||
+                     std::fabs(x3-x0) > 180) )
+                {
+                    const double dfXRef = bXRefAt180 ? 180 : -180;
+                    x0 = ShiftGeoX(psTransform, dfXRef, x0);
+                    x1 = ShiftGeoX(psTransform, dfXRef, x1);
+                    x2 = ShiftGeoX(psTransform, dfXRef, x2);
+                    x3 = ShiftGeoX(psTransform, dfXRef, x3);
+                }
+
+                oRing.setPoint(0, x0, y0);
+                oRing.setPoint(1, x2, y2);
+                oRing.setPoint(2, x3, y3);
+                oRing.setPoint(3, x1, y1);
+                oRing.setPoint(4, x0, y0);
+
+                if( oRing.isPointInRing( &oPoint ) ||
+                    oRing.isPointOnRingBoundary( &oPoint ) )
+                {
+                    const size_t nExtendedWidth = psTransform->nGeoLocXSize +
+                                ( psTransform->bOriginIsTopLeftCorner ? 0 : 1 );
+                    double dfX = static_cast<double>(nIdx % nExtendedWidth);
+                    double dfY = static_cast<double>(nIdx / nExtendedWidth);
+                    if( !psTransform->bOriginIsTopLeftCorner )
+                    {
+                        dfX -= 1.0;
+                        dfY -= 1.0;
+                    }
+                    GDALInverseBilinearInterpolation(dfGeoX, dfGeoY,
+                                                     x0, y0,
+                                                     x1, y1,
+                                                     x2, y2,
+                                                     x3, y3,
+                                                     dfX, dfY);
+
+                    dfX = (dfX + dfGeorefConventionOffset) *
+                        psTransform->dfPIXEL_STEP + psTransform->dfPIXEL_OFFSET;
+                    dfY = (dfY + dfGeorefConventionOffset) *
+                        psTransform->dfLINE_STEP + psTransform->dfLINE_OFFSET;
+
+                    bDone = true;
+                    panSuccess[i] = TRUE;
+                    padfX[i] = dfX;
+                    padfY[i] = dfY;
+                    break;
+                }
+            }
+        }
+        CPLFree(pahFeatures);
+
+        if( !bDone )
+        {
+            panSuccess[i] = FALSE;
+            padfX[i] = HUGE_VAL;
+            padfY[i] = HUGE_VAL;
+        }
+    }
+}

--- a/alg/gdalgeolocquadtree.h
+++ b/alg/gdalgeolocquadtree.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  Implements Geolocation array based transformer, using a quadtree
+ *           for inverse
+ * Author:   Even Rouault, <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Planet Labs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef GDALGEOLOCQUADTREE_H
+#define GDALGEOLOCQUADTREE_H
+
+#include "gdal_alg_priv.h"
+
+bool GDALGeoLocBuildQuadTree( GDALGeoLocTransformInfo *psTransform );
+
+void GDALGeoLocInverseTransformQuadtree(
+                    const GDALGeoLocTransformInfo *psTransform,
+                    int nPointCount,
+                    double *padfX,
+                    double *padfY,
+                    int *panSuccess );
+
+#endif

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -1656,9 +1656,13 @@ bool GDALComputeAreaOfInterest(OGRSpatialReference* poSRS,
  * (GDAL &gt;= 3.0) Area of interest, used to compute the best coordinate operation
  * between the source and target SRS. If not specified, the bounding box of the
  * source raster will be used.
- * <li> GEOLOC_BACKMAP_OVERSAMPLE_FACTOR=]0.1,2]. (GDAL &gt;= 3.5) Oversample factor
+ * <li> GEOLOC_BACKMAP_OVERSAMPLE_FACTOR=[0.1,2]. (GDAL &gt;= 3.5) Oversample factor
  * used to derive the size of the "backmap" used for geolocation array transformers.
  * Default value is 1.3.
+ * <li> GEOLOC_USE_TEMP_DATASETS=YES/NO. (GDAL &gt;= 3.5) Whether temporary
+ * GeoTIFF datasets should be used to store the backmap. The default is NO, that
+ * is to use in-memory arrays, unless the number of pixels of the geolocation
+ * array is greater than 16 megapixels.
  * </ul>
  *
  * The use case for the *_APPROX_ERROR_* options is when defining an approximate

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -1098,7 +1098,8 @@ GDALSuggestedWarpOutput2( GDALDatasetH hSrcDS,
 /*      Recompute some bounds so that all return values are consistent  */
 /* -------------------------------------------------------------------- */
     double dfMaxXOutNew = dfMinXOut + (*pnPixels) * dfPixelSizeX;
-    if( bIsGeographicCoords && dfMaxXOut <= 180 && dfMaxXOutNew > 180 )
+    if( bIsGeographicCoords &&
+        ((dfMaxXOut <= 180 && dfMaxXOutNew > 180) || dfMaxXOut == 180) )
     {
         dfMaxXOut = 180;
         dfPixelSizeX = (dfMaxXOut - dfMinXOut) / *pnPixels;
@@ -1655,6 +1656,9 @@ bool GDALComputeAreaOfInterest(OGRSpatialReference* poSRS,
  * (GDAL &gt;= 3.0) Area of interest, used to compute the best coordinate operation
  * between the source and target SRS. If not specified, the bounding box of the
  * source raster will be used.
+ * <li> GEOLOC_BACKMAP_OVERSAMPLE_FACTOR=]0.1,2]. (GDAL &gt;= 3.5) Oversample factor
+ * used to derive the size of the "backmap" used for geolocation array transformers.
+ * Default value is 1.3.
  * </ul>
  *
  * The use case for the *_APPROX_ERROR_* options is when defining an approximate
@@ -1895,7 +1899,7 @@ GDALCreateGenImgProjTransformer2( GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
              && (papszMD = GDALGetMetadata( hSrcDS, "GEOLOCATION" )) != nullptr )
     {
         psInfo->pSrcTransformArg =
-            GDALCreateGeoLocTransformer( hSrcDS, papszMD, FALSE );
+            GDALCreateGeoLocTransformerEx( hSrcDS, papszMD, FALSE, nullptr, papszOptions );
 
         if( psInfo->pSrcTransformArg == nullptr )
         {
@@ -2081,7 +2085,7 @@ GDALCreateGenImgProjTransformer2( GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
              && (papszMD = GDALGetMetadata( hDstDS, "GEOLOCATION" )) != nullptr )
     {
         psInfo->pDstTransformArg =
-            GDALCreateGeoLocTransformer( hDstDS, papszMD, FALSE );
+            GDALCreateGeoLocTransformerEx( hDstDS, papszMD, FALSE, nullptr, papszOptions );
 
         if( psInfo->pDstTransformArg == nullptr )
         {

--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -1950,6 +1950,12 @@ GDALWarpOptions * CPL_STDCALL GDALDeserializeWarpOptions( CPLXMLNode *psTree )
 
     if( pszValue != nullptr )
     {
+        CPLXMLNode* psGeoLocNode = CPLSearchXMLNode(psTree, "GeoLocTransformer");
+        if( psGeoLocNode )
+        {
+            CPLCreateXMLElementAndValue(psGeoLocNode, "SourceDataset", pszValue);
+        }
+
         CPLConfigOptionSetter oSetter("CPL_ALLOW_VSISTDIN", "NO", true);
 
         char** papszOpenOptions = GDALDeserializeOpenOptionsFromXML(psTree);

--- a/alg/makefile.vc
+++ b/alg/makefile.vc
@@ -23,6 +23,7 @@ OBJ =	gdaldither.obj gdalmediancut.obj gdal_crs.obj gdaltransformer.obj \
 	gdalsimplewarp.obj gdalwarper.obj gdalwarpkernel.obj \
 	thinplatespline.obj gdal_tps.obj gdalrasterize.obj llrasterize.obj \
 	gdalwarpoperation.obj gdalchecksum.obj gdal_rpc.obj gdalgeoloc.obj \
+	gdalgeolocquadtree.obj \
 	gdalgrid.obj gdalcutline.obj gdalproximity.obj rasterfill.obj \
 	gdalsievefilter.obj gdalrasterpolygonenumerator.obj polygonize.obj \
 	contour.obj viewshed.obj gdallinearsystem.obj \

--- a/alg/rasterfill.cpp
+++ b/alg/rasterfill.cpp
@@ -44,6 +44,7 @@
 #include "cpl_string.h"
 #include "cpl_vsi.h"
 #include "gdal.h"
+#include "gdal_priv.h"
 
 CPL_CVSID("$Id$")
 
@@ -513,6 +514,7 @@ GDALFillNodata( GDALRasterBandH hTargetBand,
             "Could not create Y index work file. Check driver capabilities.");
         return CE_Failure;
     }
+    GDALDataset::FromHandle(hYDS)->MarkSuppressOnClose();
 
     GDALRasterBandH hYBand = GDALGetRasterBand( hYDS, 1 );
 
@@ -533,6 +535,7 @@ GDALFillNodata( GDALRasterBandH hTargetBand,
             "Could not create XY value work file. Check driver capabilities.");
         return CE_Failure;
     }
+    GDALDataset::FromHandle(hValDS)->MarkSuppressOnClose();
 
     GDALRasterBandH hValBand = GDALGetRasterBand( hValDS, 1 );
 
@@ -552,6 +555,7 @@ GDALFillNodata( GDALRasterBandH hTargetBand,
             "Could not create mask work file. Check driver capabilities.");
         return CE_Failure;
     }
+    GDALDataset::FromHandle(hFiltMaskDS)->MarkSuppressOnClose();
 
     GDALRasterBandH hFiltMaskBand = GDALGetRasterBand( hFiltMaskDS, 1 );
 
@@ -899,10 +903,6 @@ end:
     GDALClose( hFiltMaskDS );
 
     CSLDestroy(papszWorkFileOptions);
-
-    GDALDeleteDataset( hDriver, osYTmpFile );
-    GDALDeleteDataset( hDriver, osValTmpFile );
-    GDALDeleteDataset( hDriver, osFiltMaskTmpFile );
 
     return eErr;
 }

--- a/autotest/gcore/data/sstgeo.vrt
+++ b/autotest/gcore/data/sstgeo.vrt
@@ -1,11 +1,13 @@
 <VRTDataset rasterXSize="60" rasterYSize="39">
   <Metadata domain="GEOLOCATION">
     <MDI key="SRS">GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9108"]],AXIS["Lat",NORTH],AXIS["Long",EAST],AUTHORITY["EPSG","4326"]]</MDI>
-    <MDI key="X_DATASET">data/sstgeo.tif</MDI>
+    <MDI key="X_DATASET">sstgeo.tif</MDI>
+    <MDI key="X_DATASET_RELATIVE_TO_SOURCE">true</MDI>
     <MDI key="X_BAND">1</MDI>
     <MDI key="PIXEL_OFFSET">0</MDI>
     <MDI key="PIXEL_STEP">1</MDI>
-    <MDI key="Y_DATASET">data/sstgeo.tif</MDI>
+    <MDI key="Y_DATASET">sstgeo.tif</MDI>
+    <MDI key="Y_DATASET_RELATIVE_TO_SOURCE">true</MDI>
     <MDI key="Y_BAND">2</MDI>
     <MDI key="LINE_OFFSET">0</MDI>
     <MDI key="LINE_STEP">1</MDI>

--- a/autotest/gcore/data/warpsst.vrt
+++ b/autotest/gcore/data/warpsst.vrt
@@ -19,11 +19,13 @@
                 <Reversed>0</Reversed>
                 <Metadata>
                   <MDI key="SRS">GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9108&quot;]],AXIS[&quot;Lat&quot;,NORTH],AXIS[&quot;Long&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</MDI>
-                  <MDI key="X_DATASET">data/sstgeo.tif</MDI>
+                  <MDI key="X_DATASET">sstgeo.tif</MDI>
+                  <MDI key="X_DATASET_RELATIVE_TO_SOURCE">true</MDI>
                   <MDI key="X_BAND">1</MDI>
                   <MDI key="PIXEL_OFFSET">0</MDI>
                   <MDI key="PIXEL_STEP">1</MDI>
-                  <MDI key="Y_DATASET">data/sstgeo.tif</MDI>
+                  <MDI key="Y_DATASET">sstgeo.tif</MDI>
+                  <MDI key="Y_DATASET_RELATIVE_TO_SOURCE">true</MDI>
                   <MDI key="Y_BAND">2</MDI>
                   <MDI key="LINE_OFFSET">0</MDI>
                   <MDI key="LINE_STEP">1</MDI>

--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -50,7 +50,8 @@ def test_geoloc_1():
 # Test that we take into account the min/max of the geoloc arrays
 
 
-def test_geoloc_bounds():
+@pytest.mark.parametrize("use_temp_datasets", ['YES', 'NO'])
+def test_geoloc_bounds(use_temp_datasets):
 
     lon_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/lon.tif', 360, 1, 1, gdal.GDT_Float32)
     lon_ds.WriteRaster(0, 0, 360, 1, array.array('f', [91 + 0.5 * x for x in range(178)] + [-179.9 + 0.5 * x for x in range(182)]))
@@ -72,8 +73,9 @@ def test_geoloc_bounds():
         'Y_BAND' : '1'
     }
     ds.SetMetadata(md, 'GEOLOCATION')
-    warped_ds = gdal.Warp('', ds, format='MEM')
-    assert warped_ds
+    with gdaltest.config_option('GDAL_GEOLOC_USE_TEMP_DATASETS', use_temp_datasets):
+        warped_ds = gdal.Warp('', ds, format='MEM')
+        assert warped_ds
 
     gdal.Unlink('/vsimem/lon.tif')
     gdal.Unlink('/vsimem/lat.tif')
@@ -86,7 +88,8 @@ def test_geoloc_bounds():
 # Test that the line filling logic works
 
 
-def test_geoloc_fill_line():
+@pytest.mark.parametrize("use_temp_datasets", ['YES', 'NO'])
+def test_geoloc_fill_line(use_temp_datasets):
 
 
     ds = gdal.GetDriverByName('MEM').Create('', 200, 372)
@@ -103,9 +106,10 @@ def test_geoloc_fill_line():
     }
     ds.SetMetadata(md, 'GEOLOCATION')
     ds.GetRasterBand(1).Fill(1)
-    warped_ds = gdal.Warp('', ds, format='MEM')
-    assert warped_ds
-    assert warped_ds.GetRasterBand(1).Checksum() == 22338
+    with gdaltest.config_option('GDAL_GEOLOC_USE_TEMP_DATASETS', use_temp_datasets):
+        warped_ds = gdal.Warp('', ds, format='MEM')
+        assert warped_ds
+        assert warped_ds.GetRasterBand(1).Checksum() == 22338
 
 
 

--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import array
+import random
 from osgeo import gdal, osr
 
 import gdaltest
@@ -41,7 +42,7 @@ import pytest
 
 def test_geoloc_1():
 
-    tst = gdaltest.GDALTest('VRT', 'warpsst.vrt', 1, 61957)
+    tst = gdaltest.GDALTest('VRT', 'warpsst.vrt', 1, 63034)
     return tst.testOpen(check_filelist=False)
 
 
@@ -68,8 +69,7 @@ def test_geoloc_bounds():
         'X_DATASET': '/vsimem/lon.tif',
         'X_BAND' : '1',
         'Y_DATASET': '/vsimem/lat.tif',
-        'Y_BAND' : '1',
-        'SRS': 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]'
+        'Y_BAND' : '1'
     }
     ds.SetMetadata(md, 'GEOLOCATION')
     warped_ds = gdal.Warp('', ds, format='MEM')
@@ -105,7 +105,7 @@ def test_geoloc_fill_line():
     ds.GetRasterBand(1).Fill(1)
     warped_ds = gdal.Warp('', ds, format='MEM')
     assert warped_ds
-    assert warped_ds.GetRasterBand(1).Checksum() == 25798
+    assert warped_ds.GetRasterBand(1).Checksum() == 22338
 
 
 
@@ -133,7 +133,8 @@ def test_geoloc_warp_to_geoloc():
         'X_BAND' : '1',
         'Y_DATASET': '/vsimem/lat.tif',
         'Y_BAND' : '1',
-        'SRS': 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]'
+        'SRS': 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]',
+        'GEOREFERENCING_CONVENTION': 'PIXEL_CENTER'
     }
     ds.SetMetadata(md, 'GEOLOCATION')
 
@@ -206,6 +207,118 @@ def test_geoloc_error_cases():
     with gdaltest.error_handler():
         transformer = gdal.Transformer(None, ds, [])
     assert transformer is None
+
+
+###############################################################################
+# Test geolocation array where the transformation is just an affine transformation
+
+
+@pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.parametrize("convention", ['TOP_LEFT_CORNER', 'PIXEL_CENTER'])
+@pytest.mark.parametrize("inverse_method", ['BACKMAP', 'QUADTREE'])
+def test_geoloc_affine_transformation(step, convention, inverse_method):
+
+    shift = 0.5 if convention == 'PIXEL_CENTER' else 0
+    lon_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/lon.tif', 20 // step, 1, 1, gdal.GDT_Float32)
+    vals = array.array('f', [-80 + step * (x + shift) for x in range(20 // step)])
+    lon_ds.WriteRaster(0, 0, 20 // step, 1, vals)
+    lon_ds = None
+    lat_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/lat.tif', 20 // step, 1, 1, gdal.GDT_Float32)
+    vals = array.array('f', [50 - step * (x + shift) for x in range(20 // step)])
+    lat_ds.WriteRaster(0, 0, 20 // step, 1, vals)
+    lat_ds = None
+    ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
+    md = {
+        'LINE_OFFSET': '0',
+        'LINE_STEP': str(step),
+        'PIXEL_OFFSET': '0',
+        'PIXEL_STEP': str(step),
+        'X_DATASET': '/vsimem/lon.tif',
+        'X_BAND' : '1',
+        'Y_DATASET': '/vsimem/lat.tif',
+        'Y_BAND' : '1',
+        'SRS': 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]',
+        'GEOREFERENCING_CONVENTION' : convention
+    }
+    ds.SetMetadata(md, 'GEOLOCATION')
+
+    with gdaltest.config_option('GDAL_GEOLOC_INVERSE_METHOD', inverse_method):
+        tr = gdal.Transformer(ds, None, [])
+
+        def check_point(x,y,X,Y):
+            success, pnt = tr.TransformPoint(False, x, y)
+            assert success
+            assert pnt == (X, Y, 0)
+
+            success, pnt = tr.TransformPoint(True, pnt[0], pnt[1])
+            assert success
+            assert pnt == pytest.approx((x, y, 0))
+
+        check_point(10, 10, -70.0, 40.0)
+        check_point(1.23, 2.34, -78.77, 47.66)
+        check_point(0,   0, -80.0, 50.0)
+        check_point(20,  0, -60.0, 50.0)
+        check_point(0,  20, -80.0, 30.0)
+        check_point(20, 20, -60.0, 30.0)
+
+    ds = None
+
+    gdal.Unlink('/vsimem/lon.tif')
+    gdal.Unlink('/vsimem/lat.tif')
+
+
+###############################################################################
+# Test geolocation array where the transformation is just an affine transformation
+
+
+@pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.parametrize("convention", ['TOP_LEFT_CORNER', 'PIXEL_CENTER'])
+def test_geoloc_affine_transformation_with_noise(step, convention):
+
+    r = random.Random(0)
+
+    shift = 0.5 if convention == 'PIXEL_CENTER' else 0
+    lon_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/lon.tif', 20 // step, 20 // step, 1, gdal.GDT_Float32)
+    for y in range(lon_ds.RasterYSize):
+        vals = array.array('f', [-80 + step * (x + shift) + r.uniform(-0.25,0.25) for x in range(lon_ds.RasterXSize)])
+        lon_ds.WriteRaster(0, y, lon_ds.RasterXSize, 1, vals)
+    lon_ds = None
+    lat_ds = gdal.GetDriverByName('GTiff').Create('/vsimem/lat.tif', 20 // step, 20 // step, 1, gdal.GDT_Float32)
+    for x in range(lat_ds.RasterXSize):
+        vals = array.array('f', [50 - step * (y + shift) + r.uniform(-0.25,0.25) for y in range(lat_ds.RasterYSize)])
+        lat_ds.WriteRaster(x, 0, 1, lat_ds.RasterYSize, vals)
+    lat_ds = None
+    ds = gdal.GetDriverByName('MEM').Create('', 20, 20)
+    md = {
+        'LINE_OFFSET': '0',
+        'LINE_STEP': str(step),
+        'PIXEL_OFFSET': '0',
+        'PIXEL_STEP': str(step),
+        'X_DATASET': '/vsimem/lon.tif',
+        'X_BAND' : '1',
+        'Y_DATASET': '/vsimem/lat.tif',
+        'Y_BAND' : '1',
+        'SRS': 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]',
+        'GEOREFERENCING_CONVENTION' : convention
+    }
+    ds.SetMetadata(md, 'GEOLOCATION')
+    tr = gdal.Transformer(ds, None, [])
+
+    def check_point(x,y):
+        success, pnt = tr.TransformPoint(False, x, y)
+        assert success
+        success, pnt = tr.TransformPoint(True, pnt[0], pnt[1])
+        assert success
+        assert pnt == pytest.approx((x, y, 0))
+
+    check_point(10, 10)
+    check_point(1.23, 2.34)
+    check_point(0, 0)
+    check_point(20, 0)
+    check_point(0, 20)
+    check_point(20, 20)
+
+    ds = None
 
     gdal.Unlink('/vsimem/lon.tif')
     gdal.Unlink('/vsimem/lat.tif')

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -105,12 +105,12 @@ def test_transformer_4():
 
     (success, pnt) = tr.TransformPoint(0, 20, 10)
 
-    assert success and abs(pnt[0] + 81.961341857910156) <= 0.000001 and pnt[1] == pytest.approx(29.612689971923828, abs=0.000001) and pnt[2] == 0, \
+    assert success and pnt[0] == pytest.approx(-81.961341857910156, abs=0.000001) and pnt[1] == pytest.approx(29.612689971923828, abs=0.000001) and pnt[2] == 0, \
         'got wrong forward transform result.'
 
     (success, pnt) = tr.TransformPoint(1, pnt[0], pnt[1], pnt[2])
 
-    assert success and pnt[0] == pytest.approx(20.436627518907024, abs=0.001) and pnt[1] == pytest.approx(10.484599774610549, abs=0.001) and pnt[2] == 0, \
+    assert success and pnt[0] == pytest.approx(20, abs=0.000001) and pnt[1] == pytest.approx(10, abs=0.000001) and pnt[2] == 0, \
         'got wrong reverse transform result.'
 
 ###############################################################################

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -342,7 +342,7 @@ def test_vrtwarp_9():
     vrtwarp_ds = gdal.Warp('tmp/vrtwarp_9.vrt', 'tmp/sstgeo.vrt', options='-overwrite -of VRT -geoloc')
     assert vrtwarp_ds.GetRasterBand(1).GetOverviewCount() == 1
     assert vrtwarp_ds.GetRasterBand(1).Checksum() == expected_cs_main
-    assert vrtwarp_ds.GetRasterBand(1).GetOverview(0).Checksum() == 63696, \
+    assert vrtwarp_ds.GetRasterBand(1).GetOverview(0).Checksum() == 62489, \
         (vrtwarp_ds.GetRasterBand(1).GetOverview(0).XSize, vrtwarp_ds.GetRasterBand(1).GetOverview(0).YSize)
     vrtwarp_ds = None
 

--- a/doc/source/development/rfc/rfc4_geolocate.rst
+++ b/doc/source/development/rfc/rfc4_geolocate.rst
@@ -47,6 +47,10 @@ relationship back to the original pixels and lines.
    pixels.
 -  LINE_STEP: each geolocation pixel represents this many geolocated
    lines.
+-  GEOREFERENCING_CONVENTION: (added in GDAL 3.5) either TOP_LEFT_CORNER
+   to indicate that the X/Y values refer to the top-left corner of the pixel,
+   or PIXEL_CENTER to indicate that they refer to the center of the pixel.
+   The default is TOP_LEFT_CORNER.
 
 In the common case where two of the bands of a dataset are actually
 latitude and longitude, and so the geolocation arrays are the same size
@@ -114,7 +118,7 @@ is the list of metadata from the GEOLOCATION metadata domain.
 
 ::
 
-    void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS, 
+    void *GDALCreateGeoLocTransformer( GDALDatasetH hBaseDS,
                                        char **papszGeolocationInfo,
                                        int bReversed );
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -4774,6 +4774,8 @@ int netCDFDataset::ProcessCFGeolocation( int nGroupId, int nVarId )
 
                     GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0", "GEOLOCATION");
                     GDALPamDataset::SetMetadataItem("LINE_STEP", "1", "GEOLOCATION");
+
+                    GDALPamDataset::SetMetadataItem("GEOREFERENCING_CONVENTION", "PIXEL_CENTER", "GEOLOCATION");
                 }
                 else
                 {

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -153,6 +153,7 @@ target_public_header(
   gdal_priv.h
   gdal_proxy.h
   gdal_rat.h
+  gdalcachedpixelaccessor.h
   rawdataset.h
   gdalgeorefpamdataset.h
   gdal_mdreader.h)

--- a/gcore/GNUmakefile
+++ b/gcore/GNUmakefile
@@ -81,6 +81,7 @@ INST_H_FILES = \
 	gdal_priv.h \
 	gdal_proxy.h \
 	gdal_rat.h \
+	gdalcachedpixelaccessor.h \
 	rawdataset.h
 
 install:

--- a/gcore/gdalcachedpixelaccessor.h
+++ b/gcore/gdalcachedpixelaccessor.h
@@ -1,0 +1,384 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  Fast access to individual pixels in a GDALRasterBand
+ * Author:   Even Rouault <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Planet Labs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef GDAL_CACHED_PIXEL_ACCESSOR_INCLUDED
+#define GDAL_CACHED_PIXEL_ACCESSOR_INCLUDED
+
+#include "gdal_priv.h"
+#include "cpl_error.h"
+
+#include <algorithm>
+#include <array>
+#include <vector>
+
+/************************************************************************/
+/*                      GDALCachedPixelAccessor                         */
+/************************************************************************/
+
+/** Class to have reasonably fast random pixel access to a raster band, when
+ * accessing multiple pixels that are close to each other.
+ *
+ * This gives faster access than using GDALRasterBand::RasterIO() with
+ * a 1x1 window.
+ *
+ * @since GDAL 3.5
+ */
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT = 4> class GDALCachedPixelAccessor
+{
+    GDALRasterBand*         m_poBand = nullptr;
+
+    struct CachedTile
+    {
+        std::vector<Type>   m_data{};
+        int                 m_nTileX = -1;
+        int                 m_nTileY = -1;
+        bool                m_bModified = false;
+    };
+
+    int                     m_nCachedTileCount = 0;
+    std::array<CachedTile, CACHED_TILE_COUNT> m_aCachedTiles{};
+
+    bool                    LoadTile(int nTileX, int nTileY);
+    bool                    FlushTile(int iSlot);
+
+    Type                    GetSlowPath(int nTileX, int nTileY,
+                                        int nXInTile, int nYInTile,
+                                        bool* pbSuccess);
+    bool                    SetSlowPath(int nTileX, int nTileY,
+                                        int nXInTile, int nYInTile,
+                                        Type val);
+
+                            GDALCachedPixelAccessor(const GDALCachedPixelAccessor&) = delete;
+    GDALCachedPixelAccessor&      operator= (const GDALCachedPixelAccessor&) = delete;
+
+public:
+    explicit                GDALCachedPixelAccessor(GDALRasterBand* poBand);
+                           ~GDALCachedPixelAccessor();
+
+    /** Assign the raster band if not known at construction time. */
+    void                    SetBand(GDALRasterBand* poBand) { m_poBand = poBand; }
+
+    Type                    Get(int nX, int nY, bool* pbSuccess = nullptr);
+    bool                    Set(int nX, int nY, Type val);
+
+    bool                    FlushCache();
+    void                    ResetModifiedFlag();
+};
+
+
+/************************************************************************/
+/*                      GDALCachedPixelAccessor()                       */
+/************************************************************************/
+
+/** Constructor.
+ *
+ * The template accepts the following parameters:
+ * - Type: should be one of GByte, GUInt16, GInt16, GUInt32, GInt32, GUInt64, GInt64, float or double
+ * - TILE_SIZE: the tile size for the cache of GDALCachedPixelAccessor.
+ *              Use a power of two for faster computation.
+ *              It doesn't need to be the same of the underlying raster
+ * - CACHED_TILE_COUNT: number of tiles to cache. Should be >= 1. Defaults to 4.
+ *
+ * @param poBand Raster band.
+ */
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::GDALCachedPixelAccessor(GDALRasterBand* poBand): m_poBand(poBand)
+{
+}
+
+/************************************************************************/
+/*                     ~GDALCachedPixelAccessor()                       */
+/************************************************************************/
+
+/** Destructor.
+ *
+ * Will call FlushCache()
+ */
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::~GDALCachedPixelAccessor()
+{
+    FlushCache();
+}
+
+/************************************************************************/
+/*                            Get()                                     */
+/************************************************************************/
+
+/** Get the value of a pixel.
+ *
+ * No bound checking of nX, nY is done.
+ *
+ * @param nX X coordinate (between 0 and GetXSize()-1)
+ * @param nY Y coordinate (between 0 and GetYSize()-1)
+ * @param[out] pbSuccess Optional pointer to a success flag
+ * @return the pixel value
+ */
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+inline
+Type GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::Get(int nX, int nY, bool* pbSuccess)
+{
+    const int nTileX = nX / TILE_SIZE;
+    const int nTileY = nY / TILE_SIZE;
+    const int nXInTile = nX % TILE_SIZE;
+    const int nYInTile = nY % TILE_SIZE;
+    if( m_aCachedTiles[0].m_nTileX == nTileX &&
+        m_aCachedTiles[0].m_nTileY == nTileY )
+    {
+        if( pbSuccess )
+            *pbSuccess = true;
+        return m_aCachedTiles[0].m_data[nYInTile * TILE_SIZE + nXInTile];
+    }
+    return GetSlowPath(nTileX, nTileY, nXInTile, nYInTile, pbSuccess);
+}
+
+/************************************************************************/
+/*                       GetSlowPath()                                  */
+/************************************************************************/
+
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+Type GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::GetSlowPath(
+        int nTileX, int nTileY, int nXInTile, int nYInTile, bool* pbSuccess)
+{
+    for( int i = 1; i < m_nCachedTileCount; ++i )
+    {
+        const auto& cachedTile = m_aCachedTiles[i];
+        if( cachedTile.m_nTileX == nTileX &&
+            cachedTile.m_nTileY == nTileY )
+        {
+            const auto ret = cachedTile.m_data[nYInTile * TILE_SIZE + nXInTile];
+            std::swap(m_aCachedTiles[0], m_aCachedTiles[i]);
+            if( pbSuccess )
+                *pbSuccess = true;
+            return ret;
+        }
+    }
+    if( !LoadTile(nTileX, nTileY) )
+    {
+        if( pbSuccess )
+            *pbSuccess = false;
+        return 0;
+    }
+    if( pbSuccess )
+        *pbSuccess = true;
+    return m_aCachedTiles[0].m_data[nYInTile * TILE_SIZE + nXInTile];
+}
+
+/************************************************************************/
+/*                            Set()                                     */
+/************************************************************************/
+
+/** Set the value of a pixel.
+ *
+ * The actual modification of the underlying raster is defered until the tile
+ * is implicit flushed while loading a new tile, or an explicit call to
+ * FlushCache().
+ *
+ * The destructor of GDALCachedPixelAccessor will take care of calling
+ * FlushCache(), if the user hasn't done it explicitly.
+ *
+ * No bound checking of nX, nY is done.
+ *
+ * @param nX X coordinate (between 0 and GetXSize()-1)
+ * @param nY Y coordinate (between 0 and GetYSize()-1)
+ * @param val pixel value
+ * @return true if success
+ */
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+inline
+bool GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::Set(int nX, int nY, Type val)
+{
+    const int nTileX = nX / TILE_SIZE;
+    const int nTileY = nY / TILE_SIZE;
+    const int nXInTile = nX % TILE_SIZE;
+    const int nYInTile = nY % TILE_SIZE;
+    if( m_aCachedTiles[0].m_nTileX == nTileX &&
+        m_aCachedTiles[0].m_nTileY == nTileY )
+    {
+        m_aCachedTiles[0].m_data[nYInTile * TILE_SIZE + nXInTile] = val;
+        m_aCachedTiles[0].m_bModified = true;
+        return true;
+    }
+    return SetSlowPath(nTileX, nTileY, nXInTile, nYInTile, val);
+}
+
+/************************************************************************/
+/*                         SetSlowPath()                                */
+/************************************************************************/
+
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+bool GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::SetSlowPath(
+    int nTileX, int nTileY, int nXInTile, int nYInTile, Type val)
+{
+    for( int i = 1; i < m_nCachedTileCount; ++i )
+    {
+        auto& cachedTile = m_aCachedTiles[i];
+        if( cachedTile.m_nTileX == nTileX &&
+            cachedTile.m_nTileY == nTileY )
+        {
+            cachedTile.m_data[nYInTile * TILE_SIZE + nXInTile] = val;
+            cachedTile.m_bModified = true;
+            if( i > 0 )
+                std::swap(m_aCachedTiles[0], m_aCachedTiles[i]);
+            return true;
+        }
+    }
+    if( !LoadTile(nTileX, nTileY) )
+    {
+        return false;
+    }
+    m_aCachedTiles[0].m_data[nYInTile * TILE_SIZE + nXInTile] = val;
+    m_aCachedTiles[0].m_bModified = true;
+    return true;
+}
+
+/************************************************************************/
+/*                            FlushCache()                              */
+/************************************************************************/
+
+/** Flush content of modified tiles and drop caches
+ *
+ * @return true if success
+ */
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+bool GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::FlushCache()
+{
+    bool bRet = true;
+    for( int i = 0; i < m_nCachedTileCount; ++i )
+    {
+        if( !FlushTile(i) )
+            bRet = false;
+        m_aCachedTiles[i].m_nTileX = -1;
+        m_aCachedTiles[i].m_nTileY = -1;
+    }
+    return bRet;
+}
+
+/************************************************************************/
+/*                      ResetModifiedFlag()                             */
+/************************************************************************/
+
+/** Reset the modified flag for cached tiles.
+ */
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+void GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::ResetModifiedFlag()
+{
+    for( int i = 0; i < m_nCachedTileCount; ++i )
+    {
+        m_aCachedTiles[i].m_bModified = false;
+    }
+}
+
+/************************************************************************/
+/*                 GDALCachedPixelAccessorGetDataType                   */
+/************************************************************************/
+
+/*! @cond Doxygen_Suppress */
+template<class T> struct GDALCachedPixelAccessorGetDataType {};
+
+template<> struct GDALCachedPixelAccessorGetDataType<GByte>   { static constexpr GDALDataType DataType = GDT_Byte; };
+template<> struct GDALCachedPixelAccessorGetDataType<GUInt16> { static constexpr GDALDataType DataType = GDT_UInt16; };
+template<> struct GDALCachedPixelAccessorGetDataType<GInt16>  { static constexpr GDALDataType DataType = GDT_Int16; };
+template<> struct GDALCachedPixelAccessorGetDataType<GUInt32> { static constexpr GDALDataType DataType = GDT_UInt32; };
+template<> struct GDALCachedPixelAccessorGetDataType<GInt32>  { static constexpr GDALDataType DataType = GDT_Int32; };
+#if SIZEOF_UNSIGNED_LONG == 8
+// std::uint64_t on Linux 64-bit resolves as unsigned long
+template<> struct GDALCachedPixelAccessorGetDataType<unsigned long> { static constexpr GDALDataType DataType = GDT_UInt64; };
+template<> struct GDALCachedPixelAccessorGetDataType<long >         { static constexpr GDALDataType DataType = GDT_Int64; };
+#endif
+template<> struct GDALCachedPixelAccessorGetDataType<GUInt64> { static constexpr GDALDataType DataType = GDT_UInt64; };
+template<> struct GDALCachedPixelAccessorGetDataType<GInt64>  { static constexpr GDALDataType DataType = GDT_Int64; };
+template<> struct GDALCachedPixelAccessorGetDataType<float>   { static constexpr GDALDataType DataType = GDT_Float32; };
+template<> struct GDALCachedPixelAccessorGetDataType<double>  { static constexpr GDALDataType DataType = GDT_Float64; };
+/*! @endcond */
+
+/************************************************************************/
+/*                          LoadTile()                                  */
+/************************************************************************/
+
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+bool GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::LoadTile(int nTileX, int nTileY)
+{
+    if( m_nCachedTileCount == CACHED_TILE_COUNT )
+    {
+        if( !FlushTile(CACHED_TILE_COUNT - 1) )
+            return false;
+        std::swap(m_aCachedTiles[0], m_aCachedTiles[CACHED_TILE_COUNT - 1]);
+    }
+    else
+    {
+        if( m_nCachedTileCount > 0 )
+            std::swap(m_aCachedTiles[0], m_aCachedTiles[m_nCachedTileCount]);
+        m_aCachedTiles[0].m_data.resize(TILE_SIZE * TILE_SIZE);
+        m_nCachedTileCount ++;
+    }
+
+    CPLAssert(!m_aCachedTiles[0].m_bModified);
+    const int nXOff = nTileX * TILE_SIZE;
+    const int nYOff = nTileY * TILE_SIZE;
+    const int nReqXSize = std::min(m_poBand->GetXSize() - nXOff, TILE_SIZE);
+    const int nReqYSize = std::min(m_poBand->GetYSize() - nYOff, TILE_SIZE);
+    if( m_poBand->RasterIO(GF_Read, nXOff, nYOff, nReqXSize, nReqYSize,
+                       m_aCachedTiles[0].m_data.data(),
+                       nReqXSize, nReqYSize,
+                       GDALCachedPixelAccessorGetDataType<Type>::DataType,
+                       sizeof(Type), TILE_SIZE * sizeof(Type),
+                       nullptr) != CE_None )
+    {
+        m_aCachedTiles[0].m_nTileX = -1;
+        m_aCachedTiles[0].m_nTileY = -1;
+        return false;
+    }
+    m_aCachedTiles[0].m_nTileX = nTileX;
+    m_aCachedTiles[0].m_nTileY = nTileY;
+    return true;
+}
+
+/************************************************************************/
+/*                          FlushTile()                                 */
+/************************************************************************/
+
+template<class Type, int TILE_SIZE, int CACHED_TILE_COUNT>
+bool GDALCachedPixelAccessor<Type, TILE_SIZE, CACHED_TILE_COUNT>::FlushTile(int iSlot)
+{
+    if( !m_aCachedTiles[iSlot].m_bModified )
+        return true;
+
+    m_aCachedTiles[iSlot].m_bModified = false;
+    const int nXOff = m_aCachedTiles[iSlot].m_nTileX * TILE_SIZE;
+    const int nYOff = m_aCachedTiles[iSlot].m_nTileY * TILE_SIZE;
+    const int nReqXSize = std::min(m_poBand->GetXSize() - nXOff, TILE_SIZE);
+    const int nReqYSize = std::min(m_poBand->GetYSize() - nYOff, TILE_SIZE);
+    return m_poBand->RasterIO(GF_Write, nXOff, nYOff, nReqXSize, nReqYSize,
+                       m_aCachedTiles[iSlot].m_data.data(),
+                       nReqXSize, nReqYSize,
+                       GDALCachedPixelAccessorGetDataType<Type>::DataType,
+                       sizeof(Type), TILE_SIZE * sizeof(Type),
+                       nullptr) == CE_None;
+}
+
+#endif // GDAL_PIXEL_ACCESSOR_INCLUDED

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -6275,6 +6275,7 @@ public:
         aosGeoLoc.SetNameValue("X_DATASET", m_osFilenameLong.c_str());
         aosGeoLoc.SetNameValue("Y_BAND", "1");
         aosGeoLoc.SetNameValue("Y_DATASET", m_osFilenameLat.c_str());
+        aosGeoLoc.SetNameValue("GEOREFERENCING_CONVENTION", "PIXEL_CENTER");
         SetMetadata(aosGeoLoc.List(), "GEOLOCATION");
     }
 

--- a/port/cpl_quad_tree.cpp
+++ b/port/cpl_quad_tree.cpp
@@ -33,6 +33,7 @@
 #include "cpl_port.h"
 #include "cpl_quad_tree.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 
@@ -65,10 +66,13 @@ struct _CPLQuadTree
 {
   QuadTreeNode             *psRoot;
   CPLQuadTreeGetBoundsFunc  pfnGetBounds;
+  CPLQuadTreeGetBoundsExFunc pfnGetBoundsEx;
+  void                     *pUserData;
   int                       nFeatures;
   int                       nMaxDepth;
   int                       nBucketCapacity;
   double                    dfSplitRatio;
+  bool                      bForceUseOfSubNodes;
 };
 
 static void CPLQuadTreeAddFeatureInternal(CPLQuadTree *hQuadTree,
@@ -160,15 +164,69 @@ CPLQuadTree *CPLQuadTreeCreate( const CPLRectObj* pGlobalBounds,
 
     hQuadTree->nFeatures = 0;
     hQuadTree->pfnGetBounds = pfnGetBounds;
+    hQuadTree->pfnGetBoundsEx = nullptr;
     hQuadTree->nMaxDepth = 0;
     hQuadTree->nBucketCapacity = 8;
 
     hQuadTree->dfSplitRatio = DEFAULT_SPLIT_RATIO;
+    hQuadTree->bForceUseOfSubNodes = false;
 
     /* -------------------------------------------------------------------- */
     /*      Allocate the psRoot psNode.                                     */
     /* -------------------------------------------------------------------- */
     hQuadTree->psRoot = CPLQuadTreeNodeCreate(pGlobalBounds);
+
+    hQuadTree->pUserData = nullptr;
+
+    return hQuadTree;
+}
+
+/************************************************************************/
+/*                         CPLQuadTreeCreateEx()                        */
+/************************************************************************/
+
+/**
+ * Create a new quadtree
+ *
+ * @param pGlobalBounds a pointer to the global extent of all
+ *                      the elements that will be inserted
+ * @param pfnGetBoundsEx  a user provided function to get the bounding box of
+ *                      the inserted elements. If it is set to NULL, then
+ *                      CPLQuadTreeInsertWithBounds() must be used, and
+ *                      extra memory will be used to keep features bounds in the
+ *                      quad tree.
+ * @param pUserData     user data passed to pfnGetBoundsEx
+ *
+ * @return a newly allocated quadtree
+ */
+
+CPLQuadTree *CPLQuadTreeCreateEx( const CPLRectObj* pGlobalBounds,
+                                  CPLQuadTreeGetBoundsExFunc pfnGetBoundsEx,
+                                  void* pUserData )
+{
+    CPLAssert(pGlobalBounds);
+
+    /* -------------------------------------------------------------------- */
+    /*      Allocate the hQuadTree object                                   */
+    /* -------------------------------------------------------------------- */
+    CPLQuadTree *hQuadTree
+        = static_cast<CPLQuadTree *>( CPLMalloc(sizeof(CPLQuadTree)) );
+
+    hQuadTree->nFeatures = 0;
+    hQuadTree->pfnGetBounds = nullptr;
+    hQuadTree->pfnGetBoundsEx = pfnGetBoundsEx;
+    hQuadTree->nMaxDepth = 0;
+    hQuadTree->nBucketCapacity = 8;
+
+    hQuadTree->dfSplitRatio = DEFAULT_SPLIT_RATIO;
+    hQuadTree->bForceUseOfSubNodes = false;
+
+    /* -------------------------------------------------------------------- */
+    /*      Allocate the psRoot psNode.                                     */
+    /* -------------------------------------------------------------------- */
+    hQuadTree->psRoot = CPLQuadTreeNodeCreate(pGlobalBounds);
+
+    hQuadTree->pUserData = pUserData;
 
     return hQuadTree;
 }
@@ -258,6 +316,23 @@ void CPLQuadTreeSetBucketCapacity(CPLQuadTree *hQuadTree, int nBucketCapacity)
         hQuadTree->nBucketCapacity = nBucketCapacity;
 }
 
+/***********************************************************************/
+/*                   CPLQuadTreeForceUseOfSubNodes()                   */
+/************************************************************************/
+
+/**
+ * Force the quadtree to insert as much as possible a feature whose bbox
+ * spread over multiple subnodes into those subnodes, rather than in the
+ * list of features attached to the node.
+ *
+ * @param hQuadTree the quad tree
+ */
+
+void CPLQuadTreeForceUseOfSubNodes(CPLQuadTree *hQuadTree)
+{
+    hQuadTree->bForceUseOfSubNodes = true;
+}
+
 /************************************************************************/
 /*                        CPLQuadTreeInsert()                           */
 /************************************************************************/
@@ -271,7 +346,7 @@ void CPLQuadTreeSetBucketCapacity(CPLQuadTree *hQuadTree, int nBucketCapacity)
 
 void CPLQuadTreeInsert(CPLQuadTree * hQuadTree, void* hFeature)
 {
-    if( hQuadTree->pfnGetBounds == nullptr )
+    if( hQuadTree->pfnGetBounds == nullptr && hQuadTree->pfnGetBoundsEx == nullptr)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "hQuadTree->pfnGetBounds == NULL");
@@ -279,7 +354,10 @@ void CPLQuadTreeInsert(CPLQuadTree * hQuadTree, void* hFeature)
     }
     hQuadTree->nFeatures++;
     CPLRectObj bounds;
-    hQuadTree->pfnGetBounds(hFeature, &bounds);
+    if( hQuadTree->pfnGetBoundsEx )
+        hQuadTree->pfnGetBoundsEx(hFeature, hQuadTree->pUserData, &bounds);
+    else
+        hQuadTree->pfnGetBounds(hFeature, &bounds);
     CPLQuadTreeAddFeatureInternal(hQuadTree, hFeature, &bounds);
 }
 
@@ -383,7 +461,8 @@ static bool CPLQuadTreeRemoveInternal(QuadTreeNode* psNode,
 void CPLQuadTreeRemove(CPLQuadTree *hQuadTree, void* hFeature,
                        const CPLRectObj* psBounds)
 {
-    if( psBounds == nullptr && hQuadTree->pfnGetBounds == nullptr )
+    if( psBounds == nullptr && hQuadTree->pfnGetBounds == nullptr &&
+        hQuadTree->pfnGetBoundsEx == nullptr )
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "hQuadTree->pfnGetBounds == NULL");
@@ -392,7 +471,10 @@ void CPLQuadTreeRemove(CPLQuadTree *hQuadTree, void* hFeature,
     CPLRectObj bounds; // keep variable in this outer scope
     if( psBounds == nullptr )
     {
-        hQuadTree->pfnGetBounds(hFeature, &bounds);
+        if( hQuadTree->pfnGetBoundsEx )
+            hQuadTree->pfnGetBoundsEx(hFeature, hQuadTree->pUserData, &bounds);
+        else
+            hQuadTree->pfnGetBounds(hFeature, &bounds);
         psBounds = &bounds;
     }
     if( CPLQuadTreeRemoveInternal(hQuadTree->psRoot, hFeature, psBounds) )
@@ -511,7 +593,8 @@ static void CPLQuadTreeNodeAddFeatureAlg1( CPLQuadTree* hQuadTree,
                 memcmp(&psNode->rect, &quad2, sizeof(CPLRectObj)) != 0 &&
                 memcmp(&psNode->rect, &quad3, sizeof(CPLRectObj)) != 0 &&
                 memcmp(&psNode->rect, &quad4, sizeof(CPLRectObj)) != 0 &&
-                (CPL_RectContained(pRect, &quad1) ||
+                (hQuadTree->bForceUseOfSubNodes ||
+                CPL_RectContained(pRect, &quad1) ||
                 CPL_RectContained(pRect, &quad2) ||
                 CPL_RectContained(pRect, &quad3) ||
                 CPL_RectContained(pRect, &quad4)) )
@@ -532,14 +615,18 @@ static void CPLQuadTreeNodeAddFeatureAlg1( CPLQuadTree* hQuadTree,
                 // Redispatch existing pahFeatures in apSubNodes.
                 for( int i = 0; i < oldNumFeatures; i++ )
                 {
-                    if( hQuadTree->pfnGetBounds == nullptr )
+                    if( hQuadTree->pfnGetBounds == nullptr &&
+                        hQuadTree->pfnGetBoundsEx == nullptr )
                         CPLQuadTreeNodeAddFeatureAlg1( hQuadTree, psNode,
                                                        oldFeatures[i],
                                                        &pasOldBounds[i]);
                     else
                     {
                         CPLRectObj bounds;
-                        hQuadTree->pfnGetBounds(oldFeatures[i], &bounds);
+                        if( hQuadTree->pfnGetBoundsEx )
+                            hQuadTree->pfnGetBoundsEx(oldFeatures[i], hQuadTree->pUserData, &bounds);
+                        else
+                            hQuadTree->pfnGetBounds(oldFeatures[i], &bounds);
                         CPLQuadTreeNodeAddFeatureAlg1( hQuadTree, psNode,
                                                        oldFeatures[i],
                                                        &bounds );
@@ -564,10 +651,38 @@ static void CPLQuadTreeNodeAddFeatureAlg1( CPLQuadTree* hQuadTree,
     /* -------------------------------------------------------------------- */
         for( int i = 0; i < psNode->nNumSubNodes; i++ )
         {
-            if( CPL_RectContained(pRect, &psNode->apSubNode[i]->rect))
+            if( CPL_RectContained(pRect, &psNode->apSubNode[i]->rect) )
             {
                 CPLQuadTreeNodeAddFeatureAlg1( hQuadTree, psNode->apSubNode[i],
                                                hFeature, pRect );
+                return;
+            }
+        }
+        if( hQuadTree->bForceUseOfSubNodes )
+        {
+            bool overlaps[4];
+            bool overlapAlls = true;
+            for( int i = 0; i < psNode->nNumSubNodes; i++ )
+            {
+                overlaps[i] = CPL_RectOverlap(pRect, &psNode->apSubNode[i]->rect);
+                if( !overlaps[i] )
+                    overlapAlls = false;
+            }
+            if( !overlapAlls )
+            {
+                for( int i = 0; i < psNode->nNumSubNodes; i++ )
+                {
+                    if( overlaps[i] )
+                    {
+                        CPLRectObj intersection;
+                        intersection.minx = std::max(pRect->minx, psNode->apSubNode[i]->rect.minx);
+                        intersection.miny = std::max(pRect->miny, psNode->apSubNode[i]->rect.miny);
+                        intersection.maxx = std::min(pRect->maxx, psNode->apSubNode[i]->rect.maxx);
+                        intersection.maxy = std::min(pRect->maxy, psNode->apSubNode[i]->rect.maxy);
+                        CPLQuadTreeNodeAddFeatureAlg1( hQuadTree, psNode->apSubNode[i],
+                                                       hFeature, &intersection );
+                    }
+                }
                 return;
             }
         }
@@ -583,7 +698,7 @@ static void CPLQuadTreeNodeAddFeatureAlg1( CPLQuadTree* hQuadTree,
         CPLAssert( psNode->pahFeatures == nullptr );
         psNode->pahFeatures = static_cast<void **>(
             CPLMalloc( hQuadTree->nBucketCapacity * sizeof(void*) ) );
-        if( hQuadTree->pfnGetBounds == nullptr )
+        if( hQuadTree->pfnGetBounds == nullptr && hQuadTree->pfnGetBoundsEx == nullptr )
             psNode->pasBounds = static_cast<CPLRectObj *>(
                 CPLMalloc( hQuadTree->nBucketCapacity * sizeof(CPLRectObj) ) );
     }
@@ -592,13 +707,13 @@ static void CPLQuadTreeNodeAddFeatureAlg1( CPLQuadTree* hQuadTree,
         psNode->pahFeatures = static_cast<void **>(
             CPLRealloc( psNode->pahFeatures,
                         sizeof(void*) * psNode->nFeatures ) );
-        if( hQuadTree->pfnGetBounds == nullptr )
+        if( hQuadTree->pfnGetBounds == nullptr && hQuadTree->pfnGetBoundsEx == nullptr )
             psNode->pasBounds = static_cast<CPLRectObj *>(
                 CPLRealloc( psNode->pasBounds,
                             sizeof(CPLRectObj) * psNode->nFeatures ) );
     }
     psNode->pahFeatures[psNode->nFeatures-1] = hFeature;
-    if( hQuadTree->pfnGetBounds == nullptr )
+    if( hQuadTree->pfnGetBounds == nullptr && hQuadTree->pfnGetBoundsEx == nullptr )
         psNode->pasBounds[psNode->nFeatures-1] = *pRect;
 
     return;
@@ -674,7 +789,7 @@ static void CPLQuadTreeNodeAddFeatureAlg2( CPLQuadTree *hQuadTree,
     psNode->pahFeatures =
         static_cast<void **>( CPLRealloc( psNode->pahFeatures,
                                           sizeof(void*) * psNode->nFeatures ) );
-    if( hQuadTree->pfnGetBounds == nullptr )
+    if( hQuadTree->pfnGetBounds == nullptr && hQuadTree->pfnGetBoundsEx == nullptr )
     {
         psNode->pasBounds =
           static_cast<CPLRectObj*>(
@@ -682,7 +797,7 @@ static void CPLQuadTreeNodeAddFeatureAlg2( CPLQuadTree *hQuadTree,
                           sizeof(CPLRectObj) * psNode->nFeatures ) );
     }
     psNode->pahFeatures[psNode->nFeatures-1] = hFeature;
-    if( hQuadTree->pfnGetBounds == nullptr )
+    if( hQuadTree->pfnGetBounds == nullptr && hQuadTree->pfnGetBoundsEx == nullptr )
     {
         psNode->pasBounds[psNode->nFeatures-1] = *pRect;
     }
@@ -742,7 +857,7 @@ static void CPLQuadTreeCollectFeatures(const CPLQuadTree *hQuadTree,
     /* -------------------------------------------------------------------- */
     for( int i = 0; i < psNode->nFeatures; i++ )
     {
-        if( hQuadTree->pfnGetBounds == nullptr )
+        if( hQuadTree->pfnGetBounds == nullptr && hQuadTree->pfnGetBoundsEx == nullptr )
         {
             if( CPL_RectOverlap(&psNode->pasBounds[i], pAoi) )
                 (*pppFeatureList)[(*pnFeatureCount)++] = psNode->pahFeatures[i];
@@ -750,7 +865,11 @@ static void CPLQuadTreeCollectFeatures(const CPLQuadTree *hQuadTree,
         else
         {
             CPLRectObj bounds;
-            hQuadTree->pfnGetBounds(psNode->pahFeatures[i], &bounds);
+            if( hQuadTree->pfnGetBoundsEx )
+                hQuadTree->pfnGetBoundsEx(psNode->pahFeatures[i], hQuadTree->pUserData, &bounds);
+            else
+                hQuadTree->pfnGetBounds(psNode->pahFeatures[i], &bounds);
+
             if( CPL_RectOverlap(&bounds, pAoi) )
                 (*pppFeatureList)[(*pnFeatureCount)++] = psNode->pahFeatures[i];
         }

--- a/port/cpl_quad_tree.h
+++ b/port/cpl_quad_tree.h
@@ -35,6 +35,8 @@
 
 #include "cpl_port.h"
 
+#include <stdbool.h>
+
 /**
  * \file cpl_quad_tree.h
  *
@@ -63,6 +65,8 @@ typedef struct _CPLQuadTree CPLQuadTree;
 
 /** CPLQuadTreeGetBoundsFunc */
 typedef void         (*CPLQuadTreeGetBoundsFunc)(const void* hFeature, CPLRectObj* pBounds);
+/** CPLQuadTreeGetBoundsExFunc */
+typedef void         (*CPLQuadTreeGetBoundsExFunc)(const void* hFeature, void* pUserData, CPLRectObj* pBounds);
 /** CPLQuadTreeForeachFunc */
 typedef int          (*CPLQuadTreeForeachFunc)(void* pElt, void* pUserData);
 /** CPLQuadTreeDumpFeatureFunc */
@@ -72,10 +76,14 @@ typedef void         (*CPLQuadTreeDumpFeatureFunc)(const void* hFeature, int nIn
 
 CPLQuadTree CPL_DLL  *CPLQuadTreeCreate(const CPLRectObj* pGlobalBounds,
                                         CPLQuadTreeGetBoundsFunc pfnGetBounds);
+CPLQuadTree CPL_DLL  *CPLQuadTreeCreateEx(const CPLRectObj* pGlobalBounds,
+                                          CPLQuadTreeGetBoundsExFunc pfnGetBounds,
+                                          void* pUserData);
 void        CPL_DLL   CPLQuadTreeDestroy(CPLQuadTree *hQuadtree);
 
 void        CPL_DLL   CPLQuadTreeSetBucketCapacity(CPLQuadTree *hQuadtree,
                                                    int nBucketCapacity);
+void        CPL_DLL   CPLQuadTreeForceUseOfSubNodes(CPLQuadTree *hQuadTree);
 int         CPL_DLL   CPLQuadTreeGetAdvisedMaxDepth(int nExpectedFeatures);
 void        CPL_DLL   CPLQuadTreeSetMaxDepth(CPLQuadTree *hQuadtree,
                                              int nMaxDepth);


### PR DESCRIPTION
Despite a few past attempts to improve it, the inverse transformer
relying on a backmap was far from being exact, with errors frequently
above 1 pixel.

This commit fixes it by using an (exact, non-interative) inverse bilinear
interpolation method (https://stackoverflow.com/a/812077) during backmap
generation itself (when the geolocation array expresses an affine
transformation, the backmap itself is exact), but also when inverse
transforming a coordinate, to fine tune the initial solution obtained
by bilinear interpolation of the backmap.

The FSHIFT and ISHIFT offsets, that were probably more empirical than
are no longer needed.

The oversampling factor [0.1,2] (default: 1.3) of the backmap can now be
controlled with the GEOLOC_BACKMAP_OVERSAMPLE_FACTOR transformer option
(or the GDAL_GEOLOC_BACKMAP_OVERSAMPLE_FACTOR configuration option).

I also noticed that the referencing convention of the geolocation array
was not clearly documented. Looking at the forward method, the existing
convention is a top-left corner one. This means that the
right-most column and bottom-most column of a raster (assuming a 1:1
match between the raster and geolocation array) are not within in a cell
of the geolocation array where we can naturally apply bilinear interpolation,
thus interpolation from the nearest cell was applied.
For a number of drivers, the georeferencing will be more using a pixel-center
convention, hence we add support in the GEOLOCATION metadata domain for a
GEOREFERENCING_CONVENTION item that defaults to TOP_LEFT_CORNER but can be
set to PIXEL_CENTER (and we set it to PIXEL_CENTER in the netCDF driver
where this is the most likely convention). The forward and inverse
transformers take into account that to apply a half-pixel shift to go
back/from the top-left corner convention used internally.

There are also quite a lot of precaution to deal with cells of the geolocation
array that span the antimeridian, to avoid erroneous interpolation to be
done (we don't want averaging longitudes close to -180 deg with ones
close to +180 deg), or missed pixels. Those cases are particular triggered
by the below mentionned dataset that includes the north Pole and thus has
discontinuity in longitudes in the geolocation array around +/- 180 deg.

There's a performance cost for those improvements.
gdalwarp applied on a Sentinel 5P product (S5P_TEST_L2__NO2____20190509T220707_20190509T234837_08137_01_010400_20200220T091343)
of size 450x3245 goes from 1.26 s to 3.52 s.

This commit also includes an alternate method for the inverse transform
that no longer uses a backmap, but a quadtree indexing the
quadrilaterals (in georeferenced coordinates) of each cell of the
geolocation array. It gives even more exact results than the above
improvements (no issue with holes and hole filling at high latitudes),
and make the code simpler, but it uses more RAM and is slower: 8.14 s on
the above mentioned test case. It can be selected by setting the GDAL_GEOLOC_INVERSE_METHOD
configuration option to QUADTREE.
