### PR TITLE
tiledb rasterio

### DIFF
--- a/autotest/gdrivers/tiledb_read.py
+++ b/autotest/gdrivers/tiledb_read.py
@@ -34,6 +34,6 @@ import pytest
 
 
 @pytest.mark.require_driver("TileDB")
-def DISABLED_test_tiledb_open():
+def test_tiledb_open():
     ut = gdaltest.GDALTest("TileDB", "tiledb_array", 1, 4857)
     ut.testOpen()

--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -239,7 +239,10 @@ def test_tiledb_write_band_meta(mode):
 
     options = ["INTERLEAVE=%s" % (mode)]
 
-    new_ds = gdaltest.tiledb_drv.CreateCopy("tmp/tiledb_meta", src_ds, options=options)
+    gdaltest.tiledb_drv.CreateCopy("tmp/tiledb_meta", src_ds, options=options)
+
+    # open array in update mode
+    new_ds = gdal.Open("tmp/tiledb_meta", gdal.GA_Update)
 
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"

--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -29,9 +29,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
-import shutil
-
 import gdaltest
 import pytest
 
@@ -39,11 +36,8 @@ from osgeo import gdal
 
 
 @pytest.mark.require_driver("TileDB")
-@pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
+@pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_complex(mode):
-    if os.path.exists("tmp/tiledb_complex64"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_complex64"))
-
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/cfloat64.tif")
@@ -67,9 +61,6 @@ def test_tiledb_write_complex(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
 def test_tiledb_write_custom_blocksize(mode):
-    if os.path.exists("tmp/tiledb_custom"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_custom"))
-
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/utmsmall.tif")
@@ -95,9 +86,6 @@ def test_tiledb_write_custom_blocksize(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_update(mode):
-    if os.path.exists("tmp/tiledb_update"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_update"))
-
     np = pytest.importorskip("numpy")
 
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
@@ -131,9 +119,6 @@ def test_tiledb_write_update(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
 def test_tiledb_write_rgb(mode):
-    if os.path.exists("tmp/tiledb_rgb"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_rgb"))
-
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/rgbsmall.tif")
@@ -154,9 +139,6 @@ def test_tiledb_write_rgb(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_attributes(mode):
-    if os.path.exists("tmp/tiledb_rgb_atts"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_rgb_atts"))
-
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/rgbsmall.tif")
@@ -226,9 +208,6 @@ def test_tiledb_write_attributes(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.require_driver("HDF5")
 def test_tiledb_write_subdatasets():
-    if os.path.exists("tmp/test_sds_array"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/test_sds_array"))
-
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open(
@@ -254,9 +233,6 @@ def test_tiledb_write_subdatasets():
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
 def test_tiledb_write_band_meta(mode):
-    if os.path.exists("tmp/tiledb_meta"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_meta"))
-
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/rgbsmall.tif")
@@ -289,9 +265,6 @@ def test_tiledb_write_band_meta(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_history(mode):
-    if os.path.exists("tmp/tiledb_versioning"):
-        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_versioning"))
-
     np = pytest.importorskip("numpy")
 
     options = ["INTERLEAVE=%s" % (mode), "TILEDB_TIMESTAMP=1"]

--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -29,6 +29,9 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import os
+import shutil
+
 import gdaltest
 import pytest
 
@@ -38,6 +41,9 @@ from osgeo import gdal
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
 def test_tiledb_write_complex(mode):
+    if os.path.exists("tmp/tiledb_complex64"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_complex64"))
+
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/cfloat64.tif")
@@ -61,6 +67,9 @@ def test_tiledb_write_complex(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
 def test_tiledb_write_custom_blocksize(mode):
+    if os.path.exists("tmp/tiledb_custom"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_custom"))
+
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/utmsmall.tif")
@@ -86,6 +95,9 @@ def test_tiledb_write_custom_blocksize(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_update(mode):
+    if os.path.exists("tmp/tiledb_update"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_update"))
+
     np = pytest.importorskip("numpy")
 
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
@@ -119,6 +131,9 @@ def test_tiledb_write_update(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
 def test_tiledb_write_rgb(mode):
+    if os.path.exists("tmp/tiledb_rgb"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_rgb"))
+
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/rgbsmall.tif")
@@ -139,6 +154,9 @@ def test_tiledb_write_rgb(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_attributes(mode):
+    if os.path.exists("tmp/tiledb_rgb_atts"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_rgb_atts"))
+
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/rgbsmall.tif")
@@ -208,6 +226,9 @@ def test_tiledb_write_attributes(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.require_driver("HDF5")
 def test_tiledb_write_subdatasets():
+    if os.path.exists("tmp/test_sds_array"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/test_sds_array"))
+
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open(
@@ -233,6 +254,9 @@ def test_tiledb_write_subdatasets():
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL", "ATTRIBUTES"])
 def test_tiledb_write_band_meta(mode):
+    if os.path.exists("tmp/tiledb_meta"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_meta"))
+
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open("../gcore/data/rgbsmall.tif")
@@ -265,6 +289,9 @@ def test_tiledb_write_band_meta(mode):
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_history(mode):
+    if os.path.exists("tmp/tiledb_versioning"):
+        shutil.rmtree(gdaltest.tiledb_drv.Delete("tmp/tiledb_versioning"))
+
     np = pytest.importorskip("numpy")
 
     options = ["INTERLEAVE=%s" % (mode), "TILEDB_TIMESTAMP=1"]

--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -207,7 +207,7 @@ def test_tiledb_write_attributes(mode):
 
 @pytest.mark.require_driver("TileDB")
 @pytest.mark.require_driver("HDF5")
-def DISABLED_test_tiledb_write_subdatasets():
+def test_tiledb_write_subdatasets():
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
 
     src_ds = gdal.Open(

--- a/frmts/tiledb/tiledbdataset.cpp
+++ b/frmts/tiledb/tiledbdataset.cpp
@@ -421,7 +421,7 @@ CPLErr TileDBRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                 GDALRasterBand *poAttrBand = poAttrDS->GetRasterBand(nBandIdx);
                 GDALDataType eAttrType = poAttrBand->GetRasterDataType();
                 int nBytes = GDALGetDataTypeSizeBytes(eAttrType);
-                int nValues = nBufXSize * nBufYSize;
+                size_t nValues = static_cast<size_t>(nBufXSize) * nBufYSize;
                 void *pAttrBlock = VSIMalloc(nBytes * nValues);
                 aBlocks.emplace_back(pAttrBlock, &VSIFree);
 
@@ -594,7 +594,7 @@ CPLErr TileDBDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
             (uint64_t)nYOff, (uint64_t)nYOff + nYSize - 1, (uint64_t)nXOff,
             (uint64_t)nXOff + nXSize - 1};
 
-        if ((eRWFlag == GF_Read) && ((eAccess == GA_Update) && (m_roArray)))
+        if ((eRWFlag == GF_Read) && (eAccess == GA_Update && m_roArray))
         {
             poQuery.reset(new tiledb::Query(*m_roCtx, *m_roArray));
         }

--- a/frmts/tiledb/tiledbdataset.cpp
+++ b/frmts/tiledb/tiledbdataset.cpp
@@ -36,7 +36,7 @@
 #include "tiledb_headers.h"
 
 #ifdef _MSC_VER
-#pragma warning( push )
+#pragma warning(push)
 // 'tiledb::Array::Array': was declared deprecated
 #pragma warning(disable : 4996) /* XXXX was deprecated */
 #endif
@@ -55,22 +55,22 @@ class TileDBDataset final : public GDALPamDataset
 {
     friend class TileDBRasterBand;
 
-    protected:
-        uint64_t      nTimestamp = 0;
-        int           nBitsPerSample = 8;
-        GDALDataType  eDataType = GDT_Unknown;
-        int           nBlockXSize = -1;
-        int           nBlockYSize = -1;
-        int           nBlocksX = 0;
-        int           nBlocksY = 0;
-        int           nBandStart = 1;
-        bool          bHasSubDatasets = false;
-        int           nSubDataCount = 0;
-        char          **papszSubDatasets = nullptr;
-        CPLStringList m_osSubdatasetMD{};
-        CPLXMLNode*   psSubDatasetsTree = nullptr;
-        CPLString     osMetaDoc;
-        TILEDB_INTERLEAVE_MODE eIndexMode = BAND;
+  protected:
+    uint64_t nTimestamp = 0;
+    int nBitsPerSample = 8;
+    GDALDataType eDataType = GDT_Unknown;
+    int nBlockXSize = -1;
+    int nBlockYSize = -1;
+    int nBlocksX = 0;
+    int nBlocksY = 0;
+    int nBandStart = 1;
+    bool bHasSubDatasets = false;
+    int nSubDataCount = 0;
+    char **papszSubDatasets = nullptr;
+    CPLStringList m_osSubdatasetMD{};
+    CPLXMLNode *psSubDatasetsTree = nullptr;
+    CPLString osMetaDoc;
+    TILEDB_INTERLEAVE_MODE eIndexMode = BAND;
 
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::Context> m_roCtx;
@@ -134,20 +134,22 @@ class TileDBDataset final : public GDALPamDataset
 class TileDBRasterBand final : public GDALPamRasterBand
 {
     friend class TileDBDataset;
-    protected:
-        TileDBDataset  *poGDS;
-        bool bStats;
-        CPLString osAttrName;
-        void* pPreviousBlock = nullptr;
-    public:
-        TileDBRasterBand( TileDBDataset *, int, CPLString = TILEDB_VALUES );
-        virtual ~TileDBRasterBand();
-        virtual CPLErr IReadBlock( int, int, void * ) override;
-        virtual CPLErr IWriteBlock( int, int, void * ) override;
-        virtual CPLErr IRasterIO( GDALRWFlag, int, int, int, int,
-                              void *, int, int, GDALDataType,
-                              GSpacing, GSpacing, GDALRasterIOExtraArg* psExtraArg ) override;
-        virtual GDALColorInterp GetColorInterpretation() override;
+
+  protected:
+    TileDBDataset *poGDS;
+    bool bStats;
+    CPLString osAttrName;
+    void *pPreviousBlock = nullptr;
+
+  public:
+    TileDBRasterBand(TileDBDataset *, int, CPLString = TILEDB_VALUES);
+    virtual ~TileDBRasterBand();
+    virtual CPLErr IReadBlock(int, int, void *) override;
+    virtual CPLErr IWriteBlock(int, int, void *) override;
+    virtual CPLErr IRasterIO(GDALRWFlag, int, int, int, int, void *, int, int,
+                             GDALDataType, GSpacing, GSpacing,
+                             GDALRasterIOExtraArg *psExtraArg) override;
+    virtual GDALColorInterp GetColorInterpretation() override;
 };
 
 static CPLString vsi_to_tiledb_uri(const char *pszUri)
@@ -230,47 +232,47 @@ static CPLErr SetBuffer(tiledb::Query *poQuery, GDALDataType eType,
     {
         case GDT_Byte:
             poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<unsigned char*>( pImage ), nSize );
+                osAttrName, reinterpret_cast<unsigned char *>(pImage), nSize);
             break;
         case GDT_UInt16:
             poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<unsigned short*>( pImage ), nSize );
+                osAttrName, reinterpret_cast<unsigned short *>(pImage), nSize);
             break;
         case GDT_UInt32:
             poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<unsigned int*>( pImage ), nSize );
+                osAttrName, reinterpret_cast<unsigned int *>(pImage), nSize);
             break;
         case GDT_Int16:
-            poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<short*>( pImage ), nSize );
+            poQuery->set_data_buffer(osAttrName,
+                                     reinterpret_cast<short *>(pImage), nSize);
             break;
         case GDT_Int32:
-            poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<int*>( pImage ), nSize );
+            poQuery->set_data_buffer(osAttrName,
+                                     reinterpret_cast<int *>(pImage), nSize);
             break;
         case GDT_Float32:
-            poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<float*>( pImage ), nSize );
+            poQuery->set_data_buffer(osAttrName,
+                                     reinterpret_cast<float *>(pImage), nSize);
             break;
         case GDT_Float64:
-            poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<double*>( pImage ), nSize );
+            poQuery->set_data_buffer(osAttrName,
+                                     reinterpret_cast<double *>(pImage), nSize);
             break;
         case GDT_CInt16:
             poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<short*>( pImage ), nSize * 2 );
+                osAttrName, reinterpret_cast<short *>(pImage), nSize * 2);
             break;
         case GDT_CInt32:
             poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<int*>( pImage ), nSize * 2 );
+                osAttrName, reinterpret_cast<int *>(pImage), nSize * 2);
             break;
         case GDT_CFloat32:
             poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<float*>( pImage ), nSize * 2 );
+                osAttrName, reinterpret_cast<float *>(pImage), nSize * 2);
             break;
         case GDT_CFloat64:
             poQuery->set_data_buffer(
-                osAttrName, reinterpret_cast<double*>( pImage ), nSize * 2 );
+                osAttrName, reinterpret_cast<double *>(pImage), nSize * 2);
             break;
         default:
             return CE_Failure;
@@ -295,10 +297,9 @@ TileDBRasterBand::TileDBRasterBand(TileDBDataset *poDSIn, int nBandIn,
     nBlockXSize = poGDS->nBlockXSize;
     nBlockYSize = poGDS->nBlockYSize;
 
-    if ( ( poGDS->eIndexMode == ATTRIBUTES ) &&
-         ( poGDS->eAccess != GA_ReadOnly ) )
-        pPreviousBlock = CPLMalloc(
-            nBlockXSize * nBlockYSize * GDALGetDataTypeSize( eDataType ) );
+    if ((poGDS->eIndexMode == ATTRIBUTES) && (poGDS->eAccess != GA_ReadOnly))
+        pPreviousBlock = CPLMalloc(nBlockXSize * nBlockYSize *
+                                   GDALGetDataTypeSize(eDataType));
 }
 
 /************************************************************************/
@@ -308,71 +309,66 @@ TileDBRasterBand::TileDBRasterBand(TileDBDataset *poDSIn, int nBandIn,
 TileDBRasterBand::~TileDBRasterBand()
 
 {
-    if ( pPreviousBlock )
-        CPLFree( pPreviousBlock );
+    if (pPreviousBlock)
+        CPLFree(pPreviousBlock);
 }
 
 /************************************************************************/
 /*                             IRasterIO()                              */
 /************************************************************************/
 
-CPLErr TileDBRasterBand::IRasterIO( GDALRWFlag eRWFlag,
-                            int nXOff, int nYOff, int nXSize, int nYSize,
-                            void * pData, int nBufXSize, int nBufYSize,
-                            GDALDataType eBufType,
-                            GSpacing nPixelSpace, GSpacing nLineSpace,
-                            GDALRasterIOExtraArg* psExtraArg )
+CPLErr TileDBRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
+                                   int nXSize, int nYSize, void *pData,
+                                   int nBufXSize, int nBufYSize,
+                                   GDALDataType eBufType, GSpacing nPixelSpace,
+                                   GSpacing nLineSpace,
+                                   GDALRasterIOExtraArg *psExtraArg)
 {
     const int nBufferDTSize(GDALGetDataTypeSizeBytes(eBufType));
 
-    if(eBufType == eDataType
-        && nXSize == nBufXSize && nYSize == nBufYSize
-        && nBufferDTSize > 0 && (nPixelSpace % nBufferDTSize) == 0 &&
-        (nLineSpace % nBufferDTSize) == 0 )
+    if (eBufType == eDataType && nXSize == nBufXSize && nYSize == nBufYSize &&
+        nBufferDTSize > 0 && (nPixelSpace % nBufferDTSize) == 0 &&
+        (nLineSpace % nBufferDTSize) == 0)
     {
         std::unique_ptr<tiledb::Query> poQuery;
         int nBandIdx = poGDS->nBandStart + nBand - 1;
         std::vector<uint64_t> oaSubarray = {
-                                        uint64_t( nBandIdx ),
-                                        uint64_t( nBandIdx ),
-                                        (uint64_t) nYOff,
-                                        (uint64_t) nYOff + nYSize - 1,
-                                        (uint64_t) nXOff,
-                                        (uint64_t) nXOff + nXSize - 1 };
-        if ( poGDS->eIndexMode == PIXEL )
-            std::rotate( oaSubarray.begin(),
-                        oaSubarray.begin() + 2,
-                        oaSubarray.end() );
+            uint64_t(nBandIdx), uint64_t(nBandIdx),
+            (uint64_t)nYOff,    (uint64_t)nYOff + nYSize - 1,
+            (uint64_t)nXOff,    (uint64_t)nXOff + nXSize - 1};
+        if (poGDS->eIndexMode == PIXEL)
+            std::rotate(oaSubarray.begin(), oaSubarray.begin() + 2,
+                        oaSubarray.end());
 
-        if ( ( eRWFlag == GF_Read ) && ( ( eAccess == GA_Update ) && ( poGDS->m_roArray ) ) )
+        if ((eRWFlag == GF_Read) &&
+            ((eAccess == GA_Update) && (poGDS->m_roArray)))
         {
-            poQuery.reset(new tiledb::Query( *poGDS->m_roCtx, *poGDS->m_roArray ) );
+            poQuery.reset(
+                new tiledb::Query(*poGDS->m_roCtx, *poGDS->m_roArray));
         }
         else
         {
-            poQuery.reset( new tiledb::Query( *poGDS->m_ctx, *poGDS->m_array ) );
+            poQuery.reset(new tiledb::Query(*poGDS->m_ctx, *poGDS->m_array));
         }
 
-        if ( poGDS->m_array->schema().domain().ndim() == 3 )
+        if (poGDS->m_array->schema().domain().ndim() == 3)
         {
-            poQuery->set_subarray( oaSubarray );
+            poQuery->set_subarray(oaSubarray);
         }
         else
         {
-            poQuery->set_subarray( std::vector<uint64_t> (
-                                        oaSubarray.cbegin() + 2,
-                                        oaSubarray.cend() ) );
+            poQuery->set_subarray(std::vector<uint64_t>(oaSubarray.cbegin() + 2,
+                                                        oaSubarray.cend()));
         }
 
-        SetBuffer( poQuery.get(), eDataType, osAttrName,
-                    pData, nXSize * nYSize );
+        SetBuffer(poQuery.get(), eDataType, osAttrName, pData, nXSize * nYSize);
 
-        if ( bStats )
+        if (bStats)
             tiledb::Stats::enable();
 
         auto status = poQuery->submit();
 
-        if ( bStats )
+        if (bStats)
         {
             tiledb::Stats::dump(stdout);
             tiledb::Stats::disable();
@@ -384,31 +380,28 @@ CPLErr TileDBRasterBand::IRasterIO( GDALRWFlag eRWFlag,
             return CE_None;
     }
 
-    return
-        GDALPamRasterBand::IRasterIO( eRWFlag, nXOff, nYOff, nXSize, nYSize,
-                                pData, nBufXSize, nBufYSize, eBufType,
-                                nPixelSpace, nLineSpace, psExtraArg );
+    return GDALPamRasterBand::IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                        pData, nBufXSize, nBufYSize, eBufType,
+                                        nPixelSpace, nLineSpace, psExtraArg);
 }
 
-CPLErr TileDBRasterBand::IReadBlock( int nBlockXOff,
-                                    int nBlockYOff,
-                                    void * pImage )
+CPLErr TileDBRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
+                                    void *pImage)
 {
     const int nXOff = nBlockXOff * nBlockXSize;
     const int nYOff = nBlockYOff * nBlockYSize;
     const int nDTSize = GDALGetDataTypeSizeBytes(eDataType);
-    return IRasterIO( GF_Read, nXOff, nYOff, nBlockXSize, nBlockYSize,
-                     pImage, nBlockXSize, nBlockYSize,
-                     eDataType, nDTSize, nDTSize * nBlockXSize,
-                     nullptr );
+    return IRasterIO(GF_Read, nXOff, nYOff, nBlockXSize, nBlockYSize, pImage,
+                     nBlockXSize, nBlockYSize, eDataType, nDTSize,
+                     nDTSize * nBlockXSize, nullptr);
 }
 
 /************************************************************************/
 /*                             IWriteBlock()                            */
 /************************************************************************/
 
-CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
-                                      int nBlockYOff, void * pImage )
+CPLErr TileDBRasterBand::IWriteBlock(int nBlockXOff, int nBlockYOff,
+                                     void *pImage)
 
 {
     if (eAccess == GA_ReadOnly)
@@ -423,67 +416,63 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
 
     int nStartX = nBlockXSize * nBlockXOff;
     int nStartY = nBlockYSize * nBlockYOff;
-    uint64_t nEndX =  nStartX + nBlockXSize;
-    uint64_t nEndY =  nStartY + nBlockYSize;
+    uint64_t nEndX = nStartX + nBlockXSize;
+    uint64_t nEndY = nStartY + nBlockYSize;
     int nBandIdx = poGDS->nBandStart + nBand - 1;
 
-    if ( poGDS->eIndexMode == ATTRIBUTES )
+    if (poGDS->eIndexMode == ATTRIBUTES)
     {
-        if ( nBand == poGDS->nBands )
+        if (nBand == poGDS->nBands)
         {
             // last band so we will write the block utilizing the cache for the other blocks
-            tiledb::Query oQuery( *poGDS->m_ctx, *poGDS->m_array );
-            oQuery.set_subarray( {
-                                    (uint64_t) nStartY,
-                                    (uint64_t) nEndY - 1,
-                                    (uint64_t) nStartX,
-                                    (uint64_t) nEndX - 1 } );
+            tiledb::Query oQuery(*poGDS->m_ctx, *poGDS->m_array);
+            oQuery.set_subarray({(uint64_t)nStartY, (uint64_t)nEndY - 1,
+                                 (uint64_t)nStartX, (uint64_t)nEndX - 1});
 
-            if ( poGDS->lpoAttributeDS.size() > 0 )
+            if (poGDS->lpoAttributeDS.size() > 0)
             {
                 std::vector<std::unique_ptr<void, decltype(&VSIFree)>> aBlocks;
 
-                for ( auto const& poAttrDS: poGDS->lpoAttributeDS )
+                for (auto const &poAttrDS : poGDS->lpoAttributeDS)
                 {
-                    GDALRasterBand* poAttrBand = poAttrDS->GetRasterBand( nBandIdx );
+                    GDALRasterBand *poAttrBand =
+                        poAttrDS->GetRasterBand(nBandIdx);
                     GDALDataType eAttrType = poAttrBand->GetRasterDataType();
-                    int nBytes = GDALGetDataTypeSizeBytes( eAttrType );
+                    int nBytes = GDALGetDataTypeSizeBytes(eAttrType);
                     int nValues = nBlockXSize * nBlockYSize;
-                    void* pAttrBlock = VSIMalloc( nBytes * nValues );
+                    void *pAttrBlock = VSIMalloc(nBytes * nValues);
                     aBlocks.emplace_back(pAttrBlock, &VSIFree);
 
-                    if ( pAttrBlock == nullptr )
+                    if (pAttrBlock == nullptr)
                     {
                         CPLError(CE_Failure, CPLE_OutOfMemory,
-                                    "Cannot allocate attribute buffer");
+                                 "Cannot allocate attribute buffer");
                         return CE_Failure;
                     }
 
                     int nXSize = nBlockXSize;
                     int nYSize = nBlockYSize;
-                    if( nBlockXOff + nXSize > nRasterXSize )
+                    if (nBlockXOff + nXSize > nRasterXSize)
                         nXSize = nRasterXSize - nBlockXOff;
-                    if( nBlockYOff + nYSize > nRasterYSize )
+                    if (nBlockYOff + nYSize > nRasterYSize)
                         nYSize = nRasterYSize - nBlockYOff;
 
-                    poAttrBand->AdviseRead(
-                        nBlockXOff, nBlockYOff, nXSize, nYSize,
-                        nBlockXSize, nBlockYSize, eAttrType, nullptr
-                    );
+                    poAttrBand->AdviseRead(nBlockXOff, nBlockYOff, nXSize,
+                                           nYSize, nBlockXSize, nBlockYSize,
+                                           eAttrType, nullptr);
 
                     CPLErr eErr = poAttrBand->RasterIO(
-                        GF_Read,
-                        nBlockXOff, nBlockYOff, nXSize, nYSize,
-                        pAttrBlock, nBlockXSize, nBlockYSize,
-                        eAttrType, 0, 0, nullptr );
+                        GF_Read, nBlockXOff, nBlockYOff, nXSize, nYSize,
+                        pAttrBlock, nBlockXSize, nBlockYSize, eAttrType, 0, 0,
+                        nullptr);
 
-                    if ( eErr == CE_None )
+                    if (eErr == CE_None)
                     {
-                        CPLString osName = CPLString().Printf( "%s",
-                            CPLGetBasename( poAttrDS->GetDescription() ) );
+                        CPLString osName = CPLString().Printf(
+                            "%s", CPLGetBasename(poAttrDS->GetDescription()));
 
-                        SetBuffer(&oQuery, eAttrType, osName,
-                            pAttrBlock, nBlockXSize * nBlockYSize );
+                        SetBuffer(&oQuery, eAttrType, osName, pAttrBlock,
+                                  nBlockXSize * nBlockYSize);
                     }
                     else
                     {
@@ -494,20 +483,21 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
 
             for (int i = 1; i < poGDS->nBands; i++)
             {
-                TileDBRasterBand* poBand = static_cast<TileDBRasterBand*>( poGDS->GetRasterBand( i ) );
-                SetBuffer( &oQuery, eDataType, poBand->osAttrName, poBand->pPreviousBlock,
-                    nBlockXSize * nBlockYSize );
+                TileDBRasterBand *poBand =
+                    static_cast<TileDBRasterBand *>(poGDS->GetRasterBand(i));
+                SetBuffer(&oQuery, eDataType, poBand->osAttrName,
+                          poBand->pPreviousBlock, nBlockXSize * nBlockYSize);
             }
 
-            SetBuffer( &oQuery, eDataType, osAttrName,
-                    pImage, nBlockXSize * nBlockYSize );
+            SetBuffer(&oQuery, eDataType, osAttrName, pImage,
+                      nBlockXSize * nBlockYSize);
 
-            if ( bStats )
+            if (bStats)
                 tiledb::Stats::enable();
 
             auto status = oQuery.submit();
 
-            if ( bStats )
+            if (bStats)
             {
                 tiledb::Stats::dump(stdout);
                 tiledb::Stats::disable();
@@ -518,26 +508,22 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
         }
         else
         {
-           // save this data block until we have collected all
-           memcpy( pPreviousBlock, pImage,
-                GDALGetDataTypeSize(eDataType) * nBlockXSize * nBlockYSize );
+            // save this data block until we have collected all
+            memcpy(pPreviousBlock, pImage,
+                   GDALGetDataTypeSize(eDataType) * nBlockXSize * nBlockYSize);
         }
         return CE_None;
     }
-    else if ( poGDS->lpoAttributeDS.size() > 0 )
+    else if (poGDS->lpoAttributeDS.size() > 0)
     {
-        tiledb::Query oQuery( *poGDS->m_ctx, *poGDS->m_array );
+        tiledb::Query oQuery(*poGDS->m_ctx, *poGDS->m_array);
         std::vector<uint64_t> oaSubarray = {
-                                        uint64_t( nBandIdx ),
-                                        uint64_t( nBandIdx ),
-                                        (uint64_t) nStartY,
-                                        (uint64_t) nEndY - 1,
-                                        (uint64_t) nStartX,
-                                        (uint64_t) nEndX - 1 };
-        oQuery.set_subarray( oaSubarray );
+            uint64_t(nBandIdx),  uint64_t(nBandIdx), (uint64_t)nStartY,
+            (uint64_t)nEndY - 1, (uint64_t)nStartX,  (uint64_t)nEndX - 1};
+        oQuery.set_subarray(oaSubarray);
         std::vector<std::unique_ptr<void, decltype(&VSIFree)>> aBlocks;
 
-        for ( auto const& poAttrDS: poGDS->lpoAttributeDS )
+        for (auto const &poAttrDS : poGDS->lpoAttributeDS)
         {
             GDALRasterBand *poAttrBand = poAttrDS->GetRasterBand(nBandIdx);
             GDALDataType eAttrType = poAttrBand->GetRasterDataType();
@@ -573,9 +559,8 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
                 CPLString osName = CPLString().Printf(
                     "%s", CPLGetBasename(poAttrDS->GetDescription()));
 
-                SetBuffer(&oQuery, eAttrType,
-                    osName,
-                    pAttrBlock, nBlockXSize * nBlockYSize );
+                SetBuffer(&oQuery, eAttrType, osName, pAttrBlock,
+                          nBlockXSize * nBlockYSize);
             }
             else
             {
@@ -583,7 +568,7 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
             }
         }
 
-        if ( bStats )
+        if (bStats)
             tiledb::Stats::enable();
 
         auto status = oQuery.submit();
@@ -603,9 +588,8 @@ CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
     {
         const int nDTSize = GDALGetDataTypeSizeBytes(eDataType);
         return IRasterIO(GF_Write, nStartX, nStartY, nBlockXSize, nBlockYSize,
-                    pImage, nBlockXSize, nBlockYSize,
-                    eDataType, nDTSize, nDTSize * nBlockXSize,
-                    nullptr);
+                         pImage, nBlockXSize, nBlockYSize, eDataType, nDTSize,
+                         nDTSize * nBlockXSize, nullptr);
     }
 }
 
@@ -697,10 +681,10 @@ CPLErr TileDBDataset::AddDimensions(tiledb::Domain &domain,
 /*                             FlushCache()                             */
 /************************************************************************/
 
-void TileDBDataset::FlushCache( bool bAtClosing)
+void TileDBDataset::FlushCache(bool bAtClosing)
 
 {
-    BlockBasedFlushCache( bAtClosing );
+    BlockBasedFlushCache(bAtClosing);
 
     if (nPamFlags & GPF_DIRTY)
         TrySaveXML();
@@ -827,9 +811,10 @@ CPLErr TileDBDataset::TrySaveXML()
         {
             if (nTimestamp)
             {
-                auto oMeta = std::unique_ptr<tiledb::Array>(
-                    new tiledb::Array( *m_ctx, m_array->uri(), TILEDB_WRITE, nTimestamp ) );
-                oMeta->put_metadata("_gdal", TILEDB_UINT8, static_cast<int>(strlen( pszTree )), pszTree);
+                auto oMeta = std::unique_ptr<tiledb::Array>(new tiledb::Array(
+                    *m_ctx, m_array->uri(), TILEDB_WRITE, nTimestamp));
+                oMeta->put_metadata("_gdal", TILEDB_UINT8,
+                                    static_cast<int>(strlen(pszTree)), pszTree);
                 oMeta->close();
             }
             else
@@ -1270,9 +1255,10 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
         const char *pszTimestamp =
             CSLFetchNameValue(poOpenInfo->papszOpenOptions, "TILEDB_TIMESTAMP");
 
-        poDS->bStats = CSLFetchBoolean( poOpenInfo->papszOpenOptions, "STATS", FALSE );
+        poDS->bStats =
+            CSLFetchBoolean(poOpenInfo->papszOpenOptions, "STATS", FALSE);
 
-        if( pszConfig != nullptr )
+        if (pszConfig != nullptr)
         {
             tiledb::Config cfg(pszConfig);
             poDS->m_ctx.reset(new tiledb::Context(cfg));
@@ -1281,8 +1267,8 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             poDS->m_ctx.reset(new tiledb::Context());
         }
-        if ( pszTimestamp )
-            poDS->nTimestamp = std::strtoull( pszTimestamp, nullptr, 10 );
+        if (pszTimestamp)
+            poDS->nTimestamp = std::strtoull(pszTimestamp, nullptr, 10);
 
         CPLString osArrayPath;
         CPLString osAux;
@@ -1331,23 +1317,22 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
         if (poOpenInfo->eAccess == GA_Update)
         {
             eMode = TILEDB_WRITE;
-            poDS->m_roCtx.reset(new tiledb::Context( poDS->m_ctx->config() ) );
+            poDS->m_roCtx.reset(new tiledb::Context(poDS->m_ctx->config()));
             poDS->m_roArray.reset(
-                new tiledb::Array( *poDS->m_roCtx, osArrayPath, TILEDB_READ )
-            );
+                new tiledb::Array(*poDS->m_roCtx, osArrayPath, TILEDB_READ));
         }
 
-        if ( poDS->nTimestamp )
+        if (poDS->nTimestamp)
         {
-            if ( eMode == TILEDB_READ )
+            if (eMode == TILEDB_READ)
             {
-                poDS->m_array.reset(
-                    new tiledb::Array( *poDS->m_ctx, osArrayPath, TILEDB_READ, poDS->nTimestamp ) );
+                poDS->m_array.reset(new tiledb::Array(
+                    *poDS->m_ctx, osArrayPath, TILEDB_READ, poDS->nTimestamp));
             }
             else
             {
-                poDS->m_array.reset(
-                    new tiledb::Array( *poDS->m_ctx, osArrayPath, TILEDB_WRITE, poDS->nTimestamp ) );
+                poDS->m_array.reset(new tiledb::Array(
+                    *poDS->m_ctx, osArrayPath, TILEDB_WRITE, poDS->nTimestamp));
             }
         }
         else
@@ -1897,11 +1882,10 @@ TileDBDataset *TileDBDataset::CreateLL(const char *pszFilename, int nXSize,
         poDS->nBlockYSize = (pszBlockYSize) ? atoi(pszBlockYSize) : 256;
         poDS->bStats = CSLFetchBoolean(papszOptions, "STATS", FALSE);
 
-        const char* pszTimestamp = CSLFetchNameValue(
-                                        papszOptions,
-                                        "TILEDB_TIMESTAMP" );
-        if ( pszTimestamp != nullptr )
-            poDS->nTimestamp = std::strtoull( pszTimestamp, nullptr, 10 );
+        const char *pszTimestamp =
+            CSLFetchNameValue(papszOptions, "TILEDB_TIMESTAMP");
+        if (pszTimestamp != nullptr)
+            poDS->nTimestamp = std::strtoull(pszTimestamp, nullptr, 10);
 
         // set dimensions and attribute type for schema
         poDS->m_schema.reset(
@@ -2142,11 +2126,11 @@ CPLErr TileDBDataset::CopySubDatasets(GDALDataset *poSrcDS,
         poDstDS->SetMetadata(poDstDS->papszSubDatasets, "SUBDATASETS");
         tiledb::Array::create(poDstDS->GetDescription(), *poDstDS->m_schema);
 
-        if ( poDstDS->nTimestamp )
+        if (poDstDS->nTimestamp)
         {
-            poDstDS->m_array.reset( new tiledb::Array(
-                *poDstDS->m_ctx, poDstDS->GetDescription(),
-                TILEDB_WRITE, poDstDS->nTimestamp ) );
+            poDstDS->m_array.reset(
+                new tiledb::Array(*poDstDS->m_ctx, poDstDS->GetDescription(),
+                                  TILEDB_WRITE, poDstDS->nTimestamp));
         }
         else
             poDstDS->m_array.reset(new tiledb::Array(
@@ -2268,9 +2252,11 @@ GDALDataset *TileDBDataset::Create(const char *pszFilename, int nXSize,
 
         for (int i = 0; i < poDS->nBands; i++)
         {
-            if ( poDS->eIndexMode == ATTRIBUTES )
-                poDS->SetBand( i+1, new TileDBRasterBand( poDS.get(), i+1,
-                               TILEDB_VALUES + CPLString().Printf( "_%i", i+1 ) ) );
+            if (poDS->eIndexMode == ATTRIBUTES)
+                poDS->SetBand(i + 1, new TileDBRasterBand(
+                                         poDS.get(), i + 1,
+                                         TILEDB_VALUES +
+                                             CPLString().Printf("_%i", i + 1)));
             else
                 poDS->SetBand(i + 1, new TileDBRasterBand(poDS.get(), i + 1));
         }
@@ -2464,15 +2450,15 @@ GDALDataset *TileDBDataset::CreateCopy(const char *pszFilename,
             poDstDS->CloneInfo(poSrcDS, nCloneFlags);
         }
 
-        CSLDestroy( papszCopyOptions );
-        if ( poDstDS->eIndexMode == ATTRIBUTES )
+        CSLDestroy(papszCopyOptions);
+        if (poDstDS->eIndexMode == ATTRIBUTES)
         {
-            poDstDS->FlushCache( false );
+            poDstDS->FlushCache(false);
         }
 
         poDstDS->m_array->close();
         poDstDS->eAccess = GA_ReadOnly;
-        poDstDS->m_array->open( TILEDB_READ );
+        poDstDS->m_array->open(TILEDB_READ);
 
         return poDstDS.release();
     }
@@ -2500,9 +2486,8 @@ CPLErr TileDBDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                                 GDALRasterIOExtraArg *psExtraArg)
 
 {
-    if ( (
-        ( eIndexMode == ATTRIBUTES )|| ( lpoAttributeDS.size() > 0 ) )
-            && ( eAccess != GA_ReadOnly ) )
+    if (((eIndexMode == ATTRIBUTES) || (lpoAttributeDS.size() > 0)) &&
+        (eAccess != GA_ReadOnly))
     {
         return GDALDataset::BlockBasedRasterIO(
             eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
@@ -2511,11 +2496,10 @@ CPLErr TileDBDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     }
     else
     {
-        return
-            GDALDataset::IRasterIO( eRWFlag, nXOff, nYOff, nXSize, nYSize,
-                                    pData, nBufXSize, nBufYSize, eBufType,
-                                    nBandCount, panBandMap,
-                                    nPixelSpace, nLineSpace, nBandSpace, psExtraArg );
+        return GDALDataset::IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                      pData, nBufXSize, nBufYSize, eBufType,
+                                      nBandCount, panBandMap, nPixelSpace,
+                                      nLineSpace, nBandSpace, psExtraArg);
     }
 }
 

--- a/frmts/tiledb/tiledbdataset.cpp
+++ b/frmts/tiledb/tiledbdataset.cpp
@@ -225,6 +225,8 @@ static const char *index_type_name(TILEDB_INTERLEAVE_MODE eMode)
 /*                             SetBuffer()                              */
 /************************************************************************/
 
+#if ((TILEDB_VERSION_MAJOR > 2) ||                                             \
+     (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 4))
 static CPLErr SetBuffer(tiledb::Query *poQuery, GDALDataType eType,
                         const CPLString &osAttrName, void *pImage, int nSize)
 {
@@ -279,6 +281,62 @@ static CPLErr SetBuffer(tiledb::Query *poQuery, GDALDataType eType,
     }
     return CE_None;
 }
+#else
+static CPLErr SetBuffer(tiledb::Query *poQuery, GDALDataType eType,
+                        const CPLString &osAttrName, void *pImage, int nSize)
+{
+    switch (eType)
+    {
+        case GDT_Byte:
+            poQuery->set_buffer(
+                osAttrName, reinterpret_cast<unsigned char *>(pImage), nSize);
+            break;
+        case GDT_UInt16:
+            poQuery->set_buffer(
+                osAttrName, reinterpret_cast<unsigned short *>(pImage), nSize);
+            break;
+        case GDT_UInt32:
+            poQuery->set_buffer(
+                osAttrName, reinterpret_cast<unsigned int *>(pImage), nSize);
+            break;
+        case GDT_Int16:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<short *>(pImage),
+                                nSize);
+            break;
+        case GDT_Int32:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<int *>(pImage),
+                                nSize);
+            break;
+        case GDT_Float32:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<float *>(pImage),
+                                nSize);
+            break;
+        case GDT_Float64:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<double *>(pImage),
+                                nSize);
+            break;
+        case GDT_CInt16:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<short *>(pImage),
+                                nSize * 2);
+            break;
+        case GDT_CInt32:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<int *>(pImage),
+                                nSize * 2);
+            break;
+        case GDT_CFloat32:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<float *>(pImage),
+                                nSize * 2);
+            break;
+        case GDT_CFloat64:
+            poQuery->set_buffer(osAttrName, reinterpret_cast<double *>(pImage),
+                                nSize * 2);
+            break;
+        default:
+            return CE_Failure;
+    }
+    return CE_None;
+}
+#endif
 
 /************************************************************************/
 /*                          TileDBRasterBand()                          */

--- a/frmts/tiledb/tiledbdataset.cpp
+++ b/frmts/tiledb/tiledbdataset.cpp
@@ -36,8 +36,7 @@
 #include "tiledb_headers.h"
 
 #ifdef _MSC_VER
-#pragma warning(push)
-// 'tiledb::Query::set_buffer': was declared deprecated
+#pragma warning( push )
 // 'tiledb::Array::Array': was declared deprecated
 #pragma warning(disable : 4996) /* XXXX was deprecated */
 #endif
@@ -56,23 +55,22 @@ class TileDBDataset final : public GDALPamDataset
 {
     friend class TileDBRasterBand;
 
-  protected:
-    uint64_t nTimestamp = 0;
-    int nBitsPerSample = 8;
-    GDALDataType eDataType = GDT_Unknown;
-    int nBlockXSize = -1;
-    int nBlockYSize = -1;
-    int nBlocksX = 0;
-    int nBlocksY = 0;
-    int nBandStart = 1;
-    bool bGlobalOrder = false;
-    bool bHasSubDatasets = false;
-    int nSubDataCount = 0;
-    char **papszSubDatasets = nullptr;
-    CPLStringList m_osSubdatasetMD{};
-    CPLXMLNode *psSubDatasetsTree = nullptr;
-    CPLString osMetaDoc;
-    TILEDB_INTERLEAVE_MODE eIndexMode = BAND;
+    protected:
+        uint64_t      nTimestamp = 0;
+        int           nBitsPerSample = 8;
+        GDALDataType  eDataType = GDT_Unknown;
+        int           nBlockXSize = -1;
+        int           nBlockYSize = -1;
+        int           nBlocksX = 0;
+        int           nBlocksY = 0;
+        int           nBandStart = 1;
+        bool          bHasSubDatasets = false;
+        int           nSubDataCount = 0;
+        char          **papszSubDatasets = nullptr;
+        CPLStringList m_osSubdatasetMD{};
+        CPLXMLNode*   psSubDatasetsTree = nullptr;
+        CPLString     osMetaDoc;
+        TILEDB_INTERLEAVE_MODE eIndexMode = BAND;
 
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::Context> m_roCtx;
@@ -136,22 +134,20 @@ class TileDBDataset final : public GDALPamDataset
 class TileDBRasterBand final : public GDALPamRasterBand
 {
     friend class TileDBDataset;
-
-  protected:
-    TileDBDataset *poGDS;
-    bool bStats;
-    CPLString osAttrName;
-    int nCurrBlockX = 0;
-    int nCurrBlockY = 0;
-    std::unique_ptr<tiledb::Query> m_query;
-    std::unique_ptr<tiledb::Query> m_roQuery;
-    void Finalize();
-
-  public:
-    TileDBRasterBand(TileDBDataset *, int, CPLString = TILEDB_VALUES);
-    virtual CPLErr IReadBlock(int, int, void *) override;
-    virtual CPLErr IWriteBlock(int, int, void *) override;
-    virtual GDALColorInterp GetColorInterpretation() override;
+    protected:
+        TileDBDataset  *poGDS;
+        bool bStats;
+        CPLString osAttrName;
+        void* pPreviousBlock = nullptr;
+    public:
+        TileDBRasterBand( TileDBDataset *, int, CPLString = TILEDB_VALUES );
+        virtual ~TileDBRasterBand();
+        virtual CPLErr IReadBlock( int, int, void * ) override;
+        virtual CPLErr IWriteBlock( int, int, void * ) override;
+        virtual CPLErr IRasterIO( GDALRWFlag, int, int, int, int,
+                              void *, int, int, GDALDataType,
+                              GSpacing, GSpacing, GDALRasterIOExtraArg* psExtraArg ) override;
+        virtual GDALColorInterp GetColorInterpretation() override;
 };
 
 static CPLString vsi_to_tiledb_uri(const char *pszUri)
@@ -233,48 +229,48 @@ static CPLErr SetBuffer(tiledb::Query *poQuery, GDALDataType eType,
     switch (eType)
     {
         case GDT_Byte:
-            poQuery->set_buffer(
-                osAttrName, reinterpret_cast<unsigned char *>(pImage), nSize);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<unsigned char*>( pImage ), nSize );
             break;
         case GDT_UInt16:
-            poQuery->set_buffer(
-                osAttrName, reinterpret_cast<unsigned short *>(pImage), nSize);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<unsigned short*>( pImage ), nSize );
             break;
         case GDT_UInt32:
-            poQuery->set_buffer(
-                osAttrName, reinterpret_cast<unsigned int *>(pImage), nSize);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<unsigned int*>( pImage ), nSize );
             break;
         case GDT_Int16:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<short *>(pImage),
-                                nSize);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<short*>( pImage ), nSize );
             break;
         case GDT_Int32:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<int *>(pImage),
-                                nSize);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<int*>( pImage ), nSize );
             break;
         case GDT_Float32:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<float *>(pImage),
-                                nSize);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<float*>( pImage ), nSize );
             break;
         case GDT_Float64:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<double *>(pImage),
-                                nSize);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<double*>( pImage ), nSize );
             break;
         case GDT_CInt16:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<short *>(pImage),
-                                nSize * 2);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<short*>( pImage ), nSize * 2 );
             break;
         case GDT_CInt32:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<int *>(pImage),
-                                nSize * 2);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<int*>( pImage ), nSize * 2 );
             break;
         case GDT_CFloat32:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<float *>(pImage),
-                                nSize * 2);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<float*>( pImage ), nSize * 2 );
             break;
         case GDT_CFloat64:
-            poQuery->set_buffer(osAttrName, reinterpret_cast<double *>(pImage),
-                                nSize * 2);
+            poQuery->set_data_buffer(
+                osAttrName, reinterpret_cast<double*>( pImage ), nSize * 2 );
             break;
         default:
             return CE_Failure;
@@ -299,130 +295,120 @@ TileDBRasterBand::TileDBRasterBand(TileDBDataset *poDSIn, int nBandIn,
     nBlockXSize = poGDS->nBlockXSize;
     nBlockYSize = poGDS->nBlockYSize;
 
-    m_query.reset(new tiledb::Query(*poGDS->m_ctx, *poGDS->m_array));
+    if ( ( poGDS->eIndexMode == ATTRIBUTES ) &&
+         ( poGDS->eAccess != GA_ReadOnly ) )
+        pPreviousBlock = CPLMalloc(
+            nBlockXSize * nBlockYSize * GDALGetDataTypeSize( eDataType ) );
+}
 
-    if ((eAccess == GA_Update) && (poGDS->m_roArray))
-    {
-        m_roQuery.reset(new tiledb::Query(*poGDS->m_roCtx, *poGDS->m_roArray));
-        m_roQuery->set_layout(TILEDB_ROW_MAJOR);
-    }
+/************************************************************************/
+/*                           ~TileDBRasterBand()                        */
+/************************************************************************/
 
-    if (poGDS->bGlobalOrder)
+TileDBRasterBand::~TileDBRasterBand()
+
+{
+    if ( pPreviousBlock )
+        CPLFree( pPreviousBlock );
+}
+
+/************************************************************************/
+/*                             IRasterIO()                              */
+/************************************************************************/
+
+CPLErr TileDBRasterBand::IRasterIO( GDALRWFlag eRWFlag,
+                            int nXOff, int nYOff, int nXSize, int nYSize,
+                            void * pData, int nBufXSize, int nBufYSize,
+                            GDALDataType eBufType,
+                            GSpacing nPixelSpace, GSpacing nLineSpace,
+                            GDALRasterIOExtraArg* psExtraArg )
+{
+    const int nBufferDTSize(GDALGetDataTypeSizeBytes(eBufType));
+
+    if(eBufType == eDataType
+        && nXSize == nBufXSize && nYSize == nBufYSize
+        && nBufferDTSize > 0 && (nPixelSpace % nBufferDTSize) == 0 &&
+        (nLineSpace % nBufferDTSize) == 0 )
     {
-        m_query->set_layout(TILEDB_GLOBAL_ORDER);
+        std::unique_ptr<tiledb::Query> poQuery;
         int nBandIdx = poGDS->nBandStart + nBand - 1;
-        // initialize to complete image block layout
         std::vector<uint64_t> oaSubarray = {
-            uint64_t(nBandIdx),
-            uint64_t(nBandIdx),
-            0,
-            uint64_t(poDSIn->nBlocksY) * nBlockYSize - 1,
-            0,
-            uint64_t(poDSIn->nBlocksX) * nBlockXSize - 1,
-        };
+                                        uint64_t( nBandIdx ),
+                                        uint64_t( nBandIdx ),
+                                        (uint64_t) nYOff,
+                                        (uint64_t) nYOff + nYSize - 1,
+                                        (uint64_t) nXOff,
+                                        (uint64_t) nXOff + nXSize - 1 };
+        if ( poGDS->eIndexMode == PIXEL )
+            std::rotate( oaSubarray.begin(),
+                        oaSubarray.begin() + 2,
+                        oaSubarray.end() );
 
-        if (poGDS->m_array->schema().domain().ndim() == 3)
+        if ( ( eRWFlag == GF_Read ) && ( ( eAccess == GA_Update ) && ( poGDS->m_roArray ) ) )
         {
-            if (poGDS->eIndexMode == PIXEL)
-                std::rotate(oaSubarray.begin(), oaSubarray.begin() + 2,
-                            oaSubarray.end());
-            m_query->set_subarray(oaSubarray);
+            poQuery.reset(new tiledb::Query( *poGDS->m_roCtx, *poGDS->m_roArray ) );
         }
         else
         {
-            m_query->set_subarray(std::vector<uint64_t>(oaSubarray.cbegin() + 2,
-                                                        oaSubarray.cend()));
+            poQuery.reset( new tiledb::Query( *poGDS->m_ctx, *poGDS->m_array ) );
         }
-    }
-    else
-        m_query->set_layout(TILEDB_ROW_MAJOR);
-}
 
-/************************************************************************/
-/*                          Finalize()                                  */
-/************************************************************************/
-
-void TileDBRasterBand::Finalize()
-
-{
-    if (poGDS->bGlobalOrder)
-    {
-        m_query->finalize();
-    }
-}
-
-/************************************************************************/
-/*                             IReadBlock()                             */
-/************************************************************************/
-
-CPLErr TileDBRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
-                                    void *pImage)
-{
-    int nStartX = nBlockXSize * nBlockXOff;
-    int nStartY = nBlockYSize * nBlockYOff;
-    uint64_t nEndX = nStartX + nBlockXSize;
-    uint64_t nEndY = nStartY + nBlockYSize;
-    int nBandIdx = poGDS->nBandStart + nBand - 1;
-
-    std::vector<uint64_t> oaSubarray = {
-        uint64_t(nBandIdx),  uint64_t(nBandIdx), (uint64_t)nStartY,
-        (uint64_t)nEndY - 1, (uint64_t)nStartX,  (uint64_t)nEndX - 1};
-
-    if (poGDS->eIndexMode == PIXEL)
-        std::rotate(oaSubarray.begin(), oaSubarray.begin() + 2,
-                    oaSubarray.end());
-
-    tiledb::Query *q;
-    if ((eAccess == GA_Update) && (poGDS->m_roArray))
-        q = m_roQuery.get();
-    else
-        q = m_query.get();
-
-    try
-    {
-        if (poGDS->m_array->schema().domain().ndim() == 3)
+        if ( poGDS->m_array->schema().domain().ndim() == 3 )
         {
-            q->set_subarray(oaSubarray);
+            poQuery->set_subarray( oaSubarray );
         }
         else
         {
-            q->set_subarray(std::vector<uint64_t>(oaSubarray.cbegin() + 2,
-                                                  oaSubarray.cend()));
+            poQuery->set_subarray( std::vector<uint64_t> (
+                                        oaSubarray.cbegin() + 2,
+                                        oaSubarray.cend() ) );
         }
-    }
-    catch (const std::exception &e)
-    {
-        CPLError(
-            CE_Failure, CPLE_AppDefined,
-            "TileDBRasterBand::IReadBlock(): set_subarray() failed with %s",
-            e.what());
-        return CE_Failure;
-    }
 
-    SetBuffer(q, eDataType, osAttrName, pImage, nBlockXSize * nBlockYSize);
+        SetBuffer( poQuery.get(), eDataType, osAttrName,
+                    pData, nXSize * nYSize );
 
-    if (bStats)
-        tiledb::Stats::enable();
+        if ( bStats )
+            tiledb::Stats::enable();
 
-    auto status = q->submit();
+        auto status = poQuery->submit();
 
-    if (bStats)
-    {
-        tiledb::Stats::dump(stdout);
-        tiledb::Stats::disable();
+        if ( bStats )
+        {
+            tiledb::Stats::dump(stdout);
+            tiledb::Stats::disable();
+        }
+
+        if (status == tiledb::Query::Status::FAILED)
+            return CE_Failure;
+        else
+            return CE_None;
     }
 
-    if (status == tiledb::Query::Status::FAILED)
-        return CE_Failure;
-    else
-        return CE_None;
+    return
+        GDALPamRasterBand::IRasterIO( eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                pData, nBufXSize, nBufYSize, eBufType,
+                                nPixelSpace, nLineSpace, psExtraArg );
+}
+
+CPLErr TileDBRasterBand::IReadBlock( int nBlockXOff,
+                                    int nBlockYOff,
+                                    void * pImage )
+{
+    const int nXOff = nBlockXOff * nBlockXSize;
+    const int nYOff = nBlockYOff * nBlockYSize;
+    const int nDTSize = GDALGetDataTypeSizeBytes(eDataType);
+    return IRasterIO( GF_Read, nXOff, nYOff, nBlockXSize, nBlockYSize,
+                     pImage, nBlockXSize, nBlockYSize,
+                     eDataType, nDTSize, nDTSize * nBlockXSize,
+                     nullptr );
 }
 
 /************************************************************************/
 /*                             IWriteBlock()                            */
 /************************************************************************/
-CPLErr TileDBRasterBand::IWriteBlock(int nBlockXOff, int nBlockYOff,
-                                     void *pImage)
+
+CPLErr TileDBRasterBand::IWriteBlock( int nBlockXOff,
+                                      int nBlockYOff, void * pImage )
 
 {
     if (eAccess == GA_ReadOnly)
@@ -435,68 +421,123 @@ CPLErr TileDBRasterBand::IWriteBlock(int nBlockXOff, int nBlockYOff,
     CPLAssert(poGDS != nullptr && nBlockXOff >= 0 && nBlockYOff >= 0 &&
               pImage != nullptr);
 
+    int nStartX = nBlockXSize * nBlockXOff;
+    int nStartY = nBlockYSize * nBlockYOff;
+    uint64_t nEndX =  nStartX + nBlockXSize;
+    uint64_t nEndY =  nStartY + nBlockYSize;
     int nBandIdx = poGDS->nBandStart + nBand - 1;
-    if (!poGDS->bGlobalOrder)
+
+    if ( poGDS->eIndexMode == ATTRIBUTES )
     {
-        int nStartX = nBlockXSize * nBlockXOff;
-        int nStartY = nBlockYSize * nBlockYOff;
-        uint64_t nEndX = nStartX + nBlockXSize;
-        uint64_t nEndY = nStartY + nBlockYSize;
-
-        std::vector<uint64_t> oaSubarray = {
-            uint64_t(nBandIdx),  uint64_t(nBandIdx), (uint64_t)nStartY,
-            (uint64_t)nEndY - 1, (uint64_t)nStartX,  (uint64_t)nEndX - 1};
-
-        if (poGDS->eIndexMode == PIXEL)
-            std::rotate(oaSubarray.begin(), oaSubarray.begin() + 2,
-                        oaSubarray.end());
-
-        try
+        if ( nBand == poGDS->nBands )
         {
-            if (poGDS->eIndexMode == ATTRIBUTES)
+            // last band so we will write the block utilizing the cache for the other blocks
+            tiledb::Query oQuery( *poGDS->m_ctx, *poGDS->m_array );
+            oQuery.set_subarray( {
+                                    (uint64_t) nStartY,
+                                    (uint64_t) nEndY - 1,
+                                    (uint64_t) nStartX,
+                                    (uint64_t) nEndX - 1 } );
+
+            if ( poGDS->lpoAttributeDS.size() > 0 )
             {
-                m_query->set_subarray(std::vector<uint64_t>(
-                    oaSubarray.cbegin() + 2, oaSubarray.cend()));
+                std::vector<std::unique_ptr<void, decltype(&VSIFree)>> aBlocks;
+
+                for ( auto const& poAttrDS: poGDS->lpoAttributeDS )
+                {
+                    GDALRasterBand* poAttrBand = poAttrDS->GetRasterBand( nBandIdx );
+                    GDALDataType eAttrType = poAttrBand->GetRasterDataType();
+                    int nBytes = GDALGetDataTypeSizeBytes( eAttrType );
+                    int nValues = nBlockXSize * nBlockYSize;
+                    void* pAttrBlock = VSIMalloc( nBytes * nValues );
+                    aBlocks.emplace_back(pAttrBlock, &VSIFree);
+
+                    if ( pAttrBlock == nullptr )
+                    {
+                        CPLError(CE_Failure, CPLE_OutOfMemory,
+                                    "Cannot allocate attribute buffer");
+                        return CE_Failure;
+                    }
+
+                    int nXSize = nBlockXSize;
+                    int nYSize = nBlockYSize;
+                    if( nBlockXOff + nXSize > nRasterXSize )
+                        nXSize = nRasterXSize - nBlockXOff;
+                    if( nBlockYOff + nYSize > nRasterYSize )
+                        nYSize = nRasterYSize - nBlockYOff;
+
+                    poAttrBand->AdviseRead(
+                        nBlockXOff, nBlockYOff, nXSize, nYSize,
+                        nBlockXSize, nBlockYSize, eAttrType, nullptr
+                    );
+
+                    CPLErr eErr = poAttrBand->RasterIO(
+                        GF_Read,
+                        nBlockXOff, nBlockYOff, nXSize, nYSize,
+                        pAttrBlock, nBlockXSize, nBlockYSize,
+                        eAttrType, 0, 0, nullptr );
+
+                    if ( eErr == CE_None )
+                    {
+                        CPLString osName = CPLString().Printf( "%s",
+                            CPLGetBasename( poAttrDS->GetDescription() ) );
+
+                        SetBuffer(&oQuery, eAttrType, osName,
+                            pAttrBlock, nBlockXSize * nBlockYSize );
+                    }
+                    else
+                    {
+                        return eErr;
+                    }
+                }
             }
-            else
+
+            for (int i = 1; i < poGDS->nBands; i++)
             {
-                m_query->set_subarray(oaSubarray);
+                TileDBRasterBand* poBand = static_cast<TileDBRasterBand*>( poGDS->GetRasterBand( i ) );
+                SetBuffer( &oQuery, eDataType, poBand->osAttrName, poBand->pPreviousBlock,
+                    nBlockXSize * nBlockYSize );
             }
-        }
-        catch (const std::exception &e)
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "TileDBRasterBand::IWriteBlock(): set_subarray() failed "
-                     "with %s",
-                     e.what());
-            return CE_Failure;
-        }
-    }
-    else
-    {
-        // global order requires ordered blocks (see FlushCache(bool
-        // bAtClosing))
-        if ((nCurrBlockX != nBlockXOff) || (nCurrBlockY != nBlockYOff))
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "Non-sequential global write to TileDB.\n");
-            return CE_Failure;
+
+            SetBuffer( &oQuery, eDataType, osAttrName,
+                    pImage, nBlockXSize * nBlockYSize );
+
+            if ( bStats )
+                tiledb::Stats::enable();
+
+            auto status = oQuery.submit();
+
+            if ( bStats )
+            {
+                tiledb::Stats::dump(stdout);
+                tiledb::Stats::disable();
+            }
+
+            if (status == tiledb::Query::Status::FAILED)
+                return CE_Failure;
         }
         else
         {
-            if (++nCurrBlockX == poGDS->nBlocksX)
-            {
-                nCurrBlockX = 0;
-                nCurrBlockY++;
-            }
+           // save this data block until we have collected all
+           memcpy( pPreviousBlock, pImage,
+                GDALGetDataTypeSize(eDataType) * nBlockXSize * nBlockYSize );
         }
+        return CE_None;
     }
-
-    std::vector<std::unique_ptr<void, decltype(&VSIFree)>> aBlocks;
-
-    if (poGDS->lpoAttributeDS.size() > 0)
+    else if ( poGDS->lpoAttributeDS.size() > 0 )
     {
-        for (auto const &poAttrDS : poGDS->lpoAttributeDS)
+        tiledb::Query oQuery( *poGDS->m_ctx, *poGDS->m_array );
+        std::vector<uint64_t> oaSubarray = {
+                                        uint64_t( nBandIdx ),
+                                        uint64_t( nBandIdx ),
+                                        (uint64_t) nStartY,
+                                        (uint64_t) nEndY - 1,
+                                        (uint64_t) nStartX,
+                                        (uint64_t) nEndX - 1 };
+        oQuery.set_subarray( oaSubarray );
+        std::vector<std::unique_ptr<void, decltype(&VSIFree)>> aBlocks;
+
+        for ( auto const& poAttrDS: poGDS->lpoAttributeDS )
         {
             GDALRasterBand *poAttrBand = poAttrDS->GetRasterBand(nBandIdx);
             GDALDataType eAttrType = poAttrBand->GetRasterDataType();
@@ -532,44 +573,20 @@ CPLErr TileDBRasterBand::IWriteBlock(int nBlockXOff, int nBlockYOff,
                 CPLString osName = CPLString().Printf(
                     "%s", CPLGetBasename(poAttrDS->GetDescription()));
 
-                SetBuffer(m_query.get(), eAttrType, osName, pAttrBlock,
-                          nBlockXSize * nBlockYSize);
+                SetBuffer(&oQuery, eAttrType,
+                    osName,
+                    pAttrBlock, nBlockXSize * nBlockYSize );
             }
             else
             {
                 return eErr;
             }
         }
-    }
 
-    if (poGDS->eIndexMode == ATTRIBUTES)
-    {
-        if (nBand != poGDS->GetRasterCount())
-        {
-            tiledb::Query *q =
-                ((TileDBRasterBand *)poGDS->GetRasterBand(poGDS->nBands))
-                    ->m_query.get();
-            SetBuffer(q, eDataType, osAttrName, pImage,
-                      nBlockXSize * nBlockYSize);
-        }
-        else
-        {
-            SetBuffer(m_query.get(), eDataType, osAttrName, pImage,
-                      nBlockXSize * nBlockYSize);
-        }
-    }
-    else
-    {
-        SetBuffer(m_query.get(), eDataType, osAttrName, pImage,
-                  nBlockXSize * nBlockYSize);
-    }
-
-    if ((poGDS->eIndexMode != ATTRIBUTES) || (nBand == poGDS->GetRasterCount()))
-    {
-        if (bStats)
+        if ( bStats )
             tiledb::Stats::enable();
 
-        auto status = m_query->submit();
+        auto status = oQuery.submit();
 
         if (bStats)
         {
@@ -579,9 +596,17 @@ CPLErr TileDBRasterBand::IWriteBlock(int nBlockXOff, int nBlockYOff,
 
         if (status == tiledb::Query::Status::FAILED)
             return CE_Failure;
-    }
 
-    return CE_None;
+        return CE_None;
+    }
+    else
+    {
+        const int nDTSize = GDALGetDataTypeSizeBytes(eDataType);
+        return IRasterIO(GF_Write, nStartX, nStartY, nBlockXSize, nBlockYSize,
+                    pImage, nBlockXSize, nBlockYSize,
+                    eDataType, nDTSize, nDTSize * nBlockXSize,
+                    nullptr);
+    }
 }
 
 /************************************************************************/
@@ -620,15 +645,6 @@ TileDBDataset::~TileDBDataset()
 
 {
     TileDBDataset::FlushCache(true);
-
-    // important to finalize arrays before closing array when updating
-    if (bGlobalOrder)
-    {
-        for (auto &&poBand : GetBands())
-        {
-            static_cast<TileDBRasterBand *>(poBand)->Finalize();
-        }
-    }
 
     try
     {
@@ -681,10 +697,10 @@ CPLErr TileDBDataset::AddDimensions(tiledb::Domain &domain,
 /*                             FlushCache()                             */
 /************************************************************************/
 
-void TileDBDataset::FlushCache(bool bAtClosing)
+void TileDBDataset::FlushCache( bool bAtClosing)
 
 {
-    BlockBasedFlushCache(bAtClosing);
+    BlockBasedFlushCache( bAtClosing );
 
     if (nPamFlags & GPF_DIRTY)
         TrySaveXML();
@@ -811,10 +827,9 @@ CPLErr TileDBDataset::TrySaveXML()
         {
             if (nTimestamp)
             {
-                auto oMeta = std::unique_ptr<tiledb::Array>(new tiledb::Array(
-                    *m_ctx, m_array->uri(), TILEDB_WRITE, nTimestamp));
-                oMeta->put_metadata("_gdal", TILEDB_UINT8,
-                                    static_cast<int>(strlen(pszTree)), pszTree);
+                auto oMeta = std::unique_ptr<tiledb::Array>(
+                    new tiledb::Array( *m_ctx, m_array->uri(), TILEDB_WRITE, nTimestamp ) );
+                oMeta->put_metadata("_gdal", TILEDB_UINT8, static_cast<int>(strlen( pszTree )), pszTree);
                 oMeta->close();
             }
             else
@@ -1255,7 +1270,9 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
         const char *pszTimestamp =
             CSLFetchNameValue(poOpenInfo->papszOpenOptions, "TILEDB_TIMESTAMP");
 
-        if (pszConfig != nullptr)
+        poDS->bStats = CSLFetchBoolean( poOpenInfo->papszOpenOptions, "STATS", FALSE );
+
+        if( pszConfig != nullptr )
         {
             tiledb::Config cfg(pszConfig);
             poDS->m_ctx.reset(new tiledb::Context(cfg));
@@ -1264,9 +1281,8 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             poDS->m_ctx.reset(new tiledb::Context());
         }
-
-        if (pszTimestamp)
-            poDS->nTimestamp = atoi(pszTimestamp);
+        if ( pszTimestamp )
+            poDS->nTimestamp = std::strtoull( pszTimestamp, nullptr, 10 );
 
         CPLString osArrayPath;
         CPLString osAux;
@@ -1315,19 +1331,25 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
         if (poOpenInfo->eAccess == GA_Update)
         {
             eMode = TILEDB_WRITE;
-            poDS->m_roCtx.reset(new tiledb::Context(poDS->m_ctx->config()));
-            if (poDS->nTimestamp)
-                poDS->m_roArray.reset(
-                    new tiledb::Array(*poDS->m_roCtx, osArrayPath, TILEDB_READ,
-                                      poDS->nTimestamp));
-            else
-                poDS->m_roArray.reset(new tiledb::Array(
-                    *poDS->m_roCtx, osArrayPath, TILEDB_READ));
+            poDS->m_roCtx.reset(new tiledb::Context( poDS->m_ctx->config() ) );
+            poDS->m_roArray.reset(
+                new tiledb::Array( *poDS->m_roCtx, osArrayPath, TILEDB_READ )
+            );
         }
 
-        if (poDS->nTimestamp)
-            poDS->m_array.reset(new tiledb::Array(*poDS->m_ctx, osArrayPath,
-                                                  eMode, poDS->nTimestamp));
+        if ( poDS->nTimestamp )
+        {
+            if ( eMode == TILEDB_READ )
+            {
+                poDS->m_array.reset(
+                    new tiledb::Array( *poDS->m_ctx, osArrayPath, TILEDB_READ, poDS->nTimestamp ) );
+            }
+            else
+            {
+                poDS->m_array.reset(
+                    new tiledb::Array( *poDS->m_ctx, osArrayPath, TILEDB_WRITE, poDS->nTimestamp ) );
+            }
+        }
         else
             poDS->m_array.reset(
                 new tiledb::Array(*poDS->m_ctx, osArrayPath, eMode));
@@ -1836,7 +1858,6 @@ TileDBDataset *TileDBDataset::CreateLL(const char *pszFilename, int nXSize,
         poDS->eDataType = eType;
         poDS->nBands = nBandsIn;
         poDS->eAccess = GA_Update;
-        poDS->bGlobalOrder = true;
 
         if (poDS->nBands == 0)  // subdatasets
         {
@@ -1876,10 +1897,11 @@ TileDBDataset *TileDBDataset::CreateLL(const char *pszFilename, int nXSize,
         poDS->nBlockYSize = (pszBlockYSize) ? atoi(pszBlockYSize) : 256;
         poDS->bStats = CSLFetchBoolean(papszOptions, "STATS", FALSE);
 
-        const char *pszTimestamp =
-            CSLFetchNameValue(papszOptions, "TILEDB_TIMESTAMP");
-        if (pszTimestamp != nullptr)
-            poDS->nTimestamp = atoi(pszTimestamp);
+        const char* pszTimestamp = CSLFetchNameValue(
+                                        papszOptions,
+                                        "TILEDB_TIMESTAMP" );
+        if ( pszTimestamp != nullptr )
+            poDS->nTimestamp = std::strtoull( pszTimestamp, nullptr, 10 );
 
         // set dimensions and attribute type for schema
         poDS->m_schema.reset(
@@ -2120,10 +2142,12 @@ CPLErr TileDBDataset::CopySubDatasets(GDALDataset *poSrcDS,
         poDstDS->SetMetadata(poDstDS->papszSubDatasets, "SUBDATASETS");
         tiledb::Array::create(poDstDS->GetDescription(), *poDstDS->m_schema);
 
-        if (poDstDS->nTimestamp)
-            poDstDS->m_array.reset(
-                new tiledb::Array(*poDstDS->m_ctx, poDstDS->GetDescription(),
-                                  TILEDB_WRITE, poDstDS->nTimestamp));
+        if ( poDstDS->nTimestamp )
+        {
+            poDstDS->m_array.reset( new tiledb::Array(
+                *poDstDS->m_ctx, poDstDS->GetDescription(),
+                TILEDB_WRITE, poDstDS->nTimestamp ) );
+        }
         else
             poDstDS->m_array.reset(new tiledb::Array(
                 *poDstDS->m_ctx, poDstDS->GetDescription(), TILEDB_WRITE));
@@ -2244,13 +2268,9 @@ GDALDataset *TileDBDataset::Create(const char *pszFilename, int nXSize,
 
         for (int i = 0; i < poDS->nBands; i++)
         {
-            if (poDS->eIndexMode == ATTRIBUTES)
-            {
-                poDS->SetBand(i + 1, new TileDBRasterBand(
-                                         poDS.get(), i + 1,
-                                         TILEDB_VALUES +
-                                             CPLString().Printf("_%i", i + 1)));
-            }
+            if ( poDS->eIndexMode == ATTRIBUTES )
+                poDS->SetBand( i+1, new TileDBRasterBand( poDS.get(), i+1,
+                               TILEDB_VALUES + CPLString().Printf( "_%i", i+1 ) ) );
             else
                 poDS->SetBand(i + 1, new TileDBRasterBand(poDS.get(), i + 1));
         }
@@ -2444,7 +2464,15 @@ GDALDataset *TileDBDataset::CreateCopy(const char *pszFilename,
             poDstDS->CloneInfo(poSrcDS, nCloneFlags);
         }
 
-        CSLDestroy(papszCopyOptions);
+        CSLDestroy( papszCopyOptions );
+        if ( poDstDS->eIndexMode == ATTRIBUTES )
+        {
+            poDstDS->FlushCache( false );
+        }
+
+        poDstDS->m_array->close();
+        poDstDS->eAccess = GA_ReadOnly;
+        poDstDS->m_array->open( TILEDB_READ );
 
         return poDstDS.release();
     }
@@ -2460,10 +2488,7 @@ GDALDataset *TileDBDataset::CreateCopy(const char *pszFilename,
 /*                             IRasterIO()                              */
 /*                                                                      */
 /*      Multi-band raster io handler.  We will use block based          */
-/*      loading for attribute only arrays and for                       */
-/*      arrays that are indexed band last as they                       */
-/*      are effectively pixel interleaved, so processing all bands      */
-/*      for a given block together avoid extra seeks.                   */
+/*      loading for writing to an array                                 */
 /************************************************************************/
 
 CPLErr TileDBDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
@@ -2475,7 +2500,9 @@ CPLErr TileDBDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                                 GDALRasterIOExtraArg *psExtraArg)
 
 {
-    if ((eIndexMode == PIXEL) || (eIndexMode == ATTRIBUTES))
+    if ( (
+        ( eIndexMode == ATTRIBUTES )|| ( lpoAttributeDS.size() > 0 ) )
+            && ( eAccess != GA_ReadOnly ) )
     {
         return GDALDataset::BlockBasedRasterIO(
             eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
@@ -2483,10 +2510,13 @@ CPLErr TileDBDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
             nBandSpace, psExtraArg);
     }
     else
-        return GDALDataset::IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize,
-                                      pData, nBufXSize, nBufYSize, eBufType,
-                                      nBandCount, panBandMap, nPixelSpace,
-                                      nLineSpace, nBandSpace, psExtraArg);
+    {
+        return
+            GDALDataset::IRasterIO( eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                    pData, nBufXSize, nBufYSize, eBufType,
+                                    nBandCount, panBandMap,
+                                    nPixelSpace, nLineSpace, nBandSpace, psExtraArg );
+    }
 }
 
 /************************************************************************/

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -4620,6 +4620,9 @@ CPLErr CPL_STDCALL GDALDatasetCopyWholeRaster(GDALDatasetH hSrcDS,
         bInterleave = true;
     else if (pszInterleave != nullptr && EQUAL(pszInterleave, "BAND"))
         bInterleave = false;
+    // attributes is specific to the TileDB driver
+    else if (pszInterleave != nullptr && EQUAL(pszInterleave, "ATTRIBUTES"))
+        bInterleave = false;
     else if (pszInterleave != nullptr)
     {
         CPLError(CE_Warning, CPLE_NotSupported,

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -4622,7 +4622,7 @@ CPLErr CPL_STDCALL GDALDatasetCopyWholeRaster(GDALDatasetH hSrcDS,
         bInterleave = false;
     // attributes is specific to the TileDB driver
     else if (pszInterleave != nullptr && EQUAL(pszInterleave, "ATTRIBUTES"))
-        bInterleave = false;
+        bInterleave = true;
     else if (pszInterleave != nullptr)
     {
         CPLError(CE_Warning, CPLE_NotSupported,


### PR DESCRIPTION
## What does this PR do?

This PR changes the way that the TileDB driver requests data using rasterio. The reason for this change is to optimize for use within MapServer so that complete regions are requested at once and the TileDB driver internally does the parallel reads.

This PR in turn fixes https://github.com/OSGeo/gdal/issues/7099 as the TileDB `Query` is now initialized for every call.

Marked as WIP until the CI passes.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/7099

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
