### PR TITLE
DXF: Show constant ATTDEFs as text

### DIFF
--- a/autotest/ogr/data/dxf/attrib.dxf
+++ b/autotest/ogr/data/dxf/attrib.dxf
@@ -123,6 +123,44 @@ MYATT1
   0
 ATTDEF
   5
+BEA1
+100
+AcDbEntity
+  8
+0
+100
+AcDbText
+ 10
+1
+ 20
+2
+ 30
+0.0
+ 40
+8.0
+  1
+Constant attribute
+ 50
+8.0
+ 72
+     1
+ 11
+0.0
+ 21
+10.0
+ 31
+0.0
+100
+AcDbAttributeDefinition
+  3
+whatever
+  2
+MYATTCONSTANT
+ 70
+     2
+  0
+ATTDEF
+  5
 BEF
 100
 AcDbEntity

--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -3611,11 +3611,17 @@ def test_ogr_dxf_49():
     # Inline blocks mode
     ds = ogr.Open("data/dxf/attrib.dxf")
     lyr = ds.GetLayer(0)
-    assert lyr.GetFeatureCount() == 6, (
+    assert lyr.GetFeatureCount() == 8, (
         "Wrong feature count, got %d" % lyr.GetFeatureCount()
     )
 
     f = lyr.GetFeature(1)
+    assert (
+        f.GetStyleString()
+        == 'LABEL(f:"Arial",t:"Constant attribute",p:2,a:8,s:8g,dx:-1g,dy:8g,c:#000000)'
+    ), "Wrong style string on constant attribute on first INSERT"
+
+    f = lyr.GetFeature(2)
     assert (
         f.GetField("Text") == "super test"
     ), "Wrong Text value on first ATTRIB on first INSERT"
@@ -3624,11 +3630,11 @@ def test_ogr_dxf_49():
         == 'LABEL(f:"Arial",t:"super test",p:2,s:8g,w:234.6,dx:30.293g,c:#ff0000)'
     ), "Wrong style string on first ATTRIB on first INSERT"
 
-    f = lyr.GetFeature(4)
+    f = lyr.GetFeature(5)
     geom = f.GetGeometryRef()
     assert geom.GetGeometryType() == ogr.wkbLineString25D, "Expected LINESTRING Z"
 
-    f = lyr.GetFeature(5)
+    f = lyr.GetFeature(7)
     assert f.GetField("Text") == "", "Wrong Text value on ATTRIB on second INSERT"
 
     # No inlining
@@ -3651,6 +3657,8 @@ def test_ogr_dxf_49():
 
     lyr = ds.GetLayerByName("blocks")
 
+    assert lyr.GetFeatureCount() == 4
+
     f = lyr.GetFeature(1)
     assert (
         f.GetField("AttributeTag") == "MYATT1"
@@ -3658,8 +3666,16 @@ def test_ogr_dxf_49():
 
     f = lyr.GetFeature(2)
     assert (
+        f.GetField("AttributeTag") == None
+    ), "Wrong AttributeTag value on second (constant) ATTDEF"
+    assert (
+        f.GetField("Text") == "Constant attribute"
+    ), "Wrong Text value on second (constant) ATTDEF"
+
+    f = lyr.GetFeature(3)
+    assert (
         f.GetField("AttributeTag") == "MYATTMULTI"
-    ), "Wrong AttributeTag value on second ATTDEF"
+    ), "Wrong AttributeTag value on third ATTDEF"
 
 
 ###############################################################################

--- a/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxflayer.cpp
@@ -752,9 +752,16 @@ OGRDXFFeature *OGRDXFLayer::TranslateTEXT(const bool bIsAttribOrAttdef)
                 break;
 
             case 70:
-                // When the LSB is set, this ATTRIB is "invisible"
-                if (bIsAttribOrAttdef && atoi(szLineBuf) & 1)
-                    poFeature->oStyleProperties["Hidden"] = "1";
+                if (bIsAttribOrAttdef)
+                {
+                    // When the LSB is set, this ATTRIB is "invisible"
+                    if (atoi(szLineBuf) & 1)
+                        poFeature->oStyleProperties["Hidden"] = "1";
+                    // If the next bit is set, this ATTDEF is to be preserved
+                    // and treated as constant TEXT
+                    else if (atoi(szLineBuf) & 2)
+                        poFeature->osAttributeTag.Clear();
+                }
                 break;
 
             default:


### PR DESCRIPTION
Constant ATTDEFs are used in the construction of dynamic blocks in AutoCAD.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
