### PR TITLE
autotest: Consolidate JSON validation logic, catch timeout errors

### DIFF
--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -39,22 +39,7 @@ from osgeo import gdal, ogr, osr
 
 pytestmark = pytest.mark.require_driver("Parquet")
 
-###############################################################################
-# Validate against GeoParquet json schema
-
-
-def _validate_json_output(instance):
-
-    try:
-        from jsonschema import validate
-    except ImportError:
-        pytest.skip("jsonschema module not available")
-
-    import json
-
-    schema = json.loads(open("data/parquet/schema.json", "rb").read())
-
-    validate(instance=instance, schema=schema)
+PARQUET_JSON_SCHEMA = "data/parquet/schema.json"
 
 
 ###############################################################################
@@ -700,7 +685,7 @@ def test_ogr_parquet_coordinate_epoch(epsg_code):
     assert "geometry" in j["columns"]
     if epsg_code == 4326:
         assert "crs" not in j["columns"]["geometry"]
-        _validate_json_output(j)
+        gdaltest.validate_json(j, PARQUET_JSON_SCHEMA)
     else:
         assert "crs" in j["columns"]["geometry"]
         assert j["columns"]["geometry"]["crs"]["type"] == "GeographicCRS"
@@ -795,7 +780,7 @@ def test_ogr_parquet_crs_identification_on_write(input_definition, expected_crs)
     else:
         assert "crs" in j["columns"]["geometry"]
         if expected_crs == "4269":
-            _validate_json_output(j)
+            gdaltest.validate_json(j, PARQUET_JSON_SCHEMA)
 
     srs = lyr.GetSpatialRef()
     assert srs is not None
@@ -834,7 +819,7 @@ def test_ogr_parquet_edges(edges):
     assert geo is not None
     j = json.loads(geo)
     assert j is not None
-    _validate_json_output(j)
+    gdaltest.validate_json(j, PARQUET_JSON_SCHEMA)
 
     ds = None
 
@@ -989,7 +974,7 @@ def test_ogr_parquet_geometry_types(
     )
 
     if expected_geometry_types == ["LineString Z", "MultiLineString"]:
-        _validate_json_output(j)
+        gdaltest.validate_json(j, PARQUET_JSON_SCHEMA)
 
     ds = None
 
@@ -1052,7 +1037,7 @@ def test_ogr_parquet_polygon_orientation(option_value, written_wkt, expected_wkt
     else:
         assert "orientation" not in j["columns"]["geometry"]
 
-    _validate_json_output(j)
+    gdaltest.validate_json(j, PARQUET_JSON_SCHEMA)
 
     ds = None
 

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -31,6 +31,7 @@
 
 import contextlib
 import io
+import json
 import math
 import os
 import os.path
@@ -2050,3 +2051,37 @@ def runexternal_out_and_err(cmd, check_memleak=True, encoding="ascii"):
         ret_stderr = f"{ret_stderr}\nERROR ret code = {waitcode}"
 
     return (ret_stdout, ret_stderr)
+
+
+###############################################################################
+# Validate JSON according to a JSON schema
+#
+# "jsn" should be a string or a json object
+# "schema" should be a path to file containing a JSON schema. If the
+# file is not found relative to the current working directory or GDAL_DATA,
+# the test will fail.
+def validate_json(jsn, schema):
+    __tracebackhide__ = True
+
+    try:
+        import jsonschema
+    except ImportError:
+        pytest.skip("jsonschema module not available")
+
+    if not os.path.exists(schema):
+        gdal_data = gdal.GetConfigOption("GDAL_DATA")
+
+        if gdal_data and os.path.exists(os.path.join(gdal_data, schema)):
+            schema = os.path.join(gdal_data, schema)
+        else:
+            pytest.fail(f"Could not find schema {schema}")
+
+    if isinstance(jsn, str):
+        jsn = json.loads(jsn)
+
+    schema = json.loads(open(schema, "rb").read())
+
+    try:
+        jsonschema.validate(instance=jsn, schema=schema)
+    except jsonschema.exceptions.RefResolutionError:
+        pytest.skip("Failed to resolve remote reference in JSON schema")

--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -47,28 +48,6 @@ def test_gdalinfo_lib_1():
 
 
 ###############################################################################
-# Validate json schema output
-
-
-def _validate_json_output(instance):
-
-    try:
-        from jsonschema import validate
-    except ImportError:
-        pytest.skip("jsonschema module not available")
-
-    gdal_data = gdal.GetConfigOption("GDAL_DATA")
-    if gdal_data is None:
-        pytest.skip("GDAL_DATA not defined")
-
-    import json
-
-    schema = json.loads(open(gdal_data + "/gdalinfo_output.schema.json", "rb").read())
-
-    validate(instance=instance, schema=schema)
-
-
-###############################################################################
 # Test Json format
 
 
@@ -79,7 +58,7 @@ def test_gdalinfo_lib_2():
     ret = gdal.Info(ds, format="json")
     assert ret["driverShortName"] == "GTiff", "wrong value for driverShortName."
 
-    _validate_json_output(ret)
+    gdaltest.validate_json(ret, "gdalinfo_output.schema.json")
 
 
 ###############################################################################
@@ -145,7 +124,7 @@ def test_gdalinfo_lib_5():
     assert "checksum" in band
     assert ret["coordinateSystem"]["dataAxisToSRSAxisMapping"] == [1, 2]
 
-    _validate_json_output(ret)
+    gdaltest.validate_json(ret, "gdalinfo_output.schema.json")
 
     ds = None
 

--- a/autotest/utilities/test_gdalmdiminfo_lib.py
+++ b/autotest/utilities/test_gdalmdiminfo_lib.py
@@ -29,33 +29,12 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import json
-import os
 import struct
 
+import gdaltest
 import pytest
 
 from osgeo import gdal, osr
-
-###############################################################################
-# Validate against schema
-
-
-def _validate(res):
-    try:
-        import jsonschema
-    except ImportError:
-        return
-
-    if isinstance(res, str):
-        res = json.loads(res)
-
-    schema_filename = "../../gdal/data/gdalmdiminfo_output.schema.json"
-    if not os.path.exists(schema_filename):
-        return
-
-    jsonschema.validate(res, json.loads(open(schema_filename, "rt").read()))
-
 
 ###############################################################################
 # Test with non multidim dataset
@@ -81,7 +60,7 @@ def test_gdalmdiminfo_lib_empty_mem_dataset():
     drv = gdal.GetDriverByName("MEM")
     ds = drv.CreateMultiDimensional("")
     ret = gdal.MultiDimInfo(ds)
-    _validate(ret)
+    gdaltest.validate_json(ret, "gdalmdiminfo_output.schema.json")
 
     assert ret == {"type": "group", "driver": "MEM", "name": "/"}
 
@@ -128,7 +107,7 @@ def test_gdalmdiminfo_lib_mem_dataset():
     attr.WriteString("bar")
 
     ret = gdal.MultiDimInfo(ds, detailed=True, as_text=True)
-    _validate(ret)
+    gdaltest.validate_json(ret, "gdalmdiminfo_output.schema.json")
 
     expected = """{
   "type": "group",
@@ -224,7 +203,7 @@ def test_gdalmdiminfo_lib_mem_dataset():
     assert ret == expected
 
     ret = gdal.MultiDimInfo(ds, array="ar_compound", detailed=True, as_text=True)
-    _validate(ret)
+    gdaltest.validate_json(ret, "gdalmdiminfo_output.schema.json")
 
     expected = """{
   "type": "array",

--- a/autotest/utilities/test_ogrinfo_lib.py
+++ b/autotest/utilities/test_ogrinfo_lib.py
@@ -27,6 +27,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -589,33 +590,13 @@ def test_ogrinfo_lib_json_features():
     assert ret_json_features == ret_features_json
 
 
-###############################################################################
-# Validate json schema output
-
-
-def _validate_json_output(instance):
-
-    try:
-        from jsonschema import validate
-    except ImportError:
-        pytest.skip("jsonschema module not available")
-
-    gdal_data = gdal.GetConfigOption("GDAL_DATA")
-    if gdal_data is None:
-        pytest.skip("GDAL_DATA not defined")
-
-    import json
-
-    schema = json.loads(open(gdal_data + "/ogrinfo_output.schema.json", "rb").read())
-
-    validate(instance=instance, schema=schema)
-
-
 def test_ogrinfo_lib_json_validate():
 
     ds = gdal.OpenEx("../ogr/data/poly.shp")
 
-    _validate_json_output(gdal.VectorInfo(ds, format="json", dumpFeatures=True))
+    ret = gdal.VectorInfo(ds, format="json", dumpFeatures=True)
+
+    gdaltest.validate_json(ret, "ogrinfo_output.schema.json")
 
 
 ###############################################################################
@@ -667,7 +648,7 @@ def test_ogrinfo_lib_json_relationships():
     ds = gdal.OpenEx("../ogr/data/filegdb/relationships.gdb")
 
     ret = gdal.VectorInfo(ds, format="json")
-    _validate_json_output(ret)
+    gdaltest.validate_json(ret, "ogrinfo_output.schema.json")
 
     # print(ret["relationships"]["composite_many_to_many"])
     assert ret["relationships"]["composite_many_to_many"] == {


### PR DESCRIPTION
## What does this PR do?

Removes duplicated JSON validation code.

Adds error handling to skip tests instead of failing if external resources in the JSON schema cannot be resolved.

Example spurious failure: https://github.com/dbaston/gdal/actions/runs/4876661250/jobs/8700425769#step:16:4680

Output with this PR:

```
 utilities/test_gdalinfo_lib.py ✓s✓✓✓✓✓✓✓✓✓✓✓                                                                                                                            100% ██████████
=============================================================================== short test summary info ================================================================================
SKIPPED [1] autotest/utilities/test_gdalinfo_lib.py:62: Failed to resolve remote reference in schema
```

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
