### PR TITLE
[Backport release/3.6] ogr2ogr: silent reprojection errors related to IsPolarToWGS84() in OGRGeometryFactory::transformWithOptions()

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -1101,6 +1101,23 @@ class CompositeCT : public OGRCoordinateTransformation
                        : nullptr;
     }
 
+    virtual bool GetEmitErrors() const override
+    {
+        if (poCT1)
+            return poCT1->GetEmitErrors();
+        if (poCT2)
+            return poCT2->GetEmitErrors();
+        return true;
+    }
+
+    virtual void SetEmitErrors(bool bEmitErrors) override
+    {
+        if (poCT1)
+            poCT1->SetEmitErrors(bEmitErrors);
+        if (poCT2)
+            poCT2->SetEmitErrors(bEmitErrors);
+    }
+
     virtual int Transform(int nCount, double *x, double *y, double *z,
                           double *t, int *pabSuccess) override
     {


### PR DESCRIPTION
Backport #6945
 **Authored by:** @rouault