### PR TITLE
[Backport release/3.6] Warper: use exact coordinate transformer on source raster edges to avoid missing pixels (fixes #6777)

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1765,7 +1765,7 @@ def test_warp_55():
 
     ds = gdal.Open("data/warpedvrt_with_ovr.vrt")
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
-    assert cs == 25128
+    assert cs == 25478
     ds = None
 
 

--- a/autotest/gdrivers/mbtiles.py
+++ b/autotest/gdrivers/mbtiles.py
@@ -609,7 +609,7 @@ def test_mbtiles_10():
 
     ds = gdal.Open("/vsimem/mbtiles_10.mbtiles")
     cs = ds.GetRasterBand(1).Checksum()
-    assert cs in (29925, 30092, 29957)  # 30092 on Mac, 29957 on Mac / Conda
+    assert cs == pytest.approx(30000, abs=200)
     ds = None
 
     gdal.Unlink("/vsimem/mbtiles_10.mbtiles")

--- a/autotest/utilities/test_gdal_viewshed.py
+++ b/autotest/utilities/test_gdal_viewshed.py
@@ -140,7 +140,7 @@ def test_gdal_viewshed_alternative_modes():
     ds = None
     gdal.Unlink(viewshed_in)
     gdal.Unlink(viewshed_out)
-    assert cs == 8364
+    assert cs == 8381
     assert nodata is None
 
 
@@ -170,7 +170,7 @@ def test_gdal_viewshed_api():
         options=["UNUSED=YES"],
     )
     gdal.Unlink(viewshed_in)
-    assert ds.GetRasterBand(1).Checksum() == 8364
+    assert ds.GetRasterBand(1).Checksum() == 8381
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -582,7 +582,7 @@ def test_gdalwarp_24():
     ds = gdal.Open("tmp/testgdalwarp24dst.tif")
     assert ds is not None
 
-    assert ds.GetRasterBand(1).Checksum() == 50634, "Bad checksum"
+    assert ds.GetRasterBand(1).Checksum() == 50683, "Bad checksum"
 
     ds = None
 


### PR DESCRIPTION
Backport #6780
 **Authored by:** @rouault