### PR TITLE
[Backport release/3.6] gdal_translate: fix crash when specifying -ovr on a dataset that has no overviews (fixes #7376)

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1483,16 +1483,27 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         {
             if (!psOptions->bQuiet)
             {
-                CPLError(CE_Warning, CPLE_AppDefined,
-                         "Cannot get overview level %d. Defaulting to level %d",
-                         psOptions->nOvLevel, nOvCount - 1);
+                if (nOvCount > 0)
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Cannot get overview level %d. "
+                             "Defaulting to level %d.",
+                             psOptions->nOvLevel, nOvCount - 1);
+                }
+                else
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Cannot get overview level %d. "
+                             "Defaulting to full resolution.",
+                             psOptions->nOvLevel);
+                }
             }
             if (nOvCount > 0)
                 poSrcOvrDS =
                     GDALCreateOverviewDataset(poSrcDS, nOvCount - 1,
                                               /* bThisLevelOnly = */ true);
         }
-        if (psOptions->dfXRes == 0.0 && !bOutsizeExplicitlySet)
+        if (poSrcOvrDS && psOptions->dfXRes == 0.0 && !bOutsizeExplicitlySet)
         {
             const double dfRatioX =
                 static_cast<double>(poSrcDSOri->GetRasterXSize()) /

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -1002,6 +1002,26 @@ def test_gdal_translate_lib_overview_level():
             0, 0, 10, 10, 2, 2
         )
 
+        # Test requesting an overview level that doesn't exist when there is overview
+        out_ds = gdal.Translate(
+            "",
+            src_ds,
+            format="MEM",
+            overviewLevel=src_ds.GetRasterBand(1).GetOverviewCount(),
+        )
+        ovr_band = src_ds.GetRasterBand(1).GetOverview(
+            src_ds.GetRasterBand(1).GetOverviewCount() - 1
+        )
+        assert out_ds.RasterXSize == ovr_band.XSize
+        assert out_ds.RasterYSize == ovr_band.YSize
+
+        # Test requesting an overview level that doesn't exist when there is no overview
+        out_ds = gdal.Translate(
+            "", "../gcore/data/byte.tif", format="MEM", overviewLevel=0
+        )
+        assert out_ds.RasterXSize == 20
+        assert out_ds.RasterYSize == 20
+
     finally:
         src_ds = None
         gdal.Unlink(src_filename)


### PR DESCRIPTION
Backport #7378
 **Authored by:** @rouault