### PR TITLE
Resolve compilation errors in HANA driver

### DIFF
--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -346,7 +346,7 @@ public:
 
     int Open(const char* newName, char** options, int update);
 
-    uint GetMajorVersion() const { return majorVersion_; }
+    int GetMajorVersion() const { return majorVersion_; }
     OGRErr DeleteLayer(int index) override;
     int GetLayerCount() override { return static_cast<int>(layers_.size()); }
     OGRLayer* GetLayer(int index) override;

--- a/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
@@ -71,7 +71,7 @@ CPLString BuildQuery(const char* source, const char* columns)
     return BuildQuery(source, columns, nullptr, nullptr, -1);
 }
 
-CPLString BuildSpatialFilter(uint dbVersion, const OGRGeometry& geom, const CPLString& clmName, int srid)
+CPLString BuildSpatialFilter(int dbVersion, const OGRGeometry& geom, const CPLString& clmName, int srid)
 {
     OGREnvelope env;
     geom.getEnvelope(&env);


### PR DESCRIPTION
This PR fixes the following compiler error that occurs when compiling on MacOS.

ogr_hana.h:349:5: error: unknown type name 'uint'; did you mean 'int'?
    uint GetMajorVersion() const { return majorVersion_; }