### PR TITLE
GPKG: improve multi-threaded implementation of GetNextArrowArray() on…

### DIFF
--- a/apps/bench_ogr_batch.cpp
+++ b/apps/bench_ogr_batch.cpp
@@ -136,6 +136,10 @@ int main(int argc, char* argv[])
         schema.release(&schema);
     }
 #endif
+
+#if 0
+    int64_t lastId = 0;
+#endif
     while( true )
     {
         struct ArrowArray array;
@@ -144,6 +148,16 @@ int main(int argc, char* argv[])
         {
             break;
         }
+#if 0
+        const int64_t* fid_col = static_cast<const int64_t*>(array.children[0]->buffers[1]);
+        for(int64_t i = 0; i < array.length; ++i )
+        {
+            int64_t id = fid_col[i];
+            if( id != lastId + 1 )
+                printf(CPL_FRMT_GIB "\n", static_cast<GIntBig>(id));
+            lastId = id;
+        }
+#endif
         array.release(&array);
     }
     stream.release(&stream);

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -629,12 +629,17 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     struct ArrowArrayPrefetchTask
     {
         std::thread                              m_oThread{};
+        std::condition_variable                  m_oCV{};
+        std::mutex                               m_oMutex{};
+        bool                                     m_bArrayReady = false;
+        bool                                     m_bFetchRows = false;
+        bool                                     m_bStop = false;
         std::unique_ptr<GDALGeoPackageDataset>   m_poDS{};
         OGRGeoPackageTableLayer                 *m_poLayer{};
         GIntBig                                  m_iStartShapeId = 0;
         std::unique_ptr<struct ArrowArray>       m_psArrowArray = nullptr;
     };
-    std::queue<ArrowArrayPrefetchTask> m_oQueueArrowArrayPrefetchTasks{};
+    std::queue<std::unique_ptr<ArrowArrayPrefetchTask>> m_oQueueArrowArrayPrefetchTasks{};
 
     // Used when m_nIsCompatOfOptimizedGetNextArrowArray == FALSE
     std::thread         m_oThreadNextArrowArray{};

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -39,6 +39,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <queue>
 #include <vector>
 #include <set>
 #include <thread>
@@ -624,10 +625,22 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
 
     CPL_DISALLOW_COPY_ASSIGN(OGRGeoPackageTableLayer)
 
+    // Used when m_nIsCompatOfOptimizedGetNextArrowArray == TRUE
+    struct ArrowArrayPrefetchTask
+    {
+        std::thread                              m_oThread{};
+        std::unique_ptr<GDALGeoPackageDataset>   m_poDS{};
+        OGRGeoPackageTableLayer                 *m_poLayer{};
+        GIntBig                                  m_iStartShapeId = 0;
+        std::unique_ptr<struct ArrowArray>       m_psArrowArray = nullptr;
+    };
+    std::queue<ArrowArrayPrefetchTask> m_oQueueArrowArrayPrefetchTasks{};
+
+    // Used when m_nIsCompatOfOptimizedGetNextArrowArray == FALSE
     std::thread         m_oThreadNextArrowArray{};
     std::unique_ptr<OGRGPKGTableLayerFillArrowArray> m_poFillArrowArray{};
     std::unique_ptr<GDALGeoPackageDataset> m_poOtherDS{};
-    struct ArrowArray*  m_psNextArrayArray = nullptr;
+
     virtual int GetNextArrowArray(struct ArrowArrayStream*,
                                    struct ArrowArray* out_array) override;
     int                 GetNextArrowArrayInternal(struct ArrowArray* out_array);


### PR DESCRIPTION
… tables with FID without holes and when no filters are applied (full bulk loading)

The previous optimization was limited to just one worker thread. Now it can use as many threads as specified with the GDAL_NUM_THREADS configuration option. Its default value will be
min(4, number_of_available_cpus) like for the Parquet driver.

Timings on the nz-building-outlines.gpkg dataset converted from https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.parquet with the bench_ogr_batch utility that iterates over the whole layer, doing nothing else than retrieving the ArrowArray batches.

GeoPackage file: size 1.6 GB (3.3 million records)

| Number of threads | Time (s) |
| ------------- | ------------- |
|        1	    |  2.100   |
|        2          |  1.380   |
|        4          |  0.810   |
|        6          |  0.700   |
|       12          |  0.655   |

to be compared with GeoParquet one: size 430 MB (3.3 million records)

| Number of threads | Time (s) |
| ------------- | ------------- |
|        1	    |  1.610   |
|        2	    |  1.120   |
|        4	    |  1.030   |
|        6	    |  0.990   |
|       12	    |  1.010   |

Run on a Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz, 6 cores hyper-threaded (12 vCPUs)
