### PR TITLE
OpenFileGDB write: fix issues related to rollback and default field width of string fields

### DIFF
--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -111,7 +111,13 @@ def test_ogr_openfilegdb_write_field_types(use_synctodisk):
 
         fld_defn = ogr.FieldDefn('str_not_nullable', ogr.OFTString)
         fld_defn.SetNullable(False)
+        with gdaltest.config_option('OPENFILEGDB_DEFAULT_STRING_WIDTH', '12345'):
+            assert lyr.CreateField(fld_defn) == ogr.OGRERR_NONE
+        assert lyr.GetLayerDefn().GetFieldDefn(lyr.GetLayerDefn().GetFieldCount() - 1).GetWidth() == 12345
+
+        fld_defn = ogr.FieldDefn('str_default_width', ogr.OFTString)
         assert lyr.CreateField(fld_defn) == ogr.OGRERR_NONE
+        assert lyr.GetLayerDefn().GetFieldDefn(lyr.GetLayerDefn().GetFieldCount() - 1).GetWidth() == 0
 
         fld_defn = ogr.FieldDefn('int32', ogr.OFTInteger)
         fld_defn.SetDefault('-12345')
@@ -188,6 +194,10 @@ def test_ogr_openfilegdb_write_field_types(use_synctodisk):
 
         fld_defn = lyr.GetLayerDefn().GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex('str_not_nullable'))
         assert fld_defn.IsNullable() == False
+        assert fld_defn.GetWidth() == 12345
+
+        fld_defn = lyr.GetLayerDefn().GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex('str_default_width'))
+        assert fld_defn.GetWidth() == 0
 
         fld_defn = lyr.GetLayerDefn().GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex('int16'))
         assert fld_defn.GetSubType() == ogr.OFSTInt16
@@ -233,6 +243,13 @@ def test_ogr_openfilegdb_write_field_types(use_synctodisk):
 
 
         ds = None
+
+        with gdaltest.config_option('OPENFILEGDB_REPORT_GENUINE_FIELD_WIDTH', 'YES'):
+            ds = ogr.Open(dirname)
+            lyr = ds.GetLayer(0)
+            fld_defn = lyr.GetLayerDefn().GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex('str_default_width'))
+            assert fld_defn.GetWidth() == 65536
+            ds = None
 
     finally:
         gdal.RmdirRecursive(dirname)

--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -2203,6 +2203,11 @@ def test_ogr_openfilegdb_write_emulated_transactions():
         assert ds.RollbackTransaction() == ogr.OGRERR_NONE
         assert lyr.GetFeatureCount() == 1
 
+        # Test that StartTransaction() / RollbackTransaction() doesn't destroy
+        # unmodified layers! (https://github.com/OSGeo/gdal/issues/5952)
+        assert ds.StartTransaction(True) == ogr.OGRERR_NONE
+        assert ds.RollbackTransaction() == ogr.OGRERR_NONE
+
         ds = None
 
         ds = ogr.Open(dirname, update=1)

--- a/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
@@ -3083,9 +3083,9 @@ bool FGdbLayer::GDBToOGRFields(CPLXMLNode* psRoot)
             }
             fieldTemplate.SetSubType(eSubType);
             /* On creation (GDBFieldTypeToWidthPrecision) if string width is 0, we pick up */
-            /* 65535 by default to mean unlimited string length, but we don't want */
+            /* 65536 by default to mean unlimited string length, but we don't want */
             /* to advertise such a big number */
-            if( ogrType == OFTString && nLength < 65535 )
+            if( ogrType == OFTString && nLength < 65536 )
                 fieldTemplate.SetWidth(nLength);
             //fieldTemplate.SetPrecision(nPrecision);
             fieldTemplate.SetNullable(bNullable);

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
@@ -703,10 +703,13 @@ int OGROpenFileGDBLayer::BuildLayerDefinition()
         oFieldDefn.SetAlternativeName(poGDBField->GetAlias().c_str());
         oFieldDefn.SetSubType(eSubType);
         // On creation in the FileGDB driver (GDBFieldTypeToWidthPrecision) if
-        // string width is 0, we pick up 65535 by default to mean unlimited
+        // string width is 0, we pick up 65536 by default to mean unlimited
         // string length, but we do not want to advertise such a big number.
-        if( eType == OFTString && nWidth < 65535 )
+        if( eType == OFTString && (nWidth < 65536 ||
+            CPLTestBool(CPLGetConfigOption("OPENFILEGDB_REPORT_GENUINE_FIELD_WIDTH", "NO"))) )
+        {
             oFieldDefn.SetWidth(nWidth);
+        }
         oFieldDefn.SetNullable(poGDBField->IsNullable());
 
         const CPLXMLNode* psFieldDef = nullptr;

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -2452,6 +2452,9 @@ bool OGROpenFileGDBLayer::CommitEmulatedTransaction()
 
 bool OGROpenFileGDBLayer::RollbackEmulatedTransaction()
 {
+    if( !m_bHasCreatedBackupForTransaction )
+        return true;
+
     SyncToDisk();
 
     // Restore feature definition

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -1082,9 +1082,11 @@ OGRErr OGROpenFileGDBLayer::CreateField(OGRFieldDefn* poField, int bApproxOK)
         nWidth = poField->GetWidth();
         if( nWidth == 0 )
         {
-            // Can be useful to try to replicate FileGDB driver, but do
-            // not use its 65536 default value.
-            nWidth = atoi(CPLGetConfigOption("OPENFILEGDB_STRING_WIDTH", "0"));
+            // We can't use a 0 width value since that prevents ArcMap
+            // from editing (#5952)
+            nWidth = atoi(CPLGetConfigOption("OPENFILEGDB_DEFAULT_STRING_WIDTH", "65536"));
+            if( nWidth < 65536 )
+                poField->SetWidth(nWidth);
         }
     }
 


### PR DESCRIPTION
Fixes #5952