### PR TITLE
[Backport release/3.6] GeoJSON writer: take into account COORDINATE_PRECISION for top bbox (fixes #7319)

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4245,3 +4245,30 @@ def test_ogr_geojson_mixed_type_promotion(properties):
     assert fld_def.GetSubType() == ogr.OFSTJSON
 
     gdal.Unlink(tmpfilename)
+
+
+###############################################################################
+# Test fix for https://github.com/OSGeo/gdal/issues/7319
+
+
+def test_ogr_geojson_coordinate_precision():
+
+    filename = "/vsimem/test_ogr_geojson_coordinate_precision.json"
+    ds = ogr.GetDriverByName("GeoJSON").CreateDataSource(filename)
+    lyr = ds.CreateLayer("foo", options=["COORDINATE_PRECISION=1", "WRITE_BBOX=YES"])
+
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1.23456789 2.3456789)"))
+    lyr.CreateFeature(f)
+
+    ds = None
+
+    fp = gdal.VSIFOpenL(filename, "rb")
+    data = gdal.VSIFReadL(1, 10000, fp).decode("ascii")
+    gdal.VSIFCloseL(fp)
+
+    gdal.Unlink(filename)
+
+    assert '"bbox": [ 1.2, 2.3, 1.2, 2.3 ]' in data
+    assert '"coordinates": [ 1.2, 2.3 ]' in data
+    assert "3456" not in data

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
@@ -86,38 +86,28 @@ OGRGeoJSONWriteLayer::~OGRGeoJSONWriteLayer()
     if (bWriteFC_BBOX && sEnvelopeLayer.IsInit())
     {
         CPLString osBBOX = "[ ";
-        if (bRFC7946_)
-        {
-            char szFormat[32];
+        char szFormat[32];
+        if (nCoordPrecision_ >= 0)
             snprintf(szFormat, sizeof(szFormat), "%%.%df", nCoordPrecision_);
-            osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MinX);
-            osBBOX += ", ";
-            osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MinY);
-            osBBOX += ", ";
-            if (bBBOX3D)
-            {
-                osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MinZ);
-                osBBOX += ", ";
-            }
-            osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MaxX);
-            osBBOX += ", ";
-            osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MaxY);
-            if (bBBOX3D)
-            {
-                osBBOX += ", ";
-                osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MaxZ);
-            }
-        }
         else
+            snprintf(szFormat, sizeof(szFormat), "%s", "%.15g");
+
+        osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MinX);
+        osBBOX += ", ";
+        osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MinY);
+        osBBOX += ", ";
+        if (bBBOX3D)
         {
-            osBBOX += CPLSPrintf("%.15g, ", sEnvelopeLayer.MinX);
-            osBBOX += CPLSPrintf("%.15g, ", sEnvelopeLayer.MinY);
-            if (bBBOX3D)
-                osBBOX += CPLSPrintf("%.15g, ", sEnvelopeLayer.MinZ);
-            osBBOX += CPLSPrintf("%.15g, ", sEnvelopeLayer.MaxX);
-            osBBOX += CPLSPrintf("%.15g", sEnvelopeLayer.MaxY);
-            if (bBBOX3D)
-                osBBOX += CPLSPrintf(", %.15g", sEnvelopeLayer.MaxZ);
+            osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MinZ);
+            osBBOX += ", ";
+        }
+        osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MaxX);
+        osBBOX += ", ";
+        osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MaxY);
+        if (bBBOX3D)
+        {
+            osBBOX += ", ";
+            osBBOX += CPLSPrintf(szFormat, sEnvelopeLayer.MaxZ);
         }
         osBBOX += " ]";
 


### PR DESCRIPTION
Backport #7337
 **Authored by:** @rouault