### PR TITLE
GPKG: add ST_EnvIntersects() for faster spatial filtering when there is no spatial index

### DIFF
--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -123,6 +123,13 @@ Spatialite, are also available :
    to the SRS of specified srs_id. If no SRS with that given srs_id is not found
    in gpkg_spatial_ref_sys, starting with GDAL 3.2, it will be interpreted as
    a EPSG code.
+-  ST_EnvIntersects(geom *Geometry*, minx *Double*, miny *Double*, maxx *Double*, maxy *Double*):
+   (GDAL >= 3.7) Returns 1 if the minimum bounding box of geom intersects the
+   bounding box defined by (minx,miny)-(maxx,maxy), or 0 otherwise.
+-  ST_EnvIntersects(geom1 *Geometry*, geom2 *Geometry*):
+   (GDAL >= 3.7) Returns 1 if the minimum bounding box of geom1 intersects the
+   one of geom2, or 0 otherwise. (Note: this function, as all others, does not
+   automatically uses spatial indices)
 
 The raster SQL functions mentioned at :ref:`raster.gpkg.raster`
 are also available.

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -5117,12 +5117,10 @@ CPLString OGRGeoPackageTableLayer::GetSpatialWhere(int iGeomColIn,
 
             /* A bit inefficient but still faster than OGR filtering */
             osSpatialWHERE.Printf(
-                "(ST_MaxX(\"%s\") >= %.12f AND ST_MinX(\"%s\") <= %.12f AND "
-                "ST_MaxY(\"%s\") >= %.12f AND ST_MinY(\"%s\") <= %.12f)",
+                "ST_EnvelopesIntersects(\"%s\", %.12f, %.12f, %.12f, %.12f)",
                 SQLEscapeName(pszC).c_str(), sEnvelope.MinX - 1e-11,
-                SQLEscapeName(pszC).c_str(), sEnvelope.MaxX + 1e-11,
-                SQLEscapeName(pszC).c_str(), sEnvelope.MinY - 1e-11,
-                SQLEscapeName(pszC).c_str(), sEnvelope.MaxY + 1e-11);
+                sEnvelope.MinY - 1e-11, sEnvelope.MaxX + 1e-11,
+                sEnvelope.MaxY + 1e-11);
         }
     }
 


### PR DESCRIPTION
Execution time can be ~ 1.5x faster.

Before:
```
$ time ogrinfo nz-building-outlines.gpkg -sql "select count(*) from \"nz-building-outlines\" where st_maxx(geometry)>=1500000 and st_maxy(geometry)>= 5200000 and st_minx(geometry) <=1800000 and st_miny(geometry) <= 5800000" -al -q

Layer name: SELECT
OGRFeature(SELECT):0
  count(*) (Integer) = 701300

real	0m0,909s
user	0m0,633s
sys	0m0,276s
```

After:
```
$ time ogrinfo nz-building-outlines.gpkg -sql "select count(*) from \"nz-building-outlines\" where ST_EnvelopesIntersects(geometry, 1500000, 5200000 ,1800000 ,5800000)" -al -q

Layer name: SELECT
OGRFeature(SELECT):0
  count(*) (Integer) = 701300

real	0m0,605s
user	0m0,310s
sys	0m0,290s
```
