### PR TITLE
[gpkg] Implement relationship creation, deletion and update support

### DIFF
--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -152,6 +152,11 @@ Relationship retrieval is supported, respecting the OGC GeoPackage Related Table
 If the Related Tables Extension is not in use then relationships will be reported for tables
 which utilize FOREIGN KEY constraints.
 
+Relationship creation, deletion and updating is supported since GDAL 3.7. Relationships can
+only be updated to change their base or related table fields, or the relationship related
+table type. It is not permissible to change the base or related table itself, or the mapping
+table details. If this is desired then a new relationship should be created instead.
+
 Dataset open options
 --------------------
 

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -266,6 +266,8 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         void                ClearCachedRelationships();
         void                LoadRelationships() const;
         void                LoadRelationshipsUsingRelatedTablesExtension() const;
+        static std::string  GenerateNameForRelationship(const char* pszBaseTableName,  const char* pszRelatedTableName,  const char* pszType );
+        bool                ValidateRelationship(const GDALRelationship * poRelationship, std::string& failureReason );
 
         bool                m_bIsGeometryTypeAggregateInterrupted = false;
         std::string         m_osGeometryTypeAggregateResult{};
@@ -324,6 +326,15 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
 
         const GDALRelationship* GetRelationship(const std::string& name) const override;
 
+        bool        AddRelationship(std::unique_ptr<GDALRelationship>&& relationship,
+                                    std::string& failureReason) override;
+
+        bool        DeleteRelationship(const std::string& name,
+                                       std::string& failureReason) override;
+
+        bool        UpdateRelationship(std::unique_ptr<GDALRelationship>&& relationship,
+                                       std::string& failureReason) override;
+
         virtual std::pair<OGRLayer*, IOGRSQLiteGetSpatialWhere*> GetLayerWithGetSpatialWhereByName( const char* pszName ) override;
 
         virtual OGRLayer *  ExecuteSQL( const char *pszSQLCommand,
@@ -348,6 +359,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         bool                    HasDataColumnConstraintsTableGPKG_1_0() const;
         bool                CreateColumnsTableAndColumnConstraintsTablesIfNecessary();
         bool                HasGpkgextRelationsTable() const;
+        bool                CreateRelationsTableIfNecessary();
         bool                HasQGISLayerStyles() const;
 
         const char*         GetGeometryTypeString(OGRwkbGeometryType eType);

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -498,6 +498,11 @@ COMPRESSION_OPTIONS
     poDriver->SetMetadataItem( GDAL_DCAP_MULTIPLE_VECTOR_LAYERS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_FIELD_DOMAINS, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_RELATIONSHIPS, "YES" );
+    poDriver->SetMetadataItem( GDAL_DCAP_CREATE_RELATIONSHIP, "YES" );
+    poDriver->SetMetadataItem( GDAL_DCAP_DELETE_RELATIONSHIP, "YES" );
+    poDriver->SetMetadataItem( GDAL_DCAP_UPDATE_RELATIONSHIP, "YES" );
+    poDriver->SetMetadataItem( GDAL_DMD_RELATIONSHIP_FLAGS, "ManyToMany Association" );
+
     poDriver->SetMetadataItem( GDAL_DCAP_RENAME_LAYERS, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATION_FIELD_DOMAIN_TYPES, "Coded Range Glob" );
 

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -858,6 +858,9 @@ int OGROpenFileGDBDataSource::TestCapability( const char * pszCap )
         EQUAL(pszCap, ODsCAddFieldDomain) ||
         EQUAL(pszCap, ODsCDeleteFieldDomain) ||
         EQUAL(pszCap, ODsCUpdateFieldDomain) ||
+        EQUAL(pszCap, GDsCAddRelationship) ||
+        EQUAL(pszCap, GDsCDeleteRelationship) ||
+        EQUAL(pszCap, GDsCUpdateRelationship) ||
         EQUAL(pszCap, ODsCEmulatedTransactions) )
     {
         return eAccess == GA_Update;


### PR DESCRIPTION
Relationships can only be updated to change their base or related table fields, or the relationship related table type. It is not permissible to change the base or related table itself, or the mapping table details. If this is desired then a new relationship should be created instead.
