### PR TITLE
OGRSpatialReference::importFromWkt(): fix compatibilty with PROJ master 9.2.0dev

### DIFF
--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -1953,18 +1953,7 @@ OGRErr OGRSpatialReference::importFromWkt( const char ** ppszInput,
         return OGRERR_CORRUPT_DATA;
 
     // Only accept CRS objects
-    const auto type = d->m_pjType;
-    if( type != PJ_TYPE_GEODETIC_CRS &&
-        type != PJ_TYPE_GEOCENTRIC_CRS &&
-        type != PJ_TYPE_GEOGRAPHIC_2D_CRS &&
-        type != PJ_TYPE_GEOGRAPHIC_3D_CRS &&
-        type != PJ_TYPE_VERTICAL_CRS &&
-        type != PJ_TYPE_PROJECTED_CRS &&
-        type != PJ_TYPE_COMPOUND_CRS &&
-        type != PJ_TYPE_TEMPORAL_CRS &&
-        type != PJ_TYPE_ENGINEERING_CRS &&
-        type != PJ_TYPE_BOUND_CRS &&
-        type != PJ_TYPE_OTHER_CRS )
+    if( !proj_is_crs(d->m_pj_crs) )
     {
         Clear();
         return OGRERR_CORRUPT_DATA;


### PR DESCRIPTION
https://github.com/OSGeo/PROJ/pull/3488 added a PJ_TYPE_DERIVED_PROJECTED_CRS value to the PJ_TYPE enumeration that we didn't test obviously. But better just use proj_is_crs() to be more robust.
