### PR TITLE
SWIG: fix MSVC library name since the switch to CMake

### DIFF
--- a/swig/python/setup.py
+++ b/swig/python/setup.py
@@ -242,9 +242,6 @@ class gdal_ext(build_ext):
         elif isinstance(self.library_dirs, str) and sys.platform == 'darwin':
             self.library_dirs += ':' + ':'.join(library_dirs)
         if self.libraries is None:
-            if self.get_compiler() == 'msvc':
-                libraries.remove('gdal')
-                libraries.append('gdal_i')
             self.libraries = libraries
 
         build_ext.finalize_options(self)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->


Following the switch to CMake that was made in 3.5, GDAL library on Windows is no longer named `gdal_i.lib`, so this has to be reflected in SWIG.
