### PR TITLE
[Backport release/3.6] Avoid warning with curl >= 7.87 about CURLOPT_PROGRESSFUNCTION being deprecated (fixes Alpine CI)

### DIFF
--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -481,6 +481,7 @@ static int NewProcessFunction(void *p, curl_off_t dltotal, curl_off_t dlnow,
     return 0;
 }
 
+#if !CURL_AT_LEAST_VERSION(7, 32, 0)
 static int ProcessFunction(void *p, double dltotal, double dlnow,
                            double ultotal, double ulnow)
 {
@@ -488,6 +489,7 @@ static int ProcessFunction(void *p, double dltotal, double dlnow,
         p, static_cast<curl_off_t>(dltotal), static_cast<curl_off_t>(dlnow),
         static_cast<curl_off_t>(ultotal), static_cast<curl_off_t>(ulnow));
 }
+#endif
 
 #endif /* def HAVE_CURL */
 
@@ -1284,15 +1286,15 @@ CPLHTTPResult *CPLHTTPFetchEx(const char *pszURL, CSLConstList papszOptions,
     CurlProcessData stProcessData = {pfnProgress, pProgressArg};
     if (nullptr != pfnProgress)
     {
-        unchecked_curl_easy_setopt(http_handle, CURLOPT_PROGRESSFUNCTION,
-                                   ProcessFunction);
-        unchecked_curl_easy_setopt(http_handle, CURLOPT_PROGRESSDATA,
-                                   &stProcessData);
-
 #if CURL_AT_LEAST_VERSION(7, 32, 0)
         unchecked_curl_easy_setopt(http_handle, CURLOPT_XFERINFOFUNCTION,
                                    NewProcessFunction);
         unchecked_curl_easy_setopt(http_handle, CURLOPT_XFERINFODATA,
+                                   &stProcessData);
+#else
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_PROGRESSFUNCTION,
+                                   ProcessFunction);
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_PROGRESSDATA,
                                    &stProcessData);
 #endif  // CURL_AT_LEAST_VERSION(7,32,0)
         unchecked_curl_easy_setopt(http_handle, CURLOPT_NOPROGRESS, 0L);

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -1307,8 +1307,16 @@ retry:
             }
         }
 
+#if CURL_AT_LEAST_VERSION(7, 55, 0)
+        curl_off_t nSizeTmp = 0;
+        const CURLcode code = curl_easy_getinfo(
+            hCurlHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &nSizeTmp);
+        CPL_IGNORE_RET_VAL(dfSize);
+        dfSize = static_cast<double>(nSizeTmp);
+#else
         const CURLcode code = curl_easy_getinfo(
             hCurlHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &dfSize);
+#endif
         if (code == 0)
         {
             oFileProp.eExists = EXIST_YES;

--- a/port/cpl_vsil_curl_streaming.cpp
+++ b/port/cpl_vsil_curl_streaming.cpp
@@ -636,8 +636,17 @@ vsi_l_offset VSICurlStreamingHandle::GetFileSize()
     double dfSize = 0;
     if (eExists != EXIST_YES)
     {
+#if CURL_AT_LEAST_VERSION(7, 55, 0)
+        curl_off_t nSizeTmp = 0;
+        const CURLcode code = curl_easy_getinfo(
+            hLocalHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &nSizeTmp);
+        CPL_IGNORE_RET_VAL(dfSize);
+        dfSize = static_cast<double>(nSizeTmp);
+#else
+        dfSize = 0;
         const CURLcode code = curl_easy_getinfo(
             hLocalHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &dfSize);
+#endif
         if (code == 0)
         {
             eExists = EXIST_YES;


### PR DESCRIPTION
Backport #6961
 **Authored by:** @rouault