### PR TITLE
Add GDAL_HTTP_TCP_KEEPALIVE/GDAL_HTTP_TCP_KEEPIDLE/GDAL_HTTP_TCP_KEEPINTVL…

### DIFF
--- a/autotest/gdrivers/gdalhttp.py
+++ b/autotest/gdrivers/gdalhttp.py
@@ -198,6 +198,26 @@ def test_http_use_capi_store_sub():
 
 
 ###############################################################################
+
+
+def test_http_keep_alive():
+
+    # Rather dummy test. Just trigger the code path
+
+    with gdaltest.config_option("GDAL_HTTP_TCP_KEEPALIVE", "YES"):
+        gdal.OpenEx("https://google.com", allowed_drivers=["HTTP"])
+
+    with gdaltest.config_options(
+        {
+            "GDAL_HTTP_TCP_KEEPALIVE": "YES",
+            "GDAL_HTTP_TCP_KEEPINTVL": "1",
+            "GDAL_HTTP_TCP_KEEPIDLE": "1",
+        }
+    ):
+        gdal.OpenEx("https://google.com", allowed_drivers=["HTTP"])
+
+
+###############################################################################
 #
 
 

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -234,6 +234,12 @@ e.g GDAL_HTTP_HEADERS=Foo: Bar,"Baz: escaped backslash \\, escaped double-quote 
 
 Starting with GDAL 2.3, the :decl_configoption:`GDAL_HTTP_MAX_RETRY` (number of attempts) and :decl_configoption:`GDAL_HTTP_RETRY_DELAY` (in seconds) configuration option can be set, so that request retries are done in case of HTTP errors 429, 502, 503 or 504.
 
+Starting with GDAL 3.6, the following configuration options control the TCP keep-alive functionality (cf https://daniel.haxx.se/blog/2020/02/10/curl-ootw-keepalive-time/ for a detailed explanation):
+
+- :decl_configoption:`GDAL_HTTP_TCP_KEEPALIVE` = YES/NO. whether to enable TCP keep-alive. Defaults to NO
+- :decl_configoption:`GDAL_HTTP_TCP_KEEPIDLE` = integer, in seconds. Keep-alive idle time. Defaults to 60. Only taken into account if GDAL_HTTP_TCP_KEEPALIVE=YES.
+- :decl_configoption:`GDAL_HTTP_TCP_KEEPINTVL` = integer, in seconds. Interval time between keep-alive probes. Defaults to 60. Only taken into account if GDAL_HTTP_TCP_KEEPALIVE=YES.
+
 More generally options of :cpp:func:`CPLHTTPFetch` available through configuration options are available.
 
 The file can be cached in RAM by setting the configuration option :decl_configoption:`VSI_CACHE` to ``TRUE``. The cache size defaults to 25 MB, but can be modified by setting the configuration option :decl_configoption:`VSI_CACHE_SIZE` (in bytes). Content in that cache is discarded when the file handle is closed.


### PR DESCRIPTION
… configuration options to control TCP keep-alive functionality (contributed by @rprinceley)
