### PR TITLE
HANA: fix invalid use of find_first_of() (CID 1500389) (master only)

### DIFF
--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -178,7 +178,7 @@ CPLString BuildConnectionString(char** openOptions)
             return;
 
         CPLString value(paramValue);
-        if (value.find_first_of(specialChars))
+        if (value.find_first_of(specialChars) != std::string::npos)
         {
             value.replaceAll("}", "}}");
             params.push_back( CPLString(paramName) + "={" + value + "}" );


### PR DESCRIPTION
find_first_of() returns a position or std::string::npos, not a bool.

CC @mrylov 