### PR TITLE
PNG: report cause when unable to create file

### DIFF
--- a/frmts/png/pngdataset.cpp
+++ b/frmts/png/pngdataset.cpp
@@ -1446,8 +1446,8 @@ PNGDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     if( fpImage == nullptr )
     {
         CPLError( CE_Failure, CPLE_OpenFailed,
-                  "Unable to create png file %s.\n",
-                  pszFilename );
+                  "Unable to create png file %s: %s\n",
+                  pszFilename, VSIStrerror(errno) );
         return nullptr;
     }
 
@@ -2443,8 +2443,8 @@ GDALDataset *PNGDataset::Create
     if( poDS->m_fpImage == NULL )
     {
         CPLError( CE_Failure, CPLE_OpenFailed,
-                  "Unable to create PNG file %s.\n",
-                  pszFilename );
+                  "Unable to create PNG file %s: %s\n",
+                  pszFilename, VSIStrerror(errno) );
         delete poDS;
         return NULL;
     }


### PR DESCRIPTION
## What does this PR do?

When creating a PNG failed the error message did not include the root cause of the failure. Added VSIStrerror(errno) following example of GTiff.
