### PR TITLE
Doc: Use python3 for executable rather than python (fixes #7383)

### DIFF
--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -59,7 +59,7 @@ Process :
      git log --reverse -v v3.4.0..HEAD . ":(exclude)autotest" ":(exclude)doc" ":(exclude).github"
 
    For a feature release, e.g 3.6.0, you can use scripts/generate_log_feature_release.py to generate a log without commit that went in the previous 3.5.x bugfix releases with:
-     python scripts/generate_log_feature_release.py
+     python3 scripts/generate_log_feature_release.py
 
   - commit new version to NEWS.md file.
 
@@ -212,7 +212,7 @@ the GDAL package by one of the current owners : HowardB/FrankW/EvenR)
 
     b) cd $BUILD_DIR/swig/python
 
-    c) python setup.py sdist
+    c) python3 setup.py sdist
 
     d) Check the output:
         twine check dist/GDAL-*.gz
@@ -227,7 +227,7 @@ the GDAL package by one of the current owners : HowardB/FrankW/EvenR)
 
     a) cd $BUILD_DIR/swig/python/gdal-utils
 
-    b) python setup.py bdist_wheel
+    b) python3 setup.py bdist_wheel
 
     c) Check the output:
         twine check dist/gdal_utils-*.whl

--- a/doc/source/api/python_bindings.rst
+++ b/doc/source/api/python_bindings.rst
@@ -21,6 +21,7 @@ be greatly helpful for beginners with GDAL/OGR in Python.
 
 
 
+
 A cookbook full of recipes for using the Python GDAL/OGR bindings : `http://pcjericks.github.io/py-gdalogr-cookbook/index.html <http://pcjericks.github.io/py-gdalogr-cookbook/index.html>`__
 
 Examples
@@ -99,14 +100,14 @@ After modifying the location of gdal-config, you can build and install with the 
 
 .. code-block:: Bash
 
-    $ python setup.py build
-    $ python setup.py install
+    $ python3 setup.py build
+    $ python3 setup.py install
 
 If you have setuptools installed, you can also generate an egg:
 
 .. code-block:: Bash
 
-    $ python setup.py bdist_egg
+    $ python3 setup.py bdist_egg
 
 
 

--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -2149,19 +2149,19 @@ the ``install`` CMake target.
 
     This option can be specified to a directory name, to override the
     ``CMAKE_INSTALL_PREFIX`` option.
-    It is used to set the value of the ``--prefix`` option of ``python setup.py install``.
+    It is used to set the value of the ``--prefix`` option of ``python3 setup.py install``.
 
 .. option:: GDAL_PYTHON_INSTALL_LAYOUT
 
     This option can be specified to set the value of the ``--install-layout``
-    option of ``python setup.py install``. The install layout is by default set to
+    option of ``python3 setup.py install``. The install layout is by default set to
     ``deb`` when it is detected that the Python installation looks for
     the ``site-packages`` subdirectory. Otherwise it is unspecified.
 
 .. option:: GDAL_PYTHON_INSTALL_LIB
 
     This option can be specified to set the value of the ``--install-lib``
-    option of ``python setup.py install``. It is only taken into account on
+    option of ``python3 setup.py install``. It is only taken into account on
     MacOS systems, when the Python installation is a framework.
 
 Java bindings options

--- a/doc/source/development/dev_practices.rst
+++ b/doc/source/development/dev_practices.rst
@@ -111,7 +111,7 @@ hooks are cloned with the repository and can be installed using
 
 .. code-block:: bash
 
-    python -m pip install pre-commit
+    python3 -m pip install pre-commit
     pre-commit install
 
 

--- a/doc/source/drivers/raster/isis3.rst
+++ b/doc/source/drivers/raster/isis3.rst
@@ -52,7 +52,7 @@ For example:
 
 ::
 
-   $ python
+   $ python 3
    from osgeo import gdal
    ds = gdal.Open('../autotest/gdrivers/data/isis3_detached.lbl')
    print(ds.GetMetadata_List('json:ISIS3')[0])

--- a/doc/source/drivers/raster/sentinel2.rst
+++ b/doc/source/drivers/raster/sentinel2.rst
@@ -346,7 +346,7 @@ Examples
 
    ::
 
-      $ python -c "import sys; from osgeo import gdal; ds = gdal.Open(sys.argv[1]); open(sys.argv[2], 'wb').write(ds.GetMetadata('xml:VRT')[0].encode('utf-8'))" \
+      $ python3 -c "import sys; from osgeo import gdal; ds = gdal.Open(sys.argv[1]); open(sys.argv[2], 'wb').write(ds.GetMetadata('xml:VRT')[0].encode('utf-8'))" \
                SENTINEL2_L1C:S2A_OPER_MTD_SAFL1C_PDMC_20150818T101440_R022_V20150813T102406_20150813T102406.xml:10m:EPSG_32632 10m.vrt
 
 -  Opening the 10 meters resolution bands of a L1B subdataset:

--- a/doc/source/drivers/raster/vicar.rst
+++ b/doc/source/drivers/raster/vicar.rst
@@ -36,7 +36,7 @@ For example:
 
 ::
 
-   $ python
+   $ python3
    from osgeo import gdal
    ds = gdal.Open('../autotest/gdrivers/data/test_vicar_truncated.bin')
    print(ds.GetMetadata_List('json:VICAR')[0])

--- a/doc/source/drivers/vector/gml.rst
+++ b/doc/source/drivers/vector/gml.rst
@@ -1003,7 +1003,7 @@ to import it into PostGIS and
 
 ::
 
-   python ogr_build_junction_table.py PG:dbname=mydb
+   python3 ogr_build_junction_table.py PG:dbname=mydb
 
 , a *myfeature_otherfeature* table will be created and will contain the
 following content :

--- a/doc/source/user/gdal_python_utilities.rst
+++ b/doc/source/user/gdal_python_utilities.rst
@@ -41,7 +41,7 @@ In your IDE set gdal-utils as the root folder,
    launch wrappers created by pip and added to PYTHONHOME/Scripts)
 
    **./osgeo_utils/samples** - working python scripts but not typically
-   available in path (run them with ``python
+   available in path (run them with ``python3
    path/to/samples/something.py``)
 
 Improve the docs by editing the RST pages in


### PR DESCRIPTION
## What does this PR do?

* This changes everything in doc folder
* It should be validated by maintainers to not break anything
* code blocks are unchanged since it's assumed they are all in python3

## What are related issues/pull requests?

#7383

## Tasklist

 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] Maintainers test new commands all work in python3

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 20.04
* Compiler: sphinx (doc changes only)
