### PR TITLE
VRT 'ot' option for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1460,6 +1460,9 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/int32.tif?a_offset=-132")
     assert ds.GetRasterBand(1).GetOffset() == -132.0
 
+    ds = gdal.Open("vrt://data/float32.tif?ot=Int32")
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_Int32
+
 
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1657,7 +1657,7 @@ For example:
 
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``, 
-``a_scale``, and ``a_offset``. 
+``a_scale``, ``a_offset``, and ``ot``. 
 
 Other options may be added in the future.
 
@@ -1686,6 +1686,9 @@ modification of pixel values is done), as with (:ref:`gdal_translate`).
 
 The effect of the ``a_offset`` option (added in GDAL 3.7) is to set band offset value (no 
 modification of pixel values is done), as with (:ref:`gdal_translate`).
+
+The effect of the ``ot`` option (added in GDAL 3.7) is to force the output image bands to have a 
+specific data type supported by the driver as with (:ref:`gdal_translate`).
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1055,6 +1055,11 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString("-a_offset");
                 argv.AddString(pszValue);
             }
+            else if (EQUAL(pszKey, "ot"))
+            {
+                argv.AddString("-ot");
+                argv.AddString(pszValue);
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Adds 'ot' output type to the allowed options for a "vrt:// connection.

## Tasklist

- [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

