### PR TITLE
Fix spelling errors.

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbindex.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbindex.cpp
@@ -2235,7 +2235,7 @@ bool FileGDBSpatialIndexIteratorImpl::Init()
             if (bReferenceOtherPages)
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
-                         "Cannot use %s as the index depth(=1) is suspicous "
+                         "Cannot use %s as the index depth(=1) is suspicious "
                          "(it should rather be 2)",
                          pszSpxName);
                 return false;


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * suspicous -> suspicious

It is not present on master due to https://github.com/OSGeo/gdal/commit/9a5080287d6bf77eee21bdab991bc5479f18f346.