### PR TITLE
Fix ogr2ogr error + invalid gpkg output file in some cases

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -4973,7 +4973,8 @@ CPLString OGRGeoPackageTableLayer::GetColumnsOfCreateTable(
     for (size_t i = 0; i < apoFields.size(); i++)
     {
         OGRFieldDefn *poFieldDefn = apoFields[i];
-        if ((eGType != wkbNone) && (stricmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
+        if ((eGType != wkbNone)
+            && (stricmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
         {
             continue;
         }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -4974,7 +4974,7 @@ CPLString OGRGeoPackageTableLayer::GetColumnsOfCreateTable(
     {
         OGRFieldDefn *poFieldDefn = apoFields[i];
         if ((eGType != wkbNone) &&
-            (stricmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
+            (strcmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
         {
             continue;
         }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -4972,13 +4972,17 @@ CPLString OGRGeoPackageTableLayer::GetColumnsOfCreateTable(
 
     for (size_t i = 0; i < apoFields.size(); i++)
     {
+        OGRFieldDefn *poFieldDefn = apoFields[i];
+        if ((eGType != wkbNone) && (stricmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
+        {
+            continue;
+        }
         if (bNeedComma)
         {
             osSQL += ", ";
         }
         bNeedComma = true;
 
-        OGRFieldDefn *poFieldDefn = apoFields[i];
         pszSQL = sqlite3_mprintf("\"%w\" %s", poFieldDefn->GetNameRef(),
                                  GPkgFieldFromOGR(poFieldDefn->GetType(),
                                                   poFieldDefn->GetSubType(),

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -4973,8 +4973,8 @@ CPLString OGRGeoPackageTableLayer::GetColumnsOfCreateTable(
     for (size_t i = 0; i < apoFields.size(); i++)
     {
         OGRFieldDefn *poFieldDefn = apoFields[i];
-        if ((eGType != wkbNone)
-            && (stricmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
+        if ((eGType != wkbNone) &&
+            (stricmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
         {
             continue;
         }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -4973,8 +4973,12 @@ CPLString OGRGeoPackageTableLayer::GetColumnsOfCreateTable(
     for (size_t i = 0; i < apoFields.size(); i++)
     {
         OGRFieldDefn *poFieldDefn = apoFields[i];
+        // Eg. when a geometry type is specified + an sql statement returns no
+        // or NULL geometry values, the geom column is incorrectly treated as
+        // an attribute column as well with the same name. Not ideal, but skip
+        // this column here to avoid duplicate column name error. Issue: #6976.
         if ((eGType != wkbNone) &&
-            (strcmp(poFieldDefn->GetNameRef(), GetGeometryColumn())))
+            (EQUAL(poFieldDefn->GetNameRef(), GetGeometryColumn())))
         {
             continue;
         }


### PR DESCRIPTION
Proposal to fix some cases where ogr2ogr and VectorTranslate write invalid gpkg output files.

When -nlt (or geometrytype in VectorTranslate) is specified in combination with one of the following situations:
  - when executing an sql statement returning NULL geoms
  - when executing an sql statement doing a spatial operation (eg. ST_Buffer) on the geom that returns no rows

This results in:
- the following error being written: ERROR 1: sqlite3_exec(CREATE TABLE "belgie_empty2" ( "fid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "geom" POLYGON, "geom" TEXT)) failed: duplicate column name: geom
- the gpkg written is invalid: gives an exception when opened.

These are cases 3.i and 4.i in the following issue: #6976

The change in this PR avoids that an attribute column having the same name as the present geometry column is retained in the create table statement.