### PR TITLE
[Backport release/3.6] GPKG: avoid nullptr dereference on corrupted databases

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -437,6 +437,15 @@ bool GDALGeoPackageDataset::ConvertGpkgSpatialRefSysToExtensionWkt2()
             const char* pszOrganization = oResultTable->GetValue(2, i);
             const char* pszOrganizationCoordsysID = oResultTable->GetValue(3, i);
             const char* pszDefinition = oResultTable->GetValue(4, i);
+            if( pszSrsName == nullptr ||
+                pszSrsId == nullptr ||
+                pszOrganization == nullptr ||
+                pszOrganizationCoordsysID == nullptr )
+            {
+                // should not happen as there are NOT NULL constraints
+                // But a database could lack such NOT NULL constraints or have
+                // large values that would cause a memory allocation failure.
+            }
             const char* pszDescription = oResultTable->GetValue(5, i);
             char* pszSQL;
 
@@ -3783,6 +3792,16 @@ char **GDALGeoPackageDataset::GetMetadata( const char *pszDomain )
         const char* pszMDStandardURI = oResult->GetValue(1, i);
         const char* pszMimeType = oResult->GetValue(2, i);
         const char* pszReferenceScope = oResult->GetValue(3, i);
+        if( pszMetadata == nullptr ||
+            pszMDStandardURI == nullptr ||
+            pszMimeType == nullptr ||
+            pszReferenceScope == nullptr )
+        {
+            // should not happen as there are NOT NULL constraints
+            // But a database could lack such NOT NULL constraints or have
+            // large values that would cause a memory allocation failure.
+            continue;
+        }
         int bIsGPKGScope = EQUAL(pszReferenceScope, "geopackage");
         if( EQUAL(pszMDStandardURI, "http://gdal.org") &&
             EQUAL(pszMimeType, "text/xml") )

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -5000,6 +5000,16 @@ char **OGRGeoPackageTableLayer::GetMetadata( const char *pszDomain )
         const char* pszMDStandardURI = oResult->GetValue(1, i);
         const char* pszMimeType = oResult->GetValue(2, i);
         //const char* pszReferenceScope = oResult->GetValue(3, i);
+        if( pszMetadata == nullptr ||
+            pszMDStandardURI == nullptr ||
+            pszMimeType == nullptr
+            /* || pszReferenceScope == nullptr */ )
+        {
+            // should not happen as there are NOT NULL constraints
+            // But a database could lack such NOT NULL constraints or have
+            // large values that would cause a memory allocation failure.
+            continue;
+        }
         //int bIsGPKGScope = EQUAL(pszReferenceScope, "geopackage");
         if( EQUAL(pszMDStandardURI, "http://gdal.org") &&
             EQUAL(pszMimeType, "text/xml") )

--- a/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
+++ b/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
@@ -2774,6 +2774,8 @@ class GPKGChecker(object):
                     (expected_version % 10000) // 100,
                     expected_version % 100,
                 )
+            else:
+                self.version = (99, 99)
 
         conn = sqlite3.connect(":memory:")
         c = conn.cursor()


### PR DESCRIPTION
Backport #6681
 **Authored by:** @rouault