### PR TITLE
[Backport release/3.5] OGRSpatialReference: evaluate OSR_DEFAULT_AXIS_MAPPING_STRATEGY config option at each object construction (fixes #6084)

### DIFF
--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -191,9 +191,7 @@ OGRSpatialReference::Private::Private():
 {
     // Get the default value for m_axisMappingStrategy from the
     // OSR_DEFAULT_AXIS_MAPPING_STRATEGY configuration option, if set.
-    static const OSRAxisMappingStrategy defaultAxisMappingStrategy = GetDefaultAxisMappingStrategy();
-
-    m_axisMappingStrategy = defaultAxisMappingStrategy;
+    m_axisMappingStrategy = GetDefaultAxisMappingStrategy();
 }
 
 OGRSpatialReference::Private::~Private()


### PR DESCRIPTION
Backport #6088
 **Authored by:** @rouault