### PR TITLE
[Backport release/3.6] FindPoppler.cmake: check that Poppler private headers are available (fixes #7352)

### DIFF
--- a/cmake/modules/packages/FindPoppler.cmake
+++ b/cmake/modules/packages/FindPoppler.cmake
@@ -135,6 +135,14 @@ find_package_handle_standard_args(Poppler
 mark_as_advanced(Poppler_INCLUDE_DIR Poppler_LIBRARY)
 
 if(Poppler_FOUND)
+  if (NOT EXISTS "${Poppler_INCLUDE_DIR}/Object.h")
+    message(WARNING "Poppler private headers not found. Make sure you build Poppler with -DENABLE_UNSTABLE_API_ABI_HEADERS")
+    unset(Poppler_FOUND)
+    unset(POPPLER_FOUND)
+  endif()
+endif()
+
+if(Poppler_FOUND)
   set(Poppler_INCLUDE_DIRS "${Poppler_INCLUDE_DIR}")
   if(Poppler_INCLUDE_DIR MATCHES ".*/poppler" OR Poppler_INCLUDE_DIR MATCHES ".*\\poppler")
       # poppler/splash/SplashBitmap.h unfortunately has a #include "poppler/GfxState.h"

--- a/doc/source/build_hints.rst
+++ b/doc/source/build_hints.rst
@@ -1477,6 +1477,9 @@ Poppler
 The `Poppler <https://poppler.freedesktop.org/>`_ library is one
 of the possible backends for the :ref:`raster.pdf` driver.
 
+Note that GDAL requires Poppler private headers, that are only installed
+if configuring Poppler with -DENABLE_UNSTABLE_API_ABI_HEADERS.
+
 .. option:: Poppler_INCLUDE_DIR
 
     Path to an include directory with the ``poppler-config.h`` header file.


### PR DESCRIPTION
Backport #7356
 **Authored by:** @rouault