### PR TITLE
VFK: Support to UTF-8 VFK data

### DIFF
--- a/gdal/ogr/ogrsf_frmts/vfk/vfkdatablock.cpp
+++ b/gdal/ogr/ogrsf_frmts/vfk/vfkdatablock.cpp
@@ -179,7 +179,7 @@ int IVFKDataBlock::AddProperty(const char *pszName, const char *pszType)
         pszType = "T30";
 
     VFKPropertyDefn *poNewProperty = new VFKPropertyDefn(pszName, pszType,
-                                                         m_poReader->IsLatin2());
+                                                         m_poReader->GetEncoding());
 
     m_nPropertyCount++;
 

--- a/gdal/ogr/ogrsf_frmts/vfk/vfkpropertydefn.cpp
+++ b/gdal/ogr/ogrsf_frmts/vfk/vfkpropertydefn.cpp
@@ -41,10 +41,10 @@ CPL_CVSID("$Id$")
 
   \param pszName property name
   \param pszType property type (original, string)
-  \param bLatin2 true for "ISO-8859-2" otherwise "WINDOWS-1250" is used (only for "text" type)
+  \param bEncoding encoding (only for "text" type)
 */
 VFKPropertyDefn::VFKPropertyDefn( const char *pszName, const char *pszType,
-                                  bool bLatin2 ) :
+                                  const char *pszEncoding ) :
     m_pszName(CPLStrdup(pszName)),
     m_pszType(CPLStrdup(pszType)),
     m_pszEncoding(nullptr),
@@ -81,7 +81,7 @@ VFKPropertyDefn::VFKPropertyDefn( const char *pszName, const char *pszType,
     else if (*m_pszType == 'T') {
         // String.
         m_eFType = OFTString;
-        m_pszEncoding = bLatin2 ? CPLStrdup("ISO-8859-2") : CPLStrdup("WINDOWS-1250");
+        m_pszEncoding = CPLStrdup(pszEncoding);
     }
     else if (*m_pszType == 'D') {
         // Date.
@@ -92,7 +92,7 @@ VFKPropertyDefn::VFKPropertyDefn( const char *pszName, const char *pszType,
     else {
         // Unknown - string.
         m_eFType = OFTString;
-        m_pszEncoding = bLatin2 ? CPLStrdup("ISO-8859-2") : CPLStrdup("WINDOWS-1250");
+        m_pszEncoding = CPLStrdup(pszEncoding);
     }
 }
 

--- a/gdal/ogr/ogrsf_frmts/vfk/vfkreader.h
+++ b/gdal/ogr/ogrsf_frmts/vfk/vfkreader.h
@@ -205,7 +205,7 @@ private:
     int               m_nPrecision;
 
 public:
-    VFKPropertyDefn(const char*, const char *, bool);
+    VFKPropertyDefn(const char*, const char *, const char *);
     virtual ~VFKPropertyDefn();
 
     const char       *GetName() const  { return m_pszName; }
@@ -381,7 +381,7 @@ public:
 
     virtual const char    *GetFilename() const = 0;
 
-    virtual bool           IsLatin2() const = 0;
+    virtual const char    *GetEncoding() const = 0;
     virtual bool           IsSpatial() const = 0;
     virtual bool           IsPreProcessed() const = 0;
     virtual bool           IsValid() const = 0;

--- a/gdal/ogr/ogrsf_frmts/vfk/vfkreaderp.h
+++ b/gdal/ogr/ogrsf_frmts/vfk/vfkreaderp.h
@@ -48,7 +48,7 @@ class VFKReader;
 class VFKReader : public IVFKReader
 {
 private:
-    bool           m_bLatin2;
+    const char    *m_pszEncoding;
 
     VSILFILE      *m_poFD;
     char          *ReadLine();
@@ -78,7 +78,7 @@ public:
 
     const char    *GetFilename() const override { return m_pszFilename; }
 
-    bool           IsLatin2() const override { return m_bLatin2; }
+    const char    *GetEncoding() const override { return m_pszEncoding; }
     bool           IsSpatial() const override { return false; }
     bool           IsPreProcessed() const override { return false; }
     bool           IsValid() const override { return true; }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Support for UTF-8 encoding. The support for old encodings and possibly new ones should also work.

## What are related issues/pull requests?

## Tasklist

## Environment

Provide environment details, if relevant:

* OS: Debian
* Compiler: gcc
