### PR TITLE
GeoParquet: update to version 0.2.0

### DIFF
--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -659,9 +659,7 @@ def test_ogr_parquet_geometry_type(written_geom_type,written_wkt,expected_geom_t
 
     outfilename = '/vsimem/out.parquet'
     ds = gdal.GetDriverByName('Parquet').Create(outfilename, 0, 0, 0, gdal.GDT_Unknown)
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(4326)
-    lyr = ds.CreateLayer('out', geom_type=written_geom_type, srs=srs)
+    lyr = ds.CreateLayer('out', geom_type=written_geom_type)
     for wkt in written_wkt:
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetGeometryDirectly(ogr.CreateGeometryFromWkt(wkt))
@@ -672,6 +670,7 @@ def test_ogr_parquet_geometry_type(written_geom_type,written_wkt,expected_geom_t
     assert ds is not None
     lyr = ds.GetLayer(0)
     assert lyr.GetGeomType() == expected_geom_type
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == '4326'
     if expected_wkts is None:
         expected_wkts = written_wkt
     for wkt in expected_wkts:

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -111,12 +111,6 @@ bool OGRParquetWriterLayer::SetOptions(CSLConstList papszOptions,
             return false;
         }
 
-        if( poSpatialRef == nullptr )
-        {
-            CPLError(CE_Warning, CPLE_AppDefined,
-                     "Geometry column should have an associated CRS");
-        }
-
         m_poFeatureDefn->SetGeomType(eGType);
         auto eGeomEncoding = m_eGeomEncoding;
         if( eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_GENERIC )
@@ -214,7 +208,7 @@ void OGRParquetWriterLayer::PerformStepsBeforeFinalFlushGroup()
         CPLTestBool(CPLGetConfigOption("OGR_PARQUET_WRITE_GEO", "YES")) )
     {
         CPLJSONObject oRoot;
-        oRoot.Add("version", "0.1.0");
+        oRoot.Add("version", "0.2.0");
         oRoot.Add("primary_column",
                   m_poFeatureDefn->GetGeomFieldDefn(0)->GetNameRef());
         CPLJSONObject oColumns;


### PR DESCRIPTION
- on layer creation, no longer warn when no CRS is provided, since this
  is now an optional member
- on reading, when 'crs' is absent, assume EPSG:4326 as mentioned in the
  specification
