### PR TITLE
MRF: When zstd is missing disable zstd, not deflate

### DIFF
--- a/frmts/mrf/mrf_band.cpp
+++ b/frmts/mrf/mrf_band.cpp
@@ -391,9 +391,9 @@ MRFRasterBand::MRFRasterBand( MRFDataset *parent_dataset,
         zstd_level = image.quality;
 
 #if !defined(ZSTD_SUPPORT)
-    if (dodeflate) { // signal error condition to caller
+    if (dozstd) { // signal error condition to caller
         CPLError(CE_Failure, CPLE_AssertionFailed, "MRF: ZSTD support is not available");
-        dodeflate = FALSE;
+        dozstd = FALSE;
     }
 #endif
         // Chose zstd over deflate if both are enabled and available


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fix a bug in MRF, where deflate was disabled by mistake on builds without ZSTD

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
