### PR TITLE
ogr2ogr: Improve performance of -clipsrc and -clipdst

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5442,14 +5442,23 @@ int LayerTranslator::Translate(OGRFeature *poFeatureIn, TargetLayerInfo *psInfo,
                 if (m_poClipSrcOri)
                 {
 
-                    const OGRGeometry *clipGeom =
+                    const OGRGeometry *poClipGeom =
                         GetSrcClipGeom(poDstGeometry->getSpatialReference());
 
                     std::unique_ptr<OGRGeometry> poClipped;
-                    if (clipGeom != nullptr &&
-                        clipGeom->Intersects(poDstGeometry))
+                    if (poClipGeom != nullptr)
                     {
-                        poClipped.reset(clipGeom->Intersection(poDstGeometry));
+                        OGREnvelope oClipEnv;
+                        OGREnvelope oDstEnv;
+
+                        poClipGeom->getEnvelope(&oClipEnv);
+                        poDstGeometry->getEnvelope(&oDstEnv);
+
+                        if (oClipEnv.Intersects(oDstEnv))
+                        {
+                            poClipped.reset(
+                                poClipGeom->Intersection(poDstGeometry));
+                        }
                     }
 
                     if (poClipped == nullptr || poClipped->IsEmpty())
@@ -5541,7 +5550,13 @@ int LayerTranslator::Translate(OGRFeature *poFeatureIn, TargetLayerInfo *psInfo,
 
                         std::unique_ptr<OGRGeometry> poClipped;
 
-                        if (poClipGeom->Intersects(poDstGeometry))
+                        OGREnvelope oClipEnv;
+                        OGREnvelope oDstEnv;
+
+                        poClipGeom->getEnvelope(&oClipEnv);
+                        poDstGeometry->getEnvelope(&oDstEnv);
+
+                        if (oClipEnv.Intersects(oDstEnv))
                         {
                             poClipped.reset(
                                 poClipGeom->Intersection(poDstGeometry));


### PR DESCRIPTION
## What does this PR do?

This PR attempts to improve the performance of `ogr2ogr` with a `-clipsrc` or `-clipdst` argument by testing whether geometries intersect the clipping area (relatively cheap) before computing their intersection (relatively expensive.)

I tested the performance of this using a dataset of ~300,000 parcel polygons for the state of Vermont. In the best reasonable case (clipping out part of one town, or 0.1% of the total polygons) it reduces runtime by ~50%, depending on the GEOS version. In the worst case, where every polygon is within the clipping window, it increases runtime by ~1%.

It could be made more efficient with a way to cache the `GEOSGeometry*` between successive calls to GEOS functions.

## What are related issues/pull requests?

None.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
