### PR TITLE
Be less sensitive on warnings at configure time

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -266,11 +266,6 @@ gdal_check_package(Iconv "Character set recoding (used in GDAL portability libra
 if (Iconv_FOUND)
   set(CMAKE_REQUIRED_INCLUDES ${Iconv_INCLUDE_DIR})
   set(CMAKE_REQUIRED_LIBRARIES ${Iconv_LIBRARY})
-  if (MSVC)
-    set(CMAKE_REQUIRED_FLAGS "/WX")
-  else ()
-    set(CMAKE_REQUIRED_FLAGS "-Werror")
-  endif ()
 
   set(ICONV_CONST_TEST_CODE
       "#include <stdlib.h>


### PR DESCRIPTION
Compile checks do not need `-Werror` - I hope

Situation here: `CXXFLAGS` contain some extra parameters (`-lunwind -Wl,--exclude-libs=libunwind.a`) which make clang throw an "unused parameter" warning which in turn make this check fail which in turn erroneously lead to `ICONV_CPP_CONST` being set which in turn leads in a compile time failure which is tricky to track down.

Is there a reason for `-Werror` here? I hope CI or @rouault can tell so we can come up with a more targeted check.