### PR TITLE
GPKG: writer: fix corruption when only a subset of all bands of a tile is flushed

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/gpkgmbtilescommon.h
+++ b/ogr/ogrsf_frmts/gpkg/gpkgmbtilescommon.h
@@ -187,9 +187,6 @@ class GDALGPKGMBTilesLikeRasterBand: public GDALPamRasterBand
         void                    SetUnitTypeInternal(const CPLString& osUom)
                                                         { m_osUom = osUom; }
 
-    protected:
-        friend class GDALGPKGMBTilesLikePseudoDataset;
-
         GDALRasterBlock*        AccessibleTryGetLockedBlockRef(int nBlockXOff, int nBlockYOff) { return TryGetLockedBlockRef(nBlockXOff, nBlockYOff); }
 };
 

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -312,6 +312,12 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         static std::string GetCurrentDateEscapedSQL();
 
     protected:
+
+        virtual CPLErr IRasterIO( GDALRWFlag, int, int, int, int,
+                                  void *, int, int, GDALDataType,
+                                  int, int *, GSpacing, GSpacing, GSpacing,
+                                  GDALRasterIOExtraArg* psExtraArg ) override;
+
         // Coming from GDALGPKGMBTilesLikePseudoDataset
 
         virtual CPLErr                  IFlushCacheWithErrCode(bool bAtClosing) override;


### PR DESCRIPTION
If a block/tile flush happens when only a subset of all bands is
'dirty', and in particular if the alpha band is not yet written, then
the tile was wrongly considered as transparent.

The issue could happen even when writing all bands together, but under
strong pressure on the block cache, due to other threads doing
concurrent reads and forcing partial flushing.