### PR TITLE
ogr/ogr_feature.h Make implicit sign conversion in  size() functions of classes GetFields() and GetGeomFields() explicit

### DIFF
--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -333,7 +333,7 @@ class CPL_DLL OGRFeatureDefn
         inline ConstIterator begin() { return ConstIterator(m_poFDefn, 0); }
         inline ConstIterator end() { return ConstIterator(m_poFDefn, m_poFDefn->GetFieldCount()); }
 
-        inline size_t size() const { return m_poFDefn->GetFieldCount(); }
+        inline size_t size() const { return static_cast<std::size_t>(m_poFDefn->GetFieldCount()); }
         inline OGRFieldDefn* operator[](size_t i) { return m_poFDefn->GetFieldDefn(static_cast<int>(i)); }
         inline const OGRFieldDefn* operator[](size_t i) const { return m_poFDefn->GetFieldDefn(static_cast<int>(i)); }
     };
@@ -400,7 +400,7 @@ class CPL_DLL OGRFeatureDefn
         inline ConstIterator begin() { return ConstIterator(m_poFDefn, 0); }
         inline ConstIterator end() { return ConstIterator(m_poFDefn, m_poFDefn->GetGeomFieldCount()); }
 
-        inline size_t size() const { return m_poFDefn->GetGeomFieldCount(); }
+        inline size_t size() const { return static_cast<std::size_t>(m_poFDefn->GetGeomFieldCount()); }
         inline OGRGeomFieldDefn* operator[](size_t i) { return m_poFDefn->GetGeomFieldDefn(static_cast<int>(i)); }
         inline const OGRGeomFieldDefn* operator[](size_t i) const { return m_poFDefn->GetGeomFieldDefn(static_cast<int>(i)); }
     };


### PR DESCRIPTION
https://github.com/OSGeo/gdal/commit/b0797370a3ed238bc5e74435262c2e889f58fe03
adds two new classes GetFields() and GetGeomFields() for easier C++ iteration.

Unfortunately clang++ -Wsign-conversion is unhappy about the implicit change of signedness in the size() functions. This pull appeases clang++ -Wsign-conversion

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
