### PR TITLE
COG: set GDAL_NUM_THREADS to NUM_THREADS if its not already set

### DIFF
--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -630,8 +630,10 @@ static std::unique_ptr<GDALDataset> CreateReprojectedDS(
         papszArg = CSLAddString(
             papszArg, (CPLString("NUM_THREADS=") + pszNumThreads).c_str());
 
-        const char* pszWarpThreads = CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
-        if (!pszWarpThreads) {
+        const char *pszWarpThreads =
+            CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
+        if (!pszWarpThreads)
+        {
             CPLSetConfigOption("GDAL_NUM_THREADS", pszNumThreads);
         }
     }

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -629,6 +629,11 @@ static std::unique_ptr<GDALDataset> CreateReprojectedDS(
         papszArg = CSLAddString(papszArg, "-wo");
         papszArg = CSLAddString(
             papszArg, (CPLString("NUM_THREADS=") + pszNumThreads).c_str());
+
+        const char* pszWarpThreads = CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
+        if (!pszWarpThreads) {
+            CPLSetConfigOption("GDAL_NUM_THREADS", pszNumThreads);
+        }
     }
 
     const auto poFirstBand = poSrcDS->GetRasterBand(1);


### PR DESCRIPTION
## What does this PR do?

This enables multithreading on the warp which greatly increases the speed of the COG creation.

## What are related issues/pull requests?

fixes: #7478

## Tasklist

 - [ ] Add test case(s)
> do you have an example test that checks Config changes, my grepping has turned up empty on GDAL_NUM_THREADS, the tests I found mostly just check the output to make sure its still the same, not that muliple threads were used?

 - [ ] Add documentation
> Do we need any docs updated for this?

 - [ ] Updated Python API documentation (swig/include/python/docs/)
> I dont think this changes the python docs


 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

