### PR TITLE
MSSQLSPATIAL: Get UID and PWD from environment variable

### DIFF
--- a/doc/source/drivers/vector/mssqlspatial.rst
+++ b/doc/source/drivers/vector/mssqlspatial.rst
@@ -59,7 +59,7 @@ The connection may contain the optional **Driver** parameter if a custom
 SQL server driver should be loaded (like FreeTDS). The default is **{SQL
 Server}**.
 
-Authentication is supported either through a **TrustedConnection** or
+Authentication is supported either through a **trusted_conection** or
 through username (**UID**) and password (**PWD**). As providing username
 and password on the commandline can be a security issue, login credentials
 can also be more securely stored in user defined environment variables

--- a/doc/source/drivers/vector/mssqlspatial.rst
+++ b/doc/source/drivers/vector/mssqlspatial.rst
@@ -57,7 +57,13 @@ to select the proper database.
 
 The connection may contain the optional **Driver** parameter if a custom
 SQL server driver should be loaded (like FreeTDS). The default is **{SQL
-Server}**
+Server}**.
+
+Authentication is supported either through a **TrustedConnection** or
+through username (**UID**) and password (**PWD**). As providing username
+and password on the commandline can be a security issue, login credentials
+can also be more securely stored in user defined environment variables
+*MSSQLSPATIAL_UID* and *MSSQLSPATIAL_PWD*.
 
 Layers
 ------
@@ -208,3 +214,11 @@ Connecting with username/password
    ::
    
       ogrinfo -al   MSSQL:server=.\MSSQLSERVER2008;database=geodb;trusted_connection=no;UID=user;PWD=pwd
+
+Connecting with username/password stored in environment variables
+
+   ::
+   
+      export MSSQLSPATIAL_UID=user
+      export MSSQLSPATIAL_PWD=pwd
+      ogrinfo -al   MSSQL:server=.\MSSQLSERVER2008;database=geodb;trusted_connection=no

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -866,8 +866,10 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
 
     if ( pszUID == nullptr )
     {
-        pszUID = getenv("MSSQLSPATIAL_UID");
-        }
+        const char* pszUIDConst = CPLGetConfigOption("MSSQLSPATIAL_UID", nullptr);
+        if( pszUIDConst )
+            pszUID = CPLStrdup(pszUIDConst);
+    }
     if ( pszUID != nullptr )
     {
         char* pszConnectionName2 = pszConnectionName;

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -878,7 +878,9 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
     }
     if ( pszPWD == nullptr )
     {
-        pszPWD = getenv("MSSQLSPATIAL_PWD");
+        const char* pszPWDConst = CPLGetConfigOption("MSSQLSPATIAL_PWD", nullptr);
+        if( pszPWDConst )
+            pszPWD = CPLStrdup(pszPWDConst);
     }
     if ( pszPWD != nullptr)
     {

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -692,7 +692,6 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
     char* pszDriver = nullptr;
     char* pszUID = nullptr;
     char* pszPWD = nullptr;
-    char* pszTrustedConnection = nullptr;
     int nCurrent, nNext, nTerm;
     nCurrent = nNext = nTerm = static_cast<int>(strlen(pszConnectionName));
 
@@ -725,10 +724,6 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
             nCurrent, nNext, nTerm, FALSE))
             continue;
 
-        if (ParseValue(&pszTrustedConnection, pszConnectionName, "trustedconnection=",
-            nCurrent, nNext, nTerm, FALSE))
-            continue;
-
         if (ParseValue(&pszGeometryFormat, pszConnectionName,
             "geometryformat=", nCurrent, nNext, nTerm, TRUE))
         {
@@ -752,7 +747,6 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
                 CPLFree(pszDriver);
                 CPLFree(pszUID);
                 CPLFree(pszPWD);
-                CPLFree(pszTrustedConnection);
                 return FALSE;
             }
 
@@ -774,7 +768,6 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
         CPLFree(pszDriver);
         CPLFree(pszUID);
         CPLFree(pszPWD);
-        CPLFree(pszTrustedConnection);
         return FALSE;
     }
 
@@ -889,6 +882,9 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
         CPLFree(pszConnectionName2);
     }
 
+    CPLFree(pszUID);
+    CPLFree(pszPWD);
+
     /* Initialize the SQL Server connection. */
     if( !oSession.EstablishSession( pszConnectionName, "", "" ) )
     {
@@ -933,9 +929,6 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
         CSLDestroy( papszSRTexts );
         CPLFree(pszGeometryFormat);
         CPLFree(pszConnectionName);
-        CPLFree(pszUID);
-        CPLFree(pszPWD);
-        CPLFree(pszTrustedConnection);
         return FALSE;
     }
 

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -866,24 +866,24 @@ int OGRMSSQLSpatialDataSource::Open( const char * pszNewName, bool bUpdate,
 
     if ( pszUID == nullptr )
     {
-		pszUID = getenv("MSSQLSPATIAL_UID");
-		}
-	if ( pszUID != nullptr )
-	{
-		char* pszConnectionName2 = pszConnectionName;
-		pszConnectionName = CPLStrdup(CPLSPrintf("%s;UID=%s", pszConnectionName2, pszUID));
-		CPLFree(pszConnectionName2);
-	}
-	if ( pszPWD == nullptr )
-	{
-		pszPWD = getenv("MSSQLSPATIAL_PWD");
-	}
-	if ( pszPWD != nullptr)
-	{
-		char* pszConnectionName2 = pszConnectionName;
-		pszConnectionName = CPLStrdup(CPLSPrintf("%s;PWD=%s", pszConnectionName2, pszPWD));
-		CPLFree(pszConnectionName2);
-	}
+        pszUID = getenv("MSSQLSPATIAL_UID");
+        }
+    if ( pszUID != nullptr )
+    {
+        char* pszConnectionName2 = pszConnectionName;
+        pszConnectionName = CPLStrdup(CPLSPrintf("%s;UID=%s", pszConnectionName2, pszUID));
+        CPLFree(pszConnectionName2);
+    }
+    if ( pszPWD == nullptr )
+    {
+        pszPWD = getenv("MSSQLSPATIAL_PWD");
+    }
+    if ( pszPWD != nullptr)
+    {
+        char* pszConnectionName2 = pszConnectionName;
+        pszConnectionName = CPLStrdup(CPLSPrintf("%s;PWD=%s", pszConnectionName2, pszPWD));
+        CPLFree(pszConnectionName2);
+    }
 
     /* Initialize the SQL Server connection. */
     if( !oSession.EstablishSession( pszConnectionName, "", "" ) )


### PR DESCRIPTION
MS SQL supports only two authentication modes: `TrustedConnection` or username and password given as `UID` and `PWD` in the connection string.
If `TrustedConnection` is not avaialable, login credentials  can be exposed to other users when command line tools (_ogrinfo_ or _ogr2ogr_) are used.

A somewhat more secure way to handle login information, is to store it in environment variables. 

## What does this PR do?
This PR allows the `MSSQLSPATIAL` driver to fetch `UID` and `PWD` from environment variables `MSSQLSPATIAL_UID` and `MSSQLSPATIAL_PWD`, if no other authentication information is provided. That way `UID` and `PWD` do not have to be provided on the command line. 

## Tasklist

 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [x] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Linux
