### PR TITLE
ogrinfo: fix -json -so -features parameters behaviour

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -1892,6 +1892,8 @@ GDALVectorInfoOptionsNew(char **papszArgv,
 {
     auto psOptions = cpl::make_unique<GDALVectorInfoOptions>();
     bool bGotFilename = false;
+    bool bFeatures = false;
+    bool bSummary = false;
 
     /* -------------------------------------------------------------------- */
     /*      Parse arguments.                                                */
@@ -2019,11 +2021,11 @@ GDALVectorInfoOptionsNew(char **papszArgv,
         else if (EQUAL(papszArgv[iArg], "-so") ||
                  EQUAL(papszArgv[iArg], "-summary"))
         {
-            psOptions->bSummaryOnly = true;
+            bSummary = true;
         }
         else if (EQUAL(papszArgv[iArg], "-features"))
         {
-            psOptions->bSummaryOnly = false;
+            bFeatures = true;
         }
         else if (STARTS_WITH_CI(papszArgv[iArg], "-fields="))
         {
@@ -2119,6 +2121,18 @@ GDALVectorInfoOptionsNew(char **papszArgv,
             psOptions->bAllLayers = false;
         }
     }
+
+    if (bSummary && bFeatures)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "-so or -summary are incompatible with -features");
+        return nullptr;
+    }
+
+    if (bSummary)
+        psOptions->bSummaryOnly = true;
+    else if (bFeatures)
+        psOptions->bSummaryOnly = false;
 
     if (psOptionsForBinary)
         psOptionsForBinary->osSQLStatement = psOptions->osSQLStatement;


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Currently `ogrinfo -json -features` behaves differently from `ogrinfo -features -json`.

This PR fixes such weird behaviour, so `ogrinfo -json -features` will be the same as `ogrinfo -features -json`. Moreover ogrinfo will fail if both `-so` (or `-summary`) and `-features` parameters are present in the command.

## What are related issues/pull requests?

See https://github.com/OSGeo/gdal/issues/7342#issuecomment-1454046572 and https://github.com/OSGeo/gdal/issues/7342#issuecomment-1454221549

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
