### PR TITLE
GPKG raster: implement setting the nodata value for Byte dataset (fixes #1569)

### DIFF
--- a/doc/source/drivers/raster/gpkg.rst
+++ b/doc/source/drivers/raster/gpkg.rst
@@ -494,6 +494,46 @@ corresponding columns of the gpkg_contents table.
 You can set the CREATE_METADATA_TABLES configuration option to NO to
 avoid creating and filling the metadata tables.
 
+IMAGE_STRUCTURE metadata item
+-----------------------------
+
+.. note::
+
+    Implementation details, normally transparent to GDAL users, but useful
+    for other implementations.
+
+Starting with GDAL 3.6.1, the following optional metadata items can be read and
+write into the ``IMAGE_STRUCTURE`` metadata domain, in the
+``<GDALMultiDomainMetadata>``` XML element:
+
+- BAND_COUNT=1, 2, 3 or 4. Applies only for Byte data. Set when creating a
+  dataset so that GDAL knows the number of bands when reopening it.
+
+- COLOR_TABLE={{r0,g0,b0,a0},...{r255,g255,b255,a255}}.
+  Applies only for Byte data and a single band dataset. Set when creating a
+  dataset from a source dataset that has a color table.
+
+- TILE_FORMAT=PNG/PNG8/PNG_JPEG/JPEG/WEBP. Set when creating a
+  dataset so that GDAL knows the tile format when reopening it, for updates.
+
+- NODATA_VALUE=integer between 0 and 255. Applies only for Byte data.
+
+
+Example:
+
+.. code-block:: sql
+
+    INSERT INTO gpkg_metadata VALUES(
+        1,
+        'dataset',
+        'http://gdal.org',
+        'text/xml',
+        '<GDALMultiDomainMetadata><Metadata domain="IMAGE_STRUCTURE"><MDI key="BAND_COUNT">1</MDI><MDI key="NODATA_VALUE">255</MDI></Metadata></GDALMultiDomainMetadata>')
+    );
+    INSERT INTO gpkg_metadata_reference VALUES(
+        'table','my_raster_table',NULL,NULL,'2022-11-09T18:44:59.723Z',1,NULL);
+
+
 Level of support of GeoPackage Extensions
 -----------------------------------------
 

--- a/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
+++ b/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
@@ -3380,8 +3380,38 @@ GDALRasterBand* GDALGeoPackageRasterBand::GetOverview(int nIdx)
 
 CPLErr GDALGeoPackageRasterBand::SetNoDataValue( double dfNoDataValue )
 {
+    GDALGeoPackageDataset *poGDS
+        = cpl::down_cast<GDALGeoPackageDataset *>( poDS );
+
     if( eDataType == GDT_Byte )
+    {
+        if( !(dfNoDataValue >= 0 && dfNoDataValue <= 255 &&
+              static_cast<int>(dfNoDataValue) == dfNoDataValue) )
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Invalid nodata value for a Byte band: %.18g", dfNoDataValue);
+            return CE_Failure;
+        }
+
+        for( int i = 1; i <= poGDS->nBands; ++i )
+        {
+            if( i != nBand )
+            {
+                int bHasNoData = FALSE;
+                double dfOtherNoDataValue = poGDS->GetRasterBand(i)->GetNoDataValue(&bHasNoData);
+                if( bHasNoData && dfOtherNoDataValue != dfNoDataValue )
+                {
+                    CPLError(CE_Failure, CPLE_NotSupported,
+                             "Only the same nodata value can be set on all bands");
+                    return CE_Failure;
+                }
+            }
+        }
+
+        SetNoDataValueInternal(dfNoDataValue);
+        poGDS->m_bMetadataDirty = true;
         return CE_None;
+    }
 
     if( CPLIsNan(dfNoDataValue) )
     {
@@ -3392,8 +3422,6 @@ CPLErr GDALGeoPackageRasterBand::SetNoDataValue( double dfNoDataValue )
 
     SetNoDataValueInternal(dfNoDataValue);
 
-    GDALGeoPackageDataset *poGDS
-        = reinterpret_cast<GDALGeoPackageDataset *>( poDS );
     char* pszSQL = sqlite3_mprintf(
         "UPDATE gpkg_2d_gridded_coverage_ancillary SET data_null = ? "
         "WHERE tile_matrix_set_name = '%q'",

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -148,6 +148,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
     int                 m_nBandCountFromMetadata = 0;
     std::unique_ptr<GDALColorTable> m_poCTFromMetadata{};
     std::string         m_osTFFromMetadata{};
+    std::string         m_osNodataValueFromMetadata{};
 
     int                 m_nOverviewCount = 0;
     GDALGeoPackageDataset** m_papoOverviewDS = nullptr;


### PR DESCRIPTION
This is implemented as a NODATA_VALUE metadata item in GDAL ``<GDALMultiDomainMetadata>`` XML element.
