### PR TITLE
Add CPLMask functions to simplify bitmask handling

### DIFF
--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -38,6 +38,7 @@
 
 #include "cpl_conv.h"
 #include "cpl_error.h"
+#include "cpl_mask.h"
 #include "cpl_minixml.h"
 #include "cpl_progress.h"
 #include "cpl_string.h"
@@ -351,7 +352,7 @@ template<class T> static CPLErr GDALWarpNoDataMaskerT( const double *padfNoData,
         if( pData[iOffset] == nNoData )
         {
             bAllValid = FALSE;
-            panValidityMask[iOffset>>5] &= ~(0x01 << (iOffset & 0x1f));
+            CPLMaskClear(panValidityMask, iOffset);
         }
     }
     *pbOutAllValid = bAllValid;
@@ -431,7 +432,7 @@ GDALWarpNoDataMasker( void *pMaskFuncArg, int nBandCount, GDALDataType eType,
                   (!bIsNoDataNan && ARE_REAL_EQUAL(fVal, fNoData)) )
               {
                   bAllValid = FALSE;
-                  panValidityMask[iOffset>>5] &= ~(0x01 << (iOffset & 0x1f));
+                  CPLMaskClear(panValidityMask, iOffset);
               }
           }
           *pbOutAllValid = bAllValid;
@@ -460,7 +461,7 @@ GDALWarpNoDataMasker( void *pMaskFuncArg, int nBandCount, GDALDataType eType,
                   (!bIsNoDataNan && ARE_REAL_EQUAL(dfVal, dfNoData)) )
               {
                   bAllValid = FALSE;
-                  panValidityMask[iOffset>>5] &= ~(0x01 << (iOffset & 0x1f));
+                  CPLMaskClear(panValidityMask, iOffset);
               }
           }
           *pbOutAllValid = bAllValid;
@@ -492,8 +493,7 @@ GDALWarpNoDataMasker( void *pMaskFuncArg, int nBandCount, GDALDataType eType,
                           iPixel + static_cast<size_t>(iLine) * nXSize;
 
                       bAllValid = FALSE;
-                      panValidityMask[iOffset>>5] &=
-                          ~(0x01 << (iOffset & 0x1f));
+                      CPLMaskClear(panValidityMask, iOffset);
                   }
               }
           }
@@ -790,7 +790,7 @@ GDALWarpSrcMaskMasker( void *pMaskFuncArg,
     for( size_t iPixel = 0; iPixel < nPixels; iPixel++ )
     {
         if( pabySrcMask[iPixel] == 0 )
-            panMask[iPixel>>5] &= ~(0x01 << (iPixel & 0x1f));
+            CPLMaskClear(panMask, iPixel);
     }
 
     CPLFree( pabySrcMask );

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -45,6 +45,7 @@
 #include "cpl_config.h"
 #include "cpl_conv.h"
 #include "cpl_error.h"
+#include "cpl_mask.h"
 #include "cpl_multiproc.h"
 #include "cpl_string.h"
 #include "cpl_vsi.h"
@@ -2107,23 +2108,17 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
             if( !bAtLeastOneBandAllValid &&
                 (pszUnifiedSrcNoData == nullptr || CPLTestBool(pszUnifiedSrcNoData)) )
             {
-                const GPtrDiff_t nBytesInMask = (
-                    static_cast<GPtrDiff_t>(oWK.nSrcXSize) * oWK.nSrcYSize + 31) / 8;
-                const GPtrDiff_t nIters = nBytesInMask / 4;
+                auto nMaskBits = static_cast<GPtrDiff_t>(oWK.nSrcXSize) * oWK.nSrcYSize;
 
                 eErr = CreateKernelMask( &oWK, 0 /* not used */, "UnifiedSrcValid" );
 
                 if( eErr == CE_None )
                 {
-                    memset( oWK.panUnifiedSrcValid, 0, nBytesInMask );
+                    CPLMaskClearAll(oWK.panUnifiedSrcValid, nMaskBits);
 
                     for( int k = 0; k < psOptions->nBandCount; k++ )
                     {
-                        for( GPtrDiff_t iWord = 0; iWord < nIters; iWord++ )
-                        {
-                            oWK.panUnifiedSrcValid[iWord] |=
-                                oWK.papanBandSrcValid[k][iWord];
-                        }
+                        CPLMaskMerge(oWK.panUnifiedSrcValid, oWK.papanBandSrcValid[k], nMaskBits);
                     }
 
                     // If UNIFIED_SRC_NODATA is set, then we will ignore the individual
@@ -2193,19 +2188,19 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
     {
         CPLAssert( oWK.panDstValid == nullptr );
 
-        const GPtrDiff_t nMaskWords = (static_cast<GPtrDiff_t>(oWK.nDstXSize) * oWK.nDstYSize + 31)/32;
+        const GPtrDiff_t nMaskBits = static_cast<GPtrDiff_t>(oWK.nDstXSize) * oWK.nDstYSize;
 
         eErr = CreateKernelMask( &oWK, 0 /* not used */, "DstValid" );
         GUInt32 *panBandMask =
             eErr == CE_None
-            ? static_cast<GUInt32 *>(CPLMalloc(nMaskWords * 4))
+            ? CPLMaskCreate(nMaskBits, true)
             : nullptr;
 
         if( eErr == CE_None && panBandMask != nullptr )
         {
             for( int iBand = 0; iBand < psOptions->nBandCount; iBand++ )
             {
-                memset( panBandMask, 0xff, nMaskWords * 4 );
+                CPLMaskSetAll(panBandMask, nMaskBits);
 
                 double adfNoData[2] =
                 {
@@ -2237,8 +2232,7 @@ CPLErr GDALWarpOperation::WarpRegionToBuffer(
                     break;
                 }
 
-                for( GPtrDiff_t iWord = nMaskWords - 1; iWord >= 0; iWord-- )
-                    oWK.panDstValid[iWord] |= panBandMask[iWord];
+                CPLMaskMerge(oWK.panDstValid, panBandMask, nMaskBits);
             }
             CPLFree( panBandMask );
         }

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -4086,6 +4086,7 @@ namespace tut
 
         VSIFree(m);
         m = CPLMaskCreate(sz, false);
+        auto m2 = CPLMaskCreate(sz, false);
 
         // Mask is unset by default
         for (std::size_t i = 0; i < sz; i++) {
@@ -4119,7 +4120,6 @@ namespace tut
             }
         }
 
-        auto m2 = CPLMaskCreate(sz, false);
         CPLMaskSet(m2, 36);
         CPLMaskMerge(m2, m, sz);
 

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -39,6 +39,7 @@
 #include "cpl_error.h"
 #include "cpl_hash_set.h"
 #include "cpl_list.h"
+#include "cpl_mask.h"
 #include "cpl_sha256.h"
 #include "cpl_string.h"
 #include "cpl_safemaths.hpp"
@@ -4068,6 +4069,80 @@ namespace tut
         }
         VSIFCloseL(fp);
         VSIUnlink("temp_test_64.bin");
+    }
+
+    // Test CPLMask implementation
+    template<>
+    template<>
+    void object::test<65>()
+    {
+        constexpr std::size_t sz = 71;
+        auto m = CPLMaskCreate(sz, true);
+
+        // Mask is set by default
+        for (std::size_t i = 0; i < sz; i++) {
+            ensure_equals("bits set by default", CPLMaskGet(m, i), true);
+        }
+
+        VSIFree(m);
+        m = CPLMaskCreate(sz, false);
+
+        // Mask is unset by default
+        for (std::size_t i = 0; i < sz; i++) {
+            ensure_equals("bits unset by default", CPLMaskGet(m, i), false);
+        }
+
+        // Set a few bits
+        CPLMaskSet(m, 10);
+        CPLMaskSet(m, 33);
+        CPLMaskSet(m, 70);
+
+        // Check all bits
+        for (std::size_t i = 0; i < sz; i++) {
+            if (i == 10 || i == 33 || i == 70) {
+                ensure_equals("bit set correctly", CPLMaskGet(m, i), true);
+            } else {
+                ensure_equals("bit remains unset", CPLMaskGet(m, i), false);
+            }
+        }
+
+        // Unset some bits
+        CPLMaskClear(m, 10);
+        CPLMaskClear(m, 70);
+
+        // Check all bits
+        for (std::size_t i = 0; i < sz; i++) {
+            if (i == 33) {
+                ensure_equals("bit remains set", CPLMaskGet(m, i), true);
+            } else {
+                ensure_equals("bit cleared correctly", CPLMaskGet(m, i), false);
+            }
+        }
+
+        auto m2 = CPLMaskCreate(sz, false);
+        CPLMaskSet(m2, 36);
+        CPLMaskMerge(m2, m, sz);
+
+        // Check all bits
+        for (std::size_t i = 0; i < sz; i++) {
+            if (i == 36 || i == 33) {
+                ensure_equals("m2 bit set correctly", CPLMaskGet(m2, i), true);
+            } else {
+                ensure_equals("m2 bit remains clear", CPLMaskGet(m2, i), false);
+            }
+        }
+
+        CPLMaskClearAll(m, sz);
+        CPLMaskSetAll(m2, sz);
+
+        // Check all bits
+        for (std::size_t i = 0; i < sz; i++) {
+            ensure_equals("all bits cleared", CPLMaskGet(m, i), false);
+            ensure_equals("all bits set", CPLMaskGet(m2, i), true);
+        }
+
+        VSIFree(m);
+        VSIFree(m2);
     }
 
     // WARNING: keep that line at bottom and read carefully:

--- a/port/cpl_mask.h
+++ b/port/cpl_mask.h
@@ -1,0 +1,136 @@
+/**********************************************************************
+ * $Id$
+ *
+ * Name:     cpl_string.h
+ * Project:  CPL - Common Portability Library
+ * Purpose:  Bitmask manipulation functions
+ * Author:   Daniel Baston, dbaston@gmail.com
+ *
+ **********************************************************************
+ * Copyright (c) 2022, ISciences LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef CPL_MASK_H_INCLUDED
+#define CPL_MASK_H_INCLUDED
+
+#include "cpl_port.h"
+#include "cpl_vsi.h"
+
+#ifdef __cplusplus
+
+#include <cstring>
+
+/**
+ * Allocates a buffer to store a given number of bits
+ *
+ * @param size number of bits
+ * @param default_value initial value of bits
+ */
+inline
+GUInt32* CPLMaskCreate(std::size_t size, bool default_value) {
+    std::size_t nBytes = (size + 31) / 8;
+    void* buf = VSI_MALLOC_VERBOSE(nBytes);
+    if (buf == nullptr) {
+        return nullptr;
+    }
+    std::memset(buf,
+                default_value ? 0xff : 0,
+                nBytes);
+    return static_cast<GUInt32*>(buf);
+}
+
+/**
+ * Get the value of a bit
+ *
+ * @param mask bit mask
+ * @param i index of bit
+ * @return `true` if bit is set
+ */
+inline
+bool CPLMaskGet(GUInt32* mask, std::size_t i) {
+    return mask[i >> 5] & (0x01 << (i & 0x1f));
+}
+
+/**
+ * Clear the value of a bit (set to false)
+ *
+ * @param mask bit mask
+ * @param i index of bit to clear
+ */
+inline
+void CPLMaskClear(GUInt32* mask, std::size_t i) {
+    mask[i >> 5] &= ~(0x01 << (i & 0x1f));
+}
+
+/**
+ * Clear all bits in a mask
+ *
+ * @param mask bit mask
+ * @param size number of bits in mask
+ */
+inline
+void CPLMaskClearAll(GUInt32* mask, std::size_t size) {
+    auto nBytes = (size + 31) / 8;
+    std::memset(mask, 0, nBytes);
+}
+
+/**
+ * Set the value of a bit to true
+ *
+ * @param mask bit mask
+ * @param i index of bit to set
+ */
+inline
+void CPLMaskSet(GUInt32* mask, std::size_t i) {
+    mask[i >> 5] |= (0x01 << (i & 0x1f));
+}
+
+/**
+ * Set all bits in a mask
+ *
+ * @param mask bit mask
+ * @param size number of bits in mask
+ */
+inline
+void CPLMaskSetAll(GUInt32* mask, std::size_t size) {
+    auto nBytes = (size + 31) / 8;
+    std::memset(mask, 0xff, nBytes);
+}
+
+/**
+ * Set a mask to true wherever a second mask is true
+ *
+ * @param mask1 destination mask
+ * @param mask2 source mask
+ * @param n number of bits in masks (must be same)
+ */
+inline
+void CPLMaskMerge(GUInt32* mask1, GUInt32* mask2, std::size_t n) {
+    std::size_t nBytes = (n + 31) / 8;
+    std::size_t nIter = nBytes / 4;
+    for (std::size_t i = 0; i < nIter; i++) {
+        mask1[i] |= mask2[i];
+    }
+}
+
+#endif // __cplusplus
+
+#endif // CPL_MASK_H

--- a/port/cpl_mask.h
+++ b/port/cpl_mask.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * $Id$
  *
- * Name:     cpl_string.h
+ * Name:     cpl_mask.h
  * Project:  CPL - Common Portability Library
  * Purpose:  Bitmask manipulation functions
  * Author:   Daniel Baston, dbaston@gmail.com


### PR DESCRIPTION
## What does this PR do?

This PR attempts to some parts of the warp code easier to read by adding functions to manipulate bit masks stored in a GUInt32*. I thought of putting this in a custom type but it seemed better to be less invasive, avoid changing signatures, and stick with GUInt32*.

## What are related issues/pull requests?

None

## Tasklist

 - [X] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed