### PR TITLE
Warper: do not use OpenCL code path when cutline (or source alpha) is used

### DIFF
--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -132,6 +132,17 @@ CPLErr CPL_DLL GDALWarpCutlineMasker(void *pMaskFuncArg, int nBandCount,
                                      int nXSize, int nYSize,
                                      GByte ** /* ppImageData */,
                                      int bMaskIsFloat, void *pValidityMask);
+
+/* GCMVF stands for GDALWARP_CUTLINE_MASKER_VALIDITY_FLAG */
+#define GCMVF_PARTIAL_INTERSECTION 0
+#define GCMVF_NO_INTERSECTION 1
+#define GCMVF_CHUNK_FULLY_WITHIN_CUTLINE 2
+CPLErr CPL_DLL GDALWarpCutlineMaskerEx(void *pMaskFuncArg, int nBandCount,
+                                       GDALDataType eType, int nXOff, int nYOff,
+                                       int nXSize, int nYSize,
+                                       GByte ** /* ppImageData */,
+                                       int bMaskIsFloat, void *pValidityMask,
+                                       int *pnValidityFlag);
 /*! @endcond */
 
 /************************************************************************/

--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -1214,12 +1214,47 @@ CPLErr GDALWarpKernel::PerformWarp()
         !bApplyVerticalShift &&
         CPLFetchBool(papszWarpOptions, "USE_OPENCL", true))
     {
-        const CPLErr eResult = GWKOpenCLCase(this);
+        if (pafUnifiedSrcDensity != nullptr)
+        {
+            // If pafUnifiedSrcDensity is only set to 1.0, then we can
+            // discard it.
+            bool bFoundNotOne = false;
+            for (GPtrDiff_t j = 0;
+                 j < static_cast<GPtrDiff_t>(nSrcXSize) * nSrcYSize; j++)
+            {
+                if (pafUnifiedSrcDensity[j] != 1.0)
+                {
+                    bFoundNotOne = true;
+                    break;
+                }
+            }
+            if (!bFoundNotOne)
+            {
+                CPLFree(pafUnifiedSrcDensity);
+                pafUnifiedSrcDensity = nullptr;
+            }
+        }
 
-        // CE_Warning tells us a suitable OpenCL environment was not available
-        // so we fall through to other CPU based methods.
-        if (eResult != CE_Warning)
-            return eResult;
+        if (pafUnifiedSrcDensity != nullptr)
+        {
+            // Typically if there's a cutline or an alpha band
+            static bool bHasWarned = false;
+            if (!bHasWarned)
+            {
+                bHasWarned = true;
+                CPLDebug("WARP", "pafUnifiedSrcDensity is not null, "
+                                 "hence OpenCL warper cannot be used");
+            }
+        }
+        else
+        {
+            const CPLErr eResult = GWKOpenCLCase(this);
+
+            // CE_Warning tells us a suitable OpenCL environment was not available
+            // so we fall through to other CPU based methods.
+            if (eResult != CE_Warning)
+                return eResult;
+        }
     }
 #endif  // defined HAVE_OPENCL
 


### PR DESCRIPTION
Fixes #7192