### PR TITLE
No longer alias VSILFILE* to FILE* in non-DEBUG builds (fixes #6790)

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -8,6 +8,16 @@ MIGRATION GUIDE FROM GDAL 3.6 to GDAL 3.7
   that used to support it, but is deprecated and external code should rather use
   the GDT_Int8 data type.
 
+- The VSILFILE* type is no longer aliased to FILE* in builds without the DEBUG
+  define (that is production builds). External code that used FILE* with
+  GDAL VSI*L API has to be changed to use VSILFILE*.
+  This aliasing dates back to old times where both types were indifferently
+  used in the code base. In the mean time, this was cleaned up. But there was a
+  drawback of having VSILFILE* being either a dedicated type oor an alias of
+  FILE* depending whether DEBUG is defined, especially with the C++ API, for
+  people building their plugins with DEBUG and running them against a non-DEBUG
+  GDAL build, or the reverse.
+
 MIGRATION GUIDE FROM GDAL 3.5 to GDAL 3.6
 -----------------------------------------
 

--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -143,20 +143,8 @@ typedef GUIntBig vsi_l_offset;
 /** Maximum value for a file offset */
 #define VSI_L_OFFSET_MAX GUINTBIG_MAX
 
-/*! @cond Doxygen_Suppress */
-/* Make VSIL_STRICT_ENFORCE active in DEBUG builds */
-#ifdef DEBUG
-#define VSIL_STRICT_ENFORCE
-#endif
-/*! @endcond */
-
-#ifdef VSIL_STRICT_ENFORCE
 /** Opaque type for a FILE that implements the VSIVirtualHandle API */
 typedef struct _VSILFILE VSILFILE;
-#else
-/** Opaque type for a FILE that implements the VSIVirtualHandle API */
-typedef FILE VSILFILE;
-#endif
 
 VSILFILE CPL_DLL *  VSIFOpenL( const char *, const char * ) CPL_WARN_UNUSED_RESULT;
 VSILFILE CPL_DLL *  VSIFOpenExL( const char *, const char *, int ) CPL_WARN_UNUSED_RESULT;


### PR DESCRIPTION
The VSILFILE* type is no longer aliased to FILE* in builds without the DEBUG define (that is production builds). External code that used FILE* with GDAL VSI*L API has to be changed to use VSILFILE*. This aliasing dates back to old times where both types were indifferently used in the code base. In the mean time, this was cleaned up. But there was a drawback of having VSILFILE* being either a dedicated type or an alias of FILE* depending whether DEBUG is defined, especially with the C++ API, for people building their plugins with DEBUG and running them against a non-DEBUG GDAL build, or the reverse.
