### PR TITLE
Multidim API: significantly enhance performance of reading transposed…

### DIFF
--- a/frmts/hdf5/hdf5multidim.cpp
+++ b/frmts/hdf5/hdf5multidim.cpp
@@ -1676,16 +1676,11 @@ bool HDF5Array::IRead(const GUInt64* arrayStartIdx,
         anStep[i] = static_cast<hsize_t>(count[i] == 1 ? 1 : arrayStep[i]);
         nEltCount *= count[i];
     }
-    size_t nCurStride = 1;
-    for( size_t i = nDims; i > 0; )
+
+    if( IsTransposedRequest(count, bufferStride) )
     {
-        --i;
-        if( count[i] != 1 && static_cast<size_t>(bufferStride[i]) != nCurStride )
-        {
-            return ReadSlow(arrayStartIdx, count, arrayStep, bufferStride,
-                            bufferDataType, pDstBuffer);
-        }
-        nCurStride *= count[i];
+        return ReadForTransposedRequest(arrayStartIdx, count, arrayStep,
+                                        bufferStride, bufferDataType, pDstBuffer);
     }
 
     hid_t hBufferType = H5I_INVALID_HID;

--- a/frmts/netcdf/netcdfmultidim.cpp
+++ b/frmts/netcdf/netcdfmultidim.cpp
@@ -2886,6 +2886,12 @@ bool netCDFVariable::IRead(const GUInt64* arrayStartIdx,
         }
     }
 
+    if( IsTransposedRequest(count, bufferStride) )
+    {
+        return ReadForTransposedRequest(arrayStartIdx, count, arrayStep,
+                                        bufferStride, bufferDataType, pDstBuffer);
+    }
+
     return IReadWrite
                 (true,
                  arrayStartIdx, count, arrayStep, bufferStride,

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1936,7 +1936,14 @@ public:
 
     static
     bool CopyValue(const void* pSrc, const GDALExtendedDataType& srcType,
-                     void* pDst, const GDALExtendedDataType& dstType);
+                   void* pDst, const GDALExtendedDataType& dstType);
+
+    static
+    bool CopyValues(const void* pSrc, const GDALExtendedDataType& srcType,
+                    GPtrDiff_t nSrcStrideInElts,
+                    void* pDst, const GDALExtendedDataType& dstType,
+                    GPtrDiff_t nDstStrideInElts,
+                    size_t nValues);
 
 private:
     GDALExtendedDataType(size_t nMaxStringLength, GDALExtendedDataTypeSubType eSubType);
@@ -2473,6 +2480,18 @@ protected:
 
     std::shared_ptr<GDALGroup> GetCacheRootGroup(bool bCanCreate,
                                                  std::string& osCacheFilenameOut) const;
+
+    // Returns if bufferStride values express a transposed view of the array
+    bool IsTransposedRequest(const size_t* count,
+                             const GPtrDiff_t* bufferStride) const;
+
+    // Should only be called if IsTransposedRequest() returns true
+    bool ReadForTransposedRequest(const GUInt64* arrayStartIdx,
+                                  const size_t* count,
+                                  const GInt64* arrayStep,
+                                  const GPtrDiff_t* bufferStride,
+                                  const GDALExtendedDataType& bufferDataType,
+                                  void* pDstBuffer) const;
 //! @endcond
 
 public:


### PR DESCRIPTION
… arrays for netCDF/HDF5

Using the netCDF/HDF5 APIs to read a slice with strides that express a
transposed view yield to extremely poor/unusable performance. This fixes
this by using temporary memory to read in a contiguous buffer in a
row-major order, and then do the transposition to the final buffer.
