### PR TITLE
GeoParquet: various fixes / enhancements (fixes #5670)

### DIFF
--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -63,6 +63,10 @@ Layer creation options
   of polygons should be counterclockwise oriented (and interior rings clockwise
   oriented), or left to their original orientation. The default is COUNTERCLOCKWISE.
 
+- **EDGES=PLANAR/SPHERICAL**: How to interpret the edges of the geometries: whether
+  the line between two points is a straight cartesian line (PLANAR) or the
+  shortest line on the sphere (geodesic line) (SPHERICAL). The default is PLANAR.
+
 Links
 -----
 

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
@@ -705,7 +705,7 @@ int OGRFeatherLayer::TestCapability(const char* pszCap)
             }
             const auto& oJSONDef = oIter->second;
             const auto oBBox = oJSONDef.GetArray("bbox");
-            if( !(oBBox.IsValid() && oBBox.Size() == 4) )
+            if( !(oBBox.IsValid() && (oBBox.Size() == 4 || oBBox.Size() == 6)) )
             {
                 return false;
             }

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -2260,6 +2260,17 @@ OGRErr OGRArrowLayer::GetExtent(int iGeomField, OGREnvelope *psExtent,
             if( psExtent->MinX <= psExtent->MaxX )
                 return OGRERR_NONE;
         }
+        else if( oBBox.IsValid() && oBBox.Size() == 6 )
+        {
+            psExtent->MinX = oBBox[0].ToDouble();
+            psExtent->MinY = oBBox[1].ToDouble();
+            // MinZ skipped
+            psExtent->MaxX = oBBox[3].ToDouble();
+            psExtent->MaxY = oBBox[4].ToDouble();
+            // MaxZ skipped
+            if( psExtent->MinX <= psExtent->MaxX )
+                return OGRERR_NONE;
+        }
     }
 
     if( !bForce && !CanRunNonForcedGetExtent() )

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -1231,8 +1231,16 @@ OGRErr OGRArrowWriterLayer::ICreateFeature( OGRFeature* poFeature )
             auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder*>(poBuilder);
             poPointBuilder->Append();
             auto poValueBuilder = static_cast<arrow::DoubleBuilder*>(poPointBuilder->value_builder());
-            poValueBuilder->Append(poPoint->getX());
-            poValueBuilder->Append(poPoint->getY());
+            if( bIsEmpty )
+            {
+                poValueBuilder->Append(std::numeric_limits<double>::quiet_NaN());
+                poValueBuilder->Append(std::numeric_limits<double>::quiet_NaN());
+            }
+            else
+            {
+                poValueBuilder->Append(poPoint->getX());
+                poValueBuilder->Append(poPoint->getY());
+            }
             if( OGR_GT_HasZ(eColumnGType) )
                 poValueBuilder->Append(poPoint->getZ());
             if( OGR_GT_HasM(eColumnGType) )

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -121,6 +121,7 @@ class OGRParquetWriterLayer final: public OGRArrowWriterLayer
         std::unique_ptr<parquet::arrow::FileWriter> m_poFileWriter{};
         std::shared_ptr<const arrow::KeyValueMetadata> m_poKeyValueMetadata{};
         bool                                           m_bForceCounterClockwiseOrientation = false;
+        bool                                           m_bEdgesSpherical = false;
 
         virtual bool            IsFileWriterCreated() const override { return m_poFileWriter != nullptr; }
         virtual void            CreateWriter() override;

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -293,6 +293,16 @@ void OGRParquetDriver::InitMetadata()
         CPLCreateXMLElementAndValue(psOption, "Value", "UNMODIFIED");
     }
 
+    {
+        auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
+        CPLAddXMLAttributeAndValue(psOption, "name", "EDGES");
+        CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
+        CPLAddXMLAttributeAndValue(psOption, "description", "Name of the coordinate system for the edges");
+        CPLAddXMLAttributeAndValue(psOption, "default", "PLANAR");
+        CPLCreateXMLElementAndValue(psOption, "Value", "PLANAR");
+        CPLCreateXMLElementAndValue(psOption, "Value", "SPHERICAL");
+    }
+
     char* pszXML = CPLSerializeXMLTree(oTree.get());
     GDALDriver::SetMetadataItem(GDAL_DS_LAYER_CREATIONOPTIONLIST, pszXML);
     CPLFree(pszXML);

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -182,6 +182,9 @@ bool OGRParquetWriterLayer::SetOptions(CSLConstList papszOptions,
         }
     }
 
+    m_bEdgesSpherical = EQUAL(
+        CSLFetchNameValueDef(papszOptions, "EDGES", "PLANAR"), "SPHERICAL");
+
     m_bInitializationOK = true;
     return true;
 }
@@ -225,20 +228,47 @@ void OGRParquetWriterLayer::PerformStepsBeforeFinalFlushGroup()
             oColumn.Add("encoding",
                         GetGeomEncodingAsString(m_aeGeomEncoding[i]));
 
-            const auto poSRS = poGeomFieldDefn->GetSpatialRef();
-            if( poSRS )
+            if( CPLTestBool(CPLGetConfigOption(
+                    "OGR_PARQUET_WRITE_CRS", "YES")) )
             {
-                const char* const apszOptions[] = {
-                    "FORMAT=WKT2_2019", "MULTILINE=NO", nullptr };
-                char* pszWKT = nullptr;
-                poSRS->exportToWkt(&pszWKT, apszOptions);
-                if( pszWKT )
-                    oColumn.Add("crs", pszWKT);
-                CPLFree(pszWKT);
+                const auto poSRS = poGeomFieldDefn->GetSpatialRef();
+                if( poSRS )
+                {
+                    if( EQUAL(CPLGetConfigOption(
+                        "OGR_PARQUET_CRS_ENCODING", "WKT"), "PROJJSON") )
+                    {
+                        // CRS encoded as PROJJSON (extension)
+                        char* pszPROJJSON = nullptr;
+                        poSRS->exportToPROJJSON(&pszPROJJSON, nullptr);
+                        CPLJSONDocument oDoc;
+                        oDoc.LoadMemory(pszPROJJSON);
+                        CPLFree(pszPROJJSON);
+                        oColumn.Add("crs", oDoc.GetRoot());
+                    }
+                    else
+                    {
+                        const char* const apszOptions[] = {
+                            "FORMAT=WKT2_2019", "MULTILINE=NO", nullptr };
+                        char* pszWKT = nullptr;
+                        poSRS->exportToWkt(&pszWKT, apszOptions);
+                        if( pszWKT )
+                            oColumn.Add("crs", pszWKT);
+                        CPLFree(pszWKT);
+                    }
 
-                const double dfCoordEpoch = poSRS->GetCoordinateEpoch();
-                if( dfCoordEpoch > 0 )
-                    oColumn.Add("epoch", dfCoordEpoch);
+                    const double dfCoordEpoch = poSRS->GetCoordinateEpoch();
+                    if( dfCoordEpoch > 0 )
+                        oColumn.Add("epoch", dfCoordEpoch);
+                }
+                else
+                {
+                    oColumn.AddNull("crs");
+                }
+            }
+
+            if( m_bEdgesSpherical )
+            {
+                oColumn.Add("edges", "spherical");
             }
 
             if( m_aoEnvelopes[i].IsInit() &&


### PR DESCRIPTION
- When writing GeoArrow.Point encoding, deal proprely with empty point
- Add a EDGES=PLANAR/SPHERICAL creation option
- When edges=spherical, report a EDGES=SPHERICAL metadata item at layer
  level
- On reading, interpret ``"crs":null`` as no CRS
- On writing, encode missing CRS as ``"crs":null``
- On reading, handle "bbox" with 6 elements (writing of Z/M/ZM
  unmodified for now, and still writing 4 values)
- (extension) On writing, if the OGR_PARQUET_CRS_ENCODING configuration
  option is set to PROJJSON, set PROJJSON content in ``crs``
- (extension) On reading, accept PROJJSON as ``crs`` value
