### PR TITLE
/vsicurl / CPLHTTPFetch(): add GDAL_HTTP_HEADERS configuration option

### DIFF
--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -220,7 +220,18 @@ The :decl_configoption:`GDAL_HTTP_PROXY` (for both HTTP and HTTPS protocols), :d
 
 Starting with GDAL 2.1.3, the :decl_configoption:`CURL_CA_BUNDLE` or :decl_configoption:`SSL_CERT_FILE` configuration options can be used to set the path to the Certification Authority (CA) bundle file (if not specified, curl will use a file in a system location).
 
-Starting with GDAL 2.3, additional HTTP headers can be sent by setting the :decl_configoption:`GDAL_HTTP_HEADER_FILE` configuration option to point to a filename of a text file with "key: value" HTTP headers.   :decl_configoption:`CPL_CURL_VERBOSE` set to ``YES`` allows one to see them and more, when combined with ``--debug``.
+Starting with GDAL 2.3, additional HTTP headers can be sent by setting the :decl_configoption:`GDAL_HTTP_HEADER_FILE` configuration option to point to a filename of a text file with "key: value" HTTP headers.
+
+As an alternative, starting with GDAL 3.6, the
+:decl_configoption:`GDAL_HTTP_HEADERS` configuration option can also be
+used to specify a comma separated list of key: value pairs. This is an
+alternative to the GDAL_HTTP_HEADER_FILE mechanism. If a comma or a double-quote
+character is needed in the value, then the key: value pair must be
+enclosed in double-quote characters. In that situation, backslash and double
+quote character must be backslash-escaped.
+e.g GDAL_HTTP_HEADERS=Foo: Bar,"Baz: escaped backslash \\, escaped double-quote \", end of value",Another: Header
+
+:decl_configoption:`CPL_CURL_VERBOSE` set to ``YES`` allows one to see them and more, when combined with ``--debug``.
 
 Starting with GDAL 2.3, the :decl_configoption:`GDAL_HTTP_MAX_RETRY` (number of attempts) and :decl_configoption:`GDAL_HTTP_RETRY_DELAY` (in seconds) configuration option can be set, so that request retries are done in case of HTTP errors 429, 502, 503 or 504.
 

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -224,8 +224,7 @@ Starting with GDAL 2.3, additional HTTP headers can be sent by setting the :decl
 
 As an alternative, starting with GDAL 3.6, the
 :decl_configoption:`GDAL_HTTP_HEADERS` configuration option can also be
-used to specify a comma separated list of key: value pairs. This is an
-alternative to the GDAL_HTTP_HEADER_FILE mechanism. If a comma or a double-quote
+used to specify a comma separated list of key: value pairs. If a comma or a double-quote
 character is needed in the value, then the key: value pair must be
 enclosed in double-quote characters. In that situation, backslash and double
 quote character must be backslash-escaped.

--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -976,6 +976,14 @@ int CPLHTTPPopFetchCallback(void)
  * GDAL_HTTP_HEADER_FILE, GDAL_HTTP_VERSION, GDAL_HTTP_SSL_VERIFYSTATUS,
  * GDAL_HTTP_USE_CAPI_STORE, GDAL_GSSAPI_DELEGATION
  *
+ * Starting with GDAL 3.6, the GDAL_HTTP_HEADERS configuration option can also be
+ * used to specify a comma separated list of key: value pairs. This is an
+ * alternative to the GDAL_HTTP_HEADER_FILE mechanism. If a comma or a double-quote
+ * character is needed in the value, then the key: value pair must be
+ * enclosed in double-quote characters. In that situation, backslash and double
+ * quote character must be backslash-escaped.
+ * e.g GDAL_HTTP_HEADERS=Foo: Bar,"Baz: escaped backslash \\, escaped double-quote \", end of value",Another: Header
+ *
  * @return a CPLHTTPResult* structure that must be freed by
  * CPLHTTPDestroyResult(), or NULL if libcurl support is disabled
  */
@@ -2311,6 +2319,17 @@ void *CPLHTTPSetOptions(void *pcurl, const char* pszURL,
             }
             VSIFCloseL(fp);
         }
+    }
+
+    const char* pszHeaders = CPLGetConfigOption("GDAL_HTTP_HEADERS", nullptr);
+    if( pszHeaders )
+    {
+         const CPLStringList aosTokens(
+             CSLTokenizeString2( pszHeaders, ",", CSLT_HONOURSTRINGS ));
+         for( int i = 0; i < aosTokens.size(); ++i )
+         {
+             headers = curl_slist_append(headers, aosTokens[i]);
+         }
     }
 
     return headers;


### PR DESCRIPTION
This is an alternative to GDAL_HTTP_HEADER_FILE, but easier to
use for less technical end users, since it allows to specify the headers
inline, without requiring an extra file.
