### PR TITLE
FileGDB/OpenFileGDB: do not touch field precision for floating-point data types

### DIFF
--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -449,7 +449,7 @@ def test_ogr_fgdb_2(ogrsf_path):
 # Run ogr2ogr
 
 
-def test_ogr_fgdb_3():
+def test_ogr_fgdb_3(openfilegdb_drv):
 
     import test_cli_utilities
 
@@ -472,6 +472,10 @@ def test_ogr_fgdb_3():
 
     if test_cli_utilities.get_test_ogrsf_path() is None:
         pytest.skip()
+
+    if openfilegdb_drv is None:
+        # OpenFileGDB is required for CreateFeature() with a FID set
+        pytest.skip("skipping test_ogrsf due to missing OpenFileGDB driver")
 
     ret = gdaltest.runexternal(
         test_cli_utilities.get_test_ogrsf_path()
@@ -2424,6 +2428,7 @@ def test_ogr_fgdb_21(fgdb_drv, fgdb_sdk_1_4_or_later):
 # Read curves
 
 
+@pytest.mark.require_driver("CSV")
 def test_ogr_fgdb_22():
 
     ds = ogr.Open("data/filegdb/curves.gdb")
@@ -2473,6 +2478,7 @@ def test_ogr_fgdb_23():
 # one of the starting point (#7017)
 
 
+@pytest.mark.require_driver("CSV")
 def test_ogr_fgdb_24():
 
     ds = ogr.Open("data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb")
@@ -2599,6 +2605,7 @@ def test_ogr_fgdb_alias(fgdb_drv):
 # Test field alias with ampersand character. Requires OpenFileGDB to be read back
 
 
+@pytest.mark.require_driver("OpenFileGDB")
 def test_ogr_fgdb_alias_with_ampersand(fgdb_drv, openfilegdb_drv):
 
     try:
@@ -2855,6 +2862,7 @@ def test_ogr_fgdb_rename_layer(fgdb_drv, options):
 # see https://github.com/OSGeo/gdal/issues/4463
 
 
+@pytest.mark.require_driver("OpenFileGDB")
 def test_ogr_filegdb_non_spatial_table_outside_gdb_items(openfilegdb_drv, fgdb_drv):
     openfilegdb_drv.Deregister()
     fgdb_drv.Deregister()
@@ -3012,6 +3020,7 @@ def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit(fgdb_drv):
         pass
 
 
+@pytest.mark.require_driver("OpenFileGDB")
 def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     openfilegdb_drv.Deregister()
     fgdb_drv.Deregister()

--- a/ogr/ogrsf_frmts/filegdb/FGdbUtils.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbUtils.cpp
@@ -271,58 +271,53 @@ bool OGRToGDBFieldType(OGRFieldType ogrType, OGRFieldSubType eSubType,
 }
 
 /*************************************************************************/
-/*                       GDBFieldTypeToWidthPrecision()                  */
+/*                       GDBFieldTypeToLengthInBytes()                   */
 /*************************************************************************/
 
-bool GDBFieldTypeToWidthPrecision(const std::string &gdbType, int *width,
-                                  int *precision)
+bool GDBFieldTypeToLengthInBytes(const std::string &gdbType, int &lengthOut)
 {
-    *precision = 0;
-
-    /* Width (Length in FileGDB terms) based on
+    /* Length based on
      * FileGDB_API/samples/XMLsamples/OneOfEachFieldType.xml */
     /* Length is in bytes per doc of FileGDB_API/xmlResources/FileGDBAPI.xsd */
     if (gdbType == "esriFieldTypeSmallInteger")
     {
-        *width = 2;
+        lengthOut = 2;
     }
     else if (gdbType == "esriFieldTypeInteger")
     {
-        *width = 4;
+        lengthOut = 4;
     }
     else if (gdbType == "esriFieldTypeSingle")
     {
-        *width = 4;
-        *precision = 5;  // FIXME ?
+        lengthOut = 4;
     }
     else if (gdbType == "esriFieldTypeDouble")
     {
-        *width = 8;
-        *precision = 15;  // FIXME ?
+        lengthOut = 8;
     }
     else if (gdbType == "esriFieldTypeString" || gdbType == "esriFieldTypeXML")
     {
-        *width = atoi(CPLGetConfigOption("FGDB_STRING_WIDTH", "65536"));
+        lengthOut = atoi(CPLGetConfigOption("FGDB_STRING_WIDTH", "65536"));
     }
     else if (gdbType == "esriFieldTypeDate")
     {
-        *width = 8;
+        lengthOut = 8;
     }
     else if (gdbType == "esriFieldTypeOID")
     {
-        *width = 4;
+        lengthOut = 4;
     }
     else if (gdbType == "esriFieldTypeGUID")
     {
-        *width = 16;
+        lengthOut = 16;
     }
     else if (gdbType == "esriFieldTypeBlob")
     {
-        *width = 0;
+        lengthOut = 0;
     }
     else if (gdbType == "esriFieldTypeGlobalID")
     {
-        *width = 38;
+        lengthOut = 38;
     }
     else
     {
@@ -335,7 +330,7 @@ bool GDBFieldTypeToWidthPrecision(const std::string &gdbType, int *width,
 }
 
 /*************************************************************************/
-/*                       GDBFieldTypeToWidthPrecision()                  */
+/*                        GDBGeometryToOGRGeometry()                     */
 /*************************************************************************/
 
 bool GDBGeometryToOGRGeometry(bool forceMulti,

--- a/ogr/ogrsf_frmts/filegdb/FGdbUtils.h
+++ b/ogr/ogrsf_frmts/filegdb/FGdbUtils.h
@@ -69,10 +69,9 @@ bool OGRToGDBFieldType(OGRFieldType ogrType, OGRFieldSubType eSubType,
                        std::string *gdbType);
 
 //
-// GDB Field Width defaults
+// GDB Field Length
 //
-bool GDBFieldTypeToWidthPrecision(const std::string &gdbType, int *width,
-                                  int *precision);
+bool GDBFieldTypeToLengthInBytes(const std::string &gdbType, int &lengthOut);
 
 //
 // GDBAPI error to OGR

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
@@ -669,7 +669,7 @@ int OGROpenFileGDBLayer::BuildLayerDefinition()
         OGRFieldDefn oFieldDefn(poGDBField->GetName().c_str(), eType);
         oFieldDefn.SetAlternativeName(poGDBField->GetAlias().c_str());
         oFieldDefn.SetSubType(eSubType);
-        // On creation in the FileGDB driver (GDBFieldTypeToWidthPrecision) if
+        // On creation in the FileGDB driver (GDBFieldTypeToLengthInBytes) if
         // string width is 0, we pick up 65536 by default to mean unlimited
         // string length, but we do not want to advertise such a big number.
         if (eType == OFTString &&

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -1333,8 +1333,8 @@ OGRErr OGROpenFileGDBLayer::AlterFieldDefn(int iFieldToAlter,
     }
     if (nFlagsIn & ALTER_WIDTH_PRECISION_FLAG)
     {
-        oField.SetWidth(poNewFieldDefn->GetWidth());
-        oField.SetPrecision(poNewFieldDefn->GetPrecision());
+        if (oField.GetType() == OFTString)
+            oField.SetWidth(poNewFieldDefn->GetWidth());
     }
     if (nFlagsIn & ALTER_DEFAULT_FLAG)
     {
@@ -1394,7 +1394,6 @@ OGRErr OGROpenFileGDBLayer::AlterFieldDefn(int iFieldToAlter,
     poFieldDefn->SetType(oField.GetType());
     poFieldDefn->SetSubType(oField.GetSubType());
     poFieldDefn->SetWidth(oField.GetWidth());
-    poFieldDefn->SetPrecision(oField.GetPrecision());
     poFieldDefn->SetDefault(oField.GetDefault());
     poFieldDefn->SetNullable(oField.IsNullable());
     poFieldDefn->SetDomainName(oField.GetDomainName());
@@ -2463,7 +2462,7 @@ void OGROpenFileGDBLayer::RefreshXMLDefinitionInMemory()
             CPLCreateXMLElementAndValue(GPFieldInfoEx, "FieldType",
                                         "esriFieldTypeOID");
             CPLCreateXMLElementAndValue(GPFieldInfoEx, "IsNullable", "false");
-            CPLCreateXMLElementAndValue(GPFieldInfoEx, "Length", "12");
+            CPLCreateXMLElementAndValue(GPFieldInfoEx, "Length", "4");
             CPLCreateXMLElementAndValue(GPFieldInfoEx, "Precision", "0");
             CPLCreateXMLElementAndValue(GPFieldInfoEx, "Scale", "0");
             CPLCreateXMLElementAndValue(GPFieldInfoEx, "Required", "true");


### PR DESCRIPTION
as it is not supported in FileGeodatabase for floating-point types.

and also correct ObjectID field to have a Length of 4.

Fixes #7283