### PR TITLE
COG: Allow creating GoogleMapsCompatible COGs with zoom level > 24 (fixes #7585)

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -1321,7 +1321,7 @@ def test_cog_zoom_level():
             gdal.GetDriverByName("COG").CreateCopy(
                 filename,
                 src_ds,
-                options=["TILING_SCHEME=GoogleMapsCompatible", "ZOOM_LEVEL=25"],
+                options=["TILING_SCHEME=GoogleMapsCompatible", "ZOOM_LEVEL=31"],
             )
             is None
         )

--- a/gcore/tilematrixset.cpp
+++ b/gcore/tilematrixset.cpp
@@ -91,7 +91,7 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
         poTMS->mBbox.mUpperCornerY = HALF_CIRCUMFERENCE;
         poTMS->mWellKnownScaleSet =
             "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible";
-        for (int i = 0; i < 25; i++)
+        for (int i = 0; i <= 30; i++)
         {
             TileMatrix tm;
             tm.mId = CPLSPrintf("%d", i);


### PR DESCRIPTION
## What does this PR do?
Increases the maximum zoom level allowed for GoogleMapsCompatible COGs from 24 to 30.

## What are related issues/pull requests?
#7585 

## Tasklist
 - [ ] Update test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
