### PR TITLE
autotest: Add some tests for OGRGeometryFactory::organizePolygons

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(
   test_gdal_gtiff.cpp
   test_gdal_pixelfn.cpp
   test_ogr.cpp
+  test_ogr_organize_polygons.cpp
   test_ogr_geometry_stealing.cpp
   test_ogr_lgpl.cpp
   test_ogr_geos.cpp

--- a/autotest/cpp/test_ogr_organize_polygons.cpp
+++ b/autotest/cpp/test_ogr_organize_polygons.cpp
@@ -1,0 +1,304 @@
+/**********************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  Test OGRGeometryFactory::organizePolygons
+ * Author:   Daniel Baston <dbaston at gmail.com>
+ *
+ **********************************************************************
+ * Copyright (c) 2023, ISciences LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_unit_test.h"
+#include "cpl_string.h"
+#include "ogr_geometry.h"
+#include "gtest_include.h"
+
+#include <vector>
+
+struct OrganizeResult
+{
+    std::unique_ptr<OGRGeometry> geom;
+    bool isValid;
+};
+
+static OrganizeResult organizePolygons(std::vector<OGRGeometry *> &polygons,
+                                       const std::string &method)
+{
+    CPLStringList options;
+    options.AddNameValue("METHOD", method.c_str());
+
+    int isValid;
+
+    OrganizeResult ret;
+    ret.geom.reset(OGRGeometryFactory::organizePolygons(
+        polygons.data(), static_cast<int>(polygons.size()), &isValid,
+        (const char **)options.List()));
+    ret.isValid = CPL_TO_BOOL(isValid);
+
+    return ret;
+}
+
+static OGRGeometry *readWKT(const std::string &wkt)
+{
+    OGRGeometry *g;
+    auto err = OGRGeometryFactory::createFromWkt(wkt.c_str(), nullptr, &g);
+
+    if (err != OGRERR_NONE)
+    {
+        throw std::runtime_error("Failed to parse WKT");
+    }
+
+    return g;
+}
+
+class OrganizePolygonsTest : public testing::TestWithParam<std::string>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    test_gdal, OrganizePolygonsTest,
+    ::testing::Values("DEFAULT", "ONLY_CCW", "SKIP"),
+    [](const ::testing::TestParamInfo<std::string> &param_info)
+    { return param_info.param; });
+
+TEST_P(OrganizePolygonsTest, EmptyInputVector)
+{
+    std::vector<OGRGeometry *> polygons;
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+    ASSERT_EQ(result.geom->getGeometryType(), wkbPolygon);
+    ASSERT_TRUE(result.geom->IsEmpty());
+    ASSERT_TRUE(result.isValid);
+}
+
+TEST_P(OrganizePolygonsTest, SinglePolygonInput)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(readWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))"));
+
+    std::unique_ptr<OGRGeometry> expected(polygons.front()->clone());
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+    ASSERT_EQ(result.geom->getGeometryType(), wkbPolygon);
+    ASSERT_TRUE(result.geom->Equals(expected.get()));
+    ASSERT_TRUE(result.isValid);
+}
+
+TEST_P(OrganizePolygonsTest, SingleCurvePolygonInput)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(readWKT("CURVEPOLYGON ((0 0, 1 0, 1 1, 0 0))"));
+
+    std::unique_ptr<OGRGeometry> expected(polygons.front()->clone());
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+    ASSERT_EQ(result.geom->getGeometryType(), wkbCurvePolygon);
+    ASSERT_TRUE(result.geom->Equals(expected.get()));
+    ASSERT_TRUE(result.isValid);
+}
+
+TEST_P(OrganizePolygonsTest, SinglePointInput)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(readWKT("POINT (0 0)"));
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+    //ASSERT_EQ(result.geom->getGeometryType(), wkbGeometryCollection);
+}
+
+TEST_P(OrganizePolygonsTest, MixedPolygonCurvePolygonInput)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(
+        readWKT("POLYGON ((10 10, 20 10, 20 20, 20 10, 10 10))"));
+    polygons.push_back(readWKT("CURVEPOLYGON ((0 0, 1 0, 1 1, 0 0))"));
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+    ASSERT_EQ(result.geom->getGeometryType(), wkbMultiSurface);
+
+    std::unique_ptr<OGRGeometry> expected(
+        readWKT("MULTISURFACE ("
+                "POLYGON ((10 10, 20 10, 20 20, 20 10, 10 10)),"
+                "CURVEPOLYGON ((0 0, 1 0, 1 1, 0 0)))"));
+
+    ASSERT_TRUE(result.geom->Equals(expected.get()));
+
+    if (method == "SKIP")
+    {
+        //ASSERT_FALSE(result.isValid);
+    }
+    else
+    {
+        ASSERT_TRUE(result.isValid);
+    }
+}
+
+TEST_P(OrganizePolygonsTest, MixedPolygonPointInput)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(readWKT("POLYGON ((0 0, 1 0, 1 1, 0 0))"));
+    polygons.push_back(readWKT("POINT (2 2)"));
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+    ASSERT_EQ(result.geom->getGeometryType(), wkbGeometryCollection);
+    ASSERT_FALSE(result.isValid);
+}
+
+TEST_P(OrganizePolygonsTest, CWPolygonCCWHole)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(readWKT("POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))"));
+    polygons.push_back(readWKT("POLYGON ((1 1, 2 1, 2 2, 1 2, 1 1))"));
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+
+    std::unique_ptr<OGRGeometry> expected;
+    if (method == "SKIP")
+    {
+        expected.reset(readWKT("MULTIPOLYGON (((0 0, 0 10, 10 10, 10 0, 0 0)), "
+                               "((1 1, 2 1, 2 2, 1 2, 1 1)))"));
+    }
+    else
+    {
+        expected.reset(readWKT("POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, "
+                               "2 1, 2 2, 1 2, 1 1))"));
+    }
+
+    ASSERT_TRUE(result.geom->Equals(expected.get()));
+
+    if (method == "SKIP")
+    {
+        //ASSERT_FALSE(result.isValid);
+    }
+    else
+    {
+        ASSERT_TRUE(result.isValid);
+    }
+}
+
+TEST_P(OrganizePolygonsTest, CWPolygonCCWLakeCWIslandInLake)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(
+        readWKT("POLYGON ((0 0, 0 100, 100 100, 100 0, 0 0))"));  // CW
+    polygons.push_back(
+        readWKT("POLYGON ((10 10, 20 10, 20 20, 10 20, 10 10))"));  // CCW
+    polygons.push_back(
+        readWKT("POLYGON ((15 15, 15 16, 16 16, 16 15, 15 15))"));  // CW
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+
+    if (method != "SKIP")
+    {
+        std::unique_ptr<OGRGeometry> expected(
+            readWKT("MULTIPOLYGON ("
+                    "((0 0, 0 100, 100 100, 100 0, 0 0), (10 10, 20 10, 20 20, "
+                    "10 20, 10 10)),"
+                    "((15 15, 15 16, 16 16, 16 15, 15 15)))"));
+        ASSERT_TRUE(result.geom->Equals(expected.get()));
+        ASSERT_TRUE(result.isValid);
+    }
+}
+
+TEST_P(OrganizePolygonsTest, AdjacentCCWPolygons)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(readWKT("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"));  // CCW
+    polygons.push_back(readWKT("POLYGON ((1 0, 2 0, 2 1, 1 1, 1 0))"));  // CCW
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+
+    std::unique_ptr<OGRGeometry> expected(
+        readWKT("MULTIPOLYGON("
+                "((0 0, 1 0, 1 1, 0 1, 0 0)), "
+                "((1 0, 2 0, 2 1, 1 1, 1 0)))"));
+    ASSERT_TRUE(result.geom->Equals(expected.get()));
+    //ASSERT_FALSE(result.isValid);
+}
+
+TEST_P(OrganizePolygonsTest, HoleAlongEdge)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(
+        readWKT("POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))"));             // CW
+    polygons.push_back(readWKT("POLYGON ((0 2, 1 2, 1 3, 0 3, 0 2))"));  // CCW
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+
+    if (method != "SKIP")
+    {
+        std::unique_ptr<OGRGeometry> expected(
+            readWKT("POLYGON("
+                    "(0 0, 0 10, 10 10, 10 0, 0 0), "
+                    "(0 2, 1 2, 1 3, 0 3, 0 2))"));
+        ASSERT_TRUE(result.geom->Equals(expected.get()));
+        //ASSERT_FALSE(result.isValid);
+    }
+}
+
+TEST_P(OrganizePolygonsTest, CrossingCCWPolygons)
+{
+    std::vector<OGRGeometry *> polygons;
+    polygons.push_back(readWKT("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"));
+    polygons.push_back(readWKT("POLYGON ((5 5, 15 5, 15 15, 5 15, 5 5))"));
+
+    auto method = GetParam();
+    auto result = organizePolygons(polygons, method);
+
+    ASSERT_NE(result.geom, nullptr);
+
+    std::unique_ptr<OGRGeometry> expected(
+        readWKT("MULTIPOLYGON("
+                "((0 0, 10 0, 10 10, 0 10, 0 0)), "
+                "((5 5, 15 5, 15 15, 5 15, 5 5)))"));
+    ASSERT_TRUE(result.geom->Equals(expected.get()));
+    //ASSERT_FALSE(result.isValid);
+}

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -1519,11 +1519,14 @@ enum OrganizePolygonMethod
  * override the value of the METHOD option of papszOptions (useful to modify the
  * behavior of the shapefile driver)
  *
- * @param papoPolygons array of geometry pointers - should all be OGRPolygons.
- * Ownership of the geometries is passed, but not of the array itself.
+ * @param papoPolygons array of geometry pointers - should all be OGRPolygons
+ * or OGRCurvePolygons. Ownership of the geometries is passed, but not of the
+ * array itself.
  * @param nPolygonCount number of items in papoPolygons
- * @param pbIsValidGeometry value will be set TRUE if result is valid or
- * FALSE otherwise.
+ * @param pbIsValidGeometry value may be set to FALSE if an invalid result is
+ * detected. Validity checks vary according to the method used and are are limited
+ * to what is needed to link inner rings to outer rings, so a result of TRUE
+ * does not mean that OGRGeometry::IsValid() returns TRUE.
  * @param papszOptions a list of strings for passing options
  *
  * @return a single resulting geometry (either OGRPolygon, OGRCurvePolygon,
@@ -1553,11 +1556,28 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
     /* -------------------------------------------------------------------- */
     if (nPolygonCount == 1)
     {
-        geom = papoPolygons[0];
+        OGRwkbGeometryType eType =
+            wkbFlatten(papoPolygons[0]->getGeometryType());
+
+        bool bIsValid = true;
+
+        if (eType != wkbPolygon && eType != wkbCurvePolygon)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "organizePolygons() received a non-Polygon geometry.");
+            bIsValid = false;
+            delete papoPolygons[0];
+            geom = new OGRPolygon();
+        }
+        else
+        {
+            geom = papoPolygons[0];
+        }
+
         papoPolygons[0] = nullptr;
 
         if (pbIsValidGeometry)
-            *pbIsValidGeometry = TRUE;
+            *pbIsValidGeometry = bIsValid;
 
         return geom;
     }
@@ -1587,11 +1607,11 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
     /* -------------------------------------------------------------------- */
     /*      Setup per polygon envelope and area information.                */
     /* -------------------------------------------------------------------- */
-    std::vector<sPolyExtended> asPolyEx(nPolygonCount);
+    std::vector<sPolyExtended> asPolyEx;
+    asPolyEx.reserve(nPolygonCount);
 
     bool bValidTopology = true;
     bool bMixedUpGeometries = false;
-    bool bNonPolygon = false;
     bool bFoundCCW = false;
 
     const char *pszMethodValue = CSLFetchNameValue(papszOptions, "METHOD");
@@ -1628,50 +1648,58 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
 
     for (int i = 0; i < nPolygonCount; i++)
     {
-        asPolyEx[i].nInitialIndex = i;
-        asPolyEx[i].poGeometry = papoPolygons[i];
-        if (papoPolygons[i]->getDimension() == 2)
-        {
-            asPolyEx[i].poPolygon = papoPolygons[i]->toCurvePolygon();
-            papoPolygons[i]->getEnvelope(&asPolyEx[i].sEnvelope);
-        }
-
         OGRwkbGeometryType eType =
             wkbFlatten(papoPolygons[i]->getGeometryType());
+
+        if (eType != wkbPolygon && eType != wkbCurvePolygon)
+        {
+            // Ignore any points or lines that find their way in here.
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "organizePolygons() received a non-Polygon geometry.");
+            delete papoPolygons[i];
+            continue;
+        }
+
+        sPolyExtended sPolyEx;
+
+        sPolyEx.nInitialIndex = i;
+        sPolyEx.poGeometry = papoPolygons[i];
+        sPolyEx.poPolygon = papoPolygons[i]->toCurvePolygon();
+
+        papoPolygons[i]->getEnvelope(&sPolyEx.sEnvelope);
+
         if (eType == wkbCurvePolygon)
             bHasCurves = true;
-        if (asPolyEx[i].poPolygon != nullptr &&
-            !asPolyEx[i].poPolygon->IsEmpty() &&
-            asPolyEx[i].poPolygon->getNumInteriorRings() == 0 &&
-            asPolyEx[i].poPolygon->getExteriorRingCurve()->getNumPoints() >= 4)
+        if (!sPolyEx.poPolygon->IsEmpty() &&
+            sPolyEx.poPolygon->getNumInteriorRings() == 0 &&
+            sPolyEx.poPolygon->getExteriorRingCurve()->getNumPoints() >= 4)
         {
             if (method != METHOD_CCW_INNER_JUST_AFTER_CW_OUTER)
-                asPolyEx[i].dfArea = asPolyEx[i].poPolygon->get_Area();
-            asPolyEx[i].poExteriorRing =
-                asPolyEx[i].poPolygon->getExteriorRingCurve();
-            asPolyEx[i].poExteriorRing->StartPoint(&asPolyEx[i].poAPoint);
+                sPolyEx.dfArea = sPolyEx.poPolygon->get_Area();
+            sPolyEx.poExteriorRing = sPolyEx.poPolygon->getExteriorRingCurve();
+            sPolyEx.poExteriorRing->StartPoint(&sPolyEx.poAPoint);
             if (eType == wkbPolygon)
             {
-                asPolyEx[i].bIsCW = CPL_TO_BOOL(
-                    asPolyEx[i].poExteriorRing->toLinearRing()->isClockwise());
-                asPolyEx[i].bIsPolygon = true;
+                sPolyEx.bIsCW = CPL_TO_BOOL(
+                    sPolyEx.poExteriorRing->toLinearRing()->isClockwise());
+                sPolyEx.bIsPolygon = true;
             }
             else
             {
-                OGRLineString *poLS = asPolyEx[i].poExteriorRing->CurveToLine();
+                OGRLineString *poLS = sPolyEx.poExteriorRing->CurveToLine();
                 OGRLinearRing oLR;
                 oLR.addSubLineString(poLS);
-                asPolyEx[i].bIsCW = CPL_TO_BOOL(oLR.isClockwise());
-                asPolyEx[i].bIsPolygon = false;
+                sPolyEx.bIsCW = CPL_TO_BOOL(oLR.isClockwise());
+                sPolyEx.bIsPolygon = false;
                 delete poLS;
             }
-            if (asPolyEx[i].bIsCW)
+            if (sPolyEx.bIsCW)
             {
                 indexOfCWPolygon = i;
                 nCountCWPolygon++;
             }
             if (!bFoundCCW)
-                bFoundCCW = !(asPolyEx[i].bIsCW);
+                bFoundCCW = !(sPolyEx.bIsCW);
         }
         else
         {
@@ -1684,9 +1712,9 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
                          "Return arguments as a collection.");
                 bMixedUpGeometries = true;
             }
-            if (eType != wkbPolygon && eType != wkbCurvePolygon)
-                bNonPolygon = true;
         }
+
+        asPolyEx.push_back(std::move(sPolyEx));
     }
 
     // If we are in ONLY_CCW mode and that we have found that there is only one
@@ -1694,10 +1722,10 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
     // are inside.
     if ((method == METHOD_ONLY_CCW ||
          method == METHOD_CCW_INNER_JUST_AFTER_CW_OUTER) &&
-        nCountCWPolygon == 1 && bUseFastVersion && !bNonPolygon)
+        nCountCWPolygon == 1 && bUseFastVersion)
     {
         OGRCurvePolygon *poCP = asPolyEx[indexOfCWPolygon].poPolygon;
-        for (int i = 0; i < nPolygonCount; i++)
+        for (int i = 0; i < static_cast<int>(asPolyEx.size()); i++)
         {
             if (i != indexOfCWPolygon)
             {
@@ -1712,8 +1740,7 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
         return poCP;
     }
 
-    if (method == METHOD_CCW_INNER_JUST_AFTER_CW_OUTER && !bNonPolygon &&
-        asPolyEx[0].bIsCW)
+    if (method == METHOD_CCW_INNER_JUST_AFTER_CW_OUTER && asPolyEx[0].bIsCW)
     {
         // Inner rings are CCW oriented and follow immediately the outer
         // ring (that is CW oriented) in which they are included.
@@ -1722,7 +1749,7 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
         OGRGeometry *poRet = poCur;
         // We have already checked that the first ring is CW.
         OGREnvelope *psEnvelope = &(asPolyEx[0].sEnvelope);
-        for (int i = 1; i < nPolygonCount; i++)
+        for (std::size_t i = 1; i < asPolyEx.size(); i++)
         {
             if (asPolyEx[i].bIsCW)
             {
@@ -1751,7 +1778,7 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
                     CPLError(CE_Warning, CPLE_AppDefined,
                              "Part %d does not respect "
                              "CCW_INNER_JUST_AFTER_CW_OUTER rule",
-                             i);
+                             static_cast<int>(i));
                 }
                 delete asPolyEx[i].poPolygon;
             }
@@ -1761,10 +1788,10 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
             *pbIsValidGeometry = TRUE;
         return poRet;
     }
-    else if (method == METHOD_CCW_INNER_JUST_AFTER_CW_OUTER && !bNonPolygon)
+    else if (method == METHOD_CCW_INNER_JUST_AFTER_CW_OUTER)
     {
         method = METHOD_ONLY_CCW;
-        for (int i = 0; i < nPolygonCount; i++)
+        for (std::size_t i = 0; i < asPolyEx.size(); i++)
             asPolyEx[i].dfArea = asPolyEx[i].poPolygon->get_Area();
     }
 
@@ -1852,7 +1879,8 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
     int nCountTopLevel = 1;
 
     // STEP 2.
-    for (int i = 1; !bMixedUpGeometries && bValidTopology && i < nPolygonCount;
+    for (int i = 1; !bMixedUpGeometries && bValidTopology &&
+                    i < static_cast<int>(asPolyEx.size());
          i++)
     {
         if (method == METHOD_ONLY_CCW && asPolyEx[i].bIsCW)
@@ -2031,7 +2059,8 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
                          "Bad intersection for polygons %d and %d\n"
                          "geom %d: %s\n"
                          "geom %d: %s",
-                         i, j, i, wkt1, j, wkt2);
+                         static_cast<int>(i), j, static_cast<int>(i), wkt1, j,
+                         wkt2);
                 CPLFree(wkt1);
                 CPLFree(wkt2);
 #endif
@@ -2051,71 +2080,55 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
     if (pbIsValidGeometry)
         *pbIsValidGeometry = bValidTopology && !bMixedUpGeometries;
 
-    /* -------------------------------------------------------------------- */
-    /*      Things broke down - just turn everything into a multipolygon.   */
-    /* -------------------------------------------------------------------- */
+    /* --------------------------------------------------------------------- */
+    /*      Things broke down - just mark everything as top-level so it gets */
+    /*      turned into a multipolygon.                                      */
+    /* --------------------------------------------------------------------- */
     if (!bValidTopology || bMixedUpGeometries)
     {
-        OGRGeometryCollection *poGC = nullptr;
-        if (bNonPolygon)
-            poGC = new OGRGeometryCollection();
-        else if (bHasCurves)
-            poGC = new OGRMultiSurface();
-        else
-            poGC = new OGRMultiPolygon();
-        geom = poGC;
-
-        for (int i = 0; i < nPolygonCount; i++)
+        for (auto &sPolyEx : asPolyEx)
         {
-            poGC->addGeometryDirectly(asPolyEx[i].poGeometry);
+            sPolyEx.bIsTopLevel = true;
         }
+        nCountTopLevel = static_cast<int>(asPolyEx.size());
     }
 
     /* -------------------------------------------------------------------- */
     /*      Try to turn into one or more polygons based on the ring         */
     /*      relationships.                                                  */
     /* -------------------------------------------------------------------- */
-    else
+    // STEP 3: Sort again in initial order.
+    std::sort(asPolyEx.begin(), asPolyEx.end(),
+              OGRGeometryFactoryCompareByIndex);
+
+    // STEP 4: Add holes as rings of their enclosing polygon.
+    for (auto &sPolyEx : asPolyEx)
     {
-        // STEP 3: Sort again in initial order.
-        std::sort(asPolyEx.begin(), asPolyEx.end(),
-                  OGRGeometryFactoryCompareByIndex);
-
-        // STEP 4: Add holes as rings of their enclosing polygon.
-        for (int i = 0; i < nPolygonCount; i++)
+        if (sPolyEx.bIsTopLevel == false)
         {
-            if (asPolyEx[i].bIsTopLevel == false)
+            sPolyEx.poEnclosingPolygon->addRingDirectly(
+                sPolyEx.poPolygon->stealExteriorRingCurve());
+            delete sPolyEx.poPolygon;
+        }
+        else if (nCountTopLevel == 1)
+        {
+            geom = sPolyEx.poPolygon;
+        }
+    }
+
+    // STEP 5: Add toplevel polygons.
+    if (nCountTopLevel > 1)
+    {
+        OGRGeometryCollection *poGC =
+            bHasCurves ? new OGRMultiSurface() : new OGRMultiPolygon();
+        for (auto &sPolyEx : asPolyEx)
+        {
+            if (sPolyEx.bIsTopLevel)
             {
-                asPolyEx[i].poEnclosingPolygon->addRingDirectly(
-                    asPolyEx[i].poPolygon->stealExteriorRingCurve());
-                delete asPolyEx[i].poPolygon;
-            }
-            else if (nCountTopLevel == 1)
-            {
-                geom = asPolyEx[i].poPolygon;
+                poGC->addGeometryDirectly(sPolyEx.poPolygon);
             }
         }
-
-        // STEP 5: Add toplevel polygons.
-        if (nCountTopLevel > 1)
-        {
-            OGRGeometryCollection *poGC = nullptr;
-            for (int i = 0; i < nPolygonCount; i++)
-            {
-                if (asPolyEx[i].bIsTopLevel)
-                {
-                    if (poGC == nullptr)
-                    {
-                        if (bHasCurves)
-                            poGC = new OGRMultiSurface();
-                        else
-                            poGC = new OGRMultiPolygon();
-                    }
-                    poGC->addGeometryDirectly(asPolyEx[i].poPolygon);
-                }
-            }
-            geom = poGC;
-        }
+        geom = poGC;
     }
 
     return geom;

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -1630,8 +1630,11 @@ OGRGeometry *OGRGeometryFactory::organizePolygons(OGRGeometry **papoPolygons,
     {
         asPolyEx[i].nInitialIndex = i;
         asPolyEx[i].poGeometry = papoPolygons[i];
-        asPolyEx[i].poPolygon = papoPolygons[i]->toCurvePolygon();
-        papoPolygons[i]->getEnvelope(&asPolyEx[i].sEnvelope);
+        if (papoPolygons[i]->getDimension() == 2)
+        {
+            asPolyEx[i].poPolygon = papoPolygons[i]->toCurvePolygon();
+            papoPolygons[i]->getEnvelope(&asPolyEx[i].sEnvelope);
+        }
 
         OGRwkbGeometryType eType =
             wkbFlatten(papoPolygons[i]->getGeometryType());


### PR DESCRIPTION
## What does this PR do?

Adds some tests for `OGRGeometryFactory::organizePolygons`. These are not exhaustive but document the basic behavior as well as some edge cases.

I commented out asserts that I would have expected to pass but do not. There are two categories of these:

1. The `pbIsValidGeometry` parameter does not behave how I would expect. It is described as "value will be set TRUE if result is valid or FALSE otherwise", but there are a number of situations where this value is `TRUE` but the result is invalid, e.g.:

- `organizePolygons` was called with a single invalid input
- `organizePolygons` was called with a method that does not perform topological validation
- `organizePolygons` was called with a method that performs topological validation, but the invalidity is not detected because `OGR_DEBUG_ORGANIZE_POLYGONS` is set to `FALSE`
- `organizePolygons` was called with a method that performs topological validation and `OGR_DEBUG_ORGANIZE_POLYGONS=YES` but the nature of the invalid result is not detected (e.g., hole touches shell at multiple points)

I don't see `pbIsValidGeometry` being used inside GDAL except to emit an error message similar to one that would be emitted inside `organizePolygons`, so maybe it makes sense to simply change the documentation of `pbIsValidGeometry` to "value may be set to FALSE if an invalid result is detected; TRUE does not indicate that the result is valid". Or remove the parameter entirely, if it's OK to change the signature.

2. The function returns a type not among those listed in the documentation (OGRPolygon, OGRCurvePolygon, OGRMultiPolygon, OGRMultiSurface or OGRGeometryCollection). For example, calling `organizePolygons` with a single `OGRPoint` will return the `OGRPoint`.

Without the change I made on line 1633, passing a non-polygonal geometry causes an assertion failure when `OGRGeometry::toCurvePolygon()` is called. So this may indicate that nothing is relying on this behavior and support for non-polygonal inputs can be removed.

## What are related issues/pull requests?

#7907

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

