### PR TITLE
#6989: GML-3-dimension as default

### DIFF
--- a/ogr/ogrsf_frmts/gml/gmlhandler.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlhandler.cpp
@@ -770,13 +770,20 @@ OGRErr GMLHandler::startElementGeometry(const char *pszName, int nLenName,
      */
     /* So we have to add it manually */
     if (strcmp(pszName, "posList") == 0 &&
-        CPLGetXMLValue(psCurNode, "srsDimension", nullptr) == nullptr &&
-        m_nSRSDimensionIfMissing != 0)
+        CPLGetXMLValue(psCurNode, "srsDimension", nullptr) == nullptr)
     {
         CPLXMLNode *psChild =
             CPLCreateXMLNode(nullptr, CXT_Attribute, "srsDimension");
-        CPLCreateXMLNode(psChild, CXT_Text,
-                         (m_nSRSDimensionIfMissing == 3) ? "3" : "2");
+
+        const char *dimension = "3";  // #6989: 3-dimension as default
+
+        // when env GML_SRS_DIMENSION_IF_MISSING is set
+        if (m_nSRSDimensionIfMissing == 2)
+        {
+            dimension = "2";
+        }
+
+        CPLCreateXMLNode(psChild, CXT_Text, dimension);
 
         if (psLastChildCurNode == nullptr)
             psCurNode->psChild = psChild;

--- a/ogr/ogrsf_frmts/gml/gmlhandler.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlhandler.cpp
@@ -775,12 +775,15 @@ OGRErr GMLHandler::startElementGeometry(const char *pszName, int nLenName,
         CPLXMLNode *psChild =
             CPLCreateXMLNode(nullptr, CXT_Attribute, "srsDimension");
 
-        const char *dimension = "3";  // #6989: 3-dimension as default
+        const char *dimension =
+            eAppSchemaType == APPSCHEMA_CITYGML
+                ? "3"
+                : "2";  // #6989: 3-dimension as default in CityGML
 
-        // when env GML_SRS_DIMENSION_IF_MISSING is set
         if (m_nSRSDimensionIfMissing != 0)
         {
-            dimension = m_nSRSDimensionIfMissing == 2 ? "2" : "3";
+            // when env GML_SRS_DIMENSION_IF_MISSING is set
+            dimension = m_nSRSDimensionIfMissing == 3 ? "3" : "2";
         }
 
         CPLCreateXMLNode(psChild, CXT_Text, dimension);

--- a/ogr/ogrsf_frmts/gml/gmlhandler.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlhandler.cpp
@@ -778,9 +778,9 @@ OGRErr GMLHandler::startElementGeometry(const char *pszName, int nLenName,
         const char *dimension = "3";  // #6989: 3-dimension as default
 
         // when env GML_SRS_DIMENSION_IF_MISSING is set
-        if (m_nSRSDimensionIfMissing == 2)
+        if (m_nSRSDimensionIfMissing != 0)
         {
-            dimension = "2";
+            dimension = m_nSRSDimensionIfMissing == 2 ? "2" : "3";
         }
 
         CPLCreateXMLNode(psChild, CXT_Text, dimension);


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

- changed to use 3-dimension as default when parsing CityGML.

## What are related issues/pull requests?

related #6989 

## Tasklist

Currently this PR is draft, when I could get consensus about this design I will fill below checklists.)

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
