### PR TITLE
[Backport release/3.5] CPLDebug: Variadic functions can't use __stdcall calling convention.

### DIFF
--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -170,7 +170,7 @@ void CPL_DLL CPL_STDCALL CPLPopErrorHandler(void);
 #ifdef WITHOUT_CPLDEBUG
 #define CPLDebug(...)  /* Eat all CPLDebug calls. */
 #else
-void CPL_DLL CPL_STDCALL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
+void CPL_DLL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
     CPL_PRINT_FUNC_FORMAT(2, 3);
 #endif
 


### PR DESCRIPTION
Backport #5962
 **Authored by:** @mmuetzel