### PR TITLE
[Backport release/3.6] OpenFileGDB: fix write corruption when re-using freespace slots in some editing scenarios (fixes #7504)

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
@@ -1875,9 +1875,11 @@ bool FileGDBTable::UpdateFeature(int nFID,
     }
     else
     {
-        // Updated feature is larger than older one: append at end of .gdbtable
+        // Updated feature is larger than older one: check if there's a chunk
+        // we can reuse by examining the .freelist, and if not, append at end
+        // of .gdbtable
         const uint64_t nFreeOffset = GetOffsetOfFreeAreaFromFreeList(
-            static_cast<uint32_t>(m_abyBuffer.size()));
+            static_cast<uint32_t>(sizeof(uint32_t) + m_abyBuffer.size()));
 
         if (nFreeOffset == OFFSET_MINUS_ONE)
         {


### PR DESCRIPTION
Backport #7525
 **Authored by:** @rouault