### PR TITLE
Fix gdal_grid and gdal_edit links in XYZ and ECW drivers docs

### DIFF
--- a/doc/source/drivers/raster/ecw.rst
+++ b/doc/source/drivers/raster/ecw.rst
@@ -184,7 +184,7 @@ SetMetadataItem(), the later values will override the values built from
 the projection string.
 
 All those can for example be modified with the -a_ullr, -a_srs or -mo
-switches of the `gdal_edit.py <gdal_edit.html>`__ utility.
+switches of the :ref:`gdal_edit` utility.
 
 For example:
 

--- a/doc/source/drivers/raster/xyz.rst
+++ b/doc/source/drivers/raster/xyz.rst
@@ -10,7 +10,7 @@ XYZ -- ASCII Gridded XYZ
 
 GDAL supports reading and writing ASCII **gridded** XYZ raster datasets
 (i.e. ungridded XYZ, LIDAR XYZ etc. must be opened by other means. See
-the documentation of the `gdal_grid <gdal_grid.html>`__ utility).
+the documentation of the :ref:`gdal_grid` utility).
 
 Those datasets are ASCII files with (at least) 3 columns, each line
 containing the X and Y coordinates of the center of the cell and the


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Fixes the links to the gdal_grid and gdal_edit tools docs in the [XYZ](https://gdal.org/drivers/raster/xyz.html) and [ECW](https://gdal.org/drivers/raster/ecw.html) drivers docs.
Currently, such links, ``gdal_grid <gdal_grid.html>`__` and ``gdal_edit.py <gdal_edit.html>`__`, point respectively to non existent https://gdal.org/drivers/raster/gdal_grid.html and https://gdal.org/drivers/raster/gdal_edit.html pages.
I've substituted them with `:ref:`gdal_grid`` and `:ref:`gdal_edit``.

I wonder if this would have been addressed by the redirection code in https://github.com/OSGeo/gdal/blob/de5c6b3dc4016c2abf055a9c7281e17bdad53e73/doc/source/_extensions/redirects.py#L85-L86