### PR TITLE
autotest: remove gdaltest.post_reason

### DIFF
--- a/autotest/gcore/gcps2geotransform.py
+++ b/autotest/gcore/gcps2geotransform.py
@@ -64,7 +64,7 @@ def test_gcps2gt_1():
             ]
         )
     )
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gt, (400000.0, 100.0, 0.0, 370000.0, 0.0, -10.0), 0.000001
     )
 
@@ -85,7 +85,7 @@ def test_gcps2gt_2():
             ]
         )
     )
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gt, (400000.0, 100.0, 0.0, 370000.0025, -5e-05, -9.999975), 0.000001
     )
 
@@ -141,7 +141,7 @@ def test_gcps2gt_5():
             ]
         )
     )
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gt, (400000.0, 100.0, 0.0, 370000.0, 0.0, -10.0), 0.000001
     )
 
@@ -162,7 +162,7 @@ def test_gcps2gt_6():
             ]
         )
     )
-    assert gdaltest.geotransform_equals(gt, (0.0, 1.0, 0.0, 0.0, 0.0, 1.0), 0.000001)
+    gdaltest.check_geotransform(gt, (0.0, 1.0, 0.0, 0.0, 0.0, 1.0), 0.000001)
 
 
 ###############################################################################
@@ -181,7 +181,7 @@ def test_gcps2gt_7():
             ]
         )
     )
-    assert gdaltest.geotransform_equals(gt, (0.0, 1.0, 0.0, 0.0, 0.0, 1.0), 0.000001)
+    gdaltest.check_geotransform(gt, (0.0, 1.0, 0.0, 0.0, 0.0, 1.0), 0.000001)
 
 
 ###############################################################################
@@ -210,4 +210,4 @@ def test_gcps2gt_8():
         2.6091510188921e-05,
         1.596921026218e-05,
     )
-    assert gdaltest.geotransform_equals(gt, gt_expected, 0.00001)
+    gdaltest.check_geotransform(gt, gt_expected, 0.00001)

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -382,7 +382,7 @@ def misc_6_internal(datatype, nBands, setDriversDone):
                                     error_detected = True
                             if not error_detected:
                                 msg = (
-                                    "write error not decteded with with drv = %s, nBands = %d, datatype = %s, truncated_size = %d"
+                                    "write error not detected with with drv = %s, nBands = %d, datatype = %s, truncated_size = %d"
                                     % (
                                         drv.ShortName,
                                         nBands,
@@ -391,7 +391,6 @@ def misc_6_internal(datatype, nBands, setDriversDone):
                                     )
                                 )
                                 print(msg)
-                                gdaltest.post_reason(msg)
 
                             fl = gdal.ReadDirRecursive("/vsimem/test_truncate")
                             if fl is not None:

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -580,7 +580,7 @@ def test_tiff_write_17():
 
     # Open the dataset, and confirm the RPC data is still intact.
     ds = gdal.Open(tmpfilename)
-    assert gdaltest.rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
+    gdaltest.check_rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
     ds = None
 
     # Modify the RPC
@@ -592,7 +592,7 @@ def test_tiff_write_17():
     ds = None
 
     ds = gdal.Open(tmpfilename)
-    assert gdaltest.rpcs_equal(ds.GetMetadata("RPC"), modified_rpc)
+    gdaltest.check_rpcs_equal(ds.GetMetadata("RPC"), modified_rpc)
     ds = None
 
     # Unset the RPC
@@ -646,7 +646,7 @@ def test_tiff_write_18():
     # Open the dataset, and confirm the RPC/IMD data is still intact.
     ds = gdal.Open("tmp/tw_18.tif")
 
-    assert gdaltest.rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
+    gdaltest.check_rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
 
     imd_md = ds.GetMetadata("IMD")
     assert (
@@ -765,7 +765,7 @@ def test_tiff_write_rpc_txt():
     # Open the dataset, and confirm the RPC data is still intact.
     ds = gdal.Open("tmp/tiff_write_rpc_txt.tif")
 
-    assert gdaltest.rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
+    gdaltest.check_rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
 
     ds = None
 
@@ -804,7 +804,7 @@ def test_tiff_write_rpc_in_pam():
     # Open the dataset, and confirm the RPC data is still intact.
     ds = gdal.Open("tmp/tiff_write_rpc_in_pam.tif")
 
-    assert gdaltest.rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
+    gdaltest.check_rpcs_equal(ds.GetMetadata("RPC"), rpc_md)
 
     ds = None
 

--- a/autotest/gcore/vsioss.py
+++ b/autotest/gcore/vsioss.py
@@ -98,8 +98,7 @@ def test_visoss_1():
 
 def test_visoss_real_test():
 
-    if gdaltest.skip_on_travis():
-        pytest.skip()
+    gdaltest.skip_on_travis()
 
     # ERROR 1: The OSS Access Key Id you provided does not exist in our records.
     gdal.ErrorReset()

--- a/autotest/gdrivers/ecrgtoc.py
+++ b/autotest/gdrivers/ecrgtoc.py
@@ -93,10 +93,7 @@ def test_ecrgtoc_1():
         -0.00044985604606525913,
     ]
     gt = ds.GetGeoTransform()
-    for i in range(6):
-        if gt[i] != pytest.approx(expected_gt[i], abs=1e-10):
-            gdaltest.post_reason("did not get expected geotransform")
-            print(gt)
+    gdaltest.check_geotransform(gt, expected_gt, 1e-10)
 
     wkt = ds.GetProjectionRef()
     assert wkt.find("WGS 84") != -1, "did not get expected SRS"
@@ -302,10 +299,7 @@ def test_ecrgtoc_4():
         -0.00044985604606525913,
     )
     gt = ds.GetGeoTransform()
-    for i in range(6):
-        assert gt[i] == pytest.approx(
-            expected_gt[i], abs=1e-10
-        ), "did not get expected geotransform"
+    gdaltest.check_geotransform(gt, expected_gt, 1e-10)
 
     wkt = ds.GetProjectionRef()
     assert wkt.find("WGS 84") != -1, "did not get expected SRS"
@@ -368,10 +362,7 @@ def test_ecrgtoc_online_1():
         -0.00044985604606525913,
     )
     gt = ds.GetGeoTransform()
-    for i in range(6):
-        if gt[i] != pytest.approx(expected_gt[i], abs=1e-10):
-            gdaltest.post_reason("did not get expected geotransform")
-            print(gt)
+    gdaltest.check_geotransform(gt, expected_gt, 1e-10)
 
     wkt = ds.GetProjectionRef()
     assert wkt.find("WGS 84") != -1, "did not get expected SRS"

--- a/autotest/gdrivers/gdalhttp.py
+++ b/autotest/gdrivers/gdalhttp.py
@@ -80,6 +80,9 @@ def skip_if_unreachable(url, try_read=False):
 
 
 def test_http_1():
+    # Regularly fails on Travis graviton2 configuration
+    gdaltest.skip_on_travis()
+
     url = "http://gdal.org/gdalicon.png"
     tst = gdaltest.GDALTest("PNG", url, 1, 7617, filename_absolute=1)
     try:

--- a/autotest/gdrivers/gdalhttp.py
+++ b/autotest/gdrivers/gdalhttp.py
@@ -122,8 +122,7 @@ def test_http_3():
 
 def test_http_4():
     # Too unreliable
-    if gdaltest.skip_on_travis():
-        pytest.skip()
+    gdaltest.skip_on_travis()
 
     url = "ftp://download.osgeo.org/gdal/data/gtiff/utm.tif"
     ds = gdal.Open("/vsicurl/" + url)

--- a/autotest/gdrivers/gif.py
+++ b/autotest/gdrivers/gif.py
@@ -114,14 +114,10 @@ def test_gif_6():
     src_ds = gdal.Open("../gcore/data/nodata_byte.tif")
 
     new_ds = gdaltest.gif_drv.CreateCopy("tmp/nodata_byte.gif", src_ds)
-    if new_ds is None:
-        gdaltest.post_reason("Create copy operation failure")
-        return "false"
+    assert new_ds is not None, "Create copy operation failure"
 
     bnd = new_ds.GetRasterBand(1)
-    if bnd.Checksum() != 4440:
-        gdaltest.post_reason("Wrong checksum")
-        return "false"
+    assert bnd.Checksum() == 4440, "Wrong checksum"
 
     bnd = None
     new_ds = None
@@ -130,15 +126,11 @@ def test_gif_6():
     new_ds = gdal.Open("tmp/nodata_byte.gif")
 
     bnd = new_ds.GetRasterBand(1)
-    if bnd.Checksum() != 4440:
-        gdaltest.post_reason("Wrong checksum")
-        return "false"
+    assert bnd.Checksum() == 4440, "Wrong checksum"
 
     # NOTE - mloskot: condition may fail as nodata is a float-point number
     nodata = bnd.GetNoDataValue()
-    if nodata != 0:
-        gdaltest.post_reason("Got unexpected nodata value.")
-        return "false"
+    assert nodata == 0, "Got unexpected nodata value."
 
     bnd = None
     new_ds = None

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -94,8 +94,8 @@ def test_grib_read_different_sizes_messages():
         result = tst.testOpen()
 
     msg = gdal.GetLastErrorMsg()
-    if msg.find("data access may be incomplete") == -1 or gdal.GetLastErrorType() != 2:
-        gdaltest.post_reason("did not get expected warning.")
+    assert "data access may be incomplete" in msg, "did not get expected warning."
+    assert gdal.GetLastErrorType() == 2, "did not get expected warning."
 
     return result
 
@@ -622,9 +622,7 @@ def test_grib_grib2_read_spatial_differencing_order_1():
 
     ds = gdal.Open("data/grib/spatial_differencing_order_1.grb2")
     cs = ds.GetRasterBand(1).Checksum()
-    if cs != 46650:
-        gdaltest.post_reason("Did not get expected checksum")
-        print(cs)
+    assert cs == 46650, "Did not get expected checksum"
 
 
 ###############################################################################
@@ -1515,11 +1513,9 @@ def test_grib_grib2_write_data_encodings():
         cs = out_ds.GetRasterBand(1).Checksum()
         out_ds = None
         gdal.Unlink(tmpfilename)
-        if cs == 0 or cs == 50235:  # 50235: lossless checksum
-            gdaltest.post_reason(
-                "did not get expected checksum for lossy JPEG2000 with " + drvname
-            )
-            print(cs)
+        assert (
+            cs != 0 and cs != 50235
+        ), f"did not get expected checksum for lossy JPEG2000 with {drvname}"  # 50235: lossless checksum
 
 
 ###############################################################################

--- a/autotest/gdrivers/mbtiles.py
+++ b/autotest/gdrivers/mbtiles.py
@@ -146,8 +146,7 @@ def test_mbtiles_3():
     )
     if locationInfo is None or locationInfo.find("France") == -1:
         print(locationInfo)
-        if gdaltest.skip_on_travis():
-            pytest.skip()
+        gdaltest.skip_on_travis()
         pytest.fail("did not get expected LocationInfo")
 
     locationInfo2 = (
@@ -157,8 +156,7 @@ def test_mbtiles_3():
     )
     if locationInfo2 != locationInfo:
         print(locationInfo2)
-        if gdaltest.skip_on_travis():
-            pytest.skip()
+        gdaltest.skip_on_travis()
         pytest.fail("did not get expected LocationInfo on overview")
 
 

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -1844,26 +1844,16 @@ def test_nitf_49():
     ds2 = gdal.GetDriverByName("NITF").CreateCopy("tmp/nitf49_2.ntf", ds)
 
     md = ds2.GetMetadata("TEXT")
-    if (
-        "DATA_0" not in md
-        or md["DATA_0"] != "COUCOU"
-        or "HEADER_0" not in md
-        or md["HEADER_0"].find("ABC  ") == -1
-    ):
-        gdaltest.post_reason("did not get expected TEXT metadata")
-        print(md)
-        return
+    assert "DATA_0" in md
+    assert md["DATA_0"] == "COUCOU"
+    assert "HEADER_0" in md
+    assert "ABC  " in md["HEADER_0"]
 
     md = ds2.GetMetadata("CGM")
-    if (
-        "SEGMENT_COUNT" not in md
-        or md["SEGMENT_COUNT"] != "1"
-        or "SEGMENT_0_DATA" not in md
-        or md["SEGMENT_0_DATA"] != "XYZ"
-    ):
-        gdaltest.post_reason("did not get expected CGM metadata")
-        print(md)
-        return
+    assert "SEGMENT_COUNT" in md
+    assert md["SEGMENT_COUNT"] == "1"
+    assert "SEGMENT_0_DATA" in md
+    assert md["SEGMENT_0_DATA"] == "XYZ"
 
     src_ds = None
     ds = None
@@ -1912,26 +1902,16 @@ def test_nitf_50():
     ds = gdal.Open("tmp/nitf50.ntf")
 
     md = ds.GetMetadata("TEXT")
-    if (
-        "DATA_0" not in md
-        or md["DATA_0"] != "COUCOU"
-        or "HEADER_0" not in md
-        or md["HEADER_0"].find("ABC  ") == -1
-    ):
-        gdaltest.post_reason("did not get expected TEXT metadata")
-        print(md)
-        return
+    assert "DATA_0" in md
+    assert md["DATA_0"] == "COUCOU"
+    assert "HEADER_0" in md
+    assert "ABC  " in md["HEADER_0"]
 
     md = ds.GetMetadata("CGM")
-    if (
-        "SEGMENT_COUNT" not in md
-        or md["SEGMENT_COUNT"] != "1"
-        or "SEGMENT_0_DATA" not in md
-        or md["SEGMENT_0_DATA"] != "XYZ"
-    ):
-        gdaltest.post_reason("did not get expected CGM metadata")
-        print(md)
-        return
+    assert "SEGMENT_COUNT" in md
+    assert md["SEGMENT_COUNT"] == "1"
+    assert "SEGMENT_0_DATA" in md
+    assert md["SEGMENT_0_DATA"] == "XYZ"
 
     ds = None
 
@@ -2143,10 +2123,7 @@ def test_nitf_57():
     gt = ds.GetGeoTransform()
     ds = None
 
-    if gt != (-180.0, 1.0, 0.0, 90.0, 0.0, -1.0):
-        gdaltest.post_reason("did not get expected geotransform")
-        print(gt)
-        return
+    assert gt == (-180.0, 1.0, 0.0, 90.0, 0.0, -1.0)
 
 
 ###############################################################################

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -6023,15 +6023,12 @@ def test_nitf_online_18():
             0.0,
             -724.73626818537434,
         )
-        assert gdaltest.geotransform_equals(
-            gt, expected_gt, 1.0
-        ), "did not get expected geotransform."
+        gdaltest.check_geotransform(gt, expected_gt, 1.0)
 
     # If we do not have a functioning coordinate transformer.
     else:
-        assert prj == "" and gdaltest.geotransform_equals(
-            gt, (0, 1, 0, 0, 0, 1), 0.00000001
-        ), "did not get expected empty gt/projection"
+        assert prj == ""
+        gdaltest.check_geotransform(gt, (0, 1, 0, 0, 0, 1), 0.00000001)
 
         prj = ds.GetGCPProjection()
         assert prj[:6] == "GEOGCS", "did not get expected geographic srs"

--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -118,9 +118,8 @@ def test_pcidsk_5():
 
     # Check metadata.
     mddef = gdaltest.pcidsk_ds.GetMetadata()
-    if mddef["GHI"] != "JKL" or mddef["XXX"] != "YYY":
-        print(mddef)
-        gdaltest.post_reason("file default domain metadata broken. ")
+    assert mddef["GHI"] == "JKL", "file default domain metadata broken. "
+    assert mddef["XXX"] == "YYY", "file default domain metadata broken. "
 
     assert gdaltest.pcidsk_ds.GetMetadataItem("GHI") == "JKL"
     assert gdaltest.pcidsk_ds.GetMetadataItem("GHI") == "JKL"
@@ -130,9 +129,7 @@ def test_pcidsk_5():
     assert gdaltest.pcidsk_ds.GetMetadataItem("I_DONT_EXIST") is None
 
     mdalt = gdaltest.pcidsk_ds.GetMetadata("AltDomain")
-    if mdalt["XYZ"] != "123":
-        print(mdalt)
-        gdaltest.post_reason("file alt domain metadata broken. ")
+    assert mdalt["XYZ"] == "123", "file alt domain metadata broken."
 
 
 ###############################################################################
@@ -157,9 +154,8 @@ def test_pcidsk_6():
     # Check metadata.
     band = gdaltest.pcidsk_ds.GetRasterBand(1)
     mddef = band.GetMetadata()
-    if mddef["GHI"] != "JKL" or mddef["XXX"] != "YYY":
-        print(mddef)
-        gdaltest.post_reason("channel default domain metadata broken. ")
+    assert mddef["GHI"] == "JKL", "channel default domain metadata broken. "
+    assert mddef["XXX"] == "YYY", "channel default domain metadata broken. "
 
     assert band.GetMetadataItem("GHI") == "JKL"
     assert band.GetMetadataItem("GHI") == "JKL"
@@ -169,9 +165,7 @@ def test_pcidsk_6():
     assert band.GetMetadataItem("I_DONT_EXIST") is None
 
     mdalt = band.GetMetadata("AltDomain")
-    if mdalt["XYZ"] != "123":
-        print(mdalt)
-        gdaltest.post_reason("channel alt domain metadata broken. ")
+    assert mdalt["XYZ"] == "123", "channel alt domain metadata broken."
 
 
 ###############################################################################
@@ -651,10 +645,7 @@ def test_pcidsk_online_1():
         "Glaciers",
     ]
 
-    if names != exp_names:
-        print(names)
-        gdaltest.post_reason("did not get expected category names.")
-        return "false"
+    assert names == exp_names, "did not get expected category names."
 
     band = ds.GetRasterBand(20)
     assert (

--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -521,8 +521,7 @@ def wms_10():
 # Permanently down
 def wms_11():
 
-    if gdaltest.skip_on_travis():
-        pytest.skip()
+    gdaltest.skip_on_travis()
 
     srv = "http://onearth.jpl.nasa.gov/wms.cgi"
     if gdaltest.gdalurlopen(srv) is None:

--- a/autotest/ogr/ogr_cad.py
+++ b/autotest/ogr/ogr_cad.py
@@ -32,7 +32,6 @@
 ################################################################################
 
 
-import gdaltest
 import ogrtest
 import pytest
 
@@ -300,13 +299,16 @@ def test_ogr_cad_6():
 
     ogrtest.check_feature_geometry(feat, "POINT(0.7413 1.7794 0)")
 
+
+@pytest.mark.xfail(reason="cannot be sure iconv is builtin")
+def test_ogr_cad_6bis():
+
+    ds = gdal.OpenEx("data/cad/text_mtext_attdef_r2000.dwg", allowed_drivers=["CAD"])
+    layer = ds.GetLayer(0)
+    feat = layer.GetNextFeature()
+
     expected_style = 'LABEL(f:"Arial",t:"Русские буквы",c:#FFFFFFFF)'
-    if feat.GetStyleString() != expected_style:
-        gdaltest.post_reason(
-            "Got unexpected style string:\n%s\ninstead of:\n%s."
-            % (feat.GetStyleString(), expected_style)
-        )
-        return "expected_fail"  # cannot sure iconv is buildin
+    assert feat.GetStyleString() == expected_style
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_feature.py
+++ b/autotest/ogr/ogr_feature.py
@@ -117,22 +117,6 @@ def mk_src_feature():
 
 
 ###############################################################################
-# Helper function to check a single field value
-
-
-def check(feat, fieldname, value):
-    if feat.GetField(fieldname) != value:
-        gdaltest.post_reason(
-            "did not get value %s for field %s, got %s."
-            % (str(value), fieldname, str(feat.GetField(fieldname))),
-            frames=3,
-        )
-        feat.DumpReadable()
-        return 0
-    return 1
-
-
-###############################################################################
 # Copy to Integer
 
 
@@ -145,29 +129,18 @@ def test_ogr_feature_cp_integer():
     with gdaltest.error_handler():
         dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", 17)
-
-    assert check(dst_feature, "field_integer64", 2147483647)
-
-    assert check(dst_feature, "field_real", 18)
-
-    assert check(dst_feature, "field_string", 0)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", None)
-
-    assert check(dst_feature, "field_time", None)
-
-    assert check(dst_feature, "field_datetime", None)
-
-    assert check(dst_feature, "field_integerlist", 15)
-
-    assert check(dst_feature, "field_integer64list", 2147483647)
-
-    assert check(dst_feature, "field_reallist", 17)
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") == 17
+    assert dst_feature.GetField("field_integer64") == 2147483647
+    assert dst_feature.GetField("field_real") == 18
+    assert dst_feature.GetField("field_string") == 0
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") is None
+    assert dst_feature.GetField("field_time") is None
+    assert dst_feature.GetField("field_datetime") is None
+    assert dst_feature.GetField("field_integerlist") == 15
+    assert dst_feature.GetField("field_integer64list") == 2147483647
+    assert dst_feature.GetField("field_reallist") == 17
+    assert dst_feature.GetField("field_stringlist") is None
 
     vals = []
     for val in dst_feature:
@@ -200,33 +173,23 @@ def test_ogr_feature_cp_integer64():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTInteger64)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", 17)
-
-    assert check(dst_feature, "field_integer64", 9876543210)
+    assert dst_feature.GetField("field_integer") == 17
+    assert dst_feature.GetField("field_integer64") == 9876543210
 
     with gdaltest.error_handler():
         int32_ovflw = dst_feature.GetFieldAsInteger("field_integer64")
     assert int32_ovflw == 2147483647
 
-    assert check(dst_feature, "field_real", 18)
-
-    assert check(dst_feature, "field_string", 0)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", None)
-
-    assert check(dst_feature, "field_time", None)
-
-    assert check(dst_feature, "field_datetime", None)
-
-    assert check(dst_feature, "field_integerlist", 15)
-
-    assert check(dst_feature, "field_integer64list", 9876543210)
-
-    assert check(dst_feature, "field_reallist", 17)
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_real") == 18
+    assert dst_feature.GetField("field_string") == 0
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") is None
+    assert dst_feature.GetField("field_time") is None
+    assert dst_feature.GetField("field_datetime") is None
+    assert dst_feature.GetField("field_integerlist") == 15
+    assert dst_feature.GetField("field_integer64list") == 9876543210
+    assert dst_feature.GetField("field_reallist") == 17
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -242,25 +205,16 @@ def test_ogr_feature_cp_real():
     with gdaltest.error_handler():
         dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", 17.0)
-
-    assert check(dst_feature, "field_real", 18.4)
-
-    assert check(dst_feature, "field_string", 0)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", None)
-
-    assert check(dst_feature, "field_time", None)
-
-    assert check(dst_feature, "field_datetime", None)
-
-    assert check(dst_feature, "field_integerlist", 15.0)
-
-    assert check(dst_feature, "field_reallist", 17.5)
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") == 17.0
+    assert dst_feature.GetField("field_real") == 18.4
+    assert dst_feature.GetField("field_string") == 0
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") is None
+    assert dst_feature.GetField("field_time") is None
+    assert dst_feature.GetField("field_datetime") is None
+    assert dst_feature.GetField("field_integerlist") == 15.0
+    assert dst_feature.GetField("field_reallist") == 17.5
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -273,29 +227,18 @@ def test_ogr_feature_cp_string():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTString)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", "17")
-
-    assert check(dst_feature, "field_integer64", "9876543210")
-
-    assert check(dst_feature, "field_real", "18.4")
-
-    assert check(dst_feature, "field_string", "abc def")
-
-    assert check(dst_feature, "field_binary", "0123465789ABCDEF")
-
-    assert check(dst_feature, "field_date", "2011/11/11")
-
-    assert check(dst_feature, "field_time", "14:10:35")
-
-    assert check(dst_feature, "field_datetime", "2011/11/11 14:10:35.123")
-
-    assert check(dst_feature, "field_integerlist", "(3:10,20,30)")
-
-    assert check(dst_feature, "field_integer64list", "(1:9876543210)")
-
-    assert check(dst_feature, "field_reallist", "(2:123.5,567)")
-
-    assert check(dst_feature, "field_stringlist", "(2:abc,def)")
+    assert dst_feature.GetField("field_integer") == "17"
+    assert dst_feature.GetField("field_integer64") == "9876543210"
+    assert dst_feature.GetField("field_real") == "18.4"
+    assert dst_feature.GetField("field_string") == "abc def"
+    assert dst_feature.GetField("field_binary") == "0123465789ABCDEF"
+    assert dst_feature.GetField("field_date") == "2011/11/11"
+    assert dst_feature.GetField("field_time") == "14:10:35"
+    assert dst_feature.GetField("field_datetime") == "2011/11/11 14:10:35.123"
+    assert dst_feature.GetField("field_integerlist") == "(3:10,20,30)"
+    assert dst_feature.GetField("field_integer64list") == "(1:9876543210)"
+    assert dst_feature.GetField("field_reallist") == "(2:123.5,567)"
+    assert dst_feature.GetField("field_stringlist") == "(2:abc,def)"
 
 
 ###############################################################################
@@ -308,15 +251,11 @@ def test_ogr_feature_cp_binary():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTBinary)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", None)
-
-    assert check(dst_feature, "field_integer64", None)
-
-    assert check(dst_feature, "field_real", None)
-
-    assert check(dst_feature, "field_string", None)
-
-    assert check(dst_feature, "field_binary", "0123465789ABCDEF")
+    assert dst_feature.GetField("field_integer") is None
+    assert dst_feature.GetField("field_integer64") is None
+    assert dst_feature.GetField("field_real") is None
+    assert dst_feature.GetField("field_string") is None
+    assert dst_feature.GetField("field_binary") == "0123465789ABCDEF"
 
     expected = b"\x01\x23\x46\x57\x89\xAB\xCD\xEF"
     assert dst_feature.GetFieldAsBinary("field_binary") == expected
@@ -327,19 +266,13 @@ def test_ogr_feature_cp_binary():
         == expected
     )
 
-    assert check(dst_feature, "field_date", None)
-
-    assert check(dst_feature, "field_time", None)
-
-    assert check(dst_feature, "field_datetime", None)
-
-    assert check(dst_feature, "field_integerlist", None)
-
-    assert check(dst_feature, "field_integer64list", None)
-
-    assert check(dst_feature, "field_reallist", None)
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_date") is None
+    assert dst_feature.GetField("field_time") is None
+    assert dst_feature.GetField("field_datetime") is None
+    assert dst_feature.GetField("field_integerlist") is None
+    assert dst_feature.GetField("field_integer64list") is None
+    assert dst_feature.GetField("field_reallist") is None
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -352,29 +285,18 @@ def test_ogr_feature_cp_date():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTDate)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", None)
-
-    assert check(dst_feature, "field_integer64", None)
-
-    assert check(dst_feature, "field_real", None)
-
-    assert check(dst_feature, "field_string", None)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", "2011/11/11")
-
-    assert check(dst_feature, "field_time", "0000/00/00")
-
-    assert check(dst_feature, "field_datetime", "2011/11/11")
-
-    assert check(dst_feature, "field_integerlist", None)
-
-    assert check(dst_feature, "field_integer64list", None)
-
-    assert check(dst_feature, "field_reallist", None)
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") is None
+    assert dst_feature.GetField("field_integer64") is None
+    assert dst_feature.GetField("field_real") is None
+    assert dst_feature.GetField("field_string") is None
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") == "2011/11/11"
+    assert dst_feature.GetField("field_time") == "0000/00/00"
+    assert dst_feature.GetField("field_datetime") == "2011/11/11"
+    assert dst_feature.GetField("field_integerlist") is None
+    assert dst_feature.GetField("field_integer64list") is None
+    assert dst_feature.GetField("field_reallist") is None
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -387,29 +309,18 @@ def test_ogr_feature_cp_time():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTTime)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", None)
-
-    assert check(dst_feature, "field_integer64", None)
-
-    assert check(dst_feature, "field_real", None)
-
-    assert check(dst_feature, "field_string", None)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", "00:00:00")
-
-    assert check(dst_feature, "field_time", "14:10:35")
-
-    assert check(dst_feature, "field_datetime", "14:10:35.123")
-
-    assert check(dst_feature, "field_integerlist", None)
-
-    assert check(dst_feature, "field_integer64list", None)
-
-    assert check(dst_feature, "field_reallist", None)
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") is None
+    assert dst_feature.GetField("field_integer64") is None
+    assert dst_feature.GetField("field_real") is None
+    assert dst_feature.GetField("field_string") is None
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") == "00:00:00"
+    assert dst_feature.GetField("field_time") == "14:10:35"
+    assert dst_feature.GetField("field_datetime") == "14:10:35.123"
+    assert dst_feature.GetField("field_integerlist") is None
+    assert dst_feature.GetField("field_integer64list") is None
+    assert dst_feature.GetField("field_reallist") is None
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -422,29 +333,18 @@ def test_ogr_feature_cp_datetime():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTDateTime)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", None)
-
-    assert check(dst_feature, "field_integer64", None)
-
-    assert check(dst_feature, "field_real", None)
-
-    assert check(dst_feature, "field_string", None)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", "2011/11/11 00:00:00")
-
-    assert check(dst_feature, "field_time", "0000/00/00 14:10:35")
-
-    assert check(dst_feature, "field_datetime", "2011/11/11 14:10:35.123")
-
-    assert check(dst_feature, "field_integerlist", None)
-
-    assert check(dst_feature, "field_integer64list", None)
-
-    assert check(dst_feature, "field_reallist", None)
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") is None
+    assert dst_feature.GetField("field_integer64") is None
+    assert dst_feature.GetField("field_real") is None
+    assert dst_feature.GetField("field_string") is None
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") == "2011/11/11 00:00:00"
+    assert dst_feature.GetField("field_time") == "0000/00/00 14:10:35"
+    assert dst_feature.GetField("field_datetime") == "2011/11/11 14:10:35.123"
+    assert dst_feature.GetField("field_integerlist") is None
+    assert dst_feature.GetField("field_integer64list") is None
+    assert dst_feature.GetField("field_reallist") is None
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -458,29 +358,18 @@ def test_ogr_feature_cp_integerlist():
     with gdaltest.error_handler():
         dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", [17])
-
-    assert check(dst_feature, "field_integer64", [2147483647])
-
-    assert check(dst_feature, "field_real", [18])
-
-    assert check(dst_feature, "field_string", None)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", None)
-
-    assert check(dst_feature, "field_time", None)
-
-    assert check(dst_feature, "field_datetime", None)
-
-    assert check(dst_feature, "field_integerlist", [10, 20, 30])
-
-    assert check(dst_feature, "field_integer64list", [2147483647])
-
-    assert check(dst_feature, "field_reallist", [123, 567])
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") == [17]
+    assert dst_feature.GetField("field_integer64") == [2147483647]
+    assert dst_feature.GetField("field_real") == [18]
+    assert dst_feature.GetField("field_string") is None
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") is None
+    assert dst_feature.GetField("field_time") is None
+    assert dst_feature.GetField("field_datetime") is None
+    assert dst_feature.GetField("field_integerlist") == [10, 20, 30]
+    assert dst_feature.GetField("field_integer64list") == [2147483647]
+    assert dst_feature.GetField("field_reallist") == [123, 567]
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -493,29 +382,18 @@ def test_ogr_feature_cp_integer64list():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTInteger64List)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", [17])
-
-    assert check(dst_feature, "field_integer64", [9876543210])
-
-    assert check(dst_feature, "field_real", [18])
-
-    assert check(dst_feature, "field_string", None)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", None)
-
-    assert check(dst_feature, "field_time", None)
-
-    assert check(dst_feature, "field_datetime", None)
-
-    assert check(dst_feature, "field_integerlist", [10, 20, 30])
-
-    assert check(dst_feature, "field_integer64list", [9876543210])
-
-    assert check(dst_feature, "field_reallist", [123, 567])
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") == [17]
+    assert dst_feature.GetField("field_integer64") == [9876543210]
+    assert dst_feature.GetField("field_real") == [18]
+    assert dst_feature.GetField("field_string") is None
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") is None
+    assert dst_feature.GetField("field_time") is None
+    assert dst_feature.GetField("field_datetime") is None
+    assert dst_feature.GetField("field_integerlist") == [10, 20, 30]
+    assert dst_feature.GetField("field_integer64list") == [9876543210]
+    assert dst_feature.GetField("field_reallist") == [123, 567]
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -528,29 +406,18 @@ def test_ogr_feature_cp_reallist():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTRealList)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", [17.0])
-
-    assert check(dst_feature, "field_integer64", [9876543210.0])
-
-    assert check(dst_feature, "field_real", [18.4])
-
-    assert check(dst_feature, "field_string", None)
-
-    assert check(dst_feature, "field_binary", None)
-
-    assert check(dst_feature, "field_date", None)
-
-    assert check(dst_feature, "field_time", None)
-
-    assert check(dst_feature, "field_datetime", None)
-
-    assert check(dst_feature, "field_integerlist", [10.0, 20.0, 30.0])
-
-    assert check(dst_feature, "field_integer64list", [9876543210.0])
-
-    assert check(dst_feature, "field_reallist", [123.5, 567.0])
-
-    assert check(dst_feature, "field_stringlist", None)
+    assert dst_feature.GetField("field_integer") == [17.0]
+    assert dst_feature.GetField("field_integer64") == [9876543210.0]
+    assert dst_feature.GetField("field_real") == [18.4]
+    assert dst_feature.GetField("field_string") is None
+    assert dst_feature.GetField("field_binary") is None
+    assert dst_feature.GetField("field_date") is None
+    assert dst_feature.GetField("field_time") is None
+    assert dst_feature.GetField("field_datetime") is None
+    assert dst_feature.GetField("field_integerlist") == [10.0, 20.0, 30.0]
+    assert dst_feature.GetField("field_integer64list") == [9876543210.0]
+    assert dst_feature.GetField("field_reallist") == [123.5, 567.0]
+    assert dst_feature.GetField("field_stringlist") is None
 
 
 ###############################################################################
@@ -563,29 +430,18 @@ def test_ogr_feature_cp_stringlist():
     dst_feature = mk_dst_feature(src_feature, ogr.OFTStringList)
     dst_feature.SetFrom(src_feature)
 
-    assert check(dst_feature, "field_integer", ["17"])
-
-    assert check(dst_feature, "field_integer64", ["9876543210"])
-
-    assert check(dst_feature, "field_real", ["18.4"])
-
-    assert check(dst_feature, "field_string", ["abc def"])
-
-    assert check(dst_feature, "field_binary", ["0123465789ABCDEF"])
-
-    assert check(dst_feature, "field_date", ["2011/11/11"])
-
-    assert check(dst_feature, "field_time", ["14:10:35"])
-
-    assert check(dst_feature, "field_datetime", ["2011/11/11 14:10:35.123"])
-
-    assert check(dst_feature, "field_integerlist", ["10", "20", "30"])
-
-    assert check(dst_feature, "field_integer64list", ["9876543210"])
-
-    assert check(dst_feature, "field_reallist", ["123.5", "567"])
-
-    assert check(dst_feature, "field_stringlist", ["abc", "def"])
+    assert dst_feature.GetField("field_integer") == ["17"]
+    assert dst_feature.GetField("field_integer64") == ["9876543210"]
+    assert dst_feature.GetField("field_real") == ["18.4"]
+    assert dst_feature.GetField("field_string") == ["abc def"]
+    assert dst_feature.GetField("field_binary") == ["0123465789ABCDEF"]
+    assert dst_feature.GetField("field_date") == ["2011/11/11"]
+    assert dst_feature.GetField("field_time") == ["14:10:35"]
+    assert dst_feature.GetField("field_datetime") == ["2011/11/11 14:10:35.123"]
+    assert dst_feature.GetField("field_integerlist") == ["10", "20", "30"]
+    assert dst_feature.GetField("field_integer64list") == ["9876543210"]
+    assert dst_feature.GetField("field_reallist") == ["123.5", "567"]
+    assert dst_feature.GetField("field_stringlist") == ["abc", "def"]
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -193,20 +193,17 @@ def test_gml_polygon():
 
 
 def _CreateGMLWithSRSFromWkt(wkt, epsg):
+    __tracebackhide__ = True
 
     geom = ogr.CreateGeometryFromWkt(wkt)
 
-    if geom is None:
-        gdaltest.post_reason("Import geometry from WKT failed")
-        return None
+    assert geom is not None, "Import geometry from WKT failed"
 
     # Assign SRS from given EPSG code
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(epsg)
 
-    if srs is None:
-        gdaltest.post_reason("SRS import from EPSG failed")
-        return None
+    assert srs is not None, "SRS import from EPSG failed"
 
     geom.AssignSpatialReference(srs)
 

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -460,8 +460,7 @@ def test_ogr_gpkg_7():
     ), "Expected failure of DeleteFeature()."
 
     # Delete the layer
-    if gpkg_ds.DeleteLayer("field_test_layer") != 0:
-        gdaltest.post_reason("got error code from DeleteLayer(field_test_layer)")
+    assert gpkg_ds.DeleteLayer("field_test_layer") == ogr.OGRERR_NONE
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -289,10 +289,7 @@ def test_ogr_mem_9():
     # Verify that count has dropped by one, and that the feature in question
     # can't be fetched.
     new_count = gdaltest.mem_lyr.GetFeatureCount()
-    if new_count != old_count - 1:
-        gdaltest.post_reason(
-            "got feature count of %d, not expected %d." % (new_count, old_count - 1)
-        )
+    assert new_count == (old_count - 1), "unexpected feature count"
 
     assert gdaltest.mem_lyr.TestCapability(
         ogr.OLCRandomRead

--- a/autotest/ogr/ogr_ngw.py
+++ b/autotest/ogr/ogr_ngw.py
@@ -799,8 +799,7 @@ def test_ogr_ngw_test_ogrsf():
     if gdaltest.ngw_ds is None:
         pytest.skip()
 
-    if gdaltest.skip_on_travis():
-        pytest.skip("skip on travis")
+    gdaltest.skip_on_travis()
 
     url = "NGW:" + gdaltest.ngw_test_server + "/resource/" + gdaltest.group_id
 

--- a/autotest/ogr/ogr_refcount.py
+++ b/autotest/ogr/ogr_refcount.py
@@ -56,9 +56,8 @@ def test_ogr_refcount_1():
     #    gdaltest.post_reason( 'Open DS count not 2 after shared opens.' )
     #    return 'failed'
 
-    if gdaltest.ds_1.GetRefCount() != 1 or gdaltest.ds_2.GetRefCount() != 1:
-        gdaltest.post_reason("Reference count not 1 on one of datasources.")
-        return "failed"
+    assert gdaltest.ds_1.GetRefCount() == 1
+    assert gdaltest.ds_2.GetRefCount() == 1
 
 
 ###############################################################################
@@ -73,17 +72,7 @@ def test_ogr_refcount_2():
     #    gdaltest.post_reason( 'Open DS count not 2 after third open.' )
     #    return 'failed'
 
-    # This test only works with the old bindings.
-    try:
-        if ds_3._o != gdaltest.ds_1._o:
-            gdaltest.post_reason("We did not get the expected pointer.")
-            return "failed"
-    except Exception:
-        pass
-
-    if ds_3.GetRefCount() != 2:
-        gdaltest.post_reason("Refcount not 2 after reopened.")
-        return "failed"
+    assert ds_3.GetRefCount() == 2, "Refcount not 2 after reopened."
 
     gdaltest.ds_3 = ds_3
 
@@ -96,9 +85,7 @@ def test_ogr_refcount_3():
 
     gdaltest.ds_3.Release()
 
-    if gdaltest.ds_1.GetRefCount() != 1:
-        gdaltest.post_reason("Refcount not decremented as expected.")
-        return "failed"
+    assert gdaltest.ds_1.GetRefCount() == 1
 
     gdaltest.ds_1.Release()
 
@@ -110,13 +97,7 @@ def test_ogr_refcount_3():
 def test_ogr_refcount_4():
 
     with gdaltest.error_handler():
-        ds = ogr.GetOpenDS(0)
-    try:
-        if ds._o != gdaltest.ds_2._o:
-            gdaltest.post_reason("failed to fetch expected datasource")
-            return "failed"
-    except Exception:
-        pass
+        ogr.GetOpenDS(0)
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_rfc35_mitab.py
+++ b/autotest/ogr/ogr_rfc35_mitab.py
@@ -482,9 +482,7 @@ def test_ogr_rfc35_mitab_5():
 
     # Check that the file size has decreased after column removing
     CheckFileSize("tmp/rfc35_test.tab")
-    if ret == "fail":
-        gdaltest.post_reason(ret)
-        return ret
+    assert ret != "fail"
 
     ds = ogr.Open("tmp/rfc35_test.tab", update=1)
     lyr = ds.GetLayer(0)

--- a/autotest/osr/osr_compd.py
+++ b/autotest/osr/osr_compd.py
@@ -124,8 +124,8 @@ def test_osr_compd_3():
         AUTHORITY["EPSG","5719"]],
     AUTHORITY["EPSG","7401"]]"""
     wkt = srs.ExportToPrettyWkt()
-    assert (
-        gdaltest.equal_srs_from_wkt(exp_wkt, wkt) != 0
+    assert gdaltest.equal_srs_from_wkt(
+        exp_wkt, wkt
     ), "did not get expected compound cs for EPSG:7401"
 
 
@@ -161,8 +161,8 @@ def test_osr_compd_4():
     AUTHORITY["EPSG","7400"]]"""
     wkt = srs.ExportToPrettyWkt()
 
-    assert (
-        gdaltest.equal_srs_from_wkt(exp_wkt, wkt) != 0
+    assert gdaltest.equal_srs_from_wkt(
+        exp_wkt, wkt
     ), "did not get expected compound cs for EPSG:7400"
 
 
@@ -209,9 +209,9 @@ def test_osr_compd_5():
         AUTHORITY["EPSG","5703"]]]"""
     wkt = srs.ExportToPrettyWkt()
 
-    if gdaltest.equal_srs_from_wkt(exp_wkt, wkt) == 0:
-        pytest.fail()
-    elif exp_wkt != wkt:
+    assert gdaltest.equal_srs_from_wkt(exp_wkt, wkt)
+
+    if exp_wkt != wkt:
         print("warning they are equivalent, but not completely the same")
         print(wkt)
 
@@ -277,9 +277,9 @@ def test_osr_compd_6():
         "unknown",
     )
 
-    if gdaltest.equal_srs_from_wkt(exp_wkt, wkt) == 0:
-        pytest.fail()
-    elif exp_wkt != wkt:
+    assert gdaltest.equal_srs_from_wkt(exp_wkt, wkt)
+
+    if exp_wkt != wkt:
         print("warning they are equivalent, but not completely the same")
         print(wkt)
 
@@ -329,9 +329,9 @@ def test_osr_compd_7():
 
     wkt = srs.ExportToPrettyWkt()
 
-    if gdaltest.equal_srs_from_wkt(exp_wkt, wkt) == 0:
-        pytest.fail()
-    elif exp_wkt != wkt:
+    assert gdaltest.equal_srs_from_wkt(exp_wkt, wkt)
+
+    if exp_wkt != wkt:
         print("warning they are equivalent, but not completely the same")
         print(wkt)
 

--- a/autotest/osr/osr_esri.py
+++ b/autotest/osr/osr_esri.py
@@ -32,7 +32,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import gdaltest
 import pytest
 
 from osgeo import osr
@@ -353,10 +352,9 @@ def test_osr_esri_12():
         "standard_parallel_1"
     )
 
-    if srs.GetAttrValue("DATUM") != "North_American_Datum_1983":
-        gdaltest.post_reason(
-            "Got wrong DATUM name (%s) after ESRI morph." % srs.GetAttrValue("DATUM")
-        )
+    assert (
+        srs.GetAttrValue("DATUM") == "North_American_Datum_1983"
+    ), "Got wrong DATUM name (%s) after ESRI morph." % srs.GetAttrValue("DATUM")
 
     assert (
         srs.GetAttrValue("UNIT") == "metre"
@@ -387,10 +385,9 @@ def test_osr_esri_13():
         "standard_parallel_1"
     )
 
-    if srs.GetAttrValue("DATUM") != "North_American_Datum_1983":
-        gdaltest.post_reason(
-            "Got wrong DATUM name (%s) after ESRI morph." % srs.GetAttrValue("DATUM")
-        )
+    assert (
+        srs.GetAttrValue("DATUM") == "North_American_Datum_1983"
+    ), "Got wrong DATUM name (%s) after ESRI morph." % srs.GetAttrValue("DATUM")
 
     assert (
         srs.GetAttrValue("UNIT") == "metre"

--- a/autotest/osr/osr_pci.py
+++ b/autotest/osr/osr_pci.py
@@ -155,10 +155,9 @@ def test_osr_pci_3():
     )
 
     wkt = srs.ExportToWkt()
-    if wkt.find('PARAMETER["false_northing",0]') == -1:
-        gdaltest.post_reason("did not default to northern hemisphere!")
-        print(wkt)
-        return "fail"
+    assert (
+        'PARAMETER["false_northing",0]' in wkt
+    ), "did not default to northern hemisphere!"
 
     srs = osr.SpatialReference()
     srs.ImportFromPCI(
@@ -186,10 +185,7 @@ def test_osr_pci_3():
     )
 
     wkt = srs.ExportToWkt()
-    if wkt.find('PARAMETER["false_northing",10000000]') == -1:
-        gdaltest.post_reason("did get northern hemisphere!")
-        print(wkt)
-        return "fail"
+    assert 'PARAMETER["false_northing",10000000]' in wkt, "did get northern hemisphere!"
 
     srs = osr.SpatialReference()
     srs.ImportFromPCI(
@@ -217,10 +213,7 @@ def test_osr_pci_3():
     )
 
     wkt = srs.ExportToWkt()
-    if wkt.find('PARAMETER["false_northing",0]') == -1:
-        gdaltest.post_reason("did get southern hemisphere!")
-        print(wkt)
-        return "fail"
+    assert 'PARAMETER["false_northing",0]' in wkt, "did get southern hemisphere!"
 
 
 ###############################################################################

--- a/autotest/osr/osr_proj4.py
+++ b/autotest/osr/osr_proj4.py
@@ -109,10 +109,7 @@ def test_osr_proj4_5():
 
     p4 = srs.ExportToProj4()
 
-    if p4 != input_p4:
-        gdaltest.post_reason("round trip via PROJ.4 damaged srs?")
-        print(p4)
-        return "fail"
+    assert p4 == input_p4, "round trip via PROJ.4 damaged srs?"
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -110,19 +110,6 @@ def get_lineno_2framesback(frames):
 ###############################################################################
 
 
-def post_reason(msg, frames=2):
-    lineno = get_lineno_2framesback(frames)
-    global reason
-
-    if lineno >= 0:
-        reason = "line %d: %s" % (lineno, msg)
-    else:
-        reason = msg
-
-
-###############################################################################
-
-
 def clean_tmp():
     all_files = os.listdir("tmp")
     for filename in all_files:
@@ -1411,17 +1398,16 @@ def filesystem_supports_sparse_files(path):
         return False
 
     if err != "":
-        post_reason("Cannot determine if filesystem supports sparse files")
+        print("Cannot determine if filesystem supports sparse files")
         return False
 
-    if ret.find("fat32") != -1:
-        post_reason("File system does not support sparse files")
+    if "fat32" in ret:
+        print("File system does not support sparse files")
         return False
 
-    if (
-        ret.find("wslfs") != -1 or ret.find("0x53464846") != -1
-    ):  # wslfs for older stat versions
-        post_reason(
+    if "wslfs" in ret or "0x53464846" in ret:
+        # wslfs for older stat versions
+        print(
             "Windows Subsystem for Linux FS is at the time of "
             + "writing not known to support sparse files"
         )
@@ -1429,19 +1415,22 @@ def filesystem_supports_sparse_files(path):
 
     # Add here any missing filesystem supporting sparse files
     # See http://en.wikipedia.org/wiki/Comparison_of_file_systems
-    if (
-        ret.find("ext3") == -1
-        and ret.find("ext4") == -1
-        and ret.find("reiser") == -1
-        and ret.find("xfs") == -1
-        and ret.find("jfs") == -1
-        and ret.find("zfs") == -1
-        and ret.find("ntfs") == -1
-    ):
-        post_reason("Filesystem %s is not believed to support sparse files" % ret)
-        return False
+    filesystems_supporting_sparse_files = {
+        "ext3",
+        "ext4",
+        "reiser",
+        "xfs",
+        "jfs",
+        "zfs",
+        "ntfs",
+    }
 
-    return True
+    for fs in filesystems_supporting_sparse_files:
+        if fs in ret:
+            return True
+
+    print("Filesystem %s is not believed to support sparse files" % ret)
+    return False
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1431,7 +1431,7 @@ def reregister_all_jpeg2000_drivers():
 
 def filesystem_supports_sparse_files(path):
 
-    if skip_on_travis():
+    if gdal.GetConfigOption("TRAVIS", None):
         return False
 
     try:
@@ -1567,11 +1567,10 @@ def support_symlink():
 
 
 def skip_on_travis():
+    __tracebackhide__ = True
     val = gdal.GetConfigOption("TRAVIS", None)
     if val is not None:
-        post_reason("Test skipped on Travis")
-        return True
-    return False
+        pytest.skip("Test skipped on Travis")
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1071,7 +1071,8 @@ def equal_srs_from_wkt(expected_wkt, got_wkt, verbose=True):
 # equivalent or not.
 
 
-def rpcs_equal(md1, md2):
+def check_rpcs_equal(md1, md2):
+    __tracebackhide__ = True
 
     simple_fields = [
         "LINE_OFF",
@@ -1094,47 +1095,23 @@ def rpcs_equal(md1, md2):
 
     for sf in simple_fields:
 
-        try:
-            if not approx_equal(float(md1[sf]), float(md2[sf])):
-                post_reason("%s values differ." % sf)
-                print(md1[sf])
-                print(md2[sf])
-                return 0
-        except Exception:
-            post_reason("%s value missing or corrupt." % sf)
-            print(md1)
-            print(md2)
-            return 0
+        assert sf in md1
+        assert sf in md2
+        assert approx_equal(float(md1[sf]), float(md2[sf]))
 
     for cf in coef_fields:
 
-        try:
-            list1 = md1[cf].split()
-            list2 = md2[cf].split()
+        list1 = md1[cf].split()
+        list2 = md2[cf].split()
 
-        except Exception:
-            post_reason("%s value missing or corrupt." % cf)
-            print(md1[cf])
-            print(md2[cf])
-            return 0
+        assert len(list1) == 20, "%s value list length wrong(1)" % cf
 
-        if len(list1) != 20:
-            post_reason("%s value list length wrong(1)" % cf)
-            print(list1)
-            return 0
-
-        if len(list2) != 20:
-            post_reason("%s value list length wrong(2)" % cf)
-            print(list2)
-            return 0
+        assert len(list2) == 20, "%s value list length wrong(2)" % cf
 
         for i in range(20):
-            if not approx_equal(float(list1[i]), float(list2[i])):
-                post_reason("%s[%d] values differ." % (cf, i))
-                print(list1[i], list2[i])
-                return 0
-
-    return 1
+            assert approx_equal(
+                float(list1[i]), float(list2[i])
+            ), "%s[%d] values differ." % (cf, i)
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1119,15 +1119,9 @@ def check_rpcs_equal(md1, md2):
 #
 
 
-def geotransform_equals(gt1, gt2, gt_epsilon):
-    for i in range(6):
-        if gt1[i] != pytest.approx(gt2[i], abs=gt_epsilon):
-            print("")
-            print("gt1 = ", gt1)
-            print("gt2 = ", gt2)
-            post_reason("Geotransform differs.")
-            return False
-    return True
+def check_geotransform(gt1, gt2, gt_epsilon):
+    __tracebackhide__ = True
+    assert gt1 == pytest.approx(gt2, abs=gt_epsilon), "Geotransform differs."
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1058,12 +1058,12 @@ def equal_srs_from_wkt(expected_wkt, got_wkt, verbose=True):
     got_srs.ImportFromWkt(got_wkt)
 
     if got_srs.IsSame(expected_srs):
-        return 1
+        return True
     if verbose:
         print("Expected:\n%s" % expected_wkt)
         print("Got:     \n%s" % got_wkt)
-        post_reason("SRS differs from expected.")
-    return 0
+        print("SRS differs from expected.")
+    return False
 
 
 ###############################################################################

--- a/autotest/pyscripts/test_gdal_ls_py.py
+++ b/autotest/pyscripts/test_gdal_ls_py.py
@@ -194,7 +194,6 @@ def test_gdal_ls_py_6(script_path):
         # FIXME
         # Fails on Travis with dates at 1970-01-01 00:00
         # Looks like a 32/64bit issue with Python bindings of VSIStatL()
-        pytest.skip()
         pytest.fail(ret_str)
 
 

--- a/autotest/pyscripts/test_gdal_ls_py.py
+++ b/autotest/pyscripts/test_gdal_ls_py.py
@@ -124,11 +124,10 @@ def test_gdal_ls_py_4(script_path):
         )
         == -1
     ):
-        if gdaltest.skip_on_travis():
-            # FIXME
-            # Fails on Travis with dates at 1970-01-01 00:00
-            # Looks like a 32/64bit issue with Python bindings of VSIStatL()
-            pytest.skip()
+        gdaltest.skip_on_travis()
+        # FIXME
+        # Fails on Travis with dates at 1970-01-01 00:00
+        # Looks like a 32/64bit issue with Python bindings of VSIStatL()
         pytest.fail(ret_str)
 
 
@@ -191,11 +190,11 @@ def test_gdal_ls_py_6(script_path):
         )
         == -1
     ):
-        if gdaltest.skip_on_travis():
-            # FIXME
-            # Fails on Travis with dates at 1970-01-01 00:00
-            # Looks like a 32/64bit issue with Python bindings of VSIStatL()
-            pytest.skip()
+        gdaltest.skip_on_travis()
+        # FIXME
+        # Fails on Travis with dates at 1970-01-01 00:00
+        # Looks like a 32/64bit issue with Python bindings of VSIStatL()
+        pytest.skip()
         pytest.fail(ret_str)
 
 

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -276,11 +276,11 @@ def test_gdal_translate_11(gdal_translate_path):
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -301,11 +301,11 @@ def test_gdal_translate_12(gdal_translate_path):
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -801,11 +801,11 @@ def test_gdal_translate_31(gdal_translate_path):
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-6,
-    ), "Bad geotransform"
+    )
 
     ds = None
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -288,11 +288,11 @@ def test_gdal_translate_lib_11():
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -313,11 +313,11 @@ def test_gdal_translate_lib_12():
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -467,11 +467,11 @@ def test_gdal_translate_lib_103():
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -147,11 +147,11 @@ def test_gdalwarp_5(gdalwarp_path):
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -171,11 +171,11 @@ def test_gdalwarp_6(gdalwarp_path):
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -194,9 +194,7 @@ def test_gdalwarp_7(gdalwarp_path):
     assert ds is not None
 
     expected_gt = (440720.0, 120.0, 0.0, 3751320.0, 0.0, -120.0)
-    assert gdaltest.geotransform_equals(
-        expected_gt, ds.GetGeoTransform(), 1e-9
-    ), "Bad geotransform"
+    gdaltest.check_geotransform(expected_gt, ds.GetGeoTransform(), 1e-9)
 
     ds = None
 
@@ -215,9 +213,7 @@ def test_gdalwarp_8(gdalwarp_path):
     assert ds is not None
 
     expected_gt = (440720.0, 120.0, 0.0, 3751320.0, 0.0, -120.0)
-    assert gdaltest.geotransform_equals(
-        expected_gt, ds.GetGeoTransform(), 1e-9
-    ), "Bad geotransform"
+    gdaltest.check_geotransform(expected_gt, ds.GetGeoTransform(), 1e-9)
 
     ds = None
 
@@ -236,11 +232,11 @@ def test_gdalwarp_9(gdalwarp_path):
     ds = gdal.Open("tmp/testgdalwarp9.tif")
     assert ds is not None
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -913,11 +909,11 @@ def test_gdalwarp_35(gdalwarp_path):
     ds = gdal.Open("tmp/testgdalwarp35.tif")
     assert ds is not None
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -936,11 +932,11 @@ def test_gdalwarp_36(gdalwarp_path):
     ds = gdal.Open("tmp/testgdalwarp36.tif")
     assert ds is not None
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -120,9 +120,7 @@ def test_gdalwarp_lib_5():
 
     assert dstDS.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
-        ds.GetGeoTransform(), dstDS.GetGeoTransform(), 1e-9
-    ), "Bad geotransform"
+    gdaltest.check_geotransform(ds.GetGeoTransform(), dstDS.GetGeoTransform(), 1e-9)
 
     dstDS = None
 
@@ -138,11 +136,11 @@ def test_gdalwarp_lib_6():
 
     assert dstDS.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         dstDS.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     dstDS = None
 
@@ -158,9 +156,7 @@ def test_gdalwarp_lib_7():
     assert dstDS is not None
 
     expected_gt = (440720.0, 120.0, 0.0, 3751320.0, 0.0, -120.0)
-    assert gdaltest.geotransform_equals(
-        expected_gt, dstDS.GetGeoTransform(), 1e-9
-    ), "Bad geotransform"
+    gdaltest.check_geotransform(expected_gt, dstDS.GetGeoTransform(), 1e-9)
 
     dstDS = None
 
@@ -176,9 +172,7 @@ def test_gdalwarp_lib_8():
     assert dstDS is not None
 
     expected_gt = (440720.0, 120.0, 0.0, 3751320.0, 0.0, -120.0)
-    assert gdaltest.geotransform_equals(
-        expected_gt, dstDS.GetGeoTransform(), 1e-9
-    ), "Bad geotransform"
+    gdaltest.check_geotransform(expected_gt, dstDS.GetGeoTransform(), 1e-9)
 
     dstDS = None
 
@@ -196,11 +190,11 @@ def test_gdalwarp_lib_9():
         outputBounds=[440720.000, 3750120.000, 441920.000, 3751320.000],
     )
 
-    assert gdaltest.geotransform_equals(
+    gdaltest.check_geotransform(
         gdal.Open("../gcore/data/byte.tif").GetGeoTransform(),
         ds.GetGeoTransform(),
         1e-9,
-    ), "Bad geotransform"
+    )
 
     ds = None
 
@@ -545,7 +539,7 @@ def test_gdalwarp_lib_32():
 
     expected_gt = (440700.0, 100.0, 0.0, 3751300.0, 0.0, -50.0)
     got_gt = ds.GetGeoTransform()
-    assert gdaltest.geotransform_equals(expected_gt, got_gt, 1e-9), "Bad geotransform"
+    gdaltest.check_geotransform(expected_gt, got_gt, 1e-9)
 
     assert (
         ds.RasterXSize == 12 and ds.RasterYSize == 24


### PR DESCRIPTION
## What does this PR do?

Removes `gdaltest.post_reason`, largely by moving the information it would provide into `assert` statements.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/7573 is resolved by this PR.

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
