### PR TITLE
MySQL: fix compliance issues with test_ogrsf

### DIFF
--- a/.github/workflows/ubuntu_18.04/test.sh
+++ b/.github/workflows/ubuntu_18.04/test.sh
@@ -20,9 +20,9 @@ AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} python3 -c 
 (cd autotest/gcore && AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} AZ_RESOURCE=mycontainer $PYTEST vsiaz_real_instance_manual.py)
 
 # MySQL 8
-(cd autotest/ogr && OGR_MYSQL_CONNECTION_STRING=mysql:test,user=root,password=passwd,port=33060,host=$IP $PYTEST ogr_mysql.py -k "not mysql_24")
+(cd autotest/ogr && OGR_MYSQL_CONNECTION_STRING=mysql:test,user=root,password=passwd,port=33060,host=$IP $PYTEST ogr_mysql.py)
 # MariaDB 10.3.9
-(cd autotest/ogr && OGR_MYSQL_CONNECTION_STRING=mysql:test,user=root,password=passwd,port=33061,host=$IP $PYTEST ogr_mysql.py -k "not mysql_24")
+(cd autotest/ogr && OGR_MYSQL_CONNECTION_STRING=mysql:test,user=root,password=passwd,port=33061,host=$IP $PYTEST ogr_mysql.py)
 
 # PostGIS tests
 (cd autotest/ogr && OGR_PG_CONNECTION_STRING="host=$IP port=25432 dbname=autotest user=docker password=docker" $PYTEST --capture=no -ra ogr_pg.py)

--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -734,7 +734,8 @@ def test_ogr_mysql_24():
         + "' tpoly"
     )
 
-    assert ret.find("INFO") != -1 and ret.find("ERROR") == -1
+    assert "INFO" in ret
+    assert "ERROR" not in ret
 
 
 ###############################################################################

--- a/ogr/ogrsf_frmts/mysql/ogr_mysql.h
+++ b/ogr/ogrsf_frmts/mysql/ogr_mysql.h
@@ -70,19 +70,46 @@
 
 #include "ogrsf_frmts.h"
 
+class OGRMySQLDataSource;
+
+/************************************************************************/
+/*                      OGRMySQLGeomFieldDefn                           */
+/************************************************************************/
+
+class OGRMySQLGeomFieldDefn final : public OGRGeomFieldDefn
+{
+    OGRMySQLGeomFieldDefn(const OGRMySQLGeomFieldDefn &) = delete;
+    OGRMySQLGeomFieldDefn &operator=(const OGRMySQLGeomFieldDefn &) = delete;
+
+  protected:
+    OGRMySQLDataSource *poDS;
+
+  public:
+    OGRMySQLGeomFieldDefn(OGRMySQLDataSource *poDSIn, const char *pszFieldName)
+        : OGRGeomFieldDefn(pszFieldName, wkbUnknown), poDS(poDSIn)
+    {
+    }
+
+    virtual const OGRSpatialReference *GetSpatialRef() const override;
+
+    void UnsetDataSource()
+    {
+        poDS = nullptr;
+    }
+
+    mutable int nSRSId = -1;
+};
+
 /************************************************************************/
 /*                            OGRMySQLLayer                             */
 /************************************************************************/
-
-class OGRMySQLDataSource;
 
 class OGRMySQLLayer CPL_NON_FINAL : public OGRLayer
 {
   protected:
     OGRFeatureDefn *poFeatureDefn;
 
-    // Layer spatial reference system, and srid.
-    OGRSpatialReference *poSRS;
+    // Layer srid.
     int nSRSId;
 
     GIntBig iNextShapeId;
@@ -119,8 +146,6 @@ class OGRMySQLLayer CPL_NON_FINAL : public OGRLayer
     {
         return poFeatureDefn;
     }
-
-    virtual OGRSpatialReference *GetSpatialRef() override;
 
     virtual const char *GetFIDColumn() override;
 

--- a/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -362,8 +362,12 @@ int OGRMySQLDataSource::TestCapability(const char *pszCap)
         return TRUE;
     if (EQUAL(pszCap, ODsCRandomLayerWrite))
         return TRUE;
-    else
-        return FALSE;
+    if (EQUAL(pszCap, ODsCMeasuredGeometries))
+        return TRUE;
+    if (EQUAL(pszCap, ODsCZGeometries))
+        return TRUE;
+
+    return FALSE;
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/mysql/ogrmysqlresultlayer.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqlresultlayer.cpp
@@ -224,9 +224,8 @@ OGRFeatureDefn *OGRMySQLResultLayer::ReadResultDefinition()
         CPLString osCommand;
         char **papszRow;
 
-        // set to unknown first
-        poDefn->SetGeomType(wkbUnknown);
-        poDefn->GetGeomFieldDefn(0)->SetName(pszGeomColumn);
+        auto poGeomFieldDefn =
+            cpl::make_unique<OGRMySQLGeomFieldDefn>(poDS, pszGeomColumn);
 
         if (poDS->GetMajorVersion() < 8 || poDS->IsMariaDB())
         {
@@ -259,10 +258,13 @@ OGRFeatureDefn *OGRMySQLResultLayer::ReadResultDefinition()
 
             OGRwkbGeometryType l_nGeomType = OGRFromOGCGeomType(pszType);
 
-            poDefn->SetGeomType(l_nGeomType);
+            poGeomFieldDefn->SetType(l_nGeomType);
         }
 
         nSRSId = FetchSRSId();
+
+        poGeomFieldDefn->nSRSId = nSRSId;
+        poDefn->AddGeomFieldDefn(std::move(poGeomFieldDefn));
     }
 
     return poDefn;


### PR DESCRIPTION
- make sure that OGRLayer::GetSpatialRef() == OGRGeomFieldDefn::GetSpatialRef()
- add missing dataset capabilities
- re-enable ogr_mysql_24 test
