### PR TITLE
COG: only update mode if the IGNORE_COG_LAYOUT_BREAK=YES open option is specified (fixes #7735)

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -749,6 +749,7 @@ def test_cog_overviews_co():
 # Test editing and invalidating a COG file
 
 
+@gdaltest.enable_exceptions()
 def test_cog_invalidation_by_data_change():
 
     filename = "/vsimem/cog.tif"
@@ -758,7 +759,15 @@ def test_cog_invalidation_by_data_change():
     )
     ds = None
 
-    ds = gdal.Open(filename, gdal.GA_Update)
+    with pytest.raises(
+        Exception,
+        match="IGNORE_COG_LAYOUT_BREAK",
+    ):
+        gdal.Open(filename, gdal.GA_Update)
+
+    ds = gdal.OpenEx(
+        filename, gdal.GA_Update, open_options=["IGNORE_COG_LAYOUT_BREAK=YES"]
+    )
     assert ds.GetMetadataItem("LAYOUT", "IMAGE_STRUCTURE") == "COG"
     src_ds = gdal.Open("data/byte.tif")
     data = src_ds.ReadRaster()
@@ -794,7 +803,9 @@ def test_cog_invalidation_by_metadata_change():
     )
     ds = None
 
-    ds = gdal.Open(filename, gdal.GA_Update)
+    ds = gdal.OpenEx(
+        filename, gdal.GA_Update, open_options=["IGNORE_COG_LAYOUT_BREAK=YES"]
+    )
     ds.GetRasterBand(1).ComputeStatistics(False)
     ds = None
 

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -4100,7 +4100,9 @@ def test_tiff_write_ifd_offsets():
     ds = None
 
     # Test rewriting but without changing strile size
-    ds = gdal.Open(filename, gdal.GA_Update)
+    ds = gdal.OpenEx(
+        filename, gdal.GA_Update, open_options=["IGNORE_COG_LAYOUT_BREAK=YES"]
+    )
     ds.GetRasterBand(1).Fill(0)
     ds = None
     assert gdal.GetLastErrorMsg() == ""
@@ -4110,7 +4112,9 @@ def test_tiff_write_ifd_offsets():
     assert "KNOWN_INCOMPATIBLE_EDITION=NO\n " in data
 
     # Test rewriting with changing strile size
-    ds = gdal.Open(filename, gdal.GA_Update)
+    ds = gdal.OpenEx(
+        filename, gdal.GA_Update, open_options=["IGNORE_COG_LAYOUT_BREAK=YES"]
+    )
     ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, "x")
     ds = None
     assert gdal.GetLastErrorMsg() != ""

--- a/doc/source/drivers/raster/cog.rst
+++ b/doc/source/drivers/raster/cog.rst
@@ -314,7 +314,7 @@ Update
 ------
 
 Updating a COG file generally breaks part of the optimizations, but still
-produce a valid GeoTIFF file. Starting with GDAL 3.8, to avoid undesired loss
+produces a valid GeoTIFF file. Starting with GDAL 3.8, to avoid undesired loss
 of the COG characteristics, opening such a file in update mode will be rejected,
 unless the IGNORE_COG_LAYOUT_BREAK open option is also explicitly set to YES.
 

--- a/doc/source/drivers/raster/cog.rst
+++ b/doc/source/drivers/raster/cog.rst
@@ -310,6 +310,17 @@ Reprojection related creation options
 - **ADD_ALPHA=YES/NO**: Whether an alpha band is added in case of reprojection.
   Defaults to YES.
 
+Update
+------
+
+Updating a COG file generally breaks part of the optimizations, but still
+produce a valid GeoTIFF file. Starting with GDAL 3.8, to avoid undesired loss
+of the COG characteristics, opening such a file in update mode will be rejected,
+unless the IGNORE_COG_LAYOUT_BREAK open option is also explicitly set to YES.
+
+Note that a subset of operations are possible when opening a COG file in
+read-only mode, like metadata edition (including statistics storage), that will
+be stored in a auxiliary .aux.xml side-car file.
 
 File format details
 -------------------

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -324,6 +324,15 @@ Open options
    blocks never written and save space; however, most non-GDAL packages
    cannot read such files. The default is FALSE.
 
+-  **IGNORE_COG_LAYOUT_BREAK=YES/NO** (GDAL >= 3.8): Updating a COG
+   (Cloud Optimized GeoTIFF) file generally breaks part of the optimizations,
+   but still produces a valid GeoTIFF file.
+   Starting with GDAL 3.8, to avoid undesired loss of the COG characteristics,
+   opening such a file in update mode will be rejected, unless this option is
+   also set to YES (default is NO).
+   This option has only effect on COG files and when opening in update mode,
+   and is ignored on regular (Geo)TIFF files.
+
 Creation Issues
 ---------------
 

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -1393,6 +1393,9 @@ void GDALRegister_GTiff()
         "default='PAM,INTERNAL,TABFILE,WORLDFILE,XML'/>"
         "   <Option name='SPARSE_OK' type='boolean' description='Should empty "
         "blocks be omitted on disk?' default='FALSE'/>"
+        "   <Option name='IGNORE_COG_LAYOUT_BREAK' type='boolean' "
+        "description='Allow update mode on files with COG structure' "
+        "default='FALSE'/>"
         "</OpenOptionList>");
     poDriver->SetMetadataItem(GDAL_DMD_SUBDATASETS, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -3785,6 +3785,22 @@ GDALDataset *GTiffDataset::Open(GDALOpenInfo *poOpenInfo)
                  poDS->m_bLeaderSizeAsUInt4 &&
                  poDS->m_bTrailerRepeatedLast4BytesRepeated)
         {
+            if (poOpenInfo->eAccess == GA_Update &&
+                !CPLTestBool(CSLFetchNameValueDef(poOpenInfo->papszOpenOptions,
+                                                  "IGNORE_COG_LAYOUT_BREAK",
+                                                  "FALSE")))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "File %s has C(loud) O(ptimized) G(eoTIFF) layout. "
+                         "Updating it will generally result in loosing part of "
+                         "the optimizations (but will still produce a valid "
+                         "GeoTIFF file). If this is acceptable, open the file "
+                         "with the IGNORE_COG_LAYOUT_BREAK open option set "
+                         "to YES.",
+                         pszFilename);
+                delete poDS;
+                return nullptr;
+            }
             poDS->m_oGTiffMDMD.SetMetadataItem("LAYOUT", "COG",
                                                "IMAGE_STRUCTURE");
         }


### PR DESCRIPTION
Updating a COG file generally breaks part of the optimizations, but still produce a valid GeoTIFF file. Starting with GDAL 3.8, to avoid undesired loss of the COG characteristics, opening such a file in update mode will be rejected, unless the IGNORE_COG_LAYOUT_BREAK open option is also explicitly set to YES.

Previously, we already got a warning that optimizations were broken, but this was after the fact, which might be frustrating for the user that needs to regenerate the COG.

CC @vincentsarago good idea ? bad idea ?