### PR TITLE
ZarrV3: fix crash on invalid shape/chunk_shape values (master only)

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -2210,6 +2210,36 @@ def test_zarr_create_array_endian_v3(options, expected_json, gdal_data_type):
             },
             "Binary representation of fill_value no supported for this data type",
         ],
+        [
+            {
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [1 << 40, 1 << 40],
+                "data_type": "uint8",
+                "chunk_grid": {
+                    "name": "regular",
+                    "configuration": {"chunk_shape": [1 << 40, 1 << 40]},
+                },
+                "chunk_key_encoding": {"name": "default"},
+                "fill_value": 0,
+            },
+            "Too large chunks",
+        ],
+        [
+            {
+                "zarr_format": 3,
+                "node_type": "array",
+                "shape": [1 << 30, 1 << 30, 1 << 30],
+                "data_type": "uint8",
+                "chunk_grid": {
+                    "name": "regular",
+                    "configuration": {"chunk_shape": [1, 1, 1]},
+                },
+                "chunk_key_encoding": {"name": "default"},
+                "fill_value": 0,
+            },
+            "Array test has more than 2^64 tiles. This is not supported.",
+        ],
     ],
 )
 def test_zarr_read_invalid_zarr_v3(j, error_msg):

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -1598,6 +1598,8 @@ ZarrV3Group::LoadArray(const std::string &osArrayName,
     auto poArray =
         ZarrV3Array::Create(m_poSharedResource, GetFullName(), osArrayName,
                             aoDims, oType, aoDtypeElts, anBlockSize);
+    if (!poArray)
+        return nullptr;
     poArray->SetUpdatable(m_bUpdatable);  // must be set before SetAttributes()
     poArray->SetFilename(osZarrayFilename);
     poArray->SetIsV2ChunkKeyEncoding(bV2ChunkKeyEncoding);


### PR DESCRIPTION
(fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59607)
