### PR TITLE
[Backport release/3.5] CMake: fix build with GDAL_BUILD_OPTIONAL_DRIVERS:BOOL=OFF (fixes #6031)

### DIFF
--- a/doc/source/build_hints.rst
+++ b/doc/source/build_hints.rst
@@ -197,6 +197,14 @@ detected. The behavior can also be globally controlled with the following variab
      This option should be set before CMakeCache.txt is created.
 
 
+.. note::
+
+    Using together GDAL_USE_EXTERNAL_LIBS=OFF and GDAL_USE_INTERNAL_LIBS=OFF
+    will result in a CMake configuration failure, because the following libraries
+    (either as external dependencies or using the internal copy) are at least
+    required: ZLIB, TIFF, GEOTIFF and JSONC. Enabling them as external or internal
+    libraries is thus required.
+
 Armadillo
 *********
 

--- a/ogr/ogrsf_frmts/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/CMakeLists.txt
@@ -23,7 +23,6 @@ ogr_default_driver(vrt "VRT - Virtual Format")
 # Caution: if modifying AVC declaration here, also modify it in gdal.cmake
 ogr_optional_driver(avc AVC)
 
-ogr_optional_driver(sdts SDTS) # depends ISO8211
 ogr_optional_driver(gml GML) # when not found both EXPAT/XercesC, return error in driver, referenced by WCS
 
 # ######################################################################################################################
@@ -50,6 +49,9 @@ ogr_optional_driver(mapml MapML)
 
 # ######################################################################################################################
 #
+
+ogr_dependent_driver(sdts SDTS "GDAL_ENABLE_DRIVER_SDTS")
+
 # XML drivers
 ogr_dependent_driver(gpx "GPX - GPS Exchange Format" "GDAL_USE_EXPAT")
 ogr_dependent_driver(gmlas GMLAS "GDAL_USE_XERCESC;OGR_ENABLE_DRIVER_PGDUMP")
@@ -65,7 +67,7 @@ ogr_dependent_driver(wfs "OGC WFS service" "GDAL_USE_CURL")
 ogr_dependent_driver(ngw "NextGIS Web" "GDAL_USE_CURL")
 ogr_dependent_driver(elastic "ElasticSearch" "GDAL_USE_CURL")
 
-ogr_optional_driver(idrisi IDRISI)
+ogr_dependent_driver(idrisi IDRISI "GDAL_ENABLE_DRIVER_IDRISI")
 
 ogr_dependent_driver(pds "Planetary Data Systems TABLE" "GDAL_ENABLE_DRIVER_PDS")
 


### PR DESCRIPTION
Backport #6032
 **Authored by:** @rouault