### PR TITLE
Add support for JPEG to gdal2tiles.py

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -910,6 +910,8 @@ def scale_query_to_tile(dsquery, dstile, options, tilefilename=""):
                 params["lossless"] = True
             else:
                 params["quality"] = options.webp_quality
+        elif options.tiledriver == "JPEG":
+            params["quality"] = options.jpeg_quality
         im1.save(tilefilename, options.tiledriver, **params)
 
     else:
@@ -1295,6 +1297,8 @@ def _get_creation_options(options):
             copts = ["LOSSLESS=True"]
         else:
             copts = ["QUALITY=" + str(options.webp_quality)]
+    elif options.tiledriver == "JPEG":
+        copts = ["QUALITY=" + str(options.jpeg_quality)]
     return copts
 
 
@@ -1408,7 +1412,7 @@ def create_base_tile(tile_job_info: "TileJobInfo", tile_detail: "TileDetail") ->
     if options.resampling != "antialias":
         # Write a copy of tile to png/jpg
         out_drv.CreateCopy(
-            tilefilename, dstile, strict=0, options=_get_creation_options(options)
+                tilefilename, dstile if tile_job_info.tile_driver != "JPEG" else remove_alpha_band(dstile), strict=0, options=_get_creation_options(options)
         )
 
     del dstile
@@ -1437,6 +1441,23 @@ def create_base_tile(tile_job_info: "TileJobInfo", tile_detail: "TileDetail") ->
                         ).encode("utf-8")
                     )
 
+def remove_alpha_band(src_ds):
+    new_band_count = src_ds.RasterCount - 1
+
+    dst_ds = gdal.GetDriverByName('MEM').Create(
+        '', src_ds.RasterXSize, src_ds.RasterYSize, new_band_count, src_ds.GetRasterBand(1).DataType
+    )
+
+    dst_ds.SetGeoTransform(src_ds.GetGeoTransform())
+    dst_ds.SetProjection(src_ds.GetProjection())
+
+    for i in range(1, new_band_count + 1):
+        src_band = src_ds.GetRasterBand(i)
+        dst_band = dst_ds.GetRasterBand(i)
+        dst_band.WriteArray(src_band.ReadAsArray())
+#        dst_band.SetNoDataValue(src_band.GetNoDataValue())
+
+    return dst_ds
 
 def create_overview_tile(
     base_tz: int,
@@ -1740,7 +1761,7 @@ def optparse_init() -> optparse.OptionParser:
     p.add_option(
         "--tiledriver",
         dest="tiledriver",
-        choices=["PNG", "WEBP"],
+        choices=["PNG", "WEBP", "JPEG"],
         default="PNG",
         type="choice",
         help="which tile driver to use for the tiles",
@@ -1835,6 +1856,17 @@ def optparse_init() -> optparse.OptionParser:
         dest="webp_lossless",
         action="store_true",
         help="use lossless compression for the webp image",
+    )
+    p.add_option_group(g)
+
+    # Jpeg options
+    g = optparse.OptionGroup(p, "JPEG options", "Options for JPEG tiledriver")
+    g.add_option(
+        "--jpeg-quality",
+        dest="jpeg_quality",
+        type=int,
+        default=80,
+        help="quality of jpeg image, integer between 1 and 100, default is 75",
     )
     p.add_option_group(g)
 
@@ -1951,6 +1983,13 @@ def options_post_processing(
             if options.webp_quality <= 0 or options.webp_quality > 100:
                 exit_with_error("webp_quality should be in the range [1-100]")
             options.webp_quality = int(options.webp_quality)
+    elif options.tiledriver == "JPEG":
+        if gdal.GetDriverByName(options.tiledriver) is None:
+            exit_with_error("JPEG driver is not available")
+
+        if options.jpeg_quality <= 0 or options.jpeg_quality > 100:
+            exit_with_error("jpeg_quality should be in the range [1-100]")
+        options.jpeg_quality = int(options.jpeg_quality)
 
     # Output the results
     if options.verbose:
@@ -2068,8 +2107,10 @@ class GDAL2Tiles(object):
         self.tiledriver = options.tiledriver
         if options.tiledriver == "PNG":
             self.tileext = "png"
-        else:
+        elif options.tiledriver == "WEBP":
             self.tileext = "webp"
+        else:
+            self.tileext = "jpg"
         if options.mpi:
             makedirs(output_folder)
             self.tmp_dir = tempfile.mkdtemp(dir=output_folder)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Add support for JPEG for `gdal2tiles.py`. Should fix #6703.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

