### PR TITLE
autotest: mark flaky tests with pytest-rerunfailures

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -427,7 +427,7 @@ jobs:
     - name: Install dependency
       shell: bash -l {0}
       run: |
-        conda install --yes --quiet curl libiconv icu python=3.10 swig numpy pytest pytest-env filelock zlib lxml jsonschema
+        conda install --yes --quiet curl libiconv icu python=3.10 swig numpy pytest pytest-env pytest-rerunfailures filelock zlib lxml jsonschema
         conda install --yes --quiet proj geos hdf4 hdf5 kealib \
             libnetcdf openjpeg poppler libtiff libpng xerces-c expat libxml2 kealib json-c \
             cfitsio freexl geotiff libjpeg-turbo libpq libspatialite libwebp-base pcre pcre2 postgresql \
@@ -513,7 +513,7 @@ jobs:
     - name: Install dependency
       shell: bash -l {0}
       run: |
-        conda install --yes --quiet proj pytest pytest-env filelock lxml
+        conda install --yes --quiet proj pytest pytest-env pytest-rerunfailures filelock lxml
     - name: Configure
       shell: bash -l {0}
       run: |

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -210,6 +210,11 @@ def pytest_collection_modifyitems(config, items):
             if not gdaltest.built_against_curl():
                 item.add_marker(pytest.mark.skip("curl support not available"))
 
+        for mark in item.iter_markers("flaky"):
+            # validate arguments for "flaky" marker from pytest-rerunfailures
+            for arg in mark.kwargs:
+                assert arg in {"reruns", "reruns_delay", "condition"}
+
 
 def pytest_addoption(parser):
     parser.addini("gdal_version", "GDAL version for which pytest.ini was generated")

--- a/autotest/gcore/vsicurl_streaming.py
+++ b/autotest/gcore/vsicurl_streaming.py
@@ -41,6 +41,7 @@ pytestmark = pytest.mark.require_curl()
 #
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_vsicurl_streaming_1():
 
     with gdal.config_option("GDAL_HTTP_CONNECTTIMEOUT", "5"):

--- a/autotest/gdrivers/gdalhttp.py
+++ b/autotest/gdrivers/gdalhttp.py
@@ -64,6 +64,8 @@ def set_http_timeout():
 
 
 def skip_if_unreachable(url, try_read=False):
+    __tracebackhide__ = True
+
     conn = gdaltest.gdalurlopen(url, timeout=4)
     if conn is None:
         pytest.skip("cannot open URL")
@@ -79,6 +81,7 @@ def skip_if_unreachable(url, try_read=False):
 # Verify we have the driver.
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_http_1():
     url = "http://gdal.org/gdalicon.png"
     tst = gdaltest.GDALTest("PNG", url, 1, 7617, filename_absolute=1)

--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -1,6 +1,11 @@
+# NOTE: when adding dependencies to this file it may also be necessary
+# to add them to CI configurations that use conda rather than pip,
+# such as .github/workflows/cmake_builds.yml
+
 pytest>=6.0.0
 pytest-sugar<=0.9.6; python_version < '3.7'
 pytest-sugar; python_version >= '3.7'
+pytest-rerunfailures
 pytest-env
 lxml
 jsonschema


### PR DESCRIPTION
## What does this PR do?

Mark tests as flaky so they can be retried automatically in an attempt to reduce spurious failures such as these: https://app.travis-ci.com/github/OSGeo/gdal/jobs/604101051#L23266

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed