### PR TITLE
[Backport release/3.6] gdalmdimtranslate: do not require VRT driver to be registered (fixes #7021)

### DIFF
--- a/apps/gdalmdimtranslate_lib.cpp
+++ b/apps/gdalmdimtranslate_lib.cpp
@@ -1683,20 +1683,7 @@ GDALMultiDimTranslate(const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
         (!psOptions->aosArraySpec.empty() || !psOptions->aosGroup.empty() ||
          !psOptions->aosSubset.empty() || !psOptions->aosScaleFactor.empty()))
     {
-        auto poVRTDriver = GDALDriver::FromHandle(GDALGetDriverByName("VRT"));
-        if (!poVRTDriver)
-        {
-#ifdef this_is_dead_code_for_now
-            if (bCloseOutDSOnError)
-#endif
-            {
-                GDALClose(hDstDS);
-                hDstDS = nullptr;
-            }
-            return nullptr;
-        }
-        poTmpDS.reset(
-            poVRTDriver->CreateMultiDimensional("", nullptr, nullptr));
+        poTmpDS.reset(VRTDataset::CreateMultiDimensional("", nullptr, nullptr));
         CPLAssert(poTmpDS);
         poTmpSrcDS = poTmpDS.get();
 


### PR DESCRIPTION
Backport #7022
 **Authored by:** @rouault