### PR TITLE
Fix static HDF4 libraries not found on Windows

### DIFF
--- a/cmake/modules/packages/FindHDF4.cmake
+++ b/cmake/modules/packages/FindHDF4.cmake
@@ -73,7 +73,7 @@ if(HDF4_INCLUDE_DIR)
           set(_names_release ${tgt}alt ${tgt} hdf libhdf)
         else()
           set(_names_debug  ${tgt}altd ${tgt}d)
-          set(_names_release ${tgt}alt ${tgt})
+          set(_names_release ${tgt}alt ${tgt} lib${tgt})
         endif()
         find_library(HDF4_${tgt}_LIBRARY_DEBUG
                      NAMES ${_names_debug}


### PR DESCRIPTION
Fixes `Could NOT find HDF4 (missing: HDF4_mfhdf_LIBRARY) (found version "4.2.15")`. The static xdr library is named `libxdr.lib` when building HDF-4.2.15 with CMake on Windows.