### PR TITLE
Parquet: update to GeoParquet 0.3.0

### DIFF
--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -59,6 +59,10 @@ Layer creation options
   layer creation option of the Parquet driver (unless ``-lco FID=`` is used to
   set an empty name)
 
+- **POLYGON_ORIENTATION=COUNTERCLOCKWISE/UNMODIFIED**: Whether exterior rings
+  of polygons should be counterclockwise oriented (and interior rings clockwise
+  oriented), or left to their original orientation. The default is COUNTERCLOCKWISE.
+
 Links
 -----
 

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -120,6 +120,7 @@ class OGRParquetWriterLayer final: public OGRArrowWriterLayer
 
         std::unique_ptr<parquet::arrow::FileWriter> m_poFileWriter{};
         std::shared_ptr<const arrow::KeyValueMetadata> m_poKeyValueMetadata{};
+        bool                                           m_bForceCounterClockwiseOrientation = false;
 
         virtual bool            IsFileWriterCreated() const override { return m_poFileWriter != nullptr; }
         virtual void            CreateWriter() override;

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -283,6 +283,16 @@ void OGRParquetDriver::InitMetadata()
         CPLAddXMLAttributeAndValue(psOption, "description", "Name of the FID column to create");
     }
 
+    {
+        auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
+        CPLAddXMLAttributeAndValue(psOption, "name", "POLYGON_ORIENTATION");
+        CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
+        CPLAddXMLAttributeAndValue(psOption, "description", "Which ring orientation to use for polygons");
+        CPLAddXMLAttributeAndValue(psOption, "default", "COUNTERCLOCKWISE");
+        CPLCreateXMLElementAndValue(psOption, "Value", "COUNTERCLOCKWISE");
+        CPLCreateXMLElementAndValue(psOption, "Value", "UNMODIFIED");
+    }
+
     char* pszXML = CPLSerializeXMLTree(oTree.get());
     GDALDriver::SetMetadataItem(GDAL_DS_LAYER_CREATIONOPTIONLIST, pszXML);
     CPLFree(pszXML);


### PR DESCRIPTION
- update version to 0.3.0
- add orientation=counterclockwise metadata item
- add a POLYGON_ORIENTATION=COUNTERCLOCKWISE/UNMODIFIED layer creation
  option to let the user decide if winding order must be adjusted
  (default), or not.
