### PR TITLE
Codec background in GTiff driver page

### DIFF
--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -817,6 +817,53 @@ the default behavior of the GTiff driver.
    always written. If set to NO, then the transformation will not be written in
    any situation.
 
+
+Codec Recommendations
+---------------------
+
+
+LZW
+~~~
+
+If you don't know what to chose, chose this one.
+
+DEFLATE
+~~~~~~~
+
+The most commonly supported TIFF codec, especially with older non-geo software.
+
+LERC
+~~~~
+
+Used for storing quantized floating point data. https://github.com/esri/lerc
+
+
+ZSTD
+~~~~
+
+Smaller and faster than DEFLATE, but not as commonly supported.
+
+WEBP
+~~~~
+
+A smaller and faster JPEG.
+
+JXL
+~~~
+
+Next-gen JPG from the JPG group.
+
+
+LZMA
+~~~~
+
+Slow but storage efficient.
+
+CCITTRLE/CCITTFAX3/CCITTFAX4
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Did you happen to have fax files from the 1990s? Use these.
+
 See Also
 --------
 

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -825,7 +825,7 @@ Codec Recommendations
 LZW
 ~~~
 
-If you don't know what to chose, chose this one.
+If you don't know what to choose, choose this one.
 
 DEFLATE
 ~~~~~~~


### PR DESCRIPTION
The GTiff driver page doesn't do a great job of telling folks *why* they might choose one TIFF codec over another. Now that there are so many to choose from, we should editorialize a little bit to point people in the right direction. 