### PR TITLE
gdal_calc: detect dataset creation failed

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -366,7 +366,7 @@ def Calc(calc: MaybeSequence[str], outfile: Optional[PathLikeOrStr] = None, NoDa
             os.fspath(outfile), DimensionsCheck[0], DimensionsCheck[1], allBandsCount,
             myOutType, creation_options)
         if myOut is None:
-            raise Exception(f"Error! Could not create file {outfile}")
+            raise Exception(f"Error! Could not create output file {outfile}")
 
         # set output geo info based on first input layer
         if not GeoTransformCheck:

--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -365,6 +365,8 @@ def Calc(calc: MaybeSequence[str], outfile: Optional[PathLikeOrStr] = None, NoDa
         myOut = myOutDrv.Create(
             os.fspath(outfile), DimensionsCheck[0], DimensionsCheck[1], allBandsCount,
             myOutType, creation_options)
+        if myOut is None:
+            raise Exception(f"Error! Could not create file {outfile}")
 
         # set output geo info based on first input layer
         if not GeoTransformCheck:


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

gdal_calc should raise an error if it could not create output dataset, instead of raising an unexpected error when executing some code like `myOut.SetGeoTransform(GeoTransformCheck) `.
https://github.com/OSGeo/gdal/blob/d5957ab81e51e9e4244053641b26da0dc4c9e31d/swig/python/gdal-utils/osgeo_utils/gdal_calc.py#L363-L373

I notice that the gdal c++ library will put an error message to stderr, for example `ERROR 4: Attempt to create new tiff file /w/a.tif failed: No such file or directory`. But it will be useful if we detect this error in python side, because gdal_calc is not only an command line tool but a library.