### PR TITLE
[Backport release/3.6] GRIB2: fix crash and invalid metadata when processing index .idx file with sub-messages (fixes #6613)

### DIFF
--- a/autotest/gdrivers/data/grib/subgrids.grib2.idx
+++ b/autotest/gdrivers/data/grib/subgrids.grib2.idx
@@ -1,0 +1,2 @@
+1.1:0:d=2020092600:UGRD:planetary boundary layer:anl:
+1.2:0:d=2020092600:VGRD:planetary boundary layer:anl:

--- a/frmts/grib/gribdataset.cpp
+++ b/frmts/grib/gribdataset.cpp
@@ -79,6 +79,8 @@ static CPLMutex *hGRIBMutex = nullptr;
 
 static CPLString ConvertUnitInText( bool bMetricUnits, const char *pszTxt )
 {
+    if( pszTxt == nullptr )
+        return CPLString();
     if( !bMetricUnits )
         return pszTxt;
 
@@ -1193,6 +1195,11 @@ class InventoryWrapperSidecar : public gdal::grib::InventoryWrapper
                 inv_[i].subgNum =
                     static_cast<unsigned short>(strtol(aosNum[1], &endptr, 10));
                 if (*endptr != 0) goto err_sidecar;
+                if( inv_[i].subgNum <= 0 )
+                    goto err_sidecar;
+                // .idx file use a 1-based indexing, whereas DEGRIB uses a
+                // 0-based one
+                -- inv_[i].subgNum;
             }
 
             inv_[i].start = strtoll(aosTokens[1], &endptr, 10);


### PR DESCRIPTION
Backport #6614
 **Authored by:** @rouault