### PR TITLE
Doc: Clarify requirements for building vs testing

### DIFF
--- a/doc/source/development/dev_environment.rst
+++ b/doc/source/development/dev_environment.rst
@@ -21,7 +21,7 @@ The minimum requirements to build GDAL are:
 Additional requirements to run the GDAL test suite are:
 
 - SWIG >= 4.0.2, for building bindings to other programming languages
-- Python >= 3.5
+- Python >= 3.6
 - Python packages listed in `autotest/requirements.txt`
 
 A number of optional libraries are also strongly recommended for most builds:

--- a/doc/source/development/dev_environment.rst
+++ b/doc/source/development/dev_environment.rst
@@ -11,14 +11,18 @@ Setting up a development environment
 Build requirements
 --------------------------------------------------------------------------------
 
-The minimum requirements are:
+The minimum requirements to build GDAL are:
 
 - CMake >= 3.10, and an associated build system (make, ninja, Visual Studio, etc.)
 - C99 compiler
 - C++11 compiler
 - PROJ >= 6.0
-- SWIG >= 4.0.2, for building bindings to other programming languages, such as Python
-- Python, for running the test suite
+
+Additional requirements to run the GDAL test suite are:
+
+- SWIG >= 4.0.2, for building bindings to other programming languages
+- Python >= 3.5
+- Python packages listed in `autotest/requirements.txt`
 
 A number of optional libraries are also strongly recommended for most builds:
 SQLite3, expat, libcurl, zlib, libtiff, libgeotiff, libpng, libjpeg, etc.


### PR DESCRIPTION
## What does this PR do?

Clarify build vs test requirements.

The python 3.5 requirement comes from our minimum pytest version, but I am not sure that the tests run with 3.5 (IIRC, the CI is using 3.6). I can look into this.

## What are related issues/pull requests?

#7330

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed