### PR TITLE
/vsiaz/: add options to pass object_id/client_id/msi_res_id in IMDS authentication requests

### DIFF
--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -741,7 +741,29 @@ The following configuration options are specific to the /vsiaz/ handler:
 
      Shared Access Signature.
 
+- .. config:: AZURE_IMDS_OBJECT_ID
+     :since: 3.8
 
+     object_id of the managed identity you would like the token for, when using
+     Azure Instance Metadata Service (IMDS) authentication in a Azure
+     Virtual Matchine. Required if your VM has multiple user-assigned managed identities.
+     This option may be set as a path-specific option with :cpp:func:`VSISetPathSpecificOption`
+
+- .. config:: AZURE_IMDS_CLIENT_ID
+     :since: 3.8
+
+     client_id of the managed identity you would like the token for, when using
+     Azure Instance Metadata Service (IMDS) authentication in a Azure
+     Virtual Matchine. Required if your VM has multiple user-assigned managed identities.
+     This option may be set as a path-specific option with :cpp:func:`VSISetPathSpecificOption`
+
+- .. config:: AZURE_IMDS_MSI_RES_ID
+     :since: 3.8
+
+     msi_res_id (Azure Resource ID) of the managed identity you would like the token for, when using
+     Azure Instance Metadata Service (IMDS) authentication in a Azure
+     Virtual Matchine. Required if your VM has multiple user-assigned managed identities.
+     This option may be set as a path-specific option with :cpp:func:`VSISetPathSpecificOption`
 
 Several authentication methods are possible, and are attempted in the following order:
 

--- a/port/cpl_azure.h
+++ b/port/cpl_azure.h
@@ -39,6 +39,7 @@
 
 class VSIAzureBlobHandleHelper final : public IVSIS3LikeHandleHelper
 {
+    std::string m_osPathForOption;
     CPLString m_osURL;
     CPLString m_osEndpoint;
     CPLString m_osBucket;
@@ -73,10 +74,11 @@ class VSIAzureBlobHandleHelper final : public IVSIS3LikeHandleHelper
 
   public:
     VSIAzureBlobHandleHelper(
-        const CPLString &osEndpoint, const CPLString &osBucket,
-        const CPLString &osObjectKey, const CPLString &osStorageAccount,
-        const CPLString &osStorageKey, const CPLString &osSAS,
-        const CPLString &osAccessToken, bool bFromManagedIdentities);
+        const std::string &osPathForOption, const CPLString &osEndpoint,
+        const CPLString &osBucket, const CPLString &osObjectKey,
+        const CPLString &osStorageAccount, const CPLString &osStorageKey,
+        const CPLString &osSAS, const CPLString &osAccessToken,
+        bool bFromManagedIdentities);
     ~VSIAzureBlobHandleHelper();
 
     static VSIAzureBlobHandleHelper *


### PR DESCRIPTION

- .. config:: AZURE_IMDS_OBJECT_ID
     :since: 3.8

     object_id of the managed identity you would like the token for, when using
     Azure Instance Metadata Service (IMDS) authentication in a Azure
     Virtual Matchine. Required if your VM has multiple user-assigned managed identities.
     This option may be set as a path-specific option with :cpp:func:`VSISetPathSpecificOption`

- .. config:: AZURE_IMDS_CLIENT_ID
     :since: 3.8

     client_id of the managed identity you would like the token for, when using
     Azure Instance Metadata Service (IMDS) authentication in a Azure
     Virtual Matchine. Required if your VM has multiple user-assigned managed identities.
     This option may be set as a path-specific option with :cpp:func:`VSISetPathSpecificOption`

- .. config:: AZURE_IMDS_MSI_RES_ID
     :since: 3.8

     msi_res_id (Azure Resource ID) of the managed identity you would like the token for, when using
     Azure Instance Metadata Service (IMDS) authentication in a Azure
     Virtual Matchine. Required if your VM has multiple user-assigned managed identities.
     This option may be set as a path-specific option with :cpp:func:`VSISetPathSpecificOption`
