### PR TITLE
GPKG: add a IMMUTABLE=YES/NO open option

### DIFF
--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -29,7 +29,7 @@ The driver also supports reading and writing the
 following non-linear geometry types: CIRCULARSTRING, COMPOUNDCURVE,
 CURVEPOLYGON, MULTICURVE and MULTISURFACE
 
-GeoPackage raster/tiles are supported. See the 
+GeoPackage raster/tiles are supported. See the
 :ref:`GeoPackage raster <raster.gpkg>` documentation page.
 
 Driver capabilities
@@ -183,6 +183,15 @@ The following open options are available:
    This corresponds to the nolock=1 query parameter described at
    https://www.sqlite.org/uri.html
 
+-  **IMMUTABLE**\= YES/NO (GDAL >= 3.5.3).
+   Whether the database should be opened by assuming that the file cannot be
+   modified by another process. This will skip any checks for change detection.
+   This can be useful for WAL enabled files on read-only storage.
+   GDAL will automatically try to turn it on when not being able to open
+   in read-only mode a WAL enabled file.
+   This corresponds to the immutable=1 query parameter described at
+   https://www.sqlite.org/uri.html
+
 Note: open options are typically specified with "-oo name=value" syntax
 in most OGR utilities, or with the ``GDALOpenEx()`` API call.
 
@@ -279,17 +288,17 @@ The following layer creation options are available:
 Configuration options
 ---------------------
 
-The following :ref:`configuration options <configoptions>` are 
+The following :ref:`configuration options <configoptions>` are
 available:
 
-- :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode 
-  of the GeoPackage (and thus SQLite) file, see also 
+- :decl_configoption:`OGR_SQLITE_JOURNAL` can be used to set the journal mode
+  of the GeoPackage (and thus SQLite) file, see also
   https://www.sqlite.org/pragma.html#pragma_journal_mode.
 
-- :decl_configoption:`OGR_SQLITE_CACHE`: see 
+- :decl_configoption:`OGR_SQLITE_CACHE`: see
   :ref:`Performance hints <target_drivers_vector_gpkg_performance_hints>`.
-  
-- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see 
+
+- :decl_configoption:`OGR_SQLITE_SYNCHRONOUS`: see
   :ref:`Performance hints <target_drivers_vector_gpkg_performance_hints>`.
 
 - :decl_configoption:`OGR_SQLITE_LOAD_EXTENSIONS` =extension1,...,extensionN,ENABLE_SQL_LOAD_EXTENSION:
@@ -308,18 +317,18 @@ available:
   `pragma <http://www.sqlite.org/pragma.html>`__ . The syntax is
   ``OGR_SQLITE_PRAGMA = "pragma_name=pragma_value[,pragma_name2=pragma_value2]*"``.
 
-- :decl_configoption:`OGR_CURRENT_DATE`: the driver updates the GeoPackage 
-  ``last_change`` timestamp when the file is created or modified. If consistent 
-  binary output is required for reproducibility, the timestamp can be forced to 
+- :decl_configoption:`OGR_CURRENT_DATE`: the driver updates the GeoPackage
+  ``last_change`` timestamp when the file is created or modified. If consistent
+  binary output is required for reproducibility, the timestamp can be forced to
   a specific value by setting this global configuration option.
   When setting the option, take care to meet the specific time format
   requirement of the GeoPackage standard,
   e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
 
-- :decl_configoption:`SQLITE_USE_OGR_VFS` =YES enables extra buffering/caching 
-  by the GDAL/OGR I/O layer and can speed up I/O. More information 
+- :decl_configoption:`SQLITE_USE_OGR_VFS` =YES enables extra buffering/caching
+  by the GDAL/OGR I/O layer and can speed up I/O. More information
   :ref:`here <target_user_virtual_file_systems_file_caching>`.
-  Be aware that no file locking will occur if this option is activated, so 
+  Be aware that no file locking will occur if this option is activated, so
   concurrent edits may lead to database corruption.
 
 Metadata
@@ -446,7 +455,7 @@ Level of support of GeoPackage Extensions
 Performance hints
 -----------------
 
-The same performance hints apply as those mentioned for the 
+The same performance hints apply as those mentioned for the
 :ref:`SQLite driver <target_drivers_vector_sqlite_performance_hints>`.
 
 Examples
@@ -462,9 +471,9 @@ Examples
 
       ogr2ogr -f GPKG filename.gpkg abc.shp
 
--  Update of an existing GeoPackage file – e.g. a GeoPackage template – 
-   by adding features to it from another GeoPackage file containing 
-   features according to the same or a backwards compatible database 
+-  Update of an existing GeoPackage file – e.g. a GeoPackage template –
+   by adding features to it from another GeoPackage file containing
+   features according to the same or a backwards compatible database
    schema.
 
    ::

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -1260,15 +1260,15 @@ int GDALGeoPackageDataset::Open( GDALOpenInfo* poOpenInfo )
     const GByte* pabyHeader = poOpenInfo->pabyHeader;
     if( STARTS_WITH_CI(poOpenInfo->pszFilename, "GPKG:") )
     {
-        char** papszTokens = CSLTokenizeString2(poOpenInfo->pszFilename, ":", 0);
+        char** papszTokens = CSLTokenizeString2(poOpenInfo->pszFilename, ":", CSLT_HONOURSTRINGS);
         int nCount = CSLCount(papszTokens);
-        if( nCount < 3 )
+        if( nCount < 2 )
         {
             CSLDestroy(papszTokens);
             return FALSE;
         }
 
-        if( nCount == 3 )
+        if( nCount <= 3 )
         {
             osFilename = papszTokens[1];
         }
@@ -1290,7 +1290,8 @@ int GDALGeoPackageDataset::Open( GDALOpenInfo* poOpenInfo )
                 osFilename += papszTokens[i];
             }
         }
-        osSubdatasetTableName = papszTokens[nCount-1];
+        if( nCount >= 3 )
+            osSubdatasetTableName = papszTokens[nCount-1];
 
         CSLDestroy(papszTokens);
         VSILFILE *fp = VSIFOpenL(osFilename, "rb");

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -459,6 +459,7 @@ void RegisterOGRGeoPackage()
 COMPRESSION_OPTIONS
 "  <Option name='PRELUDE_STATEMENTS' type='string' scope='raster,vector' description='SQL statement(s) to send on the SQLite connection before any other ones'/>"
 "  <Option name='NOLOCK' type='boolean' description='Whether the database should be opened in nolock mode'/>"
+"  <Option name='IMMUTABLE' type='boolean' description='Whether the database should be opened in immutable mode'/>"
 "</OpenOptionList>");
 
     poDriver->SetMetadataItem( GDAL_DS_LAYER_CREATIONOPTIONLIST,

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -1058,7 +1058,6 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
 #ifdef SQLITE_OPEN_URI
     if ( m_osFilenameForSQLiteOpen.empty() &&
           (flagsIn & SQLITE_OPEN_READWRITE) == 0 &&
-          !(bUseOGRVFS || STARTS_WITH(m_pszFilename, "/vsi")) &&
           !STARTS_WITH(m_pszFilename, "file:") &&
           CPLTestBool(CSLFetchNameValueDef(papszOpenOptions, "NOLOCK", "NO")) )
     {
@@ -1071,7 +1070,10 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
 #ifdef _WIN32
         osFilenameForURI.replaceAll('\\', '/');
 #endif
-        osFilenameForURI.replaceAll("//", '/');
+        if( !STARTS_WITH(m_pszFilename, "/vsicurl/http") )
+        {
+            osFilenameForURI.replaceAll("//", '/');
+        }
 #ifdef _WIN32
         if( osFilenameForURI.size() > 3 && osFilenameForURI[1] == ':' &&
             osFilenameForURI[2] == '/' )

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -1056,10 +1056,13 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
         STARTS_WITH(m_pszFilename, "/vsi");
 
 #ifdef SQLITE_OPEN_URI
+    const bool bNoLock = CPLTestBool(CSLFetchNameValueDef(papszOpenOptions, "NOLOCK", "NO"));
+    const char* pszImmutable = CSLFetchNameValue(papszOpenOptions, "IMMUTABLE");
+    const bool bImmutable = pszImmutable && CPLTestBool(pszImmutable);
     if ( m_osFilenameForSQLiteOpen.empty() &&
           (flagsIn & SQLITE_OPEN_READWRITE) == 0 &&
           !STARTS_WITH(m_pszFilename, "file:") &&
-          CPLTestBool(CSLFetchNameValueDef(papszOpenOptions, "NOLOCK", "NO")) )
+          (bNoLock || bImmutable))
     {
         m_osFilenameForSQLiteOpen = "file:";
 
@@ -1083,7 +1086,15 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
 #endif
 
         m_osFilenameForSQLiteOpen += osFilenameForURI;
-        m_osFilenameForSQLiteOpen += "?nolock=1";
+        m_osFilenameForSQLiteOpen += "?";
+        if( bNoLock )
+            m_osFilenameForSQLiteOpen += "nolock=1";
+        if( bImmutable )
+        {
+            if( m_osFilenameForSQLiteOpen.back() != '?' )
+                m_osFilenameForSQLiteOpen += '&';
+            m_osFilenameForSQLiteOpen += "immutable=1";
+        }
     }
 #endif
     if( m_osFilenameForSQLiteOpen.empty() )
@@ -1201,8 +1212,7 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
         }
 
 #ifdef SQLITE_OPEN_URI
-        if( iterOpen == 0 && m_osFilenameForSQLiteOpen != m_pszFilename &&
-            m_osFilenameForSQLiteOpen.find("?nolock=1") != std::string::npos )
+        if( iterOpen == 0 && bNoLock && !bImmutable )
         {
             int nRowCount = 0, nColCount = 0;
             char** papszResult = nullptr;
@@ -1271,12 +1281,37 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
             }
             if( bIsWAL )
             {
+#ifdef SQLITE_OPEN_URI
+                if( pszImmutable == nullptr &&
+                    (flags & SQLITE_OPEN_READONLY) != 0 &&
+                    m_osFilenameForSQLiteOpen == m_pszFilename )
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "%s: this file is a WAL-enabled database. "
+                             "It cannot be opened "
+                             "because it is presumably read-only or in a "
+                             "read-only directory. Retrying with IMMUTABLE=YES open option",
+                             pszErrMsg);
+                    sqlite3_free( pszErrMsg );
+                    CloseDB();
+                    m_osFilenameForSQLiteOpen.clear();
+                    papszOpenOptions = CSLSetNameValue(papszOpenOptions, "IMMUTABLE", "YES");
+                    return OpenOrCreateDB(flagsIn, bRegisterOGR2SQLiteExtensions);
+                }
+#endif
+
                 CPLError(CE_Failure, CPLE_AppDefined,
                     "%s: this file is a WAL-enabled database. "
                     "It cannot be opened "
                     "because it is presumably read-only or in a "
-                    "read-only directory.",
-                    pszErrMsg);
+                    "read-only directory.%s",
+                    pszErrMsg,
+#ifdef SQLITE_OPEN_URI
+                    pszImmutable != nullptr ? "" : " Try opening with IMMUTABLE=YES open option"
+#else
+                    ""
+#endif
+                );
             }
             else
             {
@@ -1306,7 +1341,8 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
     }
 
     if( m_osFilenameForSQLiteOpen != m_pszFilename &&
-            m_osFilenameForSQLiteOpen.find("?nolock=1") != std::string::npos )
+            (m_osFilenameForSQLiteOpen.find("?nolock=1") != std::string::npos ||
+             m_osFilenameForSQLiteOpen.find("&nolock=1") != std::string::npos) )
     {
         m_bNoLock = true;
         CPLDebug("SQLite", "%s open in nolock mode", m_pszFilename);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -1052,7 +1052,8 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
         OGR2SQLITE_Register();
 
     const bool bUseOGRVFS =
-        CPLTestBool(CPLGetConfigOption("SQLITE_USE_OGR_VFS", "NO"));
+        CPLTestBool(CPLGetConfigOption("SQLITE_USE_OGR_VFS", "NO")) ||
+        STARTS_WITH(m_pszFilename, "/vsi");
 
 #ifdef SQLITE_OPEN_URI
     if ( m_osFilenameForSQLiteOpen.empty() &&
@@ -1109,20 +1110,16 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
     CPLString osJournalMode =
                         CPLGetConfigOption("OGR_SQLITE_JOURNAL", "");
 
+    if (bUseOGRVFS )
+    {
+        pMyVFS = OGRSQLiteCreateVFS(OGRSQLiteBaseDataSourceNotifyFileOpened, this);
+        sqlite3_vfs_register(pMyVFS, 0);
+    }
+
     for( int iterOpen = 0; iterOpen < 2 ; iterOpen++ )
     {
-        int rc;
-        if (bUseOGRVFS || STARTS_WITH(m_pszFilename, "/vsi"))
-        {
-            pMyVFS = OGRSQLiteCreateVFS(OGRSQLiteBaseDataSourceNotifyFileOpened, this);
-            sqlite3_vfs_register(pMyVFS, 0);
-            rc = sqlite3_open_v2( m_osFilenameForSQLiteOpen.c_str(), &hDB, flags, pMyVFS->zName );
-        }
-        else
-        {
-            rc = sqlite3_open_v2( m_osFilenameForSQLiteOpen.c_str(), &hDB, flags, nullptr );
-        }
-
+        int rc = sqlite3_open_v2( m_osFilenameForSQLiteOpen.c_str(),
+                                  &hDB, flags, pMyVFS ? pMyVFS->zName : nullptr );
         if( rc != SQLITE_OK )
         {
             CPLError( CE_Failure, CPLE_OpenFailed,


### PR DESCRIPTION
and automatically turn it on (with warning) when not being able to open a WAL file in read-only mode

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2022-September/056217.html