### PR TITLE
- Added fixes for the OGC API Tiles driver

### DIFF
--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -684,7 +684,7 @@ bool OGCAPIDataset::ProcessScale(CPLJSONObject &oScaleDenominator,
         dfYSize /= 2;
     }
 
-    nRasterXSize = std::max(1, static_cast<int>(0 + 5 + dfXSize));
+    nRasterXSize = std::max(1, static_cast<int>(0.5 + dfXSize));
     nRasterYSize = std::max(1, static_cast<int>(0.5 + dfYSize));
     m_adfGeoTransform[0] = dfXMin;
     m_adfGeoTransform[1] = (dfXMax - dfXMin) / nRasterXSize;

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -94,7 +94,7 @@ class OGCAPIDataset final : public GDALDataset
 
     bool InitFromFile(GDALOpenInfo *poOpenInfo);
     bool InitFromURL(GDALOpenInfo *poOpenInfo);
-    bool ProcessScale(CPLJSONObject &oScaleDenominator, const double dfXMin,
+    void ProcessScale(CPLJSONObject &oScaleDenominator, const double dfXMin,
                       const double dfYMin, const double dfXMax,
                       const double dfYMax);
     bool InitFromCollection(GDALOpenInfo *poOpenInfo, CPLJSONDocument &oDoc);
@@ -662,12 +662,11 @@ bool OGCAPIDataset::InitFromFile(GDALOpenInfo *poOpenInfo)
 /*                        ProcessScale()                          */
 /************************************************************************/
 
-bool OGCAPIDataset::ProcessScale(CPLJSONObject &oScaleDenominator,
+void OGCAPIDataset::ProcessScale(CPLJSONObject &oScaleDenominator,
                                  const double dfXMin, const double dfYMin,
                                  const double dfXMax, const double dfYMax)
 
 {
-    bool bRet = FALSE;
     double dfRes = 1e-8;  // arbitrary
     if (oScaleDenominator.IsValid())
     {
@@ -690,10 +689,6 @@ bool OGCAPIDataset::ProcessScale(CPLJSONObject &oScaleDenominator,
     m_adfGeoTransform[1] = (dfXMax - dfXMin) / nRasterXSize;
     m_adfGeoTransform[3] = dfYMax;
     m_adfGeoTransform[5] = -(dfYMax - dfYMin) / nRasterYSize;
-
-    bRet = TRUE;
-
-    return bRet;
 }
 
 /************************************************************************/
@@ -743,11 +738,7 @@ bool OGCAPIDataset::InitFromCollection(GDALOpenInfo *poOpenInfo,
 
     auto oScaleDenominator = oRoot["scaleDenominator"];
 
-    if (!ProcessScale(oScaleDenominator, dfXMin, dfYMin, dfXMax, dfYMax))
-    {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not process scale");
-        return false;
-    }
+    ProcessScale(oScaleDenominator, dfXMin, dfYMin, dfXMax, dfYMax);
 
     bool bFoundMap = false;
     CPLString osTilesetsMapURL;

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1671,13 +1671,11 @@ bool OGCAPIDataset::InitWithTilesAPI(GDALOpenInfo *poOpenInfo,
                       MEDIA_TYPE_JSON))
         return false;
 
-    const auto uri =
-        oDoc.GetRoot().GetString("uri");
+    const auto uri = oDoc.GetRoot().GetString("uri");
 
     if (uri.empty())
     {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "Cannot parse TMS uri");
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot parse TMS uri");
         return false;
     }
 

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1696,15 +1696,11 @@ bool OGCAPIDataset::InitWithTilesAPI(GDALOpenInfo *poOpenInfo,
                       MEDIA_TYPE_JSON))
         return false;
 
+    // Attempts to find the uri for a well-known TMS; if it does not work, it will send the entire document
     const auto uri = oDoc.GetRoot().GetString("uri");
 
-    if (uri.empty())
-    {
-        CPLError(CE_Failure, CPLE_AppDefined, "Cannot parse TMS uri");
-        return false;
-    }
-
-    auto tms = gdal::TileMatrixSet::parse(uri.c_str());
+    auto tms = gdal::TileMatrixSet::parse(
+        !uri.empty() ? uri.c_str() : oDoc.SaveAsString().c_str());
     if (tms == nullptr)
         return false;
 

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1670,7 +1670,18 @@ bool OGCAPIDataset::InitWithTilesAPI(GDALOpenInfo *poOpenInfo,
     if (!DownloadJSon(osTilingSchemeURL.c_str(), oDoc, nullptr,
                       MEDIA_TYPE_JSON))
         return false;
-    auto tms = gdal::TileMatrixSet::parse(oDoc.SaveAsString().c_str());
+
+    const auto uri =
+        oDoc.GetRoot().GetString("uri");
+
+    if (uri.empty())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Cannot parse TMS uri");
+        return false;
+    }
+
+    auto tms = gdal::TileMatrixSet::parse(uri.c_str());
     if (tms == nullptr)
         return false;
 

--- a/gcore/tilematrixset.cpp
+++ b/gcore/tilematrixset.cpp
@@ -77,7 +77,8 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
     std::unique_ptr<TileMatrixSet> poTMS(new TileMatrixSet());
 
     constexpr double HALF_CIRCUMFERENCE = 6378137 * M_PI;
-    if (EQUAL(fileOrDef, "GoogleMapsCompatible"))
+    if (EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/GoogleCRS84Quad")
+            || EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad"))
     {
         /* See http://portal.opengeospatial.org/files/?artifact_id=35326
          * (WMTS 1.0), Annex E.4 */
@@ -109,7 +110,7 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
         return poTMS;
     }
 
-    if (EQUAL(fileOrDef, "InspireCRS84Quad"))
+    if (EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad"))
     {
         /* See InspireCRS84Quad at
          * http://inspire.ec.europa.eu/documents/Network_Services/TechnicalGuidance_ViewServices_v3.0.pdf

--- a/gcore/tilematrixset.cpp
+++ b/gcore/tilematrixset.cpp
@@ -77,7 +77,8 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
     std::unique_ptr<TileMatrixSet> poTMS(new TileMatrixSet());
 
     constexpr double HALF_CIRCUMFERENCE = 6378137 * M_PI;
-    if (EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/GoogleCRS84Quad")
+    if (EQUAL(fileOrDef,"GoogleMapsCompatible")
+        || EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/GoogleCRS84Quad")
             || EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad"))
     {
         /* See http://portal.opengeospatial.org/files/?artifact_id=35326
@@ -110,7 +111,8 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
         return poTMS;
     }
 
-    if (EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad"))
+    if (EQUAL(fileOrDef,"InspireCRS84Quad")
+        || EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad"))
     {
         /* See InspireCRS84Quad at
          * http://inspire.ec.europa.eu/documents/Network_Services/TechnicalGuidance_ViewServices_v3.0.pdf

--- a/gcore/tilematrixset.cpp
+++ b/gcore/tilematrixset.cpp
@@ -77,9 +77,12 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
     std::unique_ptr<TileMatrixSet> poTMS(new TileMatrixSet());
 
     constexpr double HALF_CIRCUMFERENCE = 6378137 * M_PI;
-    if (EQUAL(fileOrDef,"GoogleMapsCompatible")
-        || EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/GoogleCRS84Quad")
-            || EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad"))
+    if (EQUAL(fileOrDef, "GoogleMapsCompatible") ||
+        EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/"
+                         "GoogleCRS84Quad") ||
+        EQUAL(
+            fileOrDef,
+            "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad"))
     {
         /* See http://portal.opengeospatial.org/files/?artifact_id=35326
          * (WMTS 1.0), Annex E.4 */
@@ -111,8 +114,10 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
         return poTMS;
     }
 
-    if (EQUAL(fileOrDef,"InspireCRS84Quad")
-        || EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad"))
+    if (EQUAL(fileOrDef, "InspireCRS84Quad") ||
+        EQUAL(
+            fileOrDef,
+            "http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad"))
     {
         /* See InspireCRS84Quad at
          * http://inspire.ec.europa.eu/documents/Network_Services/TechnicalGuidance_ViewServices_v3.0.pdf

--- a/gcore/tilematrixset.cpp
+++ b/gcore/tilematrixset.cpp
@@ -78,8 +78,6 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
 
     constexpr double HALF_CIRCUMFERENCE = 6378137 * M_PI;
     if (EQUAL(fileOrDef, "GoogleMapsCompatible") ||
-        EQUAL(fileOrDef, "http://www.opengis.net/def/tilematrixset/OGC/1.0/"
-                         "GoogleCRS84Quad") ||
         EQUAL(
             fileOrDef,
             "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad"))


### PR DESCRIPTION
The OGC API Tiles dataset was not working as expected.

A complete document was being passed to TileMatrixSet::parse, which was causing a series of issues:
- the comparisons with the well-known uris were never verified
- all the other ways of retrieving a TMS were failing and it was falling back to reading TMS from a file (which had the entire document in the filename causing buffer overflow)

The well-known URI was being compared to a word/name, rather than an uri. I added support to two of the most popular ones, but we could add more.

Submitted changes:
 - Passed uri to TileMatrixSet::parse
 - updated uris of well-known tile matrix sets

With these changes, I can read raster and vector tiles from these urls:

`gdalinfo -oo API=TILES --config CPL_DEBUG ON "OGCAPI:https://maps.gnosis.earth/ogcapi/collections/blueMarble"`
`ogrinfo -oo API=TILES --config CPL_DEBUG ON "OGCAPI:https://maps.gnosis.earth/ogcapi/collections/Daraa"`
