### PR TITLE
Fix missing header file in ogrhanatablelayer.cpp

### DIFF
--- a/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
@@ -35,6 +35,7 @@
 #include <cstdio>
 #include <cstring>
 #include <regex>
+#include <sstream>
 
 #include "odbc/Exception.h"
 #include "odbc/ResultSet.h"


### PR DESCRIPTION
This PR fixes another compilation error observed on some systems.