### PR TITLE
[Backport release/3.6]  GeoJSON: avoid duplication of FID in streaming parser (fixes #7258) 

### DIFF
--- a/apps/test_ogrsf.cpp
+++ b/apps/test_ogrsf.cpp
@@ -1623,7 +1623,7 @@ static int TestOGRLayerFeatureCount(GDALDataset *poDS, OGRLayer *poLayer,
     }
 
     /* mapogr.cpp doesn't like errors after GetNextFeature() */
-    if (CPLGetLastErrorType() != CE_None)
+    if (CPLGetLastErrorType() == CE_Failure)
     {
         bRet = FALSE;
         printf("ERROR: An error was reported : %s\n", CPLGetLastErrorMsg());

--- a/autotest/ogr/data/geojson/ids_0_1_null_1_null.json
+++ b/autotest/ogr/data/geojson/ids_0_1_null_1_null.json
@@ -1,0 +1,10 @@
+{
+"type": "FeatureCollection",
+"features": [
+{ "type": "Feature", "properties": { "id": 0, "seq": 0 }, "geometry": null },
+{ "type": "Feature", "properties": { "id": 1, "seq": 1 }, "geometry": null },
+{ "type": "Feature", "properties": { "id": null, "seq": 2 }, "geometry": null },
+{ "type": "Feature", "properties": { "id": 1, "seq": 3 }, "geometry": null },
+{ "type": "Feature", "properties": { "id": null, "seq": 4 }, "geometry": null }
+]
+}

--- a/autotest/ogr/data/geojson/ids_0_1_null_unset.json
+++ b/autotest/ogr/data/geojson/ids_0_1_null_unset.json
@@ -1,0 +1,9 @@
+{
+"type": "FeatureCollection",
+"features": [
+{ "type": "Feature", "properties": { "id": 0, "seq": 0 }, "geometry": null },
+{ "type": "Feature", "properties": { "id": 1, "seq": 1 }, "geometry": null },
+{ "type": "Feature", "properties": { "id": null, "seq": 2 }, "geometry": null },
+{ "type": "Feature", "properties": { "seq": 3 }, "geometry": null }
+]
+}

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4183,3 +4183,23 @@ def test_ogr_geojson_ids_0_1_null_1_null(read_from_file):
         assert f.GetFID() == i
         assert f["seq"] == i
     assert gdal.GetLastErrorType() == gdal.CE_None
+
+
+###############################################################################
+# Run test_ogrsf
+
+
+def test_ogr_geojson_test_ogrsf():
+
+    import test_cli_utilities
+
+    if test_cli_utilities.get_test_ogrsf_path() is None:
+        pytest.skip()
+
+    ret = gdaltest.runexternal(
+        test_cli_utilities.get_test_ogrsf_path()
+        + " -ro data/geojson/ids_0_1_null_1_null.json"
+    )
+
+    assert "INFO" in ret
+    assert "ERROR" not in ret

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -120,7 +120,6 @@ class OGRGeoJSONLayer final : public OGRMemLayer
     bool bOriginalIdModified_;
     GIntBig nTotalFeatureCount_;
     GIntBig nFeatureReadSinceReset_ = 0;
-    GIntBig nNextFID_;
 
     bool IngestAll();
     void TerminateAppendSession();

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -481,7 +481,8 @@ int OGRGeoJSONDataSource::TestCapability(const char *pszCap)
 {
     if (EQUAL(pszCap, ODsCCreateLayer))
         return fpOut_ != nullptr && nLayers_ == 0;
-    else if (EQUAL(pszCap, ODsCZGeometries))
+    else if (EQUAL(pszCap, ODsCZGeometries) ||
+             EQUAL(pszCap, ODsCMeasuredGeometries))
         return TRUE;
 
     return FALSE;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
@@ -733,6 +733,7 @@ void RegisterOGRGeoJSON()
         "Integer64List RealList StringList Date DateTime");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean");
     poDriver->SetMetadataItem(GDAL_DMD_SUPPORTED_SQL_DIALECTS, "OGRSQL SQLITE");
+    poDriver->SetMetadataItem(GDAL_DCAP_MEASURED_GEOMETRIES, "YES");
 
     poDriver->pfnOpen = OGRGeoJSONDriverOpen;
     poDriver->pfnIdentify = OGRGeoJSONDriverIdentify;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
@@ -67,7 +67,7 @@ OGRGeoJSONLayer::OGRGeoJSONLayer(const char *pszName,
                                  OGRGeoJSONReader *poReader)
     : OGRMemLayer(pszName, poSRSIn, eGType), poDS_(poDS), poReader_(poReader),
       bHasAppendedFeatures_(false), bUpdated_(false),
-      bOriginalIdModified_(false), nTotalFeatureCount_(0), nNextFID_(0)
+      bOriginalIdModified_(false), nTotalFeatureCount_(0)
 {
     SetAdvertizeUTF8(true);
     SetUpdatable(poDS->IsUpdatable());
@@ -126,7 +126,6 @@ void OGRGeoJSONLayer::ResetReading()
     if (poReader_)
     {
         TerminateAppendSession();
-        nNextFID_ = 0;
         poReader_->ResetReading();
     }
     else
@@ -150,11 +149,6 @@ OGRFeature *OGRGeoJSONLayer::GetNextFeature()
             OGRFeature *poFeature = poReader_->GetNextFeature(this);
             if (poFeature == nullptr)
                 return nullptr;
-            if (poFeature->GetFID() == OGRNullFID)
-            {
-                poFeature->SetFID(nNextFID_);
-                nNextFID_++;
-            }
             if ((m_poFilterGeom == nullptr ||
                  FilterGeometry(
                      poFeature->GetGeomFieldRef(m_iGeomFieldFilter))) &&
@@ -232,7 +226,6 @@ bool OGRGeoJSONLayer::IngestAll()
         OGRGeoJSONReader *poReader = poReader_;
         poReader_ = nullptr;
 
-        nNextFID_ = 0;
         nTotalFeatureCount_ = -1;
         bool bRet = poReader->IngestAll(this);
         delete poReader;
@@ -497,7 +490,7 @@ void OGRGeoJSONLayer::AddFeature(OGRFeature *poFeature)
                     CE_Warning, CPLE_AppDefined,
                     "Several features with id = " CPL_FRMT_GIB " have been "
                     "found. Altering it to be unique. This warning will not "
-                    "be emitted for this layer",
+                    "be emitted anymore for this layer",
                     nFID);
                 bOriginalIdModified_ = true;
             }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.h
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.h
@@ -199,6 +199,7 @@ class OGRGeoJSONReader : public OGRGeoJSONBaseReader
     VSILFILE *fp_;
     bool bCanEasilyAppend_;
     bool bFCHasBBOX_;
+    bool bOriginalIdModifiedEmitted_ = false;
 
     size_t nBufferSize_;
     GByte *pabyBuffer_;


### PR DESCRIPTION
Backport #7260
 **Authored by:** @rouault