### PR TITLE
Python bindings: Invalidate band refs when dataset closes

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -771,3 +771,22 @@ def test_create_context_manager(tmp_path):
 
     ds_in = gdal.Open(fname)
     assert ds_in.GetRasterBand(1).Checksum() != 0
+
+
+def test_band_use_after_dataset_close_1():
+    ds = gdal.Open("data/byte.tif")
+    band = ds.GetRasterBand(1)
+    del ds
+
+    # Make sure "del ds" has invalidated "band" so we don't crash here
+    with pytest.raises(Exception):
+        band.Checksum()
+
+
+def test_band_use_after_dataset_close_2():
+    with gdal.Open("data/byte.tif") as ds:
+        band = ds.GetRasterBand(1)
+
+    # Make sure ds.__exit__() has invalidated "band" so we don't crash here
+    with pytest.raises(Exception):
+        band.Checksum()

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -917,6 +917,29 @@ def test_ogr_basic_create_data_source_context_manager(tmp_path):
 
 
 ###############################################################################
+# check layer access after datasource has closed
+
+
+def test_layer_use_after_datasource_close_1():
+    with ogr.Open("data/poly.shp") as ds:
+        lyr = ds.GetLayer(0)
+
+    # Make sure ds.__exit__() has invalidated "lyr" so we don't crash here
+    with pytest.raises(Exception):
+        lyr.GetFeatureCount()
+
+
+def test_layer_use_after_datasource_close_2():
+    ds = ogr.Open("data/poly.shp")
+    lyr = ds.GetLayerByName("poly")
+
+    del ds
+    # Make sure ds.__del__() has invalidated "lyr" so we don't crash here
+    with pytest.raises(Exception):
+        lyr.GetFeatureCount()
+
+
+###############################################################################
 # cleanup
 
 


### PR DESCRIPTION
## What does this PR do?

    Modify gdal.Dataset to track gdal.Band objects it creates. When
    gdal.Dataset closes, extant gdal.Band objects will be invalidated. If an
    invalidated gdal.Band object is used, it will throw an exception instead
    of creating a segfault.

I think this is the approach described in https://github.com/OSGeo/gdal/pull/7697#issuecomment-1535461854. I have a little hesitation about the list of references in `Dataset` growing without bound. This could be avoided by having bands cleanup their own references in Dataset (if they go out of scope first) or by having `GetRasterBand` return the same `Band` object if it is called multiple times with the same index.

The exception thrown when an invalidated `Band` is used is uninformative (`TypeError: in method 'Band_Checksum', argument 1 of type 'GDALRasterBandShadow *'`) but I think a bad exception is better than a segfault. We could also provide our own message by `%prepend`-ing a check on the methods of `Band`.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/7697#issuecomment-1535461854

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed