### PR TITLE
VRT 'a_offset' and 'a_scale' options for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1454,6 +1454,12 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/byte_with_ovr.tif?ovr=0")
     assert ds.RasterXSize == 10
 
+    ds = gdal.Open("vrt://data/int32.tif?a_scale=2")
+    assert ds.GetRasterBand(1).GetScale() == 2.0
+
+    ds = gdal.Open("vrt://data/int32.tif?a_offset=-132")
+    assert ds.GetRasterBand(1).GetOffset() == -132.0
+
 
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1656,7 +1656,8 @@ For example:
     vrt://my.tif?bands=2&ovr=4
 
 
-The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, and ``expand``. 
+The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``, 
+``a_scale``, and ``a_offset``. 
 
 Other options may be added in the future.
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1680,6 +1680,12 @@ level of source file must be used, with the first overview level being 0 (:ref:`
 The effect of the ``expand`` option (added in GDAL 3.7) is to expose a dataset with 1 band with 
 a color table as a dataset with 3 (RGB) or 4 (RGBA) bands, as with (:ref:`gdal_translate`).
 
+The effect of the ``a_scale`` option (added in GDAL 3.7) is to set band scaling value (no 
+modification of pixel values is done), as with (:ref:`gdal_translate`).
+
+The effect of the ``a_offset`` option (added in GDAL 3.7) is to set band offset value (no 
+modification of pixel values is done), as with (:ref:`gdal_translate`).
+
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1045,6 +1045,16 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString("-expand");
                 argv.AddString(pszValue);
             }
+            else if (EQUAL(pszKey, "a_scale"))
+            {
+                argv.AddString("-a_scale");
+                argv.AddString(pszValue);
+            }
+            else if (EQUAL(pszKey, "a_offset"))
+            {
+                argv.AddString("-a_offset");
+                argv.AddString(pszValue);
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Adds 'a_offset' and 'a_scale' to the allowed options for a "vrt:// connection.


## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed

