### PR TITLE
OpenFileGDB: open v9 rasters when layer name is explictly provided

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
+++ b/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
@@ -470,7 +470,8 @@ class OGROpenFileGDBDataSource final : public OGRDataSource
                         const std::string &osRasterLayerName,
                         std::set<int> &oSetIgnoredRasterLayerTableNum);
     int OpenFileGDBv9(int iGDBFeatureClasses, int iGDBObjectClasses,
-                      int nInterestTable);
+                      int nInterestTable,
+                      const GDALOpenInfo *poOpenInfo, const std::string &osRasterLayerName);
     bool OpenRaster(const GDALOpenInfo *poOpenInfo,
                     const std::string &osLayerName,
                     const std::string &osDefinition,

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -403,7 +403,7 @@ bool OGROpenFileGDBDataSource::Open(const GDALOpenInfo *poOpenInfo)
         }
 
         int bRet = OpenFileGDBv9(iGDBFeatureClasses, iGDBObjectClasses,
-                                 nInterestTable);
+                                 nInterestTable, poOpenInfo, osRasterLayerName);
         if (!bRet)
             return false;
     }
@@ -928,7 +928,8 @@ bool OGROpenFileGDBDataSource::OpenFileGDBv10(
 
 int OGROpenFileGDBDataSource::OpenFileGDBv9(int iGDBFeatureClasses,
                                             int iGDBObjectClasses,
-                                            int nInterestTable)
+                                            int nInterestTable,
+                                            const GDALOpenInfo *poOpenInfo, const std::string &osRasterLayerName)
 {
     auto poTable = cpl::make_unique<FileGDBTable>();
 
@@ -1053,6 +1054,11 @@ int OGROpenFileGDBDataSource::OpenFileGDBv9(int iGDBFeatureClasses,
             const std::string osName(aosName[idx - 1]);
             AddLayer(osName, nInterestTable, nCandidateLayers, nLayersSDCOrCDF,
                      "", "", eGeomType, std::string());
+
+            if (!osRasterLayerName.empty() && osRasterLayerName == osName)
+            {
+                OpenRaster(poOpenInfo, osName, "", "");
+            }
         }
     }
 


### PR DESCRIPTION
Simple patch to open v9 rasters when layer name is provided, no SRS support yet.