### PR TITLE
vrtdataset: vrt connection syntax 'a_srs'

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -40,7 +40,7 @@ import gdaltest
 import pytest
 import test_cli_utilities
 
-from osgeo import gdal
+from osgeo import gdal, osr
 
 ###############################################################################
 # When imported build a list of units based on the files available.
@@ -1441,6 +1441,10 @@ def test_vrt_protocol():
     assert ds.GetRasterBand(1).Checksum() == 4672
     assert ds.GetRasterBand(2).Checksum() == 4873
     assert ds.GetRasterBand(3).Checksum() == 4672
+
+    ds = gdal.Open("vrt://data/byte.tif?bands=1&a_srs=EPSG:3031")
+    crs = osr.SpatialReference(wkt=ds.GetProjection())
+    assert crs.GetAttrValue("AUTHORITY", 1) == "3031"
 
 
 def test_vrt_source_no_dstrect():

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1443,8 +1443,8 @@ def test_vrt_protocol():
     assert ds.GetRasterBand(3).Checksum() == 4672
 
     ds = gdal.Open("vrt://data/byte.tif?bands=1&a_srs=EPSG:3031")
-    crs = osr.SpatialReference(wkt=ds.GetProjection())
-    assert crs.GetAttrValue("AUTHORITY", 1) == "3031"
+    crs = ds.GetSpatialRef()
+    assert crs.GetAuthorityCode(None) == "3031"
 
 
 def test_vrt_source_no_dstrect():

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -40,7 +40,7 @@ import gdaltest
 import pytest
 import test_cli_utilities
 
-from osgeo import gdal, osr
+from osgeo import gdal
 
 ###############################################################################
 # When imported build a list of units based on the files available.

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1631,13 +1631,15 @@ The ``mask`` value can be used to specify the global mask band. This can also
 be seen as an equivalent of running `gdal_translate -of VRT -b num1 ... -b numN`.
 
 The effect of the a_srs option is to assign the coordinate reference system of the source 
-in the same way as (:ref:`gdal_translate`), it may be missing, or incorrect.
+in the same way as (:ref:`gdal_translate`), it may be missing, or incorrect. The value provided
+for 'a_srs' may be be a string or a file containing a srs definition.
 
-The options may be chained together separated by '&'. 
+The options may be chained together separated by '&'. (Beware the need for quoting to protect
+the ampersand).
 
 ::
 
-    vrt://my.tif?a_srs=OGC:CRS84&bands=2,1
+    "vrt://my.tif?a_srs=OGC:CRS84&bands=2,1"
     
 
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1607,18 +1607,39 @@ the dataset name since GDAL 3.1
 
     vrt://{path_to_gdal_dataset}?[bands=num1,...,numN]
 
+::
+
+    vrt://{path_to_gdal_dataset}?[a_srs=srs_def]
+
+
 For example:
 
 ::
 
     vrt://my.tif?bands=3,2,1
 
-The only supported option currently is bands. Other may be added in the future.
+::
 
-The effect of this option is to change the band composition. The values specified
+    vrt://my.tif?a_srs=OGC:CRS84
+    
+    
+The only supported options currently is bands and a_srs. Other may be added in the future.
+
+The effect of the bands option is to change the band composition. The values specified
 are the source band numbers (between 1 and N), possibly out-of-order or with repetitions.
 The ``mask`` value can be used to specify the global mask band. This can also
 be seen as an equivalent of running `gdal_translate -of VRT -b num1 ... -b numN`.
+
+The effect of the a_srs option is to assign the coordinate reference system of the source 
+in the same way as (:ref:`gdal_translate`), it may be missing, or incorrect.
+
+The options may be chained together separated by '&'. 
+
+::
+
+    vrt://my.tif?a_srs=OGC:CRS84&bands=2,1
+    
+
 
 Multi-threading optimizations
 -----------------------------

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1623,14 +1623,14 @@ For example:
     vrt://my.tif?a_srs=OGC:CRS84
     
     
-The only supported options currently is bands and a_srs. Other may be added in the future.
+The only supported options currently is ``bands`` and ``a_srs``. Other may be added in the future.
 
-The effect of the bands option is to change the band composition. The values specified
+The effect of the ``bands`` option is to change the band composition. The values specified
 are the source band numbers (between 1 and N), possibly out-of-order or with repetitions.
 The ``mask`` value can be used to specify the global mask band. This can also
 be seen as an equivalent of running `gdal_translate -of VRT -b num1 ... -b numN`.
 
-The effect of the a_srs option is to assign the coordinate reference system of the source 
+The effect of the ``a_srs`` option (added in GDAL 3.7) is to assign the coordinate reference system of the source 
 in the same way as (:ref:`gdal_translate`), it may be missing, or incorrect. The value provided
 for 'a_srs' may be be a string or a file containing a srs definition.
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -965,9 +965,6 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
     // Parse query string
     CPLStringList aosTokens(CSLTokenizeString2(osQueryString, "&", 0));
     std::vector<int> anBands;
-    CPLString osA_SRS;
-    
-    bool bTokenKnown;
     
     CPLStringList argv;
     argv.AddString("-of");
@@ -975,15 +972,12 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
    
     for( int i = 0; i < aosTokens.size(); i++ )
     {
-        bTokenKnown = false; 
-      
         char* pszKey = nullptr;
         const char* pszValue = CPLParseNameValue(aosTokens[i], &pszKey);
         if( pszKey && pszValue )
         {
             if( EQUAL(pszKey, "bands") )
             {
-                bTokenKnown = true;
                 CPLStringList aosBands(CSLTokenizeString2(pszValue, ",", 0));
                 for( int j = 0; j < aosBands.size(); j++ )
                 {
@@ -1013,14 +1007,13 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
                 }
             }
             
-            if ( EQUAL(pszKey, "a_srs")) {
-              bTokenKnown = true;
-              osA_SRS = CPLStrdup(pszValue);
-              argv.AddString("-a_srs");
-              argv.AddString(osA_SRS);
+            else if ( EQUAL(pszKey, "a_srs"))
+            {
+                argv.AddString("-a_srs");
+                argv.AddString(pszValue);
             }
             
-            if (!bTokenKnown)
+            else
             {
                 CPLError(CE_Failure, CPLE_NotSupported,
                          "Unknown option: %s", pszKey);

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -972,18 +972,18 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
     CPLStringList argv;
     argv.AddString("-of");
     argv.AddString("VRT");
-    
+   
     for( int i = 0; i < aosTokens.size(); i++ )
     {
-    	  bTokenKnown = false; 
-    	
+        bTokenKnown = false; 
+      
         char* pszKey = nullptr;
         const char* pszValue = CPLParseNameValue(aosTokens[i], &pszKey);
         if( pszKey && pszValue )
         {
             if( EQUAL(pszKey, "bands") )
             {
-              	bTokenKnown = true;
+                bTokenKnown = true;
                 CPLStringList aosBands(CSLTokenizeString2(pszValue, ",", 0));
                 for( int j = 0; j < aosBands.size(); j++ )
                 {
@@ -1008,16 +1008,16 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
                 
                 for( const int nBand: anBands )
                 {
-                	argv.AddString("-b");
-                	argv.AddString(nBand == 0 ? "mask" : CPLSPrintf("%d", nBand));
+                  argv.AddString("-b");
+                  argv.AddString(nBand == 0 ? "mask" : CPLSPrintf("%d", nBand));
                 }
             }
             
             if ( EQUAL(pszKey, "a_srs")) {
-            	bTokenKnown = true;
-            	osA_SRS = CPLStrdup(pszValue);
-            	argv.AddString("-a_srs");
-            	argv.AddString(osA_SRS);
+              bTokenKnown = true;
+              osA_SRS = CPLStrdup(pszValue);
+              argv.AddString("-a_srs");
+              argv.AddString(osA_SRS);
             }
             
             if (!bTokenKnown)


### PR DESCRIPTION
Adds 'a_srs' to the allowed options for a "vrt:// connection.  The effect of the a_srs option is to assign the coordinate reference system of the source in the same way as the argument to gdal_translate does. 

Examples

```
## source has no srs definition (non-conforming file)
gdalinfo vrt://NETCDF:"/vsicurl/https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation/v2.1/access/avhrr/202109/oisst-avhrr-v02r01.20210930.nc":sst?a_srs=OGC:CRS84

## overwrite when a file does have srs (source is EASE, this is south pole stere)
gdalinfo  vrt://autotest/gdrivers/data/netcdf/srid.nc?a_srs=EPSG:3031

## chain with 'bands'
gdalinfo  "vrt://autotest/gdrivers/data/netcdf/srid.nc?a_srs=EPSG:3031&bands=1,1"

```

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed



