### PR TITLE
[Backport release/3.6] CPLGetPhysicalRAM(): take into account current cgroup (v1 and v2)

### DIFF
--- a/port/cpl_vsisimple.cpp
+++ b/port/cpl_vsisimple.cpp
@@ -1356,7 +1356,8 @@ char *VSIStrerror(int nErrno)
 /** Return the total physical RAM in bytes.
  *
  * In the context of a container using cgroups (typically Docker), this
- * will take into account that limitation (starting with GDAL 2.4.0)
+ * will take into account that limitation (starting with GDAL 2.4.0 and
+ * with extra fixes in GDAL 3.6.3)
  *
  * You should generally use CPLGetUsablePhysicalRAM() instead.
  *
@@ -1371,20 +1372,107 @@ GIntBig CPLGetPhysicalRAM(void)
         return 0;
     GIntBig nVal = static_cast<GIntBig>(nPhysPages) * nPageSize;
 
-    // In a Docker container the memory might be limited
-    // If no limitation, on 64 bit, 9223372036854771712 is returned.
-    FILE *f = fopen("/sys/fs/cgroup/memory/memory.limit_in_bytes", "rb");
-    if (f)
+#ifdef __linux
+    char szGroupName[256];
+    bool bFromMemory = false;
+    szGroupName[0] = 0;
     {
-        char szBuffer[32];
-        const int nRead =
-            static_cast<int>(fread(szBuffer, 1, sizeof(szBuffer) - 1, f));
-        szBuffer[nRead] = 0;
+        FILE *f = fopen("/proc/self/cgroup", "rb");
+        char szLine[256];
+        // Find line like "6:memory:/user.slice/user-1000.slice/user@1000.service"
+        // and store "/user.slice/user-1000.slice/user@1000.service" in
+        // szMemoryPath for cgroup V1 or single line "0::/...." for cgroup V2.
+        while (fgets(szLine, sizeof(szLine), f))
+        {
+            const char *pszMemory = strstr(szLine, ":memory:");
+            if (pszMemory)
+            {
+                bFromMemory = true;
+                strcpy(szGroupName, pszMemory + strlen(":memory:"));
+                char *pszEOL = strchr(szGroupName, '\n');
+                if (pszEOL)
+                    *pszEOL = '\0';
+                break;
+            }
+            if (strncmp(szLine, "0::", strlen("0::")) == 0)
+            {
+                strcpy(szGroupName, szLine + strlen("0::"));
+                char *pszEOL = strchr(szGroupName, '\n');
+                if (pszEOL)
+                    *pszEOL = '\0';
+                break;
+            }
+        }
         fclose(f);
-        const GUIntBig nLimit = CPLScanUIntBig(szBuffer, nRead);
-        nVal =
-            static_cast<GIntBig>(std::min(static_cast<GUIntBig>(nVal), nLimit));
     }
+    if (szGroupName[0])
+    {
+        char szFilename[256 + 64];
+        if (bFromMemory)
+        {
+            // cgroup V1
+            // Read memory.limit_in_byte in the whole szGroupName hierarchy
+            while (true)
+            {
+                snprintf(szFilename, sizeof(szFilename),
+                         "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes",
+                         szGroupName);
+                FILE *f = fopen(szFilename, "rb");
+                if (f)
+                {
+                    // If no limitation, on 64 bit, 9223372036854771712 is returned.
+                    char szBuffer[32];
+                    const int nRead = static_cast<int>(
+                        fread(szBuffer, 1, sizeof(szBuffer) - 1, f));
+                    szBuffer[nRead] = 0;
+                    fclose(f);
+                    const GUIntBig nLimit = CPLScanUIntBig(szBuffer, nRead);
+                    nVal = static_cast<GIntBig>(
+                        std::min(static_cast<GUIntBig>(nVal), nLimit));
+                }
+                char *pszLastSlash = strrchr(szGroupName, '/');
+                if (!pszLastSlash || pszLastSlash == szGroupName)
+                    break;
+                *pszLastSlash = '\0';
+            }
+        }
+        else
+        {
+            // cgroup V2
+            // Read memory.max in the whole szGroupName hierarchy
+            while (true)
+            {
+                snprintf(szFilename, sizeof(szFilename),
+                         "/sys/fs/cgroup/%s/memory.max", szGroupName);
+                FILE *f = fopen(szFilename, "rb");
+                if (f)
+                {
+                    // If no limitation, "max" is returned.
+                    char szBuffer[32];
+                    int nRead = static_cast<int>(
+                        fread(szBuffer, 1, sizeof(szBuffer) - 1, f));
+                    szBuffer[nRead] = 0;
+                    if (nRead > 0 && szBuffer[nRead - 1] == '\n')
+                    {
+                        nRead--;
+                        szBuffer[nRead] = 0;
+                    }
+                    fclose(f);
+                    if (CPLGetValueType(szBuffer) == CPL_VALUE_INTEGER)
+                    {
+                        const GUIntBig nLimit = CPLScanUIntBig(szBuffer, nRead);
+                        nVal = static_cast<GIntBig>(
+                            std::min(static_cast<GUIntBig>(nVal), nLimit));
+                    }
+                }
+                char *pszLastSlash = strrchr(szGroupName, '/');
+                if (!pszLastSlash || pszLastSlash == szGroupName)
+                    break;
+                *pszLastSlash = '\0';
+            }
+        }
+    }
+#endif
 
     return nVal;
 }


### PR DESCRIPTION
Backport #7124
 **Authored by:** @rouault