### PR TITLE
[Backport release/3.6] Tiger: fix compiler warning with clang 16.0.0 and autotest/requirements.txt

### DIFF
--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=6.0.0
-pytest-sugar
+pytest-sugar<=0.9.6; python_version < '3.7'
+pytest-sugar; python_version >= '3.7'
 pytest-env
 lxml

--- a/ogr/ogrsf_frmts/tiger/ogr_tiger.h
+++ b/ogr/ogrsf_frmts/tiger/ogr_tiger.h
@@ -101,8 +101,8 @@ typedef struct TigerFieldInfo
     unsigned char nEnd;  // ending column number for field
     unsigned char nLen;  // length of field
 
-    int bDefine : 1;  // whether to add this field to the FeatureDefn
-    int bSet : 1;     // whether to set this field in GetFeature()
+    unsigned int bDefine : 1;  // whether to add this field to the FeatureDefn
+    unsigned int bSet : 1;     // whether to set this field in GetFeature()
 } TigerFieldInfo;
 
 typedef struct TigerRecordInfo


### PR DESCRIPTION
Backport #7591
 **Authored by:** @rouault