### PR TITLE
WEBP/JPEGXL/GTiff: add COMPRESSION_REVERSIBILITY item in IMAGE_STRUCTURE metadata domain

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -8309,7 +8309,8 @@ def test_tiff_write_171_zstd_predictor():
 # Test WEBP compression
 
 
-def test_tiff_write_webp():
+@pytest.mark.parametrize("writeImageStructureMetadata", [True, False])
+def test_tiff_write_webp(writeImageStructureMetadata):
 
     drv = gdal.GetDriverByName("GTiff")
     md = drv.GetMetadata()
@@ -8318,10 +8319,24 @@ def test_tiff_write_webp():
 
     filename = "/vsimem/test_tiff_write_webp.tif"
     src_ds = gdal.Open("data/md_ge_rgb_0010000.tif")
-    drv.CreateCopy(filename, src_ds, options=["COMPRESS=WEBP"])
+    with gdaltest.config_option(
+        "GTIFF_WRITE_IMAGE_STRUCTURE_METADATA",
+        "YES" if writeImageStructureMetadata else "NO",
+    ):
+        drv.CreateCopy(filename, src_ds, options=["COMPRESS=WEBP", "WEBP_LEVEL=50"])
     ds = gdal.Open(filename)
-    if gdal.GetDriverByName("WEBP"):
+
+    assert ds.GetMetadataItem("WEBP_LOSSLESS", "_DEBUG_") == "0"
+
+    if writeImageStructureMetadata:
+        assert ds.GetMetadataItem("WEBP_LEVEL", "_DEBUG_") == "50"
+        assert ds.GetMetadata("IMAGE_STRUCTURE")["WEBP_LEVEL"] == "50"
+    else:
+        assert ds.GetMetadataItem("WEBP_LEVEL", "_DEBUG_") == "75"
+
+    if writeImageStructureMetadata or gdal.GetDriverByName("WEBP") is not None:
         assert ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSY"
+
     cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(3)]
     assert cs != [0, 0, 0]
 
@@ -8333,9 +8348,11 @@ def test_tiff_write_webp():
 # Test WEBP compression with internal tiling
 
 
-def test_tiff_write_tiled_webp():
+@pytest.mark.parametrize("writeImageStructureMetadata", [True, False])
+def test_tiff_write_tiled_webp(writeImageStructureMetadata):
 
-    md = gdaltest.tiff_drv.GetMetadata()
+    drv = gdal.GetDriverByName("GTiff")
+    md = drv.GetMetadata()
     if md["DMD_CREATIONOPTIONLIST"].find("WEBP") == -1:
         pytest.skip()
 
@@ -8344,18 +8361,38 @@ def test_tiff_write_tiled_webp():
 
     filename = "/vsimem/tiff_write_tiled_webp.tif"
     src_ds = gdal.Open("data/md_ge_rgb_0010000.tif")
-    gdaltest.tiff_drv.CreateCopy(
-        filename, src_ds, options=["COMPRESS=WEBP", "WEBP_LOSSLESS=true", "TILED=true"]
-    )
+    with gdaltest.config_option(
+        "GTIFF_WRITE_IMAGE_STRUCTURE_METADATA",
+        "YES" if writeImageStructureMetadata else "NO",
+    ):
+        drv.CreateCopy(
+            filename,
+            src_ds,
+            options=["COMPRESS=WEBP", "WEBP_LOSSLESS=true", "TILED=true"],
+        )
     ds = gdal.Open(filename)
-    if gdal.GetDriverByName("WEBP"):
+    if writeImageStructureMetadata:
+        assert ds.GetMetadataItem("WEBP_LOSSLESS", "_DEBUG_") == "1"
+    else:
+        assert ds.GetMetadataItem("WEBP_LOSSLESS", "_DEBUG_") == "0"
+    if writeImageStructureMetadata or gdal.GetDriverByName("WEBP"):
         assert (
             ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSLESS"
         )
+    assert ds.GetMetadataItem("WEBP_LEVEL", "IMAGE_STRUCTURE") is None
     cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(3)]
     assert cs == [21212, 21053, 21349]
 
-    gdaltest.tiff_drv.Delete(filename)
+    ds = None
+    ds = gdal.Open(filename, gdal.GA_Update)
+    if writeImageStructureMetadata or gdal.GetDriverByName("WEBP"):
+        assert ds.GetMetadataItem("WEBP_LOSSLESS", "_DEBUG_") == "1"
+        assert (
+            ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSLESS"
+        )
+    ds = None
+
+    drv.Delete(filename)
     gdal.Unlink("data/md_ge_rgb_0010000.tif.aux.xml")
 
 
@@ -9448,7 +9485,8 @@ def test_tiff_write_lerc_float_with_nan(gdalDataType, structType):
 
 
 @pytest.mark.parametrize("lossless", ["YES", "NO", None])
-def test_tiff_write_jpegxl_byte_single_band(lossless):
+@pytest.mark.parametrize("writeImageStructureMetadata", [True, False])
+def test_tiff_write_jpegxl_byte_single_band(lossless, writeImageStructureMetadata):
 
     drv = gdal.GetDriverByName("GTiff")
     md = drv.GetMetadata()
@@ -9459,9 +9497,33 @@ def test_tiff_write_jpegxl_byte_single_band(lossless):
     options = ["COMPRESS=JXL"]
     if lossless:
         options += ["JXL_LOSSLESS=" + lossless]
-    drv.CreateCopy(outfile, gdal.Open("data/byte.tif"), options=options)
+    if lossless == "NO":
+        options += ["JXL_DISTANCE=0.5", "JXL_EFFORT=4"]
+    with gdaltest.config_option(
+        "GTIFF_WRITE_IMAGE_STRUCTURE_METADATA",
+        "YES" if writeImageStructureMetadata else "NO",
+    ):
+        drv.CreateCopy(outfile, gdal.Open("data/byte.tif"), options=options)
     ds = gdal.Open(outfile)
-    if gdal.GetDriverByName("JPEGXL"):
+
+    if writeImageStructureMetadata:
+        assert ds.GetMetadataItem("JXL_LOSSLESS", "_DEBUG_") == (
+            "0" if lossless == "NO" else "1"
+        )
+        if lossless == "NO":
+            assert float(ds.GetMetadataItem("JXL_DISTANCE", "_DEBUG_")) == 0.5
+            assert ds.GetMetadataItem("JXL_EFFORT", "_DEBUG_") == "4"
+    else:
+        # Default values
+        assert ds.GetMetadataItem("JXL_LOSSLESS", "_DEBUG_") == "1"
+        assert float(ds.GetMetadataItem("JXL_DISTANCE", "_DEBUG_")) == 1.0
+        assert ds.GetMetadataItem("JXL_EFFORT", "_DEBUG_") == "5"
+
+    if writeImageStructureMetadata:
+        assert ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == (
+            "LOSSY" if lossless == "NO" else "LOSSLESS"
+        )
+    elif gdal.GetDriverByName("JPEGXL") is not None:
         assert ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == (
             "LOSSY" if lossless == "NO" else "LOSSLESS (possibly)"
         )
@@ -9471,6 +9533,22 @@ def test_tiff_write_jpegxl_byte_single_band(lossless):
     else:
         assert cs == 4672
     ds = None
+
+    ds = gdal.Open(outfile, gdal.GA_Update)
+    if writeImageStructureMetadata:
+        assert ds.GetMetadataItem("JXL_LOSSLESS", "_DEBUG_") == (
+            "0" if lossless == "NO" else "1"
+        )
+    if writeImageStructureMetadata:
+        assert ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == (
+            "LOSSY" if lossless == "NO" else "LOSSLESS"
+        )
+    elif gdal.GetDriverByName("JPEGXL") is not None:
+        assert ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == (
+            "LOSSY" if lossless == "NO" else "LOSSLESS (possibly)"
+        )
+    ds = None
+
     drv.Delete(outfile)
 
 

--- a/autotest/gdrivers/webp.py
+++ b/autotest/gdrivers/webp.py
@@ -101,6 +101,10 @@ def test_webp_4():
     src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
     out_ds = gdaltest.webp_drv.CreateCopy("/vsimem/webp_4.webp", src_ds)
     src_ds = None
+    assert (
+        out_ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE")
+        == "LOSSY"
+    )
     cs1 = out_ds.GetRasterBand(1).Checksum()
     cs4 = out_ds.GetRasterBand(4).Checksum()
     out_ds = None
@@ -139,6 +143,10 @@ def test_webp_5():
         "/vsimem/webp_5.webp", src_ds, options=["LOSSLESS=YES"]
     )
     src_ds = None
+    assert (
+        out_ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE")
+        == "LOSSLESS"
+    )
     cs1 = out_ds.GetRasterBand(1).Checksum()
     cs4 = out_ds.GetRasterBand(4).Checksum()
     out_ds = None

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -461,8 +461,10 @@ bool JPEGXLDataset::Open(GDALOpenInfo* poOpenInfo)
                 return false;
             }
 
-            CPLDebug("JPEGXL", "uses_original_profile = %d",
-                     info.uses_original_profile);
+            GDALDataset::SetMetadataItem(
+                "COMPRESSION_REVERSIBILITY",
+                 info.uses_original_profile ? "LOSSLESS (possibly)": "LOSSY",
+                 "IMAGE_STRUCTURE");
 
             nRasterXSize = static_cast<int>(info.xsize);
             nRasterYSize = static_cast<int>(info.ysize);

--- a/frmts/webp/webpdataset.cpp
+++ b/frmts/webp/webpdataset.cpp
@@ -433,6 +433,8 @@ GDALDataset *WEBPDataset::Open( GDALOpenInfo * poOpenInfo )
 
     int nBands = 3;
 
+    auto poDS = cpl::make_unique<WEBPDataset>();
+
 #if WEBP_DECODER_ABI_VERSION >= 0x0002
     WebPDecoderConfig config;
     if( !WebPInitDecoderConfig(&config) )
@@ -442,6 +444,10 @@ GDALDataset *WEBPDataset::Open( GDALOpenInfo * poOpenInfo )
         = WebPGetFeatures(poOpenInfo->pabyHeader,
                           poOpenInfo->nHeaderBytes, &config.input)
         == VP8_STATUS_OK;
+
+    poDS->GDALDataset::SetMetadataItem("COMPRESSION_REVERSIBILITY",
+                                       config.input.format == 2 ? "LOSSLESS" : "LOSSY",
+                                       "IMAGE_STRUCTURE");
 
     if (config.input.has_alpha)
         nBands = 4;
@@ -464,7 +470,6 @@ GDALDataset *WEBPDataset::Open( GDALOpenInfo * poOpenInfo )
 /* -------------------------------------------------------------------- */
 /*      Create a corresponding GDALDataset.                             */
 /* -------------------------------------------------------------------- */
-    WEBPDataset *poDS = new WEBPDataset();
     poDS->nRasterXSize = nWidth;
     poDS->nRasterYSize = nHeight;
     poDS->fpImage = poOpenInfo->fpL;
@@ -474,7 +479,7 @@ GDALDataset *WEBPDataset::Open( GDALOpenInfo * poOpenInfo )
 /*      Create band information objects.                                */
 /* -------------------------------------------------------------------- */
     for( int iBand = 0; iBand < nBands; iBand++ )
-        poDS->SetBand( iBand+1, new WEBPRasterBand( poDS, iBand+1 ) );
+        poDS->SetBand( iBand+1, new WEBPRasterBand( poDS.get(), iBand+1 ) );
 
 /* -------------------------------------------------------------------- */
 /*      Initialize any PAM information.                                 */
@@ -487,9 +492,9 @@ GDALDataset *WEBPDataset::Open( GDALOpenInfo * poOpenInfo )
 /*      Open overviews.                                                 */
 /* -------------------------------------------------------------------- */
     poDS->oOvManager.Initialize(
-        poDS, poOpenInfo->pszFilename, poOpenInfo->GetSiblingFiles() );
+        poDS.get(), poOpenInfo->pszFilename, poOpenInfo->GetSiblingFiles() );
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/
@@ -836,6 +841,9 @@ WEBPDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
 
     VSIFCloseL( fpImage );
 
+    if( pfnProgress )
+        pfnProgress(1.0, "", pProgressData);
+
     if( eErr != CE_None )
     {
         VSIUnlink( pszFilename );
@@ -850,8 +858,7 @@ WEBPDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     /* If writing to stdout, we can't reopen it, so return */
     /* a fake dataset to make the caller happy */
     CPLPushErrorHandler(CPLQuietErrorHandler);
-    WEBPDataset *poDS
-        = reinterpret_cast<WEBPDataset*>( WEBPDataset::Open( &oOpenInfo ) );
+    auto poDS = cpl::down_cast<GDALPamDataset*>(WEBPDataset::Open( &oOpenInfo ));
     CPLPopErrorHandler();
     if( poDS )
     {


### PR DESCRIPTION
- WEBP: report a COMPRESSION_REVERSIBILITY=LOSSLESS/LOSSY metadata item in IMAGE_STRUCTURE
- JPEGXL: report a COMPRESSION_REVERSIBILITY=LOSSLESS (possibly)/LOSSY metadata item in IMAGE_STRUCTURE
- GTiff: report a COMPRESSION_REVERSIBILITY=LOSSLESS (possibly)/LOSSY metadata item in IMAGE_STRUCTURE for WEBP and JXL compression
    * Requires reading the header of one tile/strip and the availability of the standalone WEBP and JPEGXL drivers.
    * Use that information to set the m_bWebPLossless/m_bJxlLossless flags in update mode
- GTiff: read/write JPEGXL and WEBP compression parameters (for main dataset only) in IMAGE_STRUCTURE metadata domain of GDAL_METADATA tag