### PR TITLE
C# Bindings: Add missing GDAL wrappers

### DIFF
--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -351,4 +351,76 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
       return retval;
    }
 
+   public static Dataset BuildVRT(string dest, string[] poObjects, GDALBuildVRTOptions buidVrtAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
+      Dataset retval = null;
+      if (poObjects.Length <= 0)
+        throw new ArgumentException("poObjects size is small (BuildVRT)");
+
+      int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
+      IntPtr nativeArray = Marshal.AllocHGlobal(poObjects.Length * intPtrSize);
+      try {
+          for (int i=0; i < poObjects.Length; i++)
+            Marshal.WriteIntPtr(nativeArray, i * intPtrSize, Dataset.getCPtr(poObjects[i]).Handle);
+
+          retval  = wrapper_GDALBuildVRT_names(dstDS, poObjects, nativeArray, buidVrtAppOptions, callback, callback_data);
+      } finally {
+          Marshal.FreeHGlobal(nativeArray);
+      }
+      return retval;
+   }
+
+   public static Dataset BuildVRT(string dest, Dataset[] poObjects, GDALBuildVRTOptions buidVrtAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
+      Dataset retval = null;
+      if (poObjects.Length <= 0)
+        throw new ArgumentException("poObjects size is small (BuildVRT)");
+
+      int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
+      IntPtr nativeArray = Marshal.AllocHGlobal(poObjects.Length * intPtrSize);
+      try {
+          for (int i=0; i < poObjects.Length; i++)
+            Marshal.WriteIntPtr(nativeArray, i * intPtrSize, Dataset.getCPtr(poObjects[i]).Handle);
+
+          retval  = wrapper_GDALBuildVRT_objects(dest, poObjects.Length, nativeArray, buidVrtAppOptions, callback, callback_data);
+      } finally {
+          Marshal.FreeHGlobal(nativeArray);
+      }
+      return retval;
+   }
+
+    public static int GDALMultiDimTranslate(Dataset dstDS, Dataset[] poObjects, MultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
+      int retval = 0;
+      if (poObjects.Length <= 0)
+        throw new ArgumentException("poObjects size is small (GDALMultiDimTranslateDestDS)");
+
+      int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
+      IntPtr nativeArray = Marshal.AllocHGlobal(poObjects.Length * intPtrSize);
+      try {
+          for (int i=0; i < poObjects.Length; i++)
+            Marshal.WriteIntPtr(nativeArray, i * intPtrSize, Dataset.getCPtr(poObjects[i]).Handle);
+
+          retval  = wrapper_GDALMultiDimTranslateDestDS(dstDS, poObjects.Length, nativeArray, multiDimAppOptions, callback, callback_data);
+      } finally {
+          Marshal.FreeHGlobal(nativeArray);
+      }
+      return retval;
+   }
+
+   public static Dataset GDALMultiDimTranslate(string dest, Dataset[] poObjects, MultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
+      Dataset retval = null;
+      if (poObjects.Length <= 0)
+        throw new ArgumentException("poObjects size is small (GDALMultiDimTranslateDestName)");
+
+      int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
+      IntPtr nativeArray = Marshal.AllocHGlobal(poObjects.Length * intPtrSize);
+      try {
+          for (int i=0; i < poObjects.Length; i++)
+            Marshal.WriteIntPtr(nativeArray, i * intPtrSize, Dataset.getCPtr(poObjects[i]).Handle);
+
+          retval  = wrapper_GDALMultiDimTranslateDestName(dest, poObjects.Length, nativeArray, multiDimAppOptions, callback, callback_data);
+      } finally {
+          Marshal.FreeHGlobal(nativeArray);
+      }
+      return retval;
+   }
+
 %}

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -387,7 +387,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
       return retval;
    }
 
-    public static int GDALMultiDimTranslate(Dataset dstDS, Dataset[] poObjects, MultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
+    public static int GDALMultiDimTranslate(Dataset dstDS, Dataset[] poObjects, GDALMultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
       int retval = 0;
       if (poObjects.Length <= 0)
         throw new ArgumentException("poObjects size is small (GDALMultiDimTranslateDestDS)");
@@ -405,7 +405,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
       return retval;
    }
 
-   public static Dataset GDALMultiDimTranslate(string dest, Dataset[] poObjects, MultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
+   public static Dataset GDALMultiDimTranslate(string dest, Dataset[] poObjects, GDALMultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
       Dataset retval = null;
       if (poObjects.Length <= 0)
         throw new ArgumentException("poObjects size is small (GDALMultiDimTranslateDestName)");

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -373,7 +373,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
       return retval;
    }
 
-   public static Dataset GDALMultiDimTranslate(string dest, Dataset[] poObjects, GDALMultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
+   public static Dataset MultiDimTranslate(string dest, Dataset[] poObjects, GDALMultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
       Dataset retval = null;
       if (poObjects.Length <= 0)
         throw new ArgumentException("poObjects size is small (GDALMultiDimTranslateDestName)");

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -352,21 +352,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
    }
 
    public static Dataset BuildVRT(string dest, string[] poObjects, GDALBuildVRTOptions buidVrtAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
-      Dataset retval = null;
-      if (poObjects.Length <= 0)
-        throw new ArgumentException("poObjects size is small (BuildVRT)");
-
-      int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
-      IntPtr nativeArray = Marshal.AllocHGlobal(poObjects.Length * intPtrSize);
-      try {
-          for (int i=0; i < poObjects.Length; i++)
-            Marshal.WriteIntPtr(nativeArray, i * intPtrSize, Dataset.getCPtr(poObjects[i]).Handle);
-
-          retval  = wrapper_GDALBuildVRT_names(dstDS, poObjects, nativeArray, buidVrtAppOptions, callback, callback_data);
-      } finally {
-          Marshal.FreeHGlobal(nativeArray);
-      }
-      return retval;
+      return wrapper_GDALBuildVRT_names(dest, poObjects, buidVrtAppOptions, callback, callback_data); 
    }
 
    public static Dataset BuildVRT(string dest, Dataset[] poObjects, GDALBuildVRTOptions buidVrtAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
@@ -381,24 +367,6 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
             Marshal.WriteIntPtr(nativeArray, i * intPtrSize, Dataset.getCPtr(poObjects[i]).Handle);
 
           retval  = wrapper_GDALBuildVRT_objects(dest, poObjects.Length, nativeArray, buidVrtAppOptions, callback, callback_data);
-      } finally {
-          Marshal.FreeHGlobal(nativeArray);
-      }
-      return retval;
-   }
-
-    public static int GDALMultiDimTranslate(Dataset dstDS, Dataset[] poObjects, GDALMultiDimTranslateOptions multiDimAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
-      int retval = 0;
-      if (poObjects.Length <= 0)
-        throw new ArgumentException("poObjects size is small (GDALMultiDimTranslateDestDS)");
-
-      int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
-      IntPtr nativeArray = Marshal.AllocHGlobal(poObjects.Length * intPtrSize);
-      try {
-          for (int i=0; i < poObjects.Length; i++)
-            Marshal.WriteIntPtr(nativeArray, i * intPtrSize, Dataset.getCPtr(poObjects[i]).Handle);
-
-          retval  = wrapper_GDALMultiDimTranslateDestDS(dstDS, poObjects.Length, nativeArray, multiDimAppOptions, callback, callback_data);
       } finally {
           Marshal.FreeHGlobal(nativeArray);
       }


### PR DESCRIPTION

Initially, there was a defined wrapper only for gdal_wrap function. Other functions were not implemented, and a custom-defined method joggling with pointers is the only option to use a utility. Some older types, like `SWIGTYPE_p_p_GDALDatasetShadow` are not required with new GDAL versions and can be replaced by high-level C# methods.

This will bring more clarity into using specified functions in .NET environment. 

Resolves #7152, resolves #813, resolves #1436
Related to https://github.com/MaxRev-Dev/gdal.netcore/issues/97

## Tasklist

 - [ ] Check wrappers usability
 - [ ] Add documentation
 - [ ] Review
 - [ ] All CI builds and checks have passed
 