### PR TITLE
[Backport release/3.6] FindCryptoPP.cmake: properly take into account _LIBRARY_RELEASE/_DEBUG (fixes #7338)

### DIFF
--- a/cmake/modules/packages/FindCryptoPP.cmake
+++ b/cmake/modules/packages/FindCryptoPP.cmake
@@ -78,7 +78,20 @@ if(CRYPTOPP_FOUND)
         add_library(CRYPTOPP::CRYPTOPP UNKNOWN IMPORTED)
         set_target_properties(CRYPTOPP::CRYPTOPP PROPERTIES
                               INTERFACE_INCLUDE_DIRECTORIES "${CRYPTOPP_INCLUDE_DIR}"
-                              IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-                              IMPORTED_LOCATION "${CRYPTOPP_LIBRARY}")
+                              IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+        if(CRYPTOPP_LIBRARY_RELEASE)
+            set_property(TARGET CRYPTOPP::CRYPTOPP APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(CRYPTOPP::CRYPTOPP PROPERTIES
+                    IMPORTED_LOCATION_RELEASE "${CRYPTOPP_LIBRARY_RELEASE}")
+        endif()
+
+        if(CRYPTOPP_LIBRARY_DEBUG)
+            set_property(TARGET CRYPTOPP::CRYPTOPP APPEND PROPERTY
+                    IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(CRYPTOPP::CRYPTOPP PROPERTIES
+                    IMPORTED_LOCATION_DEBUG "${CRYPTOPP_LIBRARY_DEBUG}")
+        endif()
    endif()
 endif()

--- a/cmake/modules/packages/FindDeflate.cmake
+++ b/cmake/modules/packages/FindDeflate.cmake
@@ -107,10 +107,5 @@ if(Deflate_FOUND)
             set_target_properties(Deflate::Deflate PROPERTIES
                     IMPORTED_LOCATION_DEBUG "${Deflate_LIBRARY_DEBUG}")
         endif()
-
-        if(NOT Deflate_LIBRARY_RELEASE AND NOT Deflate_LIBRARY_DEBUG)
-            set_target_properties(Deflate::Deflate PROPERTIES
-                    IMPORTED_LOCATION_RELEASE "${Deflate_LIBRARY}")
-        endif()
     endif()
 endif()


### PR DESCRIPTION
Backport #7355
 **Authored by:** @rouault