### PR TITLE
HANA: LaunderName returns wrong value for non-ASCII characters

### DIFF
--- a/autotest/ogr/ogr_hana.py
+++ b/autotest/ogr/ogr_hana.py
@@ -981,6 +981,40 @@ def test_ogr_hana_32():
 
 
 ###############################################################################
+# Test LAUNDER option on non-ASCII characters
+
+
+def test_ogr_hana_33():
+    ds = open_datasource(1)
+
+    def launder_name(s):
+        return s.upper().replace("-", "_").replace("#", "_")
+
+    # Test layer name
+    layer_name = get_test_name() + "_table_-#äöü#\U0001f608"
+    layer = ds.CreateLayer(
+        layer_name, geom_type=ogr.wkbNone, options=["FID=fid", "LAUNDER=YES"]
+    )
+    expected_layer_name = launder_name(layer_name)
+    assert layer.GetName() == expected_layer_name, pytest.fail(
+        "GetName() returned %s instead of %s" % (layer.GetName(), expected_layer_name)
+    )
+
+    # Test field name
+    field_defn = ogr.FieldDefn("field_-#äöü#\U0001f608", ogr.OFTInteger)
+
+    assert layer.CreateField(field_defn) == ogr.OGRERR_NONE, (
+        "CreateField failed for %s" % field_defn.GetNameRef()
+    )
+    new_field_defn = layer.GetLayerDefn().GetFieldDefn(1)
+    expected_field_name = launder_name(field_defn.GetNameRef())
+    assert new_field_defn.GetNameRef() == expected_field_name, pytest.fail(
+        "GetNameRef() returned %s instead of %s"
+        % (new_field_defn.GetNameRef(), expected_field_name)
+    )
+
+
+###############################################################################
 #  Create a table from data/poly.shp
 
 

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -329,6 +329,8 @@ protected:
         const CPLString& wkt,
         const CPLString& proj4);
 
+    std::pair<OGRErr, CPLString> LaunderName(const char* name);
+
     bool IsTransactionStarted() const { return isTransactionStarted_; }
 
     void CreateParseArrayFunctions(const char* schemaName);

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -804,7 +804,7 @@ int OGRHanaDataSource::FindLayerByName(const char* name)
 CPLString OGRHanaDataSource::FindSchemaName(const char* objectName)
 {
     auto getSchemaName = [&](const char* sql) {
-        odbc::PreparedStatementRef stmt = conn_->prepareStatement(sql);
+        odbc::PreparedStatementRef stmt = PrepareStatement(sql);
         stmt->setString(1, odbc::String(objectName));
         odbc::ResultSetRef rsEntries = stmt->executeQuery();
         CPLString ret;
@@ -847,10 +847,14 @@ odbc::StatementRef OGRHanaDataSource::CreateStatement()
 
 odbc::PreparedStatementRef OGRHanaDataSource::PrepareStatement(const char* sql)
 {
+    CPLAssert(sql != nullptr);
+
     try
     {
         CPLDebug("HANA", "Prepare statement %s.", sql);
-        return conn_->prepareStatement(sql);
+
+        std::u16string sqlUtf16 = odbc::StringConverter::utf8ToUtf16(sql);
+        return conn_->prepareStatement(sqlUtf16.c_str());
     }
     catch (const odbc::Exception& ex)
     {
@@ -1043,7 +1047,7 @@ bool OGRHanaDataSource::IsSrsRoundEarth(int srid)
     const char* sql =
         "SELECT ROUND_EARTH FROM SYS.ST_SPATIAL_REFERENCE_SYSTEMS "
         "WHERE SRS_ID = ?";
-    odbc::PreparedStatementRef stmt = conn_->prepareStatement(sql);
+    odbc::PreparedStatementRef stmt = PrepareStatement(sql);
     stmt->setInt(1, odbc::Int(srid));
     odbc::ResultSetRef rs = stmt->executeQuery();
     bool ret = false;
@@ -1061,7 +1065,7 @@ bool OGRHanaDataSource::HasSrsPlanarEquivalent(int srid)
 {
     const char* sql = "SELECT COUNT(*) FROM SYS.ST_SPATIAL_REFERENCE_SYSTEMS "
                       "WHERE SRS_ID = ?";
-    odbc::PreparedStatementRef stmt = conn_->prepareStatement(sql);
+    odbc::PreparedStatementRef stmt = PrepareStatement(sql);
     stmt->setInt(1, ToPlanarSRID(srid));
     odbc::ResultSetRef rs = stmt->executeQuery();
     std::int64_t count = 0;
@@ -1082,19 +1086,10 @@ OGRErr OGRHanaDataSource::GetQueryColumns(
 {
     columnDescriptions.clear();
 
-    odbc::PreparedStatementRef stmtQuery;
+    odbc::PreparedStatementRef stmtQuery = PrepareStatement(query);
 
-    try
-    {
-        stmtQuery = conn_->prepareStatement(query);
-    }
-    catch (const odbc::Exception& ex)
-    {
-        CPLError(
-            CE_Failure, CPLE_AppDefined, "Unable to prepare statement: %s",
-            ex.what());
+    if (stmtQuery.isNull())
         return OGRERR_FAILURE;
-    }
 
     odbc::ResultSetMetaDataRef rsmd = stmtQuery->getMetaData();
     std::size_t numColumns = rsmd->getColumnCount();
@@ -1106,10 +1101,10 @@ OGRErr OGRHanaDataSource::GetQueryColumns(
     CPLString tableName = rsmd->getTableName(1);
     odbc::DatabaseMetaDataRef dmd = conn_->getDatabaseMetaData();
     odbc::PreparedStatementRef stmtArrayTypeInfo =
-        conn_->prepareStatement("SELECT DATA_TYPE_NAME FROM "
-                                "SYS.TABLE_COLUMNS_ODBC WHERE SCHEMA_NAME = ? "
-                                "AND TABLE_NAME = ? AND COLUMN_NAME = ? AND "
-                                "DATA_TYPE_NAME LIKE '% ARRAY'");
+        PrepareStatement("SELECT DATA_TYPE_NAME FROM "
+                         "SYS.TABLE_COLUMNS_ODBC WHERE SCHEMA_NAME = ? "
+                         "AND TABLE_NAME = ? AND COLUMN_NAME = ? AND "
+                         "DATA_TYPE_NAME LIKE '% ARRAY'");
 
     for (unsigned short clmIndex = 1; clmIndex <= numColumns; ++clmIndex)
     {
@@ -1256,7 +1251,7 @@ void OGRHanaDataSource::InitializeLayers(
     std::vector<CPLString> tables = SplitStrings(tableNames, ",");
 
     auto addLayersFromQuery = [&](const char* query, bool updatable) {
-        odbc::PreparedStatementRef stmt = conn_->prepareStatement(query);
+        odbc::PreparedStatementRef stmt = PrepareStatement(query);
         stmt->setString(1, odbc::String(schemaName));
         odbc::ResultSetRef rsTables = stmt->executeQuery();
         while (rsTables->next())
@@ -1303,6 +1298,72 @@ void OGRHanaDataSource::InitializeLayers(
                 "have any geometry column.",
                 layerName);
     }
+}
+
+/************************************************************************/
+/*                          LaunderName()                               */
+/************************************************************************/
+
+std::pair<OGRErr, CPLString> OGRHanaDataSource::LaunderName(const char* name)
+{
+    CPLAssert(name != nullptr);
+
+    if (!CPLIsUTF8(name, -1))
+    {
+       CPLError(
+            CE_Failure, CPLE_AppDefined,
+            "%s is not a valid UTF-8 string.", name);
+        return {OGRERR_FAILURE, ""};
+    }
+
+    auto getUTF8SequenceLength = [](char c)
+    {
+        if ((c & 0x80) == 0x00)
+            return 1;
+        if ((c & 0xE0) == 0xC0)
+            return 2;
+        if ((c & 0xF0) == 0xE0)
+            return 3;
+        if ((c & 0xF8) == 0xF0)
+            return 4;
+
+        throw std::runtime_error("Invalid UTF-8 sequence");
+    };
+
+    CPLString newName(name);
+    bool hasNonASCII = false;
+    size_t i = 0;
+
+    while(name[i] != '\0')
+    {
+        char c = name[i];
+        int len = getUTF8SequenceLength(c);
+        if (len == 1)
+        {
+            if (c == '-' || c == '#')
+                newName[i] = '_';
+            else
+                newName[i] = static_cast<char>(toupper(c));
+        }
+        else
+        {
+            hasNonASCII = true;
+        }
+
+        i += len;
+    }
+
+    if (!hasNonASCII)
+        return {OGRERR_NONE, newName};
+
+    const char* sql = "SELECT UPPER(?) FROM DUMMY";
+    odbc::PreparedStatementRef stmt = PrepareStatement(sql);
+    stmt->setString(1, odbc::String(newName.c_str()));
+    odbc::ResultSetRef rsName = stmt->executeQuery();
+    rsName->next();
+    auto upperCaseName = *rsName->getString(1);
+    rsName->close();
+    return {OGRERR_NONE, upperCaseName};
 }
 
 /************************************************************************/
@@ -1494,7 +1555,7 @@ bool OGRHanaDataSource::ParseArrayFunctionsExist(const char* schemaName)
     const char* sql =
         "SELECT COUNT(*) FROM FUNCTIONS WHERE SCHEMA_NAME = ? AND "
         "FUNCTION_NAME LIKE 'OGR_PARSE_%_ARRAY'";
-    odbc::PreparedStatementRef stmt = conn_->prepareStatement(sql);
+    odbc::PreparedStatementRef stmt = PrepareStatement(sql);
     stmt->setString(1, odbc::String(schemaName));
     odbc::ResultSetRef rsFunctions = stmt->executeQuery();
     auto numFunctions = rsFunctions->next() ? *rsFunctions->getLong(1) : 0;
@@ -1551,8 +1612,14 @@ OGRLayer* OGRHanaDataSource::ICreateLayer(
 
     bool launderNames =
         CPLFetchBool(options, LayerCreationOptionsConstants::LAUNDER, true);
-    CPLString layerName =
-        launderNames ? LaunderName(layerNameIn) : CPLString(layerNameIn);
+    CPLString layerName(layerNameIn);
+    if (launderNames)
+    {
+        auto nameRes = LaunderName(layerNameIn);
+        if (nameRes.first != OGRERR_NONE)
+            return nullptr;
+        layerName.swap(nameRes.second);
+    }
 
     CPLDebug("HANA", "Creating layer %s.", layerName.c_str());
 
@@ -1600,11 +1667,27 @@ OGRLayer* OGRHanaDataSource::ICreateLayer(
     }
 
     CPLString geomColumnName(CSLFetchNameValueDef(options, LayerCreationOptionsConstants::GEOMETRY_NAME, "OGR_GEOMETRY"));
+    if (launderNames)
+    {
+        auto nameRes = LaunderName(geomColumnName.c_str());
+        if (nameRes.first != OGRERR_NONE)
+            return nullptr;
+        geomColumnName.swap(nameRes.second);
+    }
+
     const bool geomColumnNullable = CPLFetchBool(options, LayerCreationOptionsConstants::GEOMETRY_NULLABLE, true);
     CPLString geomColumnIndexType(CSLFetchNameValueDef(options, LayerCreationOptionsConstants::GEOMETRY_INDEX, "DEFAULT"));
 
     const char* paramFidName = CSLFetchNameValueDef(options, LayerCreationOptionsConstants::FID, "OGR_FID");
-    CPLString fidName(launderNames ? LaunderName(paramFidName).c_str() : paramFidName);
+    CPLString fidName(paramFidName);
+    if (launderNames)
+    {
+        auto nameRes = LaunderName(paramFidName);
+        if (nameRes.first != OGRERR_NONE)
+            return nullptr;
+        fidName.swap(nameRes.second);
+    }
+
     CPLString fidType = CPLFetchBool(options, LayerCreationOptionsConstants::FID64, false) ? "BIGINT" : "INTEGER";
 
     CPLDebug("HANA", "Geometry Column Name %s.", geomColumnName.c_str());

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
@@ -99,22 +99,6 @@ CPLString GetFullColumnNameQuoted(
            + QuotedIdentifier(columnName);
 }
 
-CPLString LaunderName(const char* name)
-{
-    if (name == nullptr)
-        return nullptr;
-
-    CPLString newName(name);
-    for (std::size_t i = 0; newName[i] != '\0'; ++i)
-    {
-        char c = static_cast<char>(toupper(newName[i]));
-        if (c == '-' || c == '#')
-            c = '_';
-        newName[i] = c;
-    }
-    return newName;
-}
-
 CPLString Literal(const CPLString& value)
 {
     CPLString ret("'");

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.h
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.h
@@ -56,7 +56,6 @@ CPLString GetFullTableName(
     const CPLString& schemaName, const CPLString& tableName);
 CPLString GetFullTableNameQuoted(
     const CPLString& schemaName, const CPLString& tableName);
-CPLString LaunderName(const char* name);
 CPLString Literal(const CPLString& value);
 CPLString QuotedIdentifier(const CPLString& value);
 


### PR DESCRIPTION
This PR fixes the following issues in HANA driver:
 - LaunderName function doesn't properly work with non-ASCII characters
 - Geometry column name in OGRHanaDataSource::ICreateLayer is not laundered
 - OGRHanaTableLayer::CreateField function must use Unicode variant of odbc::Connection::prepareStatement

