### PR TITLE
NITF: RPFTOC use fixed values for frame size in case of CADRG and CIB…

### DIFF
--- a/frmts/nitf/rpftocdataset.cpp
+++ b/frmts/nitf/rpftocdataset.cpp
@@ -768,6 +768,15 @@ RPFTOCSubDataset::CreateDataSetFromTocEntry( const char* openInformationName,
         (entry->nwLat - entry->seLat)
         / (entry->nVertFrames * entry->vertInterval) + 0.5);
 
+    if ((EQUAL(entry->type, "CADRG") || (EQUAL(entry->type, "CIB"))))
+    {
+        // for CADRG and CIB the frame size is defined with 1536x1536
+        // CADRG: see MIL-C-89038: 3.5.2 a - Each frame shall comprise a rectangular array of 1536 by 1536 pixels
+        // CIB: see MIL-C-89041: 3.5.2 a - Each frame shall comprise a rectangular array of 1536 by 1536 pixels
+        sizeX = 1536;
+        sizeY = 1536;
+    }
+
     int nBlockXSize = 0;
     int nBlockYSize = 0;
     double geoTransf[6] = {};
@@ -785,7 +794,7 @@ RPFTOCSubDataset::CreateDataSetFromTocEntry( const char* openInformationName,
             /* Do a few sanity checks too */
             /* Ideally we should make these sanity checks now on ALL files, but it would be too slow */
             /* for large datasets. So these sanity checks will be done at the time we really need */
-            /* to access the file (see SanityCheckOK metho) */
+            /* to access the file (see SanityCheckOK method) */
             GDALDataset *poSrcDS = reinterpret_cast<GDALDataset *>(
                 GDALOpenShared( entry->frameEntries[i].fullFilePath,
                                 GA_ReadOnly ) );
@@ -800,7 +809,7 @@ RPFTOCSubDataset::CreateDataSetFromTocEntry( const char* openInformationName,
             ASSERT_CREATE_VRT((entry->horizInterval - geoTransf[GEOTRSFRM_WE_RES]) /
                                 entry->horizInterval < 0.01); /* X interval same as in TOC */
             ASSERT_CREATE_VRT((entry->vertInterval - (-geoTransf[GEOTRSFRM_NS_RES])) /
-                                entry->horizInterval < 0.01); /* Y interval same as in TOC */
+                                entry->vertInterval < 0.01); /* Y interval same as in TOC */
 
             const int ds_sizeX = poSrcDS->GetRasterXSize();
             const int ds_sizeY = poSrcDS->GetRasterYSize();
@@ -819,6 +828,7 @@ RPFTOCSubDataset::CreateDataSetFromTocEntry( const char* openInformationName,
                 sizeX = ds_sizeX;
             else
                 ASSERT_CREATE_VRT(sizeX == ds_sizeX);
+
             ASSERT_CREATE_VRT(sizeY == ds_sizeY);
             poSrcDS->GetRasterBand(1)->GetBlockSize(&nBlockXSize, &nBlockYSize);
             ASSERT_CREATE_VRT(poSrcDS->GetRasterBand(1)->GetColorInterpretation() == GCI_PaletteIndex);


### PR DESCRIPTION
… (as specified)

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
For CADRG and CIB files the frames size is set to the fixed value 1536, because this is specified in the specification. This avoids errors if the bounding in the a.toc file is not aligned on frame-size borders.

Additionally it fixes a typo and a wrong calculation of vertInterval ( in ASSERT_CREATE_VRT )

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
