### PR TITLE
OGRFeatureDefn::GetFieldDefnUnsafe(): fix -Wsign-conversion

### DIFF
--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -35,6 +35,8 @@
 #include "ogr_featurestyle.h"
 #include "ogr_geometry.h"
 
+#include <cstddef>
+
 #include <exception>
 #include <memory>
 #include <string>
@@ -307,8 +309,8 @@ class CPL_DLL OGRFeatureDefn
     int                 GetFieldCountUnsafe() const { return static_cast<int>(apoFieldDefn.size()); }
 
     // Those methods don't check i is n range.
-    OGRFieldDefn       *GetFieldDefnUnsafe( int i ) { if( apoFieldDefn.empty() ) GetFieldDefn(i); return apoFieldDefn[i].get(); }
-    const OGRFieldDefn *GetFieldDefnUnsafe( int i ) const { if( apoFieldDefn.empty() ) GetFieldDefn(i); return apoFieldDefn[i].get(); }
+    OGRFieldDefn       *GetFieldDefnUnsafe( int i ) { if( apoFieldDefn.empty() ) GetFieldDefn(i); return apoFieldDefn[static_cast<std::size_t>(i)].get(); }
+    const OGRFieldDefn *GetFieldDefnUnsafe( int i ) const { if( apoFieldDefn.empty() ) GetFieldDefn(i); return apoFieldDefn[static_cast<std::size_t>(i)].get(); }
 //! @endcond
 
     virtual void        AddFieldDefn( const OGRFieldDefn * );


### PR DESCRIPTION
Reported and suggested by @andrew-aitchison 