### PR TITLE
[Docs] Fix NetCDF driver options rendering

### DIFF
--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -284,10 +284,10 @@ The following open options are available:
    Default is NO (that is each variable will be reported as a separate
    subdataset)
    
--  **ASSUME_LONGLAT=[YES/NO]** :  (GDAL >= 3.7) Whether a Geographic CRS should
-    be assumed and applied when, none has otherwise been found, a meaningful 
-    geotransform has been found, and that geotransform is within the bounds 
-    -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.
+-  **ASSUME_LONGLAT=[YES/NO]** : (GDAL >= 3.7) Whether a Geographic CRS should
+   be assumed and applied when, none has otherwise been found, a meaningful 
+   geotransform has been found, and that geotransform is within the bounds 
+   -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.
 
 
 Creation Issues
@@ -516,10 +516,10 @@ Configuration Options
    should be always considered as geospatial axis, even if the lack
    conventional attributes confirming it. Default is NO.
 
--  **GDAL_NETCDF_ASSUME_LONGLAT=[YES/NO]** :  GDAL >= 3.7) Whether a Geographic CRS should
-    be assumed and applied when, none has otherwise been found, a meaningful 
-    geotransform has been found, and that geotransform is within the bounds 
-    -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.
+-  **GDAL_NETCDF_ASSUME_LONGLAT=[YES/NO]** : (GDAL >= 3.7) Whether a Geographic CRS should
+   be assumed and applied when, none has otherwise been found, a meaningful 
+   geotransform has been found, and that geotransform is within the bounds 
+   -180,360 -90,90, if YES assume OGC:CRS84. Default is NO.
     
 VSI Virtual File System API support
 -----------------------------------


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes the incorrect rendering of the [ASSUME_LONGLAT](https://gdal.org/drivers/raster/netcdf.html#open-options) and [GDAL_NETCDF_ASSUME_LONGLAT](https://gdal.org/drivers/raster/netcdf.html#configuration-options) NetCDF driver options.
