### PR TITLE
[Backport release/3.5] CMake: fix CMAKE_CROSSCOMPILING typo in fuzzer CMakeLists.txt

### DIFF
--- a/fuzzers/CMakeLists.txt
+++ b/fuzzers/CMakeLists.txt
@@ -3,7 +3,7 @@
 if (NOT TARGET ogr_SQLite)
   return()
 endif ()
-if (CMAKE_CROSSCOMPILONG OR WIN32)
+if (CMAKE_CROSSCOMPILING OR WIN32)
   return()
 endif ()
 if (NOT CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)


### PR DESCRIPTION
Backport #6201
 **Authored by:** @ryanking13