### PR TITLE
HDF4: avoid CMake error with Windows paths

### DIFF
--- a/cmake/modules/packages/FindHDF4.cmake
+++ b/cmake/modules/packages/FindHDF4.cmake
@@ -125,7 +125,7 @@ if(HDF4_FOUND)
 
       add_library(HDF4::HDF4 INTERFACE IMPORTED)
       set_target_properties(HDF4::HDF4 PROPERTIES
-                            INTERFACE_INCLUDE_DIRECTORIES ${HDF4_INCLUDE_DIRS}
+                            INTERFACE_INCLUDE_DIRECTORIES "${HDF4_INCLUDE_DIRS}"
                             INTERFACE_LINK_LIBRARIES "${HDF4_TARGETS}")
   endif()
 endif()


### PR DESCRIPTION
- handle cases of Windows paths such as `C:/Program Files/blah`
- prevent CMake error such as:
```
CMake Error at cmake/modules/packages/FindHDF4.cmake:127 (set_target_properties):
  set_target_properties called with incorrect number of arguments.
```
This took me a long time to debug, in the end it is a minor change, that someday will save someone else days of effort.