### PR TITLE
Zarr: hide X/Y subdatasets of a single 2D georeferenced array when opening with 2D raster API (fixes #5681)

### DIFF
--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -294,6 +294,8 @@ GDALDataset* ZarrDataset::Open(GDALOpenInfo* poOpenInfo)
 
     auto poDS = cpl::make_unique<ZarrDataset>(nullptr);
     std::shared_ptr<GDALMDArray> poMainArray;
+    std::vector<std::string> aosArrays;
+    std::string osMainArray;
     if( !osArrayOfInterest.empty() )
     {
         poMainArray = osArrayOfInterest == "/" ? poRG->OpenMDArray("/") :
@@ -340,12 +342,10 @@ GDALDataset* ZarrDataset::Open(GDALOpenInfo* poOpenInfo)
     }
     else
     {
-        std::vector<std::string> aosArrays;
         ExploreGroup(poRG, aosArrays, 0);
         if( aosArrays.empty() )
             return nullptr;
 
-        std::string osMainArray;
         if( aosArrays.size() == 1 )
         {
             poMainArray = poRG->OpenMDArrayFromFullname(aosArrays[0]);
@@ -447,17 +447,14 @@ GDALDataset* ZarrDataset::Open(GDALOpenInfo* poOpenInfo)
         {
             for( size_t i = 0; i < aosArrays.size(); ++i )
             {
-                if( aosArrays[i] != osMainArray )
-                {
-                    poDS->m_aosSubdatasets.AddString(
-                        CPLSPrintf("SUBDATASET_%d_NAME=ZARR:\"%s\":%s",
-                                   iCountSubDS, osFilename.c_str(),
-                                   aosArrays[i].c_str()));
-                    poDS->m_aosSubdatasets.AddString(
-                        CPLSPrintf("SUBDATASET_%d_DESC=Array %s",
-                                   iCountSubDS, aosArrays[i].c_str()));
-                    ++iCountSubDS;
-                }
+                poDS->m_aosSubdatasets.AddString(
+                    CPLSPrintf("SUBDATASET_%d_NAME=ZARR:\"%s\":%s",
+                               iCountSubDS, osFilename.c_str(),
+                               aosArrays[i].c_str()));
+                poDS->m_aosSubdatasets.AddString(
+                    CPLSPrintf("SUBDATASET_%d_DESC=Array %s",
+                               iCountSubDS, aosArrays[i].c_str()));
+                ++iCountSubDS;
             }
         }
     }
@@ -466,12 +463,55 @@ GDALDataset* ZarrDataset::Open(GDALOpenInfo* poOpenInfo)
     {
         std::unique_ptr<GDALDataset> poNewDS;
         if( poMainArray->GetDimensionCount() == 2 )
+        {
             poNewDS.reset(poMainArray->AsClassicDataset(1, 0));
+
+            // If we have 3 arrays, check that the 2 ones that are not the main
+            // 2D array are indexing variables of its dimensions. If so, don't
+            // expose them as subdatasets
+            if( aosArrays.size() == 3 )
+            {
+                std::vector<std::string> aosOtherArrays;
+                for( size_t i = 0; i < aosArrays.size(); ++i )
+                {
+                    if( aosArrays[i] != osMainArray )
+                    {
+                        aosOtherArrays.emplace_back(aosArrays[i]);
+                    }
+                }
+                bool bMatchFound[] = { false, false };
+                for(int i = 0; i < 2; i++ )
+                {
+                    auto poIndexingVar =
+                        poMainArray->GetDimensions()[i]->GetIndexingVariable();
+                    if( poIndexingVar )
+                    {
+                        for( int j = 0; j < 2; j++ )
+                        {
+                            if( aosOtherArrays[j] == poIndexingVar->GetFullName() )
+                            {
+                                bMatchFound[i] = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if( bMatchFound[0] && bMatchFound[1] )
+                {
+                    poDS->m_aosSubdatasets.Clear();
+                }
+            }
+        }
         else
+        {
             poNewDS.reset(poMainArray->AsClassicDataset(0, 0));
+        }
         if( !poNewDS )
             return nullptr;
-        poNewDS->SetMetadata(poDS->m_aosSubdatasets.List(), "SUBDATASETS");
+        if( !poDS->m_aosSubdatasets.empty() )
+        {
+            poNewDS->SetMetadata(poDS->m_aosSubdatasets.List(), "SUBDATASETS");
+        }
         return poNewDS.release();
     }
 


### PR DESCRIPTION
And when exposing subdatasets, also expose the main/current one in the
list
