### PR TITLE
[Backport release/3.6] BUG: fix DCAP_VECTOR metadata for Selafin and ESRIC drivers

### DIFF
--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -525,7 +525,6 @@ void CPL_DLL GDALRegister_ESRIC()
 
     poDriver->SetDescription("ESRIC");
     poDriver->SetMetadataItem(GDAL_DCAP_RASTER, "YES");
-    poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "NO");
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Esri Compact Cache");
 

--- a/ogr/ogrsf_frmts/selafin/ogrselafindriver.cpp
+++ b/ogr/ogrsf_frmts/selafin/ogrselafindriver.cpp
@@ -224,7 +224,7 @@ void RegisterOGRSelafin()
     GDALDriver *poDriver = new GDALDriver();
 
     poDriver->SetDescription("Selafin");
-    poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "Selafin");
+    poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_LAYER, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_DELETE_LAYER, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_FIELD, "YES");


### PR DESCRIPTION
Backport #6994
 **Authored by:** @jorisvandenbossche