### PR TITLE
[Backport release/3.6] ogr2ogr: add warning when -t_srs is ignored by drivers that automatically reproject to WGS 84 (fixes #6859)

### DIFF
--- a/doc/source/drivers/vector/geojsonseq.rst
+++ b/doc/source/drivers/vector/geojsonseq.rst
@@ -19,6 +19,9 @@ Sequences)
 Such files are equivalent to a GeoJSON FeatureCollection, but are more
 friendly for incremental parsing.
 
+The driver automatically reprojects geometries to WGS84 longitude, latitude,
+if the layer is created with another SRS.
+
 Appending to an existing file is supported since GDAL 3.6
 
 Driver capabilities


### PR DESCRIPTION
Backport #6863
 **Authored by:** @rouault