### PR TITLE
vsis3: Provide credentials mechanism for web identity token on AWS EKS (fixes #4058)

### DIFF
--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -266,7 +266,8 @@ Several authentication methods are possible, and are attempted in the following 
 2. The :decl_configoption:`AWS_SECRET_ACCESS_KEY` and :decl_configoption:`AWS_ACCESS_KEY_ID` configuration options can be set. The :decl_configoption:`AWS_SESSION_TOKEN` configuration option must be set when temporary credentials are used.
 3. Starting with GDAL 2.3, alternate ways of providing credentials similar to what the "aws" command line utility or Boto3 support can be used. If the above mentioned environment variables are not provided, the ``~/.aws/credentials`` or ``%UserProfile%/.aws/credentials`` file will be read (or the file pointed by :decl_configoption:`CPL_AWS_CREDENTIALS_FILE`). The profile may be specified with the :decl_configoption:`AWS_DEFAULT_PROFILE` environment variable, or starting with GDAL 3.2 with the :decl_configoption:`AWS_PROFILE` environment variable (the default profile is "default").
 4. The ``~/.aws/config`` or ``%UserProfile%/.aws/config`` file may also be used (or the file pointer by :decl_configoption:`AWS_CONFIG_FILE`) to retrieve credentials and the AWS region.
-5. If none of the above method succeeds, instance profile credentials will be retrieved when GDAL is used on EC2 instances.
+5. If :decl_configoption:`AWS_ROLE_ARN` and :decl_configoption:`AWS_WEB_IDENTITY_TOKEN_FILE` are defined we will rely on credentials mechanism for web identity token based AWS sts action AssumeRoleWithWebIdentity (See.: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+6. If none of the above method succeeds, instance profile credentials will be retrieved when GDAL is used on EC2 instances.
 
 The :decl_configoption:`AWS_REGION` (or :decl_configoption:`AWS_DEFAULT_REGION` starting with GDAL 2.3) configuration option may be set to one of the supported S3 regions and defaults to ``us-east-1``.
 

--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -819,6 +819,7 @@ bool VSIS3HandleHelper::GetConfigurationFromAssumeRoleWithWebIdentity(bool bForc
         CPLPushErrorHandler(CPLQuietErrorHandler);
 
         CPLHTTPResult* psResult = CPLHTTPFetch( osSTS_asuume_role_with_web_identity_URL.c_str(), nullptr );
+        CPLPopErrorHandler();
         if( psResult )
         {
             if( psResult->nStatus == 0 && psResult->pabyData != nullptr )

--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -730,6 +730,132 @@ static bool IsMachinePotentiallyEC2Instance()
 #endif
 }
 
+
+/************************************************************************/
+/*                   ReadAWSWebIdentityTokenFile()                      */
+/************************************************************************/
+
+static bool ReadAWSWebIdentityTokenFile(const std::string& osWebIdentityTokenFile,
+                                        CPLString& webIdentityToken)
+{
+    GByte *pabyOut = nullptr;
+    if( !VSIIngestFile( nullptr, osWebIdentityTokenFile.c_str(), &pabyOut, nullptr, -1 ) )
+        return false;
+
+    webIdentityToken = reinterpret_cast<char *>(pabyOut);
+    VSIFree(pabyOut);
+    return !webIdentityToken.empty();
+}
+
+/************************************************************************/
+/*          GetConfigurationFromAssumeRoleWithWebIdentity()             */
+/************************************************************************/
+
+bool VSIS3HandleHelper::GetConfigurationFromAssumeRoleWithWebIdentity(bool bForceRefresh,
+                                                                      const std::string& osPathForOption,
+                                                                      CPLString& osSecretAccessKey,
+                                                                      CPLString& osAccessKeyId,
+                                                                      CPLString& osSessionToken)
+{
+    CPLMutexHolder oHolder( &ghMutex );
+    if( !bForceRefresh )
+    {
+        time_t nCurTime;
+        time(&nCurTime);
+        // Try to reuse credentials if they are still valid, but
+        // keep one minute of margin...
+        if( !gosGlobalAccessKeyId.empty() && nCurTime < gnGlobalExpiration - 60 )
+        {
+            osAccessKeyId = gosGlobalAccessKeyId;
+            osSecretAccessKey = gosGlobalSecretAccessKey;
+            osSessionToken = gosGlobalSessionToken;
+            return true;
+        }
+    }
+
+    const CPLString roleArn = VSIGetCredential(osPathForOption.c_str(), "AWS_ROLE_ARN", "");
+    if( roleArn.empty() )
+    {
+        CPLDebug("AWS", "AWS_ROLE_ARN configuration option not defined");
+        return false;
+    }
+
+    const CPLString webIdentityTokenFile =  VSIGetCredential(osPathForOption.c_str(),
+                                                             "AWS_WEB_IDENTITY_TOKEN_FILE", "");
+    if( webIdentityTokenFile.empty() )
+    {
+        CPLDebug("AWS", "AWS_WEB_IDENTITY_TOKEN_FILE configuration option not defined");
+        return false;
+    }
+
+    const CPLString stsRegionalEndpoints = VSIGetCredential(osPathForOption.c_str(),
+                                                            "AWS_STS_REGIONAL_ENDPOINTS", "regional");
+
+    std::string osStsDefaultUrl;
+    if (stsRegionalEndpoints == "regional") {
+        const CPLString osRegion = VSIGetCredential(osPathForOption.c_str(), "AWS_REGION", "us-east-1");
+        osStsDefaultUrl = "https://sts." + osRegion + ".amazonaws.com";
+    } else {
+        osStsDefaultUrl = "https://sts.amazonaws.com";
+    }
+    const CPLString osStsRootUrl(
+        VSIGetCredential(osPathForOption.c_str(), "CPL_AWS_STS_ROOT_URL", osStsDefaultUrl.c_str()));
+
+    // Get token from web identity token file
+    CPLString webIdentityToken;
+    if(!ReadAWSWebIdentityTokenFile(webIdentityTokenFile, webIdentityToken) )
+    {
+        CPLDebug("AWS", "%s is empty", webIdentityTokenFile.c_str());
+        return false;
+    }
+
+    // Get credentials from sts AssumeRoleWithWebIdentity
+    std::string osExpiration;
+    {
+        const CPLString osSTS_asuume_role_with_web_identity_URL =
+            osStsRootUrl + "/?Action=AssumeRoleWithWebIdentity&RoleSessionName=gdal"
+            "&Version=2011-06-15&RoleArn=" + roleArn + "&WebIdentityToken=" + webIdentityToken;
+
+        CPLPushErrorHandler(CPLQuietErrorHandler);
+
+        CPLHTTPResult* psResult = CPLHTTPFetch( osSTS_asuume_role_with_web_identity_URL.c_str(), nullptr );
+        if( psResult )
+        {
+            if( psResult->nStatus == 0 && psResult->pabyData != nullptr )
+            {
+                CPLXMLTreeCloser oTree(CPLParseXMLString(reinterpret_cast<char*>(psResult->pabyData)));
+                if( oTree )
+                {
+                    const auto psCredentials = CPLGetXMLNode(oTree.get(),
+                        "=AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult.Credentials");
+                    if( psCredentials )
+                    {
+                        osAccessKeyId = CPLGetXMLValue(psCredentials, "AccessKeyId", "");
+                        osSecretAccessKey = CPLGetXMLValue(psCredentials, "SecretAccessKey", "");
+                        osSessionToken = CPLGetXMLValue(psCredentials, "SessionToken", "");
+                        osExpiration = CPLGetXMLValue(psCredentials, "Expiration", "");
+                    }
+                }
+            }
+            CPLHTTPDestroyResult(psResult);
+        }
+    }
+
+    GIntBig nExpirationUnix = 0;
+    if( !osAccessKeyId.empty() &&
+        !osSecretAccessKey.empty() &&
+        !osSessionToken.empty() &&
+        Iso8601ToUnixTime(osExpiration.c_str(), &nExpirationUnix) )
+    {
+        gosGlobalAccessKeyId = osAccessKeyId;
+        gosGlobalSecretAccessKey = osSecretAccessKey;
+        gosGlobalSessionToken = osSessionToken;
+        gnGlobalExpiration = nExpirationUnix;
+        CPLDebug("AWS", "Storing AIM credentials until %s", osExpiration.c_str());
+    }
+    return !osAccessKeyId.empty() && !osSecretAccessKey.empty() && !osSessionToken.empty();
+}
+
 /************************************************************************/
 /*                      GetConfigurationFromEC2()                       */
 /************************************************************************/
@@ -1436,6 +1562,19 @@ bool VSIS3HandleHelper::GetConfiguration(const std::string& osPathForOption,
         return true;
     }
 
+    if( CPLTestBool(CPLGetConfigOption("CPL_AWS_WEB_IDENTITY_ENABLE", "YES")) )
+    {
+        // WebIdentity method: use Web Identity Token
+        if( GetConfigurationFromAssumeRoleWithWebIdentity(/* bForceRefresh = */ false,
+                                                          osPathForOption,
+                                                          osSecretAccessKey, osAccessKeyId,
+                                                          osSessionToken) )
+        {
+            eCredentialsSource = AWSCredentialsSource::WEB_IDENTITY;
+            return true;
+        }
+    }
+
     // Last method: use IAM role security credentials on EC2 instances
     if( GetConfigurationFromEC2(/* bForceRefresh = */ false,
                                 osPathForOption,
@@ -1639,6 +1778,21 @@ void VSIS3HandleHelper::RefreshCredentials(const std::string& osPathForOption,
                                                     osAccessKeyId,
                                                     osSessionToken,
                                                     osRegion) )
+        {
+            m_osSecretAccessKey = osSecretAccessKey;
+            m_osAccessKeyId = osAccessKeyId;
+            m_osSessionToken = osSessionToken;
+        }
+    }
+    else if( m_eCredentialsSource == AWSCredentialsSource::WEB_IDENTITY )
+    {
+        CPLString osSecretAccessKey, osAccessKeyId, osSessionToken;
+        CPLString osRegion;
+        if( GetConfigurationFromAssumeRoleWithWebIdentity(bForceRefresh,
+                                                          osPathForOption.c_str(),
+                                                          osSecretAccessKey,
+                                                          osAccessKeyId,
+                                                          osSessionToken) )
         {
             m_osSecretAccessKey = osSecretAccessKey;
             m_osAccessKeyId = osAccessKeyId;

--- a/port/cpl_aws.h
+++ b/port/cpl_aws.h
@@ -133,6 +133,8 @@ enum class AWSCredentialsSource
 {
     REGULAR,         // credentials from env variables or ~/.aws/crediential
     EC2,             // credentials from EC2 private networking
+    WEB_IDENTITY,    // credentials from Web Identity Token
+                     // See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
     ASSUMED_ROLE     // credentials from an STS assumed role
                      // See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-cli.html
                      // and https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html
@@ -156,6 +158,12 @@ class VSIS3HandleHelper final: public IVSIS3LikeHandleHelper
         AWSCredentialsSource m_eCredentialsSource = AWSCredentialsSource::REGULAR;
 
         void RebuildURL() override;
+
+        static bool GetConfigurationFromAssumeRoleWithWebIdentity(bool bForceRefresh,
+                                                                  const std::string& osPathForOption,
+                                                                  CPLString& osSecretAccessKey,
+                                                                  CPLString& osAccessKeyId,
+                                                                  CPLString& osSessionToken);
 
         static bool GetConfigurationFromEC2(bool bForceRefresh,
                                             const std::string& osPathForOption,


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

This PR provide credentials mechanism for web identity token on AWS EKS, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.

On AWS EKS it is possible to setup service account so they are "linked" to an IAM role. AWS EKS change the configuration of the pod using the service account so they mount a specific secret containing a JWT token linked to the arn of the IAM role

From that token it is possible to get temporary credentials calling the AssumeRoleWithWebIdentity action from sts AWS service

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
