### PR TITLE
Do not advertise the KML driver as supporting feature styling

### DIFF
--- a/ogr/ogrsf_frmts/kml/ogrkmldriver.cpp
+++ b/ogr/ogrsf_frmts/kml/ogrkmldriver.cpp
@@ -161,7 +161,6 @@ void RegisterOGRKML()
     poDriver->SetMetadataItem( GDAL_DCAP_VIRTUALIO, "YES" );
     poDriver->SetMetadataItem( GDAL_DMD_CREATIONFIELDDATATYPES,
                                "Integer Real String" );
-    poDriver->SetMetadataItem( GDAL_DCAP_FEATURE_STYLES, "YES" );
     poDriver->SetMetadataItem( GDAL_DCAP_MULTIPLE_VECTOR_LAYERS, "YES" );
 
     poDriver->pfnOpen = OGRKMLDriverOpen;


### PR DESCRIPTION
## What does this PR do?

Fixes what I assume might have been a wrong assumption when adding feature styling metadata to various vector drivers in this commit (https://github.com/OSGeo/gdal/commit/23e085223024d6e033d1d315ddbffe27be4b3751): contrary to LIBKML, the KML driver does not support feature styling.

@nyalldawson , as discussed.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
