### PR TITLE
[Backport release/3.6] MITAB: Fix a typo at MITABGetCustomDatum serialization

### DIFF
--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -2638,7 +2638,19 @@ def test_ogr_mitab_custom_datum_export():
     sr.SetGeogCS("Custom", "Custom", "Sphere", 6370997.0, 0.0)
     sr.SetTOWGS84(1, 2, 3, 4, 5, 6, 7)
     proj = sr.ExportToMICoordSys()
-    assert proj == "Earth Projection 1, 9999, 12, 1, 2, 3, -4, -5, -6, -7, 0"
+    assert proj == "Earth Projection 1, 9999, 12, 1, 2, 3, -4, -5, -6, 7, 0"
+
+    sr = osr.SpatialReference()
+    sr.ImportFromMICoordSys(proj)
+    assert sr.GetTOWGS84() == (
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+    ), "Wrong ExportToMICoordSys / ImportFromMICoordSys pair"
 
     sr = osr.SpatialReference()
     sr.SetGeogCS("Custom", "Custom", "NWL-9D or WGS-66", 6378145.0, 298.25)
@@ -2647,7 +2659,7 @@ def test_ogr_mitab_custom_datum_export():
     proj = sr.ExportToMICoordSys()
     assert (
         proj
-        == 'Earth Projection 8, 9999, 42, 1, 2, 3, -4, -5, -6, -7, 0, "m", 15, 0, 0.9996, 500000, 0'
+        == 'Earth Projection 8, 9999, 42, 1, 2, 3, -4, -5, -6, 7, 0, "m", 15, 0, 0.9996, 500000, 0'
     )
 
 

--- a/ogr/ogrsf_frmts/mitab/mitab_spatialref.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_spatialref.cpp
@@ -1506,7 +1506,7 @@ static int MITABGetCustomDatum(const OGRSpatialReference *poSpatialRef,
     sTABProj.adDatumParams[0] = -adfTOWGS[3];
     sTABProj.adDatumParams[1] = -adfTOWGS[4];
     sTABProj.adDatumParams[2] = -adfTOWGS[5];
-    sTABProj.adDatumParams[3] = -adfTOWGS[6];
+    sTABProj.adDatumParams[3] = adfTOWGS[6];
 
     int nSpheroidId = -1;
 


### PR DESCRIPTION
Backport #7365
 **Authored by:** @drons