### PR TITLE
CSV docs: Fix default AUTODETECT_SIZE_LIMIT typo

### DIFF
--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -279,7 +279,7 @@ The following open options can be specified
    will be emptied.
 -  **AUTODETECT_SIZE_LIMIT**\ =size to specify the number of bytes to
    inspect to determine the data type and width/precision. The default
-   will be 100000. Setting 0 means inspecting the whole file. Note :
+   will be 1000000. Setting 0 means inspecting the whole file. Note :
    specifying a value over 1 MB (or 0 if the file is larger than 1MB)
    will prevent reading from standard input.
 -  **QUOTED_FIELDS_AS_STRING**\ =YES/NO (default NO). Only used if


### PR DESCRIPTION
## What does this PR do?

The default AUTODETECT_SIZE_LIMIT open option for the CSV driver is 1,000,000, as per ogrcsvlayer.cpp, but is incorrectly stated in the docs as 100,000. The PR corrects the typo.

## What are related issues/pull requests?

Related to #5885