### PR TITLE
VRTSourcedRasterBand: replace potentially unsafe cpl::down_cast<> by dynamic_cast<>

### DIFF
--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -168,8 +168,9 @@ CPLErr VRTSourcedRasterBand::IRasterIO(
     /*      Do we have overviews that would be appropriate to satisfy       */
     /*      this request?                                                   */
     /* ==================================================================== */
-    auto l_poDS = cpl::down_cast<VRTDataset *>(poDS);
-    if (l_poDS->m_apoOverviews.empty() &&  // do not use virtual overviews
+    auto l_poDS = dynamic_cast<VRTDataset *>(poDS);
+    if (l_poDS &&
+        l_poDS->m_apoOverviews.empty() &&  // do not use virtual overviews
         (nBufXSize < nXSize || nBufYSize < nYSize) && GetOverviewCount() > 0)
     {
         if (OverviewRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize, pData,
@@ -827,7 +828,7 @@ CPLErr VRTSourcedRasterBand::ComputeRasterMinMax(int bApproxOK,
 
         if (poBand != nullptr && poBand != this)
         {
-            auto l_poDS = cpl::down_cast<VRTDataset *>(poDS);
+            auto l_poDS = dynamic_cast<VRTDataset *>(poDS);
             if (l_poDS && !l_poDS->m_apoOverviews.empty() &&
                 dynamic_cast<VRTSourcedRasterBand *>(poBand) != nullptr)
             {
@@ -1107,7 +1108,7 @@ CPLErr VRTSourcedRasterBand::ComputeStatistics(int bApproxOK, double *pdfMin,
 
         if (poBand != nullptr && poBand != this)
         {
-            auto l_poDS = cpl::down_cast<VRTDataset *>(poDS);
+            auto l_poDS = dynamic_cast<VRTDataset *>(poDS);
             if (l_poDS && !l_poDS->m_apoOverviews.empty() &&
                 dynamic_cast<VRTSourcedRasterBand *>(poBand) != nullptr)
             {
@@ -1549,7 +1550,7 @@ CPLErr VRTSourcedRasterBand::GetHistogram(double dfMin, double dfMax,
 
         if (poBand != nullptr && poBand != this)
         {
-            auto l_poDS = cpl::down_cast<VRTDataset *>(poDS);
+            auto l_poDS = dynamic_cast<VRTDataset *>(poDS);
             if (l_poDS && !l_poDS->m_apoOverviews.empty() &&
                 dynamic_cast<VRTSourcedRasterBand *>(poBand) != nullptr)
             {
@@ -2358,7 +2359,12 @@ CPLErr VRTSourcedRasterBand::SetMetadataItem(const char *pszName,
         if (psTree == nullptr)
             return CE_Failure;
 
-        auto l_poDS = cpl::down_cast<VRTDataset *>(GetDataset());
+        auto l_poDS = dynamic_cast<VRTDataset *>(GetDataset());
+        if (l_poDS == nullptr)
+        {
+            CPLDestroyXMLNode(psTree);
+            return CE_Failure;
+        }
         VRTSource *const poSource =
             poDriver->ParseSource(psTree, nullptr, l_poDS->m_oMapSharedSources);
         CPLDestroyXMLNode(psTree);
@@ -2389,7 +2395,12 @@ CPLErr VRTSourcedRasterBand::SetMetadataItem(const char *pszName,
         if (psTree == nullptr)
             return CE_Failure;
 
-        auto l_poDS = cpl::down_cast<VRTDataset *>(GetDataset());
+        auto l_poDS = dynamic_cast<VRTDataset *>(GetDataset());
+        if (l_poDS == nullptr)
+        {
+            CPLDestroyXMLNode(psTree);
+            return CE_Failure;
+        }
         VRTSource *const poSource =
             poDriver->ParseSource(psTree, nullptr, l_poDS->m_oMapSharedSources);
         CPLDestroyXMLNode(psTree);
@@ -2440,7 +2451,12 @@ CPLErr VRTSourcedRasterBand::SetMetadata(char **papszNewMD,
             if (psTree == nullptr)
                 return CE_Failure;
 
-            auto l_poDS = cpl::down_cast<VRTDataset *>(GetDataset());
+            auto l_poDS = dynamic_cast<VRTDataset *>(GetDataset());
+            if (l_poDS == nullptr)
+            {
+                CPLDestroyXMLNode(psTree);
+                return CE_Failure;
+            }
             VRTSource *const poSource = poDriver->ParseSource(
                 psTree, nullptr, l_poDS->m_oMapSharedSources);
             CPLDestroyXMLNode(psTree);


### PR DESCRIPTION
Given that there's no guarantee that VRTSourcedRasterBand is attached to a VRTDataset
