### PR TITLE
port/cpl_recode_iconv.cpp: fix invalid cast error

### DIFF
--- a/port/cpl_recode_iconv.cpp
+++ b/port/cpl_recode_iconv.cpp
@@ -87,7 +87,7 @@ char *CPLRecodeIconv( const char *pszSource,
 
     sConv = iconv_open( pszDstEncoding, pszSrcEncoding );
 
-    if( sConv == reinterpret_cast<iconv_t>(-1) )
+    if( sConv == (iconv_t)(-1) )
     {
         CPLError( CE_Warning, CPLE_AppDefined,
                   "Recode from %s to %s failed with the error: \"%s\".",
@@ -236,7 +236,7 @@ char *CPLRecodeFromWCharIconv( const wchar_t *pwszSource,
 
     sConv = iconv_open( pszDstEncoding, pszSrcEncoding );
 
-    if( sConv == reinterpret_cast<iconv_t>(-1) )
+    if( sConv == (iconv_t)(-1) )
     {
         CPLFree( pszIconvSrcBuf );
         CPLError( CE_Warning, CPLE_AppDefined,

--- a/port/cpl_recode_iconv.cpp
+++ b/port/cpl_recode_iconv.cpp
@@ -244,7 +244,6 @@ char *CPLRecodeFromWCharIconv( const wchar_t *pwszSource,
 
     sConv = iconv_open( pszDstEncoding, pszSrcEncoding );
 
-```suggestion
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"

--- a/port/cpl_recode_iconv.cpp
+++ b/port/cpl_recode_iconv.cpp
@@ -87,7 +87,15 @@ char *CPLRecodeIconv( const char *pszSource,
 
     sConv = iconv_open( pszDstEncoding, pszSrcEncoding );
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+    // iconv_t might be a integer or a pointer, so we have to fallback to C-style cast
     if( sConv == (iconv_t)(-1) )
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
     {
         CPLError( CE_Warning, CPLE_AppDefined,
                   "Recode from %s to %s failed with the error: \"%s\".",
@@ -236,7 +244,16 @@ char *CPLRecodeFromWCharIconv( const wchar_t *pwszSource,
 
     sConv = iconv_open( pszDstEncoding, pszSrcEncoding );
 
+```suggestion
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+    // iconv_t might be a integer or a pointer, so we have to fallback to C-style cast
     if( sConv == (iconv_t)(-1) )
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
     {
         CPLFree( pszIconvSrcBuf );
         CPLError( CE_Warning, CPLE_AppDefined,


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

I'm currently packaging gdal for use with Buildroot (https://buildroot.org/) which basically aids in cross-compiling
for various (embedded) toolchains/architectures.

Unfortunately with some toolchains (e.g. arm-buildroot-linux-uclibcgnueabi-gcc) I'm getting errors during compilation:

```
cpl_recode_iconv.cpp: In function ‘char* CPLRecodeIconv(const char*, const char*, const char*)’:
cpl_recode_iconv.cpp:90:18: error: invalid cast from type ‘int’ to type ‘iconv_t’ {aka ‘long int’}
   90 |     if( sConv == reinterpret_cast<iconv_t>(-1) )
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cpl_recode_iconv.cpp: In function ‘char* CPLRecodeFromWCharIconv(const wchar_t*, const char*, const char*)’:
cpl_recode_iconv.cpp:239:18: error: invalid cast from type ‘int’ to type ‘iconv_t’ {aka ‘long int’}
  239 |     if( sConv == reinterpret_cast<iconv_t>(-1) )
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

My PR fixes the errors for all toolchains but may introduce warnings
along the lines of `use of old-style cast to ‘iconv_t’ {aka ‘void*’}`.

I don't have the expertise to attribute the error to one specific property of the toolchains
where compilation is failing.

I'm looking forward to feedback and to figuring out whether my PR is applicable.

## Environment

* Compiler: arm-buildroot-linux-uclibcgnueabi-gcc (gcc 10.3.0)