### PR TITLE
osm: Fix handling of closed_ways_are_polygons setting in osmconf.ini

### DIFF
--- a/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -3428,7 +3428,7 @@ bool OGROSMDataSource::ParseConf(char **papszOpenOptionsIn)
                 m_nMinSizeKeysInSetClosedWaysArePolygons = std::min(
                     m_nMinSizeKeysInSetClosedWaysArePolygons, nTokenSize);
                 m_nMaxSizeKeysInSetClosedWaysArePolygons = std::max(
-                    m_nMinSizeKeysInSetClosedWaysArePolygons, nTokenSize);
+                    m_nMaxSizeKeysInSetClosedWaysArePolygons, nTokenSize);
             }
             CSLDestroy(papszTokens2);
         }


### PR DESCRIPTION

## What does this PR do?

Fixes a bug were the maximum key size was always just the length of the last key in the setting. This meant that any longer previous keys were never used. 

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed