### PR TITLE
HDF5: add a GDAL_ENABLE_HDF5_GLOBAL_LOCK build option to add a global…

### DIFF
--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -734,6 +734,15 @@ detect the HDF5 library.
 
     Control whether to use HDF5. Defaults to ON when HDF5 is found.
 
+.. option:: GDAL_ENABLE_HDF5_GLOBAL_LOCK=ON/OFF
+
+    Control whether to add a global lock around calls to HDF5 library. This is
+    needed if the HDF5 library is not built with thread-safety enabled and if
+    the HDF5 driver is used in a multi-threaded way. On Unix, a heuristics
+    try to detect if the HDF5 library has been built with thread-safety enabled
+    when linking against a HDF5 library. In other situations, the setting must
+    be manually set when needed.
+
 
 HDFS
 ****

--- a/frmts/hdf5/CMakeLists.txt
+++ b/frmts/hdf5/CMakeLists.txt
@@ -14,6 +14,33 @@ set(SOURCE
 
 add_gdal_driver(TARGET gdal_HDF5 SOURCES ${SOURCE} PLUGIN_CAPABLE)
 
+if(NOT DEFINED GDAL_ENABLE_HDF5_GLOBAL_LOCK AND UNIX AND
+   (HDF5_C_LIBRARIES MATCHES ".so" OR HDF5_C_LIBRARIES MATCHES ".dylib"))
+  # We try to infer if the HDF5 library is built with thread-safe support
+  # by checking if it links against pthread
+  include(CheckCSourceRuns)
+  include(CMakePushCheckState)
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES "${HDF5_C_LIBRARIES}")
+  check_c_source_runs(
+      "
+      #include <pthread.h>
+      int main()
+      {
+          pthread_cancel(0);
+          return 0;
+      }
+      "
+      HDF5_LINKS_TO_PTHREAD)
+  cmake_pop_check_state()
+  if (NOT HDF5_LINKS_TO_PTHREAD)
+    message(WARNING "HDF5 library does not seem to have thread-safety enabled. Adding a global lock on GDAL side")
+    target_compile_definitions(gdal_HDF5 PRIVATE -DENABLE_HDF5_GLOBAL_LOCK)
+  endif()
+elseif(GDAL_ENABLE_HDF5_GLOBAL_LOCK)
+  target_compile_definitions(gdal_HDF5 PRIVATE -DENABLE_HDF5_GLOBAL_LOCK)
+endif()
+
 # When build as plugin, initialize all drivers from Register_HDF5
 if (GDAL_ENABLE_DRIVER_HDF5_PLUGIN)
   target_compile_definitions(gdal_HDF5 PRIVATE -DHDF5_PLUGIN)

--- a/frmts/hdf5/bagdataset.cpp
+++ b/frmts/hdf5/bagdataset.cpp
@@ -423,6 +423,8 @@ BAGRasterBand::BAGRasterBand(BAGDataset *poDSIn, int nBandIn)
 
 BAGRasterBand::~BAGRasterBand()
 {
+    HDF5_GLOBAL_LOCK();
+
     if (eAccess == GA_Update)
     {
         CreateDatasetIfNeeded();
@@ -740,6 +742,8 @@ CPLErr BAGRasterBand::SetNoDataValue(double dfNoData)
 /************************************************************************/
 CPLErr BAGRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pImage)
 {
+    HDF5_GLOBAL_LOCK();
+
     if (!CreateDatasetIfNeeded())
         return CE_Failure;
 
@@ -824,6 +828,8 @@ CPLErr BAGRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pImage)
 
 CPLErr BAGRasterBand::IWriteBlock(int nBlockXOff, int nBlockYOff, void *pImage)
 {
+    HDF5_GLOBAL_LOCK();
+
     if (!CreateDatasetIfNeeded())
         return CE_Failure;
 
@@ -939,6 +945,8 @@ BAGSuperGridBand::~BAGSuperGridBand() = default;
 
 CPLErr BAGSuperGridBand::IReadBlock(int, int nBlockYOff, void *pImage)
 {
+    HDF5_GLOBAL_LOCK();
+
     BAGDataset *poGDS = cpl::down_cast<BAGDataset *>(poDS);
     H5OFFSET_TYPE offset[2] = {
         static_cast<H5OFFSET_TYPE>(0),
@@ -1103,6 +1111,8 @@ double BAGResampledBand::GetMaximum(int *pbSuccess)
 CPLErr BAGResampledBand::IReadBlock(int nBlockXOff, int nBlockYOff,
                                     void *pImage)
 {
+    HDF5_GLOBAL_LOCK();
+
     BAGDataset *poGDS = cpl::down_cast<BAGDataset *>(poDS);
 #ifdef DEBUG_VERBOSE
     CPLDebug(
@@ -1644,6 +1654,8 @@ BAGGeorefMDBand::BAGGeorefMDBand(const std::shared_ptr<GDALMDArray> &poValues,
 
 CPLErr BAGGeorefMDBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pImage)
 {
+    HDF5_GLOBAL_LOCK();
+
     if (m_poKeys)
     {
         const GUInt64 arrayStartIdx[2] = {
@@ -1960,6 +1972,8 @@ GDALDataset *BAGDataset::Open(GDALOpenInfo *poOpenInfo)
     // Confirm that this appears to be a BAG file.
     if (!Identify(poOpenInfo))
         return nullptr;
+
+    HDF5_GLOBAL_LOCK();
 
     if (poOpenInfo->nOpenFlags & GDAL_OF_MULTIDIM_RASTER)
     {

--- a/frmts/hdf5/hdf5dataset.cpp
+++ b/frmts/hdf5/hdf5dataset.cpp
@@ -49,6 +49,20 @@
 
 constexpr size_t MAX_METADATA_LEN = 32768;
 
+#ifdef ENABLE_HDF5_GLOBAL_LOCK
+
+/************************************************************************/
+/*                          GetHDF5GlobalMutex()                        */
+/************************************************************************/
+
+std::recursive_mutex &GetHDF5GlobalMutex()
+{
+    static std::recursive_mutex oMutex;
+    return oMutex;
+}
+
+#endif
+
 /************************************************************************/
 /*                          HDF5GetFileDriver()                         */
 /************************************************************************/
@@ -130,6 +144,8 @@ HDF5Dataset::HDF5Dataset()
 /************************************************************************/
 HDF5Dataset::~HDF5Dataset()
 {
+    HDF5_GLOBAL_LOCK();
+
     CSLDestroy(papszMetadata);
     if (hGroupID > 0)
         H5Gclose(hGroupID);
@@ -516,6 +532,8 @@ GDALDataset *HDF5Dataset::Open(GDALOpenInfo *poOpenInfo)
 {
     if (!Identify(poOpenInfo))
         return nullptr;
+
+    HDF5_GLOBAL_LOCK();
 
     if (poOpenInfo->nOpenFlags & GDAL_OF_MULTIDIM_RASTER)
     {

--- a/frmts/hdf5/hdf5dataset.h
+++ b/frmts/hdf5/hdf5dataset.h
@@ -37,6 +37,18 @@
 #include "cpl_list.h"
 #include "gdal_pam.h"
 
+#ifdef ENABLE_HDF5_GLOBAL_LOCK
+#include <mutex>
+std::recursive_mutex &GetHDF5GlobalMutex();
+#define HDF5_GLOBAL_LOCK()                                                     \
+    std::lock_guard<std::recursive_mutex> oLock(GetHDF5GlobalMutex())
+#else
+#define HDF5_GLOBAL_LOCK()                                                     \
+    do                                                                         \
+    {                                                                          \
+    } while (0)
+#endif
+
 typedef struct HDF5GroupObjects
 {
     char *pszName;

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -184,6 +184,8 @@ HDF5ImageDataset::HDF5ImageDataset()
 /************************************************************************/
 HDF5ImageDataset::~HDF5ImageDataset()
 {
+    HDF5_GLOBAL_LOCK();
+
     FlushCache(true);
 
     if (dataset_id > 0)
@@ -319,6 +321,8 @@ double HDF5ImageRasterBand::GetNoDataValue(int *pbSuccess)
 CPLErr HDF5ImageRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
                                        void *pImage)
 {
+    HDF5_GLOBAL_LOCK();
+
     HDF5ImageDataset *poGDS = static_cast<HDF5ImageDataset *>(poDS);
 
     memset(pImage, 0,
@@ -417,6 +421,8 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
 {
     if (!STARTS_WITH_CI(poOpenInfo->pszFilename, "HDF5:"))
         return nullptr;
+
+    HDF5_GLOBAL_LOCK();
 
     // Confirm the requested access is supported.
     if (poOpenInfo->eAccess == GA_Update)


### PR DESCRIPTION
… lock when the HDF5 library is not built with thread-safety enabled (fixes #7340)

```
.. option:: GDAL_ENABLE_HDF5_GLOBAL_LOCK=ON/OFF

    Control whether to add a global lock around calls to HDF5 library. This is
    needed if the HDF5 library is not built with thread-safety enabled and if
    the HDF5 driver is used in a multi-threaded way. On Unix, a heuristics
    try to detect if the HDF5 library has been built with thread-safety enabled
    when linking against a HDF5 library. In other situations, the setting must
    be manually set when needed.
```
