### PR TITLE
ogr2ogr: discard features whose intersection with -clipsrc/-clipdst result …

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5053,12 +5053,30 @@ int LayerTranslator::Translate( OGRFeature* poFeatureIn,
                 if (m_poClipSrc)
                 {
                     OGRGeometry* poClipped = poDstGeometry->Intersection(m_poClipSrc);
-                    delete poDstGeometry;
                     if (poClipped == nullptr || poClipped->IsEmpty())
                     {
+                        delete poDstGeometry;
                         delete poClipped;
                         goto end_loop;
                     }
+
+                    const int nDim = poDstGeometry->getDimension();
+                    if (poClipped->getDimension() < nDim &&
+                        wkbFlatten(poDstFDefn->GetGeomFieldDefn(iGeom)->GetType()) != wkbUnknown)
+                    {
+                        CPLDebug("OGR2OGR",
+                                 "Discarding feature " CPL_FRMT_GIB " of layer %s, "
+                                 "as its intersection with -clipsrc is a %s "
+                                 "whereas the input is a %s",
+                                 nSrcFID, poSrcLayer->GetName(),
+                                 OGRToOGCGeomType(poClipped->getGeometryType()),
+                                 OGRToOGCGeomType(poDstGeometry->getGeometryType()));
+                        delete poDstGeometry;
+                        delete poClipped;
+                        goto end_loop;
+                    }
+
+                    delete poDstGeometry;
                     poDstGeometry = poClipped;
                 }
 
@@ -5107,13 +5125,30 @@ int LayerTranslator::Translate( OGRFeature* poFeatureIn,
                     if (m_poClipDst)
                     {
                         OGRGeometry* poClipped = poDstGeometry->Intersection(m_poClipDst);
-                        delete poDstGeometry;
                         if (poClipped == nullptr || poClipped->IsEmpty())
                         {
+                            delete poDstGeometry;
                             delete poClipped;
                             goto end_loop;
                         }
 
+                        const int nDim = poDstGeometry->getDimension();
+                        if (poClipped->getDimension() < nDim &&
+                            wkbFlatten(poDstFDefn->GetGeomFieldDefn(iGeom)->GetType()) != wkbUnknown)
+                        {
+                            CPLDebug("OGR2OGR",
+                                     "Discarding feature " CPL_FRMT_GIB " of layer %s, "
+                                     "as its intersection with -clipdst is a %s "
+                                     "whereas the input is a %s",
+                                     nSrcFID, poSrcLayer->GetName(),
+                                     OGRToOGCGeomType(poClipped->getGeometryType()),
+                                     OGRToOGCGeomType(poDstGeometry->getGeometryType()));
+                            delete poDstGeometry;
+                            delete poClipped;
+                            goto end_loop;
+                        }
+
+                        delete poDstGeometry;
                         poDstGeometry = poClipped;
                     }
 

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -1058,3 +1058,49 @@ def test_ogr2ogr_lib_spat_srs_geographic():
     )
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 1
+
+
+###############################################################################
+# Test -clipsrc and intersection being of a lower dimensionality
+
+
+def test_ogr2ogr_lib_clipsrc_discard_lower_dimensionality():
+
+    if not ogrtest.have_geos():
+        pytest.skip("GEOS is not available")
+
+    srcDS = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    srcLayer = srcDS.CreateLayer("test", srs=srs, geom_type=ogr.wkbLineString)
+    f = ogr.Feature(srcLayer.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("LINESTRING(0 0, 1 1)"))
+    srcLayer.CreateFeature(f)
+
+    # Intersection of above geometry with -clipsrc bounding box is a point
+    ds = gdal.VectorTranslate("", srcDS, options="-f Memory -clipsrc -1 -1 0 0")
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 0
+
+
+###############################################################################
+# Test -clipdst and intersection being of a lower dimensionality
+
+
+def test_ogr2ogr_lib_clipdst_discard_lower_dimensionality():
+
+    if not ogrtest.have_geos():
+        pytest.skip("GEOS is not available")
+
+    srcDS = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    srcLayer = srcDS.CreateLayer("test", srs=srs, geom_type=ogr.wkbLineString)
+    f = ogr.Feature(srcLayer.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("LINESTRING(0 0, 1 1)"))
+    srcLayer.CreateFeature(f)
+
+    # Intersection of above geometry with -clipdst bounding box is a point
+    ds = gdal.VectorTranslate("", srcDS, options="-f Memory -clipdst -1 -1 0 0")
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 0


### PR DESCRIPTION
…in a lower dimensionality geometry than the target layer geometry type (refs #6836)
