### PR TITLE
OpenFileGDB: fix performance issue when identifying a CRS

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
+++ b/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
@@ -33,6 +33,7 @@
 #include "ogrsf_frmts.h"
 #include "filegdbtable.h"
 #include "ogr_swq.h"
+#include "cpl_mem_cache.h"
 #include "cpl_quad_tree.h"
 
 #include <vector>
@@ -164,7 +165,7 @@ class OGROpenFileGDBLayer final : public OGRLayer
                                 void *pQTUserData);
 
     void TryToDetectMultiPatchKind();
-    static OGRSpatialReference *BuildSRS(const CPLXMLNode *psInfo);
+    OGRSpatialReference *BuildSRS(const CPLXMLNode *psInfo) const;
     void BuildCombinedIterator();
     bool RegisterTable();
     void RefreshXMLDefinitionInMemory();
@@ -411,6 +412,9 @@ class OGROpenFileGDBDataSource final : public OGRDataSource
     std::map<std::string, int> m_osMapNameToIdx;
     std::shared_ptr<GDALGroup> m_poRootGroup{};
 
+    lru11::Cache<std::string, std::shared_ptr<OGRSpatialReference>>
+        m_oCacheWKTToSRS{};
+
     std::string m_osRootGUID{};
     std::string m_osGDBSystemCatalogFilename{};
     std::string m_osGDBSpatialRefsFilename{};
@@ -587,6 +591,8 @@ class OGROpenFileGDBDataSource final : public OGRDataSource
     {
         return m_osTransactionBackupDirname;
     }
+
+    OGRSpatialReference *BuildSRS(const char *pszWKT);
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -1794,3 +1794,43 @@ char **OGROpenFileGDBDataSource::GetFileList()
     CSLDestroy(papszFiles);
     return osStringList.StealList();
 }
+
+/************************************************************************/
+/*                           BuildSRS()                                 */
+/************************************************************************/
+
+OGRSpatialReference *OGROpenFileGDBDataSource::BuildSRS(const char *pszWKT)
+{
+    std::shared_ptr<OGRSpatialReference> poSharedObj;
+    m_oCacheWKTToSRS.tryGet(pszWKT, poSharedObj);
+    if (poSharedObj)
+        return poSharedObj->Clone();
+
+    OGRSpatialReference *poSRS = new OGRSpatialReference();
+    poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    if (poSRS->importFromWkt(pszWKT) != OGRERR_NONE)
+    {
+        delete poSRS;
+        poSRS = nullptr;
+    }
+    if (poSRS != nullptr)
+    {
+        if (CPLTestBool(CPLGetConfigOption("USE_OSR_FIND_MATCHES", "YES")))
+        {
+            auto poSRSMatch = poSRS->FindBestMatch(100);
+            if (poSRSMatch)
+            {
+                poSRS->Release();
+                poSRS = poSRSMatch;
+                poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+            }
+            m_oCacheWKTToSRS.insert(
+                pszWKT, std::shared_ptr<OGRSpatialReference>(poSRS->Clone()));
+        }
+        else
+        {
+            poSRS->AutoIdentifyEPSG();
+        }
+    }
+    return poSRS;
+}


### PR DESCRIPTION
Fixes the use case of https://lists.osgeo.org/pipermail/gdal-dev/2023-January/056790.html when identifying the following WKT in multiple layers: 'PROJCS["GK_31",GEOGCS["GCS_MGI",DATUM["D_MGI",SPHEROID["Bessel_1841",6377397.155,299.1528128]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Gauss_Kruger"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",-5000000.0],PARAMETER["Central_Meridian",13.3333333333333],PARAMETER["Scale_Factor",1.0],PARAMETER["Latitude_Of_Origin",0.0],UNIT["Meter",1.0]]'
