### PR TITLE
Fix build related to rasterio_ssse3 on x32 architecture (fixes #5917)

### DIFF
--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -3117,9 +3117,8 @@ static inline void GDALUnrolledCopy( T* CPL_RESTRICT pDest,
 
 #ifdef HAVE_SSSE3_AT_COMPILE_TIME
 
-void GDALUnrolledCopy_GByte_3_1_SSSE3( GByte* CPL_RESTRICT pDest,
-                                             const GByte* CPL_RESTRICT pSrc,
-                                             GPtrDiff_t nIters );
+#include "rasterio_ssse3.h"
+
 #endif
 
 

--- a/gcore/rasterio_ssse3.cpp
+++ b/gcore/rasterio_ssse3.cpp
@@ -32,16 +32,14 @@ CPL_CVSID("$Id$")
 
 #if defined(HAVE_SSSE3_AT_COMPILE_TIME) && ( defined(__x86_64) || defined(_M_X64) )
 
+#include "rasterio_ssse3.h"
+
 #include <tmmintrin.h>
 #include "gdal_priv_templates.hpp"
 
 void GDALUnrolledCopy_GByte_3_1_SSSE3( GByte* CPL_RESTRICT pDest,
                                              const GByte* CPL_RESTRICT pSrc,
-                                             GInt64 nIters );
-
-void GDALUnrolledCopy_GByte_3_1_SSSE3( GByte* CPL_RESTRICT pDest,
-                                             const GByte* CPL_RESTRICT pSrc,
-                                             GInt64 nIters )
+                                             GPtrDiff_t nIters )
 {
     decltype(nIters) i;
     const __m128i xmm_shuffle0 = _mm_set_epi8(-1  ,-1  ,-1  ,-1,

--- a/gcore/rasterio_ssse3.h
+++ b/gcore/rasterio_ssse3.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *
+ * Project:  GDAL Core
+ * Purpose:  SSSE3 specializations
+ * Author:   Even Rouault <even dot rouault at spatialys dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2016, Even Rouault <even dot rouault at spatialys dot com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef RASTERIO_SSSE3_H_INCLUDED
+#define RASTERIO_SSSE3_H_INCLUDED
+
+#include "cpl_port.h"
+
+#if defined(HAVE_SSSE3_AT_COMPILE_TIME) && ( defined(__x86_64) || defined(_M_X64) )
+
+void GDALUnrolledCopy_GByte_3_1_SSSE3( GByte* CPL_RESTRICT pDest,
+                                       const GByte* CPL_RESTRICT pSrc,
+                                       GPtrDiff_t nIters );
+
+#endif
+
+#endif /* RASTERIO_SSSE3_H_INCLUDED */


### PR DESCRIPTION
The issue was due to an inconsistent declaration of the
GDALUnrolledCopy_GByte_3_1_SSSE3() method in rasterio.cpp and
rasterio_ssse3.cpp (GInt64 vs GPtrDiff_t, which are of different size on
x32)
