### PR TITLE
[Backport 3.5] vsicurl: add NEGOTIATE to proxy auth methods

### DIFF
--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -912,10 +912,10 @@ int CPLHTTPPopFetchCallback(void)
  *                  For example "Accept: application/x-ogcwkt"</li>
  * <li>HEADER_FILE=filename: filename of a text file with "key: value" headers.
  *     (GDAL >= 2.2)</li>
- * <li>HTTPAUTH=[BASIC/NTLM/GSSNEGOTIATE/ANY] to specify an authentication scheme to use.</li>
+ * <li>HTTPAUTH=[BASIC/NTLM/NEGOTIATE/ANY] to specify an authentication scheme to use.</li>
  * <li>USERPWD=userid:password to specify a user and password for authentication</li>
  * <li>GSSAPI_DELEGATION=[NONE/POLICY/ALWAYS] set allowed GSS-API delegation.
- *     Relevant only with HTTPAUTH=GSSNEGOTIATE (GDAL >= 3.3).</li>
+ *     Relevant only with HTTPAUTH=NEGOTIATE (GDAL >= 3.3).</li>
  * <li>POSTFIELDS=val, where val is a nul-terminated string to be passed to the server
  *                     with a POST request.</li>
  * <li>PROXY=val, to make requests go through a proxy server, where val is of the
@@ -924,7 +924,7 @@ int CPLHTTPPopFetchCallback(void)
  * <li>HTTPS_PROXY=val (GDAL >= 2.4), the same meaning as PROXY, but this option is taken into account only
  *                 for HTTPS URLs.</li>
  * <li>PROXYUSERPWD=val, where val is of the form username:password</li>
- * <li>PROXYAUTH=[BASIC/NTLM/DIGEST/ANY] to specify an proxy authentication scheme to use.</li>
+ * <li>PROXYAUTH=[BASIC/NTLM/DIGEST/NEGOTIATE/ANY] to specify an proxy authentication scheme to use.</li>
  * <li>NETRC=[YES/NO] to enable or disable use of $HOME/.netrc, default YES.</li>
  * <li>CUSTOMREQUEST=val, where val is GET, PUT, POST, DELETE, etc.. (GDAL >= 1.9.0)</li>
  * <li>FORM_FILE_NAME=val, where val is upload file name. If this option and
@@ -1951,10 +1951,10 @@ void *CPLHTTPSetOptions(void *pcurl, const char* pszURL,
         unchecked_curl_easy_setopt(http_handle, CURLOPT_HTTPAUTH, CURLAUTH_NTLM );
     else if( EQUAL(pszHttpAuth, "ANY") )
         unchecked_curl_easy_setopt(http_handle, CURLOPT_HTTPAUTH, CURLAUTH_ANY );
-#ifdef CURLAUTH_GSSNEGOTIATE
+#ifdef CURLAUTH_NEGOTIATE
     else if( EQUAL(pszHttpAuth, "NEGOTIATE") )
-        unchecked_curl_easy_setopt(http_handle, CURLOPT_HTTPAUTH, CURLAUTH_GSSNEGOTIATE );
-#endif //CURLAUTH_GSSNEGOTIATE
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE );
+#endif //CURLAUTH_NEGOTIATE
     else
     {
         CPLError( CE_Warning, CPLE_AppDefined,
@@ -2042,6 +2042,10 @@ void *CPLHTTPSetOptions(void *pcurl, const char* pszURL,
         unchecked_curl_easy_setopt(http_handle, CURLOPT_PROXYAUTH, CURLAUTH_DIGEST );
     else if( EQUAL(pszProxyAuth, "ANY") )
         unchecked_curl_easy_setopt(http_handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY );
+#ifdef CURLAUTH_NEGOTIATE
+    else if( EQUAL(pszProxyAuth, "NEGOTIATE") )
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_PROXYAUTH, CURLAUTH_NEGOTIATE );
+#endif //CURLAUTH_NEGOTIATE
     else
     {
         CPLError( CE_Warning, CPLE_AppDefined,


### PR DESCRIPTION
**vsicurl: add NEGOTIATE to proxy auth methods**

see https://github.com/curl/curl/blob/68784d73c3f8bc0d14502b4e1e930b1741c41699/docs/cmdline-opts/proxy-negotiate.d

deprecate CURLAUTH_GSSNEGOTIATE
see https://github.com/curl/curl/commit/e38ba430142153e95e2b0abe08a31d626a5c5864
