### PR TITLE
[Backport release/3.7] Fix build error with MSYS64 UCRT64 with gcc 13 (fixes #7909)

### DIFF
--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -114,15 +114,6 @@
 /*      MinGW stuff                                                     */
 /* ==================================================================== */
 
-/* We need __MSVCRT_VERSION__ >= 0x0700 to have "_aligned_malloc" */
-/* Latest versions of mingw32 define it, but with older ones, */
-/* we need to define it manually */
-#if defined(__MINGW32__)
-#ifndef __MSVCRT_VERSION__
-#define __MSVCRT_VERSION__ 0x0700
-#endif
-#endif
-
 /* Needed for std=c11 on Solaris to have strcasecmp() */
 #if defined(GDAL_COMPILATION) && defined(__sun__) &&                           \
     (__STDC_VERSION__ + 0) >= 201112L && (_XOPEN_SOURCE + 0) < 600

--- a/port/cpl_vsisimple.cpp
+++ b/port/cpl_vsisimple.cpp
@@ -34,6 +34,17 @@
  *
  ****************************************************************************/
 
+// Must be done before including cpl_port.h
+// We need __MSVCRT_VERSION__ >= 0x0700 to have "_aligned_malloc"
+// Latest versions of mingw32 define it, but with older ones,
+// we need to define it manually.
+#if defined(__MINGW32__)
+#include <windows.h>
+#ifndef __MSVCRT_VERSION__
+#define __MSVCRT_VERSION__ 0x0700
+#endif
+#endif
+
 #include "cpl_port.h"
 #include "cpl_vsi.h"
 


### PR DESCRIPTION
Backport #7910
 **Authored by:** @rouault