### PR TITLE
[Backport release/3.6] JPEGXL: advertize COMPRESSION_REVERSIBILITY=LOSSY when there is a JPEG reconstruction box

### DIFF
--- a/autotest/gdrivers/jpegxl.py
+++ b/autotest/gdrivers/jpegxl.py
@@ -329,7 +329,11 @@ def test_jpegxl_lossless_copy_of_jpeg():
         assert set(ds.GetMetadataDomainList()) == set(
             ["DERIVED_SUBDATASETS", "EXIF", "IMAGE_STRUCTURE"]
         )
-        assert ds.GetMetadataItem("HAS_JPEG_RECONSTRUCTION_DATA", "_DEBUG_") == "YES"
+        assert (
+            ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE")
+            == "LOSSY"
+        )
+        assert ds.GetMetadataItem("ORIGINAL_COMPRESSION", "IMAGE_STRUCTURE") == "JPEG"
 
     ds = None
     gdal.GetDriverByName("JPEGXL").Delete(outfilename)

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -475,11 +475,6 @@ bool JPEGXLDataset::Open(GDALOpenInfo *poOpenInfo)
                 return false;
             }
 
-            GDALDataset::SetMetadataItem(
-                "COMPRESSION_REVERSIBILITY",
-                info.uses_original_profile ? "LOSSLESS (possibly)" : "LOSSY",
-                "IMAGE_STRUCTURE");
-
             nRasterXSize = static_cast<int>(info.xsize);
             nRasterYSize = static_cast<int>(info.ysize);
 
@@ -770,6 +765,23 @@ bool JPEGXLDataset::Open(GDALOpenInfo *poOpenInfo)
         return false;
     }
 
+    GDALDataset::SetMetadataItem("COMPRESSION_REVERSIBILITY",
+                                 info.uses_original_profile
+#ifdef HAVE_JXL_BOX_API
+                                         && !m_bHasJPEGReconstructionData
+                                     ?
+#endif
+                                     "LOSSLESS (possibly)"
+                                     : "LOSSY",
+                                 "IMAGE_STRUCTURE");
+#ifdef HAVE_JXL_BOX_API
+    if (m_bHasJPEGReconstructionData)
+    {
+        GDALDataset::SetMetadataItem("ORIGINAL_COMPRESSION", "JPEG",
+                                     "IMAGE_STRUCTURE");
+    }
+#endif
+
 #ifdef HAVE_JXL_THREADS
     const char *pszNumThreads =
         CPLGetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS");
@@ -996,11 +1008,6 @@ const char *JPEGXLDataset::GetMetadataItem(const char *pszName,
         !m_aosEXIFMetadata.empty())
     {
         return m_aosEXIFMetadata.FetchNameValue(pszName);
-    }
-    else if (pszDomain != nullptr && EQUAL(pszDomain, "_DEBUG_"))
-    {
-        if (EQUAL(pszName, "HAS_JPEG_RECONSTRUCTION_DATA"))
-            return m_bHasJPEGReconstructionData ? "YES" : "NO";
     }
 #endif
 


### PR DESCRIPTION
Backport #7004
 **Authored by:** @rouault