### PR TITLE
Fixes NITF driver bug that prevents adding subsequent TREs after a HEX TRE (fixes #6827)

### DIFF
--- a/frmts/nitf/nitffile.c
+++ b/frmts/nitf/nitffile.c
@@ -1457,7 +1457,6 @@ static int NITFWriteTREsFromOptions(
     int bIgnoreBLOCKA =
         CSLFetchNameValue(papszOptions,"BLOCKA_BLOCK_COUNT") != NULL;
     int iOption;
-    int nTREPrefixLen = (int)strlen(pszTREPrefix);
     const bool bReserveSpaceForTREOverflow =
         CSLFetchNameValue(papszOptions,"RESERVE_SPACE_FOR_TRE_OVERFLOW") != NULL;
 
@@ -1472,6 +1471,7 @@ static int NITFWriteTREsFromOptions(
         int  nContentLength;
         const char* pszSpace;
         int bIsHex = FALSE;
+        int nTREPrefixLen = (int)strlen(pszTREPrefix);
 
         if( !EQUALN(papszOptions[iOption], pszTREPrefix, nTREPrefixLen) )
             continue;


### PR DESCRIPTION
## What does this PR do?

There was a bug in nitffile.c in method NITFWriteTREsFromOptions. In this method there is a loop. Within this loop, is a string compare method that accepts the length to compare. This string compare method is used to filter out options that do not have the correct prefix by `continue`-ing the loop (in our case the prefix is TRE=). The string compare length variable is initialized prior to the loop (in our case 4), but once a hex string is passed in, this length is increased by 4. On the next iteration of the loop, this string comparison length is not reset to the original value so all subsequent TREs are filtered out because the string comparison fails (incorrectly).  This commit fixes that issue.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/6827

## Tasklist

 - [X] Fixed bug in nitffile.c / NITFWriteTREsFromOptions
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Ubuntu 20.04
* Compiler: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0 / g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
