### PR TITLE
Docs (GTiff & COG): blocksize must be divisible by 16

### DIFF
--- a/doc/source/drivers/raster/cog.rst
+++ b/doc/source/drivers/raster/cog.rst
@@ -35,7 +35,7 @@ Creation Options
 General creation options
 ************************
 
--  **BLOCKSIZE=n**: Sets the tile width and height in pixels. Defaults to 512.
+-  **BLOCKSIZE=n**: Sets the tile width and height in pixels. Defaults to 512. Must be divisible by 16.
 
 -  **COMPRESS=[NONE/LZW/JPEG/DEFLATE/ZSTD/WEBP/LERC/LERC_DEFLATE/LERC_ZSTD/LZMA]**: Set the compression to use.
    Defaults to ``LZW`` starting with GDAL 3.4 (default in previous version is ``NONE``).

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -370,11 +370,11 @@ Creation Options
 -  **TILED=YES**: By default striped TIFF files are created. This
    option can be used to force creation of tiled TIFF files.
 
--  **BLOCKXSIZE=n**: Sets tile width, defaults to 256.
+-  **BLOCKXSIZE=n**: Sets tile width, defaults to 256. Must be divisible by 16.
 
 -  **BLOCKYSIZE=n**: Set tile or strip height. Tile height defaults to
    256, strip height defaults to a value such that one strip is 8K or
-   less.
+   less. Must be divisible by 16.
 
 -  **NBITS=n**: Create a file with less than 8 bits per sample by
    passing a value from 1 to 7. The apparent pixel type should be Byte.

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -374,7 +374,7 @@ Creation Options
 
 -  **BLOCKYSIZE=n**: Set tile or strip height. Tile height defaults to
    256, strip height defaults to a value such that one strip is 8K or
-   less. Must be divisible by 16.
+   less. Must be divisible by 16 when TILED=YES.
 
 -  **NBITS=n**: Create a file with less than 8 bits per sample by
    passing a value from 1 to 7. The apparent pixel type should be Byte.


### PR DESCRIPTION
Hi! This tripped me up in some software that doesn't pass gdal warnings / errors. So I wondered why I got no output and apparently the reason was an incorrectly set block size. This hint aims to inform users about the need that the blocksize must be divisible by 16.