### PR TITLE
Expose VRT option allocation and free in public header

### DIFF
--- a/apps/gdal_utils.h
+++ b/apps/gdal_utils.h
@@ -221,6 +221,11 @@ GDALBuildVRTOptions CPL_DLL *
 GDALBuildVRTOptionsNew(char **papszArgv,
                        GDALBuildVRTOptionsForBinary *psOptionsForBinary);
 
+GDALBuildVRTOptionsForBinary CPL_DLL *GDALBuildVRTOptionsForBinaryNew(void);
+
+void CPL_DLL GDALBuildVRTOptionsForBinaryFree(
+    GDALBuildVRTOptionsForBinary *psOptionsForBinary);
+
 void CPL_DLL GDALBuildVRTOptionsFree(GDALBuildVRTOptions *psOptions);
 
 void CPL_DLL GDALBuildVRTOptionsSetProgress(GDALBuildVRTOptions *psOptions,

--- a/apps/gdalbuildvrt_bin.cpp
+++ b/apps/gdalbuildvrt_bin.cpp
@@ -101,31 +101,6 @@ static void Usage(const char *pszErrorMsg)
 }
 
 /************************************************************************/
-/*                       GDALBuildVRTOptionsForBinaryNew()              */
-/************************************************************************/
-
-static GDALBuildVRTOptionsForBinary *GDALBuildVRTOptionsForBinaryNew(void)
-{
-    return static_cast<GDALBuildVRTOptionsForBinary *>(
-        CPLCalloc(1, sizeof(GDALBuildVRTOptionsForBinary)));
-}
-
-/************************************************************************/
-/*                       GDALBuildVRTOptionsForBinaryFree()            */
-/************************************************************************/
-
-static void GDALBuildVRTOptionsForBinaryFree(
-    GDALBuildVRTOptionsForBinary *psOptionsForBinary)
-{
-    if (psOptionsForBinary)
-    {
-        CSLDestroy(psOptionsForBinary->papszSrcFiles);
-        CPLFree(psOptionsForBinary->pszDstFilename);
-        CPLFree(psOptionsForBinary);
-    }
-}
-
-/************************************************************************/
 /*                                main()                                */
 /************************************************************************/
 

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -1943,6 +1943,31 @@ static char *SanitizeSRS(const char *pszUserInput)
 }
 
 /************************************************************************/
+/*                       GDALBuildVRTOptionsForBinaryNew()              */
+/************************************************************************/
+
+GDALBuildVRTOptionsForBinary *GDALBuildVRTOptionsForBinaryNew(void)
+{
+    return static_cast<GDALBuildVRTOptionsForBinary *>(
+        CPLCalloc(1, sizeof(GDALBuildVRTOptionsForBinary)));
+}
+
+/************************************************************************/
+/*                       GDALBuildVRTOptionsForBinaryFree()            */
+/************************************************************************/
+
+void GDALBuildVRTOptionsForBinaryFree(
+    GDALBuildVRTOptionsForBinary *psOptionsForBinary)
+{
+    if (psOptionsForBinary)
+    {
+        CSLDestroy(psOptionsForBinary->papszSrcFiles);
+        CPLFree(psOptionsForBinary->pszDstFilename);
+        CPLFree(psOptionsForBinary);
+    }
+}
+
+/************************************************************************/
 /*                             GDALBuildVRTOptionsNew()                  */
 /************************************************************************/
 


### PR DESCRIPTION
## What does this PR do?

This PR exposes two function calls for `gdalbuildvrt` that I would like to use in my application. According to the documentation for `struct GDALBuildVRTOptions`, one must use `GDALBuildVRTOptionsNew` and `GDALBuildVRTOptionsFree` to perform allocation and freeing. Likewise, in `GDALBuildVRTOptionsNew`, the options for that call must be allocated with `GDALBuildVRTOptionsForBinaryNew` , however that function is only part of `gdalbuildvrt_lib.cpp` and not a header file. Then, I moved the implementation to the installed library rather than the executable, that way I can link to those functions in my application. 

The end goal of this work (and likely some follow up PR's), is to treat the VRT building as a set of library calls that are used in another application. GDAL building VRT's is assuming there is a CLI, but that is not the case in my application. If there is a better approach to slowly refactoring the `gdalbuildvrt` code that would be more in line with that use case, please share. 
I know that the applications in `apps` directories are supposed to be examples, however there is a significant amount of functionality here that can be re-used in an another application if it's treated as a library. By doing this, our application benefits from improvements in the VRT builder. I believe this is in the spirit of RFC 59. 

## What are related issues/pull requests?

N/A

## Tasklist

 - [ ] Approve approach to add more memory allocation to public header
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 22.04
* Compiler: G++11
