### PR TITLE
gcore: Fix for Windows x64 build with AVX2 enabled (fixes #7625)

### DIFF
--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -661,6 +661,11 @@ inline __m128d SQUARE(__m128d x)
 
 #ifdef __AVX2__
 
+inline __m256d SQUARE(__m256d x)
+{
+    return _mm256_mul_pd(x, x);
+}
+
 inline __m256d FIXUP_LANES(__m256d x)
 {
     return _mm256_permute4x64_pd(x, _MM_SHUFFLE(3, 1, 2, 0));


### PR DESCRIPTION
Implements the SQUARE function with an AVX2 intrinsic to avoid build errors.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes #7625. Fixes gcore build error in Windows x64 build with AVX2 enabled.

## What are related issues/pull requests?

#7625 

## Environment

Provide environment details, if relevant:

* OS: Windows 10
* Compiler: MSVC for Visual Studio 17 2022
