### PR TITLE
GPKG: fix issue when GetNextArrowArray() is called before GetArrowSchema(), and improve Python bindings

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -6711,6 +6711,16 @@ def test_ogr_gpkg_arrow_stream_numpy():
     lyr.CreateFeature(f3)
 
     ds = None
+
+    ds = ogr.Open("/vsimem/test.gpkg")
+    lyr = ds.GetLayer(0)
+    stream = lyr.GetArrowStream()
+    array = stream.GetNextRecordBatch()
+    assert array.GetChildrenCount() == 12
+    del array
+    del stream
+    ds = None
+
     ds = ogr.Open("/vsimem/test.gpkg")
     lyr = ds.GetLayer(0)
 

--- a/doc/source/development/rfc/rfc86_column_oriented_api.rst
+++ b/doc/source/development/rfc/rfc86_column_oriented_api.rst
@@ -355,20 +355,11 @@ bench_fiona.py                            63
 bench_pyogrio_raw.py                      41
 bench_pyogrio.py                          103
 bench_geopandas.py                        227
-bench_ogr_batch.cpp (driver impl.)        1.0
+bench_ogr_batch.cpp (driver impl.)        4.8
 bench_ogr_batch.cpp (base impl.)          15.5
 bench_ogr_to_geopandas.py (driver impl.)  10
 bench_ogr_to_geopandas.py (base impl.)    21
 ========================================  ============
-
-bench_ogr_batch.cpp is faster on GeoPackage than on FlatGeoBuf, because the
-GeoPackage geometry encoding is already in WKB (with an extra header), while
-FlatGeoBuf uses a different encoding.
-
-Note: it is not fully understood why bench_ogr_batch.cpp is faster with
-GeoPackage compared to GeoParquet while being slower in bench_ogr_to_geopandas.
-It might potentially be due to Parquet batches being slices of larger arrays,
-and pa.RecordBatch.from_arrays() being able to merge them faster.
 
 
 This demonstrates that:

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -488,6 +488,7 @@ int OGRGeoPackageLayer::GetNextArrowArray(struct ArrowArrayStream* stream,
 
     if( m_poQueryStatement == nullptr )
     {
+        GetLayerDefn();
         ResetStatement();
         if (m_poQueryStatement == nullptr)
             return 0;

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -994,6 +994,57 @@ public:
 #endif /* FROM_GDAL_I */
 
 #ifdef SWIGPYTHON
+
+class ArrowArray {
+  ArrowArray();
+public:
+%extend {
+
+  ~ArrowArray() {
+    if( self->release )
+      self->release(self);
+    free(self);
+  }
+
+  VoidPtrAsLong _getPtr() {
+    return self;
+  }
+
+  GIntBig GetChildrenCount() {
+    return self->n_children;
+  }
+
+  GIntBig GetLength() {
+    return self->length;
+  }
+
+} /* %extend */
+
+}; /* class ArrowArray */
+
+class ArrowSchema {
+  ArrowSchema();
+public:
+%extend {
+
+  ~ArrowSchema() {
+    if( self->release )
+      self->release(self);
+    free(self);
+  }
+
+  VoidPtrAsLong _getPtr() {
+    return self;
+  }
+
+  GIntBig GetChildrenCount() {
+    return self->n_children;
+  }
+
+} /* %extend */
+
+}; /* class ArrowSchema */
+
 class ArrowArrayStream {
   ArrowArrayStream();
 public:
@@ -1005,7 +1056,8 @@ public:
     free(self);
   }
 
-  VoidPtrAsLong _GetSchemaPtr()
+%newobject GetSchema;
+  ArrowSchema* GetSchema()
   {
       struct ArrowSchema* schema = (struct ArrowSchema* )malloc(sizeof(struct ArrowSchema));
       if( self->get_schema(self, schema) == 0 )
@@ -1015,19 +1067,12 @@ public:
       else
       {
           free(schema);
-          return 0;
+          return NULL;
       }
   }
 
-  static void _FreeSchemaPtr(VoidPtrAsLong ptr)
-  {
-      struct ArrowSchema* schema = (struct ArrowSchema* )ptr;
-      if( schema && schema->release )
-          schema->release(schema);
-      free(schema);
-  }
-
-  VoidPtrAsLong _GetNextRecordBatchPtr(char** options = NULL)
+%newobject GetNextRecordBatch;
+  ArrowArray* GetNextRecordBatch(char** options = NULL)
   {
       struct ArrowArray* array = (struct ArrowArray* )malloc(sizeof(struct ArrowArray));
       if( self->get_next(self, array) == 0 && array->release != NULL )
@@ -1037,18 +1082,9 @@ public:
       else
       {
           free(array);
-          return 0;
+          return NULL;
       }
   }
-
-  static void _FreeRecordBatchPtr(VoidPtrAsLong ptr)
-  {
-      struct ArrowArray* array = (struct ArrowArray* )ptr;
-      if( array && array->release )
-          array->release(array);
-      free(array);
-  }
-
 } /* %extend */
 
 

--- a/swig/python/extensions/ogr_wrap.cpp
+++ b/swig/python/extensions/ogr_wrap.cpp
@@ -2694,37 +2694,39 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 
 /* -------- TYPES TABLE (BEGIN) -------- */
 
-#define SWIGTYPE_p_ArrowArrayStream swig_types[0]
-#define SWIGTYPE_p_GDALMajorObjectShadow swig_types[1]
-#define SWIGTYPE_p_GDALProgressFunc swig_types[2]
-#define SWIGTYPE_p_GIntBig swig_types[3]
-#define SWIGTYPE_p_OGRCodedValue swig_types[4]
-#define SWIGTYPE_p_OGRDataSourceShadow swig_types[5]
-#define SWIGTYPE_p_OGRDriverShadow swig_types[6]
-#define SWIGTYPE_p_OGRFeatureDefnShadow swig_types[7]
-#define SWIGTYPE_p_OGRFeatureShadow swig_types[8]
-#define SWIGTYPE_p_OGRFieldDefnShadow swig_types[9]
-#define SWIGTYPE_p_OGRFieldDomainShadow swig_types[10]
-#define SWIGTYPE_p_OGRGeomFieldDefnShadow swig_types[11]
-#define SWIGTYPE_p_OGRGeomTransformerShadow swig_types[12]
-#define SWIGTYPE_p_OGRGeometryShadow swig_types[13]
-#define SWIGTYPE_p_OGRLayerShadow swig_types[14]
-#define SWIGTYPE_p_OGRPreparedGeometryShadow swig_types[15]
-#define SWIGTYPE_p_OGRStyleTableShadow swig_types[16]
-#define SWIGTYPE_p_OSRCoordinateTransformationShadow swig_types[17]
-#define SWIGTYPE_p_OSRSpatialReferenceShadow swig_types[18]
-#define SWIGTYPE_p_char swig_types[19]
-#define SWIGTYPE_p_double swig_types[20]
-#define SWIGTYPE_p_f_double_p_q_const__char_p_void__int swig_types[21]
-#define SWIGTYPE_p_float swig_types[22]
-#define SWIGTYPE_p_int swig_types[23]
-#define SWIGTYPE_p_p_GIntBig swig_types[24]
-#define SWIGTYPE_p_p_char swig_types[25]
-#define SWIGTYPE_p_p_double swig_types[26]
-#define SWIGTYPE_p_p_int swig_types[27]
-#define SWIGTYPE_p_size_t swig_types[28]
-static swig_type_info *swig_types[30];
-static swig_module_info swig_module = {swig_types, 29, 0, 0, 0, 0};
+#define SWIGTYPE_p_ArrowArray swig_types[0]
+#define SWIGTYPE_p_ArrowArrayStream swig_types[1]
+#define SWIGTYPE_p_ArrowSchema swig_types[2]
+#define SWIGTYPE_p_GDALMajorObjectShadow swig_types[3]
+#define SWIGTYPE_p_GDALProgressFunc swig_types[4]
+#define SWIGTYPE_p_GIntBig swig_types[5]
+#define SWIGTYPE_p_OGRCodedValue swig_types[6]
+#define SWIGTYPE_p_OGRDataSourceShadow swig_types[7]
+#define SWIGTYPE_p_OGRDriverShadow swig_types[8]
+#define SWIGTYPE_p_OGRFeatureDefnShadow swig_types[9]
+#define SWIGTYPE_p_OGRFeatureShadow swig_types[10]
+#define SWIGTYPE_p_OGRFieldDefnShadow swig_types[11]
+#define SWIGTYPE_p_OGRFieldDomainShadow swig_types[12]
+#define SWIGTYPE_p_OGRGeomFieldDefnShadow swig_types[13]
+#define SWIGTYPE_p_OGRGeomTransformerShadow swig_types[14]
+#define SWIGTYPE_p_OGRGeometryShadow swig_types[15]
+#define SWIGTYPE_p_OGRLayerShadow swig_types[16]
+#define SWIGTYPE_p_OGRPreparedGeometryShadow swig_types[17]
+#define SWIGTYPE_p_OGRStyleTableShadow swig_types[18]
+#define SWIGTYPE_p_OSRCoordinateTransformationShadow swig_types[19]
+#define SWIGTYPE_p_OSRSpatialReferenceShadow swig_types[20]
+#define SWIGTYPE_p_char swig_types[21]
+#define SWIGTYPE_p_double swig_types[22]
+#define SWIGTYPE_p_f_double_p_q_const__char_p_void__int swig_types[23]
+#define SWIGTYPE_p_float swig_types[24]
+#define SWIGTYPE_p_int swig_types[25]
+#define SWIGTYPE_p_p_GIntBig swig_types[26]
+#define SWIGTYPE_p_p_char swig_types[27]
+#define SWIGTYPE_p_p_double swig_types[28]
+#define SWIGTYPE_p_p_int swig_types[29]
+#define SWIGTYPE_p_size_t swig_types[30]
+static swig_type_info *swig_types[32];
+static swig_module_info swig_module = {swig_types, 31, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3787,12 +3789,37 @@ SWIGINTERN OGRErr OGRDataSourceShadow_CommitTransaction(OGRDataSourceShadow *sel
 SWIGINTERN OGRErr OGRDataSourceShadow_RollbackTransaction(OGRDataSourceShadow *self){
     return GDALDatasetRollbackTransaction(self);
   }
+SWIGINTERN void delete_ArrowArray(ArrowArray *self){
+    if( self->release )
+      self->release(self);
+    free(self);
+  }
+SWIGINTERN VoidPtrAsLong ArrowArray__getPtr(ArrowArray *self){
+    return self;
+  }
+SWIGINTERN GIntBig ArrowArray_GetChildrenCount(ArrowArray *self){
+    return self->n_children;
+  }
+SWIGINTERN GIntBig ArrowArray_GetLength(ArrowArray *self){
+    return self->length;
+  }
+SWIGINTERN void delete_ArrowSchema(ArrowSchema *self){
+    if( self->release )
+      self->release(self);
+    free(self);
+  }
+SWIGINTERN VoidPtrAsLong ArrowSchema__getPtr(ArrowSchema *self){
+    return self;
+  }
+SWIGINTERN GIntBig ArrowSchema_GetChildrenCount(ArrowSchema *self){
+    return self->n_children;
+  }
 SWIGINTERN void delete_ArrowArrayStream(ArrowArrayStream *self){
     if( self->release )
       self->release(self);
     free(self);
   }
-SWIGINTERN VoidPtrAsLong ArrowArrayStream__GetSchemaPtr(ArrowArrayStream *self){
+SWIGINTERN ArrowSchema *ArrowArrayStream_GetSchema(ArrowArrayStream *self){
       struct ArrowSchema* schema = (struct ArrowSchema* )malloc(sizeof(struct ArrowSchema));
       if( self->get_schema(self, schema) == 0 )
       {
@@ -3801,16 +3828,10 @@ SWIGINTERN VoidPtrAsLong ArrowArrayStream__GetSchemaPtr(ArrowArrayStream *self){
       else
       {
           free(schema);
-          return 0;
+          return NULL;
       }
   }
-SWIGINTERN void ArrowArrayStream__FreeSchemaPtr(VoidPtrAsLong ptr){
-      struct ArrowSchema* schema = (struct ArrowSchema* )ptr;
-      if( schema && schema->release )
-          schema->release(schema);
-      free(schema);
-  }
-SWIGINTERN VoidPtrAsLong ArrowArrayStream__GetNextRecordBatchPtr(ArrowArrayStream *self,char **options=NULL){
+SWIGINTERN ArrowArray *ArrowArrayStream_GetNextRecordBatch(ArrowArrayStream *self,char **options=NULL){
       struct ArrowArray* array = (struct ArrowArray* )malloc(sizeof(struct ArrowArray));
       if( self->get_next(self, array) == 0 && array->release != NULL )
       {
@@ -3819,14 +3840,8 @@ SWIGINTERN VoidPtrAsLong ArrowArrayStream__GetNextRecordBatchPtr(ArrowArrayStrea
       else
       {
           free(array);
-          return 0;
+          return NULL;
       }
-  }
-SWIGINTERN void ArrowArrayStream__FreeRecordBatchPtr(VoidPtrAsLong ptr){
-      struct ArrowArray* array = (struct ArrowArray* )ptr;
-      if( array && array->release )
-          array->release(array);
-      free(array);
   }
 SWIGINTERN OGRErr OGRLayerShadow_Rename(OGRLayerShadow *self,char const *new_name){
     return OGR_L_Rename( self, new_name);
@@ -8836,6 +8851,315 @@ SWIGINTERN PyObject *DataSource_swigregister(PyObject *SWIGUNUSEDPARM(self), PyO
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_delete_ArrowArray(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  ArrowArray *arg1 = (ArrowArray *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowArray, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_ArrowArray" "', argument " "1"" of type '" "ArrowArray *""'"); 
+  }
+  arg1 = reinterpret_cast< ArrowArray * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      delete_ArrowArray(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ArrowArray__getPtr(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  ArrowArray *arg1 = (ArrowArray *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  VoidPtrAsLong result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowArray, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowArray__getPtr" "', argument " "1"" of type '" "ArrowArray *""'"); 
+  }
+  arg1 = reinterpret_cast< ArrowArray * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (VoidPtrAsLong)ArrowArray__getPtr(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    resultobj = PyLong_FromVoidPtr(result);
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ArrowArray_GetChildrenCount(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  ArrowArray *arg1 = (ArrowArray *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  GIntBig result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowArray, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowArray_GetChildrenCount" "', argument " "1"" of type '" "ArrowArray *""'"); 
+  }
+  arg1 = reinterpret_cast< ArrowArray * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = ArrowArray_GetChildrenCount(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    resultobj = PyLong_FromLongLong(result);
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ArrowArray_GetLength(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  ArrowArray *arg1 = (ArrowArray *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  GIntBig result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowArray, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowArray_GetLength" "', argument " "1"" of type '" "ArrowArray *""'"); 
+  }
+  arg1 = reinterpret_cast< ArrowArray * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = ArrowArray_GetLength(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    resultobj = PyLong_FromLongLong(result);
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *ArrowArray_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_ArrowArray, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_delete_ArrowSchema(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  ArrowSchema *arg1 = (ArrowSchema *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowSchema, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_ArrowSchema" "', argument " "1"" of type '" "ArrowSchema *""'"); 
+  }
+  arg1 = reinterpret_cast< ArrowSchema * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      delete_ArrowSchema(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ArrowSchema__getPtr(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  ArrowSchema *arg1 = (ArrowSchema *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  VoidPtrAsLong result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowSchema, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowSchema__getPtr" "', argument " "1"" of type '" "ArrowSchema *""'"); 
+  }
+  arg1 = reinterpret_cast< ArrowSchema * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (VoidPtrAsLong)ArrowSchema__getPtr(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    resultobj = PyLong_FromVoidPtr(result);
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ArrowSchema_GetChildrenCount(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  ArrowSchema *arg1 = (ArrowSchema *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  GIntBig result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowSchema, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowSchema_GetChildrenCount" "', argument " "1"" of type '" "ArrowSchema *""'"); 
+  }
+  arg1 = reinterpret_cast< ArrowSchema * >(argp1);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = ArrowSchema_GetChildrenCount(arg1);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    resultobj = PyLong_FromLongLong(result);
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *ArrowSchema_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_ArrowSchema, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_delete_ArrowArrayStream(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   ArrowArrayStream *arg1 = (ArrowArrayStream *) 0 ;
@@ -8876,19 +9200,19 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_ArrowArrayStream__GetSchemaPtr(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_ArrowArrayStream_GetSchema(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   ArrowArrayStream *arg1 = (ArrowArrayStream *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[1] ;
-  VoidPtrAsLong result;
+  ArrowSchema *result = 0 ;
   
   if (!args) SWIG_fail;
   swig_obj[0] = args;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowArrayStream, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowArrayStream__GetSchemaPtr" "', argument " "1"" of type '" "ArrowArrayStream *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowArrayStream_GetSchema" "', argument " "1"" of type '" "ArrowArrayStream *""'"); 
   }
   arg1 = reinterpret_cast< ArrowArrayStream * >(argp1);
   {
@@ -8897,7 +9221,7 @@ SWIGINTERN PyObject *_wrap_ArrowArrayStream__GetSchemaPtr(PyObject *SWIGUNUSEDPA
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      result = (VoidPtrAsLong)ArrowArrayStream__GetSchemaPtr(arg1);
+      result = (ArrowSchema *)ArrowArrayStream_GetSchema(arg1);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -8909,9 +9233,7 @@ SWIGINTERN PyObject *_wrap_ArrowArrayStream__GetSchemaPtr(PyObject *SWIGUNUSEDPA
     }
 #endif
   }
-  {
-    resultobj = PyLong_FromVoidPtr(result);
-  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_ArrowSchema, SWIG_POINTER_OWN |  0 );
   if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
   return resultobj;
 fail:
@@ -8919,55 +9241,19 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_ArrowArrayStream__FreeSchemaPtr(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
-  VoidPtrAsLong arg1 = (VoidPtrAsLong) 0 ;
-  PyObject *swig_obj[1] ;
-  
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
-  {
-    arg1 = PyLong_AsVoidPtr(swig_obj[0]);
-  }
-  {
-    if ( bUseExceptions ) {
-      ClearErrorState();
-    }
-    {
-      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      ArrowArrayStream__FreeSchemaPtr(arg1);
-      SWIG_PYTHON_THREAD_END_ALLOW;
-    }
-#ifndef SED_HACKS
-    if ( bUseExceptions ) {
-      CPLErr eclass = CPLGetLastErrorType();
-      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
-        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
-      }
-    }
-#endif
-  }
-  resultobj = SWIG_Py_Void();
-  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_ArrowArrayStream__GetNextRecordBatchPtr(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_ArrowArrayStream_GetNextRecordBatch(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   ArrowArrayStream *arg1 = (ArrowArrayStream *) 0 ;
   char **arg2 = (char **) NULL ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject *swig_obj[2] ;
-  VoidPtrAsLong result;
+  ArrowArray *result = 0 ;
   
-  if (!SWIG_Python_UnpackTuple(args, "ArrowArrayStream__GetNextRecordBatchPtr", 1, 2, swig_obj)) SWIG_fail;
+  if (!SWIG_Python_UnpackTuple(args, "ArrowArrayStream_GetNextRecordBatch", 1, 2, swig_obj)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_ArrowArrayStream, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowArrayStream__GetNextRecordBatchPtr" "', argument " "1"" of type '" "ArrowArrayStream *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ArrowArrayStream_GetNextRecordBatch" "', argument " "1"" of type '" "ArrowArrayStream *""'"); 
   }
   arg1 = reinterpret_cast< ArrowArrayStream * >(argp1);
   if (swig_obj[1]) {
@@ -8987,7 +9273,7 @@ SWIGINTERN PyObject *_wrap_ArrowArrayStream__GetNextRecordBatchPtr(PyObject *SWI
     }
     {
       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      result = (VoidPtrAsLong)ArrowArrayStream__GetNextRecordBatchPtr(arg1,arg2);
+      result = (ArrowArray *)ArrowArrayStream_GetNextRecordBatch(arg1,arg2);
       SWIG_PYTHON_THREAD_END_ALLOW;
     }
 #ifndef SED_HACKS
@@ -8999,9 +9285,7 @@ SWIGINTERN PyObject *_wrap_ArrowArrayStream__GetNextRecordBatchPtr(PyObject *SWI
     }
 #endif
   }
-  {
-    resultobj = PyLong_FromVoidPtr(result);
-  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_ArrowArray, SWIG_POINTER_OWN |  0 );
   {
     /* %typemap(freearg) char **options */
     CSLDestroy( arg2 );
@@ -9013,42 +9297,6 @@ fail:
     /* %typemap(freearg) char **options */
     CSLDestroy( arg2 );
   }
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_ArrowArrayStream__FreeRecordBatchPtr(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
-  VoidPtrAsLong arg1 = (VoidPtrAsLong) 0 ;
-  PyObject *swig_obj[1] ;
-  
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
-  {
-    arg1 = PyLong_AsVoidPtr(swig_obj[0]);
-  }
-  {
-    if ( bUseExceptions ) {
-      ClearErrorState();
-    }
-    {
-      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-      ArrowArrayStream__FreeRecordBatchPtr(arg1);
-      SWIG_PYTHON_THREAD_END_ALLOW;
-    }
-#ifndef SED_HACKS
-    if ( bUseExceptions ) {
-      CPLErr eclass = CPLGetLastErrorType();
-      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
-        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
-      }
-    }
-#endif
-  }
-  resultobj = SWIG_Py_Void();
-  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
-  return resultobj;
-fail:
   return NULL;
 }
 
@@ -31149,11 +31397,18 @@ static PyMethodDef SwigMethods[] = {
 	 { "DataSource_CommitTransaction", _wrap_DataSource_CommitTransaction, METH_O, "DataSource_CommitTransaction(DataSource self) -> OGRErr"},
 	 { "DataSource_RollbackTransaction", _wrap_DataSource_RollbackTransaction, METH_O, "DataSource_RollbackTransaction(DataSource self) -> OGRErr"},
 	 { "DataSource_swigregister", DataSource_swigregister, METH_O, NULL},
+	 { "delete_ArrowArray", _wrap_delete_ArrowArray, METH_O, "delete_ArrowArray(ArrowArray self)"},
+	 { "ArrowArray__getPtr", _wrap_ArrowArray__getPtr, METH_O, "ArrowArray__getPtr(ArrowArray self) -> VoidPtrAsLong"},
+	 { "ArrowArray_GetChildrenCount", _wrap_ArrowArray_GetChildrenCount, METH_O, "ArrowArray_GetChildrenCount(ArrowArray self) -> GIntBig"},
+	 { "ArrowArray_GetLength", _wrap_ArrowArray_GetLength, METH_O, "ArrowArray_GetLength(ArrowArray self) -> GIntBig"},
+	 { "ArrowArray_swigregister", ArrowArray_swigregister, METH_O, NULL},
+	 { "delete_ArrowSchema", _wrap_delete_ArrowSchema, METH_O, "delete_ArrowSchema(ArrowSchema self)"},
+	 { "ArrowSchema__getPtr", _wrap_ArrowSchema__getPtr, METH_O, "ArrowSchema__getPtr(ArrowSchema self) -> VoidPtrAsLong"},
+	 { "ArrowSchema_GetChildrenCount", _wrap_ArrowSchema_GetChildrenCount, METH_O, "ArrowSchema_GetChildrenCount(ArrowSchema self) -> GIntBig"},
+	 { "ArrowSchema_swigregister", ArrowSchema_swigregister, METH_O, NULL},
 	 { "delete_ArrowArrayStream", _wrap_delete_ArrowArrayStream, METH_O, "delete_ArrowArrayStream(ArrowArrayStream self)"},
-	 { "ArrowArrayStream__GetSchemaPtr", _wrap_ArrowArrayStream__GetSchemaPtr, METH_O, "ArrowArrayStream__GetSchemaPtr(ArrowArrayStream self) -> VoidPtrAsLong"},
-	 { "ArrowArrayStream__FreeSchemaPtr", _wrap_ArrowArrayStream__FreeSchemaPtr, METH_O, "ArrowArrayStream__FreeSchemaPtr(VoidPtrAsLong ptr)"},
-	 { "ArrowArrayStream__GetNextRecordBatchPtr", _wrap_ArrowArrayStream__GetNextRecordBatchPtr, METH_VARARGS, "ArrowArrayStream__GetNextRecordBatchPtr(ArrowArrayStream self, char ** options=None) -> VoidPtrAsLong"},
-	 { "ArrowArrayStream__FreeRecordBatchPtr", _wrap_ArrowArrayStream__FreeRecordBatchPtr, METH_O, "ArrowArrayStream__FreeRecordBatchPtr(VoidPtrAsLong ptr)"},
+	 { "ArrowArrayStream_GetSchema", _wrap_ArrowArrayStream_GetSchema, METH_O, "ArrowArrayStream_GetSchema(ArrowArrayStream self) -> ArrowSchema"},
+	 { "ArrowArrayStream_GetNextRecordBatch", _wrap_ArrowArrayStream_GetNextRecordBatch, METH_VARARGS, "ArrowArrayStream_GetNextRecordBatch(ArrowArrayStream self, char ** options=None) -> ArrowArray"},
 	 { "ArrowArrayStream_swigregister", ArrowArrayStream_swigregister, METH_O, NULL},
 	 { "Layer_Rename", _wrap_Layer_Rename, METH_VARARGS, "Layer_Rename(Layer self, char const * new_name) -> OGRErr"},
 	 { "Layer_GetRefCount", _wrap_Layer_GetRefCount, METH_O, "\n"
@@ -35503,7 +35758,9 @@ static void *_p_OGRLayerShadowTo_p_GDALMajorObjectShadow(void *x, int *SWIGUNUSE
 static void *_p_OGRDataSourceShadowTo_p_GDALMajorObjectShadow(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((GDALMajorObjectShadow *)  ((OGRDataSourceShadow *) x));
 }
+static swig_type_info _swigt__p_ArrowArray = {"_p_ArrowArray", "ArrowArray *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_ArrowArrayStream = {"_p_ArrowArrayStream", "ArrowArrayStream *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_ArrowSchema = {"_p_ArrowSchema", "ArrowSchema *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GDALMajorObjectShadow = {"_p_GDALMajorObjectShadow", "GDALMajorObjectShadow *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GDALProgressFunc = {"_p_GDALProgressFunc", "GDALProgressFunc *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GIntBig = {"_p_GIntBig", "GIntBig *", 0, 0, (void*)0, 0};
@@ -35534,7 +35791,9 @@ static swig_type_info _swigt__p_p_int = {"_p_p_int", "int **", 0, 0, (void*)0, 0
 static swig_type_info _swigt__p_size_t = {"_p_size_t", "size_t *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
+  &_swigt__p_ArrowArray,
   &_swigt__p_ArrowArrayStream,
+  &_swigt__p_ArrowSchema,
   &_swigt__p_GDALMajorObjectShadow,
   &_swigt__p_GDALProgressFunc,
   &_swigt__p_GIntBig,
@@ -35565,7 +35824,9 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_size_t,
 };
 
+static swig_cast_info _swigc__p_ArrowArray[] = {  {&_swigt__p_ArrowArray, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_ArrowArrayStream[] = {  {&_swigt__p_ArrowArrayStream, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_ArrowSchema[] = {  {&_swigt__p_ArrowSchema, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GDALMajorObjectShadow[] = {  {&_swigt__p_GDALMajorObjectShadow, 0, 0, 0},  {&_swigt__p_OGRDriverShadow, _p_OGRDriverShadowTo_p_GDALMajorObjectShadow, 0, 0},  {&_swigt__p_OGRLayerShadow, _p_OGRLayerShadowTo_p_GDALMajorObjectShadow, 0, 0},  {&_swigt__p_OGRDataSourceShadow, _p_OGRDataSourceShadowTo_p_GDALMajorObjectShadow, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GDALProgressFunc[] = {  {&_swigt__p_GDALProgressFunc, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_GIntBig[] = {  {&_swigt__p_GIntBig, 0, 0, 0},{0, 0, 0, 0}};
@@ -35596,7 +35857,9 @@ static swig_cast_info _swigc__p_p_int[] = {  {&_swigt__p_p_int, 0, 0, 0},{0, 0, 
 static swig_cast_info _swigc__p_size_t[] = {  {&_swigt__p_size_t, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
+  _swigc__p_ArrowArray,
   _swigc__p_ArrowArrayStream,
+  _swigc__p_ArrowSchema,
   _swigc__p_GDALMajorObjectShadow,
   _swigc__p_GDALProgressFunc,
   _swigc__p_GIntBig,

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -1062,6 +1062,52 @@ class DataSource(MajorObject):
 # Register DataSource in _ogr:
 _ogr.DataSource_swigregister(DataSource)
 
+class ArrowArray(object):
+    r"""Proxy of C++ ArrowArray class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined")
+    __repr__ = _swig_repr
+    __swig_destroy__ = _ogr.delete_ArrowArray
+
+    def _getPtr(self, *args) -> "VoidPtrAsLong":
+        r"""_getPtr(ArrowArray self) -> VoidPtrAsLong"""
+        return _ogr.ArrowArray__getPtr(self, *args)
+
+    def GetChildrenCount(self, *args) -> "GIntBig":
+        r"""GetChildrenCount(ArrowArray self) -> GIntBig"""
+        return _ogr.ArrowArray_GetChildrenCount(self, *args)
+
+    def GetLength(self, *args) -> "GIntBig":
+        r"""GetLength(ArrowArray self) -> GIntBig"""
+        return _ogr.ArrowArray_GetLength(self, *args)
+
+# Register ArrowArray in _ogr:
+_ogr.ArrowArray_swigregister(ArrowArray)
+
+class ArrowSchema(object):
+    r"""Proxy of C++ ArrowSchema class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined")
+    __repr__ = _swig_repr
+    __swig_destroy__ = _ogr.delete_ArrowSchema
+
+    def _getPtr(self, *args) -> "VoidPtrAsLong":
+        r"""_getPtr(ArrowSchema self) -> VoidPtrAsLong"""
+        return _ogr.ArrowSchema__getPtr(self, *args)
+
+    def GetChildrenCount(self, *args) -> "GIntBig":
+        r"""GetChildrenCount(ArrowSchema self) -> GIntBig"""
+        return _ogr.ArrowSchema_GetChildrenCount(self, *args)
+
+# Register ArrowSchema in _ogr:
+_ogr.ArrowSchema_swigregister(ArrowSchema)
+
 class ArrowArrayStream(object):
     r"""Proxy of C++ ArrowArrayStream class."""
 
@@ -1072,34 +1118,16 @@ class ArrowArrayStream(object):
     __repr__ = _swig_repr
     __swig_destroy__ = _ogr.delete_ArrowArrayStream
 
-    def _GetSchemaPtr(self, *args) -> "VoidPtrAsLong":
-        r"""_GetSchemaPtr(ArrowArrayStream self) -> VoidPtrAsLong"""
-        return _ogr.ArrowArrayStream__GetSchemaPtr(self, *args)
+    def GetSchema(self, *args) -> "ArrowSchema *":
+        r"""GetSchema(ArrowArrayStream self) -> ArrowSchema"""
+        return _ogr.ArrowArrayStream_GetSchema(self, *args)
 
-    @staticmethod
-    def _FreeSchemaPtr(*args) -> "void":
-        r"""_FreeSchemaPtr(VoidPtrAsLong ptr)"""
-        return _ogr.ArrowArrayStream__FreeSchemaPtr(*args)
-
-    def _GetNextRecordBatchPtr(self, *args) -> "VoidPtrAsLong":
-        r"""_GetNextRecordBatchPtr(ArrowArrayStream self, char ** options=None) -> VoidPtrAsLong"""
-        return _ogr.ArrowArrayStream__GetNextRecordBatchPtr(self, *args)
-
-    @staticmethod
-    def _FreeRecordBatchPtr(*args) -> "void":
-        r"""_FreeRecordBatchPtr(VoidPtrAsLong ptr)"""
-        return _ogr.ArrowArrayStream__FreeRecordBatchPtr(*args)
+    def GetNextRecordBatch(self, *args) -> "ArrowArray *":
+        r"""GetNextRecordBatch(ArrowArrayStream self, char ** options=None) -> ArrowArray"""
+        return _ogr.ArrowArrayStream_GetNextRecordBatch(self, *args)
 
 # Register ArrowArrayStream in _ogr:
 _ogr.ArrowArrayStream_swigregister(ArrowArrayStream)
-
-def ArrowArrayStream__FreeSchemaPtr(*args) -> "void":
-    r"""ArrowArrayStream__FreeSchemaPtr(VoidPtrAsLong ptr)"""
-    return _ogr.ArrowArrayStream__FreeSchemaPtr(*args)
-
-def ArrowArrayStream__FreeRecordBatchPtr(*args) -> "void":
-    r"""ArrowArrayStream__FreeRecordBatchPtr(VoidPtrAsLong ptr)"""
-    return _ogr.ArrowArrayStream__FreeRecordBatchPtr(*args)
 
 class Layer(MajorObject):
     r"""Proxy of C++ OGRLayerShadow class."""
@@ -2168,13 +2196,10 @@ class Layer(MajorObject):
             def schema(self):
                 """ Return the schema as a PyArrow DataType """
 
-                schema_ptr = self.stream._GetSchemaPtr()
-                if schema_ptr == 0:
+                schema = self.stream.GetSchema()
+                if schema is None:
                     raise Exception("cannot get schema")
-                try:
-                    return pa.DataType._import_from_c(schema_ptr)
-                finally:
-                    self.stream._FreeSchemaPtr(schema_ptr)
+                return pa.DataType._import_from_c(schema._getPtr())
 
             schema = property(schema)
 
@@ -2182,14 +2207,10 @@ class Layer(MajorObject):
             def _GetNextRecordBatchAsPyArrow(self, l_schema):
                 """ Return the next RecordBatch as a PyArrow StructArray, or None at end of iteration """
 
-                array_ptr = self.stream._GetNextRecordBatchPtr()
-                if array_ptr == 0:
+                array = self.stream.GetNextRecordBatch()
+                if array is None:
                     return None
-                try:
-                    return pa.Array._import_from_c(array_ptr, l_schema)
-                finally:
-                    self.stream._FreeRecordBatchPtr(array_ptr)
-
+                return pa.Array._import_from_c(array._getPtr(), l_schema)
 
             def __iter__(self):
                 """ Return an iterator over record batches as a PyArrow StructArray """
@@ -2224,23 +2245,16 @@ class Layer(MajorObject):
                 self.end_of_stream = False
                 self.use_masked_arrays = use_masked_arrays
 
-            def _GetNextRecordBatchAsNumpy(self, schema_ptr):
+            def _GetNextRecordBatchAsNumpy(self, schema):
                 """ Return the next RecordBatch as a dictionary of Numpy arrays, or None at end of iteration """
 
-                array_ptr = self.stream._GetNextRecordBatchPtr()
-                if array_ptr == 0:
+                array = self.stream.GetNextRecordBatch()
+                if array is None:
                     return None
 
-                class ArrayPointerKeeper:
-                    def __init__(self, array_ptr):
-                        self.array_ptr = array_ptr
-
-                    def __del__(self):
-                        ArrowArrayStream._FreeRecordBatchPtr(self.array_ptr)
-
-                ret = gdal_array._RecordBatchAsNumpy(array_ptr,
-                                                     schema_ptr,
-                                                     ArrayPointerKeeper(array_ptr))
+                ret = gdal_array._RecordBatchAsNumpy(array._getPtr(),
+                                                     schema._getPtr(),
+                                                     array)
                 if ret is None:
                     gdal_array._RaiseException()
                     return ret
@@ -2259,15 +2273,14 @@ class Layer(MajorObject):
                 if self.end_of_stream:
                     raise Exception("Stream has already been iterated over")
 
-                schema_ptr = self.stream._GetSchemaPtr()
+                schema = self.stream.GetSchema()
                 try:
                     while True:
-                        batch = self._GetNextRecordBatchAsNumpy(schema_ptr)
+                        batch = self._GetNextRecordBatchAsNumpy(schema)
                         if not batch:
                             break
                         yield batch
                 finally:
-                    self.stream._FreeSchemaPtr(schema_ptr)
                     self.end_of_stream = True
                     self.stream = None
 


### PR DESCRIPTION
If GetLayerDefn() wasn't called directly or indirectly, only the FID and
geometry columns were fetched. This was the reason for the odd results
in the RFC 86 benchmarks.