### PR TITLE
SDTS: fix reading of polygon geometries (fixes #7680)

### DIFF
--- a/autotest/ogr/ogr_sdts.py
+++ b/autotest/ogr/ogr_sdts.py
@@ -49,9 +49,9 @@ def module_disable_exceptions():
 
 def test_ogr_sdts_1():
 
-    gdaltest.sdts_ds = ogr.Open("data/sdts/D3607551_rd0s_1_sdts_truncated/TR01CATD.DDF")
+    ds = ogr.Open("data/sdts/D3607551_rd0s_1_sdts_truncated/TR01CATD.DDF")
 
-    assert gdaltest.sdts_ds is not None
+    assert ds is not None
 
     layers = [
         ("ARDF", 164, ogr.wkbNone, [("ENTITY_LABEL", "1700005")]),
@@ -75,15 +75,16 @@ def test_ogr_sdts_1():
     ]
 
     for layer in layers:
-        lyr = gdaltest.sdts_ds.GetLayerByName(layer[0])
+        lyr = ds.GetLayerByName(layer[0])
         assert lyr is not None, "could not get layer %s" % (layer[0])
-        assert (
-            lyr.GetFeatureCount() == layer[1]
-        ), "wrong number of features for layer %s : %d. %d were expected " % (
-            layer[0],
-            lyr.GetFeatureCount(),
-            layer[1],
-        )
+        with gdaltest.error_handler():
+            assert (
+                lyr.GetFeatureCount() == layer[1]
+            ), "wrong number of features for layer %s : %d. %d were expected " % (
+                layer[0],
+                lyr.GetFeatureCount(),
+                layer[1],
+            )
         assert lyr.GetLayerDefn().GetGeomType() == layer[2]
         feat_read = lyr.GetNextFeature()
         for item in layer[3]:
@@ -92,7 +93,16 @@ def test_ogr_sdts_1():
                 print('"%s"' % (item[1]))
                 pytest.fail('"%s"' % (feat_read.GetField(item[0])))
 
-    gdaltest.sdts_ds = None
+    # Check that we get non-empty polygons
+    lyr = ds.GetLayerByName("PC01")
+    with gdaltest.error_handler():
+        f = lyr.GetNextFeature()
+    g = f.GetGeometryRef()
+    assert g
+    assert g.GetGeometryType() == ogr.wkbPolygon25D
+    assert not g.IsEmpty()
+
+    ds = None
 
 
 ###############################################################################

--- a/frmts/sdts/sdtslinereader.cpp
+++ b/frmts/sdts/sdtslinereader.cpp
@@ -269,9 +269,6 @@ void SDTSLineReader::AttachToPolygons(SDTSTransfer *poTransfer,
                                       int iTargetPolyLayer)
 
 {
-    if (!IsIndexed())
-        return;
-
     /* -------------------------------------------------------------------- */
     /*      We force a filling of the index because when we attach the      */
     /*      lines we are just providing a pointer back to the line          */


### PR DESCRIPTION
Partially reverts commit 909a1dece84a07f2d4592860473b9080ddcd6ddd

I've verified that reverting this bogus if( !IsIndexed() ) return; statement doesn't cause any memory use issue with the datasets of https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2773 both in master, as well as going back to 2.3dev at commit
909a1dece84a07f2d4592860473b9080ddcd6ddd , so I'm not sure why this was added at that time.
