### PR TITLE
[Backport release/3.6] Add missing <cstdint headers for uint*_t types

### DIFF
--- a/frmts/mrf/LERCV1/Lerc1Image.cpp
+++ b/frmts/mrf/LERCV1/Lerc1Image.cpp
@@ -22,6 +22,7 @@ Contributors:  Thomas Maurer
 */
 
 #include "Lerc1Image.h"
+#include <cstdint>
 #include <cmath>
 #include <cfloat>
 #include <string>

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
@@ -32,6 +32,7 @@
 #include "filegdbtable_priv.h"
 
 #include <cctype>
+#include <cstdint>
 #include <algorithm>
 #include <limits>
 


### PR DESCRIPTION
Backport #6915
 **Authored by:** @trofi