### PR TITLE
[Backport release/3.6] HDF4: avoid CMake error with Windows paths

### DIFF
--- a/cmake/modules/packages/FindHDF4.cmake
+++ b/cmake/modules/packages/FindHDF4.cmake
@@ -125,7 +125,7 @@ if(HDF4_FOUND)
 
       add_library(HDF4::HDF4 INTERFACE IMPORTED)
       set_target_properties(HDF4::HDF4 PROPERTIES
-                            INTERFACE_INCLUDE_DIRECTORIES ${HDF4_INCLUDE_DIRS}
+                            INTERFACE_INCLUDE_DIRECTORIES "${HDF4_INCLUDE_DIRS}"
                             INTERFACE_LINK_LIBRARIES "${HDF4_TARGETS}")
   endif()
 endif()


### PR DESCRIPTION
Backport #7091
 **Authored by:** @jmckenna