### PR TITLE
Doc: document how to use GDAL with CMake configuration file

### DIFF
--- a/doc/source/build_hints.rst
+++ b/doc/source/build_hints.rst
@@ -67,6 +67,7 @@ for the shared lib, *e.g.* ``set (GDAL_LIB_OUTPUT_NAME gdal_x64 CACHE STRING "" 
     conflict with new settings. If strange errors appear during cmake run,
     you may try removing CMakeCache.txt to start from a clean state.
 
+Refer to :ref:`using_gdal_in_cmake` for how to use GDAL in a CMake project.
 
 CMake general configure options
 +++++++++++++++++++++++++++++++

--- a/doc/source/development/cmake.rst
+++ b/doc/source/development/cmake.rst
@@ -1,0 +1,27 @@
+.. _using_gdal_in_cmake:
+
+********************************************************************************
+Using GDAL in CMake projects
+********************************************************************************
+
+.. versionadded:: 3.5
+
+The recommended way to use the GDAL library in a CMake project is to
+link to the imported library target ``GDAL::GDAL`` provided by
+the CMake configuration which comes with the library. Typical usage is:
+
+.. code::
+
+    find_package(GDAL CONFIG REQUIRED)
+
+    target_link_libraries(MyApp PRIVATE GDAL::GDAL)
+
+By adding the imported library target ``GDAL::GDAL`` to the
+target link libraries, CMake will also pass the include directories to
+the compiler.
+
+The CMake command ``find_package`` will look for the configuration in a
+number of places. The lookup can be adjusted for all packages by setting
+the cache variable or environment variable ``CMAKE_PREFIX_PATH``. In
+particular, CMake will consult (and set) the cache variable
+``GDAL_DIR``.

--- a/doc/source/development/index.rst
+++ b/doc/source/development/index.rst
@@ -5,4 +5,5 @@ Development
 .. toctree::
     :maxdepth: 1
 
+    cmake
     rfc/index


### PR DESCRIPTION
Fixes #5875

Credits to PROJ's equivalent page for providing the skeleton.
