### PR TITLE
[Backport release/3.5] GTiff: avoid SetMetadata() to cancel effect of SetGeoTransform() (fixes #6015)

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -8439,6 +8439,27 @@ def test_tiff_write_setgeotransform_and_setmetadata(setmetadata_before):
     gdal.GetDriverByName('GTiff').Delete(filename)
 
 
+@pytest.mark.parametrize("getspatialref_before", [True, False])
+def test_tiff_write_setgeotransform_and_getspatialref(getspatialref_before):
+
+    filename = '/vsimem/out.tif'
+    ds = gdal.GetDriverByName('GTiff').Create(filename, 1, 1)
+    ds.SetGeoTransform([1,2,3,4,5,-6])
+    ds = None
+    ds = gdal.Open(filename, gdal.GA_Update)
+    if getspatialref_before:
+        ds.GetSpatialRef()
+    ds.SetGeoTransform([10,20,30,40,50,-60])
+    if not getspatialref_before:
+        ds.GetSpatialRef()
+    ds = None
+    ds = gdal.Open(filename)
+    assert ds.GetGeoTransform() == (10,20,30,40,50,-60)
+    ds = None
+
+    gdal.GetDriverByName('GTiff').Delete(filename)
+
+
 
 def test_tiff_write_cleanup():
     gdaltest.tiff_drv = None

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -8414,5 +8414,31 @@ def test_tiff_write_overview_building_and_approx_stats():
 
 
 
+###############################################################################
+# Test scenario of https://github.com/OSGeo/gdal/issues/6015
+
+
+@pytest.mark.parametrize("setmetadata_before", [True, False])
+def test_tiff_write_setgeotransform_and_setmetadata(setmetadata_before):
+
+    filename = '/vsimem/out.tif'
+    ds = gdal.GetDriverByName('GTiff').Create(filename, 1, 1)
+    ds.SetGeoTransform([1,2,3,4,5,-6])
+    ds = None
+    ds = gdal.Open(filename, gdal.GA_Update)
+    if setmetadata_before:
+        ds.SetMetadata([])
+    ds.SetGeoTransform([10,20,30,40,50,-60])
+    if not setmetadata_before:
+        ds.SetMetadata([])
+    ds = None
+    ds = gdal.Open(filename)
+    assert ds.GetGeoTransform() == (10,20,30,40,50,-60)
+    ds = None
+
+    gdal.GetDriverByName('GTiff').Delete(filename)
+
+
+
 def test_tiff_write_cleanup():
     gdaltest.tiff_drv = None

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -13961,10 +13961,6 @@ void GTiffDataset::LookForProjection()
 
         GTIFFree( hGTIF );
     }
-
-    m_bGeoTIFFInfoChanged = false;
-    m_bForceUnsetGTOrGCPs = false;
-    m_bForceUnsetProjection = false;
 }
 
 /************************************************************************/


### PR DESCRIPTION
Backport #6020
 **Authored by:** @rouault