### PR TITLE
Netcdf 6195 assume longlat

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1126,6 +1126,18 @@ def test_netcdf_assume_longlat():
         ds = gdal.Open("data/netcdf/trmm-nc2.nc")
         assert ds.GetSpatialRef() is None
 
+    # test open option and config overrides
+    with gdaltest.config_option("GDAL_NETCDF_ASSUME_LONGLAT", "YES"):
+        ds = gdal.OpenEx("data/netcdf/trmm-nc2.nc", open_options=["ASSUME_LONGLAT=NO"])
+        srs = ds.GetSpatialRef()
+        assert srs is None
+    with gdaltest.config_option("GDAL_NETCDF_ASSUME_LONGLAT", "NO"):
+        ds = gdal.OpenEx("data/netcdf/trmm-nc2.nc", open_options=["ASSUME_LONGLAT=YES"])
+        assert ds.GetSpatialRef() is not None
+        assert (
+            srs.ExportToWkt()
+            == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
+        )
 
 ###############################################################################
 # check support for writing multi-dimensional files (helper function)

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1118,10 +1118,7 @@ def test_netcdf_assume_longlat():
         ds = gdal.Open("data/netcdf/trmm-nc2.nc")
         srs = ds.GetSpatialRef()
         assert srs is not None
-        assert (
-            srs.ExportToWkt()
-            == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
-        )
+        assert srs.ExportToWkt().startswith('GEOGCS["WGS 84')
     with gdaltest.config_option("GDAL_NETCDF_ASSUME_LONGLAT", "NO"):
         ds = gdal.Open("data/netcdf/trmm-nc2.nc")
         assert ds.GetSpatialRef() is None

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1116,7 +1116,7 @@ def test_netcdf_assume_longlat():
     # test default config
     config_bak = gdal.GetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT")
     gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "YES")
-    ds = gdal.Open("data/netcdf/trmm-nc2.nc")  
+    ds = gdal.Open("data/netcdf/trmm-nc2.nc")
     srs = ds.GetSpatialRef()
     assert srs is not None
     assert (
@@ -1124,7 +1124,7 @@ def test_netcdf_assume_longlat():
         == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
     )
     gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "NO")
-    ds = gdal.Open("data/netcdf/trmm-nc2.nc")  
+    ds = gdal.Open("data/netcdf/trmm-nc2.nc")
     assert ds.GetSpatialRef() is None
     ## restore what it was
     gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", config_bak)

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1134,6 +1134,7 @@ def test_netcdf_assume_longlat():
         assert srs is not None
         assert srs.ExportToWkt().startswith('GEOGCS["WGS 84')
 
+
 ###############################################################################
 # check support for writing multi-dimensional files (helper function)
 

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1108,6 +1108,29 @@ def test_netcdf_27():
 
 
 ###############################################################################
+# check support for GDAL_NETCDF_ASSUME_LONGLAT configuration option
+
+
+def test_netcdf_assume_longlat():
+
+    # test default config
+    config_bak = gdal.GetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT")
+    gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "YES")
+    ds = gdal.Open("netcdf/trmm-nc2.nc")  
+    srs = ds.GetSpatialRef()
+    assert srs is not None
+    assert (
+        srs.ExportToWkt()
+        == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
+    )
+    gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "NO")
+    ds = gdal.Open("netcdf/trmm-nc2.nc")  
+    assert ds.GetSpatialRef() is None
+    ## restore what it was
+    gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", config_bak)
+
+
+###############################################################################
 # check support for writing multi-dimensional files (helper function)
 
 

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1130,7 +1130,8 @@ def test_netcdf_assume_longlat():
         assert srs is None
     with gdaltest.config_option("GDAL_NETCDF_ASSUME_LONGLAT", "NO"):
         ds = gdal.OpenEx("data/netcdf/trmm-nc2.nc", open_options=["ASSUME_LONGLAT=YES"])
-        assert ds.GetSpatialRef() is not None
+        srs = ds.GetSpatialRef()
+        assert srs is not None
         assert srs.ExportToWkt().startswith('GEOGCS["WGS 84')
 
 ###############################################################################

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1131,10 +1131,7 @@ def test_netcdf_assume_longlat():
     with gdaltest.config_option("GDAL_NETCDF_ASSUME_LONGLAT", "NO"):
         ds = gdal.OpenEx("data/netcdf/trmm-nc2.nc", open_options=["ASSUME_LONGLAT=YES"])
         assert ds.GetSpatialRef() is not None
-        assert (
-            srs.ExportToWkt()
-            == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
-        )
+        assert srs.ExportToWkt().startswith('GEOGCS["WGS 84')
 
 ###############################################################################
 # check support for writing multi-dimensional files (helper function)

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1116,7 +1116,7 @@ def test_netcdf_assume_longlat():
     # test default config
     config_bak = gdal.GetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT")
     gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "YES")
-    ds = gdal.Open("netcdf/trmm-nc2.nc")  
+    ds = gdal.Open("data/netcdf/trmm-nc2.nc")  
     srs = ds.GetSpatialRef()
     assert srs is not None
     assert (
@@ -1124,7 +1124,7 @@ def test_netcdf_assume_longlat():
         == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
     )
     gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "NO")
-    ds = gdal.Open("netcdf/trmm-nc2.nc")  
+    ds = gdal.Open("data/netcdf/trmm-nc2.nc")  
     assert ds.GetSpatialRef() is None
     ## restore what it was
     gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", config_bak)

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1114,20 +1114,17 @@ def test_netcdf_27():
 def test_netcdf_assume_longlat():
 
     # test default config
-    config_bak = gdal.GetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT")
-    gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "YES")
-    ds = gdal.Open("data/netcdf/trmm-nc2.nc")
-    srs = ds.GetSpatialRef()
-    assert srs is not None
-    assert (
-        srs.ExportToWkt()
-        == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
-    )
-    gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "NO")
-    ds = gdal.Open("data/netcdf/trmm-nc2.nc")
-    assert ds.GetSpatialRef() is None
-    ## restore what it was
-    gdal.SetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", config_bak)
+    with gdaltest.config_option("GDAL_NETCDF_ASSUME_LONGLAT", "YES"):
+        ds = gdal.Open("data/netcdf/trmm-nc2.nc")
+        srs = ds.GetSpatialRef()
+        assert srs is not None
+        assert (
+            srs.ExportToWkt()
+            == 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]]'
+        )
+    with gdaltest.config_option("GDAL_NETCDF_ASSUME_LONGLAT", "NO"):
+        ds = gdal.Open("data/netcdf/trmm-nc2.nc")
+        assert ds.GetSpatialRef() is None
 
 
 ###############################################################################

--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -283,6 +283,12 @@ The following open options are available:
    same dimensions, then they should be reported as multiple bands of a same dataset.
    Default is NO (that is each variable will be reported as a separate
    subdataset)
+   
+-  **ASSUME_LONGLAT=[YES/NO]** :  Whether a Geographic CRS should
+    be assumed and applied when, none has otherwise been found, a meaningful 
+    geotransform has been found, and that geotransform is within the bounds 
+    -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.
+
 
 Creation Issues
 ---------------

--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -516,7 +516,7 @@ Configuration Options
    should be always considered as geospatial axis, even if the lack
    conventional attributes confirming it. Default is NO.
 
--  **GDAL_NETCDF_ASSUME_LONGLAT=[YES/NO]** :  Whether a Geographic CRS should
+-  **GDAL_NETCDF_ASSUME_LONGLAT=[YES/NO]** :  GDAL >= 3.7) Whether a Geographic CRS should
     be assumed and applied when, none has otherwise been found, a meaningful 
     geotransform has been found, and that geotransform is within the bounds 
     -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.

--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -510,6 +510,11 @@ Configuration Options
    should be always considered as geospatial axis, even if the lack
    conventional attributes confirming it. Default is NO.
 
+-  **GDAL_NETCDF_ASSUME_LONGLAT=[YES/NO]** :  Whether a Geographic CRS should
+    be assumed and applied when, none has otherwise been found, a meaningful 
+    geotransform has been found, and that geotransform is within the bounds 
+    -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.
+    
 VSI Virtual File System API support
 -----------------------------------
 

--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -284,7 +284,7 @@ The following open options are available:
    Default is NO (that is each variable will be reported as a separate
    subdataset)
    
--  **ASSUME_LONGLAT=[YES/NO]** :  Whether a Geographic CRS should
+-  **ASSUME_LONGLAT=[YES/NO]** :  (GDAL >= 3.7) Whether a Geographic CRS should
     be assumed and applied when, none has otherwise been found, a meaningful 
     geotransform has been found, and that geotransform is within the bounds 
     -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -4783,16 +4783,10 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
     {
       if (bGotCfGT || bGotGdalGT) 
       {
-        bool bAssumedLongLat = false; 
-        // check setting of GDAL_NETCDF_ASSUME_LONGLAT config option.
-        const char *pszCfgValue = CPLGetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", nullptr);
-        if( pszCfgValue )
-        {
-          bAssumedLongLat = CPLTestBool(pszCfgValue);
-          CPLDebug("GDAL_netCDF",
-                   "set bAssumedLongLat=%d because GDAL_NETCDF_ASSUME_LONGLAT=%s",
-                   static_cast<int>(bAssumedLongLat), pszCfgValue);
-        }
+        bool bAssumedLongLat = CPLTestBool(
+          CSLFetchNameValueDef(papszOpenOptions, "ASSUME_LONGLAT",
+                               CPLGetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", "NO"))); 
+ 
         if (bAssumedLongLat && 
             adfTempGeoTransform[0] >= -180 && adfTempGeoTransform[0] < 360 &&
             (adfTempGeoTransform[0] + adfTempGeoTransform[1] * poDS->GetRasterXSize()) <= 360 &&
@@ -4816,6 +4810,12 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
             SetSpatialRefNoUpdate(&oSRS);
           }
           CPLFree(pszTempProjection);
+          
+          CPLDebug("netCDF",
+                   "Assummed Longitude Latitude CRS 'OGC:CRS84' because "
+                   "none otherwise available and geotransform within suitable bounds. "
+                   "Set GDAL_NETCDF_ASSUME_LONGLAT=NO as configuration option or "
+                   "    ASSUME_LONGLAT=NO as open option to bypass this assumption.");
         }
       }
     }
@@ -10610,6 +10610,10 @@ void GDALRegister_netCDF()
     "description='Whether 2D variables that share the same indexing dimensions "
     "should be exposed as several bands of a same dataset instead of several "
     "subdatasets.' default='NO'/>"
+"   <Option name='ASSUME_LONGLAT' type='boolean' scope='raster' "
+    "description='Whether when all else has failed for determining a CRS, a "
+    "meaningful geotransform has been found, and is within the  "
+    "bounds -180,360 -90,90, assume OGC:CRS84.' default='NO'/>"
 "</OpenOptionList>" );
 
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -4805,7 +4805,6 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
           // seems odd to use 4326 so OGC:CRS84
           oSRS.SetFromUserInput("OGC:CRS84");
           oSRS.exportToWkt(&pszTempProjection);
-          bGotGeogCS = true;
           if(returnProjStr != nullptr)
           {
             (*returnProjStr) = std::string(pszTempProjection);

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -2873,7 +2873,6 @@ netCDFDataset::netCDFDataset() :
     nYDimID(-1),
     bIsProjected(false),
     bIsGeographic(false),  // Can be not projected, and also not geographic
-    bAssumedLongLat(false), // GDAL_NETCDF_ASSUME_LONGLAT config option
     
     // State vars.
     bDefineMode(true),
@@ -4784,16 +4783,17 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
     {
       if (bGotCfGT || bGotGdalGT) 
       {
+        bool bAssumedLongLat = false; 
         // check setting of GDAL_NETCDF_ASSUME_LONGLAT config option.
         const char *pszCfgValue = CPLGetConfigOption("GDAL_NETCDF_ASSUME_LONGLAT", nullptr);
         if( pszCfgValue )
         {
-          poDS->bAssumedLongLat = CPLTestBool(pszCfgValue);
+          bAssumedLongLat = CPLTestBool(pszCfgValue);
           CPLDebug("GDAL_netCDF",
                    "set bAssumedLongLat=%d because GDAL_NETCDF_ASSUME_LONGLAT=%s",
-                   static_cast<int>(poDS->bAssumedLongLat), pszCfgValue);
+                   static_cast<int>(bAssumedLongLat), pszCfgValue);
         }
-        if (poDS->bAssumedLongLat && 
+        if (bAssumedLongLat && 
             adfTempGeoTransform[0] >= -180 && adfTempGeoTransform[0] < 360 &&
             (adfTempGeoTransform[0] + adfTempGeoTransform[1] * poDS->GetRasterXSize()) <= 360 &&
             adfTempGeoTransform[3] <= 90 && adfTempGeoTransform[3] > -90 &&

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -4780,8 +4780,6 @@ void netCDFDataset::SetProjectionFromVar( int nGroupId, int nVarId,
 
     // wish of 6195
     // we don't have CS/SRS, but we do have GT, and we live in -180,360 -90,90
-    // TODO and we check a user settable option "NETCDF_ASSUME_WGS84_IN_VERY_LIMITED_CIRCUMSTANCES"
-    // and maybe TODO also require lon*,lat* alike coord var/dim names?
     if (!bGotGeogCS && !bGotCfSRS && !bGotGdalSRS && !bGotCfWktSRS)  
     {
       if (bGotCfGT || bGotGdalGT) 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -2873,7 +2873,6 @@ netCDFDataset::netCDFDataset() :
     nYDimID(-1),
     bIsProjected(false),
     bIsGeographic(false),  // Can be not projected, and also not geographic
-    
     // State vars.
     bDefineMode(true),
     bAddedGridMappingRef(false),

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -90,6 +90,11 @@
 /* Config Options
 
    GDAL_NETCDF_BOTTOMUP=YES/NO overrides bottom-up value on import
+   GDAL_NETCDF_VERIFY_DIMS=[YES/STRICT] : Try to guess which dimensions represent the latitude and longitude only by their attributes (STRICT) or also by guessing the name (YES), default is YES.
+   GDAL_NETCDF_IGNORE_XY_AXIS_NAME_CHECKS=[YES/NO] Whether X/Y dimensions should be always considered as geospatial axis, even if the lack conventional attributes confirming it. Default is NO.
+   GDAL_NETCDF_ASSUME_LONGLAT=[YES/NO] Whether when all else has failed for determining a CRS, a meaningful geotransform has been found, and is within the bounds -180,360 -90,90, if YES assume OGC:CRS84. Default is NO. 
+ 
+   // TODO: this unusued and a few others occur in the source that are not documented, flush out unused opts and document the rest mdsumner@gmail.com 
    GDAL_NETCDF_CONVERT_LAT_180=YES/NO convert longitude values from ]180,360] to [-180,180]
 */
 
@@ -752,6 +757,7 @@ class netCDFDataset final: public GDALPamDataset
     int          nYDimID;
     bool         bIsProjected;
     bool         bIsGeographic;
+    bool         bAssumedLongLat; 
     bool         bSwitchedXY = false;
 
     /* state vars */

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -757,7 +757,6 @@ class netCDFDataset final: public GDALPamDataset
     int          nYDimID;
     bool         bIsProjected;
     bool         bIsGeographic;
-    bool         bAssumedLongLat; 
     bool         bSwitchedXY = false;
 
     /* state vars */


### PR DESCRIPTION
Implements the wish of #6195 to assume a regular grid NetCDF in a reasonable longitude/latitude range adopts the `OGC:CRS84` crs, when all prior attempts to find one have failed. 

- when all other attempts have been tried, we check the bounds and give it longlat crs if within -180,360 -90,90
- new config option `GDAL_NETCDF_ASSUME_LONGLAT` default NO, set to YES to apply the crs 
- new open option `ASSUME_LONGLAT` same as config option `GDAL_NETCDF_ASSUME_LONGLAT` 

There is a python test on `netcdf/trmm-nc2.nc` that invokes the use of the setting (this file otherwise doesn't have a crs set). 

## What are related issues/pull requests?

#6195 

## Example

here on a remote file, provides a CRS OGC:CRS84 only if the config option is set

```
export GDAL_NETCDF_ASSUME_LONGLAT=YES
gdalinfo NETCDF:"/vsicurl/https://rsg.pml.ac.uk/thredds/fileServer/cci/v6.0-release/geographic/daily/chlor_a/2021/ESACCI-OC-L3S-CHLOR_A-MERGED-1D_DAILY_4km_GEO_PML_OCx-20210101-fv6.0.nc":chlor_a -nomd
```

examples to invoke option control and overrides

```
export GDAL_NETCDF_ASSUME_LONGLAT=NO
gdalinfo ../autotest/gdrivers/data/netcdf/trmm-nc2.nc -nomd
gdalinfo ../autotest/gdrivers/data/netcdf/trmm-nc2.nc -nomd -oo ASSUME_LONGLAT=YES

export GDAL_NETCDF_ASSUME_LONGLAT=YES
gdalinfo ../autotest/gdrivers/data/netcdf/trmm-nc2.nc -nomd
gdalinfo ../autotest/gdrivers/data/netcdf/trmm-nc2.nc -nomd -oo ASSUME_LONGLAT=NO
```

Note that this flollowing file doesn't benefit from the assumption, because its geotransform puts it  (just) outside the required range. A possible offshot TODO for me for the VRT driver 'vrt://...?a_ullr', or we could expand the bounds allowed. 

```
gdalinfo ../autotest/gdrivers/data/netcdf/longitude_latitude.nc 
```

## Tasklist

 - [x] add open option as well as config option
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

