### PR TITLE
Parquet driver: update to 0.4.0 specification

### DIFF
--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -73,7 +73,8 @@ void OGRParquetLayerBase::LoadGeoMetadata(const std::shared_ptr<const arrow::Key
                 const auto osVersion = oRoot.GetString("version");
                 if( osVersion != "0.1.0" &&
                     osVersion != "0.2.0" &&
-                    osVersion != "0.3.0" )
+                    osVersion != "0.3.0" &&
+                    osVersion != "0.4.0" )
                 {
                     CPLDebug("PARQUET",
                              "version = %s not explicitly handled by the driver",


### PR DESCRIPTION
- Use PROJJSON encoding for CRS
- When writing a CRS that is equivalent to EPSG:4326 / OGC:CRS84, omit
  the ``crs`` member by default, to make it less confusing for
  non-geoaware applications (as WGS 84 long-lat is the default CRS when
  the ``crs`` member is missing)

FYI @cholmes @tschaub