### PR TITLE
autotest: Fix incomplete downloads

### DIFF
--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1212,12 +1212,12 @@ def download_file(
                 except Exception:
                     print("Did not get expected data length.")
                     return False
+                val = val + chunk
                 if len(chunk) < chunk_size:
                     if download_size < 0:
                         break
                     print("Did not get expected data length.")
                     return False
-                val = val + chunk
                 if download_size >= 0:
                     nThisTick = int(40 * len(val) / download_size)
                     while nThisTick > nLastTick:


### PR DESCRIPTION
## What does this PR do?

Fixes `gdaltest.download_file` so that files are completely downloaded even if the size cannot be determined from the `content-length` header. An example file that is not correctly downloaded is  `http://www2.census.gov/geo/tiger/tiger2006se/AL/TGR01001.ZIP` in `ogr/ogr_tiger.py`.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
