### PR TITLE
CI: Use master container as cache for feature branches

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -148,6 +148,7 @@ jobs:
           docker build \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from ${CONTAINER_REGISTRY}/osgeo/${CONTAINER_NAME} \
+            --cache-from ${CONTAINER_REGISTRY}/osgeo/${CACHE_CONTAINER_NAME} \
             --cache-from ${CONTAINER_NAME_FULL} \
             -t ${CONTAINER_NAME_FULL} \
             -f .github/workflows/${{ matrix.container }}/Dockerfile.ci \


### PR DESCRIPTION
This container is being pulled but was incorrectly omitted from the list of cache sources.

Adding this should prevent an unnecessary container rebuild in a feature branch on a fork for which a pull request has not yet been created.