### PR TITLE
postinstall checks: fix when running in the release/3.5 branch where …

### DIFF
--- a/autotest/postinstall/test_cmake.sh
+++ b/autotest/postinstall/test_cmake.sh
@@ -50,12 +50,12 @@ check_ldd(){
   esac
 }
 
-PKG_CONFIG_MODVERSION=$(pkg-config gdal --modversion)
+PKG_CONFIG_MODVERSION=$(pkg-config gdal --modversion) | sed "s/-dev//"
 
 check_version(){
   printf "Testing expected version ... "
   NTESTS=$(($NTESTS + 1))
-  VERSION_OUTPUT=$(./$1)
+  VERSION_OUTPUT=$(./$1) | sed "s/-dev//"
   case "$VERSION_OUTPUT" in
     $PKG_CONFIG_MODVERSION*)
       echo "passed" ;;

--- a/autotest/postinstall/test_gdal-config.sh
+++ b/autotest/postinstall/test_gdal-config.sh
@@ -49,12 +49,12 @@ check_ldd(){
   esac
 }
 
-GDAL_CONFIG_VERSION=$(${GDAL_CONFIG} --version)
+GDAL_CONFIG_VERSION=$(${GDAL_CONFIG} --version) | sed "s/-dev//"
 
 check_version(){
   printf "Testing expected version ... "
   NTESTS=$(($NTESTS + 1))
-  VERSION_OUTPUT=$(./$1)
+  VERSION_OUTPUT=$(./$1) | sed "s/-dev//"
   case "$VERSION_OUTPUT" in
     $GDAL_CONFIG_VERSION*)
       echo "passed" ;;

--- a/autotest/postinstall/test_pkg-config.sh
+++ b/autotest/postinstall/test_pkg-config.sh
@@ -56,12 +56,12 @@ check_ldd(){
   esac
 }
 
-PKG_CONFIG_MODVERSION=$(pkg-config gdal --modversion)
+PKG_CONFIG_MODVERSION=$(pkg-config gdal --modversion) | sed "s/-dev//"
 
 check_version(){
   printf "Testing expected version ... "
   NTESTS=$(($NTESTS + 1))
-  VERSION_OUTPUT=$(./$1)
+  VERSION_OUTPUT=$(./$1) | sed "s/-dev//"
   case "$VERSION_OUTPUT" in
     $PKG_CONFIG_MODVERSION*)
       echo "passed" ;;


### PR DESCRIPTION
…the GDALInfo() version is '3.5.0dev' but the module name is 3.5.0
