### PR TITLE
FlatGeobuf: decrease memory usage when inserting lots of features

### DIFF
--- a/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -97,7 +97,7 @@ class OGRFlatGeobufLayer final : public OGRLayer, public OGRFlatGeobufBaseLayerI
 
         // creation
         bool m_create = false;
-        std::vector<std::shared_ptr<FlatGeobuf::Item>> m_featureItems; // feature item description used to create spatial index
+        std::vector<FeatureItem> m_featureItems; // feature item description used to create spatial index
         bool m_bCreateSpatialIndexAtClose = true;
         bool m_bVerifyBuffers = true;
         VSILFILE *m_poFpWrite = nullptr;

--- a/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -37,6 +37,7 @@
 #include "feature_generated.h"
 #include "packedrtree.h"
 
+#include <deque>
 #include <limits>
 
 class OGRFlatGeobufDataset;
@@ -97,7 +98,7 @@ class OGRFlatGeobufLayer final : public OGRLayer, public OGRFlatGeobufBaseLayerI
 
         // creation
         bool m_create = false;
-        std::vector<FeatureItem> m_featureItems; // feature item description used to create spatial index
+        std::deque<FeatureItem> m_featureItems; // feature item description used to create spatial index
         bool m_bCreateSpatialIndexAtClose = true;
         bool m_bVerifyBuffers = true;
         VSILFILE *m_poFpWrite = nullptr;

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -473,7 +473,16 @@ void OGRFlatGeobufLayer::Create() {
     CPLDebugOnly("FlatGeobuf", "Creating Packed R-tree");
     c = 0;
     try {
-        PackedRTree tree(static_cast<const void*>(m_featureItems.data()), sizeof(FeatureItem), m_featureItems.size(), extent);
+        const auto fillNodeItems = [this](NodeItem* dest)
+        {
+            size_t i = 0;
+            for( const auto& featureItem: m_featureItems )
+            {
+                dest[i] = featureItem.nodeItem;
+                ++i;
+            }
+        };
+        PackedRTree tree(fillNodeItems, m_featureItems.size(), extent);
         CPLDebugOnly("FlatGeobuf", "PackedRTree extent %f, %f, %f, %f", extentVector[0], extentVector[1], extentVector[2], extentVector[3]);
         tree.streamWrite([this, &c] (uint8_t *data, size_t size) { c += VSIFWriteL(data, 1, size, m_poFp); });
     } catch (const std::exception& e) {

--- a/ogr/ogrsf_frmts/flatgeobuf/packedrtree.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/packedrtree.cpp
@@ -269,17 +269,12 @@ PackedRTree::PackedRTree(const void *data, const uint64_t numItems, const uint16
     fromData(data);
 }
 
-PackedRTree::PackedRTree(const void *itemsWithStride, size_t stride, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize) :
+PackedRTree::PackedRTree(std::function<void(NodeItem *)> fillNodeItems, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize) :
     _extent(extent),
     _numItems(numItems)
 {
     init(nodeSize);
-    auto buf = static_cast<const uint8_t *>(itemsWithStride);
-    for (uint64_t i = 0; i < _numItems; i++) {
-        const NodeItem& n = *reinterpret_cast<const NodeItem *>(buf);
-        buf += stride;
-        _nodeItems[_numNodes - _numItems + i] = n;
-    }
+    fillNodeItems(_nodeItems + _numNodes - _numItems);
     generateNodes();
 }
 

--- a/ogr/ogrsf_frmts/flatgeobuf/packedrtree.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/packedrtree.cpp
@@ -142,22 +142,6 @@ uint32_t hilbert(const NodeItem &r, uint32_t hilbertMax, const double minX, cons
     return v;
 }
 
-const uint32_t hilbertMax = (1 << 16) - 1;
-
-void hilbertSort(std::vector<std::shared_ptr<Item>> &items)
-{
-    NodeItem extent = calcExtent(items);
-    const double minX = extent.minX;
-    const double minY = extent.minY;
-    const double width = extent.width();
-    const double height = extent.height();
-    std::sort(items.begin(), items.end(), [minX, minY, width, height] (std::shared_ptr<Item> a, std::shared_ptr<Item> b) {
-        uint32_t ha = hilbert(a->nodeItem, hilbertMax, minX, minY, width, height);
-        uint32_t hb = hilbert(b->nodeItem, hilbertMax, minX, minY, width, height);
-        return ha > hb;
-    });
-}
-
 void hilbertSort(std::vector<NodeItem> &items)
 {
     NodeItem extent = calcExtent(items);
@@ -166,8 +150,8 @@ void hilbertSort(std::vector<NodeItem> &items)
     const double width = extent.width();
     const double height = extent.height();
     std::sort(items.begin(), items.end(), [minX, minY, width, height] (const NodeItem &a, const NodeItem &b) {
-        uint32_t ha = hilbert(a, hilbertMax, minX, minY, width, height);
-        uint32_t hb = hilbert(b, hilbertMax, minX, minY, width, height);
+        uint32_t ha = hilbert(a, HILBERT_MAX, minX, minY, width, height);
+        uint32_t hb = hilbert(b, HILBERT_MAX, minX, minY, width, height);
         return ha > hb;
     });
 }
@@ -283,6 +267,20 @@ PackedRTree::PackedRTree(const void *data, const uint64_t numItems, const uint16
 {
     init(nodeSize);
     fromData(data);
+}
+
+PackedRTree::PackedRTree(const void *itemsWithStride, size_t stride, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize) :
+    _extent(extent),
+    _numItems(numItems)
+{
+    init(nodeSize);
+    auto buf = static_cast<const uint8_t *>(itemsWithStride);
+    for (uint64_t i = 0; i < _numItems; i++) {
+        const NodeItem& n = *reinterpret_cast<const NodeItem *>(buf);
+        buf += stride;
+        _nodeItems[_numNodes - _numItems + i] = n;
+    }
+    generateNodes();
 }
 
 std::vector<SearchResultItem> PackedRTree::search(double minX, double minY, double maxX, double maxY) const

--- a/ogr/ogrsf_frmts/flatgeobuf/packedrtree.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/packedrtree.h
@@ -69,7 +69,32 @@ std::ostream& operator << (std::ostream& os, NodeItem const& value);
 
 uint32_t hilbert(uint32_t x, uint32_t y);
 uint32_t hilbert(const NodeItem &n, uint32_t hilbertMax, const double minX, const double minY, const double width, const double height);
-void hilbertSort(std::vector<std::shared_ptr<Item>> &items);
+
+
+constexpr uint32_t HILBERT_MAX = (1 << 16) - 1;
+
+template<class ITEM_TYPE> NodeItem calcExtent(const std::vector<ITEM_TYPE> &items)
+{
+    return std::accumulate(items.begin(), items.end(), NodeItem::create(0), [] (NodeItem a, const ITEM_TYPE& b) {
+        return a.expand(b.nodeItem);
+    });
+}
+
+template<class ITEM_TYPE> void hilbertSort(std::vector<ITEM_TYPE> &items)
+{
+    NodeItem extent = calcExtent(items);
+    const double minX = extent.minX;
+    const double minY = extent.minY;
+    const double width = extent.width();
+    const double height = extent.height();
+    std::sort(items.begin(), items.end(), [minX, minY, width, height] (ITEM_TYPE& a, ITEM_TYPE& b) {
+        uint32_t ha = hilbert(a.nodeItem, HILBERT_MAX, minX, minY, width, height);
+        uint32_t hb = hilbert(b.nodeItem, HILBERT_MAX, minX, minY, width, height);
+        return ha > hb;
+    });
+}
+
+
 void hilbertSort(std::vector<NodeItem> &items);
 NodeItem calcExtent(const std::vector<std::shared_ptr<Item>> &items);
 NodeItem calcExtent(const std::vector<NodeItem> &rects);
@@ -95,6 +120,7 @@ public:
     }
     PackedRTree(const std::vector<std::shared_ptr<Item>> &items, const NodeItem &extent, const uint16_t nodeSize = 16);
     PackedRTree(const std::vector<NodeItem> &nodes, const NodeItem &extent, const uint16_t nodeSize = 16);
+    PackedRTree(const void *itemsWithStride, size_t stride, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize = 16);
     PackedRTree(const void *data, const uint64_t numItems, const uint16_t nodeSize = 16);
     std::vector<SearchResultItem> search(double minX, double minY, double maxX, double maxY) const;
     static std::vector<SearchResultItem> streamSearch(

--- a/ogr/ogrsf_frmts/flatgeobuf/packedrtree.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/packedrtree.h
@@ -32,6 +32,7 @@
 #define FLATGEOBUF_PACKEDRTREE_H_
 
 #include <cmath>
+#include <deque>
 #include <numeric>
 
 #include "flatbuffers/flatbuffers.h"
@@ -73,14 +74,14 @@ uint32_t hilbert(const NodeItem &n, uint32_t hilbertMax, const double minX, cons
 
 constexpr uint32_t HILBERT_MAX = (1 << 16) - 1;
 
-template<class ITEM_TYPE> NodeItem calcExtent(const std::vector<ITEM_TYPE> &items)
+template<class ITEM_TYPE> NodeItem calcExtent(const std::deque<ITEM_TYPE> &items)
 {
     return std::accumulate(items.begin(), items.end(), NodeItem::create(0), [] (NodeItem a, const ITEM_TYPE& b) {
         return a.expand(b.nodeItem);
     });
 }
 
-template<class ITEM_TYPE> void hilbertSort(std::vector<ITEM_TYPE> &items)
+template<class ITEM_TYPE> void hilbertSort(std::deque<ITEM_TYPE> &items)
 {
     NodeItem extent = calcExtent(items);
     const double minX = extent.minX;
@@ -120,8 +121,8 @@ public:
     }
     PackedRTree(const std::vector<std::shared_ptr<Item>> &items, const NodeItem &extent, const uint16_t nodeSize = 16);
     PackedRTree(const std::vector<NodeItem> &nodes, const NodeItem &extent, const uint16_t nodeSize = 16);
-    PackedRTree(const void *itemsWithStride, size_t stride, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize = 16);
     PackedRTree(const void *data, const uint64_t numItems, const uint16_t nodeSize = 16);
+    PackedRTree(std::function<void(NodeItem *)> fillNodeItems, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize = 16);
     std::vector<SearchResultItem> search(double minX, double minY, double maxX, double maxY) const;
     static std::vector<SearchResultItem> streamSearch(
         const uint64_t numItems, const uint16_t nodeSize, const NodeItem &item,


### PR DESCRIPTION
should help a bit with https://lists.osgeo.org/pipermail/gdal-dev/2022-November/056534.html

Also speed-up things a bit by avoiding use of shared_ptr<>: from 26 s to 23 s when ogr2ogr from/to FlatGeoBuf with a file of 1.8 GB and 3.3 million features.

CC @bjornharrtell 