### PR TITLE
[Backport release/3.7] TileDB: FillPrimitiveListArray(): fix data corruption with spatial filter (Coverity CID 1512587, 1512576)

### DIFF
--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -4934,8 +4934,8 @@ void OGRTileDBLayer::FillPrimitiveListArray(
                 offsets.push_back(nAccLen);
                 if (nItemLen && nAccLen < nSrcOffset)
                 {
-                    memmove(v_source->data() + nAccLen * sizeof(T),
-                            v_source->data() + nSrcOffset * sizeof(T),
+                    memmove(v_source->data() + nAccLen,
+                            v_source->data() + nSrcOffset,
                             nItemLen * sizeof(T));
                 }
                 nAccLen += nItemLen;
@@ -5025,7 +5025,7 @@ void OGRTileDBLayer::FillBoolListArray(
     }
     else
     {
-        offsetsPtr->resize(offsetsPtr->size() + 1);
+        CPLAssert(offsetsPtr->size() > static_cast<size_t>(psChild->length));
 
         auto &offsets = *offsetsPtr;
         const size_t nSrcVals = offsets.size();


### PR DESCRIPTION
Backport #7852
 **Authored by:** @rouault