### PR TITLE
BUG: fix DCAP_VECTOR metadata for Selafin and ESRIC drivers

### DIFF
--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -525,7 +525,6 @@ void CPL_DLL GDALRegister_ESRIC()
 
     poDriver->SetDescription("ESRIC");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
-    poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "NO");
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Esri Compact Cache");
 

--- a/ogr/ogrsf_frmts/selafin/ogrselafindriver.cpp
+++ b/ogr/ogrsf_frmts/selafin/ogrselafindriver.cpp
@@ -224,7 +224,7 @@ void RegisterOGRSelafin()
     GDALDriver *poDriver = new GDALDriver();
 
     poDriver->SetDescription("Selafin");
-    poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "Selafin");
+    poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_LAYER, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_DELETE_LAYER, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_FIELD, "YES");


### PR DESCRIPTION
## What does this PR do?

When checking metadata in pyogrio, I noticed those two drivers had a deviating entry for `DCAP_VECTOR`:

- ESRIC: is a raster driver, and the code generally assumes that DCAP_VECTOR then will be nullptr, not a "NO" string.
- Selafin: is a vector driver, and the exact content of the string doesn't matter that much in practice, but all other vector drivers are using `"YES"` instead.



## Tasklist

Does this need a test?

 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
