### PR TITLE
swig/python_exceptions.i: Add Context Manager for handling Python exception state

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -752,6 +752,7 @@ def test_gdal_DataTypeUnion():
 
     assert gdal.DataTypeUnion(gdal.GDT_Byte, gdal.GDT_UInt16) == gdal.GDT_UInt16
 
+
 def test_exceptionmanager():
     currentExceptionsFlag = gdal.GetUseExceptions()
     usingExceptions = currentExceptionsFlag == 1

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -754,11 +754,11 @@ def test_gdal_DataTypeUnion():
 
 def test_exceptionmanager():
     currentExceptionsFlag = gdal.GetUseExceptions()
-    usingExceptions = (currentExceptionsFlag == 1)
+    usingExceptions = currentExceptionsFlag == 1
 
     # Run in context with opposite state
     with gdal.ExceptionMgr(useExceptions=(not usingExceptions)):
-        assert (gdal.GetUseExceptions() != currentExceptionsFlag)
+        assert gdal.GetUseExceptions() != currentExceptionsFlag
 
     # Check we are back to original state
-    assert (gdal.GetUseExceptions() == currentExceptionsFlag)
+    assert gdal.GetUseExceptions() == currentExceptionsFlag

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -751,3 +751,14 @@ def test_gdal_EscapeString_errors():
 def test_gdal_DataTypeUnion():
 
     assert gdal.DataTypeUnion(gdal.GDT_Byte, gdal.GDT_UInt16) == gdal.GDT_UInt16
+
+def test_exceptionmanager():
+    currentExceptionsFlag = gdal.GetUseExceptions()
+    usingExceptions = (currentExceptionsFlag == 1)
+
+    # Run in context with opposite state
+    with gdal.ExceptionMgr(useExceptions=(not usingExceptions)):
+        assert (gdal.GetUseExceptions() != currentExceptionsFlag)
+
+    # Check we are back to original state
+    assert (gdal.GetUseExceptions() == currentExceptionsFlag)

--- a/swig/include/python/python_exceptions.i
+++ b/swig/include/python/python_exceptions.i
@@ -221,3 +221,58 @@ static void StoreLastException()
 %#endif
     }
 }
+
+%pythoncode %{
+  class ExceptionMgr(object):
+      """
+      Context manager to manage Python Exception state
+      for GDAL/OGR/OSR/GNM.
+
+      Separate exception state is maintained for each
+      module (gdal, ogr, etc), and this class appears independently
+      in all of them. This is built in top of calls to the older
+      UseExceptions()/DontUseExceptions() functions.
+
+      Example::
+
+          >>> print(gdal.GetUseExceptions())
+          0
+          >>> with gdal.ExceptionMgr(useExceptions=True):
+          ...     # Exceptions are now in use
+          ...     print(gdal.GetUseExceptions())
+          1
+          >>>
+          >>> # Exception state has now been restored
+          >>> print(gdal.GetUseExceptions())
+          0
+
+      """
+      def __init__(self, useExceptions):
+          """
+          Save whether or not this context will be using exceptions
+          """
+          self.requestedUseExceptions = useExceptions
+
+      def __enter__(self):
+          """
+          On context entry, save the current GDAL exception state, and
+          set it to the state requested for the context
+
+          """
+          self.currentUseExceptions = (GetUseExceptions() != 0)
+
+          if self.requestedUseExceptions:
+              UseExceptions()
+          else:
+              DontUseExceptions()
+
+      def __exit__(self, exc_type, exc_val, exc_tb):
+          """
+          On exit, restore the GDAL/OGR/OSR/GNM exception state which was
+          current on entry to the context
+          """
+          if self.currentUseExceptions:
+              UseExceptions()
+          else:
+              DontUseExceptions()
+%}

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -162,6 +162,60 @@ def DontUseExceptions(*args) -> "void":
     r"""DontUseExceptions()"""
     return _gdal.DontUseExceptions(*args)
 
+class ExceptionMgr(object):
+    """
+    Context manager to manage Python Exception state
+    for GDAL/OGR/OSR/GNM.
+
+    Separate exception state is maintained for each
+    module (gdal, ogr, etc), and this class appears independently
+    in all of them. This is built in top of calls to the older
+    UseExceptions()/DontUseExceptions() functions.
+
+    Example::
+
+        >>> print(gdal.GetUseExceptions())
+        0
+        >>> with gdal.ExceptionMgr(useExceptions=True):
+        ...     # Exceptions are now in use
+        ...     print(gdal.GetUseExceptions())
+        1
+        >>>
+        >>> # Exception state has now been restored
+        >>> print(gdal.GetUseExceptions())
+        0
+
+    """
+    def __init__(self, useExceptions):
+        """
+        Save whether or not this context will be using exceptions
+        """
+        self.requestedUseExceptions = useExceptions
+
+    def __enter__(self):
+        """
+        On context entry, save the current GDAL exception state, and
+        set it to the state requested for the context
+
+        """
+        self.currentUseExceptions = (GetUseExceptions() != 0)
+
+        if self.requestedUseExceptions:
+            UseExceptions()
+        else:
+            DontUseExceptions()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        On exit, restore the GDAL/OGR/OSR/GNM exception state which was
+        current on entry to the context
+        """
+        if self.currentUseExceptions:
+            UseExceptions()
+        else:
+            DontUseExceptions()
+
+
 def VSIFReadL(*args) -> "void **":
     r"""VSIFReadL(unsigned int nMembSize, unsigned int nMembCount, VSILFILE fp) -> unsigned int"""
     return _gdal.VSIFReadL(*args)

--- a/swig/python/osgeo/gnm.py
+++ b/swig/python/osgeo/gnm.py
@@ -73,6 +73,60 @@ def UseExceptions(*args) -> "void":
 def DontUseExceptions(*args) -> "void":
     r"""DontUseExceptions()"""
     return _gnm.DontUseExceptions(*args)
+
+class ExceptionMgr(object):
+    """
+    Context manager to manage Python Exception state
+    for GDAL/OGR/OSR/GNM.
+
+    Separate exception state is maintained for each
+    module (gdal, ogr, etc), and this class appears independently
+    in all of them. This is built in top of calls to the older
+    UseExceptions()/DontUseExceptions() functions.
+
+    Example::
+
+        >>> print(gdal.GetUseExceptions())
+        0
+        >>> with gdal.ExceptionMgr(useExceptions=True):
+        ...     # Exceptions are now in use
+        ...     print(gdal.GetUseExceptions())
+        1
+        >>>
+        >>> # Exception state has now been restored
+        >>> print(gdal.GetUseExceptions())
+        0
+
+    """
+    def __init__(self, useExceptions):
+        """
+        Save whether or not this context will be using exceptions
+        """
+        self.requestedUseExceptions = useExceptions
+
+    def __enter__(self):
+        """
+        On context entry, save the current GDAL exception state, and
+        set it to the state requested for the context
+
+        """
+        self.currentUseExceptions = (GetUseExceptions() != 0)
+
+        if self.requestedUseExceptions:
+            UseExceptions()
+        else:
+            DontUseExceptions()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        On exit, restore the GDAL/OGR/OSR/GNM exception state which was
+        current on entry to the context
+        """
+        if self.currentUseExceptions:
+            UseExceptions()
+        else:
+            DontUseExceptions()
+
 from . import ogr
 from . import osr
 GATDijkstraShortestPath = _gnm.GATDijkstraShortestPath

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -431,6 +431,60 @@ def UseExceptions(*args) -> "void":
 def DontUseExceptions(*args) -> "void":
     r"""DontUseExceptions()"""
     return _ogr.DontUseExceptions(*args)
+
+class ExceptionMgr(object):
+    """
+    Context manager to manage Python Exception state
+    for GDAL/OGR/OSR/GNM.
+
+    Separate exception state is maintained for each
+    module (gdal, ogr, etc), and this class appears independently
+    in all of them. This is built in top of calls to the older
+    UseExceptions()/DontUseExceptions() functions.
+
+    Example::
+
+        >>> print(gdal.GetUseExceptions())
+        0
+        >>> with gdal.ExceptionMgr(useExceptions=True):
+        ...     # Exceptions are now in use
+        ...     print(gdal.GetUseExceptions())
+        1
+        >>>
+        >>> # Exception state has now been restored
+        >>> print(gdal.GetUseExceptions())
+        0
+
+    """
+    def __init__(self, useExceptions):
+        """
+        Save whether or not this context will be using exceptions
+        """
+        self.requestedUseExceptions = useExceptions
+
+    def __enter__(self):
+        """
+        On context entry, save the current GDAL exception state, and
+        set it to the state requested for the context
+
+        """
+        self.currentUseExceptions = (GetUseExceptions() != 0)
+
+        if self.requestedUseExceptions:
+            UseExceptions()
+        else:
+            DontUseExceptions()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        On exit, restore the GDAL/OGR/OSR/GNM exception state which was
+        current on entry to the context
+        """
+        if self.currentUseExceptions:
+            UseExceptions()
+        else:
+            DontUseExceptions()
+
 from . import osr
 class MajorObject(object):
     r"""Proxy of C++ GDALMajorObjectShadow class."""


### PR DESCRIPTION
## Allow the state of using exceptions to be set/reset locally, within a Python `with` statement

The Python gdal/ogr/osr/gnm modules each have a global state flag determining whether or not errors raise Exceptions. It defaults to not, and can be set or unset. However, because this is global, conflicts can arise in what a section of code requires, sometimes in code from other libraries. To avoid interfering with other code, one often needs to save current state, set desired state, perform some actions, then reset to saved state. 

This PR adds a Python Context Manager class which handles this process, so that a Python `with` statement can have a desired state within that block, and not interact with the global state. 

It is added to the generic `python_exceptions.i` SWIG code, so it appears in each of the different GDAL modules. 
