### PR TITLE
[Backport release/3.6] Rasterize all touched: tighten(decrease) the tolerance to consider that edge of geometries match pixel obundaries (fixes #7523)

### DIFF
--- a/alg/llrasterize.cpp
+++ b/alg/llrasterize.cpp
@@ -376,6 +376,12 @@ void GDALdllImageLineAllTouched(int nRasterXSize, int nRasterYSize,
                                 bool bIntersectOnly)
 
 {
+    // This is an epsilon to detect geometries that are aligned with pixel
+    // coordinates. Hard to find the right value. We put it to that value
+    // to satisfy the scenarios of https://github.com/OSGeo/gdal/issues/7523
+    // and https://github.com/OSGeo/gdal/issues/6414
+    constexpr double EPSILON_INTERSECT_ONLY = 1e-4;
+
     if (!nPartCount)
         return;
 
@@ -425,8 +431,10 @@ void GDALdllImageLineAllTouched(int nRasterXSize, int nRasterYSize,
             {
                 if (bIntersectOnly)
                 {
-                    if (std::abs(dfX - std::round(dfX)) < 0.01 &&
-                        std::abs(dfXEnd - std::round(dfXEnd)) < 0.01)
+                    if (std::abs(dfX - std::round(dfX)) <
+                            EPSILON_INTERSECT_ONLY &&
+                        std::abs(dfXEnd - std::round(dfXEnd)) <
+                            EPSILON_INTERSECT_ONLY)
                         continue;
                 }
 
@@ -502,8 +510,10 @@ void GDALdllImageLineAllTouched(int nRasterXSize, int nRasterYSize,
             {
                 if (bIntersectOnly)
                 {
-                    if (std::abs(dfY - std::round(dfY)) < 0.01 &&
-                        std::abs(dfYEnd - std::round(dfYEnd)) < 0.01)
+                    if (std::abs(dfY - std::round(dfY)) <
+                            EPSILON_INTERSECT_ONLY &&
+                        std::abs(dfYEnd - std::round(dfYEnd)) <
+                            EPSILON_INTERSECT_ONLY)
                         continue;
                 }
 

--- a/autotest/alg/rasterize.py
+++ b/autotest/alg/rasterize.py
@@ -488,6 +488,61 @@ def test_rasterize_7():
 
 
 ###############################################################################
+# Test rasterization with ALL_TOUCHED, and geometry close to a vertical line,
+# but not exactly on it
+
+
+def test_rasterize_all_touched_issue_7523():
+
+    # Setup working spatial reference
+    sr_wkt = 'LOCAL_CS["arbitrary"]'
+    sr = osr.SpatialReference(sr_wkt)
+
+    # Create a memory raster to rasterize into.
+    target_ds = gdal.GetDriverByName("MEM").Create("", 3, 5, 1, gdal.GDT_Byte)
+    target_ds.SetGeoTransform((475435, 5, 0, 424145, 0, -5))
+    target_ds.SetProjection(sr_wkt)
+
+    vect_ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    lyr = vect_ds.CreateLayer("test", sr)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetGeometryDirectly(
+        ogr.CreateGeometryFromWkt(
+            "POLYGON ((475439.996613325 424122.228740036,475439.996613325 424142.201761073,475446.914301362 424124.133743847,475439.996613325 424122.228740036))"
+        )
+    )
+    lyr.CreateFeature(f)
+
+    # Run the algorithm.
+    gdal.RasterizeLayer(
+        target_ds,
+        [1],
+        lyr,
+        burn_values=[1],
+        options=["ALL_TOUCHED=TRUE"],
+    )
+
+    # Check results.
+    assert struct.unpack("B" * (3 * 5), target_ds.GetRasterBand(1).ReadRaster()) == (
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+    )
+
+
+###############################################################################
 # Test rasterizing linestring with multiple segments and MERGE_ALG=ADD
 # Tests https://github.com/OSGeo/gdal/issues/1307
 


### PR DESCRIPTION
Backport #7526
 **Authored by:** @rouault