### PR TITLE
CI: Run ctest in parallel for most Linux builds

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -240,7 +240,7 @@ jobs:
           if test -f ".github/workflows/${{ matrix.id }}/${{ matrix.test_script }}"; then
             TEST_CMD="${GDAL_SOURCE_DIR}/.github/workflows/${{ matrix.id }}/${{ matrix.test_script }}"
           else
-            TEST_CMD="ctest -V"
+            TEST_CMD="ctest -V -j $(nproc)"
           fi
 
           docker run \

--- a/.github/workflows/ubuntu_20.04/test.sh
+++ b/.github/workflows/ubuntu_20.04/test.sh
@@ -4,4 +4,4 @@ set -eu
 
 export OGR_HANA_CONNECTION_STRING='DRIVER=/usr/sap/hdbclient/libodbcHDB.so;HOST=917df316-4e01-4a10-be54-eac1b6ab15fb.hana.prod-us10.hanacloud.ondemand.com;PORT=443;USER=GDALCI;PASSWORD=u7t!Ukeugzq7'
 
-ctest -V
+ctest -V -j $(nproc)


### PR DESCRIPTION
## What does this PR do?

Pass `-j` flag to `ctest` in Linux build configurations that use `ctest` instead of calling `pytest` directly. 

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed