### PR TITLE
CAD/libopencad: avoid infinite recursion / stack overflow.

### DIFF
--- a/ogr/ogrsf_frmts/cad/libopencad/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/cad/libopencad/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(
   cadtables.cpp
   opencad.cpp)
 target_compile_definitions(libopencad PRIVATE "OCAD_EXTERN=")
+# Enable below line to debug ossfuzz issues
+# target_compile_definitions(libopencad PRIVATE "-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION")
 target_include_directories(
   libopencad PRIVATE $<TARGET_PROPERTY:cpl,SOURCE_DIR> $<TARGET_PROPERTY:cpl,BINARY_DIR>
                      $<TARGET_PROPERTY:ogr_CAD,SOURCE_DIR> ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/dwg)


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46887

Otherwise we get the following infinite call stack:
```
 #5  0x00007fffedee20a6 in DWGFileR2000::GetObject (this=0x5555557a5c60, dHandle=0, bHandlesOnly=false) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp:1098
 #6  0x00007fffedf191e0 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:178
 #7  0x00007fffedf194f2 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:226
 #8  0x00007fffedf194f2 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:226
 #9  0x00007fffedf194f2 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:226
 #10 0x00007fffedf194f2 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:226
 #11 0x00007fffedf194f2 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:226
 #12 0x00007fffedf194f2 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:226
 #13 0x00007fffedf194f2 in CADLayer::addHandle (this=0x5555557a4180, handle=512, type=CADObject::INSERT, cadinserthandle=512) at /home/even/gdal/gdal/ogr/ogrsf_frmts/cad/libopencad/cadlayer.cpp:226
```

CC @BishopGIS 