### PR TITLE
VRT serialization: do not (generally) open source band when serialization of a ComplexSource with NODATA (fixes qgis/QGIS#48052)

### DIFF
--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -1011,17 +1011,18 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
         VRTSimpleSource* poSimpleSource;
         if (bAllowSrcNoData)
         {
-            poSimpleSource = new VRTComplexSource();
+            auto poComplexSource = new VRTComplexSource();
+            poSimpleSource = poComplexSource;
             if (nSrcNoDataCount > 0)
             {
                 if (iBand-1 < nSrcNoDataCount)
-                    poSimpleSource->SetNoDataValue( padfSrcNoData[iBand-1] );
+                    poComplexSource->SetNoDataValue( padfSrcNoData[iBand-1] );
                 else
-                    poSimpleSource->SetNoDataValue( padfSrcNoData[nSrcNoDataCount - 1] );
+                    poComplexSource->SetNoDataValue( padfSrcNoData[nSrcNoDataCount - 1] );
             }
             else if( psDatasetProperties->abHasNoData[0] )
             {
-                poSimpleSource->SetNoDataValue( psDatasetProperties->adfNoDataValues[0] );
+                poComplexSource->SetNoDataValue( psDatasetProperties->adfNoDataValues[0] );
             }
         }
         else if( bUseSrcMaskBand && psDatasetProperties->abHasMaskBand[0] )
@@ -1203,8 +1204,9 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDatasetH hVRTDS)
             VRTSimpleSource* poSimpleSource;
             if (bAllowSrcNoData && psDatasetProperties->abHasNoData[nSelBand - 1])
             {
-                poSimpleSource = new VRTComplexSource();
-                poSimpleSource->SetNoDataValue( psDatasetProperties->adfNoDataValues[nSelBand - 1] );
+                auto poComplexSource = new VRTComplexSource();
+                poSimpleSource = poComplexSource;
+                poComplexSource->SetNoDataValue( psDatasetProperties->adfNoDataValues[nSelBand - 1] );
             }
             else if( bUseSrcMaskBand && psDatasetProperties->abHasMaskBand[nSelBand - 1] )
             {

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -1834,7 +1834,12 @@ CPLErr VRTSourcedRasterBand::AddSimpleSource(
     VRTSimpleSource *poSimpleSource = nullptr;
 
     if( pszResampling != nullptr && STARTS_WITH_CI(pszResampling, "aver") )
-        poSimpleSource = new VRTAveragedSource();
+    {
+        auto poAveragedSource = new VRTAveragedSource();
+        poSimpleSource = poAveragedSource;
+        if( dfNoDataValueIn != VRT_NODATA_UNSET )
+            poAveragedSource->SetNoDataValue( dfNoDataValueIn );
+    }
     else
     {
         poSimpleSource = new VRTSimpleSource();
@@ -1851,9 +1856,6 @@ CPLErr VRTSourcedRasterBand::AddSimpleSource(
                                   dfSrcXSize, dfSrcYSize );
     poSimpleSource->SetDstWindow( dfDstXOff, dfDstYOff,
                                   dfDstXSize, dfDstYSize );
-
-    if( dfNoDataValueIn != VRT_NODATA_UNSET )
-        poSimpleSource->SetNoDataValue( dfNoDataValueIn );
 
 /* -------------------------------------------------------------------- */
 /*      add to list.                                                    */
@@ -1881,14 +1883,19 @@ CPLErr VRTSourcedRasterBand::AddSimpleSource(
     VRTSimpleSource *poSimpleSource = nullptr;
 
     if( pszResampling != nullptr && STARTS_WITH_CI(pszResampling, "aver") )
-        poSimpleSource = new VRTAveragedSource();
+    {
+        auto poAveragedSource = new VRTAveragedSource();
+        poSimpleSource = poAveragedSource;
+        if( dfNoDataValueIn != VRT_NODATA_UNSET )
+            poAveragedSource->SetNoDataValue( dfNoDataValueIn );
+    }
     else
     {
         poSimpleSource = new VRTSimpleSource();
         if( dfNoDataValueIn != VRT_NODATA_UNSET )
             CPLError(
                 CE_Warning, CPLE_AppDefined,
-                "NODATA setting not currently supported for nearest  "
+                "NODATA setting not currently supported for "
                 "neighbour sampled simple sources on Virtual Datasources." );
     }
 
@@ -1899,9 +1906,6 @@ CPLErr VRTSourcedRasterBand::AddSimpleSource(
                      dfSrcXSize, dfSrcYSize,
                      dfDstXOff, dfDstYOff,
                      dfDstXSize, dfDstYSize );
-
-    if( dfNoDataValueIn != VRT_NODATA_UNSET )
-        poSimpleSource->SetNoDataValue( dfNoDataValueIn );
 
 /* -------------------------------------------------------------------- */
 /*      add to list.                                                    */

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -118,8 +118,6 @@ VRTSimpleSource::VRTSimpleSource( const VRTSimpleSource* poSrcSource,
     m_dfDstYOff(poSrcSource->m_dfDstYOff * dfYDstRatio),
     m_dfDstXSize(poSrcSource->m_dfDstXSize * dfXDstRatio),
     m_dfDstYSize(poSrcSource->m_dfDstYSize * dfYDstRatio),
-    m_bNoDataSet(poSrcSource->m_bNoDataSet),
-    m_dfNoDataValue(poSrcSource->m_dfNoDataValue),
     m_nMaxValue(poSrcSource->m_nMaxValue),
     m_bRelativeToVRTOri(-1),
     m_nExplicitSharedStatus(poSrcSource->m_nExplicitSharedStatus),
@@ -263,24 +261,6 @@ void VRTSimpleSource::SetDstWindow( double dfNewXOff, double dfNewYOff,
     m_dfDstYOff = RoundIfCloseToInt(dfNewYOff);
     m_dfDstXSize = RoundIfCloseToInt(dfNewXSize);
     m_dfDstYSize = RoundIfCloseToInt(dfNewYSize);
-}
-
-/************************************************************************/
-/*                           SetNoDataValue()                           */
-/************************************************************************/
-
-void VRTSimpleSource::SetNoDataValue( double dfNewNoDataValue )
-
-{
-    if( dfNewNoDataValue == VRT_NODATA_UNSET )
-    {
-        m_bNoDataSet = FALSE;
-        m_dfNoDataValue = VRT_NODATA_UNSET;
-        return;
-    }
-
-    m_bNoDataSet = TRUE;
-    m_dfNoDataValue = dfNewNoDataValue;
 }
 
 /************************************************************************/
@@ -867,8 +847,6 @@ int VRTSimpleSource::IsSameExceptBandNumber( VRTSimpleSource* poOtherSource )
            m_dfDstYOff == poOtherSource->m_dfDstYOff &&
            m_dfDstXSize == poOtherSource->m_dfDstXSize &&
            m_dfDstYSize == poOtherSource->m_dfDstYSize &&
-           m_bNoDataSet == poOtherSource->m_bNoDataSet &&
-           m_dfNoDataValue == poOtherSource->m_dfNoDataValue &&
            !m_osSrcDSName.empty() &&
            m_osSrcDSName == poOtherSource->m_osSrcDSName;
 }
@@ -1749,23 +1727,6 @@ void VRTSimpleSource::SetResampling( const char* pszResampling )
 }
 
 /************************************************************************/
-/*                      GetAdjustedNoDataValue()                        */
-/************************************************************************/
-
-double VRTSimpleSource::GetAdjustedNoDataValue() const
-{
-    if( m_bNoDataSet )
-    {
-        auto l_band = GetRasterBand();
-        if( l_band && l_band->GetRasterDataType() == GDT_Float32 )
-        {
-            return GDALAdjustNoDataCloseToFloatMax(m_dfNoDataValue);
-        }
-    }
-    return m_dfNoDataValue;
-}
-
-/************************************************************************/
 /* ==================================================================== */
 /*                         VRTAveragedSource                            */
 /* ==================================================================== */
@@ -1793,6 +1754,24 @@ CPLXMLNode *VRTAveragedSource::SerializeToXML( const char *pszVRTPath )
     psSrc->pszValue = CPLStrdup( "AveragedSource" );
 
     return psSrc;
+}
+
+/************************************************************************/
+/*                           SetNoDataValue()                           */
+/************************************************************************/
+
+void VRTAveragedSource::SetNoDataValue( double dfNewNoDataValue )
+
+{
+    if( dfNewNoDataValue == VRT_NODATA_UNSET )
+    {
+        m_bNoDataSet = FALSE;
+        m_dfNoDataValue = VRT_NODATA_UNSET;
+        return;
+    }
+
+    m_bNoDataSet = TRUE;
+    m_dfNoDataValue = dfNewNoDataValue;
 }
 
 /************************************************************************/
@@ -1856,8 +1835,6 @@ VRTAveragedSource::RasterIO( GDALDataType /*eBandDataType*/,
     auto l_band = GetRasterBand();
     if( !l_band )
         return CE_Failure;
-
-    const double dfNoDataValue = GetAdjustedNoDataValue();
 
 /* -------------------------------------------------------------------- */
 /*      Allocate a temporary buffer to whole the full resolution        */
@@ -1972,9 +1949,9 @@ VRTAveragedSource::RasterIO( GDALDataType /*eBandDataType*/,
                         continue;
 
                     if( m_bNoDataSet &&
-                        GDALIsValueInRange<float>(dfNoDataValue) &&
+                        GDALIsValueInRange<float>(m_dfNoDataValue) &&
                         ARE_REAL_EQUAL(fSampledValue,
-                                       static_cast<float>(dfNoDataValue)))
+                                       static_cast<float>(m_dfNoDataValue)))
                         continue;
 
                     nPixelCount++;
@@ -2061,25 +2038,14 @@ CPLErr VRTAveragedSource::GetHistogram( int /* nXSize */,
 /*                          VRTComplexSource()                          */
 /************************************************************************/
 
-VRTComplexSource::VRTComplexSource() :
-    m_eScalingType(VRT_SCALING_NONE),
-    m_dfScaleOff(0.0),
-    m_dfScaleRatio(1.0),
-    m_bSrcMinMaxDefined(FALSE),
-    m_dfSrcMin(0.0),
-    m_dfSrcMax(0.0),
-    m_dfDstMin(0.0),
-    m_dfDstMax(0.0),
-    m_dfExponent(1.0),
-    m_nColorTableComponent(0),
-    m_padfLUTInputs(nullptr),
-    m_padfLUTOutputs(nullptr),
-    m_nLUTItemCount(0)
-{}
+VRTComplexSource::VRTComplexSource() = default;
 
 VRTComplexSource::VRTComplexSource( const VRTComplexSource* poSrcSource,
                                     double dfXDstRatio, double dfYDstRatio ) :
     VRTSimpleSource(poSrcSource, dfXDstRatio, dfYDstRatio),
+    m_bNoDataSet(poSrcSource->m_bNoDataSet),
+    m_dfNoDataValue(poSrcSource->m_dfNoDataValue),
+    m_osNoDataValueOri(poSrcSource->m_osNoDataValueOri),
     m_eScalingType(poSrcSource->m_eScalingType),
     m_dfScaleOff(poSrcSource->m_dfScaleOff),
     m_dfScaleRatio(poSrcSource->m_dfScaleRatio),
@@ -2115,6 +2081,41 @@ VRTComplexSource::~VRTComplexSource()
 }
 
 /************************************************************************/
+/*                           SetNoDataValue()                           */
+/************************************************************************/
+
+void VRTComplexSource::SetNoDataValue( double dfNewNoDataValue )
+
+{
+    if( dfNewNoDataValue == VRT_NODATA_UNSET )
+    {
+        m_bNoDataSet = FALSE;
+        m_dfNoDataValue = VRT_NODATA_UNSET;
+        return;
+    }
+
+    m_bNoDataSet = TRUE;
+    m_dfNoDataValue = dfNewNoDataValue;
+}
+
+/************************************************************************/
+/*                      GetAdjustedNoDataValue()                        */
+/************************************************************************/
+
+double VRTComplexSource::GetAdjustedNoDataValue() const
+{
+    if( m_bNoDataSet )
+    {
+        auto l_band = GetRasterBand();
+        if( l_band && l_band->GetRasterDataType() == GDT_Float32 )
+        {
+            return GDALAdjustNoDataCloseToFloatMax(m_dfNoDataValue);
+        }
+    }
+    return m_dfNoDataValue;
+}
+
+/************************************************************************/
 /*                           SerializeToXML()                           */
 /************************************************************************/
 
@@ -2136,20 +2137,27 @@ CPLXMLNode *VRTComplexSource::SerializeToXML( const char *pszVRTPath )
 
     if( m_bNoDataSet )
     {
-        GDALDataType eBandDT = GDT_Unknown;
-        double dfNoDataValue = m_dfNoDataValue;
-        const auto kMaxFloat = std::numeric_limits<float>::max();
-        if( std::fabs(std::fabs(m_dfNoDataValue) - kMaxFloat) < 1e-10 * kMaxFloat )
+        if( !m_osNoDataValueOri.empty() && GetRasterBandNoOpen() == nullptr )
         {
-            auto l_band = GetRasterBand();
-            if( l_band )
-            {
-                dfNoDataValue = GetAdjustedNoDataValue();
-                eBandDT = l_band->GetRasterDataType();
-            }
+            CPLSetXMLValue( psSrc, "NODATA", m_osNoDataValueOri.c_str() );
         }
-        CPLSetXMLValue( psSrc, "NODATA", VRTSerializeNoData(
-            dfNoDataValue, eBandDT, 16).c_str());
+        else
+        {
+            GDALDataType eBandDT = GDT_Unknown;
+            double dfNoDataValue = m_dfNoDataValue;
+            const auto kMaxFloat = std::numeric_limits<float>::max();
+            if( std::fabs(std::fabs(m_dfNoDataValue) - kMaxFloat) < 1e-10 * kMaxFloat )
+            {
+                auto l_band = GetRasterBand();
+                if( l_band )
+                {
+                    dfNoDataValue = GetAdjustedNoDataValue();
+                    eBandDT = l_band->GetRasterDataType();
+                }
+            }
+            CPLSetXMLValue( psSrc, "NODATA", VRTSerializeNoData(
+                dfNoDataValue, eBandDT, 16).c_str());
+        }
     }
 
     switch( m_eScalingType )
@@ -2284,7 +2292,8 @@ CPLErr VRTComplexSource::XMLInit( CPLXMLNode *psSrc, const char *pszVRTPath,
     if( CPLGetXMLValue(psSrc, "NODATA", nullptr) != nullptr )
     {
         m_bNoDataSet = TRUE;
-        m_dfNoDataValue = CPLAtofM( CPLGetXMLValue(psSrc, "NODATA", "0") );
+        m_osNoDataValueOri = CPLGetXMLValue(psSrc, "NODATA", "0");
+        m_dfNoDataValue = CPLAtofM( m_osNoDataValueOri.c_str() );
     }
 
     const char* pszUseMaskBand = CPLGetXMLValue(psSrc, "UseMaskBand", nullptr);

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -2136,13 +2136,20 @@ CPLXMLNode *VRTComplexSource::SerializeToXML( const char *pszVRTPath )
 
     if( m_bNoDataSet )
     {
-        auto l_band = GetRasterBand();
-        if( l_band )
+        GDALDataType eBandDT = GDT_Unknown;
+        double dfNoDataValue = m_dfNoDataValue;
+        const auto kMaxFloat = std::numeric_limits<float>::max();
+        if( std::fabs(std::fabs(m_dfNoDataValue) - kMaxFloat) < 1e-10 * kMaxFloat )
         {
-            const double dfNoDataValue = GetAdjustedNoDataValue();
-            CPLSetXMLValue( psSrc, "NODATA", VRTSerializeNoData(
-                dfNoDataValue, l_band->GetRasterDataType(), 16).c_str());
+            auto l_band = GetRasterBand();
+            if( l_band )
+            {
+                dfNoDataValue = GetAdjustedNoDataValue();
+                eBandDT = l_band->GetRasterDataType();
+            }
         }
+        CPLSetXMLValue( psSrc, "NODATA", VRTSerializeNoData(
+            dfNoDataValue, eBandDT, 16).c_str());
     }
 
     switch( m_eScalingType )


### PR DESCRIPTION
For 3.5 backport, 2b14a0396608adc2c1696977346426df4cc0302d and first commit of this PR will have to be cherry-picked