### PR TITLE
GDALRasterBand::ComputeRasterMinMax(): add optimized implementation for Byte and UInt16 data types

### DIFF
--- a/perftests/computeminmax.py
+++ b/perftests/computeminmax.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2021 Even Rouault
+
+from osgeo import gdal
+import timeit
+
+tab_ds = {}
+for dt in (gdal.GDT_Byte, gdal.GDT_UInt16, gdal.GDT_Int16, gdal.GDT_Float32, gdal.GDT_Float64):
+    tab_ds[dt] = gdal.GetDriverByName('MEM').Create('', 10000, 1000, 1, dt)
+    tab_ds[dt].GetRasterBand(1).Fill(1)
+
+
+def test(dt):
+    tab_ds[dt].GetRasterBand(1).ComputeRasterMinMax(False)
+
+
+NITERS = 500
+setup = "from osgeo import gdal; from __main__ import test"
+print('testByte(): %.3f' % timeit.timeit("test(gdal.GDT_Byte)",
+                                         setup=setup, number=NITERS))
+print('testUInt16(): %.3f' % timeit.timeit("test(gdal.GDT_UInt16)",
+                                           setup=setup, number=NITERS))
+print('testInt16(): %.3f' % timeit.timeit("test(gdal.GDT_Int16)",
+                                          setup=setup, number=NITERS))
+print('testFloat32(): %.3f' % timeit.timeit("test(gdal.GDT_Float32)",
+                                            setup=setup, number=NITERS))
+print('testFloat64(): %.3f' % timeit.timeit("test(gdal.GDT_Float64)",
+                                            setup=setup, number=NITERS))


### PR DESCRIPTION
re-use the optimizations of ComputeStatistics(), using SSE2 when available

Before:
```
$ python perftests/computeminmax.py
testByte(): 8.776
testUInt16(): 7.174
testInt16(): 8.210
testFloat32(): 7.846
testFloat64(): 9.407
```

After:
```
$ python perftests/computeminmax.py
testByte(): 0.316
testUInt16(): 0.779
testInt16(): 2.863
testFloat32(): 6.993
testFloat64(): 8.078
```

To be compared with timings of ComputeStatistics():
```
$ python ../perftests/computestatistics.py
testByte(): 0.483
testUInt16(): 1.262
testInt16(): 28.417
testFloat32(): 29.075
testFloat64(): 30.382
```