### PR TITLE
CMake: add a GDAL_USE_INTERNAL_LIBS=ON/OFF/WHEN_NO_EXTERNAL variable

### DIFF
--- a/doc/source/build_hints.rst
+++ b/doc/source/build_hints.rst
@@ -173,9 +173,29 @@ GDAL_USE_<Packagename_in_upper_case>:BOOL=ON.
 
 .. option:: GDAL_USE_EXTERNAL_LIBS:BOOL=ON/OFF
 
+     Defaults to ON. When set to OFF, all external dependencies (but mandatory
+     ones) will be disabled, unless individually enabled with
+     GDAL_USE_<Packagename_in_upper_case>:BOOL=ON.
      This option should be set before CMakeCache.txt is created. If it is set
      to OFF after CMakeCache.txt is created, then cmake should be reinvoked with
      "-UGDAL_USE_*" to cancel the activation of previously detected libraries.
+
+Some of the GDAL dependencies (GEOTIFF, GIF, JPEG, JSONC, LERC, OPENCAD, PNG, QHULL, TIFF, ZLIB)
+have a copy of their source code inside the GDAL source code tree. It is possible
+to enable this internal copy by setting the GDAL_USE_<Packagename_in_upper_case>_INTERNAL:BOOL=ON
+variable. When set, this has precedence over the external library that may be
+detected. The behavior can also be globally controlled with the following variable:
+
+.. option:: GDAL_USE_INTERNAL_LIBS=ON/OFF/WHEN_NO_EXTERNAL
+
+     Control how internal libraries should be used.
+     If set to ON, they will always be used.
+     If set to OFF, they will never be used (unless individually enabled with
+     GDAL_USE_<Packagename_in_upper_case>_INTERNAL:BOOL=ON)
+     If set to WHEN_NO_EXTERNAL (default value), they will be used only if no
+     corresponding external library is found and enabled.
+     This option should be set before CMakeCache.txt is created.
+
 
 Armadillo
 *********
@@ -457,7 +477,7 @@ GEOTIFF
 *******
 
 It is required for the :ref:`raster.gtiff` drivers, and a few other drivers.
-If not found, an internal copy of libgeotiff will be used.
+If not found, an internal copy of libgeotiff can be used.
 
 .. option:: GEOTIFF_INCLUDE_DIR
 
@@ -476,8 +496,8 @@ If not found, an internal copy of libgeotiff will be used.
 
 .. option:: GDAL_USE_GEOTIFF_INTERNAL=ON/OFF
 
-    Control whether to use internal libgeotiff copy. Defaults to ON when external
-    libgeotiff is not found.
+    Control whether to use internal libgeotiff copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_GEOTIFF=ON
 
 
 GEOS
@@ -505,7 +525,7 @@ GIF
 ***
 
 `giflib <http://giflib.sourceforge.net/>`_ is required for the :ref:`raster.gif` driver.
-If not found, an internal copy will be used.
+If not found, an internal copy can be used.
 
 .. option:: GIF_INCLUDE_DIR
 
@@ -521,8 +541,8 @@ If not found, an internal copy will be used.
 
 .. option:: GDAL_USE_GIF_INTERNAL=ON/OFF
 
-    Control whether to use internal giflib copy. Defaults to ON when external
-    giflib is not found.
+    Control whether to use internal giflib copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_GIF=ON
 
 
 GTA
@@ -702,7 +722,7 @@ JPEG
 
 libjpeg is required for the :ref:`raster.jpeg` driver, and may be used by a few
 other drivers (:ref:`raster.gpkg`, :ref:`raster.marfa`, internal libtiff, etc.)
-If not found, an internal copy of libjpeg (6b) will be used.
+If not found, an internal copy of libjpeg (6b) can be used.
 Using `libjpeg-turbo <https://github.com/libjpeg-turbo/libjpeg-turbo>`_ is highly
 recommended to get best performance.
 See https://cmake.org/cmake/help/latest/module/FindJPEG.html for more details
@@ -730,8 +750,8 @@ on how the library is detected.
 
 .. option:: GDAL_USE_JPEG_INTERNAL=ON/OFF
 
-    Control whether to use internal libjpeg copy. Defaults to ON when external
-    libjpeg is not found.
+    Control whether to use internal libjpeg copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_JPEG=ON
 
 
 JPEG12
@@ -754,7 +774,7 @@ JSON-C
 The `json-c <https://github.com/json-c/json-c>`_ library is required to read and
 write JSON content.
 It can be detected with pkg-config.
-If not found, an internal copy of json-c will be used.
+If not found, an internal copy of json-c can be used.
 
 .. option:: JSONC_INCLUDE_DIR
 
@@ -770,8 +790,8 @@ If not found, an internal copy of json-c will be used.
 
 .. option:: GDAL_USE_JSONC_INTERNAL=ON/OFF
 
-    Control whether to use internal JSON-C copy. Defaults to ON when external
-    JSON-C is not found.
+    Control whether to use internal JSON-C copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_JSONC=ON
 
 
 JXL
@@ -861,12 +881,12 @@ of the original input image is preserved (within user defined error bounds).
 
 .. option:: GDAL_USE_LERC=ON/OFF
 
-    Control whether to use LERC. Defaults to *OFF* when LERC is found.
+    Control whether to use LERC. Defaults to ON when LERC is found.
 
 .. option:: GDAL_USE_LERC_INTERNAL=ON/OFF
 
-    Control whether to use the LERC internal library. Defaults to ON,
-    unless GDAL_USE_LERC is set to ON.
+    Control whether to use the LERC internal library. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_LERC=ON
 
 
 LibKML
@@ -1184,6 +1204,31 @@ driver. It can be detected with pkg-config.
     Control whether to use OGDI. Defaults to ON when OGDI is found.
 
 
+OpenCAD
+*******
+
+`libopencad <https://github.com/nextgis-borsch/lib_opencad>`_ is required for the :ref:`vector.cad`
+driver. If not found, an internal copy can be used.
+
+.. option:: OPENCAD_INCLUDE_DIR
+
+    Path to an include directory with the ``opencad.h`` header file.
+
+.. option:: OPENCAD_LIBRARY
+
+    Path to a shared or static library file.
+
+.. option:: GDAL_USE_OPENCAD=ON/OFF
+
+    Control whether to use external libopencad. Defaults to ON when external libopencad is found.
+
+.. option:: GDAL_USE_OPENCAD_INTERNAL=ON/OFF
+
+    Control whether to use internal libopencad copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_OPENCAD=ON
+
+
+
 OpenCL
 ******
 
@@ -1328,7 +1373,7 @@ PNG
 
 `libpng <https://github.com/glennrp/libpng>`_ is required for the :ref:`raster.png`
 driver, and may be used by a few other drivers (:ref:`raster.grib`, :ref:`raster.gpkg`, etc.)
-If not found, an internal copy of libpng will be used.
+If not found, an internal copy of libpng can be used.
 See https://cmake.org/cmake/help/latest/module/FindPNG.html for more details
 on how the library is detected.
 
@@ -1348,8 +1393,8 @@ on how the library is detected.
 
 .. option:: GDAL_USE_PNG_INTERNAL=ON/OFF
 
-    Control whether to use internal libpng copy. Defaults to ON when external
-    libpng is not found.
+    Control whether to use internal libpng copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_PNG=ON
 
 
 Poppler
@@ -1413,7 +1458,7 @@ QHULL
 *****
 
 The `QHULL <https://github.com/qhull/qhull>`_ library is used for the linear
-interpolation of gdal_grid. If not found, an internal copy is used.
+interpolation of gdal_grid. If not found, an internal copy can be used.
 
 .. option:: QHULL_PACKAGE_NAME
 
@@ -1433,8 +1478,8 @@ interpolation of gdal_grid. If not found, an internal copy is used.
 
 .. option:: GDAL_USE_QHULL_INTERNAL=ON/OFF
 
-    Control whether to use internal QHULL copy. Defaults to ON when external
-    QHULL is not found.
+    Control whether to use internal QHULL copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_QHULL=ON
 
 
 RASTERLITE2
@@ -1576,7 +1621,7 @@ TIFF
 
 `libtiff <https://gitlab.com/libtiff/libtiff/>`_ is required for the
 :ref:`raster.gtiff` drivers, and a few other drivers.
-If not found, an internal copy of libtiff will be used.
+If not found, an internal copy of libtiff can be used.
 
 .. option:: TIFF_INCLUDE_DIR
 
@@ -1595,8 +1640,8 @@ If not found, an internal copy of libtiff will be used.
 
 .. option:: GDAL_USE_TIFF_INTERNAL=ON/OFF
 
-    Control whether to use internal libtiff copy. Defaults to ON when external
-    libtiff is not found.
+    Control whether to use internal libtiff copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_TIFF=ON
 
 
 TileDB
@@ -1673,8 +1718,8 @@ the lossless Deflate/Zip compression algorithm.
 
 .. option:: GDAL_USE_ZLIB_INTERNAL=ON/OFF
 
-    Control whether to use internal zlib copy. Defaults to ON when external
-    zlib is not found.
+    Control whether to use internal zlib copy. Defaults depends on GDAL_USE_INTERNAL_LIBS. When set
+    to ON, has precedence over GDAL_USE_ZLIB=ON
 
 
 ZSTD

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -777,14 +777,12 @@ if(NOT GDAL_CMAKE_QUIET)
   system_summary(DESCRIPTION "GDAL is now configured on;")
 endif()
 
-# Do not warn about Shapelib being an optional package not found, as we don't recommend using it. Same for external
-# LERC. Mono/DotNetFrameworkSdk is also an internal detail of CSharp that we don't want to report
+# Do not warn about Shapelib being an optional package not found, as we don't recommend using it.
+# Mono/DotNetFrameworkSdk is also an internal detail of CSharp that we don't want to report
 get_property(_packages_not_found GLOBAL PROPERTY PACKAGES_NOT_FOUND)
 set(_new_packages_not_found)
 foreach (_package IN LISTS _packages_not_found)
   if (NOT ${_package} STREQUAL "Shapelib"
-      AND NOT ${_package} STREQUAL "LERC"
-      AND NOT ${_package} STREQUAL "OpenCAD"
       AND NOT ${_package} STREQUAL "Podofo"
       AND NOT ${_package} STREQUAL "Mono"
       AND NOT ${_package} STREQUAL "DotNetFrameworkSdk")
@@ -806,15 +804,26 @@ foreach (_package IN LISTS _packages_found)
   if (DEFINED GDAL_USE_${key} AND NOT GDAL_USE_${key})
     if (DEFINED GDAL_USE_${key}_INTERNAL)
       if (NOT GDAL_USE_${key}_INTERNAL)
-        string(APPEND disabled_packages " *${key} component has been detected, but is disabled with GDAL_USE_${key}=${GDAL_USE_${key}}, and the internal library is also disabled with GDAL_USE_${key}_INTERNAL=${GDAL_USE_${key}_INTERNAL}\n")
+        string(APPEND disabled_packages " * ${key} component has been detected, but is disabled with GDAL_USE_${key}=${GDAL_USE_${key}}, and the internal library is also disabled with GDAL_USE_${key}_INTERNAL=${GDAL_USE_${key}_INTERNAL}\n")
       endif()
     else ()
-      string(APPEND disabled_packages " *${key} component has been detected, but is disabled with GDAL_USE_${key}=${GDAL_USE_${key}}\n")
+      string(APPEND disabled_packages " * ${key} component has been detected, but is disabled with GDAL_USE_${key}=${GDAL_USE_${key}}\n")
     endif()
   endif ()
 endforeach ()
 if (NOT GDAL_CMAKE_QUIET AND disabled_packages)
   message(STATUS "Disabled components:\n\n${disabled_packages}\n")
+endif ()
+
+set(internal_libs_used "")
+foreach (_package IN LISTS _packages_found _new_packages_not_found)
+  string(TOUPPER ${_package} key)
+  if( GDAL_USE_${key}_INTERNAL )
+      string(APPEND internal_libs_used " * ${key} internal library enabled\n")
+  endif()
+endforeach()
+if (NOT GDAL_CMAKE_QUIET AND internal_libs_used)
+  message(STATUS "Internal libraries enabled:\n\n${internal_libs_used}\n")
 endif ()
 
 if (NOT GDAL_CMAKE_QUIET AND


### PR DESCRIPTION
From updated build_hints page:
```

Some of the GDAL dependencies (GEOTIFF, GIF, JPEG, JSONC, LERC, OPENCAD, PNG, QHULL, TIFF, ZLIB)
have a copy of their source code inside the GDAL source code tree. It is possible
to enable this internal copy by setting the GDAL_USE_<Packagename_in_upper_case>_INTERNAL:BOOL=ON
variable. When set, this has precedence over the external library that may be
detected. The behavior can also be globally controlled with the following variable:

.. option:: GDAL_USE_INTERNAL_LIBS=ON/OFF/WHEN_NO_EXTERNAL

     Control how internal libraries should be used.
     If set to ON, they will always be used.
     If set to OFF, they will never be used (unless individually enabled with
     GDAL_USE_<Packagename_in_upper_case>_INTERNAL:BOOL=ON)
     If set to WHEN_NO_EXTERNAL (default value), they will be used only if no
     corresponding external library is found and enabled.
     This option should be set before CMakeCache.txt is created.
```

Also add at the end of cmake phase, a summary of internal libs used. For
example:

```
-- Internal libraries enabled:

 * TIFF internal library enabled
 * GEOTIFF internal library enabled
 * PNG internal library enabled
 * GIF internal library enabled
 * OPENCAD internal library enabled
 * LERC internal library enabled
```
