### PR TITLE
GTiff: correctly read GCPs from ArcGIS 9 .aux.xml when TIFFTAG_RESOLUTIONUNIT=3 (pixels/cm) (fixes #7484)

### DIFF
--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -15988,12 +15988,9 @@ void GTiffDataset::ApplyPamInfo()
                 psGeodataXform = CPLGetXMLNode(psValueAsXML, "=GeodataXform");
         }
 
-        const char *pszTIFFTagResUnit =
-            GetMetadataItem("TIFFTAG_RESOLUTIONUNIT");
         const char *pszTIFFTagXRes = GetMetadataItem("TIFFTAG_XRESOLUTION");
         const char *pszTIFFTagYRes = GetMetadataItem("TIFFTAG_YRESOLUTION");
-        if (psGeodataXform && pszTIFFTagResUnit && pszTIFFTagXRes &&
-            pszTIFFTagYRes && atoi(pszTIFFTagResUnit) == 2)
+        if (psGeodataXform && pszTIFFTagXRes && pszTIFFTagYRes)
         {
             CPLXMLNode *psSourceGCPs =
                 CPLGetXMLNode(psGeodataXform, "SourceGCPs");
@@ -16041,7 +16038,8 @@ void GTiffDataset::ApplyPamInfo()
                         m_pasGCPList[i].pszId = CPLStrdup("");
                         m_pasGCPList[i].pszInfo = CPLStrdup("");
                         // The origin used is the bottom left corner,
-                        // and raw values are in inches!
+                        // and raw values to be multiplied by the
+                        // TIFFTAG_XRESOLUTION/TIFFTAG_YRESOLUTION
                         m_pasGCPList[i].dfGCPPixel =
                             adfSourceGCPs[2 * i] * CPLAtof(pszTIFFTagXRes);
                         m_pasGCPList[i].dfGCPLine =


### PR DESCRIPTION
I've verified that with thix fix the GeoTIFF referenced in #7484 once warped with gdalwarp overlays correctly on top of OSM