### PR TITLE
Python bindings: Use ogr.DataSource and gdal.Dataset as context managers

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -756,3 +756,18 @@ def test_basic_test_DontUseExceptions():
     assert "ERROR " in err
     assert "FutureWarning: Neither gdal.UseExceptions()" not in err
     assert "FutureWarning: Neither ogr.UseExceptions()" not in err
+
+
+def test_create_context_manager(tmp_path):
+    fname = str(tmp_path / "out.tif")
+
+    drv = gdal.GetDriverByName("GTiff")
+    with drv.Create(fname, xsize=10, ysize=10, bands=1, eType=gdal.GDT_Float32) as ds:
+        ds.GetRasterBand(1).Fill(100)
+
+    # Make sure we don't crash when accessing ds after it has been closed
+    with pytest.raises(Exception):
+        ds.GetRasterBand(1).ReadRaster()
+
+    ds_in = gdal.Open(fname)
+    assert ds_in.GetRasterBand(1).Checksum() != 0

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -891,6 +891,32 @@ def test_ogr_basic_test_future_warning_exceptions():
 
 
 ###############################################################################
+# Test CreateDataSource context manager
+
+
+def test_ogr_basic_create_data_source_context_manager(tmp_path):
+    fname = str(tmp_path / "out.shp")
+
+    drv = ogr.GetDriverByName("ESRI Shapefile")
+    with drv.CreateDataSource(fname) as ds:
+        lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (0 0)"))
+        lyr.CreateFeature(f)
+
+    # Make sure we don't crash when accessing ds after it has been closed
+    with pytest.raises(Exception):
+        ds.GetLayerByName("test")
+
+    # Make sure the feature has actually been written
+    ds_in = ogr.Open(fname)
+    lyr_in = ds_in.GetLayer(0)
+
+    assert lyr_in.GetFeatureCount() == 1
+
+
+###############################################################################
 # cleanup
 
 

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -5756,18 +5756,17 @@ def test_ogr_shape_write_non_planar_polygon():
     filename = "/vsimem/" + layer_name + ".shp"
     shape_drv = ogr.GetDriverByName("ESRI Shapefile")
 
-    ds = shape_drv.CreateDataSource(filename)
-    lyr = ds.CreateLayer(layer_name, geom_type=ogr.wkbPolygon25D)
+    with shape_drv.CreateDataSource(filename) as ds:
+        lyr = ds.CreateLayer(layer_name, geom_type=ogr.wkbPolygon25D)
 
-    # Create a shape
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetGeometry(
-        ogr.CreateGeometryFromWkt(
-            "POLYGON Z ((516113.631069 5041435.137874 137.334, 516141.2239 5041542.465874 137.614, 515998.390418 5041476.527121 137.288, 516113.631069 5041435.137874 137.334), (516041.808551 5041476.527121 137.418, 516111.602184 5041505.337284 137.322, 516098.617322 5041456.644051 137.451, 516041.808551 5041476.527121 137.418))"
+        # Create a shape
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(
+            ogr.CreateGeometryFromWkt(
+                "POLYGON Z ((516113.631069 5041435.137874 137.334, 516141.2239 5041542.465874 137.614, 515998.390418 5041476.527121 137.288, 516113.631069 5041435.137874 137.334), (516041.808551 5041476.527121 137.418, 516111.602184 5041505.337284 137.322, 516098.617322 5041456.644051 137.451, 516041.808551 5041476.527121 137.418))"
+            )
         )
-    )
-    lyr.CreateFeature(f)
-    ds = None
+        lyr.CreateFeature(f)
 
     ds = ogr.Open(filename)
     lyr = ds.GetLayer(0)
@@ -5779,7 +5778,6 @@ def test_ogr_shape_write_non_planar_polygon():
         )
         == 0
     )
-    ds = None
 
     shape_drv.DeleteDataSource(filename)
 

--- a/swig/include/python/docs/gdal_dataset_docs.i
+++ b/swig/include/python/docs/gdal_dataset_docs.i
@@ -1,3 +1,11 @@
-%extend GDALDatasetShadow {
+%feature("docstring") GDALDatasetShadow "
+Python proxy of a raster :cpp:class:`GDALDataset`.
 
+Since GDAL 3.8, a Dataset can be used as a context manager.
+When exiting the context, the Dataset will be closed and
+data will be written to disk.
+"
+
+%extend GDALDatasetShadow {
 }
+

--- a/swig/include/python/docs/ogr_datasource_docs.i
+++ b/swig/include/python/docs/ogr_datasource_docs.i
@@ -1,3 +1,11 @@
+%feature("docstring") OGRDataSourceShadow "
+Python proxy of a vector :cpp:class:`GDALDataset`.
+
+Since GDAL 3.8, a DataSource can be used as a context manager.
+When exiting the context, the DataSource will be closed and
+features will be written to disk.
+"
+
 %extend OGRDataSourceShadow {
 // File: ogrdatasource_8cpp.xml
 %feature("docstring")  Destroy "void OGR_DS_Destroy(OGRDataSourceH

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1054,6 +1054,12 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
         else:
             return self._SetGCPs2(gcps, wkt_or_spatial_ref)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        _gdal.delete_Dataset(self)
+        self.this = None
 %}
 
 %feature("shadow") ExecuteSQL %{

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -99,6 +99,13 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
         """Returns the number of layers on the datasource"""
         return self.GetLayerCount()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.Destroy()
+        self.this = None
+
     def __getitem__(self, value):
         """Support dictionary, list, and slice -like access to the datasource.
         ds[0] would return the first layer on the datasource.


### PR DESCRIPTION
## What does this PR do?

Allows the OGRDataSource proxy to serve as a context manager, so instead of:

```
ds = drv.CreateDataSource(fname)

lyr = ds.CreateLayer('test', geom_type = ogr.wkbPoint)

f = ogr.Feature(lyr.GetLayerDefn())
f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (0 0)"))
lyr.CreateFeature(f)

del ds  # or ds = None, or ds.Destroy(), or ds.FlushCache()
```
(one of the "gotchas" documented at https://gdal.org/api/python_gotchas.html#saving-and-closing-datasets-datasources)

You can do 
```
with drv.CreateDataSource(fname) as ds:
    lyr = ds.CreateLayer('test', geom_type = ogr.wkbPoint)

    f = ogr.Feature(lyr.GetLayerDefn())
    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (0 0)"))
    lyr.CreateFeature(f)
```

I'm guessing there is a reason this hasn't been done...in which case this PR can document that reason :)

## What are related issues/pull requests?

## Tasklist

 - [x] Add test case(s)
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
