### PR TITLE
CI: Make Travis skip doc-only commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
         - DETAILS=
 
 before_install:
+  - if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.rst)$'; then travis_terminate 0; fi
   - ./ci/travis/${BUILD_NAME}/before_install.sh
 
 install:

--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -506,7 +506,7 @@ Configuration Options
 -  **GDAL_NETCDF_BOTTOMUP=[YES/NO]** : Set the y-axis order for import,
    overriding the order detected by the driver. This option is usually
    not needed unless a specific dataset is causing problems (which
-   should be reported in GDAL trac).
+   should be reported on `GitHub <https://github.com/osgeo/GDAL/issues>`_).
 
 -  **GDAL_NETCDF_VERIFY_DIMS=[YES/STRICT]** : Try to guess which dimensions
    represent the latitude and longitude only by their attributes (STRICT)

--- a/doc/source/drivers/vector/pgdump.rst
+++ b/doc/source/drivers/vector/pgdump.rst
@@ -140,7 +140,7 @@ Environment variables
 VSI Virtual File System API support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The driver supports rwriting to files managed by VSI Virtual File System
+The driver supports writing to files managed by VSI Virtual File System
 API, which include "regular" files, as well as files in the /vsizip/,
 /vsigzip/ domains.
 

--- a/frmts/netcdf/netcdfvirtual.cpp
+++ b/frmts/netcdf/netcdfvirtual.cpp
@@ -187,7 +187,7 @@ void netCDFVID::nc_vmap()
 
         if (!var.isValid())
         {
-            continue;  // don't do anywork if variable is invalid
+            continue;  // don't do any work if variable is invalid
         }
 
         // Convert each virtual dimID to a physical dimID:


### PR DESCRIPTION
## What does this PR do?

Attempts to skip Travis runs for doc-only commits. Unfortunately I can't test this in a fork so I'll do so here.

## What are related issues/pull requests?

#3529

## Tasklist

 - [x] Check that doc-only commit is skipped
 - [x] Check that non-doc commit followed by doc commit is not skipped
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed