### PR TITLE
docker/util.sh: avoid BuildKit on Docker 23

### DIFF
--- a/docker/util.sh
+++ b/docker/util.sh
@@ -126,6 +126,13 @@ if test "${DOCKER_BUILDKIT}" = "1" && test "${DOCKER_CLI_EXPERIMENTAL}" = "enabl
   DOCKER_BUILDX_ARGS=("--platform" "${ARCH_PLATFORMS}")
 fi
 
+# Docker 23 uses BuildKit by default on Linux, but BuildKit prevents
+# custom networks using docker build --network, so disable BuildKit for now.
+# https://github.com/moby/buildkit/issues/978
+if test -z "${DOCKER_BUILDKIT}"; then
+  export DOCKER_BUILDKIT=0
+fi
+
 if test "${RELEASE}" = "yes"; then
     if test "${GDAL_VERSION}" = ""; then
         echo "--gdal tag must be specified when --release is used."


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Docker 23 uses BuildKit by default on Linux,
but BuildKit prevents custom networks using
docker build --network, so disable BuildKit
for now.

This fixes the error:

ERROR: network mode "docker_build_gdal" not supported by buildkit - you can define a custom network for your builder using the network driver-opt in buildx create

when running `./ubuntu-small/build.sh --gdal master --proj master --platform linux/amd64` from the docker directory on Ubuntu 22.04 with Docker 23.0.3.

## What are related issues/pull requests?

Could not find any.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 22.04
* Compiler: gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
