### PR TITLE
SQLite/GPKG: move PRELUDE_STATEMENTS evaluation just after database opening

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -1460,14 +1460,6 @@ int GDALGeoPackageDataset::Open( GDALOpenInfo* poOpenInfo )
         }
     }
 
-    const char* pszPreludeStatements = CSLFetchNameValue(
-        poOpenInfo->papszOpenOptions, "PRELUDE_STATEMENTS");
-    if( pszPreludeStatements )
-    {
-        if( SQLCommand(hDB, pszPreludeStatements) != OGRERR_NONE )
-            return FALSE;
-    }
-
     /* Requirement 6: The SQLite PRAGMA integrity_check SQL command SHALL return “ok” */
     /* http://opengis.github.io/geopackage/#_file_integrity */
     /* Disable integrity check by default, since it is expensive on big files */

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -1177,6 +1177,14 @@ int OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn, bool bRegisterOGR2SQLit
         }
 #endif
 
+        const char* pszPreludeStatements = CSLFetchNameValue(
+            papszOpenOptions, "PRELUDE_STATEMENTS");
+        if( pszPreludeStatements )
+        {
+            if( SQLCommand(hDB, pszPreludeStatements) != OGRERR_NONE )
+                return FALSE;
+        }
+
         if (pszSqlitePragma != nullptr)
         {
             char** papszTokens = CSLTokenizeString2( pszSqlitePragma, ",",
@@ -1987,13 +1995,6 @@ bool OGRSQLiteDataSource::Open( GDALOpenInfo* poOpenInfo)
         return OpenRasterSubDataset( pszNewName );
     }
 #endif
-
-    const char* pszPreludeStatements = CSLFetchNameValue(papszOpenOptions, "PRELUDE_STATEMENTS");
-    if( pszPreludeStatements )
-    {
-        if( SQLCommand(hDB, pszPreludeStatements) != OGRERR_NONE )
-            return false;
-    }
 
 /* -------------------------------------------------------------------- */
 /*      If we have a GEOMETRY_COLUMNS tables, initialize on the basis   */


### PR DESCRIPTION
- this simplify a tiny bit the code
- and this allows to issue a 'PRAGMA writable_schema=ON' statement, to be able to read databases with STRICT tables (created with sqlite>=3.37) with earlier sqlite versions.
