### PR TITLE
[Backport release/3.6] COG: avoid warning message when using -co COMPRESS=WEBP -co QUALITY=100 (fixes #7153)

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -1532,6 +1532,38 @@ def test_cog_webp_overview_turn_on_lossy_if_webp_level():
 
 
 ###############################################################################
+# Test lossless WEBP compression
+
+
+def test_cog_webp_lossless_webp():
+
+    tmpfilename = "/vsimem/test_cog_webp_lossless_webp.tif"
+    md = gdal.GetDriverByName("COG").GetMetadata()
+    if md["DMD_CREATIONOPTIONLIST"].find("WEBP") == -1:
+        pytest.skip()
+    if gdal.GetDriverByName("WEBP") is None:
+        pytest.skip()
+
+    src_ds = gdal.Open("../gdrivers/data/small_world.tif")
+    gdal.ErrorReset()
+    gdal.Translate(
+        tmpfilename,
+        src_ds,
+        options="-of COG -co COMPRESS=WEBP -co QUALITY=100",
+    )
+    assert gdal.GetLastErrorMsg() == ""
+
+    ds = gdal.Open(tmpfilename)
+    assert (
+        ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == "LOSSLESS"
+    )
+    assert ds.GetRasterBand(1).Checksum() == src_ds.GetRasterBand(1).Checksum()
+    ds = None
+
+    gdal.Unlink(tmpfilename)
+
+
+###############################################################################
 # Test OVERVIEW_COUNT option
 
 

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -1083,8 +1083,7 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
     {
         if (pszQuality && atoi(pszQuality) == 100)
             aosOptions.SetNameValue("WEBP_LOSSLESS", "YES");
-        else
-            aosOptions.SetNameValue("WEBP_LEVEL", pszQuality);
+        aosOptions.SetNameValue("WEBP_LEVEL", pszQuality);
     }
     else if (EQUAL(osCompress, "DEFLATE") || EQUAL(osCompress, "LERC_DEFLATE"))
     {


### PR DESCRIPTION
Backport #7155
 **Authored by:** @rouault