### PR TITLE
Allow CPLSetConfigOption('PROJ_DATA', ...) to work by making it call OSRSetPROJSearchPaths()

### DIFF
--- a/autotest/osr/osr_basic_subprocess.py
+++ b/autotest/osr/osr_basic_subprocess.py
@@ -29,24 +29,46 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-from osgeo import osr
+import sys
+
+from osgeo import gdal, osr
+
+gdal.UseExceptions()
 
 if __name__ == "__main__":
-    # This test use auxiliary database created with proj 6.3.2
-    # (tested up to 8.0.0) and can be sensitive to future
-    # database structure change.
-    #
-    # See PR https://github.com/OSGeo/gdal/pull/3590
-    # Starting with sqlite 3.41, and commit
-    # https://github.com/sqlite/sqlite/commit/ed07d0ea765386c5bdf52891154c70f048046e60
-    # we must use the same exact table definition in the auxiliary db, otherwise
-    # SQLite3 is confused regarding column types. Hence this PROJ >= 9 check,
-    # to use a table structure identical to proj.db of PROJ 9.
-    if osr.GetPROJVersionMajor() >= 9:
-        osr.SetPROJAuxDbPath("../cpp/data/test_aux_proj_9.db")
-    else:
-        osr.SetPROJAuxDbPath("../cpp/data/test_aux.db")
-    sr = osr.SpatialReference()
-    assert sr.ImportFromEPSG(4326) == 0
-    assert sr.ImportFromEPSG(111111) == 0
-    exit(0)
+    if sys.argv[1] == "aux_db_test":
+        # This test use auxiliary database created with proj 6.3.2
+        # (tested up to 8.0.0) and can be sensitive to future
+        # database structure change.
+        #
+        # See PR https://github.com/OSGeo/gdal/pull/3590
+        # Starting with sqlite 3.41, and commit
+        # https://github.com/sqlite/sqlite/commit/ed07d0ea765386c5bdf52891154c70f048046e60
+        # we must use the same exact table definition in the auxiliary db, otherwise
+        # SQLite3 is confused regarding column types. Hence this PROJ >= 9 check,
+        # to use a table structure identical to proj.db of PROJ 9.
+        if osr.GetPROJVersionMajor() >= 9:
+            osr.SetPROJAuxDbPath("../cpp/data/test_aux_proj_9.db")
+        else:
+            osr.SetPROJAuxDbPath("../cpp/data/test_aux.db")
+        sr = osr.SpatialReference()
+        assert sr.ImportFromEPSG(4326) == 0
+        assert sr.ImportFromEPSG(111111) == 0
+        exit(0)
+
+    if sys.argv[1] == "config_option_ok":
+        gdal.SetConfigOption("PROJ_DATA", sys.argv[2])
+        sr = osr.SpatialReference()
+        assert sr.ImportFromEPSG(4326) == 0
+        exit(0)
+
+    if sys.argv[1] == "config_option_ko":
+        gdal.SetConfigOption("PROJ_DATA", sys.argv[2])
+        sr = osr.SpatialReference()
+        try:
+            sr.ImportFromEPSG(4326)
+            print("Expected exception")
+            sys.exit(1)
+        except Exception:
+            pass
+        exit(0)

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -1870,12 +1870,12 @@ void CPLUnsubscribeToSetConfigOption(int nId)
 }
 
 /************************************************************************/
-/*                  NotifyOtherComponentsSetConfigOptiond()          */
+/*                  NotifyOtherComponentsConfigOptionChanged()          */
 /************************************************************************/
 
-static void NotifyOtherComponentsSetConfigOptiond(const char *pszKey,
-                                                  const char *pszValue,
-                                                  bool bThreadLocal)
+static void NotifyOtherComponentsConfigOptionChanged(const char *pszKey,
+                                                     const char *pszValue,
+                                                     bool bThreadLocal)
 {
     // Hack
     if (STARTS_WITH_CI(pszKey, "AWS_"))
@@ -1936,8 +1936,8 @@ void CPL_STDCALL CPLSetConfigOption(const char *pszKey, const char *pszValue)
     g_papszConfigOptions = const_cast<volatile char **>(CSLSetNameValue(
         const_cast<char **>(g_papszConfigOptions), pszKey, pszValue));
 
-    NotifyOtherComponentsSetConfigOptiond(pszKey, pszValue,
-                                          /*bTheadLocal=*/false);
+    NotifyOtherComponentsConfigOptionChanged(pszKey, pszValue,
+                                             /*bTheadLocal=*/false);
 }
 
 /************************************************************************/
@@ -1999,8 +1999,8 @@ void CPL_STDCALL CPLSetThreadLocalConfigOption(const char *pszKey,
     CPLSetTLSWithFreeFunc(CTLS_CONFIGOPTIONS, papszTLConfigOptions,
                           CPLSetThreadLocalTLSFreeFunc);
 
-    NotifyOtherComponentsSetConfigOptiond(pszKey, pszValue,
-                                          /*bTheadLocal=*/true);
+    NotifyOtherComponentsConfigOptionChanged(pszKey, pszValue,
+                                             /*bTheadLocal=*/true);
 }
 
 /************************************************************************/

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -106,6 +106,9 @@ static bool gbIgnoreEnvVariables =
             // configuration file or
             // CPLSetConfigOption()/CPLSetThreadLocalConfigOption()
 
+static std::vector<std::pair<CPLSetConfigOptionSubscriber, void *>>
+    gSetConfigOptionSubscribers{};
+
 // Used by CPLOpenShared() and friends.
 static CPLMutex *hSharedFileMutex = nullptr;
 static int nSharedFileCount = 0;
@@ -1806,15 +1809,86 @@ const char *CPL_STDCALL CPLGetThreadLocalConfigOption(const char *pszKey,
 }
 
 /************************************************************************/
-/*                  NotifyOtherComponentsConfigOptionChanged()          */
+/*                    CPLSubscribeToSetConfigOption()                   */
 /************************************************************************/
 
-static void NotifyOtherComponentsConfigOptionChanged(const char *pszKey,
-                                                     const char * /*pszValue*/)
+/**
+ * Install a callback that will be notified of calls to CPLSetConfigOption()/
+ * CPLSetThreadLocalConfigOption()
+ *
+ * @param pfnCallback Callback. Must not be NULL
+ * @param pUserData Callback user data. May be NULL.
+ * @return subscriber ID that can be used with CPLUnsubscribeToSetConfigOption()
+ * @since GDAL 3.7
+ */
+
+int CPLSubscribeToSetConfigOption(CPLSetConfigOptionSubscriber pfnCallback,
+                                  void *pUserData)
+{
+    CPLMutexHolderD(&hConfigMutex);
+    for (int nId = 0;
+         nId < static_cast<int>(gSetConfigOptionSubscribers.size()); ++nId)
+    {
+        if (!gSetConfigOptionSubscribers[nId].first)
+        {
+            gSetConfigOptionSubscribers[nId].first = pfnCallback;
+            gSetConfigOptionSubscribers[nId].second = pUserData;
+            return nId;
+        }
+    }
+    int nId = static_cast<int>(gSetConfigOptionSubscribers.size());
+    gSetConfigOptionSubscribers.push_back(
+        std::pair<CPLSetConfigOptionSubscriber, void *>(pfnCallback,
+                                                        pUserData));
+    return nId;
+}
+
+/************************************************************************/
+/*                  CPLUnsubscribeToSetConfigOption()                   */
+/************************************************************************/
+
+/**
+ * Remove a subscriber installed with CPLSubscribeToSetConfigOption()
+ *
+ * @param nId Subscriber id returned by CPLSubscribeToSetConfigOption()
+ * @since GDAL 3.7
+ */
+
+void CPLUnsubscribeToSetConfigOption(int nId)
+{
+    CPLMutexHolderD(&hConfigMutex);
+    if (nId == static_cast<int>(gSetConfigOptionSubscribers.size()) - 1)
+    {
+        gSetConfigOptionSubscribers.resize(gSetConfigOptionSubscribers.size() -
+                                           1);
+    }
+    else if (nId >= 0 &&
+             nId < static_cast<int>(gSetConfigOptionSubscribers.size()))
+    {
+        gSetConfigOptionSubscribers[nId].first = nullptr;
+    }
+}
+
+/************************************************************************/
+/*                  NotifyOtherComponentsSetConfigOptiond()          */
+/************************************************************************/
+
+static void NotifyOtherComponentsSetConfigOptiond(const char *pszKey,
+                                                  const char *pszValue,
+                                                  bool bThreadLocal)
 {
     // Hack
     if (STARTS_WITH_CI(pszKey, "AWS_"))
         VSICurlAuthParametersChanged();
+
+    if (!gSetConfigOptionSubscribers.empty())
+    {
+        for (const auto &iter : gSetConfigOptionSubscribers)
+        {
+            if (iter.first)
+                iter.first(pszKey, pszValue, bThreadLocal, iter.second);
+        }
+    }
 }
 
 /************************************************************************/
@@ -1850,8 +1924,6 @@ static void NotifyOtherComponentsConfigOptionChanged(const char *pszKey,
 void CPL_STDCALL CPLSetConfigOption(const char *pszKey, const char *pszValue)
 
 {
-    NotifyOtherComponentsConfigOptionChanged(pszKey, pszValue);
-
 #ifdef DEBUG_CONFIG_OPTIONS
     CPLAccessConfigOption(pszKey, FALSE);
 #endif
@@ -1863,6 +1935,9 @@ void CPL_STDCALL CPLSetConfigOption(const char *pszKey, const char *pszValue)
 
     g_papszConfigOptions = const_cast<volatile char **>(CSLSetNameValue(
         const_cast<char **>(g_papszConfigOptions), pszKey, pszValue));
+
+    NotifyOtherComponentsSetConfigOptiond(pszKey, pszValue,
+                                          /*bTheadLocal=*/false);
 }
 
 /************************************************************************/
@@ -1904,8 +1979,6 @@ void CPL_STDCALL CPLSetThreadLocalConfigOption(const char *pszKey,
                                                const char *pszValue)
 
 {
-    NotifyOtherComponentsConfigOptionChanged(pszKey, pszValue);
-
 #ifdef DEBUG_CONFIG_OPTIONS
     CPLAccessConfigOption(pszKey, FALSE);
 #endif
@@ -1925,6 +1998,9 @@ void CPL_STDCALL CPLSetThreadLocalConfigOption(const char *pszKey,
 
     CPLSetTLSWithFreeFunc(CTLS_CONFIGOPTIONS, papszTLConfigOptions,
                           CPLSetThreadLocalTLSFreeFunc);
+
+    NotifyOtherComponentsSetConfigOptiond(pszKey, pszValue,
+                                          /*bTheadLocal=*/true);
 }
 
 /************************************************************************/

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -59,6 +59,16 @@ const char CPL_DLL *CPL_STDCALL CPLGetThreadLocalConfigOption(
 void CPL_DLL CPL_STDCALL CPLSetConfigOption(const char *, const char *);
 void CPL_DLL CPL_STDCALL CPLSetThreadLocalConfigOption(const char *pszKey,
                                                        const char *pszValue);
+
+/** Callback for CPLSubscribeToSetConfigOption() */
+typedef void (*CPLSetConfigOptionSubscriber)(const char *pszKey,
+                                             const char *pszValue,
+                                             bool bThreadLocal,
+                                             void *pUserData);
+int CPL_DLL CPLSubscribeToSetConfigOption(
+    CPLSetConfigOptionSubscriber pfnCallback, void *pUserData);
+void CPL_DLL CPLUnsubscribeToSetConfigOption(int nSubscriberId);
+
 /*! @cond Doxygen_Suppress */
 void CPL_DLL CPL_STDCALL CPLFreeConfig(void);
 /*! @endcond */


### PR DESCRIPTION
People expect PROJ_DATA / PROJ_LIB to be set through configuration options, whereas they only work as environment variables or when calling OSRSetPROJSearchPaths().
Make CPLSetConfigOption('PROJ_DATA', ...) to work by making it call OSRSetPROJSearchPaths()