### PR TITLE
CPLDebug: Variadic functions can't use __stdcall calling convention.

### DIFF
--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -170,7 +170,7 @@ void CPL_DLL CPL_STDCALL CPLPopErrorHandler(void);
 #ifdef WITHOUT_CPLDEBUG
 #define CPLDebug(...)  /* Eat all CPLDebug calls. */
 #else
-void CPL_DLL CPL_STDCALL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
+void CPL_DLL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
     CPL_PRINT_FUNC_FORMAT(2, 3);
 #endif
 


### PR DESCRIPTION
Variadic functions can't be called with `__stdcall` calling convention on Windows. See also this blog post by Raymond Chen:
https://devblogs.microsoft.com/oldnewthing/20040108-00/?p=41163

I'm not sure what compilers are actually doing when variadic functions are decorated with `__stdcall`. I'd guess they fall back to `__cdecl`. GCC seems to do that silently. But clang emits a lot of warnings during compilation. E.g.:
```
[569/1221] Building CXX object frmts/netcdf/CMakeFiles/gdal_netCDF.dir/netcdflayersg.cpp.obj
In file included from C:/_/mingw-w64-gdal/src/gdal-3.5.0/frmts/netcdf/netcdflayersg.cpp:29:
In file included from C:/_/mingw-w64-gdal/src/gdal-3.5.0/frmts/netcdf/netcdfdataset.h:44:
In file included from C:/_/mingw-w64-gdal/src/gdal-3.5.0/port/cpl_string.h:35:
C:/_/mingw-w64-gdal/src/gdal-3.5.0/port/cpl_error.h:173:14: warning: stdcall calling convention is not supported on variadic function [-Wignored-attributes]
void CPL_DLL CPL_STDCALL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
             ^
C:/_/mingw-w64-gdal/src/build-CLANG32-shared/port/cpl_config.h:8:23: note: expanded from macro 'CPL_STDCALL'
#  define CPL_STDCALL __stdcall
                      ^
<built-in>:412:34: note: expanded from here
#define __stdcall __attribute__((__stdcall__))
                                 ^
1 warning generated.
```

Since `__cdecl` is the only calling convention that supports variadic functions (and it is the default in C/C++), it should be enough to remove that attribute (`CPL_STDCALL`) from the function declaration (no need to explicitly specify a differing calling convention).
