### PR TITLE
JP2OpenJPEG: avoid hard crash in multi-threaded writing mode when …

### DIFF
--- a/frmts/openjpeg/openjpegdataset.cpp
+++ b/frmts/openjpeg/openjpegdataset.cpp
@@ -4433,6 +4433,13 @@ GDALDataset *JP2OpenJPEGDataset::CreateCopy(
             }
         }
 
+        if (bUseIOThread && eErr == CE_Failure)
+        {
+            // Wait for previous background I/O task to be finished
+            // before freeing buffers (pTempBuffer, etc.)
+            oPool.WaitCompletion();
+        }
+
         VSIFree(pTempBuffer);
         VSIFree(pYUV420Buffer);
 


### PR DESCRIPTION
… opj_write_tile() fails (fixes #7713)
