### PR TITLE
the original code determines two nodata with numpy.nan are not equal, …

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
@@ -32,6 +32,7 @@
 import filecmp
 import os
 import sys
+import numpy as np
 
 from osgeo import gdal, osr
 
@@ -99,11 +100,21 @@ def compare_band(golden_band, new_band, ident, options=None):
         print("  New:    " + gdal.GetDataTypeName(new_band.DataType))
         found_diff += 1
 
-    if golden_band.GetNoDataValue() != new_band.GetNoDataValue():
-        print("Band %s nodata values differ." % ident)
-        print("  Golden: " + str(golden_band.GetNoDataValue()))
-        print("  New:    " + str(new_band.GetNoDataValue()))
-        found_diff += 1
+    golden_band_nodata = golden_band.GetNoDataValue()
+    new_band_nodata = new_band.GetNoDataValue()
+    
+    if golden_band_nodata != new_band_nodata:
+        if golden_band_nodata and new_band_nodata:
+            if not (np.isnan(golden_band_nodata) and np.isnan(new_band_nodata)):
+                print("Band %s nodata values differ." % ident)
+                print("  Golden: " + str(golden_band_nodata))
+                print("  New:    " + str(new_band_nodata))
+                found_diff += 1
+        else:
+            print("Band %s nodata values differ." % ident)
+            print("  Golden: " + str(golden_band_nodata))
+            print("  New:    " + str(new_band_nodata))
+            found_diff += 1
 
     if golden_band.GetColorInterpretation() != new_band.GetColorInterpretation():
         print("Band %s color interpretation values differ." % ident)

--- a/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
@@ -102,7 +102,6 @@ def compare_band(golden_band, new_band, ident, options=None):
 
     golden_band_nodata = golden_band.GetNoDataValue()
     new_band_nodata = new_band.GetNoDataValue()
-    
     if golden_band_nodata != new_band_nodata:
         if golden_band_nodata and new_band_nodata:
             if not (math.isnan(golden_band_nodata) and math.isnan(new_band_nodata)):

--- a/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
@@ -30,9 +30,9 @@
 # ******************************************************************************
 
 import filecmp
+import math
 import os
 import sys
-import numpy as np
 
 from osgeo import gdal, osr
 
@@ -105,7 +105,7 @@ def compare_band(golden_band, new_band, ident, options=None):
     
     if golden_band_nodata != new_band_nodata:
         if golden_band_nodata and new_band_nodata:
-            if not (np.isnan(golden_band_nodata) and np.isnan(new_band_nodata)):
+            if not (math.isnan(golden_band_nodata) and math.isnan(new_band_nodata)):
                 print("Band %s nodata values differ." % ident)
                 print("  Golden: " + str(golden_band_nodata))
                 print("  New:    " + str(new_band_nodata))


### PR DESCRIPTION
…new code determine two nodata with numpy.nan are equal

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
gdalcompare.py doe not correctly compare two nodata with numpy.nan in the two geotiff files. It thinks the two numpy.nan nodata values are different, so it counts this as one more diff_count. The PR solve s the problem.
## What are related issues/pull requests?
https://github.com/OSGeo/gdal/issues/7394
## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
