### PR TITLE
gdal_calc.py: allow "none" or a float for --NoDataValue

### DIFF
--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -240,6 +240,9 @@ def test_gdal_calc_py_4(script_path):
     bnd_count = 3
     for i, checksum in zip(range(bnd_count), (29935, 13128, 59092)):
         check_file(out[1], checksum, 2, bnd_idx=i + 1)
+        # also check NoDataValue
+        ds = gdal.Open(out[1])
+        assert ds.GetRasterBand(i + 1).GetNoDataValue() == 999
 
     # these values were not tested
     test_py_scripts.run_py_script(
@@ -252,6 +255,9 @@ def test_gdal_calc_py_4(script_path):
     bnd_count = 3
     for i, checksum in zip(range(bnd_count), (10025, 62785, 10621)):
         check_file(out[2], checksum, 3, bnd_idx=i + 1)
+        # also check NoDataValue
+        ds = gdal.Open(out[2])
+        assert ds.GetRasterBand(i + 1).GetNoDataValue() == 999
 
 
 def test_gdal_calc_py_5(script_path):
@@ -529,6 +535,25 @@ def test_gdal_calc_py_9(script_path):
         i,
     )
     i += 1
+
+
+def test_gdal_calc_py_10(script_path):
+    """test --NoDataValue=none"""
+
+    infile = get_input_file()
+    test_id, test_count = 10, 4
+    out = make_temp_filename_list(test_id, test_count)
+
+    test_py_scripts.run_py_script(
+        script_path,
+        "gdal_calc",
+        f"-A {infile} --A_band=1 --NoDataValue=none --calc=A "
+        f"--overwrite --outfile {out[0]}",
+    )
+
+    check_file(out[0], input_checksum[0])
+    ds = gdal.Open(out[0])
+    assert ds.GetRasterBand(1).GetNoDataValue() is None
 
 
 def test_gdal_calc_py_multiple_inputs_same_alpha(script_path):

--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -754,6 +754,16 @@ class GDALCalc(GDALScript):
             except argparse.ArgumentError:
                 pass
 
+    def float_or_none(self, NoDataValue: str) -> Union[float, str]:
+        if NoDataValue.lower() == "none":
+            return NoDataValue
+
+        try:
+            return float(NoDataValue)
+        except ValueError:
+            msg = f"Invalid float value for NoDataValue: {NoDataValue}"
+            raise argparse.ArgumentTypeError(msg)
+
     def get_parser(self, argv) -> GDALArgumentParser:
         parser = self.parser
         parser.add_argument(
@@ -781,7 +791,7 @@ class GDALCalc(GDALScript):
         parser.add_argument(
             "--NoDataValue",
             dest="NoDataValue",
-            type=float,
+            type=self.float_or_none,
             metavar="value",
             help="output nodata value (default datatype specific value)",
         )


### PR DESCRIPTION
## What does this PR do?

It allows specifying `--NoDataValue=none`, which was previously failing due to `type=float` in the `parser.add_argument` call.