### PR TITLE
[Backport release/3.6] OGR layer algebra: make sure result layer has no duplicated field names (fixes #6851)

### DIFF
--- a/autotest/ogr/ogr_layer_algebra.py
+++ b/autotest/ogr/ogr_layer_algebra.py
@@ -101,9 +101,11 @@ def test_algebra_setup():
 
     A = ds.CreateLayer("A")
     A.CreateField(ogr.FieldDefn("A", ogr.OFTInteger))
+    A.CreateField(ogr.FieldDefn("same_in_both_layers", ogr.OFTInteger))
 
     B = ds.CreateLayer("B")
     B.CreateField(ogr.FieldDefn("B", ogr.OFTString))
+    B.CreateField(ogr.FieldDefn("same_in_both_layers", ogr.OFTInteger))
 
     pointInB = ds.CreateLayer("pointInB")
 
@@ -173,11 +175,15 @@ def test_algebra_intersection():
 
     C_defn = C.GetLayerDefn()
     assert (
-        C_defn.GetFieldCount() == 2
+        C_defn.GetFieldCount() == 4
         and C_defn.GetFieldDefn(0).GetName() == "A"
         and C_defn.GetFieldDefn(0).GetType() == ogr.OFTInteger
-        and C_defn.GetFieldDefn(1).GetName() == "B"
-        and C_defn.GetFieldDefn(1).GetType() == ogr.OFTString
+        and C_defn.GetFieldDefn(1).GetName() == "input_same_in_both_layers"
+        and C_defn.GetFieldDefn(1).GetType() == ogr.OFTInteger
+        and C_defn.GetFieldDefn(2).GetName() == "B"
+        and C_defn.GetFieldDefn(2).GetType() == ogr.OFTString
+        and C_defn.GetFieldDefn(3).GetName() == "method_same_in_both_layers"
+        and C_defn.GetFieldDefn(3).GetType() == ogr.OFTInteger
     ), "Did not get expected output schema."
 
     assert C.GetFeatureCount() == 2, (

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -39,6 +39,7 @@
 #include "cpl_time.h"
 #include <cassert>
 #include <limits>
+#include <set>
 
 
 struct OGRLayer::Private
@@ -2061,10 +2062,34 @@ OGRErr set_result_schema(OGRLayer *pLayerResult,
     } else {
         // use schema from the input layer or from input and method layers
         int nFieldsInput = poDefnInput->GetFieldCount();
+
+        // If no prefix is specified and we have input+method layers, make
+        // sure we will generate unique field names
+        std::set<std::string> oSetInputFieldNames;
+        std::set<std::string> oSetMethodFieldNames;
+        if( poDefnMethod != nullptr &&
+            pszInputPrefix == nullptr &&
+            pszMethodPrefix == nullptr )
+        {
+            for( int iField = 0; iField < nFieldsInput; iField++ ) {
+                oSetInputFieldNames.insert(poDefnInput->GetFieldDefn(iField)->GetNameRef());
+            }
+            const int nFieldsMethod = poDefnMethod->GetFieldCount();
+            for( int iField = 0; iField < nFieldsMethod; iField++ ) {
+                oSetMethodFieldNames.insert(poDefnMethod->GetFieldDefn(iField)->GetNameRef());
+            }
+        }
+
         for( int iField = 0; iField < nFieldsInput; iField++ ) {
             OGRFieldDefn oFieldDefn(poDefnInput->GetFieldDefn(iField));
             if( pszInputPrefix != nullptr )
                 oFieldDefn.SetName(CPLSPrintf("%s%s", pszInputPrefix, oFieldDefn.GetNameRef()));
+            else if( !oSetMethodFieldNames.empty() &&
+                     oSetMethodFieldNames.find(oFieldDefn.GetNameRef()) != oSetMethodFieldNames.end() )
+            {
+                // Field of same name present in method layer
+                oFieldDefn.SetName(CPLSPrintf("input_%s", oFieldDefn.GetNameRef()));
+            }
             ret = pLayerResult->CreateField(&oFieldDefn);
             if (ret != OGRERR_NONE) {
                 if (!bSkipFailures)
@@ -2080,10 +2105,17 @@ OGRErr set_result_schema(OGRLayer *pLayerResult,
         if (!combined) return ret;
         if (!mapMethod) return ret;
         if (!poDefnMethod) return ret;
-        for( int iField = 0; iField < poDefnMethod->GetFieldCount(); iField++ ) {
+        const int nFieldsMethod = poDefnMethod->GetFieldCount();
+        for( int iField = 0; iField < nFieldsMethod; iField++ ) {
             OGRFieldDefn oFieldDefn(poDefnMethod->GetFieldDefn(iField));
             if( pszMethodPrefix != nullptr )
                 oFieldDefn.SetName(CPLSPrintf("%s%s", pszMethodPrefix, oFieldDefn.GetNameRef()));
+            else if( !oSetInputFieldNames.empty() &&
+                     oSetInputFieldNames.find(oFieldDefn.GetNameRef()) != oSetInputFieldNames.end() )
+            {
+                // Field of same name present in method layer
+                oFieldDefn.SetName(CPLSPrintf("method_%s", oFieldDefn.GetNameRef()));
+            }
             ret = pLayerResult->CreateField(&oFieldDefn);
             if (ret != OGRERR_NONE) {
                 if (!bSkipFailures)

--- a/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
+++ b/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
@@ -80,6 +80,9 @@ def CreateLayer(
         print('Cannot create layer "%s"' % output_lyr_name)
         return None
 
+    if input_fields == "ALL" and method_fields == "ALL":
+        return output_lyr
+
     input_prefix = ""
     method_prefix = ""
     for val in opt:


### PR DESCRIPTION
Backport #6880
 **Authored by:** @rouault