### PR TITLE
GeoJSONSeq driver: make max allowed size of feature configurable with…

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -3235,3 +3235,21 @@ def test_ogr_geojson_write_rfc7946_from_3D_crs():
 
     # Check that we get back the ellipsoidal height
     assert '"coordinates": [ 2.0, 49.0, 100.0' in data
+
+
+###############################################################################
+# Test effect of OGR_GEOJSON_MAX_OBJ_SIZE
+
+def test_ogr_geojson_feature_large():
+
+    filename = '/vsimem/test_ogr_geojson_feature_large.json'
+    gdal.FileFromMemBuffer(filename,
+                           '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[%s]}}]}' % ','.join(["[0,0]" for _ in range(10 * 1024)]))
+    assert ogr.Open(filename) is not None
+    with gdaltest.config_option('OGR_GEOJSON_MAX_OBJ_SIZE', '0'):
+        assert ogr.Open(filename) is not None
+    with gdaltest.config_option('OGR_GEOJSON_MAX_OBJ_SIZE', '0.1'):
+        with gdaltest.error_handler():
+            assert ogr.Open(filename) is None
+    gdal.Unlink(filename)
+

--- a/autotest/ogr/ogr_geojsonseq.py
+++ b/autotest/ogr/ogr_geojsonseq.py
@@ -208,3 +208,19 @@ def test_ogr_geojsonseq_test_ogrsf():
 
 
 
+###############################################################################
+# Test effect of OGR_GEOJSON_MAX_OBJ_SIZE
+
+def test_ogr_geojsonseq_feature_large():
+
+    filename = '/vsimem/test_ogr_geojson_feature_large.geojsonl'
+    feature = '{"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[%s]}}' % ','.join(["[0,0]" for _ in range(20 * 1024)])
+    gdal.FileFromMemBuffer(filename, feature + '\n' + feature)
+    assert ogr.Open(filename) is not None
+    with gdaltest.config_option('OGR_GEOJSON_MAX_OBJ_SIZE', '0'):
+        assert ogr.Open(filename) is not None
+    with gdaltest.config_option('OGR_GEOJSON_MAX_OBJ_SIZE', '0.1'):
+        with gdaltest.error_handler():
+            assert ogr.Open(filename) is None
+    gdal.Unlink(filename)
+

--- a/doc/source/drivers/vector/geojson.rst
+++ b/doc/source/drivers/vector/geojson.rst
@@ -111,9 +111,9 @@ Schema detection will recognized fields of type String, Integer, Real,
 StringList, IntegerList and RealList, Integer(Boolean), Date, Time and DateTime.
 
 It is possible to tell the driver to not to process attributes by
-setting configuration option :decl_configoption:`ATTRIBUTES_SKIP` =YES. 
-Default behavior is to preserve all attributes (as an union, see 
-previous paragraph), what is equal to setting 
+setting configuration option :decl_configoption:`ATTRIBUTES_SKIP` =YES.
+Default behavior is to preserve all attributes (as an union, see
+previous paragraph), what is equal to setting
 :decl_configoption:`ATTRIBUTES_SKIP` =NO.
 
 If the NATIVE_DATA open option is set to YES, the Feature JSon object
@@ -147,7 +147,7 @@ the :decl_configoption:`GEOMETRY_AS_COLLECTION` configuration option to YES
 Configuration options
 ---------------------
 
-The following :ref:`configuration options <configoptions>` are 
+The following :ref:`configuration options <configoptions>` are
 available:
 
 -  :decl_configoption:`GEOMETRY_AS_COLLECTION`: used to control translation of
@@ -155,7 +155,8 @@ available:
 -  :decl_configoption:`ATTRIBUTES_SKIP` - controls translation of attributes:
    YES - skip all attributes
 -  :decl_configoption:`OGR_GEOJSON_MAX_OBJ_SIZE` (GDAL >= 3.0.2): size in
-   MBytes of the maximum accepted single feature, default value is 200MB
+   MBytes of the maximum accepted single feature, default value is 200MB.
+   Or 0 to allow for a unlimited size (GDAL >= 3.5.2).
 
 Open options
 ------------

--- a/doc/source/drivers/vector/geojsonseq.rst
+++ b/doc/source/drivers/vector/geojsonseq.rst
@@ -43,6 +43,16 @@ The driver accepts three types of sources of data:
 The URL/filename/text might be prefixed with GeoJSONSeq: to avoid any
 ambiguity with other drivers.
 
+Configuration options
+---------------------
+
+The following :ref:`configuration option <configoptions>` is
+available:
+
+-  :decl_configoption:`OGR_GEOJSON_MAX_OBJ_SIZE` (GDAL >= 3.5.2): size in
+   MBytes of the maximum accepted single feature, default value is 200MB.
+   Or 0 to allow for a unlimited size.
+
 Layer creation options
 ----------------------
 

--- a/port/cpl_json_streaming_parser.cpp
+++ b/port/cpl_json_streaming_parser.cpp
@@ -136,11 +136,10 @@ void CPLJSonStreamingParser::SkipSpace(const char*& pStr, size_t& nLength)
 bool CPLJSonStreamingParser::EmitException(const char* pszMessage)
 {
     m_bExceptionOccurred = true;
-    char szMessage[108];
-    snprintf(szMessage, sizeof(szMessage),
-             "At line %d, character %d: %s",
-             m_nLineCounter, m_nCharCounter, pszMessage);
-    Exception(szMessage);
+    CPLString osMsg;
+    osMsg.Printf("At line %d, character %d: %s",
+                 m_nLineCounter, m_nCharCounter, pszMessage);
+    Exception(osMsg.c_str());
     return false;
 }
 

--- a/port/cpl_json_streaming_parser.h
+++ b/port/cpl_json_streaming_parser.h
@@ -85,12 +85,14 @@ class CPL_DLL CPLJSonStreamingParser
         enum State currentState() { return m_aState.back(); }
         void SkipSpace(const char*& pStr, size_t& nLength);
         void AdvanceChar(const char*& pStr, size_t& nLength);
-        bool EmitException(const char* pszMessage);
         bool EmitUnexpectedChar(char ch, const char* pszExpecting = nullptr);
         bool StartNewToken(const char*& pStr, size_t& nLength);
         bool CheckAndEmitTrueFalseOrNull(char ch);
         bool CheckStackEmpty();
         void DecodeUnicode();
+
+    protected:
+        bool EmitException(const char* pszMessage);
 
     public:
         CPLJSonStreamingParser();


### PR DESCRIPTION
… the OGR_GEOJSON_MAX_OBJ_SIZE configuration option

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2022-August/056131.html