### PR TITLE
[Backport release/3.5] SQLite: allow creating layers named like 'foo(bar)' (fixes #6548)

### DIFF
--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -3283,6 +3283,32 @@ def test_ogr_sqlite_CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE():
     assert gdal.ReadDir('/vsimem/temporary_location') is None
 
 ###############################################################################
+# Test support for creating "foo(bar)" layer names
+
+
+def test_ogr_sqlite_create_layer_names_with_parenthesis():
+
+    tmpfilename = "/vsimem/test_ogr_sqlite_create_layer_names_with_parenthesis.db"
+    try:
+        src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+        src_ds.CreateLayer("foo(bar)")
+        gdal.ErrorReset()
+        out_ds = gdal.VectorTranslate(tmpfilename, src_ds, format="SQLite")
+        assert out_ds is not None
+        assert gdal.GetLastErrorMsg() == ""
+        out_ds = None
+        ds = ogr.Open(tmpfilename)
+        gdal.ErrorReset()
+        assert ds.GetLayerByName("foo(bar)") is not None
+        assert gdal.GetLastErrorMsg() == ""
+        assert ds.GetLayerByName("bar(baz)") is None
+        assert gdal.GetLastErrorMsg() == ""
+        ds = None
+    finally:
+        gdal.Unlink(tmpfilename)
+
+
+###############################################################################
 #
 
 

--- a/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -329,7 +329,8 @@ class OGRSQLiteTableLayer final: public OGRSQLiteLayer
 
     bool                CheckSpatialIndexTable(int iGeomCol);
 
-    CPLErr              EstablishFeatureDefn(const char* pszGeomCol);
+    CPLErr              EstablishFeatureDefn(const char* pszGeomCol,
+                                             bool bMayEmitError);
 
     void                LoadStatistics();
     void                LoadStatisticsSpatialite4DB();
@@ -346,7 +347,8 @@ class OGRSQLiteTableLayer final: public OGRSQLiteLayer
     CPLErr              Initialize( const char *pszTableName,
                                     bool bIsTable,
                                     bool bIsVirtualShapeIn,
-                                    bool bDeferredCreation);
+                                    bool bDeferredCreation,
+                                    bool bMayEmitError );
     void                SetCreationParameters( const char *pszFIDColumnName,
                                                OGRwkbGeometryType eGeomType,
                                                const char *pszGeomFormat,
@@ -611,7 +613,8 @@ class OGRSQLiteDataSource final : public OGRSQLiteBaseDataSource
 
     bool                OpenTable( const char *pszTableName,
                                    bool IsTable,
-                                   bool bIsVirtualShape );
+                                   bool bIsVirtualShape,
+                                   bool bMayEmitError );
     bool                OpenView( const char *pszViewName,
                                    const char *pszViewGeometry,
                                    const char *pszViewRowid,

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -1898,7 +1898,7 @@ bool OGRSQLiteDataSource::Open( GDALOpenInfo* poOpenInfo)
                 continue;
 
             if( GDALDataset::GetLayerByName(pszTableName) == nullptr )
-                OpenTable( pszTableName, true, false );
+                OpenTable( pszTableName, true, false, /* bMayEmitError = */ true );
 
             if (bListAllTables)
                 CPLHashSetInsert(hSet, CPLStrdup(pszTableName));
@@ -2107,7 +2107,7 @@ bool OGRSQLiteDataSource::Open( GDALOpenInfo* poOpenInfo)
             }
 
             if( GDALDataset::GetLayerByName(pszTableName) == nullptr )
-                OpenTable( pszTableName, true, false);
+                OpenTable( pszTableName, true, false, /* bMayEmitError = */ true);
             if (bListAllTables)
                 CPLHashSetInsert(hSet, CPLStrdup(pszTableName));
         }
@@ -2245,7 +2245,7 @@ all_tables:
         if( pszTableName != nullptr && CPLHashSetLookup(hSet, pszTableName) == nullptr )
         {
             const bool bIsTable = pszType != nullptr && strcmp(pszType, "table") == 0;
-            OpenTable( pszTableName, bIsTable, false );
+            OpenTable( pszTableName, bIsTable, false, /* bMayEmitError = */ true );
         }
     }
 
@@ -2286,7 +2286,7 @@ bool OGRSQLiteDataSource::OpenVirtualTable(const char* pszName, const char* pszS
         }
     }
 
-    if (OpenTable(pszName, true, pszVirtualShape != nullptr))
+    if (OpenTable(pszName, true, pszVirtualShape != nullptr, /* bMayEmitError = */ true))
     {
         OGRSQLiteLayer* poLayer = m_papoLayers[m_nLayers-1];
         if( poLayer->GetLayerDefn()->GetGeomFieldCount() == 1 )
@@ -2321,15 +2321,16 @@ bool OGRSQLiteDataSource::OpenVirtualTable(const char* pszName, const char* pszS
 /************************************************************************/
 
 bool OGRSQLiteDataSource::OpenTable( const char *pszTableName,
-                                    bool bIsTable,
-                                    bool bIsVirtualShape )
+                                     bool bIsTable,
+                                     bool bIsVirtualShape,
+                                     bool bMayEmitError )
 
 {
 /* -------------------------------------------------------------------- */
 /*      Create the layer object.                                        */
 /* -------------------------------------------------------------------- */
     OGRSQLiteTableLayer *poLayer = new OGRSQLiteTableLayer( this );
-    if( poLayer->Initialize( pszTableName, bIsTable, bIsVirtualShape, false) != CE_None )
+    if( poLayer->Initialize( pszTableName, bIsTable, bIsVirtualShape, false, bMayEmitError) != CE_None )
     {
         delete poLayer;
         return false;
@@ -2471,7 +2472,7 @@ OGRLayer *OGRSQLiteDataSource::GetLayerByName( const char* pszLayerName )
         break;
     }
 
-    if( !OpenTable(pszLayerName, bIsTable, false) )
+    if( !OpenTable(pszLayerName, bIsTable, /* bIsVirtualShape = */ false, /* bMayEmitError = */ false) )
         return nullptr;
 
     poLayer = m_papoLayers[m_nLayers-1];
@@ -2573,7 +2574,7 @@ OGRLayer *OGRSQLiteDataSource::GetLayerByNameNotVisible( const char* pszLayerNam
 /*      Create the layer object.                                        */
 /* -------------------------------------------------------------------- */
     OGRSQLiteTableLayer *poLayer = new OGRSQLiteTableLayer( this );
-    if( poLayer->Initialize( pszLayerName, true, false, false) != CE_None )
+    if( poLayer->Initialize( pszLayerName, true, false, false, /* bMayEmitError = */ true) != CE_None )
     {
         delete poLayer;
         return nullptr;
@@ -3100,7 +3101,8 @@ OGRSQLiteDataSource::ICreateLayer( const char * pszLayerNameIn,
 /* -------------------------------------------------------------------- */
     OGRSQLiteTableLayer *poLayer = new OGRSQLiteTableLayer( this );
 
-    poLayer->Initialize( pszLayerName, true, false, true ) ;
+    poLayer->Initialize( pszLayerName, true, false, true,
+                         /* bMayEmitError = */ false ) ;
     OGRSpatialReference* poSRSClone = poSRS;
     if( poSRSClone )
     {


### PR DESCRIPTION
Backport #6551
 **Authored by:** @rouault