### PR TITLE
Fix PG and PGDump drivers to support the TEMPORARY layer CO

### DIFF
--- a/autotest/ogr/ogr_pgdump.py
+++ b/autotest/ogr/ogr_pgdump.py
@@ -1252,6 +1252,49 @@ def test_ogr_pgdump_16():
 
 
 ###############################################################################
+# Test temporary layer creation option
+
+
+def test_ogr_pgdump_17():
+
+    ds = ogr.GetDriverByName("PGDump").CreateDataSource(
+        "/vsimem/ogr_pgdump_17.sql", options=["LINEFORMAT=LF"]
+    )
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint, options=["TEMPORARY=ON"])
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(0 1)"))
+    lyr.CreateFeature(f)
+    f = None
+    ds = None
+
+    f = gdal.VSIFOpenL("/vsimem/ogr_pgdump_17.sql", "rb")
+    sql = gdal.VSIFReadL(1, 10000, f).decode("utf8")
+    gdal.VSIFCloseL(f)
+
+    gdal.Unlink("/vsimem/ogr_pgdump_17.sql")
+
+    assert not (
+        sql.find("""DROP TABLE IF EXISTS "pg_temp"."test" CASCADE;""") == -1
+        or sql.find(
+            """CREATE TEMPORARY TABLE "test" ( "ogc_fid" SERIAL, CONSTRAINT "test_pk" PRIMARY KEY ("ogc_fid") )"""
+        )
+        == -1
+        or sql.find(
+            """SELECT AddGeometryColumn('','test','wkb_geometry',0,'POINT',2)"""
+        )
+        == -1
+        or sql.find(
+            """CREATE INDEX "test_wkb_geometry_geom_idx" ON "pg_temp"."test" USING GIST ("wkb_geometry")"""
+        )
+        == -1
+        or sql.find(
+            """INSERT INTO "pg_temp"."test" ("wkb_geometry" ) VALUES ('01010000000000000000000000000000000000F03F')"""
+        )
+        == -1
+    )
+
+
+###############################################################################
 # Cleanup
 
 

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -1697,6 +1697,12 @@ OGRPGDataSource::ICreateLayer( const char * pszLayerName,
         pszSchemaName = CPLStrdup(CSLFetchNameValue( papszOptions, "SCHEMA" ));
     }
 
+    const bool bTemporary = CPLFetchBool( papszOptions, "TEMPORARY", false );
+    if( bTemporary )
+    {
+        CPLFree(pszSchemaName);
+        pszSchemaName = CPLStrdup("pg_temp");
+    }
     if ( pszSchemaName == nullptr )
     {
         pszSchemaName = CPLStrdup(osCurrentSchema);
@@ -1862,11 +1868,8 @@ OGRPGDataSource::ICreateLayer( const char * pszLayerName,
     const char* pszSerialType = bFID64 ? "BIGSERIAL": "SERIAL";
 
     CPLString osCreateTable;
-    const bool bTemporary = CPLFetchBool( papszOptions, "TEMPORARY", false );
     if( bTemporary )
     {
-        CPLFree(pszSchemaName);
-        pszSchemaName = CPLStrdup("pg_temp_1");
         osCreateTable.Printf("CREATE TEMPORARY TABLE %s",
                              OGRPGEscapeColumnName(pszTableName).c_str());
     }

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
@@ -298,6 +298,13 @@ OGRPGDumpDataSource::ICreateLayer( const char * pszLayerName,
         }
     }
 
+    const bool bTemporary = CPLFetchBool( papszOptions, "TEMPORARY", false );
+    if( bTemporary )
+    {
+        CPLFree(pszSchemaName);
+        pszSchemaName = CPLStrdup("pg_temp");
+    }
+
     if ( pszSchemaName == nullptr)
     {
         pszSchemaName = CPLStrdup("public");
@@ -436,11 +443,8 @@ OGRPGDumpDataSource::ICreateLayer( const char * pszLayerName,
     const char* pszSerialType = bFID64 ? "BIGSERIAL": "SERIAL";
 
     CPLString osCreateTable;
-    const bool bTemporary = CPLFetchBool( papszOptions, "TEMPORARY", false );
     if( bTemporary )
     {
-        CPLFree(pszSchemaName);
-        pszSchemaName = CPLStrdup("pg_temp_1");
         osCreateTable.Printf("CREATE TEMPORARY TABLE \"%s\"", pszTableName);
     }
     else
@@ -534,7 +538,7 @@ OGRPGDumpDataSource::ICreateLayer( const char * pszLayerName,
 
         osCommand.Printf(
                 "SELECT AddGeometryColumn('%s',%s,'%s',%d,'%s%s',%d)",
-                pszSchemaName, pszEscapedTableNameSingleQuote, pszGFldName,
+                bTemporary ? "": pszSchemaName, pszEscapedTableNameSingleQuote, pszGFldName,
                 nSRSId, pszGeometryType, suffix, nDimension );
         Log(osCommand);
     }


### PR DESCRIPTION
## What does this PR do?

Currently, the PG and PGDump drivers do not correctly support the TEMPORARY layer creation options. The current code is using pg_temp_1 as the schema name, which is incorrect. Instead the [pg_temp](https://www.postgresql.org/docs/current/runtime-config-client.html) alias should be used in cases where the schema is supplied. I've fixed both the PG and PGDump drivers. The PGDump driver is for correctness with the current documentation, noting that the benefits of using the feature in PGDump are likely minimal as the driver format is likely used for data exchange rather than processing within an OGR script.

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: All 
* Compiler: All
