### PR TITLE
Add optional comment to OGRFieldDefn, read for gpkg layers

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -1146,6 +1146,7 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
             const OGRFieldDefn *poField = poDefn->GetFieldDefn(iAttr);
             const char *pszAlias = poField->GetAlternativeNameRef();
             const std::string &osDomain = poField->GetDomainName();
+            const std::string &osComment = poField->GetComment();
             if (bJson)
             {
                 CPLJSONObject oField;
@@ -1169,6 +1170,8 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
                     oField.Set("alias", pszAlias);
                 if (!osDomain.empty())
                     oField.Set("domainName", osDomain);
+                if (!osComment.empty())
+                    oField.Set("comment", osComment);
             }
             else
             {
@@ -1196,6 +1199,9 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
                 if (!osDomain.empty())
                     Concat(osRet, psOptions->bStdoutOutput, ", domain name=%s",
                            osDomain.c_str());
+                if (!osComment.empty())
+                    Concat(osRet, psOptions->bStdoutOutput, ", comment=%s",
+                           osComment.c_str());
                 Concat(osRet, psOptions->bStdoutOutput, "\n");
             }
         }

--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -2192,6 +2192,22 @@ TEST_F(test_ogr, field_domain_cloning)
     ASSERT_EQ(poClonedCoded->GetMergePolicy(), oCoded.GetMergePolicy());
 }
 
+// Test field comments
+TEST_F(test_ogr, field_comments)
+{
+    OGRFieldDefn oFieldDefn("field1", OFTString);
+    ASSERT_EQ(oFieldDefn.GetComment(), "");
+    oFieldDefn.SetComment("my comment");
+    ASSERT_EQ(oFieldDefn.GetComment(), "my comment");
+
+    OGRFieldDefn oFieldDefn2(&oFieldDefn);
+    ASSERT_EQ(oFieldDefn2.GetComment(), "my comment");
+    ASSERT_TRUE(oFieldDefn.IsSame(&oFieldDefn2));
+
+    oFieldDefn2.SetComment("my comment 2");
+    ASSERT_FALSE(oFieldDefn.IsSame(&oFieldDefn2));
+}
+
 // Test OGRFeatureDefn C++ GetFields() iterator
 TEST_F(test_ogr, feature_defn_fields_iterator)
 {

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -8454,10 +8454,10 @@ def test_ogr_gpkg_ogr_layer_Extent():
 
 
 ###############################################################################
-# Test field alternative names
+# Test field alternative names and comments
 
 
-def test_ogr_gpkg_field_alternative_names():
+def test_ogr_gpkg_field_alternative_names_comment():
 
     dbname = "/vsimem/ogr_gpkg_alternative_names.gpkg"
     ds = gdaltest.gpkg_dr.CreateDataSource(dbname)
@@ -8470,8 +8470,10 @@ def test_ogr_gpkg_field_alternative_names():
     assert lyr.GetLayerDefn().GetFieldCount() == 2
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "foo"
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetAlternativeName() == ""
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetComment() == ""
     assert lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "baz"
     assert lyr.GetLayerDefn().GetFieldDefn(1).GetAlternativeName() == ""
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetComment() == ""
 
     ds.ExecuteSQL(
         """CREATE TABLE gpkg_data_columns (
@@ -8488,7 +8490,7 @@ def test_ogr_gpkg_field_alternative_names():
     )
     # name same as column name, won't be used as alternative name
     ds.ExecuteSQL(
-        "INSERT INTO gpkg_data_columns('table_name', 'column_name', 'name') VALUES ('test', 'foo', 'foo')"
+        "INSERT INTO gpkg_data_columns('table_name', 'column_name', 'name', 'description') VALUES ('test', 'foo', 'foo', 'my description')"
     )
 
     ds = gdal.OpenEx(dbname, gdal.OF_VECTOR | gdal.OF_UPDATE)
@@ -8496,8 +8498,10 @@ def test_ogr_gpkg_field_alternative_names():
     assert lyr.GetLayerDefn().GetFieldCount() == 2
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "foo"
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetAlternativeName() == ""
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetComment() == "my description"
     assert lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "baz"
     assert lyr.GetLayerDefn().GetFieldDefn(1).GetAlternativeName() == ""
+    assert lyr.GetLayerDefn().GetFieldDefn(1).GetComment() == ""
 
     # name different from column name, should be used as alternative names
     ds.ExecuteSQL("DELETE FROM gpkg_data_columns")

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -402,6 +402,8 @@ void CPL_DLL OGR_Fld_SetDefault(OGRFieldDefnH hDefn, const char *);
 int CPL_DLL OGR_Fld_IsDefaultDriverSpecific(OGRFieldDefnH hDefn);
 const char CPL_DLL *OGR_Fld_GetDomainName(OGRFieldDefnH hDefn);
 void CPL_DLL OGR_Fld_SetDomainName(OGRFieldDefnH hDefn, const char *);
+const char CPL_DLL *OGR_Fld_GetComment(OGRFieldDefnH hDefn);
+void CPL_DLL OGR_Fld_SetComment(OGRFieldDefnH hDefn, const char *);
 
 const char CPL_DLL *OGR_GetFieldTypeName(OGRFieldType);
 const char CPL_DLL *OGR_GetFieldSubTypeName(OGRFieldSubType);

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -119,6 +119,8 @@ class CPL_DLL OGRFieldDefn
 
     std::string m_osDomainName{};  // field domain name. Might be empty
 
+    std::string m_osComment{};  // field comment. Might be empty
+
   public:
     OGRFieldDefn(const char *, OGRFieldType);
     explicit OGRFieldDefn(const OGRFieldDefn *);
@@ -218,6 +220,15 @@ class CPL_DLL OGRFieldDefn
     void SetDomainName(const std::string &osDomainName)
     {
         m_osDomainName = osDomainName;
+    }
+
+    const std::string &GetComment() const
+    {
+        return m_osComment;
+    }
+    void SetComment(const std::string &osComment)
+    {
+        m_osComment = osComment;
     }
 
     int IsSame(const OGRFieldDefn *) const;

--- a/ogr/ogrfielddefn.cpp
+++ b/ogr/ogrfielddefn.cpp
@@ -84,7 +84,8 @@ OGRFieldDefn::OGRFieldDefn(const OGRFieldDefn *poPrototype)
       bIgnore(FALSE),  // TODO(schwehr): Can we use IsIgnored()?
       eSubType(poPrototype->GetSubType()), bNullable(poPrototype->IsNullable()),
       bUnique(poPrototype->IsUnique()),
-      m_osDomainName(poPrototype->m_osDomainName)
+      m_osDomainName(poPrototype->m_osDomainName),
+      m_osComment(poPrototype->GetComment())
 {
     SetDefault(poPrototype->GetDefault());
 }
@@ -1247,7 +1248,8 @@ int OGRFieldDefn::IsSame(const OGRFieldDefn *poOtherFieldDefn) const
            eSubType == poOtherFieldDefn->eSubType &&
            nWidth == poOtherFieldDefn->nWidth &&
            nPrecision == poOtherFieldDefn->nPrecision &&
-           bNullable == poOtherFieldDefn->bNullable;
+           bNullable == poOtherFieldDefn->bNullable &&
+           m_osComment == poOtherFieldDefn->m_osComment;
 }
 
 /************************************************************************/
@@ -1510,6 +1512,78 @@ void OGR_Fld_SetDomainName(OGRFieldDefnH hDefn, const char *pszFieldName)
 {
     OGRFieldDefn::FromHandle(hDefn)->SetDomainName(pszFieldName ? pszFieldName
                                                                 : "");
+}
+
+/************************************************************************/
+/*                           GetComment()                               */
+/************************************************************************/
+
+/**
+ * \fn const std::string& OGRFieldDefn::GetComment() const
+ *
+ * \brief Return the (optional) comment for this field.
+ *
+ * By default, none (empty string) is returned.
+ *
+ * This method is the same as the C function OGR_Fld_GetComment().
+ *
+ * @return the field comment, or an empty string if there is none.
+ * @since GDAL 3.7
+ */
+
+/************************************************************************/
+/*                      OGR_Fld_GetComment()                            */
+/************************************************************************/
+
+/**
+ * \brief Return the (optional) comment for this field.
+ *
+ * By default, none (empty string) is returned.
+ *
+ * This method is the same as the C++ method OGRFieldDefn::GetComment().
+ *
+ * @param hDefn handle to the field definition
+ * @return the comment, or an empty string if there is none.
+ * @since GDAL 3.7
+ */
+
+const char *OGR_Fld_GetComment(OGRFieldDefnH hDefn)
+{
+    return OGRFieldDefn::FromHandle(hDefn)->GetComment().c_str();
+}
+
+/************************************************************************/
+/*                           SetComment()                               */
+/************************************************************************/
+
+/**
+ * \fn void OGRFieldDefn::SetComment( const std:string& osComment );
+ *
+ * \brief Set the comment for this field.
+ *
+ * This method is the same as the C function OGR_Fld_SetComment().
+ *
+ * @param osComment Field comment.
+ * @since GDAL 3.7
+ */
+
+/************************************************************************/
+/*                      OGR_Fld_SetComment()                            */
+/************************************************************************/
+
+/**
+ * \brief Set the comment for this field.
+ *
+ * This method is the same as the C++ method OGRFieldDefn::SetComment().
+ *
+ * @param hDefn handle to the field definition
+ * @param pszComment Field comment.
+ * @since GDAL 3.7
+ */
+
+void OGR_Fld_SetComment(OGRFieldDefnH hDefn, const char *pszComment)
+{
+    OGRFieldDefn::FromHandle(hDefn)->SetComment(pszComment ? pszComment : "");
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
@@ -806,6 +806,7 @@ OGRErr OGREditableLayer::AlterFieldDefn(int iField,
         poFieldDefn->SetNullable(poMemFieldDefn->IsNullable());
         poFieldDefn->SetUnique(poMemFieldDefn->IsUnique());
         poFieldDefn->SetDomainName(poMemFieldDefn->GetDomainName());
+        poFieldDefn->SetComment(poMemFieldDefn->GetComment());
         m_bStructureModified = true;
     }
     return eErr;

--- a/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
+++ b/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
@@ -683,6 +683,7 @@ OGRErr OGRLayerWithTransaction::AlterFieldDefn(int iField,
         poDstFieldDefn->SetNullable(poSrcFieldDefn->IsNullable());
         poDstFieldDefn->SetUnique(poSrcFieldDefn->IsUnique());
         poDstFieldDefn->SetDomainName(poSrcFieldDefn->GetDomainName());
+        poDstFieldDefn->SetComment(poSrcFieldDefn->GetComment());
     }
     return eErr;
 }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -1284,10 +1284,11 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
     // Look for sub-types such as JSON
     if (m_poDS->HasDataColumnsTable())
     {
-        pszSQL = sqlite3_mprintf("SELECT column_name, name, mime_type, "
-                                 "constraint_name FROM gpkg_data_columns "
-                                 "WHERE table_name = '%q'",
-                                 m_pszTableName);
+        pszSQL = sqlite3_mprintf(
+            "SELECT column_name, name, mime_type, "
+            "constraint_name, description FROM gpkg_data_columns "
+            "WHERE table_name = '%q'",
+            m_pszTableName);
         oResultTable = SQLQuery(poDb, pszSQL);
         sqlite3_free(pszSQL);
         if (oResultTable)
@@ -1308,11 +1309,22 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
 
                 if (pszAlias)
                 {
-                    int iIdx = m_poFeatureDefn->GetFieldIndex(pszColumn);
+                    const int iIdx = m_poFeatureDefn->GetFieldIndex(pszColumn);
                     if (iIdx >= 0)
                     {
                         m_poFeatureDefn->GetFieldDefn(iIdx)->SetAlternativeName(
                             pszAlias);
+                    }
+                }
+
+                if (const char *pszDescription =
+                        oResultTable->GetValue(4, iRecord))
+                {
+                    const int iIdx = m_poFeatureDefn->GetFieldIndex(pszColumn);
+                    if (iIdx >= 0)
+                    {
+                        m_poFeatureDefn->GetFieldDefn(iIdx)->SetComment(
+                            pszDescription);
                     }
                 }
 
@@ -1321,7 +1333,7 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
                     oResultTable->GetValue(3, iRecord);
                 if (pszMimeType && EQUAL(pszMimeType, "application/json"))
                 {
-                    int iIdx = m_poFeatureDefn->GetFieldIndex(pszColumn);
+                    const int iIdx = m_poFeatureDefn->GetFieldIndex(pszColumn);
                     if (iIdx >= 0 &&
                         m_poFeatureDefn->GetFieldDefn(iIdx)->GetType() ==
                             OFTString)
@@ -1332,7 +1344,7 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
                 }
                 else if (pszConstraintName)
                 {
-                    int iIdx = m_poFeatureDefn->GetFieldIndex(pszColumn);
+                    const int iIdx = m_poFeatureDefn->GetFieldIndex(pszColumn);
                     if (iIdx >= 0)
                     {
                         m_poFeatureDefn->GetFieldDefn(iIdx)->SetDomainName(

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -2566,6 +2566,13 @@ public:
     OGR_Fld_SetDomainName( self, name );
   }
 
+  const char* GetComment() {
+    return OGR_Fld_GetComment(self);
+  }
+
+  void SetComment(const char* comment ) {
+    OGR_Fld_SetComment( self, comment );
+  }
 } /* %extend */
 
 


### PR DESCRIPTION
Adds the API framework for handling field comments for OGR layers

And support reading comments for GPKG fields, using "description" from gpkg_data_columns.

(Write capacity for field comments will be added to GPKG driver in a follow up PR) 