### PR TITLE
CMake: add support for PostgreSQL 14 ...

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -582,7 +582,10 @@ gdal_check_package(NetCDF "Enable netCDF driver" CAN_DISABLE
 gdal_check_package(OGDI "Enable ogr_OGDI driver" CAN_DISABLE)
 # OpenCL warping gives different results than the ones expected by autotest, so disable it by default even if found.
 gdal_check_package(OpenCL "Enable OpenCL (may be used for warping)" DISABLED_BY_DEFAULT)
+
+set(PostgreSQL_ADDITIONAL_VERSIONS "14" CACHE STRING "Additional PostgreSQL versions to check")
 gdal_check_package(PostgreSQL "" CAN_DISABLE)
+
 gdal_check_package(FYBA "enable ogr_SOSI driver" CAN_DISABLE)
 # Assume liblzma from xzutils, skip expensive checks.
 set(LIBLZMA_HAS_AUTO_DECODER 1)

--- a/cmake/modules/GdalFindModulePath.cmake
+++ b/cmake/modules/GdalFindModulePath.cmake
@@ -3,7 +3,10 @@ list(INSERT CMAKE_MODULE_PATH 0
     "${CMAKE_CURRENT_LIST_DIR}/thirdparty")
 
 # Backported modules from cmake versions
-foreach(_version IN ITEMS 3.20 3.16 3.14 3.13 3.12)
+
+set(GDAL_VENDORED_FIND_MODULES_CMAKE_VERSIONS 3.20 3.16 3.14 3.13 3.12)
+
+foreach(_version IN LISTS GDAL_VENDORED_FIND_MODULES_CMAKE_VERSIONS)
     if(CMAKE_VERSION VERSION_LESS "${_version}")
         list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/${_version}")
     endif()

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -720,7 +720,8 @@ if (NOT GDAL_ENABLE_MACOSX_FRAMEWORK)
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/GdalFindModulePath.cmake"
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/DefineFindPackage2.cmake"
       DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/gdal/")
-    foreach(dir IN ITEMS packages thirdparty 3.20 3.16 3.14 3.13 3.12)
+    include(GdalFindModulePath)
+    foreach(dir IN LISTS GDAL_VENDORED_FIND_MODULES_CMAKE_VERSIONS ITEMS packages thirdparty)
       install(
         DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/${dir}"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/gdal")


### PR DESCRIPTION
... and avoid copy&paste related to CMake versions when installing a
static build.

I've submitted in https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7158
the addition of PG 14 so I've anticipated the updated module will be
available in CMake 3.24

Original credits to @jmckenna / https://github.com/MapServer/MapServer/pull/6509
