### PR TITLE
gdal2tiles: fix OpenLayers CDN

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -3446,8 +3446,8 @@ class GDAL2Tiles(object):
         #subheader { height: 12px; text-align: right; font-size: 10px; color: #555;}
         #map { height: 90%%; border: 1px solid #888; }
     </style>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.3.1/css/ol.css" type="text/css">
-    <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.3.1/build/ol.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@main/dist/en/v7.0.0/legacy/ol.css" type="text/css">
+    <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@main/dist/en/v7.0.0/legacy/ol.js"></script>
     <script src="https://unpkg.com/ol-layerswitcher@3.5.0"></script>
     <link rel="stylesheet" href="https://unpkg.com/ol-layerswitcher@3.5.0/src/ol-layerswitcher.css" />
 </head>
@@ -3463,7 +3463,7 @@ class GDAL2Tiles(object):
             undefinedHTML: '&nbsp;'
         });
         var map = new ol.Map({
-            controls: ol.control.defaults().extend([mousePositionControl]),
+            controls:  ol.control.defaults.defaults().extend([mousePositionControl]),
             target: 'map',
 """
             % args

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -3463,7 +3463,7 @@ class GDAL2Tiles(object):
             undefinedHTML: '&nbsp;'
         });
         var map = new ol.Map({
-            controls:  ol.control.defaults.defaults().extend([mousePositionControl]),
+            controls: ol.control.defaults.defaults().extend([mousePositionControl]),
             target: 'map',
 """
             % args


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Update OpenLayers to Version 7. The current version is not available from the CDN anymore


## Tasklist

 - [x] Update OpenLayers
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

