### PR TITLE
JPEG2000 drivers: report compression reversibility

### DIFF
--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -95,9 +95,14 @@ def test_jp2openjpeg_3():
     ds = gdal.Open("data/jpeg2000/int16.jp2")
     ds_ref = gdal.Open("data/int16.tif")
 
+    # 9x7 wavelet
+    assert ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSY"
+    assert ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSY"
+    assert ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == "LOSSY"
+
     maxdiff = gdaltest.compare_ds(ds, ds_ref)
-    print(ds.GetRasterBand(1).Checksum())
-    print(ds_ref.GetRasterBand(1).Checksum())
+    # print(ds.GetRasterBand(1).Checksum())
+    # print(ds_ref.GetRasterBand(1).Checksum())
 
     ds = None
     ds_ref = None
@@ -116,6 +121,11 @@ def test_jp2openjpeg_3():
 def test_jp2openjpeg_4(out_filename="tmp/jp2openjpeg_4.jp2"):
 
     src_ds = gdal.Open("data/jpeg2000/byte.jp2")
+    # 5x3 wavelet with Kakadu < 6.4 last layer at -256.0
+    assert (
+        src_ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE")
+        == "LOSSLESS"
+    )
     src_wkt = src_ds.GetProjectionRef()
     src_gt = src_ds.GetGeoTransform()
 

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -885,6 +885,9 @@ def test_nitf_jp2openjpeg_npje_numerically_lossless():
         "N169",
         "N174",
     )
+    assert (
+        ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == "LOSSLESS"
+    )
 
     # Get the JPEG2000 code stream subfile
     jpeg2000_ds_name = ds.GetMetadataItem("JPEG2000_DATASET_NAME", "DEBUG")
@@ -972,6 +975,7 @@ def test_nitf_jp2openjpeg_npje_visually_lossless():
     finally:
         gdaltest.reregister_all_jpeg2000_drivers()
     assert ds.GetMetadataItem("COMRAT", "DEBUG").startswith("V")
+    assert ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSY"
 
     # Get the JPEG2000 code stream subfile
     jpeg2000_ds_name = ds.GetMetadataItem("JPEG2000_DATASET_NAME", "DEBUG")

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -877,7 +877,14 @@ def test_nitf_jp2openjpeg_npje_numerically_lossless():
         ds.GetMetadataItem("J2KLRA", "TRE")
         == "0050000102000000.03125000100.06250000200.12500000300.25000000400.50000000500.60000000600.70000000700.80000000800.90000000901.00000001001.10000001101.20000001201.30000001301.50000001401.70000001502.00000001602.30000001703.50000001803.90000001912.000000"
     )
-    assert ds.GetMetadataItem("COMRAT", "DEBUG") in ("N141", "N142", "N143", "N169")
+    assert ds.GetMetadataItem("COMRAT", "DEBUG") in (
+        "N141",
+        "N142",
+        "N143",
+        "N147",
+        "N169",
+        "N174",
+    )
 
     # Get the JPEG2000 code stream subfile
     jpeg2000_ds_name = ds.GetMetadataItem("JPEG2000_DATASET_NAME", "DEBUG")

--- a/frmts/ecw/ecwdataset.cpp
+++ b/frmts/ecw/ecwdataset.cpp
@@ -3041,7 +3041,7 @@ GDALDataset *ECWDataset::Open( GDALOpenInfo * poOpenInfo, int bIsJPEG2000 )
 
 char **ECWDataset::GetMetadataDomainList()
 {
-    return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
+    return BuildMetadataDomainList(GDALJP2AbstractDataset::GetMetadataDomainList(),
                                    TRUE,
                                    "ECW", "GML", nullptr);
 }
@@ -3062,7 +3062,7 @@ const char *ECWDataset::GetMetadataItem( const char * pszName,
         if (EQUAL(pszName, "UNITS"))
             return m_osUnitsCode.size() ? m_osUnitsCode.c_str() : "METERS";
     }
-    return GDALPamDataset::GetMetadataItem(pszName, pszDomain);
+    return GDALJP2AbstractDataset::GetMetadataItem(pszName, pszDomain);
 }
 
 /************************************************************************/
@@ -3081,7 +3081,7 @@ char **ECWDataset::GetMetadata( const char *pszDomain )
         return oECWMetadataList.List();
     }
     else if( pszDomain == nullptr || !EQUAL(pszDomain,"GML") )
-        return GDALPamDataset::GetMetadata( pszDomain );
+        return GDALJP2AbstractDataset::GetMetadata( pszDomain );
     else
         return papszGMLMetadata;
 }

--- a/frmts/nitf/nitfdataset.h
+++ b/frmts/nitf/nitfdataset.h
@@ -99,6 +99,7 @@ class NITFDataset final: public GDALPamDataset
     void         InitializeCGMMetadata();
     void         InitializeTextMetadata();
     void         InitializeTREMetadata();
+    void         InitializeImageStructureMetadata();
 
     GIntBig     *panJPEGBlockOffset;
     GByte       *pabyJPEGBlock;

--- a/frmts/openjpeg/openjpegdataset.cpp
+++ b/frmts/openjpeg/openjpegdataset.cpp
@@ -247,6 +247,7 @@ class JP2OpenJPEGDataset final: public GDALJP2AbstractDataset
 
   protected:
     virtual int         CloseDependentDatasets() override;
+    virtual VSILFILE* GetFileHandle() override { return fp; }
 
   public:
                 JP2OpenJPEGDataset();

--- a/frmts/openjpeg/openjpegdataset.cpp
+++ b/frmts/openjpeg/openjpegdataset.cpp
@@ -3117,6 +3117,28 @@ GDALDataset * JP2OpenJPEGDataset::CreateCopy( const char * pszFilename,
     parameters.cblockh_init = nCblockH;
     parameters.mode = 0;
 
+    std::string osComment;
+    const char* pszCOM = CSLFetchNameValue(papszOptions, "COMMENT");
+    if( pszCOM )
+    {
+        osComment = pszCOM;
+        parameters.cp_comment = &osComment[0];
+    }
+    else if( !bIsIrreversible )
+    {
+        osComment = "Created by OpenJPEG version ";
+        osComment += opj_version();
+        if( adfRates.back() == 1.0 && !bYCBCR420 )
+        {
+            osComment += ". LOSSLESS settings used";
+        }
+        else
+        {
+            osComment += ". LOSSY settings used";
+        }
+        parameters.cp_comment = &osComment[0];
+    }
+
 #if IS_OPENJPEG_OR_LATER(2,3,0)
     // Was buggy before for some of the options
     const char* pszCodeBlockStyle = CSLFetchNameValue(papszOptions, "CODEBLOCK_STYLE");
@@ -4349,6 +4371,7 @@ void GDALRegister_JP2OpenJPEG()
 #if IS_OPENJPEG_OR_LATER(2,5,0)
 "   <Option name='TLM' type='boolean' description='True to insert TLM marker segments' default='false'/>"
 #endif
+"   <Option name='COMMENT' type='string' description='Content of the COM(ment) marker'/>"
 "</CreationOptionList>"  );
 
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );

--- a/gcore/gdaljp2abstractdataset.h
+++ b/gcore/gdaljp2abstractdataset.h
@@ -41,11 +41,13 @@ class CPL_DLL GDALJP2AbstractDataset: public GDALGeorefPamDataset
     GDALDataset*        poMemDS = nullptr;
     char**              papszMetadataFiles = nullptr;
     int                 m_nWORLDFILEIndex = -1;
+    CPLStringList       m_aosImageStructureMetadata{};
 
     CPL_DISALLOW_COPY_ASSIGN(GDALJP2AbstractDataset)
 
   protected:
     int CloseDependentDatasets() override;
+    virtual VSILFILE* GetFileHandle() { return nullptr; }
 
   public:
     GDALJP2AbstractDataset();
@@ -57,6 +59,9 @@ class CPL_DLL GDALJP2AbstractDataset: public GDALGeorefPamDataset
     void LoadVectorLayers( int bOpenRemoteResources = FALSE );
 
     char **GetFileList( void ) override;
+
+    char**      GetMetadata(const char * pszDomain = "" ) override;
+    const char* GetMetadataItem(const char* pszName, const char * pszDomain = "" ) override;
 
     int GetLayerCount() override;
     OGRLayer *GetLayer( int i ) override;

--- a/gcore/gdaljp2box.cpp
+++ b/gcore/gdaljp2box.cpp
@@ -197,7 +197,7 @@ int GDALJP2Box::ReadBox()
         nDataOffset = nBoxOffset + 16;
     }
 
-    if( nBoxLength == 0 )
+    if( nBoxLength == 0 && m_bAllowGetFileSize )
     {
         if( VSIFSeekL( fpVSIL, 0, SEEK_END ) != 0 )
             return FALSE;
@@ -213,7 +213,7 @@ int GDALJP2Box::ReadBox()
         nDataOffset += 16;
     }
 
-    if( GetDataLength() < 0 )
+    if( m_bAllowGetFileSize && GetDataLength() < 0 )
     {
         CPLDebug("GDALJP2", "Invalid length for box %s", szBoxType);
         return FALSE;

--- a/gcore/gdaljp2metadata.h
+++ b/gcore/gdaljp2metadata.h
@@ -59,11 +59,15 @@ class CPL_DLL GDALJP2Box
 
     GByte      *pabyData = nullptr;
 
+    bool        m_bAllowGetFileSize = true;
+
     CPL_DISALLOW_COPY_ASSIGN(GDALJP2Box)
 
 public:
     explicit    GDALJP2Box( VSILFILE * = nullptr );
                 ~GDALJP2Box();
+
+    void        SetAllowGetFileSize(bool b) { m_bAllowGetFileSize = b; }
 
     int         SetOffset( GIntBig nNewOffset );
     int         ReadBox();

--- a/gcore/gdaljp2metadata.h
+++ b/gcore/gdaljp2metadata.h
@@ -219,6 +219,12 @@ public:
     static int   IsUUID_XMP(const GByte *abyUUID);
 };
 
+CPLXMLNode* GDALGetJPEG2000Structure(const char* pszFilename,
+                                     VSILFILE* fp,
+                                     CSLConstList papszOptions);
+
+const char CPL_DLL *GDALGetJPEG2000Reversibility(const char* pszFilename,
+                                                 VSILFILE* fp);
 #endif /* #ifndef DOXYGEN_SKIP */
 
 #endif /* ndef GDAL_JP2READER_H_INCLUDED */

--- a/gcore/gdaljp2structure.cpp
+++ b/gcore/gdaljp2structure.cpp
@@ -2392,6 +2392,19 @@ const char* GDALGetJPEG2000Reversibility(const char* pszFilename,
                     pszReversibility = "LOSSY";
                 }
             }
+            else if( pszCOM && STARTS_WITH(pszCOM, "Created by OpenJPEG") )
+            {
+                // Starting with GDAL 3.6, the JP2OpenJPEG driver will write
+                // if the encoding parameters are lossless/lossy (for 5x3 wavelets)
+                if( strstr(pszCOM, "LOSSLESS settings used") )
+                {
+                    pszReversibility = "LOSSLESS";
+                }
+                else if( strstr(pszCOM, "LOSSY settings used") )
+                {
+                    pszReversibility = "LOSSY";
+                }
+            }
         }
     }
     CPLDestroyXMLNode(psRes);

--- a/gcore/gdaljp2structure.cpp
+++ b/gcore/gdaljp2structure.cpp
@@ -51,8 +51,17 @@ namespace
 {
     struct DumpContext
     {
-        int nCurLineCount;
-        int nMaxLineCount;
+        int nCurLineCount = 0;
+        int nMaxLineCount = 0;
+        const char* pszCodestreamMarkers = nullptr;
+        bool bDumpAll = false;
+        bool bDumpCodestream = false;
+        bool bDumpBinaryContent = false;
+        bool bDumpTextContent = false;
+        bool bDumpJP2Boxes = false;
+        bool bStopAtSOD = false;
+        bool bSODEncountered = false;
+        bool bAllowGetFileSize = true;
     };
 }
 
@@ -1048,7 +1057,7 @@ static CPLXMLNode* DumpJPK2CodeStream(CPLXMLNode* psBox,
     while( psDumpContext->nCurLineCount <= psDumpContext->nMaxLineCount + 1 )
     {
         GIntBig nOffset = static_cast<GIntBig>(VSIFTellL(fp));
-        if( nOffset == nBoxDataOffset + nBoxDataLength )
+        if( nBoxDataLength > 0 && nOffset == nBoxDataOffset + nBoxDataLength )
             break;
         if( VSIFReadL(abyMarker, 2, 1, fp) != 1 )
         {
@@ -1062,14 +1071,27 @@ static CPLXMLNode* DumpJPK2CodeStream(CPLXMLNode* psBox,
                      "Not a marker", nOffset);
             break;
         }
-        if( abyMarker[1] == 0x4F )
+        if( abyMarker[1] == 0x4F ) // SOC
         {
-            CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
-                          "SOC", nOffset, 0 );
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "SOC") )
+            {
+                CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
+                              "SOC", nOffset, 0 );
+            }
             continue;
         }
-        if( abyMarker[1] == 0x93 )
+        if( abyMarker[1] == 0x93 ) // SOD
         {
+            const bool bIncludeSOD = (
+                psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "SOD"));
+            if( psDumpContext->bStopAtSOD && !bIncludeSOD )
+            {
+                psDumpContext->bSODEncountered = true;
+                break;
+            }
+
             GIntBig nMarkerSize = 0;
             bool bBreak = false;
             if( nNextTileOffset == 0 )
@@ -1088,11 +1110,17 @@ static CPLXMLNode* DumpJPK2CodeStream(CPLXMLNode* psBox,
             else if( nNextTileOffset >= nOffset + 2 )
                 nMarkerSize = nNextTileOffset - nOffset - 2;
 
-            CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
-                          "SOD",
-                          nOffset, nMarkerSize );
-            if( bBreak )
+            if( bIncludeSOD )
+            {
+                CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
+                              "SOD",
+                              nOffset, nMarkerSize );
+            }
+            if( bBreak || psDumpContext->bStopAtSOD )
+            {
+                psDumpContext->bSODEncountered = true;
                 break;
+            }
 
             if( nNextTileOffset && nNextTileOffset == nOffset )
             {
@@ -1110,22 +1138,33 @@ static CPLXMLNode* DumpJPK2CodeStream(CPLXMLNode* psBox,
             {
                 /* We have seek and check before we hit a EOC */
                 nOffset = nBoxDataOffset + nBoxDataLength - 2;
-                CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
-                              "EOC", nOffset, 0 );
+                if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "EOC") )
+                {
+                    CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
+                                  "EOC", nOffset, 0 );
+                }
             }
             continue;
         }
         if( abyMarker[1] == 0xD9 )
         {
-            CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
-                          "EOC", nOffset, 0 );
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "EOC") )
+            {
+                CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
+                              "EOC", nOffset, 0 );
+            }
             continue;
         }
         /* Reserved markers */
         if( abyMarker[1] >= 0x30 && abyMarker[1] <= 0x3F )
         {
-            CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
-                          CPLSPrintf("Unknown 0xFF%02X", abyMarker[1]), nOffset, 0 );
+            if( psDumpContext->pszCodestreamMarkers == nullptr  )
+            {
+                CreateMarker( psCSBox, psLastChildCSBox, psDumpContext,
+                              CPLSPrintf("Unknown 0xFF%02X", abyMarker[1]), nOffset, 0 );
+            }
             continue;
         }
 
@@ -1144,11 +1183,12 @@ static CPLXMLNode* DumpJPK2CodeStream(CPLXMLNode* psBox,
             break;
         }
 
-        CPLXMLNode* psMarker = CreateMarker( psCSBox, psLastChildCSBox,
+        const auto CreateCurrentMarker = [&]() {
+            return CreateMarker( psCSBox, psLastChildCSBox,
                                              psDumpContext,
                         GetMarkerName(abyMarker[1]), nOffset, nMarkerSize );
-        if( !psMarker )
-            break;
+        };
+        CPLXMLNode* psMarker = nullptr;
         CPLXMLNode* psLastChild = nullptr;
         if( VSIFReadL(pabyMarkerData, nMarkerSize - 2, 1, fp) != 1 )
         {
@@ -1263,471 +1303,590 @@ static CPLXMLNode* DumpJPK2CodeStream(CPLXMLNode* psBox,
 
         if( abyMarker[1] == 0x90 ) /* SOT */
         {
-            READ_MARKER_FIELD_UINT16("Isot");
-            GUInt32 PSOT = READ_MARKER_FIELD_UINT32("Psot");
-            READ_MARKER_FIELD_UINT8("TPsot");
-            READ_MARKER_FIELD_UINT8("TNsot");
-            if( nRemainingMarkerSize > 0 )
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "SOT") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                READ_MARKER_FIELD_UINT16("Isot");
+                GUInt32 PSOT = READ_MARKER_FIELD_UINT32("Psot");
+                READ_MARKER_FIELD_UINT8("TPsot");
+                READ_MARKER_FIELD_UINT8("TNsot");
+                if( nRemainingMarkerSize > 0 )
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
 
-            if( PSOT )
-                nNextTileOffset = nOffset + PSOT;
+                if( PSOT )
+                    nNextTileOffset = nOffset + PSOT;
+            }
         }
         else if( abyMarker[1] == 0x50 ) /* CAP (HTJ2K) */
         {
-             const GUInt32 Pcap = READ_MARKER_FIELD_UINT32("Pcap");
-             for( int i = 0; i < 32; i++ )
-             {
-                 if( (Pcap >> (31 - i)) & 1 )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "CAP") )
+            {
+                 psMarker = CreateCurrentMarker();
+                 if( !psMarker )
+                     break;
+                 const GUInt32 Pcap = READ_MARKER_FIELD_UINT32("Pcap");
+                 for( int i = 0; i < 32; i++ )
                  {
-                     if( i + 1 == 15 )
+                     if( (Pcap >> (31 - i)) & 1 )
                      {
-                         READ_MARKER_FIELD_UINT16(CPLSPrintf("Scap_P%d", i+1), [](GUInt16 v) {
-                             std::string ret;
-                             if( (v >> 14) == 0 )
-                                 ret = "All code-blocks are HT code-blocks";
-                             else if( (v >> 14) == 2 )
-                                 ret = "Either all HT or all Part1 code-blocks per tile component";
-                             else if( (v >> 14) == 3 )
-                                 ret = "Mixed HT or all Part1 code-blocks per tile component";
-                             else
-                                 ret = "Reserved value for bit 14 and 15";
-                             ret += ", ";
-                             if( (v >> 13) & 1 )
-                                 ret += "More than one HT set per code-block";
-                             else
-                                 ret += "Zero or one HT set per code-block";
-                             ret += ", ";
-                             if( (v >> 12) & 1 )
-                                 ret += "ROI marker can be present";
-                             else
-                                 ret += "No ROI marker";
-                             ret += ", ";
-                             if( (v >> 11) & 1 )
-                                 ret += "Heterogeneous codestream";
-                             else
-                                 ret += "Homogeneous codestream";
-                             ret += ", ";
-                             if( (v >> 5) & 1 )
-                                 ret += "HT code-blocks can be used with irreversible transforms";
-                             else
-                                 ret += "HT code-blocks only used with reversible transforms";
-                             ret += ", ";
-                             ret += "P=";
-                             ret += CPLSPrintf("%d", v & 0x31);
-                             return ret;
-                         });
-                     }
-                     else
-                     {
-                         READ_MARKER_FIELD_UINT16(CPLSPrintf("Scap_P%d", i+1));
+                         if( i + 1 == 15 )
+                         {
+                             READ_MARKER_FIELD_UINT16(CPLSPrintf("Scap_P%d", i+1), [](GUInt16 v) {
+                                 std::string ret;
+                                 if( (v >> 14) == 0 )
+                                     ret = "All code-blocks are HT code-blocks";
+                                 else if( (v >> 14) == 2 )
+                                     ret = "Either all HT or all Part1 code-blocks per tile component";
+                                 else if( (v >> 14) == 3 )
+                                     ret = "Mixed HT or all Part1 code-blocks per tile component";
+                                 else
+                                     ret = "Reserved value for bit 14 and 15";
+                                 ret += ", ";
+                                 if( (v >> 13) & 1 )
+                                     ret += "More than one HT set per code-block";
+                                 else
+                                     ret += "Zero or one HT set per code-block";
+                                 ret += ", ";
+                                 if( (v >> 12) & 1 )
+                                     ret += "ROI marker can be present";
+                                 else
+                                     ret += "No ROI marker";
+                                 ret += ", ";
+                                 if( (v >> 11) & 1 )
+                                     ret += "Heterogeneous codestream";
+                                 else
+                                     ret += "Homogeneous codestream";
+                                 ret += ", ";
+                                 if( (v >> 5) & 1 )
+                                     ret += "HT code-blocks can be used with irreversible transforms";
+                                 else
+                                     ret += "HT code-blocks only used with reversible transforms";
+                                 ret += ", ";
+                                 ret += "P=";
+                                 ret += CPLSPrintf("%d", v & 0x31);
+                                 return ret;
+                             });
+                         }
+                         else
+                         {
+                             READ_MARKER_FIELD_UINT16(CPLSPrintf("Scap_P%d", i+1));
+                         }
                      }
                  }
-             }
-             if( nRemainingMarkerSize > 0 )
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
+                 if( nRemainingMarkerSize > 0 )
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
+            }
         }
         else if( abyMarker[1] == 0x51 ) /* SIZ */
         {
-            READ_MARKER_FIELD_UINT16("Rsiz", [](GUInt16 v) {
-                return std::string(
-                        (v == 0) ? "Unrestricted profile":
-                        (v == 1) ? "Profile 0":
-                        (v == 2) ? "Profile 1":
-                        (v == 16384) ? "HTJ2K": ""); });
-            READ_MARKER_FIELD_UINT32("Xsiz");
-            READ_MARKER_FIELD_UINT32("Ysiz");
-            READ_MARKER_FIELD_UINT32("XOsiz");
-            READ_MARKER_FIELD_UINT32("YOsiz");
-            READ_MARKER_FIELD_UINT32("XTsiz");
-            READ_MARKER_FIELD_UINT32("YTsiz");
-            READ_MARKER_FIELD_UINT32("XTOSiz");
-            READ_MARKER_FIELD_UINT32("YTOSiz");
-            Csiz = READ_MARKER_FIELD_UINT16("Csiz");
-            bError = false;
-            // cppcheck-suppress knownConditionTrueFalse
-            for(int i=0;i<Csiz && !bError;i++)
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "SIZ") )
             {
-                READ_MARKER_FIELD_UINT8(CPLSPrintf("Ssiz%d", i), [](GByte v) {
-                        const char* psz = GetInterpretationOfBPC(v); return std::string(psz ? psz : ""); });
-                READ_MARKER_FIELD_UINT8(CPLSPrintf("XRsiz%d", i));
-                READ_MARKER_FIELD_UINT8(CPLSPrintf("YRsiz%d", i));
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                READ_MARKER_FIELD_UINT16("Rsiz", [](GUInt16 v) {
+                    return std::string(
+                            (v == 0) ? "Unrestricted profile":
+                            (v == 1) ? "Profile 0":
+                            (v == 2) ? "Profile 1":
+                            (v == 16384) ? "HTJ2K": ""); });
+                READ_MARKER_FIELD_UINT32("Xsiz");
+                READ_MARKER_FIELD_UINT32("Ysiz");
+                READ_MARKER_FIELD_UINT32("XOsiz");
+                READ_MARKER_FIELD_UINT32("YOsiz");
+                READ_MARKER_FIELD_UINT32("XTsiz");
+                READ_MARKER_FIELD_UINT32("YTsiz");
+                READ_MARKER_FIELD_UINT32("XTOSiz");
+                READ_MARKER_FIELD_UINT32("YTOSiz");
+                Csiz = READ_MARKER_FIELD_UINT16("Csiz");
+                bError = false;
+                // cppcheck-suppress knownConditionTrueFalse
+                for(int i=0;i<Csiz && !bError;i++)
+                {
+                    READ_MARKER_FIELD_UINT8(CPLSPrintf("Ssiz%d", i), [](GByte v) {
+                            const char* psz = GetInterpretationOfBPC(v); return std::string(psz ? psz : ""); });
+                    READ_MARKER_FIELD_UINT8(CPLSPrintf("XRsiz%d", i));
+                    READ_MARKER_FIELD_UINT8(CPLSPrintf("YRsiz%d", i));
+                }
+                if( nRemainingMarkerSize > 0 )
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
             }
-            if( nRemainingMarkerSize > 0 )
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
         }
         else if( abyMarker[1] == 0x52 ) /* COD */
         {
-            bool bHasPrecincts = false;
-            if( nRemainingMarkerSize >= 1 ) {
-                auto nLastVal = *pabyMarkerDataIter;
-                CPLString osInterp;
-                if( nLastVal & 0x1 )
-                {
-                    bHasPrecincts = true;
-                    osInterp += "User defined precincts";
-                }
-                else
-                    osInterp += "Standard precincts";
-                osInterp += ", ";
-                if( nLastVal & 0x2 )
-                    osInterp += "SOP marker segments may be used";
-                else
-                    osInterp += "No SOP marker segments";
-                osInterp += ", ";
-                if( nLastVal & 0x4 )
-                    osInterp += "EPH marker segments may be used";
-                else
-                    osInterp += "No EPH marker segments";
-                AddField(psMarker, psLastChild, psDumpContext,
-                         "Scod", nLastVal, osInterp.c_str());
-                pabyMarkerDataIter += 1;
-                nRemainingMarkerSize -= 1;
-            }
-            else {
-                AddError(psMarker, psLastChild, psDumpContext,
-                         CPLSPrintf("Cannot read field %s", "Scod"));
-            }
-            READ_MARKER_FIELD_UINT8("SGcod_Progress",  lambdaPOCType);
-            READ_MARKER_FIELD_UINT16("SGcod_NumLayers");
-            READ_MARKER_FIELD_UINT8("SGcod_MCT");
-            READ_MARKER_FIELD_UINT8("SPcod_NumDecompositions");
-            READ_MARKER_FIELD_UINT8("SPcod_xcb_minus_2", [](GByte v) {
-                return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
-            READ_MARKER_FIELD_UINT8("SPcod_ycb_minus_2", [](GByte v) {
-                return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
-            READ_MARKER_FIELD_UINT8("SPcod_cbstyle", cblkstyleLamba);
-            READ_MARKER_FIELD_UINT8("SPcod_transformation", [](GByte v) {
-                return std::string(
-                       (v == 0) ? "9-7 irreversible":
-                       (v == 1) ? "5-3 reversible": ""); });
-            if( bHasPrecincts )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "COD") )
             {
-                int i = 0;
-                while( nRemainingMarkerSize >= 1 )
-                {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                bool bHasPrecincts = false;
+                if( nRemainingMarkerSize >= 1 ) {
                     auto nLastVal = *pabyMarkerDataIter;
+                    CPLString osInterp;
+                    if( nLastVal & 0x1 )
+                    {
+                        bHasPrecincts = true;
+                        osInterp += "User defined precincts";
+                    }
+                    else
+                        osInterp += "Standard precincts";
+                    osInterp += ", ";
+                    if( nLastVal & 0x2 )
+                        osInterp += "SOP marker segments may be used";
+                    else
+                        osInterp += "No SOP marker segments";
+                    osInterp += ", ";
+                    if( nLastVal & 0x4 )
+                        osInterp += "EPH marker segments may be used";
+                    else
+                        osInterp += "No EPH marker segments";
                     AddField(psMarker, psLastChild, psDumpContext,
-                             CPLSPrintf("SPcod_Precincts%d", i), *pabyMarkerDataIter,
-                             CPLSPrintf("PPx=%d PPy=%d: %dx%d",
-                                        nLastVal & 0xf, nLastVal >> 4,
-                                        1 << (nLastVal & 0xf), 1 << (nLastVal >> 4)));
+                             "Scod", nLastVal, osInterp.c_str());
                     pabyMarkerDataIter += 1;
                     nRemainingMarkerSize -= 1;
-                    i ++;
                 }
+                else {
+                    AddError(psMarker, psLastChild, psDumpContext,
+                             CPLSPrintf("Cannot read field %s", "Scod"));
+                }
+                READ_MARKER_FIELD_UINT8("SGcod_Progress",  lambdaPOCType);
+                READ_MARKER_FIELD_UINT16("SGcod_NumLayers");
+                READ_MARKER_FIELD_UINT8("SGcod_MCT");
+                READ_MARKER_FIELD_UINT8("SPcod_NumDecompositions");
+                READ_MARKER_FIELD_UINT8("SPcod_xcb_minus_2", [](GByte v) {
+                    return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
+                READ_MARKER_FIELD_UINT8("SPcod_ycb_minus_2", [](GByte v) {
+                    return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
+                READ_MARKER_FIELD_UINT8("SPcod_cbstyle", cblkstyleLamba);
+                READ_MARKER_FIELD_UINT8("SPcod_transformation", [](GByte v) {
+                    return std::string(
+                           (v == 0) ? "9-7 irreversible":
+                           (v == 1) ? "5-3 reversible": ""); });
+                if( bHasPrecincts )
+                {
+                    int i = 0;
+                    while( nRemainingMarkerSize >= 1 )
+                    {
+                        auto nLastVal = *pabyMarkerDataIter;
+                        AddField(psMarker, psLastChild, psDumpContext,
+                                 CPLSPrintf("SPcod_Precincts%d", i), *pabyMarkerDataIter,
+                                 CPLSPrintf("PPx=%d PPy=%d: %dx%d",
+                                            nLastVal & 0xf, nLastVal >> 4,
+                                            1 << (nLastVal & 0xf), 1 << (nLastVal >> 4)));
+                        pabyMarkerDataIter += 1;
+                        nRemainingMarkerSize -= 1;
+                        i ++;
+                    }
+                }
+                if( nRemainingMarkerSize > 0 )
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
             }
-            if( nRemainingMarkerSize > 0 )
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
         }
         else if( abyMarker[1] == 0x53 ) /* COC */
         {
-            if( Csiz < 257 )
-                READ_MARKER_FIELD_UINT8("Ccoc");
-            else
-                READ_MARKER_FIELD_UINT16("Ccoc");
-
-            bool bHasPrecincts = false;
-            if( nRemainingMarkerSize >= 1 ) {
-                auto nLastVal = *pabyMarkerDataIter;
-                CPLString osInterp;
-                if( nLastVal & 0x1 )
-                {
-                    bHasPrecincts = true;
-                    osInterp += "User defined precincts";
-                }
-                else
-                    osInterp += "Standard precincts";
-                AddField(psMarker, psLastChild, psDumpContext,
-                         "Scoc", nLastVal, osInterp.c_str());
-                pabyMarkerDataIter += 1;
-                nRemainingMarkerSize -= 1;
-            }
-            else {
-                AddError(psMarker, psLastChild, psDumpContext,
-                         CPLSPrintf("Cannot read field %s", "Scoc"));
-            }
-            READ_MARKER_FIELD_UINT8("SPcoc_NumDecompositions");
-            READ_MARKER_FIELD_UINT8("SPcoc_xcb_minus_2", [](GByte v) {
-                return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
-            READ_MARKER_FIELD_UINT8("SPcoc_ycb_minus_2", [](GByte v) {
-                return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
-            READ_MARKER_FIELD_UINT8("SPcoc_cbstyle", cblkstyleLamba);
-            READ_MARKER_FIELD_UINT8("SPcoc_transformation", [](GByte v) {
-                return std::string(
-                       (v == 0) ? "9-7 irreversible":
-                       (v == 1) ? "5-3 reversible": ""); });
-            if( bHasPrecincts )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "COC") )
             {
-                int i = 0;
-                while( nRemainingMarkerSize >= 1 )
-                {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                if( Csiz < 257 )
+                    READ_MARKER_FIELD_UINT8("Ccoc");
+                else
+                    READ_MARKER_FIELD_UINT16("Ccoc");
+
+                bool bHasPrecincts = false;
+                if( nRemainingMarkerSize >= 1 ) {
                     auto nLastVal = *pabyMarkerDataIter;
+                    CPLString osInterp;
+                    if( nLastVal & 0x1 )
+                    {
+                        bHasPrecincts = true;
+                        osInterp += "User defined precincts";
+                    }
+                    else
+                        osInterp += "Standard precincts";
                     AddField(psMarker, psLastChild, psDumpContext,
-                             CPLSPrintf("SPcoc_Precincts%d", i), *pabyMarkerDataIter,
-                             CPLSPrintf("PPx=%d PPy=%d: %dx%d",
-                                        nLastVal & 0xf, nLastVal >> 4,
-                                        1 << (nLastVal & 0xf), 1 << (nLastVal >> 4)));
+                             "Scoc", nLastVal, osInterp.c_str());
                     pabyMarkerDataIter += 1;
                     nRemainingMarkerSize -= 1;
-                    i ++;
                 }
+                else {
+                    AddError(psMarker, psLastChild, psDumpContext,
+                             CPLSPrintf("Cannot read field %s", "Scoc"));
+                }
+                READ_MARKER_FIELD_UINT8("SPcoc_NumDecompositions");
+                READ_MARKER_FIELD_UINT8("SPcoc_xcb_minus_2", [](GByte v) {
+                    return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
+                READ_MARKER_FIELD_UINT8("SPcoc_ycb_minus_2", [](GByte v) {
+                    return std::string(v <= 8 ? CPLSPrintf("%d", 1 << (2+v)) : "invalid"); });
+                READ_MARKER_FIELD_UINT8("SPcoc_cbstyle", cblkstyleLamba);
+                READ_MARKER_FIELD_UINT8("SPcoc_transformation", [](GByte v) {
+                    return std::string(
+                           (v == 0) ? "9-7 irreversible":
+                           (v == 1) ? "5-3 reversible": ""); });
+                if( bHasPrecincts )
+                {
+                    int i = 0;
+                    while( nRemainingMarkerSize >= 1 )
+                    {
+                        auto nLastVal = *pabyMarkerDataIter;
+                        AddField(psMarker, psLastChild, psDumpContext,
+                                 CPLSPrintf("SPcoc_Precincts%d", i), *pabyMarkerDataIter,
+                                 CPLSPrintf("PPx=%d PPy=%d: %dx%d",
+                                            nLastVal & 0xf, nLastVal >> 4,
+                                            1 << (nLastVal & 0xf), 1 << (nLastVal >> 4)));
+                        pabyMarkerDataIter += 1;
+                        nRemainingMarkerSize -= 1;
+                        i ++;
+                    }
+                }
+                if( nRemainingMarkerSize > 0 )
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
             }
-            if( nRemainingMarkerSize > 0 )
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
         }
         else if( abyMarker[1] == 0x55 ) /* TLM */
         {
-            READ_MARKER_FIELD_UINT8("Ztlm");
-            auto Stlm = READ_MARKER_FIELD_UINT8("Stlm", [](GByte v) {
-                return std::string(CPLSPrintf("ST=%d SP=%d",
-                               (v >> 4) & 3,
-                               (v >> 6) & 1)); });
-            int ST = (Stlm >> 4) & 3;
-            int SP = (Stlm >> 6) & 1;
-            int nTilePartDescLength = ST + ((SP == 0) ? 2 : 4);
-            int i = 0;
-            while( nRemainingMarkerSize >= nTilePartDescLength )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "TLM") )
             {
-                if( ST == 1 )
-                    READ_MARKER_FIELD_UINT8(CPLSPrintf("Ttlm%d", i));
-                else if( ST == 2 )
-                    READ_MARKER_FIELD_UINT16(CPLSPrintf("Ttlm%d", i));
-                if( SP == 0 )
-                    READ_MARKER_FIELD_UINT16(CPLSPrintf("Ptlm%d", i));
-                else
-                    READ_MARKER_FIELD_UINT32(CPLSPrintf("Ptlm%d", i));
-                i ++;
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                READ_MARKER_FIELD_UINT8("Ztlm");
+                auto Stlm = READ_MARKER_FIELD_UINT8("Stlm", [](GByte v) {
+                    return std::string(CPLSPrintf("ST=%d SP=%d",
+                                   (v >> 4) & 3,
+                                   (v >> 6) & 1)); });
+                int ST = (Stlm >> 4) & 3;
+                int SP = (Stlm >> 6) & 1;
+                int nTilePartDescLength = ST + ((SP == 0) ? 2 : 4);
+                int i = 0;
+                while( nRemainingMarkerSize >= nTilePartDescLength )
+                {
+                    if( ST == 1 )
+                        READ_MARKER_FIELD_UINT8(CPLSPrintf("Ttlm%d", i));
+                    else if( ST == 2 )
+                        READ_MARKER_FIELD_UINT16(CPLSPrintf("Ttlm%d", i));
+                    if( SP == 0 )
+                        READ_MARKER_FIELD_UINT16(CPLSPrintf("Ptlm%d", i));
+                    else
+                        READ_MARKER_FIELD_UINT32(CPLSPrintf("Ptlm%d", i));
+                    i ++;
+                }
+                if( nRemainingMarkerSize > 0 )
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
             }
-            if( nRemainingMarkerSize > 0 )
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
         }
         else if( abyMarker[1] == 0x57 ) /* PLM */
         {
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "PLM") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+            }
         }
         else if( abyMarker[1] == 0x58 ) /* PLT */
         {
-            READ_MARKER_FIELD_UINT8("Zplt");
-            int i = 0;
-            unsigned nPacketLength = 0;
-            while( nRemainingMarkerSize >= 1 )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "PLT") )
             {
-                auto nLastVal = *pabyMarkerDataIter;
-                nPacketLength |= (nLastVal & 0x7f);
-                if (nLastVal & 0x80)
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                READ_MARKER_FIELD_UINT8("Zplt");
+                int i = 0;
+                unsigned nPacketLength = 0;
+                while( nRemainingMarkerSize >= 1 )
                 {
-                    nPacketLength <<= 7;
+                    auto nLastVal = *pabyMarkerDataIter;
+                    nPacketLength |= (nLastVal & 0x7f);
+                    if (nLastVal & 0x80)
+                    {
+                        nPacketLength <<= 7;
+                    }
+                    else
+                    {
+                        AddField(psMarker, psLastChild, psDumpContext,
+                                 CPLSPrintf("Iplt%d", i), nPacketLength);
+                        nPacketLength = 0;
+                        i ++;
+                    }
+                    pabyMarkerDataIter += 1;
+                    nRemainingMarkerSize -= 1;
                 }
-                else
+                if( nPacketLength != 0 )
                 {
-                    AddField(psMarker, psLastChild, psDumpContext,
-                             CPLSPrintf("Iplt%d", i), nPacketLength);
-                    nPacketLength = 0;
-                    i ++;
+                    AddError(psMarker, psLastChild, psDumpContext,
+                             "Incorrect PLT marker");
                 }
-                pabyMarkerDataIter += 1;
-                nRemainingMarkerSize -= 1;
-            }
-            if( nPacketLength != 0 )
-            {
-                AddError(psMarker, psLastChild, psDumpContext,
-                         "Incorrect PLT marker");
             }
         }
         else if( abyMarker[1] == 0x59 ) /* CPF (HTJ2K) */
         {
-             const GUInt16 Lcpf = nMarkerSize;
-             if( Lcpf > 2 && (Lcpf % 2) == 0 )
-             {
-                 for( GUInt16 i = 0; i < (Lcpf - 2) / 2; i++ )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "CPF") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                        break;
+                 const GUInt16 Lcpf = nMarkerSize;
+                 if( Lcpf > 2 && (Lcpf % 2) == 0 )
                  {
-                     READ_MARKER_FIELD_UINT16(CPLSPrintf("Pcpf%d", i+1));
+                     for( GUInt16 i = 0; i < (Lcpf - 2) / 2; i++ )
+                     {
+                         READ_MARKER_FIELD_UINT16(CPLSPrintf("Pcpf%d", i+1));
+                     }
                  }
-             }
-             if( nRemainingMarkerSize > 0 )
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
+                 if( nRemainingMarkerSize > 0 )
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
+            }
         }
         else if( abyMarker[1] == 0x5C ) /* QCD */
         {
-            const int Sqcd = READ_MARKER_FIELD_UINT8("Sqcd", [](GByte v) {
-                std::string ret;
-                if( (v & 31) == 0 )
-                    ret = "No quantization";
-                else if( (v & 31) == 1 )
-                    ret = "Scalar derived";
-                else if( (v & 31) == 2 )
-                    ret = "Scalar expounded";
-                ret += ", ";
-                ret += CPLSPrintf("guard bits = %d", v >> 5);
-                return ret;
-            });
-            if( (Sqcd & 31) == 0 )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "QCD") )
             {
-                // Reversible
-                int i = 0;
-                while( nRemainingMarkerSize >= 1 )
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                const int Sqcd = READ_MARKER_FIELD_UINT8("Sqcd", [](GByte v) {
+                    std::string ret;
+                    if( (v & 31) == 0 )
+                        ret = "No quantization";
+                    else if( (v & 31) == 1 )
+                        ret = "Scalar derived";
+                    else if( (v & 31) == 2 )
+                        ret = "Scalar expounded";
+                    ret += ", ";
+                    ret += CPLSPrintf("guard bits = %d", v >> 5);
+                    return ret;
+                });
+                if( (Sqcd & 31) == 0 )
                 {
-                    READ_MARKER_FIELD_UINT8(
-                        CPLSPrintf("SPqcd%d", i),
-                        [](GByte v) {
-                            return std::string(CPLSPrintf("epsilon_b = %d", v >> 3));
-                        }
-                    );
-                    ++i;
+                    // Reversible
+                    int i = 0;
+                    while( nRemainingMarkerSize >= 1 )
+                    {
+                        READ_MARKER_FIELD_UINT8(
+                            CPLSPrintf("SPqcd%d", i),
+                            [](GByte v) {
+                                return std::string(CPLSPrintf("epsilon_b = %d", v >> 3));
+                            }
+                        );
+                        ++i;
+                    }
                 }
-            }
-            else
-            {
-                int i = 0;
-                while( nRemainingMarkerSize >= 2 )
+                else
                 {
-                    READ_MARKER_FIELD_UINT16(
-                        CPLSPrintf("SPqcd%d", i),
-                        [](GUInt16 v) {
-                            return std::string(
-                                CPLSPrintf("mantissa_b = %d, epsilon_b = %d",
-                                           v & ((1 << 11)-1),
-                                           v >> 11));
-                        }
-                    );
-                    ++i;
+                    int i = 0;
+                    while( nRemainingMarkerSize >= 2 )
+                    {
+                        READ_MARKER_FIELD_UINT16(
+                            CPLSPrintf("SPqcd%d", i),
+                            [](GUInt16 v) {
+                                return std::string(
+                                    CPLSPrintf("mantissa_b = %d, epsilon_b = %d",
+                                               v & ((1 << 11)-1),
+                                               v >> 11));
+                            }
+                        );
+                        ++i;
+                    }
                 }
             }
         }
         else if( abyMarker[1] == 0x5D ) /* QCC */
         {
-            if( Csiz < 257 )
-                READ_MARKER_FIELD_UINT8("Cqcc");
-            else
-                READ_MARKER_FIELD_UINT16("Cqcc");
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "QCC") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                if( Csiz < 257 )
+                    READ_MARKER_FIELD_UINT8("Cqcc");
+                else
+                    READ_MARKER_FIELD_UINT16("Cqcc");
 
-            const int Sqcc = READ_MARKER_FIELD_UINT8("Sqcc", [](GByte v) {
-                std::string ret;
-                if( (v & 31) == 0 )
-                    ret = "No quantization";
-                else if( (v & 31) == 1 )
-                    ret = "Scalar derived";
-                else if( (v & 31) == 2 )
-                    ret = "Scalar expounded";
-                ret += ", ";
-                ret += CPLSPrintf("guard bits = %d", v >> 5);
-                return ret;
-            });
-            if( (Sqcc & 31) == 0 )
-            {
-                // Reversible
-                int i = 0;
-                while( nRemainingMarkerSize >= 1 )
+                const int Sqcc = READ_MARKER_FIELD_UINT8("Sqcc", [](GByte v) {
+                    std::string ret;
+                    if( (v & 31) == 0 )
+                        ret = "No quantization";
+                    else if( (v & 31) == 1 )
+                        ret = "Scalar derived";
+                    else if( (v & 31) == 2 )
+                        ret = "Scalar expounded";
+                    ret += ", ";
+                    ret += CPLSPrintf("guard bits = %d", v >> 5);
+                    return ret;
+                });
+                if( (Sqcc & 31) == 0 )
                 {
-                    READ_MARKER_FIELD_UINT8(
-                        CPLSPrintf("SPqcc%d", i),
-                        [](GByte v) {
-                            return std::string(CPLSPrintf("epsilon_b = %d", v >> 3));
-                        }
-                    );
-                    ++i;
+                    // Reversible
+                    int i = 0;
+                    while( nRemainingMarkerSize >= 1 )
+                    {
+                        READ_MARKER_FIELD_UINT8(
+                            CPLSPrintf("SPqcc%d", i),
+                            [](GByte v) {
+                                return std::string(CPLSPrintf("epsilon_b = %d", v >> 3));
+                            }
+                        );
+                        ++i;
+                    }
                 }
-            }
-            else
-            {
-                int i = 0;
-                while( nRemainingMarkerSize >= 2 )
+                else
                 {
-                    READ_MARKER_FIELD_UINT16(
-                        CPLSPrintf("SPqcc%d", i),
-                        [](GUInt16 v) {
-                            return std::string(
-                                CPLSPrintf("mantissa_b = %d, epsilon_b = %d",
-                                           v & ((1 << 11)-1),
-                                           v >> 11));
-                        }
-                    );
-                    ++i;
+                    int i = 0;
+                    while( nRemainingMarkerSize >= 2 )
+                    {
+                        READ_MARKER_FIELD_UINT16(
+                            CPLSPrintf("SPqcc%d", i),
+                            [](GUInt16 v) {
+                                return std::string(
+                                    CPLSPrintf("mantissa_b = %d, epsilon_b = %d",
+                                               v & ((1 << 11)-1),
+                                               v >> 11));
+                            }
+                        );
+                        ++i;
+                    }
                 }
             }
         }
         else if( abyMarker[1] == 0x5E ) /* RGN */
         {
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "RGN") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+            }
         }
         else if( abyMarker[1] == 0x5F ) /* POC */
         {
-            const int nPOCEntrySize = Csiz < 257 ? 7 : 9;
-            int i = 0;
-            while( nRemainingMarkerSize >= nPOCEntrySize )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "POC") )
             {
-                READ_MARKER_FIELD_UINT8(CPLSPrintf("RSpoc%d", i));
-                if( nPOCEntrySize == 7 )
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                const int nPOCEntrySize = Csiz < 257 ? 7 : 9;
+                int i = 0;
+                while( nRemainingMarkerSize >= nPOCEntrySize )
                 {
-                    READ_MARKER_FIELD_UINT8(CPLSPrintf("CSpoc%d", i));
+                    READ_MARKER_FIELD_UINT8(CPLSPrintf("RSpoc%d", i));
+                    if( nPOCEntrySize == 7 )
+                    {
+                        READ_MARKER_FIELD_UINT8(CPLSPrintf("CSpoc%d", i));
+                    }
+                    else
+                    {
+                        READ_MARKER_FIELD_UINT16(CPLSPrintf("CSpoc%d", i));
+                    }
+                    READ_MARKER_FIELD_UINT16(CPLSPrintf("LYEpoc%d", i));
+                    READ_MARKER_FIELD_UINT8(CPLSPrintf("REpoc%d", i));
+                    if( nPOCEntrySize == 7 )
+                    {
+                        READ_MARKER_FIELD_UINT8(CPLSPrintf("CEpoc%d", i));
+                    }
+                    else
+                    {
+                        READ_MARKER_FIELD_UINT16(CPLSPrintf("CEpoc%d", i));
+                    }
+                    READ_MARKER_FIELD_UINT8(CPLSPrintf("Ppoc%d", i), lambdaPOCType);
+                    i ++;
                 }
-                else
+                if( nRemainingMarkerSize > 0 )
                 {
-                    READ_MARKER_FIELD_UINT16(CPLSPrintf("CSpoc%d", i));
+                    AddElement( psMarker, psLastChild, psDumpContext,
+                        CPLCreateXMLElementAndValue(
+                            nullptr, "RemainingBytes",
+                            CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
                 }
-                READ_MARKER_FIELD_UINT16(CPLSPrintf("LYEpoc%d", i));
-                READ_MARKER_FIELD_UINT8(CPLSPrintf("REpoc%d", i));
-                if( nPOCEntrySize == 7 )
-                {
-                    READ_MARKER_FIELD_UINT8(CPLSPrintf("CEpoc%d", i));
-                }
-                else
-                {
-                    READ_MARKER_FIELD_UINT16(CPLSPrintf("CEpoc%d", i));
-                }
-                READ_MARKER_FIELD_UINT8(CPLSPrintf("Ppoc%d", i), lambdaPOCType);
-                i ++;
-            }
-            if( nRemainingMarkerSize > 0 )
-            {
-                AddElement( psMarker, psLastChild, psDumpContext,
-                    CPLCreateXMLElementAndValue(
-                        nullptr, "RemainingBytes",
-                        CPLSPrintf("%d", static_cast<int>(nRemainingMarkerSize) )));
             }
         }
         else if( abyMarker[1] == 0x60 ) /* PPM */
         {
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "PPM") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+            }
         }
         else if( abyMarker[1] == 0x61 ) /* PPT */
         {
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "PPT") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+            }
         }
         else if( abyMarker[1] == 0x63 ) /* CRG */
         {
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "CRG") )
+            {
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+            }
         }
         else if( abyMarker[1] == 0x64 ) /* COM */
         {
-            auto RCom = READ_MARKER_FIELD_UINT16("Rcom", [](GUInt16 v) {
-                return std::string((v == 0 ) ? "Binary" : (v == 1) ? "LATIN1" : ""); });
-            if( RCom == 1 )
+            if( psDumpContext->pszCodestreamMarkers == nullptr ||
+                strstr(psDumpContext->pszCodestreamMarkers, "COM") )
             {
-                GByte abyBackup = pabyMarkerDataIter[nRemainingMarkerSize];
-                pabyMarkerDataIter[nRemainingMarkerSize] = 0;
-                AddField(psMarker, psLastChild, psDumpContext,
-                         "COM",
-                         static_cast<int>(nRemainingMarkerSize),
-                         reinterpret_cast<const char*>(pabyMarkerDataIter));
-                pabyMarkerDataIter[nRemainingMarkerSize] = abyBackup;
+                psMarker = CreateCurrentMarker();
+                if( !psMarker )
+                    break;
+                auto RCom = READ_MARKER_FIELD_UINT16("Rcom", [](GUInt16 v) {
+                    return std::string((v == 0 ) ? "Binary" : (v == 1) ? "LATIN1" : ""); });
+                if( RCom == 1 )
+                {
+                    GByte abyBackup = pabyMarkerDataIter[nRemainingMarkerSize];
+                    pabyMarkerDataIter[nRemainingMarkerSize] = 0;
+                    AddField(psMarker, psLastChild, psDumpContext,
+                             "COM",
+                             static_cast<int>(nRemainingMarkerSize),
+                             reinterpret_cast<const char*>(pabyMarkerDataIter));
+                    pabyMarkerDataIter[nRemainingMarkerSize] = abyBackup;
+                }
             }
         }
 
@@ -1752,7 +1911,6 @@ static
 void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
                                       VSILFILE* fp,
                                       GDALJP2Box* poParentBox,
-                                      CSLConstList papszOptions,
                                       int nRecLevel,
                                       vsi_l_offset nFileOrParentBoxSize,
                                       DumpContext* psDumpContext)
@@ -1765,6 +1923,7 @@ void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
 
     static const char* const szHex = "0123456789ABCDEF";
     GDALJP2Box oBox( fp );
+    oBox.SetAllowGetFileSize(psDumpContext->bAllowGetFileSize);
     CPLXMLNode* psLastChild = nullptr;
     if( oBox.ReadFirstChild(poParentBox) )
     {
@@ -1773,27 +1932,34 @@ void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
         {
             GIntBig nBoxDataLength = oBox.GetDataLength();
             const char* pszBoxType = oBox.GetType();
-
-            CPLXMLNode* psBox = CPLCreateXMLNode( nullptr, CXT_Element, "JP2Box" );
-            psBox = AddElement( psParent, psLastChild, psDumpContext, psBox );
-            if( !psBox )
-                break;
-            CPLAddXMLAttributeAndValue(psBox, "name", pszBoxType );
-            CPLAddXMLAttributeAndValue(psBox, "box_offset",
-                                       CPLSPrintf(CPL_FRMT_GIB, oBox.GetBoxOffset() )  );
-            CPLAddXMLAttributeAndValue(psBox, "box_length",
-                                       CPLSPrintf(CPL_FRMT_GIB, oBox.GetBoxLength() ) );
-            CPLAddXMLAttributeAndValue(psBox, "data_offset",
-                                       CPLSPrintf(CPL_FRMT_GIB, oBox.GetDataOffset() ) );
-            CPLAddXMLAttributeAndValue(psBox, "data_length",
-                                       CPLSPrintf(CPL_FRMT_GIB, nBoxDataLength ) );
-
-            if( nBoxDataLength > GINTBIG_MAX - oBox.GetDataOffset() )
+            CPLXMLNode* psBox = nullptr;
+            const auto CreateBox = [&]()
             {
-                CPLXMLNode* psLastChildBox = nullptr;
-                AddError(psBox, psLastChildBox, psDumpContext, "Invalid box_length");
-                break;
-            }
+                if( psBox != nullptr )
+                    return true;
+                psBox = CPLCreateXMLNode( nullptr, CXT_Element, "JP2Box" );
+                psBox = AddElement( psParent, psLastChild, psDumpContext, psBox );
+                if( !psBox )
+                    return false;
+                CPLAddXMLAttributeAndValue(psBox, "name", pszBoxType );
+                CPLAddXMLAttributeAndValue(psBox, "box_offset",
+                                           CPLSPrintf(CPL_FRMT_GIB, oBox.GetBoxOffset() )  );
+                const auto nBoxLength = oBox.GetBoxLength();
+                CPLAddXMLAttributeAndValue(psBox, "box_length",
+                                           nBoxLength > 0 ? CPLSPrintf(CPL_FRMT_GIB, nBoxLength ) : "unknown" );
+                CPLAddXMLAttributeAndValue(psBox, "data_offset",
+                                           CPLSPrintf(CPL_FRMT_GIB, oBox.GetDataOffset() ) );
+                CPLAddXMLAttributeAndValue(psBox, "data_length",
+                                           nBoxDataLength > 0 ? CPLSPrintf(CPL_FRMT_GIB, nBoxDataLength ) : "unknown" );
+
+                if( nBoxDataLength > GINTBIG_MAX - oBox.GetDataOffset() )
+                {
+                    CPLXMLNode* psLastChildBox = nullptr;
+                    AddError(psBox, psLastChildBox, psDumpContext, "Invalid box_length");
+                    return false;
+                }
+                return true;
+            };
 
             // Check large non-jp2c boxes against filesize
             if( strcmp(pszBoxType, "jp2c") != 0 && nBoxDataLength > 100 * 1024 )
@@ -1804,19 +1970,24 @@ void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
                     nFileOrParentBoxSize = VSIFTellL(fp);
                 }
             }
-            if( nFileOrParentBoxSize > 0 &&
+            if( nFileOrParentBoxSize > 0 && nBoxDataLength > 0 &&
                 (static_cast<vsi_l_offset>(oBox.GetDataOffset()) > nFileOrParentBoxSize ||
                  static_cast<vsi_l_offset>(nBoxDataLength) > nFileOrParentBoxSize - oBox.GetDataOffset()) )
             {
                 CPLXMLNode* psLastChildBox = nullptr;
+                if( !CreateBox() )
+                    break;
                 AddError(psBox, psLastChildBox, psDumpContext, "Invalid box_length");
                 break;
             }
 
             if( oBox.IsSuperBox() )
             {
+                if( !CreateBox() )
+                    break;
+                if( nBoxDataLength <= 0 )
+                    break;
                 GDALGetJPEG2000StructureInternal(psBox, fp, &oBox,
-                                                 papszOptions,
                                                  nRecLevel + 1,
                                                  oBox.GetDataOffset() +
                                                     static_cast<vsi_l_offset>(nBoxDataLength),
@@ -1824,8 +1995,10 @@ void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
             }
             else
             {
-                if( strcmp(pszBoxType, "uuid") == 0 )
+                if( strcmp(pszBoxType, "uuid") == 0 && psDumpContext->bDumpJP2Boxes )
                 {
+                    if( !CreateBox() )
+                        break;
                     char* pszBinaryContent = static_cast<char*>(VSIMalloc( 2 * 16 + 1 ));
                     const GByte* pabyUUID = oBox.GetUUID();
                     for(int i=0;i<16;i++)
@@ -1847,11 +2020,12 @@ void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
                     AddElement( psBox, psLastChildBox, psDumpContext, psUUIDNode );
                 }
 
-                if( (CPLFetchBool(papszOptions, "BINARY_CONTENT", false) ||
-                     CPLFetchBool(papszOptions, "ALL", false) ) &&
+                if( psDumpContext->bDumpBinaryContent &&
                     strcmp(pszBoxType, "jp2c") != 0 &&
                     nBoxDataLength < 100 * 1024 )
                 {
+                    if( !CreateBox() )
+                        break;
                     CPLXMLNode* psBinaryContent = CPLCreateXMLNode( nullptr, CXT_Element, "BinaryContent" );
                     GByte* pabyBoxData = oBox.ReadBoxData();
                     int nBoxLength = static_cast<int>(nBoxDataLength);
@@ -1873,11 +2047,12 @@ void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
                     AddElement( psBox, psLastChildBox, psDumpContext, psBinaryContent );
                 }
 
-                if( (CPLFetchBool(papszOptions, "TEXT_CONTENT", false) ||
-                     CPLFetchBool(papszOptions, "ALL", false) ) &&
+                if( psDumpContext->bDumpTextContent &&
                     strcmp(pszBoxType, "jp2c") != 0 &&
                     nBoxDataLength < 100 * 1024 )
                 {
+                    if( !CreateBox() )
+                        break;
                     GByte* pabyBoxData = oBox.ReadBoxData();
                     if( pabyBoxData )
                     {
@@ -1916,55 +2091,86 @@ void GDALGetJPEG2000StructureInternal(CPLXMLNode* psParent,
 
                 if( strcmp(pszBoxType, "jp2c") == 0 )
                 {
-                    if( CPLFetchBool(papszOptions, "CODESTREAM", false) ||
-                        CPLFetchBool(papszOptions, "ALL", false) )
+                    if( psDumpContext->bDumpCodestream ||
+                        psDumpContext->pszCodestreamMarkers )
                     {
+                        if( !CreateBox() )
+                            break;
                         DumpJPK2CodeStream(psBox, fp,
                                            oBox.GetDataOffset(),
                                            nBoxDataLength,
                                            psDumpContext);
+                        if( psDumpContext->bStopAtSOD &&
+                            psDumpContext->bSODEncountered )
+                        {
+                            break;
+                        }
                     }
+                }
+                else if( !psDumpContext->bDumpJP2Boxes )
+                {
+                    // do nothing
                 }
                 else if( strcmp(pszBoxType, "uuid") == 0 &&
                          GDALJP2Metadata::IsUUID_MSI(oBox.GetUUID()) )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpGeoTIFFBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "ftyp") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpFTYPBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "ihdr") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpIHDRBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "bpcc") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpBPCCBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "colr") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpCOLRBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "pclr") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpPCLRBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "cmap") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpCMAPBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "cdef") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpCDEFBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "resc") == 0 ||
                          strcmp(pszBoxType, "resd") == 0)
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpRESxBox(psBox, oBox, psDumpContext);
                 }
                 else if( strcmp(pszBoxType, "rreq") == 0 )
                 {
+                    if( !CreateBox() )
+                        break;
                     DumpRREQBox(psBox, oBox, psDumpContext);
                 }
             }
@@ -1987,7 +2193,9 @@ constexpr unsigned char jp2_box_jp[] = {0x6a,0x50,0x20,0x20}; /* 'jP  ' */
  * @param pszFilename filename.
  * @param papszOptions NULL terminated list of options, or NULL.
  *                     Allowed options are BINARY_CONTENT=YES, TEXT_CONTENT=YES,
- *                     CODESTREAM=YES, ALL=YES.
+ *                     CODESTREAM=YES, ALL=YES, JP2_BOXES=YES,
+ *                     CODESTREAM_MARKERS=list_of_marker_names_comma_separated,
+ *                     STOP_AT_SOD=YES, ALLOW_GET_FILE_SIZE=NO.
  * @return XML tree (to be freed with CPLDestroyXMLNode()) or NULL in case
  *         of error
  * @since GDAL 2.0
@@ -2015,19 +2223,31 @@ CPLXMLNode* GDALGetJPEG2000Structure(const char* pszFilename,
     CPLXMLNode* psParent = nullptr;
     DumpContext dc;
     dc.nCurLineCount = 0;
-    dc.nMaxLineCount = atoi(CPLGetConfigOption("GDAL_JPEG2000_STRUCTURE_MAX_LINES", "500000"));
+    dc.nMaxLineCount = atoi(CSLFetchNameValueDef(papszOptions,"MAX_LINES",
+          CPLGetConfigOption("GDAL_JPEG2000_STRUCTURE_MAX_LINES", "500000")));
+    dc.bDumpAll = CPLFetchBool(papszOptions, "ALL", false);
+    dc.bDumpCodestream = dc.bDumpAll || CPLFetchBool(papszOptions, "CODESTREAM", false);
+    dc.bDumpBinaryContent = dc.bDumpAll || CPLFetchBool(papszOptions, "BINARY_CONTENT", false);
+    dc.bDumpTextContent = dc.bDumpAll || CPLFetchBool(papszOptions, "TEXT_CONTENT", false);
+    dc.pszCodestreamMarkers = CSLFetchNameValue(papszOptions, "CODESTREAM_MARKERS");
+    dc.bDumpJP2Boxes = dc.bDumpAll ||
+                       CPLFetchBool(papszOptions, "JP2_BOXES", false) ||
+                       dc.pszCodestreamMarkers == nullptr;
+    dc.bStopAtSOD = CPLFetchBool(papszOptions, "STOP_AT_SOD", false);
+    dc.bAllowGetFileSize = CPLFetchBool(papszOptions, "ALLOW_GET_FILE_SIZE", true);
 
     if( memcmp(abyHeader, jpc_header, sizeof(jpc_header)) == 0 )
     {
-        if( CPLFetchBool(papszOptions, "CODESTREAM", false) ||
-            CPLFetchBool(papszOptions, "ALL", false) )
+        if( dc.bDumpCodestream ||
+            dc.pszCodestreamMarkers != nullptr )
         {
-            if( VSIFSeekL(fp, 0, SEEK_END) == 0 )
+            GIntBig nBoxDataLength = -1;
+            if( dc.bAllowGetFileSize && VSIFSeekL(fp, 0, SEEK_END) == 0 )
             {
-                GIntBig nBoxDataLength = static_cast<GIntBig>(VSIFTellL(fp));
-                psParent = DumpJPK2CodeStream(nullptr, fp, 0, nBoxDataLength, &dc);
-                CPLAddXMLAttributeAndValue(psParent, "filename", pszFilename );
+                nBoxDataLength = static_cast<GIntBig>(VSIFTellL(fp));
             }
+            psParent = DumpJPK2CodeStream(nullptr, fp, 0, nBoxDataLength, &dc);
+            CPLAddXMLAttributeAndValue(psParent, "filename", pszFilename );
         }
     }
     else
@@ -2035,7 +2255,7 @@ CPLXMLNode* GDALGetJPEG2000Structure(const char* pszFilename,
         psParent = CPLCreateXMLNode( nullptr, CXT_Element, "JP2File" );
         CPLAddXMLAttributeAndValue(psParent, "filename", pszFilename );
         vsi_l_offset nFileSize = 0;
-        GDALGetJPEG2000StructureInternal(psParent, fp, nullptr, papszOptions, 0, nFileSize, &dc);
+        GDALGetJPEG2000StructureInternal(psParent, fp, nullptr, 0, nFileSize, &dc);
     }
 
     if( dc.nCurLineCount > dc.nMaxLineCount )


### PR DESCRIPTION
- JPEG2000 drivers: report a COMPRESSION_REVERSIBILITY=LOSSLESS/LOSSLESS (possibly)/LOSSY metadata item in IMAGE_STRUCTURE domain
- JP2OpenJPEG: for reversible compression, write a hint in the COM marker if the compression is lossy or not, and use it on reading
- NITF: report COMPRESSION_REVERSIBILITY for JPEG2000 compressed images
