### PR TITLE
autotest: Add pytest marker for slow tests

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -138,6 +138,10 @@ def pytest_collection_modifyitems(config, items):
             for mark in item.iter_markers("require_run_on_demand"):
                 item.add_marker(skip_run_on_demand_not_set)
 
+        for mark in item.iter_markers("slow"):
+            if not gdaltest.run_slow_tests():
+                item.add_marker(pytest.mark.skip("GDAL_RUN_SLOW_TESTS not set"))
+
 
 def pytest_addoption(parser):
     parser.addini("gdal_version", "GDAL version for which pytest.ini was generated")

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -1838,10 +1838,8 @@ def test_tiff_ovr_sparse_ok_external_overview(apply_sparse):
 # Test overview on a dataset where width * height > 2 billion
 
 
+@pytest.mark.slow()
 def test_tiff_ovr_46():
-
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     # Test NEAREST
     with gdaltest.config_option("GTIFF_DONT_WRITE_BLOCKS", "YES"):

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -4159,6 +4159,7 @@ def test_tiff_read_strip_larger_than_2GB():
 # Test reading a deflate compressed file with a uncompressed strip larger than 4 GB
 
 
+@pytest.mark.slow()
 def test_tiff_read_deflate_4GB():
 
     if not check_libtiff_internal_or_at_least(4, 0, 11):
@@ -4169,9 +4170,6 @@ def test_tiff_read_deflate_4GB():
         assert ds is None
         return
     assert ds is not None
-
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     data = ds.ReadRaster(
         0, 0, ds.RasterXSize, ds.RasterYSize, buf_xsize=20, buf_ysize=20

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -4374,11 +4374,10 @@ def test_tiff_write_100():
 # reloading. tiff_write_78 doesn't produce enough big data to trigger this...
 
 
+@pytest.mark.slow()
 def test_tiff_write_101():
 
     md = gdaltest.tiff_drv.GetMetadata()
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if sys.platform.startswith("linux"):
         # Much faster to use /dev/urandom than python random generator !
@@ -9105,12 +9104,10 @@ def check_libtiff_internal_or_at_least(expected_maj, expected_min, expected_micr
 #
 
 
+@pytest.mark.slow()
 def test_tiff_write_deflate_4GB():
 
     if not check_libtiff_internal_or_at_least(4, 0, 11):
-        pytest.skip()
-
-    if not gdaltest.run_slow_tests():
         pytest.skip()
 
     ref_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)

--- a/autotest/gcore/vsicurl.py
+++ b/autotest/gcore/vsicurl.py
@@ -40,9 +40,8 @@ from osgeo import gdal, ogr
 #
 
 
+@pytest.mark.slow()
 def test_vsicurl_1():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -57,9 +56,8 @@ def test_vsicurl_1():
 #
 
 
+@pytest.mark.slow()
 def vsicurl_2():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -74,9 +72,8 @@ def vsicurl_2():
 # This server doesn't support range downloading
 
 
+@pytest.mark.slow()
 def vsicurl_3():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -91,9 +88,8 @@ def vsicurl_3():
 # This server doesn't support range downloading
 
 
+@pytest.mark.slow()
 def test_vsicurl_4():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -108,10 +104,8 @@ def test_vsicurl_4():
 # Test URL unescaping when reading HTTP file list
 
 
+@pytest.mark.slow()
 def test_vsicurl_5():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
-
     if not gdaltest.built_against_curl():
         pytest.skip()
 
@@ -125,9 +119,8 @@ def test_vsicurl_5():
 # Test with FTP server that doesn't support EPSV command
 
 
+@pytest.mark.slow()
 def vsicurl_6_disabled():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -140,9 +133,8 @@ def vsicurl_6_disabled():
 # Test Microsoft-IIS/6.0 listing
 
 
+@pytest.mark.slow()
 def test_vsicurl_7():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -155,9 +147,8 @@ def test_vsicurl_7():
 # Test interleaved reading between 2 datasets
 
 
+@pytest.mark.slow()
 def vsicurl_8():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -177,9 +168,8 @@ def vsicurl_8():
 # returns escaped sequences instead of the Chinese characters.
 
 
+@pytest.mark.slow()
 def test_vsicurl_9():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -195,9 +185,8 @@ def test_vsicurl_9():
 # Test reading a file with escaped Chinese characters.
 
 
+@pytest.mark.slow()
 def test_vsicurl_10():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()
@@ -212,9 +201,8 @@ def test_vsicurl_10():
 # Test ReadDir() after reading a file on the same server
 
 
+@pytest.mark.slow()
 def test_vsicurl_11():
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     if not gdaltest.built_against_curl():
         pytest.skip()

--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -652,10 +652,8 @@ def test_vsizip_multi_thread_below_threshold():
 # data stream < 4 GB
 
 
+@pytest.mark.slow()
 def test_vsizip_create_zip64():
-
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     niters = 1000
     s = "hello" * 1000 * 1000
@@ -686,10 +684,8 @@ def test_vsizip_create_zip64():
 # Test creating ZIP64 file: compressed data stream > 4 GB
 
 
+@pytest.mark.slow()
 def test_vsizip_create_zip64_stream_larger_than_4G():
-
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
 
     zip_name = "tmp/vsizip_create_zip64_stream_larger_than_4G.zip"
 

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -3961,11 +3961,10 @@ def test_gpkg_wkt2():
 # Test reading a 50000x25000 block uint16
 
 
+@pytest.mark.slow()
 def test_gpkg_50000_25000_uint16():
 
     if gdaltest.gpkg_dr is None:
-        pytest.skip()
-    if not gdaltest.run_slow_tests():
         pytest.skip()
     if sys.maxsize < 2**32:
         pytest.skip("Test not available on 32 bit")
@@ -3994,11 +3993,10 @@ def test_gpkg_50000_25000_uint16():
 # Test reading a 50000x50000 block uint16
 
 
+@pytest.mark.slow()
 def test_gpkg_50000_50000_uint16():
 
     if gdaltest.gpkg_dr is None:
-        pytest.skip()
-    if not gdaltest.run_slow_tests():
         pytest.skip()
     if sys.maxsize < 2**32:
         pytest.skip("Test not available on 32 bit")

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -819,12 +819,10 @@ def test_netcdf_20():
 ###############################################################################
 # check support for writing large file with DEFLATE compression
 # if chunking is not defined properly within the netcdf driver, this test can take 1h
+@pytest.mark.slow()
 def test_netcdf_21():
 
     if not gdaltest.netcdf_drv_has_nc4:
-        pytest.skip()
-
-    if not gdaltest.run_slow_tests():
         pytest.skip()
 
     bigfile = "tmp/cache/utm-big.tif"
@@ -1318,6 +1316,7 @@ def test_netcdf_33():
 # if chunking is not supported within the netcdf driver, this test can take very long
 
 
+@pytest.mark.slow()
 def test_netcdf_34():
 
     filename = "utm-big-chunks.nc"
@@ -1325,9 +1324,6 @@ def test_netcdf_34():
     timeout = 5
 
     if not gdaltest.netcdf_drv_has_nc4:
-        pytest.skip()
-
-    if not gdaltest.run_slow_tests():
         pytest.skip()
 
     try:
@@ -3471,10 +3467,9 @@ def test_netcdf_open_empty_double_attr():
 # Test writing and reading a file with huge block size
 
 
+@pytest.mark.slow()
 def test_netcdf_huge_block_size():
 
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
     if sys.maxsize < 2**32:
         pytest.skip("Test not available on 32 bit")
 

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -446,10 +446,9 @@ def test_vrtwarp_read_vrt_of_warped_vrt():
 # Test reading a warped VRT with blocks > 2 gigapixels
 
 
+@pytest.mark.slow()
 def test_vrtwarp_read_blocks_larger_than_2_gigapixels():
 
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
     if sys.maxsize < 2**32:
         pytest.skip("Test not available on 32 bit")
 

--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -702,12 +702,9 @@ def test_wms_15():
 ###############################################################################
 # Test getting subdatasets from WMS-C Capabilities
 
-
+# server often returns a 504 after ages; this test can take minutes
+@pytest.mark.slow()
 def test_wms_16():
-
-    if not gdaltest.run_slow_tests():
-        # server often returns a 504 after ages; this test can take minutes
-        pytest.skip()
 
     name = "WMS:http://demo.opengeo.org/geoserver/gwc/service/wms?tiled=TRUE"
     ds = gdal.Open(name)
@@ -993,8 +990,6 @@ def test_twms_GIBS():
         "Failing because of SSL issue. See https://github.com/OSGeo/gdal/issues/3511#issuecomment-840718083"
     )
 
-    # if not gdaltest.run_slow_tests():
-    #     pytest.skip()
     baseURL = "https://gibs.earthdata.nasa.gov/twms/epsg4326/best/twms.cgi?"
 
     try:

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -3915,12 +3915,10 @@ version="1.0.0">
 # Test we are robust to content of XML elements bigger than 2 GB
 
 
+@pytest.mark.slow()
 def test_ogr_gml_76():
 
     if not gdaltest.have_gml_reader:
-        pytest.skip()
-
-    if not gdaltest.run_slow_tests():
         pytest.skip()
 
     with gdaltest.error_handler():

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -995,9 +995,6 @@ def test_ogr_wfs_deegree_sortby():
 
 def ogr_wfs_get_multiple_layer_defn(url):
 
-    if not gdaltest.run_slow_tests():
-        pytest.skip()
-
     ds = ogr.Open("WFS:" + url)
     if ds is None:
         if gdaltest.gdalurlopen(url) is None:
@@ -1028,6 +1025,7 @@ def test_ogr_wfs_esri():
 # Test a ESRI server
 
 
+@pytest.mark.slow()
 def test_ogr_wfs_esri_2():
     return ogr_wfs_get_multiple_layer_defn(
         "http://sentinel.ga.gov.au/wfsconnector/com.esri.wfs.Esrimap"
@@ -1038,6 +1036,7 @@ def test_ogr_wfs_esri_2():
 # Test a CubeWerx server
 
 
+@pytest.mark.slow()
 def test_ogr_wfs_cubewerx():
     return ogr_wfs_get_multiple_layer_defn(
         "http://portal.cubewerx.com/cubewerx/cubeserv/cubeserv.cgi?CONFIG=haiti_vgi&DATASTORE=vgi"
@@ -1048,6 +1047,7 @@ def test_ogr_wfs_cubewerx():
 # Test a TinyOWS server
 
 
+@pytest.mark.slow()
 def test_ogr_wfs_tinyows():
     return ogr_wfs_get_multiple_layer_defn("http://www.tinyows.org/cgi-bin/tinyows")
 
@@ -1056,6 +1056,7 @@ def test_ogr_wfs_tinyows():
 # Test a ERDAS Apollo server
 
 
+@pytest.mark.slow()
 def test_ogr_wfs_erdas_apollo():
     return ogr_wfs_get_multiple_layer_defn(
         "http://apollo.erdas.com/erdas-apollo/vector/Cherokee"
@@ -1066,6 +1067,7 @@ def test_ogr_wfs_erdas_apollo():
 # Test a Integraph server
 
 
+@pytest.mark.slow()
 def test_ogr_wfs_intergraph():
     return ogr_wfs_get_multiple_layer_defn("http://ideg.xunta.es/WFS_POL/request.aspx")
 
@@ -1074,6 +1076,7 @@ def test_ogr_wfs_intergraph():
 # Test a MapInfo server
 
 
+@pytest.mark.slow()
 def test_ogr_wfs_mapinfo():
     return ogr_wfs_get_multiple_layer_defn("http://www.mapinfo.com/miwfs")
 

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -21,3 +21,4 @@ gdal_version = @GDAL_VERSION@
 markers =
     require_driver: Skip test(s) if driver isn't present
     require_run_on_demand: Skip test(s) if RUN_ON_DEMAND environment variable is not set
+    slow: Skip test(s) if GDAL_RUN_SLOW_TESTS environment variable is not set


### PR DESCRIPTION
## What does this PR do?

Add pytest marker for slow tests. This allows a consistent message to be provided when slow tests are skipped.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/1194 has some discussion about tradeoffs in adding markers.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed