### PR TITLE
[Backport release/3.6] AAIGRID: fix CreateCopy() of source raster with south-up orientation (fixes #6946)

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -997,7 +997,7 @@ def test_rasterio_15():
 nrows        2
 xllcorner    0
 yllcorner    0
-cellsize     0
+cellsize     1
   0   100
 100   100""",
     )

--- a/autotest/gdrivers/aaigrid.py
+++ b/autotest/gdrivers/aaigrid.py
@@ -32,6 +32,7 @@
 ###############################################################################
 
 import os
+import struct
 
 import gdaltest
 import pytest
@@ -452,3 +453,27 @@ null 1.5 null 3.5
     ds = None
 
     gdal.Unlink("/vsimem/test_aaigrid_null.asc")
+
+
+###############################################################################
+# Test fix for #6946
+
+
+def test_aaigrid_write_south_up_raster():
+
+    ds = gdal.Open("data/byte.tif")
+    mem_ds = gdal.GetDriverByName("MEM").Create("", 1, 2, 1, gdal.GDT_Float32)
+    mem_ds.SetGeoTransform([2, 1, 0, 49, 0, 1])
+    mem_ds.GetRasterBand(1).WriteRaster(0, 0, 1, 2, struct.pack("f" * 2, 1, 2))
+    ds = None
+    gdal.GetDriverByName("AAIGRID").CreateCopy(
+        "/vsimem/test_aaigrid_write_south_up_raster.asc", mem_ds
+    )
+
+    ds = gdal.Open("/vsimem/test_aaigrid_write_south_up_raster.asc")
+    assert ds.GetGeoTransform() == pytest.approx([2, 1, 0, 51, 0, -1])
+    assert struct.unpack("f" * 2, ds.GetRasterBand(1).ReadRaster()) == (2, 1)
+
+    gdal.GetDriverByName("AAIGRID").Delete(
+        "/vsimem/test_aaigrid_write_south_up_raster.asc"
+    )


### PR DESCRIPTION
Backport #6948
 **Authored by:** @rouault