### PR TITLE
VRT 'gcp' option for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1463,6 +1463,23 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/float32.tif?ot=Int32")
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Int32
 
+    ## 5-element GCP
+    ds = gdal.Open("vrt://data/float32.tif?gcp=0,0,0,10,0")
+    assert ds.GetGCPCount() == 1
+
+    ## multiple GCPs
+    ds = gdal.Open("vrt://data/float32.tif?gcp=0,0,0,10,0&gcp=20,0,10,10,0")
+    assert ds.GetGCPCount() == 2
+
+    ## 4-element GCP also ok
+    ds = gdal.Open("vrt://data/float32.tif?gcp=0,0,0,10&gcp=20,0,10,10")
+    assert ds.GetGCPCount() == 2
+
+    try:
+        ds = gdal.Open("vrt://data/float32.tif?gcp=invalid")
+    except SyntaxError:
+        pass
+
 
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1657,7 +1657,7 @@ For example:
 
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``, 
-``a_scale``, ``a_offset``, and ``ot``. 
+``a_scale``, ``a_offset``, ``ot``, and ``gcp``. 
 
 Other options may be added in the future.
 
@@ -1689,6 +1689,11 @@ modification of pixel values is done), as with (:ref:`gdal_translate`).
 
 The effect of the ``ot`` option (added in GDAL 3.7) is to force the output image bands to have a 
 specific data type supported by the driver as with (:ref:`gdal_translate`).
+
+The effect of the ``gcp`` option (added in GDAL 3.7) is to add the indicated ground control point 
+to the output dataset. Values are a set of as per (:ref:`gdal_translate`)``pixel,line,easting,northing,elevation``.  
+Multiple entries may be included. This can also be seen as an equivalent of running 
+`gdal_translate -of VRT -gcp pixel1 line1 easting1 northing1 [elevation1] -gcp pixel2 line2 easting2 northing2 [elevation2] ... -gcp pixelN lineN eastingN northingN [elevationN]`. 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1691,7 +1691,7 @@ The effect of the ``ot`` option (added in GDAL 3.7) is to force the output image
 specific data type supported by the driver as with (:ref:`gdal_translate`).
 
 The effect of the ``gcp`` option (added in GDAL 3.7) is to add the indicated ground control point 
-to the output dataset. Values are a set of as per (:ref:`gdal_translate`)``pixel,line,easting,northing,elevation``.  
+to the output dataset. Values are a set of numbers as per (:ref:`gdal_translate`)``pixel,line,easting,northing,elevation``.  
 Multiple entries may be included. This can also be seen as an equivalent of running 
 `gdal_translate -of VRT -gcp pixel1 line1 easting1 northing1 [elevation1] -gcp pixel2 line2 easting2 northing2 [elevation2] ... -gcp pixelN lineN eastingN northingN [elevationN]`. 
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1060,6 +1060,29 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString("-ot");
                 argv.AddString(pszValue);
             }
+            else if (EQUAL(pszKey, "gcp"))
+            {
+                CPLStringList aosGCP(CSLTokenizeString2(pszValue, ",", 0));
+
+                //FIXME:  not robust to gcp=0,0,00
+                if (aosGCP.size() < 4 || aosGCP.size() > 5)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "Invalid value for GCP: %s\n  need 4, or 5 "
+                             "numbers, comma separated: "
+                             "'gcp=<pixel>,<line>,<easting>,<northing>[,<"
+                             "elevation>]'",
+                             pszValue);
+                    poSrcDS->ReleaseRef();
+                    CPLFree(pszKey);
+                    return nullptr;
+                }
+                argv.AddString("-gcp");
+                for (int j = 0; j < aosGCP.size(); j++)
+                {
+                    argv.AddString(aosGCP[j]);
+                }
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1064,7 +1064,6 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
             {
                 CPLStringList aosGCP(CSLTokenizeString2(pszValue, ",", 0));
 
-                //FIXME:  not robust to gcp=0,0,00
                 if (aosGCP.size() < 4 || aosGCP.size() > 5)
                 {
                     CPLError(CE_Failure, CPLE_IllegalArg,


### PR DESCRIPTION
Adds 'gcp' (ground control point) to the allowed options for a "vrt:// connection.

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
