### PR TITLE
WIP: Run Python tests in parallel using CTest

### DIFF
--- a/.github/workflows/alpine/start.sh
+++ b/.github/workflows/alpine/start.sh
@@ -85,4 +85,4 @@ export PYTEST="python3 -m pytest -vv -p no:sugar --color=no"
 
 (cd build_ci_alpine && make quicktest)
 
-(cd build_ci_alpine/autotest && $PYTEST)
+(cd build_ci_alpine/autotest && ctest -R pytest -v --output-on-failure -j 3)

--- a/.github/workflows/fedora_rawhide/start.sh
+++ b/.github/workflows/fedora_rawhide/start.sh
@@ -85,5 +85,5 @@ pip3 install -U pytest pytest-sugar pytest-env
 # test_virtualmem_1 and test_virtualmem_3 fail on CI
 mv autotest/gcore/virtualmem.py autotest/gcore/virtualmem.py.disabled
 
-(cd build_fedora_rawhide/autotest && $PYTEST)
+(cd build_fedora_rawhide && ctest -R pytest -v --output-on-failure -j 3)
 

--- a/.github/workflows/ubuntu_18.04/script.sh
+++ b/.github/workflows/ubuntu_18.04/script.sh
@@ -38,4 +38,4 @@ AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} python3 -c 
 # Fails with ERROR 1: OGDI DataSource Open Failed: Could not find the dynamic library "vrf"
 rm autotest/ogr/ogr_ogdi.py
 
-(cd autotest && $PYTEST)
+ctest -R pytest -v --output-on-failure -j 3

--- a/.github/workflows/ubuntu_18.04_32bit/start.sh
+++ b/.github/workflows/ubuntu_18.04_32bit/start.sh
@@ -119,4 +119,4 @@ for i in autotest/gcore/tiff_ovr.py \
     rm -f $i
 done
 
-(cd autotest && $PYTEST)
+ctest -R pytest -v --output-on-failure -j 3

--- a/autotest/CMakeLists.txt
+++ b/autotest/CMakeLists.txt
@@ -106,7 +106,7 @@ if (Python_Interpreter_FOUND)
     # This allows parallel testing of files with `ctest -j`
     file(GLOB_RECURSE pytestpaths CONFIGURE_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${pytest_dir}/test_*.py)
     foreach(pytestpath ${pytestpaths})
-        get_filename_component(pytestfile ${pytestpath} NAME_WLE)
+        get_filename_component(pytestfile ${pytestpath} NAME_WE)
         string(REPLACE "test_" "" pytestfile ${pytestfile})
         string(REPLACE "_" "-" pytestfile ${pytestfile})
         string(CONCAT pytest_target "pytest-" ${pytest_dir} "-" ${pytestfile})

--- a/autotest/CMakeLists.txt
+++ b/autotest/CMakeLists.txt
@@ -85,7 +85,7 @@ if (Python_Interpreter_FOUND)
   endif()
 
   foreach (
-    tgt IN
+    pytest_dir IN
     ITEMS ogr
           gcore
           gdrivers
@@ -96,19 +96,27 @@ if (Python_Interpreter_FOUND)
           utilities)
     if (NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
         if (SKIP_COPYING_AUTOTEST_SUBDIRS)
-          message(STATUS "Skipping copying ${CMAKE_CURRENT_SOURCE_DIR}/${tgt}")
+          message(STATUS "Skipping copying ${CMAKE_CURRENT_SOURCE_DIR}/${pytest_dir}")
         else ()
-          symlink_or_copy(${CMAKE_CURRENT_SOURCE_DIR}/${tgt} ${CMAKE_CURRENT_BINARY_DIR}/${tgt})
+          symlink_or_copy(${CMAKE_CURRENT_SOURCE_DIR}/${pytest_dir} ${CMAKE_CURRENT_BINARY_DIR}/${pytest_dir})
         endif ()
     endif()
-    add_custom_target(
-      autotest_${tgt}
-      COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_RUN_ENV} ${Python_EXECUTABLE} -m pytest -c
-              ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini ${tgt}
-      DEPENDS ${GDAL_LIB_TARGET_NAME} gdalapps python_binding)
-    add_test(NAME autotest_${tgt} COMMAND ${Python_EXECUTABLE} -m pytest -c ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini
-                                          ${tgt})
-    set_property(TEST autotest_${tgt} PROPERTY ENVIRONMENT "${PYTHON_RUN_ENV}")
+
+    # Collect each python test file and register it as a separate test with cunit
+    # This allows parallel testing of files with `ctest -j`
+    file(GLOB_RECURSE pytestpaths CONFIGURE_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${pytest_dir}/test_*.py)
+    foreach(pytestpath ${pytestpaths})
+        get_filename_component(pytestfile ${pytestpath} NAME_WLE)
+        string(REPLACE "test_" "" pytestfile ${pytestfile})
+        string(REPLACE "_" "-" pytestfile ${pytestfile})
+        string(CONCAT pytest_target "pytest-" ${pytest_dir} "-" ${pytestfile})
+
+        add_test(NAME ${pytest_target}
+                 COMMAND ${Python_EXECUTABLE} -m pytest -c ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini ${pytestpath}
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        set_property(TEST ${pytest_target}
+                     PROPERTY ENVIRONMENT "${PYTHON_RUN_ENV}")
+    endforeach()
   endforeach ()
   add_custom_target(
     autotest

--- a/autotest/pyscripts/test_gdal_utils_cli.py
+++ b/autotest/pyscripts/test_gdal_utils_cli.py
@@ -84,17 +84,14 @@ params = [pytest.param(util) for util in utils]
 @pytest.mark.parametrize("input", params)
 def test_program(input):
     completed_process = run_program(input + ".py")
-    assert (
-        "usage:" in completed_process.stderr.lower()
-        or "usage:" in completed_process.stdout.lower()
-    )
+    output = completed_process.stderr.decode() + completed_process.stdout.decode()
+    assert "usage:" in output.lower()
 
 
 def run_program(program, args=None):
     return subprocess.run(
         [program],
         input=args,
-        capture_output=True,
-        shell=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )

--- a/autotest/pyscripts/test_gdal_utils_cli.py
+++ b/autotest/pyscripts/test_gdal_utils_cli.py
@@ -50,15 +50,11 @@ Resources used:
 """
 
 import subprocess
-import sys
 
 import pytest
 
-# Skip if gdal-utils is not known to pip (and therefore not registered in
-# python 'site-packages' and 'Scripts')
-installed = subprocess.run([sys.executable, "-m", "pip", "show", "gdal-utils"])
-if installed.returncode != 0:
-    pytest.skip("The 'gdal-utils' package is not installed.", allow_module_level=True)
+# test that osgeo_utils is available, if not skip all tests
+pytest.importorskip("osgeo_utils")
 
 utils = [
     "gdal2tiles",
@@ -87,7 +83,7 @@ params = [pytest.param(util) for util in utils]
 
 @pytest.mark.parametrize("input", params)
 def test_program(input):
-    completed_process = run_program(input)
+    completed_process = run_program(input + ".py")
     assert (
         "usage:" in completed_process.stderr.lower()
         or "usage:" in completed_process.stdout.lower()

--- a/autotest/pyscripts/test_gdal_utils_retcodes.py
+++ b/autotest/pyscripts/test_gdal_utils_retcodes.py
@@ -47,10 +47,8 @@ from pathlib import Path
 
 import pytest
 
-# pytest.skip("THIS TEST IN DRAFT MODE, SKIPPING", allow_module_level=True)
+pytest.importorskip("osgeo_utils")
 
-# here = r"D:\code\public\gdal\autotest\pyscripts"
-# script_path = r"D:\code\public\gdal\swig\python\gdal-utils\osgeo_utils"
 here = Path(__file__).parent.absolute()
 script_path = Path(here / "../../swig/python/gdal-utils/osgeo_utils/").resolve()
 
@@ -58,6 +56,7 @@ excludes = [
     "setup.py",
     "__init__.py",
     "gdal_auth.py",  # gdal_auth doesn't take arguments
+    "fft.py",  # returns 1 after ImportError
 ]
 
 
@@ -89,13 +88,6 @@ if not Path(script_path).exists():
 else:
     scripts = get_scripts(script_path, excludes)
 
-
-# Programs - standard gdal-utils we expect to be installed in PYTHONHOME\Scripts
-# Skip if gdal-utils is not known to pip (and therefore not registered in
-# python 'site-packages' and 'Scripts')
-installed = subprocess.run([sys.executable, "-m", "pip", "show", "gdal-utils"])
-if installed.returncode != 0:
-    pytest.skip("The 'gdal-utils' package is not installed.", allow_module_level=True)
 utils = [
     "gdal2tiles",
     "gdal2xyz",
@@ -128,8 +120,8 @@ def test_program(input):
     assert (
         "usage:" in completed_process.stderr.lower()
         or "usage:" in completed_process.stdout.lower()
-        and completed_process.returncode == 2
     )
+    assert completed_process.returncode == 2
 
 
 @pytest.mark.parametrize("input", sparams)
@@ -138,13 +130,13 @@ def test_script(input):
     assert (
         "usage:" in completed_process.stderr.lower()
         or "usage:" in completed_process.stdout.lower()
-        and completed_process.returncode == 2
     )
+    assert completed_process.returncode == 2
 
 
 def run_program(program, args=None):
     return subprocess.run(
-        [program],
+        [program + ".py"],
         input=args,
         capture_output=True,
         shell=True,
@@ -157,6 +149,5 @@ def run_script(program, args=None):
         [sys.executable, program],  # ["path/to/this/env's/python", 'path/to/script.py']
         input=args,
         capture_output=True,
-        shell=True,
         text=True,
     )

--- a/autotest/pyscripts/test_gdal_utils_retcodes.py
+++ b/autotest/pyscripts/test_gdal_utils_retcodes.py
@@ -117,20 +117,18 @@ sparams = [pytest.param(script) for script in scripts]
 @pytest.mark.parametrize("input", params)
 def test_program(input):
     completed_process = run_program(input)
-    assert (
-        "usage:" in completed_process.stderr.lower()
-        or "usage:" in completed_process.stdout.lower()
-    )
+    output = (completed_process.stderr + completed_process.stdout).decode()
+
+    assert "usage:" in output.lower()
     assert completed_process.returncode == 2
 
 
 @pytest.mark.parametrize("input", sparams)
 def test_script(input):
     completed_process = run_script(input)
-    assert (
-        "usage:" in completed_process.stderr.lower()
-        or "usage:" in completed_process.stdout.lower()
-    )
+    output = (completed_process.stderr + completed_process.stdout).decode()
+
+    assert "usage:" in output.lower()
     assert completed_process.returncode == 2
 
 
@@ -138,9 +136,8 @@ def run_program(program, args=None):
     return subprocess.run(
         [program + ".py"],
         input=args,
-        capture_output=True,
-        shell=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
 
 
@@ -148,6 +145,6 @@ def run_script(program, args=None):
     return subprocess.run(
         [sys.executable, program],  # ["path/to/this/env's/python", 'path/to/script.py']
         input=args,
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )

--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -3,3 +3,4 @@ pytest-sugar
 pytest-env
 lxml
 jsonschema
+numpy


### PR DESCRIPTION
## What does this PR do?

This PR makes Python unit test files run in parallel using CTest. As far as I can tell, the `pytest` way to do this is with `pytest-xdist`, but that requires making each test case independent. Instead, I registered each test file as a separate test with CTest, so the test files can be run in parallel using `ctest -j`.

Doing this still produces some random test failures and occasional segfaults from tests in the `autotest/utilities` subdirectory, perhaps with a common cause. Looking at the logs I am seeing lots of "file is not a database" errors from PROJ, e.g.:

```
Warning 1: PROJ: proj_create_from_database: SQLite error on SELECT 'geodetic_datum' FROM geodetic_datum WHERE auth_name = ? AND code = ? UNION ALL SELECT 'vertical_datum' FROM vertical_datum WHERE auth_name = ? AND code = ?: file is not a database
```

I am learning how to trace the test failures through Python. For now I just have the following backtrace from a segfault in `test_gdalwarp_lib.py`

```
#0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=140621733507520) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=11, threadid=140621733507520) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140621733507520, signo=signo@entry=11) at ./nptl/pthread_kill.c:89
#3  0x00007fe50c442476 in __GI_raise (sig=11) at ../sysdeps/posix/raise.c:26
#4  <signal handler called>
#5  0x00007fe5081e3a9e in GDALSuggestedWarpOutput2 (hSrcDS=0x55d549487c70, pfnTransformer=0x7fe5081e8870 <GDALGenImgProjTransform(void*, int, int, double*, double*, double*, int*)>, 
    pTransformArg=0x55d548f1bee0, padfGeoTransformOut=0x7ffe7dfce3b0, pnPixels=0x7ffe7dfce230, pnLines=0x7ffe7dfce250, padfExtent=0x7ffe7dfce390, nOptions=0)
    at /home/dan/dev/gdal/alg/gdaltransformer.cpp:947
#6  0x00007fe50954301f in GDALWarpCreateOutput (nSrcCount=1, pahSrcDS=0x55d549005650, pszFilename=0x55d54902c000 "", pszFormat=0x7ffe7dfce8b8 "MEM", papszTO=0x55d548f65060, 
    papszCreateOptions=0x0, eDT=GDT_Float32, phTransformArg=0x7ffe7dfce5a0, bSetColorInterpretation=false, psOptions=0x7ffe7dfce830) at /home/dan/dev/gdal/apps/gdalwarp_lib.cpp:3870
#7  0x00007fe50953bbef in CreateOutput (pszDest=0x55d54902c000 "", nSrcCount=1, pahSrcDS=0x55d549005650, psOptions=0x7ffe7dfce830, bInitDestSetByUser=false, 
    hUniqueTransformArg=@0x7ffe7dfce5a0: 0x0) at /home/dan/dev/gdal/apps/gdalwarp_lib.cpp:1612
#8  0x00007fe50953e759 in GDALWarpDirect (pszDest=0x55d54902c000 "", hDstDS=0x0, nSrcCount=1, pahSrcDS=0x55d549005650, psOptions=0x7ffe7dfce830, pbUsageError=0x7ffe7dfceaac)
    at /home/dan/dev/gdal/apps/gdalwarp_lib.cpp:2388
#9  0x00007fe50953ad73 in GDALWarp (pszDest=0x55d54902c000 "", hDstDS=0x0, nSrcCount=1, pahSrcDS=0x55d549005650, psOptionsIn=0x55d549602ae0, pbUsageError=0x7ffe7dfceaac)
    at /home/dan/dev/gdal/apps/gdalwarp_lib.cpp:1329
#10 0x00007fe509fb4832 in wrapper_GDALWarpDestName (dest=0x55d54902c000 "", object_list_count=1, poObjects=0x55d549005650, warpAppOptions=0x55d549602ae0, callback=<optimized out>, 
    callback_data=<optimized out>) at extensions/gdal_wrap.cpp:7827
#11 0x00007fe509fb4b1d in _wrap_wrapper_GDALWarpDestName (args=<optimized out>) at extensions/gdal_wrap.cpp:44704
```

I also fixed a couple of Python test files that were quietly skipped by `pytest` in the current CI environments but cause a failure when executed this way (`pytest` returns an error if you give it a file with no tests, but it is happy with directory containing files with no tests).

I will try to investigate the remaining test failures further but I wanted to give an opportunity for feedback on the overall approach.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/4407

## Tasklist

 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
