### PR TITLE
GPKG: fix threaded RTree building when creating several layers (3.6.0 regression)

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -626,6 +626,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
 
     // Variables used for background RTree building
     std::string m_osAsyncDBName{};
+    std::string m_osAsyncDBAttachName{};
     sqlite3 *m_hAsyncDBHandle = nullptr;
     cpl::ThreadSafeQueue<std::vector<GPKGRTreeEntry>> m_oQueueRTreeEntries{};
     bool m_bAllowedRTreeThread = false;
@@ -641,6 +642,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
 
     void StartAsyncRTree();
     void CancelAsyncRTree();
+    void RemoveAsyncRTreeTempDB();
     void AsyncRTreeThreadFunction();
 
     virtual OGRErr ResetStatement() override;

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -789,6 +789,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     }
 
     void CreateSpatialIndexIfNecessary();
+    void FinishOrDisableThreadedRTree();
     bool CreateSpatialIndex(const char *pszTableName = nullptr);
     bool DropSpatialIndex(bool bCalledFromSQLFunction = false);
     CPLString ReturnSQLCreateSpatialIndexTriggers(const char *pszTableName,

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -172,6 +172,8 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
 
     bool m_bDateTimeWithTZ = true;
 
+    bool m_bRemoveOGREmptyTable = false;
+
     CPLString m_osTilingScheme = "CUSTOM";
 
     bool ComputeTileAndPixelShifts();

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -6367,6 +6367,14 @@ OGRLayer *GDALGeoPackageDataset::ICreateLayer(const char *pszLayerName,
         }
     }
 
+    if (m_nLayers == 1)
+    {
+        // Async RTree building doesn't play well with multiple layer:
+        // SQLite3 locks being hold for a long time, random failed commits,
+        // etc.
+        m_papoLayers[0]->FinishOrDisableThreadedRTree();
+    }
+
     /* Create a blank layer. */
     auto poLayer = std::unique_ptr<OGRGeoPackageTableLayer>(
         new OGRGeoPackageTableLayer(this, pszLayerName));

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -2349,7 +2349,8 @@ void OGRGeoPackageTableLayer::SetDeferredSpatialIndexCreation(bool bFlag)
     if (bFlag)
     {
         m_bAllowedRTreeThread =
-            sqlite3_threadsafe() != 0 && CPLGetNumCPUs() >= 2 &&
+            m_poDS->GetLayerCount() == 1 && sqlite3_threadsafe() != 0 &&
+            CPLGetNumCPUs() >= 2 &&
             CPLTestBool(
                 CPLGetConfigOption("OGR_GPKG_ALLOW_THREADED_RTREE", "YES"));
 
@@ -2492,6 +2493,19 @@ void OGRGeoPackageTableLayer::CancelAsyncRTree()
     }
     m_bErrorDuringRTreeThread = true;
     RemoveAsyncRTreeTempDB();
+}
+
+/************************************************************************/
+/*                     FinishOrDisableThreadedRTree()                   */
+/************************************************************************/
+
+void OGRGeoPackageTableLayer::FinishOrDisableThreadedRTree()
+{
+    if (m_bThreadRTreeStarted)
+    {
+        CreateSpatialIndexIfNecessary();
+    }
+    m_bAllowedRTreeThread = false;
 }
 
 /************************************************************************/


### PR DESCRIPTION
Async RTree building doesn't play well with multiple layers: SQLite3 locks being hold for a long time, random failed commits, etc