### PR TITLE
[Backport release/3.5] ENVI: fix duplicated 'coordinate system string' when editing an existing file (fixes #6130)

### DIFF
--- a/frmts/raw/envidataset.cpp
+++ b/frmts/raw/envidataset.cpp
@@ -507,7 +507,8 @@ void ENVIDataset::FlushCache(bool bAtClosing)
              poKey == "band names" ||
              poKey == "map info" ||
              poKey == "projection info" ||
-             poKey == "data ignore value" )
+             poKey == "data ignore value" ||
+             poKey == "coordinate system string" )
         {
             CSLDestroy(papszTokens);
             continue;


### PR DESCRIPTION
Backport #6135
 **Authored by:** @rouault