### PR TITLE
fix the swig-python cmake file in order to compile on ubuntu 18.04

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -258,7 +258,7 @@ if (Python_Interpreter_FOUND)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/README.rst ${CMAKE_CURRENT_BINARY_DIR}/README.rst @ONLY)
 
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/get_suffix.py
-       "from setuptools.command.build_ext import EXTENSION_SUFFIXES; print(EXTENSION_SUFFIXES[0])\n")
+       "from importlib.machinery import EXTENSION_SUFFIXES; print(EXTENSION_SUFFIXES[0])\n")
   execute_process(
     COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/get_suffix.py
     OUTPUT_VARIABLE PY_EXT_SUFFIX


### PR DESCRIPTION
When I try to compile gdal on ubuntu 18.04, I get an error saying that `EXTENSION_SUFFIXES` doesn't exist. If I change `setuptools.command.build_ext` to` importlib.machinery` it does work correctly, and I was able to compile gdal.

I tested it on the official ubuntu 18.04 docker, with compiling the source code of gdal 3.5.2. 