### PR TITLE
CI: avoid installing sphinx 5.2.0 that causes a doc build issue

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -47,7 +47,11 @@ jobs:
           cmake --install .
           ldconfig
           popd
-
+    - name: Pin sphinx version
+      # Avoid https://github.com/sphinx-doc/sphinx/issues/10865
+      shell: bash -l {0}
+      run: |
+          python3 -m pip install --user "sphinx<5.2.0"
     - name: Print versions
       shell: bash -l {0}
       run: |


### PR DESCRIPTION
Cf https://github.com/sphinx-doc/sphinx/issues/10865
