### PR TITLE
OAPIF: implement Part 2 / CRS extension, and related enhancements

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -391,6 +391,9 @@ struct TargetLayerInfo
     bool         m_bPreserveFID = false;
     const char  *m_pszCTPipeline = nullptr;
     bool         m_bCanAvoidSetFrom = false;
+    const char*  m_pszSpatSRSDef = nullptr;
+    OGRGeometryH m_hSpatialFilter = nullptr;
+    const char*  m_pszGeomField = nullptr;
 };
 
 struct AssociatedLayers
@@ -4535,6 +4538,10 @@ std::unique_ptr<TargetLayerInfo> SetupTargetLayer::Setup(OGRLayer* poSrcLayer,
         }
     }
 
+    psInfo->m_pszSpatSRSDef = psOptions->pszSpatSRSDef;
+    psInfo->m_hSpatialFilter = psOptions->hSpatialFilter;
+    psInfo->m_pszGeomField = psOptions->pszGeomField;
+
     return psInfo;
 }
 
@@ -4550,7 +4557,8 @@ static bool SetupCT( TargetLayerInfo* psInfo,
                     OGRSpatialReference* poUserSourceSRS,
                     OGRFeature* poFeature,
                     OGRSpatialReference* poOutputSRS,
-                    OGRCoordinateTransformation* poGCPCoordTrans)
+                    OGRCoordinateTransformation* poGCPCoordTrans,
+                    bool bVerboseError )
 {
     OGRLayer    *poDstLayer = psInfo->m_poDstLayer;
     const int nDstGeomFieldCount =
@@ -4602,6 +4610,15 @@ static bool SetupCT( TargetLayerInfo* psInfo,
         }
         if( poSourceSRS == nullptr )
         {
+            if( poFeature == nullptr )
+            {
+                if( bVerboseError )
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Non-null feature expected to set transformation");
+                }
+                return false;
+            }
             OGRGeometry* poSrcGeometry =
                 poFeature->GetGeomFieldRef(iSrcGeomField);
             if( poSrcGeometry )
@@ -4625,7 +4642,52 @@ static bool SetupCT( TargetLayerInfo* psInfo,
                 CPLAssert( nullptr != poOutputSRS );
             }
 
-            if( psInfo->m_apoCT[iGeom] != nullptr &&
+            if( psInfo->m_nFeaturesRead == 0 && !psInfo->m_bPerFeatureCT )
+            {
+                const auto& supportedSRSList = poSrcLayer->GetSupportedSRSList(iGeom);
+                if( !supportedSRSList.empty() )
+                {
+                    const char* const apszOptions[] = { "IGNORE_DATA_AXIS_TO_SRS_AXIS_MAPPING=YES", nullptr };
+                    for( const auto& poSRS: supportedSRSList )
+                    {
+                        if( poSRS->IsSame(poOutputSRS, apszOptions) )
+                        {
+                            OGRSpatialReference oSourceSRSBackup;
+                            if( poSourceSRS )
+                                oSourceSRSBackup = *poSourceSRS;
+                            if( poSrcLayer->SetActiveSRS(iGeom, poSRS.get()) == OGRERR_NONE )
+                            {
+                                CPLDebug("ogr2ogr", "Switching layer active SRS to %s", poSRS->GetName());
+
+                                if( psInfo->m_hSpatialFilter != nullptr &&
+                                    ((psInfo->m_iRequestedSrcGeomField < 0 && iGeom == 0) ||
+                                     (iGeom == psInfo->m_iRequestedSrcGeomField)) )
+                                {
+                                    OGRSpatialReference oSpatSRS;
+                                    oSpatSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+                                    if( psInfo->m_pszSpatSRSDef )
+                                        oSpatSRS.SetFromUserInput( psInfo->m_pszSpatSRSDef );
+                                    ApplySpatialFilter(poSrcLayer,
+                                                       OGRGeometry::FromHandle(psInfo->m_hSpatialFilter),
+                                                       !oSpatSRS.IsEmpty() ? &oSpatSRS :
+                                                           !oSourceSRSBackup.IsEmpty() ? &oSourceSRSBackup : nullptr,
+                                                       psInfo->m_pszGeomField,
+                                                       poOutputSRS);
+                                }
+
+                                bTransform = false;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if( !bTransform )
+            {
+                // do nothing
+            }
+            else if( psInfo->m_apoCT[iGeom] != nullptr &&
                 psInfo->m_apoCT[iGeom]->GetSourceCS() == poSourceSRS )
             {
                 poCT = psInfo->m_apoCT[iGeom].get();
@@ -4799,6 +4861,15 @@ int LayerTranslator::Translate( OGRFeature* poFeatureIn,
 
     bool bRet = true;
     CPLErrorReset();
+
+    bool bSetupCTOK = false;
+    if( m_bTransform && psInfo->m_nFeaturesRead == 0 && !psInfo->m_bPerFeatureCT )
+    {
+        bSetupCTOK = SetupCT( psInfo, poSrcLayer, m_bTransform, m_bWrapDateline,
+                              m_osDateLineOffset, m_poUserSourceSRS,
+                              nullptr, poOutputSRS, m_poGCPCoordTrans, false);
+    }
+
     while( true )
     {
         if( m_nLimit >= 0 && psInfo->m_nFeaturesRead >= m_nLimit )
@@ -4822,11 +4893,11 @@ int LayerTranslator::Translate( OGRFeature* poFeatureIn,
             break;
         }
 
-        if( psInfo->m_nFeaturesRead == 0 || psInfo->m_bPerFeatureCT )
+        if( !bSetupCTOK && (psInfo->m_nFeaturesRead == 0 || psInfo->m_bPerFeatureCT) )
         {
             if( !SetupCT( psInfo, poSrcLayer, m_bTransform, m_bWrapDateline,
                           m_osDateLineOffset, m_poUserSourceSRS,
-                          poFeature.get(), poOutputSRS, m_poGCPCoordTrans) )
+                          poFeature.get(), poOutputSRS, m_poGCPCoordTrans, true) )
             {
                 return false;
             }

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -972,3 +972,14 @@ def test_ogr_mem_upsert_feature():
 
     # Verify that we have created a feature
     assert lyr.GetFeature(1) is not None
+
+
+###############################################################################
+
+
+def test_ogr_mem_get_supported_srs_list():
+
+    ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    lyr = ds.CreateLayer("foo")
+    assert lyr.GetSupportedSRSList() is None
+    assert lyr.SetActiveSRS(0, None) != ogr.OGRERR_NONE

--- a/autotest/ogr/ogr_oapif.py
+++ b/autotest/ogr/ogr_oapif.py
@@ -1625,6 +1625,16 @@ def test_ogr_opaif_crs_and_preferred_crs_open_options():
         assert srs
         assert srs.GetAuthorityCode(None) == "32631"
 
+    json_info = gdal.VectorInfo(ds, format="json", featureCount=False)
+    assert "supportedSRSList" in json_info["layers"][0]["geometryFields"][0]
+    assert len(json_info["layers"][0]["geometryFields"][0]["supportedSRSList"]) == 2
+    assert json_info["layers"][0]["geometryFields"][0]["supportedSRSList"][0] == {
+        "id": {"authority": "EPSG", "code": "32631"}
+    }
+
+    text_info = gdal.VectorInfo(ds, featureCount=False)
+    assert "Supported SRS: EPSG:32631, " in text_info
+
     # Test changing active SRS
     assert lyr.SetActiveSRS(0, supported_srs_list[1]) == ogr.OGRERR_NONE
     assert lyr.SetActiveSRS(0, None) != ogr.OGRERR_NONE

--- a/autotest/ogr/ogr_oapif.py
+++ b/autotest/ogr/ogr_oapif.py
@@ -36,33 +36,30 @@ import webserver
 
 from osgeo import ogr
 
+pytestmark = pytest.mark.require_driver("OAPIF")
+
 ###############################################################################
 # Init
 #
 
 
-def test_ogr_opaif_init():
-
-    gdaltest.opaif_drv = ogr.GetDriverByName("OAPIF")
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
+@pytest.fixture(scope="module", autouse=True)
+def init():
 
     (gdaltest.webserver_process, gdaltest.webserver_port) = webserver.launch(
         handler=webserver.DispatcherHttpHandler
     )
     if gdaltest.webserver_port == 0:
         pytest.skip()
+    yield
+
+    webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)
 
 
 ###############################################################################
 
 
 def test_ogr_opaif_errors():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add("GET", "/oapif/collections", 404)
@@ -142,11 +139,6 @@ def test_ogr_opaif_errors():
 
 
 def test_ogr_opaif_collections_paging():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -177,11 +169,6 @@ def test_ogr_opaif_collections_paging():
 
 
 def test_ogr_opaif_empty_layer_and_user_query_parameters():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -216,11 +203,6 @@ def test_ogr_opaif_empty_layer_and_user_query_parameters():
 
 
 def test_ogr_opaif_open_by_collection_and_legacy_wfs3_prefix():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -255,11 +237,6 @@ def test_ogr_opaif_open_by_collection_and_legacy_wfs3_prefix():
 
 
 def test_ogr_opaif_fc_links_next_geojson():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -344,11 +321,6 @@ def test_ogr_opaif_fc_links_next_geojson():
 
 
 def test_ogr_opaif_id_is_integer():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -424,11 +396,6 @@ def test_ogr_opaif_id_is_integer():
 
 
 def NO_LONGER_USED_test_ogr_opaif_fc_links_next_headers():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -513,11 +480,6 @@ def NO_LONGER_USED_test_ogr_opaif_fc_links_next_headers():
 
 
 def test_ogr_opaif_spatial_filter():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     # Deprecated API
     handler = webserver.SequentialHandler()
@@ -702,11 +664,6 @@ def test_ogr_opaif_spatial_filter():
 
 
 def test_ogr_opaif_get_feature_count():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -801,11 +758,6 @@ def test_ogr_opaif_get_feature_count():
 
 
 def test_ogr_opaif_get_feature_count_from_numberMatched():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -839,11 +791,6 @@ def test_ogr_opaif_get_feature_count_from_numberMatched():
 
 
 def test_ogr_opaif_attribute_filter():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -1105,11 +1052,6 @@ def test_ogr_opaif_attribute_filter():
 
 
 def test_ogr_opaif_schema_from_xml_schema():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -1189,11 +1131,6 @@ def test_ogr_opaif_schema_from_xml_schema():
 
 
 def test_ogr_opaif_schema_from_json_schema():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -1261,11 +1198,6 @@ def test_ogr_opaif_schema_from_json_schema():
 
 
 def test_ogr_opaif_stac_catalog():
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -1332,15 +1264,3 @@ def test_ogr_opaif_stac_catalog():
         f = lyr.GetNextFeature()
         assert f["foo"] == "bar2"
         assert f["asset_my_asset2_href"] == "my_url2"
-
-
-###############################################################################
-
-
-def test_ogr_opaif_cleanup():
-
-    if gdaltest.opaif_drv is None:
-        pytest.skip()
-
-    if gdaltest.webserver_port != 0:
-        webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -5132,6 +5132,128 @@ def test_ogr_wfs_vsimem_wfs200_join_distinct(with_and_without_streaming):
 
 
 ###############################################################################
+# Test GetSupportedSRSList() and SetActiveSRS()
+
+
+def test_ogr_wfs_vsimem_wfs200_supported_crs():
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/test_ogr_wfs_vsimem_wfs200_supported_crs?SERVICE=WFS&REQUEST=GetCapabilities",
+        """<WFS_Capabilities version="2.0.0">
+    <OperationsMetadata>
+        <ows:Operation name="GetFeature">
+            <ows:Parameter name="resultType">
+                <ows:Value>results</ows:Value>
+                <ows:Value>hits</ows:Value>
+            </ows:Parameter>
+        </ows:Operation>
+    </OperationsMetadata>
+    <FeatureTypeList>
+        <FeatureType>
+            <Name>foo:lyr</Name>
+            <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+            <OtherSRS>urn:ogc:def:crs:EPSG::3857</OtherSRS>
+            <OtherSRS>urn:ogc:def:crs:EPSG::4258</OtherSRS>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>-10 40</ows:LowerCorner>
+                <ows:UpperCorner>15 50</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+        </FeatureType>
+    </FeatureTypeList>
+</WFS_Capabilities>
+""",
+    )
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/test_ogr_wfs_vsimem_wfs200_supported_crs?SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=foo:lyr",
+        """<xsd:schema xmlns:foo="http://foo" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://foo">
+  <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://foo/schemas/gml/3.2.1/base/gml.xsd"/>
+  <xsd:complexType name="lyrType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element maxOccurs="1" minOccurs="0" name="str" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="shape" nillable="true" type="gml:PointPropertyType"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="lyr" substitutionGroup="gml:_Feature" type="foo:lyr1Type"/>
+</xsd:schema>
+""",
+    )
+
+    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
+
+    with gdaltest.config_option("OGR_WFS_TRUST_CAPABILITIES_BOUNDS", "YES"):
+        ds = ogr.Open("WFS:/vsimem/test_ogr_wfs_vsimem_wfs200_supported_crs")
+    lyr = ds.GetLayer(0)
+
+    minx, maxx, miny, maxy = lyr.GetExtent()
+    assert (minx, miny, maxx, maxy) == pytest.approx(
+        (-10.0, 40.0, 15.0, 50.0),
+        abs=1e-3,
+    )
+
+    supported_srs_list = lyr.GetSupportedSRSList()
+    assert supported_srs_list is not None
+    assert len(supported_srs_list) == 3
+    assert supported_srs_list[0].GetAuthorityCode(None) == "4326"
+    assert supported_srs_list[1].GetAuthorityCode(None) == "3857"
+    assert supported_srs_list[2].GetAuthorityCode(None) == "4258"
+
+    # Test changing active SRS
+    assert lyr.SetActiveSRS(0, supported_srs_list[1]) == ogr.OGRERR_NONE
+
+    minx, maxx, miny, maxy = lyr.GetExtent()
+    assert (minx, miny, maxx, maxy) == pytest.approx(
+        (-1113194.9079327357, 4865942.279503175, 1669792.3618991035, 6446275.841017161),
+        abs=1e-3,
+    )
+
+    assert lyr.SetActiveSRS(0, supported_srs_list[2]) == ogr.OGRERR_NONE
+    assert lyr.SetActiveSRS(0, None) != ogr.OGRERR_NONE
+    srs_other = osr.SpatialReference()
+    srs_other.ImportFromEPSG(32632)
+    assert lyr.SetActiveSRS(0, srs_other) != ogr.OGRERR_NONE
+
+    getfeatures_response = """<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:foo="http://foo"
+    xmlns:wfs="http://www.opengis.net/wfs/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    numberMatched="unknown" numberReturned="1" timeStamp="2015-01-01T00:00:00.000Z"
+    xsi:schemaLocation="http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd
+                        http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd
+                        http://foo /vsimem/test_ogr_wfs_vsimem_wfs200_supported_crs?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=foo:lyr">
+      <wfs:member>
+        <foo:lyr gml:id="lyr-101">
+          <foo:str>foo</foo:str>
+          <foo:shape><gml:Point srsName="urn:ogc:def:crs:EPSG::4258" gml:id="bla"><gml:pos>49 2</gml:pos></gml:Point></foo:shape>
+        </foo:lyr>
+      </wfs:member>
+</wfs:FeatureCollection>"""
+    gdal.FileFromMemBuffer(
+        "/vsimem/test_ogr_wfs_vsimem_wfs200_supported_crs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=foo:lyr&SRSNAME=urn:ogc:def:crs:EPSG::4258&COUNT=1",
+        getfeatures_response,
+    )
+    gdal.FileFromMemBuffer(
+        "/vsimem/test_ogr_wfs_vsimem_wfs200_supported_crs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=foo:lyr&SRSNAME=urn:ogc:def:crs:EPSG::4258",
+        getfeatures_response,
+    )
+
+    minx, maxx, miny, maxy = lyr.GetExtent()
+    assert (minx, miny, maxx, maxy) == pytest.approx(
+        (-10.0, 40.0, 15.0, 50.0),
+        abs=1e-3,
+    )
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4258"
+    f = lyr.GetNextFeature()
+    assert f is not None
+    assert f.GetGeometryRef().ExportToWkt() == "POINT (2 49)"
+
+
+###############################################################################
 
 
 def test_ogr_wfs_vsimem_cleanup(with_and_without_streaming):

--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -451,7 +451,7 @@ def test_osr_basic_12():
     wkt_2 = osr.GetUserInputAsWKT("WGS84")
     assert (
         wkt_1
-        == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
+        == 'GEOGCS["WGS 84 (CRS84)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH],AUTHORITY["OGC","CRS84"]]'
     )
     assert (
         wkt_2

--- a/data/ogrinfo_output.schema.json
+++ b/data/ogrinfo_output.schema.json
@@ -132,7 +132,34 @@
                       "maxItems": 4
                   }
               },
-              "coordinateSystem": { "$ref": "#/definitions/coordinateSystem" }
+              "coordinateSystem": { "$ref": "#/definitions/coordinateSystem" },
+              "supportedSRSList": {
+                  "type": "array",
+                  "items": {
+                      "oneOf": [
+                          {
+                              "type": "object",
+                              "properties": {
+                                  "id": {
+                                      "type": "object",
+                                      "properties": {
+                                          "authority": { "type": "string" },
+                                          "code": { "type": "string" }
+                                      }
+                                  }
+                              },
+                              "additionalProperties": false
+                          },
+                          {
+                              "type": "object",
+                              "properties": {
+                                  "wkt": { "type": "string" }
+                              },
+                              "additionalProperties": false
+                          }
+                      ]
+                  }
+              }
           },
           "required" : [ "name", "type" ],
           "additionalProperties": false

--- a/doc/source/drivers/vector/oapif.rst
+++ b/doc/source/drivers/vector/oapif.rst
@@ -49,7 +49,7 @@ evaluated on client-side.
 
 Rectangular spatial filtering is forward to the server as well.
 
-SRS support
+CRS support
 -----------
 
 Starting with GDAL 3.7, the driver supports the
@@ -61,6 +61,9 @@ As most all OGR drivers, the OAPIF driver will report the SRS and geometries,
 and expect spatial filters, in the "GIS-friendly" order,
 with longitude/easting first (X component), latitude/northing second (Y component),
 potentially overriding the axis order of the authority.
+
+The CRS of layers can also be controlled with the CRS or PREFERRED_CRS open
+options documented below.
 
 Open options
 ------------
@@ -75,6 +78,14 @@ The following options are available:
    and password to the remote server.
 -  **IGNORE_SCHEMA**\ = YES/NO. (GDAL >= 3.1) Set to YES to ignore the XML
    Schema or JSON schema that may be offered by the server.
+-  **CRS** = string. (GDAL >= 3.7) Set to a CRS identifier, e.g ``EPSG:3067``
+   or ``http://www.opengis.net/def/crs/EPSG/0/3067``, to use as the layer CRS.
+   That CRS must be listed in the lists of CRS supported by the layers of the
+   dataset, otherwise layers not listing it cannot be opened.
+-  **PREFERRED_CRS** = string. (GDAL >= 3.7) Identical to the CRS option, except
+   that if a layer does not list the PREFERRED_CRS in its list of supported CRS,
+   the default CRS (storageCRS when present, otherwise EPSG:4326) will be used.
+   CRS and PREFERRED_CRS option are mutually exclusive.
 
 Examples
 --------

--- a/doc/source/drivers/vector/oapif.rst
+++ b/doc/source/drivers/vector/oapif.rst
@@ -86,6 +86,13 @@ The following options are available:
    that if a layer does not list the PREFERRED_CRS in its list of supported CRS,
    the default CRS (storageCRS when present, otherwise EPSG:4326) will be used.
    CRS and PREFERRED_CRS option are mutually exclusive.
+-  **SERVER_FEATURE_AXIS_ORDER** = AUTHORITY_COMPLIANT/GIS_FRIENDLY.
+   AUTHORITY_COMPLIANT is the default.
+   This option can be set to GIS_FRIENDLY if axis order issue are noticed in
+   features received from the server, indicating that the server does not return
+   them in the axis order mandated by the CRS authority, but in a more traditional
+   "GIS friendly" order, with longitude/easting first, latitude/northing second.
+   Do not set this option unless actual problems arise.
 
 Examples
 --------

--- a/doc/source/drivers/vector/oapif.rst
+++ b/doc/source/drivers/vector/oapif.rst
@@ -49,6 +49,19 @@ evaluated on client-side.
 
 Rectangular spatial filtering is forward to the server as well.
 
+SRS support
+-----------
+
+Starting with GDAL 3.7, the driver supports the
+`OGC API - Features - Part 2: Coordinate Reference Systems by Reference <https://docs.ogc.org/is/18-058/18-058.html>`__
+extension. If a server reports a storageCRS property, that property will be
+used to set the CRS of the OGR layer. Otherwise the default will be OGC:CRS84
+(WGS84 longitude, latitude).
+As most all OGR drivers, the OAPIF driver will report the SRS and geometries,
+and expect spatial filters, in the "GIS-friendly" order,
+with longitude/easting first (X component), latitude/northing second (Y component),
+potentially overriding the axis order of the authority.
+
 Open options
 ------------
 
@@ -176,4 +189,6 @@ See Also
 
 -  `"OGC API - Features - Part 1: Core" Standard
    <http://docs.opengeospatial.org/is/17-069r3/17-069r3.html>`__
+-  `"OGC API - Features - Part 2: Coordinate Reference Systems by Reference" Standard
+   <https://docs.ogc.org/is/18-058/18-058.html>`__
 -  :ref:`WFS (1.0,1.1,2.0) driver documentation <vector.wfs>`

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -695,6 +695,12 @@ OGRErr CPL_DLL OGR_L_DeleteFeature( OGRLayerH, GIntBig ) CPL_WARN_UNUSED_RESULT;
 OGRErr CPL_DLL OGR_L_UpsertFeature( OGRLayerH, OGRFeatureH ) CPL_WARN_UNUSED_RESULT;
 OGRFeatureDefnH CPL_DLL OGR_L_GetLayerDefn( OGRLayerH );
 OGRSpatialReferenceH CPL_DLL OGR_L_GetSpatialRef( OGRLayerH );
+OGRSpatialReferenceH CPL_DLL *OGR_L_GetSupportedSRSList(OGRLayerH hLayer,
+                                                int iGeomField,
+                                                int* pnCount);
+OGRErr CPL_DLL OGR_L_SetActiveSRS(OGRLayerH hLayer,
+                                  int iGeomField,
+                                  OGRSpatialReferenceH hSRS);
 int    CPL_DLL OGR_L_FindFieldIndex( OGRLayerH, const char *, int bExactMatch );
 GIntBig CPL_DLL OGR_L_GetFeatureCount( OGRLayerH, int );
 OGRErr CPL_DLL OGR_L_GetExtent( OGRLayerH, OGREnvelope *, int );

--- a/ogr/ogr_spatialref.h
+++ b/ogr/ogr_spatialref.h
@@ -741,6 +741,13 @@ class CPL_DLL OGRSpatialReference
 
 };
 
+/*! @cond Doxygen_Suppress */
+struct CPL_DLL OGRSpatialReferenceReleaser
+{
+    void operator()(OGRSpatialReference* poSRS) const { if( poSRS ) poSRS->Release();}
+};
+/*! @endcond */
+
 /************************************************************************/
 /*                     OGRCoordinateTransformation                      */
 /*                                                                      */

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -6545,3 +6545,142 @@ OGRGeometryTypeCounter *OGR_L_GetGeometryTypes(OGRLayerH hLayer,
     return OGRLayer::FromHandle(hLayer)->GetGeometryTypes(
         iGeomField, nFlags, *pnEntryCount, pfnProgress, pProgressData);
 }
+
+/************************************************************************/
+/*                    OGRLayer::GetSupportedSRSList()                   */
+/************************************************************************/
+
+/** \brief Get the list of SRS supported.
+ *
+ * The base implementation of this method will return an empty list. Some
+ * drivers (OAPIF, WFS) may return a non-empty list.
+ *
+ * One of the SRS returned may be passed to SetActiveSRS() to change the
+ * active SRS.
+ *
+ * @param iGeomField Geometry field index.
+ * @return list of supported SRS.
+ * @since GDAL 3.7
+ */
+const OGRLayer::GetSupportedSRSListRetType& OGRLayer::GetSupportedSRSList(CPL_UNUSED int iGeomField)
+{
+    static OGRLayer::GetSupportedSRSListRetType empty;
+    return empty;
+}
+
+/************************************************************************/
+/*                    OGR_L_GetSupportedSRSList()                       */
+/************************************************************************/
+
+/** \brief Get the list of SRS supported.
+ *
+ * The base implementation of this method will return an empty list. Some
+ * drivers (OAPIF, WFS) may return a non-empty list.
+ *
+ * One of the SRS returned may be passed to SetActiveSRS() to change the
+ * active SRS.
+ *
+ * @param hLayer Layer.
+ * @param iGeomField Geometry field index.
+ * @param[out] pnCount Number of values in returned array. Must not be null.
+ * @return list of supported SRS, to be freeds with OSRFreeSRSArray(), or nullptr
+ * @since GDAL 3.7
+ */
+OGRSpatialReferenceH* OGR_L_GetSupportedSRSList(OGRLayerH hLayer,
+                                                int iGeomField,
+                                                int* pnCount)
+{
+    VALIDATE_POINTER1( hLayer, "OGR_L_GetSupportedSRSList", nullptr );
+    VALIDATE_POINTER1( pnCount, "OGR_L_GetSupportedSRSList", nullptr );
+
+    const auto& srsList =
+        OGRLayer::FromHandle(hLayer)->GetSupportedSRSList(iGeomField);
+    *pnCount = static_cast<int>(srsList.size());
+    if( srsList.empty() )
+    {
+        return nullptr;
+    }
+    OGRSpatialReferenceH* pahRet = static_cast<OGRSpatialReferenceH*>(
+                CPLMalloc((1 + srsList.size()) * sizeof(OGRSpatialReferenceH)));
+    size_t i = 0;
+    for( const auto& poSRS: srsList )
+    {
+        poSRS->Reference();
+        pahRet[i] = OGRSpatialReference::ToHandle(poSRS.get());
+        ++i;
+    }
+    pahRet[i] = nullptr;
+    return pahRet;
+}
+
+/************************************************************************/
+/*                       OGRLayer::SetActiveSRS()                       */
+/************************************************************************/
+
+/** \brief Change the active SRS.
+ *
+ * The passed SRS must be in the list returned by GetSupportedSRSList()
+ * (the actual pointer may be different, but should be tested as identical
+ * with OGRSpatialReference::IsSame()).
+ *
+ * Changing the active SRS affects:
+ * <ul>
+ * <li>the SRS in which geometries of returned features are expressed,</li>
+ * <li>the SRS in which geometries of passed features (CreateFeature(), SetFeature()) are expressed,</li>
+ * <li>the SRS returned by GetSpatialRef() and GetGeomFieldDefn()->GetSpatialRef(),</li>
+ * <li>the SRS used to interpret SetSpatialFilter() values.</li>
+ * </ul>
+ * This also resets feature reading and the spatial filter.
+ * Note however that this does not modify the storage SRS of the features of
+ * geometries. Said otherwise, this setting is volatile and has no persistent
+ * effects after dataset reopening.
+ *
+ * @param iGeomField Geometry field index.
+ * @param poSRS SRS to use
+ * @return OGRERR_NONE in case of success, or OGRERR_FAILURE if
+ *         the passed SRS is not in GetSupportedSRSList()
+ * @since GDAL 3.7
+ */
+OGRErr OGRLayer::SetActiveSRS(CPL_UNUSED int iGeomField,
+                              CPL_UNUSED const OGRSpatialReference* poSRS)
+{
+    return OGRERR_FAILURE;
+}
+
+/************************************************************************/
+/*                         OGR_L_SetActiveSRS()                         */
+/************************************************************************/
+
+/** \brief Change the active SRS.
+ *
+ * The passed SRS must be in the list returned by GetSupportedSRSList()
+ * (the actual pointer may be different, but should be tested as identical
+ * with OGRSpatialReference::IsSame()).
+ *
+ * Changing the active SRS affects:
+ * <ul>
+ * <li>the SRS in which geometries of returned features are expressed,</li>
+ * <li>the SRS in which geometries of passed features (CreateFeature(), SetFeature()) are expressed,</li>
+ * <li>the SRS returned by GetSpatialRef() and GetGeomFieldDefn()->GetSpatialRef(),</li>
+ * <li>the SRS used to interpret SetSpatialFilter() values.</li>
+ * </ul>
+ * This also resets feature reading and the spatial filter.
+ * Note however that this does not modify the storage SRS of the features of
+ * geometries. Said otherwise, this setting is volatile and has no persistent
+ * effects after dataset reopening.
+ *
+ * @param hLayer Layer.
+ * @param iGeomField Geometry field index.
+ * @param hSRS SRS to use
+ * @return OGRERR_NONE in case of success, OGRERR_FAILURE if
+ *         the passed SRS is not in GetSupportedSRSList().
+ * @since GDAL 3.7
+ */
+OGRErr OGR_L_SetActiveSRS(OGRLayerH hLayer,
+                          int iGeomField,
+                          OGRSpatialReferenceH hSRS)
+{
+    VALIDATE_POINTER1( hLayer, "OGR_L_SetActiveSRS", OGRERR_FAILURE );
+    return OGRLayer::FromHandle(hLayer)->SetActiveSRS(iGeomField,
+                                                      OGRSpatialReference::FromHandle(hSRS));
+}

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -192,6 +192,11 @@ class CPL_DLL OGRLayer : public GDALMajorObject
 
     virtual OGRSpatialReference *GetSpatialRef();
 
+    /** Return type of OGRLayer::GetSupportedSRSList() */
+    typedef std::vector<std::unique_ptr<OGRSpatialReference, OGRSpatialReferenceReleaser>> GetSupportedSRSListRetType;
+    virtual const GetSupportedSRSListRetType& GetSupportedSRSList(int iGeomField);
+    virtual OGRErr      SetActiveSRS(int iGeomField, const OGRSpatialReference* poSRS);
+
     virtual GIntBig     GetFeatureCount( int bForce = TRUE );
     virtual OGRErr      GetExtent(OGREnvelope *psExtent, int bForce = TRUE)  CPL_WARN_UNUSED_RESULT;
     virtual OGRErr      GetExtent(int iGeomField, OGREnvelope *psExtent,

--- a/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
@@ -1309,6 +1309,51 @@ int OGRWFSDataSource::Open( const char * pszFilename, int bUpdateIn,
                 if (pszDefaultSRS == nullptr)
                     pszDefaultSRS = CPLGetXMLValue(psChildIter, "DefaultCRS", nullptr); /* WFS 2.0.0 */
 
+                const CPLXMLNode* psOtherSRS = CPLGetXMLNode(psChildIter, "OtherSRS"); // WFS 1.1
+                if( psOtherSRS == nullptr )
+                    psOtherSRS = CPLGetXMLNode(psChildIter, "OtherCRS"); // WFS 2.0
+
+                std::vector<std::string> aosSupportedCRSList{};
+                OGRLayer::GetSupportedSRSListRetType apoSupportedCRSList;
+                if( psOtherSRS )
+                {
+                    {
+                        auto poSRS = std::unique_ptr<OGRSpatialReference, OGRSpatialReferenceReleaser>(
+                            new OGRSpatialReference());
+                        if( poSRS->SetFromUserInput(pszDefaultSRS,
+                            OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get()) == OGRERR_NONE )
+                        {
+                            aosSupportedCRSList.emplace_back(pszDefaultSRS);
+                            apoSupportedCRSList.emplace_back(std::move(poSRS));
+                        }
+                    }
+                    CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
+                    CPLErrorStateBackuper oErrorStateBackuper;
+                    for( const CPLXMLNode* psIter = psOtherSRS;
+                                            psIter; psIter = psIter->psNext )
+                    {
+                        if( psIter->eType == CXT_Element )
+                        {
+                            const char* pszSRS = CPLGetXMLValue(psIter, "", nullptr);
+                            if( pszSRS )
+                            {
+                                auto poSRS = std::unique_ptr<OGRSpatialReference, OGRSpatialReferenceReleaser>(
+                                    new OGRSpatialReference());
+                                if( poSRS->SetFromUserInput(EQUAL(pszSRS, "CRS:84") ? "OGC:CRS84" : pszSRS,
+                                    OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get()) == OGRERR_NONE )
+                                {
+                                    aosSupportedCRSList.emplace_back(pszSRS);
+                                    apoSupportedCRSList.emplace_back(std::move(poSRS));
+                                }
+                                else
+                                {
+                                    CPLDebug("WFS", "Invalid CRS %s", pszSRS);
+                                }
+                            }
+                        }
+                    }
+                }
+
                 CPLXMLNode* psOutputFormats = CPLGetXMLNode(psChildIter, "OutputFormats");
                 CPLString osOutputFormat;
                 if (psOutputFormats)
@@ -1363,7 +1408,8 @@ int OGRWFSDataSource::Open( const char * pszFilename, int bUpdateIn,
                     !EQUAL(pszDefaultSRS, "urn:ogc:def:crs:EPSG::404000"))
                 {
                     OGRSpatialReference oSRS;
-                    if (oSRS.SetFromUserInput(pszDefaultSRS) == OGRERR_NONE)
+                    if (oSRS.SetFromUserInput(pszDefaultSRS,
+                            OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get()) == OGRERR_NONE)
                     {
                         poSRS = oSRS.Clone();
                         poSRS->SetAxisMappingStrategy(
@@ -1496,6 +1542,7 @@ int OGRWFSDataSource::Open( const char * pszFilename, int bUpdateIn,
                             strcmp(pszProj4, "+proj=longlat +datum=WGS84 +no_defs") == 0) ||
                             strcmp(pszDefaultSRS, "urn:ogc:def:crs:OGC:1.3:CRS84") == 0)
                         {
+                            poLayer->SetWGS84Extents(dfMinX, dfMinY, dfMaxX, dfMaxY);
                             poLayer->SetExtents(dfMinX, dfMinY, dfMaxX, dfMaxY);
                         }
 
@@ -1505,54 +1552,25 @@ int OGRWFSDataSource::Open( const char * pszFilename, int bUpdateIn,
                             oWGS84.SetWellKnownGeogCS("WGS84");
                             oWGS84.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
                             CPLPushErrorHandler(CPLQuietErrorHandler);
-                            OGRCoordinateTransformation* poCT =
+                            auto poCT = std::unique_ptr<OGRCoordinateTransformation>(
                                 OGRCreateCoordinateTransformation(&oWGS84,
-                                                                  poSRS);
+                                                                  poSRS));
                             if( poCT )
                             {
-                                double dfULX = dfMinX;
-                                double dfULY = dfMaxY;
-                                double dfURX = dfMaxX;
-                                double dfURY = dfMaxY;
-                                double dfLLX = dfMinX;
-                                double dfLLY = dfMinY;
-                                double dfLRX = dfMaxX;
-                                double dfLRY = dfMinY;
-                                if (poCT->Transform(1, &dfULX, &dfULY, nullptr) &&
-                                    poCT->Transform(1, &dfURX, &dfURY, nullptr) &&
-                                    poCT->Transform(1, &dfLLX, &dfLLY, nullptr) &&
-                                    poCT->Transform(1, &dfLRX, &dfLRY, nullptr))
-                                {
-                                    dfMinX = dfULX;
-                                    dfMinX = std::min(dfMinX, dfURX);
-                                    dfMinX = std::min(dfMinX, dfLLX);
-                                    dfMinX = std::min(dfMinX, dfLRX);
-
-                                    dfMinY = dfULY;
-                                    dfMinY = std::min(dfMinY, dfURY);
-                                    dfMinY = std::min(dfMinY, dfLLY);
-                                    dfMinY = std::min(dfMinY, dfLRY);
-
-                                    dfMaxX = dfULX;
-                                    dfMaxX = std::max(dfMaxX, dfURX);
-                                    dfMaxX = std::max(dfMaxX, dfLLX);
-                                    dfMaxX = std::max(dfMaxX, dfLRX);
-
-                                    dfMaxY = dfULY;
-                                    dfMaxY = std::max(dfMaxY, dfURY);
-                                    dfMaxY = std::max(dfMaxY, dfLLY);
-                                    dfMaxY = std::max(dfMaxY, dfLRY);
-
-                                    poLayer->SetExtents(dfMinX, dfMinY, dfMaxX, dfMaxY);
-                                }
+                                poLayer->SetWGS84Extents(dfMinX, dfMinY, dfMaxX, dfMaxY);
+                                poCT->TransformBounds(dfMinX, dfMinY, dfMaxX, dfMaxY,
+                                                      &dfMinX, &dfMinY, &dfMaxX, &dfMaxY,
+                                                      20);
+                                poLayer->SetExtents(dfMinX, dfMinY, dfMaxX, dfMaxY);
                             }
-                            delete poCT;
                             CPLPopErrorHandler();
                             CPLErrorReset();
                         }
                     }
                     CPLFree(pszProj4);
                 }
+                poLayer->SetSupportedSRSList(std::move(aosSupportedCRSList),
+                                             std::move(apoSupportedCRSList));
 
                 papoLayers = (OGRWFSLayer **)CPLRealloc(papoLayers,
                                     sizeof(OGRWFSLayer*) * (nLayers + 1));

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -3339,12 +3339,15 @@ OGRErr OGRSpatialReference::SetWellKnownGeogCS( const char * pszName )
              EQUAL(pszName, "CRS:84") )
     {
         pszWKT =
-            "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\","
-            "SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],"
-            "AUTHORITY[\"EPSG\",\"6326\"]],"
-            "PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],"
-            "UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],"
-            "AXIS[\"Longitude\",EAST],AXIS[\"Latitude\",NORTH]]";
+            "GEOGCRS[\"WGS 84 (CRS84)\",DATUM[\"World Geodetic System 1984\","
+            "ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]]],"
+            "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            "CS[ellipsoidal,2],AXIS[\"geodetic longitude (Lon)\",east,ORDER[1],"
+            "ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            "AXIS[\"geodetic latitude (Lat)\",north,ORDER[2],"
+            "ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            "USAGE[SCOPE[\"unknown\"],AREA[\"World\"],BBOX[-90,-180,90,180]],"
+            "ID[\"OGC\",\"CRS84\"]]";
     }
     else if( EQUAL(pszName, "WGS72") )
         pszWKT =
@@ -3800,7 +3803,7 @@ OGRErr OGRSpatialReference::SetFromUserInput( const char * pszDefinition,
         return importFromWMSAUTO( pszDefinition );
 
     // WMS/WCS OGC codes like OGC:CRS84.
-    if( STARTS_WITH_CI(pszDefinition, "OGC:") )
+    if( EQUAL(pszDefinition, "OGC:CRS84") )
         return SetWellKnownGeogCS( pszDefinition+4 );
 
     if( STARTS_WITH_CI(pszDefinition, "CRS:") )

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -1460,6 +1460,20 @@ public:
     }
 #endif
 
+#ifdef SWIGPYTHON
+    %feature( "kwargs" ) GetSupportedSRSList;
+    void GetSupportedSRSList(OGRSpatialReferenceH** ppRet, int* pnEntryCount,
+                             int geom_field = 0)
+    {
+        *ppRet = OGR_L_GetSupportedSRSList(self, geom_field, pnEntryCount);
+    }
+#endif
+
+    OGRErr SetActiveSRS(int geom_field, OSRSpatialReferenceShadow* srs)
+    {
+        return OGR_L_SetActiveSRS(self, geom_field, srs);
+    }
+
 } /* %extend */
 
 

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -187,7 +187,7 @@ OGRErr GetWellKnownGeogCSAsWKT( const char *name, char **argout ) {
   OGRErr rcode = OSRSetWellKnownGeogCS( srs, name );
   if( rcode == OGRERR_NONE )
       rcode = OSRExportToWkt ( srs, argout );
-  OSRDestroySpatialReference( srs );
+  OSRRelease( srs );
   return rcode;
 }
 %}
@@ -201,7 +201,7 @@ OGRErr GetUserInputAsWKT( const char *name, char **argout ) {
   OGRErr rcode = OSRSetFromUserInput( srs, name );
   if( rcode == OGRERR_NONE )
       rcode = OSRExportToWkt ( srs, argout );
-  OSRDestroySpatialReference( srs );
+  OSRRelease( srs );
   return rcode;
 }
 %}
@@ -310,9 +310,7 @@ public:
   }
 
   ~OSRSpatialReferenceShadow() {
-    if (OSRDereference( self ) == 0 ) {
-      OSRDestroySpatialReference( self );
-    }
+    OSRRelease( self );
   }
 
 /* FIXME : all bindings should avoid using the #else case */

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1459,6 +1459,8 @@ def VectorInfoOptions(options=None,
                       deserialize=True,
                       layers=None,
                       dumpFeatures=False,
+                      featureCount=True,
+                      extent=True,
                       SQLStatement=None,
                       SQLDialect=None,
                       where=None,
@@ -1482,6 +1484,10 @@ def VectorInfoOptions(options=None,
             WHERE clause to apply to source layer(s)
         layers:
             list of layers of interest
+        featureCount:
+            whether to compute and display the feature count
+        extent:
+            whether to compute and display the layer extent
         dumpFeatures:
             set to True to get the dump of all features
     """
@@ -1510,6 +1516,10 @@ def VectorInfoOptions(options=None,
             new_options += ['-where', where]
         if wktFormat:
             new_options += ['-wkt_format', wktFormat]
+        if not featureCount:
+            new_options += ['-nocount']
+        if not extent:
+            new_options += ['-noextent']
         if layers:
             new_options += ["dummy_dataset_name"]
             for layer in layers:

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -2917,3 +2917,42 @@ OBJECT_LIST_INPUT(GDALEDTComponentHS)
     /* %typemap(freearg)  (OGRGeometryTypeCounter** ppRet, int* pnEntryCount) */
     VSIFree(*$1);
 }
+
+/***************************************************
+ * Typemaps for Layer.GetSupportedSRSList()
+ ***************************************************/
+%typemap(in,numinputs=0) (OGRSpatialReferenceH** ppRet, int* pnEntryCount) ( OGRSpatialReferenceH* pRet = NULL, int nEntryCount = 0 )
+{
+  /* %typemap(in,numinputs=0) (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
+  $1 = &pRet;
+  $2 = &nEntryCount;
+}
+
+%typemap(argout)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount)
+{
+  /* %typemap(argout)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
+  Py_DECREF($result);
+  int nEntryCount = *($2);
+  OGRSpatialReferenceH* pRet = *($1);
+  if( nEntryCount == 0)
+  {
+    Py_INCREF(Py_None);
+    $result = Py_None;
+  }
+  else
+  {
+    $result = PyList_New(nEntryCount);
+    for(int i = 0; i < nEntryCount; ++ i)
+    {
+      OSRReference(pRet[i]);
+      PyList_SetItem($result, i, SWIG_NewPointerObj(
+          SWIG_as_voidptr(pRet[i]),SWIGTYPE_p_OSRSpatialReferenceShadow, SWIG_POINTER_OWN) );
+    }
+  }
+}
+
+%typemap(freearg)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount)
+{
+    /* %typemap(freearg)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
+    OSRFreeSRSArray(*$1);
+}

--- a/swig/python/extensions/ogr_wrap.cpp
+++ b/swig/python/extensions/ogr_wrap.cpp
@@ -2722,12 +2722,13 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_int swig_types[25]
 #define SWIGTYPE_p_p_GIntBig swig_types[26]
 #define SWIGTYPE_p_p_OGRGeometryTypeCounter swig_types[27]
-#define SWIGTYPE_p_p_char swig_types[28]
-#define SWIGTYPE_p_p_double swig_types[29]
-#define SWIGTYPE_p_p_int swig_types[30]
-#define SWIGTYPE_p_size_t swig_types[31]
-static swig_type_info *swig_types[33];
-static swig_module_info swig_module = {swig_types, 32, 0, 0, 0, 0};
+#define SWIGTYPE_p_p_OGRSpatialReferenceH swig_types[28]
+#define SWIGTYPE_p_p_char swig_types[29]
+#define SWIGTYPE_p_p_double swig_types[30]
+#define SWIGTYPE_p_p_int swig_types[31]
+#define SWIGTYPE_p_size_t swig_types[32]
+static swig_type_info *swig_types[34];
+static swig_module_info swig_module = {swig_types, 33, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4047,6 +4048,12 @@ SWIGINTERN ArrowArrayStream *OGRLayerShadow_GetArrowStream(OGRLayerShadow *self,
   }
 SWIGINTERN void OGRLayerShadow_GetGeometryTypes(OGRLayerShadow *self,OGRGeometryTypeCounter **ppRet,int *pnEntryCount,int geom_field=0,int flags=0,GDALProgressFunc callback=NULL,void *callback_data=NULL){
         *ppRet = OGR_L_GetGeometryTypes(self, geom_field, flags, pnEntryCount, callback, callback_data);
+    }
+SWIGINTERN void OGRLayerShadow_GetSupportedSRSList(OGRLayerShadow *self,OGRSpatialReferenceH **ppRet,int *pnEntryCount,int geom_field=0){
+        *ppRet = OGR_L_GetSupportedSRSList(self, geom_field, pnEntryCount);
+    }
+SWIGINTERN OGRErr OGRLayerShadow_SetActiveSRS(OGRLayerShadow *self,int geom_field,OSRSpatialReferenceShadow *srs){
+        return OGR_L_SetActiveSRS(self, geom_field, srs);
     }
 SWIGINTERN void delete_OGRFeatureShadow(OGRFeatureShadow *self){
     OGR_F_Destroy(self);
@@ -13247,6 +13254,169 @@ fail:
     CPLFree(psProgressInfo);
     
   }
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Layer_GetSupportedSRSList(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  OGRLayerShadow *arg1 = (OGRLayerShadow *) 0 ;
+  OGRSpatialReferenceH **arg2 = (OGRSpatialReferenceH **) 0 ;
+  int *arg3 = (int *) 0 ;
+  int arg4 = (int) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  OGRSpatialReferenceH *pRet2 = NULL ;
+  int nEntryCount2 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"geom_field",  NULL 
+  };
+  
+  {
+    /* %typemap(in,numinputs=0) (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
+    arg2 = &pRet2;
+    arg3 = &nEntryCount2;
+  }
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O:Layer_GetSupportedSRSList", kwnames, &obj0, &obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_OGRLayerShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Layer_GetSupportedSRSList" "', argument " "1"" of type '" "OGRLayerShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< OGRLayerShadow * >(argp1);
+  if (obj1) {
+    ecode4 = SWIG_AsVal_int(obj1, &val4);
+    if (!SWIG_IsOK(ecode4)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "Layer_GetSupportedSRSList" "', argument " "4"" of type '" "int""'");
+    } 
+    arg4 = static_cast< int >(val4);
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      OGRLayerShadow_GetSupportedSRSList(arg1,arg2,arg3,arg4);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_Py_Void();
+  {
+    /* %typemap(argout)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
+    Py_DECREF(resultobj);
+    int nEntryCount = *(arg3);
+    OGRSpatialReferenceH* pRet = *(arg2);
+    if( nEntryCount == 0)
+    {
+      Py_INCREF(Py_None);
+      resultobj = Py_None;
+    }
+    else
+    {
+      resultobj = PyList_New(nEntryCount);
+      for(int i = 0; i < nEntryCount; ++ i)
+      {
+        OSRReference(pRet[i]);
+        PyList_SetItem(resultobj, i, SWIG_NewPointerObj(
+            SWIG_as_voidptr(pRet[i]),SWIGTYPE_p_OSRSpatialReferenceShadow, SWIG_POINTER_OWN) );
+      }
+    }
+  }
+  {
+    /* %typemap(freearg)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
+    OSRFreeSRSArray(*arg2);
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  {
+    /* %typemap(freearg)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
+    OSRFreeSRSArray(*arg2);
+  }
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Layer_SetActiveSRS(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  OGRLayerShadow *arg1 = (OGRLayerShadow *) 0 ;
+  int arg2 ;
+  OSRSpatialReferenceShadow *arg3 = (OSRSpatialReferenceShadow *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject *swig_obj[3] ;
+  OGRErr result;
+  
+  if (!SWIG_Python_UnpackTuple(args, "Layer_SetActiveSRS", 3, 3, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_OGRLayerShadow, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Layer_SetActiveSRS" "', argument " "1"" of type '" "OGRLayerShadow *""'"); 
+  }
+  arg1 = reinterpret_cast< OGRLayerShadow * >(argp1);
+  ecode2 = SWIG_AsVal_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Layer_SetActiveSRS" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3,SWIGTYPE_p_OSRSpatialReferenceShadow, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "Layer_SetActiveSRS" "', argument " "3"" of type '" "OSRSpatialReferenceShadow *""'"); 
+  }
+  arg3 = reinterpret_cast< OSRSpatialReferenceShadow * >(argp3);
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (OGRErr)OGRLayerShadow_SetActiveSRS(arg1,arg2,arg3);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  {
+    /* %typemap(out) OGRErr */
+    if ( result != 0 && bUseExceptions) {
+      const char* pszMessage = CPLGetLastErrorMsg();
+      if( pszMessage[0] != '\0' )
+      PyErr_SetString( PyExc_RuntimeError, pszMessage );
+      else
+      PyErr_SetString( PyExc_RuntimeError, OGRErrMessages(result) );
+      SWIG_fail;
+    }
+  }
+  {
+    /* %typemap(ret) OGRErr */
+    if ( ReturnSame(resultobj == Py_None || resultobj == 0) ) {
+      resultobj = PyInt_FromLong( result );
+    }
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
   return NULL;
 }
 
@@ -32444,6 +32614,8 @@ static PyMethodDef SwigMethods[] = {
 		"    values the corresponding number of geometries of that type in the layer.\n"
 		"\n"
 		""},
+	 { "Layer_GetSupportedSRSList", (PyCFunction)(void(*)(void))_wrap_Layer_GetSupportedSRSList, METH_VARARGS|METH_KEYWORDS, "Layer_GetSupportedSRSList(Layer self, int geom_field=0)"},
+	 { "Layer_SetActiveSRS", _wrap_Layer_SetActiveSRS, METH_VARARGS, "Layer_SetActiveSRS(Layer self, int geom_field, SpatialReference srs) -> OGRErr"},
 	 { "Layer_swigregister", Layer_swigregister, METH_O, NULL},
 	 { "delete_Feature", _wrap_delete_Feature, METH_O, "delete_Feature(Feature self)"},
 	 { "new_Feature", (PyCFunction)(void(*)(void))_wrap_new_Feature, METH_VARARGS|METH_KEYWORDS, "new_Feature(FeatureDefn feature_def) -> Feature"},
@@ -35986,6 +36158,7 @@ static swig_type_info _swigt__p_float = {"_p_float", "float *", 0, 0, (void*)0, 
 static swig_type_info _swigt__p_int = {"_p_int", "OGRFieldSubType *|OSRAxisMappingStrategy *|OGRFieldDomainType *|OGRFieldType *|CPLErr *|int *|OGRwkbGeometryType *|OGRJustification *|OGRAxisOrientation *|OGRFieldDomainSplitPolicy *|OGRFieldDomainMergePolicy *|OGRwkbByteOrder *|OGRErr *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_GIntBig = {"_p_p_GIntBig", "GIntBig **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_OGRGeometryTypeCounter = {"_p_p_OGRGeometryTypeCounter", "OGRGeometryTypeCounter **", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_p_OGRSpatialReferenceH = {"_p_p_OGRSpatialReferenceH", "OGRSpatialReferenceH **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_char = {"_p_p_char", "char **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_double = {"_p_p_double", "double **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_int = {"_p_p_int", "int **", 0, 0, (void*)0, 0};
@@ -36020,6 +36193,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_int,
   &_swigt__p_p_GIntBig,
   &_swigt__p_p_OGRGeometryTypeCounter,
+  &_swigt__p_p_OGRSpatialReferenceH,
   &_swigt__p_p_char,
   &_swigt__p_p_double,
   &_swigt__p_p_int,
@@ -36054,6 +36228,7 @@ static swig_cast_info _swigc__p_float[] = {  {&_swigt__p_float, 0, 0, 0},{0, 0, 
 static swig_cast_info _swigc__p_int[] = {  {&_swigt__p_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_GIntBig[] = {  {&_swigt__p_p_GIntBig, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_OGRGeometryTypeCounter[] = {  {&_swigt__p_p_OGRGeometryTypeCounter, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_OGRSpatialReferenceH[] = {  {&_swigt__p_p_OGRSpatialReferenceH, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_char[] = {  {&_swigt__p_p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_double[] = {  {&_swigt__p_p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_int[] = {  {&_swigt__p_p_int, 0, 0, 0},{0, 0, 0, 0}};
@@ -36088,6 +36263,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_int,
   _swigc__p_p_GIntBig,
   _swigc__p_p_OGRGeometryTypeCounter,
+  _swigc__p_p_OGRSpatialReferenceH,
   _swigc__p_p_char,
   _swigc__p_p_double,
   _swigc__p_p_int,

--- a/swig/python/extensions/osr_wrap.cpp
+++ b/swig/python/extensions/osr_wrap.cpp
@@ -3110,7 +3110,7 @@ OGRErr GetWellKnownGeogCSAsWKT( const char *name, char **argout ) {
   OGRErr rcode = OSRSetWellKnownGeogCS( srs, name );
   if( rcode == OGRERR_NONE )
       rcode = OSRExportToWkt ( srs, argout );
-  OSRDestroySpatialReference( srs );
+  OSRRelease( srs );
   return rcode;
 }
 
@@ -3266,7 +3266,7 @@ OGRErr GetUserInputAsWKT( const char *name, char **argout ) {
   OGRErr rcode = OSRSetFromUserInput( srs, name );
   if( rcode == OGRERR_NONE )
       rcode = OSRExportToWkt ( srs, argout );
-  OSRDestroySpatialReference( srs );
+  OSRRelease( srs );
   return rcode;
 }
 
@@ -3366,9 +3366,7 @@ SWIGINTERN OSRSpatialReferenceShadow *new_OSRSpatialReferenceShadow(char const *
     return (OSRSpatialReferenceShadow*) OSRNewSpatialReference(wkt);
   }
 SWIGINTERN void delete_OSRSpatialReferenceShadow(OSRSpatialReferenceShadow *self){
-    if (OSRDereference( self ) == 0 ) {
-      OSRDestroySpatialReference( self );
-    }
+    OSRRelease( self );
   }
 SWIGINTERN retStringAndCPLFree *OSRSpatialReferenceShadow___str__(OSRSpatialReferenceShadow *self){
     char *buf = 0;

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -313,6 +313,8 @@ def VectorInfoOptions(options=None,
                       deserialize=True,
                       layers=None,
                       dumpFeatures=False,
+                      featureCount=True,
+                      extent=True,
                       SQLStatement=None,
                       SQLDialect=None,
                       where=None,
@@ -336,6 +338,10 @@ def VectorInfoOptions(options=None,
             WHERE clause to apply to source layer(s)
         layers:
             list of layers of interest
+        featureCount:
+            whether to compute and display the feature count
+        extent:
+            whether to compute and display the layer extent
         dumpFeatures:
             set to True to get the dump of all features
     """
@@ -364,6 +370,10 @@ def VectorInfoOptions(options=None,
             new_options += ['-where', where]
         if wktFormat:
             new_options += ['-wkt_format', wktFormat]
+        if not featureCount:
+            new_options += ['-nocount']
+        if not extent:
+            new_options += ['-noextent']
         if layers:
             new_options += ["dummy_dataset_name"]
             for layer in layers:

--- a/swig/python/osgeo/ogr.py
+++ b/swig/python/osgeo/ogr.py
@@ -2204,6 +2204,14 @@ class Layer(MajorObject):
         """
         return _ogr.Layer_GetGeometryTypes(self, *args, **kwargs)
 
+    def GetSupportedSRSList(self, *args, **kwargs) -> "void":
+        r"""GetSupportedSRSList(Layer self, int geom_field=0)"""
+        return _ogr.Layer_GetSupportedSRSList(self, *args, **kwargs)
+
+    def SetActiveSRS(self, *args) -> "OGRErr":
+        r"""SetActiveSRS(Layer self, int geom_field, SpatialReference srs) -> OGRErr"""
+        return _ogr.Layer_SetActiveSRS(self, *args)
+
     def Reference(self):
       "For backwards compatibility only."
       pass


### PR DESCRIPTION
-   OAPIF: add support for OGC API Features - Part 2 CRS extension
    
    storageCrs when found is used to set the layer CRS, express the spatial
    extent in that CRS, and set the crs and bbox-crs query parameters to
    request items/features in that CRS.
    
    storageCrsCoordinateEpoch is also used when found

- OAPIF driver: add CRS/PREFERRED_CRS open options to control the active CRS

- OAPIF: add a SERVER_FEATURE_AXIS_ORDER open option

- Add OGRLayer::GetSupportedSRSList() and SetActiveSRS(), and implement in OAPIF driver

- ogrinfo: output CRS supported list

- ogr2ogr: use SetActiveSRS() when possible when -t_srs is used

- WFS: implement GetSupportedSRSList() and SetActiveSRS()
