### PR TITLE
SWIG JAVA: add Read/WriteRaster abilities for GDT_UInt64 & GDT_Int64

### DIFF
--- a/swig/include/java/gdal_java.i
+++ b/swig/include/java/gdal_java.i
@@ -254,6 +254,7 @@ static CPLErr DatasetRasterIO( GDALDatasetH hDS, GDALRWFlag eRWFlag,
 {
     if ((gdal_type == GDT_Int16 && buf_type != GDT_Int16 && buf_type != GDT_UInt16 && buf_type != GDT_CInt16) ||
         (gdal_type == GDT_Int32 && buf_type != GDT_Int32 && buf_type != GDT_UInt32 && buf_type != GDT_CInt32) ||
+        (gdal_type == GDT_Int64 && buf_type != GDT_Int64 && buf_type != GDT_UInt64) ||
         (gdal_type == GDT_Float32 && buf_type != GDT_Float32 && buf_type != GDT_CFloat32) ||
         (gdal_type == GDT_Float64 && buf_type != GDT_Float64 && buf_type != GDT_CFloat64))
   {
@@ -304,12 +305,14 @@ static CPLErr DatasetRasterIO( GDALDatasetH hDS, GDALRWFlag eRWFlag,
 %apply (char *regularArrayOut, long nRegularArraySizeOut) { (char *regularArrayOut, long nRegularArraySizeOut) };
 %apply (short *regularArrayOut, long nRegularArraySizeOut) { (short *regularArrayOut, long nRegularArraySizeOut) };
 %apply (int *regularArrayOut, long nRegularArraySizeOut) { (int *regularArrayOut, long nRegularArraySizeOut) };
+%apply (long *regularArrayOut, long nRegularArraySizeOut) { (long *regularArrayOut, long nRegularArraySizeOut) };
 %apply (float *regularArrayOut, long nRegularArraySizeOut) { (float *regularArrayOut, long nRegularArraySizeOut) };
 %apply (double *regularArrayOut, long nRegularArraySizeOut) { (double *regularArrayOut, long nRegularArraySizeOut) };
 
 %apply (char *regularArrayIn, long nRegularArraySizeIn) { (char *regularArrayIn, long nRegularArraySizeIn) };
 %apply (short *regularArrayIn, long nRegularArraySizeIn) { (short *regularArrayIn, long nRegularArraySizeIn) };
 %apply (int *regularArrayIn, long nRegularArraySizeIn) { (int *regularArrayIn, long nRegularArraySizeIn) };
+%apply (long *regularArrayIn, long nRegularArraySizeIn) { (long *regularArrayIn, long nRegularArraySizeIn) };
 %apply (float *regularArrayIn, long nRegularArraySizeIn) { (float *regularArrayIn, long nRegularArraySizeIn) };
 %apply (double *regularArrayIn, long nRegularArraySizeIn) { (double *regularArrayIn, long nRegularArraySizeIn) };
 
@@ -353,6 +356,7 @@ CPLErr ReadRaster( int xoff, int yoff, int xsize, int ysize,
   DEFINE_DS_READ_RASTER(char, GDT_Byte)
   DEFINE_DS_READ_RASTER(short, GDT_Int16)
   DEFINE_DS_READ_RASTER(int, GDT_Int32)
+  DEFINE_DS_READ_RASTER(long, GDT_Int64)
   DEFINE_DS_READ_RASTER(float, GDT_Float32)
   DEFINE_DS_READ_RASTER(double, GDT_Float64)
 
@@ -396,6 +400,7 @@ CPLErr ReadRaster( int xoff, int yoff, int xsize, int ysize,
   DEFINE_DS_WRITE_RASTER(char, GDT_Byte)
   DEFINE_DS_WRITE_RASTER(short, GDT_Int16)
   DEFINE_DS_WRITE_RASTER(int, GDT_Int32)
+  DEFINE_DS_WRITE_RASTER(long, GDT_Int64)
   DEFINE_DS_WRITE_RASTER(float, GDT_Float32)
   DEFINE_DS_WRITE_RASTER(double, GDT_Float64)
 
@@ -420,6 +425,7 @@ static CPLErr BandRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag,
 {
     if ((gdal_type == GDT_Int16 && buf_type != GDT_Int16 && buf_type != GDT_UInt16 && buf_type != GDT_CInt16) ||
         (gdal_type == GDT_Int32 && buf_type != GDT_Int32 && buf_type != GDT_UInt32 && buf_type != GDT_CInt32) ||
+        (gdal_type == GDT_Int64 && buf_type != GDT_Int64 && buf_type != GDT_UInt64) ||
         (gdal_type == GDT_Float32 && buf_type != GDT_Float32 && buf_type != GDT_CFloat32) ||
         (gdal_type == GDT_Float64 && buf_type != GDT_Float64 && buf_type != GDT_CFloat64))
     {
@@ -488,6 +494,7 @@ static CPLErr BandRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag,
   DEFINE_READ_RASTER(char, GDT_Byte)
   DEFINE_READ_RASTER(short, GDT_Int16)
   DEFINE_READ_RASTER(int, GDT_Int32)
+  DEFINE_READ_RASTER(long, GDT_Int64)
   DEFINE_READ_RASTER(float, GDT_Float32)
   DEFINE_READ_RASTER(double, GDT_Float64)
 
@@ -526,6 +533,7 @@ static CPLErr BandRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag,
   DEFINE_WRITE_RASTER(char, GDT_Byte)
   DEFINE_WRITE_RASTER(short, GDT_Int16)
   DEFINE_WRITE_RASTER(int, GDT_Int32)
+  DEFINE_WRITE_RASTER(long, GDT_Int64)
   DEFINE_WRITE_RASTER(float, GDT_Float32)
   DEFINE_WRITE_RASTER(double, GDT_Float64)
 
@@ -549,12 +557,14 @@ static CPLErr BandRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag,
 %clear (char *regularArrayOut, long nRegularArraySizeOut);
 %clear (short *regularArrayOut, long nRegularArraySizeOut);
 %clear (int *regularArrayOut, long nRegularArraySizeOut);
+%clear (long *regularArrayOut, long nRegularArraySizeOut);
 %clear (float *regularArrayOut, long nRegularArraySizeOut);
 %clear (double *regularArrayOut, long nRegularArraySizeOut);
 
 %clear (char *regularArrayIn, long nRegularArraySizeIn);
 %clear (short *regularArrayIn, long nRegularArraySizeIn);
 %clear (int *regularArrayIn, long nRegularArraySizeIn);
+%clear (long *regularArrayIn, long nRegularArraySizeIn);
 %clear (float *regularArrayIn, long nRegularArraySizeIn);
 %clear (double *regularArrayIn, long nRegularArraySizeIn);
 
@@ -801,6 +811,14 @@ import org.gdal.gdalconst.gdalconstConstants;
        return ReadRaster(xoff, yoff, xsize, ysize, xsize, ysize, gdalconstConstants.GDT_Int32, array);
    }
 
+   public int ReadRaster(int xoff, int yoff, int xsize, int ysize, int buf_type, long[] array) {
+       return ReadRaster(xoff, yoff, xsize, ysize, xsize, ysize, buf_type, array);
+   }
+
+   public int ReadRaster(int xoff, int yoff, int xsize, int ysize, long[] array) {
+       return ReadRaster(xoff, yoff, xsize, ysize, xsize, ysize, gdalconstConstants.GDT_Int64, array);
+   }
+
    public int ReadRaster(int xoff, int yoff, int xsize, int ysize, int buf_type, float[] array) {
        return ReadRaster(xoff, yoff, xsize, ysize, xsize, ysize, buf_type, array);
    }
@@ -854,6 +872,14 @@ import org.gdal.gdalconst.gdalconstConstants;
 
    public int WriteRaster(int xoff, int yoff, int xsize, int ysize, int[] array) {
        return WriteRaster(xoff, yoff, xsize, ysize, xsize, ysize, gdalconstConstants.GDT_Int32, array);
+   }
+
+   public int WriteRaster(int xoff, int yoff, int xsize, int ysize, int buf_type, long[] array) {
+       return WriteRaster(xoff, yoff, xsize, ysize, xsize, ysize, buf_type, array);
+   }
+
+   public int WriteRaster(int xoff, int yoff, int xsize, int ysize, long[] array) {
+       return WriteRaster(xoff, yoff, xsize, ysize, xsize, ysize, gdalconstConstants.GDT_Int64, array);
    }
 
    public int WriteRaster(int xoff, int yoff, int xsize, int ysize, int buf_type, float[] array) {

--- a/swig/include/java/gdal_java.i
+++ b/swig/include/java/gdal_java.i
@@ -305,14 +305,14 @@ static CPLErr DatasetRasterIO( GDALDatasetH hDS, GDALRWFlag eRWFlag,
 %apply (char *regularArrayOut, long nRegularArraySizeOut) { (char *regularArrayOut, long nRegularArraySizeOut) };
 %apply (short *regularArrayOut, long nRegularArraySizeOut) { (short *regularArrayOut, long nRegularArraySizeOut) };
 %apply (int *regularArrayOut, long nRegularArraySizeOut) { (int *regularArrayOut, long nRegularArraySizeOut) };
-%apply (long *regularArrayOut, long nRegularArraySizeOut) { (long *regularArrayOut, long nRegularArraySizeOut) };
+%apply (int64_t *regularArrayOut, long nRegularArraySizeOut) { (int64_t *regularArrayOut, long nRegularArraySizeOut) };
 %apply (float *regularArrayOut, long nRegularArraySizeOut) { (float *regularArrayOut, long nRegularArraySizeOut) };
 %apply (double *regularArrayOut, long nRegularArraySizeOut) { (double *regularArrayOut, long nRegularArraySizeOut) };
 
 %apply (char *regularArrayIn, long nRegularArraySizeIn) { (char *regularArrayIn, long nRegularArraySizeIn) };
 %apply (short *regularArrayIn, long nRegularArraySizeIn) { (short *regularArrayIn, long nRegularArraySizeIn) };
 %apply (int *regularArrayIn, long nRegularArraySizeIn) { (int *regularArrayIn, long nRegularArraySizeIn) };
-%apply (long *regularArrayIn, long nRegularArraySizeIn) { (long *regularArrayIn, long nRegularArraySizeIn) };
+%apply (int64_t *regularArrayIn, long nRegularArraySizeIn) { (int64_t *regularArrayIn, long nRegularArraySizeIn) };
 %apply (float *regularArrayIn, long nRegularArraySizeIn) { (float *regularArrayIn, long nRegularArraySizeIn) };
 %apply (double *regularArrayIn, long nRegularArraySizeIn) { (double *regularArrayIn, long nRegularArraySizeIn) };
 
@@ -356,7 +356,7 @@ CPLErr ReadRaster( int xoff, int yoff, int xsize, int ysize,
   DEFINE_DS_READ_RASTER(char, GDT_Byte)
   DEFINE_DS_READ_RASTER(short, GDT_Int16)
   DEFINE_DS_READ_RASTER(int, GDT_Int32)
-  DEFINE_DS_READ_RASTER(long, GDT_Int64)
+  DEFINE_DS_READ_RASTER(int64_t, GDT_Int64)
   DEFINE_DS_READ_RASTER(float, GDT_Float32)
   DEFINE_DS_READ_RASTER(double, GDT_Float64)
 
@@ -400,7 +400,7 @@ CPLErr ReadRaster( int xoff, int yoff, int xsize, int ysize,
   DEFINE_DS_WRITE_RASTER(char, GDT_Byte)
   DEFINE_DS_WRITE_RASTER(short, GDT_Int16)
   DEFINE_DS_WRITE_RASTER(int, GDT_Int32)
-  DEFINE_DS_WRITE_RASTER(long, GDT_Int64)
+  DEFINE_DS_WRITE_RASTER(int64_t, GDT_Int64)
   DEFINE_DS_WRITE_RASTER(float, GDT_Float32)
   DEFINE_DS_WRITE_RASTER(double, GDT_Float64)
 
@@ -494,7 +494,7 @@ static CPLErr BandRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag,
   DEFINE_READ_RASTER(char, GDT_Byte)
   DEFINE_READ_RASTER(short, GDT_Int16)
   DEFINE_READ_RASTER(int, GDT_Int32)
-  DEFINE_READ_RASTER(long, GDT_Int64)
+  DEFINE_READ_RASTER(int64_t, GDT_Int64)
   DEFINE_READ_RASTER(float, GDT_Float32)
   DEFINE_READ_RASTER(double, GDT_Float64)
 
@@ -533,7 +533,7 @@ static CPLErr BandRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag,
   DEFINE_WRITE_RASTER(char, GDT_Byte)
   DEFINE_WRITE_RASTER(short, GDT_Int16)
   DEFINE_WRITE_RASTER(int, GDT_Int32)
-  DEFINE_WRITE_RASTER(long, GDT_Int64)
+  DEFINE_WRITE_RASTER(int64_t, GDT_Int64)
   DEFINE_WRITE_RASTER(float, GDT_Float32)
   DEFINE_WRITE_RASTER(double, GDT_Float64)
 
@@ -557,14 +557,14 @@ static CPLErr BandRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag,
 %clear (char *regularArrayOut, long nRegularArraySizeOut);
 %clear (short *regularArrayOut, long nRegularArraySizeOut);
 %clear (int *regularArrayOut, long nRegularArraySizeOut);
-%clear (long *regularArrayOut, long nRegularArraySizeOut);
+%clear (int64_t *regularArrayOut, long nRegularArraySizeOut);
 %clear (float *regularArrayOut, long nRegularArraySizeOut);
 %clear (double *regularArrayOut, long nRegularArraySizeOut);
 
 %clear (char *regularArrayIn, long nRegularArraySizeIn);
 %clear (short *regularArrayIn, long nRegularArraySizeIn);
 %clear (int *regularArrayIn, long nRegularArraySizeIn);
-%clear (long *regularArrayIn, long nRegularArraySizeIn);
+%clear (int64_t *regularArrayIn, long nRegularArraySizeIn);
 %clear (float *regularArrayIn, long nRegularArraySizeIn);
 %clear (double *regularArrayIn, long nRegularArraySizeIn);
 

--- a/swig/include/java/typemaps_java.i
+++ b/swig/include/java/typemaps_java.i
@@ -1571,6 +1571,11 @@ DEFINE_REGULAR_ARRAY_OUT(int, jint, SetIntArrayRegion);
 %typemap(jtype) (int *regularArrayOut, long nRegularArraySizeOut)  "int[]"
 %typemap(jstype) (int *regularArrayOut, long nRegularArraySizeOut)  "int[]"
 
+DEFINE_REGULAR_ARRAY_OUT(int64_t, jlong, SetLongArrayRegion);
+%typemap(jni) (int64_t *regularArrayOut, long nRegularArraySizeOut)  "jlongArray"
+%typemap(jtype) (int64_t *regularArrayOut, long nRegularArraySizeOut)  "long[]"
+%typemap(jstype) (int64_t *regularArrayOut, long nRegularArraySizeOut)  "long[]"
+
 DEFINE_REGULAR_ARRAY_OUT(float, jfloat, SetFloatArrayRegion);
 %typemap(jni) (float *regularArrayOut, long nRegularArraySizeOut)  "jfloatArray"
 %typemap(jtype) (float *regularArrayOut, long nRegularArraySizeOut)  "float[]"
@@ -1634,6 +1639,11 @@ DEFINE_REGULAR_ARRAY_IN(int, jint, GetIntArrayElements, ReleaseIntArrayElements)
 %typemap(jni) (int *regularArrayIn, long nRegularArraySizeIn)  "jintArray"
 %typemap(jtype) (int *regularArrayIn, long nRegularArraySizeIn)  "int[]"
 %typemap(jstype) (int *regularArrayIn, long nRegularArraySizeIn)  "int[]"
+
+DEFINE_REGULAR_ARRAY_IN(int64_t, jlong, GetLongArrayElements, ReleaseLongArrayElements);
+%typemap(jni) (int64_t *regularArrayIn, long nRegularArraySizeIn)  "jlongArray"
+%typemap(jtype) (int64_t *regularArrayIn, long nRegularArraySizeIn)  "long[]"
+%typemap(jstype) (int64_t *regularArrayIn, long nRegularArraySizeIn)  "long[]"
 
 DEFINE_REGULAR_ARRAY_IN(float, jfloat, GetFloatArrayElements, ReleaseFloatArrayElements);
 %typemap(jni) (float *regularArrayIn, long nRegularArraySizeIn)  "jfloatArray"

--- a/swig/java/apps/GDALTestIO.java
+++ b/swig/java/apps/GDALTestIO.java
@@ -213,7 +213,7 @@ public class GDALTestIO implements Runnable
 		int nBands = 1;
         Driver driver = gdal.GetDriverByName("MEM");
         Dataset dataset = driver.Create("fred", xSz, ySz, nBands, gdalconst.GDT_Int64);
-        data1 = new long[]{1,2,3,4,5,6,7,8,9,10};
+        data1 = new long[]{1,43L*Integer.MAX_VALUE,3,4,5,6,7,8,9,10};
         data2 = new long[data1.length];
         dataset.WriteRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data1, new int[]{1});
         dataset.ReadRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data2, new int[]{1});
@@ -223,8 +223,8 @@ public class GDALTestIO implements Runnable
 		}
         data1 = new long[data2.length];
         data2 = new long[]{10,9,8,7,6,5,4,3,2,1};
-        dataset.WriteRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data1, new int[]{1});
-        dataset.ReadRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data2, new int[]{1});
+        dataset.GetRasterBand(1).WriteRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data1);
+        dataset.GetRasterBand(1).ReadRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data2);
         for (int i = 0; i < data1.length; i++) {
 			if (data1[i] != data2[i])
                 throw new RuntimeException("int64 write and read values are not the same "+data1[i]+" "+data2[i]);

--- a/swig/java/apps/GDALTestIO.java
+++ b/swig/java/apps/GDALTestIO.java
@@ -163,6 +163,8 @@ public class GDALTestIO implements Runnable
     {
         gdal.AllRegister();
 
+        testInt64();
+        
         int nbIters = 50;
 
         method = METHOD_JAVA_ARRAYS;
@@ -200,4 +202,32 @@ public class GDALTestIO implements Runnable
 
         System.out.println("Success !");
     }
+    
+    private static void testInt64() {
+		
+		long[] data1;
+		long[] data2;
+		
+		int xSz = 5;
+		int ySz = 2;
+		int nBands = 1;
+        Driver driver = gdal.GetDriverByName("MEM");
+        Dataset dataset = driver.Create("fred", xSz, ySz, nBands, gdalconst.GDT_Int64);
+        data1 = new long[]{1,2,3,4,5,6,7,8,9,10};
+        data2 = new long[data1.length];
+        dataset.WriteRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data1, new int[]{1});
+        dataset.ReadRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data2, new int[]{1});
+        for (int i = 0; i < data1.length; i++) {
+			if (data1[i] != data2[i])
+                throw new RuntimeException("int64 write and read values are not the same "+data1[i]+" "+data2[i]);
+		}
+        data1 = new long[data2.length];
+        data2 = new long[]{10,9,8,7,6,5,4,3,2,1};
+        dataset.WriteRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data1, new int[]{1});
+        dataset.ReadRaster(0, 0, xSz, ySz, xSz, ySz, gdalconst.GDT_Int64, data2, new int[]{1});
+        for (int i = 0; i < data1.length; i++) {
+			if (data1[i] != data2[i])
+                throw new RuntimeException("int64 write and read values are not the same "+data1[i]+" "+data2[i]);
+		}
+	}
 }


### PR DESCRIPTION
This commit extends the ReadRaster and WriteRaster methods in the Java API by changes to the SWIG definitions in gdal_java.i.

This is my first commit and is done by inspection. The changes are straightforward. Please let me know what things I need to continue to do. Tests? If so how? Do you need some kind of documentation? Please advise. Thanks.