### PR TITLE
GDALDatasetPool: Make VRT pool size clamping more lenient (#7977)

### DIFF
--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -250,8 +250,9 @@ Performance and caching
       Number of datasets that can be opened simultaneously by the GDALProxyPool
       mechanism (used by VRT for example). Can be increased to get better random I/O
       performance with VRT mosaics made of numerous underlying raster files. Be
-      careful : on Linux systems, the number of file handles that can be opened by a
-      process is generally limited to 1024.
+      careful: on Linux systems, the number of file handles that can be opened by a
+      process is generally limited to 1024. This is currently clamped between 2 and
+      1000.
 
 -  .. config:: GDAL_MAX_DATASET_POOL_RAM_USAGE
       :since: 3.7

--- a/gcore/gdalproxypool.cpp
+++ b/gcore/gdalproxypool.cpp
@@ -512,8 +512,10 @@ void GDALDatasetPool::Ref()
     {
         int l_maxSize =
             atoi(CPLGetConfigOption("GDAL_MAX_DATASET_POOL_SIZE", "100"));
-        if (l_maxSize < 2 || l_maxSize > 1000)
-            l_maxSize = 100;
+        if (l_maxSize < 2)
+            l_maxSize = 2;
+        else if (l_maxSize > 1000)
+            l_maxSize = 1000;
 
         // Try to not consume more than 25% of the usable RAM
         GIntBig l_nMaxRAMUsage =


### PR DESCRIPTION
## What does this PR do?

This relaxes the VRT pool size clamping so it doesn't get reset to 100 when configured to be over 1000 (or less than 2).

## What are related issues/pull requests?

#7977

## Tasklist

 - [ ] Update changelog?
 - [x] Update docs?
 - [ ] Increase limit?
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
