### PR TITLE
[Backport release/3.4] OGR: Backport fixes for `Is3D` & `IsMeasured` from #5477 to 3.4

### DIFF
--- a/gdal/ogr/ogr_geometry.h
+++ b/gdal/ogr/ogr_geometry.h
@@ -402,9 +402,9 @@ class CPL_DLL OGRGeometry
     virtual OGRGeometry* Normalize() const;
     virtual OGRBoolean  IsSimple() const;
     /*! Returns whether the geometry has a Z component. */
-    OGRBoolean  Is3D() const { return flags & OGR_G_3D; }
+    OGRBoolean  Is3D() const { return (flags & OGR_G_3D) != 0; }
     /*! Returns whether the geometry has a M component. */
-    OGRBoolean  IsMeasured() const { return flags & OGR_G_MEASURED; }
+    OGRBoolean  IsMeasured() const { return (flags & OGR_G_MEASURED) != 0; }
     virtual OGRBoolean  IsRing() const;
     virtual void        empty() = 0;
     virtual OGRGeometry *clone() const CPL_WARN_UNUSED_RESULT = 0;


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Backports fixes for `Is3D` & `IsMeasured` from #5477 to 3.4

## What are related issues/pull requests?
The GeoParquet support introduced in #5477, also fixed two smaller bugs in `Is3D` and `IsMeasured`, namely that they don't return a boolean as documented, but the result of a bitflag and operation.

This change was breaking for packages that worked around this bug, when 3.5 was introduced in downstream packages, such as GDAL.jl 1.4 in https://github.com/yeesian/ArchGDAL.jl/pull/307.

By backporting, we can align the behaviour of downstream supported versions.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
