### PR TITLE
autotest: Symlink conftest.py into build directory

### DIFF
--- a/autotest/CMakeLists.txt
+++ b/autotest/CMakeLists.txt
@@ -47,30 +47,38 @@ if (Python_Interpreter_FOUND)
   set(AUTOTEST_LOG_FILE "${CMAKE_CURRENT_BINARY_DIR}/autotest.log")
   set(PYTEST_INI_HEADER_MESSAGE "This file was generated from ${GDAL_CMAKE_TEMPLATE_PATH}/pytest.ini.in using ${CMAKE_CURRENT_LIST_FILE}")
   configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/pytest.ini.in ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini @ONLY)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/conftest.py ${CMAKE_CURRENT_BINARY_DIR}/conftest.py COPYONLY)
   unset(PYTEST_INI_HEADER_MESSAGE)
 
-  function (symlink_or_copy source destination)
-
-    if (CMAKE_VERSION VERSION_GREATER 3.14)
-      file(
-        CREATE_LINK ${source} ${destination}
-        RESULT res
-        SYMBOLIC)
-      if (NOT res EQUAL 0)
-        message(STATUS "Copying content of ${source} to ${destination}")
+function (copy_file_or_dir source dest)
+    if (IS_DIRECTORY ${source})
+        message(STATUS "Copying contents of ${source} to ${destination}")
         execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${source} ${destination})
-      endif ()
-    else ()
+    else()
+        message(STATUS "Copying ${source} to ${destination}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${source} ${destination})
+    endif()
+endfunction()
+
+function (symlink_or_copy source destination)
+  if (CMAKE_VERSION VERSION_GREATER 3.14)
+    file(
+      CREATE_LINK ${source} ${destination}
+      RESULT res
+      SYMBOLIC)
+    if (NOT res EQUAL 0)
+      copy_file_or_dir(${source} ${destination})
+    endif ()
+  else ()
       if (NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
         execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${source} ${destination})
       else ()
-        message(STATUS "Copying content of ${source} to ${destination}")
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${source} ${destination})
+        copy_file_or_dir(${source} ${destination})
       endif ()
-    endif ()
+  endif ()
 
-  endfunction ()
+endfunction ()
+
+  symlink_or_copy(${CMAKE_CURRENT_SOURCE_DIR}/conftest.py ${CMAKE_CURRENT_BINARY_DIR}/conftest.py)
 
   if (NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
       foreach (subdir IN ITEMS pymod proj_grids cpp/data)


### PR DESCRIPTION
## What does this PR do?

This PR symlinks `conftest.py` into the build directory so that changes to that file are visible to the test suite without rerunning `cmake`.

## What are related issues/pull requests?

Discussion in https://github.com/OSGeo/gdal/commit/9b3905e695acb0f9634e45acbce52500326f0f46

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
