### PR TITLE
Fix out of bounds read in CPLRecodeFromWCharIconV()

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -3669,4 +3669,27 @@ namespace tut
         VSIUnlink("/vsimem/credentials.txt");
     }
 
+    // Test CPLRecodeFromWCharIconv() with 2 bytes/char source encoding
+    template<>
+    template<>
+    void object::test<55>()
+    {
+#ifdef CPL_RECODE_ICONV
+        int N = 2048;
+        wchar_t* pszIn = static_cast<wchar_t*>(CPLMalloc((N+1)*sizeof(wchar_t)));
+        for(int i=0;i<N;i++)
+            pszIn[i] = L'A';
+        pszIn[N] = L'\0';
+        char* pszExpected = static_cast<char*>(CPLMalloc(N+1));
+        for(int i=0;i<N;i++)
+            pszExpected[i] = 'A';
+        pszExpected[N] = '\0';
+        char* pszRet = CPLRecodeFromWChar(pszIn, CPL_ENC_UTF16, CPL_ENC_UTF8);
+        ensure_equals( memcmp(pszExpected, pszRet, N+1), 0 );
+        CPLFree(pszIn);
+        CPLFree(pszRet);
+        CPLFree(pszExpected);
+#endif
+    }
+
 } // namespace tut

--- a/port/cpl_recode_iconv.cpp
+++ b/port/cpl_recode_iconv.cpp
@@ -256,7 +256,7 @@ char *CPLRecodeFromWCharIconv( const wchar_t *pwszSource,
         reinterpret_cast<char*>(pszIconvSrcBuf));
 
     /* iconv expects a number of bytes, not characters */
-    nSrcLen *= sizeof(wchar_t);
+    nSrcLen *= nTargetCharWidth;
 
 /* -------------------------------------------------------------------- */
 /*      Allocate destination buffer.                                    */

--- a/port/cpl_recode_iconv.cpp
+++ b/port/cpl_recode_iconv.cpp
@@ -277,8 +277,8 @@ char *CPLRecodeFromWCharIconv( const wchar_t *pwszSource,
             if( errno == EILSEQ )
             {
                 // Skip the invalid sequence in the input string.
-                nSrcLen--;
-                pszSrcBuf += sizeof(wchar_t);
+                nSrcLen -= nTargetCharWidth;
+                pszSrcBuf += nTargetCharWidth;
                 if( !bHaveWarned2 )
                 {
                     bHaveWarned2 = true;
@@ -309,6 +309,13 @@ char *CPLRecodeFromWCharIconv( const wchar_t *pwszSource,
         }
     }
 
+    if (nDstLen == 0)
+    {
+        ++nDstCurLen;
+        pszDestination =
+            static_cast<char *>(CPLRealloc(pszDestination, nDstCurLen));
+        ++nDstLen;
+    }
     pszDestination[nDstCurLen - nDstLen] = '\0';
 
     iconv_close( sConv );


### PR DESCRIPTION
If the number of bytes per character was different from the size of
wchar_t, the size of the input was not computed correctly.
