### PR TITLE
Add COPY_SRC_MDD=AUTO/YES/NO and SRC_MDD=domain_name creation options

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -1734,3 +1734,70 @@ def test_cog_NBITS():
     ds = None
 
     gdal.Unlink(filename)
+
+
+###############################################################################
+def test_cog_copy_mdd():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    src_ds.SetMetadataItem("FOO", "BAR")
+    src_ds.SetMetadataItem("BAR", "BAZ", "OTHER_DOMAIN")
+    src_ds.SetMetadataItem("should_not", "be_copied", "IMAGE_STRUCTURE")
+
+    filename = "/vsimem/test_tiff_write_copy_mdd.tif"
+
+    gdal.GetDriverByName("COG").CreateCopy(filename, src_ds)
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(
+        ["", "IMAGE_STRUCTURE", "DERIVED_SUBDATASETS"]
+    )
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    assert ds.GetMetadata_Dict("IMAGE_STRUCTURE") == {
+        "COMPRESSION": "LZW",
+        "INTERLEAVE": "BAND",
+        "LAYOUT": "COG",
+    }
+    ds = None
+
+    gdal.GetDriverByName("COG").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=NO"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    ds = None
+
+    gdal.GetDriverByName("COG").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=YES"]
+    )
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(
+        ["", "IMAGE_STRUCTURE", "DERIVED_SUBDATASETS", "OTHER_DOMAIN"]
+    )
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    assert ds.GetMetadata_Dict("IMAGE_STRUCTURE") == {
+        "COMPRESSION": "LZW",
+        "INTERLEAVE": "BAND",
+        "LAYOUT": "COG",
+    }
+    ds = None
+
+    gdal.GetDriverByName("COG").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.GetDriverByName("COG").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=", "SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.Unlink(filename)

--- a/autotest/gcore/vrtmisc.py
+++ b/autotest/gcore/vrtmisc.py
@@ -947,3 +947,65 @@ def test_vrtmisc_nodata_float32():
 
     gdal.Unlink(tif_filename)
     gdal.Unlink(vrt_filename)
+
+
+###############################################################################
+def test_vrt_write_copy_mdd():
+
+    src_filename = "/vsimem/test_vrt_write_copy_mdd.tif"
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 1, 1)
+    src_ds.SetMetadataItem("FOO", "BAR")
+    src_ds.SetMetadataItem("BAR", "BAZ", "OTHER_DOMAIN")
+    src_ds.SetMetadataItem("should_not", "be_copied", "IMAGE_STRUCTURE")
+
+    filename = "/vsimem/test_vrt_write_copy_mdd.vrt"
+
+    gdal.GetDriverByName("VRT").CreateCopy(filename, src_ds)
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(
+        ["", "IMAGE_STRUCTURE", "DERIVED_SUBDATASETS"]
+    )
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    assert ds.GetMetadata_Dict("IMAGE_STRUCTURE") == {"INTERLEAVE": "BAND"}
+    ds = None
+
+    gdal.GetDriverByName("VRT").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=NO"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    ds = None
+
+    gdal.GetDriverByName("VRT").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=YES"]
+    )
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(
+        ["", "IMAGE_STRUCTURE", "DERIVED_SUBDATASETS", "OTHER_DOMAIN"]
+    )
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    assert ds.GetMetadata_Dict("IMAGE_STRUCTURE") == {"INTERLEAVE": "BAND"}
+    ds = None
+
+    gdal.GetDriverByName("VRT").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.GetDriverByName("VRT").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=", "SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    src_ds = None
+    gdal.Unlink(filename)
+    gdal.Unlink(src_filename)

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -1544,6 +1544,61 @@ def test_jpeg_read_lossless_16bit():
 
 
 ###############################################################################
+def test_jpeg_copy_mdd():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    src_ds.SetMetadataItem("FOO", "BAR")
+    src_ds.SetMetadataItem("BAR", "BAZ", "OTHER_DOMAIN")
+    src_ds.SetMetadataItem("should_not", "be_copied", "IMAGE_STRUCTURE")
+
+    filename = "/vsimem/test_jpeg_copy_mdd.jpg"
+
+    gdal.GetDriverByName("JPEG").CreateCopy(filename, src_ds)
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(["", "DERIVED_SUBDATASETS"])
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    ds = None
+
+    gdal.GetDriverByName("JPEG").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=NO"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    ds = None
+
+    gdal.GetDriverByName("JPEG").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=YES"]
+    )
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(
+        ["", "DERIVED_SUBDATASETS", "OTHER_DOMAIN"]
+    )
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.GetDriverByName("JPEG").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.GetDriverByName("JPEG").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=", "SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.Unlink(filename)
+
+
+###############################################################################
 # Cleanup
 
 

--- a/autotest/gdrivers/png.py
+++ b/autotest/gdrivers/png.py
@@ -433,3 +433,58 @@ def test_png_whole_image_optim(options, nbands, xsize, ysize):
         )
 
     gdal.Unlink(filename)
+
+
+###############################################################################
+def test_png_copy_mdd():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    src_ds.SetMetadataItem("FOO", "BAR")
+    src_ds.SetMetadataItem("BAR", "BAZ", "OTHER_DOMAIN")
+    src_ds.SetMetadataItem("should_not", "be_copied", "IMAGE_STRUCTURE")
+
+    filename = "/vsimem/test_png_copy_mdd.png"
+
+    gdal.GetDriverByName("PNG").CreateCopy(filename, src_ds)
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(["", "DERIVED_SUBDATASETS"])
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    ds = None
+
+    gdal.GetDriverByName("PNG").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=NO"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {}
+    ds = None
+
+    gdal.GetDriverByName("PNG").CreateCopy(
+        filename, src_ds, options=["COPY_SRC_MDD=YES"]
+    )
+    ds = gdal.Open(filename)
+    assert set(ds.GetMetadataDomainList()) == set(
+        ["", "DERIVED_SUBDATASETS", "OTHER_DOMAIN"]
+    )
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.GetDriverByName("PNG").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.GetDriverByName("PNG").CreateCopy(
+        filename, src_ds, options=["SRC_MDD=", "SRC_MDD=OTHER_DOMAIN"]
+    )
+    ds = gdal.Open(filename)
+    assert ds.GetMetadata_Dict() == {"FOO": "BAR"}
+    assert ds.GetMetadata_Dict("OTHER_DOMAIN") == {"BAR": "BAZ"}
+    ds = None
+
+    gdal.Unlink(filename)

--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -293,7 +293,61 @@ resampling, and rescaling pixels in the process.
 
     Passes a metadata key and value to set on the output dataset if possible.
 
-.. include:: options/co.rst
+.. option:: -co <NAME=VALUE>
+
+    .. WARNING: if modifying the 2 below paragraphs, please edit options/co.rst too
+
+    Many formats have one or more optional creation options that can be
+    used to control particulars about the file created. For instance,
+    the GeoTIFF driver supports creation options to control compression,
+    and whether the file should be tiled.
+
+    The creation options available vary by format driver, and some
+    simple formats have no creation options at all. A list of options
+    supported for a format can be listed with the
+    :ref:`--formats <raster_common_options_formats>`
+    command line option but the documentation for the format is the
+    definitive source of information on driver creation options.
+    See :ref:`raster_drivers` format
+    specific documentation for legal creation options for each format.
+
+    In addition to the driver-specific creation options, gdal_translate
+    (and :cpp:func:`GDALTranslate` and :cpp:func:`GDALCreateCopy`) recognize
+    the following options:
+
+    - .. co:: APPEND_SUBDATASET
+         :choices: YES, NO
+         :default: NO
+
+      Can be specified to YES to avoid prior destruction of existing dataset,
+      for drivers that support adding several subdatasets (e.g. GTIFF, NITF)
+
+    - .. co:: COPY_SRC_MDD
+         :choices: AUTO, YES, NO
+         :default: AUTO
+         :since: 3.8
+
+      Defines if metadata domains of the source dataset should be copied to the
+      destination dataset.
+      In the default AUTO mode, only "safe" domains will be copied, which
+      include the default metadata domain (some drivers may include other
+      domains such as IMD, RPC, GEOLOCATION).
+      When setting YES, all domains will be copied (but a few reserved ones like
+      IMAGE_STRUCTURE or DERIVED_SUBDATASETS).
+      Currently only recognized by the GTiff, COG, VRT, PNG and JPEG drivers.
+
+      When setting NO, no source metadata will be copied.
+
+    - .. co:: SRC_MDD
+         :choices: <domain_name>
+         :since: 3.8
+
+      Defines which source metadata domain should be copied.
+      This option restricts the list of source metadata domains to be copied
+      (it implies COPY_SRC_MDD=YES if it is not set). This option may be specified
+      as many times as they are source domains. The default metadata domain is the
+      empty string "" ("_DEFAULT_") may also be used when empty string is not practical).
+      Currently only recognized by the GTiff, COG, VRT, PNG and JPEG drivers.
 
 .. option:: -nogcp
 

--- a/doc/source/programs/options/co.rst
+++ b/doc/source/programs/options/co.rst
@@ -1,3 +1,5 @@
+.. WARNING: if modifying that file, please edit gdal_translate.rst too
+
 .. option:: -co <NAME=VALUE>
 
     Many formats have one or more optional creation options that can be

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -1223,6 +1223,13 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
     CPLConfigOptionSetter oSetterInternalMask("GDAL_TIFF_INTERNAL_MASK", "YES",
                                               false);
 
+    const char *pszCopySrcMDD = CSLFetchNameValue(papszOptions, "COPY_SRC_MDD");
+    if (pszCopySrcMDD)
+        aosOptions.SetNameValue("COPY_SRC_MDD", pszCopySrcMDD);
+    char **papszSrcMDD = CSLFetchNameValueMultiple(papszOptions, "SRC_MDD");
+    for (; papszSrcMDD && *papszSrcMDD; ++papszSrcMDD)
+        aosOptions.AddNameValue("SRC_MDD", *papszSrcMDD);
+
     CPLDebug("COG", "Generating final product: start");
     auto poRet =
         poGTiffDrv->CreateCopy(pszFilename, poCurDS, false, aosOptions.List(),

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -525,9 +525,10 @@ class GTiffDataset final : public GDALPamDataset
 
     // Only needed by createcopy and close code.
     static void WriteRPC(GDALDataset *, TIFF *, int, GTiffProfile, const char *,
-                         char **, bool bWriteOnlyInPAMIfNeeded = false);
+                         CSLConstList papszCreationOptions,
+                         bool bWriteOnlyInPAMIfNeeded = false);
     static bool WriteMetadata(GDALDataset *, TIFF *, bool, GTiffProfile,
-                              const char *, char **,
+                              const char *, CSLConstList papszCreationOptions,
                               bool bExcludeRPBandIMGFileWriting = false);
     static void WriteNoDataValue(TIFF *, double);
     static void WriteNoDataValue(TIFF *, int64_t);

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -3690,10 +3690,11 @@ static void WriteMDMetadata(GDALMultiDomainMetadata *poMDMD, TIFF *hTIFF,
         char **papszMD = poMDMD->GetMetadata(papszDomainList[iDomain]);
         bool bIsXML = false;
 
-        if (EQUAL(papszDomainList[iDomain], "IMAGE_STRUCTURE"))
+        if (EQUAL(papszDomainList[iDomain], "IMAGE_STRUCTURE") ||
+            EQUAL(papszDomainList[iDomain], "DERIVED_SUBDATASETS"))
             continue;  // Ignored.
         if (EQUAL(papszDomainList[iDomain], "COLOR_PROFILE"))
-            continue;  // Ignored.
+            continue;  // Handled elsewhere.
         if (EQUAL(papszDomainList[iDomain], MD_DOMAIN_RPC))
             continue;  // Handled elsewhere.
         if (EQUAL(papszDomainList[iDomain], "xml:ESRI") &&
@@ -3852,7 +3853,7 @@ static void WriteMDMetadata(GDALMultiDomainMetadata *poMDMD, TIFF *hTIFF,
 void GTiffDataset::WriteRPC(GDALDataset *poSrcDS, TIFF *l_hTIFF,
                             int bSrcIsGeoTIFF, GTiffProfile eProfile,
                             const char *pszTIFFFilename,
-                            char **l_papszCreationOptions,
+                            CSLConstList papszCreationOptions,
                             bool bWriteOnlyInPAMIfNeeded)
 {
     /* -------------------------------------------------------------------- */
@@ -3874,11 +3875,11 @@ void GTiffDataset::WriteRPC(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         // Write RPB file if explicitly asked, or if a non GDAL specific
         // profile is selected and RPCTXT is not asked.
         bool bRPBExplicitlyAsked =
-            CPLFetchBool(l_papszCreationOptions, "RPB", false);
+            CPLFetchBool(papszCreationOptions, "RPB", false);
         bool bRPBExplicitlyDenied =
-            !CPLFetchBool(l_papszCreationOptions, "RPB", true);
+            !CPLFetchBool(papszCreationOptions, "RPB", true);
         if ((eProfile != GTiffProfile::GDALGEOTIFF &&
-             !CPLFetchBool(l_papszCreationOptions, "RPCTXT", false) &&
+             !CPLFetchBool(papszCreationOptions, "RPCTXT", false) &&
              !bRPBExplicitlyDenied) ||
             bRPBExplicitlyAsked)
         {
@@ -3887,7 +3888,7 @@ void GTiffDataset::WriteRPC(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             bRPCSerializedOtherWay = true;
         }
 
-        if (CPLFetchBool(l_papszCreationOptions, "RPCTXT", false))
+        if (CPLFetchBool(papszCreationOptions, "RPCTXT", false))
         {
             if (!bWriteOnlyInPAMIfNeeded)
                 GDALWriteRPCTXTFile(pszTIFFFilename, papszRPCMD);
@@ -3907,7 +3908,7 @@ void GTiffDataset::WriteRPC(GDALDataset *poSrcDS, TIFF *l_hTIFF,
 bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
                                  bool bSrcIsGeoTIFF, GTiffProfile eProfile,
                                  const char *pszTIFFFilename,
-                                 char **l_papszCreationOptions,
+                                 CSLConstList papszCreationOptions,
                                  bool bExcludeRPBandIMGFileWriting)
 
 {
@@ -3927,12 +3928,40 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
     }
     else
     {
-        char **papszMD = poSrcDS->GetMetadata();
-
-        if (CSLCount(papszMD) > 0)
+        const char *pszCopySrcMDD =
+            CSLFetchNameValueDef(papszCreationOptions, "COPY_SRC_MDD", "AUTO");
+        char **papszSrcMDD =
+            CSLFetchNameValueMultiple(papszCreationOptions, "SRC_MDD");
+        if (EQUAL(pszCopySrcMDD, "AUTO") || CPLTestBool(pszCopySrcMDD) ||
+            papszSrcMDD)
         {
             GDALMultiDomainMetadata l_oMDMD;
-            l_oMDMD.SetMetadata(papszMD);
+            char **papszMD = poSrcDS->GetMetadata();
+            if (CSLCount(papszMD) > 0 &&
+                (!papszSrcMDD || CSLFindString(papszSrcMDD, "") >= 0 ||
+                 CSLFindString(papszSrcMDD, "_DEFAULT_") >= 0))
+            {
+                l_oMDMD.SetMetadata(papszMD);
+            }
+
+            if ((!EQUAL(pszCopySrcMDD, "AUTO") && CPLTestBool(pszCopySrcMDD)) ||
+                papszSrcMDD)
+            {
+                char **papszDomainList = poSrcDS->GetMetadataDomainList();
+                for (char **papszIter = papszDomainList;
+                     papszIter && *papszIter; ++papszIter)
+                {
+                    const char *pszDomain = *papszIter;
+                    if (pszDomain[0] != 0 &&
+                        (!papszSrcMDD ||
+                         CSLFindString(papszSrcMDD, pszDomain) >= 0))
+                    {
+                        l_oMDMD.SetMetadata(poSrcDS->GetMetadata(pszDomain),
+                                            pszDomain);
+                    }
+                }
+                CSLDestroy(papszDomainList);
+            }
 
             WriteMDMetadata(&l_oMDMD, l_hTIFF, &psRoot, &psTail, 0, eProfile);
         }
@@ -3941,7 +3970,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
     if (!bExcludeRPBandIMGFileWriting)
     {
         WriteRPC(poSrcDS, l_hTIFF, bSrcIsGeoTIFF, eProfile, pszTIFFFilename,
-                 l_papszCreationOptions);
+                 papszCreationOptions);
 
         /* --------------------------------------------------------------------
          */
@@ -3960,7 +3989,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         nPhotometric = PHOTOMETRIC_MINISBLACK;
 
     const bool bStandardColorInterp = GTIFFIsStandardColorInterpretation(
-        GDALDataset::ToHandle(poSrcDS), nPhotometric, l_papszCreationOptions);
+        GDALDataset::ToHandle(poSrcDS), nPhotometric, papszCreationOptions);
 
     /* -------------------------------------------------------------------- */
     /*      We also need to address band specific metadata, and special     */
@@ -4047,7 +4076,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         }
 
         if (!bStandardColorInterp &&
-            !(nBand <= 3 && EQUAL(CSLFetchNameValueDef(l_papszCreationOptions,
+            !(nBand <= 3 && EQUAL(CSLFetchNameValueDef(papszCreationOptions,
                                                        "PHOTOMETRIC", ""),
                                   "RGB")))
         {
@@ -4059,14 +4088,14 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
     }
 
     const char *pszTilingSchemeName =
-        CSLFetchNameValue(l_papszCreationOptions, "@TILING_SCHEME_NAME");
+        CSLFetchNameValue(papszCreationOptions, "@TILING_SCHEME_NAME");
     if (pszTilingSchemeName)
     {
         AppendMetadataItem(&psRoot, &psTail, "NAME", pszTilingSchemeName, 0,
                            nullptr, "TILING_SCHEME");
 
         const char *pszZoomLevel = CSLFetchNameValue(
-            l_papszCreationOptions, "@TILING_SCHEME_ZOOM_LEVEL");
+            papszCreationOptions, "@TILING_SCHEME_ZOOM_LEVEL");
         if (pszZoomLevel)
         {
             AppendMetadataItem(&psRoot, &psTail, "ZOOM_LEVEL", pszZoomLevel, 0,
@@ -4074,7 +4103,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         }
 
         const char *pszAlignedLevels = CSLFetchNameValue(
-            l_papszCreationOptions, "@TILING_SCHEME_ALIGNED_LEVELS");
+            papszCreationOptions, "@TILING_SCHEME_ALIGNED_LEVELS");
         if (pszAlignedLevels)
         {
             AppendMetadataItem(&psRoot, &psTail, "ALIGNED_LEVELS",
@@ -4089,10 +4118,10 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             CPLGetConfigOption("GTIFF_WRITE_IMAGE_STRUCTURE_METADATA", "YES")))
     {
         const char *pszCompress =
-            CSLFetchNameValue(l_papszCreationOptions, "COMPRESS");
+            CSLFetchNameValue(papszCreationOptions, "COMPRESS");
         if (pszCompress && EQUAL(pszCompress, "WEBP"))
         {
-            if (GTiffGetWebPLossless(l_papszCreationOptions))
+            if (GTiffGetWebPLossless(papszCreationOptions))
             {
                 AppendMetadataItem(&psRoot, &psTail,
                                    "COMPRESSION_REVERSIBILITY", "LOSSLESS", 0,
@@ -4102,7 +4131,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             {
                 AppendMetadataItem(
                     &psRoot, &psTail, "WEBP_LEVEL",
-                    CPLSPrintf("%d", GTiffGetWebPLevel(l_papszCreationOptions)),
+                    CPLSPrintf("%d", GTiffGetWebPLevel(papszCreationOptions)),
                     0, nullptr, "IMAGE_STRUCTURE");
             }
         }
@@ -4110,7 +4139,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         else if (pszCompress && EQUAL(pszCompress, "JXL"))
         {
             float fDistance = 0.0f;
-            if (GTiffGetJXLLossless(l_papszCreationOptions))
+            if (GTiffGetJXLLossless(papszCreationOptions))
             {
                 AppendMetadataItem(&psRoot, &psTail,
                                    "COMPRESSION_REVERSIBILITY", "LOSSLESS", 0,
@@ -4118,13 +4147,13 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             }
             else
             {
-                fDistance = GTiffGetJXLDistance(l_papszCreationOptions);
+                fDistance = GTiffGetJXLDistance(papszCreationOptions);
                 AppendMetadataItem(&psRoot, &psTail, "JXL_DISTANCE",
                                    CPLSPrintf("%f", fDistance), 0, nullptr,
                                    "IMAGE_STRUCTURE");
             }
             const float fAlphaDistance =
-                GTiffGetJXLAlphaDistance(l_papszCreationOptions);
+                GTiffGetJXLAlphaDistance(papszCreationOptions);
             if (fAlphaDistance >= 0.0f && fAlphaDistance != fDistance)
             {
                 AppendMetadataItem(&psRoot, &psTail, "JXL_ALPHA_DISTANCE",
@@ -4133,7 +4162,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             }
             AppendMetadataItem(
                 &psRoot, &psTail, "JXL_EFFORT",
-                CPLSPrintf("%d", GTiffGetJXLEffort(l_papszCreationOptions)), 0,
+                CPLSPrintf("%d", GTiffGetJXLEffort(papszCreationOptions)), 0,
                 nullptr, "IMAGE_STRUCTURE");
         }
 #endif

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -4739,7 +4739,7 @@ GDALDataset *JPGDataset::CreateCopyStage2(
     }
 
     // Append masks to the jpeg file if necessary.
-    int nCloneFlags = GCIF_PAM_DEFAULT;
+    int nCloneFlags = GCIF_PAM_DEFAULT & ~GCIF_METADATA;
     if (bAppendMask)
     {
         CPLDebug("JPEG", "Appending Mask Bitmap");
@@ -4786,6 +4786,26 @@ GDALDataset *JPGDataset::CreateCopyStage2(
         if (poDS)
         {
             poDS->CloneInfo(poSrcDS, nCloneFlags);
+
+            char **papszExcludedDomains =
+                CSLAddString(nullptr, "COLOR_PROFILE");
+            char **papszMD = poSrcDS->GetMetadata();
+            bool bOnlyEXIF = true;
+            for (char **papszIter = papszMD; papszIter && *papszIter;
+                 ++papszIter)
+            {
+                if (!STARTS_WITH_CI(*papszIter, "EXIF_"))
+                {
+                    bOnlyEXIF = false;
+                    break;
+                }
+            }
+            if (bOnlyEXIF)
+                papszExcludedDomains = CSLAddString(papszExcludedDomains, "");
+            GDALDriver::DefaultCopyMetadata(poSrcDS, poDS, papszOptions,
+                                            papszExcludedDomains);
+            CSLDestroy(papszExcludedDomains);
+
             return poDS;
         }
 

--- a/frmts/png/pngdataset.cpp
+++ b/frmts/png/pngdataset.cpp
@@ -2820,10 +2820,17 @@ GDALDataset *PNGDataset::CreateCopy(const char *pszFilename,
         CPLPopErrorHandler();
         if (poDS)
         {
-            int nFlags = GCIF_PAM_DEFAULT;
-            if (bWriteMetadataAsText)
-                nFlags &= ~GCIF_METADATA;
+            int nFlags = GCIF_PAM_DEFAULT & ~GCIF_METADATA;
             poDS->CloneInfo(poSrcDS, nFlags);
+
+            char **papszExcludedDomains =
+                CSLAddString(nullptr, "COLOR_PROFILE");
+            if (bWriteMetadataAsText)
+                papszExcludedDomains = CSLAddString(papszExcludedDomains, "");
+            GDALDriver::DefaultCopyMetadata(poSrcDS, poDS, papszOptions,
+                                            papszExcludedDomains);
+            CSLDestroy(papszExcludedDomains);
+
             return poDS;
         }
         CPLErrorReset();

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1842,6 +1842,9 @@ class CPL_DLL GDALDriver : public GDALMajorObject
     static CPLErr DefaultRename(const char *pszNewName, const char *pszOldName);
     static CPLErr DefaultCopyFiles(const char *pszNewName,
                                    const char *pszOldName);
+    static void DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
+                                    CSLConstList papszOptions,
+                                    CSLConstList papszExcludedDomains);
     //! @endcond
 
     /** Convert a GDALDriver* to a GDALDriverH.

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -701,25 +701,7 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     /*      Copy metadata.                                                  */
     /* -------------------------------------------------------------------- */
-    if (poSrcDS->GetMetadata() != nullptr)
-        poDstDS->SetMetadata(poSrcDS->GetMetadata());
-
-    /* -------------------------------------------------------------------- */
-    /*      Copy transportable special domain metadata (RPCs).  It would    */
-    /*      be nice to copy geolocation, but it is pretty fragile.          */
-    /* -------------------------------------------------------------------- */
-    char **papszMD = poSrcDS->GetMetadata("RPC");
-    if (papszMD)
-        poDstDS->SetMetadata(papszMD, "RPC");
-
-    /* -------------------------------------------------------------------- */
-    /*      Copy XMPmetadata.                                               */
-    /* -------------------------------------------------------------------- */
-    char **papszXMP = poSrcDS->GetMetadata("xml:XMP");
-    if (papszXMP != nullptr && *papszXMP != nullptr)
-    {
-        poDstDS->SetMetadata(papszXMP, "xml:XMP");
-    }
+    DefaultCopyMetadata(poSrcDS, poDstDS, papszOptions, nullptr);
 
     /* -------------------------------------------------------------------- */
     /*      Loop copying bands.                                             */
@@ -847,6 +829,100 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
 
     return poDstDS;
 }
+
+/************************************************************************/
+/*                       DefaultCopyMetadata()                          */
+/************************************************************************/
+
+void GDALDriver::DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
+                                     CSLConstList papszOptions,
+                                     CSLConstList papszExcludedDomains)
+{
+    const char *pszCopySrcMDD =
+        CSLFetchNameValueDef(papszOptions, "COPY_SRC_MDD", "AUTO");
+    char **papszSrcMDD = CSLFetchNameValueMultiple(papszOptions, "SRC_MDD");
+    if (EQUAL(pszCopySrcMDD, "AUTO") || CPLTestBool(pszCopySrcMDD) ||
+        papszSrcMDD)
+    {
+        if ((!papszSrcMDD || CSLFindString(papszSrcMDD, "") >= 0 ||
+             CSLFindString(papszSrcMDD, "_DEFAULT_") >= 0) &&
+            CSLFindString(papszExcludedDomains, "") < 0 &&
+            CSLFindString(papszExcludedDomains, "_DEFAULT_") < 0)
+        {
+            if (poSrcDS->GetMetadata() != nullptr)
+                poDstDS->SetMetadata(poSrcDS->GetMetadata());
+        }
+
+        /* -------------------------------------------------------------------- */
+        /*      Copy transportable special domain metadata.                     */
+        /*      It would be nice to copy geolocation, but it is pretty fragile. */
+        /* -------------------------------------------------------------------- */
+        constexpr const char *apszDefaultDomains[] = {
+            "RPC", "xml:XMP", "json:ISIS3", "json:VICAR"};
+        for (const char *pszDomain : apszDefaultDomains)
+        {
+            if ((!papszSrcMDD || CSLFindString(papszSrcMDD, pszDomain) >= 0) &&
+                CSLFindString(papszExcludedDomains, pszDomain) < 0)
+            {
+                char **papszMD = poSrcDS->GetMetadata(pszDomain);
+                if (papszMD)
+                    poDstDS->SetMetadata(papszMD, pszDomain);
+            }
+        }
+
+        if ((!EQUAL(pszCopySrcMDD, "AUTO") && CPLTestBool(pszCopySrcMDD)) ||
+            papszSrcMDD)
+        {
+            char **papszDomainList = poSrcDS->GetMetadataDomainList();
+            constexpr const char *apszReservedDomains[] = {
+                "IMAGE_STRUCTURE", "DERIVED_SUBDATASETS"};
+            for (char **papszIter = papszDomainList; papszIter && *papszIter;
+                 ++papszIter)
+            {
+                const char *pszDomain = *papszIter;
+                if (pszDomain[0] != 0 &&
+                    (!papszSrcMDD ||
+                     CSLFindString(papszSrcMDD, pszDomain) >= 0))
+                {
+                    bool bCanCopy = true;
+                    if (CSLFindString(papszExcludedDomains, pszDomain) >= 0)
+                    {
+                        bCanCopy = false;
+                    }
+                    else
+                    {
+                        for (const char *pszOtherDomain : apszDefaultDomains)
+                        {
+                            if (EQUAL(pszDomain, pszOtherDomain))
+                            {
+                                bCanCopy = false;
+                                break;
+                            }
+                        }
+                        if (!papszSrcMDD)
+                        {
+                            for (const char *pszOtherDomain :
+                                 apszReservedDomains)
+                            {
+                                if (EQUAL(pszDomain, pszOtherDomain))
+                                {
+                                    bCanCopy = false;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (bCanCopy)
+                    {
+                        poDstDS->SetMetadata(poSrcDS->GetMetadata(pszDomain),
+                                             pszDomain);
+                    }
+                }
+            }
+            CSLDestroy(papszDomainList);
+        }
+    }
+}
 //! @endcond
 
 /************************************************************************/
@@ -905,8 +981,27 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
  * normally FALSE indicating that the copy may adapt as needed for the
  * output format.
  * @param papszOptions additional format dependent options controlling
- * creation of the output file. The APPEND_SUBDATASET=YES option can be
- * specified to avoid prior destruction of existing dataset.
+ * creation of the output file.
+ * The APPEND_SUBDATASET=YES option can be specified to avoid prior destruction
+ * of existing dataset.
+ * Starting with GDAL 3.8.0, the following options are recognized by the
+ * GTiff, COG, VRT, PNG au JPEG drivers:
+ * <ul>
+ * <li>COPY_SRC_MDD=AUTO/YES/NO: whether metadata domains of the source dataset
+ * should be copied to the destination dataset. In the default AUTO mode, only
+ * "safe" domains will be copied, which include the default metadata domain
+ * (some drivers may include other domains such as IMD, RPC, GEOLOCATION). When
+ * setting YES, all domains will be copied (but a few reserved ones like
+ * IMAGE_STRUCTURE or DERIVED_SUBDATASETS). When setting NO, no source metadata
+ * will be copied.
+ * </li>
+ *<li>SRC_MDD=domain_name: which source metadata domain should be copied.
+ * This option restricts the list of source metadata domains to be copied
+ * (it implies COPY_SRC_MDD=YES if it is not set). This option may be specified
+ * as many times as they are source domains. The default metadata domain is the
+ * empty string "" ("_DEFAULT_") may also be used when empty string is not practical)
+ * </li>
+ * </ul>
  * @param pfnProgress a function to be used to report progress of the copy.
  * @param pProgressData application data passed into progress function.
  *
@@ -1942,14 +2037,48 @@ int CPL_STDCALL GDALValidateCreationOptions(GDALDriverH hDriver,
     CPLString osDriver;
     osDriver.Printf("driver %s",
                     GDALDriver::FromHandle(hDriver)->GetDescription());
+    bool bFoundOptionToRemove = false;
+    for (CSLConstList papszIter = papszCreationOptions; papszIter && *papszIter;
+         ++papszIter)
+    {
+        for (const char *pszExcludedOptions :
+             {"APPEND_SUBDATASET", "COPY_SRC_MDD", "SRC_MDD"})
+        {
+            if (STARTS_WITH_CI(*papszIter, pszExcludedOptions) &&
+                (*papszIter)[strlen(pszExcludedOptions)] == '=')
+            {
+                bFoundOptionToRemove = true;
+                break;
+            }
+        }
+        if (bFoundOptionToRemove)
+            break;
+    }
     CSLConstList papszOptionsToValidate = papszCreationOptions;
     char **papszOptionsToFree = nullptr;
-    if (CSLFetchNameValue(papszCreationOptions, "APPEND_SUBDATASET"))
+    if (bFoundOptionToRemove)
     {
-        papszOptionsToFree = CSLSetNameValue(CSLDuplicate(papszCreationOptions),
-                                             "APPEND_SUBDATASET", nullptr);
+        for (CSLConstList papszIter = papszCreationOptions;
+             papszIter && *papszIter; ++papszIter)
+        {
+            bool bMatch = false;
+            for (const char *pszExcludedOptions :
+                 {"APPEND_SUBDATASET", "COPY_SRC_MDD", "SRC_MDD"})
+            {
+                if (STARTS_WITH_CI(*papszIter, pszExcludedOptions) &&
+                    (*papszIter)[strlen(pszExcludedOptions)] == '=')
+                {
+                    bMatch = true;
+                    break;
+                }
+            }
+            if (!bMatch)
+                papszOptionsToFree =
+                    CSLAddString(papszOptionsToFree, *papszIter);
+        }
         papszOptionsToValidate = papszOptionsToFree;
     }
+
     const bool bRet = CPL_TO_BOOL(GDALValidateOptions(
         pszOptionList, papszOptionsToValidate, "creation option", osDriver));
     CSLDestroy(papszOptionsToFree);


### PR DESCRIPTION
Fixes #7956

    - .. co:: COPY_SRC_MDD
         :choices: AUTO, YES, NO
         :default: AUTO
         :since: 3.8

      Defines if metadata domains of the source dataset should be copied to the
      destination dataset.
      In the default AUTO mode, only "safe" domains will be copied, which
      include the default metadata domain (some drivers may include other
      domains such as IMD, RPC, GEOLOCATION).
      When setting YES, all domains will be copied (but a few reserved ones like
      IMAGE_STRUCTURE or DERIVED_SUBDATASETS).
      Currently only recognized by the GTiff, COG, VRT, PNG and JPEG drivers.

      When setting NO, no source metadata will be copied.

    - .. co:: SRC_MDD
         :choices: <domain_name>
         :since: 3.8

      Defines which source metadata domain should be copied.
      This option restricts the list of source metadata domains to be copied
      (it implies COPY_SRC_MDD=YES if it is not set). This option may be specified
      as many times as they are source domains. The default metadata domain is the
      empty string "" ("_DEFAULT_") may also be used when empty string is not practical).
      Currently only recognized by the GTiff, COG, VRT, PNG and JPEG drivers.
