### PR TITLE
KEA: add support for 64 bit nodata functions

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -576,7 +576,7 @@ gdal_check_package(GEOS "Geometry Engine - Open Source (GDAL core dependency)" R
 )
 gdal_check_package(HDF4 "Enable HDF4 driver" CAN_DISABLE)
 
-define_find_package2(KEA libkea/KEACommon.h kea)
+define_find_package2(KEA libkea/KEACommon.h kea;libkea)
 gdal_check_package(KEA "Enable KEA driver" CAN_DISABLE)
 
 gdal_check_package(ECW "Enable ECW driver" CAN_DISABLE)

--- a/frmts/kea/keaband.cpp
+++ b/frmts/kea/keaband.cpp
@@ -558,6 +558,44 @@ double KEARasterBand::GetNoDataValue(int *pbSuccess)
     }
 }
 
+int64_t KEARasterBand::GetNoDataValueAsInt64(int *pbSuccess)
+{
+    try
+    {
+        int64_t nVal;
+        this->m_pImageIO->getNoDataValue(this->nBand, &nVal, kealib::kea_64int);
+        if( pbSuccess != nullptr )
+            *pbSuccess = 1;
+
+        return nVal;
+    }
+    catch (const kealib::KEAIOException &)
+    {
+        if( pbSuccess != nullptr )
+            *pbSuccess = 0;
+        return -1;
+    }
+}
+
+uint64_t KEARasterBand::GetNoDataValueAsUInt64(int *pbSuccess)
+{
+    try
+    {
+        uint64_t nVal;
+        this->m_pImageIO->getNoDataValue(this->nBand, &nVal, kealib::kea_64uint);
+        if( pbSuccess != nullptr )
+            *pbSuccess = 1;
+
+        return nVal;
+    }
+    catch (const kealib::KEAIOException &)
+    {
+        if( pbSuccess != nullptr )
+            *pbSuccess = 0;
+        return -1;
+    }
+}
+
 // set the no data value
 CPLErr KEARasterBand::SetNoDataValue(double dfNoData)
 {
@@ -602,6 +640,32 @@ CPLErr KEARasterBand::SetNoDataValue(double dfNoData)
     {
         return CE_Failure;
     }
+}
+
+CPLErr KEARasterBand::SetNoDataValueAsInt64(int64_t nNoData)
+{
+    try
+    {
+        this->m_pImageIO->setNoDataValue(this->nBand, &nNoData, kealib::kea_64int);
+    }
+    catch (const kealib::KEAIOException &)
+    {
+        return CE_Failure;
+    }
+    return CE_None;
+}
+
+CPLErr KEARasterBand::SetNoDataValueAsUInt64(uint64_t nNoData)
+{
+    try
+    {
+        this->m_pImageIO->setNoDataValue(this->nBand, &nNoData, kealib::kea_64uint);
+    }
+    catch (const kealib::KEAIOException &)
+    {
+        return CE_Failure;
+    }
+    return CE_None;
 }
 
 CPLErr KEARasterBand::DeleteNoDataValue()

--- a/frmts/kea/keaband.h
+++ b/frmts/kea/keaband.h
@@ -74,7 +74,13 @@ public:
 
     // virtual methods for the no data value
     double GetNoDataValue(int *pbSuccess=nullptr) override;
+    int64_t GetNoDataValueAsInt64(int *pbSuccess=nullptr) override;
+    uint64_t GetNoDataValueAsUInt64(int *pbSuccess=nullptr) override;
+
     CPLErr SetNoDataValue(double dfNoData) override;
+    CPLErr SetNoDataValueAsInt64(int64_t nNoData) override;
+    CPLErr SetNoDataValueAsUInt64(uint64_t nNoData) override;
+
     virtual CPLErr DeleteNoDataValue() override;
 
     // histogram methods


### PR DESCRIPTION
## What does this PR do?

Adds support for (u)int64 int nodata functions to the KEA driver. KEA supports reading and writing of the nodata value as any data type so we use this functionality to save and retrieve the nodata as (u)int64.

This PR also addresses finding `libkea` on Windows. Because of the somewhat non standard naming kea uses on Windows (is called `libkea.lib` there rather than `kea.lib` as `cmake` expects) we need to explicitly add `libkea` so it is found.

## What are related issues/pull requests?

Support for 64 bit KEA images was added in https://github.com/OSGeo/gdal/pull/5710.

@rouault are there any other areas of driver functionality that have been recently changed to support 64 bit?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
