### PR TITLE
Python bindings: remove redundant exception managers

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -159,22 +159,6 @@ def basic_test_7_internal():
     assert gdal.GetLastErrorType() == 0, "got unexpected error type"
 
 
-def test_basic_test_7():
-    old_val = gdal.GetUseExceptions()
-    try:
-        with gdal.enable_exceptions():
-            basic_test_7_internal()
-    finally:
-        assert old_val == gdal.GetUseExceptions()
-
-    try:
-        with gdal.enable_exceptions():
-            with gdal.enable_exceptions():
-                basic_test_7_internal()
-    finally:
-        assert old_val == gdal.GetUseExceptions()
-
-
 ###############################################################################
 # Test gdal.VersionInfo('RELEASE_DATE') and gdal.VersionInfo('LICENSE')
 

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -727,7 +727,7 @@ def test_numpy_rw_failure_in_readasarray():
     assert ds is not None
 
     exception_raised = False
-    with gdaltest.enable_exceptions():
+    with gdal.ExceptionMgr():
         try:
             ds.ReadAsArray()
         except RuntimeError:
@@ -735,7 +735,7 @@ def test_numpy_rw_failure_in_readasarray():
     assert exception_raised
 
     exception_raised = False
-    with gdaltest.enable_exceptions():
+    with gdal.ExceptionMgr():
         try:
             ds.GetRasterBand(1).ReadAsArray()
         except RuntimeError:

--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -60,17 +60,17 @@ def test_mem_md_basic():
     assert not rg.GetAttribute("not existing")
     assert not rg.GetVectorLayerNames()
     assert not rg.OpenVectorLayer("not existing")
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         rg.OpenMDArray("not existing")
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         rg.OpenMDArrayFromFullname("not existing")
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         rg.OpenGroup("not existing")
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         rg.OpenGroupFromFullname("not existing")
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         rg.GetAttribute("not existing")
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         rg.OpenVectorLayer("not existing")
 
 
@@ -103,7 +103,7 @@ def test_mem_md_subgroup():
     array = rg.OpenMDArrayFromFullname("/subgroup/myarray")
     assert array is not None
     assert array.GetFullName() == "/subgroup/myarray"
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         array.GetAttribute("not existing")
 
     copy_ds = drv.CreateCopy("", ds)
@@ -2114,7 +2114,7 @@ def test_mem_md_array_resolvemdarray():
     b.CreateMDArray("var_c", [], gdal.ExtendedDataType.Create(gdal.GDT_Int16))
 
     assert rg.ResolveMDArray("x", "/") is None
-    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+    with gdal.ExceptionMgr(), pytest.raises(Exception):
         rg.ResolveMDArray("x", "/")
 
     assert rg.ResolveMDArray("/a/var_a", "/").GetFullName() == "/a/var_a"

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -903,13 +903,13 @@ def test_ogr_basic_get_geometry_types():
 
 
 ###############################################################################
-# Test ogr.enable_exceptions()
+# Test ogr.ExceptionMgr()
 
 
 def test_ogr_exceptions():
 
     with pytest.raises(Exception):
-        with ogr.enable_exceptions():
+        with ogr.ExceptionMgr():
             ogr.CreateGeometryFromWkt("invalid")
 
 

--- a/autotest/ogr/ogr_geos.py
+++ b/autotest/ogr/ogr_geos.py
@@ -534,7 +534,7 @@ def test_ogr_geos_isvalid_false_too_few_points():
         "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (2 2, 3 2, 2 2))"
     )
 
-    with ogrtest.enable_exceptions():  # fail test if exception is thrown
+    with ogr.ExceptionMgr():  # fail test if exception is thrown
         with gdaltest.error_handler():
             isvalid = g1.IsValid()
 

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -5825,7 +5825,7 @@ def test_ogr_pg_copy_error(with_and_without_postgis):
     f = ogr.Feature(src_lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("MULTIPOLYGON(((0 0,0 1,1 1,0 0)))"))
     src_lyr.CreateFeature(f)
-    with gdaltest.enable_exceptions():
+    with gdal.ExceptionMgr():
         with pytest.raises(RuntimeError):
             gdal.VectorTranslate("PG:" + gdaltest.pg_connection_string, src_ds)
 

--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -2246,13 +2246,13 @@ def test_osr_basic_eqearth_central_meridian():
 
 
 ###############################################################################
-# Test osr.enable_exceptions()
+# Test osr.ExceptionMgr()
 
 
 def test_osr_exceptions():
 
     with pytest.raises(Exception):
-        with osr.enable_exceptions():
+        with osr.ExceptionMgr():
             srs = osr.SpatialReference()
             srs.ImportFromEPSG(0)
 

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1972,13 +1972,6 @@ def tempfile(filename, content):
 
 
 ###############################################################################
-# Temporarily enable exceptions
-
-
-enable_exceptions = gdal.enable_exceptions
-
-
-###############################################################################
 
 
 def gdalurlopen(url, timeout=10):

--- a/autotest/pymod/ogrtest.py
+++ b/autotest/pymod/ogrtest.py
@@ -24,7 +24,6 @@
 # Boston, MA 02111-1307, USA.
 ###############################################################################
 
-import contextlib
 import sys
 
 import pytest
@@ -218,26 +217,6 @@ def compare_layers(lyr, lyr_ref, excluded_fields=None):
     if f is not None:
         f.DumpReadable()
         pytest.fail()
-
-
-###############################################################################
-# Temporarily enable exceptions
-
-
-@contextlib.contextmanager
-def enable_exceptions():
-    if ogr.GetUseExceptions():
-        try:
-            yield
-        finally:
-            pass
-        return
-
-    ogr.UseExceptions()
-    try:
-        yield
-    finally:
-        ogr.DontUseExceptions()
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -539,7 +539,7 @@ def test_gdalbuildvrt_lib_warnings_and_custom_error_handler():
 
     err_handler = GdalErrorHandler()
     with gdaltest.error_handler(err_handler.handler):
-        with gdaltest.enable_exceptions():
+        with gdal.ExceptionMgr():
             vrt_ds = gdal.BuildVRT("", [ds_one_band, ds_two_band])
     assert vrt_ds
     assert not err_handler.got_failure
@@ -547,7 +547,7 @@ def test_gdalbuildvrt_lib_warnings_and_custom_error_handler():
 
     err_handler = GdalErrorHandler()
     with gdaltest.error_handler(err_handler.handler):
-        with gdaltest.enable_exceptions():
+        with gdal.ExceptionMgr():
             vrt_ds = gdal.BuildVRT("", [ds_two_band, ds_one_band])
     assert vrt_ds
     assert not err_handler.got_failure
@@ -557,7 +557,7 @@ def test_gdalbuildvrt_lib_warnings_and_custom_error_handler():
 ###############################################################################
 def test_gdalbuildvrt_lib_strict_mode():
 
-    with gdaltest.enable_exceptions():
+    with gdal.ExceptionMgr():
         with gdaltest.error_handler():
             assert (
                 gdal.BuildVRT(
@@ -566,7 +566,7 @@ def test_gdalbuildvrt_lib_strict_mode():
                 is not None
             )
 
-    with gdaltest.enable_exceptions():
+    with gdal.ExceptionMgr():
         with pytest.raises(Exception):
             gdal.BuildVRT(
                 "", ["../gcore/data/byte.tif", "i_dont_exist.tif"], strict=True

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3332,32 +3332,4 @@ def config_option(key, value, thread_local=True):
     """
     return config_options({key: value}, thread_local=thread_local)
 
-
-@contextlib.contextmanager
-def enable_exceptions():
-    """Temporarily enable exceptions.
-
-       Note: this will only affect the osgeo.gdal module. For ogr or osr
-       modules, use respectively osgeo.ogr.enable_exceptions() and
-       osgeo.osr.enable_exceptions().
-
-       Returns
-       -------
-            A context manager
-
-       Example
-       -------
-
-           with gdal.enable_exceptions():
-               gdal.Translate("out.tif", "in.tif", format="COG")
-    """
-    if GetUseExceptions():
-        yield
-    else:
-        UseExceptions()
-        try:
-            yield
-        finally:
-            DontUseExceptions()
-
 %}

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -805,35 +805,3 @@ del _Module
 
 %}
 #endif
-
-%pythoncode %{
-
-import contextlib
-@contextlib.contextmanager
-def enable_exceptions():
-    """Temporarily enable exceptions.
-
-       Note: this will only affect the osgeo.ogr module. For gdal or osr
-       modules, use respectively osgeo.gdal.enable_exceptions() and
-       osgeo.osr.enable_exceptions().
-
-       Returns
-       -------
-            A context manager
-
-       Example
-       -------
-
-           with ogr.enable_exceptions():
-               ogr.VectorTranslate("out.gpkg", "in.shp")
-    """
-    if GetUseExceptions():
-        yield
-    else:
-        UseExceptions()
-        try:
-            yield
-        finally:
-            DontUseExceptions()
-
-%}

--- a/swig/include/python/osr_python.i
+++ b/swig/include/python/osr_python.i
@@ -37,36 +37,3 @@
 
   %}
 }
-
-%pythoncode %{
-
-import contextlib
-@contextlib.contextmanager
-def enable_exceptions():
-    """Temporarily enable exceptions.
-
-       Note: this will only affect the osgeo.osr module. For gdal or ogr
-       modules, use respectively osgeo.gdal.enable_exceptions() and
-       osgeo.ogr.enable_exceptions().
-
-       Returns
-       -------
-            A context manager
-
-       Example
-       -------
-
-           with osr.enable_exceptions():
-               srs = osr.SpatialReference()
-               srs.ImportFromEPSG(code)
-    """
-    if GetUseExceptions():
-        yield
-    else:
-        UseExceptions()
-        try:
-            yield
-        finally:
-            DontUseExceptions()
-
-%}

--- a/swig/include/python/python_exceptions.i
+++ b/swig/include/python/python_exceptions.i
@@ -237,7 +237,7 @@ static void StoreLastException()
 
           >>> print(gdal.GetUseExceptions())
           0
-          >>> with gdal.ExceptionMgr(useExceptions=True):
+          >>> with gdal.ExceptionMgr():
           ...     # Exceptions are now in use
           ...     print(gdal.GetUseExceptions())
           1
@@ -247,7 +247,7 @@ static void StoreLastException()
           0
 
       """
-      def __init__(self, useExceptions):
+      def __init__(self, useExceptions=True):
           """
           Save whether or not this context will be using exceptions
           """


### PR DESCRIPTION
PR #6637 introduced a gdal/ogr/osr.ContextMgr() class, which I forgot when committing 26151f7ae405c5b213a823a316d30047d1283cb3 ("Python bindings: add gdal.enable_exceptions() context manager") in PR

So:
- remove this redundant gdal/ogr/osr.enable_exceptions()
- remove gdaltest/ogrtest.enable_exceptions()
- use ContextMgr() instead
- and make its useExceptions argument default to True
