### PR TITLE
autotest: Mark ogr_ngw tests as slow

### DIFF
--- a/autotest/ogr/ogr_ngw.py
+++ b/autotest/ogr/ogr_ngw.py
@@ -782,6 +782,7 @@ def test_ogr_ngw_15():
 #  Run test_ogrsf
 
 
+@pytest.mark.slow()  # 460 s
 def test_ogr_ngw_test_ogrsf():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:

--- a/autotest/ogr/ogr_ngw.py
+++ b/autotest/ogr/ogr_ngw.py
@@ -116,6 +116,7 @@ def startup_and_cleanup():
 # Check create datasource.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_2():
 
     create_url = "NGW:" + gdaltest.ngw_test_server + "/resource/0/" + get_new_name()
@@ -148,6 +149,7 @@ def test_ogr_ngw_2():
 # Check rename datasource.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_3():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -166,6 +168,7 @@ def test_ogr_ngw_3():
 # Check datasource metadata.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_4():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -260,6 +263,7 @@ def add_metadata(lyr):
 # Check create vector layers.
 
 
+@pytest.mark.slow()  # 12s
 def test_ogr_ngw_5():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -427,6 +431,7 @@ def test_ogr_ngw_5():
 # Check open single vector layer.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_6():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -445,6 +450,7 @@ def test_ogr_ngw_6():
 # Check insert, update and delete features.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_7():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -480,6 +486,7 @@ def test_ogr_ngw_7():
 # Check insert, update features in batch mode.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_8():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -531,6 +538,7 @@ def test_ogr_ngw_8():
 # Check paging while GetNextFeature.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_9():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -562,6 +570,7 @@ def test_ogr_ngw_9():
 # Check native data.
 
 
+@pytest.mark.slow()  # 6s
 def test_ogr_ngw_10():
     if gdal.GetDriverByName("NGW") is None or gdaltest.ngw_ds is None:
         pytest.skip()
@@ -605,6 +614,7 @@ def test_ogr_ngw_10():
 # Check ignored fields works ok
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_11():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -638,6 +648,7 @@ def test_ogr_ngw_11():
 # Check attribute filter.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_12():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -673,6 +684,7 @@ def test_ogr_ngw_12():
 # Check spatial filter.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_13():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -695,6 +707,7 @@ def test_ogr_ngw_13():
 # Check ignore geometry.
 
 
+@pytest.mark.slow()
 def test_ogr_ngw_14():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:
@@ -722,6 +735,7 @@ def test_ogr_ngw_14():
 # Check ExecuteSQL.
 
 
+@pytest.mark.slow()  # 10s
 def test_ogr_ngw_15():
     # FIXME: depends on previous test
     if gdaltest.ngw_ds is None:


### PR DESCRIPTION
## What does this PR do?

Marks the ogr_ngw tests as slow. The slowest of these, ogr_ngw_test_sf, takes about 7 minutes to run on my machine. Several of the remaining tests take > 5 seconds to run, which is longer than other tests that are currently marked as slow (e.g., test_ogr_wfs_esri_2). But because the faster tests depend on state set by the slower tests, the entire module needs to be marked as slow.

Alternatively, or additionally, these tests could be marked with `pytest.mark.run_on_demand()`.

Based on a look at the current tests that are marked as slow, I think the testing docs could be updated to recommend a marking as slow for tests taking > 5 seconds.

## What are related issues/pull requests?

#4453

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
