### PR TITLE
MEM: add spatialreference element 

### DIFF
--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -175,6 +175,35 @@ def test_mem_2():
 
         dsup = None
 
+    wktll = """GEOGCS[\\"WGS 84\\",DATUM[\\"WGS_1984\\",SPHEROID[\\"WGS 84\\",6378137,298.257223563,AUTHORITY[\\"EPSG\\",\\"7030\\"]],AUTHORITY[\\"EPSG\\",\\"6326\\"]],PRIMEM[\\"Greenwich\\",0,AUTHORITY[\\"EPSG\\",\\"8901\\"]],UNIT[\\"degree\\",0.0174532925199433,AUTHORITY[\\"EPSG\\",\\"9122\\"]],AXIS[\\"Latitude\\",NORTH],AXIS[\\"Longitude\\",EAST],AUTHORITY[\\"EPSG\\",\\"4326\\"]]"""
+
+    dsnames2 = [
+        "MEM:::DATAPOINTER=0x%X,SPATIALREFERENCE=+proj=laea +lon_0=147 +lat_0=-42,GEOTRANSFORM=-1e+06/1953.125/0/1e+06/0/-3906.25,PIXELS=%d,LINES=%d,DATATYPE=Float32"
+        % (p, width, height),
+        "MEM:::DATAPOINTER=0x%X,SPATIALREFERENCE=bogus,GEOTRANSFORM=-1e+06/1953.125/0/1e+06/0/-3906.25,PIXELS=%d,LINES=%d,DATATYPE=Float32"
+        % (p, width, height),
+        'MEM:::DATAPOINTER=0x%X,SPATIALREFERENCE="%s",GEOTRANSFORM=-1e+06/1953.125/0/1e+06/0/-3906.25,PIXELS=%d,LINES=%d,DATATYPE=Float32'
+        % (p, wktll, width, height),
+    ]
+    print(dsnames2[2])
+    cnt = 0
+    for dsname in dsnames2:
+        cnt = cnt + 1
+        for i in range(width * height):
+            float_p[i] = 5.0
+
+        dsro = gdal.Open(dsname)
+        if dsro is None:
+            free(p)
+            pytest.fail("opening MEM dataset failed in read only mode.")
+        assert dsro.GetGeoTransform() == (-1e06, 1953.125, 0, 1e06, 0, -3906.25)
+        if cnt == 1:
+            assert "Lambert" in dsro.GetProjectionRef()
+        if cnt == 2:
+            assert dsro.GetProjectionRef() == ""
+        if cnt == 3:
+            assert "GEOGCS" in dsro.GetProjectionRef()
+
     free(p)
 
 

--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -195,17 +195,16 @@ def test_mem_2():
             "GEOGCS",
         ),
     ]
-    for i in range(width * height):
-        float_p[i] = 5.0
 
     for ds_definition, expected_sr in test_data:
         dsro = gdal.Open(ds_definition)
         if dsro is None:
             free(p)
             pytest.fail("opening MEM dataset failed in read only mode.")
-        print(expected_sr)
+
         assert dsro.GetGeoTransform() == (-1e06, 1953.125, 0, 1e06, 0, -3906.25)
         assert expected_sr in dsro.GetProjectionRef()
+        dsro = None
     free(p)
 
 

--- a/doc/source/drivers/raster/mem.rst
+++ b/doc/source/drivers/raster/mem.rst
@@ -63,6 +63,14 @@ or
    the next.
 -  GEOTRANSFORM: Set the affine transformation coefficients. 6 real
    numbers with '/' as separator (optional)
+-  SPATIALREFERENCE: (GDAL >= 3.7) Set the projection. The coordinate reference 
+   systems that can be passed are anything supported by the 
+   OGRSpatialReference.SetFromUserInput() as per '-a_srs' in  
+   :ref:`gdal_translate`. If the passed string includes comma or double-quote characters (typically WKT),
+   it should be surrounded by double-quote characters and the double-quote characters inside it
+   should be escaped with anti-slash.
+   e.g ``SPATIALREFERENCE="GEOGCRS[\"WGS 84\",[... snip ...],ID[\"EPSG\",4326]]"``
+
 
 Creation Options
 ----------------

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -1214,6 +1214,20 @@ GDALDataset *MEMDataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     /* -------------------------------------------------------------------- */
+    /*      Set Projection Information                                      */
+    /* -------------------------------------------------------------------- */
+
+    pszOption = CSLFetchNameValue(papszOptions, "SPATIALREFERENCE");
+    if (pszOption != nullptr)
+    {
+        poDS->m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        if (poDS->m_oSRS.SetFromUserInput(pszOption) != OGRERR_NONE)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined, "Unrecognized crs: %s",
+                     pszOption);
+        }
+    }
+    /* -------------------------------------------------------------------- */
     /*      Try to return a regular handle on the file.                     */
     /* -------------------------------------------------------------------- */
     CSLDestroy(papszOptions);


### PR DESCRIPTION
Adds a missing 'SPATIALREFERENCE' element to the MEM driver DSN format.

## What are related issues/pull requests?

First attempt (rebase problem) with discussion and review and additions  at #7266. 

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
