### PR TITLE
GPKG: add support for reading tables with generated columns (fixes #6638)

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -7368,3 +7368,83 @@ def test_ogr_gpkg_st_area(wkt_or_binary, area):
     ds = None
     gdal.Unlink(filename)
     assert f.GetField(0) == area
+
+
+###############################################################################
+# Test reading a layer with a generated column
+
+
+@pytest.mark.skipif(
+    get_sqlite_version() < (3, 31, 0),
+    reason="sqlite >= 3.31 needed",
+)
+def test_ogr_gpkg_read_generated_column():
+
+    filename = "/vsimem/test_ogr_gpkg_read_generated_column.gpkg"
+    ds = ogr.GetDriverByName("GPKG").CreateDataSource(filename)
+    ds.ExecuteSQL(
+        "CREATE TABLE test (fid INTEGER PRIMARY KEY NOT NULL,unused TEXT,strfield TEXT,strfield_generated TEXT GENERATED ALWAYS AS (strfield || '_generated'),intfield_generated_stored INTEGER GENERATED ALWAYS AS (5) STORED)"
+    )
+    ds.ExecuteSQL(
+        "INSERT INTO gpkg_contents (table_name,data_type,identifier,description,last_change,srs_id) VALUES ('test','attributes','test','','',0)"
+    )
+    ds = None
+
+    ds = ogr.Open(filename, update=1)
+    lyr = ds.GetLayer(0)
+    assert lyr.GetLayerDefn().GetFieldCount() == 4
+    assert lyr.GetLayerDefn().GetFieldDefn(2).GetName() == "strfield_generated"
+    assert lyr.GetLayerDefn().GetFieldDefn(2).GetType() == ogr.OFTString
+    assert lyr.GetLayerDefn().GetFieldDefn(3).GetName() == "intfield_generated_stored"
+    assert lyr.GetLayerDefn().GetFieldDefn(3).GetType() == ogr.OFTInteger64
+
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("strfield", "foo")
+    assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
+
+    lyr.ResetReading()
+    f = lyr.GetNextFeature()
+    assert f["strfield"] == "foo"
+    assert f["strfield_generated"] == "foo_generated"
+    assert f["intfield_generated_stored"] == 5
+
+    assert lyr.SetFeature(f) == ogr.OGRERR_NONE
+    lyr.ResetReading()
+    f = lyr.GetNextFeature()
+    assert f["strfield"] == "foo"
+    assert f["strfield_generated"] == "foo_generated"
+
+    f.SetField("strfield", "bar")
+    assert lyr.SetFeature(f) == ogr.OGRERR_NONE
+    lyr.ResetReading()
+    f = lyr.GetNextFeature()
+    assert f["strfield"] == "bar"
+    assert f["strfield_generated"] == "bar_generated"
+
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("strfield", "foo2")
+    f.SetField("strfield_generated", "ignored")
+    assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
+
+    f = lyr.GetFeature(2)
+    assert f["strfield"] == "foo2"
+    assert f["strfield_generated"] == "foo2_generated"
+    f = None
+
+    assert lyr.DeleteField(0) == ogr.OGRERR_NONE
+
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("strfield", "foo3")
+    assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
+
+    f = lyr.GetFeature(3)
+    assert f["strfield"] == "foo3"
+    # None for sqlite < 3.35.5 that uses table recreation for DeleteField() implementation
+    # and thus for now the generated column expression is lost
+    assert (
+        f["strfield_generated"] == "foo3_generated" or f["strfield_generated"] is None
+    )
+
+    ds = None
+
+    gdal.Unlink(filename)

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -517,6 +517,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     bool                        m_bFeatureCountTriggersDeletedInTransaction = false;
 #endif
     CPLString                   m_soColumns{};
+    std::vector<bool>           m_abGeneratedColumns{}; // .size() == m_poFeatureDefn->GetFieldDefnCount()
     CPLString                   m_soFilter{};
     CPLString                   osQuery{};
     CPLString                   m_osRTreeName{};

--- a/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
+++ b/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
@@ -49,7 +49,8 @@ typedef enum
 /*                          OGRVDVParseAtrFrm()                         */
 /************************************************************************/
 
-static void OGRVDVParseAtrFrm(OGRFeatureDefn* poFeatureDefn,
+static void OGRVDVParseAtrFrm(OGRLayer* poLayer,
+                              OGRFeatureDefn* poFeatureDefn,
                               char** papszAtr,
                               char** papszFrm)
 {
@@ -126,7 +127,10 @@ static void OGRVDVParseAtrFrm(OGRFeatureDefn* poFeatureDefn,
         OGRFieldDefn oFieldDefn(papszAtr[i], eType);
         oFieldDefn.SetSubType(eSubType);
         oFieldDefn.SetWidth(nWidth);
-        poFeatureDefn->AddFieldDefn(&oFieldDefn);
+        if( poLayer )
+            poLayer->CreateField(&oFieldDefn);
+        else
+            poFeatureDefn->AddFieldDefn(&oFieldDefn);
     }
 }
 
@@ -365,10 +369,7 @@ void OGRIDFDataSource::Parse()
 
                 if( !osAtr.empty() && CSLCount(papszAtr) == CSLCount(papszFrm) )
                 {
-                    /* Note: we use AddFieldDefn() directly on the layer defn */
-                    /* This works with the current implementation of the MEM driver */
-                    /* but beware of future changes... */
-                    OGRVDVParseAtrFrm(poCurLayer->GetLayerDefn(), papszAtr, papszFrm);
+                    OGRVDVParseAtrFrm(poCurLayer, nullptr, papszAtr, papszFrm);
                 }
                 CSLDestroy(papszAtr);
                 CSLDestroy(papszFrm);
@@ -908,7 +909,7 @@ OGRVDVLayer::OGRVDVLayer(const CPLString& osTableName,
                     CSLT_ALLOWEMPTYTOKENS|CSLT_STRIPLEADSPACES|CSLT_STRIPENDSPACES);
         if( CSLCount(papszAtr) == CSLCount(papszFrm) )
         {
-            OGRVDVParseAtrFrm(m_poFeatureDefn, papszAtr, papszFrm);
+            OGRVDVParseAtrFrm(nullptr, m_poFeatureDefn, papszAtr, papszFrm);
         }
         CSLDestroy(papszAtr);
         CSLDestroy(papszFrm);


### PR DESCRIPTION
- CreateFeature() and SetFeature() ignore the value in the columns
- CreateField()/DeleteField()/ReorderFields() correctly book-keep the generated column status, but not that DeleteField() before SQLite 3.35.5 involves whole table recreation which loses the generated column expression. ReorderFields() also loses the generated column expression due to whole table recreation (for all SQLite versions)
