### PR TITLE
MRF: Prevent LERC out of bounds access

### DIFF
--- a/third_party/LercLib/BitStuffer2.cpp
+++ b/third_party/LercLib/BitStuffer2.cpp
@@ -356,7 +356,7 @@ void BitStuffer2::BitStuff_Before_Lerc2v3(Byte** ppByte, const vector<unsigned i
 // -------------------------------------------------------------------------- ;
 
 bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, 
-    vector<unsigned int>& dataVec, unsigned int numElements, int numBits)
+    vector<unsigned int>& dataVec, unsigned int numElements, int numBits) const
 {
   if (numElements == 0 || numBits >= 32)
     return false;
@@ -367,38 +367,31 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
     return false;
   size_t numUInts = (size_t)numUIntsLL;
 
-  unsigned int* arr = (unsigned int*)(*ppByte);
+  unsigned int ntbnn = NumTailBytesNotNeeded(numElements, numBits);
 
-  if (nBytesRemaining < numBytes)
+  if (numBytes != numBytesLL || nBytesRemaining + ntbnn < numBytes)
     return false;
 
   try
   {
     dataVec.resize(numElements, 0);    // init with 0
+    m_tmpBitStuffVec.resize(numUInts);
   }
   catch( const std::exception& )
   {
     return false;
   }
 
-  unsigned int* srcPtr = arr;
-  srcPtr += numUInts;
+  m_tmpBitStuffVec[numUInts - 1] = 0;    // set last uint to 0
 
-  // needed to save the 0-3 bytes not used in the last UInt
-  srcPtr--;
-  unsigned int lastUInt = *srcPtr;
-  unsigned int numBytesNotNeeded = NumTailBytesNotNeeded(numElements, numBits);
+  unsigned int nBytesToCopy = (numElements * numBits + 7) / 8;
+  memcpy(&m_tmpBitStuffVec[0], *ppByte, nBytesToCopy);
 
-  for (unsigned int n = numBytesNotNeeded; n; n--)
-  {
-    unsigned int val;
-    memcpy(&val, srcPtr, sizeof(unsigned int));
-    val <<= 8;
-    memcpy(srcPtr, &val, sizeof(unsigned int));
-  }
+  unsigned int* pLastULong = &m_tmpBitStuffVec[numUInts - 1];
+  while (ntbnn--)
+    *pLastULong <<= 8;
 
-  // do the un-stuffing
-  srcPtr = arr;
+  unsigned int* srcPtr = &m_tmpBitStuffVec[0];
   unsigned int* dstPtr = &dataVec[0];
   int bitPos = 0;
 
@@ -431,11 +424,9 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
     }
   }
 
-  if (numBytesNotNeeded > 0)
-    memcpy(srcPtr, &lastUInt, sizeof(unsigned int));  // restore the last UInt
+  *ppByte += nBytesToCopy;
+  nBytesRemaining -= nBytesToCopy;
 
-  *ppByte += numBytes - numBytesNotNeeded;
-  nBytesRemaining -= numBytes - numBytesNotNeeded;
   return true;
 }
 

--- a/third_party/LercLib/BitStuffer2.cpp
+++ b/third_party/LercLib/BitStuffer2.cpp
@@ -363,12 +363,8 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
   unsigned long long numUIntsLL = ((unsigned long long)numElements * numBits + 31) / 32;
   unsigned long long numBytesLL = numUIntsLL * sizeof(unsigned int);
   size_t numBytes = (size_t)numBytesLL; // could theoretically overflow on 32 bit system
-  if (numBytes != numBytesLL)
-    return false;
   size_t numUInts = (size_t)numUIntsLL;
-
   unsigned int ntbnn = NumTailBytesNotNeeded(numElements, numBits);
-
   if (numBytes != numBytesLL || nBytesRemaining + ntbnn < numBytes)
     return false;
 

--- a/third_party/LercLib/BitStuffer2.h
+++ b/third_party/LercLib/BitStuffer2.h
@@ -53,7 +53,7 @@ private:
   mutable std::vector<unsigned int>  m_tmpLutVec, m_tmpIndexVec, m_tmpBitStuffVec;
 
   static void BitStuff_Before_Lerc2v3(Byte** ppByte, const std::vector<unsigned int>& dataVec, int numBits);
-  static bool BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits);
+  bool BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits) const;
   void BitStuff(Byte** ppByte, const std::vector<unsigned int>& dataVec, int numBits) const;
   bool BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits) const;
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Apply the LERC "fix v22 decode short blob" patch from Esri/lerc to the internal Lerc library source. 
https://github.com/Esri/lerc/pull/198

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
