### PR TITLE
Windows: command line applications: embed manifest to declare longPathAware=true property (fixes #5836)

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -109,6 +109,9 @@ if (BUILD_APPS)
 
   add_custom_target(gdalapps DEPENDS ${APPS_TARGETS})
   foreach (UTILCMD IN ITEMS ${APPS_TARGETS})
+    if (WIN32)
+        target_sources(${UTILCMD} PRIVATE longpathaware.manifest)
+    endif()
     # Add that include directory before all others so the gdal_version.h from it is included and not
     # gcore/gdal_version.h
     target_include_directories(${UTILCMD} PRIVATE $<TARGET_PROPERTY:gcore,BINARY_DIR>/gdal_version_full)
@@ -153,6 +156,9 @@ if (BUILD_APPS)
           multireadtest
           test_ogrsf
           testreprojmulti)
+    if (WIN32)
+        target_sources(${UTILCMD} PRIVATE longpathaware.manifest)
+    endif()
     # Add that include directory before all others so the gdal_version.h from it is included and not
     # gcore/gdal_version.h
     target_include_directories(${UTILCMD} PRIVATE $<TARGET_PROPERTY:gcore,BINARY_DIR>/gdal_version_full)

--- a/apps/longpathaware.manifest
+++ b/apps/longpathaware.manifest
@@ -1,0 +1,7 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+</application>
+</assembly>


### PR DESCRIPTION
This also requires the operating system to accept long paths, by setting
a LongPathsEnabled registry key to 1, e.g with the following Powershell command:
```
New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
```

See https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell#enable-long-paths-in-windows-10-version-1607-and-later
