### PR TITLE
[Backport release/3.5] netCDF: avoid error in SetMetadataItem() when computing statistics (3.5.0 regression, fixes #6023)

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -5260,6 +5260,26 @@ def test_netcdf_read_geogcrs_component_names():
     assert srs.GetAttrValue('GEOGCS|PRIMEM') == 'Greenwich'
 
 
+###############################################################################
+
+
+def test_netcdf_stats():
+
+    src_ds = gdal.Open('data/byte.tif')
+    filename = 'tmp/test_netcdf_stats.nc'
+    gdal.GetDriverByName('netCDF').CreateCopy(filename, src_ds)
+    ds = gdal.Open(filename)
+    gdal.ErrorReset()
+    assert ds.GetRasterBand(1).ComputeStatistics(False) == pytest.approx([74.0, 255.0, 126.765, 22.928470838675658])
+    assert gdal.GetLastErrorMsg() == ''
+    ds = None
+    assert gdal.VSIStatL(filename + '.aux.xml') is not None
+    ds = gdal.Open(filename)
+    assert float(ds.GetRasterBand(1).GetMetadataItem('STATISTICS_MINIMUM')) == 74
+    ds = None
+    gdal.GetDriverByName('netCDF').Delete(filename)
+
+
 def test_clean_tmp():
     # [KEEP THIS AS THE LAST TEST]
     # i.e. please do not add any tests after this one. Put new ones above.

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -1085,15 +1085,8 @@ CPLErr netCDFRasterBand::SetMetadataItem( const char* pszName,
                                           const char* pszValue,
                                           const char* pszDomain )
 {
-    if( GetAccess() != GA_Update )
-    {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                  "netCDFRasterBand::SetMetadataItem() can only be "
-                  "called in update mode");
-        return CE_Failure;
-    }
-
-    if( (pszDomain == nullptr || pszDomain[0] == '\0') && pszValue != nullptr )
+    if( GetAccess() == GA_Update &&
+        (pszDomain == nullptr || pszDomain[0] == '\0') && pszValue != nullptr )
     {
         // Same logic as in CopyMetadata()
 
@@ -1130,7 +1123,8 @@ CPLErr netCDFRasterBand::SetMetadataItem( const char* pszName,
 
 CPLErr netCDFRasterBand::SetMetadata( char** papszMD, const char* pszDomain )
 {
-    if( pszDomain == nullptr || pszDomain[0] == '\0' )
+    if( GetAccess() == GA_Update &&
+        (pszDomain == nullptr || pszDomain[0] == '\0') )
     {
         // We don't handle metadata item removal for now
         for( const char* const*  papszIter = papszMD; papszIter && *papszIter; ++papszIter )
@@ -2920,15 +2914,8 @@ CPLErr netCDFDataset::SetMetadataItem( const char* pszName,
                                           const char* pszValue,
                                           const char* pszDomain )
 {
-    if( GetAccess() != GA_Update )
-    {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                  "netCDFDataset::SetMetadataItem() can only be "
-                  "called in update mode");
-        return CE_Failure;
-    }
-
-    if( (pszDomain == nullptr || pszDomain[0] == '\0') && pszValue != nullptr )
+    if( GetAccess() == GA_Update &&
+        (pszDomain == nullptr || pszDomain[0] == '\0') && pszValue != nullptr )
     {
         std::string osName(pszName);
 
@@ -2961,7 +2948,8 @@ CPLErr netCDFDataset::SetMetadataItem( const char* pszName,
 
 CPLErr netCDFDataset::SetMetadata( char** papszMD, const char* pszDomain )
 {
-    if( pszDomain == nullptr || pszDomain[0] == '\0' )
+    if( GetAccess() == GA_Update &&
+        (pszDomain == nullptr || pszDomain[0] == '\0') )
     {
         // We don't handle metadata item removal for now
         for( const char* const*  papszIter = papszMD; papszIter && *papszIter; ++papszIter )


### PR DESCRIPTION
Backport #6025
 **Authored by:** @rouault