### PR TITLE
nearblack: skip erosion when pixel at edge is valid

### DIFF
--- a/apps/nearblack_lib.cpp
+++ b/apps/nearblack_lib.cpp
@@ -75,9 +75,9 @@ struct GDALNearblackOptions
 
 static void ProcessLine( GByte *pabyLine, GByte *pabyMask, int iStart,
                          int iEnd, int nSrcBands, int nDstBands, int nNearDist,
-                         int nMaxNonBlack, bool bNearWhite, Colors *poColors,
+                         int nMaxNonBlack, bool bNearWhite, const Colors *poColors,
                          int *panLastLineCounts, bool bDoHorizontalCheck,
-                         bool bDoVerticalCheck, bool bBottomUp );
+                         bool bDoVerticalCheck, bool bBottomUp, int iLineFromTopOrBottom );
 
 /************************************************************************/
 /*                            GDALNearblack()                           */
@@ -389,14 +389,16 @@ GDALDatasetH CPL_DLL GDALNearblack( const char *pszDest, GDALDatasetH hDstDS,
                     panLastLineCounts,
                     true, // bDoHorizontalCheck
                     true, // bDoVerticalCheck
-                    false // bBottomUp
+                    false, // bBottomUp
+                    iLine
                     );
         ProcessLine(pabyLine, pabyMask, nXSize-1, 0, nBands, nDstBands,
                     nNearDist, nMaxNonBlack, bNearWhite, &oColors,
                     panLastLineCounts,
                     true,  // bDoHorizontalCheck
                     false, // bDoVerticalCheck
-                    false  // bBottomUp
+                    false,  // bBottomUp
+                    iLine
                     );
 
         eErr = GDALDatasetRasterIO(hDstDS, GF_Write, 0, iLine, nXSize, 1,
@@ -482,14 +484,16 @@ GDALDatasetH CPL_DLL GDALNearblack( const char *pszDest, GDALDatasetH hDstDS,
                     panLastLineCounts,
                     true, // bDoHorizontalCheck
                     true, // bDoVerticalCheck
-                    true  // bBottomUp
+                    true,  // bBottomUp
+                    nYSize-1-iLine
                     );
         ProcessLine(pabyLine, pabyMask, nXSize-1, 0, nBands, nDstBands,
                     nNearDist, nMaxNonBlack, bNearWhite, &oColors,
                     panLastLineCounts,
                     true,  // bDoHorizontalCheck
                     false, // bDoVerticalCheck
-                    true   // bBottomUp
+                    true,   // bBottomUp
+                    nYSize-1-iLine
                     );
 
         eErr = GDALDatasetRasterIO(hDstDS, GF_Write, 0, iLine, nXSize, 1,
@@ -548,9 +552,10 @@ GDALDatasetH CPL_DLL GDALNearblack( const char *pszDest, GDALDatasetH hDstDS,
 
 static void ProcessLine( GByte *pabyLine, GByte *pabyMask, int iStart,
                          int iEnd, int nSrcBands, int nDstBands, int nNearDist,
-                         int nMaxNonBlack, bool bNearWhite, Colors *poColors,
+                         int nMaxNonBlack, bool bNearWhite, const Colors *poColors,
                          int *panLastLineCounts, bool bDoHorizontalCheck,
-                         bool bDoVerticalCheck, bool bBottomUp )
+                         bool bDoVerticalCheck, bool bBottomUp,
+                         int iLineFromTopOrBottom )
 {
     const GByte nReplacevalue = bNearWhite ? 255 : 0;
 
@@ -605,6 +610,14 @@ static void ProcessLine( GByte *pabyLine, GByte *pabyMask, int iStart,
 
                 if( panLastLineCounts[i] > nMaxNonBlack )
                     continue;
+
+                if( iLineFromTopOrBottom == 0 && nMaxNonBlack > 0 )
+                {
+                    // if there's a valid value just at the top or bottom
+                    // of the raster, then ignore the nMaxNonBlack setting
+                    panLastLineCounts[i] = nMaxNonBlack + 1;
+                    continue;
+                }
             }
             //else
             //  panLastLineCounts[i] = 0; // not sure this even makes sense
@@ -689,6 +702,14 @@ static void ProcessLine( GByte *pabyLine, GByte *pabyMask, int iStart,
                 }
 
                 if( nNonBlackPixels > nMaxNonBlack ) {
+                    bDoTest = false;
+                    continue;
+                }
+
+                if( bIsNonBlack && nMaxNonBlack > 0 && i == iStart )
+                {
+                    // if there's a valid value just at the left or right
+                    // of the raster, then ignore the nMaxNonBlack setting
                     bDoTest = false;
                     continue;
                 }

--- a/autotest/utilities/test_nearblack_lib.py
+++ b/autotest/utilities/test_nearblack_lib.py
@@ -30,6 +30,8 @@
 ###############################################################################
 
 
+import array
+
 import pytest
 
 from osgeo import gdal
@@ -179,3 +181,220 @@ def test_nearblack_lib_8():
     assert ds.GetRasterBand(2).Checksum() == 20736, "Bad checksum band 2"
 
     assert ds.GetRasterBand(3).Checksum() == 21309, "Bad checksum band 3"
+
+
+def _test_nearblack(in_array, expected_mask_array, maxNonBlack=0):
+
+    ds = gdal.GetDriverByName("MEM").Create("", len(in_array[0]), len(in_array))
+    ds.WriteRaster(
+        0,
+        0,
+        ds.RasterXSize,
+        ds.RasterYSize,
+        b"".join([array.array("B", x).tobytes() for x in in_array]),
+    )
+    ret_ds = gdal.Nearblack("", ds, maxNonBlack=maxNonBlack, format="MEM", setMask=True)
+    mask_data = ret_ds.GetRasterBand(1).GetMaskBand().ReadRaster()
+    mask_array = []
+    for j in range(ds.RasterYSize):
+        ar = array.array("B")
+        ar.frombytes(mask_data[j * ds.RasterXSize : (j + 1) * ds.RasterXSize])
+        mask_array.append(ar.tolist())
+    assert mask_array == expected_mask_array
+
+
+def test_nearblack_lib_9():
+
+    # all valid -> no erosion
+    _test_nearblack(
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        maxNonBlack=1,
+    )
+
+    # all invalid
+    _test_nearblack(
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+        ],
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+        ],
+        maxNonBlack=1,
+    )
+
+    # single pixel valid -> eroded
+    _test_nearblack(
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 255, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+        ],
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+        ],
+        maxNonBlack=1,
+    )
+
+    # all countour is valid -> no erosion
+    _test_nearblack(
+        [
+            [255, 255, 255, 255, 255],
+            [255, 0, 0, 0, 255],
+            [255, 0, 0, 0, 255],
+            [255, 0, 0, 0, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        maxNonBlack=1,
+    )
+
+    # erosion from the left
+    _test_nearblack(
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [0, 0, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [0, 0, 0, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        maxNonBlack=1,
+    )
+
+    # erosion from the right
+    _test_nearblack(
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 0, 0],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 0, 0, 0],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        maxNonBlack=1,
+    )
+
+    # erosion from the top
+    _test_nearblack(
+        [
+            [255, 0, 0, 0, 255],
+            [255, 255, 0, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        [
+            [255, 0, 0, 0, 255],
+            [255, 0, 0, 0, 255],
+            [255, 255, 0, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+        ],
+        maxNonBlack=1,
+    )
+
+    # erosion from the bottom
+    _test_nearblack(
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 0, 255, 255],
+            [255, 0, 0, 0, 255],
+        ],
+        [
+            [255, 255, 255, 255, 255],
+            [255, 255, 255, 255, 255],
+            [255, 255, 0, 255, 255],
+            [255, 0, 0, 0, 255],
+            [255, 0, 0, 0, 255],
+        ],
+        maxNonBlack=1,
+    )
+
+    # Maybe erosion is a bit too greedy due to top-bottom + bottom-top passes
+    _test_nearblack(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 255, 255, 255, 0, 0],
+            [0, 0, 255, 255, 255, 0, 0],
+            [0, 255, 255, 255, 255, 255, 0],
+            [0, 0, 255, 255, 255, 0, 0],
+            [0, 0, 255, 255, 255, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ],
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 255, 0, 0, 0],
+            [0, 0, 0, 255, 0, 0, 0],
+            [0, 0, 0, 255, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ],
+        maxNonBlack=1,
+    )
+
+    # Maybe erosion is a bit too greedy due to top-bottom + bottom-top passes
+    _test_nearblack(
+        [
+            [0, 0, 0, 0, 255],
+            [0, 255, 255, 0, 0],
+            [255, 255, 255, 255, 255],
+            [255, 0, 255, 255, 0],
+            [0, 0, 0, 255, 0],
+        ],
+        [
+            [0, 0, 0, 0, 255],
+            [0, 0, 0, 0, 0],
+            [0, 0, 255, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+        ],
+        maxNonBlack=1,
+    )


### PR DESCRIPTION
Before this change, we would systematically erode non_black_pixels from
the top/bottom/left/right edges even when they were valid. Only consider erosion
if those edges pixels are invalid/black.
