### PR TITLE
Parquet: use statistics to speed-up evaluations of SQL requests with MIN/MAX/COUNT

### DIFF
--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -930,3 +930,33 @@ def test_ogr_parquet_statistics():
     with gdaltest.error_handler():
         assert ds.ExecuteSQL('SELECT MIN(int32) FROM i_dont_exist') is None
         assert ds.ExecuteSQL('SELECT MIN(i_dont_exist) FROM test') is None
+
+
+###############################################################################
+# Test setting/getting creator
+
+def test_ogr_parquet_creator():
+
+    outfilename = '/vsimem/out.parquet'
+    try:
+        ds = ogr.GetDriverByName('Parquet').CreateDataSource(outfilename)
+        ds.CreateLayer('test')
+        ds = None
+
+        ds = gdal.OpenEx(outfilename)
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadataItem("CREATOR", "_PARQUET_").startswith('GDAL ')
+        ds = None
+
+        ds = ogr.GetDriverByName('Parquet').CreateDataSource(outfilename)
+        ds.CreateLayer('test', options = ['CREATOR=my_creator'])
+        ds = None
+
+        ds = gdal.OpenEx(outfilename)
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadataItem("CREATOR", "_PARQUET_") == 'my_creator'
+        ds = None
+
+    finally:
+        gdal.Unlink(outfilename)
+

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -978,3 +978,29 @@ def test_ogr_parquet_creator():
     finally:
         gdal.Unlink(outfilename)
 
+
+
+###############################################################################
+# Test creating multiple geometry columns
+
+def test_ogr_parquet_multiple_geom_columns():
+
+    outfilename = '/vsimem/out.parquet'
+    try:
+        ds = ogr.GetDriverByName('Parquet').CreateDataSource(outfilename)
+        lyr = ds.CreateLayer('test', geom_type = ogr.wkbNone)
+        lyr.CreateGeomField(ogr.GeomFieldDefn('geom_point', ogr.wkbPoint)) == ogr.OGRERR_NONE
+        lyr.CreateGeomField(ogr.GeomFieldDefn('geom_line', ogr.wkbLineString)) == ogr.OGRERR_NONE
+        ds = None
+
+        ds = gdal.OpenEx(outfilename)
+        lyr = ds.GetLayer(0)
+        lyr_defn = lyr.GetLayerDefn()
+        assert lyr_defn.GetGeomFieldCount() == 2
+        assert lyr_defn.GetGeomFieldDefn(0).GetName() == 'geom_point'
+        assert lyr_defn.GetGeomFieldDefn(1).GetName() == 'geom_line'
+        ds = None
+
+    finally:
+        gdal.Unlink(outfilename)
+

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -67,6 +67,13 @@ Layer creation options
   the line between two points is a straight cartesian line (PLANAR) or the
   shortest line on the sphere (geodesic line) (SPHERICAL). The default is PLANAR.
 
+SQL support
+-----------
+
+SQL statements are run through the OGR SQL engine. Statistics can be used to
+speed-up evaluations of SQL requests like:
+"SELECT MIN(colname), MAX(colname), COUNT(colname) FROM layername"
+
 Links
 -----
 

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -67,6 +67,8 @@ Layer creation options
   the line between two points is a straight cartesian line (PLANAR) or the
   shortest line on the sphere (geodesic line) (SPHERICAL). The default is PLANAR.
 
+- **CREATOR=string**: Name of creating application.
+
 SQL support
 -----------
 

--- a/ogr/ogrsf_frmts/arrow/ogr_feather.h
+++ b/ogr/ogrsf_frmts/arrow/ogr_feather.h
@@ -158,6 +158,7 @@ class OGRFeatherWriterLayer final: public OGRArrowWriterLayer
         virtual std::string GetDriverUCName() const override { return ARROW_DRIVER_NAME_UC; }
 
         virtual bool            IsSupportedGeometryType(OGRwkbGeometryType eGType) const override;
+        virtual bool            IsSRSRequired() const override { return true; }
 
 public:
         OGRFeatherWriterLayer( arrow::MemoryPool* poMemoryPool,

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -233,6 +233,7 @@ protected:
                                                                const std::shared_ptr<arrow::Array>&)> postProcessArray);
 
         virtual void            FixupGeometryBeforeWriting(OGRGeometry* /* poGeom */ ) {}
+        virtual bool            IsSRSRequired() const = 0;
 
 public:
         OGRArrowWriterLayer( arrow::MemoryPool* poMemoryPool,

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -59,8 +59,32 @@ class OGRArrowDataset;
 class OGRArrowLayer CPL_NON_FINAL: public OGRLayer,
                              public OGRGetNextFeatureThroughRaw<OGRArrowLayer>
 {
+public:
+        struct Constraint
+        {
+            enum class Type
+            {
+                Integer,
+                Integer64,
+                Real,
+                String,
+            };
+            int          iField{};
+            int          iArrayIdx{};
+            int          nOperation{};
+            Type         eType{};
+            OGRField     sValue{};
+            std::string  osValue{};
+        };
+
+private:
         OGRArrowLayer(const OGRArrowLayer&) = delete;
         OGRArrowLayer& operator= (const OGRArrowLayer&) = delete;
+
+        std::vector<Constraint>  m_asAttributeFilterConstraints{};
+        int                      m_nUseOptimizedAttributeFilter = -1;
+        bool                     SkipToNextFeatureDueToAttributeFilter() const;
+        void                     ExploreExprNode(const swq_expr_node* poNode);
 
 protected:
         arrow::MemoryPool*                          m_poMemoryPool = nullptr;
@@ -136,6 +160,7 @@ public:
         OGRErr          GetExtent(OGREnvelope *psExtent, int bForce = TRUE) override;
         OGRErr          GetExtent(int iGeomField, OGREnvelope *psExtent,
                                   int bForce = TRUE) override;
+        OGRErr          SetAttributeFilter( const char* pszFilter ) override;
 
         virtual std::unique_ptr<OGRFieldDomain> BuildDomain(const std::string& osDomainName,
                                                              int iFieldIndex) const = 0;

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -139,6 +139,10 @@ public:
 
         virtual std::unique_ptr<OGRFieldDomain> BuildDomain(const std::string& osDomainName,
                                                              int iFieldIndex) const = 0;
+
+        static void TimestampToOGR(int64_t timestamp,
+                                   const arrow::TimestampType* timestampType,
+                                   OGRField* psField);
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -31,8 +31,11 @@
 #include "cpl_json.h"
 #include "cpl_time.h"
 #include "ogr_p.h"
+#include "ogr_swq.h"
 
 #include <cinttypes>
+
+#define SWQ_ISNOTNULL (-SWQ_ISNULL)
 
 /************************************************************************/
 /*                         OGRArrowLayer()                              */
@@ -2044,6 +2047,585 @@ void OGRArrowLayer::ResetReading()
     }
 }
 
+/***********************************************************************/
+/*                        GetColumnSubNode()                           */
+/***********************************************************************/
+
+static const swq_expr_node* GetColumnSubNode(const swq_expr_node* poNode)
+{
+    if( poNode->eNodeType == SNT_OPERATION &&
+        poNode->nSubExprCount == 2 )
+    {
+        if( poNode->papoSubExpr[0]->eNodeType == SNT_COLUMN )
+            return poNode->papoSubExpr[0];
+        if( poNode->papoSubExpr[1]->eNodeType == SNT_COLUMN )
+            return poNode->papoSubExpr[1];
+    }
+    return nullptr;
+}
+
+/***********************************************************************/
+/*                        GetConstantSubNode()                         */
+/***********************************************************************/
+
+static const swq_expr_node* GetConstantSubNode(const swq_expr_node* poNode)
+{
+    if( poNode->eNodeType == SNT_OPERATION &&
+        poNode->nSubExprCount == 2 )
+    {
+        if( poNode->papoSubExpr[1]->eNodeType == SNT_CONSTANT )
+            return poNode->papoSubExpr[1];
+        if( poNode->papoSubExpr[0]->eNodeType == SNT_CONSTANT )
+            return poNode->papoSubExpr[0];
+    }
+    return nullptr;
+}
+
+/***********************************************************************/
+/*                           IsComparisonOp()                          */
+/***********************************************************************/
+
+static bool IsComparisonOp(int op)
+{
+    return (op == SWQ_EQ || op == SWQ_NE || op == SWQ_LT ||
+            op == SWQ_LE || op == SWQ_GT || op == SWQ_GE);
+}
+
+/***********************************************************************/
+/*                     FillTargetValueFromSrcExpr()                    */
+/***********************************************************************/
+
+static
+bool FillTargetValueFromSrcExpr( const OGRFieldDefn* poFieldDefn,
+                                 OGRArrowLayer::Constraint* psConstraint,
+                                 const swq_expr_node* poSrcValue )
+{
+    switch( poFieldDefn->GetType() )
+    {
+        case OFTInteger:
+            psConstraint->eType = OGRArrowLayer::Constraint::Type::Integer;
+            if (poSrcValue->field_type == SWQ_FLOAT)
+                psConstraint->sValue.Integer = static_cast<int>(poSrcValue->float_value);
+            else
+                psConstraint->sValue.Integer = static_cast<int>(poSrcValue->int_value);
+            psConstraint->osValue = std::to_string(psConstraint->sValue.Integer);
+            break;
+
+        case OFTInteger64:
+            psConstraint->eType = OGRArrowLayer::Constraint::Type::Integer64;
+            if (poSrcValue->field_type == SWQ_FLOAT)
+                psConstraint->sValue.Integer64 = static_cast<GIntBig>(poSrcValue->float_value);
+            else
+                psConstraint->sValue.Integer64 = poSrcValue->int_value;
+            psConstraint->osValue = std::to_string(psConstraint->sValue.Integer64);
+            break;
+
+        case OFTReal:
+            psConstraint->eType = OGRArrowLayer::Constraint::Type::Real;
+            psConstraint->sValue.Real = poSrcValue->float_value;
+            psConstraint->osValue = std::to_string(psConstraint->sValue.Real);
+            break;
+
+        case OFTString:
+            psConstraint->eType = OGRArrowLayer::Constraint::Type::String;
+            psConstraint->sValue.String = poSrcValue->string_value;
+            psConstraint->osValue = psConstraint->sValue.String;
+            break;
+#ifdef not_yet_handled
+        case OFTDate:
+        case OFTTime:
+        case OFTDateTime:
+            if (poSrcValue->field_type == SWQ_TIMESTAMP ||
+                poSrcValue->field_type == SWQ_DATE ||
+                poSrcValue->field_type == SWQ_TIME)
+            {
+                int nYear = 0, nMonth = 0, nDay = 0, nHour = 0, nMin = 0, nSec = 0;
+                if( sscanf(poSrcValue->string_value, "%04d/%02d/%02d %02d:%02d:%02d",
+                           &nYear, &nMonth, &nDay, &nHour, &nMin, &nSec) == 6 ||
+                    sscanf(poSrcValue->string_value, "%04d/%02d/%02d",
+                           &nYear, &nMonth, &nDay) == 3 ||
+                    sscanf(poSrcValue->string_value, "%02d:%02d:%02d",
+                           &nHour, &nMin, &nSec) == 3 )
+                {
+                    psConstraint->eType = OGRArrowLayer::Constraint::Type::DateTime;
+                    psConstraint->sValue.Date.Year = (GInt16)nYear;
+                    psConstraint->sValue.Date.Month = (GByte)nMonth;
+                    psConstraint->sValue.Date.Day = (GByte)nDay;
+                    psConstraint->sValue.Date.Hour = (GByte)nHour;
+                    psConstraint->sValue.Date.Minute = (GByte)nMin;
+                    psConstraint->sValue.Date.Second = (GByte)nSec;
+                    psConstraint->sValue.Date.TZFlag = 0;
+                    psConstraint->sValue.Date.Reserved = 0;
+                }
+                else
+                    return false;
+            }
+            else
+                return false;
+            break;
+#endif
+        default:
+            return false;
+    }
+    return true;
+}
+
+/***********************************************************************/
+/*                     ExploreExprNode()                               */
+/***********************************************************************/
+
+inline void OGRArrowLayer::ExploreExprNode(const swq_expr_node* poNode)
+{
+    const auto AddConstraint = [this](Constraint& constraint)
+    {
+        if( m_bIgnoredFields )
+        {
+            constraint.iArrayIdx = m_anMapFieldIndexToArrayIndex[constraint.iField];
+            if( constraint.iArrayIdx < 0 )
+                return;
+        }
+        else
+        {
+            constraint.iArrayIdx = m_anMapFieldIndexToArrowColumn[constraint.iField][0];
+        }
+
+        m_asAttributeFilterConstraints.emplace_back(constraint);
+    };
+
+    if( poNode->eNodeType == SNT_OPERATION &&
+        poNode->nOperation == SWQ_AND && poNode->nSubExprCount == 2 )
+    {
+        ExploreExprNode(poNode->papoSubExpr[0]);
+        ExploreExprNode(poNode->papoSubExpr[1]);
+    }
+
+    else if( poNode->eNodeType == SNT_OPERATION &&
+             IsComparisonOp(poNode->nOperation) &&
+             poNode->nSubExprCount == 2 )
+    {
+        const swq_expr_node *poColumn = GetColumnSubNode(poNode);
+        const swq_expr_node *poValue = GetConstantSubNode(poNode);
+        if( poColumn != nullptr && poValue != nullptr &&
+            poColumn->field_index < m_poFeatureDefn->GetFieldCount())
+        {
+            const OGRFieldDefn *poFieldDefn =
+                m_poFeatureDefn->GetFieldDefn(poColumn->field_index);
+
+            Constraint constraint;
+            constraint.iField = poColumn->field_index;
+            constraint.nOperation = poNode->nOperation;
+
+            if( FillTargetValueFromSrcExpr(poFieldDefn, &constraint, poValue) )
+            {
+                if( poColumn == poNode->papoSubExpr[0] )
+                {
+                    // nothing to do
+                }
+                else
+                {
+                    /* If "constant op column", then we must reverse */
+                    /* the operator for LE, LT, GE, GT */
+                    switch( poNode->nOperation )
+                    {
+                        case SWQ_LE: constraint.nOperation = SWQ_GE; break;
+                        case SWQ_LT: constraint.nOperation = SWQ_GT; break;
+                        case SWQ_NE: /* do nothing */; break;
+                        case SWQ_EQ: /* do nothing */; break;
+                        case SWQ_GE: constraint.nOperation = SWQ_LE; break;
+                        case SWQ_GT: constraint.nOperation = SWQ_LT; break;
+                        default: CPLAssert(false); break;
+                    }
+                }
+
+                AddConstraint(constraint);
+            }
+        }
+    }
+
+    else if( poNode->eNodeType == SNT_OPERATION &&
+             poNode->nOperation == SWQ_ISNULL && poNode->nSubExprCount == 1 )
+    {
+        const swq_expr_node *poColumn = poNode->papoSubExpr[0];
+        if( poColumn->eNodeType == SNT_COLUMN &&
+            poColumn->field_index < m_poFeatureDefn->GetFieldCount() )
+        {
+            Constraint constraint;
+            constraint.iField = poColumn->field_index;
+            constraint.nOperation = poNode->nOperation;
+            AddConstraint(constraint);
+        }
+    }
+
+    else if( poNode->eNodeType == SNT_OPERATION &&
+                poNode->nOperation == SWQ_NOT && poNode->nSubExprCount == 1 &&
+                poNode->papoSubExpr[0]->eNodeType == SNT_OPERATION &&
+                poNode->papoSubExpr[0]->nOperation == SWQ_ISNULL &&
+                poNode->papoSubExpr[0]->nSubExprCount == 1 )
+    {
+        const swq_expr_node *poColumn = poNode->papoSubExpr[0]->papoSubExpr[0];
+        if( poColumn->eNodeType == SNT_COLUMN &&
+            poColumn->field_index < m_poFeatureDefn->GetFieldCount() )
+        {
+            Constraint constraint;
+            constraint.iField = poColumn->field_index;
+            constraint.nOperation = SWQ_ISNOTNULL;
+            AddConstraint(constraint);
+        }
+    }
+}
+
+/***********************************************************************/
+/*                         SetAttributeFilter()                        */
+/***********************************************************************/
+
+inline
+OGRErr OGRArrowLayer::SetAttributeFilter( const char* pszFilter )
+{
+    m_asAttributeFilterConstraints.clear();
+
+    OGRErr eErr = OGRLayer::SetAttributeFilter(pszFilter);
+    if( eErr != OGRERR_NONE )
+        return eErr;
+
+    if( m_poAttrQuery != nullptr )
+    {
+        if( m_nUseOptimizedAttributeFilter < 0 )
+        {
+            m_nUseOptimizedAttributeFilter = CPLTestBool(
+                CPLGetConfigOption(("OGR_" + GetDriverUCName() + "_OPTIMIZED_ATTRIBUTE_FILTER").c_str(), "YES"));
+        }
+        if( m_nUseOptimizedAttributeFilter )
+        {
+            swq_expr_node* poNode = static_cast<swq_expr_node*>(m_poAttrQuery->GetSWQExpr());
+            poNode->ReplaceBetweenByGEAndLERecurse();
+            ExploreExprNode(poNode);
+        }
+    }
+
+    return OGRERR_NONE;
+}
+
+/************************************************************************/
+/*                        ConstraintEvaluator()                         */
+/************************************************************************/
+
+namespace
+{
+template<class T, class U> struct CompareGeneric
+{
+    static inline bool get(int op, const T& val1, const U& val2)
+    {
+        switch( op )
+        {
+            case SWQ_LE: return val1 <= val2;
+            case SWQ_LT: return val1 < val2;
+            case SWQ_NE: return val1 != val2;
+            case SWQ_EQ: return val1 == val2;
+            case SWQ_GE: return val1 >= val2;
+            case SWQ_GT: return val1 > val2;
+                break;
+            default: CPLAssert(false);
+        }
+        return true;
+    }
+};
+
+template<class T, class U> struct Compare
+{
+};
+
+template<class T> struct Compare<T, T>: public CompareGeneric<T, T> {};
+template<> struct Compare<int, GIntBig>: public CompareGeneric<int, GIntBig> {};
+template<> struct Compare<double, GIntBig>
+{
+    static inline bool get(int op, double val1, GIntBig val2)
+    {
+        return CompareGeneric<double, double>::get(op, val1, static_cast<double>(val2));
+    }
+};
+template<> struct Compare<GIntBig, int>: public CompareGeneric<GIntBig, int> {};
+template<> struct Compare<double, int>: public CompareGeneric<double, int> {};
+
+template<class T> static bool ConstraintEvaluator(
+                                  const OGRArrowLayer::Constraint& constraint,
+                                  const T value)
+{
+    bool b = false;
+    switch( constraint.eType )
+    {
+        case OGRArrowLayer::Constraint::Type::Integer:
+            b = Compare<T,int>::get(
+                constraint.nOperation, value, constraint.sValue.Integer);
+            break;
+        case OGRArrowLayer::Constraint::Type::Integer64:
+            b = Compare<T,GIntBig>::get(
+                constraint.nOperation, value, constraint.sValue.Integer64);
+            break;
+        case OGRArrowLayer::Constraint::Type::Real:
+            b = Compare<double,double>::get(
+                constraint.nOperation, static_cast<double>(value), constraint.sValue.Real);
+            break;
+        case OGRArrowLayer::Constraint::Type::String:
+            b = Compare<std::string, std::string>::get(
+                constraint.nOperation, std::to_string(value), constraint.osValue);
+            break;
+    }
+    return b;
+}
+
+struct StringView
+{
+    const char* m_ptr;
+    size_t m_len;
+
+    StringView(const char* ptr, size_t len): m_ptr(ptr), m_len(len) {}
+};
+
+inline bool CompareStr(int op, const StringView& val1, const std::string& val2)
+{
+    if( op == SWQ_EQ )
+    {
+        return val1.m_len == val2.size() &&
+               memcmp(val1.m_ptr, val2.data(), val1.m_len) == 0;
+    }
+    const int cmpRes = val2.compare(0, val2.size(), val1.m_ptr, val1.m_len);
+    switch( op )
+    {
+        case SWQ_LE: return cmpRes >= 0;
+        case SWQ_LT: return cmpRes > 0;
+        case SWQ_NE: return cmpRes != 0;
+        // case SWQ_EQ: return cmpRes == 0;
+        case SWQ_GE: return cmpRes <= 0;
+        case SWQ_GT: return cmpRes < 0;
+            break;
+        default: CPLAssert(false);
+    }
+    return true;
+}
+
+inline bool ConstraintEvaluator(const OGRArrowLayer::Constraint& constraint,
+                                const StringView& value)
+{
+    return CompareStr(constraint.nOperation, value, constraint.osValue);
+}
+
+} // namespace
+
+
+/************************************************************************/
+/*                 SkipToNextFeatureDueToAttributeFilter()              */
+/************************************************************************/
+
+inline bool OGRArrowLayer::SkipToNextFeatureDueToAttributeFilter() const
+{
+    for( const auto& constraint: m_asAttributeFilterConstraints )
+    {
+        const arrow::Array* array = m_poBatchColumns[constraint.iArrayIdx].get();
+
+        const bool bIsNull = array->IsNull(m_nIdxInBatch);
+        if( constraint.nOperation == SWQ_ISNULL )
+        {
+            if( bIsNull )
+            {
+                continue;
+            }
+            return true;
+        }
+        else if( constraint.nOperation == SWQ_ISNOTNULL )
+        {
+            if( !bIsNull )
+            {
+                continue;
+            }
+            return true;
+        }
+        else if( bIsNull )
+        {
+            return true;
+        }
+
+        switch( array->type_id() )
+        {
+            case arrow::Type::NA:
+                break;
+
+            case arrow::Type::BOOL:
+            {
+                const auto castArray = static_cast<const arrow::BooleanArray*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<int>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::UINT8:
+            {
+                const auto castArray = static_cast<const arrow::UInt8Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<int>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::INT8:
+            {
+                const auto castArray = static_cast<const arrow::Int8Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<int>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::UINT16:
+            {
+                const auto castArray = static_cast<const arrow::UInt16Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<int>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::INT16:
+            {
+                const auto castArray = static_cast<const arrow::Int16Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<int>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::UINT32:
+            {
+                const auto castArray = static_cast<const arrow::UInt32Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<GIntBig>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::INT32:
+            {
+                const auto castArray = static_cast<const arrow::Int32Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    castArray->Value(m_nIdxInBatch)))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::UINT64:
+            {
+                const auto castArray = static_cast<const arrow::UInt64Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<double>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::INT64:
+            {
+                const auto castArray = static_cast<const arrow::Int64Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<GIntBig>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::HALF_FLOAT:
+            {
+                const auto castArray = static_cast<const arrow::HalfFloatArray*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<double>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::FLOAT:
+            {
+                const auto castArray = static_cast<const arrow::FloatArray*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    static_cast<double>(castArray->Value(m_nIdxInBatch))))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::DOUBLE:
+            {
+                const auto castArray = static_cast<const arrow::DoubleArray*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    castArray->Value(m_nIdxInBatch)))
+                {
+                    return true;
+                }
+                break;
+            }
+            case arrow::Type::STRING:
+            {
+                const auto castArray = static_cast<const arrow::StringArray*>(array);
+                int out_length = 0;
+                const uint8_t* data = castArray->GetValue(m_nIdxInBatch, &out_length);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    StringView(reinterpret_cast<const char*>(data), out_length)))
+                {
+                    return true;
+                }
+                break;
+            }
+
+            case arrow::Type::DECIMAL128:
+            {
+                const auto castArray = static_cast<const arrow::Decimal128Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    CPLAtof(castArray->FormatValue(m_nIdxInBatch).c_str())))
+                {
+                    return true;
+                }
+                break;
+            }
+
+            case arrow::Type::DECIMAL256:
+            {
+                const auto castArray = static_cast<const arrow::Decimal256Array*>(array);
+                if(!ConstraintEvaluator(
+                    constraint,
+                    CPLAtof(castArray->FormatValue(m_nIdxInBatch).c_str())))
+                {
+                    return true;
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+    return false;
+}
+
 /************************************************************************/
 /*                        GetNextRawFeature()                           */
 /************************************************************************/
@@ -2099,6 +2681,11 @@ OGRFeature* OGRArrowLayer::GetNextRawFeature()
                     }
                 }
                 if( !bSkipToNextFeature )
+                {
+                    break;
+                }
+                if( !m_asAttributeFilterConstraints.empty() &&
+                    !SkipToNextFeatureDueToAttributeFilter() )
                 {
                     break;
                 }
@@ -2170,6 +2757,11 @@ begin_multipolygon:
                         break;
                     }
                 }
+                if( !m_asAttributeFilterConstraints.empty() &&
+                    !SkipToNextFeatureDueToAttributeFilter() )
+                {
+                    break;
+                }
 
                 m_nFeatureIdx ++;
                 m_nIdxInBatch ++;
@@ -2208,6 +2800,11 @@ begin_multipolygon:
                 {
                     break;
                 }
+                if( !m_asAttributeFilterConstraints.empty() &&
+                    !SkipToNextFeatureDueToAttributeFilter() )
+                {
+                    break;
+                }
 
                 m_nFeatureIdx ++;
                 m_nIdxInBatch ++;
@@ -2218,6 +2815,26 @@ begin_multipolygon:
                         return nullptr;
                     array = m_poBatchColumns[iCol].get();
                 }
+            }
+        }
+    }
+
+    else if( !m_asAttributeFilterConstraints.empty() )
+    {
+        while( true )
+        {
+            if( !SkipToNextFeatureDueToAttributeFilter() )
+            {
+                break;
+            }
+
+            m_nFeatureIdx ++;
+            m_nIdxInBatch ++;
+            if( m_nIdxInBatch == m_poBatch->num_rows() )
+            {
+                m_bEOF = !ReadNextBatch();
+                if( m_bEOF )
+                    return nullptr;
             }
         }
     }

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -576,7 +576,7 @@ OGRErr OGRArrowWriterLayer::CreateGeomField( OGRGeomFieldDefn *poField, int /* b
         return OGRERR_FAILURE;
     }
 
-    if( poField->GetSpatialRef() == nullptr )
+    if( IsSRSRequired() && poField->GetSpatialRef() == nullptr )
     {
         CPLError(CE_Warning, CPLE_AppDefined,
                  "Geometry column should have an associated CRS");

--- a/ogr/ogrsf_frmts/parquet/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/parquet/CMakeLists.txt
@@ -7,5 +7,6 @@ add_gdal_driver(TARGET ogr_Parquet
                 PLUGIN_CAPABLE
                 CXX_WFLAGS_EFFCXX)
 gdal_standard_includes(ogr_Parquet)
-target_include_directories(ogr_Parquet PRIVATE $<TARGET_PROPERTY:ogrsf_generic,SOURCE_DIR>)
+target_include_directories(ogr_Parquet PRIVATE $<TARGET_PROPERTY:ogrsf_generic,SOURCE_DIR>
+                                               $<TARGET_PROPERTY:ogr_MEM,SOURCE_DIR>)
 gdal_target_link_libraries(ogr_Parquet PRIVATE arrow_shared parquet_shared)

--- a/ogr/ogrsf_frmts/parquet/ogr_include_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_include_parquet.h
@@ -50,6 +50,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "parquet/file_writer.h"
 #include "parquet/schema.h"
+#include "parquet/statistics.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/writer.h"
 #include "parquet/arrow/schema.h"

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -132,6 +132,7 @@ class OGRParquetWriterLayer final: public OGRArrowWriterLayer
         std::shared_ptr<const arrow::KeyValueMetadata> m_poKeyValueMetadata{};
         bool                                           m_bForceCounterClockwiseOrientation = false;
         bool                                           m_bEdgesSpherical = false;
+        std::shared_ptr<parquet::WriterProperties>     m_poWriterProperties{};
 
         virtual bool            IsFileWriterCreated() const override { return m_poFileWriter != nullptr; }
         virtual void            CreateWriter() override;

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -53,6 +53,7 @@ class OGRParquetLayer final: public OGRArrowLayer
         std::shared_ptr<arrow::RecordBatchReader>   m_poRecordBatchReader{};
         bool                                        m_bSingleBatch = false;
         int                                         m_iFIDParquetColumn = -1;
+        std::vector<std::shared_ptr<arrow::DataType>> m_apoArrowDataTypes{}; // .size() == field ocunt
         std::vector<int>                            m_anMapFieldIndexToParquetColumn{};
         std::vector<int>                            m_anMapGeomFieldIndexToParquetColumn{};
         bool                                        m_bHasMissingMappingToParquet = false;
@@ -97,6 +98,10 @@ public:
 
         std::unique_ptr<OGRFieldDomain> BuildDomain(const std::string& osDomainName,
                                                     int iFieldIndex) const override;
+
+        parquet::arrow::FileReader* GetReader() const { return m_poArrowReader.get(); }
+        const std::vector<int>& GetMapFieldIndexToParquetColumn() const { return m_anMapFieldIndexToParquetColumn; }
+        const std::vector<std::shared_ptr<arrow::DataType>>& GetArrowFieldTypes() const { return m_apoArrowDataTypes; }
 };
 
 /************************************************************************/
@@ -107,6 +112,11 @@ class OGRParquetDataset final: public OGRArrowDataset
 {
 public:
     explicit OGRParquetDataset(std::unique_ptr<arrow::MemoryPool>&& poMemoryPool);
+
+    OGRLayer*            ExecuteSQL( const char *pszSQLCommand,
+                                     OGRGeometry *poSpatialFilter,
+                                     const char *pszDialect ) override;
+    void                 ReleaseResultSet( OGRLayer * poResultsSet ) override;
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -132,7 +132,7 @@ class OGRParquetWriterLayer final: public OGRArrowWriterLayer
         std::shared_ptr<const arrow::KeyValueMetadata> m_poKeyValueMetadata{};
         bool                                           m_bForceCounterClockwiseOrientation = false;
         bool                                           m_bEdgesSpherical = false;
-        std::shared_ptr<parquet::WriterProperties>     m_poWriterProperties{};
+        parquet::WriterProperties::Builder             m_oWriterPropertiesBuilder{};
 
         virtual bool            IsFileWriterCreated() const override { return m_poFileWriter != nullptr; }
         virtual void            CreateWriter() override;
@@ -148,6 +148,7 @@ class OGRParquetWriterLayer final: public OGRArrowWriterLayer
         virtual bool            IsSupportedGeometryType(OGRwkbGeometryType eGType) const override;
 
         virtual void            FixupGeometryBeforeWriting(OGRGeometry* poGeom) override;
+        virtual bool            IsSRSRequired() const override { return false; }
 
 public:
         OGRParquetWriterLayer( arrow::MemoryPool* poMemoryPool,
@@ -159,6 +160,8 @@ public:
         bool            SetOptions( CSLConstList papszOptions,
                                     OGRSpatialReference *poSpatialRef,
                                     OGRwkbGeometryType eGType );
+
+        OGRErr          CreateGeomField( OGRGeomFieldDefn *poField, int bApproxOK = TRUE ) override;
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdataset.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdataset.cpp
@@ -376,6 +376,12 @@ OGRLayer* OGRParquetDataset::ExecuteSQL( const char *pszSQLCommand,
                                 }
                             }
                         }
+                        else
+                        {
+                            CPLDebug("PARQUET",
+                                     "Statistics not available for field %s",
+                                     poFieldDefn->GetNameRef());
+                        }
                     }
                     if( !bFound )
                     {

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdataset.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdataset.cpp
@@ -27,6 +27,8 @@
  ****************************************************************************/
 
 #include "ogr_parquet.h"
+#include "ogr_mem.h"
+#include "ogr_swq.h"
 
 #include "../arrow_common/ograrrowdataset.hpp"
 
@@ -37,4 +39,404 @@
 OGRParquetDataset::OGRParquetDataset(std::unique_ptr<arrow::MemoryPool>&& poMemoryPool):
     OGRArrowDataset(std::move(poMemoryPool))
 {
+}
+
+/***********************************************************************/
+/*                            GetStats()                               */
+/***********************************************************************/
+
+template<class STAT_TYPE> struct GetStats
+{
+    using T = typename STAT_TYPE::T;
+
+    static T min(const std::shared_ptr<parquet::FileMetaData>& metadata,
+                 const int numRowGroups, const int iCol, bool& bFound)
+    {
+        T v{};
+        bFound = false;
+        for(int iGroup = 0; iGroup < numRowGroups; iGroup++ )
+        {
+            const auto columnChunk = metadata->RowGroup(iGroup)->ColumnChunk(iCol);
+            const auto colStats = columnChunk->statistics();
+            if( columnChunk->is_stats_set() && colStats && colStats->HasMinMax() )
+            {
+                auto castStats = dynamic_cast<STAT_TYPE*>(colStats.get());
+                const auto rowGroupVal = castStats->min();
+                if( iGroup == 0 || rowGroupVal < v )
+                {
+                    bFound = true;
+                    v = rowGroupVal;
+                }
+            }
+        }
+        return v;
+    }
+
+    static T max(const std::shared_ptr<parquet::FileMetaData>& metadata,
+                 const int numRowGroups, const int iCol, bool& bFound)
+    {
+        T v{};
+        bFound = false;
+        for(int iGroup = 0; iGroup < numRowGroups; iGroup++ )
+        {
+            const auto columnChunk = metadata->RowGroup(iGroup)->ColumnChunk(iCol);
+            const auto colStats = columnChunk->statistics();
+            if( columnChunk->is_stats_set() && colStats && colStats->HasMinMax() )
+            {
+                auto castStats = dynamic_cast<STAT_TYPE*>(colStats.get());
+                const auto rowGroupVal = castStats->max();
+                if( iGroup == 0 || rowGroupVal > v )
+                {
+                    bFound = true;
+                    v = rowGroupVal;
+                }
+            }
+            else
+            {
+                bFound = false;
+                break;
+            }
+        }
+        return v;
+    }
+};
+
+template<> struct GetStats<parquet::ByteArrayStatistics>
+{
+    static std::string min(const std::shared_ptr<parquet::FileMetaData>& metadata,
+                 const int numRowGroups, const int iCol, bool& bFound)
+    {
+        std::string v{};
+        bFound = false;
+        for(int iGroup = 0; iGroup < numRowGroups; iGroup++ )
+        {
+            const auto columnChunk = metadata->RowGroup(iGroup)->ColumnChunk(iCol);
+            const auto colStats = columnChunk->statistics();
+            if( columnChunk->is_stats_set() && colStats && colStats->HasMinMax() )
+            {
+                auto castStats = dynamic_cast<parquet::ByteArrayStatistics*>(colStats.get());
+                const auto rowGroupValRaw = castStats->min();
+                const std::string rowGroupVal(reinterpret_cast<const char*>(rowGroupValRaw.ptr), rowGroupValRaw.len);
+                if( iGroup == 0 || rowGroupVal < v )
+                {
+                    bFound = true;
+                    v = rowGroupVal;
+                }
+            }
+        }
+        return v;
+    }
+
+    static std::string max(const std::shared_ptr<parquet::FileMetaData>& metadata,
+                 const int numRowGroups, const int iCol, bool& bFound)
+    {
+        std::string v{};
+        bFound = false;
+        for(int iGroup = 0; iGroup < numRowGroups; iGroup++ )
+        {
+            const auto columnChunk = metadata->RowGroup(iGroup)->ColumnChunk(iCol);
+            const auto colStats = columnChunk->statistics();
+            if( columnChunk->is_stats_set() && colStats && colStats->HasMinMax() )
+            {
+                auto castStats = dynamic_cast<parquet::ByteArrayStatistics*>(colStats.get());
+                const auto rowGroupValRaw = castStats->max();
+                const std::string rowGroupVal(reinterpret_cast<const char*>(rowGroupValRaw.ptr), rowGroupValRaw.len);
+                if( iGroup == 0 || rowGroupVal > v )
+                {
+                    bFound = true;
+                    v = rowGroupVal;
+                }
+            }
+            else
+            {
+                bFound = false;
+                break;
+            }
+        }
+        return v;
+    }
+};
+
+/***********************************************************************/
+/*                            ExecuteSQL()                             */
+/***********************************************************************/
+
+OGRLayer* OGRParquetDataset::ExecuteSQL( const char *pszSQLCommand,
+                                         OGRGeometry *poSpatialFilter,
+                                         const char *pszDialect )
+{
+/* -------------------------------------------------------------------- */
+/*      Special cases for SQL optimizations                             */
+/* -------------------------------------------------------------------- */
+    if( STARTS_WITH_CI(pszSQLCommand, "SELECT ") &&
+        (pszDialect == nullptr || EQUAL(pszDialect, "") ||
+         EQUAL(pszDialect, "OGRSQL")) )
+    {
+        swq_select oSelect;
+        if( oSelect.preparse(pszSQLCommand) != CE_None )
+            return nullptr;
+
+/* -------------------------------------------------------------------- */
+/*      MIN/MAX/COUNT optimization                                      */
+/* -------------------------------------------------------------------- */
+        if( oSelect.join_count == 0 && oSelect.poOtherSelect == nullptr &&
+            oSelect.table_count == 1 && oSelect.order_specs == 0 &&
+            oSelect.query_mode != SWQM_DISTINCT_LIST &&
+            oSelect.where_expr == nullptr &&
+            CPLTestBool(CPLGetConfigOption("OGR_PARQUET_USE_STATISTICS", "YES")) )
+        {
+            auto poLayer = cpl::down_cast<OGRParquetLayer *>(
+                    GetLayerByName( oSelect.table_defs[0].table_name));
+            if( poLayer )
+            {
+                OGRMemLayer* poMemLayer = nullptr;
+                const auto poLayerDefn = poLayer->GetLayerDefn();
+
+                int i = 0;  // Used after for.
+                for( ; i < oSelect.result_columns; i ++ )
+                {
+                    swq_col_func col_func = oSelect.column_defs[i].col_func;
+                    if( !(col_func == SWQCF_MIN || col_func == SWQCF_MAX ||
+                          col_func == SWQCF_COUNT) )
+                        break;
+
+                    if( oSelect.column_defs[i].field_name == nullptr )
+                        break;
+                    if( oSelect.column_defs[i].target_type != SWQ_OTHER )
+                        break;
+
+                    const int idx = poLayerDefn->GetFieldIndex(
+                                            oSelect.column_defs[i].field_name);
+                    if( idx < 0 )
+                        break;
+
+                    const OGRFieldDefn* poFieldDefn = poLayerDefn->GetFieldDefn(idx);
+
+                    OGRField sField;
+                    OGR_RawField_SetNull(&sField);
+                    OGRFieldType eType = OFTReal;
+                    OGRFieldSubType eSubType = OFSTNone;
+                    const int iCol = poLayer->GetMapFieldIndexToParquetColumn()[idx];
+                    const auto metadata = poLayer->GetReader()->parquet_reader()->metadata();
+                    const auto numRowGroups = metadata->num_row_groups();
+                    bool bFound = false;
+                    std::string sVal;
+                    if( numRowGroups > 0 )
+                    {
+                        const auto rowGroup0columnChunk = metadata->RowGroup(0)->ColumnChunk(iCol);
+                        const auto rowGroup0Stats = rowGroup0columnChunk->statistics();
+                        if( rowGroup0columnChunk->is_stats_set() && rowGroup0Stats )
+                        {
+                            const auto physicalType = rowGroup0Stats->physical_type();
+                            if( col_func == SWQCF_MIN )
+                            {
+                                if( physicalType == parquet::Type::BOOLEAN )
+                                {
+                                    eType = OFTInteger;
+                                    eSubType = OFSTBoolean;
+                                    sField.Integer = GetStats<parquet::BoolStatistics>::min(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::INT32 )
+                                {
+                                    eType = OFTInteger;
+                                    if( poFieldDefn->GetSubType() == OFSTInt16 )
+                                        eSubType = OFSTInt16;
+                                    sField.Integer = GetStats<parquet::Int32Statistics>::min(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::INT64 )
+                                {
+                                    eType = OFTInteger64;
+                                    sField.Integer64 = GetStats<parquet::Int64Statistics>::min(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::FLOAT )
+                                {
+                                    eType = OFTReal;
+                                    eSubType = OFSTFloat32;
+                                    sField.Real = GetStats<parquet::FloatStatistics>::min(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::DOUBLE )
+                                {
+                                    eType = OFTReal;
+                                    sField.Real = GetStats<parquet::DoubleStatistics>::min(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( poFieldDefn->GetType() == OFTString &&
+                                         physicalType == parquet::Type::BYTE_ARRAY )
+                                {
+                                    sVal = GetStats<parquet::ByteArrayStatistics>::min(
+                                        metadata, numRowGroups, iCol, bFound);
+                                    if( bFound )
+                                    {
+                                        eType = OFTString;
+                                        sField.String = &sVal[0];
+                                    }
+                                }
+                            }
+                            else if( col_func == SWQCF_MAX )
+                            {
+                                if( physicalType == parquet::Type::BOOLEAN )
+                                {
+                                    eType = OFTInteger;
+                                    eSubType = OFSTBoolean;
+                                    sField.Integer = GetStats<parquet::BoolStatistics>::max(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::INT32 )
+                                {
+                                    eType = OFTInteger;
+                                    if( poFieldDefn->GetSubType() == OFSTInt16 )
+                                        eSubType = OFSTInt16;
+                                    sField.Integer = GetStats<parquet::Int32Statistics>::max(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::INT64 )
+                                {
+                                    eType = OFTInteger64;
+                                    sField.Integer64 = GetStats<parquet::Int64Statistics>::max(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::FLOAT )
+                                {
+                                    eType = OFTReal;
+                                    eSubType = OFSTFloat32;
+                                    sField.Real = GetStats<parquet::FloatStatistics>::max(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( physicalType == parquet::Type::DOUBLE )
+                                {
+                                    eType = OFTReal;
+                                    sField.Real = GetStats<parquet::DoubleStatistics>::max(
+                                        metadata, numRowGroups, iCol, bFound);
+                                }
+                                else if( poFieldDefn->GetType() == OFTString &&
+                                         physicalType == parquet::Type::BYTE_ARRAY )
+                                {
+                                    sVal = GetStats<parquet::ByteArrayStatistics>::max(
+                                        metadata, numRowGroups, iCol, bFound);
+                                    if( bFound )
+                                    {
+                                        eType = OFTString;
+                                        sField.String = &sVal[0];
+                                    }
+                                }
+                            }
+                            else if( col_func == SWQCF_COUNT )
+                            {
+                                if( oSelect.column_defs[i].distinct_flag )
+                                {
+                                    eType = OFTInteger64;
+                                    sField.Integer64 = 0;
+                                    for(int iGroup = 0; iGroup < numRowGroups; iGroup++ )
+                                    {
+                                        const auto columnChunk = metadata->RowGroup(iGroup)->ColumnChunk(iCol);
+                                        const auto colStats = columnChunk->statistics();
+                                        if( columnChunk->is_stats_set() && colStats && colStats->HasDistinctCount() )
+                                        {
+                                            // Statistics generated by arrow-cpp Parquet writer seem
+                                            // to be buggy, as distinct_count() is always zero.
+                                            // We can detect this: if there are non-null values, then
+                                            // distinct_count() should be > 0.
+                                            if( colStats->distinct_count() == 0 && colStats->num_values() > 0 )
+                                            {
+                                                bFound = false;
+                                                break;
+                                            }
+                                            sField.Integer64 += colStats->distinct_count();
+                                            bFound = true;
+                                        }
+                                        else
+                                        {
+                                            bFound = false;
+                                            break;
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    eType = OFTInteger64;
+                                    sField.Integer64 = 0;
+                                    bFound = true;
+                                    for(int iGroup = 0; iGroup < numRowGroups; iGroup++ )
+                                    {
+                                        const auto columnChunk = metadata->RowGroup(iGroup)->ColumnChunk(iCol);
+                                        const auto colStats = columnChunk->statistics();
+                                        if( columnChunk->is_stats_set() && colStats )
+                                        {
+                                            sField.Integer64 += colStats->num_values();
+                                        }
+                                        else
+                                        {
+                                            bFound = false;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if( !bFound )
+                    {
+                        break;
+                    }
+
+                    const auto& arrowType = poLayer->GetArrowFieldTypes()[idx];
+                    if( eType == OFTInteger64 &&
+                        poFieldDefn->GetType() == OFTDateTime &&
+                        arrowType->id() == arrow::Type::TIMESTAMP )
+                    {
+                        const auto timestampType = static_cast<arrow::TimestampType*>(arrowType.get());
+                        const int64_t timestamp = sField.Integer64;
+                        OGRArrowLayer::TimestampToOGR(timestamp, timestampType, &sField);
+                        eType = OFTDateTime;
+                    }
+
+                    if( poMemLayer == nullptr )
+                    {
+                        poMemLayer = new OGRMemLayer("SELECT", nullptr, wkbNone);
+                        OGRFeature* poFeature = new OGRFeature(poMemLayer->GetLayerDefn());
+                        CPL_IGNORE_RET_VAL(poMemLayer->CreateFeature(poFeature));
+                        delete poFeature;
+                    }
+
+                    const char* pszMinMaxFieldName =
+                        CPLSPrintf( "%s_%s", (col_func == SWQCF_MIN) ? "MIN" :
+                                             (col_func == SWQCF_MAX) ? "MAX" :
+                                                                       "COUNT",
+                                            oSelect.column_defs[i].field_name);
+                    OGRFieldDefn oFieldDefn(pszMinMaxFieldName, eType);
+                    oFieldDefn.SetSubType(eSubType);
+                    poMemLayer->CreateField(&oFieldDefn);
+
+                    OGRFeature* poFeature = poMemLayer->GetFeature(0);
+                    poFeature->SetField(oFieldDefn.GetNameRef(), &sField);
+                    CPL_IGNORE_RET_VAL(poMemLayer->SetFeature(poFeature));
+                    delete poFeature;
+                }
+                if( i != oSelect.result_columns )
+                {
+                    delete poMemLayer;
+                }
+                else
+                {
+                    CPLDebug("PARQUET",
+                        "Using optimized MIN/MAX/COUNT implementation");
+                    return poMemLayer;
+                }
+            }
+        }
+    }
+
+    return GDALDataset::ExecuteSQL(pszSQLCommand, poSpatialFilter, pszDialect);
+}
+
+/***********************************************************************/
+/*                           ReleaseResultSet()                        */
+/***********************************************************************/
+
+void OGRParquetDataset::ReleaseResultSet( OGRLayer * poResultsSet )
+{
+    delete poResultsSet;
 }

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -303,6 +303,13 @@ void OGRParquetDriver::InitMetadata()
         CPLCreateXMLElementAndValue(psOption, "Value", "SPHERICAL");
     }
 
+    {
+        auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
+        CPLAddXMLAttributeAndValue(psOption, "name", "CREATOR");
+        CPLAddXMLAttributeAndValue(psOption, "type", "string");
+        CPLAddXMLAttributeAndValue(psOption, "description", "Name of creating application");
+    }
+
     char* pszXML = CPLSerializeXMLTree(oTree.get());
     GDALDriver::SetMetadataItem(GDAL_DS_LAYER_CREATIONOPTIONLIST, pszXML);
     CPLFree(pszXML);

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -1020,6 +1020,10 @@ const char* OGRParquetLayer::GetMetadataItem( const char* pszName,
         {
             return CPLSPrintf("%d", m_poArrowReader->num_row_groups());
         }
+        if( EQUAL(pszName, "CREATOR") )
+        {
+            return CPLSPrintf("%s", m_poArrowReader->parquet_reader()->metadata()->created_by().c_str());
+        }
         else if( sscanf(pszName, "ROW_GROUPS[%d]", &nRowGroupIdx) == 1 &&
                  strstr(pszName, ".NUM_ROWS") )
         {

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -435,6 +435,7 @@ void OGRParquetLayer::CreateFieldFromSchema(
                                     path, oMapFieldNameToGDALSchemaFieldDefn);
         if( bTypeOK )
         {
+            m_apoArrowDataTypes.push_back(type);
             m_anMapFieldIndexToParquetColumn.push_back(bParquetColValid ? iParquetCol : -1);
         }
     }

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -180,6 +180,11 @@ bool OGRParquetWriterLayer::SetOptions(CSLConstList papszOptions,
         writerPropertiesBuilder.created_by(osCreator);
     else
         writerPropertiesBuilder.created_by("GDAL " GDAL_RELEASE_NAME ", using " CREATED_BY_VERSION);
+
+    // Undocumented option. Not clear it is useful besides unit test purposes
+    if( !CPLTestBool(CSLFetchNameValueDef(papszOptions, "STATISTICS", "YES")) )
+        writerPropertiesBuilder.disable_statistics();
+
     m_poWriterProperties = writerPropertiesBuilder.build();
 
     const char* pszRowGroupSize = CSLFetchNameValue(papszOptions, "ROW_GROUP_SIZE");


### PR DESCRIPTION
SQL statements are run through the OGR SQL engine. Statistics can be used to
speed-up evaluations of SQL requests like:
"SELECT MIN(colname), MAX(colname), COUNT(colname) FROM layername"
