### PR TITLE
CI: fix build errors with openssl not coming from Conda; and use libjpeg-turbo

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -427,7 +427,7 @@ jobs:
         conda install --yes --quiet --name gdalenv curl libiconv icu python=3.9 swig numpy pytest pytest-env filelock zlib clcache lxml
         conda install --yes --quiet --name gdalenv -c conda-forge proj geos hdf4 hdf5 kealib \
             libnetcdf openjpeg poppler libtiff libpng xerces-c expat libxml2 kealib json-c \
-            cfitsio freexl geotiff jpeg libpq libspatialite libwebp-base pcre pcre2 postgresql \
+            cfitsio freexl geotiff libjpeg-turbo libpq libspatialite libwebp-base pcre pcre2 postgresql \
             sqlite tiledb zstd cryptopp cgal doxygen librttopo libkml openssl xz \
             openjdk ant qhull armadillo blas blas-devel libblas libcblas liblapack liblapacke blosc libarchive \
             "arrow-cpp>=7.0.0" "pyarrow>=7.0.0"
@@ -465,6 +465,7 @@ jobs:
       shell: cmd
       run: |
           rd /s /q C:\Strawberry
+          rd /s /q "C:\Program Files\OpenSSL\lib"
 
     - name: Configure
       shell: bash -l {0}


### PR DESCRIPTION
Some VM workers unexpectly link to OpenSSL from C:/Program Files/OpenSSL/lib/VC (at 1.1.1) but likely use headers of 3.1.0 from conda.

```
Found OpenSSL: optimized;C:/Program Files/OpenSSL/lib/VC/libcrypto64MD.lib;debug;C:/Program Files/OpenSSL/lib/VC/libcrypto64MDd.lib (found version "1.1.1t") found components: SSL Crypto
[...]
cpl_sha256.cpp.obj : error LNK2019: unresolved external symbol EVP_PKEY_get_size referenced in function CPL_RSA_SHA256_Sign
```
