### PR TITLE
CPLFindFile: Warn if file not found and GDAL_DATA not defined

### DIFF
--- a/port/cpl_findfile.cpp
+++ b/port/cpl_findfile.cpp
@@ -145,8 +145,7 @@ void CPLFinderClean()
 /************************************************************************/
 
 /** CPLDefaultFindFile */
-const char *CPLDefaultFindFile(const char * /* pszClass */,
-                               const char *pszBasename)
+const char *CPLDefaultFindFile(const char *pszClass, const char *pszBasename)
 
 {
     FindFileTLS *pTLSData = CPLGetFindFileTLS();
@@ -162,6 +161,12 @@ const char *CPLDefaultFindFile(const char * /* pszClass */,
         VSIStatBufL sStat;
         if (VSIStatL(pszResult, &sStat) == 0)
             return pszResult;
+    }
+
+    if (EQUAL(pszClass, "gdal") && !CPLGetConfigOption("GDAL_DATA", nullptr))
+    {
+        CPLError(CE_Warning, CPLE_FileIO,
+                 "Cannot find %s (GDAL_DATA is not defined)", pszBasename);
     }
 
     return nullptr;


### PR DESCRIPTION
## What does this PR do?

This PR updates `CPLDefaultFindFile` to emit a warning if a file is not found and `GDAL_DATA` is not defined.

There are handful of C++ unit tests that depend on files found in `GDAL_DATA`, and I was trying to provide information in these  cases that would guide the developer to fix their test environment. I'm not sure if there are other usages of `CPLFindFile` where it would be undesirable to emit this warning.

This seemed like a better solution than providing custom a error message for each test assert that somehow relies on `GDAL_DATA` (seems to require a lot of copy/paste), or just adding a test that verifies that `GDAL_DATA` is defined (maybe would fail unnecessarily for some test environment)

Example output for a failing test that depends on `GDAL_DATA`:

```
GDAL C/C++ API tests (GDAL 3.7.0dev-eacaa4bd48-dirty, released 2018/99/99 (debug build))
---------------------------------------------------------
Note: Google Test filter = *TileMatrix*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from test_gdal
[ RUN      ] test_gdal.TileMatrixSet
Warning 3: Cannot find tms_NZTM2000.json (GDAL_DATA is not defined)
/home/dan/dev/gdal/autotest/cpp/test_gdal.cpp:1831: Failure
Value of: l.find("NZTM2000") != l.end()
  Actual: false
Expected: true
Warning 3: Cannot find tms_LINZAntarticaMapTileGrid.json (GDAL_DATA is not defined)
ERROR 1: Invalid tiling matrix set name
/home/dan/dev/gdal/autotest/cpp/test_gdal.cpp:1868: Failure
Value of: poTMS != nullptr
  Actual: false
Expected: true
Warning 3: Cannot find tms_NZTM2000.json (GDAL_DATA is not defined)
ERROR 1: Invalid tiling matrix set name
/home/dan/dev/gdal/autotest/cpp/test_gdal.cpp:1880: Failure
Value of: poTMS != nullptr
  Actual: false
Expected: true
[  FAILED  ] test_gdal.TileMatrixSet (15 ms)
[----------] 1 test from test_gdal (15 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (16 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] test_gdal.TileMatrixSet

 1 FAILED TEST
```


## What are related issues/pull requests?

None

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
