### PR TITLE
return const OGRSpatialReference* for a few methods(fixes #7377)

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -37,6 +37,8 @@ MIGRATION GUIDE FROM GDAL 3.6 to GDAL 3.7
 - OGRCoordinateTransformation::GetSourceCS() and GetTargetCS() now returns
   a const OGRSpatialReference*
 
+- OGRGeometry::getSpatialReference() now returns a const OGRSpatialReference*
+
 MIGRATION GUIDE FROM GDAL 3.5 to GDAL 3.6
 -----------------------------------------
 

--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -34,6 +34,9 @@ MIGRATION GUIDE FROM GDAL 3.6 to GDAL 3.7
   and being sub-par solution compared to using geotransform to correlate pixels
   of panchromatic and multispectral bands.
 
+- OGRCoordinateTransformation::GetSourceCS() and GetTargetCS() now returns
+  a const OGRSpatialReference*
+
 MIGRATION GUIDE FROM GDAL 3.5 to GDAL 3.6
 -----------------------------------------
 

--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -39,6 +39,8 @@ MIGRATION GUIDE FROM GDAL 3.6 to GDAL 3.7
 
 - OGRGeometry::getSpatialReference() now returns a const OGRSpatialReference*
 
+- OGRGeomFieldDefn::GetSpatialRef() now returns a const OGRSpatialReference*
+
 MIGRATION GUIDE FROM GDAL 3.5 to GDAL 3.6
 -----------------------------------------
 

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -4362,11 +4362,11 @@ class CutlineTransformer : public OGRCoordinateTransformation
     {
     }
 
-    virtual OGRSpatialReference *GetSourceCS() override
+    virtual const OGRSpatialReference *GetSourceCS() const override
     {
         return nullptr;
     }
-    virtual OGRSpatialReference *GetTargetCS() override
+    virtual const OGRSpatialReference *GetTargetCS() const override
     {
         return nullptr;
     }

--- a/apps/gnmanalyse.cpp
+++ b/apps/gnmanalyse.cpp
@@ -285,7 +285,7 @@ static void ReportOnLayer(OGRLayer *poLayer, int bVerbose)
             {
                 OGRGeomFieldDefn *poGFldDefn =
                     poLayer->GetLayerDefn()->GetGeomFieldDefn(iGeom);
-                OGRSpatialReference *poSRS = poGFldDefn->GetSpatialRef();
+                const OGRSpatialReference *poSRS = poGFldDefn->GetSpatialRef();
                 if (poSRS == nullptr)
                     pszWKT = CPLStrdup("(unknown)");
                 else

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -1083,11 +1083,11 @@ class GCPCoordTransformation : public OGRCoordinateTransformation
             poSRS->Dereference();
     }
 
-    virtual OGRSpatialReference *GetSourceCS() override
+    virtual const OGRSpatialReference *GetSourceCS() const override
     {
         return poSRS;
     }
-    virtual OGRSpatialReference *GetTargetCS() override
+    virtual const OGRSpatialReference *GetTargetCS() const override
     {
         return poSRS;
     }
@@ -1148,14 +1148,14 @@ class CompositeCT : public OGRCoordinateTransformation
         return new CompositeCT(*this);
     }
 
-    virtual OGRSpatialReference *GetSourceCS() override
+    virtual const OGRSpatialReference *GetSourceCS() const override
     {
         return poCT1   ? poCT1->GetSourceCS()
                : poCT2 ? poCT2->GetSourceCS()
                        : nullptr;
     }
 
-    virtual OGRSpatialReference *GetTargetCS() override
+    virtual const OGRSpatialReference *GetTargetCS() const override
     {
         return poCT2   ? poCT2->GetTargetCS()
                : poCT1 ? poCT1->GetTargetCS()
@@ -1235,12 +1235,12 @@ class AxisMappingCoordinateTransformation : public OGRCoordinateTransformation
         return new AxisMappingCoordinateTransformation(*this);
     }
 
-    virtual OGRSpatialReference *GetSourceCS() override
+    virtual const OGRSpatialReference *GetSourceCS() const override
     {
         return nullptr;
     }
 
-    virtual OGRSpatialReference *GetTargetCS() override
+    virtual const OGRSpatialReference *GetTargetCS() const override
     {
         return nullptr;
     }

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -1269,9 +1269,9 @@ class AxisMappingCoordinateTransformation : public OGRCoordinateTransformation
 /************************************************************************/
 
 static void ApplySpatialFilter(OGRLayer *poLayer, OGRGeometry *poSpatialFilter,
-                               OGRSpatialReference *poSpatSRS,
+                               const OGRSpatialReference *poSpatSRS,
                                const char *pszGeomField,
-                               OGRSpatialReference *poSourceSRS)
+                               const OGRSpatialReference *poSourceSRS)
 {
     if (poSpatialFilter == nullptr)
         return;
@@ -1281,7 +1281,7 @@ static void ApplySpatialFilter(OGRLayer *poLayer, OGRGeometry *poSpatialFilter,
     {
         poSpatialFilterReprojected = poSpatialFilter->clone();
         poSpatialFilterReprojected->assignSpatialReference(poSpatSRS);
-        OGRSpatialReference *poSpatialFilterTargetSRS =
+        const OGRSpatialReference *poSpatialFilterTargetSRS =
             poSourceSRS ? poSourceSRS : poLayer->GetSpatialRef();
         if (poSpatialFilterTargetSRS)
         {
@@ -1477,9 +1477,9 @@ GDALVectorTranslateWrappedLayer::New(OGRLayer *poBaseLayer, bool bOwnBaseLayer,
     {
         if (bTransform)
         {
-            OGRSpatialReference *poSourceSRS = poBaseLayer->GetLayerDefn()
-                                                   ->GetGeomFieldDefn(i)
-                                                   ->GetSpatialRef();
+            const OGRSpatialReference *poSourceSRS = poBaseLayer->GetLayerDefn()
+                                                         ->GetGeomFieldDefn(i)
+                                                         ->GetSpatialRef();
             if (poSourceSRS == nullptr)
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
@@ -3835,7 +3835,7 @@ SetupTargetLayer::Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
         }
     }
 
-    OGRSpatialReference *poOutputSRS = m_poOutputSRS;
+    const OGRSpatialReference *poOutputSRS = m_poOutputSRS;
     if (poOutputSRS == nullptr && !m_bNullifyOutputSRS)
     {
         if (nSrcGeomFieldCount == 1 || anRequestedGeomFields.empty())
@@ -4838,13 +4838,12 @@ SetupTargetLayer::Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
 /*                               SetupCT()                              */
 /************************************************************************/
 
-static bool SetupCT(TargetLayerInfo *psInfo, OGRLayer *poSrcLayer,
-                    bool bTransform, bool bWrapDateline,
-                    const CPLString &osDateLineOffset,
-                    OGRSpatialReference *poUserSourceSRS, OGRFeature *poFeature,
-                    OGRSpatialReference *poOutputSRS,
-                    OGRCoordinateTransformation *poGCPCoordTrans,
-                    bool bVerboseError)
+static bool
+SetupCT(TargetLayerInfo *psInfo, OGRLayer *poSrcLayer, bool bTransform,
+        bool bWrapDateline, const CPLString &osDateLineOffset,
+        const OGRSpatialReference *poUserSourceSRS, OGRFeature *poFeature,
+        const OGRSpatialReference *poOutputSRS,
+        OGRCoordinateTransformation *poGCPCoordTrans, bool bVerboseError)
 {
     OGRLayer *poDstLayer = psInfo->m_poDstLayer;
     const int nDstGeomFieldCount =
@@ -5122,7 +5121,7 @@ int LayerTranslator::Translate(OGRFeature *poFeatureIn, TargetLayerInfo *psInfo,
                                GDALVectorTranslateOptions *psOptions)
 {
     const int eGType = m_eGType;
-    OGRSpatialReference *poOutputSRS = m_poOutputSRS;
+    const OGRSpatialReference *poOutputSRS = m_poOutputSRS;
 
     OGRLayer *poSrcLayer = psInfo->m_poSrcLayer;
     OGRLayer *poDstLayer = psInfo->m_poDstLayer;

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -543,8 +543,8 @@ class LayerTranslator
                   void *pProgressArg, GDALVectorTranslateOptions *psOptions);
 
   private:
-    const OGRGeometry *GetDstClipGeom(OGRSpatialReference *poGeomSRS);
-    const OGRGeometry *GetSrcClipGeom(OGRSpatialReference *poGeomSRS);
+    const OGRGeometry *GetDstClipGeom(const OGRSpatialReference *poGeomSRS);
+    const OGRGeometry *GetSrcClipGeom(const OGRSpatialReference *poGeomSRS);
 };
 
 static OGRLayer *GetLayerAndOverwriteIfNecessary(GDALDataset *poDstDS,
@@ -4856,7 +4856,7 @@ static bool SetupCT(TargetLayerInfo *psInfo, OGRLayer *poSrcLayer,
         /*      Setup coordinate transformation if we need it. */
         /* --------------------------------------------------------------------
          */
-        OGRSpatialReference *poSourceSRS = nullptr;
+        const OGRSpatialReference *poSourceSRS = nullptr;
         OGRCoordinateTransformation *poCT = nullptr;
         char **papszTransformOptions = nullptr;
 
@@ -5818,7 +5818,7 @@ int LayerTranslator::Translate(OGRFeature *poFeatureIn, TargetLayerInfo *psInfo,
 /************************************************************************/
 
 const OGRGeometry *
-LayerTranslator::GetDstClipGeom(OGRSpatialReference *poGeomSRS)
+LayerTranslator::GetDstClipGeom(const OGRSpatialReference *poGeomSRS)
 {
     if (m_poClipDstReprojectedToDstSRS_SRS != poGeomSRS)
     {
@@ -5858,7 +5858,7 @@ LayerTranslator::GetDstClipGeom(OGRSpatialReference *poGeomSRS)
 /************************************************************************/
 
 const OGRGeometry *
-LayerTranslator::GetSrcClipGeom(OGRSpatialReference *poGeomSRS)
+LayerTranslator::GetSrcClipGeom(const OGRSpatialReference *poGeomSRS)
 {
     if (m_poClipSrcReprojectedToSrcSRS_SRS != poGeomSRS)
     {

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -861,7 +861,8 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
                         oBbox.Add(oExt.MaxY);
                         oGeometryField.Add("extent", oBbox);
                     }
-                    OGRSpatialReference *poSRS = poGFldDefn->GetSpatialRef();
+                    const OGRSpatialReference *poSRS =
+                        poGFldDefn->GetSpatialRef();
                     if (poSRS)
                     {
                         CPLJSONObject oCRS;
@@ -1064,7 +1065,7 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
             {
                 OGRGeomFieldDefn *poGFldDefn =
                     poLayer->GetLayerDefn()->GetGeomFieldDefn(iGeom);
-                OGRSpatialReference *poSRS = poGFldDefn->GetSpatialRef();
+                const OGRSpatialReference *poSRS = poGFldDefn->GetSpatialRef();
                 char *pszWKT = nullptr;
                 if (poSRS == nullptr)
                 {

--- a/apps/ogrlineref.cpp
+++ b/apps/ogrlineref.cpp
@@ -596,7 +596,7 @@ static OGRErr CreatePartsFromLineString(
     }
 
     double dfTolerance = 1.0;
-    OGRSpatialReference *pSpaRef = pPathGeom->getSpatialReference();
+    const OGRSpatialReference *pSpaRef = pPathGeom->getSpatialReference();
     if (pSpaRef->IsGeographic())
     {
         dfTolerance = TOLERANCE_DEGREE;

--- a/apps/test_ogrsf.cpp
+++ b/apps/test_ogrsf.cpp
@@ -1585,7 +1585,7 @@ static int TestOGRLayerFeatureCount(GDALDataset *poDS, OGRLayer *poLayer,
                        "OLCZGeometries capability!\n");
             }
 
-            OGRSpatialReference *poGFldSRS =
+            const OGRSpatialReference *poGFldSRS =
                 poLayerDefn->GetGeomFieldDefn(iGeom)->GetSpatialRef();
 
             // Compatibility with old drivers anterior to RFC 41

--- a/apps/test_ogrsf.cpp
+++ b/apps/test_ogrsf.cpp
@@ -3634,9 +3634,9 @@ static int TestLayerSQL(GDALDataset *poDS, OGRLayer *poLayer)
                     else if (poLayerFeatGeom != nullptr &&
                              poSQLFeatGeom != nullptr)
                     {
-                        OGRSpatialReference *poLayerFeatSRS =
+                        const OGRSpatialReference *poLayerFeatSRS =
                             poLayerFeatGeom->getSpatialReference();
-                        OGRSpatialReference *poSQLFeatSRS =
+                        const OGRSpatialReference *poSQLFeatSRS =
                             poSQLFeatGeom->getSpatialReference();
                         if (poLayerFeatSRS == nullptr &&
                             poSQLFeatSRS != nullptr)

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -5736,7 +5736,7 @@ const char *NCDFGetProjectedCFUnit(const OGRSpatialReference *poSRS)
 /************************************************************************/
 
 void NCDFWriteXYVarsAttributes(nccfdriver::netCDFVID &vcdf, int nVarXID,
-                               int nVarYID, OGRSpatialReference *poSRS)
+                               int nVarYID, const OGRSpatialReference *poSRS)
 {
     const char *pszUnitsToWrite = NCDFGetProjectedCFUnit(poSRS);
 

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -1170,7 +1170,7 @@ void NCDFWriteLonLatVarsAttributes(nccfdriver::netCDFVID &vcdf, int nVarLonID,
 void NCDFWriteRLonRLatVarsAttributes(nccfdriver::netCDFVID &vcdf,
                                      int nVarRLonID, int nVarRLatID);
 void NCDFWriteXYVarsAttributes(nccfdriver::netCDFVID &vcdf, int nVarXID,
-                               int nVarYID, OGRSpatialReference *poSRS);
+                               int nVarYID, const OGRSpatialReference *poSRS);
 int NCDFWriteSRSVariable(int cdfid, const OGRSpatialReference *poSRS,
                          char **ppszCFProjection, bool bWriteGDALTags,
                          const std::string & = std::string());

--- a/frmts/netcdf/netcdflayer.cpp
+++ b/frmts/netcdf/netcdflayer.cpp
@@ -251,7 +251,7 @@ bool netCDFLayer::Create(char **papszOptions,
         }
     }
 
-    OGRSpatialReference *poSRS = nullptr;
+    const OGRSpatialReference *poSRS = nullptr;
     if (m_poFeatureDefn->GetGeomFieldCount())
         poSRS = m_poFeatureDefn->GetGeomFieldDefn(0)->GetSpatialRef();
 

--- a/frmts/vrt/vrtwarped.cpp
+++ b/frmts/vrt/vrtwarped.cpp
@@ -639,12 +639,12 @@ class GDALWarpCoordRescaler : public OGRCoordinateTransformation
     {
     }
 
-    virtual OGRSpatialReference *GetSourceCS() override
+    virtual const OGRSpatialReference *GetSourceCS() const override
     {
         return nullptr;
     }
 
-    virtual OGRSpatialReference *GetTargetCS() override
+    virtual const OGRSpatialReference *GetTargetCS() const override
     {
         return nullptr;
     }

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -268,7 +268,7 @@ class CPL_DLL OGRGeomFieldDefn
     char *pszName = nullptr;
     OGRwkbGeometryType eGeomType =
         wkbUnknown; /* all values possible except wkbNone */
-    mutable OGRSpatialReference *poSRS = nullptr;
+    mutable const OGRSpatialReference *poSRS = nullptr;
 
     int bIgnore = false;
     mutable int bNullable = true;
@@ -293,7 +293,7 @@ class CPL_DLL OGRGeomFieldDefn
     }
     void SetType(OGRwkbGeometryType eTypeIn);
 
-    virtual OGRSpatialReference *GetSpatialRef() const;
+    virtual const OGRSpatialReference *GetSpatialRef() const;
     void SetSpatialRef(const OGRSpatialReference *poSRSIn);
 
     int IsIgnored() const

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -294,7 +294,7 @@ class CPL_DLL OGRGeomFieldDefn
     void SetType(OGRwkbGeometryType eTypeIn);
 
     virtual OGRSpatialReference *GetSpatialRef() const;
-    void SetSpatialRef(OGRSpatialReference *poSRSIn);
+    void SetSpatialRef(const OGRSpatialReference *poSRSIn);
 
     int IsIgnored() const
     {

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -334,7 +334,7 @@ class CPL_DLL OGRDefaultConstGeometryVisitor : public IOGRConstGeometryVisitor
 class CPL_DLL OGRGeometry
 {
   private:
-    OGRSpatialReference *poSRS = nullptr;  // may be NULL
+    const OGRSpatialReference *poSRS = nullptr;  // may be NULL
 
   protected:
     //! @cond Doxygen_Suppress
@@ -496,14 +496,14 @@ class CPL_DLL OGRGeometry
     virtual void set3D(OGRBoolean bIs3D);
     virtual void setMeasured(OGRBoolean bIsMeasured);
 
-    virtual void assignSpatialReference(OGRSpatialReference *poSR);
-    OGRSpatialReference *getSpatialReference(void) const
+    virtual void assignSpatialReference(const OGRSpatialReference *poSR);
+    const OGRSpatialReference *getSpatialReference(void) const
     {
         return poSRS;
     }
 
     virtual OGRErr transform(OGRCoordinateTransformation *poCT) = 0;
-    OGRErr transformTo(OGRSpatialReference *poSR);
+    OGRErr transformTo(const OGRSpatialReference *poSR);
 
     virtual void segmentize(double dfMaxLength);
 
@@ -2038,7 +2038,8 @@ class CPL_DLL OGRCurveCollection
     void setCoordinateDimension(OGRGeometry *poGeom, int nNewDimension);
     void set3D(OGRGeometry *poGeom, OGRBoolean bIs3D);
     void setMeasured(OGRGeometry *poGeom, OGRBoolean bIsMeasured);
-    void assignSpatialReference(OGRGeometry *poGeom, OGRSpatialReference *poSR);
+    void assignSpatialReference(OGRGeometry *poGeom,
+                                const OGRSpatialReference *poSR);
     int getNumCurves() const;
     OGRCurve *getCurve(int);
     const OGRCurve *getCurve(int) const;
@@ -2188,7 +2189,8 @@ class CPL_DLL OGRCompoundCurve : public OGRCurve
     virtual void set3D(OGRBoolean bIs3D) override;
     virtual void setMeasured(OGRBoolean bIsMeasured) override;
 
-    virtual void assignSpatialReference(OGRSpatialReference *poSR) override;
+    virtual void
+    assignSpatialReference(const OGRSpatialReference *poSR) override;
 
     OGRErr addCurve(const OGRCurve *, double dfToleranceEps = 1e-14);
     OGRErr addCurveDirectly(OGRCurve *, double dfToleranceEps = 1e-14);
@@ -2425,7 +2427,8 @@ class CPL_DLL OGRCurvePolygon : public OGRSurface
     virtual void set3D(OGRBoolean bIs3D) override;
     virtual void setMeasured(OGRBoolean bIsMeasured) override;
 
-    virtual void assignSpatialReference(OGRSpatialReference *poSR) override;
+    virtual void
+    assignSpatialReference(const OGRSpatialReference *poSR) override;
 
     virtual OGRErr addRing(OGRCurve *);
     virtual OGRErr addRingDirectly(OGRCurve *);
@@ -2855,7 +2858,8 @@ class CPL_DLL OGRGeometryCollection : public OGRGeometry
     virtual OGRErr addGeometryDirectly(OGRGeometry *);
     virtual OGRErr removeGeometry(int iIndex, int bDelete = TRUE);
 
-    virtual void assignSpatialReference(OGRSpatialReference *poSR) override;
+    virtual void
+    assignSpatialReference(const OGRSpatialReference *poSR) override;
 
     void closeRings() override;
 
@@ -3328,7 +3332,8 @@ class CPL_DLL OGRPolyhedralSurface : public OGRSurface
         visitor->visit(this);
     }
 
-    virtual void assignSpatialReference(OGRSpatialReference *poSR) override;
+    virtual void
+    assignSpatialReference(const OGRSpatialReference *poSR) override;
 
     OGR_ALLOW_CAST_TO_THIS(PolyhedralSurface)
     OGR_ALLOW_UPCAST_TO(Surface)

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -3939,22 +3939,23 @@ class CPL_DLL OGRGeometryFactory
                                         int *pnBytesConsumed, int nRecLevel);
 
   public:
-    static OGRErr createFromWkb(const void *, OGRSpatialReference *,
+    static OGRErr createFromWkb(const void *, const OGRSpatialReference *,
                                 OGRGeometry **,
                                 size_t = static_cast<size_t>(-1),
                                 OGRwkbVariant = wkbVariantOldOgc);
-    static OGRErr createFromWkb(const void *pabyData, OGRSpatialReference *,
-                                OGRGeometry **, size_t nSize,
-                                OGRwkbVariant eVariant,
+    static OGRErr createFromWkb(const void *pabyData,
+                                const OGRSpatialReference *, OGRGeometry **,
+                                size_t nSize, OGRwkbVariant eVariant,
                                 size_t &nBytesConsumedOut);
-    static OGRErr createFromWkt(const char *, OGRSpatialReference *,
+    static OGRErr createFromWkt(const char *, const OGRSpatialReference *,
                                 OGRGeometry **);
-    static OGRErr createFromWkt(const char **, OGRSpatialReference *,
+    static OGRErr createFromWkt(const char **, const OGRSpatialReference *,
                                 OGRGeometry **);
     /** Deprecated.
      * @deprecated in GDAL 2.3
      */
-    static OGRErr createFromWkt(char **ppszInput, OGRSpatialReference *poSRS,
+    static OGRErr createFromWkt(char **ppszInput,
+                                const OGRSpatialReference *poSRS,
                                 OGRGeometry **ppoGeom)
         CPL_WARN_DEPRECATED("Use createFromWkt(const char**, ...) instead")
     {

--- a/ogr/ogr_spatialref.h
+++ b/ogr/ogr_spatialref.h
@@ -770,10 +770,10 @@ class CPL_DLL OGRCoordinateTransformation
     // From CT_CoordinateTransformation
 
     /** Fetch internal source coordinate system. */
-    virtual OGRSpatialReference *GetSourceCS() = 0;
+    virtual const OGRSpatialReference *GetSourceCS() const = 0;
 
     /** Fetch internal target coordinate system. */
-    virtual OGRSpatialReference *GetTargetCS() = 0;
+    virtual const OGRSpatialReference *GetTargetCS() const = 0;
 
     /** Whether the transformer will emit CPLError */
     virtual bool GetEmitErrors() const

--- a/ogr/ograpispy.cpp
+++ b/ogr/ograpispy.cpp
@@ -1014,7 +1014,8 @@ void OGRAPISpy_L_CreateGeomField(OGRLayerH hLayer, OGRGeomFieldDefnH hField,
     if (poGeomFieldDefn->GetSpatialRef() != nullptr)
         fprintf(fpSpyFile, "geom_fd.SetSpatialRef(%s)\n",
                 OGRAPISpyGetSRS(OGRSpatialReference::ToHandle(
-                                    poGeomFieldDefn->GetSpatialRef()))
+                                    const_cast<OGRSpatialReference *>(
+                                        poGeomFieldDefn->GetSpatialRef())))
                     .c_str());
     if (!poGeomFieldDefn->IsNullable())
         fprintf(fpSpyFile, "geom_fd.SetNullable(0)\n");

--- a/ogr/ogrcompoundcurve.cpp
+++ b/ogr/ogrcompoundcurve.cpp
@@ -395,7 +395,7 @@ void OGRCompoundCurve::setMeasured(OGRBoolean bIsMeasured)
 /*                       assignSpatialReference()                       */
 /************************************************************************/
 
-void OGRCompoundCurve::assignSpatialReference(OGRSpatialReference *poSR)
+void OGRCompoundCurve::assignSpatialReference(const OGRSpatialReference *poSR)
 {
     oCC.assignSpatialReference(this, poSR);
 }

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -754,8 +754,8 @@ class OGRProjCT : public OGRCoordinateTransformation
                    const char *pszTargetSRS,
                    const OGRCoordinateTransformationOptions &options);
 
-    OGRSpatialReference *GetSourceCS() override;
-    OGRSpatialReference *GetTargetCS() override;
+    const OGRSpatialReference *GetSourceCS() const override;
+    const OGRSpatialReference *GetTargetCS() const override;
 
     int Transform(int nCount, double *x, double *y, double *z, double *t,
                   int *pabSuccess) override;
@@ -1096,7 +1096,8 @@ OGRCoordinateTransformationH OCTClone(OGRCoordinateTransformationH hTransform)
  * @return handle to transformation's source coordinate system or NULL if not
  * present.
  *
- * The ownership of the returned CS belongs to the transformation object.
+ * The ownership of the returned SRS belongs to the transformation object, and
+ * the returned SRS should not be modified.
  *
  * @since GDAL 3.4
  */
@@ -1105,8 +1106,8 @@ OGRSpatialReferenceH OCTGetSourceCS(OGRCoordinateTransformationH hTransform)
 
 {
     VALIDATE_POINTER1(hTransform, "OCTGetSourceCS", nullptr);
-    return OGRSpatialReference::ToHandle(
-        OGRCoordinateTransformation::FromHandle(hTransform)->GetSourceCS());
+    return OGRSpatialReference::ToHandle(const_cast<OGRSpatialReference *>(
+        OGRCoordinateTransformation::FromHandle(hTransform)->GetSourceCS()));
 }
 
 /************************************************************************/
@@ -1122,7 +1123,8 @@ OGRSpatialReferenceH OCTGetSourceCS(OGRCoordinateTransformationH hTransform)
  * @return handle to transformation's target coordinate system or NULL if not
  * present.
  *
- * The ownership of the returned CS belongs to the transformation object.
+ * The ownership of the returned SRS belongs to the transformation object, and
+ * the returned SRS should not be modified.
  *
  * @since GDAL 3.4
  */
@@ -1131,8 +1133,8 @@ OGRSpatialReferenceH OCTGetTargetCS(OGRCoordinateTransformationH hTransform)
 
 {
     VALIDATE_POINTER1(hTransform, "OCTGetTargetCS", nullptr);
-    return OGRSpatialReference::ToHandle(
-        OGRCoordinateTransformation::FromHandle(hTransform)->GetTargetCS());
+    return OGRSpatialReference::ToHandle(const_cast<OGRSpatialReference *>(
+        OGRCoordinateTransformation::FromHandle(hTransform)->GetTargetCS()));
 }
 
 /************************************************************************/
@@ -2045,7 +2047,7 @@ bool OGRProjCT::ListCoordinateOperations(
 /*                            GetSourceCS()                             */
 /************************************************************************/
 
-OGRSpatialReference *OGRProjCT::GetSourceCS()
+const OGRSpatialReference *OGRProjCT::GetSourceCS() const
 
 {
     return poSRSSource;
@@ -2055,7 +2057,7 @@ OGRSpatialReference *OGRProjCT::GetSourceCS()
 /*                            GetTargetCS()                             */
 /************************************************************************/
 
-OGRSpatialReference *OGRProjCT::GetTargetCS()
+const OGRSpatialReference *OGRProjCT::GetTargetCS() const
 
 {
     return poSRSTarget;

--- a/ogr/ogrcurvecollection.cpp
+++ b/ogr/ogrcurvecollection.cpp
@@ -635,7 +635,8 @@ OGRErr OGRCurveCollection::transform(OGRGeometry *poGeom,
         }
     }
 
-    poGeom->assignSpatialReference(poCT->GetTargetCS());
+    poGeom->assignSpatialReference(
+        const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
 
     return OGRERR_NONE;
 }

--- a/ogr/ogrcurvecollection.cpp
+++ b/ogr/ogrcurvecollection.cpp
@@ -552,7 +552,7 @@ void OGRCurveCollection::setMeasured(OGRGeometry *poGeom,
 /************************************************************************/
 
 void OGRCurveCollection::assignSpatialReference(OGRGeometry *poGeom,
-                                                OGRSpatialReference *poSR)
+                                                const OGRSpatialReference *poSR)
 {
     for (auto &&poSubGeom : *this)
     {
@@ -635,8 +635,7 @@ OGRErr OGRCurveCollection::transform(OGRGeometry *poGeom,
         }
     }
 
-    poGeom->assignSpatialReference(
-        const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
+    poGeom->assignSpatialReference(poCT->GetTargetCS());
 
     return OGRERR_NONE;
 }

--- a/ogr/ogrcurvepolygon.cpp
+++ b/ogr/ogrcurvepolygon.cpp
@@ -702,7 +702,7 @@ void OGRCurvePolygon::setMeasured(OGRBoolean bIsMeasured)
 /*                       assignSpatialReference()                       */
 /************************************************************************/
 
-void OGRCurvePolygon::assignSpatialReference(OGRSpatialReference *poSR)
+void OGRCurvePolygon::assignSpatialReference(const OGRSpatialReference *poSR)
 {
     oCC.assignSpatialReference(this, poSR);
 }

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -120,7 +120,7 @@ OGRGeometry::OGRGeometry(const OGRGeometry &other)
     : poSRS(other.poSRS), flags(other.flags)
 {
     if (poSRS != nullptr)
-        poSRS->Reference();
+        const_cast<OGRSpatialReference *>(poSRS)->Reference();
 }
 
 /************************************************************************/
@@ -131,7 +131,7 @@ OGRGeometry::~OGRGeometry()
 
 {
     if (poSRS != nullptr)
-        poSRS->Release();
+        const_cast<OGRSpatialReference *>(poSRS)->Release();
 }
 
 /************************************************************************/
@@ -445,8 +445,6 @@ void OGR_G_DumpReadable(OGRGeometryH hGeom, FILE *fp, const char *pszPrefix)
 /************************************************************************/
 
 /**
- * \fn void OGRGeometry::assignSpatialReference( OGRSpatialReference * poSR );
- *
  * \brief Assign spatial reference to this object.
  *
  * Any existing spatial reference
@@ -467,14 +465,14 @@ void OGR_G_DumpReadable(OGRGeometryH hGeom, FILE *fp, const char *pszPrefix)
  * @param poSR new spatial reference system to apply.
  */
 
-void OGRGeometry::assignSpatialReference(OGRSpatialReference *poSR)
+void OGRGeometry::assignSpatialReference(const OGRSpatialReference *poSR)
 
 {
     // Do in that order to properly handle poSR == poSRS
     if (poSR != nullptr)
-        poSR->Reference();
+        const_cast<OGRSpatialReference *>(poSR)->Reference();
     if (poSRS != nullptr)
-        poSRS->Release();
+        const_cast<OGRSpatialReference *>(poSRS)->Release();
 
     poSRS = poSR;
 }
@@ -658,7 +656,7 @@ int OGR_G_Intersect(OGRGeometryH hGeom, OGRGeometryH hOtherGeom)
  * @return OGRERR_NONE on success, or an error code.
  */
 
-OGRErr OGRGeometry::transformTo(OGRSpatialReference *poSR)
+OGRErr OGRGeometry::transformTo(const OGRSpatialReference *poSR)
 
 {
     if (getSpatialReference() == nullptr)
@@ -2074,7 +2072,8 @@ OGRGeometryH OGR_G_Clone(OGRGeometryH hGeom)
  * OGRGeometry::getSpatialReference().
  *
  * @param hGeom handle on the geometry to get spatial reference from.
- * @return a reference to the spatial reference geometry.
+ * @return a reference to the spatial reference geometry, which should not be
+ * modified.
  */
 
 OGRSpatialReferenceH OGR_G_GetSpatialReference(OGRGeometryH hGeom)
@@ -2082,8 +2081,8 @@ OGRSpatialReferenceH OGR_G_GetSpatialReference(OGRGeometryH hGeom)
 {
     VALIDATE_POINTER1(hGeom, "OGR_G_GetSpatialReference", nullptr);
 
-    return OGRSpatialReference::ToHandle(
-        OGRGeometry::FromHandle(hGeom)->getSpatialReference());
+    return OGRSpatialReference::ToHandle(const_cast<OGRSpatialReference *>(
+        OGRGeometry::FromHandle(hGeom)->getSpatialReference()));
 }
 
 /**

--- a/ogr/ogrgeometrycollection.cpp
+++ b/ogr/ogrgeometrycollection.cpp
@@ -969,8 +969,7 @@ OGRErr OGRGeometryCollection::transform(OGRCoordinateTransformation *poCT)
         iGeom++;
     }
 
-    assignSpatialReference(
-        const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
+    assignSpatialReference(poCT->GetTargetCS());
 
     return OGRERR_NONE;
 }
@@ -1128,7 +1127,8 @@ OGRBoolean OGRGeometryCollection::IsEmpty() const
 /*                       assignSpatialReference()                       */
 /************************************************************************/
 
-void OGRGeometryCollection::assignSpatialReference(OGRSpatialReference *poSR)
+void OGRGeometryCollection::assignSpatialReference(
+    const OGRSpatialReference *poSR)
 {
     OGRGeometry::assignSpatialReference(poSR);
     for (auto &&poSubGeom : *this)

--- a/ogr/ogrgeometrycollection.cpp
+++ b/ogr/ogrgeometrycollection.cpp
@@ -969,7 +969,8 @@ OGRErr OGRGeometryCollection::transform(OGRCoordinateTransformation *poCT)
         iGeom++;
     }
 
-    assignSpatialReference(poCT->GetTargetCS());
+    assignSpatialReference(
+        const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
 
     return OGRERR_NONE;
 }

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -102,7 +102,7 @@
  */
 
 OGRErr OGRGeometryFactory::createFromWkb(const void *pabyData,
-                                         OGRSpatialReference *poSR,
+                                         const OGRSpatialReference *poSR,
                                          OGRGeometry **ppoReturn, size_t nBytes,
                                          OGRwkbVariant eWkbVariant)
 
@@ -147,7 +147,7 @@ OGRErr OGRGeometryFactory::createFromWkb(const void *pabyData,
  */
 
 OGRErr OGRGeometryFactory::createFromWkb(const void *pabyData,
-                                         OGRSpatialReference *poSR,
+                                         const OGRSpatialReference *poSR,
                                          OGRGeometry **ppoReturn, size_t nBytes,
                                          OGRwkbVariant eWkbVariant,
                                          size_t &nBytesConsumedOut)
@@ -352,7 +352,7 @@ OGRErr CPL_DLL OGR_G_CreateFromWkbEx(const void *pabyData,
  */
 
 OGRErr OGRGeometryFactory::createFromWkt(const char **ppszData,
-                                         OGRSpatialReference *poSR,
+                                         const OGRSpatialReference *poSR,
                                          OGRGeometry **ppoReturn)
 
 {
@@ -489,7 +489,7 @@ OGRErr OGRGeometryFactory::createFromWkt(const char **ppszData,
  */
 
 OGRErr OGRGeometryFactory::createFromWkt(const char *pszData,
-                                         OGRSpatialReference *poSR,
+                                         const OGRSpatialReference *poSR,
                                          OGRGeometry **ppoReturn)
 
 {

--- a/ogr/ogrgeomfielddefn.cpp
+++ b/ogr/ogrgeomfielddefn.cpp
@@ -481,11 +481,11 @@ OGRSpatialReferenceH OGR_GFld_GetSpatialRef(OGRGeomFieldDefnH hDefn)
  *
  * @since GDAL 1.11
  */
-void OGRGeomFieldDefn::SetSpatialRef(OGRSpatialReference *poSRSIn)
+void OGRGeomFieldDefn::SetSpatialRef(const OGRSpatialReference *poSRSIn)
 {
     if (poSRS != nullptr)
         poSRS->Release();
-    poSRS = poSRSIn;
+    poSRS = const_cast<OGRSpatialReference *>(poSRSIn);
     if (poSRS != nullptr)
         poSRS->Reference();
 }

--- a/ogr/ogrgeomfielddefn.cpp
+++ b/ogr/ogrgeomfielddefn.cpp
@@ -78,10 +78,10 @@ OGRGeomFieldDefn::OGRGeomFieldDefn(const OGRGeomFieldDefn *poPrototype)
 
 {
     Initialize(poPrototype->GetNameRef(), poPrototype->GetType());
-    auto l_poSRS = poPrototype->GetSpatialRef();
-    if (l_poSRS)
+    const OGRSpatialReference *poSRSSrc = poPrototype->GetSpatialRef();
+    if (poSRSSrc)
     {
-        l_poSRS = l_poSRS->Clone();
+        OGRSpatialReference *l_poSRS = poSRSSrc->Clone();
         SetSpatialRef(l_poSRS);
         l_poSRS->Release();
     }
@@ -134,7 +134,7 @@ OGRGeomFieldDefn::~OGRGeomFieldDefn()
     CPLFree(pszName);
 
     if (nullptr != poSRS)
-        poSRS->Release();
+        const_cast<OGRSpatialReference *>(poSRS)->Release();
 }
 
 /************************************************************************/
@@ -430,7 +430,7 @@ void OGR_GFld_SetIgnored(OGRGeomFieldDefnH hDefn, int ignore)
  * @since GDAL 1.11
  */
 
-OGRSpatialReference *OGRGeomFieldDefn::GetSpatialRef() const
+const OGRSpatialReference *OGRGeomFieldDefn::GetSpatialRef() const
 {
     return poSRS;
 }
@@ -447,7 +447,8 @@ OGRSpatialReference *OGRGeomFieldDefn::GetSpatialRef() const
  *
  * @param hDefn handle to the geometry field definition
  *
- * @return field spatial reference system.
+ * @return a reference to the field spatial reference system.
+ * It should not be modified.
  *
  * @since GDAL 1.11
  */
@@ -461,8 +462,8 @@ OGRSpatialReferenceH OGR_GFld_GetSpatialRef(OGRGeomFieldDefnH hDefn)
         OGRAPISpy_GFld_GetXXXX(hDefn, "GetSpatialRef");
 #endif
 
-    return reinterpret_cast<OGRSpatialReferenceH>(
-        OGRGeomFieldDefn::FromHandle(hDefn)->GetSpatialRef());
+    return OGRSpatialReference::ToHandle(const_cast<OGRSpatialReference *>(
+        OGRGeomFieldDefn::FromHandle(hDefn)->GetSpatialRef()));
 }
 
 /************************************************************************/
@@ -484,10 +485,10 @@ OGRSpatialReferenceH OGR_GFld_GetSpatialRef(OGRGeomFieldDefnH hDefn)
 void OGRGeomFieldDefn::SetSpatialRef(const OGRSpatialReference *poSRSIn)
 {
     if (poSRS != nullptr)
-        poSRS->Release();
-    poSRS = const_cast<OGRSpatialReference *>(poSRSIn);
+        const_cast<OGRSpatialReference *>(poSRS)->Release();
+    poSRS = poSRSIn;
     if (poSRS != nullptr)
-        poSRS->Reference();
+        const_cast<OGRSpatialReference *>(poSRS)->Reference();
 }
 
 /************************************************************************/
@@ -536,8 +537,8 @@ int OGRGeomFieldDefn::IsSame(const OGRGeomFieldDefn *poOtherFieldDefn) const
           GetType() == poOtherFieldDefn->GetType() &&
           IsNullable() == poOtherFieldDefn->IsNullable()))
         return FALSE;
-    OGRSpatialReference *poMySRS = GetSpatialRef();
-    OGRSpatialReference *poOtherSRS = poOtherFieldDefn->GetSpatialRef();
+    const OGRSpatialReference *poMySRS = GetSpatialRef();
+    const OGRSpatialReference *poOtherSRS = poOtherFieldDefn->GetSpatialRef();
     return ((poMySRS == poOtherSRS) ||
             (poMySRS != nullptr && poOtherSRS != nullptr &&
              poMySRS->IsSame(poOtherSRS)));

--- a/ogr/ogrlinestring.cpp
+++ b/ogr/ogrlinestring.cpp
@@ -2460,7 +2460,8 @@ OGRErr OGRSimpleCurve::transform(OGRCoordinateTransformation *poCT)
     CPLFree(xyz);
     CPLFree(pabSuccess);
 
-    assignSpatialReference(poCT->GetTargetCS());
+    assignSpatialReference(
+        const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
 
     return OGRERR_NONE;
 }

--- a/ogr/ogrlinestring.cpp
+++ b/ogr/ogrlinestring.cpp
@@ -2460,8 +2460,7 @@ OGRErr OGRSimpleCurve::transform(OGRCoordinateTransformation *poCT)
     CPLFree(xyz);
     CPLFree(pabSuccess);
 
-    assignSpatialReference(
-        const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
+    assignSpatialReference(poCT->GetTargetCS());
 
     return OGRERR_NONE;
 }

--- a/ogr/ogrpoint.cpp
+++ b/ogr/ogrpoint.cpp
@@ -718,8 +718,7 @@ OGRErr OGRPoint::transform(OGRCoordinateTransformation *poCT)
 {
     if (poCT->Transform(1, &x, &y, &z))
     {
-        assignSpatialReference(
-            const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
+        assignSpatialReference(poCT->GetTargetCS());
         return OGRERR_NONE;
     }
 

--- a/ogr/ogrpoint.cpp
+++ b/ogr/ogrpoint.cpp
@@ -718,7 +718,8 @@ OGRErr OGRPoint::transform(OGRCoordinateTransformation *poCT)
 {
     if (poCT->Transform(1, &x, &y, &z))
     {
-        assignSpatialReference(poCT->GetTargetCS());
+        assignSpatialReference(
+            const_cast<OGRSpatialReference *>(poCT->GetTargetCS()));
         return OGRERR_NONE;
     }
 

--- a/ogr/ogrpolyhedralsurface.cpp
+++ b/ogr/ogrpolyhedralsurface.cpp
@@ -958,7 +958,8 @@ OGRErr OGRPolyhedralSurface::removeGeometry(int iGeom, int bDelete)
 /*                       assignSpatialReference()                       */
 /************************************************************************/
 
-void OGRPolyhedralSurface::assignSpatialReference(OGRSpatialReference *poSR)
+void OGRPolyhedralSurface::assignSpatialReference(
+    const OGRSpatialReference *poSR)
 {
     OGRGeometry::assignSpatialReference(poSR);
     oMP.assignSpatialReference(poSR);

--- a/ogr/ogrsf_frmts/carto/ogr_carto.h
+++ b/ogr/ogrsf_frmts/carto/ogr_carto.h
@@ -333,7 +333,7 @@ class OGRCARTODataSource final : public OGRDataSource
     {
         return osCurrentSchema;
     }
-    static int FetchSRSId(OGRSpatialReference *poSRS);
+    static int FetchSRSId(const OGRSpatialReference *poSRS);
 
     int IsAuthenticatedConnection()
     {

--- a/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
+++ b/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
@@ -351,7 +351,7 @@ const char *OGRCARTODataSource::GetAPIURL() const
 /*                             FetchSRSId()                             */
 /************************************************************************/
 
-int OGRCARTODataSource::FetchSRSId(OGRSpatialReference *poSRS)
+int OGRCARTODataSource::FetchSRSId(const OGRSpatialReference *poSRS)
 
 {
     const char *pszAuthorityName;

--- a/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
+++ b/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
@@ -658,10 +658,10 @@ OGRErr OGRCARTOTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
         if (poFeatureDefn->GetGeomFieldCount() == 0)
             poGeomField->SetName("the_geom");
     }
-    auto l_poSRS = poGeomFieldIn->GetSpatialRef();
-    if (l_poSRS)
+    const auto poSRSIn = poGeomFieldIn->GetSpatialRef();
+    if (poSRSIn)
     {
-        l_poSRS = l_poSRS->Clone();
+        auto l_poSRS = poSRSIn->Clone();
         l_poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
         poGeomField->SetSpatialRef(l_poSRS);
         l_poSRS->Release();
@@ -675,7 +675,7 @@ OGRErr OGRCARTOTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
         CPLFree(pszSafeName);
     }
 
-    OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
+    const OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
     int nSRID = 0;
     if (poSRS != nullptr)
         nSRID = poDS->FetchSRSId(poSRS);

--- a/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -1875,10 +1875,13 @@ OGRErr OGRCSVLayer::CreateGeomField(OGRGeomFieldDefn *poGeomField,
         return OGRERR_FAILURE;
     }
     OGRGeomFieldDefn oGeomField(poGeomField);
-    if (oGeomField.GetSpatialRef())
+    auto poSRSOri = poGeomField->GetSpatialRef();
+    if (poSRSOri)
     {
-        oGeomField.GetSpatialRef()->SetAxisMappingStrategy(
-            OAMS_TRADITIONAL_GIS_ORDER);
+        auto poSRS = poSRSOri->Clone();
+        poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        oGeomField.SetSpatialRef(poSRS);
+        poSRS->Release();
     }
     poFeatureDefn->AddGeomFieldDefn(&oGeomField);
 

--- a/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -1085,11 +1085,11 @@ class GeometryInsertTransformer : public OGRCoordinateTransformation
     double dfZScale;
     double dfAngle;
 
-    OGRSpatialReference *GetSourceCS() override
+    const OGRSpatialReference *GetSourceCS() const override
     {
         return nullptr;
     }
-    OGRSpatialReference *GetTargetCS() override
+    const OGRSpatialReference *GetTargetCS() const override
     {
         return nullptr;
     }

--- a/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -170,11 +170,11 @@ class OGRDXFInsertTransformer final : public OGRCoordinateTransformation
         return new OGRDXFInsertTransformer(*this);
     }
 
-    OGRSpatialReference *GetSourceCS() override
+    const OGRSpatialReference *GetSourceCS() const override
     {
         return nullptr;
     }
-    OGRSpatialReference *GetTargetCS() override
+    const OGRSpatialReference *GetTargetCS() const override
     {
         return nullptr;
     }
@@ -287,11 +287,11 @@ class OGRDXFOCSTransformer final : public OGRCoordinateTransformation
   public:
     explicit OGRDXFOCSTransformer(double adfNIn[3], bool bInverse = false);
 
-    OGRSpatialReference *GetSourceCS() override
+    const OGRSpatialReference *GetSourceCS() const override
     {
         return nullptr;
     }
-    OGRSpatialReference *GetTargetCS() override
+    const OGRSpatialReference *GetTargetCS() const override
     {
         return nullptr;
     }

--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -2975,10 +2975,13 @@ OGRErr OGRElasticLayer::CreateGeomField(OGRGeomFieldDefn *poFieldIn,
     }
 
     OGRGeomFieldDefn oFieldDefn(poFieldIn);
-    if (oFieldDefn.GetSpatialRef())
+    auto poSRSOri = poFieldIn->GetSpatialRef();
+    if (poSRSOri)
     {
-        oFieldDefn.GetSpatialRef()->SetAxisMappingStrategy(
-            OAMS_TRADITIONAL_GIS_ORDER);
+        auto poSRS = poSRSOri->Clone();
+        poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        oFieldDefn.SetSpatialRef(poSRS);
+        poSRS->Release();
     }
     if (EQUAL(oFieldDefn.GetNameRef(), ""))
         oFieldDefn.SetName("geometry");

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -1225,7 +1225,8 @@ int OGRLayer::FindFieldIndex(const char *pszFieldName,
 OGRSpatialReference *OGRLayer::GetSpatialRef()
 {
     if (GetLayerDefn()->GetGeomFieldCount() > 0)
-        return GetLayerDefn()->GetGeomFieldDefn(0)->GetSpatialRef();
+        return const_cast<OGRSpatialReference *>(
+            GetLayerDefn()->GetGeomFieldDefn(0)->GetSpatialRef());
     else
         return nullptr;
 }

--- a/ogr/ogrsf_frmts/generic/ogrunionlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrunionlayer.cpp
@@ -127,7 +127,7 @@ OGRUnionLayer::~OGRUnionLayer()
     if (poFeatureDefn)
         poFeatureDefn->Release();
     if (poGlobalSRS != nullptr)
-        poGlobalSRS->Release();
+        const_cast<OGRSpatialReference *>(poGlobalSRS)->Release();
 }
 
 /************************************************************************/
@@ -295,7 +295,9 @@ OGRFeatureDefn *OGRUnionLayer::GetLayerDefn()
                                 poGlobalSRS =
                                     poSrcGeomFieldDefn->GetSpatialRef();
                                 if (poGlobalSRS != nullptr)
-                                    poGlobalSRS->Reference();
+                                    const_cast<OGRSpatialReference *>(
+                                        poGlobalSRS)
+                                        ->Reference();
                             }
                         }
                         break;
@@ -629,10 +631,8 @@ void OGRUnionLayer::AutoWarpLayerIfNecessary(int iLayer)
 
         for (int i = 0; i < GetLayerDefn()->GetGeomFieldCount(); i++)
         {
-            OGRSpatialReference *poSRS =
+            const OGRSpatialReference *poSRS =
                 GetLayerDefn()->GetGeomFieldDefn(i)->GetSpatialRef();
-            if (poSRS != nullptr)
-                poSRS->Reference();
 
             OGRFeatureDefn *poSrcFeatureDefn =
                 papoSrcLayers[iLayer]->GetLayerDefn();
@@ -640,7 +640,7 @@ void OGRUnionLayer::AutoWarpLayerIfNecessary(int iLayer)
                 GetLayerDefn()->GetGeomFieldDefn(i)->GetNameRef());
             if (iSrcGeomField >= 0)
             {
-                OGRSpatialReference *poSRS2 =
+                const OGRSpatialReference *poSRS2 =
                     poSrcFeatureDefn->GetGeomFieldDefn(iSrcGeomField)
                         ->GetSpatialRef();
 
@@ -682,9 +682,6 @@ void OGRUnionLayer::AutoWarpLayerIfNecessary(int iLayer)
                     }
                 }
             }
-
-            if (poSRS != nullptr)
-                poSRS->Release();
         }
     }
 }
@@ -1015,15 +1012,16 @@ OGRSpatialReference *OGRUnionLayer::GetSpatialRef()
     if (nGeomFields < 0)
         return nullptr;
     if (nGeomFields >= 1 && papoGeomFields[0]->bSRSSet)
-        return papoGeomFields[0]->GetSpatialRef();
+        return const_cast<OGRSpatialReference *>(
+            papoGeomFields[0]->GetSpatialRef());
 
     if (poGlobalSRS == nullptr)
     {
         poGlobalSRS = papoSrcLayers[0]->GetSpatialRef();
         if (poGlobalSRS != nullptr)
-            poGlobalSRS->Reference();
+            const_cast<OGRSpatialReference *>(poGlobalSRS)->Reference();
     }
-    return poGlobalSRS;
+    return const_cast<OGRSpatialReference *>(poGlobalSRS);
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/generic/ogrunionlayer.h
+++ b/ogr/ogrsf_frmts/generic/ogrunionlayer.h
@@ -94,7 +94,7 @@ class CPL_DLL OGRUnionLayer final : public OGRLayer
     int bAttrFilterPassThroughValue;
     int *pabModifiedLayers;
     int *pabCheckIfAutoWrap;
-    OGRSpatialReference *poGlobalSRS;
+    const OGRSpatialReference *poGlobalSRS;
 
     void AutoWarpLayerIfNecessary(int iSubLayer);
     OGRFeature *TranslateFromSrcLayer(OGRFeature *poSrcFeature);

--- a/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
@@ -40,7 +40,8 @@ OGRWarpedLayer::OGRWarpedLayer(OGRLayer *poDecoratedLayer, int iGeomField,
                                OGRCoordinateTransformation *poReversedCT)
     : OGRLayerDecorator(poDecoratedLayer, bTakeOwnership),
       m_poFeatureDefn(nullptr), m_iGeomField(iGeomField), m_poCT(poCT),
-      m_poReversedCT(poReversedCT), m_poSRS(m_poCT->GetTargetCS())
+      m_poReversedCT(poReversedCT),
+      m_poSRS(const_cast<OGRSpatialReference *>(m_poCT->GetTargetCS()))
 {
     CPLAssert(poCT != nullptr);
     SetDescription(poDecoratedLayer->GetDescription());

--- a/ogr/ogrsf_frmts/gml/ogrgmllayer.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmllayer.cpp
@@ -568,7 +568,7 @@ OGRFeature *OGRGMLLayer::GetNextFeature()
             poGeom = poOGRFeature->GetGeomFieldRef(i);
             if (poGeom != nullptr)
             {
-                OGRSpatialReference *poSRS =
+                const OGRSpatialReference *poSRS =
                     poFeatureDefn->GetGeomFieldDefn(i)->GetSpatialRef();
                 if (poSRS != nullptr)
                     poGeom->assignSpatialReference(poSRS);
@@ -717,8 +717,8 @@ OGRErr OGRGMLLayer::ICreateFeature(OGRFeature *poFeature)
             OGRGeomFieldDefn *poFieldDefn0 = poFeatureDefn->GetGeomFieldDefn(0);
             OGRGeomFieldDefn *poFieldDefn =
                 poFeatureDefn->GetGeomFieldDefn(iGeomField);
-            OGRSpatialReference *poSRS0 = poFieldDefn0->GetSpatialRef();
-            OGRSpatialReference *poSRS = poFieldDefn->GetSpatialRef();
+            const OGRSpatialReference *poSRS0 = poFieldDefn0->GetSpatialRef();
+            const OGRSpatialReference *poSRS = poFieldDefn->GetSpatialRef();
             if (poSRS0 != nullptr && poSRS == nullptr)
             {
                 bSameSRS = false;
@@ -1202,10 +1202,13 @@ OGRErr OGRGMLLayer::CreateGeomField(OGRGeomFieldDefn *poField, int bApproxOK)
     /*      Enforce XML naming semantics on element name.                   */
     /* -------------------------------------------------------------------- */
     OGRGeomFieldDefn oCleanCopy(poField);
-    if (oCleanCopy.GetSpatialRef())
+    auto poSRSOri = poField->GetSpatialRef();
+    if (poSRSOri)
     {
-        oCleanCopy.GetSpatialRef()->SetAxisMappingStrategy(
-            OAMS_TRADITIONAL_GIS_ORDER);
+        auto poSRS = poSRSOri->Clone();
+        poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        oCleanCopy.SetSpatialRef(poSRS);
+        poSRS->Release();
     }
     char *pszName = CPLStrdup(poField->GetNameRef());
     CPLCleanXMLElementName(pszName);

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -381,7 +381,7 @@ OGRFeature *OGRGeoPackageLayer::TranslateFeature(sqlite3_stmt *hStmt)
         if (sqlite3_column_type(hStmt, iGeomCol) != SQLITE_NULL &&
             !poGeomFieldDefn->IsIgnored())
         {
-            OGRSpatialReference *poSrs = poGeomFieldDefn->GetSpatialRef();
+            const OGRSpatialReference *poSrs = poGeomFieldDefn->GetSpatialRef();
             int iGpkgSize = sqlite3_column_bytes(hStmt, iGeomCol);
             // coverity[tainted_data_return]
             const GByte *pabyGpkg = static_cast<const GByte *>(

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -1741,17 +1741,20 @@ OGRErr OGRGeoPackageTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
     }
 
     OGRGeomFieldDefn oGeomField(poGeomFieldIn);
-    if (oGeomField.GetSpatialRef())
+    auto poSRSOri = poGeomFieldIn->GetSpatialRef();
+    if (poSRSOri)
     {
-        oGeomField.GetSpatialRef()->SetAxisMappingStrategy(
-            OAMS_TRADITIONAL_GIS_ORDER);
+        auto poSRS = poSRSOri->Clone();
+        poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        oGeomField.SetSpatialRef(poSRS);
+        poSRS->Release();
     }
     if (EQUAL(oGeomField.GetNameRef(), ""))
     {
         oGeomField.SetName("geom");
     }
 
-    OGRSpatialReference *poSRS = oGeomField.GetSpatialRef();
+    const OGRSpatialReference *poSRS = oGeomField.GetSpatialRef();
     if (poSRS != nullptr)
         m_iSrs = m_poDS->GetSrsId(*poSRS);
 

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -357,7 +357,7 @@ class OGRHanaDataSource final : public GDALDataset
     void ExecuteSQL(const CPLString &sql);
 
     OGRSpatialReference *GetSrsById(int srid);
-    int GetSrsId(OGRSpatialReference *srs);
+    int GetSrsId(const OGRSpatialReference *srs);
     bool IsSrsRoundEarth(int srid);
     bool HasSrsPlanarEquivalent(int srid);
     OGRErr GetQueryColumns(

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -955,7 +955,7 @@ OGRSpatialReference *OGRHanaDataSource::GetSrsById(int srid)
 /*                               GetSrsId()                             */
 /************************************************************************/
 
-int OGRHanaDataSource::GetSrsId(OGRSpatialReference *srs)
+int OGRHanaDataSource::GetSrsId(const OGRSpatialReference *srs)
 {
     if (srs == nullptr)
         return UNDETERMINED_SRID;

--- a/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
@@ -664,7 +664,7 @@ class OGRMSSQLSpatialDataSource final : public OGRDataSource
     OGRErr InitializeMetadataTables();
 
     OGRSpatialReference *FetchSRS(int nId);
-    int FetchSRSId(OGRSpatialReference *poSRS);
+    int FetchSRSId(const OGRSpatialReference *poSRS);
 
     OGRErr StartTransaction(CPL_UNUSED int bForce) override;
     OGRErr CommitTransaction() override;

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -1533,7 +1533,7 @@ OGRSpatialReference *OGRMSSQLSpatialDataSource::FetchSRS(int nId)
 /*      it to the table.                                                */
 /************************************************************************/
 
-int OGRMSSQLSpatialDataSource::FetchSRSId(OGRSpatialReference *poSRS)
+int OGRMSSQLSpatialDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
 
 {
     char *pszWKT = nullptr;

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -1818,7 +1818,7 @@ OGRErr OGRMSSQLSpatialTableLayer::CreateFeatureBCP(OGRFeature *poFeature)
                 // Use the SRID specified by the provided feature's geometry, if
                 // its spatial-reference system is known; otherwise, use the
                 // SRID associated with the table
-                OGRSpatialReference *poFeatureSRS =
+                const OGRSpatialReference *poFeatureSRS =
                     poGeom->getSpatialReference();
                 if (poFeatureSRS)
                     nOutgoingSRSId = poDS->FetchSRSId(poFeatureSRS);
@@ -2402,7 +2402,8 @@ OGRErr OGRMSSQLSpatialTableLayer::ICreateFeature(OGRFeature *poFeature)
             // Use the SRID specified by the provided feature's geometry, if
             // its spatial-reference system is known; otherwise, use the SRID
             // associated with the table
-            OGRSpatialReference *poFeatureSRS = poGeom->getSpatialReference();
+            const OGRSpatialReference *poFeatureSRS =
+                poGeom->getSpatialReference();
             if (poFeatureSRS)
                 nOutgoingSRSId = poDS->FetchSRSId(poFeatureSRS);
             if (nOutgoingSRSId <= 0)

--- a/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
+++ b/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
@@ -155,7 +155,7 @@ static OGRFeature *JSONToFeature(const CPLJSONObject &featureJson,
                                           nullptr, &poGeometry);
         if (poGeometry != nullptr)
         {
-            OGRSpatialReference *poSpatialRef =
+            const OGRSpatialReference *poSpatialRef =
                 poFeatureDefn->GetGeomFieldDefn(0)->GetSpatialRef();
             if (poSpatialRef != nullptr)
             {

--- a/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
+++ b/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
@@ -323,7 +323,7 @@ class OGROpenFileGDBGeomFieldDefn : public OGRGeomFieldDefn
         m_poLayer = nullptr;
     }
 
-    virtual OGRSpatialReference *GetSpatialRef() const override
+    virtual const OGRSpatialReference *GetSpatialRef() const override
     {
         if (poSRS)
             return poSRS;

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -130,7 +130,7 @@ class OGRPGGeomFieldDefn final : public OGRGeomFieldDefn
     {
     }
 
-    virtual OGRSpatialReference *GetSpatialRef() const override;
+    virtual const OGRSpatialReference *GetSpatialRef() const override;
 
     void UnsetLayer()
     {

--- a/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
@@ -2314,7 +2314,7 @@ int OGRPGLayer::ReadResultDefinition(PGresult *hInitialResultIn)
 /*                          GetSpatialRef()                             */
 /************************************************************************/
 
-OGRSpatialReference *OGRPGGeomFieldDefn::GetSpatialRef() const
+const OGRSpatialReference *OGRPGGeomFieldDefn::GetSpatialRef() const
 {
     if (poLayer == nullptr)
         return nullptr;
@@ -2325,7 +2325,7 @@ OGRSpatialReference *OGRPGGeomFieldDefn::GetSpatialRef() const
     {
         poSRS = poLayer->GetDS()->FetchSRS(nSRSId);
         if (poSRS != nullptr)
-            poSRS->Reference();
+            const_cast<OGRSpatialReference *>(poSRS)->Reference();
     }
     return poSRS;
 }

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -2464,10 +2464,10 @@ OGRErr OGRPGTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
             poGeomField->SetName(CPLSPrintf(
                 "wkb_geometry%d", poFeatureDefn->GetGeomFieldCount() + 1));
     }
-    auto l_poSRS = poGeomFieldIn->GetSpatialRef();
-    if (l_poSRS)
+    const auto poSRSIn = poGeomFieldIn->GetSpatialRef();
+    if (poSRSIn)
     {
-        l_poSRS = l_poSRS->Clone();
+        auto l_poSRS = poSRSIn->Clone();
         l_poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
         poGeomField->SetSpatialRef(l_poSRS);
         l_poSRS->Release();
@@ -2485,7 +2485,7 @@ OGRErr OGRPGTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
         CPLFree(pszSafeName);
     }
 
-    OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
+    const OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
     int nSRSId = poDS->GetUndefinedSRID();
     if (nForcedSRSId != UNDETERMINED_SRID)
         nSRSId = nForcedSRSId;

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
@@ -1676,7 +1676,7 @@ OGRErr OGRPGDumpLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
         CPLFree(pszSafeName);
     }
 
-    OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
+    const OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
     int nSRSId = nUnknownSRSId;
     if (nForcedSRSId != -2)
         nSRSId = nForcedSRSId;

--- a/ogr/ogrsf_frmts/shape/ogrshape.h
+++ b/ogr/ogrsf_frmts/shape/ogrshape.h
@@ -91,7 +91,7 @@ class OGRShapeGeomFieldDefn final : public OGRGeomFieldDefn
         CPLFree(pszFullName);
     }
 
-    OGRSpatialReference *GetSpatialRef() const override;
+    const OGRSpatialReference *GetSpatialRef() const override;
     void SetSRSSet()
     {
         bSRSSet = true;

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
@@ -558,7 +558,7 @@ static int OGR2SQLITEDealWithSpatialColumn(
     CPLString osIdxNameEscaped(SQLEscapeName(osIdxNameRaw));
 
     /* Make sure that the SRS is injected in spatial_ref_sys */
-    OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
+    const OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
     if (iGeomCol == 0 && poSRS == nullptr)
         poSRS = poLayer->GetSpatialRef();
     int nSRSId = poSQLiteDS->GetUndefinedSRID();

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
@@ -1662,10 +1662,10 @@ OGRErr OGRSQLiteTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
             poGeomField->SetName(CPLSPrintf(
                 "GEOMETRY%d", m_poFeatureDefn->GetGeomFieldCount() + 1));
     }
-    auto l_poSRS = poGeomFieldIn->GetSpatialRef();
-    if (l_poSRS)
+    auto poSRSIn = poGeomFieldIn->GetSpatialRef();
+    if (poSRSIn)
     {
-        l_poSRS = l_poSRS->Clone();
+        auto l_poSRS = poSRSIn->Clone();
         l_poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
         poGeomField->SetSpatialRef(l_poSRS);
         l_poSRS->Release();
@@ -1683,7 +1683,7 @@ OGRErr OGRSQLiteTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
         CPLFree(pszSafeName);
     }
 
-    OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
+    const OGRSpatialReference *poSRS = poGeomField->GetSpatialRef();
     int nSRSId = -1;
     if (poSRS != nullptr)
         nSRSId = m_poDS->FetchSRSId(poSRS);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -143,7 +143,7 @@ static SQLITE_EXTENSION_INIT1
     int AddExtraDS(OGRDataSource *poDS);
     OGRDataSource *GetExtraDS(int nIndex);
 
-    int FetchSRSId(OGRSpatialReference *poSRS);
+    int FetchSRSId(const OGRSpatialReference *poSRS);
 
     void RegisterVTable(const char *pszVTableName, OGRLayer *poLayer);
     void UnregisterVTable(const char *pszVTableName);
@@ -233,7 +233,7 @@ int OGR2SQLITEModule::Setup(GDALDataset *poDSIn,
 /************************************************************************/
 
 // TODO(schwehr): Refactor FetchSRSId to be much simpler.
-int OGR2SQLITEModule::FetchSRSId(OGRSpatialReference *poSRS)
+int OGR2SQLITEModule::FetchSRSId(const OGRSpatialReference *poSRS)
 {
     int nSRSId = -1;
 
@@ -1416,7 +1416,8 @@ static int OGR2SQLITE_Column(sqlite3_vtab_cursor *pCursor,
             {
                 CPLAssert(pMyCursor->pabyGeomBLOB == nullptr);
 
-                OGRSpatialReference *poSRS = poGeom->getSpatialReference();
+                const OGRSpatialReference *poSRS =
+                    poGeom->getSpatialReference();
                 int nSRSId = pMyCursor->pVTab->poModule->FetchSRSId(poSRS);
 
                 OGR2SQLITE_ExportGeometry(poGeom, nSRSId,
@@ -1452,7 +1453,7 @@ static int OGR2SQLITE_Column(sqlite3_vtab_cursor *pCursor,
         }
         else
         {
-            OGRSpatialReference *poSRS = poGeom->getSpatialReference();
+            const OGRSpatialReference *poSRS = poGeom->getSpatialReference();
             int nSRSId = pMyCursor->pVTab->poModule->FetchSRSId(poSRS);
 
             GByte *pabyGeomBLOB = nullptr;

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -717,7 +717,7 @@ static int OGR2SQLITE_ConnectCreate(sqlite3 *hDB, void *pAux, int argc,
                 osSQL += "Z";
             if (wkbHasM(poFieldDefn->GetType()))
                 osSQL += "M";
-            OGRSpatialReference *poSRS = poFieldDefn->GetSpatialRef();
+            const OGRSpatialReference *poSRS = poFieldDefn->GetSpatialRef();
             if (poSRS == nullptr && i == 0)
                 poSRS = poLayer->GetSpatialRef();
             int nSRID = poModule->FetchSRSId(poSRS);

--- a/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
+++ b/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
@@ -538,7 +538,7 @@ void OGRIDFDataSource::Parse()
         if (iLinkID >= 0)
         {
             poLinkLyr->ResetReading();
-            OGRSpatialReference *poSRS =
+            const OGRSpatialReference *poSRS =
                 poLinkLyr->GetLayerDefn()->GetGeomFieldDefn(0)->GetSpatialRef();
             for (auto &&poFeat : poLinkLyr)
             {

--- a/ogr/ogrsf_frmts/vrt/ogr_vrt.h
+++ b/ogr/ogrsf_frmts/vrt/ogr_vrt.h
@@ -60,7 +60,7 @@ class OGRVRTGeomFieldProps
   public:
     CPLString osName;  // Name of the VRT geometry field */
     OGRwkbGeometryType eGeomType;
-    OGRSpatialReference *poSRS;
+    const OGRSpatialReference *poSRS;
 
     bool bSrcClip;
     OGRGeometry *poSrcRegion;

--- a/ogr/ogrsf_frmts/vrt/ogrvrtdatasource.cpp
+++ b/ogr/ogrsf_frmts/vrt/ogrvrtdatasource.cpp
@@ -250,7 +250,7 @@ OGRLayer *OGRVRTDataSource::InstantiateWarpedLayer(CPLXMLNode *psLTree,
         }
     }
 
-    OGRSpatialReference *poSrcSRS = nullptr;
+    const OGRSpatialReference *poSrcSRS = nullptr;
     const char *pszSourceSRS = CPLGetXMLValue(psLTree, "SrcSRS", nullptr);
 
     if (pszSourceSRS == nullptr)
@@ -266,15 +266,18 @@ OGRLayer *OGRVRTDataSource::InstantiateWarpedLayer(CPLXMLNode *psLTree,
     }
     else
     {
-        poSrcSRS = new OGRSpatialReference();
-        poSrcSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
-        if (poSrcSRS->SetFromUserInput(
+        auto poSrcSRSNonConst = new OGRSpatialReference();
+        poSrcSRSNonConst->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        if (poSrcSRSNonConst->SetFromUserInput(
                 pszSourceSRS,
                 OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get()) !=
             OGRERR_NONE)
         {
-            delete poSrcSRS;
-            poSrcSRS = nullptr;
+            delete poSrcSRSNonConst;
+        }
+        else
+        {
+            poSrcSRS = poSrcSRSNonConst;
         }
     }
 

--- a/ogr/ogrsf_frmts/vrt/ogrvrtlayer.cpp
+++ b/ogr/ogrsf_frmts/vrt/ogrvrtlayer.cpp
@@ -89,7 +89,7 @@ OGRVRTGeomFieldProps::OGRVRTGeomFieldProps()
 OGRVRTGeomFieldProps::~OGRVRTGeomFieldProps()
 {
     if (poSRS != nullptr)
-        poSRS->Release();
+        const_cast<OGRSpatialReference *>(poSRS)->Release();
     if (poSrcRegion != nullptr)
         delete poSrcRegion;
 }
@@ -440,7 +440,7 @@ bool OGRVRTLayer::ParseGeometryField(CPLXMLNode *psNode,
         pszSRS = CPLGetXMLValue(psNodeParent, "LayerSRS", nullptr);
     if (pszSRS == nullptr)
     {
-        OGRSpatialReference *poSRS = nullptr;
+        const OGRSpatialReference *poSRS = nullptr;
         if (GetSrcLayerDefn()->GetGeomFieldCount() == 1)
         {
             poSRS = poSrcLayer->GetSpatialRef();
@@ -1083,11 +1083,15 @@ try_again:
             for (int i = 0; i < poFeatureDefn->GetGeomFieldCount(); i++)
             {
                 if (apoGeomFieldProps[i]->poSRS != nullptr)
-                    apoGeomFieldProps[i]->poSRS->Release();
+                    const_cast<OGRSpatialReference *>(
+                        apoGeomFieldProps[i]->poSRS)
+                        ->Release();
                 apoGeomFieldProps[i]->poSRS =
                     poFeatureDefn->GetGeomFieldDefn(i)->GetSpatialRef();
                 if (apoGeomFieldProps[i]->poSRS != nullptr)
-                    apoGeomFieldProps[i]->poSRS->Reference();
+                    const_cast<OGRSpatialReference *>(
+                        apoGeomFieldProps[i]->poSRS)
+                        ->Reference();
             }
         }
     }

--- a/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
+++ b/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
@@ -720,10 +720,13 @@ OGRErr OGRWAsPLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
                                      CPL_UNUSED int bApproxOK)
 {
     OGRGeomFieldDefn oFieldDefn(poGeomFieldIn);
-    if (oFieldDefn.GetSpatialRef())
+    auto poSRSOri = poGeomFieldIn->GetSpatialRef();
+    if (poSRSOri)
     {
-        oFieldDefn.GetSpatialRef()->SetAxisMappingStrategy(
-            OAMS_TRADITIONAL_GIS_ORDER);
+        auto poSRS = poSRSOri->Clone();
+        poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        oFieldDefn.SetSpatialRef(poSRS);
+        poSRS->Release();
     }
     poLayerDefn->AddGeomFieldDefn(&oFieldDefn);
 

--- a/ogr/ogrsf_frmts/wfs/ogrwfsfilter.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogrwfsfilter.cpp
@@ -37,7 +37,7 @@ typedef struct
     OGRDataSource *poDS;
     OGRFeatureDefn *poFDefn;
     int nUniqueGeomGMLId;
-    OGRSpatialReference *poSRS;
+    const OGRSpatialReference *poSRS;
     const char *pszNSPrefix;
 } ExprDumpFilterOptions;
 


### PR DESCRIPTION
-  Make OGRCoordinateTransformation::GetSourceCS() and GetTargetCS() return a const OGRSpatialReference* (fixes #7377)
   
    to reflect that those objects should be considered immutable.
    
    The downside is that we have internally to
    const_cast<OGRSpatialReference*>, in particular in
    OGRGeometry::transform() when assigning GetTargetCS() to the geometry,
    as assignSpatialReference() needs to increase the reference count.

-  Make OGRGeometry::getSpatialReference() return a const OGRSpatialReference*

-  Make OGRGeomFieldDefn::GetSpatialRef() return a const OGRSpatialReference*
