### PR TITLE
gdal_alg.html: padfExtent/s consistency, and small doc fixes

### DIFF
--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -261,7 +261,7 @@ GDALSuggestedWarpOutput(GDALDatasetH hSrcDS, GDALTransformerFunc pfnTransformer,
 CPLErr CPL_DLL CPL_STDCALL GDALSuggestedWarpOutput2(
     GDALDatasetH hSrcDS, GDALTransformerFunc pfnTransformer,
     void *pTransformArg, double *padfGeoTransformOut, int *pnPixels,
-    int *pnLines, double *padfExtents, int nOptions);
+    int *pnLines, double *padfExtent, int nOptions);
 
 /*! @cond Doxygen_Suppress */
 CPLXMLNode CPL_DLL *GDALSerializeTransformer(GDALTransformerFunc pfnFunc,

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -218,7 +218,7 @@ points may have failed) or FALSE if the overall transformation fails.
  * output file georeferenced coordinates.  This can be accomplished with
  * GDALCreateGenImgProjTransformer() by passing a NULL for the hDstDS.
  *
- * @param hSrcDS the input image (it is assumed the whole input images is
+ * @param hSrcDS the input image (it is assumed the whole input image is
  * being transformed).
  * @param pfnTransformer the transformer function.
  * @param pTransformArg the callback data for the transformer function.
@@ -388,7 +388,7 @@ static int GDALSuggestedWarpOutput2_MustAdjustForBottomBorder(
  * output file georeferenced coordinates.  This can be accomplished with
  * GDALCreateGenImgProjTransformer() by passing a NULL for the hDstDS.
  *
- * @param hSrcDS the input image (it is assumed the whole input images is
+ * @param hSrcDS the input image (it is assumed the whole input image is
  * being transformed).
  * @param pfnTransformer the transformer function.
  * @param pTransformArg the callback data for the transformer function.
@@ -3584,22 +3584,21 @@ static CPLXMLNode *GDALSerializeApproxTransformer(void *pTransformArg)
  * precision.
  *
  * The approximation is actually done at the point where GDALApproxTransform()
- * calls are made, and depend on the assumption that the roughly linear.  The
- * first and last point passed in must be the extreme values and the
+ * calls are made, and depend on the assumption that they are roughly linear.
+ * The first and last point passed in must be the extreme values and the
  * intermediate values should describe a curve between the end points.  The
- * approximator transforms and center using the approximate transformer, and
+ * approximator transforms and centers using the approximate transformer, and
  * then compares the true middle transformed value to a linear approximation
- * based on the end points.  If the error is within the supplied threshold
- * then the end points are used to linearly approximate all the values
- * otherwise the inputs points are split into two smaller sets, and the
- * function recursively called till a sufficiently small set of points if found
- * that the linear approximation is OK, or that all the points are exactly
- * computed.
+ * based on the end points.  If the error is within the supplied threshold then
+ * the end points are used to linearly approximate all the values otherwise the
+ * input points are split into two smaller sets, and the function is recursively
+ * called until a sufficiently small set of points is found that the linear
+ * approximation is OK, or that all the points are exactly computed.
  *
  * This function is very suitable for approximating transformation results
  * from output pixel/line space to input coordinates for warpers that operate
  * on one input scanline at a time.  Care should be taken using it in other
- * circumstances as little internal validation is done, in order to keep things
+ * circumstances as little internal validation is done in order to keep things
  * fast.
  *
  * @param pfnBaseTransformer the high precision transformer which should be

--- a/alg/gdaltransformgeolocs.cpp
+++ b/alg/gdaltransformgeolocs.cpp
@@ -48,8 +48,8 @@ CPL_CVSID("$Id$")
  * Transform locations held in bands.
  *
  * The X/Y and possibly Z values in the identified bands are transformed
- * using a spatial transformer.  The changes values are written back to the
- * source bands so they need to updatable.
+ * using a spatial transformer.  The changed values are written back to the
+ * source bands so they need to be updateable.
  *
  * @param hXBand the band containing the X locations (usually long/easting).
  * @param hYBand the band containing the Y locations (usually lat/northing).


### PR DESCRIPTION

Consistency of GDALSuggestedWarpOutput2 signature and definition, and nearby documentation clarifications that render in gdal_alg.html

Discussed at https://lists.osgeo.org/pipermail/gdal-dev/2023-February/056836.html



