### PR TITLE
CMake: fix CMAKE_CROSSCOMPILING typo in fuzzer CMakeLists.txt

### DIFF
--- a/fuzzers/CMakeLists.txt
+++ b/fuzzers/CMakeLists.txt
@@ -3,7 +3,7 @@
 if (NOT TARGET ogr_SQLite)
   return()
 endif ()
-if (CMAKE_CROSSCOMPILONG OR WIN32)
+if (CMAKE_CROSSCOMPILING OR WIN32)
   return()
 endif ()
 if (NOT CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)


### PR DESCRIPTION
## What does this PR do?

Fixes a minor typo in fuzzer/CMakeLists.txt

## What are related issues/pull requests?

None

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
