### PR TITLE
/vsicurl/: when CPL_CURL_VERBOSE is enabled, log as CPLDebug() message…

### DIFF
--- a/autotest/gcore/vsicurl.py
+++ b/autotest/gcore/vsicurl.py
@@ -579,6 +579,45 @@ def test_vsicurl_no_size_in_HEAD():
 ###############################################################################
 
 
+def test_vsicurl_test_CPL_CURL_VERBOSE():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    gdal.VSICurlClearCache()
+
+    class MyHandler:
+        def __init__(self):
+            self.found_CURL_INFO = False
+            self.found_CURL_INFO_HEADER_IN = False
+            self.found_CURL_INFO_HEADER_OUT = False
+
+        def handler(self, err_type, err_no, err_msg):
+            if 'CURL_INFO_TEXT:' in err_msg:
+                self.found_CURL_INFO_TEXT = True
+            if 'CURL_INFO_HEADER_IN:' in err_msg:
+                self.found_CURL_INFO_HEADER_IN = True
+            if 'CURL_INFO_HEADER_OUT:' in err_msg:
+                self.found_CURL_INFO_HEADER_OUT = True
+
+    handler = webserver.SequentialHandler()
+    handler.add('HEAD', '/test_vsicurl_test_CPL_CURL_VERBOSE', 200, {'Content-Length': '3'})
+    my_error_handler = MyHandler()
+    with gdaltest.config_options({'CPL_CURL_VERBOSE': 'YES', 'CPL_DEBUG': 'ON'}):
+        with gdaltest.error_handler(my_error_handler.handler):
+            with webserver.install_http_handler(handler):
+                statres = gdal.VSIStatL('/vsicurl/http://localhost:%d/test_vsicurl_test_CPL_CURL_VERBOSE' % gdaltest.webserver_port)
+    assert statres.size == 3
+
+    assert my_error_handler.found_CURL_INFO_TEXT
+    assert my_error_handler.found_CURL_INFO_HEADER_IN
+    assert my_error_handler.found_CURL_INFO_HEADER_OUT
+
+    gdal.VSICurlClearCache()
+
+###############################################################################
+
+
 def test_vsicurl_stop_webserver():
 
     if gdaltest.webserver_port == 0:

--- a/autotest/gdrivers/gdalhttp.py
+++ b/autotest/gdrivers/gdalhttp.py
@@ -50,17 +50,6 @@ except ImportError:
 pytestmark = pytest.mark.require_driver('HTTP')
 
 
-@pytest.fixture(autouse=True, scope="module")
-def disable_dods_driver():
-    dods_drv = gdal.GetDriverByName('DODS')
-    if dods_drv is not None:
-        dods_drv.Deregister()
-    yield
-    if dods_drv is not None:
-        dods_drv.Register()
-    dods_drv = None
-
-
 @pytest.fixture(autouse=True)
 def set_http_timeout():
     with gdaltest.config_option('GDAL_HTTP_TIMEOUT', '5'):

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -117,6 +117,7 @@ struct WriteFuncStruct
     VSICurlReadCbkFunc  pfnReadCbk = nullptr;
     void               *pReadCbkUserData = nullptr;
     bool                bInterrupted = false;
+    bool                bInterruptIfNonErrorPayload = false;
 
 #if !CURL_AT_LEAST_VERSION(7,54,0)
     // Workaround to ignore extra HTTP response headers from


### PR DESCRIPTION
 the error message from the server ... if there's one when checking the file size. Typically, servers
don't return an error message for the HEAD request. So one may have to
set CPL_VSIL_CURL_USE_HEAD=NO to force a GET request, which can return
an error message in the HTTP response.
