### PR TITLE
HANA: fix DSN open option

### DIFF
--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -197,9 +197,10 @@ CPLString BuildConnectionString(char **openOptions)
         addParameter(paramName, paramValue);
     };
 
-    if (CSLFindString(openOptions, OpenOptionsConstants::DSN) != -1)
+    const char *paramDSN = getOptValue(OpenOptionsConstants::DSN);
+    if (paramDSN != nullptr)
     {
-        addOptParameter(OpenOptionsConstants::DSN, "DSN", true);
+        addParameter(OpenOptionsConstants::DSN, paramDSN);
     }
     else
     {


### PR DESCRIPTION
This PR fixes a bug that doesn't allow to use DSN in open options.