### PR TITLE
Add jquery sphinx extension

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,4 +8,4 @@ sphinx_rtd_theme
 recommonmark
 sphinx-markdown-tables
 sphinxcontrib-spelling
-sphinxcontrib.jquery
+sphinxcontrib-jquery

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,3 +8,4 @@ sphinx_rtd_theme
 recommonmark
 sphinx-markdown-tables
 sphinxcontrib-spelling
+sphinxcontrib.jquery

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "redirects",
     "driverproperties",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.jquery"
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## What does this PR do?

Fix the search bar of the documentation. Right now the search box is looping forever because of JQuery `Uncaught ReferenceError: jQuery is not defined`. We had a similar problem in QGIS (https://github.com/qgis/pyqgis/issues/109). Hopefully this small PR should fix the problem

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Debian Sid
