### PR TITLE
OGRGeometry::UnionCascaded(): avoid crash with GEOS < 3.11 on empty multipolygon input

### DIFF
--- a/autotest/ogr/ogr_geos.py
+++ b/autotest/ogr/ogr_geos.py
@@ -344,6 +344,15 @@ def test_ogr_geos_unioncascaded():
 ###############################################################################
 
 
+def test_ogr_geos_unioncascaded_empty_multipolygon():
+
+    g1 = ogr.Geometry(ogr.wkbMultiPolygon)
+    cascadedunion = g1.UnionCascaded()
+    assert cascadedunion.IsEmpty()
+
+###############################################################################
+
+
 def test_ogr_geos_convexhull():
 
     g1 = ogr.CreateGeometryFromWkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))')

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -4613,6 +4613,17 @@ OGRGeometry *OGRGeometry::UnionCascaded() const
               "GEOS support not enabled." );
     return nullptr;
 #else
+
+#if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 11
+    if( wkbFlatten(getGeometryType()) == wkbMultiPolygon &&
+        IsEmpty() )
+    {
+        // GEOS < 3.11 crashes on an empty multipolygon input
+        auto poRet = new OGRGeometryCollection();
+        poRet->assignSpatialReference(getSpatialReference());
+        return poRet;
+    }
+#endif
     OGRGeometry *poOGRProduct = nullptr;
 
     GEOSContextHandle_t hGEOSCtxt = createGEOSContext();


### PR DESCRIPTION
The fix in GEOS 3.11 was likely https://github.com/libgeos/geos/commit/ba190d9016f94f92c7e152cb723dc683fd416a04