### PR TITLE
[Backport release/3.5] fix the swig-python cmake file in order to compile on ubuntu 18.04

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -193,7 +193,7 @@ if (Python_Interpreter_FOUND)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/README.rst ${CMAKE_CURRENT_BINARY_DIR}/README.rst @ONLY)
 
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/get_suffix.py
-       "from setuptools.command.build_ext import EXTENSION_SUFFIXES; print(EXTENSION_SUFFIXES[0])\n")
+       "from importlib.machinery import EXTENSION_SUFFIXES; print(EXTENSION_SUFFIXES[0])\n")
   execute_process(
     COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/get_suffix.py
     OUTPUT_VARIABLE PY_EXT_SUFFIX


### PR DESCRIPTION
Backport #6443
 **Authored by:** @idanaviv10