### PR TITLE
Multidimensional API: add GDALMDArray::Resize() / GDALMDArrayResize() 

### DIFF
--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -533,9 +533,12 @@ static void EncodeElt(const std::vector<DtypeElt> &elts, const GByte *pSrc,
 
 static void StripUselessItemsFromCompressorConfiguration(CPLJSONObject &o)
 {
-    o.Delete("num_threads");  // Blosc
-    o.Delete("typesize");     // Blosc
-    o.Delete("header");       // LZ4
+    if (o.GetType() == CPLJSONObject::Type::Object)
+    {
+        o.Delete("num_threads");  // Blosc
+        o.Delete("typesize");     // Blosc
+        o.Delete("header");       // LZ4
+    }
 }
 
 /************************************************************************/
@@ -3326,7 +3329,7 @@ ZarrGroupBase::LoadArray(const std::string &osArrayName,
             CPLError(CE_Failure, CPLE_AppDefined, "Invalid content for shape");
             return nullptr;
         }
-        aoDims.emplace_back(std::make_shared<GDALDimension>(
+        aoDims.emplace_back(std::make_shared<GDALDimensionWeakIndexingVar>(
             std::string(), CPLSPrintf("dim%d", i), std::string(), std::string(),
             nSize));
     }
@@ -3396,7 +3399,8 @@ ZarrGroupBase::LoadArray(const std::string &osArrayName,
         auto oIter = m_oMapDimensions.find(osDimName);
         if (oIter != m_oMapDimensions.end())
         {
-            if (oIter->second->GetSize() == poDim->GetSize())
+            if (m_bDimSizeInUpdate ||
+                oIter->second->GetSize() == poDim->GetSize())
             {
                 poDim = oIter->second;
                 return true;
@@ -4446,4 +4450,81 @@ ZarrArray::GetCoordinateVariables() const
     }
 
     return ret;
+}
+
+/************************************************************************/
+/*                            Resize()                                  */
+/************************************************************************/
+
+bool ZarrArray::Resize(const std::vector<GUInt64> &anNewDimSizes,
+                       CSLConstList /* papszOptions */)
+{
+    if (!IsWritable())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Resize() not supported on read-only file");
+        return false;
+    }
+
+    const auto nDimCount = GetDimensionCount();
+    if (anNewDimSizes.size() != nDimCount)
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "Not expected number of values in anNewDimSizes.");
+        return false;
+    }
+
+    auto &dims = GetDimensions();
+    std::vector<size_t> anGrownDimIdx;
+    std::map<GDALDimension *, GUInt64> oMapDimToSize;
+    for (size_t i = 0; i < nDimCount; ++i)
+    {
+        auto oIter = oMapDimToSize.find(dims[i].get());
+        if (oIter != oMapDimToSize.end() && oIter->second != anNewDimSizes[i])
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Cannot resize a dimension referenced several times "
+                     "to different sizes");
+            return false;
+        }
+        if (anNewDimSizes[i] != dims[i]->GetSize())
+        {
+            if (anNewDimSizes[i] < dims[i]->GetSize())
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Resize() does not support shrinking the array.");
+                return false;
+            }
+
+            oMapDimToSize[dims[i].get()] = anNewDimSizes[i];
+            anGrownDimIdx.push_back(i);
+        }
+        else
+        {
+            oMapDimToSize[dims[i].get()] = dims[i]->GetSize();
+        }
+    }
+    if (!anGrownDimIdx.empty())
+    {
+        m_bDefinitionModified = true;
+        for (size_t dimIdx : anGrownDimIdx)
+        {
+            auto dim = std::dynamic_pointer_cast<GDALDimensionWeakIndexingVar>(
+                dims[dimIdx]);
+            if (dim)
+            {
+                dim->SetSize(anNewDimSizes[dimIdx]);
+                if (dim->GetName() != dim->GetFullName())
+                {
+                    // This is not a local dimension
+                    m_poSharedResource->UpdateDimensionSize(dim);
+                }
+            }
+            else
+            {
+                CPLAssert(false);
+            }
+        }
+    }
+    return true;
 }

--- a/frmts/zarr/zarr_group.cpp
+++ b/frmts/zarr/zarr_group.cpp
@@ -166,6 +166,49 @@ std::shared_ptr<GDALDimension> ZarrGroupBase::CreateDimension(
 }
 
 /************************************************************************/
+/*                  ZarrGroupBase::UpdateDimensionSize()                */
+/************************************************************************/
+
+void ZarrGroupBase::UpdateDimensionSize(
+    const std::shared_ptr<GDALDimension> &poUpdatedDim)
+{
+    const auto aosGroupNames = GetGroupNames();
+    for (const auto &osGroupName : aosGroupNames)
+    {
+        auto poSubGroup = OpenZarrGroup(osGroupName);
+        if (poSubGroup)
+        {
+            poSubGroup->UpdateDimensionSize(poUpdatedDim);
+        }
+    }
+    const auto aosArrayNames = GetMDArrayNames();
+    for (const auto &osArrayName : aosArrayNames)
+    {
+        // Disable checks that size of variables referenced by _ARRAY_DIMENSIONS
+        // are consistent with array shapes, as we are in the middle of updating
+        // things
+        m_bDimSizeInUpdate = true;
+        auto poArray = OpenZarrArray(osArrayName);
+        m_bDimSizeInUpdate = false;
+        if (poArray)
+        {
+            for (auto &poDim : poArray->GetDimensions())
+            {
+                if (poDim->GetFullName() == poUpdatedDim->GetFullName())
+                {
+                    auto poModifiableDim =
+                        std::dynamic_pointer_cast<GDALDimensionWeakIndexingVar>(
+                            poDim);
+                    CPLAssert(poModifiableDim);
+                    poModifiableDim->SetSize(poUpdatedDim->GetSize());
+                    poArray->SetDefinitionModified(true);
+                }
+            }
+        }
+    }
+}
+
+/************************************************************************/
 /*                      ZarrGroupV2::Create()                           */
 /************************************************************************/
 
@@ -239,10 +282,10 @@ void ZarrGroupV2::ExploreDirectory() const
 }
 
 /************************************************************************/
-/*                             OpenMDArray()                            */
+/*                             OpenZarrArray()                          */
 /************************************************************************/
 
-std::shared_ptr<GDALMDArray> ZarrGroupV2::OpenMDArray(const std::string &osName,
+std::shared_ptr<ZarrArray> ZarrGroupV2::OpenZarrArray(const std::string &osName,
                                                       CSLConstList) const
 {
     auto oIter = m_oMapMDArrays.find(osName);
@@ -272,11 +315,11 @@ std::shared_ptr<GDALMDArray> ZarrGroupV2::OpenMDArray(const std::string &osName,
 }
 
 /************************************************************************/
-/*                              OpenGroup()                             */
+/*                              OpenZarrGroup()                             */
 /************************************************************************/
 
-std::shared_ptr<GDALGroup> ZarrGroupV2::OpenGroup(const std::string &osName,
-                                                  CSLConstList) const
+std::shared_ptr<ZarrGroupBase>
+ZarrGroupV2::OpenZarrGroup(const std::string &osName, CSLConstList) const
 {
     auto oIter = m_oMapGroups.find(osName);
     if (oIter != m_oMapGroups.end())
@@ -351,10 +394,10 @@ ZarrGroupV3::Create(const std::shared_ptr<ZarrSharedResource> &poSharedResource,
 }
 
 /************************************************************************/
-/*                             OpenMDArray()                            */
+/*                             OpenZarrArray()                          */
 /************************************************************************/
 
-std::shared_ptr<GDALMDArray> ZarrGroupV3::OpenMDArray(const std::string &osName,
+std::shared_ptr<ZarrArray> ZarrGroupV3::OpenZarrArray(const std::string &osName,
                                                       CSLConstList) const
 {
     auto oIter = m_oMapMDArrays.find(osName);
@@ -1384,6 +1427,7 @@ std::shared_ptr<GDALMDArray> ZarrGroupV2::CreateMDArray(
     poArray->SetFilters(oFilters);
     poArray->SetUpdatable(true);
     poArray->SetDefinitionModified(true);
+    poArray->Flush();
     RegisterArray(poArray);
 
     return poArray;
@@ -1517,11 +1561,11 @@ ZarrGroupV3::~ZarrGroupV3()
 }
 
 /************************************************************************/
-/*                              OpenGroup()                             */
+/*                            OpenZarrGroup()                           */
 /************************************************************************/
 
-std::shared_ptr<GDALGroup> ZarrGroupV3::OpenGroup(const std::string &osName,
-                                                  CSLConstList) const
+std::shared_ptr<ZarrGroupBase>
+ZarrGroupV3::OpenZarrGroup(const std::string &osName, CSLConstList) const
 {
     auto oIter = m_oMapGroups.find(osName);
     if (oIter != m_oMapGroups.end())
@@ -1853,6 +1897,7 @@ std::shared_ptr<GDALMDArray> ZarrGroupV3::CreateMDArray(
         poArray->SetCompressorJsonV3(oCompressor);
     poArray->SetUpdatable(true);
     poArray->SetDefinitionModified(true);
+    poArray->Flush();
     RegisterArray(poArray);
 
     return poArray;
@@ -1862,7 +1907,9 @@ std::shared_ptr<GDALMDArray> ZarrGroupV3::CreateMDArray(
 /*              ZarrSharedResource::ZarrSharedResource()                */
 /************************************************************************/
 
-ZarrSharedResource::ZarrSharedResource(const std::string &osRootDirectoryName)
+ZarrSharedResource::ZarrSharedResource(const std::string &osRootDirectoryName,
+                                       bool bUpdatable)
+    : m_bUpdatable(bUpdatable)
 {
     m_oObj.Add("zarr_consolidated_format", 1);
     m_oObj.Add("metadata", CPLJSONObject());
@@ -1874,6 +1921,18 @@ ZarrSharedResource::ZarrSharedResource(const std::string &osRootDirectoryName)
     }
     m_poPAM = std::make_shared<GDALPamMultiDim>(
         CPLFormFilename(m_osRootDirectoryName.c_str(), "pam", nullptr));
+}
+
+/************************************************************************/
+/*              ZarrSharedResource::Create()                            */
+/************************************************************************/
+
+std::shared_ptr<ZarrSharedResource>
+ZarrSharedResource::Create(const std::string &osRootDirectoryName,
+                           bool bUpdatable)
+{
+    return std::shared_ptr<ZarrSharedResource>(
+        new ZarrSharedResource(osRootDirectoryName, bUpdatable));
 }
 
 /************************************************************************/
@@ -1889,6 +1948,92 @@ ZarrSharedResource::~ZarrSharedResource()
         oDoc.Save(CPLFormFilename(m_osRootDirectoryName.c_str(), ".zmetadata",
                                   nullptr));
     }
+}
+
+/************************************************************************/
+/*             ZarrSharedResource::OpenRootGroup()                      */
+/************************************************************************/
+
+std::shared_ptr<ZarrGroupBase> ZarrSharedResource::OpenRootGroup()
+{
+    auto poRG = ZarrGroupV2::Create(shared_from_this(), std::string(), "/");
+    poRG->SetUpdatable(m_bUpdatable);
+    poRG->SetDirectoryName(m_osRootDirectoryName);
+
+    const std::string osZarrayFilename(
+        CPLFormFilename(m_osRootDirectoryName.c_str(), ".zarray", nullptr));
+    VSIStatBufL sStat;
+    if (VSIStatL(osZarrayFilename.c_str(), &sStat) == 0)
+    {
+        CPLJSONDocument oDoc;
+        if (!oDoc.Load(osZarrayFilename))
+            return nullptr;
+        const auto oRoot = oDoc.GetRoot();
+        if (oRoot["_NCZARR_ARRAY"].IsValid())
+        {
+            // If opening a NCZarr array, initialize its group from NCZarr
+            // metadata.
+            const std::string osGroupFilename(
+                CPLFormFilename(CPLGetDirname(m_osRootDirectoryName.c_str()),
+                                ".zgroup", nullptr));
+            if (VSIStatL(osGroupFilename.c_str(), &sStat) == 0)
+            {
+                CPLJSONDocument oDocGroup;
+                if (oDocGroup.Load(osGroupFilename))
+                {
+                    if (!poRG->InitFromZGroup(oDocGroup.GetRoot()))
+                        return nullptr;
+                }
+            }
+        }
+        const std::string osArrayName(
+            CPLGetBasename(m_osRootDirectoryName.c_str()));
+        std::set<std::string> oSetFilenamesInLoading;
+        if (!poRG->LoadArray(osArrayName, osZarrayFilename, oRoot, false,
+                             CPLJSONObject(), oSetFilenamesInLoading))
+            return nullptr;
+
+        return poRG;
+    }
+
+    const std::string osZmetadataFilename(
+        CPLFormFilename(m_osRootDirectoryName.c_str(), ".zmetadata", nullptr));
+    if (CPLTestBool(
+            CSLFetchNameValueDef(GetOpenOptions(), "USE_ZMETADATA", "YES")) &&
+        VSIStatL(osZmetadataFilename.c_str(), &sStat) == 0)
+    {
+        if (!m_bZMetadataEnabled)
+        {
+            CPLJSONDocument oDoc;
+            if (!oDoc.Load(osZmetadataFilename))
+                return nullptr;
+
+            m_bZMetadataEnabled = true;
+            m_oObj = oDoc.GetRoot();
+        }
+        poRG->InitFromZMetadata(m_oObj);
+
+        return poRG;
+    }
+
+    const std::string osGroupFilename(
+        CPLFormFilename(m_osRootDirectoryName.c_str(), ".zgroup", nullptr));
+    if (VSIStatL(osGroupFilename.c_str(), &sStat) == 0)
+    {
+        CPLJSONDocument oDoc;
+        if (!oDoc.Load(osGroupFilename))
+            return nullptr;
+
+        if (!poRG->InitFromZGroup(oDoc.GetRoot()))
+            return nullptr;
+        return poRG;
+    }
+
+    // Zarr v3
+    auto poRG_V3 = ZarrGroupV3::Create(shared_from_this(), std::string(), "/",
+                                       m_osRootDirectoryName);
+    poRG_V3->SetUpdatable(m_bUpdatable);
+    return poRG_V3;
 }
 
 /************************************************************************/
@@ -1910,4 +2055,25 @@ void ZarrSharedResource::SetZMetadataItem(const std::string &osFilename,
         m_oObj["metadata"].DeleteNoSplitName(pszKey);
         m_oObj["metadata"].AddNoSplitName(pszKey, obj);
     }
+}
+
+/************************************************************************/
+/*             ZarrSharedResource::UpdateDimensionSize()                */
+/************************************************************************/
+
+void ZarrSharedResource::UpdateDimensionSize(
+    const std::shared_ptr<GDALDimension> &poDim)
+{
+    auto poRG = m_poWeakRootGroup.lock();
+    if (!poRG)
+        poRG = OpenRootGroup();
+    if (poRG)
+    {
+        poRG->UpdateDimensionSize(poDim);
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "UpdateDimensionSize() failed");
+    }
+    poRG.reset();
 }

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -2127,6 +2127,9 @@ GDALAttributeH CPL_DLL GDALMDArrayCreateAttribute(
     GDALMDArrayH hArray, const char *pszName, size_t nDimensions,
     const GUInt64 *panDimensions, GDALExtendedDataTypeH hEDT,
     CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
+bool CPL_DLL GDALMDArrayResize(GDALMDArrayH hArray,
+                               const GUInt64 *panNewDimSizes,
+                               CSLConstList papszOptions);
 const void CPL_DLL *GDALMDArrayGetRawNoDataValue(GDALMDArrayH hArray);
 double CPL_DLL GDALMDArrayGetNoDataValueAsDouble(GDALMDArrayH hArray,
                                                  int *pbHasNoDataValue);

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2806,6 +2806,9 @@ class CPL_DLL GDALMDArray : virtual public GDALAbstractMDArray,
 
     bool SetNoDataValue(uint64_t nNoData);
 
+    virtual bool Resize(const std::vector<GUInt64> &anNewDimSizes,
+                        CSLConstList papszOptions);
+
     virtual double GetOffset(bool *pbHasOffset = nullptr,
                              GDALDataType *peStorageType = nullptr) const;
 
@@ -3112,6 +3115,8 @@ class CPL_DLL GDALDimensionWeakIndexingVar : public GDALDimension
 
     bool SetIndexingVariable(
         std::shared_ptr<GDALMDArray> poIndexingVariable) override;
+
+    void SetSize(GUInt64 nNewSize);
 };
 //! @endcond
 

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -2494,6 +2494,34 @@ bool GDALMDArray::SetNoDataValue(uint64_t nNoData)
 }
 
 /************************************************************************/
+/*                            Resize()                                  */
+/************************************************************************/
+
+/** Resize an array to new dimensions.
+ *
+ * Not all drivers may allow this operation, and with restrictions (e.g.
+ * for netCDF, this is limited to growing of "unlimited" dimensions)
+ *
+ * Resizing a dimension used in other arrays will cause those other arrays
+ * to be resized.
+ *
+ * This is the same as the C function GDALMDArrayResize().
+ *
+ * @param anNewDimSizes Array of GetDimensionCount() values containing the
+ *                      new size of each indexing dimension.
+ * @param papszOptions Options. (Driver specific)
+ * @return true in case of success.
+ * @since GDAL 3.7
+ */
+bool GDALMDArray::Resize(CPL_UNUSED const std::vector<GUInt64> &anNewDimSizes,
+                         CPL_UNUSED CSLConstList papszOptions)
+{
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Resize() is not supported for this array");
+    return false;
+}
+
+/************************************************************************/
 /*                               SetScale()                             */
 /************************************************************************/
 
@@ -10248,6 +10276,40 @@ int GDALMDArraySetNoDataValueAsUInt64(GDALMDArrayH hArray,
 }
 
 /************************************************************************/
+/*                        GDALMDArrayResize()                           */
+/************************************************************************/
+
+/** Resize an array to new dimensions.
+ *
+ * Not all drivers may allow this operation, and with restrictions (e.g.
+ * for netCDF, this is limited to growing of "unlimited" dimensions)
+ *
+ * Resizing a dimension used in other arrays will cause those other arrays
+ * to be resized.
+ *
+ * This is the same as the C++ method GDALMDArray::Resize().
+ *
+ * @param hArray Array.
+ * @param panNewDimSizes Array of GetDimensionCount() values containing the
+ *                       new size of each indexing dimension.
+ * @param papszOptions Options. (Driver specific)
+ * @return true in case of success.
+ * @since GDAL 3.7
+ */
+bool GDALMDArrayResize(GDALMDArrayH hArray, const GUInt64 *panNewDimSizes,
+                       CSLConstList papszOptions)
+{
+    VALIDATE_POINTER1(hArray, __func__, false);
+    VALIDATE_POINTER1(panNewDimSizes, __func__, false);
+    std::vector<GUInt64> anNewDimSizes(hArray->m_poImpl->GetDimensionCount());
+    for (size_t i = 0; i < anNewDimSizes.size(); ++i)
+    {
+        anNewDimSizes[i] = panNewDimSizes[i];
+    }
+    return hArray->m_poImpl->Resize(anNewDimSizes, papszOptions);
+}
+
+/************************************************************************/
 /*                          GDALMDArraySetScale()                       */
 /************************************************************************/
 
@@ -11718,6 +11780,11 @@ bool GDALDimensionWeakIndexingVar::SetIndexingVariable(
 {
     m_poIndexingVariable = poIndexingVariable;
     return true;
+}
+
+void GDALDimensionWeakIndexingVar::SetSize(GUInt64 nNewSize)
+{
+    m_nSize = nNewSize;
 }
 
 /************************************************************************/

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -483,6 +483,18 @@ public:
   }
 %clear char **;
 
+%apply (int nList, GUIntBig* pList) {(int nDimCount, GUIntBig* newDimSizes)};
+  CPLErr Resize( int nDimCount, GUIntBig* newDimSizes, char** options = NULL ) {
+    if( static_cast<size_t>(nDimCount) != GDALMDArrayGetDimensionCount(self) )
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "newDimSizes array not of expected size");
+        return CE_Failure;
+    }
+    return GDALMDArrayResize( self, newDimSizes, options ) ? CE_None : CE_Failure;
+  }
+%clear (int nDimCount, GUIntBig* newDimSizes);
+
 #if defined(SWIGPYTHON)
 %apply Pointer NONNULL {GDALExtendedDataTypeHS* buffer_datatype};
 %apply ( void **outPythonObject ) { (void **buf ) };


### PR DESCRIPTION
Resize an array to new dimensions.
    
Not all drivers may allow this operation, and with restrictions (e.g.
for netCDF, this is limited to growing of "unlimited" dimensions)
    
Resizing a dimension used in other arrays will cause those other arrays
to be resized.

Implemented in MEM, netCDF and ZARR drivers
