### PR TITLE
vrtdataset: vrt connection option 'a_ullr'

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1446,7 +1446,7 @@ def test_vrt_protocol():
     crs = ds.GetSpatialRef()
     assert crs.GetAuthorityCode(None) == "3031"
 
-    ds = gdal.Open("vrt://data/byte.tif?a_ullr=0 10 20 0")
+    ds = gdal.Open("vrt://data/byte.tif?a_ullr=0,10,20,0")
     geotransform = ds.GetGeoTransform()
     assert geotransform == (0.0, 1.0, 0.0, 20.0, 0.0, -0.5)
 

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1448,7 +1448,7 @@ def test_vrt_protocol():
 
     ds = gdal.Open("vrt://data/byte.tif?a_ullr=0,10,20,0")
     geotransform = ds.GetGeoTransform()
-    assert geotransform == (0.0, 1.0, 0.0, 20.0, 0.0, -0.5)
+    assert geotransform == (0.0, 1.0, 0.0, 10.0, 0.0, -0.5)
 
 
 def test_vrt_source_no_dstrect():

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1446,6 +1446,10 @@ def test_vrt_protocol():
     crs = ds.GetSpatialRef()
     assert crs.GetAuthorityCode(None) == "3031"
 
+    ds = gdal.Open("vrt://data/byte.tif?a_ullr=0 10 20 0")
+    geotransform = ds.GetGeoTransform()
+    assert geotransform == (0.0, 1.0, 0.0, 20.0, 0.0, -0.5)
+
 
 def test_vrt_source_no_dstrect():
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1613,7 +1613,7 @@ the dataset name since GDAL 3.1
 
 ::
 
-    vrt://{path_to_gdal_dataset}?[a_ullr=ulx,uly,llx,lly]
+    vrt://{path_to_gdal_dataset}?[a_ullr=ulx,uly,lrx,lry]
 
 
 For example:

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1628,20 +1628,22 @@ For example:
     "vrt://my.tif?a_ullr=0 1 1 -1"
     
     
-The supported options currently are ``bands``, ``a_srs`` and ``a_ullr``. Other may be added in the future.
+The supported options currently are ``bands``, ``a_srs`` and ``a_ullr``. Other options may be 
+added in the future.
 
 The effect of the ``bands`` option is to change the band composition. The values specified
 are the source band numbers (between 1 and N), possibly out-of-order or with repetitions.
 The ``mask`` value can be used to specify the global mask band. This can also
 be seen as an equivalent of running `gdal_translate -of VRT -b num1 ... -b numN`.
 
-The effect of the ``a_srs`` option (added in GDAL 3.7) is to assign (overrid) the coordinate 
+The effect of the ``a_srs`` option (added in GDAL 3.7) is to assign (override) the coordinate 
 reference system of the source in the same way as (:ref:`gdal_translate`), it may be missing, 
-or incorrect. The value provided for ``a_srs`` may be be a string or a file containing a srs 
+or incorrect. The value provided for ``a_srs`` may be a string or a file containing a srs 
 definition.
 
 The effect of the ``a_ullr`` option (added in GDAL 3.7) is to assign (override) the georeferenced
-bounds of the source in the same way as (:ref:`gdal_translate`).  
+bounds of the source in the same way as (:ref:`gdal_translate`). The value consists of four numeric
+values separated by spaces. 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand and spaces).

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1622,24 +1622,33 @@ For example:
 
     vrt://my.tif?a_srs=OGC:CRS84
     
+
+::
+
+    "vrt://my.tif?a_ullr=0 1 1 -1"
     
-The only supported options currently is ``bands`` and ``a_srs``. Other may be added in the future.
+    
+The supported options currently are ``bands``, ``a_srs`` and ``a_ullr``. Other may be added in the future.
 
 The effect of the ``bands`` option is to change the band composition. The values specified
 are the source band numbers (between 1 and N), possibly out-of-order or with repetitions.
 The ``mask`` value can be used to specify the global mask band. This can also
 be seen as an equivalent of running `gdal_translate -of VRT -b num1 ... -b numN`.
 
-The effect of the ``a_srs`` option (added in GDAL 3.7) is to assign the coordinate reference system of the source 
-in the same way as (:ref:`gdal_translate`), it may be missing, or incorrect. The value provided
-for 'a_srs' may be be a string or a file containing a srs definition.
+The effect of the ``a_srs`` option (added in GDAL 3.7) is to assign (overrid) the coordinate 
+reference system of the source in the same way as (:ref:`gdal_translate`), it may be missing, 
+or incorrect. The value provided for ``a_srs`` may be be a string or a file containing a srs 
+definition.
+
+The effect of the ``a_ullr`` option (added in GDAL 3.7) is to assign (override) the georeferenced
+bounds of the source in the same way as (:ref:`gdal_translate`).  
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
-the ampersand).
+the ampersand and spaces).
 
 ::
 
-    "vrt://my.tif?a_srs=OGC:CRS84&bands=2,1"
+    "vrt://my.tif?a_srs=OGC:CRS84&bands=2,1&a_ullr=-180 90 180 -90"
     
 
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1611,6 +1611,10 @@ the dataset name since GDAL 3.1
 
     vrt://{path_to_gdal_dataset}?[a_srs=srs_def]
 
+::
+
+    vrt://{path_to_gdal_dataset}?[a_ullr=ulx,uly,llx,lly]
+
 
 For example:
 
@@ -1622,12 +1626,11 @@ For example:
 
     vrt://my.tif?a_srs=OGC:CRS84
     
-
 ::
 
-    "vrt://my.tif?a_ullr=0 1 1 -1"
+    vrt://my.tif?a_ullr=0,1,1,-1
     
-    
+
 The supported options currently are ``bands``, ``a_srs`` and ``a_ullr``. Other options may be 
 added in the future.
 
@@ -1643,14 +1646,14 @@ definition.
 
 The effect of the ``a_ullr`` option (added in GDAL 3.7) is to assign (override) the georeferenced
 bounds of the source in the same way as (:ref:`gdal_translate`). The value consists of four numeric
-values separated by spaces. 
+values separated by commas. 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
-the ampersand and spaces).
+the ampersand).
 
 ::
 
-    "vrt://my.tif?a_srs=OGC:CRS84&bands=2,1&a_ullr=-180 90 180 -90"
+    "vrt://my.tif?a_srs=OGC:CRS84&bands=2,1&a_ullr=-180,90,180,-90"
     
 
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1646,7 +1646,7 @@ definition.
 
 The effect of the ``a_ullr`` option (added in GDAL 3.7) is to assign (override) the georeferenced
 bounds of the source in the same way as (:ref:`gdal_translate`). The value consists of four numeric
-values separated by commas. 
+values separated by commas, in the order 'xmin,ymax,xmax,ymin' (upper left x,y, lower right x,y). 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1013,6 +1013,32 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
                 argv.AddString(pszValue);
             }
             
+            else if ( EQUAL(pszKey, "a_ullr")) 
+            {
+              double xmin,xmax,ymin,ymax;
+              
+              // Parse the limits
+              CPLStringList aosUllr(CSLTokenizeString2(pszValue, " ", 0));
+              // fail if not four values 
+              if(aosUllr.size() != 4)
+              {
+                CPLError(CE_Failure, CPLE_IllegalArg,
+                         "Invalid a_ullr option: %s", pszValue);
+                poSrcDS->ReleaseRef();
+                CPLFree(pszKey);
+                return nullptr;
+              }
+              xmin = atof(aosUllr[0]);
+              xmax = atof(aosUllr[2]);
+              ymin = atof(aosUllr[3]);
+              ymax = atof(aosUllr[1]);
+              
+              argv.AddString("-a_ullr"); 
+              argv.AddString(CPLSPrintf("%f", xmin));
+              argv.AddString(CPLSPrintf("%f", ymax));
+              argv.AddString(CPLSPrintf("%f", xmax));
+              argv.AddString(CPLSPrintf("%f", ymin));
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported,

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1018,7 +1018,7 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
               double xmin,xmax,ymin,ymax;
               
               // Parse the limits
-              CPLStringList aosUllr(CSLTokenizeString2(pszValue, " ", 0));
+              CPLStringList aosUllr(CSLTokenizeString2(pszValue, ",", 0));
               // fail if not four values 
               if(aosUllr.size() != 4)
               {

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1015,7 +1015,6 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
             
             else if ( EQUAL(pszKey, "a_ullr")) 
             {
-              double xmin,xmax,ymin,ymax;
               
               // Parse the limits
               CPLStringList aosUllr(CSLTokenizeString2(pszValue, ",", 0));
@@ -1028,16 +1027,12 @@ GDALDataset *VRTDataset::OpenVRTProtocol( const char* pszSpec )
                 CPLFree(pszKey);
                 return nullptr;
               }
-              xmin = atof(aosUllr[0]);
-              xmax = atof(aosUllr[2]);
-              ymin = atof(aosUllr[3]);
-              ymax = atof(aosUllr[1]);
               
               argv.AddString("-a_ullr"); 
-              argv.AddString(CPLSPrintf("%f", xmin));
-              argv.AddString(CPLSPrintf("%f", ymax));
-              argv.AddString(CPLSPrintf("%f", xmax));
-              argv.AddString(CPLSPrintf("%f", ymin));
+              argv.AddString(aosUllr[0]);
+              argv.AddString(aosUllr[1]);
+              argv.AddString(aosUllr[2]);
+              argv.AddString(aosUllr[3]);
             }
             else
             {


### PR DESCRIPTION
Adds 'a_ullr' to the allowed options for a "vrt:// connection. The effect is to override the georeferenced bounds in the same way as the option to gdal_translate.

## Examples

```
gdalinfo  "vrt://autotest/gdrivers/data/netcdf/srid.nc?a_ullr=0,90,360,-90"

## chain with other options
gdalinfo  "vrt://autotest/gdrivers/data/netcdf/srid.nc?a_ullr=0,1,1,0&bands=1,1"
```


## related  pull requests

#6893 

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Review
 - [x] Adjust for comments
 - [x] review: use commas not spaces
 - [x] review: clarify order of options ulx,uly,lrx,lry (xmin, ymax, xmax, ymin)  
 - [x] review: avoid string/float churn of tokens 
 - [x] fix python assert  (!) 
 - [ ] All CI builds and checks have passed

