### PR TITLE
BUILDING.md: Add build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,15 @@
+# GDAL build instructions
+
+This file contains and points to instructions about building GDAL from source.
+
+# Building with cmake
+
+There is a [build hints](https://gdal.org/build_hints.html) page on the website.
+
+Beyond that page, note:
+  - cmake builds in the source directory are not supported (expected to fail)
+
+# Building with autoconf
+
+Building with autoconf is deprecated.  While there are many --with
+options, the build system mostly follows autoconf norms.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ NumFOCUS is 501(c)(3) non-profit charity in the United States; as such, donation
 NumFOCUS are tax-deductible as allowed by law. As with any donation, you should
 consult with your personal tax adviser or the IRS about your particular tax situation.
 
+### How to build
+
+See [BUILDING.md](BUILDING.md)
+
 ### How to contribute
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds a BUILDING.md, so that people who try to figure out how to build by looking at the source code will find the existing documentation.