### PR TITLE
GPKG: preliminary non-user-visible support for Related Tables Extension

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -295,6 +295,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         bool                    HasDataColumnsTable() const;
         bool                    HasDataColumnConstraintsTable() const;
         bool                CreateColumnsTableAndColumnConstraintsTablesIfNecessary();
+        bool                HasGpkgextRelationsTable() const;
 
         const char*         GetGeometryTypeString(OGRwkbGeometryType eType);
 


### PR DESCRIPTION
(https://docs.opengeospatial.org/is/18-000/18-000.html)

There is non-user-visible change related to that (as we don't have any
API to report relationships between table), but this brings:
- recognizing the extension as known
- take it into account during column renaming and table renaming/deletion
  to avoid corruption of the database.
- make the validate_gpkg.py validate the use of the extension

CC @nyalldawson 