### PR TITLE
GRIB multidim: fix crash when a .idx file is present (fixes #5569)

### DIFF
--- a/autotest/gdrivers/gribmultidim.py
+++ b/autotest/gdrivers/gribmultidim.py
@@ -146,3 +146,14 @@ def test_grib_multidim_different_sizes_messages():
         'Y3', 'X3', 'HTSGW_1-SFC', 'WVPER_1-SFC', 'WVDIR_1-SFC', 'PERPW_1-SFC', 'DIRPW_1-SFC', 'PERSW_1-SFC', 'DIRSW_1-SFC']
     dims = rg.GetDimensions()
     assert len(dims) == 6
+
+###############################################################################
+# Test reading file with .idx sidecar file (that we don't use in the multidim API)
+
+
+def test_grib_multidim_grib2_sidecar():
+
+    ds = gdal.OpenEx('data/grib/gfs.t06z.pgrb2.10p0.f010.grib2', gdal.OF_MULTIDIM_RASTER)
+    assert ds
+    rg = ds.GetRootGroup()
+    assert rg

--- a/doc/source/drivers/raster/grib.rst
+++ b/doc/source/drivers/raster/grib.rst
@@ -108,8 +108,8 @@ Open options
 ------------
 
 -  **USE_IDX=YES/NO**: (From GDAL 3.4) Enable automatic reading
-   of external wgrib2 external index files when available. GDAL
-   will look for a `<GRIB>.idx` in the same place as the dataset.
+   of external wgrib2 external index files when available. Default is YES.
+   GDAL will look for a `<GRIB>.idx` in the same place as the dataset.
    These files when combined with careful usage of the API or the
    CLI tools allow a GRIBv2 file to be opened without reading all
    the bands. In particular, this allows an orders of magnitude
@@ -119,7 +119,9 @@ Open options
    description of the bands should be accessed as accessing the
    metadata will require loading of the band header.
    gdal_translate is supported but gdalinfo is not.
-   Default is YES.
+   This option is ignored when using the multidimensional API (index is then
+   ignored)
+
 
 GRIB2 write support
 -------------------

--- a/frmts/grib/gribdataset.cpp
+++ b/frmts/grib/gribdataset.cpp
@@ -2181,7 +2181,8 @@ GDALDataset *GRIBDataset::OpenMultiDim( GDALOpenInfo *poOpenInfo )
     VSIFSeekL(poShared->m_fp, 0, SEEK_SET);
 
     // Contains an GRIB2 message inventory of the file.
-    auto pInventories = Inventory(poShared->m_fp, poOpenInfo);
+    // We can't use the potential .idx file
+    auto pInventories = cpl::make_unique<InventoryWrapperGrib>(poShared->m_fp);
 
     if( pInventories->result() <= 0 )
     {


### PR DESCRIPTION
We disable use of the .idx file as it doesn't contain all the details we
need to instanciate the GRIBArray objects.
