### PR TITLE
[Backport release/3.6] CMake: fix wrong test when GDAL_SET_INSTALL_RELATIVE_RPATH is set

### DIFF
--- a/gdal.cmake
+++ b/gdal.cmake
@@ -459,8 +459,8 @@ else ()
         ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
         ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}
       )
-      if( NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "" )
-          message(WARNING "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} will be ignored and replaced with ${base};${base}/${relDir} due to GDAL_SET_INSTALL_RELATIVE_RPATH being set")
+      if( NOT "${CMAKE_INSTALL_RPATH}" STREQUAL "" )
+          message(WARNING "CMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH} will be ignored and replaced with ${base};${base}/${relDir} due to GDAL_SET_INSTALL_RELATIVE_RPATH being set")
       endif()
       set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
   endif()


### PR DESCRIPTION
Backport #7105
 **Authored by:** @rouault