### PR TITLE
ODS/XLSX: accept ODS: / XLSX: prefixes

### DIFF
--- a/autotest/ogr/ogr_ods.py
+++ b/autotest/ogr/ogr_ods.py
@@ -464,3 +464,16 @@ def test_ogr_ods_multiple_text_p_elements():
     f = lyr.GetNextFeature()
     f = lyr.GetNextFeature()
     assert f["value"] == "First line\nSecond line"
+
+
+###############################################################################
+# Test reading a ODS file with ODS: prefix
+
+
+def test_ogr_ods_read_ods_prefix():
+
+    tmpfilename = "/vsimem/temp"
+    with gdaltest.tempfile(
+        tmpfilename, open("data/ods/multiple_text_p_elements.ods", "rb").read()
+    ):
+        assert ogr.Open("ODS:" + tmpfilename) is not None

--- a/autotest/ogr/ogr_xlsx.py
+++ b/autotest/ogr/ogr_xlsx.py
@@ -549,3 +549,29 @@ def test_ogr_xlsx_read_cells_with_inline_formatting():
     lyr = ds.GetLayer(0)
     got = [(f[0], f[1], f[2]) for f in lyr]
     assert got == [(1, "text 2", "text 3"), (2, "text 4", "text5")]
+
+
+###############################################################################
+# Test reading a XLSX file without a XLSX extension
+
+
+def test_ogr_xlsx_read_no_xlsx_extension():
+
+    tmpfilename = "/vsimem/temp"
+    with gdaltest.tempfile(
+        tmpfilename, open("data/xlsx/cells_with_inline_formatting.xlsx", "rb").read()
+    ):
+        assert ogr.Open(tmpfilename) is not None
+
+
+###############################################################################
+# Test reading a XLSX file with XLSX: prefix
+
+
+def test_ogr_xlsx_read_xlsx_prefix():
+
+    tmpfilename = "/vsimem/temp"
+    with gdaltest.tempfile(
+        tmpfilename, open("data/xlsx/cells_with_inline_formatting.xlsx", "rb").read()
+    ):
+        assert ogr.Open("XLSX:" + tmpfilename) is not None


### PR DESCRIPTION
- ODS: make it possible to open file without .ods extension if prefixed with ODS: (refs #6375)
- XLSX: make it possible to open file without .xlsx extension if prefixed with XLSX: (fixes #6375), and improve detection to recognize even if no XLSX: prefix or .xlsx extension
