### PR TITLE
OGR: example of API extension - add upsert operation

### DIFF
--- a/autotest/ogr/ogr_mongodbv3.py
+++ b/autotest/ogr/ogr_mongodbv3.py
@@ -730,6 +730,33 @@ def test_ogr_mongodbv3_2():
     gdal.PopErrorHandler()
     assert ret != 0
 
+    # Upsert when feature does not exist
+    gdal.PushErrorHandler()
+    ret = lyr.UpsertFeature(f)
+    gdal.PopErrorHandler()
+    assert ret != 0
+
+    gdal.PushErrorHandler()
+    ret = lyr.DeleteFeature(1)
+    gdal.PopErrorHandler()
+    assert ret != 0
+
+    # Upsert when feature already exists
+    gdal.PushErrorHandler()
+    ret = lyr.CreateFeature(f)
+    gdal.PopErrorHandler()
+    assert ret != 0
+
+    gdal.PushErrorHandler()
+    ret = lyr.UpsertFeature(f)
+    gdal.PopErrorHandler()
+    assert ret != 0
+
+    gdal.PushErrorHandler()
+    ret = lyr.DeleteFeature(1)
+    gdal.PopErrorHandler()
+    assert ret != 0
+
 ###############################################################################
 # test_ogrsf
 

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -660,6 +660,7 @@ OGRFeatureH CPL_DLL OGR_L_GetFeature( OGRLayerH, GIntBig )  CPL_WARN_UNUSED_RESU
 OGRErr CPL_DLL OGR_L_SetFeature( OGRLayerH, OGRFeatureH ) CPL_WARN_UNUSED_RESULT;
 OGRErr CPL_DLL OGR_L_CreateFeature( OGRLayerH, OGRFeatureH ) CPL_WARN_UNUSED_RESULT;
 OGRErr CPL_DLL OGR_L_DeleteFeature( OGRLayerH, GIntBig ) CPL_WARN_UNUSED_RESULT;
+OGRErr CPL_DLL OGR_L_UpsertFeature( OGRLayerH, OGRFeatureH ) CPL_WARN_UNUSED_RESULT;
 OGRFeatureDefnH CPL_DLL OGR_L_GetLayerDefn( OGRLayerH );
 OGRSpatialReferenceH CPL_DLL OGR_L_GetSpatialRef( OGRLayerH );
 int    CPL_DLL OGR_L_FindFieldIndex( OGRLayerH, const char *, int bExactMatch );

--- a/ogr/ograpispy.cpp
+++ b/ogr/ograpispy.cpp
@@ -941,6 +941,18 @@ void OGRAPISpy_L_CreateFeature( OGRLayerH hLayer, OGRFeatureH hFeat )
     OGRAPISpyFileClose();
 }
 
+void OGRAPISpy_L_UpsertFeature( OGRLayerH hLayer, OGRFeatureH hFeat )
+{
+    CPLMutexHolderD(&hMutex);
+    OGRAPISpyFlushDefered();
+    OGRAPISpyDumpFeature(hFeat);
+    fprintf(fpSpyFile, "%s.UpsertFeature(f)\n",
+            OGRAPISpyGetLayerVar(hLayer).c_str());
+    // In case layer defn is changed afterwards.
+    fprintf(fpSpyFile, "f = None\n");
+    OGRAPISpyFileClose();
+}
+
 static void OGRAPISpyDumpFieldDefn( OGRFieldDefn* poFieldDefn )
 {
     CPLMutexHolderD(&hMutex);

--- a/ogr/ograpispy.h
+++ b/ogr/ograpispy.h
@@ -114,6 +114,7 @@ void OGRAPISpy_L_SetNextByIndex( OGRLayerH hLayer, GIntBig nIndex );
 void OGRAPISpy_L_GetNextFeature( OGRLayerH hLayer );
 void OGRAPISpy_L_SetFeature( OGRLayerH hLayer, OGRFeatureH hFeat );
 void OGRAPISpy_L_CreateFeature( OGRLayerH hLayer, OGRFeatureH hFeat );
+void OGRAPISpy_L_UpsertFeature( OGRLayerH hLayer, OGRFeatureH hFeat );
 void OGRAPISpy_L_CreateField( OGRLayerH hLayer, OGRFieldDefnH hField,
                               int bApproxOK );
 void OGRAPISpy_L_DeleteField( OGRLayerH hLayer, int iField );

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -659,6 +659,44 @@ OGRErr OGR_L_CreateFeature( OGRLayerH hLayer, OGRFeatureH hFeat )
 }
 
 /************************************************************************/
+/*                           UpsertFeature()                           */
+/************************************************************************/
+
+OGRErr OGRLayer::UpsertFeature( OGRFeature *poFeature )
+
+{
+    ConvertGeomsIfNecessary(poFeature);
+    return IUpsertFeature(poFeature);
+}
+
+/************************************************************************/
+/*                           IUpsertFeature()                           */
+/************************************************************************/
+
+OGRErr OGRLayer::IUpsertFeature( OGRFeature * )
+{
+    return OGRERR_UNSUPPORTED_OPERATION;
+}
+
+/************************************************************************/
+/*                        OGR_L_UpsertFeature()                         */
+/************************************************************************/
+
+OGRErr OGR_L_UpsertFeature( OGRLayerH hLayer, OGRFeatureH hFeat )
+
+{
+    VALIDATE_POINTER1( hLayer, "OGR_L_UpsertFeature", OGRERR_INVALID_HANDLE );
+    VALIDATE_POINTER1( hFeat, "OGR_L_UpsertFeature", OGRERR_INVALID_HANDLE );
+
+#ifdef OGRAPISPY_ENABLED
+    if( bOGRAPISpyEnabled )
+        OGRAPISpy_L_UpsertFeature(hLayer, hFeat);
+#endif
+
+    return OGRLayer::FromHandle(hLayer)->UpsertFeature( OGRFeature::FromHandle(hFeat) );
+}
+
+/************************************************************************/
 /*                            CreateField()                             */
 /************************************************************************/
 

--- a/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
+++ b/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
@@ -145,7 +145,7 @@ class OGRMongoDBv3Layer final: public OGRLayer
         std::unique_ptr<OGRFeature>     Translate(const bsoncxx::document::view& doc);
         bsoncxx::document::value        BuildQuery();
         
-	OGRErr                   PrepareForUpdateOrUpsert(const OGRFeature *poFeature);
+        OGRErr                   PrepareForUpdateOrUpsert(const OGRFeature *poFeature);
         bsoncxx::document::value BuildIDMatchFilter(bsoncxx::document::view view,
                                                     const OGRFeature *poFeature) const;
 

--- a/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
+++ b/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
@@ -144,6 +144,10 @@ class OGRMongoDBv3Layer final: public OGRLayer
                                                         std::map< CPLString, CPLString>& oMapIndices);
         std::unique_ptr<OGRFeature>     Translate(const bsoncxx::document::view& doc);
         bsoncxx::document::value        BuildQuery();
+        
+	OGRErr                   PrepareForUpdateOrUpsert(const OGRFeature *poFeature);
+        bsoncxx::document::value BuildIDMatchFilter(bsoncxx::document::view view,
+                                                    const OGRFeature *poFeature) const;
 
         void                     SerializeField(bsoncxx::builder::basic::document& b,
                                                 OGRFeature *poFeature,
@@ -183,6 +187,7 @@ class OGRMongoDBv3Layer final: public OGRLayer
             OGRErr          CreateGeomField( OGRGeomFieldDefn *poFieldIn, int ) override;
             OGRErr          ICreateFeature( OGRFeature *poFeature ) override;
             OGRErr          ISetFeature( OGRFeature *poFeature ) override;
+            OGRErr          IUpsertFeature( OGRFeature *poFeature ) override;
 
             OGRErr          SyncToDisk() override;
 
@@ -1826,6 +1831,33 @@ OGRErr OGRMongoDBv3Layer::ICreateFeature( OGRFeature *poFeature )
 
 OGRErr OGRMongoDBv3Layer::ISetFeature( OGRFeature *poFeature )
 {
+    if( const OGRErr err = PrepareForUpdateOrUpsert(poFeature); err != OGRERR_NONE )
+    {
+        return err;
+    }
+
+    try
+    {
+        auto bsonObj( BuildBSONObjFromFeature(poFeature, true) );
+        auto view(bsonObj.view());
+        auto filter( BuildIDMatchFilter(view, poFeature) );
+        auto ret = m_oColl.find_one_and_replace( std::move(filter), std::move(bsonObj) );
+        return ret ? OGRERR_NONE : OGRERR_NON_EXISTING_FEATURE;
+    }
+    catch( const std::exception &ex )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s: %s",
+                 "SetFeature()", ex.what());
+        return OGRERR_FAILURE;
+    }
+}
+
+/************************************************************************/
+/*                      PrepareForUpdateOrUpsert()                      */
+/************************************************************************/
+
+OGRErr OGRMongoDBv3Layer::PrepareForUpdateOrUpsert( const OGRFeature *poFeature )
+{
     if( m_poDS->GetAccess() != GA_Update )
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Dataset opened in read-only mode");
@@ -1842,34 +1874,54 @@ OGRErr OGRMongoDBv3Layer::ISetFeature( OGRFeature *poFeature )
         CPLError(CE_Failure, CPLE_AppDefined, "_id field not set");
         return OGRERR_FAILURE;
     }
+    return OGRERR_NONE;
+}
+
+/************************************************************************/
+/*                         BuildIDMatchFilter()                         */
+/************************************************************************/
+
+bsoncxx::document::value OGRMongoDBv3Layer::BuildIDMatchFilter( bsoncxx::document::view view,
+                                                                const OGRFeature *poFeature ) const
+{
+    bsoncxx::builder::basic::document filterBuilder{};
+    filterBuilder.append( kvp("_id", view["_id"].get_oid().value ) );
+    if( !m_osFID.empty() )
+        filterBuilder.append( kvp( std::string(m_osFID),
+                              static_cast<int64_t>(poFeature->GetFID()) ) );
+
+    return filterBuilder.extract();
+}
+
+/************************************************************************/
+/*                           IUpsertFeature()                           */
+/************************************************************************/
+
+OGRErr OGRMongoDBv3Layer::IUpsertFeature( OGRFeature *poFeature )
+{
+    if( const OGRErr err = PrepareForUpdateOrUpsert(poFeature); err != OGRERR_NONE )
+    {
+        return err;
+    }
 
     try
     {
         auto bsonObj( BuildBSONObjFromFeature(poFeature, true) );
         auto view(bsonObj.view());
-
-        bsoncxx::builder::basic::document filterBuilder{};
-        filterBuilder.append( kvp("_id", view["_id"].get_oid().value ) );
-        if( !m_osFID.empty() )
-            filterBuilder.append( kvp( std::string(m_osFID),
-                                static_cast<int64_t>(poFeature->GetFID()) ) );
-
-        auto filter(filterBuilder.extract());
-        auto ret = m_oColl.find_one_and_replace( std::move(filter), std::move(bsonObj) );
-        //if( ret )
-        //{
-        //    std::string s(bsoncxx::to_json(ret->view()));
-        //    CPLDebug("MongoDBv3", "%s", s.c_str());
-        //}
-        return ret ? OGRERR_NONE : OGRERR_NON_EXISTING_FEATURE;
+        auto filter( BuildIDMatchFilter(view, poFeature) );
+        m_oColl.find_one_and_update(
+            std::move(filter), std::move(bsonObj),
+            mongocxx::options::find_one_and_update().upsert( true ) );
+        return OGRERR_NONE;
     }
     catch( const std::exception &ex )
     {
         CPLError(CE_Failure, CPLE_AppDefined, "%s: %s",
-                 "SetFeature()", ex.what());
+                 "UpsertFeature()", ex.what());
         return OGRERR_FAILURE;
     }
 }
+
 /************************************************************************/
 /*                            TestCapability()                          */
 /************************************************************************/

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -111,6 +111,7 @@ class CPL_DLL OGRLayer : public GDALMajorObject
 
     virtual OGRErr      ISetFeature( OGRFeature *poFeature ) CPL_WARN_UNUSED_RESULT;
     virtual OGRErr      ICreateFeature( OGRFeature *poFeature )  CPL_WARN_UNUSED_RESULT;
+    virtual OGRErr      IUpsertFeature( OGRFeature *poFeature )  CPL_WARN_UNUSED_RESULT;
 
   public:
     OGRLayer();
@@ -150,6 +151,7 @@ class CPL_DLL OGRLayer : public GDALMajorObject
 
     OGRErr      SetFeature( OGRFeature *poFeature )  CPL_WARN_UNUSED_RESULT;
     OGRErr      CreateFeature( OGRFeature *poFeature ) CPL_WARN_UNUSED_RESULT;
+    OGRErr      UpsertFeature( OGRFeature *poFeature )  CPL_WARN_UNUSED_RESULT;
 
     virtual OGRErr      DeleteFeature( GIntBig nFID )  CPL_WARN_UNUSED_RESULT;
 

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -1075,6 +1075,10 @@ public:
   OGRErr CreateFeature(OGRFeatureShadow *feature) {
     return OGR_L_CreateFeature(self, feature);
   }
+
+  OGRErr UpsertFeature(OGRFeatureShadow *feature) {
+    return OGR_L_UpsertFeature(self, feature);
+  }
 %clear OGRFeatureShadow *feature;
 
   OGRErr DeleteFeature(GIntBig fid) {

--- a/swig/python/extensions/ogr_wrap.cpp
+++ b/swig/python/extensions/ogr_wrap.cpp
@@ -3836,6 +3836,9 @@ SWIGINTERN OGRErr OGRLayerShadow_SetFeature(OGRLayerShadow *self,OGRFeatureShado
 SWIGINTERN OGRErr OGRLayerShadow_CreateFeature(OGRLayerShadow *self,OGRFeatureShadow *feature){
     return OGR_L_CreateFeature(self, feature);
   }
+SWIGINTERN OGRErr OGRLayerShadow_UpsertFeature(OGRLayerShadow *self,OGRFeatureShadow *feature){
+    return OGR_L_UpsertFeature(self, feature);
+  }
 SWIGINTERN OGRErr OGRLayerShadow_DeleteFeature(OGRLayerShadow *self,GIntBig fid){
     return OGR_L_DeleteFeature(self, fid);
   }
@@ -9834,6 +9837,76 @@ SWIGINTERN PyObject *_wrap_Layer_CreateFeature(PyObject *SWIGUNUSEDPARM(self), P
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
       result = (OGRErr)OGRLayerShadow_CreateFeature(arg1,arg2);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    /* %typemap(out) OGRErr */
+    if ( result != 0 && bUseExceptions) {
+      const char* pszMessage = CPLGetLastErrorMsg();
+      if( pszMessage[0] != '\0' )
+      PyErr_SetString( PyExc_RuntimeError, pszMessage );
+      else
+      PyErr_SetString( PyExc_RuntimeError, OGRErrMessages(result) );
+      SWIG_fail;
+    }
+  }
+  {
+    /* %typemap(ret) OGRErr */
+    if ( ReturnSame(resultobj == Py_None || resultobj == 0) ) {
+      resultobj = PyInt_FromLong( result );
+    }
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Layer_UpsertFeature(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  OGRLayerShadow *arg1 = (OGRLayerShadow *) 0 ;
+  OGRFeatureShadow *arg2 = (OGRFeatureShadow *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  OGRErr result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:Layer_UpsertFeature",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_OGRLayerShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Layer_UpsertFeature" "', argument " "1"" of type '" "OGRLayerShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< OGRLayerShadow * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_OGRFeatureShadow, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Layer_UpsertFeature" "', argument " "2"" of type '" "OGRFeatureShadow *""'"); 
+  }
+  arg2 = reinterpret_cast< OGRFeatureShadow * >(argp2);
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (OGRErr)OGRLayerShadow_UpsertFeature(arg1,arg2);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -31008,7 +31081,8 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"OGRERR_NONE on success. \n"
 		""},
-	 { "Layer_DeleteFeature", _wrap_Layer_DeleteFeature, METH_VARARGS, "\n"
+	 { "Layer_UpsertFeature", _wrap_Layer_UpsertFeature, METH_VARARGS, "Layer_UpsertFeature(Layer self, Feature feature) -> OGRErr"},
+   { "Layer_DeleteFeature", _wrap_Layer_DeleteFeature, METH_VARARGS, "\n"
 		"Layer_DeleteFeature(Layer self, GIntBig fid) -> OGRErr\n"
 		"OGRErr\n"
 		"OGR_L_DeleteFeature(OGRLayerH hLayer, GIntBig nFID)\n"

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -1485,6 +1485,12 @@ class Layer(MajorObject):
         """
         return _ogr.Layer_CreateFeature(self, *args)
 
+
+    def UpsertFeature(self, *args):
+        """UpsertFeature(Layer self, Feature feature) -> OGRErr"""
+        return _ogr.Layer_UpsertFeature(self, *args)
+
+
     def DeleteFeature(self, *args):
         r"""
         DeleteFeature(Layer self, GIntBig fid) -> OGRErr


### PR DESCRIPTION
## What does this PR do?

This submits for consideration a pattern by which GDAL could expand its current set of supported feature operations (`Create`, `Set`, and `Delete`, ie. `INSERT`, `UPDATE`, and `DELETE` in SQL parlance).

As an example, it adds a method for `UPSERT` (ie. if record does not exist then `INSERT`, else `UPDATE`) and implements support for that method in the MongoDBv3 driver.

I don't expect that you should simply accept the pull request, but rather I'm hoping to demonstrate the general pattern and then continue discussion with GDAL project maintainers.

## What are related issues/pull requests?

### SetFeature
The current `SetFeature` implementations for various drivers often have subtly different functionality. These usually either:
 - *Replace* the existing feature with the contents of the incoming `OGRFeature`
 - *Update* just the fields that exist on the incoming `OGRFeature`

Expanding the set of supported operations would allow an opportunity to disambiguate those cases.

### DeleteFeature
The current `DeleteFeature` implementation only allows an integer primary key. However, many formats supported by GDAL actually use string primary keys (eg. Elasticsearch, MongoDB).

Expanding the set of supported operations would allow an opportunity to provide a string-keyed overload or alternative.

### (Stretch Goal) Multiple Keys
It would be useful to allow update or delete operations to match multiple key fields on an incoming `OGRFeature` instead of just the primary key. For example, you could have an API like:

```c++
// Updates all existing features that match the values of each key field
OGRErr UpdateFeature(OGRFeature* poFeature, const int* panKeyFields, int nKeyFieldCount);
```

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

