### PR TITLE
Fix propagation of CPL_DISABLE_DLL

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -43,6 +43,10 @@ check_type_size("unsigned long" SIZEOF_UNSIGNED_LONG)
 check_type_size("void*" SIZEOF_VOIDP)
 check_type_size("size_t" SIZEOF_SIZE_T)
 
+if(MSVC AND NOT BUILD_SHARED_LIBS)
+  set(CPL_DISABLE_DLL 1)
+endif()
+
 if (MSVC)
   set(HAVE_VSNPRINTF 1)
 

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -180,6 +180,9 @@
 /* Define to 1 if the compiler supports -Wzero-as-null-pointer-constant */
 #cmakedefine HAVE_GCC_WARNING_ZERO_AS_NULL_POINTER_CONSTANT @HAVE_GCC_WARNING_ZERO_AS_NULL_POINTER_CONSTANT@
 
+/* Define if building a static windows lib */
+#cmakedefine CPL_DISABLE_DLL @CPL_DISABLE_DLL@
+
 /* Define to 1 if you have the <atlbase.h> header file. */
 #cmakedefine HAVE_ATLBASE_H 1
 

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -389,11 +389,6 @@ if (MINGW AND BUILD_SHARED_LIBS)
     set_target_properties(${GDAL_LIB_TARGET_NAME} PROPERTIES SUFFIX "-${GDAL_SOVERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}")
 endif ()
 
-
-if (MSVC AND NOT BUILD_SHARED_LIBS)
-  target_compile_definitions(${GDAL_LIB_TARGET_NAME} PUBLIC CPL_DISABLE_DLL=)
-endif ()
-
 if (MINGW)
   if (TARGET_CPU MATCHES "x86_64")
     add_definitions(-m64)


### PR DESCRIPTION
## What does this PR do?

This PR makes the CMake build system propagate `CPL_DISABLE_DLL` via `cpl_config.h`, as used to be done with `nmake`  AFAIU. The original implementation with `target_compile_definitions` seems to not propagate to compiling the individual units, probably due to the use of object libraries. This fixes:
- `DllMain` appearing in the static lib,
- `__declspec(dllexport)` being applied which building the static lib.

Cf. https://github.com/microsoft/vcpkg/issues/26362#issuecomment-1221256210, https://github.com/microsoft/vcpkg/pull/26457

Side notes: 
- I wonder if some of the `MSVC` condition should be changed in `WIN32` conditions (in CMake and in the source files), to increase consistency between MSVC and MinGW builds.
- There could be more cleanup around nmake-ish `cpl_config.h.vc*`, but this would not qualify for a direct backport to 3.5.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

Static windows triplets in vcpkg, i.e.
* OS: Windows
* Compiler: MSVC

