### PR TITLE
autotest/conftest.py: add collect_ignore_glob to ignore pymod/ files

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -23,6 +23,7 @@ collect_ignore = [
     "gdrivers/generate_bag.py",
     "gdrivers/generate_fits.py",
 ]
+collect_ignore_glob = ["pymod/*.py"]
 
 # we set ECW to not resolve projection and datum strings to get 3.x behavior.
 gdal.SetConfigOption("ECW_DO_NOT_RESOLVE_DATUM_PROJECTION", "YES")


### PR DESCRIPTION
For some reason, it doesn't seem the ``testpaths`` setting of pytest.ini is honoured as expected when running ``pytest autotest`` from the build directory (at least on Linux)
