### PR TITLE
Parquet driver: fix compression methods

### DIFF
--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -38,9 +38,9 @@ The driver supports creating only a single layer in a dataset.
 Layer creation options
 ----------------------
 
-- **COMPRESSION=string**: Compression method. Can be one of ``NONE``, ``SNAPPY``,
-  ``GZIP``, ``BROTLI``, ``ZSTD``, ``LZ4``, ``BZ2``, ``LZ4_HADOOP``. Available
-  values depend on how the Parquet library was compiled.
+- **COMPRESSION=string**: Compression method. Can be one of ``NONE`` (or
+  ``UNCOMPRESSED``), ``SNAPPY``, ``GZIP``, ``BROTLI``, ``ZSTD``, ``LZ4_RAW``,
+  ``LZ4_HADOOP``. Available values depend on how the Parquet library was compiled.
   Defaults to SNAPPY when available, otherwise NONE.
 
 - **GEOMETRY_ENCODING=WKB/WKT/GEOARROW**: Geometry encoding. Defaults to WKB.

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -652,10 +652,8 @@ void OGRParquetDriver::InitMetadata()
                                   "GZIP",
                                   "BROTLI",
                                   "ZSTD",
-                                  "LZ4",
-                                  "LZ4_FRAME",
+                                  "LZ4_RAW",
                                   "LZO",
-                                  "BZ2",
                                   "LZ4_HADOOP" } )
     {
         auto oResult = arrow::util::Codec::GetCompressionType(


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

In [docs](https://gdal.org/drivers/vector/parquet.html#layer-creation-options): adds UNCOMPRESSED, removes BZ2 and substitutes LZ4 with LZ4_RAW.

In OGRParquetDriver: removes BZ2 and LZ4_FRAME and substitutes LZ4 with LZ4_RAW. Would be OK to also remove the LZO method (it is not supported by the C++ implementation)?

See:
https://github.com/apache/parquet-format/blob/master/Compression.md
https://github.com/apache/arrow/blob/02c8598d264c839a5b5cf3109bfd406f3b8a6ba5/cpp/src/arrow/util/compression.cc#L48-L78
https://github.com/apache/arrow/blob/02c8598d264c839a5b5cf3109bfd406f3b8a6ba5/cpp/src/parquet/types.cc#L38-L51
https://github.com/apache/arrow/blob/02c8598d264c839a5b5cf3109bfd406f3b8a6ba5/cpp/src/parquet/types.cc#L57-L70
https://github.com/OSGeo/gdal/issues/6115#issuecomment-1200104043