### PR TITLE
[Perf improvement] GTiff: avoid using block cache when writing whole blocks

### DIFF
--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -444,7 +444,7 @@ def test_tiff_ovr_10(both_endian):
 
     assert src_ds is not None, "Failed to open test dataset."
 
-    ds = gdaltest.tiff_drv.CreateCopy(
+    ds = gdal.GetDriverByName("GTiff").CreateCopy(
         "tmp/ovr10.tif", src_ds, options=["COMPRESS=JPEG", "PHOTOMETRIC=YCBCR"]
     )
     src_ds = None
@@ -463,9 +463,8 @@ def test_tiff_ovr_10(both_endian):
     ds = None
 
     assert cs in (
-        5562,
-        5635,
-        5601,  # libjpeg 9e
+        5879,
+        6050,  # libjpeg 9e
     )
 
 
@@ -942,7 +941,7 @@ def test_tiff_ovr_25(both_endian):
 
 def test_tiff_ovr_26(both_endian):
 
-    ds = gdaltest.tiff_drv.Create("tmp/ovr26.tif", 100, 100, 1)
+    ds = gdal.GetDriverByName("GTiff").Create("tmp/ovr26.tif", 100, 100, 1)
     ds.GetRasterBand(1).Fill(1)
     ds.GetRasterBand(1).FlushCache()
     ds.BuildOverviews("NEAR", overviewlist=[2])

--- a/frmts/gtiff/gtiffrasterband_read.cpp
+++ b/frmts/gtiff/gtiffrasterband_read.cpp
@@ -1603,6 +1603,11 @@ const char *GTiffRasterBand::GetMetadataItem(const char *pszName,
             return CPLSPrintf(CPL_FRMT_GUIB, static_cast<GUIntBig>(nByteCount));
         }
     }
+    else if (pszDomain != nullptr && EQUAL(pszDomain, "_DEBUG_"))
+    {
+        if (EQUAL(pszName, "HAS_BLOCK_CACHE"))
+            return HasBlockCache() ? "1" : "0";
+    }
 
     const char *pszRet = m_oGTiffMDMD.GetMetadataItem(pszName, pszDomain);
 

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1353,6 +1353,11 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
 
     void AddBlockToFreeList(GDALRasterBlock *);
 
+    bool HasBlockCache() const
+    {
+        return poBandBlockCache != nullptr;
+    }
+
     bool HasDirtyBlocks() const
     {
         return poBandBlockCache && poBandBlockCache->HasDirtyBlocks();

--- a/perftests/gtiff_multi_ds_parallel_write.py
+++ b/perftests/gtiff_multi_ds_parallel_write.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023 Even Rouault
+
+# This benchmark utility helps assessing the efficiency of the bypass
+# of the block cache when writing GeoTIFF datasets.
+
+import array
+import sys
+from threading import Thread
+
+from osgeo import gdal
+
+gdal.UseExceptions()
+
+
+def Usage():
+    print("gtiff_multi_ds_parallel_write.py [--nbands VAL] [--without-optim]")
+    print("                                 [--compress NONE/ZSTD/...]")
+    print("                                 [--buffer-interleave PIXEL/BAND]")
+    sys.exit(1)
+
+
+num_threads = gdal.GetNumCPUs()
+nbands = 1
+with_optim = True
+compression = "ZSTD"
+buffer_pixel_interleaved = True
+width = 2048
+height = 2048
+
+# Parse arguments
+i = 1
+while i < len(sys.argv):
+    if sys.argv[i] == "--nbands":
+        i += 1
+        nbands = int(sys.argv[i])
+    elif sys.argv[i] == "--compress":
+        i += 1
+        compression = sys.argv[i]
+    elif sys.argv[i] == "--buffer-interleave":
+        i += 1
+        buffer_pixel_interleaved = sys.argv[i] == "PIXEL"
+    elif sys.argv[i] == "--without-optim":
+        with_optim = False
+    else:
+        Usage()
+    i += 1
+
+nloops = 1000 // nbands
+data = array.array("B", [i % 255 for i in range(nbands * width * height)])
+
+gdal.SetCacheMax(width * height * nbands * num_threads)
+
+
+def thread_function(num):
+    filename = "/vsimem/tmp%d.tif" % num
+    drv = gdal.GetDriverByName("GTiff")
+    options = ["TILED=YES", "COMPRESS=" + compression]
+    for i in range(nloops):
+        ds = drv.Create(filename, width, height, nbands, options=options)
+        if not with_optim:
+            # Calling ReadRaster() disables the cache bypass write optimization
+            ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
+        if nbands > 1:
+            if buffer_pixel_interleaved:
+                # Write pixel-interleaved buffer for maximum efficiency
+                ds.WriteRaster(
+                    0,
+                    0,
+                    width,
+                    height,
+                    data,
+                    buf_pixel_space=nbands,
+                    buf_line_space=width * nbands,
+                    buf_band_space=1,
+                )
+            else:
+                ds.WriteRaster(0, 0, width, height, data)
+        else:
+            ds.GetRasterBand(1).WriteRaster(0, 0, width, height, data)
+
+
+# Spawn num_threads running thread_function
+threads_array = []
+
+for i in range(num_threads):
+    t = Thread(target=thread_function, args=[i])
+    t.start()
+    threads_array.append(t)
+
+for t in threads_array:
+    t.join()

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -52,7 +52,6 @@ set(CPL_SOURCES
     cplstring.cpp
     cpl_vsisimple.cpp
     cpl_vsil.cpp
-    cpl_vsi_mem.cpp
     cpl_http.cpp
     cpl_hash_set.cpp
     cplkeywordparser.cpp
@@ -131,6 +130,19 @@ target_compile_definitions(cpl PRIVATE INST_DATA="${INST_DATA_PATH}")
 
 if(CMAKE_INSTALL_FULL_SYSCONFDIR)
     target_compile_definitions(cpl PRIVATE SYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
+endif()
+
+# To enable conditional use of std::shared_mutex in cpl_vsi_mem.cpp
+add_library(cpl_vsi_mem OBJECT cpl_vsi_mem.cpp)
+target_sources(${GDAL_LIB_TARGET_NAME} PRIVATE $<TARGET_OBJECTS:cpl_vsi_mem>)
+target_compile_options(cpl_vsi_mem PRIVATE ${GDAL_CXX_WARNING_FLAGS} ${WFLAG_OLD_STYLE_CAST} ${WFLAG_EFFCXX})
+set_property(TARGET cpl_vsi_mem PROPERTY POSITION_INDEPENDENT_CODE ${GDAL_OBJECT_LIBRARIES_POSITION_INDEPENDENT_CODE})
+target_include_directories(cpl_vsi_mem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++17" COMPILER_SUPPORTS_CXX17)
+if(COMPILER_SUPPORTS_CXX17)
+    target_compile_features(cpl_vsi_mem PRIVATE cxx_std_17)
 endif()
 
 if (WIN32)

--- a/port/cpl_vsi_mem.cpp
+++ b/port/cpl_vsi_mem.cpp
@@ -48,6 +48,20 @@
 #include <utility>
 #include <memory>
 
+#include <mutex>
+// c++17 or VS2017
+#if __cplusplus >= 201703L || _MSC_VER >= 1910
+#include <shared_mutex>
+#define CPL_SHARED_MUTEX_TYPE std::shared_mutex
+#define CPL_SHARED_LOCK std::shared_lock<std::shared_mutex>
+#define CPL_EXCLUSIVE_LOCK std::unique_lock<std::shared_mutex>
+#else
+// Poor-man implementation of std::shared_mutex with an exclusive mutex
+#define CPL_SHARED_MUTEX_TYPE std::mutex
+#define CPL_SHARED_LOCK std::lock_guard<std::mutex>
+#define CPL_EXCLUSIVE_LOCK std::lock_guard<std::mutex>
+#endif
+
 #include "cpl_atomic_ops.h"
 #include "cpl_conv.h"
 #include "cpl_error.h"
@@ -65,10 +79,7 @@
 ** want to create and read different files at the same time and so might
 ** collide access oFileList without the mutex.
 **
-** VSIMemFile: In theory we could allow different threads to update the
-** the same memory file, but for simplicity we restrict to single writer,
-** multiple reader as an expectation on the application code (not enforced
-** here), which means we don't need to do any protection of this class.
+** VSIMemFile: A mutex protects accesses to the file
 **
 ** VSIMemHandle: This is essentially a "current location" representing
 ** on accessor to a file, and is inherently intended only to be used in
@@ -77,10 +88,8 @@
 ** In General:
 **
 ** Multiple threads accessing the memory filesystem are ok as long as
-**  1) A given VSIMemHandle (i.e. FILE * at app level) isn't used by multiple
-**     threads at once.
-**  2) A given memory file isn't accessed by more than one thread unless
-**     all threads are just reading.
+** a given VSIMemHandle (i.e. FILE * at app level) isn't used by multiple
+** threads at once.
 */
 
 /************************************************************************/
@@ -105,6 +114,7 @@ class VSIMemFile
     vsi_l_offset nMaxLength = GUINTBIG_MAX;
 
     time_t mTime = 0;
+    CPL_SHARED_MUTEX_TYPE m_oMutex{};
 
     VSIMemFile();
     virtual ~VSIMemFile();
@@ -223,6 +233,7 @@ VSIMemFile::~VSIMemFile()
 /*                             SetLength()                              */
 /************************************************************************/
 
+// Must be called under exclusive lock
 bool VSIMemFile::SetLength(vsi_l_offset nNewLength)
 
 {
@@ -327,6 +338,8 @@ int VSIMemHandle::Close()
 int VSIMemHandle::Seek(vsi_l_offset nOffset, int nWhence)
 
 {
+    CPL_SHARED_LOCK oLock(poFile->m_oMutex);
+
     bExtendFileAtNextWrite = false;
     if (nWhence == SEEK_CUR)
     {
@@ -380,6 +393,8 @@ vsi_l_offset VSIMemHandle::Tell()
 size_t VSIMemHandle::Read(void *pBuffer, size_t nSize, size_t nCount)
 
 {
+    CPL_SHARED_LOCK oLock(poFile->m_oMutex);
+
     size_t nBytesToRead = nSize * nCount;
     if (nBytesToRead == 0)
         return 0;
@@ -417,6 +432,8 @@ size_t VSIMemHandle::Read(void *pBuffer, size_t nSize, size_t nCount)
 size_t VSIMemHandle::PRead(void *pBuffer, size_t nSize,
                            vsi_l_offset nOffset) const
 {
+    CPL_SHARED_LOCK oLock(poFile->m_oMutex);
+
     if (nOffset < poFile->nLength)
     {
         const size_t nToCopy = static_cast<size_t>(
@@ -436,6 +453,8 @@ size_t VSIMemHandle::PRead(void *pBuffer, size_t nSize,
 size_t VSIMemHandle::Write(const void *pBuffer, size_t nSize, size_t nCount)
 
 {
+    CPL_EXCLUSIVE_LOCK oLock(poFile->m_oMutex);
+
     if (!bUpdate)
     {
         errno = EACCES;
@@ -496,6 +515,8 @@ int VSIMemHandle::Truncate(vsi_l_offset nNewSize)
     }
 
     bExtendFileAtNextWrite = false;
+
+    CPL_EXCLUSIVE_LOCK oLock(poFile->m_oMutex);
     if (poFile->SetLength(nNewSize))
         return 0;
 
@@ -579,6 +600,7 @@ VSIVirtualHandle *VSIMemFilesystemHandler::Open(const char *pszFilename,
     // Overwrite
     else if (strstr(pszAccess, "w"))
     {
+        CPL_EXCLUSIVE_LOCK oLock(poFile->m_oMutex);
         poFile->SetLength(0);
         poFile->nMaxLength = nMaxLength;
     }
@@ -605,7 +627,10 @@ VSIVirtualHandle *VSIMemFilesystemHandler::Open(const char *pszFilename,
              pszFilename, static_cast<int>(poFile.use_count()));
 #endif
     if (strstr(pszAccess, "a"))
+    {
+        CPL_SHARED_LOCK oLock(poFile->m_oMutex);
         poHandle->m_nOffset = poFile->nLength;
+    }
 
     return poHandle;
 }
@@ -631,16 +656,18 @@ int VSIMemFilesystemHandler::Stat(const char *pszFilename,
         return 0;
     }
 
-    if (oFileList.find(osFilename) == oFileList.end())
+    auto oIter = oFileList.find(osFilename);
+    if (oIter == oFileList.end())
     {
         errno = ENOENT;
         return -1;
     }
 
-    std::shared_ptr<VSIMemFile> poFile = oFileList[osFilename];
+    std::shared_ptr<VSIMemFile> poFile = oIter->second;
 
     memset(pStatBuf, 0, sizeof(VSIStatBufL));
 
+    CPL_SHARED_LOCK oLock(poFile->m_oMutex);
     if (poFile->bIsDirectory)
     {
         pStatBuf->st_size = 0;
@@ -676,18 +703,19 @@ int VSIMemFilesystemHandler::Unlink_unlocked(const char *pszFilename)
 {
     const CPLString osFilename = NormalizePath(pszFilename);
 
-    if (oFileList.find(osFilename) == oFileList.end())
+    auto oIter = oFileList.find(osFilename);
+    if (oIter == oFileList.end())
     {
         errno = ENOENT;
         return -1;
     }
 
 #ifdef DEBUG_VERBOSE
-    std::shared_ptr<VSIMemFile> poFile = oFileList[osFilename];
+    std::shared_ptr<VSIMemFile> poFile = oIter->second;
     CPLDebug("VSIMEM", "Unlink %s: ref_count=%d (before)", pszFilename,
              static_cast<int>(poFile.use_count()));
 #endif
-    oFileList.erase(oFileList.find(osFilename));
+    oFileList.erase(oIter);
 
     return 0;
 }


### PR DESCRIPTION
This avoids less contention on the block cache mutex and saves memory
copies, particular when writing dataset-level RasterIO() with a buffer
with data for all bands, and with a pixel interleaving.

The optimization triggers if the following conditions are met:
- (xsize, ysize) = (bufxsize, bufysize), ie no resampling
- origin (xoff, yoff) of buffer to write is aligned on a tile boundary
- end (xoff+xsize, yoff+ysize) of buffer is aligned on tile boundary or
  raster right/bottom
- only for bit depth = 8, 16, 32, 64 or 128
- the block cache for the bands to considered has not been initialized
  at all
- and for dataset level write with pixel interleaving, all bands are
  written at once.

The visible side effects of this optimization are hopefully few, but one
particular case exhibited by the test_tiff_ovr_10() case is when writing
with a lossy compression and re-reading the raster without closing it in
between. Previously if the raster was small enough to fit in the block
cache, re-reading it would get the original pixel values. With this
change, we now get the values after decompression.

Using the gtiff_multi_ds_parallel_write.py program to write 2048x2048
tiled datasets in parallel from 12 threads, ZSTD compression

$ time python ../perftests/gtiff_multi_ds_parallel_write.py --nbands 1 --without-optim
real    0m17,768s
user    2m55,418s
sys     0m1,174s

$ time python ../perftests/gtiff_multi_ds_parallel_write.py --nbands 1
real    0m9,149s
user    1m34,882s
sys     0m0,597s

$ time python ../perftests/gtiff_multi_ds_parallel_write.py --nbands 3 --buffer-interleave BAND --without-optim
real    0m16,106s
user    2m42,623s
sys     0m0,834s

$ time python ../perftests/gtiff_multi_ds_parallel_write.py --nbands 3 --buffer-interleave BAND
real    0m9,013s
user    1m31,537s
sys     0m0,329s

$ time python ../perftests/gtiff_multi_ds_parallel_write.py --nbands 3 --buffer-interleave PIXEL --without-optim
real    0m41,574s
user    3m23,985s
sys     3m45,286s

$ time python ../perftests/gtiff_multi_ds_parallel_write.py --nbands 3 --buffer-interleave PIXEL
real    0m5,893s
user    0m56,796s
sys     0m0,402s

Helps for #4272
CC @tbonfort 