### PR TITLE
Pansharpening: require geotransform on panchromatic and multispectral bands

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -25,6 +25,15 @@ MIGRATION GUIDE FROM GDAL 3.6 to GDAL 3.7
   drivers with write support are encouraged to implement it for error
   propagation.
 
+- Pansharpening now requires that panchromatic and multispectral bands have
+  valid geotransform (in early versions, it was assumed in the case of missing
+  geotransform that they covered the same geospatial extent).
+  The undocumented VRT pansharpened MSShiftX and MSShiftY options (and the
+  corresponding C++ GDALPansharpenOptions::dfMSShiftX and dfMSShiftY members)
+  have been removed, due to using the inverted convention as one would expect,
+  and being sub-par solution compared to using geotransform to correlate pixels
+  of panchromatic and multispectral bands.
+
 MIGRATION GUIDE FROM GDAL 3.5 to GDAL 3.6
 -----------------------------------------
 

--- a/alg/gdalpansharpen.h
+++ b/alg/gdalpansharpen.h
@@ -104,15 +104,6 @@ typedef struct
      * threaded mode is enabled unless the GDAL_NUM_THREADS configuration option
      * is set to an integer or ALL_CPUS. */
     int nThreads;
-
-    /** Shift in pixels of multispectral bands w.r.t panchromatic band, in X
-     * direction */
-    double dfMSShiftX;
-
-    /** Shift in pixels of multispectral bands w.r.t panchromatic band, in Y
-     * direction */
-    double dfMSShiftY;
-
 } GDALPansharpenOptions;
 
 GDALPansharpenOptions CPL_DLL *GDALCreatePansharpenOptions(void);
@@ -135,6 +126,7 @@ CPL_C_END
 
 #ifdef __cplusplus
 
+#include <array>
 #include <vector>
 #include "gdal_priv.h"
 #include "cpl_worker_thread_pool.h"
@@ -204,6 +196,7 @@ class GDALPansharpenOperation
     int bPositiveWeights = TRUE;
     CPLWorkerThreadPool *poThreadPool = nullptr;
     int nKernelRadius = 0;
+    std::array<double, 6> m_adfPanToMSGT = {{0.0, 1.0, 0, 0.0, 0.0, 1.0}};
 
     static void PansharpenJobThreadFunc(void *pUserData);
     static void PansharpenResampleJobThreadFunc(void *pUserData);

--- a/autotest/gdrivers/vrtpansharpen.py
+++ b/autotest/gdrivers/vrtpansharpen.py
@@ -1140,6 +1140,40 @@ def test_vrtpansharpen_3():
 
     vrt_ds = None
 
+    # Now test when the spatial extent of the PAN and MS datasets is different
+    # and we create a in-memory VRT to make them consistent.
+    gdal.Translate(
+        "tmp/small_world_pan_cropped.vrt",
+        "tmp/small_world_pan.tif",
+        options="-srcwin 10 10 780 380",
+    )
+
+    xml = """<VRTDataset subClass="VRTPansharpenedDataset">
+    <PansharpeningOptions>
+        <PanchroBand>
+                <SourceFilename relativeToVRT="1">tmp/small_world_pan_cropped.vrt</SourceFilename>
+                <SourceBand>1</SourceBand>
+        </PanchroBand>
+        <SpectralBand dstBand="1">
+                <SourceFilename relativeToVRT="1">tmp/small_world.tif</SourceFilename>
+                <SourceBand>1</SourceBand>
+        </SpectralBand>
+        <SpectralBand dstBand="2">
+                <SourceFilename relativeToVRT="1">tmp/small_world.tif</SourceFilename>
+                <SourceBand>2</SourceBand>
+        </SpectralBand>
+        <SpectralBand dstBand="3">
+                <SourceFilename relativeToVRT="1">tmp/small_world.tif</SourceFilename>
+                <SourceBand>3</SourceBand>
+        </SpectralBand>
+    </PansharpeningOptions>
+</VRTDataset>"""
+
+    vrt_ds = gdal.Open(xml)
+    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 1
+    vrt_ds = None
+
+    gdal.Unlink("tmp/small_world_pan_cropped.vrt")
     gdal.Unlink("tmp/small_world_pan.tif.ovr")
 
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1486,7 +1486,7 @@ in the computation of the pansharpening, but not exposed as an output band.
 Panchromatic and spectral bands should generally come from different datasets,
 since bands of a GDAL dataset are assumed to have all the same dimensions.
 Spectral bands themselves can come from one or several datasets. The only
-constraint is that they have all the same dimensions.
+constraint is that they have all the same dimensions and geotransform.
 
 An example of a minimalist working VRT is the following. It will generates a dataset with 3 output
 bands corresponding to the 3 input spectral bands of multispectral.tif, pansharpened
@@ -1534,7 +1534,7 @@ the PansharpeningOptions element may have the following children elements :
 - **NumThreads**: Number of worker threads. Integer number or ALL_CPUS. If this option is not set, the :decl_configoption:`GDAL_NUM_THREADS` configuration option will be queried (its value can also be set to an integer or ALL_CPUS)
 - **BitDepth**: Can be used to specify the bit depth of the panchromatic and spectral bands (e.g. 12). If not specified, the NBITS metadata item from the panchromatic band will be used if it exists.
 - **NoData**: Nodata value to take into account for panchromatic and spectral bands. It will be also used as the output nodata value. If not specified and all input bands have the same nodata value, it will be implicitly used (unless the special None value is put in NoData to prevent that).
-- **SpatialExtentAdjustment**: Can be one of **Union** (default), **Intersection**, **None** or **NoneWithoutWarning**. Controls the behavior when panchromatic and spectral bands have not the same geospatial extent. By default, Union will take the union of all spatial extents. Intersection the intersection of all spatial extents. None will not proceed to any adjustment at all (might be useful if the geotransform are somehow dummy, and the top-left and bottom-right corners of all bands match), but will emit a warning. NoneWithoutWarning is the same as None, but in a silent way.
+- **SpatialExtentAdjustment**: Can be one of **Union** (default), **Intersection**, **None** or **NoneWithoutWarning**. Controls the behavior when panchromatic and spectral bands have not the same geospatial extent. By default, Union will take the union of all spatial extents. Intersection the intersection of all spatial extents. None will not proceed to any adjustment at all, but will emit a warning. NoneWithoutWarning is the same as None, but in a silent way.
 
 The below examples creates a VRT dataset with 4 bands. The first band is the
 panchromatic band. The 3 following bands are than red, green, blue pansharpened

--- a/frmts/vrt/vrtpansharpened.cpp
+++ b/frmts/vrt/vrtpansharpened.cpp
@@ -774,7 +774,9 @@ CPLErr VRTPansharpenedDataset::XMLInit(CPLXMLNode *psTree,
             VRTDataset *poVDS =
                 new VRTDataset(nAdjustRasterXSize, nAdjustRasterYSize);
             poVDS->SetWritable(FALSE);
-            poVDS->SetDescription(poSrcDS->GetDescription());
+            poVDS->SetDescription(std::string("Shifted ")
+                                      .append(poSrcDS->GetDescription())
+                                      .c_str());
             poVDS->SetGeoTransform(adfAdjustedGT);
             poVDS->SetProjection(poPanDataset->GetProjectionRef());
 


### PR DESCRIPTION
Pansharpening now requires that panchromatic and multispectral bands have valid geotransform (in early versions, it was assumed in the case of missing geotransform that they covered the same geospatial extent). The undocumented VRT pansharpened MSShiftX and MSShiftY options (and the corresponding C++ GDALPansharpenOptions::dfMSShiftX and dfMSShiftY members) have been removed, due to using the inverted convention as one would expect, and being sub-par solution compared to using geotransform to correlate pixels of panchromatic and multispectral bands.
