### PR TITLE
Updated doc for LibKML (missing LIBKML_MINIZIP_LIBRARY and LIBKML_URI…

### DIFF
--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -1039,6 +1039,13 @@ It can be detected with pkg-config.
 
     Control whether to use LibKML. Defaults to ON when LibKML is found.
 
+.. option:: LIBKML_MINIZIP_LIBRARY
+
+    Path to a shared or static library file for ``minizip``
+
+.. option:: LIBKML_URIPARSER_LIBRARY
+
+    Path to a shared or static library file for ``urlparser``
 
 LibLZMA
 *******


### PR DESCRIPTION
Updated development doc for LibKML 

fix missing LIBKML_MINIZIP_LIBRARY and LIBKML_URIPARSER_LIBRARY

