### PR TITLE
[Backport release/3.6] VDV: make creation of temporary .gpkg files more robust on some platforms

### DIFF
--- a/autotest/ogr/ogr_vdv.py
+++ b/autotest/ogr/ogr_vdv.py
@@ -82,10 +82,6 @@ def test_ogr_idf_1_with_temp_sqlite_db():
     if ogr.GetDriverByName("SQLite") is None:
         pytest.skip()
     options = {"OGR_IDF_TEMP_DB_THRESHOLD": "0"}
-    if sys.platform == "darwin":
-        # Otherwise we get a failure with system's sqlite 3.32.3 of Big Sur
-        # when chaining ogr_sqlite.py and ogr_vdv.py
-        options["OGR_IDF_DELETE_TEMP_DB"] = "NO"
     with gdaltest.config_options(options):
         return test_ogr_idf_1()
 


### PR DESCRIPTION
Backport #6740
 **Authored by:** @rouault