### PR TITLE
ADRG: add SRP pixel spacing value (SRP_PSP) to the srpdataset metadata

### DIFF
--- a/autotest/gdrivers/srp.py
+++ b/autotest/gdrivers/srp.py
@@ -68,6 +68,7 @@ def test_srp_1(filename="srp/USRP_PCB0/FKUSRP01.IMG"):
         "SRP_REVISIONDATE=20120505",
         "SRP_SCA=50000",
         "SRP_ZNA=17",
+        "SRP_PSP=100.0",
     ]
 
     got_md = ds.GetMetadata()

--- a/frmts/adrg/srpdataset.cpp
+++ b/frmts/adrg/srpdataset.cpp
@@ -680,6 +680,10 @@ bool SRPDataset::GetFromRecord( const char* pszFileName, DDFRecord * record )
     snprintf(szValue, sizeof(szValue), "%d", SCA);
     SetMetadataItem( "SRP_SCA", szValue );
 
+    // PSP Pixel Spacing, Microns at capture stage {000.0 - 100.0}
+    snprintf(szValue, sizeof(szValue), "%3.1f", PSP);
+    SetMetadataItem("SRP_PSP", szValue);
+
     nBands = 1;
     for( int i = 0; i < nBands; i++ )
         SetBand( i+1, new SRPRasterBand( this, i+1 ) );


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
adds the SRP pixelspacing value to the SRP-dataset metadata The value was already read from the data but not used.

## What are related issues/pull requests?
none

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
