### PR TITLE
CSV: do not allow CREATE_CSVT=YES with /vsistdout/ (fixes #7699), and…

### DIFF
--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -363,8 +363,8 @@ Layer Creation options
 -  **WRITE_BOM**\ =YES/NO: Write a UTF-8 Byte
    Order Mark (BOM) at the start of the file. Default value : NO
 -  **GEOMETRY_NAME**\ =name (Starting with GDAL 2.1): Name of geometry
-   column. Only used if GEOMETRY=AS_WKT and CREATE_CSVT=YES. Defaults to
-   WKT
+   column. Only used if GEOMETRY=AS_WKT (and CREATE_CSVT=YES before GDAL 3.7.1).
+   Defaults to WKT
 -  **STRING_QUOTING**\ =IF_NEEDED/IF_AMBIGUOUS/ALWAYS (Starting with
    GDAL 2.3): whether to double-quote strings. IF_AMBIGUOUS means that
    string values that look like numbers will be quoted (it also implies

--- a/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -2014,9 +2014,7 @@ OGRErr OGRCSVLayer::WriteHeader()
             if (fpCSV)
             {
                 const char *pszColName =
-                    bCreateCSVT
-                        ? poFeatureDefn->GetGeomFieldDefn(0)->GetNameRef()
-                        : "WKT";
+                    poFeatureDefn->GetGeomFieldDefn(0)->GetNameRef();
                 bOK &= VSIFPrintfL(fpCSV, "%s", pszColName) >= 0;
             }
             if (fpCSVT)


### PR DESCRIPTION
… make it possible to use GEOMETRY_NAME with /vsistdout/ (fixes #7700)
