### PR TITLE
[gpkg] Set field alternative names using name attribute from gpkg_data_columns table

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -3044,13 +3044,13 @@ def test_ogr_gpkg_34():
         """CREATE TABLE gpkg_data_columns (
   table_name TEXT NOT NULL,
   column_name TEXT NOT NULL,
-  name TEXT UNIQUE,
+  name TEXT,
   title TEXT,
   description TEXT,
   mime_type TEXT,
   constraint_name TEXT,
   CONSTRAINT pk_gdc PRIMARY KEY (table_name, column_name),
-  CONSTRAINT fk_gdc_tn FOREIGN KEY (table_name) REFERENCES gpkg_contents(table_name)
+  CONSTRAINT gdc_tn UNIQUE (table_name, name)
 )"""
     )
     ds.ExecuteSQL(
@@ -3211,13 +3211,13 @@ def test_ogr_gpkg_35():
         """CREATE TABLE gpkg_data_columns (
   table_name TEXT NOT NULL,
   column_name TEXT NOT NULL,
-  name TEXT UNIQUE,
+  name TEXT,
   title TEXT,
   description TEXT,
   mime_type TEXT,
   constraint_name TEXT,
   CONSTRAINT pk_gdc PRIMARY KEY (table_name, column_name),
-  CONSTRAINT fk_gdc_tn FOREIGN KEY (table_name) REFERENCES gpkg_contents(table_name)
+  CONSTRAINT gdc_tn UNIQUE (table_name, name)
 )"""
     )
     ds.ExecuteSQL(
@@ -3332,13 +3332,13 @@ def test_ogr_gpkg_36():
         """CREATE TABLE gpkg_data_columns (
   table_name TEXT NOT NULL,
   column_name TEXT NOT NULL,
-  name TEXT UNIQUE,
+  name TEXT,
   title TEXT,
   description TEXT,
   mime_type TEXT,
   constraint_name TEXT,
   CONSTRAINT pk_gdc PRIMARY KEY (table_name, column_name),
-  CONSTRAINT fk_gdc_tn FOREIGN KEY (table_name) REFERENCES gpkg_contents(table_name)
+  CONSTRAINT gdc_tn UNIQUE (table_name, name)
 )"""
     )
     ds.ExecuteSQL(
@@ -3533,13 +3533,13 @@ def test_ogr_gpkg_37():
         """CREATE TABLE gpkg_data_columns (
   table_name TEXT NOT NULL,
   column_name TEXT NOT NULL,
-  name TEXT UNIQUE,
+  name TEXT,
   title TEXT,
   description TEXT,
   mime_type TEXT,
   constraint_name TEXT,
   CONSTRAINT pk_gdc PRIMARY KEY (table_name, column_name),
-  CONSTRAINT fk_gdc_tn FOREIGN KEY (table_name) REFERENCES gpkg_contents(table_name)
+  CONSTRAINT gdc_tn UNIQUE (table_name, name)
 )"""
     )
     ds.ExecuteSQL(

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -8451,3 +8451,64 @@ def test_ogr_gpkg_ogr_layer_Extent():
 
     finally:
         gdal.Unlink(tmpfilename)
+
+
+###############################################################################
+# Test field alternative names
+
+
+def test_ogr_gpkg_field_alternative_names():
+
+    dbname = "/vsimem/ogr_gpkg_alternative_names.gpkg"
+    ds = gdaltest.gpkg_dr.CreateDataSource(dbname)
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPolygon)
+    lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
+    lyr.CreateField(ogr.FieldDefn("baz", ogr.OFTString))
+
+    # with no gpkg_data_columns table
+    lyr = ds.GetLayer("test")
+    assert lyr.GetLayerDefn().GetFieldCount() == 2
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "foo"
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetAlternativeName() == ""
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "baz"
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetAlternativeName() == ""
+
+    ds.ExecuteSQL(
+        """CREATE TABLE gpkg_data_columns (
+  table_name TEXT NOT NULL,
+  column_name TEXT NOT NULL,
+  name TEXT,
+  title TEXT,
+  description TEXT,
+  mime_type TEXT,
+  constraint_name TEXT,
+  CONSTRAINT pk_gdc PRIMARY KEY (table_name, column_name),
+  CONSTRAINT gdc_tn UNIQUE (table_name, name)
+)"""
+    )
+    # name same as column name, won't be used as alternative name
+    ds.ExecuteSQL(
+        "INSERT INTO gpkg_data_columns('table_name', 'column_name', 'name') VALUES ('test', 'foo', 'foo')"
+    )
+
+    ds = gdal.OpenEx(dbname, gdal.OF_VECTOR | gdal.OF_UPDATE)
+    lyr = ds.GetLayer("test")
+    assert lyr.GetLayerDefn().GetFieldCount() == 2
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "foo"
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetAlternativeName() == ""
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "baz"
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetAlternativeName() == ""
+
+    # name different from column name, should be used as alternative names
+    ds.ExecuteSQL("DELETE FROM gpkg_data_columns")
+    ds.ExecuteSQL(
+        "INSERT INTO gpkg_data_columns('table_name', 'column_name', 'name') VALUES ('test', 'foo', 'Foo field')"
+    )
+
+    ds = gdaltest.gpkg_dr.Open(dbname)
+    lyr = ds.GetLayer("test")
+    assert lyr.GetLayerDefn().GetFieldCount() == 2
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "foo"
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetAlternativeName() == "Foo field"
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "baz"
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetAlternativeName() == ""

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -3868,7 +3868,7 @@ bool GDALGeoPackageDataset::
                 "CREATE TABLE gpkg_data_columns ("
                 "table_name TEXT NOT NULL,"
                 "column_name TEXT NOT NULL,"
-                "name TEXT UNIQUE,"
+                "name TEXT,"
                 "title TEXT,"
                 "description TEXT,"
                 "mime_type TEXT,"


### PR DESCRIPTION
Note that the GeoPackage specifications for the gpkg_data_columns table specify that both a field "name" and field "title" can be present. The specifications do not further elaborate on what the intended differentiation is between these values. Accordingly, we set the field alias using either the name value or the title value, depending on which has been populated in the GeoPackage (and which isn't just a direct copy of the column name)

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
