### PR TITLE
Improve configuration options documentation + small improvements

### DIFF
--- a/doc/source/drivers/vector/amigocloud.rst
+++ b/doc/source/drivers/vector/amigocloud.rst
@@ -55,15 +55,6 @@ For example: **"AmigoCloud:1234 datasets"**
     | 5551      | points
     | 5552      | lines
 
-Configuration options
----------------------
-
-The following configuration options are available :
-
--  AMIGOCLOUD_API_URL: defaults to https://www.amigocloud.com/api/v1.
-   Can be used to point to another server.
--  AMIGOCLOUD_API_KEY: see following paragraph.
-
 Authentication
 --------------
 
@@ -120,6 +111,15 @@ The following layer creation options are available:
    the layer name to be created. Defaults to NO.
 -  **GEOMETRY_NULLABLE**\ =YES/NO: Whether the values of the geometry
    column can be NULL. Defaults to YES.
+
+Configuration options
+---------------------
+
+The following configuration options are available:
+
+-  :decl_configoption:`AMIGOCLOUD_API_URL`: defaults to 
+   https://www.amigocloud.com/api/v1. Can be used to point to another server.
+-  :decl_configoption:`AMIGOCLOUD_API_KEY`: see following paragraph.
 
 Examples
 --------

--- a/doc/source/drivers/vector/amigocloud.rst
+++ b/doc/source/drivers/vector/amigocloud.rst
@@ -115,7 +115,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`AMIGOCLOUD_API_URL`: defaults to 

--- a/doc/source/drivers/vector/amigocloud.rst
+++ b/doc/source/drivers/vector/amigocloud.rst
@@ -115,7 +115,8 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following configuration options are available:
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`AMIGOCLOUD_API_URL`: defaults to 
    https://www.amigocloud.com/api/v1. Can be used to point to another server.

--- a/doc/source/drivers/vector/carto.rst
+++ b/doc/source/drivers/vector/carto.rst
@@ -39,17 +39,6 @@ Currently the following one is supported:
 
 If several parameters are specified, they must be separated by a space.
 
-Configuration options
----------------------
-
-The following configuration options are available :
-
--  CARTO_API_URL: defaults to https://[account_name].carto.com/api/v2/sql.
-   Can be used to point to another server.
--  CARTO_HTTPS: can be set to NO to use http:// protocol instead of
-   https:// (only if CARTO_API_URL is not defined).
--  CARTO_API_KEY: see following paragraph.
-
 Authentication
 --------------
 
@@ -78,7 +67,7 @@ Paging
 ------
 
 Features are retrieved from the server by chunks of 500 by default. This
-number can be altered with the CARTO_PAGE_SIZE configuration option.
+number can be altered with the :decl_configoption:`CARTO_PAGE_SIZE` configuration option.
 
 Write support
 -------------
@@ -160,6 +149,19 @@ The following layer creation options are available:
    are preserved. The default value is "YES". If enabled the table
    (layer) name will also be laundered.
 
+Configuration options
+---------------------
+
+The following configuration options are available :
+
+-  :decl_configoption:`CARTO_API_URL`: defaults to https://[account_name].carto.com/api/v2/sql.
+   Can be used to point to another server.
+-  :decl_configoption:`CARTO_HTTPS`: can be set to NO to use http:// protocol instead of
+   https:// (only if CARTO_API_URL is not defined).
+-  :decl_configoption:`CARTO_API_KEY`: see following paragraph.
+-  :decl_configoption:`CARTO_PAGE_SIZE`: features are retrieved from the server by chunks 
+   of 500 by default. This number can be altered with the configuration option.
+   
 Examples
 --------
 

--- a/doc/source/drivers/vector/carto.rst
+++ b/doc/source/drivers/vector/carto.rst
@@ -152,7 +152,8 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following configuration options are available :
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`CARTO_API_URL`: defaults to https://[account_name].carto.com/api/v2/sql.
    Can be used to point to another server.

--- a/doc/source/drivers/vector/carto.rst
+++ b/doc/source/drivers/vector/carto.rst
@@ -152,7 +152,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`CARTO_API_URL`: defaults to https://[account_name].carto.com/api/v2/sql.

--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -370,7 +370,7 @@ Layer Creation options
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`OGR_WKT_PRECISION` =int: Number of decimals for coordinate

--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -240,6 +240,16 @@ AS float))) FROM test GROUP BY way_id"* will return :
      way_id (String) = 2
      LINESTRING (-2 49,-3 50)
 
+VSI Virtual File System API support
+-----------------------------------
+
+The driver supports reading and writing to files managed by VSI Virtual
+File System API, which include "regular" files, as well as files in the
+/vsizip/ (read-write) , /vsigzip/ (read-only) , /vsicurl/ (read-only)
+domains.
+
+Writing to /dev/stdout or /vsistdout/ is also supported.
+
 Open options
 ------------
 
@@ -322,7 +332,8 @@ deleting or replacing existing features, or adding/modifying/deleting
 fields is supported, provided the modifications done are small enough to
 be stored in RAM temporarily before flushing to disk.
 
-Layer Creation options:
+Layer Creation options
+----------------------
 
 -  **LINEFORMAT**: By default when creating new .csv files they are
    created with the line termination conventions of the local platform
@@ -356,26 +367,17 @@ Layer Creation options:
    IF_NEEDED). Defaults to IF_AMBIGUOUS (behavior in older versions was
    IF_NEEDED)
 
-Configuration options (set with ``--config key value`` on command line
-utilities):
+Configuration options
+---------------------
+They can be set with ``--config key value`` on command line utilities.
 
--  **OGR_WKT_PRECISION**\ =int: Number of decimals for coordinate
+-  :decl_configoption:`OGR_WKT_PRECISION` =int: Number of decimals for coordinate
    values. Default to 15. A heuristics is used to remove insignificant
    trailing 00000x or 99999x that can appear when formatting decimal
    numbers.
--  **OGR_WKT_ROUND**\ =YES/NO: (GDAL >= 2.3) Whether to enable the above
+-  :decl_configoption:`OGR_WKT_ROUND` =YES/NO: (GDAL >= 2.3) Whether to enable the above
    mentioned heuristics to remove insignificant trailing 00000x or
    99999x. Default to YES.
-
-VSI Virtual File System API support
------------------------------------
-
-The driver supports reading and writing to files managed by VSI Virtual
-File System API, which include "regular" files, as well as files in the
-/vsizip/ (read-write) , /vsigzip/ (read-only) , /vsicurl/ (read-only)
-domains.
-
-Writing to /dev/stdout or /vsistdout/ is also supported.
 
 Examples
 ~~~~~~~~

--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -369,7 +369,9 @@ Layer Creation options
 
 Configuration options
 ---------------------
-They can be set with ``--config key value`` on command line utilities.
+
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`OGR_WKT_PRECISION` =int: Number of decimals for coordinate
    values. Default to 15. A heuristics is used to remove insignificant

--- a/doc/source/drivers/vector/csw.rst
+++ b/doc/source/drivers/vector/csw.rst
@@ -69,7 +69,7 @@ Open options
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`GML_INVERT_AXIS_ORDER_IF_LAT_LONG=NO`: Some servers 

--- a/doc/source/drivers/vector/csw.rst
+++ b/doc/source/drivers/vector/csw.rst
@@ -26,7 +26,28 @@ Dataset name syntax
 The minimal syntax to open a CSW datasource is : *CSW:* and the URL open
 option, or *CSW:http://path/to/CSW/endpoint*
 
-The following open options are available:
+Filtering
+---------
+
+The driver will forward any spatial filter set with SetSpatialFilter()
+to the server. It also makes its best effort to do the same for
+attribute filters set with SetAttributeFilter() when possible (turning
+OGR SQL language into OGC filter description).
+
+The *anytext* field can be queried to do a search in any text field.
+Note that we always return it as null content however in OGR side, to
+avoid duplicating information.
+
+Issues
+------
+
+Some servers do not respect EPSG axis order, in particular latitude,
+longitude order for WGS 84 geodetic coordinates, so it might be needed
+to specify the :decl_configoption:`GML_INVERT_AXIS_ORDER_IF_LAT_LONG=NO` 
+configuration option in those cases.
+
+Open options
+------------
 
 -  **URL**: URL to the CSW server endpoint (if not specified in the
    connection string already)
@@ -45,25 +66,13 @@ The following open options are available:
    single time. Defaults to 500. Servers might have a lower accepted
    value.
 
-Filtering
----------
+Configuration options
+---------------------
 
-The driver will forward any spatial filter set with SetSpatialFilter()
-to the server. It also makes its best effort to do the same for
-attribute filters set with SetAttributeFilter() when possible (turning
-OGR SQL language into OGC filter description).
-
-The *anytext* field can be queried to do a search in any text field.
-Note that we always return it as null content however in OGR side, to
-avoid duplicating information.
-
-Issues
-------
-
-Some servers do not respect EPSG axis order, in particular latitude,
-longitude order for WGS 84 geodetic coordinates, so it might be needed
-to specify the GML_INVERT_AXIS_ORDER_IF_LAT_LONG=NO configuration option
-in those cases.
+-  :decl_configoption:`GML_INVERT_AXIS_ORDER_IF_LAT_LONG=NO`: Some servers 
+   do not respect EPSG axis order, in particular latitude,
+   longitude order for WGS 84 geodetic coordinates, so it might be needed
+   to specify the  configuration option in those cases.
 
 Examples
 --------

--- a/doc/source/drivers/vector/csw.rst
+++ b/doc/source/drivers/vector/csw.rst
@@ -69,6 +69,9 @@ Open options
 Configuration options
 ---------------------
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 -  :decl_configoption:`GML_INVERT_AXIS_ORDER_IF_LAT_LONG=NO`: Some servers 
    do not respect EPSG axis order, in particular latitude,
    longitude order for WGS 84 geodetic coordinates, so it might be needed

--- a/doc/source/drivers/vector/dgn.rst
+++ b/doc/source/drivers/vector/dgn.rst
@@ -122,7 +122,8 @@ Creation Issues
 -  DGN files can only have one layer. Attempts to create more than one
    layer in a DGN file will fail.
 
-The dataset creation supports the following options:
+Dataset creation options
+------------------------
 
 -  **3D=**\ *YES* or *NO*: Determine whether 2D (seed_2d.dgn) or 3D
    (seed_3d.dgn) seed file should be used. This option is ignored if the

--- a/doc/source/drivers/vector/dgnv8.rst
+++ b/doc/source/drivers/vector/dgnv8.rst
@@ -113,7 +113,8 @@ DGN files may be written with OGR with limitations:
 -  Geometries which fall outside the "design plane" of the seed file
    will be discarded, or corrupted in unpredictable ways.
 
-The dataset creation supports the following options:
+Dataset creation options
+------------------------
 
 -  **SEED=**\ *filename*: Specify the seed file to use.
 -  **COPY_SEED_FILE_COLOR_TABLE=**\ *YES/NO*: Indicates whether the
@@ -154,7 +155,8 @@ The dataset creation supports the following options:
 -  **COMPANY=**\ *string*: Set Company field in header. If not
    specified, from the seed file.
 
-The layer creation supports the following options:
+Layer creation options
+----------------------
 
 -  **DESCRIPTION=**\ *string*: Description associated with the layer. If
    not specified, from the seed file.

--- a/doc/source/drivers/vector/dwg.rst
+++ b/doc/source/drivers/vector/dwg.rst
@@ -34,6 +34,9 @@ styles or complex line style attributes.
 Configuration options
 ---------------------
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 - :decl_configoption:`OGR_ARC_STEPSIZE`: The approximation of arcs, 
   ellipses, circles and rounded polylines as linestrings is done by 
   splitting the arcs into subarcs of no more than a threshold angle. 

--- a/doc/source/drivers/vector/dwg.rst
+++ b/doc/source/drivers/vector/dwg.rst
@@ -31,50 +31,48 @@ size and orientation via OGR feature styling information when
 translating elements. Currently no effort is made to preserve fill
 styles or complex line style attributes.
 
-The approximation of arcs, ellipses, circles and rounded polylines as
-linestrings is done by splitting the arcs into subarcs of no more than a
-threshold angle. This angle is the OGR_ARC_STEPSIZE. This defaults to
-four degrees, but may be overridden by setting the configuration
-variable OGR_ARC_STEPSIZE.
+Configuration options
+---------------------
 
-DWG_INLINE_BLOCKS
------------------
+- :decl_configoption:`OGR_ARC_STEPSIZE`: The approximation of arcs, 
+  ellipses, circles and rounded polylines as linestrings is done by 
+  splitting the arcs into subarcs of no more than a threshold angle. 
+  This angle is the OGR_ARC_STEPSIZE. This defaults to four degrees, 
+  but may be overridden by setting the configuration variable.
 
-The default behavior is for block references to be expanded with the
-geometry of the block they reference. However, if the DWG_INLINE_BLOCKS
-configuration option is set to the value FALSE, then the behavior is
-different as described here.
+- :decl_configoption:`DWG_INLINE_BLOCKS`: The default behavior is for 
+  block references to be expanded with the geometry of the block they 
+  reference. However, if the :decl_configoption:`DWG_INLINE_BLOCKS` 
+  configuration option is set to the value FALSE, then the behavior is 
+  different as described here:
 
--  A new layer will be available called blocks. It will contain one or
-   more features for each block defined in the file. In addition to the
-   usual attributes, they will also have a BlockName attribute indicate
-   what block they are part of.
--  The entities layer will have new attributes BlockName, BlockScale, 
-   BlockAngle and BlockAttributes.
--  BlockAttributes will be a list of (tag x value) pairs of all 
-   visible attributes (JSON encoded).
--  block referenced will populate these new fields with the
-   corresponding information (they are null for all other entities).
--  block references will not have block geometry inlined - instead they
-   will have a point geometry for the insertion point.
+  - A new layer will be available called blocks. It will contain one or
+    more features for each block defined in the file. In addition to the
+    usual attributes, they will also have a BlockName attribute indicate
+    what block they are part of.
+  - The entities layer will have new attributes BlockName, BlockScale, 
+    BlockAngle and BlockAttributes.
+  - BlockAttributes will be a list of (tag x value) pairs of all 
+    visible attributes (JSON encoded).
+  - block referenced will populate these new fields with the
+    corresponding information (they are null for all other entities).
+  - block references will not have block geometry inlined - instead they
+    will have a point geometry for the insertion point.
 
-The intention is that with DWG_INLINE_BLOCKS disabled, the block
-references will remain as references and the original block definitions
-will be available via the blocks layer.
+  The intention is that with :decl_configoption:`DWG_INLINE_BLOCKS` 
+  disabled, the block references will remain as references and the 
+  original block definitions will be available via the blocks layer.
 
-DWG_ATTRIBUTES
---------------
+- :decl_configoption:`DWG_ATTRIBUTES`: If option is set to TRUE value, 
+  then block attributes are treated as feature attributes, one feature 
+  attribute for each tag. This option allow conversion to rows and 
+  columns data such as database tables.
 
-If option is set to TRUE value, then block attributes are treated as
-feature attributes, one feature attribute for each tag. This option allow
-conversion to rows and columns data such as database tables
-
-DWG_ALL_ATTRIBUTES
-------------------
-
-If option is set to FALSE value, then block attributes are ignored if the
-visible property of the tag attribute is false. To see all attributes set
-DWG_ALL_ATTRIBUTES to TRUE value (this is the default value)
+- :decl_configoption:`DWG_ALL_ATTRIBUTES`: If option is set to FALSE value, 
+  then block attributes are ignored if the visible property of the tag 
+  attribute is false. To see all attributes set 
+  :decl_configoption:`DWG_ALL_ATTRIBUTES` to TRUE value (this is the 
+  default value).
 
 Building
 --------

--- a/doc/source/drivers/vector/dwg.rst
+++ b/doc/source/drivers/vector/dwg.rst
@@ -34,7 +34,7 @@ styles or complex line style attributes.
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 - :decl_configoption:`OGR_ARC_STEPSIZE`: The approximation of arcs, 

--- a/doc/source/drivers/vector/eeda.rst
+++ b/doc/source/drivers/vector/eeda.rst
@@ -60,23 +60,23 @@ Configuration options
 
 The following configuration options are available:
 
--  :decl_configoption:`EEDA_BEARER`\ =value: Authentication Bearer value to pass to the
+-  :decl_configoption:`EEDA_BEARER` =value: Authentication Bearer value to pass to the
    API. This option is only useful when the token is computed by
    external code. The bearer validity is typically one hour from the
    time where it as been requested.
--  :decl_configoption:`EEDA_BEARER_FILE`\ =filename: Similar to EEDA_BEARER option,
+-  :decl_configoption:`EEDA_BEARER_FILE` =filename: Similar to EEDA_BEARER option,
    except than instead of passing the value directly, it is the filename
    where the value should be read.
--  :decl_configoption:`GOOGLE_APPLICATION_CREDENTIALS`\ =file.json: Service account
+-  :decl_configoption:`GOOGLE_APPLICATION_CREDENTIALS` =file.json: Service account
    private key file that contains a private key and client email
--  :decl_configoption:`EEDA_PRIVATE_KEY`\ =string: RSA private key encoded as a PKCS#8
+-  :decl_configoption:`EEDA_PRIVATE_KEY` =string: RSA private key encoded as a PKCS#8
    PEM file, with its header and footer. Used together with
    :decl_configoption:`EEDA_CLIENT_EMAIL` to use OAuth2 Service Account authentication.
    Requires GDAL to be built against libcrypto++ or libssl.
--  :decl_configoption:`EEDA_PRIVATE_KEY_FILE`\ =filename: Similar to 
+-  :decl_configoption:`EEDA_PRIVATE_KEY_FILE` =filename: Similar to 
    :decl_configoption:`EEDA_PRIVATE_KEY` option, except than instead of passing the 
    value directly, it is the filename where the key should be read.
--  :decl_configoption:`EEDA_CLIENT_EMAIL`\ =string: email to be specified together with
+-  :decl_configoption:`EEDA_CLIENT_EMAIL` =string: email to be specified together with
    EEDA_PRIVATE_KEY/EEDA_PRIVATE_KEY_FILE to use OAuth2 Service Account
    authentication.
 -  :decl_configoption:`EEDA_PAGE_SIZE`: Features are retrieved from the server by chunks 

--- a/doc/source/drivers/vector/eeda.rst
+++ b/doc/source/drivers/vector/eeda.rst
@@ -61,7 +61,7 @@ The following authentication methods can be used:
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`EEDA_BEARER` =value: Authentication Bearer value to pass to the

--- a/doc/source/drivers/vector/eeda.rst
+++ b/doc/source/drivers/vector/eeda.rst
@@ -61,7 +61,7 @@ The following authentication methods can be used:
 Configuration options
 ---------------------
 
-The following :ref:`configuration options <user/configoptions>` are available:
+The following configuration options are available:
 
 -  :decl_configoption:`EEDA_BEARER` =value: Authentication Bearer value to pass to the
    API. This option is only useful when the token is computed by

--- a/doc/source/drivers/vector/eeda.rst
+++ b/doc/source/drivers/vector/eeda.rst
@@ -20,7 +20,7 @@ Driver capabilities
 Dataset name syntax
 -------------------
 
-The minimal syntax to open a datasource is :
+The minimal syntax to open a datasource is:
 
 ::
 
@@ -32,7 +32,7 @@ projects/earthengine-public/assets/COPERNICUS/S2.
 Open options
 ------------
 
-The following open options are available :
+The following open options are available:
 
 -  **COLLECTION**\ =string: To specify the collection if not specified
    in the connection string.
@@ -43,22 +43,25 @@ Authentication methods
 The following authentication methods can be used:
 
 -  Authentication Bearer header passed through the EEDA_BEARER or
-   EEDA_BEARER_FILE configuration options.
+   :decl_configoption:`EEDA_BEARER_FILE` configuration options.
 -  Service account private key file, through the
-   GOOGLE_APPLICATION_CREDENTIALS configuration option.
--  OAuth2 Service Account authentication through the EEDA_PRIVATE_KEY/
-   EEDA_PRIVATE_KEY_FILE + EEDA_CLIENT_EMAIL configuration options.
+   :decl_configoption:`GOOGLE_APPLICATION_CREDENTIALS` configuration option.
+-  OAuth2 Service Account authentication through the 
+   :decl_configoption:`EEDA_PRIVATE_KEY`/
+   :decl_configoption:`EEDA_PRIVATE_KEY_FILE` + 
+   :decl_configoption:`EEDA_CLIENT_EMAIL` configuration options.
 -  Finally if none of the above method succeeds, the code will check if
    the current machine is a Google Compute Engine instance, and if so
    will use the permissions associated to it (using the default service
    account associated with the VM). To force a machine to be detected as
    a GCE instance (for example for code running in a container with no
-   access to the boot logs), you can set CPL_MACHINE_IS_GCE to YES.
+   access to the boot logs), you can set 
+   :decl_configoption:`CPL_MACHINE_IS_GCE` to YES.
 
 Configuration options
 ---------------------
 
-The following configuration options are available:
+The following :ref:`configuration options <user/configoptions>` are available:
 
 -  :decl_configoption:`EEDA_BEARER` =value: Authentication Bearer value to pass to the
    API. This option is only useful when the token is computed by

--- a/doc/source/drivers/vector/eeda.rst
+++ b/doc/source/drivers/vector/eeda.rst
@@ -61,7 +61,8 @@ The following authentication methods can be used:
 Configuration options
 ---------------------
 
-The following configuration options are available:
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`EEDA_BEARER` =value: Authentication Bearer value to pass to the
    API. This option is only useful when the token is computed by

--- a/doc/source/drivers/vector/eeda.rst
+++ b/doc/source/drivers/vector/eeda.rst
@@ -58,27 +58,30 @@ The following authentication methods can be used:
 Configuration options
 ---------------------
 
-The following configuration options are available :
+The following configuration options are available:
 
--  **EEDA_BEARER**\ =value: Authentication Bearer value to pass to the
+-  :decl_configoption:`EEDA_BEARER`\ =value: Authentication Bearer value to pass to the
    API. This option is only useful when the token is computed by
    external code. The bearer validity is typically one hour from the
    time where it as been requested.
--  **EEDA_BEARER_FILE**\ =filename: Similar to EEDA_BEARER option,
+-  :decl_configoption:`EEDA_BEARER_FILE`\ =filename: Similar to EEDA_BEARER option,
    except than instead of passing the value directly, it is the filename
    where the value should be read.
--  **GOOGLE_APPLICATION_CREDENTIALS**\ =file.json: Service account
+-  :decl_configoption:`GOOGLE_APPLICATION_CREDENTIALS`\ =file.json: Service account
    private key file that contains a private key and client email
--  **EEDA_PRIVATE_KEY**\ =string: RSA private key encoded as a PKCS#8
+-  :decl_configoption:`EEDA_PRIVATE_KEY`\ =string: RSA private key encoded as a PKCS#8
    PEM file, with its header and footer. Used together with
-   EEDA_CLIENT_EMAIL to use OAuth2 Service Account authentication.
+   :decl_configoption:`EEDA_CLIENT_EMAIL` to use OAuth2 Service Account authentication.
    Requires GDAL to be built against libcrypto++ or libssl.
--  **EEDA_PRIVATE_KEY_FILE**\ =filename: Similar to EEDA_PRIVATE_KEY
-   option, except than instead of passing the value directly, it is the
-   filename where the key should be read.
--  **EEDA_CLIENT_EMAIL**\ =string: email to be specified together with
+-  :decl_configoption:`EEDA_PRIVATE_KEY_FILE`\ =filename: Similar to 
+   :decl_configoption:`EEDA_PRIVATE_KEY` option, except than instead of passing the 
+   value directly, it is the filename where the key should be read.
+-  :decl_configoption:`EEDA_CLIENT_EMAIL`\ =string: email to be specified together with
    EEDA_PRIVATE_KEY/EEDA_PRIVATE_KEY_FILE to use OAuth2 Service Account
    authentication.
+-  :decl_configoption:`EEDA_PAGE_SIZE`: Features are retrieved from the server by chunks 
+   of 1000 by default (and this is the maximum value accepted by the server). This number 
+   can be altered with this configuration option.
 
 Attributes
 ----------
@@ -164,7 +167,7 @@ Paging
 
 Features are retrieved from the server by chunks of 1000 by default (and
 this is the maximum value accepted by the server). This number can be
-altered with the EEDA_PAGE_SIZE configuration option.
+altered with the :decl_configoption:`EEDA_PAGE_SIZE` configuration option.
 
 Extent and feature count
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/drivers/vector/elasticsearch.rst
+++ b/doc/source/drivers/vector/elasticsearch.rst
@@ -34,7 +34,8 @@ a dataset:
 -  Using *ES:http://hostname:port* (where port is typically 9200)
 -  Using *ES:* with the open options to specify HOST and PORT
 
-The open options available are :
+Layer open options
+------------------
 
 -  **HOST**\ =hostname: Server hostname. Default to localhost.
 -  **PORT**\ =port. Server port. Default to 9200.
@@ -102,27 +103,6 @@ with text fields within Elasticsearch.
 ::
 
    ogr2ogr -progress --config ES_WRITEMAP /path/to/file/map.txt -f "Elasticsearch" http://localhost:9200 my_shapefile.shp
-
-The Elasticsearch writer supports the following Configuration Options.
-Starting with GDAL 2.1, layer creation options are also available and
-should be preferred:
-
--  **ES_WRITEMAP**\ =/path/to/mapfile.txt. Creates a mapping file that
-   can be modified by the user prior to insert in to the index. No
-   feature will be written. Note that this will properly work only if
-   only one single layer is created. Starting with GDAL 2.1, the
-   **WRITE_MAPPING** layer creation option should rather be used.
--  **ES_META**\ =/path/to/mapfile.txt. Tells the driver to the
-   user-defined field mappings. Starting with GDAL 2.1, the **MAPPING**
-   layer creation option should rather be used.
--  **ES_BULK**\ =5000000. Identifies the maximum size in bytes of the
-   buffer to store documents to be inserted at a time. Lower record
-   counts help with memory consumption within Elasticsearch but take
-   longer to insert. Starting with GDAL 2.1, the **BULK_SIZE** layer
-   creation option should rather be used.
--  **ES_OVERWRITE**\ =1. Overwrites the current index by deleting an
-   existing one. Starting with GDAL 2.1, the **OVERWRITE** layer
-   creation option should rather be used.
 
 Geometry types
 --------------
@@ -495,6 +475,30 @@ options:
    in field name as sub-document. Defaults to YES.
 -  **IGNORE_SOURCE_ID**\ =YES/NO. Whether to ignore \_id field in
    features passed to CreateFeature(). Defaults to NO.
+
+Configuration options
+---------------------
+
+The Elasticsearch writer supports the following deeprecated configuration
+options. Starting with GDAL 2.1, layer creation options are also available 
+and should be preferred (see above):
+
+-  :decl_configoption:`ES_WRITEMAP`\ =/path/to/mapfile.txt. Creates a mapping file that
+   can be modified by the user prior to insert in to the index. No
+   feature will be written. Note that this will properly work only if
+   only one single layer is created. Starting with GDAL 2.1, the
+   **WRITE_MAPPING** layer creation option should rather be used.
+-  :decl_configoption:`ES_META`\ =/path/to/mapfile.txt. Tells the driver to the
+   user-defined field mappings. Starting with GDAL 2.1, the **MAPPING**
+   layer creation option should rather be used.
+-  :decl_configoption:`ES_BULK`\ =5000000. Identifies the maximum size in bytes of the
+   buffer to store documents to be inserted at a time. Lower record
+   counts help with memory consumption within Elasticsearch but take
+   longer to insert. Starting with GDAL 2.1, the **BULK_SIZE** layer
+   creation option should rather be used.
+-  :decl_configoption:`ES_OVERWRITE`\ =1. Overwrites the current index by deleting an
+   existing one. Starting with GDAL 2.1, the **OVERWRITE** layer
+   creation option should rather be used.
 
 Examples
 --------

--- a/doc/source/drivers/vector/elasticsearch.rst
+++ b/doc/source/drivers/vector/elasticsearch.rst
@@ -479,8 +479,8 @@ options:
 Configuration options
 ---------------------
 
-The Elasticsearch writer supports the following deeprecated configuration
-options. Starting with GDAL 2.1, layer creation options are also available 
+The following (deprecated) :doc:`configuration options <../../user/configoptions>` are 
+available. Starting with GDAL 2.1, layer creation options are also available 
 and should be preferred (see above):
 
 -  :decl_configoption:`ES_WRITEMAP` =/path/to/mapfile.txt. Creates a mapping file that

--- a/doc/source/drivers/vector/elasticsearch.rst
+++ b/doc/source/drivers/vector/elasticsearch.rst
@@ -479,7 +479,7 @@ options:
 Configuration options
 ---------------------
 
-The following (deprecated) :doc:`configuration options <../../user/configoptions>` are 
+The following (deprecated) :ref:`configuration options <configoptions>` are 
 available. Starting with GDAL 2.1, layer creation options are also available 
 and should be preferred (see above):
 

--- a/doc/source/drivers/vector/elasticsearch.rst
+++ b/doc/source/drivers/vector/elasticsearch.rst
@@ -483,20 +483,20 @@ The Elasticsearch writer supports the following deeprecated configuration
 options. Starting with GDAL 2.1, layer creation options are also available 
 and should be preferred (see above):
 
--  :decl_configoption:`ES_WRITEMAP`\ =/path/to/mapfile.txt. Creates a mapping file that
+-  :decl_configoption:`ES_WRITEMAP` =/path/to/mapfile.txt. Creates a mapping file that
    can be modified by the user prior to insert in to the index. No
    feature will be written. Note that this will properly work only if
    only one single layer is created. Starting with GDAL 2.1, the
    **WRITE_MAPPING** layer creation option should rather be used.
--  :decl_configoption:`ES_META`\ =/path/to/mapfile.txt. Tells the driver to the
+-  :decl_configoption:`ES_META` =/path/to/mapfile.txt. Tells the driver to the
    user-defined field mappings. Starting with GDAL 2.1, the **MAPPING**
    layer creation option should rather be used.
--  :decl_configoption:`ES_BULK`\ =5000000. Identifies the maximum size in bytes of the
+-  :decl_configoption:`ES_BULK` =5000000. Identifies the maximum size in bytes of the
    buffer to store documents to be inserted at a time. Lower record
    counts help with memory consumption within Elasticsearch but take
    longer to insert. Starting with GDAL 2.1, the **BULK_SIZE** layer
    creation option should rather be used.
--  :decl_configoption:`ES_OVERWRITE`\ =1. Overwrites the current index by deleting an
+-  :decl_configoption:`ES_OVERWRITE` =1. Overwrites the current index by deleting an
    existing one. Starting with GDAL 2.1, the **OVERWRITE** layer
    creation option should rather be used.
 

--- a/doc/source/drivers/vector/filegdb.rst
+++ b/doc/source/drivers/vector/filegdb.rst
@@ -33,7 +33,7 @@ Curve in geometries are supported on reading with GDAL >= 2.2.
 Bulk feature loading
 --------------------
 
-The FGDB_BULK_LOAD configuration option can be set to YES to speed-up
+The :decl_configoption:`FGDB_BULK_LOAD` configuration option can be set to YES to speed-up
 feature insertion (or sometimes solve problems when inserting a lot of
 features (see http://trac.osgeo.org/gdal/ticket/4420). The effect of
 this configuration option is to cause a write lock to be taken and a
@@ -169,6 +169,17 @@ Layer Creation Options
 -  **CONFIGURATION_KEYWORD**\ =DEFAULTS/TEXT_UTF16/MAX_FILE_SIZE_4GB/MAX_FILE_SIZE_256TB/GEOMETRY_OUTOFLINE/BLOB_OUTOFLINE/GEOMETRY_AND_BLOB_OUTOFLINE
    : Customize how data is stored. By default text in
    UTF-8 and data up to 1TB
+
+Configuration options
+---------------------
+
+- :decl_configoption:`FGDB_BULK_LOAD` can be set to YES to speed-up
+  feature insertion (or sometimes solve problems when inserting a lot of
+  features (see http://trac.osgeo.org/gdal/ticket/4420). The effect of
+  this configuration option is to cause a write lock to be taken and a
+  temporary disabling of the indexes. Those are restored when the
+  datasource is closed or when a read operation is done. Bulk load is 
+  enabled by default for newly created layers (unless otherwise specified).
 
 Examples
 --------

--- a/doc/source/drivers/vector/filegdb.rst
+++ b/doc/source/drivers/vector/filegdb.rst
@@ -173,6 +173,9 @@ Layer Creation Options
 Configuration options
 ---------------------
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 - :decl_configoption:`FGDB_BULK_LOAD` can be set to YES to speed-up
   feature insertion (or sometimes solve problems when inserting a lot of
   features (see http://trac.osgeo.org/gdal/ticket/4420). The effect of

--- a/doc/source/drivers/vector/filegdb.rst
+++ b/doc/source/drivers/vector/filegdb.rst
@@ -173,7 +173,7 @@ Layer Creation Options
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 - :decl_configoption:`FGDB_BULK_LOAD` can be set to YES to speed-up

--- a/doc/source/drivers/vector/geoconcept.rst
+++ b/doc/source/drivers/vector/geoconcept.rst
@@ -81,76 +81,76 @@ The OGR GeoConcept driver does not support deleting features.
 Dataset Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-**EXTENSION=TXT|GXT** : indicates the GeoConcept export file extension.
-``TXT`` was used by earlier releases of GeoConcept. ``GXT`` is currently
-used.
+-  **EXTENSION=TXT|GXT** : indicates the GeoConcept export file extension.
+   ``TXT`` was used by earlier releases of GeoConcept. ``GXT`` is currently
+   used.
 
-**CONFIG=path to the GCT** : the GCT file describe the GeoConcept types
-definitions : In this file, every line must start with ``//#`` followed
-by a keyword. Lines starting with ``//`` are comments.
+-  **CONFIG=path to the GCT** : the GCT file describe the GeoConcept types
+   definitions : In this file, every line must start with ``//#`` followed
+   by a keyword. Lines starting with ``//`` are comments.
 
-It is important to note that a GeoConcept export file can hold different
-types and associated sub-types.
+   It is important to note that a GeoConcept export file can hold different
+   types and associated sub-types.
 
--  configuration section : the GCT file starts with
-   ``//#SECTION CONFIG`` and ends with ``//#ENDSECTION CONFIG``. All the
-   configuration is enclosed within these marks.
--  map section : purely for documentation at the time of writing this
-   document. This section starts with ``//#SECTION MAP`` and ends with
-   ``//#ENDSECTION MAP``.
--  type section : this section defines a class of features. A type has a
-   name (keyword ``Name``) and an ID (keyword ``ID``). A type holds
-   sub-types and fields. This section starts with ``//#SECTION TYPE``
-   and ends with ``//#ENDSECTION TYPE``.
+   -  configuration section : the GCT file starts with
+      ``//#SECTION CONFIG`` and ends with ``//#ENDSECTION CONFIG``. All the
+      configuration is enclosed within these marks.
+   -  map section : purely for documentation at the time of writing this
+      document. This section starts with ``//#SECTION MAP`` and ends with
+      ``//#ENDSECTION MAP``.
+   -  type section : this section defines a class of features. A type has a
+      name (keyword ``Name``) and an ID (keyword ``ID``). A type holds
+      sub-types and fields. This section starts with ``//#SECTION TYPE``
+      and ends with ``//#ENDSECTION TYPE``.
 
-   -  sub-type section : this sub-section defines a kind og features
-      within a class. A sub-type has a name (keyword ``Name``), an ID
-      (keyword ``ID``), a type of geometry (keyword ``Kind``) and a
-      dimension. The following types of geometry are supported : POINT,
-      LINE, POLYGON. The current release of this driver does not support
-      the TEXT geometry. The dimension can be 2D, 3DM or 3D. A sub-type
-      holds fields. This section starts with ``//#SECTION SUBTYPE`` and
-      ends with ``//#ENDSECTION SUBTYPE``.
+      -  sub-type section : this sub-section defines a kind og features
+         within a class. A sub-type has a name (keyword ``Name``), an ID
+         (keyword ``ID``), a type of geometry (keyword ``Kind``) and a
+         dimension. The following types of geometry are supported : POINT,
+         LINE, POLYGON. The current release of this driver does not support
+         the TEXT geometry. The dimension can be 2D, 3DM or 3D. A sub-type
+         holds fields. This section starts with ``//#SECTION SUBTYPE`` and
+         ends with ``//#ENDSECTION SUBTYPE``.
 
-      -  fields section : defines user fields. A field has a name
-         (keyword ``Name``), an ID (keyword ``ID``), a type (keyword
-         ``Kind``). The following types of fields are supported : INT,
-         REAL, MEMO, CHOICE, DATE, TIME, LENGTH, AREA. This section
-         starts with ``//#SECTION FIELD`` and ends with
-         ``//#ENDSECTION FIELD``.
+         -  fields section : defines user fields. A field has a name
+            (keyword ``Name``), an ID (keyword ``ID``), a type (keyword
+            ``Kind``). The following types of fields are supported : INT,
+            REAL, MEMO, CHOICE, DATE, TIME, LENGTH, AREA. This section
+            starts with ``//#SECTION FIELD`` and ends with
+            ``//#ENDSECTION FIELD``.
 
-   -  field section : defines type fields. See above.
+      -  field section : defines type fields. See above.
 
--  field section : defines general fields. Out of these, the following
-   rules apply :
+   -  field section : defines general fields. Out of these, the following
+      rules apply :
+ 
+      -  private field names start with a '@' : the private fields are
+         ``Identifier``, ``Class``, ``Subclass``, ``Name``, ``NbFields``,
+         ``X``, ``Y``, ``XP``, ``YP``, ``Graphics``, ``Angle``.
+      -  some private field are mandatory (they must appear in the
+         configuration) : ``Identifier``, ``Class``, ``Subclass``,
+         ``Name``, ``X``, ``Y``.
+      -  If the sub-type is linear (LINE), then the following fields must
+         be declared ``XP``, ``YP``.
+      -  If the sub-type is linear or polygonal (LINE, POLY), then
+         ``Graphics`` must be declared.
+      -  If the sub-type is ponctual or textual (POINT, TEXT), the
+         ``Angle`` may be declared.
 
-   -  private field names start with a '@' : the private fields are
-      ``Identifier``, ``Class``, ``Subclass``, ``Name``, ``NbFields``,
-      ``X``, ``Y``, ``XP``, ``YP``, ``Graphics``, ``Angle``.
-   -  some private field are mandatory (they must appear in the
-      configuration) : ``Identifier``, ``Class``, ``Subclass``,
-      ``Name``, ``X``, ``Y``.
-   -  If the sub-type is linear (LINE), then the following fields must
-      be declared ``XP``, ``YP``.
-   -  If the sub-type is linear or polygonal (LINE, POLY), then
-      ``Graphics`` must be declared.
-   -  If the sub-type is ponctual or textual (POINT, TEXT), the
-      ``Angle`` may be declared.
-
-   When this option is not used, the driver manage types and sub-types
-   name based on either the layer name or on the use of ``-nln`` option.
+      When this option is not used, the driver manage types and sub-types
+      name based on either the layer name or on the use of ``-nln`` option.
 
 Layer Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
-**FEATURETYPE=TYPE.SUBTYPE** : defines the feature to be created. The
-``TYPE`` corresponds to one of the ``Name`` found in the GCT file for a
-type section. The ``SUBTYPE`` corresponds to one of the ``Name`` found
-in the GCT file for a sub-type section within the previous type section.
+-  **FEATURETYPE=TYPE.SUBTYPE** : defines the feature to be created. The
+   ``TYPE`` corresponds to one of the ``Name`` found in the GCT file for a
+   type section. The ``SUBTYPE`` corresponds to one of the ``Name`` found
+   in the GCT file for a sub-type section within the previous type section.
 
-At the present moment, coordinates are written with 2 decimals for
-Cartesian spatial reference systems (including height) or with 9
-decimals for geographical spatial reference systems.
+   At the present moment, coordinates are written with 2 decimals for
+   Cartesian spatial reference systems (including height) or with 9
+   decimals for geographical spatial reference systems.
 
 Examples
 ~~~~~~~~

--- a/doc/source/drivers/vector/geojson.rst
+++ b/doc/source/drivers/vector/geojson.rst
@@ -147,11 +147,14 @@ the :decl_configoption:`GEOMETRY_AS_COLLECTION` configuration option to YES
 Configuration options
 ---------------------
 
--  :decl_configoption:`GEOMETRY_AS_COLLECTION` - used to control translation of
-   geometries: YES - wrap geometries with OGRGeometryCollection type
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
+-  :decl_configoption:`GEOMETRY_AS_COLLECTION`: used to control translation of
+   geometries: YES: wrap geometries with OGRGeometryCollection type
 -  :decl_configoption:`ATTRIBUTES_SKIP` - controls translation of attributes:
    YES - skip all attributes
--  :decl_configoption:`OGR_GEOJSON_MAX_OBJ_SIZE` - (GDAL >= 3.0.2) size in
+-  :decl_configoption:`OGR_GEOJSON_MAX_OBJ_SIZE` (GDAL >= 3.0.2): size in
    MBytes of the maximum accepted single feature, default value is 200MB
 
 Open options

--- a/doc/source/drivers/vector/geojson.rst
+++ b/doc/source/drivers/vector/geojson.rst
@@ -147,7 +147,7 @@ the :decl_configoption:`GEOMETRY_AS_COLLECTION` configuration option to YES
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`GEOMETRY_AS_COLLECTION`: used to control translation of

--- a/doc/source/drivers/vector/geojson.rst
+++ b/doc/source/drivers/vector/geojson.rst
@@ -111,9 +111,10 @@ Schema detection will recognized fields of type String, Integer, Real,
 StringList, IntegerList and RealList, Integer(Boolean), Date, Time and DateTime.
 
 It is possible to tell the driver to not to process attributes by
-setting environment variable **ATTRIBUTES_SKIP=YES**. Default behavior
-is to preserve all attributes (as an union, see previous paragraph),
-what is equal to setting **ATTRIBUTES_SKIP=NO**.
+setting configuration option :decl_configoption:`ATTRIBUTES_SKIP` =YES. 
+Default behavior is to preserve all attributes (as an union, see 
+previous paragraph), what is equal to setting 
+:decl_configoption:`ATTRIBUTES_SKIP` =NO.
 
 If the NATIVE_DATA open option is set to YES, the Feature JSon object
 will be stored as a serialized JSon object in the NativeData property of
@@ -143,7 +144,7 @@ as a common denominator. This behavior may be controlled by setting
 the :decl_configoption:`GEOMETRY_AS_COLLECTION` configuration option to YES
 (default is NO).
 
-configuration options
+Configuration options
 ---------------------
 
 -  :decl_configoption:`GEOMETRY_AS_COLLECTION` - used to control translation of

--- a/doc/source/drivers/vector/georss.rst
+++ b/doc/source/drivers/vector/georss.rst
@@ -143,7 +143,8 @@ Supported geometries :
 
 Other type of geometries are not supported and will be silently ignored.
 
-The GeoRSS writer supports the following *dataset* creation options:
+Dataset creation options
+------------------------
 
 -  **FORMAT**\ =RSS|ATOM: whether the document must be in RSS 2.0 or
    Atom 1.0 format. Default value : RSS

--- a/doc/source/drivers/vector/gml.rst
+++ b/doc/source/drivers/vector/gml.rst
@@ -127,10 +127,10 @@ The :decl_configoption:`GML_ATTRIBUTES_TO_OGR_FIELDS`
 configuration option can be set to **YES** so that attributes of GML
 elements are also taken into account to create OGR fields.
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
-:doc:`Configuration options <../../user/configoptions>` can e.g. be set via 
+:ref:`configuration options <configoptions>` can e.g. be set via 
 the CPLSetConfigOption() function or as environment variables.
 
 You can use :decl_configoption:`GML_GFS_TEMPLATE` configuration option 

--- a/doc/source/drivers/vector/gml.rst
+++ b/doc/source/drivers/vector/gml.rst
@@ -46,7 +46,7 @@ build time, the GML driver will preferentially select at runtime the
 Expat parser for cases where it is possible (GML file in a compatible
 encoding), and default back to Xerces parser in other cases. However,
 the choice of the parser can be overridden by specifying the
-**GML_PARSER** configuration option to **EXPAT** or **XERCES**.
+:decl_configoption:`GML_PARSER` configuration option to **EXPAT** or **XERCES**.
 
 CRS support
 -----------
@@ -63,21 +63,22 @@ driver will swap the coordinates so that they are in the (longitude,
 latitude) order and report a SRS without axis order specified. It is
 possible to get the original (latitude, longitude) order and SRS with
 axis order by setting the configuration option
-**GML_INVERT_AXIS_ORDER_IF_LAT_LONG** to **NO**.
+:decl_configoption:`GML_INVERT_AXIS_ORDER_IF_LAT_LONG` to **NO**.
 
 There also situations where the srsName is of the form "EPSG:XXXX"
 (whereas "urn:ogc:def:crs:EPSG::XXXX" would have been more explicit on
 the intent) and the coordinates in the file are in (latitude, longitude)
 order. By default, OGR will not consider the EPSG axis order and will
 report the coordinates in (latitude,longitude) order. However, if you
-set the configuration option **GML_CONSIDER_EPSG_AS_URN** to **YES**,
-the rules explained in the previous paragraph will be applied.
+set the configuration option :decl_configoption:`GML_CONSIDER_EPSG_AS_URN` 
+to **YES**, the rules explained in the previous paragraph will be applied.
 
 The above also applied for projected coordinate systems
 whose EPSG preferred axis order is (northing, easting).
 
 Starting with GDAL 2.1.2, the SWAP_COORDINATES open option (or
-GML_SWAP_COORDINATES configuration option) can be set to AUTO/YES/NO. It
+:decl_configoption:`GML_SWAP_COORDINATES` configuration option) can 
+be set to AUTO/YES/NO. It
 controls whether the order of the x/y or long/lat coordinates should be
 swapped. In AUTO mode, the driver will determine if swapping must be
 done from the srsName and value of other options like
@@ -120,23 +121,23 @@ When prescanning the GML file to determine the list of feature types,
 and fields, the contents of fields are scanned to try and determine the
 type of the field. In some applications it is easier if all fields are
 just treated as string fields. This can be accomplished by setting the
-configuration option **GML_FIELDTYPES** to the value **ALWAYS_STRING**.
+configuration option :decl_configoption:`GML_FIELDTYPES` to the value **ALWAYS_STRING**.
 
-The **GML_ATTRIBUTES_TO_OGR_FIELDS**
+The :decl_configoption:`GML_ATTRIBUTES_TO_OGR_FIELDS`
 configuration option can be set to **YES** so that attributes of GML
 elements are also taken into account to create OGR fields.
 
 Configuration options can be set via the CPLSetConfigOption() function
 or as environment variables.
 
-You can use **GML_GFS_TEMPLATE** configuration option (or **GFS_TEMPLATE**
-open option) set to a **path_to_template.gfs** in order
-to unconditionally use a predefined GFS file. This option is
+You can use :decl_configoption:`GML_GFS_TEMPLATE` configuration option 
+(or **GFS_TEMPLATE** open option) set to a **path_to_template.gfs** in 
+order to unconditionally use a predefined GFS file. This option is
 really useful when you are planning to import many distinct GML
 files in subsequent steps [**-append**] and you absolutely want to
 preserve a fully consistent data layout for the whole GML set.
 Please, pay attention not to use the **-lco LAUNDER=yes** setting
-when using **GML_GFS_TEMPLATE**; this should break the correct
+when using :decl_configoption:`GML_GFS_TEMPLATE`; this should break the correct
 recognition of attribute names between subsequent GML import runs.
 
 Particular GML application schemas
@@ -198,8 +199,8 @@ interpreted as either of two types of geometries. The Edge elements in
 it contain curves and their corresponding nodes. By default only the
 curves, the main geometries, are reported as OGRMultiLineString. To
 retrieve the nodes, as OGRMultiPoint, the configuration option
-**GML_GET_SECONDARY_GEOM** should be set to the value **YES**. When this
-is set only the secondary geometries are reported.
+:decl_configoption:`GML_GET_SECONDARY_GEOM` should be set to the value 
+**YES**. When this is set only the secondary geometries are reported.
 
 Arc, ArcString, ArcByBulge, ArcByCenterPoint,
 Circle and CircleByCenterPoints will be returned as circular string OGR
@@ -219,12 +220,12 @@ gml:xlink resolving is supported. When the resolver finds
 an element containing the tag xlink:href, it tries to find the
 corresponding element with the gml:id in the same gml file, other gml
 file in the file system or on the web using cURL. Set the configuration
-option **GML_SKIP_RESOLVE_ELEMS** to **NONE** to enable resolution.
+option :decl_configoption:`GML_SKIP_RESOLVE_ELEMS` to **NONE** to enable resolution.
 
 By default the resolved file will be saved in the same directory as the
 original file with the extension ".resolved.gml", if it doesn't exist
 already. This behavior can be changed using the configuration option
-**GML_SAVE_RESOLVED_TO**. Set it to **SAME** to overwrite the original
+:decl_configoption:`GML_SAVE_RESOLVED_TO`. Set it to **SAME** to overwrite the original
 file. Set it to a **filename ending with .gml** to save it to that
 location. Any other values are ignored. If the resolver cannot write to
 the file for any reason, it will try to save it to a temporary file
@@ -238,14 +239,14 @@ CPLDebug() for every 256 links. It can be seen by setting the
 environment variable CPL_DEBUG. The resolution time can be reduced if
 you know any elements that will not be needed. Mention a comma separated
 list of names of such elements with the configuration option
-**GML_SKIP_RESOLVE_ELEMS**. Set it to **ALL** to skip resolving
-altogether (default action). Set it to **NONE** to resolve all the
-xlinks.
+:decl_configoption:`GML_SKIP_RESOLVE_ELEMS`. Set it to **ALL** to skip 
+resolving altogether (default action). Set it to **NONE** to resolve all 
+the xlinks.
 
 An alternative resolution method is available.
 This alternative method will be activated using the configuration option
-**GML_SKIP_RESOLVE_ELEMS HUGE**. In this case any gml:xlink will be
-resolved using a temporary SQLite DB so to identify any corresponding
+:decl_configoption:`GML_SKIP_RESOLVE_ELEMS HUGE`. In this case any 
+gml:xlink will be resolved using a temporary SQLite DB so to identify any corresponding
 gml:id relation. At the end of this SQL-based process, a resolved file
 will be generated exactly as in the **NONE** case but without their
 limits. The main advantages in using an external (temporary) DBMS so to
@@ -301,14 +302,14 @@ interpretation supported by OGR.
 **NOTE** : Using the newest interpretation requires GDAL/OGR to be built
 against the GEOS library.
 
-Using the **GML_FACE_HOLE_NEGATIVE** configuration option you can anyway
-select the actual interpretation to be applied when parsing GML 3
-Topologies:
+Using the :decl_configoption:`GML_FACE_HOLE_NEGATIVE` configuration option 
+you can anyway select the actual interpretation to be applied when 
+parsing GML 3 topologies:
 
--  setting **GML_FACE_HOLE_NEGATIVE NO** (*default* option) will
-   activate the newest interpretation rule
--  but explicitly setting **GML_FACE_HOLE_NEGATIVE YES** still enables
-   to activate the old interpretation rule
+-  setting :decl_configoption:`GML_FACE_HOLE_NEGATIVE` =NO (*default* 
+   option) will activate the newest interpretation rule
+-  but explicitly setting :decl_configoption:`GML_FACE_HOLE_NEGATIVE` =YES 
+   still enables to activate the old interpretation rule
 
 Encoding issues
 ---------------
@@ -351,8 +352,10 @@ attribute of the created feature.
 The driver autodetects the presence of a fid
 (GML2) (resp. gml:id (GML3)) attribute at the beginning of the file,
 and, if found, exposes it by default as a *fid* (resp. *gml_id*) field.
-The autodetection can be overridden by specifying the **GML_EXPOSE_FID**
-or **GML_EXPOSE_GML_ID** configuration option to **YES** or **NO**.
+The autodetection can be overridden by specifying the 
+:decl_configoption:`GML_EXPOSE_FID` or 
+:decl_configoption:`GML_EXPOSE_GML_ID` configuration option to 
+**YES** or **NO**.
 
 When creating a GML2 document, if a field is
 called *fid*, its content will also be used to write the content of the
@@ -366,7 +369,7 @@ layers. By default, the GML driver will restart reading from the
 beginning of the file, each time a layer is accessed for the first time,
 which can lead to poor performance with large GML files.
 
-The **GML_READ_MODE** configuration option can
+The :decl_configoption:`GML_READ_MODE` configuration option can
 be set to **SEQUENTIAL_LAYERS** if all features belonging to the same
 layer are written sequentially in the file. The reader will then avoid
 unnecessary resets when layers are read completely one after the other.
@@ -376,11 +379,11 @@ appear in the file.
 If no .xsd and .gfs files are found, the parser will detect the layout
 of layers when building the .gfs file. If the layers are found to be
 sequential, a *<SequentialLayers>true</SequentialLayers>* element will
-be written in the .gfs file, so that the GML_READ_MODE will be
-automatically initialized to SEQUENTIAL_LAYERS if not explicitly set by
-the user.
+be written in the .gfs file, so that the :decl_configoption:`GML_READ_MODE` 
+will be automatically initialized to SEQUENTIAL_LAYERS if not explicitly 
+set by the user.
 
-The GML_READ_MODE configuration option can be
+The :decl_configoption:`GML_READ_MODE` configuration option can be
 set to INTERLEAVED_LAYERS to be able to read a GML file whose features
 from different layers are interleaved. In the case, the semantics of the
 GetNextFeature() will be slightly altered, in a way where a NULL return
@@ -477,7 +480,8 @@ feature collection. Each layer's name is used as the element name for
 objects from that layer. Geometries are always written as the
 ogr:geometryProperty element on the feature.
 
-The GML writer supports the following dataset creation options:
+Dataset creation options
+------------------------
 
 -  **XSISCHEMAURI**: If provided, this URI will be inserted as the
    schema location. Note that the schema file isn't actually accessed by

--- a/doc/source/drivers/vector/gml.rst
+++ b/doc/source/drivers/vector/gml.rst
@@ -127,8 +127,11 @@ The :decl_configoption:`GML_ATTRIBUTES_TO_OGR_FIELDS`
 configuration option can be set to **YES** so that attributes of GML
 elements are also taken into account to create OGR fields.
 
-Configuration options can be set via the CPLSetConfigOption() function
-or as environment variables.
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
+:doc:`Configuration options <../../user/configoptions>` can e.g. be set via 
+the CPLSetConfigOption() function or as environment variables.
 
 You can use :decl_configoption:`GML_GFS_TEMPLATE` configuration option 
 (or **GFS_TEMPLATE** open option) set to a **path_to_template.gfs** in 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -270,7 +270,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following configuration options are available:
+The following :doc:`configuration options <../../user/configoptions>` are available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
   of the GeoPackage (and thus SQLite) file, see also 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -26,11 +26,11 @@ must be run by a user with read/write access to the files it is working
 with.
 
 The driver also supports reading and writing the
-following non-linear geometry types :CIRCULARSTRING, COMPOUNDCURVE,
+following non-linear geometry types: CIRCULARSTRING, COMPOUNDCURVE,
 CURVEPOLYGON, MULTICURVE and MULTISURFACE
 
-GeoPackage raster/tiles are supported. See
-:ref:`GeoPackage raster <raster.gpkg>` documentation page
+GeoPackage raster/tiles are supported. See the 
+:ref:`GeoPackage raster <raster.gpkg>` documentation page.
 
 Driver capabilities
 -------------------
@@ -91,32 +91,32 @@ that this will result in a full rewrite of the file.
 SQL functions
 ~~~~~~~~~~~~~
 
-The following SQL functions, from the GeoPackage specification, are available :
+The following SQL functions, from the GeoPackage specification, are available:
 
--  ST_MinX(geom *Geometry*) : returns the minimum X coordinate of the
+-  ST_MinX(geom *Geometry*): returns the minimum X coordinate of the
    geometry
--  ST_MinY(geom *Geometry*) : returns the minimum Y coordinate of the
+-  ST_MinY(geom *Geometry*): returns the minimum Y coordinate of the
    geometry
--  ST_MaxX(geom *Geometry*) : returns the maximum X coordinate of the
+-  ST_MaxX(geom *Geometry*): returns the maximum X coordinate of the
    geometry
--  ST_MaxY(geom *Geometry*) : returns the maximum Y coordinate of the
+-  ST_MaxY(geom *Geometry*): returns the maximum Y coordinate of the
    geometry
--  ST_IsEmpty(geom *Geometry*) : returns 1 if the geometry is empty (but
+-  ST_IsEmpty(geom *Geometry*): returns 1 if the geometry is empty (but
    not null), e.g. a POINT EMPTY geometry
--  ST_GeometryType(geom *Geometry*) : returns the geometry type :
+-  ST_GeometryType(geom *Geometry*): returns the geometry type:
    'POINT', 'LINESTRING', 'POLYGON', 'MULTIPOLYGON', 'MULTILINESTRING',
    'MULTIPOINT', 'GEOMETRYCOLLECTION'
--  ST_SRID(geom *Geometry*) : returns the SRID of the geometry
+-  ST_SRID(geom *Geometry*): returns the SRID of the geometry
 -  GPKG_IsAssignable(expected_geom_type *String*, actual_geom_type
    *String*) : mainly, needed for the 'Geometry Type Triggers Extension'
 
 The following functions, with identical syntax and semantics as in
 Spatialite, are also available :
 
--  CreateSpatialIndex(table_name *String*, geom_column_name *String*) :
+-  CreateSpatialIndex(table_name *String*, geom_column_name *String*):
    creates a spatial index (RTree) on the specified table/geometry
    column
--  DisableSpatialIndex(table_name *String*, geom_column_name *String*) :
+-  DisableSpatialIndex(table_name *String*, geom_column_name *String*):
    drops an existing spatial index (RTree) on the specified
    table/geometry column
 -  ST_Transform(geom *Geometry*, target_srs_id *Integer*): reproject the geometry
@@ -143,8 +143,8 @@ Transaction support
 
 The driver implements transactions at the database level, per :ref:`rfc-54`
 
-Opening options
----------------
+Dataset open options
+--------------------
 
 The following open options are available:
 
@@ -218,10 +218,12 @@ raster) are available:
    When using UTC format, with a unspecified timezone, UTC will be assumed.
 
 Other options are available for raster. See the :ref:`GeoPackage raster <raster.gpkg>`
-documentation page
+documentation page.
 
 Layer Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~
+
+The following layer creation options are available:
 
 -  **GEOMETRY_NAME**: Column to use for the geometry column. Default to
    "geom". Note: This option was called GEOMETRY_COLUMN in releases before
@@ -267,6 +269,8 @@ Layer Creation Options
 
 Configuration options
 ---------------------
+
+The following :ref:`configuration options <user/configoptions>` are available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
   of the GeoPackage (and thus SQLite) file, see also 
@@ -343,7 +347,7 @@ spatial tables that are not registered through the gdal_aspatial
 extension, and support the GeoPackage 1.2 "attributes" data type as
 well. Starting with GDAL 2.2, non spatial tables are by default created
 following the GeoPackage 1.2 "attributes" data type (can be controlled
-with the ASPATIAL_VARIANT layer creation option)
+with the ASPATIAL_VARIANT layer creation option).
 
 Spatial views
 -------------
@@ -372,7 +376,7 @@ This requires GDAL to be compiled with the SQLITE_HAS_COLUMN_METADATA
 option and SQLite3 with the SQLITE_ENABLE_COLUMN_METADATA option.
 Starting with GDAL 2.3, this can be easily verified if the
 SQLITE_HAS_COLUMN_METADATA=YES driver metadata item is declared (for
-example with "ogrinfo --format GPKG")
+example with "ogrinfo --format GPKG").
 
 Coordinate Reference Systems
 ----------------------------
@@ -423,7 +427,7 @@ Performance hints
 -----------------
 
 The same performance hints apply as those mentioned for the 
-:ref:`SQLite driver <vector.sqlite>`
+:ref:`SQLite driver <vector.sqlite:performance-hints>`.
 
 Examples
 --------

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -270,7 +270,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :ref:`configuration options <user.configoptions>` are available:
+The following :ref:`configuration options <..user.configoptions>` are available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
   of the GeoPackage (and thus SQLite) file, see also 
@@ -427,7 +427,7 @@ Performance hints
 -----------------
 
 The same performance hints apply as those mentioned for the 
-:ref:`SQLite driver <vector.sqlite:Performance-hints>`.
+:ref:`SQLite driver <vector.sqlite:Performance hints>`.
 
 Examples
 --------

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -270,7 +270,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :ref:`configuration options <user/configoptions>` are available:
+The following configuration options are available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
   of the GeoPackage (and thus SQLite) file, see also 
@@ -427,7 +427,7 @@ Performance hints
 -----------------
 
 The same performance hints apply as those mentioned for the 
-:ref:`SQLite driver <vector/sqlite:Performance hints>`.
+:ref:`SQLite driver <target_drivers_vector_sqlite_performance_hints>`.
 
 Examples
 --------

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -181,7 +181,7 @@ Note: configuration option :decl_configoption:`OGR_SQLITE_JOURNAL` can
 be used to set the journal mode of the GeoPackage (and thus SQLite)
 file, see also https://www.sqlite.org/pragma.html#pragma_journal_mode.
 
-Creation Issues
+Creation issues
 ---------------
 
 When creating a new GeoPackage file, the driver will attempt to force
@@ -197,7 +197,7 @@ When setting the option, take care to meet the specific time format
 requirement of the GeoPackage standard,
 e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
 
-Dataset Creation Options
+Dataset creation options
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following creation options (specific to vector, or common with
@@ -220,7 +220,7 @@ raster) are available:
 Other options are available for raster. See the :ref:`GeoPackage raster <raster.gpkg>`
 documentation page.
 
-Layer Creation Options
+Layer creation options
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The following layer creation options are available:
@@ -270,15 +270,18 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are available:
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
   of the GeoPackage (and thus SQLite) file, see also 
   https://www.sqlite.org/pragma.html#pragma_journal_mode.
 
-- :decl_configoption:`OGR_SQLITE_CACHE`: see Performance hints.
-
-- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see Performance hints.
+- :decl_configoption:`OGR_SQLITE_CACHE`: see 
+  :ref:`Performance hints <target_drivers_vector_gpkg_performance_hints>`.
+  
+- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see 
+  :ref:`Performance hints <target_drivers_vector_gpkg_performance_hints>`.
 
 - :decl_configoption:`OGR_SQLITE_LOAD_EXTENSIONS` =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
   (GDAL >= 3.5.0). Comma separated list of names of shared libraries containing
@@ -292,7 +295,7 @@ The following :doc:`configuration options <../../user/configoptions>` are availa
   builds of sqlite3.
   Loading extensions as a potential security impact if they are untrusted.
 
-- :decl_configoption:`OGR_SQLITE_PRAGMA` can be useed to specify any SQLite
+- :decl_configoption:`OGR_SQLITE_PRAGMA` can be used to specify any SQLite
   `pragma <http://www.sqlite.org/pragma.html>`__ . The syntax is
   ``OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"``.
 
@@ -422,6 +425,8 @@ Level of support of GeoPackage Extensions
    * - :ref:`vector.geopackage_aspatial`
      - No
      - Yes. Deprecated in GDAL 2.2 for the *attributes* official data_type
+
+.. _target_drivers_vector_gpkg_performance_hints:
 
 Performance hints
 -----------------

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -270,7 +270,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -270,7 +270,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :ref:`configuration options <user/configoptions>` are available:
+The following :ref:`configuration options <user.configoptions>` are available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
   of the GeoPackage (and thus SQLite) file, see also 
@@ -427,7 +427,7 @@ Performance hints
 -----------------
 
 The same performance hints apply as those mentioned for the 
-:ref:`SQLite driver <vector.sqlite:performance-hints>`.
+:ref:`SQLite driver <vector.sqlite:Performance-hints>`.
 
 Examples
 --------

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -175,7 +175,7 @@ The following open options are available:
    https://www.sqlite.org/uri.html
 
 Note: open options are typically specified with "-oo name=value" syntax
-in most OGR utilities, or with the GDALOpenEx() API call.
+in most OGR utilities, or with the ``GDALOpenEx()`` API call.
 
 Note: configuration option :decl_configoption:`OGR_SQLITE_JOURNAL` can
 be used to set the journal mode of the GeoPackage (and thus SQLite)
@@ -265,6 +265,40 @@ Layer Creation Options
    gpkg_extensions table. Starting with GDAL 3.3, OGR_ASPATIAL is no longer
    available on creation.
 
+Configuration options
+---------------------
+
+- :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
+  of the GeoPackage (and thus SQLite) file, see also 
+  https://www.sqlite.org/pragma.html#pragma_journal_mode.
+
+- :decl_configoption:`OGR_SQLITE_CACHE`: see Performance hints.
+
+- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see Performance hints.
+
+- :decl_configoption:`OGR_SQLITE_LOAD_EXTENSIONS` =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
+  (GDAL >= 3.5.0). Comma separated list of names of shared libraries containing
+  extensions to load at database opening.
+  If a file cannot be loaded directly, attempts are made to load with various
+  operating-system specific extensions added. So
+  for example, if "samplelib" cannot be loaded, then names like "samplelib.so"
+  or "samplelib.dylib" or "samplelib.dll" might be tried also.
+  The special value ``ENABLE_SQL_LOAD_EXTENSION`` can be used to enable the use of
+  the SQL ``load_extension()`` function, which is normally disabled in standard
+  builds of sqlite3.
+  Loading extensions as a potential security impact if they are untrusted.
+
+- :decl_configoption:`OGR_SQLITE_PRAGMA` can be useed to specify any SQLite
+  `pragma <http://www.sqlite.org/pragma.html>`__ . The syntax is
+  ``OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"``.
+
+- :decl_configoption:`OGR_CURRENT_DATE`: the driver updates the GeoPackage 
+  ``last_change`` timestamp when the file is created or modified. If consistent 
+  binary output is required for reproducibility, the timestamp can be forced to 
+  a specific value by setting this global configuration option.
+  When setting the option, take care to meet the specific time format
+  requirement of the GeoPackage standard,
+  e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
 
 Metadata
 --------
@@ -384,6 +418,12 @@ Level of support of GeoPackage Extensions
    * - :ref:`vector.geopackage_aspatial`
      - No
      - Yes. Deprecated in GDAL 2.2 for the *attributes* official data_type
+
+Performance hints
+-----------------
+
+The same performance hints apply as those mentioned for the 
+:ref:`SQLite driver <vector.sqlite>`
 
 Examples
 --------

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -307,6 +307,12 @@ available:
   requirement of the GeoPackage standard,
   e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
 
+- :decl_configoption:`SQLITE_USE_OGR_VFS` =YES enables extra buffering/caching 
+  by the GDAL/OGR I/O layer and can speed up I/O. More information 
+  :ref:`here <target_user_virtual_file_systems_file_caching>`.
+  Be aware that no file locking will occur if this option is activated, so 
+  concurrent edits may lead to database corruption.
+
 Metadata
 --------
 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -270,7 +270,7 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :ref:`configuration options <..user.configoptions>` are available:
+The following :ref:`configuration options <user/configoptions>` are available:
 
 - :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
   of the GeoPackage (and thus SQLite) file, see also 
@@ -427,7 +427,7 @@ Performance hints
 -----------------
 
 The same performance hints apply as those mentioned for the 
-:ref:`SQLite driver <vector.sqlite:Performance hints>`.
+:ref:`SQLite driver <vector/sqlite:Performance hints>`.
 
 Examples
 --------

--- a/doc/source/drivers/vector/gpsbabel.rst
+++ b/doc/source/drivers/vector/gpsbabel.rst
@@ -66,7 +66,7 @@ filename might be sufficient. The list includes for now :
 -  ozi
 -  igc
 
-The USE_TEMPFILE=YES configuration option can be used to create an
+The :decl_configoption:`USE_TEMPFILE`=YES configuration option can be used to create an
 on-disk temporary GPX file instead of a in-memory one, when reading big
 amount of data.
 
@@ -96,7 +96,7 @@ Alternatively, you can just pass a filename as output datasource name
 and specify the dataset creation option
 GPSBABEL_DRIVER=gpsbabel_file_format[,gpsbabel_format_option]\*
 
-The USE_TEMPFILE=YES configuration option can be used to create an
+The :decl_configoption:`USE_TEMPFILE`=YES configuration option can be used to create an
 on-disk temporary GPX file instead of a in-memory one, when writing big
 amount of data.
 

--- a/doc/source/drivers/vector/gpsbabel.rst
+++ b/doc/source/drivers/vector/gpsbabel.rst
@@ -66,7 +66,7 @@ filename might be sufficient. The list includes for now :
 -  ozi
 -  igc
 
-The :decl_configoption:`USE_TEMPFILE`=YES configuration option can be used to create an
+The :decl_configoption:`USE_TEMPFILE` =YES configuration option can be used to create an
 on-disk temporary GPX file instead of a in-memory one, when reading big
 amount of data.
 
@@ -96,7 +96,7 @@ Alternatively, you can just pass a filename as output datasource name
 and specify the dataset creation option
 GPSBABEL_DRIVER=gpsbabel_file_format[,gpsbabel_format_option]\*
 
-The :decl_configoption:`USE_TEMPFILE`=YES configuration option can be used to create an
+The :decl_configoption:`USE_TEMPFILE` =YES configuration option can be used to create an
 on-disk temporary GPX file instead of a in-memory one, when writing big
 amount of data.
 

--- a/doc/source/drivers/vector/gpx.rst
+++ b/doc/source/drivers/vector/gpx.rst
@@ -118,7 +118,8 @@ will be interpreted in the OGR SF model as :
 | Note : the GPX driver will output content of the extensions element
   only if it is found in the first records of the GPX file. If
   extensions appear later, you can force an explicit parsing of the
-  whole file with the **GPX_USE_EXTENSIONS** environment variable.
+  whole file with the :decl_configoption:`GPX_USE_EXTENSIONS` configuration 
+  option.
 
 Creation Issues
 ---------------
@@ -157,7 +158,8 @@ the GPX file will be built from the sequence of points with the same
 value of the 'route_fid' field. The 'route_name' field can be set on the
 first track point to fill the <name> element of the route.
 
-The GPX writer supports the following *layer* creation options:
+Layer creation options
+----------------------
 
 -  **FORCE_GPX_TRACK**: By default when writing a layer whose features
    are of type wkbLineString, the GPX driver chooses to write them as
@@ -169,7 +171,8 @@ The GPX writer supports the following *layer* creation options:
    If FORCE_GPX_ROUTE=YES is specified, they will be written as routes,
    provided that the multilines are composed of only one single line.
 
-The GPX writer supports the following *dataset* creation options:
+Dataset creation options
+------------------------
 
 -  **GPX_USE_EXTENSIONS**: By default, the GPX driver will discard
    attribute fields that do not match the GPX XML definition (name, cmt,
@@ -205,7 +208,8 @@ Issues when translating to Shapefile
    characters in the .DBF file, thus leading to duplicate names.
 
    To avoid this, you can define the
-   GPX_SHORT_NAMES configuration option to TRUE to make them be reported
+   :decl_configoption:`GPX_SHORT_NAMES` configuration option to TRUE to 
+   make them be reported
    respectively as "trksegid" and "trksegptid", which will allow them to
    be unique once translated to DBF. The "route_point_id" field of
    *route_points* layer will also be renamed to "rteptid". But note that

--- a/doc/source/drivers/vector/ili.rst
+++ b/doc/source/drivers/vector/ili.rst
@@ -101,11 +101,11 @@ Arc interpolation
 ~~~~~~~~~~~~~~~~~
 
 | Converting INTERLIS arc geometries to line segments can be forced by
-  setting the configuration variable OGR_STROKE_CURVE to TRUE.
+  setting the configuration variable :decl_configoption:`OGR_STROKE_CURVE` to TRUE.
 | The approximation of arcs as linestrings is done by splitting the arcs
   into subarcs of no more than a threshold angle. This angle is the
-  OGR_ARC_STEPSIZE. This defaults to one degree, but may be overridden
-  by setting the configuration variable OGR_ARC_STEPSIZE.
+  :decl_configoption:`OGR_ARC_STEPSIZE`. This defaults to one degree, but may be overridden
+  by setting the configuration variable :decl_configoption:`OGR_ARC_STEPSIZE`.
 
 Other Notes
 -----------

--- a/doc/source/drivers/vector/libkml.rst
+++ b/doc/source/drivers/vector/libkml.rst
@@ -48,7 +48,8 @@ By default on directory and kmz datasources, an index file of all the
 layers will be read from or written to doc.kml. It contains a
 `<NetworkLink> <https://developers.google.com/kml/documentation/kmlreference#networklink>`__
 to each layer file in the datasource. This feature can be turned off by
-setting the environment variable LIBKML_USE_DOC.KML to "no"
+setting the configuration option :decl_configoption:`LIBKML_USE_DOC.KML` 
+to "no".
 
 StyleTable
 ~~~~~~~~~~
@@ -371,7 +372,7 @@ fields are defined.
 
 KML `<GroundOverlay> <https://developers.google.com/kml/documentation/kmlreference#groundoverlay>`__
 elements are supported for reading (unless the
-LIBKML_READ_GROUND_OVERLAY configuration option is set to FALSE). For
+:decl_configoption:`LIBKML_READ_GROUND_OVERLAY` configuration option is set to FALSE). For
 such elements, there are icon and drawOrder fields.
 
 .. _style-1:
@@ -386,22 +387,22 @@ or
 in each
 `<Placemark> <https://developers.google.com/kml/documentation/kmlreference#placemark>`__.
 
-When reading a kml feature and the environment variable
-LIBKML_RESOLVE_STYLE is set to yes, styleurls are looked up in the style
+When reading a kml feature and the configuration option
+:decl_configoption:`LIBKML_RESOLVE_STYLE` is set to yes, styleurls are looked up in the style
 tables and the features style string is set to the style from the table.
 This is to allow reading of shared styles by applications, like
 mapserver, that do not read style tables.
 
-When reading a kml feature and the environment variable
-LIBKML_EXTERNAL_STYLE is set to yes, a styleurl that is external to the
+When reading a kml feature and the configuration option
+:decl_configoption:`LIBKML_EXTERNAL_STYLE` is set to yes, a styleurl that is external to the
 datasource is read from disk or fetched from the server and parsed into
 the datasource style table. If the style kml can not be read or
 LIBKML_EXTERNAL_STYLE is set to no then the styleurl is copied to the
 style string.
 
 When reading a kml StyleMap the default mapping is set to normal. If you
-wish to use the highlighted styles set the environment variable
-LIBKML_STYLEMAP_KEY to "highlight"
+wish to use the highlighted styles set the configuration option
+:decl_configoption:`LIBKML_STYLEMAP_KEY` to "highlight"
 
 When writing a kml, if there exist 2 styles of the form
 "astylename_normal" and "astylename_highlight" (where astylename is any
@@ -419,272 +420,227 @@ except for some special fields as noted below.
 
 Note: it is also possible to export fields as
 `<Data> <https://developers.google.com/kml/documentation/kmlreference#data>`__
-elements if the LIBKML_USE_SCHEMADATA configuration option is set to NO.
+elements if the :decl_configoption:`LIBKML_USE_SCHEMADATA` configuration option is set to NO.
 
-A rich set of environment variables are available to define how fields
+A rich set of configuration options are available to define how fields
 in input and output, map to a KML
 `<Placemark> <https://developers.google.com/kml/documentation/kmlreference#placemark>`__.
 For example, if you want a field called 'Cities' to map to the
 `<name> <https://developers.google.com/kml/documentation/kmlreference#name>`__;
-tag in KML, you can set an environment variable.
-
-Name
-   This String field maps to the kml tag
+tag in KML, you can set a configuration option.
+ 
+-  **name**: string field that maps to the kml tag
    `<name> <https://developers.google.com/kml/documentation/kmlreference#name>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_NAME_FIELD .
-description
-   This String field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option 
+   :decl_configoption:`LIBKML_NAME_FIELD` .
+-  **description**: string field that maps to the kml tag
    `<description> <https://developers.google.com/kml/documentation/kmlreference#description>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_DESCRIPTION_FIELD .
-timestamp
-   This string or datetime or date and/or time field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_DESCRIPTION_FIELD` .
+-  **timestamp**: string or datetime or date and/or time field that maps to the kml tag
    `<timestamp> <https://developers.google.com/kml/documentation/kmlreference#timestamp>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_TIMESTAMP_FIELD .
-begin
-   This string or datetime or date and/or time field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_TIMESTAMP_FIELD` .
+-  **begin**: string or datetime or date and/or time field that maps to the kml tag
    `<begin> <https://developers.google.com/kml/documentation/kmlreference#begin>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_BEGIN_FIELD .
-end
-   This string or datetime or date and/or time field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_BEGIN_FIELD` .
+-  **end**: string or datetime or date and/or time field that maps to the kml tag
    `<end> <https://developers.google.com/kml/documentation/kmlreference#end>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_END_FIELD .
-altitudeMode
-   This string field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_END_FIELD` .
+-  **altitudeMode**: string field that maps to the kml tag
    `<altitudeMode> <https://developers.google.com/kml/documentation/kmlreference#altitudemode>`__
    or
    `<gx:altitudeMode> <https://developers.google.com/kml/documentation/kmlreference#gxaltitudemode>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_ALTITUDEMODE_FIELD .
-tessellate
-   This integer field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_ALTITUDEMODE_FIELD` .
+-  **tessellate**: integer field that maps to the kml tag
    `<tessellate> <https://developers.google.com/kml/documentation/kmlreference#tessellate>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_TESSELLATE_FIELD .
-extrude
-   This integer field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_TESSELLATE_FIELD` .
+-  **extrude**: integer field that maps to the kml tag
    `<extrude> <https://developers.google.com/kml/documentation/kmlreference#extrude>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_EXTRUDE_FIELD .
-visibility
-   This integer field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_EXTRUDE_FIELD` .
+-  **visibility**: integer field that maps to the kml tag
    `<visibility> <https://developers.google.com/kml/documentation/kmlreference#visibility>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_VISIBILITY_FIELD .
-icon
-   This string field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_VISIBILITY_FIELD` .
+-  **icon**: string field that maps to the kml tag
    `<icon> <https://developers.google.com/kml/documentation/kmlreference#icon>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_ICON_FIELD .
-drawOrder
-   This integer field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_ICON_FIELD` .
+-  **drawOrder**: integer field that maps to the kml tag
    `<drawOrder> <https://developers.google.com/kml/documentation/kmlreference#draworder>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_DRAWORDER_FIELD .
-snippet
-   This integer field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_DRAWORDER_FIELD` .
+-  **snippet**: integer field that maps to the kml tag
    `<snippet> <https://developers.google.com/kml/documentation/kmlreference#snippet>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_SNIPPET_FIELD .
-heading
-   This real field maps to the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_SNIPPET_FIELD` .
+-  **heading**: real field that maps to the kml tag
    `<heading> <https://developers.google.com/kml/documentation/kmlreference#heading>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_HEADING_FIELD. When reading, this field is present
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_HEADING_FIELD`. When reading, this field is present
    only if a Placemark has a Camera with a heading element.
-tilt
-   This real field maps to the kml tag
+-  **tilt**: real field that maps to the kml tag
    `<tilt> <https://developers.google.com/kml/documentation/kmlreference#tilt>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_TILT_FIELD. When reading, this field is present only
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_TILT_FIELD`. When reading, this field is present only
    if a Placemark has a Camera with a tilt element.
-roll
-   This real field maps to the kml tag
+-  **roll**: real field that maps to the kml tag
    `<roll> <https://developers.google.com/kml/documentation/kmlreference#roll>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_ROLL_FIELD. When reading, this field is present only
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_ROLL_FIELD`. When reading, this field is present only
    if a Placemark has a Camera with a roll element.
-model
-   This string field can be used to define the URL of a 3D
+-  **model**: string field that can be used to define the URL of a 3D
    `<model> <https://developers.google.com/kml/documentation/kmlreference#model>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_MODEL_FIELD.
-scale_x
-   This real field maps to the x element of the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_MODEL_FIELD`.
+-  **scale_x**: real field that maps to the x element of the kml tag
    `<scale> <https://developers.google.com/kml/documentation/kmlreference#scale>`__
    for a 3D model. The name of the ogr field can be changed with the
-   environment variable LIBKML_SCALE_X_FIELD.
-scale_y
-   This real field maps to the y element of the kml tag
+   configuration option :decl_configoption:`LIBKML_SCALE_X_FIELD`.
+-  **scale_y**: real field that maps to the y element of the kml tag
    `<scale> <https://developers.google.com/kml/documentation/kmlreference#scale>`__\ for
    a 3D model. The name of the ogr field can be changed with the
-   environment variable LIBKML_SCALE_Y_FIELD.
-scale_z
-   This real field maps to the z element of the kml tag
+   configuration option :decl_configoption:`LIBKML_SCALE_Y_FIELD`.
+-  **scale_z**: real field that maps to the z element of the kml tag
    `<scale> <https://developers.google.com/kml/documentation/kmlreference#scale>`__\ for
    a 3D model. The name of the ogr field can be changed with the
-   environment variable LIBKML_SCALE_Z_FIELD.
-networklink
-   This string field maps to the href element of the kml tag
+   configuration option :decl_configoption:`LIBKML_SCALE_Z_FIELD`.
+-  **networklink**: string field that maps to the href element of the kml tag
    `<href> <https://developers.google.com/kml/documentation/kmlreference#href>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_FIELD.
-networklink_refreshvisibility
-   This integer field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_FIELD`.
+-  **networklink_refreshvisibility**: integer field that maps to kml tag
    `<refreshVisibility> <https://developers.google.com/kml/documentation/kmlreference#refreshvisibility>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_REFRESHVISIBILITY_FIELD.
-networklink_flytoview
-   This integer field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_REFRESHVISIBILITY_FIELD`.
+-  **networklink_flytoview**: integer field that maps to kml tag
    `<flyToView> <https://developers.google.com/kml/documentation/kmlreference#flytoview>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_FLYTOVIEW_FIELD.
-networklink_refreshmode
-   This string field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_FLYTOVIEW_FIELD`.
+-  **networklink_refreshmode**: string field that maps to kml tag
    `<refreshMode> <https://developers.google.com/kml/documentation/kmlreference#refreshmode>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_REFRESHMODE_FIELD.
-networklink_refreshinterval
-   This real field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_REFRESHMODE_FIELD`.
+-  **networklink_refreshinterval**: real field that maps to kml tag
    `<refreshInterval> <https://developers.google.com/kml/documentation/kmlreference#refreshinterval>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_REFRESHINTERVAL_FIELD.
-networklink_viewrefreshmode
-   This string field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_REFRESHINTERVAL_FIELD`.
+-  **networklink_viewrefreshmode**: string field that maps to kml tag
    `<viewRefreshMode> <https://developers.google.com/kml/documentation/kmlreference#viewrefreshmode>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_VIEWREFRESHMODE_FIELD.
-networklink_viewrefreshtime
-   This real field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_VIEWREFRESHMODE_FIELD`.
+-  **networklink_viewrefreshtime**: real field that maps to kml tag
    `<viewRefreshTime> <https://developers.google.com/kml/documentation/kmlreference#viewrefreshtime>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_VIEWREFRESHTIME_FIELD.
-networklink_viewboundscale
-   This real field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_VIEWREFRESHTIME_FIELD`.
+-  **networklink_viewboundscale**: real field that maps to kml tag
    `<viewBoundScale> <https://developers.google.com/kml/documentation/kmlreference#viewboundscale>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_VIEWBOUNDSCALE_FIELD.
-networklink_viewformat
-   This string field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_VIEWBOUNDSCALE_FIELD`.
+-  **networklink_viewformat**: string field that maps to kml tag
    `<viewFormat> <https://developers.google.com/kml/documentation/kmlreference#viewformat>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_VIEWFORMAT_FIELD.
-networklink_httpquery
-   This string field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_VIEWFORMAT_FIELD`.
+-  **networklink_httpquery**: string field that maps to kml tag
    `<httpQuery> <https://developers.google.com/kml/documentation/kmlreference#httpquery>`__
    of a NetworkLink. The name of the ogr field can be changed with the
-   environment variable LIBKML_NETWORKLINK_HTTPQUERY_FIELD.
-camera_longitude
-   This real field maps to kml tag
+   configuration option :decl_configoption:`LIBKML_NETWORKLINK_HTTPQUERY_FIELD`.
+-  **camera_longitude**: real field that maps to kml tag
    `<longitude> <https://developers.google.com/kml/documentation/kmlreference#longitude>`__
    of a
    `<Camera> <https://developers.google.com/kml/documentation/kmlreference#camera>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_CACameraMERA_LONGITUDE_FIELD.
-camera_latitude
-   This real field maps to kml tag
+   The name of the ogr field can be changed with the 
+   configuration option :decl_configoption:`LIBKML_CAMERA_LONGITUDE_FIELD`.
+-  **camera_latitude**: real field that maps to kml tag
    `<latitude> <https://developers.google.com/kml/documentation/kmlreference#latitude>`__
    of a
    `<Camera> <https://developers.google.com/kml/documentation/kmlreference#camera>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_CAMERA_LATITUDE_FIELD.
-camera_altitude
-   This real field maps to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_CAMERA_LATITUDE_FIELD`.
+-  **camera_altitude**: real field that maps to kml tag
    `<altitude> <https://developers.google.com/kml/documentation/kmlreference#altitude>`__
    of a
    `<Camera> <https://developers.google.com/kml/documentation/kmlreference#camera>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_CAMERA_ALTITUDE_FIELD.
-camera_altitudemode
-   This real field maps to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_CAMERA_ALTITUDE_FIELD`.
+-  **camera_altitudemode**: real field that maps to kml tag
    `<altitudeMode> <https://developers.google.com/kml/documentation/kmlreference#altitudemode>`__
    of a
    `<Camera> <https://developers.google.com/kml/documentation/kmlreference#camera>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_CAMERA_ALTITUDEMODE_FIELD.
-photooverlay
-   This string field maps to the href element of the kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_CAMERA_ALTITUDEMODE_FIELD`.
+-  **photooverlay**: string field that maps to the href element of the kml tag
    `<href> <https://developers.google.com/kml/documentation/kmlreference#href>`__
    of a
    `<PhotoOverlay> <https://developers.google.com/kml/documentation/kmlreference#photooverlay>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_PHOTOOVERLAY_FIELD.
-leftfov
-   This real field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_PHOTOOVERLAY_FIELD`.
+-  **leftfov**: real field that maps to to kml tag
    `<LeftFov> <https://developers.google.com/kml/documentation/kmlreference#leftfov>`__
    of a
    `<PhotoOverlay> <https://developers.google.com/kml/documentation/kmlreference#photooverlay>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_LEFTFOV_FIELD.
-rightfov
-   This real field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_LEFTFOV_FIELD`.
+-  **rightfov**: real field that maps to to kml tag
    `<RightFov> <https://developers.google.com/kml/documentation/kmlreference#rightfov>`__
    of a
    `<PhotoOverlay> <https://developers.google.com/kml/documentation/kmlreference#photooverlay>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_RightFOV_FIELD.
-bottomfov
-   This real field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_RIGHTFOV_FIELD`.
+-  **bottomfov**: real field that maps to to kml tag
    `<BottomFov> <https://developers.google.com/kml/documentation/kmlreference#bottomfov>`__
    of a
    `<PhotoOverlay> <https://developers.google.com/kml/documentation/kmlreference#photooverlay>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_BOTTOMTFOV_FIELD.
-topfov
-   This real field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_BOTTOMTFOV_FIELD`.
+-  **topfov**: real field that maps to to kml tag
    `<TopFov> <https://developers.google.com/kml/documentation/kmlreference#topfov>`__
    of a
    `<PhotoOverlay> <https://developers.google.com/kml/documentation/kmlreference#photooverlay>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_TOPFOV_FIELD.
-near
-   This real field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_TOPFOV_FIELD`.
+-  **near**: real field that maps to to kml tag
    `<Near> <https://developers.google.com/kml/documentation/kmlreference#leftfov>`__
    of a
    `<PhotoOverlay> <https://developers.google.com/kml/documentation/kmlreference#photooverlay>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_NEAR_FIELD.
-shape
-   This string field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_NEAR_FIELD`.
+-  **shape**: string field that maps to to kml tag
    `<shape> <https://developers.google.com/kml/documentation/kmlreference#shape>`__
    of a
    `<PhotoOverlay> <https://developers.google.com/kml/documentation/kmlreference#photooverlay>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_SHAPE_FIELD.
-imagepyramid_tilesize
-   This integer field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_SHAPE_FIELD`.
+-  **imagepyramid_tilesize**: integer field that maps to to kml tag
    `<tileSize> <https://developers.google.com/kml/documentation/kmlreference#tilesize>`__
    of a
    `<ImagePyramid> <https://developers.google.com/kml/documentation/kmlreference#imagepyramid>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_IMAGEPYRAMID_TILESIZE.
-imagepyramid_maxwidth
-   This integer field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_IMAGEPYRAMID_TILESIZE`.
+-  **imagepyramid_maxwidth**: integer field that maps to to kml tag
    `<maxWidth> <https://developers.google.com/kml/documentation/kmlreference#maxwidth>`__
    of a
    `<ImagePyramid> <https://developers.google.com/kml/documentation/kmlreference#imagepyramid>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_IMAGEPYRAMID_MAXWIDTH.
-imagepyramid_maxheight
-   This integer field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_IMAGEPYRAMID_MAXWIDTH`.
+-  **imagepyramid_maxheight**: integer field that maps to to kml tag
    `<maxHeight> <https://developers.google.com/kml/documentation/kmlreference#maxheight>`__
    of a
    `<ImagePyramid> <https://developers.google.com/kml/documentation/kmlreference#imagepyramid>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_IMAGEPYRAMID_MAXHEIGHT.
-imagepyramid_gridorigin
-   This string field maps to to kml tag
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_IMAGEPYRAMID_MAXHEIGHT`.
+-  **imagepyramid_gridorigin**: string field that maps to to kml tag
    `<gridOrigin> <https://developers.google.com/kml/documentation/kmlreference#maxheight>`__
    of a
    `<ImagePyramid> <https://developers.google.com/kml/documentation/kmlreference#imagepyramid>`__.
-   The name of the ogr field can be changed with the environment
-   variable LIBKML_IMAGEPYRAMID_GRIDORIGIN.
-OGR_STYLE
-   This string field maps to a features style string, OGR reads this
+   The name of the ogr field can be changed with the configuration option
+   :decl_configoption:`LIBKML_IMAGEPYRAMID_GRIDORIGIN`.
+-  **OGR_STYLE**: string field that maps to a features style string, OGR reads this
    field if there is no style string set on the feature.
 
 Geometry
@@ -717,8 +673,8 @@ content.
 
 Sometimes kml geometry will span the dateline, In applications like qgis
 or mapserver this will create horizontal lines all the way around the
-globe. Setting the environment variable LIBKML_WRAPDATELINE to "yes"
-will cause the libkml driver to split the geometry at the dateline when
+globe. Setting the configuration option :decl_configoption:`LIBKML_WRAPDATELINE` 
+to "yes" will cause the libkml driver to split the geometry at the dateline when
 read.
 
 VSI Virtual File System API support

--- a/doc/source/drivers/vector/libkml.rst
+++ b/doc/source/drivers/vector/libkml.rst
@@ -422,7 +422,7 @@ Note: it is also possible to export fields as
 `<Data> <https://developers.google.com/kml/documentation/kmlreference#data>`__
 elements if the :decl_configoption:`LIBKML_USE_SCHEMADATA` configuration option is set to NO.
 
-A rich set of :doc:`configuration options <../../user/configoptions>` are 
+A rich set of :ref:`configuration options <configoptions>` are 
 available to define how fields in input and output, map to a KML
 `<Placemark> <https://developers.google.com/kml/documentation/kmlreference#placemark>`__.
 For example, if you want a field called 'Cities' to map to the

--- a/doc/source/drivers/vector/libkml.rst
+++ b/doc/source/drivers/vector/libkml.rst
@@ -422,8 +422,8 @@ Note: it is also possible to export fields as
 `<Data> <https://developers.google.com/kml/documentation/kmlreference#data>`__
 elements if the :decl_configoption:`LIBKML_USE_SCHEMADATA` configuration option is set to NO.
 
-A rich set of configuration options are available to define how fields
-in input and output, map to a KML
+A rich set of :doc:`configuration options <../../user/configoptions>` are 
+available to define how fields in input and output, map to a KML
 `<Placemark> <https://developers.google.com/kml/documentation/kmlreference#placemark>`__.
 For example, if you want a field called 'Cities' to map to the
 `<name> <https://developers.google.com/kml/documentation/kmlreference#name>`__;

--- a/doc/source/drivers/vector/mitab.rst
+++ b/doc/source/drivers/vector/mitab.rst
@@ -135,7 +135,7 @@ Layer Creation Options
 Configuration options
 ~~~~~~~~~~~~~~~~~~~~~
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`MITAB_SET_TOWGS84_ON_KNOWN_DATUM` =YES/NO:

--- a/doc/source/drivers/vector/mitab.rst
+++ b/doc/source/drivers/vector/mitab.rst
@@ -135,6 +135,9 @@ Layer Creation Options
 Configuration options
 ~~~~~~~~~~~~~~~~~~~~~
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 -  :decl_configoption:`MITAB_SET_TOWGS84_ON_KNOWN_DATUM` =YES/NO:
    (GDAL >= 3.0.3). The default behavior, starting with GDAL 3.0.3, is NO.
    That is, the TOWGS84 parameters read from the .tab header will *not* be set

--- a/doc/source/drivers/vector/mssqlspatial.rst
+++ b/doc/source/drivers/vector/mssqlspatial.rst
@@ -147,7 +147,7 @@ Layer Creation Options
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`MSSQLSPATIAL_USE_BCP`: (From GDAL 2.1.0) Enable bulk insert when

--- a/doc/source/drivers/vector/mssqlspatial.rst
+++ b/doc/source/drivers/vector/mssqlspatial.rst
@@ -151,7 +151,7 @@ There are a variety of `Configuration
 Options <http://trac.osgeo.org/gdal/wiki/ConfigOptions>`__ which help
 control the behavior of this driver.
 
--  **MSSQLSPATIAL_USE_BCP**: (From GDAL 2.1.0) Enable bulk insert when
+-  :decl_configoption:`MSSQLSPATIAL_USE_BCP`: (From GDAL 2.1.0) Enable bulk insert when
    adding features. This option requires to to compile GDAL against a
    bulk copy enabled ODBC driver like SQL Server Native Client 11.0. To
    specify a BCP supported driver in the connection string, use the
@@ -161,21 +161,21 @@ control the behavior of this driver.
    connection string. If GDAL is compiled against SQL Server Native
    Client 10.0 or 11.0 the default setting of this parameter is TRUE,
    otherwise the parameter is ignored by the driver.
--  **MSSQLSPATIAL_BCP_SIZE**: (From GDAL 2.1.0) Specifies the bulk
+-  :decl_configoption:`MSSQLSPATIAL_BCP_SIZE`: (From GDAL 2.1.0) Specifies the bulk
    insert batch size. The larger value makes the insert faster, but
    consumes more memory. Default = 1000.
--  **MSSQLSPATIAL_OGR_FID**: Override FID column name. Default =
+-  :decl_configoption:`MSSQLSPATIAL_OGR_FID`: Override FID column name. Default =
    ogr_fid.
--  **MSSQLSPATIAL_ALWAYS_OUTPUT_FID**: Always retrieve the FID value of
+-  :decl_configoption:`MSSQLSPATIAL_ALWAYS_OUTPUT_FID`: Always retrieve the FID value of
    the recently created feature (even if it is not a true IDENTITY
    column). Default = "NO".
--  **MSSQLSPATIAL_SHOW_FID_COLUMN**: Force to display the FID columns as
+-  :decl_configoption:`MSSQLSPATIAL_SHOW_FID_COLUMN`: Force to display the FID columns as
    a feature attribute. Default = "NO".
--  **MSSQLSPATIAL_USE_GEOMETRY_COLUMNS**: Use/create geometry_columns
+-  :decl_configoption:`MSSQLSPATIAL_USE_GEOMETRY_COLUMNS`: Use/create geometry_columns
    metadata table in the database. Default = "YES".
--  **MSSQLSPATIAL_LIST_ALL_TABLES**: Use mssql catalog to list available
+-  :decl_configoption:`MSSQLSPATIAL_LIST_ALL_TABLES`: Use mssql catalog to list available
    layers. Default = "NO".
--  **MSSQLSPATIAL_USE_GEOMETRY_VALIDATION**: (From GDAL 3.0) Let the
+-  :decl_configoption:`MSSQLSPATIAL_USE_GEOMETRY_VALIDATION`: (From GDAL 3.0) Let the
    driver detect the geometries which would trigger run time errors at
    MSSQL server. The driver tries to correct these geometries before
    submitting that to the server. Default = "YES".

--- a/doc/source/drivers/vector/mssqlspatial.rst
+++ b/doc/source/drivers/vector/mssqlspatial.rst
@@ -147,9 +147,8 @@ Layer Creation Options
 Configuration options
 ---------------------
 
-There are a variety of `Configuration
-Options <http://trac.osgeo.org/gdal/wiki/ConfigOptions>`__ which help
-control the behavior of this driver.
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`MSSQLSPATIAL_USE_BCP`: (From GDAL 2.1.0) Enable bulk insert when
    adding features. This option requires to to compile GDAL against a

--- a/doc/source/drivers/vector/ngw.rst
+++ b/doc/source/drivers/vector/ngw.rst
@@ -66,19 +66,19 @@ Configuration options
 
 The following configuration options are available:
 
--  **NGW_USERPWD**: User name and password separated with colon.
+-  :decl_configoption:`NGW_USERPWD`: User name and password separated with colon.
    Optional and can be set using open options.
--  **NGW_BATCH_SIZE**: Size of feature insert and update operations
+-  :decl_configoption:`NGW_BATCH_SIZE`: Size of feature insert and update operations
    cache before send to server. If batch size is -1 batch mode is
    disabled. Delete operation will execute immediately.
--  **NGW_PAGE_SIZE**: If supported by server, fetch features from remote
+-  :decl_configoption:`NGW_PAGE_SIZE`: If supported by server, fetch features from remote
    server will use paging. The -1 value disables paging even it
    supported by server.
--  **NGW_NATIVE_DATA**: Whether to store the json *extensions* key in
+-  :decl_configoption:`NGW_NATIVE_DATA`: Whether to store the json *extensions* key in
    feature native data.
--  **NGW_JSON_DEPTH**: The depth of json response that can be parsed. If
+-  :decl_configoption:`NGW_JSON_DEPTH`: The depth of json response that can be parsed. If
    depth is greater than this value, parse error occurs.
--  **NGW_EXTENSIONS**: Comma separated extensions list. Available values are 
+-  :decl_configoption:`NGW_EXTENSIONS`: Comma separated extensions list. Available values are 
    `description` and `attachment`. This needed to fill native data.
 
 Authentication
@@ -136,7 +136,8 @@ Paging
 
 Features can retrieved from NextGIS Web by chunks if supported by server
 (available since NextGIS Web 3.1). The chunk size can be altered with
-the NGW_PAGE_SIZE configuration option or PAGE_SIZE open option.
+the :decl_configoption:`NGW_PAGE_SIZE` configuration option or PAGE_SIZE 
+open option.
 
 Write support
 -------------

--- a/doc/source/drivers/vector/ngw.rst
+++ b/doc/source/drivers/vector/ngw.rst
@@ -64,7 +64,8 @@ if identifier is resource group. In other case this will be a separate layer.
 Configuration options
 ---------------------
 
-The following configuration options are available:
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`NGW_USERPWD`: User name and password separated with colon.
    Optional and can be set using open options.

--- a/doc/source/drivers/vector/ngw.rst
+++ b/doc/source/drivers/vector/ngw.rst
@@ -64,7 +64,7 @@ if identifier is resource group. In other case this will be a separate layer.
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`NGW_USERPWD`: User name and password separated with colon.

--- a/doc/source/drivers/vector/oci.rst
+++ b/doc/source/drivers/vector/oci.rst
@@ -69,9 +69,9 @@ Caveats
 -  If an attribute called OGR_FID exists in the schema for tables being
    read, it will be used as the FID. Random (FID based) reads on tables
    without an identified (and indexed) FID field can be very slow. To
-   force use of a particular field name the OCI_FID configuration
-   variable (i.e. environment variable) can be set to the target field
-   name.
+   force use of a particular field name the :decl_configoption:`OCI_FID` 
+   configuration option (e.g. environment variable) can be set to the 
+   target field name.
 -  Curved geometry types are converted to linestrings or linear rings in
    six degree segments when reading. The driver has no support for
    writing curved geometries.

--- a/doc/source/drivers/vector/ods.rst
+++ b/doc/source/drivers/vector/ods.rst
@@ -34,12 +34,12 @@ Driver capabilities
 Configuration options
 ---------------------
 
--  OGR_ODS_HEADERS = FORCE / DISABLE / AUTO : By default, the driver
+-  :decl_configoption:`OGR_ODS_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver
    will read the first lines of each sheet to detect if the first line
    might be the name of columns. If set to FORCE, the driver will
    consider the first line will be taken as the header line. If set to
    DISABLE, it will be considered as the first feature. Otherwise
    auto-detection will occur.
--  OGR_ODS_FIELD_TYPES = STRING / AUTO : By default, the driver will try
+-  :decl_configoption:`OGR_ODS_FIELD_TYPES` = STRING / AUTO : By default, the driver will try
    to detect the data type of fields. If set to STRING, all fields will
    be of String type.

--- a/doc/source/drivers/vector/ods.rst
+++ b/doc/source/drivers/vector/ods.rst
@@ -34,7 +34,7 @@ Driver capabilities
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`OGR_ODS_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver

--- a/doc/source/drivers/vector/ods.rst
+++ b/doc/source/drivers/vector/ods.rst
@@ -34,6 +34,9 @@ Driver capabilities
 Configuration options
 ---------------------
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 -  :decl_configoption:`OGR_ODS_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver
    will read the first lines of each sheet to detect if the first line
    might be the name of columns. If set to FORCE, the driver will

--- a/doc/source/drivers/vector/ogdi.rst
+++ b/doc/source/drivers/vector/ogdi.rst
@@ -27,7 +27,7 @@ layers has an OGR name based on the OGDI name plus an underscore and the
 family name. For instance a layer might be called
 **watrcrsl@hydro(*)_line** if coming out of the VRF driver.
 
-Setting the *OGR_OGDI_LAUNDER_LAYER_NAMES*
+Setting the :decl_configoption:`OGR_OGDI_LAUNDER_LAYER_NAMES`
 configuration option (or environment variable) to YES causes the layer
 names to be simplified. For example : *watrcrsl_hydro* instead of
 'watrcrsl@hydro(*)_line'

--- a/doc/source/drivers/vector/openfilegdb.rst
+++ b/doc/source/drivers/vector/openfilegdb.rst
@@ -39,7 +39,7 @@ default, it also builds on the fly a in-memory spatial index during
 the first sequential read of a layer. Following spatial filtering
 operations on that layer will then benefit from that spatial index. The
 building of this in-memory spatial index can be disabled by setting the
-OPENFILEGDB_IN_MEMORY_SPI configuration option to NO.
+:decl_configoption:`OPENFILEGDB_IN_MEMORY_SPI` configuration option to NO.
 
 SQL support
 -----------

--- a/doc/source/drivers/vector/osm.rst
+++ b/doc/source/drivers/vector/osm.rst
@@ -110,11 +110,11 @@ because too many features will accumulate in the layers before being
 consumed by the user application.
 
 Starting with GDAL 2.2, applications should use the
-GDALDataset::GetNextFeature() API to iterate over features in the order
+``GDALDataset::GetNextFeature()`` API to iterate over features in the order
 they are produced.
 
 For earlier versions, for large files, applications should set the
-OGR_INTERLEAVED_READING=YES configuration option to turn on a special
+:decl_configoption:`OGR_INTERLEAVED_READING`=YES configuration option to turn on a special
 reading mode where the following reading pattern must be used:
 
 ::
@@ -139,7 +139,8 @@ reading mode where the following reading pattern must be used:
        while( bHasLayersNonEmpty );
 
 Note : the ogr2ogr application has been modified to use that
-OGR_INTERLEAVED_READING mode without any particular user action.
+:decl_configoption:`OGR_INTERLEAVED_READING` mode without any 
+particular user action.
 
 Spatial filtering
 -----------------

--- a/doc/source/drivers/vector/osm.rst
+++ b/doc/source/drivers/vector/osm.rst
@@ -114,7 +114,7 @@ Starting with GDAL 2.2, applications should use the
 they are produced.
 
 For earlier versions, for large files, applications should set the
-:decl_configoption:`OGR_INTERLEAVED_READING`=YES configuration option to turn on a special
+:decl_configoption:`OGR_INTERLEAVED_READING` =YES configuration option to turn on a special
 reading mode where the following reading pattern must be used:
 
 ::

--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -252,7 +252,7 @@ Layer Creation Options
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`PG_USE_COPY`: This may be "YES" for using COPY for inserting data

--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -252,9 +252,8 @@ Layer Creation Options
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~
 
-There are a variety of `Configuration
-Options <http://trac.osgeo.org/gdal/wiki/ConfigOptions>`__ which help
-control the behavior of this driver.
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`PG_USE_COPY`: This may be "YES" for using COPY for inserting data
    to Postgresql. COPY is significantly faster than INSERT. COPY is used by

--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -256,19 +256,19 @@ There are a variety of `Configuration
 Options <http://trac.osgeo.org/gdal/wiki/ConfigOptions>`__ which help
 control the behavior of this driver.
 
--  **PG_USE_COPY**: This may be "YES" for using COPY for inserting data
+-  :decl_configoption:`PG_USE_COPY`: This may be "YES" for using COPY for inserting data
    to Postgresql. COPY is significantly faster than INSERT. COPY is used by
    default when inserting from a table that has just been created.
--  **PGSQL_OGR_FID**: Set name of primary key instead of 'ogc_fid'. Only
+-  :decl_configoption:`PGSQL_OGR_FID`: Set name of primary key instead of 'ogc_fid'. Only
    used when opening a layer whose primary key cannot be autodetected.
    Ignored by CreateLayer() that uses the FID creation option.
--  **PG_USE_BASE64**: If set to "YES", geometries will
+-  :decl_configoption:`PG_USE_BASE64`: If set to "YES", geometries will
    be fetched as BASE64 encoded EWKB instead of canonical HEX encoded
    EWKB. This reduces the amount of data to be transferred from 2 N to
    1.333 N, where N is the size of EWKB data. However, it might be a bit
    slower than fetching in canonical form when the client and the server
    are on the same machine, so the default is NO.
--  **OGR_TRUNCATE**: If set to "YES", the content of the
+-  :decl_configoption:`OGR_TRUNCATE`: If set to "YES", the content of the
    table will be first erased with the SQL TRUNCATE command before
    inserting the first feature. This is an alternative to using the
    -overwrite flag of ogr2ogr, that avoids views based on the table to
@@ -376,8 +376,8 @@ FAQs
    have permissions to these tables. Permission issues on
    geometry_columns and/or spatial_ref_sys tables can be generally
    confirmed if you can see the tables by setting the configuration
-   option PG_LIST_ALL_TABLES to YES. (e.g. ogrinfo --config
-   PG_LIST_ALL_TABLES YES PG:xxxxx)
+   option :decl_configoption:`PG_LIST_ALL_TABLES` to YES. (e.g. ``ogrinfo --config
+   PG_LIST_ALL_TABLES YES PG:xxxxx``)
 
 See Also
 --------

--- a/doc/source/drivers/vector/pgeo.rst
+++ b/doc/source/drivers/vector/pgeo.rst
@@ -19,8 +19,9 @@ Personal Geodatabases are accessed by passing the file name of the .mdb
 file to be accessed as the data source name.
 
 In order to facilitate compatibility with different configurations, the
-PGEO_DRIVER_TEMPLATE Config Option was added to provide a way to
-programmatically set the DSN programmatically with the filename as an
+:decl_configoption:`PGEO_DRIVER_TEMPLATE` config Option was added to 
+provide a way to programmatically set the DSN programmatically with the 
+filename as an
 argument. In cases where the driver name is known, this allows for the
 construction of the DSN based on that information in a manner similar to
 the default (used for Windows access to the Microsoft Access Driver).

--- a/doc/source/drivers/vector/plscenes_data_v1.rst
+++ b/doc/source/drivers/vector/plscenes_data_v1.rst
@@ -84,7 +84,7 @@ Configuration options
 
 The following configuration options are available :
 
--  :decl_configoption:`PL_API_KEY`=value: To specify the Planet API KEY.
+-  :decl_configoption:`PL_API_KEY` =value: To specify the Planet API KEY.
 
 Attributes
 ----------

--- a/doc/source/drivers/vector/plscenes_data_v1.rst
+++ b/doc/source/drivers/vector/plscenes_data_v1.rst
@@ -82,7 +82,8 @@ The following open options are available :
 Configuration options
 ---------------------
 
-The following configuration options are available :
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 -  :decl_configoption:`PL_API_KEY` =value: To specify the Planet API KEY.
 

--- a/doc/source/drivers/vector/plscenes_data_v1.rst
+++ b/doc/source/drivers/vector/plscenes_data_v1.rst
@@ -82,7 +82,7 @@ The following open options are available :
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`PL_API_KEY` =value: To specify the Planet API KEY.

--- a/doc/source/drivers/vector/plscenes_data_v1.rst
+++ b/doc/source/drivers/vector/plscenes_data_v1.rst
@@ -30,7 +30,7 @@ Currently the following one is supported :
 -  **version**\ =data_v1: To specify the API version to request.
 -  **api_key**\ =value: To specify the Planet API KEY. It is mandatory,
    unless it is supplied through the open option API_KEY, or the
-   configuration option PL_API_KEY.
+   configuration option :decl_configoption:`PL_API_KEY`.
 -  **follow_links**\ =YES/NO: Whether assets links should be followed
    for each scene (vector). Getting assets links require a HTTP request
    per scene, which might be costly when enumerating through a lot of
@@ -84,7 +84,7 @@ Configuration options
 
 The following configuration options are available :
 
--  **PL_API_KEY**\ =value: To specify the Planet API KEY.
+-  :decl_configoption:`PL_API_KEY`=value: To specify the Planet API KEY.
 
 Attributes
 ----------
@@ -116,7 +116,8 @@ Paging
 
 Features are retrieved from the server by chunks of 250 by default (and
 this is the maximum value accepted by the server). This number can be
-altered with the PLSCENES_PAGE_SIZE configuration option.
+altered with the :decl_configoption:`PLSCENES_PAGE_SIZE` configuration 
+option.
 
 Vector layer (scene metadata) examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/drivers/vector/shapefile.rst
+++ b/doc/source/drivers/vector/shapefile.rst
@@ -48,10 +48,19 @@ specification, that is to say the vertices of outer rings should be
 oriented clockwise on the X/Y plane, and those of inner rings
 counterclockwise. If a Shapefile is broken w.r.t. that rule, it is
 possible to define the configuration option
-:decl_configoption:`OGR_ORGANIZE_POLYGONS` to DEFAULT to proceed to a full analysis based on
-topological relationships of the parts of the polygons so that the
-resulting polygons are correctly defined in the OGC Simple Feature
-convention.
+:decl_configoption:`OGR_ORGANIZE_POLYGONS` to DEFAULT to proceed to 
+a full analysis based on topological relationships of the parts of the 
+polygons so that the resulting polygons are correctly defined in the 
+OGC Simple Feature convention.
+
+Driver capabilities
+-------------------
+
+.. supports_create::
+
+.. supports_georeferencing::
+
+.. supports_virtualio::
 
 Encoding
 --------
@@ -69,55 +78,20 @@ Starting with GDAL 3.1, the following metadata items are available in the
 
 -  **LDID_VALUE**\ =integer: Raw LDID value from the DBF header. Only present
    if this value is not zero.
--  **ENCODING_FROM_LDID**\ = string: Encoding name deduced from LDID_VALUE. Only
+-  **ENCODING_FROM_LDID**\ =string: Encoding name deduced from LDID_VALUE. Only
    present if LDID_VALUE is present
 -  **CPG_VALUE**\ =string: Content of the .cpg file. Only present if the file
    exists.
--  **ENCODING_FROM_CPG**\ = string: Encoding name deduced from CPG_VALUE. Only
+-  **ENCODING_FROM_CPG**\ =string: Encoding name deduced from CPG_VALUE. Only
    present if CPG_VALUE is present
--  **SOURCE_ENCODING**\= string: Encoding used by GDAL to encode/recode strings.
-   If the user has provided the :decl_configoption:`SHAPE_ENCODING` configuration option or
-   ``ENCODING`` open option have been provided (included to empty value), then
-   their value is used to fill this metadata item.
-   Otherwise it is equal to ENCODING_FROM_CPG if it is present. Otherwise it is
-   equal to ENCODING_FROM_LDID.
+-  **SOURCE_ENCODING**\ =string: Encoding used by GDAL to encode/recode strings.
+   If the user has provided the :decl_configoption:`SHAPE_ENCODING` 
+   configuration option or ``ENCODING`` open option have been provided 
+   (included to empty value), then their value is used to fill this metadata 
+   item. Otherwise it is equal to ENCODING_FROM_CPG if it is present. 
+   Otherwise it is equal to ENCODING_FROM_LDID.
 
-Open options
-------------
-
-The following open options are available.
-
--  **ENCODING**\ =encoding_name: to override the encoding interpretation
-   of the shapefile with any encoding supported by CPLRecode or to "" to
-   avoid any recoding
--  **DBF_DATE_LAST_UPDATE=**\ *YYYY-MM-DD*: Modification date to write
-   in DBF header with year-month-day format. If not specified, current
-   date is used.
--  **ADJUST_TYPE**\ =YES/NO: Set to YES (default is NO) to read the
-   whole .dbf to adjust Real->Integer/Integer64 or Integer64->Integer
-   field types when possible. This can be used when field widths are
-   ambiguous and that by default OGR would select the larger data type.
-   For example, a numeric column with 0 decimal figures and with width
-   of 10/11 character may hold Integer or Integer64, and with width
-   19/20 may hold Integer64 or larger integer (hold as Real)
--  **ADJUST_GEOM_TYPE**\ =NO/FIRST_SHAPE/ALL_SHAPES. (Starting with GDAL
-   2.1) Defines how layer geometry type is computed, in particular to
-   distinguish shapefiles that have shapes with significant values in
-   the M dimension from the ones where the M values are set to the
-   nodata value. By default (FIRST_SHAPE), the driver will look at the
-   first shape and if it has M values it will expose the layer as having
-   a M dimension. By specifying ALL_SHAPES, the driver will iterate over
-   features until a shape with a valid M value is found to decide the
-   appropriate layer type.
--  **AUTO_REPACK=**\ *YES/NO*: (OGR >= 2.2) Default to YES in GDAL 2.2.
-   Whether the shapefile should be automatically repacked when needed,
-   at dataset closing or at FlushCache()/SyncToDisk() time.
--  **DBF_EOF_CHAR=**\ *YES/NO*: (OGR >= 2.2) Default to YES in GDAL 2.2.
-   Whether the .DBF should be terminated by a 0x1A end-of-file
-   character, as in the DBF spec and done by other software vendors.
-   Previous GDAL versions did not write one.
-
-Spatial and Attribute Indexing
+Spatial and attribute indexing
 ------------------------------
 
 The OGR Shapefile driver supports spatial indexing and a limited form of
@@ -286,18 +260,60 @@ arbitrarily large.
 However, for compatibility with other software implementation, it is not
 recommended to use a file size over 2GB for both .SHP and .DBF files.
 
-The 2GB_LIMIT=YES layer creation option can be
-used to strictly enforce that limit. For update mode, the
-:decl_configoption:`SHAPE_2GB_LIMIT` configuration option can be set to YES for similar
-effect. If nothing is set, a warning will be emitted when the 2GB limit
-is reached.
+The 2GB_LIMIT=YES layer creation option can be used to strictly enforce that 
+limit. For update mode, the :decl_configoption:`SHAPE_2GB_LIMIT` 
+configuration option can be set to YES for similar effect. If nothing is set, 
+a warning will be emitted when the 2GB limit is reached.
 
-Dataset Creation Options
+Compressed files
+----------------
+
+Starting with GDAL 3.1, the driver can also support reading, creating and
+editing .shz files (ZIP files containing the .shp, .shx, .dbf and other side-car
+files of a single layer) and .shp.zip files (ZIP files contains one or several
+layers). Creation and editing involves the creation of temporary files.
+
+Open options
+------------
+
+The following open options are available.
+
+-  **ENCODING**\ =encoding_name: to override the encoding interpretation
+   of the shapefile with any encoding supported by CPLRecode or to "" to
+   avoid any recoding
+-  **DBF_DATE_LAST_UPDATE=**\ *YYYY-MM-DD*: Modification date to write
+   in DBF header with year-month-day format. If not specified, current
+   date is used.
+-  **ADJUST_TYPE**\ =YES/NO: Set to YES (default is NO) to read the
+   whole .dbf to adjust Real->Integer/Integer64 or Integer64->Integer
+   field types when possible. This can be used when field widths are
+   ambiguous and that by default OGR would select the larger data type.
+   For example, a numeric column with 0 decimal figures and with width
+   of 10/11 character may hold Integer or Integer64, and with width
+   19/20 may hold Integer64 or larger integer (hold as Real)
+-  **ADJUST_GEOM_TYPE**\ =NO/FIRST_SHAPE/ALL_SHAPES. (Starting with GDAL
+   2.1) Defines how layer geometry type is computed, in particular to
+   distinguish shapefiles that have shapes with significant values in
+   the M dimension from the ones where the M values are set to the
+   nodata value. By default (FIRST_SHAPE), the driver will look at the
+   first shape and if it has M values it will expose the layer as having
+   a M dimension. By specifying ALL_SHAPES, the driver will iterate over
+   features until a shape with a valid M value is found to decide the
+   appropriate layer type.
+-  **AUTO_REPACK=**\ *YES/NO*: (OGR >= 2.2) Default to YES in GDAL 2.2.
+   Whether the shapefile should be automatically repacked when needed,
+   at dataset closing or at FlushCache()/SyncToDisk() time.
+-  **DBF_EOF_CHAR=**\ *YES/NO*: (OGR >= 2.2) Default to YES in GDAL 2.2.
+   Whether the .DBF should be terminated by a 0x1A end-of-file
+   character, as in the DBF spec and done by other software vendors.
+   Previous GDAL versions did not write one.
+
+Dataset creation options
 ------------------------
 
 None
 
-Layer Creation Options
+Layer creation options
 ----------------------
 
 -  **SHPT=type**: Override the type of shapefile created. Can be one of
@@ -329,20 +345,35 @@ Layer Creation Options
    character, as in the DBF spec and done by other software vendors.
    Previous GDAL versions did not write one.
 
-VSI Virtual File System API support
------------------------------------
+Configuration options
+---------------------
 
-The driver supports reading from files managed by VSI Virtual File
-System API, which include "regular" files, as well as files in the
-/vsizip/, /vsigzip/ , /vsicurl/ domains.
+The following :ref:`configuration options <configoptions>` are 
+available:
 
-Compressed files
-----------------
+- :decl_configoption:`SHAPE_REWIND_ON_WRITE` can be set to NO to prevent the 
+  shapefile writer to correct the winding order of exterior/interior rings to 
+  be conformant with the one mandated by the Shapefile specification. This can 
+  be useful in some situations where a MultiPolygon passed to the shapefile 
+  writer is not really a compliant Single Feature polygon, but originates from 
+  example from a MultiPatch object (from a Shapefile/FileGDB/PGeo datasource).
 
-Starting with GDAL 3.1, the driver can also support reading, creating and
-editing .shz files (ZIP files containing the .shp, .shx, .dbf and other side-car
-files of a single layer) and .shp.zip files (ZIP files contains one or several
-layers). Creation and editing involves the creation of temporary files.
+- :decl_configoption:`SHAPE_RESTORE_SHX` (GDAL >= 2.1): can be set to YES 
+  (default NO) to restore broken or absent .shx file from associated .shp file 
+  during opening.
+
+- :decl_configoption:`SHAPE_2GB_LIMIT` can be set to YES to strictly enforce 
+  the 2 GB file size limit when updating a shapefile. If nothing is set, a 
+  warning will be emitted when the 2 GB limit is reached.
+
+- :decl_configoption:`OGR_ORGANIZE_POLYGONS` can be set to DEFAULT to activate 
+  a full analysis based on topological relationships of the parts of the 
+  polygons to make sure that the ring ordering of all polygons are correct 
+  according to the OGC Simple Feature convention.
+
+- :decl_configoption:`SHAPE_ENCODING` may be used to override the encoding 
+  interpretation of the shapefile with any encoding supported by CPLRecode 
+  or to "" to avoid any recoding.
 
 Examples
 --------
@@ -372,30 +403,6 @@ Examples
    ::
 
       ogrinfo file1.dbf -sql "RESIZE file1"
-
-Advanced topics
----------------
-
-The :decl_configoption:`SHAPE_REWIND_ON_WRITE` configuration option/environment
-variable can be set to NO to prevent the shapefile writer to correct the
-winding order of exterior/interior rings to be conformant with the one
-mandated by the Shapefile specification. This can be useful in some
-situations where a MultiPolygon passed to the shapefile writer is not
-really a compliant Single Feature polygon, but originates from example
-from a MultiPatch object (from a Shapefile/FileGDB/PGeo datasource).
-
-(GDAL >= 2.1) The :decl_configoption:`SHAPE_RESTORE_SHX` configuration option/environment
-variable can be set to YES (default NO) to restore broken or absent .shx
-file from associated .shp file during opening.
-
-Driver capabilities
--------------------
-
-.. supports_create::
-
-.. supports_georeferencing::
-
-.. supports_virtualio::
 
 See Also
 --------

--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -354,7 +354,7 @@ Layer creation options
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 - :decl_configoption:`SQLITE_LIST_ALL_TABLES` =YES/NO: Set to "YES" to list 

--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -55,7 +55,7 @@ documentation <http://www.sqlite.org/pragma.html#pragma_synchronous>`__.
 Any SQLite
 `pragma <http://www.sqlite.org/pragma.html>`__ can be specified with the
 :decl_configoption:`OGR_SQLITE_PRAGMA` configuration option. The syntax is
-OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*".
+``OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"``.
 
 Driver capabilities
 -------------------
@@ -312,8 +312,9 @@ Layer Creation Options
    used to control if the compressed format for geometries (LINESTRINGs,
    POLYGONs) must be used. This format is understood by Spatialite v2.4
    (or any subsequent version). Default to NO. Note: when updating an
-   existing Spatialite DB, the COMPRESS_GEOM configuration option can be
-   set to produce similar results for appended/overwritten features.
+   existing Spatialite DB, the :decl_configoption:`COMPRESS_GEOM` 
+   configuration option can be set to produce similar results for 
+   appended/overwritten features.
 
 -  **SRID=srid**: Used to force the SRID
    number of the SRS associated with the layer. When this option isn't
@@ -353,20 +354,24 @@ Layer Creation Options
 Configuration Options
 ---------------------
 
-- :decl_configoption:**SQLITE_LIST_ALL_TABLES** =YES/NO: Set to "YES" to list 
+- :decl_configoption:`SQLITE_LIST_ALL_TABLES` =YES/NO: Set to "YES" to list 
   all tables (not just the tables listed in the geometry_columns table). This 
   can also be done using the LIST_ALL_TABLES open option. Default is NO.
 
-- :decl_configoption:**OGR_SQLITE_LIST_VIRTUAL_OGR** =YES/NO* Set to "YES" to 
+- :decl_configoption:`OGR_SQLITE_LIST_VIRTUAL_OGR` =YES/NO* Set to "YES" to 
   list VirtualOGR layers. Defaults to "NO" as there might be some security 
   implications if a user is provided with a file and doesn't know that there 
   are virtual OGR tables in it.
 
-- :decl_configoption:**OGR_SQLITE_CACHE**: see Performance hints
+- :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
+  of the SQLite file, see also 
+  https://www.sqlite.org/pragma.html#pragma_journal_mode.
 
-- :decl_configoption:**OGR_SQLITE_SYNCHRONOUS**: see Performance hints
+- :decl_configoption:`OGR_SQLITE_CACHE`: see Performance hints.
 
-- :decl_configoption:**OGR_SQLITE_LOAD_EXTENSIONS** =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
+- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see Performance hints.
+
+- :decl_configoption:`OGR_SQLITE_LOAD_EXTENSIONS` =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
   (GDAL >= 3.5.0). Comma separated list of names of shared libraries containing
   extensions to load at database opening.
   If a file cannot be loaded directly, attempts are made to load with various
@@ -378,9 +383,9 @@ Configuration Options
   builds of sqlite3.
   Loading extensions as a potential security impact if they are untrusted.
 
-- :decl_configoption:**OGR_SQLITE_PRAGMA**: with this option any SQLite
+- :decl_configoption:`OGR_SQLITE_PRAGMA`: with this option any SQLite
   `pragma <http://www.sqlite.org/pragma.html>`__ can be specified. The syntax is
-  `OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"`.
+  ``OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"``.
 
 Performance hints
 -----------------

--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -392,6 +392,12 @@ available:
   `pragma <http://www.sqlite.org/pragma.html>`__ can be specified. The syntax is
   ``OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"``.
 
+- :decl_configoption:`SQLITE_USE_OGR_VFS` =YES enables extra buffering/caching 
+  by the GDAL/OGR I/O layer and can speed up I/O. More information 
+  :ref:`here <target_user_virtual_file_systems_file_caching>`.
+  Be aware that no file locking will occur if this option is activated, so 
+  concurrent edits may lead to database corruption.
+
 .. _target_drivers_vector_sqlite_performance_hints:
 
 Performance hints

--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -246,7 +246,7 @@ Dataset open options
         The other database must be of a type recognized by this driver, so
         its geometry blobs are properly recognized (so typically not a GeoPackage one)
 
-Database Creation Options
+Database creation options
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  **METADATA=YES/NO**: This can be used to avoid creating the
@@ -280,7 +280,7 @@ Database Creation Options
      (*self-initialization*). Starting with libspatialite 4.0,
      INIT_WITH_EPSG defaults to YES, but can be set to NO.
 
-Layer Creation Options
+Layer creation options
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  **FORMAT=WKB/WKT/SPATIALITE**: Controls the format used for the
@@ -351,8 +351,11 @@ Layer Creation Options
    String, DateTime, Date and Time. The COMPRESS_COLUMNS option is ignored in
    strict mode.
 
-Configuration Options
+Configuration options
 ---------------------
+
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
 
 - :decl_configoption:`SQLITE_LIST_ALL_TABLES` =YES/NO: Set to "YES" to list 
   all tables (not just the tables listed in the geometry_columns table). This 
@@ -367,9 +370,11 @@ Configuration Options
   of the SQLite file, see also 
   https://www.sqlite.org/pragma.html#pragma_journal_mode.
 
-- :decl_configoption:`OGR_SQLITE_CACHE`: see Performance hints.
+- :decl_configoption:`OGR_SQLITE_CACHE`: see 
+  :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
 
-- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see Performance hints.
+- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see 
+  :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
 
 - :decl_configoption:`OGR_SQLITE_LOAD_EXTENSIONS` =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
   (GDAL >= 3.5.0). Comma separated list of names of shared libraries containing

--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -353,19 +353,20 @@ Layer Creation Options
 Configuration Options
 ---------------------
 
-- **SQLITE_LIST_ALL_TABLES** =YES/NO: Set to "YES" to list all tables
-  (not just the tables listed in the geometry_columns table). This can also
-  be done using the LIST_ALL_TABLES open option. Default is NO.
+- :decl_configoption:**SQLITE_LIST_ALL_TABLES** =YES/NO: Set to "YES" to list 
+  all tables (not just the tables listed in the geometry_columns table). This 
+  can also be done using the LIST_ALL_TABLES open option. Default is NO.
 
-- **OGR_SQLITE_LIST_VIRTUAL_OGR** =YES/NO* Set to "YES" to list VirtualOGR layers.
-  Defaults to "NO" as there might be some security implications if a user is
-  provided with a file and doesn't know that there are virtual OGR tables in it.
+- :decl_configoption:**OGR_SQLITE_LIST_VIRTUAL_OGR** =YES/NO* Set to "YES" to 
+  list VirtualOGR layers. Defaults to "NO" as there might be some security 
+  implications if a user is provided with a file and doesn't know that there 
+  are virtual OGR tables in it.
 
-- **OGR_SQLITE_CACHE**: see Performance hints
+- :decl_configoption:**OGR_SQLITE_CACHE**: see Performance hints
 
-- **OGR_SQLITE_SYNCHRONOUS**: see Performance hints
+- :decl_configoption:**OGR_SQLITE_SYNCHRONOUS**: see Performance hints
 
-- **OGR_SQLITE_LOAD_EXTENSIONS** =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
+- :decl_configoption:**OGR_SQLITE_LOAD_EXTENSIONS** =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
   (GDAL >= 3.5.0). Comma separated list of names of shared libraries containing
   extensions to load at database opening.
   If a file cannot be loaded directly, attempts are made to load with various
@@ -377,6 +378,9 @@ Configuration Options
   builds of sqlite3.
   Loading extensions as a potential security impact if they are untrusted.
 
+- :decl_configoption:**OGR_SQLITE_PRAGMA**: with this option any SQLite
+  `pragma <http://www.sqlite.org/pragma.html>`__ can be specified. The syntax is
+  `OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"`.
 
 Performance hints
 -----------------
@@ -401,14 +405,15 @@ related to a corresponding Spatial Index. Explicitly setting a much more
 generously dimensioned internal Page Cache may often help to get a
 noticeably better performance. You can
 explicitly set the internal Page Cache size using the configuration
-option :decl_configoption:`OGR_SQLITE_CACHE` *value* [*value* being measured in MB]; if
-your HW has enough available RAM, defining a Cache size as big as 512MB
-(or even 1024MB) may sometimes help a lot in order to get better
-performance.
+option :decl_configoption:`OGR_SQLITE_CACHE` *value* [*value* being 
+measured in MB]; if your HW has enough available RAM, defining a Cache 
+size as big as 512MB (or even 1024MB) may sometimes help a lot in order 
+to get better performance.
 
-Setting the :decl_configoption:`OGR_SQLITE_SYNCHRONOUS` configuration option to *OFF*
-might also increase performance when creating SQLite databases (although
-at the expense of integrity in case of interruption/crash ).
+Setting the :decl_configoption:`OGR_SQLITE_SYNCHRONOUS` configuration 
+option to *OFF* might also increase performance when creating SQLite 
+databases (although at the expense of integrity in case of 
+interruption/crash ).
 
 If many source files will be collected into the same Spatialite table,
 it can be much faster to initialize the table without a spatial index by

--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -387,6 +387,8 @@ Configuration Options
   `pragma <http://www.sqlite.org/pragma.html>`__ can be specified. The syntax is
   ``OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"``.
 
+.. _target_drivers_vector_sqlite_performance_hints:
+
 Performance hints
 -----------------
 

--- a/doc/source/drivers/vector/vfk.rst
+++ b/doc/source/drivers/vector/vfk.rst
@@ -48,17 +48,17 @@ The driver uses SQLite as a backend database
 when reading VFK data. By default, SQLite database is created in a
 directory of input VFK file (with file extension '.db').
 The user can define DB name with :decl_configoption:`OGR_VFK_DB_NAME` 
-configuration option. If :decl_configoption:`OGR_VFK_DB_OVERWRITE`=YES 
+configuration option. If :decl_configoption:`OGR_VFK_DB_OVERWRITE` =YES 
 configuration option is given, the driver overwrites existing SQLite 
 database and stores data read from input VFK file into newly created DB. 
-If :decl_configoption:`OGR_VFK_DB_DELETE`=YES configuration option is 
+If :decl_configoption:`OGR_VFK_DB_DELETE` =YES configuration option is 
 given, the driver deletes backend SQLite database when closing the datasource.
 
 Resolved geometries are stored also in backend
 SQLite database. It means that geometries are resolved only once when
 building SQLite database from VFK data. Geometries are stored in WKB
 format. Note that GDAL doesn't need to be built with SpatiaLite support.
-Geometries are not stored in DB when :decl_configoption:`OGR_VFK_DB_SPATIAL`=NO
+Geometries are not stored in DB when :decl_configoption:`OGR_VFK_DB_SPATIAL` =NO
 configuration option is given. In this case geometries are resolved when
 reading data from DB on the fly.
 
@@ -72,7 +72,7 @@ features by the driver.
 
 The driver reads by default all data blocks from VFK
 file when building backend SQLite database. When configuration option
-:decl_configoption:`OGR_VFK_DB_READ_ALL_BLOCKS`=NO is given, the driver 
+:decl_configoption:`OGR_VFK_DB_READ_ALL_BLOCKS` =NO is given, the driver 
 reads only data blocks which are requested by the user. This can be 
 useful when the user want to process only part of VFK data.
 
@@ -87,7 +87,7 @@ API, which include "regular" files, as well as files in the /vsizip/,
 
 Since GDAL 2.2 also a full path to the backend SQLite database can be
 used as an datasource. By default, such datasource is read by SQLite
-driver. If configuration option :decl_configoption:`OGR_VFK_DB_READ`=YES
+driver. If configuration option :decl_configoption:`OGR_VFK_DB_READ` =YES
 is given, such datasource is opened by VFK driver instead.
 
 Layer names

--- a/doc/source/drivers/vector/vfk.rst
+++ b/doc/source/drivers/vector/vfk.rst
@@ -42,7 +42,8 @@ Starting with GDAL 2.3, the following open options can be specified
 Configuration options
 ~~~~~~~~~~~~~~~~~~~~~
 
-(set with ``--config key value`` on GDAL command line utilities)
+Several :doc:`configuration options <../../user/configoptions>` are 
+available.
 
 The driver uses SQLite as a backend database
 when reading VFK data. By default, SQLite database is created in a

--- a/doc/source/drivers/vector/vfk.rst
+++ b/doc/source/drivers/vector/vfk.rst
@@ -42,7 +42,7 @@ Starting with GDAL 2.3, the following open options can be specified
 Configuration options
 ~~~~~~~~~~~~~~~~~~~~~
 
-Several :doc:`configuration options <../../user/configoptions>` are 
+Several :ref:`configuration options <configoptions>` are 
 available.
 
 The driver uses SQLite as a backend database

--- a/doc/source/drivers/vector/vfk.rst
+++ b/doc/source/drivers/vector/vfk.rst
@@ -47,18 +47,18 @@ Configuration options
 The driver uses SQLite as a backend database
 when reading VFK data. By default, SQLite database is created in a
 directory of input VFK file (with file extension '.db').
-The user can define DB name with **OGR_VFK_DB_NAME** configuration
-option. If **OGR_VFK_DB_OVERWRITE=YES** configuration option is given,
-the driver overwrites existing SQLite database and stores data read from
-input VFK file into newly created DB. If
-**OGR_VFK_DB_DELETE=YES** configuration option is given, the driver
-deletes backend SQLite database when closing the datasource.
+The user can define DB name with :decl_configoption:`OGR_VFK_DB_NAME` 
+configuration option. If :decl_configoption:`OGR_VFK_DB_OVERWRITE`=YES 
+configuration option is given, the driver overwrites existing SQLite 
+database and stores data read from input VFK file into newly created DB. 
+If :decl_configoption:`OGR_VFK_DB_DELETE`=YES configuration option is 
+given, the driver deletes backend SQLite database when closing the datasource.
 
 Resolved geometries are stored also in backend
 SQLite database. It means that geometries are resolved only once when
 building SQLite database from VFK data. Geometries are stored in WKB
 format. Note that GDAL doesn't need to be built with SpatiaLite support.
-Geometries are not stored in DB when **OGR_VFK_DB_SPATIAL=NO**
+Geometries are not stored in DB when :decl_configoption:`OGR_VFK_DB_SPATIAL`=NO
 configuration option is given. In this case geometries are resolved when
 reading data from DB on the fly.
 
@@ -72,9 +72,9 @@ features by the driver.
 
 The driver reads by default all data blocks from VFK
 file when building backend SQLite database. When configuration option
-**OGR_VFK_DB_READ_ALL_BLOCKS=NO** is given, the driver reads only data
-blocks which are requested by the user. This can be useful when the user
-want to process only part of VFK data.
+:decl_configoption:`OGR_VFK_DB_READ_ALL_BLOCKS`=NO is given, the driver 
+reads only data blocks which are requested by the user. This can be 
+useful when the user want to process only part of VFK data.
 
 Datasource name
 ---------------
@@ -87,8 +87,8 @@ API, which include "regular" files, as well as files in the /vsizip/,
 
 Since GDAL 2.2 also a full path to the backend SQLite database can be
 used as an datasource. By default, such datasource is read by SQLite
-driver. If configuration option **OGR_VFK_DB_READ=YES** is given, such
-datasource is open by VFK driver instead.
+driver. If configuration option :decl_configoption:`OGR_VFK_DB_READ`=YES
+is given, such datasource is opened by VFK driver instead.
 
 Layer names
 -----------

--- a/doc/source/drivers/vector/vrt.rst
+++ b/doc/source/drivers/vector/vrt.rst
@@ -52,8 +52,8 @@ format <https://github.com/OSGeo/gdal/blob/master/data/ogrvrt.xsd>`__ is
 available. When GDAL is configured with libXML2
 support, that schema will be used to validate the VRT documents.
 Non-conformities will be reported only as warnings. That validation can
-be disabled by setting the GDAL_XML_VALIDATION configuration option to
-NO.
+be disabled by setting the :decl_configoption:`GDAL_XML_VALIDATION` 
+configuration option to "NO".
 
 Metadata element
 ++++++++++++++++

--- a/doc/source/drivers/vector/wasp.rst
+++ b/doc/source/drivers/vector/wasp.rst
@@ -22,7 +22,7 @@ Driver capabilities
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`WASP_FIELDS`: a comma separated list of fields. 

--- a/doc/source/drivers/vector/wasp.rst
+++ b/doc/source/drivers/vector/wasp.rst
@@ -22,6 +22,9 @@ Driver capabilities
 Configuration options
 ---------------------
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 -  :decl_configoption:`WASP_FIELDS`: a comma separated list of fields. 
    For elevation, the name of the height field. For roughness, the 
    name of the left and right roughness fields resp.

--- a/doc/source/drivers/vector/wasp.rst
+++ b/doc/source/drivers/vector/wasp.rst
@@ -22,22 +22,23 @@ Driver capabilities
 Configuration options
 ---------------------
 
--  WASP_FIELDS : a comma separated list of fields. For elevation, the
-   name of the height field. For roughness, the name of the left and
-   right roughness fields resp.
--  WASP_MERGE : this may be set to "NO". Used only when generating
-   roughness from polygons. All polygon boundaries will be output
-   (including those with the same left and right roughness). This is
-   useful (along with option -skipfailures) for debugging incorrect
-   input geometries.
--  WASP_GEOM_FIELD : in case input has several geometry columns and the
-   first one (default) is not the right one.
--  WASP_TOLERANCE : specify a tolerance for line simplification of
-   output (calls geos).
--  WASP_ADJ_TOLER : points that are less than tolerance apart from
-   previous point on x and on y are omitted.
--  WASP_POINT_TO_CIRCLE_RADIUS : lines that became points due to
-   simplification are replaces by 8 point circles (octagons).
+-  :decl_configoption:`WASP_FIELDS`: a comma separated list of fields. 
+   For elevation, the name of the height field. For roughness, the 
+   name of the left and right roughness fields resp.
+-  :decl_configoption:`WASP_MERGE`: this may be set to "NO". Used only 
+   when generating roughness from polygons. All polygon boundaries will 
+   be output (including those with the same left and right roughness). 
+   This is useful (along with option -skipfailures) for debugging 
+   incorrect input geometries.
+-  :decl_configoption:`WASP_GEOM_FIELD`: in case input has several 
+   geometry columns and the first one (default) is not the right one.
+-  :decl_configoption:`WASP_TOLERANCE`: specify a tolerance for line 
+   simplification of output (calls geos).
+-  :decl_configoption:`WASP_ADJ_TOLER`: points that are less than 
+   tolerance apart from previous point on x and on y are omitted.
+-  :decl_configoption:`WASP_POINT_TO_CIRCLE_RADIUS`: lines that became 
+   points due to simplification are replaces by 8 point circles 
+   (octagons).
 
 Note that if not option is specified, the layer is assumed to be an
 elevation layer where the elevation is the z-components of the

--- a/doc/source/drivers/vector/wfs.rst
+++ b/doc/source/drivers/vector/wfs.rst
@@ -75,8 +75,9 @@ optionally set.
    is enabled (0 or 1). See "Request paging" section.
 -  **COOKIE**: HTTP cookies that are passed in HTTP requests, formatted
    as COOKIE1=VALUE1; COOKIE2=VALUE2... Starting with GDAL 2.3, additional
-   HTTP headers can be sent by setting the GDAL_HTTP_HEADER_FILE configuration
-   option to point to a filename of a text file with “key: value” HTTP headers.
+   HTTP headers can be sent by setting the 
+   :decl_configoption:`GDAL_HTTP_HEADER_FILE` configuration option to 
+   point to a filename of a text file with “key: value” HTTP headers.
 
 Request paging
 --------------
@@ -84,13 +85,14 @@ Request paging
 The WFS driver will read the GML content as a
 stream instead as a whole file, which will improve interactivity and
 help when the content cannot fit into memory. This can be turned off by
-setting the OGR_WFS_USE_STREAMING configuration option to NO if this is
+setting the :decl_configoption:`OGR_WFS_USE_STREAMING` configuration 
+option to NO if this is
 not desirable (for example, when iterating several times on a layer that
 can fit into memory). When streaming is enabled, GZip compression is
 also requested. It has been observed that some WFS servers, that cannot
 do on-the-fly compression, will cache on their side the whole content to
 be sent before sending the first bytes on the wire. To avoid this, you
-can set the CPL_CURL_GZIP configuration option to NO.
+can set the :decl_configoption:`CPL_CURL_GZIP` configuration option to NO.
 
 Paging with WFS 2.0
 +++++++++++++++++++
@@ -98,12 +100,13 @@ Paging with WFS 2.0
 The WFS driver will automatically detect if server supports paging, when
 requesting a WFS 2.0 server. The page size (number of features fetched in a
 single request) is limited to 100 by default when not declared by the server.
-It can be changed by setting the OGR_WFS_PAGE_SIZE configuration option, or by
+It can be changed by setting the :decl_configoption:`OGR_WFS_PAGE_SIZE` 
+configuration option, or by
 specifying COUNT as a query parameter in the URL of the connection string.
 
 If only the N first features must be downloaded and paging through the whole
-layer is not desirable, the OGR_WFS_PAGING_ALLOWED configuration option should
-be set to OFF.
+layer is not desirable, the :decl_configoption:`OGR_WFS_PAGING_ALLOWED` 
+configuration option should be set to OFF.
 
 Paging with WFS 1.0 or 1.1
 ++++++++++++++++++++++++++
@@ -113,26 +116,30 @@ that allows doing the requests per "page", and thus to avoid
 downloading the whole content of the layer in a single request. Paging
 was introduced in WFS 2.0.0 but servers may support it as an vendor
 specific option also with WFS 1.0.0 and 1.1.0. The OGR WFS client will
-use paging when the OGR_WFS_PAGING_ALLOWED configuration option is explicitly set
-to ON. The page size (number of features fetched in a single request)
+use paging when the :decl_configoption:`OGR_WFS_PAGING_ALLOWED` 
+configuration option is explicitly set to ON. 
+The page size (number of features fetched in a single request)
 is limited to 100 by default when not declared by the server.
-It can be changed by setting the OGR_WFS_PAGE_SIZE configuration option.
+It can be changed by setting the :decl_configoption:`OGR_WFS_PAGE_SIZE` 
+configuration option.
 
 WFS 2.0.2 specification has clarified that the first feature in paging
 is at index 0. But some server implementations of WFS paging have
 considered that it was at index 1 (including MapServer <= 6.2).
 The default base start index is 0, as mandated
-by the specification. The OGR_WFS_BASE_START_INDEX configuration
-option can however be set to 1 to be compatible with the server
-implementations that considered the first feature to be at index 1.
+by the specification. The :decl_configoption:`OGR_WFS_BASE_START_INDEX` 
+configuration option can however be set to 1 to be compatible with the 
+server implementations that considered the first feature to be at 
+index 1.
 
 Paging options
 ++++++++++++++
 
-Those 3 options (OGR_WFS_PAGING_ALLOWED, OGR_WFS_PAGE_SIZE,
-OGR_WFS_BASE_START_INDEX) can also be set in a WFS XML description
-file with the elements of similar names (PagingAllowed, PageSize,
-BaseStartIndex).
+Those 3 options (:decl_configoption:`OGR_WFS_PAGING_ALLOWED`, 
+:decl_configoption:`OGR_WFS_PAGE_SIZE`, 
+:decl_configoption:`OGR_WFS_BASE_START_INDEX`) can also be set in 
+a WFS XML description file with the elements of similar names 
+(PagingAllowed, PageSize, BaseStartIndex).
 
 Filtering
 ---------

--- a/doc/source/drivers/vector/xls.rst
+++ b/doc/source/drivers/vector/xls.rst
@@ -19,7 +19,7 @@ directly (but you may use the OGR VRT capabilities for that).
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`OGR_XLS_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver

--- a/doc/source/drivers/vector/xls.rst
+++ b/doc/source/drivers/vector/xls.rst
@@ -19,6 +19,9 @@ directly (but you may use the OGR VRT capabilities for that).
 Configuration options
 ---------------------
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 -  :decl_configoption:`OGR_XLS_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver
    will read the first lines of each sheet to detect if the first line
    might be the name of columns. If set to FORCE, the driver will

--- a/doc/source/drivers/vector/xlsx.rst
+++ b/doc/source/drivers/vector/xlsx.rst
@@ -42,6 +42,9 @@ Driver capabilities
 Configuration options
 ---------------------
 
+The following :doc:`configuration options <../../user/configoptions>` are 
+available:
+
 -  :decl_configoption:`OGR_XLSX_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver
    will read the first lines of each sheet to detect if the first line
    might be the name of columns. If set to FORCE, the driver will

--- a/doc/source/drivers/vector/xlsx.rst
+++ b/doc/source/drivers/vector/xlsx.rst
@@ -42,7 +42,7 @@ Driver capabilities
 Configuration options
 ---------------------
 
-The following :doc:`configuration options <../../user/configoptions>` are 
+The following :ref:`configuration options <configoptions>` are 
 available:
 
 -  :decl_configoption:`OGR_XLSX_HEADERS` = FORCE / DISABLE / AUTO : By default, the driver

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -672,6 +672,8 @@ The file referenced by /vsisparse/ should be an XML control file formatted somet
 
 Hopefully the values and semantics are fairly obvious.
 
+.. _target_user_virtual_file_systems_file_caching:
+
 File caching
 ------------
 


### PR DESCRIPTION
- Mainly improvements to the documentation of configuration options, typically 
  - add :decl_configoption: they should be present everywhere where applicable now.
  - if there is a specific section about configuration option for the driver, add a link to the configuration options page so the usage instructions are easier to find.
- Sometimes some small improvements to formatting like adding headers,... were done
- In the GPKG driver documentation added a link to "Performance hints" section in the SQLITE driver page as the performance hints are applicable to both drivers. 