### PR TITLE
gdal_polygonize.py: use transactions to speed-up writing

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
@@ -158,9 +158,14 @@ def gdal_polygonize(
     else:
         prog_func = gdal.TermProgress_nocb
 
+    dst_layer.StartTransaction()
     result = gdal.Polygonize(
         srcband, maskband, dst_layer, dst_field, options, callback=prog_func
     )
+    if result == gdal.CE_None:
+        dst_layer.CommitTransaction()
+    else:
+        dst_layer.RollbackTransaction()
 
     srcband = None
     src_ds = None


### PR DESCRIPTION
Running ``gdal_polygonize.py GDEM-10km-colorized.tif out.gpkg`` goes from 2m14s to 18s on https://asterweb.jpl.nasa.gov/images/GDEM-10km-colorized.tif
