### PR TITLE
OSRSpatialReference::SetFromUserInput(): skip leading white space (fixes #7170)

### DIFF
--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -331,14 +331,17 @@ def test_osr_basic_8():
 
 
 ###############################################################################
-# Test the Validate() method.
+# Test the Validate() method with a WKT string with leading space.
 
 
 def test_osr_basic_9():
 
     srs = osr.SpatialReference()
-    srs.SetFromUserInput(
-        'PROJCS["unnamed",GEOGCS["unnamed ellipse",DATUM["unknown",SPHEROID["unnamed",6378137,0]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Mercator_2SP"],PARAMETER["standard_parallel_1",0],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Meter",1],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"]]'
+    assert (
+        srs.SetFromUserInput(
+            ' PROJCS["unnamed",GEOGCS["unnamed ellipse",DATUM["unknown",SPHEROID["unnamed",6378137,0]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Mercator_2SP"],PARAMETER["standard_parallel_1",0],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Meter",1],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"]]'
+        )
+        == ogr.OGRERR_NONE
     )
     assert srs.Validate() == 0
 

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -1908,6 +1908,7 @@ OGRErr OGRSpatialReference::importFromWkt(const char **ppszInput,
 {
     if (!ppszInput || !*ppszInput)
         return OGRERR_FAILURE;
+
     if (strlen(*ppszInput) > 100 * 1000 &&
         CPLTestBool(CPLGetConfigOption("OSR_IMPORT_FROM_WKT_LIMIT", "YES")))
     {
@@ -3710,6 +3711,10 @@ OGRErr OGRSpatialReference::SetFromUserInput(const char *pszDefinition)
 OGRErr OGRSpatialReference::SetFromUserInput(const char *pszDefinition,
                                              CSLConstList papszOptions)
 {
+    // Skip leading white space
+    while (isspace(*pszDefinition))
+        pszDefinition++;
+
     if (STARTS_WITH_CI(pszDefinition, "ESRI::"))
     {
         pszDefinition += 6;


### PR DESCRIPTION
for consistency with importFromWkt()
