### PR TITLE
VRT 'outsize' option for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1505,6 +1505,17 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/uint16_3band.vrt?exponent_2=2.2&scale_2=0,10,0,100")
     assert ds.GetRasterBand(2).Checksum() == 4455
 
+    ds = gdal.Open("vrt://data/float32.tif?outsize=10")
+    assert ds is None
+
+    ds = gdal.Open("vrt://data/float32.tif?outsize=10,5")
+    assert ds.GetRasterBand(1).XSize == 10
+    assert ds.GetRasterBand(1).YSize == 5
+
+    ds = gdal.Open("vrt://data/float32.tif?outsize=50%,25%")
+    assert ds.GetRasterBand(1).XSize == 10
+    assert ds.GetRasterBand(1).YSize == 5
+
 
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1505,8 +1505,9 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/uint16_3band.vrt?exponent_2=2.2&scale_2=0,10,0,100")
     assert ds.GetRasterBand(2).Checksum() == 4455
 
-    ds = gdal.Open("vrt://data/float32.tif?outsize=10")
-    assert ds is None
+    with gdaltest.error_handler():
+        ds = gdal.Open("vrt://data/float32.tif?outsize=10")
+        assert ds is None
 
     ds = gdal.Open("vrt://data/float32.tif?outsize=10,5")
     assert ds.GetRasterBand(1).XSize == 10

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1657,7 +1657,7 @@ For example:
 
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``, 
-``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, and ``exponent``. 
+``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, and ``outsize``. 
 
 Other options may be added in the future.
 
@@ -1707,6 +1707,8 @@ with (:ref:`gdal_translate`).
 The effect of the ``exponent`` option (added in GDAL 3.7) is to apply non-linear scaling with a power function, 
 a single value to be used with the ``scale`` option. The same ``exponent_bn`` syntax may be used in combination with ``scale_bn`` to 
 target specific band/s as per (:ref:`gdal_translate`). 
+
+The effect of the ``outsize`` option (added in GDAL 3.7) is to set the size of the output, in numbers `pixel,line` or in fraction `pixel%,line%` as per (:ref:`gdal_translate`). 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1159,7 +1159,7 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 {
                     CPLError(CE_Failure, CPLE_IllegalArg,
                              "Invalid outsize option: %s, must be two"
-                             "values >=1 separated by comma pixel,line or two "
+                             "values separated by comma pixel,line or two "
                              "fraction values with percent symbol",
                              pszValue);
                     poSrcDS->ReleaseRef();

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1152,6 +1152,24 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString(CPLSPrintf("-%s", pszKey));
                 argv.AddString(pszValue);
             }
+            else if (EQUAL(pszKey, "outsize"))
+            {
+                CPLStringList aosOutSize(CSLTokenizeString2(pszValue, ",", 0));
+                if (aosOutSize.size() != 2)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "Invalid outsize option: %s, must be two"
+                             "values >=1 separated by comma pixel,line or two "
+                             "fraction values with percent symbol",
+                             pszValue);
+                    poSrcDS->ReleaseRef();
+                    CPLFree(pszKey);
+                    return nullptr;
+                }
+                argv.AddString("-outsize");
+                argv.AddString(aosOutSize[0]);
+                argv.AddString(aosOutSize[1]);
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Add 'outsize' to allowed options for a "vrt://" connection. 


## What are related issues/pull requests?
Discussion and summary of related PRs:  #7477
## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

