### PR TITLE
netCDF: parse coordinates attribute from Sentinel-3 Synergy product

### DIFF
--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -5144,7 +5144,7 @@ int netCDFDataset::ProcessCFGeolocation(int nGroupId, int nVarId,
     if (NCDFGetAttr(nGroupId, nVarId, "coordinates", &pszTemp) == CE_None)
     {
         // Get X and Y geolocation names from coordinates attribute.
-        char **papszTokens = CSLTokenizeString2(pszTemp, " ", 0);
+        char **papszTokens = NCDFTokenizeCoordinatesAttribute(pszTemp);
         if (CSLCount(papszTokens) >= 2)
         {
             char szGeolocXName[NC_MAX_NAME + 1];
@@ -13587,7 +13587,7 @@ CPLErr netCDFDataset::CreateGrpVectorLayers(
     if (NCDFGetAttr(nCdfId, nFirstVarId, "coordinates", &pszCoordinates) ==
         CE_None)
     {
-        char **papszTokens = CSLTokenizeString2(pszCoordinates, " ", 0);
+        char **papszTokens = NCDFTokenizeCoordinatesAttribute(pszCFCoordinates);
         for (int i = 0; papszTokens != nullptr && papszTokens[i] != nullptr;
              i++)
         {
@@ -13750,7 +13750,7 @@ static CPLErr NCDFGetCoordAndBoundVarFullNames(int nCdfId, char ***ppapszVars)
         char *pszTemp = nullptr;
         char **papszTokens = nullptr;
         if (NCDFGetAttr(nCdfId, v, "coordinates", &pszTemp) == CE_None)
-            papszTokens = CSLTokenizeString2(pszTemp, " ", 0);
+            papszTokens = NCDFTokenizeCoordinatesAttribute(pszTemp);
         CPLFree(pszTemp);
         pszTemp = nullptr;
         if (NCDFGetAttr(nCdfId, v, "bounds", &pszTemp) == CE_None &&
@@ -13821,4 +13821,13 @@ bool NCDFIsUserDefinedType(int ncid, int type)
 #else
     return false;
 #endif
+}
+
+char **NCDFTokenizeCoordinatesAttribute(const char *pszCoordinates)
+{
+    // CF conventions use space as the separator for variable names in the
+    // coordinates attribute, but some products such as
+    // https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-3-synergy/products-algorithms/level-2-aod-algorithms-and-products/level-2-aod-products-description
+    // use comma.
+    return CSLTokenizeString2(pszCoordinates, ", ", 0);
 }

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -1210,6 +1210,8 @@ bool NCDFIsVarTimeCoord(int nCdfId, int nVarId, const char *pszVarName);
 
 std::string NCDFReadMetadataAsJson(int cdfid);
 
+char **NCDFTokenizeCoordinatesAttribute(const char *pszCoordinates);
+
 extern CPLMutex *hNCMutex;
 
 #ifdef ENABLE_NCDUMP

--- a/frmts/netcdf/netcdfmultidim.cpp
+++ b/frmts/netcdf/netcdfmultidim.cpp
@@ -1341,7 +1341,7 @@ netCDFGroup::GetMDArrayNames(CSLConstList papszOptions) const
                 char *pszTemp = nullptr;
                 if (NCDFGetAttr(m_gid, varid, "coordinates", &pszTemp) ==
                     CE_None)
-                    papszTokens = CSLTokenizeString2(pszTemp, " ", 0);
+                    papszTokens = NCDFTokenizeCoordinatesAttribute(pszTemp);
                 CPLFree(pszTemp);
             }
             if (!bBounds)
@@ -1906,7 +1906,7 @@ std::shared_ptr<GDALMDArray> netCDFDimension::GetIndexingVariable() const
         // Check that the arrays has as many dimensions as its coordinates
         // attribute
         const CPLStringList aosCoordinates(
-            CSLTokenizeString2(poCoordinates->ReadAsString(), " ", 0));
+            NCDFTokenizeCoordinatesAttribute(poCoordinates->ReadAsString()));
         if (apoArrayDims.size() != static_cast<size_t>(aosCoordinates.size()))
             continue;
 
@@ -3952,7 +3952,7 @@ netCDFVariable::GetCoordinateVariables() const
         if (pszCoordinates)
         {
             const CPLStringList aosNames(
-                CSLTokenizeString2(pszCoordinates, " ", 0));
+                NCDFTokenizeCoordinatesAttribute(pszCoordinates));
             CPLMutexHolderD(&hNCMutex);
             for (int i = 0; i < aosNames.size(); i++)
             {


### PR DESCRIPTION
which uses comma instead of space as a delimiter in the CF coordinates attribute
