### PR TITLE
Multidim API: add methods to delete groups, arrays and attributes

### DIFF
--- a/autotest/gcore/hdf4multidim.py
+++ b/autotest/gcore/hdf4multidim.py
@@ -225,7 +225,7 @@ def test_hdf4multidim_gdal_sds_2d():
     ds = gdal.OpenEx("data/byte_2.hdf", gdal.OF_MULTIDIM_RASTER)
     assert ds
     rg = ds.GetRootGroup()
-    assert rg.GetGroupNames() is None
+    assert len(rg.GetGroupNames()) == 0
     assert rg.OpenGroup("scientific_datasets") is None
     assert rg.GetMDArrayNames() == ["Band0", "X", "Y"]
     dims = rg.GetDimensions()
@@ -271,7 +271,7 @@ def test_hdf4multidim_gdal_sds_3d():
     ds = gdal.OpenEx("data/byte_3.hdf", gdal.OF_MULTIDIM_RASTER)
     assert ds
     rg = ds.GetRootGroup()
-    assert rg.GetGroupNames() is None
+    assert len(rg.GetGroupNames()) == 0
     assert rg.OpenGroup("scientific_datasets") is None
     assert rg.GetMDArrayNames() == ["3-dimensional Scientific Dataset", "X", "Y"]
     dims = rg.GetDimensions()

--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -2752,6 +2752,124 @@ def test_mem_md_rename_array():
     assert set(subg.GetMDArrayNames()) == {"ar_renamed", "other_array"}
 
 
+@gdaltest.enable_exceptions()
+def test_mem_md_delete_group():
+
+    drv = gdal.GetDriverByName("MEM")
+    ds = drv.CreateMultiDimensional("myds")
+    rg = ds.GetRootGroup()
+
+    group = rg.CreateGroup("group")
+    group_attr = group.CreateAttribute(
+        "ar_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+    ar = group.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar_attr = ar.CreateAttribute(
+        "ar_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+    subgroup = group.CreateGroup("subgroup")
+
+    with pytest.raises(Exception, match="is not a sub-group"):
+        rg.DeleteGroup("non_existing")
+
+    # Delete group and test effects
+    rg.DeleteGroup("group")
+
+    assert len(rg.GetGroupNames()) == 0
+
+    with pytest.raises(Exception, match="has been deleted"):
+        group.GetMDArrayNames()
+
+    with pytest.raises(Exception, match="has been deleted"):
+        group_attr.Rename("foo")
+
+    with pytest.raises(Exception, match="has been deleted"):
+        subgroup.GetMDArrayNames()
+
+    with pytest.raises(Exception, match="has been deleted"):
+        ar.GetAttributes()
+
+    with pytest.raises(Exception, match="has been deleted"):
+        ar_attr.Rename("foo")
+
+
+@gdaltest.enable_exceptions()
+def test_mem_md_delete_array():
+
+    drv = gdal.GetDriverByName("MEM")
+    ds = drv.CreateMultiDimensional("myds")
+    rg = ds.GetRootGroup()
+
+    group = rg.CreateGroup("group")
+    ar = group.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar_attr = ar.CreateAttribute(
+        "ar_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+
+    with pytest.raises(Exception, match="is not an array"):
+        group.DeleteMDArray("non_existing")
+
+    # Delete array and test effects
+    group.DeleteMDArray("ar")
+
+    assert len(rg.GetMDArrayNames()) == 0
+
+    with pytest.raises(Exception, match="has been deleted"):
+        ar.GetAttributes()
+
+    with pytest.raises(Exception, match="has been deleted"):
+        ar_attr.Rename("foo")
+
+
+@gdaltest.enable_exceptions()
+def test_mem_md_delete_group_attribute():
+
+    drv = gdal.GetDriverByName("MEM")
+    ds = drv.CreateMultiDimensional("myds")
+    rg = ds.GetRootGroup()
+
+    group = rg.CreateGroup("group")
+    group_attr = group.CreateAttribute(
+        "group_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+
+    with pytest.raises(Exception, match="is not an attribute"):
+        group.DeleteAttribute("non_existing")
+
+    # Delete attribute and test effects
+    group.DeleteAttribute("group_attr")
+
+    assert len(group.GetAttributes()) == 0
+
+    with pytest.raises(Exception, match="has been deleted"):
+        group_attr.Rename("foo")
+
+
+@gdaltest.enable_exceptions()
+def test_mem_md_delete_array_attribute():
+
+    drv = gdal.GetDriverByName("MEM")
+    ds = drv.CreateMultiDimensional("myds")
+    rg = ds.GetRootGroup()
+
+    group = rg.CreateGroup("group")
+    ar = group.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar_attr = ar.CreateAttribute(
+        "ar_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+
+    with pytest.raises(Exception, match="is not an attribute"):
+        ar.DeleteAttribute("non_existing")
+
+    # Delete attribute and test effects
+    ar.DeleteAttribute("ar_attr")
+
+    assert len(ar.GetAttributes()) == 0
+
+    with pytest.raises(Exception, match="has been deleted"):
+        ar_attr.Rename("foo")
+
+
 def XX_test_all_forever():
     while True:
         test_mem_md_basic()

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -5778,7 +5778,7 @@ def test_netcdf_metadata_sentinel5():
     ds = gdal.OpenEx("data/netcdf/fake_ISO_METADATA.nc", gdal.OF_MULTIDIM_RASTER)
     assert ds is not None
     rg = ds.GetRootGroup()
-    assert rg.GetGroupNames() is None
+    assert len(rg.GetGroupNames()) == 0
     assert "ISO_METADATA" in [attr.GetName() for attr in rg.GetAttributes()]
     attr = rg.GetAttribute("ISO_METADATA")
     assert attr is not None

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -77,7 +77,7 @@ def test_netcdf_multidim_single_group():
     assert rg
     assert rg.GetName() == "/"
     assert rg.GetFullName() == "/"
-    assert rg.GetGroupNames() is None
+    assert len(rg.GetGroupNames()) == 0
     dims = rg.GetDimensions()
     assert len(dims) == 2
     assert dims[0].GetName() == "x"
@@ -149,7 +149,7 @@ def test_netcdf_multidim_multi_group():
     assert subgroup.GetName() == "group"
     assert subgroup.GetFullName() == "/group"
     assert rg.OpenGroup("foo") is None
-    assert subgroup.GetGroupNames() is None
+    assert len(subgroup.GetGroupNames()) == 0
     assert subgroup.GetMDArrayNames() == ["fmul"]
     assert subgroup.OpenGroup("foo") is None
 
@@ -2069,7 +2069,7 @@ def test_netcdf_multidim_group_by_same_dimension():
         gdal.OF_MULTIDIM_RASTER,
     )
     rg = ds.GetRootGroup()
-    assert rg.GetMDArrayNames(["GROUP_BY=SAME_DIMENSION"]) is None
+    assert len(rg.GetMDArrayNames(["GROUP_BY=SAME_DIMENSION"])) == 0
     groups = rg.GetGroupNames(["GROUP_BY=SAME_DIMENSION"])
     assert set(groups) == set(["time_01", "time_20_c", "time_20_ku"])
     g = rg.OpenGroup("time_01", ["GROUP_BY=SAME_DIMENSION"])

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -3386,3 +3386,72 @@ def test_netcdf_multidim_copy_group_with_indexing_variable_after_regular_var():
     finally:
         if os.path.exists(outfilename):
             gdal.Unlink(outfilename)
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_netcdf_multidim_delete_attribute():
+
+    drv = gdal.GetDriverByName("netCDF")
+    filename = "tmp/test_netcdf_multidim_delete_attribute.nc"
+
+    def test():
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        rg = ds.GetRootGroup()
+        subg = rg.CreateGroup("group")
+        subg_attr = subg.CreateAttribute(
+            "subg_attr", [], gdal.ExtendedDataType.CreateString()
+        )
+        assert subg_attr.Write("foo") == gdal.CE_None
+        subg_other_attr = subg.CreateAttribute(
+            "subg_other_attr", [], gdal.ExtendedDataType.CreateString()
+        )
+        assert subg_other_attr.Write("foo") == gdal.CE_None
+
+        ar = subg.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+        attr = ar.CreateAttribute("attr", [], gdal.ExtendedDataType.CreateString())
+        assert attr.Write("foo") == gdal.CE_None
+        other_attr = ar.CreateAttribute(
+            "other_attr", [], gdal.ExtendedDataType.CreateString()
+        )
+        assert other_attr.Write("foo") == gdal.CE_None
+
+        with pytest.raises(Exception):
+            ar.DeleteAttribute("not_existing")
+
+        # Delete array attribute and test effects
+        ar.DeleteAttribute("attr")
+
+        assert set(x.GetName() for x in ar.GetAttributes()) == {"other_attr"}
+
+        with pytest.raises(Exception, match="has been deleted"):
+            attr.Rename("foo")
+
+        with pytest.raises(Exception):
+            subg.DeleteAttribute("not_existing")
+
+        # Delete group attribute and test effects
+        subg.DeleteAttribute("subg_attr")
+
+        assert set(x.GetName() for x in subg.GetAttributes()) == {"subg_other_attr"}
+
+        with pytest.raises(Exception, match="has been deleted"):
+            subg_attr.Rename("foo")
+
+    def reopen():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        subg = rg.OpenGroup("group")
+        ar = subg.OpenMDArray("ar")
+
+        assert set(x.GetName() for x in ar.GetAttributes()) == {"other_attr"}
+        assert set(x.GetName() for x in subg.GetAttributes()) == {"subg_other_attr"}
+
+    try:
+        test()
+        reopen()
+    finally:
+        gdal.Unlink(filename)

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -865,7 +865,7 @@ def test_zarr_read_group(use_get_names):
     assert rg.OpenGroup("not_existing") is None
     assert subgroup.GetName() == "foo"
     assert subgroup.GetFullName() == "/foo"
-    assert rg.GetMDArrayNames() is None
+    assert len(rg.GetMDArrayNames()) == 0
     if use_get_names:
         assert subgroup.GetGroupNames() == ["bar"]
     assert subgroup.GetAttributes() == []
@@ -898,7 +898,7 @@ def test_zarr_read_group_with_zmetadata():
     assert rg.OpenGroup("not_existing") is None
     assert subgroup.GetName() == "foo"
     assert subgroup.GetFullName() == "/foo"
-    assert rg.GetMDArrayNames() is None
+    assert len(rg.GetMDArrayNames()) == 0
     assert subgroup.GetGroupNames() == ["bar"]
     assert subgroup.GetAttributes() == []
     subsubgroup = subgroup.OpenGroup("bar")

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -4677,3 +4677,328 @@ def test_zarr_multidim_rename_dim_after_reopening(format, create_z_metadata):
         reopen_after_rename()
     finally:
         gdal.RmdirRecursive(filename)
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "format,create_z_metadata",
+    [("ZARR_V2", "YES"), ("ZARR_V2", "NO"), ("ZARR_V3", "NO")],
+)
+@pytest.mark.parametrize("get_before_delete", [True, False])
+def test_zarr_multidim_delete_group_after_reopening(
+    format, create_z_metadata, get_before_delete
+):
+
+    drv = gdal.GetDriverByName("ZARR")
+    filename = "/vsimem/test.zarr"
+
+    def create():
+        ds = drv.CreateMultiDimensional(
+            filename,
+            options=["FORMAT=" + format, "CREATE_ZMETADATA=" + create_z_metadata],
+        )
+        rg = ds.GetRootGroup()
+        group = rg.CreateGroup("group")
+        group_attr = group.CreateAttribute(
+            "group_attr", [], gdal.ExtendedDataType.CreateString()
+        )
+        group_attr.Write("my_string")
+        rg.CreateGroup("other_group")
+        dim = group.CreateDimension(
+            "dim0", "unspecified type", "unspecified direction", 2
+        )
+        ar = group.CreateMDArray(
+            "ar", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+        )
+        attr = ar.CreateAttribute("attr", [], gdal.ExtendedDataType.CreateString())
+        attr.Write("foo")
+        attr2 = ar.CreateAttribute("attr2", [], gdal.ExtendedDataType.CreateString())
+        attr2.Write("foo")
+
+        group.CreateGroup("subgroup")
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+
+        # Read-only
+        with pytest.raises(Exception, match="not open in update mode"):
+            rg.DeleteGroup("group")
+
+        assert set(rg.GetGroupNames()) == {"group", "other_group"}
+
+        assert rg.OpenGroup("group")
+
+    def delete():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
+        rg = ds.GetRootGroup()
+
+        with pytest.raises(Exception, match="is not a sub-group of this group"):
+            rg.DeleteGroup("non_existing")
+
+        if not get_before_delete:
+            rg.DeleteGroup("group")
+
+            assert set(rg.GetGroupNames()) == {"other_group"}
+
+            with pytest.raises(Exception, match="does not exist"):
+                rg.OpenGroup("group")
+
+        else:
+            group = rg.OpenGroup("group")
+            group_attr = group.GetAttribute("group_attr")
+            ar = group.OpenMDArray("ar")
+            attr = ar.GetAttribute("attr")
+
+            # Delete group and test effects
+            rg.DeleteGroup("group")
+
+            assert set(rg.GetGroupNames()) == {"other_group"}
+
+            with pytest.raises(Exception, match="does not exist"):
+                rg.OpenGroup("group")
+
+            with pytest.raises(Exception, match="has been deleted"):
+                group.Rename("renamed")
+
+            with pytest.raises(Exception, match="has been deleted"):
+                group_attr.Rename("renamed")
+
+            with pytest.raises(Exception, match="has been deleted"):
+                ar.GetAttributes()
+
+            with pytest.raises(Exception, match="has been deleted"):
+                attr.Write("foo2")
+
+            with pytest.raises(Exception, match="has been deleted"):
+                ar.GetAttribute("attr2")
+
+    def reopen_after_delete():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+
+        assert set(rg.GetGroupNames()) == {"other_group"}
+
+    try:
+        create()
+        reopen_readonly()
+        delete()
+        reopen_after_delete()
+
+    finally:
+        gdal.RmdirRecursive(filename)
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "format,create_z_metadata",
+    [("ZARR_V2", "YES"), ("ZARR_V2", "NO"), ("ZARR_V3", "NO")],
+)
+@pytest.mark.parametrize("get_before_delete", [True, False])
+def test_zarr_multidim_delete_array_after_reopening(
+    format, create_z_metadata, get_before_delete
+):
+
+    drv = gdal.GetDriverByName("ZARR")
+    filename = "/vsimem/test.zarr"
+
+    def create():
+        ds = drv.CreateMultiDimensional(
+            filename,
+            options=["FORMAT=" + format, "CREATE_ZMETADATA=" + create_z_metadata],
+        )
+        rg = ds.GetRootGroup()
+        group = rg.CreateGroup("group")
+        ar = group.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+        attr = ar.CreateAttribute("attr", [], gdal.ExtendedDataType.CreateString())
+        attr.Write("foo")
+        attr2 = ar.CreateAttribute("attr2", [], gdal.ExtendedDataType.CreateString())
+        attr2.Write("foo")
+
+        group.CreateMDArray("other_ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        group = rg.OpenGroup("group")
+
+        # Read-only
+        with pytest.raises(Exception, match="not open in update mode"):
+            group.DeleteMDArray("ar")
+
+        assert set(group.GetMDArrayNames()) == {"ar", "other_ar"}
+
+        assert group.OpenMDArray("ar")
+
+    def delete():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
+        rg = ds.GetRootGroup()
+        group = rg.OpenGroup("group")
+
+        with pytest.raises(Exception, match="is not an array of this group"):
+            group.DeleteMDArray("non_existing")
+
+        if not get_before_delete:
+            group.DeleteMDArray("ar")
+
+            assert set(group.GetMDArrayNames()) == {"other_ar"}
+
+            with pytest.raises(Exception, match="does not exist"):
+                group.OpenMDArray("ar")
+
+        else:
+            ar = group.OpenMDArray("ar")
+            attr = ar.GetAttribute("attr")
+
+            # Delete array and test effects
+            group.DeleteMDArray("ar")
+
+            assert set(group.GetMDArrayNames()) == {"other_ar"}
+
+            with pytest.raises(Exception, match="does not exist"):
+                group.OpenMDArray("ar")
+
+            with pytest.raises(Exception, match="has been deleted"):
+                ar.GetAttributes()
+
+            with pytest.raises(Exception, match="has been deleted"):
+                attr.Write("foo2")
+
+    def reopen_after_delete():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        group = rg.OpenGroup("group")
+
+        assert set(group.GetMDArrayNames()) == {"other_ar"}
+
+    try:
+        create()
+        reopen_readonly()
+        delete()
+        reopen_after_delete()
+
+    finally:
+        gdal.RmdirRecursive(filename)
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "format,create_z_metadata",
+    [("ZARR_V2", "YES"), ("ZARR_V2", "NO"), ("ZARR_V3", "NO")],
+)
+@pytest.mark.parametrize("get_before_delete", [True, False])
+def test_zarr_multidim_delete_attribute_after_reopening(
+    format, create_z_metadata, get_before_delete
+):
+
+    drv = gdal.GetDriverByName("ZARR")
+    filename = "/vsimem/test.zarr"
+
+    def create():
+        ds = drv.CreateMultiDimensional(
+            filename,
+            options=["FORMAT=" + format, "CREATE_ZMETADATA=" + create_z_metadata],
+        )
+        rg = ds.GetRootGroup()
+        group = rg.CreateGroup("group")
+        group_attr = group.CreateAttribute(
+            "group_attr", [], gdal.ExtendedDataType.CreateString()
+        )
+        group_attr.Write("foo")
+        group_attr2 = group.CreateAttribute(
+            "group_attr2", [], gdal.ExtendedDataType.CreateString()
+        )
+        group_attr2.Write("foo")
+
+        ar = group.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+        attr = ar.CreateAttribute("attr", [], gdal.ExtendedDataType.CreateString())
+        attr.Write("foo")
+        attr2 = ar.CreateAttribute("attr2", [], gdal.ExtendedDataType.CreateString())
+        attr2.Write("foo")
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        group = rg.OpenGroup("group")
+
+        # Read-only
+        with pytest.raises(Exception, match="not open in update mode"):
+            group.DeleteAttribute("group_attr")
+
+        assert set(x.GetName() for x in group.GetAttributes()) == {
+            "group_attr",
+            "group_attr2",
+        }
+
+        ar = group.OpenMDArray("ar")
+        with pytest.raises(Exception, match="not open in update mode"):
+            ar.DeleteAttribute("attr")
+
+        assert set(x.GetName() for x in ar.GetAttributes()) == {"attr", "attr2"}
+
+    def delete():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
+        rg = ds.GetRootGroup()
+        group = rg.OpenGroup("group")
+
+        with pytest.raises(Exception, match="is not an attribute"):
+            group.DeleteAttribute("non_existing")
+
+        ar = group.OpenMDArray("ar")
+        with pytest.raises(Exception, match="is not an attribute"):
+            ar.DeleteAttribute("non_existing")
+
+        if not get_before_delete:
+            group.DeleteAttribute("group_attr")
+
+            assert set(x.GetName() for x in group.GetAttributes()) == {"group_attr2"}
+
+            ar.DeleteAttribute("attr")
+
+            assert set(x.GetName() for x in ar.GetAttributes()) == {"attr2"}
+
+        else:
+            group_attr = group.GetAttribute("group_attr")
+            attr = ar.GetAttribute("attr")
+
+            group.DeleteAttribute("group_attr")
+
+            assert set(x.GetName() for x in group.GetAttributes()) == {"group_attr2"}
+
+            with pytest.raises(Exception, match="has been deleted"):
+                group_attr.Write("foo2")
+
+            ar.DeleteAttribute("attr")
+
+            assert set(x.GetName() for x in ar.GetAttributes()) == {"attr2"}
+
+            with pytest.raises(Exception, match="has been deleted"):
+                attr.Write("foo2")
+
+    def reopen_after_delete():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        group = rg.OpenGroup("group")
+
+        assert set(x.GetName() for x in group.GetAttributes()) == {"group_attr2"}
+
+        ar = group.OpenMDArray("ar")
+        assert set(x.GetName() for x in ar.GetAttributes()) == {"attr2"}
+
+    try:
+        create()
+        reopen_readonly()
+        delete()
+        reopen_after_delete()
+
+    finally:
+        gdal.RmdirRecursive(filename)

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -2723,7 +2723,7 @@ def test_ogr_fgdb_read_layer_hierarchy():
     assert fd1 is not None
     assert fd1.GetVectorLayerNames() == ["fd1_lyr1", "fd1_lyr2"]
     assert fd1.OpenVectorLayer("not_existing") is None
-    assert fd1.GetGroupNames() is None
+    assert len(fd1.GetGroupNames()) == 0
 
     fd1_lyr1 = fd1.OpenVectorLayer("fd1_lyr1")
     assert fd1_lyr1 is not None

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -2085,7 +2085,7 @@ def test_ogr_openfilegdb_read_layer_hierarchy():
     assert fd1 is not None
     assert fd1.GetVectorLayerNames() == ["fd1_lyr1", "fd1_lyr2"]
     assert fd1.OpenVectorLayer("not_existing") is None
-    assert fd1.GetGroupNames() is None
+    assert len(fd1.GetGroupNames()) == 0
 
     fd1_lyr1 = fd1.OpenVectorLayer("fd1_lyr1")
     assert fd1_lyr1 is not None

--- a/frmts/mem/memmultidim.h
+++ b/frmts/mem/memmultidim.h
@@ -80,6 +80,8 @@ class CPL_DLL MEMGroup CPL_NON_FINAL : public GDALGroup,
 
     void NotifyChildrenOfRenaming() override;
 
+    void NotifyChildrenOfDeletion() override;
+
   public:
     MEMGroup(const std::string &osParentName, const char *pszName)
         : GDALGroup(osParentName, pszName ? pszName : "")
@@ -111,6 +113,9 @@ class CPL_DLL MEMGroup CPL_NON_FINAL : public GDALGroup,
     std::shared_ptr<GDALGroup> CreateGroup(const std::string &osName,
                                            CSLConstList papszOptions) override;
 
+    bool DeleteGroup(const std::string &osName,
+                     CSLConstList papszOptions) override;
+
     std::shared_ptr<GDALDimension>
     CreateDimension(const std::string &, const std::string &,
                     const std::string &, GUInt64,
@@ -128,6 +133,9 @@ class CPL_DLL MEMGroup CPL_NON_FINAL : public GDALGroup,
         const GDALExtendedDataType &oDataType, void *pData,
         CSLConstList papszOptions);
 
+    bool DeleteMDArray(const std::string &osName,
+                       CSLConstList papszOptions) override;
+
     std::shared_ptr<GDALAttribute>
     GetAttribute(const std::string &osName) const override;
 
@@ -142,6 +150,9 @@ class CPL_DLL MEMGroup CPL_NON_FINAL : public GDALGroup,
                     const std::vector<GUInt64> &anDimensions,
                     const GDALExtendedDataType &oDataType,
                     CSLConstList papszOptions) override;
+
+    bool DeleteAttribute(const std::string &osName,
+                         CSLConstList papszOptions) override;
 
     bool Rename(const std::string &osNewName) override;
 };
@@ -173,7 +184,6 @@ class CPL_DLL MEMAbstractMDArray : virtual public GDALAbstractMDArray
 
   protected:
     bool m_bOwnArray = false;
-    bool m_bValid = true;
     bool m_bWritable = true;
     bool m_bModified = false;
     GDALExtendedDataType m_oType;
@@ -272,6 +282,8 @@ class MEMMDArray CPL_NON_FINAL : public MEMAbstractMDArray,
 
     void NotifyChildrenOfRenaming() override;
 
+    void NotifyChildrenOfDeletion() override;
+
   protected:
     MEMMDArray(const std::string &osParentName, const std::string &osName,
                const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
@@ -322,6 +334,9 @@ class MEMMDArray CPL_NON_FINAL : public MEMAbstractMDArray,
                     const std::vector<GUInt64> &anDimensions,
                     const GDALExtendedDataType &oDataType,
                     CSLConstList papszOptions) override;
+
+    bool DeleteAttribute(const std::string &osName,
+                         CSLConstList papszOptions) override;
 
     const std::string &GetUnit() const override
     {

--- a/frmts/zarr/zarr_attribute.cpp
+++ b/frmts/zarr/zarr_attribute.cpp
@@ -346,3 +346,12 @@ void ZarrAttributeGroup::ParentRenamed(const std::string &osNewParentFullName)
         attr->ParentRenamed(m_poGroup->GetFullName());
     }
 }
+
+/************************************************************************/
+/*                          ParentDeleted()                             */
+/************************************************************************/
+
+void ZarrAttributeGroup::ParentDeleted()
+{
+    m_poGroup->Deleted();
+}

--- a/frmts/zarr/zarr_sharedresource.cpp
+++ b/frmts/zarr/zarr_sharedresource.cpp
@@ -247,10 +247,11 @@ void ZarrSharedResource::SetZMetadataItem(const std::string &osFilename,
 }
 
 /************************************************************************/
-/*             ZarrSharedResource::DeleteZMetadataItem()                */
+/*         ZarrSharedResource::DeleteZMetadataItemRecursive()           */
 /************************************************************************/
 
-void ZarrSharedResource::DeleteZMetadataItem(const std::string &osFilename)
+void ZarrSharedResource::DeleteZMetadataItemRecursive(
+    const std::string &osFilename)
 {
     if (m_bZMetadataEnabled)
     {
@@ -261,7 +262,15 @@ void ZarrSharedResource::DeleteZMetadataItem(const std::string &osFilename)
         m_bZMetadataModified = true;
         const char *pszKey =
             osNormalizedFilename.c_str() + m_osRootDirectoryName.size() + 1;
-        m_oObj["metadata"].DeleteNoSplitName(pszKey);
+
+        auto oMetadata = m_oObj["metadata"];
+        for (auto &item : oMetadata.GetChildren())
+        {
+            if (STARTS_WITH(item.GetName().c_str(), pszKey))
+            {
+                oMetadata.DeleteNoSplitName(item.GetName());
+            }
+        }
     }
 }
 

--- a/frmts/zarr/zarr_v2_array.cpp
+++ b/frmts/zarr/zarr_v2_array.cpp
@@ -94,6 +94,9 @@ ZarrV2Array::~ZarrV2Array()
 
 void ZarrV2Array::Flush()
 {
+    if (!m_bValid)
+        return;
+
     ZarrV2Array::FlushDirtyTile();
 
     if (m_bDefinitionModified)

--- a/frmts/zarr/zarr_v2_group.cpp
+++ b/frmts/zarr/zarr_v2_group.cpp
@@ -56,7 +56,7 @@ ZarrV2Group::Create(const std::shared_ptr<ZarrSharedResource> &poSharedResource,
 
 ZarrV2Group::~ZarrV2Group()
 {
-    if (m_oAttrGroup.IsModified())
+    if (m_bValid && m_oAttrGroup.IsModified())
     {
         CPLJSONDocument oDoc;
         oDoc.SetRoot(m_oAttrGroup.Serialize());
@@ -122,6 +122,9 @@ void ZarrV2Group::ExploreDirectory() const
 std::shared_ptr<ZarrArray> ZarrV2Group::OpenZarrArray(const std::string &osName,
                                                       CSLConstList) const
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     auto oIter = m_oMapMDArrays.find(osName);
     if (oIter != m_oMapMDArrays.end())
         return oIter->second;
@@ -155,6 +158,9 @@ std::shared_ptr<ZarrArray> ZarrV2Group::OpenZarrArray(const std::string &osName,
 std::shared_ptr<ZarrGroupBase>
 ZarrV2Group::OpenZarrGroup(const std::string &osName, CSLConstList) const
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     auto oIter = m_oMapGroups.find(osName);
     if (oIter != m_oMapGroups.end())
         return oIter->second;
@@ -583,6 +589,9 @@ std::shared_ptr<GDALGroup>
 ZarrV2Group::CreateGroup(const std::string &osName,
                          CSLConstList /* papszOptions */)
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     if (!m_bUpdatable)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
@@ -826,6 +835,9 @@ std::shared_ptr<GDALMDArray> ZarrV2Group::CreateMDArray(
     const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
     const GDALExtendedDataType &oDataType, CSLConstList papszOptions)
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     if (!m_bUpdatable)
     {
         CPLError(CE_Failure, CPLE_NotSupported,

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -90,6 +90,9 @@ ZarrV3Array::~ZarrV3Array()
 
 void ZarrV3Array::Flush()
 {
+    if (!m_bValid)
+        return;
+
     ZarrV3Array::FlushDirtyTile();
 
     if (!m_aoDims.empty())

--- a/frmts/zarr/zarr_v3_group.cpp
+++ b/frmts/zarr/zarr_v3_group.cpp
@@ -56,6 +56,9 @@ ZarrV3Group::Create(const std::shared_ptr<ZarrSharedResource> &poSharedResource,
 std::shared_ptr<ZarrArray> ZarrV3Group::OpenZarrArray(const std::string &osName,
                                                       CSLConstList) const
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     auto oIter = m_oMapMDArrays.find(osName);
     if (oIter != m_oMapMDArrays.end())
         return oIter->second;
@@ -196,7 +199,7 @@ ZarrV3Group::ZarrV3Group(
 
 ZarrV3Group::~ZarrV3Group()
 {
-    if (m_oAttrGroup.IsModified())
+    if (m_bValid && m_oAttrGroup.IsModified())
     {
         CPLJSONDocument oDoc;
         auto oRoot = oDoc.GetRoot();
@@ -216,6 +219,9 @@ ZarrV3Group::~ZarrV3Group()
 std::shared_ptr<ZarrGroupBase>
 ZarrV3Group::OpenZarrGroup(const std::string &osName, CSLConstList) const
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     auto oIter = m_oMapGroups.find(osName);
     if (oIter != m_oMapGroups.end())
         return oIter->second;
@@ -326,6 +332,9 @@ std::shared_ptr<GDALGroup>
 ZarrV3Group::CreateGroup(const std::string &osName,
                          CSLConstList /* papszOptions */)
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     if (!m_bUpdatable)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
@@ -490,6 +499,9 @@ std::shared_ptr<GDALMDArray> ZarrV3Group::CreateMDArray(
     const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
     const GDALExtendedDataType &oDataType, CSLConstList papszOptions)
 {
+    if (!CheckValidAndErrorOutIfNot())
+        return nullptr;
+
     if (!m_bUpdatable)
     {
         CPLError(CE_Failure, CPLE_NotSupported,

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -2120,6 +2120,8 @@ CSLConstList CPL_DLL GDALGroupGetStructuralInfo(GDALGroupH hGroup);
 GDALGroupH CPL_DLL
 GDALGroupCreateGroup(GDALGroupH hGroup, const char *pszSubGroupName,
                      CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
+bool CPL_DLL GDALGroupDeleteGroup(GDALGroupH hGroup, const char *pszName,
+                                  CSLConstList papszOptions);
 GDALDimensionH CPL_DLL GDALGroupCreateDimension(
     GDALGroupH hGroup, const char *pszName, const char *pszType,
     const char *pszDirection, GUInt64 nSize,
@@ -2128,10 +2130,14 @@ GDALMDArrayH CPL_DLL GDALGroupCreateMDArray(
     GDALGroupH hGroup, const char *pszName, size_t nDimensions,
     GDALDimensionH *pahDimensions, GDALExtendedDataTypeH hEDT,
     CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
+bool CPL_DLL GDALGroupDeleteMDArray(GDALGroupH hGroup, const char *pszName,
+                                    CSLConstList papszOptions);
 GDALAttributeH CPL_DLL GDALGroupCreateAttribute(
     GDALGroupH hGroup, const char *pszName, size_t nDimensions,
     const GUInt64 *panDimensions, GDALExtendedDataTypeH hEDT,
     CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
+bool CPL_DLL GDALGroupDeleteAttribute(GDALGroupH hGroup, const char *pszName,
+                                      CSLConstList papszOptions);
 bool CPL_DLL GDALGroupRename(GDALGroupH hGroup, const char *pszNewName);
 
 void CPL_DLL GDALMDArrayRelease(GDALMDArrayH hMDArray);
@@ -2173,6 +2179,9 @@ GDALAttributeH CPL_DLL GDALMDArrayCreateAttribute(
     GDALMDArrayH hArray, const char *pszName, size_t nDimensions,
     const GUInt64 *panDimensions, GDALExtendedDataTypeH hEDT,
     CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
+bool CPL_DLL GDALMDArrayDeleteAttribute(GDALMDArrayH hArray,
+                                        const char *pszName,
+                                        CSLConstList papszOptions);
 bool CPL_DLL GDALMDArrayResize(GDALMDArrayH hArray,
                                const GUInt64 *panNewDimSizes,
                                CSLConstList papszOptions);

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -193,6 +193,11 @@ public:
     return GDALGroupCreateGroup(self, name, options);
   }
 
+  CPLErr DeleteGroup( const char *name,
+                            char **options = 0 ) {
+    return GDALGroupDeleteGroup(self, name, options) ? CE_None : CE_Failure;
+  }
+
 %newobject CreateDimension;
   GDALDimensionHS *CreateDimension( const char *name,
                                     const char* type,
@@ -218,6 +223,11 @@ public:
 %clear (int nDimensions, GDALDimensionHS **dimensions);
 #endif
 
+  CPLErr DeleteMDArray( const char *name,
+                            char **options = 0 ) {
+    return GDALGroupDeleteMDArray(self, name, options) ? CE_None : CE_Failure;
+  }
+
 %newobject CreateAttribute;
 %apply (int nList, GUIntBig* pList) {(int nDimensions, GUIntBig *dimensions)};
   GDALAttributeHS *CreateAttribute( const char *name,
@@ -229,6 +239,11 @@ public:
     return GDALGroupCreateAttribute(self, name, nDimensions,
                                     (const GUInt64*)dimensions,
                                     data_type, options);
+  }
+
+  CPLErr DeleteAttribute( const char *name,
+                            char **options = 0 ) {
+    return GDALGroupDeleteAttribute(self, name, options) ? CE_None : CE_Failure;
   }
 
   CPLErr Rename( const char* newName ) {
@@ -849,6 +864,11 @@ public:
     return GDALMDArrayCreateAttribute(self, name, nDimensions,
                                     (const GUInt64*)dimensions,
                                     data_type, options);
+  }
+
+  CPLErr DeleteAttribute( const char *name,
+                            char **options = 0 ) {
+    return GDALMDArrayDeleteAttribute(self, name, options) ? CE_None : CE_Failure;
   }
 
 #if defined(SWIGPYTHON)

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1185,6 +1185,26 @@ def ReleaseResultSet(self, sql_lyr):
 %}
 }
 
+%extend GDALGroupHS {
+
+%feature("shadow") GetGroupNames %{
+def GetGroupNames(self, options = []) -> "list[str]":
+    ret = $action(self, options)
+    if ret is None:
+        ret = []
+    return ret
+%}
+
+%feature("shadow") GetMDArrayNames %{
+def GetMDArrayNames(self, options = []) -> "list[str]":
+    ret = $action(self, options)
+    if ret is None:
+        ret = []
+    return ret
+%}
+
+}
+
 %extend GDALMDArrayHS {
 %pythoncode %{
   def Read(self,


### PR DESCRIPTION
- Python bindings: make gdal.Group.GetGroupNames() and GetMDArrayNames() return an empty list instead of None
- Multidim API: add DeleteGroup(), DeleteMDArray(), DeleteAttribute() methods in C/C++/SWIG API
- MEM multidim: implement DeleteGroup(), DeleteMDArray(), DeleteAttribute()
- netCDF multidim: implement DeleteAttribute()
- Zarr multidim: implement DeleteGroup(), DeleteMDArray(), DeleteAttribute()
