### PR TITLE
GPKG: speed-up: implement background RTree creation in bulk insertion in a new table

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -54,6 +54,7 @@
 #include "cpl_quad_tree.h"
 #include "cpl_worker_thread_pool.h"
 #include "cpl_vsi_virtual.h"
+#include "cpl_threadsafe_queue.hpp"
 
 #include <atomic>
 #include <fstream>
@@ -4162,8 +4163,26 @@ namespace tut
         VSIFree(m2);
     }
 
-    // WARNING: keep that line at bottom and read carefully:
-    // If the number of tests reaches 100, increase the MAX_NUMBER_OF_TESTS
-    // define at top of this file (and update this comment!)
+    // Test cpl::ThreadSafeQueue
+    template<>
+    template<>
+    void object::test<66>()
+    {
+        cpl::ThreadSafeQueue<int> queue;
+        ensure(queue.empty());
+        ensure_equals(queue.size(), 0U);
+        queue.push(1);
+        ensure(!queue.empty());
+        ensure_equals(queue.size(), 1U);
+        queue.clear();
+        ensure(queue.empty());
+        ensure_equals(queue.size(), 0U);
+        int val = 10;
+        queue.push(std::move(val));
+        ensure(!queue.empty());
+        ensure_equals(queue.size(), 1U);
+        ensure_equals(queue.get_and_pop_front(), 10);
+        ensure(queue.empty());
+    }
 
 } // namespace tut

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitebase.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitebase.h
@@ -164,6 +164,7 @@ class OGRSQLiteBaseDataSource CPL_NON_FINAL: public GDALPamDataset
                         virtual ~OGRSQLiteBaseDataSource();
 
     sqlite3            *GetDB() { return hDB; }
+    sqlite3_vfs        *GetVFS() { return pMyVFS; }
     inline bool         GetUpdate() const { return eAccess == GA_Update; }
     VSILFILE*           GetVSILFILE() const { return fpMainFile; }
 

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitevfs.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitevfs.cpp
@@ -254,7 +254,13 @@ static int OGRSQLiteVFSOpen(sqlite3_vfs* pVFS,
     if ( flags & SQLITE_OPEN_READONLY )
         pMyFile->fp = VSIFOpenL(zName, "rb");
     else if ( flags & SQLITE_OPEN_CREATE )
-        pMyFile->fp = VSIFOpenL(zName, "wb+");
+    {
+        VSIStatBufL sStatBufL;
+        if( VSIStatExL(zName, &sStatBufL, VSI_STAT_EXISTS_FLAG) == 0 )
+            pMyFile->fp = VSIFOpenL(zName, "rb+");
+        else
+            pMyFile->fp = VSIFOpenL(zName, "wb+");
+    }
     else if ( flags & SQLITE_OPEN_READWRITE )
         pMyFile->fp = VSIFOpenL(zName, "rb+");
     else

--- a/port/cpl_threadsafe_queue.hpp
+++ b/port/cpl_threadsafe_queue.hpp
@@ -1,0 +1,96 @@
+/******************************************************************************
+ *
+ * Project:  CPL
+ * Purpose:  Implementation of a thread-safe queue
+ * Author:   Even Rouault <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef CPL_THREADSAFE_QUEUE_INCLUDED
+#define CPL_THREADSAFE_QUEUE_INCLUDED
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+
+namespace cpl
+{
+template <class T> class ThreadSafeQueue
+{
+private:
+    mutable std::mutex      m_mutex{};
+    std::condition_variable m_cv{};
+    std::queue<T>           m_queue{};
+
+public:
+    ThreadSafeQueue() = default;
+
+    void clear()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        while( !m_queue.empty() )
+            m_queue.pop();
+    }
+
+    bool empty() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_queue.empty();
+    }
+
+    size_t size() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_queue.size();
+    }
+
+    void push(const T& value)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.push(value);
+        m_cv.notify_one();
+    }
+
+    void push(T&& value)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.push(std::move(value));
+        m_cv.notify_one();
+    }
+
+    T get_and_pop_front()
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        while( m_queue.empty() )
+        {
+            m_cv.wait(lock);
+        }
+        T val = m_queue.front();
+        m_queue.pop();
+        return val;
+    }
+};
+
+} // namespace cpl
+
+#endif // CPL_THREADSAFE_QUEUE_INCLUDED


### PR DESCRIPTION
We create a temporary database with only the RTree, and we insert records into it in a dedicated thread, in parallel of the main thread that inserts rows in the user table. When the layer is finalized, we just use bulk copy statements of the form
INSERT INTO rtree_xxxx_rowid/node/parent SELECT * FROM temp_rtree.my_rtree_rowid/node/parent
to copy the RTree auxiliary tables into the main database, which is a very fast operation.

With that, "ogr2ogr out.gpkg nz-building-outlines.parquet" goes from 62 seconds down to 40 seconds (35% faster)
with the dataset at https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.parquet