### PR TITLE
Add missing include <memory>

### DIFF
--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -40,6 +40,7 @@
 #include "cpl_multiproc.h"
 
 #include <map>
+#include <memory>
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
Fixes the build if only `cpl_vsi_virtual.h` is included.

#### Environment

* OS: Debian 11
* Compiler: gcc 10.2.1
