### PR TITLE
Zarr: fix `ZSTD_LEVEL` range in Zarr docs

### DIFF
--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -338,7 +338,7 @@ with ``ARRAY:`` using :program:`gdalmdimtranslate`):
 - **LZMA_DELTA=integer** : Delta distance in byte. Only used when COMPRESS=LZMA.
   Defaults to 1.
 
-- **ZSTD_LEVEL=integer** [1-9]: ZSTD compression level. Only used when COMPRESS=ZSTD.
+- **ZSTD_LEVEL=integer** [1-19]: ZSTD compression level. Only used when COMPRESS=ZSTD.
   Defaults to 13.
 
 - **LZ4_ACCELERATION=integer** [1-]: LZ4 acceleration factor.

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -338,7 +338,7 @@ with ``ARRAY:`` using :program:`gdalmdimtranslate`):
 - **LZMA_DELTA=integer** : Delta distance in byte. Only used when COMPRESS=LZMA.
   Defaults to 1.
 
-- **ZSTD_LEVEL=integer** [1-19]: ZSTD compression level. Only used when COMPRESS=ZSTD.
+- **ZSTD_LEVEL=integer** [1-22]: ZSTD compression level. Only used when COMPRESS=ZSTD.
   Defaults to 13.
 
 - **LZ4_ACCELERATION=integer** [1-]: LZ4 acceleration factor.


### PR DESCRIPTION
## What does this PR do?

`ZSTD_LEVEL` defaults to 13, which is outside of the 1-9 range. I'm not sure if we accept 1-19 or 1-22 here, but GTif uses 1-19 and I can't find the code where this is actually used.

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
