### PR TITLE
GML: fix 3.7.0 regression when reading files with several layers, …

### DIFF
--- a/autotest/ogr/data/gml/bbox_and_several_geom_elements.gml
+++ b/autotest/ogr/data/gml/bbox_and_several_geom_elements.gml
@@ -1,0 +1,29 @@
+﻿<my:test xmlns:my="http://www.example.com" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <gml:featureMember>
+    <my:lyr1 gml:id="lyr1.1">
+      <gml:boundedBy>
+        <gml:Envelope>
+          <gml:lowerCorner>579038.130 6015811.242</gml:lowerCorner>
+          <gml:upperCorner>580172.650 6016465.222</gml:upperCorner>
+        </gml:Envelope>
+      </gml:boundedBy>
+      <my:geom1>
+        <gml:MultiSurface gml:id="lyr.1.1">
+        </gml:MultiSurface>
+      </my:geom1>
+    </my:lyr1>
+  </gml:featureMember>
+  <gml:featureMember>
+    <my:lyr2 gml:id="lyr2.1">
+      <gml:boundedBy>
+        <gml:Envelope>
+          <gml:lowerCorner>579038.130 6016180.006</gml:lowerCorner>
+          <gml:upperCorner>579207.414 6016451.898</gml:upperCorner>
+        </gml:Envelope>
+      </gml:boundedBy>
+      <my:geom2>
+        <gml:Point gml:id="lyr2.1.1"><gml:posList>579038.130 6016451.898</gml:posList></gml:Point>
+      </my:geom2>
+    </my:lyr2>
+  </gml:featureMember>
+</my:test>

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -4675,6 +4675,40 @@ def test_ogr_gml_read_boundedby_only_gml_null_only():
 
 
 ###############################################################################
+# Test bug fix for https://github.com/OSGeo/gdal/pull/4397
+# where there are several layers with features with gml:boundedBy elements
+# and geometries in elements with different names
+
+
+def test_ogr_gml_read_bbox_and_several_geom_elements():
+
+    if not gdaltest.have_gml_reader:
+        pytest.skip()
+
+    def check():
+        ds = gdal.OpenEx("data/gml/bbox_and_several_geom_elements.gml")
+        lyr = ds.GetLayer(0)
+        assert lyr.GetGeometryColumn() == "geom1"
+        assert lyr.GetGeomType() == ogr.wkbMultiPolygon
+        f = lyr.GetNextFeature()
+        assert f.GetGeometryRef().GetGeometryType() == ogr.wkbMultiPolygon
+        lyr = ds.GetLayer(1)
+        assert lyr.GetGeometryColumn() == "geom2"
+        assert lyr.GetGeomType() == ogr.wkbPoint
+        f = lyr.GetNextFeature()
+        assert f.GetGeometryRef().GetGeometryType() == ogr.wkbPoint
+        ds = None
+
+    gdal.Unlink("data/gml/bbox_and_several_geom_elements.gfs")
+    check()
+
+    # This time with .gfs
+    assert os.path.exists("data/gml/bbox_and_several_geom_elements.gfs")
+    check()
+    gdal.Unlink("data/gml/bbox_and_several_geom_elements.gfs")
+
+
+###############################################################################
 # Test reading a file with only a boundedBy property in features that is
 # invalid
 

--- a/ogr/ogrsf_frmts/gml/gmlhandler.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlhandler.cpp
@@ -1241,18 +1241,19 @@ OGRErr GMLHandler::startElementFeatureAttribute(const char *pszName,
 
             else
             {
-                if (m_poReader->IsConsistentSingleGeomElemPath())
+                if (!poClass->IsSchemaLocked() &&
+                    poClass->IsConsistentSingleGeomElemPath())
                 {
                     const std::string &osGeomElemPath =
-                        m_poReader->GetSingleGeomElemPath();
+                        poClass->GetSingleGeomElemPath();
                     if (osGeomElemPath.empty())
                     {
-                        m_poReader->SetSingleGeomElemPath(poState->osPath);
+                        poClass->SetSingleGeomElemPath(poState->osPath);
                     }
                     else if (poState->osPath != osGeomElemPath)
                     {
-                        m_poReader->SetConsistentSingleGeomElemPath(false);
-                        m_poReader->SetSingleGeomElemPath(std::string());
+                        poClass->SetConsistentSingleGeomElemPath(false);
+                        poClass->SetSingleGeomElemPath(std::string());
                     }
                 }
                 bReadGeometry = true;

--- a/ogr/ogrsf_frmts/gml/gmlreader.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlreader.cpp
@@ -1359,9 +1359,13 @@ bool GMLReader::PrescanForSchema(bool bGetExtents, bool bOnlyDetectSRS)
         {
             if (poClass->GetGeometryPropertyCount() == 0)
             {
-                std::string osPath(m_osSingleGeomElemPath);
-                if (osPath.empty() && psBoundedByGeometry)
+                std::string osPath(poClass->GetSingleGeomElemPath());
+                if (osPath.empty() &&
+                    poClass->IsConsistentSingleGeomElemPath() &&
+                    papsGeometry[0] == psBoundedByGeometry)
+                {
                     osPath = "boundedBy";
+                }
                 std::string osGeomName(osPath);
                 const auto nPos = osGeomName.rfind('|');
                 if (nPos != std::string::npos)

--- a/ogr/ogrsf_frmts/gml/gmlreader.h
+++ b/ogr/ogrsf_frmts/gml/gmlreader.h
@@ -269,6 +269,9 @@ class CPL_DLL GMLFeatureClass
     char *m_pszSRSName;
     bool m_bSRSNameConsistent;
 
+    bool m_bIsConsistentSingleGeomElemPath = true;
+    std::string m_osSingleGeomElemPath{};
+
   public:
     explicit GMLFeatureClass(const char *pszName = "");
     ~GMLFeatureClass();
@@ -308,6 +311,23 @@ class CPL_DLL GMLFeatureClass
     int AddProperty(GMLPropertyDefn *, int iPos = -1);
     int AddGeometryProperty(GMLGeometryPropertyDefn *);
     void ClearGeometryProperties();
+
+    void SetConsistentSingleGeomElemPath(bool b)
+    {
+        m_bIsConsistentSingleGeomElemPath = b;
+    }
+    bool IsConsistentSingleGeomElemPath() const
+    {
+        return m_bIsConsistentSingleGeomElemPath;
+    }
+    void SetSingleGeomElemPath(const std::string &s)
+    {
+        m_osSingleGeomElemPath = s;
+    }
+    const std::string &GetSingleGeomElemPath() const
+    {
+        return m_osSingleGeomElemPath;
+    }
 
     bool IsSchemaLocked() const
     {

--- a/ogr/ogrsf_frmts/gml/gmlreaderp.h
+++ b/ogr/ogrsf_frmts/gml/gmlreaderp.h
@@ -429,9 +429,6 @@ class GMLReader final : public IGMLReader
 
     bool m_bEmptyAsNull;
 
-    bool m_bIsConsistentSingleGeomElemPath = true;
-    std::string m_osSingleGeomElemPath{};
-
     bool ParseXMLHugeFile(const char *pszOutputFilename,
                           const bool bSqliteIsTempFile,
                           const int iSqliteCacheMB);
@@ -576,23 +573,6 @@ class GMLReader final : public IGMLReader
     bool IsEmptyAsNull() const
     {
         return m_bEmptyAsNull;
-    }
-
-    void SetConsistentSingleGeomElemPath(bool b)
-    {
-        m_bIsConsistentSingleGeomElemPath = b;
-    }
-    bool IsConsistentSingleGeomElemPath() const
-    {
-        return m_bIsConsistentSingleGeomElemPath;
-    }
-    void SetSingleGeomElemPath(const std::string &s)
-    {
-        m_osSingleGeomElemPath = s;
-    }
-    const std::string &GetSingleGeomElemPath() const
-    {
-        return m_osSingleGeomElemPath;
     }
 
     static CPLMutex *hMutex;


### PR DESCRIPTION
…whose features have gml:boundedBy elements and the geometry element name is different between the different layers (fixes #7925)
