### PR TITLE
GPKG: perf improvement: do not request ignored fields

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -438,6 +438,7 @@ class OGRGeoPackageLayer CPL_NON_FINAL: public OGRLayer, public IOGRSQLiteGetSpa
     void                ResetReading() override;
     int                 TestCapability( const char * ) override;
     OGRFeatureDefn*     GetLayerDefn() override { return m_poFeatureDefn; }
+    OGRErr              SetIgnoredFields( const char **papszFields ) override;
 
     virtual bool         HasFastSpatialFilter(int /*iGeomCol*/) override { return false; }
     virtual CPLString    GetSpatialWhere(int /*iGeomCol*/,

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -1072,3 +1072,18 @@ void OGRGeoPackageLayer::BuildFeatureDefn( const char *pszLayerName,
         panFieldOrdinals[m_poFeatureDefn->GetFieldCount() - 1] = iCol;
     }
 }
+
+/************************************************************************/
+/*                          SetIgnoredFields()                          */
+/************************************************************************/
+
+OGRErr OGRGeoPackageLayer::SetIgnoredFields( const char **papszFields )
+{
+    OGRErr eErr = OGRLayer::SetIgnoredFields(papszFields);
+    if( eErr == OGRERR_NONE )
+    {
+        // So that OGRGeoPackageTableLayer::BuildColumns() is called
+        ResetReading();
+    }
+    return eErr;
+}

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -149,25 +149,41 @@ OGRErr OGRGeoPackageTableLayer::BuildColumns()
     /* Add a geometry column if there is one (just one) */
     if ( m_poFeatureDefn->GetGeomFieldCount() )
     {
-        if( !soColumns.empty() )
-            soColumns += ", ";
-        soColumns += "m.\"";
-        soColumns += SQLEscapeName(m_poFeatureDefn->GetGeomFieldDefn(0)->GetNameRef());
-        soColumns += "\"";
-        iGeomCol = iCurCol;
-        iCurCol ++;
+        const auto poFieldDefn = m_poFeatureDefn->GetGeomFieldDefn(0);
+        if( poFieldDefn->IsIgnored() )
+        {
+            iGeomCol = -1;
+        }
+        else
+        {
+            if( !soColumns.empty() )
+                soColumns += ", ";
+            soColumns += "m.\"";
+            soColumns += SQLEscapeName(poFieldDefn->GetNameRef());
+            soColumns += "\"";
+            iGeomCol = iCurCol;
+            iCurCol ++;
+        }
     }
 
     /* Add all the attribute columns */
     for( int i = 0; i < m_poFeatureDefn->GetFieldCount(); i++ )
     {
-        if( !soColumns.empty() )
-            soColumns += ", ";
-        soColumns += "m.\"";
-        soColumns += SQLEscapeName(m_poFeatureDefn->GetFieldDefn(i)->GetNameRef());
-        soColumns += "\"";
-        panFieldOrdinals[i] = iCurCol;
-        iCurCol ++;
+        const auto poFieldDefn = m_poFeatureDefn->GetFieldDefn(i);
+        if( poFieldDefn->IsIgnored() )
+        {
+            panFieldOrdinals[i] = -1;
+        }
+        else
+        {
+            if( !soColumns.empty() )
+                soColumns += ", ";
+            soColumns += "m.\"";
+            soColumns += SQLEscapeName(poFieldDefn->GetNameRef());
+            soColumns += "\"";
+            panFieldOrdinals[i] = iCurCol;
+            iCurCol ++;
+        }
     }
 
     m_soColumns = soColumns;


### PR DESCRIPTION
Ignored fields were ignored in GetNextFeature(), but they were still requested to SQLite, which is not efficient at all.
