### PR TITLE
Add API methods for retrieving alternative names and comments for dataset layers

### DIFF
--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1204,6 +1204,8 @@ int CPL_DLL GDALDatasetGetLayerCount(GDALDatasetH);
 OGRLayerH CPL_DLL GDALDatasetGetLayer(GDALDatasetH, int);
 OGRLayerH CPL_DLL GDALDatasetGetLayerByName(GDALDatasetH, const char *);
 int CPL_DLL GDALDatasetIsLayerPrivate(GDALDatasetH, int);
+const char CPL_DLL *GDALDatasetGetLayerAlternativeName(GDALDatasetH, int);
+const char CPL_DLL *GDALDatasetGetLayerComment(GDALDatasetH, int);
 OGRErr CPL_DLL GDALDatasetDeleteLayer(GDALDatasetH, int);
 OGRLayerH CPL_DLL GDALDatasetCreateLayer(GDALDatasetH, const char *,
                                          OGRSpatialReferenceH,

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -388,6 +388,9 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     mutable std::map<std::string, std::unique_ptr<OGRFieldDomain>>
         m_oMapFieldDomains{};
 
+    mutable std::map<int, std::string> m_oMapLayerAlternativeNames{};
+    mutable std::map<int, std::string> m_oMapLayerComments{};
+
     GDALDataset(void);
     explicit GDALDataset(int bForceCachedIO);
 
@@ -740,6 +743,8 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     virtual OGRLayer *GetLayer(int iLayer);
 
     virtual bool IsLayerPrivate(int iLayer) const;
+    virtual const std::string &GetLayerAlternativeName(int iLayer) const;
+    virtual const std::string &GetLayerComment(int iLayer) const;
 
     /** Class returned by GetLayers() that acts as a range of layers.
      * @since GDAL 2.3

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -4566,6 +4566,56 @@ int GDALDatasetIsLayerPrivate(GDALDatasetH hDS, int iLayer)
 }
 
 /************************************************************************/
+/*                  GDALDatasetGetLayerAlternativeName()                */
+/************************************************************************/
+
+/**
+ \brief Returns the alternative name (or "alias") of the layer at the specified index.
+
+ The alternative name is an optional attribute for a layer which can provide
+ a more user-friendly, descriptive name of the layer which is not subject to
+ the usual naming constraints defined by the data provider.
+
+ @since GDAL 3.7
+
+ @param hDS the dataset handle.
+ @param iLayer a layer number between 0 and GetLayerCount()-1.
+
+ @return alternative name or nullptr if not available or not supported by the driver.
+*/
+
+const char *GDALDatasetGetLayerAlternativeName(GDALDatasetH hDS, int iLayer)
+{
+    VALIDATE_POINTER1(hDS, "GDALDatasetGetLayerAlternativeName", nullptr);
+
+    return GDALDataset::FromHandle(hDS)
+        ->GetLayerAlternativeName(iLayer)
+        .c_str();
+}
+
+/************************************************************************/
+/*                  GDALDatasetGetLayerComment()                        */
+/************************************************************************/
+
+/**
+ \brief Returns the comment for the layer at the specified index.
+
+ @since GDAL 3.7
+
+ @param hDS the dataset handle.
+ @param iLayer a layer number between 0 and GetLayerCount()-1.
+
+ @return comment or nullptr if not available or not supported by the driver.
+*/
+
+const char *GDALDatasetGetLayerComment(GDALDatasetH hDS, int iLayer)
+{
+    VALIDATE_POINTER1(hDS, "GDALDatasetGetLayerComment", nullptr);
+
+    return GDALDataset::FromHandle(hDS)->GetLayerComment(iLayer).c_str();
+}
+
+/************************************************************************/
 /*                        GDALDatasetDeleteLayer()                      */
 /************************************************************************/
 
@@ -7030,6 +7080,55 @@ OGRLayer *GDALDataset::GetLayer(CPL_UNUSED int iLayer)
 bool GDALDataset::IsLayerPrivate(CPL_UNUSED int iLayer) const
 {
     return false;
+}
+
+/************************************************************************/
+/*                       GetLayerAlternativeName()                      */
+/************************************************************************/
+
+/**
+ \fn GDALDataset::GetLayerAlternativeName(int)
+ \brief Returns the alternative name (or "alias") of the layer at the specified index.
+
+ The alternative name is an optional attribute for a layer which can provide
+ a more user-friendly, descriptive name of the layer which is not subject to
+ the usual naming constraints defined by the data provider.
+
+ This method is the same as the C function GDALDatasetGetLayerAlternativeName().
+
+ @param iLayer a layer number between 0 and GetLayerCount()-1.
+
+ @return alternative name or empty string if not available or not supported by the driver.
+
+ @since GDAL 3.7
+*/
+
+const std::string &
+GDALDataset::GetLayerAlternativeName(CPL_UNUSED int iLayer) const
+{
+    return m_oMapLayerAlternativeNames[iLayer];
+}
+
+/************************************************************************/
+/*                       GetLayerComment()                              */
+/************************************************************************/
+
+/**
+ \fn GDALDataset::GetLayerComment(int)
+ \brief Returns the comment attached to layer at the specified index.
+
+ This method is the same as the C function GDALDatasetGetLayerComment().
+
+ @param iLayer a layer number between 0 and GetLayerCount()-1.
+
+ @return comment or empty string if not available or not supported by the driver.
+
+ @since GDAL 3.7
+*/
+
+const std::string &GDALDataset::GetLayerComment(CPL_UNUSED int iLayer) const
+{
+    return m_oMapLayerComments[iLayer];
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
+++ b/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
@@ -90,6 +90,8 @@ class OGRDataSourceWithTransaction final : public OGRDataSource
     std::map<CPLString, OGRLayerWithTransaction *> m_oMapLayers{};
     std::set<OGRLayerWithTransaction *> m_oSetLayers{};
     std::set<OGRLayer *> m_oSetExecuteSQLLayers{};
+    std::string m_osEmptyAlternativeName{};
+    std::string m_osEmptyComment{};
 
     OGRLayer *WrapLayer(OGRLayer *poLayer);
     void RemapLayers();
@@ -114,6 +116,9 @@ class OGRDataSourceWithTransaction final : public OGRDataSource
     virtual OGRLayer *GetLayerByName(const char *) override;
     virtual OGRErr DeleteLayer(int) override;
     virtual bool IsLayerPrivate(int iLayer) const override;
+    virtual const std::string &
+    GetLayerAlternativeName(int iLayer) const override;
+    virtual const std::string &GetLayerComment(int iLayer) const override;
 
     virtual int TestCapability(const char *) override;
 
@@ -310,6 +315,22 @@ bool OGRDataSourceWithTransaction::IsLayerPrivate(int iLayer) const
     if (!m_poBaseDataSource)
         return false;
     return m_poBaseDataSource->IsLayerPrivate(iLayer);
+}
+
+const std::string &
+OGRDataSourceWithTransaction::GetLayerAlternativeName(int iLayer) const
+{
+    if (!m_poBaseDataSource)
+        return m_osEmptyAlternativeName;
+    return m_poBaseDataSource->GetLayerAlternativeName(iLayer);
+}
+
+const std::string &
+OGRDataSourceWithTransaction::GetLayerComment(int iLayer) const
+{
+    if (!m_poBaseDataSource)
+        return m_osEmptyComment;
+    return m_poBaseDataSource->GetLayerComment(iLayer);
 }
 
 int OGRDataSourceWithTransaction::TestCapability(const char *pszCap)

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
@@ -121,6 +121,21 @@ bool OGRMutexedDataSource::IsLayerPrivate(int iLayer) const
     return m_poBaseDataSource->IsLayerPrivate(iLayer);
 }
 
+const std::string &
+OGRMutexedDataSource::GetLayerAlternativeName(int iLayer) const
+{
+    if (!m_poBaseDataSource)
+        return m_osEmptyAlternativeName;
+    return m_poBaseDataSource->GetLayerAlternativeName(iLayer);
+}
+
+const std::string &OGRMutexedDataSource::GetLayerComment(int iLayer) const
+{
+    if (!m_poBaseDataSource)
+        return m_osEmptyComment;
+    return m_poBaseDataSource->GetLayerComment(iLayer);
+}
+
 int OGRMutexedDataSource::TestCapability(const char *pszCap)
 {
     CPLMutexHolderOptionalLockD(m_hGlobalMutex);

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
@@ -56,6 +56,9 @@ class CPL_DLL OGRMutexedDataSource : public OGRDataSource
     std::map<OGRLayer *, OGRMutexedLayer *> m_oMapLayers{};
     std::map<OGRMutexedLayer *, OGRLayer *> m_oReverseMapLayers{};
 
+    std::string m_osEmptyAlternativeName{};
+    std::string m_osEmptyComment{};
+
     OGRLayer *WrapLayerIfNecessary(OGRLayer *poLayer);
 
   public:
@@ -78,6 +81,9 @@ class CPL_DLL OGRMutexedDataSource : public OGRDataSource
     virtual OGRLayer *GetLayerByName(const char *) override;
     virtual OGRErr DeleteLayer(int) override;
     virtual bool IsLayerPrivate(int iLayer) const override;
+    virtual const std::string &
+    GetLayerAlternativeName(int iLayer) const override;
+    virtual const std::string &GetLayerComment(int iLayer) const override;
 
     virtual int TestCapability(const char *) override;
 

--- a/swig/include/Dataset.i
+++ b/swig/include/Dataset.i
@@ -809,6 +809,14 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
     return GDALDatasetIsLayerPrivate(self, index);
   }
 
+  const char * GetLayerAlternativeName( int index ) {
+    return GDALDatasetGetLayerAlternativeName(self, index);
+  }
+
+  const char * GetLayerComment( int index ) {
+    return GDALDatasetGetLayerComment(self, index);
+  }
+
 #ifdef SWIGJAVA
   OGRLayerShadow *GetLayerByIndex( int index ) {
 #else


### PR DESCRIPTION
Draft only, for feedback at this stage...

The intention is that these would be the layer-level equivalents of the OGR field alternative name / comment properties.

Eg the geopackage driver could retrieve these from the `gpkg_contents` table fields `identifier` and `description` columns respectively, and the postgres driver could retrieve table comments from which have been set via a `COMMENT ON ...` query.