### PR TITLE
Add a GDALRasterBand::GetSuggestedBlockAccessPattern() method

### DIFF
--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -1331,6 +1331,9 @@ public:
     virtual CPLErr IReadBlock( int, int, void * ) override;
     virtual CPLErr IWriteBlock( int, int, void * ) override;
 
+    virtual GDALSuggestedBlockAccessPattern GetSuggestedBlockAccessPattern()
+        const override { return GSBAP_RANDOM; }
+
     virtual int IGetDataCoverageStatus( int nXOff, int nYOff,
                                         int nXSize, int nYSize,
                                         int nMaskFlagStop,

--- a/frmts/jpeg/jpgdataset.h
+++ b/frmts/jpeg/jpgdataset.h
@@ -361,6 +361,9 @@ class JPGRasterBand final: public GDALPamRasterBand
     virtual CPLErr IReadBlock( int, int, void * ) override;
     virtual GDALColorInterp GetColorInterpretation() override;
 
+    virtual GDALSuggestedBlockAccessPattern GetSuggestedBlockAccessPattern()
+        const override { return GSBAP_TOP_TO_BOTTOM; }
+
     virtual GDALRasterBand *GetMaskBand() override;
     virtual int             GetMaskFlags() override;
 

--- a/frmts/pdf/gdal_pdf.h
+++ b/frmts/pdf/gdal_pdf.h
@@ -465,6 +465,8 @@ class PDFRasterBand CPL_NON_FINAL: public GDALPamRasterBand
                 PDFRasterBand( PDFDataset *, int, int );
     virtual ~PDFRasterBand();
 
+    virtual GDALSuggestedBlockAccessPattern GetSuggestedBlockAccessPattern() const override;
+
 #ifdef HAVE_PDFIUM
     virtual int    GetOverviewCount() override;
     virtual GDALRasterBand *GetOverview( int ) override;

--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -862,6 +862,18 @@ CPLErr PDFRasterBand::IReadBlockFromTile( int nBlockXOff, int nBlockYOff,
 }
 
 /************************************************************************/
+/*                     GetSuggestedBlockAccessPattern()                 */
+/************************************************************************/
+
+GDALSuggestedBlockAccessPattern PDFRasterBand::GetSuggestedBlockAccessPattern() const
+{
+    PDFDataset *poGDS = cpl::down_cast<PDFDataset *>(poDS);
+    if (!poGDS->aiTiles.empty() )
+        return GSBAP_RANDOM;
+    return GSBAP_LARGEST_CHUNK_POSSIBLE;
+}
+
+/************************************************************************/
 /*                             IReadBlock()                             */
 /************************************************************************/
 

--- a/frmts/png/pngdataset.h
+++ b/frmts/png/pngdataset.h
@@ -198,6 +198,9 @@ class PNGRasterBand final: public GDALPamRasterBand
 
     virtual CPLErr IReadBlock( int, int, void * ) override;
 
+    virtual GDALSuggestedBlockAccessPattern GetSuggestedBlockAccessPattern()
+        const override { return GSBAP_TOP_TO_BOTTOM; }
+
     virtual GDALColorInterp GetColorInterpretation() override;
     virtual GDALColorTable *GetColorTable() override;
     CPLErr SetNoDataValue( double dfNewValue ) override;

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1144,6 +1144,23 @@ typedef enum
     GMVR_0_AND_255_ONLY,    /*! Only 0 and 255 */
 } GDALMaskValueRange;
 
+/** Suggested/most efficient access pattern to blocks. */
+typedef int GDALSuggestedBlockAccessPattern;
+
+/** Unknown, or no particular read order is suggested. */
+constexpr GDALSuggestedBlockAccessPattern GSBAP_UNKNOWN = 0;
+
+/** Random access to blocks is efficient. */
+constexpr GDALSuggestedBlockAccessPattern GSBAP_RANDOM = 1;
+
+/** Reading by strips from top to bottom is the most efficient. */
+constexpr GDALSuggestedBlockAccessPattern GSBAP_TOP_TO_BOTTOM = 2;
+
+/** Reading by strips from bottom to top is the most efficient. */
+constexpr GDALSuggestedBlockAccessPattern GSBAP_BOTTOM_TO_TOP = 3;
+
+/** Reading the largest chunk from the raster is the most efficient (can be combined with above values). */
+constexpr GDALSuggestedBlockAccessPattern GSBAP_LARGEST_CHUNK_POSSIBLE = 0x100;
 
 /** A single raster band (or channel). */
 
@@ -1245,6 +1262,9 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     GDALDataType GetRasterDataType( void );
     void        GetBlockSize( int *, int * );
     CPLErr      GetActualBlockSize ( int, int, int *, int * );
+
+    virtual GDALSuggestedBlockAccessPattern GetSuggestedBlockAccessPattern() const;
+
     GDALAccess  GetAccess();
 
     CPLErr      RasterIO( GDALRWFlag, int, int, int, int,

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -814,6 +814,43 @@ CPLErr CPL_STDCALL GDALGetActualBlockSize( GDALRasterBandH hBand,
 }
 
 /************************************************************************/
+/*                     GetSuggestedBlockAccessPattern()                 */
+/************************************************************************/
+
+/**
+ * \brief Return the suggested/most efficient access pattern to blocks
+ *        (for read operations).
+ *
+ * While all GDAL drivers have to expose a block size, not all can guarantee
+ * efficient random access (GSBAP_RANDOM) to any block.
+ * Some drivers for example decompress sequentially a compressed stream from
+ * top raster to bottom (GSBAP_TOP_TO_BOTTOM), in which
+ * case best performance will be achieved while reading blocks in that order.
+ * (accessing blocks in random access in such rasters typically causes the
+ * decoding to be re-initialized from the start if accessing blocks in
+ * a non-sequential order)
+ *
+ * The base implementation returns GSBAP_UNKNOWN, which can also be explicitly
+ * returned by drivers that expose a somewhat artificial block size, because they can
+ * extract any part of a raster, but in a rather inefficient way.
+ *
+ * The GSBAP_LARGEST_CHUNK_POSSIBLE value can be combined as a logical bitmask
+ * with other enumeration values (GSBAP_UNKNOWN, GSBAP_RANDOM, GSBAP_TOP_TO_BOTTOM,
+ * GSBAP_BOTTOM_TO_TOP). When a driver sets this flag, the most efficient strategy
+ * is to read as many pixels as possible in the less RasterIO() operations.
+ *
+ * The return of this method is for example used to determine the swath size used by
+ * GDALDatasetCopyWholeRaster() and GDALRasterBandCopyWholeRaster().
+ *
+ * @since GDAL 3.6
+ */
+
+GDALSuggestedBlockAccessPattern GDALRasterBand::GetSuggestedBlockAccessPattern() const
+{
+    return GSBAP_UNKNOWN;
+}
+
+/************************************************************************/
 /*                         GetRasterDataType()                          */
 /************************************************************************/
 

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -4464,11 +4464,20 @@ static void GDALCopyWholeRasterGetSwathSize(
         // but try to use 10 MB at least.
         GIntBig nIdealSwathBufSize =
             static_cast<GIntBig>(nSwathCols) * nSwathLines * nPixelSize;
-        if( nIdealSwathBufSize < nTargetSwathSize &&
-            nIdealSwathBufSize < 10 * 1000 * 1000 )
+        int nMinTargetSwathSize = 10 * 1000 * 1000;
+
+        if( (poSrcPrototypeBand->GetSuggestedBlockAccessPattern() &
+                GSBAP_LARGEST_CHUNK_POSSIBLE) != 0 )
         {
-            nIdealSwathBufSize = 10 * 1000 * 1000;
+            nMinTargetSwathSize = nTargetSwathSize;
         }
+
+        if( nIdealSwathBufSize < nTargetSwathSize &&
+            nIdealSwathBufSize < nMinTargetSwathSize )
+        {
+            nIdealSwathBufSize = nMinTargetSwathSize;
+        }
+
         if( pszSrcCompression != nullptr && EQUAL(pszSrcCompression, "JPEG2000") &&
             (!bDstIsCompressed || ((nSrcBlockXSize % nBlockXSize) == 0 &&
                                    (nSrcBlockYSize % nBlockYSize) == 0)) )


### PR DESCRIPTION
Fixes #5589

```cpp
/**
 * \brief Return the suggested/most efficient access pattern to blocks
 *        (for read operations).
 *
 * While all GDAL drivers have to expose a block size, not all can guarantee
 * efficient random access (GSBAP_RANDOM) to any block.
 * Some drivers for example decompress sequentially a compressed stream from
 * top raster to bottom (GSBAP_TOP_TO_BOTTOM), in which
 * case best performance will be achieved while reading blocks in that order.
 * (accessing blocks in random access in such rasters typically causes the
 * decoding to be re-initialized from the start if accessing blocks in
 * a non-sequential order)
 *
 * The base implementation returns GSBAP_UNKNOWN, which can also be explicitly
 * returned by drivers that expose a somewhat artificial block size, because they can
 * extract any part of a raster, but in a rather inefficient way.
 *
 * The GSBAP_LARGEST_CHUNK_POSSIBLE value can be combined as a logical bitmask
 * with other enumeration values (GSBAP_UNKNOWN, GSBAP_RANDOM, GSBAP_TOP_TO_BOTTOM,
 * GSBAP_BOTTOM_TO_TOP). When a driver sets this flag, the most efficient strategy
 * is to read as many pixels as possible in the less RasterIO() operations.
 *
 * The return of this method is for example used to determine the swath size used by
 * GDALDatasetCopyWholeRaster() and GDALRasterBandCopyWholeRaster().
 *
 * @since GDAL 3.6
 */