### PR TITLE
Add version suffix to DLL when compiling for MinGW target

### DIFF
--- a/autotest/postinstall/test_pkg-config.sh
+++ b/autotest/postinstall/test_pkg-config.sh
@@ -32,7 +32,7 @@ case "$UNAME,$2" in
     ;;
   MINGW*,)
     alias ldd="sh -c 'objdump -x \$1.exe' --"
-    LDD_SUBSTR="DLL Name: libgdal.dll"
+    LDD_SUBSTR="DLL Name: libgdal"
     export PATH="$prefix/bin:$PATH"
     ;;
   *,--static)

--- a/cmake/helpers/GdalVersion.cmake
+++ b/cmake/helpers/GdalVersion.cmake
@@ -59,7 +59,7 @@ add_custom_target(generate_gdal_version_h
                     -P "${PROJECT_SOURCE_DIR}/cmake/helpers/generate_gdal_version_h.cmake"
                   VERBATIM)
 
-if (WIN32)
+if (WIN32 AND NOT MINGW)
   set(GDAL_SOVERSION "")
   set(GDAL_ABI_FULL_VERSION "${GDAL_VERSION_MAJOR}${GDAL_VERSION_MINOR}")
 else()

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -301,6 +301,10 @@ if (MSVC)
       CACHE STRING "Postfix to add to the GDAL dll name for debug builds")
   set_target_properties(${GDAL_LIB_TARGET_NAME} PROPERTIES DEBUG_POSTFIX "${GDAL_DEBUG_POSTFIX}")
 endif ()
+if (MINGW AND BUILD_SHARED_LIBS)
+    set_target_properties(${GDAL_LIB_TARGET_NAME} PROPERTIES SUFFIX "-${GDAL_SOVERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+endif ()
+
 
 if (MSVC AND NOT BUILD_SHARED_LIBS)
   target_compile_definitions(${GDAL_LIB_TARGET_NAME} PUBLIC CPL_DISABLE_DLL=)


### PR DESCRIPTION
Autotools creates DLL with a version suffix. This PR makes also cmake add a version suffix to the DLL.