### PR TITLE
Revert "doc_build.yml: pin sphinx==6.0.1 to workround .…

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -48,12 +48,6 @@ jobs:
           ldconfig
           popd
 
-    - name: Pin sphinx version
-      # Avoid https://github.com/sphinx-doc/sphinx/issues/11163
-      shell: bash -l {0}
-      run: |
-          python3 -m pip install --user "sphinx==6.0.1"
-
     - name: Print versions
       shell: bash -l {0}
       run: |


### PR DESCRIPTION
…https://githubcom/sphinx-doc/sphinx/issues/11163 (fixes #7251)"

This reverts commit 0f871c5bbd1dab7274b18ca7d3d04188893822de.

sphinx 7.0.1 has been just released
