### PR TITLE
gdal_translate: add a -ovr <level|AUTO|AUTO-n|NONE> flag (fixes #1923)

### DIFF
--- a/apps/gdal_translate_bin.cpp
+++ b/apps/gdal_translate_bin.cpp
@@ -51,6 +51,7 @@ static void Usage(const char* pszErrorMsg, int bShort)
             "       [-if format]* [-of format]\n"
             "       [-b band] [-mask band] [-expand {gray|rgb|rgba}]\n"
             "       [-outsize xsize[%%]|0 ysize[%%]|0] [-tr xres yres]\n"
+            "       [-ovr level|AUTO|AUTO-n|NONE]\n"
             "       [-r {nearest,bilinear,cubic,cubicspline,lanczos,average,mode}]\n"
             "       [-unscale] [-scale[_bn] [src_min src_max [dst_min dst_max]]]* [-exponent[_bn] exp_val]*\n"
             "       [-srcwin xoff yoff xsize ysize] [-epo] [-eco]\n"

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -71,6 +71,12 @@ typedef enum
     MASK_USER
 } MaskMode;
 
+// those values shouldn't be changed, because overview levels >= 0 are meant
+// to be overview indices, and ovr_level < OVR_LEVEL_AUTO mean overview level
+// automatically selected minus (OVR_LEVEL_AUTO - ovr_level)
+constexpr int OVR_LEVEL_AUTO = -2;
+constexpr int OVR_LEVEL_NONE = -1;
+
 /************************************************************************/
 /*                         GDALTranslateScaleParams                     */
 /************************************************************************/
@@ -288,6 +294,9 @@ struct GDALTranslateOptions
 
     /*! does not copy source XMP into destination dataset (when TRUE) */
     bool bNoXMP;
+
+    /*! overview level of source file to be used */
+    int nOvLevel;
 };
 
 /************************************************************************/
@@ -712,10 +721,11 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
     if(psOptions->adfULLR[0] != 0.0 || psOptions->adfULLR[1] != 0.0 || psOptions->adfULLR[2] != 0.0 || psOptions->adfULLR[3] != 0.0)
         bGotBounds = true;
 
-    const char *pszSource = GDALGetDescription(hSrcDataset);
+    GDALDataset* poSrcDS = GDALDataset::FromHandle(hSrcDataset);
+    const char *pszSource = poSrcDS->GetDescription();
 
     if( strcmp(pszSource, pszDest) == 0 && pszSource[0] != '\0' &&
-        GDALGetDatasetDriver(hSrcDataset) != GDALGetDriverByName("MEM") )
+        poSrcDS->GetDriver() != GDALGetDriverByName("MEM") )
     {
         CPLError( CE_Failure, CPLE_AppDefined, "Source and destination datasets must be different.");
 
@@ -784,13 +794,10 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 /* -------------------------------------------------------------------- */
 /*      Collect some information from the source file.                  */
 /* -------------------------------------------------------------------- */
-    const int nRasterXSize = GDALGetRasterXSize( hSrcDataset );
-    const int nRasterYSize = GDALGetRasterYSize( hSrcDataset );
-
     if( psOptions->adfSrcWin[2] == 0 && psOptions->adfSrcWin[3] == 0 )
     {
-        psOptions->adfSrcWin[2] = nRasterXSize;
-        psOptions->adfSrcWin[3] = nRasterYSize;
+        psOptions->adfSrcWin[2] = poSrcDS->GetRasterXSize();
+        psOptions->adfSrcWin[3] = poSrcDS->GetRasterYSize();
     }
 
 /* -------------------------------------------------------------------- */
@@ -801,7 +808,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
     if( psOptions->panBandList == nullptr )
     {
 
-        psOptions->nBandCount = GDALGetRasterCount( hSrcDataset );
+        psOptions->nBandCount = poSrcDS->GetRasterCount();
         if( ( psOptions->nBandCount == 0 ) && (psOptions->bStrict ) )
         {
             // if not strict then the driver can fail if it doesn't support zero bands
@@ -820,12 +827,12 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         for( int i = 0; i < psOptions->nBandCount; i++ )
         {
             if( std::abs(psOptions->panBandList[i]) >
-                GDALGetRasterCount(hSrcDataset) )
+                poSrcDS->GetRasterCount() )
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Band %d requested, but only bands 1 to %d available.",
                          std::abs(psOptions->panBandList[i]),
-                         GDALGetRasterCount(hSrcDataset) );
+                         poSrcDS->GetRasterCount() );
                 GDALTranslateOptionsFree(psOptions);
                 return nullptr;
             }
@@ -834,7 +841,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
                 bAllBandsInOrder = FALSE;
         }
 
-        if( psOptions->nBandCount != GDALGetRasterCount( hSrcDataset ) )
+        if( psOptions->nBandCount != poSrcDS->GetRasterCount() )
             bAllBandsInOrder = FALSE;
     }
 
@@ -875,7 +882,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
     {
         double adfGeoTransform[6];
 
-        GDALGetGeoTransform( hSrcDataset, adfGeoTransform );
+        poSrcDS->GetGeoTransform( adfGeoTransform );
 
         if( adfGeoTransform[1] == 0.0 || adfGeoTransform[5] == 0.0 )
         {
@@ -896,7 +903,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
         if( !osProjSRS.empty() )
         {
-            pszProjection = GDALGetProjectionRef( hSrcDataset );
+            pszProjection = poSrcDS->GetProjectionRef();
             if( pszProjection != nullptr && strlen(pszProjection) > 0 )
             {
                 OGRSpatialReference oSRSIn;
@@ -972,14 +979,14 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 /*      Verify source window dimensions.                                */
 /* -------------------------------------------------------------------- */
     else if( psOptions->adfSrcWin[0] <= -1 || psOptions->adfSrcWin[1] <= -1
-        || psOptions->adfSrcWin[0] + psOptions->adfSrcWin[2] >= GDALGetRasterXSize(hSrcDataset) + 1
-        || psOptions->adfSrcWin[1] + psOptions->adfSrcWin[3] >= GDALGetRasterYSize(hSrcDataset) + 1 )
+        || psOptions->adfSrcWin[0] + psOptions->adfSrcWin[2] >= poSrcDS->GetRasterXSize() + 1
+        || psOptions->adfSrcWin[1] + psOptions->adfSrcWin[3] >= poSrcDS->GetRasterYSize() + 1 )
     {
         const bool bCompletelyOutside =
             psOptions->adfSrcWin[0] + psOptions->adfSrcWin[2] <= 0 ||
             psOptions->adfSrcWin[1] + psOptions->adfSrcWin[3] <= 0 ||
-            psOptions->adfSrcWin[0] >= GDALGetRasterXSize(hSrcDataset) ||
-            psOptions->adfSrcWin[1] >= GDALGetRasterYSize(hSrcDataset);
+            psOptions->adfSrcWin[0] >= poSrcDS->GetRasterXSize() ||
+            psOptions->adfSrcWin[1] >= poSrcDS->GetRasterYSize();
         const bool bIsError =
             psOptions->bErrorOnPartiallyOutside ||
             (bCompletelyOutside && psOptions->bErrorOnCompletelyOutside);
@@ -1076,7 +1083,6 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
                 // case of overwritten a .tif.ovr file from a .tif
                 // If we probe the file list of the .tif, it will then open the
                 // .tif.ovr !
-                auto poSrcDS = GDALDataset::FromHandle(hSrcDataset);
                 const char* const apszAllowedDrivers[] = {
                     poSrcDS->GetDriver() ? poSrcDS->GetDriver()->GetDescription() : nullptr, nullptr };
                 auto poSrcDSTmp = std::unique_ptr<GDALDataset>(
@@ -1117,11 +1123,11 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         // Make sure to load early overviews, so that on the GTiff driver
         // external .ovr is looked for before it might be created as the
         // output dataset !
-        if( GDALGetRasterCount( hSrcDataset ) )
+        if( poSrcDS->GetRasterCount() )
         {
-            auto hBand = GDALGetRasterBand(hSrcDataset, 1);
-            if( hBand )
-                GDALGetOverviewCount(hBand);
+            auto poBand = poSrcDS->GetRasterBand(1);
+            if( poBand )
+                poBand->GetOverviewCount();
         }
     }
 
@@ -1158,8 +1164,8 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
     const bool bSpatialArrangementPreserved =
         psOptions->adfSrcWin[0] == 0 && psOptions->adfSrcWin[1] == 0 &&
-        psOptions->adfSrcWin[2] == GDALGetRasterXSize(hSrcDataset) &&
-        psOptions->adfSrcWin[3] == GDALGetRasterYSize(hSrcDataset) &&
+        psOptions->adfSrcWin[2] == poSrcDS->GetRasterXSize() &&
+        psOptions->adfSrcWin[3] == poSrcDS->GetRasterYSize() &&
         psOptions->nOXSizePixel == 0 && psOptions->dfOXSizePct == 0.0 &&
         psOptions->nOYSizePixel == 0 && psOptions->dfOYSizePct == 0.0 &&
         psOptions->dfXRes == 0.0;
@@ -1177,27 +1183,27 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         && !psOptions->bSetNoData && !psOptions->bUnsetNoData
         && psOptions->nRGBExpand == 0 && !psOptions->bNoRAT
         && psOptions->panColorInterp == nullptr
-        && !psOptions->bNoXMP )
+        && !psOptions->bNoXMP
+        && psOptions->nOvLevel == OVR_LEVEL_AUTO )
     {
 
         // For gdal_translate_fuzzer
         if( psOptions->nLimitOutSize > 0 )
         {
             vsi_l_offset nRawOutSize =
-               static_cast<vsi_l_offset>(GDALGetRasterXSize(hSrcDataset)) *
-                GDALGetRasterYSize(hSrcDataset) *
+               static_cast<vsi_l_offset>(poSrcDS->GetRasterXSize()) *
+                poSrcDS->GetRasterYSize() *
                 psOptions->nBandCount;
             if( psOptions->nBandCount )
             {
-                nRawOutSize *= GDALGetDataTypeSizeBytes(
-                    static_cast<GDALDataset *>(hSrcDataset)->GetRasterBand(1)->GetRasterDataType() );
+                nRawOutSize *= GDALGetDataTypeSizeBytes(poSrcDS->GetRasterBand(1)->GetRasterDataType() );
             }
             if( nRawOutSize > static_cast<vsi_l_offset>(psOptions->nLimitOutSize) )
             {
                 CPLError( CE_Failure, CPLE_IllegalArg,
                           "Attempt to create %dx%d dataset is above authorized limit.",
-                          GDALGetRasterXSize(hSrcDataset),
-                          GDALGetRasterYSize(hSrcDataset) );
+                          poSrcDS->GetRasterXSize(),
+                          poSrcDS->GetRasterYSize() );
                 GDALTranslateOptionsFree(psOptions);
                 return nullptr;
             }
@@ -1208,7 +1214,6 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 /* -------------------------------------------------------------------- */
         if (psOptions->bStats)
         {
-            GDALDataset* poSrcDS = GDALDataset::FromHandle(hSrcDataset);
             for( int i = 0; i < poSrcDS->GetRasterCount(); i++ )
             {
                 double dfMin, dfMax, dfMean, dfStdDev;
@@ -1219,7 +1224,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
             }
         }
 
-        hOutDS = GDALCreateCopy( hDriver, pszDest, hSrcDataset,
+        hOutDS = GDALCreateCopy( hDriver, pszDest, GDALDataset::ToHandle(poSrcDS),
                                  psOptions->bStrict, psOptions->papszCreateOptions,
                                  psOptions->pfnProgress, psOptions->pProgressData );
         hOutDS = GDALTranslateFlush(hOutDS);
@@ -1244,9 +1249,12 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
     bool bHasSrcGeoTransform = false;
     double adfSrcGeoTransform[6] = {};
-    if( GDALGetGeoTransform( hSrcDataset, adfSrcGeoTransform ) == CE_None )
+    if( poSrcDS->GetGeoTransform( adfSrcGeoTransform ) == CE_None )
         bHasSrcGeoTransform = true;
 
+    const bool bOutsizeExplicitlySet =
+        !(psOptions->nOXSizePixel == 0 && psOptions->dfOXSizePct == 0.0 &&
+          psOptions->nOYSizePixel == 0 && psOptions->dfOYSizePct == 0.0);
     if( psOptions->dfXRes != 0.0 )
     {
         if( !(bHasSrcGeoTransform &&
@@ -1277,7 +1285,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         nOXSize = static_cast<int>(dfOXSize);
         nOYSize = static_cast<int>(dfOYSize);
     }
-    else if( psOptions->nOXSizePixel == 0 && psOptions->dfOXSizePct == 0.0 && psOptions->nOYSizePixel == 0 && psOptions->dfOYSizePct == 0.0)
+    else if( !bOutsizeExplicitlySet )
     {
         double dfOXSize = ceil(psOptions->adfSrcWin[2]-0.001);
         double dfOYSize = ceil(psOptions->adfSrcWin[3]-0.001);
@@ -1374,6 +1382,60 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         return nullptr;
     }
 
+    // Build overview dataset if -ovr is specified
+    GDALDataset* poSrcOvrDS = nullptr;
+    GDALDataset* poSrcDSOri = poSrcDS;
+    const int nOvCount = poSrcDS->GetRasterBand(1)->GetOverviewCount();
+    if( psOptions->nOvLevel < OVR_LEVEL_AUTO && nOvCount > 0 )
+    {
+        int iOvr = 0;
+        for( ; iOvr < nOvCount - 1; iOvr++ )
+        {
+            if( poSrcDS->GetRasterBand(1)->GetOverview(iOvr)->
+                        GetXSize() <= nOXSize )
+            {
+                break;
+            }
+        }
+        iOvr += (psOptions->nOvLevel - OVR_LEVEL_AUTO);
+        if( iOvr >= 0 )
+        {
+            CPLDebug("GDAL", "Selecting overview level %d", iOvr);
+            poSrcOvrDS = GDALCreateOverviewDataset( poSrcDS, iOvr,
+                                                    /* bThisLevelOnly = */true );
+        }
+    }
+    else if( psOptions->nOvLevel >= OVR_LEVEL_NONE )
+    {
+        poSrcOvrDS = GDALCreateOverviewDataset( poSrcDS, psOptions->nOvLevel,
+                                                /* bThisLevelOnly = */true );
+        if( poSrcOvrDS == nullptr )
+        {
+            if( !psOptions->bQuiet )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Cannot get overview level %d. Defaulting to level %d",
+                         psOptions->nOvLevel, nOvCount - 1);
+            }
+            if( nOvCount > 0 )
+                poSrcOvrDS = GDALCreateOverviewDataset( poSrcDS, nOvCount - 1,
+                                                        /* bThisLevelOnly = */true );
+        }
+        if( psOptions->dfXRes == 0.0 && !bOutsizeExplicitlySet )
+        {
+            const double dfRatioX = static_cast<double>(poSrcDSOri->GetRasterXSize()) / poSrcOvrDS->GetRasterXSize();
+            const double dfRatioY = static_cast<double>(poSrcDSOri->GetRasterYSize()) / poSrcOvrDS->GetRasterYSize();
+            nOXSize = std::max(1, static_cast<int>(ceil(nOXSize / dfRatioX - 0.001)));
+            nOYSize = std::max(1, static_cast<int>(ceil(nOYSize / dfRatioY - 0.001)));
+        }
+    }
+
+    if( poSrcOvrDS )
+        poSrcDS = poSrcOvrDS;
+    else
+        poSrcDS->Reference();
+
+
     // For gdal_translate_fuzzer
     if( psOptions->nLimitOutSize > 0 )
     {
@@ -1387,11 +1449,12 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
             }
             nRawOutSize *= psOptions->nBandCount;
             const int nDTSize = GDALGetDataTypeSizeBytes(
-                static_cast<GDALDataset *>(hSrcDataset)->GetRasterBand(1)->GetRasterDataType() );
+                poSrcDS->GetRasterBand(1)->GetRasterDataType() );
             if( nDTSize > 0 &&
                 nRawOutSize > std::numeric_limits<vsi_l_offset>::max() / nDTSize )
             {
                 GDALTranslateOptionsFree(psOptions);
+                poSrcDS->Release();
                 return nullptr;
             }
             nRawOutSize *= nDTSize;
@@ -1402,10 +1465,10 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
                       "Attempt to create %dx%d dataset is above authorized limit.",
                       nOXSize, nOYSize);
             GDALTranslateOptionsFree(psOptions);
+            poSrcDS->Release();
             return nullptr;
         }
     }
-
 
 /* ==================================================================== */
 /*      Create a virtual dataset.                                       */
@@ -1426,7 +1489,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         }
         else
         {
-            const OGRSpatialReference* poSrcSRS = GDALDataset::FromHandle(hSrcDataset)->GetSpatialRef();
+            const OGRSpatialReference* poSrcSRS = poSrcDS->GetSpatialRef();
             if( poSrcSRS )
                 oSRS = *poSrcSRS;
         }
@@ -1489,18 +1552,18 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         }
         else
         {
-            const OGRSpatialReference* poSrcSRS = GDALDataset::FromHandle(hSrcDataset)->GetGCPSpatialRef();
+            const OGRSpatialReference* poSrcSRS = poSrcDS->GetGCPSpatialRef();
             if( poSrcSRS )
                 oSRS = *poSrcSRS;
         }
         poVDS->SetGCPs( psOptions->nGCPCount, psOptions->pasGCPs, !oSRS.IsEmpty() ? &oSRS : nullptr );
     }
 
-    else if( !psOptions->bNoGCP && GDALGetGCPCount( hSrcDataset ) > 0 )
+    else if( !psOptions->bNoGCP && poSrcDSOri->GetGCPCount() > 0 )
     {
-        const int nGCPs = GDALGetGCPCount(hSrcDataset);
+        const int nGCPs = poSrcDSOri->GetGCPCount();
 
-        GDAL_GCP *pasGCPs = GDALDuplicateGCPs(nGCPs, GDALGetGCPs(hSrcDataset));
+        GDAL_GCP *pasGCPs = GDALDuplicateGCPs(nGCPs, poSrcDSOri->GetGCPs());
 
         for( int i = 0; i < nGCPs; i++ )
         {
@@ -1512,8 +1575,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
                 nOYSize / static_cast<double>(psOptions->adfSrcWin[3]);
         }
 
-        poVDS->SetGCPs( nGCPs, pasGCPs,
-                        GDALGetGCPProjection( hSrcDataset ) );
+        poVDS->SetGCPs( nGCPs, pasGCPs, poSrcDSOri->GetGCPSpatialRef() );
 
         GDALDeinitGCPs( nGCPs, pasGCPs );
         CPLFree( pasGCPs );
@@ -1542,14 +1604,18 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
     static_assert(sizeof(adfSrcWinOri) == sizeof(psOptions->adfSrcWin),
                   "inconsistent adfSrcWin size");
     memcpy(adfSrcWinOri, psOptions->adfSrcWin, sizeof(psOptions->adfSrcWin));
+    const double dfRatioX = static_cast<double>(poSrcDSOri->GetRasterXSize()) / poSrcDS->GetRasterXSize();
+    const double dfRatioY = static_cast<double>(poSrcDSOri->GetRasterYSize()) / poSrcDS->GetRasterYSize();
+    psOptions->adfSrcWin[0] /= dfRatioX;
+    psOptions->adfSrcWin[1] /= dfRatioY;
+    psOptions->adfSrcWin[2] /= dfRatioX;
+    psOptions->adfSrcWin[3] /= dfRatioY;
     FixSrcDstWindow( psOptions->adfSrcWin, adfDstWin,
-                     GDALGetRasterXSize(hSrcDataset),
-                     GDALGetRasterYSize(hSrcDataset) );
+                     poSrcDS->GetRasterXSize(), poSrcDS->GetRasterYSize() );
 
 /* -------------------------------------------------------------------- */
 /*      Transfer generally applicable metadata.                         */
 /* -------------------------------------------------------------------- */
-    GDALDataset* poSrcDS = GDALDataset::FromHandle(hSrcDataset);
     char** papszMetadata = CSLDuplicate(poSrcDS->GetMetadata());
     if ( psOptions->nScaleRepeat > 0 || psOptions->bUnscale || psOptions->eOutputType != GDT_Unknown )
     {
@@ -1571,8 +1637,8 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
     // Remove NITF_BLOCKA_ stuff if georeferencing is changed
     if( !(psOptions->adfSrcWin[0] == 0 && psOptions->adfSrcWin[1] == 0 &&
-          psOptions->adfSrcWin[2] == GDALGetRasterXSize(hSrcDataset) &&
-          psOptions->adfSrcWin[3] == GDALGetRasterYSize(hSrcDataset) &&
+          psOptions->adfSrcWin[2] == poSrcDS->GetRasterXSize() &&
+          psOptions->adfSrcWin[3] == poSrcDS->GetRasterYSize() &&
           psOptions->nGCPCount == 0 && !bGotBounds) )
     {
         char** papszIter = papszMetadata;
@@ -1605,9 +1671,9 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
     poVDS->SetMetadata( papszMetadata );
     CSLDestroy( papszMetadata );
-    AttachMetadata( static_cast<GDALDatasetH>(poVDS), psOptions->papszMetadataOptions );
+    AttachMetadata( GDALDataset::ToHandle(poVDS), psOptions->papszMetadataOptions );
 
-    const char* pszInterleave = GDALGetMetadataItem(hSrcDataset, "INTERLEAVE", "IMAGE_STRUCTURE");
+    const char* pszInterleave = poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
     if (pszInterleave)
         poVDS->SetMetadataItem("INTERLEAVE", pszInterleave, "IMAGE_STRUCTURE");
 
@@ -1626,7 +1692,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         if( !bAllBandsInOrder )
         {
             CPLString osJSON = EditISIS3MetadataForBandChange(
-                papszMD_ISIS3[0], GDALGetRasterCount( hSrcDataset ), psOptions);
+                papszMD_ISIS3[0], poSrcDS->GetRasterCount(), psOptions);
             if( !osJSON.empty() )
             {
                 char* apszMD[] = { &osJSON[0], nullptr };
@@ -1672,17 +1738,17 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 /* -------------------------------------------------------------------- */
     if( bSpatialArrangementPreserved )
     {
-        char **papszMD = poSrcDS->GetMetadata("RPC");
+        char **papszMD = poSrcDSOri->GetMetadata("RPC");
         if( papszMD != nullptr )
             poVDS->SetMetadata( papszMD, "RPC" );
 
-        papszMD = poSrcDS->GetMetadata("GEOLOCATION");
+        papszMD = poSrcDSOri->GetMetadata("GEOLOCATION");
         if( papszMD != nullptr )
             poVDS->SetMetadata( papszMD, "GEOLOCATION" );
     }
     else
     {
-        char **papszMD = poSrcDS->GetMetadata("RPC");
+        char **papszMD = poSrcDSOri->GetMetadata("RPC");
         if( papszMD != nullptr )
         {
             papszMD = CSLDuplicate(papszMD);
@@ -1724,8 +1790,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
     if (psOptions->nRGBExpand != 0)
     {
-        GDALRasterBand *poSrcBand =
-            static_cast<GDALDataset*>(hSrcDataset)->
+        GDALRasterBand *poSrcBand = poSrcDS->
                 GetRasterBand(std::abs(psOptions->panBandList[0]));
         if (psOptions->panBandList[0] < 0)
             poSrcBand = poSrcBand->GetMaskBand();
@@ -1807,8 +1872,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
             nSrcBand = psOptions->panBandList[i];
         }
 
-        GDALRasterBand *poSrcBand =
-            static_cast<GDALDataset*>(hSrcDataset)->GetRasterBand(std::abs(nSrcBand));
+        GDALRasterBand *poSrcBand = poSrcDS->GetRasterBand(std::abs(nSrcBand));
 
 /* -------------------------------------------------------------------- */
 /*      Select output data type to match source.                        */
@@ -2228,7 +2292,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
             poVRTBand->SetOffset( psOptions->dfOffset );
 
         if (psOptions->eMaskMode == MASK_AUTO &&
-            (GDALGetMaskFlags(GDALGetRasterBand(hSrcDataset, 1)) & GMF_PER_DATASET) == 0 &&
+            (poSrcDS->GetRasterBand(1)->GetMaskFlags() & GMF_PER_DATASET) == 0 &&
             (poSrcBand->GetMaskFlags() & (GMF_ALL_VALID | GMF_NODATA)) == 0)
         {
             if (poVRTBand->CreateMaskBand(poSrcBand->GetMaskFlags()) == CE_None)
@@ -2246,9 +2310,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
 
     if (psOptions->eMaskMode == MASK_USER)
     {
-        GDALRasterBand *poSrcBand =
-            static_cast<GDALRasterBand*>(GDALGetRasterBand(hSrcDataset,
-                                               std::abs(psOptions->nMaskBand)));
+        GDALRasterBand *poSrcBand = poSrcDS->GetRasterBand(std::abs(psOptions->nMaskBand));
         if (poSrcBand && poVDS->CreateMaskBand(GMF_PER_DATASET) == CE_None)
         {
             VRTSourcedRasterBand* hMaskVRTBand = static_cast<VRTSourcedRasterBand*>(
@@ -2269,13 +2331,13 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
     }
     else
     if (psOptions->eMaskMode == MASK_AUTO && nSrcBandCount > 0 &&
-        GDALGetMaskFlags(GDALGetRasterBand(hSrcDataset, 1)) == GMF_PER_DATASET)
+        poSrcDS->GetRasterBand(1)->GetMaskFlags() == GMF_PER_DATASET)
     {
         if (poVDS->CreateMaskBand(GMF_PER_DATASET) == CE_None)
         {
             VRTSourcedRasterBand* hMaskVRTBand = static_cast<VRTSourcedRasterBand*>(
                 GDALGetMaskBand(GDALGetRasterBand(static_cast<GDALDataset*>(poVDS), 1)));
-            hMaskVRTBand->AddMaskBandSource(static_cast<GDALRasterBand*>(GDALGetRasterBand(hSrcDataset, 1)),
+            hMaskVRTBand->AddMaskBandSource(poSrcDS->GetRasterBand(1),
                                         psOptions->adfSrcWin[0], psOptions->adfSrcWin[1],
                                         psOptions->adfSrcWin[2], psOptions->adfSrcWin[3],
                                         adfDstWin[0], adfDstWin[1],
@@ -2303,7 +2365,7 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         psOptions->papszCreateOptions == nullptr )
     {
         poVDS->SetDescription(pszDest);
-        hOutDS = static_cast<GDALDatasetH>(poVDS);
+        hOutDS = GDALDataset::ToHandle(poVDS);
         if( !EQUAL(pszDest, "") )
         {
             hOutDS = GDALTranslateFlush(hOutDS);
@@ -2311,13 +2373,15 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
     }
     else
     {
-        hOutDS = GDALCreateCopy( hDriver, pszDest, static_cast<GDALDatasetH>(poVDS),
+        hOutDS = GDALCreateCopy( hDriver, pszDest, GDALDataset::ToHandle(poVDS),
                                 psOptions->bStrict, psOptions->papszCreateOptions,
                                 psOptions->pfnProgress, psOptions->pProgressData );
         hOutDS = GDALTranslateFlush(hOutDS);
 
         GDALClose(poVDS);
     }
+
+    poSrcDS->Release();
 
     GDALTranslateOptionsFree(psOptions);
     return hOutDS;
@@ -2546,6 +2610,7 @@ GDALTranslateOptions *GDALTranslateOptionsNew(char** papszArgv, GDALTranslateOpt
     psOptions->pszProjSRS = nullptr;
     psOptions->nLimitOutSize = 0;
     psOptions->bNoXMP = false;
+    psOptions->nOvLevel = OVR_LEVEL_AUTO;
 
     bool bParsedMaskArgument = false;
     bool bOutsizeExplicitlySet = false;
@@ -3071,6 +3136,24 @@ GDALTranslateOptions *GDALTranslateOptionsNew(char** papszArgv, GDALTranslateOpt
             psOptions->bNoXMP = true;
         }
 
+        else if( EQUAL(papszArgv[i], "-ovr") && i+1 < argc )
+        {
+            const char* pszOvLevel = papszArgv[++i];
+            if( EQUAL(pszOvLevel, "AUTO") )
+                psOptions->nOvLevel = OVR_LEVEL_AUTO;
+            else if( STARTS_WITH_CI(pszOvLevel, "AUTO-") )
+                psOptions->nOvLevel = OVR_LEVEL_AUTO-atoi(pszOvLevel + strlen("AUTO-"));
+            else if( EQUAL(pszOvLevel, "NONE") )
+                psOptions->nOvLevel = OVR_LEVEL_NONE;
+            else if( CPLGetValueType(pszOvLevel) == CPL_VALUE_INTEGER )
+                psOptions->nOvLevel = atoi(pszOvLevel);
+            else
+            {
+                CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value '%s' for -ovr option", pszOvLevel);
+                GDALTranslateOptionsFree(psOptions);
+                return nullptr;
+            }
+        }
 
         else if( papszArgv[i][0] == '-' )
         {

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -870,6 +870,132 @@ def test_gdal_translate_lib_coord_epoch_is_dynamic():
 
 
 ###############################################################################
+# Test overviewLevel option
+
+
+def test_gdal_translate_lib_overview_level():
+
+    src_filename = "/vsimem/test_gdal_translate_lib_overview_level.tif"
+    try:
+        src_ds = gdal.Translate(src_filename, "../gcore/data/byte.tif")
+        src_ds.BuildOverviews("AVERAGE", [2])
+        src_ds.BuildOverviews("NONE", [4])
+
+        with gdaltest.error_handler():
+            with pytest.raises(Exception):
+                assert gdal.Translate("", src_ds, format="MEM", overviewLevel="invalid")
+
+        out_ds = gdal.Translate("", src_ds, format="MEM", overviewLevel="NONE")
+        assert out_ds.RasterXSize == 20
+        assert out_ds.RasterYSize == 20
+        assert out_ds.ReadRaster() == src_ds.ReadRaster()
+
+        out_ds = gdal.Translate("", src_ds, format="MEM", overviewLevel=0)
+        assert out_ds.RasterXSize == 10
+        assert out_ds.RasterYSize == 10
+        assert (
+            out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
+        )
+
+        out_ds = gdal.Translate("", src_ds, format="MEM", overviewLevel=1)
+        assert out_ds.RasterXSize == 5
+        assert out_ds.RasterYSize == 5
+        assert (
+            out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(1).ReadRaster()
+        )
+
+        out_ds = gdal.Translate("", src_ds, format="MEM", overviewLevel=2)
+        assert out_ds.RasterXSize == 5
+        assert out_ds.RasterYSize == 5
+        assert (
+            out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(1).ReadRaster()
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel="AUTO", widthPct=50, heightPct=50
+        )
+        assert out_ds.RasterXSize == 10
+        assert out_ds.RasterYSize == 10
+        assert (
+            out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
+        )
+
+        out_ds = gdal.Translate("", src_ds, format="MEM", widthPct=40, heightPct=40)
+        assert out_ds.RasterXSize == 8
+        assert out_ds.RasterYSize == 8
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster(
+            0, 0, 10, 10, 8, 8
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel=0, widthPct=25, heightPct=25
+        )
+        assert out_ds.RasterXSize == 5
+        assert out_ds.RasterYSize == 5
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster(
+            0, 0, 10, 10, 5, 5
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel=0, xRes=240, yRes=240
+        )
+        assert out_ds.RasterXSize == 5
+        assert out_ds.RasterYSize == 5
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster(
+            0, 0, 10, 10, 5, 5
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel=0, srcWin=[2, 2, 16, 16]
+        )
+        assert out_ds.RasterXSize == 8
+        assert out_ds.RasterYSize == 8
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster(
+            1, 1, 8, 8
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel="AUTO-1", widthPct=60, heightPct=60
+        )
+        assert out_ds.RasterXSize == 12
+        assert out_ds.RasterYSize == 12
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).ReadRaster(
+            0, 0, 20, 20, 12, 12
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel="AUTO-1", widthPct=40, heightPct=40
+        )
+        assert out_ds.RasterXSize == 8
+        assert out_ds.RasterYSize == 8
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster(
+            0, 0, 10, 10, 8, 8
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel="AUTO-1", widthPct=25, heightPct=25
+        )
+        assert out_ds.RasterXSize == 5
+        assert out_ds.RasterYSize == 5
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster(
+            0, 0, 10, 10, 5, 5
+        )
+
+        out_ds = gdal.Translate(
+            "", src_ds, format="MEM", overviewLevel="AUTO-1", widthPct=10, heightPct=10
+        )
+        assert out_ds.RasterXSize == 2
+        assert out_ds.RasterYSize == 2
+        assert out_ds.ReadRaster() == src_ds.GetRasterBand(1).GetOverview(0).ReadRaster(
+            0, 0, 10, 10, 2, 2
+        )
+
+    finally:
+        src_ds = None
+        gdal.Unlink(src_filename)
+
+
+###############################################################################
 # Cleanup
 
 

--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -22,6 +22,7 @@ Synopsis
         [-if format]* [-of format]
         [-b band]* [-mask band] [-expand {gray|rgb|rgba}]
         [-outsize xsize[%]|0 ysize[%]|0] [-tr xres yres]
+        [-ovr level|AUTO|AUTO-n|NONE]
         [-r {nearest,bilinear,cubic,cubicspline,lanczos,average,rms,mode}]
         [-unscale] [-scale[_bn] [src_min src_max [dst_min dst_max]]]* [-exponent[_bn] exp_val]*
         [-srcwin xoff yoff xsize ysize] [-epo] [-eco]
@@ -95,6 +96,28 @@ resampling, and rescaling pixels in the process.
     set target resolution. The values must be expressed in georeferenced units.
     Both must be positive values. This is mutually exclusive with
     :option:`-outsize` and :option:`-a_ullr`.
+
+.. option:: -ovr <level|AUTO|AUTO-n|NONE>
+
+    .. versionadded:: 3.6
+
+    To specify which overview level of source file must be used. The default choice,
+    AUTO, will select the overview level whose resolution is the closest to the
+    target resolution. Specify an integer value (0-based, i.e. 0=1st overview level)
+    to select a particular level. Specify AUTO-n where n is an integer greater or
+    equal to 1, to select an overview level below the AUTO one. Or specify NONE to
+    force the base resolution to be used (can be useful if overviews have been
+    generated with a low quality resampling method, and a higher quality resampling method
+    is specified with :option:`-r`.
+
+    When :option:`-ovr` is specified to an integer value,
+    and none of :option:`-outsize` and :option:`-tr` is specified, the size of
+    the overview will be used as the output size.
+
+    When :option:`-ovr` is specified, values of :option:`-srcwin`, when specified,
+    should be expressed as pixel offset and size of the full resolution source dataset.
+    Similarly when using :option:`-outsize` with percentage values, they refer to the size
+    of the full resolution source dataset.
 
 .. option:: -r {nearest (default),bilinear,cubic,cubicspline,lanczos,average,rms,mode}
 

--- a/gcore/gdaloverviewdataset.cpp
+++ b/gcore/gdaloverviewdataset.cpp
@@ -278,6 +278,9 @@ int GDALOverviewDataset::CloseDependentDatasets()
 {
     bool bRet = false;
 
+    if( poOvrDS )
+        poOvrDS->SetEnableOverviews(true);
+
     if( poMainDS )
     {
         for( int i = 0; i < nBands; ++i )

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1488,6 +1488,7 @@ def TranslateOptions(options=None, format=None,
               outputSRS=None, nogcp=False, GCPs=None,
               noData=None, rgbExpand=None,
               stats = False, rat = True, xmp = True, resampleAlg=None,
+              overviewLevel = 'AUTO',
               callback=None, callback_data=None):
     """Create a TranslateOptions() object that can be passed to gdal.Translate()
 
@@ -1553,6 +1554,8 @@ def TranslateOptions(options=None, format=None,
         whether to copy XMP metadata
     resampleAlg:
         resampling mode
+    overviewLevel:
+        To specify which overview level of source files must be used
     callback:
         callback method
     callback_data:
@@ -1639,6 +1642,19 @@ def TranslateOptions(options=None, format=None,
                 new_options += ['-r', str(resampleAlg)]
         if xRes != 0 and yRes != 0:
             new_options += ['-tr', _strHighPrec(xRes), _strHighPrec(yRes)]
+
+        if overviewLevel is None or isinstance(overviewLevel, str):
+            pass
+        elif isinstance(overviewLevel, int):
+            if overviewLevel < 0:
+                overviewLevel = 'AUTO' + str(overviewLevel)
+            else:
+                overviewLevel = str(overviewLevel)
+        else:
+            overviewLevel = None
+
+        if overviewLevel is not None and overviewLevel != 'AUTO':
+            new_options += ['-ovr', overviewLevel]
 
     if return_option_list:
         return new_options

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -325,6 +325,7 @@ def TranslateOptions(options=None, format=None,
               outputSRS=None, nogcp=False, GCPs=None,
               noData=None, rgbExpand=None,
               stats = False, rat = True, xmp = True, resampleAlg=None,
+              overviewLevel = 'AUTO',
               callback=None, callback_data=None):
     """Create a TranslateOptions() object that can be passed to gdal.Translate()
 
@@ -390,6 +391,8 @@ def TranslateOptions(options=None, format=None,
         whether to copy XMP metadata
     resampleAlg:
         resampling mode
+    overviewLevel:
+        To specify which overview level of source files must be used
     callback:
         callback method
     callback_data:
@@ -476,6 +479,19 @@ def TranslateOptions(options=None, format=None,
                 new_options += ['-r', str(resampleAlg)]
         if xRes != 0 and yRes != 0:
             new_options += ['-tr', _strHighPrec(xRes), _strHighPrec(yRes)]
+
+        if overviewLevel is None or isinstance(overviewLevel, str):
+            pass
+        elif isinstance(overviewLevel, int):
+            if overviewLevel < 0:
+                overviewLevel = 'AUTO' + str(overviewLevel)
+            else:
+                overviewLevel = str(overviewLevel)
+        else:
+            overviewLevel = None
+
+        if overviewLevel is not None and overviewLevel != 'AUTO':
+            new_options += ['-ovr', overviewLevel]
 
     if return_option_list:
         return new_options


### PR DESCRIPTION
    To specify which overview level of source file must be used. The default choice,
    AUTO, will select the overview level whose resolution is the closest to the
    target resolution. Specify an integer value (0-based, i.e. 0=1st overview level)
    to select a particular level. Specify AUTO-n where n is an integer greater or
    equal to 1, to select an overview level below the AUTO one. Or specify NONE to
    force the base resolution to be used (can be useful if overviews have been
    generated with a low quality resampling method, and a higher quality resampling method
    is specified with :option:`-r`.

    When :option:`-ovr` is specified to an integer value,
    and none of :option:`-outsize` and :option:`-tr` is specified, the size of
    the overview will be used as the output size.

    When :option:`-ovr` is specified, values of :option:`-srcwin`, when specified,
    should be expressed as pixel offset and size of the full resolution source dataset.
    Similarly when using :option:`-outsize` with percentage values, they refer to the size
    of the full resolution source dataset.