### PR TITLE
CSHARP: Add SkiaSharp

### DIFF
--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -92,7 +92,11 @@ endif ()
 
 # needed because of differences in the packages
 if (DOTNET_FOUND)
-  set(CSHARP_DRAWING "System.Drawing.Common")
+  if(_CSHARP_LIBRARY_SDK_NUMBER LESS "6")
+    set(CSHARP_DRAWING "System.Drawing.Common")
+  else ()
+    set(CSHARP_DRAWING "System.Drawing.Primitives;SkiaSharp")
+  endif ()
 else ()
   set(CSHARP_DRAWING "System.Drawing")
 endif ()
@@ -415,7 +419,7 @@ function (gdal_build_csharp_sample)
   endif (_GBCS_DEPENDS)
   if (_GBCS_SYSTEM_DEPENDS)
     foreach (_dep IN LISTS _GBCS_SYSTEM_DEPENDS)
-      if (NOT _dep MATCHES "^OSGeo*.")
+      if (_dep MATCHES "^System*.")
         list(APPEND CSC_OPTIONS /r:${_dep}.dll)
       endif ()
     endforeach ()
@@ -429,7 +433,11 @@ function (gdal_build_csharp_sample)
 
   # build the sample exe
   if (DOTNET_FOUND)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/exe_template.csproj" "${_GBCS_PROJ}.csproj")
+    if ( "SkiaSharp" IN_LIST _GBCS_SYSTEM_DEPENDS)
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/exe_template_dcomp.csproj" "${_GBCS_PROJ}.csproj")
+    else() 
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/exe_template.csproj" "${_GBCS_PROJ}.csproj")
+    endif ()
     add_dotnet(
       ${_GBCS_PROJ_NATIVE}.csproj
       ${CSHARP_CONFIG}

--- a/swig/csharp/apps/GDALAdjustContrast.cs
+++ b/swig/csharp/apps/GDALAdjustContrast.cs
@@ -104,31 +104,6 @@ class GDALAdjustContrast {
             LoadBitmapDirect(ds, bmp, 0, 0, ds.RasterXSize, ds.RasterYSize, ds.RasterXSize, ds.RasterYSize, 0);
             Bitmap newBitmap = (Bitmap)bmp.Clone();
 
-            //create the ColorMatrix
-            float[][] colormatrix = new float[][]
-              {
-                 new float[] {contrastRatio, 0, 0, 0, 0},
-                 new float[] {0, contrastRatio, 0, 0, 0},
-                 new float[] {0, 0, contrastRatio, 0, 0},
-                 new float[] {0, 0, 0, 1, 0},
-                 new float[] {0, 0, 0, 0, 1}
-              };
-            ColorMatrix colorMatrix = new ColorMatrix(colormatrix);
-
-            //create the image attributes
-            ImageAttributes attributes = new ImageAttributes();
-
-            //set the color matrix attribute
-            attributes.SetColorMatrix(colorMatrix);
-
-            //get a graphics object from the new image
-            Graphics g = Graphics.FromImage(newBitmap);
-            //draw the original image on the new image
-            g.DrawImage(bmp,
-               new Rectangle(0, 0, bmp.Width, bmp.Height),
-               0, 0, bmp.Width, bmp.Height,
-               GraphicsUnit.Pixel, attributes);
-
             SaveBitmapDirect(ds, newBitmap, 0, 0, ds.RasterXSize, ds.RasterYSize, ds.RasterXSize, ds.RasterYSize);
 
             ds.FlushCache();

--- a/swig/csharp/drawing_compat.cs
+++ b/swig/csharp/drawing_compat.cs
@@ -1,0 +1,90 @@
+using SkiaSharp;
+using System.IO;
+using System.Drawing;
+using System;
+
+enum PixelFormat
+{
+    Alpha,
+    Canonical,
+    DontCare,
+    Extended,
+    Format16bppArgb1555,
+    Format16bppGrayScale,
+    Format16bppRgb555,
+    Format16bppRgb565,
+    Format1bppIndexed,
+    Format24bppRgb,
+    Format32bppArgb,
+    Format32bppPArgb,
+    Format32bppRgb,
+    Format48bppRgb,
+    Format4bppIndexed,
+    Format64bppPArgb,
+    Format64bppArgb,
+    Format8bppIndexed,
+    Gdi,
+    Indexed,
+    Max,
+    PAlpha,
+    Undefined
+}
+
+enum ImageLockMode
+{
+    ReadOnly,
+    ReadWrite,
+    UserInputBuffer,
+    WriteOnly
+}
+
+class BitmapData {
+    public IntPtr Scan0;
+    public Int32 Stride;
+}
+
+class ColorPalette
+{
+    public Color[] Entries = new Color[256];
+}
+
+class Bitmap : SKBitmap
+{
+    public ColorPalette Palette
+    {
+        get { return new ColorPalette(); } 
+        set { }
+    }
+
+    public Bitmap(Int32 width, Int32 height, PixelFormat pxformat) : base(width, height) { }
+
+    public Bitmap Clone()
+    {
+        return (Bitmap)Copy();
+    }
+
+    public void SetPixel(int x, int y, Color color)
+    {
+        base.SetPixel(x, y, new SKColor((uint)color.ToArgb()));
+    }
+
+    public BitmapData LockBits(System.Drawing.Rectangle rect, ImageLockMode flags, PixelFormat format)
+    {
+        return new BitmapData() { Scan0 = this.GetPixels(), Stride = this.RowBytes };
+    }
+
+    public void UnlockBits(BitmapData data) { }
+
+    public void Save(string filename)
+    {
+        using (MemoryStream memStream = new MemoryStream())
+        using (SKManagedWStream wstream = new SKManagedWStream(memStream))
+        {
+            Encode(wstream, SKEncodedImageFormat.Bmp, 1);
+            byte[] data = memStream.ToArray();
+
+            File.WriteAllBytes(filename, data);
+        }
+    }
+}
+

--- a/swig/csharp/exe_template_dcomp.csproj
+++ b/swig/csharp/exe_template_dcomp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>${CSHARP_APPLICATION_VERSION}</TargetFramework>
+        <RuntimeIdentifier>${CSHARP_RID}</RuntimeIdentifier>
+        <CheckEolTargetFramework>false</CheckEolTargetFramework>
+        <AssemblyVersion>${GDAL_VERSION_MAJOR}.${GDAL_VERSION_MINOR}.${GDAL_VERSION_REV}</AssemblyVersion>
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="${SOURCE_NATIVE}"></Compile>
+        <Compile Include="${CMAKE_CURRENT_SOURCE_DIR}/drawing_compat.cs"></Compile>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

@bjornharrtell @szekerest 

This is a reasonably complicated explanation:

1. The C# bindings build includes a number of sample apps. These are (excellent) code exemplars and also are used in all builds to test the C# bindings - but I don't think they are intended to be used for production or that anybody does so. The Sample applications use `System.Drawing.Bitmap` to manipulate bitmaps.
2. `System.Drawing.Bitmap` uses GDI+ (at least in the non-mono builds) and the cross-platform implementations of that have always been "interesting". Microsoft has clarified the situation by saying that `System.Drawing.Common` (that implements Bitmap) is NOT supported cross-platform (see https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only) after Net6. Net6 builds using this will generate a warning message and from Net7 there will be an error message.
3. In order to future-proof the use of the sample apps as tests, this PR does the following:
- Nothing to the build of actual binding libraries
- Nothing for builds using Net5 or earlier to build the Sample Apps (except for the deletion below)
- Nothing for builds using `mcs` to build the Sample Apps (except for the deletion below)
- For builds using Net6 or later to build the sample apps, the preferred MS replacements `System.Drawing.Primitives` and  `SkiaSharp` are used with a simple and simplistic compatibility layer so that `System.Drawing.Common` types are converted to `SkiaSharp` types. This is not intended to be a complete implementation - just to make sure that the GDAL API is exercised.
- One small piece of functionality is removed from `GDALAdjustContrast.cs` for all builds. This would be very complicated to implement as a compatibility layer and does not change the extent to which the GDAL API is tested.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
