### PR TITLE
Make CPLODBCSession and CPLODBCStatement member variables 'protected' (fixes #6314)

### DIFF
--- a/port/cpl_odbc.cpp
+++ b/port/cpl_odbc.cpp
@@ -1567,6 +1567,7 @@ void CPLODBCStatement::ClearColumnData()
 /*                               Failed()                               */
 /************************************************************************/
 
+//! @cond Doxygen_Suppress
 /** Failed */
 int CPLODBCStatement::Failed( int nResultCode )
 
@@ -1576,6 +1577,7 @@ int CPLODBCStatement::Failed( int nResultCode )
 
     return TRUE;
 }
+//! @endcond
 
 /************************************************************************/
 /*                         Append(const char *)                         */

--- a/port/cpl_odbc.h
+++ b/port/cpl_odbc.h
@@ -174,6 +174,7 @@ class CPL_DLL CPLODBCSession {
 
     CPL_DISALLOW_COPY_ASSIGN(CPLODBCSession)
 
+  protected:
     CPLString m_osLastError{};
     HENV      m_hEnv = nullptr;
     HDBC      m_hDBC = nullptr;
@@ -225,6 +226,7 @@ class CPL_DLL CPLODBCStatement {
 
     CPL_DISALLOW_COPY_ASSIGN(CPLODBCStatement)
 
+  protected:
     int m_nFlags = 0;
 
     CPLODBCSession     *m_poSession = nullptr;

--- a/port/cpl_odbc.h
+++ b/port/cpl_odbc.h
@@ -174,12 +174,14 @@ class CPL_DLL CPLODBCSession {
 
     CPL_DISALLOW_COPY_ASSIGN(CPLODBCSession)
 
+/*! @cond Doxygen_Suppress */
   protected:
     CPLString m_osLastError{};
     HENV      m_hEnv = nullptr;
     HDBC      m_hDBC = nullptr;
     int       m_bInTransaction = false;
     int       m_bAutoCommit = true;
+/*! @endcond */
 
   public:
     CPLODBCSession();
@@ -226,6 +228,7 @@ class CPL_DLL CPLODBCStatement {
 
     CPL_DISALLOW_COPY_ASSIGN(CPLODBCStatement)
 
+/*! @cond Doxygen_Suppress */
   protected:
     int m_nFlags = 0;
 
@@ -250,6 +253,7 @@ class CPL_DLL CPLODBCStatement {
     char          *m_pszStatement = nullptr;
     size_t         m_nStatementMax = 0;
     size_t         m_nStatementLen = 0;
+/*! @endcond */
 
   public:
 


### PR DESCRIPTION
Not private, so it's possible to create useful derived classes.

