### PR TITLE
KEA: add 64bit image types

### DIFF
--- a/frmts/kea/keadataset.cpp
+++ b/frmts/kea/keadataset.cpp
@@ -59,11 +59,17 @@ GDALDataType KEA_to_GDAL_Type( kealib::KEADataType ekeaType )
         case kealib::kea_32int:
             egdalType = GDT_Int32;
             break;
+        case kealib::kea_64int:
+            egdalType = GDT_Int64;
+            break;
         case kealib::kea_16uint:
             egdalType = GDT_UInt16;
             break;
         case kealib::kea_32uint:
             egdalType = GDT_UInt32;
+            break;
+        case kealib::kea_64uint:
+            egdalType = GDT_UInt64;
             break;
         case kealib::kea_32float:
             egdalType = GDT_Float32;
@@ -93,11 +99,17 @@ kealib::KEADataType GDAL_to_KEA_Type( GDALDataType egdalType )
         case GDT_Int32:
             ekeaType = kealib::kea_32int;
             break;
+        case GDT_Int64:
+            ekeaType = kealib::kea_64int;
+            break;
         case GDT_UInt16:
             ekeaType = kealib::kea_16uint;
             break;
         case GDT_UInt32:
             ekeaType = kealib::kea_32uint;
+            break;
+        case GDT_UInt64:
+            ekeaType = kealib::kea_64uint;
             break;
         case GDT_Float32:
             ekeaType = kealib::kea_32float;


### PR DESCRIPTION
This PR adds support for the `GDT_Int64` and `GDT_UInt64` image types. The underlying `libkea` library always had support for 64 bit types but with this PR these types can now be passed through to it.

Any chance a 64 bit int type may be added to the RasterAttributeTable in future? This is another area where `libkea` does have support and would be nice to access from GDAL...

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
