### PR TITLE
Add OGRLayer::GetGeometryTypes() 

### DIFF
--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -46,6 +46,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 CPL_C_START
 
@@ -599,6 +600,29 @@ typedef void *OGRSFDriverH;
 
 const char CPL_DLL* OGR_L_GetName( OGRLayerH );
 OGRwkbGeometryType CPL_DLL OGR_L_GetGeomType( OGRLayerH );
+
+/** Result item of OGR_L_GetGeometryTypes */
+typedef struct
+{
+    /** Geometry type */
+    OGRwkbGeometryType eGeomType;
+    /** Number of geometries of type eGeomType */
+    int64_t            nCount;
+} OGRGeometryTypeCounter;
+
+/** Flag for OGR_L_GetGeometryTypes() indicating that
+ * OGRGeometryTypeCounter::nCount value is not needed */
+#define OGR_GGT_COUNT_NOT_NEEDED     0x1
+/** Flag for OGR_L_GetGeometryTypes() indicating that iteration might stop as
+ * sooon as 2 distinct geometry types are found. */
+#define OGR_GGT_STOP_IF_MIXED        0x2
+/** Flag for OGR_L_GetGeometryTypes() indicating that a GeometryCollectionZ
+ * whose first subgeometry is a TinZ should be reported as TinZ */
+#define OGR_GGT_GEOMCOLLECTIONZ_TINZ 0x4
+OGRGeometryTypeCounter CPL_DLL *OGR_L_GetGeometryTypes(
+            OGRLayerH hLayer, int iGeomField, int nFlags, int *pnEntryCount,
+            GDALProgressFunc pfnProgress, void* pProgressData);
+
 OGRGeometryH CPL_DLL OGR_L_GetSpatialFilter( OGRLayerH );
 void   CPL_DLL OGR_L_SetSpatialFilter( OGRLayerH, OGRGeometryH );
 void   CPL_DLL OGR_L_SetSpatialFilterRect( OGRLayerH,

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -234,6 +234,9 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         void                LoadRelationships() const;
         void                LoadRelationshipsUsingRelatedTablesExtension() const;
 
+        bool                m_bIsGeometryTypeAggregateInterrupted = false;
+        std::string         m_osGeometryTypeAggregateResult{};
+
         CPL_DISALLOW_COPY_ASSIGN(GDALGeoPackageDataset)
 
     public:
@@ -327,6 +330,16 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
                                                    void * pProgressData );
 
         static std::string GetCurrentDateEscapedSQL();
+
+        bool                IsGeometryTypeAggregateInterrupted() const { return m_bIsGeometryTypeAggregateInterrupted; }
+        void                SetGeometryTypeAggregateInterrupted(bool b)
+        {
+            m_bIsGeometryTypeAggregateInterrupted = b;
+            if( b )
+                sqlite3_interrupt(hDB);
+        }
+        void                SetGeometryTypeAggregateResult(const std::string& s) { m_osGeometryTypeAggregateResult = s; }
+        const std::string&  GetGeometryTypeAggregateResult() const { return m_osGeometryTypeAggregateResult; }
 
     protected:
 
@@ -589,6 +602,9 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     OGRErr              GetExtent(OGREnvelope *psExtent, int bForce = TRUE) override;
     virtual OGRErr      GetExtent(int iGeomField, OGREnvelope *psExtent, int bForce) override
                 { return OGRGeoPackageLayer::GetExtent(iGeomField, psExtent, bForce); }
+
+    OGRGeometryTypeCounter* GetGeometryTypes(int iGeomField, int nFlagsGGT, int& nEntryCountOut,
+                                             GDALProgressFunc pfnProgress, void* pProgressData) override;
 
     void                RecomputeExtent();
 

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -227,6 +227,9 @@ class CPL_DLL OGRLayer : public GDALMajorObject
 
     virtual OGRErr      SetIgnoredFields( const char **papszFields );
 
+    virtual OGRGeometryTypeCounter* GetGeometryTypes(int iGeomField, int nFlagsGGT, int& nEntryCountOut,
+                                                     GDALProgressFunc pfnProgress, void* pProgressData);
+
     OGRErr              Intersection( OGRLayer *pLayerMethod,
                                       OGRLayer *pLayerResult,
                                       char** papszOptions = nullptr,

--- a/ogr/ogrsf_frmts/pg/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/pg/CMakeLists.txt
@@ -10,3 +10,9 @@ add_gdal_driver(
 gdal_standard_includes(ogr_PG)
 target_include_directories(ogr_PG PRIVATE ${PostgreSQL_INCLUDE_DIRS} $<TARGET_PROPERTY:ogr_PGDump,SOURCE_DIR>)
 gdal_target_link_libraries(ogr_PG PRIVATE PostgreSQL::PostgreSQL)
+
+if (OGR_ENABLE_DRIVER_PG_PLUGIN)
+    if(NOT MSVC AND CMAKE_THREAD_LIBS_INIT)
+        gdal_target_link_libraries(ogr_PG PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+    endif()
+endif()

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -394,6 +394,9 @@ public:
 
     virtual OGRErr      Rename(const char* pszNewName) override;
 
+    OGRGeometryTypeCounter* GetGeometryTypes(int iGeomField, int nFlagsGGT, int& nEntryCountOut,
+                                             GDALProgressFunc pfnProgress, void* pProgressData) override;
+
     // follow methods are not base class overrides
     void                SetLaunderFlag( int bFlag )
                                 { bLaunderColumnNames = bFlag; }

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -465,6 +465,18 @@ typedef void retGetPoints;
 %constant F_VAL_ALLOW_NULL_WHEN_DEFAULT = 0x00000008; /***<Allow fields that are null when there's an associated default value. */
 %constant F_VAL_ALL = 0xFFFFFFFF; /**< Enable all validation tests */
 
+/** Flag for OGR_L_GetGeometryTypes() indicating that
+ * OGRGeometryTypeCounter::nCount value is not needed */
+%constant GGT_COUNT_NOT_NEEDED = 0x1;
+
+/** Flag for OGR_L_GetGeometryTypes() indicating that iteration might stop as
+ * sooon as 2 distinct geometry types are found. */
+%constant GGT_STOP_IF_MIXED = 0x2;
+
+/** Flag for OGR_L_GetGeometryTypes() indicating that a GeometryCollectionZ
+ * whose first subgeometry is a TinZ should be reported as TinZ */
+%constant GGT_GEOMCOLLECTIONZ_TINZ = 0x4;
+
 %constant char *OLCRandomRead          = "RandomRead";
 %constant char *OLCSequentialWrite     = "SequentialWrite";
 %constant char *OLCRandomWrite         = "RandomWrite";
@@ -1435,6 +1447,17 @@ public:
           return NULL;
       }
   }
+#endif
+
+#ifdef SWIGPYTHON
+    %feature( "kwargs" ) GetGeometryTypes;
+    void GetGeometryTypes(OGRGeometryTypeCounter** ppRet, int* pnEntryCount,
+                          int geom_field = 0, int flags = 0,
+                          GDALProgressFunc callback=NULL,
+                          void* callback_data=NULL)
+    {
+        *ppRet = OGR_L_GetGeometryTypes(self, geom_field, flags, pnEntryCount, callback, callback_data);
+    }
 #endif
 
 } /* %extend */

--- a/swig/include/python/callback.i
+++ b/swig/include/python/callback.i
@@ -26,7 +26,7 @@ PyProgressProxy( double dfComplete, const char *pszMessage, void *pData )
     PyObject *psArgs, *psResult;
     int      bContinue = TRUE;
 
-    if( psInfo->nLastReported == (int) (100.0 * dfComplete) )
+    if( dfComplete > 0 && psInfo->nLastReported == (int) (100.0 * dfComplete) )
         return TRUE;
 
     if( psInfo->psPyCallback == NULL || psInfo->psPyCallback == Py_None )

--- a/swig/include/python/docs/ogr_layer_docs.i
+++ b/swig/include/python/docs/ogr_layer_docs.i
@@ -514,7 +514,7 @@ For more details: :cpp:func:`OGR_L_GetStyleTable`
 ";
 
 %feature("docstring")  SetStyleTableDirectly "
-Set style table (and take ownership) 
+Set style table (and take ownership)
 
 For more details: :cpp:func:`OGR_L_SetStyleTableDirectly`
 ";
@@ -757,6 +757,32 @@ Returns
 int:
     An error code if there was an error or the execution was interrupted,
     :py:const:`osgeo.ogr.OGRERR_NONE` otherwise.
+";
+
+%feature("docstring")  GetGeometryTypes "
+Get actual geometry types found in features.
+
+For more details: :cpp:func:`OGR_L_GetGeometryTypes`
+
+Parameters
+-----------
+geom_field: int, optional
+    index of the geometry field
+flags: int, optional
+    0, or a combination of :py:const:`osgeo.ogr.GGT_COUNT_NOT_NEEDED`,
+    :py:const:`osgeo.ogr.GGT_STOP_IF_MIXED` and
+    :py:const:`osgeo.ogr.GGT_GEOMCOLLECTIONZ_TINZ`
+callback: Callable, optional
+    a GDALProgressFunc() compatible callback function for
+    cancellation or None.
+callback_data:
+    Argument to be passed to 'callback'. May be None.
+
+Returns
+-------
+dict:
+    A dictionary whose keys are :py:const:`osgeo.ogr.wkbXXXX` constants and
+    values the corresponding number of geometries of that type in the layer.
 ";
 
 }

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -2879,3 +2879,41 @@ OBJECT_LIST_INPUT(GDALEDTComponentHS)
     $1 = &val;
   }
 }
+
+/***************************************************
+ * Typemaps for Layer.GetGeometryTypes()
+ ***************************************************/
+%typemap(in,numinputs=0) (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) ( OGRGeometryTypeCounter* pRet = NULL, int nEntryCount = 0 )
+{
+  /* %typemap(in,numinputs=0) (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
+  $1 = &pRet;
+  $2 = &nEntryCount;
+}
+
+%typemap(argout)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount)
+{
+  /* %typemap(argout)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
+  Py_DECREF($result);
+  int nEntryCount = *($2);
+  OGRGeometryTypeCounter* pRet = *($1);
+  if( pRet == NULL )
+  {
+      PyErr_SetString( PyExc_RuntimeError, CPLGetLastErrorMsg() );
+      SWIG_fail;
+  }
+  $result = PyDict_New();
+  for(int i = 0; i < nEntryCount; ++ i)
+  {
+      PyObject *key = PyInt_FromLong( (int)(pRet[i].eGeomType) );
+      PyObject *val = PyLong_FromLongLong( pRet[i].nCount );
+      PyDict_SetItem($result, key, val );
+      Py_DECREF(key);
+      Py_DECREF(val);
+  }
+}
+
+%typemap(freearg)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount)
+{
+    /* %typemap(freearg)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
+    VSIFree(*$1);
+}

--- a/swig/python/extensions/gdal_array_wrap.cpp
+++ b/swig/python/extensions/gdal_array_wrap.cpp
@@ -3962,7 +3962,7 @@ PyProgressProxy( double dfComplete, const char *pszMessage, void *pData )
     PyObject *psArgs, *psResult;
     int      bContinue = TRUE;
 
-    if( psInfo->nLastReported == (int) (100.0 * dfComplete) )
+    if( dfComplete > 0 && psInfo->nLastReported == (int) (100.0 * dfComplete) )
         return TRUE;
 
     if( psInfo->psPyCallback == NULL || psInfo->psPyCallback == Py_None )

--- a/swig/python/extensions/gdal_wrap.cpp
+++ b/swig/python/extensions/gdal_wrap.cpp
@@ -3644,7 +3644,7 @@ PyProgressProxy( double dfComplete, const char *pszMessage, void *pData )
     PyObject *psArgs, *psResult;
     int      bContinue = TRUE;
 
-    if( psInfo->nLastReported == (int) (100.0 * dfComplete) )
+    if( dfComplete > 0 && psInfo->nLastReported == (int) (100.0 * dfComplete) )
         return TRUE;
 
     if( psInfo->psPyCallback == NULL || psInfo->psPyCallback == Py_None )

--- a/swig/python/extensions/gnm_wrap.cpp
+++ b/swig/python/extensions/gnm_wrap.cpp
@@ -3099,7 +3099,7 @@ PyProgressProxy( double dfComplete, const char *pszMessage, void *pData )
     PyObject *psArgs, *psResult;
     int      bContinue = TRUE;
 
-    if( psInfo->nLastReported == (int) (100.0 * dfComplete) )
+    if( dfComplete > 0 && psInfo->nLastReported == (int) (100.0 * dfComplete) )
         return TRUE;
 
     if( psInfo->psPyCallback == NULL || psInfo->psPyCallback == Py_None )

--- a/swig/python/extensions/ogr_wrap.cpp
+++ b/swig/python/extensions/ogr_wrap.cpp
@@ -2721,12 +2721,13 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_float swig_types[24]
 #define SWIGTYPE_p_int swig_types[25]
 #define SWIGTYPE_p_p_GIntBig swig_types[26]
-#define SWIGTYPE_p_p_char swig_types[27]
-#define SWIGTYPE_p_p_double swig_types[28]
-#define SWIGTYPE_p_p_int swig_types[29]
-#define SWIGTYPE_p_size_t swig_types[30]
-static swig_type_info *swig_types[32];
-static swig_module_info swig_module = {swig_types, 31, 0, 0, 0, 0};
+#define SWIGTYPE_p_p_OGRGeometryTypeCounter swig_types[27]
+#define SWIGTYPE_p_p_char swig_types[28]
+#define SWIGTYPE_p_p_double swig_types[29]
+#define SWIGTYPE_p_p_int swig_types[30]
+#define SWIGTYPE_p_size_t swig_types[31]
+static swig_type_info *swig_types[33];
+static swig_module_info swig_module = {swig_types, 32, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3172,7 +3173,7 @@ PyProgressProxy( double dfComplete, const char *pszMessage, void *pData )
     PyObject *psArgs, *psResult;
     int      bContinue = TRUE;
 
-    if( psInfo->nLastReported == (int) (100.0 * dfComplete) )
+    if( dfComplete > 0 && psInfo->nLastReported == (int) (100.0 * dfComplete) )
         return TRUE;
 
     if( psInfo->psPyCallback == NULL || psInfo->psPyCallback == Py_None )
@@ -4044,6 +4045,9 @@ SWIGINTERN ArrowArrayStream *OGRLayerShadow_GetArrowStream(OGRLayerShadow *self,
           return NULL;
       }
   }
+SWIGINTERN void OGRLayerShadow_GetGeometryTypes(OGRLayerShadow *self,OGRGeometryTypeCounter **ppRet,int *pnEntryCount,int geom_field=0,int flags=0,GDALProgressFunc callback=NULL,void *callback_data=NULL){
+        *ppRet = OGR_L_GetGeometryTypes(self, geom_field, flags, pnEntryCount, callback, callback_data);
+    }
 SWIGINTERN void delete_OGRFeatureShadow(OGRFeatureShadow *self){
     OGR_F_Destroy(self);
   }
@@ -13074,6 +13078,174 @@ fail:
   {
     /* %typemap(freearg) char **options */
     CSLDestroy( arg2 );
+  }
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Layer_GetGeometryTypes(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  OGRLayerShadow *arg1 = (OGRLayerShadow *) 0 ;
+  OGRGeometryTypeCounter **arg2 = (OGRGeometryTypeCounter **) 0 ;
+  int *arg3 = (int *) 0 ;
+  int arg4 = (int) 0 ;
+  int arg5 = (int) 0 ;
+  GDALProgressFunc arg6 = (GDALProgressFunc) NULL ;
+  void *arg7 = (void *) NULL ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  OGRGeometryTypeCounter *pRet2 = NULL ;
+  int nEntryCount2 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  int val5 ;
+  int ecode5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"geom_field",  (char *)"flags",  (char *)"callback",  (char *)"callback_data",  NULL 
+  };
+  
+  /* %typemap(arginit) ( const char* callback_data=NULL)  */
+  PyProgressData *psProgressInfo;
+  psProgressInfo = (PyProgressData *) CPLCalloc(1,sizeof(PyProgressData));
+  psProgressInfo->nLastReported = -1;
+  psProgressInfo->psPyCallback = NULL;
+  psProgressInfo->psPyCallbackData = NULL;
+  arg7 = psProgressInfo;
+  {
+    /* %typemap(in,numinputs=0) (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
+    arg2 = &pRet2;
+    arg3 = &nEntryCount2;
+  }
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOO:Layer_GetGeometryTypes", kwnames, &obj0, &obj1, &obj2, &obj3, &obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_OGRLayerShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Layer_GetGeometryTypes" "', argument " "1"" of type '" "OGRLayerShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< OGRLayerShadow * >(argp1);
+  if (obj1) {
+    ecode4 = SWIG_AsVal_int(obj1, &val4);
+    if (!SWIG_IsOK(ecode4)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "Layer_GetGeometryTypes" "', argument " "4"" of type '" "int""'");
+    } 
+    arg4 = static_cast< int >(val4);
+  }
+  if (obj2) {
+    ecode5 = SWIG_AsVal_int(obj2, &val5);
+    if (!SWIG_IsOK(ecode5)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "Layer_GetGeometryTypes" "', argument " "5"" of type '" "int""'");
+    } 
+    arg5 = static_cast< int >(val5);
+  }
+  if (obj3) {
+    {
+      /* %typemap(in) (GDALProgressFunc callback = NULL) */
+      /* callback_func typemap */
+      
+      /* In some cases 0 is passed instead of None. */
+      /* See https://github.com/OSGeo/gdal/pull/219 */
+      if ( PyLong_Check(obj3) || PyInt_Check(obj3) )
+      {
+        if( PyLong_AsLong(obj3) == 0 )
+        {
+          obj3 = Py_None;
+        }
+      }
+      
+      if (obj3 && obj3 != Py_None ) {
+        void* cbfunction = NULL;
+        CPL_IGNORE_RET_VAL(SWIG_ConvertPtr( obj3,
+            (void**)&cbfunction,
+            SWIGTYPE_p_f_double_p_q_const__char_p_void__int,
+            SWIG_POINTER_EXCEPTION | 0 ));
+        
+        if ( cbfunction == GDALTermProgress ) {
+          arg6 = GDALTermProgress;
+        } else {
+          if (!PyCallable_Check(obj3)) {
+            PyErr_SetString( PyExc_RuntimeError,
+              "Object given is not a Python function" );
+            SWIG_fail;
+          }
+          psProgressInfo->psPyCallback = obj3;
+          arg6 = PyProgressProxy;
+        }
+        
+      }
+      
+    }
+  }
+  if (obj4) {
+    {
+      /* %typemap(in) ( void* callback_data=NULL)  */
+      psProgressInfo->psPyCallbackData = obj4 ;
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      OGRLayerShadow_GetGeometryTypes(arg1,arg2,arg3,arg4,arg5,arg6,arg7);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  {
+    /* %typemap(argout)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
+    Py_DECREF(resultobj);
+    int nEntryCount = *(arg3);
+    OGRGeometryTypeCounter* pRet = *(arg2);
+    if( pRet == NULL )
+    {
+      PyErr_SetString( PyExc_RuntimeError, CPLGetLastErrorMsg() );
+      SWIG_fail;
+    }
+    resultobj = PyDict_New();
+    for(int i = 0; i < nEntryCount; ++ i)
+    {
+      PyObject *key = PyInt_FromLong( (int)(pRet[i].eGeomType) );
+      PyObject *val = PyLong_FromLongLong( pRet[i].nCount );
+      PyDict_SetItem(resultobj, key, val );
+      Py_DECREF(key);
+      Py_DECREF(val);
+    }
+  }
+  {
+    /* %typemap(freearg)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
+    VSIFree(*arg2);
+  }
+  {
+    /* %typemap(freearg) ( void* callback_data=NULL)  */
+    
+    CPLFree(psProgressInfo);
+    
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  {
+    /* %typemap(freearg)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
+    VSIFree(*arg2);
+  }
+  {
+    /* %typemap(freearg) ( void* callback_data=NULL)  */
+    
+    CPLFree(psProgressInfo);
+    
   }
   return NULL;
 }
@@ -32244,6 +32416,34 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		""},
 	 { "Layer_GetArrowStream", _wrap_Layer_GetArrowStream, METH_VARARGS, "Layer_GetArrowStream(Layer self, char ** options=None) -> ArrowArrayStream"},
+	 { "Layer_GetGeometryTypes", (PyCFunction)(void(*)(void))_wrap_Layer_GetGeometryTypes, METH_VARARGS|METH_KEYWORDS, "\n"
+		"Layer_GetGeometryTypes(Layer self, int geom_field=0, int flags=0, GDALProgressFunc callback=0, void * callback_data=None)\n"
+		"\n"
+		"Get actual geometry types found in features.\n"
+		"\n"
+		"For more details: :cpp:func:`OGR_L_GetGeometryTypes`\n"
+		"\n"
+		"Parameters\n"
+		"-----------\n"
+		"geom_field: int, optional\n"
+		"    index of the geometry field\n"
+		"flags: int, optional\n"
+		"    0, or a combination of :py:const:`osgeo.ogr.GGT_COUNT_NOT_NEEDED`,\n"
+		"    :py:const:`osgeo.ogr.GGT_STOP_IF_MIXED` and\n"
+		"    :py:const:`osgeo.ogr.GGT_GEOMCOLLECTIONZ_TINZ`\n"
+		"callback: Callable, optional\n"
+		"    a GDALProgressFunc() compatible callback function for\n"
+		"    cancellation or None.\n"
+		"callback_data:\n"
+		"    Argument to be passed to 'callback'. May be None.\n"
+		"\n"
+		"Returns\n"
+		"-------\n"
+		"dict:\n"
+		"    A dictionary whose keys are :py:const:`osgeo.ogr.wkbXXXX` constants and\n"
+		"    values the corresponding number of geometries of that type in the layer.\n"
+		"\n"
+		""},
 	 { "Layer_swigregister", Layer_swigregister, METH_O, NULL},
 	 { "delete_Feature", _wrap_delete_Feature, METH_O, "delete_Feature(Feature self)"},
 	 { "new_Feature", (PyCFunction)(void(*)(void))_wrap_new_Feature, METH_VARARGS|METH_KEYWORDS, "new_Feature(FeatureDefn feature_def) -> Feature"},
@@ -35785,6 +35985,7 @@ static swig_type_info _swigt__p_f_double_p_q_const__char_p_void__int = {"_p_f_do
 static swig_type_info _swigt__p_float = {"_p_float", "float *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int = {"_p_int", "OGRFieldSubType *|OSRAxisMappingStrategy *|OGRFieldDomainType *|OGRFieldType *|CPLErr *|int *|OGRwkbGeometryType *|OGRJustification *|OGRAxisOrientation *|OGRFieldDomainSplitPolicy *|OGRFieldDomainMergePolicy *|OGRwkbByteOrder *|OGRErr *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_GIntBig = {"_p_p_GIntBig", "GIntBig **", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_p_OGRGeometryTypeCounter = {"_p_p_OGRGeometryTypeCounter", "OGRGeometryTypeCounter **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_char = {"_p_p_char", "char **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_double = {"_p_p_double", "double **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_int = {"_p_p_int", "int **", 0, 0, (void*)0, 0};
@@ -35818,6 +36019,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_float,
   &_swigt__p_int,
   &_swigt__p_p_GIntBig,
+  &_swigt__p_p_OGRGeometryTypeCounter,
   &_swigt__p_p_char,
   &_swigt__p_p_double,
   &_swigt__p_p_int,
@@ -35851,6 +36053,7 @@ static swig_cast_info _swigc__p_f_double_p_q_const__char_p_void__int[] = {  {&_s
 static swig_cast_info _swigc__p_float[] = {  {&_swigt__p_float, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_int[] = {  {&_swigt__p_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_GIntBig[] = {  {&_swigt__p_p_GIntBig, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_OGRGeometryTypeCounter[] = {  {&_swigt__p_p_OGRGeometryTypeCounter, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_char[] = {  {&_swigt__p_p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_double[] = {  {&_swigt__p_p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_int[] = {  {&_swigt__p_p_int, 0, 0, 0},{0, 0, 0, 0}};
@@ -35884,6 +36087,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_float,
   _swigc__p_int,
   _swigc__p_p_GIntBig,
+  _swigc__p_p_OGRGeometryTypeCounter,
   _swigc__p_p_char,
   _swigc__p_p_double,
   _swigc__p_p_int,
@@ -36752,6 +36956,9 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "F_VAL_WIDTH",SWIG_From_int(static_cast< int >(0x00000004)));
   SWIG_Python_SetConstant(d, "F_VAL_ALLOW_NULL_WHEN_DEFAULT",SWIG_From_int(static_cast< int >(0x00000008)));
   SWIG_Python_SetConstant(d, "F_VAL_ALL",SWIG_From_int(static_cast< int >(0xFFFFFFFF)));
+  SWIG_Python_SetConstant(d, "GGT_COUNT_NOT_NEEDED",SWIG_From_int(static_cast< int >(0x1)));
+  SWIG_Python_SetConstant(d, "GGT_STOP_IF_MIXED",SWIG_From_int(static_cast< int >(0x2)));
+  SWIG_Python_SetConstant(d, "GGT_GEOMCOLLECTIONZ_TINZ",SWIG_From_int(static_cast< int >(0x4)));
   SWIG_Python_SetConstant(d, "OLCRandomRead",SWIG_FromCharPtr("RandomRead"));
   SWIG_Python_SetConstant(d, "OLCSequentialWrite",SWIG_FromCharPtr("SequentialWrite"));
   SWIG_Python_SetConstant(d, "OLCRandomWrite",SWIG_FromCharPtr("RandomWrite"));

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -317,6 +317,12 @@ F_VAL_ALLOW_NULL_WHEN_DEFAULT = _ogr.F_VAL_ALLOW_NULL_WHEN_DEFAULT
 
 F_VAL_ALL = _ogr.F_VAL_ALL
 
+GGT_COUNT_NOT_NEEDED = _ogr.GGT_COUNT_NOT_NEEDED
+
+GGT_STOP_IF_MIXED = _ogr.GGT_STOP_IF_MIXED
+
+GGT_GEOMCOLLECTIONZ_TINZ = _ogr.GGT_GEOMCOLLECTIONZ_TINZ
+
 OLCRandomRead = _ogr.OLCRandomRead
 
 OLCSequentialWrite = _ogr.OLCSequentialWrite
@@ -2112,6 +2118,37 @@ class Layer(MajorObject):
     def GetArrowStream(self, *args) -> "ArrowArrayStream *":
         r"""GetArrowStream(Layer self, char ** options=None) -> ArrowArrayStream"""
         return _ogr.Layer_GetArrowStream(self, *args)
+
+    def GetGeometryTypes(self, *args, **kwargs) -> "void":
+        r"""
+        GetGeometryTypes(Layer self, int geom_field=0, int flags=0, GDALProgressFunc callback=0, void * callback_data=None)
+
+        Get actual geometry types found in features.
+
+        For more details: :cpp:func:`OGR_L_GetGeometryTypes`
+
+        Parameters
+        -----------
+        geom_field: int, optional
+            index of the geometry field
+        flags: int, optional
+            0, or a combination of :py:const:`osgeo.ogr.GGT_COUNT_NOT_NEEDED`,
+            :py:const:`osgeo.ogr.GGT_STOP_IF_MIXED` and
+            :py:const:`osgeo.ogr.GGT_GEOMCOLLECTIONZ_TINZ`
+        callback: Callable, optional
+            a GDALProgressFunc() compatible callback function for
+            cancellation or None.
+        callback_data:
+            Argument to be passed to 'callback'. May be None.
+
+        Returns
+        -------
+        dict:
+            A dictionary whose keys are :py:const:`osgeo.ogr.wkbXXXX` constants and
+            values the corresponding number of geometries of that type in the layer.
+
+        """
+        return _ogr.Layer_GetGeometryTypes(self, *args, **kwargs)
 
     def Reference(self):
       "For backwards compatibility only."


### PR DESCRIPTION
This method iterates over features to retrieve their geometry types. This
is mostly useful for layers that report a wkbUnknown geometry type.
    
By default this method returns an array of nEntryCount entries with each
geometry type (in OGRGeometryTypeCounter::eGeomType) and the corresponding
number of features (in OGRGeometryTypeCounter::nCount).
Features without geometries are reported as eGeomType == wkbNone.

Optimized implementations for GPKG and PostgreSQL