### PR TITLE
FlatGeobuf: in SPATIAL_INDEX=NO mode, write a meaningful featureCount and extent in the header

### DIFF
--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -435,6 +435,10 @@ def test_ogr_flatgeobuf_mixed():
     destDS = ogr.Open('/vsimem/test.fgb')
     srcLyr = srcDS.GetLayer(0)
     destLyr = destDS.GetLayer(0)
+    assert destLyr.TestCapability(ogr.OLCFastFeatureCount)
+    assert destLyr.TestCapability(ogr.OLCFastGetExtent)
+    assert destLyr.GetFeatureCount(force=0) == srcLyr.GetFeatureCount()
+    assert destLyr.GetExtent(force=0) == srcLyr.GetExtent()
     ogrtest.compare_layers(srcLyr, destLyr)
 
     ogr.GetDriverByName('FlatGeobuf').DeleteDataSource('/vsimem/test.fgb')

--- a/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -103,6 +103,7 @@ class OGRFlatGeobufLayer final : public OGRLayer, public OGRFlatGeobufBaseLayerI
         bool m_bCanCreate = true;
         VSILFILE *m_poFpWrite = nullptr;
         uint64_t m_writeOffset = 0; // current write offset
+        uint64_t m_offsetAfterHeader = 0; // offset after dummy header writing (when creating a file without spatial index)
         uint16_t m_indexNodeSize = 0;
         std::string m_osTempFile; // holds generated temp file name for two pass writing
         uint32_t m_maxFeatureSize  = 0;

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -393,10 +393,38 @@ void OGRFlatGeobufLayer::writeHeader(VSILFILE *poFp, uint64_t featuresCount, std
     m_writeOffset += c;
 }
 
+static bool SupportsSeekWhileWriting(const std::string& osFilename)
+{
+    return (!STARTS_WITH(osFilename.c_str(), "/vsi")) ||
+           STARTS_WITH(osFilename.c_str(), "/vsimem/");
+}
+
 void OGRFlatGeobufLayer::Create() {
-    // no spatial index requested, we are done
+    // no spatial index requested, we are (almost) done
     if (!m_bCreateSpatialIndexAtClose)
+    {
+        if( m_poFpWrite == nullptr ||
+            m_featuresCount == 0 ||
+            !SupportsSeekWhileWriting(m_osFilename) )
+        {
+            return;
+        }
+
+        // Rewrite header
+        VSIFSeekL(m_poFpWrite, 0, SEEK_SET);
+        m_writeOffset = 0;
+        std::vector<double> extentVector;
+        extentVector.push_back(m_sExtent.MinX);
+        extentVector.push_back(m_sExtent.MinY);
+        extentVector.push_back(m_sExtent.MaxX);
+        extentVector.push_back(m_sExtent.MaxY);
+        writeHeader(m_poFpWrite, m_featuresCount, &extentVector);
+        // Sanity check to verify that the dummy header and the real header
+        // have the same size.
+        CPLAssert(m_writeOffset == m_offsetAfterHeader);
+        CPL_IGNORE_RET_VAL(m_writeOffset); // otherwise checkers might tell the member is not used
         return;
+    }
 
     m_poFp = VSIFOpenL(m_osFilename.c_str(), "wb");
     if (m_poFp == nullptr) {
@@ -1321,7 +1349,17 @@ OGRErr OGRFlatGeobufLayer::ICreateFeature(OGRFeature *poNewFeature)
                 CPLErrorInvalidPointer("output file handler");
                 return OGRERR_FAILURE;
             }
-            writeHeader(m_poFpWrite, 0, nullptr);
+            if( !SupportsSeekWhileWriting(m_osFilename) )
+            {
+                writeHeader(m_poFpWrite, 0, nullptr);
+            }
+            else
+            {
+                std::vector<double> dummyExtent(4, std::numeric_limits<double>::quiet_NaN());
+                const uint64_t dummyFeatureCount = 0xDEADBEEF;  // write non-zero value, otherwise the reserved size is not OK
+                writeHeader(m_poFpWrite, dummyFeatureCount, &dummyExtent); // we will update it later
+                m_offsetAfterHeader = m_writeOffset;
+            }
             CPLDebugOnly("FlatGeobuf", "Writing first feature at offset: %lu", static_cast<long unsigned int>(m_writeOffset));
         }
 
@@ -1425,13 +1463,13 @@ std::string OGRFlatGeobufLayer::GetTempFilePath(const CPLString &fileName, CSLCo
     return osTempFile;
 }
 
-VSILFILE *OGRFlatGeobufLayer::CreateOutputFile(const CPLString &pszFilename, CSLConstList papszOptions, bool isTemp) {
+VSILFILE *OGRFlatGeobufLayer::CreateOutputFile(const CPLString &osFilename, CSLConstList papszOptions, bool isTemp) {
     std::string osTempFile;
     VSILFILE *poFpWrite;
     int savedErrno;
     if (isTemp) {
         CPLDebug("FlatGeobuf", "Spatial index requested will write to temp file and do second pass on close");
-        osTempFile = GetTempFilePath(pszFilename, papszOptions);
+        osTempFile = GetTempFilePath(osFilename, papszOptions);
         poFpWrite = VSIFOpenL(osTempFile.c_str(), "w+b");
         savedErrno = errno;
         // Unlink it now to avoid stale temporary file if killing the process
@@ -1439,13 +1477,16 @@ VSILFILE *OGRFlatGeobufLayer::CreateOutputFile(const CPLString &pszFilename, CSL
         VSIUnlink(osTempFile.c_str());
     } else {
         CPLDebug("FlatGeobuf", "No spatial index will write directly to output");
-        poFpWrite = VSIFOpenL(pszFilename, "wb");
+        if( !SupportsSeekWhileWriting(osFilename) )
+            poFpWrite = VSIFOpenL(osFilename, "wb");
+        else
+            poFpWrite = VSIFOpenL(osFilename, "w+b");
         savedErrno = errno;
     }
     if (poFpWrite == nullptr) {
         CPLError(CE_Failure, CPLE_OpenFailed,
                     "Failed to create %s:\n%s",
-                    pszFilename.c_str(), VSIStrerror(savedErrno));
+                    osFilename.c_str(), VSIStrerror(savedErrno));
         return nullptr;
     }
     return poFpWrite;

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -631,7 +631,7 @@ OGRErr OGRFlatGeobufLayer::readFeatureOffset(uint64_t index, uint64_t &featureOf
 
 OGRFeature *OGRFlatGeobufLayer::GetFeature(GIntBig nFeatureId)
 {
-    if (m_featuresCount == 0) {
+    if (m_indexNodeSize == 0) {
         return OGRLayer::GetFeature(nFeatureId);
     } else {
         if (static_cast<uint64_t>(nFeatureId) >= m_featuresCount) {


### PR DESCRIPTION
CC @bjornharrtell 

2 commits: the first one is a bugfix, the second one an improvement:
- fix GetFeature() when featuresCount != 0 and indexNodeSize == 0, such as files produced by the next commit
- in SPATIAL_INDEX=NO mode, write a meaningful featureCount and extent in the header. Previously featureCount=0 and extent=null where written. Writing meaningful values is a bit tricky since it involves first creating a dummy header of the right size, and overriding it at file closing.