### PR TITLE
Geopackage: Add upsert operation support

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -369,7 +369,7 @@ def test_ogr_gpkg_7():
 
     # Test upserting an existing feature
     feat.SetField("dummy", "updated")
-    assert lyr.UpsertFeature(feat) == 0, "cannot upsert existing feature"
+    assert lyr.UpsertFeature(feat) == ogr.OGRERR_NONE, "cannot upsert existing feature"
     upserted_feat = lyr.GetFeature(feat.GetFID())
     assert (
         upserted_feat.GetField("dummy") == "updated"
@@ -380,7 +380,9 @@ def test_ogr_gpkg_7():
     assert lyr.GetFeatureCount() == 1, "delete feature did not delete"
 
     # Test upserting a non-existing feature
-    assert lyr.UpsertFeature(feat) == 0, "cannot upsert non-existing feature"
+    assert (
+        lyr.UpsertFeature(feat) == ogr.OGRERR_NONE
+    ), "cannot upsert non-existing feature"
     assert lyr.GetFeatureCount() == 1, "upsert failed to add non-existing feature"
 
     # Test updating non-existing feature

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -383,7 +383,7 @@ def test_ogr_gpkg_7():
     assert (
         lyr.UpsertFeature(feat) == ogr.OGRERR_NONE
     ), "cannot upsert non-existing feature"
-    assert lyr.GetFeatureCount() == 1, "upsert failed to add non-existing feature"
+    assert lyr.GetFeatureCount() == 2, "upsert failed to add non-existing feature"
 
     # Test updating non-existing feature
     feat.SetFID(-10)

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -302,7 +302,7 @@ def test_ogr_gpkg_6():
 
 
 ###############################################################################
-# Add a feature / read a feature / delete a feature
+# Add a feature / read a feature / set a feature / upsert a feature / delete a feature
 
 
 def test_ogr_gpkg_7():
@@ -367,9 +367,21 @@ def test_ogr_gpkg_7():
         lyr.TestCapability(ogr.OLCDeleteFeature) == 1
     ), "lyr.TestCapability(ogr.OLCDeleteFeature) != 1"
 
+    # Test upserting an existing feature
+    feat.SetField("dummy", "updated")
+    assert lyr.UpsertFeature(feat) == 0, "cannot upsert existing feature"
+    upserted_feat = lyr.GetFeature(feat.GetFID())
+    assert (
+        upserted_feat.GetField("dummy") == "updated"
+    ), "upsert failed to update existing feature"
+
     # Delete a feature
     lyr.DeleteFeature(feat.GetFID())
     assert lyr.GetFeatureCount() == 1, "delete feature did not delete"
+
+    # Test upserting a non-existing feature
+    assert lyr.UpsertFeature(feat) == 0, "cannot upsert non-existing feature"
+    assert lyr.GetFeatureCount() == 1, "upsert failed to add non-existing feature"
 
     # Test updating non-existing feature
     feat.SetFID(-10)

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -534,6 +534,8 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     OGRErr              RenameFieldInAuxiliaryTables(
                             const char* pszOldName, const char* pszNewName);
 
+    bool                FeatureIDExists( GIntBig nFID );
+
     CPL_DISALLOW_COPY_ASSIGN(OGRGeoPackageTableLayer)
 
     public:

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -562,6 +562,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     void                ResetReading() override;
     OGRErr              ICreateFeature( OGRFeature *poFeater ) override;
     OGRErr              ISetFeature( OGRFeature *poFeature ) override;
+    OGRErr              IUpsertFeature( OGRFeature* poFeature ) override;
     OGRErr              DeleteFeature(GIntBig nFID) override;
     virtual void        SetSpatialFilter( OGRGeometry * ) override;
     virtual void        SetSpatialFilter( int iGeomField, OGRGeometry *poGeom ) override

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -2046,9 +2046,8 @@ OGRErr OGRGeoPackageTableLayer::ISetFeature( OGRFeature *poFeature )
 bool OGRGeoPackageTableLayer::FeatureIDExists( GIntBig nFID )
 {
    CPLString soSQL;
-   soSQL.Printf("SELECT %s FROM \"%s\" m "
+   soSQL.Printf("SELECT 1 FROM \"%s\" "
                 "WHERE \"%s\" = " CPL_FRMT_GIB,
-                m_soColumns.c_str(),
                 SQLEscapeName(m_pszTableName).c_str(),
                 SQLEscapeName(m_pszFidColumn).c_str(),
                 nFID);
@@ -2061,7 +2060,7 @@ bool OGRGeoPackageTableLayer::FeatureIDExists( GIntBig nFID )
       sqlite3_finalize(poStmt);
       CPLError(CE_Failure, CPLE_AppDefined,
                "failed to prepare SQL: %s", soSQL.c_str());
-      return nullptr;
+      return false;
    }
 
    err = sqlite3_step(poStmt);

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -2040,6 +2040,26 @@ OGRErr OGRGeoPackageTableLayer::ISetFeature( OGRFeature *poFeature )
 }
 
 /************************************************************************/
+/*                           IUpsertFeature()                           */
+/************************************************************************/
+
+OGRErr OGRGeoPackageTableLayer::IUpsertFeature( OGRFeature* poFeature )
+
+{
+   if ( !TestCapability(OLCUpsertFeature) )
+      return OGRERR_FAILURE;
+
+   if ( GetFeature(poFeature->GetFID()) )
+   {
+      return SetFeature(poFeature);
+   }
+   else
+   {
+      return CreateFeature(poFeature);
+   }
+}
+
+/************************************************************************/
 /*                         SetAttributeFilter()                         */
 /************************************************************************/
 
@@ -2831,6 +2851,7 @@ int OGRGeoPackageTableLayer::TestCapability ( const char * pszCap )
         return m_poDS->GetUpdate() && m_bIsTable;
     }
     else if ( EQUAL(pszCap, OLCDeleteFeature) ||
+              EQUAL(pszCap, OLCUpsertFeature) ||
               EQUAL(pszCap, OLCRandomWrite) )
     {
         return m_poDS->GetUpdate() && m_pszFidColumn != nullptr;


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR implements the Upsert feature operation in the OGR Geopackage driver (ie. if record does not exist then Create, else Set).

## What are related issues/pull requests?
For context, the OGR Upsert operation was added here https://github.com/OSGeo/gdal/pull/6199

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed