### PR TITLE
python: fix setup.py directory list issue on macOS

### DIFF
--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -230,13 +230,13 @@ class gdal_ext(build_ext):
         if self.include_dirs is None:
             self.include_dirs = include_dirs
         # Needed on recent MacOSX
-        elif isinstance(self.include_dirs, str) and sys.platform == 'darwin':
+        elif include_dirs and isinstance(self.include_dirs, str) and sys.platform == 'darwin':
             self.include_dirs += ':' + ':'.join(include_dirs)
 
         if self.library_dirs is None:
             self.library_dirs = library_dirs
         # Needed on recent MacOSX
-        elif isinstance(self.library_dirs, str) and sys.platform == 'darwin':
+        elif library_dirs and isinstance(self.library_dirs, str) and sys.platform == 'darwin':
             self.library_dirs += ':' + ':'.join(library_dirs)
 
         if self.libraries is None:


### PR DESCRIPTION
In `finalize_options()`, there is a code-path for existing string-style include/library dirs. In a standalone build this results in appending an empty directory to each list, which leads to CC invocations with bare `-I` and `-L -lgdal`, the latter resulting in modules not being linked to `libgdal`, as the second `-lgdal` argument is interpreted as a dir.

Fix by checking whether `include_dirs`/`library_dirs` are non-empty before appending.

I'm triggering this by using a `setup.cfg` file to cleanly pass build options, something like:

```console
$ wget https://pypi.org/packages/source/G/GDAL/GDAL-3.6.2.tar.gz 
$ tar xzf GDAL-3.6.2.tar.gz
$ cd GDAL-3.6.2
$ echo >setup.cfg <<EOF
[build_ext]
library_dirs=/path/1:/path/2
include_dirs=/path/1:/path/2
libraries=gdal
gdal_config=/path/to/gdal-config
EOF
$ python3 setup.py bdist_wheel
```

In this case `include_dirs` is an empty list, and `self.include_dirs` is `"/path/1:/path/2"` before the append (and same for `library_dirs`/`self.library_dirs`)

## What are related issues/pull requests?

Was introduced to GDAL in Oct 2016 as https://github.com/OSGeo/gdal/commit/ea00f7fb0e04a0e6bd71f441c8b085f7276b2f05

## Tasklist
 - n/a Add test case(s)
 - n/a Add documentation
 - n/a Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: macOS
* Compiler: Apple clang version 14.0.0 (clang-1400.0.29.202)
* Python 3.10.8
