### PR TITLE
polygonize: switch to The Two-Arm Chains EdgeTracing Algorithm

### DIFF
--- a/alg/CMakeLists.txt
+++ b/alg/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
   gdalwarpoperation.cpp
   llrasterize.cpp
   polygonize.cpp
+  polygonize_polygonizer_impl.cpp
   rasterfill.cpp
   thinplatespline.cpp
   gdal_simplesurf.cpp

--- a/alg/polygonize.cpp
+++ b/alg/polygonize.cpp
@@ -172,6 +172,9 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
         eErr = GDALRasterIO(hSrcBand, GF_Read, 0, iY, nXSize, 1, panThisLineVal,
                             nXSize, 1, eDT, 0, 0);
 
+        if (eErr != CE_None)
+            break;
+
         if (iY == 0)
             eErr = oFirstEnum.ProcessLine(nullptr, panThisLineVal, nullptr,
                                           panThisLineId, nXSize)
@@ -182,6 +185,7 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
                                           panLastLineId, panThisLineId, nXSize)
                        ? CE_None
                        : CE_Failure;
+
         if (eErr != CE_None)
             break;
 
@@ -231,7 +235,6 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
     }
     else
     {
-
         for (int i = 0; i < nXSize + 2; ++i)
         {
             paoLastLineArm[i].poPolyInside = oPolygonizer.getTheOuterPolygon();
@@ -346,8 +349,7 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
         /*      Report progress, and support interrupts. */
         /* --------------------------------------------------------------------
          */
-        if (eErr == CE_None &&
-            !pfnProgress(0.10 + 0.90 * ((iY + 1) / static_cast<double>(nYSize)),
+        if (!pfnProgress(0.10 + 0.90 * ((iY + 1) / static_cast<double>(nYSize)),
                          "", pProgressArg))
         {
             CPLError(CE_Failure, CPLE_UserInterrupt, "User terminated");

--- a/alg/polygonize.cpp
+++ b/alg/polygonize.cpp
@@ -51,500 +51,9 @@
 #include "cpl_string.h"
 #include "cpl_vsi.h"
 
+#include "polygonize_polygonizer.h"
+
 CPL_CVSID("$Id$")
-
-/************************************************************************/
-/* ==================================================================== */
-/*                               RPolygon                               */
-/*                                                                      */
-/*      This is a helper class to hold polygons while they are being    */
-/*      formed in memory, and to provide services to coalesce a much    */
-/*      of edge sections into complete rings.                           */
-/* ==================================================================== */
-/************************************************************************/
-
-class RPolygon
-{
-  public:
-    double dfPolyValue = 0.0;
-    int nLastLineUpdated = -1;
-
-    struct XY
-    {
-        int x;
-        int y;
-
-        bool operator<(const XY &other) const
-        {
-            if (x < other.x)
-                return true;
-            if (x > other.x)
-                return false;
-            return y < other.y;
-        }
-
-        bool operator==(const XY &other) const
-        {
-            return x == other.x && y == other.y;
-        }
-    };
-
-    typedef int StringId;
-    typedef std::map<XY, std::pair<StringId, StringId>> MapExtremity;
-
-    std::map<StringId, std::vector<XY>> oMapStrings{};
-    MapExtremity oMapStartStrings{};
-    MapExtremity oMapEndStrings{};
-    StringId iNextStringId = 0;
-
-    static StringId findExtremityNot(const MapExtremity &oMap, const XY &xy,
-                                     StringId excludedId);
-
-    static void removeExtremity(MapExtremity &oMap, const XY &xy, StringId id);
-
-    static void insertExtremity(MapExtremity &oMap, const XY &xy, StringId id);
-
-    explicit RPolygon(double dfValue) : dfPolyValue(dfValue)
-    {
-    }
-
-    void AddSegment(int x1, int y1, int x2, int y2, int direction);
-    void Dump() const;
-    void Coalesce();
-    void Merge(StringId iBaseString, StringId iSrcString, int iDirection);
-};
-
-/************************************************************************/
-/*                                Dump()                                */
-/************************************************************************/
-void RPolygon::Dump() const
-{
-    /*ok*/ printf("RPolygon: Value=%g, LastLineUpdated=%d\n", dfPolyValue,
-                  nLastLineUpdated);
-
-    for (const auto &oStringIter : oMapStrings)
-    {
-        /*ok*/ printf("  String " CPL_FRMT_GIB ":\n",
-                      static_cast<GIntBig>(oStringIter.first));
-        for (const auto &xy : oStringIter.second)
-        {
-            /*ok*/ printf("    (%d,%d)\n", xy.x, xy.y);
-        }
-    }
-}
-
-/************************************************************************/
-/*                           findExtremityNot()                         */
-/************************************************************************/
-
-RPolygon::StringId RPolygon::findExtremityNot(const MapExtremity &oMap,
-                                              const XY &xy, StringId excludedId)
-{
-    auto oIter = oMap.find(xy);
-    if (oIter == oMap.end())
-        return -1;
-    if (oIter->second.first != excludedId)
-        return oIter->second.first;
-    if (oIter->second.second != excludedId)
-        return oIter->second.second;
-    return -1;
-}
-
-/************************************************************************/
-/*                              Coalesce()                              */
-/************************************************************************/
-
-void RPolygon::Coalesce()
-
-{
-    /* -------------------------------------------------------------------- */
-    /*      Iterate over loops starting from the first, trying to merge     */
-    /*      other segments into them.                                       */
-    /* -------------------------------------------------------------------- */
-    for (auto &oStringIter : oMapStrings)
-    {
-        const auto thisId = oStringIter.first;
-        auto &oString = oStringIter.second;
-
-        /* --------------------------------------------------------------------
-         */
-        /*      Keep trying to merge others strings into our target "base" */
-        /*      string while there are matches. */
-        /* --------------------------------------------------------------------
-         */
-        while (true)
-        {
-            auto nOtherId =
-                findExtremityNot(oMapStartStrings, oString.back(), thisId);
-            if (nOtherId != -1)
-            {
-                Merge(thisId, nOtherId, 1);
-                continue;
-            }
-            else
-            {
-                nOtherId =
-                    findExtremityNot(oMapEndStrings, oString.back(), thisId);
-                if (nOtherId != -1)
-                {
-                    Merge(thisId, nOtherId, -1);
-                    continue;
-                }
-            }
-            break;
-        }
-
-        // At this point our loop *should* be closed!
-        CPLAssert(oString.front() == oString.back());
-    }
-}
-
-/************************************************************************/
-/*                           removeExtremity()                          */
-/************************************************************************/
-
-void RPolygon::removeExtremity(MapExtremity &oMap, const XY &xy, StringId id)
-{
-    auto oIter = oMap.find(xy);
-    CPLAssert(oIter != oMap.end());
-    if (oIter->second.first == id)
-    {
-        oIter->second.first = oIter->second.second;
-        oIter->second.second = -1;
-        if (oIter->second.first < 0)
-            oMap.erase(oIter);
-    }
-    else if (oIter->second.second == id)
-    {
-        oIter->second.second = -1;
-        CPLAssert(oIter->second.first >= 0);
-    }
-    else
-    {
-        CPLAssert(false);
-    }
-}
-
-/************************************************************************/
-/*                           insertExtremity()                          */
-/************************************************************************/
-
-void RPolygon::insertExtremity(MapExtremity &oMap, const XY &xy, StringId id)
-{
-    auto oIter = oMap.find(xy);
-    if (oIter != oMap.end())
-    {
-        CPLAssert(oIter->second.second == -1);
-        oIter->second.second = id;
-    }
-    else
-    {
-        oMap[xy] = std::pair<StringId, StringId>(id, -1);
-    }
-}
-
-/************************************************************************/
-/*                               Merge()                                */
-/************************************************************************/
-
-void RPolygon::Merge(StringId iBaseString, StringId iSrcString, int iDirection)
-
-{
-    auto &anBase = oMapStrings.find(iBaseString)->second;
-    auto anStringIter = oMapStrings.find(iSrcString);
-    auto &anString = anStringIter->second;
-    int iStart = 1;
-    int iEnd = -1;
-
-    if (iDirection == 1)
-    {
-        iEnd = static_cast<int>(anString.size());
-    }
-    else
-    {
-        iStart = static_cast<int>(anString.size()) - 2;
-    }
-
-    removeExtremity(oMapEndStrings, anBase.back(), iBaseString);
-
-    anBase.reserve(anBase.size() + anString.size() - 1);
-    for (int i = iStart; i != iEnd; i += iDirection)
-    {
-        anBase.push_back(anString[i]);
-    }
-
-    removeExtremity(oMapStartStrings, anString.front(), iSrcString);
-    removeExtremity(oMapEndStrings, anString.back(), iSrcString);
-    oMapStrings.erase(anStringIter);
-    insertExtremity(oMapEndStrings, anBase.back(), iBaseString);
-}
-
-/************************************************************************/
-/*                             AddSegment()                             */
-/************************************************************************/
-
-void RPolygon::AddSegment(int x1, int y1, int x2, int y2, int direction)
-
-{
-    nLastLineUpdated = std::max(y1, y2);
-
-    /* -------------------------------------------------------------------- */
-    /*      Is there an existing string ending with this?                   */
-    /* -------------------------------------------------------------------- */
-
-    XY xy1 = {x1, y1};
-    XY xy2 = {x2, y2};
-
-    StringId iExistingString = findExtremityNot(oMapEndStrings, xy1, -1);
-    if (iExistingString >= 0)
-    {
-        StringId iExistingString2 =
-            findExtremityNot(oMapEndStrings, xy1, iExistingString);
-        if (iExistingString2 >= 0)
-        {
-            // If there are two strings that ending with this segment
-            // choose the string which is in the same pixel with this segment
-            auto &anString2 = oMapStrings[iExistingString2];
-            const size_t nSSize2 = anString2.size();
-
-            if (x1 == x2)
-            {
-                // vertical segment input, choose the horizontal string
-                if (anString2[nSSize2 - 2].y == anString2[nSSize2 - 1].y)
-                {
-                    iExistingString = iExistingString2;
-                }
-            }
-            else
-            {
-                // horizontal segment input, choose the vertical string
-                if (anString2[nSSize2 - 2].x == anString2[nSSize2 - 1].x)
-                {
-                    iExistingString = iExistingString2;
-                }
-            }
-        }
-        auto &anString = oMapStrings[iExistingString];
-        const size_t nSSize = anString.size();
-
-        // We are going to add a segment, but should we just extend
-        // an existing segment already going in the right direction?
-
-        const int nLastLen =
-            std::max(std::abs(anString[nSSize - 2].x - anString[nSSize - 1].x),
-                     std::abs(anString[nSSize - 2].y - anString[nSSize - 1].y));
-
-        removeExtremity(oMapEndStrings, anString.back(), iExistingString);
-
-        if ((anString[nSSize - 2].x - anString[nSSize - 1].x ==
-             (anString[nSSize - 1].x - xy2.x) * nLastLen) &&
-            (anString[nSSize - 2].y - anString[nSSize - 1].y ==
-             (anString[nSSize - 1].y - xy2.y) * nLastLen))
-        {
-            anString[nSSize - 1] = xy2;
-        }
-        else
-        {
-            anString.push_back(xy2);
-        }
-        insertExtremity(oMapEndStrings, anString.back(), iExistingString);
-    }
-    else
-    {
-        oMapStrings[iNextStringId] = std::vector<XY>{xy1, xy2};
-        insertExtremity(oMapStartStrings, xy1, iNextStringId);
-        insertExtremity(oMapEndStrings, xy2, iNextStringId);
-
-        iExistingString = iNextStringId;
-        iNextStringId++;
-    }
-
-    // merge rings if possible
-    if (direction == 1)
-    {
-        StringId iExistingString2 =
-            findExtremityNot(oMapEndStrings, xy2, iExistingString);
-        if (iExistingString2 >= 0)
-        {
-            this->Merge(iExistingString, iExistingString2, -1);
-        }
-    }
-}
-
-/************************************************************************/
-/* ==================================================================== */
-/*     End of RPolygon                                                  */
-/* ==================================================================== */
-/************************************************************************/
-
-/************************************************************************/
-/*                              AddEdges()                              */
-/*                                                                      */
-/*      Examine one pixel and compare to its neighbour above            */
-/*      (previous) and right.  If they are different polygon ids        */
-/*      then add the pixel edge to this polygon and the one on the      */
-/*      other side of the edge.                                         */
-/************************************************************************/
-
-template <class DataType>
-static void AddEdges(GInt32 *panThisLineId, GInt32 *panLastLineId,
-                     GInt32 *panPolyIdMap, DataType *panPolyValue,
-                     RPolygon **papoPoly, int iX, int iY)
-
-{
-    // TODO(schwehr): Simplify these three vars.
-    int nThisId = panThisLineId[iX];
-    if (nThisId != -1)
-        nThisId = panPolyIdMap[nThisId];
-    int nRightId = panThisLineId[iX + 1];
-    if (nRightId != -1)
-        nRightId = panPolyIdMap[nRightId];
-    int nPreviousId = panLastLineId[iX];
-    if (nPreviousId != -1)
-        nPreviousId = panPolyIdMap[nPreviousId];
-
-    const int iXReal = iX - 1;
-
-    if (nThisId != nPreviousId)
-    {
-        if (nThisId != -1)
-        {
-            if (papoPoly[nThisId] == nullptr)
-                // FIXME loss of precision for [U]Int64
-                papoPoly[nThisId] =
-                    new RPolygon(static_cast<double>(panPolyValue[nThisId]));
-
-            papoPoly[nThisId]->AddSegment(iXReal, iY, iXReal + 1, iY, 1);
-        }
-        if (nPreviousId != -1)
-        {
-            if (papoPoly[nPreviousId] == nullptr)
-                // FIXME loss of precision for [U]Int64
-                papoPoly[nPreviousId] = new RPolygon(
-                    static_cast<double>(panPolyValue[nPreviousId]));
-
-            papoPoly[nPreviousId]->AddSegment(iXReal, iY, iXReal + 1, iY, 0);
-        }
-    }
-
-    if (nThisId != nRightId)
-    {
-        if (nThisId != -1)
-        {
-            if (papoPoly[nThisId] == nullptr)
-                // FIXME loss of precision for [U]Int64
-                papoPoly[nThisId] =
-                    new RPolygon(static_cast<double>(panPolyValue[nThisId]));
-
-            papoPoly[nThisId]->AddSegment(iXReal + 1, iY, iXReal + 1, iY + 1,
-                                          1);
-        }
-
-        if (nRightId != -1)
-        {
-            if (papoPoly[nRightId] == nullptr)
-                // FIXME loss of precision for [U]Int64
-                papoPoly[nRightId] =
-                    new RPolygon(static_cast<double>(panPolyValue[nRightId]));
-
-            papoPoly[nRightId]->AddSegment(iXReal + 1, iY, iXReal + 1, iY + 1,
-                                           0);
-        }
-    }
-}
-
-/************************************************************************/
-/*                         EmitPolygonToLayer()                         */
-/************************************************************************/
-
-static CPLErr EmitPolygonToLayer(OGRLayerH hOutLayer, int iPixValField,
-                                 RPolygon *poRPoly, double *padfGeoTransform)
-
-{
-    /* -------------------------------------------------------------------- */
-    /*      Turn bits of lines into coherent rings.                         */
-    /* -------------------------------------------------------------------- */
-    poRPoly->Coalesce();
-
-    /* -------------------------------------------------------------------- */
-    /*      Create the polygon geometry.                                    */
-    /* -------------------------------------------------------------------- */
-    OGRGeometryH hPolygon = OGR_G_CreateGeometry(wkbPolygon);
-
-    for (const auto &oIter : poRPoly->oMapStrings)
-    {
-        const auto &anString = oIter.second;
-        OGRGeometryH hRing = OGR_G_CreateGeometry(wkbLinearRing);
-
-        // We go last to first to ensure the linestring is allocated to
-        // the proper size on the first try.
-        for (int iVert = static_cast<int>(anString.size()) - 1; iVert >= 0;
-             iVert--)
-        {
-            const int nPixelX = anString[iVert].x;
-            const int nPixelY = anString[iVert].y;
-
-            const double dfX = padfGeoTransform[0] +
-                               nPixelX * padfGeoTransform[1] +
-                               nPixelY * padfGeoTransform[2];
-            const double dfY = padfGeoTransform[3] +
-                               nPixelX * padfGeoTransform[4] +
-                               nPixelY * padfGeoTransform[5];
-
-            OGR_G_SetPoint_2D(hRing, iVert, dfX, dfY);
-        }
-
-        OGR_G_AddGeometryDirectly(hPolygon, hRing);
-    }
-
-    /* -------------------------------------------------------------------- */
-    /*      Create the feature object.                                      */
-    /* -------------------------------------------------------------------- */
-    OGRFeatureH hFeat = OGR_F_Create(OGR_L_GetLayerDefn(hOutLayer));
-
-    OGR_F_SetGeometryDirectly(hFeat, hPolygon);
-
-    if (iPixValField >= 0)
-        OGR_F_SetFieldDouble(hFeat, iPixValField, poRPoly->dfPolyValue);
-
-    /* -------------------------------------------------------------------- */
-    /*      Write the to the layer.                                         */
-    /* -------------------------------------------------------------------- */
-    CPLErr eErr = CE_None;
-
-    if (OGR_L_CreateFeature(hOutLayer, hFeat) != OGRERR_NONE)
-        eErr = CE_Failure;
-
-    OGR_F_Destroy(hFeat);
-
-    return eErr;
-}
-
-/************************************************************************/
-/*                          GPMaskImageData()                           */
-/*                                                                      */
-/*      Mask out image pixels to a special nodata value if the mask     */
-/*      band is zero.                                                   */
-/************************************************************************/
-
-template <class DataType>
-static CPLErr GPMaskImageData(GDALRasterBandH hMaskBand, GByte *pabyMaskLine,
-                              int iY, int nXSize, DataType *panImageLine)
-
-{
-    const CPLErr eErr = GDALRasterIO(hMaskBand, GF_Read, 0, iY, nXSize, 1,
-                                     pabyMaskLine, nXSize, 1, GDT_Byte, 0, 0);
-    if (eErr != CE_None)
-        return eErr;
-
-    for (int i = 0; i < nXSize; i++)
-    {
-        if (pabyMaskLine[i] == 0)
-            panImageLine[i] = GP_NODATA_MARKER;
-    }
-
-    return CE_None;
-}
 
 /************************************************************************/
 /*                           GDALPolygonizeT()                          */
@@ -589,28 +98,27 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
         return CE_Failure;
     }
 
-    DataType *panLastLineVal = static_cast<DataType *>(
-        VSI_MALLOC2_VERBOSE(sizeof(DataType), nXSize + 2));
-    DataType *panThisLineVal = static_cast<DataType *>(
-        VSI_MALLOC2_VERBOSE(sizeof(DataType), nXSize + 2));
+    DataType *panLastLineVal =
+        static_cast<DataType *>(VSI_MALLOC2_VERBOSE(sizeof(DataType), nXSize));
+    DataType *panThisLineVal =
+        static_cast<DataType *>(VSI_MALLOC2_VERBOSE(sizeof(DataType), nXSize));
     GInt32 *panLastLineId =
-        static_cast<GInt32 *>(VSI_MALLOC2_VERBOSE(sizeof(GInt32), nXSize + 2));
+        static_cast<GInt32 *>(VSI_MALLOC2_VERBOSE(sizeof(GInt32), nXSize));
     GInt32 *panThisLineId =
-        static_cast<GInt32 *>(VSI_MALLOC2_VERBOSE(sizeof(GInt32), nXSize + 2));
+        static_cast<GInt32 *>(VSI_MALLOC2_VERBOSE(sizeof(GInt32), nXSize));
 
-    GByte *pabyMaskLine = hMaskBand != nullptr
-                              ? static_cast<GByte *>(VSI_MALLOC_VERBOSE(nXSize))
-                              : nullptr;
+    GByte *pabyLastLineValMask =
+        static_cast<GByte *>(VSI_MALLOC_VERBOSE(nXSize));
 
     if (panLastLineVal == nullptr || panThisLineVal == nullptr ||
         panLastLineId == nullptr || panThisLineId == nullptr ||
-        (hMaskBand != nullptr && pabyMaskLine == nullptr))
+        pabyLastLineValMask == nullptr)
     {
         CPLFree(panThisLineId);
         CPLFree(panLastLineId);
         CPLFree(panThisLineVal);
         CPLFree(panLastLineVal);
-        CPLFree(pabyMaskLine);
+        CPLFree(pabyLastLineValMask);
         return CE_Failure;
     }
 
@@ -664,12 +172,6 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
         eErr = GDALRasterIO(hSrcBand, GF_Read, 0, iY, nXSize, 1, panThisLineVal,
                             nXSize, 1, eDT, 0, 0);
 
-        if (eErr == CE_None && hMaskBand != nullptr)
-            eErr = GPMaskImageData(hMaskBand, pabyMaskLine, iY, nXSize,
-                                   panThisLineVal);
-        if (eErr != CE_None)
-            break;
-
         if (iY == 0)
             eErr = oFirstEnum.ProcessLine(nullptr, panThisLineVal, nullptr,
                                           panThisLineId, nXSize)
@@ -709,26 +211,37 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
         oFirstEnum.CompleteMerges();
 
     /* -------------------------------------------------------------------- */
-    /*      Initialize ids to -1 to serve as a nodata value for the         */
-    /*      previous line, and past the beginning and end of the            */
-    /*      scanlines.                                                      */
-    /* -------------------------------------------------------------------- */
-    panThisLineId[0] = -1;
-    panThisLineId[nXSize + 1] = -1;
-
-    for (int iX = 0; iX < nXSize + 2; iX++)
-        panLastLineId[iX] = -1;
-
-    /* -------------------------------------------------------------------- */
     /*      We will use a new enumerator for the second pass primarily      */
     /*      so we can preserve the first pass map.                          */
     /* -------------------------------------------------------------------- */
     GDALRasterPolygonEnumeratorT<DataType, EqualityTest> oSecondEnum(
         nConnectedness);
-    RPolygon **papoPoly = static_cast<RPolygon **>(
-        VSI_CALLOC_VERBOSE(sizeof(RPolygon *), oFirstEnum.nNextPolygonId));
-    if (oFirstEnum.nNextPolygonId && papoPoly == nullptr)
+
+    OGRPolygonWriter<DataType> oPolygonWriter{hOutLayer, iPixValField,
+                                              adfGeoTransform};
+    Polygonizer<GInt32, DataType> oPolygonizer{&oPolygonWriter};
+    TwoArm *paoLastLineArm =
+        static_cast<TwoArm *>(VSI_CALLOC_VERBOSE(sizeof(TwoArm), nXSize + 2));
+    TwoArm *paoThisLineArm =
+        static_cast<TwoArm *>(VSI_CALLOC_VERBOSE(sizeof(TwoArm), nXSize + 2));
+
+    if (paoThisLineArm == nullptr || paoLastLineArm == nullptr)
+    {
         eErr = CE_Failure;
+    }
+    else
+    {
+
+        for (int i = 0; i < nXSize + 2; ++i)
+        {
+            paoLastLineArm[i].poPolyInside = oPolygonizer.getTheOuterPolygon();
+        }
+
+        for (int i = 0; i < nXSize; ++i)
+        {
+            pabyLastLineValMask[i] = 1;
+        }
+    }
 
     /* ==================================================================== */
     /*      Second pass during which we will actually collect polygon       */
@@ -745,14 +258,24 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
         {
             eErr = GDALRasterIO(hSrcBand, GF_Read, 0, iY, nXSize, 1,
                                 panThisLineVal, nXSize, 1, eDT, 0, 0);
-
-            if (eErr == CE_None && hMaskBand != nullptr)
-                eErr = GPMaskImageData(hMaskBand, pabyMaskLine, iY, nXSize,
-                                       panThisLineVal);
         }
 
         if (eErr != CE_None)
             continue;
+
+        /* --------------------------------------------------------------------
+         */
+        /*      Read the mask data. */
+        /* --------------------------------------------------------------------
+         */
+        if (iY > 0 && hMaskBand != nullptr)
+        {
+            eErr = GDALRasterIO(hMaskBand, GF_Read, 0, iY - 1, nXSize, 1,
+                                pabyLastLineValMask, nXSize, 1, GDT_Byte, 0, 0);
+
+            if (eErr != CE_None)
+                continue;
+        }
 
         /* --------------------------------------------------------------------
          */
@@ -762,21 +285,20 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
          */
         if (iY == nYSize)
         {
-            for (int iX = 0; iX < nXSize + 2; iX++)
-                panThisLineId[iX] = -1;
+            for (int iX = 0; iX < nXSize; iX++)
+                panThisLineId[iX] = THE_OUTER_POLYGON_ID;
         }
         else if (iY == 0)
         {
             eErr = oSecondEnum.ProcessLine(nullptr, panThisLineVal, nullptr,
-                                           panThisLineId + 1, nXSize)
+                                           panThisLineId, nXSize)
                        ? CE_None
                        : CE_Failure;
         }
         else
         {
             eErr = oSecondEnum.ProcessLine(panLastLineVal, panThisLineVal,
-                                           panLastLineId + 1, panThisLineId + 1,
-                                           nXSize)
+                                           panLastLineId, panThisLineId, nXSize)
                        ? CE_None
                        : CE_Failure;
         }
@@ -784,40 +306,30 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
         if (eErr != CE_None)
             continue;
 
-        /* --------------------------------------------------------------------
-         */
-        /*      Add polygon edges to our polygon list for the pixel */
-        /*      boundaries within and above this line. */
-        /* --------------------------------------------------------------------
-         */
-        for (int iX = 0; iX < nXSize + 1; iX++)
+        if (iY < nYSize)
         {
-            AddEdges(panThisLineId, panLastLineId, oFirstEnum.panPolyIdMap,
-                     oFirstEnum.panPolyValue, papoPoly, iX, iY);
-        }
-
-        /* --------------------------------------------------------------------
-         */
-        /*      Periodically we scan out polygons and write out those that */
-        /*      haven't been added to on the last line as we can be sure */
-        /*      they are complete. */
-        /* --------------------------------------------------------------------
-         */
-        if (iY % 8 == 7)
-        {
-            for (int iX = 0; eErr == CE_None && iX < oSecondEnum.nNextPolygonId;
-                 iX++)
+            for (int iX = 0; iX < nXSize; iX++)
             {
-                if (papoPoly[iX] && papoPoly[iX]->nLastLineUpdated < iY - 1)
-                {
-                    eErr = EmitPolygonToLayer(hOutLayer, iPixValField,
-                                              papoPoly[iX], adfGeoTransform);
-
-                    delete papoPoly[iX];
-                    papoPoly[iX] = nullptr;
-                }
+                // Ensure that polygon id is greator that zero, id zero is used by Polygonizer internally.
+                panLastLineId[iX] =
+                    oFirstEnum.panPolyIdMap[panThisLineId[iX]] + 1;
             }
+
+            oPolygonizer.processLine(panLastLineId, panLastLineVal,
+                                     pabyLastLineValMask, paoThisLineArm,
+                                     paoLastLineArm, iY, nXSize);
+            eErr = oPolygonWriter.getErr();
         }
+        else
+        {
+            oPolygonizer.processLine(panThisLineId, panLastLineVal,
+                                     pabyLastLineValMask, paoThisLineArm,
+                                     paoLastLineArm, iY, nXSize);
+            eErr = oPolygonWriter.getErr();
+        }
+
+        if (eErr != CE_None)
+            continue;
 
         /* --------------------------------------------------------------------
          */
@@ -827,6 +339,7 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
          */
         std::swap(panLastLineVal, panThisLineVal);
         std::swap(panLastLineId, panThisLineId);
+        std::swap(paoThisLineArm, paoLastLineArm);
 
         /* --------------------------------------------------------------------
          */
@@ -843,29 +356,15 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
     }
 
     /* -------------------------------------------------------------------- */
-    /*      Make a cleanup pass for all unflushed polygons.                 */
-    /* -------------------------------------------------------------------- */
-    for (int iX = 0; eErr == CE_None && iX < oSecondEnum.nNextPolygonId; iX++)
-    {
-        if (papoPoly[iX])
-        {
-            eErr = EmitPolygonToLayer(hOutLayer, iPixValField, papoPoly[iX],
-                                      adfGeoTransform);
-
-            delete papoPoly[iX];
-            papoPoly[iX] = nullptr;
-        }
-    }
-
-    /* -------------------------------------------------------------------- */
     /*      Cleanup                                                         */
     /* -------------------------------------------------------------------- */
     CPLFree(panThisLineId);
     CPLFree(panLastLineId);
     CPLFree(panThisLineVal);
     CPLFree(panLastLineVal);
-    CPLFree(pabyMaskLine);
-    CPLFree(papoPoly);
+    CPLFree(paoThisLineArm);
+    CPLFree(paoLastLineArm);
+    CPLFree(pabyLastLineValMask);
 
     return eErr;
 }

--- a/alg/polygonize_polygonizer.cpp
+++ b/alg/polygonize_polygonizer.cpp
@@ -69,8 +69,10 @@ void ProcessArmConnections(TwoArm *poCurrent, TwoArm *poAbove, TwoArm *poLeft)
     poCurrent->poPolyLeft = poLeft->poPolyInside;
 
     int nArmConnectionType =
-        (poAbove->bSolidVertical << 3) | (poLeft->bSolidHorizontal << 2) |
-        (poCurrent->bSolidVertical << 1) | (poCurrent->bSolidHorizontal);
+        (static_cast<int>(poAbove->bSolidVertical) << 3) |
+        (static_cast<int>(poLeft->bSolidHorizontal) << 2) |
+        (static_cast<int>(poCurrent->bSolidVertical) << 1) |
+        static_cast<int>(poCurrent->bSolidHorizontal);
 
     /**
      * There are 12 valid connection types depending on the arm types(virtual or solid)
@@ -478,7 +480,8 @@ void OGRPolygonWriter<DataType>::receive(RPolygon *poPolygon,
     OGR_F_SetGeometryDirectly(hFeat, hPolygon);
 
     if (iPixValField_ >= 0)
-        OGR_F_SetFieldDouble(hFeat, iPixValField_, nPolygonCellValue);
+        OGR_F_SetFieldDouble(hFeat, iPixValField_,
+                             static_cast<double>(nPolygonCellValue));
 
     // Write the to the layer.
     if (OGR_L_CreateFeature(hOutLayer_, hFeat) != OGRERR_NONE)

--- a/alg/polygonize_polygonizer.cpp
+++ b/alg/polygonize_polygonizer.cpp
@@ -25,6 +25,8 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+/*! @cond Doxygen_Suppress */
+
 #include "polygonize_polygonizer.h"
 
 #include <algorithm>
@@ -489,3 +491,5 @@ void OGRPolygonWriter<DataType>::receive(RPolygon *poPolygon,
 
     OGR_F_Destroy(hFeat);
 }
+
+/*! @endcond */

--- a/alg/polygonize_polygonizer.cpp
+++ b/alg/polygonize_polygonizer.cpp
@@ -1,0 +1,488 @@
+/******************************************************************************
+ * Project:  GDAL
+ * Purpose:  Implements The Two-Arm Chains EdgeTracing Algorithm
+ * Author:   kikitte.lee
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, kikitte.lee <kikitte.lee@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "polygonize_polygonizer.h"
+
+#include <algorithm>
+
+RPolygon::~RPolygon()
+{
+    for (auto &arc : oArcs)
+    {
+        delete arc;
+    }
+}
+
+IndexedArc RPolygon::newArc(bool bFollowRighthand)
+{
+    Arc *poArc = new Arc();
+    std::size_t iArcIndex = oArcs.size();
+    oArcs.push_back(poArc);
+    oArcRighthandFollow.push_back(bFollowRighthand);
+    oArcConnections.push_back(iArcIndex);
+    return IndexedArc{poArc, iArcIndex};
+}
+
+void RPolygon::setArcConnection(IndexedArc &oArc, IndexedArc &oNextArc)
+{
+    oArcConnections[oArc.iIndex] = oNextArc.iIndex;
+}
+
+void RPolygon::updateBottomRightPos(IndexType iRow, IndexType iCol)
+{
+    iBottomRightRow = iRow;
+    iBottomRightCol = iCol;
+}
+
+void ProcessArmConnections(TwoArm *poCurrent, TwoArm *poAbove, TwoArm *poLeft)
+{
+    poCurrent->poPolyInside->updateBottomRightPos(poCurrent->iRow,
+                                                  poCurrent->iCol);
+    poCurrent->bSolidVertical = poCurrent->poPolyInside != poLeft->poPolyInside;
+    poCurrent->bSolidHorizontal =
+        poCurrent->poPolyInside != poAbove->poPolyInside;
+    poCurrent->poPolyAbove = poAbove->poPolyInside;
+    poCurrent->poPolyLeft = poLeft->poPolyInside;
+
+    int nArmConnectionType =
+        (poAbove->bSolidVertical << 3) | (poLeft->bSolidHorizontal << 2) |
+        (poCurrent->bSolidVertical << 1) | (poCurrent->bSolidHorizontal);
+
+    /**
+     * There are 12 valid connection types depending on the arm types(virtual or solid)
+     * The following diagram illustrates these kinds of connection types, ⇢⇣ means virtual arm, →↓ means solid arm.
+     *     ⇣        ⇣          ⇣         ⇣        ↓
+     *    ⇢ →      → →        → ⇢       → →      ⇢ →
+     *     ↓        ⇣          ↓         ↓        ⇣
+     *   type=3    type=5    type=6    type=7    type=9
+     *
+     *     ↓        ↓          ↓         ↓          ↓
+     *    ⇢ ⇢      ⇢ →        → ⇢       → →        → ⇢
+     *     ↓        ↓          ⇣         ⇣          ↓
+     *   type=10  type=11    type=12    type=13   type=14
+     *
+     *     ↓        ⇣
+     *    → →      ⇢ ⇢
+     *     ↓        ⇣
+     *   type=15  type=0
+     *
+     *   For each connection type, we may create new arc, ,
+     *   Depending on the connection type, we may do the following things:
+     *       1. Create new arc. If the arc is closed to the inner polygon, it is called "Inner Arc", otherwise "Outer Arc"
+     *       2. Pass an arc to the next arm.
+     *       3. "Close" two arcs. If two arcs meet at the bottom right corner of a cell, close them by recording the arc connection.
+     *       4. Add grid position(row, col) to an arc.
+     */
+
+    switch (nArmConnectionType)
+    {
+        case 0:
+            // nothing to do
+            break;
+
+        case 3:
+            // add inner arcs
+            poCurrent->oArcVerInner = poCurrent->poPolyInside->newArc(true);
+            poCurrent->oArcHorInner = poCurrent->poPolyInside->newArc(false);
+            poCurrent->poPolyInside->setArcConnection(poCurrent->oArcHorInner,
+                                                      poCurrent->oArcVerInner);
+            poCurrent->oArcVerInner.poArc->emplace_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            // add outer arcs
+            poCurrent->oArcHorOuter = poAbove->poPolyInside->newArc(true);
+            poCurrent->oArcVerOuter = poAbove->poPolyInside->newArc(false);
+            poAbove->poPolyInside->setArcConnection(poCurrent->oArcVerOuter,
+                                                    poCurrent->oArcHorOuter);
+            poCurrent->oArcHorOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            break;
+        case 5:
+            // pass arcs
+            poCurrent->oArcHorInner = poLeft->oArcHorInner;
+            poCurrent->oArcHorOuter = poLeft->oArcHorOuter;
+
+            break;
+        case 6:
+            // pass arcs
+            poCurrent->oArcVerInner = poLeft->oArcHorOuter;
+            poCurrent->oArcVerOuter = poLeft->oArcHorInner;
+            poCurrent->oArcVerInner.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+            poCurrent->oArcVerOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            break;
+        case 7:
+            // pass arcs
+            poCurrent->oArcHorOuter = poLeft->oArcHorOuter;
+            poCurrent->oArcVerOuter = poLeft->oArcHorInner;
+            poLeft->oArcHorInner.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            // add inner arcs
+            poCurrent->oArcVerInner = poCurrent->poPolyInside->newArc(true);
+            poCurrent->oArcHorInner = poCurrent->poPolyInside->newArc(false);
+            poCurrent->poPolyInside->setArcConnection(poCurrent->oArcHorInner,
+                                                      poCurrent->oArcVerInner);
+            poCurrent->oArcVerInner.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            break;
+        case 9:
+            // pass arcs
+            poCurrent->oArcHorOuter = poAbove->oArcVerInner;
+            poCurrent->oArcHorInner = poAbove->oArcVerOuter;
+            poCurrent->oArcHorOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+            poCurrent->oArcHorInner.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            break;
+        case 10:
+            // pass arcs
+            poCurrent->oArcVerInner = poAbove->oArcVerInner;
+            poCurrent->oArcVerOuter = poAbove->oArcVerOuter;
+
+            break;
+        case 11:
+            // pass arcs
+            poCurrent->oArcHorOuter = poAbove->oArcVerInner;
+            poCurrent->oArcVerOuter = poAbove->oArcVerOuter;
+            poCurrent->oArcHorOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+            // add inner arcs
+            poCurrent->oArcVerInner = poCurrent->poPolyInside->newArc(true);
+            poCurrent->oArcHorInner = poCurrent->poPolyInside->newArc(false);
+            poCurrent->poPolyInside->setArcConnection(poCurrent->oArcHorInner,
+                                                      poCurrent->oArcVerInner);
+            poCurrent->oArcVerInner.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            break;
+        case 12:
+            // close arcs
+            poLeft->oArcHorOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+            poLeft->poPolyAbove->setArcConnection(poLeft->oArcHorOuter,
+                                                  poAbove->oArcVerOuter);
+            // close arcs
+            poAbove->oArcVerInner.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+            poCurrent->poPolyInside->setArcConnection(poAbove->oArcVerInner,
+                                                      poLeft->oArcHorInner);
+
+            break;
+        case 13:
+            // close arcs
+            poLeft->oArcHorOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+            poLeft->poPolyAbove->setArcConnection(poLeft->oArcHorOuter,
+                                                  poAbove->oArcVerOuter);
+            // pass arcs
+            poCurrent->oArcHorOuter = poAbove->oArcVerInner;
+            poCurrent->oArcHorInner = poLeft->oArcHorInner;
+            poCurrent->oArcHorOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            break;
+        case 14:
+            // close arcs
+            poLeft->oArcHorOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+            poLeft->poPolyAbove->setArcConnection(poLeft->oArcHorOuter,
+                                                  poAbove->oArcVerOuter);
+            // pass arcs
+            poCurrent->oArcVerInner = poAbove->oArcVerInner;
+            poCurrent->oArcVerOuter = poLeft->oArcHorInner;
+            poCurrent->oArcVerOuter.poArc->push_back(
+                Point{poCurrent->iRow, poCurrent->iCol});
+
+            break;
+        case 15:
+            // Tow pixels of the main diagonal belong to the same polygon
+            if (poAbove->poPolyLeft == poCurrent->poPolyInside)
+            {
+                // pass arcs
+                poCurrent->oArcVerInner = poLeft->oArcHorOuter;
+                poCurrent->oArcHorInner = poAbove->oArcVerOuter;
+                poCurrent->oArcVerInner.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+                poCurrent->oArcHorInner.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+            }
+            else
+            {
+                // close arcs
+                poLeft->oArcHorOuter.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+                poLeft->poPolyAbove->setArcConnection(poLeft->oArcHorOuter,
+                                                      poAbove->oArcVerOuter);
+                // add inner arcs
+                poCurrent->oArcVerInner = poCurrent->poPolyInside->newArc(true);
+                poCurrent->oArcHorInner =
+                    poCurrent->poPolyInside->newArc(false);
+                poCurrent->poPolyInside->setArcConnection(
+                    poCurrent->oArcHorInner, poCurrent->oArcVerInner);
+                poCurrent->oArcVerInner.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+            }
+
+            // Tow pixels of the secondary diagonal belong to the same polygon
+            if (poAbove->poPolyInside == poLeft->poPolyInside)
+            {
+                // close arcs
+                poAbove->poPolyInside->setArcConnection(poAbove->oArcVerInner,
+                                                        poLeft->oArcHorInner);
+                poAbove->oArcVerInner.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+                // add outer arcs
+                poCurrent->oArcHorOuter = poAbove->poPolyInside->newArc(true);
+                poCurrent->oArcVerOuter = poAbove->poPolyInside->newArc(false);
+                poCurrent->oArcHorOuter.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+                poAbove->poPolyInside->setArcConnection(
+                    poCurrent->oArcVerOuter, poCurrent->oArcHorOuter);
+            }
+            else
+            {
+                // pass arcs
+                poCurrent->oArcHorOuter = poAbove->oArcVerInner;
+                poCurrent->oArcVerOuter = poLeft->oArcHorInner;
+                poCurrent->oArcHorOuter.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+                poCurrent->oArcVerOuter.poArc->push_back(
+                    Point{poCurrent->iRow, poCurrent->iCol});
+            }
+
+            break;
+
+        default:
+            break;
+    }
+}
+
+template <typename PolyIdType, typename DataType>
+Polygonizer<PolyIdType, DataType>::Polygonizer(
+    PolygonReceiver<DataType> *poPolygonReceiver)
+    : poPolygonReceiver_(poPolygonReceiver)
+{
+    poTheOuterPolygon_ = createPolygon(THE_OUTER_POLYGON_ID);
+}
+
+template <typename PolyIdType, typename DataType>
+Polygonizer<PolyIdType, DataType>::~Polygonizer()
+{
+    for (auto &pair : oPolygonMap_)
+    {
+        delete pair.second;
+    }
+}
+
+template <typename PolyIdType, typename DataType>
+RPolygon *Polygonizer<PolyIdType, DataType>::getPolygon(PolyIdType nPolygonId)
+{
+    if (oPolygonMap_.count(nPolygonId) == 0)
+    {
+        return createPolygon(nPolygonId);
+    }
+    else
+    {
+        return oPolygonMap_[nPolygonId];
+    }
+}
+
+template <typename PolyIdType, typename DataType>
+RPolygon *
+Polygonizer<PolyIdType, DataType>::createPolygon(PolyIdType nPolygonId)
+{
+    auto polygon = new RPolygon();
+    oPolygonMap_[nPolygonId] = polygon;
+    return polygon;
+}
+
+template <typename PolyIdType, typename DataType>
+void Polygonizer<PolyIdType, DataType>::destroyPolygon(PolyIdType nPolygonId)
+{
+    delete oPolygonMap_[nPolygonId];
+    oPolygonMap_.erase(nPolygonId);
+}
+
+template <typename PolyIdType, typename DataType>
+void Polygonizer<PolyIdType, DataType>::processLine(
+    const PolyIdType *panThisLineId, const DataType *panLastLineVal,
+    const GByte *pabyLastLineValMask, TwoArm *poThisLineArm,
+    TwoArm *poLastLineArm, const IndexType nCurrentRow, const IndexType nCols)
+{
+    TwoArm *poCurrent, *poAbove, *poLeft;
+
+    poCurrent = poThisLineArm + 1;
+    poCurrent->iRow = nCurrentRow;
+    poCurrent->iCol = 0;
+    poCurrent->poPolyInside = getPolygon(panThisLineId[0]);
+    poAbove = poLastLineArm + 1;
+    poLeft = poThisLineArm;
+    poLeft->poPolyInside = poTheOuterPolygon_;
+    ProcessArmConnections(poCurrent, poAbove, poLeft);
+    for (IndexType col = 1; col < nCols; ++col)
+    {
+        IndexType iArmIndex = col + 1;
+        poCurrent = poThisLineArm + iArmIndex;
+        poCurrent->iRow = nCurrentRow;
+        poCurrent->iCol = col;
+        poCurrent->poPolyInside = getPolygon(panThisLineId[col]);
+        poAbove = poLastLineArm + iArmIndex;
+        poLeft = poThisLineArm + iArmIndex - 1;
+        ProcessArmConnections(poCurrent, poAbove, poLeft);
+    }
+    poCurrent = poThisLineArm + nCols + 1;
+    poCurrent->iRow = nCurrentRow;
+    poCurrent->iCol = nCols;
+    poCurrent->poPolyInside = poTheOuterPolygon_;
+    poAbove = poLastLineArm + nCols + 1;
+    poAbove->poPolyInside = poTheOuterPolygon_;
+    poLeft = poThisLineArm + nCols;
+    ProcessArmConnections(poCurrent, poAbove, poLeft);
+
+    /**
+     *
+     * Find those polygons haven't been processed on this line as we can be sure they are completed
+     *
+     */
+    std::vector<PolygonMapEntry> oCompletedPolygons;
+    for (auto &entry : oPolygonMap_)
+    {
+        RPolygon *poPolygon = entry.second;
+
+        if (poPolygon->iBottomRightRow == nCurrentRow - 1)
+        {
+            oCompletedPolygons.push_back(entry);
+        }
+    }
+    for (auto &entry : oCompletedPolygons)
+    {
+        PolyIdType nPolyId = entry.first;
+        RPolygon *poPolygon = entry.second;
+
+        // emit valid polygon only
+        if (pabyLastLineValMask[poPolygon->iBottomRightCol])
+        {
+            poPolygonReceiver_->receive(
+                poPolygon, panLastLineVal[poPolygon->iBottomRightCol]);
+        }
+
+        destroyPolygon(nPolyId);
+    }
+}
+
+template <typename DataType>
+OGRPolygonWriter<DataType>::OGRPolygonWriter(OGRLayerH hOutLayer,
+                                             int iPixValField,
+                                             double *padfGeoTransform)
+    : PolygonReceiver<DataType>(), hOutLayer_(hOutLayer),
+      iPixValField_(iPixValField), padfGeoTransform_(padfGeoTransform)
+{
+}
+
+template <typename DataType>
+void OGRPolygonWriter<DataType>::receive(RPolygon *poPolygon,
+                                         DataType nPolygonCellValue)
+{
+    std::vector<bool> oAccessedArc(poPolygon->oArcConnections.size(), false);
+    double *padfGeoTransform = padfGeoTransform_;
+
+    OGRGeometryH hPolygon = OGR_G_CreateGeometry(wkbPolygon);
+
+    auto AddRingToPolygon = [&poPolygon, &oAccessedArc, &hPolygon,
+                             padfGeoTransform](std::size_t iFirstArcIndex)
+    {
+        OGRGeometryH hRing = OGR_G_CreateGeometry(wkbLinearRing);
+
+        auto AddArcToRing =
+            [&poPolygon, &hRing, padfGeoTransform](std::size_t iArcIndex)
+        {
+            auto oArc = poPolygon->oArcs[iArcIndex];
+            bool bArcFollowRighthand =
+                poPolygon->oArcRighthandFollow[iArcIndex];
+            for (std::size_t i = 0; i < oArc->size(); ++i)
+            {
+                Point &oPixel =
+                    (*oArc)[bArcFollowRighthand ? i : (oArc->size() - i - 1)];
+
+                const double dfX = padfGeoTransform[0] +
+                                   oPixel[1] * padfGeoTransform[1] +
+                                   oPixel[0] * padfGeoTransform[2];
+                const double dfY = padfGeoTransform[3] +
+                                   oPixel[1] * padfGeoTransform[4] +
+                                   oPixel[0] * padfGeoTransform[5];
+
+                OGR_G_AddPoint_2D(hRing, dfX, dfY);
+            }
+        };
+
+        AddArcToRing(iFirstArcIndex);
+
+        std::size_t iArcIndex = iFirstArcIndex;
+        std::size_t iNextArcIndex = poPolygon->oArcConnections[iArcIndex];
+        oAccessedArc[iArcIndex] = true;
+        while (iNextArcIndex != iFirstArcIndex)
+        {
+            AddArcToRing(iNextArcIndex);
+            iArcIndex = iNextArcIndex;
+            iNextArcIndex = poPolygon->oArcConnections[iArcIndex];
+            oAccessedArc[iArcIndex] = true;
+        }
+
+        // close ring manually
+        OGR_G_AddPoint_2D(hRing, OGR_G_GetX(hRing, 0), OGR_G_GetY(hRing, 0));
+
+        OGR_G_AddGeometryDirectly(hPolygon, hRing);
+    };
+
+    std::vector<bool>::iterator ite;
+    while ((ite = std::find_if_not(oAccessedArc.begin(), oAccessedArc.end(),
+                                   [](bool accessed) { return accessed; })) !=
+           oAccessedArc.end())
+    {
+        AddRingToPolygon(ite - oAccessedArc.begin());
+    }
+
+    // Create the feature object
+    OGRFeatureH hFeat = OGR_F_Create(OGR_L_GetLayerDefn(hOutLayer_));
+
+    OGR_F_SetGeometryDirectly(hFeat, hPolygon);
+
+    if (iPixValField_ >= 0)
+        OGR_F_SetFieldDouble(hFeat, iPixValField_, nPolygonCellValue);
+
+    // Write the to the layer.
+    if (OGR_L_CreateFeature(hOutLayer_, hFeat) != OGRERR_NONE)
+        eErr_ = CE_Failure;
+
+    OGR_F_Destroy(hFeat);
+}

--- a/alg/polygonize_polygonizer.h
+++ b/alg/polygonize_polygonizer.h
@@ -1,0 +1,215 @@
+/******************************************************************************
+ * Project:  GDAL
+ * Purpose:  Implements The Two-Arm Chains EdgeTracing Algorithm
+ * Author:   kikitte.lee
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, kikitte.lee <kikitte.lee@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef POLYGONIZE_POLYGONIZER_H_INCLUDED
+#define POLYGONIZE_POLYGONIZER_H_INCLUDED
+
+#include <array>
+#include <vector>
+#include <unordered_map>
+
+#include "cpl_error.h"
+#include "ogr_api.h"
+
+#define THE_OUTER_POLYGON_ID 0
+
+using IndexType = std::uint32_t;
+using Point = std::array<IndexType, 2>;
+using Arc = std::vector<Point>;
+struct IndexedArc
+{
+    Arc *poArc;
+    std::size_t iIndex;
+};
+
+/**
+ * A raster polygon(RPolygon) is formed by a list of arcs in order.
+ * Each arc has two properties:
+ *     1. does the arc follows the right-hand rule respect to the area it bounds
+ *     2. the next arc of the current arc
+ */
+struct RPolygon
+{
+    IndexType iBottomRightRow{0};
+    IndexType iBottomRightCol{0};
+    // arc object list
+    std::vector<Arc *> oArcs{};
+    // does arc follows the right-hand rule with
+    std::vector<bool> oArcRighthandFollow{};
+    // each element is the next arc index of the current arc
+    std::vector<std::size_t> oArcConnections{};
+
+    RPolygon() = default;
+
+    RPolygon(const RPolygon &) = delete;
+
+    RPolygon &operator=(const RPolygon &) = delete;
+
+    ~RPolygon();
+
+    /**
+     * create a new arc object
+     * @param bFollowRighthand
+     * @return
+     */
+    IndexedArc newArc(bool bFollowRighthand);
+
+    /**
+     * set the next arc index of the current arc
+     * @param oArc
+     * @param oNextArc
+     */
+    void setArcConnection(IndexedArc &oArc, IndexedArc &oNextArc);
+
+    /**
+     * update the bottom-right most cell index of the current polygon
+     * @param iRow
+     * @param iCol
+     */
+    void updateBottomRightPos(IndexType iRow, IndexType iCol);
+};
+
+/**
+ * Arm class is used to record the tracings of both arcs and polygons.
+ */
+struct TwoArm
+{
+    IndexType iRow{0};
+    IndexType iCol{0};
+
+    RPolygon *poPolyInside{nullptr};
+    RPolygon *poPolyAbove{nullptr};
+    RPolygon *poPolyLeft{nullptr};
+
+    IndexedArc oArcHorOuter{};
+    IndexedArc oArcHorInner{};
+    IndexedArc oArcVerInner{};
+    IndexedArc oArcVerOuter{};
+
+    bool bSolidHorizontal{false};
+    bool bSolidVertical{false};
+};
+
+/**
+ * Process different kinds of Arm connections.
+ * @param poCurrent
+ * @param poAbove
+ * @param poLeft
+ */
+void ProcessArmConnections(TwoArm *poCurrent, TwoArm *poAbove, TwoArm *poLeft);
+
+template <typename DataType> class PolygonReceiver
+{
+  public:
+    PolygonReceiver() = default;
+
+    PolygonReceiver(const PolygonReceiver<DataType> &) = delete;
+
+    virtual ~PolygonReceiver() = default;
+
+    PolygonReceiver<DataType> &
+    operator=(const PolygonReceiver<DataType> &) = delete;
+
+    virtual void receive(RPolygon *poPolygon, DataType nPolygonCellValue) = 0;
+};
+
+/**
+ * Polygonizer is used to manage polygon memory and do the edge tracing process
+ * @tparam PolyIdType
+ * @tparam DataType
+ */
+template <typename PolyIdType, typename DataType> class Polygonizer
+{
+    using PolygonMap = std::unordered_map<PolyIdType, RPolygon *>;
+    using PolygonMapEntry = typename PolygonMap::value_type;
+
+    RPolygon *poTheOuterPolygon_{nullptr};
+    PolygonMap oPolygonMap_{};
+
+    PolygonReceiver<DataType> *poPolygonReceiver_;
+
+    RPolygon *getPolygon(PolyIdType nPolygonId);
+
+    RPolygon *createPolygon(PolyIdType nPolygonId);
+
+    void destroyPolygon(PolyIdType nPolygonId);
+
+  public:
+    explicit Polygonizer(PolygonReceiver<DataType> *poPolygonReceiver);
+
+    Polygonizer(const Polygonizer<PolyIdType, DataType> &) = delete;
+
+    ~Polygonizer();
+
+    Polygonizer<PolyIdType, DataType> &
+    operator=(const Polygonizer<PolyIdType, DataType> &) = delete;
+
+    RPolygon *getTheOuterPolygon() const
+    {
+        return poTheOuterPolygon_;
+    }
+
+    void processLine(const PolyIdType *panThisLineId,
+                     const DataType *panLastLineVal,
+                     const GByte *pabyLastLineValMask, TwoArm *poThisLineArm,
+                     TwoArm *poLastLineArm, IndexType nCurrentRow,
+                     IndexType nCols);
+};
+
+/**
+ * Write raster polygon object to OGR layer.
+ * @tparam DataType
+ */
+template <typename DataType>
+class OGRPolygonWriter : public PolygonReceiver<DataType>
+{
+    OGRLayerH hOutLayer_;
+    int iPixValField_;
+    double *padfGeoTransform_;
+
+    CPLErr eErr_{CE_None};
+
+  public:
+    OGRPolygonWriter(OGRLayerH hOutLayer, int iPixValField,
+                     double *padfGeoTransform);
+
+    OGRPolygonWriter(const OGRPolygonWriter<DataType> &) = delete;
+
+    ~OGRPolygonWriter() = default;
+
+    OGRPolygonWriter<DataType> &
+    operator=(const OGRPolygonWriter<DataType> &) = delete;
+
+    void receive(RPolygon *poPolygon, DataType nPolygonCellValue) override;
+
+    inline CPLErr getErr()
+    {
+        return eErr_;
+    }
+};
+
+#endif /* POLYGONIZE_POLYGONIZER_H_INCLUDED */

--- a/alg/polygonize_polygonizer.h
+++ b/alg/polygonize_polygonizer.h
@@ -73,22 +73,16 @@ struct RPolygon
 
     /**
      * create a new arc object
-     * @param bFollowRighthand
-     * @return
      */
     IndexedArc newArc(bool bFollowRighthand);
 
     /**
      * set the next arc index of the current arc
-     * @param oArc
-     * @param oNextArc
      */
     void setArcConnection(IndexedArc &oArc, IndexedArc &oNextArc);
 
     /**
      * update the bottom-right most cell index of the current polygon
-     * @param iRow
-     * @param iCol
      */
     void updateBottomRightPos(IndexType iRow, IndexType iCol);
 };
@@ -116,9 +110,6 @@ struct TwoArm
 
 /**
  * Process different kinds of Arm connections.
- * @param poCurrent
- * @param poAbove
- * @param poLeft
  */
 void ProcessArmConnections(TwoArm *poCurrent, TwoArm *poAbove, TwoArm *poLeft);
 
@@ -139,8 +130,6 @@ template <typename DataType> class PolygonReceiver
 
 /**
  * Polygonizer is used to manage polygon memory and do the edge tracing process
- * @tparam PolyIdType
- * @tparam DataType
  */
 template <typename PolyIdType, typename DataType> class Polygonizer
 {
@@ -182,7 +171,6 @@ template <typename PolyIdType, typename DataType> class Polygonizer
 
 /**
  * Write raster polygon object to OGR layer.
- * @tparam DataType
  */
 template <typename DataType>
 class OGRPolygonWriter : public PolygonReceiver<DataType>

--- a/alg/polygonize_polygonizer.h
+++ b/alg/polygonize_polygonizer.h
@@ -29,6 +29,7 @@
 #define POLYGONIZE_POLYGONIZER_H_INCLUDED
 
 #include <array>
+#include <cstdint>
 #include <vector>
 #include <unordered_map>
 

--- a/alg/polygonize_polygonizer.h
+++ b/alg/polygonize_polygonizer.h
@@ -28,6 +28,8 @@
 #ifndef POLYGONIZE_POLYGONIZER_H_INCLUDED
 #define POLYGONIZE_POLYGONIZER_H_INCLUDED
 
+/*! @cond Doxygen_Suppress */
+
 #include <array>
 #include <cstdint>
 #include <vector>
@@ -200,5 +202,7 @@ class OGRPolygonWriter : public PolygonReceiver<DataType>
         return eErr_;
     }
 };
+
+/*! @endcond */
 
 #endif /* POLYGONIZE_POLYGONIZER_H_INCLUDED */

--- a/alg/polygonize_polygonizer_impl.cpp
+++ b/alg/polygonize_polygonizer_impl.cpp
@@ -1,0 +1,9 @@
+#include "polygonize_polygonizer.cpp"
+
+template class Polygonizer<GInt32, std::int64_t>;
+
+template class Polygonizer<GInt32, float>;
+
+template class OGRPolygonWriter<std::int64_t>;
+
+template class OGRPolygonWriter<float>;

--- a/autotest/alg/polygonize.py
+++ b/autotest/alg/polygonize.py
@@ -126,7 +126,25 @@ def test_polygonize_2():
     expected_feature_number = 17
     assert mem_layer.GetFeatureCount() == expected_feature_number
 
-    expect = [132, 115, 123, 107, 132, 140, 115, 148, 123, 132, 132, 140, 102, 101, 100, 103, 156]
+    expect = [
+        132,
+        115,
+        123,
+        107,
+        132,
+        140,
+        115,
+        148,
+        123,
+        132,
+        132,
+        140,
+        102,
+        101,
+        100,
+        103,
+        156,
+    ]
 
     tr = ogrtest.check_features_against_list(mem_layer, "DN", expect)
 
@@ -212,7 +230,24 @@ def test_polygonize_4():
     expected_feature_number = 16
     assert mem_layer.GetFeatureCount() == expected_feature_number
 
-    expect = [132, 115, 123, 107, 140, 115, 148, 123, 132, 140, 132, 102, 101, 100, 103, 156]
+    expect = [
+        132,
+        115,
+        123,
+        107,
+        140,
+        115,
+        148,
+        123,
+        132,
+        140,
+        132,
+        102,
+        101,
+        100,
+        103,
+        156,
+    ]
 
     tr = ogrtest.check_features_against_list(mem_layer, "DN", expect)
 

--- a/autotest/alg/polygonize.py
+++ b/autotest/alg/polygonize.py
@@ -71,7 +71,7 @@ def test_polygonize_1(is_int_polygonize=True):
     expected_feature_number = 13
     assert mem_layer.GetFeatureCount() == expected_feature_number
 
-    expect = [107, 123, 115, 115, 140, 148, 123, 140, 156, 100, 101, 102, 103]
+    expect = [115, 123, 107, 140, 115, 148, 123, 140, 102, 101, 100, 103, 156]
 
     tr = ogrtest.check_features_against_list(mem_layer, "DN", expect)
 
@@ -126,25 +126,7 @@ def test_polygonize_2():
     expected_feature_number = 17
     assert mem_layer.GetFeatureCount() == expected_feature_number
 
-    expect = [
-        107,
-        123,
-        115,
-        132,
-        115,
-        132,
-        140,
-        132,
-        148,
-        123,
-        140,
-        132,
-        156,
-        100,
-        101,
-        102,
-        103,
-    ]
+    expect = [132, 115, 123, 107, 132, 140, 115, 148, 123, 132, 132, 140, 102, 101, 100, 103, 156]
 
     tr = ogrtest.check_features_against_list(mem_layer, "DN", expect)
 
@@ -230,24 +212,7 @@ def test_polygonize_4():
     expected_feature_number = 16
     assert mem_layer.GetFeatureCount() == expected_feature_number
 
-    expect = [
-        107,
-        123,
-        132,
-        115,
-        132,
-        115,
-        140,
-        148,
-        123,
-        140,
-        132,
-        156,
-        100,
-        101,
-        102,
-        103,
-    ]
+    expect = [132, 115, 123, 107, 140, 115, 148, 123, 132, 140, 132, 102, 101, 100, 103, 156]
 
     tr = ogrtest.check_features_against_list(mem_layer, "DN", expect)
 
@@ -284,11 +249,11 @@ def test_polygonize_5():
     expected_feature_number = 3
     assert mem_layer.GetFeatureCount() == expected_feature_number
 
-    expect = [1, 0, 0]
+    expect = [0, 0, 1]
     expect_wkt = [
-        "POLYGON ((0 4,0 0,4 0,4 4,0 4),(1 3,1 2,2 2,2 3,1 3),(2 2,2 1,3 1,3 2,2 2))",
         "POLYGON ((1 3,1 2,2 2,2 3,1 3))",
         "POLYGON ((2 2,2 1,3 1,3 2,2 2))",
+        "POLYGON ((0 4,0 0,4 0,4 4,0 4),(1 3,2 3,2 2,1 2,1 3),(2 2,3 2,3 1,2 1,2 2))",
     ]
 
     idx = 0
@@ -337,7 +302,7 @@ def test_polygonize_6():
     expect_wkt = [
         "POLYGON ((2 3,2 2,3 2,3 3,2 3))",
         "POLYGON ((1 2,1 1,2 1,2 2,1 2))",
-        "POLYGON ((0 4,0 0,4 0,4 4,0 4),(2 3,2 2,3 2,3 3,2 3),(1 2,1 1,2 1,2 2,1 2))",
+        "POLYGON ((0 4,0 0,4 0,4 4,0 4),(2 3,3 3,3 2,2 2,2 3),(1 2,2 2,2 1,1 1,1 2))",
     ]
 
     idx = 0

--- a/autotest/pyscripts/test_gdal_polygonize.py
+++ b/autotest/pyscripts/test_gdal_polygonize.py
@@ -139,7 +139,25 @@ def test_gdal_polygonize_2(script_path):
     expected_feature_number = 17
     assert lyr.GetFeatureCount() == expected_feature_number
 
-    expect = [132, 115, 123, 107, 132, 140, 115, 148, 123, 132, 132, 140, 102, 101, 100, 103, 156]
+    expect = [
+        132,
+        115,
+        123,
+        107,
+        132,
+        140,
+        115,
+        148,
+        123,
+        132,
+        132,
+        140,
+        102,
+        101,
+        100,
+        103,
+        156,
+    ]
 
     tr = ogrtest.check_features_against_list(lyr, "DN", expect)
 

--- a/autotest/pyscripts/test_gdal_polygonize.py
+++ b/autotest/pyscripts/test_gdal_polygonize.py
@@ -85,7 +85,7 @@ def test_gdal_polygonize_1(script_path):
     expected_feature_number = 13
     assert shp_lyr.GetFeatureCount() == expected_feature_number
 
-    expect = [107, 123, 115, 115, 140, 148, 123, 140, 156, 100, 101, 102, 103]
+    expect = [115, 123, 107, 140, 115, 148, 123, 140, 102, 101, 100, 103, 156]
 
     tr = ogrtest.check_features_against_list(shp_lyr, "DN", expect)
 
@@ -139,25 +139,7 @@ def test_gdal_polygonize_2(script_path):
     expected_feature_number = 17
     assert lyr.GetFeatureCount() == expected_feature_number
 
-    expect = [
-        107,
-        123,
-        115,
-        132,
-        115,
-        132,
-        140,
-        132,
-        148,
-        123,
-        140,
-        132,
-        156,
-        100,
-        101,
-        102,
-        103,
-    ]
+    expect = [132, 115, 123, 107, 132, 140, 115, 148, 123, 132, 132, 140, 102, 101, 100, 103, 156]
 
     tr = ogrtest.check_features_against_list(lyr, "DN", expect)
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
This polygonize algorithm does a faster, memory saving, and robust polygonize job. It is an implementation of `The Two-Arm Chains EdgeTracing Algorithm` described in [Junhua Teng, Fahui Wang, Yu Liu, An Efficient Algorithm for Raster-to-Vector Data Conversion](https://doi.org/10.1080/10824000809480639).

Below is the some benefits of this algorithm compared to the original polygonize alg in GDAL:
- Fast
Tested on [OR_NLCD_2011.zip](https://oe.oregonexplorer.info/ExternalContent/SpatialDataforDownload/OR_NLCD_2011.zip), it takes **2:05.05** to finish, the original takes **12:18.47**. Testing script is `time -v gdal_polygonize.py -q nlcd_or_20111.tif nlcd_or_20111_newalg.shp` .

- Robust
This algorithm can handle many special cases gracefully, produce accurate polygon geometry without topology error. And polygons produced by this follow the right-hand rule for orientation (counterclockwise external rings, clockwise internal rings).
- Easy to extend
It is easy to extend this algorithm to do another jobs by deriving the  `PolygonReceiver` base class. For eaxmple, Finding the boundary cells of a raster.
- Less memory usage
The top memory usage is 1017932 kbytes, the original is 1246088 kbytes. 

I share it here and hope it can saving the people's time for raster to vector processing.
