### PR TITLE
OSRImportFromEPSG(): emit warning message about deprecated CRS substitution (fixes #7524)

### DIFF
--- a/apps/gdalsrsinfo.cpp
+++ b/apps/gdalsrsinfo.cpp
@@ -415,29 +415,6 @@ bool FindSRS(const char *pszInput, OGRSpatialReference &oSRS)
         {
             CPLDebug("gdalsrsinfo", "got SRS from user input");
             bGotSRS = true;
-
-            if (CPLGetConfigOption("OSR_USE_NON_DEPRECATED", nullptr) ==
-                nullptr)
-            {
-                const char *pszAuthName = oSRS.GetAuthorityName(nullptr);
-                const char *pszAuthCode = oSRS.GetAuthorityCode(nullptr);
-
-                CPLConfigOptionSetter oSetter("OSR_USE_NON_DEPRECATED", "NO",
-                                              false);
-                OGRSpatialReference oSRS2;
-                oSRS2.SetFromUserInput(pszInput);
-                const char *pszAuthCode2 = oSRS2.GetAuthorityCode(nullptr);
-                if (pszAuthName && pszAuthCode && pszAuthCode2 &&
-                    !EQUAL(pszAuthCode, pszAuthCode2))
-                {
-                    printf("CRS %s is deprecated, and the following output "
-                           "will use its non-deprecated replacement %s:%s.\n"
-                           "To use the original CRS, set the "
-                           "OSR_USE_NON_DEPRECATED "
-                           "configuration option to NO.\n",
-                           pszInput, pszAuthName, pszAuthCode);
-                }
-            }
         }
     }
 

--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -34,7 +34,7 @@
 import gdaltest
 import pytest
 
-from osgeo import osr
+from osgeo import gdal, osr
 
 ###############################################################################
 # Verify that deprecated EPSG:26591 ends up picking non-deprecated EPSG:3003
@@ -43,7 +43,9 @@ from osgeo import osr
 def test_osr_epsg_1():
 
     srs = osr.SpatialReference()
-    srs.ImportFromEPSG(26591)
+    with gdaltest.error_handler():
+        srs.ImportFromEPSG(26591)
+        assert "OSR_USE_NON_DEPRECATED" in gdal.GetLastErrorMsg()
     assert srs.GetAuthorityCode(None) == "3003"
 
 


### PR DESCRIPTION
rather than just in gdalsrsinfo
