### PR TITLE
[Backport release/3.6] DIMAP: optimize performance of dataset RasterIO() (improve perf on multispectral datasets with JP2KAK underlying driver)

### DIFF
--- a/autotest/gdrivers/dimap.py
+++ b/autotest/gdrivers/dimap.py
@@ -234,3 +234,10 @@ def test_dimap_2_vhr2020_ms_fs():
         "Red Edge",
         "Deep Blue",
     ]
+    rgb_ds = gdal.Open("data/dimap2/vhr2020_ms_fs/MS-FS/IMG_RGB_R1C1.TIF")
+    ned_ds = gdal.Open("data/dimap2/vhr2020_ms_fs/MS-FS/IMG_NED_R1C1.TIF")
+    assert ds.ReadRaster() == rgb_ds.ReadRaster() + ned_ds.ReadRaster()
+    assert ds.ReadRaster(0, 0, 1663, 1366, 100, 100) == rgb_ds.ReadRaster(
+        0, 0, 1663, 1366, 100, 100
+    ) + ned_ds.ReadRaster(0, 0, 1663, 1366, 100, 100)
+    assert ds.GetRasterBand(1).ReadRaster() == rgb_ds.GetRasterBand(1).ReadRaster()

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -93,6 +93,10 @@ class DIMAPDataset final : public GDALPamDataset
     char **GetMetadata(const char *pszDomain) override;
     char **GetFileList() override;
 
+    CPLErr IRasterIO(GDALRWFlag, int, int, int, int, void *, int, int,
+                     GDALDataType, int, int *, GSpacing, GSpacing, GSpacing,
+                     GDALRasterIOExtraArg *psExtraArg) override;
+
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Open(GDALOpenInfo *);
 
@@ -335,6 +339,34 @@ CPLErr DIMAPRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     return poVRTBand->IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize, pData,
                                 nBufXSize, nBufYSize, eBufType, nPixelSpace,
                                 nLineSpace, psExtraArg);
+}
+
+/************************************************************************/
+/*                             IRasterIO()                              */
+/************************************************************************/
+
+CPLErr DIMAPDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
+                               int nXSize, int nYSize, void *pData,
+                               int nBufXSize, int nBufYSize,
+                               GDALDataType eBufType, int nBandCount,
+                               int *panBandMap, GSpacing nPixelSpace,
+                               GSpacing nLineSpace, GSpacing nBandSpace,
+                               GDALRasterIOExtraArg *psExtraArg)
+
+{
+    if (cpl::down_cast<DIMAPRasterBand *>(papoBands[0])
+            ->GDALPamRasterBand::GetOverviewCount() > 0)
+    {
+        return GDALPamDataset::IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                         pData, nBufXSize, nBufYSize, eBufType,
+                                         nBandCount, panBandMap, nPixelSpace,
+                                         nLineSpace, nBandSpace, psExtraArg);
+    }
+
+    return poVRTDS->IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize, pData,
+                              nBufXSize, nBufYSize, eBufType, nBandCount,
+                              panBandMap, nPixelSpace, nLineSpace, nBandSpace,
+                              psExtraArg);
 }
 
 /************************************************************************/


### PR DESCRIPTION
Backport #7075
 **Authored by:** @rouault