### PR TITLE
Doc: Migrate remaining program notes from wiki

### DIFF
--- a/doc/source/programs/gdal_merge.rst
+++ b/doc/source/programs/gdal_merge.rst
@@ -102,19 +102,72 @@ target pixel in the resulting raster nor will it overwrite a valid pixel value.
     gdal_merge.py is a Python script, and will only work if GDAL was built
     with Python support.
 
-Example
--------
+Examples
+--------
 
-Create an image with the pixels in all bands initialized to 255.
+Creating an image with the pixels in all bands initialized to 255
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
     gdal_merge.py -init 255 -o out.tif in1.tif in2.tif
 
 
-Create an RGB image that shows blue in pixels with no data. The first two bands
-will be initialized to 0 and the third band will be initialized to 255.
+Creating an RGB image that shows blue in pixels with no data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The first two bands will be initialized to 0 and the third band will be
+initialized to 255.
 
 ::
 
     gdal_merge.py -init "0 0 255" -o out.tif in1.tif in2.tif
+
+
+Passing a large list of files to :program:`gdal_merge`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A large list of files can be passed to :program:`gdal_merge` by
+listing them in a text file using:
+
+.. code-block:: bash
+
+   ls -1 *.tif > tiff_list.txt
+
+on Linux, or
+
+.. code-block:: doscon
+
+   dir /b /s *.tif > tiff_list.txt
+
+on Windows. The text file can then be passed to :program:`gdal_merge`
+using `--optfile`:
+
+::
+
+   gdal_merge.py -o mosaic.tif --optfile tiff_list.txt
+
+Creating an RGB image by merging 3 different greyscale bands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Conduct "merging by stacking" with the :option:`-separate` flag. Given three
+greyscale files that cover the same area, you can run:
+
+.. code-block:: bash
+
+   gdal_merge.py -separate 1.tif 2.tif 3.tif -o rgb.tif
+
+This maps :file:`1.tif` to red, :file:`2.tif` to green and :file:`3.tif` to blue.
+
+Specifying overlap precedence
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The last image in the input line comes out on top of the finished image stack.
+You might also need to use :option:`-n` to note which value should not be
+copied into the destination image if it is not already defined as nodata.
+
+
+.. code-block:: bash
+
+   gdal_merge.py -o merge.tif -n 0 image1.tif image2.tif image3.tif image4.tif
+

--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -225,8 +225,7 @@ resampling, and rescaling pixels in the process.
 .. option:: -a_srs <srs_def>
 
     Override the projection for the output file. Can be used with
-    :option:`-a_ullr` to specify the pixel coordinate and size in this
-    projection.
+    :option:`-a_ullr` to specify the extent in this projection.
 
     .. include:: options/srs_def.rst
 

--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -224,7 +224,9 @@ resampling, and rescaling pixels in the process.
 
 .. option:: -a_srs <srs_def>
 
-    Override the projection for the output file.
+    Override the projection for the output file. Can be used with
+    :option:`-a_ullr` to specify the pixel coordinate and size in this
+    projection.
 
     .. include:: options/srs_def.rst
 
@@ -367,3 +369,9 @@ To create a RGBA dataset from a RGB dataset with a mask
 
     gdal_translate withmask.tif rgba.tif -b 1 -b 2 -b 3 -b mask
 
+
+Subsetting using :option:`-projwin` and :option:`-outsize`:
+
+.. code-block:: bash
+
+   gdal_translate -projwin -20037500 10037500 0 0 -outsize 100 100 frmt_wms_googlemaps_tms.xml junk.png

--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -364,6 +364,15 @@ with control information.
     in megabytes if the value is less than 10000. For values >=10000, this is
     interpreted as bytes.
 
+    The warper will total up the memory required to hold the input and output
+    image arrays and any auxilary masking arrays and if they are larger than
+    the "warp memory" allowed it will subdivide the chunk into smaller chunks
+    and try again.
+
+    If the -wm value is very small there is some extra overhead in doing many
+    small chunks so setting it larger is better but it is a matter of
+    diminishing returns.
+
 .. option:: -multi
 
     Use multithreaded warping implementation.
@@ -481,7 +490,7 @@ The details of how it is taken into account depends on the resampling kernel:
 
 - for bilinear, cubic, cubicspline and lanczos, for each target pixel, the
   coordinate of its center is projected back to source coordinates and a
-  correspond source pixel is identified. If this source pixel is invalid, the
+  corresponding source pixel is identified. If this source pixel is invalid, the
   target pixel is considered as nodata.
   Given that those resampling kernels have a non-null kernel radius, this source
   pixel is just one among other several source pixels, and it might be possible
@@ -492,6 +501,138 @@ The details of how it is taken into account depends on the resampling kernel:
 - for the other resampling methods, source pixels contributing to the target pixel
   are ignored if invalid. Only the valid ones are taken into account. If there are
   none, the target pixel is considered as nodata.
+
+If using :option:`-srcnodata` for multiple images with different invalid
+values, you need to either (a) pre-process them to have the same to-be-ignored
+value, or (b) set the nodata flag for each file. Use (b) if you need to preserve
+the original values for some reason, for example:
+
+.. code-block:: bash
+
+   # for this image we want to ignore black (0)
+   gdalwarp -srcnodata 0 -dstnodata 0 orig-ignore-black.tif black-nodata.tif
+
+   # and now we want to ignore white (0)
+   gdalwarp -srcnodata 255 -dstnodata 255 orig-ignore-white.tif white-nodata.tif
+
+   # and finally ignore a particular blue-grey (RGB 125 125 150)
+   gdalwarp -srcnodata "125 125 150" -dstnodata "125 125 150" orig-ignore-grey.tif grey-nodata.tif
+
+   # now we can mosaic them all and not worry about nodata parameters
+   gdalwarp black-nodata.tif grey-nodata.tif white-nodata.tif final-mosaic.tif
+
+
+Approximate transformation
+--------------------------
+
+By default :program:`gdalwarp` uses a linear approximator for the
+transformations with a permitted error of 0.125 pixels. The approximator
+basically transforms three points on a scanline: the start, end and middle.
+Then it compares the linear approximation of the center based on the end points
+to the real thing and checks the error. If the error is less than the error
+threshold then the remaining points are approximated (in two chunks utilizing
+the center point). If the error exceeds the threshold, the scanline is split
+into two sections, and the approximator is recursively applied to each section
+until the error is less than the threshold or all points have been exactly
+computed.
+
+The error threshold (in pixels) can be controlled with the gdalwarp
+:option:`-et` switch. If you want to compare a true pixel-by-pixel reprojection
+use :option:`-et 0` which disables this approximator entirely.
+
+
+Memory usage
+------------
+
+Adding RAM will almost certainly increase the speed of :program:`gdalwarp`.
+That's not at all the same as saying that it is worth it, or that the speed
+increase will be significant. Disks are the slowest part of the process.  By
+default :program:`gdalwarp` won't take much advantage of RAM. Using the flag
+:option:`-wm 500` will operate on 500MB chunks at a time which is better than
+the default. The warp memory specified by :option:`-wm` is shared among all
+threads, so it is especially beneficial to increase this value when running
+:program:`gdalwarp` with :option:`-wo NUM_THREADS` (or its equivalent
+:config:`GDAL_NUM_THREADS`) greater than 1.
+
+Increasing the I/O block cache size may also help. This can be done by
+setting the :config:`GDAL_CACHEMAX` configuration like:
+
+.. code-block:: bash
+
+   gdalwarp --config GDAL_CACHEMAX 500 -wm 500 ...
+
+This uses 500MB of RAM for read/write caching, and 500MB of RAM for working
+buffers during the warp. Beyond that it is doubtful more memory will make a
+substantial difference.
+
+Check CPU usage while :program:`gdalwarp` is running. If it is substantially
+less than 100% then you know things are IO bound. Otherwise they are CPU bound.
+The ``--debug`` option may also provide useful information. For instance, after
+running the following:
+
+.. code-block::
+
+   gdalwarp --debug on abc.tif def.tif
+
+a message like the following will be output:
+
+::
+
+  GDAL: 224 block reads on 32 block band 1 of utm.tif
+
+In this case it is saying that band 1 of :file:`utm.tif` has 32 blocks, but
+that 224 block reads were done, implying that lots of data was having to be
+re-read, presumably because of a limited IO cache. You will also see messages
+like:
+
+::
+
+   GDAL: GDALWarpKernel()::GWKNearestNoMasksByte()
+   Src=0,0,512x512 Dst=0,0,512x512
+
+The Src/Dst windows show you the "chunk size" being used. In this case my whole
+image which is very small. If you find things are being broken into a lot of
+chunks increasing :option:`-wm` may help somewhat.
+
+But far more important than memory are ensuring you are going through an
+optimized path in the warper. If you ever see it reporting
+``GDALWarpKernel()::GWKGeneralCase()`` you know things will be relatively slow.
+Basically, the fastest situations are nearest neighbour resampling on 8bit data
+without nodata or alpha masking in effect.
+
+
+Compressed output
+-----------------
+
+In some cases, the output of :program:`gdalwarp` may be much larger than the
+original, even if the same compression algorithm is used. By default,
+:program:`gdalwarp` operates on chunks that are not necessarily aligned with
+the boundaries of the blocks/tiles/strips of the output format, so this might
+cause repeated compression/decompression of partial blocks, leading to lost
+space in the output format.
+
+The situation can be improved by using the ``OPTIMIZE_SIZE`` warping option
+(:option:`-wo OPTIMIZE_SIZE=YES`), but note that depending on the source and
+target projections, it might also significantly slow down the warping process.
+
+Another possibility is to use :program:`gdalwarp` without compression and then
+follow up with :program:`gdal_translate` with compression:
+
+.. code-block:: bash
+
+   gdalwarp infile tempfile.tif ...options...
+   gdal_translate tempfile.tif outfile.tif -co compress=lzw ...etc.
+
+Alternatively, you can use a VRT file as the output format of :program:`gdalwarp`. The
+VRT file is just an XML file that will be created immediately. The
+:program:`gdal_translate` operations will be of course a bit slower as it will do the
+real warping operation.
+
+.. code-block:: bash
+
+   gdalwarp -of VRT infile tempfile.vrt ...options...
+   gdal_translate tempfile.vrt outfile.tif -co compress=lzw ...etc.
+
 
 Examples
 --------

--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -534,6 +534,14 @@ in a layer:
 
 Example of updating a value of an attribute in a shapefile with SQL by using the SQLite dialect:
 
-.. code-block::
+.. code-block:: bash
 
-    ogrinfo test.shp -dialect sqlite -sql "update test set attr='bar' where attr='foo'"
+   ogrinfo test.shp -dialect sqlite -sql "update test set attr='bar' where attr='foo'"
+
+Adding a column to an input file:
+
+.. code-block:: bash
+
+   ogrinfo input.shp -sql "ALTER TABLE input ADD fieldX float"
+
+

--- a/doc/source/programs/options/srs_def.rst
+++ b/doc/source/programs/options/srs_def.rst
@@ -1,4 +1,4 @@
 The coordinate reference systems that can be passed are anything supported by the
-OGRSpatialReference.SetFromUserInput() call, which includes EPSG Projected,
+:cpp:func:`OGRSpatialReference::SetFromUserInput` call, which includes EPSG Projected,
 Geographic or Compound CRS (i.e. EPSG:4296), a well known text (WKT) CRS definition,
 PROJ.4 declarations, or the name of a .prj file containing a WKT CRS definition.

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -205,8 +205,16 @@ Performance and caching
       :choices: <size>
       :default: 5%
 
-      This option controls the default GDAL raster block cache size. If its value
-      is small (less than 100000), it is assumed to be measured in megabytes,
+      Controls the default GDAL raster block cache size. When
+      blocks are read from disk, or written to disk, they are cached in a
+      global block cache by the :cpp:class:`GDALRasterBlock` class. Once this
+      cache exceeds :config:`GDAL_CACHEMAX` old blocks are flushed from the
+      cache.
+      This cache is mostly beneficial when needing to read or write blocks
+      several times. This could occur, for instance, in a scanline oriented
+      input file which is processed in multiple chunks (horizontally) by
+      :program:`gdalwarp`.
+      If its value is small (less than 100000), it is assumed to be measured in megabytes,
       otherwise in bytes. Alternatively, the value can be set to "X%" to mean X%
       of the usable physical RAM. Note that this value is only consulted the first
       time the cache size is requested.  To change this value programmatically

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -212,7 +212,7 @@ Performance and caching
       cache.
       This cache is mostly beneficial when needing to read or write blocks
       several times. This could occur, for instance, in a scanline oriented
-      input file which is processed in multiple chunks (horizontally) by
+      input file which is processed in multiple rectangular chunks by
       :program:`gdalwarp`.
       If its value is small (less than 100000), it is assumed to be measured in megabytes,
       otherwise in bytes. Alternatively, the value can be set to "X%" to mean X%

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -196,10 +196,9 @@ Performance and caching
 
 -  .. config:: GDAL_NUM_THREADS
       :choices: ALL_CPUS, <integer>
-      :default: ALL_CPUS
 
       Sets the number of worker threads to be used by GDAL operations that support
-      multithreading.
+      multithreading. The default value depends on the context in which it is used.
 
 -  .. config:: GDAL_CACHEMAX
       :choices: <size>


### PR DESCRIPTION
## What does this PR do?

Migrates program notes from https://trac.osgeo.org/gdal/wiki/UserDocs, except for https://trac.osgeo.org/gdal/wiki/UserDocs/Gdal2Tiles (would take me some time to understand those notes)

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
