### PR TITLE
[Backport release/3.5] OSRGetProjTLSContext(): make it faster on Linux by saving getpid() system call

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -116,6 +116,13 @@ else ()
         "
     HAVE_5ARGS_MREMAP)
 
+  check_c_source_compiles(
+    "
+        #include <pthread.h>
+        int main() { pthread_atfork(0,0,0); 0; }
+        "
+    HAVE_PTHREAD_ATFORK)
+
   check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
   if (${CMAKE_SYSTEM} MATCHES "Linux")
       check_include_file("linux/fs.h" HAVE_LINUX_FS_H)

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -58,6 +58,9 @@
 /* Define to 1 if you have the `pthread_spinlock_t' type. */
 #cmakedefine HAVE_PTHREAD_SPINLOCK 1
 
+/* Define to 1 if you have the `pthread_atfork' function. */
+#cmakedefine HAVE_PTHREAD_ATFORK 1
+
 /* Define to 1 if you have the 5 args `mremap' function. */
 #cmakedefine HAVE_5ARGS_MREMAP 1
 

--- a/ogr/ogr_proj_p.cpp
+++ b/ogr/ogr_proj_p.cpp
@@ -38,6 +38,9 @@
 #ifndef _WIN32
 #include <sys/types.h>
 #include <unistd.h>
+#if defined(HAVE_PTHREAD_ATFORK)
+#include <pthread.h>
+#endif
 #endif
 
 #include <mutex>
@@ -74,6 +77,14 @@ static int g_projNetworkEnabled = -1;
 static unsigned g_projNetworkEnabledGenerationCounter = 0;
 #endif
 
+#if !defined(_WIN32) && defined(HAVE_PTHREAD_ATFORK)
+static bool g_bForkOccured = false;
+static void ForkOccured(void)
+{
+    g_bForkOccured = true;
+}
+#endif
+
 struct OSRPJContextHolder
 {
     unsigned searchPathGenerationCounter = 0;
@@ -84,14 +95,25 @@ struct OSRPJContextHolder
     PJ_CONTEXT* context = nullptr;
     OSRProjTLSCache oCache{};
 #if !defined(_WIN32)
+#if !defined(HAVE_PTHREAD_ATFORK)
     pid_t curpid = 0;
+#endif
 #if defined(SIMUL_OLD_PROJ6) || !(PROJ_VERSION_MAJOR > 6 || PROJ_VERSION_MINOR >= 2)
     std::vector<PJ_CONTEXT*> oldcontexts{};
 #endif
 #endif
 
 #if !defined(_WIN32)
-    OSRPJContextHolder(): curpid(getpid()) { init(); }
+    OSRPJContextHolder()
+#if !defined(HAVE_PTHREAD_ATFORK)
+        : curpid(getpid())
+#endif
+    {
+#if HAVE_PTHREAD_ATFORK
+        pthread_atfork(nullptr, nullptr, ForkOccured);
+#endif
+        init();
+    }
 #else
     OSRPJContextHolder() { init(); }
 #endif
@@ -178,11 +200,17 @@ static OSRPJContextHolder& GetProjTLSContextHolder()
     // Detect if we are now running in a child process created by fork()
     // In that situation we must make sure *not* to use the same underlying
     // file open descriptor to the sqlite3 database, since seeks&reads in one
+#if defined(HAVE_PTHREAD_ATFORK)
+    if( g_bForkOccured )
+#else
     // of the parent or child will affect the other end.
     const pid_t curpid = getpid();
     if( curpid != l_projContext.curpid )
+#endif
     {
+#if !defined(HAVE_PTHREAD_ATFORK)
         l_projContext.curpid = curpid;
+#endif
 #if defined(SIMUL_OLD_PROJ6) || !(PROJ_VERSION_MAJOR > 6 || PROJ_VERSION_MINOR >= 2)
         // PROJ < 6.2 ? Recreate new context
         l_projContext.oldcontexts.push_back(l_projContext.context);


### PR DESCRIPTION
Backport #6002
 **Authored by:** @rouault