### PR TITLE
NITF: avoid excessive memory allocation on broken files

### DIFF
--- a/frmts/nitf/nitfimage.c
+++ b/frmts/nitf/nitfimage.c
@@ -625,6 +625,22 @@ NITFImage *NITFImageAccess( NITFFile *psFile, int iSegment )
         return NULL;
     }
 
+    if( psImage->nBlocksPerRow * psImage->nBlocksPerColumn * psImage->nBands > 1000 * 1000 )
+    {
+        // Sanity check to avoid allocating too much memory
+        VSIFSeekL( psFile->fp, 0, SEEK_END );
+        // This is really a very safe bound. A smarter check would taken
+        // into account the block size as well and/or the size of an entry
+        // in the offset table.
+        if( VSIFTellL(psFile->fp) < (unsigned)(psImage->nBlocksPerRow) * psImage->nBlocksPerColumn )
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "File is too small compared to the number of blocks");
+            NITFImageDeaccess(psImage);
+            return NULL;
+        }
+    }
+
 /* -------------------------------------------------------------------- */
 /*      Override nCols and nRows for NITF 1.1 (not sure why!)           */
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52642