### PR TITLE
TileDB: add read/write multidimensional support

### DIFF
--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -106,7 +106,7 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}
   | tar xz -C /usr/local --strip-components=1
 
 # Build tiledb (requires CMake 3.21)
-ENV TILEDB_VERSION=2.9.4
+ENV TILEDB_VERSION=2.15.3
 RUN mkdir tiledb \
     && wget -q https://github.com/TileDB-Inc/TileDB/archive/${TILEDB_VERSION}.tar.gz -O - \
         | tar xz -C tiledb --strip-components=1 \

--- a/apps/gdalmdiminfo_lib.cpp
+++ b/apps/gdalmdiminfo_lib.cpp
@@ -36,6 +36,13 @@
 #include <limits>
 #include <set>
 
+static void DumpArray(const std::shared_ptr<GDALGroup> &rootGroup,
+                      const std::shared_ptr<GDALMDArray> &array,
+                      CPLJSonStreamingWriter &serializer,
+                      const GDALMultiDimInfoOptions *psOptions,
+                      std::set<std::string> &alreadyDumpedDimensions,
+                      bool bOutputObjType, bool bOutputName);
+
 /************************************************************************/
 /*                       GDALMultiDimInfoOptions                        */
 /************************************************************************/
@@ -631,9 +638,10 @@ static void DumpArrayRec(std::shared_ptr<GDALMDArray> array,
 /************************************************************************/
 
 static void
-DumpDimensions(const std::vector<std::shared_ptr<GDALDimension>> &dims,
+DumpDimensions(const std::shared_ptr<GDALGroup> &rootGroup,
+               const std::vector<std::shared_ptr<GDALDimension>> &dims,
                CPLJSonStreamingWriter &serializer,
-               const GDALMultiDimInfoOptions *,
+               const GDALMultiDimInfoOptions *psOptions,
                std::set<std::string> &alreadyDumpedDimensions)
 {
     auto arrayContext(serializer.MakeArrayContext());
@@ -678,7 +686,19 @@ DumpDimensions(const std::vector<std::shared_ptr<GDALDimension>> &dims,
         if (poIndexingVariable)
         {
             serializer.AddObjKey("indexing_variable");
-            serializer.Add(poIndexingVariable->GetFullName());
+            if (rootGroup->OpenMDArray(poIndexingVariable->GetFullName()))
+            {
+                serializer.Add(poIndexingVariable->GetFullName());
+            }
+            else
+            {
+                auto indexingVariableContext(serializer.MakeObjectContext());
+                serializer.AddObjKey(poIndexingVariable->GetName());
+                DumpArray(rootGroup, poIndexingVariable, serializer, psOptions,
+                          alreadyDumpedDimensions,
+                          /* bOutputObjType = */ false,
+                          /* bOutputName = */ false);
+            }
         }
     }
 }
@@ -713,7 +733,8 @@ static void DumpStructuralInfo(CSLConstList papszStructuralInfo,
 /*                             DumpArray()                              */
 /************************************************************************/
 
-static void DumpArray(std::shared_ptr<GDALMDArray> array,
+static void DumpArray(const std::shared_ptr<GDALGroup> &rootGroup,
+                      const std::shared_ptr<GDALMDArray> &array,
                       CPLJSonStreamingWriter &serializer,
                       const GDALMultiDimInfoOptions *psOptions,
                       std::set<std::string> &alreadyDumpedDimensions,
@@ -739,7 +760,8 @@ static void DumpArray(std::shared_ptr<GDALMDArray> array,
     if (!dims.empty())
     {
         serializer.AddObjKey("dimensions");
-        DumpDimensions(dims, serializer, psOptions, alreadyDumpedDimensions);
+        DumpDimensions(rootGroup, dims, serializer, psOptions,
+                       alreadyDumpedDimensions);
 
         serializer.AddObjKey("dimension_size");
         auto arrayContext(serializer.MakeArrayContext());
@@ -896,7 +918,8 @@ static void DumpArray(std::shared_ptr<GDALMDArray> array,
 /*                            DumpArrays()                              */
 /************************************************************************/
 
-static void DumpArrays(std::shared_ptr<GDALGroup> group,
+static void DumpArrays(const std::shared_ptr<GDALGroup> &rootGroup,
+                       const std::shared_ptr<GDALGroup> &group,
                        const std::vector<std::string> &arrayNames,
                        CPLJSonStreamingWriter &serializer,
                        const GDALMultiDimInfoOptions *psOptions,
@@ -913,8 +936,8 @@ static void DumpArrays(std::shared_ptr<GDALGroup> group,
         if (array)
         {
             serializer.AddObjKey(array->GetName());
-            DumpArray(array, serializer, psOptions, alreadyDumpedDimensions,
-                      false, false);
+            DumpArray(rootGroup, array, serializer, psOptions,
+                      alreadyDumpedDimensions, false, false);
         }
     }
 }
@@ -923,7 +946,8 @@ static void DumpArrays(std::shared_ptr<GDALGroup> group,
 /*                             DumpGroup()                              */
 /************************************************************************/
 
-static void DumpGroup(std::shared_ptr<GDALGroup> group,
+static void DumpGroup(const std::shared_ptr<GDALGroup> &rootGroup,
+                      const std::shared_ptr<GDALGroup> &group,
                       const char *pszDriverName,
                       CPLJSonStreamingWriter &serializer,
                       const GDALMultiDimInfoOptions *psOptions,
@@ -968,7 +992,8 @@ static void DumpGroup(std::shared_ptr<GDALGroup> group,
     if (!dims.empty())
     {
         serializer.AddObjKey("dimensions");
-        DumpDimensions(dims, serializer, psOptions, alreadyDumpedDimensions);
+        DumpDimensions(rootGroup, dims, serializer, psOptions,
+                       alreadyDumpedDimensions);
     }
 
     CPLStringList aosOptionsGetArray(psOptions->aosArrayOptions);
@@ -978,7 +1003,7 @@ static void DumpGroup(std::shared_ptr<GDALGroup> group,
     if (!arrayNames.empty())
     {
         serializer.AddObjKey("arrays");
-        DumpArrays(group, arrayNames, serializer, psOptions,
+        DumpArrays(rootGroup, group, arrayNames, serializer, psOptions,
                    alreadyDumpedDimensions);
     }
 
@@ -1002,8 +1027,8 @@ static void DumpGroup(std::shared_ptr<GDALGroup> group,
                 if (subgroup)
                 {
                     serializer.AddObjKey(subgroupName);
-                    DumpGroup(subgroup, nullptr, serializer, psOptions,
-                              alreadyDumpedDimensions, false, false);
+                    DumpGroup(rootGroup, subgroup, nullptr, serializer,
+                              psOptions, alreadyDumpedDimensions, false, false);
                 }
             }
         }
@@ -1015,8 +1040,8 @@ static void DumpGroup(std::shared_ptr<GDALGroup> group,
                 auto subgroup = group->OpenGroup(subgroupName);
                 if (subgroup)
                 {
-                    DumpGroup(subgroup, nullptr, serializer, psOptions,
-                              alreadyDumpedDimensions, false, true);
+                    DumpGroup(rootGroup, subgroup, nullptr, serializer,
+                              psOptions, alreadyDumpedDimensions, false, true);
                 }
             }
         }
@@ -1082,7 +1107,7 @@ char *GDALMultiDimInfo(GDALDatasetH hDataset,
             auto poDriver = poDS->GetDriver();
             if (poDriver)
                 pszDriverName = poDriver->GetDescription();
-            DumpGroup(group, pszDriverName, serializer, psOptions,
+            DumpGroup(group, group, pszDriverName, serializer, psOptions,
                       alreadyDumpedDimensions, true, true);
         }
         else
@@ -1109,8 +1134,8 @@ char *GDALMultiDimInfo(GDALDatasetH hDataset,
                          pszArrayName);
                 return nullptr;
             }
-            DumpArray(array, serializer, psOptions, alreadyDumpedDimensions,
-                      true, true);
+            DumpArray(group, array, serializer, psOptions,
+                      alreadyDumpedDimensions, true, true);
         }
     }
     catch (const std::exception &e)

--- a/autotest/gdrivers/tiledb_multidim.py
+++ b/autotest/gdrivers/tiledb_multidim.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test read/write multidimensional functionality for TileDB format.
+# Author:   TileDB, Inc
+#
+###############################################################################
+# Copyright (c) 2023, TileDB, Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import array
+import math
+import os
+import shutil
+
+import pytest
+
+from osgeo import gdal, osr
+
+
+def has_tiledb_multidim():
+    drv = gdal.GetDriverByName("TileDB")
+    if drv is None:
+        return False
+    return drv.GetMetadataItem(gdal.DCAP_CREATE_MULTIDIMENSIONAL) == "YES"
+
+
+pytestmark = [
+    pytest.mark.require_driver("TileDB"),
+    pytest.mark.skipif(not has_tiledb_multidim(), reason="TileDB >= 2.15 required"),
+]
+
+
+def test_tiledb_multidim_basic():
+
+    filename = "tmp/test_tiledb_multidim_basic.tiledb"
+
+    def create():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        assert rg
+        assert rg.GetName() == "/"
+        assert rg.GetFullName() == "/"
+        assert not rg.GetMDArrayNames()
+        assert not rg.GetGroupNames()
+        assert not rg.GetAttributes()
+        assert not rg.GetDimensions()
+        with pytest.raises(Exception):
+            rg.OpenMDArray("not existing")
+        with pytest.raises(Exception):
+            rg.OpenGroup("not existing")
+        with pytest.raises(Exception):
+            rg.GetAttribute("not existing")
+
+        group = rg.CreateGroup("group")
+        assert rg.GetGroupNames() == ["group"]
+        assert group.GetName() == "group"
+        assert group.GetFullName() == "/group"
+        group_got = rg.OpenGroup("group")
+        assert group_got.GetName() == "group"
+
+        with pytest.raises(Exception, match="already exists"):
+            rg.CreateGroup("group")
+
+        with pytest.raises(Exception, match="Zero-dimension"):
+            group.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+
+        dim0 = rg.CreateDimension("dim0", None, None, 2)
+        with pytest.raises(Exception, match="Only numeric data types"):
+            group.CreateMDArray("ar", [dim0], gdal.ExtendedDataType.CreateString())
+
+        with pytest.raises(Exception, match="Invalid array name"):
+            group.CreateMDArray("", [dim0], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+
+        os.mkdir(filename + "/group/ar")
+        with pytest.raises(Exception, match="Path .* already exists"):
+            group.CreateMDArray(
+                "ar", [dim0], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+            )
+        os.rmdir(filename + "/group/ar")
+
+        ar = group.CreateMDArray(
+            "ar", [dim0], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+        )
+        assert group.GetMDArrayNames() == ["ar"]
+        assert ar.GetName() == "ar"
+        assert ar.GetFullName() == "/group/ar"
+        ar.SetUnit("my_unit")
+
+        group.CreateGroup("subgroup")
+        with pytest.raises(Exception, match="An array named ar already exists"):
+            group.CreateGroup("ar")
+        with pytest.raises(Exception, match="A group named subgroup already exists"):
+            group.CreateMDArray(
+                "subgroup", [dim0], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+            )
+
+        attr = group.CreateAttribute(
+            "str_attr", [], gdal.ExtendedDataType.CreateString()
+        )
+        assert attr
+        assert attr.Write("my_string") == gdal.CE_None
+
+        attr = group.CreateAttribute(
+            "float64_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        assert attr
+        assert attr.Write(1.25) == gdal.CE_None
+
+        attr = group.CreateAttribute(
+            "two_int32_attr", [2], gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+        )
+        assert attr
+        assert attr.Write([123456789, -123456789]) == gdal.CE_None
+
+        attr = group.CreateAttribute(
+            "to_be_deleted", [], gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+        )
+        assert attr
+        group.DeleteAttribute("to_be_deleted")
+        with pytest.raises(Exception, match="has been deleted"):
+            attr.Write(1)
+        with pytest.raises(Exception, match="has been deleted"):
+            attr.Read()
+
+        attr = ar.CreateAttribute("foo", [], gdal.ExtendedDataType.CreateString())
+        assert attr
+        assert attr.Write("bar") == gdal.CE_None
+
+        attr = ar.CreateAttribute(
+            "to_be_deleted", [], gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+        )
+        assert attr
+        group.DeleteAttribute("to_be_deleted")
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        assert rg
+        assert rg.GetGroupNames() == ["group"]
+        group = rg.OpenGroup("group")
+        assert group.GetName() == "group"
+        assert group.GetFullName() == "/group"
+
+        assert group.GetMDArrayNames() == ["ar"]
+        assert group.GetGroupNames() == ["subgroup"]
+
+        assert set([x.GetName() for x in group.GetAttributes()]) == set(
+            ["str_attr", "float64_attr", "two_int32_attr"]
+        )
+
+        attr = group.GetAttribute("str_attr")
+        assert attr.GetDataType().GetClass() == gdal.GEDTC_STRING
+        assert attr.Read() == "my_string"
+        with pytest.raises(Exception, match=r".*not .* in update mode.*"):
+            attr.Write("modified")
+
+        attr = group.GetAttribute("float64_attr")
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
+        assert attr.GetDimensionsSize() == [1]
+        assert attr.Read() == 1.25
+
+        attr = group.GetAttribute("two_int32_attr")
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
+        assert attr.GetDimensionsSize() == [2]
+        assert attr.Read() == (123456789, -123456789)
+
+        with pytest.raises(Exception, match=r".*not .* in update mode.*"):
+            group.CreateGroup("new_subgroup")
+
+        dim0 = rg.CreateDimension("dim0", None, None, 2)
+
+        with pytest.raises(Exception, match=r".*not .* in update mode.*"):
+            group.CreateMDArray(
+                "new_ar", [dim0], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+            )
+
+        with pytest.raises(Exception, match=r".*not .* in update mode.*"):
+            group.CreateAttribute("new_attr", [], gdal.ExtendedDataType.CreateString())
+
+        with pytest.raises(Exception, match=r".*not .* in update mode.*"):
+            group.DeleteAttribute("str_attr")
+
+        ar = group.OpenMDArray("ar")
+        assert ar.GetDimensionCount() == 1
+        assert ar.GetDimensions()[0].GetName() == "dim0"
+        assert ar.GetDimensions()[0].GetSize() == 2
+        assert set([x.GetName() for x in ar.GetAttributes()]) == set(["foo"])
+        assert ar.GetAttribute("foo").Read() == "bar"
+        assert ar.GetUnit() == "my_unit"
+
+        with pytest.raises(Exception, match=r".*not .* in update mode.*"):
+            ar.CreateAttribute("new_attr", [], gdal.ExtendedDataType.CreateString())
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        create()
+        reopen_readonly()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "gdal_data_type",
+    [
+        gdal.GDT_Int8,
+        gdal.GDT_Byte,
+        gdal.GDT_Int16,
+        gdal.GDT_UInt16,
+        gdal.GDT_Int32,
+        gdal.GDT_UInt32,
+        gdal.GDT_Int64,
+        gdal.GDT_UInt64,
+        gdal.GDT_Float32,
+        gdal.GDT_Float64,
+        gdal.GDT_CInt16,
+        gdal.GDT_CInt32,
+        gdal.GDT_CFloat32,
+        gdal.GDT_CFloat64,
+    ],
+)
+def test_tiledb_multidim_array_data_types(gdal_data_type):
+
+    filename = "tmp/test_tiledb_multidim_array_data_types.tiledb"
+
+    def create():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        dim0 = rg.CreateDimension("dim0", None, None, 2)
+        ar = rg.CreateMDArray(
+            "ar", [dim0], gdal.ExtendedDataType.Create(gdal_data_type)
+        )
+        assert ar.GetDataType() == gdal.ExtendedDataType.Create(gdal_data_type)
+        ar.Write(b"\0" * (ar.GetDataType().GetSize() * dim0.GetSize()))
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("ar")
+        assert ar.GetDataType() == gdal.ExtendedDataType.Create(gdal_data_type)
+        dim0 = ar.GetDimensions()[0]
+        assert ar.Read() == b"\0" * (ar.GetDataType().GetSize() * dim0.GetSize())
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        create()
+        reopen_readonly()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+def test_tiledb_multidim_array_nodata():
+
+    filename = "tmp/test_tiledb_multidim_array_nodata.tiledb"
+
+    def test():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        dim0 = rg.CreateDimension("dim0", None, None, 3)
+        dim1 = rg.CreateDimension("dim1", None, None, 5)
+        ar = rg.CreateMDArray(
+            "ar", [dim0, dim1], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        ar.SetNoDataValue(1.5)
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("ar")
+        assert ar.GetNoDataValueAsDouble() == 1.5
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+        reopen_readonly()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+def test_tiledb_multidim_array_nodata_cannot_be_set_after_finalize():
+
+    filename = (
+        "tmp/test_tiledb_multidim_array_nodata_cannot_be_set_after_finalize.tiledb"
+    )
+
+    def test():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        dim0 = rg.CreateDimension("dim0", None, None, 3)
+        dim1 = rg.CreateDimension("dim1", None, None, 5)
+        ar = rg.CreateMDArray(
+            "ar", [dim0, dim1], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        ar.Write(array.array("d", [i for i in range(3 * 5)]))
+        with pytest.raises(
+            Exception, match="not supported after array has been finalized"
+        ):
+            ar.SetNoDataValue(1.5)
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("ar")
+        assert math.isnan(ar.GetNoDataValueAsDouble())
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+        reopen_readonly()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+def test_tiledb_multidim_array_blocksize():
+
+    filename = "tmp/test_tiledb_multidim_array_blocksize.tiledb"
+
+    def test():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        dim0 = rg.CreateDimension("dim0", None, None, 3)
+        dim1 = rg.CreateDimension("dim1", None, None, 5)
+        rg.CreateMDArray(
+            "ar",
+            [dim0, dim1],
+            gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+            ["BLOCKSIZE=2,4"],
+        )
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("ar")
+        assert ar.GetBlockSize() == [2, 4]
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+        reopen_readonly()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+def test_tiledb_multidim_array_compression():
+
+    filename = "tmp/test_tiledb_multidim_array_compression.tiledb"
+
+    def test():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        dim0 = rg.CreateDimension("dim0", None, None, 3)
+        rg.CreateMDArray(
+            "ar",
+            [dim0],
+            gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+            ["COMPRESSION=ZSTD"],
+        )
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("ar")
+        assert ar.GetStructuralInfo() == {"FILTER_LIST": "ZSTD"}
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+        reopen_readonly()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+def test_tiledb_multidim_array_read_write():
+
+    filename = "tmp/test_tiledb_multidim_array_read_write.tiledb"
+
+    def test():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        dim0 = rg.CreateDimension("dim0", None, None, 3)
+        dim1 = rg.CreateDimension("dim1", None, None, 5)
+        ar = rg.CreateMDArray(
+            "ar", [dim0, dim1], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        ar.Write(
+            array.array("d", [i for i in range(1 * 5)]),
+            array_start_idx=[0, 0],
+            count=[1, 5],
+        )
+        ar.Write(
+            array.array("d", [5 + i for i in range(2 * 5)]),
+            array_start_idx=[1, 0],
+            count=[2, 5],
+        )
+
+        with pytest.raises(Exception, match="Write parameters not supported"):
+            ar.Write(
+                array.array("f", [0 for i in range(3 * 5)]),
+                buffer_datatype=gdal.ExtendedDataType.Create(gdal.GDT_Float32),
+            )
+
+        assert array.array("d", ar.Read()).tolist() == [i for i in range(3 * 5)]
+        assert array.array(
+            "d", ar.Read(array_start_idx=[1, 2], count=[1, 1])
+        ).tolist() == [7]
+        assert array.array(
+            "d", ar.Read(array_start_idx=[0, 1], count=[2, 1])
+        ).tolist() == [1, 6]
+        assert array.array(
+            "d", ar.Read(array_start_idx=[1, 0], count=[1, 2])
+        ).tolist() == [5, 6]
+
+        # Uses GDALMDArray::ReadUsingContiguousIRead()
+        assert array.array(
+            "f", ar.Read(buffer_datatype=gdal.ExtendedDataType.Create(gdal.GDT_Float32))
+        ).tolist() == [i for i in range(3 * 5)]
+        assert array.array("d", ar.Read(buffer_stride=[1, 3])).tolist() == [
+            0.0,
+            5.0,
+            10.0,
+            1.0,
+            6.0,
+            11.0,
+            2.0,
+            7.0,
+            12.0,
+            3.0,
+            8.0,
+            13.0,
+            4.0,
+            9.0,
+            14.0,
+        ]
+        assert (
+            array.array(
+                "d", ar.Read(array_start_idx=[2, 4], count=[3, 5], array_step=[-1, -1])
+            ).tolist()
+            == [i for i in range(3 * 5)][::-1]
+        )
+        assert array.array(
+            "d", ar.Read(array_start_idx=[2, 1], count=[1, 2], array_step=[1, 2])
+        ).tolist() == [11, 13]
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize("epsg_code,axis_mapping", [(4326, [1, 2]), (32631, [2, 1])])
+def test_tiledb_multidim_array_read_dim_label_and_spatial_ref(epsg_code, axis_mapping):
+
+    filename = "tmp/test_tiledb_multidim_array_read_dim_label.tiledb"
+
+    def test():
+
+        drv = gdal.GetDriverByName("TileDB")
+        ds = drv.CreateMultiDimensional(filename)
+        rg = ds.GetRootGroup()
+        dim0 = rg.CreateDimension("dim0", "type", "direction", 3)
+        dim0_ar = rg.CreateMDArray(
+            "dim0",
+            [dim0],
+            gdal.ExtendedDataType.Create(gdal.GDT_Float32),
+            ["IN_MEMORY=YES"],
+        )
+        dim0_ar.Write(array.array("f", [3, 2, 0]))
+        dim0.SetIndexingVariable(dim0_ar)
+        dim1 = rg.CreateDimension("dim1", None, None, 5)
+        dim1_ar = rg.CreateMDArray(
+            "dim1",
+            [dim1],
+            gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+            ["IN_MEMORY=YES"],
+        )
+        dim1_ar.Write(array.array("d", [10, 20, 30, 40, 60]))
+        dim1.SetIndexingVariable(dim1_ar)
+        ar = rg.CreateMDArray(
+            "ar", [dim0, dim1], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(epsg_code)
+        ar.SetSpatialRef(srs)
+
+    def reopen_readonly():
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("ar")
+        dims = ar.GetDimensions()
+        assert dims[0].GetName() == "dim0"
+        assert dims[0].GetType() == "type"
+        assert dims[0].GetDirection() == "direction"
+        assert array.array("f", dims[0].GetIndexingVariable().Read()).tolist() == [
+            3,
+            2,
+            0,
+        ]
+        assert dims[1].GetName() == "dim1"
+        assert array.array("d", dims[1].GetIndexingVariable().Read()).tolist() == [
+            10,
+            20,
+            30,
+            40,
+            60,
+        ]
+        srs = ar.GetSpatialRef()
+        assert srs.GetAuthorityCode(None) == str(epsg_code)
+        assert srs.GetDataAxisToSRSAxisMapping() == axis_mapping
+
+        # Test that gdalmdiminfo can deal with dimensions whose indexing variable
+        # is not owned by a group, but by the array itself
+        info = gdal.MultiDimInfo(ds, detailed=True)
+        assert info["arrays"]["ar"]["dimensions"][0]["indexing_variable"] == {
+            "dim0": {
+                "datatype": "Float32",
+                "dimensions": [
+                    {"name": "index", "full_name": "/ar/dim0/index", "size": 3}
+                ],
+                "dimension_size": [3],
+                "block_size": [3],
+                "attributes": {
+                    "_DIM_DIRECTION": {"datatype": "String", "value": "direction"},
+                    "_DIM_TYPE": {"datatype": "String", "value": "type"},
+                },
+                "nodata_value": "NaN",
+                "values": [3, 2, 0],
+            }
+        }
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+        reopen_readonly()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+def test_tiledb_multidim_array_read_gdal_raster_classic():
+
+    filename = "tmp/test_tiledb_multidim_array_read_gdal_raster_classic.tiledb"
+
+    def test():
+        gdal.Translate(filename, "data/small_world.tif", format="TileDB")
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray(rg.GetMDArrayNames()[0])
+        dims = ar.GetDimensions()
+        assert len(dims) == 3
+        assert dims[0].GetName() == "BANDS"
+        assert dims[0].GetSize() == 3
+        assert dims[1].GetName() == "Y"
+        assert dims[1].GetType() == "HORIZONTAL_Y"
+        assert dims[1].GetSize() == 200
+        assert dims[2].GetName() == "X"
+        assert dims[2].GetType() == "HORIZONTAL_X"
+        assert dims[2].GetSize() == 400
+        Y = dims[1].GetIndexingVariable()
+        assert array.array("d", Y.Read()).tolist() == pytest.approx(
+            [89.55 - i * 0.90 for i in range(200)]
+        )
+        X = dims[2].GetIndexingVariable()
+        assert array.array("d", X.Read()).tolist() == pytest.approx(
+            [-179.55 + i * 0.90 for i in range(400)]
+        )
+        srs = ar.GetSpatialRef()
+        assert srs.GetAuthorityCode(None) == "4326"
+        assert srs.GetDataAxisToSRSAxisMapping() == [2, 3]
+        ds_ref = gdal.Open("data/small_world.tif")
+        assert ar.Read() == ds_ref.ReadRaster()
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+def test_tiledb_multidim_array_read_gdal_raster_classic_interleave_attributes():
+
+    filename = "tmp/test_tiledb_multidim_array_read_gdal_raster_classic_interleave_attributes.tiledb"
+
+    def test():
+        gdal.Translate(
+            filename,
+            "data/small_world.tif",
+            format="TileDB",
+            creationOptions=["INTERLEAVE=ATTRIBUTES"],
+        )
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        assert rg.GetMDArrayNames() == [
+            filename[len("tmp/") :] + ".TDB_VALUES_%d" % i for i in range(1, 3 + 1)
+        ]
+        ar = rg.OpenMDArray(rg.GetMDArrayNames()[0])
+        dims = ar.GetDimensions()
+        assert len(dims) == 2
+        assert dims[0].GetName() == "Y"
+        assert dims[0].GetSize() == 200
+        assert dims[1].GetName() == "X"
+        assert dims[1].GetSize() == 400
+        ds_ref = gdal.Open("data/small_world.tif")
+        assert ar.Read() == ds_ref.GetRasterBand(1).ReadRaster()
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+
+###############################################################################
+
+
+@pytest.mark.require_driver("netCDF")
+def test_tiledb_multidim_translate_from_netcdf():
+
+    filename = "tmp/test_tiledb_multidim_translate_from_netcdf.tiledb"
+
+    def test():
+        gdal.MultiDimTranslate(
+            filename, "data/netcdf/netcdf-4d.nc", format="TileDB", arraySpecs=["t"]
+        )
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("t")
+        assert ar.GetDimensionCount() == 4
+        assert ar.GetDimensions()[0].GetIndexingVariable().GetName() == "time"
+        assert ar.GetDimensions()[1].GetIndexingVariable().GetName() == "levelist"
+        assert ar.GetDimensions()[2].GetIndexingVariable().GetName() == "latitude"
+        assert ar.GetDimensions()[3].GetIndexingVariable().GetName() == "longitude"
+        assert ar.GetNoDataValueAsDouble() == -32767.0
+
+    if os.path.exists(filename):
+        shutil.rmtree(filename)
+    try:
+        test()
+    finally:
+        if os.path.exists(filename):
+            shutil.rmtree(filename)

--- a/doc/source/drivers/raster/tiledb.rst
+++ b/doc/source/drivers/raster/tiledb.rst
@@ -34,6 +34,62 @@ Various creation and open options exists, among them :
 -  **TILEDB_CONFIG=config**: A local file with TileDB configuration
    `options <https://docs.tiledb.io/en/stable/tutorials/config.html>`__
 
+Multidimensional API support
+----------------------------
+
+.. versionadded:: 3.8
+
+The TileDB driver supports the :ref:`multidim_raster_data_model` for reading
+and writing operations. It requires GDAL to be built and run against TileDB >= 2.15.
+
+The driver supports:
+- creating and reading groups and subgroups
+- creating and reading multidimensional dense arrays with a numeric data type
+- creating and reading numeric or string attributes in groups and arrays
+- storing an indexing array of a dimension as a TileDB dimension label
+
+The multidimensional API supports reading dense arrays created by the classic
+raster API of GDAL.
+
+The following multidimensional dataset open options are available:
+
+-  **TILEDB_CONFIG=config**: A local file with TileDB configuration
+   `options <https://docs.tiledb.io/en/stable/tutorials/config.html>`__
+
+-  **TILEDB_TIMESTAMP=val**: inclusive ending timestamp when opening this array
+
+
+The following multidimensional dataset creation options are available:
+
+-  **TILEDB_CONFIG=config**: A local file with TileDB configuration
+   `options <https://docs.tiledb.io/en/stable/tutorials/config.html>`__
+
+-  **TILEDB_TIMESTAMP=val**: inclusive ending timestamp when opening this array
+
+
+The following array open options are available:
+
+-  **TILEDB_TIMESTAMP=val**: inclusive ending timestamp when opening this array
+
+
+The following array creation options are available:
+
+-  **BLOCKSIZE=val1,val2,...,valN**: Block size in pixels
+
+-  **COMPRESSION=NONE/GZIP/ZSTD/LZ4/RLE/BZIP2/DOUBLE-DELTA/POSITIVE-DELTA**:
+   Compression to use. Default is NONE
+
+-  **COMPRESSION_LEVEL=int_value**: compression level
+
+-  **IN_MEMORY=YES/NO**: hether the array should be only in-memory. Useful to
+   create an indexing variable that is serialized as a dimension label
+
+-  **TILEDB_TIMESTAMP=val**: inclusive ending timestamp when opening this array
+
+
+Cf :source_file:`autotest/gdrivers/tiledb_multidim.py` for examples of how to
+use the Python multidimensional API with the TileDB driver.
+
 See Also
 --------
 

--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -125,7 +125,7 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && for i in /build_thirdparty/usr/bin/*; do strip -s $i 2>/dev/null || /bin/true; done
 
 # Build tiledb
-ARG TILEDB_VERSION=2.14.1
+ARG TILEDB_VERSION=2.15.3
 RUN . /buildscripts/bh-set-envvars.sh \
     && mkdir tiledb \
     && wget -q https://github.com/TileDB-Inc/TileDB/archive/${TILEDB_VERSION}.tar.gz -O - \

--- a/frmts/gtiff/libtiff/tif_lzw.c
+++ b/frmts/gtiff/libtiff/tif_lzw.c
@@ -748,8 +748,9 @@ after_loop:
 no_eoi:
     sp->read_error = 1;
     TIFFErrorExtR(tif, module,
-                  "LZWDecode: Strip %" PRIu32 " not terminated with EOI code",
-                  tif->tif_curstrip);
+                  "LZWDecode: Strip %" PRIu32 " not terminated with EOI code"
+                  " (short %" PRIu64" bytes)",
+                  tif->tif_curstrip, (uint64_t)occ);
     return 0;
 error_code:
     sp->read_error = 1;

--- a/frmts/mem/memmultidim.h
+++ b/frmts/mem/memmultidim.h
@@ -258,9 +258,9 @@ class CPL_DLL MEMAbstractMDArray : virtual public GDALAbstractMDArray
 #pragma warning(disable : 4250)
 #endif  //_MSC_VER
 
-class MEMMDArray CPL_NON_FINAL : public MEMAbstractMDArray,
-                                 public GDALMDArray,
-                                 public MEMAttributeHolder
+class CPL_DLL MEMMDArray CPL_NON_FINAL : public MEMAbstractMDArray,
+                                         public GDALMDArray,
+                                         public MEMAttributeHolder
 {
     std::string m_osUnit{};
     std::shared_ptr<OGRSpatialReference> m_poSRS{};

--- a/frmts/tiledb/CMakeLists.txt
+++ b/frmts/tiledb/CMakeLists.txt
@@ -1,5 +1,16 @@
-add_gdal_driver(TARGET gdal_TileDB SOURCES tiledbcommon.cpp tiledbdense.cpp tiledbsparse.cpp PLUGIN_CAPABLE)
+add_gdal_driver(TARGET gdal_TileDB SOURCES
+                tiledbcommon.cpp
+                tiledbdense.cpp
+                tiledbsparse.cpp
+                tiledbmultidim.cpp
+                tiledbmultidimattribute.cpp
+                tiledbmultidimattributeholder.cpp
+                tiledbmultidimgroup.cpp
+                tiledbmultidimarray.cpp
+                PLUGIN_CAPABLE)
 gdal_standard_includes(gdal_TileDB)
+target_include_directories(gdal_TileDB PRIVATE
+                           ${GDAL_RASTER_FORMAT_SOURCE_DIR}/mem)
 target_compile_definitions(gdal_TileDB PRIVATE -DTILEDB_DEPRECATED=)
 target_compile_features(gdal_TileDB PRIVATE cxx_std_17)
 gdal_target_link_libraries(gdal_TileDB PRIVATE TileDB::tiledb_shared)

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -614,7 +614,7 @@ CPLErr TileDBRasterDataset::TrySaveXML()
 #if TILEDB_VERSION_MAJOR == 1 && TILEDB_VERSION_MINOR < 7
             vfs.remove_file(psPam->pszPamFilename);
 #else
-            m_array->delete_metadata("_gdal");
+            m_array->delete_metadata(GDAL_ATTRIBUTE_NAME);
 #endif
             return CE_None;
         }
@@ -696,7 +696,7 @@ CPLErr TileDBRasterDataset::TrySaveXML()
             {
                 auto oMeta = std::unique_ptr<tiledb::Array>(new tiledb::Array(
                     *m_ctx, m_array->uri(), TILEDB_WRITE, nTimestamp));
-                oMeta->put_metadata("_gdal", TILEDB_UINT8,
+                oMeta->put_metadata(GDAL_ATTRIBUTE_NAME, TILEDB_UINT8,
                                     static_cast<int>(strlen(pszTree)), pszTree);
                 oMeta->close();
             }
@@ -704,14 +704,14 @@ CPLErr TileDBRasterDataset::TrySaveXML()
             {
                 auto oMeta = std::unique_ptr<tiledb::Array>(
                     new tiledb::Array(*m_ctx, m_array->uri(), TILEDB_WRITE));
-                oMeta->put_metadata("_gdal", TILEDB_UINT8,
+                oMeta->put_metadata(GDAL_ATTRIBUTE_NAME, TILEDB_UINT8,
                                     static_cast<int>(strlen(pszTree)), pszTree);
                 oMeta->close();
             }
         }
         else
         {
-            m_array->put_metadata("_gdal", TILEDB_UINT8,
+            m_array->put_metadata(GDAL_ATTRIBUTE_NAME, TILEDB_UINT8,
                                   static_cast<int>(strlen(pszTree)), pszTree);
         }
 
@@ -860,7 +860,8 @@ CPLErr TileDBRasterDataset::TryLoadCachedXML(char ** /*papszSiblingFiles*/,
                 uint32_t v_num = 0;
                 if ((eAccess == GA_Update) && (m_roArray))
                 {
-                    m_roArray->get_metadata("_gdal", &v_type, &v_num, &v_r);
+                    m_roArray->get_metadata(GDAL_ATTRIBUTE_NAME, &v_type,
+                                            &v_num, &v_r);
                     if (v_r)
                     {
                         osMetaDoc =
@@ -869,7 +870,8 @@ CPLErr TileDBRasterDataset::TryLoadCachedXML(char ** /*papszSiblingFiles*/,
                 }
                 else
                 {
-                    m_array->get_metadata("_gdal", &v_type, &v_num, &v_r);
+                    m_array->get_metadata(GDAL_ATTRIBUTE_NAME, &v_type, &v_num,
+                                          &v_r);
 
                     if (v_r)
                     {

--- a/frmts/tiledb/tiledbheaders.h
+++ b/frmts/tiledb/tiledbheaders.h
@@ -74,6 +74,15 @@
 #define HAS_TILEDB_WORKING_UTF8_STRING_FILTER
 #endif
 
+#if TILEDB_VERSION_MAJOR > 2 ||                                                \
+    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 15)
+#define HAS_TILEDB_DIMENSION_LABEL
+#endif
+
+#ifdef HAS_TILEDB_DIMENSION_LABEL
+#define HAS_TILEDB_MULTIDIM
+#endif
+
 typedef enum
 {
     BAND = 0,
@@ -85,7 +94,9 @@ typedef enum
 
 #define DEFAULT_BATCH_SIZE 500000
 
-const CPLString TILEDB_VALUES("TDB_VALUES");
+constexpr const char *TILEDB_VALUES = "TDB_VALUES";
+
+constexpr const char *GDAL_ATTRIBUTE_NAME = "_gdal";
 
 /************************************************************************/
 /* ==================================================================== */
@@ -123,6 +134,13 @@ class TileDBDataset : public GDALPamDataset
                                    char **papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
+#ifdef HAS_TILEDB_MULTIDIM
+    static GDALDataset *OpenMultiDimensional(GDALOpenInfo *);
+    static GDALDataset *
+    CreateMultiDimensional(const char *pszFilename,
+                           CSLConstList papszRootGroupOptions,
+                           CSLConstList papszOptions);
+#endif
 };
 
 /************************************************************************/

--- a/frmts/tiledb/tiledbmultidim.cpp
+++ b/frmts/tiledb/tiledbmultidim.cpp
@@ -1,0 +1,216 @@
+/******************************************************************************
+ *
+ * Project:  GDAL TileDB Driver
+ * Purpose:  Implement GDAL TileDB multidimensional support based on https://www.tiledb.io
+ * Author:   TileDB, Inc
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, TileDB, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "tiledbmultidim.h"
+
+#ifdef HAS_TILEDB_MULTIDIM
+
+/************************************************************************/
+/*              TileDBSingleArrayGroup::SanitizeNameForPath()           */
+/************************************************************************/
+
+/* static */
+std::string TileDBSharedResource::SanitizeNameForPath(const std::string &osName)
+{
+    CPLString osSanitized(osName);
+    // Reserved characters on Windows
+    for (char ch : {'<', '>', ':', '"', '/', '\\', '|', '?', '*'})
+        osSanitized.replaceAll(ch, '_');
+    return osSanitized;
+}
+
+/************************************************************************/
+/*                    TileDBArrayGroup::Create()                        */
+/************************************************************************/
+
+std::shared_ptr<GDALGroup> TileDBArrayGroup::Create(
+    const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+    const std::string &osArrayPath)
+{
+    auto poTileDBArray = std::make_unique<tiledb::Array>(
+        poSharedResource->GetCtx(), osArrayPath, TILEDB_READ);
+    auto schema = poTileDBArray->schema();
+    const auto nAttributes = schema.attribute_num();
+    const std::string osBaseName(CPLGetFilename(osArrayPath.c_str()));
+    std::vector<std::shared_ptr<GDALMDArray>> apoArrays;
+    if (nAttributes == 1)
+    {
+        auto poArray =
+            TileDBArray::OpenFromDisk(poSharedResource, "/", osBaseName,
+                                      std::string(), osArrayPath, nullptr);
+        if (!poArray)
+            return nullptr;
+        apoArrays.emplace_back(poArray);
+    }
+    else
+    {
+        for (uint32_t i = 0; i < nAttributes; ++i)
+        {
+            auto poArray = TileDBArray::OpenFromDisk(
+                poSharedResource, "/",
+                osBaseName + "." + schema.attribute(i).name(),
+                schema.attribute(i).name(), osArrayPath, nullptr);
+            if (!poArray)
+                return nullptr;
+            apoArrays.emplace_back(poArray);
+        }
+    }
+    return std::make_shared<TileDBArrayGroup>(apoArrays);
+}
+
+/************************************************************************/
+/*                TileDBArrayGroup::GetMDArrayNames()                   */
+/************************************************************************/
+
+std::vector<std::string>
+TileDBArrayGroup::GetMDArrayNames(CSLConstList /*papszOptions*/) const
+{
+    std::vector<std::string> aosNames;
+    for (const auto &poArray : m_apoArrays)
+        aosNames.emplace_back(poArray->GetName());
+    return aosNames;
+}
+
+/************************************************************************/
+/*                  TileDBArrayGroup::OpenMDArray()                     */
+/************************************************************************/
+
+std::shared_ptr<GDALMDArray>
+TileDBArrayGroup::OpenMDArray(const std::string &osName,
+                              CSLConstList /*papszOptions*/) const
+{
+    for (const auto &poArray : m_apoArrays)
+    {
+        if (poArray->GetName() == osName)
+            return poArray;
+    }
+    return nullptr;
+}
+
+/************************************************************************/
+/*                       OpenMultiDimensional()                         */
+/************************************************************************/
+
+GDALDataset *TileDBDataset::OpenMultiDimensional(GDALOpenInfo *poOpenInfo)
+{
+    const char *pszConfig =
+        CSLFetchNameValue(poOpenInfo->papszOpenOptions, "TILEDB_CONFIG");
+
+    std::unique_ptr<tiledb::Context> pCtxt;
+    if (pszConfig != nullptr)
+    {
+        tiledb::Config cfg(pszConfig);
+        pCtxt.reset(new tiledb::Context(cfg));
+    }
+    else
+    {
+        pCtxt.reset(new tiledb::Context());
+    }
+
+    const std::string osPath =
+        TileDBDataset::VSI_to_tiledb_uri(poOpenInfo->pszFilename);
+
+    const auto eType = tiledb::Object::object(*(pCtxt.get()), osPath).type();
+
+    auto poSharedResource = std::make_shared<TileDBSharedResource>(
+        std::move(pCtxt), poOpenInfo->eAccess == GA_Update);
+
+    poSharedResource->SetDumpStats(CPLTestBool(
+        CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "STATS", "FALSE")));
+
+    const char *pszTimestamp =
+        CSLFetchNameValue(poOpenInfo->papszOpenOptions, "TILEDB_TIMESTAMP");
+    if (pszTimestamp)
+        poSharedResource->SetTimestamp(
+            std::strtoull(pszTimestamp, nullptr, 10));
+
+    std::shared_ptr<GDALGroup> poRG;
+    if (eType == tiledb::Object::Type::Array)
+    {
+        poRG = TileDBArrayGroup::Create(poSharedResource, osPath);
+    }
+    else
+    {
+        poRG = TileDBGroup::OpenFromDisk(poSharedResource, std::string(), "/",
+                                         osPath);
+    }
+    if (!poRG)
+        return nullptr;
+
+    auto poDS = new TileDBMultiDimDataset(poRG);
+    poDS->SetDescription(poOpenInfo->pszFilename);
+    return poDS;
+}
+
+/************************************************************************/
+/*                     CreateMultiDimensional()                         */
+/************************************************************************/
+
+GDALDataset *
+TileDBDataset::CreateMultiDimensional(const char *pszFilename,
+                                      CSLConstList /*papszRootGroupOptions*/,
+                                      CSLConstList papszOptions)
+{
+    const char *pszConfig = CSLFetchNameValue(papszOptions, "TILEDB_CONFIG");
+
+    std::unique_ptr<tiledb::Context> pCtxt;
+    if (pszConfig != nullptr)
+    {
+        tiledb::Config cfg(pszConfig);
+        pCtxt.reset(new tiledb::Context(cfg));
+    }
+    else
+    {
+        pCtxt.reset(new tiledb::Context());
+    }
+
+    const std::string osPath = TileDBDataset::VSI_to_tiledb_uri(pszFilename);
+
+    auto poSharedResource =
+        std::make_shared<TileDBSharedResource>(std::move(pCtxt), true);
+
+    poSharedResource->SetDumpStats(
+        CPLTestBool(CSLFetchNameValueDef(papszOptions, "STATS", "FALSE")));
+
+    const char *pszTimestamp =
+        CSLFetchNameValue(papszOptions, "TILEDB_TIMESTAMP");
+    if (pszTimestamp)
+        poSharedResource->SetTimestamp(
+            std::strtoull(pszTimestamp, nullptr, 10));
+
+    auto poRG =
+        TileDBGroup::CreateOnDisk(poSharedResource, std::string(), "/", osPath);
+    if (!poRG)
+        return nullptr;
+
+    auto poDS = new TileDBMultiDimDataset(poRG);
+    poDS->SetDescription(pszFilename);
+    return poDS;
+}
+
+#endif  // HAS_TILEDB_MULTIDIM

--- a/frmts/tiledb/tiledbmultidim.h
+++ b/frmts/tiledb/tiledbmultidim.h
@@ -1,0 +1,625 @@
+/******************************************************************************
+ *
+ * Project:  GDAL TileDB Driver
+ * Purpose:  Implement GDAL TileDB multidimensional support based on https://www.tiledb.io
+ * Author:   TileDB, Inc
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, TileDB, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef TILEDBMULTIDIM_H_INCLUDED
+#define TILEDBMULTIDIM_H_INCLUDED
+
+#include "tiledbheaders.h"
+
+#ifdef HAS_TILEDB_MULTIDIM
+
+constexpr const char *CRS_ATTRIBUTE_NAME = "_CRS";
+constexpr const char *UNIT_ATTRIBUTE_NAME = "_UNIT";
+constexpr const char *DIM_TYPE_ATTRIBUTE_NAME = "_DIM_TYPE";
+constexpr const char *DIM_DIRECTION_ATTRIBUTE_NAME = "_DIM_DIRECTION";
+
+/************************************************************************/
+/*                     TileDBSharedResource                            */
+/************************************************************************/
+
+class TileDBSharedResource
+{
+    std::unique_ptr<tiledb::Context> m_ctx{};
+    bool m_bUpdatable = false;
+    bool m_bStats = false;
+    uint64_t m_nTimestamp = 0;
+
+  public:
+    TileDBSharedResource(std::unique_ptr<tiledb::Context> &&ctx,
+                         bool bUpdatable)
+        : m_ctx(std::move(ctx)), m_bUpdatable(bUpdatable)
+    {
+    }
+
+    inline bool IsUpdatable() const
+    {
+        return m_bUpdatable;
+    }
+
+    inline tiledb::Context &GetCtx() const
+    {
+        return *(m_ctx.get());
+    }
+
+    static std::string SanitizeNameForPath(const std::string &osName);
+
+    void SetDumpStats(bool b)
+    {
+        m_bStats = b;
+    }
+
+    bool GetDumpStats() const
+    {
+        return m_bStats;
+    }
+
+    void SetTimestamp(uint64_t t)
+    {
+        m_nTimestamp = t;
+    }
+
+    uint64_t GetTimestamp() const
+    {
+        return m_nTimestamp;
+    }
+};
+
+/************************************************************************/
+/*                      TileDBAttributeHolder                           */
+/************************************************************************/
+
+class TileDBAttributeHolder
+{
+  private:
+    mutable std::map<std::string, std::shared_ptr<GDALAttribute>>
+        m_oMapAttributes{};
+
+    virtual uint64_t metadata_num() const = 0;
+    virtual void get_metadata_from_index(uint64_t index, std::string *key,
+                                         tiledb_datatype_t *value_type,
+                                         uint32_t *value_num,
+                                         const void **value) const = 0;
+    virtual bool has_metadata(const std::string &key,
+                              tiledb_datatype_t *value_type) const = 0;
+    virtual void get_metadata(const std::string &key,
+                              tiledb_datatype_t *value_type,
+                              uint32_t *value_num,
+                              const void **value) const = 0;
+    virtual void put_metadata(const std::string &key,
+                              tiledb_datatype_t value_type, uint32_t value_num,
+                              const void *value) = 0;
+    virtual void delete_metadata(const std::string &key) = 0;
+
+    virtual bool EnsureOpenAs(tiledb_query_type_t mode) const = 0;
+    virtual std::shared_ptr<TileDBAttributeHolder>
+    AsAttributeHolderSharedPtr() const = 0;
+
+    static std::shared_ptr<GDALAttribute>
+    CreateAttribute(const std::shared_ptr<TileDBAttributeHolder> &poSelf,
+                    const std::string &osName, tiledb_datatype_t value_type,
+                    uint32_t value_num, const void *value);
+
+  public:
+    virtual ~TileDBAttributeHolder() = 0;
+
+    virtual bool IIsWritable() const = 0;
+    virtual const std::string &IGetFullName() const = 0;
+
+    std::shared_ptr<GDALAttribute>
+    CreateAttributeImpl(const std::string &osName,
+                        const std::vector<GUInt64> &anDimensions,
+                        const GDALExtendedDataType &oDataType,
+                        CSLConstList papszOptions = nullptr);
+
+    std::shared_ptr<GDALAttribute>
+    GetAttributeImpl(const std::string &osName) const;
+
+    std::vector<std::shared_ptr<GDALAttribute>>
+    GetAttributesImpl(CSLConstList papszOptions = nullptr) const;
+
+    bool DeleteAttributeImpl(const std::string &osName,
+                             CSLConstList papszOptions = nullptr);
+
+    bool GetMetadata(const std::string &key, tiledb_datatype_t *value_type,
+                     uint32_t *value_num, const void **value) const;
+    bool PutMetadata(const std::string &key, tiledb_datatype_t value_type,
+                     uint32_t value_num, const void *value);
+};
+
+/************************************************************************/
+/*                          TileDBGroup                                 */
+/************************************************************************/
+
+class TileDBArray;
+
+class TileDBGroup final : public GDALGroup, public TileDBAttributeHolder
+{
+    std::shared_ptr<TileDBSharedResource> m_poSharedResource{};
+    const std::string m_osPath;
+    std::weak_ptr<TileDBGroup> m_pSelf{};
+    mutable std::unique_ptr<tiledb::Group> m_poTileDBGroup{};
+    mutable std::map<std::string, std::shared_ptr<TileDBGroup>> m_oMapGroups{};
+    mutable std::map<std::string, std::shared_ptr<TileDBArray>> m_oMapArrays{};
+    mutable std::map<std::string, std::shared_ptr<GDALDimension>>
+        m_oMapDimensions{};
+
+    TileDBGroup(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+                const std::string &osParentName, const std::string &osName,
+                const std::string &osPath)
+        : GDALGroup(osParentName, osName), m_poSharedResource(poSharedResource),
+          m_osPath(osPath)
+    {
+    }
+
+    static std::shared_ptr<TileDBGroup>
+    Create(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+           const std::string &osParentName, const std::string &osName,
+           const std::string &osPath)
+    {
+        auto poGroup = std::shared_ptr<TileDBGroup>(
+            new TileDBGroup(poSharedResource, osParentName, osName, osPath));
+        poGroup->m_pSelf = poGroup;
+        return poGroup;
+    }
+
+    bool HasObjectOfSameName(const std::string &osName) const;
+
+  protected:
+    // BEGIN: interfaces of TileDBAttributeHolder
+
+    bool EnsureOpenAs(tiledb_query_type_t mode) const override;
+
+    uint64_t metadata_num() const override
+    {
+        return m_poTileDBGroup->metadata_num();
+    }
+    void get_metadata_from_index(uint64_t index, std::string *key,
+                                 tiledb_datatype_t *value_type,
+                                 uint32_t *value_num,
+                                 const void **value) const override
+    {
+        m_poTileDBGroup->get_metadata_from_index(index, key, value_type,
+                                                 value_num, value);
+    }
+    bool has_metadata(const std::string &key,
+                      tiledb_datatype_t *value_type) const override
+    {
+        return m_poTileDBGroup->has_metadata(key, value_type);
+    }
+    void get_metadata(const std::string &key, tiledb_datatype_t *value_type,
+                      uint32_t *value_num, const void **value) const override
+    {
+        m_poTileDBGroup->get_metadata(key, value_type, value_num, value);
+    }
+    void put_metadata(const std::string &key, tiledb_datatype_t value_type,
+                      uint32_t value_num, const void *value) override
+    {
+        m_poTileDBGroup->put_metadata(key, value_type, value_num, value);
+    }
+    void delete_metadata(const std::string &key) override
+    {
+        m_poTileDBGroup->delete_metadata(key);
+    }
+    std::shared_ptr<TileDBAttributeHolder>
+    AsAttributeHolderSharedPtr() const override
+    {
+        return std::dynamic_pointer_cast<TileDBAttributeHolder>(m_pSelf.lock());
+    }
+
+    bool IIsWritable() const override
+    {
+        return m_poSharedResource->IsUpdatable();
+    }
+    const std::string &IGetFullName() const override
+    {
+        return GetFullName();
+    }
+
+    // END: interfaces of TileDBAttributeHolder
+
+  public:
+    ~TileDBGroup() override;
+
+    static std::shared_ptr<TileDBGroup>
+    CreateOnDisk(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+                 const std::string &osParentName, const std::string &osName,
+                 const std::string &osPath);
+
+    static std::shared_ptr<TileDBGroup>
+    OpenFromDisk(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+                 const std::string &osParentName, const std::string &osName,
+                 const std::string &osPath);
+
+    const std::string &GetPath() const
+    {
+        return m_osPath;
+    }
+
+    std::vector<std::string>
+    GetMDArrayNames(CSLConstList papszOptions = nullptr) const override;
+
+    std::vector<std::string>
+    GetGroupNames(CSLConstList papszOptions = nullptr) const override;
+
+    std::shared_ptr<GDALDimension>
+    CreateDimension(const std::string &osName, const std::string &osType,
+                    const std::string &osDirection, GUInt64 nSize,
+                    CSLConstList) override;
+
+    std::shared_ptr<GDALGroup>
+    CreateGroup(const std::string &osName,
+                CSLConstList papszOptions = nullptr) override;
+
+    std::shared_ptr<GDALGroup>
+    OpenGroup(const std::string &osName,
+              CSLConstList papszOptions = nullptr) const override;
+
+    std::shared_ptr<GDALMDArray> CreateMDArray(
+        const std::string &osName,
+        const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
+        const GDALExtendedDataType &oDataType,
+        CSLConstList papszOptions = nullptr) override;
+
+    std::shared_ptr<GDALMDArray>
+    OpenMDArray(const std::string &osName,
+                CSLConstList papszOptions = nullptr) const override;
+
+    bool AddMember(const std::string &osPath, const std::string &osName);
+
+    std::shared_ptr<GDALAttribute>
+    CreateAttribute(const std::string &osName,
+                    const std::vector<GUInt64> &anDimensions,
+                    const GDALExtendedDataType &oDataType,
+                    CSLConstList papszOptions = nullptr) override;
+
+    std::shared_ptr<GDALAttribute>
+    GetAttribute(const std::string &osName) const override;
+
+    std::vector<std::shared_ptr<GDALAttribute>>
+    GetAttributes(CSLConstList papszOptions = nullptr) const override;
+
+    bool DeleteAttribute(const std::string &osName,
+                         CSLConstList papszOptions = nullptr) override;
+};
+
+/************************************************************************/
+/*                          TileDBArray                                 */
+/************************************************************************/
+
+class TileDBArray final : public GDALMDArray, public TileDBAttributeHolder
+{
+    std::shared_ptr<TileDBSharedResource> m_poSharedResource{};
+    const std::vector<std::shared_ptr<GDALDimension>> m_aoDims;
+    const GDALExtendedDataType m_oType;
+    const std::string m_osPath;
+    std::vector<GUInt64> m_anBlockSize{};
+    // Starting offset of each dimension (if not zero)
+    std::vector<uint64_t> m_anStartDimOffset{};
+    mutable bool m_bFinalized = true;
+    mutable std::unique_ptr<tiledb::ArraySchema> m_poSchema{};
+
+    std::string m_osAttrName{};  // (TileDB) attribute name
+    mutable std::unique_ptr<tiledb::Attribute> m_poAttr{};
+    mutable std::unique_ptr<tiledb::Array> m_poTileDBArray{};
+    mutable std::vector<GByte> m_abyNoData{};
+    std::shared_ptr<OGRSpatialReference> m_poSRS{};
+    std::string m_osUnit{};
+    bool m_bStats = false;
+
+    // inclusive ending timestamp when opening this array
+    uint64_t m_nTimestamp = 0;
+
+    std::weak_ptr<TileDBGroup> m_poParent{};  // used for creation path
+    std::string m_osParentPath{};             // used for creation path
+    // used for creation path.
+    // To keep a reference on the indexing variables in CreateOnDisk(),
+    // so they are still alive at Finalize() time
+    std::vector<std::shared_ptr<GDALMDArray>> m_apoIndexingVariables{};
+
+    CPLStringList m_aosStructuralInfo{};
+
+    TileDBArray(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+                const std::string &osParentName, const std::string &osName,
+                const std::vector<std::shared_ptr<GDALDimension>> &aoDims,
+                const GDALExtendedDataType &oType, const std::string &osPath);
+
+    static std::shared_ptr<TileDBArray>
+    Create(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+           const std::string &osParentName, const std::string &osName,
+           const std::vector<std::shared_ptr<GDALDimension>> &aoDims,
+           const GDALExtendedDataType &oType, const std::string &osPath);
+
+    bool Finalize() const;
+
+  protected:
+    bool IRead(const GUInt64 *arrayStartIdx, const size_t *count,
+               const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+               const GDALExtendedDataType &bufferDataType,
+               void *pDstBuffer) const override;
+
+    bool IWrite(const GUInt64 *arrayStartIdx, const size_t *count,
+                const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+                const GDALExtendedDataType &bufferDataType,
+                const void *pSrcBuffer) override;
+
+    // BEGIN: interfaces of TileDBAttributeHolder
+
+    bool EnsureOpenAs(tiledb_query_type_t mode) const override;
+
+    uint64_t metadata_num() const override
+    {
+        return m_poTileDBArray->metadata_num();
+    }
+    void get_metadata_from_index(uint64_t index, std::string *key,
+                                 tiledb_datatype_t *value_type,
+                                 uint32_t *value_num,
+                                 const void **value) const override
+    {
+        m_poTileDBArray->get_metadata_from_index(index, key, value_type,
+                                                 value_num, value);
+    }
+    bool has_metadata(const std::string &key,
+                      tiledb_datatype_t *value_type) const override
+    {
+        return m_poTileDBArray->has_metadata(key, value_type);
+    }
+    void get_metadata(const std::string &key, tiledb_datatype_t *value_type,
+                      uint32_t *value_num, const void **value) const override
+    {
+        m_poTileDBArray->get_metadata(key, value_type, value_num, value);
+    }
+    void put_metadata(const std::string &key, tiledb_datatype_t value_type,
+                      uint32_t value_num, const void *value) override
+    {
+        m_poTileDBArray->put_metadata(key, value_type, value_num, value);
+    }
+    void delete_metadata(const std::string &key) override
+    {
+        m_poTileDBArray->delete_metadata(key);
+    }
+    std::shared_ptr<TileDBAttributeHolder>
+    AsAttributeHolderSharedPtr() const override
+    {
+        return std::dynamic_pointer_cast<TileDBAttributeHolder>(m_pSelf.lock());
+    }
+
+    bool IIsWritable() const override
+    {
+        return IsWritable();
+    }
+    const std::string &IGetFullName() const override
+    {
+        return GetFullName();
+    }
+
+    // END: interfaces of TileDBAttributeHolder
+
+  public:
+    ~TileDBArray() override;
+
+    static std::shared_ptr<TileDBArray>
+    OpenFromDisk(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+                 const std::string &osParentName, const std::string &osName,
+                 const std::string &osAttributeName, const std::string &osPath,
+                 CSLConstList papszOptions);
+
+    static std::shared_ptr<TileDBArray> CreateOnDisk(
+        const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+        const std::shared_ptr<TileDBGroup> &poParent, const std::string &osName,
+        const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
+        const GDALExtendedDataType &oDataType, CSLConstList papszOptions);
+
+    bool IsWritable() const override
+    {
+        return m_poSharedResource->IsUpdatable();
+    }
+
+    const std::string &GetFilename() const override
+    {
+        return m_osPath;
+    }
+
+    const std::vector<std::shared_ptr<GDALDimension>> &
+    GetDimensions() const override
+    {
+        return m_aoDims;
+    }
+
+    const GDALExtendedDataType &GetDataType() const override
+    {
+        return m_oType;
+    }
+
+    std::vector<GUInt64> GetBlockSize() const override
+    {
+        return m_anBlockSize;
+    }
+
+    const void *GetRawNoDataValue() const override;
+
+    bool SetRawNoDataValue(const void *pRawNoData) override;
+
+    std::shared_ptr<OGRSpatialReference> GetSpatialRef() const override
+    {
+        return m_poSRS;
+    }
+
+    bool SetSpatialRef(const OGRSpatialReference *poSRS) override;
+
+    const std::string &GetUnit() const override
+    {
+        return m_osUnit;
+    }
+
+    bool SetUnit(const std::string &osUnit) override;
+
+    CSLConstList GetStructuralInfo() const override;
+
+    std::shared_ptr<GDALAttribute>
+    CreateAttribute(const std::string &osName,
+                    const std::vector<GUInt64> &anDimensions,
+                    const GDALExtendedDataType &oDataType,
+                    CSLConstList papszOptions = nullptr) override;
+
+    std::shared_ptr<GDALAttribute>
+    GetAttribute(const std::string &osName) const override;
+
+    std::vector<std::shared_ptr<GDALAttribute>>
+    GetAttributes(CSLConstList papszOptions = nullptr) const override;
+
+    bool DeleteAttribute(const std::string &osName,
+                         CSLConstList papszOptions = nullptr) override;
+    static GDALDataType
+    TileDBDataTypeToGDALDataType(tiledb_datatype_t tiledb_dt);
+
+    static bool GDALDataTypeToTileDB(GDALDataType dt,
+                                     tiledb_datatype_t &tiledb_dt);
+};
+
+/************************************************************************/
+/*                       TileDBAttribute                                */
+/************************************************************************/
+
+// Caution: TileDBAttribute implements a GDAL multidim attribute, which
+// in TileDB terminology maps to a TileDB metadata item.
+class TileDBAttribute final : public GDALAttribute
+{
+    std::shared_ptr<GDALAttribute> m_poMemAttribute;
+    std::weak_ptr<TileDBAttributeHolder> m_poParent;
+
+    TileDBAttribute(const std::string &osParentName, const std::string &osName);
+
+  protected:
+    bool IRead(const GUInt64 *arrayStartIdx, const size_t *count,
+               const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+               const GDALExtendedDataType &bufferDataType,
+               void *pDstBuffer) const override;
+
+    bool IWrite(const GUInt64 *arrayStartIdx, const size_t *count,
+                const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+                const GDALExtendedDataType &bufferDataType,
+                const void *pSrcBuffer) override;
+
+    const std::vector<std::shared_ptr<GDALDimension>> &
+    GetDimensions() const override
+    {
+        return m_poMemAttribute->GetDimensions();
+    }
+
+    const GDALExtendedDataType &GetDataType() const override
+    {
+        return m_poMemAttribute->GetDataType();
+    }
+
+  public:
+    static std::shared_ptr<GDALAttribute>
+    Create(const std::shared_ptr<TileDBAttributeHolder> &poParent,
+           const std::string &osName, const std::vector<GUInt64> &anDimensions,
+           const GDALExtendedDataType &oDataType);
+};
+
+/************************************************************************/
+/*                           TileDBDimension                            */
+/************************************************************************/
+
+class TileDBDimension final : public GDALDimension
+{
+    // OK as a shared_ptr rather a weak_ptr, given that for the use we make
+    // of it, m_poIndexingVariable doesn't point to a TileDBDimension
+    std::shared_ptr<GDALMDArray> m_poIndexingVariable{};
+
+  public:
+    TileDBDimension(const std::string &osParentName, const std::string &osName,
+                    const std::string &osType, const std::string &osDirection,
+                    GUInt64 nSize)
+        : GDALDimension(osParentName, osName, osType, osDirection, nSize)
+    {
+    }
+
+    std::shared_ptr<GDALMDArray> GetIndexingVariable() const override
+    {
+        return m_poIndexingVariable;
+    }
+
+    void SetIndexingVariableOneTime(
+        const std::shared_ptr<GDALMDArray> &poIndexingVariable)
+    {
+        m_poIndexingVariable = poIndexingVariable;
+    }
+};
+
+/************************************************************************/
+/*                       TileDBArrayGroup                               */
+/************************************************************************/
+
+class TileDBArrayGroup final : public GDALGroup
+{
+    std::vector<std::shared_ptr<GDALMDArray>> m_apoArrays;
+
+  public:
+    TileDBArrayGroup(const std::vector<std::shared_ptr<GDALMDArray>> &apoArrays)
+        : GDALGroup(std::string(), "/"), m_apoArrays(apoArrays)
+    {
+    }
+
+    static std::shared_ptr<GDALGroup>
+    Create(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+           const std::string &osArrayPath);
+
+    std::vector<std::string>
+        GetMDArrayNames(CSLConstList /*papszOptions*/ = nullptr) const override;
+
+    std::shared_ptr<GDALMDArray>
+    OpenMDArray(const std::string &osName,
+                CSLConstList /*papszOptions*/ = nullptr) const override;
+};
+
+/************************************************************************/
+/*                     TileDBMultiDimDataset                            */
+/************************************************************************/
+
+class TileDBMultiDimDataset final : public GDALDataset
+{
+    friend class TileDBDataset;
+
+    std::shared_ptr<GDALGroup> m_poRG{};
+
+  public:
+    TileDBMultiDimDataset(const std::shared_ptr<GDALGroup> &poRG) : m_poRG(poRG)
+    {
+    }
+
+    std::shared_ptr<GDALGroup> GetRootGroup() const override
+    {
+        return m_poRG;
+    }
+};
+
+#endif  // HAS_TILEDB_MULTIDIM
+
+#endif  // TILEDBMULTIDIM_H_INCLUDED

--- a/frmts/tiledb/tiledbmultidimarray.cpp
+++ b/frmts/tiledb/tiledbmultidimarray.cpp
@@ -1,0 +1,1413 @@
+/******************************************************************************
+ *
+ * Project:  GDAL TileDB Driver
+ * Purpose:  Implement GDAL TileDB multidimensional support based on https://www.tiledb.io
+ * Author:   TileDB, Inc
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, TileDB, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "tiledbmultidim.h"
+
+#include <algorithm>
+#include <limits>
+
+#ifdef HAS_TILEDB_MULTIDIM
+
+/************************************************************************/
+/*                   TileDBArray::TileDBArray()                         */
+/************************************************************************/
+
+TileDBArray::TileDBArray(
+    const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+    const std::string &osParentName, const std::string &osName,
+    const std::vector<std::shared_ptr<GDALDimension>> &aoDims,
+    const GDALExtendedDataType &oType, const std::string &osPath)
+    : GDALAbstractMDArray(osParentName, osName),
+      GDALMDArray(osParentName, osName), m_poSharedResource(poSharedResource),
+      m_aoDims(aoDims), m_oType(oType), m_osPath(osPath),
+      m_bStats(poSharedResource->GetDumpStats())
+{
+}
+
+/************************************************************************/
+/*                   TileDBArray::Create()                              */
+/************************************************************************/
+
+/*static*/ std::shared_ptr<TileDBArray> TileDBArray::Create(
+    const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+    const std::string &osParentName, const std::string &osName,
+    const std::vector<std::shared_ptr<GDALDimension>> &aoDims,
+    const GDALExtendedDataType &oType, const std::string &osPath)
+{
+    auto poArray = std::shared_ptr<TileDBArray>(new TileDBArray(
+        poSharedResource, osParentName, osName, aoDims, oType, osPath));
+    poArray->SetSelf(poArray);
+    return poArray;
+}
+
+/************************************************************************/
+/*                   TileDBArray::~TileDBArray()                        */
+/************************************************************************/
+
+TileDBArray::~TileDBArray()
+{
+    if (!m_bFinalized)
+        Finalize();
+}
+
+/************************************************************************/
+/*                   BuildDimensionLabelName()                          */
+/************************************************************************/
+
+static std::string
+BuildDimensionLabelName(const std::shared_ptr<GDALDimension> &poDim)
+{
+    return poDim->GetName() + "_label";
+}
+
+/************************************************************************/
+/*                   TileDBDataTypeToGDALDataType()                     */
+/************************************************************************/
+
+/*static*/ GDALDataType
+TileDBArray::TileDBDataTypeToGDALDataType(tiledb_datatype_t tiledb_dt)
+{
+    GDALDataType eDT = GDT_Unknown;
+    switch (tiledb_dt)
+    {
+        case TILEDB_UINT8:
+            eDT = GDT_Byte;
+            break;
+
+        case TILEDB_INT8:
+            eDT = GDT_Int8;
+            break;
+
+        case TILEDB_UINT16:
+            eDT = GDT_UInt16;
+            break;
+
+        case TILEDB_INT16:
+            eDT = GDT_Int16;
+            break;
+
+        case TILEDB_UINT32:
+            eDT = GDT_UInt32;
+            break;
+
+        case TILEDB_INT32:
+            eDT = GDT_Int32;
+            break;
+
+        case TILEDB_UINT64:
+            eDT = GDT_UInt64;
+            break;
+
+        case TILEDB_INT64:
+            eDT = GDT_Int64;
+            break;
+
+        case TILEDB_FLOAT32:
+            eDT = GDT_Float32;
+            break;
+
+        case TILEDB_FLOAT64:
+            eDT = GDT_Float64;
+            break;
+
+        case TILEDB_CHAR:
+        case TILEDB_STRING_ASCII:
+        case TILEDB_STRING_UTF8:
+        case TILEDB_STRING_UTF16:
+        case TILEDB_STRING_UTF32:
+        case TILEDB_STRING_UCS2:
+        case TILEDB_STRING_UCS4:
+        case TILEDB_ANY:
+        case TILEDB_DATETIME_YEAR:
+        case TILEDB_DATETIME_MONTH:
+        case TILEDB_DATETIME_WEEK:
+        case TILEDB_DATETIME_DAY:
+        case TILEDB_DATETIME_HR:
+        case TILEDB_DATETIME_MIN:
+        case TILEDB_DATETIME_SEC:
+        case TILEDB_DATETIME_MS:
+        case TILEDB_DATETIME_US:
+        case TILEDB_DATETIME_NS:
+        case TILEDB_DATETIME_PS:
+        case TILEDB_DATETIME_FS:
+        case TILEDB_DATETIME_AS:
+        case TILEDB_TIME_HR:
+        case TILEDB_TIME_MIN:
+        case TILEDB_TIME_SEC:
+        case TILEDB_TIME_MS:
+        case TILEDB_TIME_US:
+        case TILEDB_TIME_NS:
+        case TILEDB_TIME_PS:
+        case TILEDB_TIME_FS:
+        case TILEDB_TIME_AS:
+        case TILEDB_BLOB:
+        case TILEDB_BOOL:
+        {
+            break;
+        }
+    }
+    return eDT;
+}
+
+/************************************************************************/
+/*                   TileDBArray::Finalize()                            */
+/************************************************************************/
+
+bool TileDBArray::Finalize() const
+{
+    if (m_bFinalized)
+        return m_poTileDBArray != nullptr;
+
+    m_bFinalized = true;
+
+    CPLAssert(m_poSchema);
+    CPLAssert(m_poAttr);
+
+    try
+    {
+        // TODO: set nodata as fill_value
+
+        m_poSchema->add_attribute(*(m_poAttr.get()));
+
+        tiledb::Array::create(m_osPath, *m_poSchema);
+
+        bool bAdded = false;
+        auto poGroup = m_poParent.lock();
+        if (!poGroup)
+        {
+            // Temporarily instanciate a TileDBGroup to call AddMember() on it
+            poGroup = TileDBGroup::OpenFromDisk(
+                m_poSharedResource,
+                /* osParentName = */ std::string(),
+                CPLGetFilename(m_osParentPath.c_str()), m_osParentPath);
+        }
+        if (poGroup)
+        {
+            bAdded = poGroup->AddMember(m_osPath, m_osName);
+        }
+        if (!bAdded)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Could not add array %s as a member of group %s",
+                     m_osName.c_str(), m_osParentPath.c_str());
+        }
+
+        auto &ctx = m_poSharedResource->GetCtx();
+        m_poTileDBArray =
+            std::make_unique<tiledb::Array>(ctx, m_osPath, TILEDB_READ);
+        if (m_nTimestamp > 0)
+            m_poTileDBArray->set_open_timestamp_end(m_nTimestamp);
+        m_poSchema =
+            std::make_unique<tiledb::ArraySchema>(m_poTileDBArray->schema());
+        m_poAttr.reset();
+
+        // Write dimension label values
+        for (const auto &poDim : m_aoDims)
+        {
+            auto poVar = poDim->GetIndexingVariable();
+            if (poVar)
+            {
+                const std::string osLabelName(BuildDimensionLabelName(poDim));
+                if (tiledb::ArraySchemaExperimental::has_dimension_label(
+                        ctx, *(m_poSchema.get()), osLabelName))
+                {
+                    auto label =
+                        tiledb::ArraySchemaExperimental::dimension_label(
+                            ctx, *(m_poSchema.get()), osLabelName);
+                    tiledb::Array labelArray(ctx, label.uri(), TILEDB_WRITE);
+                    auto label_attr = labelArray.schema().attribute(0);
+                    const auto eDT =
+                        TileDBDataTypeToGDALDataType(label_attr.type());
+                    if (eDT != GDT_Unknown)
+                    {
+                        std::vector<GByte> abyVals;
+                        abyVals.resize(static_cast<size_t>(
+                            poVar->GetDimensions()[0]->GetSize() *
+                            GDALGetDataTypeSizeBytes(eDT)));
+                        GUInt64 anStart[1] = {0};
+                        size_t anCount[1] = {static_cast<size_t>(
+                            poVar->GetDimensions()[0]->GetSize())};
+                        if (poVar->Read(anStart, anCount, nullptr, nullptr,
+                                        GDALExtendedDataType::Create(eDT),
+                                        abyVals.data()))
+                        {
+                            tiledb::Query query(ctx, labelArray);
+                            query.set_data_buffer(
+                                label_attr.name(),
+                                static_cast<void *>(abyVals.data()),
+                                anCount[0]);
+                            if (query.submit() !=
+                                tiledb::Query::Status::COMPLETE)
+                            {
+                                CPLError(CE_Failure, CPLE_AppDefined,
+                                         "Could not write values for dimension "
+                                         "label %s",
+                                         osLabelName.c_str());
+                            }
+
+                            if (!poDim->GetType().empty())
+                            {
+                                labelArray.put_metadata(
+                                    DIM_TYPE_ATTRIBUTE_NAME, TILEDB_STRING_UTF8,
+                                    static_cast<uint32_t>(
+                                        poDim->GetType().size()),
+                                    poDim->GetType().c_str());
+                            }
+
+                            if (!poDim->GetDirection().empty())
+                            {
+                                labelArray.put_metadata(
+                                    DIM_DIRECTION_ATTRIBUTE_NAME,
+                                    TILEDB_STRING_UTF8,
+                                    static_cast<uint32_t>(
+                                        poDim->GetDirection().size()),
+                                    poDim->GetDirection().c_str());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Array %s creation failed with: %s", m_osName.c_str(),
+                 e.what());
+        return false;
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                   TileDBArray::OpenFromDisk()                        */
+/************************************************************************/
+
+/* static */
+std::shared_ptr<TileDBArray> TileDBArray::OpenFromDisk(
+    const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+    const std::string &osParentName, const std::string &osName,
+    const std::string &osAttributeName, const std::string &osPath,
+    CSLConstList papszOptions)
+{
+    try
+    {
+        auto &ctx = poSharedResource->GetCtx();
+        uint64_t nTimestamp = poSharedResource->GetTimestamp();
+        const char *pszTimestamp =
+            CSLFetchNameValue(papszOptions, "TILEDB_TIMESTAMP");
+        if (pszTimestamp)
+            nTimestamp = std::strtoull(pszTimestamp, nullptr, 10);
+
+        auto poTileDBArray =
+            std::make_unique<tiledb::Array>(ctx, osPath, TILEDB_READ);
+        if (nTimestamp > 0)
+            poTileDBArray->set_open_timestamp_end(nTimestamp);
+
+        auto schema = poTileDBArray->schema();
+
+        if (schema.attribute_num() != 1 && osAttributeName.empty())
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Array %s has %u attributes. "
+                     "osAttributeName must be specified",
+                     osName.c_str(), schema.attribute_num());
+            return nullptr;
+        }
+
+        auto attr = osAttributeName.empty() ? schema.attribute(0)
+                                            : schema.attribute(osAttributeName);
+        GDALDataType eDT = TileDBDataTypeToGDALDataType(attr.type());
+        if (eDT == GDT_Unknown)
+        {
+            const char *pszTypeName = "";
+            tiledb_datatype_to_str(attr.type(), &pszTypeName);
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Array %s has type %s, which is unsupported",
+                     osName.c_str(), pszTypeName);
+            return nullptr;
+        }
+
+        if (attr.variable_sized())
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Variable sized attribute not supported");
+            return nullptr;
+        }
+        if (attr.cell_val_num() == 2)
+        {
+            if (attr.type() == TILEDB_INT16)
+                eDT = GDT_CInt16;
+            else if (attr.type() == TILEDB_INT32)
+                eDT = GDT_CInt32;
+            else if (attr.type() == TILEDB_FLOAT32)
+                eDT = GDT_CFloat32;
+            else if (attr.type() == TILEDB_FLOAT64)
+                eDT = GDT_CFloat64;
+            else
+            {
+                const char *pszTypeName = "";
+                tiledb_datatype_to_str(attr.type(), &pszTypeName);
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Attribute with number of values per cell = %u not "
+                         "supported for type %s",
+                         attr.cell_val_num(), pszTypeName);
+                return nullptr;
+            }
+        }
+        else if (attr.cell_val_num() != 1)
+        {
+            CPLError(
+                CE_Failure, CPLE_NotSupported,
+                "Attribute with number of values per cell = %u not supported",
+                attr.cell_val_num());
+            return nullptr;
+        }
+
+        // Compatibility with the 2D raster side: extract X_SIZE, Y_SIZE, SRS
+        // and geotransform
+        int nXSize = 0;
+        int nYSize = 0;
+        std::shared_ptr<OGRSpatialReference> poSRS;
+        double adfGeoTransform[6] = {0};
+        bool bHasGeoTransform = false;
+        {
+            tiledb_datatype_t value_type = TILEDB_ANY;
+            uint32_t value_num = 0;
+            const void *value = nullptr;
+            poTileDBArray->get_metadata(GDAL_ATTRIBUTE_NAME, &value_type,
+                                        &value_num, &value);
+            if (value && value_num && value_type == TILEDB_UINT8 &&
+                CPLIsUTF8(static_cast<const char *>(value), value_num))
+            {
+                std::string osXML;
+                osXML.assign(static_cast<const char *>(value), value_num);
+                CPLXMLNode *psRoot = CPLParseXMLString(osXML.c_str());
+                if (psRoot)
+                {
+                    const CPLXMLNode *psDataset =
+                        CPLGetXMLNode(psRoot, "=PAMDataset");
+                    if (psDataset)
+                    {
+                        for (const CPLXMLNode *psIter = psDataset->psChild;
+                             psIter; psIter = psIter->psNext)
+                        {
+                            if (psIter->eType == CXT_Element &&
+                                strcmp(psIter->pszValue, "Metadata") == 0 &&
+                                strcmp(CPLGetXMLValue(psIter, "domain", ""),
+                                       "IMAGE_STRUCTURE") == 0)
+                            {
+                                for (const CPLXMLNode *psIter2 =
+                                         psIter->psChild;
+                                     psIter2; psIter2 = psIter2->psNext)
+                                {
+                                    if (psIter2->eType == CXT_Element &&
+                                        strcmp(psIter2->pszValue, "MDI") == 0 &&
+                                        strcmp(
+                                            CPLGetXMLValue(psIter2, "key", ""),
+                                            "X_SIZE") == 0)
+                                    {
+                                        nXSize = atoi(CPLGetXMLValue(
+                                            psIter2, nullptr, "0"));
+                                    }
+                                    else if (psIter2->eType == CXT_Element &&
+                                             strcmp(psIter2->pszValue, "MDI") ==
+                                                 0 &&
+                                             strcmp(CPLGetXMLValue(psIter2,
+                                                                   "key", ""),
+                                                    "Y_SIZE") == 0)
+                                    {
+                                        nYSize = atoi(CPLGetXMLValue(
+                                            psIter2, nullptr, "0"));
+                                    }
+                                }
+                            }
+                        }
+
+                        const char *pszSRS =
+                            CPLGetXMLValue(psDataset, "SRS", nullptr);
+                        if (pszSRS)
+                        {
+                            poSRS = std::make_shared<OGRSpatialReference>();
+                            poSRS->SetAxisMappingStrategy(
+                                OAMS_TRADITIONAL_GIS_ORDER);
+                            if (poSRS->importFromWkt(pszSRS) != OGRERR_NONE)
+                            {
+                                poSRS.reset();
+                            }
+                        }
+
+                        const char *pszGeoTransform =
+                            CPLGetXMLValue(psDataset, "GeoTransform", nullptr);
+                        if (pszGeoTransform)
+                        {
+                            const CPLStringList aosTokens(
+                                CSLTokenizeString2(pszGeoTransform, ", ", 0));
+                            if (aosTokens.size() == 6)
+                            {
+                                bHasGeoTransform = true;
+                                for (int i = 0; i < 6; ++i)
+                                    adfGeoTransform[i] = CPLAtof(aosTokens[i]);
+                            }
+                        }
+                    }
+
+                    CPLDestroyXMLNode(psRoot);
+                }
+            }
+        }
+
+        // Read CRS from _CRS attribute otherwise
+        if (!poSRS)
+        {
+            tiledb_datatype_t value_type = TILEDB_ANY;
+            uint32_t value_num = 0;
+            const void *value = nullptr;
+            poTileDBArray->get_metadata(CRS_ATTRIBUTE_NAME, &value_type,
+                                        &value_num, &value);
+            if (value && value_num &&
+                (value_type == TILEDB_STRING_ASCII ||
+                 value_type == TILEDB_STRING_UTF8))
+            {
+                std::string osStr;
+                osStr.assign(static_cast<const char *>(value), value_num);
+                poSRS = std::make_shared<OGRSpatialReference>();
+                poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+                if (poSRS->SetFromUserInput(
+                        osStr.c_str(),
+                        OGRSpatialReference::
+                            SET_FROM_USER_INPUT_LIMITATIONS_get()) !=
+                    OGRERR_NONE)
+                {
+                    poSRS.reset();
+                }
+            }
+        }
+
+        // Read unit
+        std::string osUnit;
+        {
+            tiledb_datatype_t value_type = TILEDB_ANY;
+            uint32_t value_num = 0;
+            const void *value = nullptr;
+            poTileDBArray->get_metadata(UNIT_ATTRIBUTE_NAME, &value_type,
+                                        &value_num, &value);
+            if (value && value_num &&
+                (value_type == TILEDB_STRING_ASCII ||
+                 value_type == TILEDB_STRING_UTF8))
+            {
+                osUnit.assign(static_cast<const char *>(value), value_num);
+            }
+        }
+
+        // Read dimensions
+        std::vector<std::shared_ptr<GDALDimension>> aoDims;
+        const auto dims = schema.domain().dimensions();
+        std::vector<GUInt64> anBlockSize;
+        std::vector<uint64_t> anStartDimOffset;
+        const std::string osArrayFullName(
+            (osParentName == "/" ? std::string() : osParentName) + "/" +
+            osName);
+        for (size_t i = 0; i < dims.size(); ++i)
+        {
+            const auto &dim = dims[i];
+            if (dim.type() != TILEDB_UINT64)
+            {
+                const char *pszTypeName = "";
+                tiledb_datatype_to_str(dim.type(), &pszTypeName);
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Dimension %s of array %s has type %s, which is "
+                         "unsupported. Only UInt64 is supported",
+                         dim.name().c_str(), osName.c_str(), pszTypeName);
+                return nullptr;
+            }
+            const auto domain = dim.domain<uint64_t>();
+            anStartDimOffset.push_back(domain.first);
+            const uint64_t nSize = (i + 2 == dims.size() && nYSize > 0) ? nYSize
+                                   : (i + 1 == dims.size() && nXSize > 0)
+                                       ? nXSize
+                                       : domain.second - domain.first + 1;
+            std::string osType;
+            std::string osDirection;
+            auto poDim = std::make_shared<TileDBDimension>(
+                osArrayFullName, dim.name(), osType, osDirection, nSize);
+
+            const std::string osLabelName(BuildDimensionLabelName(poDim));
+            if (tiledb::ArraySchemaExperimental::has_dimension_label(
+                    ctx, schema, osLabelName))
+            {
+                auto label = tiledb::ArraySchemaExperimental::dimension_label(
+                    ctx, schema, osLabelName);
+                auto poIndexingVar = OpenFromDisk(
+                    poSharedResource, osArrayFullName, poDim->GetName(),
+                    /* osAttributeName = */ std::string(), label.uri(),
+                    /* papszOptions= */ nullptr);
+                if (poIndexingVar)
+                {
+                    auto poAttr =
+                        poIndexingVar->GetAttribute(DIM_TYPE_ATTRIBUTE_NAME);
+                    if (poAttr &&
+                        poAttr->GetDataType().GetClass() == GEDTC_STRING)
+                    {
+                        const char *pszVal = poAttr->ReadAsString();
+                        if (pszVal)
+                            osType = pszVal;
+                    }
+
+                    poAttr = poIndexingVar->GetAttribute(
+                        DIM_DIRECTION_ATTRIBUTE_NAME);
+                    if (poAttr &&
+                        poAttr->GetDataType().GetClass() == GEDTC_STRING)
+                    {
+                        const char *pszVal = poAttr->ReadAsString();
+                        if (pszVal)
+                            osDirection = pszVal;
+                    }
+
+                    if (!osType.empty() || !osDirection.empty())
+                    {
+                        // Recreate dimension with type and/or direction info
+                        poDim = std::make_shared<TileDBDimension>(
+                            osArrayFullName, dim.name(), osType, osDirection,
+                            nSize);
+                    }
+
+                    poDim->SetIndexingVariableOneTime(poIndexingVar);
+                }
+            }
+            if (bHasGeoTransform && !poDim->GetIndexingVariable() &&
+                i + 2 >= dims.size() && adfGeoTransform[2] == 0 &&
+                adfGeoTransform[4] == 0)
+            {
+                // Recreate dimension with type and/or direction info
+                if (i + 2 == dims.size())
+                {
+                    osType = GDAL_DIM_TYPE_HORIZONTAL_Y;
+                    osDirection = "NORTH";
+                }
+                else /* if( i + 1 == dims.size()) */
+                {
+                    osType = GDAL_DIM_TYPE_HORIZONTAL_X;
+                    osDirection = "EAST";
+                }
+                poDim = std::make_shared<TileDBDimension>(
+                    osArrayFullName, dim.name(), osType, osDirection, nSize);
+                // Do not create indexing variable with poDim, otherwise
+                // both dimension and indexing variable will have a shared_ptr
+                // to each other, causing memory leak
+                auto poDimTmp = std::make_shared<GDALDimension>(
+                    std::string(), dim.name(), /* osType = */ std::string(),
+                    /* osDirection = */ std::string(), nSize);
+                const double dfStart =
+                    (i + 2 == dims.size())
+                        ? adfGeoTransform[3] + adfGeoTransform[5] / 2
+                        : adfGeoTransform[0] + adfGeoTransform[1] / 2;
+                const double dfStep = (i + 2 == dims.size())
+                                          ? adfGeoTransform[5]
+                                          : adfGeoTransform[1];
+                poDim->SetIndexingVariableOneTime(
+                    GDALMDArrayRegularlySpaced::Create(
+                        osArrayFullName, poDim->GetName(), poDimTmp, dfStart,
+                        dfStep, 0));
+            }
+
+            aoDims.emplace_back(std::move(poDim));
+            anBlockSize.push_back(dim.tile_extent<uint64_t>());
+        }
+
+        // Set SRS DataAxisToSRSAxisMapping
+        if (poSRS)
+        {
+            int iDimX = 0;
+            int iDimY = 0;
+            int iCount = 1;
+            for (const auto &poDim : aoDims)
+            {
+                if (poDim->GetType() == GDAL_DIM_TYPE_HORIZONTAL_X)
+                    iDimX = iCount;
+                else if (poDim->GetType() == GDAL_DIM_TYPE_HORIZONTAL_Y)
+                    iDimY = iCount;
+                iCount++;
+            }
+            if ((iDimX == 0 || iDimY == 0) && aoDims.size() >= 2)
+            {
+                iDimX = static_cast<int>(aoDims.size());
+                iDimY = iDimX - 1;
+            }
+            if (iDimX > 0 && iDimY > 0)
+            {
+                if (poSRS->GetDataAxisToSRSAxisMapping() ==
+                    std::vector<int>{2, 1})
+                    poSRS->SetDataAxisToSRSAxisMapping({iDimY, iDimX});
+                else if (poSRS->GetDataAxisToSRSAxisMapping() ==
+                         std::vector<int>{1, 2})
+                    poSRS->SetDataAxisToSRSAxisMapping({iDimX, iDimY});
+            }
+        }
+
+        GDALExtendedDataType oType = GDALExtendedDataType::Create(eDT);
+        auto poArray = Create(poSharedResource, osParentName, osName, aoDims,
+                              oType, osPath);
+        poArray->m_poTileDBArray = std::move(poTileDBArray);
+        poArray->m_poSchema = std::make_unique<tiledb::ArraySchema>(
+            poArray->m_poTileDBArray->schema());
+        poArray->m_anBlockSize = std::move(anBlockSize);
+        poArray->m_anStartDimOffset = std::move(anStartDimOffset);
+        poArray->m_osAttrName = attr.name();
+        poArray->m_osUnit = osUnit;
+        poArray->m_poSRS = poSRS;
+        poArray->m_nTimestamp = nTimestamp;
+
+        const auto filters = attr.filter_list();
+        std::string osFilters;
+        for (uint32_t j = 0; j < filters.nfilters(); ++j)
+        {
+            const auto filter = filters.filter(j);
+            if (j > 0)
+                osFilters += ',';
+            osFilters += tiledb::Filter::to_str(filter.filter_type());
+        }
+        if (!osFilters.empty())
+        {
+            poArray->m_aosStructuralInfo.SetNameValue("FILTER_LIST",
+                                                      osFilters.c_str());
+        }
+
+        return poArray;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "OpenFromDisk() failed with: %s",
+                 e.what());
+        return nullptr;
+    }
+}
+
+/************************************************************************/
+/*                   TileDBArray::EnsureOpenAs()                        */
+/************************************************************************/
+
+bool TileDBArray::EnsureOpenAs(tiledb_query_type_t mode) const
+{
+    if (!m_bFinalized && !Finalize())
+        return false;
+    if (!m_poTileDBArray)
+        return false;
+    if (m_poTileDBArray->query_type() == mode && m_poTileDBArray->is_open())
+        return true;
+    try
+    {
+        m_poTileDBArray->close();
+        m_poTileDBArray->open(mode);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        m_poTileDBArray.reset();
+        return false;
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                          TileDBArray::IRead()                        */
+/************************************************************************/
+
+bool TileDBArray::IRead(const GUInt64 *arrayStartIdx, const size_t *count,
+                        const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+                        const GDALExtendedDataType &bufferDataType,
+                        void *pDstBuffer) const
+{
+    if (!EnsureOpenAs(TILEDB_READ))
+        return false;
+
+    if (!IsStepOneContiguousRowMajorOrderedSameDataType(
+            count, arrayStep, bufferStride, bufferDataType))
+    {
+        return ReadUsingContiguousIRead(arrayStartIdx, count, arrayStep,
+                                        bufferStride, bufferDataType,
+                                        pDstBuffer);
+    }
+    else
+    {
+        std::vector<uint64_t> anSubArray;
+        const auto nDims = m_aoDims.size();
+        anSubArray.reserve(2 * nDims);
+        size_t nBufferSize =
+            GDALDataTypeIsComplex(m_oType.GetNumericDataType()) ? 2 : 1;
+        for (size_t i = 0; i < nDims; ++i)
+        {
+            anSubArray.push_back(m_anStartDimOffset[i] + arrayStartIdx[i]);
+            anSubArray.push_back(m_anStartDimOffset[i] + arrayStartIdx[i] +
+                                 count[i] - 1);
+            nBufferSize *= count[i];
+        }
+        try
+        {
+            tiledb::Query query(m_poSharedResource->GetCtx(),
+                                *(m_poTileDBArray.get()));
+            query.set_subarray(anSubArray);
+            query.set_data_buffer(m_osAttrName, pDstBuffer, nBufferSize);
+
+            if (m_bStats)
+                tiledb::Stats::enable();
+
+            const auto ret = query.submit();
+
+            if (m_bStats)
+            {
+                tiledb::Stats::dump(stdout);
+                tiledb::Stats::disable();
+            }
+
+            return ret == tiledb::Query::Status::COMPLETE;
+        }
+        catch (const std::exception &e)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Read() failed with %s",
+                     e.what());
+        }
+    }
+
+    return false;
+}
+
+/************************************************************************/
+/*                          TileDBArray::IWrite()                       */
+/************************************************************************/
+
+bool TileDBArray::IWrite(const GUInt64 *arrayStartIdx, const size_t *count,
+                         const GInt64 *arrayStep,
+                         const GPtrDiff_t *bufferStride,
+                         const GDALExtendedDataType &bufferDataType,
+                         const void *pSrcBuffer)
+{
+    if (!IsWritable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return false;
+    }
+
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return false;
+
+    if (!IsStepOneContiguousRowMajorOrderedSameDataType(
+            count, arrayStep, bufferStride, bufferDataType))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Write parameters not supported");
+        return false;
+    }
+    else
+    {
+        std::vector<uint64_t> anSubArray;
+        const auto nDims = m_aoDims.size();
+        anSubArray.reserve(2 * nDims);
+        size_t nBufferSize =
+            GDALDataTypeIsComplex(m_oType.GetNumericDataType()) ? 2 : 1;
+        for (size_t i = 0; i < nDims; ++i)
+        {
+            anSubArray.push_back(m_anStartDimOffset[i] + arrayStartIdx[i]);
+            anSubArray.push_back(m_anStartDimOffset[i] + arrayStartIdx[i] +
+                                 count[i] - 1);
+            nBufferSize *= count[i];
+        }
+        try
+        {
+            tiledb::Query query(m_poSharedResource->GetCtx(),
+                                *(m_poTileDBArray.get()));
+            query.set_subarray(anSubArray);
+            query.set_data_buffer(m_osAttrName, const_cast<void *>(pSrcBuffer),
+                                  nBufferSize);
+
+            return query.submit() == tiledb::Query::Status::COMPLETE;
+        }
+        catch (const std::exception &e)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Write() failed with %s",
+                     e.what());
+        }
+    }
+
+    return false;
+}
+
+/************************************************************************/
+/*                  TileDBArray::GetRawNoDataValue()                    */
+/************************************************************************/
+
+const void *TileDBArray::GetRawNoDataValue() const
+{
+    if (!m_bFinalized)
+        return nullptr;
+
+    if (m_abyNoData.empty())
+    {
+        const void *value = nullptr;
+        uint64_t size = 0;
+        // Caution: 2 below statements must not be combined in a single one,
+        // as the lifetime of value is linked to the return value of
+        // attribute()
+        auto attr = m_poSchema->attribute(m_osAttrName);
+        attr.get_fill_value(&value, &size);
+        if (size == m_oType.GetSize())
+        {
+            m_abyNoData.resize(size);
+            memcpy(m_abyNoData.data(), value, size);
+        }
+    }
+
+    return m_abyNoData.empty() ? nullptr : m_abyNoData.data();
+}
+
+/************************************************************************/
+/*                  TileDBArray::SetRawNoDataValue()                    */
+/************************************************************************/
+
+bool TileDBArray::SetRawNoDataValue(const void *pRawNoData)
+{
+    if (m_bFinalized)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "SetRawNoDataValue() not supported after array has been "
+                 "finalized.");
+        return false;
+    }
+
+    if (pRawNoData)
+    {
+        CPLAssert(m_poAttr);
+        m_poAttr->set_fill_value(pRawNoData, m_oType.GetSize());
+        m_abyNoData.resize(m_oType.GetSize());
+        memcpy(m_abyNoData.data(), pRawNoData, m_oType.GetSize());
+    }
+
+    Finalize();
+
+    return true;
+}
+
+/************************************************************************/
+/*                  TileDBArray::CreateAttribute()                      */
+/************************************************************************/
+
+std::shared_ptr<GDALAttribute> TileDBArray::CreateAttribute(
+    const std::string &osName, const std::vector<GUInt64> &anDimensions,
+    const GDALExtendedDataType &oDataType, CSLConstList papszOptions)
+{
+    return CreateAttributeImpl(osName, anDimensions, oDataType, papszOptions);
+}
+
+/************************************************************************/
+/*                   TileDBArray::GetAttribute()                        */
+/************************************************************************/
+
+std::shared_ptr<GDALAttribute>
+TileDBArray::GetAttribute(const std::string &osName) const
+{
+    return GetAttributeImpl(osName);
+}
+
+/************************************************************************/
+/*                   TileDBArray::GetAttributes()                       */
+/************************************************************************/
+
+std::vector<std::shared_ptr<GDALAttribute>>
+TileDBArray::GetAttributes(CSLConstList papszOptions) const
+{
+    return GetAttributesImpl(papszOptions);
+}
+
+/************************************************************************/
+/*                   TileDBArray::DeleteAttribute()                     */
+/************************************************************************/
+
+bool TileDBArray::DeleteAttribute(const std::string &osName,
+                                  CSLConstList papszOptions)
+{
+    return DeleteAttributeImpl(osName, papszOptions);
+}
+
+/************************************************************************/
+/*                   TileDBArray::SetSpatialRef()                       */
+/************************************************************************/
+
+bool TileDBArray::SetSpatialRef(const OGRSpatialReference *poSRS)
+{
+    if (!IsWritable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return false;
+    }
+
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return false;
+
+    try
+    {
+        if (m_poSRS && !poSRS)
+            m_poTileDBArray->delete_metadata(CRS_ATTRIBUTE_NAME);
+
+        m_poSRS.reset();
+        if (poSRS)
+        {
+            m_poSRS.reset(poSRS->Clone());
+
+            char *pszPROJJSON = nullptr;
+            if (m_poSRS->exportToPROJJSON(&pszPROJJSON, nullptr) ==
+                    OGRERR_NONE &&
+                pszPROJJSON != nullptr)
+            {
+                m_poTileDBArray->put_metadata(
+                    CRS_ATTRIBUTE_NAME, TILEDB_STRING_UTF8,
+                    static_cast<uint32_t>(strlen(pszPROJJSON)), pszPROJJSON);
+                CPLFree(pszPROJJSON);
+            }
+            else
+            {
+                CPLFree(pszPROJJSON);
+                return false;
+            }
+        }
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "SetSpatialRef() failed with: %s",
+                 e.what());
+        return false;
+    }
+}
+
+/************************************************************************/
+/*                       TileDBArray::SetUnit()                         */
+/************************************************************************/
+
+bool TileDBArray::SetUnit(const std::string &osUnit)
+{
+    if (!IsWritable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return false;
+    }
+
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return false;
+
+    try
+    {
+        if (!m_osUnit.empty() && osUnit.empty())
+            m_poTileDBArray->delete_metadata(UNIT_ATTRIBUTE_NAME);
+
+        m_osUnit = osUnit;
+        if (!osUnit.empty())
+        {
+            m_poTileDBArray->put_metadata(
+                UNIT_ATTRIBUTE_NAME, TILEDB_STRING_UTF8,
+                static_cast<uint32_t>(osUnit.size()), osUnit.data());
+        }
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "SetUnit() failed with: %s",
+                 e.what());
+        return false;
+    }
+}
+
+/************************************************************************/
+/*                          FillBlockSize()                             */
+/************************************************************************/
+
+static bool
+FillBlockSize(const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
+              const GDALExtendedDataType &oDataType,
+              std::vector<GUInt64> &anBlockSize, CSLConstList papszOptions)
+{
+    const auto nDims = aoDimensions.size();
+    anBlockSize.resize(nDims);
+    for (size_t i = 0; i < nDims; ++i)
+        anBlockSize[i] = 1;
+    if (nDims >= 2)
+    {
+        anBlockSize[nDims - 2] =
+            std::min(std::max<GUInt64>(1, aoDimensions[nDims - 2]->GetSize()),
+                     static_cast<GUInt64>(256));
+        anBlockSize[nDims - 1] =
+            std::min(std::max<GUInt64>(1, aoDimensions[nDims - 1]->GetSize()),
+                     static_cast<GUInt64>(256));
+    }
+    else if (nDims == 1)
+    {
+        anBlockSize[0] = std::max<GUInt64>(1, aoDimensions[0]->GetSize());
+    }
+
+    const char *pszBlockSize = CSLFetchNameValue(papszOptions, "BLOCKSIZE");
+    if (pszBlockSize)
+    {
+        const auto aszTokens(
+            CPLStringList(CSLTokenizeString2(pszBlockSize, ",", 0)));
+        if (static_cast<size_t>(aszTokens.size()) != nDims)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Invalid number of values in BLOCKSIZE");
+            return false;
+        }
+        size_t nBlockSize = oDataType.GetSize();
+        for (size_t i = 0; i < nDims; ++i)
+        {
+            anBlockSize[i] = static_cast<GUInt64>(CPLAtoGIntBig(aszTokens[i]));
+            if (anBlockSize[i] == 0)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Values in BLOCKSIZE should be > 0");
+                return false;
+            }
+            if (anBlockSize[i] >
+                std::numeric_limits<size_t>::max() / nBlockSize)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Too large values in BLOCKSIZE");
+                return false;
+            }
+            nBlockSize *= static_cast<size_t>(anBlockSize[i]);
+        }
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                 TileDBArray::GDALDataTypeToTileDB()                  */
+/************************************************************************/
+
+/*static*/ bool TileDBArray::GDALDataTypeToTileDB(GDALDataType dt,
+                                                  tiledb_datatype_t &tiledb_dt)
+{
+    switch (dt)
+    {
+        case GDT_Byte:
+            tiledb_dt = TILEDB_UINT8;
+            break;
+        case GDT_Int8:
+            tiledb_dt = TILEDB_INT8;
+            break;
+        case GDT_UInt16:
+            tiledb_dt = TILEDB_UINT16;
+            break;
+        case GDT_CInt16:
+        case GDT_Int16:
+            tiledb_dt = TILEDB_INT16;
+            break;
+        case GDT_UInt32:
+            tiledb_dt = TILEDB_UINT32;
+            break;
+        case GDT_CInt32:
+        case GDT_Int32:
+            tiledb_dt = TILEDB_INT32;
+            break;
+        case GDT_UInt64:
+            tiledb_dt = TILEDB_UINT64;
+            break;
+        case GDT_Int64:
+            tiledb_dt = TILEDB_INT64;
+            break;
+        case GDT_CFloat32:
+        case GDT_Float32:
+            tiledb_dt = TILEDB_FLOAT32;
+            break;
+        case GDT_CFloat64:
+        case GDT_Float64:
+            tiledb_dt = TILEDB_FLOAT64;
+            break;
+
+        case GDT_Unknown:
+        case GDT_TypeCount:
+        {
+            CPLError(CE_Failure, CPLE_NotSupported, "Unsupported data type: %s",
+                     GDALGetDataTypeName(dt));
+            return false;
+        }
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                 IsIncreasingOrDecreasing1DVar()                      */
+/************************************************************************/
+
+static void
+IsIncreasingOrDecreasing1DVar(const std::shared_ptr<GDALMDArray> &poVar,
+                              bool &bIncreasing, bool &bDecreasing)
+{
+    bIncreasing = false;
+    bDecreasing = false;
+    std::vector<double> adfVals;
+    try
+    {
+        adfVals.resize(
+            static_cast<size_t>(poVar->GetDimensions()[0]->GetSize()));
+    }
+    catch (const std::exception &)
+    {
+    }
+    if (adfVals.size() > 1)
+    {
+        GUInt64 anStart[1] = {0};
+        size_t anCount[1] = {adfVals.size()};
+        if (poVar->Read(anStart, anCount, nullptr, nullptr,
+                        GDALExtendedDataType::Create(GDT_Float64),
+                        adfVals.data()))
+        {
+            if (adfVals[1] > adfVals[0])
+                bIncreasing = true;
+            else if (adfVals[1] < adfVals[0])
+                bDecreasing = true;
+            if (bIncreasing || bDecreasing)
+            {
+                for (size_t i = 2; i < adfVals.size(); ++i)
+                {
+                    if (bIncreasing)
+                    {
+                        if (!(adfVals[i] > adfVals[i - 1]))
+                        {
+                            bIncreasing = false;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (!(adfVals[i] < adfVals[i - 1]))
+                        {
+                            bDecreasing = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/************************************************************************/
+/*                   TileDBArray::CreateOnDisk()                        */
+/************************************************************************/
+
+/* static */
+std::shared_ptr<TileDBArray> TileDBArray::CreateOnDisk(
+    const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+    const std::shared_ptr<TileDBGroup> &poParent, const std::string &osName,
+    const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
+    const GDALExtendedDataType &oDataType, CSLConstList papszOptions)
+{
+    if (aoDimensions.empty())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Zero-dimensions arrays are not supported by TileDB");
+        return nullptr;
+    }
+
+    tiledb_datatype_t tiledb_dt = TILEDB_ANY;
+    if (oDataType.GetClass() != GEDTC_NUMERIC)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Only numeric data types are supported");
+        return nullptr;
+    }
+    if (!GDALDataTypeToTileDB(oDataType.GetNumericDataType(), tiledb_dt))
+        return nullptr;
+
+    try
+    {
+        const auto osSanitizedName =
+            TileDBSharedResource::SanitizeNameForPath(osName);
+        if (osSanitizedName.empty() || osName.find("./") == 0 ||
+            osName.find("../") == 0 || osName.find(".\\") == 0 ||
+            osName.find("..\\") == 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Invalid array name");
+            return nullptr;
+        }
+        std::string osArrayPath = poParent->GetPath() + "/" + osSanitizedName;
+        const char *pszURI = CSLFetchNameValue(papszOptions, "URI");
+        if (pszURI)
+            osArrayPath = pszURI;
+
+        auto &ctx = poSharedResource->GetCtx();
+        tiledb::VFS vfs(ctx);
+        if (vfs.is_dir(osArrayPath))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Path %s already exists",
+                     osArrayPath.c_str());
+            return nullptr;
+        }
+
+        std::vector<GUInt64> anBlockSize;
+        if (!FillBlockSize(aoDimensions, oDataType, anBlockSize, papszOptions))
+            return nullptr;
+
+        auto poSchema =
+            std::make_unique<tiledb::ArraySchema>(ctx, TILEDB_DENSE);
+        poSchema->set_tile_order(TILEDB_ROW_MAJOR);
+        poSchema->set_cell_order(TILEDB_ROW_MAJOR);
+
+        tiledb::FilterList filterList(ctx);
+        const char *pszCompression =
+            CSLFetchNameValue(papszOptions, "COMPRESSION");
+        const char *pszCompressionLevel =
+            CSLFetchNameValue(papszOptions, "COMPRESSION_LEVEL");
+
+        if (pszCompression != nullptr)
+        {
+            int nLevel = (pszCompressionLevel) ? atoi(pszCompressionLevel) : -1;
+            if (TileDBDataset::AddFilter(ctx, filterList, pszCompression,
+                                         nLevel) != CE_None)
+            {
+                return nullptr;
+            }
+        }
+        poSchema->set_coords_filter_list(filterList);
+
+        tiledb::Domain domain(ctx);
+        for (size_t i = 0; i < aoDimensions.size(); ++i)
+        {
+            const auto &poDim = aoDimensions[i];
+            if (poDim->GetSize() == 0)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined, "Invalid dim size: 0");
+                return nullptr;
+            }
+            auto dim = tiledb::Dimension::create<uint64_t>(
+                ctx, poDim->GetName(), {0, poDim->GetSize() - 1},
+                anBlockSize[i]);
+            domain.add_dimension(std::move(dim));
+        }
+
+        poSchema->set_domain(domain);
+
+        std::vector<std::shared_ptr<GDALMDArray>> apoIndexingVariables;
+        for (size_t i = 0; i < aoDimensions.size(); ++i)
+        {
+            const auto &poDim = aoDimensions[i];
+            auto poIndexingVar = poDim->GetIndexingVariable();
+            bool bDimLabelCreated = false;
+            tiledb_datatype_t dim_label_tiledb_dt = TILEDB_ANY;
+            if (poIndexingVar && poIndexingVar->GetDimensionCount() == 1 &&
+                poIndexingVar->GetDataType().GetClass() == GEDTC_NUMERIC &&
+                poIndexingVar->GetDimensions()[0]->GetName() ==
+                    poDim->GetName() &&
+                poIndexingVar->GetDimensions()[0]->GetSize() <
+                    10 * 1024 * 1024 &&
+                !GDALDataTypeIsComplex(
+                    poIndexingVar->GetDataType().GetNumericDataType()) &&
+                GDALDataTypeToTileDB(
+                    poIndexingVar->GetDataType().GetNumericDataType(),
+                    dim_label_tiledb_dt))
+            {
+                bool bIncreasing = false;
+                bool bDecreasing = false;
+                IsIncreasingOrDecreasing1DVar(poIndexingVar, bIncreasing,
+                                              bDecreasing);
+                if (bIncreasing || bDecreasing)
+                {
+                    bDimLabelCreated = true;
+                    apoIndexingVariables.push_back(poIndexingVar);
+                    tiledb::ArraySchemaExperimental::add_dimension_label(
+                        ctx, *(poSchema.get()), static_cast<uint32_t>(i),
+                        BuildDimensionLabelName(poDim),
+                        bIncreasing ? TILEDB_INCREASING_DATA
+                                    : TILEDB_DECREASING_DATA,
+                        dim_label_tiledb_dt,
+                        std::optional<tiledb::FilterList>(filterList));
+                }
+            }
+            if (poIndexingVar && !bDimLabelCreated)
+            {
+                CPLDebug("TILEDB",
+                         "Dimension %s has indexing variable %s, "
+                         "but not compatible of a dimension label",
+                         poDim->GetName().c_str(),
+                         poIndexingVar->GetName().c_str());
+            }
+        }
+
+        auto attr = std::make_unique<tiledb::Attribute>(
+            tiledb::Attribute::create(ctx, TILEDB_VALUES, tiledb_dt));
+        if (GDALDataTypeIsComplex(oDataType.GetNumericDataType()))
+            attr->set_cell_val_num(2);
+        attr->set_filter_list(filterList);
+
+        // Implement a defered TileDB array creation given that we might
+        // need to set the fill value of the attribute from the nodata value
+        auto poArray = Create(poSharedResource, poParent->GetFullName(), osName,
+                              aoDimensions, oDataType, osArrayPath);
+        poArray->m_bFinalized = false;
+        poArray->m_poParent = poParent;
+        poArray->m_osParentPath = poParent->GetPath();
+        poArray->m_poSchema = std::move(poSchema);
+        poArray->m_osAttrName = attr->name();
+        poArray->m_poAttr = std::move(attr);
+        poArray->m_anBlockSize = anBlockSize;
+        poArray->m_anStartDimOffset.resize(aoDimensions.size());
+        // To keep a reference on the indexing variables, so they are still
+        // alive at Finalize() time
+        poArray->m_apoIndexingVariables = std::move(apoIndexingVariables);
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "STATS", "FALSE")))
+            poArray->m_bStats = true;
+
+        uint64_t nTimestamp = poSharedResource->GetTimestamp();
+        const char *pszTimestamp =
+            CSLFetchNameValue(papszOptions, "TILEDB_TIMESTAMP");
+        if (pszTimestamp)
+            nTimestamp = std::strtoull(pszTimestamp, nullptr, 10);
+        poArray->m_nTimestamp = nTimestamp;
+
+        return poArray;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "CreateMDArray() failed with: %s",
+                 e.what());
+        return nullptr;
+    }
+}
+
+/************************************************************************/
+/*                    TileDBArray::GetStructuralInfo()                  */
+/************************************************************************/
+
+CSLConstList TileDBArray::GetStructuralInfo() const
+{
+    return m_aosStructuralInfo.List();
+}
+
+#endif  // HAS_TILEDB_MULTIDIM

--- a/frmts/tiledb/tiledbmultidimarray.cpp
+++ b/frmts/tiledb/tiledbmultidimarray.cpp
@@ -1361,7 +1361,7 @@ std::shared_ptr<TileDBArray> TileDBArray::CreateOnDisk(
         }
 
         auto attr = std::make_unique<tiledb::Attribute>(
-            tiledb::Attribute::create(ctx, TILEDB_VALUES, tiledb_dt));
+            tiledb::Attribute::create(ctx, osName, tiledb_dt));
         if (GDALDataTypeIsComplex(oDataType.GetNumericDataType()))
             attr->set_cell_val_num(2);
         attr->set_filter_list(filterList);

--- a/frmts/tiledb/tiledbmultidimattribute.cpp
+++ b/frmts/tiledb/tiledbmultidimattribute.cpp
@@ -1,0 +1,203 @@
+/******************************************************************************
+ *
+ * Project:  GDAL TileDB Driver
+ * Purpose:  Implement GDAL TileDB multidimensional support based on https://www.tiledb.io
+ * Author:   TileDB, Inc
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, TileDB, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "tiledbmultidim.h"
+#include "memmultidim.h"
+
+#ifdef HAS_TILEDB_MULTIDIM
+
+/************************************************************************/
+/*                TileDBAttribute::TileDBAttribute()                    */
+/************************************************************************/
+
+TileDBAttribute::TileDBAttribute(const std::string &osParentName,
+                                 const std::string &osName)
+    : GDALAbstractMDArray(osParentName, osName),
+      GDALAttribute(osParentName, osName)
+{
+}
+
+/************************************************************************/
+/*                TileDBAttribute::Create()                             */
+/************************************************************************/
+
+/*static*/ std::shared_ptr<GDALAttribute>
+TileDBAttribute::Create(const std::shared_ptr<TileDBAttributeHolder> &poParent,
+                        const std::string &osName,
+                        const std::vector<GUInt64> &anDimensions,
+                        const GDALExtendedDataType &oDataType)
+{
+    if (anDimensions.size() > 1)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Only 0 or 1-dimensional attribute are supported");
+        return nullptr;
+    }
+    if (oDataType.GetClass() == GEDTC_STRING)
+    {
+        if (anDimensions.size() == 1 && anDimensions[0] != 1)
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Only single value string attribute are supported");
+            return nullptr;
+        }
+    }
+    else if (oDataType.GetClass() == GEDTC_COMPOUND)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Compound data type attribute are not supported");
+        return nullptr;
+    }
+
+    auto poAttr = std::shared_ptr<TileDBAttribute>(
+        new TileDBAttribute(poParent->IGetFullName(), osName));
+    poAttr->m_poMemAttribute = MEMAttribute::Create(
+        poParent->IGetFullName(), osName, anDimensions, oDataType);
+    if (!poAttr->m_poMemAttribute)
+        return nullptr;
+    poAttr->m_poParent = poParent;
+    return poAttr;
+}
+
+/************************************************************************/
+/*                     TileDBAttribute::IRead()                         */
+/************************************************************************/
+
+bool TileDBAttribute::IRead(const GUInt64 *arrayStartIdx, const size_t *count,
+                            const GInt64 *arrayStep,
+                            const GPtrDiff_t *bufferStride,
+                            const GDALExtendedDataType &bufferDataType,
+                            void *pDstBuffer) const
+{
+    if (!CheckValidAndErrorOutIfNot())
+        return false;
+    auto poParent = m_poParent.lock();
+    if (!poParent)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "TileDBAttribute::IRead() failed because owing array object"
+                 "is no longer alive");
+        return false;
+    }
+    if (GetDataType().GetClass() == GEDTC_STRING)
+    {
+        tiledb_datatype_t tiledb_dt;
+        uint32_t nLen = 0;
+        const void *ptr = nullptr;
+        if (!poParent->GetMetadata(m_osName, &tiledb_dt, &nLen, &ptr))
+            return false;
+        if (tiledb_dt != TILEDB_STRING_UTF8 &&
+            tiledb_dt != TILEDB_STRING_ASCII && tiledb_dt != TILEDB_UINT8)
+            return false;
+        std::string osStr;
+        osStr.assign(static_cast<const char *>(ptr), nLen);
+        if (!m_poMemAttribute->Write(osStr.c_str()))
+            return false;
+    }
+    else
+    {
+        tiledb_datatype_t expected_tiledb_dt = TILEDB_ANY;
+        if (!TileDBArray::GDALDataTypeToTileDB(
+                GetDataType().GetNumericDataType(), expected_tiledb_dt))
+            return false;
+        tiledb_datatype_t tiledb_dt;
+        uint32_t nLen = 0;
+        const void *ptr = nullptr;
+        if (!poParent->GetMetadata(m_osName, &tiledb_dt, &nLen, &ptr))
+            return false;
+        if (tiledb_dt != expected_tiledb_dt)
+            return false;
+        if (!m_poMemAttribute->Write(ptr, nLen * GetDataType().GetSize()))
+            return false;
+    }
+    return m_poMemAttribute->Read(arrayStartIdx, count, arrayStep, bufferStride,
+                                  bufferDataType, pDstBuffer);
+}
+
+/************************************************************************/
+/*                     TileDBAttribute::IWrite()                        */
+/************************************************************************/
+
+bool TileDBAttribute::IWrite(const GUInt64 *arrayStartIdx, const size_t *count,
+                             const GInt64 *arrayStep,
+                             const GPtrDiff_t *bufferStride,
+                             const GDALExtendedDataType &bufferDataType,
+                             const void *pSrcBuffer)
+{
+    if (!CheckValidAndErrorOutIfNot())
+        return false;
+    auto poParent = m_poParent.lock();
+    if (!poParent)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "TileDBAttribute::IWrite() failed because owing array object"
+                 "is no longer alive");
+        return false;
+    }
+    if (!poParent->IIsWritable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return false;
+    }
+
+    if (!m_poMemAttribute->Write(arrayStartIdx, count, arrayStep, bufferStride,
+                                 bufferDataType, pSrcBuffer))
+    {
+        return false;
+    }
+
+    if (GetDataType().GetClass() == GEDTC_STRING)
+    {
+        const char *pszStr = m_poMemAttribute->ReadAsString();
+        if (pszStr)
+        {
+            const auto tiledb_dt = CPLIsASCII(pszStr, -1) ? TILEDB_STRING_ASCII
+                                                          : TILEDB_STRING_UTF8;
+            return poParent->PutMetadata(m_osName, tiledb_dt,
+                                         static_cast<uint32_t>(strlen(pszStr)),
+                                         pszStr);
+        }
+        return false;
+    }
+
+    tiledb_datatype_t tiledb_dt = TILEDB_ANY;
+    if (!TileDBArray::GDALDataTypeToTileDB(GetDataType().GetNumericDataType(),
+                                           tiledb_dt))
+        return false;
+
+    auto oRawResult = m_poMemAttribute->ReadAsRaw();
+    if (!oRawResult.data())
+        return false;
+    const auto nValues =
+        static_cast<uint32_t>(oRawResult.size() / GetDataType().GetSize());
+    return poParent->PutMetadata(m_osName, tiledb_dt, nValues,
+                                 oRawResult.data());
+}
+
+#endif  // HAS_TILEDB_MULTIDIM

--- a/frmts/tiledb/tiledbmultidimattributeholder.cpp
+++ b/frmts/tiledb/tiledbmultidimattributeholder.cpp
@@ -1,0 +1,304 @@
+/******************************************************************************
+ *
+ * Project:  GDAL TileDB Driver
+ * Purpose:  Implement GDAL TileDB multidimensional support based on https://www.tiledb.io
+ * Author:   TileDB, Inc
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, TileDB, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "tiledbmultidim.h"
+
+#ifdef HAS_TILEDB_MULTIDIM
+
+/************************************************************************/
+/*           TileDBAttributeHolder::~TileDBAttributeHolder()            */
+/************************************************************************/
+
+TileDBAttributeHolder::~TileDBAttributeHolder() = default;
+
+/************************************************************************/
+/*             TileDBAttributeHolder::CreateAttributeImpl()             */
+/************************************************************************/
+
+std::shared_ptr<GDALAttribute> TileDBAttributeHolder::CreateAttributeImpl(
+    const std::string &osName, const std::vector<GUInt64> &anDimensions,
+    const GDALExtendedDataType &oDataType, CSLConstList /*papszOptions*/)
+{
+    if (!IIsWritable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return nullptr;
+    }
+
+    if (!EnsureOpenAs(TILEDB_READ))
+        return nullptr;
+    try
+    {
+        tiledb_datatype_t value_type;
+        if (m_oMapAttributes.find(osName) != m_oMapAttributes.end() ||
+            has_metadata(osName, &value_type))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "An attribute with same name already exists");
+            return nullptr;
+        }
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "has_metadata() failed with: %s",
+                 e.what());
+        return nullptr;
+    }
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return nullptr;
+
+    auto poAttr = TileDBAttribute::Create(AsAttributeHolderSharedPtr(), osName,
+                                          anDimensions, oDataType);
+    if (poAttr)
+        m_oMapAttributes[osName] = poAttr;
+    return poAttr;
+}
+
+/************************************************************************/
+/*                TileDBAttributeHolder::CreateAttribute()              */
+/************************************************************************/
+
+/* static */ std::shared_ptr<GDALAttribute>
+TileDBAttributeHolder::CreateAttribute(
+    const std::shared_ptr<TileDBAttributeHolder> &poSelf,
+    const std::string &osName, tiledb_datatype_t value_type, uint32_t value_num,
+    const void *value)
+{
+    if (value_type == TILEDB_STRING_ASCII || value_type == TILEDB_STRING_UTF8 ||
+        (osName == "_gdal" && value_type == TILEDB_UINT8 && value &&
+         CPLIsUTF8(static_cast<const char *>(value), value_num)))
+    {
+        return TileDBAttribute::Create(poSelf, osName, {},
+                                       GDALExtendedDataType::CreateString());
+    }
+    else
+    {
+        GDALDataType eDT =
+            TileDBArray::TileDBDataTypeToGDALDataType(value_type);
+        if (eDT == GDT_Unknown)
+        {
+            const char *pszTypeName = "";
+            tiledb_datatype_to_str(value_type, &pszTypeName);
+            CPLDebug("TILEDB",
+                     "Metadata item %s ignored because of unsupported "
+                     "type %s",
+                     osName.c_str(), pszTypeName);
+        }
+        else
+        {
+            return TileDBAttribute::Create(poSelf, osName, {value_num},
+                                           GDALExtendedDataType::Create(eDT));
+        }
+    }
+    return nullptr;
+}
+
+/************************************************************************/
+/*                TileDBAttributeHolder::GetAttributeImpl()             */
+/************************************************************************/
+
+std::shared_ptr<GDALAttribute>
+TileDBAttributeHolder::GetAttributeImpl(const std::string &osName) const
+{
+    if (!EnsureOpenAs(TILEDB_READ))
+        return nullptr;
+
+    auto oIter = m_oMapAttributes.find(osName);
+    if (oIter != m_oMapAttributes.end())
+        return oIter->second;
+
+    try
+    {
+        tiledb_datatype_t value_type;
+        uint32_t value_num;
+        const void *value;
+        get_metadata(osName, &value_type, &value_num, &value);
+        if (value == nullptr)
+            return nullptr;
+
+        auto poAttr = CreateAttribute(AsAttributeHolderSharedPtr(), osName,
+                                      value_type, value_num, value);
+        if (poAttr)
+        {
+            m_oMapAttributes[osName] = poAttr;
+        }
+        return poAttr;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "GetAttribute() failed with: %s",
+                 e.what());
+        return nullptr;
+    }
+}
+
+/************************************************************************/
+/*                       IsSpecialAttribute()                           */
+/************************************************************************/
+
+static bool IsSpecialAttribute(const std::string &osName)
+{
+    return osName == CRS_ATTRIBUTE_NAME || osName == UNIT_ATTRIBUTE_NAME ||
+           osName == DIM_TYPE_ATTRIBUTE_NAME ||
+           osName == DIM_DIRECTION_ATTRIBUTE_NAME ||
+           osName == GDAL_ATTRIBUTE_NAME;
+}
+
+/************************************************************************/
+/*                TileDBAttributeHolder::GetAttributesImpl()            */
+/************************************************************************/
+
+std::vector<std::shared_ptr<GDALAttribute>>
+TileDBAttributeHolder::GetAttributesImpl(CSLConstList papszOptions) const
+{
+    if (!EnsureOpenAs(TILEDB_READ))
+        return {};
+
+    const bool bShowAll =
+        CPLTestBool(CSLFetchNameValueDef(papszOptions, "SHOW_ALL", "NO"));
+
+    try
+    {
+        std::vector<std::shared_ptr<GDALAttribute>> apoAttributes;
+        const uint64_t nAttributes = metadata_num();
+        auto poSelf = AsAttributeHolderSharedPtr();
+        for (uint64_t i = 0; i < nAttributes; ++i)
+        {
+            std::string key;
+            tiledb_datatype_t value_type;
+            uint32_t value_num;
+            const void *value;
+            get_metadata_from_index(i, &key, &value_type, &value_num, &value);
+            if (bShowAll || !IsSpecialAttribute(key))
+            {
+                auto poAttr =
+                    CreateAttribute(poSelf, key, value_type, value_num, value);
+                if (poAttr)
+                {
+                    apoAttributes.emplace_back(std::move(poAttr));
+                    m_oMapAttributes[key] = apoAttributes.back();
+                }
+            }
+        }
+        return apoAttributes;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "GetAttributes() failed with: %s",
+                 e.what());
+        return {};
+    }
+}
+
+/************************************************************************/
+/*             TileDBAttributeHolder::DeleteAttributeImpl()             */
+/************************************************************************/
+
+bool TileDBAttributeHolder::DeleteAttributeImpl(const std::string &osName,
+                                                CSLConstList /*papszOptions*/)
+{
+    if (!IIsWritable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return false;
+    }
+
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return false;
+
+    auto oIter = m_oMapAttributes.find(osName);
+
+    try
+    {
+        delete_metadata(osName);
+
+        if (oIter != m_oMapAttributes.end())
+        {
+            oIter->second->Deleted();
+            m_oMapAttributes.erase(oIter);
+        }
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "DeleteAttribute() failed with: %s", e.what());
+        return false;
+    }
+}
+
+/************************************************************************/
+/*                TileDBAttributeHolder::GetMetadata()                  */
+/************************************************************************/
+
+bool TileDBAttributeHolder::GetMetadata(const std::string &key,
+                                        tiledb_datatype_t *value_type,
+                                        uint32_t *value_num,
+                                        const void **value) const
+{
+    if (!EnsureOpenAs(TILEDB_READ))
+        return false;
+    try
+    {
+        get_metadata(key, value_type, value_num, value);
+        return *value != nullptr;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "GetMetadata() failed with: %s",
+                 e.what());
+        return false;
+    }
+}
+
+/************************************************************************/
+/*                TileDBAttributeHolder::PutMetadata()                  */
+/************************************************************************/
+
+bool TileDBAttributeHolder::PutMetadata(const std::string &key,
+                                        tiledb_datatype_t value_type,
+                                        uint32_t value_num, const void *value)
+{
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return false;
+    try
+    {
+        put_metadata(key, value_type, value_num, value);
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "PutMetadata() failed with: %s",
+                 e.what());
+        return false;
+    }
+}
+
+#endif

--- a/frmts/tiledb/tiledbmultidimgroup.cpp
+++ b/frmts/tiledb/tiledbmultidimgroup.cpp
@@ -1,0 +1,578 @@
+/******************************************************************************
+ *
+ * Project:  GDAL TileDB Driver
+ * Purpose:  Implement GDAL TileDB multidimensional support based on https://www.tiledb.io
+ * Author:   TileDB, Inc
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, TileDB, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "tiledbmultidim.h"
+
+#ifdef HAS_TILEDB_MULTIDIM
+
+#include "memmultidim.h"
+
+/************************************************************************/
+/*                   TileDBGroup::~TileDBGroup()                        */
+/************************************************************************/
+
+TileDBGroup::~TileDBGroup()
+{
+    m_oMapGroups.clear();
+    m_oMapArrays.clear();
+    if (m_poTileDBGroup)
+    {
+        try
+        {
+            m_poTileDBGroup->close();
+            m_poTileDBGroup.reset();
+        }
+        catch (const std::exception &e)
+        {
+            // Will leak memory, but better that than crashing
+            // Cf https://github.com/TileDB-Inc/TileDB/issues/4101
+            m_poTileDBGroup.release();
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "TileDBGroup::~TileDBGroup(): %s", e.what());
+        }
+    }
+}
+
+/************************************************************************/
+/*                   TileDBGroup::GetGroupNames()                       */
+/************************************************************************/
+
+std::vector<std::string>
+TileDBGroup::GetGroupNames(CSLConstList /*papszOptions*/) const
+{
+    if (!EnsureOpenAs(TILEDB_READ))
+        return {};
+
+    std::vector<std::string> aosNames;
+    for (uint64_t i = 0; i < m_poTileDBGroup->member_count(); ++i)
+    {
+        auto obj = m_poTileDBGroup->member(i);
+        if (obj.type() == tiledb::Object::Type::Group)
+        {
+            if (obj.name().has_value())
+                aosNames.push_back(*(obj.name()));
+            else
+                aosNames.push_back(CPLGetFilename(obj.uri().c_str()));
+        }
+    }
+    return aosNames;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::OpenFromDisk()                        */
+/************************************************************************/
+
+/* static */
+std::shared_ptr<TileDBGroup> TileDBGroup::OpenFromDisk(
+    const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+    const std::string &osParentName, const std::string &osName,
+    const std::string &osPath)
+{
+    const auto eType =
+        tiledb::Object::object(poSharedResource->GetCtx(), osPath).type();
+    if (eType != tiledb::Object::Type::Group)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s is not a TileDB group",
+                 osPath.c_str());
+        return nullptr;
+    }
+
+    auto poTileDBGroup = std::make_unique<tiledb::Group>(
+        poSharedResource->GetCtx(), osPath, TILEDB_READ);
+
+    auto poGroup =
+        TileDBGroup::Create(poSharedResource, osParentName, osName, osPath);
+    poGroup->m_poTileDBGroup = std::move(poTileDBGroup);
+    return poGroup;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::CreateOnDisk()                        */
+/************************************************************************/
+
+/* static */
+std::shared_ptr<TileDBGroup> TileDBGroup::CreateOnDisk(
+    const std::shared_ptr<TileDBSharedResource> &poSharedResource,
+    const std::string &osParentName, const std::string &osName,
+    const std::string &osPath)
+{
+    try
+    {
+        tiledb::create_group(poSharedResource->GetCtx(), osPath);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+
+    auto poTileDBGroup = std::make_unique<tiledb::Group>(
+        poSharedResource->GetCtx(), osPath, TILEDB_WRITE);
+
+    auto poGroup =
+        TileDBGroup::Create(poSharedResource, osParentName, osName, osPath);
+    poGroup->m_poTileDBGroup = std::move(poTileDBGroup);
+    return poGroup;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::EnsureOpenAs()                        */
+/************************************************************************/
+
+bool TileDBGroup::EnsureOpenAs(tiledb_query_type_t mode) const
+{
+    if (!m_poTileDBGroup)
+        return false;
+    if (m_poTileDBGroup->query_type() == mode && m_poTileDBGroup->is_open())
+        return true;
+    try
+    {
+        m_poTileDBGroup->close();
+        m_poTileDBGroup->open(mode);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        m_poTileDBGroup.reset();
+        return false;
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                 TileDBGroup::HasObjectOfSameName()                   */
+/************************************************************************/
+
+bool TileDBGroup::HasObjectOfSameName(const std::string &osName) const
+{
+    if (m_oMapGroups.find(osName) != m_oMapGroups.end())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "A group named %s already exists",
+                 osName.c_str());
+        return true;
+    }
+    if (m_oMapArrays.find(osName) != m_oMapArrays.end())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "An array named %s already exists", osName.c_str());
+        return true;
+    }
+
+    if (!EnsureOpenAs(TILEDB_READ))
+        return {};
+    for (uint64_t i = 0; i < m_poTileDBGroup->member_count(); ++i)
+    {
+        auto obj = m_poTileDBGroup->member(i);
+        std::string osObjName = obj.name().has_value()
+                                    ? *(obj.name())
+                                    : CPLGetFilename(obj.uri().c_str());
+        if (osName == osObjName)
+        {
+            if (obj.type() == tiledb::Object::Type::Group)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "A group named %s already exists", osName.c_str());
+                return true;
+            }
+            else if (obj.type() == tiledb::Object::Type::Array)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "An array named %s already exists", osName.c_str());
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::OpenGroup()                           */
+/************************************************************************/
+
+std::shared_ptr<GDALGroup>
+TileDBGroup::OpenGroup(const std::string &osName,
+                       CSLConstList /*papszOptions*/) const
+{
+    auto oIter = m_oMapGroups.find(osName);
+    if (oIter != m_oMapGroups.end())
+    {
+        return oIter->second;
+    }
+    if (!m_poTileDBGroup)
+        return nullptr;
+
+    // Try to match by member name property first, and if not use the
+    // last part of their URI
+    std::string osSubPath;
+    std::string osSubPathCandidate;
+    for (uint64_t i = 0; i < m_poTileDBGroup->member_count(); ++i)
+    {
+        auto obj = m_poTileDBGroup->member(i);
+        if (obj.type() == tiledb::Object::Type::Group)
+        {
+            if (obj.name().has_value() && *(obj.name()) == osName)
+            {
+                osSubPath = obj.uri();
+                break;
+            }
+            else if (CPLGetFilename(obj.uri().c_str()) == osName)
+            {
+                osSubPathCandidate = osSubPath;
+            }
+        }
+    }
+    if (osSubPath.empty())
+        osSubPath = osSubPathCandidate;
+    if (osSubPath.empty())
+        return nullptr;
+
+    auto poSubGroup = TileDBGroup::OpenFromDisk(
+        m_poSharedResource, m_osFullName, osName, osSubPath);
+    if (!poSubGroup)
+        return nullptr;
+
+    m_oMapGroups[osName] = poSubGroup;
+
+    return poSubGroup;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::CreateGroup()                         */
+/************************************************************************/
+
+std::shared_ptr<GDALGroup> TileDBGroup::CreateGroup(const std::string &osName,
+                                                    CSLConstList papszOptions)
+{
+    if (!m_poSharedResource->IsUpdatable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return nullptr;
+    }
+
+    if (HasObjectOfSameName(osName))
+        return nullptr;
+
+    std::string osSubPath = m_poTileDBGroup->uri() + "/" +
+                            TileDBSharedResource::SanitizeNameForPath(osName);
+    const char *pszURI = CSLFetchNameValue(papszOptions, "URI");
+    if (pszURI)
+        osSubPath = pszURI;
+    auto poSubGroup =
+        CreateOnDisk(m_poSharedResource, m_osFullName, osName, osSubPath);
+    if (!poSubGroup)
+        return nullptr;
+
+    if (!AddMember(osSubPath, osName))
+        return nullptr;
+    m_oMapGroups[osName] = poSubGroup;
+
+    return poSubGroup;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::AddMember()                           */
+/************************************************************************/
+
+bool TileDBGroup::AddMember(const std::string &osPath,
+                            const std::string &osName)
+{
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return false;
+
+    try
+    {
+        m_poTileDBGroup->add_member(osPath, /* relative= */ false, osName);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "AddMember() failed with: %s",
+                 e.what());
+        return false;
+    }
+    // Force close() and re-open() to avoid
+    // https://github.com/TileDB-Inc/TileDB/issues/4101
+    try
+    {
+        m_poTileDBGroup->close();
+        m_poTileDBGroup->open(TILEDB_WRITE);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "AddMember() failed with: %s",
+                 e.what());
+        m_poTileDBGroup.reset();
+        return false;
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                    TileDBGroup::CreateDimension()                    */
+/************************************************************************/
+
+std::shared_ptr<GDALDimension> TileDBGroup::CreateDimension(
+    const std::string &osName, const std::string &osType,
+    const std::string &osDirection, GUInt64 nSize, CSLConstList)
+{
+    if (osName.empty())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Empty dimension name not supported");
+        return nullptr;
+    }
+
+    if (m_oMapDimensions.find(osName) != m_oMapDimensions.end())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "A dimension with same name already exists");
+        return nullptr;
+    }
+    auto newDim(std::make_shared<GDALDimensionWeakIndexingVar>(
+        GetFullName(), osName, osType, osDirection, nSize));
+    m_oMapDimensions[osName] = newDim;
+    return newDim;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::GetMDArrayNames()                     */
+/************************************************************************/
+
+std::vector<std::string>
+TileDBGroup::GetMDArrayNames(CSLConstList /*papszOptions */) const
+{
+    if (!EnsureOpenAs(TILEDB_READ))
+        return {};
+
+    std::vector<std::string> aosNames;
+    for (uint64_t i = 0; i < m_poTileDBGroup->member_count(); ++i)
+    {
+        auto obj = m_poTileDBGroup->member(i);
+        if (obj.type() == tiledb::Object::Type::Array)
+        {
+            tiledb::ArraySchema schema(m_poSharedResource->GetCtx(), obj.uri());
+            if (schema.array_type() == TILEDB_DENSE)
+            {
+                const std::string osName =
+                    obj.name().has_value() ? *(obj.name())
+                                           : CPLGetFilename(obj.uri().c_str());
+                const auto nAttributes = schema.attribute_num();
+                if (nAttributes != 1)
+                {
+                    for (uint32_t iAttr = 0; iAttr < nAttributes; ++iAttr)
+                    {
+                        aosNames.push_back(osName + "." +
+                                           schema.attribute(iAttr).name());
+                    }
+                }
+                else
+                {
+                    aosNames.push_back(osName);
+                }
+            }
+        }
+    }
+
+    // As array creation is deferred, the above loop didn't get freshly
+    // created arrays
+    for (const auto &kv : m_oMapArrays)
+    {
+        if (std::find(aosNames.begin(), aosNames.end(), kv.first) ==
+            aosNames.end())
+        {
+            aosNames.push_back(kv.first);
+        }
+    }
+
+    return aosNames;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::OpenMDArray()                         */
+/************************************************************************/
+
+std::shared_ptr<GDALMDArray>
+TileDBGroup::OpenMDArray(const std::string &osName,
+                         CSLConstList papszOptions) const
+{
+    auto oIter = m_oMapArrays.find(osName);
+    if (oIter != m_oMapArrays.end())
+    {
+        return oIter->second;
+    }
+    if (!m_poTileDBGroup)
+        return nullptr;
+
+    std::string osNamePrefix = osName;
+    std::string osNameSuffix;
+    const auto nLastDot = osName.rfind('.');
+    if (nLastDot != std::string::npos)
+    {
+        osNamePrefix = osName.substr(0, nLastDot);
+        osNameSuffix = osName.substr(nLastDot + 1);
+    }
+
+    // Try to match by member name property first, and if not use the
+    // last part of their URI
+    std::string osSubPath;
+    std::string osSubPathCandidate;
+    for (uint64_t i = 0; i < m_poTileDBGroup->member_count(); ++i)
+    {
+        auto obj = m_poTileDBGroup->member(i);
+
+        const auto MatchNameSuffix =
+            [this, &obj, &osName, &osNamePrefix,
+             &osNameSuffix](const std::string &osObjName)
+        {
+            tiledb::ArraySchema schema(m_poSharedResource->GetCtx(), obj.uri());
+            if (osNameSuffix.empty() && osObjName == osName)
+            {
+                return true;
+            }
+            else if (osObjName == osNamePrefix && !osNameSuffix.empty() &&
+                     schema.has_attribute(osNameSuffix))
+            {
+                return true;
+            }
+            return false;
+        };
+
+        if (obj.type() == tiledb::Object::Type::Array)
+        {
+            if (obj.name().has_value() && MatchNameSuffix(*(obj.name())))
+            {
+                osSubPath = obj.uri();
+                break;
+            }
+            else if (MatchNameSuffix(CPLGetFilename(obj.uri().c_str())))
+            {
+                osSubPathCandidate = osSubPath;
+            }
+        }
+    }
+    if (osSubPath.empty())
+        osSubPath = osSubPathCandidate;
+    if (osSubPath.empty())
+        return nullptr;
+
+    auto poArray =
+        TileDBArray::OpenFromDisk(m_poSharedResource, m_osFullName, osName,
+                                  osNameSuffix, osSubPath, papszOptions);
+    if (!poArray)
+        return nullptr;
+
+    m_oMapArrays[osName] = poArray;
+
+    return poArray;
+}
+
+/************************************************************************/
+/*                   TileDBGroup::CreateMDArray()                       */
+/************************************************************************/
+
+std::shared_ptr<GDALMDArray> TileDBGroup::CreateMDArray(
+    const std::string &osName,
+    const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,
+    const GDALExtendedDataType &oDataType, CSLConstList papszOptions)
+{
+    if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "IN_MEMORY", "NO")))
+    {
+        auto poArray =
+            MEMMDArray::Create(std::string(), osName, aoDimensions, oDataType);
+        if (!poArray || !poArray->Init())
+            return nullptr;
+        return poArray;
+    }
+
+    if (!m_poSharedResource->IsUpdatable())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Dataset not open in update mode");
+        return nullptr;
+    }
+
+    if (HasObjectOfSameName(osName))
+        return nullptr;
+
+    if (!EnsureOpenAs(TILEDB_WRITE))
+        return nullptr;
+
+    auto poSelf = m_pSelf.lock();
+    CPLAssert(poSelf);
+    auto poArray =
+        TileDBArray::CreateOnDisk(m_poSharedResource, poSelf, osName,
+                                  aoDimensions, oDataType, papszOptions);
+    if (!poArray)
+        return nullptr;
+
+    m_oMapArrays[osName] = poArray;
+    return poArray;
+}
+
+/************************************************************************/
+/*                  TileDBGroup::CreateAttribute()                      */
+/************************************************************************/
+
+std::shared_ptr<GDALAttribute> TileDBGroup::CreateAttribute(
+    const std::string &osName, const std::vector<GUInt64> &anDimensions,
+    const GDALExtendedDataType &oDataType, CSLConstList papszOptions)
+{
+    return CreateAttributeImpl(osName, anDimensions, oDataType, papszOptions);
+}
+
+/************************************************************************/
+/*                   TileDBGroup::GetAttribute()                        */
+/************************************************************************/
+
+std::shared_ptr<GDALAttribute>
+TileDBGroup::GetAttribute(const std::string &osName) const
+{
+    return GetAttributeImpl(osName);
+}
+
+/************************************************************************/
+/*                   TileDBGroup::GetAttributes()                       */
+/************************************************************************/
+
+std::vector<std::shared_ptr<GDALAttribute>>
+TileDBGroup::GetAttributes(CSLConstList /* papszOptions */) const
+{
+    return GetAttributesImpl();
+}
+
+/************************************************************************/
+/*                   TileDBGroup::DeleteAttribute()                     */
+/************************************************************************/
+
+bool TileDBGroup::DeleteAttribute(const std::string &osName,
+                                  CSLConstList papszOptions)
+{
+    return DeleteAttributeImpl(osName, papszOptions);
+}
+
+#endif  // HAS_TILEDB_MULTIDIM

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2817,6 +2817,19 @@ class CPL_DLL GDALMDArray : virtual public GDALAbstractMDArray,
                                   const GDALExtendedDataType &bufferDataType,
                                   void *pDstBuffer) const;
 
+    bool IsStepOneContiguousRowMajorOrderedSameDataType(
+        const size_t *count, const GInt64 *arrayStep,
+        const GPtrDiff_t *bufferStride,
+        const GDALExtendedDataType &bufferDataType) const;
+
+    // Should only be called if IsStepOneContiguousRowMajorOrderedSameDataType()
+    // returns false
+    bool ReadUsingContiguousIRead(const GUInt64 *arrayStartIdx,
+                                  const size_t *count, const GInt64 *arrayStep,
+                                  const GPtrDiff_t *bufferStride,
+                                  const GDALExtendedDataType &bufferDataType,
+                                  void *pDstBuffer) const;
+
     //! @endcond
 
   public:


### PR DESCRIPTION
It requires GDAL to be built and run against TileDB >= 2.15 (for older
versions, it is just disabled)

The driver supports:
- creating and reading groups and subgroups
- creating and reading multidimensional dense arrays with a numeric data type
- creating and reading numeric or string attributes in groups and arrays
- storing an indexing array of a dimension as a TileDB dimension label

The multidimensional API supports reading dense arrays created by the classic
raster API of GDAL.

CC @normanb 