### PR TITLE
RPC DEM extraction: use a block base approach to query the DEM

### DIFF
--- a/alg/gdal_rpc.cpp
+++ b/alg/gdal_rpc.cpp
@@ -40,6 +40,7 @@
 
 #include "cpl_conv.h"
 #include "cpl_error.h"
+#include "cpl_mem_cache.h"
 #include "cpl_minixml.h"
 #include "cpl_string.h"
 #include "cpl_vsi.h"
@@ -261,16 +262,8 @@ typedef struct {
     int         bApplyDEMVDatumShift;
 
     GDALDataset *poDS;
-    double     *padfDEMBuffer;
-    int         nDEMExtractions;
-    int         nBufferMaxRadius;
-    int         nHitsInBuffer;
-    int         nBufferX;
-    int         nBufferY;
-    int         nBufferWidth;
-    int         nBufferHeight;
-    int         nLastQueriedX;
-    int         nLastQueriedY;
+    // the key is (nYBlock << 32) | nXBlock)
+    lru11::Cache<uint64_t, std::shared_ptr<std::vector<double>>>* poCacheDEM;
 
     OGRCoordinateTransformation *poCT;
 
@@ -1116,7 +1109,7 @@ void GDALDestroyRPCTransformer( void *pTransformAlg )
 
     if( psTransform->poDS )
         GDALClose(psTransform->poDS);
-    CPLFree(psTransform->padfDEMBuffer);
+    delete psTransform->poCacheDEM;
     if( psTransform->poCT )
         OCTDestroyCoordinateTransformation(
             reinterpret_cast<OGRCoordinateTransformationH>(psTransform->poCT));
@@ -1412,112 +1405,75 @@ static bool GDALRPCExtractDEMWindow( GDALRPCTransformInfo *psTransform,
                                      int nX, int nY, int nWidth, int nHeight,
                                      double* padfOut )
 {
-    psTransform->nDEMExtractions++;
-    if( psTransform->padfDEMBuffer == nullptr )
-    {
-        // Should only happen in case of failed memory allocation.
-        return psTransform->poDS->GetRasterBand(1)->
-                                  RasterIO(GF_Read, nX, nY, nWidth, nHeight,
-                                           padfOut, nWidth, nHeight,
-                                           GDT_Float64, 0, 0,
-                                           nullptr) == CE_None;
-    }
+    constexpr int BLOCK_SIZE = 64;
 
-    // Instead of reading just nWidth * nHeight pixels (with those being <= 4),
-    // target a larger buffer since small extractions can be costly, particular
-    // with VRT.
-    if( !(nX >= psTransform->nBufferX &&
-          nX + nWidth <= psTransform->nBufferX + psTransform->nBufferWidth &&
-          nY >= psTransform->nBufferY &&
-          nY + nHeight <= psTransform->nBufferY + psTransform->nBufferHeight ) )
-    {
-#ifdef DEBUG_VERBOSE_EXTRACT_DEM
-        CPLDebug("RPC", "Current request: %d,%d-%dx%d",
-                  nX, nY, nWidth, nHeight);
-        CPLDebug("RPC", "Hits in last DEM buffer: %d (%d pixels)",
-                 psTransform->nHitsInBuffer,
-                 psTransform->nBufferWidth * psTransform->nBufferHeight);
-        CPLDebug("RPC", "Last DEM buffer: %d,%d-%dx%d",
-                 psTransform->nBufferX,
-                 psTransform->nBufferY,
-                 psTransform->nBufferWidth,
-                 psTransform->nBufferHeight);
-#endif
-        const int nRasterXSize = psTransform->poDS->GetRasterXSize();
-        const int nRasterYSize = psTransform->poDS->GetRasterYSize();
-        // If we have only queried a few points, no need to extract on a large
-        // window We will progressively extend the window up to its maximum size
-        // if we extract a significant number of points.
-        int nRadius = psTransform->nBufferMaxRadius;
-        if( psTransform->nDEMExtractions <
-            psTransform->nBufferMaxRadius * psTransform->nBufferMaxRadius )
-        {
-            nRadius = static_cast<int> (
-                  sqrt(static_cast<double>(psTransform->nDEMExtractions)) );
-            CPLAssert( nRadius <= psTransform->nBufferMaxRadius );
-        }
-        // Check if there's some overlap between consecutive requests to decide
-        // if we must have a buffer around the interest window.
-        const int nDiffX = nX - psTransform->nLastQueriedX;
-        const int nDiffY = nY - psTransform->nLastQueriedY;
-        if( psTransform->nLastQueriedX >= 0 &&
-            (nDiffX > nRadius || -nDiffX > nRadius ||
-             nDiffY > nRadius || -nDiffY > nRadius) )
-        {
-            nRadius = 0;
-        }
-        psTransform->nBufferX = nX - nRadius;
-        if( psTransform->nBufferX < 0 )
-            psTransform->nBufferX = 0;
-        psTransform->nBufferY = nY - nRadius;
-        if( psTransform->nBufferY < 0 )
-            psTransform->nBufferY = 0;
-        psTransform->nBufferWidth = nWidth + 2 * nRadius;
-        if( psTransform->nBufferX + psTransform->nBufferWidth > nRasterXSize )
-            psTransform->nBufferWidth = nRasterXSize - psTransform->nBufferX;
-        psTransform->nBufferHeight = nHeight + 2 * nRadius;
-        if( psTransform->nBufferY + psTransform->nBufferHeight > nRasterYSize )
-            psTransform->nBufferHeight = nRasterYSize - psTransform->nBufferY;
-#ifdef DEBUG_VERBOSE_EXTRACT_DEM
-        CPLDebug("RPC", "New DEM buffer: %d,%d-%dx%d",
-                 psTransform->nBufferX,
-                 psTransform->nBufferY,
-                 psTransform->nBufferWidth,
-                 psTransform->nBufferHeight);
-#endif
-        CPLErr eErr = psTransform->poDS->GetRasterBand(1)->RasterIO(GF_Read,
-                        psTransform->nBufferX, psTransform->nBufferY,
-                        psTransform->nBufferWidth, psTransform->nBufferHeight,
-                        psTransform->padfDEMBuffer,
-                        psTransform->nBufferWidth, psTransform->nBufferHeight,
-                        GDT_Float64, 0, 0, nullptr);
-        if( eErr != CE_None )
-        {
-            psTransform->nBufferX = -1;
-            psTransform->nBufferY = -1;
-            psTransform->nBufferWidth = -1;
-            psTransform->nBufferHeight = -1;
-            return false;
-        }
-#ifdef DEBUG_VERBOSE_EXTRACT_DEM
-         psTransform->nHitsInBuffer = 1;
-#endif
-    }
-    else
-    {
-#ifdef DEBUG_VERBOSE
-        psTransform->nHitsInBuffer++;
-#endif
-    }
-    psTransform->nLastQueriedX = nX;
-    psTransform->nLastQueriedY = nY;
+    // Request the DEM by blocks of BLOCK_SIZE * BLOCK_SIZE and put them
+    // in poCacheDEM
+    if( psTransform->poCacheDEM == nullptr )
+        psTransform->poCacheDEM = new lru11::Cache<uint64_t, std::shared_ptr<std::vector<double>>>();
 
-    for( int i=0; i<nHeight; i++)
+    const int nXIters = (nX + nWidth - 1) / BLOCK_SIZE - nX / BLOCK_SIZE + 1;
+    const int nYIters = (nY + nHeight - 1) / BLOCK_SIZE - nY / BLOCK_SIZE + 1;
+    const int nRasterXSize = psTransform->poDS->GetRasterXSize();
+    const int nRasterYSize = psTransform->poDS->GetRasterYSize();
+    for(int iY = 0; iY < nYIters; iY++)
     {
-        memcpy( padfOut + i * nWidth,
-                psTransform->padfDEMBuffer + (nY - psTransform->nBufferY + i) *
-                    psTransform->nBufferWidth + nX - psTransform->nBufferX,
-                nWidth * sizeof(double) );
+        const int nBlockY = nY / BLOCK_SIZE + iY;
+        const int nReqYSize = std::min( nRasterYSize - nBlockY * BLOCK_SIZE, BLOCK_SIZE );
+        const int nFirstLineInCachedBlock = (iY == 0) ? nY % BLOCK_SIZE : 0;
+        const int nFirstLineInOutput = (iY == 0) ? 0 : BLOCK_SIZE - (nY % BLOCK_SIZE) + (iY - 1) * BLOCK_SIZE;
+        const int nLinesToCopy =
+            (nYIters == 1) ? nHeight :
+            (iY == 0) ? BLOCK_SIZE - (nY % BLOCK_SIZE) :
+            (iY == nYIters - 1) ? 1 + (nY + nHeight - 1) % BLOCK_SIZE :
+            BLOCK_SIZE;
+        for(int iX = 0; iX < nXIters; iX++)
+        {
+            const int nBlockX = nX / BLOCK_SIZE + iX;
+            const int nReqXSize = std::min( nRasterXSize - nBlockX * BLOCK_SIZE, BLOCK_SIZE );
+            const uint64_t nKey = (static_cast<uint64_t>(nBlockY) << 32) | nBlockX;
+            const int nFirstColInCachedBlock = (iX == 0) ? nX % BLOCK_SIZE : 0;
+            const int nFirstColInOutput = (iX == 0) ? 0 : BLOCK_SIZE - (nX % BLOCK_SIZE) + (iX - 1) * BLOCK_SIZE;
+            const int nColsToCopy =
+                (nXIters == 1) ? nWidth :
+                (iX == 0) ? BLOCK_SIZE - (nX % BLOCK_SIZE) :
+                (iX == nXIters - 1) ? 1 + (nX + nWidth - 1) % BLOCK_SIZE :
+                BLOCK_SIZE;
+
+#if 0
+            CPLDebug("RPC", "nY=%d nX=%d nBlockY=%d nBlockX=%d "
+                     "nFirstLineInCachedBlock=%d nFirstLineInOutput=%d nLinesToCopy=%d "
+                     "nFirstColInCachedBlock=%d nFirstColInOutput=%d nColsToCopy=%d",
+                     nY, nX, nBlockY, nBlockX, nFirstLineInCachedBlock, nFirstLineInOutput, nLinesToCopy,
+                     nFirstColInCachedBlock, nFirstColInOutput, nColsToCopy);
+#endif
+
+            std::shared_ptr<std::vector<double>> poValue;
+            if( !psTransform->poCacheDEM->tryGet(nKey, poValue) )
+            {
+                poValue = std::make_shared<std::vector<double>>(nReqXSize * nReqYSize);
+                CPLErr eErr = psTransform->poDS->GetRasterBand(1)->RasterIO(GF_Read,
+                                nBlockX * BLOCK_SIZE, nBlockY * BLOCK_SIZE,
+                                nReqXSize, nReqYSize,
+                                poValue->data(),
+                                nReqXSize, nReqYSize,
+                                GDT_Float64,
+                                0, 0, nullptr);
+                if( eErr != CE_None )
+                {
+                    return false;
+                }
+                psTransform->poCacheDEM->insert(nKey, poValue);
+            }
+
+            // Compose the cached block to the final buffer
+            for( int j=0; j<nLinesToCopy; j++)
+            {
+                memcpy( padfOut + (nFirstLineInOutput + j) * nWidth + nFirstColInOutput,
+                        poValue->data() + (nFirstLineInCachedBlock + j) * nReqXSize + nFirstColInCachedBlock,
+                        nColsToCopy * sizeof(double) );
+            }
+        }
     }
 
 #if 0
@@ -1962,29 +1918,6 @@ static bool GDALRPCOpenDEM( GDALRPCTransformInfo* psTransform )
     if( psTransform->poDS != nullptr &&
         psTransform->poDS->GetRasterCount() >= 1 )
     {
-        psTransform->nBufferMaxRadius =
-            atoi(CPLGetConfigOption("GDAL_RPC_DEM_BUFFER_MAX_RADIUS", "2"));
-        psTransform->nHitsInBuffer = 0;
-        constexpr int nMaxWindowSize = 4;
-        if( psTransform->nBufferMaxRadius <= 0 ||
-            psTransform->nBufferMaxRadius > (INT_MAX - nMaxWindowSize) / 2 )
-        {
-            return false;
-        }
-        const int nWindowSize = nMaxWindowSize + 2 * psTransform->nBufferMaxRadius;
-        psTransform->padfDEMBuffer = static_cast<double*>(VSI_MALLOC3_VERBOSE(
-            nWindowSize, nWindowSize, sizeof(double) ));
-        if( psTransform->padfDEMBuffer == nullptr )
-        {
-            return false;
-        }
-        psTransform->nBufferX = -1;
-        psTransform->nBufferY = -1;
-        psTransform->nBufferWidth = -1;
-        psTransform->nBufferHeight = -1;
-        psTransform->nLastQueriedX = -1;
-        psTransform->nLastQueriedY = -1;
-
         OGRSpatialReference oDEMSRS;
         if ( psTransform->pszDEMSRS != nullptr )
         {

--- a/alg/gdal_rpc.cpp
+++ b/alg/gdal_rpc.cpp
@@ -1520,6 +1520,21 @@ static bool GDALRPCExtractDEMWindow( GDALRPCTransformInfo *psTransform,
                 nWidth * sizeof(double) );
     }
 
+#if 0
+    CPLDebug("RPC_DEM", "DEM for %d,%d,%d,%d", nX, nY, nWidth, nHeight);
+    for(int j = 0; j < nHeight; j++)
+    {
+        std::string osLine;
+        for(int i = 0; i < nWidth; ++i )
+        {
+            if( !osLine.empty() )
+                osLine += ", ";
+            osLine += std::to_string(padfOut[j * nWidth + i]);
+        }
+        CPLDebug("RPC_DEM", "%s", osLine.c_str());
+    }
+#endif
+
     return true;
 }
 

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -3610,7 +3610,7 @@ def test_tiff_read_big_strip_chunky_way():
     )
     ds = gdal.Open("/vsimem/test.tif")
     cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 38337
+    assert cs == 38441
     ds = None
     gdal.Unlink("/vsimem/test.tif")
 

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -8024,7 +8024,7 @@ def test_tiff_write_163():
     )
     ds = gdal.Open("/vsimem/tiff_write_163.tif")
     cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 47567
+    assert cs == 47600
     # Check that IsBlockAvailable() works properly in that mode
     offset_0_2 = ds.GetRasterBand(1).GetMetadataItem("BLOCK_OFFSET_0_2", "TIFF")
     assert offset_0_2 == str(146 + 2 * 8192)

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -1044,6 +1044,19 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
     *pnReqXOff = static_cast<int>( floor(*pdfReqXOff) );
     *pnReqYOff = static_cast<int>( floor(*pdfReqYOff) );
 
+    constexpr double EPS = 1e-3;
+    constexpr double ONE_MINUS_EPS = 1.0 - EPS;
+    if( *pdfReqXOff - *pnReqXOff > ONE_MINUS_EPS )
+    {
+        (*pnReqXOff) ++;
+        *pdfReqXOff = *pnReqXOff;
+    }
+    if( *pdfReqYOff - *pnReqYOff > ONE_MINUS_EPS )
+    {
+        (*pnReqYOff) ++;
+        *pdfReqYOff = *pnReqYOff;
+    }
+
     if( *pdfReqXSize > INT_MAX )
         *pnReqXSize = INT_MAX;
     else
@@ -1138,7 +1151,7 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
             else if( dfOutXOff > INT_MAX )
                 *pnOutXOff = INT_MAX;
             else
-                *pnOutXOff = static_cast<int>(dfOutXOff+0.001);
+                *pnOutXOff = static_cast<int>(dfOutXOff+EPS);
 
             // Apply correction on floating-point source window
             {
@@ -1154,7 +1167,8 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
                 return FALSE;
             if( dfOutRightXOff > INT_MAX )
                 dfOutRightXOff = INT_MAX;
-            *pnOutXSize = static_cast<int>(ceil(dfOutRightXOff-0.001) - *pnOutXOff);
+            const int nOutRightXOff = static_cast<int>(ceil(dfOutRightXOff-EPS));
+            *pnOutXSize = nOutRightXOff - *pnOutXOff;
 
             if( *pnOutXSize > INT_MAX - *pnOutXOff ||
                 *pnOutXOff + *pnOutXSize > nBufXSize )
@@ -1162,7 +1176,7 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
 
             // Apply correction on floating-point source window
             {
-                double dfDstDeltaX = (ceil(dfOutRightXOff) - dfOutRightXOff) / dfScaleWinToBufX;
+                double dfDstDeltaX = (nOutRightXOff - dfOutRightXOff) / dfScaleWinToBufX;
                 double dfSrcDeltaX = dfDstDeltaX / m_dfDstXSize * m_dfSrcXSize;
                 *pdfReqXSize = std::min( *pdfReqXSize + dfSrcDeltaX,
                                          static_cast<double>(INT_MAX) );
@@ -1179,7 +1193,7 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
             else if( dfOutYOff > INT_MAX )
                 *pnOutYOff = INT_MAX;
             else
-                *pnOutYOff = static_cast<int>(dfOutYOff+0.001);
+                *pnOutYOff = static_cast<int>(dfOutYOff+EPS);
 
             // Apply correction on floating-point source window
             {
@@ -1195,7 +1209,8 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
                 return FALSE;
             if( dfOutTopYOff > INT_MAX )
                 dfOutTopYOff = INT_MAX;
-            *pnOutYSize = static_cast<int>( ceil(dfOutTopYOff-0.001) ) - *pnOutYOff;
+            const int nOutTopYOff = static_cast<int>( ceil(dfOutTopYOff-EPS) );
+            *pnOutYSize = nOutTopYOff - *pnOutYOff;
 
             if( *pnOutYSize > INT_MAX - *pnOutYOff ||
                 *pnOutYOff + *pnOutYSize > nBufYSize )
@@ -1203,7 +1218,7 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
 
             // Apply correction on floating-point source window
             {
-                double dfDstDeltaY = (ceil(dfOutTopYOff) - dfOutTopYOff) / dfScaleWinToBufY;
+                double dfDstDeltaY = (nOutTopYOff - dfOutTopYOff) / dfScaleWinToBufY;
                 double dfSrcDeltaY = dfDstDeltaY / m_dfDstYSize * m_dfSrcYSize;
                 *pdfReqYSize = std::min( *pdfReqYSize + dfSrcDeltaY,
                                          static_cast<double>(INT_MAX) );
@@ -1213,6 +1228,11 @@ VRTSimpleSource::GetSrcDstWindow( double dfXOff, double dfYOff,
         if( *pnOutXSize < 1 || *pnOutYSize < 1 )
             return FALSE;
     }
+
+    *pdfReqXOff = RoundIfCloseToInt(*pdfReqXOff);
+    *pdfReqYOff = RoundIfCloseToInt(*pdfReqYOff);
+    *pdfReqXSize = RoundIfCloseToInt(*pdfReqXSize);
+    *pdfReqYSize = RoundIfCloseToInt(*pdfReqYSize);
 
     return TRUE;
 }


### PR DESCRIPTION
Before this commit, we would query small windows, of growing radius when
querying in the same area, at 'random' locations. When transforming
several points with the same transformer object, there was no guarantee
that the same input coordinates would result in reading the DEM in the
same window. For 'normal' rasters, this didn't make any difference, but
when requesting a VRT with non-integer src/dst offsets or scaling, there
is no guarantee that extracting values from those windows results in
consistent values being returned (can be seen as a bug of the VRT
driver, but it is extraordinary complicated, if not impossible, to offer
such stability property with it).
Consequently let's query the DEM by non-overlapping fixed-size blocks,
which eliminates that issue.