### PR TITLE
Nearblack: add "-alg floodfill" to select a flood fill algorithm

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   ogr2ogr_lib.cpp
   gdaldem_lib.cpp
   nearblack_lib.cpp
+  nearblack_lib_floodfill.cpp
   gdalmdiminfo_lib.cpp
   gdalmdimtranslate_lib.cpp)
 add_dependencies(appslib generate_gdal_version_h)

--- a/apps/nearblack_bin.cpp
+++ b/apps/nearblack_bin.cpp
@@ -39,8 +39,8 @@ static void Usage(const char *pszErrorMsg = nullptr)
 {
     printf("nearblack [-of format] [-white | [-color c1,c2,c3...cn]*] [-near "
            "dist] [-nb non_black_pixels]\n"
-           "          [-setalpha] [-setmask] [-o outfile] [-q] [-co "
-           "\"NAME=VALUE\"]* infile\n");
+           "          [-setalpha] [-setmask] [-alg twopasses|floodfill]\n"
+           "          [-o outfile] [-q] [-co \"NAME=VALUE\"]* infile\n");
 
     if (pszErrorMsg != nullptr)
         fprintf(stderr, "\nFAILURE: %s\n", pszErrorMsg);

--- a/apps/nearblack_lib.cpp
+++ b/apps/nearblack_lib.cpp
@@ -49,12 +49,6 @@
 
 #include "nearblack_lib.h"
 
-static bool TwoPassesAlgorithm(const GDALNearblackOptions *psOptions,
-                               GDALDatasetH hSrcDataset, GDALDatasetH hDstDS,
-                               GDALRasterBandH hMaskBand, int nBands,
-                               int nDstBands, bool bSetMask,
-                               const Colors &oColors);
-
 static void ProcessLine(GByte *pabyLine, GByte *pabyMask, int iStart, int iEnd,
                         int nSrcBands, int nDstBands, int nNearDist,
                         int nMaxNonBlack, bool bNearWhite,
@@ -325,8 +319,9 @@ GDALDatasetH CPL_DLL GDALNearblack(const char *pszDest, GDALDatasetH hDstDS,
     }
     else
     {
-        bRet = TwoPassesAlgorithm(psOptions, hSrcDataset, hDstDS, hMaskBand,
-                                  nBands, nDstBands, bSetMask, oColors);
+        bRet = GDALNearblackTwoPassesAlgorithm(psOptions, hSrcDataset, hDstDS,
+                                               hMaskBand, nBands, nDstBands,
+                                               bSetMask, oColors);
     }
     if (!bRet)
     {
@@ -339,16 +334,17 @@ GDALDatasetH CPL_DLL GDALNearblack(const char *pszDest, GDALDatasetH hDstDS,
 }
 
 /************************************************************************/
-/*                       TwoPassesAlgorithm()                           */
+/*                   GDALNearblackTwoPassesAlgorithm()                  */
 /*                                                                      */
 /* Do a top-to-bottom pass, followed by a bottom-to-top one.            */
 /************************************************************************/
 
-static bool TwoPassesAlgorithm(const GDALNearblackOptions *psOptions,
-                               GDALDatasetH hSrcDataset, GDALDatasetH hDstDS,
-                               GDALRasterBandH hMaskBand, int nBands,
-                               int nDstBands, bool bSetMask,
-                               const Colors &oColors)
+bool GDALNearblackTwoPassesAlgorithm(const GDALNearblackOptions *psOptions,
+                                     GDALDatasetH hSrcDataset,
+                                     GDALDatasetH hDstDS,
+                                     GDALRasterBandH hMaskBand, int nBands,
+                                     int nDstBands, bool bSetMask,
+                                     const Colors &oColors)
 {
     const int nXSize = GDALGetRasterXSize(hSrcDataset);
     const int nYSize = GDALGetRasterYSize(hSrcDataset);

--- a/apps/nearblack_lib.h
+++ b/apps/nearblack_lib.h
@@ -65,6 +65,13 @@ struct GDALNearblackOptions
     CPLStringList aosCreationOptions{};
 };
 
+bool GDALNearblackTwoPassesAlgorithm(const GDALNearblackOptions *psOptions,
+                                     GDALDatasetH hSrcDataset,
+                                     GDALDatasetH hDstDS,
+                                     GDALRasterBandH hMaskBand, int nBands,
+                                     int nDstBands, bool bSetMask,
+                                     const Colors &oColors);
+
 bool GDALNearblackFloodFill(const GDALNearblackOptions *psOptions,
                             GDALDatasetH hSrcDataset, GDALDatasetH hDstDS,
                             GDALRasterBandH hMaskBand, int nSrcBands,

--- a/apps/nearblack_lib.h
+++ b/apps/nearblack_lib.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+ *
+ * Project:  GDAL Utilities
+ * Purpose:  Convert nearly black or nearly white border to exact black/white.
+ * Author:   Frank Warmerdam, warmerdam@pobox.com
+ *
+ * ****************************************************************************
+ * Copyright (c) 2006, MapShots Inc (www.mapshots.com)
+ * Copyright (c) 2007-2013, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef NEARBLACK_LIB_H
+#define NEARBLACK_LIB_H
+
+#ifndef DOXYGEN_SKIP
+
+#include "cpl_progress.h"
+#include "cpl_string.h"
+
+#include <string>
+#include <vector>
+
+typedef std::vector<int> Color;
+typedef std::vector<Color> Colors;
+
+struct GDALNearblackOptions
+{
+    /*! output format. Use the short format name. */
+    std::string osFormat{};
+
+    /*! the progress function to use */
+    GDALProgressFunc pfnProgress = GDALDummyProgress;
+
+    /*! pointer to the progress data variable */
+    void *pProgressData = nullptr;
+
+    int nMaxNonBlack = 2;
+    int nNearDist = 15;
+    bool bNearWhite = false;
+    bool bSetAlpha = false;
+    bool bSetMask = false;
+
+    bool bFloodFill = false;
+
+    Colors oColors{};
+
+    CPLStringList aosCreationOptions{};
+};
+
+bool GDALNearblackFloodFill(const GDALNearblackOptions *psOptions,
+                            GDALDatasetH hSrcDataset, GDALDatasetH hDstDS,
+                            GDALRasterBandH hMaskBand, int nSrcBands,
+                            int nDstBands, bool bSetMask,
+                            const Colors &oColors);
+
+#endif  // DOXYGEN_SKIP
+
+#endif  // NEARBLACK_LIB_H

--- a/apps/nearblack_lib_floodfill.cpp
+++ b/apps/nearblack_lib_floodfill.cpp
@@ -1,0 +1,635 @@
+/******************************************************************************
+ *
+ * Project:  GDAL Utilities
+ * Purpose:  Convert nearly black or nearly white border to exact black/white
+ *           using the flood fill algorithm.
+ * Author:   Even Rouault <even dot rouault at spatialys.com>
+ *
+ * ****************************************************************************
+ * Copyright (c) 2023, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_priv.h"
+#include "nearblack_lib.h"
+
+#include <algorithm>
+#include <memory>
+#include <queue>
+
+/************************************************************************/
+/*                    GDALNearblackFloodFillAlg                         */
+/************************************************************************/
+
+// Implements the "final, combined-scan-and-fill span filler was then published
+// in 1990" algorithm of https://en.wikipedia.org/wiki/Flood_fill#Span_filling
+
+struct GDALNearblackFloodFillAlg
+{
+    // Input arguments of the algorithm
+    const GDALNearblackOptions *m_psOptions = nullptr;
+    GDALDataset *m_poSrcDataset = nullptr;
+    GDALDataset *m_poDstDS = nullptr;
+    GDALRasterBand *m_poMaskBand = nullptr;
+    int m_nSrcBands = 0;
+    int m_nDstBands = 0;
+    bool m_bSetMask = false;
+    Colors m_oColors{};
+    GByte m_nReplacevalue = 0;
+
+    // As we (generally) do not modify the value of pixels that are "black"
+    // we need to keep track of the pixels we visited
+    // Cf https://en.wikipedia.org/wiki/Flood_fill#Disadvantages_2
+    // and https://en.wikipedia.org/wiki/Flood_fill#Adding_pattern_filling_support
+    // for the requirement to add that extra sentinel
+    std::unique_ptr<GDALDataset> m_poVisitedDS = nullptr;
+
+    // Active line for the m_abyLine, m_abyLineMustSet, m_abyMask buffers
+    int m_nLoadedLine = -1;
+
+    // Whether Set(..., m_nLoadedLine) has been called
+    bool m_bLineModified = true;
+
+    // Content of m_poSrcDataset/m_poDstDS for m_nLoadedLine
+    // Contains m_nDstBands * nXSize values in the order (R,G,B),(R,G,B),...
+    std::vector<GByte> m_abyLine{};
+
+    static constexpr GByte MUST_FILL_UNINIT = 0;  // must be 0
+    static constexpr GByte MUST_FILL_FALSE = 1;
+    static constexpr GByte MUST_FILL_TRUE = 2;
+    // Content of m_poVisitedDS for m_nLoadedLine
+    std::vector<GByte> m_abyLineMustSet{};
+
+    // Only use if m_bSetMask
+    std::vector<GByte> m_abyMask{};
+
+    // Used for progress bar. Incremented the first time a line ifs loaded
+    int m_nCountLoadedOnce = 0;
+
+    // m_abLineLoadedOnce[line] is set to true after the first time the line
+    // of m_poSrcDataset is loaded by LoadLine(line)
+    std::vector<bool> m_abLineLoadedOnce{};
+
+    // m_abLineSavedOnce[line] is set to true after the first time the line
+    // of m_poDstDS is written by LoadLine()
+    std::vector<bool> m_abLineSavedOnce{};
+
+#ifdef DEBUG
+    size_t m_nMaxQueueSize = 0;
+#endif
+
+    // Entry point
+    bool Process();
+
+  private:
+    bool Fill(int iX, int iY);
+    bool LoadLine(int iY);
+    bool MustSet(int iX, int iY);
+    bool Set(int iX, int iY);
+};
+
+/************************************************************************/
+/*              GDALNearblackFloodFillAlg::MustSet()                    */
+/*                                                                      */
+/* Called Inside() in https://en.wikipedia.org/wiki/Flood_fill          */
+/************************************************************************/
+
+// Returns true if the pixel (iX, iY) is "black" (or more generally transparent
+// according to m_oColors)
+bool GDALNearblackFloodFillAlg::MustSet(int iX, int iY)
+{
+    CPLAssert(iX >= 0);
+    CPLAssert(iX < m_poSrcDataset->GetRasterXSize());
+
+    CPLAssert(iY >= 0);
+    CPLAssert(iY < m_poSrcDataset->GetRasterYSize());
+    CPLAssert(iY == m_nLoadedLine);
+    CPL_IGNORE_RET_VAL(iY);
+
+    if (m_abyLineMustSet[iX] != MUST_FILL_UNINIT)
+    {
+        return m_abyLineMustSet[iX] == MUST_FILL_TRUE;
+    }
+
+    /***** loop over the colors *****/
+
+    for (int iColor = 0; iColor < static_cast<int>(m_oColors.size()); iColor++)
+    {
+        const Color &oColor = m_oColors[iColor];
+
+        /***** loop over the bands *****/
+        bool bIsNonBlack = false;
+
+        for (int iBand = 0; iBand < m_nSrcBands; iBand++)
+        {
+            const int nPix = m_abyLine[iX * m_nDstBands + iBand];
+
+            if (oColor[iBand] - nPix > m_psOptions->nNearDist ||
+                nPix > m_psOptions->nNearDist + oColor[iBand])
+            {
+                bIsNonBlack = true;
+                break;
+            }
+        }
+
+        if (!bIsNonBlack)
+        {
+            m_abyLineMustSet[iX] = MUST_FILL_TRUE;
+            return true;
+        }
+    }
+
+    m_abyLineMustSet[iX] = MUST_FILL_FALSE;
+    return false;
+}
+
+/************************************************************************/
+/*             GDALNearblackFloodFillAlg::LoadLine()                    */
+/************************************************************************/
+
+// Load the new line iY, and saves if needed buffer of the previous loaded
+// line (m_nLoadedLine).
+// Returns true if no error
+bool GDALNearblackFloodFillAlg::LoadLine(int iY)
+{
+    if (iY != m_nLoadedLine)
+    {
+#ifdef DEBUG
+        // CPLDebug("GDAL", "GDALNearblackFloodFillAlg::LoadLine(%d)", iY);
+#endif
+        const int nXSize = m_poSrcDataset->GetRasterXSize();
+
+        if (m_nLoadedLine >= 0)
+        {
+            if (m_bLineModified || (m_poDstDS != m_poSrcDataset &&
+                                    !m_abLineSavedOnce[m_nLoadedLine]))
+            {
+                if (m_poDstDS->RasterIO(
+                        GF_Write, 0, m_nLoadedLine, nXSize, 1, m_abyLine.data(),
+                        nXSize, 1, GDT_Byte, m_nDstBands, nullptr, m_nDstBands,
+                        nXSize * m_nDstBands, 1, nullptr) != CE_None)
+                {
+                    return false;
+                }
+            }
+
+            if (m_bSetMask &&
+                (m_bLineModified || !m_abLineSavedOnce[m_nLoadedLine]))
+            {
+                if (m_poMaskBand->RasterIO(GF_Write, 0, m_nLoadedLine, nXSize,
+                                           1, m_abyMask.data(), nXSize, 1,
+                                           GDT_Byte, 0, 0, nullptr) != CE_None)
+                {
+                    return false;
+                }
+            }
+
+            m_abLineSavedOnce[m_nLoadedLine] = true;
+        }
+
+        if (iY >= 0)
+        {
+            if (m_poDstDS != m_poSrcDataset && m_abLineSavedOnce[iY])
+            {
+                // If the output dataset is different from the source one,
+                // load from the output dataset if we have already written the
+                // line of interest
+                if (m_poDstDS->RasterIO(
+                        GF_Read, 0, iY, nXSize, 1, m_abyLine.data(), nXSize, 1,
+                        GDT_Byte, m_nDstBands, nullptr, m_nDstBands,
+                        nXSize * m_nDstBands, 1, nullptr) != CE_None)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                // Otherwise load from the source data
+                if (m_poSrcDataset->RasterIO(
+                        GF_Read, 0, iY, nXSize, 1, m_abyLine.data(), nXSize, 1,
+                        GDT_Byte,
+                        // m_nSrcBands intended
+                        m_nSrcBands,
+                        // m_nDstBands intended
+                        nullptr, m_nDstBands, nXSize * m_nDstBands, 1,
+                        nullptr) != CE_None)
+                {
+                    return false;
+                }
+
+                // Initialize the alpha component to 255 if it is the first time
+                // we load that line.
+                if (m_psOptions->bSetAlpha && !m_abLineLoadedOnce[iY])
+                {
+                    for (int iCol = 0; iCol < nXSize; iCol++)
+                    {
+                        m_abyLine[iCol * m_nDstBands + m_nDstBands - 1] = 255;
+                    }
+                }
+            }
+
+            if (m_bSetMask)
+            {
+                if (!m_abLineLoadedOnce[iY])
+                {
+                    for (int iCol = 0; iCol < nXSize; iCol++)
+                    {
+                        m_abyMask[iCol] = 255;
+                    }
+                }
+                else
+                {
+                    if (m_poMaskBand->RasterIO(
+                            GF_Read, 0, iY, nXSize, 1, m_abyMask.data(), nXSize,
+                            1, GDT_Byte, 0, 0, nullptr) != CE_None)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (!m_abLineLoadedOnce[iY])
+            {
+                m_nCountLoadedOnce++;
+                // Very rough progression report based on the first time
+                // we load a line...
+                // We arbitrarily consider that it's 90% of the processing time
+                const int nYSize = m_poSrcDataset->GetRasterYSize();
+                if (!(m_psOptions->pfnProgress(
+                        0.9 *
+                            (m_nCountLoadedOnce / static_cast<double>(nYSize)),
+                        nullptr, m_psOptions->pProgressData)))
+                {
+                    return false;
+                }
+                m_abLineLoadedOnce[iY] = true;
+            }
+        }
+
+        if (m_nLoadedLine >= 0)
+        {
+            if (m_poVisitedDS->GetRasterBand(1)->RasterIO(
+                    GF_Write, 0, m_nLoadedLine, nXSize, 1,
+                    m_abyLineMustSet.data(), nXSize, 1, GDT_Byte, 0, 0,
+                    nullptr) != CE_None)
+            {
+                return false;
+            }
+        }
+
+        if (iY >= 0)
+        {
+            if (m_poVisitedDS->GetRasterBand(1)->RasterIO(
+                    GF_Read, 0, iY, nXSize, 1, m_abyLineMustSet.data(), nXSize,
+                    1, GDT_Byte, 0, 0, nullptr) != CE_None)
+            {
+                return false;
+            }
+        }
+
+        m_bLineModified = false;
+        m_nLoadedLine = iY;
+    }
+    return true;
+}
+
+/************************************************************************/
+/*              GDALNearblackFloodFillAlg::Set()                        */
+/************************************************************************/
+
+// Mark the pixel as transparent
+// Returns true if no error
+bool GDALNearblackFloodFillAlg::Set(int iX, int iY)
+{
+    CPLAssert(iY == m_nLoadedLine);
+    CPL_IGNORE_RET_VAL(iY);
+
+    m_bLineModified = true;
+    m_abyLineMustSet[iX] = MUST_FILL_FALSE;
+
+    for (int iBand = 0; iBand < m_nSrcBands; iBand++)
+        m_abyLine[iX * m_nDstBands + iBand] = m_nReplacevalue;
+
+    /***** alpha *****/
+    if (m_nDstBands > m_nSrcBands)
+        m_abyLine[iX * m_nDstBands + m_nDstBands - 1] = 0;
+
+    if (m_bSetMask)
+        m_abyMask[iX] = 0;
+
+    return true;
+}
+
+/************************************************************************/
+/*              GDALNearblackFloodFillAlg::Fill()                       */
+/************************************************************************/
+
+/* Implements the "final, combined-scan-and-fill span filler was then published
+ * in 1990" algorithm of https://en.wikipedia.org/wiki/Flood_fill#Span_filling
+ * with the following enhancements:
+ * - extra bound checking to avoid calling MustSet() outside the raster
+ * - extra bound checking to avoid pushing spans outside the raster
+ * - taking into accout nMaxNonBlack in the horizontal direction
+ *
+ * Returns true if no error.
+ */
+
+bool GDALNearblackFloodFillAlg::Fill(int iXInit, int iYInit)
+{
+    const int nXSize = m_poSrcDataset->GetRasterXSize();
+    const int nYSize = m_poSrcDataset->GetRasterYSize();
+    const int nMaxNonBlack = m_psOptions->nMaxNonBlack;
+
+    struct Span
+    {
+        int x1;
+        int x2;
+        int y;
+        int dy;
+
+        Span(int x1In, int x2In, int yIn, int dyIn)
+            : x1(x1In), x2(x2In), y(yIn), dy(dyIn)
+        {
+        }
+    };
+
+    if (!LoadLine(iYInit))
+        return false;
+
+    if (!MustSet(iXInit, iYInit))
+    {
+        // nothing to do
+        return true;
+    }
+
+    std::queue<Span> queue;
+    queue.emplace(Span(iXInit, iXInit, iYInit, 1));
+    if (iYInit > 0)
+    {
+        queue.emplace(Span(iXInit, iXInit, iYInit - 1, -1));
+    }
+
+    while (!queue.empty())
+    {
+#ifdef DEBUG
+        m_nMaxQueueSize = std::max(m_nMaxQueueSize, queue.size());
+#endif
+
+        const Span s = queue.front();
+        queue.pop();
+
+        CPLAssert(s.x1 >= 0);
+        CPLAssert(s.x1 < nXSize);
+        CPLAssert(s.x2 >= 0);
+        CPLAssert(s.x2 < nXSize);
+        CPLAssert(s.x2 >= s.x1);
+        CPLAssert(s.y >= 0);
+        CPLAssert(s.y < nYSize);
+
+        int iX = s.x1;
+        const int iY = s.y;
+
+        if (!LoadLine(iY))
+            return false;
+
+        if (iX > 0 && MustSet(iX, iY))
+        {
+            int nNonBlackPixels = 0;
+            while (true)
+            {
+                if (!MustSet(iX - 1, iY))
+                {
+                    nNonBlackPixels++;
+                    if (nNonBlackPixels > nMaxNonBlack)
+                        break;
+                }
+                else
+                {
+                    nNonBlackPixels = 0;
+                }
+                if (!Set(iX - 1, iY))
+                    return false;
+                iX--;
+                if (iX == 0)
+                    break;
+            }
+        }
+        if (iX >= 0 && iX <= s.x1 - 1 && iY - s.dy >= 0 && iY - s.dy < nYSize)
+        {
+            queue.emplace(Span(iX, s.x1 - 1, iY - s.dy, -s.dy));
+        }
+        int iX1 = s.x1;
+        const int iX2 = s.x2;
+        while (iX1 <= iX2)
+        {
+            if (MustSet(iX1, iY))
+            {
+                if (!Set(iX1, iY))
+                    return false;
+                iX1++;
+
+                int nNonBlackPixels = 0;
+                while (iX1 < nXSize)
+                {
+                    if (!MustSet(iX1, iY))
+                    {
+                        nNonBlackPixels++;
+                        if (nNonBlackPixels > nMaxNonBlack)
+                            break;
+                    }
+                    else
+                    {
+                        nNonBlackPixels = 0;
+                    }
+                    if (!Set(iX1, iY))
+                        return false;
+                    iX1++;
+                }
+            }
+            if (iX <= iX1 - 1 && iY + s.dy >= 0 && iY + s.dy < nYSize)
+            {
+                queue.emplace(Span(iX, iX1 - 1, iY + s.dy, s.dy));
+            }
+            if (iX1 - 1 > iX2 && iY - s.dy >= 0 && iY - s.dy < nYSize)
+            {
+                queue.emplace(Span(iX2 + 1, iX1 - 1, iY - s.dy, -s.dy));
+            }
+            iX1++;
+            while (iX1 < iX2 && !MustSet(iX1, iY))
+                iX1++;
+            iX = iX1;
+        }
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*              GDALNearblackFloodFillAlg::Process()                    */
+/************************************************************************/
+
+// Entry point.
+// Returns true if no error.
+
+bool GDALNearblackFloodFillAlg::Process()
+{
+    const int nXSize = m_poSrcDataset->GetRasterXSize();
+    const int nYSize = m_poSrcDataset->GetRasterYSize();
+
+    /* -------------------------------------------------------------------- */
+    /*      Allocate working buffers.                                       */
+    /* -------------------------------------------------------------------- */
+    try
+    {
+        m_abyLine.resize(nXSize * m_nDstBands);
+        m_abyLineMustSet.resize(nXSize);
+        if (m_bSetMask)
+            m_abyMask.resize(nXSize);
+
+        m_abLineLoadedOnce.resize(nYSize);
+        m_abLineSavedOnce.resize(nYSize);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate working buffers: %s", e.what());
+        return false;
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Create a temporary dataset to save visited state                */
+    /* -------------------------------------------------------------------- */
+
+    // For debugging / testing purposes only
+    const char *pszTmpDriver =
+        CPLGetConfigOption("GDAL_TEMP_DRIVER_NAME", nullptr);
+    if (!pszTmpDriver)
+    {
+        pszTmpDriver =
+            (nXSize < 100 * 1024 * 1024 / nYSize ||
+             (m_poDstDS->GetDriver() &&
+              strcmp(m_poDstDS->GetDriver()->GetDescription(), "MEM") == 0))
+                ? "MEM"
+                : "GTiff";
+    }
+    GDALDriverH hDriver = GDALGetDriverByName(pszTmpDriver);
+    if (!hDriver)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Cannot find driver %s for temporary file", pszTmpDriver);
+        return false;
+    }
+    std::string osVisitedDataset = m_poDstDS->GetDescription();
+    VSIStatBuf sStat;
+    if (strcmp(pszTmpDriver, "MEM") == 0 ||
+        STARTS_WITH(osVisitedDataset.c_str(), "/vsimem/") ||
+        // Regular VSIStat() (not VSIStatL()) intended to check this is
+        // a real file
+        VSIStat(osVisitedDataset.c_str(), &sStat) == 0)
+    {
+        osVisitedDataset += ".visited";
+    }
+    else
+    {
+        osVisitedDataset = CPLGenerateTempFilename(osVisitedDataset.c_str());
+    }
+    CPLStringList aosOptions;
+    if (strcmp(pszTmpDriver, "GTiff") == 0)
+    {
+        aosOptions.SetNameValue("SPARSE_OK", "YES");
+        aosOptions.SetNameValue("COMPRESS", "LZW");
+        osVisitedDataset += ".tif";
+    }
+    m_poVisitedDS.reset(GDALDataset::FromHandle(
+        GDALCreate(hDriver, osVisitedDataset.c_str(), nXSize, nYSize, 1,
+                   GDT_Byte, aosOptions.List())));
+    if (!m_poVisitedDS)
+        return false;
+    if (strcmp(pszTmpDriver, "MEM") != 0)
+    {
+        VSIUnlink(osVisitedDataset.c_str());
+    }
+    m_poVisitedDS->MarkSuppressOnClose();
+
+    /* -------------------------------------------------------------------- */
+    /*      Iterate over the border of the raster                           */
+    /* -------------------------------------------------------------------- */
+    // Fill from top line
+    for (int iX = 0; iX < nXSize; iX++)
+    {
+        if (!Fill(iX, 0))
+            return false;
+    }
+
+    // Fill from left and right side
+    for (int iY = 1; iY < nYSize - 1; iY++)
+    {
+        if (!Fill(0, iY))
+            return false;
+        if (!Fill(nXSize - 1, iY))
+            return false;
+    }
+
+    // Fill from bottom line
+    for (int iX = 0; iX < nXSize; iX++)
+    {
+        if (!Fill(iX, nYSize - 1))
+            return false;
+    }
+
+    if (!(m_psOptions->pfnProgress(1.0, nullptr, m_psOptions->pProgressData)))
+    {
+        return false;
+    }
+
+#ifdef DEBUG
+    CPLDebug("GDAL", "flood fill max queue size = %u",
+             unsigned(m_nMaxQueueSize));
+#endif
+
+    // Force update of last visited line
+    return LoadLine(-1);
+}
+
+/************************************************************************/
+/*                    GDALNearblackFloodFill()                          */
+/************************************************************************/
+
+// Entry point.
+// Returns true if no error.
+
+bool GDALNearblackFloodFill(const GDALNearblackOptions *psOptions,
+                            GDALDatasetH hSrcDataset, GDALDatasetH hDstDS,
+                            GDALRasterBandH hMaskBand, int nSrcBands,
+                            int nDstBands, bool bSetMask, const Colors &oColors)
+{
+    GDALNearblackFloodFillAlg alg;
+    alg.m_psOptions = psOptions;
+    alg.m_poSrcDataset = GDALDataset::FromHandle(hSrcDataset);
+    alg.m_poDstDS = GDALDataset::FromHandle(hDstDS);
+    alg.m_poMaskBand = GDALRasterBand::FromHandle(hMaskBand);
+    alg.m_nSrcBands = nSrcBands;
+    alg.m_nDstBands = nDstBands;
+    alg.m_bSetMask = bSetMask;
+    alg.m_oColors = oColors;
+    alg.m_nReplacevalue = psOptions->bNearWhite ? 255 : 0;
+
+    return alg.Process();
+}

--- a/autotest/utilities/test_nearblack_lib.py
+++ b/autotest/utilities/test_nearblack_lib.py
@@ -40,10 +40,11 @@ from osgeo import gdal
 # Basic test
 
 
-def test_nearblack_lib_1():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_1(alg):
 
     src_ds = gdal.Open("../gdrivers/data/rgbsmall.tif")
-    ds = gdal.Nearblack("", src_ds, format="MEM", maxNonBlack=0, nearDist=15)
+    ds = gdal.Nearblack("", src_ds, format="MEM", maxNonBlack=0, nearDist=15, alg=alg)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 21106, "Bad checksum band 1"
@@ -68,10 +69,16 @@ def test_nearblack_lib_1():
 # Add alpha band
 
 
-def test_nearblack_lib_2():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_2(alg):
 
     ds = gdal.Nearblack(
-        "", "../gdrivers/data/rgbsmall.tif", format="MEM", maxNonBlack=0, setAlpha=True
+        "",
+        "../gdrivers/data/rgbsmall.tif",
+        format="MEM",
+        maxNonBlack=0,
+        setAlpha=True,
+        alg=alg,
     )
     assert ds is not None
 
@@ -84,12 +91,13 @@ def test_nearblack_lib_2():
 # Set existing alpha band
 
 
-def test_nearblack_lib_3():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_3(alg):
 
     src_ds = gdal.Nearblack(
         "", "../gdrivers/data/rgbsmall.tif", format="MEM", maxNonBlack=0, setAlpha=True
     )
-    ds = gdal.Nearblack("", src_ds, format="MEM", maxNonBlack=0, setAlpha=True)
+    ds = gdal.Nearblack("", src_ds, format="MEM", maxNonBlack=0, setAlpha=True, alg=alg)
     assert ds is not None
 
     assert ds.GetRasterBand(4).Checksum() == 22002, "Bad checksum band 0"
@@ -101,7 +109,8 @@ def test_nearblack_lib_3():
 # Test -white
 
 
-def test_nearblack_lib_4():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_4(alg):
 
     src_ds = gdal.Warp(
         "",
@@ -111,11 +120,12 @@ def test_nearblack_lib_4():
         srcNodata=0,
     )
     ds = gdal.Nearblack(
-        "", src_ds, format="MEM", white=True, maxNonBlack=0, setAlpha=True
+        "", src_ds, format="MEM", white=True, maxNonBlack=0, setAlpha=True, alg=alg
     )
     assert ds is not None
 
-    assert ds.GetRasterBand(4).Checksum() == 24151, "Bad checksum band 0"
+    expected_cs = 24151 if alg == "twopasses" else 24024
+    assert ds.GetRasterBand(4).Checksum() == expected_cs, "Bad checksum band 0"
 
     ds = None
 
@@ -124,7 +134,8 @@ def test_nearblack_lib_4():
 # Add mask band
 
 
-def test_nearblack_lib_5():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_5(alg):
 
     ds = gdal.Nearblack(
         "/vsimem/test_nearblack_lib_5.tif",
@@ -132,6 +143,7 @@ def test_nearblack_lib_5():
         format="GTiff",
         maxNonBlack=0,
         setMask=True,
+        alg=alg,
     )
     assert ds is not None
 
@@ -149,15 +161,21 @@ def test_nearblack_lib_5():
 # Test -color
 
 
-def test_nearblack_lib_7():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_7(alg):
 
     ds = gdal.Nearblack(
-        "", "data/whiteblackred.tif", format="MEM", colors=((0, 0, 0), (255, 255, 255))
+        "",
+        "data/whiteblackred.tif",
+        format="MEM",
+        colors=((0, 0, 0), (255, 255, 255)),
+        alg=alg,
+        maxNonBlack=0,
     )
     assert ds is not None
 
     assert (
-        ds.GetRasterBand(1).Checksum() == 418
+        ds.GetRasterBand(1).Checksum() == 1217
         and ds.GetRasterBand(2).Checksum() == 0
         and ds.GetRasterBand(3).Checksum() == 0
     ), "Bad checksum"
@@ -169,11 +187,12 @@ def test_nearblack_lib_7():
 # Test in-place update
 
 
-def test_nearblack_lib_8():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_8(alg):
 
     src_ds = gdal.Open("../gdrivers/data/rgbsmall.tif")
     ds = gdal.GetDriverByName("MEM").CreateCopy("", src_ds)
-    ret = gdal.Nearblack(ds, ds, maxNonBlack=0)
+    ret = gdal.Nearblack(ds, ds, maxNonBlack=0, alg=alg)
     assert ret == 1
 
     assert ds.GetRasterBand(1).Checksum() == 21106, "Bad checksum band 1"
@@ -183,7 +202,7 @@ def test_nearblack_lib_8():
     assert ds.GetRasterBand(3).Checksum() == 21309, "Bad checksum band 3"
 
 
-def _test_nearblack(in_array, expected_mask_array, maxNonBlack=0):
+def _test_nearblack(in_array, expected_mask_array, maxNonBlack=0, alg=None):
 
     ds = gdal.GetDriverByName("MEM").Create("", len(in_array[0]), len(in_array))
     ds.WriteRaster(
@@ -193,7 +212,9 @@ def _test_nearblack(in_array, expected_mask_array, maxNonBlack=0):
         ds.RasterYSize,
         b"".join([array.array("B", x).tobytes() for x in in_array]),
     )
-    ret_ds = gdal.Nearblack("", ds, maxNonBlack=maxNonBlack, format="MEM", setMask=True)
+    ret_ds = gdal.Nearblack(
+        "", ds, maxNonBlack=maxNonBlack, format="MEM", setMask=True, alg=alg
+    )
     mask_data = ret_ds.GetRasterBand(1).GetMaskBand().ReadRaster()
     mask_array = []
     for j in range(ds.RasterYSize):
@@ -203,7 +224,8 @@ def _test_nearblack(in_array, expected_mask_array, maxNonBlack=0):
     assert mask_array == expected_mask_array
 
 
-def test_nearblack_lib_9():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_all_valid(alg):
 
     # all valid -> no erosion
     _test_nearblack(
@@ -222,7 +244,12 @@ def test_nearblack_lib_9():
             [255, 255, 255, 255, 255],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
+
+
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_all_invalid(alg):
 
     # all invalid
     _test_nearblack(
@@ -241,7 +268,12 @@ def test_nearblack_lib_9():
             [0, 0, 0, 0, 0],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
+
+
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_single_pixel_valid(alg):
 
     # single pixel valid -> eroded
     _test_nearblack(
@@ -260,7 +292,13 @@ def test_nearblack_lib_9():
             [0, 0, 0, 0, 0],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
+
+
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+@pytest.mark.parametrize("maxNonBlack", [0, 1, 5])
+def test_nearblack_lib_all_contour_valid(alg, maxNonBlack):
 
     # all contour is valid -> no erosion
     _test_nearblack(
@@ -278,8 +316,13 @@ def test_nearblack_lib_9():
             [255, 255, 255, 255, 255],
             [255, 255, 255, 255, 255],
         ],
-        maxNonBlack=1,
+        maxNonBlack=maxNonBlack,
+        alg=alg,
     )
+
+
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_erosion_from_left(alg):
 
     # erosion from the left
     _test_nearblack(
@@ -298,8 +341,12 @@ def test_nearblack_lib_9():
             [255, 255, 255, 255, 255],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
 
+
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_erosion_from_right(alg):
     # erosion from the right
     _test_nearblack(
         [
@@ -317,7 +364,11 @@ def test_nearblack_lib_9():
             [255, 255, 255, 255, 255],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
+
+
+def test_nearblack_lib_erosion_from_top():
 
     # erosion from the top
     _test_nearblack(
@@ -338,6 +389,9 @@ def test_nearblack_lib_9():
         maxNonBlack=1,
     )
 
+
+def test_nearblack_lib_erosion_from_bottom():
+
     # erosion from the bottom
     _test_nearblack(
         [
@@ -356,6 +410,9 @@ def test_nearblack_lib_9():
         ],
         maxNonBlack=1,
     )
+
+
+def test_nearblack_lib_erosion_from_top_and_bottom():
 
     # Maybe erosion is a bit too greedy due to top-bottom + bottom-top passes
     _test_nearblack(
@@ -397,4 +454,76 @@ def test_nearblack_lib_9():
             [0, 0, 0, 0, 0],
         ],
         maxNonBlack=1,
+    )
+
+
+def test_nearblack_lib_floodfill_concave_from_left():
+
+    XXX = 0
+    input_ar = [
+        [255, 255, 255, 255, 255],
+        [255, XXX, XXX, XXX, 255],
+        [XXX, XXX, 255, XXX, 255],
+        [255, 255, XXX, XXX, 255],
+        [255, 255, 255, 255, 255],
+    ]
+    _test_nearblack(
+        input_ar,
+        input_ar,
+        maxNonBlack=0,
+        alg="floodfill",
+    )
+
+
+def test_nearblack_lib_floodfill_concave_from_right():
+
+    XXX = 0
+    input_ar = [
+        [255, 255, 255, 255, 255],
+        [255, XXX, XXX, XXX, 255],
+        [255, XXX, 255, XXX, XXX],
+        [255, XXX, XXX, 255, 255],
+        [255, 255, 255, 255, 255],
+    ]
+    _test_nearblack(
+        input_ar,
+        input_ar,
+        maxNonBlack=0,
+        alg="floodfill",
+    )
+
+
+def test_nearblack_lib_floodfill_concave_from_top():
+
+    XXX = 0
+    input_ar = [
+        [255, XXX, 255, 255, 255],
+        [255, XXX, XXX, XXX, 255],
+        [255, 255, 255, XXX, 255],
+        [255, 255, XXX, XXX, 255],
+        [255, 255, 255, 255, 255],
+    ]
+    _test_nearblack(
+        input_ar,
+        input_ar,
+        maxNonBlack=0,
+        alg="floodfill",
+    )
+
+
+def test_nearblack_lib_floodfill_concave_from_bottom():
+
+    XXX = 0
+    input_ar = [
+        [255, 255, 255, 255, 255],
+        [255, 255, XXX, XXX, 255],
+        [255, 255, 255, XXX, 255],
+        [255, XXX, XXX, XXX, 255],
+        [255, XXX, 255, 255, 255],
+    ]
+    _test_nearblack(
+        input_ar,
+        input_ar,
+        maxNonBlack=0,
+        alg="floodfill",
     )

--- a/autotest/utilities/test_nearblack_lib.py
+++ b/autotest/utilities/test_nearblack_lib.py
@@ -368,7 +368,8 @@ def test_nearblack_lib_erosion_from_right(alg):
     )
 
 
-def test_nearblack_lib_erosion_from_top():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_erosion_from_top(alg):
 
     # erosion from the top
     _test_nearblack(
@@ -387,10 +388,12 @@ def test_nearblack_lib_erosion_from_top():
             [255, 255, 255, 255, 255],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
 
 
-def test_nearblack_lib_erosion_from_bottom():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_erosion_from_bottom(alg):
 
     # erosion from the bottom
     _test_nearblack(
@@ -409,10 +412,12 @@ def test_nearblack_lib_erosion_from_bottom():
             [255, 0, 0, 0, 255],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
 
 
-def test_nearblack_lib_erosion_from_top_and_bottom():
+@pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
+def test_nearblack_lib_erosion_from_top_and_bottom(alg):
 
     # Maybe erosion is a bit too greedy due to top-bottom + bottom-top passes
     _test_nearblack(
@@ -435,6 +440,7 @@ def test_nearblack_lib_erosion_from_top_and_bottom():
             [0, 0, 0, 0, 0, 0, 0],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
 
     # Maybe erosion is a bit too greedy due to top-bottom + bottom-top passes
@@ -454,6 +460,7 @@ def test_nearblack_lib_erosion_from_top_and_bottom():
             [0, 0, 0, 0, 0],
         ],
         maxNonBlack=1,
+        alg=alg,
     )
 
 
@@ -525,5 +532,30 @@ def test_nearblack_lib_floodfill_concave_from_bottom():
         input_ar,
         input_ar,
         maxNonBlack=0,
+        alg="floodfill",
+    )
+
+
+def test_nearblack_lib_floodfill_concave_from_bottom_non_black():
+
+    XXX = 0
+    input_ar = [
+        [255, 255, 255, 255, 255],
+        [255, XXX, XXX, XXX, 255],
+        [255, 255, 255, 255, 255],
+        [255, XXX, 255, 255, 255],
+        [255, XXX, 255, 255, 255],
+    ]
+    output_ar = [
+        [255, 255, 255, 255, 255],
+        [255, XXX, XXX, XXX, 255],
+        [255, XXX, 255, 255, 255],
+        [255, XXX, 255, 255, 255],
+        [255, XXX, 255, 255, 255],
+    ]
+    _test_nearblack(
+        input_ar,
+        output_ar,
+        maxNonBlack=1,
         alg="floodfill",
     )

--- a/doc/source/programs/nearblack.rst
+++ b/doc/source/programs/nearblack.rst
@@ -16,7 +16,8 @@ Synopsis
 .. code-block::
 
     nearblack [-of format] [-white | [-color c1,c2,c3...cn]*] [-near dist] [-nb non_black_pixels]
-              [-setalpha] [-setmask] [-o outfile] [-q]  [-co "NAME=VALUE"]* infile
+              [-setalpha] [-setmask] [-o outfile] [-q] [-alg twopasses|floodfill]
+              [-co "NAME=VALUE"]* infile
 
 Description
 -----------
@@ -64,7 +65,8 @@ if either alpha band or mask band is not set.
 
 .. option:: -nb <non_black_pixels>
 
-    number of non-black pixels that can be encountered before the giving up search inwards. Defaults to 2.
+    number of consecutive non-black pixels that can be encountered before the
+    giving up search inwards. Defaults to 2.
 
 .. option:: -setalpha
 
@@ -79,6 +81,26 @@ if either alpha band or mask band is not set.
     or adds a mask band to the input file if it does not already have one and no output file is specified.
     The mask band is set to 0 in the image collar and to 255 elsewhere.
 
+.. option:: -alg twopasses|floodfill
+
+    .. versionadded:: 3.8
+
+    Selects the algorithm to apply.
+
+    ``twopasses`` uses a top-to-bottom pass followed by a bottom-to-top pass.
+    This is the only algorithm implemented before GDAL 3.8. It may miss with
+    concave areas.
+    The algorithm processes the image one scanline at a time.  A scan "in" is done
+    from either end setting pixels to black or white until at least
+    "non_black_pixels" pixels that are more than "dist" gray levels away from
+    black, white or custom colors have been encountered at which point the scan stops.  The nearly
+    black, white or custom color pixels are set to black or white. The algorithm also scans from
+    top to bottom and from bottom to top to identify indentations in the top or bottom.
+
+    ``floodfill`` (added in GDAL 3.8) uses the `Flood Fill <https://en.wikipedia.org/wiki/Flood_fill#Span_filling>`_
+    algorithm and will work with concave areas. It requires creating a temporary
+    dataset and is slower than ``twopasses``.
+
 .. option:: -q
 
     Suppress progress monitor and other non-error output.
@@ -88,12 +110,6 @@ if either alpha band or mask band is not set.
     The input file.  Any GDAL supported format, any number of bands, normally 8bit
     Byte bands.
 
-The algorithm processes the image one scanline at a time.  A scan "in" is done
-from either end setting pixels to black or white until at least
-"non_black_pixels" pixels that are more than "dist" gray levels away from
-black, white or custom colors have been encountered at which point the scan stops.  The nearly
-black, white or custom color pixels are set to black or white. The algorithm also scans from
-top to bottom and from bottom to top to identify indentations in the top or bottom.
 
 The processing is all done in 8bit (Bytes).
 

--- a/doc/source/programs/nearblack.rst
+++ b/doc/source/programs/nearblack.rst
@@ -99,7 +99,8 @@ if either alpha band or mask band is not set.
 
     ``floodfill`` (added in GDAL 3.8) uses the `Flood Fill <https://en.wikipedia.org/wiki/Flood_fill#Span_filling>`_
     algorithm and will work with concave areas. It requires creating a temporary
-    dataset and is slower than ``twopasses``.
+    dataset and is slower than ``twopasses``. When a non-zero value for :option:`-nb`
+    is used, ``twopasses`` is actually called as an initial step of ``floodfill``.
 
 .. option:: -q
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2796,6 +2796,7 @@ def DEMProcessing(destName, srcDS, processing, **kwargs):
 def NearblackOptions(options=None, format=None,
          creationOptions=None, white = False, colors=None,
          maxNonBlack=None, nearDist=None, setAlpha = False, setMask = False,
+         alg=None,
          callback=None, callback_data=None):
     """Create a NearblackOptions() object that can be passed to gdal.Nearblack()
 
@@ -2819,6 +2820,8 @@ def NearblackOptions(options=None, format=None,
         adds an alpha band to the output file.
     setMask:
         adds a mask band to the output file.
+    alg:
+        "twopasses" (default), or "floodfill"
     callback:
         callback method
     callback_data:
@@ -2853,6 +2856,8 @@ def NearblackOptions(options=None, format=None,
             new_options += ['-setalpha']
         if setMask:
             new_options += ['-setmask']
+        if alg:
+            new_options += ['-alg', alg]
 
     return (GDALNearblackOptions(new_options), callback, callback_data)
 


### PR DESCRIPTION
This algorithm, based on https://en.wikipedia.org/wiki/Flood_fill#Span_filling, works with concave areas, which the traditional -alg twopasses algorithm didn't work well.

Refs #6264
