### PR TITLE
[Backport release/3.7] Fix parsing of floating-point numbers in JSON with internal libjson-c on Windows

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -63,6 +63,17 @@ jobs:
       - name: Detect missing includes
         run: ./scripts/detect_missing_include.sh
 
+      # Helps detecting updates of internal libjson-c where replacement
+      # of strtod() -> CPLStrtod() is missing. The later function is not
+      # locale sensitive. An alternative would be to make sure that HAVE_USELOCALE
+      # or HAVE_SETLOCALE are passed on Windows, but avoiding to mess with
+      # locale seems to be a better option
+      - name: Detect invalid use of atof() or strtod() in internal libjson
+        run: |
+          grep -e "CPLStrtod(" ../ogr/ogrsf_frmts/geojson/libjson/*.c >/dev/null && echo "CPLStrtod() found as expected"
+          if grep -e "strtod(" ogr/ogrsf_frmts/geojson/libjson/*.c; then echo "Unexpected use of strtod(). Use CPLStrtod() instead"; /bin/false; fi
+          if grep -e "atof(" ogr/ogrsf_frmts/geojson/libjson/*.c; then echo "Unexpected use of atof()."; /bin/false; fi
+
       - name: Shellcheck
         run: shellcheck -e SC2086,SC2046,SC2164,SC2054 $(find . -name '*.sh' -a -not -name ltmain.sh -a -not -wholename "./autotest/*" -a -not -wholename "./.github/*")
 

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4343,3 +4343,22 @@ def test_ogr_geojson_field_types():
     assert '{ "prop0": { "a": "b" } }' in data
 
     gdal.Unlink(filename)
+
+
+###############################################################################
+# Test openening with non C locale
+
+
+def test_ogr_geojson_open_with_non_C_locale():
+
+    import locale
+
+    original_locale = locale.setlocale(locale.LC_ALL)
+    try:
+        locale.setlocale(locale.LC_ALL, "")
+        if locale.localeconv()["decimal_point"] == ".":
+            pytest.skip("cannot test, as decimal_point is dot")
+
+        test_ogr_geojson_2()
+    finally:
+        locale.setlocale(locale.LC_ALL, original_locale)

--- a/ogr/ogrsf_frmts/geojson/libjson/GDAL_README.txt
+++ b/ogr/ogrsf_frmts/geojson/libjson/GDAL_README.txt
@@ -1,0 +1,10 @@
+Upgrading internal libjson is a non trivial exercice as we have a number of
+patches.
+Look at
+git diff 5fee60ed3e64794f0a58bd7d4e3f6a072acd5fcf..HEAD ogr/ogrsf_frmts/geojson/libjson/
+for changes that have been applied on top of libjson-c 0.15
+
+A point of caution is related to libjson using uselocale()/setlocale() to force
+the C locale to be able to use strtod().
+On Windows, the related macros to signal the availability of those functions
+are not set (at least currently), so we replace strtod() by CPLStrtod().

--- a/ogr/ogrsf_frmts/geojson/libjson/json_object.c
+++ b/ogr/ogrsf_frmts/geojson/libjson/json_object.c
@@ -37,6 +37,8 @@
 #include "snprintf_compat.h"
 #include "strdup_compat.h"
 
+#include "cpl_string.h"
+
 #if SIZEOF_LONG_LONG != SIZEOF_INT64_T
 #error "The long long type isn't 64-bits"
 #endif
@@ -1192,7 +1194,7 @@ double json_object_get_double(const struct json_object *jso)
 	case json_type_boolean: return JC_BOOL_C(jso)->c_boolean;
 	case json_type_string:
 		errno = 0;
-		cdouble = strtod(get_string_component(jso), &errPtr);
+		cdouble = CPLStrtod(get_string_component(jso), &errPtr);
 
 		/* if conversion stopped at the first character, return 0.0 */
 		if (errPtr == get_string_component(jso))

--- a/ogr/ogrsf_frmts/geojson/libjson/json_tokener.c
+++ b/ogr/ogrsf_frmts/geojson/libjson/json_tokener.c
@@ -44,6 +44,8 @@
 #include <strings.h>
 #endif /* HAVE_STRINGS_H */
 
+#include "cpl_string.h"
+
 #define jt_hexdigit(x) (((x) <= '9') ? (x) - '0' : ((x)&7) + 9)
 
 #if !HAVE_STRNCASECMP && defined(_MSC_VER)
@@ -1261,7 +1263,7 @@ size_t json_tokener_get_parse_end(struct json_tokener *tok)
 static int json_tokener_parse_double(const char *buf, int len, double *retval)
 {
 	char *end;
-	*retval = strtod(buf, &end);
+	*retval = CPLStrtod(buf, &end);
 	if (buf + len == end)
 		return 0; // It worked
 	return 1;

--- a/ogr/ogrsf_frmts/geojson/libjson/json_util.c
+++ b/ogr/ogrsf_frmts/geojson/libjson/json_util.c
@@ -58,6 +58,8 @@
 #include "json_util.h"
 #include "printbuf.h"
 
+#include "cpl_string.h"
+
 static int _json_object_to_fd(int fd, struct json_object *obj, int flags, const char *filename);
 
 static char _last_err[256] = "";
@@ -227,7 +229,7 @@ int json_object_to_file(const char *filename, struct json_object *obj)
 int json_parse_double(const char *buf, double *retval)
 {
 	char *end;
-	*retval = strtod(buf, &end);
+	*retval = CPLStrtod(buf, &end);
 	return end == buf ? 1 : 0;
 }
 

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -46,6 +46,10 @@ for f in $FILES; do
 	  continue
 	  ;;
 
+	*ogr/ogrsf_frmts/geojson/libjson*)
+	  continue
+	  ;;
+
 	*swig/*)
 	  continue
 	  ;;


### PR DESCRIPTION
Backport #7725
 **Authored by:** @rouault