### PR TITLE
Rename GDAL_HAVE_XLOCALE_H to HAVE_XLOCALE_H

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -34,7 +34,7 @@ check_include_file("fcntl.h" HAVE_FCNTL_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
 check_include_file("locale.h" HAVE_LOCALE_H)
-check_include_file("xlocale.h" GDAL_HAVE_XLOCALE_H)
+check_include_file("xlocale.h" HAVE_XLOCALE_H)
 check_include_file("direct.h" HAVE_DIRECT_H)
 check_include_file("dlfcn.h" HAVE_DLFCN_H)
 
@@ -236,7 +236,7 @@ else ()
   set(UNIX_STDIO_64 TRUE)
 
   set(INCLUDE_XLOCALE_H)
-  if(GDAL_HAVE_XLOCALE_H)
+  if(HAVE_XLOCALE_H)
     set(INCLUDE_XLOCALE_H "#include <xlocale.h>")
   endif()
   check_c_source_compiles(

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -98,7 +98,7 @@
 #cmakedefine HAVE_UNISTD_H 1
 
 /* Define to 1 if you have the <xlocale.h> header file. */
-#cmakedefine GDAL_HAVE_XLOCALE_H 1
+#cmakedefine HAVE_XLOCALE_H 1
 
 /* Define to 1 if you have the `vsnprintf' function. */
 #cmakedefine HAVE_VSNPRINTF 1

--- a/configure.ac
+++ b/configure.ac
@@ -354,9 +354,9 @@ AC_CHECK_FUNC_CUSTOM(gmtime_r,[#include <time.h>],[time_t t; struct tm ltime; t 
 AC_CHECK_FUNC_CUSTOM(localtime_r,[#include <time.h>],[time_t t; struct tm ltime; t = time(0); localtime_r( &t, &ltime );])
 AC_LANG_POP(C++)
 
-AC_CHECK_HEADERS([xlocale.h],[GDAL_HAVE_XLOCALE_H=1])
-if test "$GDAL_HAVE_XLOCALE_H" = "1"; then
-  AC_DEFINE_UNQUOTED(GDAL_HAVE_XLOCALE_H, 1,
+AC_CHECK_HEADERS([xlocale.h],[HAVE_XLOCALE_H=1])
+if test "$HAVE_XLOCALE_H" = "1"; then
+  AC_DEFINE_UNQUOTED(HAVE_XLOCALE_H, 1,
             [Define if you have the <xlocale.h> header file.])
 fi
 

--- a/port/cpl_config.h.in
+++ b/port/cpl_config.h.in
@@ -94,7 +94,7 @@
 #undef HAVE_UNISTD_H
 
 /* Define to 1 if you have the <xlocale.h> header file. */
-#undef GDAL_HAVE_XLOCALE_H
+#undef HAVE_XLOCALE_H
 
 /* Define to 1 if you have the `vsnprintf' function. */
 #undef HAVE_VSNPRINTF

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -72,7 +72,7 @@
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#if GDAL_HAVE_XLOCALE_H
+#if HAVE_XLOCALE_H
 #include <xlocale.h> // for LC_NUMERIC_MASK on MacOS
 #endif
 


### PR DESCRIPTION
## What does this PR do?
Renames `GDAL_HAVE_XLOCALE_H` to `HAVE_XLOCALE_H` to be consistent with `ogr/ogrsf_frmts/geojson/libjson/json_tokener.c` that uses `HAVE_XLOCALE_H`. Otherwise it may not work compiling that file when there is `xlocale.h`

## What are related issues/pull requests?
#5027

## Tasklist

 - [ ] Review
 - [ ] All CI builds and checks have passed

## Environment
Detected doing Cross Compilation in macOS x86_64 to M1 (arm)
