### PR TITLE
gdal_translate: emit warning when -a_scale/-a_offset + -unscale is specified (fixes #7863)

### DIFF
--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import os
+import sys
 
 import gdaltest
 import pytest
@@ -1035,6 +1036,20 @@ def test_gdal_translate_if_option(gdal_translate_path):
         gdal_translate_path + " -if HFA ../gcore/data/byte.tif /vsimem/out.tif"
     )
     assert err is not None
+
+
+###############################################################################
+# Test -scale and -a_offset + -a_scale
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="not working on Windows")
+def test_gdal_translate_scale_and_unscale_incompatible(gdal_translate_path):
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_translate_path
+        + " -a_scale 0.0001 -a_offset 0.1 -unscale ../gcore/data/byte.tif /vsimem/out.tif"
+    )
+    assert "-a_scale/-a_offset are not applied by -unscale" in err
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -1040,6 +1040,26 @@ def test_gdal_translate_lib_no_input_band():
 
 
 ###############################################################################
+# Test -scale and -unscape
+
+
+@gdaltest.enable_exceptions()
+def test_gdal_translate_lib_scale_and_unscale_incompatible():
+
+    with pytest.raises(
+        Exception, match=r"-scale and -unscale cannot be used as the same time"
+    ):
+        gdal.Translate(
+            "",
+            gdal.Open("../gcore/data/byte.tif"),
+            format="MEM",
+            scaleParams=[[0, 255, 0, 65535]],
+            unscale=True,
+            outputType=gdal.GDT_UInt16,
+        )
+
+
+###############################################################################
 # Cleanup
 
 

--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -239,13 +239,23 @@ resampling, and rescaling pixels in the process.
 
 .. option:: -a_scale <value>
 
-    Set band scaling value (no modification of pixel values is done)
+    Set band scaling value. No modification of pixel values is done.
+    Note that the :option:`-unscale` does not take into account :option:`-a_scale`.
+    You may for example specify ``-scale 0 1 <offset> <offset+scale>`` to
+    apply a (offset, scale) tuple, for the equivalent of the 2 steps:
+    ``gdal_translate input.tif tmp.vrt -a_scale scale -a_offset offset`` followed by
+    ``gdal_translate tmp.vrt output.tif -unscale``
 
     .. versionadded:: 2.3
 
-.. option:: -a_offset<value>
+.. option:: -a_offset <value>
 
-    Set band offset value (no modification of pixel values is done)
+    Set band offset value. No modification of pixel values is done.
+    Note that the :option:`-unscale` does not take into account :option:`-a_offset`.
+    You may for example specify ``-scale 0 1 <offset> <offset+scale>`` to
+    apply a (offset, scale) tuple, for the equivalent of the 2 steps:
+    ``gdal_translate input.tif tmp.vrt -a_scale scale -a_offset offset`` followed by
+    ``gdal_translate tmp.vrt output.tif -unscale``
 
     .. versionadded:: 2.3
 


### PR DESCRIPTION
The warning suggests to use ``-scale 0 1 <offset> <offset+scale>``

- also improves doc with that issue and suggestion
- and error out if -scale and -unscale are specified
