### PR TITLE
nitf: add support for COMNTA

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -4231,6 +4231,42 @@ def test_nitf_91():
 
 
 ###############################################################################
+# Test parsing COMNTA TRE
+
+
+def test_nitf_comnta_doc():
+    tre_data = (
+        "FILE_TRE=HEX/COMNTA="
+        + hex_string("Hyperion data courtesy of the U.S. Geological Survey.")
+        + "0d0a"
+        + hex_string("Relative Spectral Response for SWIR FPA bands only.")
+        + "0d0a"
+        + hex_string("Thanks USGS! ")
+        + "f09f8e89"
+    )
+
+    ds = gdal.GetDriverByName("NITF").Create(
+        "/vsimem/nitf_comnta.ntf", 1, 1, options=[tre_data]
+    )
+    ds = None
+
+    ds = gdal.Open("/vsimem/nitf_comnta.ntf")
+    data = ds.GetMetadata("xml:TRE")[0]
+    ds = None
+
+    gdal.GetDriverByName("NITF").Delete("/vsimem/nitf_comnta.ntf")
+
+    expected_data = """<tres>
+  <tre name="COMNTA" location="file">
+    <field name="COMMENT" value="Hyperion data courtesy of the U.S. Geological Survey.\r\nRelative Spectral Response for SWIR FPA bands only.\r\nThanks USGS! 🎉" />
+  </tre>
+</tres>
+"""
+
+    assert data == expected_data
+
+
+###############################################################################
 # Test parsing RSMAPB TRE (STDI-0002-1-v5.0 App U)
 
 

--- a/data/nitf_spec.xml
+++ b/data/nitf_spec.xml
@@ -350,6 +350,11 @@
         </loop>
     </tre>
 
+
+    <tre name="COMNTA">
+        <field name="COMMENT" length_var="*"/>
+    </tre>
+
     <tre name="CSDIDA" md_prefix="NITF_CSDIDA_" length="70" location="file">
         <field name="DAY" length="2"/>
         <field name="MONTH" length="3"/>

--- a/frmts/nitf/nitffile.c
+++ b/frmts/nitf/nitffile.c
@@ -2641,31 +2641,40 @@ static char **NITFGenericMetadataReadTREInternal(
                     CPLGetXMLValue(psIter, "length_var", NULL);
                 if (pszLengthVar != NULL)
                 {
-                    // Preferably look for item at the same level as ours.
-                    const char *pszLengthValue = CSLFetchNameValue(
-                        papszMD, CPLSPrintf("%s%s", pszMDPrefix, pszLengthVar));
-                    if (pszLengthValue != NULL)
+                    if (strcmp(pszLengthVar, "*") == 0)
                     {
-                        nLength = atoi(pszLengthValue);
+                        // Whatever is left
+                        nLength = nTRESize - *pnTreOffset;
                     }
                     else
                     {
-                        char **papszMDIter = papszMD;
-                        while (papszMDIter != NULL && *papszMDIter != NULL)
+                        // Preferably look for item at the same level as ours.
+                        const char *pszLengthValue = CSLFetchNameValue(
+                            papszMD,
+                            CPLSPrintf("%s%s", pszMDPrefix, pszLengthVar));
+                        if (pszLengthValue != NULL)
                         {
-                            if (strstr(*papszMDIter, pszLengthVar) != NULL)
+                            nLength = atoi(pszLengthValue);
+                        }
+                        else
+                        {
+                            char **papszMDIter = papszMD;
+                            while (papszMDIter != NULL && *papszMDIter != NULL)
                             {
-                                const char *pszEqual =
-                                    strchr(*papszMDIter, '=');
-                                if (pszEqual != NULL)
+                                if (strstr(*papszMDIter, pszLengthVar) != NULL)
                                 {
-                                    nLength = atoi(pszEqual + 1);
-                                    // Voluntary missing break so as to find the
-                                    // "closest" item to ours in case it is not
-                                    // defined in the same level
+                                    const char *pszEqual =
+                                        strchr(*papszMDIter, '=');
+                                    if (pszEqual != NULL)
+                                    {
+                                        nLength = atoi(pszEqual + 1);
+                                        // Voluntary missing break so as to find the
+                                        // "closest" item to ours in case it is not
+                                        // defined in the same level
+                                    }
                                 }
+                                papszMDIter++;
                             }
-                            papszMDIter++;
                         }
                     }
                 }


### PR DESCRIPTION
## What does this PR do?

Add support for a draft NITF TRE that provides UTF-8 text comments.

The curious part of this is that the TRE only has one item, and it just "the TRE length, as UTF-8 encoded characters". That is, the length is variable, but there is no field that signals the length. So we need to handle that somehow. The approach used in NITRO is to say "remaining bytes" (`NITF_TRE_GOBBLE`) in a few definitions (JITCID - not actually a real TRE, and a couple of RPF TREs). We could just say "all bytes", but the "remaining bytes" concept seems more general.

The way I've currently approached the encoding is to use the `length_var` keyword, but with a value of `*` to indicate the wildcard that means "remaining bytes". That seemed like a simple solution. I also considered using a label like `TREL` or a silly magic value that probably wouldn't appear as a TRE field name (e.g. "NOM, NOM, NOM"). We could also modify the parsing to add a new keyword i.e. instead of the logic choice between `length` or `length_var`, there would be `length`, `length_var` and `length_remaining` (which would have no argument).

The TRE isn't approved yet, so I'm putting this up early as a draft to solicit feedback.

## What are related issues/pull requests?

N/A.

## Tasklist

 - [ ] Resolve remaining bytes syntax.
 - [x] Add test case(s)
 - [N/A] Add documentation
 - [N/A] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

N/A.