### PR TITLE
Doc: Add doxygen target to doc Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,12 +14,15 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile clean generated_rst_files
+.PHONY: help Makefile clean generated_rst_files doxygen
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+doxygen:
+	$(MAKE) -B .doxygen_up_to_date
 
 .doxygen_up_to_date:
 	mkdir -p build/xml && cd .. && ((cat Doxyfile | sed "s/PREDEFINED             = /PREDEFINED             = DOXYGEN_XML /"; printf "GENERATE_HTML=NO\nGENERATE_XML=YES\nXML_OUTPUT=doc/build/xml\nXML_PROGRAMLISTING=NO") | doxygen -)

--- a/doc/source/development/dev_documentation.rst
+++ b/doc/source/development/dev_documentation.rst
@@ -22,7 +22,8 @@ Building documentation
 ######################
 
 HTML documentation can be built by running ``make html`` in the ``doc`` subdirectory of the GDAL source repository.
- The generated files will be output to ``doc/build`` where they can be viewed using a web browser.
+The generated files will be output to ``doc/build`` where they can be viewed using a web browser.
+Doxygen content that is incorporated into the output is not automatically rebuilt but can be regenerated using ``make doxygen``.
 
 To visualize documentation changes while editing, it may be useful to install the |sphinx-autobuild| python package.
 Once installed, running ``sphinx-autobuild -b html source build`` from the ``doc`` subdirectory will build documentation


### PR DESCRIPTION
## What does this PR do?

Small change to clarify the journey from Doxygen markup to HTML documentation.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed