### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -256,6 +256,23 @@ available at https://anaconda.org/conda-forge/gdal.
 
     conda install -c conda-forge gdal
 
+Vcpkg
+................................................................................
+
+The gdal port in vcpkg is kept up to date by Microsoft team members and community contributors.
+The url of vcpkg is: https://github.com/Microsoft/vcpkg .
+You can download and install gdal using the vcpkg dependency manager:
+
+::
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+    ./vcpkg integrate install
+    ./vcpkg install gdal
+
+If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`__ on the vcpkg repository.
+
 
 Linux Docker images
 ................................................................................


### PR DESCRIPTION
Gdal is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for gdal and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build gdal, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/gdal/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.