### PR TITLE
[Backport release/3.5] gdalbuildvrt: skip source datasets that just touch by an edge the area of interest, and would result in a source with 0 width/height

### DIFF
--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -208,8 +208,8 @@ static int  GetSrcDstWin(DatasetProperty* psDP,
         *pdfSrcYSize = *pdfDstYSize / dfSrcToDstYSize;
     }
 
-    return *pdfSrcXSize >= 0 && *pdfDstXSize >= 0 &&
-           *pdfSrcYSize >= 0 && *pdfDstYSize >= 0;
+    return *pdfSrcXSize > 0 && *pdfDstXSize > 0 &&
+           *pdfSrcYSize > 0 && *pdfDstYSize > 0;
 }
 
 /************************************************************************/

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -148,15 +148,15 @@ static int  GetSrcDstWin(DatasetProperty* psDP,
     /* Check that the destination bounding box intersects the source bounding box */
     if ( psDP->adfGeoTransform[GEOTRSFRM_TOPLEFT_X] +
          psDP->nRasterXSize *
-         psDP->adfGeoTransform[GEOTRSFRM_WE_RES] < minX )
+         psDP->adfGeoTransform[GEOTRSFRM_WE_RES] <= minX )
          return FALSE;
-    if ( psDP->adfGeoTransform[GEOTRSFRM_TOPLEFT_X] > maxX )
+    if ( psDP->adfGeoTransform[GEOTRSFRM_TOPLEFT_X] >= maxX )
          return FALSE;
     if ( psDP->adfGeoTransform[GEOTRSFRM_TOPLEFT_Y] +
          psDP->nRasterYSize *
-         psDP->adfGeoTransform[GEOTRSFRM_NS_RES] > maxY )
+         psDP->adfGeoTransform[GEOTRSFRM_NS_RES] >= maxY )
          return FALSE;
-    if ( psDP->adfGeoTransform[GEOTRSFRM_TOPLEFT_Y] < minY )
+    if ( psDP->adfGeoTransform[GEOTRSFRM_TOPLEFT_Y] <= minY )
          return FALSE;
 
     if ( psDP->adfGeoTransform[GEOTRSFRM_TOPLEFT_X] < minX )
@@ -208,7 +208,8 @@ static int  GetSrcDstWin(DatasetProperty* psDP,
         *pdfSrcYSize = *pdfDstYSize / dfSrcToDstYSize;
     }
 
-    return TRUE;
+    return *pdfSrcXSize >= 0 && *pdfDstXSize >= 0 &&
+           *pdfSrcYSize >= 0 && *pdfDstYSize >= 0;
 }
 
 /************************************************************************/
@@ -928,6 +929,8 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
         if (psDatasetProperties->isFileOK == FALSE)
             continue;
 
+        const char* dsFileName = ppszInputFilenames[i];
+
         double dfSrcXOff, dfSrcYOff, dfSrcXSize, dfSrcYSize,
                dfDstXOff, dfDstYOff, dfDstXSize, dfDstYSize;
         if (bHasGeoTransform)
@@ -937,7 +940,12 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
                         nRasterXSize, nRasterYSize,
                         &dfSrcXOff, &dfSrcYOff, &dfSrcXSize, &dfSrcYSize,
                         &dfDstXOff, &dfDstYOff, &dfDstXSize, &dfDstYSize) )
+            {
+                CPLDebug("BuildVRT",
+                         "Skipping %s as not intersecting area of interest",
+                         dsFileName);
                 continue;
+            }
         }
         else
         {
@@ -945,8 +953,6 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
             dfSrcXSize = dfDstXSize = nRasterXSize;
             dfSrcYSize = dfDstYSize = nRasterYSize;
         }
-
-        const char* dsFileName = ppszInputFilenames[i];
 
         GDALAddBand(hVRTDS, psDatasetProperties->firstBandType, nullptr);
 
@@ -1106,6 +1112,8 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDatasetH hVRTDS)
         if (psDatasetProperties->isFileOK == FALSE)
             continue;
 
+        const char* dsFileName = ppszInputFilenames[i];
+
         double dfSrcXOff;
         double dfSrcYOff;
         double dfSrcXSize;
@@ -1119,7 +1127,12 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDatasetH hVRTDS)
                         nRasterXSize, nRasterYSize,
                         &dfSrcXOff, &dfSrcYOff, &dfSrcXSize, &dfSrcYSize,
                         &dfDstXOff, &dfDstYOff, &dfDstXSize, &dfDstYSize) )
+        {
+            CPLDebug("BuildVRT",
+                     "Skipping %s as not intersecting area of interest",
+                     dsFileName);
             continue;
+        }
 
         anIdxValidDatasets.push_back(i);
 
@@ -1137,8 +1150,6 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDatasetH hVRTDS)
             for( int nOvFactor: psDatasetProperties->anOverviewFactors )
                 anOverviewFactorsSet.insert(nOvFactor);
         }
-
-        const char* dsFileName = ppszInputFilenames[i];
 
         GDALDatasetH hSourceDS;
         bool bDropRef = false;

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -521,3 +521,18 @@ def test_gdalbuildvrt_lib_strict_mode():
     with gdaltest.enable_exceptions():
         with pytest.raises(Exception):
             gdal.BuildVRT('', ['../gcore/data/byte.tif', 'i_dont_exist.tif'], strict = True)
+
+
+###############################################################################
+def test_gdalbuildvrt_lib_te_touching_on_edge():
+
+    tmp_filename = '/vsimem/test_gdalbuildvrt_lib_te_touching_on_edge.vrt'
+    ds = gdal.BuildVRT(tmp_filename, '../gcore/data/byte.tif', outputBounds=[440600, 3750000, 440720, 3750120], xRes=60, yRes=60)
+    assert ds is not None
+    ds = None
+
+    ds = gdal.Open(tmp_filename)
+    assert ds.GetRasterBand(1).Checksum() == 0
+    ds = None
+
+    gdal.Unlink(tmp_filename)


### PR DESCRIPTION
Backport #6171
 **Authored by:** @rouault