### PR TITLE
Arrow: fix extension name key in field metadata

### DIFF
--- a/autotest/ogr/ogr_arrow.py
+++ b/autotest/ogr/ogr_arrow.py
@@ -367,3 +367,27 @@ def test_ogr_arrow_coordinate_epoch(write_gdal_footer):
     ds = None
 
     gdal.Unlink(outfilename)
+
+
+###############################################################################
+# Test that Arrow extension type is recognized as geometry column
+# if "geo" metadata is absent
+
+
+def test_ogr_arrow_extension_type():
+
+    outfilename = '/vsimem/out.feather'
+    with gdaltest.config_options({'OGR_ARROW_WRITE_GDAL_FOOTER': 'NO',
+                                  'OGR_ARROW_WRITE_GEO': 'NO'}):
+        gdal.VectorTranslate(outfilename, 'data/arrow/test.feather')
+
+    ds = ogr.Open(outfilename)
+    assert ds is not None
+    lyr = ds.GetLayer(0)
+    assert lyr is not None
+    assert lyr.GetGeometryColumn()
+    assert lyr.GetLayerDefn().GetGeomFieldCount() == 1
+    lyr = None
+    ds = None
+
+    gdal.Unlink(outfilename)

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -305,7 +305,7 @@ void OGRArrowWriterLayer::CreateSchemaCommon()
         {
             auto kvMetadata = field->metadata() ? field->metadata()->Copy() :
                               std::make_shared<arrow::KeyValueMetadata>();
-            kvMetadata->Append("ARROW::extension:name",
+            kvMetadata->Append("ARROW:extension:name",
                                GetGeomEncodingAsString(m_aeGeomEncoding[i]));
             field = field->WithMetadata(kvMetadata);
         }


### PR DESCRIPTION
## What does this PR do?

The current field metadata key for the extension name is using a double colon, but that should be a single colon, see https://arrow.apache.org/docs/format/Columnar.html#extension-types

Noticed this while testing to read GDAL produced files with pyarrow with extension types registered for those "geoarrow.<geometry_type>" types (https://github.com/jorisvandenbossche/python-geoarrow/)


## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

Does this require a test case? 
I see that this key is actually checked for when reading, but since it also checks in the metadata for the known geometry columns (and its encoding), this ARROW:extension:name key is not required I suppose. 
