### PR TITLE
Configuration file: add a ignore-env-vars=yes setting

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -3820,7 +3820,7 @@ namespace tut
         ensure( CPLGetConfigOption("SOME_ENV_VAR_FOR_TEST_CPL_61", nullptr) != nullptr );
 
         VSILFILE* fp = VSIFOpenL("/vsimem/.gdal/gdalrc", "wb");
-        VSIFPrintfL(fp, "[general]\n");
+        VSIFPrintfL(fp, "[directives]\n");
         VSIFPrintfL(fp, "ignore-env-vars=yes\n");
         VSIFPrintfL(fp, "[configoptions]\n");
         VSIFPrintfL(fp, "CONFIG_OPTION_FOR_TEST_CPL_61=BAR\n");
@@ -3837,7 +3837,7 @@ namespace tut
 
         // Reset ignore-env-vars=no
         fp = VSIFOpenL("/vsimem/.gdal/gdalrc", "wb");
-        VSIFPrintfL(fp, "[general]\n");
+        VSIFPrintfL(fp, "[directives]\n");
         VSIFPrintfL(fp, "ignore-env-vars=no\n");
         VSIFPrintfL(fp, "[configoptions]\n");
         VSIFPrintfL(fp, "SOME_ENV_VAR_FOR_TEST_CPL_61=BAR\n");

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -3810,6 +3810,50 @@ namespace tut
 #endif
     }
 
+    // Test ignore-env-vars = yes of configuration file
+    template<>
+    template<>
+    void object::test<61>()
+    {
+        char szEnvVar[] = "SOME_ENV_VAR_FOR_TEST_CPL_61=FOO";
+        putenv(szEnvVar);
+        ensure( CPLGetConfigOption("SOME_ENV_VAR_FOR_TEST_CPL_61", nullptr) != nullptr );
+
+        VSILFILE* fp = VSIFOpenL("/vsimem/.gdal/gdalrc", "wb");
+        VSIFPrintfL(fp, "[general]\n");
+        VSIFPrintfL(fp, "ignore-env-vars=yes\n");
+        VSIFPrintfL(fp, "[configoptions]\n");
+        VSIFPrintfL(fp, "CONFIG_OPTION_FOR_TEST_CPL_61=BAR\n");
+        VSIFCloseL(fp);
+
+        // Load configuration file
+        CPLLoadConfigOptionsFromFile("/vsimem/.gdal/gdalrc", false);
+
+        // Check that reading configuration option works
+        ensure( EQUAL(CPLGetConfigOption("CONFIG_OPTION_FOR_TEST_CPL_61", ""), "BAR") );
+
+        // Check that environment variables are not read as configuration options
+        ensure( CPLGetConfigOption("SOME_ENV_VAR_FOR_TEST_CPL_61", nullptr) == nullptr );
+
+        // Reset ignore-env-vars=no
+        fp = VSIFOpenL("/vsimem/.gdal/gdalrc", "wb");
+        VSIFPrintfL(fp, "[general]\n");
+        VSIFPrintfL(fp, "ignore-env-vars=no\n");
+        VSIFPrintfL(fp, "[configoptions]\n");
+        VSIFPrintfL(fp, "SOME_ENV_VAR_FOR_TEST_CPL_61=BAR\n");
+        VSIFCloseL(fp);
+
+        // Reload configuration file
+        CPLLoadConfigOptionsFromFile("/vsimem/.gdal/gdalrc", false);
+
+        // Check that environment variables are read as configuration options
+        // and override configuration options
+        ensure( CPLGetConfigOption("SOME_ENV_VAR_FOR_TEST_CPL_61", nullptr) != nullptr );
+        ensure_equals( std::string(CPLGetConfigOption("SOME_ENV_VAR_FOR_TEST_CPL_61", "")), std::string("FOO") );
+
+        VSIUnlink("/vsimem/.gdal/gdalrc");
+    }
+
     // WARNING: keep that line at bottom and read carefully:
     // If the number of tests reaches 100, increase the MAX_NUMBER_OF_TESTS
     // define at top of this file (and update this comment!)

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -90,8 +90,11 @@ The following locations are tried by :cpp:func:`CPLLoadConfigOptionsFromPredefin
  - for Windows builds, the location pointed by $(USERPROFILE)/.gdal/gdalrc
    is attempted.
 
-A configuration file is a text file in a .ini style format, that lists
-configuration options and their values. Lines starting with `#` are comment lines.
+A configuration file is a text file in a .ini style format.
+Lines starting with `#` are comment lines.
+
+The file may contain a ``[configoptions]`` section, that lists configuration
+options and their values.
 
 Example:
 
@@ -107,7 +110,42 @@ by calls to :cpp:func:`CPLSetConfigOption` or  :cpp:func:`CPLSetThreadLocalConfi
 or through the ``--config`` command line switch.
 
 The value of environment variables set before GDAL starts will be used instead
-of the value set in the configuration files.
+of the value set in the configuration files, unless, starting with GDAL 3.6,
+the configuration file starts with a ``[general]`` section that contains a
+``ignore-env-variables=yes`` entry.
+
+.. code-block::
+
+    [general]
+    # ignore environent variables. Take only into account the content of the
+    # [configoptions] section, or ones defined programmatically with
+    # CPLSetConfigOption / CPLSetThreadLocalConfigOption.
+    ignore-env-variables=yes
+
+
+Starting with GDAL 3.5, a configuration file can also contain credentials
+(or more generally options related to a virtual file system) for a given path prefix,
+that can also be set with :cpp:func:`VSISetCredential`. Credentials should be put under
+a ``[credentials]`` section, and for each path prefix, under a relative subsection
+whose name starts with "[." (e.g. "[.some_arbitrary_name]"), and whose first
+key is "path".
+
+Example:
+
+.. code-block::
+
+    [credentials]
+
+    [.private_bucket]
+    path=/vsis3/my_private_bucket
+    AWS_SECRET_ACCESS_KEY=...
+    AWS_ACCESS_KEY_ID=...
+
+    [.sentinel_s2_l1c]
+    path=/vsis3/sentinel-s2-l1c
+    AWS_REQUEST_PAYER=requester
+    \endverbatim
+
 
 .. _list_config_options:
 

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -111,12 +111,12 @@ or through the ``--config`` command line switch.
 
 The value of environment variables set before GDAL starts will be used instead
 of the value set in the configuration files, unless, starting with GDAL 3.6,
-the configuration file starts with a ``[general]`` section that contains a
+the configuration file starts with a ``[directives]`` section that contains a
 ``ignore-env-variables=yes`` entry.
 
 .. code-block::
 
-    [general]
+    [directives]
     # ignore environent variables. Take only into account the content of the
     # [configoptions] section, or ones defined programmatically with
     # CPLSetConfigOption / CPLSetThreadLocalConfigOption.

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -103,6 +103,7 @@ CPL_CVSID("$Id$")
 
 static CPLMutex *hConfigMutex = nullptr;
 static volatile char **g_papszConfigOptions = nullptr;
+static bool gbIgnoreEnvVariables = false; // if true, only take into account configuration options set through configuration file or CPLSetConfigOption()/CPLSetThreadLocalConfigOption()
 
 // Used by CPLOpenShared() and friends.
 static CPLMutex *hSharedFileMutex = nullptr;
@@ -1699,7 +1700,25 @@ CPLGetConfigOption( const char *pszKey, const char *pszDefault )
     }
 
     if( pszResult == nullptr )
-        pszResult = getenv(pszKey);
+    {
+#if !defined(DEBUG)
+        if( !gbIgnoreEnvVariables )
+        {
+            pszResult = getenv(pszKey);
+        }
+#else
+        const char* pszEnvVar = getenv(pszKey);
+        if( pszEnvVar && gbIgnoreEnvVariables )
+        {
+            CPLDebugOnly("GDAL", "Ignoring environment variable %s=%s",
+                         pszKey, pszEnvVar);
+        }
+        else
+        {
+            pszResult = pszEnvVar;
+        }
+#endif
+    }
 
     if( pszResult == nullptr )
         return pszDefault;
@@ -2028,6 +2047,12 @@ path=/vsis3/sentinel-s2-l1c
 AWS_REQUEST_PAYER=requester
 \endverbatim
 
+Starting with GDAL 3.6, a leading [general] section might be added with
+a "ignore-env-vars=yes" setting to indicate that, starting with that point,
+all environment variables should be ignored, and only configuration options
+defined in the [configoptions] sections or through the CPLSetConfigOption() /
+CPLSetThreadLocalConfigOption() functions should be taken into account.
+
 This function is typically called by CPLLoadConfigOptionsFromPredefinedFiles()
 
 @param pszFilename File where to load configuration from.
@@ -2042,10 +2067,17 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
         return;
     CPLDebug("CPL", "Loading configuration from %s", pszFilename);
     const char* pszLine;
-    bool bInConfigOptions = false;
-    bool bInCredentials = false;
+    enum class Section
+    {
+        NONE,
+        GENERAL,
+        CONFIG_OPTIONS,
+        CREDENTIALS,
+    };
+    Section eCurrentSection = Section::NONE;
     bool bInSubsection = false;
     std::string osPath;
+    int nSectionCounter = 0;
 
     const auto IsSpaceOnly = [](const char* pszStr)
     {
@@ -2069,17 +2101,48 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
         }
         else if( strcmp(pszLine, "[configoptions]") == 0 )
         {
-            bInConfigOptions = true;
-            bInCredentials = false;
+            nSectionCounter ++;
+            eCurrentSection = Section::CONFIG_OPTIONS;
         }
         else if( strcmp(pszLine, "[credentials]") == 0 )
         {
-            bInConfigOptions = false;
-            bInCredentials = true;
+            nSectionCounter ++;
+            eCurrentSection = Section::CREDENTIALS;
             bInSubsection = false;
             osPath.clear();
         }
-        else if( bInCredentials )
+        else if( strcmp(pszLine, "[general]") == 0 )
+        {
+            nSectionCounter ++;
+            if( nSectionCounter != 1 )
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "The [general] section should be the first one in "
+                         "the file, otherwise some its settings might not be "
+                         "used correctly.");
+            }
+            eCurrentSection = Section::GENERAL;
+        }
+        else if( eCurrentSection == Section::GENERAL )
+        {
+            char* pszKey = nullptr;
+            const char* pszValue = CPLParseNameValue(pszLine, &pszKey);
+            if( pszKey && pszValue )
+            {
+                if( strcmp(pszKey, "ignore-env-vars") == 0 )
+                {
+                    gbIgnoreEnvVariables = CPLTestBool(pszValue);
+                }
+                else
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Ignoring %s line in [general] section",
+                             pszLine);
+                }
+            }
+            CPLFree(pszKey);
+        }
+        else if( eCurrentSection == Section::CREDENTIALS )
         {
             if( strncmp(pszLine, "[.", 2) == 0 )
             {
@@ -2121,8 +2184,7 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
             }
             else if( pszLine[0] == '[' )
             {
-                bInConfigOptions = false;
-                bInCredentials = false;
+                eCurrentSection = Section::NONE;
             }
             else
             {
@@ -2133,16 +2195,15 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
         }
         else if( pszLine[0] == '[' )
         {
-            bInConfigOptions = false;
-            bInCredentials = false;
+            eCurrentSection = Section::NONE;
         }
-        else if( bInConfigOptions )
+        else if( eCurrentSection == Section::CONFIG_OPTIONS )
         {
             char* pszKey = nullptr;
             const char* pszValue = CPLParseNameValue(pszLine, &pszKey);
             if( pszKey && pszValue )
             {
-                if( bOverrideEnvVars || getenv(pszKey) == nullptr )
+                if( bOverrideEnvVars || gbIgnoreEnvVariables || getenv(pszKey) == nullptr )
                 {
                     CPLDebugOnly("CPL",
                                  "Setting configuration option %s=%s",
@@ -2183,7 +2244,8 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
  *
  * CPLLoadConfigOptionsFromFile() will be called with bOverrideEnvVars = false,
  * that is the value of environment variables previously set will be used instead
- * of the value set in the configuration files.
+ * of the value set in the configuration files (unless the configuration file
+ * contains a leading [general] section with a "ignore-env-vars=yes" setting).
  *
  * This function is automatically called by GDALDriverManager() constructor
  *

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -2042,7 +2042,7 @@ path=/vsis3/sentinel-s2-l1c
 AWS_REQUEST_PAYER=requester
 \endverbatim
 
-Starting with GDAL 3.6, a leading [general] section might be added with
+Starting with GDAL 3.6, a leading [directives] section might be added with
 a "ignore-env-vars=yes" setting to indicate that, starting with that point,
 all environment variables should be ignored, and only configuration options
 defined in the [configoptions] sections or through the CPLSetConfigOption() /
@@ -2106,13 +2106,13 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
             bInSubsection = false;
             osPath.clear();
         }
-        else if( strcmp(pszLine, "[general]") == 0 )
+        else if( strcmp(pszLine, "[directives]") == 0 )
         {
             nSectionCounter ++;
             if( nSectionCounter != 1 )
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
-                         "The [general] section should be the first one in "
+                         "The [directives] section should be the first one in "
                          "the file, otherwise some its settings might not be "
                          "used correctly.");
             }
@@ -2131,7 +2131,7 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
                 else
                 {
                     CPLError(CE_Warning, CPLE_AppDefined,
-                             "Ignoring %s line in [general] section",
+                             "Ignoring %s line in [directives] section",
                              pszLine);
                 }
             }
@@ -2241,7 +2241,7 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
  * CPLLoadConfigOptionsFromFile() will be called with bOverrideEnvVars = false,
  * that is the value of environment variables previously set will be used instead
  * of the value set in the configuration files (unless the configuration file
- * contains a leading [general] section with a "ignore-env-vars=yes" setting).
+ * contains a leading [directives] section with a "ignore-env-vars=yes" setting).
  *
  * This function is automatically called by GDALDriverManager() constructor
  *


### PR DESCRIPTION
in a [directives] leading section to disable environment
variables to be used as configuration options (fixes #6280)
