### PR TITLE
cpl_config.h: Don't use __stdcall on MinGW 

### DIFF
--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -3,7 +3,7 @@
 #ifndef CPL_CONFIG_H
 #define CPL_CONFIG_H
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 # ifndef CPL_DISABLE_STDCALL
 #  define CPL_STDCALL __stdcall
 # endif


### PR DESCRIPTION
Fixes a regression from b90f823be80d6447aec23d15525fdfc8fb5310cf

Before that change, `CPL_STDCALL` was set to `__stdcall` only for MSVC compilers (not MinGW). After that change, it is always set on Windows (MSVC or MinGW doesn't matter).

This proposed change reverts to not using `__stdcall` for MinGW. Instead, the interface would use `__cdecl` again which was used before and is the preferred calling convention for MinGW.