### PR TITLE
Autotest: Check for build/runtime verison mismatch

### DIFF
--- a/autotest/CMakeLists.txt
+++ b/autotest/CMakeLists.txt
@@ -45,8 +45,10 @@ if (Python_Interpreter_FOUND)
   string(REPLACE ";" "\n   " TEST_ENV "${_TEST_ENV}")
 
   set(AUTOTEST_LOG_FILE "${CMAKE_CURRENT_BINARY_DIR}/autotest.log")
+  set(PYTEST_INI_HEADER_MESSAGE "This file was generated from ${GDAL_CMAKE_TEMPLATE_PATH}/pytest.ini.in using ${CMAKE_CURRENT_LIST_FILE}")
   configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/pytest.ini.in ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini @ONLY)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/conftest.py ${CMAKE_CURRENT_BINARY_DIR}/conftest.py COPYONLY)
+  unset(PYTEST_INI_HEADER_MESSAGE)
 
   function (symlink_or_copy source destination)
 

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -137,3 +137,18 @@ def pytest_collection_modifyitems(config, items):
         if not gdal.GetConfigOption("RUN_ON_DEMAND"):
             for mark in item.iter_markers("require_run_on_demand"):
                 item.add_marker(skip_run_on_demand_not_set)
+
+
+def pytest_addoption(parser):
+    parser.addini("gdal_version", "GDAL version for which pytest.ini was generated")
+
+
+def pytest_configure(config):
+    test_version = config.getini("gdal_version")
+    lib_version = gdal.__version__
+
+    if not lib_version.startswith(test_version):
+        raise Exception(
+            f"Attempting to run tests for GDAL {test_version} but library version is "
+            f"{lib_version}. Do you need to run setdevenv.sh ?"
+        )

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -16,6 +16,7 @@ env =
 # Deprecated vector drivers
    GDAL_ENABLE_DEPRECATED_DRIVER_OGR_DODS=YES
    GDAL_ENABLE_DEPRECATED_DRIVER_TIGER=YES
+gdal_version = @GDAL_VERSION@
 
 markers =
     require_driver: Skip test(s) if driver isn't present

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -1,3 +1,5 @@
+; @PYTEST_INI_HEADER_MESSAGE@
+
 [pytest]
 python_files = *.py
 testpaths = ogr gcore gdrivers osr alg gnm utilities pyscripts


### PR DESCRIPTION
## What does this PR do?

This PR stores the GDAL version available to CMake in the generated `pytest.ini`. Before tests are run, pytest can then check this version against what it reads from `gdal.__version__` to make sure that paths/etc. were set properly. If they were not, it will bail before any tests are run, emitting a message that should more clearly indicate the problem to the developer.

```
➜  build-gdal-Desktop-Debug pytest autotest/ogr
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/usr/lib/python3/dist-packages/_pytest/main.py", line 265, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/usr/lib/python3/dist-packages/_pytest/config/__init__.py", line 982, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/hooks.py", line 308, in call_historic
INTERNALERROR>     res = self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/manager.py", line 92, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/manager.py", line 83, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/dan/dev/build-gdal-Desktop-Debug/autotest/conftest.py", line 110, in pytest_configure
INTERNALERROR>     raise Exception(
INTERNALERROR> Exception: Attempting to run tests for GDAL 3.7.0 but library version is 3.4.1. Do you need to run setdevenv.sh ?
```
replacing the following message from `master`:
```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/usr/lib/python3/dist-packages/_pytest/main.py", line 269, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/usr/lib/python3/dist-packages/_pytest/main.py", line 322, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/manager.py", line 92, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/manager.py", line 83, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/_pytest/main.py", line 333, in pytest_collection
INTERNALERROR>     session.perform_collect()
INTERNALERROR>   File "/usr/lib/python3/dist-packages/_pytest/main.py", line 637, in perform_collect
INTERNALERROR>     hook.pytest_collection_modifyitems(
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/manager.py", line 92, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/manager.py", line 83, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/lib/python3/dist-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/dan/dev/build-gdal-Desktop-Debug/autotest/conftest.py", line 82, in pytest_collection_modifyitems
INTERNALERROR>     import gdaltest
INTERNALERROR>   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
INTERNALERROR>   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
INTERNALERROR>   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
INTERNALERROR>   File "/usr/lib/python3/dist-packages/_pytest/assertion/rewrite.py", line 170, in exec_module
INTERNALERROR>     exec(co, module.__dict__)
INTERNALERROR>   File "/home/dan/dev/build-gdal-Desktop-Debug/autotest/pymod/gdaltest.py", line 1875, in <module>
INTERNALERROR>     config_option = gdal.config_option
INTERNALERROR> AttributeError: module 'osgeo.gdal' has no attribute 'config_option'
```


The PR also updates the generated `pytest.ini` to store a comment indicating how it was generated:

```
; This file was generated from /home/dan/dev/gdal/cmake/template/pytest.ini.in using /home/dan/dev/gdal/autotest/CMakeLists.txt

[pytest]
...
```


## What are related issues/pull requests?

None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
