### PR TITLE
Massive linting in RawRasterBand based drivers

### DIFF
--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -950,9 +950,17 @@ GDALDataset *ERSDataset::Open(GDALOpenInfo *poOpenInfo)
     /*     Get the HeaderOffset if it exists in the header                  */
     /* -------------------------------------------------------------------- */
     GIntBig nHeaderOffset = 0;
-    if (poHeader->Find("HeaderOffset") != nullptr)
+    const char *pszHeaderOffset = poHeader->Find("HeaderOffset");
+    if (pszHeaderOffset != nullptr)
     {
-        nHeaderOffset = atoi(poHeader->Find("HeaderOffset"));
+        nHeaderOffset = CPLAtoGIntBig(pszHeaderOffset);
+        if (nHeaderOffset < 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Illegal value for HeaderOffset: %s", pszHeaderOffset);
+            delete poDS;
+            return nullptr;
+        }
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -1089,7 +1089,7 @@ GDALDataset *ERSDataset::Open(GDALOpenInfo *poOpenInfo)
                     bNative);
                 if (!poBand->IsValid())
                     return nullptr;
-                poDS->SetBand(iBand + 1, poBand.release());
+                poDS->SetBand(iBand + 1, std::move(poBand));
             }
         }
     }

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -243,6 +243,7 @@ class ISISTiledBand final : public GDALPamRasterBand
     double m_dfOffset;
     double m_dfScale;
     double m_dfNoData;
+    bool m_bValid = false;
 
   public:
     ISISTiledBand(GDALDataset *poDS, VSILFILE *fpVSIL, int nBand,
@@ -251,6 +252,11 @@ class ISISTiledBand final : public GDALPamRasterBand
                   GIntBig nYTileOffset, int bNativeOrder);
     virtual ~ISISTiledBand()
     {
+    }
+
+    bool IsValid() const
+    {
+        return m_bValid;
     }
 
     virtual CPLErr IReadBlock(int, int, void *) override;
@@ -443,6 +449,7 @@ ISISTiledBand::ISISTiledBand(GDALDataset *poDSIn, VSILFILE *fpVSILIn,
         }
         m_nFirstTileOffset += (nBand - 1) * m_nYTileOffset * l_nBlocksPerColumn;
     }
+    m_bValid = true;
 }
 
 /************************************************************************/
@@ -1641,13 +1648,12 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Open the file using the large file API.                         */
     /* -------------------------------------------------------------------- */
-    ISIS3Dataset *poDS = new ISIS3Dataset();
+    auto poDS = cpl::make_unique<ISIS3Dataset>();
 
     if (!poDS->m_oKeywords.Ingest(poOpenInfo->fpL, 0))
     {
         VSIFCloseL(poOpenInfo->fpL);
         poOpenInfo->fpL = nullptr;
-        delete poDS;
         return nullptr;
     }
     poDS->m_oJSonLabel = poDS->m_oKeywords.GetJsonObject();
@@ -1759,7 +1765,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_OpenFailed,
                      "Wrong tile dimensions : %d x %d", tileSizeX, tileSizeY);
-            delete poDS;
             return nullptr;
         }
     }
@@ -1767,7 +1772,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
     {
         CPLError(CE_Failure, CPLE_OpenFailed, "%s format not supported.",
                  osFormat.c_str());
-        delete poDS;
         return nullptr;
     }
 
@@ -1806,7 +1810,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
     {
         CPLError(CE_Failure, CPLE_OpenFailed, "%s pixel type not supported.",
                  itype);
-        delete poDS;
         return nullptr;
     }
 
@@ -2109,7 +2112,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
     if (!GDALCheckDatasetDimensions(nCols, nRows) ||
         !GDALCheckBandCount(nBands, false))
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -2133,14 +2135,12 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
         if (osQubeFile == poOpenInfo->pszFilename)
         {
             CPLError(CE_Failure, CPLE_AppDefined, "A ^Core file must be set");
-            delete poDS;
             return nullptr;
         }
         poDS->m_poExternalDS =
             GDALDataset::FromHandle(GDALOpen(osQubeFile, poOpenInfo->eAccess));
         if (poDS->m_poExternalDS == nullptr)
         {
-            delete poDS;
             return nullptr;
         }
         if (poDS->m_poExternalDS->GetRasterXSize() != poDS->nRasterXSize ||
@@ -2153,7 +2153,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
                      "%s has incompatible characteristics with the ones "
                      "declared in the label.",
                      osQubeFile.c_str());
-            delete poDS;
             return nullptr;
         }
     }
@@ -2168,7 +2167,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_OpenFailed, "Failed to open %s: %s.",
                      osQubeFile.c_str(), VSIStrerror(errno));
-            delete poDS;
             return nullptr;
         }
 
@@ -2279,7 +2277,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
         }
         catch (const CPLSafeIntOverflow &)
         {
-            delete poDS;
             return nullptr;
         }
         nBandOffset = static_cast<vsi_l_offset>(nLineOffset) * nRows;
@@ -2417,44 +2414,42 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
 
     for (int i = 0; i < nBands; i++)
     {
-        GDALRasterBand *poBand = nullptr;
+        GDALRasterBand *poBand;
 
         if (poDS->m_poExternalDS != nullptr)
         {
-            ISIS3WrapperRasterBand *poISISBand = new ISIS3WrapperRasterBand(
+            auto poISISBand = cpl::make_unique<ISIS3WrapperRasterBand>(
                 poDS->m_poExternalDS->GetRasterBand(i + 1));
-            poBand = poISISBand;
-            poDS->SetBand(i + 1, poBand);
-
-            poISISBand->SetMaskBand(new ISISMaskBand(poISISBand));
+            poISISBand->SetMaskBand(new ISISMaskBand(poISISBand.get()));
+            poDS->SetBand(i + 1, std::move(poISISBand));
+            poBand = poDS->GetRasterBand(i + 1);
         }
         else if (poDS->m_bIsTiled)
         {
-            CPLErrorReset();
-            ISISTiledBand *poISISBand = new ISISTiledBand(
-                poDS, poDS->m_fpImage, i + 1, eDataType, tileSizeX, tileSizeY,
-                nSkipBytes, 0, 0, bNativeOrder);
-            if (CPLGetLastErrorType() != CE_None)
+            auto poISISBand = cpl::make_unique<ISISTiledBand>(
+                poDS.get(), poDS->m_fpImage, i + 1, eDataType, tileSizeX,
+                tileSizeY, nSkipBytes, 0, 0, bNativeOrder);
+            if (!poISISBand->IsValid())
             {
-                delete poISISBand;
-                delete poDS;
                 return nullptr;
             }
-            poBand = poISISBand;
-            poDS->SetBand(i + 1, poBand);
-
-            poISISBand->SetMaskBand(new ISISMaskBand(poISISBand));
+            poISISBand->SetMaskBand(new ISISMaskBand(poISISBand.get()));
+            poDS->SetBand(i + 1, std::move(poISISBand));
+            poBand = poDS->GetRasterBand(i + 1);
         }
         else
         {
-            ISIS3RawRasterBand *poISISBand = new ISIS3RawRasterBand(
-                poDS, i + 1, poDS->m_fpImage, nSkipBytes + nBandOffset * i,
-                nPixelOffset, nLineOffset, eDataType, bNativeOrder);
-
-            poBand = poISISBand;
-            poDS->SetBand(i + 1, poBand);
-
-            poISISBand->SetMaskBand(new ISISMaskBand(poISISBand));
+            auto poISISBand = cpl::make_unique<ISIS3RawRasterBand>(
+                poDS.get(), i + 1, poDS->m_fpImage,
+                nSkipBytes + nBandOffset * i, nPixelOffset, nLineOffset,
+                eDataType, bNativeOrder);
+            if (!poISISBand->IsValid())
+            {
+                return nullptr;
+            }
+            poISISBand->SetMaskBand(new ISISMaskBand(poISISBand.get()));
+            poDS->SetBand(i + 1, std::move(poISISBand));
+            poBand = poDS->GetRasterBand(i + 1);
         }
 
         if (i < static_cast<int>(aosBandNames.size()))
@@ -2563,9 +2558,9 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/pds/pds4dataset.h
+++ b/frmts/pds/pds4dataset.h
@@ -464,7 +464,7 @@ class PDS4RawRasterBand final : public RawRasterBand
     PDS4RawRasterBand(GDALDataset *l_poDS, int l_nBand, VSILFILE *l_fpRaw,
                       vsi_l_offset l_nImgOffset, int l_nPixelOffset,
                       int l_nLineOffset, GDALDataType l_eDataType,
-                      int l_bNativeOrder);
+                      RawRasterBand::ByteOrder eByteOrderIn);
     virtual ~PDS4RawRasterBand()
     {
     }

--- a/frmts/pds/vicardataset.cpp
+++ b/frmts/pds/vicardataset.cpp
@@ -2558,12 +2558,11 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
         return Open(&oOpenInfo);
     }
 
-    VICARDataset *poDS = new VICARDataset();
+    auto poDS = cpl::make_unique<VICARDataset>();
     poDS->fpImage = poOpenInfo->fpL;
     poOpenInfo->fpL = nullptr;
     if (!poDS->oKeywords.Ingest(poDS->fpImage, poOpenInfo->pabyHeader))
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -2597,7 +2596,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
                  "File %s appears to be a VICAR file, but failed to find some "
                  "required keywords.",
                  poOpenInfo->pszFilename);
-        delete poDS;
         return nullptr;
     }
 
@@ -2607,7 +2605,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Could not find known VICAR label entries!\n");
-        delete poDS;
         return nullptr;
     }
     double dfNoData = 0.0;
@@ -2643,7 +2640,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "INTFMT=%s layout not supported.", value);
-            delete poDS;
             return nullptr;
         }
     }
@@ -2666,7 +2662,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "REALFMT=%s layout not supported.", value);
-            delete poDS;
             return nullptr;
         }
     }
@@ -2710,7 +2705,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
                                      (nNBB + nBandOffset * (nBands - 1)))
     {
         CPLDebug("VICAR", "Invalid spacings found");
-        delete poDS;
         return nullptr;
     }
 
@@ -2801,7 +2795,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "Update of compressed VICAR file not supported");
-            delete poDS;
             return nullptr;
         }
         poDS->SetMetadataItem("COMPRESS", osCompress, "IMAGE_STRUCTURE");
@@ -2811,14 +2804,12 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "Too many records for compressed dataset");
-            delete poDS;
             return nullptr;
         }
         if (!GDALDataTypeIsInteger(eDataType))
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "Data type incompatible of compression");
-            delete poDS;
             return nullptr;
         }
         // To avoid potential issues in basic_decode()
@@ -2826,7 +2817,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
         if (nDTSize == 0 || poDS->nRasterXSize > INT_MAX / nDTSize)
         {
             CPLError(CE_Failure, CPLE_NotSupported, "Too large scanline");
-            delete poDS;
             return nullptr;
         }
         const int nRecords = poDS->nRasterYSize * nBands;
@@ -2838,7 +2828,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
         catch (const std::exception &e)
         {
             CPLError(CE_Failure, CPLE_OutOfMemory, "%s", e.what());
-            delete poDS;
             return nullptr;
         }
         if (poDS->m_eCompress == COMPRESS_BASIC)
@@ -2856,7 +2845,6 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
     {
         CPLError(CE_Failure, CPLE_NotSupported, "COMPRESS=%s not supported",
                  osCompress.c_str());
-        delete poDS;
         return nullptr;
     }
 
@@ -2865,30 +2853,29 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     for (int i = 0; i < nBands; i++)
     {
-        GDALRasterBand *poBand;
+        std::unique_ptr<GDALRasterBand> poBand;
 
         if (poDS->m_eCompress == COMPRESS_BASIC ||
             poDS->m_eCompress == COMPRESS_BASIC2)
         {
-            poBand = new VICARBASICRasterBand(poDS, i + 1, eDataType);
+            poBand = cpl::make_unique<VICARBASICRasterBand>(poDS.get(), i + 1,
+                                                            eDataType);
         }
         else
         {
-            poBand = new VICARRawRasterBand(
-                poDS, i + 1, poDS->fpImage,
+            auto poRawBand = cpl::make_unique<VICARRawRasterBand>(
+                poDS.get(), i + 1, poDS->fpImage,
                 static_cast<vsi_l_offset>(nImageOffsetWithoutNBB + nNBB +
                                           nBandOffset * i),
                 static_cast<int>(nPixelOffset), static_cast<int>(nLineOffset),
                 eDataType, eByteOrder);
-            if (CPLGetLastErrorType() != CE_None)
+            if (!poRawBand->IsValid())
             {
-                delete poBand;
-                delete poDS;
                 return nullptr;
             }
+            poBand = std::move(poRawBand);
         }
 
-        poDS->SetBand(i + 1, poBand);
         // only set NoData if instrument is supported
         if (bInstKnown)
             poBand->SetNoDataValue(dfNoData);
@@ -2937,6 +2924,8 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
             pszStdDev != nullptr)
             poBand->SetStatistics(CPLAtofM(pszMin), CPLAtofM(pszMax),
                                   CPLAtofM(pszMean), CPLAtofM(pszStdDev));
+
+        poDS->SetBand(i + 1, std::move(poBand));
     }
 
     /* -------------------------------------------------------------------- */
@@ -3090,9 +3079,9 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/
@@ -3414,8 +3403,8 @@ GDALDataset *VICARDataset::CreateCopy(const char *pszFilename,
     const int nYSize = poSrcDS->GetRasterYSize();
     const int nBands = poSrcDS->GetRasterCount();
     GDALDataType eType = poSrcDS->GetRasterBand(1)->GetRasterDataType();
-    auto poDS = CreateInternal(pszFilename, nXSize, nYSize, nBands, eType,
-                               papszOptions);
+    auto poDS = std::unique_ptr<VICARDataset>(CreateInternal(
+        pszFilename, nXSize, nYSize, nBands, eType, papszOptions));
     if (poDS == nullptr)
         return nullptr;
 
@@ -3444,16 +3433,15 @@ GDALDataset *VICARDataset::CreateCopy(const char *pszFilename,
     }
 
     poDS->m_bInitToNodata = false;
-    CPLErr eErr = GDALDatasetCopyWholeRaster(poSrcDS, poDS, nullptr,
+    CPLErr eErr = GDALDatasetCopyWholeRaster(poSrcDS, poDS.get(), nullptr,
                                              pfnProgress, pProgressData);
     poDS->FlushCache(false);
     if (eErr != CE_None)
     {
-        delete poDS;
         return nullptr;
     }
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/raw/dipxdataset.cpp
+++ b/frmts/raw/dipxdataset.cpp
@@ -251,17 +251,14 @@ GDALDataset *DIPExDataset::Open(GDALOpenInfo *poOpenInfo)
     CPLErrorReset();
     for (int iBand = 0; iBand < nBands; iBand++)
     {
-        poDS->SetBand(iBand + 1,
-                      new RawRasterBand(poDS, iBand + 1, poDS->fp,
-                                        1024 + iBand * nLineOffset,
-                                        nBytesPerSample, nLineOffset * nBands,
-                                        poDS->eRasterDataType, CPL_IS_LSB,
-                                        RawRasterBand::OwnFP::NO));
-        if (CPLGetLastErrorType() != CE_None)
-        {
-            delete poDS;
+        auto poBand = RawRasterBand::Create(
+            poDS, iBand + 1, poDS->fp, 1024 + iBand * nLineOffset,
+            nBytesPerSample, nLineOffset * nBands, poDS->eRasterDataType,
+            RawRasterBand::ByteOrder::ORDER_LITTLE_ENDIAN,
+            RawRasterBand::OwnFP::NO);
+        if (!poBand)
             return nullptr;
-        }
+        poDS->SetBand(iBand + 1, std::move(poBand));
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/raw/ehdrdataset.h
+++ b/frmts/raw/ehdrdataset.h
@@ -140,6 +140,7 @@ class EHdrRasterBand final : public RawRasterBand
     std::shared_ptr<GDALColorTable> m_poColorTable{};
     std::shared_ptr<GDALRasterAttributeTable> m_poRAT{};
 
+    bool m_bValid = false;
     int nBits{};
     vsi_l_offset nStartBit{};
     int nPixelOffsetBits{};
@@ -163,8 +164,13 @@ class EHdrRasterBand final : public RawRasterBand
   public:
     EHdrRasterBand(GDALDataset *poDS, int nBand, VSILFILE *fpRaw,
                    vsi_l_offset nImgOffset, int nPixelOffset, int nLineOffset,
-                   GDALDataType eDataType, int bNativeOrder, int nBits);
-    ~EHdrRasterBand() override;
+                   GDALDataType eDataType,
+                   RawRasterBand::ByteOrder eByteOrderIn, int nBits);
+
+    bool IsValid() const
+    {
+        return m_bValid;
+    }
 
     CPLErr IReadBlock(int, int, void *) override;
     CPLErr IWriteBlock(int, int, void *) override;

--- a/frmts/raw/envidataset.h
+++ b/frmts/raw/envidataset.h
@@ -164,10 +164,7 @@ class ENVIRasterBand final : public RawRasterBand
     ENVIRasterBand(GDALDataset *poDSIn, int nBandIn, VSILFILE *fpRawIn,
                    vsi_l_offset nImgOffsetIn, int nPixelOffsetIn,
                    int nLineOffsetIn, GDALDataType eDataTypeIn,
-                   int bNativeOrderIn);
-    ~ENVIRasterBand() override
-    {
-    }
+                   RawRasterBand::ByteOrder eByteOrderIn);
 
     void SetDescription(const char *) override;
     CPLErr SetNoDataValue(double) override;

--- a/frmts/raw/landataset.cpp
+++ b/frmts/raw/landataset.cpp
@@ -396,26 +396,22 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
-    LANDataset *poDS = new LANDataset();
+    auto poDS = cpl::make_unique<LANDataset>();
 
     poDS->eAccess = poOpenInfo->eAccess;
-    poDS->fpImage = poOpenInfo->fpL;
-    poOpenInfo->fpL = nullptr;
+    std::swap(poDS->fpImage, poOpenInfo->fpL);
 
     /* -------------------------------------------------------------------- */
     /*      Do we need to byte swap the headers to local machine order?     */
     /* -------------------------------------------------------------------- */
-    int bBigEndian = poOpenInfo->pabyHeader[8] == 0;
+    const RawRasterBand::ByteOrder eByteOrder =
+        poOpenInfo->pabyHeader[8] == 0
+            ? RawRasterBand::ByteOrder::ORDER_BIG_ENDIAN
+            : RawRasterBand::ByteOrder::ORDER_LITTLE_ENDIAN;
 
     memcpy(poDS->pachHeader, poOpenInfo->pabyHeader, ERD_HEADER_SIZE);
 
-#ifdef CPL_LSB
-    const int bNeedSwap = bBigEndian;
-#else
-    const int bNeedSwap = !bBigEndian;
-#endif
-
-    if (bNeedSwap)
+    if (eByteOrder != RawRasterBand::NATIVE_BYTE_ORDER)
     {
         CPL_SWAP16PTR(poDS->pachHeader + 6);
         CPL_SWAP16PTR(poDS->pachHeader + 8);
@@ -480,8 +476,6 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Unsupported pixel type (%d).",
                  nTmp16);
-
-        delete poDS;
         return nullptr;
     }
 
@@ -491,7 +485,6 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
     if (!GDALCheckDatasetDimensions(poDS->nRasterXSize, poDS->nRasterYSize) ||
         !GDALCheckBandCount(nBandCount, FALSE))
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -500,31 +493,27 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
         poDS->nRasterXSize > INT_MAX / (nPixelOffset * nBandCount))
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
-        delete poDS;
         return nullptr;
     }
 
     /* -------------------------------------------------------------------- */
     /*      Create band information object.                                 */
     /* -------------------------------------------------------------------- */
-    CPLErrorReset();
     for (int iBand = 1; iBand <= nBandCount; iBand++)
     {
         if (nPixelOffset == -1) /* 4 bit case */
-            poDS->SetBand(iBand, new LAN4BitRasterBand(poDS, iBand));
+            poDS->SetBand(iBand, new LAN4BitRasterBand(poDS.get(), iBand));
         else
-            poDS->SetBand(iBand,
-                          new RawRasterBand(
-                              poDS, iBand, poDS->fpImage,
-                              ERD_HEADER_SIZE + (iBand - 1) * nPixelOffset *
-                                                    poDS->nRasterXSize,
-                              nPixelOffset,
-                              poDS->nRasterXSize * nPixelOffset * nBandCount,
-                              eDataType, !bNeedSwap, RawRasterBand::OwnFP::NO));
-        if (CPLGetLastErrorType() != CE_None)
         {
-            delete poDS;
-            return nullptr;
+            auto poBand = RawRasterBand::Create(
+                poDS.get(), iBand, poDS->fpImage,
+                ERD_HEADER_SIZE +
+                    (iBand - 1) * nPixelOffset * poDS->nRasterXSize,
+                nPixelOffset, poDS->nRasterXSize * nPixelOffset * nBandCount,
+                eDataType, eByteOrder, RawRasterBand::OwnFP::NO);
+            if (!poBand)
+                return nullptr;
+            poDS->SetBand(iBand, std::move(poBand));
         }
     }
 
@@ -538,7 +527,7 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
     /* -------------------------------------------------------------------- */
     /*      Try to interpret georeferencing.                                */
@@ -614,7 +603,7 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
         CPL_IGNORE_RET_VAL(VSIFReadL(szTRLData, 1, 896, fpTRL));
         CPL_IGNORE_RET_VAL(VSIFCloseL(fpTRL));
 
-        GDALColorTable *poCT = new GDALColorTable();
+        GDALColorTable oCT;
         for (int iColor = 0; iColor < 256; iColor++)
         {
             GDALColorEntry sEntry = {0, 0, 0, 0};
@@ -625,23 +614,21 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
             sEntry.c3 =
                 reinterpret_cast<GByte *>(szTRLData)[iColor + 128 + 512];
             sEntry.c4 = 255;
-            poCT->SetColorEntry(iColor, &sEntry);
+            oCT.SetColorEntry(iColor, &sEntry);
 
             // Only 16 colors in 4bit files.
             if (nPixelOffset == -1 && iColor == 15)
                 break;
         }
 
-        poDS->GetRasterBand(1)->SetColorTable(poCT);
+        poDS->GetRasterBand(1)->SetColorTable(&oCT);
         poDS->GetRasterBand(1)->SetColorInterpretation(GCI_PaletteIndex);
-
-        delete poCT;
     }
 
     CPLFree(pszPath);
     CPLFree(pszBasename);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/raw/lcpdataset.cpp
+++ b/frmts/raw/lcpdataset.cpp
@@ -34,6 +34,8 @@
 #include "ogr_spatialref.h"
 #include "rawdataset.h"
 
+#include <algorithm>
+
 constexpr size_t LCP_HEADER_SIZE = 7316;
 constexpr int LCP_MAX_BANDS = 10;
 constexpr int LCP_MAX_PATH = 256;
@@ -247,9 +249,8 @@ GDALDataset *LCPDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
-    LCPDataset *poDS = new LCPDataset();
-    poDS->fpImage = poOpenInfo->fpL;
-    poOpenInfo->fpL = nullptr;
+    auto poDS = cpl::make_unique<LCPDataset>();
+    std::swap(poDS->fpImage, poOpenInfo->fpL);
 
     /* -------------------------------------------------------------------- */
     /*      Read the header and extract some information.                   */
@@ -259,7 +260,6 @@ GDALDataset *LCPDataset::Open(GDALOpenInfo *poOpenInfo)
             LCP_HEADER_SIZE)
     {
         CPLError(CE_Failure, CPLE_FileIO, "File too short");
-        delete poDS;
         return nullptr;
     }
 
@@ -271,7 +271,6 @@ GDALDataset *LCPDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (!GDALCheckDatasetDimensions(poDS->nRasterXSize, poDS->nRasterYSize))
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -324,15 +323,8 @@ GDALDataset *LCPDataset::Open(GDALOpenInfo *poOpenInfo)
     if (nWidth > INT_MAX / iPixelSize)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred");
-        delete poDS;
         return nullptr;
     }
-
-#ifdef CPL_LSB
-    const bool bNativeOrder = true;
-#else
-    const bool bNativeOrder = false;
-#endif
 
     // TODO(schwehr): Explain the 2048.
     char *pszList = static_cast<char *>(CPLMalloc(2048));
@@ -340,12 +332,14 @@ GDALDataset *LCPDataset::Open(GDALOpenInfo *poOpenInfo)
 
     for (int iBand = 1; iBand <= nBands; iBand++)
     {
-        GDALRasterBand *poBand = new RawRasterBand(
-            poDS, iBand, poDS->fpImage, LCP_HEADER_SIZE + ((iBand - 1) * 2),
-            iPixelSize, iPixelSize * nWidth, GDT_Int16, bNativeOrder,
-            RawRasterBand::OwnFP::NO);
-
-        poDS->SetBand(iBand, poBand);
+        auto poBand =
+            RawRasterBand::Create(poDS.get(), iBand, poDS->fpImage,
+                                  LCP_HEADER_SIZE + ((iBand - 1) * 2),
+                                  iPixelSize, iPixelSize * nWidth, GDT_Int16,
+                                  RawRasterBand::ByteOrder::ORDER_LITTLE_ENDIAN,
+                                  RawRasterBand::OwnFP::NO);
+        if (!poBand)
+            return nullptr;
 
         switch (iBand)
         {
@@ -758,6 +752,8 @@ GDALDataset *LCPDataset::Open(GDALOpenInfo *poOpenInfo)
 
                 break;
         }
+
+        poDS->SetBand(iBand, std::move(poBand));
     }
 
     /* -------------------------------------------------------------------- */
@@ -804,12 +800,12 @@ GDALDataset *LCPDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for external overviews.                                   */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename,
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename,
                                 poOpenInfo->GetSiblingFiles());
 
     CPLFree(pszList);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/raw/ndfdataset.cpp
+++ b/frmts/raw/ndfdataset.cpp
@@ -264,7 +264,7 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
-    NDFDataset *poDS = new NDFDataset();
+    auto poDS = cpl::make_unique<NDFDataset>();
     poDS->papszHeader = papszHeader;
 
     poDS->nRasterXSize = atoi(poDS->Get("PIXELS_PER_LINE", ""));
@@ -278,7 +278,6 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
     if (pszBand == nullptr)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Cannot find band count");
-        delete poDS;
         return nullptr;
     }
     const int nBands = atoi(pszBand);
@@ -286,7 +285,6 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
     if (!GDALCheckDatasetDimensions(poDS->nRasterXSize, poDS->nRasterYSize) ||
         !GDALCheckBandCount(nBands, FALSE))
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -316,14 +314,16 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Failed to open band file: %s", osFilename.c_str());
-            delete poDS;
             return nullptr;
         }
         poDS->papszExtraFiles = CSLAddString(poDS->papszExtraFiles, osFilename);
 
-        RawRasterBand *poBand =
-            new RawRasterBand(poDS, iBand + 1, fpRaw, 0, 1, poDS->nRasterXSize,
-                              GDT_Byte, TRUE, RawRasterBand::OwnFP::YES);
+        auto poBand = RawRasterBand::Create(
+            poDS.get(), iBand + 1, fpRaw, 0, 1, poDS->nRasterXSize, GDT_Byte,
+            RawRasterBand::ByteOrder::ORDER_LITTLE_ENDIAN,
+            RawRasterBand::OwnFP::YES);
+        if (!poBand)
+            return nullptr;
 
         snprintf(szKey, sizeof(szKey), "BAND%d_NAME", iBand + 1);
         poBand->SetDescription(poDS->Get(szKey, ""));
@@ -335,23 +335,21 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
                  iBand + 1);
         poBand->SetMetadataItem("RADIOMETRIC_GAINS_BIAS", poDS->Get(szKey, ""));
 
-        poDS->SetBand(iBand + 1, poBand);
+        poDS->SetBand(iBand + 1, std::move(poBand));
     }
 
     /* -------------------------------------------------------------------- */
     /*      Fetch and parse USGS projection parameters.                     */
     /* -------------------------------------------------------------------- */
     double adfUSGSParams[15] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    char **papszParamTokens = CSLTokenizeStringComplex(
-        poDS->Get("USGS_PROJECTION_NUMBER", ""), ",", FALSE, TRUE);
+    const CPLStringList aosParamTokens(CSLTokenizeStringComplex(
+        poDS->Get("USGS_PROJECTION_NUMBER", ""), ",", FALSE, TRUE));
 
-    if (CSLCount(papszParamTokens) >= 15)
+    if (aosParamTokens.size() >= 15)
     {
         for (int i = 0; i < 15; i++)
-            adfUSGSParams[i] = CPLAtof(papszParamTokens[i]);
+            adfUSGSParams[i] = CPLAtof(aosParamTokens[i]);
     }
-    CSLDestroy(papszParamTokens);
-    papszParamTokens = nullptr;
 
     /* -------------------------------------------------------------------- */
     /*      Minimal georef support ... should add full USGS style           */
@@ -433,9 +431,9 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/raw/ntv2dataset.cpp
+++ b/frmts/raw/ntv2dataset.cpp
@@ -96,18 +96,19 @@ constexpr size_t knMAX_RECORD_SIZE = 24;
 class NTv2Dataset final : public RawDataset
 {
   public:
-    bool m_bMustSwap;
-    VSILFILE *fpImage;  // image data file.
+    RawRasterBand::ByteOrder m_eByteOrder = RawRasterBand::NATIVE_BYTE_ORDER;
+    bool m_bMustSwap = false;
+    VSILFILE *fpImage = nullptr;  // image data file.
 
     size_t nRecordSize = 0;
-    vsi_l_offset nGridOffset;
+    vsi_l_offset nGridOffset = 0;
 
     OGRSpatialReference m_oSRS{};
     double adfGeoTransform[6];
 
     void CaptureMetadataItem(const char *pszItem);
 
-    int OpenGrid(char *pachGridHeader, vsi_l_offset nDataStart);
+    bool OpenGrid(const char *pachGridHeader, vsi_l_offset nDataStart);
 
     CPL_DISALLOW_COPY_ASSIGN(NTv2Dataset)
 
@@ -145,7 +146,6 @@ class NTv2Dataset final : public RawDataset
 /************************************************************************/
 
 NTv2Dataset::NTv2Dataset()
-    : m_bMustSwap(false), fpImage(nullptr), nGridOffset(0)
 {
     m_oSRS.SetFromUserInput(SRS_WKT_WGS84_LAT_LONG);
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
@@ -431,7 +431,7 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
-    NTv2Dataset *poDS = new NTv2Dataset();
+    auto poDS = cpl::make_unique<NTv2Dataset>();
     poDS->eAccess = poOpenInfo->eAccess;
 
     /* -------------------------------------------------------------------- */
@@ -444,7 +444,6 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (poDS->fpImage == nullptr)
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -456,7 +455,6 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
     if (VSIFSeekL(poDS->fpImage, 0, SEEK_SET) != 0 ||
         VSIFReadL(achHeader, 1, 64, poDS->fpImage) != 64)
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -467,7 +465,6 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
     if (VSIFReadL(achHeader + 64, 1, 11 * poDS->nRecordSize - 64,
                   poDS->fpImage) != 11 * poDS->nRecordSize - 64)
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -477,24 +474,20 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
                        achHeader[10] == 0 && achHeader[11] == 11;
     if (!bIsLE && !bIsBE)
     {
-        delete poDS;
         return nullptr;
     }
-#ifdef CPL_LSB
-    const bool bMustSwap = bIsBE;
-#else
-    const bool bMustSwap = bIsLE;
-#endif
-    poDS->m_bMustSwap = bMustSwap;
+    poDS->m_eByteOrder = bIsLE ? RawRasterBand::ByteOrder::ORDER_LITTLE_ENDIAN
+                               : RawRasterBand::ByteOrder::ORDER_BIG_ENDIAN;
+    poDS->m_bMustSwap = poDS->m_eByteOrder != RawRasterBand::NATIVE_BYTE_ORDER;
 
-    SwapPtr32IfNecessary(bMustSwap, achHeader + 2 * poDS->nRecordSize + 8);
+    SwapPtr32IfNecessary(poDS->m_bMustSwap,
+                         achHeader + 2 * poDS->nRecordSize + 8);
     GInt32 nSubFileCount = 0;
     memcpy(&nSubFileCount, achHeader + 2 * poDS->nRecordSize + 8, 4);
     if (nSubFileCount <= 0 || nSubFileCount >= 1024)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Invalid value for NUM_FILE : %d",
                  nSubFileCount);
-        delete poDS;
         return nullptr;
     }
 
@@ -505,23 +498,23 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
 
     double dfValue = 0.0;
     memcpy(&dfValue, achHeader + 7 * poDS->nRecordSize + 8, 8);
-    SwapPtr64IfNecessary(bMustSwap, &dfValue);
+    SwapPtr64IfNecessary(poDS->m_bMustSwap, &dfValue);
     CPLString osFValue;
     osFValue.Printf("%.15g", dfValue);
     poDS->SetMetadataItem("MAJOR_F", osFValue);
 
     memcpy(&dfValue, achHeader + 8 * poDS->nRecordSize + 8, 8);
-    SwapPtr64IfNecessary(bMustSwap, &dfValue);
+    SwapPtr64IfNecessary(poDS->m_bMustSwap, &dfValue);
     osFValue.Printf("%.15g", dfValue);
     poDS->SetMetadataItem("MINOR_F", osFValue);
 
     memcpy(&dfValue, achHeader + 9 * poDS->nRecordSize + 8, 8);
-    SwapPtr64IfNecessary(bMustSwap, &dfValue);
+    SwapPtr64IfNecessary(poDS->m_bMustSwap, &dfValue);
     osFValue.Printf("%.15g", dfValue);
     poDS->SetMetadataItem("MAJOR_T", osFValue);
 
     memcpy(&dfValue, achHeader + 10 * poDS->nRecordSize + 8, 8);
-    SwapPtr64IfNecessary(bMustSwap, &dfValue);
+    SwapPtr64IfNecessary(poDS->m_bMustSwap, &dfValue);
     osFValue.Printf("%.15g", dfValue);
     poDS->SetMetadataItem("MINOR_T", osFValue);
 
@@ -538,15 +531,15 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Cannot read header for subfile %d", iGrid);
-            delete poDS;
             return nullptr;
         }
 
         for (int i = 4; i <= 9; i++)
-            SwapPtr64IfNecessary(bMustSwap,
+            SwapPtr64IfNecessary(poDS->m_bMustSwap,
                                  achHeader + i * poDS->nRecordSize + 8);
 
-        SwapPtr32IfNecessary(bMustSwap, achHeader + 10 * poDS->nRecordSize + 8);
+        SwapPtr32IfNecessary(poDS->m_bMustSwap,
+                             achHeader + 10 * poDS->nRecordSize + 8);
 
         GUInt32 nGSCount = 0;
         memcpy(&nGSCount, achHeader + 10 * poDS->nRecordSize + 8, 4);
@@ -560,7 +553,6 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
         {
             if (!poDS->OpenGrid(achHeader, nGridOffset))
             {
-                delete poDS;
                 return nullptr;
             }
         }
@@ -592,9 +584,9 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/
@@ -604,7 +596,7 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
 /*      portions of the header.                                         */
 /************************************************************************/
 
-int NTv2Dataset::OpenGrid(char *pachHeader, vsi_l_offset nGridOffsetIn)
+bool NTv2Dataset::OpenGrid(const char *pachHeader, vsi_l_offset nGridOffsetIn)
 
 {
     nGridOffset = nGridOffsetIn;
@@ -629,12 +621,12 @@ int NTv2Dataset::OpenGrid(char *pachHeader, vsi_l_offset nGridOffsetIn)
     w_long *= -1;
 
     if (long_inc == 0.0 || lat_inc == 0.0)
-        return FALSE;
+        return false;
     const double dfXSize = floor((e_long - w_long) / long_inc + 1.5);
     const double dfYSize = floor((n_lat - s_lat) / lat_inc + 1.5);
     if (!(dfXSize >= 0 && dfXSize < INT_MAX) ||
         !(dfYSize >= 0 && dfYSize < INT_MAX))
-        return FALSE;
+        return false;
     nRasterXSize = static_cast<int>(dfXSize);
     nRasterYSize = static_cast<int>(dfYSize);
 
@@ -642,9 +634,9 @@ int NTv2Dataset::OpenGrid(char *pachHeader, vsi_l_offset nGridOffsetIn)
     const int nPixelSize = l_nBands * 4;
 
     if (!GDALCheckDatasetDimensions(nRasterXSize, nRasterYSize))
-        return FALSE;
+        return false;
     if (nRasterXSize > INT_MAX / nPixelSize)
-        return FALSE;
+        return false;
 
     /* -------------------------------------------------------------------- */
     /*      Create band information object.                                 */
@@ -655,15 +647,17 @@ int NTv2Dataset::OpenGrid(char *pachHeader, vsi_l_offset nGridOffsetIn)
     /* -------------------------------------------------------------------- */
     for (int iBand = 0; iBand < l_nBands; iBand++)
     {
-        RawRasterBand *poBand = new RawRasterBand(
+        auto poBand = RawRasterBand::Create(
             this, iBand + 1, fpImage,
             nGridOffset + 4 * iBand + 11 * nRecordSize +
                 (nRasterXSize - 1) * nPixelSize +
                 static_cast<vsi_l_offset>(nRasterYSize - 1) * nPixelSize *
                     nRasterXSize,
-            -nPixelSize, -nPixelSize * nRasterXSize, GDT_Float32, !m_bMustSwap,
+            -nPixelSize, -nPixelSize * nRasterXSize, GDT_Float32, m_eByteOrder,
             RawRasterBand::OwnFP::NO);
-        SetBand(iBand + 1, poBand);
+        if (!poBand)
+            return false;
+        SetBand(iBand + 1, std::move(poBand));
     }
 
     if (l_nBands == 4)
@@ -702,7 +696,7 @@ int NTv2Dataset::OpenGrid(char *pachHeader, vsi_l_offset nGridOffsetIn)
     adfGeoTransform[4] = 0.0;
     adfGeoTransform[5] = (-1 * lat_inc) / 3600.0;
 
-    return TRUE;
+    return true;
 }
 
 /************************************************************************/

--- a/frmts/raw/pauxdataset.cpp
+++ b/frmts/raw/pauxdataset.cpp
@@ -679,7 +679,7 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
-    PAuxDataset *poDS = new PAuxDataset();
+    auto poDS = cpl::make_unique<PAuxDataset>();
 
     /* -------------------------------------------------------------------- */
     /*      Load the .aux file into a string list suitable to be            */
@@ -697,33 +697,27 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
     // some cases.  See bug 947.
     if (pszLine == nullptr)
     {
-        delete poDS;
         return nullptr;
     }
 
-    char **papszTokens = CSLTokenizeString(pszLine);
+    const CPLStringList aosTokens(CSLTokenizeString(pszLine));
 
-    if (CSLCount(papszTokens) < 3)
+    if (aosTokens.size() < 3)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "RawDefinition missing or corrupt in %s.",
                  poOpenInfo->pszFilename);
-        delete poDS;
-        CSLDestroy(papszTokens);
         return nullptr;
     }
 
-    poDS->nRasterXSize = atoi(papszTokens[0]);
-    poDS->nRasterYSize = atoi(papszTokens[1]);
-    poDS->nBands = atoi(papszTokens[2]);
+    poDS->nRasterXSize = atoi(aosTokens[0]);
+    poDS->nRasterYSize = atoi(aosTokens[1]);
+    int l_nBands = atoi(aosTokens[2]);
     poDS->eAccess = poOpenInfo->eAccess;
 
-    CSLDestroy(papszTokens);
-
     if (!GDALCheckDatasetDimensions(poDS->nRasterXSize, poDS->nRasterYSize) ||
-        !GDALCheckBandCount(poDS->nBands, FALSE))
+        !GDALCheckBandCount(l_nBands, FALSE))
     {
-        delete poDS;
         return nullptr;
     }
 
@@ -739,7 +733,6 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
             CPLError(CE_Failure, CPLE_OpenFailed,
                      "File %s is missing or read-only, check permissions.",
                      osTarget.c_str());
-            delete poDS;
             return nullptr;
         }
     }
@@ -751,7 +744,6 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLError(CE_Failure, CPLE_OpenFailed,
                      "File %s is missing or unreadable.", osTarget.c_str());
-            delete poDS;
             return nullptr;
         }
     }
@@ -760,8 +752,7 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
     /*      Collect raw definitions of each channel and create              */
     /*      corresponding bands.                                            */
     /* -------------------------------------------------------------------- */
-    int iBand = 0;
-    for (int i = 0; i < poDS->nBands; i++)
+    for (int i = 0; i < l_nBands; i++)
     {
         char szDefnName[32] = {'\0'};
         snprintf(szDefnName, sizeof(szDefnName), "ChanDefinition-%d", i + 1);
@@ -772,56 +763,51 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
             continue;
         }
 
-        papszTokens = CSLTokenizeString(pszLine);
-        if (CSLCount(papszTokens) < 4)
+        const CPLStringList aosTokensBand(CSLTokenizeString(pszLine));
+        if (aosTokensBand.size() < 4)
         {
             // Skip the band with broken description
-            CSLDestroy(papszTokens);
             continue;
         }
 
         GDALDataType eType = GDT_Unknown;
-        if (EQUAL(papszTokens[0], "16U"))
+        if (EQUAL(aosTokensBand[0], "16U"))
             eType = GDT_UInt16;
-        else if (EQUAL(papszTokens[0], "16S"))
+        else if (EQUAL(aosTokensBand[0], "16S"))
             eType = GDT_Int16;
-        else if (EQUAL(papszTokens[0], "32R"))
+        else if (EQUAL(aosTokensBand[0], "32R"))
             eType = GDT_Float32;
         else
             eType = GDT_Byte;
 
         bool bNative = true;
-        if (CSLCount(papszTokens) > 4)
+        if (CSLCount(aosTokensBand) > 4)
         {
 #ifdef CPL_LSB
-            bNative = EQUAL(papszTokens[4], "Swapped");
+            bNative = EQUAL(aosTokensBand[4], "Swapped");
 #else
-            bNative = EQUAL(papszTokens[4], "Unswapped");
+            bNative = EQUAL(aosTokensBand[4], "Unswapped");
 #endif
         }
 
         const vsi_l_offset nBandOffset = CPLScanUIntBig(
-            papszTokens[1], static_cast<int>(strlen(papszTokens[1])));
-        const int nPixelOffset = atoi(papszTokens[2]);
-        const int nLineOffset = atoi(papszTokens[3]);
+            aosTokensBand[1], static_cast<int>(strlen(aosTokensBand[1])));
+        const int nPixelOffset = atoi(aosTokensBand[2]);
+        const int nLineOffset = atoi(aosTokensBand[3]);
 
         if (nPixelOffset <= 0 || nLineOffset <= 0)
         {
             // Skip the band with broken offsets.
-            CSLDestroy(papszTokens);
             continue;
         }
 
-        poDS->SetBand(iBand + 1,
-                      new PAuxRasterBand(poDS, iBand + 1, poDS->fpImage,
-                                         nBandOffset, nPixelOffset, nLineOffset,
-                                         eType, bNative));
-        iBand++;
-
-        CSLDestroy(papszTokens);
+        auto poBand = cpl::make_unique<PAuxRasterBand>(
+            poDS.get(), poDS->nBands + 1, poDS->fpImage, nBandOffset,
+            nPixelOffset, nLineOffset, eType, bNative);
+        if (!poBand->IsValid())
+            return nullptr;
+        poDS->SetBand(poDS->nBands + 1, std::move(poBand));
     }
-
-    poDS->nBands = iBand;
 
     /* -------------------------------------------------------------------- */
     /*      Get the projection.                                             */
@@ -845,12 +831,12 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, osTarget);
+    poDS->oOvManager.Initialize(poDS.get(), osTarget);
 
     poDS->ScanForGCPs();
     poDS->bAuxUpdated = FALSE;
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/raw/pnmdataset.cpp
+++ b/frmts/raw/pnmdataset.cpp
@@ -30,6 +30,8 @@
 #include "cpl_string.h"
 #include "gdal_frmts.h"
 #include "rawdataset.h"
+
+#include <algorithm>
 #include <cctype>
 
 /************************************************************************/
@@ -228,7 +230,7 @@ GDALDataset *PNMDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
-    PNMDataset *poDS = new PNMDataset();
+    auto poDS = cpl::make_unique<PNMDataset>();
 
     /* -------------------------------------------------------------------- */
     /*      Capture some information from the file that is of interest.     */
@@ -237,19 +239,13 @@ GDALDataset *PNMDataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->nRasterYSize = nHeight;
 
     // Borrow file pointer
-    poDS->fpImage = poOpenInfo->fpL;
-    poOpenInfo->fpL = nullptr;
+    std::swap(poDS->fpImage, poOpenInfo->fpL);
 
     poDS->eAccess = poOpenInfo->eAccess;
 
-/* -------------------------------------------------------------------- */
-/*      Create band information objects.                                */
-/* -------------------------------------------------------------------- */
-#ifdef CPL_LSB
-    const bool bMSBFirst = false;
-#else
-    const bool bMSBFirst = true;
-#endif
+    /* -------------------------------------------------------------------- */
+    /*      Create band information objects.                                */
+    /* -------------------------------------------------------------------- */
 
     GDALDataType eDataType = GDT_Unknown;
     if (nMaxValue < 256)
@@ -264,39 +260,37 @@ GDALDataset *PNMDataset::Open(GDALOpenInfo *poOpenInfo)
         if (nWidth > INT_MAX / iPixelSize)
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
-            delete poDS;
             return nullptr;
         }
-        poDS->SetBand(1,
-                      new RawRasterBand(poDS, 1, poDS->fpImage, iIn, iPixelSize,
-                                        nWidth * iPixelSize, eDataType,
-                                        bMSBFirst, RawRasterBand::OwnFP::NO));
-        poDS->GetRasterBand(1)->SetColorInterpretation(GCI_GrayIndex);
+        auto poBand = RawRasterBand::Create(
+            poDS.get(), 1, poDS->fpImage, iIn, iPixelSize, nWidth * iPixelSize,
+            eDataType, RawRasterBand::ByteOrder::ORDER_BIG_ENDIAN,
+            RawRasterBand::OwnFP::NO);
+        if (!poBand)
+            return nullptr;
+        poBand->SetColorInterpretation(GCI_GrayIndex);
+        poDS->SetBand(1, std::move(poBand));
     }
     else
     {
         if (nWidth > INT_MAX / (3 * iPixelSize))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
-            delete poDS;
             return nullptr;
         }
-        poDS->SetBand(
-            1, new RawRasterBand(poDS, 1, poDS->fpImage, iIn, 3 * iPixelSize,
-                                 nWidth * 3 * iPixelSize, eDataType, bMSBFirst,
-                                 RawRasterBand::OwnFP::NO));
-        poDS->SetBand(2, new RawRasterBand(
-                             poDS, 2, poDS->fpImage, iIn + iPixelSize,
-                             3 * iPixelSize, nWidth * 3 * iPixelSize, eDataType,
-                             bMSBFirst, RawRasterBand::OwnFP::NO));
-        poDS->SetBand(3, new RawRasterBand(
-                             poDS, 3, poDS->fpImage, iIn + 2 * iPixelSize,
-                             3 * iPixelSize, nWidth * 3 * iPixelSize, eDataType,
-                             bMSBFirst, RawRasterBand::OwnFP::NO));
-
-        poDS->GetRasterBand(1)->SetColorInterpretation(GCI_RedBand);
-        poDS->GetRasterBand(2)->SetColorInterpretation(GCI_GreenBand);
-        poDS->GetRasterBand(3)->SetColorInterpretation(GCI_BlueBand);
+        for (int i = 0; i < 3; ++i)
+        {
+            auto poBand = RawRasterBand::Create(
+                poDS.get(), i + 1, poDS->fpImage, iIn + i * iPixelSize,
+                3 * iPixelSize, nWidth * 3 * iPixelSize, eDataType,
+                RawRasterBand::ByteOrder::ORDER_BIG_ENDIAN,
+                RawRasterBand::OwnFP::NO);
+            if (!poBand)
+                return nullptr;
+            poBand->SetColorInterpretation(
+                static_cast<GDALColorInterp>(GCI_RedBand + i));
+            poDS->SetBand(i + 1, std::move(poBand));
+        }
     }
 
     /* -------------------------------------------------------------------- */
@@ -314,9 +308,9 @@ GDALDataset *PNMDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/raw/snodasdataset.cpp
+++ b/frmts/raw/snodasdataset.cpp
@@ -456,7 +456,7 @@ GDALDataset *SNODASDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
-    SNODASDataset *poDS = new SNODASDataset();
+    auto poDS = cpl::make_unique<SNODASDataset>();
 
     poDS->nRasterXSize = nCols;
     poDS->nRasterYSize = nRows;
@@ -498,7 +498,10 @@ GDALDataset *SNODASDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Create band information objects.                                */
     /* -------------------------------------------------------------------- */
-    poDS->SetBand(1, new SNODASRasterBand(fpRaw, nCols, nRows));
+    auto poBand = cpl::make_unique<SNODASRasterBand>(fpRaw, nCols, nRows);
+    if (!poBand->IsValid())
+        return nullptr;
+    poDS->SetBand(1, std::move(poBand));
 
     /* -------------------------------------------------------------------- */
     /*      Initialize any PAM information.                                 */
@@ -509,9 +512,9 @@ GDALDataset *SNODASDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/safe/safedataset.cpp
+++ b/frmts/safe/safedataset.cpp
@@ -1492,7 +1492,8 @@ GDALDataset *SAFEDataset::Open(GDALOpenInfo *poOpenInfo)
                                  osCalibrationFilePath.c_str());
                         return nullptr;
                     }
-                    poDS->SetBand(poDS->GetRasterCount() + 1, poBand.release());
+                    poDS->SetBand(poDS->GetRasterCount() + 1,
+                                  std::move(poBand));
                 }
             }
         }

--- a/frmts/vrt/vrtrawrasterband.cpp
+++ b/frmts/vrt/vrtrawrasterband.cpp
@@ -274,10 +274,17 @@ CPLErr VRTRawRasterBand::SetRawLink(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     /*      Create a corresponding RawRasterBand.                           */
     /* -------------------------------------------------------------------- */
-    m_poRawRaster = new RawRasterBand(
-        reinterpret_cast<VSILFILE *>(fp), nImageOffset, nPixelOffset,
-        nLineOffset, GetRasterDataType(), eByteOrder, GetXSize(), GetYSize(),
-        RawRasterBand::OwnFP::NO);
+    m_poRawRaster =
+        RawRasterBand::Create(reinterpret_cast<VSILFILE *>(fp), nImageOffset,
+                              nPixelOffset, nLineOffset, GetRasterDataType(),
+                              eByteOrder, GetXSize(), GetYSize(),
+                              RawRasterBand::OwnFP::NO)
+            .release();
+    if (!m_poRawRaster)
+    {
+        CPLCloseShared(fp);
+        return CE_Failure;
+    }
 
     /* -------------------------------------------------------------------- */
     /*      Reset block size to match the raw raster.                       */

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -393,7 +393,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
 
     void RasterInitialize(int, int);
     void SetBand(int, GDALRasterBand *);
-    void SetBand(int nNewBand, std::unique_ptr<GDALRasterBand> &&poBand);
+    void SetBand(int nNewBand, std::unique_ptr<GDALRasterBand> poBand);
 
     GDALDefaultOverviews oOvManager{};
 

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -393,6 +393,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
 
     void RasterInitialize(int, int);
     void SetBand(int, GDALRasterBand *);
+    void SetBand(int nNewBand, std::unique_ptr<GDALRasterBand> &&poBand);
 
     GDALDefaultOverviews oOvManager{};
 

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -804,6 +804,25 @@ void GDALDataset::SetBand(int nNewBand, GDALRasterBand *poBand)
 //! @endcond
 
 /************************************************************************/
+/*                              SetBand()                               */
+/************************************************************************/
+
+//! @cond Doxygen_Suppress
+/**  Set a band in the band array, updating the band count, and array size
+ * appropriately.
+ *
+ * @param nNewBand new band number (indexing starts at 1)
+ * @param poBand band object.
+ */
+
+void GDALDataset::SetBand(int nNewBand,
+                          std::unique_ptr<GDALRasterBand> &&poBand)
+{
+    SetBand(nNewBand, poBand.release());
+}
+//! @endcond
+
+/************************************************************************/
 /*                           GetRasterXSize()                           */
 /************************************************************************/
 

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -815,8 +815,7 @@ void GDALDataset::SetBand(int nNewBand, GDALRasterBand *poBand)
  * @param poBand band object.
  */
 
-void GDALDataset::SetBand(int nNewBand,
-                          std::unique_ptr<GDALRasterBand> &&poBand)
+void GDALDataset::SetBand(int nNewBand, std::unique_ptr<GDALRasterBand> poBand)
 {
     SetBand(nNewBand, poBand.release());
 }

--- a/gcore/rawdataset.cpp
+++ b/gcore/rawdataset.cpp
@@ -111,6 +111,24 @@ RawRasterBand::RawRasterBand(GDALDataset *poDSIn, int nBandIn,
 }
 
 /************************************************************************/
+/*                          RawRasterBand::Create()                     */
+/************************************************************************/
+
+std::unique_ptr<RawRasterBand>
+RawRasterBand::Create(GDALDataset *poDSIn, int nBandIn, VSILFILE *fpRawLIn,
+                      vsi_l_offset nImgOffsetIn, int nPixelOffsetIn,
+                      int nLineOffsetIn, GDALDataType eDataTypeIn,
+                      ByteOrder eByteOrderIn, OwnFP bOwnsFPIn)
+{
+    auto poBand = cpl::make_unique<RawRasterBand>(
+        poDSIn, nBandIn, fpRawLIn, nImgOffsetIn, nPixelOffsetIn, nLineOffsetIn,
+        eDataTypeIn, eByteOrderIn, bOwnsFPIn);
+    if (!poBand->IsValid())
+        return nullptr;
+    return poBand;
+}
+
+/************************************************************************/
 /*                           RawRasterBand()                            */
 /************************************************************************/
 
@@ -129,6 +147,24 @@ RawRasterBand::RawRasterBand(VSILFILE *fpRawLIn, vsi_l_offset nImgOffsetIn,
 #endif
                     nXSize, nYSize, bOwnsFPIn)
 {
+}
+
+/************************************************************************/
+/*                          RawRasterBand::Create()                     */
+/************************************************************************/
+
+std::unique_ptr<RawRasterBand>
+RawRasterBand::Create(VSILFILE *fpRawIn, vsi_l_offset nImgOffsetIn,
+                      int nPixelOffsetIn, int nLineOffsetIn,
+                      GDALDataType eDataTypeIn, ByteOrder eByteOrderIn,
+                      int nXSizeIn, int nYSizeIn, OwnFP bOwnsFPIn)
+{
+    auto poBand = cpl::make_unique<RawRasterBand>(
+        fpRawIn, nImgOffsetIn, nPixelOffsetIn, nLineOffsetIn, eDataTypeIn,
+        eByteOrderIn, nXSizeIn, nYSizeIn, bOwnsFPIn);
+    if (!poBand->IsValid())
+        return nullptr;
+    return poBand;
 }
 
 /************************************************************************/

--- a/gcore/rawdataset.h
+++ b/gcore/rawdataset.h
@@ -94,6 +94,13 @@ class CPL_DLL RawRasterBand : public GDALPamRasterBand
         ORDER_VAX  // only valid for Float32, Float64, CFloat32 and CFloat64
     };
 
+#ifdef CPL_LSB
+    static constexpr ByteOrder NATIVE_BYTE_ORDER =
+        ByteOrder::ORDER_LITTLE_ENDIAN;
+#else
+    static constexpr ByteOrder NATIVE_BYTE_ORDER = ByteOrder::ORDER_BIG_ENDIAN;
+#endif
+
   protected:
     friend class RawDataset;
 
@@ -145,23 +152,44 @@ class CPL_DLL RawRasterBand : public GDALPamRasterBand
         YES
     };
 
+    // IsValid() should be called afterwards
     RawRasterBand(GDALDataset *poDS, int nBand, VSILFILE *fpRaw,
                   vsi_l_offset nImgOffset, int nPixelOffset, int nLineOffset,
                   GDALDataType eDataType, int bNativeOrder, OwnFP bOwnsFP);
 
+    // IsValid() should be called afterwards
     RawRasterBand(GDALDataset *poDS, int nBand, VSILFILE *fpRaw,
                   vsi_l_offset nImgOffset, int nPixelOffset, int nLineOffset,
                   GDALDataType eDataType, ByteOrder eByteOrder, OwnFP bOwnsFP);
 
+    // IsValid() should be called afterwards
     RawRasterBand(VSILFILE *fpRaw, vsi_l_offset nImgOffset, int nPixelOffset,
                   int nLineOffset, GDALDataType eDataType, int bNativeOrder,
                   int nXSize, int nYSize, OwnFP bOwnsFP);
 
+    // IsValid() should be called afterwards
     RawRasterBand(VSILFILE *fpRaw, vsi_l_offset nImgOffset, int nPixelOffset,
                   int nLineOffset, GDALDataType eDataType, ByteOrder eByteOrder,
                   int nXSize, int nYSize, OwnFP bOwnsFP);
 
+    // Returns nullptr in case of error
+    static std::unique_ptr<RawRasterBand>
+    Create(GDALDataset *poDS, int nBand, VSILFILE *fpRaw,
+           vsi_l_offset nImgOffset, int nPixelOffset, int nLineOffset,
+           GDALDataType eDataType, ByteOrder eByteOrder, OwnFP bOwnsFP);
+
+    // Returns nullptr in case of error
+    static std::unique_ptr<RawRasterBand>
+    Create(VSILFILE *fpRaw, vsi_l_offset nImgOffset, int nPixelOffset,
+           int nLineOffset, GDALDataType eDataType, ByteOrder eByteOrder,
+           int nXSize, int nYSize, OwnFP bOwnsFP);
+
     virtual ~RawRasterBand() /* = 0 */;
+
+    bool IsValid() const
+    {
+        return pLineStart != nullptr;
+    }
 
     CPLErr IReadBlock(int, int, void *) override;
     CPLErr IWriteBlock(int, int, void *) override;


### PR DESCRIPTION
Initially to fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57124 in ERS driver, but turned to be a systematic issue among all those RawRasterBand based drivers.
- GDALDataset:: add a SetBand() method that takes a std::unique_ptr<GDALRasterBand>&&
- RawRasterBand: add IsValid() and Create() methods that return a unique_ptr<RawRasterBand>
- Use std::unique_ptr<>'ification for dataset and band objects in those drivers, use RawRasterBand:IsValid()/Ceate()