### PR TITLE
PG: Add SKIP_VIEWS open option to replace PG_SKIP_VIEWS config option

### DIFF
--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -151,6 +151,8 @@ Dataset open options
    separated).
 -  **LIST_ALL_TABLES**\ =YES/NO: This may be "YES" to force all tables,
    including non-spatial ones, to be listed.
+-  **SKIP_VIEWS**\ =YES/NO: (GDAL >= 3.7) This may be "YES" to prevent
+   views from being listed.
 -  **PRELUDE_STATEMENTS**\ =string (GDAL >= 2.1). SQL statement(s) to
    send on the PostgreSQL client connection before any other ones. In
    case of several statements, they must be separated with the

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -600,6 +600,8 @@ class OGRPGDataSource final : public OGRDataSource
     int bHasLoadTables = false;
     CPLString osActiveSchema{};
     int bListAllTables = false;
+    bool m_bSkipViews = false;
+
     void LoadTables();
 
     CPLString osDebugLastTransactionCommand{};

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -964,6 +964,10 @@ int OGRPGDataSource::Open(const char *pszNewName, int bUpdate, int bTestOpen,
         CSLFetchNameValueDef(papszOpenOptions, "LIST_ALL_TABLES",
                              CPLGetConfigOption("PG_LIST_ALL_TABLES", "NO")));
 
+    m_bSkipViews = CPLTestBool(
+        CSLFetchNameValueDef(papszOpenOptions, "SKIP_VIEWS",
+                             CPLGetConfigOption("PG_SKIP_VIEWS", "NO")));
+
     return TRUE;
 }
 
@@ -1049,10 +1053,7 @@ void OGRPGDataSource::LoadTables()
     /*      Get a list of available tables if they have not been            */
     /*      specified through the TABLES connection string param           */
     /* -------------------------------------------------------------------- */
-    const char *pszAllowedRelations =
-        CPLTestBool(CPLGetConfigOption("PG_SKIP_VIEWS", "NO"))
-            ? "'r'"
-            : "'r','v','m','f'";
+    const char *pszAllowedRelations = m_bSkipViews ? "'r'" : "'r','v','m','f'";
 
     hSetTables = CPLHashSetNew(OGRPGHashTableEntry, OGRPGEqualTableEntry,
                                OGRPGFreeTableEntry);

--- a/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
@@ -143,6 +143,9 @@ void RegisterOGRPG()
         "  <Option name='CLOSING_STATEMENTS' type='string' description='SQL "
         "statements() to send on the PostgreSQL client connection after any "
         "other ones'/>"
+        "  <Option name='SKIP_VIEWS' type='boolean' description='Whether "
+        "views should be omitted from the list' "
+        "default='NO'/>"
         "</OpenOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST,


### PR DESCRIPTION
## What does this PR do?

Adds a `SKIP_VIEWS` open option to the Postgres driver to replace the undocumented `PG_SKIP_VIEWS` config option

## What are related issues/pull requests?

## Tasklist

 - [X] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
