### PR TITLE
Add missing <cstdint headers for uint*_t types

### DIFF
--- a/frmts/mrf/LERCV1/Lerc1Image.cpp
+++ b/frmts/mrf/LERCV1/Lerc1Image.cpp
@@ -22,6 +22,7 @@ Contributors:  Thomas Maurer
 */
 
 #include "Lerc1Image.h"
+#include <cstdint>
 #include <cmath>
 #include <cfloat>
 #include <string>

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
@@ -32,6 +32,7 @@
 #include "filegdbtable_priv.h"
 
 #include <cctype>
+#include <cstdint>
 #include <algorithm>
 #include <limits>
 


### PR DESCRIPTION
Without the change buld fails on upcomig `gcc-13` as:

    frmts/mrf/LERCV1/Lerc1Image.cpp: In member function 'bool Lerc1NS::Lerc1Image::isallsameval(int, int, int, int) const':
    frmts/mrf/LERCV1/Lerc1Image.cpp:730:5: error: 'uint32_t' was not declared in this scope
      730 |     uint32_t val = *reinterpret_cast<const uint32_t *>(&(*this)(r0, c0));
          |     ^~~~~~~~
    /build/gdal/frmts/mrf/LERCV1/Lerc1Image.cpp:29:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       28 | #include <algorithm>
      +++ |+#include <cstdint>

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
