### PR TITLE
Parquet: update to GeoParquet 1.0.0-beta.1 specification (fixes #6646)

### DIFF
--- a/autotest/ogr/data/parquet/schema.json
+++ b/autotest/ogr/data/parquet/schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GeoParquet",
+  "description": "Parquet metadata included in the geo field.",
+  "type": "object",
+  "required": ["version", "primary_column", "columns"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0.0-beta.1"
+    },
+    "primary_column": {
+      "type": "string",
+      "minLength": 1
+    },
+    "columns": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        ".+": {
+          "type": "object",
+          "required": ["encoding", "geometry_types"],
+          "properties": {
+            "encoding": {
+              "type": "string",
+              "const": "WKB"
+            },
+            "geometry_types": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^(GeometryCollection|(Multi)?(Point|LineString|Polygon))( Z)?$"
+              }
+            },
+            "crs": {
+              "oneOf": [
+                {
+                  "$ref": "https://proj.org/schemas/v0.5/projjson.schema.json"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "edges": {
+              "type": "string",
+              "enum": ["planar", "spherical"]
+            },
+            "orientation": {
+              "type": "string",
+              "const": "counterclockwise"
+            },
+            "bbox": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "oneOf": [
+                {
+                  "description": "2D bbox consisting of (xmin, ymin, xmax, ymax)",
+                  "minItems": 4,
+                  "maxItems": 4
+                },
+                {
+                  "description": "3D bbox consisting of (xmin, ymin, zmin, xmax, ymax, zmax)",
+                  "minItems": 6,
+                  "maxItems": 6
+                }
+              ]
+            },
+            "epoch": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -510,7 +510,7 @@ def test_ogr_parquet_write_from_another_dataset(use_vsi, row_group_size, fid):
         j = json.loads(geo)
         assert j is not None
         assert "version" in j
-        assert j["version"] == "0.4.0"
+        assert j["version"] == "1.0.0-beta.1"
         assert "primary_column" in j
         assert j["primary_column"] == "geometry"
         assert "columns" in j
@@ -814,14 +814,20 @@ def test_ogr_parquet_edges(edges):
 
 
 ###############################################################################
-# Test geometry_type support
+# Test geometry_types support
 
 
 @pytest.mark.parametrize(
-    "written_geom_type,written_wkt,expected_geom_type,expected_wkts",
+    "written_geom_type,written_wkt,expected_ogr_geom_type,expected_wkts,expected_geometry_types",
     [
-        (ogr.wkbPoint, ["POINT (1 2)"], ogr.wkbPoint, None),
-        (ogr.wkbLineString, ["LINESTRING (1 2,3 4)"], ogr.wkbLineString, None),
+        (ogr.wkbPoint, ["POINT (1 2)"], ogr.wkbPoint, None, ["Point"]),
+        (
+            ogr.wkbLineString,
+            ["LINESTRING (1 2,3 4)"],
+            ogr.wkbLineString,
+            None,
+            ["LineString"],
+        ),
         (
             ogr.wkbPolygon,
             [
@@ -833,29 +839,39 @@ def test_ogr_parquet_edges(edges):
                 "POLYGON ((0 0,1 0,1 1,0 1,0 0))",
                 "POLYGON ((0 0,1 0,1 1,0 1,0 0),(0.2 0.2,0.2 0.8,0.8 0.8,0.2 0.2))",
             ],
+            ["Polygon"],
         ),
-        (ogr.wkbMultiPoint, ["MULTIPOINT ((1 2))"], ogr.wkbMultiPoint, None),
+        (
+            ogr.wkbMultiPoint,
+            ["MULTIPOINT ((1 2))"],
+            ogr.wkbMultiPoint,
+            None,
+            ["MultiPoint"],
+        ),
         (
             ogr.wkbMultiLineString,
             ["MULTILINESTRING ((1 2,3 4))"],
             ogr.wkbMultiLineString,
             None,
+            ["MultiLineString"],
         ),
         (
             ogr.wkbMultiPolygon,
             ["MULTIPOLYGON (((0 0,1 0,1 1,0 1,0 0)))"],
             ogr.wkbMultiPolygon,
             None,
+            ["MultiPolygon"],
         ),
         (
             ogr.wkbGeometryCollection,
             ["GEOMETRYCOLLECTION (POINT (1 2))"],
             ogr.wkbGeometryCollection,
             None,
+            ["GeometryCollection"],
         ),
-        (ogr.wkbPoint25D, ["POINT Z (1 2 3)"], ogr.wkbPoint25D, None),
-        (ogr.wkbUnknown, ["POINT (1 2)"], ogr.wkbPoint, None),
-        (ogr.wkbUnknown, ["POINT Z (1 2 3)"], ogr.wkbPoint25D, None),
+        (ogr.wkbPoint25D, ["POINT Z (1 2 3)"], ogr.wkbPoint25D, None, ["Point Z"]),
+        (ogr.wkbUnknown, ["POINT (1 2)"], ogr.wkbPoint, None, ["Point"]),
+        (ogr.wkbUnknown, ["POINT Z (1 2 3)"], ogr.wkbPoint25D, None, ["Point Z"]),
         (
             ogr.wkbUnknown,
             [
@@ -867,12 +883,14 @@ def test_ogr_parquet_edges(edges):
                 "MULTIPOLYGON (((0 0,1 0,1 1,0 1,0 0)))",
                 "MULTIPOLYGON (((0 0,1 0,1 1,0 1,0 0)))",
             ],
+            ["Polygon", "MultiPolygon"],
         ),
         (
             ogr.wkbUnknown,
             ["LINESTRING (1 2,3 4)", "MULTILINESTRING ((10 2,3 4))"],
             ogr.wkbMultiLineString,
             ["MULTILINESTRING ((1 2,3 4))", "MULTILINESTRING ((10 2,3 4))"],
+            ["LineString", "MultiLineString"],
         ),
         (
             ogr.wkbUnknown,
@@ -882,12 +900,33 @@ def test_ogr_parquet_edges(edges):
                 "MULTILINESTRING Z ((1 2 10,3 4 20))",
                 "MULTILINESTRING Z ((1 2 10,3 4 20))",
             ],
+            ["LineString Z", "MultiLineString Z"],
         ),
-        (ogr.wkbUnknown, ["POINT (1 2)", "LINESTRING (1 2,3 4)"], ogr.wkbUnknown, None),
+        (
+            ogr.wkbUnknown,
+            ["POINT (1 2)", "LINESTRING (1 2,3 4)"],
+            ogr.wkbUnknown,
+            None,
+            ["Point", "LineString"],
+        ),
+        (
+            ogr.wkbUnknown,
+            ["LINESTRING Z (1 2 10,3 4 20)", "MULTILINESTRING ((1 2,3 4))"],
+            ogr.wkbMultiLineString25D,
+            [
+                "MULTILINESTRING Z ((1 2 10,3 4 20))",
+                "MULTILINESTRING Z ((1 2 0,3 4 0))",
+            ],
+            ["LineString Z", "MultiLineString"],
+        ),
     ],
 )
-def test_ogr_parquet_geometry_type(
-    written_geom_type, written_wkt, expected_geom_type, expected_wkts
+def test_ogr_parquet_geometry_types(
+    written_geom_type,
+    written_wkt,
+    expected_ogr_geom_type,
+    expected_wkts,
+    expected_geometry_types,
 ):
 
     outfilename = "/vsimem/out.parquet"
@@ -902,13 +941,25 @@ def test_ogr_parquet_geometry_type(
     ds = ogr.Open(outfilename)
     assert ds is not None
     lyr = ds.GetLayer(0)
-    assert lyr.GetGeomType() == expected_geom_type
+    assert lyr.GetGeomType() == expected_ogr_geom_type
     assert lyr.GetSpatialRef() is None
     if expected_wkts is None:
         expected_wkts = written_wkt
     for wkt in expected_wkts:
         f = lyr.GetNextFeature()
         assert f.GetGeometryRef().ExportToIsoWkt() == wkt
+
+    geo = lyr.GetMetadataItem("geo", "_PARQUET_METADATA_")
+    assert geo is not None
+    j = json.loads(geo)
+    assert j is not None
+    assert "columns" in j
+    assert "geometry" in j["columns"]
+    assert "geometry_types" in j["columns"]["geometry"]
+    assert set(j["columns"]["geometry"]["geometry_types"]) == set(
+        expected_geometry_types
+    )
+    ds = None
 
     gdal.Unlink(outfilename)
 
@@ -1512,3 +1563,46 @@ def test_ogr_parquet_arrow_stream_numpy():
         len(batch.keys())
         == lyr.GetLayerDefn().GetFieldCount() - len(ignored_fields) + 1 + 1
     )
+
+
+###############################################################################
+# Test bbox
+
+
+@pytest.mark.parametrize(
+    "input_geometries,expected_bbox",
+    [
+        (["POINT(1 2)"], [1, 2, 1, 2]),
+        (["POINT(1 2 3)"], [1, 2, 3, 1, 2, 3]),
+        (["POINT(3 4)", "POINT(1 2)"], [1, 2, 3, 4]),
+        (["POINT(4 5 6)", "POINT(1 2 3)"], [1, 2, 3, 4, 5, 6]),
+        (["POINT(4 5 6)", "POINT(1 2)"], [1, 2, 6, 4, 5, 6]),
+    ],
+)
+def test_ogr_parquet_bbox(input_geometries, expected_bbox):
+
+    outfilename = "/vsimem/out.parquet"
+    ds = gdal.GetDriverByName("Parquet").Create(outfilename, 0, 0, 0, gdal.GDT_Unknown)
+    lyr = ds.CreateLayer("out")
+    for input_geom in input_geometries:
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometryDirectly(ogr.CreateGeometryFromWkt(input_geom))
+        lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open(outfilename)
+    assert ds is not None
+    lyr = ds.GetLayer(0)
+    assert lyr is not None
+
+    geo = lyr.GetMetadataItem("geo", "_PARQUET_METADATA_")
+    assert geo is not None
+    j = json.loads(geo)
+    assert j is not None
+    assert "columns" in j
+    assert "geometry" in j["columns"]
+    assert "bbox" in j["columns"]["geometry"]
+    assert j["columns"]["geometry"]["bbox"] == expected_bbox
+    ds = None
+
+    gdal.Unlink(outfilename)

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -19,6 +19,7 @@ This driver also supports geometry columns using the GeoParquet specification.
 
 .. note:: The driver should be considered experimental as the GeoParquet specification is not finalized yet.
 
+The GeoParquet 1.0.0-beta1 specification is supported since GDAL 3.6.2
 
 Driver capabilities
 -------------------

--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -241,6 +241,14 @@ class CPL_DLL OGREnvelope3D : public OGREnvelope
         MaxZ = MAX(MaxZ,sOther.MaxZ);
     }
 
+    /** Update the current object by computing its union with the other rectangle */
+    void Merge( OGREnvelope const& sOther ) {
+        MinX = MIN(MinX,sOther.MinX);
+        MaxX = MAX(MaxX,sOther.MaxX);
+        MinY = MIN(MinY,sOther.MinY);
+        MaxY = MAX(MaxY,sOther.MaxY);
+    }
+
     /** Update the current object by computing its union with the provided point */
     void Merge( double dfX, double dfY, double dfZ ) {
         MinX = MIN(MinX,dfX);

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -253,7 +253,7 @@ protected:
         std::vector<uint8_t>                        m_abyBuffer{};
 
         std::vector<int>                            m_anTZFlag{};    // size: GetFieldCount()
-        std::vector<OGREnvelope>                    m_aoEnvelopes{}; // size: GetGeomFieldCount()
+        std::vector<OGREnvelope3D>                  m_aoEnvelopes{}; // size: GetGeomFieldCount()
         std::vector<std::set<OGRwkbGeometryType>>   m_oSetWrittenGeometryTypes{}; // size: GetGeomFieldCount()
 
         static OGRArrowGeomEncoding GetPreciseArrowGeomEncoding(

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -1156,9 +1156,18 @@ OGRErr OGRArrowWriterLayer::ICreateFeature( OGRFeature* poFeature )
         const bool bIsEmpty = poGeom != nullptr && poGeom->IsEmpty();
         if( poGeom != nullptr && !bIsEmpty )
         {
-            OGREnvelope oEnvelope;
-            poGeom->getEnvelope(&oEnvelope);
-            m_aoEnvelopes[i].Merge(oEnvelope);
+            if( poGeom->Is3D() )
+            {
+                OGREnvelope3D oEnvelope;
+                poGeom->getEnvelope(&oEnvelope);
+                m_aoEnvelopes[i].Merge(oEnvelope);
+            }
+            else
+            {
+                OGREnvelope oEnvelope;
+                poGeom->getEnvelope(&oEnvelope);
+                m_aoEnvelopes[i].Merge(oEnvelope);
+            }
             m_oSetWrittenGeometryTypes[i].insert(eGType);
         }
 


### PR DESCRIPTION
Main changes in the implementation are:
- "geometry_type" is renamed as "geometry_types" and is always an array
- "bbox" is written with zmin and zmax when there are 3D geometries
- slightly improved deduction of OGR layer geometry type when there are mixes like LineString, LineString Z, MultiLineString in geometry_types

CC @jorisvandenbossche @paleolimbot @cholmes