### PR TITLE
Add required CMakePushCheckState include to FindSQLite3.cmake

### DIFF
--- a/cmake/modules/packages/FindSQLite3.cmake
+++ b/cmake/modules/packages/FindSQLite3.cmake
@@ -26,7 +26,7 @@ This module will set the following variables if found:
   Copyright (c) 2018,2021 Hiroshi Miura
   Copyright (c) 2019 Chuck Atkins
 #]=======================================================================]
-
+include (CMakePushCheckState)
 # Accept upper case variant for SQLite3_INCLUDE_DIR
 if(SQLITE3_INCLUDE_DIR)
   if(SQLite3_INCLUDE_DIR AND NOT "${SQLite3_INCLUDE_DIR}" STREQUAL "${SQLITE3_INCLUDE_DIR}")


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This fixes a build issue
> "Unknown CMake command cmake_push_check_state". 

When FindSQLite3.cmake is invoked. 

## What are related issues/pull requests?
None
## Tasklist
 
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 
## Environment

* OS: Apple M1 Pro, Ventura 13.0.1 (22A400)
* Compiler: Apple clang version 14.0.0 (clang-1400.0.29.202)
