### PR TITLE
cpl_http: Change behaviour - CUSTOMREQUEST option overrides POST request method while sending form

### DIFF
--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -2413,14 +2413,14 @@ void *CPLHTTPSetOptions(void *pcurl, const char *pszURL,
             unchecked_curl_easy_setopt(http_handle, CURLOPT_POSTFIELDS,
                                        pszPost);
         }
+    }
 
-        const char *pszCustomRequest =
-            CSLFetchNameValue(papszOptions, "CUSTOMREQUEST");
-        if (pszCustomRequest != nullptr)
-        {
-            unchecked_curl_easy_setopt(http_handle, CURLOPT_CUSTOMREQUEST,
-                                       pszCustomRequest);
-        }
+    const char *pszCustomRequest =
+        CSLFetchNameValue(papszOptions, "CUSTOMREQUEST");
+    if (pszCustomRequest != nullptr)
+    {
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_CUSTOMREQUEST,
+                                   pszCustomRequest);
     }
 
     const char *pszCookie = CSLFetchNameValue(papszOptions, "COOKIE");


### PR DESCRIPTION
## What does this PR do?
Current CPLHTTPFetch function only allows to send form using POST request method.  This PR also add ability to send form using PUT or PATCH request method.

