### PR TITLE
FileGDB/OpenFileGDB: handle Shape_Area/Shape_Length fields

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -3757,7 +3757,7 @@ def test_ogr_gpkg_48():
     # No geom field, one single field with default value
     lyr = ds.CreateLayer('default_field_no_geom', geom_type=ogr.wkbNone)
     fld_defn = ogr.FieldDefn('foo')
-    fld_defn.SetDefault('x')
+    fld_defn.SetDefault("'x'")
     lyr.CreateField(fld_defn)
     f = ogr.Feature(lyr.GetLayerDefn())
     assert lyr.CreateFeature(f) == 0

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -1753,6 +1753,18 @@ def test_ogr_openfilegdb_spx_zero_in_value_count_trailer():
 
 
 ###############################################################################
+# Test reading .gdb with LengthFieldName / AreaFieldName
+
+
+def test_ogr_openfilegdb_shape_length_shape_area_as_default_in_field_defn():
+    ds = ogr.Open('data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb')
+    lyr = ds.GetLayer(0)
+    lyr_defn = lyr.GetLayerDefn()
+    assert lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('Shape_Area')).GetDefault() == 'FILEGEODATABASE_SHAPE_AREA'
+    assert lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex('Shape_Length')).GetDefault() == 'FILEGEODATABASE_SHAPE_LENGTH'
+
+
+###############################################################################
 # Cleanup
 
 

--- a/doc/source/drivers/vector/filegdb.rst
+++ b/doc/source/drivers/vector/filegdb.rst
@@ -180,6 +180,13 @@ Layer Creation Options
 -  **CONFIGURATION_KEYWORD**\ =DEFAULTS/TEXT_UTF16/MAX_FILE_SIZE_4GB/MAX_FILE_SIZE_256TB/GEOMETRY_OUTOFLINE/BLOB_OUTOFLINE/GEOMETRY_AND_BLOB_OUTOFLINE
    : Customize how data is stored. By default text in
    UTF-8 and data up to 1TB
+-  **CREATE_SHAPE_AREA_AND_LENGTH_FIELDS**\ =YES/NO. (GDAL >= 3.6.0)
+   Defaults to NO (through CreateLayer() API). When this option is set,
+   a Shape_Area and Shape_Length special fields will be created for polygonal
+   layers (Shape_Length only for linear layers). When using ogr2ogr with a
+   source layer that has Shape_Area/Shape_Length special fields, and this option
+   is not explicitly set, it will be automatically set, so that the resulting
+   FileGeodatabase has those fields properly tagged.
 
 Configuration options
 ---------------------

--- a/ogr/ogrfeature.cpp
+++ b/ogr/ogrfeature.cpp
@@ -6640,10 +6640,11 @@ void OGRFeature::FillUnsetWithDefault( int bNotNullableOnly,
     {
         if( IsFieldSet(i) )
             continue;
-        if( bNotNullableOnly && poDefn->GetFieldDefn(i)->IsNullable() )
+        const auto poFieldDefn = poDefn->GetFieldDefn(i);
+        if( bNotNullableOnly && poFieldDefn->IsNullable() )
             continue;
-        const char* pszDefault = poDefn->GetFieldDefn(i)->GetDefault();
-        OGRFieldType eType = poDefn->GetFieldDefn(i)->GetType();
+        const char* pszDefault = poFieldDefn->GetDefault();
+        OGRFieldType eType = poFieldDefn->GetType();
         if( pszDefault != nullptr )
         {
             if( eType == OFTDate || eType == OFTTime || eType == OFTDateTime )
@@ -6688,7 +6689,7 @@ void OGRFeature::FillUnsetWithDefault( int bNotNullableOnly,
                 SetField(i, pszTmp);
                 CPLFree(pszTmp);
             }
-            else
+            else if ( !poFieldDefn->IsDefaultDriverSpecific() )
                 SetField(i, pszDefault);
         }
     }

--- a/ogr/ogrsf_frmts/filegdb/FGdbDriver.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbDriver.cpp
@@ -882,6 +882,10 @@ void RegisterOGRFileGDB()
 "    <Value>BLOB_OUTOFLINE</Value>"
 "    <Value>GEOMETRY_AND_BLOB_OUTOFLINE</Value>"
 "  </Option>"
+"  <Option name='CREATE_SHAPE_AREA_AND_LENGTH_FIELDS' type='boolean' description='Whether to create special Shape_Length and Shape_Area fields' default='NO'/>"
+// Setting to another value than the default one doesn't really work with the SDK
+//"  <Option name='AREA_FIELD_NAME' type='string' description='Name of the column that contains the geometry area' default='Shape_Area'/>"
+//"  <Option name='length_field_name' type='string' description='Name of the column that contains the geometry length' default='Shape_Length'/>"
 "</LayerCreationOptionList>");
 
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
@@ -692,6 +692,8 @@ int OGROpenFileGDBLayer::BuildLayerDefinition()
     CPLXMLTreeCloser oTree(nullptr);
     const CPLXMLNode* psGPFieldInfoExs = nullptr;
 
+    std::string osAreaFieldName;
+    std::string osLengthFieldName;
     if( !m_osDefinition.empty() )
     {
         oTree.reset(CPLParseXMLString(m_osDefinition.c_str()));
@@ -703,8 +705,12 @@ int OGROpenFileGDBLayer::BuildLayerDefinition()
             if( psInfo == nullptr )
                 psInfo = CPLSearchXMLNode( oTree.get(), "=DETableInfo" );
             if( psInfo != nullptr )
+            {
                 psGPFieldInfoExs =
                     CPLGetXMLNode(psInfo, "GPFieldInfoExs");
+                osAreaFieldName = CPLGetXMLValue(psInfo, "AreaFieldName", "");
+                osLengthFieldName = CPLGetXMLValue(psInfo, "LengthFieldName", "");
+            }
         }
     }
 
@@ -895,6 +901,15 @@ int OGROpenFileGDBLayer::BuildLayerDefinition()
             const char* pszDomainName = CPLGetXMLValue(psFieldDef, "DomainName", nullptr);
             if( pszDomainName )
                 oFieldDefn.SetDomainName(pszDomainName);
+        }
+
+        if( osAreaFieldName == poGDBField->GetName() )
+        {
+            oFieldDefn.SetDefault("FILEGEODATABASE_SHAPE_AREA");
+        }
+        else if( osLengthFieldName == poGDBField->GetName() )
+        {
+            oFieldDefn.SetDefault("FILEGEODATABASE_SHAPE_LENGTH");
         }
 
         m_poFeatureDefn->AddFieldDefn(&oFieldDefn);


### PR DESCRIPTION
FileGDB and OpenFileGDB:
- on reading, when parsing the XML layer definition, use the
  AreaFieldName and LengthFieldName attributes to set the default value
  of the corresponding OGR fields to the driver specific value of
  "FILEGEODATABASE_SHAPE_AREA" / "FILEGEODATABASE_SHAPE_LENGTH"

FileGDB:
- on writing, add a CREATE_SHAPE_AREA_AND_LENGTH_FIELDS=YES/NO creation
  option to automatically create the Shape_Area and Shape_Length special
  fields
- make ogr2ogr automatically set that option when the source layer has
  the Shape_Area and Shape_Length special fields
