### PR TITLE
[Backport release/3.6] configure.cmake: fix wrong detection of pread64 for iOS (patch by Nik Sands)

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -241,16 +241,6 @@ else ()
   check_type_size("off_t" SIZEOF_OFF_T)
 
   check_function_exists(pread64 HAVE_PREAD64)
-  if( NOT HAVE_PREAD64 )
-    check_c_source_compiles(
-      "
-         #include <sys/types.h>
-         #include <sys/uio.h>
-         #include <unistd.h>
-         int main() { pread(0, NULL, 0, 0); return 0; }
-        "
-      HAVE_PREAD_BSD)
-  endif()
 
   check_function_exists(ftruncate64 HAVE_FTRUNCATE64)
   if (HAVE_FTRUNCATE64)
@@ -280,6 +270,19 @@ else ()
     unset(HAVE_FSEEK64 CACHE)
     unset(HAVE_STATVFS64)
     unset(HAVE_STATVFS64 CACHE)
+    unset(HAVE_PREAD64)
+    unset(HAVE_PREAD64 CACHE)
+  endif()
+
+  if( NOT HAVE_PREAD64 )
+    check_c_source_compiles(
+      "
+         #include <sys/types.h>
+         #include <sys/uio.h>
+         #include <unistd.h>
+         int main() { pread(0, NULL, 0, 0); return 0; }
+        "
+      HAVE_PREAD_BSD)
   endif()
 
   set(UNIX_STDIO_64 TRUE)


### PR DESCRIPTION
Backport #6673
 **Authored by:** @rouault