### PR TITLE
[Backport release/3.6] GEOJSON: fix mixed type field not flagged as JSON if first occurrence is a string  (fixes #7313)

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4212,6 +4212,7 @@ def test_ogr_geojson_test_ogrsf():
 @pytest.mark.parametrize(
     "properties",
     [
+        ["a_string", 42.0, {"a_field": "a_value"}],
         ["a_string", 42, {"a_field": "a_value"}],
         ["a_string", {"a_field": "a_value"}, 42],
         [42, "a_string", {"a_field": "a_value"}],

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
@@ -1937,7 +1937,7 @@ void OGRGeoJSONReaderAddOrUpdateField(
                 {
                     poFDefn->SetType(OFTStringList);
                 }
-                else if (eNewType == OFTInteger)
+                else if (eNewType != OFTString)
                 {
                     poFDefn->SetSubType(OFSTJSON);
                 }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
@@ -1934,7 +1934,13 @@ void OGRGeoJSONReaderAddOrUpdateField(
             if (eSubType == OFSTNone)
             {
                 if (eNewType == OFTStringList)
+                {
                     poFDefn->SetType(OFTStringList);
+                }
+                else if (eNewType == OFTInteger)
+                {
+                    poFDefn->SetSubType(OFSTJSON);
+                }
             }
         }
         else if (eType == OFTIntegerList)


### PR DESCRIPTION
Backport #7315
 **Authored by:** @elpaso