### PR TITLE
[Backport release/3.6] gdalwarp: fix vshift mode when vertical unit of dstSrs is non-metric

### DIFF
--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -4984,6 +4984,12 @@ static void GWKGeneralCaseThread(void *pData)
     GDALWarpKernel *poWK = psJob->poWK;
     const int iYMin = psJob->iYMin;
     const int iYMax = psJob->iYMax;
+    const double dfMultFactorVerticalShiftPipeline =
+        poWK->bApplyVerticalShift
+            ? CPLAtof(CSLFetchNameValueDef(
+                  poWK->papszWarpOptions, "MULT_FACTOR_VERTICAL_SHIFT_PIPELINE",
+                  "1.0"))
+            : 0.0;
 
     int nDstXSize = poWK->nDstXSize;
     int nSrcXSize = poWK->nSrcXSize;
@@ -5153,7 +5159,7 @@ static void GWKGeneralCaseThread(void *pData)
                     // from target to source
                     dfValueReal =
                         dfValueReal * poWK->dfMultFactorVerticalShift -
-                        padfZ[iDstX];
+                        padfZ[iDstX] * dfMultFactorVerticalShiftPipeline;
                 }
 
                 bHasFoundDensity = true;
@@ -5227,6 +5233,12 @@ static void GWKRealCaseThread(void *pData)
     const int nDstXSize = poWK->nDstXSize;
     const int nSrcXSize = poWK->nSrcXSize;
     const int nSrcYSize = poWK->nSrcYSize;
+    const double dfMultFactorVerticalShiftPipeline =
+        poWK->bApplyVerticalShift
+            ? CPLAtof(CSLFetchNameValueDef(
+                  poWK->papszWarpOptions, "MULT_FACTOR_VERTICAL_SHIFT_PIPELINE",
+                  "1.0"))
+            : 0.0;
 
     /* -------------------------------------------------------------------- */
     /*      Allocate x,y,z coordinate arrays for transformation ... one     */
@@ -5426,7 +5438,7 @@ static void GWKRealCaseThread(void *pData)
                     // from target to source
                     dfValueReal =
                         dfValueReal * poWK->dfMultFactorVerticalShift -
-                        padfZ[iDstX];
+                        padfZ[iDstX] * dfMultFactorVerticalShiftPipeline;
                 }
 
                 bHasFoundDensity = true;
@@ -5495,6 +5507,12 @@ static void GWKResampleNoMasksOrDstDensityOnlyThreadInternal(void *pData)
     GDALWarpKernel *poWK = psJob->poWK;
     const int iYMin = psJob->iYMin;
     const int iYMax = psJob->iYMax;
+    const double dfMultFactorVerticalShiftPipeline =
+        poWK->bApplyVerticalShift
+            ? CPLAtof(CSLFetchNameValueDef(
+                  poWK->papszWarpOptions, "MULT_FACTOR_VERTICAL_SHIFT_PIPELINE",
+                  "1.0"))
+            : 0.0;
 
     const int nDstXSize = poWK->nDstXSize;
     const int nSrcXSize = poWK->nSrcXSize;
@@ -5612,7 +5630,8 @@ static void GWKResampleNoMasksOrDstDensityOnlyThreadInternal(void *pData)
                     // Subtract padfZ[] since the coordinate transformation is
                     // from target to source
                     value = GWKClampValueT<T>(
-                        value * poWK->dfMultFactorVerticalShift - padfZ[iDstX]);
+                        value * poWK->dfMultFactorVerticalShift -
+                        padfZ[iDstX] * dfMultFactorVerticalShiftPipeline);
                 }
 
                 if (poWK->pafDstDensity)
@@ -5727,6 +5746,12 @@ template <class T> static void GWKNearestThread(void *pData)
     GDALWarpKernel *poWK = psJob->poWK;
     const int iYMin = psJob->iYMin;
     const int iYMax = psJob->iYMax;
+    const double dfMultFactorVerticalShiftPipeline =
+        poWK->bApplyVerticalShift
+            ? CPLAtof(CSLFetchNameValueDef(
+                  poWK->papszWarpOptions, "MULT_FACTOR_VERTICAL_SHIFT_PIPELINE",
+                  "1.0"))
+            : 0.0;
 
     const int nDstXSize = poWK->nDstXSize;
     const int nSrcXSize = poWK->nSrcXSize;
@@ -5855,7 +5880,7 @@ template <class T> static void GWKNearestThread(void *pData)
                         // is from target to source
                         value = GWKClampValueT<T>(
                             value * poWK->dfMultFactorVerticalShift -
-                            padfZ[iDstX]);
+                            padfZ[iDstX] * dfMultFactorVerticalShiftPipeline);
                     }
 
                     if (dfBandDensity < 1.0)
@@ -6021,6 +6046,12 @@ static void GWKAverageOrModeThread(void *pData)
     GDALWarpKernel *poWK = psJob->poWK;
     const int iYMin = psJob->iYMin;
     const int iYMax = psJob->iYMax;
+    const double dfMultFactorVerticalShiftPipeline =
+        poWK->bApplyVerticalShift
+            ? CPLAtof(CSLFetchNameValueDef(
+                  poWK->papszWarpOptions, "MULT_FACTOR_VERTICAL_SHIFT_PIPELINE",
+                  "1.0"))
+            : 0.0;
 
     const int nDstXSize = poWK->nDstXSize;
     const int nSrcXSize = poWK->nSrcXSize;
@@ -6401,7 +6432,8 @@ static void GWKAverageOrModeThread(void *pData)
                             // transformation is from target to source
                             dfValueReal =
                                 dfValueReal * poWK->dfMultFactorVerticalShift -
-                                padfZ[iDstX];
+                                padfZ[iDstX] *
+                                    dfMultFactorVerticalShiftPipeline;
                         }
 
                         if (bIsComplex)
@@ -6469,7 +6501,8 @@ static void GWKAverageOrModeThread(void *pData)
                             // transformation is from target to source
                             dfValueReal =
                                 dfValueReal * poWK->dfMultFactorVerticalShift -
-                                padfZ[iDstX];
+                                padfZ[iDstX] *
+                                    dfMultFactorVerticalShiftPipeline;
                         }
 
                         if (bIsComplex)
@@ -6536,7 +6569,8 @@ static void GWKAverageOrModeThread(void *pData)
                             // transformation is from target to source
                             dfValueReal =
                                 dfValueReal * poWK->dfMultFactorVerticalShift -
-                                padfZ[iDstX];
+                                padfZ[iDstX] *
+                                    dfMultFactorVerticalShiftPipeline;
                         }
 
                         if (bIsComplex)
@@ -6628,7 +6662,8 @@ static void GWKAverageOrModeThread(void *pData)
                                 dfValueReal =
                                     dfValueReal *
                                         poWK->dfMultFactorVerticalShift -
-                                    padfZ[iDstX];
+                                    padfZ[iDstX] *
+                                        dfMultFactorVerticalShiftPipeline;
                             }
 
                             dfBandDensity = 1;
@@ -6692,7 +6727,8 @@ static void GWKAverageOrModeThread(void *pData)
                                 dfValueReal =
                                     dfValueReal *
                                         poWK->dfMultFactorVerticalShift -
-                                    padfZ[iDstX];
+                                    padfZ[iDstX] *
+                                        dfMultFactorVerticalShiftPipeline;
                             }
 
                             dfBandDensity = 1;
@@ -6752,7 +6788,8 @@ static void GWKAverageOrModeThread(void *pData)
                             // transformation is from target to source
                             dfValueReal =
                                 dfValueReal * poWK->dfMultFactorVerticalShift -
-                                padfZ[iDstX];
+                                padfZ[iDstX] *
+                                    dfMultFactorVerticalShiftPipeline;
                         }
 
                         dfBandDensity = 1;
@@ -6811,7 +6848,8 @@ static void GWKAverageOrModeThread(void *pData)
                             // transformation is from target to source
                             dfValueReal =
                                 dfValueReal * poWK->dfMultFactorVerticalShift -
-                                padfZ[iDstX];
+                                padfZ[iDstX] *
+                                    dfMultFactorVerticalShiftPipeline;
                         }
 
                         dfBandDensity = 1;
@@ -6872,7 +6910,8 @@ static void GWKAverageOrModeThread(void *pData)
                             // transformation is from target to source
                             dfValueReal =
                                 dfValueReal * poWK->dfMultFactorVerticalShift -
-                                padfZ[iDstX];
+                                padfZ[iDstX] *
+                                    dfMultFactorVerticalShiftPipeline;
                         }
 
                         dfBandDensity = 1;

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -1759,6 +1759,18 @@ def test_gdalwarp_lib_135():
         src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
         src_ds.GetRasterBand(1).Fill(100)
 
+        # Target CRS in us-ft
+        ds = gdal.Warp(
+            "",
+            src_ds,
+            format="VRT",
+            outputType=gdal.GDT_Float32,
+            srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
+            dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid2.gtx +vunits=us-ft +no_defs",
+        )
+        data = struct.unpack("f" * 1, ds.GetRasterBand(1).ReadRaster())[0]
+        assert data == pytest.approx(115 / (1200.0 / 3937)), "Bad value"
+
         # Both transforms to regular VRT
         gdal.GetDriverByName("GTiff").CreateCopy("tmp/dem.tif", src_ds)
         gdal.Warp(


### PR DESCRIPTION
Backport #7064
 **Authored by:** @rouault