### PR TITLE
VFK: add support for UTF-8 (quick fix)

### DIFF
--- a/ogr/ogrsf_frmts/vfk/vfkpropertydefn.cpp
+++ b/ogr/ogrsf_frmts/vfk/vfkpropertydefn.cpp
@@ -41,7 +41,7 @@ CPL_CVSID("$Id$")
 
   \param pszName property name
   \param pszType property type (original, string)
-  \param bLatin2 true for "ISO-8859-2" otherwise "WINDOWS-1250" is used (only for "text" type)
+  \param bLatin2 true for "ISO-8859-2" otherwise "UTF-8" is used (only for "text" type)
 */
 VFKPropertyDefn::VFKPropertyDefn( const char *pszName, const char *pszType,
                                   bool bLatin2 ) :
@@ -81,7 +81,7 @@ VFKPropertyDefn::VFKPropertyDefn( const char *pszName, const char *pszType,
     else if (*m_pszType == 'T') {
         // String.
         m_eFType = OFTString;
-        m_pszEncoding = bLatin2 ? CPLStrdup("ISO-8859-2") : CPLStrdup("WINDOWS-1250");
+        m_pszEncoding = bLatin2 ? CPLStrdup("ISO-8859-2") : CPLStrdup("UTF-8");
     }
     else if (*m_pszType == 'D') {
         // Date.
@@ -92,7 +92,7 @@ VFKPropertyDefn::VFKPropertyDefn( const char *pszName, const char *pszType,
     else {
         // Unknown - string.
         m_eFType = OFTString;
-        m_pszEncoding = bLatin2 ? CPLStrdup("ISO-8859-2") : CPLStrdup("WINDOWS-1250");
+        m_pszEncoding = bLatin2 ? CPLStrdup("ISO-8859-2") : CPLStrdup("UTF-8");
     }
 }
 

--- a/ogr/ogrsf_frmts/vfk/vfkreader.cpp
+++ b/ogr/ogrsf_frmts/vfk/vfkreader.cpp
@@ -65,7 +65,7 @@ IVFKReader *CreateVFKReader( const GDALOpenInfo *poOpenInfo )
   \brief VFKReader constructor
 */
 VFKReader::VFKReader( const GDALOpenInfo* poOpenInfo ) :
-    m_bLatin2(true),  // Encoding ISO-8859-2 or WINDOWS-1250.
+    m_bLatin2(true),  // Encoding ISO-8859-2 or UTF-8.
     m_poFD(nullptr),
     m_pszFilename(CPLStrdup(poOpenInfo->pszFilename)),
     m_poFStat((VSIStatBufL*) CPLCalloc(1, sizeof(VSIStatBufL))),
@@ -539,7 +539,7 @@ void VFKReader::AddInfo(const char *pszLine)
     }
 
     char *pszValueEnc = CPLRecode(pszValue,
-                            m_bLatin2 ? "ISO-8859-2" : "WINDOWS-1250",
+                            m_bLatin2 ? "ISO-8859-2" : "UTF-8",
                             CPL_ENC_UTF8);
     if (poInfo.find(pszKey) == poInfo.end() ) {
         poInfo[pszKey] = pszValueEnc;


### PR DESCRIPTION
## What does this PR do?

This PR adds support for UTF-8 in VFK driver. Reason: VFK in version 6 swiched encoding from ISO-8859-2 to UTF-8 (https://www.cuzk.cz/Katastr-nemovitosti/Poskytovani-udaju-z-KN/Vymenny-format-KN/Vymenny-format-ISKN-v-textovem-tvaru/Popis_VF_ISKN-v6_0.aspx in Czech). 

This is a quick solution which can be also backported. Previously supported WINDOWS-1250 encoding is replaced by UTF-8. VFK files with WINDOWS-1250 is not used since VFK version 2. Support for WINDOWS-1250 can be discarded by GDAL VFK implementation because there is no regression.

How to test:

```sh
wget https://services.cuzk.cz/vfk/anonym/mapa/930431.zip
unzip 930431.zip
ogrinfo 602515.vfk TYPPPD -fid 1
...
  VYZNAM (String) = Hranice okresu pohyblivá, nestálá (na obou koncích)
```

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed