### PR TITLE
[Backport 3.6] userfaultfd: avoid it to stall on 32bit and test real working of syscall in CPLIsUserFaultMappingSupported()

### DIFF
--- a/.github/workflows/ubuntu_18.04_32bit/start.sh
+++ b/.github/workflows/ubuntu_18.04_32bit/start.sh
@@ -87,9 +87,6 @@ rm -f "$WORK_DIR/ccache.tar.gz"
 
 export PYTEST="python3 -m pytest -vv -p no:sugar --color=no"
 
-# userfaultfd doesn't seem to work under Docker and/or 32bit (stalls on netcdf.py otherwise)
-export CPL_ENABLE_USERFAULTFD=NO
-
 (cd build && make quicktest)
 
 # install pip and use it to install test dependencies

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -2276,25 +2276,25 @@ def test_netcdf_multidim_open_userfaultfd():
 
     # Can only work on Linux, with some kernel versions... not in Docker by default
     # so mostly test that we don't crash
-    with gdaltest.error_handler():
-        ds = gdal.OpenEx(
-            "/vsizip/tmp/test_netcdf_open_userfaultfd.zip/test.nc",
-            gdal.OF_MULTIDIM_RASTER,
+    import netcdf
+
+    if netcdf.has_working_userfaultfd():
+        assert (
+            gdal.OpenEx(
+                "/vsizip/tmp/test_netcdf_open_userfaultfd.zip/test.nc",
+                gdal.OF_MULTIDIM_RASTER,
+            )
+            is not None
         )
-
-    success_expected = False
-    if "CI" not in os.environ:
-        if sys.platform.startswith("linux"):
-            uname = os.uname()
-            version = uname.release.split(".")
-            major = int(version[0])
-            minor = int(version[1])
-            if (major, minor) >= (5, 11):
-                assert ds
-                success_expected = True
-
-    if ds and not success_expected:
-        print("/vsi access through userfaultfd succeeded")
+    else:
+        with gdaltest.error_handler():
+            assert (
+                gdal.OpenEx(
+                    "/vsizip/tmp/test_netcdf_open_userfaultfd.zip/test.nc",
+                    gdal.OF_MULTIDIM_RASTER,
+                )
+                is None
+            )
 
     gdal.Unlink("tmp/test_netcdf_open_userfaultfd.zip")
 


### PR DESCRIPTION
Backport of PR #7429 