### PR TITLE
Doc: Add sphinxcontrib.jquery to requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,6 +4,7 @@ sphinx
 breathe
 sphinx_bootstrap_theme
 sphinxcontrib-bibtex
+sphinxcontrib.jquery
 sphinx_rtd_theme
 recommonmark
 sphinx-markdown-tables


### PR DESCRIPTION
This dependency was introduced in ef12528. Apparently it's brought in implicitly in Sphinx 6 (that's how the CI gets it), but I needed to add it locally to avoid:

```
python3 "source/build_driver_summary.py" "source/drivers/raster" raster_driver_summary "source/drivers/raster/driver_summary.rst"
python3 "source/build_driver_summary.py" "source/drivers/vector" vector_driver_summary "source/drivers/vector/driver_summary.rst"
python3 "source/build_configoptions_index.py"  "source" "build/xml" "source/user/configoptions_index_generated.rst"
sphinx-build -M html "source" "build" --keep-going -j auto -W 
Running Sphinx v5.3.0

Extension error:
Could not import extension sphinxcontrib.jquery (exception: No module named 'sphinxcontrib.jquery')
make: *** [Makefile:36: html] Error 2
```

Alternatively, the file could require sphinx >= 6.