### PR TITLE
[Backport release/3.5] CPLODBCStatement::Fetch(): do not emit error message when fetching backwards or with offset > 0 when there is no more rows (fixes #6368)

### DIFF
--- a/port/cpl_odbc.cpp
+++ b/port/cpl_odbc.cpp
@@ -1158,30 +1158,21 @@ int CPLODBCStatement::Fetch( int nOrientation, int nOffset )
     if( nOrientation == SQL_FETCH_NEXT && nOffset == 0 )
     {
         nRetCode = SQLFetch( m_hStmt );
-        if( Failed(nRetCode) )
-        {
-            if( nRetCode != SQL_NO_DATA )
-            {
-                CPLError( CE_Failure, CPLE_AppDefined, "%s",
-                          m_poSession->GetLastError() );
-            }
-            return FALSE;
-        }
     }
     else
     {
         nRetCode = SQLFetchScroll(m_hStmt,
                                   static_cast<SQLSMALLINT>(nOrientation),
                                   nOffset);
-        if( Failed(nRetCode) )
+    }
+    if( Failed(nRetCode) )
+    {
+        if( nRetCode != SQL_NO_DATA )
         {
-            if( nRetCode == SQL_NO_DATA )
-            {
-                CPLError( CE_Failure, CPLE_AppDefined, "%s",
-                          m_poSession->GetLastError() );
-            }
-            return FALSE;
+            CPLError( CE_Failure, CPLE_AppDefined, "%s",
+                      m_poSession->GetLastError() );
         }
+        return FALSE;
     }
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Backport #6385
 **Authored by:** @rouault