### PR TITLE
[Backport release/3.6] Fix static HDF4 libraries not found on Windows

### DIFF
--- a/cmake/modules/packages/FindHDF4.cmake
+++ b/cmake/modules/packages/FindHDF4.cmake
@@ -73,7 +73,7 @@ if(HDF4_INCLUDE_DIR)
           set(_names_release ${tgt}alt ${tgt} hdf libhdf)
         else()
           set(_names_debug  ${tgt}altd ${tgt}d)
-          set(_names_release ${tgt}alt ${tgt})
+          set(_names_release ${tgt}alt ${tgt} lib${tgt})
         endif()
         find_library(HDF4_${tgt}_LIBRARY_DEBUG
                      NAMES ${_names_debug}


### PR DESCRIPTION
Backport #6683
 **Authored by:** @cgohlke