### PR TITLE
gdalinfo -json: fix eo:bands in stac output

### DIFF
--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -918,6 +918,12 @@ char *GDALInfo( GDALDatasetH hDataset, const GDALInfoOptions *psOptions )
                         GDALGetRasterColorInterpretation(hBand)) );
         }
 
+        if (bJson)
+        {
+            json_object *poBandName = json_object_new_string(CPLSPrintf("b%i", iBand + 1));
+            json_object_object_add(poStacEOBand, "name", poBandName);
+        }
+
         if( GDALGetDescription( hBand ) != nullptr
             && strlen(GDALGetDescription( hBand )) > 0 )
         {
@@ -936,6 +942,17 @@ char *GDALInfo( GDALDatasetH hDataset, const GDALInfoOptions *psOptions )
             {
                 Concat( osStr, psOptions->bStdoutOutput, "  Description = %s\n",
                         GDALGetDescription(hBand) );
+            }
+        }
+        else
+        {
+            if (bJson)
+            {
+                json_object *poColorInterp =
+                    json_object_new_string(
+                        GDALGetColorInterpretationName(
+                            GDALGetRasterColorInterpretation(hBand)));
+                json_object_object_add(poStacEOBand, "description", poColorInterp);
             }
         }
 

--- a/autotest/utilities/test_gdalinfo.py
+++ b/autotest/utilities/test_gdalinfo.py
@@ -1155,6 +1155,9 @@ def test_gdalinfo_stac_json():
     assert "histogram" in raster_band
 
     assert len(stac["eo:bands"]) == 1
+    band = stac["eo:bands"][0]
+    assert band["name"] == "b1"
+    assert band["description"] == "Gray"
 
     # Test eo:bands cloud_cover
     # https://github.com/OSGeo/gdal/pull/6265#issuecomment-1232229669


### PR DESCRIPTION
## What does this PR do?

We auto-populate the band name and description so we don't have empty eo:bands (empty are invalid [per the extension](https://github.com/stac-extensions/eo#band-object)).

```shell
$  gdalinfo -json autotest/gcore/data/md_dg.tif | jq  '.stac."eo:bands"'   
[
  {
    "name": "b1",
    "description": "Red"
  },
  {
    "name": "b2",
    "description": "Green"
  },
  {
    "name": "b3",
    "description": "Blue"
  }
]
```

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/6265#issuecomment-1235671013

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed