### PR TITLE
[Backport release/3.6] NITF: update CLEVEL to appropriate values when using compression / multiple image segments

### DIFF
--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -5577,7 +5577,7 @@ static bool NITFPatchImageLength(const char *pszFilename, int nIMIndex,
     }
 
     /* -------------------------------------------------------------------- */
-    /*      Update COMRAT, the compression rate variable.                   */
+    /*      Update COMRAT, the compression rate variable, and CLEVEL        */
     /* -------------------------------------------------------------------- */
 
     /* Set to IC position */
@@ -5640,6 +5640,47 @@ static bool NITFPatchImageLength(const char *pszFilename, int nIMIndex,
         }
 
         bOK &= VSIFWriteL(szCOMRAT, 4, 1, fpVSIL) == 1;
+
+        /* ---------------------------------------------------------------- */
+        /*      Update CLEVEL.                                              */
+        /* ---------------------------------------------------------------- */
+        // Get existing CLEVEL
+        constexpr int OFFSET_CLEVEL = 9;
+        constexpr int SIZE_CLEVEL = 2;
+        bOK &= VSIFSeekL(fpVSIL, OFFSET_CLEVEL, SEEK_SET) == 0;
+        char szCLEVEL[SIZE_CLEVEL + 1] = {0};
+        bOK &= VSIFReadL(szCLEVEL, 1, SIZE_CLEVEL, fpVSIL) != 0;
+        int nCLevel = atoi(szCLEVEL);
+        if (nCLevel >= 3 && nCLevel <= 7)
+        {
+            const int nCLevelOri = nCLevel;
+            if (nFileLen > 2147483647)
+            {
+                nCLevel = MAX(nCLevel, 7);
+            }
+            else if (nFileLen > 1073741833)
+            {
+                nCLevel = MAX(nCLevel, 6);
+            }
+            else if (nFileLen > 52428799)
+            {
+                nCLevel = MAX(nCLevel, 5);
+            }
+            if (nCLevel != nCLevelOri)
+            {
+                CPLDebug("NITF", "Updating CLEVEL from %02d to %02d",
+                         nCLevelOri, nCLevel);
+                snprintf(szCLEVEL, sizeof(szCLEVEL), "%02d", nCLevel);
+                bOK &= VSIFSeekL(fpVSIL, OFFSET_CLEVEL, SEEK_SET) == 0;
+                bOK &= VSIFWriteL(szCLEVEL, 1, SIZE_CLEVEL, fpVSIL) != 0;
+            }
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Invalid CLEVEL=%s value found when updating NITF header.",
+                     szCLEVEL);
+        }
     }
 
     if (VSIFCloseL(fpVSIL) != 0)

--- a/frmts/nitf/nitffile.c
+++ b/frmts/nitf/nitffile.c
@@ -548,7 +548,7 @@ int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
     VSILFILE *fp;
     GUIntBig nCur = 0;
     int nOffset = 0, iBand, nIHSize, nNPPBH, nNPPBV;
-    GUIntBig nImageSize;
+    GUIntBig nImageSize = 0;
     int nNBPR, nNBPC;
     const char *pszIREP;
     const char *pszIC = CSLFetchNameValue(papszOptions, "IC");
@@ -691,8 +691,11 @@ int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
         nNPPBH = 0;
         nNPPBV = 0;
 
-        nImageSize =
-            ((nBitsPerSample) / 8) * ((GUIntBig)nPixels * nLines) * nBands;
+        if (EQUAL(pszIC, "NC"))
+        {
+            nImageSize =
+                ((nBitsPerSample) / 8) * ((GUIntBig)nPixels * nLines) * nBands;
+        }
     }
     else if ((EQUAL(pszIC, "NC") || EQUAL(pszIC, "C8")) && nPixels > 8192 &&
              nNPPBH == nPixels)
@@ -711,8 +714,11 @@ int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
             return FALSE;
         }
 
-        nImageSize = ((nBitsPerSample) / 8) *
-                     ((GUIntBig)nPixels * (nNBPC * nNPPBV)) * nBands;
+        if (EQUAL(pszIC, "NC"))
+        {
+            nImageSize = ((nBitsPerSample) / 8) *
+                         ((GUIntBig)nPixels * (nNBPC * nNPPBV)) * nBands;
+        }
     }
     else if ((EQUAL(pszIC, "NC") || EQUAL(pszIC, "C8")) && nLines > 8192 &&
              nNPPBV == nLines)
@@ -731,8 +737,11 @@ int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
             return FALSE;
         }
 
-        nImageSize = ((nBitsPerSample) / 8) *
-                     ((GUIntBig)nLines * (nNBPR * nNPPBH)) * nBands;
+        if (EQUAL(pszIC, "NC"))
+        {
+            nImageSize = ((nBitsPerSample) / 8) *
+                         ((GUIntBig)nLines * (nNBPR * nNPPBH)) * nBands;
+        }
     }
     else
     {
@@ -750,8 +759,11 @@ int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
             return FALSE;
         }
 
-        nImageSize = ((nBitsPerSample) / 8) * ((GUIntBig)nNBPR * nNBPC) *
-                     nNPPBH * nNPPBV * nBands;
+        if (EQUAL(pszIC, "NC"))
+        {
+            nImageSize = ((nBitsPerSample) / 8) * ((GUIntBig)nNBPR * nNBPC) *
+                         nNPPBH * nNPPBV * nBands;
+        }
     }
 
     if (EQUAL(pszIC, "NC"))


### PR DESCRIPTION
Backport #7158
 **Authored by:** @rouault