### PR TITLE
autotest: Use pytest.mark instead of skip decorators

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -6,7 +6,7 @@ import sys
 
 import pytest
 
-from osgeo import gdal, ogr
+from osgeo import gdal, ogr, osr
 
 # Explicitly enable exceptions since autotest/ now assumes them to be
 # enabled
@@ -167,6 +167,26 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(
                     pytest.mark.skip(
                         f"Requires GEOS >= {'.'.join(str(x) for x in required_version)}"
+                    )
+                )
+
+        for mark in item.iter_markers("require_proj"):
+            required_version = (
+                mark.args[0],
+                mark.args[1] if len(mark.args) > 1 else 0,
+                mark.args[2] if len(mark.args) > 2 else 0,
+            )
+
+            actual_version = (
+                osr.GetPROJVersionMajor(),
+                osr.GetPROJVersionMinor(),
+                osr.GetPROJVersionMicro(),
+            )
+
+            if actual_version < required_version:
+                item.add_marker(
+                    pytest.mark.skip(
+                        f"Requires PROJ >= {'.'.join(str(x) for x in required_version)}"
                     )
                 )
 

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -147,6 +147,22 @@ def pytest_collection_modifyitems(config, items):
             if not gdaltest.run_slow_tests():
                 item.add_marker(pytest.mark.skip("GDAL_RUN_SLOW_TESTS not set"))
 
+        for mark in item.iter_markers("require_creation_option"):
+
+            driver, option = mark.args
+
+            drv = gdal.GetDriverByName(driver)
+            if drv is None:
+                item.add_marker(
+                    pytest.mark.skip(f"{driver} driver is not included in this build")
+                )
+            elif option not in drv.GetMetadata()["DMD_CREATIONOPTIONLIST"]:
+                item.add_marker(
+                    pytest.mark.skip(
+                        f"{driver} creation option {option} not supported in this build"
+                    )
+                )
+
         for mark in item.iter_markers("require_geos"):
             if not ogrtest.have_geos():
                 item.add_marker(pytest.mark.skip("GEOS not available"))

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -299,7 +299,7 @@ def test_cog_creation_of_overviews():
 # Test creation of overviews with a different compression method
 
 
-@gdaltest.require_creation_option("COG", "JPEG")
+@pytest.mark.require_creation_option("COG", "JPEG")
 def test_cog_creation_of_overviews_with_compression():
 
     directory = "/vsimem/test_cog_creation_of_overviews_with_compression"
@@ -391,7 +391,7 @@ def test_cog_creation_of_overviews_with_mask():
 # Test full world reprojection to WebMercator
 
 
-@gdaltest.require_creation_option("COG", "JPEG")
+@pytest.mark.require_creation_option("COG", "JPEG")
 def test_cog_small_world_to_web_mercator():
 
     tab = [0]
@@ -948,7 +948,7 @@ def test_cog_sparse():
 # Test SPARSE_OK=YES with mask
 
 
-@gdaltest.require_creation_option("COG", "JPEG")
+@pytest.mark.require_creation_option("COG", "JPEG")
 def test_cog_sparse_mask():
 
     filename = "/vsimem/cog.tif"
@@ -1043,7 +1043,7 @@ def test_cog_sparse_mask():
 # Test SPARSE_OK=YES with imagery at 0 and mask at 255
 
 
-@gdaltest.require_creation_option("COG", "JPEG")
+@pytest.mark.require_creation_option("COG", "JPEG")
 def test_cog_sparse_imagery_0_mask_255():
 
     filename = "/vsimem/cog.tif"
@@ -1099,7 +1099,7 @@ def test_cog_sparse_imagery_0_mask_255():
 # Test SPARSE_OK=YES with imagery at 0 or 255 and mask at 255
 
 
-@gdaltest.require_creation_option("COG", "JPEG")
+@pytest.mark.require_creation_option("COG", "JPEG")
 def test_cog_sparse_imagery_0_or_255_mask_255():
 
     filename = "/vsimem/cog.tif"
@@ -1169,7 +1169,7 @@ def test_cog_sparse_imagery_0_or_255_mask_255():
 # Test SPARSE_OK=YES with imagery and mask at 0
 
 
-@gdaltest.require_creation_option("COG", "JPEG")
+@pytest.mark.require_creation_option("COG", "JPEG")
 def test_cog_sparse_imagery_mask_0():
 
     filename = "/vsimem/cog.tif"
@@ -1529,7 +1529,7 @@ def test_cog_odd_overview_size_and_msk():
 # Test turning on lossy WEBP compression if OVERVIEW_QUALITY < 100 specified
 
 
-@gdaltest.require_creation_option("COG", "WEBP")
+@pytest.mark.require_creation_option("COG", "WEBP")
 @pytest.mark.require_driver("WEBP")
 def test_cog_webp_overview_turn_on_lossy_if_webp_level():
 
@@ -1561,7 +1561,7 @@ def test_cog_webp_overview_turn_on_lossy_if_webp_level():
 # Test lossless WEBP compression
 
 
-@gdaltest.require_creation_option("COG", "WEBP")
+@pytest.mark.require_creation_option("COG", "WEBP")
 @pytest.mark.require_driver("WEBP")
 def test_cog_webp_lossless_webp():
 
@@ -1641,7 +1641,7 @@ def test_cog_overview_count_existing():
 # Test JPEGXL compression with alpha
 
 
-@gdaltest.require_creation_option("COG", "JXL")
+@pytest.mark.require_creation_option("COG", "JXL")
 def test_cog_write_jpegxl_alpha():
 
     src_ds = gdal.Open("data/stefan_full_rgba.tif")
@@ -1681,7 +1681,7 @@ def test_cog_write_jpegxl_alpha():
 # Test JXL_ALPHA_DISTANCE creation option
 
 
-@gdaltest.require_creation_option(
+@pytest.mark.require_creation_option(
     "COG", "JXL_ALPHA_DISTANCE"
 )  # "libjxl > 0.8.1 required"
 def test_cog_write_jpegxl_alpha_distance_zero():

--- a/autotest/gcore/mask.py
+++ b/autotest/gcore/mask.py
@@ -461,7 +461,7 @@ def test_mask_13():
 # Test creation of internal TIFF mask band
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_mask_14():
 
     src_ds = gdal.Open("data/byte.tif")
@@ -800,7 +800,7 @@ def test_mask_22():
 # internal mask (#3800)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_mask_23():
 
     drv = gdal.GetDriverByName("GTiff")

--- a/autotest/gcore/pam.py
+++ b/autotest/gcore/pam.py
@@ -176,7 +176,7 @@ def test_pam_4():
 #
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_pam_5():
 
     ds = gdal.Open("data/sasha.tif")

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -379,7 +379,7 @@ def test_tiff_ovr_rms_palette(both_endian):
 
 @pytest.mark.parametrize("option_name_suffix", ["", "_OVERVIEW"])
 @pytest.mark.parametrize("read_only", [True, False])
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_ovr_9(both_endian, option_name_suffix, read_only):
 
     tiff_drv = gdal.GetDriverByName("GTiff")
@@ -437,7 +437,7 @@ def test_tiff_ovr_9(both_endian, option_name_suffix, read_only):
 # Similar to tiff_ovr_9 but with internal overviews.
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_ovr_10(both_endian):
 
     src_ds = gdal.Open("data/rgbsmall.tif", gdal.GA_ReadOnly)
@@ -1595,7 +1595,7 @@ def test_tiff_ovr_42(both_endian):
 @pytest.mark.skipif(
     "SKIP_TIFF_JPEG12" in os.environ, reason="Crashes on build-windows-msys2-mingw"
 )
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_ovr_43(both_endian):
 
     with gdaltest.config_option("CPL_ACCUM_ERROR_MSG", "ON"):
@@ -2144,7 +2144,7 @@ def test_tiff_ovr_53():
 # Test external overviews building in several steps with jpeg compression
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_ovr_54():
 
     src_ds = gdal.Open("../gdrivers/data/small_world.tif")

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -250,7 +250,7 @@ def test_tiff_read_cmyk_raw():
 # Test reading a OJPEG image
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_ojpeg():
     with gdal.ExceptionMgr(useExceptions=False):
         with gdaltest.error_handler():
@@ -705,7 +705,7 @@ def test_tiff_GTModelTypeGeoKey_only():
 @pytest.mark.skipif(
     "SKIP_TIFF_JPEG12" in os.environ, reason="Crashes on build-windows-msys2-mingw"
 )
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @gdaltest.disable_exceptions()
 def test_tiff_12bitjpeg():
     gdal.ErrorReset()
@@ -1071,7 +1071,7 @@ def test_tiff_read_exif_and_gps():
 # Test reading a pixel interleaved RGBA JPEG-compressed TIFF
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_jpeg_rgba_pixel_interleaved():
     ds = gdal.Open("data/stefan_full_rgba_jpeg_contig.tif")
     md = ds.GetMetadata("IMAGE_STRUCTURE")
@@ -1094,7 +1094,7 @@ def test_tiff_jpeg_rgba_pixel_interleaved():
 # Test reading a band interleaved RGBA JPEG-compressed TIFF
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_jpeg_rgba_band_interleaved():
     ds = gdal.Open("data/stefan_full_rgba_jpeg_separate.tif")
     md = ds.GetMetadata("IMAGE_STRUCTURE")
@@ -1117,7 +1117,7 @@ def test_tiff_jpeg_rgba_band_interleaved():
 # Test reading a YCbCr JPEG all-in-one-strip multiband TIFF (#3259, #3894)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_online_1():
     gdaltest.download_or_skip(
         "http://trac.osgeo.org/gdal/raw-attachment/ticket/3259/imgpb17.tif",
@@ -1251,7 +1251,7 @@ def test_tiff_read_bigtiff():
 # Test reading in TIFF metadata domain
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_tiff_metadata():
 
     ds = gdal.Open("data/stefan_full_rgba_jpeg_contig.tif")
@@ -1272,7 +1272,7 @@ def test_tiff_read_tiff_metadata():
 # Test reading a JPEG-in-TIFF with tiles of irregular size (corrupted image)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_irregular_tile_size_jpeg_in_tiff():
 
     ds = gdal.Open("data/irregular_tile_size_jpeg_in_tiff.tif")
@@ -1281,7 +1281,7 @@ def test_tiff_read_irregular_tile_size_jpeg_in_tiff():
 
 
 # Getting (hidden) overview band requires JPEG driver availability
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 def test_tiff_read_irregular_tile_size_jpeg_in_tiff_overview():
 
@@ -3280,7 +3280,7 @@ def test_tiff_read_one_band_from_two_bands():
     gdal.Unlink("/vsimem/tiff_read_one_band_from_two_bands_dst.tif")
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_jpeg_cloud_optimized():
 
     for i in range(4):
@@ -3297,7 +3297,7 @@ def test_tiff_read_jpeg_cloud_optimized():
 # error while jpeg-8 works fine
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_corrupted_jpeg_cloud_optimized():
 
     ds = gdal.Open("data/byte_ovr_jpeg_tablesmode_not_correctly_set_on_ovr.tif")
@@ -3829,7 +3829,7 @@ def test_tiff_read_stripoffset_types():
 # http://www.libjpeg-turbo.org/pmwiki/uploads/About/TwoIssueswiththeJPEGStandard.pdf
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_progressive_jpeg_denial_of_service():
 
     if not check_libtiff_internal_or_at_least(4, 0, 9):
@@ -3910,7 +3910,7 @@ def test_tiff_read_mmap_interface():
 # image height.
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_jpeg_too_big_last_stripe():
 
     if not check_libtiff_internal_or_at_least(4, 0, 9):
@@ -3950,7 +3950,7 @@ def test_tiff_read_negative_scaley():
 # Test ZSTD compression
 
 
-@gdaltest.require_creation_option("GTiff", "ZSTD")
+@pytest.mark.require_creation_option("GTiff", "ZSTD")
 def test_tiff_read_zstd():
 
     ut = gdaltest.GDALTest("GTiff", "byte_zstd.tif", 1, 4672)
@@ -3961,7 +3961,7 @@ def test_tiff_read_zstd():
 # Test ZSTD compression
 
 
-@gdaltest.require_creation_option("GTiff", "ZSTD")
+@pytest.mark.require_creation_option("GTiff", "ZSTD")
 def test_tiff_read_zstd_corrupted():
 
     ut = gdaltest.GDALTest("GTiff", "byte_zstd_corrupted.tif", 1, -1)
@@ -3973,7 +3973,7 @@ def test_tiff_read_zstd_corrupted():
 # Test ZSTD compression
 
 
-@gdaltest.require_creation_option("GTiff", "ZSTD")
+@pytest.mark.require_creation_option("GTiff", "ZSTD")
 def test_tiff_read_zstd_corrupted2():
 
     ut = gdaltest.GDALTest("GTiff", "byte_zstd_corrupted2.tif", 1, -1)
@@ -3985,7 +3985,7 @@ def test_tiff_read_zstd_corrupted2():
 # Test WEBP compression
 
 
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_read_webp():
 
     stats = (0, 215, 66.38, 47.186)
@@ -3999,7 +3999,7 @@ def test_tiff_read_webp():
 # Test WEBP compression
 
 
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_read_webp_huge_single_strip():
 
     ds = gdal.Open("data/tif_webp_huge_single_strip.tif")
@@ -4019,7 +4019,7 @@ def test_tiff_read_1bit_2bands():
 # Test LERC compression
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_read_lerc():
 
     ut = gdaltest.GDALTest("GTiff", "byte_lerc.tif", 1, 4672)
@@ -4539,7 +4539,7 @@ def test_tiff_read_unhandled_codec_unknown_name():
 # channel handling was not explicitly handled (#6393)
 
 
-@gdaltest.require_creation_option("GTiff", "JXL")
+@pytest.mark.require_creation_option("GTiff", "JXL")
 def test_tiff_jxl_read_for_files_created_before_6393():
     gdal.ErrorReset()
     with gdaltest.error_handler():

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -372,7 +372,7 @@ def test_tiff_write_11():
 # Read JPEG Compressed YCbCr subsampled image.
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_12():
 
     ds = gdal.Open("data/sasha.tif")
@@ -384,7 +384,7 @@ def test_tiff_write_12():
 # Write JPEG Compressed YCbCr subsampled image.
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_13():
 
     src_ds = gdal.Open("data/sasha.tif")
@@ -1905,7 +1905,7 @@ def test_tiff_write_53_bis():
 # and write data into it without closing it and re-opening it (#2645)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_54():
 
     ds = gdaltest.tiff_drv.Create(
@@ -2561,7 +2561,7 @@ def test_tiff_write_73():
 @pytest.mark.skipif(
     "SKIP_TIFF_JPEG12" in os.environ, reason="Crashes on build-windows-msys2-mingw"
 )
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_74():
 
     with gdal.config_option("CPL_ACCUM_ERROR_MSG", "ON"):
@@ -2732,7 +2732,7 @@ def test_tiff_write_77():
 # Test generating & reading a YCbCr JPEG all-in-one-strip multiband TIFF (#3259)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_78():
 
     src_ds = gdaltest.tiff_drv.Create("tmp/tiff_write_78_src.tif", 16, 2048, 3)
@@ -3080,7 +3080,7 @@ def test_tiff_write_83():
 # changes in the midst of encoding of tiles (#3539)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_84():
 
     with gdaltest.SetCacheMax(0):
@@ -3407,7 +3407,7 @@ def test_tiff_write_88():
 # Test JPEG_QUALITY propagation while creating a (default compressed) mask band
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_89():
 
     last_size = 0
@@ -3459,7 +3459,7 @@ def test_tiff_write_89():
 # Test JPEG_QUALITY propagation/override while creating (internal) overviews
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_90():
 
     checksums = {}
@@ -3516,7 +3516,7 @@ def test_tiff_write_90():
 
 
 @pytest.mark.parametrize("external_ovr", [True, False])
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_write_90_webp(external_ovr):
 
     checksums = {}
@@ -3575,7 +3575,7 @@ def test_tiff_write_90_webp(external_ovr):
 
 
 @pytest.mark.parametrize("external_ovr", [True, False])
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_write_90_webp_lossless(external_ovr):
 
     checksums = {}
@@ -3619,7 +3619,7 @@ def test_tiff_write_90_webp_lossless(external_ovr):
 # Test JPEG_QUALITY propagation while creating (internal) overviews after re-opening
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_91():
 
     checksums = {}
@@ -3674,7 +3674,7 @@ def test_tiff_write_91():
 # Test WEBP_LEVEL_OVERVIEW while creating (internal) overviews after re-opening
 
 
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_write_91_webp():
 
     checksums = {}
@@ -3727,7 +3727,7 @@ def test_tiff_write_91_webp():
 # This will test that we correctly guess the quality of the main dataset
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_92():
 
     last_size = 0
@@ -3780,7 +3780,7 @@ def test_tiff_write_92():
 # Test JPEG_QUALITY_OVERVIEW propagation while creating external overviews
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_93():
 
     src_ds = gdal.Open("../gdrivers/data/utm.tif")
@@ -3843,7 +3843,7 @@ def test_tiff_write_93():
 # and check JPEG_QUALITY propagation without warning
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_94():
 
     src_ds = gdal.GetDriverByName("GTiff").Create(
@@ -4276,7 +4276,7 @@ def test_tiff_write_tiepoints_pixelispoint():
 # Create copy into a RGB JPEG-IN-TIFF (#3887)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_99():
 
     src_ds = gdal.Open("data/rgbsmall.tif")
@@ -4301,7 +4301,7 @@ def test_tiff_write_99():
 # Create copy into a 2 band JPEG-IN-TIFF (#3887)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_100():
 
     src_ds = gdaltest.tiff_drv.Create("/vsimem/test_100_src.tif", 16, 16, 2)
@@ -4540,7 +4540,7 @@ def test_tiff_write_105():
 # Test the direct copy mechanism of JPEG source
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 @pytest.mark.parametrize(
     "filename,options,check_cs",
@@ -4636,7 +4636,7 @@ def test_tiff_write_114():
 # Test writing a pixel interleaved RGBA JPEG-compressed TIFF
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_115():
 
     tmpfilename = "/vsimem/tiff_write_115.tif"
@@ -4684,7 +4684,7 @@ def test_tiff_write_115():
 # Test writing a band interleaved RGBA JPEG-compressed TIFF
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_116():
 
     tmpfilename = "/vsimem/tiff_write_116.tif"
@@ -5336,7 +5336,7 @@ def test_tiff_write_125():
 # Test implicit JPEG-in-TIFF overviews
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 def test_tiff_write_126():
 
@@ -5626,7 +5626,7 @@ def test_tiff_write_127():
 # Test lossless copying of a CMYK JPEG into JPEG-in-TIFF (#5712)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 def test_tiff_write_128():
 
@@ -5706,7 +5706,7 @@ def test_tiff_write_128():
 # Check effective guessing of existing JPEG quality
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_129():
 
     for jpegtablesmode in ["1", "3"]:
@@ -5757,7 +5757,7 @@ def test_tiff_write_129():
 # Test cases where JPEG quality will fail
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_130():
 
     shutil.copyfile(
@@ -5793,7 +5793,7 @@ def test_tiff_write_130():
 # Test LZMA compression
 
 
-@gdaltest.require_creation_option("GTiff", "LZMA")
+@pytest.mark.require_creation_option("GTiff", "LZMA")
 def test_tiff_write_131(level=1):
 
     filename = "/vsimem/tiff_write_131.tif"
@@ -5816,7 +5816,7 @@ def test_tiff_write_131(level=1):
     gdal.Unlink(filename)
 
 
-@gdaltest.require_creation_option("GTiff", "LZMA")
+@pytest.mark.require_creation_option("GTiff", "LZMA")
 def test_tiff_write_131_level_9():
     return test_tiff_write_131(level=9)
 
@@ -7083,7 +7083,7 @@ def test_tiff_write_145():
 # is a legal formulation since 4 bands should probably be seen as CMYK)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 def test_tiff_write_146():
 
@@ -7118,7 +7118,7 @@ def test_tiff_write_146():
 # to RGBA
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 def test_tiff_write_147():
 
@@ -7138,7 +7138,7 @@ def test_tiff_write_147():
 # Test that we can use implicit JPEG-in-TIFF overviews with CMYK in raw mode
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 def test_tiff_write_148():
 
@@ -7776,7 +7776,7 @@ def test_tiff_write_158():
 # result in a https://trac.osgeo.org/gdal/wiki/CloudOptimizedGeoTIFF
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_159():
 
     prev_table = ""
@@ -7920,7 +7920,7 @@ def test_tiff_write_161():
 # Test creating a JPEG compressed file with big tiles (#6757)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_162():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 512, 512, 3)
@@ -8202,7 +8202,7 @@ def test_tiff_write_170_invalid_compresion():
 # Test ZSTD compression
 
 
-@gdaltest.require_creation_option("GTiff", "ZSTD")
+@pytest.mark.require_creation_option("GTiff", "ZSTD")
 def test_tiff_write_171_zstd():
 
     ut = gdaltest.GDALTest(
@@ -8215,7 +8215,7 @@ def test_tiff_write_171_zstd():
 # Test ZSTD compression with PREDICTOR = 2
 
 
-@gdaltest.require_creation_option("GTiff", "ZSTD")
+@pytest.mark.require_creation_option("GTiff", "ZSTD")
 def test_tiff_write_171_zstd_predictor():
 
     ut = gdaltest.GDALTest(
@@ -8233,7 +8233,7 @@ def test_tiff_write_171_zstd_predictor():
 
 
 @pytest.mark.parametrize("writeImageStructureMetadata", [True, False])
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_write_webp(writeImageStructureMetadata):
 
     filename = "/vsimem/test_tiff_write_webp.tif"
@@ -8270,8 +8270,8 @@ def test_tiff_write_webp(writeImageStructureMetadata):
 
 
 @pytest.mark.parametrize("writeImageStructureMetadata", [True, False])
-@gdaltest.require_creation_option("GTiff", "WEBP")
-@gdaltest.require_creation_option("GTiff", "WEBP_LOSSLESS")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP_LOSSLESS")
 def test_tiff_write_tiled_webp(writeImageStructureMetadata):
 
     filename = "/vsimem/tiff_write_tiled_webp.tif"
@@ -8315,7 +8315,7 @@ def test_tiff_write_tiled_webp(writeImageStructureMetadata):
 # Test WEBP compression with huge single strip
 
 
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_write_webp_huge_single_strip():
 
     filename = "/vsimem/tif_webp_huge_single_strip.tif"
@@ -8371,7 +8371,7 @@ def test_tiff_write_172_geometadata_tiff_rsid():
 # Test LERC compression
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_173_lerc():
 
     ut = gdaltest.GDALTest("GTiff", "byte.tif", 1, 4672, options=["COMPRESS=LERC"])
@@ -8382,7 +8382,7 @@ def test_tiff_write_173_lerc():
 # Test LERC_DEFLATE compression
 
 
-@gdaltest.require_creation_option("GTiff", "LERC_DEFLATE")
+@pytest.mark.require_creation_option("GTiff", "LERC_DEFLATE")
 def test_tiff_write_174_lerc_deflate():
 
     ut = gdaltest.GDALTest(
@@ -8395,7 +8395,7 @@ def test_tiff_write_174_lerc_deflate():
 # Test LERC_DEFLATE compression
 
 
-@gdaltest.require_creation_option("GTiff", "LERC_DEFLATE")
+@pytest.mark.require_creation_option("GTiff", "LERC_DEFLATE")
 def test_tiff_write_174_lerc_deflate_with_level():
 
     ut = gdaltest.GDALTest(
@@ -8408,7 +8408,7 @@ def test_tiff_write_174_lerc_deflate_with_level():
 # Test LERC_ZSTD compression
 
 
-@gdaltest.require_creation_option("GTiff", "LERC_ZSTD")
+@pytest.mark.require_creation_option("GTiff", "LERC_ZSTD")
 def test_tiff_write_175_lerc_zstd():
 
     ut = gdaltest.GDALTest("GTiff", "byte.tif", 1, 4672, options=["COMPRESS=LERC_ZSTD"])
@@ -8419,7 +8419,7 @@ def test_tiff_write_175_lerc_zstd():
 # Test LERC_ZSTD compression
 
 
-@gdaltest.require_creation_option("GTiff", "LERC_ZSTD")
+@pytest.mark.require_creation_option("GTiff", "LERC_ZSTD")
 def test_tiff_write_175_lerc_zstd_with_level():
 
     ut = gdaltest.GDALTest(
@@ -8432,7 +8432,7 @@ def test_tiff_write_175_lerc_zstd_with_level():
 # Test LERC compression with MAX_Z_ERROR
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_176_lerc_max_z_error():
 
     ut = gdaltest.GDALTest(
@@ -8445,7 +8445,7 @@ def test_tiff_write_176_lerc_max_z_error():
 # Test LERC compression with several bands and tiling
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_177_lerc_several_bands_tiling():
 
     filename = "/vsimem/tiff_write_177_lerc_several_bands_tiling.tif"
@@ -8465,7 +8465,7 @@ def test_tiff_write_177_lerc_several_bands_tiling():
 # Test LERC compression with alpha band
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_178_lerc_with_alpha():
 
     filename = "/vsimem/tiff_write_178_lerc_with_alpha.tif"
@@ -8483,7 +8483,7 @@ def test_tiff_write_178_lerc_with_alpha():
 # Test LERC compression with alpha band with only 0 and 255
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_178_lerc_with_alpha_0_and_255():
 
     filename = "/vsimem/tiff_write_178_lerc_with_alpha_0_and_255.tif"
@@ -8503,7 +8503,7 @@ def test_tiff_write_178_lerc_with_alpha_0_and_255():
 # Test LERC compression with different data types
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_179_lerc_data_types():
 
     filename = "/vsimem/tiff_write_179_lerc_data_types.tif"
@@ -8548,7 +8548,7 @@ def test_tiff_write_179_lerc_data_types():
 # Test LERC compression with several bands and separate
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_180_lerc_separate():
 
     filename = "/vsimem/tiff_write_180_lerc_separate.tif"
@@ -8646,7 +8646,7 @@ def test_tiff_write_lerc_overview(external_ovr, compression):
 
 
 @pytest.mark.parametrize("external_ovr", [True, False])
-@gdaltest.require_creation_option("GTiff", "LERC_DEFLATE")
+@pytest.mark.require_creation_option("GTiff", "LERC_DEFLATE")
 def test_tiff_write_lerc_zlevel(external_ovr):
 
     filesize = {}
@@ -8683,7 +8683,7 @@ def test_tiff_write_lerc_zlevel(external_ovr):
 
 
 @pytest.mark.parametrize("external_ovr", [True, False])
-@gdaltest.require_creation_option("GTiff", "LERC_ZSTD")
+@pytest.mark.require_creation_option("GTiff", "LERC_ZSTD")
 def test_tiff_write_lerc_zstd_level(external_ovr):
 
     filesize = {}
@@ -8841,7 +8841,7 @@ def test_tiff_write_184_create_append_subdataset():
 # Fixes https://github.com/OSGeo/gdal/issues/1257
 
 
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_185_lerc_create_and_overview():
 
     filename = "/vsimem/test_tiff_write_185_lerc_create_and_overview.tif"
@@ -9005,7 +9005,7 @@ def test_tiff_write_overviews_mask_no_ovr_on_mask():
 # Test that -co PHOTOMETRIC=YCBCR -co COMPRESS=JPEG does not create a TIFFTAG_GDAL_METADATA
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_no_gdal_metadata_tag_for_ycbcr_jpeg():
 
     tmpfile = "/vsimem/test_tiff_write_no_gdal_metadata_tag_for_ycbcr_jpeg.tif"
@@ -9201,7 +9201,7 @@ def test_tiff_write_too_many_tiles():
 #
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_write_jpeg_incompatible_of_paletted():
 
     src_ds = gdal.Open("data/test_average_palette.tif")
@@ -9300,7 +9300,7 @@ def test_tiff_write_internal_ovr_default_blocksize(blockSize, numThreads):
 @pytest.mark.parametrize(
     "gdalDataType,structType", [[gdal.GDT_Float32, "f"], [gdal.GDT_Float64, "d"]]
 )
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_lerc_float(gdalDataType, structType):
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1, gdalDataType)
@@ -9322,7 +9322,7 @@ def test_tiff_write_lerc_float(gdalDataType, structType):
 @pytest.mark.parametrize(
     "gdalDataType,structType", [[gdal.GDT_Float32, "f"], [gdal.GDT_Float64, "d"]]
 )
-@gdaltest.require_creation_option("GTiff", "LERC")
+@pytest.mark.require_creation_option("GTiff", "LERC")
 def test_tiff_write_lerc_float_with_nan(gdalDataType, structType):
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1, gdalDataType)
@@ -9345,7 +9345,7 @@ def test_tiff_write_lerc_float_with_nan(gdalDataType, structType):
 
 @pytest.mark.parametrize("lossless", ["YES", "NO", None])
 @pytest.mark.parametrize("writeImageStructureMetadata", [True, False])
-@gdaltest.require_creation_option("GTiff", "JXL")
+@pytest.mark.require_creation_option("GTiff", "JXL")
 def test_tiff_write_jpegxl_byte_single_band(lossless, writeImageStructureMetadata):
 
     outfile = "/vsimem/test_tiff_write_jpegxl_byte_single_band.tif"
@@ -9413,7 +9413,7 @@ def test_tiff_write_jpegxl_byte_single_band(lossless, writeImageStructureMetadat
 # Test JXL compression
 
 
-@gdaltest.require_creation_option("GTiff", "JXL")
+@pytest.mark.require_creation_option("GTiff", "JXL")
 def test_tiff_write_jpegxl_byte_three_band():
 
     ut = gdaltest.GDALTest("GTiff", "rgbsmall.tif", 1, 21212, options=["COMPRESS=JXL"])
@@ -9424,7 +9424,7 @@ def test_tiff_write_jpegxl_byte_three_band():
 # Test JXL compression
 
 
-@gdaltest.require_creation_option("GTiff", "JXL")
+@pytest.mark.require_creation_option("GTiff", "JXL")
 def test_tiff_write_jpegxl_uint16_single_band():
 
     ut = gdaltest.GDALTest("GTiff", "uint16.tif", 1, 4672, options=["COMPRESS=JXL"])
@@ -9435,7 +9435,7 @@ def test_tiff_write_jpegxl_uint16_single_band():
 # Test JXL_ALPHA_DISTANCE option
 
 
-@gdaltest.require_creation_option("GTiff", "JXL_ALPHA_DISTANCE")
+@pytest.mark.require_creation_option("GTiff", "JXL_ALPHA_DISTANCE")
 def test_tiff_write_jpegxl_alpha_distance_zero():
 
     drv = gdal.GetDriverByName("GTiff")
@@ -10241,7 +10241,7 @@ def test_tiff_write_createcopy_alpha_not_in_last_band(options):
 
 ###############################################################################
 # Test JXL compression
-@gdaltest.require_creation_option("GTiff", "JXL")
+@pytest.mark.require_creation_option("GTiff", "JXL")
 def test_tiff_write_jpegxl_band_combinations():
 
     tmpfilename = "/vsimem/test_tiff_write_jpegxl_band_combinations.tif"
@@ -10386,7 +10386,7 @@ def test_tiff_write_jpegxl_band_combinations():
 # Test turning on lossy WEBP compression if WEBP_LEVEL_OVERVIEW specified
 
 
-@gdaltest.require_creation_option("GTiff", "WEBP")
+@pytest.mark.require_creation_option("GTiff", "WEBP")
 @pytest.mark.require_driver("WEBP")
 def test_tiff_write_webp_overview_turn_on_lossy_if_webp_level():
 
@@ -10422,7 +10422,7 @@ def test_tiff_write_webp_overview_turn_on_lossy_if_webp_level():
 
 
 @pytest.mark.parametrize("extra_options", ["-co PHOTOMETRIC=YCBCR", ""])
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 @pytest.mark.require_driver("JPEG")
 def test_tiff_write_lossless_extraction_of_JPEG_tile(extra_options):
 
@@ -10453,7 +10453,7 @@ def test_tiff_write_lossless_extraction_of_JPEG_tile(extra_options):
 # Test lossless extraction of a JPEGXL compressed tile to JPEGXL
 
 
-@gdaltest.require_creation_option("GTiff", "JXL")
+@pytest.mark.require_creation_option("GTiff", "JXL")
 @pytest.mark.require_driver("JPEGXL")
 def test_tiff_write_lossless_extraction_of_JPEGXL_tile():
 

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -4192,7 +4192,7 @@ def test_gpkg_coordinate_epoch():
 # Test preservation of IsDynamic() and support for coordinate epoch
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_gpkg_coordinate_epoch_is_dynamic():
 
     gdal.Unlink("/vsimem/tmp.gpkg")

--- a/autotest/gdrivers/isis.py
+++ b/autotest/gdrivers/isis.py
@@ -2001,7 +2001,7 @@ def test_isis3_point_perspective_read():
     )
 
 
-@gdaltest.require_proj_version(7)
+@pytest.mark.require_proj(7)
 def test_isis3_point_perspective_write():
 
     sr = osr.SpatialReference()

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -3552,7 +3552,7 @@ def test_jp2openjpeg_50():
 # Test CODEBLOCK_STYLE
 
 
-@gdaltest.require_creation_option("JP2OpenJPEG", "CODEBLOCK_STYLE")
+@pytest.mark.require_creation_option("JP2OpenJPEG", "CODEBLOCK_STYLE")
 def test_jp2openjpeg_codeblock_style():
 
     filename = "/vsimem/jp2openjpeg_codeblock_style.jp2"
@@ -3658,7 +3658,7 @@ def test_jp2openjpeg_odd_dimensions():
 ###############################################################################
 
 
-@gdaltest.require_creation_option("JP2OpenJPEG", "CODEBLOCK_STYLE")
+@pytest.mark.require_creation_option("JP2OpenJPEG", "CODEBLOCK_STYLE")
 def test_jp2openjpeg_odd_dimensions_overviews():
 
     # Check that we don't request outside of the full resolution coordinates
@@ -3695,7 +3695,7 @@ def test_jp2openjpeg_tilesize_16():
 # Test generation of PLT marker segments
 
 
-@gdaltest.require_creation_option(
+@pytest.mark.require_creation_option(
     "JP2OpenJPEG", "PLT"
 )  # Only try the test with openjpeg >= 2.4.0 that supports it
 def test_jp2openjpeg_generate_PLT():
@@ -3722,7 +3722,7 @@ def test_jp2openjpeg_generate_PLT():
 # Test generation of TLM marker segments
 
 
-@gdaltest.require_creation_option(
+@pytest.mark.require_creation_option(
     "JP2OpenJPEG", "TLM"
 )  # Only try the test with openjpeg >= 2.5.0 that supports it
 def test_jp2openjpeg_generate_TLM():
@@ -3749,7 +3749,7 @@ def test_jp2openjpeg_generate_TLM():
 # Test STRICT=NO open option
 
 
-@gdaltest.require_creation_option(
+@pytest.mark.require_creation_option(
     "JP2OpenJPEG", "'STRICT'"
 )  # Only try the test with openjpeg >= 2.5.0 that supports it
 def test_jp2openjpeg_STRICT_NO():

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -1435,7 +1435,7 @@ def test_jpeg_apply_orientation(orientation):
 # Test lossless conversion from JPEGXL
 
 
-@gdaltest.require_creation_option("JPEGXL", "COMPRESS_BOXES")
+@pytest.mark.require_creation_option("JPEGXL", "COMPRESS_BOXES")
 def test_jpeg_from_jpegxl():
 
     jpegxl_drv = gdal.GetDriverByName("JPEGXL")

--- a/autotest/gdrivers/jpegxl.py
+++ b/autotest/gdrivers/jpegxl.py
@@ -168,7 +168,7 @@ def test_jpegxl_rgba_quality(quality, equivalent_distance):
     gdal.GetDriverByName("JPEGXL").Delete(outfilename)
 
 
-@gdaltest.require_creation_option("JPEGXL", "COMPRESS_BOX")
+@pytest.mark.require_creation_option("JPEGXL", "COMPRESS_BOX")
 def test_jpegxl_xmp():
 
     src_ds = gdal.Open("data/gtiff/byte_with_xmp.tif")
@@ -185,7 +185,7 @@ def test_jpegxl_xmp():
     gdal.GetDriverByName("JPEGXL").Delete(outfilename)
 
 
-@gdaltest.require_creation_option("JPEGXL", "COMPRESS_BOX")
+@pytest.mark.require_creation_option("JPEGXL", "COMPRESS_BOX")
 def test_jpegxl_exif():
 
     src_ds = gdal.Open("../gcore/data/exif_and_gps.tif")
@@ -202,7 +202,7 @@ def test_jpegxl_exif():
     gdal.GetDriverByName("JPEGXL").Delete(outfilename)
 
 
-@gdaltest.require_creation_option("JPEGXL", "COMPRESS_BOX")
+@pytest.mark.require_creation_option("JPEGXL", "COMPRESS_BOX")
 def test_jpegxl_read_huge_xmp_compressed_box():
 
     with gdaltest.error_handler():
@@ -364,7 +364,7 @@ def test_jpegxl_lossless_copy_of_jpeg():
             )
 
 
-@gdaltest.require_creation_option("JPEGXL", "COMPRESS_BOX")
+@pytest.mark.require_creation_option("JPEGXL", "COMPRESS_BOX")
 def test_jpegxl_lossless_copy_of_jpeg_disabled():
 
     jpeg_drv = gdal.GetDriverByName("JPEG")
@@ -436,7 +436,7 @@ def test_jpegxl_lossless_copy_of_jpeg_with_mask_band():
     jpeg_drv.Delete(outfilename_jpg)
 
 
-@gdaltest.require_creation_option("JPEGXL", "COMPRESS_BOX")
+@pytest.mark.require_creation_option("JPEGXL", "COMPRESS_BOX")
 def test_jpegxl_lossless_copy_of_jpeg_xmp():
 
     jpeg_drv = gdal.GetDriverByName("JPEG")
@@ -802,7 +802,7 @@ def test_jpegxl_apply_orientation(orientation):
 # Test ALPHA_DISTANCE option
 
 
-@gdaltest.require_creation_option(
+@pytest.mark.require_creation_option(
     "JPEGXL", "ALPHA_DISTANCE"
 )  # "libjxl > 0.8.1 required"
 def test_jpegxl_alpha_distance_zero():

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -428,7 +428,7 @@ def test_mrf_overview_external():
     cleanup()
 
 
-@gdaltest.require_creation_option("MRF", "LERC")
+@pytest.mark.require_creation_option("MRF", "LERC")
 def test_mrf_lerc_nodata():
 
     gdal.Translate(
@@ -448,7 +448,7 @@ def test_mrf_lerc_nodata():
     cleanup()
 
 
-@gdaltest.require_creation_option("MRF", "LERC")
+@pytest.mark.require_creation_option("MRF", "LERC")
 def test_mrf_lerc_with_huffman():
 
     gdal.Translate(
@@ -467,7 +467,7 @@ def test_mrf_lerc_with_huffman():
     cleanup()
 
 
-@gdaltest.require_creation_option("MRF", "LERC")
+@pytest.mark.require_creation_option("MRF", "LERC")
 def test_raw_lerc():
 
     # Defaults to LERC2

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -3300,7 +3300,7 @@ def test_netcdf_81():
 # Write netCDF file in rotated_pole projection
 
 
-@gdaltest.require_proj_version(7, 1)
+@pytest.mark.require_proj(7, 1)
 def test_netcdf_write_rotated_pole_from_method_proj():
 
     ds = gdal.GetDriverByName("netCDF").Create("tmp/rotated_pole.nc", 2, 2)
@@ -3333,7 +3333,7 @@ def test_netcdf_write_rotated_pole_from_method_proj():
 # Write netCDF file in rotated_pole projection
 
 
-@gdaltest.require_proj_version(8, 2)
+@pytest.mark.require_proj(8, 2)
 def test_netcdf_write_rotated_pole_from_method_netcdf_cf():
 
     expected_wkt = """GEOGCRS["Rotated_pole",BASEGEOGCRS["unknown",DATUM["unnamed",ELLIPSOID["Spheroid",6367470,594.313048347956,LENGTHUNIT["metre",1,ID["EPSG",9001]]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]],DERIVINGCONVERSION["Pole rotation (netCDF CF convention)",METHOD["Pole rotation (netCDF CF convention)"],PARAMETER["Grid north pole latitude (netCDF CF convention)",39.25,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]],PARAMETER["Grid north pole longitude (netCDF CF convention)",-162,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]],PARAMETER["North pole grid longitude (netCDF CF convention)",0,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]],CS[ellipsoidal,2],AXIS["latitude",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]],AXIS["longitude",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9122]]]]"""
@@ -3356,7 +3356,7 @@ def test_netcdf_write_rotated_pole_from_method_netcdf_cf():
 # Write netCDF file in rotated_pole projection
 
 
-@gdaltest.require_proj_version(7, 0)
+@pytest.mark.require_proj(7, 0)
 def test_netcdf_write_rotated_pole_from_method_grib():
 
     ds = gdal.GetDriverByName("netCDF").Create("tmp/rotated_pole.nc", 2, 2)

--- a/autotest/gdrivers/vrtmask.py
+++ b/autotest/gdrivers/vrtmask.py
@@ -120,7 +120,7 @@ def test_vrtmask_2():
 # Translate a RGB dataset with a mask into a VRT
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_vrtmask_3():
 
     src_ds = gdal.Open("../gcore/data/ycbcr_with_mask.tif")
@@ -146,7 +146,7 @@ def test_vrtmask_3():
 # Same with gdalbuildvrt
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_vrtmask_4():
 
     src_ds = gdal.Open("../gcore/data/ycbcr_with_mask.tif")
@@ -167,7 +167,7 @@ def test_vrtmask_4():
 # Same with gdal_translate
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_vrtmask_5():
 
     gdal.Translate(
@@ -193,7 +193,7 @@ def test_vrtmask_5():
 # Same with gdal_translate with explicit -b and -mask arguments
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_vrtmask_6():
 
     gdal.Translate(
@@ -219,7 +219,7 @@ def test_vrtmask_6():
 # gdal_translate with RGBmask -> RGBA and then RGBA->RGBmask
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_vrtmask_7():
 
     try:
@@ -267,7 +267,7 @@ def test_vrtmask_7():
 # gdal_translate with RGBmask -> RGB
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_vrtmask_8():
 
     gdal.Translate(

--- a/autotest/gdrivers/webp.py
+++ b/autotest/gdrivers/webp.py
@@ -74,7 +74,7 @@ def test_webp_3():
 # CreateCopy() on RGBA
 
 
-@gdaltest.require_creation_option("WEBP", "LOSSLESS")
+@pytest.mark.require_creation_option("WEBP", "LOSSLESS")
 def test_webp_4():
 
     src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
@@ -108,7 +108,7 @@ def test_webp_4():
 # CreateCopy() on RGBA with lossless compression
 
 
-@gdaltest.require_creation_option("WEBP", "LOSSLESS")
+@pytest.mark.require_creation_option("WEBP", "LOSSLESS")
 def test_webp_5():
 
     src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
@@ -136,8 +136,8 @@ def test_webp_5():
 # CreateCopy() on RGBA with lossless compression and exact rgb values
 
 
-@gdaltest.require_creation_option("WEBP", "LOSSLESS")
-@gdaltest.require_creation_option("WEBP", "EXACT")
+@pytest.mark.require_creation_option("WEBP", "LOSSLESS")
+@pytest.mark.require_creation_option("WEBP", "EXACT")
 def test_webp_6():
 
     src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")

--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -4186,7 +4186,7 @@ def test_ogr_openfilegdb_write_delete():
 @pytest.mark.parametrize(
     "write_wkid,write_vcswkid", [(True, True), (True, False), (False, False)]
 )
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_ogr_openfilegdb_write_compound_crs(write_wkid, write_vcswkid):
 
     dirname = "/vsimem/test_ogr_openfilegdb_write_compound_crs.gdb"

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -1437,7 +1437,7 @@ def test_ogr_parquet_read_partitioned_geo():
 # Cf https://github.com/opengeospatial/geoparquet/discussions/110
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_ogr_parquet_write_crs_without_id_in_datum_ensemble_members():
 
     outfilename = "/vsimem/out.parquet"

--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -1532,7 +1532,7 @@ def test_osr_basic_set_from_user_input_non_existing_authority():
 # Test IAU: CRS
 
 
-@gdaltest.require_proj_version(8, 2)
+@pytest.mark.require_proj(8, 2)
 def test_osr_basic_set_from_user_input_IAU():
 
     srs = osr.SpatialReference()
@@ -1758,7 +1758,7 @@ def test_osr_get_name():
     assert sr.GetName() == "WGS 84"
 
 
-@gdaltest.require_proj_version(6, 1)
+@pytest.mark.require_proj(6, 1)
 def test_SetPROJSearchPath():
 
     # OSRSetPROJSearchPaths() is only taken into priority over other methods
@@ -1797,7 +1797,7 @@ def test_SetPROJSearchPath():
     assert sr.ImportFromEPSG(32631) == 0
 
 
-@gdaltest.require_proj_version(6, 1)
+@pytest.mark.require_proj(6, 1)
 def test_Set_PROJ_DATA_config_option():
 
     # OSRSetPROJSearchPaths() is only taken into priority over other methods
@@ -1843,7 +1843,7 @@ def test_Set_PROJ_DATA_config_option():
 ###############################################################################
 
 
-@gdaltest.require_proj_version(6, 1)
+@pytest.mark.require_proj(6, 1)
 def test_Set_PROJ_DATA_config_option_sub_proccess_config_option_ok():
 
     backup_search_paths = osr.GetPROJSearchPaths()
@@ -1862,7 +1862,7 @@ def test_Set_PROJ_DATA_config_option_sub_proccess_config_option_ok():
 ###############################################################################
 
 
-@gdaltest.require_proj_version(6, 1)
+@pytest.mark.require_proj(6, 1)
 def test_Set_PROJ_DATA_config_option_sub_proccess_config_option_ko():
 
     backup_search_paths = osr.GetPROJSearchPaths()
@@ -1887,7 +1887,7 @@ def test_osr_import_projjson_possibly_error_out():
         sr.SetFromUserInput(projjson)
 
 
-@gdaltest.require_proj_version(6, 2)
+@pytest.mark.require_proj(6, 2)
 def test_osr_import_projjson():
 
     sr = osr.SpatialReference()
@@ -1910,7 +1910,7 @@ def test_osr_export_projjson_possibly_error_out():
         sr.ExportToPROJJSON()
 
 
-@gdaltest.require_proj_version(6, 2)
+@pytest.mark.require_proj(6, 2)
 def test_osr_export_projjson():
 
     sr = osr.SpatialReference()
@@ -1928,7 +1928,7 @@ def test_osr_promote_to_3D_possibly_error_out():
         sr.PromoteTo3D()
 
 
-@gdaltest.require_proj_version(6, 3)
+@pytest.mark.require_proj(6, 3)
 def test_osr_promote_to_3D():
 
     sr = osr.SpatialReference()
@@ -1992,7 +1992,7 @@ def test_osr_SpatialReference_invalid_wkt_in_constructor():
 # Check GetUTMZone() on a Projected 3D CRS
 
 
-@gdaltest.require_proj_version(6, 3)
+@pytest.mark.require_proj(6, 3)
 def test_osr_GetUTMZone_Projected3D():
 
     utm_srs = osr.SpatialReference()
@@ -2011,7 +2011,7 @@ def test_osr_GetUTMZone_Projected3D():
 # Check GetProjParm() on a Projected 3D CRS
 
 
-@gdaltest.require_proj_version(6, 3)
+@pytest.mark.require_proj(6, 3)
 def test_osr_GetProjParm_Projected3D():
 
     utm_srs = osr.SpatialReference()
@@ -2052,7 +2052,7 @@ def test_SetPROJAuxDbPaths():
 # Test IsDynamic()
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_osr_basic_is_dynamic():
 
     srs = osr.SpatialReference()
@@ -2259,7 +2259,7 @@ def test_osr_basic_export_derived_projected_crs_to_wkt():
 # Test osr.GetPROJEnableNetwork / osr.SetPROJEnableNetwork
 
 
-@gdaltest.require_proj_version(7)
+@pytest.mark.require_proj(7)
 def test_osr_basic_proj_network():
 
     initial_value = osr.GetPROJEnableNetwork()
@@ -2306,7 +2306,7 @@ def test_osr_basic_get_linear_units_compound_engineering_crs():
 # Test EPSG:horizontal_code+geographic_code
 
 
-@gdaltest.require_proj_version(9)
+@pytest.mark.require_proj(9)
 def test_osr_basic_epsg_horizontal_and_ellipsoidal_height():
 
     sr = osr.SpatialReference()
@@ -2343,7 +2343,7 @@ def test_osr_exceptions():
 # Test SetFromUserInput() with COORDINATEMETADATA[]
 
 
-@gdaltest.require_proj_version(9, 2)
+@pytest.mark.require_proj(9, 2)
 def test_osr_basic_set_from_user_input_COORDINATEMETADATA_with_epoch():
 
     srs = osr.SpatialReference()
@@ -2382,7 +2382,7 @@ def test_osr_basic_set_from_user_input_COORDINATEMETADATA_with_epoch():
 # Test SetFromUserInput() with COORDINATEMETADATA[]
 
 
-@gdaltest.require_proj_version(9, 2)
+@pytest.mark.require_proj(9, 2)
 def test_osr_basic_set_from_user_input_COORDINATEMETADATA_without_epoch():
 
     srs = osr.SpatialReference()

--- a/autotest/osr/osr_compd.py
+++ b/autotest/osr/osr_compd.py
@@ -356,7 +356,7 @@ def test_osr_compd_8():
 # Test COMPD_CS with a VERT_DATUM type = 2002 (Ellipsoid height)
 
 
-@gdaltest.require_proj_version(7, 1)
+@pytest.mark.require_proj(7, 1)
 def test_osr_compd_vert_datum_2002():
 
     sr = osr.SpatialReference()

--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -486,7 +486,7 @@ def test_osr_ct_geocentric():
 # Test with +lon_wrap=180
 
 
-@gdaltest.require_proj_version(7, 0, 1)
+@pytest.mark.require_proj(7, 0, 1)
 def test_osr_ct_lon_wrap():
 
     s = osr.SpatialReference()
@@ -505,7 +505,7 @@ def test_osr_ct_lon_wrap():
 # Test ct.TransformPointWithErrorCode
 
 
-@gdaltest.require_proj_version(8)
+@pytest.mark.require_proj(8)
 def test_osr_ct_transformpointwitherrorcode():
 
     s = osr.SpatialReference()
@@ -591,7 +591,7 @@ def test_osr_ct_non_specified_time_with_time_dependent_transformation():
 # Test using OGRSpatialReference::CoordinateEpoch()
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_osr_ct_take_into_account_srs_coordinate_epoch():
 
     s = osr.SpatialReference()
@@ -700,7 +700,7 @@ def test_osr_ct_wkt_non_consistent_with_epsg_definition():
 # https://github.com/OSGeo/PROJ/issues/2955
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_osr_ct_OGR_CT_PREFER_OFFICIAL_SRS_DEF():
 
     # Not sure about the minimal version, but works as expected with 7.2.1

--- a/autotest/osr/osr_proj4.py
+++ b/autotest/osr/osr_proj4.py
@@ -804,7 +804,7 @@ def test_osr_proj4_error_cases_export_mercator():
         srs.ExportToProj4()
 
 
-@gdaltest.require_proj_version(6, 2)
+@pytest.mark.require_proj(6, 2)
 def test_osr_unknown_member_id_in_datum_ensemble():
 
     # Test workaround fix for https://github.com/OSGeo/PROJ/pull/3221

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -30,7 +30,6 @@
 ###############################################################################
 
 import contextlib
-import functools
 import io
 import math
 import os
@@ -1575,31 +1574,6 @@ def skip_on_travis():
         post_reason("Test skipped on Travis")
         return True
     return False
-
-
-###############################################################################
-# Decorator to skip a test if specified creation option is not available
-
-
-def require_creation_option(driver, option):
-
-    drv = gdal.GetDriverByName(driver)
-
-    def decorator(func):
-        @pytest.mark.skipif(
-            drv is None or option not in drv.GetMetadata()["DMD_CREATIONOPTIONLIST"],
-            reason=f"{driver} creation option {option} not supported in this build",
-        )
-        @pytest.mark.skipif(
-            drv is None, reason=f"{driver} driver is not included in this build"
-        )
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1603,33 +1603,6 @@ def require_creation_option(driver, option):
 
 
 ###############################################################################
-# Decorator to skip a test if PROJ version < (major, minor, micro)
-
-
-def require_proj_version(major, minor=0, micro=0):
-
-    from osgeo import osr
-
-    def decorator(func):
-        @pytest.mark.skipif(
-            (
-                osr.GetPROJVersionMajor(),
-                osr.GetPROJVersionMinor(),
-                osr.GetPROJVersionMicro(),
-            )
-            < (major, minor, micro),
-            reason=f"PROJ version < {major}.{minor}.{micro}",
-        )
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-###############################################################################
 # Return True if the provided name is in TRAVIS_BRANCH or BUILD_NAME
 
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -856,7 +856,7 @@ def test_gdal_translate_lib_not_delete_shared_auxiliary_files():
 # Test preservation of IsDynamic() and support for coordinate epoch
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_gdal_translate_lib_coord_epoch_is_dynamic():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -543,7 +543,7 @@ def test_gdalwarp_24(gdalwarp_path):
 # Test warping a full EPSG:4326 extent to +proj=sinu (#2305)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_gdalwarp_25(gdalwarp_path):
 
     gdaltest.runexternal(
@@ -575,7 +575,7 @@ def test_gdalwarp_25(gdalwarp_path):
 # Test warping a full EPSG:4326 extent to +proj=eck4 (#2305)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_gdalwarp_26(gdalwarp_path):
 
     gdaltest.runexternal(
@@ -607,7 +607,7 @@ def test_gdalwarp_26(gdalwarp_path):
 # Test warping a full EPSG:4326 extent to +proj=vandg (#2305)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_gdalwarp_27(gdalwarp_path):
 
     gdaltest.runexternal(
@@ -641,7 +641,7 @@ def test_gdalwarp_27(gdalwarp_path):
 # Test warping a full EPSG:4326 extent to +proj=aeqd +lat_0=45 +lon_0=90 (#2305)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_gdalwarp_28(gdalwarp_path):
 
     gdaltest.runexternal(
@@ -676,7 +676,7 @@ def test_gdalwarp_28(gdalwarp_path):
 # Test warping a full EPSG:4326 extent to EPSG:3785 (#2305)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def DISABLED_test_gdalwarp_29(gdalwarp_path):
 
     # This test has been disabled since PROJ 8 will reproject a coordinates at
@@ -712,7 +712,7 @@ def DISABLED_test_gdalwarp_29(gdalwarp_path):
 # Test the effect of the -wo OPTIMIZE_SIZE=TRUE and -wo STREAMABLE_OUTPUT=TRUE options (#3459, #1866)
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_gdalwarp_30(gdalwarp_path):
 
     te = " -te -20037508.343 -16206629.152 20036845.112 16213801.068"
@@ -846,7 +846,7 @@ def test_gdalwarp_32(gdalwarp_path):
 # Test warping a JPEG compressed image with a mask into a RGBA image
 
 
-@gdaltest.require_creation_option("GTiff", "JPEG")
+@pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_gdalwarp_33(gdalwarp_path):
 
     if test_cli_utilities.get_gdal_translate_path() is None:

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -2736,7 +2736,7 @@ def test_gdalwarp_lib_propagating_coordinate_epoch():
 # Test support for -s_coord_epoch
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_gdalwarp_lib_s_coord_epoch():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
@@ -2760,7 +2760,7 @@ def test_gdalwarp_lib_s_coord_epoch():
 # Test support for -s_coord_epoch
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_gdalwarp_lib_t_coord_epoch():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
@@ -2894,7 +2894,7 @@ def test_gdalwarp_lib_src_points_outside_of_earth():
 
 
 # Not completely sure about the minimum version to have ob_tran working fine.
-@gdaltest.require_proj_version(7)
+@pytest.mark.require_proj(7)
 def test_gdalwarp_lib_from_ob_tran_including_north_pole_to_geographic():
 
     ds = gdal.Warp(
@@ -3020,7 +3020,7 @@ def test_gdalwarp_lib_epsg_4326_to_esri_53037():
     "resampleAlg", ["average", "mode", "min", "max", "med", "q1", "q3", "sum", "rms"]
 )
 # 6.3.1 might not be the lowest bound, but 6.0.0 definitely doesn't work for that test
-@gdaltest.require_proj_version(6, 3, 1)
+@pytest.mark.require_proj(6, 3, 1)
 def test_gdalwarp_lib_epsg_4326_to_esri_102020(resampleAlg):
 
     # Scenario of https://github.com/OSGeo/gdal/issues/6155
@@ -3337,7 +3337,7 @@ def test_gdalwarp_lib_preserve_non_square_pixels_if_no_reprojection():
 ###############################################################################
 
 
-@gdaltest.require_proj_version(6, 3)
+@pytest.mark.require_proj(6, 3)
 def test_gdalwarp_lib_preserve_non_square_pixels_same_horizontal_crs():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 20, 10)

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -821,7 +821,7 @@ def test_ogr2ogr_assign_coord_epoch():
 # Test -s_coord_epoch
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_ogr2ogr_s_coord_epoch():
 
     src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
@@ -847,7 +847,7 @@ def test_ogr2ogr_s_coord_epoch():
 # Test -t_coord_epoch
 
 
-@gdaltest.require_proj_version(7, 2)
+@pytest.mark.require_proj(7, 2)
 def test_ogr2ogr_t_coord_epoch():
 
     src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -22,6 +22,7 @@ markers =
     require_curl: Skip test(s) if curl support is absent
     require_driver: Skip test(s) if driver isn't present
     require_geos: Skip test(s) if required GEOS version is not available
+    require_proj: Skip test(s) if required PROJ version is not available
     require_run_on_demand: Skip test(s) if RUN_ON_DEMAND environment variable is not set
     slow: Skip test(s) if GDAL_RUN_SLOW_TESTS environment variable is not set
 

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -20,6 +20,7 @@ gdal_version = @GDAL_VERSION@
 
 markers =
     require_curl: Skip test(s) if curl support is absent
+    require_creation_option: Skip test(s) if required creation option is not available
     require_driver: Skip test(s) if driver isn't present
     require_geos: Skip test(s) if required GEOS version is not available
     require_proj: Skip test(s) if required PROJ version is not available


### PR DESCRIPTION
## What does this PR do?

Use a single pattern for conditional skipping, as discussed in #7436

## What are related issues/pull requests?

#7436

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
