### PR TITLE
RawDataset: avoid Valgrind use-of-unitialized memory warning 

### DIFF
--- a/gcore/rawdataset.h
+++ b/gcore/rawdataset.h
@@ -68,17 +68,8 @@ class CPL_DLL RawDataset : public GDALPamDataset
   private:
     CPL_DISALLOW_COPY_ASSIGN(RawDataset)
   protected:
-    typedef union
-    {
-        struct
-        {
-            bool valid;  // false if no value is cached
-            char value;
-        } data;
-        int all;  // this unioned field can be used to help query/update the
-                  // cached value with atomic operations
-    } CachedValidValue_t;
-    CachedValidValue_t cachedCPLOneBigReadOption;
+    int cachedCPLOneBigReadOption =
+        0;  // [0-7] bits are "valid", [8-15] bits are "value"
 };
 
 /************************************************************************/


### PR DESCRIPTION
(amends 3c5f1a040b98fbe188d55e1ee7061e6937cfaaac)
