### PR TITLE
[Backport release/3.6] MRF: restore SetSpatialRef() that was wrongly deleted in 3.6.0

### DIFF
--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -33,7 +33,7 @@ import glob
 import gdaltest
 import pytest
 
-from osgeo import gdal
+from osgeo import gdal, osr
 
 pytestmark = pytest.mark.require_driver("MRF")
 
@@ -633,6 +633,21 @@ def test_mrf_versioned():
     assert ds is None
 
     cleanup()
+
+
+def test_mrf_setspatialref():
+
+    filename = "/vsimem/out.mrf"
+    ds = gdal.GetDriverByName("MRF").Create(filename, 1, 1)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(32631)
+    ds.SetSpatialRef(srs)
+    ds = None
+    gdal.Unlink(filename + ".aux.xml")
+    ds = gdal.Open(filename)
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    ds = None
+    gdal.GetDriverByName("MRF").Delete(filename)
 
 
 def test_mrf_cleanup():

--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -387,6 +387,14 @@ class MRFDataset final : public GDALPamDataset
         return m_oSRS.IsEmpty() ? nullptr : &m_oSRS;
     }
 
+    CPLErr SetSpatialRef(const OGRSpatialReference *poSRS) override
+    {
+        m_oSRS.Clear();
+        if (poSRS)
+            m_oSRS = *poSRS;
+        return CE_None;
+    }
+
     virtual CPLString const &GetPhotometricInterpretation()
     {
         return photometric;


### PR DESCRIPTION
Backport #7407
 **Authored by:** @rouault