### PR TITLE
OSM: add a tags_format=json osmconf.ini setting and TAGS_FORMAT=JSON …

### DIFF
--- a/data/osmconf.ini
+++ b/data/osmconf.ini
@@ -20,6 +20,11 @@ closed_ways_are_polygons=aeroway,amenity,boundary,building,craft,geological,hist
 # uncomment to report all ways, including the ones without any (significant) tag
 #report_all_ways=yes
 
+# uncomment to specify the the format for the all_tags/other_tags field should be JSON
+# instead of the default HSTORE formatting.
+# Valid values for tags_format are "hstore" and "json"
+#tags_format=json
+
 [points]
 # common attributes
 osm_id=yes

--- a/doc/source/drivers/vector/osm.rst
+++ b/doc/source/drivers/vector/osm.rst
@@ -56,12 +56,19 @@ When keys are not strictly identified in the *osmconf.ini* file, the
 key/value pair is appended in a "other_tags" field, with a syntax
 compatible with the PostgreSQL HSTORE type. See the *COLUMN_TYPES* layer
 creation option of the :ref:`PG driver <vector.pg>`.
+The ``hstore_get_value()`` function can be used with the :ref:`OGRSQL <ogr_sql_dialect>`
+or :ref:`SQLite <sql_sqlite_dialect>` SQL dialects to extract the value of a
+given key.
 
 For example :
 
 ::
 
    ogr2ogr -f PostgreSQL "PG:dbname=osm" test.pbf -lco COLUMN_TYPES=other_tags=hstore
+
+Starting with GDAL 3.7, it is possible to ask the format of this field to
+be JSON encoded, by using the TAGS_FORMAT=JSON open option, or the
+``tags_format=json`` setting in the *osmconf.ini* file.
 
 "all_tags" field
 ~~~~~~~~~~~~~~~~
@@ -139,7 +146,7 @@ reading mode where the following reading pattern must be used:
        while( bHasLayersNonEmpty );
 
 Note : the ogr2ogr application has been modified to use that
-:decl_configoption:`OGR_INTERLEAVED_READING` mode without any 
+:decl_configoption:`OGR_INTERLEAVED_READING` mode without any
 particular user action.
 
 Spatial filtering
@@ -197,6 +204,8 @@ Open options
    disk. Defaults to 100.
 -  **INTERLEAVED_READING=YES/NO**: Whether to enable
    interleaved reading. Defaults to NO.
+-  **TAGS_FORMAT=HSTORE/JSON**: (GDAL >=3.7) Format for all_tags/other_tags fields.
+   Defaults to HSTORE.
 
 See Also
 --------

--- a/ogr/ogrsf_frmts/osm/ogr_osm.h
+++ b/ogr/ogrsf_frmts/osm/ogr_osm.h
@@ -179,7 +179,8 @@ class OGROSMLayer final : public OGRLayer
                    int bCheckFeatureThreshold = TRUE);
     void ForceResetReading();
 
-    void AddField(const char *pszName, OGRFieldType eFieldType);
+    void AddField(const char *pszName, OGRFieldType eFieldType,
+                  OGRFieldSubType eSubType = OFSTNone);
     int GetFieldIndex(const char *pszName);
 
     bool HasOSMId() const
@@ -420,6 +421,7 @@ class OGROSMDataSource final : public OGRDataSource
 
     bool m_bReportAllNodes = false;
     bool m_bReportAllWays = false;
+    bool m_bTagsAsHSTORE = true;  // if false, as JSON
 
     bool m_bFeatureAdded = false;
 

--- a/ogr/ogrsf_frmts/osm/ogrosmdriver.cpp
+++ b/ogr/ogrsf_frmts/osm/ogrosmdriver.cpp
@@ -130,6 +130,11 @@ void RegisterOGROSM()
         "will go to disk' default='100'/>"
         "  <Option name='INTERLEAVED_READING' type='boolean' "
         "description='Whether to enable interleaved reading.' default='NO'/>"
+        "  <Option name='TAGS_FORMAT' type='string-select' "
+        "description='Format for all_tags/other_tags fields.' default='HSTORE'>"
+        "    <Value>HSTORE</Value>"
+        "    <Value>JSON</Value>"
+        "  </Option>"
         "</OpenOptionList>");
 
     poDriver->pfnOpen = OGROSMDriverOpen;


### PR DESCRIPTION
…open option, as an alternative for HSTORE formatting for other_tags/all_tags fields (fixes #7533)
