### PR TITLE
[Backport release/3.6] Python bindings: make Geometry.__str__() use ExportToIsoWkt() (fixes #6842)

### DIFF
--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -840,16 +840,19 @@ def test_ogr_geom_segmentize():
         )
         == 0
     )
+    assert str(geom) == geom.ExportToIsoWkt()
 
     # 2D + M
     geom = ogr.CreateGeometryFromWkt("LINESTRING M(0 0 1,0 10 2)")
     geom.Segmentize(5)
     assert geom.ExportToIsoWkt() == "LINESTRING M (0 0 1,0 5 2,0 10 2)"
+    assert str(geom) == geom.ExportToIsoWkt()
 
     # 2D + ZM
     geom = ogr.CreateGeometryFromWkt("LINESTRING ZM(0 0 1 2,0 10 1 2)")
     geom.Segmentize(5)
     assert geom.ExportToIsoWkt() == "LINESTRING ZM (0 0 1 2,0 5 1 2,0 10 1 2)"
+    assert str(geom) == geom.ExportToIsoWkt()
 
     # Test distance between points <<<< segmentization threshold
     # https://github.com/OSGeo/gdal/issues/1414

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -649,7 +649,7 @@
     self.thisown = 0
 
   def __str__(self):
-    return self.ExportToWkt()
+    return self.ExportToIsoWkt()
 
   def __copy__(self):
     return self.Clone()

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -6796,7 +6796,7 @@ class Geometry(object):
       self.thisown = 0
 
     def __str__(self):
-      return self.ExportToWkt()
+      return self.ExportToIsoWkt()
 
     def __copy__(self):
       return self.Clone()


### PR DESCRIPTION
Backport #6844
 **Authored by:** @rouault