### PR TITLE
GEOJSON: fix mixed type field not flagged as JSON if first occurrence is a string  (fixes #7313)

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4253,6 +4253,7 @@ def test_ogr_geojson_test_ogrsf():
 @pytest.mark.parametrize(
     "properties",
     [
+        ["a_string", 42.0, {"a_field": "a_value"}],
         ["a_string", 42, {"a_field": "a_value"}],
         ["a_string", {"a_field": "a_value"}, 42],
         [42, "a_string", {"a_field": "a_value"}],

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4244,3 +4244,44 @@ def test_ogr_geojson_test_ogrsf():
 
     assert "INFO" in ret
     assert "ERROR" not in ret
+
+
+###############################################################################
+# Test fix for https://github.com/OSGeo/gdal/issues/7313
+
+
+@pytest.mark.parametrize(
+    "properties",
+    [
+        ["a_string", 42, {"a_field": "a_value"}],
+        ["a_string", {"a_field": "a_value"}, 42],
+        [42, "a_string", {"a_field": "a_value"}],
+        [42, {"a_field": "a_value"}, "a_string"],
+        [{"a_field": "a_value"}, 42, "a_string"],
+        [{"a_field": "a_value"}, "a_string", 42],
+    ],
+)
+def test_ogr_geojson_mixed_type_promotion(properties):
+
+    tmpfilename = "/vsimem/temp.json"
+
+    jdata = {"type": "FeatureCollection", "features": []}
+
+    for prop_val in properties:
+        jdata["features"].append({"type": "Feature", "properties": {"prop0": prop_val}})
+
+    gdal.FileFromMemBuffer(
+        tmpfilename,
+        json.dumps(jdata),
+    )
+
+    ds = gdal.OpenEx(tmpfilename, gdal.OF_VECTOR)
+    assert ds is not None
+
+    lyr = ds.GetLayer(0)
+    lyr_def = lyr.GetLayerDefn()
+    fld_def = lyr_def.GetFieldDefn(0)
+    assert fld_def.GetTypeName() == "String"
+    assert fld_def.GetSubType() == ogr.OFSTJSON
+
+    gdal.Unlink(tmpfilename)

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
@@ -1937,7 +1937,7 @@ void OGRGeoJSONReaderAddOrUpdateField(
                 {
                     poFDefn->SetType(OFTStringList);
                 }
-                else if (eNewType == OFTInteger)
+                else if (eNewType != OFTString)
                 {
                     poFDefn->SetSubType(OFSTJSON);
                 }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
@@ -1934,7 +1934,13 @@ void OGRGeoJSONReaderAddOrUpdateField(
             if (eSubType == OFSTNone)
             {
                 if (eNewType == OFTStringList)
+                {
                     poFDefn->SetType(OFTStringList);
+                }
+                else if (eNewType == OFTInteger)
+                {
+                    poFDefn->SetSubType(OFSTJSON);
+                }
             }
         }
         else if (eType == OFTIntegerList)


### PR DESCRIPTION
Set the field subtype to OFSTJSON even when the first occurrence of the field was a string.

fixes #7313