### PR TITLE
[Backport release/3.5] fmts/sigdem: Add missing header

### DIFF
--- a/frmts/sigdem/sigdemdataset.cpp
+++ b/frmts/sigdem/sigdemdataset.cpp
@@ -29,6 +29,8 @@
 #include "sigdemdataset.h"
 #include "rawdataset.h"
 
+#include <algorithm>
+
 CPL_CVSID("$Id$")
 
 #ifdef CPL_IS_LSB


### PR DESCRIPTION
Backport #6180
 **Authored by:** @SeTSeR