### PR TITLE
ODBC: fix issue with odbc large data (fixes #6196)

### DIFF
--- a/port/cpl_odbc.cpp
+++ b/port/cpl_odbc.cpp
@@ -1270,7 +1270,7 @@ int CPLODBCStatement::Fetch( int nOrientation, int nOffset )
         // Assume big result: should check for state=SQLSATE 01004.
         else if( nRetCode == SQL_SUCCESS_WITH_INFO )
         {
-            if( cbDataLen >= static_cast<CPL_SQLLEN>(sizeof(szWrkData)-1) )
+          if( cbDataLen >= static_cast<CPL_SQLLEN>(sizeof(szWrkData)-1) || cbDataLen == SQL_NO_TOTAL )
             {
                 cbDataLen = static_cast<CPL_SQLLEN>(sizeof(szWrkData)-1);
                 if( nFetchType == SQL_C_CHAR )


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

As per ODBC documentation of the [SQLGetData](https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/getting-long-data?view=sql-server-ver16) function, there are 2 possible scenario when reading large columns data (e.g WKT);
1. some drivers will return the remaining bytes to be read in `cbDataLen` while
2. some drivers will return  `SQL_NO_TOTAL` in `cbDataLen`

The current code was not addressing the second use case. This PR address it.

## What are related issues/pull requests?

#6196 

## Test Cases

- [use case for `SQL_NO_TOTAL`] Given an ODBC connection for the [Kinetica database](https://docs.kinetica.com/7.1/connectors/sql_guide/#odbc)
  - Given a table pre-loaded with WKT
    - When running `ogrinfo` it should not fail
      ```
      ogrinfo --debug ON -so -al 'ODBC:user/password@kinetica-odbc-connection,prism.operator_acreage_view(WKT)'
      ```
    - When running `ogr2ogr` to extract the table as CSV and loading the resulting CSV in QGis, we should see the features
      ```
      ogr2ogr --debug ON -f CSV operator.csv -lco GEOMETRY=AS_WKT -sql 'select PK, UIOpName, WKT from 
      prism.operator_acreage_view' 'ODBC:user/password@kinetica-odbc-connection,prism.operator_acreage_view(WKT)'
      ```

- [use case for remaining bytes in `cbDataLen`] Given an ODBC connection for the [SQLite](https://packages.ubuntu.com/search?suite=focal&arch=any&searchon=names&keywords=libsqliteodbc)
  - Given a table pre-loaded with WKT
    - When running `ogrinfo` it should not fail
      ```
      # .odbc.ini
      [sqlite-test]
      Driver   = /usr/lib/x86_64-linux-gnu/odbc/libsqlite3odbc.so
      Database = /home/pascal/tmp/test.sqlite

      # run ogrinfo
      ogrinfo --debug ON -so -al 'ODBC:sqlite-test,operator_acreage_view(WKT)'
      ```
    - When running `ogr2ogr` to extract the table as CSV and loading the resulting CSV in QGis, we should see the features
      ```
      ogr2ogr --debug ON -f CSV operator.csv -lco GEOMETRY=AS_WKT -sql 'select PK, UIOpName from operator_acreage_view' 'ODBC:sqlite-test,operator_acreage_view(WKT)'
      ```



## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 20.04.4 LTS 64 bit
* Compiler: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
