### PR TITLE
autotest: Print GDAL build info in test report header

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -156,16 +156,26 @@ def pytest_configure(config):
             f"{lib_version}. Do you need to run setdevenv.sh ?"
         )
 
+
+def pytest_report_header(config):
+    gdal_header_info = "GDAL Build Info:"
+    for item in gdal.VersionInfo("BUILD_INFO").strip().split("\n"):
+        gdal_header_info += "\n  " + item.replace("=", ": ")
+
     import gdaltest
 
+    gdal_download_test_data = gdal.GetConfigOption("GDAL_DOWNLOAD_TEST_DATA")
+    if gdal_download_test_data is None:
+        gdal_download_test_data = "undefined"
+    gdal_header_info += f"\nGDAL_DOWNLOAD_TEST_DATA: {gdal_download_test_data}"
     if not gdaltest.download_test_data():
-        print(
-            "As GDAL_DOWNLOAD_TEST_DATA environment variable is not defined or set to NO, tests relying on downloaded data may be skipped.",
-            file=sys.stderr,
-        )
+        gdal_header_info += " (tests relying on downloaded data may be skipped)"
 
+    gdal_run_slow_tests = gdal.GetConfigOption("GDAL_RUN_SLOW_TESTS")
+    if gdal_run_slow_tests is None:
+        gdal_run_slow_tests = "undefined"
+    gdal_header_info += f"\nGDAL_RUN_SLOW_TESTS: {gdal_run_slow_tests}"
     if not gdaltest.run_slow_tests():
-        print(
-            'As GDAL_RUN_SLOW_TESTS environment variable is not defined or set to NO, some "slow" tests will be skipped.',
-            file=sys.stderr,
-        )
+        gdal_header_info += ' (tests marked as "slow" will be skipped)'
+
+    return gdal_header_info


### PR DESCRIPTION
## What does this PR do?

Prints the contents of `gdal.VersionInfo('BUILD_INFO')` below the platform information printed by `pytest`. I now realize the `pytest_report_header` hook used here is probably the more idiomatic way to report on environment variables that affect tests, so I moved the information from 0bfe1ad here as well.

Motivation: Trying to figure out why a single parquet test fails locally but passes CI, suspecting that a PROJ version difference factors into it. The PROJ version is reported in CMake configure output, but that pretty distant from the test output.

Result:

```
Test session starts (platform: linux, Python 3.10.6, pytest 7.2.1, pytest-sugar 0.9.6)
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
GDAL Build Info:
  PAM_ENABLED: YES
  OGR_ENABLED: YES
  GEOS_ENABLED: YES
  GEOS_VERSION: 3.12.0dev-CAPI-1.18.0
  PROJ_BUILD_VERSION: 8.2.1
  PROJ_RUNTIME_VERSION: 8.2.1
  COMPILER: GCC 12.1.0
GDAL_DOWNLOAD_TEST_DATA: undefined (tests relying on downloaded data may be skipped)
GDAL_RUN_SLOW_TESTS: undefined (tests marked as "slow" will be skipped)
rootdir: /home/dan/dev/build-gdal-Desktop-Debug/autotest, configfile: pytest.ini
plugins: xdist-3.2.0, custom-exit-code-0.3.0, random-order-1.1.0, anyio-3.6.1, sugar-0.9.6, env-0.8.1
collecting ... 
 ogr/ogr_shape.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                  
```

## What are related issues/pull requests?

#7262

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
