### PR TITLE
SWIG: Increment FeatureDefn ref count on ogr.Layer.GetLayerDefn()

### DIFF
--- a/autotest/ogr/data/testograpispy.py
+++ b/autotest/ogr/data/testograpispy.py
@@ -123,6 +123,6 @@ ds1 = None
 ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('/vsimem/test')
 ds1 = ogr.GetDriverByName('CSV').CreateDataSource('/vsimem/test2.csv', options=['GEOMETRY=AS_WKT'])
 ds1_lyr1 = ds1.CreateLayer('test2', srs=None, geom_type=ogr.wkbUnknown, options=[])
-fdefn1 = ds1_lyr1.GetLayerDefn()
+fdefn3 = ds1_lyr1.GetLayerDefn()
 ds1 = None
 ogr.GetDriverByName('ESRI Shapefile').DeleteDataSource('/vsimem/test2.csv')

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -891,6 +891,29 @@ def test_ogr_basic_test_future_warning_exceptions():
 
 
 ###############################################################################
+# check feature defn access after layer has been destroyed
+
+
+def test_feature_defn_use_after_layer_del():
+    with ogr.Open("data/poly.shp") as ds:
+        lyr = ds.GetLayer(0)
+
+        defn1 = lyr.GetLayerDefn()
+        defn2 = lyr.GetLayerDefn()
+
+        lyr.GetLayerDefn().AddFieldDefn(ogr.FieldDefn("cookie", ogr.OFTInteger))
+
+        assert defn1.GetReferenceCount() == 3
+        del defn2
+        assert defn1.GetReferenceCount() == 2
+
+    del lyr
+
+    assert defn1.GetReferenceCount() == 1
+    assert defn1.GetFieldDefn(3).GetName() == "cookie"
+
+
+###############################################################################
 # Test CreateDataSource context manager
 
 

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -1242,8 +1242,12 @@ public:
     return OGR_L_SyncToDisk(self);
   }
 
+  %newobject GetLayerDefn;
   OGRFeatureDefnShadow *GetLayerDefn() {
-    return (OGRFeatureDefnShadow*) OGR_L_GetLayerDefn(self);
+    auto defn = (OGRFeatureDefnShadow*) OGR_L_GetLayerDefn(self);
+    if (defn)
+        OGR_FD_Reference(defn);
+    return defn;
   }
 
 #ifndef SWIGJAVA


### PR DESCRIPTION
## What does this PR do?

Increments reference count on `OGRFeatureDefn` so that a layer definition can be accessed without segfaulting after the layer has been destroyed.

This took some trial and error to figure out so I was a bit skeptical until I realized it is an independent rediscovery of https://github.com/OSGeo/gdal/commit/36700d390937c409f91a72fc0d217a37077ecbde

## What are related issues/pull requests?

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
