### PR TITLE
OpenFileGDB: CreateField(): in approxOK mode, do not error out …

### DIFF
--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -1079,6 +1079,30 @@ def test_ogr_openfilegdb_write_add_field_to_non_empty_table_extra_non_nullable(
             fld_defn.SetDefault("'2022-11-04T12:34:56+02:00'")
             assert lyr.CreateField(fld_defn) == ogr.OGRERR_NONE
 
+            fld_defn = ogr.FieldDefn("dt_invalid_default", ogr.OFTDateTime)
+            fld_defn.SetDefault("'foo'")
+            with gdaltest.error_handler():
+                assert lyr.CreateField(fld_defn, False) == ogr.OGRERR_FAILURE
+                assert gdal.GetLastErrorMsg() == "Cannot parse foo as a date time"
+
+            fld_defn = ogr.FieldDefn("dt_CURRENT_TIMESTAMP", ogr.OFTDateTime)
+            fld_defn.SetDefault("CURRENT_TIMESTAMP")
+            with gdaltest.error_handler():
+                assert lyr.CreateField(fld_defn, False) == ogr.OGRERR_FAILURE
+                assert (
+                    gdal.GetLastErrorMsg()
+                    == "CURRENT_TIMESTAMP is not supported as a default value in File Geodatabase"
+                )
+
+            fld_defn = ogr.FieldDefn("dt_CURRENT_TIMESTAMP_2", ogr.OFTDateTime)
+            fld_defn.SetDefault("CURRENT_TIMESTAMP")
+            with gdaltest.error_handler():
+                assert lyr.CreateField(fld_defn, True) == ogr.OGRERR_NONE
+                assert (
+                    gdal.GetLastErrorMsg()
+                    == "CURRENT_TIMESTAMP is not supported as a default value in File Geodatabase"
+                )
+
             assert lyr.SyncToDisk() == ogr.OGRERR_NONE
 
             ds = None
@@ -1098,6 +1122,7 @@ def test_ogr_openfilegdb_write_add_field_to_non_empty_table_extra_non_nullable(
             assert f["float32"] == 1.25
             assert f["float64"] == 1.23456789
             assert f["dt"] == "2022/11/04 10:34:56+00"
+            assert f.IsFieldNull("dt_CURRENT_TIMESTAMP_2")
             f = lyr.GetNextFeature()
             assert f["str"] == "two"
             assert f["str2"] == "default val"

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -923,7 +923,8 @@ static CPLXMLNode *CreateXMLFieldDefinition(const OGRFieldDefn *poFieldDefn,
 /************************************************************************/
 
 static bool GetDefault(const OGRFieldDefn *poField, FileGDBFieldType eType,
-                       OGRField &sDefault, std::string &osDefaultVal)
+                       OGRField &sDefault, std::string &osDefaultVal,
+                       bool bApproxOK)
 {
     sDefault = FileGDBField::UNSET_FIELD;
     const char *pszDefault = poField->GetDefault();
@@ -950,6 +951,16 @@ static bool GetDefault(const OGRFieldDefn *poField, FileGDBFieldType eType,
         else if (eType == FGFT_DATETIME)
         {
             osDefaultVal = pszDefault;
+            if (osDefaultVal == "CURRENT_TIMESTAMP" ||
+                osDefaultVal == "CURRENT_TIME" ||
+                osDefaultVal == "CURRENT_DATE")
+            {
+                CPLError(bApproxOK ? CE_Warning : CE_Failure, CPLE_AppDefined,
+                         "%s is not supported as a default value in File "
+                         "Geodatabase",
+                         osDefaultVal.c_str());
+                return bApproxOK;
+            }
             if (osDefaultVal[0] == '\'' && osDefaultVal.back() == '\'')
             {
                 osDefaultVal = osDefaultVal.substr(1);
@@ -960,7 +971,12 @@ static bool GetDefault(const OGRFieldDefn *poField, FileGDBFieldType eType,
                 CPLFree(pszTmp);
             }
             if (!OGRParseDate(osDefaultVal.c_str(), &sDefault, 0))
-                return false;
+            {
+                CPLError(bApproxOK ? CE_Warning : CE_Failure, CPLE_AppDefined,
+                         "Cannot parse %s as a date time",
+                         osDefaultVal.c_str());
+                return bApproxOK;
+            }
         }
     }
     return true;
@@ -1217,7 +1233,8 @@ OGRErr OGROpenFileGDBLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
 
     OGRField sDefault = FileGDBField::UNSET_FIELD;
     std::string osDefaultVal;
-    if (!GetDefault(poField, eType, sDefault, osDefaultVal))
+    if (!GetDefault(poField, eType, sDefault, osDefaultVal,
+                    CPL_TO_BOOL(bApproxOK)))
         return OGRERR_FAILURE;
 
     if (!poField->GetDomainName().empty() &&
@@ -1409,7 +1426,8 @@ OGRErr OGROpenFileGDBLayer::AlterFieldDefn(int iFieldToAlter,
 
     OGRField sDefault = FileGDBField::UNSET_FIELD;
     std::string osDefaultVal;
-    if (!GetDefault(&oField, eType, sDefault, osDefaultVal))
+    if (!GetDefault(&oField, eType, sDefault, osDefaultVal,
+                    /*bApproxOK=*/false))
         return OGRERR_FAILURE;
 
     const char *pszAlias = oField.GetAlternativeNameRef();


### PR DESCRIPTION
…if default value of a DateTime field is CURRENT_TIMESTAMP, just ignore it with a warning

Fixes #7589