### PR TITLE
OGCAPI: Fix TILES raster API not working

### DIFF
--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -822,7 +822,7 @@ bool OGCAPIDataset::InitFromCollection(GDALOpenInfo *poOpenInfo,
         if (!osTilesetsMapURL.empty())
             bRet = InitWithTilesAPI(poOpenInfo, osTilesetsMapURL, true, dfXMin,
                                     dfYMin, dfXMax, dfYMax, oDoc.GetRoot());
-        if (!osTilesetsVectorURL.empty())
+        if (!bRet && !osTilesetsVectorURL.empty())
             bRet =
                 InitWithTilesAPI(poOpenInfo, osTilesetsVectorURL, false, dfXMin,
                                  dfYMin, dfXMax, dfYMax, oDoc.GetRoot());


### PR DESCRIPTION
Fix unreported bug with OGCAPI TILES raster API.

The test is in a separate PR with the other regression tests for OGCAPI.