### PR TITLE
Overview building: fix MODE resampling on large datasets (fixes #6587)

### DIFF
--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -1062,7 +1062,8 @@ GTIFFBuildOverviewsEx( const char * pszFilename,
           EQUAL(pszResampling, "CUBIC") ||
           EQUAL(pszResampling, "CUBICSPLINE") ||
           EQUAL(pszResampling, "LANCZOS") ||
-          EQUAL(pszResampling, "BILINEAR")) )
+          EQUAL(pszResampling, "BILINEAR") ||
+          EQUAL(pszResampling, "MODE")) )
     {
         // In the case of pixel interleaved compressed overviews, we want to
         // generate the overviews for all the bands block by block, and not

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -4240,7 +4240,8 @@ GDALRegenerateOverviewsEx( GDALRasterBandH hSrcBand,
          EQUAL(pszResampling, "CUBIC") ||
          EQUAL(pszResampling, "CUBICSPLINE") ||
          EQUAL(pszResampling, "LANCZOS") ||
-         EQUAL(pszResampling, "BILINEAR")) && nOverviewCount > 1
+         EQUAL(pszResampling, "BILINEAR") ||
+         EQUAL(pszResampling, "MODE")) && nOverviewCount > 1
          && bCanUseCascaded )
         return GDALRegenerateCascadingOverviews( poSrcBand,
                                                  nOverviewCount, papoOvrBands,
@@ -4866,7 +4867,8 @@ GDALRegenerateOverviewsMultiBand( int nBands, GDALRasterBand* const* papoSrcBand
         !EQUAL(pszResampling, "CUBIC") &&
         !EQUAL(pszResampling, "CUBICSPLINE") &&
         !EQUAL(pszResampling, "LANCZOS") &&
-        !EQUAL(pszResampling, "BILINEAR") )
+        !EQUAL(pszResampling, "BILINEAR") &&
+        !EQUAL(pszResampling, "MODE") )
     {
         CPLError(
             CE_Failure, CPLE_NotSupported,


### PR DESCRIPTION
A workaround for affected versions is to set the GDAL_OVR_CHUNK_MAX_SIZE configuration option to a large int32 value, like 2100000000.
