### PR TITLE
fix uclibc build without NPTL

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -110,9 +110,9 @@ else ()
     "
         #define _GNU_SOURCE
         #include <pthread.h>
-        int main() { pthread_spinlock_t spin; return 1; }
+        int main() { pthread_spinlock_t spin; return pthread_spin_lock(&spin); }
         "
-    HAVE_PTHREAD_SPINLOCK)
+    HAVE_PTHREAD_SPIN_LOCK)
 
   check_c_source_compiles(
     "

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -61,8 +61,8 @@
 /* Define to 1 if you have the `PTHREAD_MUTEX_ADAPTIVE_NP' constant. */
 #cmakedefine HAVE_PTHREAD_MUTEX_ADAPTIVE_NP 1
 
-/* Define to 1 if you have the `pthread_spinlock_t' type. */
-#cmakedefine HAVE_PTHREAD_SPINLOCK 1
+/* Define to 1 if you have the `pthread_spin_lock' function. */
+#cmakedefine HAVE_PTHREAD_SPIN_LOCK 1
 
 /* Define to 1 if you have the `pthread_atfork' function. */
 #cmakedefine HAVE_PTHREAD_ATFORK 1

--- a/port/cpl_config.h.in
+++ b/port/cpl_config.h.in
@@ -51,8 +51,8 @@
 /* Define to 1 if you have the `PTHREAD_MUTEX_ADAPTIVE_NP' constant. */
 #undef HAVE_PTHREAD_MUTEX_ADAPTIVE_NP
 
-/* Define to 1 if you have the `pthread_spinlock_t' type. */
-#undef HAVE_PTHREAD_SPINLOCK
+/* Define to 1 if you have the `pthread_spin_lock' function. */
+#undef HAVE_PTHREAD_SPIN_LOCK
 
 /* Define to 1 if you have the 5 args `mremap' function. */
 #undef HAVE_5ARGS_MREMAP

--- a/port/cpl_multiproc.cpp
+++ b/port/cpl_multiproc.cpp
@@ -2232,7 +2232,7 @@ void CPLCleanupTLS()
 /*                          CPLCreateSpinLock()                         */
 /************************************************************************/
 
-#if defined(HAVE_PTHREAD_SPINLOCK)
+#if defined(HAVE_PTHREAD_SPIN_LOCK)
 #define HAVE_SPINLOCK_IMPL
 
 struct _CPLSpinLock
@@ -2310,7 +2310,7 @@ void CPLDestroySpinLock(CPLSpinLock *psSpin)
     pthread_spin_destroy(&(psSpin->spin));
     free(psSpin);
 }
-#endif  // HAVE_PTHREAD_SPINLOCK
+#endif  // HAVE_PTHREAD_SPIN_LOCK
 
 #endif  // def CPL_MULTIPROC_PTHREAD
 


### PR DESCRIPTION
Check for `pthread_spin_lock` instead of `pthread_spin_lock_t` to avoid the following uclibc build failure:

```
/tmp/instance-7/output-1/build/gdal-3.5.2/port/cpl_multiproc.cpp: In function 'CPLSpinLock* CPLCreateSpinLock()': /tmp/instance-7/output-1/build/gdal-3.5.2/port/cpl_multiproc.cpp:2265:9: error: 'pthread_spin_init' was not declared in this scope; did you mean 'pthread_cond_init'?
 2265 |         pthread_spin_init(&(psSpin->spin), PTHREAD_PROCESS_PRIVATE) == 0 )
      |         ^~~~~~~~~~~~~~~~~
      |         pthread_cond_init
/tmp/instance-7/output-1/build/gdal-3.5.2/port/cpl_multiproc.cpp: In function 'int CPLAcquireSpinLock(CPLSpinLock*)':
/tmp/instance-7/output-1/build/gdal-3.5.2/port/cpl_multiproc.cpp:2283:12: error: 'pthread_spin_lock' was not declared in this scope; did you mean 'pthread_spinlock_t'?
 2283 |     return pthread_spin_lock( &(psSpin->spin) ) == 0;
      |            ^~~~~~~~~~~~~~~~~
      |            pthread_spinlock_t

```
Fixes:
 - http://autobuild.buildroot.org/results/aa2a88990a07e551c40efb0c2180768add600c4f