### PR TITLE
DOC: Adding --tmscompatible option to gdal2tiles.py documentation

### DIFF
--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -20,7 +20,7 @@ Synopsis
                   [-e] [-a nodata] [-v] [-q] [-h] [-k] [-n] [-u url]
                   [-w webviewer] [-t title] [-c copyright]
                   [--processes=NB_PROCESSES] [--mpi] [--xyz]
-                  --tilesize=PIXELS
+                  [--tilesize=PIXELS] [--tmscompatible]
                   [-g googlekey] [-b bingkey] input_file [output_dir] [COMMON_OPTIONS]
 
 Description
@@ -75,6 +75,11 @@ can publish a picture without proper georeferencing too.
   in XYZ mode (used by OGC WMTS too), tiles at y=0 are the northern-most tiles.
 
   .. versionadded:: 3.1
+  
+.. option:: -d, --tmscompatible
+  
+  When using the geodetic profile, specifies the base resolution as 0.703125
+  or 2 tiles at zoom level 0.
 
 .. option:: -z <ZOOM>, --zoom=<ZOOM>
 


### PR DESCRIPTION
`--tmscompatible` has been a valid option for a while and was already described in the `gdal2tiles.py` help section but was not explicitly defined in the online documentation. This simply corrects that oversight.