### PR TITLE
[Backport release/3.6] GenSQL: fix SetAttributeFilter() when dialect=OGRSQL and not forwarding the initial where clause to the source layer (fixes #7087)

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogr_gensql.h
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.h
@@ -62,7 +62,8 @@ class OGRGenSQLResultsLayer final : public OGRLayer
     OGRLayer *poSrcLayer;
     void *pSelectInfo;
 
-    char *pszWHERE;
+    std::string m_osInitialWHERE{};
+    bool m_bForwardWhereToSourceLayer = true;
 
     OGRLayer **papoTableLayers;
 


### PR DESCRIPTION
Backport #7088
 **Authored by:** @rouault