### PR TITLE
Elasticsearch: Add upsert operation support

### DIFF
--- a/autotest/ogr/ogr_elasticsearch.py
+++ b/autotest/ogr/ogr_elasticsearch.py
@@ -1173,6 +1173,7 @@ def test_ogr_elasticsearch_4():
         ret = lyr.SetFeature(lyr.GetNextFeature())
     assert ret != 0
 
+    lyr.ResetReading()
     with gdaltest.error_handler():
         ret = lyr.UpsertFeature(lyr.GetNextFeature())
     assert ret != 0

--- a/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -194,7 +194,7 @@ public:
 
     virtual OGRErr      ICreateFeature(OGRFeature *poFeature) override;
     virtual OGRErr      ISetFeature(OGRFeature *poFeature) override;
-    OGRErr IUpsertFeature(OGRFeature *poFeature) override;
+    OGRErr              IUpsertFeature(OGRFeature *poFeature) override;
     virtual OGRErr      CreateField(OGRFieldDefn *poField, int bApproxOK) override;
     virtual OGRErr      CreateGeomField(OGRGeomFieldDefn *poField, int bApproxOK) override;
 

--- a/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -194,6 +194,7 @@ public:
 
     virtual OGRErr      ICreateFeature(OGRFeature *poFeature) override;
     virtual OGRErr      ISetFeature(OGRFeature *poFeature) override;
+    OGRErr IUpsertFeature(OGRFeature *poFeature) override;
     virtual OGRErr      CreateField(OGRFieldDefn *poField, int bApproxOK) override;
     virtual OGRErr      CreateGeomField(OGRGeomFieldDefn *poField, int bApproxOK) override;
 

--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -2567,6 +2567,88 @@ OGRErr OGRElasticLayer::ISetFeature(OGRFeature *poFeature)
 }
 
 /************************************************************************/
+/*                          IUpsertFeature()                            */
+/************************************************************************/
+
+OGRErr OGRElasticLayer::IUpsertFeature(OGRFeature *poFeature)
+{
+    if( m_poDS->GetAccess() != GA_Update )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Dataset opened in read-only mode");
+        return OGRERR_FAILURE;
+    }
+
+    FinalizeFeatureDefn();
+
+    if( WriteMapIfNecessary() != OGRERR_NONE )
+        return OGRERR_FAILURE;
+
+    if (!m_osWriteMapFilename.empty() )
+        return OGRERR_NONE;
+
+    if( poFeature->GetFID() < 0 )
+    {
+        if( m_nNextFID < 0 )
+            m_nNextFID = GetFeatureCount(FALSE);
+        poFeature->SetFID(++m_nNextFID);
+    }
+
+    CPLString osFields(BuildJSonFromFeature(poFeature));
+
+    const char* pszId = nullptr;
+    if( poFeature->IsFieldSetAndNotNull(0) )
+    {
+        pszId = poFeature->GetFieldAsString(0);
+    }
+    else
+    {
+        return OGRERR_FAILURE;
+    }
+
+    // Check to see if we're using bulk uploading
+    if (m_nBulkUpload > 0)
+    {
+        m_osBulkContent += CPLSPrintf("{\"update\":{\"_index\":\"%s\",\"_id\":\"%s\"", m_osIndexName.c_str(), pszId);
+        if(m_poDS->m_nMajorVersion < 7)
+        {
+            m_osBulkContent += CPLSPrintf(", \"_type\":\"%s\"", m_osMappingName.c_str());
+        }
+        m_osBulkContent += "}}\n{\"doc\":" + osFields + ",\"doc_as_upsert\":true}\n\n";
+
+        // Only push the data if we are over our bulk upload limit
+        if (m_osBulkContent.length() > static_cast<size_t>(m_nBulkUpload))
+        {
+            if( !PushIndex() )
+            {
+                return OGRERR_FAILURE;
+            }
+        }
+    }
+    else
+    {
+        // Fall back to using single item upload for every feature.
+        CPLString osURL(BuildMappingURL(false));
+        if (m_poDS->m_nMajorVersion < 7)
+        {
+           osURL += CPLSPrintf("/%s/_update", pszId);
+        }
+        else
+        {
+           osURL += CPLSPrintf("/_update/%s", pszId);
+        }
+
+        const CPLString osUpdate = CPLSPrintf("{\"doc\":%s,\"doc_as_upsert\":true}", osFields.c_str());
+        const CPLString osMethod = "POST";
+        if (!m_poDS->UploadFile(osURL, osUpdate, osMethod))
+        {
+           return OGRERR_FAILURE;
+        }
+    }
+
+    return OGRERR_NONE;
+}
+
+/************************************************************************/
 /*                             PushIndex()                              */
 /************************************************************************/
 

--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -2825,6 +2825,7 @@ int OGRElasticLayer::TestCapability(const char * pszCap) {
         return TRUE;
 
     else if (EQUAL(pszCap, OLCSequentialWrite) ||
+             EQUAL(pszCap, OLCUpsertFeature) ||
              EQUAL(pszCap, OLCRandomWrite) )
         return m_poDS->GetAccess() == GA_Update;
     else if (EQUAL(pszCap, OLCCreateField) ||


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This PR implements the Upsert feature operation in the OGR Elasticsearch driver (ie. if record does not exist then Create, else Set).

## What are related issues/pull requests?
For context, the OGR Upsert operation was added here https://github.com/OSGeo/gdal/pull/6199

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed