### PR TITLE
FlatGeoBuf and GPKG: improve DateTime parsing perf + GPKG improve GetNextArrowArray() perf

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -148,6 +148,7 @@ if (BUILD_APPS)
   add_executable(multireadtest EXCLUDE_FROM_ALL multireadtest.cpp)
   add_executable(test_ogrsf test_ogrsf.cpp)
   add_executable(testreprojmulti EXCLUDE_FROM_ALL testreprojmulti.cpp)
+  add_executable(bench_ogr_batch EXCLUDE_FROM_ALL bench_ogr_batch.cpp)
 
   foreach (
     UTILCMD IN
@@ -159,7 +160,8 @@ if (BUILD_APPS)
           gdalwarpsimple
           multireadtest
           test_ogrsf
-          testreprojmulti)
+          testreprojmulti
+          bench_ogr_batch)
     if (WIN32)
         target_sources(${UTILCMD} PRIVATE longpathaware.manifest)
     endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -149,6 +149,7 @@ if (BUILD_APPS)
   add_executable(test_ogrsf test_ogrsf.cpp)
   add_executable(testreprojmulti EXCLUDE_FROM_ALL testreprojmulti.cpp)
   add_executable(bench_ogr_batch EXCLUDE_FROM_ALL bench_ogr_batch.cpp)
+  add_executable(bench_ogr_c_api EXCLUDE_FROM_ALL bench_ogr_c_api.cpp)
 
   foreach (
     UTILCMD IN
@@ -161,7 +162,8 @@ if (BUILD_APPS)
           multireadtest
           test_ogrsf
           testreprojmulti
-          bench_ogr_batch)
+          bench_ogr_batch
+          bench_ogr_c_api)
     if (WIN32)
         target_sources(${UTILCMD} PRIVATE longpathaware.manifest)
     endif()

--- a/apps/bench_ogr_batch.cpp
+++ b/apps/bench_ogr_batch.cpp
@@ -1,0 +1,113 @@
+/******************************************************************************
+ *
+ * Project:  GDAL Utilities
+ * Purpose:  bench_ogr_bach
+ * Author:   Even Rouault, <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_priv.h"
+#include "ogr_api.h"
+#include "ogrsf_frmts.h"
+#include "ogr_recordbatch.h"
+
+/************************************************************************/
+/*                               Usage()                                */
+/************************************************************************/
+
+static void Usage()
+{
+    printf("Usage: bench_ogr_bach filename\n");
+    exit(1);
+}
+
+/************************************************************************/
+/*                               main()                                 */
+/************************************************************************/
+
+int main(int argc, char* argv[])
+{
+/* -------------------------------------------------------------------- */
+/*      Process arguments.                                              */
+/* -------------------------------------------------------------------- */
+    argc = GDALGeneralCmdLineProcessor(argc, &argv, 0);
+    if( argc < 1 )
+        exit(-argc);
+
+    if( argc != 2 )
+        Usage();
+
+    GDALAllRegister();
+
+    auto poDS = std::unique_ptr<GDALDataset>(GDALDataset::Open(argv[1]));
+    if( poDS == nullptr)
+    {
+        fprintf(stderr, "Cannot open %s\n", argv[1]);
+        CSLDestroy(argv);
+        exit(1);
+    }
+
+    OGRLayer* poLayer = poDS->GetLayer(0);
+    if( poLayer == nullptr )
+    {
+        fprintf(stderr, "Cannot find layer\n");
+        CSLDestroy(argv);
+        exit(1);
+    }
+
+    OGRLayerH hLayer = OGRLayer::ToHandle(poLayer);
+    struct ArrowArrayStream stream;
+    if( !OGR_L_GetArrowStream(hLayer, &stream, nullptr))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "OGR_L_GetArrowStream() failed\n");
+        CSLDestroy(argv);
+        exit(1);
+    }
+#if 0
+    struct ArrowSchema schema;
+    if( stream.get_schema(&stream, &schema) == 0 )
+    {
+        // Do something useful
+        schema.release(&schema);
+    }
+#endif
+    while( true )
+    {
+        struct ArrowArray array;
+        if( stream.get_next(&stream, &array) != 0 ||
+            array.release == nullptr )
+        {
+            break;
+        }
+        array.release(&array);
+    }
+    stream.release(&stream);
+
+    poDS.reset();
+
+    CSLDestroy(argv);
+
+    GDALDestroyDriverManager();
+
+    return 0;
+}

--- a/apps/bench_ogr_c_api.cpp
+++ b/apps/bench_ogr_c_api.cpp
@@ -1,0 +1,122 @@
+/******************************************************************************
+ *
+ * Project:  GDAL Utilities
+ * Purpose:  bench_ogr_c_api
+ * Author:   Even Rouault, <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2022, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_priv.h"
+#include "ogr_api.h"
+#include "ogrsf_frmts.h"
+
+/************************************************************************/
+/*                               Usage()                                */
+/************************************************************************/
+
+static void Usage()
+{
+    printf("Usage: bench_ogr_c_api filename\n");
+    exit(1);
+}
+
+/************************************************************************/
+/*                               main()                                 */
+/************************************************************************/
+
+int main(int argc, char* argv[])
+{
+/* -------------------------------------------------------------------- */
+/*      Process arguments.                                              */
+/* -------------------------------------------------------------------- */
+    argc = GDALGeneralCmdLineProcessor(argc, &argv, 0);
+    if( argc < 1 )
+        exit(-argc);
+
+    if( argc != 2 )
+        Usage();
+
+    GDALAllRegister();
+
+    auto poDS = std::unique_ptr<GDALDataset>(GDALDataset::Open(argv[1]));
+    if( poDS == nullptr)
+    {
+        fprintf(stderr, "Cannot open %s\n", argv[1]);
+        CSLDestroy(argv);
+        exit(1);
+    }
+
+    OGRLayer* poLayer = poDS->GetLayer(0);
+    if( poLayer == nullptr )
+    {
+        fprintf(stderr, "Cannot find layer\n");
+        CSLDestroy(argv);
+        exit(1);
+    }
+
+    OGRLayerH hLayer = OGRLayer::ToHandle(poLayer);
+    OGRFeatureDefnH hFDefn = OGR_L_GetLayerDefn(hLayer);
+    int nFields = OGR_FD_GetFieldCount(hFDefn);
+    std::vector<OGRFieldType> aeTypes;
+    for( int i = 0; i < nFields; i++ )
+        aeTypes.push_back(OGR_Fld_GetType(OGR_FD_GetFieldDefn(hFDefn, i)));
+    int nYear, nMonth, nDay, nHour, nMin, nSecond, nTZ;
+    while( true )
+    {
+        OGRFeatureH hFeat = OGR_L_GetNextFeature(hLayer);
+        if( hFeat == nullptr )
+            break;
+        OGR_F_GetFID(hFeat);
+        for( int i = 0; i < nFields; i++ )
+        {
+            if( aeTypes[i] == OFTInteger )
+                OGR_F_GetFieldAsInteger(hFeat, i);
+            else if( aeTypes[i] == OFTInteger64 )
+                OGR_F_GetFieldAsInteger64(hFeat, i);
+            else if( aeTypes[i] == OFTReal )
+                OGR_F_GetFieldAsDouble(hFeat, i);
+            else if( aeTypes[i] == OFTString )
+                OGR_F_GetFieldAsString(hFeat, i);
+            else if( aeTypes[i] == OFTDate ||
+                     aeTypes[i] == OFTDateTime )
+                OGR_F_GetFieldAsDateTime(hFeat, i, &nYear, &nMonth, &nDay, &nHour, &nMin, &nSecond, &nTZ);
+        }
+        OGRGeometryH hGeom = OGR_F_GetGeometryRef(hFeat);
+        if( hGeom )
+        {
+            int size = OGR_G_WkbSize(hGeom);
+            GByte* pabyWKB = static_cast<GByte*>(malloc(size));
+            OGR_G_ExportToIsoWkb( hGeom, wkbNDR, pabyWKB);
+            CPLFree(pabyWKB);
+        }
+        OGR_F_Destroy(hFeat);
+    }
+
+    poDS.reset();
+
+    CSLDestroy(argv);
+
+    GDALDestroyDriverManager();
+
+    return 0;
+}

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -6802,6 +6802,22 @@ def test_ogr_gpkg_arrow_stream_numpy():
     assert batch["int16"][0] == 123
     assert len(batch["fid"]) == 1
 
+    with lyr.GetArrowStreamAsNumPy(options=["MAX_FEATURES_IN_BATCH=1"]) as stream:
+        batches = [batch for batch in stream]
+        assert len(batches) == 3
+        assert len(batches[0]["fid"]) == 1
+        assert batches[0]["fid"][0] == 1
+        assert len(batches[1]["fid"]) == 1
+        assert batches[1]["fid"][0] == 2
+        assert len(batches[2]["fid"]) == 1
+        assert batches[2]["fid"][0] == 3
+
+    for i in range(2):
+        with lyr.GetArrowStreamAsNumPy(options=["MAX_FEATURES_IN_BATCH=1"]) as stream:
+            batch = stream.GetNextRecordBatch()
+            assert len(batch["fid"]) == 1, i
+            assert batch["fid"][0] == 1, i
+
     # Test attribute filter
     lyr.SetAttributeFilter("int16 = 123")
     stream = lyr.GetArrowStreamAsNumPy()

--- a/ogr/ogr_p.h
+++ b/ogr/ogr_p.h
@@ -115,6 +115,8 @@ char CPL_DLL * OGRGetRFC822DateTime(const OGRField* psField);
 char CPL_DLL * OGRGetXMLDateTime(const OGRField* psField);
 char CPL_DLL * OGRGetXMLDateTime(const OGRField* psField, bool bAlwaysMillisecond);
 char CPL_DLL * OGRGetXML_UTF8_EscapedString(const char* pszString);
+bool CPL_DLL OGRParseDateTimeYYYYMMDDTHHMMSSZ( const char *pszInput, size_t nLen, OGRField *psField );
+bool CPL_DLL OGRParseDateTimeYYYYMMDDTHHMMSSsssZ( const char *pszInput, size_t nLen, OGRField *psField );
 
 int OGRCompareDate(const OGRField *psFirstTuple,
                    const OGRField *psSecondTuple ); /* used by ogr_gensql.cpp and ogrfeaturequery.cpp */

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
@@ -31,6 +31,22 @@
 //! @cond Doxygen_Suppress
 
 /************************************************************************/
+/*                       GetMaxFeaturesInBatch()                          */
+/************************************************************************/
+
+int OGRArrowArrayHelper::GetMaxFeaturesInBatch(const CPLStringList& aosArrowArrayStreamOptions)
+{
+    int l_nMaxBatchSize = atoi(aosArrowArrayStreamOptions.FetchNameValueDef(
+                                        "MAX_FEATURES_IN_BATCH", "65536"));
+    if( l_nMaxBatchSize <= 0 )
+        l_nMaxBatchSize = 1;
+    if( l_nMaxBatchSize > INT_MAX - 1 )
+        l_nMaxBatchSize = INT_MAX - 1;
+
+    return l_nMaxBatchSize;
+}
+
+/************************************************************************/
 /*                       OGRArrowArrayHelper()                          */
 /************************************************************************/
 
@@ -40,16 +56,10 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(GDALDataset* poDS,
                     struct ArrowArray* out_array):
     bIncludeFID(CPLTestBool(
         aosArrowArrayStreamOptions.FetchNameValueDef("INCLUDE_FID", "YES"))),
-    nMaxBatchSize(atoi(
-        aosArrowArrayStreamOptions.FetchNameValueDef("MAX_FEATURES_IN_BATCH", "65536"))),
+    nMaxBatchSize(GetMaxFeaturesInBatch(aosArrowArrayStreamOptions)),
     m_out_array(out_array)
 {
     memset(out_array, 0, sizeof(*out_array));
-
-    if( nMaxBatchSize <= 0 )
-        nMaxBatchSize = 1;
-    if( nMaxBatchSize > INT_MAX - 1 )
-        nMaxBatchSize = INT_MAX - 1;
 
     nFieldCount = poFeatureDefn->GetFieldCount();
     nGeomFieldCount = poFeatureDefn->GetGeomFieldCount();

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
@@ -55,6 +55,8 @@ public:
     int64_t* panFIDValues = nullptr;
     struct ArrowArray* m_out_array = nullptr;
 
+    static int GetMaxFeaturesInBatch(const CPLStringList& aosArrowArrayStreamOptions);
+
     OGRArrowArrayHelper(GDALDataset* poDS,
                         OGRFeatureDefn* poFeatureDefn,
                         const CPLStringList& aosArrowArrayStreamOptions,

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -404,7 +404,7 @@ class OGRGeoPackageLayer CPL_NON_FINAL: public OGRLayer, public IOGRSQLiteGetSpa
     GDALGeoPackageDataset *m_poDS;
 
     OGRFeatureDefn*      m_poFeatureDefn;
-    int                  iNextShapeId;
+    GIntBig              iNextShapeId;
 
     sqlite3_stmt        *m_poQueryStatement;
     bool                 bDoStep;

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -37,6 +37,7 @@
 
 #include <vector>
 #include <set>
+#include <thread>
 
 #define UNKNOWN_SRID   -2
 #define DEFAULT_SRID    0
@@ -573,8 +574,12 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
 
     CPL_DISALLOW_COPY_ASSIGN(OGRGeoPackageTableLayer)
 
+    std::thread         m_oThreadNextArrowArray{};
+    std::unique_ptr<GDALGeoPackageDataset> m_poOtherDS{};
+    struct ArrowArray*  m_psNextArrayArray = nullptr;
     virtual int GetNextArrowArray(struct ArrowArrayStream*,
                                    struct ArrowArray* out_array) override;
+    int                 GetNextArrowArrayInternal(struct ArrowArray* out_array);
 
     public:
                         OGRGeoPackageTableLayer( GDALGeoPackageDataset *poDS,

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -421,12 +421,20 @@ class OGRGeoPackageLayer CPL_NON_FINAL: public OGRLayer, public IOGRSQLiteGetSpa
                                            sqlite3_stmt *hStmt );
 
     OGRFeature*         TranslateFeature(sqlite3_stmt* hStmt);
+    bool                ParseDateField(const char* pszTxt,
+                                       OGRField* psField,
+                                       const OGRFieldDefn* poFieldDefn,
+                                       GIntBig nFID);
     bool                ParseDateField(sqlite3_stmt* hStmt,
                                         int iRawField,
                                         int nSqlite3ColType,
                                         OGRField* psField,
                                         const OGRFieldDefn* poFieldDefn,
                                         GIntBig nFID);
+    bool                ParseDateTimeField(const char* pszTxt,
+                                       OGRField* psField,
+                                       const OGRFieldDefn* poFieldDefn,
+                                       GIntBig nFID);
     bool                ParseDateTimeField(sqlite3_stmt* hStmt,
                                         int iRawField,
                                         int nSqlite3ColType,

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -399,6 +399,8 @@ class GDALGeoPackageRasterBand final: public GDALGPKGMBTilesLikeRasterBand
 class OGRGeoPackageLayer CPL_NON_FINAL: public OGRLayer, public IOGRSQLiteGetSpatialWhere
 {
   protected:
+    friend void OGR_GPKG_FillArrowArray_Step(sqlite3_context* pContext, int /*argc*/, sqlite3_value** argv);
+
     GDALGeoPackageDataset *m_poDS;
 
     OGRFeatureDefn*      m_poFeatureDefn;
@@ -518,6 +520,8 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     GPKGASpatialVariant         m_eASpatialVariant = GPKG_ATTRIBUTES;
     std::set<OGRwkbGeometryType> m_eSetBadGeomTypeWarned{};
 
+    int                         m_nIsCompatOfOptimizedGetNextArrowArray = -1;
+
     int                         m_nCountInsertInTransactionThreshold = -1;
     GIntBig                     m_nCountInsertInTransaction = 0;
     std::vector<CPLString >     m_aoRTreeTriggersSQL{};
@@ -565,7 +569,12 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
 
     OGRErr              CreateOrUpsertFeature( OGRFeature *poFeature, bool bUpsert );
 
+    GIntBig             GetTotalFeatureCount();
+
     CPL_DISALLOW_COPY_ASSIGN(OGRGeoPackageTableLayer)
+
+    virtual int GetNextArrowArray(struct ArrowArrayStream*,
+                                   struct ArrowArray* out_array) override;
 
     public:
                         OGRGeoPackageTableLayer( GDALGeoPackageDataset *poDS,

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -168,49 +168,7 @@ bool OGRGeoPackageLayer::ParseDateField(sqlite3_stmt* hStmt,
     if( nSqlite3ColType == SQLITE_TEXT )
     {
         const char* pszTxt = reinterpret_cast<const char*>(sqlite3_column_text( hStmt, iRawField ));
-        if( pszTxt == nullptr )
-        {
-            CPLError(CE_Failure, CPLE_AppDefined, "%s",
-                     sqlite3_errmsg(m_poDS->GetDB()));
-            return false;
-        }
-        const size_t nLen = strlen(pszTxt);
-        // nominal format: "YYYY-MM-DD" (10 characters)
-        const bool bNominalFormat = (
-            nLen == 10 && pszTxt[4] == '-' && pszTxt[7] == '-');
-        if ( OGRParseDate(pszTxt, psField, 0) )
-        {
-            if( !bNominalFormat || psField->Date.Hour != 0 ||
-                psField->Date.Minute != 0 || psField->Date.Second != 0 )
-            {
-                constexpr int line = __LINE__;
-                if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
-                {
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "Non-conformant content for record "
-                             CPL_FRMT_GIB " in column %s, %s, "
-                             "successfully parsed",
-                             nFID,
-                             poFieldDefn->GetNameRef(), pszTxt);
-                    m_poDS->m_oSetGPKGLayerWarnings[line] = true;
-                }
-            }
-        }
-        else
-        {
-            OGR_RawField_SetUnset(psField);
-            constexpr int line = __LINE__;
-            if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
-            {
-                CPLError(CE_Warning, CPLE_AppDefined,
-                         "Invalid content for record "
-                         CPL_FRMT_GIB " in column %s: %s",
-                         nFID,
-                         poFieldDefn->GetNameRef(), pszTxt);
-                m_poDS->m_oSetGPKGLayerWarnings[line] = true;
-            }
-            return false;
-        }
+        return ParseDateField(pszTxt, psField, poFieldDefn, nFID);
     }
     else
     {
@@ -222,6 +180,86 @@ bool OGRGeoPackageLayer::ParseDateField(sqlite3_stmt* hStmt,
                      CPL_FRMT_GIB " in column %s",
                      nFID,
                      poFieldDefn->GetNameRef());
+            m_poDS->m_oSetGPKGLayerWarnings[line] = true;
+        }
+        return false;
+    }
+}
+
+bool OGRGeoPackageLayer::ParseDateField(const char* pszTxt,
+                                        OGRField* psField,
+                                        const OGRFieldDefn* poFieldDefn,
+                                        GIntBig nFID)
+{
+    if( pszTxt == nullptr )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                 sqlite3_errmsg(m_poDS->GetDB()));
+        return false;
+    }
+    const size_t nLen = strlen(pszTxt);
+    // nominal format: "YYYY-MM-DD" (10 characters)
+    const bool bNominalFormat = (
+        nLen == 10 && pszTxt[4] == '-' && pszTxt[7] == '-' &&
+        static_cast<unsigned>(pszTxt[0] - '0') <= 9 &&
+        static_cast<unsigned>(pszTxt[1] - '0') <= 9 &&
+        static_cast<unsigned>(pszTxt[2] - '0') <= 9 &&
+        static_cast<unsigned>(pszTxt[3] - '0') <= 9 &&
+        static_cast<unsigned>(pszTxt[5] - '0') <= 9 &&
+        static_cast<unsigned>(pszTxt[6] - '0') <= 9 &&
+        static_cast<unsigned>(pszTxt[8] - '0') <= 9 &&
+        static_cast<unsigned>(pszTxt[9] - '0') <= 9 );
+
+    bool bError = false;
+    if( bNominalFormat )
+    {
+        psField->Date.Year = static_cast<GUInt16>(
+            ((((pszTxt[0] - '0') * 10 + (pszTxt[1] - '0')) * 10) +
+            (pszTxt[2] - '0')) * 10 + (pszTxt[3] - '0'));
+        psField->Date.Month = static_cast<GByte>(
+            (pszTxt[5] - '0') * 10 + (pszTxt[6] - '0'));
+        psField->Date.Day = static_cast<GByte>(
+            (pszTxt[8] - '0') * 10 + (pszTxt[9] - '0'));
+        psField->Date.Hour = 0;
+        psField->Date.Minute = 0;
+        psField->Date.Second = 0.0f;
+        psField->Date.TZFlag = 0;
+        if( psField->Date.Month == 0 || psField->Date.Month > 12 ||
+            psField->Date.Day == 0 ||   psField->Date.Day > 31 )
+        {
+            bError = true;
+        }
+    }
+    else if ( OGRParseDate(pszTxt, psField, 0) )
+    {
+        constexpr int line = __LINE__;
+        if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Non-conformant content for record "
+                     CPL_FRMT_GIB " in column %s, %s, "
+                     "successfully parsed",
+                     nFID,
+                     poFieldDefn->GetNameRef(), pszTxt);
+            m_poDS->m_oSetGPKGLayerWarnings[line] = true;
+        }
+    }
+    else
+    {
+        bError = true;
+    }
+
+    if( bError )
+    {
+        OGR_RawField_SetUnset(psField);
+        constexpr int line = __LINE__;
+        if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Invalid content for record "
+                     CPL_FRMT_GIB " in column %s: %s",
+                     nFID,
+                     poFieldDefn->GetNameRef(), pszTxt);
             m_poDS->m_oSetGPKGLayerWarnings[line] = true;
         }
         return false;
@@ -244,53 +282,7 @@ bool OGRGeoPackageLayer::ParseDateTimeField(sqlite3_stmt* hStmt,
     if( nSqlite3ColType == SQLITE_TEXT )
     {
         const char* pszTxt = reinterpret_cast<const char*>(sqlite3_column_text( hStmt, iRawField ));
-        if( pszTxt == nullptr )
-        {
-            CPLError(CE_Failure, CPLE_AppDefined, "%s",
-                     sqlite3_errmsg(m_poDS->GetDB()));
-            return false;
-        }
-        const size_t nLen = strlen(pszTxt);
-        // nominal format: "YYYY-MM-DDTHH:MM:SS.SSSZ" (24 characters)
-        // but we also silently accept without timezone as OGR can
-        // write this
-        const bool bNominalFormat = (
-            nLen >= 23 &&
-            pszTxt[4] == '-' && pszTxt[7] == '-' &&
-            pszTxt[10] == 'T' && pszTxt[13] == ':' && pszTxt[16] == ':' &&
-            pszTxt[19] == '.');
-        if ( OGRParseDate(pszTxt, psField, 0) )
-        {
-            if( !bNominalFormat )
-            {
-                constexpr int line = __LINE__;
-                if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
-                {
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "Non-conformant content for record "
-                             CPL_FRMT_GIB " in column %s, %s, "
-                             "successfully parsed",
-                             nFID,
-                             poFieldDefn->GetNameRef(), pszTxt);
-                    m_poDS->m_oSetGPKGLayerWarnings[line] = true;
-                }
-            }
-        }
-        else
-        {
-            OGR_RawField_SetUnset(psField);
-            constexpr int line = __LINE__;
-            if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
-            {
-                CPLError(CE_Warning, CPLE_AppDefined,
-                         "Invalid content for record "
-                         CPL_FRMT_GIB " in column %s: %s",
-                         nFID,
-                         poFieldDefn->GetNameRef(), pszTxt);
-               m_poDS->m_oSetGPKGLayerWarnings[line] = true;
-            }
-            return false;
-        }
+        return ParseDateTimeField(pszTxt, psField, poFieldDefn, nFID);
     }
     else
     {
@@ -306,6 +298,56 @@ bool OGRGeoPackageLayer::ParseDateTimeField(sqlite3_stmt* hStmt,
         }
         return false;
     }
+}
+
+bool OGRGeoPackageLayer::ParseDateTimeField(const char* pszTxt,
+                                            OGRField* psField,
+                                            const OGRFieldDefn* poFieldDefn,
+                                            GIntBig nFID)
+{
+    if( pszTxt == nullptr )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                 sqlite3_errmsg(m_poDS->GetDB()));
+        return false;
+    }
+
+    const size_t nLen = strlen(pszTxt);
+
+    if( OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(pszTxt, nLen, psField) )
+    {
+        // nominal format
+    }
+    else if ( OGRParseDate(pszTxt, psField, 0) )
+    {
+        constexpr int line = __LINE__;
+        if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Non-conformant content for record "
+                     CPL_FRMT_GIB " in column %s, %s, "
+                     "successfully parsed",
+                     nFID,
+                     poFieldDefn->GetNameRef(), pszTxt);
+            m_poDS->m_oSetGPKGLayerWarnings[line] = true;
+        }
+    }
+    else
+    {
+        OGR_RawField_SetUnset(psField);
+        constexpr int line = __LINE__;
+        if( !m_poDS->m_oSetGPKGLayerWarnings[line] )
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Invalid content for record "
+                     CPL_FRMT_GIB " in column %s: %s",
+                     nFID,
+                     poFieldDefn->GetNameRef(), pszTxt);
+           m_poDS->m_oSetGPKGLayerWarnings[line] = true;
+        }
+        return false;
+    }
+
     return true;
 }
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -32,6 +32,7 @@
 #include "ogrsqliteutility.h"
 #include "cpl_time.h"
 #include "ogr_p.h"
+#include "ograrrowarrayhelper.h"
 
 #include <algorithm>
 #include <cmath>
@@ -2720,6 +2721,36 @@ OGRErr OGRGeoPackageTableLayer::RollbackTransaction()
 }
 
 /************************************************************************/
+/*                      GetTotalFeatureCount()                          */
+/************************************************************************/
+
+GIntBig OGRGeoPackageTableLayer::GetTotalFeatureCount()
+{
+#ifdef ENABLE_GPKG_OGR_CONTENTS
+    if( m_nTotalFeatureCount < 0 && m_poDS->m_bHasGPKGOGRContents )
+    {
+        char* pszSQL = sqlite3_mprintf(
+            "SELECT feature_count FROM gpkg_ogr_contents WHERE "
+            "lower(table_name) = lower('%q') LIMIT 2",
+            m_pszTableName);
+        auto oResult = SQLQuery( m_poDS->GetDB(), pszSQL);
+        sqlite3_free(pszSQL);
+        if( oResult && oResult->RowCount() == 1 )
+        {
+            const char* pszFeatureCount = oResult->GetValue(0, 0);
+            if( pszFeatureCount )
+            {
+                m_nTotalFeatureCount = CPLAtoGIntBig(pszFeatureCount);
+            }
+        }
+    }
+    return m_nTotalFeatureCount;
+#else
+    return 0;
+#endif
+}
+
+/************************************************************************/
 /*                        GetFeatureCount()                             */
 /************************************************************************/
 
@@ -2730,32 +2761,9 @@ GIntBig OGRGeoPackageTableLayer::GetFeatureCount( int /*bForce*/ )
 #ifdef ENABLE_GPKG_OGR_CONTENTS
     if( m_poFilterGeom == nullptr && m_pszAttrQueryString == nullptr )
     {
-        if( m_nTotalFeatureCount >= 0 )
-        {
-            return m_nTotalFeatureCount;
-        }
-
-        if( m_poDS->m_bHasGPKGOGRContents )
-        {
-            char* pszSQL = sqlite3_mprintf(
-                "SELECT feature_count FROM gpkg_ogr_contents WHERE "
-                "lower(table_name) = lower('%q') LIMIT 2",
-                m_pszTableName);
-            auto oResult = SQLQuery( m_poDS->GetDB(), pszSQL);
-            sqlite3_free(pszSQL);
-            if( oResult && oResult->RowCount() == 1 )
-            {
-                const char* pszFeatureCount = oResult->GetValue(0, 0);
-                if( pszFeatureCount )
-                {
-                    m_nTotalFeatureCount = CPLAtoGIntBig(pszFeatureCount);
-                }
-            }
-            if( m_nTotalFeatureCount >= 0 )
-            {
-                return m_nTotalFeatureCount;
-            }
-        }
+        const auto nCount = GetTotalFeatureCount();
+        if( nCount >= 0 )
+            return nCount;
     }
 #endif
 
@@ -5984,4 +5992,407 @@ OGRGeometryTypeCounter* OGRGeoPackageTableLayer::GetGeometryTypes(
         }
     }
     return pasRet;
+}
+
+/************************************************************************/
+/*                    OGR_GPKG_FillArrowArray_Step()                    */
+/************************************************************************/
+
+namespace {
+struct GPKGTableLayerFillArrowArray
+{
+    OGRArrowArrayHelper *psHelper = nullptr;
+    int                  nCountRows = 0;
+    bool                 bErrorOccured = false;
+    OGRFeatureDefn      *poFeatureDefn = nullptr;
+    OGRGeoPackageLayer  *poLayer = nullptr;
+    struct tm            brokenDown{};
+    sqlite3*             hDB = nullptr;
+};
+} // namespace
+
+void
+OGR_GPKG_FillArrowArray_Step(sqlite3_context* pContext, int /*argc*/, sqlite3_value** argv);
+
+void
+OGR_GPKG_FillArrowArray_Step(sqlite3_context* pContext, int /*argc*/, sqlite3_value** argv)
+{
+    auto psFillArrowArray = static_cast<GPKGTableLayerFillArrowArray*>(sqlite3_user_data(pContext));
+    if( psFillArrowArray == nullptr )
+        return;
+    auto psHelper = psFillArrowArray->psHelper;
+
+    const int iFeat = psFillArrowArray->nCountRows;
+    if( iFeat >= psHelper->nMaxBatchSize )
+    {
+        // should not happen !
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "OGR_GPKG_FillArrowArray_Step() got more rows than expected!");
+        sqlite3_interrupt(psFillArrowArray->hDB);
+        psFillArrowArray->bErrorOccured = true;
+        return;
+    }
+
+    int iCol = 0;
+
+    GIntBig nFID = sqlite3_value_int64(argv[iCol]);
+    if( psHelper->panFIDValues )
+    {
+        psHelper->panFIDValues[iFeat] = nFID;
+    }
+    iCol ++;
+
+    if( !psHelper->mapOGRGeomFieldToArrowField.empty() &&
+        psHelper->mapOGRGeomFieldToArrowField[0] > 0 )
+    {
+        const int iArrowField = psHelper->mapOGRGeomFieldToArrowField[0];
+        auto psArray = psHelper->m_out_array->children[iArrowField];
+        size_t nWKBSize = 0;
+        const int nSqlite3ColType = sqlite3_value_type(argv[iCol]);
+        if( nSqlite3ColType == SQLITE_BLOB )
+        {
+            const GByte *pabyWkb = nullptr;
+            const int iGpkgSize = sqlite3_value_bytes(argv[iCol]);
+            // coverity[tainted_data_return]
+            const GByte *pabyGpkg = static_cast<const GByte *>(sqlite3_value_blob(argv[iCol]));
+            if( iGpkgSize >= 8 && pabyGpkg && pabyGpkg[0] == 'G' && pabyGpkg[1] == 'P' )
+            {
+                GPkgHeader oHeader;
+
+                /* Read header */
+                OGRErr err = GPkgHeaderFromWKB(pabyGpkg, iGpkgSize, &oHeader);
+                if ( err == OGRERR_NONE )
+                {
+                    /* WKB pointer */
+                    pabyWkb = pabyGpkg + oHeader.nHeaderLen;
+                    nWKBSize = iGpkgSize - oHeader.nHeaderLen;
+                }
+            }
+
+            if( nWKBSize != 0 )
+            {
+                GByte* outPtr = psHelper->GetPtrForStringOrBinary(iArrowField, iFeat, nWKBSize);
+                if( outPtr == nullptr )
+                {
+                     goto error;
+                }
+                memcpy(outPtr, pabyWkb, nWKBSize);
+            }
+            else
+            {
+                psHelper->SetEmptyStringOrBinary(psArray, iFeat);
+            }
+        }
+
+        if( nWKBSize == 0 )
+        {
+            if( !psHelper->SetNull(iArrowField, iFeat) )
+            {
+                goto error;
+            }
+        }
+        iCol ++;
+    }
+
+    for( int iField = 0; iField < psHelper->nFieldCount; iField++ )
+    {
+        const int iArrowField = psHelper->mapOGRFieldToArrowField[iField];
+        if( iArrowField < 0 )
+            continue;
+
+        const OGRFieldDefn *poFieldDefn = psFillArrowArray->poFeatureDefn->GetFieldDefnUnsafe( iField );
+
+        auto psArray = psHelper->m_out_array->children[iArrowField];
+
+        const int nSqlite3ColType = sqlite3_value_type(argv[iCol]);
+        if( nSqlite3ColType == SQLITE_NULL )
+        {
+            if( !psHelper->SetNull(iArrowField, iFeat) )
+            {
+                goto error;
+            }
+            iCol ++;
+            continue;
+        }
+
+        switch( poFieldDefn->GetType() )
+        {
+            case OFTInteger:
+            {
+                const int nVal = sqlite3_value_int(argv[iCol]);
+                if( poFieldDefn->GetSubType() == OFSTBoolean )
+                {
+                    if( nVal != 0 )
+                    {
+                        psHelper->SetBoolOn(psArray, iFeat);
+                    }
+                }
+                else if( poFieldDefn->GetSubType() == OFSTInt16 )
+                {
+                    psHelper->SetInt16(psArray, iFeat,
+                                     static_cast<int16_t>(nVal));
+                }
+                else
+                {
+                    psHelper->SetInt32(psArray, iFeat, nVal);
+                }
+                break;
+            }
+
+            case OFTInteger64:
+            {
+                psHelper->SetInt64(psArray, iFeat,
+                                 sqlite3_value_int64(argv[iCol]));
+                break;
+            }
+
+            case OFTReal:
+            {
+                const double dfVal = sqlite3_value_double(argv[iCol]);
+                if( poFieldDefn->GetSubType() == OFSTFloat32 )
+                {
+                    psHelper->SetFloat(psArray, iFeat, static_cast<float>(dfVal));
+                }
+                else
+                {
+                    psHelper->SetDouble(psArray, iFeat, dfVal);
+                }
+                break;
+            }
+
+            case OFTBinary:
+            {
+                const uint32_t nBytes = static_cast<uint32_t>(sqlite3_value_bytes(argv[iCol]));
+                // coverity[tainted_data_return]
+                const void* pabyData = sqlite3_value_blob(argv[iCol]);
+                if( pabyData != nullptr || nBytes == 0 )
+                {
+                    GByte* outPtr = psHelper->GetPtrForStringOrBinary(iArrowField, iFeat, nBytes);
+                    if( outPtr == nullptr )
+                    {
+                        goto error;
+                    }
+                    if( nBytes )
+                        memcpy(outPtr, pabyData, nBytes);
+                }
+                else
+                {
+                    psHelper->SetEmptyStringOrBinary(psArray, iFeat);
+                }
+                break;
+            }
+
+            case OFTDate:
+            {
+                OGRField ogrField;
+                const auto pszTxt = reinterpret_cast<const char*>(sqlite3_value_text(argv[iCol]));
+                if( pszTxt != nullptr &&
+                    psFillArrowArray->poLayer->ParseDateField(pszTxt, &ogrField,
+                                                              poFieldDefn, nFID) )
+                {
+                    psHelper->SetDate(psArray, iFeat, psFillArrowArray->brokenDown, ogrField);
+                }
+                break;
+            }
+
+            case OFTDateTime:
+            {
+                OGRField ogrField;
+                const auto pszTxt = reinterpret_cast<const char*>(sqlite3_value_text(argv[iCol]));
+                if( pszTxt != nullptr &&
+                    psFillArrowArray->poLayer->ParseDateTimeField(pszTxt, &ogrField,
+                                                                  poFieldDefn, nFID) )
+                {
+                    psHelper->SetDateTime(psArray, iFeat, psFillArrowArray->brokenDown, ogrField);
+                }
+                break;
+            }
+
+            case OFTString:
+            {
+                const auto pszTxt = reinterpret_cast<const char*>(sqlite3_value_text(argv[iCol]));
+                if( pszTxt != nullptr )
+                {
+                    const size_t nBytes = strlen(pszTxt);
+                    GByte* outPtr = psHelper->GetPtrForStringOrBinary(iArrowField, iFeat, nBytes);
+                    if( outPtr == nullptr )
+                    {
+                        goto error;
+                    }
+                    if( nBytes )
+                        memcpy(outPtr, pszTxt, nBytes);
+                }
+                else
+                {
+                    psHelper->SetEmptyStringOrBinary(psArray, iFeat);
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+
+        iCol ++;
+    }
+
+    psFillArrowArray->nCountRows ++;
+    return;
+
+error:
+    sqlite3_interrupt(psFillArrowArray->hDB);
+    psFillArrowArray->bErrorOccured = true;
+}
+
+/************************************************************************/
+/*                   OGR_GPKG_FillArrowArray_Finalize()                 */
+/************************************************************************/
+
+static
+void
+OGR_GPKG_FillArrowArray_Finalize(sqlite3_context* /*pContext*/)
+{
+
+}
+
+/************************************************************************/
+/*                      GetNextArrowArray()                             */
+/************************************************************************/
+
+int OGRGeoPackageTableLayer::GetNextArrowArray(struct ArrowArrayStream* stream,
+                                               struct ArrowArray* out_array)
+{
+    GetLayerDefn();
+
+    if( m_nIsCompatOfOptimizedGetNextArrowArray == FALSE ||
+        m_pszFidColumn == nullptr ||
+        m_poFilterGeom != nullptr ||
+        m_pszAttrQueryString != nullptr ||
+        CPLTestBool(CPLGetConfigOption("OGR_GPKG_STREAM_BASE_IMPL", "NO")) )
+    {
+        return OGRGeoPackageLayer::GetNextArrowArray(stream, out_array);
+    }
+
+    // We can use this optimized version only if there is no hole in FID
+    // numbering. That is min(fid) == 1 and max(fid) == m_nTotalFeatureCount
+    if( m_nIsCompatOfOptimizedGetNextArrowArray < 0 )
+    {
+        m_nIsCompatOfOptimizedGetNextArrowArray = FALSE;
+        const auto nTotalFeatureCount = GetTotalFeatureCount();
+        if( nTotalFeatureCount < 0 )
+            return OGRGeoPackageLayer::GetNextArrowArray(stream, out_array);
+        {
+            char* pszSQL = sqlite3_mprintf("SELECT MAX(\"%w\") FROM \"%w\"",
+                                           m_pszFidColumn, m_pszTableName);
+            OGRErr err;
+            const auto nMaxFID = SQLGetInteger64(m_poDS->GetDB(), pszSQL, &err);
+            sqlite3_free(pszSQL);
+            if( nMaxFID != nTotalFeatureCount )
+                return OGRGeoPackageLayer::GetNextArrowArray(stream, out_array);
+        }
+        {
+            char* pszSQL = sqlite3_mprintf("SELECT MIN(\"%w\") FROM \"%w\"",
+                                           m_pszFidColumn, m_pszTableName);
+            OGRErr err;
+            const auto nMinFID = SQLGetInteger64(m_poDS->GetDB(), pszSQL, &err);
+            sqlite3_free(pszSQL);
+            if( nMinFID != 1 )
+                return OGRGeoPackageLayer::GetNextArrowArray(stream, out_array);
+        }
+        m_nIsCompatOfOptimizedGetNextArrowArray = TRUE;
+    }
+
+    memset(out_array, 0, sizeof(*out_array));
+
+    if( m_bEOF )
+        return 0;
+
+    OGRArrowArrayHelper sHelper(m_poDS, m_poFeatureDefn,
+                                m_aosArrowArrayStreamOptions,
+                                out_array);
+    if( out_array->release == nullptr )
+    {
+        return ENOMEM;
+    }
+
+    GPKGTableLayerFillArrowArray sFillArrowArray;
+    sFillArrowArray.psHelper = &sHelper;
+    sFillArrowArray.nCountRows = 0;
+    sFillArrowArray.bErrorOccured = false;
+    sFillArrowArray.poFeatureDefn = m_poFeatureDefn;
+    sFillArrowArray.poLayer = this;
+    sFillArrowArray.hDB = m_poDS->GetDB();
+    memset(&sFillArrowArray.brokenDown, 0, sizeof(sFillArrowArray.brokenDown));
+
+    sqlite3_create_function(m_poDS->GetDB(), "OGR_GPKG_FillArrowArray_INTERNAL", -1,
+                            SQLITE_UTF8 | SQLITE_DETERMINISTIC, &sFillArrowArray,
+                            nullptr, OGR_GPKG_FillArrowArray_Step,
+                            OGR_GPKG_FillArrowArray_Finalize);
+
+    std::string osSQL;
+    osSQL = "SELECT OGR_GPKG_FillArrowArray_INTERNAL(";
+
+    osSQL += '"';
+    osSQL += SQLEscapeName(m_pszFidColumn);
+    osSQL += '"';
+
+    if( !sHelper.mapOGRGeomFieldToArrowField.empty() &&
+        sHelper.mapOGRGeomFieldToArrowField[0] > 0 )
+    {
+        osSQL += ',';
+        osSQL += '"';
+        osSQL += SQLEscapeName(GetGeometryColumn());
+        osSQL += '"';
+    }
+    for( int iField = 0; iField < sHelper.nFieldCount; iField++ )
+    {
+        const int iArrowField = sHelper.mapOGRFieldToArrowField[iField];
+        if( iArrowField >= 0 )
+        {
+            const OGRFieldDefn *poFieldDefn = m_poFeatureDefn->GetFieldDefnUnsafe( iField );
+            osSQL += ',';
+            osSQL += '"';
+            osSQL += SQLEscapeName(poFieldDefn->GetNameRef());
+            osSQL += '"';
+        }
+    }
+    osSQL += ") FROM \"";
+    osSQL += SQLEscapeName(m_pszTableName);
+    osSQL += "\" WHERE \"";
+    osSQL += SQLEscapeName(m_pszFidColumn);
+    osSQL += "\" BETWEEN ";
+    osSQL += std::to_string(iNextShapeId+1);
+    osSQL += " AND ";
+    osSQL += std::to_string(iNextShapeId+sHelper.nMaxBatchSize);
+
+    char* pszErrMsg = nullptr;
+    if( sqlite3_exec(m_poDS->GetDB(), osSQL.c_str(), nullptr, nullptr, &pszErrMsg) != SQLITE_OK )
+    {
+        if( !sFillArrowArray.bErrorOccured )
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "%s", pszErrMsg ? pszErrMsg : "unknown error");
+        }
+    }
+    sqlite3_free(pszErrMsg);
+
+    // "Unregister" function by setting its user data pointer to nullptr
+    sqlite3_create_function(m_poDS->GetDB(), "OGR_GPKG_FillArrowArray_INTERNAL", -1,
+                            SQLITE_UTF8 | SQLITE_DETERMINISTIC, nullptr,
+                            nullptr, OGR_GPKG_FillArrowArray_Step,
+                            OGR_GPKG_FillArrowArray_Finalize);
+
+    if( sFillArrowArray.bErrorOccured )
+    {
+        sHelper.ClearArray();
+        return ENOMEM;
+    }
+
+    sHelper.Shrink(sFillArrowArray.nCountRows);
+
+    iNextShapeId += sFillArrowArray.nCountRows;
+    if( iNextShapeId >= m_nTotalFeatureCount )
+        m_bEOF = true;
+
+    return 0;
 }

--- a/ogr/ogrutils.cpp
+++ b/ogr/ogrutils.cpp
@@ -1144,6 +1144,119 @@ int OGRParseDate( const char *pszInput,
 }
 
 /************************************************************************/
+/*               OGRParseDateTimeYYYYMMDDTHHMMSSZ()                     */
+/************************************************************************/
+
+bool OGRParseDateTimeYYYYMMDDTHHMMSSZ( const char *pszInput, size_t nLen, OGRField *psField )
+{
+    // Detect "YYYY-MM-DDTHH:MM:SS[Z]" (19 or 20 characters)
+    if( (nLen == 19 || (nLen == 20 && pszInput[19] == 'Z')) &&
+        pszInput[4] == '-' && pszInput[7] == '-' &&
+        pszInput[10] == 'T' && pszInput[13] == ':' && pszInput[16] == ':' &&
+        static_cast<unsigned>(pszInput[0] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[1] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[2] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[3] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[5] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[6] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[8] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[9] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[11] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[12] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[14] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[15] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[17] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[18] - '0') <= 9 )
+    {
+        psField->Date.Year = static_cast<GInt16>(
+            ((((pszInput[0] - '0') * 10 + (pszInput[1] - '0')) * 10) +
+                             (pszInput[2] - '0')) * 10 + (pszInput[3] - '0'));
+        psField->Date.Month = static_cast<GByte>(
+            (pszInput[5] - '0') * 10 + (pszInput[6] - '0'));
+        psField->Date.Day = static_cast<GByte>(
+            (pszInput[8] - '0') * 10 + (pszInput[9] - '0'));
+        psField->Date.Hour = static_cast<GByte>(
+            (pszInput[11] - '0') * 10 + (pszInput[12] - '0'));
+        psField->Date.Minute = static_cast<GByte>(
+            (pszInput[14] - '0') * 10 + (pszInput[15] - '0'));
+        psField->Date.Second = static_cast<float>(
+            ((pszInput[17] - '0') * 10 + (pszInput[18] - '0')));
+        psField->Date.TZFlag = nLen == 19 ? 0 : 100;
+        psField->Date.Reserved = 0;
+        if( psField->Date.Month == 0 || psField->Date.Month > 12 ||
+            psField->Date.Day == 0 ||   psField->Date.Day > 31 ||
+            psField->Date.Hour > 23 ||
+            psField->Date.Minute > 59 ||
+            psField->Date.Second >= 61.0f )
+        {
+            return false;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+/************************************************************************/
+/*              OGRParseDateTimeYYYYMMDDTHHMMSSsssZ()                   */
+/************************************************************************/
+
+bool OGRParseDateTimeYYYYMMDDTHHMMSSsssZ( const char *pszInput, size_t nLen, OGRField *psField )
+{
+    // Detect "YYYY-MM-DDTHH:MM:SS.SSS[Z]" (23 or 24 characters)
+    if( (nLen == 23 || (nLen == 24 && pszInput[23] == 'Z')) &&
+        pszInput[4] == '-' && pszInput[7] == '-' &&
+        pszInput[10] == 'T' && pszInput[13] == ':' && pszInput[16] == ':' &&
+        pszInput[19] == '.' &&
+        static_cast<unsigned>(pszInput[0] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[1] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[2] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[3] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[5] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[6] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[8] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[9] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[11] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[12] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[14] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[15] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[17] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[18] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[20] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[21] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[22] - '0') <= 9 )
+    {
+        psField->Date.Year = static_cast<GInt16>(
+            ((((pszInput[0] - '0') * 10 + (pszInput[1] - '0')) * 10) +
+                             (pszInput[2] - '0')) * 10 + (pszInput[3] - '0'));
+        psField->Date.Month = static_cast<GByte>(
+            (pszInput[5] - '0') * 10 + (pszInput[6] - '0'));
+        psField->Date.Day = static_cast<GByte>(
+            (pszInput[8] - '0') * 10 + (pszInput[9] - '0'));
+        psField->Date.Hour = static_cast<GByte>(
+            (pszInput[11] - '0') * 10 + (pszInput[12] - '0'));
+        psField->Date.Minute = static_cast<GByte>(
+            (pszInput[14] - '0') * 10 + (pszInput[15] - '0'));
+        psField->Date.Second = static_cast<float>(
+            ((pszInput[17] - '0') * 10 + (pszInput[18] - '0')) +
+            ((pszInput[20] - '0') * 100 + (pszInput[21] - '0') * 10 + (pszInput[22] - '0')) / 1000.0);
+        psField->Date.TZFlag = nLen == 23 ? 0 : 100;
+        psField->Date.Reserved = 0;
+        if( psField->Date.Month == 0 || psField->Date.Month > 12 ||
+            psField->Date.Day == 0 ||   psField->Date.Day > 31 ||
+            psField->Date.Hour > 23 ||
+            psField->Date.Minute > 59 ||
+            psField->Date.Second >= 61.0f )
+        {
+            return false;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+/************************************************************************/
 /*                           OGRParseXMLDateTime()                      */
 /************************************************************************/
 

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -235,23 +235,28 @@
 
             schema = property(schema)
 
+            def __enter__(self):
+                return self
 
-            def _GetNextRecordBatchAsPyArrow(self, l_schema):
+            def __exit__(self, type, value, tb):
+                self.end_of_stream = True
+                self.stream = None
+
+            def GetNextRecordBatch(self):
                 """ Return the next RecordBatch as a PyArrow StructArray, or None at end of iteration """
 
                 array = self.stream.GetNextRecordBatch()
                 if array is None:
                     return None
-                return pa.Array._import_from_c(array._getPtr(), l_schema)
+                return pa.Array._import_from_c(array._getPtr(), self.schema)
 
             def __iter__(self):
                 """ Return an iterator over record batches as a PyArrow StructArray """
                 if self.end_of_stream:
                     raise Exception("Stream has already been iterated over")
 
-                l_schema = self.schema
                 while True:
-                    batch = self._GetNextRecordBatchAsPyArrow(l_schema)
+                    batch = self.GetNextRecordBatch()
                     if not batch:
                         break
                     yield batch
@@ -274,10 +279,19 @@
         class Stream:
             def __init__(self, stream, use_masked_arrays):
                 self.stream = stream
+                self.schema = stream.GetSchema()
                 self.end_of_stream = False
                 self.use_masked_arrays = use_masked_arrays
 
-            def _GetNextRecordBatchAsNumpy(self, schema):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, type, value, tb):
+                self.end_of_stream = True
+                self.schema = None
+                self.stream = None
+
+            def GetNextRecordBatch(self):
                 """ Return the next RecordBatch as a dictionary of Numpy arrays, or None at end of iteration """
 
                 array = self.stream.GetNextRecordBatch()
@@ -285,7 +299,7 @@
                     return None
 
                 ret = gdal_array._RecordBatchAsNumpy(array._getPtr(),
-                                                     schema._getPtr(),
+                                                     self.schema._getPtr(),
                                                      array)
                 if ret is None:
                     gdal_array._RaiseException()
@@ -305,10 +319,9 @@
                 if self.end_of_stream:
                     raise Exception("Stream has already been iterated over")
 
-                schema = self.stream.GetSchema()
                 try:
                     while True:
-                        batch = self._GetNextRecordBatchAsNumpy(schema)
+                        batch = self.GetNextRecordBatch()
                         if not batch:
                             break
                         yield batch

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -2240,23 +2240,28 @@ class Layer(MajorObject):
 
             schema = property(schema)
 
+            def __enter__(self):
+                return self
 
-            def _GetNextRecordBatchAsPyArrow(self, l_schema):
+            def __exit__(self, type, value, tb):
+                self.end_of_stream = True
+                self.stream = None
+
+            def GetNextRecordBatch(self):
                 """ Return the next RecordBatch as a PyArrow StructArray, or None at end of iteration """
 
                 array = self.stream.GetNextRecordBatch()
                 if array is None:
                     return None
-                return pa.Array._import_from_c(array._getPtr(), l_schema)
+                return pa.Array._import_from_c(array._getPtr(), self.schema)
 
             def __iter__(self):
                 """ Return an iterator over record batches as a PyArrow StructArray """
                 if self.end_of_stream:
                     raise Exception("Stream has already been iterated over")
 
-                l_schema = self.schema
                 while True:
-                    batch = self._GetNextRecordBatchAsPyArrow(l_schema)
+                    batch = self.GetNextRecordBatch()
                     if not batch:
                         break
                     yield batch
@@ -2279,10 +2284,19 @@ class Layer(MajorObject):
         class Stream:
             def __init__(self, stream, use_masked_arrays):
                 self.stream = stream
+                self.schema = stream.GetSchema()
                 self.end_of_stream = False
                 self.use_masked_arrays = use_masked_arrays
 
-            def _GetNextRecordBatchAsNumpy(self, schema):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, type, value, tb):
+                self.end_of_stream = True
+                self.schema = None
+                self.stream = None
+
+            def GetNextRecordBatch(self):
                 """ Return the next RecordBatch as a dictionary of Numpy arrays, or None at end of iteration """
 
                 array = self.stream.GetNextRecordBatch()
@@ -2290,7 +2304,7 @@ class Layer(MajorObject):
                     return None
 
                 ret = gdal_array._RecordBatchAsNumpy(array._getPtr(),
-                                                     schema._getPtr(),
+                                                     self.schema._getPtr(),
                                                      array)
                 if ret is None:
                     gdal_array._RaiseException()
@@ -2310,10 +2324,9 @@ class Layer(MajorObject):
                 if self.end_of_stream:
                     raise Exception("Stream has already been iterated over")
 
-                schema = self.stream.GetSchema()
                 try:
                     while True:
-                        batch = self._GetNextRecordBatchAsNumpy(schema)
+                        batch = self.GetNextRecordBatch()
                         if not batch:
                             break
                         yield batch


### PR DESCRIPTION
With those improvements, the timing of [bench_ogr_batch](https://github.com/OSGeo/gdal/blob/3f5cd1cc33685a627ee786bccaa0bf312d394ad9/apps/bench_ogr_batch.cpp), which uses ArrowArray batch reading, on GPKG and FlatGeoBuf files converted from https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.parquet goes from:

- FlatGeoBuf: 4.5 s -> 3.2 s
- GPKG: 4.5 s -> 2.2 s (single-threaded) -> 1.5 s (main thread + worker thread)

compared to 1.4 s on the GeoParquet file (whose reading uses threading)