### PR TITLE
autotest: Use gdal.config_option context manager

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -855,48 +855,34 @@ def test_warp_29():
     cs_monothread = ds.GetRasterBand(1).Checksum()
     ds = None
 
-    old_val = gdal.GetConfigOption("GDAL_NUM_THREADS")
-    gdal.SetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS")
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", "0")
-    ds = gdal.Open("data/white_nodata.vrt")
-    cs_multithread = ds.GetRasterBand(1).Checksum()
-    ds = None
-    gdal.SetConfigOption("GDAL_NUM_THREADS", old_val)
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", None)
+    with gdal.config_options(
+        {"GDAL_NUM_THREADS": "ALL_CPUS", "WARP_THREAD_CHUNK_SIZE": "0"}
+    ):
+        ds = gdal.Open("data/white_nodata.vrt")
+        cs_multithread = ds.GetRasterBand(1).Checksum()
+        ds = None
 
     assert cs_monothread == cs_multithread
 
-    old_val = gdal.GetConfigOption("GDAL_NUM_THREADS")
-    gdal.SetConfigOption("GDAL_NUM_THREADS", "2")
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", "0")
-    ds = gdal.Open("data/white_nodata.vrt")
-    cs_multithread = ds.GetRasterBand(1).Checksum()
-    ds = None
-    gdal.SetConfigOption("GDAL_NUM_THREADS", old_val)
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", None)
+    with gdal.config_options({"GDAL_NUM_THREADS": "2", "WARP_THREAD_CHUNK_SIZE": "0"}):
+        ds = gdal.Open("data/white_nodata.vrt")
+        cs_multithread = ds.GetRasterBand(1).Checksum()
+        ds = None
 
     assert cs_monothread == cs_multithread
 
     src_ds = gdal.Open("../gcore/data/byte.tif")
 
     ds = gdal.Open("data/byte_gcp.vrt")
-    old_val = gdal.GetConfigOption("GDAL_NUM_THREADS")
-    gdal.SetConfigOption("GDAL_NUM_THREADS", "2")
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", "0")
-    got_cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_NUM_THREADS", old_val)
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", None)
+    with gdal.config_options({"GDAL_NUM_THREADS": "2", "WARP_THREAD_CHUNK_SIZE": "0"}):
+        got_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     assert got_cs == src_ds.GetRasterBand(1).Checksum()
 
     ds = gdal.Open("data/byte_tps.vrt")
-    old_val = gdal.GetConfigOption("GDAL_NUM_THREADS")
-    gdal.SetConfigOption("GDAL_NUM_THREADS", "2")
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", "0")
-    got_cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_NUM_THREADS", old_val)
-    gdal.SetConfigOption("WARP_THREAD_CHUNK_SIZE", None)
+    with gdal.config_options({"GDAL_NUM_THREADS": "2", "WARP_THREAD_CHUNK_SIZE": "0"}):
+        got_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     assert got_cs == src_ds.GetRasterBand(1).Checksum()

--- a/autotest/gcore/hfa_write.py
+++ b/autotest/gcore/hfa_write.py
@@ -262,11 +262,9 @@ def test_hfa_use_rrd():
 
     shutil.copyfile("data/small_ov.img", "tmp/small.img")
 
-    old_value = gdal.GetConfigOption("HFA_USE_RRD", "NO")
-    gdal.SetConfigOption("HFA_USE_RRD", "YES")
-    ds = gdal.Open("tmp/small.img", gdal.GA_Update)
-    result = ds.BuildOverviews(overviewlist=[2])
-    gdal.SetConfigOption("HFA_USE_RRD", old_value)
+    with gdal.config_option("HFA_USE_RRD", "YES"):
+        ds = gdal.Open("tmp/small.img", gdal.GA_Update)
+        result = ds.BuildOverviews(overviewlist=[2])
 
     assert result == 0, "BuildOverviews() failed."
     ds = None
@@ -293,74 +291,66 @@ def test_hfa_use_rrd():
 @pytest.mark.require_driver("BMP")
 def test_hfa_update_existing_aux_overviews():
 
-    gdal.SetConfigOption("USE_RRD", "YES")
+    with gdal.config_option("USE_RRD", "YES"):
 
-    ds = gdal.GetDriverByName("BMP").Create(
-        "tmp/hfa_update_existing_aux_overviews.bmp", 100, 100, 1
-    )
-    ds.GetRasterBand(1).Fill(255)
-    ds = None
+        ds = gdal.GetDriverByName("BMP").Create(
+            "tmp/hfa_update_existing_aux_overviews.bmp", 100, 100, 1
+        )
+        ds.GetRasterBand(1).Fill(255)
+        ds = None
 
-    # Create overviews
-    ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
-    ds.BuildOverviews("NEAR", overviewlist=[2, 4])
-    ds = None
+        # Create overviews
+        ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
+        ds.BuildOverviews("NEAR", overviewlist=[2, 4])
+        ds = None
 
-    # Save overviews checksum
-    ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
-    cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
-    cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
+        # Save overviews checksum
+        ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
+        cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
+        cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
 
-    # and regenerate them
-    ds.BuildOverviews("NEAR", overviewlist=[2, 4])
-    ds = None
+        # and regenerate them
+        ds.BuildOverviews("NEAR", overviewlist=[2, 4])
+        ds = None
 
-    ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
-    # Check overviews checksum
-    new_cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
-    new_cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
-    if cs_ovr0 != new_cs_ovr0:
-        gdal.SetConfigOption("USE_RRD", None)
-        pytest.fail()
-    if cs_ovr1 != new_cs_ovr1:
-        gdal.SetConfigOption("USE_RRD", None)
-        pytest.fail()
+        ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
+        # Check overviews checksum
+        new_cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
+        new_cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
+        if cs_ovr0 != new_cs_ovr0:
+            pytest.fail()
+        if cs_ovr1 != new_cs_ovr1:
+            pytest.fail()
 
-    # and regenerate them twice in a row
-    ds.BuildOverviews("NEAR", overviewlist=[2, 4])
-    ds.BuildOverviews("NEAR", overviewlist=[2, 4])
-    ds = None
+        # and regenerate them twice in a row
+        ds.BuildOverviews("NEAR", overviewlist=[2, 4])
+        ds.BuildOverviews("NEAR", overviewlist=[2, 4])
+        ds = None
 
-    ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
-    # Check overviews checksum
-    new_cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
-    new_cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
-    if cs_ovr0 != new_cs_ovr0:
-        gdal.SetConfigOption("USE_RRD", None)
-        pytest.fail()
-    if cs_ovr1 != new_cs_ovr1:
-        gdal.SetConfigOption("USE_RRD", None)
-        pytest.fail()
+        ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
+        # Check overviews checksum
+        new_cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
+        new_cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
+        if cs_ovr0 != new_cs_ovr0:
+            pytest.fail()
+        if cs_ovr1 != new_cs_ovr1:
+            pytest.fail()
 
-    # and regenerate them with an extra overview level
-    ds.BuildOverviews("NEAR", overviewlist=[8])
-    ds = None
+        # and regenerate them with an extra overview level
+        ds.BuildOverviews("NEAR", overviewlist=[8])
+        ds = None
 
-    ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
-    # Check overviews checksum
-    new_cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
-    new_cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
-    if cs_ovr0 != new_cs_ovr0:
-        gdal.SetConfigOption("USE_RRD", None)
-        pytest.fail()
-    if cs_ovr1 != new_cs_ovr1:
-        gdal.SetConfigOption("USE_RRD", None)
-        pytest.fail()
-    ds = None
+        ds = gdal.Open("tmp/hfa_update_existing_aux_overviews.bmp")
+        # Check overviews checksum
+        new_cs_ovr0 = ds.GetRasterBand(1).GetOverview(0).Checksum()
+        new_cs_ovr1 = ds.GetRasterBand(1).GetOverview(1).Checksum()
+        if cs_ovr0 != new_cs_ovr0:
+            pytest.fail()
+        if cs_ovr1 != new_cs_ovr1:
+            pytest.fail()
+        ds = None
 
-    gdal.GetDriverByName("BMP").Delete("tmp/hfa_update_existing_aux_overviews.bmp")
-
-    gdal.SetConfigOption("USE_RRD", None)
+        gdal.GetDriverByName("BMP").Delete("tmp/hfa_update_existing_aux_overviews.bmp")
 
 
 ###############################################################################

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -224,37 +224,37 @@ def test_misc_5():
         # This is to speed-up the runtime of tests on EXT4 filesystems
         # Do not use this for production environment if you care about data safety
         # w.r.t system/OS crashes, unless you know what you are doing.
-        gdal.SetConfigOption("OGR_SQLITE_SYNCHRONOUS", "OFF")
+        with gdal.config_option("OGR_SQLITE_SYNCHRONOUS", "OFF"):
 
-        # Test Create() with various band numbers, including 0
-        for i in range(gdal.GetDriverCount()):
-            drv = gdal.GetDriver(i)
-            md = drv.GetMetadata()
-            if drv.ShortName == "PDF":
-                # PDF Create() is vector-only
-                continue
-            if drv.ShortName == "MBTiles":
-                # MBTiles only support some precise resolutions
-                continue
-            if "DCAP_CREATE" in md and "DCAP_RASTER" in md:
-                datatype = gdal.GDT_Byte
-                for nBands in range(6):
-                    _misc_5_internal(drv, datatype, nBands)
-
-                for nBands in [1, 3]:
-                    for datatype in (
-                        gdal.GDT_UInt16,
-                        gdal.GDT_Int16,
-                        gdal.GDT_UInt32,
-                        gdal.GDT_Int32,
-                        gdal.GDT_Float32,
-                        gdal.GDT_Float64,
-                        gdal.GDT_CInt16,
-                        gdal.GDT_CInt32,
-                        gdal.GDT_CFloat32,
-                        gdal.GDT_CFloat64,
-                    ):
+            # Test Create() with various band numbers, including 0
+            for i in range(gdal.GetDriverCount()):
+                drv = gdal.GetDriver(i)
+                md = drv.GetMetadata()
+                if drv.ShortName == "PDF":
+                    # PDF Create() is vector-only
+                    continue
+                if drv.ShortName == "MBTiles":
+                    # MBTiles only support some precise resolutions
+                    continue
+                if "DCAP_CREATE" in md and "DCAP_RASTER" in md:
+                    datatype = gdal.GDT_Byte
+                    for nBands in range(6):
                         _misc_5_internal(drv, datatype, nBands)
+
+                    for nBands in [1, 3]:
+                        for datatype in (
+                            gdal.GDT_UInt16,
+                            gdal.GDT_Int16,
+                            gdal.GDT_UInt32,
+                            gdal.GDT_Int32,
+                            gdal.GDT_Float32,
+                            gdal.GDT_Float64,
+                            gdal.GDT_CInt16,
+                            gdal.GDT_CInt32,
+                            gdal.GDT_CFloat32,
+                            gdal.GDT_CFloat64,
+                        ):
+                            _misc_5_internal(drv, datatype, nBands)
 
 
 ###############################################################################
@@ -477,33 +477,33 @@ def test_misc_6():
         # This is to speed-up the runtime of tests on EXT4 filesystems
         # Do not use this for production environment if you care about data safety
         # w.r.t system/OS crashes, unless you know what you are doing.
-        gdal.SetConfigOption("OGR_SQLITE_SYNCHRONOUS", "OFF")
+        with gdal.config_option("OGR_SQLITE_SYNCHRONOUS", "OFF"):
 
-        datatype = gdal.GDT_Byte
-        setDriversDone = set()
-        for nBands in range(6):
-            ret = misc_6_internal(datatype, nBands, setDriversDone)
-            if ret != "success":
-                gdal.PopErrorHandler()
-                return ret
+            datatype = gdal.GDT_Byte
+            setDriversDone = set()
+            for nBands in range(6):
+                ret = misc_6_internal(datatype, nBands, setDriversDone)
+                if ret != "success":
+                    gdal.PopErrorHandler()
+                    return ret
 
-        nBands = 1
-        for datatype in (
-            gdal.GDT_UInt16,
-            gdal.GDT_Int16,
-            gdal.GDT_UInt32,
-            gdal.GDT_Int32,
-            gdal.GDT_Float32,
-            gdal.GDT_Float64,
-            gdal.GDT_CInt16,
-            gdal.GDT_CInt32,
-            gdal.GDT_CFloat32,
-            gdal.GDT_CFloat64,
-        ):
-            ret = misc_6_internal(datatype, nBands, setDriversDone)
-            if ret != "success":
-                gdal.PopErrorHandler()
-                return ret
+            nBands = 1
+            for datatype in (
+                gdal.GDT_UInt16,
+                gdal.GDT_Int16,
+                gdal.GDT_UInt32,
+                gdal.GDT_Int32,
+                gdal.GDT_Float32,
+                gdal.GDT_Float64,
+                gdal.GDT_CInt16,
+                gdal.GDT_CInt32,
+                gdal.GDT_CFloat32,
+                gdal.GDT_CFloat64,
+            ):
+                ret = misc_6_internal(datatype, nBands, setDriversDone)
+                if ret != "success":
+                    gdal.PopErrorHandler()
+                    return ret
 
 
 ###############################################################################

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -688,9 +688,8 @@ def test_numpy_rw_17():
         ds = gdal.Open(gdal_array.GetArrayFilename(array))
     assert ds is None
 
-    gdal.SetConfigOption("GDAL_ARRAY_OPEN_BY_FILENAME", "TRUE")
-    ds = gdal.Open(gdal_array.GetArrayFilename(array))
-    gdal.SetConfigOption("GDAL_ARRAY_OPEN_BY_FILENAME", None)
+    with gdal.config_option("GDAL_ARRAY_OPEN_BY_FILENAME", "TRUE"):
+        ds = gdal.Open(gdal_array.GetArrayFilename(array))
     assert ds is not None
 
     # Invalid value

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -157,9 +157,8 @@ def test_tiff_check_alpha():
 
     ds = None
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("data/stefan_full_greyalpha.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("data/stefan_full_greyalpha.tif")
     gdaltest.supports_force_rgba = False
     if ds.RasterCount == 4:
         gdaltest.supports_force_rgba = True
@@ -179,9 +178,8 @@ def test_tiff_check_alpha():
     ds = None
 
     if gdaltest.supports_force_rgba:
-        gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-        ds = gdal.Open("data/stefan_full_rgba.tif")
-        gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+        with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+            ds = gdal.Open("data/stefan_full_rgba.tif")
         got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
         # FIXME? Not the same as without GTIFF_FORCE_RGBA=YES
         assert got_cs == [11547, 57792, 35643, 10807]
@@ -198,9 +196,8 @@ def test_tiff_check_alpha():
     ds = None
 
     if gdaltest.supports_force_rgba:
-        gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-        ds = gdal.Open("data/stefan_full_rgba_photometric_rgb.tif")
-        gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+        with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+            ds = gdal.Open("data/stefan_full_rgba_photometric_rgb.tif")
         got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
         assert got_cs == [12603, 58561, 36064, 10807]
         ds = None
@@ -517,48 +514,46 @@ def test_tiff_linearparmunits():
 
 def test_tiff_linearparmunits2():
 
-    gdal.SetConfigOption("GTIFF_LINEAR_UNITS", "BROKEN")
+    with gdal.config_option("GTIFF_LINEAR_UNITS", "BROKEN"):
 
-    # Test the file with the correct formulation.
+        # Test the file with the correct formulation.
 
-    ds = gdal.Open("data/spaf27_correct.tif")
-    wkt = ds.GetProjectionRef()
-    ds = None
+        ds = gdal.Open("data/spaf27_correct.tif")
+        wkt = ds.GetProjectionRef()
+        ds = None
 
-    srs = osr.SpatialReference(wkt)
+        srs = osr.SpatialReference(wkt)
 
-    fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
-    assert fe == pytest.approx(
-        6561666.66667, abs=0.001
-    ), "did not get expected false easting (1)"
+        fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
+        assert fe == pytest.approx(
+            6561666.66667, abs=0.001
+        ), "did not get expected false easting (1)"
 
-    # Test the file with the correct formulation that is marked as correct.
+        # Test the file with the correct formulation that is marked as correct.
 
-    ds = gdal.Open("data/spaf27_markedcorrect.tif")
-    wkt = ds.GetProjectionRef()
-    ds = None
+        ds = gdal.Open("data/spaf27_markedcorrect.tif")
+        wkt = ds.GetProjectionRef()
+        ds = None
 
-    srs = osr.SpatialReference(wkt)
+        srs = osr.SpatialReference(wkt)
 
-    fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
-    assert fe == pytest.approx(
-        2000000.0, abs=0.001
-    ), "did not get expected false easting (2)"
+        fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
+        assert fe == pytest.approx(
+            2000000.0, abs=0.001
+        ), "did not get expected false easting (2)"
 
-    # Test the file with the old (broken) GDAL formulation.
+        # Test the file with the old (broken) GDAL formulation.
 
-    ds = gdal.Open("data/spaf27_brokengdal.tif")
-    wkt = ds.GetProjectionRef()
-    ds = None
+        ds = gdal.Open("data/spaf27_brokengdal.tif")
+        wkt = ds.GetProjectionRef()
+        ds = None
 
-    srs = osr.SpatialReference(wkt)
+        srs = osr.SpatialReference(wkt)
 
-    fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
-    assert fe == pytest.approx(
-        2000000.0, abs=0.001
-    ), "did not get expected false easting (3)"
-
-    gdal.SetConfigOption("GTIFF_LINEAR_UNITS", "DEFAULT")
+        fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
+        assert fe == pytest.approx(
+            2000000.0, abs=0.001
+        ), "did not get expected false easting (3)"
 
 
 ###############################################################################
@@ -713,10 +708,8 @@ def test_tiff_GTModelTypeGeoKey_only():
 @gdaltest.require_creation_option("GTiff", "JPEG")
 @gdaltest.disable_exceptions()
 def test_tiff_12bitjpeg():
-    old_accum = gdal.GetConfigOption("CPL_ACCUM_ERROR_MSG", "OFF")
-    gdal.SetConfigOption("CPL_ACCUM_ERROR_MSG", "ON")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.config_option("CPL_ACCUM_ERROR_MSG", "ON"), gdaltest.error_handler():
 
         if os.path.exists("data/mandrilmini_12bitjpeg.tif.aux.xml"):
             os.unlink("data/mandrilmini_12bitjpeg.tif.aux.xml")
@@ -726,8 +719,6 @@ def test_tiff_12bitjpeg():
             ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
         except Exception:
             ds = None
-
-    gdal.SetConfigOption("CPL_ACCUM_ERROR_MSG", old_accum)
 
     if gdal.GetLastErrorMsg().find("Unsupported JPEG data precision 12") != -1:
         pytest.skip("12bit jpeg not available")
@@ -839,29 +830,27 @@ Definition Table
 
 def test_tiff_read_pixelispoint():
 
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", "FALSE")
+    with gdal.config_option("GTIFF_POINT_GEO_IGNORE", "FALSE"):
 
-    ds = gdal.Open("data/byte_point.tif")
-    gt = ds.GetGeoTransform()
-    ds = None
+        ds = gdal.Open("data/byte_point.tif")
+        gt = ds.GetGeoTransform()
+        ds = None
 
-    gt_expected = (440690.0, 60.0, 0.0, 3751350.0, 0.0, -60.0)
+        gt_expected = (440690.0, 60.0, 0.0, 3751350.0, 0.0, -60.0)
 
-    assert gt == gt_expected, "did not get expected geotransform"
+        assert gt == gt_expected, "did not get expected geotransform"
 
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", "TRUE")
+    with gdal.config_option("GTIFF_POINT_GEO_IGNORE", "TRUE"):
 
-    ds = gdal.Open("data/byte_point.tif")
-    gt = ds.GetGeoTransform()
-    ds = None
+        ds = gdal.Open("data/byte_point.tif")
+        gt = ds.GetGeoTransform()
+        ds = None
 
-    gt_expected = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
+        gt_expected = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
-    assert (
-        gt == gt_expected
-    ), "did not get expected geotransform with GTIFF_POINT_GEO_IGNORE TRUE"
-
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", None)
+        assert (
+            gt == gt_expected
+        ), "did not get expected geotransform with GTIFF_POINT_GEO_IGNORE TRUE"
 
 
 ###############################################################################
@@ -870,29 +859,27 @@ def test_tiff_read_pixelispoint():
 
 def test_tiff_read_geomatrix():
 
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", "FALSE")
+    with gdal.config_option("GTIFF_POINT_GEO_IGNORE", "FALSE"):
 
-    ds = gdal.Open("data/geomatrix.tif")
-    gt = ds.GetGeoTransform()
-    ds = None
+        ds = gdal.Open("data/geomatrix.tif")
+        gt = ds.GetGeoTransform()
+        ds = None
 
-    gt_expected = (1841001.75, 1.5, -5.0, 1144003.25, -5.0, -1.5)
+        gt_expected = (1841001.75, 1.5, -5.0, 1144003.25, -5.0, -1.5)
 
-    assert gt == gt_expected, "did not get expected geotransform"
+        assert gt == gt_expected, "did not get expected geotransform"
 
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", "TRUE")
+    with gdal.config_option("GTIFF_POINT_GEO_IGNORE", "TRUE"):
 
-    ds = gdal.Open("data/geomatrix.tif")
-    gt = ds.GetGeoTransform()
-    ds = None
+        ds = gdal.Open("data/geomatrix.tif")
+        gt = ds.GetGeoTransform()
+        ds = None
 
-    gt_expected = (1841000.0, 1.5, -5.0, 1144000.0, -5.0, -1.5)
+        gt_expected = (1841000.0, 1.5, -5.0, 1144000.0, -5.0, -1.5)
 
-    assert (
-        gt == gt_expected
-    ), "did not get expected geotransform with GTIFF_POINT_GEO_IGNORE TRUE"
-
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", None)
+        assert (
+            gt == gt_expected
+        ), "did not get expected geotransform with GTIFF_POINT_GEO_IGNORE TRUE"
 
 
 ###############################################################################
@@ -944,10 +931,8 @@ def test_tiff_read_corrupted_gtiff():
 def test_tiff_read_tag_without_null_byte():
 
     gdal.ErrorReset()
-    oldval = gdal.GetConfigOption("CPL_DEBUG")
-    gdal.SetConfigOption("CPL_DEBUG", "OFF")
-    ds = gdal.Open("data/tag_without_null_byte.tif")
-    gdal.SetConfigOption("CPL_DEBUG", oldval)
+    with gdal.config_option("CPL_DEBUG", "OFF"):
+        ds = gdal.Open("data/tag_without_null_byte.tif")
     assert (
         gdal.GetLastErrorType() == 0
     ), "should have not emitted a warning, but only a CPLDebug() message"
@@ -2638,12 +2623,10 @@ def test_tiff_read_strace_check():
 
 def test_tiff_read_readdir_limit_on_open():
 
-    gdal.SetConfigOption("GDAL_READDIR_LIMIT_ON_OPEN", "1")
+    with gdal.config_option("GDAL_READDIR_LIMIT_ON_OPEN", "1"):
 
-    ds = gdal.Open("data/md_kompsat.tif", gdal.GA_ReadOnly)
-    filelist = ds.GetFileList()
-
-    gdal.SetConfigOption("GDAL_READDIR_LIMIT_ON_OPEN", None)
+        ds = gdal.Open("data/md_kompsat.tif", gdal.GA_ReadOnly)
+        filelist = ds.GetFileList()
 
     assert len(filelist) == 3, "did not get expected file list."
 
@@ -2657,9 +2640,8 @@ def test_tiff_read_minisblack_as_rgba():
     if not gdaltest.supports_force_rgba:
         pytest.skip()
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("data/byte.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("data/byte.tif")
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
     assert got_cs == [4672, 4672, 4672, 4873]
     ds = None
@@ -2674,9 +2656,8 @@ def test_tiff_read_colortable_as_rgba():
     if not gdaltest.supports_force_rgba:
         pytest.skip()
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("data/test_average_palette.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("data/test_average_palette.tif")
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
     assert got_cs == [2433, 2433, 2433, 4873]
     ds = None
@@ -2691,9 +2672,8 @@ def test_tiff_read_logl_as_rgba():
     if not gdaltest.supports_force_rgba:
         pytest.skip()
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("data/uint16_sgilog.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("data/uint16_sgilog.tif")
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
     # I'm pretty sure this isn't the expected result...
     assert got_cs == [0, 0, 0, 4873]
@@ -2716,9 +2696,8 @@ def test_tiff_read_strip_separate_as_rgba():
         options="-co INTERLEAVE=BAND",
     )
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("/vsimem/tiff_read_strip_separate_as_rgba.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("/vsimem/tiff_read_strip_separate_as_rgba.tif")
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
     assert got_cs == [21212, 21053, 21349, 30658]
     ds = None
@@ -2733,9 +2712,8 @@ def test_tiff_read_strip_separate_as_rgba():
         options="-co INTERLEAVE=BAND -co PHOTOMETRIC=MINISBLACK",
     )
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("/vsimem/tiff_read_strip_separate_as_rgba.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("/vsimem/tiff_read_strip_separate_as_rgba.tif")
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
     assert got_cs == [21212, 21212, 21212, 30658]
     ds = None
@@ -2759,9 +2737,8 @@ def test_tiff_read_tiled_separate_as_rgba():
         options="-co TILED=YES -co INTERLEAVE=BAND",
     )
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("/vsimem/tiff_read_tiled_separate_as_rgba.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("/vsimem/tiff_read_tiled_separate_as_rgba.tif")
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
     assert got_cs == [21212, 21053, 21349, 30658]
     ds = None
@@ -2775,9 +2752,8 @@ def test_tiff_read_tiled_separate_as_rgba():
         options="-co TILED=YES -co INTERLEAVE=BAND",
     )
 
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", "YES")
-    ds = gdal.Open("/vsimem/tiff_read_tiled_separate_as_rgba.tif")
-    gdal.SetConfigOption("GTIFF_FORCE_RGBA", None)
+    with gdal.config_option("GTIFF_FORCE_RGBA", "YES"):
+        ds = gdal.Open("/vsimem/tiff_read_tiled_separate_as_rgba.tif")
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]
     assert got_cs == [4672, 4672, 4672, 4873]
     ds = None
@@ -2955,35 +2931,35 @@ def test_tiff_read_nogeoref():
         expected_gt,
     ) in tests:
         for iteration in range(2):
-            gdal.SetConfigOption("GDAL_GEOREF_SOURCES", config_option_value)
-            gdal.FileFromMemBuffer(
-                "/vsimem/byte_nogeoref.tif", open("data/byte_nogeoref.tif", "rb").read()
-            )
-            if copy_pam:
+            with gdal.config_option("GDAL_GEOREF_SOURCES", config_option_value):
                 gdal.FileFromMemBuffer(
-                    "/vsimem/byte_nogeoref.tif.aux.xml",
-                    open("data/byte_nogeoref.tif.aux.xml", "rb").read(),
+                    "/vsimem/byte_nogeoref.tif",
+                    open("data/byte_nogeoref.tif", "rb").read(),
                 )
-            if copy_worldfile:
-                gdal.FileFromMemBuffer(
-                    "/vsimem/byte_nogeoref.tfw",
-                    open("data/byte_nogeoref.tfw", "rb").read(),
-                )
-            if copy_tabfile:
-                gdal.FileFromMemBuffer(
-                    "/vsimem/byte_nogeoref.tab",
-                    open("data/byte_nogeoref.tab", "rb").read(),
-                )
+                if copy_pam:
+                    gdal.FileFromMemBuffer(
+                        "/vsimem/byte_nogeoref.tif.aux.xml",
+                        open("data/byte_nogeoref.tif.aux.xml", "rb").read(),
+                    )
+                if copy_worldfile:
+                    gdal.FileFromMemBuffer(
+                        "/vsimem/byte_nogeoref.tfw",
+                        open("data/byte_nogeoref.tfw", "rb").read(),
+                    )
+                if copy_tabfile:
+                    gdal.FileFromMemBuffer(
+                        "/vsimem/byte_nogeoref.tab",
+                        open("data/byte_nogeoref.tab", "rb").read(),
+                    )
 
-            ds = gdal.Open("/vsimem/byte_nogeoref.tif")
-            if iteration == 0:
-                gt = ds.GetGeoTransform()
-                srs_wkt = ds.GetProjectionRef()
-            else:
-                srs_wkt = ds.GetProjectionRef()
-                gt = ds.GetGeoTransform()
-            ds = None
-            gdal.SetConfigOption("GDAL_GEOREF_SOURCES", None)
+                ds = gdal.Open("/vsimem/byte_nogeoref.tif")
+                if iteration == 0:
+                    gt = ds.GetGeoTransform()
+                    srs_wkt = ds.GetProjectionRef()
+                else:
+                    srs_wkt = ds.GetProjectionRef()
+                    gt = ds.GetGeoTransform()
+                ds = None
             with gdal.ExceptionMgr(useExceptions=False):
                 gdal.Unlink("/vsimem/byte_nogeoref.tif")
                 gdal.Unlink("/vsimem/byte_nogeoref.tif.aux.xml")
@@ -3116,35 +3092,34 @@ def test_tiff_read_inconsistent_georef():
         expected_gt,
     ) in tests:
         for iteration in range(2):
-            gdal.SetConfigOption("GDAL_GEOREF_SOURCES", config_option_value)
-            gdal.FileFromMemBuffer(
-                "/vsimem/byte_inconsistent_georef.tif",
-                open("data/byte_inconsistent_georef.tif", "rb").read(),
-            )
-            if copy_pam:
+            with gdal.config_option("GDAL_GEOREF_SOURCES", config_option_value):
                 gdal.FileFromMemBuffer(
-                    "/vsimem/byte_inconsistent_georef.tif.aux.xml",
-                    open("data/byte_inconsistent_georef.tif.aux.xml", "rb").read(),
+                    "/vsimem/byte_inconsistent_georef.tif",
+                    open("data/byte_inconsistent_georef.tif", "rb").read(),
                 )
-            if copy_worldfile:
-                gdal.FileFromMemBuffer(
-                    "/vsimem/byte_inconsistent_georef.tfw",
-                    open("data/byte_inconsistent_georef.tfw", "rb").read(),
-                )
-            if copy_tabfile:
-                gdal.FileFromMemBuffer(
-                    "/vsimem/byte_inconsistent_georef.tab",
-                    open("data/byte_inconsistent_georef.tab", "rb").read(),
-                )
-            ds = gdal.Open("/vsimem/byte_inconsistent_georef.tif")
-            if iteration == 0:
-                gt = ds.GetGeoTransform()
-                srs_wkt = ds.GetProjectionRef()
-            else:
-                srs_wkt = ds.GetProjectionRef()
-                gt = ds.GetGeoTransform()
-            ds = None
-            gdal.SetConfigOption("GDAL_GEOREF_SOURCES", None)
+                if copy_pam:
+                    gdal.FileFromMemBuffer(
+                        "/vsimem/byte_inconsistent_georef.tif.aux.xml",
+                        open("data/byte_inconsistent_georef.tif.aux.xml", "rb").read(),
+                    )
+                if copy_worldfile:
+                    gdal.FileFromMemBuffer(
+                        "/vsimem/byte_inconsistent_georef.tfw",
+                        open("data/byte_inconsistent_georef.tfw", "rb").read(),
+                    )
+                if copy_tabfile:
+                    gdal.FileFromMemBuffer(
+                        "/vsimem/byte_inconsistent_georef.tab",
+                        open("data/byte_inconsistent_georef.tab", "rb").read(),
+                    )
+                ds = gdal.Open("/vsimem/byte_inconsistent_georef.tif")
+                if iteration == 0:
+                    gt = ds.GetGeoTransform()
+                    srs_wkt = ds.GetProjectionRef()
+                else:
+                    srs_wkt = ds.GetProjectionRef()
+                    gt = ds.GetGeoTransform()
+                ds = None
             with gdal.ExceptionMgr(useExceptions=False):
                 gdal.Unlink("/vsimem/byte_inconsistent_georef.tif")
                 gdal.Unlink("/vsimem/byte_inconsistent_georef.tif.aux.xml")
@@ -3911,10 +3886,9 @@ def test_tiff_read_mmap_interface():
     tmpfile = "/vsimem/tiff_read_mmap_interface.tif"
     for options in [[], ["TILED=YES"], ["COMPRESS=LZW"], ["COMPRESS=LZW", "TILED=YES"]]:
         gdal.GetDriverByName("GTiff").CreateCopy(tmpfile, src_ds, options=options)
-        gdal.SetConfigOption("GTIFF_USE_MMAP", "YES")
-        ds = gdal.Open(tmpfile)
-        cs = ds.GetRasterBand(1).Checksum()
-        gdal.SetConfigOption("GTIFF_USE_MMAP", None)
+        with gdal.config_option("GTIFF_USE_MMAP", "YES"):
+            ds = gdal.Open(tmpfile)
+            cs = ds.GetRasterBand(1).Checksum()
         assert cs == 4672, (options, cs)
 
         f = gdal.VSIFOpenL(tmpfile, "rb")
@@ -3923,12 +3897,10 @@ def test_tiff_read_mmap_interface():
         f = gdal.VSIFOpenL(tmpfile, "wb")
         gdal.VSIFWriteL(data, 1, len(data), f)
         gdal.VSIFCloseL(f)
-        gdal.SetConfigOption("GTIFF_USE_MMAP", "YES")
-        with gdaltest.error_handler():
+        with gdal.config_option("GTIFF_USE_MMAP", "YES"):
             ds = gdal.Open(tmpfile)
             with pytest.raises(Exception):
                 ds.GetRasterBand(1).Checksum()
-        gdal.SetConfigOption("GTIFF_USE_MMAP", None)
         gdal.Unlink(tmpfile)
 
 

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -780,15 +780,12 @@ def test_transformer_14():
     ]
     ds.SetMetadata(rpc, "RPC")
 
-    old_rpc_inverse_verbose = gdal.GetConfigOption("RPC_INVERSE_VERBOSE")
-    gdal.SetConfigOption("RPC_INVERSE_VERBOSE", "YES")
-    old_rpc_inverse_log = gdal.GetConfigOption("RPC_INVERSE_LOG")
-    gdal.SetConfigOption("RPC_INVERSE_LOG", "/vsimem/transformer_14.csv")
-    tr = gdal.Transformer(
-        ds, None, ["METHOD=RPC", "RPC_DEM=data/transformer_14_dem.tif"]
-    )
-    gdal.SetConfigOption("RPC_INVERSE_VERBOSE", old_rpc_inverse_verbose)
-    gdal.SetConfigOption("RPC_INVERSE_LOG", old_rpc_inverse_log)
+    with gdal.config_options(
+        {"RPC_INVERSE_VERBOSE": "YES", "RPC_INVERSE_LOG": "/vsimem/transformer_14.csv"}
+    ):
+        tr = gdal.Transformer(
+            ds, None, ["METHOD=RPC", "RPC_DEM=data/transformer_14_dem.tif"]
+        )
     (success, pnt) = tr.TransformPoint(0, 0, 0)
     assert (
         success

--- a/autotest/gcore/vsicrypt.py
+++ b/autotest/gcore/vsicrypt.py
@@ -170,12 +170,10 @@ def test_vsicrypt_2():
             if fp is not None:
                 gdal.VSIFCloseL(fp)
 
-    gdal.SetConfigOption("VSICRYPT_IV", "TOO_SHORT")
-    with gdaltest.error_handler():
+    with gdal.config_option("VSICRYPT_IV", "TOO_SHORT"), gdaltest.error_handler():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=" "/vsimem/file.bin", "wb"
         )
-    gdal.SetConfigOption("VSICRYPT_IV", None)
     if fp is not None:
         gdal.VSIFCloseL(fp)
 
@@ -442,11 +440,10 @@ def test_vsicrypt_3():
     # Test key generation
 
     # Do NOT set VSICRYPT_CRYPTO_RANDOM=NO in production. This is just to speed up tests !
-    gdal.SetConfigOption("VSICRYPT_CRYPTO_RANDOM", "NO")
-    fp = gdal.VSIFOpenL(
-        "/vsicrypt/key=GENERATE_IT,add_key_check=yes,file=/vsimem/file.bin", "wb"
-    )
-    gdal.SetConfigOption("VSICRYPT_CRYPTO_RANDOM", None)
+    with gdal.config_option("VSICRYPT_CRYPTO_RANDOM", "NO"):
+        fp = gdal.VSIFOpenL(
+            "/vsicrypt/key=GENERATE_IT,add_key_check=yes,file=/vsimem/file.bin", "wb"
+        )
 
     # Get the generated random key
     key_b64 = gdal.GetConfigOption("VSICRYPT_KEY_B64")

--- a/autotest/gcore/vsicurl_streaming.py
+++ b/autotest/gcore/vsicurl_streaming.py
@@ -43,12 +43,12 @@ pytestmark = pytest.mark.require_curl()
 
 def test_vsicurl_streaming_1():
 
-    gdal.SetConfigOption("GDAL_HTTP_CONNECTTIMEOUT", "5")
-    fp = gdal.VSIFOpenL(
-        "/vsicurl_streaming/http://download.osgeo.org/gdal/data/usgsdem/cded/114p01_0100_deme.dem",
-        "rb",
-    )
-    gdal.SetConfigOption("GDAL_HTTP_CONNECTTIMEOUT", None)
+    with gdal.config_option("GDAL_HTTP_CONNECTTIMEOUT", "5"):
+        fp = gdal.VSIFOpenL(
+            "/vsicurl_streaming/http://download.osgeo.org/gdal/data/usgsdem/cded/114p01_0100_deme.dem",
+            "rb",
+        )
+
     if fp is None:
         if (
             gdaltest.gdalurlopen(

--- a/autotest/gcore/vsiwebhdfs.py
+++ b/autotest/gcore/vsiwebhdfs.py
@@ -40,23 +40,23 @@ from osgeo import gdal
 pytestmark = pytest.mark.require_curl()
 
 
-def open_for_read(uri):
-    """
-    Opens a test file for reading.
-    """
-    return gdal.VSIFOpenExL(uri, "rb", 1)
+@pytest.fixture(scope="module", autouse=True)
+def startup_and_cleanup():
+
+    options = {"WEBHDFS_USERNAME": None, "WEBHDFS_DELEGATION": None}
+
+    with gdal.config_options(options):
+        yield
 
 
 ###############################################################################
 
 
-def test_vsiwebhdfs_init():
-
-    gdaltest.webhdfs_vars = {}
-    for var in ("WEBHDFS_USERNAME", "WEBHDFS_DELEGATION"):
-        gdaltest.webhdfs_vars[var] = gdal.GetConfigOption(var)
-        if gdaltest.webhdfs_vars[var] is not None:
-            gdal.SetConfigOption(var, "")
+def open_for_read(uri):
+    """
+    Opens a test file for reading.
+    """
+    return gdal.VSIFOpenExL(uri, "rb", 1)
 
 
 ###############################################################################
@@ -666,12 +666,3 @@ def test_vsiwebhdfs_extra_1():
     gdal.VSIFCloseL(f)
 
     assert len(ret) == 1
-
-
-###############################################################################
-
-
-def test_vsiwebhdfs_cleanup():
-
-    for var in gdaltest.webhdfs_vars:
-        gdal.SetConfigOption(var, gdaltest.webhdfs_vars[var])

--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -412,9 +412,8 @@ def test_vsizip_9():
 
 def test_vsizip_10():
 
-    gdal.SetConfigOption("CPL_ZIP_ENCODING", "CP866")
-    content = gdal.ReadDir("/vsizip/data/cp866.zip")
-    gdal.SetConfigOption("CPL_ZIP_ENCODING", None)
+    with gdal.config_option("CPL_ZIP_ENCODING", "CP866"):
+        content = gdal.ReadDir("/vsizip/data/cp866.zip")
     ok = 0
     try:
         local_vars = {"content": content, "ok": ok}

--- a/autotest/gdrivers/aaigrid.py
+++ b/autotest/gdrivers/aaigrid.py
@@ -257,9 +257,8 @@ def test_aaigrid_10():
             pass
 
         if i == 0:
-            gdal.SetConfigOption("AAIGRID_DATATYPE", "Float64")
-            ds = gdal.Open("data/aaigrid/float64.asc")
-            gdal.SetConfigOption("AAIGRID_DATATYPE", None)
+            with gdal.config_option("AAIGRID_DATATYPE", "Float64"):
+                ds = gdal.Open("data/aaigrid/float64.asc")
         else:
             ds = gdal.OpenEx(
                 "data/aaigrid/float64.asc", open_options=["DATATYPE=Float64"]

--- a/autotest/gdrivers/adrg.py
+++ b/autotest/gdrivers/adrg.py
@@ -104,10 +104,9 @@ def test_adrg_2subdatasets():
     drv = gdal.GetDriverByName("ADRG")
     srcds = gdal.Open("data/adrg/SMALL_ADRG/ABCDEF01.GEN")
 
-    gdal.SetConfigOption("ADRG_SIMULATE_MULTI_IMG", "ON")
-    dstds = drv.CreateCopy("tmp/XXXXXX01.GEN", srcds)
-    del dstds
-    gdal.SetConfigOption("ADRG_SIMULATE_MULTI_IMG", "OFF")
+    with gdal.config_option("ADRG_SIMULATE_MULTI_IMG", "ON"):
+        dstds = drv.CreateCopy("tmp/XXXXXX01.GEN", srcds)
+        del dstds
 
     shutil.copy("tmp/XXXXXX01.IMG", "tmp/XXXXXX02.IMG")
 

--- a/autotest/gdrivers/daas.py
+++ b/autotest/gdrivers/daas.py
@@ -56,16 +56,12 @@ def module_disable_exceptions():
 def startup_and_cleanup():
 
     # Unset environment variables that influence the driver behavior
-    daas_vars = {}
-    for var in (
-        "GDAL_DAAS_API_KEY",
-        "GDAL_DAAS_CLIENT_ID",
-        "GDAL_DAAS_AUTH_URL",
-        "GDAL_DAAS_ACCESS_TOKEN",
-    ):
-        daas_vars[var] = gdal.GetConfigOption(var)
-        if daas_vars[var] is not None:
-            gdal.SetConfigOption(var, "")
+    options = {
+        "GDAL_DAAS_API_KEY": None,
+        "GDAL_DAAS_CLIENT_ID": None,
+        "GDAL_DAAS_AUTH_URL": None,
+        "GDAL_DAAS_ACCESS_TOKEN": None,
+    }
 
     (gdaltest.webserver_process, gdaltest.webserver_port) = webserver.launch(
         handler=webserver.DispatcherHttpHandler
@@ -73,15 +69,13 @@ def startup_and_cleanup():
     if gdaltest.webserver_port == 0:
         pytest.skip()
 
-    yield
+    with gdal.config_options(options):
+        yield
 
     if gdaltest.webserver_port != 0:
         webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)
 
     gdal.RmdirRecursive("/vsimem/cache_dir")
-
-    for var in daas_vars:
-        gdal.SetConfigOption(var, daas_vars[var])
 
 
 ###############################################################################

--- a/autotest/gdrivers/dted.py
+++ b/autotest/gdrivers/dted.py
@@ -331,16 +331,15 @@ def test_dted_14():
 
 def test_dted_15():
 
-    gdal.SetConfigOption("GDAL_DTED_SINGLE_BLOCK", "YES")
-    tst = gdaltest.GDALTest("dted", "n43.dt0", 1, 49187)
-    ret = tst.testOpen()
-    gdal.SetConfigOption("GDAL_DTED_SINGLE_BLOCK", None)
+    with gdal.config_option("GDAL_DTED_SINGLE_BLOCK", "YES"):
+        tst = gdaltest.GDALTest("dted", "n43.dt0", 1, 49187)
+        ret = tst.testOpen()
     return ret
 
 
 def test_dted_16():
 
-    with gdaltest.config_option("DTED_APPLY_PIXEL_IS_POINT", "TRUE"):
+    with gdal.config_option("DTED_APPLY_PIXEL_IS_POINT", "TRUE"):
         ds = gdal.Open("data/n43.dt0")
         assert ds is not None
 

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -113,9 +113,8 @@ def startup_and_cleanup():
         gdaltest.ecw_drv.minor_version = 3
 
     # we set ECW to not resolve projection and datum strings to get 3.x behavior.
-    gdal.SetConfigOption("ECW_DO_NOT_RESOLVE_DATUM_PROJECTION", "YES")
-
-    yield
+    with gdal.config_option("ECW_DO_NOT_RESOLVE_DATUM_PROJECTION", "YES"):
+        yield
 
     gdaltest.reregister_all_jpeg2000_drivers()
 
@@ -2341,11 +2340,9 @@ def test_ecw_48():
 
 def test_ecw_49():
 
-    ecw_upward_old = gdal.GetConfigOption("ECW_ALWAYS_UPWARD", "TRUE")
-    gdal.SetConfigOption("ECW_ALWAYS_UPWARD", "FALSE")
-    ds = gdal.Open("data/ecw/spif83_downward.ecw")
-    gt = ds.GetGeoTransform()
-    gdal.SetConfigOption("ECW_ALWAYS_UPWARD", ecw_upward_old)
+    with gdal.config_option("ECW_ALWAYS_UPWARD", "FALSE"):
+        ds = gdal.Open("data/ecw/spif83_downward.ecw")
+        gt = ds.GetGeoTransform()
 
     # expect Y resolution positive
     expected_gt = (

--- a/autotest/gdrivers/hfa.py
+++ b/autotest/gdrivers/hfa.py
@@ -983,22 +983,18 @@ def test_hfa_write_bit2grayscale():
     shutil.copyfile("data/hfa/small1bit.img", "tmp/small1bit.img")
     shutil.copyfile("data/hfa/small1bit.rrd", "tmp/small1bit.rrd")
 
-    gdal.SetConfigOption("USE_RRD", "YES")
-    gdal.SetConfigOption("HFA_USE_RRD", "YES")
+    with gdal.config_options({"USE_RRD": "YES", "HFA_USE_RRD": "YES"}):
 
-    ds = gdal.Open("tmp/small1bit.img", gdal.GA_Update)
-    ds.BuildOverviews(resampling="average_bit2grayscale", overviewlist=[2])
+        ds = gdal.Open("tmp/small1bit.img", gdal.GA_Update)
+        ds.BuildOverviews(resampling="average_bit2grayscale", overviewlist=[2])
 
-    ov = ds.GetRasterBand(1).GetOverview(1)
+        ov = ds.GetRasterBand(1).GetOverview(1)
 
-    assert ov.Checksum() == 57325, "wrong checksum for greyscale overview."
+        assert ov.Checksum() == 57325, "wrong checksum for greyscale overview."
 
-    ds = None
+        ds = None
 
-    gdal.GetDriverByName("HFA").Delete("tmp/small1bit.img")
-
-    gdal.SetConfigOption("USE_RRD", "NO")
-    gdal.SetConfigOption("HFA_USE_RRD", "NO")
+        gdal.GetDriverByName("HFA").Delete("tmp/small1bit.img")
 
     # as an aside, confirm the .rrd file was deleted.
     assert not os.path.exists("tmp/small1bit.rrd")

--- a/autotest/gdrivers/isis.py
+++ b/autotest/gdrivers/isis.py
@@ -1668,13 +1668,12 @@ def test_isis_30():
 
 def test_isis_31():
 
-    gdal.SetConfigOption("GDAL_FORCE_CACHING", "YES")
-    ds = gdal.GetDriverByName("ISIS3").Create(
-        "/vsimem/test.lbl", 1, 1, options=["DATA_LOCATION=GEOTIFF"]
-    )
-    ds.WriteRaster(0, 0, 1, 1, struct.pack("B" * 1, 1))
-    ds = None
-    gdal.SetConfigOption("GDAL_FORCE_CACHING", None)
+    with gdal.config_option("GDAL_FORCE_CACHING", "YES"):
+        ds = gdal.GetDriverByName("ISIS3").Create(
+            "/vsimem/test.lbl", 1, 1, options=["DATA_LOCATION=GEOTIFF"]
+        )
+        ds.WriteRaster(0, 0, 1, 1, struct.pack("B" * 1, 1))
+        ds = None
 
     ds = gdal.Open("/vsimem/test.lbl")
     cs = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/jp2kak.py
+++ b/autotest/gdrivers/jp2kak.py
@@ -323,35 +323,34 @@ def test_jp2kak_16():
 
 def test_jp2kak_17():
 
-    gdal.SetConfigOption("GDAL_JP2K_ALT_OFFSETVECTOR_ORDER", "YES")
+    with gdal.config_option("GDAL_JP2K_ALT_OFFSETVECTOR_ORDER", "YES"):
 
-    ds = gdal.Open("data/jpeg2000/gmljp2_dtedsm_epsg_4326_axes_alt_offsetVector.jp2")
+        ds = gdal.Open(
+            "data/jpeg2000/gmljp2_dtedsm_epsg_4326_axes_alt_offsetVector.jp2"
+        )
 
-    gt = ds.GetGeoTransform()
-    gte = (
-        42.999583333333369,
-        0.008271349862259,
-        0,
-        34.000416666666631,
-        0,
-        -0.008271349862259,
-    )
+        gt = ds.GetGeoTransform()
+        gte = (
+            42.999583333333369,
+            0.008271349862259,
+            0,
+            34.000416666666631,
+            0,
+            -0.008271349862259,
+        )
 
-    if (
-        gt[0] != pytest.approx(gte[0], abs=0.0000001)
-        or gt[3] != pytest.approx(gte[3], abs=0.000001)
-        or gt[1] != pytest.approx(gte[1], abs=0.000000000005)
-        or gt[2] != pytest.approx(gte[2], abs=0.000000000005)
-        or gt[4] != pytest.approx(gte[4], abs=0.000000000005)
-        or gt[5] != pytest.approx(gte[5], abs=0.000000000005)
-    ):
-        print("got: ", gt)
-        gdal.SetConfigOption("GDAL_JP2K_ALT_OFFSETVECTOR_ORDER", "NO")
-        pytest.fail("did not get expected geotransform")
+        if (
+            gt[0] != pytest.approx(gte[0], abs=0.0000001)
+            or gt[3] != pytest.approx(gte[3], abs=0.000001)
+            or gt[1] != pytest.approx(gte[1], abs=0.000000000005)
+            or gt[2] != pytest.approx(gte[2], abs=0.000000000005)
+            or gt[4] != pytest.approx(gte[4], abs=0.000000000005)
+            or gt[5] != pytest.approx(gte[5], abs=0.000000000005)
+        ):
+            print("got: ", gt)
+            pytest.fail("did not get expected geotransform")
 
-    ds = None
-
-    gdal.SetConfigOption("GDAL_JP2K_ALT_OFFSETVECTOR_ORDER", "NO")
+        ds = None
 
 
 ###############################################################################

--- a/autotest/gdrivers/jp2metadata.py
+++ b/autotest/gdrivers/jp2metadata.py
@@ -210,8 +210,6 @@ def test_jp2metadata_3():
 
     ds = None
 
-    gdal.SetConfigOption("GDAL_IGNORE_AXIS_ORIENTATION", "NO")
-
 
 ###############################################################################
 # Test reading a file with axis orientation set properly for an alternate

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -482,13 +482,11 @@ def test_jp2openjpeg_16():
 
     assert gt == gt_expected, "did not get expected geotransform"
 
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", "TRUE")
+    with gdal.config_option("GTIFF_POINT_GEO_IGNORE", "TRUE"):
 
-    ds = gdal.Open("data/jpeg2000/byte_point.jp2")
-    gt = ds.GetGeoTransform()
-    ds = None
-
-    gdal.SetConfigOption("GTIFF_POINT_GEO_IGNORE", None)
+        ds = gdal.Open("data/jpeg2000/byte_point.jp2")
+        gt = ds.GetGeoTransform()
+        ds = None
 
     gt_expected = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
@@ -1664,7 +1662,6 @@ def test_jp2openjpeg_39():
     # No metadata
     src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
     src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
-    gdal.SetConfigOption("GMLJP2OVERRIDE", "/vsimem/override.gml")
     # This GML has srsName only on RectifiedGrid (taken from D.2.2.2 from DGIWG_Profile_of_JPEG2000_for_Georeferenced_Imagery.pdf)
     gdal.FileFromMemBuffer(
         "/vsimem/override.gml",
@@ -1715,10 +1712,10 @@ def test_jp2openjpeg_39():
   </gml:featureMember>
 </gml:FeatureCollection>""",
     )
-    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
-        "/vsimem/jp2openjpeg_39.jp2", src_ds, options=["GeoJP2=NO"]
-    )
-    gdal.SetConfigOption("GMLJP2OVERRIDE", None)
+    with gdal.config_option("GMLJP2OVERRIDE", "/vsimem/override.gml"):
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_39.jp2", src_ds, options=["GeoJP2=NO"]
+        )
     gdal.Unlink("/vsimem/override.gml")
     del out_ds
     ds = gdal.Open("/vsimem/jp2openjpeg_39.jp2")
@@ -1736,7 +1733,6 @@ def test_jp2openjpeg_40():
     # No metadata
     src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
     src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
-    gdal.SetConfigOption("GMLJP2OVERRIDE", "/vsimem/override.gml")
 
     gdal.FileFromMemBuffer(
         "/vsimem/override.gml",
@@ -1790,10 +1786,10 @@ def test_jp2openjpeg_40():
     </gmljp2:featureMember>
 </gmljp2:GMLJP2CoverageCollection>""",
     )
-    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
-        "/vsimem/jp2openjpeg_40.jp2", src_ds, options=["GeoJP2=NO"]
-    )
-    gdal.SetConfigOption("GMLJP2OVERRIDE", None)
+    with gdal.config_option("GMLJP2OVERRIDE", "/vsimem/override.gml"):
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_40.jp2", src_ds, options=["GeoJP2=NO"]
+        )
     gdal.Unlink("/vsimem/override.gml")
     del out_ds
     ds = gdal.Open("/vsimem/jp2openjpeg_40.jp2")
@@ -3295,26 +3291,25 @@ def test_jp2openjpeg_49():
         expected_srs,
         expected_gt,
     ) in tests:
-        gdal.SetConfigOption("GDAL_GEOREF_SOURCES", config_option_value)
-        gdal.FileFromMemBuffer(
-            "/vsimem/byte_nogeoref.jp2",
-            open("data/jpeg2000/byte_nogeoref.jp2", "rb").read(),
-        )
-        if copy_pam:
+        with gdal.config_option("GDAL_GEOREF_SOURCES", config_option_value):
             gdal.FileFromMemBuffer(
-                "/vsimem/byte_nogeoref.jp2.aux.xml",
-                open("data/jpeg2000/byte_nogeoref.jp2.aux.xml", "rb").read(),
+                "/vsimem/byte_nogeoref.jp2",
+                open("data/jpeg2000/byte_nogeoref.jp2", "rb").read(),
             )
-        if copy_worldfile:
-            gdal.FileFromMemBuffer(
-                "/vsimem/byte_nogeoref.j2w",
-                open("data/jpeg2000/byte_nogeoref.j2w", "rb").read(),
-            )
-        ds = gdal.Open("/vsimem/byte_nogeoref.jp2")
-        gt = ds.GetGeoTransform()
-        srs_wkt = ds.GetProjectionRef()
-        ds = None
-        gdal.SetConfigOption("GDAL_GEOREF_SOURCES", None)
+            if copy_pam:
+                gdal.FileFromMemBuffer(
+                    "/vsimem/byte_nogeoref.jp2.aux.xml",
+                    open("data/jpeg2000/byte_nogeoref.jp2.aux.xml", "rb").read(),
+                )
+            if copy_worldfile:
+                gdal.FileFromMemBuffer(
+                    "/vsimem/byte_nogeoref.j2w",
+                    open("data/jpeg2000/byte_nogeoref.j2w", "rb").read(),
+                )
+            ds = gdal.Open("/vsimem/byte_nogeoref.jp2")
+            gt = ds.GetGeoTransform()
+            srs_wkt = ds.GetProjectionRef()
+            ds = None
         gdal.Unlink("/vsimem/byte_nogeoref.jp2")
         gdal.Unlink("/vsimem/byte_nogeoref.jp2.aux.xml")
         gdal.Unlink("/vsimem/byte_nogeoref.j2w")

--- a/autotest/gdrivers/l1b.py
+++ b/autotest/gdrivers/l1b.py
@@ -174,11 +174,10 @@ def test_l1b_metadata_before_noaa_15():
     except OSError:
         pytest.skip()
 
-    gdal.SetConfigOption("L1B_FETCH_METADATA", "YES")
-    gdal.SetConfigOption("L1B_METADATA_DIRECTORY", "tmp")
-    ds = gdal.Open("tmp/cache/n12gac10bit.l1b")
-    gdal.SetConfigOption("L1B_FETCH_METADATA", None)
-    gdal.SetConfigOption("L1B_METADATA_DIRECTORY", None)
+    with gdal.config_options(
+        {"L1B_FETCH_METADATA": "YES", "L1B_METADATA_DIRECTORY": "tmp"}
+    ):
+        ds = gdal.Open("tmp/cache/n12gac10bit.l1b")
     del ds
 
     f = open("tmp/n12gac10bit.l1b_metadata.csv", "rb")
@@ -261,11 +260,10 @@ def test_l1b_metadata_after_noaa_15():
     except OSError:
         pytest.skip()
 
-    gdal.SetConfigOption("L1B_FETCH_METADATA", "YES")
-    gdal.SetConfigOption("L1B_METADATA_DIRECTORY", "tmp")
-    ds = gdal.Open("tmp/cache/n16gac10bit.l1b")
-    gdal.SetConfigOption("L1B_FETCH_METADATA", None)
-    gdal.SetConfigOption("L1B_METADATA_DIRECTORY", None)
+    with gdal.config_options(
+        {"L1B_FETCH_METADATA": "YES", "L1B_METADATA_DIRECTORY": "tmp"}
+    ):
+        ds = gdal.Open("tmp/cache/n16gac10bit.l1b")
     del ds
 
     f = open("tmp/n16gac10bit.l1b_metadata.csv", "rb")

--- a/autotest/gdrivers/mbtiles.py
+++ b/autotest/gdrivers/mbtiles.py
@@ -514,19 +514,14 @@ def test_mbtiles_9():
 @pytest.mark.require_driver("PNG")
 def test_mbtiles_10():
 
-    old_val_GPKG_FORCE_TEMPDB_COMPACTION = gdal.GetConfigOption(
-        "GPKG_FORCE_TEMPDB_COMPACTION"
-    )
-    gdal.SetConfigOption("GPKG_FORCE_TEMPDB_COMPACTION", "YES")
-    with gdaltest.SetCacheMax(0):
+    with gdal.config_option(
+        "GPKG_FORCE_TEMPDB_COMPACTION", "YES"
+    ), gdaltest.SetCacheMax(0):
         gdal.Translate(
             "/vsimem/mbtiles_10.mbtiles",
             "../gcore/data/byte.tif",
             options="-of MBTILES -outsize 512 512",
         )
-    gdal.SetConfigOption(
-        "GPKG_FORCE_TEMPDB_COMPACTION", old_val_GPKG_FORCE_TEMPDB_COMPACTION
-    )
 
     ds = gdal.Open("/vsimem/mbtiles_10.mbtiles")
     cs = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1086,17 +1086,13 @@ def test_netcdf_27():
 
     # test default config
     test = gdaltest.GDALTest("NETCDF", "netcdf/int16-nogeo.nc", 1, 4672)
-    config_bak = gdal.GetConfigOption("GDAL_NETCDF_BOTTOMUP")
-    gdal.SetConfigOption("GDAL_NETCDF_BOTTOMUP", None)
-    test.testOpen()
-    gdal.SetConfigOption("GDAL_NETCDF_BOTTOMUP", config_bak)
+    with gdal.config_option("GDAL_NETCDF_BOTTOMUP", None):
+        test.testOpen()
 
     # test GDAL_NETCDF_BOTTOMUP=NO
     test = gdaltest.GDALTest("NETCDF", "netcdf/int16-nogeo.nc", 1, 4855)
-    config_bak = gdal.GetConfigOption("GDAL_NETCDF_BOTTOMUP")
-    gdal.SetConfigOption("GDAL_NETCDF_BOTTOMUP", "NO")
-    test.testOpen()
-    gdal.SetConfigOption("GDAL_NETCDF_BOTTOMUP", config_bak)
+    with gdal.config_option("GDAL_NETCDF_BOTTOMUP", "NO"):
+        test.testOpen()
 
 
 ###############################################################################
@@ -1282,8 +1278,6 @@ def test_netcdf_32():
 
     ifile = "data/byte.tif"
     ofile = "tmp/netcdf_32.nc"
-
-    # gdal.SetConfigOption('CPL_DEBUG', 'ON')
 
     # test basic read/write
     netcdf_test_copy(ifile, 1, 4672, ofile, ["FORMAT=NC4"])
@@ -2980,18 +2974,17 @@ def test_netcdf_67():
         pytest.skip()
 
     # disable bottom-up mode to use the real file's blocks size
-    gdal.SetConfigOption("GDAL_NETCDF_BOTTOMUP", "NO")
-    # for the moment the next test using check_stat does not work, seems like
-    # the last pixel (9) of the image is not handled by stats...
-    #    tst = gdaltest.GDALTest( 'NetCDF', 'partial_block_ticket5950.nc', 1, 45 )
-    #    result = tst.testOpen( check_stat=(1, 9, 5, 2.582) )
-    # so for the moment compare the full image
-    ds = gdal.Open("data/netcdf/partial_block_ticket5950.nc", gdal.GA_ReadOnly)
-    ref = numpy.arange(1, 10).reshape((3, 3))
-    if not numpy.array_equal(ds.GetRasterBand(1).ReadAsArray(), ref):
-        pytest.fail()
-    ds = None
-    gdal.SetConfigOption("GDAL_NETCDF_BOTTOMUP", None)
+    with gdal.config_option("GDAL_NETCDF_BOTTOMUP", "NO"):
+        # for the moment the next test using check_stat does not work, seems like
+        # the last pixel (9) of the image is not handled by stats...
+        #    tst = gdaltest.GDALTest( 'NetCDF', 'partial_block_ticket5950.nc', 1, 45 )
+        #    result = tst.testOpen( check_stat=(1, 9, 5, 2.582) )
+        # so for the moment compare the full image
+        ds = gdal.Open("data/netcdf/partial_block_ticket5950.nc", gdal.GA_ReadOnly)
+        ref = numpy.arange(1, 10).reshape((3, 3))
+        if not numpy.array_equal(ds.GetRasterBand(1).ReadAsArray(), ref):
+            pytest.fail()
+        ds = None
 
 
 ###############################################################################

--- a/autotest/gdrivers/ngw.py
+++ b/autotest/gdrivers/ngw.py
@@ -271,14 +271,12 @@ def test_ngw_7():
         pytest.skip()
 
     gdal.ErrorReset()
-    gdal.SetConfigOption("CPL_ACCUM_ERROR_MSG", "ON")
-    with gdaltest.error_handler():
+    with gdal.config_option("CPL_ACCUM_ERROR_MSG", "ON"), gdaltest.error_handler():
 
         ovr_band = gdaltest.ngw_ds.GetRasterBand(1).GetOverview(21)
         assert ovr_band is not None
         ovr_band.Checksum()
 
-    gdal.SetConfigOption("CPL_ACCUM_ERROR_MSG", "OFF")
     msg = gdal.GetLastErrorMsg()
 
     assert gdal.GetLastErrorType() != gdal.CE_Failure, msg

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -6251,12 +6251,10 @@ def test_nitf_online_24():
     except OSError:
         pytest.skip()
 
-    oldval = gdal.GetConfigOption("NITF_OPEN_UNDERLYING_DS")
-    gdal.SetConfigOption("NITF_OPEN_UNDERLYING_DS", "NO")
-    ds = gdal.Open(
-        "/vsizip/tmp/cache/ECRG_Sample.zip/ECRG_Sample/EPF/clfc/2/000000009s0013.lf2"
-    )
-    gdal.SetConfigOption("NITF_OPEN_UNDERLYING_DS", oldval)
+    with gdal.config_option("NITF_OPEN_UNDERLYING_DS", "NO"):
+        ds = gdal.Open(
+            "/vsizip/tmp/cache/ECRG_Sample.zip/ECRG_Sample/EPF/clfc/2/000000009s0013.lf2"
+        )
     assert ds is not None
     xml_tre = ds.GetMetadata("xml:TRE")[0]
     ds = None

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -285,9 +285,8 @@ def test_pdf_online_2(poppler_or_pdfium):
 
 
 def test_pdf_1(poppler_or_pdfium):
-    gdal.SetConfigOption("GDAL_PDF_DPI", "200")
-    ds = gdal.Open("data/pdf/adobe_style_geospatial.pdf")
-    gdal.SetConfigOption("GDAL_PDF_DPI", None)
+    with gdal.config_option("GDAL_PDF_DPI", "200"):
+        ds = gdal.Open("data/pdf/adobe_style_geospatial.pdf")
     assert ds is not None
 
     gt = ds.GetGeoTransform()
@@ -376,15 +375,16 @@ def test_pdf_iso32000_dpi_300(poppler_or_pdfium):
 
 
 def test_pdf_ogcbp(poppler_or_pdfium_or_podofo):
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", "FALSE")
-    tst = gdaltest.GDALTest("PDF", "byte.tif", 1, None, options=["GEO_ENCODING=OGC_BP"])
-    ret = tst.testCreateCopy(
-        check_minmax=0,
-        check_gt=1,
-        check_srs=True,
-        check_checksum_not_null=pdf_checksum_available(),
-    )
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", None)
+    with gdal.config_option("GDAL_PDF_OGC_BP_WRITE_WKT", "FALSE"):
+        tst = gdaltest.GDALTest(
+            "PDF", "byte.tif", 1, None, options=["GEO_ENCODING=OGC_BP"]
+        )
+        ret = tst.testCreateCopy(
+            check_minmax=0,
+            check_gt=1,
+            check_srs=True,
+            check_checksum_not_null=pdf_checksum_available(),
+        )
 
     return ret
 
@@ -394,17 +394,16 @@ def test_pdf_ogcbp(poppler_or_pdfium_or_podofo):
 
 
 def test_pdf_ogcbp_dpi_300(poppler_or_pdfium):
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", "FALSE")
-    tst = gdaltest.GDALTest(
-        "PDF", "byte.tif", 1, None, options=["GEO_ENCODING=OGC_BP", "DPI=300"]
-    )
-    ret = tst.testCreateCopy(
-        check_minmax=0,
-        check_gt=1,
-        check_srs=True,
-        check_checksum_not_null=pdf_checksum_available(),
-    )
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", None)
+    with gdal.config_option("GDAL_PDF_OGC_BP_WRITE_WKT", "FALSE"):
+        tst = gdaltest.GDALTest(
+            "PDF", "byte.tif", 1, None, options=["GEO_ENCODING=OGC_BP", "DPI=300"]
+        )
+        ret = tst.testCreateCopy(
+            check_minmax=0,
+            check_gt=1,
+            check_srs=True,
+            check_checksum_not_null=pdf_checksum_available(),
+        )
 
     return ret
 
@@ -431,11 +430,10 @@ def test_pdf_ogcbp_lcc(poppler_or_pdfium):
     src_ds.SetProjection(wkt)
     src_ds.SetGeoTransform([500000, 1, 0, 1000000, 0, -1])
 
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", "FALSE")
-    out_ds = gdaltest.pdf_drv.CreateCopy("tmp/pdf_ogcbp_lcc.pdf", src_ds)
-    out_wkt = out_ds.GetProjectionRef()
-    out_ds = None
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", None)
+    with gdal.config_option("GDAL_PDF_OGC_BP_WRITE_WKT", "FALSE"):
+        out_ds = gdaltest.pdf_drv.CreateCopy("tmp/pdf_ogcbp_lcc.pdf", src_ds)
+        out_wkt = out_ds.GetProjectionRef()
+        out_ds = None
 
     src_ds = None
 
@@ -552,11 +550,10 @@ def pdf_rgba_default_compression(options_param=None):
     out_ds = None
 
     # gdal.SetConfigOption('GDAL_PDF_BANDS', '4')
-    gdal.SetConfigOption("PDF_DUMP_OBJECT", "tmp/rgba.pdf.txt")
-    gdal.SetConfigOption("PDF_DUMP_PARENT", "YES")
-    out_ds = gdal.Open("tmp/rgba.pdf")
-    gdal.SetConfigOption("PDF_DUMP_OBJECT", None)
-    gdal.SetConfigOption("PDF_DUMP_PARENT", None)
+    with gdal.config_options(
+        {"PDF_DUMP_OBJECT": "tmp/rgba.pdf.txt", "PDF_DUMP_PARENT": "YES"}
+    ):
+        out_ds = gdal.Open("tmp/rgba.pdf")
     content = open("tmp/rgba.pdf.txt", "rt").read()
     os.unlink("tmp/rgba.pdf.txt")
     cs1 = out_ds.GetRasterBand(1).Checksum()
@@ -1043,9 +1040,8 @@ def test_pdf_update_gcps_iso32000(poppler_or_pdfium):
 
 
 def test_pdf_update_gcps_ogc_bp(poppler_or_pdfium):
-    gdal.SetConfigOption("GDAL_PDF_GEO_ENCODING", "OGC_BP")
-    _pdf_update_gcps(poppler_or_pdfium)
-    gdal.SetConfigOption("GDAL_PDF_GEO_ENCODING", None)
+    with gdal.config_option("GDAL_PDF_GEO_ENCODING", "OGC_BP"):
+        _pdf_update_gcps(poppler_or_pdfium)
 
 
 ###############################################################################
@@ -1240,24 +1236,23 @@ def _pdf_set_neatline(pdf_backend, geo_encoding, dpi=300):
     ds = None
 
     # Check
-    gdal.SetConfigOption("GDAL_PDF_GEO_ENCODING", geo_encoding)
-    ds = gdal.Open(out_filename)
-    got_gt = ds.GetGeoTransform()
-    got_neatline = ds.GetMetadataItem("NEATLINE")
+    with gdal.config_option("GDAL_PDF_GEO_ENCODING", geo_encoding):
+        ds = gdal.Open(out_filename)
+        got_gt = ds.GetGeoTransform()
+        got_neatline = ds.GetMetadataItem("NEATLINE")
 
-    if pdf_is_pdfium():
-        if geo_encoding == "ISO32000":
-            expected_gt = (
-                440722.36151923181,
-                59.93217744208814,
-                0.0,
-                3751318.7819266757,
-                0.0,
-                -59.941906300000845,
-            )
+        if pdf_is_pdfium():
+            if geo_encoding == "ISO32000":
+                expected_gt = (
+                    440722.36151923181,
+                    59.93217744208814,
+                    0.0,
+                    3751318.7819266757,
+                    0.0,
+                    -59.941906300000845,
+                )
 
-    ds = None
-    gdal.SetConfigOption("GDAL_PDF_GEO_ENCODING", None)
+        ds = None
 
     for i in range(6):
         assert not (
@@ -1324,12 +1319,13 @@ def test_pdf_check_identity_ogc_bp(poppler_or_pdfium):
     out_filename = "tmp/pdf_check_identity_ogc_bp.pdf"
 
     src_ds = gdal.Open("data/pdf/test_pdf.vrt")
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", "NO")
-    out_ds = gdaltest.pdf_drv.CreateCopy(
-        out_filename, src_ds, options=["GEO_ENCODING=OGC_BP", "STREAM_COMPRESS=NONE"]
-    )
-    del out_ds
-    gdal.SetConfigOption("GDAL_PDF_OGC_BP_WRITE_WKT", None)
+    with gdal.config_option("GDAL_PDF_OGC_BP_WRITE_WKT", "NO"):
+        out_ds = gdaltest.pdf_drv.CreateCopy(
+            out_filename,
+            src_ds,
+            options=["GEO_ENCODING=OGC_BP", "STREAM_COMPRESS=NONE"],
+        )
+        del out_ds
     src_ds = None
 
     f = open("data/pdf/test_ogc_bp.pdf", "rb")
@@ -1371,20 +1367,18 @@ def test_pdf_layers(poppler_or_pdfium):
         pytest.skip()
 
     # Turn a layer off
-    gdal.SetConfigOption("GDAL_PDF_LAYERS_OFF", "New_Data_Frame")
-    ds = gdal.Open("data/pdf/adobe_style_geospatial.pdf")
-    cs2 = ds.GetRasterBand(1).Checksum()
-    ds = None
-    gdal.SetConfigOption("GDAL_PDF_LAYERS_OFF", None)
+    with gdal.config_option("GDAL_PDF_LAYERS_OFF", "New_Data_Frame"):
+        ds = gdal.Open("data/pdf/adobe_style_geospatial.pdf")
+        cs2 = ds.GetRasterBand(1).Checksum()
+        ds = None
 
     assert cs2 != cs1, "did not get expected checksum"
 
     # Turn the other layer on
-    gdal.SetConfigOption("GDAL_PDF_LAYERS", "Layers")
-    ds = gdal.Open("data/pdf/adobe_style_geospatial.pdf")
-    cs3 = ds.GetRasterBand(1).Checksum()
-    ds = None
-    gdal.SetConfigOption("GDAL_PDF_LAYERS", None)
+    with gdal.config_option("GDAL_PDF_LAYERS", "Layers"):
+        ds = gdal.Open("data/pdf/adobe_style_geospatial.pdf")
+        cs3 = ds.GetRasterBand(1).Checksum()
+        ds = None
 
     # So the end result must be identical
     assert cs3 == cs2, "did not get expected checksum"
@@ -1758,14 +1752,13 @@ def test_pdf_jpeg_in_vrt_direct_copy(poppler_or_pdfium):
 @pytest.mark.parametrize("src_filename", ["data/byte.tif", "data/rgbsmall.tif"])
 def pdf_georef_on_image(src_filename, pdf_backend):
     src_ds = gdal.Open(src_filename)
-    gdal.SetConfigOption("GDAL_PDF_WRITE_GEOREF_ON_IMAGE", "YES")
-    out_ds = gdaltest.pdf_drv.CreateCopy(
-        "tmp/pdf_georef_on_image.pdf",
-        src_ds,
-        options=["MARGIN=10", "GEO_ENCODING=NONE"],
-    )
-    del out_ds
-    gdal.SetConfigOption("GDAL_PDF_WRITE_GEOREF_ON_IMAGE", None)
+    with gdal.config_option("GDAL_PDF_WRITE_GEOREF_ON_IMAGE", "YES"):
+        out_ds = gdaltest.pdf_drv.CreateCopy(
+            "tmp/pdf_georef_on_image.pdf",
+            src_ds,
+            options=["MARGIN=10", "GEO_ENCODING=NONE"],
+        )
+        del out_ds
     if pdf_checksum_available():
         src_cs = src_ds.GetRasterBand(1).Checksum()
     else:

--- a/autotest/gdrivers/pds.py
+++ b/autotest/gdrivers/pds.py
@@ -54,11 +54,10 @@ def test_pds_1():
         0,
         -926.115274429321289,
     )
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", "-0.5")
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", "-0.5")
-    tst.testOpen(check_prj=expected_prj, check_gt=expected_gt)
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", None)
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", None)
+    with gdal.config_options(
+        {"PDS_SampleProjOffset_Shift": "-0.5", "PDS_LineProjOffset_Shift": "-0.5"}
+    ):
+        tst.testOpen(check_prj=expected_prj, check_gt=expected_gt)
 
 
 ###############################################################################
@@ -86,11 +85,10 @@ def test_pds_2():
         0.0,
         -75.000002980232239,
     )
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", "-0.5")
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", "-0.5")
-    tst.testOpen(check_prj=expected_prj, check_gt=expected_gt)
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", None)
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", None)
+    with gdal.config_options(
+        {"PDS_SampleProjOffset_Shift": "-0.5", "PDS_LineProjOffset_Shift": "-0.5"}
+    ):
+        tst.testOpen(check_prj=expected_prj, check_gt=expected_gt)
 
     ds = gdal.Open("data/pds/fl73n003_truncated.img")
     assert ds.GetRasterBand(1).GetNoDataValue() == 7
@@ -136,11 +134,10 @@ def test_pds_4():
         0.0,
         -1.0113804322107001,
     )
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", "-0.5")
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", "-0.5")
-    tst.testOpen(check_gt=gt_expected)
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", None)
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", None)
+    with gdal.config_options(
+        {"PDS_SampleProjOffset_Shift": "-0.5", "PDS_LineProjOffset_Shift": "-0.5"}
+    ):
+        tst.testOpen(check_gt=gt_expected)
 
 
 ###############################################################################
@@ -167,11 +164,10 @@ def test_pds_6():
 
     gt_expected = (-6139197.5, 0.5, 0.0, 936003.0, 0.0, -0.5)
 
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", "-0.5")
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", "-0.5")
-    tst.testOpen(check_gt=gt_expected)
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", None)
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", None)
+    with gdal.config_options(
+        {"PDS_SampleProjOffset_Shift": "-0.5", "PDS_LineProjOffset_Shift": "-0.5"}
+    ):
+        tst.testOpen(check_gt=gt_expected)
 
     ds = gdal.Open("data/pds/ESP_013951_1955_RED.LBL")
 
@@ -213,11 +209,10 @@ def test_pds_7():
     PARAMETER["false_easting",0],
     PARAMETER["false_northing",0],UNIT["metre",1]]"""
 
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", "-0.5")
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", "-0.5")
-    tst.testOpen(check_prj=prj_expected, check_gt=gt_expected)
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", None)
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", None)
+    with gdal.config_options(
+        {"PDS_SampleProjOffset_Shift": "-0.5", "PDS_LineProjOffset_Shift": "-0.5"}
+    ):
+        tst.testOpen(check_prj=prj_expected, check_gt=gt_expected)
 
 
 ###############################################################################
@@ -228,29 +223,27 @@ def test_pds_7():
 def test_pds_8():
 
     # values for MAGELLAN FMAP data.
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", "1.5")
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", "1.5")
-    gdal.SetConfigOption("PDS_SampleProjOffset_Mult", "1.0")
-    gdal.SetConfigOption("PDS_LineProjOffset_Mult", "-1.0")
+    options = {
+        "PDS_SampleProjOffset_Shift": "1.5",
+        "PDS_LineProjOffset_Shift": "1.5",
+        "PDS_SampleProjOffset_Mult": "1.0",
+        "PDS_LineProjOffset_Mult": "-1.0",
+    }
 
-    tst = gdaltest.GDALTest("PDS", "pds/mc02_truncated.img", 1, 47151)
+    with gdal.config_options(options):
 
-    expected_gt = (
-        10670237.134337425,
-        926.11527442932129,
-        0.0,
-        -3854028.7145376205,
-        0.0,
-        -926.11527442932129,
-    )
+        tst = gdaltest.GDALTest("PDS", "pds/mc02_truncated.img", 1, 47151)
 
-    result = tst.testOpen(check_gt=expected_gt)
+        expected_gt = (
+            10670237.134337425,
+            926.11527442932129,
+            0.0,
+            -3854028.7145376205,
+            0.0,
+            -926.11527442932129,
+        )
 
-    # clear config settings
-    gdal.SetConfigOption("PDS_SampleProjOffset_Shift", None)
-    gdal.SetConfigOption("PDS_LineProjOffset_Shift", None)
-    gdal.SetConfigOption("PDS_SampleProjOffset_Mult", None)
-    gdal.SetConfigOption("PDS_LineProjOffset_Mult", None)
+        result = tst.testOpen(check_gt=expected_gt)
 
     return result
 

--- a/autotest/gdrivers/plmosaic.py
+++ b/autotest/gdrivers/plmosaic.py
@@ -53,10 +53,8 @@ def module_disable_exceptions():
 
 def test_plmosaic_2():
 
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/root")
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER)
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
 
@@ -66,10 +64,10 @@ def test_plmosaic_2():
 
 def test_plmosaic_3():
 
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/does_not_exist/")
+    with gdal.config_option(
+        "PL_URL", "/vsimem/does_not_exist/"
+    ), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
 
@@ -81,10 +79,8 @@ def test_plmosaic_4():
 
     gdal.FileFromMemBuffer("/vsimem/root", """{""")
 
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/root")
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
 
@@ -96,10 +92,8 @@ def test_plmosaic_5():
 
     gdal.FileFromMemBuffer("/vsimem/root", """null""")
 
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/root")
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
 
@@ -111,10 +105,8 @@ def test_plmosaic_6():
 
     gdal.FileFromMemBuffer("/vsimem/root", """{}""")
 
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/root")
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
 
@@ -131,9 +123,8 @@ def test_plmosaic_7():
 }""",
     )
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds is None
     ds = None
 
@@ -188,9 +179,8 @@ def test_plmosaic_8():
 }""",
     )
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds.GetMetadata("SUBDATASETS") == {
         "SUBDATASET_2_NAME": "PLMOSAIC:mosaic=another_mosaic_name",
         "SUBDATASET_2_DESC": "Mosaic another_mosaic_name",
@@ -206,14 +196,12 @@ def test_plmosaic_8():
 
 def test_plmosaic_9():
 
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/root")
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=does_not_exist"],
         )
-        gdal.SetConfigOption("PL_URL", None)
     assert (
         ds is None
         and gdal.GetLastErrorMsg().find("/vsimem/root/?name__is=does_not_exist") >= 0
@@ -227,14 +215,12 @@ def test_plmosaic_9():
 def test_plmosaic_9bis():
 
     gdal.FileFromMemBuffer("/vsimem/root/?name__is=my_mosaic", """{""")
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds is None and gdal.GetLastErrorMsg().find("JSON parsing error") >= 0
 
 
@@ -245,14 +231,12 @@ def test_plmosaic_9bis():
 def test_plmosaic_9ter():
 
     gdal.FileFromMemBuffer("/vsimem/root/?name__is=my_mosaic", """{}""")
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds is None and gdal.GetLastErrorMsg().find("No mosaic my_mosaic") >= 0
 
 
@@ -271,14 +255,12 @@ def test_plmosaic_10():
 }]
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds is None and gdal.GetLastErrorMsg().find("Missing required parameter") >= 0
 
 
@@ -303,14 +285,12 @@ def test_plmosaic_11():
 }]
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert (
         ds is None and gdal.GetLastErrorMsg().find("Unsupported coordinate_system") >= 0
     )
@@ -337,14 +317,12 @@ def test_plmosaic_12():
 }]
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds is None and gdal.GetLastErrorMsg().find("Unsupported data_type") >= 0
 
 
@@ -369,14 +347,12 @@ def test_plmosaic_13():
 }]
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds is None and gdal.GetLastErrorMsg().find("Unsupported resolution") >= 0
 
 
@@ -401,14 +377,12 @@ def test_plmosaic_14():
 }]
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds is None and gdal.GetLastErrorMsg().find("Unsupported quad_size") >= 0
 
 
@@ -439,14 +413,12 @@ def test_plmosaic_15():
 }]
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
             open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=tmp"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert gdal.GetLastErrorMsg().find("Invalid _links.tiles") >= 0
     assert ds.GetRasterBand(1).GetOverviewCount() == 0
     assert ds.GetRasterBand(1).GetOverview(0) is None
@@ -504,18 +476,15 @@ def test_plmosaic_16():
 }""",
     )
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:api_key=foo,unsupported_option=val", gdal.OF_RASTER)
-    gdal.SetConfigOption("PL_URL", None)
     assert (
         ds is None
         and gdal.GetLastErrorMsg().find("Unsupported option unsupported_option") >= 0
     )
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds.GetMetadata("SUBDATASETS") == {}
     assert ds.GetMetadata() == {
         "LAST_ACQUIRED": "last_date",
@@ -531,13 +500,12 @@ def test_plmosaic_16():
 
 def test_plmosaic_17():
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx(
-        "PLMosaic:",
-        gdal.OF_RASTER,
-        open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=tmp"],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx(
+            "PLMosaic:",
+            gdal.OF_RASTER,
+            open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=tmp"],
+        )
     assert ds is not None
     assert ds.GetMetadata() == {
         "LAST_ACQUIRED": "last_date",
@@ -652,12 +620,11 @@ def test_plmosaic_17():
     # Read again from file cache, but with TRUST_CACHE=YES
     # delete the full GeoTIFF before
     gdal.Unlink("/vsimem/root/my_mosaic_id/quads/0-2047/full")
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx(
-        "PLMosaic:API_KEY=foo,MOSAIC=my_mosaic,CACHE_PATH=tmp,TRUST_CACHE=YES",
-        gdal.OF_RASTER,
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx(
+            "PLMosaic:API_KEY=foo,MOSAIC=my_mosaic,CACHE_PATH=tmp,TRUST_CACHE=YES",
+            gdal.OF_RASTER,
+        )
 
     val = ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
     val = struct.unpack("B", val)[0]
@@ -665,13 +632,12 @@ def test_plmosaic_17():
     ds = None
 
     # Read again from file cache but the metatile has changed in between
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx(
-        "PLMosaic:",
-        gdal.OF_RASTER,
-        open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=tmp"],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx(
+            "PLMosaic:",
+            gdal.OF_RASTER,
+            open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=tmp"],
+        )
 
     tmp_ds = gdal.GetDriverByName("GTiff").Create(
         "/vsimem/root/my_mosaic_id/quads/0-2047/full",
@@ -697,13 +663,12 @@ def test_plmosaic_18():
 
     shutil.rmtree("tmp/plmosaic_cache")
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx(
-        "PLMosaic:",
-        gdal.OF_RASTER,
-        open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=tmp"],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx(
+            "PLMosaic:",
+            gdal.OF_RASTER,
+            open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=tmp"],
+        )
 
     ret = ds.GetRasterBand(1).GetMetadataItem("Pixel_0_0", "LocationInfo")
     assert (
@@ -747,13 +712,16 @@ def test_plmosaic_18():
 
 def test_plmosaic_19():
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx(
-        "PLMosaic:",
-        gdal.OF_RASTER,
-        open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH=/does_not_exist"],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx(
+            "PLMosaic:",
+            gdal.OF_RASTER,
+            open_options=[
+                "API_KEY=foo",
+                "MOSAIC=my_mosaic",
+                "CACHE_PATH=/does_not_exist",
+            ],
+        )
     with gdaltest.error_handler():
         val = ds.ReadRaster(0, 0, 1, 1)
     val = struct.unpack("B" * 4, val)
@@ -771,13 +739,12 @@ def test_plmosaic_19():
 
 def test_plmosaic_20():
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx(
-        "PLMosaic:",
-        gdal.OF_RASTER,
-        open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH="],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx(
+            "PLMosaic:",
+            gdal.OF_RASTER,
+            open_options=["API_KEY=foo", "MOSAIC=my_mosaic", "CACHE_PATH="],
+        )
     val = ds.ReadRaster(0, 0, 1, 1)
     val = struct.unpack("B" * 4, val)
     assert val == (254, 0, 0, 0)
@@ -794,18 +761,17 @@ def test_plmosaic_20():
 
 def test_plmosaic_21():
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx(
-        "PLMosaic:",
-        gdal.OF_RASTER,
-        open_options=[
-            "API_KEY=foo",
-            "MOSAIC=my_mosaic",
-            "CACHE_PATH=",
-            "USE_TILES=YES",
-        ],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx(
+            "PLMosaic:",
+            gdal.OF_RASTER,
+            open_options=[
+                "API_KEY=foo",
+                "MOSAIC=my_mosaic",
+                "CACHE_PATH=",
+                "USE_TILES=YES",
+            ],
+        )
 
     gdal.ErrorReset()
     with gdaltest.error_handler():
@@ -846,8 +812,7 @@ def test_plmosaic_21():
 
     # Should emit a warning
     gdal.ErrorReset()
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/root")
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -858,7 +823,6 @@ def test_plmosaic_21():
                 "USE_TILES=YES",
             ],
         )
-        gdal.SetConfigOption("PL_URL", None)
     assert (
         gdal.GetLastErrorMsg().find(
             "Cannot use tile API for full resolution data on non Byte mosaic"
@@ -887,8 +851,7 @@ def test_plmosaic_21():
 
     # Should emit a warning
     gdal.ErrorReset()
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/root")
+    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -899,7 +862,6 @@ def test_plmosaic_21():
                 "USE_TILES=YES",
             ],
         )
-        gdal.SetConfigOption("PL_URL", None)
     assert (
         gdal.GetLastErrorMsg().find(
             "Cannot find tile definition, so use_tiles will be ignored"
@@ -965,9 +927,8 @@ def test_plmosaic_with_bbox():
 }""",
     )
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/root")
-    ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/root"):
+        ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds.RasterXSize == 233472
     assert ds.RasterYSize == 286720
     got_gt = ds.GetGeoTransform()

--- a/autotest/gdrivers/rl2.py
+++ b/autotest/gdrivers/rl2.py
@@ -90,9 +90,8 @@ def test_rl2_2():
     expected_subds = []
     assert subds == expected_subds
 
-    gdal.SetConfigOption("RL2_SHOW_ALL_PYRAMID_LEVELS", "YES")
-    ds = gdal.Open("data/rasterlite2/byte.rl2")
-    gdal.SetConfigOption("RL2_SHOW_ALL_PYRAMID_LEVELS", None)
+    with gdal.config_option("RL2_SHOW_ALL_PYRAMID_LEVELS", "YES"):
+        ds = gdal.Open("data/rasterlite2/byte.rl2")
 
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     assert cs == 1087

--- a/autotest/gdrivers/rpftoc.py
+++ b/autotest/gdrivers/rpftoc.py
@@ -67,16 +67,15 @@ def test_rpftoc_1():
 
 
 def test_rpftoc_2():
-    gdal.SetConfigOption("RPFTOC_FORCE_RGBA", "YES")
-    tst = gdaltest.GDALTest(
-        "RPFTOC",
-        "NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:data/nitf/A.TOC",
-        1,
-        0,
-        filename_absolute=1,
-    )
-    res = tst.testOpen()
-    gdal.SetConfigOption("RPFTOC_FORCE_RGBA", "NO")
+    with gdal.config_option("RPFTOC_FORCE_RGBA", "YES"):
+        tst = gdaltest.GDALTest(
+            "RPFTOC",
+            "NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:data/nitf/A.TOC",
+            1,
+            0,
+            filename_absolute=1,
+        )
+        res = tst.testOpen()
     return res
 
 
@@ -106,29 +105,27 @@ def test_rpftoc_3():
 
 
 def test_rpftoc_4():
-    gdal.SetConfigOption("RPFTOC_FORCE_RGBA", "YES")
 
     shutil.copyfile("data/nitf/A.TOC", "tmp/A.TOC")
     shutil.copyfile("data/nitf/RPFTOC01.ON2", "tmp/RPFTOC01.ON2")
 
-    ds = gdal.Open("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:tmp/A.TOC")
-    err = ds.BuildOverviews(overviewlist=[2, 4])
+    with gdal.config_option("RPFTOC_FORCE_RGBA", "YES"):
+        ds = gdal.Open("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:tmp/A.TOC")
+        err = ds.BuildOverviews(overviewlist=[2, 4])
 
-    assert err == 0, "BuildOverviews reports an error"
+        assert err == 0, "BuildOverviews reports an error"
 
-    assert (
-        ds.GetRasterBand(1).GetOverviewCount() == 2
-    ), "Overview missing on target file."
+        assert (
+            ds.GetRasterBand(1).GetOverviewCount() == 2
+        ), "Overview missing on target file."
 
-    ds = None
-    ds = gdal.Open("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:tmp/A.TOC")
-    assert (
-        ds.GetRasterBand(1).GetOverviewCount() == 2
-    ), "Overview missing on target file after re-open."
+        ds = None
+        ds = gdal.Open("NITF_TOC_ENTRY:CADRG_ONC_1,000,000_2_0:tmp/A.TOC")
+        assert (
+            ds.GetRasterBand(1).GetOverviewCount() == 2
+        ), "Overview missing on target file after re-open."
 
-    ds = None
-
-    gdal.SetConfigOption("RPFTOC_FORCE_RGBA", "NO")
+        ds = None
 
     os.unlink("tmp/A.TOC")
     os.unlink("tmp/A.TOC.1.ovr")

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -708,11 +708,10 @@ def test_sentinel2_l1c_tile_2():
 
     filename_xml = "data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/S2A_OPER_MTD_L1C_T32TQR.xml"
     gdal.ErrorReset()
-    gdal.SetConfigOption(
+    with gdal.config_option(
         "SENTINEL2_USE_MAIN_MTD", "NO"
-    )  # Simulate absence of main MTD file
-    ds = gdal.Open(filename_xml)
-    gdal.SetConfigOption("SENTINEL2_USE_MAIN_MTD", None)
+    ):  # Simulate absence of main MTD file
+        ds = gdal.Open(filename_xml)
     assert ds is not None and gdal.GetLastErrorMsg() == ""
 
     expected_md = {
@@ -871,13 +870,12 @@ def test_sentinel2_l1c_tile_4():
 
     filename_xml = "data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/GRANULE/S2A_OPER_MSI_L1C_T32TQR_N01.03/S2A_OPER_MTD_L1C_T32TQR.xml"
     gdal.ErrorReset()
-    gdal.SetConfigOption(
+    with gdal.config_option(
         "SENTINEL2_USE_MAIN_MTD", "NO"
-    )  # Simulate absence of main MTD file
-    ds = gdal.OpenEx(
-        "SENTINEL2_L1C_TILE:%s:10m" % filename_xml, open_options=["ALPHA=YES"]
-    )
-    gdal.SetConfigOption("SENTINEL2_USE_MAIN_MTD", None)
+    ):  # Simulate absence of main MTD file
+        ds = gdal.OpenEx(
+            "SENTINEL2_L1C_TILE:%s:10m" % filename_xml, open_options=["ALPHA=YES"]
+        )
     assert ds is not None and gdal.GetLastErrorMsg() == ""
 
     expected_md = {

--- a/autotest/gdrivers/srp.py
+++ b/autotest/gdrivers/srp.py
@@ -113,9 +113,8 @@ def test_srp_4():
 
 def test_srp_5():
 
-    gdal.SetConfigOption("SRP_SINGLE_GEN_IN_THF_AS_DATASET", "FALSE")
-    ds = gdal.Open("data/srp/USRP_PCB0/TRANSH01.THF")
-    gdal.SetConfigOption("SRP_SINGLE_GEN_IN_THF_AS_DATASET", None)
+    with gdal.config_option("SRP_SINGLE_GEN_IN_THF_AS_DATASET", "FALSE"):
+        ds = gdal.Open("data/srp/USRP_PCB0/TRANSH01.THF")
     subdatasets = ds.GetMetadata("SUBDATASETS")
     assert (
         subdatasets["SUBDATASET_1_NAME"].replace("\\", "/")

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -229,10 +229,9 @@ def test_vrtderived_5():
     except (ImportError, AttributeError):
         pytest.skip()
 
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    ds = gdal.Open("data/vrt/n43_hillshade.vrt")
-    cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        ds = gdal.Open("data/vrt/n43_hillshade.vrt")
+        cs = ds.GetRasterBand(1).Checksum()
     assert cs == 50577, "invalid checksum"
 
 
@@ -249,10 +248,9 @@ def test_vrtderived_6():
     except (ImportError, AttributeError):
         pytest.skip()
 
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    ds = gdal.Open("data/vrt/python_ones.vrt")
-    cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        ds = gdal.Open("data/vrt/python_ones.vrt")
+        cs = ds.GetRasterBand(1).Checksum()
     assert cs == 10000, "invalid checksum"
 
 
@@ -341,11 +339,10 @@ def test_vrtderived_8():
     except (ImportError, AttributeError):
         pytest.skip()
 
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "NO")
-    ds = gdal.Open("data/vrt/n43_hillshade.vrt")
-    with gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "NO"):
+        ds = gdal.Open("data/vrt/n43_hillshade.vrt")
+        with gdaltest.error_handler():
+            cs = ds.GetRasterBand(1).Checksum()
     assert cs == -1, "invalid checksum"
 
     ds = gdal.Open("data/vrt/n43_hillshade.vrt")
@@ -451,10 +448,8 @@ syntax_error
 </VRTDataset>
 """
     )
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    with gdaltest.error_handler():
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
         cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
     if cs != -1:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -475,10 +470,8 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
 </VRTDataset>
 """
     )
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    with gdaltest.error_handler():
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
         cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
     if cs != -1:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -498,10 +491,8 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
 </VRTDataset>
 """
     )
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    with gdaltest.error_handler():
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
         cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
     if cs != -1:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -521,10 +512,8 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
 </VRTDataset>
 """
     )
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    with gdaltest.error_handler():
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
         cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
     if cs != -1:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -544,10 +533,8 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
 </VRTDataset>
 """
     )
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    with gdaltest.error_handler():
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
         cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
     if cs != -1:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -566,10 +553,8 @@ uncallable_object = True
 </VRTDataset>
 """
     )
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    with gdaltest.error_handler():
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
         cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
     if cs != -1:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -584,10 +569,8 @@ uncallable_object = True
 </VRTDataset>
 """
     )
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
         cs = ds.GetRasterBand(1).Checksum()
-        gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
     if cs != -1:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -684,9 +667,8 @@ def test_vrtderived_10():
 """
 
     ds = gdal.Open(content)
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        cs = ds.GetRasterBand(1).Checksum()
     if cs != 100:
         print(gdal.GetLastErrorMsg())
         pytest.fail("invalid checksum")
@@ -707,10 +689,10 @@ def test_vrtderived_10():
         "vrtderive.*" "vrtderivedX.*",
     ]:
         ds = gdal.Open(content)
-        gdal.SetConfigOption("GDAL_VRT_PYTHON_TRUSTED_MODULES", val)
-        with gdaltest.error_handler():
+        with gdal.config_option(
+            "GDAL_VRT_PYTHON_TRUSTED_MODULES", val
+        ), gdaltest.error_handler():
             cs = ds.GetRasterBand(1).Checksum()
-        gdal.SetConfigOption("GDAL_VRT_PYTHON_TRUSTED_MODULES", None)
         if cs != -1:
             print(gdal.GetLastErrorMsg())
             pytest.fail("invalid checksum")
@@ -724,9 +706,8 @@ def test_vrtderived_10():
         "foo,vrtderi*,bar",
     ]:
         ds = gdal.Open(content)
-        gdal.SetConfigOption("GDAL_VRT_PYTHON_TRUSTED_MODULES", val)
-        cs = ds.GetRasterBand(1).Checksum()
-        gdal.SetConfigOption("GDAL_VRT_PYTHON_TRUSTED_MODULES", None)
+        with gdal.config_option("GDAL_VRT_PYTHON_TRUSTED_MODULES", val):
+            cs = ds.GetRasterBand(1).Checksum()
         if cs != 100:
             print(gdal.GetLastErrorMsg())
             pytest.fail("invalid checksum")
@@ -758,9 +739,8 @@ def test_vrtderived_11():
     ds.SetMetadataItem("foo", "bar")
     ds = None
     ds = gdal.Open("/vsimem/n43_hillshade.vrt")
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    cs = ds.GetRasterBand(1).Checksum()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     gdal.Unlink("/vsimem/n43_hillshade.vrt")
@@ -806,10 +786,10 @@ def test_vrtderived_12():
             % dt
         )
 
-        gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-        with gdaltest.error_handler():
+        with gdal.config_option(
+            "GDAL_VRT_ENABLE_PYTHON", "YES"
+        ), gdaltest.error_handler():
             cs = ds.GetRasterBand(1).Checksum()
-        gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
         # CInt16/CInt32 do not map to native numpy types
         if dt == "CInt16" or dt == "CInt32":
             expected_cs = -1  # error
@@ -834,10 +814,10 @@ def test_vrtderived_12():
             % dt
         )
 
-        gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-        with gdaltest.error_handler():
+        with gdal.config_option(
+            "GDAL_VRT_ENABLE_PYTHON", "YES"
+        ), gdaltest.error_handler():
             cs = ds.GetRasterBand(1).Checksum()
-        gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
         if cs != -1:
             print(dt)
             print(gdal.GetLastErrorMsg())
@@ -857,12 +837,11 @@ def test_vrtderived_13():
     except (ImportError, AttributeError):
         pytest.skip()
 
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    # Will test the VRTDerivedRasterBand::IGetDataCoverageStatus() interface
-    ds = gdal.GetDriverByName("GTiff").CreateCopy(
-        "/vsimem/vrtderived_13.tif", gdal.Open("data/vrt/python_ones.vrt")
-    )
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        # Will test the VRTDerivedRasterBand::IGetDataCoverageStatus() interface
+        ds = gdal.GetDriverByName("GTiff").CreateCopy(
+            "/vsimem/vrtderived_13.tif", gdal.Open("data/vrt/python_ones.vrt")
+        )
     cs = ds.GetRasterBand(1).Checksum()
     ds = None
     gdal.Unlink("/vsimem/vrtderived_13.tif")
@@ -883,14 +862,13 @@ def test_vrtderived_14():
     except (ImportError, AttributeError):
         pytest.skip()
 
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
-    ds = gdal.GetDriverByName("VRT").CreateCopy(
-        "/vsimem/vrtderived_14.vrt", gdal.Open("data/vrt/python_ones.vrt")
-    )
-    (my_min, my_max) = ds.GetRasterBand(1).ComputeRasterMinMax()
-    (my_min2, my_max2, mean, stddev) = ds.GetRasterBand(1).ComputeStatistics(False)
-    hist = ds.GetRasterBand(1).GetHistogram()
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        ds = gdal.GetDriverByName("VRT").CreateCopy(
+            "/vsimem/vrtderived_14.vrt", gdal.Open("data/vrt/python_ones.vrt")
+        )
+        (my_min, my_max) = ds.GetRasterBand(1).ComputeRasterMinMax()
+        (my_min2, my_max2, mean, stddev) = ds.GetRasterBand(1).ComputeStatistics(False)
+        hist = ds.GetRasterBand(1).GetHistogram()
 
     assert (my_min, my_max) == (1.0, 1.0), "invalid ComputeRasterMinMax"
 
@@ -941,22 +919,24 @@ def test_vrtderived_15():
 
     gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
 
-    threads = []
-    args_array = []
-    for i in range(4):
-        args_dict = {"ret": True}
-        t = threading.Thread(target=vrtderived_15_worker, args=(args_dict,))
-        args_array.append(args_dict)
-        threads.append(t)
-        t.start()
+    try:
+        threads = []
+        args_array = []
+        for i in range(4):
+            args_dict = {"ret": True}
+            t = threading.Thread(target=vrtderived_15_worker, args=(args_dict,))
+            args_array.append(args_dict)
+            threads.append(t)
+            t.start()
 
-    ret = True
-    for i in range(4):
-        threads[i].join()
-        if not args_array[i]:
-            ret = False
+        ret = True
+        for i in range(4):
+            threads[i].join()
+            if not args_array[i]:
+                ret = False
 
-    gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
+    finally:
+        gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", None)
 
     assert ret
 

--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -112,12 +112,9 @@ def wms_4():
     if gdaltest.wms_ds is None or not gdaltest.wms_srv1_ok:
         pytest.skip()
 
-    gdal.SetConfigOption("CPL_ACCUM_ERROR_MSG", "ON")
-
-    with gdaltest.error_handler():
+    with gdal.config_option("CPL_ACCUM_ERROR_MSG", "ON"), gdaltest.error_handler():
         cs = gdaltest.wms_ds.GetRasterBand(1).Checksum(0, 0, 100, 100)
 
-    gdal.SetConfigOption("CPL_ACCUM_ERROR_MSG", "OFF")
     msg = gdal.GetLastErrorMsg()
     gdal.ErrorReset()
 

--- a/autotest/gdrivers/xmp.py
+++ b/autotest/gdrivers/xmp.py
@@ -83,29 +83,29 @@ def test_xmp(drivername, filename, expect_xmp):
             pytest.skip()
 
     # we set ECW to not resolve projection and datum strings to get 3.x behavior.
-    gdal.SetConfigOption("ECW_DO_NOT_RESOLVE_DATUM_PROJECTION", "YES")
+    with gdal.config_option("ECW_DO_NOT_RESOLVE_DATUM_PROJECTION", "YES"):
 
-    if ".jp2" in filename:
-        gdaltest.deregister_all_jpeg2000_drivers_but(drivername)
-
-    try:
-        ds = gdal.Open(filename)
-        if filename == "data/rgbsmall_with_xmp.webp":
-            if ds is None:
-                pytest.skip("Old libwebp don't support VP8X containers")
-        else:
-            assert ds is not None, "open failed"
-
-        xmp_md = ds.GetMetadata("xml:XMP")
-
-        assert ds.GetDriver().ShortName == drivername, "opened with wrong driver"
-        assert not (expect_xmp and not xmp_md), "did not find xml:XMP metadata"
-        assert not (
-            expect_xmp and "xml:XMP" not in ds.GetMetadataDomainList()
-        ), "did not find xml:XMP metadata domain"
-        assert expect_xmp or not xmp_md, "found unexpected xml:XMP metadata"
-
-        ds = None
-    finally:
         if ".jp2" in filename:
-            gdaltest.reregister_all_jpeg2000_drivers()
+            gdaltest.deregister_all_jpeg2000_drivers_but(drivername)
+
+        try:
+            ds = gdal.Open(filename)
+            if filename == "data/rgbsmall_with_xmp.webp":
+                if ds is None:
+                    pytest.skip("Old libwebp don't support VP8X containers")
+            else:
+                assert ds is not None, "open failed"
+
+            xmp_md = ds.GetMetadata("xml:XMP")
+
+            assert ds.GetDriver().ShortName == drivername, "opened with wrong driver"
+            assert not (expect_xmp and not xmp_md), "did not find xml:XMP metadata"
+            assert not (
+                expect_xmp and "xml:XMP" not in ds.GetMetadataDomainList()
+            ), "did not find xml:XMP metadata domain"
+            assert expect_xmp or not xmp_md, "found unexpected xml:XMP metadata"
+
+            ds = None
+        finally:
+            if ".jp2" in filename:
+                gdaltest.reregister_all_jpeg2000_drivers()

--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -732,8 +732,7 @@ def test_ogr_dxf_15():
 
 def test_ogr_dxf_16():
 
-    gdal.SetConfigOption("DXF_INLINE_BLOCKS", "FALSE")
-    try:
+    with gdal.config_option("DXF_INLINE_BLOCKS", "FALSE"):
 
         dxf_ds = ogr.Open("data/dxf/assorted.dxf")
 
@@ -814,10 +813,6 @@ def test_ogr_dxf_16():
         )
 
         feat = None
-
-    finally:
-        # cleanup
-        gdal.SetConfigOption("DXF_INLINE_BLOCKS", None)
 
 
 ###############################################################################
@@ -1163,10 +1158,9 @@ def test_ogr_dxf_21():
         "LINESTRING (5 2 3,4.990256201039297 1.720974105023499 3,4.961072274966281 1.443307596159738 3,4.912590402935223 1.168353236728963 3,4.845046783753276 0.897450576732003 3,4.758770483143634 0.631919426697325 3,4.654181830570403 0.373053427696799 3,4.531790371435708 0.122113748856437 3,4.392192384625703 -0.11967705693282 3,4.23606797749979 -0.351141009169893 3,4.064177772475912 -0.571150438746157 3,3.877359201354605 -0.778633481835989 3,3.676522425435433 -0.972579301909577 3,3.462645901302633 -1.152043014426888 3,3.236771613882987 -1.316150290220167 3,3.0 -1.464101615137754 3,2.75348458715631 -1.595176185196668 3,2.498426373663648 -1.70873541826715 3,2.23606797749979 -1.804226065180614 3,1.967687582398672 -1.881182905103986 3,1.694592710667722 -1.939231012048832 3,1.418113853070614 -1.978087581473093 3,1.139597986810004 -1.997563308076383 3,0.860402013189997 -1.997563308076383 3,0.581886146929387 -1.978087581473094 3,0.305407289332279 -1.939231012048832 3,0.032312417601329 -1.881182905103986 3,-0.236067977499789 -1.804226065180615 3,-0.498426373663648 -1.70873541826715 3,-0.75348458715631 -1.595176185196668 3,-1.0 -1.464101615137755 3,-1.236771613882987 -1.316150290220167 3,-1.462645901302633 -1.152043014426888 3,-1.676522425435433 -0.972579301909577 3,-1.877359201354605 -0.778633481835989 3,-2.064177772475912 -0.571150438746158 3,-2.236067977499789 -0.351141009169893 3,-2.392192384625704 -0.11967705693282 3,-2.531790371435707 0.122113748856436 3,-2.654181830570403 0.373053427696798 3,-2.758770483143633 0.631919426697324 3,-2.845046783753275 0.897450576732001 3,-2.912590402935223 1.168353236728963 3,-2.961072274966281 1.443307596159737 3,-2.990256201039297 1.720974105023498 3,-3.0 2.0 3,-2.990256201039297 2.279025894976499 3,-2.961072274966281 2.556692403840262 3,-2.912590402935223 2.831646763271036 3,-2.845046783753276 3.102549423267996 3,-2.758770483143634 3.368080573302675 3,-2.654181830570404 3.626946572303199 3,-2.531790371435708 3.877886251143563 3,-2.392192384625704 4.119677056932819 3,-2.23606797749979 4.351141009169892 3,-2.064177772475912 4.571150438746157 3,-1.877359201354604 4.778633481835989 3,-1.676522425435434 4.972579301909576 3,-1.462645901302632 5.152043014426889 3,-1.236771613882989 5.316150290220166 3,-1.0 5.464101615137753 3,-0.753484587156311 5.595176185196667 3,-0.498426373663649 5.70873541826715 3,-0.23606797749979 5.804226065180615 3,0.032312417601329 5.881182905103985 3,0.305407289332279 5.939231012048833 3,0.581886146929387 5.978087581473094 3,0.860402013189993 5.997563308076383 3,1.139597986810005 5.997563308076383 3,1.418113853070612 5.978087581473094 3,1.69459271066772 5.939231012048833 3,1.96768758239867 5.881182905103986 3,2.236067977499789 5.804226065180615 3,2.498426373663648 5.70873541826715 3,2.75348458715631 5.595176185196668 3,3.0 5.464101615137754 3,3.236771613882985 5.316150290220168 3,3.462645901302634 5.152043014426887 3,3.676522425435431 4.972579301909578 3,3.877359201354603 4.778633481835991 3,4.064177772475912 4.571150438746159 3,4.23606797749979 4.351141009169893 3,4.392192384625702 4.119677056932823 3,4.531790371435708 3.877886251143563 3,4.654181830570404 3.626946572303201 3,4.758770483143634 3.368080573302675 3,4.845046783753275 3.102549423267999 3,4.912590402935223 2.831646763271039 3,4.961072274966281 2.556692403840263 3,4.990256201039298 2.279025894976499 3,5.0 2.0 3)",
     )
 
-    gdal.SetConfigOption("OGR_ARC_MAX_GAP", "80")
-    feat = lyr.GetNextFeature()
-    geom = feat.GetGeometryRef()
-    gdal.SetConfigOption("OGR_ARC_MAX_GAP", None)
+    with gdal.config_option("OGR_ARC_MAX_GAP", "80"):
+        feat = lyr.GetNextFeature()
+        geom = feat.GetGeometryRef()
 
     assert geom.GetPointCount() == 4, (
         "did not get expected number of points, got %d" % geom.GetPointCount()
@@ -1222,9 +1216,8 @@ def test_ogr_dxf_22():
     gdal.Unlink("/vsimem/ogr_dxf_22.dxf")
 
     # Now try reading in the MTEXT feature without translating escape sequences
-    gdal.SetConfigOption("DXF_TRANSLATE_ESCAPE_SEQUENCES", "FALSE")
-    ds = ogr.Open("data/dxf/text.dxf")
-    gdal.SetConfigOption("DXF_TRANSLATE_ESCAPE_SEQUENCES", None)
+    with gdal.config_option("DXF_TRANSLATE_ESCAPE_SEQUENCES", "FALSE"):
+        ds = ogr.Open("data/dxf/text.dxf")
     lyr = ds.GetLayer(0)
 
     feat = lyr.GetNextFeature()
@@ -1279,17 +1272,15 @@ def test_ogr_dxf_24():
     ds = ogr.Open("data/dxf/hatch.dxf")
     lyr = ds.GetLayer(0)
 
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    feat = lyr.GetNextFeature()
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        feat = lyr.GetNextFeature()
     assert not ogrtest.check_feature_geometry(
         feat,
         "POLYGON ((2 1,1.646446609406726 0.853553390593274,1.5 0.5,1.646446609406726 0.146446609406726,2 0,2.146446609406726 -0.353553390593274,2.5 -0.5,2.853553390593274 -0.353553390593274,3.0 -0.0,3.353553390593274 0.146446609406726,3.5 0.5,3.353553390593274 0.853553390593273,3 1,2.853553390593274 1.353553390593274,2.5 1.5,2.146446609406726 1.353553390593274,2 1))",
     )
 
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    feat = lyr.GetNextFeature()
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        feat = lyr.GetNextFeature()
     assert not ogrtest.check_feature_geometry(
         feat,
         "POLYGON ((0.0 0.0 0,-0.353553390593274 0.146446609406726 0,-0.5 0.5 0,-0.353553390593274 0.853553390593274 0,-0.0 1.0 0,0.146446609406726 1.353553390593274 0,0.5 1.5 0,0.853553390593274 1.353553390593274 0,1.0 1.0 0,1.353553390593274 0.853553390593274 0,1.5 0.5 0,1.353553390593274 0.146446609406727 0,1.0 0.0 0,0.853553390593274 -0.353553390593274 0,0.5 -0.5 0,0.146446609406726 -0.353553390593274 0,0.0 0.0 0))",
@@ -1888,9 +1879,8 @@ def test_ogr_dxf_31():
 
 def test_ogr_dxf_32():
 
-    gdal.SetConfigOption("DXF_INCLUDE_RAW_CODE_VALUES", "TRUE")
-    ds = ogr.Open("data/dxf/ocs2wcs2.dxf")
-    gdal.SetConfigOption("DXF_INCLUDE_RAW_CODE_VALUES", None)
+    with gdal.config_option("DXF_INCLUDE_RAW_CODE_VALUES", "TRUE"):
+        ds = ogr.Open("data/dxf/ocs2wcs2.dxf")
     lyr = ds.GetLayer(0)
 
     # INFO: Open of `ocs2wcs2.dxf' using driver `DXF' successful.
@@ -2483,9 +2473,8 @@ def test_ogr_dxf_32():
 
 def test_ogr_dxf_33():
 
-    gdal.SetConfigOption("DXF_3D_EXTENSIBLE_MODE", "TRUE")
-    ds = ogr.Open("data/dxf/3d.dxf")
-    gdal.SetConfigOption("DXF_3D_EXTENSIBLE_MODE", None)
+    with gdal.config_option("DXF_3D_EXTENSIBLE_MODE", "TRUE"):
+        ds = ogr.Open("data/dxf/3d.dxf")
 
     layer = ds.GetLayer(0)
 
@@ -2843,9 +2832,8 @@ def test_ogr_dxf_35():
 
 def test_ogr_dxf_36():
 
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE")
-    ds = ogr.Open("data/dxf/insert_only.dxf")
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", None)
+    with gdal.config_option("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE"):
+        ds = ogr.Open("data/dxf/insert_only.dxf")
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 5
 
@@ -2869,9 +2857,8 @@ def test_ogr_dxf_37():
     ds = None
 
     # Read back.
-    gdal.SetConfigOption("DXF_INLINE_BLOCKS", "FALSE")
-    ds = ogr.Open("/vsimem/ogr_dxf_37.dxf")
-    gdal.SetConfigOption("DXF_INLINE_BLOCKS", None)
+    with gdal.config_option("DXF_INLINE_BLOCKS", "FALSE"):
+        ds = ogr.Open("/vsimem/ogr_dxf_37.dxf")
     lyr = ds.GetLayerByName("blocks")
 
     # Check first feature
@@ -3041,9 +3028,8 @@ def test_ogr_dxf_42():
     )
 
     # No inlining, merging
-    gdal.SetConfigOption("DXF_INLINE_BLOCKS", "FALSE")
-    ds = ogr.Open("data/dxf/block-insert-order.dxf")
-    gdal.SetConfigOption("DXF_INLINE_BLOCKS", None)
+    with gdal.config_option("DXF_INLINE_BLOCKS", "FALSE"):
+        ds = ogr.Open("data/dxf/block-insert-order.dxf")
 
     lyr = ds.GetLayerByName("entities")
     assert lyr.GetFeatureCount() == 2, (
@@ -3087,9 +3073,8 @@ def test_ogr_dxf_42():
     assert f.GetField("Block") == "BLOCK3", "Wrong Block"
 
     # Inlining, no merging
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE")
-    ds = ogr.Open("data/dxf/block-insert-order.dxf")
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", None)
+    with gdal.config_option("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE"):
+        ds = ogr.Open("data/dxf/block-insert-order.dxf")
 
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 4, (
@@ -3536,9 +3521,8 @@ def test_ogr_dxf_47():
 
 def test_ogr_dxf_48():
 
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE")
-    ds = ogr.Open("data/dxf/byblock-bylayer.dxf")
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", None)
+    with gdal.config_option("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE"):
+        ds = ogr.Open("data/dxf/byblock-bylayer.dxf")
 
     lyr = ds.GetLayer(0)
 
@@ -3648,9 +3632,8 @@ def test_ogr_dxf_49():
     assert f.GetField("Text") == "", "Wrong Text value on ATTRIB on second INSERT"
 
     # No inlining
-    gdal.SetConfigOption("DXF_INLINE_BLOCKS", "FALSE")
-    ds = ogr.Open("data/dxf/attrib.dxf")
-    gdal.SetConfigOption("DXF_INLINE_BLOCKS", None)
+    with gdal.config_option("DXF_INLINE_BLOCKS", "FALSE"):
+        ds = ogr.Open("data/dxf/attrib.dxf")
 
     lyr = ds.GetLayerByName("entities")
 
@@ -3685,9 +3668,8 @@ def test_ogr_dxf_49():
 
 def test_ogr_dxf_50():
 
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE")
-    ds = ogr.Open("data/dxf/text-fancy.dxf")
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", None)
+    with gdal.config_option("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE"):
+        ds = ogr.Open("data/dxf/text-fancy.dxf")
 
     lyr = ds.GetLayer(0)
 
@@ -3911,9 +3893,8 @@ def test_ogr_dxf_53():
 
 def test_ogr_dxf_54():
 
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE")
-    ds = ogr.Open("data/dxf/frozen-off.dxf")
-    gdal.SetConfigOption("DXF_MERGE_BLOCK_GEOMETRIES", None)
+    with gdal.config_option("DXF_MERGE_BLOCK_GEOMETRIES", "FALSE"):
+        ds = ogr.Open("data/dxf/frozen-off.dxf")
     lyr = ds.GetLayer(0)
 
     # Features should be visible/hidden in the following order:

--- a/autotest/ogr/ogr_eeda.py
+++ b/autotest/ogr/ogr_eeda.py
@@ -44,15 +44,8 @@ pytestmark = pytest.mark.require_driver("EEDA")
 
 @pytest.fixture(autouse=True, scope="module")
 def startup_and_cleanup():
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-    yield
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", None)
-    gdal.SetConfigOption("EEDA_BEARER", None)
-    gdal.SetConfigOption("EEDA_URL", None)
-    gdal.SetConfigOption("EEDA_PRIVATE_KEY", None)
-    gdal.SetConfigOption("EEDA_CLIENT_EMAIL", None)
-    gdal.SetConfigOption("GO2A_AUD", None)
-    gdal.SetConfigOption("GOA2_NOW", None)
+    with gdal.config_option("CPL_CURL_ENABLE_VSIMEM", "YES"):
+        yield
 
     gdal.Unlink("/vsimem/ee/")
     gdal.Unlink(
@@ -93,283 +86,299 @@ def test_eeda_2():
     # To please the unregistering of the persistent connection
     gdal.FileFromMemBuffer("/vsimem/ee/", "")
 
-    gdal.SetConfigOption("EEDA_BEARER", "mybearer")
-    gdal.SetConfigOption("EEDA_URL", "/vsimem/ee/")
-    ds = ogr.Open("EEDA:collection")
-    gdal.SetConfigOption("EEDA_URL", None)
+    with gdal.config_option("EEDA_BEARER", "mybearer"):
 
-    lyr = ds.GetLayer(0)
+        with gdal.config_option("EEDA_URL", "/vsimem/ee/"):
+            ds = ogr.Open("EEDA:collection")
 
-    assert lyr.TestCapability(ogr.OLCStringsAsUTF8) == 1
+        lyr = ds.GetLayer(0)
 
-    assert lyr.TestCapability("foo") == 0
+        assert lyr.TestCapability(ogr.OLCStringsAsUTF8) == 1
 
-    assert lyr.GetLayerDefn().GetFieldCount() == 8 + 7 + 4
+        assert lyr.TestCapability("foo") == 0
 
-    assert lyr.GetExtent() == (-180.0, 180.0, -90.0, 90.0)
+        assert lyr.GetLayerDefn().GetFieldCount() == 8 + 7 + 4
 
-    assert lyr.GetFeatureCount() == -1
+        assert lyr.GetExtent() == (-180.0, 180.0, -90.0, 90.0)
 
-    gdal.FileFromMemBuffer(
-        "/vsimem/ee/projects/earthengine-public/assets/collection:listImages",
-        json.dumps(
-            {
-                "images": [
-                    {
-                        "name": "projects/earthengine-public/assets/collection/first_feature",
-                        "id": "collection/first_feature",
-                        "updateTime": "2017-01-04T12:34:56.789Z",
-                        "startTime": "2017-01-02T12:34:56.789Z",
-                        "endTime": "2017-01-03T12:34:56.789Z",
-                        "sizeBytes": 1,
-                        "geometry": {
-                            "type": "Polygon",
-                            "coordinates": [
-                                [[2, 49], [2.1, 49], [2.1, 49.1], [2, 49.1], [2, 49]]
-                            ],
-                        },
-                        "properties": {
-                            "string_field": "bar",
-                            "int_field": 1,
-                            "int64_field": 123456789012,
-                            "double_field": 1.23,
-                            "another_prop": 3,
-                        },
-                        "bands": [
-                            {
-                                "id": "B1",
-                                "dataType": {"precision": "INT", "range": {"max": 255}},
-                                "grid": {
-                                    "crsCode": "EPSG:32610",
-                                    "affineTransform": {
-                                        "translateX": 499980,
-                                        "translateY": 4200000,
-                                        "scaleX": 60,
-                                        "scaleY": -60,
+        assert lyr.GetFeatureCount() == -1
+
+        gdal.FileFromMemBuffer(
+            "/vsimem/ee/projects/earthengine-public/assets/collection:listImages",
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "name": "projects/earthengine-public/assets/collection/first_feature",
+                            "id": "collection/first_feature",
+                            "updateTime": "2017-01-04T12:34:56.789Z",
+                            "startTime": "2017-01-02T12:34:56.789Z",
+                            "endTime": "2017-01-03T12:34:56.789Z",
+                            "sizeBytes": 1,
+                            "geometry": {
+                                "type": "Polygon",
+                                "coordinates": [
+                                    [
+                                        [2, 49],
+                                        [2.1, 49],
+                                        [2.1, 49.1],
+                                        [2, 49.1],
+                                        [2, 49],
+                                    ]
+                                ],
+                            },
+                            "properties": {
+                                "string_field": "bar",
+                                "int_field": 1,
+                                "int64_field": 123456789012,
+                                "double_field": 1.23,
+                                "another_prop": 3,
+                            },
+                            "bands": [
+                                {
+                                    "id": "B1",
+                                    "dataType": {
+                                        "precision": "INT",
+                                        "range": {"max": 255},
                                     },
-                                    "dimensions": {"width": 1830, "height": 1831},
-                                },
-                            }
-                        ],
-                    },
-                    {
-                        "name": "projects/earthengine-public/assets/collection/second_feature"
-                    },
-                ],
-                "nextPageToken": "myToken",
-            }
-        ),
-    )
-
-    f = lyr.GetNextFeature()
-    if (
-        f.GetField("name")
-        != "projects/earthengine-public/assets/collection/first_feature"
-        or f.GetField("id") != "collection/first_feature"
-        or f.GetField("gdal_dataset")
-        != "EEDAI:projects/earthengine-public/assets/collection/first_feature"
-        or f.GetField("updateTime") != "2017/01/04 12:34:56.789+00"
-        or f.GetField("startTime") != "2017/01/02 12:34:56.789+00"
-        or f.GetField("endTime") != "2017/01/03 12:34:56.789+00"
-        or f.GetField("sizeBytes") != 1
-        or f.GetField("band_count") != 1
-        or f.GetField("band_max_width") != 1830
-        or f.GetField("band_max_height") != 1831
-        or f.GetField("band_min_pixel_size") != 60
-        or f.GetField("band_upper_left_x") != 499980
-        or f.GetField("band_upper_left_y") != 4200000
-        or f.GetField("band_crs") != "EPSG:32610"
-        or f.GetField("string_field") != "bar"
-        or f.GetField("int_field") != 1
-        or f.GetField("int64_field") != 123456789012
-        or f.GetField("double_field") != 1.23
-        or f.GetField("other_properties") != '{ "another_prop": 3 }'
-        or f.GetGeometryRef().ExportToWkt()
-        != "MULTIPOLYGON (((2 49,2.1 49.0,2.1 49.1,2.0 49.1,2 49)))"
-    ):
-        f.DumpReadable()
-        pytest.fail()
-
-    f = lyr.GetNextFeature()
-    if (
-        f.GetField("name")
-        != "projects/earthengine-public/assets/collection/second_feature"
-    ):
-        f.DumpReadable()
-        pytest.fail()
-
-    gdal.FileFromMemBuffer(
-        "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageToken=myToken",
-        json.dumps(
-            {
-                "images": [
-                    {
-                        "name": "projects/earthengine-public/assets/collection/third_feature"
-                    }
-                ]
-            }
-        ),
-    )
-
-    f = lyr.GetNextFeature()
-    if (
-        f.GetField("name")
-        != "projects/earthengine-public/assets/collection/third_feature"
-    ):
-        f.DumpReadable()
-        pytest.fail()
-
-    f = lyr.GetNextFeature()
-    assert f is None
-
-    lyr.ResetReading()
-
-    f = lyr.GetNextFeature()
-    if (
-        f.GetField("name")
-        != "projects/earthengine-public/assets/collection/first_feature"
-    ):
-        f.DumpReadable()
-        pytest.fail()
-
-    lyr.SetAttributeFilter("EEDA:raw_filter")
-
-    gdal.FileFromMemBuffer(
-        "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?filter=raw%5Ffilter",
-        json.dumps(
-            {
-                "images": [
-                    {"name": "projects/earthengine-public/assets/collection/raw_filter"}
-                ]
-            }
-        ),
-    )
-
-    f = lyr.GetNextFeature()
-    assert (
-        f.GetField("name") == "projects/earthengine-public/assets/collection/raw_filter"
-    )
-
-    lyr.SetAttributeFilter(None)
-    lyr.SetAttributeFilter(
-        "startTime >= '1980-01-01T00:00:00Z' AND "
-        + "string_field = 'bar' AND "
-        + "int_field > 0 AND "
-        + "int_field < 2 AND "
-        + "int64_field >= 0 AND "
-        + "int64_field <= 9999999999999 AND "
-        + "double_field != 3.5 AND "
-        + "string_field IN ('bar', 'baz') AND "
-        + "NOT( int_field IN (0) OR double_field IN (3.5) )"
-    )
-
-    tmpfile = "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?region=%7B%20%22type%22%3A%20%22Polygon%22%2C%20%22coordinates%22%3A%20%5B%20%5B%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%20%5D%20%5D%20%7D&filter=%28%28%28string%5Ffield%20%3D%20%22bar%22%20AND%20%28int%5Ffield%20%3E%200%20AND%20int%5Ffield%20%3C%202%29%29%20AND%20%28%28int64%5Ffield%20%3E%3D%200%20AND%20int64%5Ffield%20%3C%3D%209999999999999%29%20AND%20%28double%5Ffield%20%21%3D%203%2E5%20AND%20string%5Ffield%20%3D%20%22bar%22%20OR%20string%5Ffield%20%3D%20%22baz%22%29%29%29%20AND%20%28NOT%20%28int%5Ffield%20%3D%200%20OR%20double%5Ffield%20%3D%203%2E5%29%29%29&startTime=1980%2D01%2D01T00%3A00%3A00Z"
-    with gdaltest.tempfile(
-        tmpfile,
-        json.dumps(
-            {
-                "images": [
-                    {
-                        "name": "projects/earthengine-public/assets/collection/filtered_feature",
-                        "updateTime": "2017-01-03T12:34:56.789Z",
-                        "startTime": "2017-01-02T12:34:56.789Z",
-                        "sizeBytes": 1,
-                        "geometry": {
-                            "type": "Polygon",
-                            "coordinates": [
-                                [[2, 49], [2.1, 49], [2.1, 49.1], [2, 49.1], [2, 49]]
+                                    "grid": {
+                                        "crsCode": "EPSG:32610",
+                                        "affineTransform": {
+                                            "translateX": 499980,
+                                            "translateY": 4200000,
+                                            "scaleX": 60,
+                                            "scaleY": -60,
+                                        },
+                                        "dimensions": {"width": 1830, "height": 1831},
+                                    },
+                                }
                             ],
                         },
-                        "properties": {
-                            "string_field": "bar",
-                            "int_field": 1,
-                            "int64_field": 123456789012,
-                            "double_field": 1.23,
-                            "another_prop": 3,
+                        {
+                            "name": "projects/earthengine-public/assets/collection/second_feature"
                         },
-                    },
-                    {
-                        "name": "projects/earthengine-public/assets/collection/second_feature"
-                    },
-                ]
-            }
-        ),
-    ):
-
-        lyr.SetSpatialFilterRect(-180, -90, 180, 90)
+                    ],
+                    "nextPageToken": "myToken",
+                }
+            ),
+        )
 
         f = lyr.GetNextFeature()
-
-    assert (
-        f.GetField("name")
-        == "projects/earthengine-public/assets/collection/filtered_feature"
-    )
-
-    lyr.SetSpatialFilter(None)
-
-    # Test time equality with second granularity
-    lyr.SetAttributeFilter(
-        "startTime >= '1980-01-01T00:00:00Z' AND endTime <= '1980-01-02T23:59:59Z'"
-    )
-
-    tmpfile = "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D02T23%3A59%3A59Z"
-    with gdaltest.tempfile(
-        tmpfile,
-        json.dumps(
-            {
-                "images": [
-                    {
-                        "name": "projects/earthengine-public/assets/collection/filtered_feature",
-                        "startTime": "1980-01-01T00:00:00Z",
-                        "endTime": "1980-01-02T23:59:59Z",
-                    },
-                    {
-                        "name": "projects/earthengine-public/assets/collection/second_feature"
-                    },
-                ]
-            }
-        ),
-    ):
+        if (
+            f.GetField("name")
+            != "projects/earthengine-public/assets/collection/first_feature"
+            or f.GetField("id") != "collection/first_feature"
+            or f.GetField("gdal_dataset")
+            != "EEDAI:projects/earthengine-public/assets/collection/first_feature"
+            or f.GetField("updateTime") != "2017/01/04 12:34:56.789+00"
+            or f.GetField("startTime") != "2017/01/02 12:34:56.789+00"
+            or f.GetField("endTime") != "2017/01/03 12:34:56.789+00"
+            or f.GetField("sizeBytes") != 1
+            or f.GetField("band_count") != 1
+            or f.GetField("band_max_width") != 1830
+            or f.GetField("band_max_height") != 1831
+            or f.GetField("band_min_pixel_size") != 60
+            or f.GetField("band_upper_left_x") != 499980
+            or f.GetField("band_upper_left_y") != 4200000
+            or f.GetField("band_crs") != "EPSG:32610"
+            or f.GetField("string_field") != "bar"
+            or f.GetField("int_field") != 1
+            or f.GetField("int64_field") != 123456789012
+            or f.GetField("double_field") != 1.23
+            or f.GetField("other_properties") != '{ "another_prop": 3 }'
+            or f.GetGeometryRef().ExportToWkt()
+            != "MULTIPOLYGON (((2 49,2.1 49.0,2.1 49.1,2.0 49.1,2 49)))"
+        ):
+            f.DumpReadable()
+            pytest.fail()
 
         f = lyr.GetNextFeature()
+        if (
+            f.GetField("name")
+            != "projects/earthengine-public/assets/collection/second_feature"
+        ):
+            f.DumpReadable()
+            pytest.fail()
 
-    assert (
-        f.GetField("name")
-        == "projects/earthengine-public/assets/collection/filtered_feature"
-    )
-
-    # Test time equality with day granularity
-    lyr.SetAttributeFilter("startTime = '1980-01-01' AND endTime = '1980-01-02'")
-
-    tmpfile = "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D02T23%3A59%3A59Z"
-    with gdaltest.tempfile(
-        tmpfile,
-        json.dumps(
-            {
-                "images": [
-                    {
-                        "name": "projects/earthengine-public/assets/collection/filtered_feature",
-                        "startTime": "1980-01-01T12:00:00Z",
-                        "endTime": "1980-01-02T23:59:59Z",
-                    },
-                    {
-                        "name": "projects/earthengine-public/assets/collection/second_feature"
-                    },
-                ]
-            }
-        ),
-    ):
+        gdal.FileFromMemBuffer(
+            "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?pageToken=myToken",
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "name": "projects/earthengine-public/assets/collection/third_feature"
+                        }
+                    ]
+                }
+            ),
+        )
 
         f = lyr.GetNextFeature()
+        if (
+            f.GetField("name")
+            != "projects/earthengine-public/assets/collection/third_feature"
+        ):
+            f.DumpReadable()
+            pytest.fail()
 
-    assert (
-        f.GetField("name")
-        == "projects/earthengine-public/assets/collection/filtered_feature"
-    )
+        f = lyr.GetNextFeature()
+        assert f is None
 
-    ds = None
+        lyr.ResetReading()
 
-    gdal.SetConfigOption("EEDA_BEARER", None)
+        f = lyr.GetNextFeature()
+        if (
+            f.GetField("name")
+            != "projects/earthengine-public/assets/collection/first_feature"
+        ):
+            f.DumpReadable()
+            pytest.fail()
+
+        lyr.SetAttributeFilter("EEDA:raw_filter")
+
+        gdal.FileFromMemBuffer(
+            "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?filter=raw%5Ffilter",
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "name": "projects/earthengine-public/assets/collection/raw_filter"
+                        }
+                    ]
+                }
+            ),
+        )
+
+        f = lyr.GetNextFeature()
+        assert (
+            f.GetField("name")
+            == "projects/earthengine-public/assets/collection/raw_filter"
+        )
+
+        lyr.SetAttributeFilter(None)
+        lyr.SetAttributeFilter(
+            "startTime >= '1980-01-01T00:00:00Z' AND "
+            + "string_field = 'bar' AND "
+            + "int_field > 0 AND "
+            + "int_field < 2 AND "
+            + "int64_field >= 0 AND "
+            + "int64_field <= 9999999999999 AND "
+            + "double_field != 3.5 AND "
+            + "string_field IN ('bar', 'baz') AND "
+            + "NOT( int_field IN (0) OR double_field IN (3.5) )"
+        )
+
+        tmpfile = "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?region=%7B%20%22type%22%3A%20%22Polygon%22%2C%20%22coordinates%22%3A%20%5B%20%5B%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%2090%2E0%20%5D%2C%20%5B%20180%2E0%2C%20%2D90%2E0%20%5D%2C%20%5B%20%2D180%2E0%2C%20%2D90%2E0%20%5D%20%5D%20%5D%20%7D&filter=%28%28%28string%5Ffield%20%3D%20%22bar%22%20AND%20%28int%5Ffield%20%3E%200%20AND%20int%5Ffield%20%3C%202%29%29%20AND%20%28%28int64%5Ffield%20%3E%3D%200%20AND%20int64%5Ffield%20%3C%3D%209999999999999%29%20AND%20%28double%5Ffield%20%21%3D%203%2E5%20AND%20string%5Ffield%20%3D%20%22bar%22%20OR%20string%5Ffield%20%3D%20%22baz%22%29%29%29%20AND%20%28NOT%20%28int%5Ffield%20%3D%200%20OR%20double%5Ffield%20%3D%203%2E5%29%29%29&startTime=1980%2D01%2D01T00%3A00%3A00Z"
+        with gdaltest.tempfile(
+            tmpfile,
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "name": "projects/earthengine-public/assets/collection/filtered_feature",
+                            "updateTime": "2017-01-03T12:34:56.789Z",
+                            "startTime": "2017-01-02T12:34:56.789Z",
+                            "sizeBytes": 1,
+                            "geometry": {
+                                "type": "Polygon",
+                                "coordinates": [
+                                    [
+                                        [2, 49],
+                                        [2.1, 49],
+                                        [2.1, 49.1],
+                                        [2, 49.1],
+                                        [2, 49],
+                                    ]
+                                ],
+                            },
+                            "properties": {
+                                "string_field": "bar",
+                                "int_field": 1,
+                                "int64_field": 123456789012,
+                                "double_field": 1.23,
+                                "another_prop": 3,
+                            },
+                        },
+                        {
+                            "name": "projects/earthengine-public/assets/collection/second_feature"
+                        },
+                    ]
+                }
+            ),
+        ):
+
+            lyr.SetSpatialFilterRect(-180, -90, 180, 90)
+
+            f = lyr.GetNextFeature()
+
+        assert (
+            f.GetField("name")
+            == "projects/earthengine-public/assets/collection/filtered_feature"
+        )
+
+        lyr.SetSpatialFilter(None)
+
+        # Test time equality with second granularity
+        lyr.SetAttributeFilter(
+            "startTime >= '1980-01-01T00:00:00Z' AND endTime <= '1980-01-02T23:59:59Z'"
+        )
+
+        tmpfile = "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D02T23%3A59%3A59Z"
+        with gdaltest.tempfile(
+            tmpfile,
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "name": "projects/earthengine-public/assets/collection/filtered_feature",
+                            "startTime": "1980-01-01T00:00:00Z",
+                            "endTime": "1980-01-02T23:59:59Z",
+                        },
+                        {
+                            "name": "projects/earthengine-public/assets/collection/second_feature"
+                        },
+                    ]
+                }
+            ),
+        ):
+
+            f = lyr.GetNextFeature()
+
+        assert (
+            f.GetField("name")
+            == "projects/earthengine-public/assets/collection/filtered_feature"
+        )
+
+        # Test time equality with day granularity
+        lyr.SetAttributeFilter("startTime = '1980-01-01' AND endTime = '1980-01-02'")
+
+        tmpfile = "/vsimem/ee/projects/earthengine-public/assets/collection:listImages?startTime=1980%2D01%2D01T00%3A00%3A00Z&endTime=1980%2D01%2D02T23%3A59%3A59Z"
+        with gdaltest.tempfile(
+            tmpfile,
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "name": "projects/earthengine-public/assets/collection/filtered_feature",
+                            "startTime": "1980-01-01T12:00:00Z",
+                            "endTime": "1980-01-02T23:59:59Z",
+                        },
+                        {
+                            "name": "projects/earthengine-public/assets/collection/second_feature"
+                        },
+                    ]
+                }
+            ),
+        ):
+
+            f = lyr.GetNextFeature()
+
+        assert (
+            f.GetField("name")
+            == "projects/earthengine-public/assets/collection/filtered_feature"
+        )
+
+        ds = None
 
 
 ###############################################################################
@@ -378,17 +387,13 @@ def test_eeda_2():
 
 def test_eeda_3():
 
-    gdal.SetConfigOption("EEDA_BEARER", "mybearer")
-    gdal.SetConfigOption("EEDA_URL", "/vsimem/ee/")
-    ds = ogr.Open("EEDA:##example_collection/example_subcollection")
-    gdal.SetConfigOption("EEDA_URL", None)
+    with gdal.config_options({"EEDA_BEARER": "mybearer", "EEDA_URL": "/vsimem/ee/"}):
+        ds = ogr.Open("EEDA:##example_collection/example_subcollection")
 
-    lyr = ds.GetLayer(0)
+        lyr = ds.GetLayer(0)
 
-    assert lyr.GetLayerDefn().GetFieldCount() == 8 + 7 + 4
-    ds = None
-
-    gdal.SetConfigOption("EEDA_BEARER", None)
+        assert lyr.GetLayerDefn().GetFieldCount() == 8 + 7 + 4
+        ds = None
 
 
 ###############################################################################
@@ -397,75 +402,77 @@ def test_eeda_3():
 
 def test_eeda_4():
 
-    gdal.SetConfigOption("EEDA_BEARER", "mybearer")
-    gdal.SetConfigOption("EEDA_URL", "/vsimem/ee/")
-
-    # User asset ID ("users/**").
-    tmpfile = (
-        "/vsimem/ee/projects/earthengine-legacy/assets/users/foo:listImages?pageSize=1"
-    )
-    with gdaltest.tempfile(
-        tmpfile,
-        json.dumps(
-            {"images": [{"name": "projects/earthengine-legacy/assets/users/foo/bar"}]}
-        ),
+    with gdaltest.config_options(
+        {"EEDA_BEARER": "mybearer", "EEDA_URL": "/vsimem/ee/"}
     ):
-        assert ogr.Open("EEDA:users/foo").GetLayer(0)
 
-    # Project asset ID ("projects/**").
-    tmpfile = "/vsimem/ee/projects/earthengine-legacy/assets/projects/foo:listImages?pageSize=1"
-    with gdaltest.tempfile(
-        tmpfile,
-        json.dumps(
-            {
-                "images": [
-                    {"name": "projects/earthengine-legacy/assets/projects/foo/bar"}
-                ]
-            }
-        ),
-    ):
-        ds = ogr.Open("EEDA:projects/foo")
-        assert ds.GetLayer(0)
-    ds = None
+        # User asset ID ("users/**").
+        tmpfile = "/vsimem/ee/projects/earthengine-legacy/assets/users/foo:listImages?pageSize=1"
+        with gdaltest.tempfile(
+            tmpfile,
+            json.dumps(
+                {
+                    "images": [
+                        {"name": "projects/earthengine-legacy/assets/users/foo/bar"}
+                    ]
+                }
+            ),
+        ):
+            assert ogr.Open("EEDA:users/foo").GetLayer(0)
 
-    # Multi-folder project asset ID ("projects/foo/bar/baz").
-    tmpfile = "/vsimem/ee/projects/earthengine-legacy/assets/projects/foo/bar/baz:listImages?pageSize=1"
-    with gdaltest.tempfile(
-        tmpfile,
-        json.dumps(
-            {
-                "images": [
-                    {
-                        "name": "projects/earthengine-legacy/assets/projects/foo/bar/baz/qux"
-                    }
-                ]
-            }
-        ),
-    ):
-        ds = ogr.Open("EEDA:projects/foo/bar/baz")
-        assert ds.GetLayer(0)
-    ds = None
+        # Project asset ID ("projects/**").
+        tmpfile = "/vsimem/ee/projects/earthengine-legacy/assets/projects/foo:listImages?pageSize=1"
+        with gdaltest.tempfile(
+            tmpfile,
+            json.dumps(
+                {
+                    "images": [
+                        {"name": "projects/earthengine-legacy/assets/projects/foo/bar"}
+                    ]
+                }
+            ),
+        ):
+            ds = ogr.Open("EEDA:projects/foo")
+            assert ds.GetLayer(0)
+        ds = None
 
-    # Public-catalog asset ID (e.g. "LANDSAT").
-    tmpfile = "/vsimem/ee/projects/earthengine-public/assets/foo:listImages?pageSize=1"
-    with gdaltest.tempfile(
-        tmpfile,
-        json.dumps(
-            {"images": [{"name": "projects/earthengine-public/assets/foo/bar"}]}
-        ),
-    ):
-        ds = ogr.Open("EEDA:foo")
-        assert ds.GetLayer(0)
-    ds = None
+        # Multi-folder project asset ID ("projects/foo/bar/baz").
+        tmpfile = "/vsimem/ee/projects/earthengine-legacy/assets/projects/foo/bar/baz:listImages?pageSize=1"
+        with gdaltest.tempfile(
+            tmpfile,
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "name": "projects/earthengine-legacy/assets/projects/foo/bar/baz/qux"
+                        }
+                    ]
+                }
+            ),
+        ):
+            ds = ogr.Open("EEDA:projects/foo/bar/baz")
+            assert ds.GetLayer(0)
+        ds = None
 
-    # Asset name ("projects/*/assets/**").
-    tmpfile = "/vsimem/ee/projects/foo/assets/bar:listImages?pageSize=1"
-    with gdaltest.tempfile(
-        tmpfile, json.dumps({"images": [{"name": "projects/foo/assets/bar/baz"}]})
-    ):
-        ds = ogr.Open("EEDA:projects/foo/assets/bar")
-        assert ds.GetLayer(0)
-    ds = None
+        # Public-catalog asset ID (e.g. "LANDSAT").
+        tmpfile = (
+            "/vsimem/ee/projects/earthengine-public/assets/foo:listImages?pageSize=1"
+        )
+        with gdaltest.tempfile(
+            tmpfile,
+            json.dumps(
+                {"images": [{"name": "projects/earthengine-public/assets/foo/bar"}]}
+            ),
+        ):
+            ds = ogr.Open("EEDA:foo")
+            assert ds.GetLayer(0)
+        ds = None
 
-    gdal.SetConfigOption("EEDA_BEARER", None)
-    gdal.SetConfigOption("EEDA_URL", None)
+        # Asset name ("projects/*/assets/**").
+        tmpfile = "/vsimem/ee/projects/foo/assets/bar:listImages?pageSize=1"
+        with gdaltest.tempfile(
+            tmpfile, json.dumps({"images": [{"name": "projects/foo/assets/bar/baz"}]})
+        ):
+            ds = ogr.Open("EEDA:projects/foo/assets/bar")
+            assert ds.GetLayer(0)
+        ds = None

--- a/autotest/ogr/ogr_elasticsearch.py
+++ b/autotest/ogr/ogr_elasticsearch.py
@@ -91,13 +91,11 @@ def startup_and_cleanup():
 
     ogrtest.elasticsearch_drv = ogr.GetDriverByName("Elasticsearch")
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
+    with gdal.config_option("CPL_CURL_ENABLE_VSIMEM", "YES"):
 
-    yield
+        yield
 
-    ogr_elasticsearch_delete_files()
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", None)
+        ogr_elasticsearch_delete_files()
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_factory.py
+++ b/autotest/ogr/ogr_factory.py
@@ -887,9 +887,8 @@ def test_ogr_factory_8():
     for (src_wkt, exp_wkt, target_type) in tests:
 
         src_geom = ogr.CreateGeometryFromWkt(src_wkt)
-        gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-        dst_geom = ogr.ForceTo(src_geom, target_type)
-        gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+        with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+            dst_geom = ogr.ForceTo(src_geom, target_type)
 
         if exp_wkt is None:
             exp_wkt = src_wkt

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -619,21 +619,19 @@ def test_ogr_fgdb_7(fgdb_drv):
     ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
     lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
     lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
-    gdal.SetConfigOption("FGDB_BULK_LOAD", "YES")
-    for i in range(1000):
-        feat = ogr.Feature(lyr.GetLayerDefn())
-        feat.SetField(0, i)
-        geom = ogr.CreateGeometryFromWkt("POINT(0 1)")
-        feat.SetGeometry(geom)
-        lyr.CreateFeature(feat)
-        feat = None
+    with gdal.config_option("FGDB_BULK_LOAD", "YES"):
+        for i in range(1000):
+            feat = ogr.Feature(lyr.GetLayerDefn())
+            feat.SetField(0, i)
+            geom = ogr.CreateGeometryFromWkt("POINT(0 1)")
+            feat.SetGeometry(geom)
+            lyr.CreateFeature(feat)
+            feat = None
 
-    lyr.ResetReading()
-    feat = lyr.GetNextFeature()
-    assert feat.GetField(0) == 0
-    ds = None
-
-    gdal.SetConfigOption("FGDB_BULK_LOAD", None)
+        lyr.ResetReading()
+        feat = lyr.GetNextFeature()
+        assert feat.GetField(0) == 0
+        ds = None
 
 
 ###############################################################################
@@ -1450,19 +1448,15 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     # Simulate an error case where StartTransaction() cannot copy backup files
     lyr_count = ds.GetLayerCount()
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE1")
-    with gdaltest.error_handler():
+    with gdal.config_option("FGDB_SIMUL_FAIL", "CASE1"), gdaltest.error_handler():
         ret = ds.StartTransaction(force=True)
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
     assert ret != 0
 
     assert ds.GetLayerCount() == lyr_count
 
     # Simulate an error case where StartTransaction() cannot reopen database
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE2")
-    with gdaltest.error_handler():
+    with gdal.config_option("FGDB_SIMUL_FAIL", "CASE2"), gdaltest.error_handler():
         ret = ds.StartTransaction(force=True)
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
     assert ret != 0
 
     assert ds.GetLayerCount() == 0
@@ -1543,10 +1537,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         ds.DeleteLayer(ds.GetLayerCount() - 1)
 
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE1")
-        with gdaltest.error_handler():
+        with gdal.config_option("FGDB_SIMUL_FAIL", "CASE1"), gdaltest.error_handler():
             ret = ds.CommitTransaction()
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
         assert ret != 0
 
         ds = None
@@ -1575,10 +1567,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
         lyr.SetFeature(f)
         f = None
 
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE2")
-        with gdaltest.error_handler():
+        with gdal.config_option("FGDB_SIMUL_FAIL", "CASE2"), gdaltest.error_handler():
             ret = ds.CommitTransaction()
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
         assert ret != 0
 
         ds = None
@@ -1602,10 +1592,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
         lyr.SetFeature(f)
         f = None
 
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE3")
-        with gdaltest.error_handler():
+        with gdal.config_option("FGDB_SIMUL_FAIL", "CASE3"), gdaltest.error_handler():
             ret = ds.CommitTransaction()
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
         assert ret != 0
 
         ds = None
@@ -1631,10 +1619,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
             lyr.SetFeature(f)
             f = None
 
-            gdal.SetConfigOption("FGDB_SIMUL_FAIL", case)
-            with gdaltest.error_handler():
+            with gdal.config_option("FGDB_SIMUL_FAIL", case), gdaltest.error_handler():
                 ret = ds.CommitTransaction()
-            gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
             assert ret == 0, case
 
             ds = None
@@ -1660,10 +1646,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         assert ds.StartTransaction(force=True) == 0
 
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE1")
-        with gdaltest.error_handler():
+        with gdal.config_option("FGDB_SIMUL_FAIL", "CASE1"), gdaltest.error_handler():
             ret = ds.CommitTransaction()
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
         assert ret != 0
 
         ds = None
@@ -1677,10 +1661,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         assert ds.StartTransaction(force=True) == 0
 
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE2")
-        with gdaltest.error_handler():
+        with gdal.config_option("FGDB_SIMUL_FAIL", "CASE2"), gdaltest.error_handler():
             ret = ds.CommitTransaction()
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
         assert ret != 0
 
         ds = None
@@ -1695,10 +1677,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         assert ds.StartTransaction(force=True) == 0
 
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE3")
-        with gdaltest.error_handler():
+        with gdal.config_option("FGDB_SIMUL_FAIL", "CASE3"), gdaltest.error_handler():
             ret = ds.CommitTransaction()
-        gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
         assert ret == 0
 
         ds = None
@@ -1713,10 +1693,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     assert ds.StartTransaction(force=True) == 0
 
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE_REOPEN")
-    with gdaltest.error_handler():
+    with gdal.config_option("FGDB_SIMUL_FAIL", "CASE_REOPEN"), gdaltest.error_handler():
         ret = ds.CommitTransaction()
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
     assert ret != 0
 
     assert ds.GetLayerCount() == 0
@@ -1732,10 +1710,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     assert ds.StartTransaction(force=True) == 0
 
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE1")
-    with gdaltest.error_handler():
+    with gdal.config_option("FGDB_SIMUL_FAIL", "CASE1"), gdaltest.error_handler():
         ret = ds.RollbackTransaction()
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
     assert ret != 0
 
     ds = None
@@ -1750,10 +1726,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     assert ds.StartTransaction(force=True) == 0
 
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", "CASE2")
-    with gdaltest.error_handler():
+    with gdal.config_option("FGDB_SIMUL_FAIL", "CASE2"), gdaltest.error_handler():
         ret = ds.RollbackTransaction()
-    gdal.SetConfigOption("FGDB_SIMUL_FAIL", None)
     assert ret != 0
 
     assert ds.GetLayerCount() == 0
@@ -1787,9 +1761,8 @@ def test_ogr_fgdb_19bis(openfilegdb_drv, fgdb_drv):
     if not bPerLayerCopyingForTransaction:
         pytest.skip()
 
-    gdal.SetConfigOption("FGDB_PER_LAYER_COPYING_TRANSACTION", "FALSE")
-    ret = test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv)
-    gdal.SetConfigOption("FGDB_PER_LAYER_COPYING_TRANSACTION", None)
+    with gdal.config_option("FGDB_PER_LAYER_COPYING_TRANSACTION", "FALSE"):
+        ret = test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv)
     return ret
 
 
@@ -2101,19 +2074,17 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     # Multi-page indexes
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(32630)
-    gdal.SetConfigOption("FGDB_RESYNC_THRESHOLD", "600")
-    lyr = ds.CreateLayer("ogr_fgdb_20_indexes", geom_type=ogr.wkbPoint, srs=srs)
-    gdal.SetConfigOption("FGDB_RESYNC_THRESHOLD", None)
+    with gdal.config_option("FGDB_RESYNC_THRESHOLD", "600"):
+        lyr = ds.CreateLayer("ogr_fgdb_20_indexes", geom_type=ogr.wkbPoint, srs=srs)
     lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
     ds.ExecuteSQL("CREATE INDEX ogr_fgdb_20_indexes_id ON ogr_fgdb_20_indexes(id)")
-    gdal.SetConfigOption("FGDB_BULK_LOAD", "YES")
-    for i in range(1000):
-        f = ogr.Feature(lyr.GetLayerDefn())
-        f.SetFID(i + 2)
-        f.SetField("id", i + 2)
-        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (%d 0)" % i))
-        lyr.CreateFeature(f)
-    gdal.SetConfigOption("FGDB_BULK_LOAD", None)
+    with gdal.config_option("FGDB_BULK_LOAD", "YES"):
+        for i in range(1000):
+            f = ogr.Feature(lyr.GetLayerDefn())
+            f.SetFID(i + 2)
+            f.SetField("id", i + 2)
+            f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (%d 0)" % i))
+            lyr.CreateFeature(f)
     ds = None
 
     # Check consistency after re-opening
@@ -2258,9 +2229,8 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
         lyr.CreateFeature(f)
 
         with gdaltest.error_handler():
-            gdal.SetConfigOption("FGDB_SIMUL_FAIL_REOPEN", case)
-            sql_lyr = ds.ExecuteSQL("SELECT * FROM foo")
-            gdal.SetConfigOption("FGDB_SIMUL_FAIL_REOPEN", None)
+            with gdal.config_option("FGDB_SIMUL_FAIL_REOPEN", case):
+                sql_lyr = ds.ExecuteSQL("SELECT * FROM foo")
         if case == "CASE3":
             assert sql_lyr is not None, case
             ds.ReleaseResultSet(sql_lyr)

--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -560,11 +560,10 @@ def test_ogr_wfs_fake_wfs_server():
     if port == 0:
         pytest.skip()
 
-    gdal.SetConfigOption("OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN", "NO")
-    ds = ogr.Open(
-        "WFS:http://127.0.0.1:%d/fakewfs?OUTPUTFORMAT=application/flatgeobuf" % port
-    )
-    gdal.SetConfigOption("OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN", None)
+    with gdal.config_option("OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN", "NO"):
+        ds = ogr.Open(
+            "WFS:http://127.0.0.1:%d/fakewfs?OUTPUTFORMAT=application/flatgeobuf" % port
+        )
     if ds is None:
         webserver.server_stop(process, port)
         pytest.fail("did not managed to open WFS datastore")

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -1401,7 +1401,7 @@ def test_ogr_geom_triangle_invalid_wkt():
 def test_ogr_geom_triangle_sfcgal():
 
     if not ogrtest.have_sfcgal():
-        pytest.skip()
+        pytest.skip("SFCGAL is not available")
 
     g1 = ogr.CreateGeometryFromWkt("TRIANGLE ((0 0,100 0 100,0 100 100,0 0))")
     g2 = ogr.CreateGeometryFromWkt("TRIANGLE ((-1 -1,100 0 100,0 100 100,-1 -1))")
@@ -3816,7 +3816,7 @@ def test_ogr_geom_remove_geometry():
 def test_ogr_geom_sfcgal():
 
     if not ogrtest.have_sfcgal():
-        pytest.skip()
+        pytest.skip("SFCGAL is not available")
 
     g1 = ogr.CreateGeometryFromWkt("TIN EMPTY")
 

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -1500,12 +1500,9 @@ def test_ogr_geom_circularstring():
     assert in_wkt == out_wkt
 
     # Test stroking
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "TRUE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    in_wkt = "CIRCULARSTRING (0 0,1 1,1 -1)"
-    g1 = ogr.CreateGeometryFromWkt(in_wkt)
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "FALSE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_options({"OGR_STROKE_CURVE": "TRUE", "OGR_ARC_STEPSIZE": "45"}):
+        in_wkt = "CIRCULARSTRING (0 0,1 1,1 -1)"
+        g1 = ogr.CreateGeometryFromWkt(in_wkt)
 
     expected_g = ogr.CreateGeometryFromWkt(
         "LINESTRING (0 0,0.218168517531969 0.623489801858729,0.777479066043687 0.974927912181831,1.433883739117561 0.900968867902435,1.900968867902463 0.433883739117562,1.974927912181821 -0.222520933956316,1.623489801858719 -0.78183148246804,1 -1)"
@@ -1516,11 +1513,8 @@ def test_ogr_geom_circularstring():
     g1 = ogr.CreateGeometryFromWkt(in_wkt)
     in_wkb = g1.ExportToWkb()
 
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "TRUE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.CreateGeometryFromWkb(in_wkb)
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "FALSE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_options({"OGR_STROKE_CURVE": "TRUE", "OGR_ARC_STEPSIZE": "45"}):
+        g2 = ogr.CreateGeometryFromWkb(in_wkb)
 
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
@@ -1533,18 +1527,16 @@ def test_ogr_geom_circularstring():
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
     # Test ForceToLineString
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToLineString(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
     # Test ForceToMultiLineString
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    expected_g2 = ogr.CreateGeometryFromWkt(
-        "MULTILINESTRING ((0 0,0.218168517531969 0.623489801858729,0.777479066043687 0.974927912181831,1.433883739117561 0.900968867902435,1.900968867902463 0.433883739117562,1.974927912181821 -0.222520933956316,1.623489801858719 -0.78183148246804,1 -1))"
-    )
-    g2 = ogr.ForceToMultiLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        expected_g2 = ogr.CreateGeometryFromWkt(
+            "MULTILINESTRING ((0 0,0.218168517531969 0.623489801858729,0.777479066043687 0.974927912181831,1.433883739117561 0.900968867902435,1.900968867902463 0.433883739117562,1.974927912181821 -0.222520933956316,1.623489801858719 -0.78183148246804,1 -1))"
+        )
+        g2 = ogr.ForceToMultiLineString(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g2) == 0
 
     # Test GEOS operations
@@ -1562,15 +1554,13 @@ def test_ogr_geom_circularstring():
         assert g2 is not None
 
     # Test ForceToLineString
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToLineString(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
     # Test ForceToMultiLineString
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToMultiLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToMultiLineString(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g2) == 0
 
     # Test stroking of full circle with 3 points. ISO draft
@@ -1954,12 +1944,9 @@ def test_ogr_geom_compoundcurve():
     assert in_wkt == out_wkt
 
     # Test stroking
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "TRUE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    in_wkt = "COMPOUNDCURVE (CIRCULARSTRING (0 0,1 1,1 -1))"
-    g1 = ogr.CreateGeometryFromWkt(in_wkt)
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "FALSE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_options({"OGR_STROKE_CURVE": "TRUE", "OGR_ARC_STEPSIZE": "45"}):
+        in_wkt = "COMPOUNDCURVE (CIRCULARSTRING (0 0,1 1,1 -1))"
+        g1 = ogr.CreateGeometryFromWkt(in_wkt)
 
     expected_g = ogr.CreateGeometryFromWkt(
         "LINESTRING (0 0,0.218168517531969 0.623489801858729,0.777479066043687 0.974927912181831,1.433883739117561 0.900968867902435,1.900968867902463 0.433883739117562,1.974927912181821 -0.222520933956316,1.623489801858719 -0.78183148246804,1 -1)"
@@ -1970,11 +1957,8 @@ def test_ogr_geom_compoundcurve():
     g1 = ogr.CreateGeometryFromWkt(in_wkt)
     in_wkb = g1.ExportToWkb()
 
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "TRUE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.CreateGeometryFromWkb(in_wkb)
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "FALSE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_options({"OGR_STROKE_CURVE": "TRUE", "OGR_ARC_STEPSIZE": "45"}):
+        g2 = ogr.CreateGeometryFromWkb(in_wkb)
 
     expected_g = ogr.CreateGeometryFromWkt(
         "LINESTRING (0 0,0.218168517531969 0.623489801858729,0.777479066043687 0.974927912181831,1.433883739117561 0.900968867902435,1.900968867902463 0.433883739117562,1.974927912181821 -0.222520933956316,1.623489801858719 -0.78183148246804,1 -1)"
@@ -1991,17 +1975,15 @@ def test_ogr_geom_compoundcurve():
     g2 = g1.GetLinearGeometry(45)
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToLineString(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    expected_g = ogr.CreateGeometryFromWkt(
-        "MULTILINESTRING ((0 0,0.218168517531969 0.623489801858729,0.777479066043687 0.974927912181831,1.433883739117561 0.900968867902435,1.900968867902463 0.433883739117562,1.974927912181821 -0.222520933956316,1.623489801858719 -0.78183148246804,1 -1))"
-    )
-    g2 = ogr.ForceToMultiLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        expected_g = ogr.CreateGeometryFromWkt(
+            "MULTILINESTRING ((0 0,0.218168517531969 0.623489801858729,0.777479066043687 0.974927912181831,1.433883739117561 0.900968867902435,1.900968867902463 0.433883739117562,1.974927912181821 -0.222520933956316,1.623489801858719 -0.78183148246804,1 -1))"
+        )
+        g2 = ogr.ForceToMultiLineString(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
     # Check segmentize
@@ -2167,12 +2149,9 @@ def test_ogr_geom_curvepolygon():
     assert in_wkt == out_wkt
 
     # Test stroking
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "TRUE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    in_wkt = "CURVEPOLYGON (CIRCULARSTRING (0 0,1 0,0 0))"
-    g1 = ogr.CreateGeometryFromWkt(in_wkt)
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "FALSE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_options({"OGR_STROKE_CURVE": "TRUE", "OGR_ARC_STEPSIZE": "45"}):
+        in_wkt = "CURVEPOLYGON (CIRCULARSTRING (0 0,1 0,0 0))"
+        g1 = ogr.CreateGeometryFromWkt(in_wkt)
 
     expected_g = ogr.CreateGeometryFromWkt(
         "POLYGON ((0 0,0.116977778440514 -0.321393804843282,0.413175911166547 -0.49240387650611,0.75 -0.433012701892224,0.969846310392967 -0.171010071662835,0.969846310392967 0.171010071662835,0.75 0.433012701892224,0.413175911166547 0.49240387650611,0.116977778440514 0.321393804843282,0 0))"
@@ -2183,11 +2162,8 @@ def test_ogr_geom_curvepolygon():
     g1 = ogr.CreateGeometryFromWkt(in_wkt)
     in_wkb = g1.ExportToWkb()
 
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "TRUE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.CreateGeometryFromWkb(in_wkb)
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "FALSE")
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_options({"OGR_STROKE_CURVE": "TRUE", "OGR_ARC_STEPSIZE": "45"}):
+        g2 = ogr.CreateGeometryFromWkb(in_wkb)
 
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
@@ -2200,24 +2176,21 @@ def test_ogr_geom_curvepolygon():
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
     # Test ForceToPolygon
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToPolygon(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToPolygon(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
     # Test ForceToMultiPolygon
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    expected_g2 = ogr.CreateGeometryFromWkt(
-        "MULTIPOLYGON (((0 0,0.116977778440514 -0.321393804843282,0.413175911166547 -0.49240387650611,0.75 -0.433012701892224,0.969846310392967 -0.171010071662835,0.969846310392967 0.171010071662835,0.75 0.433012701892224,0.413175911166547 0.49240387650611,0.116977778440514 0.321393804843282,0 0)))"
-    )
-    g2 = ogr.ForceToMultiPolygon(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        expected_g2 = ogr.CreateGeometryFromWkt(
+            "MULTIPOLYGON (((0 0,0.116977778440514 -0.321393804843282,0.413175911166547 -0.49240387650611,0.75 -0.433012701892224,0.969846310392967 -0.171010071662835,0.969846310392967 0.171010071662835,0.75 0.433012701892224,0.413175911166547 0.49240387650611,0.116977778440514 0.321393804843282,0 0)))"
+        )
+        g2 = ogr.ForceToMultiPolygon(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g2) == 0
 
     # Test ForceToMultiLineString
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToMultiLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToMultiLineString(g1)
     expected_g3 = ogr.CreateGeometryFromWkt(
         "MULTILINESTRING ((0 0,0.116977778440514 -0.321393804843282,0.413175911166547 -0.49240387650611,0.75 -0.433012701892224,0.969846310392967 -0.171010071662835,0.969846310392967 0.171010071662835,0.75 0.433012701892224,0.413175911166547 0.49240387650611,0.116977778440514 0.321393804843282,0 0))"
     )
@@ -2246,15 +2219,13 @@ def test_ogr_geom_curvepolygon():
         assert g2 is not None
 
     # Test ForceToPolygon
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToPolygon(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToPolygon(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
     # Test ForceToMultiPolygon
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToMultiPolygon(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToMultiPolygon(g1)
     assert ogrtest.check_feature_geometry(g2, expected_g2) == 0
 
     # Error case : not enough points
@@ -2313,12 +2284,11 @@ def test_ogr_geom_curvepolygon():
         % (1 + math.cos(math.pi / 6) - 1e-4, math.sin(math.pi / 6))
     )
     # To prove that we don't use discretization
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    res = g1.Intersects(p1)
-    res = res & p1.Intersects(g1)
-    res = res & g1.Contains(p1)
-    res = res & p1.Within(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        res = g1.Intersects(p1)
+        res = res & p1.Intersects(g1)
+        res = res & g1.Contains(p1)
+        res = res & p1.Within(g1)
     assert res
 
     # Test point slightly outside circle
@@ -2464,9 +2434,8 @@ def test_ogr_geom_multicurve():
     assert in_wkt == out_wkt
 
     # Test ForceToMultiLineString
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToMultiLineString(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToMultiLineString(g1)
     expected_g = "MULTILINESTRING ((0 0,0.116977778440514 -0.321393804843282,0.413175911166547 -0.49240387650611,0.75 -0.433012701892224,0.969846310392967 -0.171010071662835,0.969846310392967 0.171010071662835,0.75 0.433012701892224,0.413175911166547 0.49240387650611,0.116977778440514 0.321393804843282,0 0),(0 0,1 1),(0 0,1 1,2 2,3 3))"
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 
@@ -2540,9 +2509,8 @@ def test_ogr_geom_multisurface():
     assert in_wkt == out_wkt
 
     # Test ForceToMultiPolygon
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", "45")
-    g2 = ogr.ForceToMultiPolygon(g1)
-    gdal.SetConfigOption("OGR_ARC_STEPSIZE", None)
+    with gdal.config_option("OGR_ARC_STEPSIZE", "45"):
+        g2 = ogr.ForceToMultiPolygon(g1)
     expected_g = "MULTIPOLYGON (((0 0,0 10,10 10,10 0,0 0)),((0 0,0.116977778440514 -0.321393804843282,0.413175911166547 -0.49240387650611,0.75 -0.433012701892224,0.969846310392967 -0.171010071662835,0.969846310392967 0.171010071662835,0.75 0.433012701892224,0.413175911166547 0.49240387650611,0.116977778440514 0.321393804843282,0 0)))"
     assert ogrtest.check_feature_geometry(g2, expected_g) == 0
 

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -356,9 +356,8 @@ def test_ogr_gml_7():
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    gdal.SetConfigOption("GML_EXPOSE_FID", "FALSE")
-    gml_ds = ogr.Open("data/gml/test_point.gml")
-    gdal.SetConfigOption("GML_EXPOSE_FID", None)
+    with gdal.config_option("GML_EXPOSE_FID", "FALSE"):
+        gml_ds = ogr.Open("data/gml/test_point.gml")
     lyr = gml_ds.GetLayer()
     ldefn = lyr.GetLayerDefn()
 
@@ -676,17 +675,24 @@ def test_ogr_gml_14():
     for f in files:
         gdaltest.download_or_skip("http://download.osgeo.org/gdal/data/gml/" + f, f)
 
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", "NONE")
-    gdal.SetConfigOption("GML_SAVE_RESOLVED_TO", "tmp/cache/xlink1resolved.gml")
-    with gdaltest.error_handler():
-        gml_ds = ogr.Open("tmp/cache/xlink1.gml")
+    with gdal.config_options(
+        {
+            "GML_SKIP_RESOLVE_ELEMS": "NONE",
+            "GML_SAVE_RESOLVED_TO": "tmp/cache/xlink1resolved.gml",
+        }
+    ):
+        with gdaltest.error_handler():
+            gml_ds = ogr.Open("tmp/cache/xlink1.gml")
     gml_ds = None
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", "gml:directedNode")
-    gdal.SetConfigOption("GML_SAVE_RESOLVED_TO", "tmp/cache/xlink2resolved.gml")
-    gml_ds = ogr.Open("tmp/cache/xlink1.gml")
-    del gml_ds
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", None)
-    gdal.SetConfigOption("GML_SAVE_RESOLVED_TO", None)
+
+    with gdal.config_options(
+        {
+            "GML_SKIP_RESOLVE_ELEMS": "gml:directedNode",
+            "GML_SAVE_RESOLVED_TO": "tmp/cache/xlink2resolved.gml",
+        }
+    ):
+        gml_ds = ogr.Open("tmp/cache/xlink1.gml")
+        del gml_ds
 
     try:
         fp = open("tmp/cache/xlink1resolved.gml", "r")
@@ -883,9 +889,8 @@ def test_ogr_gml_19():
     except OSError:
         pass
 
-    gdal.SetConfigOption("GML_INVERT_AXIS_ORDER_IF_LAT_LONG", "NO")
-    ds = ogr.Open("data/gml/gnis_pop_110.gml")
-    gdal.SetConfigOption("GML_INVERT_AXIS_ORDER_IF_LAT_LONG", None)
+    with gdal.config_option("GML_INVERT_AXIS_ORDER_IF_LAT_LONG", "NO"):
+        ds = ogr.Open("data/gml/gnis_pop_110.gml")
 
     lyr = ds.GetLayer(0)
     sr = lyr.GetSpatialRef()
@@ -1151,9 +1156,8 @@ def test_ogr_gml_25():
     except OSError:
         pass
 
-    gdal.SetConfigOption("GML_FACE_HOLE_NEGATIVE", "YES")
-    ds = ogr.Open("data/gml/curveProperty.xml")
-    gdal.SetConfigOption("GML_FACE_HOLE_NEGATIVE", None)
+    with gdal.config_option("GML_FACE_HOLE_NEGATIVE", "YES"):
+        ds = ogr.Open("data/gml/curveProperty.xml")
 
     lyr = ds.GetLayer(0)
 
@@ -1366,14 +1370,12 @@ def test_ogr_gml_31():
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    gdal.SetConfigOption("GML_READ_MODE", "SEQUENTIAL_LAYERS")
-    test_ogr_gml_29()
-    gdal.SetConfigOption("GML_READ_MODE", None)
+    with gdal.config_option("GML_READ_MODE", "SEQUENTIAL_LAYERS"):
+        test_ogr_gml_29()
 
     # Test reading second layer and then first layer
-    gdal.SetConfigOption("GML_READ_MODE", "SEQUENTIAL_LAYERS")
-    ds = ogr.Open("data/gml/testfmegml.gml")
-    gdal.SetConfigOption("GML_READ_MODE", None)
+    with gdal.config_option("GML_READ_MODE", "SEQUENTIAL_LAYERS"):
+        ds = ogr.Open("data/gml/testfmegml.gml")
 
     lyr = ds.GetLayer(1)
     feat = lyr.GetNextFeature()
@@ -1437,9 +1439,8 @@ def test_ogr_gml_33():
         pytest.skip()
 
     # Test reading second layer and then first layer
-    gdal.SetConfigOption("GML_READ_MODE", "INTERLEAVED_LAYERS")
-    ds = ogr.Open("data/gml/testfmegml_interleaved.gml")
-    gdal.SetConfigOption("GML_READ_MODE", None)
+    with gdal.config_option("GML_READ_MODE", "INTERLEAVED_LAYERS"):
+        ds = ogr.Open("data/gml/testfmegml_interleaved.gml")
 
     read_sequence = [
         [0, 1],
@@ -1523,9 +1524,8 @@ def test_ogr_gml_35():
 
     shutil.copy("data/gml/GmlTopo-sample.xml", "tmp/GmlTopo-sample.xml")
 
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", "HUGE")
-    ds = ogr.Open("tmp/GmlTopo-sample.xml")
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", None)
+    with gdal.config_option("GML_SKIP_RESOLVE_ELEMS", "HUGE"):
+        ds = ogr.Open("tmp/GmlTopo-sample.xml")
 
     assert not os.path.exists("tmp/GmlTopo-sample.sqlite")
 
@@ -1571,11 +1571,13 @@ def test_ogr_gml_36(GML_FACE_HOLE_NEGATIVE="NO"):
 
     shutil.copy("data/gml/GmlTopo-sample.xml", "tmp/GmlTopo-sample.xml")
 
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", "NONE")
-    gdal.SetConfigOption("GML_FACE_HOLE_NEGATIVE", GML_FACE_HOLE_NEGATIVE)
-    ds = ogr.Open("tmp/GmlTopo-sample.xml")
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", None)
-    gdal.SetConfigOption("GML_FACE_HOLE_NEGATIVE", None)
+    with gdal.config_options(
+        {
+            "GML_SKIP_RESOLVE_ELEMS": "NONE",
+            "GML_FACE_HOLE_NEGATIVE": GML_FACE_HOLE_NEGATIVE,
+        }
+    ):
+        ds = ogr.Open("tmp/GmlTopo-sample.xml")
     assert gdal.GetLastErrorMsg() == "", "did not expect error"
 
     lyr = ds.GetLayerByName("Suolo")
@@ -1588,9 +1590,8 @@ def test_ogr_gml_36(GML_FACE_HOLE_NEGATIVE="NO"):
 
     ds = None
 
-    gdal.SetConfigOption("GML_FACE_HOLE_NEGATIVE", GML_FACE_HOLE_NEGATIVE)
-    ds = ogr.Open("tmp/GmlTopo-sample.xml")
-    gdal.SetConfigOption("GML_FACE_HOLE_NEGATIVE", None)
+    with gdal.config_option("GML_FACE_HOLE_NEGATIVE", GML_FACE_HOLE_NEGATIVE):
+        ds = ogr.Open("tmp/GmlTopo-sample.xml")
     lyr = ds.GetLayerByName("Suolo")
     feat = lyr.GetNextFeature()
     assert not ogrtest.check_feature_geometry(feat, wkt), feat.GetGeometryRef()
@@ -1633,9 +1634,8 @@ def internal_ogr_gml_38(resolver):
         "tmp/sample_gml_face_hole_negative_no.xml",
     )
 
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", resolver)
-    ds = ogr.Open("tmp/sample_gml_face_hole_negative_no.xml")
-    gdal.SetConfigOption("GML_SKIP_RESOLVE_ELEMS", None)
+    with gdal.config_option("GML_SKIP_RESOLVE_ELEMS", resolver):
+        ds = ogr.Open("tmp/sample_gml_face_hole_negative_no.xml")
     gdal.SetConfigOption("GML_FACE_HOLE_NEGATIVE", None)
 
     if resolver == "HUGE":
@@ -1708,11 +1708,10 @@ def test_ogr_gml_41():
 
     ds = ogr.Open("data/gml/expected_gml_gml3.gml")
 
-    gdal.SetConfigOption(
+    with gdal.config_option(
         "GDAL_OPENGIS_SCHEMAS", "/vsizip/./tmp/cache/SCHEMAS_OPENGIS_NET.zip"
-    )
-    lyr = ds.ExecuteSQL("SELECT ValidateSchema()")
-    gdal.SetConfigOption("GDAL_OPENGIS_SCHEMAS", None)
+    ):
+        lyr = ds.ExecuteSQL("SELECT ValidateSchema()")
 
     feat = lyr.GetNextFeature()
     val = feat.GetFieldAsInteger(0)
@@ -1758,9 +1757,8 @@ def validate(filename):
 
     ds = ogr.Open(filename)
 
-    gdal.SetConfigOption("GDAL_OPENGIS_SCHEMAS", "./tmp/cache/SCHEMAS_OPENGIS_NET")
-    lyr = ds.ExecuteSQL("SELECT ValidateSchema()")
-    gdal.SetConfigOption("GDAL_OPENGIS_SCHEMAS", None)
+    with gdal.config_option("GDAL_OPENGIS_SCHEMAS", "./tmp/cache/SCHEMAS_OPENGIS_NET"):
+        lyr = ds.ExecuteSQL("SELECT ValidateSchema()")
 
     feat = lyr.GetNextFeature()
     val = feat.GetFieldAsInteger(0)
@@ -1787,7 +1785,7 @@ def test_ogr_gml_42():
 def test_ogr_gml_43():
 
     # The service times out
-    pytest.skip()
+    pytest.skip("Test disabled because service regularly times out")
 
     # pylint: disable=unreachable
     if not gdaltest.have_gml_reader:
@@ -2376,9 +2374,8 @@ def test_ogr_gml_56():
 
     gdal.Unlink("data/gml/ogr_gml_56.gfs")
 
-    gdal.SetConfigOption("GML_REGISTRY", "data/gml/ogr_gml_56_registry.xml")
-    ds = ogr.Open("data/gml/ogr_gml_56.gml")
-    gdal.SetConfigOption("GML_REGISTRY", None)
+    with gdal.config_option("GML_REGISTRY", "data/gml/ogr_gml_56_registry.xml"):
+        ds = ogr.Open("data/gml/ogr_gml_56.gml")
     lyr = ds.GetLayerByName("mainFeature")
     assert lyr.GetSpatialRef() is not None
     feat = lyr.GetNextFeature()
@@ -2955,19 +2952,17 @@ def test_ogr_gml_63():
 # Test multiple instances of parsers (#5571)
 
 
-def test_ogr_gml_64():
+@pytest.mark.parametrize("parser", ("XERCES", "EXPAT"))
+def test_ogr_gml_64(parser):
 
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    for parser in ["XERCES", "EXPAT"]:
-        for _ in range(2):
-            gdal.SetConfigOption("GML_PARSER", parser)
-            ds = ogr.Open("data/gml/rnf_eg.gml")
-            gdal.SetConfigOption("GML_PARSER", None)
-            lyr = ds.GetLayer(0)
-            feat = lyr.GetNextFeature()
-            assert feat is not None, parser
+    with gdal.config_option("GML_PARSER", parser):
+        ds = ogr.Open("data/gml/rnf_eg.gml")
+    lyr = ds.GetLayer(0)
+    feat = lyr.GetNextFeature()
+    assert feat is not None, parser
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_gmlas.py
+++ b/autotest/ogr/ogr_gmlas.py
@@ -1617,20 +1617,19 @@ def test_ogr_gmlas_xlink_resolver():
     # Enable remote resolution (but local caching disabled)
     gdal.FileFromMemBuffer("/vsimem/resource.xml", "bar")
     gdal.FileFromMemBuffer("/vsimem/resource2.xml", "baz")
-    gdal.SetConfigOption("GMLAS_XLINK_RAM_CACHE_SIZE", "5")
-    ds = gdal.OpenEx(
-        "GMLAS:/vsimem/ogr_gmlas_xlink_resolver.xml",
-        open_options=[
-            """CONFIG_FILE=<Configuration>
-        <XLinkResolution>
-            <CacheDirectory>/vsimem/gmlas_xlink_cache</CacheDirectory>
-            <DefaultResolution enabled="true">
-                <AllowRemoteDownload>true</AllowRemoteDownload>
-            </DefaultResolution>
-        </XLinkResolution></Configuration>"""
-        ],
-    )
-    gdal.SetConfigOption("GMLAS_XLINK_RAM_CACHE_SIZE", None)
+    with gdal.config_option("GMLAS_XLINK_RAM_CACHE_SIZE", "5"):
+        ds = gdal.OpenEx(
+            "GMLAS:/vsimem/ogr_gmlas_xlink_resolver.xml",
+            open_options=[
+                """CONFIG_FILE=<Configuration>
+            <XLinkResolution>
+                <CacheDirectory>/vsimem/gmlas_xlink_cache</CacheDirectory>
+                <DefaultResolution enabled="true">
+                    <AllowRemoteDownload>true</AllowRemoteDownload>
+                </DefaultResolution>
+            </XLinkResolution></Configuration>"""
+            ],
+        )
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     if f["my_link_rawcontent"] != "bar":

--- a/autotest/ogr/ogr_gmt.py
+++ b/autotest/ogr/ogr_gmt.py
@@ -177,9 +177,8 @@ def test_ogr_gmt_5():
         )
     )
     dst_feat.SetField("ID", 15)
-    gdal.SetConfigOption("GMT_USE_TAB", "TRUE")  # Ticket #6453
-    gmt_lyr.CreateFeature(dst_feat)
-    gdal.SetConfigOption("GMT_USE_TAB", None)
+    with gdal.config_option("GMT_USE_TAB", "TRUE"):  # Ticket #6453
+        gmt_lyr.CreateFeature(dst_feat)
 
     dst_feat = ogr.Feature(feature_def=gmt_lyr.GetLayerDefn())
     dst_feat.SetGeometryDirectly(

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -66,11 +66,9 @@ def startup_and_cleanup():
     # This is to speed-up the runtime of tests on EXT4 filesystems
     # Do not use this for production environment if you care about data safety
     # w.r.t system/OS crashes, unless you know what you are doing.
-    gdal.SetConfigOption("OGR_SQLITE_SYNCHRONOUS", "OFF")
+    with gdal.config_option("OGR_SQLITE_SYNCHRONOUS", "OFF"):
 
-    yield
-
-    gdal.SetConfigOption("OGR_SQLITE_SYNCHRONOUS", None)
+        yield
 
     if gdal.ReadDir("/vsimem") is not None:
         print(gdal.ReadDir("/vsimem"))
@@ -1735,11 +1733,11 @@ def test_ogr_gpkg_20():
 
     ds.ExecuteSQL("DELETE FROM gpkg_spatial_ref_sys WHERE srs_id = 4326")
     ds = None
-    gdal.SetConfigOption("OGR_GPKG_FOREIGN_KEY_CHECK", "NO")
-    # Warning 1: unable to read srs_id '4326' from gpkg_spatial_ref_sys
-    with gdaltest.error_handler():
+    with gdal.config_option(
+        "OGR_GPKG_FOREIGN_KEY_CHECK", "NO"
+    ), gdaltest.error_handler():
+        # Warning 1: unable to read srs_id '4326' from gpkg_spatial_ref_sys
         ds = ogr.Open("/vsimem/ogr_gpkg_20.gpkg", update=1)
-    gdal.SetConfigOption("OGR_GPKG_FOREIGN_KEY_CHECK", None)
     ds = None
 
     gdal.Unlink("/vsimem/ogr_gpkg_20.gpkg")
@@ -1762,9 +1760,10 @@ def test_ogr_gpkg_20():
     )
     ds = None
 
-    gdal.SetConfigOption("OGR_GPKG_FOREIGN_KEY_CHECK", "NO")
     # Warning 1: null definition for srs_id '4326' in gpkg_spatial_ref_sys
-    with gdaltest.error_handler():
+    with gdal.config_option(
+        "OGR_GPKG_FOREIGN_KEY_CHECK", "NO"
+    ), gdaltest.error_handler():
         ds = ogr.Open("/vsimem/ogr_gpkg_20.gpkg", update=1)
     ds = None
 
@@ -2990,11 +2989,10 @@ def test_ogr_gpkg_32():
 
 def test_ogr_gpkg_33():
 
-    gdal.SetConfigOption("OGR_CURRENT_DATE", "2000-01-01T:00:00:00.000Z")
-    ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_33.gpkg")
-    ds.CreateLayer("test", geom_type=ogr.wkbNone)
-    ds = None
-    gdal.SetConfigOption("OGR_CURRENT_DATE", None)
+    with gdal.config_option("OGR_CURRENT_DATE", "2000-01-01T:00:00:00.000Z"):
+        ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_33.gpkg")
+        ds.CreateLayer("test", geom_type=ogr.wkbNone)
+        ds = None
 
     ds = ogr.Open("/vsimem/ogr_gpkg_33.gpkg")
     sql_lyr = ds.ExecuteSQL(
@@ -3999,11 +3997,10 @@ def test_ogr_gpkg_43():
 
 def test_ogr_gpkg_44():
 
-    gdal.SetConfigOption("CREATE_METADATA_TABLES", "NO")
-    ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_44.gpkg")
-    ds.CreateLayer("foo")
-    ds = None
-    gdal.SetConfigOption("CREATE_METADATA_TABLES", None)
+    with gdal.config_option("CREATE_METADATA_TABLES", "NO"):
+        ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_44.gpkg")
+        ds.CreateLayer("foo")
+        ds = None
 
     assert validate("/vsimem/ogr_gpkg_44.gpkg"), "validation failed"
 
@@ -4180,9 +4177,8 @@ def test_ogr_gpkg_47():
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO")
-    ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", None)
+    with gdal.config_option("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO"):
+        ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
     assert gdal.GetLastErrorMsg() == ""
 
     gdaltest.gpkg_dr.CreateDataSource(
@@ -4202,9 +4198,8 @@ def test_ogr_gpkg_47():
     ds = None
 
     gdal.ErrorReset()
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO")
-    ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", None)
+    with gdal.config_option("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO"):
+        ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
     assert gdal.GetLastErrorMsg() == ""
 
     # Set GPKG 1.2.1
@@ -4226,9 +4221,8 @@ def test_ogr_gpkg_47():
     ds = None
 
     gdal.ErrorReset()
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO")
-    ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", None)
+    with gdal.config_option("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO"):
+        ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
     assert gdal.GetLastErrorMsg() == ""
 
     # Set GPKG 1.3.0
@@ -4248,9 +4242,8 @@ def test_ogr_gpkg_47():
     ds = None
 
     gdal.ErrorReset()
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO")
-    ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", None)
+    with gdal.config_option("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO"):
+        ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
     assert gdal.GetLastErrorMsg() == ""
 
     # Set GPKG 1.99.0
@@ -4270,9 +4263,8 @@ def test_ogr_gpkg_47():
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO")
-    ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
-    gdal.SetConfigOption("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", None)
+    with gdal.config_option("GPKG_WARN_UNRECOGNIZED_APPLICATION_ID", "NO"):
+        ogr.Open("/vsimem/ogr_gpkg_47.gpkg")
     assert gdal.GetLastErrorMsg() == ""
 
     # Just for the sake of coverage testing in DEBUG mode
@@ -4398,9 +4390,8 @@ def test_ogr_gpkg_49():
 
 def test_ogr_gpkg_50():
 
-    gdal.SetConfigOption("GPKG_ADD_DEFINITION_12_063", "YES")
-    gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_50.gpkg")
-    gdal.SetConfigOption("GPKG_ADD_DEFINITION_12_063", None)
+    with gdal.config_option("GPKG_ADD_DEFINITION_12_063", "YES"):
+        gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_50.gpkg")
 
     ds = ogr.Open("/vsimem/ogr_gpkg_50.gpkg", update=1)
     srs32631 = osr.SpatialReference()

--- a/autotest/ogr/ogr_ili.py
+++ b/autotest/ogr/ogr_ili.py
@@ -40,7 +40,6 @@ pytestmark = pytest.mark.require_driver("Interlis 1")
 @pytest.fixture(autouse=True, scope="module")
 def startup_and_cleanup():
     yield
-    gdal.SetConfigOption("OGR_STROKE_CURVE", None)
 
     gdaltest.clean_tmp()
 
@@ -687,153 +686,157 @@ def test_ogr_interlis1_13():
 
 def test_ogr_interlis1_13_linear():
 
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "YES")
+    with gdal.config_option("OGR_STROKE_CURVE", "YES"):
 
-    ds = ogr.Open("data/ili/surface.itf,data/ili/surface.imd")
+        ds = ogr.Open("data/ili/surface.itf,data/ili/surface.imd")
 
-    layers = [
-        "SURFC_TOP__SURFC_TBL",
-        "SURFC_TOP__SURFC_TBL_SHAPE",
-        "SURFC_TOP__SURFC_TBL_TEXT_ID",
-        "SURFC_TOP__SURFC_TBL_TEXT_ID_SHAPE",
-        "SURFC_TOP__LineAttrib1",
-        "SURFC_TOP__Flaechenelement",
-        "SURFC_TOP__Flaechenelement_Geometrie",
-    ]
+        layers = [
+            "SURFC_TOP__SURFC_TBL",
+            "SURFC_TOP__SURFC_TBL_SHAPE",
+            "SURFC_TOP__SURFC_TBL_TEXT_ID",
+            "SURFC_TOP__SURFC_TBL_TEXT_ID_SHAPE",
+            "SURFC_TOP__LineAttrib1",
+            "SURFC_TOP__Flaechenelement",
+            "SURFC_TOP__Flaechenelement_Geometrie",
+        ]
 
-    assert ds.GetLayerCount() == len(layers), "layer count wrong."
+        assert ds.GetLayerCount() == len(layers), "layer count wrong."
 
-    for i in range(ds.GetLayerCount()):
-        assert ds.GetLayer(i).GetName() in layers, "Did not get right layers"
+        for i in range(ds.GetLayerCount()):
+            assert ds.GetLayer(i).GetName() in layers, "Did not get right layers"
 
-    lyr = ds.GetLayerByName("SURFC_TOP__SURFC_TBL_SHAPE")
+        lyr = ds.GetLayerByName("SURFC_TOP__SURFC_TBL_SHAPE")
 
-    assert lyr.GetFeatureCount() == 5, "feature count wrong."
+        assert lyr.GetFeatureCount() == 5, "feature count wrong."
 
-    lyr = ds.GetLayerByName("SURFC_TOP__SURFC_TBL")
+        lyr = ds.GetLayerByName("SURFC_TOP__SURFC_TBL")
 
-    assert lyr.GetFeatureCount() == 4, "feature count wrong."
+        assert lyr.GetFeatureCount() == 4, "feature count wrong."
 
-    feat = lyr.GetNextFeature()
+        feat = lyr.GetNextFeature()
 
-    field_values = ["103", 1, 3, 1, 23, 25000, 20060111]
+        field_values = ["103", 1, 3, 1, 23, 25000, 20060111]
 
-    assert feat.GetFieldCount() == len(field_values), "field count wrong."
+        assert feat.GetFieldCount() == len(field_values), "field count wrong."
 
-    for i in range(feat.GetFieldCount()):
-        if feat.GetFieldAsString(i) != str(field_values[i]):
-            feat.DumpReadable()
-            print(feat.GetFieldAsString(i))
-            pytest.fail("field value wrong.")
+        for i in range(feat.GetFieldCount()):
+            if feat.GetFieldAsString(i) != str(field_values[i]):
+                feat.DumpReadable()
+                print(feat.GetFieldAsString(i))
+                pytest.fail("field value wrong.")
 
-    geom_field_values = [
-        "POLYGON ((598600.961 249487.174,598608.899 249538.768,598624.774 249594.331,598648.586 249630.05,598684.305 249661.8,598763.68 249685.612,598850.993 249685.612,598854.962 249618.143,598843.055 249550.675,598819.243 249514.956,598763.68 249479.237,598692.243 249447.487,598612.868 249427.643,598600.961 249487.174))"
-    ]
+        geom_field_values = [
+            "POLYGON ((598600.961 249487.174,598608.899 249538.768,598624.774 249594.331,598648.586 249630.05,598684.305 249661.8,598763.68 249685.612,598850.993 249685.612,598854.962 249618.143,598843.055 249550.675,598819.243 249514.956,598763.68 249479.237,598692.243 249447.487,598612.868 249427.643,598600.961 249487.174))"
+        ]
 
-    assert feat.GetGeomFieldCount() == len(geom_field_values), "geom field count wrong."
+        assert feat.GetGeomFieldCount() == len(
+            geom_field_values
+        ), "geom field count wrong."
 
-    for i in range(feat.GetGeomFieldCount()):
-        geom = feat.GetGeomFieldRef(i)
-        if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
-            feat.DumpReadable()
-            pytest.fail()
+        for i in range(feat.GetGeomFieldCount()):
+            geom = feat.GetGeomFieldRef(i)
+            if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
+                feat.DumpReadable()
+                pytest.fail()
 
-    # --- test curved polygon
+        # --- test curved polygon
 
-    geom_field_values = [
-        "POLYGON ((598600.961 249487.174,598608.899 249538.768,598624.774 249594.331,598648.586 249630.05,598684.305 249661.8,598763.68 249685.612,598850.993 249685.612,598854.962 249618.143,598843.055 249550.675,598819.243 249514.956,598763.68 249479.237,598692.243 249447.487,598612.868 249427.643,598600.961 249487.174))"
-    ]
+        geom_field_values = [
+            "POLYGON ((598600.961 249487.174,598608.899 249538.768,598624.774 249594.331,598648.586 249630.05,598684.305 249661.8,598763.68 249685.612,598850.993 249685.612,598854.962 249618.143,598843.055 249550.675,598819.243 249514.956,598763.68 249479.237,598692.243 249447.487,598612.868 249427.643,598600.961 249487.174))"
+        ]
 
-    assert feat.GetGeomFieldCount() == len(geom_field_values), "geom field count wrong."
+        assert feat.GetGeomFieldCount() == len(
+            geom_field_values
+        ), "geom field count wrong."
 
-    for i in range(feat.GetGeomFieldCount()):
-        geom = feat.GetGeomFieldRef(i)
-        if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
-            feat.DumpReadable()
-            pytest.fail()
+        for i in range(feat.GetGeomFieldCount()):
+            geom = feat.GetGeomFieldRef(i)
+            if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
+                feat.DumpReadable()
+                pytest.fail()
 
-    # --- test multi-ring polygon
+        # --- test multi-ring polygon
 
-    feat = lyr.GetNextFeature()
-    feat = lyr.GetNextFeature()
-    # field_values = ['106', 3, 3, 1, 23, 25000, 20060111]
-    field_values = ["105", 3, 3, 1, 23, 25000, 20060111]
+        feat = lyr.GetNextFeature()
+        feat = lyr.GetNextFeature()
+        # field_values = ['106', 3, 3, 1, 23, 25000, 20060111]
+        field_values = ["105", 3, 3, 1, 23, 25000, 20060111]
 
-    assert feat.GetFieldCount() == len(field_values), "field count wrong."
+        assert feat.GetFieldCount() == len(field_values), "field count wrong."
 
-    for i in range(feat.GetFieldCount()):
-        if feat.GetFieldAsString(i) != str(field_values[i]):
-            feat.DumpReadable()
-            print(feat.GetFieldAsString(i))
-            pytest.fail("field value wrong.")
+        for i in range(feat.GetFieldCount()):
+            if feat.GetFieldAsString(i) != str(field_values[i]):
+                feat.DumpReadable()
+                print(feat.GetFieldAsString(i))
+                pytest.fail("field value wrong.")
 
-    geom_field_values = [
-        "POLYGON ((598330.204 249028.397,598344.756 249057.501,598390.838 249074.479,598422.367 249081.755,598459.96 249093.882,598493.915 249101.158,598523.019 249106.008,598563.038 249084.18,598589.716 249042.949,598603.056 249011.42,598607.907 248966.551,598577.59 248960.487,598493.915 248983.528,598424.793 248996.868,598359.308 249010.207,598330.204 249028.397))"
-    ]
+        geom_field_values = [
+            "POLYGON ((598330.204 249028.397,598344.756 249057.501,598390.838 249074.479,598422.367 249081.755,598459.96 249093.882,598493.915 249101.158,598523.019 249106.008,598563.038 249084.18,598589.716 249042.949,598603.056 249011.42,598607.907 248966.551,598577.59 248960.487,598493.915 248983.528,598424.793 248996.868,598359.308 249010.207,598330.204 249028.397))"
+        ]
 
-    assert feat.GetGeomFieldCount() == len(geom_field_values), "geom field count wrong."
+        assert feat.GetGeomFieldCount() == len(
+            geom_field_values
+        ), "geom field count wrong."
 
-    for i in range(feat.GetGeomFieldCount()):
-        geom = feat.GetGeomFieldRef(i)
-        if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
-            feat.DumpReadable()
-            pytest.fail()
+        for i in range(feat.GetGeomFieldCount()):
+            geom = feat.GetGeomFieldRef(i)
+            if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
+                feat.DumpReadable()
+                pytest.fail()
 
-    lyr = ds.GetLayerByName("SURFC_TOP__Flaechenelement_Geometrie")
-    assert lyr.GetFeatureCount() == 3, "feature count wrong."
+        lyr = ds.GetLayerByName("SURFC_TOP__Flaechenelement_Geometrie")
+        assert lyr.GetFeatureCount() == 3, "feature count wrong."
 
-    feat = lyr.GetNextFeature()
+        feat = lyr.GetNextFeature()
 
-    geom_field_values = [
-        "MULTICURVE (COMPOUNDCURVE ((697064.616 245051.751,697064.773 245052.007,697067.63 245050.258,697067.473 245050.002,697064.616 245051.751)))"
-    ]
+        geom_field_values = [
+            "MULTICURVE (COMPOUNDCURVE ((697064.616 245051.751,697064.773 245052.007,697067.63 245050.258,697067.473 245050.002,697064.616 245051.751)))"
+        ]
 
-    for i in range(feat.GetGeomFieldCount()):
-        geom = feat.GetGeomFieldRef(i)
-        if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
-            feat.DumpReadable()
-            pytest.fail()
+        for i in range(feat.GetGeomFieldCount()):
+            geom = feat.GetGeomFieldRef(i)
+            if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
+                feat.DumpReadable()
+                pytest.fail()
 
-    feat = lyr.GetNextFeature()
+        feat = lyr.GetNextFeature()
 
-    geom_field_values = [
-        "MULTICURVE (COMPOUNDCURVE ((698298.028 246754.897,698295.899 246752.775,698293.113 246755.525,698295.243 246757.648)))"
-    ]
+        geom_field_values = [
+            "MULTICURVE (COMPOUNDCURVE ((698298.028 246754.897,698295.899 246752.775,698293.113 246755.525,698295.243 246757.648)))"
+        ]
 
-    for i in range(feat.GetGeomFieldCount()):
-        geom = feat.GetGeomFieldRef(i)
-        if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
-            feat.DumpReadable()
-            pytest.fail()
+        for i in range(feat.GetGeomFieldCount()):
+            geom = feat.GetGeomFieldRef(i)
+            if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
+                feat.DumpReadable()
+                pytest.fail()
 
-    lyr = ds.GetLayerByName("SURFC_TOP__Flaechenelement")
-    assert lyr.GetFeatureCount() == 2, "feature count wrong."
+        lyr = ds.GetLayerByName("SURFC_TOP__Flaechenelement")
+        assert lyr.GetFeatureCount() == 2, "feature count wrong."
 
-    feat = lyr.GetNextFeature()
+        feat = lyr.GetNextFeature()
 
-    geom_field_values = [
-        "POLYGON ((697064.616 245051.751,697064.773 245052.007,697067.63 245050.258,697067.473 245050.002,697064.616 245051.751))"
-    ]
+        geom_field_values = [
+            "POLYGON ((697064.616 245051.751,697064.773 245052.007,697067.63 245050.258,697067.473 245050.002,697064.616 245051.751))"
+        ]
 
-    for i in range(feat.GetGeomFieldCount()):
-        geom = feat.GetGeomFieldRef(i)
-        if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
-            feat.DumpReadable()
-            pytest.fail()
+        for i in range(feat.GetGeomFieldCount()):
+            geom = feat.GetGeomFieldRef(i)
+            if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
+                feat.DumpReadable()
+                pytest.fail()
 
-    feat = lyr.GetNextFeature()
+        feat = lyr.GetNextFeature()
 
-    geom_field_values = [
-        "POLYGON ((698298.028 246754.897,698295.899 246752.775,698293.113 246755.525,698295.243 246757.648,698298.028 246754.897))"
-    ]
+        geom_field_values = [
+            "POLYGON ((698298.028 246754.897,698295.899 246752.775,698293.113 246755.525,698295.243 246757.648,698298.028 246754.897))"
+        ]
 
-    for i in range(feat.GetGeomFieldCount()):
-        geom = feat.GetGeomFieldRef(i)
-        if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
-            feat.DumpReadable()
-            pytest.fail()
-
-    gdal.SetConfigOption("OGR_STROKE_CURVE", None)
+        for i in range(feat.GetGeomFieldCount()):
+            geom = feat.GetGeomFieldRef(i)
+            if ogrtest.check_feature_geometry(geom, geom_field_values[i]) != 0:
+                feat.DumpReadable()
+                pytest.fail()
 
 
 ###############################################################################
@@ -1174,11 +1177,9 @@ def test_ogr_interlis2_4():
 
 def test_ogr_interlis_arc1():
 
-    gdal.SetConfigOption("OGR_STROKE_CURVE", "TRUE")
-    # gdal.SetConfigOption('OGR_ARC_STEPSIZE', '0.96')
-    ds = ogr.Open("data/ili/Beispiel.itf,data/ili/Beispiel.imd")
-
-    gdal.SetConfigOption("OGR_STROKE_CURVE", None)
+    with gdal.config_option("OGR_STROKE_CURVE", "TRUE"):
+        # gdal.SetConfigOption('OGR_ARC_STEPSIZE', '0.96')
+        ds = ogr.Open("data/ili/Beispiel.itf,data/ili/Beispiel.imd")
 
     length_0_1_deg = 72.7181992353  # Line length with 0.1 degree segments
 

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -499,9 +499,8 @@ def test_ogr_libkml_check_write_kmz():
 
 
 def test_ogr_libkml_write_kmz_use_doc_off():
-    gdal.SetConfigOption("LIBKML_USE_DOC.KML", "NO")
-    ret = ogr_libkml_write("/vsimem/libkml_use_doc_off.kmz")
-    gdal.SetConfigOption("LIBKML_USE_DOC.KML", None)
+    with gdal.config_option("LIBKML_USE_DOC.KML", "NO"):
+        ret = ogr_libkml_write("/vsimem/libkml_use_doc_off.kmz")
     return ret
 
 
@@ -1437,10 +1436,9 @@ def test_ogr_libkml_read_write_style():
         pytest.fail(resolved_stylemap)
 
     # Test reading highlight style in StyleMap
-    gdal.SetConfigOption("LIBKML_STYLEMAP_KEY", "HIGHLIGHT")
-    src_ds = ogr.Open("/vsimem/ogr_libkml_read_write_style_read.kml")
-    style_table = src_ds.GetStyleTable()
-    gdal.SetConfigOption("LIBKML_STYLEMAP_KEY", None)
+    with gdal.config_option("LIBKML_STYLEMAP_KEY", "HIGHLIGHT"):
+        src_ds = ogr.Open("/vsimem/ogr_libkml_read_write_style_read.kml")
+        style_table = src_ds.GetStyleTable()
 
     ds = ogr.GetDriverByName("LIBKML").CreateDataSource(
         "/vsimem/ogr_libkml_read_write_style_write.kml"
@@ -1930,9 +1928,8 @@ def test_ogr_libkml_read_write_data():
     ds = ogr.GetDriverByName("LIBKML").CreateDataSource(
         "/vsimem/ogr_libkml_read_write_data.kml"
     )
-    gdal.SetConfigOption("LIBKML_USE_SIMPLEFIELD", "NO")
-    lyr = ds.CreateLayer("test")
-    gdal.SetConfigOption("LIBKML_USE_SIMPLEFIELD", None)
+    with gdal.config_option("LIBKML_USE_SIMPLEFIELD", "NO"):
+        lyr = ds.CreateLayer("test")
     lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetField("foo", "bar")

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -1805,9 +1805,8 @@ def test_ogr_mitab_35():
         coordsys
         == 'CoordSys Earth Projection 3, 33, "m", 3, 46.5, 44, 49.00000000002, 700000, 6600000'
     )
-    gdal.SetConfigOption("MITAB_BOUNDS_FILE", "data/mitab/mitab_bounds.txt")
-    coordsys = get_coordsys_from_srs(srs)
-    gdal.SetConfigOption("MITAB_BOUNDS_FILE", None)
+    with gdal.config_option("MITAB_BOUNDS_FILE", "data/mitab/mitab_bounds.txt"):
+        coordsys = get_coordsys_from_srs(srs)
     assert (
         coordsys
         == 'CoordSys Earth Projection 3, 33, "m", 3, 46.5, 44, 49.00000000002, 700000, 6600000 Bounds (75000, 6000000) (1275000, 7200000)'

--- a/autotest/ogr/ogr_mongodbv3.py
+++ b/autotest/ogr/ogr_mongodbv3.py
@@ -604,13 +604,12 @@ def test_ogr_mongodbv3_2():
     ogrtest.mongodbv3_layer_name_with_2d_index = (
         ogrtest.mongodbv3_layer_name + "_with_2d_index"
     )
-    gdal.SetConfigOption("OGR_MONGODB_SPAT_INDEX_TYPE", "2d")
-    lyr = ogrtest.mongodbv3_ds.CreateLayer(
-        ogrtest.mongodbv3_layer_name_with_2d_index,
-        geom_type=ogr.wkbPoint,
-        options=["FID=", "WRITE_OGR_METADATA=NO"],
-    )
-    gdal.SetConfigOption("OGR_MONGODB_SPAT_INDEX_TYPE", None)
+    with gdal.config_option("OGR_MONGODB_SPAT_INDEX_TYPE", "2d"):
+        lyr = ogrtest.mongodbv3_ds.CreateLayer(
+            ogrtest.mongodbv3_layer_name_with_2d_index,
+            geom_type=ogr.wkbPoint,
+            options=["FID=", "WRITE_OGR_METADATA=NO"],
+        )
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(2 49)"))
     assert lyr.CreateFeature(f) == 0

--- a/autotest/ogr/ogr_ods.py
+++ b/autotest/ogr/ogr_ods.py
@@ -189,14 +189,12 @@ def test_ogr_ods_kspread_1():
 
 def test_ogr_ods_2():
 
-    gdal.SetConfigOption("OGR_ODS_HEADERS", "DISABLE")
-    ds = ogr.Open("data/ods/test.ods")
+    with gdal.config_option("OGR_ODS_HEADERS", "DISABLE"):
+        ds = ogr.Open("data/ods/test.ods")
 
-    lyr = ds.GetLayerByName("Feuille7")
+        lyr = ds.GetLayerByName("Feuille7")
 
-    assert lyr.GetFeatureCount() == 3
-
-    gdal.SetConfigOption("OGR_ODS_HEADERS", None)
+        assert lyr.GetFeatureCount() == 3
 
 
 ###############################################################################
@@ -205,14 +203,12 @@ def test_ogr_ods_2():
 
 def test_ogr_ods_3():
 
-    gdal.SetConfigOption("OGR_ODS_FIELD_TYPES", "STRING")
-    ds = ogr.Open("data/ods/test.ods")
+    with gdal.config_option("OGR_ODS_FIELD_TYPES", "STRING"):
+        ds = ogr.Open("data/ods/test.ods")
 
-    lyr = ds.GetLayerByName("Feuille7")
+        lyr = ds.GetLayerByName("Feuille7")
 
-    assert lyr.GetLayerDefn().GetFieldDefn(1).GetType() == ogr.OFTString
-
-    gdal.SetConfigOption("OGR_ODS_FIELD_TYPES", None)
+        assert lyr.GetLayerDefn().GetFieldDefn(1).GetType() == ogr.OFTString
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -273,13 +273,12 @@ def ogr_openfilegdb_make_test_data():
     if True:  # pylint: disable=using-constant-test
         lyr = ds.CreateLayer("big_layer", geom_type=ogr.wkbNone)
         lyr.CreateField(ogr.FieldDefn("real", ogr.OFTReal))
-        gdal.SetConfigOption("FGDB_BULK_LOAD", "YES")
-        # for i in range(340*341+1):
-        for i in range(340 + 1):
-            feat = ogr.Feature(lyr.GetLayerDefn())
-            feat.SetField(0, i % 4)
-            lyr.CreateFeature(feat)
-        gdal.SetConfigOption("FGDB_BULK_LOAD", None)
+        with gdal.config_option("FGDB_BULK_LOAD", "YES"):
+            # for i in range(340*341+1):
+            for i in range(340 + 1):
+                feat = ogr.Feature(lyr.GetLayerDefn())
+                feat.SetField(0, i % 4)
+                lyr.CreateFeature(feat)
 
     if True:  # pylint: disable=using-constant-test
         lyr = ds.CreateLayer("hole", geom_type=ogr.wkbPoint, srs=None)
@@ -1011,12 +1010,11 @@ def test_ogr_openfilegdb_8():
     ds = None
 
     dict_feat_count2 = {}
-    gdal.SetConfigOption("OPENFILEGDB_IGNORE_GDBTABLX", "YES")
-    ds = ogr.Open("data/filegdb/testopenfilegdb.gdb.zip")
-    for i in range(ds.GetLayerCount()):
-        lyr = ds.GetLayer(i)
-        dict_feat_count2[lyr.GetName()] = lyr.GetFeatureCount()
-    gdal.SetConfigOption("OPENFILEGDB_IGNORE_GDBTABLX", None)
+    with gdal.config_option("OPENFILEGDB_IGNORE_GDBTABLX", "YES"):
+        ds = ogr.Open("data/filegdb/testopenfilegdb.gdb.zip")
+        for i in range(ds.GetLayerCount()):
+            lyr = ds.GetLayer(i)
+            dict_feat_count2[lyr.GetName()] = lyr.GetFeatureCount()
 
     assert dict_feat_count == dict_feat_count2
 

--- a/autotest/ogr/ogr_osm.py
+++ b/autotest/ogr/ogr_osm.py
@@ -366,9 +366,8 @@ def test_ogr_osm_3(options=None, all_layers=False):
 
 
 def test_ogr_osm_3_sqlite_nodes():
-    gdal.SetConfigOption("OSM_USE_CUSTOM_INDEXING", "NO")
-    ret = test_ogr_osm_3(options="-skip")
-    gdal.SetConfigOption("OSM_USE_CUSTOM_INDEXING", None)
+    with gdal.config_option("OSM_USE_CUSTOM_INDEXING", "NO"):
+        ret = test_ogr_osm_3(options="-skip")
     return ret
 
 
@@ -377,9 +376,8 @@ def test_ogr_osm_3_sqlite_nodes():
 
 
 def test_ogr_osm_3_custom_compress_nodes():
-    gdal.SetConfigOption("OSM_COMPRESS_NODES", "YES")
-    ret = test_ogr_osm_3()
-    gdal.SetConfigOption("OSM_COMPRESS_NODES", None)
+    with gdal.config_option("OSM_COMPRESS_NODES", "YES"):
+        ret = test_ogr_osm_3()
     return ret
 
 
@@ -580,10 +578,8 @@ def test_ogr_osm_8():
 
 def test_ogr_osm_9():
 
-    old_val = gdal.GetConfigOption("OSM_USE_CUSTOM_INDEXING")
-    gdal.SetConfigOption("OSM_USE_CUSTOM_INDEXING", "NO")
-    ret = test_ogr_osm_8()
-    gdal.SetConfigOption("OSM_USE_CUSTOM_INDEXING", old_val)
+    with gdal.config_option("OSM_USE_CUSTOM_INDEXING", "NO"):
+        ret = test_ogr_osm_8()
 
     return ret
 
@@ -669,9 +665,8 @@ def test_ogr_osm_10():
 
 def test_ogr_osm_11():
 
-    gdal.SetConfigOption("OSM_CONFIG_FILE", "data/osm/osmconf_alltags.ini")
-    ds = ogr.Open("data/osm/test.pbf")
-    gdal.SetConfigOption("OSM_CONFIG_FILE", None)
+    with gdal.config_option("OSM_CONFIG_FILE", "data/osm/osmconf_alltags.ini"):
+        ds = ogr.Open("data/osm/test.pbf")
     lyr = ds.GetLayerByName("points")
     feat = lyr.GetNextFeature()
     if (

--- a/autotest/ogr/ogr_pdf.py
+++ b/autotest/ogr/ogr_pdf.py
@@ -278,10 +278,9 @@ def test_ogr_pdf_4_podofo():
 
     md = gdal_pdf_drv.GetMetadata()
     if "HAVE_POPPLER" in md and "HAVE_PODOFO" in md:
-        gdal.SetConfigOption("GDAL_PDF_LIB", "PODOFO")
-        print("Using podofo now")
-        ret = test_ogr_pdf_4()
-        gdal.SetConfigOption("GDAL_PDF_LIB", None)
+        with gdal.config_option("GDAL_PDF_LIB", "PODOFO"):
+            print("Using podofo now")
+            ret = test_ogr_pdf_4()
         return ret
     pytest.skip()
 

--- a/autotest/ogr/ogr_pgdump.py
+++ b/autotest/ogr/ogr_pgdump.py
@@ -542,37 +542,35 @@ def test_ogr_pgdump_6():
     field_defn.SetDefault("CURRENT_TIME")
     lyr.CreateField(field_defn)
 
-    gdal.SetConfigOption("PG_USE_COPY", "YES")
+    with gdal.config_option("PG_USE_COPY", "YES"):
 
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetField("field_string", "a")
-    f.SetField("field_int", 456)
-    f.SetField("field_real", 4.56)
-    f.SetField("field_datetime", "2015/06/30 12:34:56")
-    f.SetField("field_datetime2", "2015/06/30 12:34:56")
-    f.SetField("field_date", "2015/06/30")
-    f.SetField("field_time", "12:34:56")
-    lyr.CreateFeature(f)
-    f = None
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetField("field_string", "a")
+        f.SetField("field_int", 456)
+        f.SetField("field_real", 4.56)
+        f.SetField("field_datetime", "2015/06/30 12:34:56")
+        f.SetField("field_datetime2", "2015/06/30 12:34:56")
+        f.SetField("field_date", "2015/06/30")
+        f.SetField("field_time", "12:34:56")
+        lyr.CreateFeature(f)
+        f = None
 
-    # Transition from COPY to INSERT
-    f = ogr.Feature(lyr.GetLayerDefn())
-    lyr.CreateFeature(f)
-    f = None
+        # Transition from COPY to INSERT
+        f = ogr.Feature(lyr.GetLayerDefn())
+        lyr.CreateFeature(f)
+        f = None
 
-    # Transition from INSERT to COPY
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetField("field_string", "b")
-    f.SetField("field_int", 456)
-    f.SetField("field_real", 4.56)
-    f.SetField("field_datetime", "2015/06/30 12:34:56")
-    f.SetField("field_datetime2", "2015/06/30 12:34:56")
-    f.SetField("field_date", "2015/06/30")
-    f.SetField("field_time", "12:34:56")
-    lyr.CreateFeature(f)
-    f = None
-
-    gdal.SetConfigOption("PG_USE_COPY", None)
+        # Transition from INSERT to COPY
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetField("field_string", "b")
+        f.SetField("field_int", 456)
+        f.SetField("field_real", 4.56)
+        f.SetField("field_datetime", "2015/06/30 12:34:56")
+        f.SetField("field_datetime2", "2015/06/30 12:34:56")
+        f.SetField("field_date", "2015/06/30")
+        f.SetField("field_time", "12:34:56")
+        lyr.CreateFeature(f)
+        f = None
 
     ds = None
 
@@ -751,17 +749,15 @@ def test_ogr_pgdump_8():
     feat.SetField("str", "first string")
     feat.SetField("myfid", 10)
     feat.SetField("str2", "second string")
-    gdal.SetConfigOption("PG_USE_COPY", "YES")
-    ret = lyr.CreateFeature(feat)
-    gdal.SetConfigOption("PG_USE_COPY", None)
+    with gdal.config_option("PG_USE_COPY", "YES"):
+        ret = lyr.CreateFeature(feat)
     assert ret == 0
     assert feat.GetFID() == 10
 
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetField("str2", "second string")
-    gdal.SetConfigOption("PG_USE_COPY", "YES")
-    ret = lyr.CreateFeature(feat)
-    gdal.SetConfigOption("PG_USE_COPY", None)
+    with gdal.config_option("PG_USE_COPY", "YES"):
+        ret = lyr.CreateFeature(feat)
     assert ret == 0
     if feat.GetFID() < 0:
         feat.DumpReadable()
@@ -779,10 +775,8 @@ def test_ogr_pgdump_8():
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetFID(1)
     feat.SetField("myfid", 10)
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PG_USE_COPY", "YES")
+    with gdaltest.error_handler(), gdal.config_option("PG_USE_COPY", "YES"):
         ret = lyr.CreateFeature(feat)
-        gdal.SetConfigOption("PG_USE_COPY", None)
     assert ret != 0
 
     # gdal.PushErrorHandler()
@@ -804,9 +798,8 @@ def test_ogr_pgdump_8():
     feat.SetField("str", "first string")
     feat.SetField("myfid", 12)
     feat.SetField("str2", "second string")
-    gdal.SetConfigOption("PG_USE_COPY", "YES")
-    ret = lyr.CreateFeature(feat)
-    gdal.SetConfigOption("PG_USE_COPY", None)
+    with gdal.config_option("PG_USE_COPY", "YES"):
+        ret = lyr.CreateFeature(feat)
     assert ret == 0
     assert feat.GetFID() == 12
 
@@ -1243,11 +1236,10 @@ def test_ogr_pgdump_15():
 # Test sequence updating
 
 
-def test_ogr_pgdump_16():
+@pytest.mark.parametrize("pg_use_copy", ["YES", "NO"])
+def test_ogr_pgdump_16(pg_use_copy):
 
-    for pg_use_copy in ("YES", "NO"):
-
-        gdal.SetConfigOption("PG_USE_COPY", pg_use_copy)
+    with gdal.config_option("PG_USE_COPY", pg_use_copy):
         ds = ogr.GetDriverByName("PGDump").CreateDataSource(
             "/vsimem/ogr_pgdump_16.sql", options=["LINEFORMAT=LF"]
         )
@@ -1269,8 +1261,6 @@ def test_ogr_pgdump_16():
             """SELECT setval(pg_get_serial_sequence('"public"."test"', 'ogc_fid'), MAX("ogc_fid")) FROM "public"."test";"""
             in sql
         )
-
-    gdal.SetConfigOption("PG_USE_COPY", None)
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_plscenes.py
+++ b/autotest/ogr/ogr_plscenes.py
@@ -68,11 +68,10 @@ def test_ogr_plscenes_data_v1_catalog_no_paging():
     gdal.FileFromMemBuffer(
         "/vsimem/data_v1/item-types", '{ "item_types": [ { "id": "PSScene3Band" } ] }'
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
+        )
     assert ds is not None
     with gdaltest.error_handler():
         assert ds.GetLayerByName("non_existing") is None
@@ -101,11 +100,10 @@ def test_ogr_plscenes_data_v1_catalog_paging():
         "/vsimem/data_v1/item-types/page_2",
         '{ "item_types": [ { "id": "PSScene4Band" } ] }',
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
+        )
     assert ds is not None
     with gdaltest.error_handler():
         assert ds.GetLayerByName("non_existing") is None
@@ -141,18 +139,16 @@ def test_ogr_plscenes_data_v1_nominal():
      "id": "PSOrthoTile"}
 ]}""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
+        )
     assert ds is not None
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:version=data_v1,api_key=foo,FOLLOW_LINKS=YES", gdal.OF_VECTOR
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:version=data_v1,api_key=foo,FOLLOW_LINKS=YES", gdal.OF_VECTOR
+        )
     assert ds is not None
 
     lyr = ds.GetLayer(0)
@@ -232,13 +228,12 @@ def test_ogr_plscenes_data_v1_nominal():
 }""",
     )
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:",
-        gdal.OF_VECTOR,
-        open_options=["VERSION=data_v1", "API_KEY=foo", "FOLLOW_LINKS=YES"],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:",
+            gdal.OF_VECTOR,
+            open_options=["VERSION=data_v1", "API_KEY=foo", "FOLLOW_LINKS=YES"],
+        )
     lyr = ds.GetLayer(0)
 
     f = lyr.GetNextFeature()
@@ -432,19 +427,17 @@ def test_ogr_plscenes_data_v1_nominal():
     # Try raster access
 
     # Missing catalog
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
-        ds_raster = gdal.OpenEx(
-            "PLScenes:",
-            gdal.OF_RASTER,
-            open_options=["VERSION=data_v1", "API_KEY=foo", "SCENE=id"],
-        )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        with gdaltest.error_handler():
+            ds_raster = gdal.OpenEx(
+                "PLScenes:",
+                gdal.OF_RASTER,
+                open_options=["VERSION=data_v1", "API_KEY=foo", "SCENE=id"],
+            )
     assert ds_raster is None and gdal.GetLastErrorMsg().find("Missing catalog") >= 0
 
     # Invalid catalog
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -455,15 +448,13 @@ def test_ogr_plscenes_data_v1_nominal():
                 "SCENE=id",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
 
     # visual not an object
     gdal.FileFromMemBuffer(
         "/vsimem/data_v1/item-types/PSOrthoTile/items/id/assets",
         """{ "visual": false }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -474,7 +465,6 @@ def test_ogr_plscenes_data_v1_nominal():
                 "SCENE=id",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is None
 
     # Inactive file, and activation link not working
@@ -491,8 +481,7 @@ def test_ogr_plscenes_data_v1_nominal():
   }
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -505,7 +494,6 @@ def test_ogr_plscenes_data_v1_nominal():
                 "ASSET=analytic",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is None
 
     # File in activation
@@ -522,8 +510,7 @@ def test_ogr_plscenes_data_v1_nominal():
   }
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -536,7 +523,6 @@ def test_ogr_plscenes_data_v1_nominal():
                 "ASSET=analytic",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is None
 
     gdal.FileFromMemBuffer(
@@ -556,8 +542,7 @@ def test_ogr_plscenes_data_v1_nominal():
     )
 
     # Missing /vsimem/data_v1/item-types/PSOrthoTile/items/id/assets/analytic/my.tiff
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -570,7 +555,6 @@ def test_ogr_plscenes_data_v1_nominal():
                 "ASSET=analytic",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is None
 
     # JSon content for /vsimem/data_v1/item-types/PSOrthoTile/items/id/assets/analytic/my.tiff
@@ -578,8 +562,7 @@ def test_ogr_plscenes_data_v1_nominal():
         "/vsimem/data_v1/item-types/PSOrthoTile/items/id/assets/analytic/my.tiff",
         """{}""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -592,7 +575,6 @@ def test_ogr_plscenes_data_v1_nominal():
                 "ASSET=analytic",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is None
 
     # Missing metadata
@@ -600,8 +582,7 @@ def test_ogr_plscenes_data_v1_nominal():
         "/vsimem/data_v1/item-types/PSOrthoTile/items/id/assets/analytic/my.tiff",
         open("../gcore/data/byte.tif", "rb").read(),
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -614,7 +595,6 @@ def test_ogr_plscenes_data_v1_nominal():
                 "ASSET=analytic",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is not None
     ds_raster = None
 
@@ -622,20 +602,19 @@ def test_ogr_plscenes_data_v1_nominal():
     gdal.FileFromMemBuffer(
         "/vsimem/data_v1/item-types/PSOrthoTile", """{"id": "PSOrthoTile"}"""
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds_raster = gdal.OpenEx(
-        "PLScenes:",
-        gdal.OF_RASTER,
-        open_options=[
-            "VERSION=data_v1",
-            "API_KEY=foo",
-            "ITEMTYPES=PSOrthoTile",
-            "SCENE=id",
-            "ACTIVATION_TIMEOUT=1",
-            "ASSET=analytic",
-        ],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds_raster = gdal.OpenEx(
+            "PLScenes:",
+            gdal.OF_RASTER,
+            open_options=[
+                "VERSION=data_v1",
+                "API_KEY=foo",
+                "ITEMTYPES=PSOrthoTile",
+                "SCENE=id",
+                "ACTIVATION_TIMEOUT=1",
+                "ASSET=analytic",
+            ],
+        )
     assert ds_raster is not None
     ds_raster = None
 
@@ -649,27 +628,25 @@ def test_ogr_plscenes_data_v1_nominal():
     },
 }""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds_raster = gdal.OpenEx(
-        "PLScenes:",
-        gdal.OF_RASTER,
-        open_options=[
-            "VERSION=data_v1",
-            "API_KEY=foo",
-            "ITEMTYPES=PSOrthoTile",
-            "SCENE=id",
-            "ACTIVATION_TIMEOUT=1",
-            "ASSET=analytic",
-        ],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds_raster = gdal.OpenEx(
+            "PLScenes:",
+            gdal.OF_RASTER,
+            open_options=[
+                "VERSION=data_v1",
+                "API_KEY=foo",
+                "ITEMTYPES=PSOrthoTile",
+                "SCENE=id",
+                "ACTIVATION_TIMEOUT=1",
+                "ASSET=analytic",
+            ],
+        )
     assert ds_raster is not None
     assert ds_raster.GetMetadataItem("anomalous_pixels") == "1.23"
     ds_raster = None
 
     # Test invalid ASSET
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_RASTER,
@@ -682,29 +659,26 @@ def test_ogr_plscenes_data_v1_nominal():
                 "ASSET=invalid",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is None
 
     # Test subdatasets
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds_raster = gdal.OpenEx(
-        "PLScenes:",
-        gdal.OF_RASTER,
-        open_options=[
-            "VERSION=data_v1",
-            "API_KEY=foo",
-            "ITEMTYPES=PSOrthoTile",
-            "ASSET=list",
-            "SCENE=id",
-        ],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds_raster = gdal.OpenEx(
+            "PLScenes:",
+            gdal.OF_RASTER,
+            open_options=[
+                "VERSION=data_v1",
+                "API_KEY=foo",
+                "ITEMTYPES=PSOrthoTile",
+                "ASSET=list",
+                "SCENE=id",
+            ],
+        )
     assert len(ds_raster.GetSubDatasets()) == 1
     ds_raster = None
 
     # Unsupported option
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds_raster = gdal.OpenEx(
             "PLScenes:unsupported=yes",
             gdal.OF_RASTER,
@@ -715,27 +689,23 @@ def test_ogr_plscenes_data_v1_nominal():
                 "SCENE=id",
             ],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds_raster is None
 
     # Test catalog with vector access
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds2 = gdal.OpenEx(
-        "PLScenes:",
-        gdal.OF_VECTOR,
-        open_options=["VERSION=data_v1", "API_KEY=foo", "ITEMTYPES=PSOrthoTile"],
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds2 = gdal.OpenEx(
+            "PLScenes:",
+            gdal.OF_VECTOR,
+            open_options=["VERSION=data_v1", "API_KEY=foo", "ITEMTYPES=PSOrthoTile"],
+        )
     assert ds2 is not None and ds2.GetLayerCount() == 1
 
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    with gdaltest.error_handler():
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds2 = gdal.OpenEx(
             "PLScenes:",
             gdal.OF_VECTOR,
             open_options=["VERSION=data_v1", "API_KEY=foo", "ITEMTYPES=invalid"],
         )
-    gdal.SetConfigOption("PL_URL", None)
     assert ds2 is None
 
     fl = gdal.ReadDir("/vsimem/data_v1")
@@ -753,55 +723,42 @@ def test_ogr_plscenes_data_v1_errors():
         pytest.skip()
 
     # No PL_API_KEY
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    old_key = gdal.GetConfigOption("PL_API_KEY")
-    if old_key:
-        gdal.SetConfigOption("PL_API_KEY", "")
-    with gdaltest.error_handler():
+    with gdal.config_options(
+        {"PL_API_KEY": "", "PL_URL": "/vsimem/data_v1/"}
+    ), gdaltest.error_handler():
         ds = gdal.OpenEx("PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1"])
-    if old_key:
-        gdal.SetConfigOption("PL_API_KEY", old_key)
-    gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
     # Invalid option
     gdal.FileFromMemBuffer("/vsimem/data_v1/item-types", '{ "item-types": [] }')
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLScenes:version=data_v1,api_key=foo,invalid=invalid", gdal.OF_VECTOR
         )
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
     # Invalid JSON
     gdal.FileFromMemBuffer("/vsimem/data_v1/item-types", "{invalid_json")
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
         )
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
     # Not an object
     gdal.FileFromMemBuffer("/vsimem/data_v1/item-types", "false")
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
         )
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
     # Lack of "item_types"
     gdal.FileFromMemBuffer("/vsimem/data_v1/item-types", "{}")
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
         )
-        gdal.SetConfigOption("PL_URL", None)
     assert ds is None
 
     # Invalid catalog objects
@@ -810,11 +767,10 @@ def test_ogr_plscenes_data_v1_errors():
         """{"item_types": [{}, [], null, {"id":null},
     {"id":"foo"}]}""",
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
+        )
     assert ds.GetLayerCount() == 1
 
     # Invalid next URL
@@ -822,11 +778,10 @@ def test_ogr_plscenes_data_v1_errors():
         "/vsimem/data_v1/item-types",
         '{"_links": { "_next": "/vsimem/inexisting" }, "item_types": [{"id": "my_catalog"}]}',
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
+        )
     with gdaltest.error_handler():
         lyr_count = ds.GetLayerCount()
     assert lyr_count == 1
@@ -834,11 +789,10 @@ def test_ogr_plscenes_data_v1_errors():
     gdal.FileFromMemBuffer(
         "/vsimem/data_v1/item-types", '{"item_types": [{"id": "PSScene3Band"}]}'
     )
-    gdal.SetConfigOption("PL_URL", "/vsimem/data_v1/")
-    ds = gdal.OpenEx(
-        "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
-    )
-    gdal.SetConfigOption("PL_URL", None)
+    with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
+        ds = gdal.OpenEx(
+            "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
+        )
     lyr = ds.GetLayer(0)
 
     # Invalid index
@@ -887,9 +841,8 @@ def test_ogr_plscenes_data_v1_live():
     if api_key is None:
         pytest.skip("Skipping test as PL_API_KEY not defined")
 
-    gdal.SetConfigOption("PLSCENES_PAGE_SIZE", "10")
-    ds = ogr.Open("PLScenes:version=data_v1,FOLLOW_LINKS=YES")
-    gdal.SetConfigOption("PLSCENES_PAGE_SIZE", None)
+    with gdal.config_option("PLSCENES_PAGE_SIZE", "10"):
+        ds = ogr.Open("PLScenes:version=data_v1,FOLLOW_LINKS=YES")
     assert ds is not None
 
     lyr = ds.GetLayer(0)

--- a/autotest/ogr/ogr_rfc35_sqlite.py
+++ b/autotest/ogr/ogr_rfc35_sqlite.py
@@ -43,6 +43,16 @@ def module_disable_exceptions():
 
 
 ###############################################################################
+@pytest.fixture(autouse=True, scope="module")
+def setup_and_cleanup():
+    # This is to speed-up the runtime of tests on EXT4 filesystems
+    # Do not use this for production environment if you care about data safety
+    # w.r.t system/OS crashes, unless you know what you are doing.
+    with gdal.config_option("OGR_SQLITE_SYNCHRONOUS", "OFF"):
+        yield
+
+
+###############################################################################
 # Initiate the test file
 
 
@@ -55,11 +65,6 @@ def test_ogr_rfc35_sqlite_1():
         pytest.skip()
 
     gdal.Unlink("tmp/rfc35_test.sqlite")
-
-    # This is to speed-up the runtime of tests on EXT4 filesystems
-    # Do not use this for production environment if you care about data safety
-    # w.r.t system/OS crashes, unless you know what you are doing.
-    gdal.SetConfigOption("OGR_SQLITE_SYNCHRONOUS", "OFF")
 
     gdaltest.rfc35_sqlite_ds_name = "/vsimem/rfc35_test.sqlite"
     with gdaltest.error_handler():

--- a/autotest/ogr/ogr_s57.py
+++ b/autotest/ogr/ogr_s57.py
@@ -56,10 +56,6 @@ def test_ogr_s57_1():
 
     gdaltest.s57_ds = None
 
-    # Clear S57 options if set or our results will be messed up.
-    if gdal.GetConfigOption("OGR_S57_OPTIONS", "") != "":
-        gdal.SetConfigOption("OGR_S57_OPTIONS", "")
-
     gdaltest.s57_ds = ogr.Open("data/s57/1B5X02NE.000")
     assert gdaltest.s57_ds is not None, "failed to open test file."
 
@@ -256,12 +252,12 @@ def test_ogr_s57_write():
 
     gdal.Unlink("tmp/ogr_s57_9.000")
 
-    gdal.SetConfigOption(
+    with gdal.config_option(
         "OGR_S57_OPTIONS", "RETURN_PRIMITIVES=ON,RETURN_LINKAGES=ON,LNAM_REFS=ON"
-    )
-    ds = ogr.GetDriverByName("S57").CreateDataSource("tmp/ogr_s57_9.000")
-    src_ds = ogr.Open("data/s57/1B5X02NE.000")
-    gdal.SetConfigOption("OGR_S57_OPTIONS", None)
+    ):
+        ds = ogr.GetDriverByName("S57").CreateDataSource("tmp/ogr_s57_9.000")
+        src_ds = ogr.Open("data/s57/1B5X02NE.000")
+
     for src_lyr in src_ds:
         if src_lyr.GetName() == "DSID":
             continue
@@ -286,15 +282,14 @@ def test_ogr_s57_write():
 
     gdal.Unlink("tmp/ogr_s57_9.000")
 
-    gdal.SetConfigOption(
+    with gdal.config_option(
         "OGR_S57_OPTIONS", "RETURN_PRIMITIVES=ON,RETURN_LINKAGES=ON,LNAM_REFS=ON"
-    )
-    gdal.VectorTranslate(
-        "tmp/ogr_s57_9.000",
-        "data/s57/1B5X02NE.000",
-        options="-f S57 IsolatedNode ConnectedNode Edge Face M_QUAL SOUNDG",
-    )
-    gdal.SetConfigOption("OGR_S57_OPTIONS", None)
+    ):
+        gdal.VectorTranslate(
+            "tmp/ogr_s57_9.000",
+            "data/s57/1B5X02NE.000",
+            options="-f S57 IsolatedNode ConnectedNode Edge Face M_QUAL SOUNDG",
+        )
 
     ds = gdal.OpenEx("tmp/ogr_s57_9.000", open_options=["RETURN_PRIMITIVES=ON"])
     assert ds is not None
@@ -445,11 +440,10 @@ def test_ogr_s57_online_4():
         except OSError:
             pytest.skip()
 
-    gdal.SetConfigOption(
+    with gdal.config_option(
         "OGR_S57_OPTIONS", "RETURN_PRIMITIVES=ON,RETURN_LINKAGES=ON,LNAM_REFS=ON"
-    )
-    ds = ogr.Open("tmp/cache/ENC_ROOT/JP34NC94.000")
-    gdal.SetConfigOption("OGR_S57_OPTIONS", None)
+    ):
+        ds = ogr.Open("tmp/cache/ENC_ROOT/JP34NC94.000")
     lyr = ds.GetLayerByName("LNDMRK")
     for feat in lyr:
         feat.NOBJNM

--- a/autotest/ogr/ogr_vfk.py
+++ b/autotest/ogr/ogr_vfk.py
@@ -48,10 +48,8 @@ def test_ogr_vfk_1():
     if gdaltest.vfk_drv is None:
         pytest.skip()
 
-    gdal.SetConfigOption("OGR_VFK_DB_OVERWRITE", "YES")
-
-    gdaltest.vfk_ds = ogr.Open("data/vfk/bylany.vfk")
-    gdal.SetConfigOption("OGR_VFK_DB_OVERWRITE", None)
+    with gdal.config_option("OGR_VFK_DB_OVERWRITE", "YES"):
+        gdaltest.vfk_ds = ogr.Open("data/vfk/bylany.vfk")
 
     assert gdaltest.vfk_ds is not None
 

--- a/autotest/ogr/ogr_virtualogr.py
+++ b/autotest/ogr/ogr_virtualogr.py
@@ -186,9 +186,8 @@ def test_ogr_virtualogr_2(require_auto_load_extension):
     ds = None
 
     # Check that it is listed if OGR_SQLITE_LIST_VIRTUAL_OGR=YES
-    gdal.SetConfigOption("OGR_SQLITE_LIST_VIRTUAL_OGR", "YES")
-    ds = ogr.Open("/vsimem/ogr_virtualogr_2.db")
-    gdal.SetConfigOption("OGR_SQLITE_LIST_VIRTUAL_OGR", None)
+    with gdal.config_option("OGR_SQLITE_LIST_VIRTUAL_OGR", "YES"):
+        ds = ogr.Open("/vsimem/ogr_virtualogr_2.db")
     found = False
     for i in range(ds.GetLayerCount()):
         if ds.GetLayer(i).GetName() == "foo":
@@ -220,10 +219,10 @@ def test_ogr_virtualogr_2(require_auto_load_extension):
         pytest.fail("expected a failure")
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
-        gdal.SetConfigOption("OGR_SQLITE_LIST_VIRTUAL_OGR", "YES")
+    with gdal.config_option(
+        "OGR_SQLITE_LIST_VIRTUAL_OGR", "YES"
+    ), gdaltest.error_handler():
         ds = ogr.Open("/vsimem/ogr_virtualogr_2.db")
-        gdal.SetConfigOption("OGR_SQLITE_LIST_VIRTUAL_OGR", None)
     if gdal.GetLastErrorMsg() == "":
         ds = None
         gdal.Unlink("/vsimem/ogr_virtualogr_2.db")

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -345,13 +345,12 @@ def test_ogr_wfs_geoserver_paging():
     ds = None
 
     # Test with WFS 1.0.0
-    gdal.SetConfigOption("OGR_WFS_PAGING_ALLOWED", "ON")
-    gdal.SetConfigOption("OGR_WFS_PAGE_SIZE", "%d" % page_size)
-    ds = ogr.Open(
-        "WFS:http://demo.opengeo.org/geoserver/wfs?TYPENAME=og:bugsites&VERSION=1.0.0"
-    )
-    gdal.SetConfigOption("OGR_WFS_PAGING_ALLOWED", None)
-    gdal.SetConfigOption("OGR_WFS_PAGE_SIZE", None)
+    with gdal.config_options(
+        {"OGR_WFS_PAGING_ALLOWED": "ON", "OGR_WFS_PAGE_SIZE": "%d" % page_size}
+    ):
+        ds = ogr.Open(
+            "WFS:http://demo.opengeo.org/geoserver/wfs?TYPENAME=og:bugsites&VERSION=1.0.0"
+        )
     assert ds is not None, "did not managed to open WFS datastore"
 
     lyr = ds.GetLayer(0)
@@ -361,13 +360,12 @@ def test_ogr_wfs_geoserver_paging():
     assert feature_count_wfs100 == feature_count_ref
 
     # Test with WFS 1.1.0
-    gdal.SetConfigOption("OGR_WFS_PAGING_ALLOWED", "ON")
-    gdal.SetConfigOption("OGR_WFS_PAGE_SIZE", "%d" % page_size)
-    ds = ogr.Open(
-        "WFS:http://demo.opengeo.org/geoserver/wfs?TYPENAME=og:bugsites&VERSION=1.1.0"
-    )
-    gdal.SetConfigOption("OGR_WFS_PAGING_ALLOWED", None)
-    gdal.SetConfigOption("OGR_WFS_PAGE_SIZE", None)
+    with gdal.config_options(
+        {"OGR_WFS_PAGING_ALLOWED": "ON", "OGR_WFS_PAGE_SIZE": "%d" % page_size}
+    ):
+        ds = ogr.Open(
+            "WFS:http://demo.opengeo.org/geoserver/wfs?TYPENAME=og:bugsites&VERSION=1.1.0"
+        )
     assert ds is not None, "did not managed to open WFS datastore"
 
     lyr = ds.GetLayer(0)
@@ -556,9 +554,8 @@ def test_ogr_wfs_fake_wfs_server():
     if port == 0:
         pytest.skip()
 
-    gdal.SetConfigOption("OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN", "NO")
-    ds = ogr.Open("WFS:http://127.0.0.1:%d/fakewfs" % port)
-    gdal.SetConfigOption("OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN", None)
+    with gdal.config_option("OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN", "NO"):
+        ds = ogr.Open("WFS:http://127.0.0.1:%d/fakewfs" % port)
     if ds is None:
         webserver.server_stop(process, port)
         pytest.fail("did not managed to open WFS datastore")
@@ -1428,23 +1425,20 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_describefeaturetype(
     lyr_defn = lyr.GetLayerDefn()
     assert lyr_defn.GetFieldCount() == 7
 
-    gdal.SetConfigOption("GML_EXPOSE_GML_ID", "YES")
-    ds = gdal.OpenEx("WFS:/vsimem/wfs_endpoint", open_options=["EXPOSE_GML_ID=NO"])
-    gdal.SetConfigOption("GML_EXPOSE_GML_ID", None)
+    with gdal.config_option("GML_EXPOSE_GML_ID", "YES"):
+        ds = gdal.OpenEx("WFS:/vsimem/wfs_endpoint", open_options=["EXPOSE_GML_ID=NO"])
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
     assert lyr_defn.GetFieldCount() == 7
 
-    gdal.SetConfigOption("GML_EXPOSE_GML_ID", "NO")
-    ds = gdal.OpenEx("WFS:/vsimem/wfs_endpoint", open_options=["EXPOSE_GML_ID=YES"])
-    gdal.SetConfigOption("GML_EXPOSE_GML_ID", None)
+    with gdal.config_option("GML_EXPOSE_GML_ID", "NO"):
+        ds = gdal.OpenEx("WFS:/vsimem/wfs_endpoint", open_options=["EXPOSE_GML_ID=YES"])
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
     assert lyr_defn.GetFieldCount() == 8
 
-    gdal.SetConfigOption("GML_EXPOSE_GML_ID", "NO")
-    ds = gdal.OpenEx("WFS:/vsimem/wfs_endpoint")
-    gdal.SetConfigOption("GML_EXPOSE_GML_ID", None)
+    with gdal.config_option("GML_EXPOSE_GML_ID", "NO"):
+        ds = gdal.OpenEx("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
     assert lyr_defn.GetFieldCount() == 7
@@ -2013,9 +2007,8 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getextent_optimized(
     lyr = ds.GetLayer(1)
     assert lyr.GetExtent() == (-170.0, 170.0, -80.0, 80.0)
 
-    gdal.SetConfigOption("OGR_WFS_TRUST_CAPABILITIES_BOUNDS", "YES")
-    ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
-    gdal.SetConfigOption("OGR_WFS_TRUST_CAPABILITIES_BOUNDS", None)
+    with gdal.config_option("OGR_WFS_TRUST_CAPABILITIES_BOUNDS", "YES"):
+        ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
 
     lyr = ds.GetLayer(2)
     expected_extent = (

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -77,6 +77,12 @@ def with_and_without_streaming(request):
         yield
 
 
+@pytest.fixture(autouse=True, scope="module")
+def curl_enable_vsimem():
+    with gdal.config_option("CPL_CURL_ENABLE_VSIMEM", "YES"):
+        yield
+
+
 ###############################################################################
 # Test reading a MapServer WFS server
 
@@ -1102,8 +1108,6 @@ def test_ogr_wfs_vsimem_fail_because_not_enabled(with_and_without_streaming):
 ###############################################################################
 def test_ogr_wfs_vsimem_fail_because_no_get_capabilities(with_and_without_streaming):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     with gdaltest.error_handler():
         ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     assert ds is None
@@ -1113,8 +1117,6 @@ def test_ogr_wfs_vsimem_fail_because_no_get_capabilities(with_and_without_stream
 
 
 def test_ogr_wfs_vsimem_fail_because_empty_response(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities", ""
@@ -1130,8 +1132,6 @@ def test_ogr_wfs_vsimem_fail_because_empty_response(with_and_without_streaming):
 
 def test_ogr_wfs_vsimem_fail_because_no_WFS_Capabilities(with_and_without_streaming):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities", "<foo/>"
     )
@@ -1145,8 +1145,6 @@ def test_ogr_wfs_vsimem_fail_because_no_WFS_Capabilities(with_and_without_stream
 
 
 def test_ogr_wfs_vsimem_fail_because_exception(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -1170,8 +1168,6 @@ def test_ogr_wfs_vsimem_fail_because_invalid_xml_capabilities(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities", "<invalid_xml"
     )
@@ -1187,8 +1183,6 @@ def test_ogr_wfs_vsimem_fail_because_invalid_xml_capabilities(
 def test_ogr_wfs_vsimem_fail_because_missing_featuretypelist(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -1283,8 +1277,6 @@ def test_ogr_wfs_vsimem_wfs110_open_getcapabilities_file(with_and_without_stream
 
 def test_ogr_wfs_vsimem_wfs110_minimal_instance(with_and_without_streaming):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     # Invalid response, but enough for use
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -1316,8 +1308,6 @@ def test_ogr_wfs_vsimem_wfs110_minimal_instance(with_and_without_streaming):
 def test_ogr_wfs_vsimem_wfs110_one_layer_missing_describefeaturetype(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     # Invalid response, but enough for use
     gdal.FileFromMemBuffer(
@@ -1355,8 +1345,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_invalid_describefeaturetype(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1380,8 +1368,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_describefeaturetype_missing_schema(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1404,8 +1390,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_describefeaturetype_missing_schema(
 def test_ogr_wfs_vsimem_wfs110_one_layer_describefeaturetype(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -1470,8 +1454,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_describefeaturetype(
 def test_ogr_wfs_vsimem_wfs110_one_layer_xmldescriptionfile_to_be_updated(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/ogr_wfs_xmldescriptionfile_to_be_updated.xml",
@@ -1593,8 +1575,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeaturecount_no_hits(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1611,8 +1591,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeaturecount_no_hits(
 def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeaturecount_with_hits(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -1656,8 +1634,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_invalid_getfeaturecount_with_hits(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1679,8 +1655,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_invalid_getfeaturecount_with_hits(
 def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_missing_FeatureCollection(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -1704,8 +1678,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_invalid_xml(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1728,8 +1700,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_ServiceExcept
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1749,8 +1719,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_ServiceExcept
 def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_missing_numberOfFeatures(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -1773,8 +1741,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_missing_numbe
 def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -1805,8 +1771,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 
 def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeature(with_and_without_streaming):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1821,8 +1785,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeature(with_and_without_str
 
 
 def test_ogr_wfs_vsimem_wfs110_one_layer_invalid_getfeature(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -1847,8 +1809,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_exception_getfeature(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -1869,8 +1829,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_exception_getfeature(
 
 
 def test_ogr_wfs_vsimem_wfs110_one_layer_getfeature(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -1953,8 +1911,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 
 def test_ogr_wfs_vsimem_wfs110_one_layer_getextent(with_and_without_streaming):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
     assert lyr.GetExtent() == (2, 2, 49, 49)
@@ -1966,8 +1922,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getextent(with_and_without_streaming):
 def test_ogr_wfs_vsimem_wfs110_one_layer_getextent_without_getfeature(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -1990,8 +1944,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getextent_without_getfeature(
 def test_ogr_wfs_vsimem_wfs110_one_layer_getextent_optimized(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -2083,8 +2035,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getextent_optimized(
 def test_ogr_wfs_vsimem_wfs110_one_layer_getfeature_ogr_getfeature(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -2186,8 +2136,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_filter_gml_id_failed(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -2224,8 +2172,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 def test_ogr_wfs_vsimem_wfs110_one_layer_filter_gml_id_success(
     with_and_without_streaming,
 ):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -2274,8 +2220,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 
 
 def test_ogr_wfs_vsimem_wfs110_one_layer_filter(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -2326,8 +2270,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 
 
 def test_ogr_wfs_vsimem_wfs110_one_layer_filter_spatial_ops(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
@@ -2557,8 +2499,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 
 def test_ogr_wfs_vsimem_wfs110_one_layer_spatial_filter(with_and_without_streaming):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -2622,8 +2562,6 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_spatial_filter_and_attribute_filter(
     with_and_without_streaming,
 ):
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
 
@@ -2674,8 +2612,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 def test_ogr_wfs_vsimem_wfs110_insertfeature(with_and_without_streaming):
 
     wfs_insert_url = None
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     gdal.FileFromMemBuffer(
         "/vsimem/wfs_endpoint?SERVICE=WFS&REQUEST=GetCapabilities",
@@ -3095,8 +3031,6 @@ def test_ogr_wfs_vsimem_wfs110_updatefeature(with_and_without_streaming):
 
     wfs_update_url = None
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint", update=1)
     lyr = ds.GetLayer(0)
 
@@ -3261,8 +3195,6 @@ def test_ogr_wfs_vsimem_wfs110_deletefeature(with_and_without_streaming):
 
     wfs_delete_url = None
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint", update=1)
     lyr = ds.GetLayer(0)
 
@@ -3398,8 +3330,6 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 
 
 def test_ogr_wfs_vsimem_wfs110_schema_not_understood(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     # Invalid response, but enough for use
     gdal.FileFromMemBuffer(
@@ -3538,8 +3468,6 @@ def test_ogr_wfs_vsimem_wfs110_multiple_layers(with_and_without_streaming):
 </WFS_Capabilities>
 """,
     )
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs110_multiple_layers")
     lyr = ds.GetLayer(0)
@@ -3696,8 +3624,6 @@ def test_ogr_wfs_vsimem_wfs110_multiple_layers_same_name_different_ns(
 """,
     )
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs110_multiple_layers_different_ns")
     lyr = ds.GetLayer(0)
     gdal.FileFromMemBuffer(
@@ -3852,8 +3778,6 @@ def test_ogr_wfs_vsimem_wfs200_paging(with_and_without_streaming):
 </WFS_Capabilities>
 """,
     )
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs200_endpoint_paging")
     lyr = ds.GetLayer(0)
@@ -4062,8 +3986,6 @@ def test_ogr_wfs_vsimem_wfs200_json(with_and_without_streaming):
 """,
     )
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs200_endpoint_json?OUTPUTFORMAT=application/json")
     lyr = ds.GetLayer(0)
 
@@ -4135,8 +4057,6 @@ def test_ogr_wfs_vsimem_wfs200_multipart(with_and_without_streaming):
 </WFS_Capabilities>
 """,
     )
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs200_endpoint_multipart?OUTPUTFORMAT=multipart")
     lyr = ds.GetLayer(0)
@@ -4322,8 +4242,6 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
 </xsd:schema>
 """,
     )
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs200_endpoint_join")
     sql_lyr = ds.ExecuteSQL("SELECT * FROM lyr1 JOIN lyr2 ON lyr1.str = lyr2.str2")
@@ -4832,8 +4750,6 @@ def test_ogr_wfs_vsimem_wfs200_join_layer_with_namespace_prefix(
 """,
     )
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     ds = ogr.Open("WFS:/vsimem/wfs200_endpoint_join")
     sql_lyr = ds.ExecuteSQL("SELECT * FROM lyr1 JOIN lyr2 ON lyr1.str = lyr2.str2")
 
@@ -4961,8 +4877,6 @@ def test_ogr_wfs_vsimem_wfs200_join_distinct(with_and_without_streaming):
 </xsd:schema>
 """,
     )
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
 
     ds = ogr.Open("WFS:/vsimem/wfs200_endpoint_join")
     sql_lyr = ds.ExecuteSQL(
@@ -5104,8 +5018,6 @@ def test_ogr_wfs_vsimem_wfs200_supported_crs():
 """,
     )
 
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", "YES")
-
     with gdaltest.config_option("OGR_WFS_TRUST_CAPABILITIES_BOUNDS", "YES"):
         ds = ogr.Open("WFS:/vsimem/test_ogr_wfs_vsimem_wfs200_supported_crs")
     lyr = ds.GetLayer(0)
@@ -5178,8 +5090,6 @@ def test_ogr_wfs_vsimem_wfs200_supported_crs():
 
 
 def test_ogr_wfs_vsimem_cleanup(with_and_without_streaming):
-
-    gdal.SetConfigOption("CPL_CURL_ENABLE_VSIMEM", None)
 
     for f in gdal.ReadDir("/vsimem/"):
         gdal.Unlink("/vsimem/" + f)

--- a/autotest/ogr/ogr_xls.py
+++ b/autotest/ogr/ogr_xls.py
@@ -102,14 +102,12 @@ def test_ogr_xls_2():
     if drv is None:
         pytest.skip()
 
-    gdal.SetConfigOption("OGR_XLS_HEADERS", "DISABLE")
-    ds = ogr.Open("data/xls/test972000xp.xls")
+    with gdal.config_option("OGR_XLS_HEADERS", "DISABLE"):
+        ds = ogr.Open("data/xls/test972000xp.xls")
 
-    lyr = ds.GetLayer(0)
+        lyr = ds.GetLayer(0)
 
-    assert lyr.GetFeatureCount() == 4
-
-    gdal.SetConfigOption("OGR_XLS_HEADERS", None)
+        assert lyr.GetFeatureCount() == 4
 
 
 ###############################################################################
@@ -122,14 +120,12 @@ def test_ogr_xls_3():
     if drv is None:
         pytest.skip()
 
-    gdal.SetConfigOption("OGR_XLS_FIELD_TYPES", "STRING")
-    ds = ogr.Open("data/xls/test972000xp.xls")
+    with gdal.config_option("OGR_XLS_FIELD_TYPES", "STRING"):
+        ds = ogr.Open("data/xls/test972000xp.xls")
 
-    lyr = ds.GetLayer(0)
+        lyr = ds.GetLayer(0)
 
-    assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTString
-
-    gdal.SetConfigOption("OGR_XLS_FIELD_TYPES", None)
+        assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTString
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_xlsx.py
+++ b/autotest/ogr/ogr_xlsx.py
@@ -120,14 +120,12 @@ def test_ogr_xlsx_1():
 
 def test_ogr_xlsx_2():
 
-    gdal.SetConfigOption("OGR_XLSX_HEADERS", "DISABLE")
-    ds = ogr.Open("data/xlsx/test.xlsx")
+    with gdal.config_option("OGR_XLSX_HEADERS", "DISABLE"):
+        ds = ogr.Open("data/xlsx/test.xlsx")
 
-    lyr = ds.GetLayerByName("Feuille7")
+        lyr = ds.GetLayerByName("Feuille7")
 
-    assert lyr.GetFeatureCount() == 3
-
-    gdal.SetConfigOption("OGR_XLSX_HEADERS", None)
+        assert lyr.GetFeatureCount() == 3
 
 
 ###############################################################################
@@ -136,14 +134,12 @@ def test_ogr_xlsx_2():
 
 def test_ogr_xlsx_3():
 
-    gdal.SetConfigOption("OGR_XLSX_FIELD_TYPES", "STRING")
-    ds = ogr.Open("data/xlsx/test.xlsx")
+    with gdal.config_option("OGR_XLSX_FIELD_TYPES", "STRING"):
+        ds = ogr.Open("data/xlsx/test.xlsx")
 
-    lyr = ds.GetLayerByName("Feuille7")
+        lyr = ds.GetLayerByName("Feuille7")
 
-    assert lyr.GetLayerDefn().GetFieldDefn(1).GetType() == ogr.OFTString
-
-    gdal.SetConfigOption("OGR_XLSX_FIELD_TYPES", None)
+        assert lyr.GetLayerDefn().GetFieldDefn(1).GetType() == ogr.OFTString
 
 
 ###############################################################################
@@ -196,22 +192,20 @@ def test_ogr_xlsx_5():
 def test_ogr_xlsx_6():
 
     # In this dataset the column titles are not recognised by default.
-    gdal.SetConfigOption("OGR_XLSX_HEADERS", "FORCE")
-    ds = ogr.Open("data/xlsx/inlineStr.xlsx")
+    with gdal.config_option("OGR_XLSX_HEADERS", "FORCE"):
+        ds = ogr.Open("data/xlsx/inlineStr.xlsx")
 
-    lyr = ds.GetLayerByName("inlineStr")
+        lyr = ds.GetLayerByName("inlineStr")
 
-    assert lyr.GetFeatureCount() == 1
+        assert lyr.GetFeatureCount() == 1
 
-    lyr.ResetReading()
-    feat = lyr.GetNextFeature()
-    assert feat.Bl_District_t == "text6", "Did not get expected value(1)"
+        lyr.ResetReading()
+        feat = lyr.GetNextFeature()
+        assert feat.Bl_District_t == "text6", "Did not get expected value(1)"
 
-    assert float(feat.GetField("Lat")) == pytest.approx(
-        23.6247122, abs=0.00001
-    ), "Did not get expected value(2)"
-
-    gdal.SetConfigOption("OGR_XLSX_HEADERS", None)
+        assert float(feat.GetField("Lat")) == pytest.approx(
+            23.6247122, abs=0.00001
+        ), "Did not get expected value(2)"
 
 
 ###############################################################################
@@ -383,7 +377,6 @@ def test_ogr_xlsx_12():
 
 def test_ogr_xlsx_13():
 
-    gdal.SetConfigOption("OGR_XLSX_FIELD_TYPES", None)
     ds = ogr.Open("data/xlsx/test_missing_row1_data.xlsx")
 
     lyr = ds.GetLayer(0)
@@ -430,7 +423,6 @@ def test_ogr_xlsx_13():
 
 def test_ogr_xlsx_14():
 
-    gdal.SetConfigOption("OGR_XLSX_FIELD_TYPES", None)
     ds = ogr.Open("data/xlsx/test_empty_last_field.xlsx")
 
     lyr = ds.GetLayer(0)

--- a/autotest/ogr/ograpispy.py
+++ b/autotest/ogr/ograpispy.py
@@ -109,14 +109,16 @@ def test_ograpispy_2():
         lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
         ds = None
 
-        gdal.SetConfigOption("OGR_API_SPY_FILE", "tmp/ograpispy_2.py")
-        gdal.SetConfigOption("OGR_API_SPY_SNAPSHOT_PATH", "tmp")
-        ds = ogr.Open("tmp/ograpispy_2.shp", update=1)
-        lyr = ds.GetLayer(0)
-        lyr.CreateFeature(ogr.Feature(lyr.GetLayerDefn()))
-        ds = None
-        gdal.SetConfigOption("OGR_API_SPY_FILE", None)
-        gdal.SetConfigOption("OGR_API_SPY_SNAPSHOT_PATH", None)
+        with gdal.config_options(
+            {
+                "OGR_API_SPY_FILE": "tmp/ograpispy_2.py",
+                "OGR_API_SPY_SNAPSHOT_PATH": "tmp",
+            }
+        ):
+            ds = ogr.Open("tmp/ograpispy_2.shp", update=1)
+            lyr = ds.GetLayer(0)
+            lyr.CreateFeature(ogr.Feature(lyr.GetLayerDefn()))
+            ds = None
 
         ds = ogr.Open("tmp/snapshot_1/source/ograpispy_2.shp")
         lyr = ds.GetLayer(0)

--- a/autotest/utilities/test_gdal_grid_lib.py
+++ b/autotest/utilities/test_gdal_grid_lib.py
@@ -124,38 +124,34 @@ def test_gdal_grid_lib_2():
     shape_lyr.CreateFeature(dst_feat)
     shape_ds = None
 
-    for env_list in [
-        [("GDAL_USE_AVX", "NO"), ("GDAL_USE_SSE", "NO")],
-        [("GDAL_USE_AVX", "NO")],
-        [],
+    for env in [
+        {"GDAL_USE_AVX": "NO", "GDAL_USE_SSE": "NO"},
+        {"GDAL_USE_AVX": "NO"},
+        {},
     ]:
 
-        for (key, value) in env_list:
-            gdal.SetConfigOption(key, value)
+        with gdal.config_options(env):
 
-        # Point strictly on grid
-        ds1 = gdal.Grid(
-            "",
-            "/vsimem/tmp/test_gdal_grid_lib_2.shp",
-            format="MEM",
-            outputBounds=[-0.5, -0.5, 0.5, 0.5],
-            width=1,
-            height=1,
-            outputType=gdal.GDT_Byte,
-        )
+            # Point strictly on grid
+            ds1 = gdal.Grid(
+                "",
+                "/vsimem/tmp/test_gdal_grid_lib_2.shp",
+                format="MEM",
+                outputBounds=[-0.5, -0.5, 0.5, 0.5],
+                width=1,
+                height=1,
+                outputType=gdal.GDT_Byte,
+            )
 
-        ds2 = gdal.Grid(
-            "",
-            "/vsimem/tmp/test_gdal_grid_lib_2.shp",
-            format="MEM",
-            outputBounds=[-0.4, -0.4, 0.6, 0.6],
-            width=10,
-            height=10,
-            outputType=gdal.GDT_Byte,
-        )
-
-        gdal.SetConfigOption("GDAL_USE_AVX", None)
-        gdal.SetConfigOption("GDAL_USE_SSE", None)
+            ds2 = gdal.Grid(
+                "",
+                "/vsimem/tmp/test_gdal_grid_lib_2.shp",
+                format="MEM",
+                outputBounds=[-0.4, -0.4, 0.6, 0.6],
+                width=10,
+                height=10,
+                outputType=gdal.GDT_Byte,
+            )
 
         cs = ds1.GetRasterBand(1).Checksum()
         assert cs == 2

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -1341,25 +1341,23 @@ def test_gdalwarp_lib_128():
         gdal.Unlink(cutlineDSName)
         return
 
-    gdal.SetConfigOption("GDALWARP_DENSIFY_CUTLINE", "ONLY_IF_INVALID")
-    ds = gdal.Warp(
-        "",
-        mem_ds,
-        format="MEM",
-        cutlineDSName=cutlineDSName,
-        dstSRS="EPSG:4326",
-        outputBounds=[7.2, 32.52, 7.217, 32.59],
-        xRes=0.000226555,
-        yRes=0.000226555,
-        transformerOptions=["RPC_DEM=data/test_gdalwarp_lib_128_dem.tif"],
-    )
-    gdal.SetConfigOption("GDALWARP_DENSIFY_CUTLINE", None)
+    with gdal.config_option("GDALWARP_DENSIFY_CUTLINE", "ONLY_IF_INVALID"):
+        ds = gdal.Warp(
+            "",
+            mem_ds,
+            format="MEM",
+            cutlineDSName=cutlineDSName,
+            dstSRS="EPSG:4326",
+            outputBounds=[7.2, 32.52, 7.217, 32.59],
+            xRes=0.000226555,
+            yRes=0.000226555,
+            transformerOptions=["RPC_DEM=data/test_gdalwarp_lib_128_dem.tif"],
+        )
     cs = ds.GetRasterBand(1).Checksum()
 
     assert cs == 4248, "bad checksum"
 
-    gdal.SetConfigOption("GDALWARP_DENSIFY_CUTLINE", "NO")
-    with pytest.raises(Exception):
+    with gdal.config_option("GDALWARP_DENSIFY_CUTLINE", "NO"), pytest.raises(Exception):
         gdal.Warp(
             "",
             mem_ds,
@@ -1371,7 +1369,6 @@ def test_gdalwarp_lib_128():
             yRes=0.000226555,
             transformerOptions=["RPC_DEM=data/test_gdalwarp_lib_128_dem.tif"],
         )
-    gdal.SetConfigOption("GDALWARP_DENSIFY_CUTLINE", None)
 
     gdal.Unlink(cutlineDSName)
 


### PR DESCRIPTION
## What does this PR do?

Replaces _most_ usages of `gdal.SetConfigOption` with `wwith gdal.config_option`. Leaves some complex usages of `gdal.SetConfigOption` (e.g., within loops) as-is.

## What are related issues/pull requests?

#7417

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
