### PR TITLE
BUG: Improve TransformBounds error handling

### DIFF
--- a/autotest/osr/osr_ct_proj.py
+++ b/autotest/osr/osr_ct_proj.py
@@ -35,7 +35,7 @@ import os
 
 import pytest
 
-from osgeo import osr
+from osgeo import gdal, osr
 
 bonne = 'PROJCS["bonne",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["bonne"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",0.0],PARAMETER["Standard_Parallel_1",60.0],UNIT["Meter",1.0]]'
 
@@ -503,3 +503,20 @@ def test_transform_bounds__south_pole__xy():
     ) == pytest.approx(
         (-1371213.76, -1405880.72, 5371213.76, 5405880.72)
     )
+
+
+def test_transform_bounds__internal_error_message():
+    # make sure error message cleared on success
+    src = osr.SpatialReference()
+    src.SetAxisMappingStrategy(osr.OAMS_AUTHORITY_COMPLIANT)
+    assert src.ImportFromEPSG(6931) == 0
+    dst = osr.SpatialReference()
+    dst.SetAxisMappingStrategy(osr.OAMS_AUTHORITY_COMPLIANT)
+    assert dst.ImportFromEPSG(4326) == 0
+    ctr = osr.CoordinateTransformation(src, dst)
+    assert ctr.TransformBounds(
+        458872.4197335826, -2998046.478919534, 584059.8115540259, -2883810.102037343, 21
+    ) == pytest.approx(
+        (62.36651782187522, 8.701995124479733, 63.605850064663514, 11.449280848814887)
+    )
+    assert gdal.GetLastErrorMsg() == ""

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -2891,7 +2891,7 @@ bool OGRProjCT::ContainsNorthPole(
     auto inverseCT = GetInverse();
     if (!inverseCT)
         return false;
-    inverseCT->TransformWithErrorCodes(
+    bool success = inverseCT->TransformWithErrorCodes(
         1,
         &pole_x,
         &pole_y,
@@ -2899,6 +2899,8 @@ bool OGRProjCT::ContainsNorthPole(
         nullptr,
         nullptr
     );
+    if (success && CPLGetLastErrorType() != CE_None)
+        CPLErrorReset();
     delete inverseCT;
     if (xmin < pole_x && pole_x < xmax && ymax > pole_y && pole_y > ymin)
         return true;
@@ -2926,7 +2928,7 @@ bool OGRProjCT::ContainsSouthPole(
     auto inverseCT = GetInverse();
     if (!inverseCT)
         return false;
-    inverseCT->TransformWithErrorCodes(
+    bool success = inverseCT->TransformWithErrorCodes(
         1,
         &pole_x,
         &pole_y,
@@ -2934,6 +2936,8 @@ bool OGRProjCT::ContainsSouthPole(
         nullptr,
         nullptr
     );
+    if (success && CPLGetLastErrorType() != CE_None)
+        CPLErrorReset();
     delete inverseCT;
     if (xmin < pole_x && pole_x < xmax && ymax > pole_y && pole_y > ymin)
         return true;
@@ -2952,6 +2956,7 @@ int OGRProjCT::TransformBounds(
     double* out_ymax,
     const int densify_pts
 ) {
+    CPLErrorReset();
 
     if ( bNoTransform ) {
         *out_xmin = xmin;
@@ -3035,6 +3040,7 @@ int OGRProjCT::TransformBounds(
     bool north_pole_in_bounds = false;
     bool south_pole_in_bounds = false;
     if (degree_output) {
+        CPLPushErrorHandler(CPLQuietErrorHandler);
         north_pole_in_bounds = ContainsNorthPole(
             xmin,
             ymin,
@@ -3042,6 +3048,9 @@ int OGRProjCT::TransformBounds(
             ymax,
             output_lon_lat_order
         );
+        if (CPLGetLastErrorType() != CE_None) {
+            return false;
+        }
         south_pole_in_bounds = ContainsSouthPole(
             xmin,
             ymin,
@@ -3049,6 +3058,10 @@ int OGRProjCT::TransformBounds(
             ymax,
             output_lon_lat_order
         );
+        if (CPLGetLastErrorType() != CE_None) {
+            return false;
+        }
+        CPLPopErrorHandler();
     }
 
     if (degree_input && xmax < xmin) {
@@ -3091,7 +3104,7 @@ int OGRProjCT::TransformBounds(
         x_boundary_array[iii + side_pts * 3] = xmax - iii * delta_x;
     }
 
-    TransformWithErrorCodes(
+    bool success = TransformWithErrorCodes(
         boundary_len,
         &x_boundary_array[0],
         &y_boundary_array[0],
@@ -3099,6 +3112,11 @@ int OGRProjCT::TransformBounds(
         nullptr,
         nullptr
     );
+    if (success && CPLGetLastErrorType() != CE_None) {
+        CPLErrorReset();
+    } else if (!success) {
+        return false;
+    }
 
     if (!degree_output) {
         *out_xmin = simple_min(&x_boundary_array[0], boundary_len);

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -3040,7 +3040,7 @@ int OGRProjCT::TransformBounds(
     bool north_pole_in_bounds = false;
     bool south_pole_in_bounds = false;
     if (degree_output) {
-        CPLPushErrorHandler(CPLQuietErrorHandler);
+        CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
         north_pole_in_bounds = ContainsNorthPole(
             xmin,
             ymin,
@@ -3061,7 +3061,6 @@ int OGRProjCT::TransformBounds(
         if (CPLGetLastErrorType() != CE_None) {
             return false;
         }
-        CPLPopErrorHandler();
     }
 
     if (degree_input && xmax < xmin) {


### PR DESCRIPTION
## What does this PR do?

Current behavior:
```
>>> from osgeo import osr, gdal
>>> src = osr.SpatialReference()
>>> src.SetAxisMappingStrategy(osr.OAMS_AUTHORITY_COMPLIANT)
>>> assert src.ImportFromEPSG(6931) == 0
>>> dst = osr.SpatialReference()
>>> dst.SetAxisMappingStrategy(osr.OAMS_AUTHORITY_COMPLIANT)
>>> assert dst.ImportFromEPSG(4326) == 0
>>> ctr = osr.CoordinateTransformation(src, dst)
>>> ctr.TransformBounds(
...         458872.4197335826, -2998046.478919534, 584059.8115540259, -2883810.102037343, 21
...     )
ERROR 1: Point outside of projection domain
(62.36651782187522, 8.701995124479733, 63.605850064663514, 11.449280848814887)
>>> gdal.GetLastErrorMsg()
'Point outside of projection domain'
```

## What are related issues/pull requests?
- https://github.com/rasterio/rasterio/pull/2526#issuecomment-1186044742

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

