### PR TITLE
[Backport release/3.6] GPKG/SQLite dialect: fix issues when SQL statement provided to ExecuteSQL() starts with space/tabulation/newline (fixes #6976)

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -6638,7 +6638,7 @@ OGRLayer *GDALGeoPackageDataset::ExecuteSQL(const char *pszSQLCommand,
 
     FlushMetadata();
 
-    while (*pszSQLCommand == ' ')
+    while (*pszSQLCommand != '\0' && isspace(*pszSQLCommand))
         pszSQLCommand++;
 
     CPLString osSQLCommand(pszSQLCommand);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
@@ -713,6 +713,9 @@ OGRLayer *OGRSQLiteExecuteSQL(GDALDataset *poDS, const char *pszStatement,
                               OGRGeometry *poSpatialFilter,
                               CPL_UNUSED const char *pszDialect)
 {
+    while (*pszStatement != '\0' && isspace(*pszStatement))
+        pszStatement++;
+
     char *pszTmpDBName = (char *)CPLMalloc(256);
     char szPtr[32];
     snprintf(szPtr, sizeof(szPtr), "%p", pszTmpDBName);


### PR DESCRIPTION
Backport #6979
 **Authored by:** @rouault