### PR TITLE
Fixed build documentation for version 3.6.0 with cmake

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,7 +2,7 @@
 
 This file contains and points to instructions about building GDAL from source.
 
-# Building with cmake (GDAL >= 3.5.0)
+# Building with cmake (GDAL >= 3.6.0)
 
 CMake is the only build system supported since GDAL 3.6.0.
 


### PR DESCRIPTION
## What does this PR do?
Fixes build documentation for version 3.6.0 which uses cmake.