### PR TITLE
GeoJSON reader: expose EPSG:4979 as CRS when none is specified and 3D geoms are found

### DIFF
--- a/autotest/cpp/test_osr.cpp
+++ b/autotest/cpp/test_osr.cpp
@@ -438,4 +438,38 @@ namespace tut
         ensure_equals(oSRS.GetEPSGGeogCS(), 4326);
     }
 
+    // Test GetOGCURN
+    template<>
+    template<>
+    void object::test<10>()
+    {
+        {
+            OGRSpatialReference oSRS;
+            ensure(oSRS.GetOGCURN() == nullptr);
+        }
+        {
+            OGRSpatialReference oSRS;
+            oSRS.SetFromUserInput("+proj=longlat");
+            ensure(oSRS.GetOGCURN() == nullptr);
+        }
+
+        {
+            OGRSpatialReference oSRS;
+            oSRS.importFromEPSG(32631);
+            char* pszRet = oSRS.GetOGCURN();
+            ensure(pszRet != nullptr);
+            ensure(strcmp(pszRet, "urn:ogc:def:crs:EPSG::32631") == 0);
+            CPLFree(pszRet);
+        }
+
+        {
+            OGRSpatialReference oSRS;
+            oSRS.SetFromUserInput("EPSG:32631+5773");
+            char* pszRet = oSRS.GetOGCURN();
+            ensure(pszRet != nullptr);
+            ensure(strcmp(pszRet, "urn:ogc:def:crs,crs:EPSG::32631,crs:EPSG::5773") == 0);
+            CPLFree(pszRet);
+        }
+    }
+
 } // namespace tut

--- a/autotest/ogr/data/geojson/featurecollection_point.json
+++ b/autotest/ogr/data/geojson/featurecollection_point.json
@@ -1,0 +1,1 @@
+{"type":"FeatureCollection","features":[{"type":"Feature","properties":null,"geometry":{"type":"Point","coordinates":[1,2]}}]}

--- a/autotest/ogr/data/geojson/featurecollection_pointz.json
+++ b/autotest/ogr/data/geojson/featurecollection_pointz.json
@@ -1,0 +1,1 @@
+{"type":"FeatureCollection","features":[{"type":"Feature","properties":null,"geometry":{"type":"Point","coordinates":[1,2,3]}}]}

--- a/autotest/ogr/data/geojson/pointz.json
+++ b/autotest/ogr/data/geojson/pointz.json
@@ -1,0 +1,1 @@
+{"type":"Point","coordinates":[1,2,3]}

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -3176,3 +3176,27 @@ def test_ogr_geojson_sparse_fields():
     lyr_defn = lyr.GetLayerDefn()
     field_names = [ lyr_defn.GetFieldDefn(i).GetName() for i in range(lyr_defn.GetFieldCount()) ]
     assert field_names == [ 'C', 'B', 'A', 'D', 'E_prev', 'E', 'E_next', 'F', 'X']
+
+###############################################################################
+
+
+@pytest.mark.parametrize('filename', ['point.geojson', 'featurecollection_point.json'])
+def test_ogr_geojson_crs_4326(filename):
+
+    ds = ogr.Open('data/geojson/' + filename)
+    lyr = ds.GetLayer(0)
+    srs = lyr.GetSpatialRef()
+    assert srs.GetAuthorityCode(None) == '4326'
+    assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
+
+###############################################################################
+
+
+@pytest.mark.parametrize('filename', ['pointz.json', 'featurecollection_pointz.json'])
+def test_ogr_geojson_crs_4979(filename):
+
+    ds = ogr.Open('data/geojson/' + filename)
+    lyr = ds.GetLayer(0)
+    srs = lyr.GetSpatialRef()
+    assert srs.GetAuthorityCode(None) == '4979'
+    assert srs.GetDataAxisToSRSAxisMapping() == [2, 1, 3]

--- a/ogr/ogr_spatialref.h
+++ b/ogr/ogr_spatialref.h
@@ -421,6 +421,7 @@ class CPL_DLL OGRSpatialReference
 
     const char *GetAuthorityCode( const char * pszTargetKey ) const;
     const char *GetAuthorityName( const char * pszTargetKey ) const;
+    char       *GetOGCURN() const;
 
     bool        GetAreaOfUse( double* pdfWestLongitudeDeg,
                               double* pdfSouthLatitudeDeg,

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -377,6 +377,25 @@ OGRLayer* OGRGeoJSONDataSource::ICreateLayer( const char* pszNameIn,
             CPLError(CE_Warning, CPLE_AppDefined,
                      "No SRS set on layer. Assuming it is long/lat on WGS84 ellipsoid");
         }
+        else if( poSRS->GetAxesCount() == 3 )
+        {
+            OGRSpatialReference oSRS_EPSG_4979;
+            oSRS_EPSG_4979.importFromEPSG(4979);
+            oSRS_EPSG_4979.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+            if( !poSRS->IsSame(&oSRS_EPSG_4979) )
+            {
+                poCT = OGRCreateCoordinateTransformation( poSRS, &oSRS_EPSG_4979 );
+                if( poCT == nullptr )
+                {
+                    CPLError(
+                        CE_Warning, CPLE_AppDefined,
+                        "Failed to create coordinate transformation between the "
+                        "input coordinate system and WGS84." );
+
+                    return nullptr;
+                }
+            }
+        }
         else
         {
             OGRSpatialReference oSRSWGS84;


### PR DESCRIPTION
Cf 'An OPTIONAL third-position element SHALL be the height in meters above or below
the WGS 84 reference ellipsoid', paragraph 4. of https://datatracker.ietf.org/doc/html/rfc7946
