### PR TITLE
VRT: 'expand' opt for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1456,7 +1456,7 @@ def test_vrt_protocol():
 
 
 @pytest.mark.require_driver("BMP")
-def test_vrt_protocol_bmp():
+def test_vrt_protocol_expand_option():
     ds = gdal.Open("vrt://data/8bit_pal.bmp?expand=rgb")
     assert ds.GetRasterBand(1).GetRasterColorInterpretation() == gdal.GCI_RedBand
 

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1454,6 +1454,9 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/byte_with_ovr.tif?ovr=0")
     assert ds.RasterXSize == 10
 
+
+@pytest.mark.require_driver("BMP")
+def test_vrt_protocol_bmp():
     ds = gdal.Open("vrt://data/8bit_pal.bmp?expand=rgb")
     assert ds.GetRasterBand(1).GetRasterColorInterpretation() == gdal.GCI_RedBand
 

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1454,6 +1454,9 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/byte_with_ovr.tif?ovr=0")
     assert ds.RasterXSize == 10
 
+    ds = gdal.Open("vrt://data/8bit_pal.bmp?expand=rgb")
+    assert ds.GetRasterBand(1).GetRasterColorInterpretation() == gdal.GCI_RedBand
+
 
 def test_vrt_source_no_dstrect():
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1656,7 +1656,7 @@ For example:
     vrt://my.tif?bands=2&ovr=4
 
 
-The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, and ``ovr``. 
+The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, and ``expand``. 
 
 Other options may be added in the future.
 
@@ -1676,6 +1676,9 @@ values separated by commas, in the order 'xmin,ymax,xmax,ymin' (upper left x,y, 
 
 The effect of the ``ovr``` option (added in GDAL 3.7) is to specify which overview 
 level of source file must be used, with the first overview level being 0 (:ref:`gdal_translate`).
+
+The effect of the ``expand`` option (added in GDAL 3.7) is to expose a dataset with 1 band with 
+a color table as a dataset with 3 (RGB) or 4 (RGBA) bands, as with (:ref:`gdal_translate`).
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1040,7 +1040,11 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString("-ovr");
                 argv.AddString(pszValue);
             }
-
+            else if (EQUAL(pszKey, "expand"))
+            {
+                argv.AddString("-expand");
+                argv.AddString(pszValue);
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Adds 'expand' to the allowed options for a "vrt:// connection. The effect is to expand a palette image index by a 1 band dataset  RGB, RGBA, or Gray dataset. 

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
