### PR TITLE
[Backport release/3.5] CSV: push the maximum size of a line to 10 million by default, and make it configurable with a MAX_LINE_SIZE open option

### DIFF
--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -321,6 +321,8 @@ The following open options can be specified
    values are strictly numeric.
 -  **EMPTY_STRING_AS_NULL**\ =YES/NO (default NO) (GDAL >= 2.1) Whether
    to consider empty strings as null fields on reading'.
+-  **MAX_LINE_SIZE**\ =integer (default 10000000) (GDAL >= 3.5.3) Maximum number
+   of bytes for a line (-1=unlimited).
 
 Creation Issues
 ---------------

--- a/ogr/ogrsf_frmts/csv/ogr_csv.h
+++ b/ogr/ogrsf_frmts/csv/ogr_csv.h
@@ -63,7 +63,9 @@ typedef enum
 
 void OGRCSVDriverRemoveFromMap(const char *pszName, GDALDataset *poDS);
 
-constexpr size_t OGR_CSV_MAX_LINE_SIZE = 1024 * 1024;
+// Must be kept as a macro with the value fully resolved, as it is used
+// by STRINGIFY(x) to generate open option description.
+#define OGR_CSV_DEFAULT_MAX_LINE_SIZE 10000000
 
 /************************************************************************/
 /*                             OGRCSVLayer                              */
@@ -85,6 +87,7 @@ class OGRCSVLayer final: public OGRLayer
     std::set<CPLString> m_oSetFields;
 
     VSILFILE           *fpCSV;
+    const int           m_nMaxLineSize = -1;
 
     int                 nNextFID;
 
@@ -147,7 +150,8 @@ class OGRCSVLayer final: public OGRLayer
 
   public:
 
-    OGRCSVLayer( const char *pszName, VSILFILE *fp, const char *pszFilename,
+    OGRCSVLayer( const char *pszName, VSILFILE *fp, int nMaxLineSize,
+                 const char *pszFilename,
                  int bNew, int bInWriteMode, char chDelimiter );
     virtual ~OGRCSVLayer() GDAL_OVERRIDE;
 

--- a/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
@@ -288,6 +288,9 @@ static void OGRCSVDriverUnload( GDALDriver * )
 /*                           RegisterOGRCSV()                           */
 /************************************************************************/
 
+#define XSTRINGIFY(x) #x
+#define STRINGIFY(x) XSTRINGIFY(x)
+
 void RegisterOGRCSV()
 
 {
@@ -374,6 +377,7 @@ void RegisterOGRCSV()
 "    <Value>AUTO</Value>"
 "  </Option>"
 "  <Option name='EMPTY_STRING_AS_NULL' type='boolean' description='Whether to consider empty strings as null fields on reading' default='NO'/>"
+"  <Option name='MAX_LINE_SIZE' type='int' description='Maximum number of bytes for a line (-1=unlimited)' default='" STRINGIFY(OGR_CSV_DEFAULT_MAX_LINE_SIZE) "'/>"
 "</OpenOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");

--- a/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -69,11 +69,13 @@ CPL_CVSID("$Id$")
 /************************************************************************/
 
 OGRCSVLayer::OGRCSVLayer( const char *pszLayerNameIn,
-                          VSILFILE  *fp, const char *pszFilenameIn,
+                          VSILFILE  *fp, int nMaxLineSize,
+                          const char *pszFilenameIn,
                           int bNewIn, int bInWriteModeIn,
                           char chDelimiterIn ) :
     poFeatureDefn(nullptr),
     fpCSV(fp),
+    m_nMaxLineSize(nMaxLineSize),
     nNextFID(1),
     bHasFieldNames(false),
     bNew(CPL_TO_BOOL(bNewIn)),
@@ -382,7 +384,7 @@ void OGRCSVLayer::BuildFeatureDefn( const char *pszNfdcGeomField,
             {
                 VSIRewindL(fpCSVT);
                 papszFieldTypes = CSVReadParseLine3L(fpCSVT,
-                                                     OGR_CSV_MAX_LINE_SIZE, // nMaxLineSize
+                                                     m_nMaxLineSize,
                                                      ",",
                                                      true, // bHonourStrings
                                                      false, // bKeepLeadingAndClosingQuotes
@@ -985,7 +987,7 @@ char **OGRCSVLayer::AutodetectFieldTypes(char **papszOpenOptions,
     {
         char **papszTokens =
             CSVReadParseLine3L(fp,
-                               OGR_CSV_MAX_LINE_SIZE,
+                               m_nMaxLineSize,
                                szDelimiter,
                                true, // bHonourStrings
                                bQuotedFieldAsString,
@@ -1305,7 +1307,7 @@ void OGRCSVLayer::ResetReading()
     if( bHasFieldNames )
         CSLDestroy(
             CSVReadParseLine3L( fpCSV,
-                                OGR_CSV_MAX_LINE_SIZE,
+                                m_nMaxLineSize,
                                 szDelimiter,
                                 bHonourStrings,
                                 false, // bKeepLeadingAndClosingQuotes
@@ -1328,7 +1330,7 @@ char **OGRCSVLayer::GetNextLineTokens()
     {
         // Read the CSV record.
         char **papszTokens = CSVReadParseLine3L( fpCSV,
-                                OGR_CSV_MAX_LINE_SIZE,
+                                m_nMaxLineSize,
                                 szDelimiter,
                                 bHonourStrings,
                                 false, // bKeepLeadingAndClosingQuotes


### PR DESCRIPTION
Backport #6403
 **Authored by:** @rouault