### PR TITLE
autotest: Add output about files not downloaded

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -152,3 +152,17 @@ def pytest_configure(config):
             f"Attempting to run tests for GDAL {test_version} but library version is "
             f"{lib_version}. Do you need to run setdevenv.sh ?"
         )
+
+    import gdaltest
+
+    if not gdaltest.download_test_data():
+        print(
+            "As GDAL_DOWNLOAD_TEST_DATA environment variable is not defined or set to NO, tests relying on downloaded data may be skipped.",
+            file=sys.stderr,
+        )
+
+    if not gdaltest.run_slow_tests():
+        print(
+            'As GDAL_RUN_SLOW_TESTS environment variable is not defined or set to NO, some "slow" tests will be skipped.',
+            file=sys.stderr,
+        )

--- a/autotest/gcore/bmp_read.py
+++ b/autotest/gcore/bmp_read.py
@@ -51,10 +51,9 @@ def test_bmp_open(filename, checksum):
 
 def test_bmp_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/bmp/8bit_pal_rle.bmp", "8bit_pal_rle.bmp"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "BMP", "tmp/cache/8bit_pal_rle.bmp", 1, 17270, filename_absolute=1
@@ -65,10 +64,9 @@ def test_bmp_online_1():
 
 def test_bmp_online_2():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/bmp/24bit.bmp", "24bit.bmp"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest("BMP", "tmp/cache/24bit.bmp", 1, 7158, filename_absolute=1)
     if tst == "success":

--- a/autotest/gcore/hdf4_read.py
+++ b/autotest/gcore/hdf4_read.py
@@ -105,11 +105,10 @@ def test_hdf4_more_than_32_files():
     ):
         pytest.skip("HDF4_HAS_MAXOPENFILES not set")
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://gamma.hdfgroup.org/ftp/pub/outgoing/NASAHDFfiles2/eosweb/hdf4/hdfeos2-swath-wo-dimmaps/AMSR_E_L2_Ocean_B01_200206182340_A.hdf",
         "AMSR_E_L2_Ocean_B01_200206182340_A.hdf",
-    ):
-        pytest.skip()
+    )
 
     tab = []
     for i in range(33):
@@ -131,11 +130,10 @@ def test_hdf4_read_online_1():
     if gdaltest.hdf4_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/A2004259075000.L2_LAC_SST.hdf",
         "A2004259075000.L2_LAC_SST.hdf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "HDF4Image",
@@ -157,11 +155,10 @@ def test_hdf4_read_online_2():
     if gdaltest.hdf4_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/A2006005182000.L2_LAC_SST.x.hdf",
         "A2006005182000.L2_LAC_SST.x.hdf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "HDF4Image",
@@ -192,11 +189,10 @@ def test_hdf4_read_online_3():
     if gdaltest.hdf4_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/MO36MW14.chlor_MODIS.ADD2001089.004.2002186190207.hdf",
         "MO36MW14.chlor_MODIS.ADD2001089.004.2002186190207.hdf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "HDF4Image",
@@ -231,11 +227,10 @@ def test_hdf4_read_online_4():
     if gdaltest.hdf4_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/S2002196124536.L1A_HDUN.BartonBendish.extract.hdf",
         "S2002196124536.L1A_HDUN.BartonBendish.extract.hdf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "HDF4Image",
@@ -263,11 +258,10 @@ def test_hdf4_read_online_5():
         pytest.skip()
 
     # 13 MB
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "ftp://data.nodc.noaa.gov/pub/data.nodc/pathfinder/Version5.0/Monthly/1991/199101.s04m1pfv50-sst-16b.hdf",
         "199101.s04m1pfv50-sst-16b.hdf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "HDF4Image",
@@ -290,11 +284,10 @@ def test_hdf4_read_online_6():
         pytest.skip()
 
     # 1 MB
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/MOD09Q1G_EVI.A2006233.h07v03.005.2008338190308.hdf",
         "MOD09Q1G_EVI.A2006233.h07v03.005.2008338190308.hdf",
-    ):
-        pytest.skip()
+    )
 
     # Test with quoting of components
     tst = gdaltest.GDALTest(
@@ -331,11 +324,10 @@ def test_hdf4_read_online_7():
         pytest.skip()
 
     # 4 MB
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/MOD09A1.A2010041.h06v03.005.2010051001103.hdf",
         "MOD09A1.A2010041.h06v03.005.2010051001103.hdf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "HDF4Image",
@@ -372,11 +364,10 @@ def test_hdf4_read_online_8():
         pytest.skip()
 
     # 5 MB
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://e4ftl01.cr.usgs.gov/MOLT/MOD13Q1.006/2006.06.10/MOD13Q1.A2006161.h34v09.006.2015161173716.hdf",
         "MOD13Q1.A2006161.h34v09.006.2015161173716.hdf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "HDF4Image",
@@ -413,17 +404,15 @@ def test_hdf4_read_online_9():
     if gdaltest.hdf4_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "ftp://ftp.maps.canada.ca/pub/nrcan_rncan/archive/image/landsat_7/geobase_hdf/L71002025_02520010722/L71002025_02520010722_MTL.L1G",
         "L71002025_02520010722_MTL.L1G",
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "ftp://ftp.maps.canada.ca/pub/nrcan_rncan/archive/image/landsat_7/geobase_hdf/L71002025_02520010722/L71002025_02520010722_HDF.L1G",
         "L71002025_02520010722_HDF.L1G",
-    ):
-        pytest.skip()
+    )
 
     f = open("tmp/cache/L71002025_02520010722_B10.L1G", "wb")
     f.close()
@@ -444,11 +433,10 @@ def test_hdf4_read_online_10():
     if gdaltest.hdf4_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://trac.osgeo.org/gdal/raw-attachment/ticket/4672/MOD16A2.A2000M01.h14v02.105.2010357183410.hdf",
         "MOD16A2.A2000M01.h14v02.105.2010357183410.hdf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open(
         'HDF4_EOS:EOS_GRID:"tmp/cache/MOD16A2.A2000M01.h14v02.105.2010357183410.hdf":MOD_Grid_MOD16A2:ET_1km'
@@ -473,11 +461,10 @@ def test_hdf4_read_online_11():
     if gdaltest.hdf4_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://gamma.hdfgroup.org/ftp/pub/outgoing/NASAHDFfiles2/eosweb/hdf4/hdfeos2-swath-wo-dimmaps/AMSR_E_L2_Ocean_B01_200206182340_A.hdf",
         "AMSR_E_L2_Ocean_B01_200206182340_A.hdf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open(
         'HDF4_EOS:EOS_SWATH:"tmp/cache/AMSR_E_L2_Ocean_B01_200206182340_A.hdf":Swath1:Ocean_products_quality_flag'

--- a/autotest/gcore/hdf4multidim.py
+++ b/autotest/gcore/hdf4multidim.py
@@ -44,11 +44,10 @@ pytestmark = pytest.mark.require_driver("HDF4")
 
 def test_hdf4multidim_hdfeos_swath():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://gamma.hdfgroup.org/ftp/pub/outgoing/NASAHDFfiles2/eosweb/hdf4/hdfeos2-swath-wo-dimmaps/AMSR_E_L2_Ocean_B01_200206182340_A.hdf",
         "AMSR_E_L2_Ocean_B01_200206182340_A.hdf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.OpenEx(
         "tmp/cache/AMSR_E_L2_Ocean_B01_200206182340_A.hdf", gdal.OF_MULTIDIM_RASTER
@@ -134,11 +133,10 @@ def test_hdf4multidim_hdfeos_swath():
 
 def test_hdf4multidim_hdfeos_grid():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/MOD09A1.A2010041.h06v03.005.2010051001103.hdf",
         "MOD09A1.A2010041.h06v03.005.2010051001103.hdf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.OpenEx(
         "tmp/cache/MOD09A1.A2010041.h06v03.005.2010051001103.hdf",
@@ -388,11 +386,10 @@ def test_hdf4multidim_sds_unlimited_dim():
 
 def test_hdf4multidim_sds_read_world():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/hdf4/A2004259075000.L2_LAC_SST.hdf",
         "A2004259075000.L2_LAC_SST.hdf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.OpenEx("tmp/cache/A2004259075000.L2_LAC_SST.hdf", gdal.OF_MULTIDIM_RASTER)
     assert ds
@@ -429,11 +426,10 @@ def test_hdf4multidim_sds_read_world():
 
 def test_hdf4multidim_sds_read_world_with_indexing_variable():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://download.osgeo.org/gdal/data/hdf4/REANALYSIS_1999217.hdf",
         "REANALYSIS_1999217.hdf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.OpenEx("tmp/cache/REANALYSIS_1999217.hdf", gdal.OF_MULTIDIM_RASTER)
     assert ds

--- a/autotest/gcore/rfc30.py
+++ b/autotest/gcore/rfc30.py
@@ -32,7 +32,6 @@
 import urllib.parse
 
 import gdaltest
-import pytest
 
 from osgeo import gdal
 
@@ -45,10 +44,9 @@ def test_rfc30_1():
     filename = "xx\u4E2D\u6587.\u4E2D\u6587"
     filename_escaped = urllib.parse.quote(filename)
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/gtiff/" + filename_escaped, filename
-    ):
-        pytest.skip()
+    )
 
     filename = "tmp/cache/" + filename
 

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -1166,11 +1166,10 @@ def test_tiff_read_online_1():
     if md["DMD_CREATIONOPTIONLIST"].find("JPEG") == -1:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://trac.osgeo.org/gdal/raw-attachment/ticket/3259/imgpb17.tif",
         "imgpb17.tif",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/imgpb17.tif")
     gdal.ErrorReset()

--- a/autotest/gdrivers/aigrid.py
+++ b/autotest/gdrivers/aigrid.py
@@ -202,11 +202,10 @@ def test_aigrid_online_1():
         pass
 
     for filename in list_files:
-        if not gdaltest.download_file(
+        gdaltest.download_or_skip(
             "http://download.osgeo.org/gdal/data/aig/nzdem/" + filename,
             "nzdem/" + filename,
-        ):
-            pytest.skip()
+        )
 
     tst = gdaltest.GDALTest(
         "AIG", "tmp/cache/nzdem/nzdem500/hdr.adf", 1, 45334, filename_absolute=1
@@ -252,10 +251,9 @@ def test_aigrid_online_1():
 
 def test_aigrid_online_2():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/aig/ai_bug_6886.zip", "ai_bug_6886.zip"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/ai_bug")

--- a/autotest/gdrivers/ecrgtoc.py
+++ b/autotest/gdrivers/ecrgtoc.py
@@ -347,10 +347,9 @@ def test_ecrgtoc_4():
 
 def test_ecrgtoc_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.falconview.org/trac/FalconView/downloads/17", "ECRG_Sample.zip"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/ECRG_Sample.zip")

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -2384,11 +2384,10 @@ def test_ecw_online_1():
     if gdaltest.jp2ecw_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k",
         "7sisters200.j2k",
-    ):
-        pytest.skip()
+    )
 
     # checksum = 32316 on my PC
     tst = gdaltest.GDALTest(
@@ -2409,10 +2408,9 @@ def test_ecw_online_2():
     if gdaltest.jp2ecw_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2", "gcp.jp2"
-    ):
-        pytest.skip()
+    )
 
     # checksum = 1292 on my PC
     tst = gdaltest.GDALTest("JP2ECW", "tmp/cache/gcp.jp2", 1, None, filename_absolute=1)
@@ -2437,14 +2435,13 @@ def ecw_online_3():
     if gdaltest.ecw_drv.major_version == 4:
         pytest.skip("4.x SDK gets unreliable results for jp2")
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.j2k", "Bretagne1.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.bmp", "Bretagne1.bmp"
-    ):
-        pytest.skip()
+    )
 
     # checksum = 16481 on my PC
     tst = gdaltest.GDALTest(
@@ -2477,14 +2474,13 @@ def test_ecw_online_4():
     if gdaltest.ecw_drv.major_version == 5 and gdaltest.ecw_drv.minor_version == 2:
         pytest.skip("This test hangs on Linux in a mutex in the SDK 5.2.1")
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.j2k", "Bretagne2.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.bmp", "Bretagne2.bmp"
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 53054 on my PC
     tst = gdaltest.GDALTest(
@@ -2511,10 +2507,9 @@ def test_ecw_online_4():
 
 def test_ecw_online_5():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/ecw/red_flower.ecw", "red_flower.ecw"
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/red_flower.ecw")
 
@@ -2585,11 +2580,10 @@ def test_ecw_online_6():
 
 def test_ecw_online_7():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/ecw/sandiego2m_null.ecw",
         "sandiego2m_null.ecw",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/sandiego2m_null.ecw")
     if gdaltest.ecw_drv.major_version == 3:

--- a/autotest/gdrivers/envisat.py
+++ b/autotest/gdrivers/envisat.py
@@ -81,10 +81,7 @@ class EnvisatTestBase(object):
 
     def download_file(self):
         # download and decompress
-        if not gdaltest.download_file(
-            self.downloadURL, os.path.basename(self.downloadURL), -1
-        ):
-            return False
+        gdaltest.download_or_skip(self.downloadURL)
 
         filename = os.path.join("tmp", "cache", self.fileName)
         if os.path.exists(filename):
@@ -102,8 +99,7 @@ class EnvisatTestBase(object):
         return True
 
     def test_envisat_1(self):
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -117,8 +113,7 @@ class EnvisatTestBase(object):
         )
 
     def test_envisat_2(self):
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -132,9 +127,7 @@ class EnvisatTestBase(object):
 
     def test_envisat_3(self):
         # Regression test for #3160 and #3709.
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -149,9 +142,7 @@ class EnvisatTestBase(object):
 
     def test_envisat_4(self):
         # test number of bands
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         filename = os.path.join("tmp", "cache", self.fileName)
         mds_num = _get_mds_num(filename)
@@ -163,9 +154,7 @@ class EnvisatTestBase(object):
 
     def test_envisat_5(self):
         # test metadata in RECORDS domain
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -190,9 +179,7 @@ class TestEnvisatASAR(EnvisatTestBase):
 
     def test_envisat_asar_1(self):
         # test sensor ID
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -203,9 +190,7 @@ class TestEnvisatASAR(EnvisatTestBase):
 
     def test_envisat_asar_2(self):
         # test metadata in RECORDS domain
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -250,9 +235,7 @@ class TestEnvisatMERIS(EnvisatTestBase):
 
     def test_envisat_meris_1(self):
         # test sensor ID
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -263,9 +246,7 @@ class TestEnvisatMERIS(EnvisatTestBase):
 
     def test_envisat_meris_2(self):
         # test metadata in RECORDS domain
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -285,9 +266,7 @@ class TestEnvisatMERIS(EnvisatTestBase):
 
     def test_envisat_meris_3(self):
         # test Flag bands
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None
@@ -334,9 +313,7 @@ class TestEnvisatMERIS(EnvisatTestBase):
 
     def test_envisat_meris_4(self):
         # test DEM corrections (see #5423)
-
-        if not self.download_file():
-            pytest.skip()
+        self.download_file()
 
         ds = gdal.Open(os.path.join("tmp", "cache", self.fileName))
         assert ds is not None

--- a/autotest/gdrivers/gff.py
+++ b/autotest/gdrivers/gff.py
@@ -29,7 +29,6 @@
 ###############################################################################
 
 import gdaltest
-import pytest
 
 from osgeo import gdal
 
@@ -39,12 +38,11 @@ from osgeo import gdal
 
 def test_gff_1():
     # 12088 = 2048 + 8 * 1255
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://sandia.gov/RADAR/complex_data/MiniSAR20050519p0001image008.gff",
         "MiniSAR20050519p0001image008.gff",
         12088,
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "GFF",

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -1812,10 +1812,7 @@ def test_grib_online_grib2_jpeg2000_single_line():
         pytest.skip()
 
     filename = "CMC_hrdps_continental_PRATE_SFC_0_ps2.5km_2017111712_P001-00.grib2"
-    if not gdaltest.download_file(
-        "http://download.osgeo.org/gdal/data/grib/" + filename
-    ):
-        pytest.skip()
+    gdaltest.download_or_skip("http://download.osgeo.org/gdal/data/grib/" + filename)
 
     ds = gdal.Open("tmp/cache/" + filename)
     cs = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/gxf.py
+++ b/autotest/gdrivers/gxf.py
@@ -4,7 +4,7 @@
 # $Id$
 #
 # Project:  GDAL/OGR Test Suite
-# Purpose:  Test read/write functionality for NITF driver.
+# Purpose:  Test read/write functionality for GXF driver.
 # Author:   Even Rouault <even dot rouault at spatialys.com>
 #
 ###############################################################################
@@ -88,10 +88,7 @@ gxf_list = [
     ids=[tup[1] for tup in gxf_list],
 )
 def test_gxf(downloadURL, fileName, checksum, download_size):
-    if not gdaltest.download_file(
-        downloadURL + "/" + fileName, fileName, download_size
-    ):
-        pytest.skip()
+    gdaltest.download_or_skip(downloadURL + "/" + fileName, fileName, download_size)
 
     ds = gdal.Open("tmp/cache/" + fileName)
 

--- a/autotest/gdrivers/hdf5.py
+++ b/autotest/gdrivers/hdf5.py
@@ -345,11 +345,10 @@ def test_hdf5_11():
 
 def test_hdf5_12():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://trac.osgeo.org/gdal/raw-attachment/ticket/5032/norsa.ss.ppi-00.5-dbz.aeqd-1000.20070601T000039Z.hdf",
         "norsa.ss.ppi-00.5-dbz.aeqd-1000.20070601T000039Z.hdf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/norsa.ss.ppi-00.5-dbz.aeqd-1000.20070601T000039Z.hdf")
     got_projection = ds.GetProjection()
@@ -374,11 +373,10 @@ def test_hdf5_12():
 
 def test_hdf5_13():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://oceandata.sci.gsfc.nasa.gov/cgi/getfile/A2016273115000.L2_LAC_OC.nc",
         "A2016273115000.L2_LAC_OC.nc",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open(
         'HDF5:"tmp/cache/A2016273115000.L2_LAC_OC.nc"://geophysical_data/Kd_490'
@@ -522,10 +520,7 @@ hdf5_list = [
     ids=['HDF5:"' + item[1] + '"://' + item[2] for item in hdf5_list],
 )
 def test_hdf5(downloadURL, fileName, subdatasetname, checksum, download_size):
-    if not gdaltest.download_file(
-        downloadURL + "/" + fileName, fileName, download_size
-    ):
-        pytest.skip("no download")
+    gdaltest.download_or_skip(downloadURL + "/" + fileName, fileName, download_size)
 
     ds = gdal.Open('HDF5:"tmp/cache/' + fileName + '"://' + subdatasetname)
 

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -626,13 +626,12 @@ def test_jp2lura_20():
             shutil.copy("../ogr/tmp/cache/SCHEMAS_OPENGIS_NET.zip", "tmp/cache")
         except OSError:
             url = "http://schemas.opengis.net/SCHEMAS_OPENGIS_NET.zip"
-            if not gdaltest.download_file(
+            gdaltest.download_or_skip(
                 url,
                 "SCHEMAS_OPENGIS_NET.zip",
                 force_download=True,
                 max_download_duration=20,
-            ):
-                pytest.skip("Cannot get SCHEMAS_OPENGIS_NET.zip")
+            )
 
     try:
         os.mkdir("tmp/cache/SCHEMAS_OPENGIS_NET")
@@ -659,13 +658,12 @@ def test_jp2lura_20():
             max_download_duration=10,
         ):
             xlink_xsd_url = "http://even.rouault.free.fr/xlink.xsd"
-            if not gdaltest.download_file(
+            gdaltest.download_or_skip(
                 xlink_xsd_url,
                 "SCHEMAS_OPENGIS_NET/xlink.xsd",
                 force_download=True,
                 max_download_duration=10,
-            ):
-                pytest.skip("Cannot get xlink.xsd")
+            )
 
     try:
         os.stat("tmp/cache/SCHEMAS_OPENGIS_NET/xml.xsd")
@@ -678,13 +676,12 @@ def test_jp2lura_20():
             max_download_duration=10,
         ):
             xlink_xsd_url = "http://even.rouault.free.fr/xml.xsd"
-            if not gdaltest.download_file(
+            gdaltest.download_or_skip(
                 xlink_xsd_url,
                 "SCHEMAS_OPENGIS_NET/xml.xsd",
                 force_download=True,
                 max_download_duration=10,
-            ):
-                pytest.skip("Cannot get xml.xsd")
+            )
 
     xmlvalidate.transform_abs_links_to_ref_links("tmp/cache/SCHEMAS_OPENGIS_NET")
 
@@ -1672,11 +1669,10 @@ def test_jp2lura_48():
 
 def test_jp2lura_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k",
         "7sisters200.j2k",
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 32669 on my PC
     tst = gdaltest.GDALTest(
@@ -1695,10 +1691,9 @@ def test_jp2lura_online_1():
 
 def test_jp2lura_online_2():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2", "gcp.jp2"
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 15621 on my PC
     tst = gdaltest.GDALTest(
@@ -1722,14 +1717,13 @@ def test_jp2lura_online_2():
 
 def test_jp2lura_online_3():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.j2k", "Bretagne1.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.bmp", "Bretagne1.bmp"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "JP2Lura", "tmp/cache/Bretagne1.j2k", 1, None, filename_absolute=1
@@ -1755,14 +1749,13 @@ def test_jp2lura_online_3():
 
 def test_jp2lura_online_4():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.j2k", "Bretagne2.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.bmp", "Bretagne2.bmp"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "JP2Lura", "tmp/cache/Bretagne2.j2k", 1, None, filename_absolute=1
@@ -1789,11 +1782,10 @@ def test_jp2lura_online_4():
 
 def test_jp2lura_online_5():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9.jp2",
         "file9.jp2",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/file9.jp2")
     cs1 = ds.GetRasterBand(1).Checksum()
@@ -1810,11 +1802,10 @@ def test_jp2lura_online_5():
 
 def test_jp2lura_online_6():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_03/file3.jp2",
         "file3.jp2",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/file3.jp2")
     # cs1 = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -568,13 +568,12 @@ def test_jp2openjpeg_20():
             shutil.copy("../ogr/tmp/cache/SCHEMAS_OPENGIS_NET.zip", "tmp/cache")
         except OSError:
             url = "http://schemas.opengis.net/SCHEMAS_OPENGIS_NET.zip"
-            if not gdaltest.download_file(
+            gdaltest.download_or_skip(
                 url,
                 "SCHEMAS_OPENGIS_NET.zip",
                 force_download=True,
                 max_download_duration=20,
-            ):
-                pytest.skip("Cannot get SCHEMAS_OPENGIS_NET.zip")
+            )
 
     try:
         os.mkdir("tmp/cache/SCHEMAS_OPENGIS_NET")
@@ -601,13 +600,12 @@ def test_jp2openjpeg_20():
             max_download_duration=10,
         ):
             xlink_xsd_url = "http://even.rouault.free.fr/xlink.xsd"
-            if not gdaltest.download_file(
+            gdaltest.download_or_skip(
                 xlink_xsd_url,
                 "SCHEMAS_OPENGIS_NET/xlink.xsd",
                 force_download=True,
                 max_download_duration=10,
-            ):
-                pytest.skip("Cannot get xlink.xsd")
+            )
 
     try:
         os.stat("tmp/cache/SCHEMAS_OPENGIS_NET/xml.xsd")
@@ -620,13 +618,12 @@ def test_jp2openjpeg_20():
             max_download_duration=10,
         ):
             xlink_xsd_url = "http://even.rouault.free.fr/xml.xsd"
-            if not gdaltest.download_file(
+            gdaltest.download_or_skip(
                 xlink_xsd_url,
                 "SCHEMAS_OPENGIS_NET/xml.xsd",
                 force_download=True,
                 max_download_duration=10,
-            ):
-                pytest.skip("Cannot get xml.xsd")
+            )
 
     xmlvalidate.transform_abs_links_to_ref_links("tmp/cache/SCHEMAS_OPENGIS_NET")
 
@@ -3092,11 +3089,10 @@ def test_jp2openjpeg_48():
 
 def test_jp2openjpeg_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k",
         "7sisters200.j2k",
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 32669 on my PC
     tst = gdaltest.GDALTest(
@@ -3115,10 +3111,9 @@ def test_jp2openjpeg_online_1():
 
 def test_jp2openjpeg_online_2():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2", "gcp.jp2"
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 15621 on my PC
     tst = gdaltest.GDALTest(
@@ -3141,14 +3136,13 @@ def test_jp2openjpeg_online_2():
 
 def test_jp2openjpeg_online_3():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.j2k", "Bretagne1.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.bmp", "Bretagne1.bmp"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "JP2OpenJPEG", "tmp/cache/Bretagne1.j2k", 1, None, filename_absolute=1
@@ -3174,14 +3168,13 @@ def test_jp2openjpeg_online_3():
 
 def test_jp2openjpeg_online_4():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.j2k", "Bretagne2.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.bmp", "Bretagne2.bmp"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "JP2OpenJPEG", "tmp/cache/Bretagne2.j2k", 1, None, filename_absolute=1
@@ -3208,11 +3201,10 @@ def test_jp2openjpeg_online_4():
 
 def test_jp2openjpeg_online_5():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9.jp2",
         "file9.jp2",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/file9.jp2")
     cs1 = ds.GetRasterBand(1).Checksum()
@@ -3229,11 +3221,10 @@ def test_jp2openjpeg_online_5():
 
 def test_jp2openjpeg_online_6():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_03/file3.jp2",
         "file3.jp2",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/file3.jp2")
     cs1 = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/l1b.py
+++ b/autotest/gdrivers/l1b.py
@@ -101,10 +101,7 @@ l1b_list = [
     ids=[item[1] for item in l1b_list],
 )
 def test_l1b(downloadURL, fileName, checksum, download_size, gcpNumber):
-    if not gdaltest.download_file(
-        downloadURL + "/" + fileName, fileName, download_size
-    ):
-        pytest.skip()
+    gdaltest.download_or_skip(downloadURL + "/" + fileName, fileName, download_size)
 
     ds = gdal.Open("tmp/cache/" + fileName)
 

--- a/autotest/gdrivers/mrsid.py
+++ b/autotest/gdrivers/mrsid.py
@@ -414,11 +414,10 @@ def test_mrsid_online_1():
     if gdaltest.jp2mrsid_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k",
         "7sisters200.j2k",
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 29473 on my PC
     tst = gdaltest.GDALTest(
@@ -440,10 +439,9 @@ def test_mrsid_online_2():
     if gdaltest.jp2mrsid_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2", "gcp.jp2"
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 209 on my PC
     tst = gdaltest.GDALTest(
@@ -475,14 +473,13 @@ def test_mrsid_online_3():
     if gdaltest.jp2mrsid_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.j2k", "Bretagne1.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne1.bmp", "Bretagne1.bmp"
-    ):
-        pytest.skip()
+    )
 
     # checksum = 14443 on my PC
     tst = gdaltest.GDALTest(
@@ -515,14 +512,13 @@ def test_mrsid_online_4():
     if gdaltest.jp2mrsid_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.j2k", "Bretagne2.j2k"
-    ):
-        pytest.skip()
-    if not gdaltest.download_file(
+    )
+
+    gdaltest.download_or_skip(
         "http://www.openjpeg.org/samples/Bretagne2.bmp", "Bretagne2.bmp"
-    ):
-        pytest.skip()
+    )
 
     # Checksum = 53186 on my PC
     tst = gdaltest.GDALTest(

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1335,10 +1335,9 @@ def test_netcdf_34():
     except ImportError:
         pytest.skip("from multiprocessing import Process failed")
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/netcdf/" + filename, filename
-    ):
-        pytest.skip()
+    )
 
     sys.stdout.write(".")
     sys.stdout.flush()

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -5545,11 +5545,10 @@ def test_nitf_metadata_validation_des():
 
 def test_nitf_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/bugs/NITF21_CGM_ANNO_Uncompressed_unmasked.ntf",
         "NITF21_CGM_ANNO_Uncompressed_unmasked.ntf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF",
@@ -5573,10 +5572,9 @@ def test_nitf_online_1():
 
 def test_nitf_online_2():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/nitf1.1/U_0001a.ntf", "U_0001a.ntf"
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/U_0001a.ntf")
 
@@ -5591,10 +5589,9 @@ def test_nitf_online_2():
 
 def test_nitf_online_3():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/nitf1.1/U_0001a.ntf", "U_0001a.ntf"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "NITF_IM:3:tmp/cache/U_0001a.ntf", 1, 23463, filename_absolute=1
@@ -5609,10 +5606,9 @@ def test_nitf_online_3():
 
 def test_nitf_online_4():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/cadrg/001zc013.on1", "001zc013.on1"
-    ):
-        pytest.skip()
+    )
 
     # check that the RPF attribute metadata was carried through.
     ds = gdal.Open("tmp/cache/001zc013.on1")
@@ -5638,10 +5634,9 @@ def test_nitf_online_4():
 
 def test_nitf_online_5():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/cadrg/overview.ovr", "overview.ovr"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "tmp/cache/overview.ovr", 1, 60699, filename_absolute=1
@@ -5656,10 +5651,9 @@ def test_nitf_online_5():
 
 def test_nitf_online_6():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/nitf2.0/U_4001b.ntf", "U_4001b.ntf"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "tmp/cache/U_4001b.ntf", 1, 60030, filename_absolute=1
@@ -5675,12 +5669,11 @@ def test_nitf_online_6():
 def test_nitf_online_7():
 
     for filename in ["ns3228b.nsf", "i_3228c.ntf", "ns3228d.nsf", "i_3228e.ntf"]:
-        if not gdaltest.download_file(
+        gdaltest.download_or_skip(
             "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/"
             + filename,
             filename,
-        ):
-            pytest.skip()
+        )
 
         ds = gdal.Open("tmp/cache/" + filename)
         assert ds.RasterCount == 6
@@ -5712,11 +5705,10 @@ def test_nitf_online_7():
 
 def test_nitf_online_8():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/ns3301j.nsf",
         "ns3301j.nsf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "tmp/cache/ns3301j.nsf", 1, 56861, filename_absolute=1
@@ -5731,11 +5723,10 @@ def test_nitf_online_8():
 
 def test_nitf_online_9():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/ns3304a.nsf",
         "ns3304a.nsf",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "tmp/cache/ns3304a.nsf", 1, 32419, filename_absolute=1
@@ -5750,11 +5741,10 @@ def test_nitf_online_9():
 
 def test_nitf_online_10():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/ns3119b.nsf",
         "ns3119b.nsf",
-    ):
-        pytest.skip()
+    )
 
     # Shut up the warning about missing image segment
     gdal.PushErrorHandler("CPLQuietErrorHandler")
@@ -5804,10 +5794,9 @@ def test_nitf_online_10():
 
 def test_nitf_online_11():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/nitf2.0/U_1122a.ntf", "U_1122a.ntf"
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/U_1122a.ntf")
 
@@ -5838,10 +5827,9 @@ def test_nitf_online_11():
 
 def test_nitf_online_12():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/bugs/i_3430a.ntf", "i_3430a.ntf"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "tmp/cache/i_3430a.ntf", 1, 38647, filename_absolute=1
@@ -5856,10 +5844,9 @@ def test_nitf_online_12():
 
 def test_nitf_online_13():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/u_3054a.ntf", "u_3054a.ntf"
-    ):
-        pytest.skip()
+    )
 
     # Shut up the warning about missing image segment
     ds = gdal.Open("NITF_IM:2:tmp/cache/u_3054a.ntf")
@@ -5906,10 +5893,9 @@ def test_nitf_online_13():
 
 def test_nitf_online_14(not_jpeg_9b):
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/nitf2.0/U_4020h.ntf", "U_4020h.ntf"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.remove("tmp/cache/U_4020h.ntf.aux.xml")
@@ -5939,11 +5925,10 @@ def test_nitf_online_14(not_jpeg_9b):
 
 
 def nitf_online_15(driver_to_test, expected_cs=1054):
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/p0_01/p0_01a.ntf",
         "p0_01a.ntf",
-    ):
-        pytest.skip()
+    )
 
     jp2_drv = gdal.GetDriverByName(driver_to_test)
 
@@ -5986,11 +5971,10 @@ def test_nitf_online_15_openjpeg():
 
 
 def nitf_online_16(driver_to_test):
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9_jp2_2places.ntf",
         "file9_jp2_2places.ntf",
-    ):
-        pytest.skip()
+    )
 
     jp2_drv = gdal.GetDriverByName(driver_to_test)
 
@@ -6046,11 +6030,10 @@ def test_nitf_online_16_openjpeg():
 
 
 def nitf_online_17(driver_to_test):
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9_j2c.ntf",
         "file9_j2c.ntf",
-    ):
-        pytest.skip()
+    )
 
     jp2_drv = gdal.GetDriverByName(driver_to_test)
 
@@ -6099,10 +6082,9 @@ def test_nitf_online_17_openjpeg():
 
 
 def test_nitf_online_18():
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/bugs/bug3337.ntf", "bug3337.ntf"
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/bug3337.ntf")
 
@@ -6151,10 +6133,9 @@ def test_nitf_online_18():
 
 def test_nitf_online_19():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/0000M033.GN3", "0000M033.GN3"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "tmp/cache/0000M033.GN3", 1, 38928, filename_absolute=1
@@ -6180,10 +6161,9 @@ def test_nitf_online_19():
 
 def test_nitf_online_20():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/0000M033.GN3", "0000M033.GN3"
-    ):
-        pytest.skip()
+    )
 
     # check that the RPF attribute metadata was carried through.
     # Special case where the reported size of the attribute subsection is
@@ -6204,11 +6184,10 @@ def test_nitf_online_20():
 
 def test_nitf_online_21():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/ns3321a.nsf",
         "ns3321a.nsf",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/ns3321a.nsf")
     md = ds.GetMetadata()
@@ -6225,11 +6204,10 @@ def test_nitf_online_21():
 
 def test_nitf_online_22():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv1_1/U_0001C.NTF",
         "U_0001C.NTF",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("NITF_IM:1:tmp/cache/U_0001C.NTF")
     md = ds.GetMetadata()
@@ -6326,10 +6304,9 @@ def test_nitf_online_22():
 
 def test_nitf_online_23():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/nitf/nitf2.0/U_3058b.ntf", "U_3058b.ntf"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF", "tmp/cache/U_3058b.ntf", 1, 44748, filename_absolute=1
@@ -6344,10 +6321,9 @@ def test_nitf_online_23():
 
 def test_nitf_online_24():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.falconview.org/trac/FalconView/downloads/17", "ECRG_Sample.zip"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/ECRG_Sample.zip")
@@ -6380,11 +6356,10 @@ def test_nitf_online_24():
 
 def test_nitf_online_25():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.gwg.nga.mil/ntb/baseline/docs/HRE_spec/Case1_HRE10G324642N1170747W_Uxx.hr5",
         "Case1_HRE10G324642N1170747W_Uxx.hr5",
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "NITF",

--- a/autotest/gdrivers/ntv2.py
+++ b/autotest/gdrivers/ntv2.py
@@ -155,10 +155,9 @@ def test_ntv2_7():
 
 def test_ntv2_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/proj/nzgd2kgrid0005.gsb", "nzgd2kgrid0005.gsb"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/nzgd2kgrid0005.gsb")

--- a/autotest/gdrivers/ozi.py
+++ b/autotest/gdrivers/ozi.py
@@ -43,10 +43,9 @@ pytestmark = pytest.mark.require_driver("OZI")
 
 def test_ozi_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.oziexplorer2.com/maps/Europe2001_setup.exe", "Europe2001_setup.exe"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/Europe 2001_OZF.map")

--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -578,11 +578,10 @@ def test_pcidsk_online_1():
     if gdaltest.pcidsk_new == 0:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/pcidsk/sdk_testsuite/irvine_gcp2.pix",
         "irvine_gcp2.pix",
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.Open("tmp/cache/irvine_gcp2.pix")
 
@@ -754,10 +753,9 @@ def test_pcidsk_tile_v2_overview():
 
 def test_pcidsk_online_rpc():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://github.com/OSGeo/gdal/files/6822835/pix-test.zip", "pix-test.zip"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/demo.PIX")

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -142,11 +142,10 @@ def pdf_checksum_available():
 
 
 def test_pdf_online_1(poppler_or_pdfium):
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.agc.army.mil/GeoPDFgallery/Imagery/Cherrydale_eDOQQ_1m_0_033_R1C1.pdf",
         "Cherrydale_eDOQQ_1m_0_033_R1C1.pdf",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/Cherrydale_eDOQQ_1m_0_033_R1C1.pdf")

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -50,101 +50,88 @@ def validate_xml(filename):
 
     # for GDAL 3.4 / PDS4_PDS_1G00
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1G00.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1G00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1G00_1950.xsd",
         "pds.nasa.gov_pds4_cart_v1_PDS4_CART_1G00_1950.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1G00_1500.xsd",
         "pds.nasa.gov_pds4_disp_v1_PDS4_DISP_1G00_1500.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Used by PDS4_CART_1G00_1950.xsd
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/geom/v1/PDS4_GEOM_1G00_1920.xsd",
         "pds.nasa.gov_pds4_geom_v1_PDS4_GEOM_1G00_1920.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # GDAL 3.3
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1D00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1D00_1933.xsd",
         "pds.nasa.gov_pds4_cart_v1_PDS4_CART_1D00_1933.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.xsd",
         "pds.nasa.gov_pds4_disp_v1_PDS4_DISP_1B00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1B00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Needed by PDS4_CART_1D00_1933
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/geom/v1/PDS4_GEOM_1B10_1700.xsd",
         "pds.nasa.gov_pds4_geom_v1_PDS4_GEOM_1B10_1700.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B10.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1B10.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Older schemas
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1800.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1700.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1700.xsd",
         "pds.nasa.gov_pds4_cart_v1_PDS4_CART_1700.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.OpenEx(
         "GMLAS:" + filename,
@@ -1747,36 +1734,32 @@ def test_pds4_createlabelonly_pds3():
 def test_pds4_spectral_characteristics():
 
     # Needed by template_with_sp.xml
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://pds.nasa.gov/pds4/sp/v1/PDS4_SP_1100.xsd",
         "pds.nasa.gov_pds4_sp_v1_PDS4_SP_1100.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Needed by PDS4_SP_1100.xsd
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1100.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1100.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Needed by template_with_sp.xml
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1600.xsd",
         "pds.nasa.gov_pds4_disp_v1_PDS4_DISP_1600.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Needed by PDS4_DISP_1600.xsd
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1600.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1600.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     filename = "/vsimem/out.xml"
     with hide_substitution_warnings_error_handler():

--- a/autotest/gdrivers/rik.py
+++ b/autotest/gdrivers/rik.py
@@ -45,11 +45,10 @@ def test_rik_online_1():
     if gdal.GetDriverByName("RIK") is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.lantmateriet.se/upload/filer/kartor/programvaror/sverige500_swe99.zip",
         "sverige500_swe99.zip",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/sverige500_swe99.rik")
@@ -80,10 +79,9 @@ def test_rik_online_2():
     if gdal.GetDriverByName("RIK") is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://trac.osgeo.org/gdal/raw-attachment/ticket/3674/ab-del.rik", "ab-del.rik"
-    ):
-        pytest.skip()
+    )
 
     tst = gdaltest.GDALTest(
         "RIK", "tmp/cache/ab-del.rik", 1, 44974, filename_absolute=1

--- a/autotest/gdrivers/xpm.py
+++ b/autotest/gdrivers/xpm.py
@@ -45,10 +45,7 @@ pytestmark = pytest.mark.require_driver("XPM")
     ids=[item[1] for item in xpm_list],
 )
 def test_xpm(downloadURL, fileName, checksum, download_size):
-    if not gdaltest.download_file(
-        downloadURL + "/" + fileName, fileName, download_size
-    ):
-        pytest.skip()
+    gdaltest.download_or_skip(downloadURL + "/" + fileName, fileName, download_size)
 
     ds = gdal.Open("tmp/cache/" + fileName)
 

--- a/autotest/ogr/ogr_dgn.py
+++ b/autotest/ogr/ogr_dgn.py
@@ -275,10 +275,9 @@ def test_ogr_dgn_8():
 
 def test_ogr_dgn_online_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/dgn/DGNSample_v7.dgn", "DGNSample_v7.dgn"
-    ):
-        pytest.skip()
+    )
 
     ds = ogr.Open("tmp/cache/DGNSample_v7.dgn")
     assert ds is not None

--- a/autotest/ogr/ogr_edigeo.py
+++ b/autotest/ogr/ogr_edigeo.py
@@ -60,8 +60,7 @@ def test_ogr_edigeo_1():
     base_url = "https://raw.githubusercontent.com/geotools/geotools/affa340d16681f1bb78673d23fb38a6c1eb2b38a/modules/unsupported/edigeo/src/test/resources/org/geotools/data/edigeo/test-data/"
 
     for filename in filelist:
-        if not gdaltest.download_file(base_url + filename, filename):
-            pytest.skip()
+        gdaltest.download_or_skip(base_url + filename, filename)
 
     try:
         for filename in filelist:

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -668,10 +668,7 @@ def test_ogr_gml_14():
 
     files = ["xlink1.gml", "xlink2.gml", "expected1.gml", "expected2.gml"]
     for f in files:
-        if not gdaltest.download_file(
-            "http://download.osgeo.org/gdal/data/gml/" + f, f
-        ):
-            pytest.skip()
+        gdaltest.download_or_skip("http://download.osgeo.org/gdal/data/gml/" + f, f)
 
     gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", "NONE")
     gdal.SetConfigOption("GML_SAVE_RESOLVED_TO", "tmp/cache/xlink1resolved.gml")
@@ -1699,10 +1696,9 @@ def test_ogr_gml_41():
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://schemas.opengis.net/SCHEMAS_OPENGIS_NET.zip", "SCHEMAS_OPENGIS_NET.zip"
-    ):
-        pytest.skip()
+    )
 
     ds = ogr.Open("data/gml/expected_gml_gml3.gml")
 

--- a/autotest/ogr/ogr_nas.py
+++ b/autotest/ogr/ogr_nas.py
@@ -52,11 +52,10 @@ def test_ogr_nas_1():
     if drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.geodatenzentrum.de/gdz1/abgabe/testdaten/vektor/nas_testdaten_peine.zip",
         "nas_testdaten_peine.zip",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/BKG_NAS_Peine.xml")
@@ -115,11 +114,10 @@ def test_ogr_nas_2():
     if drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://trac.wheregroup.com/PostNAS/browser/trunk/demodaten/lverm_geo_rlp/gid-6.0/gm2566-testdaten-gid60-2008-11-11.xml.zip?format=raw",
         "gm2566-testdaten-gid60-2008-11-11.xml.zip",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/gm2566-testdaten-gid60-2008-11-11.xml")

--- a/autotest/ogr/ogr_ntf.py
+++ b/autotest/ogr/ogr_ntf.py
@@ -90,11 +90,10 @@ pytestmark = pytest.mark.require_driver("NTF")
 
 def test_ogr_ntf_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.ordnancesurvey.co.uk/oswebsite/products/strategi/sampledata/stratntf.exe",
         "stratntf.exe",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/SS.ntf")
@@ -136,11 +135,10 @@ def test_ogr_ntf_1():
 ###############################################################################
 def test_ogr_ntf_2():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.ordnancesurvey.co.uk/oswebsite/products/meridian2/sampledata/meridian2ntf.exe",
         "meridian2ntf.exe",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/Port_Talbot_NTF/SS78.ntf")

--- a/autotest/ogr/ogr_ogdi.py
+++ b/autotest/ogr/ogr_ogdi.py
@@ -52,11 +52,10 @@ def test_ogr_ogdi_1():
     if ogrtest.ogdi_drv is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://freefr.dl.sourceforge.net/project/ogdi/OGDI_Test_Suite/3.1/ogdits-3.1.0.zip",
         "ogdits-3.1.0.zip",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/ogdits-3.1")

--- a/autotest/ogr/ogr_pcidsk.py
+++ b/autotest/ogr/ogr_pcidsk.py
@@ -282,11 +282,10 @@ def test_ogr_pcidsk_online_1():
     if ogr.GetDriverByName("PCIDSK") is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/pcidsk/sdk_testsuite/polygon.pix",
         "polygon.pix",
-    ):
-        pytest.skip()
+    )
 
     ds = ogr.Open("tmp/cache/polygon.pix")
     assert ds is not None
@@ -317,11 +316,10 @@ def test_ogr_pcidsk_online_2():
     if ogr.GetDriverByName("PCIDSK") is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/pcidsk/sdk_testsuite/polygon.pix",
         "polygon.pix",
-    ):
-        pytest.skip()
+    )
 
     ret = gdaltest.runexternal(
         test_cli_utilities.get_test_ogrsf_path() + " -ro tmp/cache/polygon.pix"

--- a/autotest/ogr/ogr_pdf.py
+++ b/autotest/ogr/ogr_pdf.py
@@ -337,11 +337,10 @@ def test_ogr_pdf_online_1():
     if not has_read_support():
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www.terragotech.com/images/pdf/webmap_urbansample.pdf",
         "webmap_urbansample.pdf",
-    ):
-        pytest.skip()
+    )
 
     expected_layers = [
         ["Cadastral Boundaries", ogr.wkbPolygon],
@@ -398,11 +397,10 @@ def test_ogr_pdf_online_2():
     if not has_read_support():
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://download.osgeo.org/gdal/data/pdf/340711752_Azusa_FSTopo.pdf",
         "340711752_Azusa_FSTopo.pdf",
-    ):
-        pytest.skip()
+    )
 
     expected_layers = [
         ["Other_5", 0],

--- a/autotest/ogr/ogr_pds4.py
+++ b/autotest/ogr/ogr_pds4.py
@@ -48,99 +48,86 @@ def validate_xml(filename):
 
     # for GDAL 3.4 / PDS4_PDS_1G00
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1G00.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1G00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1G00_1950.xsd",
         "pds.nasa.gov_pds4_cart_v1_PDS4_CART_1G00_1950.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1G00_1500.xsd",
         "pds.nasa.gov_pds4_disp_v1_PDS4_DISP_1G00_1500.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Used by PDS4_CART_1G00_1950.xsd
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/geom/v1/PDS4_GEOM_1G00_1920.xsd",
         "pds.nasa.gov_pds4_geom_v1_PDS4_GEOM_1G00_1920.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1D00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1D00_1933.xsd",
         "pds.nasa.gov_pds4_cart_v1_PDS4_CART_1D00_1933.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.xsd",
         "pds.nasa.gov_pds4_disp_v1_PDS4_DISP_1B00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1B00.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Needed by PDS4_CART_1D00_1933
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/geom/v1/PDS4_GEOM_1B10_1700.xsd",
         "pds.nasa.gov_pds4_geom_v1_PDS4_GEOM_1B10_1700.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B10.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1B10.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     # Older schemas
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1800.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1700.xsd",
         "pds.nasa.gov_pds4_pds_v1_PDS4_PDS_1700.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1700.xsd",
         "pds.nasa.gov_pds4_cart_v1_PDS4_CART_1700.xsd",
         force_download=True,
-    ):
-        pytest.skip()
+    )
 
     ds = gdal.OpenEx(
         "GMLAS:" + filename,

--- a/autotest/ogr/ogr_pgeo.py
+++ b/autotest/ogr/ogr_pgeo.py
@@ -72,10 +72,9 @@ def setup_driver():
 
 @pytest.fixture()
 def download_test_data():
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/pgeo/PGeoTest.zip", "PGeoTest.zip"
-    ):
-        pytest.skip("Test data could not be downloaded")
+    )
 
     try:
         os.stat("tmp/cache/Autodesk Test.mdb")

--- a/autotest/ogr/ogr_s57.py
+++ b/autotest/ogr/ogr_s57.py
@@ -334,10 +334,7 @@ def test_ogr_s57_11():
 
 def test_ogr_s57_online_1():
 
-    if not gdaltest.download_file(
-        "ftp://sdg.ivs90.nl/ENC/1R5MK050.000", "1R5MK050.000"
-    ):
-        pytest.skip()
+    gdaltest.download_or_skip("ftp://sdg.ivs90.nl/ENC/1R5MK050.000", "1R5MK050.000")
 
     ds = ogr.Open("tmp/cache/1R5MK050.000")
     assert ds is not None
@@ -362,10 +359,9 @@ def test_ogr_s57_online_1():
 
 def test_ogr_s57_online_2():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/s57/enctds/GB5X01SW.000", "GB5X01SW.000"
-    ):
-        pytest.skip()
+    )
 
     gdaltest.clean_tmp()
     shutil.copy("tmp/cache/GB5X01SW.000", "tmp/GB5X01SW.000")
@@ -394,10 +390,9 @@ def test_ogr_s57_online_2():
 
 def test_ogr_s57_online_3():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://download.osgeo.org/gdal/data/s57/enctds/GB5X01SW.001", "GB5X01SW.001"
-    ):
-        pytest.skip()
+    )
 
     shutil.copy("tmp/cache/GB5X01SW.001", "tmp/GB5X01SW.001")
     ds = ogr.Open("tmp/GB5X01SW.000")
@@ -427,10 +422,9 @@ def test_ogr_s57_online_3():
 
 def test_ogr_s57_online_4():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www1.kaiho.mlit.go.jp/KOKAI/ENC/images/sample/sample.zip", "sample.zip"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/ENC_ROOT/JP34NC94.000")
@@ -475,10 +469,9 @@ def test_ogr_s57_update_dsid():
 
 def test_ogr_s57_more_than_255_updates_to_feature():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "https://www.charts.noaa.gov/ENCs/US5ME51M.zip", "US5ME51M.zip"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/US5ME51M")

--- a/autotest/ogr/ogr_shape_sbn.py
+++ b/autotest/ogr/ogr_shape_sbn.py
@@ -110,11 +110,10 @@ def search_all_features(lyr):
 
 def test_ogr_shape_sbn_1():
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://pubs.usgs.gov/sim/3194/contents/Cochiti_shapefiles.zip",
         "Cochiti_shapefiles.zip",
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/CochitiDamShapeFiles/CochitiBoundary.shp")

--- a/autotest/ogr/ogr_sosi.py
+++ b/autotest/ogr/ogr_sosi.py
@@ -42,11 +42,10 @@ def test_ogr_sosi_1():
     if ogr.GetDriverByName("SOSI") is None:
         pytest.skip()
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://trac.osgeo.org/gdal/raw-attachment/ticket/3638/20BygnAnlegg.SOS",
         "20BygnAnlegg.SOS",
-    ):
-        pytest.skip()
+    )
 
     import test_cli_utilities
 

--- a/autotest/ogr/ogr_tiger.py
+++ b/autotest/ogr/ogr_tiger.py
@@ -45,10 +45,9 @@ def test_ogr_tiger_1():
 
     ogrtest.tiger_ds = None
 
-    if not gdaltest.download_file(
+    gdaltest.download_or_skip(
         "http://www2.census.gov/geo/tiger/tiger2006se/AL/TGR01001.ZIP", "TGR01001.ZIP"
-    ):
-        pytest.skip()
+    )
 
     try:
         os.stat("tmp/cache/TGR01001/TGR01001.MET")

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -59,8 +59,6 @@ skip_counter = 0
 failure_summary = []
 
 reason = None
-count_skipped_tests_download = 0
-count_skipped_tests_slow = 0
 start_time = None
 end_time = None
 
@@ -1522,35 +1520,15 @@ def neginf():
 ###############################################################################
 # Has the user requested to download test data
 def download_test_data():
-    global count_skipped_tests_download
     val = gdal.GetConfigOption("GDAL_DOWNLOAD_TEST_DATA", None)
-    if val != "yes" and val != "YES":
-
-        if count_skipped_tests_download == 0:
-            print(
-                "As GDAL_DOWNLOAD_TEST_DATA environment variable is not defined or set to NO, some tests relying on data to downloaded from the Web will be skipped"
-            )
-        count_skipped_tests_download = count_skipped_tests_download + 1
-
-        return False
-    return True
+    return val == "yes" or val == "YES"
 
 
 ###############################################################################
 # Has the user requested to run the slow tests
 def run_slow_tests():
-    global count_skipped_tests_slow
     val = gdal.GetConfigOption("GDAL_RUN_SLOW_TESTS", None)
-    if val != "yes" and val != "YES":
-
-        if count_skipped_tests_slow == 0:
-            print(
-                'As GDAL_RUN_SLOW_TESTS environment variable is not defined or set to NO, some "slow" tests will be skipped'
-            )
-        count_skipped_tests_slow = count_skipped_tests_slow + 1
-
-        return False
-    return True
+    return val == "yes" or val == "YES"
 
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

This PR updates the Python test output to provide additional information about tests skipped because of data that could not be downloaded.

First, the following message  (if applicable) is printed immediately after calling `pytest`:

```
As GDAL_DOWNLOAD_TEST_DATA environment variable is not defined or set to NO, some tests relying on downloaded data will be skipped.
```

This message was previously sent to `print()` when a test actually tried to download a file, but that output was not emitted for skipped tests.

Second, a `download_or_skip` helper function is used to provide a more informative skip message in case of failure.


Full output when `GDAL_DOWNLOAD_TEST_DATA` is not set:

```
➜  autotest pytest -r s gcore/hdf4_read.py
As GDAL_DOWNLOAD_TEST_DATA environment variable is not defined or set to NO, some tests relying on downloaded data will be skipped.
As GDAL_RUN_SLOW_TESTS environment variable is not defined or set to NO, some "slow" tests will be skipped.
Test session starts (platform: linux, Python 3.10.6, pytest 7.2.1, pytest-sugar 0.9.6)
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/dan/dev/build-gdal-Desktop-Debug/autotest, configfile: pytest.ini
plugins: xdist-3.2.0, custom-exit-code-0.3.0, random-order-1.1.0, anyio-3.6.1, sugar-0.9.6, env-0.8.1
collecting ... 
 gcore/hdf4_read.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓s✓✓s✓✓✓                                                                                                                       100% ██████████
=============================================================================== short test summary info ================================================================================
SKIPPED [1] pymod/gdaltest.py:1272: test_hdf4_read_online_5 (hdf4_read.py:261) GDAL_DOWNLOAD_TEST_DATA is not set to YES
SKIPPED [1] pymod/gdaltest.py:1272: test_hdf4_read_online_8 (hdf4_read.py:367) GDAL_DOWNLOAD_TEST_DATA is not set to YES

Results (2.40s):
      28 passed
       2 skipped
```

Full output when `GDAL_DOWNLOAD_TEST_DATA=YES`:

```
➜  autotest pytest -r s gcore/hdf4_read.py    
As GDAL_RUN_SLOW_TESTS environment variable is not defined or set to NO, some "slow" tests will be skipped.
Test session starts (platform: linux, Python 3.10.6, pytest 7.2.1, pytest-sugar 0.9.6)
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/dan/dev/build-gdal-Desktop-Debug/autotest, configfile: pytest.ini
plugins: xdist-3.2.0, custom-exit-code-0.3.0, random-order-1.1.0, anyio-3.6.1, sugar-0.9.6, env-0.8.1
collecting ... 
 gcore/hdf4_read.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓s✓✓s✓✓✓                                                                                                                       100% ██████████
=============================================================================== short test summary info ================================================================================
SKIPPED [1] pymod/gdaltest.py:1272: test_hdf4_read_online_5 (hdf4_read.py:261) Failed to download ftp://data.nodc.noaa.gov/pub/data.nodc/pathfinder/Version5.0/Monthly/1991/199101.s04m1pfv50-sst-16b.hdf : HTTP service for ftp://data.nodc.noaa.gov/pub/data.nodc/pathfinder/Version5.0/Monthly/1991/199101.s04m1pfv50-sst-16b.hdf is down (URL Error: ftp error: TimeoutError('timed out'))
SKIPPED [1] pymod/gdaltest.py:1272: test_hdf4_read_online_8 (hdf4_read.py:367) Failed to download https://e4ftl01.cr.usgs.gov/MOLT/MOD13Q1.006/2006.06.10/MOD13Q1.A2006161.h34v09.006.2015161173716.hdf : HTTP service for https://e4ftl01.cr.usgs.gov/MOLT/MOD13Q1.006/2006.06.10/MOD13Q1.A2006161.h34v09.006.2015161173716.hdf is down (HTTP Error: 401)

Results (12.74s):
      28 passed
       2 skipped

```

It would be nice to remove `pymod/gdaltest.py:1272: ` from the messages, but I didn't see a clean way to do that.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
