### PR TITLE
Add support for Haiku OS

### DIFF
--- a/port/cpl_vsil_unix_stdio_64.cpp
+++ b/port/cpl_vsil_unix_stdio_64.cpp
@@ -1023,7 +1023,7 @@ begin:
                 osCurFile += '/';
             osCurFile += entry.pszName;
 
-#if !defined(__sun)
+#if !defined(__sun) && !defined(__HAIKU__)
             if( psEntry->d_type == DT_REG )
                 entry.nMode = S_IFREG;
             else if( psEntry->d_type == DT_DIR )
@@ -1052,7 +1052,7 @@ begin:
                 if( STARTS_WITH(m_osFilterPrefix.c_str(), osName.c_str()) &&
                     m_osFilterPrefix[osName.size()] == '/' )
                 {
-#if !defined(__sun)
+#if !defined(__sun) && !defined(__HAIKU__)
                     if( psEntry->d_type == DT_UNKNOWN )
 #endif
                     {
@@ -1072,7 +1072,7 @@ begin:
             }
 
             if( !m_bNameAndTypeOnly
-#if !defined(__sun)
+#if !defined(__sun) && !defined(__HAIKU__)
                 || psEntry->d_type == DT_UNKNOWN
 #endif
                 )


### PR DESCRIPTION
## What does this PR do?

Fixes compilation on Haiku OS (https://www.haiku-os.org/). Like Solaris, Haiku doesn't have the `d_type` member of the `dirent` structure.

Is this ok, or would you rather I add a cmake `CHECK_STRUCT_HAS_MEMBER` test?

## What are related issues/pull requests?

https://github.com/haikuports/haikuports/pull/6854

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Haiku OS
* Compiler: gcc 11
