### PR TITLE
Fix multiple build and runtime issues on architectures with "capability pointers"

### DIFF
--- a/alg/gdalgeoloc_carray_accessor.h
+++ b/alg/gdalgeoloc_carray_accessor.h
@@ -177,14 +177,13 @@ GDALDataset* GDALGeoLocCArrayAccessors::GetBackmapDataset()
 
     for( int i = 1; i <= 2; i++ )
     {
-        char szBuffer[32] = { '\0' };
-        char szBuffer0[64] = { '\0' };
-        char* apszOptions[] = { szBuffer0, nullptr };
-
         void* ptr = (i == 1) ? m_pafBackMapX : m_pafBackMapY;
-        szBuffer[CPLPrintPointer(szBuffer, ptr, sizeof(szBuffer))] = '\0';
-        snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
-        poMEMDS->AddBand(GDT_Float32, apszOptions);
+        GDALRasterBandH hMEMBand = MEMCreateRasterBandEx( poMEMDS,
+                                                      i, static_cast<GByte*>(ptr),
+                                                      GDT_Float32,
+                                                      0, 0,
+                                                      false );
+        poMEMDS->AddMEMBand(hMEMBand);
         poMEMDS->GetRasterBand(i)->SetNoDataValue(INVALID_BMXY);
     }
     return poMEMDS;

--- a/alg/gdalgeolocquadtree.cpp
+++ b/alg/gdalgeolocquadtree.cpp
@@ -186,7 +186,7 @@ bool GDALGeoLocBuildQuadTree( GDALGeoLocTransformInfo *psTransform )
         }
 
         CPLQuadTreeInsert(psTransform->hQuadTree,
-                          reinterpret_cast<void*>(i));
+                          reinterpret_cast<void*>(static_cast<uintptr_t>(i)));
 
         // For a geometry crossing the antimeridian, we've insert before
         // the "version" around -180 deg. Insert its corresponding version around
@@ -201,7 +201,7 @@ bool GDALGeoLocBuildQuadTree( GDALGeoLocTransformInfo *psTransform )
                      std::fabs(x3-x0) > 180) )
         {
             CPLQuadTreeInsert(psTransform->hQuadTree,
-                              reinterpret_cast<void*>(i | BIT_IDX_RANGE_180_SET));
+                              reinterpret_cast<void*>(static_cast<uintptr_t>(i | BIT_IDX_RANGE_180_SET)));
         }
     }
 

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -2446,7 +2446,7 @@ CPLErr GDALWarpOperation::CreateKernelMask( GDALWarpKernel *poKernel,
           : (static_cast<GIntBig>(nXSize) * nYSize + nExtraElts + 31) / 8;
 
         const size_t nByteSize_t = static_cast<size_t>(nBytes);
-#if SIZEOF_VOIDP != 8
+#if SIZEOF_VOIDP == 4
         if( static_cast<GIntBig>(nByteSize_t) != nBytes )
         {
             CPLError(

--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -41,6 +41,7 @@ check_include_file("dlfcn.h" HAVE_DLFCN_H)
 check_type_size("int" SIZEOF_INT)
 check_type_size("unsigned long" SIZEOF_UNSIGNED_LONG)
 check_type_size("void*" SIZEOF_VOIDP)
+check_type_size("size_t" SIZEOF_SIZE_T)
 
 if (MSVC)
   set(HAVE_VSNPRINTF 1)

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -21,6 +21,9 @@
 /* The size of `void*', as computed by sizeof. */
 #cmakedefine SIZEOF_VOIDP @SIZEOF_VOIDP@
 
+/* The size of `size_t', as computed by sizeof. */
+#cmakedefine SIZEOF_SIZE_T @SIZEOF_SIZE_T@
+
 /* Define to 1, if you have LARGEFILE64_SOURCE */
 #cmakedefine VSI_NEED_LARGEFILE64_SOURCE 1
 

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -2493,20 +2493,16 @@ CPLErr GDALDAASRasterBand::GetBlocks(int nBlockXOff, int nBlockYOff,
                     nBufferDTSize );
 #endif
 
-        poTileDS = MEMDataset::Create(
+        auto poMEMDS = MEMDataset::Create(
             "", nRequestWidth, nRequestHeight, 0, eBufferDataType, nullptr);
+        poTileDS = poMEMDS;
         for( int i = 0; i < static_cast<int>(anRequestedBands.size()); i++ )
         {
-            char szBuffer0[128] = {};
-            char szBuffer[64] = {};
-            int nRet = CPLPrintPointer(
-                szBuffer,
+            auto hBand = MEMCreateRasterBandEx(
+                poMEMDS, i + 1,
                 pabySrcData + i * nGotHeight * nGotWidth * nBufferDTSize,
-                sizeof(szBuffer));
-            szBuffer[nRet] = 0;
-            snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
-            char* apszOptions[2] = { szBuffer0, nullptr };
-            poTileDS->AddBand(eBufferDataType, apszOptions);
+                eBufferDataType, 0, 0, false );
+            poMEMDS->AddMEMBand(hBand);
         }
     }
     else

--- a/frmts/gif/giflib/gifalloc.c
+++ b/frmts/gif/giflib/gifalloc.c
@@ -370,10 +370,10 @@ MakeSavedImage(GifFileType * GifFile,
         return ((SavedImage *)NULL);
     else {
         sp = &GifFile->SavedImages[GifFile->ImageCount++];
-        memset((char *)sp, '\0', sizeof(SavedImage));
+        memset(sp, '\0', sizeof(SavedImage));
 
         if (CopyFrom) {
-            memcpy((char *)sp, CopyFrom, sizeof(SavedImage));
+            memcpy(sp, CopyFrom, sizeof(SavedImage));
 
             /* 
              * Make our own allocated copies of the heap fields in the

--- a/frmts/gtiff/libtiff/tif_config.h
+++ b/frmts/gtiff/libtiff/tif_config.h
@@ -58,6 +58,10 @@
 /* Pointer difference type */
 #define TIFF_PTRDIFF_T ptrdiff_t
 
+#ifndef SIZEOF_SIZE_T
+#define SIZEOF_SIZE_T SIZEOF_VOIDP
+#endif
+
 /* Signed size type */
 #ifdef _WIN64
 #  define TIFF_SSIZE_T GIntBig
@@ -66,7 +70,7 @@
 #else
 #  define TIFF_SSIZE_T signed long
 #  define TIFF_SSIZE_FORMAT "ld"
-#  if SIZEOF_VOIDP == 8
+#  if SIZEOF_SIZE_T == 8
 #    define TIFF_SIZE_FORMAT "lu"
 #  else
 #    define TIFF_SIZE_FORMAT "u"
@@ -90,10 +94,6 @@
 
 #ifdef JPEG_DUAL_MODE_8_12
 #  define LIBJPEG_12_PATH "../../jpeg/libjpeg12/jpeglib.h"
-#endif
-
-#ifndef SIZEOF_SIZE_T
-#define SIZEOF_SIZE_T SIZEOF_VOIDP
 #endif
 
 #define HAVE_ASSERT_H

--- a/frmts/gtiff/libtiff/tif_open.c
+++ b/frmts/gtiff/libtiff/tif_open.c
@@ -96,7 +96,6 @@ TIFFClientOpen(
 	assert(sizeof(int32_t) == 4);
 	assert(sizeof(uint64_t) == 8);
 	assert(sizeof(int64_t) == 8);
-	assert(sizeof(tmsize_t)==sizeof(void*));
 	{
 		union{
 			uint8_t a8[2];

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -933,10 +933,11 @@ CPLErr MEMDataset::IBuildOverviews( const char *pszResampling,
         // for it
         MEMRasterBand* poMEMBand = reinterpret_cast<MEMRasterBand*>(poBand);
         const bool bMustGenerateMaskOvr =
-                ( (poMEMBand->bOwnMask && poMEMBand->poMask != nullptr) ||
+            ( (poMEMBand->bOwnMask && poMEMBand->poMask != nullptr) ||
         // Or if it is a per-dataset mask, in which case just do it for the
         // first band
-                  ((poMEMBand->nMaskFlags & GMF_PER_DATASET) != 0 && iBand == 0) );
+                  ((poMEMBand->nMaskFlags & GMF_PER_DATASET) != 0 && iBand == 0) ) &&
+            dynamic_cast<MEMRasterBand*>(poBand->GetMaskBand()) != nullptr;
 
         if( nNewOverviews > 0 && bMustGenerateMaskOvr )
         {

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -1719,7 +1719,7 @@ void MEMAbstractMDArray::ReadWrite(bool bIsWrite,
                 CPLAssert(false);
             }
             else if ( bBothAreNumericDT
-#if SIZEOF_VOIDP == 8
+#if SIZEOF_VOIDP >= 8
                       && src_inc_offset <= std::numeric_limits<int>::max()
                       && dst_inc_offset <= std::numeric_limits<int>::max()
 #endif

--- a/frmts/mem/memdataset.h
+++ b/frmts/mem/memdataset.h
@@ -79,6 +79,13 @@ class CPL_DLL MEMDataset CPL_NON_FINAL: public GDALDataset
     virtual void                LeaveReadWrite();
 #endif
 
+    friend void GDALRegister_MEM();
+
+    // cppcheck-suppress unusedPrivateFunction
+    static GDALDataset *CreateBase( const char * pszFilename,
+                                int nXSize, int nYSize, int nBands,
+                                GDALDataType eType, char ** papszParamList );
+
   public:
                  MEMDataset();
     virtual      ~MEMDataset();
@@ -125,8 +132,10 @@ class CPL_DLL MEMDataset CPL_NON_FINAL: public GDALDataset
 
     std::shared_ptr<GDALGroup> GetRootGroup() const override;
 
+    void   AddMEMBand(GDALRasterBandH hMEMBand);
+
     static GDALDataset *Open( GDALOpenInfo * );
-    static GDALDataset *Create( const char * pszFilename,
+    static MEMDataset *Create( const char * pszFilename,
                                 int nXSize, int nYSize, int nBands,
                                 GDALDataType eType, char ** papszParamList );
     static GDALDataset *CreateMultiDimensional( const char * pszFilename,

--- a/frmts/mem/memmultidim.h
+++ b/frmts/mem/memmultidim.h
@@ -31,6 +31,14 @@
 
 #include "gdal_priv.h"
 
+// If modifying the below declaration, modify it in gdal_array.i too
+std::shared_ptr<GDALMDArray> CPL_DLL MEMGroupCreateMDArray(GDALGroup* poGroup,
+                                                   const std::string& osName,
+                                                   const std::vector<std::shared_ptr<GDALDimension>>& aoDimensions,
+                                                   const GDALExtendedDataType& oDataType,
+                                                   void* pData,
+                                                   CSLConstList papszOptions);
+
 /************************************************************************/
 /*                               MEMGroup                               */
 /************************************************************************/
@@ -66,6 +74,12 @@ public:
                                                        const std::vector<std::shared_ptr<GDALDimension>>& aoDimensions,
                                                        const GDALExtendedDataType& oDataType,
                                                        CSLConstList papszOptions) override;
+
+    std::shared_ptr<GDALMDArray> CreateMDArray(const std::string& osName,
+                                                       const std::vector<std::shared_ptr<GDALDimension>>& aoDimensions,
+                                                       const GDALExtendedDataType& oDataType,
+                                                       void* pData,
+                                                       CSLConstList papszOptions);
 
     std::shared_ptr<GDALAttribute> GetAttribute(const std::string& osName) const override;
 

--- a/frmts/pcidsk/sdk/port/pthread_mutex.cpp
+++ b/frmts/pcidsk/sdk/port/pthread_mutex.cpp
@@ -61,16 +61,16 @@ PThreadMutex::PThreadMutex()
 {
     hMutex = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
 
-#if defined(PTHREAD_MUTEX_RECURSIVE)
+#if defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
+    pthread_mutex_t tmp_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+    *hMutex = tmp_mutex;
+#elif defined(PTHREAD_MUTEX_RECURSIVE) || defined(HAVE_PTHREAD_MUTEX_RECURSIVE)
     {
         pthread_mutexattr_t  attr;
         pthread_mutexattr_init( &attr );
         pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_RECURSIVE );
         pthread_mutex_init( hMutex, &attr );
     }
-#elif defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
-    pthread_mutex_t tmp_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-    *hMutex = tmp_mutex;
 #else
 #error "Recursive mutexes apparently unsupported, configure --without-threads"
 #endif

--- a/frmts/pdf/pdfcreatecopy.cpp
+++ b/frmts/pdf/pdfcreatecopy.cpp
@@ -34,6 +34,7 @@
 #include "cpl_error.h"
 #include "ogr_spatialref.h"
 #include "ogr_geometry.h"
+#include "memdataset.h"
 #include "vrtdataset.h"
 
 #include "pdfobject.h"
@@ -3887,7 +3888,7 @@ GDALPDFObjectNum GDALPDFBaseWriter::WriteBlock(GDALDataset* poSrcDS,
 
     CPLErr eErr = CE_None;
     GDALDataset* poBlockSrcDS = nullptr;
-    GDALDatasetH hMemDS = nullptr;
+    std::unique_ptr<MEMDataset> poMEMDS;
     GByte* pabyMEMDSBuffer = nullptr;
 
     if (eCompressMethod == COMPRESS_DEFAULT)
@@ -3991,21 +3992,13 @@ GDALPDFObjectNum GDALPDFBaseWriter::WriteBlock(GDALDataset* poSrcDS,
         if (nBands == 4)
             nBands = 3;
 
-        GDALDriverH hMemDriver = GDALGetDriverByName("MEM");
-        if( hMemDriver == nullptr )
-            return GDALPDFObjectNum();
-
-        hMemDS = GDALCreate(hMemDriver, "MEM:::",
-                            nReqXSize, nReqYSize, 0,
-                            GDT_Byte, nullptr);
-        if (hMemDS == nullptr)
-            return GDALPDFObjectNum();
+        poMEMDS.reset(MEMDataset::Create("", nReqXSize, nReqYSize,
+                                         0, GDT_Byte, nullptr));
 
         pabyMEMDSBuffer =
             (GByte*)VSIMalloc3(nReqXSize, nReqYSize, nBands);
         if (pabyMEMDSBuffer == nullptr)
         {
-            GDALClose(hMemDS);
             return GDALPDFObjectNum();
         }
 
@@ -4019,24 +4012,19 @@ GDALPDFObjectNum GDALPDFBaseWriter::WriteBlock(GDALDataset* poSrcDS,
         if( eErr != CE_None )
         {
             CPLFree(pabyMEMDSBuffer);
-            GDALClose(hMemDS);
             return GDALPDFObjectNum();
         }
 
         int iBand;
         for(iBand = 0; iBand < nBands; iBand ++)
         {
-            char** papszMEMDSOptions = nullptr;
-            char szTmp[64];
-            memset(szTmp, 0, sizeof(szTmp));
-            CPLPrintPointer(szTmp,
-                            pabyMEMDSBuffer + iBand * nReqXSize * nReqYSize, sizeof(szTmp));
-            papszMEMDSOptions = CSLSetNameValue(papszMEMDSOptions, "DATAPOINTER", szTmp);
-            GDALAddBand(hMemDS, GDT_Byte, papszMEMDSOptions);
-            CSLDestroy(papszMEMDSOptions);
+            auto hBand = MEMCreateRasterBandEx( poMEMDS.get(), iBand + 1,
+                                                pabyMEMDSBuffer + iBand * nReqXSize * nReqYSize,
+                                                GDT_Byte, 0, 0, false );
+            poMEMDS->AddMEMBand(hBand);
         }
 
-        poBlockSrcDS = (GDALDataset*) hMemDS;
+        poBlockSrcDS = poMEMDS.get();
     }
 
     auto nImageId = AllocNewObject();
@@ -4236,11 +4224,6 @@ GDALPDFObjectNum GDALPDFBaseWriter::WriteBlock(GDALDataset* poSrcDS,
 end:
     CPLFree(pabyMEMDSBuffer);
     pabyMEMDSBuffer = nullptr;
-    if( hMemDS != nullptr )
-    {
-        GDALClose(hMemDS);
-        hMemDS = nullptr;
-    }
 
     EndObjWithStream();
 

--- a/frmts/png/libpng/pngpriv.h
+++ b/frmts/png/libpng/pngpriv.h
@@ -494,7 +494,9 @@
    static_cast<type>(static_cast<const void*>(value))
 #else
 #  define png_voidcast(type, value) (value)
-#  ifdef _WIN64
+#  ifdef __UINTPTR_TYPE__
+      typedef __UINTPTR_TYPE__ png_ptruint;
+#  elif defined(_WIN64)
 #     ifdef __GNUC__
          typedef unsigned long long png_ptruint;
 #     else

--- a/frmts/rasterlite/CMakeLists.txt
+++ b/frmts/rasterlite/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_gdal_driver(TARGET gdal_Rasterlite SOURCES rasterlitedataset.h rasterlitecreatecopy.cpp rasterlitedataset.cpp
                                                rasterliteoverviews.cpp PLUGIN_CAPABLE NO_DEPS)
 gdal_standard_includes(gdal_Rasterlite)
+target_include_directories(gdal_Rasterlite PRIVATE ${GDAL_RASTER_FORMAT_SOURCE_DIR}/mem)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
   # These files has CPL_CVSID("$id$") which break ODR and UNITY_BUILD
   set_property(SOURCE rasterlitecreatecopy.cpp rasterlitedataset.cpp rasterliteoverviews.cpp

--- a/frmts/rasterlite/GNUmakefile
+++ b/frmts/rasterlite/GNUmakefile
@@ -3,7 +3,7 @@ include ../../GDALmake.opt
 
 OBJ	=	rasterlitedataset.o rasterlitecreatecopy.o rasterliteoverviews.o
 
-CPPFLAGS	:=	 $(CPPFLAGS) -iquote ../../ogr
+CPPFLAGS	:=	 $(CPPFLAGS) -iquote ../../ogr -iquote ../mem
 
 default:	$(OBJ:.o=.$(OBJ_EXT))
 

--- a/frmts/rasterlite/makefile.vc
+++ b/frmts/rasterlite/makefile.vc
@@ -1,7 +1,7 @@
 
 OBJ	=	rasterlitedataset.obj rasterlitecreatecopy.obj rasterliteoverviews.obj
 
-EXTRAFLAGS = -I../../ogr
+EXTRAFLAGS = -I../../ogr -I../mem
 
 GDAL_ROOT	=	..\..
 

--- a/frmts/rasterlite/rasterliteoverviews.cpp
+++ b/frmts/rasterlite/rasterliteoverviews.cpp
@@ -29,6 +29,7 @@
 #include "cpl_string.h"
 #include "ogr_api.h"
 #include "ogr_srs_api.h"
+#include "memdataset.h"
 
 #include "rasterlitedataset.h"
 
@@ -425,7 +426,7 @@ CPLErr RasterliteDataset::CreateOverviewLevel(const char * pszResampling,
     {
         for( int nBlockXOff = 0; eErr == CE_None && nBlockXOff < nXBlocks; nBlockXOff++ )
         {
-            GDALDatasetH hPrevOvrMemDS = nullptr;
+            std::unique_ptr<MEMDataset> poPrevOvrMemDS;
 
 /* -------------------------------------------------------------------- */
 /*      Create in-memory tile                                           */
@@ -457,27 +458,18 @@ CPLErr RasterliteDataset::CreateOverviewLevel(const char * pszResampling,
                     break;
                 }
 
-                hPrevOvrMemDS = GDALCreate(hMemDriver, "MEM:::",
+                poPrevOvrMemDS.reset(MEMDataset::Create("",
                                            nPrevOvrReqXSize, nPrevOvrReqYSize, 0,
-                                           eDataType, nullptr);
-
-                if (hPrevOvrMemDS == nullptr)
-                {
-                    eErr = CE_Failure;
-                    break;
-                }
+                                           eDataType, nullptr));
 
                 for( int iBand = 0; iBand < nBands; iBand++ )
                 {
-                    char szTmp[64];
-                    memset(szTmp, 0, sizeof(szTmp));
-                    CPLPrintPointer(szTmp,
-                                    pabyPrevOvrMEMDSBuffer + iBand * nDataTypeSize *
-                                    nPrevOvrReqXSize * nPrevOvrReqYSize, sizeof(szTmp));
-                    char** l_papszOptions
-                        = CSLSetNameValue(nullptr, "DATAPOINTER", szTmp);
-                    GDALAddBand(hPrevOvrMemDS, eDataType, l_papszOptions);
-                    CSLDestroy(l_papszOptions);
+                    auto hBand = MEMCreateRasterBandEx(
+                        poPrevOvrMemDS.get(), iBand + 1,
+                        pabyPrevOvrMEMDSBuffer + iBand * nDataTypeSize *
+                            nPrevOvrReqXSize * nPrevOvrReqYSize,
+                        eDataType, 0, 0, false );
+                    poPrevOvrMemDS->AddMEMBand(hBand);
                 }
             }
             else
@@ -495,35 +487,27 @@ CPLErr RasterliteDataset::CreateOverviewLevel(const char * pszResampling,
                 }
             }
 
-            GDALDatasetH hMemDS = GDALCreate(hMemDriver, "MEM:::",
-                                              nReqXSize, nReqYSize, 0,
-                                              eDataType, nullptr);
-            if (hMemDS == nullptr)
-            {
-                eErr = CE_Failure;
-                break;
-            }
-
+            auto poMemDS = std::unique_ptr<MEMDataset>(
+                MEMDataset::Create("", nReqXSize, nReqYSize, 0, eDataType, nullptr));
             for(int iBand = 0; iBand < nBands; iBand ++)
             {
-                char szTmp[64];
-                memset(szTmp, 0, sizeof(szTmp));
-                CPLPrintPointer(szTmp,
-                                pabyMEMDSBuffer + iBand * nDataTypeSize *
-                                nReqXSize * nReqYSize, sizeof(szTmp));
-                char** l_papszOptions
-                    = CSLSetNameValue(nullptr, "DATAPOINTER", szTmp);
-                GDALAddBand(hMemDS, eDataType, l_papszOptions);
-                CSLDestroy(l_papszOptions);
+                auto hBand = MEMCreateRasterBandEx(
+                    poMemDS.get(), iBand + 1,
+                    pabyMEMDSBuffer + iBand * nDataTypeSize *
+                                nReqXSize * nReqYSize,
+                    eDataType, 0, 0, false );
+                poMemDS->AddMEMBand(hBand);
             }
 
-            if( hPrevOvrMemDS != nullptr )
+            auto hMemDS = GDALDataset::ToHandle(poMemDS.get());
+            if( poPrevOvrMemDS != nullptr )
             {
                 for(int iBand = 0; iBand < nBands; iBand ++)
                 {
                     GDALRasterBandH hDstOvrBand = GDALGetRasterBand(hMemDS, iBand+1);
 
-                    eErr = GDALRegenerateOverviews( GDALGetRasterBand(hPrevOvrMemDS, iBand+1),
+                    auto hPrevOvrMEMDS = GDALDataset::ToHandle(poPrevOvrMemDS.get());
+                    eErr = GDALRegenerateOverviews( GDALGetRasterBand(hPrevOvrMEMDS, iBand+1),
                                                     1, &hDstOvrBand,
                                                     pszResampling,
                                                     nullptr, nullptr );
@@ -531,14 +515,14 @@ CPLErr RasterliteDataset::CreateOverviewLevel(const char * pszResampling,
                         break;
                 }
 
-                GDALClose(hPrevOvrMemDS);
+                poPrevOvrMemDS.reset();
             }
 
             GDALDatasetH hOutDS = GDALCreateCopy(hTileDriver,
                                         osTempFileName.c_str(), hMemDS, FALSE,
                                         papszTileDriverOptions, nullptr, nullptr);
 
-            GDALClose(hMemDS);
+            poMemDS.reset();
             if (! hOutDS)
             {
                 eErr = CE_Failure;

--- a/frmts/raw/ntv2dataset.cpp
+++ b/frmts/raw/ntv2dataset.cpp
@@ -298,8 +298,8 @@ void NTv2Dataset::FlushCache(bool bAtClosing)
         }
         else if( EQUAL(pszKey,"SUB_NAME") )
         {
-            memcpy( achGridHeader + 0*nRecordSize+8, "        ", 8 );
-            memcpy( achGridHeader + 0*nRecordSize+8,
+            memcpy( achGridHeader + /*0*nRecordSize+*/8, "        ", 8 );
+            memcpy( achGridHeader + /*0*nRecordSize+*/8,
                     pszValue,
                     std::min(nMinLen, strlen(pszValue)) );
         }

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -352,28 +352,16 @@ CPLErr STACTARawDataset::IRasterIO( GDALRWFlag eRWFlag,
             }
 
 
-            auto poMEMDS = std::unique_ptr<GDALDataset>(
+            auto poMEMDS = std::unique_ptr<MEMDataset>(
                 MEMDataset::Create( "", nXSizeMod, nYSizeMod, 0,
                                     eBandDT, nullptr ));
             for( int i = 0; i < nBandCount; i++ )
             {
-                char szBuffer[32] = { '\0' };
-                int nRet = CPLPrintPointer(
-                        szBuffer,
-                        &abyBuf[0] + i * nDTSize * nXSizeMod * nYSizeMod,
-                        sizeof(szBuffer));
-                szBuffer[nRet] = '\0';
-
-                char szBuffer0[64] = { '\0' };
-                snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
-                char szBuffer1[64] = { '\0' };
-                snprintf( szBuffer1, sizeof(szBuffer1),
-                          "PIXELOFFSET=%d", nDTSize );
-                char szBuffer2[64] = { '\0' };
-                snprintf( szBuffer2, sizeof(szBuffer2),
-                          "LINEOFFSET=%d", nDTSize * nXSizeMod );
-                char* apszOptions[4] = { szBuffer0, szBuffer1, szBuffer2, nullptr };
-                poMEMDS->AddBand(eBandDT, apszOptions);
+                auto hBand = MEMCreateRasterBandEx(
+                    poMEMDS.get(), i + 1,
+                    &abyBuf[0] + i * nDTSize * nXSizeMod * nYSizeMod,
+                    eBandDT, 0, 0, false );
+                poMEMDS->AddMEMBand(hBand);
             }
 
             sExtraArgs.eResampleAlg = psExtraArg->eResampleAlg;

--- a/frmts/usgsdem/CMakeLists.txt
+++ b/frmts/usgsdem/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_gdal_driver(TARGET gdal_USGSDEM SOURCES usgsdem_create.cpp usgsdemdataset.cpp PLUGIN_CAPABLE NO_DEPS)
 gdal_standard_includes(gdal_USGSDEM)
-target_include_directories(gdal_USGSDEM PRIVATE $<TARGET_PROPERTY:alg,SOURCE_DIR>)
+target_include_directories(gdal_USGSDEM PRIVATE $<TARGET_PROPERTY:alg,SOURCE_DIR> ${GDAL_RASTER_FORMAT_SOURCE_DIR}/mem)

--- a/frmts/usgsdem/GNUmakefile
+++ b/frmts/usgsdem/GNUmakefile
@@ -3,7 +3,7 @@ include ../../GDALmake.opt
 
 OBJ	=	usgsdemdataset.o usgsdem_create.o
 
-CPPFLAGS	:=	 -iquote ../../alg $(CPPFLAGS)
+CPPFLAGS	:=	 -iquote ../../alg -iquote ../mem $(CPPFLAGS)
 
 default:	$(OBJ:.o=.$(OBJ_EXT))
 

--- a/frmts/usgsdem/makefile.vc
+++ b/frmts/usgsdem/makefile.vc
@@ -1,7 +1,7 @@
 
 OBJ	=	usgsdemdataset.obj usgsdem_create.obj
 
-EXTRAFLAGS = 	-I..\..\alg
+EXTRAFLAGS = 	-I..\..\alg -I..\mem
 
 GDAL_ROOT	=	..\..
 

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -897,6 +897,8 @@ class VRTDriver final: public GDALDriver
 {
     CPL_DISALLOW_COPY_ASSIGN(VRTDriver)
 
+    std::map<std::string, VRTSourceParser> m_oMapSourceParser{};
+
   public:
                  VRTDriver();
     virtual ~VRTDriver();

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -1320,7 +1320,7 @@ bool GDALExtendedDataType::CopyValue(const void* pSrc,
         const char* srcStrPtr;
         memcpy(&srcStrPtr, pSrc, sizeof(const char*));
         char* pszDup = srcStrPtr ? CPLStrdup(srcStrPtr) : nullptr;
-        memcpy(pDst, &pszDup, sizeof(char*));
+        *reinterpret_cast<void**>(pDst) = pszDup;
         return true;
     }
     if( srcType.GetClass() == GEDTC_NUMERIC &&
@@ -1386,7 +1386,7 @@ bool GDALExtendedDataType::CopyValue(const void* pSrc,
                 break;
         }
         char* pszDup = str ? CPLStrdup(str) : nullptr;
-        memcpy(pDst, &pszDup, sizeof(char*));
+        *reinterpret_cast<void**>(pDst) = pszDup;
         return true;
     }
     if( srcType.GetClass() == GEDTC_STRING &&

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -1091,27 +1091,14 @@ CPLErr GDALRasterBand::RasterIOResampled(
     poMEMDS = MEMDataset::Create( "", nDestXOffVirtual + nBufXSize,
                                   nDestYOffVirtual + nBufYSize, 0,
                                   eDTMem, nullptr );
-    char szBuffer[32] = { '\0' };
-    int nRet =
-        CPLPrintPointer(
-            szBuffer, static_cast<GByte*>(pDataMem)
-            - nPSMem * nDestXOffVirtual
-            - nLSMem * nDestYOffVirtual, sizeof(szBuffer));
-    szBuffer[nRet] = '\0';
-
-    char szBuffer0[64] = { '\0' };
-    snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
-    char szBuffer1[64] = { '\0' };
-    snprintf( szBuffer1, sizeof(szBuffer1),
-              "PIXELOFFSET=" CPL_FRMT_GIB, static_cast<GIntBig>(nPSMem) );
-    char szBuffer2[64] = { '\0' };
-    snprintf( szBuffer2, sizeof(szBuffer2),
-              "LINEOFFSET=" CPL_FRMT_GIB, static_cast<GIntBig>(nLSMem) );
-    char* apszOptions[4] = { szBuffer0, szBuffer1, szBuffer2, nullptr };
-
-    poMEMDS->AddBand(eDTMem, apszOptions);
-
-    GDALRasterBandH hMEMBand = poMEMDS->GetRasterBand(1);
+    GByte* pabyData = static_cast<GByte*>(pDataMem)
+                        - nPSMem * nDestXOffVirtual
+                        - nLSMem * nDestYOffVirtual;
+    GDALRasterBandH hMEMBand = MEMCreateRasterBandEx( poDS, 1, pabyData,
+                                                      eDTMem,
+                                                      nPSMem, nLSMem,
+                                                      false );
+    poMEMDS->SetBand(1, GDALRasterBand::FromHandle(hMEMBand));
 
     const char* pszNBITS = GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
     if( pszNBITS )

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -5261,7 +5261,7 @@ bool GDALBufferHasOnlyNoData( const void* pBuffer,
 {
     // In the case where the nodata is 0, we can compare several bytes at
     // once. Select the largest natural integer type for the architecture.
-#if SIZEOF_VOIDP == 8 || defined(__x86_64__)
+#if SIZEOF_VOIDP >= 8 || defined(__x86_64__)
     // We test __x86_64__ for x32 arch where SIZEOF_VOIDP == 4
     typedef std::uint64_t WordType;
 #else
@@ -5275,7 +5275,7 @@ bool GDALBufferHasOnlyNoData( const void* pBuffer,
         size_t i = 0;
         const size_t nInitialIters = std::min(
             sizeof(WordType) -
-                (reinterpret_cast<std::uintptr_t>(pabyBuffer) % sizeof(WordType)),
+                static_cast<size_t>(reinterpret_cast<std::uintptr_t>(pabyBuffer) % sizeof(WordType)),
             nSize);
         for( ; i < nInitialIters; i++ )
         {

--- a/ogr/ogrsf_frmts/geojson/libjson/config.h
+++ b/ogr/ogrsf_frmts/geojson/libjson/config.h
@@ -128,3 +128,7 @@
 #define HAVE_DECL_NAN
 
 #include "cpl_config.h"
+
+#ifndef SIZE_T_MAX
+#define SIZE_T_MAX  (~(size_t)0)
+#endif

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
@@ -1580,7 +1580,7 @@ json_object* json_object_new_double_with_precision(double dfVal,
 {
     json_object* jso = json_object_new_double(dfVal);
     json_object_set_serializer(jso, OGR_json_double_with_precision_to_string,
-                               (void*)(size_t)nCoordPrecision, nullptr );
+                               (void*)(uintptr_t)nCoordPrecision, nullptr );
     return jso;
 }
 
@@ -1682,7 +1682,7 @@ json_object_new_double_with_significant_figures( double dfVal,
     json_object* jso = json_object_new_double(dfVal);
     json_object_set_serializer(
         jso, OGR_json_double_with_significant_figures_to_string,
-        reinterpret_cast<void*>(static_cast<size_t>(nSignificantFigures)),
+        reinterpret_cast<void*>(static_cast<uintptr_t>(nSignificantFigures)),
         nullptr );
     return jso;
 }
@@ -1740,7 +1740,7 @@ json_object_new_float_with_significant_figures( float fVal,
     json_object* jso = json_object_new_double(fVal);
     json_object_set_serializer(
         jso, OGR_json_float_with_significant_figures_to_string,
-        reinterpret_cast<void*>(static_cast<size_t>(nSignificantFigures)),
+        reinterpret_cast<void*>(static_cast<uintptr_t>(nSignificantFigures)),
         nullptr );
     return jso;
 }

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
@@ -1739,7 +1739,7 @@ OGRFeature* OGROpenFileGDBLayer::GetCurrentFeature()
                         sBounds.maxx = sFeatureEnvelope.MaxX;
                         sBounds.maxy = sFeatureEnvelope.MaxY;
                         CPLQuadTreeInsertWithBounds(m_pQuadTree,
-                                                    (void*)(size_t)iRow,
+                                                    reinterpret_cast<void*>(static_cast<uintptr_t>(iRow)),
                                                     &sBounds);
                     }
                 }
@@ -2112,7 +2112,7 @@ GIntBig OGROpenFileGDBLayer::GetFeatureCount( int bForce )
                         sBounds.maxx = sFeatureEnvelope.MaxX;
                         sBounds.maxy = sFeatureEnvelope.MaxY;
                         CPLQuadTreeInsertWithBounds(m_pQuadTree,
-                                                    (void*)(size_t)i,
+                                                    reinterpret_cast<void*>(static_cast<uintptr_t>(i)),
                                                     &sBounds);
                     }
                 }
@@ -2134,7 +2134,7 @@ GIntBig OGROpenFileGDBLayer::GetFeatureCount( int bForce )
                                         sizeof(void*) *
                                         nFilteredFeatureCountAlloc));
                             }
-                            m_pahFilteredFeatures[nCount] = (void*)(size_t)i;
+                            m_pahFilteredFeatures[nCount] = reinterpret_cast<void*>(static_cast<uintptr_t>(i));
                         }
                         nCount ++;
                     }

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitebase.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitebase.h
@@ -156,6 +156,7 @@ class OGRSQLiteBaseDataSource CPL_NON_FINAL: public GDALPamDataset
 
     sqlite3            *GetDB() { return hDB; }
     inline bool         GetUpdate() const { return eAccess == GA_Update; }
+    VSILFILE*           GetVSILFILE() const { return fpMainFile; }
 
     void                NotifyFileOpened (const char* pszFilename,
                                           VSILFILE* fp);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -2640,20 +2640,6 @@ OGRLayer * OGRSQLiteDataSource::ExecuteSQL( const char *pszSQLCommand,
     }
 
 /* -------------------------------------------------------------------- */
-/*      Special case GetVSILFILE() command (used by GDAL MBTiles driver)*/
-/* -------------------------------------------------------------------- */
-    if (strcmp(pszSQLCommand, "GetVSILFILE()") == 0)
-    {
-        if (fpMainFile == nullptr)
-            return nullptr;
-
-        char szVal[64];
-        int nRet = CPLPrintPointer( szVal, fpMainFile, sizeof(szVal)-1 );
-        szVal[nRet] = '\0';
-        return new OGRSQLiteSingleFeatureLayer( "VSILFILE", szVal );
-    }
-
-/* -------------------------------------------------------------------- */
 /*      Special case for SQLITE_HAS_COLUMN_METADATA()                   */
 /* -------------------------------------------------------------------- */
     if (strcmp(pszSQLCommand, "SQLITE_HAS_COLUMN_METADATA()") == 0)

--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -78,7 +78,7 @@
 #error "Unexpected value for SIZEOF_UNSIGNED_LONG"
 #endif
 
-#if !defined(SIZEOF_VOIDP) || (SIZEOF_VOIDP != 4 && SIZEOF_VOIDP != 8)
+#if !defined(SIZEOF_VOIDP)
 #error "Unexpected value for SIZEOF_VOIDP"
 #endif
 
@@ -257,8 +257,11 @@ typedef GUIntBig         GUInt64;
 /** Minimum GUInt64 value */
 #define GUINT64_MAX     GUINTBIG_MAX
 
-
-#if SIZEOF_VOIDP == 8
+#if SIZEOF_VOIDP > 8
+#include <stddef.h> // ptrdiff_t
+/** Integer type large enough to hold the difference between 2 addresses */
+typedef ptrdiff_t        GPtrDiff_t;
+#elif SIZEOF_VOIDP == 8
 /** Integer type large enough to hold the difference between 2 addresses */
 typedef GIntBig          GPtrDiff_t;
 #else

--- a/port/cpl_spawn.cpp
+++ b/port/cpl_spawn.cpp
@@ -57,7 +57,11 @@
         #include <crt_externs.h>
         #define environ (*_NSGetEnviron())
     #else
-        extern char** environ;
+        #if defined(__FreeBSD__)
+            extern __attribute__((__weak__)) char **environ;
+        #else
+            extern char** environ;
+        #endif
     #endif
 #endif
 #endif

--- a/port/cpl_vsil_unix_stdio_64.cpp
+++ b/port/cpl_vsil_unix_stdio_64.cpp
@@ -228,7 +228,7 @@ class VSIUnixStdioHandle final : public VSIVirtualHandle
     int Close() override;
     int Truncate( vsi_l_offset nNewSize ) override;
     void *GetNativeFileDescriptor() override {
-        return reinterpret_cast<void *>(static_cast<size_t>(fileno(fp))); }
+        return reinterpret_cast<void *>(static_cast<uintptr_t>(fileno(fp))); }
     VSIRangeStatus GetRangeStatus( vsi_l_offset nOffset,
                                    vsi_l_offset nLength ) override;
 };

--- a/swig/python/extensions/gdal_array_wrap.cpp
+++ b/swig/python/extensions/gdal_array_wrap.cpp
@@ -3254,6 +3254,15 @@ typedef void GDALDatasetShadow;
 typedef void GDALRasterAttributeTableShadow;
 #endif
 
+// Declaration from memmultidim.h
+std::shared_ptr<GDALMDArray> CPL_DLL MEMGroupCreateMDArray(GDALGroup* poGroup,
+                                                   const std::string& osName,
+                                                   const std::vector<std::shared_ptr<GDALDimension>>& aoDimensions,
+                                                   const GDALExtendedDataType& oDataType,
+                                                   void* pData,
+                                                   CSLConstList papszOptions);
+
+
 CPL_C_START
 
 GDALRasterBandH CPL_DLL MEMCreateRasterBandEx( GDALDataset *, int, GByte *,
@@ -3766,16 +3775,11 @@ GDALDataset* NUMPYMultiDimensionalDataset::Open( PyArrayObject *psArray )
                               static_cast<GIntBig>(PyArray_STRIDES(psArray)[i]));
     }
     CPLStringList aosOptions;
-    char szDataPointer[128] = { '\0' };
-    int nChars = CPLPrintPointer( szDataPointer,
-                                  PyArray_DATA(psArray),
-                                  sizeof(szDataPointer) );
-    szDataPointer[nChars] = 0;
-    aosOptions.SetNameValue("DATAPOINTER", szDataPointer);
     aosOptions.SetNameValue("STRIDES", strides.c_str());
-    auto mdArray = poGroup->CreateMDArray("array",
+    auto mdArray = MEMGroupCreateMDArray(poGroup.get(), "array",
                                       apoDims,
                                       GDALExtendedDataType::Create(eType),
+                                      PyArray_DATA(psArray),
                                       aosOptions.List());
     if( !mdArray )
     {


### PR DESCRIPTION
Architectures such as ARM Morello or RISC V CHERI (see https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/) use 128 bit pointers that have extra protection against wrong usage. So in particular on those architectures sizeof(void*) == 16 and sizeof(size_t) == 8. This breaks a couple assumption in code
Another more tricky aspect is that a valid pointer cannot be used from the string representation of its address (it crashes at runtime, due to being considered invalid). So basically all uses of CPLPrintPointer() / DATAPOINTER with the MEM driver, and other more confidential usages in a few drivers, are all broken. Fortunately they can be avoided.