### PR TITLE
VRT 'scale' and 'exponent' option for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1486,6 +1486,25 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/float32.tif?if=AAIGrid,GTiff")
     assert ds is not None
 
+    ## check exponent and scale
+    ds = gdal.Open("vrt://data/float32.tif?scale=0,255,255,255")
+    assert ds.GetRasterBand(1).Checksum() == 4873
+
+    ds = gdal.Open("vrt://data/uint16_3band.vrt?scale_2=0,255,255,255")
+    assert ds.GetRasterBand(2).Checksum() == 5047
+
+    ds = gdal.Open("vrt://data/float32.tif?scale_1=0,10")
+    assert ds.GetRasterBand(1).Checksum() == 4867
+
+    ds = gdal.Open("vrt://data/float32.tif?exponent=2.2")
+    assert ds is None
+
+    ds = gdal.Open("vrt://data/float32.tif?exponent=2.2&scale=0,100")
+    assert ds.GetRasterBand(1).Checksum() == 5294
+
+    ds = gdal.Open("vrt://data/uint16_3band.vrt?exponent_2=2.2&scale_2=0,10,0,100")
+    assert ds.GetRasterBand(2).Checksum() == 4455
+
 
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1657,7 +1657,7 @@ For example:
 
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``, 
-``a_scale``, ``a_offset``, ``ot``, ``gcp``, and ``if``. 
+``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, and ``exponent``. 
 
 Other options may be added in the future.
 
@@ -1691,13 +1691,22 @@ The effect of the ``ot`` option (added in GDAL 3.7) is to force the output image
 specific data type supported by the driver as with (:ref:`gdal_translate`).
 
 The effect of the ``gcp`` option (added in GDAL 3.7) is to add the indicated ground control point
-to the output dataset. Values are a set of numbers as per (:ref:`gdal_translate`)``pixel,line,easting,northing[,elevation]``.
+to the output dataset. Values are a set of numbers as per (:ref:`gdal_translate`) ``pixel,line,easting,northing[,elevation]``.
 Multiple entries may be included. This can also be seen as an equivalent of running
 `gdal_translate -of VRT -gcp pixel1 line1 easting1 northing1 [elevation1] -gcp pixel2 line2 easting2 northing2 [elevation2] ... -gcp pixelN lineN eastingN northingN [elevationN]`.
 
 The effect of the ``if`` option (added in GDAL 3.7) is to specify the format/driver name/s
 to be attempted to open the input file (:ref:`gdal_translate`). Values may be repeated separated by comma
 This can also be seen as an equivalent of running `gdal_translate -of VRT -if DRV1 -if DRV2 ... -if DRVN`.
+
+The effect of the ``scale`` option (added in GDAL 3.7) is to rescale the input pixel values from the 
+range **src_min** to **src_max** to the range **dst_min** to **dst_max**  ``src_min,src_max[,dst_min,dst_max]`` 
+either 2 or 4 comma separated values. The same rules apply for the source and destination ranges, and ``scale_bn`` syntax may be used as it is
+with (:ref:`gdal_translate`). 
+
+The effect of the ``exponent`` option (added in GDAL 3.7) is to apply non-linear scaling with a power function, 
+a single value to be used with the ``scale`` option. The same ``exponent_bn`` syntax may be used in combination with ``scale_bn`` to 
+target specific band/s as per (:ref:`gdal_translate`). 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1122,6 +1122,36 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                     argv.AddString(aosGCP[j]);
                 }
             }
+            else if (EQUAL(pszKey, "scale") || STARTS_WITH_CI(pszKey, "scale_"))
+            {
+                argv.AddString(CPLSPrintf("-%s", pszKey));
+                CPLStringList aosScaleParams(
+                    CSLTokenizeString2(pszValue, ",", 0));
+                if (!(aosScaleParams.size() == 2) &&
+                    !(aosScaleParams.size() == 4))
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "Invalid value for explicit scale or scale_bn: "
+                             "%s\n  need 2, or 4 "
+                             "numbers, comma separated: "
+                             "'scale=src_min,src_max[,dst_min,dst_max]'"
+                             "'scale_bn=src_min,src_max[,dst_min,dst_max]'",
+                             pszValue);
+                    poSrcDS->ReleaseRef();
+                    CPLFree(pszKey);
+                    return nullptr;
+                }
+                for (int j = 0; j < aosScaleParams.size(); j++)
+                {
+                    argv.AddString(aosScaleParams[j]);
+                }
+            }
+            else if (EQUAL(pszKey, "exponent") ||
+                     STARTS_WITH_CI(pszKey, "exponent_"))
+            {
+                argv.AddString(CPLSPrintf("-%s", pszKey));
+                argv.AddString(pszValue);
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Add 'scale' and 'exponent' to allowed options for a "vrt:// connection.

Note this does not implement the case where 'scale' is include with no value as per '-scale' in gdal_translate. 

## What are related issues/pull requests?

Discussion and summary of related PRs: #7477 

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

