### PR TITLE
[Backport release/3.7] Parquet: fix crash when calling SetIgnoredFields() after SetAttributeFilter() (fixes qgis/QGIS#53301)

### DIFF
--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -70,9 +70,9 @@ class OGRArrowLayer CPL_NON_FINAL
             Real,
             String,
         };
-        int iField{};
-        int iArrayIdx{};
-        int nOperation{};
+        int iField = -1;      // index to a OGRFeatureDefn OGRField
+        int iArrayIdx = -1;   // index to m_poBatchColumns
+        int nOperation = -1;  // SWQ_xxxx
         Type eType{};
         OGRField sValue{};
         std::string osValue{};
@@ -175,6 +175,9 @@ class OGRArrowLayer CPL_NON_FINAL
         m_poBatch = poBatch;
         m_poBatchColumns = m_poBatch->columns();
     }
+
+    // Refreshes Constraint.iArrayIdx from iField. To be called by SetIgnoredFields()
+    void ComputeConstraintsArrayIdx();
 
     virtual bool GetFastExtent(int iGeomField, OGREnvelope *psExtent) const;
     static OGRErr GetExtentFromMetadata(const CPLJSONObject &oJSONDef,

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -2150,28 +2150,42 @@ static bool FillTargetValueFromSrcExpr(const OGRFieldDefn *poFieldDefn,
 }
 
 /***********************************************************************/
-/*                     ExploreExprNode()                               */
+/*                  ComputeConstraintsArrayIdx()                       */
 /***********************************************************************/
 
-inline void OGRArrowLayer::ExploreExprNode(const swq_expr_node *poNode)
+inline void OGRArrowLayer::ComputeConstraintsArrayIdx()
 {
-    const auto AddConstraint = [this](Constraint &constraint)
+    for (auto &constraint : m_asAttributeFilterConstraints)
     {
         if (m_bIgnoredFields)
         {
             constraint.iArrayIdx =
                 m_anMapFieldIndexToArrayIndex[constraint.iField];
             if (constraint.iArrayIdx < 0)
-                return;
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Constraint on field %s cannot be applied due to "
+                         "it being ignored",
+                         m_poFeatureDefn->GetFieldDefn(constraint.iField)
+                             ->GetNameRef());
+            }
         }
         else
         {
             constraint.iArrayIdx =
                 m_anMapFieldIndexToArrowColumn[constraint.iField][0];
         }
+    }
+}
 
-        m_asAttributeFilterConstraints.emplace_back(constraint);
-    };
+/***********************************************************************/
+/*                     ExploreExprNode()                               */
+/***********************************************************************/
+
+inline void OGRArrowLayer::ExploreExprNode(const swq_expr_node *poNode)
+{
+    const auto AddConstraint = [this](Constraint &constraint)
+    { m_asAttributeFilterConstraints.emplace_back(constraint); };
 
     if (poNode->eNodeType == SNT_OPERATION && poNode->nOperation == SWQ_AND &&
         poNode->nSubExprCount == 2)
@@ -2293,6 +2307,7 @@ inline OGRErr OGRArrowLayer::SetAttributeFilter(const char *pszFilter)
                 static_cast<swq_expr_node *>(m_poAttrQuery->GetSWQExpr());
             poNode->ReplaceBetweenByGEAndLERecurse();
             ExploreExprNode(poNode);
+            ComputeConstraintsArrayIdx();
         }
     }
 
@@ -2439,6 +2454,14 @@ inline bool OGRArrowLayer::SkipToNextFeatureDueToAttributeFilter() const
 {
     for (const auto &constraint : m_asAttributeFilterConstraints)
     {
+        if (constraint.iArrayIdx < 0)
+        {
+            // can happen if ignoring a field that is needed by the
+            // attribute filter. ComputeConstraintsArrayIdx() will have
+            // warned about that
+            continue;
+        }
+
         const arrow::Array *array =
             m_poBatchColumns[constraint.iArrayIdx].get();
 

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -1139,6 +1139,8 @@ OGRErr OGRParquetLayer::SetIgnoredFields(const char **papszFields)
         }
     }
 
+    ComputeConstraintsArrayIdx();
+
     // Full invalidation
     m_iRecordBatch = -1;
     m_bSingleBatch = false;


### PR DESCRIPTION
Backport #7882
 **Authored by:** @rouault