### PR TITLE
Typo-Fix: gdal_calc.py --extent flag description

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -212,7 +212,7 @@ def Calc(
             alphas = [alphas]
         else:
             # I guess this alphas should be in the global_namespace,
-            # It would have been better to pass it as user_namepsace, but I'll accept it anyway
+            # It would have been better to pass it as user_namespace, but I'll accept it anyway
             global_namespace[alphas] = filenames
             continue
         for alpha, filename in zip(alphas * len(filenames), filenames):
@@ -847,7 +847,7 @@ class GDALCalc(GDALScript):
             "--extent",
             dest="extent",
             choices=[e.name.lower() for e in Extent],
-            help="how to treat mixed geotrasnforms",
+            help="how to treat mixed geotransforms",
         )
         group.add_argument(
             "--projwin",


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes a small typo (misspelling of "geotransforms") in the `gdal_calc.py` `--help` information for the flag `--extents`.

---

I was getting ready to use this functionality and noticed this typo. Apologies for opening up such a minor PR but I figured it couldn't hurt. Feel free to close this and incorporate the change in a bigger commit if desired. Big thanks to all the maintainers for keeping the amazing tool that is GDAL up and running!