### PR TITLE
ossfuzz builds: use internal libpng

### DIFF
--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -37,7 +37,7 @@ if test "${CIFUZZ:-}" = "True"; then
   echo "Running under CI fuzz"
 
   PACKAGES="zlib1g-dev${ARCH_SUFFIX} libexpat-dev${ARCH_SUFFIX} liblzma-dev${ARCH_SUFFIX} \
-          libpng-dev${ARCH_SUFFIX} libgif-dev${ARCH_SUFFIX} \
+          libgif-dev${ARCH_SUFFIX} \
           libjpeg-dev${ARCH_SUFFIX} \
           libwebp-dev${ARCH_SUFFIX} \
           libzstd-dev${ARCH_SUFFIX} \
@@ -69,6 +69,7 @@ if test "${CIFUZZ:-}" = "True"; then
         -DOGR_ENABLE_DRIVER_GPKG:BOOL=ON \
         -DOGR_ENABLE_DRIVER_SQLITE:BOOL=ON \
         -DGDAL_ENABLE_DRIVER_ZARR:BOOL=ON \
+        -DGDAL_USE_PNG_INTERNAL=ON \
         -DGDAL_USE_TIFF_INTERNAL=ON \
         -DGDAL_USE_GEOTIFF_INTERNAL=ON
   make -j$(nproc) GDAL
@@ -87,7 +88,7 @@ if test "${CIFUZZ:-}" = "True"; then
             $LIB_FUZZING_ENGINE \
             -L$SRC_DIR/build -lgdal \
             -lproj \
-            -Wl,-Bstatic -lzstd -lwebp -llzma -lexpat -lsqlite3 -lgif -ljpeg -lpng -lz \
+            -Wl,-Bstatic -lzstd -lwebp -llzma -lexpat -lsqlite3 -lgif -ljpeg -lz \
             -Wl,-Bdynamic -ldl -lpthread
 
   echo "Building ogr_fuzzer"
@@ -101,7 +102,7 @@ if test "${CIFUZZ:-}" = "True"; then
             $LIB_FUZZING_ENGINE \
             -L$SRC_DIR/build -lgdal \
             -L$SRC/install/lib -lproj \
-            -Wl,-Bstatic -lzstd -lwebp -llzma -lexpat -lsqlite3 -lgif -ljpeg -lpng -lz \
+            -Wl,-Bstatic -lzstd -lwebp -llzma -lexpat -lsqlite3 -lgif -ljpeg -lz \
             -Wl,-Bdynamic -ldl -lpthread
 
   echo "Building gdal_fuzzer_seed_corpus.zip"
@@ -293,6 +294,7 @@ cmake .. \
     -DGDAL_USE_TIFF_INTERNAL=ON \
     -DGDAL_USE_GEOTIFF_INTERNAL=ON \
     -DGDAL_USE_HDF5=OFF \
+    -DGDAL_USE_PNG_INTERNAL=ON \
     -DBUILD_APPS:BOOL=OFF  \
     -DBUILD_CSHARP_BINDINGS:BOOL=OFF  \
     -DBUILD_JAVA_BINDINGS:BOOL=OFF  \
@@ -306,7 +308,7 @@ export EXTRA_LIBS="-Wl,-Bstatic "
 export EXTRA_LIBS="$EXTRA_LIBS -L$SRC/install/lib -lcurl -lssl -lcrypto -lz"
 # PROJ
 export EXTRA_LIBS="$EXTRA_LIBS -lproj -ltiff "
-export EXTRA_LIBS="$EXTRA_LIBS -ljbig -lzstd -lwebp -llzma -lexpat -L$SRC/install/lib -lsqlite3 -lgif -ljpeg -lpng -lz"
+export EXTRA_LIBS="$EXTRA_LIBS -ljbig -lzstd -lwebp -llzma -lexpat -L$SRC/install/lib -lsqlite3 -lgif -ljpeg -lz"
 # Xerces-C related
 export EXTRA_LIBS="$EXTRA_LIBS -L$SRC/install/lib -lxerces-c"
 if [ "$ARCHITECTURE" = "x86_64" ]; then


### PR DESCRIPTION
Avoids running into memory leak of https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47258 that was fixed in internal libpng per f19f56b4f126421ef3bcd7cf6490c39431933dde
