### PR TITLE
JP2KAK: add support for ARM builds

### DIFF
--- a/cmake/modules/packages/FindKDU.cmake
+++ b/cmake/modules/packages/FindKDU.cmake
@@ -39,6 +39,24 @@ if(KDU_ROOT AND EXISTS "${KDU_ROOT}/coresys")
         find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
                      PATH ${KDU_ROOT}/lib/Linux-x86-64-gcc)
 
+    elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+        file(READ "${KDU_ROOT}/coresys/make/Makefile-Linux-arm-64-gcc" CORESYS_MAKEFILE_CONTENTS)
+        string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
+        file(READ "${KDU_ROOT}/managed/make/Makefile-Linux-arm-64-gcc" MANAGED_MAKEFILE_CONTENTS)
+        string(REGEX REPLACE ".*AUX_SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_AUX_SHARED_LIB_NAME ${MANAGED_MAKEFILE_CONTENTS})
+
+        string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.so" "\\1" KDU_MAJOR_VERSION "${KDU_SHARED_LIB_NAME}")
+        string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.so" "\\2" KDU_MINOR_VERSION "${KDU_SHARED_LIB_NAME}")
+        if( KDU_MINOR_VERSION STREQUAL "A" )
+            set(KDU_MINOR_VERSION 10)
+        endif()
+        set(KDU_VERSION_VAR "${KDU_MAJOR_VERSION}.${KDU_MINOR_VERSION}")
+
+        find_library(KDU_LIBRARY ${KDU_SHARED_LIB_NAME}
+                     PATH ${KDU_ROOT}/lib/Linux-arm-64-gcc)
+        find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
+                     PATH ${KDU_ROOT}/lib/Linux-arm-64-gcc)
+
     elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
         file(READ "${KDU_ROOT}/coresys/make/Makefile-Mac-x86-64-gcc" CORESYS_MAKEFILE_CONTENTS)
         string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
@@ -49,6 +67,17 @@ if(KDU_ROOT AND EXISTS "${KDU_ROOT}/coresys")
                      PATH ${KDU_ROOT}/lib/Mac-x86-64-gcc)
         find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
                      PATH ${KDU_ROOT}/lib/Mac-x86-64-gcc)
+
+    elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+        file(READ "${KDU_ROOT}/coresys/make/Makefile-Mac-arm-64-gcc" CORESYS_MAKEFILE_CONTENTS)
+        string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
+        file(READ "${KDU_ROOT}/managed/make/Makefile-Mac-arm-64-gcc" MANAGED_MAKEFILE_CONTENTS)
+        string(REGEX REPLACE ".*AUX_SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_AUX_SHARED_LIB_NAME ${MANAGED_MAKEFILE_CONTENTS})
+
+        find_library(KDU_LIBRARY ${KDU_SHARED_LIB_NAME}
+                     PATH ${KDU_ROOT}/lib/Mac-arm-64-gcc)
+        find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
+                     PATH ${KDU_ROOT}/lib/Mac-arm-64-gcc)
 
      elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AMD64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
         file(READ "${KDU_ROOT}/coresys/coresys_2019.vcxproj" CORESYS_MAKEFILE_CONTENTS)

--- a/cmake/modules/packages/FindKDU.cmake
+++ b/cmake/modules/packages/FindKDU.cmake
@@ -19,67 +19,45 @@ if(CMAKE_VERSION VERSION_LESS 3.13)
     set(KDU_ROOT CACHE PATH "KAKADU library base directory")
 endif()
 
+macro(find_kdu_libs_from_makefiles)
+    # first argument = platform
+    # second argument = library extension (without .)
+    file(READ "${KDU_ROOT}/coresys/make/Makefile-${ARGV0}" CORESYS_MAKEFILE_CONTENTS)
+    string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.${ARGV1}).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
+    file(READ "${KDU_ROOT}/managed/make/Makefile-${ARGV0}" MANAGED_MAKEFILE_CONTENTS)
+    string(REGEX REPLACE ".*AUX_SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.${ARGV1}).*" "\\1\\2" KDU_AUX_SHARED_LIB_NAME ${MANAGED_MAKEFILE_CONTENTS})
+
+    string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.${ARGV1}" "\\1" KDU_MAJOR_VERSION "${KDU_SHARED_LIB_NAME}")
+    string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.${ARGV1}" "\\2" KDU_MINOR_VERSION "${KDU_SHARED_LIB_NAME}")
+    if( KDU_MINOR_VERSION STREQUAL "A" )
+        set(KDU_MINOR_VERSION 10)
+    endif()
+    set(KDU_VERSION_VAR "${KDU_MAJOR_VERSION}.${KDU_MINOR_VERSION}")
+
+    find_library(KDU_LIBRARY ${KDU_SHARED_LIB_NAME}
+                 PATH ${KDU_ROOT}/lib/${ARGV0})
+    find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
+                 PATH ${KDU_ROOT}/lib/${ARGV0})
+endmacro()
+
 set(KDU_VERSION_VAR "")
 if(KDU_ROOT AND EXISTS "${KDU_ROOT}/coresys")
     if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-        file(READ "${KDU_ROOT}/coresys/make/Makefile-Linux-x86-64-gcc" CORESYS_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
-        file(READ "${KDU_ROOT}/managed/make/Makefile-Linux-x86-64-gcc" MANAGED_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*AUX_SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_AUX_SHARED_LIB_NAME ${MANAGED_MAKEFILE_CONTENTS})
-
-        string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.so" "\\1" KDU_MAJOR_VERSION "${KDU_SHARED_LIB_NAME}")
-        string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.so" "\\2" KDU_MINOR_VERSION "${KDU_SHARED_LIB_NAME}")
-        if( KDU_MINOR_VERSION STREQUAL "A" )
-            set(KDU_MINOR_VERSION 10)
-        endif()
-        set(KDU_VERSION_VAR "${KDU_MAJOR_VERSION}.${KDU_MINOR_VERSION}")
-
-        find_library(KDU_LIBRARY ${KDU_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Linux-x86-64-gcc)
-        find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Linux-x86-64-gcc)
-
+        find_kdu_libs_from_makefiles("Linux-x86-64-gcc" "so")
+    
     elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-        file(READ "${KDU_ROOT}/coresys/make/Makefile-Linux-arm-64-gcc" CORESYS_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
-        file(READ "${KDU_ROOT}/managed/make/Makefile-Linux-arm-64-gcc" MANAGED_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*AUX_SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_AUX_SHARED_LIB_NAME ${MANAGED_MAKEFILE_CONTENTS})
-
-        string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.so" "\\1" KDU_MAJOR_VERSION "${KDU_SHARED_LIB_NAME}")
-        string(REGEX REPLACE "libkdu_v([0-9])([0-9A-F])R\.so" "\\2" KDU_MINOR_VERSION "${KDU_SHARED_LIB_NAME}")
-        if( KDU_MINOR_VERSION STREQUAL "A" )
-            set(KDU_MINOR_VERSION 10)
-        endif()
-        set(KDU_VERSION_VAR "${KDU_MAJOR_VERSION}.${KDU_MINOR_VERSION}")
-
-        find_library(KDU_LIBRARY ${KDU_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Linux-arm-64-gcc)
-        find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Linux-arm-64-gcc)
+        find_kdu_libs_from_makefiles("Linux-arm-64-gcc" "so")
 
     elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-        file(READ "${KDU_ROOT}/coresys/make/Makefile-Mac-x86-64-gcc" CORESYS_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
-        file(READ "${KDU_ROOT}/managed/make/Makefile-Mac-x86-64-gcc" MANAGED_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*AUX_SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_AUX_SHARED_LIB_NAME ${MANAGED_MAKEFILE_CONTENTS})
-
-        find_library(KDU_LIBRARY ${KDU_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Mac-x86-64-gcc)
-        find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Mac-x86-64-gcc)
+        find_kdu_libs_from_makefiles("Mac-x86-64-gcc" "so")
 
     elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-        file(READ "${KDU_ROOT}/coresys/make/Makefile-Mac-arm-64-gcc" CORESYS_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
-        file(READ "${KDU_ROOT}/managed/make/Makefile-Mac-arm-64-gcc" MANAGED_MAKEFILE_CONTENTS)
-        string(REGEX REPLACE ".*AUX_SHARED_LIB_NAME[ \t]*=[ \t]*([^.]*)(\.so).*" "\\1\\2" KDU_AUX_SHARED_LIB_NAME ${MANAGED_MAKEFILE_CONTENTS})
+        find_kdu_libs_from_makefiles("Mac-arm-64-gcc" "so")
 
-        find_library(KDU_LIBRARY ${KDU_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Mac-arm-64-gcc)
-        find_library(KDU_AUX_LIBRARY ${KDU_AUX_SHARED_LIB_NAME}
-                     PATH ${KDU_ROOT}/lib/Mac-arm-64-gcc)
-
-     elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AMD64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND MINGW)
+        find_kdu_libs_from_makefiles("Mingw-x86-64-gcc" "dll")
+        
+    elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AMD64" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND MSVC)
         file(READ "${KDU_ROOT}/coresys/coresys_2019.vcxproj" CORESYS_MAKEFILE_CONTENTS)
         string(REGEX REPLACE [[.*<ImportLibrary>([^l]*)(lib_x64\\)([^R]*R)(\.lib).*]] "\\1\\2\\3\\4" KDU_SHARED_LIB_NAME ${CORESYS_MAKEFILE_CONTENTS})
         file(READ "${KDU_ROOT}/managed/kdu_aux/kdu_aux_2019.vcxproj" MANAGED_MAKEFILE_CONTENTS)

--- a/frmts/jp2kak/CMakeLists.txt
+++ b/frmts/jp2kak/CMakeLists.txt
@@ -8,6 +8,7 @@ gdal_target_link_libraries(gdal_JP2KAK PRIVATE KDU::KDU)
 # according to Compiling_Instructions.txt: "Note that this macro does not normally need to
 #             be set explicitly, since it is automatically configured
 #             by "kdu_arch.h" if the usual "__ARM_NEON__" is found"
+# __ARM_NEON__ appears to be defined when NEON extensions available (https://developer.arm.com/documentation/dui0491/i/Compiler-specific-Features/Predefined-macros)
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64")
     target_compile_definitions(gdal_JP2KAK PRIVATE -DKDU_X86_INTRINSICS)
 endif()

--- a/frmts/jp2kak/CMakeLists.txt
+++ b/frmts/jp2kak/CMakeLists.txt
@@ -9,6 +9,6 @@ gdal_target_link_libraries(gdal_JP2KAK PRIVATE KDU::KDU)
 #             be set explicitly, since it is automatically configured
 #             by "kdu_arch.h" if the usual "__ARM_NEON__" is found"
 # __ARM_NEON__ appears to be defined when NEON extensions available (https://developer.arm.com/documentation/dui0491/i/Compiler-specific-Features/Predefined-macros)
-if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64")
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AMD64")
     target_compile_definitions(gdal_JP2KAK PRIVATE -DKDU_X86_INTRINSICS)
 endif()

--- a/frmts/jp2kak/CMakeLists.txt
+++ b/frmts/jp2kak/CMakeLists.txt
@@ -2,4 +2,12 @@ add_gdal_driver(TARGET gdal_JP2KAK SOURCES jp2kakdataset.cpp jp2kak_headers.h jp
                                            vsil_target.h PLUGIN_CAPABLE)
 gdal_standard_includes(gdal_JP2KAK)
 gdal_target_link_libraries(gdal_JP2KAK PRIVATE KDU::KDU)
-target_compile_definitions(gdal_JP2KAK PRIVATE -DKDU_X86_INTRINSICS)
+
+# this appears necessary on x64 machines to match the compilation of the library
+# But for ARM we don't need to define KDU_NEON_INTRINSICS, because 
+# according to Compiling_Instructions.txt: "Note that this macro does not normally need to
+#             be set explicitly, since it is automatically configured
+#             by "kdu_arch.h" if the usual "__ARM_NEON__" is found"
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64")
+    target_compile_definitions(gdal_JP2KAK PRIVATE -DKDU_X86_INTRINSICS)
+endif()


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes building against the Kakadu driver for ARM CPUs on Linux and OSX. Tested on Linux aarch64 and x64. 

Unfortunately I don't have access to an Apple M1 to check the OSX changes with.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed


