### PR TITLE
Autotest: Remove order dependencies between C++ tests

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -82,6 +82,12 @@ struct test_cpl : public ::testing::Test
         // Compose data path for test group
         data_ = tut::common::data_basedir;
     }
+
+    void SetUp() override
+    {
+        CPLSetConfigOptions(nullptr);
+        CPLSetThreadLocalConfigOptions(nullptr);
+    }
 };
 
 // Test cpl_list API


### PR DESCRIPTION
## What does this PR do?

Removes order dependencies between C++ unit tests. Without this PR, the following fail:

`gdal_unit_test --gtest_shuffle --gtest_random_seed=25391 --gtest_filter="test_cpl*"`
`gdal_unit_test --gtest_shuffle --gtest_random_seed=31047 --gtest_filter="*shape*"`

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
