### PR TITLE
[Backport release/3.6] GML: fix recognizing WFS GetFeature response with a very long initial XML element (fixes #6940)

### DIFF
--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -247,6 +247,9 @@ OGRGMLDataSource::~OGRGMLDataSource()
 
 bool OGRGMLDataSource::CheckHeader(const char *pszStr)
 {
+    if (strstr(pszStr, "<wfs:FeatureCollection ") != nullptr)
+        return true;
+
     if (strstr(pszStr, "opengis.net/gml") == nullptr &&
         strstr(pszStr, "<csw:GetRecordsResponse") == nullptr)
     {


### PR DESCRIPTION
Backport #6941
 **Authored by:** @rouault