### PR TITLE
[Backport release/3.6] CSV: accept comma as decimal separator in X_POSSIBLE_NAMES, Y_POSSIBLE_NAMES and Z_POSSIBLE_NAMES fields

### DIFF
--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -1872,8 +1872,8 @@ def test_ogr_csv_37():
     gdal.FileFromMemBuffer(
         "/vsimem/ogr_csv_37.csv",
         """id,y,other,x,z
-1,49,a,2,100
-2,50,b,3,
+1,49,a,2,"100,5"
+2,"50,5",b,"3,5",
 3,49,c,
 4,0,d,0,0
 """,
@@ -1892,12 +1892,12 @@ def test_ogr_csv_37():
         or f["x"] != 2
         or f["y"] != 49
         or f["other"] != "a"
-        or f["z"] != "100"
+        or f["z"] != "100,5"
     ):
         f.DumpReadable()
         pytest.fail()
     f = lyr.GetNextFeature()
-    if f.GetGeometryRef().ExportToWkt() != "POINT (3 50)":
+    if f.GetGeometryRef().ExportToWkt() != "POINT (3.5 50.5)":
         f.DumpReadable()
         pytest.fail()
     f = lyr.GetNextFeature()
@@ -1923,17 +1923,17 @@ def test_ogr_csv_37():
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     if (
-        f.GetGeometryRef().ExportToWkt() != "POINT (2 49 100)"
+        f.GetGeometryRef().ExportToWkt() != "POINT (2 49 100.5)"
         or f["id"] != "1"
         or f["x"] != 2
         or f["y"] != 49
         or f["other"] != "a"
-        or f["z"] != 100
+        or f["z"] != 100.5
     ):
         f.DumpReadable()
         pytest.fail()
     f = lyr.GetNextFeature()
-    if f.GetGeometryRef().ExportToWkt() != "POINT (3 50)":
+    if f.GetGeometryRef().ExportToWkt() != "POINT (3.5 50.5)":
         f.DumpReadable()
         pytest.fail()
     f = lyr.GetNextFeature()


### PR DESCRIPTION
Backport #6756
 **Authored by:** @rouault