### PR TITLE
Add GDALMDArray::GetGridded() and GDALMDArrayGetGridded()

### DIFF
--- a/alg/delaunay.c
+++ b/alg/delaunay.c
@@ -627,7 +627,16 @@ int GDALTriangulationFindFacetDirected(const GDALTriangulation *psDT,
         }
     }
 
-    CPLDebug("GDAL", "Using brute force lookup");
+    static int nDebugMsgCount = 0;
+    if (nDebugMsgCount <= 20)
+    {
+        CPLDebug("GDAL", "Using brute force lookup%s",
+                 (nDebugMsgCount == 20)
+                     ? " (this debug message will no longer be emitted)"
+                     : "");
+        nDebugMsgCount++;
+    }
+
     return GDALTriangulationFindFacetBruteForce(psDT, dfX, dfY,
                                                 panOutputFacetIdx);
 }

--- a/alg/gdalgrid.cpp
+++ b/alg/gdalgrid.cpp
@@ -3675,15 +3675,15 @@ CPLErr GDALGridCreate(GDALGridAlgorithm eAlgorithm, const void *poOptions,
 }
 
 /************************************************************************/
-/*                      ParseAlgorithmAndOptions()                      */
+/*                   GDALGridParseAlgorithmAndOptions()                 */
 /************************************************************************/
 
 /** Translates mnemonic gridding algorithm names into GDALGridAlgorithm code,
  * parse control parameters and assign defaults.
  */
-CPLErr ParseAlgorithmAndOptions(const char *pszAlgorithm,
-                                GDALGridAlgorithm *peAlgorithm,
-                                void **ppOptions)
+CPLErr GDALGridParseAlgorithmAndOptions(const char *pszAlgorithm,
+                                        GDALGridAlgorithm *peAlgorithm,
+                                        void **ppOptions)
 {
     CPLAssert(pszAlgorithm);
     CPLAssert(peAlgorithm);

--- a/alg/gdalgrid.h
+++ b/alg/gdalgrid.h
@@ -103,8 +103,16 @@ CPLErr GDALGridDataMetricAverageDistancePts(const void *, GUInt32,
 CPLErr GDALGridLinear(const void *, GUInt32, const double *, const double *,
                       const double *, double, double, double *, void *);
 
-CPLErr CPL_DLL ParseAlgorithmAndOptions(const char *, GDALGridAlgorithm *,
-                                        void **);
+#ifndef GDAL_COMPILATION
+/* ParseAlgorithmAndOptions() is used by PostGIS Raster, hence this alias */
+
+/** Compatibility deprecated alias for GDALGridParseAlgorithmAndOptions() */
+#define ParseAlgorithmAndOptions GDALGridParseAlgorithmAndOptions
+#endif
+
+CPLErr CPL_DLL GDALGridParseAlgorithmAndOptions(const char *,
+                                                GDALGridAlgorithm *, void **);
+
 CPL_C_END
 
 #endif /* GDALGRID_H_INCLUDED */

--- a/apps/gdal_grid_lib.cpp
+++ b/apps/gdal_grid_lib.cpp
@@ -985,8 +985,8 @@ GDALGridOptionsNew(char **papszArgv,
     psOptions->bNoDataSet = false;
     psOptions->dfNoDataValue = 0;
 
-    ParseAlgorithmAndOptions(szAlgNameInvDist, &psOptions->eAlgorithm,
-                             &psOptions->pOptions);
+    GDALGridParseAlgorithmAndOptions(szAlgNameInvDist, &psOptions->eAlgorithm,
+                                     &psOptions->pOptions);
 
     bool bGotSourceFilename = false;
     bool bGotDestFilename = false;
@@ -1236,8 +1236,9 @@ GDALGridOptionsNew(char **papszArgv,
         {
             const char *pszAlgorithm = papszArgv[++i];
             CPLFree(psOptions->pOptions);
-            if (ParseAlgorithmAndOptions(pszAlgorithm, &psOptions->eAlgorithm,
-                                         &psOptions->pOptions) != CE_None)
+            if (GDALGridParseAlgorithmAndOptions(
+                    pszAlgorithm, &psOptions->eAlgorithm,
+                    &psOptions->pOptions) != CE_None)
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Failed to process algorithm name and parameters");

--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -2311,6 +2311,45 @@ def test_mem_md_array_nodata_uint64():
     assert ds.GetRasterBand(1).GetNoDataValue() == val
 
 
+def test_mem_md_getcoordinatevariables():
+
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("myds")
+    rg = mem_ds.GetRootGroup()
+
+    dimOther = rg.CreateDimension("other", None, None, 4)
+    other = rg.CreateMDArray(
+        "other", [dimOther], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    assert other
+
+    dimNode = rg.CreateDimension("node", None, None, 4)
+    varX = rg.CreateMDArray(
+        "varX", [dimNode], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    assert varX
+    varY = rg.CreateMDArray(
+        "varY", [dimNode], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    assert varY
+
+    ar = rg.CreateMDArray(
+        "ar", [dimOther, dimNode], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    coordinates = ar.CreateAttribute(
+        "coordinates", [], gdal.ExtendedDataType.CreateString()
+    )
+    assert coordinates.WriteString("other varY varX") == 0
+
+    coordVars = ar.GetCoordinateVariables()
+    assert len(coordVars) == 3
+
+    assert coordinates.WriteString("other non_existing") == 0
+    with gdaltest.error_handler():
+        coordVars = ar.GetCoordinateVariables()
+        assert len(coordVars) == 1
+
+
 def XX_test_all_forever():
     while True:
         test_mem_md_basic()

--- a/frmts/mem/memmultidim.h
+++ b/frmts/mem/memmultidim.h
@@ -48,11 +48,17 @@ class CPL_DLL MEMGroup CPL_NON_FINAL : public GDALGroup
     std::map<CPLString, std::shared_ptr<GDALMDArray>> m_oMapMDArrays{};
     std::map<CPLString, std::shared_ptr<GDALAttribute>> m_oMapAttributes{};
     std::map<CPLString, std::shared_ptr<GDALDimension>> m_oMapDimensions{};
+    std::weak_ptr<MEMGroup> m_pSelf{};
 
   public:
     MEMGroup(const std::string &osParentName, const char *pszName)
         : GDALGroup(osParentName, pszName ? pszName : "")
     {
+    }
+
+    void SetSelf(std::weak_ptr<MEMGroup> self)
+    {
+        m_pSelf = self;
     }
 
     std::vector<std::string>
@@ -216,6 +222,7 @@ class MEMMDArray CPL_NON_FINAL : public MEMAbstractMDArray, public GDALMDArray
     GDALDataType m_eOffsetStorageType = GDT_Unknown;
     GDALDataType m_eScaleStorageType = GDT_Unknown;
     std::string m_osFilename{};
+    std::weak_ptr<GDALGroup> m_poGroupWeak{};
 
     MEMMDArray(const MEMMDArray &) = delete;
     MEMMDArray &operator=(const MEMMDArray &) = delete;
@@ -247,6 +254,11 @@ class MEMMDArray CPL_NON_FINAL : public MEMAbstractMDArray, public GDALMDArray
     const std::string &GetFilename() const override
     {
         return m_osFilename;
+    }
+
+    void RegisterGroup(std::weak_ptr<GDALGroup> group)
+    {
+        m_poGroupWeak = group;
     }
 
     std::shared_ptr<GDALAttribute>
@@ -322,6 +334,9 @@ class MEMMDArray CPL_NON_FINAL : public MEMAbstractMDArray, public GDALMDArray
         m_eScaleStorageType = eStorageType;
         return true;
     }
+
+    std::vector<std::shared_ptr<GDALMDArray>>
+    GetCoordinateVariables() const override;
 };
 
 /************************************************************************/

--- a/frmts/netcdf/netcdfmultidim.cpp
+++ b/frmts/netcdf/netcdfmultidim.cpp
@@ -1587,7 +1587,6 @@ std::shared_ptr<GDALMDArray> netCDFDimension::GetIndexingVariable() const
     netCDFGroup oGroup(m_poShared, m_gid);
     const auto arrayNames = oGroup.GetMDArrayNames(nullptr);
     std::shared_ptr<GDALMDArray> candidateIndexingVariable;
-    int nCountCandidateIndexingVariable = 0;
     for (const auto &arrayName : arrayNames)
     {
         const auto poArray = oGroup.OpenMDArray(arrayName, nullptr);
@@ -1608,15 +1607,14 @@ std::shared_ptr<GDALMDArray> netCDFDimension::GetIndexingVariable() const
                 // If the array doesn't have a coordinates variable, but is a 1D
                 // array indexed by our dimension, then use it as the indexing
                 // variable, provided it is the only such variable.
-                if (nCountCandidateIndexingVariable == 0)
+                if (!candidateIndexingVariable)
                 {
                     candidateIndexingVariable = poArray;
                 }
                 else
                 {
-                    candidateIndexingVariable.reset();
+                    return nullptr;
                 }
-                nCountCandidateIndexingVariable++;
                 continue;
             }
         }

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(
   rasterio.cpp
   rawdataset.cpp
   gdalmultidim.cpp
+  gdalmultidim_gridded.cpp
   gdalpython.cpp
   gdalpythondriverloader.cpp
   tilematrixset.cpp

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -2188,6 +2188,10 @@ GDALMDArrayH CPL_DLL GDALMDArrayGetResampled(GDALMDArrayH hArray,
                                              GDALRIOResampleAlg resampleAlg,
                                              OGRSpatialReferenceH hTargetSRS,
                                              CSLConstList papszOptions);
+GDALMDArrayH CPL_DLL GDALMDArrayGetGridded(
+    GDALMDArrayH hArray, const char *pszGridOptions, GDALMDArrayH hXArray,
+    GDALMDArrayH hYArray, CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
+
 GDALMDArrayH CPL_DLL *
 GDALMDArrayGetCoordinateVariables(GDALMDArrayH hArray,
                                   size_t *pnCount) CPL_WARN_UNUSED_RESULT;

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2857,6 +2857,12 @@ class CPL_DLL GDALMDArray : virtual public GDALAbstractMDArray,
                  const OGRSpatialReference *poTargetSRS,
                  CSLConstList papszOptions) const;
 
+    std::shared_ptr<GDALMDArray>
+    GetGridded(const std::string &osGridOptions,
+               const std::shared_ptr<GDALMDArray> &poXArray = nullptr,
+               const std::shared_ptr<GDALMDArray> &poYArray = nullptr,
+               CSLConstList papszOptions = nullptr) const;
+
     virtual GDALDataset *AsClassicDataset(size_t iXDim, size_t iYDim) const;
 
     virtual CPLErr GetStatistics(bool bApproxOK, bool bForce, double *pdfMin,

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -10810,6 +10810,34 @@ GDALMDArrayH *GDALMDArrayGetCoordinateVariables(GDALMDArrayH hArray,
 }
 
 /************************************************************************/
+/*                     GDALMDArrayGetGridded()                          */
+/************************************************************************/
+
+/** Return a gridded array from scattered point data, that is from an array
+ * whose last dimension is the indexing variable of X and Y arrays.
+ *
+ * The returned object should be released with GDALMDArrayRelease().
+ *
+ * This is the same as the C++ method GDALMDArray::GetGridded().
+ *
+ * @since GDAL 3.7
+ */
+GDALMDArrayH GDALMDArrayGetGridded(GDALMDArrayH hArray,
+                                   const char *pszGridOptions,
+                                   GDALMDArrayH hXArray, GDALMDArrayH hYArray,
+                                   CSLConstList papszOptions)
+{
+    VALIDATE_POINTER1(hArray, __func__, nullptr);
+    VALIDATE_POINTER1(pszGridOptions, __func__, nullptr);
+    auto gridded = hArray->m_poImpl->GetGridded(
+        pszGridOptions, hXArray ? hXArray->m_poImpl : nullptr,
+        hYArray ? hYArray->m_poImpl : nullptr, papszOptions);
+    if (!gridded)
+        return nullptr;
+    return new GDALMDArrayHS(gridded);
+}
+
+/************************************************************************/
 /*                        GDALReleaseArrays()                           */
 /************************************************************************/
 

--- a/gcore/gdalmultidim_gridded.cpp
+++ b/gcore/gdalmultidim_gridded.cpp
@@ -1,0 +1,854 @@
+/******************************************************************************
+ * $Id$
+ *
+ * Name:     gdalmultidim_gridded.cpp
+ * Project:  GDAL Core
+ * Purpose:  GDALMDArray::GetGridded() implementation
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_alg.h"
+#include "gdalgrid.h"
+#include "gdal_priv.h"
+#include "gdal_pam.h"
+#include "ogrsf_frmts.h"
+
+#include <algorithm>
+#include <limits>
+#include <new>
+
+/************************************************************************/
+/*                          GetPAM()                                    */
+/************************************************************************/
+
+static std::shared_ptr<GDALPamMultiDim>
+GetPAM(const std::shared_ptr<GDALMDArray> &poParent)
+{
+    auto poPamArray = dynamic_cast<GDALPamMDArray *>(poParent.get());
+    if (poPamArray)
+        return poPamArray->GetPAM();
+    return nullptr;
+}
+
+/************************************************************************/
+/*                         GDALMDArrayGridded                           */
+/************************************************************************/
+
+class GDALMDArrayGridded final : public GDALPamMDArray
+{
+  private:
+    std::shared_ptr<GDALMDArray> m_poParent{};
+    std::vector<std::shared_ptr<GDALDimension>> m_apoDims{};
+    std::shared_ptr<GDALMDArray> m_poVarX{};
+    std::shared_ptr<GDALMDArray> m_poVarY{};
+    std::unique_ptr<GDALDataset> m_poVectorDS{};
+    GDALGridAlgorithm m_eAlg;
+    std::unique_ptr<void, CPLFreeReleaser> m_poGridOptions;
+    const GDALExtendedDataType m_dt;
+    std::vector<GUInt64> m_anBlockSize{};
+    const double m_dfNoDataValue;
+    const double m_dfMinX;
+    const double m_dfResX;
+    const double m_dfMinY;
+    const double m_dfResY;
+    const double m_dfRadius;
+    mutable std::vector<GUInt64> m_anLastStartIdx{};
+    mutable std::vector<double> m_adfZ{};
+
+  protected:
+    explicit GDALMDArrayGridded(
+        const std::shared_ptr<GDALMDArray> &poParent,
+        const std::vector<std::shared_ptr<GDALDimension>> &apoDims,
+        const std::shared_ptr<GDALMDArray> &poVarX,
+        const std::shared_ptr<GDALMDArray> &poVarY,
+        std::unique_ptr<GDALDataset> &&poVectorDS, GDALGridAlgorithm eAlg,
+        std::unique_ptr<void, CPLFreeReleaser> &&poGridOptions,
+        double dfNoDataValue, double dfMinX, double dfResX, double dfMinY,
+        double dfResY, double dfRadius)
+        : GDALAbstractMDArray(std::string(),
+                              "Gridded view of " + poParent->GetFullName()),
+          GDALPamMDArray(std::string(),
+                         "Gridded view of " + poParent->GetFullName(),
+                         ::GetPAM(poParent)),
+          m_poParent(std::move(poParent)), m_apoDims(apoDims), m_poVarX(poVarX),
+          m_poVarY(poVarY), m_poVectorDS(std::move(poVectorDS)), m_eAlg(eAlg),
+          m_poGridOptions(std::move(poGridOptions)),
+          m_dt(GDALExtendedDataType::Create(GDT_Float64)),
+          m_dfNoDataValue(dfNoDataValue), m_dfMinX(dfMinX), m_dfResX(dfResX),
+          m_dfMinY(dfMinY), m_dfResY(dfResY), m_dfRadius(dfRadius)
+    {
+        const auto anParentBlockSize = m_poParent->GetBlockSize();
+        m_anBlockSize.resize(m_apoDims.size());
+        for (size_t i = 0; i + 1 < m_apoDims.size(); ++i)
+            m_anBlockSize[i] = anParentBlockSize[i];
+        m_anBlockSize[m_apoDims.size() - 2] = 256;
+        m_anBlockSize[m_apoDims.size() - 1] = 256;
+    }
+
+    bool IRead(const GUInt64 *arrayStartIdx, const size_t *count,
+               const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+               const GDALExtendedDataType &bufferDataType,
+               void *pDstBuffer) const override;
+
+  public:
+    static std::shared_ptr<GDALMDArrayGridded>
+    Create(const std::shared_ptr<GDALMDArray> &poParent,
+           const std::vector<std::shared_ptr<GDALDimension>> &apoDims,
+           const std::shared_ptr<GDALMDArray> &poVarX,
+           const std::shared_ptr<GDALMDArray> &poVarY,
+           std::unique_ptr<GDALDataset> &&poVectorDS, GDALGridAlgorithm eAlg,
+           std::unique_ptr<void, CPLFreeReleaser> &&poGridOptions,
+           double dfNoDataValue, double dfMinX, double dfResX, double dfMinY,
+           double dfResY, double dfRadius)
+    {
+        auto newAr(std::shared_ptr<GDALMDArrayGridded>(new GDALMDArrayGridded(
+            poParent, apoDims, poVarX, poVarY, std::move(poVectorDS), eAlg,
+            std::move(poGridOptions), dfNoDataValue, dfMinX, dfResX, dfMinY,
+            dfResY, dfRadius)));
+        newAr->SetSelf(newAr);
+        return newAr;
+    }
+
+    bool IsWritable() const override
+    {
+        return false;
+    }
+
+    const std::string &GetFilename() const override
+    {
+        return m_poParent->GetFilename();
+    }
+
+    const std::vector<std::shared_ptr<GDALDimension>> &
+    GetDimensions() const override
+    {
+        return m_apoDims;
+    }
+
+    const void *GetRawNoDataValue() const override
+    {
+        return &m_dfNoDataValue;
+    }
+
+    std::vector<GUInt64> GetBlockSize() const override
+    {
+        return m_anBlockSize;
+    }
+
+    const GDALExtendedDataType &GetDataType() const override
+    {
+        return m_dt;
+    }
+
+    const std::string &GetUnit() const override
+    {
+        return m_poParent->GetUnit();
+    }
+
+    std::shared_ptr<OGRSpatialReference> GetSpatialRef() const override
+    {
+        return m_poParent->GetSpatialRef();
+    }
+
+    std::shared_ptr<GDALAttribute>
+    GetAttribute(const std::string &osName) const override
+    {
+        return m_poParent->GetAttribute(osName);
+    }
+
+    std::vector<std::shared_ptr<GDALAttribute>>
+    GetAttributes(CSLConstList papszOptions = nullptr) const override
+    {
+        return m_poParent->GetAttributes(papszOptions);
+    }
+};
+
+/************************************************************************/
+/*                             IRead()                                  */
+/************************************************************************/
+
+bool GDALMDArrayGridded::IRead(const GUInt64 *arrayStartIdx,
+                               const size_t *count, const GInt64 *arrayStep,
+                               const GPtrDiff_t *bufferStride,
+                               const GDALExtendedDataType &bufferDataType,
+                               void *pDstBuffer) const
+{
+    if (bufferDataType.GetClass() != GEDTC_NUMERIC)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "GDALMDArrayGridded::IRead() only support numeric "
+                 "bufferDataType");
+        return false;
+    }
+    const auto nDims = GetDimensionCount();
+
+    std::vector<GUInt64> anStartIdx;
+    for (size_t i = 0; i + 2 < nDims; ++i)
+    {
+        anStartIdx.push_back(arrayStartIdx[i]);
+        if (count[i] != 1)
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "GDALMDArrayGridded::IRead() only support count = 1 in "
+                     "the first dimensions, except the last 2 Y,X ones");
+            return false;
+        }
+    }
+
+    const auto iDimX = nDims - 1;
+    const auto iDimY = nDims - 2;
+
+    if (arrayStep[iDimX] < 0)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "GDALMDArrayGridded::IRead(): "
+                 "arrayStep[iDimX] < 0 not supported");
+        return false;
+    }
+
+    if (arrayStep[iDimY] < 0)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "GDALMDArrayGridded::IRead(): "
+                 "arrayStep[iDimY] < 0 not supported");
+        return false;
+    }
+
+    // Load the values taken by the variable at the considered slice
+    // (if not already done)
+    if (m_adfZ.empty() || m_anLastStartIdx != anStartIdx)
+    {
+        std::vector<GUInt64> anTempStartIdx(anStartIdx);
+        anTempStartIdx.push_back(0);
+        const std::vector<GInt64> anTempArrayStep(
+            m_poParent->GetDimensionCount(), 1);
+        std::vector<GPtrDiff_t> anTempBufferStride(
+            m_poParent->GetDimensionCount() - 1, 0);
+        anTempBufferStride.push_back(1);
+        std::vector<size_t> anTempCount(m_poParent->GetDimensionCount() - 1, 1);
+        anTempCount.push_back(
+            static_cast<size_t>(m_poParent->GetDimensions().back()->GetSize()));
+        CPLAssert(anTempStartIdx.size() == m_poParent->GetDimensionCount());
+        CPLAssert(anTempCount.size() == m_poParent->GetDimensionCount());
+        CPLAssert(anTempArrayStep.size() == m_poParent->GetDimensionCount());
+        CPLAssert(anTempBufferStride.size() == m_poParent->GetDimensionCount());
+
+        try
+        {
+            m_adfZ.resize(anTempCount.back());
+        }
+        catch (const std::bad_alloc &e)
+        {
+            CPLError(CE_Failure, CPLE_OutOfMemory, "%s", e.what());
+            return false;
+        }
+
+        if (!m_poParent->Read(anTempStartIdx.data(), anTempCount.data(),
+                              anTempArrayStep.data(), anTempBufferStride.data(),
+                              m_dt, m_adfZ.data()))
+        {
+            return false;
+        }
+        m_anLastStartIdx = anStartIdx;
+    }
+
+    // Determine the X,Y spatial extent of the request
+    const double dfX1 = m_dfMinX + arrayStartIdx[iDimX] * m_dfResX;
+    const double dfX2 = m_dfMinX + (arrayStartIdx[iDimX] +
+                                    (count[iDimX] - 1) * arrayStep[iDimX]) *
+                                       m_dfResX;
+    const double dfMinX = std::min(dfX1, dfX2) - m_dfResX / 2;
+    const double dfMaxX = std::max(dfX1, dfX2) + m_dfResX / 2;
+
+    const double dfY1 = m_dfMinY + arrayStartIdx[iDimY] * m_dfResY;
+    const double dfY2 = m_dfMinY + (arrayStartIdx[iDimY] +
+                                    (count[iDimY] - 1) * arrayStep[iDimY]) *
+                                       m_dfResY;
+    const double dfMinY = std::min(dfY1, dfY2) - m_dfResY / 2;
+    const double dfMaxY = std::max(dfY1, dfY2) + m_dfResY / 2;
+
+    // Extract relevant variable values
+    auto poLyr = m_poVectorDS->GetLayer(0);
+    if (!(arrayStartIdx[iDimX] == 0 &&
+          arrayStartIdx[iDimX] + (count[iDimX] - 1) * arrayStep[iDimX] ==
+              m_apoDims[iDimX]->GetSize() - 1 &&
+          arrayStartIdx[iDimY] == 0 &&
+          arrayStartIdx[iDimY] + (count[iDimY] - 1) * arrayStep[iDimY] ==
+              m_apoDims[iDimY]->GetSize() - 1))
+    {
+        poLyr->SetSpatialFilterRect(dfMinX - m_dfRadius, dfMinY - m_dfRadius,
+                                    dfMaxX + m_dfRadius, dfMaxY + m_dfRadius);
+    }
+    else
+    {
+        poLyr->SetSpatialFilter(nullptr);
+    }
+    std::vector<double> adfX;
+    std::vector<double> adfY;
+    std::vector<double> adfZ;
+    try
+    {
+        for (auto &&poFeat : poLyr)
+        {
+            const auto poGeom = poFeat->GetGeometryRef();
+            CPLAssert(poGeom);
+            CPLAssert(poGeom->getGeometryType() == wkbPoint);
+            adfX.push_back(poGeom->toPoint()->getX());
+            adfY.push_back(poGeom->toPoint()->getY());
+            const size_t nIdxInDataset =
+                static_cast<size_t>(poFeat->GetFieldAsInteger64(0));
+            adfZ.push_back(m_adfZ[nIdxInDataset]);
+        }
+    }
+    catch (const std::bad_alloc &e)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory, "%s", e.what());
+        return false;
+    }
+
+    const size_t nXSize =
+        static_cast<size_t>((count[iDimX] - 1) * arrayStep[iDimX] + 1);
+    const size_t nYSize =
+        static_cast<size_t>((count[iDimY] - 1) * arrayStep[iDimY] + 1);
+    if (nXSize > std::numeric_limits<GUInt32>::max() / nYSize)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Too many points queried at once");
+        return false;
+    }
+    std::vector<double> adfRes;
+    try
+    {
+        adfRes.resize(nXSize * nYSize, m_dfNoDataValue);
+    }
+    catch (const std::bad_alloc &e)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory, "%s", e.what());
+        return false;
+    }
+#if 0
+    CPLDebug("GDAL",
+             "dfMinX=%f, dfMaxX=%f, dfMinY=%f, dfMaxY=%f",
+             dfMinX, dfMaxX, dfMinY, dfMaxY);
+#endif
+
+    // Finally do the gridded interpolation
+    if (!adfX.empty() &&
+        GDALGridCreate(
+            m_eAlg, m_poGridOptions.get(), static_cast<GUInt32>(adfX.size()),
+            adfX.data(), adfY.data(), adfZ.data(), dfMinX, dfMaxX, dfMinY,
+            dfMaxY, static_cast<GUInt32>(nXSize), static_cast<GUInt32>(nYSize),
+            GDT_Float64, adfRes.data(), nullptr, nullptr) != CE_None)
+    {
+        return false;
+    }
+
+    // Copy interpolated data into destination buffer
+    GByte *pabyDestBuffer = static_cast<GByte *>(pDstBuffer);
+    const auto eBufferDT = bufferDataType.GetNumericDataType();
+    const auto nBufferDTSize = GDALGetDataTypeSizeBytes(eBufferDT);
+    for (size_t iY = 0; iY < count[iDimY]; ++iY)
+    {
+        GDALCopyWords64(
+            adfRes.data() + iY * arrayStep[iDimY] * nXSize, GDT_Float64,
+            static_cast<int>(sizeof(double) * arrayStep[iDimX]),
+            pabyDestBuffer + iY * bufferStride[iDimY] * nBufferDTSize,
+            eBufferDT, static_cast<int>(bufferStride[iDimX] * nBufferDTSize),
+            static_cast<GPtrDiff_t>(count[iDimX]));
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                            GetGridded()                              */
+/************************************************************************/
+
+/** Return a gridded array from scattered point data, that is from an array
+ * whose last dimension is the indexing variable of X and Y arrays.
+ *
+ * The gridding is done in 2D, using GDALGridCreate(), on-the-fly at Read()
+ * time, taking into account the spatial extent of the request to limit the
+ * gridding. The results got on the whole extent or a subset of it might not be
+ * strictly identical depending on the gridding algorithm and its radius.
+ * Setting a radius in osGridOptions is recommended to improve performance.
+ * For arrays which have more dimensions than the dimension of the indexing
+ * variable of the X and Y arrays, Read() must be called on slices of the extra
+ * dimensions (ie count[i] must be set to 1, except for the X and Y dimensions
+ * of the array returned by this method).
+ *
+ * This is the same as the C function GDALMDArrayGetGridded().
+ *
+ * @param osGridOptions Gridding algorithm and options.
+ * e.g. "invdist:nodata=nan:radius1=1:radius2=1:max_points=5".
+ * See documentation of the <a href="/programs/gdal_grid.html">gdal_grid</a>
+ * utility for all options.
+ * @param poXArrayIn Single-dimension array containing X values, and whose
+ * dimension is the last one of this array. If set to nullptr, the "coordinates"
+ * attribute must exist on this array, and the X variable will be the (N-1)th one
+ * mentioned in it, unless there is a "x" or "lon" variable in "coordinates".
+ * @param poYArrayIn Single-dimension array containing Y values, and whose
+ * dimension is the last one of this array. If set to nullptr, the "coordinates"
+ * attribute must exist on this array, and the Y variable will be the (N-2)th one
+ * mentioned in it,  unless there is a "y" or "lat" variable in "coordinates".
+ * @param papszOptions NULL terminated list of options, or nullptr. Supported
+ * options are:
+ * <ul>
+ * <li>RESOLUTION=val: Spatial resolution of the returned array. If not set,
+ * will be guessed from the typical spacing of (X,Y) points.</li>
+ * </ul>
+ *
+ * @return gridded array, or nullptr in case of error.
+ *
+ * @since GDAL 3.7
+ */
+std::shared_ptr<GDALMDArray>
+GDALMDArray::GetGridded(const std::string &osGridOptions,
+                        const std::shared_ptr<GDALMDArray> &poXArrayIn,
+                        const std::shared_ptr<GDALMDArray> &poYArrayIn,
+                        CSLConstList papszOptions) const
+{
+    auto self = std::dynamic_pointer_cast<GDALMDArray>(m_pSelf.lock());
+    if (!self)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Driver implementation issue: m_pSelf not set !");
+        return nullptr;
+    }
+
+    GDALGridAlgorithm eAlg;
+    void *pOptions = nullptr;
+    if (GDALGridParseAlgorithmAndOptions(osGridOptions.c_str(), &eAlg,
+                                         &pOptions) != CE_None)
+    {
+        return nullptr;
+    }
+
+    std::unique_ptr<void, CPLFreeReleaser> poGridOptions(pOptions);
+
+    if (GetDataType().GetClass() != GEDTC_NUMERIC)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "GetDataType().GetClass() != GEDTC_NUMERIC");
+        return nullptr;
+    }
+
+    if (GetDimensionCount() == 0)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported, "GetDimensionCount() == 0");
+        return nullptr;
+    }
+
+    if (poXArrayIn && !poYArrayIn)
+    {
+        CPLError(
+            CE_Failure, CPLE_AppDefined,
+            "As poXArrayIn is specified, poYArrayIn must also be specified");
+        return nullptr;
+    }
+    else if (!poXArrayIn && poYArrayIn)
+    {
+        CPLError(
+            CE_Failure, CPLE_AppDefined,
+            "As poYArrayIn is specified, poXArrayIn must also be specified");
+        return nullptr;
+    }
+    std::shared_ptr<GDALMDArray> poXArray = poXArrayIn;
+    std::shared_ptr<GDALMDArray> poYArray = poYArrayIn;
+
+    if (!poXArray)
+    {
+        const auto aoCoordVariables = GetCoordinateVariables();
+        if (aoCoordVariables.size() < 2)
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "aoCoordVariables.size() < 2");
+            return nullptr;
+        }
+
+        if (aoCoordVariables.size() != GetDimensionCount() + 1)
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "aoCoordVariables.size() != GetDimensionCount() + 1");
+            return nullptr;
+        }
+
+        // Default choice for X and Y arrays
+        poYArray = aoCoordVariables[aoCoordVariables.size() - 2];
+        poXArray = aoCoordVariables[aoCoordVariables.size() - 1];
+
+        // Detect X and Y array from coordinate variables
+        for (const auto &poVar : aoCoordVariables)
+        {
+            const auto &osVarName = poVar->GetName();
+#ifdef disabled
+            if (poVar->GetDimensionCount() != 1)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Coordinate variable %s is not 1-dimensional",
+                         osVarName.c_str());
+                return nullptr;
+            }
+            const auto &osVarDimName = poVar->GetDimensions()[0]->GetFullName();
+            bool bFound = false;
+            for (const auto &poDim : GetDimensions())
+            {
+                if (osVarDimName == poDim->GetFullName())
+                {
+                    bFound = true;
+                    break;
+                }
+            }
+            if (!bFound)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Dimension %s of coordinate variable %s is not a "
+                         "dimension of this array",
+                         osVarDimName.c_str(), osVarName.c_str());
+                return nullptr;
+            }
+#endif
+            if (osVarName == "x" || osVarName == "lon")
+            {
+                poXArray = poVar;
+            }
+            else if (osVarName == "y" || osVarName == "lat")
+            {
+                poYArray = poVar;
+            }
+        }
+    }
+
+    if (poYArray->GetDimensionCount() != 1)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "aoCoordVariables[aoCoordVariables.size() - "
+                 "2]->GetDimensionCount() != 1");
+        return nullptr;
+    }
+    if (poYArray->GetDataType().GetClass() != GEDTC_NUMERIC)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "poYArray->GetDataType().GetClass() != GEDTC_NUMERIC");
+        return nullptr;
+    }
+
+    if (poXArray->GetDimensionCount() != 1)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "aoCoordVariables[aoCoordVariables.size() - "
+                 "1]->GetDimensionCount() != 1");
+        return nullptr;
+    }
+    if (poXArray->GetDataType().GetClass() != GEDTC_NUMERIC)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "poXArray->GetDataType().GetClass() != GEDTC_NUMERIC");
+        return nullptr;
+    }
+
+    if (poYArray->GetDimensions()[0]->GetFullName() !=
+        poXArray->GetDimensions()[0]->GetFullName())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "poYArray->GetDimensions()[0]->GetFullName() != "
+                 "poXArray->GetDimensions()[0]->GetFullName()");
+        return nullptr;
+    }
+
+    if (poXArray->GetDimensions()[0]->GetFullName() !=
+        GetDimensions().back()->GetFullName())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "poYArray->GetDimensions()[0]->GetFullName() != "
+                 "GetDimensions().back()->GetFullName()");
+        return nullptr;
+    }
+
+    if (poXArray->GetTotalElementsCount() <= 2)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "poXArray->GetTotalElementsCount() <= 2");
+        return nullptr;
+    }
+
+    if (poXArray->GetTotalElementsCount() >
+        std::numeric_limits<size_t>::max() / 2)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "poXArray->GetTotalElementsCount() > "
+                 "std::numeric_limits<size_t>::max() / 2");
+        return nullptr;
+    }
+
+    if (poXArray->GetTotalElementsCount() > 10 * 1024 * 1024 &&
+        !CPLTestBool(CSLFetchNameValueDef(
+            papszOptions, "ACCEPT_BIG_SPATIAL_INDEXING_VARIABLE", "NO")))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "The spatial indexing variable has " CPL_FRMT_GIB " elements. "
+                 "Set the ACCEPT_BIG_SPATIAL_INDEXING_VARIABLE=YES option of "
+                 "GetGridded() to mean you want to continue and are aware of "
+                 "big RAM and CPU time requirements",
+                 static_cast<GIntBig>(poXArray->GetTotalElementsCount()));
+        return nullptr;
+    }
+
+    std::vector<double> adfXVals;
+    std::vector<double> adfYVals;
+    try
+    {
+        adfXVals.resize(static_cast<size_t>(poXArray->GetTotalElementsCount()));
+        adfYVals.resize(static_cast<size_t>(poXArray->GetTotalElementsCount()));
+    }
+    catch (const std::bad_alloc &e)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory, "%s", e.what());
+        return nullptr;
+    }
+
+    // Ingest X and Y arrays
+    const GUInt64 arrayStartIdx[] = {0};
+    const size_t count[] = {adfXVals.size()};
+    const GInt64 arrayStep[] = {1};
+    const GPtrDiff_t bufferStride[] = {1};
+    if (!poXArray->Read(arrayStartIdx, count, arrayStep, bufferStride,
+                        GDALExtendedDataType::Create(GDT_Float64),
+                        adfXVals.data()))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "poXArray->Read() failed");
+        return nullptr;
+    }
+    if (!poYArray->Read(arrayStartIdx, count, arrayStep, bufferStride,
+                        GDALExtendedDataType::Create(GDT_Float64),
+                        adfYVals.data()))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "poYArray->Read() failed");
+        return nullptr;
+    }
+
+    const char *pszExt = "fgb";
+    GDALDriver *poDrv = GetGDALDriverManager()->GetDriverByName("FlatGeoBuf");
+    if (!poDrv)
+    {
+        pszExt = "gpkg";
+        poDrv = GetGDALDriverManager()->GetDriverByName("GPKG");
+        if (!poDrv)
+        {
+            pszExt = "mem";
+            poDrv = GetGDALDriverManager()->GetDriverByName("Memory");
+            if (!poDrv)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Cannot get driver FlatGeoBuf, GPKG or Memory");
+                return nullptr;
+            }
+        }
+    }
+
+    // Create a in-memory vector layer with (X,Y) points
+    CPLString osTmpFilename;
+    osTmpFilename.Printf("/vsimem/GDALMDArray::GetGridded_%p_%p.%s", this,
+                         pOptions, pszExt);
+    auto poDS = std::unique_ptr<GDALDataset>(
+        poDrv->Create(osTmpFilename.c_str(), 0, 0, 0, GDT_Unknown, nullptr));
+    if (!poDS)
+        return nullptr;
+    auto poLyr = poDS->CreateLayer("layer", nullptr, wkbPoint);
+    if (!poLyr)
+        return nullptr;
+    OGRFieldDefn oFieldDefn("IDX", OFTInteger64);
+    poLyr->CreateField(&oFieldDefn);
+    if (poLyr->StartTransaction() != OGRERR_NONE)
+        return nullptr;
+    OGRFeature oFeat(poLyr->GetLayerDefn());
+    for (size_t i = 0; i < adfXVals.size(); ++i)
+    {
+        auto poPoint = new OGRPoint(adfXVals[i], adfYVals[i]);
+        oFeat.SetFID(OGRNullFID);
+        oFeat.SetGeometryDirectly(poPoint);
+        oFeat.SetField(0, static_cast<GIntBig>(i));
+        if (poLyr->CreateFeature(&oFeat) != OGRERR_NONE)
+            return nullptr;
+    }
+    if (poLyr->CommitTransaction() != OGRERR_NONE)
+        return nullptr;
+    OGREnvelope sEnvelope;
+    CPL_IGNORE_RET_VAL(poLyr->GetExtent(&sEnvelope));
+    if (!EQUAL(pszExt, "mem"))
+    {
+        if (poDS->Close() != OGRERR_NONE)
+            return nullptr;
+        poDS.reset(GDALDataset::Open(osTmpFilename.c_str(), GDAL_OF_VECTOR));
+        if (!poDS)
+            return nullptr;
+        poDS->MarkSuppressOnClose();
+    }
+
+    /* Set of constraints:
+    nX * nY = nCount
+    nX * res = MaxX - MinX
+    nY * res = MaxY - MinY
+    */
+
+    double dfRes;
+    const char *pszRes = CSLFetchNameValue(papszOptions, "RESOLUTION");
+    if (pszRes)
+    {
+        dfRes = CPLAtofM(pszRes);
+    }
+    else
+    {
+        const double dfTotalArea = (sEnvelope.MaxY - sEnvelope.MinY) *
+                                   (sEnvelope.MaxX - sEnvelope.MinX);
+        dfRes = sqrt(dfTotalArea / static_cast<double>(adfXVals.size()));
+        // CPLDebug("GDAL", "dfRes = %f", dfRes);
+
+        // Take 10 "random" points in the set, and find the minimum distance from
+        // each to the closest one. And take the geometric average of those minimum
+        // distances as the resolution.
+        const size_t nNumSamplePoints = std::min<size_t>(10, adfXVals.size());
+
+        poLyr = poDS->GetLayer(0);
+        double dfSumDist2Min = 0;
+        int nCountDistMin = 0;
+        for (size_t i = 0; i < nNumSamplePoints; ++i)
+        {
+            const auto nIdx = i * adfXVals.size() / nNumSamplePoints;
+            poLyr->SetSpatialFilterRect(
+                adfXVals[nIdx] - 2 * dfRes, adfYVals[nIdx] - 2 * dfRes,
+                adfXVals[nIdx] + 2 * dfRes, adfYVals[nIdx] + 2 * dfRes);
+            double dfDist2Min = std::numeric_limits<double>::max();
+            for (auto &&poFeat : poLyr)
+            {
+                const auto poGeom = poFeat->GetGeometryRef();
+                CPLAssert(poGeom);
+                CPLAssert(poGeom->getGeometryType() == wkbPoint);
+                double dfDX = poGeom->toPoint()->getX() - adfXVals[nIdx];
+                double dfDY = poGeom->toPoint()->getY() - adfYVals[nIdx];
+                double dfDist2 = dfDX * dfDX + dfDY * dfDY;
+                if (dfDist2 > 0 && dfDist2 < dfDist2Min)
+                    dfDist2Min = dfDist2;
+            }
+            if (dfDist2Min < std::numeric_limits<double>::max())
+            {
+                dfSumDist2Min += dfDist2Min;
+                nCountDistMin++;
+            }
+        }
+        poLyr->SetSpatialFilter(nullptr);
+        if (nCountDistMin > 0)
+        {
+            const double dfNewRes = sqrt(dfSumDist2Min / nCountDistMin);
+            // CPLDebug("GDAL", "dfRes = %f, dfNewRes = %f", dfRes, dfNewRes);
+            dfRes = dfNewRes;
+        }
+    }
+
+    if (!(dfRes > 0))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid RESOLUTION");
+        return nullptr;
+    }
+
+    constexpr double EPS = 1e-8;
+    const double dfXSize =
+        1 + std::floor((sEnvelope.MaxX - sEnvelope.MinX) / dfRes + EPS);
+    if (dfXSize > std::numeric_limits<int>::max())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Integer overflow with dfXSize");
+        return nullptr;
+    }
+    const int nXSize = std::max(2, static_cast<int>(dfXSize));
+
+    const double dfYSize =
+        1 + std::floor((sEnvelope.MaxY - sEnvelope.MinY) / dfRes + EPS);
+    if (dfYSize > std::numeric_limits<int>::max())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Integer overflow with dfYSize");
+        return nullptr;
+    }
+    const int nYSize = std::max(2, static_cast<int>(dfYSize));
+
+    const double dfResX = (sEnvelope.MaxX - sEnvelope.MinX) / (nXSize - 1);
+    const double dfResY = (sEnvelope.MaxY - sEnvelope.MinY) / (nYSize - 1);
+    // CPLDebug("GDAL", "nXSize = %d, nYSize = %d", nXSize, nYSize);
+
+    std::vector<std::shared_ptr<GDALDimension>> apoNewDims;
+    const auto apoSelfDims = GetDimensions();
+    for (size_t i = 0; i < GetDimensionCount() - 1; ++i)
+        apoNewDims.emplace_back(apoSelfDims[i]);
+
+    auto poDimY = std::make_shared<GDALDimensionWeakIndexingVar>(
+        std::string(), "dimY", GDAL_DIM_TYPE_HORIZONTAL_Y, "NORTH", nYSize);
+    auto varY = GDALMDArrayRegularlySpaced::Create(
+        std::string(), poDimY->GetName(), poDimY, sEnvelope.MinY, dfResY, 0);
+    poDimY->SetIndexingVariable(varY);
+
+    auto poDimX = std::make_shared<GDALDimensionWeakIndexingVar>(
+        std::string(), "dimX", GDAL_DIM_TYPE_HORIZONTAL_X, "EAST", nXSize);
+    auto varX = GDALMDArrayRegularlySpaced::Create(
+        std::string(), poDimX->GetName(), poDimX, sEnvelope.MinX, dfResX, 0);
+    poDimX->SetIndexingVariable(varX);
+
+    apoNewDims.emplace_back(poDimY);
+    apoNewDims.emplace_back(poDimX);
+
+    const CPLStringList aosTokens(
+        CSLTokenizeString2(osGridOptions.c_str(), ":", FALSE));
+
+    // Extract nodata value from gridding options
+    const char *pszNoDataValue = aosTokens.FetchNameValue("nodata");
+    double dfNoDataValue = 0;
+    if (pszNoDataValue != nullptr)
+    {
+        dfNoDataValue = CPLAtofM(pszNoDataValue);
+    }
+
+    // Extract radius from gridding options
+    double dfRadius = 5 * std::max(dfResX, dfResY);
+    const char *pszRadius = aosTokens.FetchNameValue("radius");
+    if (pszRadius)
+    {
+        dfRadius = CPLAtofM(pszRadius);
+    }
+    else
+    {
+        const char *pszRadius1 = aosTokens.FetchNameValue("radius1");
+        if (pszRadius1)
+        {
+            dfRadius = CPLAtofM(pszRadius1);
+            const char *pszRadius2 = aosTokens.FetchNameValue("radius2");
+            if (pszRadius2)
+            {
+                dfRadius = std::max(dfRadius, CPLAtofM(pszRadius2));
+            }
+        }
+    }
+
+    return GDALMDArrayGridded::Create(
+        self, apoNewDims, varX, varY, std::move(poDS), eAlg,
+        std::move(poGridOptions), dfNoDataValue, sEnvelope.MinX, dfResX,
+        sEnvelope.MinY, dfResY, dfRadius);
+}

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -1032,6 +1032,17 @@ public:
   }
 %clear char **;
 
+%newobject GetGridded;
+%feature ("kwargs") GetGridded;
+%apply Pointer NONNULL {const char* pszGridOptions};
+  GDALMDArrayHS* GetGridded(const char* pszGridOptions,
+                            GDALMDArrayHS* xArray = NULL,
+                            GDALMDArrayHS* yArray = NULL,
+                            char** options = 0)
+  {
+    return GDALMDArrayGetGridded(self, pszGridOptions, xArray, yArray, options);
+  }
+
 %newobject AsClassicDataset;
   GDALDatasetShadow* AsClassicDataset(size_t iXDim, size_t iYDim)
   {

--- a/swig/include/Operations.i
+++ b/swig/include/Operations.i
@@ -470,11 +470,11 @@ int wrapper_GridCreate( char* algorithmOptions,
 
     if ( algorithmOptions )
     {
-        eErr = ParseAlgorithmAndOptions( algorithmOptions, &eAlgorithm, &pOptions );
+        eErr = GDALGridParseAlgorithmAndOptions( algorithmOptions, &eAlgorithm, &pOptions );
     }
     else
     {
-        eErr = ParseAlgorithmAndOptions( szAlgNameInvDist, &eAlgorithm, &pOptions );
+        eErr = GDALGridParseAlgorithmAndOptions( szAlgNameInvDist, &eAlgorithm, &pOptions );
     }
 
     if ( eErr != CE_None )

--- a/swig/python/extensions/gdal_wrap.cpp
+++ b/swig/python/extensions/gdal_wrap.cpp
@@ -6027,6 +6027,9 @@ SWIGINTERN GDALMDArrayHS *GDALMDArrayHS_GetUnscaled(GDALMDArrayHS *self){
 SWIGINTERN GDALMDArrayHS *GDALMDArrayHS_GetMask(GDALMDArrayHS *self,char **options=0){
     return GDALMDArrayGetMask(self, options);
   }
+SWIGINTERN GDALMDArrayHS *GDALMDArrayHS_GetGridded(GDALMDArrayHS *self,char const *pszGridOptions,GDALMDArrayHS *xArray=NULL,GDALMDArrayHS *yArray=NULL,char **options=0){
+    return GDALMDArrayGetGridded(self, pszGridOptions, xArray, yArray, options);
+  }
 SWIGINTERN GDALDatasetShadow *GDALMDArrayHS_AsClassicDataset(GDALMDArrayHS *self,size_t iXDim,size_t iYDim){
     return (GDALDatasetShadow*)GDALMDArrayAsClassicDataset(self, iXDim, iYDim);
   }
@@ -27706,6 +27709,109 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_MDArray_GetGridded(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
+  GDALMDArrayHS *arg1 = (GDALMDArrayHS *) 0 ;
+  char *arg2 = (char *) 0 ;
+  GDALMDArrayHS *arg3 = (GDALMDArrayHS *) NULL ;
+  GDALMDArrayHS *arg4 = (GDALMDArrayHS *) NULL ;
+  char **arg5 = (char **) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"pszGridOptions",  (char *)"xArray",  (char *)"yArray",  (char *)"options",  NULL 
+  };
+  GDALMDArrayHS *result = 0 ;
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|OOO:MDArray_GetGridded", kwnames, &obj0, &obj1, &obj2, &obj3, &obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_GDALMDArrayHS, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MDArray_GetGridded" "', argument " "1"" of type '" "GDALMDArrayHS *""'"); 
+  }
+  arg1 = reinterpret_cast< GDALMDArrayHS * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MDArray_GetGridded" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_GDALMDArrayHS, 0 |  0 );
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "MDArray_GetGridded" "', argument " "3"" of type '" "GDALMDArrayHS *""'"); 
+    }
+    arg3 = reinterpret_cast< GDALMDArrayHS * >(argp3);
+  }
+  if (obj3) {
+    res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_GDALMDArrayHS, 0 |  0 );
+    if (!SWIG_IsOK(res4)) {
+      SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "MDArray_GetGridded" "', argument " "4"" of type '" "GDALMDArrayHS *""'"); 
+    }
+    arg4 = reinterpret_cast< GDALMDArrayHS * >(argp4);
+  }
+  if (obj4) {
+    {
+      /* %typemap(in) char **options */
+      int bErr = FALSE;
+      arg5 = CSLFromPySequence(obj4, &bErr);
+      if( bErr )
+      {
+        SWIG_fail;
+      }
+    }
+  }
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    if ( bUseExceptions ) {
+      ClearErrorState();
+    }
+    {
+      SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+      result = (GDALMDArrayHS *)GDALMDArrayHS_GetGridded(arg1,(char const *)arg2,arg3,arg4,arg5);
+      SWIG_PYTHON_THREAD_END_ALLOW;
+    }
+#ifndef SED_HACKS
+    if ( bUseExceptions ) {
+      CPLErr eclass = CPLGetLastErrorType();
+      if ( eclass == CE_Failure || eclass == CE_Fatal ) {
+        SWIG_exception( SWIG_RuntimeError, CPLGetLastErrorMsg() );
+      }
+    }
+#endif
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_GDALMDArrayHS, SWIG_POINTER_OWN |  0 );
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  {
+    /* %typemap(freearg) char **options */
+    CSLDestroy( arg5 );
+  }
+  if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  {
+    /* %typemap(freearg) char **options */
+    CSLDestroy( arg5 );
+  }
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_MDArray_AsClassicDataset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0; int bLocalUseExceptionsCode = bUseExceptions;
   GDALMDArrayHS *arg1 = (GDALMDArrayHS *) 0 ;
@@ -47346,6 +47452,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "MDArray_Transpose", _wrap_MDArray_Transpose, METH_VARARGS, "MDArray_Transpose(MDArray self, int nList) -> MDArray"},
 	 { "MDArray_GetUnscaled", _wrap_MDArray_GetUnscaled, METH_O, "MDArray_GetUnscaled(MDArray self) -> MDArray"},
 	 { "MDArray_GetMask", _wrap_MDArray_GetMask, METH_VARARGS, "MDArray_GetMask(MDArray self, char ** options=None) -> MDArray"},
+	 { "MDArray_GetGridded", (PyCFunction)(void(*)(void))_wrap_MDArray_GetGridded, METH_VARARGS|METH_KEYWORDS, "MDArray_GetGridded(MDArray self, char const * pszGridOptions, MDArray xArray=None, MDArray yArray=None, char ** options=None) -> MDArray"},
 	 { "MDArray_AsClassicDataset", _wrap_MDArray_AsClassicDataset, METH_VARARGS, "MDArray_AsClassicDataset(MDArray self, size_t iXDim, size_t iYDim) -> Dataset"},
 	 { "MDArray_GetStatistics", (PyCFunction)(void(*)(void))_wrap_MDArray_GetStatistics, METH_VARARGS|METH_KEYWORDS, "MDArray_GetStatistics(MDArray self, bool approx_ok=FALSE, bool force=TRUE, GDALProgressFunc callback=0, void * callback_data=None) -> Statistics"},
 	 { "MDArray_ComputeStatistics", (PyCFunction)(void(*)(void))_wrap_MDArray_ComputeStatistics, METH_VARARGS|METH_KEYWORDS, "MDArray_ComputeStatistics(MDArray self, bool approx_ok=FALSE, GDALProgressFunc callback=0, void * callback_data=None) -> Statistics"},

--- a/swig/python/osgeo/gdal.py
+++ b/swig/python/osgeo/gdal.py
@@ -3630,6 +3630,10 @@ class MDArray(object):
         r"""GetMask(MDArray self, char ** options=None) -> MDArray"""
         return _gdal.MDArray_GetMask(self, *args)
 
+    def GetGridded(self, *args, **kwargs) -> "GDALMDArrayHS *":
+        r"""GetGridded(MDArray self, char const * pszGridOptions, MDArray xArray=None, MDArray yArray=None, char ** options=None) -> MDArray"""
+        return _gdal.MDArray_GetGridded(self, *args, **kwargs)
+
     def AsClassicDataset(self, *args) -> "GDALDatasetShadow *":
         r"""AsClassicDataset(MDArray self, size_t iXDim, size_t iYDim) -> Dataset"""
         return _gdal.MDArray_AsClassicDataset(self, *args)


### PR DESCRIPTION
Return a gridded array from scattered point data, that is from an array
whose last dimension is the indexing variable of X and Y arrays.

e.g. the zeta variable in:
```
dimensions:
        node = 303714 ;
        time = UNLIMITED ; // (1 currently)
variables:
        float lon(node) ;
                lon:long_name = "nodal longitude" ;
                lon:standard_name = "longitude" ;
                lon:units = "degrees_east" ;
        float lat(node) ;
                lat:long_name = "nodal latitude" ;
                lat:standard_name = "latitude" ;
                lat:units = "degrees_north" ;
        float zeta(time, node) ;
                zeta:long_name = "Water Surface Elevation" ;
                zeta:units = "meters" ;
                zeta:positive = "up" ;
                zeta:standard_name = "sea_surface_height_above_geoid" ;
                zeta:grid = "Bathymetry_Mesh" ;
                zeta:coordinates = "time lat lon" ;
                zeta:type = "data" ;
                zeta:location = "node" ;
```

The gridding is done in 2D, using GDALGridCreate(), on-the-fly at Read()
time, taking into account the spatial extent of the request to limit the
gridding. The results got on the whole extent or a subset of it might not be
strictly identical depending on the gridding algorithm and its radius.
Setting a radius in osGridOptions is recommended to improve performance.
For arrays which have more dimensions than the dimension of the indexing
variable of the X and Y arrays, Read() must be called on slices of the extra
dimensions (ie count[i] must be set to 1, except for the X and Y dimensions
of the array returned by this method).
