### PR TITLE
Add missing limits include

### DIFF
--- a/gdal/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
+++ b/gdal/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <limits> // for  std::numeric_limits
 
 #if ((defined(__sun__) || defined(__FreeBSD__)) && __GNUC__ == 4 && __GNUC_MINOR__ == 8) || defined(__ANDROID__)
 // gcc 4.8 on Solaris 11.3 or FreeBSD 11 doesn't have std::string


### PR DESCRIPTION
Fixes build of the 3.1 branch on Ubuntu 22.04.2 LTS
with gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
