### PR TITLE
Zarr: do not open non-existant dataset when prefixing with ZARR:, 

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -1012,6 +1012,52 @@ def test_zarr_read_half_float(endianness):
     assert ar.Read() == array.array("f", [1.5, float("nan")])
 
 
+def test_zarr_read_mdim_zarr_non_existing():
+
+    with gdaltest.error_handler():
+        assert (
+            gdal.OpenEx('ZARR:"data/zarr/not_existing.zarr"', gdal.OF_MULTIDIM_RASTER)
+            is None
+        )
+
+    with gdaltest.error_handler():
+        assert (
+            gdal.OpenEx(
+                'ZARR:"https://example.org/not_existing.zarr"', gdal.OF_MULTIDIM_RASTER
+            )
+            is None
+        )
+    assert (
+        "The filename should likely be prefixed with /vsicurl/"
+        in gdal.GetLastErrorMsg()
+    )
+
+    with gdaltest.error_handler():
+        assert (
+            gdal.OpenEx(
+                "ZARR:https://example.org/not_existing.zarr", gdal.OF_MULTIDIM_RASTER
+            )
+            is None
+        )
+    assert (
+        "There is likely a quoting error of the whole connection string, and the filename should likely be prefixed with /vsicurl/"
+        in gdal.GetLastErrorMsg()
+    )
+
+    with gdaltest.error_handler():
+        assert (
+            gdal.OpenEx(
+                "ZARR:/vsicurl/https://example.org/not_existing.zarr",
+                gdal.OF_MULTIDIM_RASTER,
+            )
+            is None
+        )
+    assert (
+        "There is likely a quoting error of the whole connection string."
+        in gdal.GetLastErrorMsg()
+    )
+
+
 def test_zarr_read_classic():
 
     ds = gdal.Open("data/zarr/zlib.zarr")

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -49,7 +49,19 @@ For Zarr V3, the dataset name recognized by the Open() method of the driver is
 a directory that contains a :file:`zarr.json` file (root of the dataset).
 
 For datasets on file systems where file listing is not reliable, as often with
-/vsicurl/, it is also possible to prefix the directory name with ``ZARR:``.
+/vsicurl/, it is also possible to prefix the directory name with ``ZARR:``,
+and it is necessary to surround the /vsicurl/-prefixed URL with double quotes.
+e.g `ZARR:"/vsicurl/https://example.org/foo.zarr"`. Note that when passing such
+string in a command line shell, extra quoting might be necessary to preserve the
+double-quoting.
+
+For example with a Bash shell, the whole connection string needs to be surrounded
+with single-quote characters:
+
+::
+
+    gdalmdiminfo 'ZARR:"/vsicurl/https://example.org/foo.zarr"'
+
 
 Compression methods
 -------------------
@@ -379,7 +391,12 @@ Convert a 2D slice (the one at index 0 of the non-2D dimension) of a 3D array to
 
 ::
 
-    gdal_translate ZARR:"my.zarr":/group/myarray:0 out.tif
+    gdal_translate 'ZARR:"my.zarr":/group/myarray:0' out.tif
+
+
+.. note::
+    The single quoting around the connection string is specific to the Bash shell
+    to make sure that the double quoting is preserved.
 
 
 See Also:


### PR DESCRIPTION
and add more informative error messages for quoting errors and/or lack of /vsicurl/ prefix.
Also improve doc related to /vsicurl/

cf https://lists.osgeo.org/pipermail/gdal-dev/2022-September/056200.html