### PR TITLE
[Backport release/3.6] osm: Fix handling of closed_ways_are_polygons setting in osmconf.ini

### DIFF
--- a/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -3429,7 +3429,7 @@ bool OGROSMDataSource::ParseConf(char **papszOpenOptionsIn)
                 m_nMinSizeKeysInSetClosedWaysArePolygons = std::min(
                     m_nMinSizeKeysInSetClosedWaysArePolygons, nTokenSize);
                 m_nMaxSizeKeysInSetClosedWaysArePolygons = std::max(
-                    m_nMinSizeKeysInSetClosedWaysArePolygons, nTokenSize);
+                    m_nMaxSizeKeysInSetClosedWaysArePolygons, nTokenSize);
             }
             CSLDestroy(papszTokens2);
         }


### PR DESCRIPTION
Backport #7487
 **Authored by:** @xabbu42