### PR TITLE
Make CPL_VSIS3_USE_BASE_RMDIR_RECURSIVE and GDAL_DISABLE_READDIR_ON_OPEN path-specific options

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -3619,19 +3619,19 @@ namespace tut
         ensure_equals(CPLGetLastErrorType(), CE_None);
 
         {
-            const char* pszVal = VSIGetCredential("/vsi_test/foo/bar", "FOO", nullptr);
+            const char* pszVal = VSIGetPathSpecificOption("/vsi_test/foo/bar", "FOO", nullptr);
             ensure(pszVal != nullptr);
             ensure_equals(std::string(pszVal), std::string("BAR"));
         }
 
         {
-            const char* pszVal = VSIGetCredential("/vsi_test/foo/bar", "FOO2", nullptr);
+            const char* pszVal = VSIGetPathSpecificOption("/vsi_test/foo/bar", "FOO2", nullptr);
             ensure(pszVal != nullptr);
             ensure_equals(std::string(pszVal), std::string("BAR2"));
         }
 
         {
-            const char* pszVal = VSIGetCredential("/vsi_test/bar/baz", "BAR", nullptr);
+            const char* pszVal = VSIGetPathSpecificOption("/vsi_test/bar/baz", "BAR", nullptr);
             ensure(pszVal != nullptr);
             ensure_equals(std::string(pszVal), std::string("BAZ"));
         }
@@ -3642,11 +3642,11 @@ namespace tut
             ensure_equals(std::string(pszVal), std::string("BAR"));
         }
 
-        VSIClearCredentials("/vsi_test/bar/baz");
+        VSIClearPathSpecificOptions("/vsi_test/bar/baz");
         CPLSetConfigOption("configoptions_FOO", nullptr);
 
         {
-            const char* pszVal = VSIGetCredential("/vsi_test/bar/baz", "BAR", nullptr);
+            const char* pszVal = VSIGetPathSpecificOption("/vsi_test/bar/baz", "BAR", nullptr);
             ensure(pszVal == nullptr);
         }
 
@@ -3717,12 +3717,12 @@ namespace tut
         ensure_equals(CPLGetLastErrorType(), CE_Warning);
 
         {
-            const char* pszVal = VSIGetCredential("/vsi_test/foo", "FOO", nullptr);
+            const char* pszVal = VSIGetPathSpecificOption("/vsi_test/foo", "FOO", nullptr);
             ensure(pszVal != nullptr);
         }
 
         {
-            const char* pszVal = VSIGetCredential("/vsi_test/foo", "BAR", nullptr);
+            const char* pszVal = VSIGetPathSpecificOption("/vsi_test/foo", "BAR", nullptr);
             ensure(pszVal == nullptr);
         }
 

--- a/autotest/gcore/vsipathspecificoption.py
+++ b/autotest/gcore/vsipathspecificoption.py
@@ -3,7 +3,7 @@
 # $Id$
 #
 # Project:  GDAL/OGR Test Suite
-# Purpose:  Test VSI credentials
+# Purpose:  Test VSI path specific options
 # Author:   Even Rouault <even dot rouault at spatialys dot com>
 #
 ###############################################################################
@@ -33,39 +33,39 @@ import pytest
 from osgeo import gdal
 
 
-def test_vsicredential():
+def test_vsi_path_specific_options():
 
     with pytest.raises(Exception):
-        assert gdal.GetCredential(None, "key")
+        assert gdal.GetPathSpecificOption(None, "key")
 
     with pytest.raises(Exception):
-        assert gdal.GetCredential("prefix", None)
+        assert gdal.GetPathSpecificOption("prefix", None)
 
-    assert gdal.GetCredential("prefix", "key") is None
+    assert gdal.GetPathSpecificOption("prefix", "key") is None
 
-    assert gdal.GetCredential("prefix", "key", "default") == "default"
-
-    with pytest.raises(Exception):
-        gdal.SetCredential(None, "key", "value")
+    assert gdal.GetPathSpecificOption("prefix", "key", "default") == "default"
 
     with pytest.raises(Exception):
-        gdal.SetCredential("prefix", None, "value")
+        gdal.SetPathSpecificOption(None, "key", "value")
 
-    gdal.SetCredential("prefix", "key", "value")
-    assert gdal.GetCredential("prefix", "key") == "value"
-    assert gdal.GetCredential("prefix/object", "key") == "value"
-    assert gdal.GetCredential("prefix", "key", "default") == "value"
-    assert gdal.GetCredential("another_prefix", "key") is None
+    with pytest.raises(Exception):
+        gdal.SetPathSpecificOption("prefix", None, "value")
 
-    gdal.SetCredential("prefix", "key", None)
-    assert gdal.GetCredential("prefix", "key") is None
+    gdal.SetPathSpecificOption("prefix", "key", "value")
+    assert gdal.GetPathSpecificOption("prefix", "key") == "value"
+    assert gdal.GetPathSpecificOption("prefix/object", "key") == "value"
+    assert gdal.GetPathSpecificOption("prefix", "key", "default") == "value"
+    assert gdal.GetPathSpecificOption("another_prefix", "key") is None
 
-    gdal.SetCredential("prefix", "key", "value")
-    gdal.ClearCredentials("prefix")
-    assert gdal.GetCredential("prefix", "key") is None
+    gdal.SetPathSpecificOption("prefix", "key", None)
+    assert gdal.GetPathSpecificOption("prefix", "key") is None
 
-    gdal.SetCredential("prefix", "key", "value")
-    gdal.ClearCredentials("another_prefix")
-    assert gdal.GetCredential("prefix", "key") == "value"
-    gdal.ClearCredentials()
-    assert gdal.GetCredential("prefix", "key") is None
+    gdal.SetPathSpecificOption("prefix", "key", "value")
+    gdal.ClearPathSpecificOptions("prefix")
+    assert gdal.GetPathSpecificOption("prefix", "key") is None
+
+    gdal.SetPathSpecificOption("prefix", "key", "value")
+    gdal.ClearPathSpecificOptions("another_prefix")
+    assert gdal.GetPathSpecificOption("prefix", "key") == "value"
+    gdal.ClearPathSpecificOptions()
+    assert gdal.GetPathSpecificOption("prefix", "key") is None

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -125,7 +125,7 @@ the configuration file starts with a ``[directives]`` section that contains a
 
 Starting with GDAL 3.5, a configuration file can also contain credentials
 (or more generally options related to a virtual file system) for a given path prefix,
-that can also be set with :cpp:func:`VSISetCredential`. Credentials should be put under
+that can also be set with :cpp:func:`VSISetPathSpecificOption`. Credentials should be put under
 a ``[credentials]`` section, and for each path prefix, under a relative subsection
 whose name starts with "[." (e.g. "[.some_arbitrary_name]"), and whose first
 key is "path".

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -152,12 +152,12 @@ Cloud storage services require setting credentials. For some of them, they can
 be provided through configuration files (~/.aws/config, ~/.boto, ..) or through
 environment variables / configuration options.
 
-Starting with GDAL 3.5, :cpp:func:`VSISetCredential` can be used to set configuration
+Starting with GDAL 3.6, :cpp:func:`VSISetPathSpecificOption` can be used to set configuration
 options with a granularity at the level of a file path, which makes it easier if using
 the same virtual file system but with different credentials (e.g. different
 credentials for bucket "/vsis3/foo" and "/vsis3/bar")
 
-Starting with GDAL 3.5, credentials can be specified in a
+Starting with GDAL 3.5, credentials (or path specific options) can be specified in a
 :ref:`GDAL configuration file <gdal_configuration_file>`, either in a specific one
 explicitly loaded with :cpp:func:`CPLLoadConfigOptionsFromFile`, or
 one of the default automatically loaded by :cpp:func:`CPLLoadConfigOptionsFromPredefinedFiles`.

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -313,7 +313,7 @@ accept a comma-separated list of storage class names and defaults to ``GLACIER,D
 
 Since GDAL 3.1, the :cpp:func:`VSIRename` operation is supported (first doing a copy of the original file and then deleting it)
 
-Since GDAL 3.1, the :cpp:func:`VSIRmdirRecursive` operation is supported (using batch deletion method). The :decl_configoption:`CPL_VSIS3_USE_BASE_RMDIR_RECURSIVE` configuration option can be set to YES if using a S3-like API that doesn't support batch deletion (GDAL >= 3.2)
+Since GDAL 3.1, the :cpp:func:`VSIRmdirRecursive` operation is supported (using batch deletion method). The :decl_configoption:`CPL_VSIS3_USE_BASE_RMDIR_RECURSIVE` configuration option can be set to YES if using a S3-like API that doesn't support batch deletion (GDAL >= 3.2). Starting with GDAL 3.6, this can be set as a path-specific option in the :ref:`GDAL configuration file <gdal_configuration_file>`
 
 Starting with GDAL 3.5, profiles that use IAM role assumption (see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html) are handled. The ``role_arn`` and ``source_profile`` keywords are required in such profiles. The optional ``external_id``, ``mfa_serial`` and ``role_session_name`` can be specified. ``credential_source`` is not supported currently.
 

--- a/gcore/gdalopeninfo.cpp
+++ b/gcore/gdalopeninfo.cpp
@@ -354,7 +354,7 @@ retry:  // TODO(schwehr): Stop using goto.
         else
         {
             const char* pszOptionVal =
-                CPLGetConfigOption( "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
+                VSIGetPathSpecificOption( pszFilename, "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
             if (EQUAL(pszOptionVal, "EMPTY_DIR"))
             {
                 papszSiblingFiles =
@@ -417,7 +417,7 @@ char** GDALOpenInfo::GetSiblingFiles()
 
     CPLString osDir = CPLGetDirname( pszFilename );
     const int nMaxFiles =
-        atoi(CPLGetConfigOption("GDAL_READDIR_LIMIT_ON_OPEN", "1000"));
+        atoi(VSIGetPathSpecificOption( pszFilename, "GDAL_READDIR_LIMIT_ON_OPEN", "1000"));
     papszSiblingFiles = VSIReadDirEx( osDir, nMaxFiles );
     if( nMaxFiles > 0 && CSLCount(papszSiblingFiles) > nMaxFiles )
     {

--- a/port/cpl_alibaba_oss.cpp
+++ b/port/cpl_alibaba_oss.cpp
@@ -204,13 +204,13 @@ bool VSIOSSHandleHelper::GetConfiguration(const std::string& osPathForOption,
 {
     osSecretAccessKey = CSLFetchNameValueDef(papszOptions,
         "OSS_SECRET_ACCESS_KEY",
-        VSIGetCredential(osPathForOption.c_str(), "OSS_SECRET_ACCESS_KEY", ""));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "OSS_SECRET_ACCESS_KEY", ""));
 
     if( !osSecretAccessKey.empty() )
     {
         osAccessKeyId = CSLFetchNameValueDef(papszOptions,
             "OSS_ACCESS_KEY_ID",
-            VSIGetCredential(osPathForOption.c_str(), "OSS_ACCESS_KEY_ID", ""));
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "OSS_ACCESS_KEY_ID", ""));
         if( osAccessKeyId.empty() )
         {
             VSIError(VSIE_AWSInvalidCredentials,
@@ -248,7 +248,7 @@ VSIOSSHandleHelper* VSIOSSHandleHelper::BuildFromURI( const char* pszURI,
 
     const CPLString osEndpoint = CSLFetchNameValueDef(papszOptions,
         "OSS_ENDPOINT",
-        VSIGetCredential(osPathForOption.c_str(), "OSS_ENDPOINT", "oss-us-east-1.aliyuncs.com"));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "OSS_ENDPOINT", "oss-us-east-1.aliyuncs.com"));
     CPLString osBucket;
     CPLString osObjectKey;
     if( pszURI != nullptr && pszURI[0] != '\0' &&
@@ -257,11 +257,11 @@ VSIOSSHandleHelper* VSIOSSHandleHelper::BuildFromURI( const char* pszURI,
     {
         return nullptr;
     }
-    const bool bUseHTTPS = CPLTestBool(VSIGetCredential(osPathForOption.c_str(), "OSS_HTTPS", "YES"));
+    const bool bUseHTTPS = CPLTestBool(VSIGetPathSpecificOption(osPathForOption.c_str(), "OSS_HTTPS", "YES"));
     const bool bIsValidNameForVirtualHosting =
         osBucket.find('.') == std::string::npos;
     const bool bUseVirtualHosting = CPLTestBool(
-        VSIGetCredential(osPathForOption.c_str(), "OSS_VIRTUAL_HOSTING",
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "OSS_VIRTUAL_HOSTING",
                            bIsValidNameForVirtualHosting ? "TRUE" : "FALSE"));
     return new VSIOSSHandleHelper(osSecretAccessKey, osAccessKeyId,
                                  osEndpoint,

--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -773,14 +773,14 @@ bool VSIS3HandleHelper::GetConfigurationFromAssumeRoleWithWebIdentity(bool bForc
         }
     }
 
-    const CPLString roleArn = VSIGetCredential(osPathForOption.c_str(), "AWS_ROLE_ARN", "");
+    const CPLString roleArn = VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_ROLE_ARN", "");
     if( roleArn.empty() )
     {
         CPLDebug("AWS", "AWS_ROLE_ARN configuration option not defined");
         return false;
     }
 
-    const CPLString webIdentityTokenFile =  VSIGetCredential(osPathForOption.c_str(),
+    const CPLString webIdentityTokenFile =  VSIGetPathSpecificOption(osPathForOption.c_str(),
                                                              "AWS_WEB_IDENTITY_TOKEN_FILE", "");
     if( webIdentityTokenFile.empty() )
     {
@@ -788,18 +788,18 @@ bool VSIS3HandleHelper::GetConfigurationFromAssumeRoleWithWebIdentity(bool bForc
         return false;
     }
 
-    const CPLString stsRegionalEndpoints = VSIGetCredential(osPathForOption.c_str(),
+    const CPLString stsRegionalEndpoints = VSIGetPathSpecificOption(osPathForOption.c_str(),
                                                             "AWS_STS_REGIONAL_ENDPOINTS", "regional");
 
     std::string osStsDefaultUrl;
     if (stsRegionalEndpoints == "regional") {
-        const CPLString osRegion = VSIGetCredential(osPathForOption.c_str(), "AWS_REGION", "us-east-1");
+        const CPLString osRegion = VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_REGION", "us-east-1");
         osStsDefaultUrl = "https://sts." + osRegion + ".amazonaws.com";
     } else {
         osStsDefaultUrl = "https://sts.amazonaws.com";
     }
     const CPLString osStsRootUrl(
-        VSIGetCredential(osPathForOption.c_str(), "CPL_AWS_STS_ROOT_URL", osStsDefaultUrl.c_str()));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "CPL_AWS_STS_ROOT_URL", osStsDefaultUrl.c_str()));
 
     // Get token from web identity token file
     CPLString webIdentityToken;
@@ -887,10 +887,10 @@ bool VSIS3HandleHelper::GetConfigurationFromEC2(bool bForceRefresh,
     const CPLString osEC2DefaultURL("http://169.254.169.254");
     // coverity[tainted_data]
     const CPLString osEC2RootURL(
-        VSIGetCredential(osPathForOption.c_str(), "CPL_AWS_EC2_API_ROOT_URL", osEC2DefaultURL));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "CPL_AWS_EC2_API_ROOT_URL", osEC2DefaultURL));
     // coverity[tainted_data]
     const CPLString osECSRelativeURI(
-        VSIGetCredential(osPathForOption.c_str(), "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", ""));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", ""));
     CPLString osToken;
     if( osEC2RootURL == osEC2DefaultURL && !osECSRelativeURI.empty() )
     {
@@ -1111,9 +1111,9 @@ bool VSIS3HandleHelper::GetConfigurationFromAWSConfigFiles(
     // If AWS_DEFAULT_PROFILE is set (obsolete, no longer documented), use it in priority
     // Otherwise use AWS_PROFILE
     // Otherwise fallback to "default"
-    const char* pszProfile = VSIGetCredential(osPathForOption.c_str(), "AWS_DEFAULT_PROFILE", "");
+    const char* pszProfile = VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_DEFAULT_PROFILE", "");
     if( pszProfile[0] == '\0' )
-        pszProfile = VSIGetCredential(osPathForOption.c_str(), "AWS_PROFILE", "");
+        pszProfile = VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_PROFILE", "");
     const CPLString osProfile(pszProfile[0] != '\0' ? pszProfile : "default");
 
 #ifdef WIN32
@@ -1133,7 +1133,7 @@ bool VSIS3HandleHelper::GetConfigurationFromAWSConfigFiles(
     // GDAL specific config option (mostly for testing purpose, but also
     // used in production in some cases)
     const char* pszCredentials =
-        VSIGetCredential(osPathForOption.c_str(), "CPL_AWS_CREDENTIALS_FILE", nullptr );
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "CPL_AWS_CREDENTIALS_FILE", nullptr );
     if( pszCredentials )
     {
         osCredentials = pszCredentials;
@@ -1150,7 +1150,7 @@ bool VSIS3HandleHelper::GetConfigurationFromAWSConfigFiles(
 
     // And then ~/.aws/config file (unless AWS_CONFIG_FILE is defined)
     const char* pszAWSConfigFileEnv =
-        VSIGetCredential(osPathForOption.c_str(), "AWS_CONFIG_FILE", nullptr );
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_CONFIG_FILE", nullptr );
     CPLString osConfig;
     if( pszAWSConfigFileEnv )
     {
@@ -1436,9 +1436,9 @@ bool VSIS3HandleHelper::GetConfiguration(const std::string& osPathForOption,
     // AWS_REGION is GDAL specific. Later overloaded by standard
     // AWS_DEFAULT_REGION
     osRegion = CSLFetchNameValueDef(papszOptions, "AWS_REGION",
-            VSIGetCredential(osPathForOption.c_str(), "AWS_REGION", "us-east-1"));
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_REGION", "us-east-1"));
 
-    if( CPLTestBool(VSIGetCredential(osPathForOption.c_str(), "AWS_NO_SIGN_REQUEST", "NO")) )
+    if( CPLTestBool(VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_NO_SIGN_REQUEST", "NO")) )
     {
         osSecretAccessKey.clear();
         osAccessKeyId.clear();
@@ -1448,12 +1448,12 @@ bool VSIS3HandleHelper::GetConfiguration(const std::string& osPathForOption,
 
     osSecretAccessKey = CSLFetchNameValueDef(papszOptions,
         "AWS_SECRET_ACCESS_KEY",
-        VSIGetCredential(osPathForOption.c_str(), "AWS_SECRET_ACCESS_KEY", ""));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_SECRET_ACCESS_KEY", ""));
     if( !osSecretAccessKey.empty() )
     {
         osAccessKeyId = CSLFetchNameValueDef(papszOptions,
             "AWS_ACCESS_KEY_ID",
-            VSIGetCredential(osPathForOption.c_str(), "AWS_ACCESS_KEY_ID", ""));
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_ACCESS_KEY_ID", ""));
         if( osAccessKeyId.empty() )
         {
             VSIError(VSIE_AWSInvalidCredentials,
@@ -1463,7 +1463,7 @@ bool VSIS3HandleHelper::GetConfiguration(const std::string& osPathForOption,
 
         osSessionToken = CSLFetchNameValueDef(papszOptions,
             "AWS_SESSION_TOKEN",
-            VSIGetCredential(osPathForOption.c_str(), "AWS_SESSION_TOKEN", ""));
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_SESSION_TOKEN", ""));
         return true;
     }
 
@@ -1657,16 +1657,16 @@ VSIS3HandleHelper* VSIS3HandleHelper::BuildFromURI( const char* pszURI,
     // " This variable overrides the default region of the in-use profile, if set."
     const CPLString osDefaultRegion = CSLFetchNameValueDef(
         papszOptions, "AWS_DEFAULT_REGION",
-        VSIGetCredential(osPathForOption.c_str(), "AWS_DEFAULT_REGION", ""));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_DEFAULT_REGION", ""));
     if( !osDefaultRegion.empty() )
     {
         osRegion = osDefaultRegion;
     }
 
     const CPLString osEndpoint =
-        VSIGetCredential(osPathForOption.c_str(), "AWS_S3_ENDPOINT", "s3.amazonaws.com");
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_S3_ENDPOINT", "s3.amazonaws.com");
     const CPLString osRequestPayer =
-        VSIGetCredential(osPathForOption.c_str(), "AWS_REQUEST_PAYER", "");
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_REQUEST_PAYER", "");
     CPLString osBucket;
     CPLString osObjectKey;
     if( pszURI != nullptr && pszURI[0] != '\0' &&
@@ -1675,12 +1675,12 @@ VSIS3HandleHelper* VSIS3HandleHelper::BuildFromURI( const char* pszURI,
     {
         return nullptr;
     }
-    const bool bUseHTTPS = CPLTestBool(VSIGetCredential(osPathForOption.c_str(), "AWS_HTTPS", "YES"));
+    const bool bUseHTTPS = CPLTestBool(VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_HTTPS", "YES"));
     const bool bIsValidNameForVirtualHosting =
         osBucket.find('.') == std::string::npos;
     const bool bUseVirtualHosting = CPLTestBool(
         CSLFetchNameValueDef(papszOptions, "AWS_VIRTUAL_HOSTING",
-                VSIGetCredential(osPathForOption.c_str(), "AWS_VIRTUAL_HOSTING",
+                VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_VIRTUAL_HOSTING",
                            bIsValidNameForVirtualHosting ? "TRUE" : "FALSE")));
     return new VSIS3HandleHelper(osSecretAccessKey, osAccessKeyId,
                                  osSessionToken,
@@ -1819,7 +1819,7 @@ VSIS3HandleHelper::GetCurlHeaders( const CPLString& osVerb,
 
     RefreshCredentials(osPathForOption, /* bForceRefresh = */ false);
 
-    CPLString osXAMZDate = VSIGetCredential(osPathForOption.c_str(), "AWS_TIMESTAMP", "");
+    CPLString osXAMZDate = VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_TIMESTAMP", "");
     if( osXAMZDate.empty() )
         osXAMZDate = CPLGetAWS_SIGN4_Timestamp(time(nullptr));
 
@@ -2079,7 +2079,7 @@ CPLString VSIS3HandleHelper::GetSignedURL(CSLConstList papszOptions)
     osPathForOption += m_osObjectKey;
 
     CPLString osXAMZDate = CSLFetchNameValueDef(papszOptions, "START_DATE",
-        VSIGetCredential(osPathForOption.c_str(), "AWS_TIMESTAMP", ""));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_TIMESTAMP", ""));
     if( osXAMZDate.empty() )
         osXAMZDate = CPLGetAWS_SIGN4_Timestamp(time(nullptr));
     CPLString osDate(osXAMZDate);

--- a/port/cpl_azure.cpp
+++ b/port/cpl_azure.cpp
@@ -528,14 +528,14 @@ bool VSIAzureBlobHandleHelper::GetConfiguration(const std::string& osPathForOpti
     bFromManagedIdentities = false;
 
     const CPLString osServicePrefix ( eService == Service::SERVICE_BLOB ? "blob" : "dfs" );
-    bUseHTTPS = CPLTestBool(VSIGetCredential(
+    bUseHTTPS = CPLTestBool(VSIGetPathSpecificOption(
         osPathForOption.c_str(), "CPL_AZURE_USE_HTTPS", "YES"));
-    osEndpoint = VSIGetCredential(
+    osEndpoint = VSIGetPathSpecificOption(
         osPathForOption.c_str(), "CPL_AZURE_ENDPOINT", "");
 
     const CPLString osStorageConnectionString(
         CSLFetchNameValueDef(papszOptions, "AZURE_STORAGE_CONNECTION_STRING",
-        VSIGetCredential(osPathForOption.c_str(), "AZURE_STORAGE_CONNECTION_STRING", "")));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "AZURE_STORAGE_CONNECTION_STRING", "")));
     if( !osStorageConnectionString.empty() )
     {
         return ParseStorageConnectionString(osStorageConnectionString,
@@ -549,7 +549,7 @@ bool VSIAzureBlobHandleHelper::GetConfiguration(const std::string& osPathForOpti
     {
         osStorageAccount = CSLFetchNameValueDef(papszOptions,
             "AZURE_STORAGE_ACCOUNT",
-            VSIGetCredential(osPathForOption.c_str(), "AZURE_STORAGE_ACCOUNT", ""));
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "AZURE_STORAGE_ACCOUNT", ""));
         if( !osStorageAccount.empty() )
         {
             if( osEndpoint.empty() )
@@ -557,21 +557,21 @@ bool VSIAzureBlobHandleHelper::GetConfiguration(const std::string& osPathForOpti
 
             osAccessToken = CSLFetchNameValueDef(papszOptions,
                 "AZURE_STORAGE_ACCESS_TOKEN",
-                VSIGetCredential(osPathForOption.c_str(), "AZURE_STORAGE_ACCESS_TOKEN", ""));
+                VSIGetPathSpecificOption(osPathForOption.c_str(), "AZURE_STORAGE_ACCESS_TOKEN", ""));
             if( !osAccessToken.empty() )
                 return true;
 
             osStorageKey = CSLFetchNameValueDef(papszOptions,
                 "AZURE_STORAGE_ACCESS_KEY",
-                VSIGetCredential(osPathForOption.c_str(), "AZURE_STORAGE_ACCESS_KEY", ""));
+                VSIGetPathSpecificOption(osPathForOption.c_str(), "AZURE_STORAGE_ACCESS_KEY", ""));
             if( osStorageKey.empty() )
             {
-                osSAS = VSIGetCredential(osPathForOption.c_str(),
+                osSAS = VSIGetPathSpecificOption(osPathForOption.c_str(),
                                          "AZURE_STORAGE_SAS_TOKEN",
                                          CPLGetConfigOption("AZURE_SAS", "")); // AZURE_SAS for GDAL < 3.5
                 if( osSAS.empty() )
                 {
-                    if( CPLTestBool(VSIGetCredential(
+                    if( CPLTestBool(VSIGetPathSpecificOption(
                             osPathForOption.c_str(), "AZURE_NO_SIGN_REQUEST", "NO")) )
                     {
                         return true;
@@ -659,7 +659,7 @@ VSIAzureBlobHandleHelper* VSIAzureBlobHandleHelper::BuildFromURI( const char* ps
         return nullptr;
     }
 
-    if( CPLTestBool(VSIGetCredential(
+    if( CPLTestBool(VSIGetPathSpecificOption(
             osPathForOption.c_str(), "AZURE_NO_SIGN_REQUEST", "NO")) )
     {
         osStorageKey.clear();

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -2023,7 +2023,7 @@ FOO=BAR
 
 Starting with GDAL 3.5, a configuration file can also contain credentials
 (or more generally options related to a virtual file system) for a given path prefix,
-that can also be set with VSISetCredential(). Credentials should be put under
+that can also be set with VSISetPathSpecificOption(). Credentials should be put under
 a [credentials] section, and for each path prefix, under a relative subsection
 whose name starts with "[." (e.g. "[.some_arbitrary_name]"), and whose first
 key is "path".
@@ -2172,7 +2172,7 @@ void CPLLoadConfigOptionsFromFile(const char* pszFilename, int bOverrideEnvVars)
                     }
                     else
                     {
-                        VSISetCredential(osPath.c_str(), pszKey, pszValue);
+                        VSISetPathSpecificOption(osPath.c_str(), pszKey, pszValue);
                     }
                 }
                 CPLFree(pszKey);

--- a/port/cpl_google_cloud.cpp
+++ b/port/cpl_google_cloud.cpp
@@ -151,7 +151,7 @@ struct curl_slist* GetGSHeaders( const std::string& osPathForOption,
         return nullptr;
     }
 
-    CPLString osDate = VSIGetCredential(osPathForOption.c_str(), "CPL_GS_TIMESTAMP", "");
+    CPLString osDate = VSIGetPathSpecificOption(osPathForOption.c_str(), "CPL_GS_TIMESTAMP", "");
     if( osDate.empty() )
     {
         osDate = IVSIS3LikeHandleHelper::GetRFC822DateTime();
@@ -339,18 +339,18 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
     osAccessKeyId.clear();
     osHeaderFile.clear();
 
-    if( CPLTestBool(VSIGetCredential(
+    if( CPLTestBool(VSIGetPathSpecificOption(
             osPathForOption.c_str(), "GS_NO_SIGN_REQUEST", "NO")) )
     {
         return true;
     }
 
     osSecretAccessKey =
-        VSIGetCredential(osPathForOption.c_str(), "GS_SECRET_ACCESS_KEY", "");
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_SECRET_ACCESS_KEY", "");
     if( !osSecretAccessKey.empty() )
     {
         osAccessKeyId =
-            VSIGetCredential(osPathForOption.c_str(), "GS_ACCESS_KEY_ID", "");
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_ACCESS_KEY_ID", "");
         if( osAccessKeyId.empty() )
         {
             VSIError(VSIE_AWSInvalidCredentials,
@@ -370,7 +370,7 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
     }
 
     osHeaderFile =
-        VSIGetCredential(osPathForOption.c_str(), "GDAL_HTTP_HEADER_FILE", "");
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "GDAL_HTTP_HEADER_FILE", "");
     bool bMayWarnDidNotFindAuth = false;
     if( !osHeaderFile.empty() )
     {
@@ -425,7 +425,7 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
         }
     }
 
-    CPLString osRefreshToken( VSIGetCredential(
+    CPLString osRefreshToken( VSIGetPathSpecificOption(
         osPathForOption.c_str(), "GS_OAUTH2_REFRESH_TOKEN", "") );
     if( !osRefreshToken.empty() )
     {
@@ -438,9 +438,9 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
         }
 
         CPLString osClientId =
-            VSIGetCredential(osPathForOption.c_str(), "GS_OAUTH2_CLIENT_ID", "");
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_OAUTH2_CLIENT_ID", "");
         CPLString osClientSecret =
-            VSIGetCredential(osPathForOption.c_str(), "GS_OAUTH2_CLIENT_SECRET", "");
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_OAUTH2_CLIENT_SECRET", "");
 
         int nCount = (!osClientId.empty() ? 1 : 0) +
                      (!osClientSecret.empty() ? 1 : 0);
@@ -470,7 +470,7 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
 
     CPLString osJsonFile( CSLFetchNameValueDef(papszOptions,
         "GOOGLE_APPLICATION_CREDENTIALS",
-        VSIGetCredential(osPathForOption.c_str(), "GOOGLE_APPLICATION_CREDENTIALS", "")));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "GOOGLE_APPLICATION_CREDENTIALS", "")));
     if( !osJsonFile.empty() )
     {
         CPLJSONDocument oDoc;
@@ -489,7 +489,7 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
             CPLString osClientEmail = oDoc.GetRoot().GetString("client_email");
             const char* pszScope =
                 CSLFetchNameValueDef( papszOptions, "GS_OAUTH2_SCOPE",
-                VSIGetCredential(osPathForOption.c_str(), "GS_OAUTH2_SCOPE",
+                VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_OAUTH2_SCOPE",
                     "https://www.googleapis.com/auth/devstorage.read_write"));
 
             return oManager.SetAuthFromServiceAccount(
@@ -516,10 +516,10 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
 
     CPLString osPrivateKey = CSLFetchNameValueDef(papszOptions,
         "GS_OAUTH2_PRIVATE_KEY",
-        VSIGetCredential(osPathForOption.c_str(), "GS_OAUTH2_PRIVATE_KEY", ""));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_OAUTH2_PRIVATE_KEY", ""));
     CPLString osPrivateKeyFile = CSLFetchNameValueDef(papszOptions,
         "GS_OAUTH2_PRIVATE_KEY_FILE",
-        VSIGetCredential(osPathForOption.c_str(), "GS_OAUTH2_PRIVATE_KEY_FILE", ""));
+        VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_OAUTH2_PRIVATE_KEY_FILE", ""));
     if( !osPrivateKey.empty() || !osPrivateKeyFile.empty() )
     {
         if( !osPrivateKeyFile.empty() )
@@ -545,7 +545,7 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
 
         CPLString osClientEmail = CSLFetchNameValueDef(papszOptions,
             "GS_OAUTH2_CLIENT_EMAIL",
-            VSIGetCredential(osPathForOption.c_str(), "GS_OAUTH2_CLIENT_EMAIL", ""));
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_OAUTH2_CLIENT_EMAIL", ""));
         if( osClientEmail.empty() )
         {
             CPLError(CE_Failure, CPLE_AppDefined,
@@ -555,7 +555,7 @@ bool VSIGSHandleHelper::GetConfiguration(const std::string& osPathForOption,
         }
         const char* pszScope =
             CSLFetchNameValueDef( papszOptions, "GS_OAUTH2_SCOPE",
-            VSIGetCredential(osPathForOption.c_str(), "GS_OAUTH2_SCOPE",
+            VSIGetPathSpecificOption(osPathForOption.c_str(), "GS_OAUTH2_SCOPE",
                 "https://www.googleapis.com/auth/devstorage.read_write"));
 
         if( bFirstTimeForDebugMessage )
@@ -732,7 +732,7 @@ VSIGSHandleHelper* VSIGSHandleHelper::BuildFromURI( const char* pszURI,
 
     // pszURI == bucket/object
     const CPLString osBucketObject( pszURI );
-    CPLString osEndpoint( VSIGetCredential(
+    CPLString osEndpoint( VSIGetPathSpecificOption(
         osPathForOption.c_str(), "CPL_GS_ENDPOINT", ""));
     if( osEndpoint.empty() )
         osEndpoint = "https://storage.googleapis.com/";
@@ -752,7 +752,7 @@ VSIGSHandleHelper* VSIGSHandleHelper::BuildFromURI( const char* pszURI,
     // https://cloud.google.com/storage/docs/xml-api/reference-headers#xgooguserproject
     // The Project ID for an existing Google Cloud project to bill for access
     // charges associated with the request.
-    const std::string osUserProject = VSIGetCredential(
+    const std::string osUserProject = VSIGetPathSpecificOption(
         osPathForOption.c_str(), "GS_USER_PROJECT", "");
 
     return new VSIGSHandleHelper( osEndpoint,

--- a/port/cpl_swift.cpp
+++ b/port/cpl_swift.cpp
@@ -94,10 +94,10 @@ bool VSISwiftHandleHelper::GetConfiguration(const std::string& osPathForOption,
                                             CPLString& osStorageURL,
                                             CPLString& osAuthToken)
 {
-    osStorageURL = VSIGetCredential(osPathForOption.c_str(), "SWIFT_STORAGE_URL", "");
+    osStorageURL = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_STORAGE_URL", "");
     if( !osStorageURL.empty() )
     {
-        osAuthToken = VSIGetCredential(osPathForOption.c_str(), "SWIFT_AUTH_TOKEN", "");
+        osAuthToken = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_AUTH_TOKEN", "");
         if( osAuthToken.empty() )
         {
             const char* pszMsg = "Missing SWIFT_AUTH_TOKEN";
@@ -108,10 +108,10 @@ bool VSISwiftHandleHelper::GetConfiguration(const std::string& osPathForOption,
         return true;
     }
 
-    const CPLString osAuthVersion = VSIGetCredential(osPathForOption.c_str(), "OS_IDENTITY_API_VERSION", "");
+    const CPLString osAuthVersion = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_IDENTITY_API_VERSION", "");
     if ( osAuthVersion == "3" )
     {
-        const CPLString osAuthType = VSIGetCredential(osPathForOption.c_str(), "OS_AUTH_TYPE", "");
+        const CPLString osAuthType = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_AUTH_TYPE", "");
         if( ! CheckCredentialsV3(osPathForOption, osAuthType) )
             return false;
         if( osAuthType == "v3applicationcredential" )
@@ -131,7 +131,7 @@ bool VSISwiftHandleHelper::GetConfiguration(const std::string& osPathForOption,
     }
     else
     {
-        const CPLString osAuthV1URL = VSIGetCredential(osPathForOption.c_str(), "SWIFT_AUTH_V1_URL", "");
+        const CPLString osAuthV1URL = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_AUTH_V1_URL", "");
         if ( ! osAuthV1URL.empty() )
         {
             if( ! CheckCredentialsV1(osPathForOption) )
@@ -159,9 +159,9 @@ bool VSISwiftHandleHelper::AuthV1(const std::string& osPathForOption,
                                   CPLString& osStorageURL,
                                   CPLString& osAuthToken)
 {
-    CPLString osAuthURL = VSIGetCredential(osPathForOption.c_str(), "SWIFT_AUTH_V1_URL", "");
-    CPLString osUser = VSIGetCredential(osPathForOption.c_str(), "SWIFT_USER", "");
-    CPLString osKey = VSIGetCredential(osPathForOption.c_str(), "SWIFT_KEY", "");
+    CPLString osAuthURL = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_AUTH_V1_URL", "");
+    CPLString osUser = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_USER", "");
+    CPLString osKey = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_KEY", "");
     char** papszHeaders = CSLSetNameValue(nullptr, "HEADERS",
         CPLSPrintf("X-Auth-User: %s\r\n"
                    "X-Auth-Key: %s",
@@ -212,9 +212,9 @@ CPLJSONObject VSISwiftHandleHelper::CreateAuthV3RequestObject(const std::string&
     if ( osAuthType == "v3applicationcredential" )
     {
         CPLString osApplicationCredentialID =
-                VSIGetCredential(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_ID", "");
+                VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_ID", "");
         CPLString osApplicationCredentialSecret =
-                VSIGetCredential(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_SECRET", "");
+                VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_SECRET", "");
         CPLJSONObject applicationCredential;
         applicationCredential.Add("id", osApplicationCredentialID);
         applicationCredential.Add("secret", osApplicationCredentialSecret);
@@ -224,14 +224,14 @@ CPLJSONObject VSISwiftHandleHelper::CreateAuthV3RequestObject(const std::string&
     }
     else
     {
-        CPLString osUser = VSIGetCredential(osPathForOption.c_str(), "OS_USERNAME", "");
-        CPLString osPassword = VSIGetCredential(osPathForOption.c_str(), "OS_PASSWORD", "");
+        CPLString osUser = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_USERNAME", "");
+        CPLString osPassword = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_PASSWORD", "");
 
         CPLJSONObject user;
         user.Add("name", osUser);
         user.Add("password", osPassword);
 
-        CPLString osUserDomainName = VSIGetCredential(osPathForOption.c_str(), "OS_USER_DOMAIN_NAME", "");
+        CPLString osUserDomainName = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_USER_DOMAIN_NAME", "");
         if( ! osUserDomainName.empty() )
         {
             CPLJSONObject userDomain;
@@ -245,13 +245,13 @@ CPLJSONObject VSISwiftHandleHelper::CreateAuthV3RequestObject(const std::string&
         identity.Add("password", password);
 
         //Request a scope if one is specified in the configuration
-        CPLString osProjectName = VSIGetCredential(osPathForOption.c_str(), "OS_PROJECT_NAME", "");
+        CPLString osProjectName = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_PROJECT_NAME", "");
         if( ! osProjectName.empty() )
         {
             CPLJSONObject project;
             project.Add("name", osProjectName);
 
-            CPLString osProjectDomainName = VSIGetCredential(osPathForOption.c_str(), "OS_PROJECT_DOMAIN_NAME", "");
+            CPLString osProjectDomainName = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_PROJECT_DOMAIN_NAME", "");
             if( ! osProjectDomainName.empty() )
             {
                 CPLJSONObject projectDomain;
@@ -312,7 +312,7 @@ bool VSISwiftHandleHelper::GetAuthV3StorageURL(const std::string& osPathForOptio
     if( endpoints.Size() == 0 )
         return false;
 
-    CPLString osRegionName = VSIGetCredential(osPathForOption.c_str(), "OS_REGION_NAME", "");
+    CPLString osRegionName = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_REGION_NAME", "");
     if( osRegionName.empty() )
     {
         for(int i = 0; i < endpoints.Size(); ++i)
@@ -359,13 +359,13 @@ bool VSISwiftHandleHelper::AuthV3(const std::string& osPathForOption,
     CPLString osAuthKey;
     if( osAuthType.empty() || osAuthType == "password" )
     {
-        osAuthID = VSIGetCredential(osPathForOption.c_str(), "OS_USERNAME", "");
-        osAuthKey = VSIGetCredential(osPathForOption.c_str(), "OS_PASSWORD", "");
+        osAuthID = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_USERNAME", "");
+        osAuthKey = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_PASSWORD", "");
     }
     else if( osAuthType == "v3applicationcredential" )
     {
-        osAuthID = VSIGetCredential(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_ID", "");
-        osAuthKey = VSIGetCredential(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_SECRET", "");
+        osAuthID = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_ID", "");
+        osAuthKey = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_APPLICATION_CREDENTIAL_SECRET", "");
     }
     else
     {
@@ -377,7 +377,7 @@ bool VSISwiftHandleHelper::AuthV3(const std::string& osPathForOption,
     std::string post = postObject.Format(CPLJSONObject::PrettyFormat::Plain);
 
     // coverity[tainted_data]
-    CPLString osAuthURL = VSIGetCredential(osPathForOption.c_str(), "OS_AUTH_URL", "");
+    CPLString osAuthURL = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_AUTH_URL", "");
     std::string url = osAuthURL;
     if( !url.empty() && url.back() != '/' )
         url += '/';
@@ -432,15 +432,15 @@ bool VSISwiftHandleHelper::AuthV3(const std::string& osPathForOption,
 
 bool VSISwiftHandleHelper::Authenticate(const std::string& osPathForOption)
 {
-    CPLString osAuthV1URL = VSIGetCredential(osPathForOption.c_str(), "SWIFT_AUTH_V1_URL", "");
+    CPLString osAuthV1URL = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_AUTH_V1_URL", "");
     if( !osAuthV1URL.empty() && AuthV1(osPathForOption, m_osStorageURL, m_osAuthToken) )
     {
         RebuildURL();
         return true;
     }
 
-    const CPLString osAuthVersion = VSIGetCredential(osPathForOption.c_str(), "OS_IDENTITY_API_VERSION", "");
-    const CPLString osAuthType = VSIGetCredential(osPathForOption.c_str(), "OS_AUTH_TYPE", "");
+    const CPLString osAuthVersion = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_IDENTITY_API_VERSION", "");
+    const CPLString osAuthType = VSIGetPathSpecificOption(osPathForOption.c_str(), "OS_AUTH_TYPE", "");
     if( osAuthVersion == "3" && AuthV3(osPathForOption, osAuthType, m_osStorageURL, m_osAuthToken) )
     {
         RebuildURL();
@@ -457,8 +457,8 @@ bool VSISwiftHandleHelper::Authenticate(const std::string& osPathForOption)
 bool VSISwiftHandleHelper::CheckCredentialsV1(const std::string& osPathForOption)
 {
     const char* pszMissingKey = nullptr;
-    CPLString osUser = VSIGetCredential(osPathForOption.c_str(), "SWIFT_USER", "");
-    CPLString osKey = VSIGetCredential(osPathForOption.c_str(), "SWIFT_KEY", "");
+    CPLString osUser = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_USER", "");
+    CPLString osKey = VSIGetPathSpecificOption(osPathForOption.c_str(), "SWIFT_KEY", "");
     if( osUser.empty() )
     {
         pszMissingKey = "SWIFT_USER";
@@ -508,7 +508,7 @@ bool VSISwiftHandleHelper::CheckCredentialsV3(const std::string& osPathForOption
     }
     for( auto const * pszOptionKey : papszMandatoryOptionKeys )
     {
-        CPLString option = VSIGetCredential(osPathForOption.c_str(), pszOptionKey, "");
+        CPLString option = VSIGetPathSpecificOption(osPathForOption.c_str(), pszOptionKey, "");
         if( option.empty() )
         {
             CPLDebug("SWIFT", "Missing %s configuration option", pszOptionKey);
@@ -530,9 +530,9 @@ bool VSISwiftHandleHelper::GetCached(const std::string& osPathForOption,
                                      CPLString& osStorageURL,
                                      CPLString& osAuthToken)
 {
-    CPLString osAuthURL = VSIGetCredential(osPathForOption.c_str(), pszURLKey, "");
-    CPLString osUser = VSIGetCredential(osPathForOption.c_str(), pszUserKey, "");
-    CPLString osKey = VSIGetCredential(osPathForOption.c_str(), pszPasswordKey, "");
+    CPLString osAuthURL = VSIGetPathSpecificOption(osPathForOption.c_str(), pszURLKey, "");
+    CPLString osUser = VSIGetPathSpecificOption(osPathForOption.c_str(), pszUserKey, "");
+    CPLString osKey = VSIGetPathSpecificOption(osPathForOption.c_str(), pszPasswordKey, "");
 
     CPLMutexHolder oHolder( &g_hMutex );
     // Re-use cached credentials if available

--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -247,11 +247,29 @@ int CPL_DLL VSISetFileMetadata( const char * pszFilename,
                                 const char* pszDomain,
                                 CSLConstList papszOptions );
 
+void CPL_DLL VSISetPathSpecificOption( const char* pszPathPrefix, const char* pszKey,
+                                       const char* pszValue );
+void CPL_DLL VSIClearPathSpecificOptions(const char* pszPathPrefix );
+const char CPL_DLL* VSIGetPathSpecificOption( const char* pszPath, const char* pszKey,
+                                              const char* pszDefault );
+
 void CPL_DLL VSISetCredential( const char* pszPathPrefix, const char* pszKey,
-                               const char* pszValue );
-void CPL_DLL VSIClearCredentials(const char* pszPathPrefix );
+                               const char* pszValue )
+/*! @cond Doxygen_Suppress */
+    CPL_WARN_DEPRECATED("Use VSISetPathSpecificOption instead")
+/*! @endcond */
+    ;
+void CPL_DLL VSIClearCredentials(const char* pszPathPrefix )
+/*! @cond Doxygen_Suppress */
+    CPL_WARN_DEPRECATED("Use VSIClearPathSpecificOptions instead")
+/*! @endcond */
+    ;
 const char CPL_DLL* VSIGetCredential( const char* pszPath, const char* pszKey,
-                                      const char* pszDefault );
+                                      const char* pszDefault )
+/*! @cond Doxygen_Suppress */
+    CPL_WARN_DEPRECATED("Use VSIGetPathSpecificOption instead")
+/*! @endcond */
+    ;
 
 /* ==================================================================== */
 /*      Memory allocation                                               */

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -2720,18 +2720,31 @@ const char* VSIGetFileSystemOptions( const char* pszFilename )
 }
 
 /************************************************************************/
-/*                          VSISetCredential()                          */
+/*                       VSISetPathSpecificOption()                     */
 /************************************************************************/
 
-static std::mutex oMutexCredentials;
+static std::mutex oMutexPathSpecificOptions;
 
 // key is a path prefix
 // value is a map of key, value pair
-static std::map<std::string, std::map<std::string, std::string>> oMapCredentials;
+static std::map<std::string, std::map<std::string, std::string>> oMapPathSpecificOptions;
 
 /**
  * \brief Set a credential (or more generally an option related to a
  *        virtual file system) for a given path prefix.
+ * @deprecated in GDAL 3.6 for the bettern named VSISetPathSpecificOption()
+ * @see VSISetPathSpecificOption()
+ */
+void VSISetCredential( const char* pszPathPrefix, const char* pszKey, const char* pszValue )
+{
+    VSISetPathSpecificOption(pszPathPrefix, pszKey, pszValue);
+}
+
+/**
+ * \brief Set a path specific option for a given path prefix.
+ *
+ * Such option is typically, but not limited to, a credential setting for a
+ * virtual file system.
  *
  * That option may also be set as a configuration option with CPLSetConfigOption(),
  * but this function allows to specify them with a granularity at the level of a
@@ -2753,19 +2766,19 @@ static std::map<std::string, std::map<std::string, std::string>> oMapCredentials
  * @param pszKey        Option name. Must NOT be NULL.
  * @param pszValue      Option value. May be NULL to erase it.
  *
- * @since GDAL 3.5
+ * @since GDAL 3.6
  */
 
-void VSISetCredential( const char* pszPathPrefix, const char* pszKey, const char* pszValue )
+void VSISetPathSpecificOption( const char* pszPathPrefix, const char* pszKey, const char* pszValue )
 {
-    std::lock_guard<std::mutex> oLock(oMutexCredentials);
-    auto oIter = oMapCredentials.find(pszPathPrefix);
+    std::lock_guard<std::mutex> oLock(oMutexPathSpecificOptions);
+    auto oIter = oMapPathSpecificOptions.find(pszPathPrefix);
     CPLString osKey(pszKey);
     osKey.toupper();
-    if( oIter == oMapCredentials.end() )
+    if( oIter == oMapPathSpecificOptions.end() )
     {
         if( pszValue != nullptr )
-            oMapCredentials[pszPathPrefix][osKey] = pszValue;
+            oMapPathSpecificOptions[pszPathPrefix][osKey] = pszValue;
     }
     else if( pszValue != nullptr )
         oIter->second[osKey] = pszValue;
@@ -2774,53 +2787,77 @@ void VSISetCredential( const char* pszPathPrefix, const char* pszKey, const char
 }
 
 /************************************************************************/
-/*                         VSIClearCredentials()                        */
+/*                       VSIClearPathSpecificOptions()                  */
 /************************************************************************/
 
 /**
- * \brief Clear credentials set with VSISetCredential()
- *
- * Note that no particular care is taken to remove them from RAM in a secure way.
- *
- * @param pszPathPrefix If set to NULL, all credentials are cleared.
- *                      If set to not-NULL, only those set with
- *                      VSISetCredential(pszPathPrefix, ...) will be cleared.
- *
- * @since GDAL 3.5
+ * \brief Clear path specific options set with VSISetPathSpecificOption()
+ * @deprecated in GDAL 3.6 for the bettern named VSIClearPathSpecificOptions()
+ * @see VSIClearPathSpecificOptions()
  */
 void VSIClearCredentials(const char* pszPathPrefix)
 {
-    std::lock_guard<std::mutex> oLock(oMutexCredentials);
+    return VSIClearPathSpecificOptions(pszPathPrefix);
+}
+
+/**
+ * \brief Clear path specific options set with VSISetPathSpecificOption()
+ *
+ * Note that no particular care is taken to remove them from RAM in a secure way.
+ *
+ * @param pszPathPrefix If set to NULL, all path specific options are cleared.
+ *                      If set to not-NULL, only those set with
+ *                      VSISetPathSpecificOption(pszPathPrefix, ...) will be cleared.
+ *
+ * @since GDAL 3.6
+ */
+void VSIClearPathSpecificOptions(const char* pszPathPrefix)
+{
+    std::lock_guard<std::mutex> oLock(oMutexPathSpecificOptions);
     if( pszPathPrefix == nullptr )
     {
-        oMapCredentials.clear();
+        oMapPathSpecificOptions.clear();
     }
     else
     {
-        oMapCredentials.erase(pszPathPrefix);
+        oMapPathSpecificOptions.erase(pszPathPrefix);
     }
 }
 
 /************************************************************************/
-/*                           VSIGetCredential()                         */
+/*                        VSIGetPathSpecificOption()                    */
 /************************************************************************/
 
 /**
- * \brief Get a credential option for a given path.
+ * \brief Get the value of a credential (or more generally an option related to a
+ *        virtual file system) for a given path.
+ * @deprecated in GDAL 3.6 for the bettern named VSIGetPathSpecificOption()
+ * @see VSIGetPathSpecificOption()
+ */
+const char* VSIGetCredential( const char* pszPath, const char* pszKey, const char* pszDefault )
+{
+    return VSIGetPathSpecificOption(pszPath, pszKey, pszDefault);
+}
+
+/**
+ * \brief Get the value a path specific option.
+ *
+ * Such option is typically, but not limited to, a credential setting for a
+ * virtual file system.
  *
  * If no match occurs, CPLGetConfigOption(pszKey, pszDefault) is returned.
  *
- * Mostly to be use by virtual file system implementations.
+ * Mostly to be used by virtual file system implementations.
  *
- * @since GDAL 3.5
- * @see VSISetCredential()
+ * @since GDAL 3.6
+ * @see VSISetPathSpecificOption()
  */
-const char* VSIGetCredential( const char* pszPath, const char* pszKey,
-                              const char* pszDefault )
+const char* VSIGetPathSpecificOption( const char* pszPath, const char* pszKey,
+                                      const char* pszDefault )
 {
     {
-        std::lock_guard<std::mutex> oLock(oMutexCredentials);
-        for (auto it = oMapCredentials.rbegin(); it != oMapCredentials.rend(); ++it)
+        std::lock_guard<std::mutex> oLock(oMutexPathSpecificOptions);
+        for (auto it = oMapPathSpecificOptions.rbegin(); it != oMapPathSpecificOptions.rend(); ++it)
         {
             if( STARTS_WITH(pszPath, it->first.c_str()) )
             {

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -3548,7 +3548,7 @@ VSIVirtualHandle* VSICurlFilesystemHandlerBase::Open( const char *pszFilename,
                                   nullptr, nullptr));
 
     const char* pszOptionVal =
-        CPLGetConfigOption( "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
+        VSIGetPathSpecificOption( pszFilename, "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
     const bool bSkipReadDir = !bListDir || bEmptyDir ||
         EQUAL(pszOptionVal, "EMPTY_DIR") || CPLTestBool(pszOptionVal) ||
         !AllowCachedDataFor(pszFilename);
@@ -4535,7 +4535,7 @@ int VSICurlFilesystemHandlerBase::Stat( const char *pszFilename,
                                   nullptr, nullptr));
 
     const char* pszOptionVal =
-        CPLGetConfigOption( "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
+        VSIGetPathSpecificOption( pszFilename, "GDAL_DISABLE_READDIR_ON_OPEN", "NO" );
     const bool bSkipReadDir = !bListDir || bEmptyDir ||
         EQUAL(pszOptionVal, "EMPTY_DIR") || CPLTestBool(pszOptionVal) ||
         !AllowCachedDataFor(pszFilename);

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -2293,7 +2293,7 @@ int* VSIS3FSHandler::UnlinkBatch( CSLConstList papszFiles )
 int VSIS3FSHandler::RmdirRecursive( const char* pszDirname )
 {
     // Some S3-like APIs do not support DeleteObjects
-    if( CPLTestBool(CPLGetConfigOption("CPL_VSIS3_USE_BASE_RMDIR_RECURSIVE", "NO")) )
+    if( CPLTestBool(VSIGetPathSpecificOption(pszDirname, "CPL_VSIS3_USE_BASE_RMDIR_RECURSIVE", "NO")) )
         return VSIFilesystemHandler::RmdirRecursive(pszDirname);
 
     // For debug / testing only

--- a/port/cpl_vsil_webhdfs.cpp
+++ b/port/cpl_vsil_webhdfs.cpp
@@ -173,7 +173,7 @@ static CPLString PatchWebHDFSUrl(const CPLString& osURLIn,
 
 static CPLString GetWebHDFSDataNodeHost(const char* pszFilename)
 {
-    return CPLString(VSIGetCredential(pszFilename, "WEBHDFS_DATANODE_HOST", ""));
+    return CPLString(VSIGetPathSpecificOption(pszFilename, "WEBHDFS_DATANODE_HOST", ""));
 }
 
 /************************************************************************/
@@ -236,10 +236,10 @@ VSIWebHDFSWriteHandle::VSIWebHDFSWriteHandle( VSIWebHDFSFSHandler* poFS,
         m_osDataNodeHost( GetWebHDFSDataNodeHost(pszFilename) )
 {
     // cppcheck-suppress useInitializationList
-    m_osUsernameParam = VSIGetCredential(pszFilename, "WEBHDFS_USERNAME", "");
+    m_osUsernameParam = VSIGetPathSpecificOption(pszFilename, "WEBHDFS_USERNAME", "");
     if( !m_osUsernameParam.empty() )
         m_osUsernameParam = "&user.name=" + m_osUsernameParam;
-    m_osDelegationParam = VSIGetCredential(pszFilename, "WEBHDFS_DELEGATION", "");
+    m_osDelegationParam = VSIGetPathSpecificOption(pszFilename, "WEBHDFS_DELEGATION", "");
     if( !m_osDelegationParam.empty() )
         m_osDelegationParam = "&delegation=" + m_osDelegationParam;
 
@@ -305,11 +305,11 @@ bool VSIWebHDFSWriteHandle::CreateFile()
     CPLString osURL = m_osURL + "?op=CREATE&overwrite=true" +
         m_osUsernameParam + m_osDelegationParam;
 
-    CPLString osPermission = VSIGetCredential(m_osFilename.c_str(), "WEBHDFS_PERMISSION", "");
+    CPLString osPermission = VSIGetPathSpecificOption(m_osFilename.c_str(), "WEBHDFS_PERMISSION", "");
     if( !osPermission.empty() )
         osURL += "&permission=" + osPermission;
 
-    CPLString osReplication = VSIGetCredential(m_osFilename.c_str(), "WEBHDFS_REPLICATION", "");
+    CPLString osReplication = VSIGetPathSpecificOption(m_osFilename.c_str(), "WEBHDFS_REPLICATION", "");
     if( !osReplication.empty() )
         osURL += "&replication=" + osReplication;
 
@@ -627,10 +627,10 @@ char** VSIWebHDFSFSHandler::GetFileList( const char *pszDirname,
 
     CURLM* hCurlMultiHandle = GetCurlMultiHandleFor(osBaseURL);
 
-    CPLString osUsernameParam = VSIGetCredential(pszDirname, "WEBHDFS_USERNAME", "");
+    CPLString osUsernameParam = VSIGetPathSpecificOption(pszDirname, "WEBHDFS_USERNAME", "");
     if( !osUsernameParam.empty() )
         osUsernameParam = "&user.name=" + osUsernameParam;
-    CPLString osDelegationParam = VSIGetCredential(pszDirname, "WEBHDFS_DELEGATION", "");
+    CPLString osDelegationParam = VSIGetPathSpecificOption(pszDirname, "WEBHDFS_DELEGATION", "");
     if( !osDelegationParam.empty() )
         osDelegationParam = "&delegation=" + osDelegationParam;
     CPLString osURL = osBaseURL + "?op=LISTSTATUS" + osUsernameParam + osDelegationParam;
@@ -725,10 +725,10 @@ int VSIWebHDFSFSHandler::Unlink( const char *pszFilename )
 
     CURLM* hCurlMultiHandle = GetCurlMultiHandleFor(osBaseURL);
 
-    CPLString osUsernameParam = VSIGetCredential(pszFilename, "WEBHDFS_USERNAME", "");
+    CPLString osUsernameParam = VSIGetPathSpecificOption(pszFilename, "WEBHDFS_USERNAME", "");
     if( !osUsernameParam.empty() )
         osUsernameParam = "&user.name=" + osUsernameParam;
-    CPLString osDelegationParam = VSIGetCredential(pszFilename, "WEBHDFS_DELEGATION", "");
+    CPLString osDelegationParam = VSIGetPathSpecificOption(pszFilename, "WEBHDFS_DELEGATION", "");
     if( !osDelegationParam.empty() )
         osDelegationParam = "&delegation=" + osDelegationParam;
     CPLString osURL = osBaseURL + "?op=DELETE" + osUsernameParam + osDelegationParam;
@@ -840,10 +840,10 @@ int VSIWebHDFSFSHandler::Mkdir( const char *pszDirname, long nMode )
 
     CURLM* hCurlMultiHandle = GetCurlMultiHandleFor(osBaseURL);
 
-    CPLString osUsernameParam = VSIGetCredential(pszDirname, "WEBHDFS_USERNAME", "");
+    CPLString osUsernameParam = VSIGetPathSpecificOption(pszDirname, "WEBHDFS_USERNAME", "");
     if( !osUsernameParam.empty() )
         osUsernameParam = "&user.name=" + osUsernameParam;
-    CPLString osDelegationParam = VSIGetCredential(pszDirname, "WEBHDFS_DELEGATION", "");
+    CPLString osDelegationParam = VSIGetPathSpecificOption(pszDirname, "WEBHDFS_DELEGATION", "");
     if( !osDelegationParam.empty() )
         osDelegationParam = "&delegation=" + osDelegationParam;
     CPLString osURL = osBaseURL + "?op=MKDIRS" + osUsernameParam + osDelegationParam;
@@ -926,10 +926,10 @@ VSIWebHDFSHandle::VSIWebHDFSHandle( VSIWebHDFSFSHandler* poFSIn,
         m_osDataNodeHost(GetWebHDFSDataNodeHost(pszFilename))
 {
     // cppcheck-suppress useInitializationList
-    m_osUsernameParam = VSIGetCredential(pszFilename, "WEBHDFS_USERNAME", "");
+    m_osUsernameParam = VSIGetPathSpecificOption(pszFilename, "WEBHDFS_USERNAME", "");
     if( !m_osUsernameParam.empty() )
         m_osUsernameParam = "&user.name=" + m_osUsernameParam;
-    m_osDelegationParam = VSIGetCredential(pszFilename, "WEBHDFS_DELEGATION", "");
+    m_osDelegationParam = VSIGetPathSpecificOption(pszFilename, "WEBHDFS_DELEGATION", "");
     if( !m_osDelegationParam.empty() )
         m_osDelegationParam = "&delegation=" + m_osDelegationParam;
 

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -186,9 +186,12 @@ void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* psz
 %rename (GetConfigOption) wrapper_CPLGetConfigOption;
 %rename (SetThreadLocalConfigOption) CPLSetThreadLocalConfigOption;
 %rename (GetThreadLocalConfigOption) wrapper_CPLGetThreadLocalConfigOption;
-%rename (SetCredential) VSISetCredential;
+%rename (SetCredential) wrapper_VSISetCredential;
 %rename (GetCredential) wrapper_VSIGetCredential;
 %rename (ClearCredentials) wrapper_VSIClearCredentials;
+%rename (SetPathSpecificOption) VSISetPathSpecificOption;
+%rename (GetPathSpecificOption) wrapper_VSIGetPathSpecificOption;
+%rename (ClearPathSpecificOptions) wrapper_VSIClearPathSpecificOptions;
 %rename (CPLBinaryToHex) CPLBinaryToHex;
 %rename (CPLHexToBinary) CPLHexToBinary;
 %rename (FileFromMemBuffer) wrapper_VSIFileFromMemBuffer;
@@ -484,12 +487,22 @@ const char *wrapper_CPLGetThreadLocalConfigOption( const char * pszKey, const ch
 }
 
 %apply Pointer NONNULL {const char * pszPathPrefix};
-void VSISetCredential( const char* pszPathPrefix, const char * pszKey, const char * pszValue );
+void VSISetPathSpecificOption( const char* pszPathPrefix, const char * pszKey, const char * pszValue );
 
 %inline {
+void wrapper_VSISetCredential( const char* pszPathPrefix, const char * pszKey, const char * pszValue )
+{
+    VSISetPathSpecificOption(pszPathPrefix, pszKey, pszValue);
+}
+
 const char *wrapper_VSIGetCredential( const char* pszPathPrefix, const char * pszKey, const char * pszDefault = NULL )
 {
-    return VSIGetCredential( pszPathPrefix, pszKey, pszDefault );
+    return VSIGetPathSpecificOption( pszPathPrefix, pszKey, pszDefault );
+}
+
+const char *wrapper_VSIGetPathSpecificOption( const char* pszPathPrefix, const char * pszKey, const char * pszDefault = NULL )
+{
+    return VSIGetPathSpecificOption( pszPathPrefix, pszKey, pszDefault );
 }
 }
 
@@ -500,7 +513,11 @@ const char *wrapper_VSIGetCredential( const char* pszPathPrefix, const char * ps
 %inline {
 void wrapper_VSIClearCredentials(const char * pszPathPrefix = NULL)
 {
-    VSIClearCredentials( pszPathPrefix );
+    VSIClearPathSpecificOptions( pszPathPrefix );
+}
+void wrapper_VSIClearPathSpecificOptions(const char * pszPathPrefix = NULL)
+{
+    VSIClearPathSpecificOptions( pszPathPrefix );
 }
 }
 

--- a/swig/python/extensions/gdal_wrap.cpp
+++ b/swig/python/extensions/gdal_wrap.cpp
@@ -4015,15 +4015,29 @@ const char *wrapper_CPLGetThreadLocalConfigOption( const char * pszKey, const ch
 }
 
 
+void wrapper_VSISetCredential( const char* pszPathPrefix, const char * pszKey, const char * pszValue )
+{
+    VSISetPathSpecificOption(pszPathPrefix, pszKey, pszValue);
+}
+
 const char *wrapper_VSIGetCredential( const char* pszPathPrefix, const char * pszKey, const char * pszDefault = NULL )
 {
-    return VSIGetCredential( pszPathPrefix, pszKey, pszDefault );
+    return VSIGetPathSpecificOption( pszPathPrefix, pszKey, pszDefault );
+}
+
+const char *wrapper_VSIGetPathSpecificOption( const char* pszPathPrefix, const char * pszKey, const char * pszDefault = NULL )
+{
+    return VSIGetPathSpecificOption( pszPathPrefix, pszKey, pszDefault );
 }
 
 
 void wrapper_VSIClearCredentials(const char * pszPathPrefix = NULL)
 {
-    VSIClearCredentials( pszPathPrefix );
+    VSIClearPathSpecificOptions( pszPathPrefix );
+}
+void wrapper_VSIClearPathSpecificOptions(const char * pszPathPrefix = NULL)
+{
+    VSIClearPathSpecificOptions( pszPathPrefix );
 }
 
 
@@ -10539,6 +10553,80 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SetPathSpecificOption(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  char *arg1 = (char *) 0 ;
+  char *arg2 = (char *) 0 ;
+  char *arg3 = (char *) 0 ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int res3 ;
+  char *buf3 = 0 ;
+  int alloc3 = 0 ;
+  PyObject *swig_obj[3] ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "SetPathSpecificOption", 3, 3, swig_obj)) SWIG_fail;
+  res1 = SWIG_AsCharPtrAndSize(swig_obj[0], &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SetPathSpecificOption" "', argument " "1"" of type '" "char const *""'");
+  }
+  arg1 = reinterpret_cast< char * >(buf1);
+  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SetPathSpecificOption" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  res3 = SWIG_AsCharPtrAndSize(swig_obj[2], &buf3, NULL, &alloc3);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "SetPathSpecificOption" "', argument " "3"" of type '" "char const *""'");
+  }
+  arg3 = reinterpret_cast< char * >(buf3);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      VSISetPathSpecificOption((char const *)arg1,(char const *)arg2,(char const *)arg3);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  if (alloc3 == SWIG_NEWOBJ) delete[] buf3;
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  if (alloc3 == SWIG_NEWOBJ) delete[] buf3;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SetCredential(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   char *arg1 = (char *) 0 ;
@@ -10587,7 +10675,7 @@ SWIGINTERN PyObject *_wrap_SetCredential(PyObject *SWIGUNUSEDPARM(self), PyObjec
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      VSISetCredential((char const *)arg1,(char const *)arg2,(char const *)arg3);
+      wrapper_VSISetCredential((char const *)arg1,(char const *)arg2,(char const *)arg3);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -10690,6 +10778,83 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_GetPathSpecificOption(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  char *arg1 = (char *) 0 ;
+  char *arg2 = (char *) 0 ;
+  char *arg3 = (char *) NULL ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int res3 ;
+  char *buf3 = 0 ;
+  int alloc3 = 0 ;
+  PyObject *swig_obj[3] ;
+  char *result = 0 ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "GetPathSpecificOption", 2, 3, swig_obj)) SWIG_fail;
+  res1 = SWIG_AsCharPtrAndSize(swig_obj[0], &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GetPathSpecificOption" "', argument " "1"" of type '" "char const *""'");
+  }
+  arg1 = reinterpret_cast< char * >(buf1);
+  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GetPathSpecificOption" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (swig_obj[2]) {
+    res3 = SWIG_AsCharPtrAndSize(swig_obj[2], &buf3, NULL, &alloc3);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "GetPathSpecificOption" "', argument " "3"" of type '" "char const *""'");
+    }
+    arg3 = reinterpret_cast< char * >(buf3);
+  }
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (char *)wrapper_VSIGetPathSpecificOption((char const *)arg1,(char const *)arg2,(char const *)arg3);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_FromCharPtr((const char *)result);
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  if (alloc3 == SWIG_NEWOBJ) delete[] buf3;
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  if (alloc3 == SWIG_NEWOBJ) delete[] buf3;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ClearCredentials(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   char *arg1 = (char *) NULL ;
@@ -10713,6 +10878,50 @@ SWIGINTERN PyObject *_wrap_ClearCredentials(PyObject *SWIGUNUSEDPARM(self), PyOb
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
       wrapper_VSIClearCredentials((char const *)arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ClearPathSpecificOptions(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  char *arg1 = (char *) NULL ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "ClearPathSpecificOptions", 0, 1, swig_obj)) SWIG_fail;
+  if (swig_obj[0]) {
+    res1 = SWIG_AsCharPtrAndSize(swig_obj[0], &buf1, NULL, &alloc1);
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ClearPathSpecificOptions" "', argument " "1"" of type '" "char const *""'");
+    }
+    arg1 = reinterpret_cast< char * >(buf1);
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      wrapper_VSIClearPathSpecificOptions((char const *)arg1);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -46253,9 +46462,12 @@ static PyMethodDef SwigMethods[] = {
 	 { "SetThreadLocalConfigOption", _wrap_SetThreadLocalConfigOption, METH_VARARGS, "SetThreadLocalConfigOption(char const * pszKey, char const * pszValue)"},
 	 { "GetConfigOption", _wrap_GetConfigOption, METH_VARARGS, "GetConfigOption(char const * pszKey, char const * pszDefault=None) -> char const *"},
 	 { "GetThreadLocalConfigOption", _wrap_GetThreadLocalConfigOption, METH_VARARGS, "GetThreadLocalConfigOption(char const * pszKey, char const * pszDefault=None) -> char const *"},
+	 { "SetPathSpecificOption", _wrap_SetPathSpecificOption, METH_VARARGS, "SetPathSpecificOption(char const * pszPathPrefix, char const * pszKey, char const * pszValue)"},
 	 { "SetCredential", _wrap_SetCredential, METH_VARARGS, "SetCredential(char const * pszPathPrefix, char const * pszKey, char const * pszValue)"},
 	 { "GetCredential", _wrap_GetCredential, METH_VARARGS, "GetCredential(char const * pszPathPrefix, char const * pszKey, char const * pszDefault=None) -> char const *"},
+	 { "GetPathSpecificOption", _wrap_GetPathSpecificOption, METH_VARARGS, "GetPathSpecificOption(char const * pszPathPrefix, char const * pszKey, char const * pszDefault=None) -> char const *"},
 	 { "ClearCredentials", _wrap_ClearCredentials, METH_VARARGS, "ClearCredentials(char const * pszPathPrefix=None)"},
+	 { "ClearPathSpecificOptions", _wrap_ClearPathSpecificOptions, METH_VARARGS, "ClearPathSpecificOptions(char const * pszPathPrefix=None)"},
 	 { "CPLBinaryToHex", _wrap_CPLBinaryToHex, METH_O, "CPLBinaryToHex(int nBytes) -> retStringAndCPLFree *"},
 	 { "CPLHexToBinary", _wrap_CPLHexToBinary, METH_VARARGS, "CPLHexToBinary(char const * pszHex, int * pnBytes) -> GByte *"},
 	 { "FileFromMemBuffer", _wrap_FileFromMemBuffer, METH_VARARGS, "FileFromMemBuffer(char const * utf8_path, GIntBig nBytes)"},

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -1977,6 +1977,10 @@ def GetThreadLocalConfigOption(*args) -> "char const *":
     r"""GetThreadLocalConfigOption(char const * pszKey, char const * pszDefault=None) -> char const *"""
     return _gdal.GetThreadLocalConfigOption(*args)
 
+def SetPathSpecificOption(*args) -> "void":
+    r"""SetPathSpecificOption(char const * pszPathPrefix, char const * pszKey, char const * pszValue)"""
+    return _gdal.SetPathSpecificOption(*args)
+
 def SetCredential(*args) -> "void":
     r"""SetCredential(char const * pszPathPrefix, char const * pszKey, char const * pszValue)"""
     return _gdal.SetCredential(*args)
@@ -1985,9 +1989,17 @@ def GetCredential(*args) -> "char const *":
     r"""GetCredential(char const * pszPathPrefix, char const * pszKey, char const * pszDefault=None) -> char const *"""
     return _gdal.GetCredential(*args)
 
+def GetPathSpecificOption(*args) -> "char const *":
+    r"""GetPathSpecificOption(char const * pszPathPrefix, char const * pszKey, char const * pszDefault=None) -> char const *"""
+    return _gdal.GetPathSpecificOption(*args)
+
 def ClearCredentials(*args) -> "void":
     r"""ClearCredentials(char const * pszPathPrefix=None)"""
     return _gdal.ClearCredentials(*args)
+
+def ClearPathSpecificOptions(*args) -> "void":
+    r"""ClearPathSpecificOptions(char const * pszPathPrefix=None)"""
+    return _gdal.ClearPathSpecificOptions(*args)
 
 def CPLBinaryToHex(*args) -> "retStringAndCPLFree *":
     r"""CPLBinaryToHex(int nBytes) -> retStringAndCPLFree *"""


### PR DESCRIPTION
- Add VSISetPathSpecificOption() / VSIGetPathSpecificOption() / VSIClearPathSpecificOptions()
    
    Those are just better named functions of the VSISetCredential() /
    VSIGetCredential() / VSIClearCredentials() introduced in GDAL 3.5, which
    are kept for backward compatibility, but deprecated.

- /vsis3/: make CPL_VSIS3_USE_BASE_RMDIR_RECURSIVE a path-specific configuration option

- Make GDAL_DISABLE_READDIR_ON_OPEN a path-specific configuration option
