### PR TITLE
SQLITE/GPKG: add a gdal_get_pixel_value() SQL function.

### DIFF
--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -4217,6 +4217,118 @@ def test_gpkg_byte_nodata_value(band_count):
 
 
 ###############################################################################
+# Test gdal_get_layer_pixel_value() function
+
+
+def test_gpkg_sql_gdal_get_layer_pixel_value():
+
+    filename = "/vsimem/test_ogr_gpkg_sql_gdal_get_layer_pixel_value.gpkg"
+    src_ds = gdal.Open("data/byte.tif")
+    gdal.GetDriverByName("GPKG").CreateCopy(
+        filename, src_ds, options=["RASTER_TABLE=byte"]
+    )
+    src_ds = gdal.Open("data/float32.tif")
+    gdal.GetDriverByName("GPKG").CreateCopy(
+        filename, src_ds, options=["APPEND_SUBDATASET=YES"]
+    )
+
+    ds = gdal.OpenEx(filename)
+    sql_lyr = ds.ExecuteSQL(
+        "select gdal_get_layer_pixel_value('byte', 1, 'georef', 440780, 3751080)"
+    )
+    f = sql_lyr.GetNextFeature()
+    ds.ReleaseResultSet(sql_lyr)
+    assert f[0] == 156
+
+    sql_lyr = ds.ExecuteSQL(
+        "select gdal_get_layer_pixel_value('byte', 1, 'pixel', 1, 4)"
+    )
+    f = sql_lyr.GetNextFeature()
+    ds.ReleaseResultSet(sql_lyr)
+    assert f[0] == 156
+
+    sql_lyr = ds.ExecuteSQL(
+        "select gdal_get_layer_pixel_value('float32', 1, 'pixel', 0, 1)"
+    )
+    f = sql_lyr.GetNextFeature()
+    ds.ReleaseResultSet(sql_lyr)
+    assert f[0] == 115.0
+
+    # Invalid column
+    sql_lyr = ds.ExecuteSQL(
+        "select gdal_get_layer_pixel_value('byte', 1, 'pixel', -1, 0)"
+    )
+    f = sql_lyr.GetNextFeature()
+    ds.ReleaseResultSet(sql_lyr)
+    assert f[0] is None
+
+    # NULL as 1st arg
+    with gdaltest.error_handler():
+        sql_lyr = ds.ExecuteSQL(
+            "select gdal_get_layer_pixel_value(NULL, 1, 'pixel', 0, 0)"
+        )
+        f = sql_lyr.GetNextFeature()
+        ds.ReleaseResultSet(sql_lyr)
+        assert f[0] is None
+
+    # NULL as 2nd arg
+    with gdaltest.error_handler():
+        sql_lyr = ds.ExecuteSQL(
+            "select gdal_get_layer_pixel_value('byte', NULL, 'pixel', 0, 0)"
+        )
+        f = sql_lyr.GetNextFeature()
+        ds.ReleaseResultSet(sql_lyr)
+        assert f[0] is None
+
+    # NULL as 3rd arg
+    with gdaltest.error_handler():
+        sql_lyr = ds.ExecuteSQL(
+            "select gdal_get_layer_pixel_value('byte', 1, NULL, 0, 0)"
+        )
+        f = sql_lyr.GetNextFeature()
+        ds.ReleaseResultSet(sql_lyr)
+        assert f[0] is None
+
+    # NULL as 4th arg
+    with gdaltest.error_handler():
+        sql_lyr = ds.ExecuteSQL(
+            "select gdal_get_layer_pixel_value('byte', 1, 'pixel', NULL, 0)"
+        )
+        f = sql_lyr.GetNextFeature()
+        ds.ReleaseResultSet(sql_lyr)
+        assert f[0] is None
+
+    # NULL as 5th arg
+    with gdaltest.error_handler():
+        sql_lyr = ds.ExecuteSQL(
+            "select gdal_get_layer_pixel_value('byte', 1, 'pixel', 0, NULL)"
+        )
+        f = sql_lyr.GetNextFeature()
+        ds.ReleaseResultSet(sql_lyr)
+        assert f[0] is None
+
+    # Invalid band number
+    with gdaltest.error_handler():
+        sql_lyr = ds.ExecuteSQL(
+            "select gdal_get_layer_pixel_value('byte', 0, 'pixel', 0, 0)"
+        )
+        f = sql_lyr.GetNextFeature()
+        ds.ReleaseResultSet(sql_lyr)
+        assert f[0] is None
+
+    # Invalid value for 3rd argument
+    with gdaltest.error_handler():
+        sql_lyr = ds.ExecuteSQL(
+            "select gdal_get_layer_pixel_value('byte', 1, 'invalid', 0, 0)"
+        )
+        f = sql_lyr.GetNextFeature()
+        ds.ReleaseResultSet(sql_lyr)
+        assert f[0] is None
+
+    gdal.Unlink(filename)
+
+
+###############################################################################
 #
 
 

--- a/doc/source/drivers/raster/gpkg.rst
+++ b/doc/source/drivers/raster/gpkg.rst
@@ -610,6 +610,33 @@ Examples
 
       gdalinfo my.gpkg -oo TABLE=a_table
 
+.. _raster.gpkg.raster:
+
+Raster SQL functions
+~~~~~~~~~~~~~~~~~~~~
+
+The raster SQL functions mentioned at :ref:`sql_sqlite_dialect_raster_functions`
+are also available.
+
+The ``gdal_get_layer_pixel_value()`` function (added in GDAL 3.7), variant of the
+generic ``gdal_get_pixel_value()``, can be used to extract the value of a pixel
+in a raster layer of the current dataset.
+
+It takes 5 arguments:
+
+* a string with the layer/table name
+* a band number (numbering starting at 1)
+* a string being "georef" to indicate that subsequent values will be georeferenced
+  coordinates, or "pixel" to indicate that subsequent values will be in column, line
+  pixel space
+* georeferenced X value or column number
+* georeferenced Y value or line number
+
+.. code-block::
+
+    SELECT gdal_get_layer_pixel_value('my_raster_table', 1, 'georef', 440720, 3751320)
+    SELECT gdal_get_layer_pixel_value('my_raster_table', 1, 'pixel', 0, 0)
+
 See Also
 --------
 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -124,7 +124,7 @@ Spatialite, are also available :
    in gpkg_spatial_ref_sys, starting with GDAL 3.2, it will be interpreted as
    a EPSG code.
 
-The raster SQL functions mentioned at :ref:`sql_sqlite_dialect_raster_functions`
+The raster SQL functions mentioned at :ref:`raster.gpkg.raster`
 are also available.
 
 Link with Spatialite

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -124,6 +124,9 @@ Spatialite, are also available :
    in gpkg_spatial_ref_sys, starting with GDAL 3.2, it will be interpreted as
    a EPSG code.
 
+The raster SQL functions mentioned at :ref:`sql_sqlite_dialect_raster_functions`
+are also available.
+
 Link with Spatialite
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/user/sql_sqlite_dialect.rst
+++ b/doc/source/user/sql_sqlite_dialect.rst
@@ -257,6 +257,31 @@ a value associate to a key from a HSTORE string, formatted like "key=>value,othe
 
     SELECT hstore_get_value('a => b, "key with space"=> "value with space"', 'key with space') --> 'value with space'
 
+.. _sql_sqlite_dialect_raster_functions:
+
+Raster related functions
+++++++++++++++++++++++++
+
+The ``gdal_get_pixel_value()`` function (added in GDAL 3.7) can be used to extract the value
+of a pixel in a GDAL dataset. It requires the configuration option OGR_SQLITE_ALLOW_EXTERNAL_ACCESS
+to be set to YES (for security reasons).
+
+It takes 5 arguments:
+
+* a string with the dataset name
+* a band number (numbering starting at 1)
+* a string being "georef" to indicate that subsequent values will be georeferenced
+  coordinates, or "pixel" to indicate that subsequent values will be in column, line
+  pixel space
+* georeferenced X value or column number
+* georeferenced Y value or line number
+
+.. code-block::
+
+    SELECT gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'georef', 440720, 3751320)
+    SELECT gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'pixel', 0, 0)
+
+
 OGR geocoding functions
 +++++++++++++++++++++++
 

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -273,6 +273,9 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         bool                m_bIsGeometryTypeAggregateInterrupted = false;
         std::string         m_osGeometryTypeAggregateResult{};
 
+        // Used by GDALGeoPackageDataset::GetRasterLayerDataset()
+        std::map< std::string, std::unique_ptr<GDALDataset> > m_oCachedRasterDS{};
+
         void                CloseDB();
 
         CPL_DISALLOW_COPY_ASSIGN(GDALGeoPackageDataset)
@@ -389,6 +392,8 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
         }
         void                SetGeometryTypeAggregateResult(const std::string& s) { m_osGeometryTypeAggregateResult = s; }
         const std::string&  GetGeometryTypeAggregateResult() const { return m_osGeometryTypeAggregateResult; }
+
+        GDALDataset*        GetRasterLayerDataset(const char* pszLayerName);
 
     protected:
 

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -122,6 +122,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
                                        int argc,
                                        sqlite3_value** argv);
 
+    void               *m_pSQLFunctionData = nullptr;
     GUInt32             m_nApplicationId = GPKG_APPLICATION_ID;
     GUInt32             m_nUserVersion = GPKG_1_2_VERSION;
     OGRGeoPackageTableLayer** m_papoLayers = nullptr;
@@ -271,6 +272,8 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource, public GDALG
 
         bool                m_bIsGeometryTypeAggregateInterrupted = false;
         std::string         m_osGeometryTypeAggregateResult{};
+
+        void                CloseDB();
 
         CPL_DISALLOW_COPY_ASSIGN(GDALGeoPackageDataset)
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -8084,6 +8084,134 @@ void GPKG_GDAL_HasColorTable(sqlite3_context* pContext,
 }
 
 /************************************************************************/
+/*                      GetRasterLayerDataset()                         */
+/************************************************************************/
+
+GDALDataset* GDALGeoPackageDataset::GetRasterLayerDataset(const char* pszLayerName)
+{
+    auto oIter = m_oCachedRasterDS.find(pszLayerName);
+    if( oIter != m_oCachedRasterDS.end() )
+        return oIter->second.get();
+
+    auto poDS = std::unique_ptr<GDALDataset>(
+        GDALDataset::Open(
+            (std::string("GPKG:\"") + m_pszFilename + "\":" + pszLayerName).c_str(),
+            GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
+    if( !poDS )
+    {
+        return nullptr;
+    }
+    m_oCachedRasterDS[pszLayerName] = std::move(poDS);
+    return m_oCachedRasterDS[pszLayerName].get();
+}
+
+/************************************************************************/
+/*                   GPKG_gdal_get_layer_pixel_value()                  */
+/************************************************************************/
+
+static
+void GPKG_gdal_get_layer_pixel_value(sqlite3_context* pContext,
+                                     CPL_UNUSED int argc,
+                                     sqlite3_value** argv)
+{
+    if( sqlite3_value_type (argv[0]) != SQLITE_TEXT ||
+        sqlite3_value_type (argv[1]) != SQLITE_INTEGER ||
+        sqlite3_value_type (argv[2]) != SQLITE_TEXT ||
+        (sqlite3_value_type (argv[3]) != SQLITE_INTEGER &&
+         sqlite3_value_type (argv[3]) != SQLITE_FLOAT) ||
+        (sqlite3_value_type (argv[4]) != SQLITE_INTEGER &&
+         sqlite3_value_type (argv[4]) != SQLITE_FLOAT) )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Invalid arguments to gdal_get_layer_pixel_value()");
+        sqlite3_result_null (pContext);
+        return;
+    }
+
+    const char* pszLayerName = reinterpret_cast<const char*>(sqlite3_value_text(argv[0]));
+
+    GDALGeoPackageDataset* poGlobalDS = static_cast<GDALGeoPackageDataset*>(
+        sqlite3_user_data(pContext));
+    auto poDS = poGlobalDS->GetRasterLayerDataset(pszLayerName);
+    if( !poDS )
+    {
+        sqlite3_result_null (pContext);
+        return;
+    }
+
+    const int nBand = sqlite3_value_int(argv[1]);
+    auto poBand = poDS->GetRasterBand(nBand);
+    if( !poBand )
+    {
+        sqlite3_result_null (pContext);
+        return;
+    }
+
+    const char* pszCoordType = reinterpret_cast<const char*>(
+        sqlite3_value_text(argv[2]));
+    int x, y;
+    if( EQUAL(pszCoordType, "georef") )
+    {
+        const double X = sqlite3_value_double(argv[3]);
+        const double Y = sqlite3_value_double(argv[4]);
+        double adfGeoTransform[6];
+        if( poDS->GetGeoTransform(adfGeoTransform) != CE_None )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        double adfInvGT[6];
+        if( !GDALInvGeoTransform(adfGeoTransform, adfInvGT) )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        x = static_cast<int>(adfInvGT[0] + X * adfInvGT[1] + Y * adfInvGT[2]);
+        y = static_cast<int>(adfInvGT[3] + X * adfInvGT[4] + Y * adfInvGT[5]);
+    }
+    else if( EQUAL(pszCoordType, "pixel") )
+    {
+        x = sqlite3_value_int(argv[3]);
+        y = sqlite3_value_int(argv[4]);
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Invalid value for 3rd argument of gdal_get_pixel_value(): "
+                 "only 'georef' or 'pixel' are supported");
+        sqlite3_result_null (pContext);
+        return;
+    }
+    if( x < 0 || x >= poDS->GetRasterXSize() ||
+        y < 0 || y >= poDS->GetRasterYSize() )
+    {
+        sqlite3_result_null (pContext);
+        return;
+    }
+    const auto eDT = poBand->GetRasterDataType();
+    if( eDT != GDT_UInt64 && GDALDataTypeIsInteger(eDT) )
+    {
+        int64_t nValue = 0;
+        if( poBand->RasterIO(GF_Read, x, y, 1, 1, &nValue, 1, 1, GDT_Int64, 0, 0, nullptr) != CE_None )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        return sqlite3_result_int64(pContext, nValue);
+    }
+    else
+    {
+        double dfValue = 0;
+        if( poBand->RasterIO(GF_Read, x, y, 1, 1, &dfValue, 1, 1, GDT_Float64, 0, 0, nullptr) != CE_None )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        return sqlite3_result_double(pContext, dfValue);
+    }
+}
+
+/************************************************************************/
 /*                      InstallSQLFunctions()                           */
 /************************************************************************/
 
@@ -8213,6 +8341,10 @@ void GDALGeoPackageDataset::InstallSQLFunctions()
                                 SQLITE_UTF8 | SQLITE_DETERMINISTIC, nullptr,
                                 GPKG_GDAL_HasColorTable, nullptr, nullptr);
     }
+
+    sqlite3_create_function(hDB, "gdal_get_layer_pixel_value", 5,
+                            SQLITE_UTF8, this,
+                            GPKG_gdal_get_layer_pixel_value, nullptr, nullptr);
 
     m_pSQLFunctionData = OGRSQLiteRegisterSQLFunctionsCommon(hDB);
 }

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteregexp.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteregexp.h
@@ -30,7 +30,7 @@
 #ifndef OGR_SQLITE_REGEXP_INCLUDED
 #define OGR_SQLITE_REGEXP_INCLUDED
 
-#include "ogr_sqlite.h"
+#include "sqlite3.h"
 
 static void* OGRSQLiteRegisterRegExpFunction(sqlite3* hDB);
 static void OGRSQLiteFreeRegExpCache(void* hRegExpCache);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitesqlfunctionscommon.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitesqlfunctionscommon.cpp
@@ -1,0 +1,307 @@
+/******************************************************************************
+ *
+ * Project:  OpenGIS Simple Features Reference Implementation
+ * Purpose:  Extension SQL functions used by both SQLite dialect and GPKG driver
+ * Author:   Even Rouault, even dot rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2012-2022, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+/* WARNING: VERY IMPORTANT NOTE: This file MUST not be directly compiled as */
+/* a standalone object. It must be included from ogrsqlitevirtualogr.cpp */
+#ifndef COMPILATION_ALLOWED
+#error See comment in file
+#endif
+
+#include "gdal_priv.h"
+#include "ogr_geocoding.h"
+
+#include "ogrsqliteregexp.cpp" /* yes the .cpp file, to make it work on Windows with load_extension('gdalXX.dll') */
+
+#include <map>
+
+namespace {
+class OGRSQLiteExtensionData
+{
+#ifdef DEBUG
+    void* pDummy = nullptr; /* to track memory leaks */
+#endif
+    std::map< std::pair<int,int>, OGRCoordinateTransformation*> oCachedTransformsMap{};
+    std::map< std::string, std::unique_ptr<GDALDataset> > oCachedDS{};
+
+    void* hRegExpCache = nullptr;
+
+    OGRGeocodingSessionH hGeocodingSession = nullptr;
+
+    OGRSQLiteExtensionData(const OGRSQLiteExtensionData&) = delete;
+    OGRSQLiteExtensionData& operator=(const OGRSQLiteExtensionData&) = delete;
+
+  public:
+    explicit                     OGRSQLiteExtensionData(sqlite3* hDB);
+                                ~OGRSQLiteExtensionData();
+
+#ifdef DEFINE_OGRSQLiteExtensionData_GetTransform
+    OGRCoordinateTransformation* GetTransform(int nSrcSRSId, int nDstSRSId);
+#endif
+
+    GDALDataset                 *GetDataset(const char* pszDSName);
+
+    OGRGeocodingSessionH         GetGeocodingSession() { return hGeocodingSession; }
+    void                         SetGeocodingSession(OGRGeocodingSessionH hGeocodingSessionIn) { hGeocodingSession = hGeocodingSessionIn; }
+
+    void                         SetRegExpCache(void* hRegExpCacheIn) { hRegExpCache = hRegExpCacheIn; }
+};
+
+/************************************************************************/
+/*                     OGRSQLiteExtensionData()                         */
+/************************************************************************/
+
+OGRSQLiteExtensionData::OGRSQLiteExtensionData(CPL_UNUSED sqlite3* hDB) :
+#ifdef DEBUG
+    pDummy(CPLMalloc(1)),
+#endif
+    hRegExpCache(nullptr),
+    hGeocodingSession(nullptr)
+{}
+
+/************************************************************************/
+/*                       ~OGRSQLiteExtensionData()                      */
+/************************************************************************/
+
+OGRSQLiteExtensionData::~OGRSQLiteExtensionData()
+{
+#ifdef DEBUG
+    CPLFree(pDummy);
+#endif
+
+    std::map< std::pair<int,int>, OGRCoordinateTransformation*>::iterator oIter =
+        oCachedTransformsMap.begin();
+    for(; oIter != oCachedTransformsMap.end(); ++oIter)
+        delete oIter->second;
+
+    OGRSQLiteFreeRegExpCache(hRegExpCache);
+
+    OGRGeocodeDestroySession(hGeocodingSession);
+}
+
+/************************************************************************/
+/*                          GetTransform()                              */
+/************************************************************************/
+
+#ifdef DEFINE_OGRSQLiteExtensionData_GetTransform
+OGRCoordinateTransformation* OGRSQLiteExtensionData::GetTransform(int nSrcSRSId,
+                                                                  int nDstSRSId)
+{
+    std::map< std::pair<int,int>, OGRCoordinateTransformation*>::iterator oIter =
+        oCachedTransformsMap.find(std::pair<int,int>(nSrcSRSId, nDstSRSId));
+    if( oIter == oCachedTransformsMap.end() )
+    {
+        OGRCoordinateTransformation* poCT = nullptr;
+        OGRSpatialReference oSrcSRS, oDstSRS;
+        oSrcSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        oDstSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        if (oSrcSRS.importFromEPSG(nSrcSRSId) == OGRERR_NONE &&
+            oDstSRS.importFromEPSG(nDstSRSId) == OGRERR_NONE )
+        {
+            poCT = OGRCreateCoordinateTransformation( &oSrcSRS, &oDstSRS );
+        }
+        oCachedTransformsMap[std::pair<int,int>(nSrcSRSId, nDstSRSId)] = poCT;
+        return poCT;
+    }
+    else
+        return oIter->second;
+}
+#endif
+
+/************************************************************************/
+/*                          GetDataset()                                */
+/************************************************************************/
+
+GDALDataset* OGRSQLiteExtensionData::GetDataset(const char* pszDSName)
+{
+    auto oIter = oCachedDS.find(pszDSName);
+    if( oIter != oCachedDS.end() )
+        return oIter->second.get();
+
+    auto poDS = std::unique_ptr<GDALDataset>(
+        GDALDataset::Open(pszDSName,
+                          GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
+    if( !poDS )
+    {
+        return nullptr;
+    }
+    oCachedDS[pszDSName] = std::move(poDS);
+    return oCachedDS[pszDSName].get();
+}
+
+
+} // namespace
+
+/************************************************************************/
+/*                    OGRSQLITE_gdal_get_pixel_value()                  */
+/************************************************************************/
+
+static
+void OGRSQLITE_gdal_get_pixel_value(sqlite3_context* pContext,
+                                        CPL_UNUSED int argc,
+                                        sqlite3_value** argv)
+{
+    if( !CPLTestBool(CPLGetConfigOption("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "NO")) )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "gdal_get_pixel_value() SQL function not available "
+                 "if OGR_SQLITE_ALLOW_EXTERNAL_ACCESS configuration option "
+                 "is not set");
+        sqlite3_result_null( pContext );
+        return;
+    }
+
+    if( sqlite3_value_type (argv[0]) != SQLITE_TEXT ||
+        sqlite3_value_type (argv[1]) != SQLITE_INTEGER ||
+        sqlite3_value_type (argv[2]) != SQLITE_TEXT ||
+        (sqlite3_value_type (argv[3]) != SQLITE_INTEGER &&
+         sqlite3_value_type (argv[3]) != SQLITE_FLOAT) ||
+        (sqlite3_value_type (argv[4]) != SQLITE_INTEGER &&
+         sqlite3_value_type (argv[4]) != SQLITE_FLOAT) )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Invalid arguments to gdal_get_pixel_value()");
+        sqlite3_result_null (pContext);
+        return;
+    }
+
+    const char* pszDSName = reinterpret_cast<const char*>(sqlite3_value_text(argv[0]));
+
+    OGRSQLiteExtensionData* poModule = static_cast<OGRSQLiteExtensionData*>(
+        sqlite3_user_data(pContext));
+    auto poDS = poModule->GetDataset(pszDSName);
+    if( !poDS )
+    {
+        sqlite3_result_null (pContext);
+        return;
+    }
+
+    const int nBand = sqlite3_value_int(argv[1]);
+    auto poBand = poDS->GetRasterBand(nBand);
+    if( !poBand )
+    {
+        sqlite3_result_null (pContext);
+        return;
+    }
+
+    const char* pszCoordType = reinterpret_cast<const char*>(
+        sqlite3_value_text(argv[2]));
+    int x, y;
+    if( EQUAL(pszCoordType, "georef") )
+    {
+        const double X = sqlite3_value_double(argv[3]);
+        const double Y = sqlite3_value_double(argv[4]);
+        double adfGeoTransform[6];
+        if( poDS->GetGeoTransform(adfGeoTransform) != CE_None )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        double adfInvGT[6];
+        if( !GDALInvGeoTransform(adfGeoTransform, adfInvGT) )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        x = static_cast<int>(adfInvGT[0] + X * adfInvGT[1] + Y * adfInvGT[2]);
+        y = static_cast<int>(adfInvGT[3] + X * adfInvGT[4] + Y * adfInvGT[5]);
+    }
+    else if( EQUAL(pszCoordType, "pixel") )
+    {
+        x = sqlite3_value_int(argv[3]);
+        y = sqlite3_value_int(argv[4]);
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Invalid value for 3rd argument of gdal_get_pixel_value(): "
+                 "only 'georef' or 'pixel' are supported");
+        sqlite3_result_null (pContext);
+        return;
+    }
+    if( x < 0 || x >= poDS->GetRasterXSize() ||
+        y < 0 || y >= poDS->GetRasterYSize() )
+    {
+        sqlite3_result_null (pContext);
+        return;
+    }
+    const auto eDT = poBand->GetRasterDataType();
+    if( eDT != GDT_UInt64 && GDALDataTypeIsInteger(eDT) )
+    {
+        int64_t nValue = 0;
+        if( poBand->RasterIO(GF_Read, x, y, 1, 1, &nValue, 1, 1, GDT_Int64, 0, 0, nullptr) != CE_None )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        return sqlite3_result_int64(pContext, nValue);
+    }
+    else
+    {
+        double dfValue = 0;
+        if( poBand->RasterIO(GF_Read, x, y, 1, 1, &dfValue, 1, 1, GDT_Float64, 0, 0, nullptr) != CE_None )
+        {
+            sqlite3_result_null (pContext);
+            return;
+        }
+        return sqlite3_result_double(pContext, dfValue);
+    }
+}
+
+
+/************************************************************************/
+/*                 OGRSQLiteRegisterSQLFunctionsCommon()                */
+/************************************************************************/
+
+#ifndef SQLITE_DETERMINISTIC
+#define SQLITE_DETERMINISTIC 0
+#endif
+
+static
+OGRSQLiteExtensionData* OGRSQLiteRegisterSQLFunctionsCommon(sqlite3* hDB)
+{
+    OGRSQLiteExtensionData* pData = new OGRSQLiteExtensionData(hDB);
+
+    sqlite3_create_function(hDB, "gdal_get_pixel_value", 5,
+                            SQLITE_UTF8, pData,
+                            OGRSQLITE_gdal_get_pixel_value, nullptr, nullptr);
+
+    pData->SetRegExpCache(OGRSQLiteRegisterRegExpFunction(hDB));
+
+    return pData;
+}
+
+/************************************************************************/
+/*                   OGRSQLiteUnregisterSQLFunctions()                  */
+/************************************************************************/
+
+static
+void OGRSQLiteUnregisterSQLFunctions(void* hHandle)
+{
+    OGRSQLiteExtensionData* pData = static_cast<OGRSQLiteExtensionData*>(hHandle);
+    delete pData;
+}


### PR DESCRIPTION
Applies to both SQL SQLite dialect and GPKG

The ``gdal_get_pixel_value()`` function (added in GDAL 3.7) can be used to extract the value of a pixel in a GDAL dataset. It requires the configuration option OGR_SQLITE_ALLOW_EXTERNAL_ACCESS to be set to YES (for security reasons).

It takes 5 arguments:

* a string with the dataset name
* a band number (numbering starting at 1)
* a string being "georef" to indicate that subsequent values will be georeferenced coordinates, or "pixel" to indicate that subsequent values will be in column, line pixel space
* georeferenced X value or column number
* georeferenced Y value or line number

Example:

    SELECT gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'georef', 440720, 3751320)
    SELECT gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'pixel', 0, 0)
