### PR TITLE
gdalwarp: add -srcband and -dstband options

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -896,7 +896,7 @@ void GDALWarpOperation::CollectChunkList(int nDstXOff, int nDstYOff,
                 ->AdviseRead(nSrcXOff, nSrcYOff, nSrcX2Off - nSrcXOff,
                              nSrcY2Off - nSrcYOff, nDstXSize, nDstYSize,
                              psOptions->eWorkingDataType, psOptions->nBandCount,
-                             nullptr, nullptr);
+                             psOptions->panSrcBands, nullptr);
         }
     }
 }

--- a/apps/gdalwarp_bin.cpp
+++ b/apps/gdalwarp_bin.cpp
@@ -67,6 +67,7 @@ static void Usage(const char *pszErrorMsg = nullptr)
 {
     printf(
         "Usage: gdalwarp [--help-general] [--formats]\n"
+        "    [-srcband n]* [-dstband n]*\n"
         "    [-s_srs srs_def] [-t_srs srs_def] [-to \"NAME=VALUE\"]* [-vshift "
         "| -novshift]\n"
         "    [[-s_coord_epoch epoch] | [-t_coord_epoch epoch]]\n"

--- a/apps/gdalwarp_bin.cpp
+++ b/apps/gdalwarp_bin.cpp
@@ -67,7 +67,7 @@ static void Usage(const char *pszErrorMsg = nullptr)
 {
     printf(
         "Usage: gdalwarp [--help-general] [--formats]\n"
-        "    [-srcband n]* [-dstband n]*\n"
+        "    [-b|-srcband n]* [-dstband n]*\n"
         "    [-s_srs srs_def] [-t_srs srs_def] [-to \"NAME=VALUE\"]* [-vshift "
         "| -novshift]\n"
         "    [[-s_coord_epoch epoch] | [-t_coord_epoch epoch]]\n"

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -5248,7 +5248,9 @@ GDALWarpAppOptionsNew(char **papszArgv,
             }
         }
 
-        else if (EQUAL(papszArgv[i], "-srcband") && i + 1 < argc)
+        else if ((EQUAL(papszArgv[i], "-srcband") ||
+                  EQUAL(papszArgv[i], "-b")) &&
+                 i + 1 < argc)
         {
             psOptions->anSrcBands.push_back(atoi(papszArgv[++i]));
         }

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -238,6 +238,12 @@ struct GDALWarpAppOptions
 
     /*! Whether to disable vertical shift adjustment */
     bool bNoVShift = false;
+
+    /*! Source bands */
+    std::vector<int> anSrcBands{};
+
+    /*! Destination bands */
+    std::vector<int> anDstBands{};
 };
 
 static CPLErr LoadCutline(const std::string &osCutlineDSName,
@@ -1849,7 +1855,8 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
 
         for (int i = 0; !bHaveNodata && i < psWO->nBandCount; i++)
         {
-            GDALRasterBandH hBand = GDALGetRasterBand(hWrkSrcDS, i + 1);
+            GDALRasterBandH hBand =
+                GDALGetRasterBand(hWrkSrcDS, psWO->panSrcBands[i]);
             dfReal = GDALGetRasterNoDataValue(hBand, &bHaveNodata);
         }
 
@@ -1871,7 +1878,8 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
 
             for (int i = 0; i < psWO->nBandCount; i++)
             {
-                GDALRasterBandH hBand = GDALGetRasterBand(hWrkSrcDS, i + 1);
+                GDALRasterBandH hBand =
+                    GDALGetRasterBand(hWrkSrcDS, psWO->panSrcBands[i]);
 
                 dfReal = GDALGetRasterNoDataValue(hBand, &bHaveNodata);
 
@@ -1950,7 +1958,8 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
                 }
             }
 
-            GDALRasterBandH hBand = GDALGetRasterBand(hDstDS, i + 1);
+            GDALRasterBandH hBand =
+                GDALGetRasterBand(hDstDS, psWO->panDstBands[i]);
             int bClamped = FALSE;
             int bRounded = FALSE;
             psWO->padfDstNoDataReal[i] = GDALAdjustValueToDataType(
@@ -1963,7 +1972,7 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
                     CE_Warning, CPLE_AppDefined,
                     "for band %d, destination nodata value has been clamped "
                     "to %.0f, the original value being out of range.",
-                    i + 1, psWO->padfDstNoDataReal[i]);
+                    psWO->panDstBands[i], psWO->padfDstNoDataReal[i]);
             }
             else if (bRounded)
             {
@@ -1971,7 +1980,7 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
                     CE_Warning, CPLE_AppDefined,
                     "for band %d, destination nodata value has been rounded "
                     "to %.0f, %s being an integer datatype.",
-                    i + 1, psWO->padfDstNoDataReal[i],
+                    psWO->panDstBands[i], psWO->padfDstNoDataReal[i],
                     GDALGetDataTypeName(GDALGetRasterDataType(hBand)));
             }
 
@@ -1992,7 +2001,8 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
         int bHaveNodataAll = TRUE;
         for (int i = 0; i < psWO->nBandCount; i++)
         {
-            GDALRasterBandH hBand = GDALGetRasterBand(hDstDS, i + 1);
+            GDALRasterBandH hBand =
+                GDALGetRasterBand(hDstDS, psWO->panDstBands[i]);
             int bHaveNodata = FALSE;
             GDALGetRasterNoDataValue(hBand, &bHaveNodata);
             bHaveNodataAll &= bHaveNodata;
@@ -2003,7 +2013,8 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
                 CPLMalloc(psWO->nBandCount * sizeof(double)));
             for (int i = 0; i < psWO->nBandCount; i++)
             {
-                GDALRasterBandH hBand = GDALGetRasterBand(hDstDS, i + 1);
+                GDALRasterBandH hBand =
+                    GDALGetRasterBand(hDstDS, psWO->panDstBands[i]);
                 int bHaveNodata = FALSE;
                 psWO->padfDstNoDataReal[i] =
                     GDALGetRasterNoDataValue(hBand, &bHaveNodata);
@@ -2021,7 +2032,8 @@ static void SetupNoData(const char *pszDest, int iSrc, GDALDatasetH hSrcDS,
     {
         for (int i = 0; i < psWO->nBandCount; i++)
         {
-            GDALRasterBandH hBand = GDALGetRasterBand(hDstDS, i + 1);
+            GDALRasterBandH hBand =
+                GDALGetRasterBand(hDstDS, psWO->panDstBands[i]);
             int bHaveNodata = FALSE;
             CPLPushErrorHandler(CPLQuietErrorHandler);
             bool bRedefinedOK =
@@ -2770,10 +2782,17 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
         /*      Setup band mapping. */
         /* --------------------------------------------------------------------
          */
-        if (bEnableSrcAlpha)
-            psWO->nBandCount = GDALGetRasterCount(hWrkSrcDS) - 1;
+        if (psOptions->anSrcBands.empty())
+        {
+            if (bEnableSrcAlpha)
+                psWO->nBandCount = GDALGetRasterCount(hWrkSrcDS) - 1;
+            else
+                psWO->nBandCount = GDALGetRasterCount(hWrkSrcDS);
+        }
         else
-            psWO->nBandCount = GDALGetRasterCount(hWrkSrcDS);
+        {
+            psWO->nBandCount = static_cast<int>(psOptions->anSrcBands.size());
+        }
 
         const int nNeededDstBands =
             psWO->nBandCount + (bEnableDstAlpha ? 1 : 0);
@@ -2795,11 +2814,47 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
             static_cast<int *>(CPLMalloc(psWO->nBandCount * sizeof(int)));
         psWO->panDstBands =
             static_cast<int *>(CPLMalloc(psWO->nBandCount * sizeof(int)));
-
-        for (int i = 0; i < psWO->nBandCount; i++)
+        if (psOptions->anSrcBands.empty())
         {
-            psWO->panSrcBands[i] = i + 1;
-            psWO->panDstBands[i] = i + 1;
+            for (int i = 0; i < psWO->nBandCount; i++)
+            {
+                psWO->panSrcBands[i] = i + 1;
+                psWO->panDstBands[i] = i + 1;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < psWO->nBandCount; i++)
+            {
+                if (psOptions->anSrcBands[i] <= 0 ||
+                    psOptions->anSrcBands[i] > GDALGetRasterCount(hSrcDS))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "-srcband[%d] = %d is invalid", i,
+                             psOptions->anSrcBands[i]);
+                    GDALDestroyTransformer(hTransformArg);
+                    GDALDestroyWarpOptions(psWO);
+                    OGR_G_DestroyGeometry(hCutline);
+                    GDALReleaseDataset(hWrkSrcDS);
+                    GDALReleaseDataset(hDstDS);
+                    return nullptr;
+                }
+                if (psOptions->anDstBands[i] <= 0 ||
+                    psOptions->anDstBands[i] > GDALGetRasterCount(hDstDS))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "-dstband[%d] = %d is invalid", i,
+                             psOptions->anDstBands[i]);
+                    GDALDestroyTransformer(hTransformArg);
+                    GDALDestroyWarpOptions(psWO);
+                    OGR_G_DestroyGeometry(hCutline);
+                    GDALReleaseDataset(hWrkSrcDS);
+                    GDALReleaseDataset(hDstDS);
+                    return nullptr;
+                }
+                psWO->panSrcBands[i] = psOptions->anSrcBands[i];
+                psWO->panDstBands[i] = psOptions->anDstBands[i];
+            }
         }
 
         /* --------------------------------------------------------------------
@@ -2811,7 +2866,13 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
             psWO->nSrcAlphaBand = GDALGetRasterCount(hWrkSrcDS);
 
         if (bEnableDstAlpha)
-            psWO->nDstAlphaBand = GDALGetRasterCount(hDstDS);
+        {
+            if (psOptions->anSrcBands.empty())
+                psWO->nDstAlphaBand = GDALGetRasterCount(hDstDS);
+            else
+                psWO->nDstAlphaBand =
+                    static_cast<int>(psOptions->anDstBands.size()) + 1;
+        }
 
         /* --------------------------------------------------------------------
          */
@@ -3448,7 +3509,6 @@ static GDALDatasetH GDALWarpCreateOutput(
          */
         if (iSrc == 0)
         {
-            nDstBandCount = GDALGetRasterCount(hSrcDS);
             hCT = GDALGetRasterColorTable(GDALGetRasterBand(hSrcDS, 1));
             if (hCT != nullptr)
             {
@@ -3458,11 +3518,52 @@ static GDALDatasetH GDALWarpCreateOutput(
                            GDALGetDescription(hSrcDS));
             }
 
-            for (int iBand = 0; iBand < nDstBandCount; iBand++)
+            if (psOptions->anDstBands.empty())
             {
-                GDALColorInterp eInterp = GDALGetRasterColorInterpretation(
-                    GDALGetRasterBand(hSrcDS, iBand + 1));
-                apeColorInterpretations.push_back(eInterp);
+                nDstBandCount = GDALGetRasterCount(hSrcDS);
+                for (int iBand = 0; iBand < nDstBandCount; iBand++)
+                {
+                    if (psOptions->anDstBands.empty())
+                    {
+                        GDALColorInterp eInterp =
+                            GDALGetRasterColorInterpretation(
+                                GDALGetRasterBand(hSrcDS, iBand + 1));
+                        apeColorInterpretations.push_back(eInterp);
+                    }
+                }
+
+                // Do we want to generate an alpha band in the output file?
+                if (psOptions->bEnableSrcAlpha)
+                    nDstBandCount--;
+
+                if (psOptions->bEnableDstAlpha)
+                    nDstBandCount++;
+            }
+            else
+            {
+                for (int nSrcBand : psOptions->anSrcBands)
+                {
+                    auto hBand = GDALGetRasterBand(hSrcDS, nSrcBand);
+                    GDALColorInterp eInterp =
+                        hBand ? GDALGetRasterColorInterpretation(hBand)
+                              : GCI_Undefined;
+                    apeColorInterpretations.push_back(eInterp);
+                }
+                nDstBandCount = static_cast<int>(psOptions->anDstBands.size());
+                if (psOptions->bEnableDstAlpha)
+                {
+                    nDstBandCount++;
+                    apeColorInterpretations.push_back(GCI_AlphaBand);
+                }
+                else if (GDALGetRasterCount(hSrcDS) &&
+                         GDALGetRasterColorInterpretation(GDALGetRasterBand(
+                             hSrcDS, GDALGetRasterCount(hSrcDS))) ==
+                             GCI_AlphaBand &&
+                         !psOptions->bDisableSrcAlpha)
+                {
+                    nDstBandCount++;
+                    apeColorInterpretations.push_back(GCI_AlphaBand);
+                }
             }
         }
 
@@ -4001,15 +4102,6 @@ static GDALDatasetH GDALWarpCreateOutput(
         adfDstGeoTransform[5] = -psOptions->dfYRes;
     }
 
-    /* -------------------------------------------------------------------- */
-    /*      Do we want to generate an alpha band in the output file?        */
-    /* -------------------------------------------------------------------- */
-    if (psOptions->bEnableSrcAlpha)
-        nDstBandCount--;
-
-    if (psOptions->bEnableDstAlpha)
-        nDstBandCount++;
-
     if (EQUAL(pszFormat, "GTiff"))
     {
 
@@ -4159,18 +4251,24 @@ static GDALDatasetH GDALWarpCreateOutput(
 
         for (int i = 0; i < nBandsToCopy; i++)
         {
-            auto poSrcBand = poSrcDS->GetRasterBand(i + 1);
-            auto poDstBand = poDstDS->GetRasterBand(i + 1);
+            auto poSrcBand = poSrcDS->GetRasterBand(
+                psOptions->anSrcBands.empty() ? i + 1
+                                              : psOptions->anSrcBands[i]);
+            auto poDstBand = poDstDS->GetRasterBand(
+                psOptions->anDstBands.empty() ? i + 1
+                                              : psOptions->anDstBands[i]);
+            if (poSrcBand && poDstBand)
+            {
+                int bHasScale = FALSE;
+                const double dfScale = poSrcBand->GetScale(&bHasScale);
+                if (bHasScale)
+                    poDstBand->SetScale(dfScale);
 
-            int bHasScale = FALSE;
-            const double dfScale = poSrcBand->GetScale(&bHasScale);
-            if (bHasScale)
-                poDstBand->SetScale(dfScale);
-
-            int bHasOffset = FALSE;
-            const double dfOffset = poSrcBand->GetOffset(&bHasOffset);
-            if (bHasOffset)
-                poDstBand->SetOffset(dfOffset);
+                int bHasOffset = FALSE;
+                const double dfOffset = poSrcBand->GetOffset(&bHasOffset);
+                if (bHasOffset)
+                    poDstBand->SetOffset(dfOffset);
+            }
         }
     }
 
@@ -5150,6 +5248,16 @@ GDALWarpAppOptionsNew(char **papszArgv,
             }
         }
 
+        else if (EQUAL(papszArgv[i], "-srcband") && i + 1 < argc)
+        {
+            psOptions->anSrcBands.push_back(atoi(papszArgv[++i]));
+        }
+
+        else if (EQUAL(papszArgv[i], "-dstband") && i + 1 < argc)
+        {
+            psOptions->anDstBands.push_back(atoi(papszArgv[++i]));
+        }
+
         else if (papszArgv[i][0] == '-')
         {
             CPLError(CE_Failure, CPLE_NotSupported, "Unknown option name '%s'",
@@ -5172,6 +5280,21 @@ GDALWarpAppOptionsNew(char **papszArgv,
         CPLError(CE_Failure, CPLE_IllegalArg,
                  "-srcalpha and -nosrcalpha cannot be used together");
         return nullptr;
+    }
+
+    if (!psOptions->anDstBands.empty() &&
+        psOptions->anSrcBands.size() != psOptions->anDstBands.size())
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "-srcband should be specified as many times as -dstband is");
+        return nullptr;
+    }
+    else if (!psOptions->anSrcBands.empty() && psOptions->anDstBands.empty())
+    {
+        for (int i = 0; i < static_cast<int>(psOptions->anSrcBands.size()); ++i)
+        {
+            psOptions->anDstBands.push_back(i + 1);
+        }
     }
 
     if (psOptionsForBinary)

--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -16,6 +16,7 @@ Synopsis
 .. code-block::
 
     gdalwarp [--help-general] [--formats]
+        [-srcband n]* [-dstband n]*
         [-s_srs srs_def] [-t_srs srs_def] [-ct string] [-to "NAME=VALUE"]* [-vshift | -novshift]
         [[-s_coord_epoch epoch] | [-t_coord_epoch epoch]]
         [-order n | -tps | -rpc | -geoloc] [-et err_threshold]
@@ -42,6 +43,31 @@ and can also apply GCPs stored with the image if the image is "raw"
 with control information.
 
 .. program:: gdalwarp
+
+.. option:: -srcband <n>
+
+    .. versionadded:: 3.7
+
+    Specify a input band number to warp (between 1 and the number of bands
+    of the source dataset). This option may be repeated multiple times, to warp
+    several bands of the input dataset. The alpha band should not be specified
+    in the list, as it will be automatically retrieved (unless :option:`-nosrcalpha`
+    is specified).
+    If :option:`-srcband` is not specified, all input bands are used.
+
+.. option:: -dstband <n>
+
+    .. versionadded:: 3.7
+
+    Specify the output band number in which to warp.
+    If :option:`-srcband` is specified, there must be as many occurences of
+    :option:`-dstband` as there are of :option:`-srcband`.
+    The output alpha band should not be specified, as it will be automatically
+    created if the input dataset has an alpha band, or if :option:`-dstalpha`
+    is specified.
+    If :option:`-dstband` is not specified, then
+    ``-dstband 1 -dstband 2 ... -dstband N`` is assumed where N is the number
+    of input bands specified explicitly or implicitly.
 
 .. option:: -s_srs <srs def>
 

--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -16,7 +16,7 @@ Synopsis
 .. code-block::
 
     gdalwarp [--help-general] [--formats]
-        [-srcband n]* [-dstband n]*
+        [-b|-srcband n]* [-dstband n]*
         [-s_srs srs_def] [-t_srs srs_def] [-ct string] [-to "NAME=VALUE"]* [-vshift | -novshift]
         [[-s_coord_epoch epoch] | [-t_coord_epoch epoch]]
         [-order n | -tps | -rpc | -geoloc] [-et err_threshold]
@@ -44,30 +44,61 @@ with control information.
 
 .. program:: gdalwarp
 
+.. option:: -b <n>
+
 .. option:: -srcband <n>
 
     .. versionadded:: 3.7
 
-    Specify a input band number to warp (between 1 and the number of bands
-    of the source dataset). This option may be repeated multiple times, to warp
-    several bands of the input dataset. The alpha band should not be specified
-    in the list, as it will be automatically retrieved (unless :option:`-nosrcalpha`
-    is specified).
-    If :option:`-srcband` is not specified, all input bands are used.
+    Specify an input band number to warp (between 1 and the number of bands
+    of the source dataset).
+
+    This option is used to warp a subset of the input bands. All input bands
+    are used when it is not specified.
+
+    This option may be repeated multiple times to select several input bands.
+    The order in which bands are specified will be the order in which they
+    appear in the output dataset (unless :option:`-dstband` is specified).
+
+    The alpha band should not be specified in the list, as it will be
+    automatically retrieved (unless :option:`-nosrcalpha` is specified).
+
+    The following invokation will warp an input datasets with bands ordered as
+    Blue, Green, Red, NearInfraRed in an output dataset with bands ordered as
+    Red, Green, Blue.
+
+    ::
+
+        gdalwarp in_bgrn.tif out_rgb.tif -b 3 -b 2 -b 1 -overwrite
+
 
 .. option:: -dstband <n>
 
     .. versionadded:: 3.7
 
-    Specify the output band number in which to warp.
+    Specify the output band number in which to warp. In practice, this option
+    is only useful when updating an existing dataset, e.g to warp one band at
+    at time.
+
+    ::
+
+        gdal_create -if in_red.tif -bands 3 out_rgb.tif
+        gdalwarp in_red.tif out_rgb.tif -srcband 1 -dstband 1
+        gdalwarp in_green.tif out_rgb.tif -srcband 1 -dstband 2
+        gdalwarp in_blue.tif out_rgb.tif -srcband 1 -dstband 3
+
+
     If :option:`-srcband` is specified, there must be as many occurences of
     :option:`-dstband` as there are of :option:`-srcband`.
+
     The output alpha band should not be specified, as it will be automatically
     created if the input dataset has an alpha band, or if :option:`-dstalpha`
     is specified.
+
     If :option:`-dstband` is not specified, then
     ``-dstband 1 -dstband 2 ... -dstband N`` is assumed where N is the number
-    of input bands specified explicitly or implicitly.
+    of input bands (specified explicitly either with :option:`-srcband` or
+    implicitly)
 
 .. option:: -s_srs <srs def>
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1832,13 +1832,15 @@ def Translate(destName, srcDS, **kwargs):
     return TranslateInternal(destName, srcDS, opts, callback, callback_data)
 
 def WarpOptions(options=None, format=None,
+         srcBands=None,
+         dstBands=None,
          outputBounds=None,
          outputBoundsSRS=None,
          xRes=None, yRes=None, targetAlignedPixels = False,
          width = 0, height = 0,
          srcSRS=None, dstSRS=None,
          coordinateOperation=None,
-         srcAlpha = False, dstAlpha = False,
+         srcAlpha = None, dstAlpha = False,
          warpOptions=None, errorThreshold=None,
          warpMemoryLimit=None, creationOptions=None, outputType = gdalconst.GDT_Unknown,
          workingType = gdalconst.GDT_Unknown, resampleAlg=None,
@@ -1858,6 +1860,10 @@ def WarpOptions(options=None, format=None,
         can be be an array of strings, a string or let empty and filled from other keywords.
     format:
         output format ("GTiff", etc...)
+    srcBands:
+        list of source band numbers (between 1 and the number of input bands)
+    dstBands:
+        list of output band numbers
     outputBounds:
         output bounds as (minX, minY, maxX, maxY) in target SRS
     outputBoundsSRS:
@@ -1879,7 +1885,8 @@ def WarpOptions(options=None, format=None,
     coordinateOperation:
         coordinate operation as a PROJ string or WKT string
     srcAlpha:
-        whether to force the last band of the input dataset to be considered as an alpha band
+        whether to force the last band of the input dataset to be considered as an alpha band.
+        If set to False, source alpha warping will be disabled.
     dstAlpha:
         whether to force the creation of an output alpha band
     outputType:
@@ -1949,6 +1956,12 @@ def WarpOptions(options=None, format=None,
         new_options = ParseCommandLine(options)
     else:
         new_options = options
+        if srcBands:
+            for b in srcBands:
+                new_options += ['-srcband', str(b)]
+        if dstBands:
+            for b in dstBands:
+                new_options += ['-dstband', str(b)]
         if format is not None:
             new_options += ['-of', format]
         if outputType != gdalconst.GDT_Unknown:
@@ -1973,6 +1986,8 @@ def WarpOptions(options=None, format=None,
             new_options += ['-tap']
         if srcAlpha:
             new_options += ['-srcalpha']
+        elif srcAlpha is not None:
+            new_options += ['-nosrcalpha']
         if dstAlpha:
             new_options += ['-dstalpha']
         if warpOptions is not None:

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -686,13 +686,15 @@ def Translate(destName, srcDS, **kwargs):
     return TranslateInternal(destName, srcDS, opts, callback, callback_data)
 
 def WarpOptions(options=None, format=None,
+         srcBands=None,
+         dstBands=None,
          outputBounds=None,
          outputBoundsSRS=None,
          xRes=None, yRes=None, targetAlignedPixels = False,
          width = 0, height = 0,
          srcSRS=None, dstSRS=None,
          coordinateOperation=None,
-         srcAlpha = False, dstAlpha = False,
+         srcAlpha = None, dstAlpha = False,
          warpOptions=None, errorThreshold=None,
          warpMemoryLimit=None, creationOptions=None, outputType = gdalconst.GDT_Unknown,
          workingType = gdalconst.GDT_Unknown, resampleAlg=None,
@@ -712,6 +714,10 @@ def WarpOptions(options=None, format=None,
         can be be an array of strings, a string or let empty and filled from other keywords.
     format:
         output format ("GTiff", etc...)
+    srcBands:
+        list of source band numbers (between 1 and the number of input bands)
+    dstBands:
+        list of output band numbers
     outputBounds:
         output bounds as (minX, minY, maxX, maxY) in target SRS
     outputBoundsSRS:
@@ -733,7 +739,8 @@ def WarpOptions(options=None, format=None,
     coordinateOperation:
         coordinate operation as a PROJ string or WKT string
     srcAlpha:
-        whether to force the last band of the input dataset to be considered as an alpha band
+        whether to force the last band of the input dataset to be considered as an alpha band.
+        If set to False, source alpha warping will be disabled.
     dstAlpha:
         whether to force the creation of an output alpha band
     outputType:
@@ -803,6 +810,12 @@ def WarpOptions(options=None, format=None,
         new_options = ParseCommandLine(options)
     else:
         new_options = options
+        if srcBands:
+            for b in srcBands:
+                new_options += ['-srcband', str(b)]
+        if dstBands:
+            for b in dstBands:
+                new_options += ['-dstband', str(b)]
         if format is not None:
             new_options += ['-of', format]
         if outputType != gdalconst.GDT_Unknown:
@@ -827,6 +840,8 @@ def WarpOptions(options=None, format=None,
             new_options += ['-tap']
         if srcAlpha:
             new_options += ['-srcalpha']
+        elif srcAlpha is not None:
+            new_options += ['-nosrcalpha']
         if dstAlpha:
             new_options += ['-dstalpha']
         if warpOptions is not None:


### PR DESCRIPTION
.. option:: -srcband <n>

    Specify a input band number to warp (between 1 and the number of bands
    of the source dataset). This option may be repeated multiple times, to warp
    several bands of the input dataset. The alpha band should not be specified
    in the list, as it will be automatically retrieved (unless :option:`-nosrcalpha`
    is specified).
    If :option:`-srcband` is not specified, all input bands are used.

.. option:: -dstband <n>

    Specify the output band number in which to warp.
    If :option:`-srcband` is specified, there must be as many occurences of
    :option:`-dstband` as there are of :option:`-srcband`.
    The output alpha band should not be specified, as it will be automatically
    created if the input dataset has an alpha band, or if :option:`-dstalpha`
    is specified.
    If :option:`-dstband` is not specified, then
    ``-dstband 1 -dstband 2 ... -dstband N`` is assumed where N is the number
    of input bands specified explicitly or implicitly.
