### PR TITLE
MRF: Add padding after encoding LERC

### DIFF
--- a/frmts/mrf/LERC_band.cpp
+++ b/frmts/mrf/LERC_band.cpp
@@ -386,12 +386,12 @@ static CPLErr CompressLERC2(buf_mgr &dst, buf_mgr &src, const ILImage &img, doub
         pbm, precision,
         reinterpret_cast<Lerc1NS::Byte*>(dst.buffer), static_cast<unsigned int>(dst.size), &sz);
 
-    if (L2NS::ErrCode::Ok != static_cast<L2NS::ErrCode>(status) || sz > dst.size) {
+    if (L2NS::ErrCode::Ok != static_cast<L2NS::ErrCode>(status) || sz > (dst.size - PADDING_BYTES)) {
         CPLError(CE_Failure, CPLE_AppDefined, "MRF: Error during LERC2 compression");
         return CE_Failure;
     }
 
-    dst.size = static_cast<size_t>(sz);
+    dst.size = static_cast<size_t>(sz) + PADDING_BYTES;
     return CE_None;
 }
 


### PR DESCRIPTION
Lerc2 decoding might need access to three bytes past the end of the compressed buffer

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

When decoding, LERC2 might access to up three more bytes than the encoded buffer. When refactoring the MRF code to use the LERC2 public API, this padded was not taken into account, this PR restores the correct behavior.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
