### PR TITLE
[Backport release/3.6] GTiffJPEGOverviewBand::IReadBlock(): remove hack that causes read errors in some circumstances

### DIFF
--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -2330,12 +2330,14 @@ CPLErr GTiffDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     if (nBufXSize < nXSize && nBufYSize < nYSize)
     {
         int bTried = FALSE;
-        ++m_nJPEGOverviewVisibilityCounter;
+        if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+            ++m_nJPEGOverviewVisibilityCounter;
         const CPLErr eErr = TryOverviewRasterIO(
             eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
             eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace,
             nBandSpace, psExtraArg, &bTried);
-        --m_nJPEGOverviewVisibilityCounter;
+        if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+            --m_nJPEGOverviewVisibilityCounter;
         if (bTried)
             return eErr;
     }
@@ -2405,12 +2407,14 @@ CPLErr GTiffDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     }
 #endif
 
-    ++m_nJPEGOverviewVisibilityCounter;
+    if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+        ++m_nJPEGOverviewVisibilityCounter;
     const CPLErr eErr = GDALPamDataset::IRasterIO(
         eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
         eBufType, nBandCount, panBandMap, nPixelSpace, nLineSpace, nBandSpace,
         psExtraArg);
-    m_nJPEGOverviewVisibilityCounter--;
+    if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+        m_nJPEGOverviewVisibilityCounter--;
 
     if (pBufferedData)
     {
@@ -5574,11 +5578,13 @@ CPLErr GTiffRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     if (nBufXSize < nXSize && nBufYSize < nYSize)
     {
         int bTried = FALSE;
-        ++m_poGDS->m_nJPEGOverviewVisibilityCounter;
+        if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+            ++m_poGDS->m_nJPEGOverviewVisibilityCounter;
         const CPLErr eErr = TryOverviewRasterIO(
             eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
             eBufType, nPixelSpace, nLineSpace, psExtraArg, &bTried);
-        --m_poGDS->m_nJPEGOverviewVisibilityCounter;
+        if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+            --m_poGDS->m_nJPEGOverviewVisibilityCounter;
         if (bTried)
             return eErr;
     }
@@ -5695,11 +5701,13 @@ CPLErr GTiffRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
         }
     }
 
-    ++m_poGDS->m_nJPEGOverviewVisibilityCounter;
+    if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+        ++m_poGDS->m_nJPEGOverviewVisibilityCounter;
     const CPLErr eErr = GDALPamRasterBand::IRasterIO(
         eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
         eBufType, nPixelSpace, nLineSpace, psExtraArg);
-    --m_poGDS->m_nJPEGOverviewVisibilityCounter;
+    if (psExtraArg->eResampleAlg == GRIORA_NearestNeighbour)
+        --m_poGDS->m_nJPEGOverviewVisibilityCounter;
 
     m_poGDS->m_bLoadingOtherBands = false;
 


### PR DESCRIPTION
Backport #7134
 **Authored by:** @rouault