### PR TITLE
[Backport release/3.5] cpl_config.h: Don't use __stdcall on MinGW 

### DIFF
--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -3,7 +3,7 @@
 #ifndef CPL_CONFIG_H
 #define CPL_CONFIG_H
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 # ifndef CPL_DISABLE_STDCALL
 #  define CPL_STDCALL __stdcall
 # endif


### PR DESCRIPTION
Backport #5963
 **Authored by:** @mmuetzel