### PR TITLE
CSV vector: pipe separator for read

### DIFF
--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -2750,3 +2750,24 @@ def test_ogr_csv_iter_and_set_feature():
     gdal.Unlink("/vsimem/ogr_csv_iter_and_set_feature.csv")
 
     assert count == 2
+
+
+###############################################################################
+
+
+def test_ogr_csv_pipe_separated():
+    gdal.FileFromMemBuffer(
+        "/vsimem/test_ogr_csv_pipe_separated.psv",
+        """id|str
+1|foo
+""",
+    )
+
+    ds = gdal.OpenEx("/vsimem/test_ogr_csv_pipe_separated.psv")
+    lyr = ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    assert f["id"] == "1"
+    assert f["str"] == "foo"
+    ds = None
+
+    gdal.Unlink("/vsimem/test_ogr_csv_pipe_separated.psv")

--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -20,6 +20,8 @@ point to a directory. For a directory to be recognised as a .csv
 datasource at least half the files in the directory need to have the
 extension .csv. One layer (table) is produced from each .csv file
 accessed.
+Starting with GDAL 3.7, pipe separated values files with .psv extension
+are also recognized.
 
 For files structured as CSV, but not ending
 with .CSV extension, the 'CSV:' prefix can be added before the filename
@@ -77,7 +79,7 @@ CSV files have one line for each feature (record) in the layer (table).
 The attribute field values are separated by commas. At least two fields
 per line must be present. Lines may be terminated by a DOS (CR/LF) or
 Unix (LF) style line terminators. Each record should have the same
-number of fields. The driver will also accept a semicolon, a tabulation, 
+number of fields. The driver will also accept a semicolon, a tabulation,
 a pipe, or a space character as field separator .
 This autodetection will work only if there's no other potential
 separator on the first line of the CSV file. Otherwise it will default

--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -77,8 +77,8 @@ CSV files have one line for each feature (record) in the layer (table).
 The attribute field values are separated by commas. At least two fields
 per line must be present. Lines may be terminated by a DOS (CR/LF) or
 Unix (LF) style line terminators. Each record should have the same
-number of fields. The driver will also accept a semicolon, a tabulation
-or a space character as field separator .
+number of fields. The driver will also accept a semicolon, a tabulation, 
+a pipe, or a space character as field separator .
 This autodetection will work only if there's no other potential
 separator on the first line of the CSV file. Otherwise it will default
 to comma as separator.

--- a/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
@@ -478,6 +478,9 @@ CPLString OGRCSVDataSource::GetRealExtension(CPLString osFilename)
         else if( osFilename.size() > 7 &&
                  EQUAL(osFilename + osFilename.size() - 7, ".tsv.gz") )
             return "tsv";
+        else if( osFilename.size() > 7 &&
+                 EQUAL(osFilename + osFilename.size() - 7, ".psv.gz") )
+            return "psv";
     }
     return osExt;
 }
@@ -570,7 +573,8 @@ int OGRCSVDataSource::Open( const char *pszFilename, int bUpdateIn,
 
     // Is this a single CSV file?
     if( VSI_ISREG(sStatBuf.st_mode)
-        && (bIgnoreExtension || EQUAL(osExt, "csv") || EQUAL(osExt, "tsv")) )
+        && (bIgnoreExtension || EQUAL(osExt, "csv") || EQUAL(osExt, "tsv") ||
+            EQUAL(osExt, "psv")) )
     {
         if (EQUAL(CPLGetFilename(osFilename), "NfdcFacilities.xls"))
         {
@@ -750,6 +754,12 @@ bool OGRCSVDataSource::OpenTable( const char *pszFilename,
         {
             osLayerName = osLayerName.substr(0, osLayerName.size() - 4);
             osExt = "tsv";
+        }
+        else if( strlen(pszFilename) > 7 &&
+                 EQUAL(pszFilename + strlen(pszFilename) - 7, ".psv.gz") )
+        {
+            osLayerName = osLayerName.substr(0, osLayerName.size() - 4);
+            osExt = "psv";
         }
     }
 

--- a/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
@@ -94,7 +94,7 @@ static int OGRCSVDriverIdentify( GDALOpenInfo *poOpenInfo )
         {
             return TRUE;
         }
-        else if( EQUAL(osExt, "csv") || EQUAL(osExt, "tsv") )
+        else if( EQUAL(osExt, "csv") || EQUAL(osExt, "tsv") || EQUAL(osExt, "psv") )
         {
             return TRUE;
         }
@@ -313,7 +313,7 @@ void RegisterOGRCSV()
 
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME,
                               "Comma Separated Value (.csv)");
-    poDriver->SetMetadataItem(GDAL_DMD_EXTENSION, "csv");
+    poDriver->SetMetadataItem(GDAL_DMD_EXTENSIONS, "csv tsv psv");
     poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/vector/csv.html");
     poDriver->SetMetadataItem( GDAL_DMD_SUPPORTED_SQL_DIALECTS, "OGRSQL SQLITE" );
 

--- a/port/cpl_csv.cpp
+++ b/port/cpl_csv.cpp
@@ -537,7 +537,7 @@ char CSVDetectSeperator( const char* pszLine )
     for( ; *pszLine != '\0'; pszLine++ )
     {
         if( !bInString && ( *pszLine == ',' || *pszLine == ';'
-                            || *pszLine == '\t'))
+                            || *pszLine == '\t' || *pszLine == '|'))
         {
             if( chDelimiter == '\0' )
             {

--- a/port/cpl_csv.cpp
+++ b/port/cpl_csv.cpp
@@ -523,10 +523,11 @@ static void CSVIngest( const char *pszFilename )
 
 /** Detect which field separator is used.
  *
- * Currently, it can detect comma, semicolon, space or tabulation. In case of
- * ambiguity or no separator found, comma will be considered as the separator.
+ * Currently, it can detect comma, semicolon, space, tabulation or pipe.
+ * In case of ambiguity or no separator found, comma will be considered as the
+ * separator.
  *
- * @return ',', ';', ' ' or tabulation character.
+ * @return ',', ';', ' ', tabulation character or '|'.
  */
 char CSVDetectSeperator( const char* pszLine )
 {


### PR DESCRIPTION
Adds the PIPE separator for CSV vector driver in read mode. 

I tested on GNAF file (download link from link in #6811 

Note the use of driver declaration with "CSV:<file>", else rename to ".csv". 

```R
ogrinfo CSV:TAS_ADDRESS_DEFAULT_GEOCODE_psv.psv
INFO: Open of `CSV:TAS_ADDRESS_DEFAULT_GEOCODE_psv.psv'
      using driver `CSV' successful.
1: TAS_ADDRESS_DEFAULT_GEOCODE_psv (None)
```

(I haven't attempted autotests because the python is a bit more involved than I'm comfortable with yet.)

## What are related issues/pull requests?

#6811  feature wish, and suggested PR approach


## Tasklist

 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

