### PR TITLE
[Shapefile] SHPRestoreSHX: update SHX content length even if an error occurred

### DIFF
--- a/ogr/ogrsf_frmts/shape/shpopen.c
+++ b/ogr/ogrsf_frmts/shape/shpopen.c
@@ -855,6 +855,13 @@ int SHPAPI_CALL SHPRestoreSHX(const char *pszLayer, const char *pszAccess,
         {
             psHooks->Error("Error parsing .shp to restore .shx");
 
+            // Update SHX content size in the SHX header even if an error occurred
+            nRealSHXContentSize /= 2;  // Bytes counted -> WORDs
+            if (!bBigEndian)
+                SwapWord(4, &nRealSHXContentSize);
+            psHooks->FSeek(fpSHX, 24, 0);
+            psHooks->FWrite(&nRealSHXContentSize, 4, 1, fpSHX);
+
             psHooks->FClose(fpSHX);
             psHooks->FClose(fpSHP);
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Fixes SHPRestoreSHX in order to update the SHX content length in the SHX header even if an error occurred.

## What are related issues/pull requests?

See https://lists.osgeo.org/pipermail/gdal-dev/2023-May/057229.html.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
