### PR TITLE
Fix 'union' and 'intersect' descriptions in gdal_calc.py documentation

### DIFF
--- a/doc/source/programs/gdal_calc.rst
+++ b/doc/source/programs/gdal_calc.rst
@@ -108,9 +108,9 @@ but no projection checking is performed (unless projectionCheck option is used).
     
     ``fail`` - the dimensions and the extent (bounds) of the rasters must agree, otherwise the operation will fail.
     
-    ``union`` - the extent (bounds) of the output will be the minimal rectangle that contains all the input extents.
+    ``intersect`` - the extent (bounds) of the output will be the minimal rectangle that contains all the input extents.
     
-    ``intersect`` - the extent (bounds) of the output will be the maximal rectangle that is contained in all the input extents.
+    ``union`` - the extent (bounds) of the output will be the maximal rectangle that is contained in all the input extents.
 
 .. option:: --projwin <ulx> <uly> <lrx> <lry>
 


### PR DESCRIPTION
The definitions of the `union` and `intersect` parameters of the `extent` option seemed to be reversed in the gdal_calc.py documentation