### PR TITLE
[Backport release/3.6] GML: default srsDimension to 3 for CityGML files (fixes #6989)

### DIFF
--- a/autotest/ogr/data/gml/citygml.gml
+++ b/autotest/ogr/data/gml/citygml.gml
@@ -10,7 +10,9 @@
     <trans:Road gml:id="id1">
       <gml:name>aname</gml:name>
       <gml:boundedBy>
-        <gml:Envelope srsDimension="3" srsName="urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783">
+        <!-- Do not specify srsDimension="3" so we check we can default to it for CityGML (#6989) -->
+        <!--<gml:Envelope srsDimension="3" srsName="urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783">-->
+        <gml:Envelope>
           <gml:lowerCorner>0 0 0</gml:lowerCorner>
           <gml:upperCorner>1 1 0</gml:upperCorner>
         </gml:Envelope>
@@ -31,7 +33,7 @@
             <gml:Polygon gml:id="id3">
               <gml:exterior>
                 <gml:LinearRing gml:id="id4">
-                    <gml:posList srsDimension="3">0 0 0 0 1 0 1 1 0 1 0 0 0 0 0</gml:posList>
+                    <gml:posList>0 0 0 0 0.5 0 0 1 0 1 1 0 1 0 0 0 0 0</gml:posList>
                 </gml:LinearRing>
               </gml:exterior>
             </gml:Polygon>

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -733,25 +733,29 @@ def test_ogr_gml_15():
 
 
 ###############################################################################
-# Read CityGML generic attributes
+# Read CityGML generic attributes and reading 3D geometries by default
 
 
-def test_ogr_gml_16():
+def test_ogr_gml_city_gml():
 
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
     ds = ogr.Open("data/gml/citygml.gml")
     lyr = ds.GetLayer(0)
+    assert lyr.GetGeomType() == ogr.wkbMultiPolygon25D
     feat = lyr.GetNextFeature()
 
-    if (
-        feat.GetField("Name_") != "aname"
-        or feat.GetField("a_int_attr") != 2
-        or feat.GetField("a_double_attr") != 3.45
-    ):
-        feat.DumpReadable()
-        pytest.fail("did not get expected values")
+    assert feat.GetField("Name_") == "aname"
+    assert feat.GetField("a_int_attr") == 2
+    assert feat.GetField("a_double_attr") == 3.45
+    assert (
+        feat.GetGeometryRef().ExportToIsoWkt()
+        == "MULTIPOLYGON Z (((0 0 0,0.0 0.5 0,0 1 0,1 1 0,1 0 0,0 0 0)))"
+    )
+    ds = None
+
+    gdal.Unlink("data/gml/citygml.gfs")
 
 
 ###############################################################################

--- a/ogr/ogrsf_frmts/gml/gmlhandler.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlhandler.cpp
@@ -1370,6 +1370,9 @@ OGRErr GMLHandler::startElementTop(const char *pszName, int /*nLenName*/,
     if (strcmp(pszName, "CityModel") == 0)
     {
         eAppSchemaType = APPSCHEMA_CITYGML;
+        // Default to 3D geometries for CityGML (#6989)
+        if (m_nSRSDimensionIfMissing == 0)
+            m_nSRSDimensionIfMissing = 3;
     }
     else if (strcmp(pszName, "AIXMBasicMessage") == 0)
     {


### PR DESCRIPTION
Backport #6997
 **Authored by:** @rouault