### PR TITLE
[Backport release/3.6] CMake: fix Win32 csharp build (#6620)

### DIFF
--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -39,7 +39,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 elseif ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "x64")
   set(CSHARP_RID "win-x64")
 elseif ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win32")
-  set(CSHARP_RID "win-32")
+  set(CSHARP_RID "win-x86")
 endif ()
 
 # needed because of differences in the packages


### PR DESCRIPTION
Backport #6621
 **Authored by:** @szekerest