### PR TITLE
gdal.org doc build: copy resources/ directory for gdal2tiles need

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -115,6 +115,7 @@ jobs:
         rm gdal-docs/gdal.pdf
         cp gdal/doc/build/latex/gdal.pdf gdal-docs
         cp gdal/data/gdalicon.png gdal-docs # For GDAL autotest...
+        cp -r gdal/resources gdal-docs # Do not change this without changing swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
         cd gdal-docs
         wget http://download.osgeo.org/gdal/for_doc/javadoc.zip -O /tmp/javadoc.zip
         unzip -q /tmp/javadoc.zip


### PR DESCRIPTION
restore behavior added in 2e3f6126c41fdc19a70d9ccbefbe3e75d29430f that was lost in azure pipelines to gha migration
