### PR TITLE
autotest: skip test_vsicurl_streaming_1 on Travis

### DIFF
--- a/autotest/gcore/vsicurl_streaming.py
+++ b/autotest/gcore/vsicurl_streaming.py
@@ -42,6 +42,8 @@ pytestmark = pytest.mark.require_curl()
 
 
 def test_vsicurl_streaming_1():
+    # Occasionally fails on Travis graviton2 configuration
+    gdaltest.skip_on_travis()
 
     with gdal.config_option("GDAL_HTTP_CONNECTTIMEOUT", "5"):
         fp = gdal.VSIFOpenL(


### PR DESCRIPTION
## What does this PR do?

Skips a test that I sometimes see failing, but only on Travis graviton2
https://app.travis-ci.com/github/OSGeo/gdal/jobs/604580643#L20341