### PR TITLE
Allow SetAttributeFilter, SetSpatialFilter, SetSpatialFilterRect to be used as context managers

### DIFF
--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -130,14 +130,13 @@ def test_ogr_sql_1():
     gdaltest.ds = ogr.Open("data")
     gdaltest.lyr = gdaltest.ds.GetLayerByName("poly")
 
-    gdaltest.lyr.SetAttributeFilter("eas_id < 167")
+    with gdaltest.lyr.SetAttributeFilter("eas_id < 167"):
 
-    count = gdaltest.lyr.GetFeatureCount()
-    assert count == 3, (
-        "Got wrong count with GetFeatureCount() - %d, expecting 3" % count
-    )
+        count = gdaltest.lyr.GetFeatureCount()
+        assert count == 3, (
+            "Got wrong count with GetFeatureCount() - %d, expecting 3" % count
+        )
 
-    gdaltest.lyr.SetAttributeFilter("")
     count = gdaltest.lyr.GetFeatureCount()
     assert count == 10, (
         "Got wrong count with GetFeatureCount() - %d, expecting 10" % count
@@ -1167,9 +1166,8 @@ def test_ogr_sql_41():
 def test_ogr_sql_42():
 
     lyr = gdaltest.ds.GetLayerByName("poly")
-    lyr.SetAttributeFilter("prfedea <> ''")
-    feat = lyr.GetNextFeature()
-    lyr.SetAttributeFilter(None)
+    with lyr.SetAttributeFilter("prfedea <> ''"):
+        feat = lyr.GetNextFeature()
     assert feat is not None
 
     with gdaltest.ds.ExecuteSQL("SELECT * FROM poly WHERE prfedea <> ''") as sql_lyr:
@@ -1496,20 +1494,20 @@ def test_ogr_sql_attribute_filter_on_top_of_non_forward_where_clause(dialect):
     with mem_ds.ExecuteSQL(
         "SELECT * FROM test WHERE OGR_GEOMETRY = 'POLYGON'", dialect=dialect
     ) as sql_lyr:
-        sql_lyr.SetAttributeFilter("")
-        assert sql_lyr.GetFeatureCount() == 1
+        with sql_lyr.SetAttributeFilter(""):
+            assert sql_lyr.GetFeatureCount() == 1
 
     with mem_ds.ExecuteSQL(
         "SELECT * FROM test WHERE OGR_GEOMETRY = 'POLYGON'", dialect=dialect
     ) as sql_lyr:
-        sql_lyr.SetAttributeFilter("1")
-        assert sql_lyr.GetFeatureCount() == 1
+        with sql_lyr.SetAttributeFilter("1"):
+            assert sql_lyr.GetFeatureCount() == 1
 
     with mem_ds.ExecuteSQL(
         "SELECT * FROM test WHERE OGR_GEOMETRY = 'POLYGON'", dialect=dialect
     ) as sql_lyr:
-        sql_lyr.SetAttributeFilter("0")
-        assert sql_lyr.GetFeatureCount() == 0
+        with sql_lyr.SetAttributeFilter("0"):
+            assert sql_lyr.GetFeatureCount() == 0
 
 
 ###############################################################################

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -597,15 +597,12 @@ def ReleaseResultSet(self, sql_lyr):
 
               if filter is None:
                 filter_geom = None
-              if type(filter) is str:
+              elif type(filter) is str:
                 filter_geom = CreateGeometryFromWkt(filter)
               else:
                 filter_geom = filter
 
               self.err = $action(lyr, geom_field, filter_geom)
-
-              if type(filter) is str:
-                 filter_geom.Destroy()
 
           def __int__(self):
               return self.err
@@ -658,7 +655,7 @@ def ReleaseResultSet(self, sql_lyr):
 
       1. Use as a context manager:
 
-      >>> with lyr.SetSpatialFilterRect(0, 10, 10, 20, 20)"):
+      >>> with lyr.SetSpatialFilterRect(0, 10, 10, 20, 20):
       ...     print(lyr.GetFeatureCount())
 
       2. Used to set the filter until it is explicitly disabled.


### PR DESCRIPTION
## What does this PR do?

Allows `SetAttributeLayer`, `SetSpatialFilter`, and `SetSpatialFilterRect` to be used as context managers. Also allows `SetSpatialFilter` to handle WKT filters.

The intent is to avoid constructions like

```
geom = ogr.CreateGeometryFromWkt(wkt)
lyr.SetSpatialFilter(geom)
geom.Destroy()
tr = ogrtest.check_features_against_list(lyr, lst)
lyr.SetSpatialFilter(None)
assert tr
```

in favor of

```
with lyr.SetSpatialFilter(wkt):
  assert ogrtest.check_features_against_list(lyr, lst)
```

To retain the traditional usage, the proxy returned by `SetAttributeLayer` and `SetSpatialFilter` can be compared to an int, e.g.:

```
assert lyr.SetSpatialFilter(geom) == gdal.CE_None
```

I originally implemented helpers in `gdaltest` to accomplish the same thing (https://github.com/dbaston/gdal/commit/9c3331582928a9d7600377e2a2cddfa804e46d36) but decided to try doing it via SWIG instead. I'm not sure if it's a good idea or creates too much clutter. If it seems positive on the whole, I can complete with docstrings/tests/handling of multiple geometry fields.



## What are related issues/pull requests?

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed
