### PR TITLE
GPKG: raster overlays: Fix min max mean std_dev values when creating overviews

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -5504,6 +5504,9 @@ GDALDataset* GDALGeoPackageDataset::CreateCopy( const char *pszFilename,
         return nullptr;
     }
 
+    // Assign nodata values before the SetGeoTransform call.
+    // SetGeoTransform will trigger creation of the overview datasets for each zoom level
+    // and at that point the nodata value needs to be known.
     int bHasNoData = FALSE;
     double dfNoDataValue =
             poSrcDS->GetRasterBand(1)->GetNoDataValue(&bHasNoData);

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -5504,6 +5504,14 @@ GDALDataset* GDALGeoPackageDataset::CreateCopy( const char *pszFilename,
         return nullptr;
     }
 
+    int bHasNoData = FALSE;
+    double dfNoDataValue =
+            poSrcDS->GetRasterBand(1)->GetNoDataValue(&bHasNoData);
+    if( eDT != GDT_Byte && bHasNoData )
+    {
+        poDS->GetRasterBand(1)->SetNoDataValue(dfNoDataValue);
+    }
+
     poDS->SetGeoTransform(adfGeoTransform);
     poDS->SetProjection(pszWKT);
     CPLFree(pszWKT);
@@ -5511,14 +5519,6 @@ GDALDataset* GDALGeoPackageDataset::CreateCopy( const char *pszFilename,
     if( nTargetBands == 1 && nBands == 1 && poSrcDS->GetRasterBand(1)->GetColorTable() != nullptr )
     {
         poDS->GetRasterBand(1)->SetColorTable( poSrcDS->GetRasterBand(1)->GetColorTable() );
-    }
-
-    int bHasNoData = FALSE;
-    double dfNoDataValue =
-            poSrcDS->GetRasterBand(1)->GetNoDataValue(&bHasNoData);
-    if( eDT != GDT_Byte && bHasNoData )
-    {
-        poDS->GetRasterBand(1)->SetNoDataValue(dfNoDataValue);
     }
 
     hTransformArg =


### PR DESCRIPTION
## What does this PR do?
Fix the values of the `min` `max` `mean` `std_dev` columns of the `gpkg_2d_gridded_tile_ancillary` table

When creating overlays for a GeoPackage containing raster tiles that have a nodata of e.g. -9999
The values of min max mean will be calculated without ignoring the nodata entries.

Reason:
In the `GDALGeoPackageDataset::CreateCopy` implementation `poDS->SetGeoTransform(adfGeoTransform);` is called before the nodata values are taken over.

`SetGeoTransform` calls `GDALGeoPackageDataset::FinalizeRasterRegistration` which in turn calls `poOvrDS->InitRaster` for each zoom level.

This is currently done before the nodata has been assigned to the parent dataset so when the overview tiles are created in `GDALGPKGMBTilesLikePseudoDataset::WriteTileInternal` `bHasNoData` will be false and de nodata values will be included in the statistics calculation.

This pull request puts the copy of the nodata values before the call to `SetGeoTransform`

## What are related issues/pull requests?
None

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

