### PR TITLE
GPKG: minimum (read) support for non-standard multiple geometry columns per table

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -4709,34 +4709,97 @@ def test_ogr_gpkg_creation_fid():
 
 def test_ogr_gpkg_57():
 
-    if gdaltest.gpkg_dr.GetMetadataItem("ENABLE_SQL_GPKG_FORMAT") != "YES":
-        pytest.skip()
+    out_filename = "/vsimem/test_ogr_gpkg_57.gpkg"
+    ogr.GetDriverByName("GPKG").CreateDataSource(out_filename)
 
-    tmpfile = "/vsimem/tmp.gpkg.txt"
-    gdal.FileFromMemBuffer(
-        tmpfile,
-        """-- SQL GPKG
-CREATE TABLE gpkg_spatial_ref_sys (srs_name,srs_id,organization,organization_coordsys_id,definition,description);
-INSERT INTO "gpkg_spatial_ref_sys" VALUES('',0,'NONE',0,'undefined','');
-CREATE TABLE gpkg_contents (table_name,data_type,identifier,description,last_change,min_x, min_y,max_x, max_y,srs_id);
-INSERT INTO "gpkg_contents" VALUES('poly','features','poly','','',NULL,NULL,NULL,NULL,0);
-INSERT INTO "gpkg_contents" VALUES('poly','features','poly','','',NULL,NULL,NULL,NULL,0);
-CREATE TABLE gpkg_geometry_columns (table_name,column_name,geometry_type_name,srs_id,z,m);
-INSERT INTO "gpkg_geometry_columns" VALUES('poly','geom','POLYGON',0,0,0);
-CREATE TABLE "poly"("fid" INTEGER PRIMARY KEY, "geom" POLYGON);
-""",
+    ds = ogr.Open(out_filename, update=1)
+    ds.ExecuteSQL("DROP TABLE gpkg_contents")
+    ds.ExecuteSQL(
+        "CREATE TABLE gpkg_contents (table_name,data_type,identifier,description,last_change,min_x, min_y,max_x, max_y,srs_id)"
     )
+    ds.ExecuteSQL(
+        """INSERT INTO "gpkg_contents" VALUES('poly','features','poly','','',NULL,NULL,NULL,NULL,0)"""
+    )
+    ds.ExecuteSQL(
+        """INSERT INTO "gpkg_contents" VALUES('poly','features','poly','','',NULL,NULL,NULL,NULL,0)"""
+    )
+    ds.ExecuteSQL(
+        """INSERT INTO "gpkg_geometry_columns" VALUES('poly','geom','POLYGON',0,0,0)"""
+    )
+    ds.ExecuteSQL("""CREATE TABLE "poly"("fid" INTEGER PRIMARY KEY, "geom" POLYGON)""")
+    ds = None
 
     gdal.ErrorReset()
     with gdaltest.error_handler():
-        ds = ogr.Open(tmpfile)
+        ds = ogr.Open(out_filename)
     assert ds.GetLayerCount() == 1, "bad layer count"
-    assert (
-        gdal.GetLastErrorMsg().find("Table poly appearing several times") >= 0
-    ), "should NOT have warned"
+    assert gdal.GetLastErrorMsg() != ""
     ds = None
 
-    gdal.Unlink(tmpfile)
+    gdal.Unlink(out_filename)
+
+
+###############################################################################
+# Test opening a non-standard GeoPackage with multiple geometry columns
+
+
+def test_ogr_gpkg_multiple_geom_columns():
+
+    out_filename = "/vsimem/test_ogr_gpkg_multiple_geom_columns.gpkg"
+    ogr.GetDriverByName("GPKG").CreateDataSource(out_filename)
+
+    ds = ogr.Open(out_filename, update=1)
+    ds.ExecuteSQL("DROP TABLE gpkg_geometry_columns")
+    # Modified gpkg_geometry_columns definition with a UNIQUE constraint on both (table_name, column_name)
+    ds.ExecuteSQL(
+        """CREATE TABLE gpkg_geometry_columns (table_name TEXT NOT NULL,column_name TEXT NOT NULL,geometry_type_name TEXT NOT NULL,srs_id INTEGER NOT NULL,z TINYINT NOT NULL,m TINYINT NOT NULL,CONSTRAINT pk_geom_cols PRIMARY KEY (table_name, column_name),CONSTRAINT uk_gc_table_name_column_name UNIQUE (table_name, column_name),CONSTRAINT fk_gc_tn FOREIGN KEY (table_name) REFERENCES gpkg_contents(table_name),CONSTRAINT fk_gc_srs FOREIGN KEY (srs_id) REFERENCES gpkg_spatial_ref_sys (srs_id));"""
+    )
+    ds.ExecuteSQL(
+        """CREATE TABLE "test" ( "ogc_fid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "poly" POLYGON, "pt" POINT, "area" REAL, "eas_id" INTEGER, "prfedea" TEXT(16))"""
+    )
+    ds.ExecuteSQL(
+        "INSERT INTO test VALUES(1,X'4750000300000000000000401f401d41000000e05e511d4100000080322c5241000000001d2d52410103000000010000001b000000000000c01a481d4100000080072d5241000000e0814b1d41000000001d2d524100000040c44b1d41000000000f2d5241000000002c4c1d41000000a0002d524100000000774d1d41000000c0072d5241000000a0c44e1d4100000080112d52410000002008501d41000000c0172d5241000000e05e511d4100000020dd2c5241000000405e511d4100000040cf2c524100000000f0501d41000000c0ba2c52410000008084501d4100000020af2c524100000040a94f1d4100000000a42c524100000080744e1d41000000a09a2c524100000040014f1d41000000c0852c5241000000e0e04d1d4100000020872c524100000040f8441d41000000e0432c5241000000c012441d4100000080322c524100000000ff431d4100000020362c5241000000004b431d4100000080552c52410000000030431d41000000c05d2c5241000000c09b421d4100000000712c524100000080d6411d4100000080912c52410000008027411d4100000040b22c5241000000401f401d4100000040d62c5241000000a043441d4100000060f02c524100000060aa461d4100000080ff2c5241000000c01a481d4100000080072d5241',X'4750000100000000010100000000000000804b1d41000000001d2d5241',NULL,170,NULL);"
+    )
+    ds.ExecuteSQL(
+        "INSERT INTO gpkg_contents VALUES('test','features','test',NULL,'2023-04-21T13:53:59.009Z',478315.53124999999998,4762880.5,481645.3125,4765610.4999999999998,0);"
+    )
+    ds.ExecuteSQL(
+        "INSERT INTO gpkg_geometry_columns VALUES('test','poly','POLYGON',-1,0,0);"
+    )
+    ds.ExecuteSQL(
+        "INSERT INTO gpkg_geometry_columns VALUES('test','pt','POINT',4326,0,0);"
+    )
+    ds = None
+
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        ds = ogr.Open(out_filename)
+    assert gdal.GetLastErrorMsg() != ""
+    assert ds.GetLayerCount() == 2
+
+    lyr = ds.GetLayerByName("test (poly)")
+    assert lyr.GetGeomType() == ogr.wkbPolygon
+    assert lyr.GetGeometryColumn() == "poly"
+    assert lyr.GetSpatialRef().GetName() == "Undefined Cartesian SRS"
+    assert lyr.GetLayerDefn().GetFieldCount() == 3
+    f = lyr.GetNextFeature()
+    assert f.GetFID() == 1
+    assert f["eas_id"] == 170
+    assert f.GetGeometryRef().ExportToWkt().startswith("POLYGON ((479750")
+
+    lyr = ds.GetLayerByName("test (pt)")
+    assert lyr.GetGeomType() == ogr.wkbPoint
+    assert lyr.GetGeometryColumn() == "pt"
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetLayerDefn().GetFieldCount() == 3
+    f = lyr.GetNextFeature()
+    assert f.GetFID() == 1
+    assert f["eas_id"] == 170
+    assert f.GetGeometryRef().ExportToWkt() == "POINT (479968 4764788)"
+
+    ds = None
+
+    gdal.Unlink(out_filename)
 
 
 ###############################################################################

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -820,7 +820,8 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
 
     void RecomputeExtent();
 
-    void SetOpeningParameters(const char *pszObjectType, bool bIsInGpkgContents,
+    void SetOpeningParameters(const char *pszTableName,
+                              const char *pszObjectType, bool bIsInGpkgContents,
                               bool bIsSpatial, const char *pszGeomColName,
                               const char *pszGeomType, bool bHasZ, bool bHasM);
     void SetCreationParameters(OGRwkbGeometryType eGType,

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -1670,13 +1670,13 @@ int GDALGeoPackageDataset::Open(GDALOpenInfo *poOpenInfo,
             m_papoLayers = static_cast<OGRGeoPackageTableLayer **>(CPLMalloc(
                 sizeof(OGRGeoPackageTableLayer *) * oResult->RowCount()));
 
-            std::set<CPLString> oSetTables;
+            std::map<std::string, int> oMapTableRefCount;
             for (int i = 0; i < oResult->RowCount(); i++)
             {
                 const char *pszTableName = oResult->GetValue(0, i);
                 if (pszTableName == nullptr)
                     continue;
-                if (oSetTables.find(pszTableName) != oSetTables.end())
+                if (++oMapTableRefCount[pszTableName] == 2)
                 {
                     // This should normally not happen if all constraints are
                     // properly set
@@ -1684,9 +1684,17 @@ int GDALGeoPackageDataset::Open(GDALOpenInfo *poOpenInfo,
                              "Table %s appearing several times in "
                              "gpkg_contents and/or gpkg_geometry_columns",
                              pszTableName);
-                    continue;
                 }
-                oSetTables.insert(pszTableName);
+            }
+
+            std::set<std::string> oExistingLayers;
+            for (int i = 0; i < oResult->RowCount(); i++)
+            {
+                const char *pszTableName = oResult->GetValue(0, i);
+                if (pszTableName == nullptr)
+                    continue;
+                const bool bTableHasSeveralGeomColumns =
+                    oMapTableRefCount[pszTableName] > 1;
                 bool bIsSpatial = CPL_TO_BOOL(oResult->GetValueAsInteger(2, i));
                 const char *pszGeomColName = oResult->GetValue(3, i);
                 const char *pszGeomType = oResult->GetValue(4, i);
@@ -1707,8 +1715,25 @@ int GDALGeoPackageDataset::Open(GDALOpenInfo *poOpenInfo,
                              pszTableName);
                     continue;
                 }
+                // Non-standard and undocumented behavior:
+                // if the same table appears to have several geometry columns,
+                // handle it for now as multiple layers named
+                // "table_name (geom_col_name)"
+                // The way we handle that might change in the future (e.g
+                // could be a single layer with multiple geometry columns)
+                const std::string osLayerNameWithGeomColName =
+                    pszGeomColName ? std::string(pszTableName) + " (" +
+                                         pszGeomColName + ')'
+                                   : std::string(pszTableName);
+                if (oExistingLayers.find(osLayerNameWithGeomColName) !=
+                    oExistingLayers.end())
+                    continue;
+                oExistingLayers.insert(osLayerNameWithGeomColName);
+                const std::string osLayerName = bTableHasSeveralGeomColumns
+                                                    ? osLayerNameWithGeomColName
+                                                    : std::string(pszTableName);
                 OGRGeoPackageTableLayer *poLayer =
-                    new OGRGeoPackageTableLayer(this, pszTableName);
+                    new OGRGeoPackageTableLayer(this, osLayerName.c_str());
                 bool bHasZ = pszZ && atoi(pszZ) > 0;
                 bool bHasM = pszM && atoi(pszM) > 0;
                 if (pszGeomType && EQUAL(pszGeomType, "GEOMETRY"))
@@ -1718,9 +1743,9 @@ int GDALGeoPackageDataset::Open(GDALOpenInfo *poOpenInfo,
                     if (pszM && atoi(pszM) == 2)
                         bHasM = false;
                 }
-                poLayer->SetOpeningParameters(pszObjectType, bIsInGpkgContents,
-                                              bIsSpatial, pszGeomColName,
-                                              pszGeomType, bHasZ, bHasM);
+                poLayer->SetOpeningParameters(
+                    pszTableName, pszObjectType, bIsInGpkgContents, bIsSpatial,
+                    pszGeomColName, pszGeomType, bHasZ, bHasM);
                 m_papoLayers[m_nLayers++] = poLayer;
             }
         }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -914,6 +914,10 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
     }
 #endif
 
+    bool bHasPreexistingSingleGeomColumn =
+        m_poFeatureDefn->GetGeomFieldCount() == 1;
+    bool bHasMultipleGeomColsInGpkgGeometryColumns = false;
+
     if (m_bIsInGpkgContents)
     {
         /* Check that the table name is registered in gpkg_contents */
@@ -961,7 +965,7 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
 #ifdef WORKAROUND_SQLITE3_BUGS
                                            " OR 0"
 #endif
-                                           " LIMIT 2",
+                                           " LIMIT 2000",
                                            m_pszTableName);
 
             auto oResultGeomCols = SQLQuery(poDb, pszSQL);
@@ -975,7 +979,7 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
 #ifdef WORKAROUND_SQLITE3_BUGS
                                          " OR 0"
 #endif
-                                         " LIMIT 2",
+                                         " LIMIT 2000",
                                          m_pszTableName);
 
                 oResultGeomCols = SQLQuery(poDb, pszSQL);
@@ -983,31 +987,64 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
             }
 
             /* gpkg_geometry_columns query has to work */
-            /* gpkg_geometry_columns.table_name is supposed to be unique */
-            if (!oResultGeomCols || oResultGeomCols->RowCount() != 1)
+            if (!(oResultGeomCols && oResultGeomCols->RowCount() > 0))
             {
-                if (oResultGeomCols)
-                    CPLError(
-                        CE_Failure, CPLE_AppDefined,
-                        "layer '%s' is not registered in gpkg_geometry_columns",
-                        m_pszTableName);
-
-                return OGRERR_FAILURE;
+                CPLError(
+                    CE_Warning, CPLE_AppDefined,
+                    "layer '%s' is not registered in gpkg_geometry_columns",
+                    m_pszTableName);
             }
-
-            const char *pszGeomColName = oResultGeomCols->GetValue(1, 0);
-            if (pszGeomColName != nullptr)
-                osGeomColumnName = pszGeomColName;
-            const char *pszGeomColsType = oResultGeomCols->GetValue(2, 0);
-            if (pszGeomColsType != nullptr)
-                osGeomColsType = pszGeomColsType;
-            m_iSrs = oResultGeomCols->GetValueAsInteger(3, 0);
-            m_nZFlag = oResultGeomCols->GetValueAsInteger(4, 0);
-            m_nMFlag = oResultGeomCols->GetValueAsInteger(5, 0);
-            if (!(EQUAL(osGeomColsType, "GEOMETRY") && m_nZFlag == 2))
+            else
             {
-                bHasZ = CPL_TO_BOOL(m_nZFlag);
-                bHasM = CPL_TO_BOOL(m_nMFlag);
+                int iRow = -1;
+                bHasMultipleGeomColsInGpkgGeometryColumns =
+                    oResultGeomCols->RowCount() > 1;
+                for (int i = 0; i < oResultGeomCols->RowCount(); ++i)
+                {
+                    const char *pszGeomColName =
+                        oResultGeomCols->GetValue(1, i);
+                    if (!pszGeomColName)
+                        continue;
+                    if (!bHasPreexistingSingleGeomColumn ||
+                        strcmp(pszGeomColName,
+                               m_poFeatureDefn->GetGeomFieldDefn(0)
+                                   ->GetNameRef()) == 0)
+                    {
+                        iRow = i;
+                        break;
+                    }
+                }
+
+                if (iRow >= 0)
+                {
+                    const char *pszGeomColName =
+                        oResultGeomCols->GetValue(1, iRow);
+                    if (pszGeomColName != nullptr)
+                        osGeomColumnName = pszGeomColName;
+                    const char *pszGeomColsType =
+                        oResultGeomCols->GetValue(2, iRow);
+                    if (pszGeomColsType != nullptr)
+                        osGeomColsType = pszGeomColsType;
+                    m_iSrs = oResultGeomCols->GetValueAsInteger(3, iRow);
+                    m_nZFlag = oResultGeomCols->GetValueAsInteger(4, iRow);
+                    m_nMFlag = oResultGeomCols->GetValueAsInteger(5, iRow);
+                    if (!(EQUAL(osGeomColsType, "GEOMETRY") && m_nZFlag == 2))
+                    {
+                        bHasZ = CPL_TO_BOOL(m_nZFlag);
+                        bHasM = CPL_TO_BOOL(m_nMFlag);
+                    }
+                }
+                else
+                {
+                    CPLError(
+                        CE_Warning, CPLE_AppDefined,
+                        "Cannot find record for layer '%s' and geometry column "
+                        "'%s' in gpkg_geometry_columns",
+                        m_pszTableName,
+                        bHasPreexistingSingleGeomColumn
+                            ? m_poFeatureDefn->GetGeomFieldDefn(0)->GetNameRef()
+                            : "unknown");
+                }
             }
         }
     }
@@ -1059,8 +1096,6 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
                  m_pszTableName);
     }
 
-    bool bHasPreexistingSingleGeomColumn =
-        m_poFeatureDefn->GetGeomFieldCount() == 1;
     m_abGeneratedColumns.resize(oResultTable->RowCount());
     for (int iRecord = 0; iRecord < oResultTable->RowCount(); iRecord++)
     {
@@ -1117,22 +1152,29 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
                 oGeomType = wkbUnknown;
             if (oGeomType != wkbNone)
             {
-                OGRwkbGeometryType oGeomTypeGeomCols =
-                    GPkgGeometryTypeToWKB(osGeomColsType.c_str(), bHasZ, bHasM);
-                /* Enforce consistency between table and metadata */
-                if (wkbFlatten(oGeomType) == wkbUnknown)
-                    oGeomType = oGeomTypeGeomCols;
-                if (oGeomType != oGeomTypeGeomCols)
-                {
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "geometry column type in '%s.%s' is not "
-                             "consistent with type in gpkg_geometry_columns",
-                             m_pszTableName, pszName);
-                }
-
-                if (bHasPreexistingSingleGeomColumn ||
+                if ((bHasPreexistingSingleGeomColumn &&
+                     (!bHasMultipleGeomColsInGpkgGeometryColumns ||
+                      strcmp(pszName, m_poFeatureDefn->GetGeomFieldDefn(0)
+                                          ->GetNameRef()) == 0)) ||
                     m_poFeatureDefn->GetGeomFieldCount() == 0)
                 {
+                    OGRwkbGeometryType oGeomTypeGeomCols =
+                        GPkgGeometryTypeToWKB(osGeomColsType.c_str(), bHasZ,
+                                              bHasM);
+                    /* Enforce consistency between table and metadata */
+                    if (wkbFlatten(oGeomType) == wkbUnknown)
+                        oGeomType = oGeomTypeGeomCols;
+                    if (oGeomType != oGeomTypeGeomCols)
+                    {
+                        CPLError(CE_Warning, CPLE_AppDefined,
+                                 "geometry column type for layer '%s' in "
+                                 "'%s.%s' (%s) is not "
+                                 "consistent with type in "
+                                 "gpkg_geometry_columns (%s)",
+                                 GetName(), m_pszTableName, pszName,
+                                 osType.c_str(), osGeomColsType.c_str());
+                    }
+
                     if (!bHasPreexistingSingleGeomColumn)
                     {
                         OGRGeomFieldDefn oGeomField(pszName, oGeomType);
@@ -1152,19 +1194,18 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
                         poSRS->Dereference();
                     }
                 }
-                else
+                else if (!STARTS_WITH(
+                             GetName(),
+                             (std::string(m_pszTableName) + " (").c_str()))
                 {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "table '%s' has multiple geometry fields? not "
-                             "legal in gpkg",
-                             m_pszTableName);
-                    return OGRERR_FAILURE;
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "table '%s' has multiple geometry fields. "
+                             "Ignoring field '%s' for this layer",
+                             m_pszTableName, pszName);
                 }
             }
             else
             {
-                // CPLError( CE_Failure, CPLE_AppDefined, "invalid field type
-                // '%s'", osType.c_str() );
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "geometry column '%s' of type '%s' ignored", pszName,
                          osType.c_str());
@@ -5168,9 +5209,12 @@ void OGRGeoPackageTableLayer::BuildWhere()
 /************************************************************************/
 
 void OGRGeoPackageTableLayer::SetOpeningParameters(
-    const char *pszObjectType, bool bIsInGpkgContents, bool bIsSpatial,
-    const char *pszGeomColName, const char *pszGeomType, bool bHasZ, bool bHasM)
+    const char *pszTableName, const char *pszObjectType, bool bIsInGpkgContents,
+    bool bIsSpatial, const char *pszGeomColName, const char *pszGeomType,
+    bool bHasZ, bool bHasM)
 {
+    CPLFree(m_pszTableName);
+    m_pszTableName = CPLStrdup(pszTableName);
     m_bIsTable = EQUAL(pszObjectType, "table");
     m_bIsInGpkgContents = bIsInGpkgContents;
     m_bIsSpatial = bIsSpatial;


### PR DESCRIPTION

Refs https://github.com/opengisch/QgisModelBaker/issues/531

If a table has several geometry coluns in its DDL and is declared as many times in a modified gpkg_geometry_columns whose uk_gc_table_name unique constraint has been modified to have (table_name, column_name) as the unique constraint, then instantiate as many OGR layers has geometry columns.

e.g with the following content
```
INSERT INTO gpkg_geometry_columns VALUES('test','poly','POLYGON',0,0,0)
INSERT INTO gpkg_geometry_columns VALUES('test','pt','POINT',0,0,0)
CREATE TABLE "test" ( "ogc_fid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "poly" POLYGON, "pt" POINT, "area" REAL, "eas_id" INTEGER, "prfedea" TEXT(16))
```

the driver will report 2 layers: "test (poly)" and "test (pt)" In "test(poly)", the "pt" geometry column will be ignored, and in similarly for "test(pt)" where the "poly" geometry column will be ignored.

This might not be fully bullet proof for edition support (e.g if adding a feature in one layer, the driver might be a bit confused if not closing and re-opening), but should be OK for read support.

The way we handle that might change in the future (e.g could be a single layer with multiple geometry columns)
