### PR TITLE
gcore/gdalrasterband.cpp: Support 64 bit images in Band.GetHistogram()

### DIFF
--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -3379,6 +3379,12 @@ CPLErr GDALRasterBand::GetHistogram( double dfMin, double dfMax,
                   case GDT_Int32:
                     dfValue = static_cast<GInt32 *>(pData)[iOffset];
                     break;
+                  case GDT_UInt64:
+                    dfValue = static_cast<GUInt64 *>(pData)[iOffset];
+                    break;
+                  case GDT_Int64:
+                    dfValue = static_cast<GInt64 *>(pData)[iOffset];
+                    break;
                   case GDT_Float32:
                   {
                     const float fValue = static_cast<float *>(pData)[iOffset];
@@ -3566,6 +3572,12 @@ CPLErr GDALRasterBand::GetHistogram( double dfMin, double dfMax,
                         break;
                       case GDT_Int32:
                         dfValue = static_cast<GInt32 *>(pData)[iOffset];
+                        break;
+                      case GDT_UInt64:
+                        dfValue = static_cast<GUInt64 *>(pData)[iOffset];
+                        break;
+                      case GDT_Int64:
+                        dfValue = static_cast<GInt64 *>(pData)[iOffset];
                         break;
                       case GDT_Float32:
                       {

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -3380,10 +3380,10 @@ CPLErr GDALRasterBand::GetHistogram( double dfMin, double dfMax,
                     dfValue = static_cast<GInt32 *>(pData)[iOffset];
                     break;
                   case GDT_UInt64:
-                    dfValue = static_cast<GUInt64 *>(pData)[iOffset];
+                    dfValue = static_cast<double>(static_cast<GUInt64 *>(pData)[iOffset]);
                     break;
                   case GDT_Int64:
-                    dfValue = static_cast<GInt64 *>(pData)[iOffset];
+                    dfValue = static_cast<double>(static_cast<GInt64 *>(pData)[iOffset]);
                     break;
                   case GDT_Float32:
                   {
@@ -3574,10 +3574,10 @@ CPLErr GDALRasterBand::GetHistogram( double dfMin, double dfMax,
                         dfValue = static_cast<GInt32 *>(pData)[iOffset];
                         break;
                       case GDT_UInt64:
-                        dfValue = static_cast<GUInt64 *>(pData)[iOffset];
+                        dfValue = static_cast<double>(static_cast<GUInt64 *>(pData)[iOffset]);
                         break;
                       case GDT_Int64:
-                        dfValue = static_cast<GInt64 *>(pData)[iOffset];
+                        dfValue = static_cast<double>(static_cast<GInt64 *>(pData)[iOffset]);
                         break;
                       case GDT_Float32:
                       {


### PR DESCRIPTION
Support for 64 bit images was recently added, but the GetHistogram function did not yet support them. The switch statements for handling pixel data types requires cases for Int64 and UInt64. Without them, the histogram was always just zeros. 
