### PR TITLE
RFC87: emit a warning when querying PIXELTYPE band IMAGE_STRUCTURE metadata item

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -612,9 +612,11 @@ static double AdjustNoDataValue( double dfInputNoDataValue,
 {
     bool bSignedByte = false;
     const char* pszPixelType = CSLFetchNameValue( psOptions->papszCreateOptions, "PIXELTYPE" );
-    if( pszPixelType == nullptr )
+    if( pszPixelType == nullptr && poBand->GetRasterDataType() == GDT_Byte )
     {
+        poBand->EnablePixelTypeSignedByteWarning(false);
         pszPixelType = poBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+        poBand->EnablePixelTypeSignedByteWarning(true);
     }
     if( pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE") )
         bSignedByte = true;
@@ -1998,11 +2000,18 @@ GDALDatasetH GDALTranslate( const char *pszDest, GDALDatasetH hSrcDataset,
         }
 
         // Preserve PIXELTYPE if no option change values
-        const char* pszPixelType = poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
-        if( pszPixelType && psOptions->nRGBExpand == 0 && psOptions->nScaleRepeat == 0 &&
-            !psOptions->bUnscale && psOptions->eOutputType == GDT_Unknown && psOptions->pszResampling == nullptr )
+        if( poSrcBand->GetRasterDataType() == GDT_Byte &&
+            psOptions->nRGBExpand == 0 && psOptions->nScaleRepeat == 0 &&
+            !psOptions->bUnscale && psOptions->eOutputType == GDT_Unknown &&
+            psOptions->pszResampling == nullptr )
         {
-            poVRTBand->SetMetadataItem("PIXELTYPE", pszPixelType, "IMAGE_STRUCTURE");
+            poSrcBand->EnablePixelTypeSignedByteWarning(false);
+            const char* pszPixelType = poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            poSrcBand->EnablePixelTypeSignedByteWarning(true);
+            if( pszPixelType )
+            {
+                poVRTBand->SetMetadataItem("PIXELTYPE", pszPixelType, "IMAGE_STRUCTURE");
+            }
         }
 
         const char* pszCompression = poSrcBand->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -4928,3 +4928,19 @@ def test_tiff_read_multi_threaded_vsicurl(use_dataset_readraster):
         webserver.server_stop(webserver_process, webserver_port)
 
         gdal.VSICurlClearCache()
+
+
+###############################################################################
+# Test that a user receives a warning when it queries
+# GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
+
+
+def test_tiff_warning_get_metadata_item_PIXELTYPE():
+
+    ds = gdal.Open("data/byte.tif")
+    with gdaltest.error_handler():
+        ds.GetRasterBand(1).GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
+    assert (
+        gdal.GetLastErrorMsg()
+        == "Starting with GDAL 3.7, PIXELTYPE=SIGNEDBYTE is no longer used to signal signed 8-bit raster. Change your code to test for the new GDT_Int8 data type instead."
+    )

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -6177,6 +6177,22 @@ def test_netcdf_read_cf_xy_latlon_crs_wkt():
     assert ds.GetGeoTransform() == (3500000.0, 1000.0, 0.0, 2102000.0, 0.0, -1000.0)
 
 
+###############################################################################
+# Test that a user receives a warning when it queries
+# GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
+
+
+def test_netcdf_warning_get_metadata_item_PIXELTYPE():
+
+    ds = gdal.Open("data/netcdf/byte_no_cf.nc")
+    with gdaltest.error_handler():
+        ds.GetRasterBand(1).GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
+    assert (
+        gdal.GetLastErrorMsg()
+        == "Starting with GDAL 3.7, PIXELTYPE=SIGNEDBYTE is no longer used to signal signed 8-bit raster. Change your code to test for the new GDT_Int8 data type instead."
+    )
+
+
 def test_clean_tmp():
     # [KEEP THIS AS THE LAST TEST]
     # i.e. please do not add any tests after this one. Put new ones above.

--- a/frmts/cals/calsdataset.cpp
+++ b/frmts/cals/calsdataset.cpp
@@ -123,7 +123,11 @@ class CALSRasterBand final: public GDALPamRasterBand
     const char* GetMetadataItem( const char* pszKey,
                                  const char* pszDomain ) override
     {
-        return poUnderlyingBand->GetMetadataItem(pszKey, pszDomain);
+        if( !m_bEnablePixelTypeSignedByteWarning )
+            poUnderlyingBand->EnablePixelTypeSignedByteWarning(false);
+        const char* pszRet = poUnderlyingBand->GetMetadataItem(pszKey, pszDomain);
+        poUnderlyingBand->EnablePixelTypeSignedByteWarning(true);
+        return pszRet;
     }
 };
 

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -6732,7 +6732,17 @@ const char *GTiffRasterBand::GetMetadataItem( const char * pszName,
             return CPLSPrintf(CPL_FRMT_GUIB, static_cast<GUIntBig>(nByteCount));
         }
     }
-    return m_oGTiffMDMD.GetMetadataItem( pszName, pszDomain );
+
+    const char* pszRet = m_oGTiffMDMD.GetMetadataItem( pszName, pszDomain );
+
+    if( pszRet == nullptr && eDataType == GDT_Byte &&
+        pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE") &&
+        EQUAL(pszName, "PIXELTYPE") )
+    {
+        // to get a chance of emitting the warning about this legacy usage
+        pszRet = GDALRasterBand::GetMetadataItem( pszName, pszDomain );
+    }
+    return pszRet;
 }
 
 /************************************************************************/
@@ -19908,13 +19918,17 @@ GTiffDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     }
 
     if( CSLFetchNameValue( papszOptions, "PIXELTYPE" ) == nullptr
-        && eType == GDT_Byte
-        && poPBand->GetMetadataItem( "PIXELTYPE", "IMAGE_STRUCTURE" ) )
+        && eType == GDT_Byte )
     {
-        papszCreateOptions =
-            CSLSetNameValue( papszCreateOptions, "PIXELTYPE",
-                             poPBand->GetMetadataItem(
-                                 "PIXELTYPE", "IMAGE_STRUCTURE" ) );
+        poPBand->EnablePixelTypeSignedByteWarning(false);
+        const char* pszPixelType = poPBand->GetMetadataItem( "PIXELTYPE", "IMAGE_STRUCTURE" );
+        poPBand->EnablePixelTypeSignedByteWarning(true);
+        if( pszPixelType )
+        {
+            papszCreateOptions =
+                CSLSetNameValue( papszCreateOptions, "PIXELTYPE",
+                                 pszPixelType );
+        }
     }
 
 /* -------------------------------------------------------------------- */
@@ -20727,8 +20741,11 @@ GTiffDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     {
         for(int i = 0; i < poDS->nBands; ++i )
         {
-            static_cast<GTiffRasterBand*>(poDS->papoBands[i])->eDataType = GDT_Byte;
-            poDS->papoBands[i]->SetMetadataItem("PIXELTYPE", "SIGNEDBYTE", "IMAGE_STRUCTURE");
+            auto poBand = static_cast<GTiffRasterBand*>(poDS->papoBands[i]);
+            poBand->eDataType = GDT_Byte;
+            poBand->EnablePixelTypeSignedByteWarning(false);
+            poBand->SetMetadataItem("PIXELTYPE", "SIGNEDBYTE", "IMAGE_STRUCTURE");
+            poBand->EnablePixelTypeSignedByteWarning(true);
         }
     }
 

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -4968,14 +4968,18 @@ HFADataset::CreateCopy( const char *pszFilename, GDALDataset *poSrcDS,
     // through as a creation option.
     if( CSLFetchNameValue(papszOptions, "PIXELTYPE") == nullptr &&
         nBandCount > 0 &&
-        eType == GDT_Byte &&
-        poSrcDS->GetRasterBand(1)->GetMetadataItem("PIXELTYPE",
-                                                   "IMAGE_STRUCTURE") )
+        eType == GDT_Byte )
     {
-        papszModOptions =
-            CSLSetNameValue(papszModOptions, "PIXELTYPE",
-                            poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                                "PIXELTYPE", "IMAGE_STRUCTURE"));
+        auto poSrcBand = poSrcDS->GetRasterBand(1);
+        poSrcBand->EnablePixelTypeSignedByteWarning(false);
+        const char* pszPixelType = poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+        poSrcBand->EnablePixelTypeSignedByteWarning(true);
+        if( pszPixelType )
+        {
+            papszModOptions =
+                CSLSetNameValue(papszModOptions, "PIXELTYPE",
+                                pszPixelType);
+        }
     }
 
     HFADataset *poDS =

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -10033,17 +10033,7 @@ netCDFDataset::CreateCopy( const char *pszFilename, GDALDataset *poSrcDS,
         else
             szLongName[0] = '\0';
 
-        bool bSignedData = true;
-        if( eDT == GDT_Byte )
-        {
-            // GDAL defaults to unsigned bytes, but check if metadata says its
-            // signed, as NetCDF can support this for certain formats.
-            bSignedData = false;
-            tmpMetadata =
-                poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
-            if( tmpMetadata && EQUAL(tmpMetadata, "SIGNEDBYTE") )
-                bSignedData = true;
-        }
+        constexpr bool bSignedData = false;
 
         if( nDim > 2 )
             poBand = new netCDFRasterBand(

--- a/frmts/vrt/vrtrasterband.cpp
+++ b/frmts/vrt/vrtrasterband.cpp
@@ -114,8 +114,13 @@ CPLErr VRTRasterBand::CopyCommonInfoFrom( GDALRasterBand * poSrcBand )
     SetMetadata( poSrcBand->GetMetadata() );
     const char* pszNBits = poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
     SetMetadataItem( "NBITS", pszNBits, "IMAGE_STRUCTURE" );
-    const char* pszPixelType = poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
-    SetMetadataItem( "PIXELTYPE", pszPixelType, "IMAGE_STRUCTURE" );
+    if( poSrcBand->GetRasterDataType() == GDT_Byte )
+    {
+        poSrcBand->EnablePixelTypeSignedByteWarning(false);
+        const char* pszPixelType = poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+        poSrcBand->EnablePixelTypeSignedByteWarning(true);
+        SetMetadataItem( "PIXELTYPE", pszPixelType, "IMAGE_STRUCTURE" );
+    }
     SetColorTable( poSrcBand->GetColorTable() );
     SetColorInterpretation(poSrcBand->GetColorInterpretation());
     if( strlen(poSrcBand->GetDescription()) > 0 )

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -934,9 +934,15 @@ CPLErr VRTSourcedRasterBand::ComputeRasterMinMax( int bApproxOK, double* adfMinM
             return eErr;
         }
 
-        const char* pszPixelType = GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
-        const bool bSignedByte =
-            pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
+        bool bSignedByte = false;
+        if( eDataType == GDT_Byte )
+        {
+            EnablePixelTypeSignedByteWarning(false);
+            const char* pszPixelType = GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            EnablePixelTypeSignedByteWarning(true);
+            bSignedByte =
+                pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
+        }
 
         double dfGlobalMin = std::numeric_limits<double>::max();
         double dfGlobalMax = -std::numeric_limits<double>::max();

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1213,6 +1213,7 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
 
     GDALRasterBand *poMask = nullptr;
     bool        bOwnMask = false;
+    bool        m_bEnablePixelTypeSignedByteWarning = true; // Remove me in GDAL 4.0. See GetMetadataItem() implementation
     int         nMaskFlags = 0;
 
     void        InvalidateMaskBand();
@@ -1228,6 +1229,7 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     void         LeaveReadWrite();
     void         InitRWLock();
     void         SetValidPercent( GUIntBig nSampleCount, GUIntBig nValidCount );
+
 //! @endcond
 
   protected:
@@ -1345,6 +1347,8 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
                                  const char * pszValue,
                                  const char * pszDomain ) override;
 #endif
+    virtual const char *GetMetadataItem( const char * pszName,
+                                         const char * pszDomain = "" ) override;
 
     virtual int HasArbitraryOverviews();
     virtual int GetOverviewCount();
@@ -1409,6 +1413,17 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
      */
     static inline GDALRasterBand* FromHandle(GDALRasterBandH hBand)
         { return static_cast<GDALRasterBand*>(hBand); }
+
+//! @cond Doxygen_Suppress
+    // Remove me in GDAL 4.0. See GetMetadataItem() implementation
+    // Internal use in GDAL only !
+    void EnablePixelTypeSignedByteWarning(bool b)
+#ifndef GDAL_COMPILATION
+            CPL_WARN_DEPRECATED("Do not use that method outside of GDAL!")
+#endif
+                                                    ;
+
+//! @endcond
 
 private:
     CPL_DISALLOW_COPY_ASSIGN(GDALRasterBand)
@@ -3304,6 +3319,11 @@ void CPL_DLL GDALCopyNoDataValue(GDALRasterBand* poDstBand,
 
 double CPL_DLL GDALGetNoDataValueCastToDouble(int64_t nVal);
 double CPL_DLL GDALGetNoDataValueCastToDouble(uint64_t nVal);
+
+// Remove me in GDAL 4.0. See GetMetadataItem() implementation
+// Internal use in GDAL only !
+// Declaration copied in swig/include/gdal.i
+void CPL_DLL GDALEnablePixelTypeSignedByteWarning(GDALRasterBandH hBand, bool b);
 
 //! @endcond
 

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -630,9 +630,12 @@ GDALDataset *GDALDriver::DefaultCreateCopy( const char * pszFilename,
          iOptItem += 2 )
     {
         // does the source have this metadata item on the first band?
+        auto poBand = poSrcDS->GetRasterBand(1);
+        poBand->EnablePixelTypeSignedByteWarning(false);
         const char *pszValue =
-            poSrcDS->GetRasterBand(1)->GetMetadataItem(
+            poBand->GetMetadataItem(
                 apszOptItems[iOptItem], apszOptItems[iOptItem+1] );
+        poBand->EnablePixelTypeSignedByteWarning(true);
 
         if( pszValue == nullptr )
             continue;

--- a/gcore/gdalproxydataset.cpp
+++ b/gcore/gdalproxydataset.cpp
@@ -306,9 +306,23 @@ RB_PROXY_METHOD_WITH_RET(char**, nullptr, GetMetadata, (const char * pszDomain),
 RB_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, SetMetadata,
                         (char ** papszMetadata, const char * pszDomain),
                         (papszMetadata, pszDomain))
-RB_PROXY_METHOD_WITH_RET(const char*, nullptr, GetMetadataItem,
-                        (const char * pszName, const char * pszDomain),
-                        (pszName, pszDomain))
+
+const char* GDALProxyRasterBand::GetMetadataItem( const char* pszKey,
+                                                  const char* pszDomain )
+{
+    const char* pszRet = nullptr;
+    GDALRasterBand* poSrcBand = RefUnderlyingRasterBand();
+    if (poSrcBand)
+    {
+        if( !m_bEnablePixelTypeSignedByteWarning )
+            poSrcBand->EnablePixelTypeSignedByteWarning(false);
+        pszRet = poSrcBand->GetMetadataItem(pszKey, pszDomain);
+        poSrcBand->EnablePixelTypeSignedByteWarning(true);
+        UnrefUnderlyingRasterBand(poSrcBand);
+    }
+    return pszRet;
+}
+
 RB_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, SetMetadataItem,
                         (const char * pszName, const char * pszValue, const char * pszDomain),
                         (pszName, pszValue, pszDomain))

--- a/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
+++ b/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
@@ -987,10 +987,6 @@ RL2RasterBand::RL2RasterBand(const RL2RasterBand* poOther)
         const_cast<RL2RasterBand*>(poOther)->
                     GetMetadataItem("NBITS", "IMAGE_STRUCTURE"),
         "IMAGE_STRUCTURE" );
-    GDALRasterBand::SetMetadataItem( "PIXELTYPE",
-        const_cast<RL2RasterBand*>(poOther)->
-                    GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE"),
-        "IMAGE_STRUCTURE" );
     m_eColorInterp = poOther->m_eColorInterp;
     m_bHasNoData = poOther->m_bHasNoData;
     m_dfNoDataValue = poOther->m_dfNoDataValue;

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -671,6 +671,12 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
     return GDALRasterBandAsMDArray(self);
   }
 
+  /* Internal use only! To be removed in GDAL 4.0 */
+  void _EnablePixelTypeSignedByteWarning(bool b)
+  {
+      GDALEnablePixelTypeSignedByteWarning(self, b);
+  }
+
 } /* %extend */
 
 };

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -71,6 +71,9 @@ using namespace std;
 #include "gdalwarper.h"
 #include "ogr_srs_api.h"
 
+// From gdal_priv.h
+void CPL_DLL GDALEnablePixelTypeSignedByteWarning(GDALRasterBandH hBand, bool b);
+
 typedef void GDALMajorObjectShadow;
 typedef void GDALDriverShadow;
 typedef void GDALDatasetShadow;

--- a/swig/include/gdal_array.i
+++ b/swig/include/gdal_array.i
@@ -2175,8 +2175,12 @@ def DatasetReadAsArray(ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_o
         else:
             buf_type = NumericTypeCodeToGDALTypeCode(typecode)
 
-        if buf_type == gdalconst.GDT_Byte and ds.GetRasterBand(1).GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
-            typecode = numpy.int8
+        if buf_type == gdalconst.GDT_Byte:
+            band = ds.GetRasterBand(1)
+            band._EnablePixelTypeSignedByteWarning(False)
+            if band.GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
+                typecode = numpy.int8
+            band._EnablePixelTypeSignedByteWarning(True)
         buf_shape = (nbands, buf_ysize, buf_xsize) if interleave else (buf_ysize, buf_xsize, nbands)
         buf_obj = numpy.empty(buf_shape, dtype=typecode)
 
@@ -2305,8 +2309,11 @@ def BandReadAsArray(band, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
         else:
             buf_type = NumericTypeCodeToGDALTypeCode(typecode)
 
-        if buf_type == gdalconst.GDT_Byte and band.GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
-            typecode = numpy.int8
+        if buf_type == gdalconst.GDT_Byte:
+            band._EnablePixelTypeSignedByteWarning(False)
+            if band.GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
+                typecode = numpy.int8
+            band._EnablePixelTypeSignedByteWarning(True)
         buf_obj = numpy.empty([buf_ysize, buf_xsize], dtype=typecode)
 
     else:

--- a/swig/python/extensions/gdal_wrap.cpp
+++ b/swig/python/extensions/gdal_wrap.cpp
@@ -2892,6 +2892,9 @@ using namespace std;
 #include "gdalwarper.h"
 #include "ogr_srs_api.h"
 
+// From gdal_priv.h
+void CPL_DLL GDALEnablePixelTypeSignedByteWarning(GDALRasterBandH hBand, bool b);
+
 typedef void GDALMajorObjectShadow;
 typedef void GDALDriverShadow;
 typedef void GDALDatasetShadow;
@@ -6586,6 +6589,9 @@ SWIGINTERN CPLErr GDALRasterBandShadow_AdviseRead(GDALRasterBandShadow *self,int
 }
 SWIGINTERN GDALMDArrayHS *GDALRasterBandShadow_AsMDArray(GDALRasterBandShadow *self){
     return GDALRasterBandAsMDArray(self);
+  }
+SWIGINTERN void GDALRasterBandShadow__EnablePixelTypeSignedByteWarning(GDALRasterBandShadow *self,bool b){
+      GDALEnablePixelTypeSignedByteWarning(self, b);
   }
 SWIGINTERN CPLErr GDALRasterBandShadow_ReadRaster1(GDALRasterBandShadow *self,double xoff,double yoff,double xsize,double ysize,void **buf,int *buf_xsize=0,int *buf_ysize=0,GDALDataType *buf_type=0,GIntBig *buf_pixel_space=0,GIntBig *buf_line_space=0,GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour,GDALProgressFunc callback=NULL,void *callback_data=NULL,void *inputOutputBuf=NULL){
 
@@ -34423,6 +34429,53 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Band__EnablePixelTypeSignedByteWarning(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  GDALRasterBandShadow *arg1 = (GDALRasterBandShadow *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "Band__EnablePixelTypeSignedByteWarning", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_GDALRasterBandShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Band__EnablePixelTypeSignedByteWarning" "', argument " "1"" of type '" "GDALRasterBandShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< GDALRasterBandShadow * >(argp1);
+  ecode2 = SWIG_AsVal_bool(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Band__EnablePixelTypeSignedByteWarning" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      GDALRasterBandShadow__EnablePixelTypeSignedByteWarning(arg1,arg2);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Band_ReadRaster1(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   GDALRasterBandShadow *arg1 = (GDALRasterBandShadow *) 0 ;
@@ -46959,6 +47012,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "Band_GetDataCoverageStatus", _wrap_Band_GetDataCoverageStatus, METH_VARARGS, "Band_GetDataCoverageStatus(Band self, int nXOff, int nYOff, int nXSize, int nYSize, int nMaskFlagStop=0) -> int"},
 	 { "Band_AdviseRead", _wrap_Band_AdviseRead, METH_VARARGS, "Band_AdviseRead(Band self, int xoff, int yoff, int xsize, int ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, char ** options=None) -> CPLErr"},
 	 { "Band_AsMDArray", _wrap_Band_AsMDArray, METH_O, "Band_AsMDArray(Band self) -> MDArray"},
+	 { "Band__EnablePixelTypeSignedByteWarning", _wrap_Band__EnablePixelTypeSignedByteWarning, METH_VARARGS, "Band__EnablePixelTypeSignedByteWarning(Band self, bool b)"},
 	 { "Band_ReadRaster1", (PyCFunction)(void(*)(void))_wrap_Band_ReadRaster1, METH_VARARGS|METH_KEYWORDS, "Band_ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"},
 	 { "Band_ReadBlock", (PyCFunction)(void(*)(void))_wrap_Band_ReadBlock, METH_VARARGS|METH_KEYWORDS, "Band_ReadBlock(Band self, int xoff, int yoff, void * buf_obj=None) -> CPLErr"},
 	 { "Band_swigregister", Band_swigregister, METH_O, NULL},

--- a/swig/python/gdal-utils/osgeo_utils/auxiliary/numpy_util.py
+++ b/swig/python/gdal-utils/osgeo_utils/auxiliary/numpy_util.py
@@ -45,11 +45,14 @@ def GDALTypeCodeToNumericTypeCodeEx(buf_type, signed_byte, default=None):
 
 
 def GDALTypeCodeAndNumericTypeCodeFromDataSet(ds):
-    buf_type = ds.GetRasterBand(1).DataType
-    signed_byte = (
-        ds.GetRasterBand(1).GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
-        == "SIGNEDBYTE"
-    )
+    band = ds.GetRasterBand(1)
+    buf_type = band.DataType
+    if buf_type == gdal.GDT_Byte:
+        band._EnablePixelTypeSignedByteWarning(False)
+        signed_byte = (
+            band.GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE") == "SIGNEDBYTE"
+        )
+        band._EnablePixelTypeSignedByteWarning(True)
     np_typecode = GDALTypeCodeToNumericTypeCodeEx(
         buf_type, signed_byte=signed_byte, default=np.float32
     )

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -4131,6 +4131,10 @@ class Band(MajorObject):
         r"""AsMDArray(Band self) -> MDArray"""
         return _gdal.Band_AsMDArray(self, *args)
 
+    def _EnablePixelTypeSignedByteWarning(self, *args) -> "void":
+        r"""_EnablePixelTypeSignedByteWarning(Band self, bool b)"""
+        return _gdal.Band__EnablePixelTypeSignedByteWarning(self, *args)
+
     def ReadRaster1(self, *args, **kwargs) -> "CPLErr":
         r"""ReadRaster1(Band self, double xoff, double yoff, double xsize, double ysize, int * buf_xsize=None, int * buf_ysize=None, GDALDataType * buf_type=None, GIntBig * buf_pixel_space=None, GIntBig * buf_line_space=None, GDALRIOResampleAlg resample_alg=GRIORA_NearestNeighbour, GDALProgressFunc callback=0, void * callback_data=None, void * inputOutputBuf=None) -> CPLErr"""
         return _gdal.Band_ReadRaster1(self, *args, **kwargs)

--- a/swig/python/osgeo/gdal_array.py
+++ b/swig/python/osgeo/gdal_array.py
@@ -292,8 +292,12 @@ def DatasetReadAsArray(ds, xoff=0, yoff=0, win_xsize=None, win_ysize=None, buf_o
         else:
             buf_type = NumericTypeCodeToGDALTypeCode(typecode)
 
-        if buf_type == gdalconst.GDT_Byte and ds.GetRasterBand(1).GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
-            typecode = numpy.int8
+        if buf_type == gdalconst.GDT_Byte:
+            band = ds.GetRasterBand(1)
+            band._EnablePixelTypeSignedByteWarning(False)
+            if band.GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
+                typecode = numpy.int8
+            band._EnablePixelTypeSignedByteWarning(True)
         buf_shape = (nbands, buf_ysize, buf_xsize) if interleave else (buf_ysize, buf_xsize, nbands)
         buf_obj = numpy.empty(buf_shape, dtype=typecode)
 
@@ -422,8 +426,11 @@ def BandReadAsArray(band, xoff=0, yoff=0, win_xsize=None, win_ysize=None,
         else:
             buf_type = NumericTypeCodeToGDALTypeCode(typecode)
 
-        if buf_type == gdalconst.GDT_Byte and band.GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
-            typecode = numpy.int8
+        if buf_type == gdalconst.GDT_Byte:
+            band._EnablePixelTypeSignedByteWarning(False)
+            if band.GetMetadataItem('PIXELTYPE', 'IMAGE_STRUCTURE') == 'SIGNEDBYTE':
+                typecode = numpy.int8
+            band._EnablePixelTypeSignedByteWarning(True)
         buf_obj = numpy.empty([buf_ysize, buf_xsize], dtype=typecode)
 
     else:


### PR DESCRIPTION
so that users are aware of the change and can adapt accordingly.

Attempt to alleviate the complaints about the silent breakage situation

Downside is that re-adds some clutter in our code base